### PR TITLE
feat(scripts): run the PR gates locally before pushing (#13338)

### DIFF
--- a/docs/developer/CLAUDE_WORKFLOW.md
+++ b/docs/developer/CLAUDE_WORKFLOW.md
@@ -217,6 +217,14 @@ Subagents cannot autonomously acquire Bash permission. Run batch file-manipulati
 
 Run these gates before creating a PR or merging any branch. Gates are ordered by cost — cheapest first.
 
+**Shortcut — run the CI-facing gates in one command:**
+
+```bash
+scripts/pr-preflight.sh --issue N [--body pr.md] [--message msg.txt]
+```
+
+It reuses the *same* logic CI does rather than approximating it: the same `awk` extraction as `pr-template-check.yml` (so a heading that is present but placeholder-only fails locally exactly as it does in CI), the same keyword regex as `pr-issue-validation.yml`, and black/isort/flake8/bandit with the same flags as `code-quality.yml` — including bandit's absent severity floor, which is stricter than the medium-and-up filter used elsewhere. It also catches backticks in a commit message (the shell executes them when the message is passed via `-m`), authorship trailers, conflict markers, and fleet IPs. The gates below remain the reference; this runs the mechanical ones early.
+
 ### Gate 0: Squash-Duplicate Detection
 
 Before running any other validation, check whether the branch contains commits that are already squash-merged to `Dev_new_gui`. A squash merge collapses N commits into one, so the individual commit SHAs differ even though the diff is identical. `git log --cherry-pick` detects this by comparing patch IDs rather than SHAs.

--- a/scripts/pr-preflight.sh
+++ b/scripts/pr-preflight.sh
@@ -1,0 +1,290 @@
+#!/usr/bin/env bash
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+#
+# Pre-flight for a PR: run every gate that CI runs, locally, BEFORE pushing.
+#
+# Each check here exists because it has actually cost a round-trip:
+#   - a PR body missing "## What Changed"      -> PR Template Check red, twice
+#   - a body with no Closes/Refs keyword       -> PR issue-link gate red, twice
+#   - backticks in a commit message            -> the shell EXECUTED them and
+#                                                 blanked a line of the message
+#   - a fleet address in source                -> repo secret-scanning hook
+#   - lint run with different flags than CI    -> green locally, red in CI
+#
+# Usage:
+#   scripts/pr-preflight.sh --issue 13162 [--body pr.md] [--message msg.txt]
+#
+#   --issue N     the issue this PR links to (required)
+#   --body FILE   the PR body you are about to post
+#   --message F   the commit message file you are about to pass to git commit -F
+#
+# Exit 0 = every gate that can be checked locally would pass.
+
+set -uo pipefail
+
+ISSUE="" BODY_FILE="" MSG_FILE=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --issue)   ISSUE="$2";     shift 2 ;;
+    --body)    BODY_FILE="$2"; shift 2 ;;
+    --message) MSG_FILE="$2";  shift 2 ;;
+    -h|--help) sed -n '3,22p' "$0"; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+REPO_ROOT=$(git rev-parse --show-toplevel) || exit 2
+cd "$REPO_ROOT" || exit 2
+
+BASE="${PREFLIGHT_BASE:-origin/Dev_new_gui}"
+FAILED=0
+
+# The fleet range is deliberately NOT written here -- putting it in a script is
+# the very thing being checked for. It is read from the existing lint rule,
+# which is the single source of truth for what "fleet IP" means.
+FLEET_RULE="tools/lint/check_no_hardcoded_ip_fallbacks.py"
+FLEET_IP_RE=$(grep -oE '\^[0-9]{1,3}\\\.[0-9]{1,3}\\\.[0-9]{1,3}\\\.' "$FLEET_RULE" 2>/dev/null \
+              | head -1 | sed 's/^\^//' | sed 's/\\\././g')
+if [ -n "$FLEET_IP_RE" ]; then
+  FLEET_IP_RE="$(printf '%s' "$FLEET_IP_RE" | sed 's/\./\\./g')[0-9]{1,3}"
+else
+  FLEET_IP_RE='(?!)'  # rule file unreadable -- match nothing rather than guess
+fi
+pass() { printf '  ok    %s\n' "$1"; }
+fail() { printf '  FAIL  %s\n' "$1"; FAILED=$((FAILED + 1)); }
+note() { printf '  --    %s\n' "$1"; }
+section() { printf '\n%s\n' "$1"; }
+
+# ---------------------------------------------------------------- branch
+section "branch"
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+case "$BRANCH" in
+  main|master|Dev_new_gui)
+    fail "on protected branch '$BRANCH' -- the pre-commit hook will refuse this" ;;
+  *) pass "branch '$BRANCH' is not protected" ;;
+esac
+
+if [ "$(git rev-parse --show-toplevel)" = "$(git rev-parse --git-common-dir | xargs dirname 2>/dev/null)" ]; then
+  note "this looks like the main checkout, not a worktree"
+fi
+
+# ---------------------------------------------------------------- commit message
+if [ -n "$MSG_FILE" ]; then
+  section "commit message ($MSG_FILE)"
+
+  if [ ! -f "$MSG_FILE" ]; then
+    fail "no such file"
+  else
+    # Backticks are the expensive one: `git commit -m "...\`x\`..."` runs x.
+    if grep -q '`' "$MSG_FILE"; then
+      fail "contains a backtick -- the shell will EXECUTE it if this is ever passed via -m"
+      grep -n '`' "$MSG_FILE" | sed 's/^/        /'
+    else
+      pass "no backticks"
+    fi
+
+    SUBJECT=$(head -1 "$MSG_FILE")
+    if printf '%s' "$SUBJECT" | grep -qE '^[a-z]+(\([a-z0-9._-]+\))?: .+ \(#[0-9]+\)$'; then
+      pass "subject matches <type>(scope): <description> (#issue)"
+    else
+      fail "subject does not match <type>(scope): <description> (#issue)"
+      printf '        %s\n' "$SUBJECT"
+    fi
+
+    if [ "${#SUBJECT}" -gt 100 ]; then
+      fail "subject is ${#SUBJECT} chars (keep it under 100)"
+    else
+      pass "subject length ${#SUBJECT}"
+    fi
+
+    # mrveiss is sole author; a "No commit trailers" job enforces this.
+    if grep -qiE '^(co-authored-by|signed-off-by|generated with|assisted-by):' "$MSG_FILE"; then
+      fail "contains an authorship trailer -- the 'No commit trailers' check will fail"
+    else
+      pass "no authorship trailers"
+    fi
+  fi
+fi
+
+# Trailers already committed on this branch would fail the same gate.
+if git rev-parse --verify --quiet "$BASE" >/dev/null; then
+  section "commits on this branch"
+  if git log --format='%B' "$BASE..HEAD" | grep -qiE '^(co-authored-by|signed-off-by|assisted-by):'; then
+    fail "a commit already on this branch carries an authorship trailer"
+  else
+    pass "no authorship trailers in $(git rev-list --count "$BASE..HEAD") commit(s)"
+  fi
+else
+  note "$BASE not found -- skipping branch-commit checks (run git fetch)"
+fi
+
+# ---------------------------------------------------------------- PR body
+if [ -n "$BODY_FILE" ]; then
+  section "PR body ($BODY_FILE)"
+
+  if [ ! -f "$BODY_FILE" ]; then
+    fail "no such file"
+  else
+    BODY=$(cat "$BODY_FILE")
+
+    # Mirrors .github/workflows/pr-template-check.yml exactly: content between
+    # this ## header and the next ## header, comments stripped, must be
+    # non-empty. A heading present but empty fails there and must fail here.
+    for heading in "Thinking Path" "What Changed" "Verification" "Model Used"; do
+      content=$(printf '%s' "$BODY" \
+        | awk "/^## ${heading}/{found=1; next} found && /^## /{exit} found{print}" \
+        | sed 's/<!--[^>]*-->//g' \
+        | sed '/^[[:space:]]*$/d')
+      if [ -z "$content" ]; then
+        fail "section '## ${heading}' is missing or empty"
+      else
+        pass "section '## ${heading}'"
+      fi
+    done
+
+    # Mirrors .github/workflows/pr-issue-validation.yml.
+    if printf '%s' "$BODY" \
+      | grep -iqE "(resolves|closes|fixes|refs|references|part of)[[:space:]]+(#?[0-9]+|MVA-[0-9]+)"; then
+      pass "carries a close/refs keyword"
+    else
+      fail "no Closes/Fixes/Refs keyword -- the issue-link gate requires one even for partial work"
+    fi
+
+    if [ -n "$ISSUE" ]; then
+      if printf '%s' "$BODY" | grep -qE "#${ISSUE}([^0-9]|$)"; then
+        pass "names issue #${ISSUE}"
+      else
+        fail "does not name issue #${ISSUE}"
+      fi
+      # Partial delivery must not silently close the issue.
+      if printf '%s' "$BODY" | grep -iqE "(closes|fixes|resolves)[[:space:]]+#${ISSUE}([^0-9]|$)" \
+         && printf '%s' "$BODY" | grep -iq "partial"; then
+        note "closes #${ISSUE} AND says 'partial' -- confirm the body states the issue stays open"
+      fi
+    fi
+
+    # Only the fleet deployment range. tools/lint/check_no_hardcoded_ip_fallbacks.py
+    # is explicit that loopback and RFC-1918 example space are legitimate by
+    # project convention -- flagging those would make this script cry wolf.
+    if printf '%s' "$BODY" | grep -qE "$FLEET_IP_RE"; then
+      fail "contains a fleet IP -- outward artifacts must not carry one"
+    else
+      pass "no fleet IP literals"
+    fi
+
+    if printf '%s' "$BODY" | grep -qE '(/home/|/opt/autobot|/var/log/autobot)'; then
+      fail "contains an internal filesystem path"
+    else
+      pass "no internal filesystem paths"
+    fi
+  fi
+fi
+
+# ---------------------------------------------------------------- changed files
+section "changed files"
+
+if ! git rev-parse --verify --quiet "$BASE" >/dev/null; then
+  note "$BASE not found -- skipping lint (run git fetch)"
+else
+  mapfile -t CHANGED < <(git diff --name-only --diff-filter=ACMR "$BASE...HEAD"; git diff --name-only --diff-filter=ACMR HEAD)
+  mapfile -t PY < <(printf '%s\n' "${CHANGED[@]}" | sort -u | grep -E '\.py$' | while read -r f; do [ -f "$f" ] && printf '%s\n' "$f"; done)
+
+  if [ "${#PY[@]}" -eq 0 ]; then
+    note "no changed Python files"
+  else
+    printf '  %d changed Python file(s)\n' "${#PY[@]}"
+
+    # Same flags as .github/workflows/code-quality.yml. Different flags is how
+    # a local green becomes a CI red.
+    if python3 -m black --check --line-length=120 "${PY[@]}" >/dev/null 2>&1; then
+      pass "black --line-length=120"
+    else
+      fail "black -- run: python3 -m black --line-length=120 ${PY[*]}"
+    fi
+
+    if python3 -m isort --check-only --settings-path=. --line-length=120 "${PY[@]}" >/dev/null 2>&1; then
+      pass "isort --settings-path=. --line-length=120"
+    else
+      fail "isort -- run: python3 -m isort --settings-path=. --line-length=120 ${PY[*]}"
+    fi
+
+    if python3 -m flake8 --config=.flake8 "${PY[@]}" >/dev/null 2>&1; then
+      pass "flake8 --config=.flake8"
+    else
+      fail "flake8 --config=.flake8"
+      python3 -m flake8 --config=.flake8 "${PY[@]}" 2>&1 | head -15 | sed 's/^/        /'
+    fi
+
+    # code-quality.yml runs bandit with NO severity floor -- stricter than the
+    # medium-and-up filter used elsewhere. A B105 on a constant named *_PREFIX
+    # is the classic false positive; annotate it with "# nosec B105".
+    BANDIT_OUT=$(python3 -m bandit -c .bandit -q "${PY[@]}" 2>&1)
+    if [ -z "$BANDIT_OUT" ]; then
+      pass "bandit -c .bandit (no severity floor, as CI runs it)"
+    else
+      fail "bandit"
+      printf '%s\n' "$BANDIT_OUT" | head -15 | sed 's/^/        /'
+    fi
+  fi
+
+  section "content of changed files"
+
+  mapfile -t EXISTING < <(printf '%s\n' "${CHANGED[@]}" | sort -u | while read -r f; do [ -f "$f" ] && printf '%s\n' "$f"; done)
+
+  if [ "${#EXISTING[@]}" -eq 0 ]; then
+    note "nothing to scan"
+  else
+    if grep -nE '^(<<<<<<< |=======$|>>>>>>> )' "${EXISTING[@]}" >/dev/null 2>&1; then
+      fail "conflict markers present"
+      grep -nE '^(<<<<<<< |>>>>>>> )' "${EXISTING[@]}" 2>/dev/null | head -10 | sed 's/^/        /'
+    else
+      pass "no conflict markers"
+    fi
+
+    # The next two look at ADDED lines only. A pre-existing marker elsewhere in
+    # a file this PR happens to touch is not this PR's to answer for, and
+    # flagging it would train the reader to ignore the script.
+    #
+    # This script and its test are excluded: they necessarily contain the
+    # patterns they search for (the message strings below say "TODO/FIXME"),
+    # so scanning them reports the checker as a violation of itself.
+    # tools/lint/check_no_hardcoded_ip_fallbacks.py carries an ALLOWLIST for
+    # exactly this reason.
+    SELF_EXCLUDE=(':(exclude)scripts/pr-preflight.sh' ':(exclude)scripts/pr-preflight_test.sh')
+    ADDED=$( { git diff "$BASE...HEAD" -- . "${SELF_EXCLUDE[@]}"
+               git diff HEAD -- . "${SELF_EXCLUDE[@]}"; } 2>/dev/null \
+             | grep '^+' | grep -v '^+++' | sed 's/^+//')
+
+    # Mirrors .claude/hooks/scan-secrets.sh: the fleet range only, and not when
+    # the line is a comment or an SSOT lookup -- the same exemptions the hook
+    # grants. Loopback and RFC-1918 example space stay allowed by convention.
+    FLEET_HITS=$(printf '%s\n' "$ADDED" | grep -E "$FLEET_IP_RE" \
+                 | grep -vE '^[[:space:]]*(#|//|/\*|\*|<!--|""")' \
+                 | grep -viE '(config\.|ssot_config|AUTOBOT_REFERENCE|NetworkConstants)')
+    if [ -n "$FLEET_HITS" ]; then
+      fail "an added line carries a fleet IP -- source it from SSOT NetworkConstants instead"
+      printf '%s\n' "$FLEET_HITS" | head -10 | sed 's/^/        /'
+    else
+      pass "no fleet IP literals in added lines"
+    fi
+
+    MARKERS=$(printf '%s\n' "$ADDED" | grep -nE '\bTODO\b|\bFIXME\b')
+    if [ -n "$MARKERS" ]; then
+      fail "an added line carries a TODO/FIXME -- this repo does not accept deferred-work markers"
+      printf '%s\n' "$MARKERS" | head -10 | sed 's/^/        /'
+    else
+      pass "no TODO/FIXME in added lines"
+    fi
+  fi
+fi
+
+# ---------------------------------------------------------------- result
+printf '\n'
+if [ "$FAILED" -eq 0 ]; then
+  printf 'pre-flight clean -- safe to commit and push\n'
+  exit 0
+fi
+printf '%d pre-flight failure(s) -- fix before pushing\n' "$FAILED"
+exit 1

