### PR TITLE
fix(chat): interleave per-iteration prose with tool output on reload (#13295)

### DIFF
--- a/autobot-backend/chat_workflow/graph.py
+++ b/autobot-backend/chat_workflow/graph.py
@@ -1294,7 +1294,11 @@ async def _persist_error_turn(manager, state: ChatState) -> None:
             )
         ]
     try:
-        await manager._persist_workflow_messages(session_id, wf_messages, "")
+        # Issue #13295: no completed response exists on this path — an empty
+        # list (not "") falls through _build_persist_batch's iteration loop
+        # untouched, so every wf_messages entry is appended via its unchanged
+        # leftover fallback, exactly as before.
+        await manager._persist_workflow_messages(session_id, wf_messages, [])
     except Exception as exc:  # noqa: BLE001
         logger.error("Failed to persist error turn for session %s: %s", session_id, exc, exc_info=True)
 
@@ -1353,14 +1357,20 @@ async def persist_conversation(state: ChatState, config: RunnableConfig) -> dict
 
     manager = config["configurable"]["manager"]
     session_id = state.get("session_id", "")
-    combined_response = "\n\n".join(state.get("all_llm_responses", []))
+    all_llm_responses = state.get("all_llm_responses", [])
+    combined_response = "\n\n".join(all_llm_responses)
 
     # Emit LOOP_COMPLETE hook to notify extensions
     await _emit_loop_complete(state.get("iteration_count", 0), combined_response, session_id)
 
     try:
         session = await manager.get_or_create_session(session_id)
-        # Issue #4263: allow extensions to inspect/modify response before sending
+        # Issue #4263: allow extensions to inspect/modify response before sending.
+        # Issue #13295: the (rare, default no-op) hook output feeds the combined
+        # session-level view below; it is intentionally NOT threaded into
+        # all_llm_responses, since a single edited string cannot be split back
+        # into the per-iteration entries _persist_workflow_messages now needs
+        # to interleave with tool output.
         combined_response = await _emit_before_response_send_safe(combined_response, session_id)
 
         await manager._persist_conversation(session_id, session, state["user_message"], combined_response)
@@ -1369,7 +1379,7 @@ async def persist_conversation(state: ChatState, config: RunnableConfig) -> dict
         await manager._persist_workflow_messages(
             session_id,
             wf_messages,
-            combined_response,
+            all_llm_responses,
             selected_model=state.get("llm_params", {}).get("selected_model", ""),
             rag_citations=state.get("rag_citations", []),
             used_knowledge=state.get("used_knowledge", False),

--- a/autobot-backend/chat_workflow/graph.py
+++ b/autobot-backend/chat_workflow/graph.py
@@ -1378,7 +1378,11 @@ async def persist_conversation(state: ChatState, config: RunnableConfig) -> dict
     manager = config["configurable"]["manager"]
     session_id = state.get("session_id", "")
     all_llm_responses = state.get("all_llm_responses", [])
-    combined_response = "\n\n".join(all_llm_responses)
+    # Review B3 makes ``all_llm_responses`` carry "" for an iteration with no
+    # prose, so the blanks must be dropped here or a leading/interior "\n\n"
+    # reaches conversation_history — which feeds the NEXT turn's LLM context —
+    # plus the transcript file and the LOOP_COMPLETE/BEFORE_RESPONSE_SEND hooks.
+    combined_response = "\n\n".join(r for r in all_llm_responses if r)
 
     # Emit LOOP_COMPLETE hook to notify extensions
     await _emit_loop_complete(state.get("iteration_count", 0), combined_response, session_id)

--- a/autobot-backend/chat_workflow/graph.py
+++ b/autobot-backend/chat_workflow/graph.py
@@ -605,9 +605,13 @@ async def _generate_response_planned(
 
     await _emit_planned_agent_complete_hook(session_id, iteration, llm_response or "")
 
+    # Issue #13295 (review B3): append unconditionally — iteration_count below
+    # increments every pass regardless of whether llm_response was falsy, so a
+    # skipped append here would desync all_responses[idx] from iteration=idx+1
+    # and misfile every later iteration's tool output under the wrong prose.
+    # _build_final_response_entry already no-ops on empty content.
     all_responses = list(state.get("all_llm_responses", []))
-    if llm_response:
-        all_responses.append(llm_response)
+    all_responses.append(llm_response or "")
 
     tool_calls = tool_calls or []
     for tc in tool_calls:
@@ -728,9 +732,11 @@ async def generate_response(state: ChatState, config: RunnableConfig) -> dict:
     except Exception as _hook_exc:  # noqa: BLE001
         logger.debug("Plugin hook ON_AGENT_COMPLETE failed (non-fatal): %s", _hook_exc)
 
+    # Issue #13295 (review B3): append unconditionally — see the matching
+    # comment in _generate_response_planned for why a skipped append here
+    # would desync all_responses[idx] from iteration=idx+1.
     all_responses = list(state.get("all_llm_responses", []))
-    if llm_response:
-        all_responses.append(llm_response)
+    all_responses.append(llm_response or "")
     parsed_tool_calls = list(ctx.execution_history) if ctx.execution_history else []
 
     # Issue #3232: emit plan event when the response contains a planning block.
@@ -954,6 +960,12 @@ async def execute_tools(state: ChatState, config: RunnableConfig) -> dict:
     stream_cb = config["configurable"].get("stream_callback")
     messages = list(state.get("workflow_messages", []))
     session_id = state.get("session_id")
+    # Issue #13295 (review B1): the GH#11202 interrupt-resume dispatch below
+    # calls manager._process_tool_calls directly, bypassing
+    # _process_tool_results/_handle_tool_message_types entirely — so nothing
+    # tags these messages unless this node does it. generate_response already
+    # set iteration_count to the LLM pass that produced these tool_calls.
+    iteration = state.get("iteration_count", 0)
 
     decision = state.get("approval_decision")
     tool_calls = state.get("tool_calls", [])
@@ -1005,6 +1017,7 @@ async def execute_tools(state: ChatState, config: RunnableConfig) -> dict:
         deny_msg = {
             "type": "response",
             "content": f"Command denied: {decision.get('reason', 'User denied')}",
+            "metadata": {"iteration": iteration},
         }
         messages.append(deny_msg)
         if stream_cb:
@@ -1086,6 +1099,12 @@ async def execute_tools(state: ChatState, config: RunnableConfig) -> dict:
             break_loop, _ = item
         else:
             msg_dict = item.to_dict() if hasattr(item, "to_dict") else item
+            # Issue #13295 (review B1): _process_tool_calls is the same
+            # producer _process_tool_results drives, but this interrupt-resume
+            # dispatch never routes through it — tag here so these messages
+            # interleave correctly instead of falling into the untagged
+            # leftover fallback.
+            msg_dict.setdefault("metadata", {})["iteration"] = iteration
             # Stream ALL messages for real-time display
             if stream_cb:
                 stream_cb(msg_dict)
@@ -1107,6 +1126,7 @@ async def execute_tools(state: ChatState, config: RunnableConfig) -> dict:
                 "and stopped the loop. Please let me know if you would like me to "
                 "try a different approach."
             ),
+            "metadata": {"iteration": iteration},
         }
         messages.append(abort_msg)
         if stream_cb:

