### PR TITLE
fix(a2a,utils): repair the 15 red tests in utils/ and a2a/ - one production bug, four stale fakes (#13162)

### DIFF
--- a/autobot-backend/a2a/a2a_security_test.py
+++ b/autobot-backend/a2a/a2a_security_test.py
@@ -7,12 +7,18 @@ A2A Security, Tracing & Capability Tests
 
 Issue #968: Unit tests for the new security cards, distributed tracing,
 capability verifier, and updated task manager.
+Issue #13162: TaskManager is Redis-backed (#4502), so its tests build the
+              manager on the shared fake Redis client and read trace events
+              back through get_audit_log() — the persisted trace record —
+              rather than off a stale local Task object.
 """
 
 import time
 from unittest.mock import patch
 
 import pytest
+
+from a2a.conftest import make_redis_mock
 
 # ---------------------------------------------------------------------------
 # SecurityCardSigner tests
@@ -171,7 +177,8 @@ class TestTaskManagerWithTrace:
     def setup_method(self):
         from a2a.task_manager import TaskManager
 
-        self.mgr = TaskManager()
+        with patch("a2a.task_manager.get_redis_client", return_value=make_redis_mock()):
+            self.mgr = TaskManager()
 
     def test_create_task_assigns_trace(self):
         task = self.mgr.create_task("Hello", caller_id="agent:bot")
@@ -189,14 +196,14 @@ class TestTaskManagerWithTrace:
         task = self.mgr.create_task("Test")
         self.mgr.update_state(task.id, TaskState.WORKING)
         self.mgr.update_state(task.id, TaskState.COMPLETED)
-        events = [e.event for e in task.trace_context.events]
+        events = [entry["event"] for entry in self.mgr.get_audit_log(task.id)]
         assert "task.submitted" in events
-        assert "task.state_transition" in events
+        assert events.count("task.state_transition") == 2
 
     def test_cancel_records_trace_event(self):
         task = self.mgr.create_task("Cancel me")
         self.mgr.cancel_task(task.id)
-        events = [e.event for e in task.trace_context.events]
+        events = [entry["event"] for entry in self.mgr.get_audit_log(task.id)]
         assert "task.cancelled" in events
 
     def test_get_audit_log(self):

--- a/autobot-backend/a2a/a2a_test.py
+++ b/autobot-backend/a2a/a2a_test.py
@@ -7,14 +7,17 @@ A2A Protocol Unit Tests
 
 Issue #961: Tests for types, agent_card builder, and task_manager.
 Issue #4502: TaskManager tests now mock Redis instead of the in-process dict.
+Issue #13162: The fake Redis client moved to conftest so every A2A test module
+              shares one implementation that tracks the production commands.
 Uses no network connections and no external dependencies.
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
 from a2a.agent_card import build_agent_card
+from a2a.conftest import make_redis_mock
 from a2a.task_manager import TaskManager
 from a2a.types import AgentCapabilities, AgentCard, AgentSkill, TaskArtifact, TaskState
 
@@ -143,58 +146,6 @@ class TestBuildAgentCard:
 
 
 # ---------------------------------------------------------------------------
-# Redis mock fixture
-# ---------------------------------------------------------------------------
-
-
-def _make_redis_mock():
-    """Return a MagicMock that mimics the subset of redis.Redis used by TaskManager."""
-    store: dict = {}
-    audit_lists: dict = {}
-    task_set: set = set()
-
-    mock = MagicMock()
-
-    def _set(key, value, ex=None):
-        store[key] = value if isinstance(value, str) else value.decode("utf-8")
-
-    def _get(key):
-        v = store.get(key)
-        return v.encode("utf-8") if v is not None else None
-
-    def _sadd(key, member):
-        task_set.add(member if isinstance(member, str) else member.decode("utf-8"))
-
-    def _srem(key, member):
-        task_set.discard(member if isinstance(member, str) else member.decode("utf-8"))
-
-    def _smembers(key):
-        return {m.encode("utf-8") for m in task_set}
-
-    def _rpush(key, value):
-        audit_lists.setdefault(key, []).append(value if isinstance(value, str) else value.decode("utf-8"))
-
-    def _lrange(key, start, end):
-        entries = audit_lists.get(key, [])
-        result = entries[start : end + 1 if end != -1 else None]
-        return [e.encode("utf-8") for e in result]
-
-    def _expire(key, ttl):
-        pass  # TTL not needed in unit tests
-
-    mock.set.side_effect = _set
-    mock.get.side_effect = _get
-    mock.sadd.side_effect = _sadd
-    mock.srem.side_effect = _srem
-    mock.smembers.side_effect = _smembers
-    mock.rpush.side_effect = _rpush
-    mock.lrange.side_effect = _lrange
-    mock.expire.side_effect = _expire
-
-    return mock
-
-
-# ---------------------------------------------------------------------------
 # TaskManager tests
 # ---------------------------------------------------------------------------
 
@@ -202,7 +153,7 @@ def _make_redis_mock():
 class TestTaskManager:
     def setup_method(self):
         """Fresh manager with mocked Redis for each test."""
-        with patch("a2a.task_manager.get_redis_client", return_value=_make_redis_mock()):
+        with patch("a2a.task_manager.get_redis_client", return_value=make_redis_mock()):
             self.mgr = TaskManager()
 
     def test_create_task_returns_task(self):
@@ -339,7 +290,7 @@ class TestTaskManagerEviction:
     """
 
     def setup_method(self):
-        self._redis_mock = _make_redis_mock()
+        self._redis_mock = make_redis_mock()
         with patch("a2a.task_manager.get_redis_client", return_value=self._redis_mock):
             self.mgr = TaskManager()
 
@@ -406,7 +357,7 @@ class TestPublishEvent:
     """
 
     def setup_method(self):
-        self._redis_mock = _make_redis_mock()
+        self._redis_mock = make_redis_mock()
         with patch("a2a.task_manager.get_redis_client", return_value=self._redis_mock):
             self.mgr = TaskManager()
 
@@ -449,7 +400,7 @@ class TestGetTaskTTLSliding:
     """
 
     def setup_method(self):
-        self._redis_mock = _make_redis_mock()
+        self._redis_mock = make_redis_mock()
         with patch("a2a.task_manager.get_redis_client", return_value=self._redis_mock):
             self.mgr = TaskManager()
 
@@ -505,7 +456,7 @@ class TestSaveTTL:
     """
 
     def setup_method(self):
-        self._redis_mock = _make_redis_mock()
+        self._redis_mock = make_redis_mock()
         with patch("a2a.task_manager.get_redis_client", return_value=self._redis_mock):
             self.mgr = TaskManager()
 
@@ -634,7 +585,7 @@ class TestExecuteA2aTaskEvalGate:
     """
 
     def _make_manager(self):
-        with patch("a2a.task_manager.get_redis_client", return_value=_make_redis_mock()):
+        with patch("a2a.task_manager.get_redis_client", return_value=make_redis_mock()):
             mgr = TaskManager()
         return mgr
 

--- a/autobot-backend/a2a/conftest.py
+++ b/autobot-backend/a2a/conftest.py
@@ -1,0 +1,116 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Shared pytest fixtures for the A2A test modules.
+
+Issue #13162: ``TaskManager`` is Redis-backed (#4502) and batches its
+round-trips with MGET/pipelines (#8162).  The fake Redis client used by the
+A2A tests therefore has to model ``mget()`` and ``pipeline()`` as well as the
+plain commands, otherwise tests silently exercise MagicMock defaults instead
+of the real code paths.  This factory is the single canonical fake — both
+``a2a_test.py`` and ``a2a_security_test.py`` build their managers from it.
+"""
+
+from typing import Any, Callable, Dict, List, Set
+from unittest.mock import MagicMock
+
+import pytest
+
+# Commands TaskManager queues on a pipeline before calling execute().
+_PIPELINED_COMMANDS = ("set", "get", "sadd", "srem", "expire", "rpush", "delete", "publish")
+
+
+def _make_pipeline(client: MagicMock) -> MagicMock:
+    """Return a fake pipeline that replays queued commands on execute().
+
+    Mirrors redis-py semantics: commands are buffered, then applied against
+    the same backing store when ``execute()`` is called.  Replaying through
+    ``client`` keeps the top-level call records (e.g. ``client.expire``)
+    authoritative, so assertions do not have to know whether production code
+    pipelined a command or issued it directly.
+    """
+    pipe = MagicMock()
+    queued: List[tuple] = []
+
+    def _queue(name: str) -> Callable[..., MagicMock]:
+        def _record(*args: Any, **kwargs: Any) -> MagicMock:
+            queued.append((name, args, kwargs))
+            return pipe
+
+        return _record
+
+    for command in _PIPELINED_COMMANDS:
+        getattr(pipe, command).side_effect = _queue(command)
+
+    def _execute() -> List[Any]:
+        results = [getattr(client, name)(*args, **kwargs) for name, args, kwargs in queued]
+        queued.clear()
+        return results
+
+    pipe.execute.side_effect = _execute
+    pipe.__enter__.return_value = pipe
+    pipe.__exit__.return_value = False
+    return pipe
+
+
+def make_redis_mock() -> MagicMock:
+    """Return a MagicMock that mimics the subset of redis.Redis used by TaskManager."""
+    store: Dict[str, str] = {}
+    audit_lists: Dict[str, List[str]] = {}
+    task_set: Set[str] = set()
+
+    mock = MagicMock()
+
+    def _decode(value: Any) -> str:
+        return value if isinstance(value, str) else value.decode("utf-8")
+
+    def _set(key, value, ex=None):
+        store[key] = _decode(value)
+
+    def _get(key):
+        value = store.get(key)
+        return value.encode("utf-8") if value is not None else None
+
+    def _mget(keys):
+        return [_get(key) for key in keys]
+
+    def _sadd(key, member):
+        task_set.add(_decode(member))
+
+    def _srem(key, member):
+        task_set.discard(_decode(member))
+
+    def _smembers(key):
+        return {member.encode("utf-8") for member in task_set}
+
+    def _rpush(key, value):
+        audit_lists.setdefault(key, []).append(_decode(value))
+
+    def _lrange(key, start, end):
+        entries = audit_lists.get(key, [])
+        result = entries[start : end + 1 if end != -1 else None]
+        return [entry.encode("utf-8") for entry in result]
+
+    def _expire(key, ttl):
+        pass  # TTL is asserted via call records, not simulated
+
+    mock.set.side_effect = _set
+    mock.get.side_effect = _get
+    mock.mget.side_effect = _mget
+    mock.sadd.side_effect = _sadd
+    mock.srem.side_effect = _srem
+    mock.smembers.side_effect = _smembers
+    mock.rpush.side_effect = _rpush
+    mock.lrange.side_effect = _lrange
+    mock.expire.side_effect = _expire
+    mock.pipeline.side_effect = lambda *args, **kwargs: _make_pipeline(mock)
+
+    return mock
+
+
+@pytest.fixture
+def redis_mock() -> MagicMock:
+    """Fresh fake Redis client for a single test."""
+    return make_redis_mock()

--- a/autobot-backend/a2a/pii_pipeline_test.py
+++ b/autobot-backend/a2a/pii_pipeline_test.py
@@ -15,6 +15,7 @@ Covers:
 - Performance: <5ms p99 on 1KB message (benchmarked via timeit)
 """
 
+import time
 import timeit
 import unittest
 
@@ -346,7 +347,15 @@ class TestIntegration(unittest.TestCase):
 
 class TestPerformance(unittest.TestCase):
     def test_pipeline_under_5ms_p99(self):
-        """Pipeline overhead on 1KB payload must be <5ms p99 (measured over 200 runs)."""
+        """Pipeline overhead on 1KB payload must be <5ms p99 (measured over 200 runs).
+
+        Issue #13162: measured with ``time.thread_time`` (CPU time consumed by
+        this thread) rather than wall clock.  ``scrub()`` is pure regex work
+        with no I/O, so its cost is exactly its CPU time; wall clock also
+        charges the pipeline for every unrelated process the machine happens
+        to be running, which made the budget report false regressions when the
+        suite ran alongside other tests.  The 5ms budget is unchanged.
+        """
         payload = "Task update: " + "x" * 1000  # ~1KB, no PII matches
         pipeline = PIIPipeline()
 
@@ -357,9 +366,9 @@ class TestPerformance(unittest.TestCase):
         for _ in range(10):
             _run()
 
-        times = timeit.repeat(_run, number=1, repeat=200)
+        times = timeit.repeat(_run, number=1, repeat=200, timer=time.thread_time)
         p99_ms = sorted(times)[197] * 1000  # 99th percentile in ms
-        self.assertLess(p99_ms, 5.0, f"p99 latency {p99_ms:.2f}ms exceeds 5ms budget")
+        self.assertLess(p99_ms, 5.0, f"p99 CPU latency {p99_ms:.2f}ms exceeds 5ms budget")
 
 
 if __name__ == "__main__":

--- a/autobot-backend/a2a/task_executor_trust_test.py
+++ b/autobot-backend/a2a/task_executor_trust_test.py
@@ -174,15 +174,16 @@ class TestExecutorRecordsFailure:
 class TestExecutorRecordsThreatEvent:
     @pytest.mark.asyncio
     async def test_inbound_pii_block_records_threat_event(self):
-        from a2a.pii_pipeline import PIIBlocked
+        from a2a.pii_pipeline import PIIBlocked, PIIType
 
         tm = _make_task_manager_mock()
         trust_mgr = MagicMock()
+        blocked = PIIBlocked([PIIType.SSN], peer_id="suspect-agent")
 
         with (
             patch("a2a.task_executor.get_task_manager", return_value=tm),
             patch("a2a.task_executor.get_trust_manager", return_value=trust_mgr),
-            patch("a2a.task_executor.scrub_outbound", side_effect=PIIBlocked("pii found")),
+            patch("a2a.task_executor.scrub_outbound", side_effect=blocked),
         ):
             await execute_a2a_task("task-5", "ssn: 123-45-6789", peer_id="suspect-agent")
 
@@ -192,7 +193,7 @@ class TestExecutorRecordsThreatEvent:
 
     @pytest.mark.asyncio
     async def test_outbound_pii_block_records_threat_event(self):
-        from a2a.pii_pipeline import PIIBlocked
+        from a2a.pii_pipeline import PIIBlocked, PIIType
 
         tm = _make_task_manager_mock()
         trust_mgr = MagicMock()
@@ -212,7 +213,7 @@ class TestExecutorRecordsThreatEvent:
                 result.redaction_count = 0
                 return result
             # Outbound response: blocked
-            raise PIIBlocked("secret in response")
+            raise PIIBlocked([PIIType.API_KEY], peer_id="suspect-agent")
 
         with (
             patch("a2a.task_executor.get_task_manager", return_value=tm),

--- a/autobot-backend/a2a/trust_score.py
+++ b/autobot-backend/a2a/trust_score.py
@@ -409,7 +409,7 @@ class TrustScoreManager:
         )
         record.current_level = new_level
         record.last_level_change_at = time.time()
-        self._snapshot(record, old_level, new_level)
+        self._snapshot(record, old_level, new_level, reason=reason)
 
     # ------------------------------------------------------------------
     # Redis persistence

--- a/autobot-backend/utils/file_locking_test.py
+++ b/autobot-backend/utils/file_locking_test.py
@@ -358,35 +358,58 @@ class TestConcurrentFileWriteSafety:
 
     @pytest.mark.asyncio
     async def test_different_files_can_write_concurrently(self):
-        """Test that writes to different files happen concurrently"""
-        import time
+        """Writes to different files must hold their locks concurrently.
 
+        Issue #13162: the previous version inferred concurrency from wall-clock
+        elapsed time (<0.04s for five 10ms critical sections), which reported a
+        serialization regression whenever the machine was merely busy — it was
+        already relaxed once for the same reason (#11954). This version proves
+        the property directly: every writer parks inside its own critical
+        section until all five are inside simultaneously. A shared (serialized)
+        lock makes that state unreachable, so the wait times out and the test
+        fails with a clear message instead of depending on scheduler timing.
+        """
         import aiofiles
 
         from api.filesystem_mcp import _get_file_lock
 
+        writer_count = 5
+        # Generous: only a genuinely serialized lock can exhaust this.
+        rendezvous_timeout = 10.0
+
         with tempfile.TemporaryDirectory() as tmpdir:
-            start_times = {}
-            end_times = {}
+            inside = 0
+            all_inside = asyncio.Event()
+            peak_concurrency = 0
 
             async def write_to_file(file_num: int):
+                nonlocal inside, peak_concurrency
                 test_file = Path(tmpdir) / f"file_{file_num}.txt"
                 lock = await _get_file_lock(str(test_file))
                 async with lock:
-                    start_times[file_num] = time.time()
                     async with aiofiles.open(test_file, "w", encoding="utf-8") as f:
                         await f.write(f"Content {file_num}")
-                    await asyncio.sleep(0.01)  # Small delay to detect serialization
-                    end_times[file_num] = time.time()
+                    inside += 1
+                    peak_concurrency = max(peak_concurrency, inside)
+                    if inside == writer_count:
+                        all_inside.set()
+                    try:
+                        await asyncio.wait_for(all_inside.wait(), timeout=rendezvous_timeout)
+                    except asyncio.TimeoutError:
+                        # Serialized: release the other writers so the run ends
+                        # cleanly; peak_concurrency below reports the failure.
+                        all_inside.set()
+                    finally:
+                        inside -= 1
 
-            # Write to 5 different files
-            await asyncio.gather(*[write_to_file(i) for i in range(5)])
+            await asyncio.gather(*[write_to_file(i) for i in range(writer_count)])
 
-            # If writes were serialized, total time would be ~50ms
-            # If concurrent, should be close to 10ms. Threshold has headroom
-            # above the 10ms sleep for scheduler jitter (#11954 flaky at 0.03).
-            total_elapsed = max(end_times.values()) - min(start_times.values())
-            assert total_elapsed < 0.04, f"Writes appear serialized: {total_elapsed:.3f}s (expected <0.04s)"
+            assert peak_concurrency == writer_count, (
+                f"Writes to different files are serialized: only {peak_concurrency} of "
+                f"{writer_count} per-file locks were held at the same time"
+            )
+            for file_num in range(writer_count):
+                assert (Path(tmpdir) / f"file_{file_num}.txt").read_text(encoding="utf-8") == f"Content {file_num}"
 
 
 class TestLockPatternConsistency:


### PR DESCRIPTION
Closes #13162

> **PARTIAL — #13162 must stay open.** This PR fixes only two of the campaign's
> clusters (`autobot-backend/utils/` and `autobot-backend/a2a/`). Other agents
> are working the remaining clusters, so the umbrella issue is not resolved by
> this change and must be reopened if the close keyword fires on merge.

## Thinking Path

Baseline first: the two directories ran 15 red. Every failure was diagnosed
before anything was touched, because a red test is as likely to be right as the
code under it. One turned out to be a production bug; the rest were tests that
had drifted behind refactors of the code they cover, or that measured a property
by proxy instead of asserting it.

**Production bug — the trust audit trail recorded no reason.**
`TrustScoreManager._apply_level_change()` takes a `reason` argument, logs it,
then calls `self._snapshot(record, old_level, new_level)` — dropping it.
`_snapshot()` declares `reason: str = ""`, so every row ever written to the
`trust_audit` SQLite table stored an empty reason. The audit log could not
distinguish a peer demoted for a threat event from one demoted for an integrity
violation or an ordinary score update, which is the entire point of the table.
`trust_score_test.TestGetAuditLog.test_threat_event_audit_entry` asserted
`"threat_event" in reasons` and got `['', '']`. The test was right; the reason
is now forwarded.

**Stale fake — the A2A Redis double predates two refactors of the code it stands
in for.** Issue #8162 batched `TaskManager` round-trips into `MGET` and
pipelines. The fake implemented neither, so `mget()` returned a bare `MagicMock`
whose default iteration is empty (`list_tasks()` silently saw zero tasks, and
`stats()` with it), and every `EXPIRE` issued through `pipeline()` landed on an
anonymous child mock rather than the client, so the TTL-sliding test counted
zero. Nothing was wrong with `task_manager.py` — the double had stopped
modelling it. It now implements `mget()` and a pipeline that buffers commands
and replays them through the same client on `execute()`, matching redis-py
semantics and keeping the client's call records authoritative, so assertions do
not have to know whether production code pipelined a command or issued it
directly.

**Stale setup — `TestTaskManagerWithTrace` predates the Redis-backed store.**
Issue #4502 replaced the in-process dict with Redis; this class still built a
bare `TaskManager()`. With no Redis reachable the client is `None` and all seven
tests died on `AttributeError: 'NoneType' object has no attribute 'set'`. Two of
them also read trace events off the local `Task` object after calling
`update_state()`/`cancel_task()` — valid when the manager handed back the very
object it stored, meaningless now that it round-trips through Redis and mutates
reloaded copies. The persisted trace record is the audit log, so those two now
assert through `get_audit_log()`, and the state-transition test pins the event
count at two rather than merely checking membership.

**Wrong constructor — the PII block never reached the executor's handler.**
`task_executor_trust_test` raised `PIIBlocked("pii found")`. The exception's
signature is `(blocked_types: List[PIIType], peer_id)`, and building its message
does `", ".join(t.value for t in blocked_types)` — over a string, that iterates
characters and dies with `AttributeError` inside `__init__`. The executor caught
that as a generic task failure instead of a PII block, so
`record_threat_event()` was never called. Constructed with real `PIIType`
values, both tests pass unchanged, confirming the executor wiring was correct
all along.

**Two timing proxies.** The PII pipeline p99 budget and the per-file lock
concurrency check both passed alone and failed when the suites ran together —
they were measuring the machine, not the code.

- The PII budget used the wall clock, which charges the pipeline for every
  unrelated process the host happens to run. `scrub()` is pure regex work with
  no I/O, so its cost is exactly its CPU time; the measurement moves to
  `time.thread_time`. The 5ms budget is unchanged, and observed p99 is ~1.3ms.
- `test_different_files_can_write_concurrently` inferred lock independence from
  elapsed time (five 10ms critical sections had to finish inside 40ms). The
  threshold had already been relaxed once for exactly this flakiness (#11954).
  It now asserts the property itself: every writer parks inside its own critical
  section until all five are inside simultaneously, and peak concurrency must
  equal the writer count. A serialized lock makes that state unreachable.

No test was skipped, xfailed, or had an assertion loosened. The two rewritten
timing tests are strictly stronger than what they replace, and the concurrency
one was mutation-checked (see Verification).

**Discovered, filed rather than fixed here — #13339.** The `AttributeError` that
killed `TestTaskManagerWithTrace` exposed a real production shape problem:
`TaskManager` resolves `get_redis_client()` once in `__init__`, the module
builds the singleton at import, and `get_redis_client()` documents `None` as a
return value. So a backend that starts while Redis is down has a permanently
broken A2A task store — no `None` check, and no re-resolution after Redis
recovers. `TrustScoreManager`, in the same package, resolves per call and
degrades explicitly; `TaskManager` should match it. That change moves where
every A2A test has to patch Redis, so it is a refactor with its own blast
radius rather than part of a test-repair PR.

## What Changed

**Production**

- `autobot-backend/a2a/trust_score.py` — `_apply_level_change()` forwards
  `reason` to `_snapshot()`, so trust audit rows record why the level changed.

**Tests**

- `autobot-backend/a2a/conftest.py` *(new)* — canonical fake Redis client for
  the A2A tests, now modelling `mget()` and `pipeline()`. Lives in `conftest` so
  both A2A test modules share one implementation instead of drifting apart
  again; also exposed as a `redis_mock` fixture.
- `autobot-backend/a2a/a2a_test.py` — drops its local copy of the fake in favour
  of the shared one.
- `autobot-backend/a2a/a2a_security_test.py` — `TestTaskManagerWithTrace` builds
  its manager on the shared fake; the two trace assertions read the persisted
  audit log instead of a stale local `Task`.
- `autobot-backend/a2a/task_executor_trust_test.py` — `PIIBlocked` constructed
  with `PIIType` values and a peer id, per its signature.
- `autobot-backend/a2a/pii_pipeline_test.py` — p99 measured with
  `time.thread_time`; budget unchanged at 5ms.
- `autobot-backend/utils/file_locking_test.py` — concurrency proven by a
  rendezvous inside the critical sections instead of by wall clock; the test
  also now checks each file received its own content, which the timing version
  never did.

## Verification

Command (network and Redis unavailable, as expected):

```
export SLM_SECRET_KEY=throwaway SLM_ENCRYPTION_KEY=x
PYTHONPATH="$PWD/autobot-backend:$PWD" python3 -m pytest \
  autobot-backend/utils autobot-backend/a2a -q -p no:cacheprovider \
  -m "not integration and not slow and not distributed and not performance"
```

Before:

```
15 failed, 683 passed, 14 skipped, 42 warnings in 573.15s (0:09:33)
```

After:

```
696 passed, 14 skipped, 2 deselected, 42 warnings in 410.48s (0:06:50)
```

All 15 previously-failing tests pass and nothing that was passing regressed:
683 + 15 - 2 = 696, with the skip count unchanged at 14. The 2 deselected are
`utils/simple_optimization_test.py`, which upstream marked
`pytest.mark.performance` in #13284 and which this branch picked up when it was
rebased onto the current `Dev_new_gui`; the marker filter in the command above
excludes them. Nothing in this PR skips or marks anything.

Mutation check that the rewritten concurrency test is not vacuous — with
`_get_file_lock` replaced by a single global lock:

```
MUTATION CAUGHT: Writes to different files are serialized: only 1 of 5 per-file locks were held at the same time
```

Gates (run on the seven touched files):

```
python3 -m isort --settings-path=. <files>     # clean
python3 -m black --line-length=120 <files>     # 7 files left unchanged
python3 -m flake8 --config=.flake8 <files>     # 0
python3 -m bandit -c .bandit -r autobot-backend/a2a autobot-backend/utils
                                               # No issues identified
```

## Model Used

Claude Opus 5 (`claude-opus-5[1m]`) under Claude Code.
