### PR TITLE
fix(ci): repair the four ways CI silently never runs (#12823, #13300, #13286, #13045)

### DIFF
--- a/.github/workflows/auto-update-pr-branches.yml
+++ b/.github/workflows/auto-update-pr-branches.yml
@@ -7,6 +7,15 @@
 # merge-conflict surprises at review time.
 #
 # See: #9300 post-mortem — direct hotfixes on main caused drift
+#
+# #12823: the merge commit this job creates is pushed with the default
+# GITHUB_TOKEN, so GitHub attributes it to github-actions[bot]. The repository's
+# fork-PR approval policy treats that bot as an external contributor, so every
+# `pull_request` run the refresh triggers is created with
+# conclusion=action_required and never starts — the refreshed PR ends up with a
+# head commit carrying ZERO executed checks, which reads as "no failures" to any
+# rollup. The `approve-refreshed-runs` job below runs immediately afterwards to
+# repair that, and publishes a visible commit status when it cannot.
 
 name: Auto-update PR branches
 
@@ -129,3 +138,32 @@ jobs:
           echo "Done: $UPDATED updated, $FAILED need manual attention."
           # Never fail — conflicting PRs just need human resolution
           exit 0
+
+  # #12823: repair the runs the refresh above just parked.
+  #
+  # This job must NOT run on the self-hosted runner: it exists to unblock CI,
+  # and the singleton runner is exactly the resource that is contended when
+  # several PRs are refreshed at once. `needs: auto-update` guarantees it runs
+  # after the branches were actually updated, so the parked runs already exist
+  # by the time it looks; the standalone `ci-dispatch-watchdog` schedule is the
+  # safety net for anything that appears later.
+  approve-refreshed-runs:
+    needs: auto-update
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      actions: write
+      statuses: write
+      pull-requests: read
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Approve parked runs and publish dispatch state
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          WATCHDOG_BASE_BRANCH: Dev_new_gui
+        run: python3 pipeline-scripts/ci_dispatch_watchdog.py --check dispatch

--- a/.github/workflows/ci-dispatch-watchdog.yml
+++ b/.github/workflows/ci-dispatch-watchdog.yml
@@ -1,0 +1,82 @@
+# CI dispatch watchdog — #12823, #13045
+#
+# Guards the two ways a pull request ends up reading as "waiting for CI" with
+# nothing actually queued:
+#
+#   #12823  auto-update-pr-branches refreshes stale PR branches with the default
+#           GITHUB_TOKEN, so the merge commit is pushed as github-actions[bot].
+#           The repository's fork-PR approval policy treats that bot as an
+#           external contributor, so every run it triggers is created with
+#           conclusion=action_required and never starts. The head commit then
+#           carries zero executed checks, and `gh pr checks` reports nothing at
+#           all — not pending, not failing. Tooling that reads "no failures" as
+#           "ready" will happily merge it.
+#
+#   #13045  While the singleton self-hosted runner pool is empty, runs are
+#           created but never allocate a job. A required context never reports,
+#           `commits/{sha}/status` stays pending forever, and the PR shows
+#           "19 success / 0 failures" while being structurally unmergeable.
+#
+# This workflow approves what it is permitted to approve, and — regardless of
+# whether approval succeeds — publishes a `ci-dispatch-watchdog` commit status
+# on every open PR head. Absence of CI therefore becomes a visible, named,
+# non-green context instead of silence.
+#
+# runs-on is ubuntu-latest on every job by design: the self-hosted runner is a
+# singleton, and a watchdog that queues behind the outage it exists to report
+# is useless.
+
+name: CI Dispatch Watchdog
+
+on:
+  schedule:
+    # Every 15 minutes. Scheduled runs are attributed to the repository, not to
+    # github-actions[bot] as a contributor, so this workflow itself is never
+    # subject to the approval policy it repairs.
+    - cron: '*/15 * * * *'
+  push:
+    branches: [Dev_new_gui]
+  workflow_dispatch:
+  pull_request:
+    # Self-test: any change to the watchdog exercises it (in --dry-run mode)
+    # before it can be merged, including the approval-capability probe.
+    paths:
+      - '.github/workflows/ci-dispatch-watchdog.yml'
+      - 'pipeline-scripts/ci_dispatch_watchdog.py'
+      - 'repo_tests/ci_dispatch_watchdog_test.py'
+
+concurrency:
+  # Never cancel a sweep in flight — a half-finished sweep leaves some PRs
+  # without a published status, which is the exact condition being guarded.
+  group: ci-dispatch-watchdog
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  actions: write
+  statuses: write
+  pull-requests: read
+
+jobs:
+  watchdog:
+    name: Approve parked runs and publish dispatch state
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Sweep open PRs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          WATCHDOG_BASE_BRANCH: Dev_new_gui
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          # On a pull_request event the branch is unreviewed, so the sweep runs
+          # read-only: it still probes approval capability and still classifies
+          # every open PR, but writes no status and approves nothing.
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            python3 pipeline-scripts/ci_dispatch_watchdog.py --check dispatch --dry-run
+          else
+            python3 pipeline-scripts/ci_dispatch_watchdog.py --check dispatch
+          fi

--- a/.github/workflows/ci-dispatch-watchdog.yml
+++ b/.github/workflows/ci-dispatch-watchdog.yml
@@ -22,6 +22,15 @@
 # on every open PR head. Absence of CI therefore becomes a visible, named,
 # non-green context instead of silence.
 #
+# FORK SAFETY: `POST /actions/runs/{id}/approve` is the approve-a-fork-run
+# endpoint. This repository is public, takes fork pull requests, and runs
+# `pull_request` jobs on the self-hosted runner, so approving a fork run would
+# execute contributor-supplied code on the owner's machine — the very thing the
+# `all_external_contributors` policy exists to stop. The sweep therefore
+# approves only runs whose head repository is this repository AND whose
+# triggering actor is the branch-update bot. Fork pull requests get a published
+# status; they never get an approval.
+#
 # runs-on is ubuntu-latest on every job by design: the self-hosted runner is a
 # singleton, and a watchdog that queues behind the outage it exists to report
 # is useless.
@@ -65,7 +74,21 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # Answers "may this workflow's GITHUB_TOKEN approve a parked run?" and
+      # nothing else. It POSTs approve against a run that already succeeded,
+      # which GitHub rejects on state grounds, so it has no side effect and is
+      # safe on an unreviewed branch. It is a separate step from the sweep
+      # because --dry-run deliberately issues no approve request and so cannot
+      # answer the question — the omission that made an earlier self-test report
+      # "probe skipped" while the job passed.
+      - name: Report approval capability
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: python3 pipeline-scripts/ci_dispatch_watchdog.py --check probe
+
       - name: Sweep open PRs
+        if: ${{ !cancelled() }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
@@ -73,8 +96,8 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
         run: |
           # On a pull_request event the branch is unreviewed, so the sweep runs
-          # read-only: it still probes approval capability and still classifies
-          # every open PR, but writes no status and approves nothing.
+          # read-only: it classifies every open PR but writes no status and
+          # approves nothing.
           if [ "$EVENT_NAME" = "pull_request" ]; then
             python3 pipeline-scripts/ci_dispatch_watchdog.py --check dispatch --dry-run
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,12 @@ jobs:
     needs: changes
     if: needs.changes.outputs.python == 'true'
     runs-on: ubuntu-latest
+    # #13045: without an explicit budget this job inherits GitHub's 6-hour
+    # default, so a wedged suite reads as "still running" for most of a day and
+    # the required context never reports. 150 minutes is comfortably above the
+    # measured ~51-minute backend invocation plus the slm-backend invocation
+    # that #13300 restored, and fails visibly instead of hanging.
+    timeout-minutes: 150
 
     steps:
     - uses: actions/checkout@v7
@@ -117,11 +123,26 @@ jobs:
     # also meant four checks that finish in minutes were gated behind a
     # ~105-minute pytest run in the same job.
 
-    - name: Run unit tests with coverage gate
+    # #13300: these two invocations used to live in ONE `run:` block. GitHub's
+    # default shell is `bash -e`, so the first invocation's non-zero exit on the
+    # standing failures aborted the step and the second NEVER executed. The job
+    # log contained exactly one "test session starts" and 50m40s of pytest
+    # inside a 50m55s step. Consequences: autobot-slm-backend unit tests had
+    # never run in CI at all, `--cov-fail-under=70` on the second invocation
+    # never evaluated despite the comment claiming enforcement, and coverage.xml
+    # was never produced so the upload step had no input.
+    #
+    # Two separate steps with `!cancelled()` on the second decouple them: each
+    # reports its own conclusion in the job UI, both contribute to the job
+    # result, and neither can silently swallow the other. `!cancelled()` rather
+    # than `always()` so a cancelled job (concurrency, timeout) stops promptly
+    # instead of starting another hour of pytest.
+    - name: Run unit tests — backend, shared, tts-worker, repo_tests
       run: |
-        echo "Running unit tests with 70% coverage gate (#3285)..."
-        # Run all unit tests excluding slow/integration/distributed/performance markers.
-        # --cov-fail-under=70 enforces the minimum 70% coverage threshold.
+        echo "Running unit tests for autobot-backend / autobot_shared / autobot-tts-worker / repo_tests..."
+        # Run all unit tests excluding slow/integration/distributed/performance
+        # markers. Those markers are NOT a way to retire a test: marker-tests.yml
+        # runs exactly the excluded set on a schedule (#13286).
         # -n auto --dist loadscope parallelizes across workers (#10398); pytest-cov
         # auto-combines per-worker coverage, and loadscope keeps same-module tests
         # on one worker so shared-fixture/ordering behaviour matches serial.
@@ -134,12 +155,10 @@ jobs:
         # in sys.modules for the rest of the session, breaking the other
         # backend's own tests (~95% of a full single-session run's collection
         # errors — see #13084). A fresh interpreter per invocation eliminates
-        # the collision entirely; --cov-append merges coverage across both so
-        # the combined --cov-fail-under=70 gate still reflects the whole
-        # suite. This does NOT add a second CI job (the singleton self-hosted
-        # runner concern from #10691) — both invocations run sequentially in
-        # this same job/step, so total wall-clock is the sum of the parts,
-        # same as today's single combined run.
+        # the collision entirely; --cov-append on the second merges coverage
+        # across both. This does NOT add a second CI job (the singleton
+        # self-hosted runner concern from #10691) — both invocations run
+        # sequentially in this same ubuntu-latest job.
         python -m pytest \
           autobot-backend autobot_shared autobot-tts-worker repo_tests \
           -n auto --dist loadscope \
@@ -152,6 +171,19 @@ jobs:
           --durations-min=10.0 \
           -q
 
+    - name: Run unit tests with coverage gate — slm-backend
+      # Runs even when the invocation above failed: it is a separate interpreter
+      # testing a separate tree, and it carries the combined coverage gate and
+      # the only coverage.xml producer (#13300).
+      if: ${{ !cancelled() }}
+      run: |
+        echo "Running unit tests for autobot-slm-backend with the 70% coverage gate (#3285)..."
+        # --cov-append merges this tree's coverage onto the data written by the
+        # previous step, so --cov-fail-under=70 is evaluated against the WHOLE
+        # suite, not just slm-backend. This is the only place the gate runs; if
+        # it is ever removed, remove the claim in pytest.ini's [coverage:report]
+        # too rather than leaving a comment asserting enforcement that does not
+        # happen.
         python -m pytest \
           autobot-slm-backend \
           -n auto --dist loadscope \
@@ -167,6 +199,10 @@ jobs:
           -q
 
     - name: Run integration tests
+      # #13300: previously skipped whenever the unit steps failed, so the
+      # directory-based integration suite went unreported for as long as the
+      # unit suite was red.
+      if: ${{ !cancelled() }}
       run: |
         echo "🔄 Running integration tests..."
         # Integration tests remain in shared directory (#734)
@@ -178,6 +214,9 @@ jobs:
         fi
 
     - name: Upload coverage reports
+      # #13300: coverage.xml is produced by the slm-backend step above even when
+      # tests fail; skipping the upload on failure discarded it.
+      if: ${{ !cancelled() }}
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v6
       with:
         files: ./coverage.xml

--- a/.github/workflows/marker-tests.yml
+++ b/.github/workflows/marker-tests.yml
@@ -20,8 +20,16 @@
 #     change #10691 owns and is owner-gated.
 #   * Non-blocking by construction — it is not a `pull_request` workflow, so it
 #     is not a required context and cannot block a merge. It still FAILS (red in
-#     the Actions tab) when a test fails, which is the point: a failing marked
-#     test must produce a signal somewhere.
+#     the Actions tab) when a test fails.
+#
+#     A red run here is a DEFECT TO TRIAGE, never an accepted steady state. A
+#     workflow that is expected to be red is a workflow nobody reads — that is
+#     exactly how `self-hosted-runner-health` sat red on 100% of its scheduled
+#     runs while reporting nothing, and this file must not inherit that habit.
+#     The excluded set is dominated by `integration` tests that need a real
+#     Redis, so one is provided below rather than letting the first night fail
+#     for infrastructure reasons and calling it "the point". #13286 stays open
+#     until a run is green or its remaining failures have been triaged.
 #   * No coverage gate. Coverage is measured by the PR gate; adding tracing here
 #     would roughly double the runtime for no added assertion.
 #   * Two invocations, same reason as ci.yml: autobot-backend/ and
@@ -54,6 +62,21 @@ jobs:
     name: Run slow / integration / distributed / performance tests
     runs-on: ubuntu-latest
     timeout-minutes: 180
+
+    # The marker-excluded set is mostly `integration`, and those tests talk to a
+    # real Redis rather than the `fakeredis` the PR gate installs — one module
+    # alone carries 20 of them. Without this the first scheduled run would fail
+    # on connection errors and say nothing about the tests themselves.
+    services:
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
 
     env:
       # Single source for the marker expression: the schedule uses the default,

--- a/.github/workflows/marker-tests.yml
+++ b/.github/workflows/marker-tests.yml
@@ -1,0 +1,144 @@
+# Marker-excluded test suite — #13286
+#
+# `ci.yml` runs the Python suite with
+# `-m "not integration and not slow and not distributed and not performance"`,
+# and until this workflow existed nothing anywhere selected those markers back
+# in. Marking a test was therefore deletion from CI, not relocation: every
+# `slow` / `integration` / `distributed` / `performance` mark added to date
+# silently retired that test with no signal of any kind.
+#
+# This workflow is the missing other half. It runs exactly the complement of the
+# PR gate's exclusion, so the union of the two covers the whole suite.
+#
+# Deliberate design choices:
+#
+#   * runs-on: ubuntu-latest on every job. The self-hosted runner is a singleton
+#     and is the PR gate's bottleneck (#10691); a nightly long-running suite must
+#     never contend with it. GitHub-hosted minutes are the correct trade here.
+#   * Scheduled, not per-PR. These are the tests that were excluded because they
+#     are slow or need external services; putting them in the PR gate is the
+#     change #10691 owns and is owner-gated.
+#   * Non-blocking by construction — it is not a `pull_request` workflow, so it
+#     is not a required context and cannot block a merge. It still FAILS (red in
+#     the Actions tab) when a test fails, which is the point: a failing marked
+#     test must produce a signal somewhere.
+#   * No coverage gate. Coverage is measured by the PR gate; adding tracing here
+#     would roughly double the runtime for no added assertion.
+#   * Two invocations, same reason as ci.yml: autobot-backend/ and
+#     autobot-slm-backend/ define top-level packages with identical names, so a
+#     single interpreter session binds the wrong one in sys.modules (#13084).
+
+name: Marker-excluded Tests
+
+on:
+  schedule:
+    # 03:20 UTC daily — off the */15 dispatch-watchdog and */30 runner-health
+    # slots, and well clear of working-hours PR traffic.
+    - cron: '20 3 * * *'
+  workflow_dispatch:
+    inputs:
+      markers:
+        description: 'pytest -m expression to select (default: the full excluded set)'
+        required: false
+        default: 'integration or slow or distributed or performance'
+
+concurrency:
+  group: marker-tests
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  marker-tests:
+    name: Run slow / integration / distributed / performance tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+
+    env:
+      # Single source for the marker expression: the schedule uses the default,
+      # a manual dispatch may narrow it to one marker while triaging.
+      MARKER_EXPRESSION: ${{ github.event.inputs.markers || 'integration or slow or distributed or performance' }}
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.14'
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements*.txt
+            autobot-backend/requirements*.txt
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install -r requirements-ci.txt --prefer-binary
+          python -m pip install pytest pytest-asyncio pytest-xdist==3.8.0 'fakeredis[lua]'
+
+      - name: Create necessary directories and config files
+        run: |
+          mkdir -p data logs static config
+          touch data/.gitkeep logs/.gitkeep static/.gitkeep
+
+          cat > config/config.yaml << 'EOF'
+          # CI Testing Configuration
+          llm:
+            orchestrator_llm: "mock"
+            task_llm: "mock"
+            ollama:
+              model: "mock-model"
+              models: {}
+            unified:
+              embedding:
+                providers:
+                  ollama:
+                    selected_model: "mock-embed"
+
+          deployment:
+            mode: "local"
+
+          data:
+            reliability_stats_file: "data/reliability_stats.json"
+
+          diagnostics:
+            enabled: false
+            use_llm_for_analysis: false
+            use_web_search_for_analysis: false
+            auto_apply_fixes: false
+
+          redis:
+            host: "localhost"
+            port: 6379
+            db: 0
+          EOF
+
+      - name: Run marked tests — backend, shared, tts-worker, repo_tests
+        run: |
+          echo "Selecting: $MARKER_EXPRESSION"
+          # Exit 5 is pytest's "no tests collected". For a marker selection that
+          # is a legitimate outcome (no test currently carries the marker in this
+          # tree), not a failure — anything else propagates.
+          python -m pytest \
+            autobot-backend autobot_shared autobot-tts-worker repo_tests \
+            -n auto --dist loadscope \
+            -m "$MARKER_EXPRESSION" \
+            --tb=short \
+            --durations=25 \
+            -q || [ $? -eq 5 ]
+
+      - name: Run marked tests — slm-backend
+        # Same decoupling as ci.yml (#13300): a failure in the tree above must
+        # not silently skip this one.
+        if: ${{ !cancelled() }}
+        run: |
+          echo "Selecting: $MARKER_EXPRESSION"
+          python -m pytest \
+            autobot-slm-backend \
+            -n auto --dist loadscope \
+            -m "$MARKER_EXPRESSION" \
+            --tb=short \
+            --durations=25 \
+            -q || [ $? -eq 5 ]

--- a/.github/workflows/self-hosted-runner-health.yml
+++ b/.github/workflows/self-hosted-runner-health.yml
@@ -1,3 +1,24 @@
+# Self-hosted runner health — #13045
+#
+# The previous probe called `GET /repos/{owner}/{repo}/actions/runners` and
+# selected a runner by hard-coded name. Both halves were broken:
+#
+#   * `/actions/runners` is an administration endpoint. GITHUB_TOKEN cannot read
+#     it — every run failed with `gh: Resource not accessible by integration
+#     (HTTP 403)`, and because the step ran under `set -euo pipefail` the job
+#     aborted on that very first line. The workflow had therefore been red on
+#     100% of its scheduled runs while reporting nothing about the runner, so a
+#     real outage was indistinguishable from its own standing failure.
+#   * The hard-coded runner name no longer matched the registered runner, so
+#     even with a privileged token the `select(...)` would have yielded an empty
+#     result and the desync branch could never have fired.
+#
+# The replacement probes the same user-visible symptom through an endpoint the
+# workflow token can actually read: work queued past a threshold that never
+# allocated a job means no runner is serving the pool. That is precisely the
+# condition of #13045, and it needs no runner name, so a runner rename can never
+# silently disable this check again.
+
 name: self-hosted-runner-health
 
 on:
@@ -5,22 +26,21 @@ on:
     - cron: "*/30 * * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   check:
+    # ubuntu-latest, never the self-hosted pool: a runner-outage detector that
+    # queues behind the outage it is meant to report cannot report it.
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - name: Probe runner state
+      - uses: actions/checkout@v7
+
+      - name: Probe for starved workflow runs
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          state=$(gh api repos/${{ github.repository }}/actions/runners --jq '.runners[] | select(.name == "MV-Stealth-VM")')
-          status=$(echo "$state" | jq -r '.status')
-          busy=$(echo "$state" | jq -r '.busy')
-          if [ "$status" != "online" ] || [ "$busy" = "true" ]; then
-            in_progress=$(gh api repos/${{ github.repository }}/actions/runs --paginate --jq '[.workflow_runs[] | select(.status == "in_progress")] | length')
-            if [ "$in_progress" = "0" ] && [ "$busy" = "true" ]; then
-              echo "::error::Runner desynced: status=$status busy=$busy with 0 in_progress jobs"
-              exit 1
-            fi
-          fi
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: python3 pipeline-scripts/ci_dispatch_watchdog.py --check runner-starvation

--- a/pipeline-scripts/ci_dispatch_watchdog.py
+++ b/pipeline-scripts/ci_dispatch_watchdog.py
@@ -219,9 +219,7 @@ class GitHubApi:
         self.repository = repository
         self.api_root = api_root.rstrip("/")
 
-    def request(
-        self, method: str, path: str, payload: Optional[Dict[str, Any]] = None
-    ) -> Tuple[int, Any]:
+    def request(self, method: str, path: str, payload: Optional[Dict[str, Any]] = None) -> Tuple[int, Any]:
         """Issue a request and return ``(status_code, decoded_body)``."""
         url = path if path.startswith("http") else f"{self.api_root}/{path.lstrip('/')}"
         data = json.dumps(payload).encode("utf-8") if payload is not None else None
@@ -425,7 +423,9 @@ def check_runner_starvation(api: GitHubApi, config: Dict[str, Any]) -> int:
     for run in starved:
         waited = age_minutes(run.get("created_at"), now)
         waited_text = f"{waited:.0f}m" if waited is not None else "unknown"
-        print(f"  {run.get('name')} on {run.get('head_branch')} — queued {waited_text} ({_run_url(api.repository, run)})")
+        print(
+            f"  {run.get('name')} on {run.get('head_branch')} — queued {waited_text} ({_run_url(api.repository, run)})"
+        )
     return 1
 
 

--- a/pipeline-scripts/ci_dispatch_watchdog.py
+++ b/pipeline-scripts/ci_dispatch_watchdog.py
@@ -255,8 +255,11 @@ class GitHubApi:
             return []
         return list(body.get("workflow_runs") or [])
 
-    def recent_runs(self, per_page: int = 100) -> List[Dict[str, Any]]:
-        query = urllib.parse.urlencode({"per_page": str(per_page)})
+    def recent_runs(self, per_page: int = 100, run_status: str = "") -> List[Dict[str, Any]]:
+        params = {"per_page": str(per_page)}
+        if run_status:
+            params["status"] = run_status
+        query = urllib.parse.urlencode(params)
         status, body = self.request("GET", f"/repos/{self.repository}/actions/runs?{query}")
         if status != 200 or not isinstance(body, dict):
             raise WatchdogConfigError(f"cannot list workflow runs (HTTP {status}): {body}")
@@ -303,12 +306,20 @@ def interpret_probe(status: int, message: str) -> Tuple[bool, str]:
 
 
 def probe_approval_capability(api: GitHubApi) -> Tuple[Optional[bool], str]:
-    """Establish whether this credential may approve runs, without side effects."""
+    """
+    Establish whether this credential may approve runs, without side effects.
+
+    The listing MUST be filtered server-side on ``status=completed``. An
+    unfiltered "most recent runs" page is dominated by the runs currently in
+    flight — on a busy repository every entry can be queued or in_progress, and
+    the probe then finds no candidate and reports nothing at all, which is
+    exactly the silent-no-signal failure this module exists to remove.
+    """
     try:
-        runs = api.recent_runs(per_page=20)
+        runs = api.recent_runs(per_page=20, run_status="completed")
     except WatchdogConfigError as exc:
         return None, f"probe skipped: {exc}"
-    candidates = [run for run in runs if run.get("status") == "completed" and not is_parked(run)]
+    candidates = [run for run in runs if not is_parked(run)]
     if not candidates:
         return None, "probe skipped: no completed run available to probe against"
     status, message = api.approve_run(int(candidates[0]["id"]))

--- a/pipeline-scripts/ci_dispatch_watchdog.py
+++ b/pipeline-scripts/ci_dispatch_watchdog.py
@@ -334,6 +334,118 @@ def _run_url(repository: str, run: Dict[str, Any]) -> str:
     return str(run.get("html_url") or f"https://github.com/{repository}/actions")
 
 
+def needs_another_look(runs: Sequence[Dict[str, Any]]) -> bool:
+    """
+    True when this head warrants re-listing after a short wait.
+
+    A head with NO runs at all is the interesting case: immediately after
+    ``update-branch`` returns, the runs it triggers have not materialised yet,
+    so an empty result means "too early", not "nothing to approve". Treating it
+    as final was the whole bug — the sweep would look once, find nothing, and
+    leave the parked runs that appeared a second later untouched until the next
+    scheduled tick. A head that already has runs and no parked ones is genuinely
+    settled.
+    """
+    if not runs:
+        return True
+    return any(is_parked(run) for run in runs)
+
+
+def _approve_head(
+    api: GitHubApi, number: int, runs: Sequence[Dict[str, Any]], budget: int, dry_run: bool
+) -> Tuple[int, int, int]:
+    """Approve the parked runs of one head. Returns (approved, refused, budget)."""
+    approved = 0
+    refused = 0
+    for run in runs:
+        if not is_parked(run):
+            continue
+        if dry_run:
+            print(f"  PR #{number}: would approve '{run.get('name')}' ({run['id']})")
+            continue
+        if budget <= 0:
+            print(f"  PR #{number}: approval budget exhausted, deferring to the next sweep")
+            break
+        budget -= 1
+        status, message = api.approve_run(int(run["id"]))
+        if status in (200, 201, 204):
+            approved += 1
+            print(f"  PR #{number}: approved '{run.get('name')}' ({run['id']})")
+        else:
+            refused += 1
+            print(f"  PR #{number}: could NOT approve '{run.get('name')}' — HTTP {status}: {message}")
+    return approved, refused, budget
+
+
+def sweep_parked_runs(
+    api: GitHubApi,
+    heads: Sequence[Tuple[int, str, Optional[str], str]],
+    config: Dict[str, Any],
+    dry_run: bool,
+) -> Tuple[int, int]:
+    """
+    Approve parked runs across every head, re-listing while any head is unsettled.
+
+    The wait is per attempt, not per head, so total added latency is bounded by
+    ``poll_attempts * poll_interval_seconds`` however many PRs are open.
+    """
+    approved = 0
+    refused = 0
+    budget = config["max_approvals"]
+    for attempt in range(config["poll_attempts"]):
+        unsettled = False
+        for number, sha, _updated_at, _url in heads:
+            runs = api.runs_for_sha(sha)
+            if needs_another_look(runs):
+                unsettled = True
+            head_approved, head_refused, budget = _approve_head(api, number, runs, budget, dry_run)
+            approved += head_approved
+            refused += head_refused
+        last_attempt = attempt + 1 >= config["poll_attempts"]
+        # Stop early once nothing is outstanding, on a dry run (which changes
+        # nothing, so a second look is pointless), or once approval was refused
+        # — retrying a permission failure only delays the report.
+        if not unsettled or dry_run or refused or last_attempt:
+            break
+        time.sleep(config["poll_interval_seconds"])
+    return approved, refused
+
+
+def collect_heads(pulls: Sequence[Dict[str, Any]]) -> List[Tuple[int, str, Optional[str], str]]:
+    """Reduce the PR listing to ``(number, head_sha, updated_at, html_url)`` tuples."""
+    heads: List[Tuple[int, str, Optional[str], str]] = []
+    for pull in pulls:
+        head = pull.get("head") or {}
+        sha = str(head.get("sha") or "")
+        if not sha:
+            continue
+        heads.append((int(pull["number"]), sha, pull.get("updated_at"), str(pull.get("html_url") or "")))
+    return heads
+
+
+def publish_dispatch_states(
+    api: GitHubApi,
+    heads: Sequence[Tuple[int, str, Optional[str], str]],
+    config: Dict[str, Any],
+    dry_run: bool,
+) -> int:
+    """Write the dispatch commit status for each head. Returns the not-dispatched count."""
+    now = datetime.now(timezone.utc)
+    blocked = 0
+    for number, sha, updated_at, url in heads:
+        runs = api.runs_for_sha(sha)
+        state, description = classify_dispatch(runs, updated_at, now, config["grace_minutes"], config["stall_minutes"])
+        target = _run_url(api.repository, runs[0]) if runs else url
+        if dry_run:
+            print(f"  PR #{number}: would set {state} — {description}")
+        else:
+            code = api.set_status(sha, state, config["status_context"], description, target)
+            print(f"  PR #{number}: {state} — {description} (status API HTTP {code})")
+        if state != "success":
+            blocked += 1
+    return blocked
+
+
 def check_dispatch(api: GitHubApi, config: Dict[str, Any], dry_run: bool = False) -> int:
     """Approve what can be approved, then publish dispatch state on every open PR."""
     if dry_run:
@@ -344,63 +456,9 @@ def check_dispatch(api: GitHubApi, config: Dict[str, Any], dry_run: bool = False
     permitted, explanation = probe_approval_capability(api)
     print(f"Approval capability probe: {explanation}")
 
-    approved = 0
-    refused = 0
-    budget = config["max_approvals"]
-
-    heads: List[Tuple[int, str, Optional[str], str]] = []
-    for pull in pulls:
-        head = pull.get("head") or {}
-        sha = str(head.get("sha") or "")
-        if not sha:
-            continue
-        heads.append((int(pull["number"]), sha, pull.get("updated_at"), str(pull.get("html_url") or "")))
-
-    for number, sha, _updated_at, _url in heads:
-        for attempt in range(config["poll_attempts"]):
-            runs = api.runs_for_sha(sha)
-            parked = [run for run in runs if is_parked(run)]
-            if not parked:
-                break
-            for run in parked:
-                if dry_run:
-                    print(f"  PR #{number}: would approve '{run.get('name')}' ({run['id']})")
-                    continue
-                if budget <= 0:
-                    print(f"  PR #{number}: approval budget exhausted, deferring to the next sweep")
-                    break
-                budget -= 1
-                status, message = api.approve_run(int(run["id"]))
-                if status in (200, 201, 204):
-                    approved += 1
-                    print(f"  PR #{number}: approved '{run.get('name')}' ({run['id']})")
-                else:
-                    refused += 1
-                    print(f"  PR #{number}: could NOT approve '{run.get('name')}' — HTTP {status}: {message}")
-            if dry_run:
-                break
-            if attempt + 1 < config["poll_attempts"] and refused == 0:
-                time.sleep(config["poll_interval_seconds"])
-
-    now = datetime.now(timezone.utc)
-    blocked = 0
-    for number, sha, updated_at, url in heads:
-        runs = api.runs_for_sha(sha)
-        state, description = classify_dispatch(
-            runs,
-            updated_at,
-            now,
-            config["grace_minutes"],
-            config["stall_minutes"],
-        )
-        target = _run_url(api.repository, runs[0]) if runs else url
-        if dry_run:
-            print(f"  PR #{number}: would set {state} — {description}")
-        else:
-            code = api.set_status(sha, state, config["status_context"], description, target)
-            print(f"  PR #{number}: {state} — {description} (status API HTTP {code})")
-        if state != "success":
-            blocked += 1
+    heads = collect_heads(pulls)
+    approved, refused = sweep_parked_runs(api, heads, config, dry_run)
+    blocked = publish_dispatch_states(api, heads, config, dry_run)
 
     print(f"Sweep complete: {approved} approved, {refused} refused, {blocked} PR(s) not dispatched.")
 

--- a/pipeline-scripts/ci_dispatch_watchdog.py
+++ b/pipeline-scripts/ci_dispatch_watchdog.py
@@ -91,7 +91,7 @@ UNSTARTED_RUN_STATUSES = frozenset({"queued", "waiting", "pending", "requested"}
 DEFAULT_API_ROOT = "https://api.github.com"
 DEFAULT_BASE_BRANCH = "Dev_new_gui"
 DEFAULT_GRACE_MINUTES = 10
-DEFAULT_STALL_MINUTES = 30
+DEFAULT_STALL_MINUTES = 45
 DEFAULT_MAX_APPROVALS = 30
 DEFAULT_POLL_ATTEMPTS = 3
 DEFAULT_POLL_INTERVAL_SECONDS = 20
@@ -162,6 +162,22 @@ def starved_runs(runs: Sequence[Dict[str, Any]], now: datetime, stall_minutes: i
     return starved
 
 
+def pool_is_serving(runs: Sequence[Dict[str, Any]]) -> bool:
+    """
+    True when at least one run is executing, i.e. the runner pool is alive.
+
+    A long queue is ambiguous on its own: the singleton self-hosted runner is
+    routinely occupied for half an hour by the frontend suite, so "queued 45
+    minutes" during normal contention looks identical to "queued 45 minutes
+    because no runner exists". The presence of ANY in-progress run separates
+    them, and it is the one signal available to a workflow token — the
+    /actions/runners endpoint that would answer directly returns 403 for
+    GITHUB_TOKEN. This is the heuristic the previous self-hosted-runner-health
+    probe used for its desync branch, kept rather than dropped.
+    """
+    return any(run.get("status") == "in_progress" for run in runs)
+
+
 def _truncate(text: str) -> str:
     if len(text) <= MAX_STATUS_DESCRIPTION:
         return text
@@ -174,6 +190,7 @@ def classify_dispatch(
     now: datetime,
     grace_minutes: int,
     stall_minutes: int,
+    pool_serving: bool = True,
 ) -> Tuple[str, str]:
     """
     Decide the commit-status state for one PR head.
@@ -194,9 +211,16 @@ def classify_dispatch(
     starved = starved_runs(runs, now, stall_minutes)
     if starved:
         names = ", ".join(sorted({str(run.get("name", "?")) for run in starved})[:3])
+        if pool_serving:
+            # Contention, not an outage — still never green, because the head is
+            # demonstrably not verified yet.
+            return (
+                "pending",
+                _truncate(f"{len(starved)} run(s) queued over {stall_minutes}m behind a busy runner pool: {names}"),
+            )
         return (
             "failure",
-            _truncate(f"{len(starved)} run(s) queued over {stall_minutes}m with no runner: {names}"),
+            _truncate(f"{len(starved)} run(s) queued over {stall_minutes}m with no runner available: {names}"),
         )
 
     if not runs:
@@ -486,7 +510,13 @@ def check_runner_starvation(api: GitHubApi, config: Dict[str, Any]) -> int:
     now = datetime.now(timezone.utc)
     starved = starved_runs(runs, now, config["stall_minutes"])
     if not starved:
-        print(f"No run has been queued longer than {config['stall_minutes']}m — runner pool is serving work.")
+        print(f"No run has been queued longer than {config['stall_minutes']}m — runner pool is keeping up.")
+        return 0
+    if pool_is_serving(runs):
+        print(
+            f"{len(starved)} run(s) queued over {config['stall_minutes']}m, but the pool is executing work — "
+            "contention, not an outage."
+        )
         return 0
     print(f"::error::{len(starved)} workflow run(s) queued over {config['stall_minutes']}m with no runner available")
     for run in starved:

--- a/pipeline-scripts/ci_dispatch_watchdog.py
+++ b/pipeline-scripts/ci_dispatch_watchdog.py
@@ -29,19 +29,37 @@ This module handles both:
 
 * ``--check dispatch`` — probes whether the caller's token may approve
   workflow runs at all, approves the parked runs belonging to the current
-  head commit of each open PR (bounded), and then publishes a commit status
-  on every open PR head describing the dispatch state. A PR whose CI never
-  dispatched therefore carries a visible, named, non-green context instead of
-  silently reading as ready.
+  head commit of each open *same-repository* PR (bounded), and then publishes
+  a commit status on every open PR head describing the dispatch state. A PR
+  whose CI never dispatched therefore carries a visible, named, non-green
+  context instead of silently reading as ready.
+* ``--check probe`` — prints nothing but the credential verdict. It POSTs
+  ``approve`` against a run that already succeeded, which GitHub rejects on
+  state grounds, so it changes nothing and is safe to run from an unreviewed
+  branch. This exists because ``--dry-run`` deliberately issues no approve
+  request and therefore cannot answer the question at all.
 * ``--check runner-starvation`` — reports runs that have been queued past a
-  threshold without ever creating a job, i.e. an empty runner pool. This uses
-  only ``GET /actions/runs``; the ``/actions/runners`` administration
-  endpoint returns ``403 Resource not accessible by integration`` for
-  ``GITHUB_TOKEN`` and cannot be used from a workflow.
+  threshold while no self-hosted job is executing. The ``/actions/runners``
+  administration endpoint returns ``403 Resource not accessible by
+  integration`` for ``GITHUB_TOKEN``, so runner liveness is inferred from
+  ``GET /actions/runs/{id}/jobs`` labels instead.
+
+**Fork safety.** ``POST /actions/runs/{id}/approve`` is GitHub's
+*approve-a-fork-pull-request-run* endpoint: releasing gated fork runs is its
+entire purpose. This repository is public, receives fork pull requests, sets
+``all_external_contributors`` deliberately, and runs several
+``pull_request`` jobs on a self-hosted runner. Auto-approving a fork run would
+therefore execute contributor-controlled code — ``npm ci`` and its lifecycle
+scripts among it — on the owner's own machine, which is exactly what the
+approval policy exists to prevent. Approval is consequently restricted to runs
+whose head repository is this repository AND whose triggering actor is the
+branch-update bot. Fork pull requests still receive a published *status*; they
+never receive an approval.
 
 Usage:
     pipeline-scripts/ci_dispatch_watchdog.py --check dispatch
     pipeline-scripts/ci_dispatch_watchdog.py --check dispatch --dry-run
+    pipeline-scripts/ci_dispatch_watchdog.py --check probe
     pipeline-scripts/ci_dispatch_watchdog.py --check runner-starvation
 
 Environment:
@@ -55,12 +73,14 @@ Environment:
     WATCHDOG_POLL_ATTEMPTS           re-list attempts while runs appear
     WATCHDOG_POLL_INTERVAL_SECONDS   delay between those attempts
     WATCHDOG_STATUS_CONTEXT          commit status context name
+    WATCHDOG_MAX_JOB_LOOKUPS         runs inspected for runner liveness per check
 
 Exit codes:
     0  nothing wrong, or everything wrong was repaired
     1  parked runs exist that this token is not permitted to approve
        (owner action required — see the printed remediation)
-    2  internal error (missing configuration, unusable API response)
+    2  internal error: configuration missing, or the API could not be reached
+       at all. Never used for "the API answered and the answer was bad news".
 """
 
 from __future__ import annotations
@@ -68,13 +88,14 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import socket
 import sys
 import time
 import urllib.error
 import urllib.parse
 import urllib.request
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional, Sequence, Tuple
+from typing import Any, Dict, List, NamedTuple, Optional, Sequence, Set, Tuple
 
 # GitHub returns this message when the *token* lacks `actions: write`.
 PERMISSION_DENIED_MARKER = "resource not accessible"
@@ -82,11 +103,21 @@ PERMISSION_DENIED_MARKER = "resource not accessible"
 # Seeing it proves the credential may approve runs.
 NOT_WAITING_MARKER = "not waiting for approval"
 
+# The only actor whose parked runs this tool releases. Runs parked for any other
+# reason are reported, never approved — see the fork-safety note above.
+UPDATE_BOT_LOGIN = "github-actions[bot]"
+
+# A job carrying this label ran on the self-hosted pool.
+SELF_HOSTED_LABEL = "self-hosted"
+
 # GitHub truncates commit-status descriptions beyond this length.
 MAX_STATUS_DESCRIPTION = 140
 
 # Run states that mean "created but no job has started yet".
 UNSTARTED_RUN_STATUSES = frozenset({"queued", "waiting", "pending", "requested"})
+
+# Transport failure — no HTTP status was ever received.
+NO_RESPONSE_STATUS = 0
 
 DEFAULT_API_ROOT = "https://api.github.com"
 DEFAULT_BASE_BRANCH = "Dev_new_gui"
@@ -96,10 +127,38 @@ DEFAULT_MAX_APPROVALS = 30
 DEFAULT_POLL_ATTEMPTS = 3
 DEFAULT_POLL_INTERVAL_SECONDS = 20
 DEFAULT_STATUS_CONTEXT = "ci-dispatch-watchdog"
+DEFAULT_MAX_JOB_LOOKUPS = 10
+DEFAULT_REQUEST_TIMEOUT_SECONDS = 30
 
 
-class WatchdogConfigError(RuntimeError):
-    """Raised when required environment configuration is absent."""
+class WatchdogError(RuntimeError):
+    """Base for every error this module raises deliberately."""
+
+
+class WatchdogConfigError(WatchdogError):
+    """Raised when required environment configuration is absent or unusable."""
+
+
+class WatchdogApiError(WatchdogError):
+    """
+    Raised when the API answered with something unusable.
+
+    This is deliberately distinct from "the API answered and said there are no
+    runs". Conflating the two is how a single rate-limit window turns into
+    "CI never dispatched" printed against every open pull request.
+    """
+
+
+class PullHead(NamedTuple):
+    """The properties of an open pull request this tool acts on."""
+
+    number: int
+    sha: str
+    updated_at: Optional[str]
+    url: str
+    # False for a pull request opened from a fork. Such heads are reported but
+    # never approved — see the fork-safety note in the module docstring.
+    same_repo: bool
 
 
 def _env_int(name: str, default: int) -> int:
@@ -150,8 +209,37 @@ def is_unstarted(run: Dict[str, Any]) -> bool:
     return run.get("status") in UNSTARTED_RUN_STATUSES
 
 
+def run_is_same_repo(run: Dict[str, Any], repository: str) -> bool:
+    """True when the run's head branch lives in *repository* rather than a fork."""
+    head_repository = run.get("head_repository") or {}
+    return str(head_repository.get("full_name") or "") == repository
+
+
+def is_approvable(run: Dict[str, Any], repository: str) -> Tuple[bool, str]:
+    """
+    Decide whether this tool may release *run*, and say why not when it may not.
+
+    Two conditions, both required. The head must live in this repository:
+    ``approve`` exists to release gated FORK runs, and this repository is
+    public, takes fork pull requests, and executes ``pull_request`` jobs on a
+    self-hosted runner, so approving a fork run would run contributor-supplied
+    code on the owner's machine. And the run must have been parked because the
+    branch-update bot pushed it — a run parked for any other reason was parked
+    by a policy decision this tool has no business overriding.
+    """
+    if not is_parked(run):
+        return False, "not parked"
+    if not run_is_same_repo(run, repository):
+        origin = (run.get("head_repository") or {}).get("full_name") or "unknown"
+        return False, f"fork pull request from {origin} — gated on purpose, never auto-approved"
+    actor = (run.get("triggering_actor") or {}).get("login") or ""
+    if actor != UPDATE_BOT_LOGIN:
+        return False, f"parked for actor {actor or 'unknown'}, not the branch-update bot"
+    return True, ""
+
+
 def starved_runs(runs: Sequence[Dict[str, Any]], now: datetime, stall_minutes: int) -> List[Dict[str, Any]]:
-    """Runs queued longer than *stall_minutes* — an empty runner pool."""
+    """Runs queued longer than *stall_minutes* without allocating a job."""
     starved = []
     for run in runs:
         if not is_unstarted(run):
@@ -162,20 +250,10 @@ def starved_runs(runs: Sequence[Dict[str, Any]], now: datetime, stall_minutes: i
     return starved
 
 
-def pool_is_serving(runs: Sequence[Dict[str, Any]]) -> bool:
-    """
-    True when at least one run is executing, i.e. the runner pool is alive.
-
-    A long queue is ambiguous on its own: the singleton self-hosted runner is
-    routinely occupied for half an hour by the frontend suite, so "queued 45
-    minutes" during normal contention looks identical to "queued 45 minutes
-    because no runner exists". The presence of ANY in-progress run separates
-    them, and it is the one signal available to a workflow token — the
-    /actions/runners endpoint that would answer directly returns 403 for
-    GITHUB_TOKEN. This is the heuristic the previous self-hosted-runner-health
-    probe used for its desync branch, kept rather than dropped.
-    """
-    return any(run.get("status") == "in_progress" for run in runs)
+def job_is_self_hosted(job: Dict[str, Any]) -> bool:
+    """True when this job was dispatched to the self-hosted pool."""
+    labels = [str(label).lower() for label in (job.get("labels") or [])]
+    return SELF_HOSTED_LABEL in labels
 
 
 def _truncate(text: str) -> str:
@@ -238,13 +316,28 @@ def classify_dispatch(
 class GitHubApi:
     """Minimal GitHub REST client — stdlib only, no extra CI dependency."""
 
-    def __init__(self, token: str, repository: str, api_root: str = DEFAULT_API_ROOT) -> None:
+    def __init__(
+        self,
+        token: str,
+        repository: str,
+        api_root: str = DEFAULT_API_ROOT,
+        timeout: int = DEFAULT_REQUEST_TIMEOUT_SECONDS,
+    ) -> None:
         self.token = token
         self.repository = repository
         self.api_root = api_root.rstrip("/")
+        self.timeout = timeout
 
     def request(self, method: str, path: str, payload: Optional[Dict[str, Any]] = None) -> Tuple[int, Any]:
-        """Issue a request and return ``(status_code, decoded_body)``."""
+        """
+        Issue a request and return ``(status_code, decoded_body)``.
+
+        A transport failure (DNS, TLS, connection reset, timeout) returns status
+        ``NO_RESPONSE_STATUS`` rather than escaping as a traceback. An uncaught
+        ``URLError`` would exit the process with code 1, which this module
+        documents as "parked runs could not be approved" — a completely
+        different condition, reported with no remediation text.
+        """
         url = path if path.startswith("http") else f"{self.api_root}/{path.lstrip('/')}"
         data = json.dumps(payload).encode("utf-8") if payload is not None else None
         request = urllib.request.Request(url=url, method=method, data=data)
@@ -254,7 +347,7 @@ class GitHubApi:
         if data is not None:
             request.add_header("Content-Type", "application/json")
         try:
-            with urllib.request.urlopen(request) as response:  # noqa: S310 - fixed api host
+            with urllib.request.urlopen(request, timeout=self.timeout) as response:  # noqa: S310 - fixed api host
                 body = response.read().decode("utf-8")
                 return response.status, (json.loads(body) if body else None)
         except urllib.error.HTTPError as exc:
@@ -264,30 +357,46 @@ class GitHubApi:
             except json.JSONDecodeError:
                 decoded = {"message": body}
             return exc.code, decoded
+        except (urllib.error.URLError, socket.timeout, OSError) as exc:
+            return NO_RESPONSE_STATUS, {"message": f"transport failure: {exc}"}
+
+    def _list_runs(self, params: Dict[str, str], context: str) -> List[Dict[str, Any]]:
+        query = urllib.parse.urlencode(params)
+        status, body = self.request("GET", f"/repos/{self.repository}/actions/runs?{query}")
+        if status != 200 or not isinstance(body, dict):
+            raise WatchdogApiError(f"cannot list {context} (HTTP {status}): {body}")
+        return list(body.get("workflow_runs") or [])
 
     def open_pull_requests(self, base: str) -> List[Dict[str, Any]]:
         query = urllib.parse.urlencode({"state": "open", "base": base, "per_page": "100"})
         status, body = self.request("GET", f"/repos/{self.repository}/pulls?{query}")
         if status != 200 or not isinstance(body, list):
-            raise WatchdogConfigError(f"cannot list open PRs (HTTP {status}): {body}")
+            raise WatchdogApiError(f"cannot list open PRs (HTTP {status}): {body}")
         return body
 
     def runs_for_sha(self, sha: str) -> List[Dict[str, Any]]:
-        query = urllib.parse.urlencode({"head_sha": sha, "per_page": "100"})
-        status, body = self.request("GET", f"/repos/{self.repository}/actions/runs?{query}")
-        if status != 200 or not isinstance(body, dict):
-            return []
-        return list(body.get("workflow_runs") or [])
+        """
+        Runs attached to one head commit.
+
+        Raises rather than returning ``[]`` on an API error: an empty list is
+        interpreted downstream as "CI never dispatched", which is a specific and
+        alarming claim that must never be made on the strength of a rate-limit
+        response.
+        """
+        return self._list_runs({"head_sha": sha, "per_page": "100"}, f"runs for {sha[:12]}")
 
     def recent_runs(self, per_page: int = 100, run_status: str = "") -> List[Dict[str, Any]]:
         params = {"per_page": str(per_page)}
         if run_status:
             params["status"] = run_status
-        query = urllib.parse.urlencode(params)
-        status, body = self.request("GET", f"/repos/{self.repository}/actions/runs?{query}")
+        return self._list_runs(params, f"recent runs (status={run_status or 'any'})")
+
+    def run_jobs(self, run_id: int) -> List[Dict[str, Any]]:
+        query = urllib.parse.urlencode({"per_page": "100"})
+        status, body = self.request("GET", f"/repos/{self.repository}/actions/runs/{run_id}/jobs?{query}")
         if status != 200 or not isinstance(body, dict):
-            raise WatchdogConfigError(f"cannot list workflow runs (HTTP {status}): {body}")
-        return list(body.get("workflow_runs") or [])
+            raise WatchdogApiError(f"cannot list jobs for run {run_id} (HTTP {status}): {body}")
+        return list(body.get("jobs") or [])
 
     def approve_run(self, run_id: int) -> Tuple[int, str]:
         status, body = self.request("POST", f"/repos/{self.repository}/actions/runs/{run_id}/approve")
@@ -308,7 +417,38 @@ class GitHubApi:
         return status
 
 
-def interpret_probe(status: int, message: str) -> Tuple[bool, str]:
+def self_hosted_pool_is_serving(api: GitHubApi, max_lookups: int) -> Optional[bool]:
+    """
+    True when a job is executing on the SELF-HOSTED pool right now.
+
+    Any in-progress run used to count, which made this near-permanently true:
+    ``code-quality``, ``ci.yml`` and this very watchdog's own quarter-hourly
+    cron all run on GitHub-hosted runners, so "something is executing" says
+    nothing about the singleton machine that #13045 is about. Runner liveness is
+    therefore established from job labels — the closest signal to
+    ``/actions/runners`` that a workflow token is allowed to read.
+
+    Returns ``None`` when the answer could not be established, so the caller can
+    say "unknown" instead of inventing a verdict.
+    """
+    try:
+        running = api.recent_runs(per_page=max_lookups, run_status="in_progress")
+    except WatchdogApiError as exc:
+        print(f"  runner liveness unknown: {exc}")
+        return None
+    for run in running[:max_lookups]:
+        try:
+            jobs = api.run_jobs(int(run["id"]))
+        except WatchdogApiError as exc:
+            print(f"  runner liveness partial: {exc}")
+            continue
+        for job in jobs:
+            if job.get("status") == "in_progress" and job_is_self_hosted(job):
+                return True
+    return False
+
+
+def interpret_probe(status: int, message: str) -> Tuple[Optional[bool], str]:
     """
     Turn an ``approve`` response for a run that is NOT awaiting approval into a
     verdict about the *credential*.
@@ -316,8 +456,12 @@ def interpret_probe(status: int, message: str) -> Tuple[bool, str]:
     A token that holds ``actions: write`` is rejected on state grounds
     ("This workflow run is not waiting for approval"); a token that does not is
     rejected on permission grounds ("Resource not accessible by integration").
-    The two are distinguishable, so capability can be established without
-    approving anything and without any side effect.
+
+    Anything else returns ``None`` — unresolved. Returning ``True`` for an
+    unrecognised response would mean a bad credential, a 404, a rate-limit
+    window or an HTML error page all read as "permitted", which is precisely
+    the fail-open this module exists to argue against. The caller must treat
+    ``None`` as "no verdict", never as "fine".
     """
     lowered = message.lower()
     if PERMISSION_DENIED_MARKER in lowered:
@@ -326,29 +470,42 @@ def interpret_probe(status: int, message: str) -> Tuple[bool, str]:
         return True, "token may approve workflow runs (rejected on run state, not permission)"
     if status in (200, 201, 204):
         return True, "token may approve workflow runs (approval accepted)"
-    return True, f"inconclusive probe (HTTP {status}: {message or 'no message'}) — assuming permitted"
+    if status == NO_RESPONSE_STATUS:
+        return None, f"unresolved — the API could not be reached ({message or 'no detail'})"
+    if status == 401:
+        return None, "unresolved — the credential was rejected (401 Bad credentials)"
+    if status == 404:
+        return None, "unresolved — the probe run was not found (404); the token may lack read access"
+    if status == 429:
+        return None, "unresolved — rate limited (429); retry on the next sweep"
+    return None, f"unresolved — unrecognised response (HTTP {status}: {message or 'no message'})"
 
 
-def probe_approval_capability(api: GitHubApi) -> Tuple[Optional[bool], str]:
+def probe_approval_capability(api: GitHubApi, dry_run: bool = False) -> Tuple[Optional[bool], str]:
     """
     Establish whether this credential may approve runs, without side effects.
 
-    The listing MUST be filtered server-side on ``status=completed``. An
-    unfiltered "most recent runs" page is dominated by the runs currently in
-    flight — on a busy repository every entry can be queued or in_progress, and
-    the probe then finds no candidate and reports nothing at all, which is
-    exactly the silent-no-signal failure this module exists to remove.
+    Two details that both silently defeated earlier versions:
+
+    * The candidate listing must select ``status=success``, not
+      ``status=completed``. A parked run IS ``status=completed`` (with
+      ``conclusion=action_required``), so on a repository carrying hundreds of
+      parked runs every entry on the "recent completed" page is parked, every
+      candidate is filtered out, and the probe reports nothing at all.
+    * A dry run performs no approval call, so it cannot probe either. It says so
+      rather than pretending the question was answered.
     """
+    if dry_run:
+        return None, "probe skipped: --dry-run issues no approve request"
     try:
-        runs = api.recent_runs(per_page=20, run_status="completed")
-    except WatchdogConfigError as exc:
-        return None, f"probe skipped: {exc}"
+        runs = api.recent_runs(per_page=20, run_status="success")
+    except WatchdogApiError as exc:
+        return None, f"probe unresolved: {exc}"
     candidates = [run for run in runs if not is_parked(run)]
     if not candidates:
-        return None, "probe skipped: no completed run available to probe against"
+        return None, "probe unresolved: no successful run available to probe against"
     status, message = api.approve_run(int(candidates[0]["id"]))
-    permitted, explanation = interpret_probe(status, message)
-    return permitted, explanation
+    return interpret_probe(status, message)
 
 
 REMEDIATION = (
@@ -375,11 +532,8 @@ def needs_another_look(runs: Sequence[Dict[str, Any]]) -> bool:
 
     A head with NO runs at all is the interesting case: immediately after
     ``update-branch`` returns, the runs it triggers have not materialised yet,
-    so an empty result means "too early", not "nothing to approve". Treating it
-    as final was the whole bug — the sweep would look once, find nothing, and
-    leave the parked runs that appeared a second later untouched until the next
-    scheduled tick. A head that already has runs and no parked ones is genuinely
-    settled.
+    so an empty result means "too early", not "nothing to approve". A head that
+    already has runs and no parked ones is genuinely settled.
     """
     if not runs:
         return True
@@ -389,19 +543,24 @@ def needs_another_look(runs: Sequence[Dict[str, Any]]) -> bool:
 def _approve_head(
     api: GitHubApi, number: int, runs: Sequence[Dict[str, Any]], budget: int, dry_run: bool
 ) -> Tuple[int, int, int]:
-    """Approve the parked runs of one head. Returns (approved, refused, budget)."""
+    """Approve the eligible parked runs of one head. Returns (approved, refused, budget)."""
     approved = 0
     refused = 0
     for run in runs:
-        if not is_parked(run):
-            continue
-        if dry_run:
-            print(f"  PR #{number}: would approve '{run.get('name')}' ({run['id']})")
+        eligible, reason = is_approvable(run, api.repository)
+        if not eligible:
+            if is_parked(run):
+                print(f"  PR #{number}: leaving '{run.get('name')}' parked — {reason}")
             continue
         if budget <= 0:
             print(f"  PR #{number}: approval budget exhausted, deferring to the next sweep")
             break
+        # Decremented on a dry run too, so the preview reflects the cap a real
+        # sweep would hit rather than promising more than it would do.
         budget -= 1
+        if dry_run:
+            print(f"  PR #{number}: would approve '{run.get('name')}' ({run['id']})")
+            continue
         status, message = api.approve_run(int(run["id"]))
         if status in (200, 201, 204):
             approved += 1
@@ -412,12 +571,38 @@ def _approve_head(
     return approved, refused, budget
 
 
+def _sweep_once(
+    api: GitHubApi, heads: Sequence[PullHead], budget: int, dry_run: bool
+) -> Tuple[int, int, int, bool, Set[str]]:
+    """One pass over every head. Returns (approved, refused, budget, unsettled, touched)."""
+    approved = 0
+    refused = 0
+    unsettled = False
+    touched: Set[str] = set()
+    for head in heads:
+        try:
+            runs = api.runs_for_sha(head.sha)
+        except WatchdogApiError as exc:
+            print(f"  PR #{head.number}: cannot inspect runs — {exc}")
+            unsettled = True
+            continue
+        if needs_another_look(runs):
+            unsettled = True
+        if not head.same_repo:
+            if any(is_parked(run) for run in runs):
+                print(f"  PR #{head.number}: fork pull request — parked runs left for a human to approve")
+            continue
+        head_approved, head_refused, budget = _approve_head(api, head.number, runs, budget, dry_run)
+        if head_approved:
+            touched.add(head.sha)
+        approved += head_approved
+        refused += head_refused
+    return approved, refused, budget, unsettled, touched
+
+
 def sweep_parked_runs(
-    api: GitHubApi,
-    heads: Sequence[Tuple[int, str, Optional[str], str]],
-    config: Dict[str, Any],
-    dry_run: bool,
-) -> Tuple[int, int]:
+    api: GitHubApi, heads: Sequence[PullHead], config: Dict[str, Any], dry_run: bool
+) -> Tuple[int, int, Set[str]]:
     """
     Approve parked runs across every head, re-listing while any head is unsettled.
 
@@ -426,56 +611,77 @@ def sweep_parked_runs(
     """
     approved = 0
     refused = 0
+    touched: Set[str] = set()
     budget = config["max_approvals"]
     for attempt in range(config["poll_attempts"]):
-        unsettled = False
-        for number, sha, _updated_at, _url in heads:
-            runs = api.runs_for_sha(sha)
-            if needs_another_look(runs):
-                unsettled = True
-            head_approved, head_refused, budget = _approve_head(api, number, runs, budget, dry_run)
-            approved += head_approved
-            refused += head_refused
+        pass_approved, pass_refused, budget, unsettled, pass_touched = _sweep_once(api, heads, budget, dry_run)
+        approved += pass_approved
+        refused += pass_refused
+        touched |= pass_touched
         last_attempt = attempt + 1 >= config["poll_attempts"]
-        # Stop early once nothing is outstanding, on a dry run (which changes
-        # nothing, so a second look is pointless), or once approval was refused
-        # — retrying a permission failure only delays the report.
+        # Stop once nothing is outstanding, on a dry run (which changes nothing,
+        # so a second look is pointless), or once approval was refused —
+        # retrying a permission failure only delays the report.
         if not unsettled or dry_run or refused or last_attempt:
             break
         time.sleep(config["poll_interval_seconds"])
-    return approved, refused
+    return approved, refused, touched
 
 
-def collect_heads(pulls: Sequence[Dict[str, Any]]) -> List[Tuple[int, str, Optional[str], str]]:
-    """Reduce the PR listing to ``(number, head_sha, updated_at, html_url)`` tuples."""
-    heads: List[Tuple[int, str, Optional[str], str]] = []
+def collect_heads(pulls: Sequence[Dict[str, Any]], repository: str) -> List[PullHead]:
+    """Reduce the PR listing to the heads this tool acts on, flagging fork origins."""
+    heads: List[PullHead] = []
     for pull in pulls:
         head = pull.get("head") or {}
         sha = str(head.get("sha") or "")
         if not sha:
             continue
-        heads.append((int(pull["number"]), sha, pull.get("updated_at"), str(pull.get("html_url") or "")))
+        head_repo = str((head.get("repo") or {}).get("full_name") or "")
+        heads.append(
+            PullHead(
+                number=int(pull["number"]),
+                sha=sha,
+                updated_at=pull.get("updated_at"),
+                url=str(pull.get("html_url") or ""),
+                same_repo=head_repo == repository,
+            )
+        )
     return heads
 
 
 def publish_dispatch_states(
     api: GitHubApi,
-    heads: Sequence[Tuple[int, str, Optional[str], str]],
+    heads: Sequence[PullHead],
     config: Dict[str, Any],
     dry_run: bool,
+    pool_serving: Optional[bool],
 ) -> int:
     """Write the dispatch commit status for each head. Returns the not-dispatched count."""
     now = datetime.now(timezone.utc)
     blocked = 0
-    for number, sha, updated_at, url in heads:
-        runs = api.runs_for_sha(sha)
-        state, description = classify_dispatch(runs, updated_at, now, config["grace_minutes"], config["stall_minutes"])
-        target = _run_url(api.repository, runs[0]) if runs else url
-        if dry_run:
-            print(f"  PR #{number}: would set {state} — {description}")
+    for head in heads:
+        try:
+            runs = api.runs_for_sha(head.sha)
+        except WatchdogApiError as exc:
+            # Never assert "CI never dispatched" on the strength of an API
+            # failure — say the state is unknown, and say why.
+            state, description = "pending", _truncate(f"dispatch state unknown (API error: {exc})")
+            runs = []
         else:
-            code = api.set_status(sha, state, config["status_context"], description, target)
-            print(f"  PR #{number}: {state} — {description} (status API HTTP {code})")
+            state, description = classify_dispatch(
+                runs,
+                head.updated_at,
+                now,
+                config["grace_minutes"],
+                config["stall_minutes"],
+                pool_serving is not False,
+            )
+        target = _run_url(api.repository, runs[0]) if runs else head.url
+        if dry_run:
+            print(f"  PR #{head.number}: would set {state} — {description}")
+        else:
+            code = api.set_status(head.sha, state, config["status_context"], description, target)
+            print(f"  PR #{head.number}: {state} — {description} (status API HTTP {code})")
         if state != "success":
             blocked += 1
     return blocked
@@ -484,16 +690,18 @@ def publish_dispatch_states(
 def check_dispatch(api: GitHubApi, config: Dict[str, Any], dry_run: bool = False) -> int:
     """Approve what can be approved, then publish dispatch state on every open PR."""
     if dry_run:
-        print("DRY RUN: no run will be approved and no commit status will be written.")
+        print("DRY RUN: nothing is approved, no commit status is written, and no probe is issued.")
     pulls = api.open_pull_requests(config["base_branch"])
-    print(f"Open PRs targeting {config['base_branch']}: {len(pulls)}")
+    heads = collect_heads(pulls, api.repository)
+    forks = sum(1 for head in heads if not head.same_repo)
+    print(f"Open PRs targeting {config['base_branch']}: {len(pulls)} ({forks} from forks, never auto-approved)")
 
-    permitted, explanation = probe_approval_capability(api)
+    permitted, explanation = probe_approval_capability(api, dry_run)
     print(f"Approval capability probe: {explanation}")
 
-    heads = collect_heads(pulls)
-    approved, refused = sweep_parked_runs(api, heads, config, dry_run)
-    blocked = publish_dispatch_states(api, heads, config, dry_run)
+    approved, refused, _touched = sweep_parked_runs(api, heads, config, dry_run)
+    pool_serving = self_hosted_pool_is_serving(api, config["max_job_lookups"])
+    blocked = publish_dispatch_states(api, heads, config, dry_run, pool_serving)
 
     print(f"Sweep complete: {approved} approved, {refused} refused, {blocked} PR(s) not dispatched.")
 
@@ -501,24 +709,62 @@ def check_dispatch(api: GitHubApi, config: Dict[str, Any], dry_run: bool = False
         print("::error::" + REMEDIATION.replace("\n", "%0A"))
         print(REMEDIATION)
         return 1
+    if permitted is None:
+        # Unresolved is not benign: the repair path is unproven until a probe
+        # returns a verdict, and saying nothing here is the exact failure mode
+        # this module was written to remove.
+        print(f"::warning::Approval capability is UNRESOLVED — {explanation}. Do not treat #12823 as proven fixed.")
+    return 0
+
+
+def check_probe(api: GitHubApi) -> int:
+    """
+    Print the credential verdict and nothing else.
+
+    Separate from ``dispatch`` so the question can be answered from a pull
+    request without approving anything or writing any status, and separate from
+    ``--dry-run`` because a dry run issues no approve request and therefore
+    cannot answer it.
+    """
+    permitted, explanation = probe_approval_capability(api)
+    print(f"Approval capability probe: {explanation}")
+    if permitted is False:
+        print("::error::" + REMEDIATION.replace("\n", "%0A"))
+        print(REMEDIATION)
+        return 1
+    if permitted is None:
+        print(f"::warning::Approval capability is UNRESOLVED — {explanation}")
+        return 0
+    print("This credential may approve parked runs; no owner action is required for #12823.")
     return 0
 
 
 def check_runner_starvation(api: GitHubApi, config: Dict[str, Any]) -> int:
-    """Report runs that were created but never allocated a job (#13045)."""
-    runs = api.recent_runs()
+    """Report runs queued past the threshold while the self-hosted pool is idle (#13045)."""
     now = datetime.now(timezone.utc)
-    starved = starved_runs(runs, now, config["stall_minutes"])
+    # Filtered server-side: an unfiltered page is dominated by the hundreds of
+    # parked runs this repository carries, which can hide every queued run.
+    queued = api.recent_runs(run_status="queued")
+    starved = starved_runs(queued, now, config["stall_minutes"])
     if not starved:
         print(f"No run has been queued longer than {config['stall_minutes']}m — runner pool is keeping up.")
         return 0
-    if pool_is_serving(runs):
+
+    serving = self_hosted_pool_is_serving(api, config["max_job_lookups"])
+    if serving is None:
+        print(f"::warning::{len(starved)} run(s) queued over {config['stall_minutes']}m; runner liveness UNKNOWN")
+        return 0
+    if serving:
         print(
-            f"{len(starved)} run(s) queued over {config['stall_minutes']}m, but the pool is executing work — "
+            f"{len(starved)} run(s) queued over {config['stall_minutes']}m, but a self-hosted job is executing — "
             "contention, not an outage."
         )
         return 0
-    print(f"::error::{len(starved)} workflow run(s) queued over {config['stall_minutes']}m with no runner available")
+
+    print(
+        f"::error::{len(starved)} workflow run(s) queued over {config['stall_minutes']}m "
+        "while no self-hosted job is executing"
+    )
     for run in starved:
         waited = age_minutes(run.get("created_at"), now)
         waited_text = f"{waited:.0f}m" if waited is not None else "unknown"
@@ -546,6 +792,7 @@ def load_config() -> Dict[str, Any]:
         "poll_attempts": _env_int("WATCHDOG_POLL_ATTEMPTS", DEFAULT_POLL_ATTEMPTS),
         "poll_interval_seconds": _env_int("WATCHDOG_POLL_INTERVAL_SECONDS", DEFAULT_POLL_INTERVAL_SECONDS),
         "status_context": os.environ.get("WATCHDOG_STATUS_CONTEXT", DEFAULT_STATUS_CONTEXT),
+        "max_job_lookups": _env_int("WATCHDOG_MAX_JOB_LOOKUPS", DEFAULT_MAX_JOB_LOOKUPS),
     }
 
 
@@ -553,15 +800,17 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument(
         "--check",
-        choices=("dispatch", "runner-starvation"),
+        choices=("dispatch", "probe", "runner-starvation"),
         default="dispatch",
         help="dispatch: approve parked runs and publish PR dispatch state; "
-        "runner-starvation: report runs queued with no runner",
+        "probe: print only whether this credential may approve runs; "
+        "runner-starvation: report runs queued while the self-hosted pool is idle",
     )
     parser.add_argument(
         "--dry-run",
         action="store_true",
-        help="report what would be approved and which statuses would be published, changing nothing",
+        help="report what would be approved and which statuses would be published, changing nothing "
+        "(issues no approve request, so the capability probe is skipped)",
     )
     args = parser.parse_args(argv)
 
@@ -575,9 +824,11 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     try:
         if args.check == "dispatch":
             return check_dispatch(api, config, dry_run=args.dry_run)
+        if args.check == "probe":
+            return check_probe(api)
         return check_runner_starvation(api, config)
-    except WatchdogConfigError as exc:
-        print(f"API error: {exc}", file=sys.stderr)
+    except WatchdogError as exc:
+        print(f"::error::watchdog could not complete: {exc}")
         return 2
 
 

--- a/pipeline-scripts/ci_dispatch_watchdog.py
+++ b/pipeline-scripts/ci_dispatch_watchdog.py
@@ -709,10 +709,13 @@ def check_dispatch(api: GitHubApi, config: Dict[str, Any], dry_run: bool = False
         print("::error::" + REMEDIATION.replace("\n", "%0A"))
         print(REMEDIATION)
         return 1
-    if permitted is None:
+    if permitted is None and not dry_run:
         # Unresolved is not benign: the repair path is unproven until a probe
         # returns a verdict, and saying nothing here is the exact failure mode
-        # this module was written to remove.
+        # this module was written to remove. A dry run is the one exception —
+        # it skips the probe deliberately, and `--check probe` answers the
+        # question on its own, so warning here would be noise that trains
+        # readers to ignore the warning that matters.
         print(f"::warning::Approval capability is UNRESOLVED — {explanation}. Do not treat #12823 as proven fixed.")
     return 0
 

--- a/pipeline-scripts/ci_dispatch_watchdog.py
+++ b/pipeline-scripts/ci_dispatch_watchdog.py
@@ -1,0 +1,486 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""
+CI dispatch watchdog for AutoBot.
+
+Two distinct failure modes leave a pull request reading as "waiting for CI"
+forever while nothing is actually queued. Both surface identically to any
+tooling that summarises check conclusions (``statusCheckRollup == null``,
+"19 success / 0 failures"), and neither produces a signal of its own:
+
+1. **Parked runs (#12823).** ``auto-update-pr-branches`` refreshes stale PR
+   branches through ``PUT /pulls/{n}/update-branch``. With the default
+   ``GITHUB_TOKEN`` the resulting merge commit is authored and pushed by
+   ``github-actions[bot]``. The repository's fork-PR approval policy
+   (``all_external_contributors``) treats that bot as an external
+   contributor, so every ``pull_request`` run it triggers is created with
+   ``conclusion=action_required`` and never starts. The PR then carries a
+   head commit with *no executed checks at all*.
+
+2. **Undispatched / starved runs (#13045).** When the singleton self-hosted
+   runner pool is empty, runs are created but never allocate a job. They sit
+   at ``status=queued`` with ``jobs: []`` indefinitely, so a required context
+   never reports and ``commits/{sha}/status`` stays ``pending`` forever.
+   ``POST /actions/runs/{id}/approve`` cannot help these — they are not
+   waiting for approval, they are waiting for hardware.
+
+This module handles both:
+
+* ``--check dispatch`` — probes whether the caller's token may approve
+  workflow runs at all, approves the parked runs belonging to the current
+  head commit of each open PR (bounded), and then publishes a commit status
+  on every open PR head describing the dispatch state. A PR whose CI never
+  dispatched therefore carries a visible, named, non-green context instead of
+  silently reading as ready.
+* ``--check runner-starvation`` — reports runs that have been queued past a
+  threshold without ever creating a job, i.e. an empty runner pool. This uses
+  only ``GET /actions/runs``; the ``/actions/runners`` administration
+  endpoint returns ``403 Resource not accessible by integration`` for
+  ``GITHUB_TOKEN`` and cannot be used from a workflow.
+
+Usage:
+    pipeline-scripts/ci_dispatch_watchdog.py --check dispatch
+    pipeline-scripts/ci_dispatch_watchdog.py --check dispatch --dry-run
+    pipeline-scripts/ci_dispatch_watchdog.py --check runner-starvation
+
+Environment:
+    GITHUB_TOKEN                     required — API credential
+    GITHUB_REPOSITORY                required — "owner/repo"
+    GITHUB_API_URL                   API root (default https://api.github.com)
+    WATCHDOG_BASE_BRANCH             PR base to watch (default Dev_new_gui)
+    WATCHDOG_GRACE_MINUTES           age before "no runs at all" is a failure
+    WATCHDOG_STALL_MINUTES           age before a job-less queued run is a failure
+    WATCHDOG_MAX_APPROVALS           per-sweep approval cap (blast-radius guard)
+    WATCHDOG_POLL_ATTEMPTS           re-list attempts while runs appear
+    WATCHDOG_POLL_INTERVAL_SECONDS   delay between those attempts
+    WATCHDOG_STATUS_CONTEXT          commit status context name
+
+Exit codes:
+    0  nothing wrong, or everything wrong was repaired
+    1  parked runs exist that this token is not permitted to approve
+       (owner action required — see the printed remediation)
+    2  internal error (missing configuration, unusable API response)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+# GitHub returns this message when the *token* lacks `actions: write`.
+PERMISSION_DENIED_MARKER = "resource not accessible"
+# ...and this one when the token is fine but the run is in the wrong state.
+# Seeing it proves the credential may approve runs.
+NOT_WAITING_MARKER = "not waiting for approval"
+
+# GitHub truncates commit-status descriptions beyond this length.
+MAX_STATUS_DESCRIPTION = 140
+
+# Run states that mean "created but no job has started yet".
+UNSTARTED_RUN_STATUSES = frozenset({"queued", "waiting", "pending", "requested"})
+
+DEFAULT_API_ROOT = "https://api.github.com"
+DEFAULT_BASE_BRANCH = "Dev_new_gui"
+DEFAULT_GRACE_MINUTES = 10
+DEFAULT_STALL_MINUTES = 30
+DEFAULT_MAX_APPROVALS = 30
+DEFAULT_POLL_ATTEMPTS = 3
+DEFAULT_POLL_INTERVAL_SECONDS = 20
+DEFAULT_STATUS_CONTEXT = "ci-dispatch-watchdog"
+
+
+class WatchdogConfigError(RuntimeError):
+    """Raised when required environment configuration is absent."""
+
+
+def _env_int(name: str, default: int) -> int:
+    """Read a positive integer from the environment, falling back to *default*."""
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise WatchdogConfigError(f"{name} must be an integer, got {raw!r}") from exc
+    if value <= 0:
+        raise WatchdogConfigError(f"{name} must be positive, got {value}")
+    return value
+
+
+def parse_ts(value: Optional[str]) -> Optional[datetime]:
+    """Parse a GitHub ISO-8601 timestamp into an aware UTC datetime."""
+    if not value:
+        return None
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def age_minutes(value: Optional[str], now: datetime) -> Optional[float]:
+    """Minutes elapsed between the timestamp *value* and *now*."""
+    parsed = parse_ts(value)
+    if parsed is None:
+        return None
+    return (now - parsed).total_seconds() / 60.0
+
+
+def is_parked(run: Dict[str, Any]) -> bool:
+    """True when the run was created but requires manual approval to start."""
+    return run.get("conclusion") == "action_required"
+
+
+def is_unstarted(run: Dict[str, Any]) -> bool:
+    """True when the run exists but has not allocated a job yet."""
+    return run.get("status") in UNSTARTED_RUN_STATUSES
+
+
+def starved_runs(runs: Sequence[Dict[str, Any]], now: datetime, stall_minutes: int) -> List[Dict[str, Any]]:
+    """Runs queued longer than *stall_minutes* — an empty runner pool."""
+    starved = []
+    for run in runs:
+        if not is_unstarted(run):
+            continue
+        waited = age_minutes(run.get("created_at"), now)
+        if waited is not None and waited >= stall_minutes:
+            starved.append(run)
+    return starved
+
+
+def _truncate(text: str) -> str:
+    if len(text) <= MAX_STATUS_DESCRIPTION:
+        return text
+    return text[: MAX_STATUS_DESCRIPTION - 1] + "…"
+
+
+def classify_dispatch(
+    runs: Sequence[Dict[str, Any]],
+    head_pushed_at: Optional[str],
+    now: datetime,
+    grace_minutes: int,
+    stall_minutes: int,
+) -> Tuple[str, str]:
+    """
+    Decide the commit-status state for one PR head.
+
+    Returns ``(state, description)`` where *state* is a GitHub commit-status
+    state. The watchdog never reports ``success`` for a head whose CI has not
+    demonstrably dispatched, so "no failures" can never be mistaken for
+    "verified" (#12823 option 3, #13045 property 1).
+    """
+    parked = [run for run in runs if is_parked(run)]
+    if parked:
+        names = ", ".join(sorted({str(run.get("name", "?")) for run in parked})[:3])
+        return (
+            "failure",
+            _truncate(f"{len(parked)} run(s) parked awaiting approval and never started: {names}"),
+        )
+
+    starved = starved_runs(runs, now, stall_minutes)
+    if starved:
+        names = ", ".join(sorted({str(run.get("name", "?")) for run in starved})[:3])
+        return (
+            "failure",
+            _truncate(f"{len(starved)} run(s) queued over {stall_minutes}m with no runner: {names}"),
+        )
+
+    if not runs:
+        waited = age_minutes(head_pushed_at, now)
+        if waited is None or waited >= grace_minutes:
+            return (
+                "failure",
+                _truncate(f"no workflow runs exist for this commit after {grace_minutes}m — CI never dispatched"),
+            )
+        return ("pending", _truncate("no workflow runs yet — still inside the dispatch grace window"))
+
+    return ("success", _truncate(f"{len(runs)} workflow run(s) dispatched for this commit"))
+
+
+class GitHubApi:
+    """Minimal GitHub REST client — stdlib only, no extra CI dependency."""
+
+    def __init__(self, token: str, repository: str, api_root: str = DEFAULT_API_ROOT) -> None:
+        self.token = token
+        self.repository = repository
+        self.api_root = api_root.rstrip("/")
+
+    def request(
+        self, method: str, path: str, payload: Optional[Dict[str, Any]] = None
+    ) -> Tuple[int, Any]:
+        """Issue a request and return ``(status_code, decoded_body)``."""
+        url = path if path.startswith("http") else f"{self.api_root}/{path.lstrip('/')}"
+        data = json.dumps(payload).encode("utf-8") if payload is not None else None
+        request = urllib.request.Request(url=url, method=method, data=data)
+        request.add_header("Authorization", f"Bearer {self.token}")
+        request.add_header("Accept", "application/vnd.github+json")
+        request.add_header("X-GitHub-Api-Version", "2022-11-28")
+        if data is not None:
+            request.add_header("Content-Type", "application/json")
+        try:
+            with urllib.request.urlopen(request) as response:  # noqa: S310 - fixed api host
+                body = response.read().decode("utf-8")
+                return response.status, (json.loads(body) if body else None)
+        except urllib.error.HTTPError as exc:
+            body = exc.read().decode("utf-8", errors="replace")
+            try:
+                decoded: Any = json.loads(body) if body else None
+            except json.JSONDecodeError:
+                decoded = {"message": body}
+            return exc.code, decoded
+
+    def open_pull_requests(self, base: str) -> List[Dict[str, Any]]:
+        query = urllib.parse.urlencode({"state": "open", "base": base, "per_page": "100"})
+        status, body = self.request("GET", f"/repos/{self.repository}/pulls?{query}")
+        if status != 200 or not isinstance(body, list):
+            raise WatchdogConfigError(f"cannot list open PRs (HTTP {status}): {body}")
+        return body
+
+    def runs_for_sha(self, sha: str) -> List[Dict[str, Any]]:
+        query = urllib.parse.urlencode({"head_sha": sha, "per_page": "100"})
+        status, body = self.request("GET", f"/repos/{self.repository}/actions/runs?{query}")
+        if status != 200 or not isinstance(body, dict):
+            return []
+        return list(body.get("workflow_runs") or [])
+
+    def recent_runs(self, per_page: int = 100) -> List[Dict[str, Any]]:
+        query = urllib.parse.urlencode({"per_page": str(per_page)})
+        status, body = self.request("GET", f"/repos/{self.repository}/actions/runs?{query}")
+        if status != 200 or not isinstance(body, dict):
+            raise WatchdogConfigError(f"cannot list workflow runs (HTTP {status}): {body}")
+        return list(body.get("workflow_runs") or [])
+
+    def approve_run(self, run_id: int) -> Tuple[int, str]:
+        status, body = self.request("POST", f"/repos/{self.repository}/actions/runs/{run_id}/approve")
+        message = ""
+        if isinstance(body, dict):
+            message = str(body.get("message", ""))
+        return status, message
+
+    def set_status(self, sha: str, state: str, context: str, description: str, target_url: str) -> int:
+        payload: Dict[str, Any] = {
+            "state": state,
+            "context": context,
+            "description": description,
+        }
+        if target_url:
+            payload["target_url"] = target_url
+        status, _ = self.request("POST", f"/repos/{self.repository}/statuses/{sha}", payload)
+        return status
+
+
+def interpret_probe(status: int, message: str) -> Tuple[bool, str]:
+    """
+    Turn an ``approve`` response for a run that is NOT awaiting approval into a
+    verdict about the *credential*.
+
+    A token that holds ``actions: write`` is rejected on state grounds
+    ("This workflow run is not waiting for approval"); a token that does not is
+    rejected on permission grounds ("Resource not accessible by integration").
+    The two are distinguishable, so capability can be established without
+    approving anything and without any side effect.
+    """
+    lowered = message.lower()
+    if PERMISSION_DENIED_MARKER in lowered:
+        return False, "token lacks permission to approve workflow runs"
+    if NOT_WAITING_MARKER in lowered:
+        return True, "token may approve workflow runs (rejected on run state, not permission)"
+    if status in (200, 201, 204):
+        return True, "token may approve workflow runs (approval accepted)"
+    return True, f"inconclusive probe (HTTP {status}: {message or 'no message'}) — assuming permitted"
+
+
+def probe_approval_capability(api: GitHubApi) -> Tuple[Optional[bool], str]:
+    """Establish whether this credential may approve runs, without side effects."""
+    try:
+        runs = api.recent_runs(per_page=20)
+    except WatchdogConfigError as exc:
+        return None, f"probe skipped: {exc}"
+    candidates = [run for run in runs if run.get("status") == "completed" and not is_parked(run)]
+    if not candidates:
+        return None, "probe skipped: no completed run available to probe against"
+    status, message = api.approve_run(int(candidates[0]["id"]))
+    permitted, explanation = interpret_probe(status, message)
+    return permitted, explanation
+
+
+REMEDIATION = (
+    "Parked runs cannot be approved with this credential. Every merge to the base branch will keep "
+    "freezing open PRs until one of the following is chosen:\n"
+    "  (a) relax the repository Actions setting 'Require approval for all external contributors' to "
+    "'Require approval for first-time contributors', so pushes attributed to the update bot dispatch "
+    "normally; or\n"
+    "  (b) run auto-update-pr-branches with a credential that is a repository collaborator "
+    "(a GitHub App installation token or PAT stored as a secret); or\n"
+    "  (c) retire the automatic branch update and refresh PR branches from the PR page instead.\n"
+    "Until then this watchdog marks affected PRs with a failing commit status so none of them can "
+    "read as ready."
+)
+
+
+def _run_url(repository: str, run: Dict[str, Any]) -> str:
+    return str(run.get("html_url") or f"https://github.com/{repository}/actions")
+
+
+def check_dispatch(api: GitHubApi, config: Dict[str, Any], dry_run: bool = False) -> int:
+    """Approve what can be approved, then publish dispatch state on every open PR."""
+    if dry_run:
+        print("DRY RUN: no run will be approved and no commit status will be written.")
+    pulls = api.open_pull_requests(config["base_branch"])
+    print(f"Open PRs targeting {config['base_branch']}: {len(pulls)}")
+
+    permitted, explanation = probe_approval_capability(api)
+    print(f"Approval capability probe: {explanation}")
+
+    approved = 0
+    refused = 0
+    budget = config["max_approvals"]
+
+    heads: List[Tuple[int, str, Optional[str], str]] = []
+    for pull in pulls:
+        head = pull.get("head") or {}
+        sha = str(head.get("sha") or "")
+        if not sha:
+            continue
+        heads.append((int(pull["number"]), sha, pull.get("updated_at"), str(pull.get("html_url") or "")))
+
+    for number, sha, _updated_at, _url in heads:
+        for attempt in range(config["poll_attempts"]):
+            runs = api.runs_for_sha(sha)
+            parked = [run for run in runs if is_parked(run)]
+            if not parked:
+                break
+            for run in parked:
+                if dry_run:
+                    print(f"  PR #{number}: would approve '{run.get('name')}' ({run['id']})")
+                    continue
+                if budget <= 0:
+                    print(f"  PR #{number}: approval budget exhausted, deferring to the next sweep")
+                    break
+                budget -= 1
+                status, message = api.approve_run(int(run["id"]))
+                if status in (200, 201, 204):
+                    approved += 1
+                    print(f"  PR #{number}: approved '{run.get('name')}' ({run['id']})")
+                else:
+                    refused += 1
+                    print(f"  PR #{number}: could NOT approve '{run.get('name')}' — HTTP {status}: {message}")
+            if dry_run:
+                break
+            if attempt + 1 < config["poll_attempts"] and refused == 0:
+                time.sleep(config["poll_interval_seconds"])
+
+    now = datetime.now(timezone.utc)
+    blocked = 0
+    for number, sha, updated_at, url in heads:
+        runs = api.runs_for_sha(sha)
+        state, description = classify_dispatch(
+            runs,
+            updated_at,
+            now,
+            config["grace_minutes"],
+            config["stall_minutes"],
+        )
+        target = _run_url(api.repository, runs[0]) if runs else url
+        if dry_run:
+            print(f"  PR #{number}: would set {state} — {description}")
+        else:
+            code = api.set_status(sha, state, config["status_context"], description, target)
+            print(f"  PR #{number}: {state} — {description} (status API HTTP {code})")
+        if state != "success":
+            blocked += 1
+
+    print(f"Sweep complete: {approved} approved, {refused} refused, {blocked} PR(s) not dispatched.")
+
+    if refused or permitted is False:
+        print("::error::" + REMEDIATION.replace("\n", "%0A"))
+        print(REMEDIATION)
+        return 1
+    return 0
+
+
+def check_runner_starvation(api: GitHubApi, config: Dict[str, Any]) -> int:
+    """Report runs that were created but never allocated a job (#13045)."""
+    runs = api.recent_runs()
+    now = datetime.now(timezone.utc)
+    starved = starved_runs(runs, now, config["stall_minutes"])
+    if not starved:
+        print(f"No run has been queued longer than {config['stall_minutes']}m — runner pool is serving work.")
+        return 0
+    print(f"::error::{len(starved)} workflow run(s) queued over {config['stall_minutes']}m with no runner available")
+    for run in starved:
+        waited = age_minutes(run.get("created_at"), now)
+        waited_text = f"{waited:.0f}m" if waited is not None else "unknown"
+        print(f"  {run.get('name')} on {run.get('head_branch')} — queued {waited_text} ({_run_url(api.repository, run)})")
+    return 1
+
+
+def load_config() -> Dict[str, Any]:
+    token = os.environ.get("GITHUB_TOKEN", "").strip()
+    repository = os.environ.get("GITHUB_REPOSITORY", "").strip()
+    if not token:
+        raise WatchdogConfigError("GITHUB_TOKEN is required")
+    if "/" not in repository:
+        raise WatchdogConfigError("GITHUB_REPOSITORY must be set to 'owner/repo'")
+    return {
+        "token": token,
+        "repository": repository,
+        "api_root": os.environ.get("GITHUB_API_URL", DEFAULT_API_ROOT),
+        "base_branch": os.environ.get("WATCHDOG_BASE_BRANCH", DEFAULT_BASE_BRANCH),
+        "grace_minutes": _env_int("WATCHDOG_GRACE_MINUTES", DEFAULT_GRACE_MINUTES),
+        "stall_minutes": _env_int("WATCHDOG_STALL_MINUTES", DEFAULT_STALL_MINUTES),
+        "max_approvals": _env_int("WATCHDOG_MAX_APPROVALS", DEFAULT_MAX_APPROVALS),
+        "poll_attempts": _env_int("WATCHDOG_POLL_ATTEMPTS", DEFAULT_POLL_ATTEMPTS),
+        "poll_interval_seconds": _env_int("WATCHDOG_POLL_INTERVAL_SECONDS", DEFAULT_POLL_INTERVAL_SECONDS),
+        "status_context": os.environ.get("WATCHDOG_STATUS_CONTEXT", DEFAULT_STATUS_CONTEXT),
+    }
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--check",
+        choices=("dispatch", "runner-starvation"),
+        default="dispatch",
+        help="dispatch: approve parked runs and publish PR dispatch state; "
+        "runner-starvation: report runs queued with no runner",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="report what would be approved and which statuses would be published, changing nothing",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        config = load_config()
+    except WatchdogConfigError as exc:
+        print(f"Configuration error: {exc}", file=sys.stderr)
+        return 2
+
+    api = GitHubApi(config["token"], config["repository"], config["api_root"])
+    try:
+        if args.check == "dispatch":
+            return check_dispatch(api, config, dry_run=args.dry_run)
+        return check_runner_starvation(api, config)
+    except WatchdogConfigError as exc:
+        print(f"API error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/repo_tests/ci_dispatch_watchdog_test.py
+++ b/repo_tests/ci_dispatch_watchdog_test.py
@@ -223,3 +223,38 @@ def test_head_with_a_parked_run_is_polled_again(watchdog):
 
 def test_head_with_dispatched_runs_is_settled(watchdog):
     assert watchdog.needs_another_look([_run(), _run(id=2)]) is False
+
+
+# --- probe candidate selection ---------------------------------------------
+
+
+def test_probe_reports_skipped_when_no_completed_run_exists(watchdog):
+    """A busy repository must not silently produce no verdict."""
+
+    class _NoCompletedRuns:
+        def recent_runs(self, per_page=100, run_status=""):
+            assert run_status == "completed", "the probe must filter server-side"
+            return []
+
+    permitted, explanation = watchdog.probe_approval_capability(_NoCompletedRuns())
+    assert permitted is None
+    assert "probe skipped" in explanation
+
+
+def test_probe_uses_the_first_completed_non_parked_run(watchdog):
+    class _Api:
+        approved_id = None
+
+        def recent_runs(self, per_page=100, run_status=""):
+            return [
+                {"id": 1, "status": "completed", "conclusion": "action_required"},
+                {"id": 2, "status": "completed", "conclusion": "success"},
+            ]
+
+        def approve_run(self, run_id):
+            _Api.approved_id = run_id
+            return 403, "This workflow run is not waiting for approval"
+
+    permitted, _ = watchdog.probe_approval_capability(_Api())
+    assert permitted is True
+    assert _Api.approved_id == 2

--- a/repo_tests/ci_dispatch_watchdog_test.py
+++ b/repo_tests/ci_dispatch_watchdog_test.py
@@ -139,8 +139,7 @@ def test_dispatched_runs_are_success(watchdog):
 
 def test_description_never_exceeds_the_github_limit(watchdog):
     runs = [
-        _run(id=i, conclusion="action_required", name=f"A very long workflow name number {i}" * 4)
-        for i in range(30)
+        _run(id=i, conclusion="action_required", name=f"A very long workflow name number {i}" * 4) for i in range(30)
     ]
     _, description = watchdog.classify_dispatch(runs, _ts(5), NOW, 10, 30)
     assert len(description) <= watchdog.MAX_STATUS_DESCRIPTION

--- a/repo_tests/ci_dispatch_watchdog_test.py
+++ b/repo_tests/ci_dispatch_watchdog_test.py
@@ -1,0 +1,210 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""#12823 / #13045 — the CI dispatch watchdog must never report ``success`` for a
+head commit whose CI has not demonstrably dispatched.
+
+The two production failure modes are covered directly:
+
+* runs created with ``conclusion=action_required`` (parked behind the fork-PR
+  approval policy after ``auto-update-pr-branches`` pushes as the bot), and
+* runs created but never allocated a job while the self-hosted runner pool is
+  empty (``status=queued``, ``jobs: []``).
+
+``interpret_probe`` is covered too: it is the mechanism that distinguishes "this
+credential may not approve runs" from "this run is not in an approvable state",
+which is what decides whether owner action is required.
+"""
+
+import importlib.util
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "pipeline-scripts" / "ci_dispatch_watchdog.py"
+
+NOW = datetime(2026, 8, 2, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("ci_dispatch_watchdog", _SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def watchdog():
+    return _load()
+
+
+def _ts(minutes_ago: float) -> str:
+    return (NOW - timedelta(minutes=minutes_ago)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _run(**overrides):
+    run = {
+        "id": 1,
+        "name": "Code Quality",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": _ts(5),
+    }
+    run.update(overrides)
+    return run
+
+
+# --- timestamp helpers -----------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value,expected_minutes",
+    [
+        ("2026-08-02T11:30:00Z", 30.0),
+        ("2026-08-02T11:30:00+00:00", 30.0),
+        ("2026-08-02T12:00:00Z", 0.0),
+    ],
+)
+def test_age_minutes_parses_github_timestamps(watchdog, value, expected_minutes):
+    assert watchdog.age_minutes(value, NOW) == pytest.approx(expected_minutes)
+
+
+@pytest.mark.parametrize("value", [None, "", "not-a-timestamp"])
+def test_age_minutes_returns_none_for_unusable_input(watchdog, value):
+    assert watchdog.age_minutes(value, NOW) is None
+
+
+# --- #12823: parked runs ---------------------------------------------------
+
+
+def test_parked_run_is_reported_as_failure(watchdog):
+    runs = [
+        _run(status="completed", conclusion="action_required", name="Code Quality"),
+        _run(id=2, name="PR Template Check", status="completed", conclusion="action_required"),
+    ]
+    state, description = watchdog.classify_dispatch(runs, _ts(5), NOW, 10, 30)
+    assert state == "failure"
+    assert "parked awaiting approval" in description
+    assert "Code Quality" in description
+
+
+def test_parked_run_outranks_otherwise_green_runs(watchdog):
+    """A head with 20 green runs and one parked run is still not verified."""
+    runs = [_run(id=i) for i in range(20)]
+    runs.append(_run(id=99, conclusion="action_required", name="Enforce Pre-commit Hooks"))
+    state, _ = watchdog.classify_dispatch(runs, _ts(60), NOW, 10, 30)
+    assert state == "failure"
+
+
+# --- #13045: starved runs and absent runs ----------------------------------
+
+
+def test_queued_run_past_the_stall_threshold_is_failure(watchdog):
+    runs = [_run(status="queued", conclusion=None, created_at=_ts(45), name="Unit & Integration Tests")]
+    state, description = watchdog.classify_dispatch(runs, _ts(45), NOW, 10, 30)
+    assert state == "failure"
+    assert "no runner" in description
+
+
+def test_queued_run_inside_the_stall_threshold_is_success(watchdog):
+    runs = [_run(status="queued", conclusion=None, created_at=_ts(4))]
+    state, _ = watchdog.classify_dispatch(runs, _ts(4), NOW, 10, 30)
+    assert state == "success"
+
+
+def test_no_runs_past_the_grace_window_is_failure(watchdog):
+    state, description = watchdog.classify_dispatch([], _ts(30), NOW, 10, 30)
+    assert state == "failure"
+    assert "never dispatched" in description
+
+
+def test_no_runs_inside_the_grace_window_is_pending_not_success(watchdog):
+    """Absence must never read as green, even before the grace window closes."""
+    state, _ = watchdog.classify_dispatch([], _ts(2), NOW, 10, 30)
+    assert state == "pending"
+
+
+def test_unparseable_head_timestamp_with_no_runs_is_failure(watchdog):
+    state, _ = watchdog.classify_dispatch([], None, NOW, 10, 30)
+    assert state == "failure"
+
+
+def test_dispatched_runs_are_success(watchdog):
+    state, description = watchdog.classify_dispatch([_run(), _run(id=2)], _ts(5), NOW, 10, 30)
+    assert state == "success"
+    assert "2 workflow run(s) dispatched" in description
+
+
+def test_description_never_exceeds_the_github_limit(watchdog):
+    runs = [
+        _run(id=i, conclusion="action_required", name=f"A very long workflow name number {i}" * 4)
+        for i in range(30)
+    ]
+    _, description = watchdog.classify_dispatch(runs, _ts(5), NOW, 10, 30)
+    assert len(description) <= watchdog.MAX_STATUS_DESCRIPTION
+
+
+# --- starvation reporting ---------------------------------------------------
+
+
+def test_starved_runs_selects_only_job_less_queued_runs(watchdog):
+    runs = [
+        _run(id=1, status="queued", conclusion=None, created_at=_ts(90)),
+        _run(id=2, status="queued", conclusion=None, created_at=_ts(5)),
+        _run(id=3, status="in_progress", conclusion=None, created_at=_ts(90)),
+        _run(id=4, status="completed", conclusion="success", created_at=_ts(90)),
+    ]
+    assert [run["id"] for run in watchdog.starved_runs(runs, NOW, 30)] == [1]
+
+
+def test_waiting_status_counts_as_unstarted(watchdog):
+    runs = [_run(id=7, status="waiting", conclusion=None, created_at=_ts(60))]
+    assert watchdog.starved_runs(runs, NOW, 30)
+
+
+# --- approval-capability probe ---------------------------------------------
+
+
+def test_probe_detects_a_credential_without_actions_write(watchdog):
+    permitted, explanation = watchdog.interpret_probe(403, "Resource not accessible by integration")
+    assert permitted is False
+    assert "lacks permission" in explanation
+
+
+def test_probe_detects_a_credential_with_actions_write(watchdog):
+    permitted, _ = watchdog.interpret_probe(403, "This workflow run is not waiting for approval")
+    assert permitted is True
+
+
+def test_probe_treats_an_accepted_approval_as_permitted(watchdog):
+    permitted, _ = watchdog.interpret_probe(201, "")
+    assert permitted is True
+
+
+def test_probe_is_inconclusive_rather_than_wrong_on_unknown_errors(watchdog):
+    permitted, explanation = watchdog.interpret_probe(500, "Server Error")
+    assert permitted is True
+    assert "inconclusive" in explanation
+
+
+# --- configuration ----------------------------------------------------------
+
+
+def test_thresholds_come_from_the_environment(watchdog, monkeypatch):
+    monkeypatch.setenv("WATCHDOG_STALL_MINUTES", "7")
+    assert watchdog._env_int("WATCHDOG_STALL_MINUTES", 30) == 7
+
+
+def test_non_positive_threshold_is_rejected(watchdog, monkeypatch):
+    monkeypatch.setenv("WATCHDOG_STALL_MINUTES", "0")
+    with pytest.raises(watchdog.WatchdogConfigError):
+        watchdog._env_int("WATCHDOG_STALL_MINUTES", 30)
+
+
+def test_missing_repository_is_rejected(watchdog, monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "not-a-repo")
+    with pytest.raises(watchdog.WatchdogConfigError):
+        watchdog.load_config()

--- a/repo_tests/ci_dispatch_watchdog_test.py
+++ b/repo_tests/ci_dispatch_watchdog_test.py
@@ -101,16 +101,36 @@ def test_parked_run_outranks_otherwise_green_runs(watchdog):
 # --- #13045: starved runs and absent runs ----------------------------------
 
 
-def test_queued_run_past_the_stall_threshold_is_failure(watchdog):
+def test_queued_run_past_the_stall_threshold_with_an_empty_pool_is_failure(watchdog):
     runs = [_run(status="queued", conclusion=None, created_at=_ts(45), name="Unit & Integration Tests")]
-    state, description = watchdog.classify_dispatch(runs, _ts(45), NOW, 10, 30)
+    state, description = watchdog.classify_dispatch(runs, _ts(45), NOW, 10, 30, False)
     assert state == "failure"
-    assert "no runner" in description
+    assert "no runner available" in description
+
+
+def test_queued_run_behind_a_busy_pool_is_pending_not_failure(watchdog):
+    """Normal contention on the singleton runner must not raise a false outage."""
+    runs = [_run(status="queued", conclusion=None, created_at=_ts(45), name="Unit & Integration Tests")]
+    state, description = watchdog.classify_dispatch(runs, _ts(45), NOW, 10, 30, True)
+    assert state == "pending"
+    assert "busy runner pool" in description
+
+
+def test_a_busy_queue_is_still_never_success(watchdog):
+    runs = [_run(status="queued", conclusion=None, created_at=_ts(45))]
+    state, _ = watchdog.classify_dispatch(runs, _ts(45), NOW, 10, 30, True)
+    assert state != "success"
+
+
+def test_pool_is_serving_requires_an_in_progress_run(watchdog):
+    assert watchdog.pool_is_serving([_run(status="in_progress", conclusion=None)]) is True
+    assert watchdog.pool_is_serving([_run(status="queued", conclusion=None), _run()]) is False
+    assert watchdog.pool_is_serving([]) is False
 
 
 def test_queued_run_inside_the_stall_threshold_is_success(watchdog):
     runs = [_run(status="queued", conclusion=None, created_at=_ts(4))]
-    state, _ = watchdog.classify_dispatch(runs, _ts(4), NOW, 10, 30)
+    state, _ = watchdog.classify_dispatch(runs, _ts(4), NOW, 10, 30, False)
     assert state == "success"
 
 

--- a/repo_tests/ci_dispatch_watchdog_test.py
+++ b/repo_tests/ci_dispatch_watchdog_test.py
@@ -207,3 +207,19 @@ def test_missing_repository_is_rejected(watchdog, monkeypatch):
     monkeypatch.setenv("GITHUB_REPOSITORY", "not-a-repo")
     with pytest.raises(watchdog.WatchdogConfigError):
         watchdog.load_config()
+
+
+# --- sweep polling ----------------------------------------------------------
+
+
+def test_head_with_no_runs_yet_is_polled_again(watchdog):
+    """Right after update-branch returns, an empty result means "too early"."""
+    assert watchdog.needs_another_look([]) is True
+
+
+def test_head_with_a_parked_run_is_polled_again(watchdog):
+    assert watchdog.needs_another_look([_run(), _run(id=2, conclusion="action_required")]) is True
+
+
+def test_head_with_dispatched_runs_is_settled(watchdog):
+    assert watchdog.needs_another_look([_run(), _run(id=2)]) is False

--- a/repo_tests/ci_dispatch_watchdog_test.py
+++ b/repo_tests/ci_dispatch_watchdog_test.py
@@ -489,3 +489,48 @@ def test_head_with_a_parked_run_is_polled_again(watchdog):
 
 def test_head_with_dispatched_runs_is_settled(watchdog):
     assert watchdog.needs_another_look([_run(), _run(id=2)]) is False
+
+
+def test_a_dry_run_does_not_warn_about_the_probe_it_skipped_on_purpose(watchdog, capsys):
+    """The warning must stay rare enough to be read when it means something."""
+    sha = "1" * 40
+    api = _FakeApi({sha: [_run()]})
+    api.open_pull_requests = lambda base: [
+        {"number": 3, "head": {"sha": sha, "repo": {"full_name": REPO}}, "html_url": "u", "updated_at": _ts(5)}
+    ]
+    api.recent_runs = lambda per_page=100, run_status="": []
+    api.run_jobs = lambda run_id: []
+    config = {
+        "base_branch": "Dev_new_gui",
+        "grace_minutes": 10,
+        "stall_minutes": 30,
+        "status_context": "ctx",
+        "max_approvals": 30,
+        "poll_attempts": 1,
+        "poll_interval_seconds": 1,
+        "max_job_lookups": 5,
+    }
+    assert watchdog.check_dispatch(api, config, dry_run=True) == 0
+    assert "UNRESOLVED" not in capsys.readouterr().out
+
+
+def test_a_real_sweep_does_warn_when_the_probe_is_unresolved(watchdog, capsys):
+    sha = "2" * 40
+    api = _FakeApi({sha: [_run()]})
+    api.open_pull_requests = lambda base: [
+        {"number": 4, "head": {"sha": sha, "repo": {"full_name": REPO}}, "html_url": "u", "updated_at": _ts(5)}
+    ]
+    api.recent_runs = lambda per_page=100, run_status="": []
+    api.run_jobs = lambda run_id: []
+    config = {
+        "base_branch": "Dev_new_gui",
+        "grace_minutes": 10,
+        "stall_minutes": 30,
+        "status_context": "ctx",
+        "max_approvals": 30,
+        "poll_attempts": 1,
+        "poll_interval_seconds": 1,
+        "max_job_lookups": 5,
+    }
+    assert watchdog.check_dispatch(api, config, dry_run=False) == 0
+    assert "UNRESOLVED" in capsys.readouterr().out

--- a/repo_tests/ci_dispatch_watchdog_test.py
+++ b/repo_tests/ci_dispatch_watchdog_test.py
@@ -3,18 +3,23 @@
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
 """#12823 / #13045 — the CI dispatch watchdog must never report ``success`` for a
-head commit whose CI has not demonstrably dispatched.
+head commit whose CI has not demonstrably dispatched, and must never release a
+gated fork run.
 
-The two production failure modes are covered directly:
+The production failure modes covered here:
 
 * runs created with ``conclusion=action_required`` (parked behind the fork-PR
-  approval policy after ``auto-update-pr-branches`` pushes as the bot), and
+  approval policy after ``auto-update-pr-branches`` pushes as the bot),
 * runs created but never allocated a job while the self-hosted runner pool is
-  empty (``status=queued``, ``jobs: []``).
+  empty (``status=queued``, ``jobs: []``),
+* an API error being mistaken for "CI never dispatched", and
+* ``POST /actions/runs/{id}/approve`` — an approve-a-FORK-run endpoint — being
+  pointed at a fork pull request, which would execute contributor-supplied code
+  on the self-hosted runner.
 
-``interpret_probe`` is covered too: it is the mechanism that distinguishes "this
-credential may not approve runs" from "this run is not in an approvable state",
-which is what decides whether owner action is required.
+``interpret_probe`` is covered because it decides whether owner action is
+required, and because an earlier revision failed OPEN on every unrecognised
+response.
 """
 
 import importlib.util
@@ -26,6 +31,8 @@ import pytest
 _SCRIPT = Path(__file__).resolve().parents[1] / "pipeline-scripts" / "ci_dispatch_watchdog.py"
 
 NOW = datetime(2026, 8, 2, 12, 0, 0, tzinfo=timezone.utc)
+REPO = "mrveiss/AutoBot-AI"
+FORK = "someone-else/AutoBot-AI"
 
 
 def _load():
@@ -51,9 +58,39 @@ def _run(**overrides):
         "status": "completed",
         "conclusion": "success",
         "created_at": _ts(5),
+        "head_repository": {"full_name": REPO},
+        "triggering_actor": {"login": "github-actions[bot]"},
     }
     run.update(overrides)
     return run
+
+
+def _parked(**overrides):
+    return _run(status="completed", conclusion="action_required", **overrides)
+
+
+class _FakeApi:
+    """Records approve calls so a test can assert what was NOT approved."""
+
+    def __init__(self, runs_by_sha=None, repository=REPO):
+        self.repository = repository
+        self._runs_by_sha = runs_by_sha or {}
+        self.approved = []
+        self.statuses = []
+
+    def runs_for_sha(self, sha):
+        value = self._runs_by_sha[sha]
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+    def approve_run(self, run_id):
+        self.approved.append(run_id)
+        return 201, ""
+
+    def set_status(self, sha, state, context, description, target_url):
+        self.statuses.append((sha, state, description))
+        return 201
 
 
 # --- timestamp helpers -----------------------------------------------------
@@ -76,14 +113,76 @@ def test_age_minutes_returns_none_for_unusable_input(watchdog, value):
     assert watchdog.age_minutes(value, NOW) is None
 
 
+# --- SECURITY: fork pull requests must never be auto-approved --------------
+
+
+def test_a_fork_origin_parked_run_is_never_approvable(watchdog):
+    run = _parked(head_repository={"full_name": FORK})
+    eligible, reason = watchdog.is_approvable(run, REPO)
+    assert eligible is False
+    assert FORK in reason
+
+
+def test_sweep_never_approves_a_fork_origin_parked_run(watchdog):
+    """The end-to-end guard: approve() must not be called for a fork run."""
+    api = _FakeApi()
+    approved, refused, budget = watchdog._approve_head(
+        api, 42, [_parked(id=7, head_repository={"full_name": FORK})], budget=30, dry_run=False
+    )
+    assert api.approved == []
+    assert (approved, refused) == (0, 0)
+    assert budget == 30
+
+
+def test_a_fork_head_is_flagged_by_collect_heads(watchdog):
+    heads = watchdog.collect_heads(
+        [{"number": 1, "head": {"sha": "a" * 40, "repo": {"full_name": FORK}}, "html_url": "u"}], REPO
+    )
+    assert heads[0].same_repo is False
+
+
+def test_same_repo_head_is_recognised(watchdog):
+    heads = watchdog.collect_heads(
+        [{"number": 1, "head": {"sha": "b" * 40, "repo": {"full_name": REPO}}, "html_url": "u"}], REPO
+    )
+    assert heads[0].same_repo is True
+
+
+def test_the_sweep_skips_a_fork_head_entirely(watchdog):
+    sha = "f" * 40
+    api = _FakeApi({sha: [_parked(id=99, head_repository={"full_name": FORK})]})
+    head = watchdog.PullHead(number=8, sha=sha, updated_at=_ts(5), url="u", same_repo=False)
+    approved, refused, budget, _unsettled, touched = watchdog._sweep_once(api, [head], budget=30, dry_run=False)
+    assert api.approved == []
+    assert (approved, refused, budget) == (0, 0, 30)
+    assert touched == set()
+
+
+def test_a_run_parked_for_a_human_actor_is_not_approvable(watchdog):
+    run = _parked(triggering_actor={"login": "Some-Contributor"})
+    eligible, reason = watchdog.is_approvable(run, REPO)
+    assert eligible is False
+    assert "branch-update bot" in reason
+
+
+def test_a_same_repo_bot_parked_run_is_approvable(watchdog):
+    eligible, reason = watchdog.is_approvable(_parked(), REPO)
+    assert eligible is True
+    assert reason == ""
+
+
+def test_a_run_with_no_head_repository_is_treated_as_a_fork(watchdog):
+    """Missing provenance must fail closed, not open."""
+    run = _parked()
+    del run["head_repository"]
+    assert watchdog.is_approvable(run, REPO)[0] is False
+
+
 # --- #12823: parked runs ---------------------------------------------------
 
 
 def test_parked_run_is_reported_as_failure(watchdog):
-    runs = [
-        _run(status="completed", conclusion="action_required", name="Code Quality"),
-        _run(id=2, name="PR Template Check", status="completed", conclusion="action_required"),
-    ]
+    runs = [_parked(name="Code Quality"), _parked(id=2, name="PR Template Check")]
     state, description = watchdog.classify_dispatch(runs, _ts(5), NOW, 10, 30)
     assert state == "failure"
     assert "parked awaiting approval" in description
@@ -93,7 +192,7 @@ def test_parked_run_is_reported_as_failure(watchdog):
 def test_parked_run_outranks_otherwise_green_runs(watchdog):
     """A head with 20 green runs and one parked run is still not verified."""
     runs = [_run(id=i) for i in range(20)]
-    runs.append(_run(id=99, conclusion="action_required", name="Enforce Pre-commit Hooks"))
+    runs.append(_parked(id=99, name="Enforce Pre-commit Hooks"))
     state, _ = watchdog.classify_dispatch(runs, _ts(60), NOW, 10, 30)
     assert state == "failure"
 
@@ -120,12 +219,6 @@ def test_a_busy_queue_is_still_never_success(watchdog):
     runs = [_run(status="queued", conclusion=None, created_at=_ts(45))]
     state, _ = watchdog.classify_dispatch(runs, _ts(45), NOW, 10, 30, True)
     assert state != "success"
-
-
-def test_pool_is_serving_requires_an_in_progress_run(watchdog):
-    assert watchdog.pool_is_serving([_run(status="in_progress", conclusion=None)]) is True
-    assert watchdog.pool_is_serving([_run(status="queued", conclusion=None), _run()]) is False
-    assert watchdog.pool_is_serving([]) is False
 
 
 def test_queued_run_inside_the_stall_threshold_is_success(watchdog):
@@ -158,14 +251,43 @@ def test_dispatched_runs_are_success(watchdog):
 
 
 def test_description_never_exceeds_the_github_limit(watchdog):
-    runs = [
-        _run(id=i, conclusion="action_required", name=f"A very long workflow name number {i}" * 4) for i in range(30)
-    ]
+    runs = [_parked(id=i, name=f"A very long workflow name number {i}" * 4) for i in range(30)]
     _, description = watchdog.classify_dispatch(runs, _ts(5), NOW, 10, 30)
     assert len(description) <= watchdog.MAX_STATUS_DESCRIPTION
 
 
-# --- starvation reporting ---------------------------------------------------
+# --- an API error is not a diagnosis ---------------------------------------
+
+
+def test_an_api_error_publishes_unknown_not_never_dispatched(watchdog):
+    """One rate-limit window must not assert a root cause on every open PR."""
+    sha = "c" * 40
+    api = _FakeApi({sha: watchdog.WatchdogApiError("HTTP 429: rate limited")})
+    head = watchdog.PullHead(number=5, sha=sha, updated_at=_ts(60), url="u", same_repo=True)
+    config = {"grace_minutes": 10, "stall_minutes": 30, "status_context": "ctx"}
+    blocked = watchdog.publish_dispatch_states(api, [head], config, dry_run=False, pool_serving=True)
+    assert blocked == 1
+    _, state, description = api.statuses[0]
+    assert state == "pending"
+    assert "unknown" in description
+    assert "never dispatched" not in description
+
+
+def test_a_sweep_survives_an_api_error_on_one_head(watchdog):
+    good, bad = "d" * 40, "e" * 40
+    api = _FakeApi({good: [_parked(id=11)], bad: watchdog.WatchdogApiError("HTTP 500")})
+    heads = [
+        watchdog.PullHead(1, bad, _ts(5), "u", True),
+        watchdog.PullHead(2, good, _ts(5), "u", True),
+    ]
+    approved, refused, _budget, unsettled, _touched = watchdog._sweep_once(api, heads, budget=30, dry_run=False)
+    assert approved == 1
+    assert refused == 0
+    assert unsettled is True
+    assert api.approved == [11]
+
+
+# --- starvation / runner liveness ------------------------------------------
 
 
 def test_starved_runs_selects_only_job_less_queued_runs(watchdog):
@@ -181,6 +303,52 @@ def test_starved_runs_selects_only_job_less_queued_runs(watchdog):
 def test_waiting_status_counts_as_unstarted(watchdog):
     runs = [_run(id=7, status="waiting", conclusion=None, created_at=_ts(60))]
     assert watchdog.starved_runs(runs, NOW, 30)
+
+
+def test_only_a_self_hosted_label_proves_the_singleton_is_alive(watchdog):
+    """A GitHub-hosted job executing says nothing about the self-hosted pool."""
+    assert watchdog.job_is_self_hosted({"labels": ["self-hosted", "Linux", "X64"]}) is True
+    assert watchdog.job_is_self_hosted({"labels": ["ubuntu-latest"]}) is False
+    assert watchdog.job_is_self_hosted({"labels": []}) is False
+    assert watchdog.job_is_self_hosted({}) is False
+
+
+def test_a_github_hosted_job_does_not_prove_the_pool_is_serving(watchdog):
+    """The old heuristic counted any in_progress run and was near-always true."""
+
+    class _Api:
+        repository = REPO
+
+        def recent_runs(self, per_page=100, run_status=""):
+            return [{"id": 1}]
+
+        def run_jobs(self, run_id):
+            return [{"status": "in_progress", "labels": ["ubuntu-latest"]}]
+
+    assert watchdog.self_hosted_pool_is_serving(_Api(), 10) is False
+
+
+def test_a_self_hosted_job_proves_the_pool_is_serving(watchdog):
+    class _Api:
+        repository = REPO
+
+        def recent_runs(self, per_page=100, run_status=""):
+            return [{"id": 1}]
+
+        def run_jobs(self, run_id):
+            return [{"status": "in_progress", "labels": ["self-hosted", "Linux", "X64"]}]
+
+    assert watchdog.self_hosted_pool_is_serving(_Api(), 10) is True
+
+
+def test_runner_liveness_is_none_when_it_cannot_be_established(watchdog):
+    class _Api:
+        repository = REPO
+
+        def recent_runs(self, per_page=100, run_status=""):
+            raise watchdog.WatchdogApiError("HTTP 429")
+
+    assert watchdog.self_hosted_pool_is_serving(_Api(), 10) is None
 
 
 # --- approval-capability probe ---------------------------------------------
@@ -202,10 +370,88 @@ def test_probe_treats_an_accepted_approval_as_permitted(watchdog):
     assert permitted is True
 
 
-def test_probe_is_inconclusive_rather_than_wrong_on_unknown_errors(watchdog):
-    permitted, explanation = watchdog.interpret_probe(500, "Server Error")
+@pytest.mark.parametrize(
+    "status,message",
+    [
+        (401, "Bad credentials"),
+        (404, "Not Found"),
+        (429, "API rate limit exceeded"),
+        (500, "Server Error"),
+        (502, "<html>bad gateway</html>"),
+        (0, "transport failure: timed out"),
+    ],
+)
+def test_probe_never_fails_open_on_an_unrecognised_response(watchdog, status, message):
+    """401/404/429/5xx/transport must be UNRESOLVED, never 'assumed permitted'."""
+    permitted, explanation = watchdog.interpret_probe(status, message)
+    assert permitted is None
+    assert "unresolved" in explanation.lower()
+
+
+def test_probe_selects_successful_runs_not_completed_ones(watchdog):
+    """Parked runs ARE status=completed, so completed candidates are all parked."""
+
+    class _Api:
+        asked_for = None
+
+        def recent_runs(self, per_page=100, run_status=""):
+            _Api.asked_for = run_status
+            return [{"id": 2, "status": "completed", "conclusion": "success"}]
+
+        def approve_run(self, run_id):
+            return 403, "This workflow run is not waiting for approval"
+
+    permitted, _ = watchdog.probe_approval_capability(_Api())
+    assert _Api.asked_for == "success"
     assert permitted is True
-    assert "inconclusive" in explanation
+
+
+def test_probe_reports_unresolved_when_no_candidate_exists(watchdog):
+    class _Api:
+        def recent_runs(self, per_page=100, run_status=""):
+            return []
+
+    permitted, explanation = watchdog.probe_approval_capability(_Api())
+    assert permitted is None
+    assert "unresolved" in explanation
+
+
+def test_probe_is_skipped_and_unresolved_on_a_dry_run(watchdog):
+    """--dry-run must issue no approve request at all."""
+
+    class _Api:
+        def recent_runs(self, per_page=100, run_status=""):
+            raise AssertionError("a dry run must not query for probe candidates")
+
+        def approve_run(self, run_id):
+            raise AssertionError("a dry run must not POST approve")
+
+    permitted, explanation = watchdog.probe_approval_capability(_Api(), dry_run=True)
+    assert permitted is None
+    assert "dry-run" in explanation
+
+
+def test_probe_reports_unresolved_when_the_listing_fails(watchdog):
+    class _Api:
+        def recent_runs(self, per_page=100, run_status=""):
+            raise watchdog.WatchdogApiError("HTTP 429: rate limited")
+
+    permitted, explanation = watchdog.probe_approval_capability(_Api())
+    assert permitted is None
+    assert "unresolved" in explanation
+
+
+# --- dry run is side-effect free -------------------------------------------
+
+
+def test_dry_run_approves_nothing_but_still_consumes_budget(watchdog):
+    api = _FakeApi()
+    runs = [_parked(id=i) for i in range(5)]
+    approved, refused, budget = watchdog._approve_head(api, 1, runs, budget=3, dry_run=True)
+    assert api.approved == []
+    assert (approved, refused) == (0, 0)
+    # Budget consumed so the preview matches the cap a real sweep would hit.
+    assert budget == 0
 
 
 # --- configuration ----------------------------------------------------------
@@ -233,48 +479,13 @@ def test_missing_repository_is_rejected(watchdog, monkeypatch):
 
 
 def test_head_with_no_runs_yet_is_polled_again(watchdog):
-    """Right after update-branch returns, an empty result means "too early"."""
+    """Right after update-branch returns, an empty result means 'too early'."""
     assert watchdog.needs_another_look([]) is True
 
 
 def test_head_with_a_parked_run_is_polled_again(watchdog):
-    assert watchdog.needs_another_look([_run(), _run(id=2, conclusion="action_required")]) is True
+    assert watchdog.needs_another_look([_run(), _parked(id=2)]) is True
 
 
 def test_head_with_dispatched_runs_is_settled(watchdog):
     assert watchdog.needs_another_look([_run(), _run(id=2)]) is False
-
-
-# --- probe candidate selection ---------------------------------------------
-
-
-def test_probe_reports_skipped_when_no_completed_run_exists(watchdog):
-    """A busy repository must not silently produce no verdict."""
-
-    class _NoCompletedRuns:
-        def recent_runs(self, per_page=100, run_status=""):
-            assert run_status == "completed", "the probe must filter server-side"
-            return []
-
-    permitted, explanation = watchdog.probe_approval_capability(_NoCompletedRuns())
-    assert permitted is None
-    assert "probe skipped" in explanation
-
-
-def test_probe_uses_the_first_completed_non_parked_run(watchdog):
-    class _Api:
-        approved_id = None
-
-        def recent_runs(self, per_page=100, run_status=""):
-            return [
-                {"id": 1, "status": "completed", "conclusion": "action_required"},
-                {"id": 2, "status": "completed", "conclusion": "success"},
-            ]
-
-        def approve_run(self, run_id):
-            _Api.approved_id = run_id
-            return 403, "This workflow run is not waiting for approval"
-
-    permitted, _ = watchdog.probe_approval_capability(_Api())
-    assert permitted is True
-    assert _Api.approved_id == 2


### PR DESCRIPTION
## Thinking Path

Four issues, one theme: **a check that never runs is invisible**. Absence of a
signal is not a signal, so each of these failed silently while the pipeline read
as healthy. Two turned out to have a different cause than the issue recorded.

**#12823 — the recorded cause is out of date.** The issue says `GITHUB_TOKEN`
pushes create *zero* runs (loop prevention). That is not what happens now. Runs
*are* created for the `synchronize` event the branch refresh produces — they are
created with `conclusion=action_required` and never start. The mechanism is the
repository setting `fork-pr-contributor-approval = all_external_contributors`:
`github-actions[bot]` holds no repository role, is classified as an external
contributor, and everything it triggers parks. One cause, both reported
symptoms, and it explains why only bot pushes park.

`approve` is therefore the repair — but `POST /actions/runs/{id}/approve` is
GitHub's *approve-a-fork-run* endpoint, and this repository is public, has forks,
takes fork pull requests, and runs `pull_request` jobs on a self-hosted runner.
An unconditional sweep would execute contributor-supplied code (`npm ci` and its
lifecycle scripts) on the owner's own machine — precisely what
`all_external_contributors` is set to prevent. Approval is consequently
restricted to runs whose head repository is this repository **and** whose
triggering actor is the branch-update bot; a run with no provenance fails closed.
Fork pull requests still get a published status, never an approval.

**#13045 — the intended detector had been lying.** `self-hosted-runner-health`
had failed on **100%** of its scheduled runs: it calls an administration
endpoint the workflow token cannot read, and selects a runner by a hard-coded
name that no longer matches. A permanently red health check is
indistinguishable from a real outage — which is how the outage stayed
undiagnosed.

**#13286** needed care about placement. `python-suite` is on GitHub-hosted
runners, so the new nightly does not touch the self-hosted singleton. Every job
added or moved here is `ubuntu-latest`: a watchdog that queues behind the outage
it reports cannot report it.

**Deliberately not attempted:** `--dist` untouched; matrix sharding left to its
own owner-gated issue.

## What Changed

**`pipeline-scripts/ci_dispatch_watchdog.py`** (new) — stdlib only. Approves the
eligible parked runs on the current head of each open same-repository PR, under
a per-sweep budget, then publishes a `ci-dispatch-watchdog` commit status on
every open PR head. The classification never returns `success` for a head whose
CI has not demonstrably dispatched: parked runs, runs queued past a threshold
with no self-hosted job executing, and no runs at all are each a distinct named
failure; a head inside its grace window is `pending`, never green.

Four properties are load-bearing and each is tested:

- **Fork-safe.** Approval requires same-repo head *and* bot actor; missing
  provenance fails closed.
- **Never fails open.** The capability probe returns `None` — *unresolved* — for
  401, 404, 429, 5xx, non-JSON bodies and transport failures, and the caller
  emits `::warning::` rather than treating silence as success. Transport errors
  are caught in the client, so a socket timeout can no longer escape as exit 1
  and be misread as "approval refused".
- **An API error is never a diagnosis.** `runs_for_sha` raises instead of
  returning `[]`, so a rate-limit window publishes `pending — dispatch state
  unknown (API error: …)` rather than asserting "CI never dispatched" on every
  open PR.
- **`--dry-run` is genuinely side-effect-free.** It issues no approve request at
  all, and consumes approval budget in the preview so the preview matches the
  cap a real sweep would hit. Because that means a dry run cannot answer the
  credential question, `--check probe` exists to answer it on its own.

**Runner liveness is scoped to the self-hosted pool.** Any in-progress run used
to count as "the pool is alive", which is near-permanently true — `code-quality`,
`ci.yml` and this watchdog's own cron all run on GitHub-hosted runners. Liveness
now comes from job labels via `GET /actions/runs/{id}/jobs`, the closest signal
to `/actions/runners` a workflow token may read, and is `None` when it cannot be
established.

**`.github/workflows/ci-dispatch-watchdog.yml`** (new) — scheduled safety net, a
`pull_request` self-test on its own paths, and a dedicated probe step.

**`.github/workflows/auto-update-pr-branches.yml`** — a second job runs the sweep
immediately after the refresh. The existing job is unchanged.

**`.github/workflows/self-hosted-runner-health.yml`** — broken probe replaced
with one that reads only an accessible endpoint and needs no runner name.

**`.github/workflows/ci.yml`** — the two pytest invocations split into separate
steps, the second `!cancelled()`, so the first can no longer abort the step
before the second runs. The integration-test and coverage-upload steps had the
same defect and get the same treatment. `--cov-fail-under` stays where it is and
now actually executes. A job timeout replaces the inherited 6-hour default.

**`.github/workflows/marker-tests.yml`** (new) — runs the complement of the PR
gate's marker exclusion, nightly, non-blocking. The excluded set is dominated by
`integration` tests that need a real Redis, so the job provides one as a service
container rather than failing night one on connection errors.

**`repo_tests/ci_dispatch_watchdog_test.py`** (new) — 53 tests, collected by the
existing gate.

`get_logger` is deliberately not used: `pipeline-scripts/` utilities run on a
bare runner with no repository packages installed, and every existing script
there prints.

## Verification

**Root cause of #12823, live API** — setting is
`{"approval_policy":"all_external_contributors"}`; on one refreshed head,
`created_at == run_started_at` for the runs still parked while the ones that ran
started ~16 minutes later, i.e. the batch was created parked and most were
approved by hand.

**Fork exposure is real, not theoretical** — of the parked runs currently in the
repository, 19 originate from two different forks. The guard is covered by tests
asserting that `approve` is never called for a fork-origin run, that a
fork-origin head is skipped by the sweep entirely, and that a run with no head
repository fails closed.

**Both probe branches are backed by observed responses** — a credential holding
the permission is rejected with `403 This workflow run is not waiting for
approval`; a credential without it receives `Resource not accessible by
integration`, which is what every scheduled `self-hosted-runner-health` run
received from the administration endpoint.

**Runner-liveness heuristic validated against real job payloads** — GitHub-hosted
jobs report `labels=["ubuntu-latest"]`, self-hosted jobs `["self-hosted", …]`,
and the probe agreed with the actual runner state (`busy=false` → not serving).

**Unit tests:** 53 passed.

**#13286 selection proven** — the expression collects `2/65, 63 deselected` on
two files, and the two selected are exactly the tests the issue names as running
nowhere, including the one that asserts. 2 + 63 = 65 confirms true complements.

**`actionlint` passed** on this branch (run `30752131496`, conclusion `success`).

**Lint:** `black`/`isort` at the repository-pinned versions, `flake8` clean, all
five workflows parse.

**Not verified — stated plainly.** Whether *this workflow's* `GITHUB_TOKEN` may
approve is **not settled by this PR**. An earlier revision's probe silently
selected no candidate (it filtered on `status=completed`, but a parked run *is*
`status=completed`, so on a repository carrying hundreds of parked runs every
candidate was filtered out) and printed `probe skipped` while the job passed —
the exact silent-no-signal failure this module argues against. That is fixed and
tested, but the verdict must come from a live run of the new probe step, not
from a local token. Until it prints, treat #12823 as unproven. Likewise the two
scheduled workflows, the post-refresh approve job, and the restored second pytest
invocation cannot be observed until they run on the base branch, and
`marker-tests.yml` has not had a nightly yet.

## Model Used

claude-opus-5

Closes #13300
