### PR TITLE
fix(security): green the security/ and multimodal_processor/ test clusters — 3 production bugs, rest stale-test repointing (#13162)

### DIFF
--- a/autobot-backend/encryption_service.py
+++ b/autobot-backend/encryption_service.py
@@ -59,10 +59,10 @@ class EncryptionService:
 
     def _load_master_key(self) -> str | None:
         """Load master key from environment variables."""
-        key = config.encryption_key
-        if not key:
-            # Try alternative environment variable names
-            key = config.encryption_key or config.master_key
+        # AUTOBOT_ENCRYPTION_KEY / ENCRYPTION_KEY first, then MASTER_KEY.
+        # (#13162: the old two-step form re-tested config.encryption_key
+        # inside its own `if not key` branch — same result, twice the read.)
+        key = config.encryption_key or config.master_key
 
         if not key:
             logger.error("No encryption key found in environment variables. " "Please set AUTOBOT_ENCRYPTION_KEY.")

--- a/autobot-backend/multimodal_processor/multimodal_system_integration_test.py
+++ b/autobot-backend/multimodal_processor/multimodal_system_integration_test.py
@@ -8,19 +8,25 @@ Tests component integration, processing workflows, and system reliability
 import time
 from unittest.mock import AsyncMock, Mock, patch
 
+import numpy as np
 import pytest
+import torch
 
+from computer_vision.types import ScreenState
 from computer_vision_system import ComputerVisionSystem
 from config.manager import ConfigManager as ConfigManager
+from memory.enums import MemoryCategory
 from multimodal_processor import (
     ContextProcessor,
     ModalityType,
     MultiModalInput,
     MultiModalProcessor,
     ProcessingIntent,
+    ProcessingResult,
     VisionProcessor,
     VoiceProcessor,
 )
+from multimodal_processor.processors import vision, voice
 
 
 class TestUnifiedMultiModalSystem:
@@ -53,10 +59,21 @@ class TestUnifiedMultiModalSystem:
 
     @pytest.fixture
     def processor(self, mock_config):
-        """Create unified processor with mocked config"""
-        with patch(
-            "multimodal_processor.processors.vision.get_config_section",
-            lambda section: mock_config.get_config_section(section),
+        """Create unified processor with mocked config.
+
+        ``torch.cuda.is_available()`` is pinned False: autobot-backend/
+        conftest.py substitutes a bare ``MagicMock`` for torch when the real
+        package is absent, so the CUDA branch of
+        ``MultiModalProcessor.__init__`` would otherwise run against Mock
+        device properties. Neither CI nor the dev box has a GPU, so False is
+        the truthful answer.
+        """
+        with (
+            patch(
+                "multimodal_processor.processors.vision.get_config_section",
+                lambda section: mock_config.get_config_section(section),
+            ),
+            patch.object(torch.cuda, "is_available", return_value=False),
         ):
             return MultiModalProcessor()
 
@@ -156,18 +173,30 @@ class TestUnifiedMultiModalSystem:
             metadata={"image": b"fake_image_data", "audio": b"fake_audio_data"},
         )
 
-        # Mock both processors
-        vision_result = Mock(
+        # Real ProcessingResult instances: _simple_combination
+        # (processor.py:485) deliberately skips anything that is not a
+        # ProcessingResult, because asyncio.gather(return_exceptions=True)
+        # can hand it raw exceptions. Mocks are silently dropped by that
+        # guard, so they can never exercise the combination logic.
+        vision_result = ProcessingResult(
+            result_id="vision_test_combined_001_image",
+            input_id="test_combined_001_image",
+            modality_type=ModalityType.IMAGE,
+            intent=ProcessingIntent.AUTOMATION_TASK,
             success=True,
             confidence=0.8,
             result_data={"elements": ["button"]},
-            modality_type=ModalityType.IMAGE,
+            processing_time=0.1,
         )
-        voice_result = Mock(
+        voice_result = ProcessingResult(
+            result_id="voice_test_combined_001_audio",
+            input_id="test_combined_001_audio",
+            modality_type=ModalityType.AUDIO,
+            intent=ProcessingIntent.AUTOMATION_TASK,
             success=True,
             confidence=0.9,
             result_data={"command": "click button"},
-            modality_type=ModalityType.AUDIO,
+            processing_time=0.1,
         )
 
         with (
@@ -193,7 +222,8 @@ class TestUnifiedMultiModalSystem:
             assert "results" in result.result_data
             assert len(result.result_data["results"]) == 2
             assert result.result_data["success_count"] == 2
-            assert result.result_data["confidence"] == 0.85  # Average of 0.8 and 0.9
+            # Average of 0.8 and 0.9 — binary float sum is not exactly 0.85.
+            assert result.result_data["confidence"] == pytest.approx(0.85)
 
     @pytest.mark.asyncio
     async def test_processing_error_handling(self, processor):
@@ -215,9 +245,13 @@ class TestUnifiedMultiModalSystem:
             # Process should handle error gracefully
             result = await processor.process(error_input)
 
-            # Verify error handling
+            # Verify error handling. `_create_error_result` (processor.py:132)
+            # stores the bare `str(error)`, matching every sibling processor;
+            # "Multi-modal processing failed: %s" is only the log line.
             assert result.success is False
-            assert result.error_message == "Multi-modal processing failed: Processing failed"
+            assert result.error_message == "Processing failed"
+            assert result.result_id == "unified_test_error_001"
+            assert result.result_data is None
             assert result.confidence == 0.0
 
     def test_statistics_tracking(self, processor):
@@ -275,22 +309,24 @@ class TestUnifiedMultiModalSystem:
             data="test decision context",
         )
 
-        # Mock context processor and memory manager
+        # Issue #10626 replaced the non-existent MemoryManager.store_task()
+        # with store_memory(); patch what production actually calls.
         with (
             patch.object(processor.context_processor, "process", new_callable=AsyncMock) as mock_process,
-            patch.object(processor.memory_manager, "store_task", new_callable=AsyncMock) as mock_store,
+            patch.object(processor.memory_manager, "store_memory", new_callable=AsyncMock) as mock_store,
         ):
-            mock_result = Mock(
+            mock_result = ProcessingResult(
                 result_id="context_test_memory_001",
+                input_id="test_memory_001",
+                modality_type=ModalityType.TEXT,
+                intent=ProcessingIntent.DECISION_MAKING,
                 success=True,
                 confidence=0.95,
-                processing_time=0.3,
                 result_data={
                     "decision": "proceed",
                     "reasoning": "context supports action",
                 },
-                modality_type=ModalityType.TEXT,
-                intent=ProcessingIntent.DECISION_MAKING,
+                processing_time=0.3,
             )
             mock_process.return_value = mock_result
 
@@ -300,9 +336,12 @@ class TestUnifiedMultiModalSystem:
             # Verify result storage was attempted
             mock_store.assert_called_once()
             call_args = mock_store.call_args[1]
-            assert call_args["task_id"] == "context_test_memory_001"
-            assert call_args["task_type"] == "multimodal_processing"
-            assert call_args["status"] == "completed"
+            assert call_args["category"] is MemoryCategory.EXECUTION
+            metadata = call_args["metadata"]
+            assert metadata["result_id"] == "context_test_memory_001"
+            assert metadata["task_type"] == "multimodal_processing"
+            assert metadata["status"] == "completed"
+            assert metadata["modality"] == ModalityType.TEXT.value
 
     def test_vision_processor_configuration(self, mock_config):
         """Test vision processor uses configuration correctly"""
@@ -334,19 +373,34 @@ class TestUnifiedMultiModalSystem:
                 data=b"fake_image_data",
             )
 
-            # Process image (will use placeholder logic)
             result = await vision_proc.process(image_input)
 
-            # Verify basic processing structure
-            assert result.success is True
+            # Envelope contract holds on both branches (#6755: never raise).
             assert result.result_id == "vision_vision_test_001"
+            assert result.input_id == "vision_test_001"
             assert result.modality_type == ModalityType.IMAGE
             assert isinstance(result.processing_time, float)
             assert result.processing_time > 0
 
+            if vision.VISION_MODELS_AVAILABLE and vision_proc.clip_model and vision_proc.blip_model:
+                assert result.success is True
+                assert result.error_message is None
+            else:
+                # Issue #466 removed the placeholder fallback: the guard in
+                # vision._process_image raises RuntimeError, and process()
+                # must degrade it to a failure envelope.
+                assert result.success is False
+                assert result.result_data is None
+                assert "Vision processing unavailable" in result.error_message
+
     @pytest.mark.asyncio
     async def test_voice_processor_audio_processing(self):
-        """Test voice processor audio processing"""
+        """Voice processing returns a well-formed envelope, models or not.
+
+        Same #466/#6755 contract as the vision case: the model guard in
+        voice._validate_audio_models_available raises RuntimeError and
+        process() must convert it into a failure ProcessingResult.
+        """
         voice_proc = VoiceProcessor()
 
         # Create audio input
@@ -357,18 +411,30 @@ class TestUnifiedMultiModalSystem:
             data=b"fake_audio_data",
         )
 
-        # Process audio (will use placeholder logic)
         result = await voice_proc.process(audio_input)
 
-        # Verify basic processing structure
-        assert result.success is True
         assert result.result_id == "voice_voice_test_001"
+        assert result.input_id == "voice_test_001"
         assert result.modality_type == ModalityType.AUDIO
         assert isinstance(result.processing_time, float)
 
+        if voice.AUDIO_MODELS_AVAILABLE and voice_proc.whisper_model and voice_proc.wav2vec_model:
+            assert result.success is True
+            assert result.error_message is None
+        else:
+            assert result.success is False
+            assert result.result_data is None
+            assert "Voice processing unavailable" in result.error_message
+
     @pytest.mark.asyncio
     async def test_context_processor_decision_making(self):
-        """Test context processor decision making"""
+        """Context decision making is unimplemented and must say so (#466).
+
+        ``ContextProcessor._process_context`` deliberately raises
+        NotImplementedError instead of returning placeholder decisions.
+        ``process()`` must surface that as a failure envelope rather than
+        propagating the exception to callers.
+        """
         context_proc = ContextProcessor()
 
         # Create context input
@@ -379,14 +445,15 @@ class TestUnifiedMultiModalSystem:
             data="Make a decision based on this context",
         )
 
-        # Process context (will use placeholder logic)
         result = await context_proc.process(context_input)
 
-        # Verify basic processing structure
-        assert result.success is True
         assert result.result_id == "context_context_test_001"
+        assert result.input_id == "context_test_001"
         assert result.modality_type == ModalityType.TEXT
         assert isinstance(result.processing_time, float)
+        assert result.success is False
+        assert result.result_data is None
+        assert "Context processing not yet implemented" in result.error_message
 
     def test_processor_confidence_calculation(self):
         """Test confidence calculation in base processor"""
@@ -403,16 +470,23 @@ class TestUnifiedMultiModalSystem:
         """Test integration with computer vision system"""
         cv_system = ComputerVisionSystem()
 
-        # Mock the screen analyzer and its dependencies
+        # Stub the analyzer with a real ScreenState: ComputerVisionSystem
+        # calls screen_state.get_analysis_summary() / get_element_collection()
+        # (computer_vision/system.py:39-57), which a bare Mock cannot satisfy —
+        # it would hand back un-subscriptable Mock objects.
         with patch.object(cv_system.screen_analyzer, "analyze_current_screen", new_callable=AsyncMock) as mock_analyze:
-            mock_screen_state = Mock(
+            screen_state = ScreenState(
                 timestamp=time.time(),
+                screenshot=np.zeros((2, 2, 3), dtype=np.uint8),
                 ui_elements=[],
-                confidence_score=0.8,
-                context_analysis={"application_type": "test"},
+                text_regions=[],
+                dominant_colors=[],
+                layout_structure={},
                 automation_opportunities=[],
+                context_analysis={"application_type": "test"},
+                confidence_score=0.8,
             )
-            mock_analyze.return_value = mock_screen_state
+            mock_analyze.return_value = screen_state
 
             # Analyze screen
             result = await cv_system.analyze_and_understand_screen()

--- a/autobot-backend/security/config_security_test.py
+++ b/autobot-backend/security/config_security_test.py
@@ -13,7 +13,7 @@ from unittest.mock import patch
 import pytest
 
 from autobot_shared.logging_manager import get_logger
-from config.loader import load_yaml_config
+from config.loader import _convert_env_value, load_yaml_config
 from config.manager import ConfigManager as ConfigManager
 
 
@@ -52,10 +52,16 @@ class TestConfigurationSecurity:
             assert result["backend"]["llm"]["local"]["provider"] == "ollama"
 
     def test_environment_variable_injection_protection(self):
-        """Test protection against environment variable injection"""
-        config_manager = ConfigManager()
+        """Environment overrides are allowlisted, and applied verbatim.
 
-        # Test with potentially malicious environment variables
+        #13162: this test used to assume ConfigManager derived config keys
+        from arbitrary ``AUTOBOT_*`` variable names. It never did, and it
+        must not: ``config.loader.apply_env_overrides()`` walks a fixed
+        ``ENV_VAR_MAPPINGS`` allowlist (loader.py:27-71), which *is* the
+        injection protection. Pin both halves — unmapped names are ignored
+        entirely, and a mapped name carrying a shell payload is stored as an
+        inert string.
+        """
         with patch.dict(
             os.environ,
             {
@@ -63,19 +69,22 @@ class TestConfigurationSecurity:
                 "AUTOBOT_SCRIPT_INJECTION": "$(malicious_command)",
                 "AB_XSS_ATTEMPT": '<script>alert("xss")</script>',
                 "SHELL_INJECTION": "; malicious_command; echo",
+                # Allowlisted name (ENV_VAR_MAPPINGS -> ["ui", "theme"]).
+                "AUTOBOT_UI_THEME": "$(malicious_command)",
             },
         ):
-            # Environment variables should be returned as-is but not executed
-            dangerous_cmd = config_manager.get("dangerous.command")
-            script_injection = config_manager.get("script.injection")
-            xss_attempt = config_manager.get("xss.attempt")
-            shell_injection = config_manager.get("shell.injection", "default")
+            # Constructed inside the patch: overrides are applied on load.
+            config_manager = ConfigManager()
 
-            # Values should be retrieved but not interpreted as commands
-            assert dangerous_cmd == "rm -rf /"  # Raw value, not executed
-            assert script_injection == "$(malicious_command)"  # Not evaluated
-            assert xss_attempt == '<script>alert("xss")</script>'  # Not sanitized at config level
-            assert shell_injection == "default"  # Should use default if not found
+            # Unmapped names never become config keys, under any spelling.
+            assert config_manager.get_nested("dangerous.command") is None
+            assert config_manager.get_nested("script.injection") is None
+            assert config_manager.get_nested("xss.attempt") is None
+            assert config_manager.get("shell.injection", "default") == "default"
+            assert "AUTOBOT_DANGEROUS_COMMAND" not in config_manager.to_dict()
+
+            # Mapped names land at their mapped path as raw, unevaluated text.
+            assert config_manager.get_nested("ui.theme") == "$(malicious_command)"
 
     def test_yaml_deserialization_safety(self):
         """Test YAML deserialization safety against malicious payloads"""
@@ -121,17 +130,20 @@ args: [["echo", "exploit"]]
         """Test that sensitive data is not accidentally exposed"""
         config_manager = ConfigManager()
 
-        # Set some sensitive data
-        config_manager.set("database.password", "super_secret_password")
-        config_manager.set("api.keys.openai", "sk-very-secret-key")
-        config_manager.set("security.secrets_key", "encryption_key_123")
+        # #13162: set()/get() are the flat key pair and set_nested()/
+        # get_nested() the dot-notation pair (config/sync_ops.py:36-76).
+        # Nested assertions need the nested setters.
+        config_manager.set_nested("database.password", "super_secret_password")
+        config_manager.set_nested("api.keys.openai", "sk-very-secret-key")
+        config_manager.set_nested("security.secrets_key", "encryption_key_123")
 
-        # Test that get_all_config doesn't expose everything by default in logs
-        all_config = config_manager.get_all_config()
+        # #13162: get_all_config() never existed; to_dict() (config/
+        # sync_ops.py:133) is the whole-config accessor.
+        all_config = config_manager.to_dict()
 
         # Sensitive data should be accessible via direct key access
-        assert config_manager.get("database.password") == "super_secret_password"
-        assert config_manager.get("api.keys.openai") == "sk-very-secret-key"
+        assert config_manager.get_nested("database.password") == "super_secret_password"
+        assert config_manager.get_nested("api.keys.openai") == "sk-very-secret-key"
 
         # But should be present in all_config (caller responsible for handling)
         assert "database" in all_config
@@ -155,15 +167,20 @@ args: [["echo", "exploit"]]
         }
 
         for key, value in malicious_configs.items():
-            config_manager.set(key, value)
+            config_manager.set_nested(key, value)
 
-        # Validation should identify potential issues
-        issues = config_manager.validate_config()
+        # Validation should complete and report structurally, not raise.
+        # #13162: validate_config() returns a status *dict* whose "issues"
+        # key holds the list (config/validation.py:218-237) — the old
+        # `isinstance(status, list)` assertion predates that shape.
+        status = config_manager.validate_config()
 
-        # Should validate without throwing errors
-        assert isinstance(issues, list)
-        # Note: The current validation doesn't check for malicious hosts,
-        # but it should at least complete without errors
+        assert isinstance(status, dict)
+        assert status["config_loaded"] is True
+        assert isinstance(status["issues"], list)
+        # Malicious values are stored verbatim, never executed or resolved.
+        assert config_manager.get_nested("redis.host") == "attacker-redis.com"
+        assert config_manager.get_nested("security.allowed_commands") == ["rm -rf /"]
 
     def test_config_file_permissions_handling(self):
         """Test handling of config files with various permissions"""
@@ -204,10 +221,12 @@ backend:
             os.rmdir(tmp_dir)
 
     def test_environment_variable_name_sanitization(self):
-        """Test that environment variable names are properly sanitized"""
-        config_manager = ConfigManager()
+        """Odd env var names cannot manufacture config keys.
 
-        # Test with various potentially problematic env var names
+        #13162: name matching is exact against ENV_VAR_MAPPINGS, so no
+        name — however it is punctuated — is ever *derived* into a config
+        path. Loading with these variables present must also not raise.
+        """
         with patch.dict(
             os.environ,
             {
@@ -217,13 +236,19 @@ backend:
                 "AUTOBOT_KEY_WITH_123": "numbered_value",
             },
         ):
-            # Normal key should work
-            assert config_manager.get("normal.key") == "normal_value"
+            config_manager = ConfigManager()
 
-            # Keys with special characters should be handled
-            # The _get_env_var method should handle conversion properly
-            dotted_value = config_manager.get("key.with.dots")
-            assert dotted_value in ["dotted_value", None]  # Depends on conversion logic
+            for derived_key in (
+                "normal.key",
+                "key.with.dots",
+                "key-with-dashes",
+                "key.with.123",
+            ):
+                assert config_manager.get_nested(derived_key) is None
+                assert config_manager.get(derived_key) is None
+
+            # The load itself stays healthy — defaults are still in place.
+            assert config_manager.get_nested("backend.llm.local.provider") == "ollama"
 
     def test_config_injection_via_yaml_anchors(self):
         """Test protection against YAML anchor-based injection"""
@@ -326,33 +351,27 @@ section_b:
             os.rmdir(tmp_dir)
 
     def test_environment_variable_type_confusion(self):
-        """Test protection against type confusion in environment variables"""
-        config_manager = ConfigManager()
+        """Env value coercion is total and never raises.
 
-        # Test with environment variables that might cause type confusion
-        with patch.dict(
-            os.environ,
-            {
-                "AUTOBOT_FAKE_BOOL": "True",  # Capital T, might be confused with bool
-                "AUTOBOT_FAKE_INT": "123abc",  # Starts with number but has letters
-                "AUTOBOT_FAKE_FLOAT": "3.14.159",  # Invalid float format
-                "AUTOBOT_FAKE_LIST": "item1,item2,",  # Trailing comma
-            },
-        ):
-            # Should handle type parsing errors gracefully
-            fake_bool = config_manager.get("fake.bool")
-            fake_int = config_manager.get("fake.int")
-            fake_float = config_manager.get("fake.float")
-            fake_list = config_manager.get("fake.list")
+        #13162: the old body read unmapped ``AUTOBOT_FAKE_*`` names, which
+        never enter config at all. The coercion that *does* run on every
+        allowlisted override is ``config.loader._convert_env_value()``
+        (loader.py:158-173): "true"/"false" -> bool, all-digits -> int,
+        anything else -> the untouched string. Exercise that directly with
+        the ambiguous payloads.
+        """
+        assert _convert_env_value("True") is True  # case-insensitive bool
+        assert _convert_env_value("false") is False
+        assert _convert_env_value("123") == 123  # pure digits -> int
+        assert _convert_env_value("123abc") == "123abc"  # letters -> stays a string
+        assert _convert_env_value("3.14.159") == "3.14.159"  # invalid float -> string
+        assert _convert_env_value("item1,item2,") == "item1,item2,"  # never split
+        assert _convert_env_value("") == ""  # empty is not an error
 
-            # Should return parsed values or original strings without errors
-            assert fake_bool in [
-                True,
-                "True",
-            ]  # Might be parsed as bool or kept as string
-            assert fake_int == "123abc"  # Should remain string due to letters
-            assert fake_float == "3.14.159"  # Should remain string due to invalid format
-            assert isinstance(fake_list, (list, str))  # Should handle trailing comma
+        # And the mapped path receives exactly that coerced value.
+        with patch.dict(os.environ, {"AUTOBOT_REDIS_ENABLED": "false"}):
+            config_manager = ConfigManager()
+            assert config_manager.get_nested("memory.redis.enabled") is False
 
     def test_config_backup_and_recovery_security(self):
         """Test security of config backup and recovery operations"""
@@ -431,11 +450,12 @@ class TestSecretsHandlingInConfig:
         import yaml
 
         config_manager = ConfigManager()
-        config_manager.set("public.setting", "public_value")
-        config_manager.set("secret.api_key", "secret_key_value")
+        config_manager.set_nested("public.setting", "public_value")
+        config_manager.set_nested("secret.api_key", "secret_key_value")
 
-        # Get all config
-        all_config = config_manager.get_all_config()
+        # #13162: to_dict() is the whole-config accessor; get_all_config()
+        # never existed on ConfigManager.
+        all_config = config_manager.to_dict()
 
         # Verify secrets are in the config (as expected)
         assert all_config["secret"]["api_key"] == "secret_key_value"

--- a/autobot-backend/security/encryption_service_test.py
+++ b/autobot-backend/security/encryption_service_test.py
@@ -7,14 +7,33 @@ Unit tests for the EncryptionService module.
 
 import os
 import unittest
+from contextlib import contextmanager
 from unittest.mock import patch
 
+from autobot_shared.ssot_config import reload_config
 from encryption_service import (
     EncryptionService,
     decrypt_data,
     encrypt_data,
     is_encryption_enabled,
 )
+
+
+@contextmanager
+def encryption_key_env(value: str):
+    """Publish an encryption key through the environment, SSOT-aware.
+
+    ``autobot_shared.ssot_config.get_config()`` is an ``lru_cache``
+    singleton, so patching ``os.environ`` alone is invisible to
+    ``config.encryption_key``. Reload inside the patch, and again on the way
+    out so the cached singleton does not leak the test key into other tests.
+    """
+    try:
+        with patch.dict(os.environ, {"AUTOBOT_ENCRYPTION_KEY": value}):
+            reload_config()
+            yield
+    finally:
+        reload_config()
 
 
 class TestEncryptionService(unittest.TestCase):
@@ -36,10 +55,10 @@ class TestEncryptionService(unittest.TestCase):
         with self.assertRaises(ValueError):
             EncryptionService()
 
-    @patch.dict(os.environ, {"AUTOBOT_ENCRYPTION_KEY": "env_test_key"})
     def test_initialization_from_environment(self):
         """Test service initialization from environment variable."""
-        service = EncryptionService()
+        with encryption_key_env("env_test_key"):
+            service = EncryptionService()
         self.assertEqual(service.master_key, "env_test_key")
 
     def test_encrypt_decrypt_string(self):
@@ -169,23 +188,23 @@ class TestEncryptionService(unittest.TestCase):
 class TestConvenienceFunctions(unittest.TestCase):
     """Test convenience functions."""
 
-    @patch.dict(os.environ, {"AUTOBOT_ENCRYPTION_KEY": "test_key_for_convenience"})
     def test_encrypt_decrypt_data_string(self):
         """Test convenience functions with string data."""
         original = "Test message for convenience functions"
 
-        encrypted = encrypt_data(original)
-        decrypted = decrypt_data(encrypted)
+        with encryption_key_env("test_key_for_convenience"):
+            encrypted = encrypt_data(original)
+            decrypted = decrypt_data(encrypted)
 
         self.assertEqual(decrypted, original)
 
-    @patch.dict(os.environ, {"AUTOBOT_ENCRYPTION_KEY": "test_key_for_convenience"})
     def test_encrypt_decrypt_data_json(self):
         """Test convenience functions with JSON data."""
         original = {"message": "test", "value": 42}
 
-        encrypted = encrypt_data(original)
-        decrypted = decrypt_data(encrypted, as_json=True)
+        with encryption_key_env("test_key_for_convenience"):
+            encrypted = encrypt_data(original)
+            decrypted = decrypt_data(encrypted, as_json=True)
 
         self.assertEqual(decrypted, original)
 

--- a/autobot-backend/security/security_integration_test.py
+++ b/autobot-backend/security/security_integration_test.py
@@ -62,7 +62,15 @@ class TestSecuritySystemIntegration:
         policy = security_layer.command_executor.policy
         assert "echo" in policy.safe_commands
         assert "sudo" in policy.high_risk_commands
-        assert len(policy.dangerous_patterns) > 0
+
+        # #765 moved the pattern list off SecurityPolicy into the central
+        # security.command_patterns module; the executor reaches it through
+        # _check_dangerous_patterns(). Same repoint as #7147 applied to
+        # secure_command_executor_test.py.
+        from security.command_patterns import DANGEROUS_PATTERNS
+
+        assert len(DANGEROUS_PATTERNS) > 0
+        assert security_layer.command_executor._check_dangerous_patterns("rm -rf /")
 
     @pytest.mark.asyncio
     async def test_end_to_end_safe_command_execution(self, security_layer):

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -1507,7 +1507,15 @@ class MiscConfig(RedactedSettings):
     desktop_max_sessions: str = Field(default="", alias="AUTOBOT_DESKTOP_MAX_SESSIONS")
     desktop_resolution: str = Field(default="", alias="AUTOBOT_DESKTOP_RESOLUTION")
     dev_mode: str = Field(default="", alias="AUTOBOT_DEV_MODE")
-    encryption_key: str = Field(default="", alias="AUTOBOT_ENCRYPTION_KEY")
+    # #13162: this field used to be declared twice in MiscConfig — the later
+    # ``alias="ENCRYPTION_KEY"`` copy silently won, so the documented and
+    # deployed ``AUTOBOT_ENCRYPTION_KEY`` (docker-compose.yml, the ValueError
+    # raised by EncryptionService) was never read. Both spellings are now
+    # accepted, AUTOBOT_-prefixed first.
+    encryption_key: str = Field(
+        default="",
+        validation_alias=AliasChoices("AUTOBOT_ENCRYPTION_KEY", "ENCRYPTION_KEY"),
+    )
     env: str = Field(default="", alias="AUTOBOT_ENV")
     error_resolved_ttl_seconds: str = Field(
         default="",
@@ -1802,7 +1810,9 @@ class MiscConfig(RedactedSettings):
     display: str = Field(default="", alias="DISPLAY")
     display_height: str = Field(default="", alias="DISPLAY_HEIGHT")
     display_width: str = Field(default="", alias="DISPLAY_WIDTH")
-    encryption_key: str = Field(default="", alias="ENCRYPTION_KEY")  # type: ignore[no-redef]  # GH#7105
+    # #13162: `encryption_key` is declared once, above, with an AliasChoices
+    # that already covers the bare ENCRYPTION_KEY spelling. Re-declaring it
+    # here shadowed the AUTOBOT_ENCRYPTION_KEY alias.
     # #11681: restore pre-#7437 default (300 s) — 0 made every file-list entry expire instantly
     file_cache_ttl_seconds: int = Field(default=300, alias="FILE_CACHE_TTL_SECONDS")
     gateway_enable_sandbox: str = Field(default="", alias="GATEWAY_ENABLE_SANDBOX")

--- a/requirements-ci/utilities.txt
+++ b/requirements-ci/utilities.txt
@@ -5,3 +5,4 @@ click==8.4.2
 jsonschema==4.26.0
 psutil==7.2.2
 watchdog==6.0.0    # services/documentation_watcher imports it; without it documentation_watcher_staleness_test fails collection (#11687)
+cachetools>=7.1.6  # security/enterprise/domain_reputation imports it; security/enterprise/__init__ re-exports that module, so without it the whole security suite aborts at collection (#13162)


### PR DESCRIPTION
> **Rebased onto current `Dev_new_gui` (was 66 commits behind) — one claim below no longer applies.**
>
> The `api/security.py` fix described here **is not in this PR any more.** The defect was real, but #13258 had already fixed it upstream while this branch was being written; after the rebase that hunk was identical to base and dropped out. `api/security.py` is no longer in the changed-file list.
>
> The `multimodal_system_integration_test.py` fixture also collided with #13199, which fixed the same `set()`/`set_nested()` defect upstream. Resolved by keeping **both**: #13199's `CACHE_DURATION` pin (which this branch lacked) and this branch's `torch.cuda.is_available()` pin (which #13199 lacked).
>
> Re-verified after rebase: **282 passed, 0 failed** across `security/` + `multimodal_processor/` (one module excluded locally for the missing `cachetools` this PR adds to CI). isort · black · flake8 · bandit all clean on the 6 remaining Python files.
>
> The two genuinely new production fixes — the duplicate `encryption_key` field and the missing `cachetools` — are unaffected.

Closes #13162

> **PARTIAL — do not let this close the issue.** This PR only turns two clusters green (`autobot-backend/security/`, `autobot-backend/multimodal_processor/`). #13162 covers the whole ~450-test Python regression plus the missing required-check wiring, and **must stay open** after this merges. Please re-open it if the close keyword fires.

## Thinking Path

The brief was "make these two directories green", but three of the reds turned out to be production defects wearing test-failure clothes, so the first job was separating "the test is stale" from "the code is wrong".

The tell each time was asking *who else believes this?* rather than *what makes the assertion pass?*

- `EncryptionService()` refused to start from `AUTOBOT_ENCRYPTION_KEY`. The obvious "fix" is to rewrite the test to use whatever variable happens to work. But `docker-compose.yml` passes `AUTOBOT_ENCRYPTION_KEY` into two services, `migrate_encryption.py` documents it, and `EncryptionService` names it in its own `ValueError`. Four independent sources agreed with the test, so the code was wrong. `MiscConfig` declared `encryption_key` **twice** — the later `alias="ENCRYPTION_KEY"` copy silently shadowed the earlier `alias="AUTOBOT_ENCRYPTION_KEY"` one, and the `# type: ignore[no-redef]` on it had been suppressing the complaint. Data-at-rest encryption has been unconfigurable through the deployed variable.
- `/api/security/pending-approvals` answered `{"success": true, "data": null}`. `PendingApprovalsData` carries its *own* `success` field, which only makes sense if it is the whole body — so `response_model=DataResponse[PendingApprovalsData]` was the regression, not the handler. FastAPI had been silently discarding `count` and the list on three endpoints.
- The `cachetools` `ModuleNotFoundError` looked like a local venv gap. It isn't: no `requirements-ci/*.txt` installs it either, and because `security/enterprise/__init__.py` eagerly re-exports `domain_reputation`, the missing package is a **collection** error that aborts the entire security suite rather than skipping one module. `watchdog` was added to the same file for exactly this reason in #11687.

Everything else was genuine test rot, and each one got repointed at the API that replaced it rather than loosened:

- `get_section` → `get_config_section`; `set`/`get` (flat pair) → `set_nested`/`get_nested` (dot-notation pair). Fixing only the first of those would have produced a silently-empty section and a *differently* failing assertion.
- The env-var "injection protection" tests assumed ConfigManager derived config keys from arbitrary `AUTOBOT_*` names. It never did — `apply_env_overrides()` walks a fixed `ENV_VAR_MAPPINGS` allowlist, and that allowlist *is* the protection. The tests now assert the stronger property (unmapped names never become keys at all) instead of the weaker one they were written for.
- The vision/voice/context "will use placeholder logic" assertions predate #466/#620 deliberately deleting those placeholders. They now pin the real contract: the model guard raises, and `process()` must convert that into a failure `ProcessingResult` rather than propagating (the behavioural half of what `lsp_exception_contract_test.py` pins at source level).
- `Mock(...)` stand-ins were being dropped on the floor by `_simple_combination`'s `isinstance(result, ProcessingResult)` guard — a guard that is correct, because `asyncio.gather(return_exceptions=True)` can hand it raw exceptions. Real `ProcessingResult` / `ScreenState` objects now.

No test was skipped, xfailed, or weakened to go green.

## What Changed

**Production fixes**

| File | Fix |
|---|---|
| `autobot_shared/ssot_config.py` | `MiscConfig.encryption_key` declared once, with `AliasChoices("AUTOBOT_ENCRYPTION_KEY", "ENCRYPTION_KEY")`. Both spellings work; the `AUTOBOT_`-prefixed one wins. |
| `autobot-backend/api/security.py` | `/pending-approvals`, `/command-history`, `/audit-log` repointed from `DataResponse[XData]` to the flat `XData` models they actually return (matching `/status`). Unused `DataResponse` import dropped. |
| `requirements-ci/utilities.txt` | `cachetools>=7.1.6` added, with the same style of comment #11687 left for `watchdog`. |
| `autobot-backend/encryption_service.py` | `_load_master_key()` fallback re-read the property it had just proven falsy; collapsed to `config.encryption_key or config.master_key`. |

**Test repointing**

- `multimodal_system_integration_test.py` — `get_config_section` / `set_nested`; `store_memory` (#10626) instead of the removed `store_task`; real `ProcessingResult` and `ScreenState` objects; graceful-degradation contract for vision/voice/context; `torch.cuda.is_available()` pinned False because `conftest.py` substitutes a bare `MagicMock` for torch; `pytest.approx` for the `(0.8 + 0.9) / 2` average.
- `config_security_test.py` — allowlist semantics for the three env-var tests, `_convert_env_value()` exercised directly, `to_dict()` for `get_all_config()`, `validate_config()` treated as the status dict it returns.
- `encryption_service_test.py` — new `encryption_key_env()` helper reloads the `lru_cache`d SSOT config inside the `os.environ` patch and restores it after, so the key cannot leak into sibling tests.
- `security_integration_test.py` — `DANGEROUS_PATTERNS` from `security.command_patterns` (#765), the repoint #7147 already applied to `secure_command_executor_test.py`.

**Discovered, filed, not fixed here:** #13344 — one run surfaced an intermittent
`ValueError: duration_seconds cannot be negative` from `MemoryManager.complete_task()`, which
`TaskExecutionTracker.track_task()` re-raises, so a tracker-bookkeeping glitch fails the *tracked*
operation. Lives in `memory/` + `task_execution_tracker.py`, outside these two clusters.

**Shared-module note for the other clusters:** `autobot_shared/ssot_config.py` and `autobot-backend/api/security.py` are outside the two assigned directories. Both changes are strictly additive — `ENCRYPTION_KEY` keeps working, and the response-model change restores the payload that consumers (`security_endpoints_e2e_test.py` reads `data.get('count')`) already expect. No frontend consumes these three endpoints.

## Verification

Baseline and after, same command, same machine:

```
export SLM_SECRET_KEY=throwaway SLM_ENCRYPTION_KEY=x
PYTHONPATH="$PWD/autobot-backend:$PWD" python3 -m pytest \
  autobot-backend/security autobot-backend/multimodal_processor \
  -q -p no:cacheprovider \
  -m "not integration and not slow and not distributed and not performance"
```

| | before | after |
|---|---|---|
| failed | **16** | **0** |
| passed | 218 | **241** |
| errors | 8 (1 collection + 7 setup) | 1 collection (`cachetools`, local venv only — fixed for CI by this PR) |
| skipped / xfailed | 1 / 2 | 1 / 2 |

Split, for the record — before: `security/` 11 failed, 207 passed, 1 error; `multimodal_processor/` 5 failed, 11 passed, 7 errors. After: `multimodal_processor/` 23 passed (verified green on 3 consecutive runs); `security/` 218 passed.

The one remaining collection error is `cachetools` missing from this dev venv. Installing it here is out of policy (no ad-hoc installs), and the actual fix — adding it to `requirements-ci/utilities.txt` — ships in this PR, so CI collects and runs `test_learner.py` for real.

Adjacent cluster, not regressed and partly repaired by the response-model fix:

```
autobot-backend/api/security_api_test.py
  before: 14 failed, 11 passed
  after:  10 failed, 15 passed   # remaining 10 are a strict subset of the 14
```

Gates:

```
python3 -m isort  --settings-path=. <changed .py>   # clean
python3 -m black  --line-length=120 <changed .py>   # 7 files left unchanged
python3 -m flake8 --config=.flake8  <changed .py>   # 0
python3 -m bandit -c .bandit -r autobot-backend/security \
    autobot-backend/multimodal_processor autobot_shared/ssot_config.py \
    autobot-backend/api/security.py autobot-backend/encryption_service.py
  # No issues identified. 13146 LOC scanned.
```

Alias fix proven end to end:

```
$ AUTOBOT_ENCRYPTION_KEY=env_test_key python3 -c "...; print(config.encryption_key)"
env_test_key          # before this PR: ''
$ ENCRYPTION_KEY=legacy_key      python3 -c "...; print(config.encryption_key)"
legacy_key            # legacy spelling still honoured
```

## Model Used

Claude Opus 5 (1M context).