--- a/autobot-backend/chat_workflow/internal_prompt_filter_test.py
+++ b/autobot-backend/chat_workflow/internal_prompt_filter_test.py
@@ -123,11 +123,13 @@ class _FakeManager:
     async def _persist_conversation(self, session_id, session, message, llm_response):
         self.persisted["conversation"] = llm_response
 
-    async def _persist_workflow_messages(self, session_id, workflow_messages, combined_response, **_kwargs):
+    async def _persist_workflow_messages(self, session_id, workflow_messages, all_llm_responses, **_kwargs):
         # #13292: production now calls this with keyword-only selected_model/
         # rag_citations/used_knowledge — accept and ignore them here since this
         # fake only asserts on the filtered text, not persisted metadata.
-        self.persisted["workflow"] = combined_response
+        # #13295: production now passes the per-iteration response list
+        # (filtered per-item) instead of one pre-joined string.
+        self.persisted["workflow"] = all_llm_responses
 
     async def _fire_stop_hook(self, *args, **kwargs):
         return None
@@ -158,8 +160,9 @@ class TestProductionWirePoint:
         assert "CRITICAL MULTI-STEP" not in persisted
         assert "YOUR RESPONSE" not in persisted
         assert REAL_ANSWER in persisted
-        # Both persist sinks receive the same filtered text.
-        assert fake.persisted["workflow"] == persisted
+        # #13295: the workflow sink now receives the per-iteration list (one
+        # entry here); each entry is filtered the same way as the join.
+        assert fake.persisted["workflow"] == [persisted]
 
     def test_raw_join_would_leak_echo_on_base(self):
         """Documents the base defect: the pre-fix expression leaks the echo."""

--- a/autobot-backend/chat_workflow/manager.py
+++ b/autobot-backend/chat_workflow/manager.py
@@ -3001,7 +3001,11 @@ before summarizing.
         the whole batch is built, on whichever entry is actually last.
         """
         entry["metadata"]["model"] = selected_model
-        entry["sources"] = _kb_sources_from_citations(rag_citations or []) if used_knowledge else []
+        kb_sources = _kb_sources_from_citations(rag_citations or []) if used_knowledge else []
+        # Never blank out sources an entry already carries — the fallback target
+        # may be a tool entry that legitimately has its own.
+        if kb_sources or not entry.get("sources"):
+            entry["sources"] = kb_sources
 
     def _build_workflow_message_batch(self, chat_mgr, workflow_messages: List[WorkflowMessage]) -> List[Dict[str, Any]]:
         """Build the chat-history message dicts for one turn's WorkflowMessages.
@@ -3137,8 +3141,15 @@ before summarizing.
         leftover = [m for m in workflow_messages if id(m) not in consumed]
         batch.extend(self._build_workflow_message_batch(chat_mgr, leftover))
 
-        if last_prose_entry is not None:
-            self._attach_model_and_citations(last_prose_entry, selected_model, rag_citations, used_knowledge)
+        # Review F5: when every iteration's prose is empty or deduped away — the
+        # ``respond``-tool turn — no prose entry exists, and the model badge and
+        # KB sources would be carried by nothing. Fall back to the last assistant
+        # entry actually written so #13292 cannot regress to "no entry has them".
+        target = last_prose_entry or next(
+            (e for e in reversed(batch) if e.get("sender") == "assistant"), None
+        )
+        if target is not None:
+            self._attach_model_and_citations(target, selected_model, rag_citations, used_knowledge)
         return batch
 
     async def _persist_workflow_messages(

--- a/autobot-backend/chat_workflow/manager.py
+++ b/autobot-backend/chat_workflow/manager.py
@@ -3145,9 +3145,7 @@ before summarizing.
         # ``respond``-tool turn — no prose entry exists, and the model badge and
         # KB sources would be carried by nothing. Fall back to the last assistant
         # entry actually written so #13292 cannot regress to "no entry has them".
-        target = last_prose_entry or next(
-            (e for e in reversed(batch) if e.get("sender") == "assistant"), None
-        )
+        target = last_prose_entry or next((e for e in reversed(batch) if e.get("sender") == "assistant"), None)
         if target is not None:
             self._attach_model_and_citations(target, selected_model, rag_citations, used_knowledge)
         return batch

--- a/autobot-backend/chat_workflow/manager.py
+++ b/autobot-backend/chat_workflow/manager.py
@@ -2235,16 +2235,10 @@ before summarizing.
         self,
         tool_msg: WorkflowMessage,
         workflow_messages: List[WorkflowMessage],
-        iteration: int,
     ) -> tuple:
         """Issue #665: Extracted from _process_tool_results to reduce function length.
 
         Handle various tool message types and track state.
-
-        Issue #13295: stamps ``metadata.iteration`` on every message actually
-        appended, so ``_build_persist_batch`` can later interleave each
-        iteration's tool output with the prose it followed instead of
-        collapsing the whole turn into "tool output, then everything else".
 
         Returns:
             Tuple of (has_pending_approval, processed_any_command)
@@ -2256,7 +2250,6 @@ before summarizing.
             logger.info("[Issue #651] Command requires approval - will wait for resolution")
 
         if tool_msg.type in _TERMINAL_MESSAGE_TYPES:
-            tool_msg.metadata["iteration"] = iteration
             workflow_messages.append(tool_msg)
 
         if tool_msg.type == "error":
@@ -2284,8 +2277,15 @@ before summarizing.
         Issue #651: Fixed logic that incorrectly broke continuation loop.
         Issue #654: Added support for 'respond' tool with break_loop pattern.
         Issue #2310: Accepts optional ctx for consecutive-invalid-tool tracking.
-        Issue #13295: *iteration* is stamped onto every persisted tool message
-        so the turn can be reconstructed in true order on reload.
+        Issue #13295 (review B1): *iteration* is stamped on EVERY yielded tool
+        message, not only the ``_TERMINAL_MESSAGE_TYPES`` ones
+        ``_handle_tool_message_types`` appends to ``workflow_messages``. The
+        graph path's accumulator (``graph._run_llm_iteration``) persists every
+        non-streaming item this generator yields regardless of type — an
+        untagged ``tool_result``/``response``/etc. fell into
+        ``_build_persist_batch``'s untagged-leftover fallback and was
+        misordered (and, for a ``response``-type duplicate of the completing
+        prose, skipped the dedup guard entirely).
 
         Yields:
             WorkflowMessage items, then (results, has_pending_approval, should_break, break_loop_requested)
@@ -2313,7 +2313,10 @@ before summarizing.
             if self._handle_execution_summary(tool_msg, new_execution_results, execution_history):
                 continue
 
-            pending, _ = self._handle_tool_message_types(tool_msg, workflow_messages, iteration)
+            if tool_msg.metadata is not None:
+                tool_msg.metadata["iteration"] = iteration
+
+            pending, _ = self._handle_tool_message_types(tool_msg, workflow_messages)
             has_pending_approval = has_pending_approval or pending
 
             yield tool_msg
@@ -2934,9 +2937,6 @@ before summarizing.
         chat_mgr,
         llm_response: str,
         batch: List[Dict[str, Any]],
-        selected_model: str = "",
-        rag_citations: List[Dict[str, Any]] | None = None,
-        used_knowledge: bool = False,
         iteration: int | None = None,
     ) -> Dict[str, Any] | None:
         """Build the chat-history entry for one iteration's completed prose (#13214).
