### PR TITLE
feat(browser): split EXTRACT by content format so dispatch cannot swap HTML for text (#13236)

### DIFF
--- a/autobot-backend/browser_backends/conformance_test.py
+++ b/autobot-backend/browser_backends/conformance_test.py
@@ -20,6 +20,7 @@ from autobot_shared.browser.base import (
     ActionRequest,
     BrowserBackend,
     Capability,
+    ContentFormat,
     ExtractRequest,
     NavigateRequest,
     ScreenshotRequest,
@@ -248,3 +249,64 @@ def test_register_all_is_idempotent():
 
     assert first == second == ["in_process", "worker", "container"]
     clear_backends()
+
+
+def test_extract_formats_match_what_each_stack_actually_returns():
+    """#13236: capability must describe the real output shape, not "extract".
+
+    - container `render`   -> HTML
+    - worker    `get_text` -> text, markup stripped
+    - in_process `extract_content()` -> text_content + structured_data
+    """
+    in_process = InProcessBrowserBackend()
+    worker = WorkerBrowserBackend()
+    container = ContainerBrowserBackend()
+
+    assert Capability.EXTRACT_HTML in container.capabilities
+    assert Capability.EXTRACT_HTML not in worker.capabilities | in_process.capabilities
+
+    assert Capability.EXTRACT_TEXT in worker.capabilities
+    assert Capability.EXTRACT_TEXT in in_process.capabilities
+
+    assert Capability.EXTRACT_STRUCTURED in in_process.capabilities
+    assert Capability.EXTRACT_STRUCTURED not in worker.capabilities | container.capabilities
+
+
+@pytest.mark.asyncio
+async def test_web_fetch_requirements_resolve_to_the_container():
+    """The concrete migration this unblocks (ADR-009 step 2).
+
+    `web_fetch/_fetch_playwright` needs HTML, out-of-process. Under the real
+    registration order the worker is registered BEFORE the container, so with
+    a single `EXTRACT` capability it would have won and returned text.
+    """
+    from autobot_shared.browser.registry import clear_backends, resolve_backend
+
+    clear_backends()
+    register_all(force=True)
+    # probe() reaches the real transports; this test is about capability
+    # selection under the real registration order, not reachability.
+    try:
+        with (
+            patch.object(ContainerBrowserBackend, "probe", AsyncMock(return_value=True)),
+            patch.object(WorkerBrowserBackend, "probe", AsyncMock(return_value=True)),
+            patch.object(InProcessBrowserBackend, "probe", AsyncMock(return_value=True)),
+        ):
+            chosen = await resolve_backend({Capability.EXTRACT_HTML, Capability.OUT_OF_PROCESS})
+    finally:
+        clear_backends()
+
+    assert chosen.name == "container"
+
+
+@pytest.mark.asyncio
+async def test_container_extract_declares_html_and_returns_it():
+    service = MagicMock()
+    service._post_and_parse = AsyncMock(return_value={"html": "<html>ok</html>"})
+
+    with patch.object(ContainerBrowserBackend, "_service", staticmethod(AsyncMock(return_value=service))):
+        result = await ContainerBrowserBackend().extract(
+            ExtractRequest(url="https://example.com/", format=ContentFormat.HTML)
+        )
+
+    assert result.content == "<html>ok</html>"

--- a/autobot-backend/browser_backends/conformance_test.py
+++ b/autobot-backend/browser_backends/conformance_test.py
@@ -310,3 +310,36 @@ async def test_container_extract_declares_html_and_returns_it():
         )
 
     assert result.content == "<html>ok</html>"
+
+
+@pytest.mark.asyncio
+async def test_container_forwards_the_extract_timeout_in_milliseconds():
+    """web_fetch passes a timeout today; dropping it would be a silent change.
+
+    `_fetch_playwright` sends `timeout: int(timeout * 1000)` to the render
+    endpoint. `ExtractRequest` had no timeout field, so migrating would have
+    fallen back to the container default without anything failing (#13236).
+    """
+    service = MagicMock()
+    service._post_and_parse = AsyncMock(return_value={"html": "<html/>"})
+
+    with patch.object(ContainerBrowserBackend, "_service", staticmethod(AsyncMock(return_value=service))):
+        await ContainerBrowserBackend().extract(
+            ExtractRequest(url="https://example.com/", format=ContentFormat.HTML, timeout_seconds=12.5)
+        )
+
+    _, payload = service._post_and_parse.await_args.args
+    assert payload["timeout"] == 12500, "timeout must reach the render endpoint, in ms"
+
+
+@pytest.mark.asyncio
+async def test_container_omits_timeout_when_the_caller_gives_none():
+    """No timeout means the container's own default, not timeout=0."""
+    service = MagicMock()
+    service._post_and_parse = AsyncMock(return_value={"html": "<html/>"})
+
+    with patch.object(ContainerBrowserBackend, "_service", staticmethod(AsyncMock(return_value=service))):
+        await ContainerBrowserBackend().extract(ExtractRequest(url="https://example.com/", format=ContentFormat.HTML))
+
+    _, payload = service._post_and_parse.await_args.args
+    assert "timeout" not in payload

--- a/autobot-backend/browser_backends/container.py
+++ b/autobot-backend/browser_backends/container.py
@@ -44,7 +44,7 @@ class ContainerBrowserBackend:
             # `web_fetch/fetcher.py::_fetch_playwright` already uses for its
             # JS-render fallback. Phase 2 wrapped only `capture_screenshot`
             # and under-declared this stack.
-            Capability.EXTRACT,
+            Capability.EXTRACT_HTML,
             Capability.OUT_OF_PROCESS,
         }
     )
