### PR TITLE
fix(llc): route health probe through app.state, fix costs 500 (#13331, #13330)

### DIFF
--- a/autobot-backend/initialization/lifespan_test.py
+++ b/autobot-backend/initialization/lifespan_test.py
@@ -223,6 +223,90 @@ async def test_init_budget_watchdog_actually_starts_it():
 
 
 @pytest.mark.asyncio
+async def test_health_probe_reports_liveness_monitor_and_checkpointer_running_via_real_lifespan():
+    """#13331: llc/health/probe.py used to build its own private,
+    never-started LivenessMonitor/SessionCheckpointer singletons instead of
+    reading the ones lifespan actually starts and stores on app.state, so
+    the probe permanently reported them as not running. Asserting against a
+    mock would not catch that class of bug -- the objects here are started
+    through the REAL production init functions (same precedent as
+    test_init_liveness_monitor_actually_starts_it above), and the probe must
+    report them running.
+    """
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from initialization.lifespan import _init_liveness_monitor, _init_session_checkpointer
+    from llc.health.probe import probe_llc
+
+    app = SimpleNamespace(state=SimpleNamespace())
+    await _init_liveness_monitor(app)
+    await _init_session_checkpointer(app)
+
+    request = MagicMock()
+    request.app = app
+
+    # Only the DB/Redis-backed metrics unrelated to this regression are
+    # stubbed -- the liveness-monitor/session-checkpointer wiring under test
+    # runs for real.
+    try:
+        with (
+            patch("llc.health.probe._count_overdue_agents", new=AsyncMock(return_value=(0, 0))),
+            patch("llc.health.probe._budget_counts", new=AsyncMock(return_value=(0, 0))),
+            patch("llc.health.probe._pending_approvals_critical", new=AsyncMock(return_value=0)),
+            patch("llc.health.probe._count_agents_missing_instructions", new=AsyncMock(return_value=0)),
+            patch("llc.health.probe._scheduler_tick_age", new=AsyncMock(return_value=None)),
+            patch("llc.health.probe._session_recovery_available", new=AsyncMock(return_value=False)),
+        ):
+            result = await probe_llc(request)
+
+        assert result.data["liveness_monitor_wired"] is True
+        assert (
+            result.data["liveness_monitor_running"] is True
+        ), "must report the object lifespan actually started, not a disconnected shadow (GH#13331)"
+        assert result.data["session_checkpointer_wired"] is True
+        assert (
+            result.data["session_checkpointer_running"] is True
+        ), "must report the object lifespan actually started, not a disconnected shadow (GH#13331)"
+    finally:
+        await app.state.llc_liveness_monitor.aclose()
+        await app.state.llc_session_checkpointer.aclose()
+
+
+@pytest.mark.asyncio
+async def test_health_probe_reports_wired_but_not_running_after_real_shutdown():
+    """#13331: a component lifespan started and then stopped (aclose()) is
+    wired=True, running=False -- degraded, not down. Distinct from the
+    unwired case (no request / app.state never got the attribute), which is
+    the whole point of this fix -- see llc/tests/test_health_probe.py's
+    _app_state_scheduler_state unit tests for the unwired-vs-not-running
+    matrix."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from initialization.lifespan import _init_liveness_monitor
+    from llc.health.probe import probe_llc
+
+    app = SimpleNamespace(state=SimpleNamespace())
+    await _init_liveness_monitor(app)
+    await app.state.llc_liveness_monitor.aclose()
+
+    request = MagicMock()
+    request.app = app
+
+    with (
+        patch("llc.health.probe._count_overdue_agents", new=AsyncMock(return_value=(0, 0))),
+        patch("llc.health.probe._budget_counts", new=AsyncMock(return_value=(0, 0))),
+        patch("llc.health.probe._pending_approvals_critical", new=AsyncMock(return_value=0)),
+        patch("llc.health.probe._count_agents_missing_instructions", new=AsyncMock(return_value=0)),
+        patch("llc.health.probe._scheduler_tick_age", new=AsyncMock(return_value=None)),
+        patch("llc.health.probe._session_recovery_available", new=AsyncMock(return_value=False)),
+    ):
+        result = await probe_llc(request)
+
+    assert result.data["liveness_monitor_wired"] is True
+    assert result.data["liveness_monitor_running"] is False
+
+
+@pytest.mark.asyncio
 async def test_cleanup_drain_uses_the_real_scheduler_contract():
     """The drain wired into cleanup_services matches PollLoopScheduler's own API.
 

--- a/autobot-backend/llc/api/budget.py
+++ b/autobot-backend/llc/api/budget.py
@@ -19,6 +19,7 @@ from llc.deps import assert_company_access, load_authorized
 from llc.exceptions import BudgetExhausted
 from llc.models.budget import LLCAgentBudget
 from llc.services.budget import BudgetService
+from models.agent_org import AgentOrgNode
 from user_management.database import get_async_session
 from user_management.services import TenantContext
 
@@ -360,7 +361,23 @@ async def list_cost_events(
 
 
 class AgentModelCostRow(BaseModel):
-    """Per-agent + per-model token breakdown row."""
+    """Per-agent + per-model token breakdown row.
+
+    Mirrors ``llc/api/costs.py``'s ``AgentModelCost`` (GH#13067): this
+    endpoint previously raw-SELECTed ``hr.tokens_in`` / ``hr.tokens_out`` from
+    ``llc_heartbeat_runs``, columns that never existed on that model
+    (GH#13330 — every call 500'd).  The only real per-agent token source is
+    ``llc_agent_budgets.tokens_spent`` — a single combined
+    ``tokens_in + tokens_out`` lifetime counter (``llc/services/budget.py``'s
+    ``ingest_cost_event``), with no per-model dimension and no input/output
+    split.  ``input_tokens`` / ``cached_input_tokens`` / ``output_tokens``
+    stay ``0`` rather than putting the combined total under
+    ``output_tokens`` — the first #13067 attempt did exactly that and applied
+    output-rate pricing to input tokens (3-5x over).  The real number is
+    reported only in ``total_tokens``.  ``cache_hit_rate`` has no source at
+    all — no per-model cache-read counter exists anywhere in the schema — so
+    it is ``None`` rather than a fabricated value.
+    """
 
     agent_id: str
     agent_name: str
@@ -368,7 +385,8 @@ class AgentModelCostRow(BaseModel):
     input_tokens: int
     cached_input_tokens: int
     output_tokens: int
-    cache_hit_rate: float
+    total_tokens: int
+    cache_hit_rate: Optional[float] = None
     cost_usd: str
 
 
@@ -383,58 +401,37 @@ async def costs_by_agent_model(
     _current_user: dict = Depends(get_current_user),
     ctx: TenantContext = Depends(require_org_context),
 ) -> List[AgentModelCostRow]:
-    """Return token usage broken down by agent and model for a company.
+    """Return lifetime token totals per agent for a company (GH#13330).
 
-    Required fields: agentId, agentName, model, inputTokens,
-    cachedInputTokens, outputTokens, cacheHitRate.
-
-    Cache hit rate = cachedInputTokens / totalInputTokens.  A low rate
-    signals session churn — the agent is not benefiting from prompt caching.
-
-    Data is sourced from ``agent_org_nodes`` (for model + name) joined to
-    ``llc_heartbeat_runs`` (for token usage).  Rows without any heartbeat
-    runs are included with zero token counts so the roster is always complete.
-
-    Note: ``llc_heartbeat_runs`` does not yet have ``input_tokens`` /
-    ``cached_input_tokens`` columns.  The query returns zeros for those until
-    a future migration adds the columns.  The endpoint is intentionally
-    available from day one so dashboards can start wiring up immediately.
+    Sourced from ``llc_agent_budgets`` — the table ``BudgetService.
+    ingest_cost_event`` (the actual writer) maintains — enriched with the
+    display name from ``agent_org_nodes`` when the agent is registered there.
+    ``model`` is always ``"unknown"`` and ``input_tokens`` /
+    ``cached_input_tokens`` / ``output_tokens`` / ``cache_hit_rate`` cannot be
+    populated honestly (see ``AgentModelCostRow`` docstring); the real spend
+    signal is ``total_tokens`` and ``cost_usd``. Matches ``llc/api/costs.py``'s
+    ``/costs/by-agent-model`` sibling endpoint, fixed for the identical gap
+    in GH#13067.
     """
     assert_company_access(ctx, company_id)
     result = await session.execute(
-        text("""
-            SELECT
-                aon.agent_id,
-                aon.name                                   AS agent_name,
-                COALESCE(aon.model, 'claude-sonnet-4-6')   AS model,
-                COALESCE(SUM(hr.tokens_in), 0)             AS input_tokens,
-                0                                          AS cached_input_tokens,
-                COALESCE(SUM(hr.tokens_out), 0)            AS output_tokens
-            FROM agent_org_nodes aon
-            LEFT JOIN llc_heartbeat_runs hr
-                   ON hr.agent_id = aon.agent_id
-            WHERE aon.company_id = :company_id
-            GROUP BY aon.agent_id, aon.name, aon.model
-            ORDER BY output_tokens DESC
-        """),
-        {"company_id": company_id},
+        select(LLCAgentBudget, AgentOrgNode.name)
+        .outerjoin(AgentOrgNode, AgentOrgNode.agent_id == LLCAgentBudget.agent_id)
+        .where(LLCAgentBudget.company_id == company_id)
+        .order_by(LLCAgentBudget.agent_id)
     )
-    rows = result.mappings().all()
 
-    out: List[AgentModelCostRow] = []
-    for row in rows:
-        total_in = int(row["input_tokens"]) + int(row["cached_input_tokens"])
-        cache_hit_rate = round(int(row["cached_input_tokens"]) / total_in, 4) if total_in > 0 else 0.0
-        out.append(
-            AgentModelCostRow(
-                agent_id=row["agent_id"],
-                agent_name=row["agent_name"],
-                model=row["model"],
-                input_tokens=int(row["input_tokens"]),
-                cached_input_tokens=int(row["cached_input_tokens"]),
-                output_tokens=int(row["output_tokens"]),
-                cache_hit_rate=cache_hit_rate,
-                cost_usd="0.00",  # populated by a future cost calculation pass
-            )
+    return [
+        AgentModelCostRow(
+            agent_id=budget.agent_id,
+            agent_name=agent_name or budget.agent_id,
+            model="unknown",
+            input_tokens=0,
+            cached_input_tokens=0,
+            output_tokens=0,
+            total_tokens=int(budget.tokens_spent),
+            cache_hit_rate=None,
+            cost_usd=str(budget.budget_spent),
         )
-    return out
+        for budget, agent_name in result.all()
+    ]

--- a/autobot-backend/llc/api/budget.py
+++ b/autobot-backend/llc/api/budget.py
@@ -376,7 +376,10 @@ class AgentModelCostRow(BaseModel):
     output-rate pricing to input tokens (3-5x over).  The real number is
     reported only in ``total_tokens``.  ``cache_hit_rate`` has no source at
     all — no per-model cache-read counter exists anywhere in the schema — so
-    it is ``None`` rather than a fabricated value.
+    it is ``None`` rather than a fabricated value.  ``window`` is always
+    ``"lifetime"`` — this endpoint has no date/period parameter, and both
+    ``total_tokens`` and ``cost_usd`` are cumulative totals-to-date, matching
+    ``AgentModelCost.window`` in ``llc/api/costs.py``.
     """
 
     agent_id: str
@@ -388,12 +391,13 @@ class AgentModelCostRow(BaseModel):
     total_tokens: int
     cache_hit_rate: Optional[float] = None
     cost_usd: str
+    window: str = "lifetime"
 
 
 @costs_by_model_router.get(
     "/{company_id}/costs/by-agent-model",
     response_model=List[AgentModelCostRow],
-    summary="Token breakdown per agent+model with cache hit rate (GH#8486)",
+    summary="Lifetime token/cost totals per agent (GH#8486, GH#13330)",
 )
 async def costs_by_agent_model(
     company_id: str,
@@ -405,17 +409,17 @@ async def costs_by_agent_model(
 
     Sourced from ``llc_agent_budgets`` — the table ``BudgetService.
     ingest_cost_event`` (the actual writer) maintains — enriched with the
-    display name from ``agent_org_nodes`` when the agent is registered there.
-    ``model`` is always ``"unknown"`` and ``input_tokens`` /
-    ``cached_input_tokens`` / ``output_tokens`` / ``cache_hit_rate`` cannot be
-    populated honestly (see ``AgentModelCostRow`` docstring); the real spend
-    signal is ``total_tokens`` and ``cost_usd``. Matches ``llc/api/costs.py``'s
+    display name and model from ``agent_org_nodes`` when the agent is
+    registered there. ``input_tokens`` / ``cached_input_tokens`` /
+    ``output_tokens`` / ``cache_hit_rate`` cannot be populated honestly (see
+    ``AgentModelCostRow`` docstring); the real spend signal is
+    ``total_tokens`` and ``cost_usd``. Matches ``llc/api/costs.py``'s
     ``/costs/by-agent-model`` sibling endpoint, fixed for the identical gap
     in GH#13067.
     """
     assert_company_access(ctx, company_id)
     result = await session.execute(
-        select(LLCAgentBudget, AgentOrgNode.name)
+        select(LLCAgentBudget, AgentOrgNode.name, AgentOrgNode.model)
         .outerjoin(AgentOrgNode, AgentOrgNode.agent_id == LLCAgentBudget.agent_id)
         .where(LLCAgentBudget.company_id == company_id)
         .order_by(LLCAgentBudget.agent_id)
@@ -425,7 +429,7 @@ async def costs_by_agent_model(
         AgentModelCostRow(
             agent_id=budget.agent_id,
             agent_name=agent_name or budget.agent_id,
-            model="unknown",
+            model=model or "unknown",
             input_tokens=0,
             cached_input_tokens=0,
             output_tokens=0,
@@ -433,5 +437,5 @@ async def costs_by_agent_model(
             cache_hit_rate=None,
             cost_usd=str(budget.budget_spent),
         )
-        for budget, agent_name in result.all()
+        for budget, agent_name, model in result.all()
     ]

--- a/autobot-backend/llc/health/probe.py
+++ b/autobot-backend/llc/health/probe.py
@@ -119,14 +119,17 @@ def _compute_status(metrics: dict) -> str:
         return "down"
     if metrics["agents_overdue_critical"] > 0:
         return "down"
-    # Issue #13331: an unwired probe (app.state never got the attribute the
-    # lifespan sets — the probe cannot verify the component at all) is a
-    # different, more severe problem than a wired-but-stopped component, and
-    # must not collapse into the same "degraded" bucket. `.get(..., True)`
-    # keeps pre-#13331 hand-built metrics dicts (missing the new keys) at
-    # their old "assume wired" behaviour.
-    if not metrics.get("liveness_monitor_wired", True) or not metrics.get("session_checkpointer_wired", True):
-        return "down"
+    # Issue #13331: `liveness_monitor_running`/`session_checkpointer_running`
+    # are only True when `_app_state_scheduler_state` found the attribute
+    # AND it is running — an unwired probe (attribute never set) already
+    # reports `running=False` here, same as wired but stopped, so it already
+    # falls into this "degraded" bucket below with no extra branch needed.
+    # This matches api/system_health.py's probe_app_state(): a missing
+    # attribute is "degraded", not "down" — a request-less internal caller
+    # or a not-yet-finished lifespan startup window must not drag the whole
+    # aggregate to "down". `*_wired` stays in `data` purely as a diagnostic
+    # (was it never wired, or did it start and stop?) — it does not change
+    # severity on its own.
     if (
         metrics["agents_overdue_degraded"] > 0
         or metrics["budget_exhausted_companies"] > 0
@@ -156,12 +159,16 @@ def _app_state_scheduler_state(request: Request | None, attr: str) -> tuple[bool
     regardless of the real component's health.
 
     ``wired=False`` means ``app.state`` never got the attribute at all —
-    lifespan never ran, or this probe call has no request context — which is
-    a probe-integration failure, distinct from ``wired=True, running=False``
+    lifespan never ran (or hasn't reached this init step yet — see
+    initialization/lifespan.py's background phase-2 ordering), or this probe
+    call has no request context — distinct from ``wired=True, running=False``
     (lifespan set the attribute — possibly to ``None`` after a caught startup
-    failure — but the component is not currently running). Conflating the two
-    is exactly how this bug survived: a probe that cannot tell "never wired"
-    from "wired but stopped" reports the same status for both.
+    failure — but the component is not currently running). Conflating the
+    two was the original bug: a probe that cannot tell "never wired" from
+    "wired but stopped" reports the same verdict for both. ``running`` is
+    ``False`` in both cases — see ``_compute_status`` for why that alone is
+    enough to drive severity, and why ``wired`` is reported in ``data`` as a
+    diagnostic only, not as its own severity input.
     """
     if request is None or request.app is None or not hasattr(request.app.state, attr):
         return False, False

--- a/autobot-backend/llc/health/probe.py
+++ b/autobot-backend/llc/health/probe.py
@@ -35,26 +35,6 @@ from ..models.enums import ApprovalStatus
 
 # HeartbeatScheduler import is lazy (inside _collect_metrics) to avoid circular-import
 # chains when the probe module is loaded in test environments.
-# LivenessMonitor singleton wrapper is created once at module level inside a try/except
-# so it is cached for the process lifetime without forcing an import at module load in
-# environments where the scheduler package is not yet available.
-try:
-    from autobot_shared.singleton_factory import lazy_singleton as _lazy_singleton
-
-    from ..scheduler.liveness_monitor import LivenessMonitor as _LivenessMonitor
-
-    _get_lm = _lazy_singleton(_LivenessMonitor)
-except ImportError:
-    _get_lm = None
-
-try:
-    from autobot_shared.singleton_factory import lazy_singleton as _lazy_singleton_sc
-
-    from ..scheduler.session_checkpointer import SessionCheckpointer as _SessionCheckpointer
-
-    _get_sc = _lazy_singleton_sc(_SessionCheckpointer)
-except ImportError:
-    _get_sc = None
 
 logger = logging.getLogger(__name__)
 
@@ -78,7 +58,7 @@ async def probe_llc(request: Request | None = None) -> ComponentHealth:
     start = time.monotonic()
 
     try:
-        metrics = await _collect_metrics()
+        metrics = await _collect_metrics(request)
         status = _compute_status(metrics)
         latency_ms = (time.monotonic() - start) * 1000
         return ComponentHealth(
@@ -98,16 +78,16 @@ async def probe_llc(request: Request | None = None) -> ComponentHealth:
         )
 
 
-async def _collect_metrics() -> dict:
+async def _collect_metrics(request: Request | None = None) -> dict:
     from ..scheduler.heartbeat_scheduler import get_heartbeat_scheduler
 
     scheduler = get_heartbeat_scheduler()
-    liveness_monitor = _get_liveness_monitor()
-    session_checkpointer = _get_session_checkpointer()
 
     heartbeat_scheduler_running = _is_scheduler_running(scheduler)
-    liveness_monitor_running = _is_liveness_monitor_running(liveness_monitor)
-    session_checkpointer_running = _is_session_checkpointer_running(session_checkpointer)
+    liveness_monitor_wired, liveness_monitor_running = _app_state_scheduler_state(request, "llc_liveness_monitor")
+    session_checkpointer_wired, session_checkpointer_running = _app_state_scheduler_state(
+        request, "llc_session_checkpointer"
+    )
     session_recovery_available = await _session_recovery_available()
     scheduler_last_tick_age_seconds = await _scheduler_tick_age()
     agents_overdue_degraded, agents_overdue_critical = await _count_overdue_agents()
@@ -117,7 +97,9 @@ async def _collect_metrics() -> dict:
 
     return {
         "heartbeat_scheduler_running": heartbeat_scheduler_running,
+        "liveness_monitor_wired": liveness_monitor_wired,
         "liveness_monitor_running": liveness_monitor_running,
+        "session_checkpointer_wired": session_checkpointer_wired,
         "session_checkpointer_running": session_checkpointer_running,
         "session_recovery_available": session_recovery_available,
         "scheduler_last_tick_age_seconds": scheduler_last_tick_age_seconds,
@@ -137,6 +119,14 @@ def _compute_status(metrics: dict) -> str:
         return "down"
     if metrics["agents_overdue_critical"] > 0:
         return "down"
+    # Issue #13331: an unwired probe (app.state never got the attribute the
+    # lifespan sets — the probe cannot verify the component at all) is a
+    # different, more severe problem than a wired-but-stopped component, and
+    # must not collapse into the same "degraded" bucket. `.get(..., True)`
+    # keeps pre-#13331 hand-built metrics dicts (missing the new keys) at
+    # their old "assume wired" behaviour.
+    if not metrics.get("liveness_monitor_wired", True) or not metrics.get("session_checkpointer_wired", True):
+        return "down"
     if (
         metrics["agents_overdue_degraded"] > 0
         or metrics["budget_exhausted_companies"] > 0
@@ -155,32 +145,30 @@ def _is_scheduler_running(scheduler: object) -> bool:
     return bool(getattr(scheduler, "is_running", False))
 
 
-def _get_liveness_monitor() -> object | None:
-    """Return the singleton LivenessMonitor if it exists, else None."""
-    if _get_lm is None:
-        return None
-    try:
-        return _get_lm()
-    except Exception:
-        return None
+def _app_state_scheduler_state(request: Request | None, attr: str) -> tuple[bool, bool]:
+    """Return ``(wired, running)`` for a poll-loop scheduler singleton kept on ``app.state``.
 
+    Issue #13331: the probe used to build its own private ``lazy_singleton``
+    instances of ``LivenessMonitor``/``SessionCheckpointer`` — objects
+    entirely disconnected from the ones ``initialization/lifespan.py``
+    actually starts and stores on ``app.state``. Those private instances were
+    never started, so the probe permanently reported them as not running,
+    regardless of the real component's health.
 
-def _is_liveness_monitor_running(monitor: object | None) -> bool:
-    return monitor is not None and bool(getattr(monitor, "is_running", False))
-
-
-def _get_session_checkpointer() -> object | None:
-    """Return the singleton SessionCheckpointer if it exists, else None."""
-    if _get_sc is None:
-        return None
-    try:
-        return _get_sc()
-    except Exception:
-        return None
-
-
-def _is_session_checkpointer_running(checkpointer: object | None) -> bool:
-    return checkpointer is not None and bool(getattr(checkpointer, "is_running", False))
+    ``wired=False`` means ``app.state`` never got the attribute at all —
+    lifespan never ran, or this probe call has no request context — which is
+    a probe-integration failure, distinct from ``wired=True, running=False``
+    (lifespan set the attribute — possibly to ``None`` after a caught startup
+    failure — but the component is not currently running). Conflating the two
+    is exactly how this bug survived: a probe that cannot tell "never wired"
+    from "wired but stopped" reports the same status for both.
+    """
+    if request is None or request.app is None or not hasattr(request.app.state, attr):
+        return False, False
+    instance = getattr(request.app.state, attr)
+    if instance is None:
+        return True, False
+    return True, bool(getattr(instance, "is_running", False))
 
 
 async def _session_recovery_available() -> bool:

--- a/autobot-backend/llc/tests/test_costs_by_agent_model_row.py
+++ b/autobot-backend/llc/tests/test_costs_by_agent_model_row.py
@@ -101,7 +101,14 @@ async def _insert_budget(
         await session.commit()
 
 
-async def _insert_agent_org_node(session_factory, company_id: str, agent_id: str, name: str) -> None:  # noqa: ANN001
+async def _insert_agent_org_node(
+    session_factory,  # noqa: ANN001
+    company_id: str,
+    agent_id: str,
+    name: str,
+    *,
+    model: str | None = None,
+) -> None:
     async with session_factory() as session:
         session.add(
             AgentOrgNode(
@@ -110,6 +117,7 @@ async def _insert_agent_org_node(session_factory, company_id: str, agent_id: str
                 agent_id=agent_id,
                 name=name,
                 org_role="worker",
+                model=model,
             )
         )
         await session.commit()
@@ -130,6 +138,10 @@ async def test_returns_real_data_instead_of_500(session_factory) -> None:  # noq
     body = resp.json()
     assert len(body) == 1
     assert body[0]["agent_id"] == "agent-alpha"
+    # No agent_org_nodes row exists for this agent -- the LEFT join's NULL
+    # branch must fall back to the raw agent_id slug (see
+    # test_agent_name_enriched_from_agent_org_nodes for the non-NULL branch).
+    assert body[0]["agent_name"] == "agent-alpha"
     # tokens_spent is an input+output COMBINED total (llc/services/budget.py's
     # total_tokens = tokens_in + tokens_out) with no record of the split, so
     # it must surface only via total_tokens -- not fabricated into
@@ -147,6 +159,7 @@ async def test_returns_real_data_instead_of_500(session_factory) -> None:  # noq
     # not fabricate a specific hit rate.
     assert body[0]["cache_hit_rate"] is None
     assert body[0]["model"] == "unknown"
+    assert body[0]["window"] == "lifetime"
 
 
 @pytest.mark.asyncio
@@ -175,6 +188,24 @@ async def test_agent_name_enriched_from_agent_org_nodes(session_factory) -> None
     assert resp.status_code == 200, resp.text
     body = resp.json()
     assert body[0]["agent_name"] == "Beta Prime"
+
+
+@pytest.mark.asyncio
+async def test_model_enriched_from_agent_org_nodes(session_factory) -> None:  # noqa: ANN001
+    """model comes from agent_org_nodes.model when the agent is registered
+    there, falling back to "unknown" otherwise (review nit: the endpoint
+    already joins agent_org_nodes for agent_name -- reading its real model
+    column too costs nothing over hard-coding "unknown")."""
+    company_id = str(uuid.uuid4())
+    await _insert_budget(session_factory, company_id, "agent-gamma", tokens_spent=5)
+    await _insert_agent_org_node(session_factory, company_id, "agent-gamma", "Gamma", model="claude-haiku-4-5")
+
+    async with _client(_make_app(session_factory, company_id)) as client:
+        resp = await client.get(f"/api/llc/companies/{company_id}/costs/by-agent-model")
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body[0]["model"] == "claude-haiku-4-5"
 
 
 @pytest.mark.asyncio

--- a/autobot-backend/llc/tests/test_costs_by_agent_model_row.py
+++ b/autobot-backend/llc/tests/test_costs_by_agent_model_row.py
@@ -1,0 +1,191 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Regression tests for GET /companies/{company_id}/costs/by-agent-model (#13330).
+
+Before #13330 this endpoint raw-SELECTed ``hr.tokens_in`` / ``hr.tokens_out``
+from ``llc_heartbeat_runs``, columns that do not exist anywhere on that model
+(see ``llc/models/heartbeat_run.py``). The unguarded ``text()`` query always
+raised ``UndefinedColumn``, so the endpoint 500'd in every environment.
+
+These tests use a real in-memory SQLite schema (not mocks) so a query against
+a genuinely nonexistent column fails the same way it would against Postgres,
+and prove the endpoint now returns real data sourced from
+``llc_agent_budgets`` — the same table ``llc/api/costs.py``'s sibling
+``/costs/by-agent-model`` endpoint was fixed to use in #13067.
+"""
+
+import uuid
+from typing import AsyncIterator
+
+import httpx
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from llc.models.budget import LLCAgentBudget
+from llc.tests import _e2e_harness as harness
+from models.agent_org import AgentOrgNode
+
+_FIXED_USER_ID = uuid.UUID("77777777-7777-7777-7777-777777777777")
+
+
+@pytest_asyncio.fixture
+async def engine():  # noqa: ANN201
+    eng = create_async_engine("sqlite+aiosqlite:///:memory:")  # canonical: ignore py-adhoc-db-engine
+    await harness.create_loop_schema(eng)
+    yield eng
+    await eng.dispose()
+
+
+@pytest_asyncio.fixture
+async def session_factory(engine):  # noqa: ANN001, ANN201
+    return async_sessionmaker(
+        engine, expire_on_commit=False, class_=AsyncSession
+    )  # canonical: ignore py-adhoc-db-engine
+
+
+def _make_app(session_factory, company_id: str) -> FastAPI:  # noqa: ANN001
+    from api.user_management.dependencies import get_current_user, require_org_context
+    from llc.api import budget as budget_api
+    from user_management.database import get_async_session
+    from user_management.services import TenantContext
+
+    app = FastAPI()
+    app.include_router(budget_api.costs_by_model_router, prefix="/api/llc")
+
+    async def _override_session() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    app.dependency_overrides[get_async_session] = _override_session
+    app.dependency_overrides[get_current_user] = lambda: {
+        "id": str(_FIXED_USER_ID),
+        "user_id": str(_FIXED_USER_ID),
+    }
+    app.dependency_overrides[require_org_context] = lambda: TenantContext(
+        org_id=uuid.UUID(company_id),
+        user_id=_FIXED_USER_ID,
+        is_platform_admin=False,
+    )
+    return app
+
+
+def _client(app: FastAPI) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test")
+
+
+async def _insert_budget(
+    session_factory,  # noqa: ANN001
+    company_id: str,
+    agent_id: str,
+    *,
+    tokens_spent: int,
+    budget_spent: str = "1.50",
+) -> None:
+    async with session_factory() as session:
+        session.add(
+            LLCAgentBudget(
+                id=uuid.uuid4(),
+                company_id=company_id,
+                agent_id=agent_id,
+                budget_mode="dollars",
+                budget_limit="100.00",
+                budget_spent=budget_spent,
+                tokens_spent=tokens_spent,
+                alert_threshold=0.8,
+            )
+        )
+        await session.commit()
+
+
+async def _insert_agent_org_node(session_factory, company_id: str, agent_id: str, name: str) -> None:  # noqa: ANN001
+    async with session_factory() as session:
+        session.add(
+            AgentOrgNode(
+                id=uuid.uuid4(),
+                company_id=uuid.UUID(company_id),
+                agent_id=agent_id,
+                name=name,
+                org_role="worker",
+            )
+        )
+        await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_returns_real_data_instead_of_500(session_factory) -> None:  # noqa: ANN001
+    """The core #13330 regression: real llc_agent_budgets rows must surface
+    with a 200, not a 500 from selecting nonexistent hr.tokens_in/tokens_out
+    columns."""
+    company_id = str(uuid.uuid4())
+    await _insert_budget(session_factory, company_id, "agent-alpha", tokens_spent=4200, budget_spent="2.75")
+
+    async with _client(_make_app(session_factory, company_id)) as client:
+        resp = await client.get(f"/api/llc/companies/{company_id}/costs/by-agent-model")
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert len(body) == 1
+    assert body[0]["agent_id"] == "agent-alpha"
+    # tokens_spent is an input+output COMBINED total (llc/services/budget.py's
+    # total_tokens = tokens_in + tokens_out) with no record of the split, so
+    # it must surface only via total_tokens -- not fabricated into
+    # output_tokens, which would misrepresent it as 100% output and apply
+    # the wrong per-token price to it (the #13067 precedent this mirrors).
+    assert body[0]["total_tokens"] == 4200
+    assert body[0]["input_tokens"] == 0
+    assert body[0]["cached_input_tokens"] == 0
+    assert body[0]["output_tokens"] == 0
+    # Numeric(15, 6) — str(Decimal) preserves the column's declared scale,
+    # matching list_cost_events's identical str(row.budget_spent) precedent
+    # in this same module.
+    assert body[0]["cost_usd"] == "2.750000"
+    # No per-model cache-read counter exists anywhere in the schema -- must
+    # not fabricate a specific hit rate.
+    assert body[0]["cache_hit_rate"] is None
+    assert body[0]["model"] == "unknown"
+
+
+@pytest.mark.asyncio
+async def test_empty_when_no_budget_rows(session_factory) -> None:  # noqa: ANN001
+    """No spend recorded yet must still return 200 + [] (not a 500)."""
+    company_id = str(uuid.uuid4())
+
+    async with _client(_make_app(session_factory, company_id)) as client:
+        resp = await client.get(f"/api/llc/companies/{company_id}/costs/by-agent-model")
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == []
+
+
+@pytest.mark.asyncio
+async def test_agent_name_enriched_from_agent_org_nodes(session_factory) -> None:  # noqa: ANN001
+    """agent_name comes from agent_org_nodes.name when the agent is registered
+    there, falling back to the raw agent_id slug otherwise."""
+    company_id = str(uuid.uuid4())
+    await _insert_budget(session_factory, company_id, "agent-beta", tokens_spent=10)
+    await _insert_agent_org_node(session_factory, company_id, "agent-beta", "Beta Prime")
+
+    async with _client(_make_app(session_factory, company_id)) as client:
+        resp = await client.get(f"/api/llc/companies/{company_id}/costs/by-agent-model")
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body[0]["agent_name"] == "Beta Prime"
+
+
+@pytest.mark.asyncio
+async def test_other_companys_budget_rows_are_excluded(session_factory) -> None:  # noqa: ANN001
+    """Cross-tenant isolation: another company's spend must never appear."""
+    company_a = str(uuid.uuid4())
+    company_b = str(uuid.uuid4())
+    await _insert_budget(session_factory, company_b, "agent-other-tenant", tokens_spent=999)
+
+    async with _client(_make_app(session_factory, company_a)) as client:
+        resp = await client.get(f"/api/llc/companies/{company_a}/costs/by-agent-model")
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == []

--- a/autobot-backend/llc/tests/test_haiku_tier.py
+++ b/autobot-backend/llc/tests/test_haiku_tier.py
@@ -218,13 +218,18 @@ class TestCostsByAgentModel:
             input_tokens=1000,
             cached_input_tokens=800,
             output_tokens=200,
+            total_tokens=1200,
             cache_hit_rate=0.8,
             cost_usd="0.00",
         )
         assert row.cache_hit_rate == 0.8
         assert row.cached_input_tokens == 800
+        assert row.total_tokens == 1200
 
-    def test_cache_hit_rate_zero_when_no_tokens(self) -> None:
+    def test_cache_hit_rate_none_by_default(self) -> None:
+        """No per-model cache-read counter exists anywhere in the schema
+        (GH#13330) -- cache_hit_rate must default to None, not a fabricated
+        0.0, when the caller omits it."""
         mod = _get_budget_mod()
         row = mod.AgentModelCostRow(
             agent_id="a2",
@@ -233,10 +238,10 @@ class TestCostsByAgentModel:
             input_tokens=0,
             cached_input_tokens=0,
             output_tokens=0,
-            cache_hit_rate=0.0,
+            total_tokens=0,
             cost_usd="0.00",
         )
-        assert row.cache_hit_rate == 0.0
+        assert row.cache_hit_rate is None
 
     def test_costs_by_model_router_exported(self) -> None:
         """costs_by_model_router must be exported from budget.py for __init__.py."""

--- a/autobot-backend/llc/tests/test_health_probe.py
+++ b/autobot-backend/llc/tests/test_health_probe.py
@@ -289,31 +289,35 @@ def test_status_degraded_monitor_down():
     assert _compute_status(_base_metrics(liveness_monitor_running=False)) == "degraded"
 
 
-def test_status_down_when_liveness_monitor_unwired():
-    """GH#13331: unwired must be worse than degraded, and distinct from the
-    wired-but-stopped case above."""
+def test_status_degraded_when_liveness_monitor_unwired():
+    """GH#13331: unwired (never set on app.state) must land at "degraded",
+    matching api/system_health.py's probe_app_state() precedent for a
+    missing attribute -- NOT "down". A request-less internal caller, or the
+    background lifespan window before this init step runs, must not drag
+    the whole system-health aggregate to "down" (#13336 review A1/A2)."""
     from llc.health.probe import _compute_status
 
     m = _base_metrics(liveness_monitor_wired=False, liveness_monitor_running=False)
-    assert _compute_status(m) == "down"
+    assert _compute_status(m) == "degraded"
 
 
-def test_status_down_when_session_checkpointer_unwired():
+def test_status_degraded_when_session_checkpointer_unwired():
     from llc.health.probe import _compute_status
 
     m = _base_metrics(session_checkpointer_wired=False, session_checkpointer_running=False)
-    assert _compute_status(m) == "down"
+    assert _compute_status(m) == "degraded"
 
 
-def test_status_backward_compat_missing_wired_keys_defaults_ok():
-    """A metrics dict built before GH#13331 (no *_wired keys) must not be
-    newly downgraded to "down" -- absence of the key means "assume wired"."""
+def test_status_wired_key_is_diagnostic_only_not_a_severity_input():
+    """The *_wired keys exist purely so callers can distinguish "never wired"
+    from "wired but stopped" in `data` -- _compute_status must derive
+    severity from `running` alone, so wired=True with the same running value
+    produces an identical status to wired=False (#13336 review A1)."""
     from llc.health.probe import _compute_status
 
-    m = _base_metrics()
-    del m["liveness_monitor_wired"]
-    del m["session_checkpointer_wired"]
-    assert _compute_status(m) == "ok"
+    wired = _base_metrics(liveness_monitor_wired=True, liveness_monitor_running=False)
+    unwired = _base_metrics(liveness_monitor_wired=False, liveness_monitor_running=False)
+    assert _compute_status(wired) == _compute_status(unwired) == "degraded"
 
 
 def test_status_degraded_pending_approvals():
@@ -412,10 +416,12 @@ async def test_probe_returns_degraded_when_agents_overdue_degraded():
 
 
 @pytest.mark.asyncio
-async def test_probe_returns_unwired_down_with_no_request_context():
-    """GH#13331: without a request, the probe cannot reach app.state at all
-    and must report the components unwired (down) rather than fabricate a
-    running/not-running verdict from a disconnected shadow singleton."""
+async def test_probe_returns_unwired_degraded_with_no_request_context():
+    """GH#13331 (review A1/A2): without a request, the probe cannot reach
+    app.state at all and must report the components unwired -- but that is
+    "degraded", not "down". A missing request context (an internal caller,
+    or the background lifespan window before this init step has run) must
+    not drag the whole /api/health aggregate to "down"."""
     from unittest.mock import patch
 
     async_pair = AsyncMock(return_value=(0, 0))
@@ -424,6 +430,10 @@ async def test_probe_returns_unwired_down_with_no_request_context():
     async_false = AsyncMock(return_value=False)
 
     with (
+        # Isolate the wired/unwired behaviour under test from the unrelated
+        # HeartbeatScheduler-not-started case, which would independently
+        # force "down" via the very first _compute_status check.
+        patch("llc.health.probe._is_scheduler_running", return_value=True),
         patch("llc.health.probe._count_overdue_agents", new=async_pair),
         patch("llc.health.probe._budget_counts", new=async_pair),
         patch("llc.health.probe._pending_approvals_critical", new=async_zero),
@@ -437,16 +447,28 @@ async def test_probe_returns_unwired_down_with_no_request_context():
 
     assert result.data["liveness_monitor_wired"] is False
     assert result.data["session_checkpointer_wired"] is False
-    assert result.status == "down"
+    assert result.status == "degraded"
 
 
-# NOTE: the "real lifespan objects" regression test for this fix lives in
-# initialization/lifespan_test.py, not here. llc/tests/conftest.py stubs
-# sys.modules["agents"] at collection time (to dodge the chromadb import
-# chain) so every test file under llc/tests/ can import cleanly -- but that
-# stub also permanently breaks `initialization.lifespan`'s own import chain
-# (api.overseer_handlers -> agents.overseer) for the rest of the pytest
-# process once it has run. Exercising the real lifespan init functions from
-# initialization/lifespan_test.py avoids that collision and matches the
-# precedent already established there (test_init_liveness_monitor_actually_starts_it,
-# #13085).
+# NOTE on why the real-lifespan-objects test for this fix lives in
+# initialization/lifespan_test.py instead of here: this is NOT primarily a
+# "safer file placement" choice -- it works today because
+# initialization/lifespan_test.py:19 imports `initialization.lifespan` at
+# MODULE level (eagerly, at collection time), and pytest's default
+# collection order visits `autobot-backend/initialization/` before
+# `autobot-backend/llc/` (plain alphabetical directory order) when both are
+# swept in one run. `initialization.lifespan` and its transitive
+# `api.overseer_handlers -> agents.overseer` chain are therefore already
+# fully imported and cached in sys.modules before llc/tests/conftest.py ever
+# installs its `sys.modules["agents"]` stub (added to dodge the chromadb
+# import chain) -- so the stub has nothing left to shadow for that already
+# -cached module.
+#
+# That invariant is fragile, not structural: (1) it silently breaks if
+# `lifespan_test.py`'s top-level import is ever converted to a lazy
+# in-function import, matching the style this file's own two new tests
+# already use; (2) it is already broken today for anyone who runs
+# `pytest autobot-backend/llc/tests autobot-backend/initialization` (llc
+# first) -- confirmed the ModuleNotFoundError reproduces with that explicit
+# ordering. See GH#13331 PR review (#13336) for the filed follow-up on
+# conftest.py's stub scoping.

--- a/autobot-backend/llc/tests/test_health_probe.py
+++ b/autobot-backend/llc/tests/test_health_probe.py
@@ -34,10 +34,19 @@ def _make_monitor(*, running: bool = True, task_done: bool = False) -> MagicMock
     return m
 
 
+def _make_request(app_state: object | None) -> MagicMock:
+    """Build a minimal fastapi.Request-like double exposing .app.state."""
+    request = MagicMock()
+    request.app.state = app_state
+    return request
+
+
 def _base_metrics(**overrides) -> dict:
     base = {
         "heartbeat_scheduler_running": True,
+        "liveness_monitor_wired": True,
         "liveness_monitor_running": True,
+        "session_checkpointer_wired": True,
         "session_checkpointer_running": True,
         "scheduler_last_tick_age_seconds": 2.5,
         "agents_overdue_degraded": 0,
@@ -81,26 +90,72 @@ def test_scheduler_not_running_falls_back_for_missing_property():
 
 
 # ---------------------------------------------------------------------------
-# _is_liveness_monitor_running
+# _app_state_scheduler_state — GH#13331: wired-vs-running distinction
 # ---------------------------------------------------------------------------
 
 
-def test_monitor_running():
-    from llc.health.probe import _is_liveness_monitor_running
+def test_wired_and_running_when_app_state_has_a_running_instance():
+    from types import SimpleNamespace
 
-    assert _is_liveness_monitor_running(_make_monitor(running=True, task_done=False)) is True
+    from llc.health.probe import _app_state_scheduler_state
 
-
-def test_monitor_not_running_when_none():
-    from llc.health.probe import _is_liveness_monitor_running
-
-    assert _is_liveness_monitor_running(None) is False
+    request = _make_request(SimpleNamespace(llc_liveness_monitor=_make_monitor(running=True)))
+    wired, running = _app_state_scheduler_state(request, "llc_liveness_monitor")
+    assert (wired, running) == (True, True)
 
 
-def test_monitor_not_running_when_stopped():
-    from llc.health.probe import _is_liveness_monitor_running
+def test_wired_but_not_running_when_app_state_instance_is_stopped():
+    from types import SimpleNamespace
 
-    assert _is_liveness_monitor_running(_make_monitor(running=False)) is False
+    from llc.health.probe import _app_state_scheduler_state
+
+    request = _make_request(SimpleNamespace(llc_liveness_monitor=_make_monitor(running=False)))
+    wired, running = _app_state_scheduler_state(request, "llc_liveness_monitor")
+    assert (wired, running) == (True, False)
+
+
+def test_wired_but_not_running_when_app_state_attr_is_none():
+    """Lifespan caught a startup failure and recorded None -- attribute IS
+    present, so this must read as wired, not unwired (GH#13331)."""
+    from types import SimpleNamespace
+
+    from llc.health.probe import _app_state_scheduler_state
+
+    request = _make_request(SimpleNamespace(llc_liveness_monitor=None))
+    wired, running = _app_state_scheduler_state(request, "llc_liveness_monitor")
+    assert (wired, running) == (True, False)
+
+
+def test_unwired_when_app_state_never_got_the_attribute():
+    """The core #13331 regression: an attribute lifespan never set must
+    report distinctly (unwired) from a wired-but-stopped component -- both
+    used to collapse into a single not-running bool."""
+    from types import SimpleNamespace
+
+    from llc.health.probe import _app_state_scheduler_state
+
+    request = _make_request(SimpleNamespace())  # no llc_liveness_monitor at all
+    wired, running = _app_state_scheduler_state(request, "llc_liveness_monitor")
+    assert (wired, running) == (False, False)
+
+
+def test_unwired_when_request_is_none():
+    """No request context (e.g. an internal caller) cannot verify wiring --
+    must report unwired, not fabricate a running/not-running verdict."""
+    from llc.health.probe import _app_state_scheduler_state
+
+    wired, running = _app_state_scheduler_state(None, "llc_liveness_monitor")
+    assert (wired, running) == (False, False)
+
+
+def test_app_state_scheduler_state_works_for_session_checkpointer_attr():
+    from types import SimpleNamespace
+
+    from llc.health.probe import _app_state_scheduler_state
+
+    request = _make_request(SimpleNamespace(llc_session_checkpointer=_make_monitor(running=True)))
+    wired, running = _app_state_scheduler_state(request, "llc_session_checkpointer")
+    assert (wired, running) == (True, True)
 
 
 # ---------------------------------------------------------------------------
@@ -234,6 +289,33 @@ def test_status_degraded_monitor_down():
     assert _compute_status(_base_metrics(liveness_monitor_running=False)) == "degraded"
 
 
+def test_status_down_when_liveness_monitor_unwired():
+    """GH#13331: unwired must be worse than degraded, and distinct from the
+    wired-but-stopped case above."""
+    from llc.health.probe import _compute_status
+
+    m = _base_metrics(liveness_monitor_wired=False, liveness_monitor_running=False)
+    assert _compute_status(m) == "down"
+
+
+def test_status_down_when_session_checkpointer_unwired():
+    from llc.health.probe import _compute_status
+
+    m = _base_metrics(session_checkpointer_wired=False, session_checkpointer_running=False)
+    assert _compute_status(m) == "down"
+
+
+def test_status_backward_compat_missing_wired_keys_defaults_ok():
+    """A metrics dict built before GH#13331 (no *_wired keys) must not be
+    newly downgraded to "down" -- absence of the key means "assume wired"."""
+    from llc.health.probe import _compute_status
+
+    m = _base_metrics()
+    del m["liveness_monitor_wired"]
+    del m["session_checkpointer_wired"]
+    assert _compute_status(m) == "ok"
+
+
 def test_status_degraded_pending_approvals():
     from llc.health.probe import _compute_status
 
@@ -327,3 +409,44 @@ async def test_probe_returns_degraded_when_agents_overdue_degraded():
         result = await probe_llc(None)
         assert result.status == "degraded"
         assert result.data["agents_overdue_degraded"] == 2
+
+
+@pytest.mark.asyncio
+async def test_probe_returns_unwired_down_with_no_request_context():
+    """GH#13331: without a request, the probe cannot reach app.state at all
+    and must report the components unwired (down) rather than fabricate a
+    running/not-running verdict from a disconnected shadow singleton."""
+    from unittest.mock import patch
+
+    async_pair = AsyncMock(return_value=(0, 0))
+    async_zero = AsyncMock(return_value=0)
+    async_none = AsyncMock(return_value=None)
+    async_false = AsyncMock(return_value=False)
+
+    with (
+        patch("llc.health.probe._count_overdue_agents", new=async_pair),
+        patch("llc.health.probe._budget_counts", new=async_pair),
+        patch("llc.health.probe._pending_approvals_critical", new=async_zero),
+        patch("llc.health.probe._count_agents_missing_instructions", new=async_zero),
+        patch("llc.health.probe._scheduler_tick_age", new=async_none),
+        patch("llc.health.probe._session_recovery_available", new=async_false),
+    ):
+        from llc.health.probe import probe_llc
+
+        result = await probe_llc(None)
+
+    assert result.data["liveness_monitor_wired"] is False
+    assert result.data["session_checkpointer_wired"] is False
+    assert result.status == "down"
+
+
+# NOTE: the "real lifespan objects" regression test for this fix lives in
+# initialization/lifespan_test.py, not here. llc/tests/conftest.py stubs
+# sys.modules["agents"] at collection time (to dodge the chromadb import
+# chain) so every test file under llc/tests/ can import cleanly -- but that
+# stub also permanently breaks `initialization.lifespan`'s own import chain
+# (api.overseer_handlers -> agents.overseer) for the rest of the pytest
+# process once it has run. Exercising the real lifespan init functions from
+# initialization/lifespan_test.py avoids that collision and matches the
+# precedent already established there (test_init_liveness_monitor_actually_starts_it,
+# #13085).

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -49106,16 +49106,16 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Token breakdown per agent+model with cache hit rate (GH#8486)
+         * Lifetime token/cost totals per agent (GH#8486, GH#13330)
          * @description Return lifetime token totals per agent for a company (GH#13330).
          *
          *     Sourced from ``llc_agent_budgets`` — the table ``BudgetService.
          *     ingest_cost_event`` (the actual writer) maintains — enriched with the
-         *     display name from ``agent_org_nodes`` when the agent is registered there.
-         *     ``model`` is always ``"unknown"`` and ``input_tokens`` /
-         *     ``cached_input_tokens`` / ``output_tokens`` / ``cache_hit_rate`` cannot be
-         *     populated honestly (see ``AgentModelCostRow`` docstring); the real spend
-         *     signal is ``total_tokens`` and ``cost_usd``. Matches ``llc/api/costs.py``'s
+         *     display name and model from ``agent_org_nodes`` when the agent is
+         *     registered there. ``input_tokens`` / ``cached_input_tokens`` /
+         *     ``output_tokens`` / ``cache_hit_rate`` cannot be populated honestly (see
+         *     ``AgentModelCostRow`` docstring); the real spend signal is
+         *     ``total_tokens`` and ``cost_usd``. Matches ``llc/api/costs.py``'s
          *     ``/costs/by-agent-model`` sibling endpoint, fixed for the identical gap
          *     in GH#13067.
          */
@@ -54568,7 +54568,10 @@ export interface components {
          *     output-rate pricing to input tokens (3-5x over).  The real number is
          *     reported only in ``total_tokens``.  ``cache_hit_rate`` has no source at
          *     all — no per-model cache-read counter exists anywhere in the schema — so
-         *     it is ``None`` rather than a fabricated value.
+         *     it is ``None`` rather than a fabricated value.  ``window`` is always
+         *     ``"lifetime"`` — this endpoint has no date/period parameter, and both
+         *     ``total_tokens`` and ``cost_usd`` are cumulative totals-to-date, matching
+         *     ``AgentModelCost.window`` in ``llc/api/costs.py``.
          */
         AgentModelCostRow: {
             /** Agent Id */
@@ -54589,6 +54592,11 @@ export interface components {
             cache_hit_rate?: number | null;
             /** Cost Usd */
             cost_usd: string;
+            /**
+             * Window
+             * @default lifetime
+             */
+            window: string;
         } & {
             [key: string]: unknown;
         };

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -49107,22 +49107,17 @@ export interface paths {
         };
         /**
          * Token breakdown per agent+model with cache hit rate (GH#8486)
-         * @description Return token usage broken down by agent and model for a company.
+         * @description Return lifetime token totals per agent for a company (GH#13330).
          *
-         *     Required fields: agentId, agentName, model, inputTokens,
-         *     cachedInputTokens, outputTokens, cacheHitRate.
-         *
-         *     Cache hit rate = cachedInputTokens / totalInputTokens.  A low rate
-         *     signals session churn — the agent is not benefiting from prompt caching.
-         *
-         *     Data is sourced from ``agent_org_nodes`` (for model + name) joined to
-         *     ``llc_heartbeat_runs`` (for token usage).  Rows without any heartbeat
-         *     runs are included with zero token counts so the roster is always complete.
-         *
-         *     Note: ``llc_heartbeat_runs`` does not yet have ``input_tokens`` /
-         *     ``cached_input_tokens`` columns.  The query returns zeros for those until
-         *     a future migration adds the columns.  The endpoint is intentionally
-         *     available from day one so dashboards can start wiring up immediately.
+         *     Sourced from ``llc_agent_budgets`` — the table ``BudgetService.
+         *     ingest_cost_event`` (the actual writer) maintains — enriched with the
+         *     display name from ``agent_org_nodes`` when the agent is registered there.
+         *     ``model`` is always ``"unknown"`` and ``input_tokens`` /
+         *     ``cached_input_tokens`` / ``output_tokens`` / ``cache_hit_rate`` cannot be
+         *     populated honestly (see ``AgentModelCostRow`` docstring); the real spend
+         *     signal is ``total_tokens`` and ``cost_usd``. Matches ``llc/api/costs.py``'s
+         *     ``/costs/by-agent-model`` sibling endpoint, fixed for the identical gap
+         *     in GH#13067.
          */
         get: operations["costs_by_agent_model_api_llc_companies__company_id__costs_by_agent_model_get"];
         put?: never;
@@ -54559,6 +54554,21 @@ export interface components {
         /**
          * AgentModelCostRow
          * @description Per-agent + per-model token breakdown row.
+         *
+         *     Mirrors ``llc/api/costs.py``'s ``AgentModelCost`` (GH#13067): this
+         *     endpoint previously raw-SELECTed ``hr.tokens_in`` / ``hr.tokens_out`` from
+         *     ``llc_heartbeat_runs``, columns that never existed on that model
+         *     (GH#13330 — every call 500'd).  The only real per-agent token source is
+         *     ``llc_agent_budgets.tokens_spent`` — a single combined
+         *     ``tokens_in + tokens_out`` lifetime counter (``llc/services/budget.py``'s
+         *     ``ingest_cost_event``), with no per-model dimension and no input/output
+         *     split.  ``input_tokens`` / ``cached_input_tokens`` / ``output_tokens``
+         *     stay ``0`` rather than putting the combined total under
+         *     ``output_tokens`` — the first #13067 attempt did exactly that and applied
+         *     output-rate pricing to input tokens (3-5x over).  The real number is
+         *     reported only in ``total_tokens``.  ``cache_hit_rate`` has no source at
+         *     all — no per-model cache-read counter exists anywhere in the schema — so
+         *     it is ``None`` rather than a fabricated value.
          */
         AgentModelCostRow: {
             /** Agent Id */
@@ -54573,8 +54583,10 @@ export interface components {
             cached_input_tokens: number;
             /** Output Tokens */
             output_tokens: number;
+            /** Total Tokens */
+            total_tokens: number;
             /** Cache Hit Rate */
-            cache_hit_rate: number;
+            cache_hit_rate?: number | null;
             /** Cost Usd */
             cost_usd: string;
         } & {


### PR DESCRIPTION
Closes #13331, #13330

## Thinking Path

Both bugs are in `autobot-backend/llc/`, share the "raw text/private state disconnected from the real object" shape, and are small enough to land in one PR.

**#13331** — `llc/health/probe.py:_collect_metrics()` built its own module-private `lazy_singleton(LivenessMonitor)` / `lazy_singleton(SessionCheckpointer)` instances. `initialization/lifespan.py`'s `_init_liveness_monitor`/`_init_session_checkpointer` construct their own `LivenessMonitor()`/`SessionCheckpointer()` directly (not through that factory) and store them on `app.state.llc_liveness_monitor` / `app.state.llc_session_checkpointer`. The probe's private instances are a completely different object graph that is never `.start()`ed, so `liveness_monitor_running`/`session_checkpointer_running` were permanently `False`. Fix: read `request.app.state` instead, and return a `(wired, running)` pair so "the attribute was never set" (probe not wired to lifespan, or no request context) reports distinctly from "the attribute is set but the object isn't running" (started then stopped, or a caught startup failure recorded `None`).

**#13330** — `llc/api/budget.py`'s `/companies/{company_id}/costs/by-agent-model` raw-SELECTed `hr.tokens_in`/`hr.tokens_out` from `llc_heartbeat_runs`; `llc/models/heartbeat_run.py` has no such columns, so every call raised `UndefinedColumn`/`OperationalError` and 500'd. Read #13067 first (`llc/api/costs.py`'s sibling `/costs/by-agent-model`, fixed for the identical class of bug): the only real per-agent token source is `llc_agent_budgets.tokens_spent`, a single `tokens_in + tokens_out` lifetime total with no per-model dimension and no split. #13067's first attempt was blocked for reporting that combined total as `output_tokens`, which applies output-rate pricing to input tokens (3-5x over). Mirrored the same fix here: add `total_tokens` to `AgentModelCostRow`, keep the split fields at `0`, and source `cost_usd` from the same table's `budget_spent` (a real dollar figure, unlike `input_tokens`). `cache_hit_rate` has no source anywhere in the schema, so it stays `None` rather than a fabricated number.

## What Changed

**`llc/health/probe.py`**
- Removed the private `lazy_singleton(LivenessMonitor)`/`lazy_singleton(SessionCheckpointer)` wiring — this was the bug itself, not an unwired feature; the real objects already exist on `app.state`.
- Added `_app_state_scheduler_state(request, attr) -> (wired, running)`, mirroring `api/system_health.py`'s existing `probe_app_state()` wired/None/value distinction.
- `_collect_metrics()` now takes `request` and returns `liveness_monitor_wired` / `session_checkpointer_wired` alongside the existing `*_running` keys.
- `_compute_status()` treats "unwired" as `down` (a probe-integration failure) and keeps "wired but not running" at `degraded` (unchanged prior behaviour). `.get(key, True)` keeps metrics dicts built before this change (missing the new keys) at their old "assume wired" behaviour.

**`llc/api/budget.py`**
- `costs_by_agent_model()` now queries `LLCAgentBudget` outer-joined to `AgentOrgNode` (ORM, not raw SQL) instead of the nonexistent `hr.tokens_in`/`hr.tokens_out` columns.
- `AgentModelCostRow` gains `total_tokens: int`; `cache_hit_rate` becomes `Optional[float] = None`. `input_tokens`/`cached_input_tokens`/`output_tokens` stay `0` (documented, not fabricated); `cost_usd` sources from `budget_spent`.

**Tests**
- `llc/tests/test_costs_by_agent_model_row.py` (new) — real in-memory SQLite schema (not mocks), same harness `test_costs_by_agent_model.py` (#13067) uses, so a query against a genuinely nonexistent column fails the same way it would against Postgres.
- `llc/tests/test_health_probe.py` — replaced the `_is_liveness_monitor_running`/`_is_session_checkpointer_running` unit tests (which tested the removed private-singleton path) with `_app_state_scheduler_state` unit tests covering all four wired/running combinations, plus `_compute_status` cases for the new unwired-is-worse-than-degraded rule and backward compatibility with pre-existing metrics dicts.
- `initialization/lifespan_test.py` — two new tests start the **real** `LivenessMonitor`/`SessionCheckpointer` through the real `_init_liveness_monitor`/`_init_session_checkpointer` (same precedent as the existing `test_init_liveness_monitor_actually_starts_it`, #13085) and assert `probe_llc()` reports them running, and reports `wired=True, running=False` after a real `aclose()`. These live in `initialization/lifespan_test.py` rather than `llc/tests/` because `llc/tests/conftest.py` stubs `sys.modules["agents"]` at collection time, which breaks `initialization.lifespan`'s own import chain (`api.overseer_handlers -> agents.overseer`) for the rest of the pytest process once that conftest has loaded — confirmed this collides with the *pre-existing* `test_init_liveness_monitor_actually_starts_it` too when both directories are collected in one session (see Verification/Discoveries).
- `llc/tests/test_haiku_tier.py` — updated the two `AgentModelCostRow` schema tests for the new `total_tokens` field and `cache_hit_rate` default.

## Verification

All commands run from `autobot-backend/` via `/opt/autobot/autobot-backend/venv/bin/python3` (project's documented venv, read-only).

**#13331 — before (original `probe.py`, new tests):**
```
$ pytest llc/tests/test_health_probe.py -q
...
9 failed, 27 passed
FAILED test_wired_and_running_when_app_state_has_a_running_instance - ImportError: cannot import name '_app_state_scheduler_state'
FAILED test_status_down_when_liveness_monitor_unwired - AssertionError: assert 'degraded' == 'down'
FAILED test_probe_returns_unwired_down_with_no_request_context - KeyError: 'liveness_monitor_wired'
(+6 more ImportError failures)

$ pytest initialization/lifespan_test.py -q
2 failed, 10 passed
FAILED test_health_probe_reports_liveness_monitor_and_checkpointer_running_via_real_lifespan - KeyError: 'liveness_monitor_wired'
FAILED test_health_probe_reports_wired_but_not_running_after_real_shutdown
```

**#13331 — after (fixed `probe.py`):**
```
$ pytest llc/tests/test_health_probe.py -q
36 passed in 0.39s

$ pytest initialization/lifespan_test.py -q
12 passed in 7.96s
```

**#13330 — before (original `budget.py`, new test):**
```
$ pytest llc/tests/test_costs_by_agent_model_row.py -q
4 failed
sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) no such column: hr.tokens_in
[SQL: SELECT ... COALESCE(SUM(hr.tokens_in), 0) ... FROM agent_org_nodes aon LEFT JOIN llc_heartbeat_runs hr ...]
```

**#13330 — after (fixed `budget.py`):**
```
$ pytest llc/tests/test_costs_by_agent_model_row.py llc/tests/test_haiku_tier.py llc/tests/test_costs_by_agent_model.py -q
31 passed in 4.35s
```

**Regression check — full `llc/tests/` suite:** 1390 passed, 1 skipped, 1 pre-existing failure unrelated to this change (`test_heartbeat_context.py::test_assemble_merges_chunks_from_collections`, a chromadb-client-mock issue in `llc/kb/rag_assembler.py` — confirmed pre-existing, no file this PR touches is anywhere near it). All tests in the two touched files complete in under 2s; nothing added exceeds the 10s budget (#13284).

**Lint/format:** `ruff check`, `flake8 --config=.flake8`, `black --check --line-length=120`, `isort --check --profile=black --line-length=120`, `autoflake --check` all clean on every changed file.

**OpenAPI schema:** dumped via `scripts/audit_api_wiring.py --dump-openapi` (same recipe as `verify-generated-types.yml`, no live DB/Redis needed) and confirmed `AgentModelCostRow` now carries `total_tokens` (required) and `cache_hit_rate` (nullable). Did not hand-run `npm run gen:types` against the full frontend toolchain — `auto-fix-generated-types.yml` self-heals `autobot-frontend/src/types/generated/api.ts` on this PR branch in CI, which is what it exists for.

### Discoveries (not filed as separate issues per task instructions)
- `test_budget_idor.py`, `test_budget_provision.py`, `test_budget_service.py` each have one call taking ~30s in this sandbox (real network connect-timeout retries, unrelated files, not touched here) — worth a look given the "zero tests over 10s" rule (#13284), but out of scope for this PR.
- `llc/tests/conftest.py`'s `sys.modules["agents"]` stub (added to dodge the chromadb import chain) permanently breaks `initialization.lifespan`'s import chain for the rest of any pytest process that also collects `llc/tests/`. This is pre-existing — it also breaks the already-existing `test_init_liveness_monitor_actually_starts_it` when both directories run in one session — and only avoided here by keeping the two new lifespan-integration tests in `initialization/lifespan_test.py`.

### Duplicate-endpoint call
`llc/api/costs.py`'s `GET /costs/by-agent-model?company_id=` (#13067) and `llc/api/budget.py`'s `GET /companies/{company_id}/costs/by-agent-model` (#13330, this PR) now return the same underlying data (`llc_agent_budgets`, `total_tokens`, `cost_usd`) via different URL shapes and slightly different response schemas (`AgentModelCost` vs `AgentModelCostRow`, the latter carrying `cache_hit_rate`/`cost_usd`/split-token fields the former doesn't). No frontend `.vue`/`.ts` caller of either was found beyond the generated OpenAPI types. **Recommendation: subsume `AgentModelCostRow`/budget.py's route into `costs.py`'s `AgentModelCost`** (path-param variant becomes a thin wrapper, or is deprecated in favor of the query-param one) once a consumer is built — today both are unused by the frontend, so consolidating is a product/scope decision rather than a blocking part of either bug fix, and out of scope for this PR.

## Model Used

Sonnet 5