@@ -2949,20 +2949,15 @@ before summarizing.
         ``llm_response`` arrived here and was dropped, so a conversational streamed
         reply persisted nothing and ``chat:session:*`` read back user-turns only.
 
-        Issue #13292: the streamed chunks carried ``metadata.model`` and KB
-        citations (built by ``_build_stream_chunk_message``/``_build_source_list``)
-        but, being streaming, were never the entries actually persisted — so the
-        persisted turn had no model badge and ``sources: []`` regardless of
-        whether the knowledge base was used. ``selected_model``/``rag_citations``
-        mirror what the discarded chunks carried, sourced from the same
-        ``LLMIterationContext``/state the caller already threads through RAG.
-
         Issue #13295: *iteration* records which continuation pass produced this
         prose (1-indexed, matching ``all_llm_responses``) so a reload can be
         cross-referenced against the tool output it was interleaved with.
-        Only the FINAL iteration's entry carries ``selected_model``/
-        ``rag_citations`` — earlier iterations' prose precedes tool execution
-        and never made the model/citation decision the completing entry did.
+        The entry is built WITHOUT ``selected_model``/``rag_citations`` — Issue
+        #13292's model badge/KB sources are attached retroactively by
+        ``_attach_model_and_citations`` to whichever prose entry actually ends
+        up LAST in the persisted batch, since the "final" iteration's own
+        entry can be ``None`` (empty content, or deduped) and #13292 must not
+        regress by leaving no entry carrying them at all (review F5).
 
         Returns None when there is nothing to add — an empty reply, or an assistant
         entry in *batch* already carrying byte-identical text. The scan is restricted
@@ -2975,7 +2970,6 @@ before summarizing.
         assistant_texts = ((e.get("text") or "").strip() for e in batch if e.get("sender") == "assistant")
         if any(text == content for text in assistant_texts):
             return None
-        sources = _kb_sources_from_citations(rag_citations or []) if used_knowledge else []
         return chat_mgr._build_message_dict(
             "assistant",
             content,
@@ -2983,12 +2977,31 @@ before summarizing.
             {
                 "message_type": "llm_response",
                 "streamed": True,
-                "model": selected_model,
+                "model": "",
                 "iteration": iteration,
             },
             None,
-            sources=sources,
+            sources=[],
         )
+
+    def _attach_model_and_citations(
+        self,
+        entry: Dict[str, Any],
+        selected_model: str,
+        rag_citations: List[Dict[str, Any]] | None,
+        used_knowledge: bool,
+    ) -> None:
+        """Retroactively tag the LAST prose entry actually persisted (#13292, review F5).
+
+        Issue #13292: the streamed chunks carried ``metadata.model`` and KB
+        citations but, being streaming, were never the entries actually
+        persisted. Attaching these at build time only to "the final
+        iteration's" entry breaks when that entry is ``None`` (empty content
+        or deduped) — no entry would carry them at all. Called once, after
+        the whole batch is built, on whichever entry is actually last.
+        """
+        entry["metadata"]["model"] = selected_model
+        entry["sources"] = _kb_sources_from_citations(rag_citations or []) if used_knowledge else []
 
     def _build_workflow_message_batch(self, chat_mgr, workflow_messages: List[WorkflowMessage]) -> List[Dict[str, Any]]:
         """Build the chat-history message dicts for one turn's WorkflowMessages.
@@ -3033,12 +3046,8 @@ before summarizing.
         workflow_messages: List[WorkflowMessage],
         response_text: str,
         iteration: int,
-        is_final_iteration: bool,
-        selected_model: str,
-        rag_citations: List[Dict[str, Any]] | None,
-        used_knowledge: bool,
         batch: List[Dict[str, Any]],
-    ) -> tuple[List[Dict[str, Any]], set]:
+    ) -> tuple[List[Dict[str, Any]], set, Dict[str, Any] | None]:
         """Build one iteration's prose + tool-message entries, in that order.
 
         Issue #13295: extracted from ``_build_persist_batch`` to keep it short.
@@ -3047,7 +3056,7 @@ before summarizing.
         tool calls it contained (``_yield_tool_results_and_decide``) — so the
         prose entry precedes this iteration's own tool entries, not the other
         way around. Returns (this iteration's entries, ids of workflow_messages
-        consumed).
+        consumed, the prose entry actually built or None).
         """
         iter_messages = [m for m in workflow_messages if (m.metadata or {}).get("iteration") == iteration]
         consumed = {id(m) for m in iter_messages}
@@ -3061,14 +3070,11 @@ before summarizing.
             chat_mgr,
             response_text,
             batch + tool_entries,
-            selected_model=selected_model if is_final_iteration else "",
-            rag_citations=rag_citations if is_final_iteration else None,
-            used_knowledge=used_knowledge if is_final_iteration else False,
             iteration=iteration,
         )
         entries = [final_entry] if final_entry else []
         entries.extend(tool_entries)
-        return entries, consumed
+        return entries, consumed, final_entry
 
     def _build_persist_batch(
         self,
@@ -3093,11 +3099,17 @@ before summarizing.
         case (prose1 -> tool_output -> prose2 became tool_output -> combined);
         inserted-first breaks the single-iteration case.
 
-        Fix: ``_handle_tool_message_types``/``_collect_llm_iteration_response``
-        now stamp ``metadata.iteration`` on every message they append. This
-        walks iterations 1..N, emitting iteration *i*'s prose
-        (``all_llm_responses[i-1]``) followed by its own tool messages —
-        matching the live order exactly, for any number of iterations.
+        Fix: every point that appends a workflow message now stamps
+        ``metadata.iteration`` on it (``_process_tool_results`` for the shared
+        tool-dispatch path, ``_collect_llm_iteration_response`` for other LLM
+        yields, and ``graph.execute_tools`` for the GH#11202 interrupt-resume
+        dispatch that bypasses ``_process_tool_results`` entirely). This walks
+        iterations 1..N, emitting iteration *i*'s prose (``all_llm_responses[i-1]``)
+        followed by its own tool messages — matching the live order exactly,
+        for any number of iterations. ``selected_model``/``rag_citations`` are
+        attached after the loop (``_attach_model_and_citations``) to whichever
+        prose entry actually ends up last — not necessarily the final
+        iteration's, since that entry can be ``None`` (#13292 review F5).
 
         Messages carrying no iteration tag, or one beyond ``len(all_llm_responses)``
         (the error-turn path, which passes an empty response list — #13295
@@ -3106,26 +3118,27 @@ before summarizing.
         """
         batch: List[Dict[str, Any]] = []
         consumed: set = set()
