### PR TITLE
fix(tests): clear all collection-error clusters polluting every python-suite shard (#13086)

### DIFF
--- a/autobot-backend/pki/test_renewal.py
+++ b/autobot-backend/pki/test_renewal.py
@@ -90,7 +90,7 @@ def test_renew_no_certs_returns_true(tmp_path):
 def test_renew_ca_raises_value_error(tmp_path):
     manager = _make_manager(tmp_path)
 
-    with pytest.raises(ValueError, match="CA certificate renewal requires manual steps"):
+    with pytest.raises(ValueError, match="CA certificate renewal is a manual process"):
         asyncio.run(manager.renew(certificates=["ca"]))
 
     manager.generator._renew_service_cert.assert_not_called()

--- a/autobot-backend/security/enterprise/threat_detection/test_learner.py
+++ b/autobot-backend/security/enterprise/threat_detection/test_learner.py
@@ -12,6 +12,7 @@ All Redis calls are patched so the suite runs without a live Redis instance.
 
 from __future__ import annotations
 
+import importlib
 from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
@@ -30,6 +31,18 @@ from security.enterprise.threat_detection.learner import (  # noqa: E402
     ThreatDetectionLearner,
 )
 
+# Resolved through sys.modules rather than by dotted-string lookup (#13086).
+# Under pytest's `--import-mode=importlib` (set in pytest.ini) the package
+# `security/enterprise/threat_detection/__init__.py` is executed a second time
+# as this test module's parent. That second execution re-imports its own
+# submodules, but CPython only binds a submodule as an attribute of its parent
+# on a FRESH load -- the submodules are already in sys.modules, so the bindings
+# are silently skipped. `mock.patch("a.b.c.symbol")` walks exactly those
+# attributes, so the string form raises AttributeError before it ever reaches
+# the patch. `import_module` returns sys.modules[name] directly and is correct
+# under both import modes.
+_learner_module = importlib.import_module("security.enterprise.threat_detection.learner")
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -47,10 +60,7 @@ def mock_redis():
 @pytest.fixture()
 def learner(mock_redis):
     """Return a ThreatDetectionLearner with its Redis client mocked."""
-    with patch(
-        "security.enterprise.threat_detection.learner.get_redis_client",
-        return_value=mock_redis,
-    ):
+    with patch.object(_learner_module, "get_redis_client", return_value=mock_redis):
         return ThreatDetectionLearner()
 
 

--- a/autobot-backend/tools/__init__.py
+++ b/autobot-backend/tools/__init__.py
@@ -7,9 +7,24 @@ Unified Tools Package
 
 This package provides a centralized tool registry that eliminates duplication
 between the standard orchestrator and LangChain orchestrator implementations.
+
+Namespace note (#13086): the repo has two `tools/` directories —
+`/autobot-backend/tools/` (this one: production tool registry / parallel
+executor) and `/tools/` at the repo root (lint hooks, canonical-check runner).
+Both must be reachable as `tools.X` no matter which one Python binds to the
+`tools` name first. The root package already calls `pkgutil.extend_path`; this
+one must do the same, otherwise a test session that imports
+`tools.tool_registry` before `tools.lint` pins `tools.__path__` to this
+directory alone and every `tools.lint.*` import fails with ModuleNotFoundError.
+`extend_path` only appends `tools/` directories that are actually on sys.path,
+so production deployments (repo root not on sys.path) are unaffected.
 """
+
+import pkgutil
 
 from .code_interpreter import CODE_INTERPRETER_SCHEMA, execute_code
 from .tool_registry import ToolRegistry, get_tool_registry
+
+__path__ = pkgutil.extend_path(__path__, __name__)
 
 __all__ = ["CODE_INTERPRETER_SCHEMA", "ToolRegistry", "execute_code", "get_tool_registry"]

--- a/autobot-backend/training/completion_trainer_test.py
+++ b/autobot-backend/training/completion_trainer_test.py
@@ -14,9 +14,20 @@ from pathlib import Path
 
 import pytest
 
-# Optional ML dependency (torch is in requirements-gpu.txt, never default reqs).
-# Skip cleanly when absent; run for real when torch IS installed (e.g. GPU CI).
+# Optional ML training stack. Skip cleanly when absent; run for real when it IS
+# installed (e.g. a GPU CI image or a local dev box with the full backend reqs).
+#
+# BOTH imports must be guarded (#13086). `training/evaluator.py` — pulled in
+# below — imports `torchmetrics` at module level, and the `python-suite` CI
+# environment installs torch TRANSITIVELY via sentence-transformers while never
+# installing torchmetrics. That combination let the torch guard pass and then
+# blew up on torchmetrics, turning this module into a hard collection ERROR on
+# every shard. torchmetrics is deliberately NOT added to requirements-ci.txt:
+# the repo already treats this subsystem as optional (`training/__init__.py`
+# wraps every symbol in `optional_import`), and the CI install resolves torch
+# against the CPU-only index specifically to keep the CUDA-adjacent closure out.
 pytest.importorskip("torch.nn.functional", reason="torch not installed — optional ML dep")
+pytest.importorskip("torchmetrics", reason="torchmetrics not installed — optional ML dep (training/evaluator.py)")
 
 import torch  # noqa: E402 — after importorskip by design
 

--- a/autobot-backend/training/completion_trainer_test.py
+++ b/autobot-backend/training/completion_trainer_test.py
@@ -14,18 +14,15 @@ from pathlib import Path
 
 import pytest
 
-# Optional ML training stack. Skip cleanly when absent; run for real when it IS
-# installed (e.g. a GPU CI image or a local dev box with the full backend reqs).
+# Optional ML training stack — a LOCAL-DEV guard, not a CI opt-out (#13086).
+# CI installs both: torch arrives transitively via sentence-transformers and
+# torchmetrics is pinned in requirements-ci/ai-ml.txt, so all 17 tests below run
+# on every shard. These two lines only spare a dev box that has neither.
 #
-# BOTH imports must be guarded (#13086). `training/evaluator.py` — pulled in
-# below — imports `torchmetrics` at module level, and the `python-suite` CI
-# environment installs torch TRANSITIVELY via sentence-transformers while never
-# installing torchmetrics. That combination let the torch guard pass and then
-# blew up on torchmetrics, turning this module into a hard collection ERROR on
-# every shard. torchmetrics is deliberately NOT added to requirements-ci.txt:
-# the repo already treats this subsystem as optional (`training/__init__.py`
-# wraps every symbol in `optional_import`), and the CI install resolves torch
-# against the CPU-only index specifically to keep the CUDA-adjacent closure out.
+# BOTH must be guarded. `training/evaluator.py` — pulled in below — imports
+# `torchmetrics` at module level. Guarding torch alone let the guard pass in CI
+# (torch present) and then blow up on torchmetrics, turning this module into a
+# hard collection ERROR on every shard rather than a skip.
 pytest.importorskip("torch.nn.functional", reason="torch not installed — optional ML dep")
 pytest.importorskip("torchmetrics", reason="torchmetrics not installed — optional ML dep (training/evaluator.py)")
 

--- a/requirements-ci/ai-ml.txt
+++ b/requirements-ci/ai-ml.txt
@@ -6,3 +6,11 @@ sentence-transformers==5.6.1
 -c ../constraints/shared.txt  # single source of truth for shared versions (#10524)
 numpy  # version from constraints/shared.txt
 pillow==12.3.0
+# Mirrors autobot-backend/requirements.txt:42. training/evaluator.py imports it at
+# module level, so without it completion_trainer_test.py's 17 tests never run —
+# including the torch.load weights_only=True RCE regression test (#13086).
+# Cheap: torchmetrics and its only new transitive (lightning-utilities) are both
+# py3-none-any, and torch is ALREADY installed here transitively via
+# sentence-transformers. No nvidia-* wheels — the CPU-only index in
+# .github/actions/setup-python-suite keeps resolving torch, so the ~3GB saving stands.
+torchmetrics>=1.9.0,<2.0.0

--- a/requirements-ci/networking.txt
+++ b/requirements-ci/networking.txt
@@ -3,4 +3,4 @@ requests==2.34.2
 aiohttp==3.14.3
 httpx==0.28.1
 aiofiles==25.1.0
-asyncssh>=2.24.0   # production dep (requirements.txt); pki/distributor.py + pki/configurator.py import it unconditionally, so pki/test_renewal.py fails collection without it (#13086)
+asyncssh>=2.24.0,<3.0.0   # production dep (requirements.txt); pki/distributor.py + pki/configurator.py import it unconditionally, so pki/test_renewal.py fails collection without it (#13086)

--- a/requirements-ci/networking.txt
+++ b/requirements-ci/networking.txt
@@ -3,3 +3,4 @@ requests==2.34.2
 aiohttp==3.14.3
 httpx==0.28.1
 aiofiles==25.1.0
+asyncssh>=2.24.0   # production dep (requirements.txt); pki/distributor.py + pki/configurator.py import it unconditionally, so pki/test_renewal.py fails collection without it (#13086)

--- a/requirements-ci/storage.txt
+++ b/requirements-ci/storage.txt
@@ -4,3 +4,4 @@ chromadb==1.5.9
 sqlalchemy==2.0.51
 aiosqlite==0.22.1
 alembic==1.18.5  # migration-gate static tests import migrations.baseline (#10001)
+psycopg2-binary>=2.9.12  # production dep (autobot-slm-backend/requirements.txt): the sync driver every migrations/*.py uses. migrations/utils.py + migrations/runner.py import it at module level, so migrations/utils_test.py fails collection without it (#13086)

--- a/requirements-ci/storage.txt
+++ b/requirements-ci/storage.txt
@@ -4,4 +4,4 @@ chromadb==1.5.9
 sqlalchemy==2.0.51
 aiosqlite==0.22.1
 alembic==1.18.5  # migration-gate static tests import migrations.baseline (#10001)
-psycopg2-binary>=2.9.12  # production dep (autobot-slm-backend/requirements.txt): the sync driver every migrations/*.py uses. migrations/utils.py + migrations/runner.py import it at module level, so migrations/utils_test.py fails collection without it (#13086)
+psycopg2-binary>=2.9.12,<3.0.0  # production dep (autobot-slm-backend/requirements.txt): the sync driver every migrations/*.py uses. migrations/utils.py + migrations/runner.py import it at module level, so migrations/utils_test.py fails collection without it (#13086)

--- a/requirements-ci/utilities.txt
+++ b/requirements-ci/utilities.txt
@@ -6,3 +6,5 @@ jsonschema==4.26.0
 psutil==7.2.2
 watchdog==6.0.0    # services/documentation_watcher imports it; without it documentation_watcher_staleness_test fails collection (#11687)
 cachetools>=7.1.6  # security/enterprise/domain_reputation imports it; security/enterprise/__init__ re-exports that module, so without it the whole security suite aborts at collection (#13162)
+croniter>=6.2.4,<7.0.0        # production dep of BOTH backends; autobot-slm-backend/services/schedule_executor.py imports it unconditionally (reached via slm main.py), and llc/api/routines.py + llc/scheduler/heartbeat_scheduler.py silently degrade to croniter=None without it (#13086)
+apscheduler>=3.11.3,<4.0.0    # production dep (autobot-backend/requirements.txt); services/llm_key_rotation_scheduler.py imports it at module level. Errors nothing today only because lifespan.py imports that module inside a function — same latent shape as croniter (#13351)


### PR DESCRIPTION
## Thinking Path

Every `python-suite` shard reported ~23 errors that were **collection failures, not test
failures** — six missing-module root causes duplicated across all 12 shards. They sat on
top of the real failures and made the suite unreadable.

**`tools.lint` (#13086) — the real blast radius.** The issue guessed a `pythonpath`
gap and an earlier analysis proposed renaming the repo-root `tools/` directory. Both
are wrong. Measured: the repo has two regular packages both named `tools`
(repo-root `tools/` = lint hooks/canonical runner, `autobot-backend/tools/` =
production tool registry). Renaming either is 25 files (root) or 15 files (backend)
of Python imports, plus pre-commit config, shell scripts and workflow references for
the root one — and workflows are off-limits in this change.

No rename is needed. The repo-root `tools/__init__.py` **already** solves this with
`pkgutil.extend_path`; it just only wins when it is imported *first*. Under
`--import-mode=importlib`, pytest resolves a test file's module name by walking up
while `__init__.py` exists, so `autobot-backend/tools/tool_registry_test.py` binds the
name `tools` to the backend package directly — bypassing `sys.path` order entirely.
Whichever backend collects first pins `tools.__path__`, and `tools.lint` then does not
exist. The fix is to make the backend package reciprocate: two lines, zero renames.
The two directories share **zero** module names, so merging them cannot shadow anything.

**Per-package dependency decisions — no blanket add.** Every one of these turned out
to be a **declared production dependency the CI install simply omitted**, so the
question was never "is it optional" but "does CI exercise that code path":

| Package | Declared in | Decision | Why |
|---|---|---|---|
| `psycopg2-binary` | slm backend — "sync driver for migrations" | **add** (`storage.txt`) | Every `migrations/*.py` uses it; `migrations/utils.py` + `runner.py` import it at module level. |
| `asyncssh` | root `requirements.txt` | **add** (`networking.txt`) | `pki/distributor.py` + `pki/configurator.py` import it unconditionally; mTLS cert distribution is a real supported path. |
| `croniter` | **both** backends | **add** (`utilities.txt`) | `services/schedule_executor.py` imports it at module level, reached from slm `main.py`. Also flips `llc/api/routines.py` and `llc/scheduler/heartbeat_scheduler.py` off their silent `croniter = None` degraded branch. |
| `apscheduler` | backend `requirements.txt` | **add** (`utilities.txt`) | Same shape as croniter: `services/llm_key_rotation_scheduler.py` imports it at module level, and it errors nothing today only because `lifespan.py` imports that module inside a function. Omitting it would have been an inconsistency, not a principle. |
| `torchmetrics` | backend `requirements.txt:42` | **add** (`ai-ml.txt`) | See below. |
| `cachetools` | backend `requirements.txt` | **already on base** | Landed in `2d2037142` (#13162) while this branch was open; dropped from this PR on rebase. |

`torchmetrics` was initially guarded with `importorskip` instead. That was wrong, and
the stated reason did not hold: the comment claimed it was excluded to keep the
CUDA-adjacent closure out, but **torch is already installed in CI**, resolved through
the CPU-only index in `setup-python-suite`. Verified independently — torchmetrics 1.9.0
is `py3-none-any`, its only new transitive is `lightning-utilities` (also `py3-none-any`,
needing just `packaging` + `typing_extensions`, both already present), and it is a
transitive of neither `sentence-transformers` nor `transformers`. Zero nvidia wheels;
the ~3 GB saving is untouched. What the skip cost was **17 tests**, including
`test_load_checkpoint_rejects_malicious_pickle` — a `torch.load` RCE regression test of
the CVE-2025-32434 class. It is now installed and the `importorskip` stays purely as a
local-dev guard, with the comment corrected to say so.

Added packages carry `<next-major` bounds, matching the dominant convention in
`requirements-ci/` (`redis`, `langchain-core`, `llama-index-core`). The venv cache key
hashes `requirements-ci/*.txt` and cannot see an upstream release, so an unbounded `>=`
lets a cache-hit shard and a cache-miss shard hold different major versions.

**Two latent bugs surfaced by making these modules collect.** Turning a collection
error into a *test failure* is not progress, so both are fixed here:

1. `pki/test_renewal.py` asserted an error message production stopped emitting. The
   production text changed deliberately in `2d4e912d5` to point at the CA-rotation
   runbook; the test drifted, invisibly, because it never ran. Production is right.
2. `threat_detection/test_learner.py` patched by dotted string. Under
   `--import-mode=importlib` the package `__init__.py` is executed a second time as the
   test module's parent; that second execution re-imports its own submodules, but CPython
   only binds a submodule onto its parent on a *fresh* load, so the bindings are skipped.
   `mock.patch("a.b.c.symbol")` walks exactly those attributes, so `_dot_lookup` raises
   `AttributeError` and all 28 tests fail at setup. Confirmed by diffing import modes:
   28 passed under `prepend`, 28 setup errors under `importlib`. Resolved via
   `importlib.import_module` + `patch.object`, correct under both. Blast radius on base
   is exactly this one file; a preventive lint rule is tracked in #13350.

## What Changed

- `autobot-backend/tools/__init__.py` — `pkgutil.extend_path`, mirroring the repo-root
  `tools/__init__.py`, so the two same-named packages merge whichever binds first.
- `requirements-ci/storage.txt` — `psycopg2-binary>=2.9.12,<3.0.0`
- `requirements-ci/networking.txt` — `asyncssh>=2.24.0,<3.0.0`
- `requirements-ci/utilities.txt` — `croniter>=6.2.4,<7.0.0`, `apscheduler>=3.11.3,<4.0.0`
- `requirements-ci/ai-ml.txt` — `torchmetrics>=1.9.0,<2.0.0`
- `autobot-backend/training/completion_trainer_test.py` — `importorskip("torchmetrics")`
  beside the existing torch guard, as a local-dev guard; comment corrected.
- `autobot-backend/pki/test_renewal.py` — expected message realigned with production.
- `autobot-backend/security/enterprise/threat_detection/test_learner.py` — patch target
  resolved through `sys.modules` instead of dotted-attribute lookup.

No workflow files touched. No test deleted, skipped-away or marked.

## Verification

Measured on the two invocations `pytest.ini` mandates (the backends must not share a
process — #13084). The missing packages cannot be installed on this box, so a pytest
plugin reproduces each environment exactly: it blocks what base does not install and
stubs in what base does install but this box lacks (`cachetools`, `sklearn`).

**Whole-suite collection errors, against the current base:**

```
                              BEFORE                    AFTER
backend  invocation   22534 tests, 13 errors    22601 tests, 0 errors
slm      invocation    1557 tests,  1 error      1562 tests, 0 errors
                       ------------------        -----------------
                             14 errors                 0 errors
```

Base is 13 + 1 locally; in CI it is one higher (15), because `completion_trainer_test.py`
only reaches its torchmetrics error when torch is present — this box has no torch, so it
short-circuits on the first guard instead.

**Per root cause:**

| Root cause | Before | After |
|---|---|---|
| `tools.lint` | 12 collection errors | 0 — **56 tests newly run** |
| `asyncssh` (`pki/test_renewal.py`) | 1 collection error | 0 — **11 passed** |
| `psycopg2` (`migrations/utils_test.py`) | 1 collection error | 0 — **5 passed** |
| `cachetools` (`threat_detection/test_learner.py`) | **28 setup errors** | 0 — **28 passed** |
| `torchmetrics` (`completion_trainer_test.py`) | 1 collection error (CI) | 0 — 17 tests now installed and run |
| `croniter` (`services/schedule_executor`) | module unimportable | imports |
| `apscheduler` (`services/llm_key_rotation_scheduler`) | module unimportable | imports |

The cachetools row is a *setup*-error row, not a collection-error row: base already
installs the package (#13162), so that module collects on base and then dies 28 times in
fixture setup on the dotted-patch bug above.

`tools.lint` reproduction (both backends in one process, which is what a shard does):

```
$ pytest autobot-backend/tools repo_tests/lint/canonical/ --co     # before
E   ModuleNotFoundError: No module named 'tools.lint'
==== 75 tests collected, 12 errors ====

$ pytest autobot-backend/tools repo_tests/lint/canonical/ --co     # after
==== 131 tests collected in 0.63s ====
```

Order-independent — the reverse order collects clean too.

**Skips did not rise to buy the error drop.** No net new skip: `completion_trainer_test.py`
now installs its dependency rather than skipping, so its 17 tests run in CI.
**100 tests that could not previously be collected now execute and pass**, slowest 0.39s,
none near the 10s ceiling:

```
$ pytest <the 12 formerly-erroring lint modules>       56 passed in 0.53s
$ pytest autobot-backend/pki/test_renewal.py           11 passed in 1.22s
$ pytest .../threat_detection/test_learner.py          28 passed in 0.92s
$ pytest autobot-slm-backend/migrations/utils_test.py   5 passed in 0.16s
```

56, not 64: `repo_tests/lint/canonical` holds 64 tests but 8 (the two runner-CLI modules)
were already collectable on base. Independently corroborated by `.test_durations`, which
holds exactly 8 `lint/canonical` entries.

The 17 torchmetrics-gated tests cannot be run on this box (no torch), so they are not
counted above. Cross-checked statically instead: every symbol and signature the module
uses still exists in production — `CompletionEvaluator(device="cpu")`, `HitAtK(k=5)`,
`MeanReciprocalRank()`, `Tokenizer()`, `CompletionModel(vocab_size, embedding_dim,
hidden_dim)` — and `completion_trainer.py:303` really does call
`torch.load(..., weights_only=True)`, so the RCE regression test's sink is present. No
API drift of the kind that had rotted the pki test. The `importorskip` remains, so a
failed install degrades to a skip rather than a collection error.

**Production import path is unchanged for the deployed shape.** `pkgutil.extend_path`
merges any `tools/` reachable from `sys.path`, *including the implicit cwd entry* — run
from the repo root the path is `['<repo>/autobot-backend/tools', '<repo>/tools',
'<repo>/./tools']` even without the root explicitly on `sys.path`. That is dev/CI. The
deployed shape is genuinely unchanged: systemd sets `WorkingDirectory` and `PYTHONPATH`
to the backend directory, neither of which contains a second `tools/`, and simulating
that gives `['<repo>/autobot-backend/tools']` with `tools.lint` absent, exactly as today.
`tools.tool_registry` and `tools.lint.canonical.diagnostic` each resolve to their own
package in both directions.

**Sharding note:** `.test_durations` has no entries for the ~100 newly collected tests
(0 for pki, learner, migrations and training; 8 for lint, the already-collectable ones),
so pytest-split assigns them the average until the durations job regenerates the file.
They are all sub-second, so the split stays balanced in the meantime.

**Pre-existing, not introduced here:** `autobot-backend/tools/respond_tool_test.py` has
2 failures — filed as #13360, which also records that one of them performs a live DNS
lookup from a unit test. Reproduced identically on unmodified base (`2 failed, 65 passed`
across `autobot-backend/tools` before and after this change).

## Model Used

claude-opus-4-6

Closes #13086
Closes #13351
Refs #10691, #13350, #13360
