### PR TITLE
refactor(web-fetch): render through the canonical browser interface (#13236)

### DIFF
--- a/autobot-backend/web_fetch/fetch_playwright_interface_test.py
+++ b/autobot-backend/web_fetch/fetch_playwright_interface_test.py
@@ -1,0 +1,144 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""`_fetch_playwright` goes through the canonical browser interface (#13236).
+
+ADR-009 step 2 — the first caller migrated off a directly-named stack.
+
+The migration is only safe if it lands on the *same* stack it called before.
+It nearly did not: the worker and the container both satisfy
+`EXTRACT + OUT_OF_PROCESS`, and `register_all` registers the worker first, so
+under the pre-#13306 contract this caller would have resolved to the worker
+and received `get_text` output — plain text where a parser expects HTML, with
+nothing raising because text is a valid result.
+
+These pin the properties that make it behaviour-preserving: the container
+serves it, the render payload is unchanged, the caller's timeout survives, and
+failure still yields `None` rather than propagating.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import browser_backends
+from autobot_shared.browser.base import Capability, ContentFormat
+from autobot_shared.browser.registry import clear_backends
+from browser_backends import ContainerBrowserBackend, InProcessBrowserBackend, WorkerBrowserBackend
+from web_fetch.fetcher import _fetch_playwright
+
+
+@pytest.fixture(autouse=True)
+def _registry():
+    clear_backends()
+    browser_backends._registered = False
+    yield
+    clear_backends()
+    browser_backends._registered = False
+
+
+def _all_probes_up():
+    """Probe reaches real transports; this is about routing, not reachability."""
+    return (
+        patch.object(ContainerBrowserBackend, "probe", AsyncMock(return_value=True)),
+        patch.object(WorkerBrowserBackend, "probe", AsyncMock(return_value=True)),
+        patch.object(InProcessBrowserBackend, "probe", AsyncMock(return_value=True)),
+    )
+
+
+@pytest.mark.asyncio
+async def test_renders_through_the_container_with_the_payload_it_always_sent():
+    """Same stack, same endpoint, same wait — and the timeout survives."""
+    service = MagicMock()
+    service._post_and_parse = AsyncMock(return_value={"html": "<html>page</html>"})
+
+    p_container, p_worker, p_inproc = _all_probes_up()
+    with (
+        patch("web_fetch.fetcher._is_public_url", AsyncMock(return_value=True)),
+        patch.object(ContainerBrowserBackend, "_service", staticmethod(AsyncMock(return_value=service))),
+        p_container,
+        p_worker,
+        p_inproc,
+    ):
+        html = await _fetch_playwright("https://example.com/", timeout=7.5)
+
+    assert html == "<html>page</html>"
+    endpoint, payload = service._post_and_parse.await_args.args
+    assert endpoint == "render"
+    assert payload["url"] == "https://example.com/"
+    assert payload["wait"] == "networkidle"
+    assert payload["timeout"] == 7500, "the caller's timeout must reach the render endpoint"
+
+
+@pytest.mark.asyncio
+async def test_the_worker_is_not_selected_even_though_it_registers_first():
+    """The regression #13306 prevents, asserted end to end from this caller."""
+    worker_called = AsyncMock()
+    service = MagicMock()
+    service._post_and_parse = AsyncMock(return_value={"html": "<html/>"})
+
+    p_container, p_worker, p_inproc = _all_probes_up()
+    with (
+        patch("web_fetch.fetcher._is_public_url", AsyncMock(return_value=True)),
+        patch.object(ContainerBrowserBackend, "_service", staticmethod(AsyncMock(return_value=service))),
+        patch.object(WorkerBrowserBackend, "extract", worker_called),
+        p_container,
+        p_worker,
+        p_inproc,
+    ):
+        await _fetch_playwright("https://example.com/", timeout=5.0)
+
+    worker_called.assert_not_awaited()
+    service._post_and_parse.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_a_non_public_url_never_reaches_a_backend():
+    """The inline guard is kept as defence in depth alongside the registry's."""
+    service = MagicMock()
+    service._post_and_parse = AsyncMock()
+
+    with (
+        patch("web_fetch.fetcher._is_public_url", AsyncMock(return_value=False)),
+        patch.object(ContainerBrowserBackend, "_service", staticmethod(AsyncMock(return_value=service))),
+    ):
+        result = await _fetch_playwright("http://169.254.169.254/", timeout=5.0)
+
+    assert result is None
+    service._post_and_parse.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_failure_still_returns_none_rather_than_raising():
+    """The render cascade depends on this returning None to try the next step."""
+    p_container, p_worker, p_inproc = _all_probes_up()
+    with (
+        patch("web_fetch.fetcher._is_public_url", AsyncMock(return_value=True)),
+        patch.object(
+            ContainerBrowserBackend, "_service", staticmethod(AsyncMock(side_effect=RuntimeError("container down")))
+        ),
+        p_container,
+        p_worker,
+        p_inproc,
+    ):
+        assert await _fetch_playwright("https://example.com/", timeout=5.0) is None
+
+
+@pytest.mark.asyncio
+async def test_no_capable_backend_returns_none_not_an_exception():
+    """Nothing registered at all must degrade, not propagate."""
+    with patch("web_fetch.fetcher._is_public_url", AsyncMock(return_value=True)):
+        with patch.object(browser_backends, "register_all", lambda **_: None):
+            assert await _fetch_playwright("https://example.com/", timeout=5.0) is None
+
+
+def test_the_requirements_describe_what_this_caller_needs():
+    """Documented so a later edit cannot quietly widen them."""
+    import inspect
+
+    src = inspect.getsource(_fetch_playwright)
+
+    assert "Capability.EXTRACT_HTML" in src, "a parser needs markup, not text"
+    assert "Capability.OUT_OF_PROCESS" in src, "Playwright must stay out of the backend process"
+    assert "ContentFormat.HTML" in src
+    assert str(Capability.EXTRACT_HTML.value) == "extract_html"
+    assert str(ContentFormat.HTML.value) == "html"

--- a/autobot-backend/web_fetch/fetcher.py
+++ b/autobot-backend/web_fetch/fetcher.py
@@ -227,23 +227,46 @@ async def _fetch_bs4(url: str, timeout: float) -> tuple[str | None, int | None]:
 
 
 async def _fetch_playwright(url: str, timeout: float) -> str | None:
-    """Fetch via Playwright bridge (services/playwright_service.py).
+    """Render *url* through the canonical browser interface (#13236, ADR-009).
 
-    SSRF guard enforced inline (defense in depth) — the Playwright service
-    runs in a separate container with potential network reach to private IPs,
-    so the URL must be validated even though the public ``WebFetcher.fetch``
-    pipeline already checks.
+    First caller migrated off a directly-named stack. The requirements express
+    what this fallback has always actually needed:
+
+    - ``EXTRACT_HTML`` — the result feeds a parser, so text will not do. Under
+      the earlier single ``EXTRACT`` capability the worker (registered first)
+      would have matched and returned ``get_text`` output, which is a valid
+      result shape and would have failed silently.
+    - ``OUT_OF_PROCESS`` — the whole point of this fallback is that Playwright
+      does not run inside the backend's own process.
+
+    Together those resolve to the container backend, which is exactly the
+    stack this function called directly before, with the same ``render``
+    endpoint and the caller's timeout preserved.
+
+    The inline SSRF check is **kept** even though the interface now enforces
+    the same DNS-resolving guard before dispatch. It is deliberate defence in
+    depth: the Playwright container has network reach to private IPs, and this
+    function is reachable from the render cascade, so the cost of one extra
+    resolution is worth not depending on a single chokepoint.
     """
     if not await _is_public_url(url):
         return None
     try:
-        from services.playwright_service import get_playwright_service
-
-        svc = await get_playwright_service()
-        result = await svc._post_and_parse(
-            "render", {"url": url, "wait": "networkidle", "timeout": int(timeout * 1000)}
+        import browser_backends
+        from autobot_shared.browser import (
+            Capability,
+            ContentFormat,
+            ExtractRequest,
+            get_browser,
         )
-        return result.get("html") or result.get("content")
+
+        browser_backends.register_all()  # idempotent
+
+        browser = await get_browser(
+            requires={Capability.EXTRACT_HTML, Capability.OUT_OF_PROCESS},
+        )
+        result = await browser.extract(ExtractRequest(url=url, format=ContentFormat.HTML, timeout_seconds=timeout))
+        return result.content if result.success else None
     except Exception as exc:
         logger.debug("Playwright fetch failed for %s: %s", url, exc)
         return None


### PR DESCRIPTION
Closes #13236

> **Partial — #13236 must stay OPEN.** The close keyword is required by the
> `Validate PR issue link` gate; merging to `Dev_new_gui` does not auto-close.
> This is **step 2 of 5**. Steps 3–5 (`content_reach`, `tool_handler`,
> `api/playwright`) remain, and **#13204** closes only with step 4.

## Thinking Path

The first caller migrated off a directly-named stack, now that the five
contract gaps the audit exposed are closed.

`_fetch_playwright` imported `services.playwright_service` directly. It now
declares what it actually needs and lets dispatch resolve it:

```python
requires={Capability.EXTRACT_HTML, Capability.OUT_OF_PROCESS}
```

**Both requirements are load-bearing, not decoration.** The worker and the
container *both* satisfy out-of-process extraction, and `register_all`
registers the **worker first**. Under the pre-#13306 single `EXTRACT`
capability this caller would have resolved to the worker and received
`get_text` output — plain text where a parser expects HTML, and **nothing
would have raised**, because text is a valid `content` value.

That is why this migration went second rather than first, and why the format
split had to land before it.

## What Changed

`autobot-backend/web_fetch/fetcher.py` — `_fetch_playwright` resolves a
browser by capability instead of importing a stack, and passes its timeout
through `ExtractRequest.timeout_seconds`.

**The inline SSRF check is kept**, not deferred to the registry's guard. The
container has network reach to private IPs, so one extra DNS resolution is
cheaper than depending on a single chokepoint — and the docstring now says so,
to stop a later reader deleting it as redundant.

`fetch_playwright_interface_test.py` — 6 tests.

## Verification

```
autobot-backend/tests/unit/web_fetch
  + tests/test_untrusted_web_content_boundary.py
  + autobot-backend/web_fetch                       186 passed
autobot_shared/browser + browser_backends            46 passed
bandit                                                0 issues
isort · black --line-length=120 · flake8              clean
```

The tests pin behaviour-preservation rather than just "it runs":

- it lands on the **container**, the same stack it called before;
- the `render` payload is unchanged — same endpoint, same `wait: networkidle`;
- the caller's timeout still reaches the endpoint, in milliseconds;
- **the worker is never selected**, asserted end-to-end from this caller
  despite it registering first — the exact silent swap this prevents;
- a non-public URL never reaches a backend;
- failure still returns `None`, so the render cascade falls through to the
  next step rather than propagating.

## What this does not do

- **#13204 is untouched.** It closes only with step 4 (`tool_handler`), which
  is the production behaviour change: the guard starts rejecting internal URLs
  that `send_to_browser_vm` accepts today. That step needs the existing
  `is_url_allowed` allowlist call sites enumerated first, and your sign-off.
- `content_reach` (step 3) is next and now unblocked — `BrowserResult.structured`
  exists for it.

## Model Used

Claude Opus 5 (1M context)