-        num_iterations = len(all_llm_responses)
+        last_prose_entry: Dict[str, Any] | None = None
 
         for idx, response_text in enumerate(all_llm_responses):
             iteration = idx + 1
-            entries, group_consumed = self._iteration_persist_group(
+            entries, group_consumed, final_entry = self._iteration_persist_group(
                 chat_mgr,
                 workflow_messages,
                 response_text,
                 iteration,
-                iteration == num_iterations,
-                selected_model,
-                rag_citations,
-                used_knowledge,
                 batch,
             )
+            if final_entry is not None:
+                last_prose_entry = final_entry
             batch.extend(entries)
             consumed.update(group_consumed)
 
         leftover = [m for m in workflow_messages if id(m) not in consumed]
         batch.extend(self._build_workflow_message_batch(chat_mgr, leftover))
+
+        if last_prose_entry is not None:
+            self._attach_model_and_citations(last_prose_entry, selected_model, rag_citations, used_knowledge)
         return batch
 
     async def _persist_workflow_messages(

--- a/autobot-backend/chat_workflow/manager.py
+++ b/autobot-backend/chat_workflow/manager.py
@@ -2235,10 +2235,16 @@ before summarizing.
         self,
         tool_msg: WorkflowMessage,
         workflow_messages: List[WorkflowMessage],
+        iteration: int,
     ) -> tuple:
         """Issue #665: Extracted from _process_tool_results to reduce function length.
 
         Handle various tool message types and track state.
+
+        Issue #13295: stamps ``metadata.iteration`` on every message actually
+        appended, so ``_build_persist_batch`` can later interleave each
+        iteration's tool output with the prose it followed instead of
+        collapsing the whole turn into "tool output, then everything else".
 
         Returns:
             Tuple of (has_pending_approval, processed_any_command)
@@ -2250,6 +2256,7 @@ before summarizing.
             logger.info("[Issue #651] Command requires approval - will wait for resolution")
 
         if tool_msg.type in _TERMINAL_MESSAGE_TYPES:
+            tool_msg.metadata["iteration"] = iteration
             workflow_messages.append(tool_msg)
 
         if tool_msg.type == "error":
@@ -2269,6 +2276,7 @@ before summarizing.
         selected_model: str,
         execution_history: List[Dict[str, Any]],
         workflow_messages: List[WorkflowMessage],
+        iteration: int,
         ctx: LLMIterationContext | None = None,
     ):
         """Issue #665: Refactored - Process tool calls and collect results.
@@ -2276,6 +2284,8 @@ before summarizing.
         Issue #651: Fixed logic that incorrectly broke continuation loop.
         Issue #654: Added support for 'respond' tool with break_loop pattern.
         Issue #2310: Accepts optional ctx for consecutive-invalid-tool tracking.
+        Issue #13295: *iteration* is stamped onto every persisted tool message
+        so the turn can be reconstructed in true order on reload.
 
         Yields:
             WorkflowMessage items, then (results, has_pending_approval, should_break, break_loop_requested)
@@ -2303,7 +2313,7 @@ before summarizing.
             if self._handle_execution_summary(tool_msg, new_execution_results, execution_history):
                 continue
 
-            pending, _ = self._handle_tool_message_types(tool_msg, workflow_messages)
+            pending, _ = self._handle_tool_message_types(tool_msg, workflow_messages, iteration)
             has_pending_approval = has_pending_approval or pending
 
             yield tool_msg
@@ -2398,6 +2408,11 @@ before summarizing.
                 # The final complete response is persisted in _persist_workflow_messages
                 is_streaming_chunk = hasattr(item, "metadata") and item.metadata.get("streaming", False)
                 if not is_streaming_chunk:
+                    # Issue #13295: stamp the iteration that produced this
+                    # message so _build_persist_batch can interleave it with
+                    # the prose it followed, instead of collapsing the turn.
+                    if hasattr(item, "metadata") and item.metadata is not None:
+                        item.metadata["iteration"] = iteration
                     ctx.workflow_messages.append(item)
                 yield item
 
@@ -2498,6 +2513,7 @@ before summarizing.
             ctx.selected_model,
             ctx.execution_history,
             ctx.workflow_messages,
+            iteration,
             ctx=ctx,
         ):
             if isinstance(item, tuple):
@@ -2921,8 +2937,9 @@ before summarizing.
         selected_model: str = "",
         rag_citations: List[Dict[str, Any]] | None = None,
         used_knowledge: bool = False,
+        iteration: int | None = None,
     ) -> Dict[str, Any] | None:
-        """Build the chat-history entry for the completed streamed reply (#13214).
+        """Build the chat-history entry for one iteration's completed prose (#13214).
 
         Streamed chunks carry ``metadata.streaming = True`` (set unconditionally by
         ``StreamingMessage.to_workflow_message``) and are deliberately excluded from
@@ -2940,6 +2957,13 @@ before summarizing.
         mirror what the discarded chunks carried, sourced from the same
         ``LLMIterationContext``/state the caller already threads through RAG.
 
+        Issue #13295: *iteration* records which continuation pass produced this
+        prose (1-indexed, matching ``all_llm_responses``) so a reload can be
+        cross-referenced against the tool output it was interleaved with.
+        Only the FINAL iteration's entry carries ``selected_model``/
+        ``rag_citations`` — earlier iterations' prose precedes tool execution
+        and never made the model/citation decision the completing entry did.
+
         Returns None when there is nothing to add — an empty reply, or an assistant
         entry in *batch* already carrying byte-identical text. The scan is restricted
         to assistant entries so that a ``terminal_output`` or other system message
@@ -2956,7 +2980,12 @@ before summarizing.
             "assistant",
             content,
             "response",
-            {"message_type": "llm_response", "streamed": True, "model": selected_model},
+            {
+                "message_type": "llm_response",
+                "streamed": True,
+                "model": selected_model,
+                "iteration": iteration,
+            },
             None,
             sources=sources,
         )
@@ -2998,46 +3027,112 @@ before summarizing.
             )
         return batch
 
