### PR TITLE
fix(security): validate URLs at the browser transport, exempting the admin surface (#13204)

### DIFF
--- a/autobot-backend/api/browser_mcp.py
+++ b/autobot-backend/api/browser_mcp.py
@@ -77,6 +77,7 @@ from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.http_client import get_http_client
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.time_utils import now_utc
+from autobot_shared.url_safety import is_public_url_async
 from constants.network_constants import NetworkConstants
 from research_browser_manager import get_research_browser_manager
 from services.mcp_bridge_manifest import MCPBridgeManifest
@@ -631,10 +632,31 @@ async def get_browser_mcp_tools() -> List[MCPTool]:
 # Tool Implementations
 
 
+async def _reject_non_public_url(params: Metadata) -> None:
+    """Validate a ``url`` in *params* with the DNS-resolving guard (#13204).
+
+    No-op when the action carries no URL. Raises 403 rather than returning a
+    falsy result so a caller cannot mistake a blocked navigation for an empty
+    page.
+    """
+    url = params.get("url") if isinstance(params, dict) else None
+    if not url:
+        return
+
+    if not await is_public_url_async(str(url)):
+        logger.warning("Blocked browser navigation to non-public URL: %s", url)
+        raise HTTPException(
+            status_code=403,
+            detail="URL is not a public address",
+        )
+
+
 async def send_to_browser_vm(
     action: str,
     params: Metadata,
     session_id: str = DEFAULT_BROWSER_SESSION_ID,
+    *,
+    internal_ok: bool = False,
 ) -> Metadata:
     """
     Send automation command to Browser VM
@@ -645,7 +667,40 @@ async def send_to_browser_vm(
     Issue #11539: ``session_id`` is threaded on every call so the worker
     routes to the BrowserContext dedicated to that conversation instead of a
     single context shared (and its cookies leaked) across every caller.
+
+    #13204: any URL in *params* is validated here, at the transport itself.
+    This helper previously performed **no** validation, and it is reachable
+    from the agent tool path — ``chat_workflow/tool_handler.py`` forwards a
+    model-chosen ``tool_name`` with model-supplied ``params``, so a navigate
+    URL could come straight from the model to the browser worker.
+
+    The guard lives here rather than at each call site deliberately: it is the
+    one place every current *and future* caller passes through, so a new call
+    site cannot reintroduce the gap. An audit found only ``navigate`` carries
+    a URL at all — the rest pass selectors, scripts and indices — so this
+    validates the URL when present and leaves the others untouched.
+
+    Args:
+        internal_ok: Skip the public-address check. Set **only** by this
+            module's own ``/browser/mcp/*`` endpoints, which are an admin
+            browser-remote-control surface (router-level
+            ``check_admin_permission`` plus per-endpoint rate limiting).
+
+            That surface is deliberately allowed to reach internal hosts, and
+            the reason is worth recording so this exemption is not later
+            removed as a leftover: pointing the browser at an internal service
+            and reading what the page actually requests is how wrong API calls
+            get found and callers mapped to the right routes. Blocking
+            loopback and the VM range would remove that, which is what
+            ``ALLOWED_URL_PATTERNS``' loopback and VM-range entries exist for.
+
+            Callers carrying untrusted input — above all the agent tool path,
+            where ``tool_handler`` forwards a model-chosen tool name with
+            model-supplied params — must leave this False.
     """
+    if not internal_ok:
+        await _reject_non_public_url(params)
+
     try:
         http_client = get_http_client()
         payload = {
@@ -713,6 +768,7 @@ async def navigate_mcp(request: BrowserNavigateRequest) -> Metadata:
             "timeout": request.timeout,
         },
         session_id=request.session_id or DEFAULT_BROWSER_SESSION_ID,
+        internal_ok=True,
     )
 
     return {
@@ -741,6 +797,7 @@ async def click_mcp(request: BrowserClickRequest) -> Metadata:
         "click",
         {"selector": request.selector, "timeout": request.timeout},
         session_id=request.session_id or DEFAULT_BROWSER_SESSION_ID,
+        internal_ok=True,
     )
 
     return {
@@ -773,6 +830,7 @@ async def fill_mcp(request: BrowserFillRequest) -> Metadata:
             "timeout": request.timeout,
         },
         session_id=request.session_id or DEFAULT_BROWSER_SESSION_ID,