--- a/scripts/pr-preflight_test.sh
+++ b/scripts/pr-preflight_test.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+#
+# Unit tests for scripts/pr-preflight.sh -- the local run of the PR gates.
+# Run: bash scripts/pr-preflight_test.sh
+#
+# Each case below corresponds to a gate that has actually gone red in CI, so a
+# regression here means the round-trip it exists to prevent comes back.
+#
+# PREFLIGHT_BASE is pinned to HEAD so the changed-file section finds nothing:
+# these tests cover the body/message logic, which is where the recurring
+# misses have been. The lint section just shells out to the same tools CI
+# runs and has nothing of its own to test.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="${HERE}/pr-preflight.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+
+pass=0
+fail=0
+
+# Assert that running the script over the given fixtures does (or does not)
+# report a failure whose text contains $pattern.
+check_reports() {
+    local name="$1" expected="$2" pattern="$3" body="$4" message="$5"
+    local out
+    out=$(PREFLIGHT_BASE=HEAD bash "${SCRIPT}" --issue 9999 \
+            ${body:+--body "$body"} ${message:+--message "$message"} 2>&1)
+    local actual="no"
+    printf '%s' "$out" | grep -q "FAIL.*${pattern}" && actual="yes"
+    if [ "$expected" = "$actual" ]; then
+        pass=$((pass + 1))
+    else
+        fail=$((fail + 1))
+        echo "  FAIL: ${name} -- expected reported=[${expected}], got [${actual}]"
+        printf '%s\n' "$out" | sed 's/^/         /'
+    fi
+}
+
+# ---------------------------------------------------------------- fixtures
+
+GOOD_BODY="${TMP}/good_body.md"
+cat > "${GOOD_BODY}" <<'EOF'
+Closes #9999
+
+## Thinking Path
+Why.
+
+## What Changed
+What.
+
+## Verification
+Evidence.
+
+## Model Used
+A model.
+EOF
+
+# The exact shape that failed CI: heading present, content only a placeholder
+# comment. The awk extraction strips comments, so this is empty.
+PLACEHOLDER_BODY="${TMP}/placeholder_body.md"
+sed 's/^What\.$/<!-- describe the change -->/' "${GOOD_BODY}" > "${PLACEHOLDER_BODY}"
+
+NO_KEYWORD_BODY="${TMP}/no_keyword_body.md"
+sed 's/^Closes #9999$/Relates to issue 9999./' "${GOOD_BODY}" > "${NO_KEYWORD_BODY}"
+
+MISSING_SECTION_BODY="${TMP}/missing_section_body.md"
+grep -v -e '^## Verification$' -e '^Evidence\.$' "${GOOD_BODY}" > "${MISSING_SECTION_BODY}"
+
+GOOD_MSG="${TMP}/good_msg.txt"
+printf 'fix(scope): do the thing (#9999)\n\nBody text.\n' > "${GOOD_MSG}"
+
+BACKTICK_MSG="${TMP}/backtick_msg.txt"
+printf 'fix(scope): do the thing (#9999)\n\nSee the `run_it` helper.\n' > "${BACKTICK_MSG}"
+
+BAD_SUBJECT_MSG="${TMP}/bad_subject_msg.txt"
+printf 'made some changes\n\nBody text.\n' > "${BAD_SUBJECT_MSG}"
+
+TRAILER_MSG="${TMP}/trailer_msg.txt"
+printf 'fix(scope): do the thing (#9999)\n\nBody.\n\nCo-Authored-By: Someone <a@b.c>\n' > "${TRAILER_MSG}"
+
+# ---------------------------------------------------------------- PR body
+
+echo "== PR body =="
+check_reports "good body passes template check" \
+    "no" "section" "${GOOD_BODY}" ""
+check_reports "placeholder-only section is caught" \
+    "yes" "What Changed" "${PLACEHOLDER_BODY}" ""
+check_reports "missing section is caught" \
+    "yes" "Verification" "${MISSING_SECTION_BODY}" ""
+check_reports "good body carries a close keyword" \
+    "no" "Closes/Fixes/Refs" "${GOOD_BODY}" ""
+check_reports "missing close keyword is caught" \
+    "yes" "Closes/Fixes/Refs" "${NO_KEYWORD_BODY}" ""
+
+# ---------------------------------------------------------------- commit message
+
+echo "== commit message =="
+check_reports "good message passes" \
+    "no" "backtick" "" "${GOOD_MSG}"
+check_reports "backtick is caught" \
+    "yes" "backtick" "" "${BACKTICK_MSG}"
+check_reports "malformed subject is caught" \
+    "yes" "subject does not match" "" "${BAD_SUBJECT_MSG}"
+check_reports "good subject is accepted" \
+    "no" "subject does not match" "" "${GOOD_MSG}"
+check_reports "authorship trailer is caught" \
+    "yes" "authorship trailer" "" "${TRAILER_MSG}"
+check_reports "clean message has no trailer reported" \
+    "no" "authorship trailer" "" "${GOOD_MSG}"
+
+# ---------------------------------------------------------------- fleet IP rule
+
+echo "== fleet IP rule =="
+# The range is never written here -- it is read from the same lint rule the
+# script reads, so this test cannot drift from the rule it is checking.
+FLEET_RULE="$(cd "${HERE}/.." && pwd)/tools/lint/check_no_hardcoded_ip_fallbacks.py"
+if [ -r "${FLEET_RULE}" ]; then
+    derived=$(grep -oE '\^[0-9]{1,3}\\\.[0-9]{1,3}\\\.[0-9]{1,3}\\\.' "${FLEET_RULE}" \
+              | head -1 | sed 's/^\^//' | sed 's/\\\././g')
+    if [ -n "${derived}" ]; then
+        pass=$((pass + 1))
+        fleet_body="${TMP}/fleet_body.md"
+        sed "s/^Why\.$/Deployed at ${derived}9 for testing./" "${GOOD_BODY}" > "${fleet_body}"
+        check_reports "fleet IP in body is caught" \
+            "yes" "fleet IP" "${fleet_body}" ""
+        # Loopback and RFC-1918 example space are legitimate per the lint rule's
+        # own stated convention -- flagging them would make the script cry wolf.
+        loopback_body="${TMP}/loopback_body.md"
+        sed 's/^Why\.$/Bound to 127.0.0.1 and 192.168.1.5 in the example./' "${GOOD_BODY}" > "${loopback_body}"
+        check_reports "loopback and example space are not flagged" \
+            "no" "fleet IP" "${loopback_body}" ""
+    else
+        fail=$((fail + 1))
+        echo "  FAIL: fleet regex derivation -- got nothing from ${FLEET_RULE}"
+    fi
+else
+    echo "  SKIP: ${FLEET_RULE} not readable"
+fi
+
+# ---------------------------------------------------------------- result
+
+echo ""
+echo "passed: ${pass}  failed: ${fail}"
+[ "${fail}" -eq 0 ] || exit 1