+    def _iteration_persist_group(
+        self,
+        chat_mgr,
+        workflow_messages: List[WorkflowMessage],
+        response_text: str,
+        iteration: int,
+        is_final_iteration: bool,
+        selected_model: str,
+        rag_citations: List[Dict[str, Any]] | None,
+        used_knowledge: bool,
+        batch: List[Dict[str, Any]],
+    ) -> tuple[List[Dict[str, Any]], set]:
+        """Build one iteration's prose + tool-message entries, in that order.
+
+        Issue #13295: extracted from ``_build_persist_batch`` to keep it short.
+        Live, ``_run_continuation_iteration`` always generates an iteration's
+        prose (``_yield_llm_response_and_check_stop``) BEFORE dispatching the
+        tool calls it contained (``_yield_tool_results_and_decide``) — so the
+        prose entry precedes this iteration's own tool entries, not the other
+        way around. Returns (this iteration's entries, ids of workflow_messages
+        consumed).
+        """
+        iter_messages = [m for m in workflow_messages if (m.metadata or {}).get("iteration") == iteration]
+        consumed = {id(m) for m in iter_messages}
+        # Built before the dedup check (not before the *returned* order) so a
+        # same-iteration duplicate — e.g. the ``respond`` tool's own "response"
+        # workflow message carrying byte-identical text — is still caught even
+        # though it is placed AFTER the prose entry in the final order.
+        tool_entries = self._build_workflow_message_batch(chat_mgr, iter_messages)
+
+        final_entry = self._build_final_response_entry(
+            chat_mgr,
+            response_text,
+            batch + tool_entries,
+            selected_model=selected_model if is_final_iteration else "",
+            rag_citations=rag_citations if is_final_iteration else None,
+            used_knowledge=used_knowledge if is_final_iteration else False,
+            iteration=iteration,
+        )
+        entries = [final_entry] if final_entry else []
+        entries.extend(tool_entries)
+        return entries, consumed
+
     def _build_persist_batch(
         self,
         chat_mgr,
         workflow_messages: List[WorkflowMessage],
-        llm_response: str,
+        all_llm_responses: List[str],
         selected_model: str,
         rag_citations: List[Dict[str, Any]] | None,
         used_knowledge: bool,
     ) -> List[Dict[str, Any]]:
