### PR TITLE
fix(ci): accept Refs as valid PR issue linkage (#13327)

### DIFF
--- a/.github/workflows/pr-issue-validation.yml
+++ b/.github/workflows/pr-issue-validation.yml
@@ -58,11 +58,19 @@ jobs:
 
           BODY="${PR_BODY:-}"
 
-          # (a) The body must contain at least one closing keyword, so a PR that
-          # merely mentions an issue in prose is not treated as linking it.
-          if ! printf '%s' "$BODY" | grep -iqE "(resolves|closes|fixes)[[:space:]]+(#?[0-9]+|MVA-[0-9]+)"; then
-            echo "::error::PR body has no 'Resolves/Closes/Fixes #N' linkage."
-            echo "::error::Add 'Closes #${EXPECTED_ISSUE}' to the PR body."
+          # (a) The body must link the issue with a recognised keyword, so a PR
+          # that merely mentions an issue in prose is not treated as linking it.
+          #
+          # #13327: `Refs` counts. A PR that genuinely does not close its issue
+          # must be able to say so — partial delivery never closes (closure
+          # Gate 3), and a gate that only accepts closing keywords pressures
+          # authors into over-claiming closure to get a green check. That is the
+          # opposite of what the closure rule wants. Four PRs in one day hit
+          # this: each had to invent a scoped issue purely to satisfy the gate.
+          if ! printf '%s' "$BODY" | grep -iqE "(resolves|closes|fixes|refs|references|part of)[[:space:]]+(#?[0-9]+|MVA-[0-9]+)"; then
+            echo "::error::PR body has no issue linkage."
+            echo "::error::Add 'Closes #${EXPECTED_ISSUE}' if this PR fully delivers it,"
+            echo "::error::or 'Refs #${EXPECTED_ISSUE}' if it does not."
             echo "status=failure" >> "$GITHUB_OUTPUT"
             exit 1
           fi
@@ -82,7 +90,7 @@ jobs:
             exit 0
           fi
 
-          echo "::error::PR closes some issue(s) but not ${EXPECTED_ISSUE} (implied by branch ${PR_BRANCH})."
-          echo "::error::Add 'Closes #${EXPECTED_ISSUE}' (or 'Closes MVA-${EXPECTED_ISSUE}') to the PR body."
+          echo "::error::PR links some issue(s) but not ${EXPECTED_ISSUE} (implied by branch ${PR_BRANCH})."
+          echo "::error::Add 'Closes #${EXPECTED_ISSUE}' or 'Refs #${EXPECTED_ISSUE}' to the PR body."
           echo "status=failure" >> "$GITHUB_OUTPUT"
           exit 1


### PR DESCRIPTION
## Thinking Path

The issue-link gate required a **closing** keyword:

```bash
grep -iqE "(resolves|closes|fixes)[[:space:]]+(#?[0-9]+|MVA-[0-9]+)"
```

So a PR that honestly does not close its branch's issue could not pass. That directly contradicts closure Gate 3 — *partial delivery never closes* — by making the honest outcome red and rewarding over-claimed closure with green.

Four PRs hit this in one day: **#13314** (sharding delivered; #10691 is about enforcing the suite as a required check, which it does not do), **#13318** (watchdog triggers delivered; #12823's primary defect is structurally unfixed), **#13319** (repair tool written; #13277 cannot close until an operator runs it against real data), and **#13320** (four slow tests fixed; 4 of #13312's 56).

**Two issues — #13316 and #13323 — exist only because of this gate.** That is tooling manufacturing backlog.

## What Changed

`.github/workflows/pr-issue-validation.yml`, check (a) only:

```diff
-(resolves|closes|fixes)[[:space:]]+(#?[0-9]+|MVA-[0-9]+)
+(resolves|closes|fixes|refs|references|part of)[[:space:]]+(#?[0-9]+|MVA-[0-9]+)
```

Error messages now offer both forms — `Closes #N` if the PR fully delivers the issue, `Refs #N` if it does not — instead of instructing `Closes` unconditionally.

**Check (b) is untouched.** The branch's issue must still appear as a standalone token with the same superstring guards, so a PR still cannot link some *other* issue and pass.

## Verification

The regex exercised exactly as the workflow invokes it:

| body | verdict |
|---|---|
| `Closes #13277` | ACCEPT |
| `Refs #13277` | ACCEPT |
| `References #13277` | ACCEPT |
| `Part of #13277` | ACCEPT |
| `Fixes MVA-3244` | ACCEPT |
| `see issue 13277` | REJECT |
| `this mentions #13277 in prose` | REJECT |

Prose mentions are still rejected — the property the gate exists to enforce is preserved. YAML parses.

**Not verified without a live event:** the gate running end-to-end on a real `pull_request`. This PR itself is the first test — its body uses `Closes`, so a `Refs`-only body is exercised by the next PR that needs one.

## Model Used

Sonnet 5

Closes #13327