### PR DESCRIPTION
Closes #13338

## Thinking Path

Every gate this script checks has already cost a round-trip, some more than once. The pattern was always the same: push, wait for CI, read a one-line failure, fix, push again. None of the checks are expensive — they were just happening in the wrong place.

The design constraint that mattered: **mirror the gates, do not approximate them.** An approximation that disagrees with CI is worse than no check, because it either blocks work that would have passed or passes work that will fail. So the template check reuses CI's own `awk` extraction verbatim, and the lint steps use CI's exact flags.

The second constraint: **do not cry wolf.** My first draft flagged every private IP. But `tools/lint/check_no_hardcoded_ip_fallbacks.py` is explicit that only the fleet deployment range is banned and that loopback and RFC-1918 example space are legitimate by project convention. That draft reported two false positives on a known-good PR. A checker that is wrong on correct work gets ignored, so the rule is now read from that lint file at runtime.

## What Changed

| File | Change |
|---|---|
| `scripts/pr-preflight.sh` | New. Runs the PR gates locally: template sections, issue-link keyword, commit-message shape, lint, conflict markers, fleet IPs. |
| `scripts/pr-preflight_test.sh` | New. 14 checks, one per failure mode, following the `scripts/lib/branch-guards_test.sh` harness shape. |
| `docs/developer/CLAUDE_WORKFLOW.md` | Pre-Merge Validation now points at the script as the one-command shortcut for the mechanical gates. |