-        """Build the full persisted batch for one turn: tool entries + completed reply.
+        """Build the full persisted batch for one turn, in true chronological order.
 
         Extracted from ``_persist_workflow_messages`` (#13296 / #13303 review).
-        Issue #13214: the completed reply is appended LAST. Issue #13295
-        (investigated, NOT fixed): that is only correct for the common
-        2+-iteration tool turn (prose1 -> tool_output -> prose2-the-answer,
-        collapsed by ``"\\n\\n".join(all_llm_responses)`` into the one string
-        received here, which legitimately follows the tool output) — it is
-        known-wrong for a single-iteration turn, where the lone prose blob
-        preceded the tool call live. See ``streamed_reply_persistence_test.py``
-        for both cases documented; fixing this needs per-iteration data this
-        signature does not carry (tracked on #13295, out of scope here).
+
+        Issue #13295: a tool-using turn normally runs 2+ continuation iterations
+        (``manager.MAX_CONTINUATION_ITERATIONS`` loop); each appends its own
+        prose to *all_llm_responses*, and live, an iteration's prose streams
+        BEFORE the tool call it introduces executes. Reverted front-insertion
+        (#13303 review) showed the whole reply — every iteration's prose
+        collapsed into one string — cannot be positioned correctly with a
+        single insertion point: appended-last inverts the common 2-iteration
+        case (prose1 -> tool_output -> prose2 became tool_output -> combined);
+        inserted-first breaks the single-iteration case.
+
+        Fix: ``_handle_tool_message_types``/``_collect_llm_iteration_response``
+        now stamp ``metadata.iteration`` on every message they append. This
+        walks iterations 1..N, emitting iteration *i*'s prose
+        (``all_llm_responses[i-1]``) followed by its own tool messages —
+        matching the live order exactly, for any number of iterations.
+
+        Messages carrying no iteration tag, or one beyond ``len(all_llm_responses)``
+        (the error-turn path, which passes an empty response list — #13295
+        confirmed unchanged), are appended last, preserving the pre-#13295 flat
+        behaviour for that case.
         """
-        batch = self._build_workflow_message_batch(chat_mgr, workflow_messages)
-        final_entry = self._build_final_response_entry(
-            chat_mgr,
-            llm_response,
-            batch,
-            selected_model=selected_model,
-            rag_citations=rag_citations,
-            used_knowledge=used_knowledge,
-        )
-        if final_entry:
-            batch.append(final_entry)
+        batch: List[Dict[str, Any]] = []
+        consumed: set = set()
+        num_iterations = len(all_llm_responses)
+
+        for idx, response_text in enumerate(all_llm_responses):
+            iteration = idx + 1
+            entries, group_consumed = self._iteration_persist_group(
+                chat_mgr,
+                workflow_messages,
+                response_text,
+                iteration,
+                iteration == num_iterations,
+                selected_model,
+                rag_citations,
+                used_knowledge,
+                batch,
+            )
+            batch.extend(entries)
+            consumed.update(group_consumed)
+
+        leftover = [m for m in workflow_messages if id(m) not in consumed]
+        batch.extend(self._build_workflow_message_batch(chat_mgr, leftover))
         return batch
 
     async def _persist_workflow_messages(
         self,
         session_id: str,
         workflow_messages: List[WorkflowMessage],
-        llm_response: str,
+        all_llm_responses: List[str],
         *,
         selected_model: str = "",
         rag_citations: List[Dict[str, Any]] | None = None,
@@ -3048,21 +3143,27 @@ before summarizing.
         Issue #332: Original implementation.
         Issue #1316: Batch all messages into one load/save cycle instead
         of N individual add_message() calls.
-        Issue #13214: also persist *llm_response* — the completed streamed reply —
-        which every caller already passes but which was previously ignored.
+        Issue #13214: also persist the completed streamed reply — which every
+        caller already computed but which was previously ignored.
         Issue #13292: ``selected_model``/``rag_citations``/``used_knowledge`` let
         the completed-reply entry carry the same model badge and KB citations the
         (discarded) streaming chunks carried — keyword-only and defaulted so
         existing callers (incl. the error-turn path, which never has a model to
-        report) are unaffected. See ``_build_persist_batch`` for turn-ordering
-        details (#13295).
+        report) are unaffected.
+        Issue #13295: *all_llm_responses* replaces the pre-joined
+        ``"\\n\\n".join(...)`` string — one entry per continuation iteration —
+        so ``_build_persist_batch`` can interleave each iteration's prose with
+        the tool output it introduced instead of appending the whole reply
+        after every tool entry. The error-turn path passes ``[]`` (never had a
+        completed response); see ``_build_persist_batch`` for the exact
+        ordering and its unchanged fallback for that case.
         """
         from chat_history import ChatHistoryManager
 
         try:
             chat_mgr = ChatHistoryManager()
             batch = self._build_persist_batch(
-                chat_mgr, workflow_messages, llm_response, selected_model, rag_citations, used_knowledge
+                chat_mgr, workflow_messages, all_llm_responses, selected_model, rag_citations, used_knowledge
             )
 
             if batch:
@@ -3349,15 +3450,18 @@ before summarizing.
                 yield item
 
         # Issue #716/#11867: strip any internal continuation prompt the LLM echoed
-        # back before the final response is persisted / shown to the user. Runs once
-        # on the complete text (multi-line patterns intact) — a no-op unless a genuine
-        # internal-prompt echo is present, so legitimate output is never altered.
-        combined_response = self._filter_internal_prompts("\n\n".join(all_llm_responses))
+        # back before the response is persisted / shown to the user — per-iteration
+        # (Issue #13295: _persist_workflow_messages now needs each iteration's
+        # prose separately to interleave with its tool output), which is at least
+        # as precise as the prior joined-then-filtered pass since each pattern is
+        # matched within one iteration's own text.
+        filtered_responses = [self._filter_internal_prompts(r) for r in all_llm_responses]
+        combined_response = "\n\n".join(filtered_responses)
         await self._persist_conversation(session_id, session, message, combined_response)
         await self._persist_workflow_messages(
             session_id,
             workflow_messages,
-            combined_response,
+            filtered_responses,
             selected_model=ctx.selected_model,
             rag_citations=ctx.rag_citations,
             used_knowledge=ctx.used_knowledge,

--- a/autobot-backend/chat_workflow/streamed_reply_persistence_test.py
+++ b/autobot-backend/chat_workflow/streamed_reply_persistence_test.py
@@ -114,7 +114,7 @@ class TestStreamedReplyIsReadableAfterReload:
     @pytest.mark.asyncio
     async def test_conversational_streamed_reply_is_persisted(self, store):
         """FAILS pre-fix: batch is empty, so the session reads back with zero turns."""
-        await ChatWorkflowManager._persist_workflow_messages(_manager(), SESSION_ID, [], REPLY)
+        await ChatWorkflowManager._persist_workflow_messages(_manager(), SESSION_ID, [], [REPLY])
 
         persisted = await store.load_session(SESSION_ID)
         assistant = _assistant_turns(persisted)
@@ -146,70 +146,65 @@ class TestStreamedReplyIsReadableAfterReload:
             for m in messages
         ]
 
-        await ChatWorkflowManager._persist_workflow_messages(_manager(), SESSION_ID, wf_messages, llm_response)
+        await ChatWorkflowManager._persist_workflow_messages(_manager(), SESSION_ID, wf_messages, [llm_response])
 
         reloaded = await store.load_session(SESSION_ID)
         assert [m["text"] for m in _assistant_turns(reloaded)] == [REPLY]
 
     @pytest.mark.asyncio
-    async def test_reply_appended_after_tool_output(self, store):
-        """Issue #13295 (investigated, NOT fixed here): documents the CURRENT order.
+    async def test_reply_precedes_its_own_iteration_tool_output(self, store):
+        """Issue #13295 FIXED: a single-iteration tool turn reloads in live order.
 
-        A front-insertion fix was tried and reverted after code review: it
-        assumed the reply is always chronologically first, which only holds
-        for a single-iteration turn. The common case is 2+ iterations —
-        prose1 -> tool call -> terminal_output -> prose2 (the actual answer,
-        a SECOND LLM pass) — and "\n\n".join(all_llm_responses) collapses
-        both prose segments into the one string this function receives, which
-        legitimately belongs AFTER the tool output it was derived from.
-        Appending (this test) is therefore correct for the common case and
-        matches pre-PR behavior.
-
-        It is still WRONG for the single-iteration case (one prose blob
-        emitted BEFORE the only tool call, no second LLM pass) — see
-        ``test_two_iteration_turn_reload_order_matches_live_order`` below for
-        the case this DOES get right, and #13295 for the real fix (needs
-        _persist_workflow_messages to receive the per-iteration response list
-        plus an iteration marker on workflow_messages, so each prose segment
-        can be interleaved at its true position instead of collapsed to one
-        string with a single insertion point).
+        Live, the model's prose is generated (and streamed) BEFORE the tool
+        call it contains is dispatched (``_run_continuation_iteration`` runs
+        ``_yield_llm_response_and_check_stop`` before
+        ``_yield_tool_results_and_decide``). When the loop stops after that
+        one tool call (no second LLM pass), true order is prose -> tool
+        output — the reverse of the old flat "all tool output, then the
+        whole reply" batch, which a prior fix attempt (#13303 review) showed
+        cannot be produced by a single front/back insertion point. The tool
+        message's ``metadata.iteration`` (stamped by
+        ``_handle_tool_message_types``) is what lets ``_build_persist_batch``
+        place it after the prose that introduced it.
         """
         wf_messages = [
-            SimpleNamespace(type="terminal_output", content="uptime: 3 days", metadata={}),
+            SimpleNamespace(type="terminal_output", content="uptime: 3 days", metadata={"iteration": 1}),
         ]
 
-        await ChatWorkflowManager._persist_workflow_messages(_manager(), SESSION_ID, wf_messages, REPLY)
+        await ChatWorkflowManager._persist_workflow_messages(_manager(), SESSION_ID, wf_messages, [REPLY])
 
         persisted = await store.load_session(SESSION_ID)
-        assert [m["sender"] for m in persisted] == ["system", "assistant"]
-        assert persisted[-1]["text"] == REPLY
+        assert [m["sender"] for m in persisted] == ["assistant", "system"]
+        assert persisted[0]["text"] == REPLY
 
     @pytest.mark.asyncio
     async def test_two_iteration_turn_reload_order_matches_live_order(self, store):
-        """Baseline for #13295: a genuine 2-iteration tool turn reloads correctly.
+        """Issue #13295 FIXED: a genuine 2-iteration tool turn reloads in live order.
 
-        iteration 1: model streams "Let me check." then calls a tool.
+        iteration 1: model streams "Let me check." then calls a tool (tagged
+        ``metadata.iteration = 1`` on the persisted terminal_output).
         iteration 2 (continuation, AFTER the tool result comes back): model
-        streams "Uptime is 3 days." — the actual answer.
-        combined_response = "Let me check.\n\nUptime is 3 days." (see
-        manager.py's ``"\n\n".join(all_llm_responses)`` / graph.py's
-        equivalent). The tool output belongs BETWEEN the two prose segments
-        live, but since both collapse into one persisted string, appending
-        that string after the tool output is the closest available
-        approximation with the current signature — not a regression to fix
-        here, just documented as the target the real interleaving fix must
-        preserve.
+        streams "Uptime is 3 days." — the actual answer, no further tool call.
+        Live order is prose1 -> tool output -> prose2. Previously (#13303),
+        both prose segments collapsed into one joined string with a single
+        insertion point, which could only match ONE of the single-iteration
+        or 2-iteration cases at a time — not both. ``_persist_workflow_messages``
+        now takes the per-iteration response list directly and interleaves
+        using each message's iteration tag.
         """
-        combined_response = "Let me check.\n\nUptime is 3 days."
         wf_messages = [
-            SimpleNamespace(type="terminal_output", content="uptime: 3 days", metadata={}),
+            SimpleNamespace(type="terminal_output", content="uptime: 3 days", metadata={"iteration": 1}),
         ]
+        all_llm_responses = ["Let me check.", "Uptime is 3 days."]
 
-        await ChatWorkflowManager._persist_workflow_messages(_manager(), SESSION_ID, wf_messages, combined_response)
+        await ChatWorkflowManager._persist_workflow_messages(_manager(), SESSION_ID, wf_messages, all_llm_responses)
 
         persisted = await store.load_session(SESSION_ID)
-        assert [m["sender"] for m in persisted] == ["system", "assistant"]
-        assert persisted[-1]["text"] == combined_response
+        assert [(m["sender"], m["text"]) for m in persisted] == [
+            ("assistant", "Let me check."),
+            ("system", "uptime: 3 days"),
+            ("assistant", "Uptime is 3 days."),
+        ]
 
 
 class TestNoDuplicateOrEmptyTurns:
@@ -217,25 +212,38 @@ class TestNoDuplicateOrEmptyTurns:
 
     @pytest.mark.asyncio
     async def test_empty_llm_response_writes_nothing(self, store):
-        await ChatWorkflowManager._persist_workflow_messages(_manager(), SESSION_ID, [], "")
+        await ChatWorkflowManager._persist_workflow_messages(_manager(), SESSION_ID, [], [""])
         assert await store.load_session(SESSION_ID) == []
 
     @pytest.mark.asyncio
     async def test_identical_existing_turn_is_not_duplicated(self, store):
-        """The ``respond`` tool already emits a non-streaming turn with this text."""
-        wf_messages = [SimpleNamespace(type="response", content=REPLY, metadata={"message_type": "respond_tool"})]
+        """The ``respond`` tool already emits a non-streaming turn with this text.
 
-        await ChatWorkflowManager._persist_workflow_messages(_manager(), SESSION_ID, wf_messages, REPLY)
+        Issue #13295: the duplicate is produced in the SAME iteration as the
+        prose it echoes — the dedup scan must see it even though it is
+        persisted AFTER the prose entry in the corrected order.
+        """
+        wf_messages = [
+            SimpleNamespace(type="response", content=REPLY, metadata={"message_type": "respond_tool", "iteration": 1})
+        ]
+
+        await ChatWorkflowManager._persist_workflow_messages(_manager(), SESSION_ID, wf_messages, [REPLY])
 
         persisted = await store.load_session(SESSION_ID)
         assert len(_assistant_turns(persisted)) == 1
 
     @pytest.mark.asyncio
     async def test_error_turn_persist_is_unchanged(self, store):
-        """``_persist_error_turn`` passes llm_response='' — behaviour must not change."""
+        """``_persist_error_turn`` passes ``all_llm_responses=[]`` — behaviour unchanged.
+
+        Issue #13295: confirms the error-turn path (no completed response at
+        all) still falls through to the flat, un-interleaved batch — every
+        workflow_messages entry is appended via the leftover fallback exactly
+        as the pre-#13295 code did.
+        """
         wf_messages = [SimpleNamespace(type="error", content="The assistant could not respond.", metadata={})]
 
-        await ChatWorkflowManager._persist_workflow_messages(_manager(), SESSION_ID, wf_messages, "")
+        await ChatWorkflowManager._persist_workflow_messages(_manager(), SESSION_ID, wf_messages, [])
 
         persisted = await store.load_session(SESSION_ID)
         assert len(persisted) == 1
@@ -258,7 +266,7 @@ class TestFinalReplyCarriesModelAndCitations:
     async def test_model_is_recorded_on_the_persisted_turn(self, store):
         """FAILS pre-fix: metadata has no 'model' key at all."""
         await ChatWorkflowManager._persist_workflow_messages(
-            _manager(), SESSION_ID, [], REPLY, selected_model=self.MODEL
+            _manager(), SESSION_ID, [], [REPLY], selected_model=self.MODEL
         )
 
         persisted = await store.load_session(SESSION_ID)
@@ -271,7 +279,7 @@ class TestFinalReplyCarriesModelAndCitations:
             _manager(),
             SESSION_ID,
             [],
-            REPLY,
+            [REPLY],
             selected_model=self.MODEL,
             rag_citations=self.CITATIONS,
             used_knowledge=True,
@@ -288,7 +296,7 @@ class TestFinalReplyCarriesModelAndCitations:
             _manager(),
             SESSION_ID,
             [],
-            REPLY,
+            [REPLY],
             selected_model=self.MODEL,
             rag_citations=self.CITATIONS,
             used_knowledge=False,

--- a/autobot-backend/chat_workflow/streamed_reply_persistence_test.py
+++ b/autobot-backend/chat_workflow/streamed_reply_persistence_test.py
@@ -26,9 +26,10 @@ from typing import Any, Dict, List
 
 import pytest
 
+from async_chat_workflow import WorkflowMessage
 from chat_history.messages import MessagesMixin
 from chat_workflow.manager import ChatWorkflowManager
-from chat_workflow.models import StreamingMessage
+from chat_workflow.models import LLMIterationContext, StreamingMessage
 
 SESSION_ID = "sess-13214"
 REPLY = "Hello! I'm AutoBot. How can I help you today?"
@@ -205,6 +206,68 @@ class TestStreamedReplyIsReadableAfterReload:
             ("system", "uptime: 3 days"),
             ("assistant", "Uptime is 3 days."),
         ]
