### PR TITLE
fix(tests): SSO/JWKS/RBAC-gate security tests — stop cross-file autobot_shared stub leak (#13312)

### DIFF
--- a/autobot-slm-backend/api/sso_auth.py
+++ b/autobot-slm-backend/api/sso_auth.py
@@ -94,31 +94,46 @@ async def get_audit_db():
         yield session
 
 
+_ALLOWED_CALLBACK_SCHEMES = frozenset({"http", "https"})
+
+
+def _reject_callback(reason: str, **extra) -> None:
+    """Log and raise the uniform 400 used by every _build_callback_url guard."""
+    logger.error("OAuth callback rejected: %s", reason, extra=extra)
+    raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid callback host")
+
+
 def _build_callback_url(request: Request) -> str:
     """Build OAuth2 callback URL with security validation (MVA-3542)."""
     scheme = request.headers.get("x-forwarded-proto", request.url.scheme)
     raw_host = request.headers.get("x-forwarded-host", request.url.netloc) or ""
 
+    # #13312: x-forwarded-proto is attacker-controlled like x-forwarded-host
+    # below but was reaching the returned redirect_uri unvalidated
+    # ("javascript" -> "javascript://host/...").
+    if scheme.lower() not in _ALLOWED_CALLBACK_SCHEMES:
+        _reject_callback("invalid scheme", scheme=scheme)
+
     # Block malicious characters (MVA-3542: SSRF/CRLF prevention)
     if any(c in raw_host for c in "@/\\#?"):
-        logger.error("OAuth callback rejected: malicious characters", extra={"host": raw_host})
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid callback host")
+        _reject_callback("malicious characters", host=raw_host)
 
-    # Parse with urlsplit to prevent parser differential attacks
+    # #13312: urlsplit() is lazy — .port re-parses on access and raises for a
+    # non-numeric/out-of-range port, so it must stay inside this try or a
+    # malformed port on this public, pre-auth endpoint 500s instead of 400ing.
     try:
         parsed = urlsplit(f"//{raw_host}")
         hostname = (parsed.hostname or "").lower().rstrip(".")
+        port = parsed.port
     except Exception as e:
-        logger.error("OAuth callback rejected: parse failed", extra={"host": raw_host, "error": str(e)})
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid callback host") from e
+        _reject_callback("parse failed", host=raw_host, error=str(e))
 
     # Validate hostname against allowlist
     if not hostname or hostname not in _ALLOWED_CALLBACK_HOSTS:
-        logger.error("OAuth callback rejected: not in allowlist", extra={"hostname": hostname})
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid callback host")
+        _reject_callback("not in allowlist", hostname=hostname)
 
     # Reconstruct netloc from validated components
-    netloc = hostname + (f":{parsed.port}" if parsed.port else "")
+    netloc = hostname + (f":{port}" if port else "")
     return f"{scheme}://{netloc}/api/auth/sso/callback"
 
 

--- a/autobot-slm-backend/tests/api/test_auth_logout.py
+++ b/autobot-slm-backend/tests/api/test_auth_logout.py
@@ -266,10 +266,17 @@ class TestRevokeTtlFromToken:
         redis_mock.set = AsyncMock(return_value=True)
         get_client = AsyncMock(return_value=redis_mock)
 
-        with patch.object(_dl_mod, "get_redis_client", get_client):
+        # #12807/#12827 migrated token_denylist.py off the sync-returning
+        # get_redis_client(async_client=True) footgun onto get_async_redis_client()
+        # (autobot_shared/redis_client.py) but this test's patch target was never
+        # updated (#13312): patch.object(_dl_mod, "get_redis_client", ...) raised
+        # AttributeError because that name no longer exists on the module, so this
+        # test collected as a failure with zero real-defect signal in the control
+        # it claims to verify — revoke_jti was already using the safe helper.
+        with patch.object(_dl_mod, "get_async_redis_client", get_client):
             await _dl_mod.revoke_jti(jti, ttl_seconds=expected_ttl)
 
-        get_client.assert_called_once_with(async_client=True)
+        get_client.assert_called_once_with()
         redis_mock.set.assert_awaited_once()
         _, kwargs = redis_mock.set.call_args
         assert kwargs["ex"] >= 1

--- a/autobot-slm-backend/tests/api/test_sso_auth.py
+++ b/autobot-slm-backend/tests/api/test_sso_auth.py
@@ -55,6 +55,14 @@ _SSO_AUTH_PY = Path(__file__).parent.parent.parent / "api" / "sso_auth.py"
 # failed (tests/test_prometheus_registry_endpoint.py,
 # tests/test_api_request_counter.py; #11798).  All loads now go through this
 # snapshot/restore helper (same pattern as _load_sso_auth_with_real_endpoints).
+#
+# #13312: "api.security" was missing here — sso_auth.py's `from api.security
+# import create_audit_log` then real-imports api/security.py, whose module-
+# level route decorators read fastapi.status.HTTP_201_CREATED. Tests that pass
+# a restricted fastapi_stub (only HTTP_400_BAD_REQUEST) raised AttributeError
+# the FIRST time this ran in the process; it only worked afterwards because a
+# real "api.security" import from an earlier test in the same session got
+# cached in sys.modules. Stubbing it here removes that run-order dependency.
 _SSO_STUB_KEYS = (
     "fastapi",
     "fastapi.responses",
@@ -64,6 +72,7 @@ _SSO_STUB_KEYS = (
     "user_management.services.base_service",
     "user_management.services.sso_service",
     "services.auth",
+    "api.security",
 )
 
 
@@ -146,6 +155,69 @@ def test_build_callback_url_host_with_port():
     assert (
         result == "http://localhost:8000/api/auth/sso/callback"
     )  # canonical: ignore py-hardcoded-url — test fixture/mock URL, not an executable default
+
+
+def test_build_callback_url_invalid_port_rejected():
+    """Test callback URL rejects an out-of-range port with 400, not an unhandled 500 (#13312).
+
+    urlsplit()'s .port property re-parses on access and raises ValueError for
+    a non-numeric or >65535 port; that access must stay inside the function's
+    try/except or it escapes past every caller of _build_callback_url — both
+    public, pre-auth SSO endpoints — as an unhandled 500.
+    """
+
+    class MockHTTPException(Exception):
+        def __init__(self, status_code, detail):
+            self.status_code = status_code
+            self.detail = detail
+            super().__init__(detail)
+
+    fastapi_mock = MagicMock()
+    fastapi_mock.HTTPException = MockHTTPException
+    fastapi_mock.status = SimpleNamespace(HTTP_400_BAD_REQUEST=400)
+
+    sso_auth = _load_sso_auth_with_stubs(fastapi_stub=fastapi_mock)
+
+    request = _make_mock_request(
+        "http", "localhost:99999", {"x-forwarded-proto": "http", "x-forwarded-host": "localhost:99999"}
+    )
+
+    with pytest.raises(MockHTTPException) as exc_info:
+        sso_auth._build_callback_url(request)
+
+    assert exc_info.value.status_code == 400
+    assert "Invalid callback host" in exc_info.value.detail
+
+
+def test_build_callback_url_invalid_scheme_rejected():
+    """Test callback URL rejects a non-http(s) x-forwarded-proto (#13312).
+
+    x-forwarded-proto is attacker-controlled the same as x-forwarded-host, but
+    used to reach the returned redirect_uri unvalidated (e.g. "javascript" ->
+    "javascript://localhost/api/auth/sso/callback").
+    """
+
+    class MockHTTPException(Exception):
+        def __init__(self, status_code, detail):
+            self.status_code = status_code
+            self.detail = detail
+            super().__init__(detail)
+
+    fastapi_mock = MagicMock()
+    fastapi_mock.HTTPException = MockHTTPException
+    fastapi_mock.status = SimpleNamespace(HTTP_400_BAD_REQUEST=400)
+
+    sso_auth = _load_sso_auth_with_stubs(fastapi_stub=fastapi_mock)
+
+    request = _make_mock_request(
+        "javascript", "localhost", {"x-forwarded-proto": "javascript", "x-forwarded-host": "localhost"}
+    )
+
+    with pytest.raises(MockHTTPException) as exc_info:
+        sso_auth._build_callback_url(request)
+
+    assert exc_info.value.status_code == 400
+    assert "Invalid callback host" in exc_info.value.detail
 
 
 def test_build_callback_url_case_insensitive():

--- a/autobot-slm-backend/tests/test_rbac_middleware_cache.py
+++ b/autobot-slm-backend/tests/test_rbac_middleware_cache.py
@@ -20,6 +20,7 @@ via importlib — matching the approach used in other SLM unit tests that avoid 
 import asyncio
 import importlib.util
 import json
+import logging
 import sys
 import time
 import types
@@ -88,8 +89,13 @@ _fastapi_mock.status = http.HTTPStatus
 # that does a real `from autobot_shared.X import Y` then failed the same way.
 # TTL_5_MINUTES must be the real int (not a MagicMock) because CACHE_TTL_SECONDS
 # is used in real arithmetic/comparisons (time.time() - CACHE_TTL_SECONDS).
+# get_logger must resolve to the real stdlib logging.getLogger (not a MagicMock):
+# rbac_middleware.py's module-level `logger = get_logger(__name__)` is then a
+# genuine stdlib Logger, so logger.error(...) reaches caplog. A MagicMock logger
+# swallows every call silently, which would make any test asserting on
+# caplog.records for this module unable to ever pass (#13312).
 _logging_manager_mod = MagicMock()
-_logging_manager_mod.get_logger = MagicMock(return_value=MagicMock())
+_logging_manager_mod.get_logger = logging.getLogger
 sys.modules["autobot_shared.logging_manager"] = _logging_manager_mod
 _ssot_constants_mod = MagicMock()
 _ssot_constants_mod.TTL_5_MINUTES = 300
@@ -142,6 +148,17 @@ def _make_redis(get_return=None):
         yield  # make it an async generator
 
     r.scan_iter = _empty_scan
+
+    # redis.asyncio.Redis.pipeline() is SYNCHRONOUS — it returns a Pipeline
+    # object immediately, whose .delete() buffers synchronously and whose
+    # .execute() is the only awaited call (rbac_middleware.py:299-302). `r`
+    # being a bare AsyncMock made `r.pipeline` auto-spec as an AsyncMock too,
+    # so `redis.pipeline()` returned an un-awaited coroutine instead of a
+    # pipeline object and `pipeline.delete(key)` raised AttributeError (#13312).
+    _pipe = MagicMock()
+    _pipe.delete = MagicMock()
+    _pipe.execute = AsyncMock()
+    r.pipeline = MagicMock(return_value=_pipe)
     return r
 
 

--- a/autobot-slm-backend/tests/test_rbac_middleware_cache.py
+++ b/autobot-slm-backend/tests/test_rbac_middleware_cache.py
@@ -80,26 +80,45 @@ _fastapi_mock.HTTPException = type("HTTPException", (Exception,), {"__init__": l
 _fastapi_mock.Request = type("Request", (), {})
 _fastapi_mock.status = http.HTTPStatus
 
-# Load the module under test directly (bypasses __init__ import chain)
-_SPEC = importlib.util.spec_from_file_location(
-    "user_management.middleware.rbac_middleware",
-    _SLM_ROOT / "user_management" / "middleware" / "rbac_middleware.py",
-)
-_rbac_mod: types.ModuleType = types.ModuleType(_SPEC.name)
-_SPEC.loader.exec_module(_rbac_mod)
+# autobot_shared.logging_manager / .ssot_constants are imported by rbac_middleware
+# but were missing from _MOCK_NAMES (#13312): a bare MagicMock has no submodule
+# for either, so exec_module() below raised ModuleNotFoundError *before* the
+# restore block ran, permanently leaving sys.modules["autobot_shared"] as a
+# path-less MagicMock for the rest of the pytest session — every later test file
+# that does a real `from autobot_shared.X import Y` then failed the same way.
+# TTL_5_MINUTES must be the real int (not a MagicMock) because CACHE_TTL_SECONDS
+# is used in real arithmetic/comparisons (time.time() - CACHE_TTL_SECONDS).
+_logging_manager_mod = MagicMock()
+_logging_manager_mod.get_logger = MagicMock(return_value=MagicMock())
+sys.modules["autobot_shared.logging_manager"] = _logging_manager_mod
+_ssot_constants_mod = MagicMock()
+_ssot_constants_mod.TTL_5_MINUTES = 300
+sys.modules["autobot_shared.ssot_constants"] = _ssot_constants_mod
 
-# Aliases for readability
-_CACHE_TTL = _rbac_mod.CACHE_TTL_SECONDS
-_REDIS_PREFIX = _rbac_mod._REDIS_KEY_PREFIX
-_PUBSUB_CHANNEL = _rbac_mod._PUBSUB_CHANNEL
+# Load the module under test directly (bypasses __init__ import chain).
+# The restore block MUST run even if exec_module() raises, or a bad stub here
+# (or a future import added to rbac_middleware.py) leaks these MagicMocks into
+# every test collected afterward (#13312).
+try:
+    _SPEC = importlib.util.spec_from_file_location(
+        "user_management.middleware.rbac_middleware",
+        _SLM_ROOT / "user_management" / "middleware" / "rbac_middleware.py",
+    )
+    _rbac_mod: types.ModuleType = types.ModuleType(_SPEC.name)
+    _SPEC.loader.exec_module(_rbac_mod)
 
-# #11794: restore the pre-bootstrap sys.modules state (see snapshot above).
-for _k in list(sys.modules):
-    if _k not in _PRE_BOOTSTRAP_MODULES:
-        del sys.modules[_k]
-    elif sys.modules[_k] is not _PRE_BOOTSTRAP_MODULES[_k]:
-        sys.modules[_k] = _PRE_BOOTSTRAP_MODULES[_k]
-del _PRE_BOOTSTRAP_MODULES
+    # Aliases for readability
+    _CACHE_TTL = _rbac_mod.CACHE_TTL_SECONDS
+    _REDIS_PREFIX = _rbac_mod._REDIS_KEY_PREFIX
+    _PUBSUB_CHANNEL = _rbac_mod._PUBSUB_CHANNEL
+finally:
+    # #11794: restore the pre-bootstrap sys.modules state (see snapshot above).
+    for _k in list(sys.modules):
+        if _k not in _PRE_BOOTSTRAP_MODULES:
+            del sys.modules[_k]
+        elif sys.modules[_k] is not _PRE_BOOTSTRAP_MODULES[_k]:
+            sys.modules[_k] = _PRE_BOOTSTRAP_MODULES[_k]
+    del _PRE_BOOTSTRAP_MODULES
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-slm-backend/tests/test_rbac_permission_denied_audit.py
+++ b/autobot-slm-backend/tests/test_rbac_permission_denied_audit.py
@@ -93,21 +93,37 @@ _audit_mod.AuditLog = _AuditLog
 _audit_mod.AuditAction = _AuditAction
 _audit_mod.AuditResourceType = _AuditResourceType
 
-# Load the module under test
-_SPEC = importlib.util.spec_from_file_location(
-    "user_management.middleware.rbac_middleware",
-    _SLM_ROOT / "user_management" / "middleware" / "rbac_middleware.py",
-)
-_rbac_mod: types.ModuleType = types.ModuleType(_SPEC.name)
-_SPEC.loader.exec_module(_rbac_mod)
+# autobot_shared.logging_manager / .ssot_constants are imported by rbac_middleware
+# but were missing from _MOCK_NAMES (#13312): a bare MagicMock has no submodule
+# for either, so exec_module() below raised ModuleNotFoundError *before* the
+# restore block ran, permanently leaving sys.modules["autobot_shared"] as a
+# path-less MagicMock for the rest of the pytest session — every later test file
+# that does a real `from autobot_shared.X import Y` then failed the same way.
+_logging_manager_mod = MagicMock()
+_logging_manager_mod.get_logger = MagicMock(return_value=MagicMock())
+sys.modules["autobot_shared.logging_manager"] = _logging_manager_mod
+_ssot_constants_mod = MagicMock()
+_ssot_constants_mod.TTL_5_MINUTES = 300
+sys.modules["autobot_shared.ssot_constants"] = _ssot_constants_mod
 
-# #11794: restore the pre-bootstrap sys.modules state (see snapshot above).
-for _k in list(sys.modules):
-    if _k not in _PRE_BOOTSTRAP_MODULES:
-        del sys.modules[_k]
-    elif sys.modules[_k] is not _PRE_BOOTSTRAP_MODULES[_k]:
-        sys.modules[_k] = _PRE_BOOTSTRAP_MODULES[_k]
-del _PRE_BOOTSTRAP_MODULES
+# Load the module under test. The restore block MUST run even if exec_module()
+# raises, or a bad stub here (or a future import added to rbac_middleware.py)
+# leaks these MagicMocks into every test collected afterward (#13312).
+try:
+    _SPEC = importlib.util.spec_from_file_location(
+        "user_management.middleware.rbac_middleware",
+        _SLM_ROOT / "user_management" / "middleware" / "rbac_middleware.py",
+    )
+    _rbac_mod: types.ModuleType = types.ModuleType(_SPEC.name)
+    _SPEC.loader.exec_module(_rbac_mod)
+finally:
+    # #11794: restore the pre-bootstrap sys.modules state (see snapshot above).
+    for _k in list(sys.modules):
+        if _k not in _PRE_BOOTSTRAP_MODULES:
+            del sys.modules[_k]
+        elif sys.modules[_k] is not _PRE_BOOTSTRAP_MODULES[_k]:
+            sys.modules[_k] = _PRE_BOOTSTRAP_MODULES[_k]
+    del _PRE_BOOTSTRAP_MODULES
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-slm-backend/tests/test_rbac_permission_denied_audit.py
+++ b/autobot-slm-backend/tests/test_rbac_permission_denied_audit.py
@@ -16,6 +16,7 @@ into sys.modules before loading the module under test via importlib.
 """
 
 import importlib.util
+import logging
 import sys
 import types
 import uuid
@@ -99,8 +100,13 @@ _audit_mod.AuditResourceType = _AuditResourceType
 # restore block ran, permanently leaving sys.modules["autobot_shared"] as a
 # path-less MagicMock for the rest of the pytest session — every later test file
 # that does a real `from autobot_shared.X import Y` then failed the same way.
+# get_logger must resolve to the real stdlib logging.getLogger (not a MagicMock):
+# rbac_middleware.py's module-level `logger = get_logger(__name__)` is then a
+# genuine stdlib Logger, so logger.error(...) reaches caplog. A MagicMock logger
+# swallows every call silently, so test_db_failure_logs_error (which asserts on
+# caplog.records) could never pass with the old stub (#13312).
 _logging_manager_mod = MagicMock()
-_logging_manager_mod.get_logger = MagicMock(return_value=MagicMock())
+_logging_manager_mod.get_logger = logging.getLogger
 sys.modules["autobot_shared.logging_manager"] = _logging_manager_mod
 _ssot_constants_mod = MagicMock()
 _ssot_constants_mod.TTL_5_MINUTES = 300


### PR DESCRIPTION
## Thinking Path

#13312 reported 56 failures + 11 errors from `autobot-slm-backend`'s first-ever CI run. This PR fixes the security-relevant subset — SSO secret migration, SSO auth callback-URL, JWKS/token verification, and the service-management RBAC gate — plus everything else provably cleared by the same root-cause fix.

For each failing test I first checked whether production code or the test was wrong, running each cluster standalone and comparing against git history for the modules under test.

- `migrations/migrate_sso_secrets_test.py`, `tests/api/test_sso_auth.py`, `services/jwks_verifier_test.py`, `tests/test_service_management_gate.py` all pass standalone — encryption-at-rest, rollback/commit, the callback-host allowlist, RS256/HS256 JWKS verification, and the `SERVICE_MANAGEMENT` RBAC gate are all correctly implemented.
- Running the **full** `autobot-slm-backend` suite with `-n auto --dist loadscope` (the invocation `ci.yml` used before #13314's sharding, still what each shard runs internally) reproduced 33 of the 56 tracked failures deterministically, spanning 11 files, all with the identical symptom: `ModuleNotFoundError: ... 'autobot_shared' is not a package` or a permission/status object resolving to a `MagicMock` instead of its real value.
- Root-caused with a `pytest_collectstart` probe plugin (not committed) plus a `--continue-on-collection-errors` serial run: `tests/test_rbac_middleware_cache.py` and `tests/test_rbac_permission_denied_audit.py` each replace `sys.modules["autobot_shared"]` with a bare `MagicMock()` (no `__path__`) at module scope, then `exec_module()` the real `rbac_middleware.py`. `git log -S` on that import traces the second dependency it needs (`autobot_shared.ssot_constants`) to `486eb1900` (#13213, 2026-08-01, an ancestor of the #13300 baseline run) — before that refactor `rbac_middleware.py` didn't import either module and these two test files collected fine. Neither test file's stub list was updated, so `exec_module()` raises `ModuleNotFoundError` **before** the sys.modules-restore block that follows it — outside any `try/finally`. Both files fail to collect even in isolation. Because the restore never runs, the broken `autobot_shared`/`fastapi` stubs stay in `sys.modules` for the rest of the pytest process, breaking every later real `from autobot_shared.X import Y` — this is what took down the other 9 files.
- pytest-split (the #13314 sharding) deselects tests in `pytest_collection_modifyitems`, which runs *after* collection/module-import — so the leak reaches every shard's collection regardless of which shard a given test lands in. Rebased onto `c4938ec36` (post-sharding) and re-verified with the actual `--splits 12 --group N` invocation for the two shards that contain every file this PR touches.
- `tests/api/test_auth_logout.py::test_revoke_called_with_positive_ttl` is unrelated to the leak: `services/token_denylist.py` was migrated from `get_redis_client(async_client=True)` to the safe `get_async_redis_client()` wrapper in #12807/#12827, which updated patch targets in six test files but missed this one.
- Fixing the leak let two more RBAC test files run for the first time and immediately surfaced two more defects, both in the tests, both in files already in this diff: a `get_logger` stub returning a `MagicMock` (so `logger.error(...)` never reached `caplog`) and a `redis.pipeline()` stub that auto-specced as async when the real client's `pipeline()` is synchronous.
- Reading `_build_callback_url` line-by-line for the reconstruction/allowlist logic (needed to diagnose the port question) surfaced two real, if low-severity, gaps: `urlsplit().port` is accessed outside the try that is supposed to turn a bad host into a 400, and `X-Forwarded-Proto` reaches the returned `redirect_uri` with no scheme validation despite `X-Forwarded-Host` on the very next line being treated as hostile. Fixed both with regression tests proven to fail pre-fix.

## What Changed

**Test-infrastructure fix (the root cause):**
- `autobot-slm-backend/tests/test_rbac_middleware_cache.py`, `tests/test_rbac_permission_denied_audit.py`: add the missing `autobot_shared.logging_manager` / `autobot_shared.ssot_constants` stubs, wrap the `exec_module()` call + `sys.modules` restore in `try/finally` so a future import added to `rbac_middleware.py` can't leak stub state again, fix `get_logger`'s stub to be the real `logging.getLogger` (not a swallowing `MagicMock`), and fix the fake Redis client's `.pipeline()` to match the real synchronous-pipeline/async-`.execute()` shape.

**Test-only fix (stale patch target, unrelated to the leak):**
- `autobot-slm-backend/tests/api/test_auth_logout.py`: patch `get_async_redis_client` instead of the removed `get_redis_client`.

**Production security fix** (`autobot-slm-backend/api/sso_auth.py`), both on public, pre-auth SSO endpoints, both with new regression tests proven to fail against the pre-fix code:
- Move the `urlsplit().port` read inside the existing try/except — it re-parses lazily and raises `ValueError` for a non-numeric or >65535 port, which previously escaped as an unhandled 500 instead of the intended 400.
- Reject any `X-Forwarded-Proto` outside `{http, https}` before it reaches the returned `redirect_uri` — it was unvalidated attacker input reaching the response unlike `X-Forwarded-Host` on the next line.
- Extracted the repeated log+raise into `_reject_callback()` to keep the function within the house line-count convention with the two new guards.

**Test-only fix** (`autobot-slm-backend/tests/api/test_sso_auth.py`): stub `api.security` in `_load_sso_auth_with_stubs()` — its absence meant `sso_auth.py`'s `from api.security import create_audit_log` real-imported `api/security.py`, whose route decorators need `fastapi.status.HTTP_201_CREATED`, present on a full `MagicMock` fastapi but not on the narrower stub some tests pass. Discovered because the pre-existing `test_build_callback_url_invalid_host_rejected` has the identical failure mode in isolation.

## Verification

Rebased onto `origin/Dev_new_gui` at `c4938ec36` (#13314's 12-way shard) for the sweeps below, then rebased once more onto `93c17474d` (#13328, the issue-link gate widening) before the final push — no test-affecting change in that second rebase. All numbers below are from the `c4938ec36` base.

**Accounting reconciled against a full sweep on the rebased base, before any commit in this PR** (`-n auto --dist loadscope`, unsharded — equivalent to any one shard's internal collection since pytest-split deselects after import): **33 failed, 1462 passed, 10 errors.** 33 + the 23 below = 56, matching #13312 exactly.

33 verified-resolved by this PR, enumerated by file:

| File | Failing before | Resolved |
|---|---|---|
| `tests/api/test_sso_auth.py` | 5 | yes |
| `tests/test_service_management_gate.py` | 6 | yes |
| `services/jwks_verifier_test.py` | 2 | yes |
| `api/code_source_test.py` | 3 | yes (side effect of the leak fix — file untouched) |
| `tests/test_prometheus_registry_endpoint.py` | 6 | yes (side effect — file untouched) |
| `tests/test_api_request_counter.py` | 4 | yes (side effect — file untouched) |
| `tests/api/test_node_code_status_read_derivation_12428.py` | 1 | yes (side effect — file untouched) |
| `tests/api/test_role_migration_extra_vars.py` | 1 | yes (side effect — file untouched) |
| `tests/test_code_sync_topology.py` | 2 | yes (side effect — file untouched) |
| `tests/api/test_nodes_list_timeout_10913.py` | 2 | yes (side effect — file untouched) |
| `tests/api/test_auth_logout.py` | 1 | yes (unrelated stale patch target, fixed separately) |

23 tracked in #13312 with **no reproducible local failure and no known cause** — not touched, not claimed as resolved:
- `migrations/migrate_sso_secrets_test.py` — 18. Ran standalone, full-suite unsharded, and sharded (`--splits 12 --group 1`, the shard this file lands in): passes every time, before and after this PR. `git log adf289c60..HEAD` on the migration script and its test is empty. I have no working hypothesis for why CI's original run saw 18 failures here and explicitly do not carry one — an earlier draft of this PR blamed a worker-count-dependent pollution reach, which a `-n 4 --cov` re-run disproved (byte-identical 33/10 failure set): pytest-xdist workers each perform a full collection, so the leak's reach does not vary with worker count, and it isn't the explanation for this cluster either.
- `tests/services/version_checker_test.py` — 5. Same: no reproducible failure found in any invocation.

**Full local sweep after this PR, same unsharded invocation:** `1556 passed, 3 skipped, 1 xfailed, 0 failed, 0 errors`.

**Sharded verification matching the actual CI gate** (`--splits 12 --group N --durations-path .test_durations_slm`, the exact flags `ci.yml`'s `python-shard` job uses): every file this PR touches or that the leak fix clears lands in shard 1 or shard 5 of 12. Both shards, post-fix:
```
shard 1/12: 497 passed  (includes migrate_sso_secrets_test.py, jwks_verifier_test.py, test_auth_logout.py)
shard 5/12: 964 passed, 3 skipped, 1 xfailed  (includes test_sso_auth.py, test_service_management_gate.py,
             test_rbac_middleware_cache.py, test_rbac_permission_denied_audit.py)
```
Zero failures, zero errors in either shard.

New regression tests, proven to fail against the pre-fix `api/sso_auth.py`:
```
FAILED test_build_callback_url_invalid_port_rejected — ValueError: Port out of range 0-65535 (uncaught)
FAILED test_build_callback_url_invalid_scheme_rejected — Failed: DID NOT RAISE (javascript:// accepted)
```
Both pass against the fixed code, along with the full existing 15-test file (17 total after the additions).

**Collection errors, part of #13312's tracked "11 errors" bucket per the two RBAC files:** `test_rbac_middleware_cache.py` and `test_rbac_permission_denied_audit.py` failed to collect (`ModuleNotFoundError`) both standalone and in every full-suite run before this PR; both collect and pass fully after. `test_redis_service_router.py` and `main_ensure_local_node_test.py` (7 sub-tests) also went from erroring to passing locally as a further side effect of the leak fix — not claimed as part of the tracked 11 since that isn't independently confirmed.

No production code changed except the two `_build_callback_url` guards in `api/sso_auth.py`. flake8/isort/black clean on every touched file. No commit trailers.

Refs #13312

## Model Used

Sonnet 5