+        internal_ok=True,
     )
 
     return {
@@ -802,6 +860,7 @@ async def screenshot_mcp(request: BrowserScreenshotRequest) -> Metadata:
         "screenshot",
         {"selector": request.selector, "full_page": request.full_page},
         session_id=request.session_id or DEFAULT_BROWSER_SESSION_ID,
+        internal_ok=True,
     )
 
     return {
@@ -838,6 +897,7 @@ async def evaluate_mcp(request: BrowserEvaluateRequest) -> Metadata:
         "evaluate",
         {"script": request.script},
         session_id=request.session_id or DEFAULT_BROWSER_SESSION_ID,
+        internal_ok=True,
     )
 
     return {
@@ -870,6 +930,7 @@ async def wait_for_selector_mcp(request: BrowserWaitForSelectorRequest) -> Metad
             "state": request.state,
         },
         session_id=request.session_id or DEFAULT_BROWSER_SESSION_ID,
+        internal_ok=True,
     )
 
     return {
@@ -899,6 +960,7 @@ async def get_text_mcp(request: BrowserGetTextRequest) -> Metadata:
         "get_text",
         {"selector": request.selector},
         session_id=request.session_id or DEFAULT_BROWSER_SESSION_ID,
+        internal_ok=True,
     )
 
     return {
@@ -927,6 +989,7 @@ async def get_attribute_mcp(request: BrowserGetAttributeRequest) -> Metadata:
         "get_attribute",
         {"selector": request.selector, "attribute": request.attribute},
         session_id=request.session_id or DEFAULT_BROWSER_SESSION_ID,
+        internal_ok=True,
     )
 
     return {
@@ -956,6 +1019,7 @@ async def select_mcp(request: BrowserSelectRequest) -> Metadata:
         "select",
         {"selector": request.selector, "value": request.value},
         session_id=request.session_id or DEFAULT_BROWSER_SESSION_ID,
+        internal_ok=True,
     )
 
     return {
@@ -985,6 +1049,7 @@ async def hover_mcp(request: BrowserHoverRequest) -> Metadata:
         "hover",
         {"selector": request.selector},
         session_id=request.session_id or DEFAULT_BROWSER_SESSION_ID,
+        internal_ok=True,
     )
 
     return {
@@ -1014,6 +1079,7 @@ async def browser_state_mcp(request: BrowserStateRequest) -> Metadata:
         "browser_state",
         {},
         session_id=request.session_id or DEFAULT_BROWSER_SESSION_ID,
+        internal_ok=True,
     )
 
     return {
@@ -1045,6 +1111,7 @@ async def click_index_mcp(request: BrowserClickIndexRequest) -> Metadata:
             "expected_element_count": request.expected_element_count,
         },
         session_id=request.session_id or DEFAULT_BROWSER_SESSION_ID,
+        internal_ok=True,
     )
 
     return {
@@ -1078,6 +1145,7 @@ async def fill_index_mcp(request: BrowserFillIndexRequest) -> Metadata:
             "expected_element_count": request.expected_element_count,
         },
         session_id=request.session_id or DEFAULT_BROWSER_SESSION_ID,
+        internal_ok=True,
     )
 
     return {
@@ -1111,6 +1179,7 @@ async def select_index_mcp(request: BrowserSelectIndexRequest) -> Metadata:
             "expected_element_count": request.expected_element_count,
         },
         session_id=request.session_id or DEFAULT_BROWSER_SESSION_ID,