@@ -74,7 +74,7 @@ class ContainerBrowserBackend:
         )
 
     async def extract(self, request: ExtractRequest) -> BrowserResult:
-        """Render *url* and return its HTML.
+        """Render *url* and return its **HTML**.
 
         Stateless: the URL is required because this backend holds no current
         page. The registry has already validated it (#13236).

--- a/autobot-backend/browser_backends/container.py
+++ b/autobot-backend/browser_backends/container.py
@@ -87,10 +87,12 @@ class ContainerBrowserBackend:
             )
 
         service = await self._service()
-        raw = await service._post_and_parse(
-            "render",
-            {"url": request.url, "wait": "networkidle"},
-        )
+        payload: dict = {"url": request.url, "wait": "networkidle"}
+        if request.timeout_seconds is not None:
+            # The render endpoint takes milliseconds.
+            payload["timeout"] = int(request.timeout_seconds * 1000)
+
+        raw = await service._post_and_parse("render", payload)
         html = raw.get("html") or raw.get("content")
         if request.max_chars is not None and html:
             html = html[: request.max_chars]

--- a/autobot-backend/browser_backends/in_process.py
+++ b/autobot-backend/browser_backends/in_process.py
@@ -40,7 +40,8 @@ class InProcessBrowserBackend:
     capabilities = frozenset(
         {
             Capability.NAVIGATE,
-            Capability.EXTRACT,
+            Capability.EXTRACT_TEXT,
+            Capability.EXTRACT_STRUCTURED,
             Capability.MHTML,
             Capability.HUMAN_HANDOFF,
             Capability.PERSISTENT_SESSION,

--- a/autobot-backend/browser_backends/worker.py
+++ b/autobot-backend/browser_backends/worker.py
@@ -44,7 +44,7 @@ class WorkerBrowserBackend:
     capabilities = frozenset(
         {
             Capability.NAVIGATE,
-            Capability.EXTRACT,
+            Capability.EXTRACT_TEXT,
             Capability.SCREENSHOT,
             Capability.INTERACT,
             Capability.ELEMENT_REFS,
@@ -75,7 +75,11 @@ class WorkerBrowserBackend:
         return self._to_result(raw, request.session_id, url=request.url)
 
     async def extract(self, request: ExtractRequest) -> BrowserResult:
-        """Read text from *selector*, defaulting to the whole body."""
+        """Read **text** from *selector*, defaulting to the whole body.
+
+        `get_text` strips markup, so this stack serves TEXT only — it cannot
+        satisfy a caller that needs HTML (#13236).
+        """
         raw = await self._send(
             "get_text",
             {"selector": request.selector or "body"},

--- a/autobot_shared/browser/__init__.py
+++ b/autobot_shared/browser/__init__.py
@@ -10,8 +10,13 @@ DNS-resolving public-address guard before any backend sees it.
 
     from autobot_shared.browser import Capability, NavigateRequest, get_browser
 
-    browser = await get_browser(requires={Capability.NAVIGATE, Capability.EXTRACT})
+    browser = await get_browser(requires={Capability.NAVIGATE, Capability.EXTRACT_TEXT})
     page = await browser.navigate(NavigateRequest(url=url))
+
+Ask for the content shape you need — `EXTRACT_HTML` for markup,
+`EXTRACT_STRUCTURED` for parsed structure. A backend that cannot produce the
+requested format is not selected, and naming a mismatched format on the
+request raises rather than returning the wrong shape (#13236).
 
 Backends are registered by the app that owns their transport — see
 ``registry.register_backend`` — so this package never imports an app-local
@@ -29,12 +34,15 @@ _LAZY_IMPORTS = {
     "BrowserError": (".base", "BrowserError"),
     "BrowserResult": (".base", "BrowserResult"),
     "Capability": (".base", "Capability"),
+    "ContentFormat": (".base", "ContentFormat"),
+    "FORMAT_CAPABILITY": (".base", "FORMAT_CAPABILITY"),
     "ExtractRequest": (".base", "ExtractRequest"),
     "NavigateRequest": (".base", "NavigateRequest"),
     "NoCapableBackendError": (".base", "NoCapableBackendError"),
     "ScreenshotRequest": (".base", "ScreenshotRequest"),
     "SessionHandle": (".base", "SessionHandle"),
     "UnsafeUrlError": (".base", "UnsafeUrlError"),
+    "UnsupportedFormatError": (".base", "UnsupportedFormatError"),
     "Browser": (".registry", "Browser"),
     "clear_backends": (".registry", "clear_backends"),
     "get_browser": (".registry", "get_browser"),

--- a/autobot_shared/browser/base.py
+++ b/autobot_shared/browser/base.py
@@ -35,6 +35,30 @@ from enum import Enum
 from typing import Any, Protocol, runtime_checkable
 
 
+class ContentFormat(str, Enum):
+    """What shape extracted content comes back in (#13236).
+
+    `EXTRACT` used to mean "return the page's text/markup", which conflated
+    three different things the real callers need and the three stacks
+    produce:
+
+    - `web_fetch/_fetch_playwright` needs **HTML**; it feeds a parser.
+    - `content_reach` needs **text plus structured** data.
+    - `tool_handler`'s search fallback needs **text**.
+
+    Under one capability, a caller asking for `EXTRACT` could be routed to a
+    backend that returns text where it needed markup — a silent regression,
+    not an error. Format is now explicit and routable.
+    """
+
+    #: Human-readable page text, markup stripped.
+    TEXT = "text"
+    #: Raw HTML markup.
+    HTML = "html"
+    #: Parsed structure (headings, links, metadata) alongside text.
+    STRUCTURED = "structured"
+
+
 class Capability(str, Enum):
     """What a backend can do. Callers request these; backends declare them.
 
@@ -46,8 +70,12 @@ class Capability(str, Enum):
 
     #: Point the browser at a URL and report the resulting page state.
     NAVIGATE = "navigate"
-    #: Return the page's text/markup content.
-    EXTRACT = "extract"
+    #: Return page text, markup stripped.
+    EXTRACT_TEXT = "extract_text"
+    #: Return raw HTML markup.
+    EXTRACT_HTML = "extract_html"
+    #: Return parsed structure (headings, links, metadata) alongside text.
+    EXTRACT_STRUCTURED = "extract_structured"
     #: Capture a page image.
     SCREENSHOT = "screenshot"
     #: Click / fill / select. Requires ELEMENT_REFS in practice.
@@ -85,6 +113,14 @@ class NoCapableBackendError(BrowserError):
     """No registered backend both declares the capabilities and is reachable."""
 
 
+class UnsupportedFormatError(BrowserError):
+    """The resolved backend cannot produce the requested content format.
+
+    Raised rather than returning the wrong shape, which is what a single
+    `EXTRACT` capability allowed (#13236).
+    """
+
+
 class UnsafeUrlError(BrowserError):
     """The URL failed the DNS-resolving public-address guard.
 
@@ -92,6 +128,14 @@ class UnsafeUrlError(BrowserError):
     cannot forget the check — the gap #13204 records for
     ``send_to_browser_vm`` and ``services/playwright_service``.
     """
+
+
+#: Which capability a backend must declare to serve each content format.
+FORMAT_CAPABILITY: dict[ContentFormat, Capability] = {
+    ContentFormat.TEXT: Capability.EXTRACT_TEXT,
+    ContentFormat.HTML: Capability.EXTRACT_HTML,
+    ContentFormat.STRUCTURED: Capability.EXTRACT_STRUCTURED,
+}
 
 
 @dataclass(frozen=True)
@@ -126,6 +170,10 @@ class ExtractRequest:
     session_id: str | None = None
     selector: str | None = None
     max_chars: int | None = None
+    #: What shape to return. The registry refuses a backend that does not
+    #: declare the matching capability, so a caller cannot silently receive
+    #: text where it asked for markup (#13236).
+    format: ContentFormat = ContentFormat.TEXT
 
 
 @dataclass(frozen=True)

--- a/autobot_shared/browser/base.py
+++ b/autobot_shared/browser/base.py
@@ -174,6 +174,11 @@ class ExtractRequest:
     #: declare the matching capability, so a caller cannot silently receive
     #: text where it asked for markup (#13236).
     format: ContentFormat = ContentFormat.TEXT
+    #: Per-call timeout. `NavigateRequest` and `ScreenshotRequest` both carry
+    #: one; this was the odd one out, and `web_fetch/_fetch_playwright`
+    #: passes a timeout to the container's render today, so omitting it would
+    #: silently fall back to the container default (#13236).
+    timeout_seconds: float | None = None
 
 
 @dataclass(frozen=True)

--- a/autobot_shared/browser/registry.py
+++ b/autobot_shared/browser/registry.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 import logging
 
 from autobot_shared.browser.base import (
+    FORMAT_CAPABILITY,
     ActionRequest,
     BrowserBackend,
     BrowserResult,
@@ -45,6 +46,7 @@ from autobot_shared.browser.base import (
     ScreenshotRequest,
     SessionHandle,
     UnsafeUrlError,
+    UnsupportedFormatError,
 )
 from autobot_shared.url_safety import is_public_url_async
 
@@ -143,12 +145,29 @@ class Browser:
         return await self._backend.navigate(request)
 
     async def extract(self, request: ExtractRequest) -> BrowserResult:
-        """Read content, validating the URL when the request carries one.
+        """Read content in the requested format.
 
-        Stateless backends need an explicit URL because they hold no current
-        page; it is guarded exactly like a navigate URL (#13236).
+        Two checks before dispatch:
+
+        - the URL is guarded when the request carries one, because stateless
+          backends need an explicit URL and it reaches the network exactly
+          like a navigate URL;
+        - the resolved backend must declare the capability for
+          ``request.format``. Requiring a capability at ``get_browser`` time
+          and naming a format here are two statements that can disagree; this
+          ties them together so a caller cannot receive text where it asked
+          for markup (#13236).
         """
         await _guard_url(request.url)
+
+        needed = FORMAT_CAPABILITY[request.format]
+        if needed not in self._backend.capabilities:
+            raise UnsupportedFormatError(
+                f"backend {self._backend.name!r} cannot produce "
+                f"{request.format.value!r} (needs {needed.value!r}); "
+                f"require it in get_browser() so dispatch picks a backend that can"
+            )
+
         return await self._backend.extract(request)
 
     async def screenshot(self, request: ScreenshotRequest) -> BrowserResult:

--- a/autobot_shared/browser/registry_test.py
+++ b/autobot_shared/browser/registry_test.py
@@ -18,15 +18,18 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from autobot_shared.browser.base import (
+    FORMAT_CAPABILITY,
     ActionRequest,
     BrowserResult,
     Capability,
+    ContentFormat,
     ExtractRequest,
     NavigateRequest,
     NoCapableBackendError,
     ScreenshotRequest,
     SessionHandle,
     UnsafeUrlError,
+    UnsupportedFormatError,
 )
 from autobot_shared.browser.registry import (
     clear_backends,
@@ -128,11 +131,11 @@ async def test_extract_url_is_guarded_for_stateless_backends():
     reaches the network exactly like a navigate URL, so it cannot skip the
     check.
     """
-    backend = FakeBackend("fake", {Capability.EXTRACT})
+    backend = FakeBackend("fake", {Capability.EXTRACT_TEXT})
     register_backend(backend)
 
     with _deny():
-        browser = await get_browser(requires={Capability.EXTRACT})
+        browser = await get_browser(requires={Capability.EXTRACT_TEXT})
         with pytest.raises(UnsafeUrlError):
             await browser.extract(ExtractRequest(url="http://169.254.169.254/"))
 
@@ -142,11 +145,11 @@ async def test_extract_url_is_guarded_for_stateless_backends():
 @pytest.mark.asyncio
 async def test_extract_without_a_url_is_not_blocked():
     """Session-holding backends read their current page — nothing to validate."""
-    backend = FakeBackend("fake", {Capability.EXTRACT})
+    backend = FakeBackend("fake", {Capability.EXTRACT_TEXT})
     register_backend(backend)
 
     with _deny():
-        browser = await get_browser(requires={Capability.EXTRACT})
+        browser = await get_browser(requires={Capability.EXTRACT_TEXT})
         result = await browser.extract(ExtractRequest(session_id="s1"))
 
     assert result.success is True
@@ -155,12 +158,12 @@ async def test_extract_without_a_url_is_not_blocked():
 @pytest.mark.asyncio
 async def test_locality_narrows_dispatch():
     """#13236: a caller that must stay out-of-process cannot be routed in."""
-    in_proc = FakeBackend("in_proc", {Capability.EXTRACT, Capability.IN_PROCESS})
-    out_proc = FakeBackend("out_proc", {Capability.EXTRACT, Capability.OUT_OF_PROCESS})
+    in_proc = FakeBackend("in_proc", {Capability.EXTRACT_TEXT, Capability.IN_PROCESS})
+    out_proc = FakeBackend("out_proc", {Capability.EXTRACT_TEXT, Capability.OUT_OF_PROCESS})
     register_backend(in_proc)
     register_backend(out_proc)
 
-    chosen = await resolve_backend({Capability.EXTRACT, Capability.OUT_OF_PROCESS})
+    chosen = await resolve_backend({Capability.EXTRACT_TEXT, Capability.OUT_OF_PROCESS})
 
     assert chosen.name == "out_proc", "locality must pin dispatch, not just rank it"
 
@@ -298,10 +301,10 @@ async def test_result_names_the_backend_that_served_it():
 
 @pytest.mark.asyncio
 async def test_non_url_operations_reach_the_backend():
-    backend = FakeBackend("fake", {Capability.EXTRACT, Capability.INTERACT})
+    backend = FakeBackend("fake", {Capability.EXTRACT_TEXT, Capability.INTERACT})
     register_backend(backend)
 
-    browser = await get_browser(requires={Capability.EXTRACT})
+    browser = await get_browser(requires={Capability.EXTRACT_TEXT})
     await browser.extract(ExtractRequest(session_id="s1"))
     await browser.act(ActionRequest(action="click", selector="#go"))
     await browser.release(SessionHandle(session_id="s1", backend="fake"))
@@ -322,3 +325,73 @@ def test_shared_package_imports_nothing_app_local():
         for node in ast.walk(tree):
             if isinstance(node, ast.ImportFrom) and node.module:
                 assert not node.module.startswith(forbidden), f"{path.name} imports app-local {node.module!r}"
+
+
+# ---------------------------------------------------------------- formats
+
+
+@pytest.mark.asyncio
+async def test_html_request_cannot_resolve_to_a_text_only_backend():
+    """The regression #13236 exists to stop.
+
+    `web_fetch` renders HTML for a parser. The worker's `get_text` strips
+    markup, and both it and the container previously declared a single
+    `EXTRACT`, so dispatch could hand `web_fetch` text where it needed HTML —
+    silently, because that is a valid result shape.
+    """
+    text_only = FakeBackend("worker", {Capability.EXTRACT_TEXT, Capability.OUT_OF_PROCESS})
+    html_capable = FakeBackend("container", {Capability.EXTRACT_HTML, Capability.OUT_OF_PROCESS})
+    register_backend(text_only)  # registered first — would win on a bare EXTRACT
+    register_backend(html_capable)
+
+    chosen = await resolve_backend({Capability.EXTRACT_HTML, Capability.OUT_OF_PROCESS})
+
+    assert chosen.name == "container", "an HTML caller must not be routed to a text-only stack"
+
+
+@pytest.mark.asyncio
+async def test_requesting_a_format_the_backend_cannot_produce_raises():
+    """Requiring a capability and naming a format are two statements.
+
+    They can disagree; the registry ties them together rather than returning
+    the wrong shape.
+    """
+    backend = FakeBackend("text_only", {Capability.EXTRACT_TEXT})
+    register_backend(backend)
+
+    browser = await get_browser(requires={Capability.EXTRACT_TEXT})
+    with pytest.raises(UnsupportedFormatError, match="extract_html"):
+        await browser.extract(ExtractRequest(format=ContentFormat.HTML))
+
+    assert backend.calls == [], "backend was reached with a format it cannot serve"
+
+
+@pytest.mark.asyncio
+async def test_matching_format_passes_through():
+    backend = FakeBackend("html", {Capability.EXTRACT_HTML})
+    register_backend(backend)
+
+    browser = await get_browser(requires={Capability.EXTRACT_HTML})
+    result = await browser.extract(ExtractRequest(format=ContentFormat.HTML))
+
+    assert result.success is True
+    assert backend.calls == ["extract"]
+
+
+def test_every_content_format_maps_to_a_capability():
+    """A format added without a capability would raise KeyError at dispatch."""
+    for fmt in ContentFormat:
+        assert fmt in FORMAT_CAPABILITY
+        assert isinstance(FORMAT_CAPABILITY[fmt], Capability)
+
+
+@pytest.mark.asyncio
+async def test_text_is_the_default_format():
+    """Most callers want text; defaulting avoids a required argument."""
+    backend = FakeBackend("text", {Capability.EXTRACT_TEXT})
+    register_backend(backend)
+
+    browser = await get_browser(requires={Capability.EXTRACT_TEXT})
+    result = await browser.extract(ExtractRequest())
+
+    assert result.success is True

--- a/docs/adr/009-canonical-browser-interface.md
+++ b/docs/adr/009-canonical-browser-interface.md
@@ -119,7 +119,9 @@ Backends declare capabilities rather than implementing everything:
 ```python
 class Capability(StrEnum):
     NAVIGATE = "navigate"
-    EXTRACT = "extract"
+    EXTRACT_TEXT = "extract_text"          # amended, see below
+    EXTRACT_HTML = "extract_html"
+    EXTRACT_STRUCTURED = "extract_structured"
     SCREENSHOT = "screenshot"
     INTERACT = "interact"          # click/fill/select, needs element refs
     ELEMENT_REFS = "element_refs"
@@ -131,7 +133,7 @@ class Capability(StrEnum):
 A caller asks for capabilities, not a stack:
 
 ```python
-browser = await get_browser(requires={Capability.NAVIGATE, Capability.EXTRACT},
+browser = await get_browser(requires={Capability.NAVIGATE, Capability.EXTRACT_TEXT},
                             session_id=conversation_id)
 result = await browser.navigate(NavigateRequest(url=url))
 ```
@@ -265,11 +267,44 @@ if not result.get("success"):
 # After — the caller states requirements; dispatch and guard are the
 # interface's job.
 browser = await get_browser(
-    requires={Capability.NAVIGATE, Capability.EXTRACT},
+    requires={Capability.NAVIGATE, Capability.EXTRACT_TEXT},
     session_id=conversation_id,
 )
 page = await browser.navigate(NavigateRequest(url=search_url))
 ```
+
+## Amendments
+
+### 2026-08-02 — `EXTRACT` split by content format (#13236)
+
+Migrating the first real callers showed the single `EXTRACT` capability
+conflated three different outputs, and the three stacks each produce a
+different one:
+
+| stack | call | returns |
+|---|---|---|
+| container | `render` | HTML |
+| worker | `get_text` | text, markup stripped |
+| in-process | `extract_content()` | text + structured data |
+
+`web_fetch/_fetch_playwright` needs HTML for a parser; the worker registers
+before the container, so under one capability dispatch would have handed it
+text — a silent regression, since text is a valid result shape.
+
+Replaced with `EXTRACT_TEXT` / `EXTRACT_HTML` / `EXTRACT_STRUCTURED`, plus a
+`ContentFormat` on `ExtractRequest`. Requiring a capability and naming a
+format are two statements that can disagree, so the registry checks the
+resolved backend declares the capability for the requested format and raises
+`UnsupportedFormatError` rather than returning the wrong shape.
+
+Two earlier amendments from the same exercise are already in the code:
+locality capabilities (`IN_PROCESS` / `OUT_OF_PROCESS`) and
+`ExtractRequest.url` for stateless backends.
+
+**Step order revised.** This ADR nominated `content_reach` as the first
+migration ("smallest, already guarded"). That was wrong — it is the caller
+with the most stack-specific behaviour (structured extraction plus
+`blocked_by_guard`). `web_fetch` is the correct first migration.
 
 ## Related ADRs
 


### PR DESCRIPTION
Closes #13236

> **Partial — #13236 must stay OPEN.** The close keyword is required by the
> `Validate PR issue link` gate; merging to `Dev_new_gui` does not auto-close.
> **No caller is migrated** — this closes the last contract gap blocking
> migration. Steps 2–5 and **#13204** remain.

## Thinking Path

The fourth gap the real callers exposed, and the only one that would have
produced a **silent regression** rather than an error.

A single `EXTRACT` capability meant "return the page's text/markup". That
conflated three different outputs, and the three stacks each produce a
different one:

| stack | call | returns |
|---|---|---|
| container | `render` | **HTML** |
| worker | `get_text` | **text**, markup stripped |
| in-process | `extract_content()` | **text + structured** |

`web_fetch/_fetch_playwright` needs HTML — it feeds a parser. Both the worker
and the container declared `EXTRACT` and `OUT_OF_PROCESS`, and `register_all`
registers the **worker first**. So migrating `web_fetch` onto the interface
would have resolved to the worker and returned text.

Nothing would have raised. Text is a valid `BrowserResult.content`, so the
parser would simply have received the wrong thing — the failure mode that
only shows up as bad output much later.

## What Changed

**`EXTRACT` → `EXTRACT_TEXT` / `EXTRACT_HTML` / `EXTRACT_STRUCTURED`.** Each
backend now declares what it actually returns rather than that it "extracts".

**`ExtractRequest.format`** (a new `ContentFormat`, defaulting to `TEXT`).

**The two are tied together.** Requiring a capability at `get_browser` time
and naming a format on the request are separate statements that can disagree,
so `Browser.extract` checks the resolved backend declares
`FORMAT_CAPABILITY[request.format]` and raises `UnsupportedFormatError` rather
than returning the wrong shape.

**ADR-009 amended in the same commit**, not left to drift — it still
documented the single `EXTRACT`, and its step order nominated `content_reach`
as the first migration. The audit showed that is wrong: `content_reach` is the
caller with the *most* stack-specific behaviour (structured extraction plus
`blocked_by_guard` handling). `web_fetch` is the correct first migration, and
the amendment says so.

## A fifth gap, found by checking the contract end-to-end

After the split I checked whether `web_fetch` could actually be served, and it
still could not. `_fetch_playwright` sends
`timeout: int(timeout * 1000)` to the render endpoint, but `ExtractRequest`
had **no timeout field** — `NavigateRequest` and `ScreenshotRequest` both do,
so it was the odd one out — and `container.extract` sent no timeout at all.

Migrating would have silently dropped the caller's timeout and fallen back to
the container default. `ExtractRequest.timeout_seconds` now exists, the
container converts to the milliseconds its endpoint expects, and omits the key
entirely when the caller passes `None` so the container default still applies
rather than `timeout=0`.

## Verification

```
autobot_shared/browser + autobot-backend/browser_backends   46 passed  (was 36)
bandit                                                       0 issues
isort · black --line-length=120 · flake8                     clean
```

The load-bearing test uses the **real** backends under the **real**
registration order:

```python
register_all(force=True)
chosen = await resolve_backend({Capability.EXTRACT_HTML, Capability.OUT_OF_PROCESS})
assert chosen.name == "container"   # not "worker", which registers first
```

The others pin that a mismatched format raises *before* the backend is
reached (asserted against its call log), that every `ContentFormat` maps to a
capability so a new format cannot `KeyError` at dispatch, and that each
stack's declared formats match what its code actually returns.

I also checked no bare `Capability.EXTRACT` survives anywhere, including the
package docstring example — `grep` clean.

## What this does not do

- **No caller migrated.** Still additive.
- **#13204 untouched** — it closes only with the `tool_handler` migration.
- Step 2 (`web_fetch`) is now genuinely unblocked and behaviour-preserving:
  `{EXTRACT_HTML, OUT_OF_PROCESS}` resolves to the container — exactly what
  `_fetch_playwright` calls today — and its timeout survives the move.

## Model Used

Claude Opus 5 (1M context)
