### PR TITLE
refactor(content-reach): route the browser backend through the canonical interface (#13236)

### DIFF
--- a/autobot-backend/browser_backends/in_process.py
+++ b/autobot-backend/browser_backends/in_process.py
@@ -57,8 +57,19 @@ class InProcessBrowserBackend:
         return get_research_browser_manager()
 
     async def probe(self) -> bool:
-        """Reachable whenever the manager module imports."""
+        """Reachable when Playwright is actually available to this process.
+
+        Importability is not the signal — ``research_browser_manager`` imports
+        fine without Playwright installed and exposes ``PLAYWRIGHT_AVAILABLE``
+        to say so. Reading the flag is what `content_reach` did before it
+        moved onto this interface, and probe must not be weaker than the check
+        it replaced (#13236).
+        """
         try:
+            import research_browser_manager as rbm
+
+            if not rbm.PLAYWRIGHT_AVAILABLE:
+                return False
             self._manager()
             return True
         except Exception as exc:
@@ -154,6 +165,10 @@ class InProcessBrowserBackend:
                 "browser_url": raw.get("browser_url"),
                 "actions": raw.get("actions"),
                 "mhtml_backup": content.get("mhtml_backup"),
-                "blocked_by_guard": navigation.get("blocked_by_guard"),
+                # #13018 rejections short-circuit research_url, which returns
+                # the navigate result *directly* — so the flag sits at the top
+                # level, not under "navigation". Reading only the nested spot
+                # silently dropped it (#13236).
+                "blocked_by_guard": navigation.get("blocked_by_guard") or raw.get("blocked_by_guard"),
             },
         )

--- a/autobot-backend/content_reach/backends/browser.py
+++ b/autobot-backend/content_reach/backends/browser.py
@@ -2,11 +2,17 @@
 # SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