+
+    @pytest.mark.asyncio
+    async def test_graph_path_tags_and_dedupes_via_process_tool_results(self, store, monkeypatch):
+        """Review F4: drives the REAL _process_tool_results -> graph._run_llm_iteration
+        -> _persist_workflow_messages — not a hand-tagged ``SimpleNamespace`` fixture.
+
+        Only the innermost LLM-call (``_process_single_llm_iteration``) and
+        tool-dispatch (``_process_tool_calls``) primitives are faked; every
+        manager/graph method between them — including the fixed
+        ``_process_tool_results`` — runs for real. Catches two regressions a
+        hand-built fixture cannot: (B1) a NON-terminal tool message
+        (``tool_result``) was only tagged when its type was in
+        ``_TERMINAL_MESSAGE_TYPES``, so it fell into the untagged leftover
+        bucket and was misordered after the answer; (B2) the ``respond``
+        tool's own byte-identical ``response`` message was likewise untagged,
+        so the dedup guard never saw it and the answer was duplicated.
+        """
+        from chat_workflow import graph as graph_mod
+
+        manager = ChatWorkflowManager.__new__(ChatWorkflowManager)
+        answer = "Uptime is 3 days."
+
+        async def fake_llm_iteration(*_args, **_kwargs):
+            yield (answer, [{"name": "respond", "params": {"message": answer}}])
+
+        async def fake_tool_calls(*_args, **_kwargs):
+            yield WorkflowMessage(type="tool_result", content="checked uptime", metadata={})
+            yield WorkflowMessage(type="terminal_output", content="uptime: 3 days", metadata={})
+            yield WorkflowMessage(type="response", content=answer, metadata={"message_type": "respond_tool"})
+            yield (True, answer)  # break_loop_requested=True: respond tool ends the turn
+
+        monkeypatch.setattr(manager, "_process_single_llm_iteration", fake_llm_iteration)
+        monkeypatch.setattr(manager, "_process_tool_calls", fake_tool_calls)
+
+        ctx = LLMIterationContext(
+            ollama_endpoint="http://fake",
+            selected_model="test-model",
+            session_id=SESSION_ID,
+            terminal_session_id="term-1",
+            used_knowledge=False,
+            rag_citations=[],
+            workflow_messages=[],
+            initial_prompt="What is the uptime?",
+        )
+
+        messages, llm_response, should_continue = await graph_mod._run_llm_iteration(manager, ctx, 1, [], None)
+        assert should_continue is False
+
+        wf_messages = graph_mod._build_workflow_messages_from_state({"workflow_messages": messages})
+        await ChatWorkflowManager._persist_workflow_messages(manager, SESSION_ID, wf_messages, [llm_response])
+
+        persisted = await store.load_session(SESSION_ID)
+        # B1: tool_result (non-terminal) stays interleaved with terminal_output,
+        # not shoved to the end as an untagged leftover.
+        # B2: the respond-tool's own "response" entry IS the answer bubble — the
+        # dedup guard suppresses a second, separately-built prose entry.
+        assert [(m["sender"], m["text"]) for m in persisted] == [
+            ("assistant", "checked uptime"),
+            ("system", "uptime: 3 days"),
+            ("assistant", answer),
+        ]
+        assert len(_assistant_turns(persisted)) == 2
 
 
 class TestNoDuplicateOrEmptyTurns:


