### PR TITLE
fix(slm-tests): code-sync unit tests dead-waited 180s on live health polls (#13312)

### DIFF
--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -1741,7 +1741,17 @@ _FAST_HEALTH_POLL_TIMEOUT: float = float(
     os.environ.get("AUTOBOT_HEALTH_POLL_TIMEOUT_FAST", _FAST_HEALTH_POLL_TIMEOUT_S)
 )
 # Per-attempt connect timeout (seconds) when probing the health endpoint.
-_HEALTH_POLL_CONNECT_TIMEOUT: float = 3.0
+_DEFAULT_HEALTH_POLL_CONNECT_TIMEOUT_S = "3"
+_HEALTH_POLL_CONNECT_TIMEOUT: float = float(
+    os.environ.get("AUTOBOT_HEALTH_POLL_CONNECT_TIMEOUT", _DEFAULT_HEALTH_POLL_CONNECT_TIMEOUT_S)
+)
+# Delay between health-probe attempts (seconds). Env-overridable alongside the
+# windows above so the whole poll shape is configurable from one place rather
+# than a literal buried in the loop.
+_DEFAULT_HEALTH_POLL_INTERVAL_S = "2"
+_HEALTH_POLL_INTERVAL: float = float(
+    os.environ.get("AUTOBOT_HEALTH_POLL_INTERVAL", _DEFAULT_HEALTH_POLL_INTERVAL_S)
+)
 # Per-component health URLs (localhost only — never egress).
 _COMPONENT_HEALTH_URLS: Dict[str, str] = {
     "autobot-backend": "http://127.0.0.1:8001/api/health",
@@ -2375,7 +2385,7 @@ async def _wait_component_healthy(component: str, steps: List[str], *, slow_star
                 return True
         except Exception:
             pass
-        await asyncio.sleep(2.0)
+        await asyncio.sleep(_HEALTH_POLL_INTERVAL)
 
     # Timeout reached but no systemd failure — the unit may still be starting
     # (e.g. py3.14 venv cold-start). Warn but do NOT roll back (#11413).
@@ -2385,7 +2395,7 @@ async def _wait_component_healthy(component: str, steps: List[str], *, slow_star
         return False
     steps.append(
         f"health: {component} did not respond within {timeout:.0f}s"
-        " — unit not failed; deploy treated as successful (check {url} manually)"
+        f" — unit not failed; deploy treated as successful (check {url} manually)"
     )
     logger.warning("health: %s timeout after %.0fs but unit not failed — proceeding", component, timeout)
     return True

--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -1749,9 +1749,7 @@ _HEALTH_POLL_CONNECT_TIMEOUT: float = float(
 # windows above so the whole poll shape is configurable from one place rather
 # than a literal buried in the loop.
 _DEFAULT_HEALTH_POLL_INTERVAL_S = "2"
-_HEALTH_POLL_INTERVAL: float = float(
-    os.environ.get("AUTOBOT_HEALTH_POLL_INTERVAL", _DEFAULT_HEALTH_POLL_INTERVAL_S)
-)
+_HEALTH_POLL_INTERVAL: float = float(os.environ.get("AUTOBOT_HEALTH_POLL_INTERVAL", _DEFAULT_HEALTH_POLL_INTERVAL_S))
 # Per-component health URLs (localhost only — never egress).
 _COMPONENT_HEALTH_URLS: Dict[str, str] = {
     "autobot-backend": "http://127.0.0.1:8001/api/health",

--- a/autobot-slm-backend/conftest.py
+++ b/autobot-slm-backend/conftest.py
@@ -24,6 +24,7 @@ Issue: #3499
 """
 
 import ast
+import importlib
 import sys
 import types
 from pathlib import Path
@@ -39,6 +40,49 @@ _api_mod.__path__ = [_API_DIR]  # type: ignore[assignment]
 _api_mod.__package__ = "api"
 _api_mod.__spec__ = None  # type: ignore[assignment]
 sys.modules.setdefault("api", _api_mod)
+
+
+# ---------------------------------------------------------------------------
+# Warning modules the xdist controller must still be able to import (#13312)
+# ---------------------------------------------------------------------------
+# pytest-xdist rebuilds every worker warning in the CONTROLLER process by
+# importing the warning class's module
+# (xdist.workermanage.unserialize_warning_message).  The controller loads this
+# conftest too, so the stubs above make ``sqlalchemy`` a non-package there and
+# ``import sqlalchemy.exc`` — home of SAWarning — raises ModuleNotFoundError.
+# xdist has no guard for that: the node goes down and the whole session ends in
+# an INTERNALERROR, losing every result.
+#
+# Whether it fires is pure scheduling luck (``--dist loadscope`` hands scopes to
+# whichever worker is free), which is why it stayed latent until the code-sync
+# tests stopped spending ~780s on dead health-poll wait and changed the
+# distribution.  Keep the REAL warning module in sys.modules so the import
+# resolves, while the stub still shadows the package for the tests.
+_REAL_WARNING_MODULES = ("sqlalchemy.exc",)
+
+
+def _import_real_module(name: str):
+    """Import *name* for real, leaving the surrounding stub tree untouched."""
+    root = name.split(".")[0]
+    saved = {m: mod for m, mod in sys.modules.items() if m == root or m.startswith(f"{root}.")}
+    for stale in saved:
+        del sys.modules[stale]
+    try:
+        return importlib.import_module(name)
+    except ImportError:
+        return None
+    finally:
+        for m in [m for m in sys.modules if m == root or m.startswith(f"{root}.")]:
+            del sys.modules[m]
+        sys.modules.update(saved)
+
+
+def _preserve_real_warning_modules() -> None:
+    """Re-register the real warning modules on top of the stubbed parents."""
+    for name in _REAL_WARNING_MODULES:
+        real = _import_real_module(name)
+        if real is not None:
+            sys.modules[name] = real
 
 
 # ---------------------------------------------------------------------------
@@ -92,6 +136,8 @@ for _m in [
     "sqlalchemy.orm",
 ]:
     _stub(_m)
+
+_preserve_real_warning_modules()
 
 # ── models ────────────────────────────────────────────────────────────────────
 # Both the parent package and each submodule must be in sys.modules so that

--- a/autobot-slm-backend/conftest.py
+++ b/autobot-slm-backend/conftest.py
@@ -58,6 +58,11 @@ sys.modules.setdefault("api", _api_mod)
 # tests stopped spending ~780s on dead health-poll wait and changed the
 # distribution.  Keep the REAL warning module in sys.modules so the import
 # resolves, while the stub still shadows the package for the tests.
+#
+# This is a whitelist of exactly one: any other warning module under a stubbed
+# package — ``sqlalchemy.orm.exc`` is the obvious next one — still raises the
+# identical ModuleNotFoundError in the controller.  Add it here when a worker
+# starts emitting from it rather than rediscovering the INTERNALERROR.
 _REAL_WARNING_MODULES = ("sqlalchemy.exc",)
 
 
@@ -69,7 +74,11 @@ def _import_real_module(name: str):
         del sys.modules[stale]
     try:
         return importlib.import_module(name)
-    except ImportError:
+    except Exception:
+        # Deliberately broad: this runs at conftest import, so anything escaping
+        # here (a C-extension load failure, a version guard, an env assertion)
+        # takes the entire session down — strictly worse than skipping the
+        # preload and leaving the original xdist crash possible.
         return None
     finally:
         for m in [m for m in sys.modules if m == root or m.startswith(f"{root}.")]:
@@ -81,8 +90,17 @@ def _preserve_real_warning_modules() -> None:
     """Re-register the real warning modules on top of the stubbed parents."""
     for name in _REAL_WARNING_MODULES:
         real = _import_real_module(name)
-        if real is not None:
-            sys.modules[name] = real
+        if real is None:
+            continue
+        sys.modules[name] = real
+        # Bind onto the stub parent too: ``from sqlalchemy.exc import X`` reads
+        # sys.modules while ``patch("sqlalchemy.exc.X")`` resolves via
+        # getattr(sys.modules["sqlalchemy"], "exc").  Without this the two see
+        # different objects — the divergence _stub()'s own docstring (#9780)
+        # exists to prevent.
+        parent, _, child = name.rpartition(".")
+        if parent in sys.modules:
+            setattr(sys.modules[parent], child, real)
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-slm-backend/tests/api/conftest.py
+++ b/autobot-slm-backend/tests/api/conftest.py
@@ -40,29 +40,42 @@ if "python_multipart" not in sys.modules:
 
 
 # ---------------------------------------------------------------------------
-# #13312 — no live health polls from the unit gate
+# #13312 — the unit gate never touches the network, the system, or the install
 # ---------------------------------------------------------------------------
-# api.code_sync._wait_component_healthy probes a component's HTTP health URL
-# every _HEALTH_POLL_INTERVAL seconds until _HEALTH_POLL_TIMEOUT (180s) or
-# _FAST_HEALTH_POLL_TIMEOUT (60s).  A _run_post_sync_steps test that does not
-# mock the poll therefore performs real outbound requests and burns the whole
-# window as dead wait — on a runner where nothing listens on the health port
-# that is ~180s per test.  This has now been fixed three times test-by-test
-# (#11462, #11467, #13312), so the guard lives here instead of in each file.
+# Two escape hatches in api/code_sync.py turn a forgotten mock into real I/O:
 #
-# httpx.AsyncClient is used by exactly one place in api/code_sync.py — the
-# health poll — so replacing it for the code-sync modules cannot mask anything
-# else.  Tests that legitimately exercise the poll install their own
-# httpx.AsyncClient stand-in inside the test body; that inner patch wins over
-# this fixture, so they are unaffected.
+#   * _wait_component_healthy probes a component's HTTP health URL every
+#     _HEALTH_POLL_INTERVAL seconds until _HEALTH_POLL_TIMEOUT (180s) or
+#     _FAST_HEALTH_POLL_TIMEOUT (60s) expires, swallowing every per-attempt
+#     error.  Unmocked, that is ~90 live requests and the whole window as dead
+#     wait on a runner where nothing listens.
+#   * _snapshot_component / _rollback_component / _is_systemd_unit_failed and
+#     friends shell out through asyncio.create_subprocess_exec — a deleting
+#     rsync against the deployed tree, systemctl against real units.  rsync
+#     creates its destination before failing, so an unmocked snapshot litters
+#     the live snapshot store with empty directories on any host where the test
+#     user can write there.
 #
-# The guard raises through pytest.fail (an OutcomeException, i.e. a
-# BaseException) precisely because _wait_component_healthy wraps the probe in a
-# broad ``except Exception`` — a plain error would be swallowed and the loop
-# would keep spinning for the full window, which is the failure mode being
+# Both have now been patched test-by-test several times over (#11462, #11467,
+# #13312) and both keep coming back, so the guards live here for the whole
+# tests/api package rather than in individual files.  Neither masks anything:
+# httpx.AsyncClient is used by exactly one place in api/code_sync.py (the health
+# poll), and every test that legitimately drives either path installs its own
+# stand-in inside the test body, whose inner patch wins over these guards.
+#
+# The guards raise through pytest.fail (an OutcomeException, i.e. a
+# BaseException) precisely because the code under test wraps these calls in
+# broad ``except Exception`` handlers — a plain error would be swallowed and the
+# poll would keep spinning for the full window, which is the failure mode being
 # prevented.
-_CODE_SYNC_MODULE_PREFIX = "test_code_sync_"
-
+#
+# Deliberately a runtest hook and NOT an autouse fixture.  An autouse fixture
+# that requests monkeypatch registers a finalizer for every test in the package,
+# and that extra teardown step reorders the async session fixture in
+# test_slm_endpoints_12515.py enough to break its ``async with
+# session_factory()`` exit (9 teardown errors).  A hookwrapper adds no fixture
+# and no finalizer, and wraps only the call phase — which is also the correct
+# scope, since the I/O being guarded happens inside the test body.
 _LIVE_POLL_MESSAGE = (
     "unit test attempted a live component health poll via httpx.AsyncClient. "
     "api.code_sync._wait_component_healthy polls until its timeout window "
@@ -70,6 +83,17 @@ _LIVE_POLL_MESSAGE = (
     "real network I/O (#13312). Patch 'api.code_sync._wait_component_healthy' "
     "when the test is about post-sync orchestration, or install an "
     "httpx.AsyncClient stand-in when the poll itself is under test."
+)
+
+_LIVE_SUBPROCESS_MESSAGE = (
+    "unit test spawned the real subprocess {argv} via "
+    "asyncio.create_subprocess_exec (#13312). api/code_sync.py shells out to "
+    "rsync, systemctl and ansible against the live install; rsync creates its "
+    "destination before failing, so this leaves debris behind wherever the test "
+    "user can write. Patch the helper that owns the call — "
+    "'api.code_sync._snapshot_component', '..._rollback_component', "
+    "'..._is_systemd_unit_failed' — or patch asyncio.create_subprocess_exec "
+    "with a fake when the invocation itself is under test."
 )
 
 
@@ -80,16 +104,30 @@ class _LiveHealthPollBlocked:
         pytest.fail(_LIVE_POLL_MESSAGE, pytrace=False)
 
 
-@pytest.fixture(autouse=True)
-def _block_live_code_sync_health_polls(request, monkeypatch):
-    """Fail fast instead of dead-waiting when a code-sync test polls for real."""
-    module_name = getattr(request.module, "__name__", "")
-    if not module_name.rpartition(".")[2].startswith(_CODE_SYNC_MODULE_PREFIX):
-        return
+def _blocked_subprocess_exec(*cmd: object, **kwargs: object):
+    """asyncio.create_subprocess_exec stand-in that refuses to spawn."""
+    argv = " ".join(str(c) for c in cmd[:3]) or "<no argv>"
+    pytest.fail(_LIVE_SUBPROCESS_MESSAGE.format(argv=argv), pytrace=False)
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_call(item):
+    """Fail fast instead of dead-waiting or touching the host."""
     try:
+        import asyncio
+
         import httpx
     except ImportError:
         # _wait_component_healthy short-circuits to "healthy" without httpx, so
         # there is no live poll to block.
+        yield
         return
-    monkeypatch.setattr(httpx, "AsyncClient", _LiveHealthPollBlocked)
+    saved_client = httpx.AsyncClient
+    saved_exec = asyncio.create_subprocess_exec
+    httpx.AsyncClient = _LiveHealthPollBlocked
+    asyncio.create_subprocess_exec = _blocked_subprocess_exec
+    try:
+        yield
+    finally:
+        httpx.AsyncClient = saved_client
+        asyncio.create_subprocess_exec = saved_exec

--- a/autobot-slm-backend/tests/api/conftest.py
+++ b/autobot-slm-backend/tests/api/conftest.py
@@ -11,10 +11,15 @@ place to install the stub — by the time any test module does
 `from api.code_sync import ...` the starlette cache is already clean.
 
 This does NOT affect CI (where the correct packages are installed in the venv).
+
+It also carries the live-health-poll guard for the ``test_code_sync_*`` modules
+(#13312) — see ``_block_live_code_sync_health_polls``.
 """
 
 import sys
 import types
+
+import pytest
 
 if "multipart" not in sys.modules or not hasattr(sys.modules.get("multipart"), "parse_options_header"):
     # Stub multipart.multipart.parse_options_header so starlette.formparsers loads
@@ -32,3 +37,59 @@ if "python_multipart" not in sys.modules:
     _pymp.multipart = _pymp_inner  # type: ignore[attr-defined]
     sys.modules.setdefault("python_multipart", _pymp)
     sys.modules.setdefault("python_multipart.multipart", _pymp_inner)
+
+
+# ---------------------------------------------------------------------------
+# #13312 — no live health polls from the unit gate
+# ---------------------------------------------------------------------------
+# api.code_sync._wait_component_healthy probes a component's HTTP health URL
+# every _HEALTH_POLL_INTERVAL seconds until _HEALTH_POLL_TIMEOUT (180s) or
+# _FAST_HEALTH_POLL_TIMEOUT (60s).  A _run_post_sync_steps test that does not
+# mock the poll therefore performs real outbound requests and burns the whole
+# window as dead wait — on a runner where nothing listens on the health port
+# that is ~180s per test.  This has now been fixed three times test-by-test
+# (#11462, #11467, #13312), so the guard lives here instead of in each file.
+#
+# httpx.AsyncClient is used by exactly one place in api/code_sync.py — the
+# health poll — so replacing it for the code-sync modules cannot mask anything
+# else.  Tests that legitimately exercise the poll install their own
+# httpx.AsyncClient stand-in inside the test body; that inner patch wins over
+# this fixture, so they are unaffected.
+#
+# The guard raises through pytest.fail (an OutcomeException, i.e. a
+# BaseException) precisely because _wait_component_healthy wraps the probe in a
+# broad ``except Exception`` — a plain error would be swallowed and the loop
+# would keep spinning for the full window, which is the failure mode being
+# prevented.
+_CODE_SYNC_MODULE_PREFIX = "test_code_sync_"
+
+_LIVE_POLL_MESSAGE = (
+    "unit test attempted a live component health poll via httpx.AsyncClient. "
+    "api.code_sync._wait_component_healthy polls until its timeout window "
+    "expires, so an unmocked poll costs up to 180s of dead wait and performs "
+    "real network I/O (#13312). Patch 'api.code_sync._wait_component_healthy' "
+    "when the test is about post-sync orchestration, or install an "
+    "httpx.AsyncClient stand-in when the poll itself is under test."
+)
+
+
+class _LiveHealthPollBlocked:
+    """httpx.AsyncClient stand-in that refuses to perform a real probe."""
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        pytest.fail(_LIVE_POLL_MESSAGE, pytrace=False)
+
+
+@pytest.fixture(autouse=True)
+def _block_live_code_sync_health_polls(request, monkeypatch):
+    """Fail fast instead of dead-waiting when a code-sync test polls for real."""
+    module_name = getattr(request.module, "__name__", "")
+    if not module_name.rpartition(".")[2].startswith(_CODE_SYNC_MODULE_PREFIX):
+        return
+    try:
+        import httpx
+    except ImportError:
+        # _wait_component_healthy short-circuits to "healthy" without httpx, so
+        # there is no live poll to block.
+        return
+    monkeypatch.setattr(httpx, "AsyncClient", _LiveHealthPollBlocked)

--- a/autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py
+++ b/autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py
@@ -26,6 +26,8 @@ import time
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 # ---------------------------------------------------------------------------
 # #12572: import api.code_sync with real Pydantic schema stand-ins installed
 # then removed.  On the dev host models.schemas is a MagicMock, which makes
@@ -1833,6 +1835,29 @@ def test_wait_component_healthy_returns_false_when_unit_failed_during_poll() -> 
 
     assert result is False, "confirmed systemd failure must trigger rollback (return False)"
     assert any("failed" in s for s in steps)
+
+
+def test_unmocked_health_poll_fails_fast_instead_of_dead_waiting() -> None:
+    """#13312: an unmocked live health poll must fail immediately, not dead-wait.
+
+    _wait_component_healthy retries until _HEALTH_POLL_TIMEOUT (180s) expires and
+    swallows every per-attempt error, so a test that forgets to mock it used to
+    cost ~3 minutes of real network I/O and still pass.  The tests/api conftest
+    guard replaces httpx.AsyncClient for this module with a stand-in that calls
+    pytest.fail; this asserts the guard is armed and that it escapes the poll's
+    broad ``except Exception``.
+    """
+    steps: list[str] = []
+    started = time.monotonic()
+
+    with (
+        patch("api.code_sync._COMPONENT_HEALTH_URLS", {"autobot-backend": "http://127.0.0.1:8001/api/health"}),
+        patch("api.code_sync._is_systemd_unit_failed", AsyncMock(return_value=False)),
+        pytest.raises(pytest.fail.Exception),
+    ):
+        _run(_wait_component_healthy("autobot-backend", steps, slow_start=True))
+
+    assert time.monotonic() - started < 5.0, "guard must abort the poll, not wait out the window"
 
 
 def test_is_systemd_unit_failed_returns_true_on_failed_output() -> None:

--- a/autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py
+++ b/autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py
@@ -1867,6 +1867,19 @@ def test_unmocked_health_poll_fails_fast_instead_of_dead_waiting() -> None:
     assert time.monotonic() - started < 5.0, "guard must abort the poll, not wait out the window"
 
 
+def test_unmocked_subprocess_fails_fast_instead_of_touching_the_host() -> None:
+    """#13312: an unmocked shell-out must fail immediately, not run for real.
+
+    _is_systemd_unit_failed returns False on any exception, so a real
+    `systemctl` that is missing, slow or answering about the host's actual units
+    produced a green test either way.  The tests/api conftest guard replaces
+    asyncio.create_subprocess_exec with a stand-in that calls pytest.fail, which
+    escapes that broad handler.
+    """
+    with pytest.raises(pytest.fail.Exception):
+        _run(_is_systemd_unit_failed("autobot-backend"))
+
+
 def test_is_systemd_unit_failed_returns_true_on_failed_output() -> None:
     """_is_systemd_unit_failed returns True only when systemctl prints 'failed' (#11413)."""
 

--- a/autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py
+++ b/autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py
@@ -260,13 +260,17 @@ def test_run_post_sync_steps_pip_ok_true_on_success() -> None:
         patch("api.code_sync._run_alembic_migrations", AsyncMock(return_value=True)),
         patch("api.code_sync._ensure_autobot_shared_symlink", AsyncMock()),
         patch("api.code_sync._restart_component_services", AsyncMock()),
-        patch("api.code_sync._wait_component_healthy", AsyncMock(return_value=True)),
+        patch("api.code_sync._wait_component_healthy", AsyncMock(return_value=True)) as wait_mock,
         patch("api.code_sync._rollback_component", AsyncMock()),
     ):
         _, _, pip_ok = _run(
             _run_post_sync_steps("autobot-backend", "/src/autobot-backend", "/opt/autobot/autobot-backend")
         )
     assert pip_ok is True
+    # #13312: _run_post_sync_steps forwards _ensure_venv_python's return as
+    # slow_start.  Assert the window selection instead of leaving it to a mock
+    # default — a bare AsyncMock() is truthy and silently picks the 180s window.
+    assert wait_mock.await_args.kwargs["slow_start"] is False
 
 
 # ---------------------------------------------------------------------------
@@ -1493,6 +1497,9 @@ def test_wait_component_healthy_returns_true_on_healthy_response() -> None:
         patch("api.code_sync._HEALTH_POLL_TIMEOUT", 5.0),
         patch("api.code_sync._FAST_HEALTH_POLL_TIMEOUT", 5.0),  # #11458/#11467: default slow_start uses the fast window
         patch("httpx.AsyncClient", return_value=_FakeClient()),
+        # #13312: the poll checks systemd BEFORE probing, so without this the
+        # test spawns a real `systemctl is-failed` against the host's units.
+        patch("api.code_sync._is_systemd_unit_failed", AsyncMock(return_value=False)),
     ):
         result = _run(_wait_component_healthy("autobot-backend", steps))
 
@@ -1901,7 +1908,9 @@ def test_run_post_sync_steps_does_not_roll_back_on_slow_start() -> None:
         patch("api.code_sync._deploy_constraints_dir", AsyncMock()),
         patch("api.code_sync._deploy_repo_root_requirements", AsyncMock()),
         patch("api.code_sync._ensure_target_python_installed", AsyncMock()),
-        patch("api.code_sync._ensure_venv_python", AsyncMock()),
+        # #13312: bare AsyncMock() returns a truthy MagicMock, which
+        # _run_post_sync_steps forwards as slow_start=True — the 180s window.
+        patch("api.code_sync._ensure_venv_python", AsyncMock(return_value=False)),
         patch("api.code_sync._install_pip_deps_for_component", AsyncMock(return_value=True)),
         patch("api.code_sync._run_alembic_migrations", AsyncMock(return_value=True)),
         patch("api.code_sync._ensure_autobot_shared_symlink", AsyncMock()),

--- a/autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py
+++ b/autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py
@@ -216,14 +216,23 @@ def test_pip_returns_false_on_failure(tmp_path) -> None:
 def test_run_post_sync_steps_pip_ok_false_on_pip_failure() -> None:
     """When pip returns False, _run_post_sync_steps returns pip_ok=False."""
     with (
+        # #13312: _run_post_sync_steps' side-effecting helpers must ALL be mocked.
+        # _snapshot_component rsyncs the live deployed dir, _ensure_target_python_installed
+        # can shell out to ansible, and _wait_component_healthy polls a real HTTP
+        # endpoint until its window expires (~180s of dead wait on a host where
+        # nothing is listening). None of them is what these tests assert.
         patch("api.code_sync._compute_deps_changed", AsyncMock(return_value=False)),
+        patch("api.code_sync._snapshot_component", AsyncMock(return_value=None)),
         patch("api.code_sync._deploy_constraints_dir", AsyncMock()),
         patch("api.code_sync._deploy_repo_root_requirements", AsyncMock()),
-        patch("api.code_sync._ensure_venv_python", AsyncMock()),
+        patch("api.code_sync._ensure_target_python_installed", AsyncMock()),
+        patch("api.code_sync._ensure_venv_python", AsyncMock(return_value=False)),
         patch("api.code_sync._install_pip_deps_for_component", AsyncMock(return_value=False)),
-        patch("api.code_sync._run_alembic_migrations", AsyncMock()),
+        patch("api.code_sync._run_alembic_migrations", AsyncMock(return_value=True)),
         patch("api.code_sync._ensure_autobot_shared_symlink", AsyncMock()),
         patch("api.code_sync._restart_component_services", AsyncMock()),
+        patch("api.code_sync._wait_component_healthy", AsyncMock(return_value=True)),
+        patch("api.code_sync._rollback_component", AsyncMock()),
     ):
         _, _, pip_ok = _run(
             _run_post_sync_steps("autobot-backend", "/src/autobot-backend", "/opt/autobot/autobot-backend")
@@ -234,14 +243,23 @@ def test_run_post_sync_steps_pip_ok_false_on_pip_failure() -> None:
 def test_run_post_sync_steps_pip_ok_true_on_success() -> None:
     """When pip returns True, _run_post_sync_steps returns pip_ok=True."""
     with (
+        # #13312: _run_post_sync_steps' side-effecting helpers must ALL be mocked.
+        # _snapshot_component rsyncs the live deployed dir, _ensure_target_python_installed
+        # can shell out to ansible, and _wait_component_healthy polls a real HTTP
+        # endpoint until its window expires (~180s of dead wait on a host where
+        # nothing is listening). None of them is what these tests assert.
         patch("api.code_sync._compute_deps_changed", AsyncMock(return_value=False)),
+        patch("api.code_sync._snapshot_component", AsyncMock(return_value=None)),
         patch("api.code_sync._deploy_constraints_dir", AsyncMock()),
         patch("api.code_sync._deploy_repo_root_requirements", AsyncMock()),
-        patch("api.code_sync._ensure_venv_python", AsyncMock()),
+        patch("api.code_sync._ensure_target_python_installed", AsyncMock()),
+        patch("api.code_sync._ensure_venv_python", AsyncMock(return_value=False)),
         patch("api.code_sync._install_pip_deps_for_component", AsyncMock(return_value=True)),
-        patch("api.code_sync._run_alembic_migrations", AsyncMock()),
+        patch("api.code_sync._run_alembic_migrations", AsyncMock(return_value=True)),
         patch("api.code_sync._ensure_autobot_shared_symlink", AsyncMock()),
         patch("api.code_sync._restart_component_services", AsyncMock()),
+        patch("api.code_sync._wait_component_healthy", AsyncMock(return_value=True)),
+        patch("api.code_sync._rollback_component", AsyncMock()),
     ):
         _, _, pip_ok = _run(
             _run_post_sync_steps("autobot-backend", "/src/autobot-backend", "/opt/autobot/autobot-backend")
@@ -503,14 +521,23 @@ def test_run_post_sync_steps_calls_deploy_repo_root_requirements() -> None:
         called.append(True)
 
     with (
+        # #13312: _run_post_sync_steps' side-effecting helpers must ALL be mocked.
+        # _snapshot_component rsyncs the live deployed dir, _ensure_target_python_installed
+        # can shell out to ansible, and _wait_component_healthy polls a real HTTP
+        # endpoint until its window expires (~180s of dead wait on a host where
+        # nothing is listening). None of them is what these tests assert.
         patch("api.code_sync._compute_deps_changed", AsyncMock(return_value=False)),
+        patch("api.code_sync._snapshot_component", AsyncMock(return_value=None)),
         patch("api.code_sync._deploy_constraints_dir", AsyncMock()),
         patch("api.code_sync._deploy_repo_root_requirements", side_effect=_fake_deploy),
-        patch("api.code_sync._ensure_venv_python", AsyncMock()),
+        patch("api.code_sync._ensure_target_python_installed", AsyncMock()),
+        patch("api.code_sync._ensure_venv_python", AsyncMock(return_value=False)),
         patch("api.code_sync._install_pip_deps_for_component", AsyncMock(return_value=True)),
-        patch("api.code_sync._run_alembic_migrations", AsyncMock()),
+        patch("api.code_sync._run_alembic_migrations", AsyncMock(return_value=True)),
         patch("api.code_sync._ensure_autobot_shared_symlink", AsyncMock()),
         patch("api.code_sync._restart_component_services", AsyncMock()),
+        patch("api.code_sync._wait_component_healthy", AsyncMock(return_value=True)),
+        patch("api.code_sync._rollback_component", AsyncMock()),
     ):
         _run(_run_post_sync_steps("autobot-backend", "/src/autobot-backend", "/opt/autobot/autobot-backend"))
 
@@ -618,15 +645,23 @@ def test_run_post_sync_steps_provisions_python_before_venv() -> None:
         order.append("venv")
 
     with (
+        # #13312: _run_post_sync_steps' side-effecting helpers must ALL be mocked.
+        # _snapshot_component rsyncs the live deployed dir, _ensure_target_python_installed
+        # can shell out to ansible, and _wait_component_healthy polls a real HTTP
+        # endpoint until its window expires (~180s of dead wait on a host where
+        # nothing is listening). None of them is what these tests assert.
         patch("api.code_sync._compute_deps_changed", AsyncMock(return_value=False)),
+        patch("api.code_sync._snapshot_component", AsyncMock(return_value=None)),
         patch("api.code_sync._deploy_constraints_dir", AsyncMock()),
         patch("api.code_sync._deploy_repo_root_requirements", AsyncMock()),
         patch("api.code_sync._ensure_target_python_installed", side_effect=_provision),
         patch("api.code_sync._ensure_venv_python", side_effect=_venv),
         patch("api.code_sync._install_pip_deps_for_component", AsyncMock(return_value=True)),
-        patch("api.code_sync._run_alembic_migrations", AsyncMock()),
+        patch("api.code_sync._run_alembic_migrations", AsyncMock(return_value=True)),
         patch("api.code_sync._ensure_autobot_shared_symlink", AsyncMock()),
         patch("api.code_sync._restart_component_services", AsyncMock()),
+        patch("api.code_sync._wait_component_healthy", AsyncMock(return_value=True)),
+        patch("api.code_sync._rollback_component", AsyncMock()),
     ):
         _run(_run_post_sync_steps("autobot-backend", "/src/autobot-backend", "/opt/autobot/autobot-backend"))
 
@@ -880,9 +915,17 @@ def test_build_returns_false_on_npm_ci_failure(tmp_path) -> None:
 def test_run_post_sync_steps_pip_ok_false_on_npm_failure() -> None:
     """When npm build returns False, _run_post_sync_steps returns pip_ok=False."""
     with (
+        # #13312: _run_post_sync_steps' side-effecting helpers must ALL be mocked.
+        # _snapshot_component rsyncs the live deployed dir, _ensure_target_python_installed
+        # can shell out to ansible, and _wait_component_healthy polls a real HTTP
+        # endpoint until its window expires (~180s of dead wait on a host where
+        # nothing is listening). None of them is what these tests assert.
         patch("api.code_sync._compute_deps_changed", AsyncMock(return_value=False)),
+        patch("api.code_sync._snapshot_component", AsyncMock(return_value=None)),
         patch("api.code_sync._build_npm_frontend_for_component", AsyncMock(return_value=False)),
         patch("api.code_sync._restart_component_services", AsyncMock()),
+        patch("api.code_sync._wait_component_healthy", AsyncMock(return_value=True)),
+        patch("api.code_sync._rollback_component", AsyncMock()),
     ):
         _, _, pip_ok = _run(
             _run_post_sync_steps(
@@ -897,9 +940,17 @@ def test_run_post_sync_steps_pip_ok_false_on_npm_failure() -> None:
 def test_run_post_sync_steps_pip_ok_true_on_npm_success() -> None:
     """When npm build returns True, _run_post_sync_steps returns pip_ok=True."""
     with (
+        # #13312: _run_post_sync_steps' side-effecting helpers must ALL be mocked.
+        # _snapshot_component rsyncs the live deployed dir, _ensure_target_python_installed
+        # can shell out to ansible, and _wait_component_healthy polls a real HTTP
+        # endpoint until its window expires (~180s of dead wait on a host where
+        # nothing is listening). None of them is what these tests assert.
         patch("api.code_sync._compute_deps_changed", AsyncMock(return_value=False)),
+        patch("api.code_sync._snapshot_component", AsyncMock(return_value=None)),
         patch("api.code_sync._build_npm_frontend_for_component", AsyncMock(return_value=True)),
         patch("api.code_sync._restart_component_services", AsyncMock()),
+        patch("api.code_sync._wait_component_healthy", AsyncMock(return_value=True)),
+        patch("api.code_sync._rollback_component", AsyncMock()),
     ):
         _, _, pip_ok = _run(
             _run_post_sync_steps(

--- a/autobot-slm-backend/tests/api/test_code_sync_symlink_restore.py
+++ b/autobot-slm-backend/tests/api/test_code_sync_symlink_restore.py
@@ -246,8 +246,11 @@ def test_pip_backend_emits_symlink_step(tmp_path) -> None:
             patch("api.code_sync._install_pip_deps_for_component", AsyncMock(return_value=True)),
             patch("api.code_sync._deploy_constraints_dir", AsyncMock()),
             patch("api.code_sync._deploy_repo_root_requirements", AsyncMock()),
-            # #13312: unmocked this shells out to `sudo ansible-playbook` when the
-            # target interpreter is not on PATH.
+            # #13312: unmocked this would shell out to `sudo ansible-playbook`
+            # when the target interpreter is off PATH.  Under the stubs the
+            # playbook path resolves through a mocked repo root so .exists() is
+            # False and it short-circuits — this is defence in depth against a
+            # run with a real SLM_REPO_PATH, not a live invocation today.
             patch("api.code_sync._ensure_target_python_installed", AsyncMock()),
             patch("api.code_sync._ensure_venv_python", AsyncMock(return_value=False)),
             patch("api.code_sync._run_alembic_migrations", AsyncMock(return_value=True)),

--- a/autobot-slm-backend/tests/api/test_code_sync_symlink_restore.py
+++ b/autobot-slm-backend/tests/api/test_code_sync_symlink_restore.py
@@ -239,17 +239,24 @@ def test_pip_backend_emits_symlink_step(tmp_path) -> None:
             patch("api.code_sync._get_deploy_base", return_value=tmp_path),
             patch("api.code_sync._ensure_autobot_shared_symlink", side_effect=_fake_ensure),
             patch("api.code_sync._compute_deps_changed", AsyncMock(return_value=False)),
+            # #13312: _snapshot_component rsyncs the LIVE deployed dir into the
+            # snapshot base — a real subprocess writing outside the test tree.
+            patch("api.code_sync._snapshot_component", AsyncMock(return_value=None)),
             # _install_pip_deps_for_component now returns bool (#11322)
             patch("api.code_sync._install_pip_deps_for_component", AsyncMock(return_value=True)),
             patch("api.code_sync._deploy_constraints_dir", AsyncMock()),
             patch("api.code_sync._deploy_repo_root_requirements", AsyncMock()),
-            patch("api.code_sync._ensure_venv_python", AsyncMock()),
-            patch("api.code_sync._run_alembic_migrations", AsyncMock()),
+            # #13312: unmocked this shells out to `sudo ansible-playbook` when the
+            # target interpreter is not on PATH.
+            patch("api.code_sync._ensure_target_python_installed", AsyncMock()),
+            patch("api.code_sync._ensure_venv_python", AsyncMock(return_value=False)),
+            patch("api.code_sync._run_alembic_migrations", AsyncMock(return_value=True)),
             patch("api.code_sync._restart_component_services", AsyncMock()),
             # restart=True runs the post-restart health poll; without this mock it
             # makes real httpx polls until the deadline — ~3 min of dead wait that
             # reads as a hang (#11467, same class as #11462).
             patch("api.code_sync._wait_component_healthy", AsyncMock(return_value=True)),
+            patch("api.code_sync._rollback_component", AsyncMock()),
         ):
             _, steps, _ = _run(_run_post_sync_steps(component, f"/src/{component}", f"/opt/autobot/{component}"))
             steps_collected.extend(steps)
@@ -278,6 +285,17 @@ def test_autobot_shared_component_restores_both_backends(tmp_path) -> None:
         patch("api.code_sync._ensure_autobot_shared_symlink", side_effect=_fake_ensure),
         patch("api.code_sync._restart_component_services", AsyncMock()),
         patch("api.code_sync._compute_deps_changed", AsyncMock(return_value=False)),
+        # #13312: the autobot_shared branch fans out through
+        # _restart_dependents_with_health, which health-polls EVERY dependent
+        # that has a health URL.  Unmocked that is ~180s of real httpx traffic
+        # per dependent; _is_systemd_unit_failed likewise spawns a real
+        # systemctl for the dependents that have none, and _snapshot_component
+        # rsyncs the live deployed dir.  This test asserts the symlink fan-out
+        # only.
+        patch("api.code_sync._snapshot_component", AsyncMock(return_value=None)),
+        patch("api.code_sync._wait_component_healthy", AsyncMock(return_value=True)),
+        patch("api.code_sync._is_systemd_unit_failed", AsyncMock(return_value=False)),
+        patch("api.code_sync._rollback_component", AsyncMock()),
     ):
         _run(
             _run_post_sync_steps(

--- a/autobot-slm-backend/tests/api/test_component_resolve_job.py
+++ b/autobot-slm-backend/tests/api/test_component_resolve_job.py
@@ -154,6 +154,11 @@ def test_run_post_sync_steps_restart_false_does_not_call_restart() -> None:
     restart_mock = AsyncMock()
     with (
         patch("api.code_sync._compute_deps_changed", AsyncMock(return_value=False)),
+        # #13312: unmocked, _snapshot_component spawns a real deleting rsync into
+        # the live snapshot store.  rsync creates the destination before it fails,
+        # so each run leaves an empty snapshot dir behind on any host where the
+        # test user can write there.
+        patch("api.code_sync._snapshot_component", AsyncMock(return_value=None)),
         patch("api.code_sync._deploy_constraints_dir", AsyncMock()),
         patch("api.code_sync._deploy_repo_root_requirements", AsyncMock()),
         patch("api.code_sync._ensure_target_python_installed", AsyncMock()),
@@ -182,6 +187,11 @@ def test_run_post_sync_steps_restart_true_calls_restart() -> None:
     restart_mock = AsyncMock()
     with (
         patch("api.code_sync._compute_deps_changed", AsyncMock(return_value=False)),
+        # #13312: unmocked, _snapshot_component spawns a real deleting rsync into
+        # the live snapshot store.  rsync creates the destination before it fails,
+        # so each run leaves an empty snapshot dir behind on any host where the
+        # test user can write there.
+        patch("api.code_sync._snapshot_component", AsyncMock(return_value=None)),
         patch("api.code_sync._deploy_constraints_dir", AsyncMock()),
         patch("api.code_sync._deploy_repo_root_requirements", AsyncMock()),
         patch("api.code_sync._ensure_target_python_installed", AsyncMock()),
@@ -213,6 +223,11 @@ def test_run_post_sync_steps_restart_false_frontend() -> None:
     restart_mock = AsyncMock()
     with (
         patch("api.code_sync._compute_deps_changed", AsyncMock(return_value=False)),
+        # #13312: unmocked, _snapshot_component spawns a real deleting rsync into
+        # the live snapshot store.  rsync creates the destination before it fails,
+        # so each run leaves an empty snapshot dir behind on any host where the
+        # test user can write there.
+        patch("api.code_sync._snapshot_component", AsyncMock(return_value=None)),
         patch("api.code_sync._build_npm_frontend_for_component", AsyncMock()),
         patch("api.code_sync._restart_component_services", restart_mock),
     ):
@@ -234,6 +249,11 @@ def test_run_post_sync_steps_restart_false_shared_library() -> None:
     restart_mock = AsyncMock()
     with (
         patch("api.code_sync._compute_deps_changed", AsyncMock(return_value=False)),
+        # #13312: unmocked, _snapshot_component spawns a real deleting rsync into
+        # the live snapshot store.  rsync creates the destination before it fails,
+        # so each run leaves an empty snapshot dir behind on any host where the
+        # test user can write there.
+        patch("api.code_sync._snapshot_component", AsyncMock(return_value=None)),
         patch("api.code_sync._ensure_autobot_shared_symlink", AsyncMock()),
         patch("api.code_sync._restart_component_services", restart_mock),
     ):


### PR DESCRIPTION
## Thinking Path

Four tests took ~180s each and accounted for ~87% of the first-ever `autobot-slm-backend` CI invocation. 180s is a timeout shape, so the question was "what never arrives?", not "what is slow?".

`api/code_sync.py` defines `_HEALTH_POLL_TIMEOUT = 180` (slow-start window) and `_FAST_HEALTH_POLL_TIMEOUT = 60`. `_wait_component_healthy` probes a component's HTTP health URL, swallows every per-attempt error, sleeps, and retries until the window expires. Five tests drove `_run_post_sync_steps(..., restart=True)` without mocking that poll, so each performed ~90 live HTTP requests and then burned the full window.

They looked fast on a workstation only because a real backend answers the health port there — the first probe returned 200 and the poll exited immediately. Reproducing the CI shape needed an environment where nothing is listening; a network namespace (`unshare -rn`) gives exactly that and reproduced all four to the second, plus a fifth at 61s (the 60s fast window).

The health poll turned out to be only half of it. The same tests left `_snapshot_component` unmocked, and it shells out to a deleting `rsync` against the deployed tree. The source is a stubbed mock so no live data is read or removed, but **rsync creates its destination before failing**, so every run left an empty `<component>_<timestamp>/` directory in the live snapshot store on any host where the test user can write there. `_prune_old_snapshots` is gated on `rc == 0` and never cleaned them up. Introduced 2026-07-09; defused on the machine used here only because that directory is not group-writable.

`AsyncMock()` returning a truthy `MagicMock` is what selected the 180s window rather than the 60s one: `_run_post_sync_steps` passes `_ensure_venv_python`'s return as `slow_start`.

Removing ~780s of dead wait changed which worker `--dist loadscope` hands each module to, and that unmasked a latent xdist crash — see below.

## What Changed

**Tests no longer perform live I/O** (`tests/api/test_code_sync_deploy_bugs.py`, `tests/api/test_code_sync_symlink_restore.py`, `tests/api/test_component_resolve_job.py`)

Fifteen existing tests are touched; they now mock the complete set of side-effecting helpers — `_snapshot_component`, `_ensure_target_python_installed`, `_wait_component_healthy`, `_rollback_component`, `_is_systemd_unit_failed`. `_ensure_venv_python` returns `False` instead of a truthy mock, and `slow_start is False` is now asserted rather than left to a mock default. No test's assertions were weakened.

**Guards for the whole `tests/api` package** (`tests/api/conftest.py`)

Both leaks have been patched test-by-test several times over (#11462, #11467, here) and both kept coming back, so the guards moved into the shared conftest: `httpx.AsyncClient` and `asyncio.create_subprocess_exec` are replaced with stand-ins that fail the test. Neither masks anything — `httpx` is used by exactly one place in `api/code_sync.py`, and every test that legitimately drives either path installs its own stand-in inside the test body, whose inner patch wins. They raise through `pytest.fail` (a `BaseException`) precisely because the code under test wraps both calls in broad `except Exception` handlers; a plain error would be swallowed. Two tests lock in each guard.

This is a `pytest_runtest_call` hookwrapper and **not** an autouse fixture. See the correction below — an autouse fixture requesting `monkeypatch` was the actual cause of the teardown errors this PR previously misattributed.

**Health-poll shape is fully env-fed** (`api/code_sync.py`)

The inter-attempt delay was a literal `2.0` buried in the loop and the per-attempt connect timeout a literal `3.0`, next to a block of env-fed constants. Both are now module constants with env overrides at their existing defaults. Also fixed a non-f-string that emitted a literal `{url}` in the operator-facing timeout step.

**xdist controller crash** (`conftest.py`)

The root conftest stubs `sqlalchemy` as a `MagicMock` in every process, including the pytest-xdist *controller*. The controller rebuilds each worker warning by importing the warning class's module, so a worker `SAWarning` made it call `importlib.import_module('sqlalchemy.exc')` against a non-package stub: the node went down and the session ended in an `INTERNALERROR` with every result lost. Which worker picks up which scope is timing-dependent, so this stayed latent until the suite got faster — then it fired on every run.

The real warning module is now imported in isolation and re-registered, **and bound onto the stub parent** so `from sqlalchemy.exc import X` and `patch("sqlalchemy.exc.X")` resolve to the same object — the divergence `_stub()`'s own docstring (#9780) exists to prevent. The import guard is deliberately `except Exception`: this runs at conftest import, where anything escaping takes the whole session down, which is worse than the bug being fixed. The whitelist is one entry deep and says so; `sqlalchemy.orm.exc` would raise the identical error.

## Correction to the previous body

The earlier revision claimed nine teardown errors in `tests/api/test_slm_endpoints_12515.py` were pre-existing and merely rescheduled. **That was wrong, and it was this PR that caused them.** The guard was an autouse fixture taking `monkeypatch` as a parameter, which registers a finalizer for *every* test in `tests/api`; that extra teardown step broke the async `db` fixture's `async with session_factory()` exit. The "reproduces on base" check behind the claim was invalid — it reverted only the root conftest and left the guard fixture active.

```
base, isolated, serial   ->  29 passed, 0 errors
prev revision, isolated  ->  29 passed, 9 errors
this revision, isolated  ->  29 passed, 0 errors
```

Ruling out scheduling as an alternative explanation, on a **pristine base tree** with the poll windows forced low so the wall time matches this branch:

```
base + AUTOBOT_HEALTH_POLL_TIMEOUT=1 AUTOBOT_HEALTH_POLL_TIMEOUT_FAST=1
  -> 33 failed, 1463 passed, 10 errors in 104.91s
```

Same runtime, 10 errors. The extra nine were the fixture, not the schedule.

## Verification

All runs use the CI invocation inside a network namespace, so nothing answers the health URLs — the CI condition. A workstation with a live backend on the health port hides the defect entirely.

Per-test, single file, serial:

| Test | Before | After |
|---|---|---|
| `deploy_bugs::test_run_post_sync_steps_pip_ok_true_on_npm_success` | 182.01s | 0.02s |
| `deploy_bugs::test_run_post_sync_steps_pip_ok_true_on_success` | 181.15s | 0.02s |
| `deploy_bugs::test_run_post_sync_steps_calls_deploy_repo_root_requirements` | 180.64s | 0.02s |
| `symlink_restore::test_autobot_shared_component_restores_both_backends` | 180.19s | 0.02s |
| `deploy_bugs::test_run_post_sync_steps_provisions_python_before_venv` (not in the reported four — 60s fast window) | 61.21s | 0.01s |

Whole files:

```
before  test_code_sync_deploy_bugs.py      89 passed in 608.20s
after   test_code_sync_deploy_bugs.py      91 passed in   1.61s
before  test_code_sync_symlink_restore.py  11 passed in 184.02s
after   test_code_sync_symlink_restore.py  11 passed in   2.98s
```

Whole `autobot-slm-backend` suite, `-n auto --dist loadscope` with the CI marker filter:

```
before  33 failed, 1463 passed, 2 skipped, 1 xfailed, 10 errors in 664.93s
after   33 failed, 1465 passed, 2 skipped, 1 xfailed, 10 errors in 120.76s
```

**Error count is back at 10, matching base.** The `FAILED` set is byte-identical — `md5 742f52fb51b6d1be6a40a2c5991d957c` on both sides — and the `ERROR` set matches base exactly. No `INTERNALERROR`. The two extra passes are the two guard tests.

Neither guard fires anywhere in the suite (`0` hits for both messages), i.e. no test in `tests/api` still reaches a live health poll or spawns a real subprocess. No code-sync test appears in `--durations-min=10.0` any more.

None of the four tests was among #13312's 56 failures — all four passed before and after; only their runtime changed.

Lint clean (`flake8 --max-line-length=127`) on all five changed files.

Not verified without a live system: whether the 180s window is correct for a real deploy is unchanged by this PR — no production timeout value moved, only the literals became env-overridable at their existing defaults.

Refs #13312

## Model Used

claude-opus-5