What it checks:

- **Template sections** — same `awk` extraction as `.github/workflows/pr-template-check.yml`, so a heading present but placeholder-only fails identically.
- **Issue-link keyword** — same regex as `.github/workflows/pr-issue-validation.yml`, including that a *partial* PR still needs the keyword.
- **Commit message** — backticks (the shell executes them when passed via `-m`), `<type>(scope): <desc> (#N)` shape, subject length, authorship trailers. Also scans commits already on the branch.
- **Lint** — black, isort, flake8, bandit with `code-quality.yml`'s exact flags, including bandit's absent severity floor.
- **Content** — conflict markers, fleet IPs, TODO/FIXME. The last two look at **added lines only**.

The fleet range is never written into the script. It is derived from the lint rule at runtime, so there is one source of truth and no address in the source.

The script and its test are excluded from the added-line scans. They necessarily contain the patterns they search for — the failure message literally says `TODO/FIXME` — so scanning them reports the checker as a violation of itself. `check_no_hardcoded_ip_fallbacks.py` carries an `ALLOWLIST` for the same reason. **This was found by running the script on its own PR**, which is the one case a fixture-based test would not have covered.

## Verification

Test suite:

```
$ bash scripts/pr-preflight_test.sh
== PR body ==
== commit message ==
== fleet IP rule ==

passed: 14  failed: 0
```

Validated in both directions before this PR existed:

- **Clean on a known-good branch** — run against the branch behind #13317, every check passed.
- **Catches each failure mode** — placeholder-only `What Changed`, missing `Verification`, absent close keyword, backtick in message, malformed subject, authorship trailer, fleet IP in an added line.
- **Does not cry wolf** — loopback and RFC-1918 example space are not flagged, matching the lint rule's stated convention.

The fleet-regex derivation was verified end-to-end: it is non-empty, it matches an address built from the rule itself, and it ignores `127.0.0.1`, `10.99.0.7`, `192.168.1.5` and `169.254.169.254`.

This PR was itself checked with the script before pushing.

## Model Used

Claude Opus 5 (1M context)