### PR DESCRIPTION
## Thinking Path

On a tool-using turn the reloaded transcript showed the assistant's prose **after** the tool output it introduced. Live order is `prose1 → tool output → prose2(the answer)`; reload appended the whole reply last.

**This is the third attempt, and the first two were blocked for false premises — both worth recording so a fourth does not repeat them.**

1. PR #13303 inserted the reply at the **front** of the batch, on the premise that it is chronologically first. False for the common case: a tool-using turn normally runs **two** iterations (`manager.py:2841`; `_check_continuation_decision` at `:2515-2555` returns True after a normal tool execution), each appending its own prose (`:2864`), with everything collapsed into one string by `"\n\n".join(all_llm_responses)` (`:3338`, `graph.py:1315`). Front-insertion put the final answer *before* the tool output it was derived from.
2. The first version of this PR stamped `metadata["iteration"]` only for `_TERMINAL_MESSAGE_TYPES`. But **the production path is LangGraph** (`manager.py:3637-3645` — legacy is only an `except` fallback), and the graph accumulates *every* non-streaming message. Nine other types went untagged, fell through to `leftover`, and landed after the answer — **worse than base** — while the untagged `respond` message became invisible to the dedup scan and produced a **duplicated assistant turn**.

## What Changed

**Per-iteration interleaving.** `_persist_workflow_messages`/`_build_persist_batch` take `all_llm_responses: List[str]` instead of the pre-joined string. `_build_persist_batch` walks iterations 1..N emitting **prose first, then that iteration's own tool entries**, matching the live order: `_run_continuation_iteration` (`manager.py:2660-2675`) fully drains `_yield_llm_response_and_check_stop` before `_yield_tool_results_and_decide` (`:2616`).

**Tagging covers every path.** Stamped unconditionally immediately before each `yield` in `_process_tool_results` (`manager.py:2316-2317`) and `_collect_llm_iteration_response` (`:2417-2418`), plus `graph.execute_tools` (`graph.py:1107`), which calls `manager._process_tool_calls` directly and bypasses `_handle_tool_message_types` entirely. `deny_msg` (`graph.py:1020`) and `abort_msg` (`:1129`) are plain dicts and got `metadata` keys.

**Iteration↔index desync fixed.** `graph.py:613-614` and `:738-739` now `append(llm_response or "")`; previously `if llm_response:` guarded the append while `iteration` incremented unconditionally, so one falsy prose shifted every later iteration and filed iteration *i+1*'s tool output under iteration *i*'s prose.

**Blank segments dropped from the joined prose** (`graph.py:1381`). The desync fix makes `all_llm_responses` carry `""`, which would otherwise put a leading/interior `"\n\n"` into `conversation_history` — which feeds the **next** turn's LLM context — plus the transcript file and the LOOP_COMPLETE / BEFORE_RESPONSE_SEND hooks.

**Model badge and KB sources can no longer be carried by nothing.** They were attached only to the final iteration's prose entry; when every iteration's prose is empty or deduped away — the `respond`-tool turn, which this PR's own end-to-end test exercises — no entry carried them, silently regressing #13292. Now falls back to the last assistant entry actually written, guarded so it cannot blank out sources an entry already has.

## Verification

**End-to-end, not hand-tagged fixtures.** `streamed_reply_persistence_test.py:211-269` monkeypatches only the innermost LLM-call and tool-dispatch primitives and lets `_process_tool_results`, `_handle_tool_message_types`, `_run_llm_iteration`, `_build_workflow_messages_from_state` and `_persist_workflow_messages` all run for real. This matters: the previous version's tests hand-wrote `metadata={"iteration": 1}` on a `response` message — a tag production never applies — so they asserted the implementation back to itself and both blockers survived review.

Independent probe pushing all 15 message types through the real `graph._run_llm_iteration`:

```
TOTAL accumulated: 16   UNTAGGED: []
```

`respond`-tool turn driven end to end: exactly 2 assistant entries, no duplicate. Falsy iteration-1 prose: `all_llm_responses = ['', 'The answer is 42.']`, iteration-1 tool output correctly filed under iteration 1.

Mainline reload order:
```
assistant | Let me check.
assistant | running uptime
system    | up 3 days
assistant | Uptime is 3 days.   model=gpt-4o sources=1
```

F5 case (every prose deduped away) now yields `model='gpt-4o' sources=1`; before the amendment it was `model=None sources=[]`.

**443 passed** across `chat_workflow/` and `chat_history/`. `flake8` and `black --check` clean. Exactly one `add_messages_batch` call site remains (`manager.py:3183`), preserving #13214's single-writer property.

**Two tests over 10s in that run** (`workflow_plan_approval_test.py::test_cancel_workflow_clears_approval` 30.1s, `chat_history/add_message_call_sites_test.py` 12.9s) are pre-existing and untouched by this diff.

## Not delivered here

**#13293** — the backfill module's insertion point is unaffected (it only fires when a turn window has zero assistant entries, and its source carries one combined assistant string per exchange with no per-iteration breakdown). But a **repaired** turn will read `user, system, assistant(combined)` while a freshly persisted turn now reads `user, assistant(prose1), system, assistant(prose2)`. Unavoidable given the source data — recorded on #13293 so a repaired turn is never later misread as evidence this fix regressed.

Reported, not fixed: `_filter_internal_prompts` (#716/#11867) runs only on the legacy path (`manager.py:3471`); `graph.py::persist_conversation` never filters, so the internal-prompt strip has never applied to the production path's persisted prose. And `manager.py:2878-2882` appends `all_llm_responses` *before* `_emit_after_continuation`, discarding that hook's edit on the legacy path.

## Model Used

Sonnet 5

Closes #13295
Refs #13293