+        internal_ok=True,
     )
 
     return {
@@ -1140,6 +1209,7 @@ async def hover_index_mcp(request: BrowserHoverIndexRequest) -> Metadata:
         "hover_index",
         {"index": request.index, "expected_element_count": request.expected_element_count},
         session_id=request.session_id or DEFAULT_BROWSER_SESSION_ID,
+        internal_ok=True,
     )
 
     return {

--- a/autobot-backend/tests/unit/api/test_browser_mcp_session_isolation.py
+++ b/autobot-backend/tests/unit/api/test_browser_mcp_session_isolation.py
@@ -29,6 +29,18 @@ from api.browser_mcp import DEFAULT_BROWSER_SESSION_ID, send_to_browser_vm
 from tests.unit.api._fake_http_client import fake_http_client as _fake_http_client
 
 
+@pytest.fixture(autouse=True)
+def _allow_public_urls():
+    """#13204 added a DNS-resolving URL guard to ``send_to_browser_vm``.
+
+    These tests are about session-id routing, not URL validation, and a live
+    DNS lookup would make them depend on network access. Satisfy the guard so
+    they keep testing what they were written to test.
+    """
+    with patch("api.browser_mcp.is_public_url_async", AsyncMock(return_value=True)):
+        yield
+
+
 @pytest.mark.asyncio
 async def test_send_to_browser_vm_puts_session_id_on_the_wire():
     """Explicit session_id must appear verbatim in the /automation payload."""

--- a/autobot-backend/tests/unit/api/test_browser_mcp_url_guard.py
+++ b/autobot-backend/tests/unit/api/test_browser_mcp_url_guard.py
@@ -1,0 +1,114 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""`send_to_browser_vm` validates untrusted URLs, and only untrusted ones (#13204).
+
+The gap: this helper performed **no** URL validation and is reachable from the
+agent tool path — `chat_workflow/tool_handler.py` forwards a model-chosen
+`tool_name` with model-supplied `params`, so a navigate URL could travel from
+the model to the browser worker unchecked. `is_url_allowed` guarded exactly one
+HTTP endpoint, and is a regex over the string, so it cannot see where a host
+resolves.
+
+The guard sits at the transport because that is the one place every current and
+future caller passes through — a new call site cannot reintroduce the gap.
+
+The admin `/browser/mcp/*` endpoints opt out on purpose. They are behind
+`check_admin_permission` and rate limiting, and reaching internal hosts is the
+point of them: pointing the browser at an internal service and reading what the
+page requests is how wrong API calls get found. These tests pin **both** halves,
+because a later edit could plausibly break either.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from api.browser_mcp import _reject_non_public_url, send_to_browser_vm
+
+_GUARD = "api.browser_mcp.is_public_url_async"
+
+
+@pytest.mark.asyncio
+async def test_navigate_to_a_non_public_url_is_refused():
+    """The agent path: a model-supplied URL must not reach the worker."""
+    with patch(_GUARD, AsyncMock(return_value=False)):
+        with pytest.raises(HTTPException) as excinfo:
+            await send_to_browser_vm("navigate", {"url": "http://169.254.169.254/latest/meta-data/"})
+
+    assert excinfo.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_a_refused_url_never_reaches_the_transport():
+    """Raising after the POST would be no guard at all."""
+    with patch(_GUARD, AsyncMock(return_value=False)):
+        with patch("api.browser_mcp.get_http_client") as http:
+            with pytest.raises(HTTPException):
+                await send_to_browser_vm("navigate", {"url": "http://127.0.0.1:6379/"})
+
+    http.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_actions_without_a_url_are_not_blocked():
+    """Only `navigate` carries a URL; selectors and scripts must pass through."""
+    with patch(_GUARD, AsyncMock(return_value=False)) as guard:
+        await _reject_non_public_url({"selector": "#submit"})
+        await _reject_non_public_url({"script": "return 1"})
+        await _reject_non_public_url({"index": 3})
+        await _reject_non_public_url({})
+
+    guard.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_a_public_url_passes_the_guard():
+    with patch(_GUARD, AsyncMock(return_value=True)) as guard:
+        await _reject_non_public_url({"url": "https://example.com/"})
+
+    guard.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_admin_surface_may_still_reach_internal_hosts():
+    """internal_ok=True is how the admin endpoints keep working.
+
+    Removing this exemption would break the diagnostic use the surface exists
+    for — driving the browser at an internal service to see what it requests.
+    """
+    reached_transport = RuntimeError("reached the transport")
+
+    with patch(_GUARD, AsyncMock(return_value=False)) as guard:
+        with patch("api.browser_mcp.get_http_client", side_effect=reached_transport):
+            # Getting as far as the transport is the assertion: with the guard
+            # active this would have raised 403 before ever calling it.
+            with pytest.raises(RuntimeError, match="reached the transport"):
+                await send_to_browser_vm(
+                    "navigate",
+                    {"url": "http://localhost:3000/"},
+                    internal_ok=True,
+                )
+
+    guard.assert_not_awaited()
+
+
+def test_the_guard_defaults_to_enforced():
+    """A new caller that forgets the flag must be guarded, not exempt."""
+    import inspect
+
+    sig = inspect.signature(send_to_browser_vm)
+    param = sig.parameters["internal_ok"]
+
+    assert param.default is False
+    assert param.kind is inspect.Parameter.KEYWORD_ONLY, "must be explicit at the call site"
+
+
+def test_only_the_admin_endpoints_opt_out():
+    """The agent path must never pass internal_ok."""
+    import pathlib
+
+    root = pathlib.Path(__file__).resolve().parents[3]
+    tool_handler = (root / "chat_workflow/tool_handler.py").read_text(encoding="utf-8")
+
+    assert "internal_ok" not in tool_handler, "the agent tool path must stay guarded"


### PR DESCRIPTION
Closes #13204

## Thinking Path

`send_to_browser_vm` performed **no** URL validation, and it is reachable from
the agent tool path: `chat_workflow/tool_handler.py:2210` forwards a
model-chosen `tool_name` with model-supplied `params`, so a navigate URL could
travel from the model straight to the browser worker. `is_url_allowed` guarded
exactly **one** endpoint out of the module, and is a regex over the URL string,
so it cannot see where a hostname resolves.

**The guard goes at the transport, not at each call site.** That is the one
place every current *and future* caller passes through, so a new call site
cannot reintroduce the gap. Enumerating every call site first showed this is
narrower than it sounds — only `navigate` carries a URL at all:

```
6  "selector"    click / fill / hover / wait_for_selector / get_text ...
1  "script"      evaluate
1  "index" / "select_index" / "hover_index"
1  "navigate"    <- the only one with a URL
```

So the guard is a no-op for every other action.

### Why the admin surface is exempt

I first proposed enforcing this everywhere with an empty exception list, on the
evidence that no *production code* navigates to loopback. That reading was
incomplete, and you caught it: `/browser/mcp/*` is an **admin browser
remote-control surface** — 19 endpoints behind router-level
`check_admin_permission` plus per-endpoint rate limiting — and its callers are
not in the codebase. They are people.

Reaching internal hosts is the **point** of that surface: pointing the browser
at an internal service and reading what the page actually requests is how wrong
API calls get found and callers mapped to the right routes. That is what
`ALLOWED_URL_PATTERNS`' loopback and VM-range entries are for, and an empty
exception list would have removed a real diagnostic capability.

So those endpoints pass `internal_ok=True`, and **the reason is in the
docstring** rather than left implicit — otherwise the next audit reads the
exemption as a leftover and deletes it, exactly as I nearly did with the
allowlist.

## What Changed

- `send_to_browser_vm(..., *, internal_ok: bool = False)` — validates any
  `url` in `params` with `is_public_url_async` (DNS-resolving) before the POST.
- The 15 admin endpoint call sites pass `internal_ok=True`.
- `tool_handler.py` is untouched, so the agent path is guarded by default.
- `test_browser_mcp_session_isolation.py` made hermetic — it drives
  `send_to_browser_vm` with a real URL, which the new guard would resolve over
  DNS, turning a session-routing test into a network-dependent one.

`internal_ok` is **keyword-only and defaults to False**, so a caller that
forgets it is guarded rather than exempt.

## Verification

```
tests/unit/api + browser_backends + autobot_shared/browser   131 passed
bandit                                                         0 issues
isort · black --line-length=120 · flake8                       clean
```

Seven new tests pin both halves, because either could plausibly be broken by a
later edit:

- a non-public navigate URL is refused **403**, and `get_http_client` is never
  called — raising after the POST would be no guard at all;
- actions carrying selectors/scripts/indices are not blocked;
- **the admin surface can still reach internal hosts** — asserted by reaching
  the transport with the guard stubbed to reject;
- `internal_ok` is keyword-only and defaults to `False`;
- **`tool_handler.py` never passes `internal_ok`**, asserted by reading the
  file, so the agent path cannot be quietly exempted later.

## What this does not do

This closes the injection-reachable half of #13204 — the severity. The
remaining weakness is that `/mcp/navigate`'s own `is_url_allowed` is still a
regex rather than a resolving check. It is admin-gated and rate-limited, so it
is a hardening item rather than an exposure; worth a follow-up if you want it,
but replacing it with the resolving guard would need the internal-host
exceptions expressed explicitly, which is the design question this PR
deliberately leaves open.

ADR-009 steps 3 and 5 (`content_reach`, `api/playwright`) also remain, tracked
in #13236.

## Model Used

Claude Opus 5 (1M context)
