### PR TITLE
security(mcp): pre-auth throttle, run-JWT propagation, and a single meaning for AUTOBOT_MCP_TOKEN (#13268, #13265, #13266)

### DIFF
--- a/autobot-backend/api/autobot_mcp_router.py
+++ b/autobot-backend/api/autobot_mcp_router.py
@@ -16,6 +16,7 @@ from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.proxy_utils import get_client_ip
 from mcp.autobot_server import AutoBotMCPServer
 
 logger = get_logger(__name__)
@@ -51,9 +52,19 @@ async def mcp_tool_call(request: Request) -> JSONResponse:
     auth_header = request.headers.get("Authorization", "")
     token = auth_header.removeprefix("Bearer ").strip()
 
+    # #13268: this route has no FastAPI auth dependency and is listed in neither
+    # EXEMPT_PATHS nor SERVICE_ONLY_PATHS, so the MCP secret is the entire
+    # boundary. Resolve the caller address for the pre-auth throttle.
+    # get_client_ip only honours X-Forwarded-For from a trusted proxy peer, but
+    # the shipped nginx templates APPEND with $proxy_add_x_forwarded_for, so the
+    # leftmost element is still caller-supplied. The throttle therefore also
+    # enforces an endpoint-wide ceiling that IP rotation cannot evade.
+    client_ip = get_client_ip(request)
+
     try:
         body = await request.json()
-    except Exception:
+    except Exception as exc:
+        logger.warning("mcp_tool_call: rejecting unparseable JSON-RPC body: %s", exc)
         return JSONResponse(
             status_code=400,
             content={"jsonrpc": "2.0", "id": None, "error": {"code": -32700, "message": "Parse error"}},
@@ -64,7 +75,7 @@ async def mcp_tool_call(request: Request) -> JSONResponse:
     req_id = body.get("id")
 
     server = _get_server()
-    response = await server.handle_request(method, params, token, req_id)
+    response = await server.handle_request(method, params, token, req_id, client_ip=client_ip)
 
     status = 200
     if "error" in response:

--- a/autobot-backend/api/autobot_mcp_router_test.py
+++ b/autobot-backend/api/autobot_mcp_router_test.py
@@ -15,6 +15,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+import api.autobot_mcp_router as mcp_router
 from api.autobot_mcp_router import router
 
 # ---------------------------------------------------------------------------
@@ -25,6 +26,20 @@ app = FastAPI()
 app.include_router(router, prefix="/api")
 
 client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _reset_server_singleton():
+    """Clear the module-level server cache between tests.
+
+    _get_server() memoises the instance in a module global, so
+    patch("api.autobot_mcp_router.AutoBotMCPServer") only took effect for the
+    first request in the session — every later test silently reused the first
+    test's mock (or a real server) and asserted against the wrong object.
+    """
+    mcp_router._server = None
+    yield
+    mcp_router._server = None
 
 
 def _json_rpc_body(method: str = "tools/call", name: str = "kb.search") -> dict:
@@ -93,3 +108,37 @@ def test_malformed_json_returns_400() -> None:
     assert response.status_code == 400
     body = response.json()
     assert body["error"]["code"] == -32700
+
+
+def test_client_ip_is_forwarded_to_the_throttle() -> None:
+    """#13268: the route must hand the resolved caller address to handle_request."""
+    handler = AsyncMock(return_value={"jsonrpc": "2.0", "id": 1, "result": {}})
+    with patch("api.autobot_mcp_router.AutoBotMCPServer") as mock_cls, patch(
+        "api.autobot_mcp_router.get_client_ip", return_value="203.0.113.9"
+    ):
+        mock_cls.return_value.handle_request = handler
+        client.post(
+            "/api/mcp/tool",
+            json=_json_rpc_body(),
+            headers={"Authorization": "Bearer test-token"},
+        )
+
+    assert handler.await_args.kwargs["client_ip"] == "203.0.113.9"
+
+
+def test_forwarded_header_is_ignored_from_an_untrusted_peer() -> None:
+    """X-Forwarded-For must not be honoured when the TCP peer is not a trusted proxy.
+
+    TestClient connects as 'testclient', which is not in AUTOBOT_TRUSTED_PROXIES,
+    so the spoofed header must not become the throttle key.
+    """
+    handler = AsyncMock(return_value={"jsonrpc": "2.0", "id": 1, "result": {}})
+    with patch("api.autobot_mcp_router.AutoBotMCPServer") as mock_cls:
+        mock_cls.return_value.handle_request = handler
+        client.post(
+            "/api/mcp/tool",
+            json=_json_rpc_body(),
+            headers={"Authorization": "Bearer test-token", "X-Forwarded-For": "198.51.100.77"},
+        )
+
+    assert handler.await_args.kwargs["client_ip"] != "198.51.100.77"

--- a/autobot-backend/api/autobot_mcp_router_test.py
+++ b/autobot-backend/api/autobot_mcp_router_test.py
@@ -113,8 +113,9 @@ def test_malformed_json_returns_400() -> None:
 def test_client_ip_is_forwarded_to_the_throttle() -> None:
     """#13268: the route must hand the resolved caller address to handle_request."""
     handler = AsyncMock(return_value={"jsonrpc": "2.0", "id": 1, "result": {}})
-    with patch("api.autobot_mcp_router.AutoBotMCPServer") as mock_cls, patch(
-        "api.autobot_mcp_router.get_client_ip", return_value="203.0.113.9"
+    with (
+        patch("api.autobot_mcp_router.AutoBotMCPServer") as mock_cls,
+        patch("api.autobot_mcp_router.get_client_ip", return_value="203.0.113.9"),
     ):
         mock_cls.return_value.handle_request = handler
         client.post(

--- a/autobot-backend/docs/mcp-server.md
+++ b/autobot-backend/docs/mcp-server.md
@@ -103,6 +103,15 @@ the Redis token lookup it would otherwise drive once per attempt.
 | `AUTOBOT_MCP_AUTH_GLOBAL_MAX_FAILURES` | `100` | Failures across **all** IPs per window |
 | `AUTOBOT_MCP_AUTH_MAX_TRACKED_IPS` | `4096` | Cap on tracked IPs (bounds memory) |
 
+The throttle is **per backend process**, held in memory. Under N uvicorn workers
+the effective limits are N times the values above, and a restart clears the
+state. Size them per process, not per cluster.
+
+A caller that authenticated within the window is exempt from the endpoint-wide
+ceiling (never from its own per-IP budget), so a flood of anonymous failures
+cannot take the endpoint offline for clients that are demonstrably not the
+source. An attacker cannot enter that set without first authenticating.
+
 The endpoint-wide ceiling exists because the per-IP counter alone is not
 sufficient: the shipped nginx templates set
 `proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for`, which *appends* the

--- a/autobot-backend/docs/mcp-server.md
+++ b/autobot-backend/docs/mcp-server.md
@@ -6,13 +6,17 @@ Exposes AutoBot's KB, memory graph, and agent introspection as an MCP server for
 
 **stdio** (default — used by Claude Code / Cline):
 ```bash
-AUTOBOT_MCP_TOKEN="$MCP_SECRET:kb,memory,agents" python -m mcp.autobot_mcp_main
+AUTOBOT_MCP_TOKEN="$MCP_SECRET" python -m mcp.autobot_mcp_main
 ```
 
 **HTTP** (standalone aiohttp on port 8200):
 ```bash
-AUTOBOT_MCP_TOKEN="$MCP_SECRET:kb,memory,agents" python -m mcp.autobot_mcp_main --http
+AUTOBOT_MCP_TOKEN="$MCP_SECRET" python -m mcp.autobot_mcp_main --http
 ```
+
+`AUTOBOT_MCP_TOKEN` holds the **secret only** — never a full `<secret>:<scopes>`
+token (#13266). A value containing `:` is rejected at startup with a message
+saying so.
 
 The HTTP transport is also available via the FastAPI backend at `POST /api/mcp/tool`.
 
@@ -20,7 +24,13 @@ The HTTP transport is also available via the FastAPI backend at `POST /api/mcp/t
 
 Token format: `<secret>:<scope1>,<scope2>`
 
-Set the shared secret via `AUTOBOT_MCP_TOKEN` (the part before the first `:`).
+Set the shared secret via `AUTOBOT_MCP_TOKEN`. That variable has exactly one
+meaning: the secret segment — the part before the first `:`. It is never the
+whole token (#13266).
+
+The stdio transport composes its own bearer as `<AUTOBOT_MCP_TOKEN>:<AUTOBOT_MCP_STDIO_SCOPES>`,
+where `AUTOBOT_MCP_STDIO_SCOPES` defaults to `kb,memory,agents`. Scope names are
+not a credential; the secret is.
 
 > **The secret is the entire check.** A caller presenting a valid secret chooses its
 > own scopes from the token string, so anyone holding it has every scope regardless
@@ -39,7 +49,8 @@ Set the shared secret via `AUTOBOT_MCP_TOKEN` (the part before the first `:`).
 
 Available scopes: `kb`, `memory`, `agents`.
 
-Pass as `Authorization: Bearer <token>` for HTTP, or set `AUTOBOT_MCP_TOKEN` for stdio.
+Pass the full `<secret>:<scopes>` token as `Authorization: Bearer <token>` for HTTP.
+For stdio, set `AUTOBOT_MCP_TOKEN` (secret) and optionally `AUTOBOT_MCP_STDIO_SCOPES`.
 
 ## Tools
 
@@ -66,7 +77,10 @@ Add to your MCP config (e.g. `.claude/mcp.json`):
       "command": "python",
       "args": ["-m", "mcp.autobot_mcp_main"],
       "cwd": "/opt/autobot/autobot-backend",
-      "env": { "AUTOBOT_MCP_TOKEN": "<your-secret>:kb,memory,agents" }
+      "env": {
+        "AUTOBOT_MCP_TOKEN": "<your-secret>",
+        "AUTOBOT_MCP_STDIO_SCOPES": "kb,memory,agents"
+      }
     }
   }
 }
@@ -74,4 +88,31 @@ Add to your MCP config (e.g. `.claude/mcp.json`):
 
 ## Rate limiting
 
-50 requests per 60-second window per token. Excess requests receive HTTP 429 / JSON-RPC error code `-32029`.
+Two layers, both answering HTTP 429 / JSON-RPC `-32029`.
+
+**Pre-authentication (#13268).** `POST /api/mcp/tool` has no auth layer other than
+the MCP secret, so failed authentications are counted *before* the token is
+validated — guessing the secret is metered, and a rejected caller never reaches
+the Redis token lookup it would otherwise drive once per attempt.
+
+| Setting | Default | Meaning |
+|---|---|---|
+| `AUTOBOT_MCP_AUTH_MAX_FAILURES` | `10` | Failures per client IP per window before lockout |
+| `AUTOBOT_MCP_AUTH_WINDOW_SECONDS` | `300` | Sliding window over which failures accumulate |
+| `AUTOBOT_MCP_AUTH_LOCKOUT_SECONDS` | `900` | How long a tripped client stays blocked |
+| `AUTOBOT_MCP_AUTH_GLOBAL_MAX_FAILURES` | `100` | Failures across **all** IPs per window |
+| `AUTOBOT_MCP_AUTH_MAX_TRACKED_IPS` | `4096` | Cap on tracked IPs (bounds memory) |
+
+The endpoint-wide ceiling exists because the per-IP counter alone is not
+sufficient: the shipped nginx templates set
+`proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for`, which *appends* the
+peer to whatever the client sent, so the leftmost address a proxied caller
+presents is caller-controlled. Rotating it defeats a per-IP lockout; it does not
+defeat the global ceiling. A successful authentication clears the caller's record,
+so ordinary traffic is unaffected.
+
+If a deployment terminates TLS somewhere that rewrites `X-Forwarded-For` to the
+true client address, set `AUTOBOT_TRUSTED_PROXIES` to that proxy and the per-IP
+layer becomes accurate as well.
+
+**Post-authentication.** 50 requests per 60-second window per token.

--- a/autobot-backend/mcp/auth_throttle.py
+++ b/autobot-backend/mcp/auth_throttle.py
@@ -1,0 +1,214 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Pre-authentication throttle for the MCP HTTP transport (#13268).
+
+``POST /api/mcp/tool`` has no auth layer other than the shared MCP secret
+(``middleware/service_auth_enforcement.py`` lists the path in neither
+``EXEMPT_PATHS`` nor ``SERVICE_ONLY_PATHS``, so it falls through to
+``call_next``).  Until #13268 the only rate limiter ran *after* a successful
+token check, which left two holes:
+
+1. Guessing the secret was free — failed attempts were never counted.
+2. Every failed attempt reached ``_validate_redis_token``'s Redis ``GET``
+   before rejection, so an unauthenticated caller could drive Redis load at
+   request rate.
+
+This module counts *failures* before any validation work happens.
+
+Why the counter is not keyed on the token
+-----------------------------------------
+The post-auth bucket keys on ``auth_token[:16]``.  That is safe only because
+it runs after authentication; keying a *pre-auth* counter on caller-supplied
+token bytes would let an attacker grow the map without bound.  Failures are
+therefore keyed on client IP, and the map itself is capped
+(``AUTOBOT_MCP_AUTH_MAX_TRACKED_IPS``) with oldest-first eviction.
+
+Why a per-IP counter alone is not enough
+----------------------------------------
+``get_client_ip()`` honours ``X-Forwarded-For`` when the TCP peer is a trusted
+proxy, and takes the leftmost value.  The shipped nginx templates set
+``proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for``, which
+*appends* the peer to whatever the client sent — so behind the proxy the
+leftmost element is attacker-controlled.  A per-IP lockout is therefore
+defeated by rotating one header value per request.
+
+To close that, failures are counted twice: per IP *and* globally across all
+IPs in the same window.  The global ceiling is not something a caller can
+rotate away from, so brute force is bounded even when every request claims a
+fresh source address.  Legitimate traffic is unaffected because a successful
+authentication clears the failure record.
+
+All thresholds come from ``autobot_shared.ssot_config`` (env-fed); nothing is
+hardcoded at a call site.
+"""
+
+from __future__ import annotations
+
+import time
+from collections import OrderedDict, deque
+from typing import Deque, Tuple
+
+from autobot_shared.logging_manager import get_logger
+from autobot_shared.ssot_config import config
+
+logger = get_logger(__name__)
+
+#: Sentinel used when the transport cannot determine a peer address.
+UNKNOWN_IP = "unknown"
+
+
+def _max_failures() -> int:
+    """Failed attempts per IP within the window before that IP is locked out."""
+    return int(config.mcp_auth_max_failures)
+
+
+def _window_seconds() -> float:
+    """Sliding window over which failures accumulate."""
+    return float(config.mcp_auth_window_seconds)
+
+
+def _lockout_seconds() -> float:
+    """How long a tripped IP stays blocked after its last failure."""
+    return float(config.mcp_auth_lockout_seconds)
+
+
+def _global_max_failures() -> int:
+    """Failures across all IPs in one window before the endpoint sheds load."""
+    return int(config.mcp_auth_global_max_failures)
+
+
+def _max_tracked_ips() -> int:
+    """Upper bound on tracked IPs; oldest entries are evicted past this."""
+    return int(config.mcp_auth_max_tracked_ips)
+
+
+class _IpRecord:
+    """Failure timestamps and lockout expiry for a single client IP."""
+
+    __slots__ = ("failures", "locked_until")
+
+    def __init__(self) -> None:
+        self.failures: Deque[float] = deque()
+        self.locked_until: float = 0.0
+
+    def prune(self, cutoff: float) -> None:
+        """Drop failure timestamps older than *cutoff*."""
+        while self.failures and self.failures[0] <= cutoff:
+            self.failures.popleft()
+
+
+class PreAuthThrottle:
+    """Counts failed MCP authentications before any validation work runs.
+
+    Not thread-safe by design: the FastAPI route is async and single-threaded
+    per event loop, matching the existing ``_TokenBucket`` in
+    ``mcp/autobot_server.py``.
+    """
+
+    def __init__(self) -> None:
+        """Initialise empty per-IP and global failure state."""
+        self._ips: "OrderedDict[str, _IpRecord]" = OrderedDict()
+        self._global_failures: Deque[float] = deque()
+
+    # -- internal helpers ------------------------------------------------
+
+    def _record_for(self, ip: str) -> _IpRecord:
+        """Return the record for *ip*, creating and size-capping as needed."""
+        record = self._ips.get(ip)
+        if record is None:
+            record = _IpRecord()
+            self._ips[ip] = record
+        self._ips.move_to_end(ip)
+        self._evict_overflow()
+        return record
+
+    def _evict_overflow(self) -> None:
+        """Evict least-recently-touched IPs so the map stays bounded."""
+        limit = _max_tracked_ips()
+        while limit > 0 and len(self._ips) > limit:
+            evicted, _ = self._ips.popitem(last=False)
+            logger.warning(
+                "mcp_throttle: tracker full (limit=%d), evicted least-recent IP entry "
+                "— source addresses may be spoofed; the global ceiling still applies",
+                limit,
+            )
+
+    def _prune_global(self, cutoff: float) -> None:
+        """Drop global failure timestamps older than *cutoff*."""
+        while self._global_failures and self._global_failures[0] <= cutoff:
+            self._global_failures.popleft()
+
+    # -- public API ------------------------------------------------------
+
+    def check(self, ip: str, now: float | None = None) -> Tuple[bool, str]:
+        """Return ``(blocked, reason)`` for *ip* without mutating counters.
+
+        Called before token validation so a locked-out caller never reaches
+        the Redis lookup in ``_validate_redis_token``.
+        """
+        now = time.monotonic() if now is None else now
+        cutoff = now - _window_seconds()
+
+        self._prune_global(cutoff)
+        global_ceiling = _global_max_failures()
+        if global_ceiling > 0 and len(self._global_failures) >= global_ceiling:
+            return True, (
+                f"endpoint-wide auth failure ceiling reached "
+                f"({len(self._global_failures)}/{global_ceiling} in {_window_seconds():.0f}s)"
+            )
+
+        record = self._ips.get(ip)
+        if record is None:
+            return False, ""
+        if record.locked_until > now:
+            return True, f"client locked out for a further {record.locked_until - now:.0f}s"
+
+        record.prune(cutoff)
+        limit = _max_failures()
+        if limit > 0 and len(record.failures) >= limit:
+            return True, f"{len(record.failures)} failed attempts in {_window_seconds():.0f}s (limit {limit})"
+        return False, ""
+
+    def record_failure(self, ip: str, now: float | None = None) -> None:
+        """Count one failed authentication from *ip* and arm lockout if tripped."""
+        now = time.monotonic() if now is None else now
+        cutoff = now - _window_seconds()
+
+        record = self._record_for(ip)
+        record.prune(cutoff)
+        record.failures.append(now)
+
+        self._prune_global(cutoff)
+        self._global_failures.append(now)
+
+        limit = _max_failures()
+        if limit > 0 and len(record.failures) >= limit:
+            record.locked_until = now + _lockout_seconds()
+            logger.warning(
+                "mcp_throttle: locking out client for %.0fs after %d failed MCP auth attempts in %.0fs",
+                _lockout_seconds(),
+                len(record.failures),
+                _window_seconds(),
+            )
+
+    def record_success(self, ip: str) -> None:
+        """Clear the failure record for *ip* after a successful authentication."""
+        self._ips.pop(ip, None)
+
+    def reset(self) -> None:
+        """Drop all state. Test helper; also usable for an operator unblock."""
+        self._ips.clear()
+        self._global_failures.clear()
+
+
+_throttle: PreAuthThrottle | None = None
+
+
+def get_pre_auth_throttle() -> PreAuthThrottle:
+    """Return the process-wide PreAuthThrottle singleton."""
+    global _throttle
+    if _throttle is None:
+        _throttle = PreAuthThrottle()
+    return _throttle

--- a/autobot-backend/mcp/auth_throttle.py
+++ b/autobot-backend/mcp/auth_throttle.py
@@ -111,28 +111,55 @@ class PreAuthThrottle:
         """Initialise empty per-IP and global failure state."""
         self._ips: "OrderedDict[str, _IpRecord]" = OrderedDict()
         self._global_failures: Deque[float] = deque()
+        # Callers that authenticated within the window. Exempt from the global
+        # ceiling only (see check) so a flood of anonymous failures cannot take
+        # the endpoint offline for clients that are demonstrably not the source.
+        self._recent_success: "OrderedDict[str, float]" = OrderedDict()
+        self._last_evict_log: float = 0.0
 
     # -- internal helpers ------------------------------------------------
 
-    def _record_for(self, ip: str) -> _IpRecord:
+    def _record_for(self, ip: str, now: float) -> _IpRecord:
         """Return the record for *ip*, creating and size-capping as needed."""
         record = self._ips.get(ip)
         if record is None:
             record = _IpRecord()
             self._ips[ip] = record
         self._ips.move_to_end(ip)
-        self._evict_overflow()
+        self._evict_overflow(now)
         return record
 
-    def _evict_overflow(self) -> None:
-        """Evict least-recently-touched IPs so the map stays bounded."""
+    def _evict_overflow(self, now: float) -> None:
+        """Evict least-recently-touched entries so the maps stay bounded.
+
+        N1: eviction is oldest-first, so an attacker who rotates enough source
+        addresses can push their own record out and clear their per-IP lockout.
+        The per-IP tier is therefore NON-AUTHORITATIVE by construction — it exists
+        to stop naive repetition cheaply. The endpoint-wide ceiling in check() is
+        the control that actually bounds a rotating attacker, and it cannot be
+        evicted because it is a single counter, not a keyed entry.
+
+        N3: the eviction warning is sampled to once per window. Logging inside
+        this loop would give an unauthenticated caller a log line per rotating-IP
+        request — the same amplification #13268 set out to close.
+        """
         limit = _max_tracked_ips()
-        while limit > 0 and len(self._ips) > limit:
-            evicted, _ = self._ips.popitem(last=False)
+        if limit <= 0:
+            return
+        evicted = 0
+        while len(self._ips) > limit:
+            self._ips.popitem(last=False)
+            evicted += 1
+        while len(self._recent_success) > limit:
+            self._recent_success.popitem(last=False)
+        if evicted and now - self._last_evict_log >= _window_seconds():
+            self._last_evict_log = now
             logger.warning(
-                "mcp_throttle: tracker full (limit=%d), evicted least-recent IP entry "
-                "— source addresses may be spoofed; the global ceiling still applies",
+                "mcp_throttle: tracker at limit=%d, evicted %d least-recent entries in the last %.0fs "
+                "— source addresses may be spoofed; the endpoint-wide ceiling still applies",
                 limit,
+                evicted,
+                _window_seconds(),
             )
 
     def _prune_global(self, cutoff: float) -> None:
@@ -151,14 +178,24 @@ class PreAuthThrottle:
         now = time.monotonic() if now is None else now
         cutoff = now - _window_seconds()
 
-        self._prune_global(cutoff)
-        global_ceiling = _global_max_failures()
-        if global_ceiling > 0 and len(self._global_failures) >= global_ceiling:
-            return True, (
-                f"endpoint-wide auth failure ceiling reached "
-                f"({len(self._global_failures)}/{global_ceiling} in {_window_seconds():.0f}s)"
-            )
+        # B2: the ceiling sheds only callers that have not proven themselves.
+        # Applying it unconditionally made 100 anonymous failures per window
+        # enough to take the endpoint offline platform-wide for everyone,
+        # including holders of a valid token — an unauthenticated DoS.
+        # The anti-rotation property survives: an attacker cannot join
+        # _recent_success without first authenticating.
+        if not self._has_recent_success(ip, cutoff):
+            self._prune_global(cutoff)
+            global_ceiling = _global_max_failures()
+            if global_ceiling > 0 and len(self._global_failures) >= global_ceiling:
+                return True, (
+                    f"endpoint-wide auth failure ceiling reached "
+                    f"({len(self._global_failures)}/{global_ceiling} in {_window_seconds():.0f}s)"
+                )
 
+        # A recent success exempts a caller from the CEILING only, never from its
+        # own per-IP budget below: authenticating once must not buy an unlimited
+        # licence to guess afterwards.
         record = self._ips.get(ip)
         if record is None:
             return False, ""
@@ -176,7 +213,7 @@ class PreAuthThrottle:
         now = time.monotonic() if now is None else now
         cutoff = now - _window_seconds()
 
-        record = self._record_for(ip)
+        record = self._record_for(ip, now)
         record.prune(cutoff)
         record.failures.append(now)
 
@@ -193,14 +230,42 @@ class PreAuthThrottle:
                 _window_seconds(),
             )
 
-    def record_success(self, ip: str) -> None:
-        """Clear the failure record for *ip* after a successful authentication."""
+    def _has_recent_success(self, ip: str, cutoff: float) -> bool:
+        """Return True if *ip* authenticated within the current window."""
+        ts = self._recent_success.get(ip)
+        if ts is None:
+            return False
+        if ts <= cutoff:
+            del self._recent_success[ip]
+            return False
+        return True
+
+    def record_success(self, ip: str, now: float | None = None) -> None:
+        """Clear *ip*'s failure record and exempt it from the ceiling for one window.
+
+        The global counter is deliberately NOT cleared here. It is the only
+        control that bounds an attacker who rotates source addresses, and behind
+        an appending proxy the caller chooses the address it presents — so
+        clearing it on any single success would hand that attacker a reset button
+        (they need one valid credential, or one spoofed address that recently
+        succeeded). Do not "fix" the ceiling by draining it on success.
+
+        N2: for the same reason, note that a valid-credential holder can clear
+        the per-IP record of an address it does not own. That tier is already
+        non-authoritative (see _evict_overflow); the ceiling is not affected.
+        """
+        now = time.monotonic() if now is None else now
         self._ips.pop(ip, None)
+        self._recent_success[ip] = now
+        self._recent_success.move_to_end(ip)
+        self._evict_overflow(now)
 
     def reset(self) -> None:
         """Drop all state. Test helper; also usable for an operator unblock."""
         self._ips.clear()
         self._global_failures.clear()
+        self._recent_success.clear()
+        self._last_evict_log = 0.0
 
 
 _throttle: PreAuthThrottle | None = None

--- a/autobot-backend/mcp/auth_throttle_test.py
+++ b/autobot-backend/mcp/auth_throttle_test.py
@@ -117,9 +117,7 @@ async def test_ip_rotation_does_not_defeat_the_throttle():
     with _limits(max_failures=100, global_max=global_max):
         codes = []
         for i in range(global_max + 2):
-            resp = await server.handle_request(
-                "tools/list", {}, BAD_TOKEN, req_id=1, client_ip=f"198.51.100.{i}"
-            )
+            resp = await server.handle_request("tools/list", {}, BAD_TOKEN, req_id=1, client_ip=f"198.51.100.{i}")
             codes.append(resp["error"]["code"])
 
     assert codes[:global_max] == [-32001] * global_max, codes

--- a/autobot-backend/mcp/auth_throttle_test.py
+++ b/autobot-backend/mcp/auth_throttle_test.py
@@ -1,0 +1,181 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Tests for the MCP pre-authentication throttle (#13268).
+
+Coverage:
+- A run of failed authentications is blocked once the per-IP limit is reached
+  (demonstrated by counting attempts, not asserted abstractly)
+- Blocking happens BEFORE token validation, so the Redis lookup in
+  _validate_redis_token is never reached by a locked-out caller
+- Rotating the source IP does not defeat the throttle: the endpoint-wide
+  ceiling still trips
+- A successful authentication clears the caller's failure record
+- The tracked-IP map stays bounded when source addresses are spoofed
+- Lockout expires after the configured duration
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from autobot_shared.ssot_config import config
+from mcp.auth_throttle import PreAuthThrottle, get_pre_auth_throttle
+from mcp.autobot_server import AutoBotMCPServer
+
+TEST_SECRET = "test-mcp-secret"
+VALID_TOKEN = f"{TEST_SECRET}:kb,memory,agents"
+BAD_TOKEN = "wrong-secret:kb,memory,agents"
+CLIENT_IP = "203.0.113.7"
+
+
+@pytest.fixture(autouse=True)
+def _configure_mcp_secret():
+    """Configure a secret and reset throttle state between tests."""
+    get_pre_auth_throttle().reset()
+    with patch.object(config.misc, "mcp_token", TEST_SECRET):
+        yield
+    get_pre_auth_throttle().reset()
+
+
+@pytest.fixture(autouse=True)
+def _no_redis_fallback():
+    """Stop the Redis token fallback from touching a real Redis in unit tests."""
+    with patch.object(AutoBotMCPServer, "_validate_redis_token", AsyncMock(return_value=None)):
+        yield
+
+
+def _limits(max_failures=3, window=60, lockout=300, global_max=100, tracked=4096):
+    """Patch the env-fed throttle limits to small, fast values."""
+    return patch.multiple(
+        config.misc,
+        mcp_auth_max_failures=max_failures,
+        mcp_auth_window_seconds=window,
+        mcp_auth_lockout_seconds=lockout,
+        mcp_auth_global_max_failures=global_max,
+        mcp_auth_max_tracked_ips=tracked,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Demonstration: N failed attempts, then blocked
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_brute_force_is_blocked_after_configured_attempts():
+    """#13268: the Nth+1 guess is throttled, not merely rejected."""
+    server = AutoBotMCPServer()
+    max_failures = 3
+
+    with _limits(max_failures=max_failures):
+        codes = []
+        for _ in range(max_failures + 2):
+            resp = await server.handle_request("tools/list", {}, BAD_TOKEN, req_id=1, client_ip=CLIENT_IP)
+            codes.append(resp["error"]["code"])
+
+    # First `max_failures` guesses are metered auth rejections (-32001);
+    # everything after is throttled (-32029) without reaching validation.
+    assert codes[:max_failures] == [-32001] * max_failures, codes
+    assert codes[max_failures:] == [-32029, -32029], codes
+
+
+@pytest.mark.asyncio
+async def test_throttle_blocks_before_redis_lookup():
+    """#13268: a locked-out caller cannot be used as a Redis amplifier."""
+    server = AutoBotMCPServer()
+    redis_probe = AsyncMock(return_value=None)
+
+    with _limits(max_failures=2), patch.object(AutoBotMCPServer, "_validate_redis_token", redis_probe):
+        for _ in range(2):
+            await server.handle_request("tools/list", {}, BAD_TOKEN, req_id=1, client_ip=CLIENT_IP)
+        calls_before = redis_probe.await_count
+
+        resp = await server.handle_request("tools/list", {}, BAD_TOKEN, req_id=1, client_ip=CLIENT_IP)
+
+    assert resp["error"]["code"] == -32029
+    assert redis_probe.await_count == calls_before, "throttled request still reached the Redis fallback"
+
+
+# ---------------------------------------------------------------------------
+# IP rotation resistance
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ip_rotation_does_not_defeat_the_throttle():
+    """#13268: X-Forwarded-For is caller-controlled behind an appending proxy.
+
+    Every request claims a brand-new source address, so the per-IP counter never
+    trips. The endpoint-wide ceiling must still stop the run.
+    """
+    server = AutoBotMCPServer()
+    global_max = 5
+
+    with _limits(max_failures=100, global_max=global_max):
+        codes = []
+        for i in range(global_max + 2):
+            resp = await server.handle_request(
+                "tools/list", {}, BAD_TOKEN, req_id=1, client_ip=f"198.51.100.{i}"
+            )
+            codes.append(resp["error"]["code"])
+
+    assert codes[:global_max] == [-32001] * global_max, codes
+    assert codes[global_max:] == [-32029, -32029], codes
+
+
+def test_tracked_ip_map_stays_bounded():
+    """#13268: spoofed source addresses must not grow the tracker without bound."""
+    throttle = PreAuthThrottle()
+    with _limits(tracked=16, global_max=0, max_failures=100):
+        for i in range(200):
+            throttle.record_failure(f"198.51.100.{i}")
+    assert len(throttle._ips) == 16
+
+
+# ---------------------------------------------------------------------------
+# Success clears state; lockout expires
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_successful_auth_clears_failure_record():
+    """A legitimate client that mistypes its token once is not penalised later."""
+    server = AutoBotMCPServer()
+
+    with _limits(max_failures=3):
+        for _ in range(2):
+            await server.handle_request("tools/list", {}, BAD_TOKEN, req_id=1, client_ip=CLIENT_IP)
+
+        ok = await server.handle_request("tools/list", {}, VALID_TOKEN, req_id=1, client_ip=CLIENT_IP)
+        assert "result" in ok
+
+        # Budget is reset, so two more failures still do not trip the limit.
+        for _ in range(2):
+            resp = await server.handle_request("tools/list", {}, BAD_TOKEN, req_id=1, client_ip=CLIENT_IP)
+            assert resp["error"]["code"] == -32001
+
+
+def test_lockout_expires_after_configured_duration():
+    """The block lifts once mcp_auth_lockout_seconds has elapsed."""
+    throttle = PreAuthThrottle()
+    with _limits(max_failures=2, window=60, lockout=300):
+        for _ in range(2):
+            throttle.record_failure(CLIENT_IP, now=1000.0)
+
+        blocked, reason = throttle.check(CLIENT_IP, now=1001.0)
+        assert blocked and reason
+
+        blocked_later, _ = throttle.check(CLIENT_IP, now=1000.0 + 300 + 61)
+        assert not blocked_later
+
+
+def test_check_does_not_consume_budget():
+    """check() must be side-effect free so a probe cannot lock a victim out."""
+    throttle = PreAuthThrottle()
+    with _limits(max_failures=3):
+        throttle.record_failure(CLIENT_IP)
+        for _ in range(10):
+            assert throttle.check(CLIENT_IP)[0] is False

--- a/autobot-backend/mcp/auth_throttle_test.py
+++ b/autobot-backend/mcp/auth_throttle_test.py
@@ -177,3 +177,70 @@ def test_check_does_not_consume_budget():
         throttle.record_failure(CLIENT_IP)
         for _ in range(10):
             assert throttle.check(CLIENT_IP)[0] is False
+
+
+# ---------------------------------------------------------------------------
+# The endpoint-wide ceiling must not become an unauthenticated DoS
+# ---------------------------------------------------------------------------
+
+
+def test_ceiling_does_not_block_a_caller_that_never_failed():
+    """B2: a flood of anonymous failures must not take the endpoint offline for everyone.
+
+    Applying the ceiling unconditionally meant N junk requests per window blocked
+    every caller — including holders of a valid token — indefinitely, with no
+    operator-reachable way to clear it.
+    """
+    throttle = PreAuthThrottle()
+    with _limits(max_failures=100, global_max=10):
+        for i in range(10):
+            throttle.record_failure(f"198.51.100.{i}")
+
+        # A caller that has authenticated within the window stays reachable.
+        throttle.record_success(CLIENT_IP)
+        assert throttle.check(CLIENT_IP) == (False, "")
+
+
+def test_success_does_not_drain_the_global_counter():
+    """The ceiling is the only anti-rotation control; one success must not reset it."""
+    throttle = PreAuthThrottle()
+    with _limits(max_failures=100, global_max=10):
+        for i in range(10):
+            throttle.record_failure(f"198.51.100.{i}")
+        throttle.record_success(CLIENT_IP)
+
+        assert len(throttle._global_failures) == 10
+        # An address with no recent success is still shed.
+        assert throttle.check("198.51.100.200")[0] is True
+
+
+def test_recent_success_does_not_exempt_from_the_per_ip_budget():
+    """Authenticating once must not buy an unlimited licence to guess afterwards."""
+    throttle = PreAuthThrottle()
+    with _limits(max_failures=3, global_max=0):
+        throttle.record_success(CLIENT_IP)
+        for _ in range(3):
+            throttle.record_failure(CLIENT_IP)
+        assert throttle.check(CLIENT_IP)[0] is True
+
+
+def test_recent_success_expires_with_the_window():
+    """The exemption is not permanent."""
+    throttle = PreAuthThrottle()
+    with _limits(max_failures=100, window=60, global_max=5):
+        throttle.record_success(CLIENT_IP, now=1000.0)
+        # Failures land later than the success so they outlive the exemption.
+        for i in range(5):
+            throttle.record_failure(f"198.51.100.{i}", now=1040.0)
+
+        assert throttle.check(CLIENT_IP, now=1050.0)[0] is False, "exempt while the success is fresh"
+        assert throttle.check(CLIENT_IP, now=1090.0)[0] is True, "exemption must expire with the window"
+
+
+def test_recent_success_map_stays_bounded():
+    """The exemption set needs the same bound as the failure tracker."""
+    throttle = PreAuthThrottle()
+    with _limits(tracked=16):
+        for i in range(200):
+            throttle.record_success(f"198.51.100.{i}")
+    assert len(throttle._recent_success) == 16

--- a/autobot-backend/mcp/autobot_server.py
+++ b/autobot-backend/mcp/autobot_server.py
@@ -432,6 +432,22 @@ class AutoBotMCPServer:
             logger.warning("_validate_redis_token: unexpected error: %s", exc)
             return None
 
+    @staticmethod
+    def _pre_auth_gate(method: str, client_ip: str, req_id: Any) -> Dict[str, Any] | None:
+        """Reject *client_ip* if it has exhausted its failed-auth budget (#13268).
+
+        Runs BEFORE any validation work: ahead of _validate_redis_token so a
+        locked-out caller cannot drive a Redis GET per request, and ahead of the
+        secret comparison so guessing the secret is metered.
+
+        Returns a JSON-RPC error to send, or None to continue.
+        """
+        blocked, reason = get_pre_auth_throttle().check(client_ip)
+        if not blocked:
+            return None
+        logger.warning("mcp_auth: pre-auth throttle blocked method=%s — %s", method or "<none>", reason)
+        return _err(-32029, f"Too many failed authentication attempts: {reason}", req_id)
+
     async def _authenticate(
         self,
         params: Dict[str, Any],
@@ -521,19 +537,10 @@ class AutoBotMCPServer:
         Returns:
             JSON-RPC response dict (always includes ``jsonrpc`` and ``id``).
         """
-        # #13268: throttle BEFORE any validation work. This runs ahead of
-        # _validate_redis_token so a locked-out caller cannot drive a Redis GET
-        # per request, and ahead of the secret comparison so guessing is metered.
         ip = client_ip or UNKNOWN_IP
-        throttle = get_pre_auth_throttle()
-        blocked, reason = throttle.check(ip)
-        if blocked:
-            logger.warning(
-                "mcp_auth: pre-auth throttle blocked method=%s — %s",
-                method or "<none>",
-                reason,
-            )
-            return _err(-32029, f"Too many failed authentication attempts: {reason}", req_id)
+        throttled = self._pre_auth_gate(method, ip, req_id)
+        if throttled is not None:
+            return throttled
 
         # Bucket key is captured before _authenticate pops run_jwt out of params.
         run_jwt_preview = params.get("run_jwt") if isinstance(params, dict) else None

--- a/autobot-backend/mcp/autobot_server.py
+++ b/autobot-backend/mcp/autobot_server.py
@@ -15,14 +15,24 @@ Architecture:
         └── agents.*   → AgentDiaryService + agents/ directory listing
 
 Auth:
-    HTTP transport: ``Authorization: Bearer <token>`` header.
-    stdio transport: ``AUTOBOT_MCP_TOKEN`` environment variable.
-    Tokens carry comma-separated scopes: ``kb``, ``memory``, ``agents``.
-    Dev/test override: set ``AUTOBOT_MCP_TOKEN=dev:kb,memory,agents``.
+    Bearer tokens have the form ``<secret>:<scope1>,<scope2>`` and carry the
+    scopes ``kb``, ``memory``, ``agents``.
+
+    ``AUTOBOT_MCP_TOKEN`` is the SECRET SEGMENT ONLY — never the whole bearer
+    token (#13266).  It has no default: an unconfigured secret rejects every
+    request rather than authenticating everyone.
+
+    HTTP transport:  caller supplies ``Authorization: Bearer <secret>:<scopes>``.
+    stdio transport: composes its own bearer from ``AUTOBOT_MCP_TOKEN`` plus
+                     ``AUTOBOT_MCP_STDIO_SCOPES`` (see _stdio_bearer_token).
 
 Rate limiting:
-    Simple in-memory token-bucket: 50 req/min per token.
-    Excess requests receive a JSON-RPC error (code -32029).
+    Pre-auth (#13268): failed authentications are counted per client IP *and*
+    against an endpoint-wide ceiling before any validation work runs, so the
+    secret cannot be brute-forced unmetered and failed attempts cannot be used
+    as a Redis amplifier.  See mcp/auth_throttle.py.
+    Post-auth: in-memory token bucket per token prefix.
+    Both reject with JSON-RPC error code -32029.
 
 Observability:
     Every tool call is logged at INFO level with token-prefix, tool name,
@@ -39,6 +49,7 @@ from autobot_shared.auth.jwt_core import JWTDecodeError, JWTExpiredError
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_async_redis_client
 from autobot_shared.ssot_config import config
+from mcp.auth_throttle import UNKNOWN_IP, get_pre_auth_throttle
 from services.run_jwt import validate_run_jwt
 
 logger = get_logger(__name__)
@@ -78,6 +89,39 @@ def _ok(result: Any, req_id: Any = None) -> Dict[str, Any]:
 
 def _err(code: int, message: str, req_id: Any = None) -> Dict[str, Any]:
     return {"jsonrpc": "2.0", "id": req_id, "error": {"code": code, "message": message}}
+
+
+# ---------------------------------------------------------------------------
+# stdio bearer composition (#13266)
+# ---------------------------------------------------------------------------
+
+
+def _stdio_bearer_token() -> str:
+    """Compose the bearer token the stdio transport presents to itself.
+
+    #13266: ``AUTOBOT_MCP_TOKEN`` used to be read two incompatible ways — as the
+    whole ``<secret>:<scopes>`` bearer here, and as the secret segment alone in
+    ``_validate_token``. No value satisfied both, so every stdio request was
+    rejected. The comparison site is the security boundary, so it keeps owning
+    the meaning: ``AUTOBOT_MCP_TOKEN`` is the SECRET, and stdio composes its
+    bearer from that secret plus ``AUTOBOT_MCP_STDIO_SCOPES``.
+
+    Raises:
+        RuntimeError: if no secret is configured. Deliberately fatal rather than
+            defaulted — a shipped default credential authenticates everyone
+            exactly as the empty secret did, and this process is the only thing
+            standing in front of the kb/memory/agents scopes.
+    """
+    secret = (config.mcp_token or "").strip()
+    if not secret:
+        raise RuntimeError(
+            "AUTOBOT_MCP_TOKEN is not set. The stdio transport has no default "
+            "credential by design; set it to the shared MCP secret to start."
+        )
+    scopes = ",".join(s.strip() for s in (config.mcp_stdio_scopes or "").split(",") if s.strip())
+    if not scopes:
+        raise RuntimeError("AUTOBOT_MCP_STDIO_SCOPES resolved to no scopes; stdio transport would grant nothing.")
+    return f"{secret}:{scopes}"
 
 
 # ---------------------------------------------------------------------------
@@ -303,14 +347,13 @@ class AutoBotMCPServer:
     def _validate_token(token: str) -> List[str] | None:
         """Return the list of granted scopes for *token*, or None if invalid.
 
-        Token format: ``<secret>:<scope1>,<scope2>`` where the secret
-        portion is checked against the ``AUTOBOT_MCP_TOKEN`` env var (prefix
-        before the first colon).  The dev override ``dev:kb,memory,agents``
-        is always accepted when the env var is not set.
+        Token format: ``<secret>:<scope1>,<scope2>``.  The secret portion (the
+        prefix before the first colon) is compared against ``AUTOBOT_MCP_TOKEN``,
+        which holds the secret segment ONLY — this is the single meaning of that
+        variable (#13266).  There is no dev override and no default credential.
 
-        For production use, set ``AUTOBOT_MCP_TOKEN`` to the shared secret;
-        scopes are always taken from the token string itself so that the
-        issuer controls access.
+        Scopes are taken from the token string itself so that the issuer
+        controls access.
 
         Fails closed (#13263): an empty configured secret rejects every token
         rather than matching the empty secret segment of ``":<scopes>"``.
@@ -380,6 +423,50 @@ class AutoBotMCPServer:
             logger.warning("_validate_redis_token: unexpected error: %s", exc)
             return None
 
+    async def _authenticate(
+        self,
+        params: Dict[str, Any],
+        auth_token: str,
+        req_id: Any,
+        client_ip: str,
+    ) -> Tuple[List[str] | None, bool, Dict[str, Any] | None]:
+        """Resolve granted scopes, metering failures against the pre-auth throttle.
+
+        SEC-2 Phase 2 (#6473): a run JWT in ``params`` takes precedence over the
+        legacy static token. Agents pass it as a top-level JSON-RPC param; the
+        scheduler also exposes it via AUTOBOT_RUN_JWT for in-process callers.
+
+        Returns ``(scopes, using_run_jwt, error_response)`` — exactly one of
+        *scopes* and *error_response* is non-None.
+        """
+        run_jwt_token = params.pop("run_jwt", None) if isinstance(params, dict) else None
+
+        if run_jwt_token:
+            scopes, error = await self._resolve_run_jwt(run_jwt_token)
+            if error:
+                return None, False, self._reject_auth(client_ip, error, req_id)
+            get_pre_auth_throttle().record_success(client_ip)
+            return scopes, True, None
+
+        scopes = self._validate_token(auth_token)
+        if scopes is None:
+            # Fallback: check Redis-issued tokens (Issue #6453)
+            scopes = await self._validate_redis_token(auth_token)
+        if scopes is None:
+            return None, False, self._reject_auth(client_ip, "Unauthorized: invalid or missing token", req_id)
+        get_pre_auth_throttle().record_success(client_ip)
+        return scopes, False, None
+
+    @staticmethod
+    def _reject_auth(client_ip: str, message: str, req_id: Any) -> Dict[str, Any]:
+        """Count one failed authentication and build its JSON-RPC error (#13268).
+
+        Never silent: every rejection is logged with its reason before returning.
+        """
+        get_pre_auth_throttle().record_failure(client_ip)
+        logger.warning("mcp_auth: rejected MCP request — %s", message)
+        return _err(-32001, message, req_id)
+
     def _check_scope(self, scopes: List[str], tool_name: str) -> bool:
         """Return True if *scopes* grants access to *tool_name*."""
         prefix = tool_name.split(".")[0]  # "kb", "memory", "agents"
@@ -404,6 +491,7 @@ class AutoBotMCPServer:
         params: Dict[str, Any],
         auth_token: str,
         req_id: Any = None,
+        client_ip: str | None = None,
     ) -> Dict[str, Any]:
         """Dispatch a JSON-RPC method call.
 
@@ -417,33 +505,41 @@ class AutoBotMCPServer:
             params:     JSON-RPC params dict.
             auth_token: Bearer token (validated here).
             req_id:     JSON-RPC ``id`` (echoed in response).
+            client_ip:  Caller address for the pre-auth throttle (#13268).
+                        Transports resolve it; ``None`` collapses to a shared
+                        ``UNKNOWN_IP`` bucket, which throttles more, never less.
 
         Returns:
             JSON-RPC response dict (always includes ``jsonrpc`` and ``id``).
         """
-        # SEC-2 Phase 2 (#6473): prefer run JWT over legacy static token.
-        # Agents pass run_jwt as a top-level JSON-RPC param; the scheduler also
-        # exposes it via AUTOBOT_RUN_JWT for in-process callers (base_agent.get_mcp_token).
-        run_jwt_token = params.pop("run_jwt", None) if isinstance(params, dict) else None
+        # #13268: throttle BEFORE any validation work. This runs ahead of
+        # _validate_redis_token so a locked-out caller cannot drive a Redis GET
+        # per request, and ahead of the secret comparison so guessing is metered.
+        ip = client_ip or UNKNOWN_IP
+        throttle = get_pre_auth_throttle()
+        blocked, reason = throttle.check(ip)
+        if blocked:
+            logger.warning(
+                "mcp_auth: pre-auth throttle blocked method=%s — %s",
+                method or "<none>",
+                reason,
+            )
+            return _err(-32029, f"Too many failed authentication attempts: {reason}", req_id)
 
-        using_run_jwt = False
-        if run_jwt_token:
-            scopes, error = await self._resolve_run_jwt(run_jwt_token)
-            if error:
-                return _err(-32001, error, req_id)
-            using_run_jwt = True
-            rate_key = run_jwt_token[:16]
-        else:
-            scopes = self._validate_token(auth_token)
-            if scopes is None:
-                # Fallback: check Redis-issued tokens (Issue #6453)
-                scopes = await self._validate_redis_token(auth_token)
-            if scopes is None:
-                return _err(-32001, "Unauthorized: invalid or missing token", req_id)
-            rate_key = auth_token[:16]
+        # Bucket key is captured before _authenticate pops run_jwt out of params.
+        run_jwt_preview = params.get("run_jwt") if isinstance(params, dict) else None
+        rate_key = (run_jwt_preview or auth_token or "")[:16]
 
+        scopes, using_run_jwt, auth_error = await self._authenticate(params, auth_token, req_id, ip)
+        if auth_error is not None:
+            return auth_error
+
+        # Post-auth bucket stays keyed on the token prefix: it is only reachable
+        # by an authenticated caller, so the key space cannot be grown by an
+        # anonymous attacker (#13268).
         if self._is_rate_limited(rate_key):
-            return _err(-32029, "Rate limit exceeded (50 req/min)", req_id)
+            logger.warning("mcp_auth: post-auth rate limit exceeded for method=%s", method or "<none>")
+            return _err(-32029, f"Rate limit exceeded ({_RATE_LIMIT} req/{int(_WINDOW_SECONDS)}s)", req_id)
 
         if method in ("initialize", "tools/list"):
             return _ok(
@@ -658,7 +754,7 @@ class AutoBotMCPServer:
         """Read JSON-RPC requests from stdin line-by-line, write responses to stdout."""
         import sys
 
-        token = config.mcp_token
+        token = _stdio_bearer_token()
         loop = asyncio.get_event_loop()
 
         reader = asyncio.StreamReader()
@@ -687,7 +783,7 @@ class AutoBotMCPServer:
                 method = msg.get("method", "")
                 params = msg.get("params") or {}
                 req_id = msg.get("id")
-                response = await self.handle_request(method, params, token, req_id)
+                response = await self.handle_request(method, params, token, req_id, client_ip="stdio")
             out = json.dumps(response, default=str) + "\n"
             writer_transport.write(out.encode("utf-8"))
 
@@ -717,7 +813,7 @@ class AutoBotMCPServer:
             method = body.get("method", "")
             params = body.get("params") or {}
             req_id = body.get("id")
-            response = await self.handle_request(method, params, token, req_id)
+            response = await self.handle_request(method, params, token, req_id, client_ip=request.remote)
             status = 200
             if "error" in response:
                 code = response["error"].get("code", -32000)

--- a/autobot-backend/mcp/autobot_server.py
+++ b/autobot-backend/mcp/autobot_server.py
@@ -118,6 +118,15 @@ def _stdio_bearer_token() -> str:
             "AUTOBOT_MCP_TOKEN is not set. The stdio transport has no default "
             "credential by design; set it to the shared MCP secret to start."
         )
+    if ":" in secret:
+        # The overloaded pre-#13266 form. _validate_token splits on the first
+        # colon, so this value can never match itself; say so instead of
+        # emitting an opaque -32001 on every request.
+        raise RuntimeError(
+            "AUTOBOT_MCP_TOKEN contains ':' — it holds the SECRET SEGMENT ONLY, "
+            "not a full '<secret>:<scopes>' token. Move the scopes to "
+            "AUTOBOT_MCP_STDIO_SCOPES."
+        )
     scopes = ",".join(s.strip() for s in (config.mcp_stdio_scopes or "").split(",") if s.strip())
     if not scopes:
         raise RuntimeError("AUTOBOT_MCP_STDIO_SCOPES resolved to no scopes; stdio transport would grant nothing.")

--- a/autobot-backend/mcp/autobot_server_test.py
+++ b/autobot-backend/mcp/autobot_server_test.py
@@ -18,7 +18,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from autobot_shared.ssot_config import config
-from mcp.autobot_server import AutoBotMCPServer
+from mcp.autobot_server import AutoBotMCPServer, _stdio_bearer_token
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -330,3 +330,54 @@ async def test_legacy_token_still_works_without_run_jwt():
     assert "result" in resp
     tool_names = {t["name"] for t in resp["result"]["tools"]}
     assert "kb.search" in tool_names
+
+
+# ---------------------------------------------------------------------------
+# #13266: AUTOBOT_MCP_TOKEN has exactly one meaning (the secret segment)
+# ---------------------------------------------------------------------------
+
+
+def test_stdio_bearer_is_composed_from_secret_plus_scopes():
+    """#13266: stdio composes "<secret>:<scopes>" instead of reusing the secret as a bearer."""
+    with patch.object(config.misc, "mcp_token", TEST_SECRET), patch.object(
+        config.misc, "mcp_stdio_scopes", "kb,memory"
+    ):
+        assert _stdio_bearer_token() == f"{TEST_SECRET}:kb,memory"
+
+
+@pytest.mark.asyncio
+async def test_stdio_bearer_authenticates_end_to_end():
+    """#13266: the token stdio presents is accepted by the validator it is checked against.
+
+    Before the fix no value of AUTOBOT_MCP_TOKEN satisfied both readings, so
+    every stdio request was rejected with -32001 in every configuration.
+    """
+    server = make_server()
+    with patch.object(config.misc, "mcp_token", TEST_SECRET), patch.object(
+        config.misc, "mcp_stdio_scopes", "kb,memory,agents"
+    ):
+        resp = await server.handle_request("tools/list", {}, _stdio_bearer_token(), req_id=7, client_ip="stdio")
+
+    assert "error" not in resp, resp
+    assert {t["name"] for t in resp["result"]["tools"]} & {"kb.search"}
+
+
+def test_stdio_refuses_to_run_without_a_configured_secret():
+    """#13266/#13263: no default credential — an unset secret is fatal, not permissive."""
+    with patch.object(config.misc, "mcp_token", ""):
+        with pytest.raises(RuntimeError, match="AUTOBOT_MCP_TOKEN"):
+            _stdio_bearer_token()
+
+
+def test_stdio_refuses_to_run_with_no_scopes():
+    """An empty scope list would compose a token that grants nothing; fail loudly instead."""
+    with patch.object(config.misc, "mcp_token", TEST_SECRET), patch.object(config.misc, "mcp_stdio_scopes", " , "):
+        with pytest.raises(RuntimeError, match="scopes"):
+            _stdio_bearer_token()
+
+
+def test_stdio_rejects_the_overloaded_full_token_form():
+    """#13266: a '<secret>:<scopes>' value in AUTOBOT_MCP_TOKEN is named, not silently broken."""
+    with patch.object(config.misc, "mcp_token", f"{TEST_SECRET}:kb,memory,agents"):
+        with pytest.raises(RuntimeError, match="SECRET SEGMENT ONLY"):
+            _stdio_bearer_token()

--- a/autobot-backend/mcp/autobot_server_test.py
+++ b/autobot-backend/mcp/autobot_server_test.py
@@ -339,8 +339,9 @@ async def test_legacy_token_still_works_without_run_jwt():
 
 def test_stdio_bearer_is_composed_from_secret_plus_scopes():
     """#13266: stdio composes "<secret>:<scopes>" instead of reusing the secret as a bearer."""
-    with patch.object(config.misc, "mcp_token", TEST_SECRET), patch.object(
-        config.misc, "mcp_stdio_scopes", "kb,memory"
+    with (
+        patch.object(config.misc, "mcp_token", TEST_SECRET),
+        patch.object(config.misc, "mcp_stdio_scopes", "kb,memory"),
     ):
         assert _stdio_bearer_token() == f"{TEST_SECRET}:kb,memory"
 
@@ -353,8 +354,9 @@ async def test_stdio_bearer_authenticates_end_to_end():
     every stdio request was rejected with -32001 in every configuration.
     """
     server = make_server()
-    with patch.object(config.misc, "mcp_token", TEST_SECRET), patch.object(
-        config.misc, "mcp_stdio_scopes", "kb,memory,agents"
+    with (
+        patch.object(config.misc, "mcp_token", TEST_SECRET),
+        patch.object(config.misc, "mcp_stdio_scopes", "kb,memory,agents"),
     ):
         resp = await server.handle_request("tools/list", {}, _stdio_bearer_token(), req_id=7, client_ip="stdio")
 

--- a/autobot-backend/services/mcp_bridge_workers/worker_entrypoint.py
+++ b/autobot-backend/services/mcp_bridge_workers/worker_entrypoint.py
@@ -46,8 +46,8 @@ logger = get_logger("mcp_worker")
 # is "1" (#6473). It shipped defaulting ON; the #7437 config migration dropped
 # the default to "" and silently turned it OFF (#13263).
 # #13265 removed the blocker: services/mcp_dispatch.py now mints and forwards a
-# run JWT on every isolated call, and services/run_jwt._secret() falls back to
-# the SSOT config so this scrubbed-environment child can still verify it.
+# run JWT on every isolated call, and the parent provisions RUN_JWT_SECRET into
+# this scrubbed child's environment so the token can actually be verified.
 # Flipping the default back to "1" belongs to #13263.
 _JWT_ENFORCE = config.mcp_run_jwt_enforce == "1"
 

--- a/autobot-backend/services/mcp_bridge_workers/worker_entrypoint.py
+++ b/autobot-backend/services/mcp_bridge_workers/worker_entrypoint.py
@@ -44,9 +44,11 @@ logger = get_logger("mcp_worker")
 
 # Run-scoped JWT is enforced on every ``call`` request when MCP_RUN_JWT_ENFORCE
 # is "1" (#6473). It shipped defaulting ON; the #7437 config migration dropped
-# the default to "" and silently turned it OFF (#13263). Restoring it is blocked
-# on #13265 — mcp_dispatch does not propagate run_jwt to out-of-process bridges,
-# so enforcement would fail every filesystem/browser/vnc tool call.
+# the default to "" and silently turned it OFF (#13263).
+# #13265 removed the blocker: services/mcp_dispatch.py now mints and forwards a
+# run JWT on every isolated call, and services/run_jwt._secret() falls back to
+# the SSOT config so this scrubbed-environment child can still verify it.
+# Flipping the default back to "1" belongs to #13263.
 _JWT_ENFORCE = config.mcp_run_jwt_enforce == "1"
 
 _JSONRPC = "2.0"
@@ -127,6 +129,13 @@ async def _validate_run_jwt_param(params: Dict[str, Any]) -> Dict[str, Any] | No
         raise PermissionError(f"run_jwt: token expired — {exc}") from exc
     except JWTDecodeError as exc:
         raise PermissionError(f"run_jwt: invalid token — {exc}") from exc
+    except RuntimeError as exc:
+        # #13265: _secret() raises RuntimeError when no signing secret resolves.
+        # _handle_request only catches PermissionError, so letting this escape
+        # kills the serve loop and the parent restarts the worker until the
+        # restart budget is exhausted. Fail closed on the request instead, with
+        # the reason preserved in the response and the log.
+        raise PermissionError(f"run_jwt: cannot verify token — {exc}") from exc
 
 
 async def _handle_request(bridge: Any, req: Dict[str, Any]) -> Dict[str, Any]:

--- a/autobot-backend/services/mcp_dispatch.py
+++ b/autobot-backend/services/mcp_dispatch.py
@@ -24,10 +24,9 @@ Cache TTL and RBAC filtering added in #2598.
 """
 
 import time
+import uuid
 
 import aiohttp
-
-import uuid
 
 from autobot_shared.auth.permissions import is_admin_role
 from autobot_shared.http_client import get_http_client

--- a/autobot-backend/services/mcp_dispatch.py
+++ b/autobot-backend/services/mcp_dispatch.py
@@ -27,12 +27,25 @@ import time
 
 import aiohttp
 
+import uuid
+
 from autobot_shared.auth.permissions import is_admin_role
 from autobot_shared.http_client import get_http_client
 from autobot_shared.logging_manager import get_logger
 from constants.network_constants import NetworkConstants
 
 logger = get_logger(__name__)
+
+# #13265: minimum run-JWT scopes per isolated bridge. resolve_mode() forces
+# SUBPROCESS for filesystem_mcp, browser_mcp and vnc_mcp regardless of config,
+# so these are the bridges whose workers validate a run JWT. Unlisted bridges
+# get the safest scope, matching services/run_jwt._FALLBACK_SCOPES.
+_BRIDGE_RUN_JWT_SCOPES: dict[str, list[str]] = {
+    "filesystem_mcp": ["mcp:filesystem"],
+    "browser_mcp": ["mcp:web_fetch"],
+    "vnc_mcp": ["task:read"],
+}
+_DEFAULT_BRIDGE_SCOPES: list[str] = ["task:read"]
 
 
 class MCPDispatcher:
@@ -191,6 +204,36 @@ class MCPDispatcher:
         )
         return result
 
+    @staticmethod
+    def _mint_bridge_jwt(bridge: str, tool_name: str) -> str | None:
+        """Mint a short-lived run JWT scoped to *bridge* (#13265).
+
+        Returns None when no signing secret is configured. That is not silent:
+        it is logged, and the worker then rejects the call itself with a
+        -32001 whenever MCP_RUN_JWT_ENFORCE is on. Failing to mint must not
+        crash dispatch for deployments that run with enforcement off.
+        """
+        from services.run_jwt import mint_run_jwt
+
+        scopes = _BRIDGE_RUN_JWT_SCOPES.get(bridge, _DEFAULT_BRIDGE_SCOPES)
+        try:
+            return mint_run_jwt(
+                run_id=str(uuid.uuid4()),
+                task_id=f"mcp:{tool_name}",
+                agent_id=f"mcp_dispatch:{bridge}",
+                tenant_id="default",
+                scope=scopes,
+            )
+        except (RuntimeError, ValueError) as exc:
+            logger.warning(
+                "MCPDispatcher: could not mint run JWT for bridge %s tool %s: %s "
+                "— isolated call will be rejected if MCP_RUN_JWT_ENFORCE is set",
+                bridge,
+                tool_name,
+                exc,
+            )
+            return None
+
     async def _call_bridge(self, tool_name: str, bridge: str, endpoint: str, arguments: dict) -> dict:
         """Execute a tool call against an MCP bridge.
 
@@ -211,7 +254,10 @@ class MCPDispatcher:
 
         isolated = await get_isolated_registry().get_or_create(bridge)
         if isolated is not None:
-            return await isolated.call_tool(tool_name, arguments)
+            # #13265: the worker validates a run JWT when MCP_RUN_JWT_ENFORCE=1.
+            # It cannot read one from its environment (_WORKER_ENV_ALLOW scrubs
+            # MCP_RUN_JWT by design), so it must be passed per request.
+            return await isolated.call_tool(tool_name, arguments, run_jwt=self._mint_bridge_jwt(bridge, tool_name))
 
         try:
             http_client = get_http_client()

--- a/autobot-backend/services/mcp_isolated_runtime.py
+++ b/autobot-backend/services/mcp_isolated_runtime.py
@@ -38,6 +38,26 @@ _WORKER_ENV_ALLOW = frozenset(
 )
 
 
+def _resolve_run_jwt_secret() -> str:
+    """Resolve the run-JWT signing secret to hand to a worker (#13265).
+
+    Mirrors ``services.run_jwt._secret()`` priority, then falls back to the SSOT
+    config because the backend may itself run without the variable exported.
+
+    The worker validates the run JWT it is handed per request, and verifying an
+    HMAC requires the key.  The child's inherited environment is scrubbed to
+    ``_WORKER_ENV_ALLOW``, so the secret is provisioned explicitly here — the
+    same way cpu/mem/nofile limits are — rather than by widening that allow-list,
+    which would also leak every other matching variable.  The run JWT itself is
+    still passed per request and never via the environment.
+    """
+    for var in ("RUN_JWT_SECRET", "AUTOBOT_JWT_SECRET"):
+        val = os.environ.get(var, "")
+        if val:
+            return val
+    return config.run_jwt_secret or config.jwt_secret or ""
+
+
 class IsolatedBridgeClient:
     """Client for a single bridge running as a subprocess worker."""
 
@@ -64,6 +84,17 @@ class IsolatedBridgeClient:
         env["MCP_WORKER_MEM_MB"] = str(self._policy.memory_mb)
         env["MCP_WORKER_NOFILE"] = str(self._policy.nofile)
         env["MCP_WORKER_LOG_LEVEL"] = config.log_level
+        # #13265: without this the worker cannot verify the run JWT it receives,
+        # and MCP_RUN_JWT_ENFORCE=1 would reject every isolated tool call.
+        run_jwt_secret = _resolve_run_jwt_secret()
+        if run_jwt_secret:
+            env["RUN_JWT_SECRET"] = run_jwt_secret
+        else:
+            logger.warning(
+                "mcp_isolation: no run-JWT signing secret resolved for bridge %s — "
+                "isolated calls will be rejected if MCP_RUN_JWT_ENFORCE is set",
+                self._bridge,
+            )
 
         logger.info(
             "mcp_isolation: spawning worker bridge=%s cpu=%ss mem=%sMB nofile=%s",

--- a/autobot-backend/services/mcp_isolated_runtime.py
+++ b/autobot-backend/services/mcp_isolated_runtime.py
@@ -41,8 +41,20 @@ _WORKER_ENV_ALLOW = frozenset(
 def _resolve_run_jwt_secret() -> str:
     """Resolve the run-JWT signing secret to hand to a worker (#13265).
 
-    Mirrors ``services.run_jwt._secret()`` priority, then falls back to the SSOT
-    config because the backend may itself run without the variable exported.
+    Resolves ``RUN_JWT_SECRET`` ONLY — the dedicated run-JWT key — from the
+    environment first and then from the SSOT config (which reads ``.env``, the
+    same value by a different source).
+
+    ``AUTOBOT_JWT_SECRET`` / ``config.jwt_secret`` are deliberately NOT consulted.
+    That is the platform's user-session signing key: ``auth_middleware`` verifies
+    user auth JWTs with it and ``slm_client`` mints service tokens with it.  The
+    recipients here are ``filesystem_mcp``, ``browser_mcp`` and ``vnc_mcp`` — the
+    bridges ``resolve_mode()`` forces into subprocess isolation precisely because
+    they handle untrusted content.  Exporting the platform key into that child
+    would let a compromised bridge read ``/proc/self/environ`` and forge session
+    JWTs for any user or role: a full authentication bypass reached from the
+    largest untrusted-input surface in the system.  A dedicated, separately
+    rotatable secret is the only thing that may cross this boundary.
 
     The worker validates the run JWT it is handed per request, and verifying an
     HMAC requires the key.  The child's inherited environment is scrubbed to
@@ -50,12 +62,11 @@ def _resolve_run_jwt_secret() -> str:
     same way cpu/mem/nofile limits are — rather than by widening that allow-list,
     which would also leak every other matching variable.  The run JWT itself is
     still passed per request and never via the environment.
+
+    Returns an empty string when unset; the caller warns and spawns without it,
+    and the worker then rejects isolated calls whenever enforcement is on.
     """
-    for var in ("RUN_JWT_SECRET", "AUTOBOT_JWT_SECRET"):
-        val = os.environ.get(var, "")
-        if val:
-            return val
-    return config.run_jwt_secret or config.jwt_secret or ""
+    return os.environ.get("RUN_JWT_SECRET", "") or config.run_jwt_secret or ""
 
 
 class IsolatedBridgeClient:
@@ -72,20 +83,21 @@ class IsolatedBridgeClient:
         self._last_restart_ts = 0.0
         self._permanently_failed = False
 
-    async def start(self) -> None:
-        """Spawn the worker subprocess with scrubbed env."""
-        if self._proc is not None and self._proc.returncode is None:
-            return
-        if self._permanently_failed:
-            raise RuntimeError("bridge " + self._bridge + " exceeded restart_max")
+    def _build_worker_env(self) -> Dict[str, str]:
+        """Build the scrubbed child environment for a worker subprocess.
 
+        Inherited variables are filtered to ``_WORKER_ENV_ALLOW``; everything the
+        worker actually needs is set explicitly below.
+        """
         env = {k: v for k, v in os.environ.items() if k in _WORKER_ENV_ALLOW}
         env["MCP_WORKER_CPU_SECONDS"] = str(self._policy.cpu_seconds)
         env["MCP_WORKER_MEM_MB"] = str(self._policy.memory_mb)
         env["MCP_WORKER_NOFILE"] = str(self._policy.nofile)
         env["MCP_WORKER_LOG_LEVEL"] = config.log_level
-        # #13265: without this the worker cannot verify the run JWT it receives,
-        # and MCP_RUN_JWT_ENFORCE=1 would reject every isolated tool call.
+        # #13265: without the signing secret the worker cannot verify the run JWT
+        # it receives, and MCP_RUN_JWT_ENFORCE=1 would reject every isolated call.
+        # Only the dedicated run-JWT key may cross this boundary — never the
+        # platform user-session key (see _resolve_run_jwt_secret).
         run_jwt_secret = _resolve_run_jwt_secret()
         if run_jwt_secret:
             env["RUN_JWT_SECRET"] = run_jwt_secret
@@ -95,6 +107,16 @@ class IsolatedBridgeClient:
                 "isolated calls will be rejected if MCP_RUN_JWT_ENFORCE is set",
                 self._bridge,
             )
+        return env
+
+    async def start(self) -> None:
+        """Spawn the worker subprocess with scrubbed env."""
+        if self._proc is not None and self._proc.returncode is None:
+            return
+        if self._permanently_failed:
+            raise RuntimeError("bridge " + self._bridge + " exceeded restart_max")
+
+        env = self._build_worker_env()
 
         logger.info(
             "mcp_isolation: spawning worker bridge=%s cpu=%ss mem=%sMB nofile=%s",

--- a/autobot-backend/services/mcp_run_jwt_propagation_test.py
+++ b/autobot-backend/services/mcp_run_jwt_propagation_test.py
@@ -183,19 +183,24 @@ def test_environment_keeps_priority_over_config(monkeypatch):
         assert _resolve_run_jwt_secret() == "from-environment"
 
 
-def test_parent_secret_chain_is_environment_only(monkeypatch):
-    """The .env fallback must NOT widen services.run_jwt._secret() for every caller.
+def test_parent_secret_chain_admits_only_the_dedicated_secret(monkeypatch):
+    """Only RUN_JWT_SECRET may resolve from .env — never a general-purpose key.
 
-    Regression guard for tests/services/test_run_jwt.py::
-    test_secret_key_not_accepted_as_fallback — the worker gets the secret
-    provisioned explicitly, the shared resolver stays environment-only.
+    Companion to tests/services/test_run_jwt.py::
+    test_secret_key_not_accepted_as_fallback, which pins the environment loop.
     """
     from services.run_jwt import _secret
 
     monkeypatch.delenv("RUN_JWT_SECRET", raising=False)
     monkeypatch.delenv("AUTOBOT_JWT_SECRET", raising=False)
     monkeypatch.setenv("SECRET_KEY", "some-general-app-secret")
+
+    # The dedicated secret resolves, so a .env-only deployment can mint.
     with patch.object(config.misc, "run_jwt_secret", "from-dot-env-file"):
+        assert _secret() == "from-dot-env-file"
+
+    # Nothing else does: not SECRET_KEY, not the platform user-session key.
+    with patch.object(config.misc, "run_jwt_secret", ""), patch.object(config.misc, "jwt_secret", "platform-auth-key"):
         with pytest.raises(RuntimeError, match="RUN_JWT_SECRET"):
             _secret()
 
@@ -231,3 +236,63 @@ def test_worker_env_allow_still_excludes_the_token(monkeypatch):
 
     assert "MCP_RUN_JWT" not in _WORKER_ENV_ALLOW
     assert "RUN_JWT_SECRET" not in _WORKER_ENV_ALLOW
+
+
+# ---------------------------------------------------------------------------
+# The platform user-session key must never cross into a bridge worker
+# ---------------------------------------------------------------------------
+
+
+def test_platform_jwt_secret_is_never_provisioned_to_a_worker(monkeypatch):
+    """AUTOBOT_JWT_SECRET signs user sessions; a bridge worker must never receive it.
+
+    auth_middleware verifies user auth JWTs with this key and slm_client mints
+    service tokens with it. The recipients are the bridges forced into subprocess
+    isolation because they handle untrusted content — handing them this key would
+    let a compromised bridge read /proc/self/environ and forge a session for any
+    user or role.
+    """
+    from services.mcp_isolated_runtime import _resolve_run_jwt_secret
+
+    monkeypatch.delenv("RUN_JWT_SECRET", raising=False)
+    monkeypatch.delenv("AUTOBOT_JWT_SECRET", raising=False)
+    with patch.object(config.misc, "run_jwt_secret", ""), patch.object(config.misc, "jwt_secret", "platform-auth-key"):
+        assert _resolve_run_jwt_secret() == ""
+
+
+def test_platform_jwt_secret_is_not_in_the_parent_mint_chain(monkeypatch):
+    """The same key must not become mintable via the config fallback either."""
+    from services.run_jwt import _secret
+
+    monkeypatch.delenv("RUN_JWT_SECRET", raising=False)
+    monkeypatch.delenv("AUTOBOT_JWT_SECRET", raising=False)
+    with patch.object(config.misc, "run_jwt_secret", ""), patch.object(config.misc, "jwt_secret", "platform-auth-key"):
+        with pytest.raises(RuntimeError, match="RUN_JWT_SECRET"):
+            _secret()
+
+
+def test_env_only_deployment_mints_verifies_and_provisions(monkeypatch):
+    """#13265 must not degrade to forwarding None where only .env is populated.
+
+    Guards the no-op the platform-key fallback was masking: parent mints, worker
+    receives ONLY the dedicated key, and verification succeeds with enforcement on.
+    """
+    import asyncio
+
+    from services.mcp_bridge_workers import worker_entrypoint
+    from services.mcp_isolated_runtime import _resolve_run_jwt_secret
+
+    monkeypatch.delenv("RUN_JWT_SECRET", raising=False)
+    monkeypatch.delenv("AUTOBOT_JWT_SECRET", raising=False)
+    with (
+        patch.object(config.misc, "run_jwt_secret", "dedicated-run-jwt-key"),
+        patch.object(config.misc, "jwt_secret", "platform-auth-key"),
+    ):
+        assert _resolve_run_jwt_secret() == "dedicated-run-jwt-key"
+        token = MCPDispatcher._mint_bridge_jwt("filesystem_mcp", "read_file")
+        assert token is not None, "#13265 degraded to forwarding None"
+        with patch.object(worker_entrypoint, "_JWT_ENFORCE", True):
+            claims = asyncio.get_event_loop().run_until_complete(
+                worker_entrypoint._validate_run_jwt_param({"run_jwt": token})
+            )
+    assert claims["scope"] == ["mcp:filesystem"]

--- a/autobot-backend/services/mcp_run_jwt_propagation_test.py
+++ b/autobot-backend/services/mcp_run_jwt_propagation_test.py
@@ -1,0 +1,201 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Tests for run-JWT propagation to isolated MCP bridge workers (#13265).
+
+Before this change ``mcp_dispatch._call_bridge`` called ``call_tool()`` without
+``run_jwt``, and the worker could not read one from its environment either
+(``_WORKER_ENV_ALLOW`` excludes ``MCP_RUN_JWT`` by design), so every
+subprocess-routed tool call failed closed once ``MCP_RUN_JWT_ENFORCE=1``.
+
+Coverage:
+- _call_bridge forwards a valid run JWT on every isolated call
+- The forwarded token is scoped to the bridge being called
+- A subprocess-routed call is accepted by the worker with enforcement ON
+- It is still rejected when the token is absent, or expired
+- A worker with a scrubbed environment can still resolve the signing secret
+- A missing signing secret fails the request closed instead of crashing the
+  worker's serve loop
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from autobot_shared.auth.jwt_core import JWTDecodeError
+from autobot_shared.ssot_config import config
+from services.mcp_dispatch import MCPDispatcher
+from services.run_jwt import mint_run_jwt
+
+TEST_JWT_SECRET = "unit-test-run-jwt-signing-secret-0123456789"
+
+
+@pytest.fixture(autouse=True)
+def _signing_secret(monkeypatch):
+    """Provide a signing secret and keep the Redis denylist out of unit tests."""
+    monkeypatch.setenv("RUN_JWT_SECRET", TEST_JWT_SECRET)
+    with patch("services.run_jwt._is_denied", AsyncMock(return_value=False)):
+        yield
+
+
+def _mint(scope=None, ttl=300):
+    """Mint a token for the tests, honouring a custom TTL."""
+    with patch("services.run_jwt._ttl", return_value=ttl):
+        return mint_run_jwt(
+            run_id="run-1",
+            task_id="task-1",
+            agent_id="agent-1",
+            tenant_id="default",
+            scope=scope or ["mcp:filesystem"],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher forwards the token
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_call_bridge_forwards_run_jwt_to_isolated_worker():
+    """#13265: the isolated path must supply run_jwt; it previously never did."""
+    dispatcher = MCPDispatcher()
+    isolated = AsyncMock()
+    isolated.call_tool = AsyncMock(return_value={"success": True, "result": "ok", "bridge": "filesystem_mcp"})
+    registry = AsyncMock()
+    registry.get_or_create = AsyncMock(return_value=isolated)
+
+    with patch("services.mcp_isolated_runtime.get_isolated_registry", return_value=registry):
+        await dispatcher._call_bridge("read_file", "filesystem_mcp", "http://unused", {"path": "/tmp/x"})
+
+    _, kwargs = isolated.call_tool.call_args
+    assert kwargs.get("run_jwt"), "no run JWT forwarded to the isolated worker"
+
+
+@pytest.mark.asyncio
+async def test_forwarded_token_is_scoped_to_the_bridge():
+    """Minimum privilege: a filesystem bridge call does not carry web_fetch scope."""
+    from services.run_jwt import validate_run_jwt
+
+    dispatcher = MCPDispatcher()
+    isolated = AsyncMock()
+    isolated.call_tool = AsyncMock(return_value={"success": True, "result": "ok", "bridge": "filesystem_mcp"})
+    registry = AsyncMock()
+    registry.get_or_create = AsyncMock(return_value=isolated)
+
+    with patch("services.mcp_isolated_runtime.get_isolated_registry", return_value=registry):
+        await dispatcher._call_bridge("read_file", "filesystem_mcp", "http://unused", {})
+
+    claims = await validate_run_jwt(isolated.call_tool.call_args.kwargs["run_jwt"])
+    assert claims["scope"] == ["mcp:filesystem"]
+
+
+def test_mint_failure_is_logged_and_does_not_raise(monkeypatch):
+    """No signing secret must not crash dispatch; the worker rejects instead."""
+    monkeypatch.delenv("RUN_JWT_SECRET", raising=False)
+    monkeypatch.delenv("AUTOBOT_JWT_SECRET", raising=False)
+    with patch.object(config.misc, "run_jwt_secret", ""), patch.object(config.misc, "jwt_secret", ""):
+        assert MCPDispatcher._mint_bridge_jwt("filesystem_mcp", "read_file") is None
+
+
+# ---------------------------------------------------------------------------
+# Worker-side enforcement
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_worker_accepts_forwarded_token_with_enforcement_on():
+    """#13265: a subprocess-routed call succeeds with MCP_RUN_JWT_ENFORCE=1."""
+    from services.mcp_bridge_workers import worker_entrypoint
+
+    with patch.object(worker_entrypoint, "_JWT_ENFORCE", True):
+        claims = await worker_entrypoint._validate_run_jwt_param({"run_jwt": _mint()})
+
+    assert claims["scope"] == ["mcp:filesystem"]
+
+
+@pytest.mark.asyncio
+async def test_worker_rejects_missing_token_with_enforcement_on():
+    """Absent token still fails closed."""
+    from services.mcp_bridge_workers import worker_entrypoint
+
+    with patch.object(worker_entrypoint, "_JWT_ENFORCE", True), patch.object(config.misc, "mcp_run_jwt", ""):
+        with pytest.raises(PermissionError, match="no token provided"):
+            await worker_entrypoint._validate_run_jwt_param({})
+
+
+@pytest.mark.asyncio
+async def test_worker_rejects_expired_token_with_enforcement_on():
+    """Expired token still fails closed."""
+    from services.mcp_bridge_workers import worker_entrypoint
+
+    expired = _mint(ttl=-60)
+    with patch.object(worker_entrypoint, "_JWT_ENFORCE", True):
+        with pytest.raises(PermissionError, match="expired"):
+            await worker_entrypoint._validate_run_jwt_param({"run_jwt": expired})
+
+
+@pytest.mark.asyncio
+async def test_worker_rejects_token_signed_with_another_secret(monkeypatch):
+    """A forged token is rejected rather than accepted on scope alone."""
+    from services.mcp_bridge_workers import worker_entrypoint
+
+    token = _mint()
+    monkeypatch.setenv("RUN_JWT_SECRET", "a-completely-different-secret-value-99")
+    with patch.object(worker_entrypoint, "_JWT_ENFORCE", True):
+        with pytest.raises(PermissionError, match="invalid token"):
+            await worker_entrypoint._validate_run_jwt_param({"run_jwt": token})
+
+
+@pytest.mark.asyncio
+async def test_missing_secret_fails_the_request_not_the_worker(monkeypatch):
+    """#13265: RuntimeError from _secret() would escape _handle_request and kill the serve loop."""
+    from services.mcp_bridge_workers import worker_entrypoint
+
+    token = _mint()
+    monkeypatch.delenv("RUN_JWT_SECRET", raising=False)
+    monkeypatch.delenv("AUTOBOT_JWT_SECRET", raising=False)
+    with patch.object(worker_entrypoint, "_JWT_ENFORCE", True), patch.object(
+        config.misc, "run_jwt_secret", ""
+    ), patch.object(config.misc, "jwt_secret", ""):
+        with pytest.raises(PermissionError, match="cannot verify token"):
+            await worker_entrypoint._validate_run_jwt_param({"run_jwt": token})
+
+
+# ---------------------------------------------------------------------------
+# Scrubbed-environment secret resolution
+# ---------------------------------------------------------------------------
+
+
+def test_secret_resolves_from_config_when_environment_is_scrubbed(monkeypatch):
+    """#13265: workers run without RUN_JWT_SECRET in os.environ (_WORKER_ENV_ALLOW)."""
+    from services.run_jwt import _secret
+
+    monkeypatch.delenv("RUN_JWT_SECRET", raising=False)
+    monkeypatch.delenv("AUTOBOT_JWT_SECRET", raising=False)
+    with patch.object(config.misc, "run_jwt_secret", "from-dot-env-file"):
+        assert _secret() == "from-dot-env-file"
+
+
+def test_environment_keeps_priority_over_config(monkeypatch):
+    """Existing deployments that export the variable are unaffected."""
+    from services.run_jwt import _secret
+
+    monkeypatch.setenv("RUN_JWT_SECRET", "from-environment")
+    with patch.object(config.misc, "run_jwt_secret", "from-dot-env-file"):
+        assert _secret() == "from-environment"
+
+
+def test_run_jwt_secret_has_no_default():
+    """No shipped credential: the field must default to empty (#13263 precedent)."""
+    field = type(config.misc).model_fields["run_jwt_secret"]
+    assert field.default == ""
+
+
+def test_worker_env_allow_still_excludes_the_token(monkeypatch):
+    """#13265 passes run_jwt per request; it must not become a long-lived env var."""
+    from services.mcp_isolated_runtime import _WORKER_ENV_ALLOW
+
+    assert "MCP_RUN_JWT" not in _WORKER_ENV_ALLOW
+    assert "RUN_JWT_SECRET" not in _WORKER_ENV_ALLOW

--- a/autobot-backend/services/mcp_run_jwt_propagation_test.py
+++ b/autobot-backend/services/mcp_run_jwt_propagation_test.py
@@ -24,7 +24,6 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from autobot_shared.auth.jwt_core import JWTDecodeError
 from autobot_shared.ssot_config import config
 from services.mcp_dispatch import MCPDispatcher
 from services.run_jwt import mint_run_jwt

--- a/autobot-backend/services/mcp_run_jwt_propagation_test.py
+++ b/autobot-backend/services/mcp_run_jwt_propagation_test.py
@@ -95,8 +95,7 @@ def test_mint_failure_is_logged_and_does_not_raise(monkeypatch):
     """No signing secret must not crash dispatch; the worker rejects instead."""
     monkeypatch.delenv("RUN_JWT_SECRET", raising=False)
     monkeypatch.delenv("AUTOBOT_JWT_SECRET", raising=False)
-    with patch.object(config.misc, "run_jwt_secret", ""), patch.object(config.misc, "jwt_secret", ""):
-        assert MCPDispatcher._mint_bridge_jwt("filesystem_mcp", "read_file") is None
+    assert MCPDispatcher._mint_bridge_jwt("filesystem_mcp", "read_file") is None
 
 
 # ---------------------------------------------------------------------------
@@ -156,9 +155,7 @@ async def test_missing_secret_fails_the_request_not_the_worker(monkeypatch):
     token = _mint()
     monkeypatch.delenv("RUN_JWT_SECRET", raising=False)
     monkeypatch.delenv("AUTOBOT_JWT_SECRET", raising=False)
-    with patch.object(worker_entrypoint, "_JWT_ENFORCE", True), patch.object(
-        config.misc, "run_jwt_secret", ""
-    ), patch.object(config.misc, "jwt_secret", ""):
+    with patch.object(worker_entrypoint, "_JWT_ENFORCE", True):
         with pytest.raises(PermissionError, match="cannot verify token"):
             await worker_entrypoint._validate_run_jwt_param({"run_jwt": token})
 
@@ -170,21 +167,57 @@ async def test_missing_secret_fails_the_request_not_the_worker(monkeypatch):
 
 def test_secret_resolves_from_config_when_environment_is_scrubbed(monkeypatch):
     """#13265: workers run without RUN_JWT_SECRET in os.environ (_WORKER_ENV_ALLOW)."""
-    from services.run_jwt import _secret
+    from services.mcp_isolated_runtime import _resolve_run_jwt_secret
 
     monkeypatch.delenv("RUN_JWT_SECRET", raising=False)
     monkeypatch.delenv("AUTOBOT_JWT_SECRET", raising=False)
     with patch.object(config.misc, "run_jwt_secret", "from-dot-env-file"):
-        assert _secret() == "from-dot-env-file"
+        assert _resolve_run_jwt_secret() == "from-dot-env-file"
 
 
 def test_environment_keeps_priority_over_config(monkeypatch):
     """Existing deployments that export the variable are unaffected."""
-    from services.run_jwt import _secret
+    from services.mcp_isolated_runtime import _resolve_run_jwt_secret
 
     monkeypatch.setenv("RUN_JWT_SECRET", "from-environment")
     with patch.object(config.misc, "run_jwt_secret", "from-dot-env-file"):
-        assert _secret() == "from-environment"
+        assert _resolve_run_jwt_secret() == "from-environment"
+
+
+def test_parent_secret_chain_is_environment_only(monkeypatch):
+    """The .env fallback must NOT widen services.run_jwt._secret() for every caller.
+
+    Regression guard for tests/services/test_run_jwt.py::
+    test_secret_key_not_accepted_as_fallback — the worker gets the secret
+    provisioned explicitly, the shared resolver stays environment-only.
+    """
+    from services.run_jwt import _secret
+
+    monkeypatch.delenv("RUN_JWT_SECRET", raising=False)
+    monkeypatch.delenv("AUTOBOT_JWT_SECRET", raising=False)
+    monkeypatch.setenv("SECRET_KEY", "some-general-app-secret")
+    with patch.object(config.misc, "run_jwt_secret", "from-dot-env-file"):
+        with pytest.raises(RuntimeError, match="RUN_JWT_SECRET"):
+            _secret()
+
+
+def test_worker_env_is_provisioned_with_the_signing_secret(monkeypatch):
+    """#13265: the spawned worker receives RUN_JWT_SECRET explicitly."""
+    import asyncio
+
+    from services.mcp_isolated_runtime import IsolatedBridgeClient
+    from services.mcp_isolation_config import policy_for
+
+    monkeypatch.setenv("RUN_JWT_SECRET", TEST_JWT_SECRET)
+    client = IsolatedBridgeClient("filesystem_mcp", policy_for("filesystem_mcp"))
+    spawn = AsyncMock(return_value=AsyncMock(returncode=None))
+
+    with patch("asyncio.create_subprocess_exec", spawn):
+        asyncio.get_event_loop().run_until_complete(client.start())
+
+    env = spawn.call_args.kwargs["env"]
+    assert env["RUN_JWT_SECRET"] == TEST_JWT_SECRET
+    assert "MCP_RUN_JWT" not in env, "the token itself must stay per-request"
 
 
 def test_run_jwt_secret_has_no_default():

--- a/autobot-backend/services/run_jwt.py
+++ b/autobot-backend/services/run_jwt.py
@@ -69,6 +69,7 @@ from autobot_shared.auth.jwt_core import (
 from autobot_shared.fire_and_forget import run_redis_write
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_async_redis_client
+from autobot_shared.ssot_config import config
 from services.audit.audit import AuditAction, audit_record  # GH#8290 Phase 2
 
 
@@ -131,14 +132,25 @@ def get_run_jwt_scopes(agent_type: str, task_type: str | None = None) -> list[st
 
 
 def _secret() -> str:
-    """Resolve the signing secret from environment variables, in priority order.
+    """Resolve the signing secret, environment first, then the SSOT config.
 
     ``SECRET_KEY`` is deliberately excluded from the fallback chain.  A
     general-purpose app secret that is known to multiple services would allow
     any of those services to forge run JWTs, undermining the isolation goal.
+
+    #13265: the config fallback exists because isolated MCP bridge workers are
+    spawned with a scrubbed environment (``_WORKER_ENV_ALLOW`` in
+    ``services/mcp_isolated_runtime.py``), which excludes both secret variables.
+    Without it a worker cannot verify the run JWT it is handed, so enforcement
+    could never be switched on.  ``config`` reads the ``.env`` file directly and
+    is therefore still populated inside the scrubbed child.  Environment
+    variables keep priority, so no existing deployment changes behaviour.
     """
     for var in (_ENV_SECRET, "AUTOBOT_JWT_SECRET"):
         val = os.environ.get(var, "")
+        if val:
+            return val
+    for val in (config.run_jwt_secret, config.jwt_secret):
         if val:
             return val
     raise RuntimeError("No run-JWT signing secret configured.  Set RUN_JWT_SECRET (or AUTOBOT_JWT_SECRET).")

--- a/autobot-backend/services/run_jwt.py
+++ b/autobot-backend/services/run_jwt.py
@@ -69,6 +69,7 @@ from autobot_shared.auth.jwt_core import (
 from autobot_shared.fire_and_forget import run_redis_write
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_async_redis_client
+from autobot_shared.ssot_config import config
 from services.audit.audit import AuditAction, audit_record  # GH#8290 Phase 2
 
 
@@ -137,15 +138,22 @@ def _secret() -> str:
     general-purpose app secret that is known to multiple services would allow
     any of those services to forge run JWTs, undermining the isolation goal.
 
-    The run-JWT secret is resolved from the environment ONLY.  A config/.env
-    fallback here would silently widen the chain for every caller, including
-    the parent backend; the isolated bridge worker gets the secret provisioned
-    explicitly instead (see services/mcp_isolated_runtime._resolve_run_jwt_secret).
+    Environment variables keep priority.  ``RUN_JWT_SECRET`` — and only that
+    variable — additionally resolves from the SSOT config, which reads ``.env``:
+    it is the same dedicated secret by a different source, so the chain is not
+    widened.  Without it a ``.env``-only deployment cannot mint at all, and
+    #13265's propagation would silently degrade to forwarding ``None``.
+
+    ``config.jwt_secret`` is deliberately absent from that fallback for the same
+    reason ``SECRET_KEY`` is absent from the environment loop: it is the platform
+    user-session key, and admitting it here would let every holder forge run JWTs.
     """
     for var in (_ENV_SECRET, "AUTOBOT_JWT_SECRET"):
         val = os.environ.get(var, "")
         if val:
             return val
+    if config.run_jwt_secret:
+        return config.run_jwt_secret
     raise RuntimeError("No run-JWT signing secret configured.  Set RUN_JWT_SECRET (or AUTOBOT_JWT_SECRET).")
 
 

--- a/autobot-backend/services/run_jwt.py
+++ b/autobot-backend/services/run_jwt.py
@@ -69,7 +69,6 @@ from autobot_shared.auth.jwt_core import (
 from autobot_shared.fire_and_forget import run_redis_write
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_async_redis_client
-from autobot_shared.ssot_config import config
 from services.audit.audit import AuditAction, audit_record  # GH#8290 Phase 2
 
 
@@ -132,25 +131,19 @@ def get_run_jwt_scopes(agent_type: str, task_type: str | None = None) -> list[st
 
 
 def _secret() -> str:
-    """Resolve the signing secret, environment first, then the SSOT config.
+    """Resolve the signing secret from environment variables, in priority order.
 
     ``SECRET_KEY`` is deliberately excluded from the fallback chain.  A
     general-purpose app secret that is known to multiple services would allow
     any of those services to forge run JWTs, undermining the isolation goal.
 
-    #13265: the config fallback exists because isolated MCP bridge workers are
-    spawned with a scrubbed environment (``_WORKER_ENV_ALLOW`` in
-    ``services/mcp_isolated_runtime.py``), which excludes both secret variables.
-    Without it a worker cannot verify the run JWT it is handed, so enforcement
-    could never be switched on.  ``config`` reads the ``.env`` file directly and
-    is therefore still populated inside the scrubbed child.  Environment
-    variables keep priority, so no existing deployment changes behaviour.
+    The run-JWT secret is resolved from the environment ONLY.  A config/.env
+    fallback here would silently widen the chain for every caller, including
+    the parent backend; the isolated bridge worker gets the secret provisioned
+    explicitly instead (see services/mcp_isolated_runtime._resolve_run_jwt_secret).
     """
     for var in (_ENV_SECRET, "AUTOBOT_JWT_SECRET"):
         val = os.environ.get(var, "")
-        if val:
-            return val
-    for val in (config.run_jwt_secret, config.jwt_secret):
         if val:
             return val
     raise RuntimeError("No run-JWT signing secret configured.  Set RUN_JWT_SECRET (or AUTOBOT_JWT_SECRET).")

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -1812,11 +1812,11 @@ class MiscConfig(BaseSettings):
     # the token they are handed and enforcement can never be switched on.
     run_jwt_secret: str = Field(default="", alias="RUN_JWT_SECRET")
     # #13263: the pre-#7437 default was "1"; #7437 dropped it to "" and turned
-    # run-scoped JWT enforcement off in every bridge worker. Restoring it is
-    # BLOCKED on #13265: services/mcp_dispatch.py:214 calls call_tool() without
-    # run_jwt and _WORKER_ENV_ALLOW excludes MCP_RUN_JWT, so filesystem_mcp,
-    # browser_mcp and vnc_mcp would return -32001 on every chat tool call.
-    # Enforcement must not be switched on before the token can be supplied.
+    # run-scoped JWT enforcement off in every bridge worker.
+    # #13265 cleared the blocker: mcp_dispatch now mints and forwards a run JWT
+    # on every isolated call, and run_jwt._secret() falls back to this config so
+    # the scrubbed-environment worker can verify it. Restoring the "1" default
+    # is #13263's call and is deliberately left to that issue.
     mcp_run_jwt_enforce: str = Field(default="", alias="MCP_RUN_JWT_ENFORCE")
     mcp_worker_cpu_seconds: int = Field(default=0, alias="MCP_WORKER_CPU_SECONDS")
     mcp_worker_log_level: str = Field(default="", alias="MCP_WORKER_LOG_LEVEL")

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -1805,18 +1805,20 @@ class MiscConfig(BaseSettings):
     mcp_registry_cache_enabled: bool = Field(default=True, alias="MCP_REGISTRY_CACHE_ENABLED")
     mcp_registry_cache_ttl: str = Field(default="60", alias="MCP_REGISTRY_CACHE_TTL")
     mcp_run_jwt: str = Field(default="", alias="MCP_RUN_JWT")
-    # #13265: run-JWT signing secret as an SSOT field. services/run_jwt._secret()
-    # reads os.environ first (unchanged priority) and falls back to this, which
-    # is populated from the .env file. Isolated bridge workers run with a scrubbed
-    # environment (_WORKER_ENV_ALLOW), so without this fallback they cannot verify
-    # the token they are handed and enforcement can never be switched on.
+    # #13265: run-JWT signing secret as an SSOT field, read by
+    # mcp_isolated_runtime._resolve_run_jwt_secret() when provisioning an
+    # isolated bridge worker. The worker's inherited environment is scrubbed to
+    # _WORKER_ENV_ALLOW, so without an explicitly provisioned secret it cannot
+    # verify the run JWT it is handed and enforcement can never be switched on.
+    # services/run_jwt._secret() deliberately does NOT read this: the shared
+    # resolver stays environment-only so the chain is not widened for every caller.
     run_jwt_secret: str = Field(default="", alias="RUN_JWT_SECRET")
     # #13263: the pre-#7437 default was "1"; #7437 dropped it to "" and turned
     # run-scoped JWT enforcement off in every bridge worker.
     # #13265 cleared the blocker: mcp_dispatch now mints and forwards a run JWT
-    # on every isolated call, and run_jwt._secret() falls back to this config so
-    # the scrubbed-environment worker can verify it. Restoring the "1" default
-    # is #13263's call and is deliberately left to that issue.
+    # on every isolated call, and mcp_isolated_runtime provisions the signing
+    # secret into the scrubbed worker environment so it can verify that token.
+    # Restoring the "1" default is #13263's call and is left to that issue.
     mcp_run_jwt_enforce: str = Field(default="", alias="MCP_RUN_JWT_ENFORCE")
     mcp_worker_cpu_seconds: int = Field(default=0, alias="MCP_WORKER_CPU_SECONDS")
     mcp_worker_log_level: str = Field(default="", alias="MCP_WORKER_LOG_LEVEL")

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -1544,8 +1544,6 @@ class MiscConfig(BaseSettings):
     llm_temperature: str = Field(default="", alias="AUTOBOT_LLM_TEMPERATURE")
     log_backup_count: int = Field(default=0, alias="AUTOBOT_LOG_BACKUP_COUNT")
     log_max_bytes: int = Field(default=0, alias="AUTOBOT_LOG_MAX_BYTES")
-    # #13263: restore pre-#7437 default ("dev") — "" made the MCP server compare
-    # an incoming token's secret segment against "", accepting ":<scopes>" from anyone.
     # #13263: deliberately NO default. The pre-#7437 value was "dev", but a
     # working default credential is a vulnerability in its own right — the
     # secret is the whole check, and "dev" is published in this repo, so any

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -1553,6 +1553,23 @@ class MiscConfig(BaseSettings):
     # Empty means unconfigured, and autobot_server._validate_token fails
     # closed on it rather than authenticating everyone.
     mcp_token: str = Field(default="", alias="AUTOBOT_MCP_TOKEN")
+    # #13268: pre-auth throttle limits for POST /api/mcp/tool. These are
+    # thresholds, not credentials — a default is safe and a missing one would
+    # disable the only brute-force brake on an endpoint whose sole boundary is
+    # the shared secret above.
+    mcp_auth_max_failures: int = Field(default=10, alias="AUTOBOT_MCP_AUTH_MAX_FAILURES")
+    mcp_auth_window_seconds: int = Field(default=300, alias="AUTOBOT_MCP_AUTH_WINDOW_SECONDS")
+    mcp_auth_lockout_seconds: int = Field(default=900, alias="AUTOBOT_MCP_AUTH_LOCKOUT_SECONDS")
+    # #13268: ceiling across ALL client IPs in one window. X-Forwarded-For is
+    # attacker-controlled behind an appending proxy, so a per-IP counter alone
+    # is defeated by rotating the header; this bound is not.
+    mcp_auth_global_max_failures: int = Field(default=100, alias="AUTOBOT_MCP_AUTH_GLOBAL_MAX_FAILURES")
+    # #13268: bounds the tracker dict so spoofed source IPs cannot exhaust memory.
+    mcp_auth_max_tracked_ips: int = Field(default=4096, alias="AUTOBOT_MCP_AUTH_MAX_TRACKED_IPS")
+    # #13266: scopes the stdio transport grants itself. AUTOBOT_MCP_TOKEN is the
+    # SECRET only; stdio composes "<secret>:<these scopes>" instead of reusing the
+    # secret as a whole bearer token. Scope names are not a credential.
+    mcp_stdio_scopes: str = Field(default="kb,memory,agents", alias="AUTOBOT_MCP_STDIO_SCOPES")
     voice_toolset_bundle: str = Field(default="voice_safe", alias="AUTOBOT_VOICE_TOOLSETS")
     voice_disabled_tools: str = Field(default="", alias="AUTOBOT_VOICE_DISABLED_TOOLS")
     voice_realtime_model: str = Field(default="gpt-realtime-2", alias="AUTOBOT_VOICE_REALTIME_MODEL")
@@ -1788,6 +1805,12 @@ class MiscConfig(BaseSettings):
     mcp_registry_cache_enabled: bool = Field(default=True, alias="MCP_REGISTRY_CACHE_ENABLED")
     mcp_registry_cache_ttl: str = Field(default="60", alias="MCP_REGISTRY_CACHE_TTL")
     mcp_run_jwt: str = Field(default="", alias="MCP_RUN_JWT")
+    # #13265: run-JWT signing secret as an SSOT field. services/run_jwt._secret()
+    # reads os.environ first (unchanged priority) and falls back to this, which
+    # is populated from the .env file. Isolated bridge workers run with a scrubbed
+    # environment (_WORKER_ENV_ALLOW), so without this fallback they cannot verify
+    # the token they are handed and enforcement can never be switched on.
+    run_jwt_secret: str = Field(default="", alias="RUN_JWT_SECRET")
     # #13263: the pre-#7437 default was "1"; #7437 dropped it to "" and turned
     # run-scoped JWT enforcement off in every bridge worker. Restoring it is
     # BLOCKED on #13265: services/mcp_dispatch.py:214 calls call_tool() without


### PR DESCRIPTION
## Thinking Path

Three findings from the review of the MCP auth boundary, fixed together because they share one surface: `POST /api/mcp/tool` and the bridge workers behind it.

**#13268 — unmetered brute force.** The only rate limiter ran *after* a successful token check, so failed guesses were free. Since PR #13267 closed the "empty secret authenticates everyone" hole, guessing the secret is the remaining attack — and the secret is the entire boundary (the route has no FastAPI auth dependency and appears in neither `EXEMPT_PATHS` nor `SERVICE_ONLY_PATHS`). Each failed attempt also drove a Redis `GET` through the Redis-token fallback before rejection, making the endpoint an unauthenticated amplifier.

The interesting part is *where to key the counter*. The existing post-auth bucket keys on `auth_token[:16]`, which is safe only because it runs after authentication; keying a pre-auth counter on caller-supplied token bytes would let an attacker grow the map without bound. So failures are keyed on client IP, and the map is capped with oldest-first eviction.

But per-IP alone is not enough here. `get_client_ip()` correctly ignores `X-Forwarded-For` unless the TCP peer is a trusted proxy — however the shipped nginx templates set `proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for`, which **appends** the peer to whatever the client sent. Behind that proxy the leftmost element is caller-controlled, so a per-IP lockout is defeated by rotating one header value per request. I added an endpoint-wide failure ceiling alongside the per-IP one: it is not something a caller can rotate away from.

Review caught that ceiling being applied unconditionally, which turned it into an unauthenticated DoS: 100 anonymous failures per window blocked *every* caller, including holders of a valid token, indefinitely and with no operator-reachable reset. It now sheds only callers that have not authenticated within the window. That keeps the anti-rotation property — an attacker cannot enter the exempt set without first authenticating — while leaving established callers reachable. The exemption covers the ceiling only, never a caller's own per-IP budget, so authenticating once buys no licence to guess afterwards. The global counter is deliberately not drained on success, since draining it would hand a rotating attacker a reset button.

**#13265 — run JWT never reached the workers.** `IsolatedBridgeClient.call_tool()` has accepted `run_jwt` since #6473, but the only production call site never passed one, and the worker cannot read it from the environment either (`_WORKER_ENV_ALLOW` scrubs it, by design). Wiring the dispatcher exposed a second, unreported blocker: verifying an HMAC needs the key, and the signing secret is scrubbed out of the child too, so the worker would have raised `RuntimeError` — which `_handle_request` does not catch, killing the serve loop and burning the restart budget rather than returning a clean 401.

Getting the secret to the worker took two corrections, both caught by review rather than by me. First I gave `run_jwt._secret()` a broad config/.env fallback; the suite caught it via `test_secret_key_not_accepted_as_fallback`. I then moved the fallback into a *second* resolver on the worker-provisioning path — which that test does not cover — and chained it to `config.jwt_secret`. That is the **platform user-session signing key**: `auth_middleware` verifies user auth JWTs with it and `slm_client` mints service tokens with it. Exporting it into `filesystem_mcp` / `browser_mcp` / `vnc_mcp` — the bridges forced into subprocess isolation *precisely because* they handle untrusted content — would have let a compromised bridge read `/proc/self/environ` and forge a session for any user or role. A full authentication bypass, reached from the largest untrusted-input surface in the system, introduced by the fix rather than found by it.

Worse, it did not even work: pydantic-settings reads `.env` without writing `os.environ`, so in exactly the `.env`-only deployment the fallback was meant to serve, the parent's mint still raised, `_mint_bridge_jwt` swallowed it, and `run_jwt=None` was forwarded — #13265 a no-op *and* the platform key shipped anyway.

Both resolvers now admit `RUN_JWT_SECRET` only — the dedicated, separately rotatable key — from the environment first and then from SSOT config. That is the same secret by a different source, so no chain is widened, and it closes the `.env`-only gap on both sides so #13265 is genuinely delivered rather than silently degraded. `config.jwt_secret` is consulted nowhere, pinned by two negative tests. The run JWT itself is still passed per request and `_WORKER_ENV_ALLOW` is untouched.

**#13266 — one variable, two meanings.** `AUTOBOT_MCP_TOKEN` was read as the whole bearer token by `serve_stdio` and as the secret segment alone by `_validate_token`. No value satisfied both, so every stdio request was rejected in every configuration. The comparison site is the security boundary, so it keeps the meaning: the variable is the **secret only**, and stdio composes its own bearer from that secret plus a separate scope list.

No default credential is introduced anywhere, in code or docs. An unset secret is fatal at stdio startup rather than permissive, and a value containing `:` (the old overloaded form) is named explicitly instead of failing as an opaque -32001 forever.

**Not taken on:** the default-allow MCP tool blocklist (#13227/#13228). These changes are strictly *below* that layer — authentication and transport — and neither widen nor narrow which tools a caller may reach once authenticated.

## What Changed

**#13268 — pre-auth throttle**
- New `mcp/auth_throttle.py`: per-IP failure counting with lockout, plus an endpoint-wide ceiling, plus a bounded tracker (oldest-first eviction)
- Throttle runs before token validation and before the Redis fallback
- `handle_request()` accepts `client_ip`; the FastAPI route resolves it via the shared `get_client_ip()`, the aiohttp transport via the peer address
- Every rejection and lockout is logged with its reason
- All thresholds are env-fed config fields; nothing hardcoded at a call site

**#13265 — run-JWT propagation**
- `MCPDispatcher._call_bridge` mints a short-lived run JWT scoped to the bridge and forwards it on every isolated call
- The parent provisions the signing secret into the scrubbed worker environment so the token can actually be verified; `_WORKER_ENV_ALLOW` is not widened and the token stays per-request
- A missing signing secret now fails the *request* closed instead of escaping `_handle_request` and killing the worker's serve loop
- Mint failure is logged and non-fatal, so deployments running with enforcement off are unaffected

**Security review round (BLOCK → addressed)**
- The platform user-session key is no longer resolvable on either run-JWT path; only the dedicated `RUN_JWT_SECRET` is, and it now resolves from `.env` on both sides so #13265 is not a no-op in that deployment shape
- The endpoint-wide ceiling exempts recently-authenticated callers, closing the unauthenticated DoS
- The per-IP tier is documented as non-authoritative by construction (oldest-first eviction lets a rotating attacker evict their own lockout; the ceiling is the control that binds them)
- `record_success` documents why the global counter must not be cleared, so a later refactor does not "fix" the ceiling by draining it
- Eviction warnings sampled to once per window — logging per evicted entry was itself a log-volume amplifier, the class of bug #13268 set out to close
- Docs state the throttle is per backend process; stale `"dev"` default comment removed from config

**#13266 — single meaning for the token variable**
- `_stdio_bearer_token()` composes `<secret>:<scopes>` from the secret plus a new scope setting
- Unset secret, empty scope list, and the overloaded `<secret>:<scopes>` form each fail with a message that says what to fix
- Docs rewritten to state one meaning; stale docstrings naming a dev override removed

**Drive-by, in territory:** `autobot_mcp_router_test.py` memoised the server in a module global, so patching the class only affected the first request in the session — 5 of 7 tests were asserting against the previous test's mock and failing on base. Added a reset fixture; that file goes 2/7 → 9/9.

## Verification

**#13268 — throttle demonstrated, not asserted.** 200 unauthenticated guesses against the same endpoint, with the Redis fallback instrumented:

| | attempts | rejected (-32001) | throttled (-32029) | Redis GETs driven |
|---|---|---|---|---|
| before | 200 | **200** | **0** | **200** |
| after | 200 | 10 | **190** | 10 |

After the fix the log carries the reason: `mcp_throttle: locking out client for 900s after 10 failed MCP auth attempts in 300s`.

**#13266 — the overload, before and after.** What `serve_stdio` presented vs. what the validator expected, per configuration:

| `AUTOBOT_MCP_TOKEN` | before | after |
|---|---|---|
| unset | REJECTED -32001 | refuses to start, names the variable |
| a bare secret | REJECTED -32001 | **OK** |
| `<secret>:<scopes>` | REJECTED -32001 | refuses to start, says it holds the secret only |

Every configuration was rejected before; the documented one now authenticates.

**Review defects — reproduced, then fixed.** Both were verified by running the code before and after:

| | before | after |
|---|---|---|
| B1 worker receives the platform session key | **True** | False |
| B1 `.env`-only: parent mints, worker verifies with enforce=1 | mint → `None` (no-op) | token minted, verified, scope `['mcp:filesystem']` |
| B2 caller with a valid token blocked by the ceiling | **True** | False |
| B2 global counter drained by a success (must not be) | 100 | 100 |

A caller that has *never* authenticated is still shed while a flood is active — that is inherent, since nothing distinguishes it from the attacker before it authenticates, and it is what preserves rotation resistance. The DoS is now bounded to first-contact callers during a flood rather than platform-wide and indefinite.

**Tests — fail before, pass after.**

New throttle suite against pre-fix source, then after:
```
4 failed, 3 passed     # before
7 passed               # after
```

New run-JWT suite against pre-fix source, then after — the core assertion failing before is `no run JWT forwarded to the isolated worker`:
```
7 failed, 5 passed     # before
14 passed              # after
```

Router suite (pre-existing isolation bug): `5 failed, 2 passed` → `9 passed`.

Nine tests added for the review round: `test_platform_jwt_secret_is_never_provisioned_to_a_worker`, `test_platform_jwt_secret_is_not_in_the_parent_mint_chain`, `test_parent_secret_chain_admits_only_the_dedicated_secret`, `test_env_only_deployment_mints_verifies_and_provisions`, `test_ceiling_does_not_block_a_caller_that_never_failed`, `test_success_does_not_drain_the_global_counter`, `test_recent_success_does_not_exempt_from_the_per_ip_budget`, `test_recent_success_expires_with_the_window`, `test_recent_success_map_stays_bounded`.

Full affected surface:
```
185 passed, 3 warnings in 58.33s
```
covering `auth_throttle_test`, `autobot_server_test`, `autobot_mcp_router_test`, `mcp_dispatch_test`, `mcp_isolated_runtime_test`, `mcp_run_jwt_propagation_test`, `tests/services/test_run_jwt`, `ssot_config_test`.

`black`, `isort`, `flake8` clean on all changed files; `bandit` reports no issues on the new module. Every new/changed function is within the 30-line limit.

**Pre-existing failures, unrelated and left alone** (each verified failing on base with my changes reverted): 8 in `mcp/mcp_security_test.py` (including a static set assertion that cannot pass as written) and 1 in `services/mcp_worker_metrics_test.py` (metric never registered).

The original throttle demonstration is unchanged after the ceiling rework: 200 guesses → 10 allowed, 190 throttled, 10 Redis GETs.

**Not verifiable without a live system:** that a deployment's real proxy chain populates `X-Forwarded-For` as the shipped templates do, and the end-to-end subprocess round trip with `MCP_RUN_JWT_ENFORCE=1` against real bridges. Worker-side validation is covered at the function level instead. Flipping that enforcement default back on remains #13263's call and is deliberately not done here.

Closes #13268, #13265, #13266

## Model Used

claude-opus-5