-"""Shared browser-backed content backend using research_browser_manager (#10932).
+"""Shared browser-backed content backend (#10932, #13236).
 
-BrowserBackend wraps get_research_browser_manager().research_url() and maps its
-dict return to ContentResult.  Playwright availability is checked lazily (inside
-each method) so importing this module never loads the playwright stack.
+BrowserBackend asks the canonical browser interface for a browser that can
+navigate *and* extract structured content, and maps the ``BrowserResult`` onto
+``ContentResult``. It no longer names a stack: ``EXTRACT_STRUCTURED`` is what
+selects the research browser, because that is the only stack producing the
+``structured`` half of a ``ContentResult`` (ADR-009 step 3).
+
+Everything stays lazy — the interface, the backends and Playwright itself are
+imported inside the methods that need them, so importing this module never
+loads the browser stack.
 
 BrowserSearchBackend extends BrowserBackend for query→search: it builds a
 DuckDuckGo HTML search URL from the request query, then delegates to the browser
@@ -17,6 +23,11 @@ from __future__ import annotations
 
 from urllib.parse import quote_plus
 
+from autobot_shared.browser import (
+    Capability,
+    NavigateRequest,
+    get_browser,
+)
 from autobot_shared.logging_manager import get_logger
 from content_reach._url_guard import ensure_public_url, ensure_robots_allowed
 from content_reach.base import BackendError, ContentBackend, ContentRequest, ContentResult
@@ -27,19 +38,18 @@ logger = get_logger(__name__)
 _DDG_SEARCH_URL = "https://duckduckgo.com/html/?q={}"
 
 
-def _get_manager():
-    """Lazy accessor for the research browser manager (avoids import at module load)."""
-    from research_browser_manager import get_research_browser_manager
-
-    return get_research_browser_manager()
-
-
 class BrowserBackend(ContentBackend):
     """Content backend that uses the Playwright-based research browser manager.
 
     probe() returns PLAYWRIGHT_AVAILABLE — imported lazily to avoid loading the
     playwright stack at module import time.
     """
+
+    #: What this backend needs from a browser. EXTRACT_STRUCTURED because the
+    #: ContentResult carries `structured` alongside `text`, and only the
+    #: research stack produces it — so this both states the requirement and
+    #: pins the routing (#13236).
+    _REQUIRES = frozenset({Capability.NAVIGATE, Capability.EXTRACT_STRUCTURED})
 
     def __init__(
         self,
@@ -50,10 +60,22 @@ class BrowserBackend(ContentBackend):
         self.name = name
 
     async def probe(self) -> bool:
-        """Return True iff Playwright is available in this environment."""
-        import research_browser_manager as rbm
+        """True when a browser able to serve this backend is reachable.
 
-        return rbm.PLAYWRIGHT_AVAILABLE
+        Previously this read ``research_browser_manager.PLAYWRIGHT_AVAILABLE``
+        directly — a module-level flag on one stack. It now asks the same
+        question the fetch will ask, so probe and fetch cannot disagree
+        (#13236).
+        """
+        import browser_backends
+        from autobot_shared.browser import NoCapableBackendError, resolve_backend
+
+        browser_backends.register_all()
+        try:
+            await resolve_backend(self._REQUIRES)
+            return True
+        except NoCapableBackendError:
+            return False
 
     async def fetch(self, request: ContentRequest) -> ContentResult:
         """Navigate to request.url and return extracted content.
@@ -69,16 +91,21 @@ class BrowserBackend(ContentBackend):
         return await self._navigate(request)
 
     @staticmethod
-    def _raise_for_failed_result(result: dict, url: str) -> None:
-        """Raise BackendError for a failed research_url result, distinguishing
-        an SSRF-guard rejection (#13018 -- see research_browser_manager's
-        navigate_to re-check, tagged ``blocked_by_guard``) from any other
-        research_url failure, instead of one generic message for both.
+    def _raise_for_failed_result(result, url: str) -> None:
+        """Raise BackendError for a failed navigation, distinguishing an
+        SSRF-guard rejection (#13018 -- research_browser_manager re-checks the
+        guard immediately before Playwright resolves the host, and tags the
+        result ``blocked_by_guard``) from any other failure, instead of one
+        generic message for both.
+
+        #13236: reads the canonical ``BrowserResult`` rather than
+        ``research_url``'s dict. The guard flag survives the move because the
+        in-process backend carries it through in ``details``.
         """
-        if result.get("blocked_by_guard"):
+        if result.details.get("blocked_by_guard"):
             raise BackendError(f"BrowserBackend: blocked by SSRF guard at navigate time for {url!r}")
-        error = result.get("error", "unknown error")
-        raise BackendError(f"BrowserBackend: research_url failed for {url!r}: {error}")
+        error = result.error or "unknown error"
+        raise BackendError(f"BrowserBackend: navigation failed for {url!r}: {error}")
 
     async def _navigate(self, request: ContentRequest) -> ContentResult:
         """Issue the browser navigation call and map result to ContentResult.
@@ -90,29 +117,36 @@ class BrowserBackend(ContentBackend):
         before Playwright's own DNS resolution as a compensating control
         (#13018 -- narrows, does not close, that TOCTOU window).
         """
-        manager = _get_manager()
-        result = await manager.research_url(
-            request.conversation_id,
-            request.url,
-            extract_content=True,
+        import browser_backends
+
+        browser_backends.register_all()  # idempotent
+
+        browser = await get_browser(requires=self._REQUIRES, session_id=request.conversation_id)
+        result = await browser.navigate(
+            NavigateRequest(
+                url=request.url,
+                session_id=request.conversation_id,
+                # research_url does navigation and extraction in one round
+                # trip; asking here avoids navigating twice.
+                extract=True,
+            )
         )
 
-        if not result.get("success"):
+        if not result.success:
             self._raise_for_failed_result(result, request.url)
-
-        content = result.get("content") or {}
-        text = content.get("text_content", "")
-        structured = content.get("structured_data") or {}
 
         return ContentResult(
             success=True,
             source_type=self.source_type,
             backend_used=self.name,
-            text=text,
-            structured=structured,
+            text=result.content or "",
+            structured=result.structured,
             url=request.url,
             reliability=SourceReliability.MEDIUM,
-            metadata={"title": result.get("title", "")},
+            # The old code read a top-level "title" that research_url never
+            # returned, so this was always "". The canonical result carries
+            # the real page title (#13236).
+            metadata={"title": result.title or ""},
         )
 
 

--- a/autobot-backend/tests/content_reach/backends/test_browser.py
+++ b/autobot-backend/tests/content_reach/backends/test_browser.py
@@ -58,7 +58,7 @@ async def test_browser_probe_reflects_playwright_available_false(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_browser_fetch_maps_research_result(monkeypatch):
+async def test_browser_fetch_maps_research_result(monkeypatch, stub_browser_manager):
     stub_manager = _StubManager(
         {
             "success": True,
@@ -69,9 +69,8 @@ async def test_browser_fetch_maps_research_result(monkeypatch):
             "title": "T",
         }
     )
-    import content_reach.backends.browser as browser_mod
 
-    monkeypatch.setattr(browser_mod, "_get_manager", lambda: stub_manager)
+    stub_browser_manager(stub_manager)
 
     backend = BrowserBackend(source_type=SourceType.WEB_PAGE)
     request = ContentRequest(url="https://example.com", query="")
@@ -85,10 +84,9 @@ async def test_browser_fetch_maps_research_result(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_browser_fetch_raises_without_url(monkeypatch):
-    import content_reach.backends.browser as browser_mod
+async def test_browser_fetch_raises_without_url(monkeypatch, stub_browser_manager):
 
-    monkeypatch.setattr(browser_mod, "_get_manager", lambda: _StubManager({}))
+    stub_browser_manager(_StubManager({}))
 
     backend = BrowserBackend(source_type=SourceType.WEB_PAGE)
     request = ContentRequest(query="x")  # url defaults to ""
@@ -97,11 +95,10 @@ async def test_browser_fetch_raises_without_url(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_browser_fetch_raises_on_unsuccessful(monkeypatch):
+async def test_browser_fetch_raises_on_unsuccessful(monkeypatch, stub_browser_manager):
     stub_manager = _StubManager({"success": False, "error": "Failed to create browser session"})
-    import content_reach.backends.browser as browser_mod
 
-    monkeypatch.setattr(browser_mod, "_get_manager", lambda: stub_manager)
+    stub_browser_manager(stub_manager)
 
     backend = BrowserBackend(source_type=SourceType.WEB_PAGE)
     request = ContentRequest(url="https://example.com")
@@ -110,16 +107,15 @@ async def test_browser_fetch_raises_on_unsuccessful(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_browser_fetch_distinguishes_guard_rejection_from_generic_failure(monkeypatch):
+async def test_browser_fetch_distinguishes_guard_rejection_from_generic_failure(monkeypatch, stub_browser_manager):
     """Issue #13018: a navigate_to guard rejection (blocked_by_guard=True) must
     raise a distinctly-worded BackendError, not the generic navigation-failure
     message used for other research_url failures."""
     stub_manager = _StubManager(
         {"success": False, "error": "blocked by SSRF guard: non-public address", "blocked_by_guard": True}
     )
-    import content_reach.backends.browser as browser_mod
 
-    monkeypatch.setattr(browser_mod, "_get_manager", lambda: stub_manager)
+    stub_browser_manager(stub_manager)
 
     backend = BrowserBackend(source_type=SourceType.WEB_PAGE)
     request = ContentRequest(url="https://example.com")
@@ -133,7 +129,7 @@ async def test_browser_fetch_distinguishes_guard_rejection_from_generic_failure(
 
 
 @pytest.mark.asyncio
-async def test_browser_search_builds_ddg_url(monkeypatch):
+async def test_browser_search_builds_ddg_url(monkeypatch, stub_browser_manager):
     stub_manager = _StubManager(
         {
             "success": True,
@@ -141,9 +137,8 @@ async def test_browser_search_builds_ddg_url(monkeypatch):
             "title": "DDG",
         }
     )
-    import content_reach.backends.browser as browser_mod
 
-    monkeypatch.setattr(browser_mod, "_get_manager", lambda: stub_manager)
+    stub_browser_manager(stub_manager)
 
     backend = BrowserSearchBackend(source_type=SourceType.WEB_SEARCH)
     request = ContentRequest(query="cats dogs")

--- a/autobot-backend/tests/content_reach/backends/test_browser_get_manager.py
+++ b/autobot-backend/tests/content_reach/backends/test_browser_get_manager.py
@@ -2,22 +2,42 @@
 # SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
-"""Smoke test: _get_manager() actually resolves to the ResearchBrowserManager singleton (#11078).
+"""Smoke test: the research-browser import path resolves to the singleton (#11078).
 
-This test exercises the real import path so the line is covered and the pragma
-no-cover comment has been removed from browser.py.
+This originally covered `content_reach.backends.browser._get_manager`. That
+helper is gone — `content_reach` reaches the browser through the canonical
+interface now (#13236, ADR-009 step 3) rather than importing one stack.
+
+The property #11078 cared about is unchanged and still worth covering: the lazy
+import actually resolves, and it resolves to the *singleton* rather than a
+fresh manager (a second instance would mean per-caller browser sessions). It
+just lives one layer down, in the in-process backend `content_reach` routes to.
 """
 
 from __future__ import annotations
 
 
-def test_get_manager_returns_research_browser_manager_singleton():
-    """_get_manager() returns the ResearchBrowserManager singleton (import path works)."""
-    from content_reach.backends.browser import _get_manager
+def test_in_process_backend_resolves_the_research_manager_singleton():
+    """The backend's lazy accessor returns the ResearchBrowserManager singleton."""
+    from browser_backends import InProcessBrowserBackend
     from research_browser_manager import ResearchBrowserManager, get_research_browser_manager
 
-    manager = _get_manager()
+    manager = InProcessBrowserBackend._manager()
 
-    # Must be the same singleton returned by the canonical accessor.
     assert manager is get_research_browser_manager()
     assert isinstance(manager, ResearchBrowserManager)
+
+
+def test_content_reach_no_longer_imports_a_stack_directly():
+    """ADR-009's goal, asserted structurally: no caller names a stack."""
+    import ast
+    import pathlib
+
+    src = pathlib.Path(__file__).resolve().parents[3] / "content_reach/backends/browser.py"
+    tree = ast.parse(src.read_text(encoding="utf-8"))
+
+    imported = {node.module for node in ast.walk(tree) if isinstance(node, ast.ImportFrom) and node.module} | {
+        alias.name for node in ast.walk(tree) if isinstance(node, ast.Import) for alias in node.names
+    }
+
+    assert "research_browser_manager" not in imported, "content_reach must route through the interface"

--- a/autobot-backend/tests/content_reach/conftest.py
+++ b/autobot-backend/tests/content_reach/conftest.py
@@ -1,0 +1,60 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Shared browser stubbing for content_reach tests (#13236).
+
+`content_reach/backends/browser.py` used to call `_get_manager()` directly, so
+tests injected a stub by patching that module attribute. It now goes through
+the canonical browser interface (ADR-009 step 3), and the equivalent seam is
+the in-process backend's `_manager`.
+
+`stub_browser_manager` keeps the injection a one-liner at each call site: hand
+it the same stub manager the test already builds, and it registers the real
+backends, points the in-process one at the stub, and forces `probe()` true so
+routing is exercised without reaching a real transport.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import browser_backends
+from autobot_shared.browser.registry import clear_backends
+from browser_backends import ContainerBrowserBackend, InProcessBrowserBackend, WorkerBrowserBackend
+
+
+@pytest.fixture
+def stub_browser_manager():
+    """Return a callable that installs *stub* behind the browser interface.
+
+    Usage mirrors the old `monkeypatch.setattr(browser_mod, "_get_manager", ...)`::
+
+        def test_x(stub_browser_manager):
+            stub_browser_manager(_StubManager({...}))
+            ...
+    """
+    stack: list = []
+
+    def _install(stub):
+        clear_backends()
+        browser_backends._registered = False
+        browser_backends.register_all(force=True)
+
+        patches = [
+            patch.object(InProcessBrowserBackend, "_manager", staticmethod(lambda: stub)),
+            # probe() reaches real transports; these tests are about content
+            # mapping and the URL guard, not reachability.
+            patch.object(InProcessBrowserBackend, "probe", AsyncMock(return_value=True)),
+            patch.object(WorkerBrowserBackend, "probe", AsyncMock(return_value=False)),
+            patch.object(ContainerBrowserBackend, "probe", AsyncMock(return_value=False)),
+        ]
+        for p in patches:
+            p.start()
+            stack.append(p)
+        return stub
+
+    yield _install
+
+    for p in reversed(stack):
+        p.stop()
+    clear_backends()
+    browser_backends._registered = False

--- a/autobot-backend/tests/content_reach/sources/test_social.py
+++ b/autobot-backend/tests/content_reach/sources/test_social.py
@@ -47,7 +47,7 @@ def test_build_social_chain():
 
 
 @pytest.mark.asyncio
-async def test_social_fetch_carries_social_source_type(monkeypatch):
+async def test_social_fetch_carries_social_source_type(monkeypatch, stub_browser_manager):
     """BrowserBackend(SOCIAL).fetch() maps the stub result and carries source_type=SOCIAL."""
     stub_manager = _StubManager(
         {
@@ -61,14 +61,13 @@ async def test_social_fetch_carries_social_source_type(monkeypatch):
     )
 
     import content_reach._url_guard as guard_mod
-    import content_reach.backends.browser as browser_mod
 
     async def _always_public(_url: str) -> bool:
         return True
 
     monkeypatch.setattr(guard_mod, "_is_public_url_async", _always_public)
     monkeypatch.setattr(guard_mod, "_RESPECT_ROBOTS", False)
-    monkeypatch.setattr(browser_mod, "_get_manager", lambda: stub_manager)
+    stub_browser_manager(stub_manager)
 
     from content_reach.sources.social import build_social_chain
 

--- a/autobot-backend/tests/content_reach/test_url_guard.py
+++ b/autobot-backend/tests/content_reach/test_url_guard.py
@@ -233,10 +233,9 @@ async def test_jina_reader_ssrf_block_no_fetch(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_browser_backend_ssrf_block_no_manager_call(monkeypatch):
+async def test_browser_backend_ssrf_block_no_manager_call(monkeypatch, stub_browser_manager):
     """BrowserBackend.fetch raises BackendError on private URL and never calls manager."""
     import content_reach._url_guard as guard_mod
-    import content_reach.backends.browser as browser_mod
     from content_reach.backends.browser import BrowserBackend
     from content_reach.base import BackendError, ContentRequest
     from source_attribution import SourceType
@@ -253,7 +252,7 @@ async def test_browser_backend_ssrf_block_no_manager_call(monkeypatch):
             manager_calls.append(url)
             return {"success": True, "content": {"text_content": "x", "structured_data": {}}}
 
-    monkeypatch.setattr(browser_mod, "_get_manager", lambda: _StubManager())
+    stub_browser_manager(_StubManager())
 
     backend = BrowserBackend(source_type=SourceType.WEB_PAGE)
     request = ContentRequest(url="http://192.168.1.1/internal")
@@ -376,10 +375,9 @@ async def test_yt_dlp_ssrf_block_caption_url_no_http(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_browser_search_ssrf_block_ddg_url(monkeypatch):
+async def test_browser_search_ssrf_block_ddg_url(monkeypatch, stub_browser_manager):
     """BrowserSearchBackend raises BackendError when SSRF guard blocks the DDG URL."""
     import content_reach._url_guard as guard_mod
-    import content_reach.backends.browser as browser_mod
     from content_reach.backends.browser import BrowserSearchBackend
     from content_reach.base import BackendError, ContentRequest
     from source_attribution import SourceType
@@ -396,7 +394,7 @@ async def test_browser_search_ssrf_block_ddg_url(monkeypatch):
             manager_calls.append(url)
             return {"success": True, "content": {"text_content": "x", "structured_data": {}}}
 
-    monkeypatch.setattr(browser_mod, "_get_manager", lambda: _StubManager())
+    stub_browser_manager(_StubManager())
 
     backend = BrowserSearchBackend(source_type=SourceType.WEB_SEARCH)
     request = ContentRequest(query="test query")


### PR DESCRIPTION
Closes #13236

> **Partial — #13236 must stay OPEN.** The close keyword is required by the
> `Validate PR issue link` gate. This is **step 3 of 5**; step 5
> (`api/playwright`) remains.

## Thinking Path

`content_reach` no longer imports `research_browser_manager`. It states what it
needs and lets dispatch resolve it:

```python
_REQUIRES = frozenset({Capability.NAVIGATE, Capability.EXTRACT_STRUCTURED})
```

`EXTRACT_STRUCTURED` is both the honest requirement and what pins the routing:
`ContentResult` carries `structured` alongside `text`, and the research stack is
the only one that produces it.

## What Changed

- `content_reach/backends/browser.py` — `_navigate` resolves a browser by
  capability instead of importing `research_browser_manager`; `probe()` asks
  the interface the same question the fetch will ask; `_raise_for_failed_result`
  reads the canonical `BrowserResult`; `_get_manager` removed; module docstring
  corrected.
- `browser_backends/in_process.py` — the two wrapper bugs described below.
- `tests/content_reach/conftest.py` — new shared `stub_browser_manager` fixture.
- 4 test files converted onto it; the #11078 smoke test repointed.

## Migrating a second real caller found two bugs in the wrapper I shipped

Both are in `InProcessBrowserBackend` from #13226, and both are fixed here at
the source rather than worked around:

**1. An SSRF-guard rejection was silently losing its flag.** `research_url`
short-circuits on a #13018 guard block and returns the navigate result
**directly** — so `blocked_by_guard` sits at the *top level*, while `_to_result`
only read it from the nested `"navigation"` key. `content_reach` distinguishes
"blocked by SSRF guard" from a generic failure in its error message, and that
distinction would have quietly vanished. Caught because an existing test
asserts the specific message.

**2. `probe()` was weaker than the check it replaced.** It only verified that
`research_browser_manager` imports — but that module imports fine *without*
Playwright installed and exposes `PLAYWRIGHT_AVAILABLE` to say so, which is
exactly what `content_reach.probe()` read before. It now reads the flag.

## The test conversion

Five files patched `content_reach.backends.browser._get_manager` to inject a
stub, **including the two SSRF-guard test files** — the reason I flagged this
step as having more blast radius than its size suggests.

They now use a shared `stub_browser_manager` fixture
(`tests/content_reach/conftest.py`) that registers the real backends and points
the in-process one at the *same stub object the tests already build*. The
injection stays a one-liner at each call site, so the tests kept their original
shape and assertions.

`_get_manager` is removed — nothing referenced it after the migration. Its
#11078 smoke test is **repointed rather than deleted**: the property it covered
(the lazy import resolves to the **singleton**, not a fresh manager — a second
instance would mean per-caller browser sessions) still matters, it just lives
one layer down now. A new structural test asserts `content_reach` imports no
stack directly.

**Incidental fix:** `metadata["title"]` read a top-level `"title"` that
`research_url` never returned, so it was always `""`. The canonical result
carries the real page title.

## Verification

```
tests/content_reach                                   147 passed  (baseline 146)
+ browser_backends + autobot_shared/browser + web_fetch  199 passed
bandit                                                  0 issues
isort · black --line-length=120 · flake8                clean
```

Verified against the **146-passing baseline** captured before touching
anything, as I said I would — every original test still passes; the extra one
is the new structural check.

## Model Used

Claude Opus 5 (1M context)
