### PR TITLE
fix(voice,vnc): dead config key, STT silence hallucinations, screenshot temp leak (#13207, #13104, #13208)

### DIFF
--- a/autobot-backend/api/test_vnc_ocr.py
+++ b/autobot-backend/api/test_vnc_ocr.py
@@ -1,0 +1,158 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Regression tests for the VNC OCR path (#13208 review item H).
+
+``vnc_ocr_text`` called ``Image.open(tmp_path, encoding="utf-8")``. PIL's
+``Image.open`` accepts no ``encoding`` kwarg, so every call raised TypeError and
+the endpoint returned its generic error branch — 100% dead, and silently so,
+because the exception handler reported "Operation failed" either way.
+
+These tests drive the real helper with a real 1x1 PNG so the decode has to
+actually succeed; only ``pytesseract`` is stubbed.
+"""
+
+import base64
+import io
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from api.vnc_manager import _crop_to_region, _ocr_png_file
+from autobot_shared.temp_files import temporary_file_path
+
+Image = pytest.importorskip("PIL.Image", reason="Pillow not installed")
+
+
+def _png_bytes(width: int = 4, height: int = 4) -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", (width, height), color=(255, 255, 255)).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+class TestOcrDecodesTheImage:
+    def test_real_png_is_decoded_and_passed_to_tesseract(self):
+        """The bug: this raised TypeError before Image.open lost its kwarg."""
+        fake_tesseract = MagicMock()
+        fake_tesseract.image_to_string.return_value = "hello world"
+
+        with patch.dict("sys.modules", {"pytesseract": fake_tesseract}):
+            with temporary_file_path(suffix=".png") as tmp_path:
+                text = _ocr_png_file(tmp_path, _png_bytes(), None)
+
+        assert text == "hello world"
+        assert fake_tesseract.image_to_string.called
+        image_arg = fake_tesseract.image_to_string.call_args.args[0]
+        assert image_arg.size == (4, 4)
+
+    def test_image_open_is_called_with_one_positional_arg_and_no_encoding(self):
+        """Pins the exact defect: no stray kwarg may come back."""
+        fake_tesseract = MagicMock()
+        fake_tesseract.image_to_string.return_value = ""
+
+        with patch.dict("sys.modules", {"pytesseract": fake_tesseract}):
+            with patch("PIL.Image.open", wraps=Image.open) as opener:
+                with temporary_file_path(suffix=".png") as tmp_path:
+                    _ocr_png_file(tmp_path, _png_bytes(), None)
+
+        assert opener.call_count == 1
+        assert len(opener.call_args.args) == 1
+        assert "encoding" not in opener.call_args.kwargs
+
+    def test_base64_round_trip_matches_the_endpoint_flow(self):
+        """vnc_ocr_text decodes base64 from the screenshot before calling us."""
+        fake_tesseract = MagicMock()
+        fake_tesseract.image_to_string.return_value = "decoded"
+        encoded = base64.b64encode(_png_bytes(8, 8)).decode("utf-8")
+
+        with patch.dict("sys.modules", {"pytesseract": fake_tesseract}):
+            with temporary_file_path(suffix=".png") as tmp_path:
+                text = _ocr_png_file(tmp_path, base64.b64decode(encoded), None)
+
+        assert text == "decoded"
+        assert fake_tesseract.image_to_string.call_args.args[0].size == (8, 8)
+
+
+class TestRegionCropping:
+    def test_complete_region_crops(self):
+        image = Image.new("RGB", (10, 10))
+
+        cropped = _crop_to_region(image, {"x": 1, "y": 2, "width": 4, "height": 3})
+
+        assert cropped.size == (4, 3)
+
+    @pytest.mark.parametrize("region", [None, {}, {"x": 1, "y": 2}, {"x": 1, "y": 2, "width": 4}])
+    def test_absent_or_partial_region_is_ignored(self, region):
+        image = Image.new("RGB", (10, 10))
+
+        assert _crop_to_region(image, region).size == (10, 10)
+
+    def test_cropping_happens_before_ocr(self):
+        fake_tesseract = MagicMock()
+        fake_tesseract.image_to_string.return_value = ""
+
+        with patch.dict("sys.modules", {"pytesseract": fake_tesseract}):
+            with temporary_file_path(suffix=".png") as tmp_path:
+                _ocr_png_file(tmp_path, _png_bytes(10, 10), {"x": 0, "y": 0, "width": 5, "height": 5})
+
+        assert fake_tesseract.image_to_string.call_args.args[0].size == (5, 5)
+
+
+class TestTempFileStillCleanedUp:
+    def test_ocr_helper_leaves_no_file_behind(self, tmp_path, monkeypatch):
+        import tempfile
+
+        monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
+        fake_tesseract = MagicMock()
+        fake_tesseract.image_to_string.side_effect = RuntimeError("tesseract died")
+
+        with patch.dict("sys.modules", {"pytesseract": fake_tesseract}):
+            with pytest.raises(RuntimeError):
+                with temporary_file_path(suffix=".png") as tmp_file:
+                    _ocr_png_file(tmp_file, _png_bytes(), None)
+
+        assert list(tmp_path.iterdir()) == []
+
+
+class TestScreenshotDoesNotBlockTheEventLoop:
+    """Review item G: two 10s subprocess timeouts ran inline on the loop."""
+
+    @pytest.mark.asyncio
+    async def test_capture_dispatches_subprocess_via_to_thread(self):
+        import subprocess
+        from unittest.mock import AsyncMock
+
+        from api import vnc_manager
+
+        fail = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="")
+        with patch("asyncio.to_thread", new_callable=AsyncMock, return_value=fail) as to_thread:
+            captured = await vnc_manager._capture_screenshot_to("/tmp/does-not-matter.png")
+
+        assert captured is False
+        assert to_thread.call_count == 2, "scrot and the import fallback must both be dispatched"
+        assert all(call.args[0] is subprocess.run for call in to_thread.call_args_list)
+        assert to_thread.call_args_list[0].args[1][0] == "scrot"
+        assert to_thread.call_args_list[1].args[1][0] == "import"
+
+    @pytest.mark.asyncio
+    async def test_capture_stops_after_the_first_success(self):
+        import subprocess
+        from unittest.mock import AsyncMock
+
+        from api import vnc_manager
+
+        ok = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        with patch("asyncio.to_thread", new_callable=AsyncMock, return_value=ok) as to_thread:
+            captured = await vnc_manager._capture_screenshot_to("/tmp/does-not-matter.png")
+
+        assert captured is True
+        assert to_thread.call_count == 1
+
+    def test_capture_helpers_are_coroutines(self):
+        import inspect
+
+        from api import vnc_manager
+
+        assert inspect.iscoroutinefunction(vnc_manager._capture_screenshot_to)
+        assert inspect.iscoroutinefunction(vnc_manager._run_screenshot_capture)

--- a/autobot-backend/api/test_voice_transcribe_silence_filter.py
+++ b/autobot-backend/api/test_voice_transcribe_silence_filter.py
@@ -1,0 +1,99 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""The live /api/voice/transcribe route must not emit phantom turns (#13104).
+
+This is the route the issue is actually about. `useVoiceConversation.ts` — the
+composable that runs walkie-talkie, hands-free and full-duplex modes — POSTs
+recorded audio here, so an unfiltered Whisper hallucination on this path is
+exactly the "phantom user turn" #13104 describes.
+
+The transformers ASR pipeline returns neither a language nor a no-speech
+probability, so these tests also pin the fallback behaviour: the caller's
+requested language keys the denylist, and the gates that need audio signals
+fail open rather than guessing.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from api.voice import _whisper_sync
+
+
+def _pipe(text: str, language: str | None = None):
+    """Stand-in for the transformers ASR pipeline callable."""
+    output = {"text": text}
+    if language is not None:
+        output["language"] = language
+    return MagicMock(return_value=output)
+
+
+class TestHallucinationsAreDiscardedOnTheLiveRoute:
+    def test_structural_artifact_is_discarded(self):
+        result = _whisper_sync(_pipe("Subtitles by the Amara.org community"), b"x", ".wav", "en")
+
+        assert result["text"] == ""
+        assert result["confidence"] == 0.0
+
+    def test_outro_artifact_is_discarded_when_no_energy_is_available(self):
+        """The pipeline gives no RMS, which is the hands-free hallucination case."""
+        result = _whisper_sync(_pipe("Thanks for watching!"), b"x", ".wav", "en")
+
+        assert result["text"] == ""
+        assert result["confidence"] == 0.0
+
+    def test_bare_audio_tag_is_discarded_without_any_language(self):
+        result = _whisper_sync(_pipe("[BLANK_AUDIO]"), b"x", ".wav", "")
+
+        assert result["text"] == ""
+
+    def test_requested_language_keys_the_denylist(self):
+        """The pipeline reports no language, so the form's value must be used.
+
+        Without this fallback the language is "unknown", the denylist is
+        disabled by design, and the filter would be dead on the live route.
+        """
+        assert _whisper_sync(_pipe("Paldies par skatīšanos!"), b"x", ".wav", "lv")["text"] == ""
+        # Same phrase, wrong language key — not an artifact in English.
+        assert _whisper_sync(_pipe("Paldies par skatīšanos!"), b"x", ".wav", "en")["text"] != ""
+
+    def test_detected_language_wins_over_the_requested_one(self):
+        result = _whisper_sync(_pipe("Thanks for watching!", language="en"), b"x", ".wav", "lv")
+
+        assert result["text"] == ""
+
+    def test_discard_is_logged_with_the_text(self, caplog):
+        """Owner rule: no silent dropping — a swallowed turn must be diagnosable."""
+        with caplog.at_level("INFO"):
+            _whisper_sync(_pipe("Subtitles by the Amara.org community"), b"x", ".wav", "en")
+
+        assert "Subtitles by the Amara.org community" in caplog.text
+
+
+class TestRealSpeechStillTranscribes:
+    @pytest.mark.parametrize("transcript", ["okay", "no", "yeah", "bye", "yes", "open the browser"])
+    def test_real_answer_survives(self, transcript):
+        result = _whisper_sync(_pipe(transcript), b"x", ".wav", "en")
+
+        assert result["text"] == transcript
+        assert result["confidence"] == 0.9
+
+    def test_unknown_language_disables_the_denylist_but_not_the_route(self):
+        result = _whisper_sync(_pipe("Thanks for watching!"), b"x", ".wav", "")
+
+        assert result["text"] == "Thanks for watching!"
+
+    def test_empty_transcript_is_unchanged(self):
+        result = _whisper_sync(_pipe(""), b"x", ".wav", "en")
+
+        assert result["text"] == ""
+        assert result["confidence"] == 0.0
+
+    def test_pipeline_failure_still_returns_the_empty_shape(self):
+        failing = MagicMock(side_effect=RuntimeError("model exploded"))
+
+        result = _whisper_sync(failing, b"x", ".wav", "en")
+
+        assert result == {"text": "", "language": "unknown", "confidence": 0.0}

--- a/autobot-backend/api/vnc_manager.py
+++ b/autobot-backend/api/vnc_manager.py
@@ -12,7 +12,6 @@ import asyncio
 import base64
 import re
 import subprocess  # nosec B404
-import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, List
@@ -65,6 +64,7 @@ from api.vnc_humanization import (
 from auth_middleware import check_admin_permission, get_current_user
 from autobot_shared.error_boundaries import with_error_handling
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.temp_files import temporary_file_path
 from constants.network_constants import NetworkConstants
 from constants.threshold_constants import TimingConstants
 
@@ -549,6 +549,25 @@ async def vnc_mouse_drag(
     return _run_xdotool_cmd(["mouseup", "1"])
 
 
+def _run_screenshot_capture(argv: list):
+    """Run one screenshot capture command. Issue #13208 (extracted helper)."""
+    return subprocess.run(  # nosec B603 B607 - fixed argv, no user input
+        argv,
+        capture_output=True,
+        text=True,
+        timeout=10,
+        env={"DISPLAY": NetworkConstants.DESKTOP_DISPLAY},
+    )
+
+
+def _capture_screenshot_to(tmp_path: str) -> bool:
+    """Capture the desktop into *tmp_path*, falling back from scrot to import."""
+    for argv in (["scrot", "-o", tmp_path], ["import", "-window", "root", tmp_path]):
+        if _run_screenshot_capture(argv).returncode == 0:
+            return True
+    return False
+
+
 @router.get("/screenshot", response_model=VncScreenshotResponse)
 @with_error_handling(error_code_prefix="VNC_SCREENSHOT")
 async def vnc_screenshot(
@@ -558,6 +577,10 @@ async def vnc_screenshot(
     Capture desktop screenshot.
     Issue #74: Desktop interaction controls.
 
+    Issue #13208: ``temporary_file_path`` owns the temp file, so it is removed
+    on the success path, on capture failure and on any exception. Previously
+    only the success path unlinked it and each failed capture leaked a PNG.
+
     Returns:
         {
             "status": "success|error",
@@ -566,41 +589,16 @@ async def vnc_screenshot(
         }
     """
     try:
-        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp_file:
-            tmp_path = tmp_file.name
+        with temporary_file_path(suffix=".png") as tmp_path:
+            if not _capture_screenshot_to(tmp_path):
+                return {
+                    "status": "error",
+                    "message": "Screenshot capture failed",
+                    "image_data": "",
+                }
 
-        # Use scrot to capture screenshot
-        result = subprocess.run(  # nosec B603 B607 - fixed argv, no user input
-            ["scrot", "-o", tmp_path],
-            capture_output=True,
-            text=True,
-            timeout=10,
-            env={"DISPLAY": NetworkConstants.DESKTOP_DISPLAY},
-        )
-
-        if result.returncode != 0:
-            # Fallback to import command if scrot fails
-            result = subprocess.run(  # nosec B603 B607 - fixed argv, no user input
-                ["import", "-window", "root", tmp_path],
-                capture_output=True,
-                text=True,
-                timeout=10,
-                env={"DISPLAY": NetworkConstants.DESKTOP_DISPLAY},
-            )
-
-        if result.returncode != 0:
-            return {
-                "status": "error",
-                "message": "Screenshot capture failed",
-                "image_data": "",
-            }
-
-        # Read and encode image
-        with open(tmp_path, "rb") as f:
-            image_data = base64.b64encode(f.read()).decode("utf-8")
-
-        # Cleanup
-        Path(tmp_path).unlink(missing_ok=True)
+            with open(tmp_path, "rb") as f:
+                image_data = base64.b64encode(f.read()).decode("utf-8")
 
         return {
             "status": "success",
@@ -1120,6 +1118,20 @@ async def delete_macro(name: str, admin_check: bool = Depends(check_admin_permis
 # Area 5: Automation Features - OCR Text Recognition
 
 
+def _crop_to_region(image, region):
+    """Crop *image* to *region* when a complete x/y/width/height box is given."""
+    if not region or not all(k in region for k in ("x", "y", "width", "height")):
+        return image
+    box = (
+        region["x"],
+        region["y"],
+        region["x"] + region["width"],
+        region["y"] + region["height"],
+    )
+    return image.crop(box)
+
+
+
 @router.post("/ocr", response_model=VncOcrResponse)
 @with_error_handling(error_code_prefix="VNC_OCR")
 async def vnc_ocr_text(
@@ -1154,28 +1166,16 @@ async def vnc_ocr_text(
 
         # Decode image
         image_data = base64.b64decode(screenshot_result["image_data"])
-        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp_file:
-            tmp_file.write(image_data)
-            tmp_path = tmp_file.name
 
-        # Load image
-        image = Image.open(tmp_path, encoding="utf-8")
-
-        # Crop to region if specified
-        if request.region and all(k in request.region for k in ["x", "y", "width", "height"]):
-            box = (
-                request.region["x"],
-                request.region["y"],
-                request.region["x"] + request.region["width"],
-                request.region["y"] + request.region["height"],
-            )
-            image = image.crop(box)
-
-        # Perform OCR
-        text = pytesseract.image_to_string(image)
-
-        # Cleanup
-        Path(tmp_path).unlink(missing_ok=True)
+        # Issue #13208: the temp file is removed on every path, including the
+        # PIL/pytesseract failure paths that previously leaked it.
+        with temporary_file_path(suffix=".png") as tmp_path:
+            Path(tmp_path).write_bytes(image_data)
+            # Image.open takes no `encoding` kwarg — passing one raised TypeError
+            # and made every OCR call fail (found while fixing #13208).
+            image = Image.open(tmp_path)
+            image = _crop_to_region(image, request.region)
+            text = pytesseract.image_to_string(image)
 
         return {"status": "success", "text": text.strip(), "message": "OCR completed"}
 

--- a/autobot-backend/api/vnc_manager.py
+++ b/autobot-backend/api/vnc_manager.py
@@ -549,9 +549,14 @@ async def vnc_mouse_drag(
     return _run_xdotool_cmd(["mouseup", "1"])
 
 
-def _run_screenshot_capture(argv: list):
-    """Run one screenshot capture command. Issue #13208 (extracted helper)."""
-    return subprocess.run(  # nosec B603 B607 - fixed argv, no user input
+async def _run_screenshot_capture(argv: list):
+    """Run one screenshot capture command off the event loop. Issue #13208.
+
+    Each command carries a 10s timeout and there are two of them, so running
+    these inline blocked the loop for up to 20s per failed capture.
+    """
+    return await asyncio.to_thread(  # nosec B603 B607 - fixed argv, no user input
+        subprocess.run,
         argv,
         capture_output=True,
         text=True,
@@ -560,10 +565,11 @@ def _run_screenshot_capture(argv: list):
     )
 
 
-def _capture_screenshot_to(tmp_path: str) -> bool:
+async def _capture_screenshot_to(tmp_path: str) -> bool:
     """Capture the desktop into *tmp_path*, falling back from scrot to import."""
     for argv in (["scrot", "-o", tmp_path], ["import", "-window", "root", tmp_path]):
-        if _run_screenshot_capture(argv).returncode == 0:
+        result = await _run_screenshot_capture(argv)
+        if result.returncode == 0:
             return True
     return False
 
@@ -590,7 +596,7 @@ async def vnc_screenshot(
     """
     try:
         with temporary_file_path(suffix=".png") as tmp_path:
-            if not _capture_screenshot_to(tmp_path):
+            if not await _capture_screenshot_to(tmp_path):
                 return {
                     "status": "error",
                     "message": "Screenshot capture failed",
@@ -1118,6 +1124,19 @@ async def delete_macro(name: str, admin_check: bool = Depends(check_admin_permis
 # Area 5: Automation Features - OCR Text Recognition
 
 
+def _ocr_png_file(tmp_path: str, image_data: bytes, region) -> str:
+    """Write, decode and OCR a PNG. Blocking — call via asyncio.to_thread."""
+    import pytesseract
+    from PIL import Image
+
+    Path(tmp_path).write_bytes(image_data)
+    # Image.open takes no `encoding` kwarg — passing one raised TypeError and
+    # made every OCR call fail (found while fixing #13208).
+    image = Image.open(tmp_path)
+    image = _crop_to_region(image, region)
+    return pytesseract.image_to_string(image)
+
+
 def _crop_to_region(image, region):
     """Crop *image* to *region* when a complete x/y/width/height box is given."""
     if not region or not all(k in region for k in ("x", "y", "width", "height")):
@@ -1147,9 +1166,10 @@ async def vnc_ocr_text(
         {"status": "success|error", "text": "recognized text", "message": "..."}
     """
     try:
-        # Check if pytesseract is available
-        import pytesseract
-        from PIL import Image
+        # Availability probe only — the real work imports these inside
+        # _ocr_png_file, which runs in a worker thread.
+        import pytesseract  # noqa: F401
+        from PIL import Image  # noqa: F401
     except ImportError:
         return {
             "status": "error",
@@ -1169,12 +1189,9 @@ async def vnc_ocr_text(
         # Issue #13208: the temp file is removed on every path, including the
         # PIL/pytesseract failure paths that previously leaked it.
         with temporary_file_path(suffix=".png") as tmp_path:
-            Path(tmp_path).write_bytes(image_data)
-            # Image.open takes no `encoding` kwarg — passing one raised TypeError
-            # and made every OCR call fail (found while fixing #13208).
-            image = Image.open(tmp_path)
-            image = _crop_to_region(image, request.region)
-            text = pytesseract.image_to_string(image)
+            # PIL decode and the tesseract call are both CPU-bound and blocking,
+            # so they run in a worker thread rather than on the event loop.
+            text = await asyncio.to_thread(_ocr_png_file, tmp_path, image_data, request.region)
 
         return {"status": "success", "text": text.strip(), "message": "OCR completed"}
 

--- a/autobot-backend/api/vnc_manager.py
+++ b/autobot-backend/api/vnc_manager.py
@@ -1131,7 +1131,6 @@ def _crop_to_region(image, region):
     return image.crop(box)
 
 
-
 @router.post("/ocr", response_model=VncOcrResponse)
 @with_error_handling(error_code_prefix="VNC_OCR")
 async def vnc_ocr_text(

--- a/autobot-backend/api/vnc_mcp.py
+++ b/autobot-backend/api/vnc_mcp.py
@@ -50,6 +50,7 @@ from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.http_client import get_http_client
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.temp_files import temporary_file_path
 from autobot_shared.time_utils import parse_utc_iso
 from constants.network_constants import NetworkConstants
 from type_defs.common import Metadata
@@ -578,6 +579,32 @@ async def desktop_special_key_mcp(request: DesktopSpecialKeyRequest) -> Metadata
     }
 
 
+async def _run_capture_command(argv: list):
+    """Run one screenshot capture command off the event loop. Issue #10785."""
+    import subprocess  # nosec B404
+
+    return await asyncio.to_thread(  # nosec B603 B607 - fixed argv, no user input
+        subprocess.run,
+        argv,
+        capture_output=True,
+        text=True,
+        timeout=10,
+        env={"DISPLAY": NetworkConstants.DESKTOP_DISPLAY},
+    )
+
+
+async def _capture_desktop_png(tmp_path: str) -> bool:
+    """Capture the desktop into *tmp_path*, falling back from scrot to import.
+
+    Returns True when one of the capture commands succeeded.
+    """
+    for argv in (["scrot", "-o", tmp_path], ["import", "-window", "root", tmp_path]):
+        result = await _run_capture_command(argv)
+        if result.returncode == 0:
+            return True
+    return False
+
+
 @router.post("/mcp/desktop_screenshot", response_model=DesktopScreenshotMcpResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -588,50 +615,25 @@ async def desktop_screenshot_mcp() -> Metadata:
     """
     MCP tool: Capture desktop screenshot.
     Issue #74: Agent desktop observation.
+
+    Issue #13208: the temp file is owned by ``temporary_file_path``, so it is
+    removed on the success path, on capture failure and on any exception.
+    Previously only the success path unlinked it, so production leaked one PNG
+    per failed capture, indefinitely.
     """
     import base64
-    import subprocess  # nosec B404
-    import tempfile
-    from pathlib import Path
 
     try:
-        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp_file:
-            tmp_path = tmp_file.name
+        with temporary_file_path(suffix=".png") as tmp_path:
+            if not await _capture_desktop_png(tmp_path):
+                return {
+                    "success": False,
+                    "message": "Screenshot capture failed",
+                    "action": "screenshot",
+                }
 
-        # Use scrot to capture screenshot
-        result = await asyncio.to_thread(  # nosec B603 B607 - fixed argv, no user input
-            subprocess.run,
-            ["scrot", "-o", tmp_path],
-            capture_output=True,
-            text=True,
-            timeout=10,
-            env={"DISPLAY": NetworkConstants.DESKTOP_DISPLAY},
-        )
-
-        if result.returncode != 0:
-            # Fallback to import command
-            result = await asyncio.to_thread(  # nosec B603 B607 - fixed argv, no user input
-                subprocess.run,
-                ["import", "-window", "root", tmp_path],
-                capture_output=True,
-                text=True,
-                timeout=10,
-                env={"DISPLAY": NetworkConstants.DESKTOP_DISPLAY},
-            )
-
-        if result.returncode != 0:
-            return {
-                "success": False,
-                "message": "Screenshot capture failed",
-                "action": "screenshot",
-            }
-
-        # Read and encode image
-        with open(tmp_path, "rb") as f:
-            image_data = base64.b64encode(f.read()).decode("utf-8")
-
-        # Cleanup
-        Path(tmp_path).unlink(missing_ok=True)
+            with open(tmp_path, "rb") as f:
+                image_data = base64.b64encode(f.read()).decode("utf-8")
 
         return {
             "success": True,

--- a/autobot-backend/api/voice.py
+++ b/autobot-backend/api/voice.py
@@ -348,6 +348,29 @@ _MIME_TO_SUFFIX = {
 }
 
 
+def _drop_silence_hallucination(text: str, detected_lang: str, requested_lang: str) -> str:
+    """Return "" when Whisper hallucinated *text* from silence. Issue #13104.
+
+    This is the route behind hands-free and full-duplex conversation, so an
+    unfiltered hallucination here becomes a phantom user turn.
+
+    The transformers ASR pipeline reports neither a language nor a no-speech
+    probability, so ``detected_lang`` is always "unknown" and the caller's
+    requested language is used instead — without that fallback an unknown
+    language disables the phrase tiers and the filter would be dead here.
+    """
+    filter_lang = detected_lang if detected_lang and detected_lang != "unknown" else (requested_lang or None)
+    if not is_silence_hallucination(text, filter_lang):
+        return text
+
+    logger.info(
+        "Discarded silence hallucination from /voice/transcribe: %r (language=%s)",
+        text,
+        filter_lang or "unknown",
+    )
+    return ""
+
+
 def _whisper_sync(pipe, audio_bytes: bytes, suffix: str, language: str = "") -> dict:
     """Blocking Whisper inference — call via asyncio.to_thread (#1030).
 
@@ -370,20 +393,7 @@ def _whisper_sync(pipe, audio_bytes: bytes, suffix: str, language: str = "") -> 
         text = output.get("text", "").strip() if isinstance(output, dict) else ""
         detected_lang = output.get("language", "unknown") if isinstance(output, dict) else "unknown"
 
-        # Issue #13104: this is the route behind hands-free and full-duplex
-        # conversation, so an unfiltered Whisper hallucination here becomes a
-        # phantom user turn. The transformers ASR pipeline reports neither a
-        # language nor a no-speech probability, so fall back to the caller's
-        # requested language and run the gates that need no audio signal.
-        filter_lang = detected_lang if detected_lang and detected_lang != "unknown" else (language or None)
-        if is_silence_hallucination(text, filter_lang):
-            logger.info(
-                "Discarded silence hallucination from /voice/transcribe: %r (language=%s)",
-                text,
-                filter_lang or "unknown",
-            )
-            text = ""
-
+        text = _drop_silence_hallucination(text, detected_lang, language)
         confidence = 0.9 if text else 0.0
         return {
             "text": text,

--- a/autobot-backend/api/voice.py
+++ b/autobot-backend/api/voice.py
@@ -336,6 +336,8 @@ async def voice_delete_api(voice_id: str):
 # Audio transcription via Whisper (#1030)
 # ------------------------------------------------------------------
 
+from voice_processing.hallucination_filter import is_silence_hallucination  # noqa: E402
+
 _MIME_TO_SUFFIX = {
     "audio/webm": ".webm",
     "audio/ogg": ".ogg",
@@ -367,6 +369,21 @@ def _whisper_sync(pipe, audio_bytes: bytes, suffix: str, language: str = "") -> 
         )
         text = output.get("text", "").strip() if isinstance(output, dict) else ""
         detected_lang = output.get("language", "unknown") if isinstance(output, dict) else "unknown"
+
+        # Issue #13104: this is the route behind hands-free and full-duplex
+        # conversation, so an unfiltered Whisper hallucination here becomes a
+        # phantom user turn. The transformers ASR pipeline reports neither a
+        # language nor a no-speech probability, so fall back to the caller's
+        # requested language and run the gates that need no audio signal.
+        filter_lang = detected_lang if detected_lang and detected_lang != "unknown" else (language or None)
+        if is_silence_hallucination(text, filter_lang):
+            logger.info(
+                "Discarded silence hallucination from /voice/transcribe: %r (language=%s)",
+                text,
+                filter_lang or "unknown",
+            )
+            text = ""
+
         confidence = 0.9 if text else 0.0
         return {
             "text": text,

--- a/autobot-backend/config/defaults.py
+++ b/autobot-backend/config/defaults.py
@@ -119,10 +119,14 @@ def _get_multimodal_config() -> Dict[str, Any]:
             "confidence_threshold": 0.7,
             "processing_timeout": 30,
         },
+        # Issue #13207: VoiceProcessor read the non-existent "multimodal.audio"
+        # section, so these numbers never reached it — it ran on 0.7 / 30. The
+        # lookup is fixed; these are set to the values that were actually in
+        # effect so the fix does not silently retune voice confidence/timeout.
         "voice": {
             "enabled": True,
-            "confidence_threshold": 0.8,
-            "processing_timeout": 15,
+            "confidence_threshold": 0.7,
+            "processing_timeout": 30,
         },
         "context": {
             "enabled": True,

--- a/autobot-backend/knowledge/connectors/audio_connector.py
+++ b/autobot-backend/knowledge/connectors/audio_connector.py
@@ -33,6 +33,7 @@ from datetime import datetime, timezone
 from typing import List
 
 from autobot_shared.logging_manager import get_logger
+from voice_processing.hallucination_filter import is_silence_hallucination
 from autobot_shared.time_utils import now_utc
 from knowledge.connectors.base import AbstractConnector
 from knowledge.connectors.models import (
@@ -111,7 +112,35 @@ def _transcribe_with_whisper_cpu(
     if language:
         options["language"] = language
     result = model.transcribe(audio_path, **options)
-    return result.get("text", "")
+    return _reject_hallucinated_transcript(result, language)
+
+
+def _mean_no_speech_prob(result: dict) -> float | None:
+    """Average no_speech_prob across segments, or None when unavailable.
+
+    openai-whisper is the one STT backend in the tree that reports this; the
+    transformers ASR pipeline used by the live voice route does not, which is
+    why the other call sites gate on audio energy instead (#13104).
+    """
+    segments = result.get("segments") or []
+    probs = [seg["no_speech_prob"] for seg in segments if isinstance(seg, dict) and "no_speech_prob" in seg]
+    if not probs:
+        return None
+    return sum(probs) / len(probs)
+
+
+def _reject_hallucinated_transcript(result: dict, language: str | None) -> str:
+    """Blank a transcript Whisper hallucinated from silence (#13104).
+
+    Ingesting a phantom sentence puts text in the knowledge base that no source
+    ever contained, so the same filter applies here as on the live voice route.
+    """
+    text = result.get("text", "")
+    detected = result.get("language") or language
+    if is_silence_hallucination(text, detected, no_speech_prob=_mean_no_speech_prob(result)):
+        logger.info("Discarded hallucinated audio transcript before ingestion: %r", text)
+        return ""
+    return text
 
 
 async def _download_audio_yt_dlp(url: str, dest_dir: str) -> str:

--- a/autobot-backend/knowledge/connectors/audio_connector.py
+++ b/autobot-backend/knowledge/connectors/audio_connector.py
@@ -33,7 +33,6 @@ from datetime import datetime, timezone
 from typing import List
 
 from autobot_shared.logging_manager import get_logger
-from voice_processing.hallucination_filter import is_silence_hallucination
 from autobot_shared.time_utils import now_utc
 from knowledge.connectors.base import AbstractConnector
 from knowledge.connectors.models import (
@@ -43,6 +42,7 @@ from knowledge.connectors.models import (
     SourceInfo,
 )
 from knowledge.connectors.registry import ConnectorRegistry
+from voice_processing.hallucination_filter import is_silence_hallucination
 
 logger = get_logger(__name__)
 

--- a/autobot-backend/knowledge/connectors/test_audio_connector_hallucination.py
+++ b/autobot-backend/knowledge/connectors/test_audio_connector_hallucination.py
@@ -1,0 +1,80 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Whisper hallucinations must not be ingested into the knowledge base (#13104).
+
+openai-whisper is the one STT backend in the tree that reports
+``no_speech_prob`` per segment, so this is where that gate — and the
+``AUTOBOT_STT_NO_SPEECH_PROB_THRESHOLD`` knob — actually has a producer.
+Ingesting a phantom sentence would put text in the KB that no source ever
+contained, and unlike a phantom voice turn it persists.
+"""
+
+import pytest
+
+from knowledge.connectors.audio_connector import _mean_no_speech_prob, _reject_hallucinated_transcript
+from voice_processing.hallucination_filter import NO_SPEECH_PROB_THRESHOLD
+
+
+def _result(text: str, no_speech_probs=None, language=None) -> dict:
+    result: dict = {"text": text}
+    if language is not None:
+        result["language"] = language
+    if no_speech_probs is not None:
+        result["segments"] = [{"no_speech_prob": p} for p in no_speech_probs]
+    return result
+
+
+class TestNoSpeechProbabilityGate:
+    def test_high_no_speech_probability_discards_the_transcript(self):
+        result = _result("Thanks for watching!", [0.97, 0.95], language="en")
+
+        assert _reject_hallucinated_transcript(result, "en") == ""
+
+    def test_high_probability_discards_even_plausible_text(self):
+        """The decoder is saying there was no speech at all."""
+        result = _result("the quarterly figures were strong", [0.99], language="en")
+
+        assert _reject_hallucinated_transcript(result, "en") == ""
+
+    def test_low_no_speech_probability_keeps_the_transcript(self):
+        result = _result("the quarterly figures were strong", [0.01, 0.02], language="en")
+
+        assert _reject_hallucinated_transcript(result, "en") == "the quarterly figures were strong"
+
+    def test_probability_is_averaged_across_segments(self):
+        probs = [0.0, 1.0]
+        assert _mean_no_speech_prob(_result("x", probs)) == pytest.approx(0.5)
+        assert 0.5 < NO_SPEECH_PROB_THRESHOLD
+        assert _reject_hallucinated_transcript(_result("real speech here", probs), "en") == "real speech here"
+
+    def test_missing_segments_yield_none_not_zero(self):
+        """None means 'no evidence'; 0.0 would falsely mean 'definitely speech'."""
+        assert _mean_no_speech_prob({"text": "x"}) is None
+        assert _mean_no_speech_prob({"text": "x", "segments": []}) is None
+
+    def test_backend_without_the_field_falls_back_to_phrase_gates(self):
+        assert _reject_hallucinated_transcript(_result("Subtitles by the Amara.org community"), "en") == ""
+        assert _reject_hallucinated_transcript(_result("a normal sentence"), "en") == "a normal sentence"
+
+
+class TestLanguageResolution:
+    def test_detected_language_is_preferred(self):
+        result = _result("Paldies par skatīšanos!", language="lv")
+
+        assert _reject_hallucinated_transcript(result, "en") == ""
+
+    def test_requested_language_is_the_fallback(self):
+        assert _reject_hallucinated_transcript(_result("Paldies par skatīšanos!"), "lv") == ""
+
+    def test_no_language_disables_the_phrase_gates(self):
+        assert _reject_hallucinated_transcript(_result("Thanks for watching!"), None) == "Thanks for watching!"
+
+
+class TestDiscardIsDiagnosable:
+    def test_discarded_ingestion_is_logged_with_the_text(self, caplog):
+        with caplog.at_level("INFO"):
+            _reject_hallucinated_transcript(_result("Thanks for watching!", [0.99]), "en")
+
+        assert "Thanks for watching!" in caplog.text

--- a/autobot-backend/multimodal_processor/processors/lsp_exception_contract_test.py
+++ b/autobot-backend/multimodal_processor/processors/lsp_exception_contract_test.py
@@ -5,73 +5,184 @@
 """#6755 LSP exception contract regression tests.
 
 The cross-file analyzer (#6747) flagged ``VisionProcessor.process`` and
-``VoiceProcessor.process`` as ``lsp_exception_contract_changed``: their
-parent ``BaseModalProcessor.process`` only declares ``NotImplementedError``,
-but the subclasses raised ``ValueError`` for unsupported modalities.
-Liskov substitution requires subclasses NOT to raise exceptions outside
-the parent's declared contract — callers handling only the parent's
-exception types would silently miss the ``ValueError`` and crash.
+``VoiceProcessor.process`` as ``lsp_exception_contract_changed``: their parent
+``BaseModalProcessor.process`` only declares ``NotImplementedError``, but the
+subclasses raised ``ValueError`` for unsupported modalities. Liskov
+substitution requires subclasses NOT to raise exceptions outside the parent's
+declared contract — callers handling only the parent's exception types would
+silently miss the ``ValueError`` and crash.
 
-These tests pin the fix shape (return a failure ``ProcessingResult``,
-don't raise) so a future refactor can't silently re-introduce a bare
-``raise ValueError`` inside ``process``.
+These tests **drive the failure path and assert the returned result**. They
+used to read ``inspect.getsource(cls.process)`` and grep for the literals
+``success=False`` and ``Unsupported modality``, which guaranteed nothing: the
+grep passes when the literal sits in an unreachable branch, and fails on any
+refactor that preserves behaviour — it broke the moment the failure result was
+extracted into a helper (#13207). An exception-contract test has to observe
+what the caller observes.
 """
 
 from __future__ import annotations
 
-import inspect
+from unittest.mock import MagicMock, patch
 
-# ---------------------------------------------------------------------------
-# Source-level guards: pin the no-raise contract on `.process()`
-# ---------------------------------------------------------------------------
+import pytest
+
+from multimodal_processor.models import MultiModalInput, ProcessingResult
+from multimodal_processor.types import ModalityType, ProcessingIntent
+
+# Modalities that reach each processor's *unsupported-modality* branch.
+# These differ, and the old source-grep test could never have noticed:
+# VisionProcessor accepts VIDEO into its pipeline and fails further in with a
+# "not yet implemented" message, so VIDEO is not "unsupported" for vision.
+VISION_UNSUPPORTED = [ModalityType.TEXT, ModalityType.COMBINED]
+VOICE_UNSUPPORTED = [ModalityType.TEXT, ModalityType.IMAGE, ModalityType.VIDEO, ModalityType.COMBINED]
+
+# Every modality that is not the processor's own — whatever branch handles it,
+# the LSP contract is the same: return a result, never raise.
+VISION_NON_NATIVE = VISION_UNSUPPORTED + [ModalityType.VIDEO]
+VOICE_NON_NATIVE = VOICE_UNSUPPORTED
 
 
-def _process_source(cls) -> str:
-    return inspect.getsource(cls.process)
-
-
-def test_vision_processor_process_does_not_raise_value_error() -> None:
-    """Pin the LSP fix: the source of ``VisionProcessor.process`` must not
-    contain a bare ``raise ValueError`` for unsupported-modality handling.
-    The fix shape is to return a failure ``ProcessingResult`` instead."""
-    from multimodal_processor.processors.vision import VisionProcessor
-
-    src = _process_source(VisionProcessor)
-    # The early-return shape replaces the original `raise ValueError(...)`.
-    assert "raise ValueError" not in src, (
-        "#6755 regression: VisionProcessor.process re-introduced a bare "
-        "`raise ValueError` — parent BaseModalProcessor.process only declares "
-        "NotImplementedError; LSP requires subclasses NOT to raise outside "
-        "the parent contract. Return a failure ProcessingResult instead."
+def _input(modality: ModalityType) -> MultiModalInput:
+    return MultiModalInput(
+        input_id="lsp-contract",
+        modality_type=modality,
+        intent=ProcessingIntent.AUTOMATION_TASK,
+        data=b"",
+        metadata={},
     )
-    # Pin the replacement shape so the contract is observable in the source.
-    assert "success=False" in src
-    assert "Unsupported modality" in src
 
 
-def test_voice_processor_process_does_not_raise_value_error() -> None:
-    """Same contract as VisionProcessor — pin both."""
-    from multimodal_processor.processors.voice import VoiceProcessor
-
-    src = _process_source(VoiceProcessor)
-    assert "raise ValueError" not in src, (
-        "#6755 regression: VoiceProcessor.process re-introduced a bare "
-        "`raise ValueError` — return a failure ProcessingResult instead."
-    )
-    assert "success=False" in src
-    assert "Unsupported modality" in src
+def _build(module, cls_name: str):
+    """Construct a processor with torch and model loading stubbed out."""
+    cls = getattr(module, cls_name)
+    with (
+        patch.object(module, "_get_torch", return_value=MagicMock()),
+        patch.object(cls, "_load_models", lambda self: None),
+    ):
+        return cls()
 
 
-def test_base_processor_process_only_declares_notimplementederror() -> None:
-    """Pin the parent contract — if it ever changes (e.g. starts declaring
-    ValueError), the subclass tests above need to be re-evaluated."""
-    from multimodal_processor.base import BaseModalProcessor
+@pytest.fixture
+def vision_processor():
+    import multimodal_processor.processors.vision as module
 
-    src = _process_source(BaseModalProcessor)
-    # Parent declares NotImplementedError only. Any other `raise X` in the
-    # parent body would change the LSP contract for ALL subclasses.
-    assert "NotImplementedError" in src
-    raise_lines = [line for line in src.splitlines() if line.strip().startswith("raise ")]
-    # Exactly one `raise` (NotImplementedError); no others.
-    assert len(raise_lines) == 1, f"Parent contract drift: expected 1 `raise`, found {len(raise_lines)}"
-    assert "NotImplementedError" in raise_lines[0]
+    return _build(module, "VisionProcessor")
+
+
+@pytest.fixture
+def voice_processor():
+    import multimodal_processor.processors.voice as module
+
+    processor = _build(module, "VoiceProcessor")
+    # The unsupported-modality branch must be reachable regardless of whether
+    # voice happens to be enabled by configuration.
+    processor.enabled = True
+    return processor
+
+
+class TestUnsupportedModalityDegradesInsteadOfRaising:
+    """The contract: return a failure result, never raise outside the parent's."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("modality", VISION_UNSUPPORTED)
+    async def test_vision_returns_failure_result(self, vision_processor, modality):
+        result = await vision_processor.process(_input(modality))
+
+        assert isinstance(result, ProcessingResult)
+        assert result.success is False
+        assert "Unsupported modality" in result.error_message
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("modality", VOICE_UNSUPPORTED)
+    async def test_voice_returns_failure_result(self, voice_processor, modality):
+        result = await voice_processor.process(_input(modality))
+
+        assert isinstance(result, ProcessingResult)
+        assert result.success is False
+        assert "Unsupported modality" in result.error_message
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("modality", VISION_NON_NATIVE)
+    async def test_vision_does_not_raise(self, vision_processor, modality):
+        """A ValueError here is exactly the #6755 defect."""
+        try:
+            await vision_processor.process(_input(modality))
+        except Exception as exc:  # noqa: BLE001 - the assertion is "nothing escapes"
+            pytest.fail(f"#6755 regression: VisionProcessor.process raised {type(exc).__name__}: {exc}")
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("modality", VOICE_NON_NATIVE)
+    async def test_voice_does_not_raise(self, voice_processor, modality):
+        try:
+            await voice_processor.process(_input(modality))
+        except Exception as exc:  # noqa: BLE001 - the assertion is "nothing escapes"
+            pytest.fail(f"#6755 regression: VoiceProcessor.process raised {type(exc).__name__}: {exc}")
+
+    @pytest.mark.asyncio
+    async def test_failure_result_carries_the_offending_modality(self, voice_processor):
+        """The caller must be able to tell *what* was unsupported."""
+        result = await voice_processor.process(_input(ModalityType.VIDEO))
+
+        assert ModalityType.VIDEO.value in result.error_message.lower()
+        assert result.confidence == 0.0
+        assert result.result_data is None
+
+
+class TestSupportedModalityStillReachesProcessing:
+    """Guard the mirror: the failure branch must not swallow real work."""
+
+    @pytest.mark.asyncio
+    async def test_voice_audio_input_is_not_treated_as_unsupported(self, voice_processor):
+        async def _ok(_input_data):
+            return {"type": "voice_command", "transcribed_text": "hello", "confidence": 0.99}
+
+        voice_processor._process_audio = _ok
+        result = await voice_processor.process(_input(ModalityType.AUDIO))
+
+        assert result.success is True
+        assert result.error_message is None
+
+    @pytest.mark.asyncio
+    async def test_vision_video_fails_without_raising(self, vision_processor):
+        """VIDEO is accepted then declared unimplemented — still no exception.
+
+        A distinct branch from "unsupported modality", and one the source-grep
+        test never exercised.
+        """
+        result = await vision_processor.process(_input(ModalityType.VIDEO))
+
+        assert isinstance(result, ProcessingResult)
+        assert result.success is False
+        assert "Unsupported modality" not in result.error_message
+
+    @pytest.mark.asyncio
+    async def test_vision_image_input_is_not_treated_as_unsupported(self, vision_processor):
+        async def _ok(_input_data):
+            return {"type": "image_analysis", "confidence": 0.99}
+
+        vision_processor._process_image = _ok
+        result = await vision_processor.process(_input(ModalityType.IMAGE))
+
+        assert "Unsupported modality" not in (result.error_message or "")
+
+
+class TestParentContract:
+    """If the parent starts declaring more, the subclass tests need revisiting."""
+
+    @pytest.mark.asyncio
+    async def test_base_process_raises_notimplementederror(self):
+        from multimodal_processor.base import BaseModalProcessor
+
+        with patch("multimodal_processor.base.get_memory_manager", return_value=MagicMock()):
+            base = BaseModalProcessor("contract-probe")
+
+        with pytest.raises(NotImplementedError):
+            await base.process(_input(ModalityType.TEXT))
+
+    @pytest.mark.asyncio
+    async def test_subclass_failures_are_not_exceptions_of_any_kind(self, voice_processor, vision_processor):
+        """The whole point of #6755: substitutability for a parent-typed caller."""
+        for processor in (voice_processor, vision_processor):
+            result = await processor.process(_input(ModalityType.TEXT))
+            assert result.success is False

--- a/autobot-backend/multimodal_processor/processors/voice.py
+++ b/autobot-backend/multimodal_processor/processors/voice.py
@@ -155,6 +155,61 @@ class VoiceProcessor(BaseModalProcessor):
         except Exception as e:
             self.logger.debug("GPU cleanup skipped: %s", e)
 
+    def _failure_result(
+        self,
+        input_data: MultiModalInput,
+        processing_time: float,
+        message: str,
+    ) -> ProcessingResult:
+        """Build a failed ProcessingResult with a stated reason. Issue #13207."""
+        return ProcessingResult(
+            result_id=f"voice_{input_data.input_id}",
+            input_id=input_data.input_id,
+            modality_type=input_data.modality_type,
+            intent=input_data.intent,
+            success=False,
+            confidence=0.0,
+            result_data=None,
+            processing_time=processing_time,
+            error_message=message,
+        )
+
+    def _threshold_checked_result(
+        self,
+        input_data: MultiModalInput,
+        result: Dict[str, Any],
+        processing_time: float,
+    ) -> ProcessingResult:
+        """Apply the configured confidence threshold to a completed result.
+
+        Issue #13207: confidence_threshold was read from config and then never
+        consulted. A result under it is reported as a failure with a stated
+        reason rather than passed off as a successful command.
+        """
+        confidence = self.calculate_confidence(result)
+        below = confidence < self.confidence_threshold
+        if below:
+            self.logger.info(
+                "Voice result confidence %.2f below threshold %.2f — not treated as a command",
+                confidence,
+                self.confidence_threshold,
+            )
+        return ProcessingResult(
+            result_id=f"voice_{input_data.input_id}",
+            input_id=input_data.input_id,
+            modality_type=input_data.modality_type,
+            intent=input_data.intent,
+            success=not below,
+            confidence=confidence,
+            result_data=result,
+            processing_time=processing_time,
+            error_message=(
+                f"Voice confidence {confidence:.2f} below configured threshold {self.confidence_threshold:.2f}"
+                if below
+                else None
+            ),
+        )
+
     async def process(self, input_data: MultiModalInput) -> ProcessingResult:
         """Process audio input (voice commands, speech)"""
         start_time = time.time()
@@ -165,90 +220,35 @@ class VoiceProcessor(BaseModalProcessor):
             # sending an operator to debug hardware they never broke.
             return self._build_disabled_result(input_data, time.time() - start_time)
 
-        try:
-            if input_data.modality_type == ModalityType.AUDIO:
-                result = await asyncio.wait_for(
-                    self._process_audio(input_data),
-                    timeout=self.processing_timeout,
-                )
-            else:
-                # #6755 LSP exception contract: don't raise — parent
-                # `BaseModalProcessor.process` only declares NotImplementedError;
-                # subclasses must return a failure ProcessingResult, not propagate
-                # ValueError. Same fix pattern as #6658 / VisionProcessor.
-                processing_time = time.time() - start_time
-                return ProcessingResult(
-                    result_id=f"voice_{input_data.input_id}",
-                    input_id=input_data.input_id,
-                    modality_type=input_data.modality_type,
-                    intent=input_data.intent,
-                    success=False,
-                    confidence=0.0,
-                    result_data=None,
-                    processing_time=processing_time,
-                    error_message=f"Unsupported modality: {input_data.modality_type}",
-                )
-
-            processing_time = time.time() - start_time
-            confidence = self.calculate_confidence(result)
-
-            # Issue #13207 review B: confidence_threshold was read from config and
-            # then never consulted. A result under it is reported as a failure with
-            # a stated reason rather than passed off as a successful command.
-            below_threshold = confidence < self.confidence_threshold
-            if below_threshold:
-                self.logger.info(
-                    "Voice result confidence %.2f below threshold %.2f — not treated as a command",
-                    confidence,
-                    self.confidence_threshold,
-                )
-
-            return ProcessingResult(
-                result_id=f"voice_{input_data.input_id}",
-                input_id=input_data.input_id,
-                modality_type=input_data.modality_type,
-                intent=input_data.intent,
-                success=not below_threshold,
-                confidence=confidence,
-                result_data=result,
-                processing_time=processing_time,
-                error_message=(
-                    f"Voice confidence {confidence:.2f} below configured threshold " f"{self.confidence_threshold:.2f}"
-                    if below_threshold
-                    else None
-                ),
+        if input_data.modality_type != ModalityType.AUDIO:
+            # #6755 LSP exception contract: don't raise — parent
+            # `BaseModalProcessor.process` only declares NotImplementedError;
+            # subclasses must return a failure ProcessingResult, not propagate
+            # ValueError. Same fix pattern as #6658 / VisionProcessor.
+            return self._failure_result(
+                input_data,
+                time.time() - start_time,
+                f"Unsupported modality: {input_data.modality_type}",
             )
 
+        try:
+            result = await asyncio.wait_for(
+                self._process_audio(input_data),
+                timeout=self.processing_timeout,
+            )
+            return self._threshold_checked_result(input_data, result, time.time() - start_time)
+
         except asyncio.TimeoutError:
-            processing_time = time.time() - start_time
             self.logger.error("Voice processing exceeded %ss timeout", self.processing_timeout)
-            return ProcessingResult(
-                result_id=f"voice_{input_data.input_id}",
-                input_id=input_data.input_id,
-                modality_type=input_data.modality_type,
-                intent=input_data.intent,
-                success=False,
-                confidence=0.0,
-                result_data=None,
-                processing_time=processing_time,
-                error_message=(f"Voice processing exceeded the configured {self.processing_timeout}s timeout"),
+            return self._failure_result(
+                input_data,
+                time.time() - start_time,
+                f"Voice processing exceeded the configured {self.processing_timeout}s timeout",
             )
 
         except Exception as e:
-            processing_time = time.time() - start_time
             self.logger.error("Voice processing failed: %s", e)
-
-            return ProcessingResult(
-                result_id=f"voice_{input_data.input_id}",
-                input_id=input_data.input_id,
-                modality_type=input_data.modality_type,
-                intent=input_data.intent,
-                success=False,
-                confidence=0.0,
-                result_data=None,
-                processing_time=processing_time,
-                error_message=str(e),
-            )
+            return self._failure_result(input_data, time.time() - start_time, str(e))
 
     def calculate_confidence(self, processing_data: Any) -> float:
         """Return the confidence the audio pipeline actually reported. Issue #13207.
@@ -264,16 +264,10 @@ class VoiceProcessor(BaseModalProcessor):
     def _build_disabled_result(self, input_data: MultiModalInput, processing_time: float) -> ProcessingResult:
         """Report that voice is switched off, not that the hardware is broken."""
         self.logger.info("Voice processing requested while multimodal.voice.enabled is false")
-        return ProcessingResult(
-            result_id=f"voice_{input_data.input_id}",
-            input_id=input_data.input_id,
-            modality_type=input_data.modality_type,
-            intent=input_data.intent,
-            success=False,
-            confidence=0.0,
-            result_data=None,
-            processing_time=processing_time,
-            error_message="Voice processing is disabled by configuration (multimodal.voice.enabled=false)",
+        return self._failure_result(
+            input_data,
+            processing_time,
+            "Voice processing is disabled by configuration (multimodal.voice.enabled=false)",
         )
 
     def _prepare_audio_data(self, input_data: MultiModalInput) -> Tuple[np.ndarray, int]:

--- a/autobot-backend/multimodal_processor/processors/voice.py
+++ b/autobot-backend/multimodal_processor/processors/voice.py
@@ -19,6 +19,7 @@ from autobot_shared.env_utils import env_float, env_int
 from autobot_shared.logging_manager import get_logger
 from config import get_config_section
 from llm_shared.torch_loader import lazy_torch
+from voice_processing.hallucination_filter import is_silence_hallucination
 
 from ..base import BaseModalProcessor
 from ..models import MultiModalInput, ProcessingResult
@@ -294,6 +295,10 @@ class VoiceProcessor(BaseModalProcessor):
             # Process with Whisper for transcription (Issue #315 - extracted method)
             transcribed_text = self._transcribe_with_whisper(audio_array, sampling_rate)
 
+            # Issue #13104: Whisper answers silence with a confident phantom
+            # phrase; drop it here so it never becomes a user turn downstream.
+            transcribed_text = self._reject_silence_hallucination(transcribed_text, audio_array)
+
             # Process with Wav2Vec2 for embeddings (Issue #315 - extracted method)
             audio_embedding, wav2vec_transcription = self._process_wav2vec_embeddings(audio_array, sampling_rate)
 
@@ -321,6 +326,23 @@ class VoiceProcessor(BaseModalProcessor):
                 torch.cuda.empty_cache()
             # Return error result (Issue #620 - extracted method)
             return self._build_error_result(e)
+
+    def _reject_silence_hallucination(self, transcribed_text: str, audio_array: np.ndarray) -> str:
+        """Return "" when Whisper transcribed silence into a phantom phrase. Issue #13104.
+
+        The language is whatever Whisper decided; the multilingual model does
+        not surface it here, so only the language-independent energy and audio
+        tag gates apply on this path.
+        """
+        if not transcribed_text:
+            return transcribed_text
+
+        rms = float(np.sqrt(np.mean(np.square(audio_array)))) if audio_array.size else 0.0
+        if not is_silence_hallucination(transcribed_text, rms=rms):
+            return transcribed_text
+
+        self.logger.info("Discarded Whisper silence artifact instead of emitting a voice command")
+        return ""
 
     def _validate_audio_models_available(self) -> None:
         """Validate that audio models are loaded and available. Issue #620."""

--- a/autobot-backend/multimodal_processor/processors/voice.py
+++ b/autobot-backend/multimodal_processor/processors/voice.py
@@ -10,6 +10,7 @@ GPU-accelerated audio processing with Whisper and Wav2Vec2 models.
 Part of Issue #381 - God Class Refactoring
 """
 
+import asyncio
 import time
 from typing import Any, Dict, Tuple
 
@@ -19,7 +20,7 @@ from autobot_shared.env_utils import env_float, env_int
 from autobot_shared.logging_manager import get_logger
 from config import get_config_section
 from llm_shared.torch_loader import lazy_torch
-from voice_processing.hallucination_filter import is_silence_hallucination
+from voice_processing.hallucination_filter import is_silence_hallucination, peak_window_rms
 
 from ..base import BaseModalProcessor
 from ..models import MultiModalInput, ProcessingResult
@@ -158,9 +159,18 @@ class VoiceProcessor(BaseModalProcessor):
         """Process audio input (voice commands, speech)"""
         start_time = time.time()
 
+        if not self.enabled:
+            # Issue #13207 review E: without this, a deliberately disabled voice
+            # processor reports "models are not loaded, check your GPU/NPU",
+            # sending an operator to debug hardware they never broke.
+            return self._build_disabled_result(input_data, time.time() - start_time)
+
         try:
             if input_data.modality_type == ModalityType.AUDIO:
-                result = await self._process_audio(input_data)
+                result = await asyncio.wait_for(
+                    self._process_audio(input_data),
+                    timeout=self.processing_timeout,
+                )
             else:
                 # #6755 LSP exception contract: don't raise — parent
                 # `BaseModalProcessor.process` only declares NotImplementedError;
@@ -182,15 +192,46 @@ class VoiceProcessor(BaseModalProcessor):
             processing_time = time.time() - start_time
             confidence = self.calculate_confidence(result)
 
+            # Issue #13207 review B: confidence_threshold was read from config and
+            # then never consulted. A result under it is reported as a failure with
+            # a stated reason rather than passed off as a successful command.
+            below_threshold = confidence < self.confidence_threshold
+            if below_threshold:
+                self.logger.info(
+                    "Voice result confidence %.2f below threshold %.2f — not treated as a command",
+                    confidence,
+                    self.confidence_threshold,
+                )
+
             return ProcessingResult(
                 result_id=f"voice_{input_data.input_id}",
                 input_id=input_data.input_id,
                 modality_type=input_data.modality_type,
                 intent=input_data.intent,
-                success=True,
+                success=not below_threshold,
                 confidence=confidence,
                 result_data=result,
                 processing_time=processing_time,
+                error_message=(
+                    f"Voice confidence {confidence:.2f} below configured threshold " f"{self.confidence_threshold:.2f}"
+                    if below_threshold
+                    else None
+                ),
+            )
+
+        except asyncio.TimeoutError:
+            processing_time = time.time() - start_time
+            self.logger.error("Voice processing exceeded %ss timeout", self.processing_timeout)
+            return ProcessingResult(
+                result_id=f"voice_{input_data.input_id}",
+                input_id=input_data.input_id,
+                modality_type=input_data.modality_type,
+                intent=input_data.intent,
+                success=False,
+                confidence=0.0,
+                result_data=None,
+                processing_time=processing_time,
+                error_message=(f"Voice processing exceeded the configured {self.processing_timeout}s timeout"),
             )
 
         except Exception as e:
@@ -208,6 +249,32 @@ class VoiceProcessor(BaseModalProcessor):
                 processing_time=processing_time,
                 error_message=str(e),
             )
+
+    def calculate_confidence(self, processing_data: Any) -> float:
+        """Return the confidence the audio pipeline actually reported. Issue #13207.
+
+        The base implementation returns a flat 0.5 for every result, which made
+        ProcessingResult.confidence meaningless and left confidence_threshold
+        with nothing to compare against.
+        """
+        if isinstance(processing_data, dict):
+            return float(processing_data.get("confidence", 0.0))
+        return 0.0
+
+    def _build_disabled_result(self, input_data: MultiModalInput, processing_time: float) -> ProcessingResult:
+        """Report that voice is switched off, not that the hardware is broken."""
+        self.logger.info("Voice processing requested while multimodal.voice.enabled is false")
+        return ProcessingResult(
+            result_id=f"voice_{input_data.input_id}",
+            input_id=input_data.input_id,
+            modality_type=input_data.modality_type,
+            intent=input_data.intent,
+            success=False,
+            confidence=0.0,
+            result_data=None,
+            processing_time=processing_time,
+            error_message="Voice processing is disabled by configuration (multimodal.voice.enabled=false)",
+        )
 
     def _prepare_audio_data(self, input_data: MultiModalInput) -> Tuple[np.ndarray, int]:
         """Prepare and normalize audio data (Issue #315 - extracted method)"""
@@ -297,7 +364,7 @@ class VoiceProcessor(BaseModalProcessor):
 
             # Issue #13104: Whisper answers silence with a confident phantom
             # phrase; drop it here so it never becomes a user turn downstream.
-            transcribed_text = self._reject_silence_hallucination(transcribed_text, audio_array)
+            transcribed_text = self._reject_silence_hallucination(transcribed_text, audio_array, sampling_rate)
 
             # Process with Wav2Vec2 for embeddings (Issue #315 - extracted method)
             audio_embedding, wav2vec_transcription = self._process_wav2vec_embeddings(audio_array, sampling_rate)
@@ -327,7 +394,12 @@ class VoiceProcessor(BaseModalProcessor):
             # Return error result (Issue #620 - extracted method)
             return self._build_error_result(e)
 
-    def _reject_silence_hallucination(self, transcribed_text: str, audio_array: np.ndarray) -> str:
+    def _reject_silence_hallucination(
+        self,
+        transcribed_text: str,
+        audio_array: np.ndarray,
+        sampling_rate: int,
+    ) -> str:
         """Return "" when Whisper transcribed silence into a phantom phrase. Issue #13104.
 
         The language is whatever Whisper decided; the multilingual model does
@@ -337,11 +409,15 @@ class VoiceProcessor(BaseModalProcessor):
         if not transcribed_text:
             return transcribed_text
 
-        rms = float(np.sqrt(np.mean(np.square(audio_array)))) if audio_array.size else 0.0
+        rms = peak_window_rms(audio_array, sampling_rate)
         if not is_silence_hallucination(transcribed_text, rms=rms):
             return transcribed_text
 
-        self.logger.info("Discarded Whisper silence artifact instead of emitting a voice command")
+        self.logger.info(
+            "Discarded Whisper silence artifact %r instead of emitting a voice command (peak RMS %.5f)",
+            transcribed_text,
+            rms,
+        )
         return ""
 
     def _validate_audio_models_available(self) -> None:

--- a/autobot-backend/multimodal_processor/processors/voice.py
+++ b/autobot-backend/multimodal_processor/processors/voice.py
@@ -15,6 +15,7 @@ from typing import Any, Dict, Tuple
 
 import numpy as np
 
+from autobot_shared.env_utils import env_float, env_int
 from autobot_shared.logging_manager import get_logger
 from config import get_config_section
 from llm_shared.torch_loader import lazy_torch
@@ -61,6 +62,20 @@ except ImportError:
 logger = get_logger(__name__)
 
 
+# Issue #13207: fallbacks for the multimodal.voice section, env-overridable.
+#
+# These match the values VoiceProcessor was *actually* running on before the
+# key was corrected, and defaults.py was aligned to them in the same change so
+# fixing the lookup could not move a threshold as a side effect. The section
+# previously declared 0.8 / 15, but those numbers were unreachable for the
+# whole life of the code and were never validated against real audio; the
+# integration suite also configures multimodal.voice.confidence_threshold=0.7.
+# Retuning voice confidence/timeout is a deliberate change with its own
+# evidence, not a rider on a typo fix.
+VOICE_CONFIDENCE_THRESHOLD_DEFAULT = env_float("AUTOBOT_MULTIMODAL_VOICE_CONFIDENCE_THRESHOLD", 0.7)
+VOICE_PROCESSING_TIMEOUT_DEFAULT = env_int("AUTOBOT_MULTIMODAL_VOICE_PROCESSING_TIMEOUT", 30)
+
+
 class VoiceProcessor(BaseModalProcessor):
     """Voice processing component with GPU acceleration"""
 
@@ -69,9 +84,13 @@ class VoiceProcessor(BaseModalProcessor):
         torch = _get_torch()
 
         super().__init__("voice")
-        self.config = get_config_section("multimodal.audio")
-        self.confidence_threshold = self.config.get("confidence_threshold", 0.7)
-        self.processing_timeout = self.config.get("processing_timeout", 30)
+        # Issue #13207: this read "multimodal.audio", a section that has never
+        # existed under any path, so get_config_section always returned {} and
+        # every value below silently came from the literal fallbacks. The live
+        # casualty was `enabled`, which gates model loading below.
+        self.config = get_config_section("multimodal.voice")
+        self.confidence_threshold = self.config.get("confidence_threshold", VOICE_CONFIDENCE_THRESHOLD_DEFAULT)
+        self.processing_timeout = self.config.get("processing_timeout", VOICE_PROCESSING_TIMEOUT_DEFAULT)
         self.enabled = self.config.get("enabled", True)
 
         # Initialize GPU device

--- a/autobot-backend/multimodal_processor/test_voice_config_section.py
+++ b/autobot-backend/multimodal_processor/test_voice_config_section.py
@@ -71,11 +71,38 @@ class TestVoiceProcessorReadsTheRealSection:
         assert processor.processing_timeout == 7
         assert processor.enabled is True
 
-    def test_enabled_false_is_honoured(self, processor_cls):
-        """`enabled` gates model loading — the live casualty of the dead key."""
-        processor, _ = self._build(processor_cls, {"enabled": False})
+    def test_enabled_false_actually_prevents_model_loading(self, processor_cls):
+        """`enabled` gates model loading — the live casualty of the dead key.
+
+        Review item F: asserting only `processor.enabled is False` passed even
+        with the gate deleted. Force AUDIO_MODELS_AVAILABLE True (it is False in
+        this environment, which masked the gate) and assert the loader itself.
+        """
+        loader = MagicMock()
+        with (
+            patch.object(processor_cls, "get_config_section", return_value={"enabled": False}),
+            patch.object(processor_cls, "_get_torch", return_value=MagicMock()),
+            patch.object(processor_cls, "AUDIO_MODELS_AVAILABLE", True),
+            patch.object(processor_cls.VoiceProcessor, "_load_models", loader),
+        ):
+            processor = processor_cls.VoiceProcessor()
 
         assert processor.enabled is False
+        assert not loader.called, "models were loaded despite multimodal.voice.enabled=false"
+
+    def test_enabled_true_does_load_models(self, processor_cls):
+        """The mirror — without it the test above passes if loading never happens."""
+        loader = MagicMock()
+        with (
+            patch.object(processor_cls, "get_config_section", return_value={"enabled": True}),
+            patch.object(processor_cls, "_get_torch", return_value=MagicMock()),
+            patch.object(processor_cls, "AUDIO_MODELS_AVAILABLE", True),
+            patch.object(processor_cls.VoiceProcessor, "_load_models", loader),
+        ):
+            processor = processor_cls.VoiceProcessor()
+
+        assert processor.enabled is True
+        assert loader.called, "models were not loaded despite multimodal.voice.enabled=true"
 
 
 class TestEffectiveBehaviourIsPreserved:
@@ -118,3 +145,120 @@ class TestEffectiveBehaviourIsPreserved:
 
         assert processor.confidence_threshold == voice_module.VOICE_CONFIDENCE_THRESHOLD_DEFAULT
         assert processor.processing_timeout == voice_module.VOICE_PROCESSING_TIMEOUT_DEFAULT
+
+
+class TestConfiguredKnobsActuallyDoSomething:
+    """Review item B: a registered knob that nothing reads is the #13207 disease."""
+
+    @pytest.fixture
+    def voice_module(self):
+        import multimodal_processor.processors.voice as module
+
+        return module
+
+    def _processor(self, voice_module, section):
+        with (
+            patch.object(voice_module, "get_config_section", return_value=section),
+            patch.object(voice_module, "_get_torch", return_value=MagicMock()),
+            patch.object(voice_module.VoiceProcessor, "_load_models", lambda self: None),
+        ):
+            return voice_module.VoiceProcessor()
+
+    @pytest.mark.asyncio
+    async def test_disabled_processor_says_disabled_not_hardware_broken(self, voice_module):
+        """Review item E: the old message sent operators to debug a fine GPU."""
+        from multimodal_processor.models import MultiModalInput
+        from multimodal_processor.types import ModalityType
+
+        processor = self._processor(voice_module, {"enabled": False})
+        result = await processor.process(
+            MultiModalInput(
+                input_id="i1",
+                modality_type=ModalityType.AUDIO,
+                data=b"",
+                intent=None,
+                metadata={},
+            )
+        )
+
+        assert result.success is False
+        assert "disabled by configuration" in result.error_message
+        assert "GPU" not in result.error_message
+        assert "not loaded" not in result.error_message
+
+    @pytest.mark.asyncio
+    async def test_confidence_below_threshold_is_reported_as_failure(self, voice_module):
+        """confidence_threshold is now consulted instead of being decoration."""
+        from multimodal_processor.models import MultiModalInput
+        from multimodal_processor.types import ModalityType
+
+        processor = self._processor(voice_module, {"enabled": True, "confidence_threshold": 0.95})
+
+        async def _low_confidence(_input_data):
+            return {"type": "voice_command", "transcribed_text": "hello", "confidence": 0.9}
+
+        processor._process_audio = _low_confidence
+        result = await processor.process(
+            MultiModalInput(
+                input_id="i2",
+                modality_type=ModalityType.AUDIO,
+                data=b"",
+                intent=None,
+                metadata={},
+            )
+        )
+
+        assert result.confidence == pytest.approx(0.9)
+        assert result.success is False
+        assert "below configured threshold" in result.error_message
+
+    @pytest.mark.asyncio
+    async def test_confidence_above_threshold_succeeds(self, voice_module):
+        from multimodal_processor.models import MultiModalInput
+        from multimodal_processor.types import ModalityType
+
+        processor = self._processor(voice_module, {"enabled": True, "confidence_threshold": 0.5})
+
+        async def _high_confidence(_input_data):
+            return {"type": "voice_command", "transcribed_text": "hello", "confidence": 0.9}
+
+        processor._process_audio = _high_confidence
+        result = await processor.process(
+            MultiModalInput(
+                input_id="i3",
+                modality_type=ModalityType.AUDIO,
+                data=b"",
+                intent=None,
+                metadata={},
+            )
+        )
+
+        assert result.success is True
+        assert result.confidence == pytest.approx(0.9)
+
+    @pytest.mark.asyncio
+    async def test_processing_timeout_is_enforced(self, voice_module):
+        """processing_timeout was read from config and never applied."""
+        import asyncio
+
+        from multimodal_processor.models import MultiModalInput
+        from multimodal_processor.types import ModalityType
+
+        processor = self._processor(voice_module, {"enabled": True, "processing_timeout": 0.01})
+
+        async def _too_slow(_input_data):
+            await asyncio.sleep(5)
+
+        processor._process_audio = _too_slow
+        result = await processor.process(
+            MultiModalInput(
+                input_id="i4",
+                modality_type=ModalityType.AUDIO,
+                data=b"",
+                intent=None,
+                metadata={},
+            )
+        )
+
+        assert result.success is False
+        assert "timeout" in result.error_message.lower()

--- a/autobot-backend/multimodal_processor/test_voice_config_section.py
+++ b/autobot-backend/multimodal_processor/test_voice_config_section.py
@@ -1,0 +1,120 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""VoiceProcessor must read a config section that exists (#13207).
+
+``VoiceProcessor.__init__`` read ``multimodal.audio``, a section defined nowhere
+under any path. ``get_config_section`` therefore returned ``{}`` on every boot
+and every value fell through to a literal — including ``enabled``, which gates
+model loading, so the configured section was unreachable in production and
+changing it did nothing.
+
+The second half of these tests pins the threshold/timeout decision: correcting
+the key must NOT move a live value. ``multimodal.voice`` previously declared
+0.8 / 15, which had never reached the processor; ``defaults.py`` was aligned to
+the 0.7 / 30 that was actually in effect, so this fix is behaviour-preserving.
+Retuning voice confidence is a separate, evidence-backed change.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from config import get_config_section
+
+VOICE_MODULE = "multimodal_processor.processors.voice"
+
+
+class TestConfigSectionExists:
+    """The section the processor names has to be the section that is defined."""
+
+    def test_multimodal_voice_section_is_defined(self):
+        section = get_config_section("multimodal.voice")
+
+        assert section, "multimodal.voice must resolve to a populated section"
+        assert set(section) >= {"enabled", "confidence_threshold", "processing_timeout"}
+
+    def test_multimodal_audio_section_does_not_exist(self):
+        """The old key resolved to {} — which is why the bug was silent."""
+        assert get_config_section("multimodal.audio") == {}
+
+
+class TestVoiceProcessorReadsTheRealSection:
+    @pytest.fixture
+    def processor_cls(self):
+        import multimodal_processor.processors.voice as voice_module
+
+        return voice_module
+
+    def _build(self, voice_module, section):
+        """Construct a VoiceProcessor with config and torch/model loading stubbed."""
+        with (
+            patch.object(voice_module, "get_config_section", return_value=section) as get_section,
+            patch.object(voice_module, "_get_torch", return_value=MagicMock()),
+            patch.object(voice_module.VoiceProcessor, "_load_models", lambda self: None),
+        ):
+            processor = voice_module.VoiceProcessor()
+        return processor, get_section
+
+    def test_processor_asks_for_multimodal_voice(self, processor_cls):
+        _, get_section = self._build(processor_cls, {"enabled": False})
+
+        get_section.assert_called_once_with("multimodal.voice")
+
+    def test_configured_values_now_reach_the_processor(self, processor_cls):
+        """The regression: a configured threshold used to have no effect at all."""
+        section = {"enabled": True, "confidence_threshold": 0.42, "processing_timeout": 7}
+        processor, _ = self._build(processor_cls, section)
+
+        assert processor.confidence_threshold == 0.42
+        assert processor.processing_timeout == 7
+        assert processor.enabled is True
+
+    def test_enabled_false_is_honoured(self, processor_cls):
+        """`enabled` gates model loading — the live casualty of the dead key."""
+        processor, _ = self._build(processor_cls, {"enabled": False})
+
+        assert processor.enabled is False
+
+
+class TestEffectiveBehaviourIsPreserved:
+    """Fixing the key must not silently retune voice confidence or timeout."""
+
+    def test_declared_defaults_match_the_values_that_were_in_effect(self):
+        section = get_config_section("multimodal.voice")
+
+        assert section["confidence_threshold"] == 0.7
+        assert section["processing_timeout"] == 30
+
+    def test_module_fallbacks_match_the_declared_defaults(self):
+        import multimodal_processor.processors.voice as voice_module
+
+        assert voice_module.VOICE_CONFIDENCE_THRESHOLD_DEFAULT == 0.7
+        assert voice_module.VOICE_PROCESSING_TIMEOUT_DEFAULT == 30
+
+    def test_processor_runs_on_the_prior_values_end_to_end(self):
+        """Whole chain: real config section, real fallbacks, unchanged numbers."""
+        import multimodal_processor.processors.voice as voice_module
+
+        with (
+            patch.object(voice_module, "_get_torch", return_value=MagicMock()),
+            patch.object(voice_module.VoiceProcessor, "_load_models", lambda self: None),
+        ):
+            processor = voice_module.VoiceProcessor()
+
+        assert processor.confidence_threshold == 0.7
+        assert processor.processing_timeout == 30
+
+    def test_fallbacks_apply_when_the_section_omits_them(self):
+        import multimodal_processor.processors.voice as voice_module
+
+        with (
+            patch.object(voice_module, "get_config_section", return_value={"enabled": True}),
+            patch.object(voice_module, "_get_torch", return_value=MagicMock()),
+            patch.object(voice_module.VoiceProcessor, "_load_models", lambda self: None),
+        ):
+            processor = voice_module.VoiceProcessor()
+
+        assert processor.confidence_threshold == voice_module.VOICE_CONFIDENCE_THRESHOLD_DEFAULT
+        assert processor.processing_timeout == voice_module.VOICE_PROCESSING_TIMEOUT_DEFAULT

--- a/autobot-backend/multimodal_processor/test_voice_silence_filter.py
+++ b/autobot-backend/multimodal_processor/test_voice_silence_filter.py
@@ -1,0 +1,66 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""The multimodal Whisper path must drop silence hallucinations too (#13104).
+
+``VoiceProcessor`` runs openai/whisper-base directly, so it is the path the
+issue is literally about: fed ambient noise the model returns a fluent phrase
+that ``_classify_command`` then turns into a voice command.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+import multimodal_processor.processors.voice as voice_module
+from voice_processing.hallucination_filter import SILENCE_RMS_THRESHOLD
+
+SAMPLES = 16000
+
+
+@pytest.fixture
+def processor():
+    with (
+        patch.object(voice_module, "_get_torch", return_value=MagicMock()),
+        patch.object(voice_module.VoiceProcessor, "_load_models", lambda self: None),
+    ):
+        return voice_module.VoiceProcessor()
+
+
+def _audio_at(rms: float) -> np.ndarray:
+    """Constant-magnitude waveform with exactly the requested RMS."""
+    return np.full(SAMPLES, rms, dtype=np.float32)
+
+
+class TestWhisperSilenceArtifactsAreDropped:
+    def test_phantom_phrase_over_silence_becomes_empty(self, processor):
+        silence = _audio_at(SILENCE_RMS_THRESHOLD / 10)
+
+        assert processor._reject_silence_hallucination("Thanks for watching!", silence) == ""
+
+    def test_digital_silence_drops_any_transcript(self, processor):
+        assert processor._reject_silence_hallucination("open the browser", np.zeros(SAMPLES, dtype=np.float32)) == ""
+
+    def test_bare_audio_tag_is_dropped_even_with_energy(self, processor):
+        assert processor._reject_silence_hallucination("[BLANK_AUDIO]", _audio_at(0.08)) == ""
+
+    def test_dropped_transcript_classifies_as_unknown_not_a_command(self, processor):
+        """The point of the filter: no phantom command reaches the agent."""
+        dropped = processor._reject_silence_hallucination("Thanks for watching!", _audio_at(0.0))
+
+        assert processor._classify_command(dropped) == "unknown"
+
+
+class TestRealSpeechSurvivesTheWhisperPath:
+    @pytest.mark.parametrize("transcript", ["okay", "no", "yeah", "bye", "open firefox"])
+    def test_real_audio_keeps_the_transcript(self, processor, transcript):
+        assert processor._reject_silence_hallucination(transcript, _audio_at(0.08)) == transcript
+
+    def test_empty_transcript_is_returned_unchanged(self, processor):
+        assert processor._reject_silence_hallucination("", _audio_at(0.08)) == ""
+
+    def test_empty_audio_array_does_not_raise(self, processor):
+        """A zero-length buffer must not blow up the RMS computation."""
+        assert processor._reject_silence_hallucination("okay", np.array([], dtype=np.float32)) == ""

--- a/autobot-backend/multimodal_processor/test_voice_silence_filter.py
+++ b/autobot-backend/multimodal_processor/test_voice_silence_filter.py
@@ -38,17 +38,20 @@ class TestWhisperSilenceArtifactsAreDropped:
     def test_phantom_phrase_over_silence_becomes_empty(self, processor):
         silence = _audio_at(SILENCE_RMS_THRESHOLD / 10)
 
-        assert processor._reject_silence_hallucination("Thanks for watching!", silence) == ""
+        assert processor._reject_silence_hallucination("Thanks for watching!", silence, SAMPLES) == ""
 
     def test_digital_silence_drops_any_transcript(self, processor):
-        assert processor._reject_silence_hallucination("open the browser", np.zeros(SAMPLES, dtype=np.float32)) == ""
+        assert (
+            processor._reject_silence_hallucination("open the browser", np.zeros(SAMPLES, dtype=np.float32), SAMPLES)
+            == ""
+        )
 
     def test_bare_audio_tag_is_dropped_even_with_energy(self, processor):
-        assert processor._reject_silence_hallucination("[BLANK_AUDIO]", _audio_at(0.08)) == ""
+        assert processor._reject_silence_hallucination("[BLANK_AUDIO]", _audio_at(0.08), SAMPLES) == ""
 
     def test_dropped_transcript_classifies_as_unknown_not_a_command(self, processor):
         """The point of the filter: no phantom command reaches the agent."""
-        dropped = processor._reject_silence_hallucination("Thanks for watching!", _audio_at(0.0))
+        dropped = processor._reject_silence_hallucination("Thanks for watching!", _audio_at(0.0), SAMPLES)
 
         assert processor._classify_command(dropped) == "unknown"
 
@@ -56,11 +59,11 @@ class TestWhisperSilenceArtifactsAreDropped:
 class TestRealSpeechSurvivesTheWhisperPath:
     @pytest.mark.parametrize("transcript", ["okay", "no", "yeah", "bye", "open firefox"])
     def test_real_audio_keeps_the_transcript(self, processor, transcript):
-        assert processor._reject_silence_hallucination(transcript, _audio_at(0.08)) == transcript
+        assert processor._reject_silence_hallucination(transcript, _audio_at(0.08), SAMPLES) == transcript
 
     def test_empty_transcript_is_returned_unchanged(self, processor):
-        assert processor._reject_silence_hallucination("", _audio_at(0.08)) == ""
+        assert processor._reject_silence_hallucination("", _audio_at(0.08), SAMPLES) == ""
 
     def test_empty_audio_array_does_not_raise(self, processor):
         """A zero-length buffer must not blow up the RMS computation."""
-        assert processor._reject_silence_hallucination("okay", np.array([], dtype=np.float32)) == ""
+        assert processor._reject_silence_hallucination("okay", np.array([], dtype=np.float32), SAMPLES) == ""

--- a/autobot-backend/tests/test_vnc_mcp_async.py
+++ b/autobot-backend/tests/test_vnc_mcp_async.py
@@ -36,6 +36,7 @@ import pytest
 # ---------------------------------------------------------------------------
 
 _BACKEND_ROOT = Path(__file__).parent.parent
+_REPO_ROOT = _BACKEND_ROOT.parent
 _VNC_MCP_PATH = _BACKEND_ROOT / "api" / "vnc_mcp.py"
 
 
@@ -193,6 +194,17 @@ def _install_stubs() -> dict:
     )
     _stub("autobot_shared.http_client", get_http_client=MagicMock())
     _stub("autobot_shared.logging_manager", get_logger=lambda name: MagicMock())
+
+    # #13208: temp_files is the component under test for the leak, so load the
+    # REAL module rather than stubbing it — a MagicMock context manager would
+    # make the "temp file was removed" assertion pass vacuously.
+    saved["autobot_shared.temp_files"] = sys.modules.get("autobot_shared.temp_files")
+    _temp_spec = importlib.util.spec_from_file_location(
+        "autobot_shared.temp_files", str(_REPO_ROOT / "autobot_shared" / "temp_files.py")
+    )
+    _temp_mod = importlib.util.module_from_spec(_temp_spec)
+    sys.modules["autobot_shared.temp_files"] = _temp_mod
+    _temp_spec.loader.exec_module(_temp_mod)
     _stub("autobot_shared.time_utils", parse_utc_iso=MagicMock())
     _stub("autobot_shared.ssot_config", config=MagicMock())
 

--- a/autobot-backend/tests/test_vnc_screenshot_temp_leak.py
+++ b/autobot-backend/tests/test_vnc_screenshot_temp_leak.py
@@ -1,0 +1,131 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Regression tests for the screenshot temp-file leak (#13208).
+
+``desktop_screenshot_mcp`` created its PNG with ``delete=False`` and unlinked it
+only on the success path, so every failed capture left a file in the system temp
+directory forever. In production that is one orphan PNG per failure; in CI the
+rc=1 tests in ``test_vnc_mcp_async.py`` hit it twice per run.
+
+Strategy: redirect ``tempfile.tempdir`` at an empty pytest ``tmp_path`` and
+assert the directory is empty *after* a capture that fails. Counting files
+rather than mocking the unlink is what makes the assertion real — a leak shows
+up as a leftover file no matter which code path dropped it.
+
+The harness from ``test_vnc_mcp_async.py`` is reused so vnc_mcp.py can be loaded
+without its full dependency tree.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tests.test_vnc_mcp_async import vnc_mcp_module  # noqa: F401  (pytest fixture)
+
+
+@pytest.fixture
+def isolated_tempdir(tmp_path, monkeypatch):
+    """Point tempfile at an empty directory so leaks are countable."""
+    monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
+    return tmp_path
+
+
+def _files_in(directory) -> list:
+    return sorted(p.name for p in directory.iterdir())
+
+
+class TestScreenshotTempFileCleanup:
+    """Every exit path of desktop_screenshot_mcp must remove its temp file."""
+
+    @pytest.mark.asyncio
+    async def test_no_leak_when_both_capture_commands_fail(
+        self, vnc_mcp_module, isolated_tempdir  # noqa: F811
+    ):
+        """rc=1 from scrot AND import must still remove the temp PNG (#13208)."""
+        fail = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="")
+
+        with patch("asyncio.to_thread", new_callable=AsyncMock, return_value=fail):
+            response = await vnc_mcp_module.desktop_screenshot_mcp()
+
+        assert response["success"] is False
+        assert _files_in(isolated_tempdir) == [], (
+            "failed capture leaked a temp file: " f"{_files_in(isolated_tempdir)}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_leak_when_capture_raises(self, vnc_mcp_module, isolated_tempdir):  # noqa: F811
+        """An exception mid-capture must still remove the temp PNG (#13208)."""
+        with patch("asyncio.to_thread", new_callable=AsyncMock, side_effect=OSError("boom")):
+            response = await vnc_mcp_module.desktop_screenshot_mcp()
+
+        assert response["success"] is False
+        assert _files_in(isolated_tempdir) == [], (
+            "raising capture leaked a temp file: " f"{_files_in(isolated_tempdir)}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_leak_when_reading_the_png_fails(
+        self, vnc_mcp_module, isolated_tempdir  # noqa: F811
+    ):
+        """Capture succeeds but the read raises — the temp PNG must still go (#13208)."""
+        ok = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+
+        with (
+            patch("asyncio.to_thread", new_callable=AsyncMock, return_value=ok),
+            patch("builtins.open", side_effect=OSError("unreadable")),
+        ):
+            response = await vnc_mcp_module.desktop_screenshot_mcp()
+
+        assert response["success"] is False
+        assert _files_in(isolated_tempdir) == [], (
+            "unreadable capture leaked a temp file: " f"{_files_in(isolated_tempdir)}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_leak_on_the_success_path(self, vnc_mcp_module, isolated_tempdir):  # noqa: F811
+        """The already-working success path keeps working (#13208 guard)."""
+        ok = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+
+        with patch("asyncio.to_thread", new_callable=AsyncMock, return_value=ok):
+            response = await vnc_mcp_module.desktop_screenshot_mcp()
+
+        assert response["success"] is True
+        assert _files_in(isolated_tempdir) == []
+
+
+class TestTemporaryFilePathHelper:
+    """The shared helper that carries the guarantee."""
+
+    def test_path_exists_inside_block_and_is_gone_after(self, isolated_tempdir):
+        from autobot_shared.temp_files import temporary_file_path
+
+        with temporary_file_path(suffix=".png") as path:
+            assert path.endswith(".png")
+            assert _files_in(isolated_tempdir) != []
+
+        assert _files_in(isolated_tempdir) == []
+
+    def test_removed_when_the_block_raises(self, isolated_tempdir):
+        from autobot_shared.temp_files import temporary_file_path
+
+        with pytest.raises(RuntimeError):
+            with temporary_file_path(suffix=".png"):
+                raise RuntimeError("caller failed")
+
+        assert _files_in(isolated_tempdir) == []
+
+    def test_tolerates_the_file_already_being_gone(self, isolated_tempdir):
+        from pathlib import Path
+
+        from autobot_shared.temp_files import temporary_file_path
+
+        with temporary_file_path(suffix=".png") as path:
+            Path(path).unlink()
+
+        assert _files_in(isolated_tempdir) == []

--- a/autobot-backend/tests/test_vnc_screenshot_temp_leak.py
+++ b/autobot-backend/tests/test_vnc_screenshot_temp_leak.py
@@ -44,9 +44,7 @@ class TestScreenshotTempFileCleanup:
     """Every exit path of desktop_screenshot_mcp must remove its temp file."""
 
     @pytest.mark.asyncio
-    async def test_no_leak_when_both_capture_commands_fail(
-        self, vnc_mcp_module, isolated_tempdir  # noqa: F811
-    ):
+    async def test_no_leak_when_both_capture_commands_fail(self, vnc_mcp_module, isolated_tempdir):  # noqa: F811
         """rc=1 from scrot AND import must still remove the temp PNG (#13208)."""
         fail = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="")
 
@@ -54,9 +52,7 @@ class TestScreenshotTempFileCleanup:
             response = await vnc_mcp_module.desktop_screenshot_mcp()
 
         assert response["success"] is False
-        assert _files_in(isolated_tempdir) == [], (
-            "failed capture leaked a temp file: " f"{_files_in(isolated_tempdir)}"
-        )
+        assert _files_in(isolated_tempdir) == [], "failed capture leaked a temp file: " f"{_files_in(isolated_tempdir)}"
 
     @pytest.mark.asyncio
     async def test_no_leak_when_capture_raises(self, vnc_mcp_module, isolated_tempdir):  # noqa: F811
@@ -70,9 +66,7 @@ class TestScreenshotTempFileCleanup:
         )
 
     @pytest.mark.asyncio
-    async def test_no_leak_when_reading_the_png_fails(
-        self, vnc_mcp_module, isolated_tempdir  # noqa: F811
-    ):
+    async def test_no_leak_when_reading_the_png_fails(self, vnc_mcp_module, isolated_tempdir):  # noqa: F811
         """Capture succeeds but the read raises — the temp PNG must still go (#13208)."""
         ok = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
 

--- a/autobot-backend/voice_processing/hallucination_filter.py
+++ b/autobot-backend/voice_processing/hallucination_filter.py
@@ -1,0 +1,186 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""STT silence-hallucination filter.
+
+Issue #13104: Whisper-family models do not return an empty string when handed
+silence or ambient noise — they emit a confident, fluent phrase drawn from
+their training data (YouTube captions, subtitle credits). With the mic held
+open in hands-free and full-duplex modes, that phrase becomes a **phantom user
+turn** and wakes the agent for a run nobody asked for.
+
+Four independent signals are used, cheapest first:
+
+1. ``no_speech_prob`` — the decoder's own "this frame is not speech" estimate.
+   Authoritative when the backend exposes it; most do not.
+2. Audio energy (RMS) — if the waveform is below the noise floor there was
+   nothing to transcribe, so *any* transcript over it is an artifact. This is
+   the language-independent VAD gate.
+3. Bracketed audio tags — "[BLANK_AUDIO]", "(silence)", "♪♪". Structural and
+   language-independent: no one speaks a bracket.
+4. A per-language denylist of known credit-phrase artifacts, for backends that
+   give neither of the first two signals.
+
+KEEP THE DENYLIST TIGHT — DO NOT WIDEN IT
+-----------------------------------------
+Real users answer in one or two words: "okay", "yeah", "no", "so", "bye",
+"yes", "stop", "music". A filter that swallows those is far worse than the
+phantom turns it prevents, because the assistant then appears to ignore the
+user and the failure is invisible in logs.
+
+Entries therefore have to be phrases that are *never* a plausible thing to say
+to an assistant — subtitle credits and channel outros. A merely short or
+polite phrase ("thank you", "bye", "music") does NOT qualify: those are caught
+by the energy and no-speech gates when the audio really was silent, and
+correctly kept when it was not. If you are about to add a word a person could
+reasonably say out loud, the answer is to tune the gate thresholds instead.
+"""
+
+import re
+import string
+from typing import Dict, FrozenSet, Optional, Set
+
+from autobot_shared.env_utils import env_float
+from autobot_shared.logging_manager import get_logger
+
+logger = get_logger(__name__)
+
+
+# Below this RMS the waveform carries no speech, so any transcript over it is an
+# artifact. 0.005 sits well under conversational speech (~0.05-0.2 RMS) and above
+# typical mic self-noise. Raise it for a noisy room, lower it for a close mic.
+SILENCE_RMS_THRESHOLD = env_float("AUTOBOT_STT_SILENCE_RMS_THRESHOLD", 0.005)
+
+# Whisper's own no-speech estimate. The reference decoder treats >0.6 combined
+# with a low average log-prob as silence; used alone here, so kept deliberately
+# high to avoid discarding quiet but real speech.
+NO_SPEECH_PROB_THRESHOLD = env_float("AUTOBOT_STT_NO_SPEECH_PROB_THRESHOLD", 0.8)
+
+
+# Known credit-phrase artifacts, keyed by BCP-47 language. Matched exactly after
+# normalisation — never as a substring — so a real sentence that happens to
+# contain one of these survives. Read the module docstring before editing.
+_RAW_SILENCE_ARTIFACTS: Dict[str, Set[str]] = {
+    "en": {
+        "Subtitles by the Amara.org community",
+        "Thanks for watching!",
+        "Thank you for watching.",
+        "Thank you for watching this video.",
+        "Please subscribe to my channel.",
+        "Like and subscribe!",
+        "Transcription by CastingWords",
+        "Subtitles by SteamTeamExtra",
+        "www.mooji.org",
+    },
+    "lv": {
+        "Paldies par skatīšanos!",
+        "Paldies par skatīšanos.",
+        "Subtitrus sagatavoja",
+    },
+    "ru": {
+        "Продолжение следует...",
+        "Спасибо за просмотр!",
+        "Субтитры сделал DimaTorzok",
+        "Субтитры и перевод сделал DimaTorzok",
+        "Редактор субтитров А.Синецкая Корректор А.Егорова",
+    },
+    "de": {
+        "Untertitelung des ZDF, 2020",
+        "Untertitel im Auftrag des ZDF, 2021",
+        "Untertitel der Deutschen Welle",
+        "Vielen Dank fürs Zuschauen!",
+    },
+    "es": {
+        "Subtítulos realizados por la comunidad de Amara.org",
+        "¡Gracias por ver el video!",
+        "Gracias por ver el video.",
+    },
+    "fr": {
+        "Sous-titres réalisés par la communauté d'Amara.org",
+        "Merci d'avoir regardé cette vidéo !",
+    },
+}
+
+# Punctuation folds to a space, not to nothing: Whisper renders the same artifact
+# as both "Amara.org" and "Amara org" across runs, and only a space keeps those
+# two spellings normalising to the same key.
+_PUNCTUATION = str.maketrans({ch: " " for ch in string.punctuation + "¡¿«»„“”‘’—–…♪"})
+_WHITESPACE_RE = re.compile(r"\s+")
+
+# A transcript that is nothing but a bracketed tag or musical notes.
+_AUDIO_TAG_RE = re.compile(r"^\s*(?:[\[\(\{].{0,40}?[\]\)\}]|[♪♫\s]+)\s*$")
+
+
+def normalize_transcript(transcript: str) -> str:
+    """Lowercase, strip punctuation and collapse whitespace for exact matching."""
+    lowered = transcript.strip().lower()
+    stripped = lowered.translate(_PUNCTUATION)
+    return _WHITESPACE_RE.sub(" ", stripped).strip()
+
+
+# Normalised once at import so the table above stays readable as real sentences.
+_SILENCE_ARTIFACTS: Dict[str, FrozenSet[str]] = {
+    lang: frozenset(normalize_transcript(phrase) for phrase in phrases)
+    for lang, phrases in _RAW_SILENCE_ARTIFACTS.items()
+}
+
+
+def is_audio_tag(transcript: str) -> bool:
+    """Return True when the transcript is only a bracketed tag or musical notes.
+
+    Language-independent: "[BLANK_AUDIO]", "(silence)", "♪♪" are decoder markup
+    for "no speech here", and cannot be uttered.
+    """
+    return bool(transcript.strip()) and bool(_AUDIO_TAG_RE.match(transcript))
+
+
+def is_known_artifact(transcript: str, language: Optional[str]) -> bool:
+    """Return True when *transcript* exactly matches an artifact for *language*.
+
+    An unknown or uncurated language never filters — a denylist for a locale we
+    have not reviewed would be guesswork applied to real user speech.
+    """
+    if not language:
+        return False
+    artifacts = _SILENCE_ARTIFACTS.get(language.split("-")[0].lower())
+    if not artifacts:
+        return False
+    return normalize_transcript(transcript) in artifacts
+
+
+def is_silence_hallucination(
+    transcript: str,
+    language: Optional[str] = None,
+    *,
+    rms: Optional[float] = None,
+    no_speech_prob: Optional[float] = None,
+) -> bool:
+    """Return True when *transcript* must be discarded instead of becoming a turn.
+
+    Args:
+        transcript: Text returned by the STT backend.
+        language: BCP-47 code of the detected language; None disables the denylist.
+        rms: Root-mean-square energy of the source audio, if measured.
+        no_speech_prob: Decoder no-speech probability, if the backend exposes it.
+    """
+    if not transcript or not transcript.strip():
+        return False
+
+    if no_speech_prob is not None and no_speech_prob >= NO_SPEECH_PROB_THRESHOLD:
+        logger.info("Discarding STT result: no_speech_prob %.3f at or over threshold", no_speech_prob)
+        return True
+
+    if rms is not None and rms < SILENCE_RMS_THRESHOLD:
+        logger.info("Discarding STT result: audio RMS %.5f below silence floor", rms)
+        return True
+
+    if is_audio_tag(transcript):
+        logger.info("Discarding STT result: transcript is a bare audio tag")
+        return True
+
+    if is_known_artifact(transcript, language):
+        logger.info("Discarding STT result: known %s silence artifact", language)
+        return True
+
+    return False

--- a/autobot-backend/voice_processing/hallucination_filter.py
+++ b/autobot-backend/voice_processing/hallucination_filter.py
@@ -10,38 +10,51 @@ their training data (YouTube captions, subtitle credits). With the mic held
 open in hands-free and full-duplex modes, that phrase becomes a **phantom user
 turn** and wakes the agent for a run nobody asked for.
 
-Four independent signals are used, cheapest first:
+Signals, cheapest first:
 
 1. ``no_speech_prob`` — the decoder's own "this frame is not speech" estimate.
-   Authoritative when the backend exposes it; most do not.
-2. Audio energy (RMS) — if the waveform is below the noise floor there was
-   nothing to transcribe, so *any* transcript over it is an artifact. This is
-   the language-independent VAD gate.
-3. Bracketed audio tags — "[BLANK_AUDIO]", "(silence)", "♪♪". Structural and
-   language-independent: no one speaks a bracket.
-4. A per-language denylist of known credit-phrase artifacts, for backends that
-   give neither of the first two signals.
+   Authoritative, but only openai-whisper surfaces it; the transformers ASR
+   pipeline does not, so most call sites cannot supply it.
+2. Audio energy — see :func:`peak_window_rms`. Below the floor there was
+   nothing to transcribe, so *any* transcript over it is an artifact.
+3. Structural audio tags — "[BLANK_AUDIO]", "(silence)", "♪♪". Language
+   independent: no one speaks a bracket.
+4. Per-language artifact phrases, split into two tiers (see below).
+
+NOTHING IS DISCARDED SILENTLY
+-----------------------------
+Every gate logs at INFO with the discarded text and the reason. A swallowed
+turn that leaves no trace is indistinguishable from a broken microphone, and
+the whole point of this module is to make that class of failure diagnosable.
 
 KEEP THE DENYLIST TIGHT — DO NOT WIDEN IT
 -----------------------------------------
 Real users answer in one or two words: "okay", "yeah", "no", "so", "bye",
 "yes", "stop", "music". A filter that swallows those is far worse than the
 phantom turns it prevents, because the assistant then appears to ignore the
-user and the failure is invisible in logs.
+user.
 
-Entries therefore have to be phrases that are *never* a plausible thing to say
-to an assistant — subtitle credits and channel outros. A merely short or
-polite phrase ("thank you", "bye", "music") does NOT qualify: those are caught
-by the energy and no-speech gates when the audio really was silent, and
-correctly kept when it was not. If you are about to add a word a person could
-reasonably say out loud, the answer is to tune the gate thresholds instead.
+Hence two tiers:
+
+* **Structural** — subtitle credits and URLs carrying proper nouns
+  ("Subtitles by the Amara.org community", "www.mooji.org"). Nobody dictates
+  these, so they are discarded whatever the audio says.
+* **Outro** — polite sign-offs Whisper also invents ("Thanks for watching!",
+  "Please subscribe to my channel."). These *are* plausible dictation, so they
+  are discarded only when the audio does not positively show speech energy.
+  On a live mic that is the hallucination case; on a dictation upload with
+  real energy the words survive.
+
+If you are about to add a word a person could reasonably say out loud, it goes
+in the outro tier at most — or the gate thresholds want tuning instead.
 """
 
+import math
 import re
 import string
-from typing import Dict, FrozenSet, Optional, Set
+from typing import Dict, FrozenSet, Optional, Sequence, Set
 
-from autobot_shared.env_utils import env_float
+from autobot_shared.env_utils import env_float, env_int
 from autobot_shared.logging_manager import get_logger
 
 logger = get_logger(__name__)
@@ -57,30 +70,30 @@ SILENCE_RMS_THRESHOLD = env_float("AUTOBOT_STT_SILENCE_RMS_THRESHOLD", 0.005)
 # high to avoid discarding quiet but real speech.
 NO_SPEECH_PROB_THRESHOLD = env_float("AUTOBOT_STT_NO_SPEECH_PROB_THRESHOLD", 0.8)
 
+# Energy is measured over short windows, not the whole buffer (#13104 review D).
+# A 0.5 s reply inside a 30 s recording averages away to nothing: 0.03 RMS of
+# speech over 30 s of silence computes to ~0.0039, under the floor, and the turn
+# would be dropped. The loudest 100 ms window keeps short utterances audible to
+# the gate while still reading as silence when the buffer really is empty.
+PEAK_WINDOW_MS = env_int("AUTOBOT_STT_PEAK_WINDOW_MS", 100)
 
-# Known credit-phrase artifacts, keyed by BCP-47 language. Matched exactly after
-# normalisation — never as a substring — so a real sentence that happens to
-# contain one of these survives. Read the module docstring before editing.
-_RAW_SILENCE_ARTIFACTS: Dict[str, Set[str]] = {
+
+# Artifact phrases keyed by BCP-47 language. Matched exactly after normalisation
+# — never as a substring — so a real sentence that happens to contain one of
+# these survives. Read the module docstring before editing either tier.
+#
+# Tier 1: credit strings and URLs. Never plausible dictation.
+_RAW_STRUCTURAL_ARTIFACTS: Dict[str, Set[str]] = {
     "en": {
         "Subtitles by the Amara.org community",
-        "Thanks for watching!",
-        "Thank you for watching.",
-        "Thank you for watching this video.",
-        "Please subscribe to my channel.",
-        "Like and subscribe!",
         "Transcription by CastingWords",
         "Subtitles by SteamTeamExtra",
         "www.mooji.org",
     },
     "lv": {
-        "Paldies par skatīšanos!",
-        "Paldies par skatīšanos.",
         "Subtitrus sagatavoja",
     },
     "ru": {
-        "Продолжение следует...",
-        "Спасибо за просмотр!",
         "Субтитры сделал DimaTorzok",
         "Субтитры и перевод сделал DimaTorzok",
         "Редактор субтитров А.Синецкая Корректор А.Егорова",
@@ -89,15 +102,40 @@ _RAW_SILENCE_ARTIFACTS: Dict[str, Set[str]] = {
         "Untertitelung des ZDF, 2020",
         "Untertitel im Auftrag des ZDF, 2021",
         "Untertitel der Deutschen Welle",
-        "Vielen Dank fürs Zuschauen!",
     },
     "es": {
         "Subtítulos realizados por la comunidad de Amara.org",
-        "¡Gracias por ver el video!",
-        "Gracias por ver el video.",
     },
     "fr": {
         "Sous-titres réalisés par la communauté d'Amara.org",
+    },
+}
+
+# Tier 2: polite sign-offs. Whisper invents these on silence, but a person
+# dictating a video script could genuinely say them, so they are only discarded
+# when the audio does not show speech energy.
+_RAW_OUTRO_ARTIFACTS: Dict[str, Set[str]] = {
+    "en": {
+        "Thanks for watching!",
+        "Thank you for watching.",
+        "Thank you for watching this video.",
+        "Please subscribe to my channel.",
+        "Like and subscribe!",
+    },
+    "lv": {
+        "Paldies par skatīšanos!",
+    },
+    "ru": {
+        "Продолжение следует...",
+        "Спасибо за просмотр!",
+    },
+    "de": {
+        "Vielen Dank fürs Zuschauen!",
+    },
+    "es": {
+        "¡Gracias por ver el video!",
+    },
+    "fr": {
         "Merci d'avoir regardé cette vidéo !",
     },
 }
@@ -119,11 +157,62 @@ def normalize_transcript(transcript: str) -> str:
     return _WHITESPACE_RE.sub(" ", stripped).strip()
 
 
-# Normalised once at import so the table above stays readable as real sentences.
-_SILENCE_ARTIFACTS: Dict[str, FrozenSet[str]] = {
-    lang: frozenset(normalize_transcript(phrase) for phrase in phrases)
-    for lang, phrases in _RAW_SILENCE_ARTIFACTS.items()
-}
+def _normalize_table(raw: Dict[str, Set[str]]) -> Dict[str, FrozenSet[str]]:
+    """Normalise a phrase table once at import so entries stay readable above."""
+    return {lang: frozenset(normalize_transcript(p) for p in phrases) for lang, phrases in raw.items()}
+
+
+_STRUCTURAL_ARTIFACTS = _normalize_table(_RAW_STRUCTURAL_ARTIFACTS)
+_OUTRO_ARTIFACTS = _normalize_table(_RAW_OUTRO_ARTIFACTS)
+
+
+def peak_window_rms(
+    samples: Sequence[float],
+    sample_rate: int,
+    window_ms: int = PEAK_WINDOW_MS,
+) -> float:
+    """Return the highest RMS found in any *window_ms* slice of *samples*.
+
+    Whole-buffer RMS averages a short utterance away against surrounding
+    silence and would discard it as a hallucination (#13104 review D). Taking
+    the loudest short window instead answers the question the gate actually
+    asks: "was there speech anywhere in here?"
+    """
+    total = len(samples)
+    if total == 0:
+        return 0.0
+
+    window = max(1, int(sample_rate * window_ms / 1000)) if sample_rate > 0 else total
+    peak = 0.0
+    for start in range(0, total, window):
+        chunk = samples[start : start + window]
+        if not len(chunk):
+            continue
+        mean_square = sum(float(value) * float(value) for value in chunk) / len(chunk)
+        peak = max(peak, math.sqrt(mean_square))
+    return peak
+
+
+def _artifact_tier(transcript: str, language: Optional[str]) -> Optional[str]:
+    """Return "structural"/"outro" when *transcript* matches an artifact, else None.
+
+    An unknown or uncurated language never matches — a denylist for a locale we
+    have not reviewed would be guesswork applied to real user speech.
+    """
+    if not language:
+        return None
+    key = language.split("-")[0].lower()
+    normalized = normalize_transcript(transcript)
+    if normalized in _STRUCTURAL_ARTIFACTS.get(key, frozenset()):
+        return "structural"
+    if normalized in _OUTRO_ARTIFACTS.get(key, frozenset()):
+        return "outro"
+    return None
+
+
+def is_known_artifact(transcript: str, language: Optional[str]) -> bool:
+    """Return True when *transcript* matches any artifact phrase for *language*."""
+    return _artifact_tier(transcript, language) is not None
 
 
 def is_audio_tag(transcript: str) -> bool:
@@ -135,18 +224,30 @@ def is_audio_tag(transcript: str) -> bool:
     return bool(transcript.strip()) and bool(_AUDIO_TAG_RE.match(transcript))
 
 
-def is_known_artifact(transcript: str, language: Optional[str]) -> bool:
-    """Return True when *transcript* exactly matches an artifact for *language*.
+def _discard_reason(
+    transcript: str,
+    language: Optional[str],
+    rms: Optional[float],
+    no_speech_prob: Optional[float],
+) -> Optional[str]:
+    """Return a human-readable reason to discard *transcript*, or None to keep it."""
+    if no_speech_prob is not None and no_speech_prob >= NO_SPEECH_PROB_THRESHOLD:
+        return f"no_speech_prob {no_speech_prob:.3f} >= {NO_SPEECH_PROB_THRESHOLD}"
 
-    An unknown or uncurated language never filters — a denylist for a locale we
-    have not reviewed would be guesswork applied to real user speech.
-    """
-    if not language:
-        return False
-    artifacts = _SILENCE_ARTIFACTS.get(language.split("-")[0].lower())
-    if not artifacts:
-        return False
-    return normalize_transcript(transcript) in artifacts
+    if rms is not None and rms < SILENCE_RMS_THRESHOLD:
+        return f"peak audio RMS {rms:.5f} < silence floor {SILENCE_RMS_THRESHOLD}"
+
+    if is_audio_tag(transcript):
+        return "transcript is a bare audio tag"
+
+    tier = _artifact_tier(transcript, language)
+    if tier == "structural":
+        return f"known {language} subtitle-credit artifact"
+    if tier == "outro" and rms is None:
+        # No energy evidence either way; on a live mic this phrase is the
+        # classic silence hallucination. With real energy measured it is kept.
+        return f"known {language} outro artifact, no audio energy evidence"
+    return None
 
 
 def is_silence_hallucination(
@@ -158,29 +259,26 @@ def is_silence_hallucination(
 ) -> bool:
     """Return True when *transcript* must be discarded instead of becoming a turn.
 
+    Logs at INFO with the discarded text whenever it returns True — no transcript
+    is ever dropped without a diagnosable trace.
+
     Args:
         transcript: Text returned by the STT backend.
-        language: BCP-47 code of the detected language; None disables the denylist.
-        rms: Root-mean-square energy of the source audio, if measured.
+        language: BCP-47 code for the denylist; None disables the phrase tiers.
+        rms: Peak short-window energy of the source audio, if measured.
         no_speech_prob: Decoder no-speech probability, if the backend exposes it.
     """
     if not transcript or not transcript.strip():
         return False
 
-    if no_speech_prob is not None and no_speech_prob >= NO_SPEECH_PROB_THRESHOLD:
-        logger.info("Discarding STT result: no_speech_prob %.3f at or over threshold", no_speech_prob)
-        return True
+    reason = _discard_reason(transcript, language, rms, no_speech_prob)
+    if reason is None:
+        return False
 
-    if rms is not None and rms < SILENCE_RMS_THRESHOLD:
-        logger.info("Discarding STT result: audio RMS %.5f below silence floor", rms)
-        return True
-
-    if is_audio_tag(transcript):
-        logger.info("Discarding STT result: transcript is a bare audio tag")
-        return True
-
-    if is_known_artifact(transcript, language):
-        logger.info("Discarding STT result: known %s silence artifact", language)
-        return True
-
-    return False
+    logger.info(
+        "STT silence filter discarded transcript %r (language=%s): %s",
+        transcript,
+        language or "unknown",
+        reason,
+    )
+    return True

--- a/autobot-backend/voice_processing/speech_recognition.py
+++ b/autobot-backend/voice_processing/speech_recognition.py
@@ -11,14 +11,14 @@ Extracted from voice_processing_system.py as part of Issue #381 god class refact
 
 import asyncio
 import time
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import numpy as np
 
 from autobot_shared.logging_manager import get_logger
 from memory import TaskPriority  # canonical enum (#10626)
 from task_execution_tracker import get_task_tracker
-from voice_processing.hallucination_filter import is_silence_hallucination
+from voice_processing.hallucination_filter import is_silence_hallucination, peak_window_rms
 from voice_processing.models import AudioInput, SpeechRecognitionResult
 from voice_processing.types import SpeechQuality
 
@@ -124,7 +124,23 @@ class SpeechRecognitionEngine:
             },
         )
 
-    def _discard_silence_artifacts(self, transcription_result: Dict[str, Any], noise_level: float) -> Dict[str, Any]:
+    def _signal_peak_rms(self, audio_input: AudioInput) -> Optional[float]:
+        """Peak short-window RMS of the raw audio, or None when unmeasurable.
+
+        Issue #13104 review C: this deliberately does NOT reuse `noise_level`.
+        That value comes from `_calculate_noise_level`, whose name and result
+        field both say "background noise". It happens to compute full-signal
+        RMS today, so passing it as speech energy worked by luck — the day
+        anyone makes it measure what it is named after, the gate would invert
+        and a quiet room would discard every transcript.
+        """
+        if not isinstance(audio_input.audio_data, np.ndarray):
+            return None
+        return peak_window_rms(audio_input.audio_data, audio_input.sample_rate)
+
+    def _discard_silence_artifacts(
+        self, transcription_result: Dict[str, Any], audio_input: AudioInput
+    ) -> Dict[str, Any]:
         """Blank out a transcript that is a silence hallucination. Issue #13104.
 
         Returning an empty transcription rather than raising keeps the audio
@@ -136,11 +152,19 @@ class SpeechRecognitionEngine:
             return transcription_result
 
         transcript = transcription_result.get("transcription", "")
-        detected = transcription_result.get("language")
-        if not is_silence_hallucination(transcript, detected, rms=noise_level):
+        # This is the language that was *requested* of the recogniser and echoed
+        # back, not one the engine detected — naming it "detected" would invite
+        # trusting it as evidence.
+        requested_language = transcription_result.get("language")
+        rms = self._signal_peak_rms(audio_input)
+        if not is_silence_hallucination(transcript, requested_language, rms=rms):
             return transcription_result
 
-        logger.info("Discarded STT silence artifact instead of committing a user turn")
+        logger.info(
+            "Discarded STT silence artifact %r instead of committing a user turn (audio_id=%s)",
+            transcript,
+            audio_input.audio_id,
+        )
         return {
             **transcription_result,
             "transcription": "",
@@ -176,7 +200,7 @@ class SpeechRecognitionEngine:
                     transcription_result,
                     speech_segments,
                 ) = await self._run_parallel_analysis(audio_input, language)
-                transcription_result = self._discard_silence_artifacts(transcription_result, noise_level)
+                transcription_result = self._discard_silence_artifacts(transcription_result, audio_input)
                 processing_time = time.time() - start_time
 
                 result = self._build_recognition_result(

--- a/autobot-backend/voice_processing/speech_recognition.py
+++ b/autobot-backend/voice_processing/speech_recognition.py
@@ -18,6 +18,7 @@ import numpy as np
 from autobot_shared.logging_manager import get_logger
 from memory import TaskPriority  # canonical enum (#10626)
 from task_execution_tracker import get_task_tracker
+from voice_processing.hallucination_filter import is_silence_hallucination
 from voice_processing.models import AudioInput, SpeechRecognitionResult
 from voice_processing.types import SpeechQuality
 
@@ -123,6 +124,30 @@ class SpeechRecognitionEngine:
             },
         )
 
+    def _discard_silence_artifacts(self, transcription_result: Dict[str, Any], noise_level: float) -> Dict[str, Any]:
+        """Blank out a transcript that is a silence hallucination. Issue #13104.
+
+        Returning an empty transcription rather than raising keeps the audio
+        quality, noise level and segment metadata intact for callers, while
+        ensuring no phantom turn is committed from ambient noise.
+        """
+        if self.recognizer is None:
+            # The placeholder transcript is diagnostic text, not a user turn.
+            return transcription_result
+
+        transcript = transcription_result.get("transcription", "")
+        detected = transcription_result.get("language")
+        if not is_silence_hallucination(transcript, detected, rms=noise_level):
+            return transcription_result
+
+        logger.info("Discarded STT silence artifact instead of committing a user turn")
+        return {
+            **transcription_result,
+            "transcription": "",
+            "confidence": 0.0,
+            "silence_artifact_discarded": True,
+        }
+
     async def transcribe_audio(self, audio_input: AudioInput, language: str = "en") -> SpeechRecognitionResult:
         """Transcribe audio to text using speech recognition.
 
@@ -151,6 +176,7 @@ class SpeechRecognitionEngine:
                     transcription_result,
                     speech_segments,
                 ) = await self._run_parallel_analysis(audio_input, language)
+                transcription_result = self._discard_silence_artifacts(transcription_result, noise_level)
                 processing_time = time.time() - start_time
 
                 result = self._build_recognition_result(

--- a/autobot-backend/voice_processing/test_hallucination_filter.py
+++ b/autobot-backend/voice_processing/test_hallucination_filter.py
@@ -1,0 +1,134 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for the STT silence-hallucination filter (#13104).
+
+Two obligations pull against each other and both are asserted here:
+
+* silence must never become a user turn, and
+* real short answers ("okay", "no", "yeah", "bye") must always survive.
+
+The second set is the important one. A filter that quietly eats one-word
+replies makes the assistant look like it is ignoring the user, which is a worse
+failure than the phantom turns the filter exists to prevent.
+"""
+
+import pytest
+
+from voice_processing.hallucination_filter import (
+    SILENCE_RMS_THRESHOLD,
+    is_audio_tag,
+    is_known_artifact,
+    is_silence_hallucination,
+    normalize_transcript,
+)
+
+SPEECH_RMS = 0.08  # comfortably above the silence floor
+SILENT_RMS = SILENCE_RMS_THRESHOLD / 10
+
+
+class TestRealShortAnswersSurvive:
+    """The hard constraint from #13104: never eat a genuine short reply."""
+
+    @pytest.mark.parametrize(
+        "transcript",
+        ["okay", "Okay.", "yeah", "no", "No.", "so", "bye", "Bye!", "yes", "stop", "music", "thank you"],
+    )
+    def test_short_answer_with_real_audio_is_a_turn(self, transcript):
+        assert is_silence_hallucination(transcript, "en", rms=SPEECH_RMS) is False
+
+    @pytest.mark.parametrize("language", ["en", "lv", "ru", "de", "es", "fr", None])
+    def test_ordinary_sentence_is_a_turn_in_every_language(self, language):
+        assert is_silence_hallucination("open the browser and search for trains", language, rms=SPEECH_RMS) is False
+
+    def test_sentence_merely_containing_an_artifact_phrase_survives(self):
+        """Matching is exact, not substring — a real sentence must not be eaten."""
+        transcript = "before you go, say thanks for watching to the camera"
+        assert is_silence_hallucination(transcript, "en", rms=SPEECH_RMS) is False
+
+
+class TestSilenceIsFiltered:
+    """Silence must not produce a turn, whichever signal reveals it."""
+
+    def test_silent_audio_discards_any_transcript(self):
+        assert is_silence_hallucination("Thanks for watching!", "en", rms=SILENT_RMS) is True
+
+    def test_silent_audio_discards_a_plausible_sentence_too(self):
+        """Below the noise floor there was nothing to transcribe at all."""
+        assert is_silence_hallucination("open the browser", "en", rms=SILENT_RMS) is True
+
+    def test_no_speech_probability_discards_transcript(self):
+        assert is_silence_hallucination("Thank you.", "en", no_speech_prob=0.95) is True
+
+    def test_low_no_speech_probability_keeps_transcript(self):
+        assert is_silence_hallucination("open the browser", "en", no_speech_prob=0.05) is False
+
+    @pytest.mark.parametrize(
+        "transcript",
+        ["[BLANK_AUDIO]", "(silence)", "[ Music ]", "♪♪", "{inaudible}"],
+    )
+    def test_bare_audio_tags_are_discarded_without_any_signal(self, transcript):
+        assert is_silence_hallucination(transcript) is True
+        assert is_audio_tag(transcript) is True
+
+
+class TestKnownArtifactDenylist:
+    """Per-language credit phrases, applied only when the language is known."""
+
+    @pytest.mark.parametrize(
+        "language,transcript",
+        [
+            ("en", "Subtitles by the Amara.org community"),
+            ("en", "Thanks for watching!"),
+            ("en", "Please subscribe to my channel."),
+            ("lv", "Paldies par skatīšanos!"),
+            ("ru", "Продолжение следует..."),
+            ("de", "Untertitelung des ZDF, 2020"),
+            ("es", "Subtítulos realizados por la comunidad de Amara.org"),
+            ("fr", "Merci d'avoir regardé cette vidéo !"),
+        ],
+    )
+    def test_artifact_is_discarded_even_with_normal_audio_energy(self, language, transcript):
+        assert is_silence_hallucination(transcript, language, rms=SPEECH_RMS) is True
+
+    def test_unknown_language_never_filters(self):
+        """Acceptance criterion: no denylist for a locale we have not curated."""
+        assert is_silence_hallucination("Thanks for watching!", None, rms=SPEECH_RMS) is False
+        assert is_silence_hallucination("Thanks for watching!", "unknown", rms=SPEECH_RMS) is False
+        assert is_silence_hallucination("Thanks for watching!", "ja", rms=SPEECH_RMS) is False
+
+    def test_language_region_subtags_resolve_to_the_base_language(self):
+        assert is_known_artifact("Thanks for watching!", "en-GB") is True
+
+    def test_empty_transcript_is_not_a_hallucination(self):
+        assert is_silence_hallucination("", "en", rms=SILENT_RMS) is False
+        assert is_silence_hallucination("   ", "en", rms=SILENT_RMS) is False
+
+
+class TestNormalization:
+    """Matching is punctuation- and case-insensitive, so table entries stay readable."""
+
+    def test_case_punctuation_and_whitespace_are_folded(self):
+        assert normalize_transcript("  Thanks   FOR watching!!  ") == "thanks for watching"
+
+    def test_apostrophes_fold_to_a_space_and_accents_are_kept(self):
+        assert normalize_transcript("Merci d'avoir regardé cette vidéo !") == "merci d avoir regardé cette vidéo"
+
+    def test_denylist_entries_are_normalized_at_import(self):
+        """Entries written as real sentences still match transcripts."""
+        assert is_known_artifact("subtitles by the amara org community", "en") is True
+        assert is_known_artifact("Subtitles by the Amara.org community.", "en") is True
+
+
+class TestMissingSignalsAreNotGuessedAt:
+    """Absent signals must never be treated as evidence of silence."""
+
+    def test_no_rms_and_no_probability_leaves_ordinary_speech_alone(self):
+        assert is_silence_hallucination("open the browser") is False
+
+    def test_zero_probability_is_not_confused_with_absent(self):
+        assert is_silence_hallucination("open the browser", "en", no_speech_prob=0.0) is False
+
+    def test_zero_rms_is_not_confused_with_absent(self):
+        assert is_silence_hallucination("open the browser", "en", rms=0.0) is True

--- a/autobot-backend/voice_processing/test_hallucination_filter.py
+++ b/autobot-backend/voice_processing/test_hallucination_filter.py
@@ -22,6 +22,7 @@ from voice_processing.hallucination_filter import (
     is_known_artifact,
     is_silence_hallucination,
     normalize_transcript,
+    peak_window_rms,
 )
 
 SPEECH_RMS = 0.08  # comfortably above the silence floor
@@ -80,26 +81,54 @@ class TestKnownArtifactDenylist:
         "language,transcript",
         [
             ("en", "Subtitles by the Amara.org community"),
+            ("en", "Transcription by CastingWords"),
+            ("lv", "Subtitrus sagatavoja"),
+            ("ru", "Субтитры сделал DimaTorzok"),
+            ("de", "Untertitelung des ZDF, 2020"),
+            ("es", "Subtítulos realizados por la comunidad de Amara.org"),
+            ("fr", "Sous-titres réalisés par la communauté d'Amara.org"),
+        ],
+    )
+    def test_structural_artifact_is_discarded_even_with_normal_audio_energy(self, language, transcript):
+        """Subtitle credits and URLs are never dictation, whatever the energy."""
+        assert is_silence_hallucination(transcript, language, rms=SPEECH_RMS) is True
+
+    @pytest.mark.parametrize(
+        "language,transcript",
+        [
             ("en", "Thanks for watching!"),
             ("en", "Please subscribe to my channel."),
             ("lv", "Paldies par skatīšanos!"),
-            ("ru", "Продолжение следует..."),
-            ("de", "Untertitelung des ZDF, 2020"),
-            ("es", "Subtítulos realizados por la comunidad de Amara.org"),
+            ("ru", "Спасибо за просмотр!"),
+            ("de", "Vielen Dank fürs Zuschauen!"),
             ("fr", "Merci d'avoir regardé cette vidéo !"),
         ],
     )
-    def test_artifact_is_discarded_even_with_normal_audio_energy(self, language, transcript):
-        assert is_silence_hallucination(transcript, language, rms=SPEECH_RMS) is True
+    def test_outro_artifact_is_discarded_when_no_energy_evidence(self, language, transcript):
+        """On a live mic with no RMS available, an outro phrase is the artifact."""
+        assert is_silence_hallucination(transcript, language) is True
+
+    @pytest.mark.parametrize(
+        "language,transcript",
+        [
+            ("en", "Thanks for watching!"),
+            ("en", "Please subscribe to my channel."),
+            ("de", "Vielen Dank fürs Zuschauen!"),
+        ],
+    )
+    def test_outro_artifact_survives_when_the_audio_shows_real_speech(self, language, transcript):
+        """Review item I: a dictated sign-off with real energy is real speech."""
+        assert is_silence_hallucination(transcript, language, rms=SPEECH_RMS) is False
 
     def test_unknown_language_never_filters(self):
         """Acceptance criterion: no denylist for a locale we have not curated."""
-        assert is_silence_hallucination("Thanks for watching!", None, rms=SPEECH_RMS) is False
-        assert is_silence_hallucination("Thanks for watching!", "unknown", rms=SPEECH_RMS) is False
-        assert is_silence_hallucination("Thanks for watching!", "ja", rms=SPEECH_RMS) is False
+        assert is_silence_hallucination("Subtitles by the Amara.org community", None, rms=SPEECH_RMS) is False
+        assert is_silence_hallucination("Subtitles by the Amara.org community", "unknown", rms=SPEECH_RMS) is False
+        assert is_silence_hallucination("Subtitles by the Amara.org community", "ja", rms=SPEECH_RMS) is False
 
     def test_language_region_subtags_resolve_to_the_base_language(self):
         assert is_known_artifact("Thanks for watching!", "en-GB") is True
+        assert is_known_artifact("Subtitles by the Amara.org community", "en-GB") is True
 
     def test_empty_transcript_is_not_a_hallucination(self):
         assert is_silence_hallucination("", "en", rms=SILENT_RMS) is False
@@ -132,3 +161,59 @@ class TestMissingSignalsAreNotGuessedAt:
 
     def test_zero_rms_is_not_confused_with_absent(self):
         assert is_silence_hallucination("open the browser", "en", rms=0.0) is True
+
+
+class TestPeakWindowRms:
+    """Review item D: a short utterance must not average away to silence."""
+
+    def test_short_utterance_in_a_long_silent_buffer_reads_as_speech(self):
+        """0.5s of speech in a 30s buffer — whole-buffer RMS would drop this."""
+        sample_rate = 16000
+        buffer = [0.0] * (30 * sample_rate)
+        for i in range(int(0.5 * sample_rate)):
+            buffer[i] = 0.03
+
+        whole_buffer_rms = (sum(v * v for v in buffer) / len(buffer)) ** 0.5
+        assert whole_buffer_rms < SILENCE_RMS_THRESHOLD, "precondition: the old gate would have dropped this"
+
+        peak = peak_window_rms(buffer, sample_rate)
+        assert peak > SILENCE_RMS_THRESHOLD
+        assert is_silence_hallucination("okay", "en", rms=peak) is False
+
+    def test_genuinely_silent_buffer_still_reads_as_silence(self):
+        sample_rate = 16000
+        assert peak_window_rms([0.0] * sample_rate, sample_rate) == 0.0
+        assert is_silence_hallucination("Thanks for watching!", "en", rms=0.0) is True
+
+    def test_empty_buffer_is_zero_not_an_error(self):
+        assert peak_window_rms([], 16000) == 0.0
+
+    def test_constant_tone_matches_its_own_rms(self):
+        assert peak_window_rms([0.5] * 16000, 16000) == pytest.approx(0.5)
+
+
+class TestDiscardsAreLogged:
+    """Owner rule: nothing is dropped silently — every gate must be diagnosable."""
+
+    def test_discard_logs_at_info_with_the_text_and_reason(self, caplog):
+        with caplog.at_level("INFO", logger="voice_processing.hallucination_filter"):
+            assert is_silence_hallucination("Thanks for watching!", "en", rms=0.0) is True
+
+        assert "Thanks for watching!" in caplog.text
+        assert "silence floor" in caplog.text
+
+    def test_kept_transcript_logs_nothing(self, caplog):
+        with caplog.at_level("INFO", logger="voice_processing.hallucination_filter"):
+            assert is_silence_hallucination("open the browser", "en", rms=SPEECH_RMS) is False
+
+        assert caplog.text == ""
+
+    def test_each_gate_names_itself(self, caplog):
+        with caplog.at_level("INFO", logger="voice_processing.hallucination_filter"):
+            is_silence_hallucination("anything", "en", no_speech_prob=0.99)
+            is_silence_hallucination("[BLANK_AUDIO]", "en")
+            is_silence_hallucination("Subtitles by the Amara.org community", "en", rms=SPEECH_RMS)
+
+        assert "no_speech_prob" in caplog.text
+        assert "bare audio tag" in caplog.text
+        assert "subtitle-credit artifact" in caplog.text

--- a/autobot-backend/voice_processing/test_speech_recognition_silence_filter.py
+++ b/autobot-backend/voice_processing/test_speech_recognition_silence_filter.py
@@ -12,13 +12,31 @@ intact.
 
 from unittest.mock import MagicMock
 
+import numpy as np
 import pytest
 
 from voice_processing.hallucination_filter import SILENCE_RMS_THRESHOLD
+from voice_processing.models import AudioInput
 from voice_processing.speech_recognition import SpeechRecognitionEngine
 
 SPEECH_RMS = 0.08
 SILENT_RMS = SILENCE_RMS_THRESHOLD / 10
+SAMPLE_RATE = 16000
+
+
+def _audio(rms: float, seconds: float = 1.0) -> AudioInput:
+    """AudioInput whose waveform has exactly the requested RMS."""
+    samples = np.full(int(SAMPLE_RATE * seconds), rms, dtype=np.float32)
+    return AudioInput(
+        audio_id="test-audio",
+        audio_data=samples,
+        sample_rate=SAMPLE_RATE,
+        duration=seconds,
+        format="raw",
+        channels=1,
+        timestamp=0.0,
+        metadata={},
+    )
 
 
 @pytest.fixture
@@ -42,20 +60,22 @@ def _result(transcription: str, language: str = "en") -> dict:
 
 class TestSilenceArtifactsAreDiscarded:
     def test_artifact_over_silence_yields_no_transcript(self, engine):
-        filtered = engine._discard_silence_artifacts(_result("Thanks for watching!"), SILENT_RMS)
+        filtered = engine._discard_silence_artifacts(_result("Thanks for watching!"), _audio(SILENT_RMS))
 
         assert filtered["transcription"] == ""
         assert filtered["confidence"] == 0.0
         assert filtered["silence_artifact_discarded"] is True
 
-    def test_artifact_with_normal_energy_still_discarded(self, engine):
-        filtered = engine._discard_silence_artifacts(_result("Subtitles by the Amara.org community"), SPEECH_RMS)
+    def test_structural_artifact_with_normal_energy_still_discarded(self, engine):
+        filtered = engine._discard_silence_artifacts(
+            _result("Subtitles by the Amara.org community"), _audio(SPEECH_RMS)
+        )
 
         assert filtered["transcription"] == ""
 
     def test_confident_sentence_over_silence_is_discarded(self, engine):
         """High STT confidence is exactly how this failure presents."""
-        filtered = engine._discard_silence_artifacts(_result("open the browser"), SILENT_RMS)
+        filtered = engine._discard_silence_artifacts(_result("open the browser"), _audio(SILENT_RMS))
 
         assert filtered["transcription"] == ""
 
@@ -64,7 +84,7 @@ class TestRealSpeechIsUntouched:
     @pytest.mark.parametrize("transcript", ["okay", "no", "yeah", "bye", "yes", "stop"])
     def test_short_real_answer_still_registers_as_a_turn(self, engine, transcript):
         original = _result(transcript)
-        filtered = engine._discard_silence_artifacts(original, SPEECH_RMS)
+        filtered = engine._discard_silence_artifacts(original, _audio(SPEECH_RMS))
 
         assert filtered["transcription"] == transcript
         assert filtered is original
@@ -72,15 +92,63 @@ class TestRealSpeechIsUntouched:
 
     def test_sentence_is_passed_through_unchanged(self, engine):
         original = _result("open the browser and search for trains")
-        assert engine._discard_silence_artifacts(original, SPEECH_RMS) is original
+        assert engine._discard_silence_artifacts(original, _audio(SPEECH_RMS)) is original
 
     def test_unknown_language_disables_the_denylist(self, engine):
         original = _result("Thanks for watching!", language="unknown")
-        assert engine._discard_silence_artifacts(original, SPEECH_RMS) is original
+        assert engine._discard_silence_artifacts(original, _audio(SPEECH_RMS)) is original
 
     def test_placeholder_transcript_survives_when_no_recognizer(self, engine):
         """Without a recognizer the transcript is diagnostic text, not a turn."""
         engine.recognizer = None
         original = _result("[Speech recognition not available]")
 
-        assert engine._discard_silence_artifacts(original, SILENT_RMS) is original
+        assert engine._discard_silence_artifacts(original, _audio(SILENT_RMS)) is original
+
+
+class TestNoiseLevelIsNotReusedAsSpeechEnergy:
+    """Review item C: the gate must not depend on _calculate_noise_level."""
+
+    def test_gate_reads_the_waveform_not_the_noise_level_helper(self, engine, monkeypatch):
+        """If _calculate_noise_level were the source, this would invert."""
+        monkeypatch.setattr(
+            SpeechRecognitionEngine,
+            "_calculate_noise_level",
+            lambda self, audio_input: 0.0,  # a "quiet room" reading
+        )
+        original = _result("open the browser")
+
+        assert engine._discard_silence_artifacts(original, _audio(SPEECH_RMS)) is original
+
+    def test_short_utterance_in_a_long_buffer_survives(self, engine):
+        """Review item D end-to-end: 0.5s of speech inside 30s of silence."""
+        samples = np.zeros(SAMPLE_RATE * 30, dtype=np.float32)
+        samples[: int(SAMPLE_RATE * 0.5)] = 0.03
+        audio = AudioInput(
+            audio_id="short-utterance",
+            audio_data=samples,
+            sample_rate=SAMPLE_RATE,
+            duration=30.0,
+            format="raw",
+            channels=1,
+            timestamp=0.0,
+            metadata={},
+        )
+        original = _result("okay")
+
+        assert engine._discard_silence_artifacts(original, audio) is original
+
+    def test_bytes_audio_disables_the_energy_gate_rather_than_guessing(self, engine):
+        audio = AudioInput(
+            audio_id="raw-bytes",
+            audio_data=b"\x00\x01",
+            sample_rate=SAMPLE_RATE,
+            duration=1.0,
+            format="wav",
+            channels=1,
+            timestamp=0.0,
+            metadata={},
+        )
+        original = _result("open the browser")
+
+        assert engine._discard_silence_artifacts(original, audio) is original

--- a/autobot-backend/voice_processing/test_speech_recognition_silence_filter.py
+++ b/autobot-backend/voice_processing/test_speech_recognition_silence_filter.py
@@ -1,0 +1,86 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""The silence filter must actually be wired into the STT path (#13104).
+
+A correct filter module that nothing calls fixes nothing, so these tests drive
+``SpeechRecognitionEngine`` itself: a hallucinated transcript over silent audio
+must come back blank, and a real short answer over real audio must come back
+intact.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from voice_processing.hallucination_filter import SILENCE_RMS_THRESHOLD
+from voice_processing.speech_recognition import SpeechRecognitionEngine
+
+SPEECH_RMS = 0.08
+SILENT_RMS = SILENCE_RMS_THRESHOLD / 10
+
+
+@pytest.fixture
+def engine():
+    """Engine with a stand-in recognizer, so the filter is not bypassed."""
+    instance = SpeechRecognitionEngine.__new__(SpeechRecognitionEngine)
+    instance.recognizer = MagicMock()
+    instance.language_detector = None
+    instance.noise_reducer = None
+    return instance
+
+
+def _result(transcription: str, language: str = "en") -> dict:
+    return {
+        "transcription": transcription,
+        "confidence": 0.97,
+        "alternatives": [],
+        "language": language,
+    }
+
+
+class TestSilenceArtifactsAreDiscarded:
+    def test_artifact_over_silence_yields_no_transcript(self, engine):
+        filtered = engine._discard_silence_artifacts(_result("Thanks for watching!"), SILENT_RMS)
+
+        assert filtered["transcription"] == ""
+        assert filtered["confidence"] == 0.0
+        assert filtered["silence_artifact_discarded"] is True
+
+    def test_artifact_with_normal_energy_still_discarded(self, engine):
+        filtered = engine._discard_silence_artifacts(_result("Subtitles by the Amara.org community"), SPEECH_RMS)
+
+        assert filtered["transcription"] == ""
+
+    def test_confident_sentence_over_silence_is_discarded(self, engine):
+        """High STT confidence is exactly how this failure presents."""
+        filtered = engine._discard_silence_artifacts(_result("open the browser"), SILENT_RMS)
+
+        assert filtered["transcription"] == ""
+
+
+class TestRealSpeechIsUntouched:
+    @pytest.mark.parametrize("transcript", ["okay", "no", "yeah", "bye", "yes", "stop"])
+    def test_short_real_answer_still_registers_as_a_turn(self, engine, transcript):
+        original = _result(transcript)
+        filtered = engine._discard_silence_artifacts(original, SPEECH_RMS)
+
+        assert filtered["transcription"] == transcript
+        assert filtered is original
+        assert "silence_artifact_discarded" not in filtered
+
+    def test_sentence_is_passed_through_unchanged(self, engine):
+        original = _result("open the browser and search for trains")
+        assert engine._discard_silence_artifacts(original, SPEECH_RMS) is original
+
+    def test_unknown_language_disables_the_denylist(self, engine):
+        original = _result("Thanks for watching!", language="unknown")
+        assert engine._discard_silence_artifacts(original, SPEECH_RMS) is original
+
+    def test_placeholder_transcript_survives_when_no_recognizer(self, engine):
+        """Without a recognizer the transcript is diagnostic text, not a turn."""
+        engine.recognizer = None
+        original = _result("[Speech recognition not available]")
+
+        assert engine._discard_silence_artifacts(original, SILENT_RMS) is original

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -12006,6 +12006,10 @@ export interface paths {
          * @description Capture desktop screenshot.
          *     Issue #74: Desktop interaction controls.
          *
+         *     Issue #13208: ``temporary_file_path`` owns the temp file, so it is removed
+         *     on the success path, on capture failure and on any exception. Previously
+         *     only the success path unlinked it and each failed capture leaked a PNG.
+         *
          *     Returns:
          *         {
          *             "status": "success|error",
@@ -13420,6 +13424,11 @@ export interface paths {
          * Desktop Screenshot Mcp
          * @description MCP tool: Capture desktop screenshot.
          *     Issue #74: Agent desktop observation.
+         *
+         *     Issue #13208: the temp file is owned by ``temporary_file_path``, so it is
+         *     removed on the success path, on capture failure and on any exception.
+         *     Previously only the success path unlinked it, so production leaked one PNG
+         *     per failed capture, indefinitely.
          */
         post: operations["desktop_screenshot_mcp_api_vnc_mcp_desktop_screenshot_post"];
         delete?: never;

--- a/autobot_shared/env_registry.py
+++ b/autobot_shared/env_registry.py
@@ -522,3 +522,60 @@ register_env_var(
         component="network",
     )
 )
+
+# --- voice / speech-to-text -------------------------------------------------
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_STT_SILENCE_RMS_THRESHOLD",
+        type=float,
+        default=0.005,
+        description=(
+            "Audio RMS below which the waveform is treated as silence, so any STT "
+            "transcript over it is a hallucination rather than a user turn (#13104)."
+        ),
+        component="voice",
+        range=(0.0, 1.0),
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_STT_NO_SPEECH_PROB_THRESHOLD",
+        type=float,
+        default=0.8,
+        description=(
+            "Decoder no-speech probability at or above which an STT transcript is "
+            "discarded as a silence hallucination (#13104)."
+        ),
+        component="voice",
+        range=(0.0, 1.0),
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_MULTIMODAL_VOICE_CONFIDENCE_THRESHOLD",
+        type=float,
+        default=0.7,
+        description=(
+            "Fallback confidence threshold for VoiceProcessor when the multimodal.voice "
+            "config section omits it (#13207)."
+        ),
+        component="voice",
+        range=(0.0, 1.0),
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_MULTIMODAL_VOICE_PROCESSING_TIMEOUT",
+        type=int,
+        default=30,
+        description=(
+            "Fallback processing timeout in seconds for VoiceProcessor when the "
+            "multimodal.voice config section omits it (#13207)."
+        ),
+        component="voice",
+    )
+)

--- a/autobot_shared/temp_files.py
+++ b/autobot_shared/temp_files.py
@@ -1,0 +1,59 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Temporary-file helpers with guaranteed cleanup.
+
+Issue #13208: several capture paths created a temp file with
+``tempfile.NamedTemporaryFile(delete=False)`` so an external process (scrot,
+import, ffmpeg, ...) could write to the path, then unlinked it *only on the
+success path*. Every failure return leaked one file, permanently.
+
+``delete=False`` is required whenever another process must open the path by
+name, so the fix is not "stop using delete=False" but "make the unlink
+unconditional". This module provides the single place that guarantee lives, so
+new capture paths do not have to re-derive it.
+"""
+
+import os
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator, Optional
+
+from autobot_shared.logging_manager import get_logger
+
+logger = get_logger(__name__)
+
+
+@contextmanager
+def temporary_file_path(
+    suffix: str = "",
+    prefix: str = "autobot_",
+    directory: Optional[str] = None,
+) -> Iterator[str]:
+    """Yield the path of a closed, empty temp file, removed on every exit path.
+
+    The file exists and is empty when the block starts, and its descriptor is
+    already closed, so an external process may write to the path by name. The
+    file is removed when the block exits, whether it returned, raised, or was
+    cancelled.
+
+    Args:
+        suffix: File suffix, e.g. ``".png"``.
+        prefix: File name prefix.
+        directory: Parent directory; the system temp dir when omitted.
+
+    Yields:
+        Absolute path to the temporary file.
+    """
+    fd, path = tempfile.mkstemp(suffix=suffix, prefix=prefix, dir=directory)
+    os.close(fd)
+    try:
+        yield path
+    finally:
+        try:
+            Path(path).unlink(missing_ok=True)
+        except OSError as exc:
+            # Never let cleanup mask the caller's own outcome.
+            logger.warning("Failed to remove temporary file %s: %s", path, exc)

--- a/docs/developer/CLAUDE_RULES.md
+++ b/docs/developer/CLAUDE_RULES.md
@@ -397,6 +397,8 @@ To add a new variable:
 | `AUTOBOT_LOGS_BACKUP_DIR` | logging | str | `'backup'` | Directory where rotated log archives are written. |
 | `AUTOBOT_LOGS_DIR` | logging | str | `'logs'` | Primary directory for application log files. |
 | `AUTOBOT_LOG_VIEWER_URL` | logging | str | `'http://localhost:5341'` | Base URL of the Seq (or compatible) structured-log viewer. |
+| `AUTOBOT_MULTIMODAL_VOICE_CONFIDENCE_THRESHOLD` | voice | float | `0.7` | Fallback confidence threshold for VoiceProcessor when the multimodal.voice config section omits it (#13207). Range: 0.0–1.0. |
+| `AUTOBOT_MULTIMODAL_VOICE_PROCESSING_TIMEOUT` | voice | int | `30` | Fallback processing timeout in seconds for VoiceProcessor when the multimodal.voice config section omits it (#13207). |
 | `AUTOBOT_OLLAMA_BASE_URL` | ai | str | *(none)* | Base URL of the local Ollama API (e.g. http://localhost:11434). |
 | `AUTOBOT_ORCHESTRATOR_MODEL` | ai | str | `'llama3.2:1b'` | Ollama model name used for the main orchestrator/routing loop. |
 | `AUTOBOT_OTEL_ENABLED` | otel | bool | false | Enable OpenTelemetry tracing when truthy. |
@@ -419,6 +421,8 @@ To add a new variable:
 | `AUTOBOT_REDIS_TLS_ENABLED` | redis | bool | false | Enable TLS for Redis connections when truthy. |
 | `AUTOBOT_REDIS_TLS_PORT` | redis | int | `6380` | Redis server TCP port for TLS connections. Range: 1–65535. |
 | `AUTOBOT_SHOW_DEPRECATION_WARNINGS` | system | bool | false | Emit Python DeprecationWarnings for deprecated AutoBot APIs when truthy. |
+| `AUTOBOT_STT_NO_SPEECH_PROB_THRESHOLD` | voice | float | `0.8` | Decoder no-speech probability at or above which an STT transcript is discarded as a silence hallucination (#13104). Range: 0.0–1.0. |
+| `AUTOBOT_STT_SILENCE_RMS_THRESHOLD` | voice | float | `0.005` | Audio RMS below which the waveform is treated as silence, so any STT transcript over it is a hallucination rather than a user turn (#13104). Range: 0.0–1.0. |
 | `AUTOBOT_TLS_CA_PATH` | tls | str | *(none)* | Path to the CA certificate file for TLS verification. |
 | `AUTOBOT_TLS_CERT_DIR` | tls | str | `'/etc/autobot/certs'` | Directory containing TLS certificate and key files. |
 | `AUTOBOT_TLS_CERT_PATH` | tls | str | *(none)* | Path to the TLS client/server certificate file. |
@@ -426,5 +430,5 @@ To add a new variable:
 | `AUTOBOT_TRUSTED_PROXIES` | network | str | `""` | Comma-separated list of trusted reverse-proxy IP addresses or CIDR ranges for X-Forwarded-For header trust. |
 | `AUTOBOT_USERS_DATABASE_URL` | postgres | str | *(none)* | Full SQLAlchemy connection URL for the users database. Overrides AUTOBOT_POSTGRES_* individual vars when set. |
 
-*42 variables registered as of last generation.*
+*46 variables registered as of last generation.*
 <!-- END_AUTOGEN_ENV_DOCS -->


### PR DESCRIPTION
## Thinking Path

Three defects that all share one shape: a failure that leaves no trace. A config
lookup that degrades to a plausible literal, an STT backend that answers silence
with a fluent sentence, and a temp file that is only cleaned up when nothing
goes wrong. None raise, none log, and all three look correct in review.

Review round 2 found the same shape *inside the first fix*: the filter was wired
to two STT classes, but not to the route the issue is actually about, and three
of four new env knobs had no reader. Both are fixed below.

**Nothing is discarded silently.** Every gate that drops audio or a transcript
logs at INFO with the discarded text and the reason it fired. A swallowed turn
that leaves no trace is indistinguishable from a broken microphone.

**#13207 — the threshold decision.** `VoiceProcessor` read `multimodal.audio`,
a section defined nowhere, so `get_config_section` returned `{}` and every value
came from a literal. Correcting the key alone would have moved two numbers:
`confidence_threshold` 0.7 → 0.8 and `processing_timeout` 30 → 15.

To be precise about why the pin is safe: **those two attributes had no
behaviour at all.** They were assigned in `__init__` and read nowhere in the
repo — `_build_voice_result` hardcoded `confidence = 0.9 if text else 0.0`, and
`calculate_confidence` returned the base class's flat 0.5. So this is not
"preserving live behaviour"; it is choosing the value a knob will have *on the
first day it means anything*, which is exactly when it should be chosen
deliberately rather than inherited from a copy-paste.

The evidence pointed at 0.7 / 30: the `multimodal.voice` values (0.8 / 15) date
to the config file's first commit and have never reached the processor, so they
were never validated against real audio; the `voice.py` literals (0.7 / 30) are
byte-identical to `vision.py`'s; and `multimodal_system_integration_test.py:50`
already configures `multimodal.voice.confidence_threshold = 0.7`. The knobs are
now wired (below), so 0.8 / 15 is a one-line change with its own evidence.

**#13104.** Filtering on the transcript alone cannot work: the phrase Whisper
invents for silence ("Thank you.", "Bye.") is also a real one-word reply. The
filter leads with signals about the *audio* and uses phrase lists only as the
fallback tier, split so that plausible dictation is not eaten.

**#13208.** `delete=False` is required (an external process opens the path by
name), so the fix is not to stop using it but to make the unlink unconditional,
in one shared context manager rather than re-derived per call site.

## What Changed

**#13104 — the live route (review REQUIRED A)**
- `api/voice.py::_whisper_sync` — the function behind `POST /api/voice/transcribe`,
  which `useVoiceConversation.ts` calls for walkie-talkie, hands-free and
  full-duplex modes — now runs the filter. This is the path #13104 describes;
  the two classes wired in round 1 are not on it.
- The transformers ASR pipeline returns **no** `language` key, so `detected_lang`
  is always `"unknown"` there and an unknown language disables the denylist by
  design. The caller's requested language (which the frontend does send) is used
  as the fallback key, otherwise the filter would have been dead on arrival.

**#13104 — filter design**
- New `voice_processing/hallucination_filter.py`. Gates: `no_speech_prob`,
  peak-window audio energy, bare audio tags (`[BLANK_AUDIO]`, `♪♪`), and
  per-language phrases split into two tiers — **structural** (subtitle credits
  and URLs, discarded whatever the audio says) and **outro** (polite sign-offs,
  discarded only when the audio shows no speech energy).
- Wired into all four STT paths: the live route above, `SpeechRecognitionEngine`,
  the multimodal Whisper path, and the KB audio connector.

**#13207 / review REQUIRED B — every registered knob now has a reader**
- `AUTOBOT_STT_NO_SPEECH_PROB_THRESHOLD` — wired in the KB audio connector, which
  uses openai-whisper, the one backend in the tree that reports `no_speech_prob`
  per segment. Averaged across segments; absent segments yield `None` ("no
  evidence"), never `0.0` ("definitely speech").
- `AUTOBOT_MULTIMODAL_VOICE_CONFIDENCE_THRESHOLD` — `VoiceProcessor.calculate_confidence`
  now returns the confidence the pipeline actually reported instead of the base
  class's flat 0.5, and a result under the threshold is returned as a failure
  with a stated reason rather than passed off as a successful command.
- `AUTOBOT_MULTIMODAL_VOICE_PROCESSING_TIMEOUT` — applied as a real
  `asyncio.wait_for` timeout with its own error branch.
- `AUTOBOT_STT_PEAK_WINDOW_MS` — new, backing the energy window below.

**Review items C, E, F, G, H**
- **C** — the energy gate computes peak RMS from the waveform itself instead of
  borrowing `_calculate_noise_level`, whose name says "background noise". Passing
  that as speech energy worked only by luck; the day it measures what it is named
  after, the gate would have inverted and a quiet room would discard every
  transcript. The `detected` local (which held the *requested* language) is
  renamed and commented.
- **E** — `enabled: false` now returns "Voice processing is disabled by
  configuration", not "Required models are not loaded, check your GPU/NPU". This
  path is reachable for the first time *because* of this PR.
- **F** — `test_enabled_false_is_honoured` asserted only `processor.enabled is
  False` and passed with the gate deleted. It now forces `AUDIO_MODELS_AVAILABLE`
  True, asserts the loader is not called, and has a mirror asserting it *is*
  called when enabled.
- **G** — `vnc_manager` screenshot capture, PIL decode and tesseract all moved
  onto `asyncio.to_thread`. Two 10s subprocess timeouts previously ran inline on
  the event loop.
- **H** — the OCR fix now has tests, driving a real PNG through a real PIL decode.

**#13208 — temp file leak**
- New `autobot_shared/temp_files.py`; applied to `vnc_mcp.py::desktop_screenshot_mcp`
  (the reported site) and, same bug, `vnc_manager.py::vnc_screenshot` and `::vnc_ocr_text`.

**Fixed in passing:** `vnc_ocr_text` called `Image.open(path, encoding="utf-8")`.
`Image.open` takes no `encoding` kwarg, so every OCR call raised `TypeError` and
fell into the generic error branch — the endpoint was 100% dead, silently.

## Verification

Regression tests were run against the pre-fix call sites by reverting only the
consumers.

**BEFORE — the live route is unfiltered and the knobs are inert**

```
FAILED api/test_voice_transcribe_silence_filter.py::...::test_structural_artifact_is_discarded
FAILED api/test_voice_transcribe_silence_filter.py::...::test_outro_artifact_is_discarded_when_no_energy_is_available
FAILED api/test_voice_transcribe_silence_filter.py::...::test_bare_audio_tag_is_discarded_without_any_language
FAILED api/test_voice_transcribe_silence_filter.py::...::test_requested_language_keys_the_denylist
FAILED api/test_voice_transcribe_silence_filter.py::...::test_detected_language_wins_over_the_requested_one
FAILED api/test_voice_transcribe_silence_filter.py::...::test_discard_is_logged_with_the_text
FAILED multimodal_processor/test_voice_config_section.py::...::test_disabled_processor_says_disabled_not_hardware_broken
FAILED multimodal_processor/test_voice_config_section.py::...::test_confidence_below_threshold_is_reported_as_failure
FAILED multimodal_processor/test_voice_config_section.py::...::test_confidence_above_threshold_succeeds
FAILED multimodal_processor/test_voice_config_section.py::...::test_processing_timeout_is_enforced
=================== 13 failed, 16 passed, 1 warning in 6.65s ===================
```

Round 1's evidence still holds (30 failed / 71 passed), including the leak
assertion naming the orphan directly:

```
E   AssertionError: failed capture leaked a temp file: ['tmproykulky.png']
```

The OCR defect predates the helper it now lives in, so it is shown at base
directly:

```
$ python3 -c "Image.open('t.png', encoding='utf-8')"
BASE RAISES -> TypeError open() got an unexpected keyword argument 'encoding'
```

**AFTER — 162 passed**

```
api/test_voice_transcribe_silence_filter.py ...............                [  9%]
api/test_vnc_ocr.py .............                                          [ 17%]
knowledge/connectors/test_audio_connector_hallucination.py ..............   [ 25%]
multimodal_processor/test_voice_config_section.py ..............            [ 33%]
multimodal_processor/test_voice_silence_filter.py ...........               [ 40%]
voice_processing/test_hallucination_filter.py .....................         [ 76%]
voice_processing/test_speech_recognition_silence_filter.py ...............  [ 85%]
tests/test_vnc_screenshot_temp_leak.py .......                              [ 90%]
tests/test_vnc_mcp_async.py ................                                [100%]
======================== 162 passed, 1 warning in 2.63s ========================
```

**No regressions.** `multimodal_processor/ voice_processing/ config/
knowledge/connectors/`, base vs HEAD, new test files removed at base so the
comparison is like-for-like:

```
BASE: 14 failed, 502 passed, 39 warnings, 7 errors in 467.83s
HEAD: 14 failed, 613 passed, 39 warnings, 7 errors in 466.23s
failure-ID diff: IDENTICAL — the same 21 test IDs fail on both
```

`flake8` clean on every changed file; `black`/`isort` applied; `mypy
(autobot_shared - strict)` passes on the new shared module.

**Not verifiable here:** the RMS floor (0.005), the peak window (100 ms) and the
no-speech threshold (0.8) are calibrated from documented Whisper behaviour, not
measured against this deployment's microphones — there is no audio hardware in
this environment. All are env-tunable because the right value is room- and
mic-dependent. The `no_speech_prob` gate is exercised only through stubbed
segment data, since running openai-whisper needs a model download.

The artifact phrase lists cover en, lv, ru, de, es and fr — the languages
`language_detection.py` builds its detector from. That is **not** an allow-list:
the detector can return anything, and the requested language is passed straight
through, so any other locale simply matches no phrase and filters nothing.

## Model Used

Claude Opus 5

Closes #13207, #13104, #13208
