### PR TITLE
fix(config,test): default service-auth enforcement on with a drift guard; replace source-text assertions with behaviour

### DIFF
--- a/autobot-backend/api/chat_generate_ai_response_test.py
+++ b/autobot-backend/api/chat_generate_ai_response_test.py
@@ -186,16 +186,13 @@ class TestGetLlmServiceResolvesTheCanonicalModule:
         assert first is second
         assert request.app.state.llm_service is first
 
-    def test_the_legacy_module_name_does_not_exist(self) -> None:
-        """The bug shape only worked if a top-level ``llm_service`` existed.
-
-        Asserting it does not is what makes the reintroduced import fatal --
-        and fatal at the seam this test drives, not somewhere in production.
-        """
-        import importlib
-
-        with pytest.raises(ModuleNotFoundError):
-            importlib.import_module("llm_service")
+    # A ``pytest.raises(ModuleNotFoundError): import_module("llm_service")``
+    # check lived here and was dropped: its premise is a global sys.path /
+    # sys.modules property that conftest's ``services.llm_service`` stub and
+    # sibling suites can invalidate, so it passed alone and failed in the
+    # sharded run. It was also redundant --
+    # ``test_constructs_the_class_from_services_llm_service`` above already
+    # goes red when the import is pointed at the legacy module name.
 
     def test_a_broken_import_surfaces_rather_than_silently_returning_none(self, monkeypatch) -> None:
         """``lazy_init_singleton`` swallows factory exceptions and returns None.

--- a/autobot-backend/api/chat_generate_ai_response_test.py
+++ b/autobot-backend/api/chat_generate_ai_response_test.py
@@ -22,6 +22,9 @@ recur silently.
 
 from __future__ import annotations
 
+import sys
+import types
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock
 
@@ -136,18 +139,78 @@ async def test_generate_ai_response_does_not_call_legacy_generate_response(make_
     llm_service.chat.assert_awaited_once()
 
 
-def test_get_llm_service_imports_canonical_module_path() -> None:
-    """Regression pin: the lazy import inside ``get_llm_service`` must
-    resolve to ``services.llm_service.LLMService`` (the canonical post-#3185
-    location), not a non-existent top-level ``llm_service`` module.
+class TestGetLlmServiceResolvesTheCanonicalModule:
+    """#7047's first defect: a function-scoped ``from llm_service import ...``
+    naming a module that does not exist, so it raised ModuleNotFoundError on
+    the first chat request rather than at import time.
+
+    This used to assert the import *statement* appeared in
+    ``inspect.getsource(get_llm_service)`` (#13311) -- which passes when the
+    literal sits in a dead branch and fails on any refactor that moves it.
+    Swapping the module in ``sys.modules`` and observing which class the
+    accessor constructs proves the lookup actually happens, and where.
     """
-    import inspect
 
-    from api import chat
+    @pytest.fixture
+    def canonical_module(self, monkeypatch):
+        """Install a sentinel at the canonical path and yield its class."""
+        sentinel_cls = type("SentinelLLMService", (), {})
+        module = types.ModuleType("services.llm_service")
+        module.LLMService = sentinel_cls
+        monkeypatch.setitem(sys.modules, "services.llm_service", module)
+        return sentinel_cls
 
-    src = inspect.getsource(chat.get_llm_service)
-    assert "from services.llm_service import LLMService" in src, (
-        "get_llm_service must import from services.llm_service "
-        "(canonical post-#3185 path); the older 'from llm_service import' "
-        "raises ModuleNotFoundError at first call."
-    )
+    @staticmethod
+    def _request():
+        return SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace()))
+
+    def test_constructs_the_class_from_services_llm_service(self, canonical_module) -> None:
+        from api.chat import get_llm_service
+
+        service = get_llm_service(self._request())
+
+        assert isinstance(service, canonical_module), (
+            "get_llm_service resolved something other than "
+            "services.llm_service.LLMService -- the canonical post-#3185 path"
+        )
+
+    def test_result_is_cached_on_app_state(self, canonical_module) -> None:
+        """Lazy init is what let the broken import fire late; the caching half
+        of that contract still has to hold."""
+        from api.chat import get_llm_service
+
+        request = self._request()
+        first = get_llm_service(request)
+        second = get_llm_service(request)
+
+        assert first is second
+        assert request.app.state.llm_service is first
+
+    def test_the_legacy_module_name_does_not_exist(self) -> None:
+        """The bug shape only worked if a top-level ``llm_service`` existed.
+
+        Asserting it does not is what makes the reintroduced import fatal --
+        and fatal at the seam this test drives, not somewhere in production.
+        """
+        import importlib
+
+        with pytest.raises(ModuleNotFoundError):
+            importlib.import_module("llm_service")
+
+    def test_a_broken_import_surfaces_rather_than_silently_returning_none(self, monkeypatch) -> None:
+        """``lazy_init_singleton`` swallows factory exceptions and returns None.
+
+        That is exactly how #7047 stayed invisible, so pin the observable:
+        a caller must be able to tell resolution failed.
+        """
+        from api.chat import get_llm_service
+
+        broken = types.ModuleType("services.llm_service")
+
+        def _explode(*_args, **_kwargs):
+            raise ModuleNotFoundError("No module named 'llm_service'")
+
+        broken.LLMService = _explode
+        monkeypatch.setitem(sys.modules, "services.llm_service", broken)
+
+        assert get_llm_service(self._request()) is None

--- a/autobot-backend/api/marketplace_source_aware_test.py
+++ b/autobot-backend/api/marketplace_source_aware_test.py
@@ -11,6 +11,9 @@ from a user-added marketplace 404.
 """
 
 import inspect
+from unittest.mock import AsyncMock, patch
+
+import pytest
 
 
 def test_install_request_has_source_id_field():
@@ -69,32 +72,129 @@ def test_install_plugin_takes_install_request_body():
     ), f"#6524: body annotation must be InstallRequest; got {body_param.annotation!r}"
 
 
-def test_install_plugin_no_longer_hardcoded_to_builtin_catalog():
+class TestSourceRoutingIsObservedNotGrepped:
     """The bug shape was ``catalog = await _get_catalog()`` inside
-    ``install_plugin`` (and ``get_catalog_entry``) — flat call against the
+    ``install_plugin`` (and ``get_catalog_entry``) — a flat call against the
     built-in catalog regardless of which marketplace the user was browsing.
 
-    Pin against re-introduction: install_plugin source must call
-    ``_resolve_catalog`` (which routes by source_id), not ``_get_catalog``.
+    These used to assert ``"_resolve_catalog" in inspect.getsource(...)``,
+    which proves nothing (#13311): the literal passes from a dead branch and
+    fails on any behaviour-preserving refactor. Instead, stub the *seam* the
+    routing goes through and observe which catalog the endpoint actually
+    consulted, and with which source_id.
     """
-    from api.marketplace import install_plugin
 
-    src = inspect.getsource(install_plugin)
-    assert "_resolve_catalog" in src, (
-        "#6524 regression: install_plugin must call _resolve_catalog(source_id), "
-        "not the legacy _get_catalog() that returned only the built-in catalog."
-    )
-    # Original bug shape: bare `_get_catalog()` call without arguments.
-    assert "await _get_catalog()" not in src, (
-        "#6524 regression: install_plugin must NOT use `await _get_catalog()` — "
-        "that's the bug shape that hard-coded routing to the built-in catalog."
-    )
+    CUSTOM_SOURCE = "11111111-2222-3333-4444-555555555555"
+    CUSTOM_ENTRY = {
+        "name": "custom-only-plugin",
+        "display_name": "Custom Only Plugin",
+        "description": "Present ONLY in the user-added catalog",
+        "category": "automation",
+        "version": "1.0.0",
+        "author": "someone",
+        "entry_point": "custom_only_plugin:main",
+    }
 
+    @pytest.fixture
+    def routed(self, monkeypatch):
+        """Record every source_id ``_resolve_catalog`` is asked for.
 
-def test_get_catalog_entry_no_longer_hardcoded_to_builtin_catalog():
-    """Same regression guard for the detail endpoint."""
-    from api.marketplace import get_catalog_entry
+        ``_get_catalog`` (the built-in-only accessor that caused #6524) is
+        replaced by an exploding stub: if the endpoint bypasses routing and
+        reaches for the built-in catalog directly, the test fails loudly
+        instead of quietly returning the wrong catalog.
+        """
+        from api import marketplace as mod
 
-    src = inspect.getsource(get_catalog_entry)
-    assert "_resolve_catalog" in src, "#6524: get_catalog_entry must call _resolve_catalog"
-    assert "await _get_catalog()" not in src, "#6524: get_catalog_entry must NOT use bare _get_catalog()"
+        asked: list[str] = []
+
+        async def _resolve(source_id):
+            asked.append(source_id)
+            if source_id == mod.BUILTIN_SOURCE_ID:
+                return []
+            return [dict(self.CUSTOM_ENTRY)]
+
+        async def _explode():
+            raise AssertionError("#6524 regression: endpoint bypassed source routing and called _get_catalog()")
+
+        monkeypatch.setattr(mod, "_resolve_catalog", _resolve)
+        monkeypatch.setattr(mod, "_get_catalog", _explode)
+        return asked
+
+    @pytest.mark.asyncio
+    async def test_install_resolves_against_the_browsed_source(self, routed):
+        """An install from a user-added marketplace must succeed — this is the
+        headline #6524 symptom (every such install 404'd)."""
+        from api.marketplace import install_plugin
+        from api.schemas_workflows import InstallRequest
+
+        redis = AsyncMock()
+        with patch("api.marketplace.get_async_redis_client", AsyncMock(return_value=redis)):
+            result = await install_plugin(
+                body=InstallRequest(plugin_name=self.CUSTOM_ENTRY["name"], source_id=self.CUSTOM_SOURCE),
+                user={"id": "u1"},
+            )
+
+        assert routed == [self.CUSTOM_SOURCE], f"install routed to {routed}, not the browsed source"
+        assert result["status"] == "installed"
+
+    @pytest.mark.asyncio
+    async def test_install_from_a_source_that_lacks_the_plugin_still_404s(self, routed):
+        """The mirror: routing must not become 'try every catalog'.
+
+        ``InstallRequest.source_id`` is a Pydantic default, so an omitted body
+        field really does arrive as the built-in source id here.
+        """
+        from fastapi import HTTPException
+
+        from api.marketplace import install_plugin
+        from api.schemas_workflows import InstallRequest
+
+        with pytest.raises(HTTPException) as exc_info:
+            await install_plugin(
+                body=InstallRequest(plugin_name=self.CUSTOM_ENTRY["name"]),
+                user={"id": "u1"},
+            )
+
+        assert exc_info.value.status_code == 404
+        assert routed == ["builtin"]
+
+    @pytest.mark.asyncio
+    async def test_detail_endpoint_resolves_against_the_browsed_source(self, routed):
+        """Deep-linking into a custom marketplace entry must resolve (#6524)."""
+        from api.marketplace import get_catalog_entry
+
+        entry = await get_catalog_entry(
+            plugin_name=self.CUSTOM_ENTRY["name"],
+            source_id=self.CUSTOM_SOURCE,
+            user={"id": "u1"},
+        )
+
+        assert routed == [self.CUSTOM_SOURCE]
+        assert entry.name == self.CUSTOM_ENTRY["name"]
+
+    @pytest.mark.asyncio
+    async def test_detail_endpoint_declared_default_routes_to_the_builtin_source(self, routed):
+        """Backward compat: an omitted ``?source_id=`` must still mean built-in.
+
+        The declared ``Query`` default is read and then *passed through the
+        endpoint*, because a direct call bypasses FastAPI's parameter
+        resolution — omitting the argument would hand the body a ``Query``
+        object and prove nothing.
+        """
+        from fastapi import HTTPException
+
+        from api.marketplace import BUILTIN_SOURCE_ID, get_catalog_entry
+
+        declared_default = inspect.signature(get_catalog_entry).parameters["source_id"].default.default
+        assert declared_default == BUILTIN_SOURCE_ID
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_catalog_entry(
+                plugin_name=self.CUSTOM_ENTRY["name"],
+                source_id=declared_default,
+                user={"id": "u1"},
+            )
+
+        assert exc_info.value.status_code == 404
+        assert routed == [BUILTIN_SOURCE_ID]

--- a/autobot-backend/api/provider_auth.py
+++ b/autobot-backend/api/provider_auth.py
@@ -81,7 +81,7 @@ async def _reject_redirect(resp, what: str) -> None:
     """
     if not 300 <= resp.status < 400:
         return
-    location = resp.headers.get("Location", "") if hasattr(resp, "headers") else ""
+    location = resp.headers.get("Location", "")
     logger.warning("%s returned HTTP %s; redirects are disabled (SSRF guard)", what, resp.status)
     target = f" -> {location[:100]}" if location else ""
     raise HTTPException(

--- a/autobot-backend/api/provider_auth.py
+++ b/autobot-backend/api/provider_auth.py
@@ -83,9 +83,10 @@ async def _reject_redirect(resp, what: str) -> None:
         return
     location = resp.headers.get("Location", "") if hasattr(resp, "headers") else ""
     logger.warning("%s returned HTTP %s; redirects are disabled (SSRF guard)", what, resp.status)
+    target = f" -> {location[:100]}" if location else ""
     raise HTTPException(
         status_code=status.HTTP_502_BAD_GATEWAY,
-        detail=f"{what} redirected (HTTP {resp.status}); redirects are disabled to prevent SSRF{location and ' -> ' + location[:100]}",
+        detail=f"{what} redirected (HTTP {resp.status}){target}; redirects are disabled to prevent SSRF",
     )
 
 

--- a/autobot-backend/api/provider_auth.py
+++ b/autobot-backend/api/provider_auth.py
@@ -69,6 +69,26 @@ def _validate_outbound_url(url: str) -> None:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
 
 
+async def _reject_redirect(resp, what: str) -> None:
+    """Turn an un-followed 3xx into a clean 502 (#13311).
+
+    ``allow_redirects=False`` stops a compromised-but-allowlisted provider
+    redirecting us to an internal host, but neither caller handled what comes
+    back: ``device_initiate`` only rejected ``>= 400`` and then indexed the
+    absent ``device_code``, and ``device_poll`` called ``resp.json()`` on an
+    HTML redirect body. Both raised an unhandled 500. A 3xx is never a valid
+    answer here, so say so.
+    """
+    if not 300 <= resp.status < 400:
+        return
+    location = resp.headers.get("Location", "") if hasattr(resp, "headers") else ""
+    logger.warning("%s returned HTTP %s; redirects are disabled (SSRF guard)", what, resp.status)
+    raise HTTPException(
+        status_code=status.HTTP_502_BAD_GATEWAY,
+        detail=f"{what} redirected (HTTP {resp.status}); redirects are disabled to prevent SSRF{location and ' -> ' + location[:100]}",
+    )
+
+
 async def _pinned_connector(url: str):
     """Resolve *url* once, assert it is public, and return an IP-pinned connector.
 
@@ -431,6 +451,7 @@ async def device_initiate(
                 headers={"Accept": "application/json"},
                 allow_redirects=False,
             ) as resp:
+                await _reject_redirect(resp, "Device authorization endpoint")
                 if resp.status >= 400:
                     body = await resp.text()
                     raise HTTPException(
@@ -508,6 +529,9 @@ async def device_poll(
                 headers={"Accept": "application/json"},
                 allow_redirects=False,
             ) as resp:
+                # A 400 here is normal (RFC-8628 carries `authorization_pending`
+                # in a 400 body), so only 3xx is rejected outright.
+                await _reject_redirect(resp, "Token endpoint")
                 data = await resp.json(content_type=None)
     except aiohttp.ClientError as exc:
         raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc)) from exc

--- a/autobot-backend/api/tests/test_provider_auth_device_poll_limit.py
+++ b/autobot-backend/api/tests/test_provider_auth_device_poll_limit.py
@@ -23,8 +23,12 @@ from auth_middleware import check_admin_permission, get_current_user
 
 
 class _FakeResp:
-    def __init__(self, data):
+    def __init__(self, data, status=200):
         self._data = data
+        # #13311: the device-flow callers reject a 3xx outright (redirects are
+        # disabled to prevent SSRF), so every response fake must carry a status.
+        self.status = status
+        self.headers: dict[str, str] = {}
 
     async def __aenter__(self):
         return self

--- a/autobot-backend/chat_history/cache_test.py
+++ b/autobot-backend/chat_history/cache_test.py
@@ -67,14 +67,63 @@ def test_env_var_zero_or_negative_falls_back_with_warning(caplog):
     assert any("must be positive" in r.getMessage() for r in caplog.records)
 
 
-def test_no_3600_literal_in_module_source():
-    """Pin the regression: original bug was `setex(key, 3600, ...)`."""
-    import inspect
+class TestTheTtlActuallySentToRedis:
+    """#6743's bug was ``setex(key, 3600, ...)`` -- a literal that ignored the
+    resolved TTL entirely.
 
-    import chat_history.cache as cache_mod
+    This used to assert ``"3600" not in inspect.getsource(...)`` (#13311),
+    which proves nothing about what Redis receives: any other hard-coded
+    number passes, and the assertion breaks the moment the call moves into a
+    helper. Observe the argument instead.
+    """
 
-    src = inspect.getsource(cache_mod.CacheMixin._async_cache_session)
-    assert "3600" not in src, "TTL must not be a 3600 literal in _async_cache_session"
+    @staticmethod
+    def _mixin_with_recording_redis(cache_mod):
+        """A CacheMixin instance whose Redis records every setex call."""
+        mixin = cache_mod.CacheMixin()
+        calls: list[tuple] = []
+
+        class _Redis:
+            @staticmethod
+            def setex(key, ttl, payload):
+                calls.append((key, ttl, payload))
+
+        mixin.redis_client = _Redis()
+        return mixin, calls
+
+    @pytest.mark.asyncio
+    async def test_setex_receives_the_resolved_ttl_not_a_literal(self):
+        cache_mod = _reload_cache_with_env(None)
+        mixin, calls = self._mixin_with_recording_redis(cache_mod)
+
+        await mixin._async_cache_session("chat:session:abc", {"messages": []})
+
+        assert len(calls) == 1, "session caching must reach Redis exactly once"
+        key, ttl, _payload = calls[0]
+        assert key == "chat:session:abc"
+        assert ttl == cache_mod._CHAT_SESSION_CACHE_TTL == 86_400
+
+    @pytest.mark.asyncio
+    async def test_env_override_changes_what_redis_is_told(self):
+        """The whole point of the knob: a configured TTL must reach Redis."""
+        cache_mod = _reload_cache_with_env("7200")
+        mixin, calls = self._mixin_with_recording_redis(cache_mod)
+
+        await mixin._async_cache_session("chat:session:abc", {"messages": []})
+
+        assert calls[0][1] == 7200, "a 3600 (or any hard-coded) literal would show up here"
+
+    @pytest.mark.asyncio
+    async def test_payload_is_the_serialized_session(self):
+        """Guard the mirror: pinning the TTL must not let the body rot."""
+        import json
+
+        cache_mod = _reload_cache_with_env(None)
+        mixin, calls = self._mixin_with_recording_redis(cache_mod)
+
+        await mixin._async_cache_session("chat:session:abc", {"messages": [{"role": "user"}]})
+
+        assert json.loads(calls[0][2]) == {"messages": [{"role": "user"}]}
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/code_analysis/src/remediation_loop_test.py
+++ b/autobot-backend/code_analysis/src/remediation_loop_test.py
@@ -417,9 +417,29 @@ class TestSnapshot:
 #
 # They are now parsed. Same intent, no false positives, no false negatives.
 
-FORBIDDEN_IMPORTS = {"subprocess", "os.system", "pty", "shutil"}
+# Top-level module names only: ``_imported_module_names`` keeps the first
+# dotted segment, so an entry like "os.system" here could never match. The
+# ``os.system`` *call* is caught by FORBIDDEN_CALLS below instead.
+FORBIDDEN_IMPORTS = {"subprocess", "pty", "shutil", "tempfile"}
 FORBIDDEN_CALLS = {"system", "popen", "Popen", "run", "call", "check_call", "check_output", "spawn"}
 WRITE_MODES = {"w", "wb", "a", "ab", "x", "xb", "w+", "r+", "a+"}
+# Writers that never go through ``open()`` at all -- ``Path.write_text``,
+# ``Path.write_bytes``, ``os.remove`` and friends mutate the filesystem just as
+# effectively, and the mode-argument check above cannot see any of them.
+FORBIDDEN_WRITE_METHODS = {
+    "write_text",
+    "write_bytes",
+    "mkdir",
+    "touch",
+    "unlink",
+    "rename",
+    "replace",
+    "remove",
+    "rmtree",
+    "copy",
+    "copy2",
+    "move",
+}
 
 
 def _module_ast(module) -> ast.Module:
@@ -437,16 +457,25 @@ def _imported_module_names(tree: ast.Module) -> set[str]:
     return names
 
 
-def _write_mode_open_calls(tree: ast.Module) -> list[ast.Call]:
-    """``open(...)`` calls whose mode argument is a writing mode."""
-    calls = []
+def _is_write_mode_open(node: ast.Call) -> bool:
+    """``open(...)`` / ``io.open(...)`` with a writing mode argument."""
+    name = getattr(node.func, "attr", None) or getattr(node.func, "id", None)
+    if name != "open":
+        return False
+    modes = list(node.args[1:2]) + [kw.value for kw in node.keywords if kw.arg == "mode"]
+    return any(isinstance(m, ast.Constant) and str(m.value) in WRITE_MODES for m in modes)
+
+
+def _filesystem_write_calls(tree: ast.Module) -> list[str]:
+    """Every call that can mutate the filesystem, by any route."""
+    found = []
     for node in ast.walk(tree):
-        if not isinstance(node, ast.Call) or getattr(node.func, "id", None) != "open":
+        if not isinstance(node, ast.Call):
             continue
-        modes = [a for a in node.args[1:2]] + [kw.value for kw in node.keywords if kw.arg == "mode"]
-        if any(isinstance(m, ast.Constant) and str(m.value) in WRITE_MODES for m in modes):
-            calls.append(node)
-    return calls
+        name = getattr(node.func, "attr", None) or getattr(node.func, "id", None)
+        if _is_write_mode_open(node) or name in FORBIDDEN_WRITE_METHODS:
+            found.append(f"{name} (line {node.lineno})")
+    return found
 
 
 def _shell_out_calls(tree: ast.Module) -> list[str]:
@@ -469,9 +498,9 @@ class ReadOnlyCapabilityChecks:
         violations = imported & FORBIDDEN_IMPORTS
         assert not violations, f"module imports process/filesystem mutation modules: {violations}"
 
-    def test_no_file_is_opened_for_writing(self):
-        calls = _write_mode_open_calls(_module_ast(self.mod))
-        assert not calls, f"open(..., <write mode>) at line(s) {[c.lineno for c in calls]}"
+    def test_nothing_writes_to_the_filesystem(self):
+        calls = _filesystem_write_calls(_module_ast(self.mod))
+        assert not calls, f"filesystem-mutating calls present: {calls}"
 
     def test_nothing_shells_out(self):
         found = _shell_out_calls(_module_ast(self.mod))
@@ -480,14 +509,29 @@ class ReadOnlyCapabilityChecks:
     def test_the_checks_would_notice_a_violation(self):
         """Guard the guards: a parser that finds nothing passes everything."""
         offending = ast.parse(
-            "import subprocess\n"
-            "def f():\n"
-            "    subprocess.Popen(['gh', 'pr', 'create'])\n"
-            "    open('/tmp/x', 'w').write('mutated')\n"
+            "import subprocess as sp\n"
+            "from pathlib import Path\n"
+            "def f(p):\n"
+            "    sp.Popen(['gh', 'pr', 'create'])\n"
+            "    open('/x', mode='a').write('mutated')\n"
+            "    Path(p).write_text('mutated')\n"
+            "    os.system('git commit')\n"
         )
         assert _imported_module_names(offending) & FORBIDDEN_IMPORTS == {"subprocess"}
-        assert _write_mode_open_calls(offending)
-        assert _shell_out_calls(offending)
+        writes = _filesystem_write_calls(offending)
+        assert any(w.startswith("open") for w in writes), writes
+        assert any(w.startswith("write_text") for w in writes), writes
+        shells = _shell_out_calls(offending)
+        assert any(s.startswith("Popen") for s in shells), shells
+        assert any(s.startswith("system") for s in shells), shells
+
+    def test_the_lint_does_not_fire_on_a_clean_module(self):
+        """The mirror: a read-only module must produce no findings at all."""
+        clean = ast.parse("import json\ndef f(p):\n    return json.loads(open(p).read())\n")
+
+        assert not _imported_module_names(clean) & FORBIDDEN_IMPORTS
+        assert not _filesystem_write_calls(clean)
+        assert not _shell_out_calls(clean)
 
 
 class TestReadOnlyContract(ReadOnlyCapabilityChecks):

--- a/autobot-backend/code_analysis/src/remediation_loop_test.py
+++ b/autobot-backend/code_analysis/src/remediation_loop_test.py
@@ -21,7 +21,10 @@ Test plan:
 
 from __future__ import annotations
 
+import ast
+import inspect
 import json
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -82,9 +85,13 @@ def _load_module():
     import importlib.util
     import sys
 
+    # #13311: resolved from this file, not from the process CWD. The literal
+    # relative path silently skipped every test in this module (the loader
+    # raised FileNotFoundError, which the except below turns into a skip)
+    # whenever pytest was invoked from anywhere but the repository root.
     spec = importlib.util.spec_from_file_location(
         "remediation_loop_test_module",
-        "autobot-backend/code_analysis/src/remediation_loop.py",
+        str(Path(__file__).resolve().parent / "remediation_loop.py"),
     )
     mod = importlib.util.module_from_spec(spec)
 
@@ -391,7 +398,99 @@ class TestSnapshot:
 # ---------------------------------------------------------------------------
 
 
-class TestReadOnlyContract:
+# ---------------------------------------------------------------------------
+# Read-only capability guard (#13311)
+# ---------------------------------------------------------------------------
+#
+# These five checks are a *lint*, not a behavioural contract, and they stay one:
+# proving the absence of a capability is exactly what source inspection is for,
+# and no amount of driving the module can show that a mutation path does not
+# exist. What was wrong with them was the substring matching:
+#
+#   * ``assert "gh " not in src``  matched this very comment, and any prose
+#     containing "gh " -- "through ", "high " -- so it fired on documentation.
+#   * ``assert "open(" not in src or '"w"' not in src`` passes whenever the
+#     module happens to contain no ``"w"`` anywhere else, and fails for an
+#     unrelated ``"w"`` in a docstring; it never inspected an actual call.
+#   * ``"import subprocess" not in src`` missed ``import subprocess as sp`` and
+#     ``from subprocess import run``.
+#
+# They are now parsed. Same intent, no false positives, no false negatives.
+
+FORBIDDEN_IMPORTS = {"subprocess", "os.system", "pty", "shutil"}
+FORBIDDEN_CALLS = {"system", "popen", "Popen", "run", "call", "check_call", "check_output", "spawn"}
+WRITE_MODES = {"w", "wb", "a", "ab", "x", "xb", "w+", "r+", "a+"}
+
+
+def _module_ast(module) -> ast.Module:
+    return ast.parse(inspect.getsource(module))
+
+
+def _imported_module_names(tree: ast.Module) -> set[str]:
+    """Every module reachable by import, aliases resolved."""
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            names.add(node.module.split(".")[0])
+    return names
+
+
+def _write_mode_open_calls(tree: ast.Module) -> list[ast.Call]:
+    """``open(...)`` calls whose mode argument is a writing mode."""
+    calls = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or getattr(node.func, "id", None) != "open":
+            continue
+        modes = [a for a in node.args[1:2]] + [kw.value for kw in node.keywords if kw.arg == "mode"]
+        if any(isinstance(m, ast.Constant) and str(m.value) in WRITE_MODES for m in modes):
+            calls.append(node)
+    return calls
+
+
+def _shell_out_calls(tree: ast.Module) -> list[str]:
+    """Calls whose *name* is a process-spawning primitive, wherever they sit."""
+    found = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        name = getattr(node.func, "attr", None) or getattr(node.func, "id", None)
+        if name in FORBIDDEN_CALLS and name != "run":
+            found.append(f"{name} (line {node.lineno})")
+    return found
+
+
+class ReadOnlyCapabilityChecks:
+    """Mixin: the read-only lint, shared by both contract classes below."""
+
+    def test_no_process_spawning_module_is_imported(self):
+        imported = _imported_module_names(_module_ast(self.mod))
+        violations = imported & FORBIDDEN_IMPORTS
+        assert not violations, f"module imports process/filesystem mutation modules: {violations}"
+
+    def test_no_file_is_opened_for_writing(self):
+        calls = _write_mode_open_calls(_module_ast(self.mod))
+        assert not calls, f"open(..., <write mode>) at line(s) {[c.lineno for c in calls]}"
+
+    def test_nothing_shells_out(self):
+        found = _shell_out_calls(_module_ast(self.mod))
+        assert not found, f"process-spawning calls present: {found}"
+
+    def test_the_checks_would_notice_a_violation(self):
+        """Guard the guards: a parser that finds nothing passes everything."""
+        offending = ast.parse(
+            "import subprocess\n"
+            "def f():\n"
+            "    subprocess.Popen(['gh', 'pr', 'create'])\n"
+            "    open('/tmp/x', 'w').write('mutated')\n"
+        )
+        assert _imported_module_names(offending) & FORBIDDEN_IMPORTS == {"subprocess"}
+        assert _write_mode_open_calls(offending)
+        assert _shell_out_calls(offending)
+
+
+class TestReadOnlyContract(ReadOnlyCapabilityChecks):
     """Assert that the module exposes NO code-mutation or dispatch entry point.
 
     Any function that writes source files, calls batch-implement, mutates code,
@@ -416,21 +515,6 @@ class TestReadOnlyContract:
         public_names = {name for name in dir(self.mod) if not name.startswith("__")}
         violations = forbidden_names & public_names
         assert not violations, f"Module exposes forbidden dispatch names: {violations}"
-
-    def test_no_subprocess_import(self):
-        """The module must not import subprocess (a proxy for shell mutation)."""
-        import inspect
-
-        src = inspect.getsource(self.mod)
-        assert "import subprocess" not in src, "Module must not import subprocess"
-
-    def test_no_open_write(self):
-        """The module must not open any file in write mode."""
-        import inspect
-
-        src = inspect.getsource(self.mod)
-        # open(..., "w") or open(..., mode="w") patterns
-        assert "open(" not in src or '"w"' not in src, "Module must not write files via open()"
 
     def test_remediation_loop_class_has_only_safe_methods(self):
         """RemediationLoop must only expose snapshot, select_targets, record_delta, dispatch_proposal."""
@@ -637,7 +721,7 @@ class TestDispatchProposalEnabled:
 # ---------------------------------------------------------------------------
 
 
-class TestDispatchReadOnlyContract:
+class TestDispatchReadOnlyContract(ReadOnlyCapabilityChecks):
     """Even with dispatch enabled, the module must not shell out, write files,
     or create PRs.  Mock the module constants to verify no forbidden I/O path
     is reachable via dispatch_proposal."""
@@ -658,27 +742,6 @@ class TestDispatchReadOnlyContract:
             }
             for i in range(count)
         ]
-
-    def test_no_subprocess_in_module_source(self):
-        import inspect
-
-        src = inspect.getsource(self.mod)
-        assert "import subprocess" not in src, "Module must never import subprocess"
-
-    def test_no_file_write_in_module_source(self):
-        import inspect
-
-        src = inspect.getsource(self.mod)
-        assert "open(" not in src or '"w"' not in src, "Module must not write files"
-
-    def test_no_gh_cli_call_in_source(self):
-        """No shelling out to gh CLI or git."""
-        import inspect
-
-        src = inspect.getsource(self.mod)
-        assert "gh " not in src
-        assert "os.system" not in src
-        assert "Popen" not in src
 
     def test_dispatch_enabled_returns_dict_no_network(self):
         """With gate enabled, dispatch_proposal returns a dict synchronously — no network."""

--- a/autobot-backend/computer_vision/computer_vision_refactoring_test.py
+++ b/autobot-backend/computer_vision/computer_vision_refactoring_test.py
@@ -7,6 +7,8 @@ Test suite for computer vision system refactoring (Issue #312)
 Verifies Tell Don't Ask pattern implementation and backward compatibility
 """
 
+from unittest.mock import patch
+
 import numpy as np
 import pytest
 
@@ -62,13 +64,42 @@ class TestUIElementCollection:
         ]
 
     def test_detect_application_type_form(self, sample_elements):
-        """Test application type detection for form applications"""
-        collection = UIElementCollection(sample_elements)
+        """Test application type detection for form applications.
+
+        Pre-existing red test found while converting this file (#13311): the
+        shared fixture carries ONE input field, but ``detect_application_type``
+        requires ``input_count > 3 and button_count > 1``, so it returned
+        "unknown". The heuristic is left alone -- lowering the threshold is a
+        product decision -- and the test now supplies a screen that genuinely
+        clears it.
+        """
+        form_fields = [
+            UIElement(
+                element_id=f"input_{i}",
+                element_type=ElementType.INPUT_FIELD,
+                bbox={"x": 10, "y": 100 + i * 40, "width": 200, "height": 30},
+                center_point=(110, 115 + i * 40),
+                confidence=0.85,
+                text_content="",
+                attributes={},
+                possible_interactions=[InteractionType.CLICK, InteractionType.TYPE_TEXT],
+            )
+            for i in range(2, 6)
+        ]
+        collection = UIElementCollection(sample_elements + form_fields)
         screenshot = np.zeros((100, 400, 3), dtype=np.uint8)
 
         app_type = collection.detect_application_type(screenshot)
 
         assert app_type == "form_application", "Should detect form application with inputs and buttons"
+
+    def test_detect_application_type_needs_more_than_three_inputs(self, sample_elements):
+        """Pin the threshold the test above depends on, so a change to the
+        heuristic surfaces here rather than as a mystery failure."""
+        collection = UIElementCollection(sample_elements)
+
+        assert collection.count_input_elements() == 1
+        assert collection.detect_application_type(np.zeros((100, 400, 3), dtype=np.uint8)) == "unknown"
 
     def test_detect_application_type_web(self):
         """Test application type detection for web browsers"""
@@ -238,26 +269,83 @@ class TestContextAnalyzer:
         assert "input_field" in distribution
 
 
+# #13311: a module-level element set for the delegation tests below. The two
+# per-class ``sample_elements`` fixtures above predate this file's split and are
+# left untouched; this one is scoped to the Feature-Envy checks.
+@pytest.fixture
+def context_elements():
+    """One clickable button and one typable input — enough for every branch."""
+    return [
+        UIElement(
+            element_id="button_1",
+            element_type=ElementType.BUTTON,
+            bbox={"x": 10, "y": 20, "width": 100, "height": 30},
+            center_point=(60, 35),
+            confidence=0.9,
+            text_content="Submit",
+            attributes={},
+            possible_interactions=[InteractionType.CLICK],
+        ),
+        UIElement(
+            element_id="input_1",
+            element_type=ElementType.INPUT_FIELD,
+            bbox={"x": 10, "y": 60, "width": 200, "height": 30},
+            center_point=(110, 75),
+            confidence=0.85,
+            text_content="",
+            attributes={},
+            possible_interactions=[InteractionType.CLICK, InteractionType.TYPE_TEXT],
+        ),
+    ]
+
+
 class TestFeatureEnvyElimination:
     """Verify Feature Envy code smells are eliminated"""
 
-    def test_context_analyzer_uses_collection(self):
-        """Verify ContextAnalyzer delegates to UIElementCollection (Tell Don't Ask)"""
-        import inspect
+    # Delegation is observed, not grepped (#13311): asserting
+    # ``"collection.count_by_type" in inspect.getsource(...)`` passed for a
+    # call sitting in a dead branch and failed for a rename that changed
+    # nothing, and it never showed that the collection's answer is the one the
+    # caller receives.
+    DELEGATED = [
+        ("detect_application_type", "application_type"),
+        ("calculate_interaction_complexity", "interaction_complexity"),
+        ("assess_automation_readiness", "automation_readiness"),
+        ("count_by_type", "dominant_element_types"),
+    ]
 
-        source = inspect.getsource(ContextAnalyzer.analyze_context)
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("method, context_key", DELEGATED)
+    async def test_each_context_field_comes_from_the_collection(self, context_elements, method, context_key):
+        """Stub one collection method and watch its value surface in the result."""
+        import computer_vision.classifiers as classifiers_mod
 
-        # Should create UIElementCollection and use its methods
-        assert "UIElementCollection" in source, "Should use UIElementCollection for analysis"
+        sentinel = f"sentinel-for-{method}"
+        with patch.object(classifiers_mod.UIElementCollection, method, return_value=sentinel):
+            context = await ContextAnalyzer().analyze_context(np.zeros((100, 400, 3), dtype=np.uint8), context_elements)
 
-        # Should NOT directly access element internals in loops
-        assert "for el in ui_elements" not in source, "Should NOT iterate elements directly - use collection methods"
+        assert context[context_key] == sentinel, (
+            f"context['{context_key}'] did not come from "
+            f"UIElementCollection.{method} — ContextAnalyzer computed it itself (Feature Envy)"
+        )
 
-        # Should use collection methods
-        assert "collection.detect_application_type" in source
-        assert "collection.calculate_interaction_complexity" in source
-        assert "collection.assess_automation_readiness" in source
-        assert "collection.count_by_type" in source
+    @pytest.mark.asyncio
+    async def test_the_collection_is_built_from_the_caller_s_elements(self, context_elements):
+        """Delegation to a collection built from *something else* would still
+        pass the per-field checks above."""
+        import computer_vision.classifiers as classifiers_mod
+
+        seen = []
+        original = classifiers_mod.UIElementCollection
+
+        def _record(elements):
+            seen.append(list(elements))
+            return original(elements)
+
+        with patch.object(classifiers_mod, "UIElementCollection", _record):
+            await ContextAnalyzer().analyze_context(np.zeros((100, 400, 3), dtype=np.uint8), context_elements)
+
+        assert seen == [list(context_elements)]
 
     def test_ui_element_collection_encapsulates_behavior(self):
         """Verify UIElementCollection owns element analysis logic"""

--- a/autobot-backend/llc/tests/test_haiku_tier.py
+++ b/autobot-backend/llc/tests/test_haiku_tier.py
@@ -198,9 +198,11 @@ class TestHireAgentNamedBindDict:
         no amount of driving the module can prove the absence of a string it
         never happens to execute in a test. What changed is that it now scans
         string literals via the AST instead of raw text, so a ``:name::type``
-        written in a comment or docstring (documenting the very bug) no longer
-        fails the build, and one hidden inside a multi-line SQL constant is
-        still caught.
+        written in a ``#`` comment (documenting the very bug) no longer fails
+        the build, while one hidden inside a multi-line SQL constant is still
+        caught. Docstrings are ``ast.Constant`` nodes and so are still scanned
+        -- deliberately: a docstring is where a copy-pasteable SQL example
+        lives, and a wrong example there propagates into real queries.
         """
         import ast
         import inspect
@@ -231,7 +233,7 @@ class TestHireAgentNamedBindDict:
             for match in pattern.findall(node.value)
         ]
 
-        assert offenders == [":company_id::uuid"], "the lint must catch SQL and ignore comments"
+        assert offenders == [":company_id::uuid"], "the lint must catch a SQL constant and ignore a # comment"
 
 
 # ===========================================================================

--- a/autobot-backend/llc/tests/test_haiku_tier.py
+++ b/autobot-backend/llc/tests/test_haiku_tier.py
@@ -191,14 +191,47 @@ class TestHireAgentNamedBindDict:
         )
 
     def test_no_naked_colon_colon_cast_after_named_bind(self) -> None:
-        """Guard against reintroducing ':name::type' anywhere in the module."""
+        """Guard against reintroducing ``:name::type`` in any SQL the module builds.
+
+        #13311 triage: this one stays a source-level check on purpose. It is a
+        *lint* -- "this token sequence must not appear in SQL we emit" -- and
+        no amount of driving the module can prove the absence of a string it
+        never happens to execute in a test. What changed is that it now scans
+        string literals via the AST instead of raw text, so a ``:name::type``
+        written in a comment or docstring (documenting the very bug) no longer
+        fails the build, and one hidden inside a multi-line SQL constant is
+        still caught.
+        """
+        import ast
         import inspect
         import re
 
-        mod = _get_agent_hires_mod()
-        source = inspect.getsource(mod)
-        offenders = re.findall(r":\w+::\w+", source)
+        pattern = re.compile(r":\w+::\w+")
+        tree = ast.parse(inspect.getsource(_get_agent_hires_mod()))
+        offenders = [
+            (node.lineno, match)
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Constant) and isinstance(node.value, str)
+            for match in pattern.findall(node.value)
+        ]
+
         assert not offenders, f"Use CAST(:name AS type), not ':name::type' (GH#12134): {offenders}"
+
+    def test_the_cast_lint_actually_matches(self) -> None:
+        """Guard the guard: a scanner that finds nothing passes everything."""
+        import ast
+        import re
+
+        pattern = re.compile(r":\w+::\w+")
+        tree = ast.parse('SQL = """SELECT :company_id::uuid FROM agent_hires"""\n# :other::uuid in a comment\n')
+        offenders = [
+            match
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Constant) and isinstance(node.value, str)
+            for match in pattern.findall(node.value)
+        ]
+
+        assert offenders == [":company_id::uuid"], "the lint must catch SQL and ignore comments"
 
 
 # ===========================================================================

--- a/autobot-backend/llm_shared/tests/test_provider_auth.py
+++ b/autobot-backend/llm_shared/tests/test_provider_auth.py
@@ -828,26 +828,12 @@ class TestProviderAuthSecurity:
             _validate_outbound_url("https://internal.corp/steal-metadata")
         assert exc_info.value.status_code == 400
 
-    def test_allow_redirects_false_in_device_initiate(self):
-        """Verify allow_redirects=False is wired into the aiohttp POST in device_initiate.
-
-        We inspect the source to confirm the argument is present, preventing
-        a 302-redirect SSRF bypass from an allowlisted host to an internal one.
-        """
-        import inspect
-
-        from api import provider_auth as _pa_module
-
-        src = inspect.getsource(_pa_module.device_initiate)
-        assert "allow_redirects=False" in src, "device_initiate must pass allow_redirects=False to aiohttp"
-
-    def test_allow_redirects_false_in_device_poll(self):
-        import inspect
-
-        from api import provider_auth as _pa_module
-
-        src = inspect.getsource(_pa_module.device_poll)
-        assert "allow_redirects=False" in src, "device_poll must pass allow_redirects=False to aiohttp"
+    # #13311: these two used to assert ``"allow_redirects=False" in
+    # inspect.getsource(...)``. That literal passes from a comment or a dead
+    # branch and breaks on any refactor, and it never established that the
+    # redirect is actually *not followed*. See
+    # ``TestRedirectsAreNotFollowedOnTheDeviceFlow`` below, which drives the
+    # endpoints against a session that follows redirects when told to.
 
     def test_malformed_port_returns_400_not_500(self):
         """#11066 audit: a malformed port raises ValueError on parsed.port access —
@@ -1051,3 +1037,151 @@ class TestVaultWriteCreatedByGuard:
         real = "11111111-2222-3333-4444-555555555555"
         created_by, _uuid = self._run(real)
         assert created_by == _uuid.UUID(real)
+
+
+# ---------------------------------------------------------------------------
+# #12278 / #13311: redirects on the device-code flow
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    """Minimal aiohttp response usable as an async context manager."""
+
+    def __init__(self, status: int, payload: dict | None, text: str = ""):
+        self.status = status
+        self.headers = {"Location": "https://internal.invalid/token"} if 300 <= status < 400 else {}
+        self._payload = payload
+        self._text = text
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_exc):
+        return False
+
+    async def json(self, content_type=None):
+        if self._payload is None:
+            # A real 302 body is HTML; aiohttp raises rather than inventing a dict.
+            raise ValueError("Expecting value: line 1 column 1 (char 0)")
+        return self._payload
+
+    async def text(self):
+        return self._text
+
+
+class _RedirectFollowingSession:
+    """A session that follows a 302 exactly when ``allow_redirects`` says so.
+
+    Real ``aiohttp`` does this internally, so a fake that always returns the
+    302 could never tell a fixed caller from a broken one. Here the redirect
+    target stands in for the internal host an SSRF bypass would reach: if the
+    caller opts into following it, the endpoint receives a *successful* token
+    payload sourced from somewhere the allowlist never approved.
+    """
+
+    INTERNAL_PAYLOAD = {
+        "device_code": "leaked",
+        "user_code": "LEAKED",
+        "verification_uri": "https://internal.invalid/",
+        "access_token": "leaked-token",
+        "token_type": "bearer",
+    }
+
+    def __init__(self, **_kwargs):
+        self.calls: list[dict] = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_exc):
+        return False
+
+    def post(self, url, **kwargs):
+        self.calls.append({"url": url, **kwargs})
+        if kwargs.get("allow_redirects"):
+            return _FakeResponse(200, dict(self.INTERNAL_PAYLOAD))
+        return _FakeResponse(302, None, text="<html>Found</html>")
+
+
+class TestRedirectsAreNotFollowedOnTheDeviceFlow:
+    """A 302 from an allowlisted host must not be chased to an internal one.
+
+    Replaces two ``inspect.getsource`` greps for the literal
+    ``allow_redirects=False`` (#13311) with the consequence a caller can see.
+    """
+
+    ALLOWED_DEVICE_URL = "https://accounts.google.com/o/oauth2/device/code"
+    ALLOWED_TOKEN_URL = "https://oauth2.googleapis.com/token"
+
+    @pytest.fixture
+    def session_spy(self, monkeypatch):
+        """Swap aiohttp's session and neuter the DNS-pinning connector."""
+        import aiohttp
+
+        from api import provider_auth as pa
+
+        created: list[_RedirectFollowingSession] = []
+
+        def _factory(**kwargs):
+            session = _RedirectFollowingSession(**kwargs)
+            created.append(session)
+            return session
+
+        monkeypatch.setattr(aiohttp, "ClientSession", _factory)
+        monkeypatch.setattr(pa, "_pinned_connector", AsyncMock(return_value=None))
+        return created
+
+    @pytest.mark.asyncio
+    async def test_device_initiate_surfaces_the_302_instead_of_following_it(self, session_spy):
+        from fastapi import HTTPException
+
+        from api.provider_auth import DeviceInitiateRequest, device_initiate
+
+        with pytest.raises(HTTPException) as exc_info:
+            await device_initiate(
+                req=DeviceInitiateRequest(
+                    provider_name="google",
+                    client_id="cid",
+                    device_authorization_url=self.ALLOWED_DEVICE_URL,
+                ),
+                user={"id": "u1"},
+                _admin=True,
+            )
+
+        assert exc_info.value.status_code == 502, "a followed redirect would have returned 200 and leaked a device code"
+        assert session_spy[0].calls[0]["allow_redirects"] is False
+
+    @pytest.mark.asyncio
+    async def test_device_poll_surfaces_the_302_instead_of_following_it(self, session_spy, monkeypatch):
+        from fastapi import HTTPException
+
+        from api import provider_auth as pa
+        from api.provider_auth import DevicePollRequest, device_poll
+
+        monkeypatch.setattr(pa, "get_redis_client", lambda database=None: None)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await device_poll(
+                req=DevicePollRequest(
+                    provider_name="google",
+                    client_id="cid",
+                    device_code="dc",
+                    token_url=self.ALLOWED_TOKEN_URL,
+                ),
+                session=AsyncMock(),
+                user={"id": "u1"},
+                _admin=True,
+            )
+
+        assert exc_info.value.status_code == 502, "a followed redirect would have persisted an internally-sourced token"
+        assert session_spy[0].calls[0]["allow_redirects"] is False
+
+    @pytest.mark.asyncio
+    async def test_the_spy_really_would_have_followed_a_redirect(self, session_spy):
+        """Guard the guard: prove the fake distinguishes the two settings."""
+        session = _RedirectFollowingSession()
+        async with session.post("https://x/", allow_redirects=True) as resp:
+            assert resp.status == 200
+            assert (await resp.json())["access_token"] == "leaked-token"
+        async with session.post("https://x/", allow_redirects=False) as resp:
+            assert resp.status == 302

--- a/autobot-backend/llm_shared/tests/test_provider_registry_key_coverage.py
+++ b/autobot-backend/llm_shared/tests/test_provider_registry_key_coverage.py
@@ -23,7 +23,6 @@ import pytest
 
 from services.provider_key_vault import LLM_PROVIDER_KEY_NAMES
 
-
 # Names whose resolution is gated behind a *separate* setting, so a bare
 # registry build never reaches them.  The gate is enabled below rather than
 # excused: a vault name that no reachable configuration consults would be dead,

--- a/autobot-backend/llm_shared/tests/test_provider_registry_key_coverage.py
+++ b/autobot-backend/llm_shared/tests/test_provider_registry_key_coverage.py
@@ -1,0 +1,97 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Every vault-declared provider key must be resolved at registry build time.
+
+``LLM_PROVIDER_KEY_NAMES`` is the set of API-key names the provider-key vault
+captures and hydrates (#10088 Task 7).  A name in that set that no provider
+ever asks for is dead configuration: the operator stores a key and nothing
+consumes it.
+
+The check used to sit in ``tests/migrations/test_provider_key_vault.py`` as
+``assert name in inspect.getsource(_populate_default_providers)`` -- a grep
+that a docstring mention satisfied, and that the module's ``requires_postgres``
+gate skipped entirely on any machine without a disposable Postgres (#13311).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from services.provider_key_vault import LLM_PROVIDER_KEY_NAMES
+
+
+# Names whose resolution is gated behind a *separate* setting, so a bare
+# registry build never reaches them.  The gate is enabled below rather than
+# excused: a vault name that no reachable configuration consults would be dead,
+# and the grep this file replaced could not tell the two apart.
+GATED_BY = {"CUSTOM_OPENAI_API_KEY": ("custom_openai_base_url", "https://custom-openai.invalid/v1")}
+
+
+@pytest.fixture
+def resolved_key_names(monkeypatch) -> list[str]:
+    """Run the registry build, recording every key name it resolves.
+
+    The spy returns ``""`` so no cloud provider is constructed: the assertion
+    is about which names are *asked for*, and building real providers would
+    need credentials and network.
+    """
+    import services.provider_key_vault as vault_mod
+    from autobot_shared.ssot_config import config
+    from llm_shared import provider_registry
+
+    for _name, (setting, value) in GATED_BY.items():
+        monkeypatch.setattr(config, setting, value, raising=False)
+
+    asked: list[str] = []
+
+    def _spy(name: str, fallback: str = "") -> str:
+        asked.append(name)
+        return ""
+
+    monkeypatch.setattr(vault_mod, "resolve_provider_key", _spy)
+    provider_registry._populate_default_providers(MagicMock())
+    return asked
+
+
+def test_the_gated_names_really_are_gated(monkeypatch) -> None:
+    """Document the gap the coverage fixture papers over.
+
+    Storing ``CUSTOM_OPENAI_API_KEY`` in the vault does nothing at all unless
+    ``CUSTOM_OPENAI_BASE_URL`` is also set, and the only signal is a DEBUG log.
+    Pin that so the coupling cannot change silently.
+    """
+    import services.provider_key_vault as vault_mod
+    from autobot_shared.ssot_config import config
+    from llm_shared import provider_registry
+
+    asked: list[str] = []
+    monkeypatch.setattr(vault_mod, "resolve_provider_key", lambda name, fallback="": (asked.append(name), "")[1])
+    for _name, (setting, _value) in GATED_BY.items():
+        monkeypatch.setattr(config, setting, "", raising=False)
+    provider_registry._populate_default_providers(MagicMock())
+
+    assert set(GATED_BY) & set(asked) == set(), "gate removed -- update GATED_BY, it is now unconditional"
+
+
+def test_the_spy_saw_the_registry_run(resolved_key_names: list[str]) -> None:
+    """Guard the guard: an empty recording would satisfy every assertion below."""
+    assert resolved_key_names, "_populate_default_providers resolved no keys at all"
+
+
+def test_every_declared_name_is_resolved_at_runtime(resolved_key_names: list[str]) -> None:
+    """A declared name nobody asks for is a key the operator stores in vain."""
+    missing = [name for name in LLM_PROVIDER_KEY_NAMES if name not in resolved_key_names]
+
+    assert not missing, f"declared in LLM_PROVIDER_KEY_NAMES but never resolved at runtime: {missing}"
+
+
+def test_no_key_is_resolved_under_a_name_the_vault_never_captures(resolved_key_names: list[str]) -> None:
+    """The mirror: a name the registry asks for but the vault never stores can
+    only ever be served from the environment, never from the vault."""
+    unknown = sorted(set(resolved_key_names) - set(LLM_PROVIDER_KEY_NAMES))
+
+    assert not unknown, f"resolved through the vault but never captured into it: {unknown}"

--- a/autobot-backend/orchestration/workflow_documentation_summary_test.py
+++ b/autobot-backend/orchestration/workflow_documentation_summary_test.py
@@ -150,17 +150,51 @@ async def test_summary_swallows_exception_and_logs(make_llm_response: Any, caplo
 
 
 # ---------------------------------------------------------------------------
-# Source-level pin — catches reintroduction of the bug
+# Migration pin — #3185 retired LLMService.chat_completion
 # ---------------------------------------------------------------------------
 
 
-def test_source_does_not_call_chat_completion() -> None:
-    """Read the source of the migrated method and assert the legacy
-    method name is gone. Catches future regressions even if no test
-    runtime path covers them.
+@pytest.mark.asyncio
+async def test_summary_never_reaches_for_the_retired_chat_completion(make_llm_response: Any) -> None:
+    """``chat_completion`` no longer exists on LLMService, so calling it would
+    raise AttributeError at runtime and the broad except-guard would swallow it
+    into a missing summary — silently, exactly like the original defect.
+
+    This replaces ``assert ".chat_completion(" not in inspect.getsource(...)``
+    (#13311): a comment mentioning the old name failed that grep, and moving
+    the call into a helper failed it too, while neither told us what the
+    method actually calls.
     """
-    src = inspect.getsource(WorkflowDocumenter._generate_llm_summary)
-    assert ".chat_completion(" not in src, (
-        "_generate_llm_summary must call llm_service.chat(...), " "not the deleted-from-LLMService chat_completion(...)"
-    )
-    assert ".chat(" in src, "expected a llm_service.chat(...) call"
+    llm_service = AsyncMock()
+    llm_service.chat = AsyncMock(return_value=make_llm_response(content="a summary", error=None))
+    llm_service.chat_completion = AsyncMock(side_effect=AssertionError("retired LLMService.chat_completion called"))
+
+    documenter = WorkflowDocumenter(llm_service=llm_service)
+    workflow_doc = _make_workflow_doc()
+
+    await documenter._generate_llm_summary(workflow_doc, {"status": "completed"})
+
+    assert workflow_doc.content["generated_summary"] == "a summary"
+    llm_service.chat.assert_awaited_once()
+    llm_service.chat_completion.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_a_service_without_chat_produces_no_summary_and_logs(caplog) -> None:
+    """The mirror of the guard above: pin that an absent ``chat`` is visible.
+
+    ``spec=[]`` gives an object with no attributes at all, so any method name
+    the documenter reaches for raises — the observable is the warning, not a
+    silently empty document.
+    """
+    import logging
+    from unittest.mock import MagicMock
+
+    documenter = WorkflowDocumenter(llm_service=MagicMock(spec=[]))
+    workflow_doc = _make_workflow_doc()
+
+    with caplog.at_level(logging.WARNING):
+        await documenter._generate_llm_summary(workflow_doc, {"status": "completed"})
+
+    assert "generated_summary" not in workflow_doc.content
+    assert any("Failed to generate workflow summary" in r.message for r in caplog.records)

--- a/autobot-backend/secure_command_executor_argument_aware_test.py
+++ b/autobot-backend/secure_command_executor_argument_aware_test.py
@@ -148,28 +148,68 @@ def test_dns_recon_classifies_at_least_moderate(
 # ---------------------------------------------------------------------------
 
 
-def test_argument_aware_check_runs_before_base_command_lookup() -> None:
-    """Pin the architectural decision: argument-aware checks fire BEFORE
-    the base-command allowlist. Otherwise `docker run --privileged …`
-    would resolve as MODERATE (docker is allowlisted) and miss the
-    elevation.
+class TestArgumentAwareRiskWinsOverTheAllowlistedBaseCommand:
+    """Pin the architectural decision *by its consequence*.
 
-    Scoped to `assess_command_risk` body only — `_extract_command_name`
-    appears in many sibling helpers; we want the order WITHIN
-    `assess_command_risk` itself.
+    Argument-aware checks fire BEFORE the base-command allowlist, otherwise
+    ``docker run --privileged ...`` resolves as whatever ``docker`` alone is
+    worth and the elevation is lost.
+
+    This used to compare ``src.find("_check_argument_aware_risk")`` against
+    ``src.find("base_command = self._extract_command_name")`` inside
+    ``inspect.getsource(assess_command_risk)`` (#13311): it broke on any
+    rename or extraction, and it never checked that the ordering *mattered* --
+    it would have passed just as happily if both branches returned the same
+    thing.
     """
-    import inspect
 
-    import secure_command_executor as mod
+    @staticmethod
+    def _bare_base_command_risk(executor: SecureCommandExecutor, base: str) -> CommandRisk:
+        """What the allowlist alone says about the base command."""
+        risk, _reasons = executor.assess_command_risk(base)
+        return risk
 
-    src = inspect.getsource(mod.SecureCommandExecutor.assess_command_risk)
-    arg_aware_pos = src.find("_check_argument_aware_risk")
-    base_lookup_pos = src.find("base_command = self._extract_command_name")
-    assert arg_aware_pos != -1, "_check_argument_aware_risk must be wired into assess_command_risk"
-    assert base_lookup_pos != -1, "base_command extraction must be present in assess_command_risk"
-    assert arg_aware_pos < base_lookup_pos, (
-        "#7384: _check_argument_aware_risk must run BEFORE the "
-        "`base_command = self._extract_command_name(...)` call inside "
-        "assess_command_risk so argument-elevated risks override the "
-        "allowlisted base command."
+    @pytest.mark.parametrize(
+        "base, elevated",
+        [
+            ("docker ps", "docker run --privileged alpine"),
+            ("find /tmp -name x", "find / -perm -4000"),
+        ],
     )
+    def test_the_argument_elevates_above_the_base_commands_own_rating(
+        self, executor: SecureCommandExecutor, base: str, elevated: str
+    ) -> None:
+        """If the allowlist were consulted first, both would rate the same."""
+        base_risk = self._bare_base_command_risk(executor, base)
+        elevated_risk, reasons = executor.assess_command_risk(elevated)
+
+        order = list(CommandRisk)
+        assert order.index(elevated_risk) > order.index(base_risk), (
+            f"#7384: `{elevated}` rated {elevated_risk.value}, the same or less than "
+            f"`{base}` at {base_risk.value} -- the allowlist won, so the "
+            f"argument-aware check no longer runs first. Reasons: {reasons}"
+        )
+
+    def test_the_reason_names_the_argument_not_the_base_command(self, executor: SecureCommandExecutor) -> None:
+        """Ordering is only useful if the *more specific* reason survives."""
+        _risk, reasons = executor.assess_command_risk("docker run --privileged alpine")
+
+        joined = " ".join(reasons).lower()
+        assert "--privileged" in joined, f"expected the offending flag in the reasons; got {reasons}"
+
+    def test_a_dangerous_env_var_prefix_still_outranks_the_argument_check(
+        self, executor: SecureCommandExecutor
+    ) -> None:
+        """#7375 sits ahead of #7384; guard that this ordering did not invert."""
+        risk, reasons = executor.assess_command_risk("LD_PRELOAD=/tmp/e.so docker run --privileged alpine")
+
+        assert risk == CommandRisk.FORBIDDEN
+        assert any("env-var prefix" in r.lower() for r in reasons), reasons
+
+    def test_an_allowlisted_command_without_the_argument_is_not_elevated(
+        self, executor: SecureCommandExecutor
+    ) -> None:
+        """The mirror: the argument-aware branch must not swallow normal use."""
+        risk, _reasons = executor.assess_command_risk("docker ps")
+
+        assert risk != CommandRisk.FORBIDDEN

--- a/autobot-backend/secure_command_executor_argument_aware_test.py
+++ b/autobot-backend/secure_command_executor_argument_aware_test.py
@@ -206,9 +206,7 @@ class TestArgumentAwareRiskWinsOverTheAllowlistedBaseCommand:
         assert risk == CommandRisk.FORBIDDEN
         assert any("env-var prefix" in r.lower() for r in reasons), reasons
 
-    def test_an_allowlisted_command_without_the_argument_is_not_elevated(
-        self, executor: SecureCommandExecutor
-    ) -> None:
+    def test_an_allowlisted_command_without_the_argument_is_not_elevated(self, executor: SecureCommandExecutor) -> None:
         """The mirror: the argument-aware branch must not swallow normal use."""
         risk, _reasons = executor.assess_command_risk("docker ps")
 

--- a/autobot-backend/security/service_auth.py
+++ b/autobot-backend/security/service_auth.py
@@ -19,6 +19,7 @@ from fastapi import HTTPException, Request
 
 from autobot_shared.redis_client import get_async_redis_client
 from autobot_shared.service_signing import _service_signature
+from autobot_shared.ssot_config import config
 from constants.ttl_constants import TTL_90_DAYS
 from utils.catalog_http_exceptions import raise_auth_error, raise_server_error
 
@@ -36,7 +37,10 @@ class ServiceAuthManager:
             redis_client: AsyncRedisDatabase instance for key storage
         """
         self.redis = redis_client
-        self.timestamp_window = 300  # 5 minutes - prevents replay attacks
+        # #13335: AUTH_TIMESTAMP_WINDOW was written by the service_auth Ansible
+        # role and by export_service_keys.py but read by nobody -- this value was
+        # hard-coded, so the documented knob silently did nothing.
+        self.timestamp_window = config.service_auth_timestamp_window
 
     async def generate_service_key(self, service_id: str) -> str:
         """

--- a/autobot-backend/tests/migrations/test_provider_key_vault.py
+++ b/autobot-backend/tests/migrations/test_provider_key_vault.py
@@ -167,12 +167,10 @@ async def test_hydrate_never_logs_secret_value(session, caplog, monkeypatch):
     assert plaintext not in caplog.text
 
 
-def test_all_names_have_a_real_runtime_reader():
-    """Every name here must actually be consulted by provider_registry (no dead entries)."""
-    import inspect
-
-    from llm_shared import provider_registry
-
-    source = inspect.getsource(provider_registry._populate_default_providers)
-    for name in LLM_PROVIDER_KEY_NAMES:
-        assert name in source, f"{name} is declared but never resolved in _populate_default_providers"
+# #13311: the "every declared name has a real runtime reader" check used to
+# live here as an ``inspect.getsource`` grep over
+# ``provider_registry._populate_default_providers``.  It is now a behavioural
+# test that records which names the registry actually resolves, and it moved to
+# ``llm_shared/tests/test_provider_registry_key_coverage.py`` because this
+# module is gated behind ``requires_postgres`` -- a coverage assertion that
+# needs no database must not be skipped along with the migration tests.

--- a/autobot-backend/tests/migrations/test_provider_key_vault.py
+++ b/autobot-backend/tests/migrations/test_provider_key_vault.py
@@ -21,7 +21,6 @@ from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from autobot_shared.secrets_vault import VaultKind, VaultRef
 from services.envelope_secrets_service import EnvelopeSecretsService
 from services.provider_key_vault import (
-    LLM_PROVIDER_KEY_NAMES,
     _hydrated_keys,
     capture_provider_key,
     hydrate_provider_keys_from_vault,

--- a/autobot-backend/tests/test_memory_graph_init_contract_12873.py
+++ b/autobot-backend/tests/test_memory_graph_init_contract_12873.py
@@ -16,7 +16,9 @@ error because nothing had failed, which is why #12780's fix removed the visible
 errors without recovering the feature.
 """
 
+import ast
 import inspect
+import textwrap
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -82,10 +84,39 @@ def test_signature_declares_a_bool_return():
     )
 
 
-def test_every_exit_path_returns_true_or_raises():
-    """No path may fall off the end and implicitly return None again."""
-    src = inspect.getsource(AutoBotMemoryGraph.initialize)
-    body = src.split('"""', 2)[-1]
+def _return_statements(func) -> list[ast.Return]:
+    """Every ``return`` in *func*, parsed rather than grepped.
 
-    assert body.count("return True") == 2, "expected the early-return and success paths to return True"
-    assert "return False" not in body, "failures raise; a False return would be silently unactionable"
+    ``assert body.count("return True") == 2`` (#13311) counted literals in the
+    source text: it matched a ``return True`` in a comment, missed
+    ``return bool(...)``, and pinned the exact number of branches so any
+    refactor broke it. The property that actually matters is that no exit path
+    yields a falsy value.
+    """
+    tree = ast.parse(textwrap.dedent(inspect.getsource(func)))
+    return [node for node in ast.walk(tree) if isinstance(node, ast.Return)]
+
+
+def test_no_exit_path_yields_a_falsy_value():
+    """The #12873 defect: a successful init that the caller reads as failure."""
+    returns = _return_statements(AutoBotMemoryGraph.initialize)
+
+    assert returns, "initialize has no return statement at all — it falls through to None"
+    for node in returns:
+        assert node.value is not None, f"bare `return` at line {node.lineno} yields None — the original bug"
+        assert not isinstance(node.value, ast.Constant) or bool(node.value.value), (
+            f"`return {ast.unparse(node.value)}` at line {node.lineno} is falsy; "
+            "a failed init must raise so the cause reaches the caller"
+        )
+
+
+def test_the_function_cannot_fall_off_its_end():
+    """A trailing non-return statement re-creates the implicit ``return None``."""
+    tree = ast.parse(textwrap.dedent(inspect.getsource(AutoBotMemoryGraph.initialize)))
+    func = tree.body[0]
+    last = func.body[-1]
+
+    assert isinstance(last, (ast.Return, ast.Raise, ast.With, ast.AsyncWith, ast.Try)), (
+        f"initialize ends with {type(last).__name__}; execution can reach the end of "
+        "the function and implicitly return None (#12873)"
+    )

--- a/autobot-backend/utils/file_locking_test.py
+++ b/autobot-backend/utils/file_locking_test.py
@@ -46,33 +46,23 @@ class TestWebsocketsNPUEventsLocking:
 
         assert hasattr(websockets, "_npu_events_subscribed")
 
-    def test_subscription_happens_exactly_once_under_contention(self):
-        """The #513 defect: without the lock, racing callers each subscribed.
-
-        This used to grep ``inspect.getsource`` for ``with _npu_events_lock:``
-        and count occurrences of the flag name (#13311) -- a pattern match that
-        passes for a lock held around the wrong thing, and breaks on any
-        refactor. The observable is duplicate subscriptions: a handler
-        registered N times fires N times per event.
-        """
-        import threading
-
-        from api import websockets
-
-        websockets._npu_events_subscribed = False
-        subscriptions = []
-        barrier = threading.Barrier(THREAD_COUNT)
-        errors = []
-
+    @staticmethod
+    def _slow_recording_bus(subscriptions: list) -> MagicMock:
+        """A bus whose subscribe is slow enough to expose an unguarded check."""
         bus = MagicMock()
 
-        def _record(topic, handler):
-            # Widen the race the lock has to close: a slow subscribe is what
-            # lets a second thread through an unguarded check.
+        def _record(topic, _handler):
             subscriptions.append(topic)
             time.sleep(0.001)
 
         bus.subscribe = _record
+        return bus
+
+    @staticmethod
+    def _init_concurrently(websockets, bus) -> list:
+        """Release THREAD_COUNT initialisers at once; return their errors."""
+        barrier = threading.Barrier(THREAD_COUNT)
+        errors = []
 
         def _init():
             try:
@@ -87,6 +77,23 @@ class TestWebsocketsNPUEventsLocking:
                 t.start()
             for t in threads:
                 t.join(timeout=10)
+        return errors
+
+    def test_subscription_happens_exactly_once_under_contention(self):
+        """The #513 defect: without the lock, racing callers each subscribed.
+
+        This used to grep ``inspect.getsource`` for ``with _npu_events_lock:``
+        and count occurrences of the flag name (#13311) -- a pattern match that
+        passes for a lock held around the wrong thing, and breaks on any
+        refactor. The observable is duplicate subscriptions: a handler
+        registered N times fires N times per event.
+        """
+        from api import websockets
+
+        websockets._npu_events_subscribed = False
+        subscriptions = []
+
+        errors = self._init_concurrently(websockets, self._slow_recording_bus(subscriptions))
 
         assert not errors, f"errors during concurrent init: {errors}"
         assert len(subscriptions) == len(set(subscriptions)), (

--- a/autobot-backend/utils/file_locking_test.py
+++ b/autobot-backend/utils/file_locking_test.py
@@ -20,10 +20,14 @@ These tests verify the acceptance criteria:
 import asyncio
 import tempfile
 import threading
+import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+# Enough concurrency to lose an unguarded double-check reliably on WSL2/CI.
+THREAD_COUNT = 20
 
 
 class TestWebsocketsNPUEventsLocking:
@@ -42,19 +46,68 @@ class TestWebsocketsNPUEventsLocking:
 
         assert hasattr(websockets, "_npu_events_subscribed")
 
-    def test_init_npu_worker_websocket_uses_lock(self):
-        """Test that init_npu_worker_websocket uses the lock"""
-        import inspect
+    def test_subscription_happens_exactly_once_under_contention(self):
+        """The #513 defect: without the lock, racing callers each subscribed.
+
+        This used to grep ``inspect.getsource`` for ``with _npu_events_lock:``
+        and count occurrences of the flag name (#13311) -- a pattern match that
+        passes for a lock held around the wrong thing, and breaks on any
+        refactor. The observable is duplicate subscriptions: a handler
+        registered N times fires N times per event.
+        """
+        import threading
 
         from api import websockets
 
-        source = inspect.getsource(websockets.init_npu_worker_websocket)
+        websockets._npu_events_subscribed = False
+        subscriptions = []
+        barrier = threading.Barrier(THREAD_COUNT)
+        errors = []
 
-        # Verify double-checked locking pattern
-        assert "_npu_events_lock" in source, "Lock not used in function"
-        assert "with _npu_events_lock:" in source, "Lock context manager not used"
-        # Check for double-check pattern (two checks of _npu_events_subscribed)
-        assert source.count("_npu_events_subscribed") >= 2, "Double-checked locking not implemented"
+        bus = MagicMock()
+
+        def _record(topic, handler):
+            # Widen the race the lock has to close: a slow subscribe is what
+            # lets a second thread through an unguarded check.
+            subscriptions.append(topic)
+            time.sleep(0.001)
+
+        bus.subscribe = _record
+
+        def _init():
+            try:
+                barrier.wait(timeout=5)
+                websockets.init_npu_worker_websocket()
+            except Exception as exc:  # noqa: BLE001 - reported via `errors`
+                errors.append(exc)
+
+        with patch.object(websockets, "get_event_bus", lambda: bus):
+            threads = [threading.Thread(target=_init) for _ in range(THREAD_COUNT)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join(timeout=10)
+
+        assert not errors, f"errors during concurrent init: {errors}"
+        assert len(subscriptions) == len(set(subscriptions)), (
+            f"#513 regression: {len(subscriptions)} subscribe() calls for "
+            f"{len(set(subscriptions))} distinct topics — every event would be "
+            f"broadcast more than once"
+        )
+        assert websockets._npu_events_subscribed is True
+
+    def test_a_failed_subscribe_does_not_latch_the_flag(self):
+        """The mirror: the flag must not claim success the bus never gave."""
+        from api import websockets
+
+        websockets._npu_events_subscribed = False
+        bus = MagicMock()
+        bus.subscribe = MagicMock(side_effect=RuntimeError("bus down"))
+
+        with patch.object(websockets, "get_event_bus", lambda: bus):
+            websockets.init_npu_worker_websocket()
+
+        assert websockets._npu_events_subscribed is False, "a failed subscribe must stay retryable"
 
     def test_concurrent_init_npu_worker_websocket(self):
         """Test concurrent calls to init_npu_worker_websocket"""

--- a/autobot-backend/utils/thread_safety_test.py
+++ b/autobot-backend/utils/thread_safety_test.py
@@ -21,6 +21,9 @@ from unittest.mock import MagicMock
 
 import pytest
 
+# Enough concurrency to lose an unguarded double-check reliably on WSL2/CI.
+THREAD_COUNT = 20
+
 
 def _require_real_tracing_service() -> None:
     """Skip when OpenTelemetry is absent; fail when TracingService is a stub.
@@ -327,20 +330,77 @@ class TestDoubleCheckedLocking:
         """Guard: real TracingService or skip — never a Mock (#11681, #13094)."""
         _require_real_tracing_service()
 
-    def test_tracing_service_double_check(self):
-        """Test TracingService uses double-checked locking"""
-        import inspect
+    def test_racing_constructors_all_get_the_same_instance(self):
+        """The #481 defect: two threads past an unguarded check each built one.
+
+        This used to grep ``inspect.getsource(TracingService.__new__)`` for
+        ``with cls._lock:`` and count ``_instance is None`` (#13311) -- a shape
+        match that says nothing about whether the lock guards the right thing,
+        and that a rename breaks. Race the constructor instead and assert the
+        singleton identity every caller depends on.
+        """
+        import threading
 
         from services.tracing_service import TracingService
 
-        # Get the source of __new__
-        source = inspect.getsource(TracingService.__new__)
+        TracingService.reset_instance()
+        barrier = threading.Barrier(THREAD_COUNT)
+        instances = []
+        errors = []
 
-        # Verify double-check pattern exists
-        assert "if cls._instance is None:" in source
-        assert "with cls._lock:" in source
-        # Should have two None checks (outer and inner)
-        assert source.count("_instance is None") >= 2, "Double-checked locking not implemented"
+        def _construct():
+            try:
+                barrier.wait(timeout=5)
+                instances.append(TracingService())
+            except Exception as exc:  # noqa: BLE001 - reported via `errors`
+                errors.append(exc)
+
+        threads = [threading.Thread(target=_construct) for _ in range(THREAD_COUNT)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        assert not errors, f"errors during concurrent construction: {errors}"
+        assert len(instances) == THREAD_COUNT
+        distinct = {id(instance) for instance in instances}
+        assert len(distinct) == 1, (
+            f"#481 regression: {len(distinct)} distinct TracingService objects were "
+            f"created concurrently — spans would be split across tracer providers"
+        )
+
+    def test_the_race_is_actually_run(self):
+        """Guard the guard: a singleton already built before the threads start
+        would make the assertion above hold for the wrong reason."""
+        import threading
+
+        from services.tracing_service import TracingService
+
+        TracingService.reset_instance()
+        assert TracingService._instance is None
+
+        created = []
+        original_new = TracingService.__new__
+
+        def _counting_new(cls):
+            instance = original_new(cls)
+            created.append(id(instance))
+            return instance
+
+        barrier = threading.Barrier(THREAD_COUNT)
+
+        def _construct():
+            barrier.wait(timeout=5)
+            _counting_new(TracingService)
+
+        threads = [threading.Thread(target=_construct) for _ in range(THREAD_COUNT)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        assert len(created) == THREAD_COUNT, "the threads did not all reach __new__"
+        assert len(set(created)) == 1
 
 
 if __name__ == "__main__":

--- a/autobot-backend/utils/thread_safety_test.py
+++ b/autobot-backend/utils/thread_safety_test.py
@@ -14,7 +14,10 @@ Verifies thread safety of:
 These tests use concurrent execution to verify no race conditions exist.
 """
 
+import ast
 import asyncio
+import inspect
+import textwrap
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import MagicMock
@@ -322,6 +325,53 @@ class TestExistingLockVerification:
         assert isinstance(analytics_controller._analytics_state_lock, asyncio.Lock)
 
 
+def _run_on_threads(target, count: int = THREAD_COUNT) -> list:
+    """Release *count* threads simultaneously and collect their exceptions."""
+    barrier = threading.Barrier(count)
+    errors: list[BaseException] = []
+
+    def _wrapped():
+        try:
+            barrier.wait(timeout=5)
+            target()
+        except BaseException as exc:  # noqa: BLE001 - reported via `errors`
+            errors.append(exc)
+
+    threads = [threading.Thread(target=_wrapped) for _ in range(count)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+    return errors
+
+
+def _lock_guarded_assignment_targets_from_source(source: str) -> set[str]:
+    """Names assigned inside a ``with ..._lock:`` block in *source*."""
+    guarded: set[str] = set()
+    for node in ast.walk(ast.parse(textwrap.dedent(source))):
+        if not isinstance(node, ast.With):
+            continue
+        if not any("_lock" in ast.unparse(item.context_expr) for item in node.items):
+            continue
+        for inner in ast.walk(node):
+            if isinstance(inner, ast.Assign):
+                guarded.update(ast.unparse(t) for t in inner.targets)
+    return guarded
+
+
+def _lock_guarded_assignment_targets(func) -> set[str]:
+    """Names assigned inside a ``with cls._lock:`` block in *func*.
+
+    The behavioural race test below cannot see a missing lock: under the GIL,
+    20 threads never interleave the two bytecodes between the ``is None`` check
+    and the assignment, so removing the lock leaves it green (#13311 review,
+    mutation M7). Whether a critical section is *held* is a structural property
+    of the code, so it is asserted structurally — same "kept as a lint, but
+    parsed" treatment used elsewhere in this PR.
+    """
+    return _lock_guarded_assignment_targets_from_source(inspect.getsource(func))
+
+
 class TestDoubleCheckedLocking:
     """Test that double-checked locking pattern is correctly implemented"""
 
@@ -334,32 +384,16 @@ class TestDoubleCheckedLocking:
         """The #481 defect: two threads past an unguarded check each built one.
 
         This used to grep ``inspect.getsource(TracingService.__new__)`` for
-        ``with cls._lock:`` and count ``_instance is None`` (#13311) -- a shape
-        match that says nothing about whether the lock guards the right thing,
-        and that a rename breaks. Race the constructor instead and assert the
-        singleton identity every caller depends on.
+        ``with cls._lock:`` and count ``_instance is None`` (#13311). Race the
+        constructor instead and assert the singleton identity callers depend
+        on. Pairs with the lint below, which covers what a race cannot see.
         """
-        import threading
-
         from services.tracing_service import TracingService
 
         TracingService.reset_instance()
-        barrier = threading.Barrier(THREAD_COUNT)
         instances = []
-        errors = []
 
-        def _construct():
-            try:
-                barrier.wait(timeout=5)
-                instances.append(TracingService())
-            except Exception as exc:  # noqa: BLE001 - reported via `errors`
-                errors.append(exc)
-
-        threads = [threading.Thread(target=_construct) for _ in range(THREAD_COUNT)]
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join(timeout=10)
+        errors = _run_on_threads(lambda: instances.append(TracingService()))
 
         assert not errors, f"errors during concurrent construction: {errors}"
         assert len(instances) == THREAD_COUNT
@@ -369,11 +403,33 @@ class TestDoubleCheckedLocking:
             f"created concurrently — spans would be split across tracer providers"
         )
 
+    def test_the_singleton_assignment_happens_under_the_lock(self):
+        """A GIL-invisible unlocked window is still the #481 defect.
+
+        ``cls._instance = ...`` must sit inside ``with cls._lock:``; the race
+        test above stays green without it, so this is the half that catches it.
+        """
+        from services.tracing_service import TracingService
+
+        guarded = _lock_guarded_assignment_targets(TracingService.__new__)
+
+        assert "cls._instance" in guarded, (
+            "#481 regression: TracingService.__new__ assigns cls._instance outside "
+            f"`with cls._lock:` — a second thread can build a second singleton. "
+            f"Assignments currently under the lock: {sorted(guarded) or 'none'}"
+        )
+
+    def test_the_lock_lint_can_tell_the_two_shapes_apart(self):
+        """Guard the guard: a parser that returns nothing passes everything."""
+        locked = "def __new__(cls):\n    with cls._lock:\n        cls._instance = object()\n"
+        unlocked = "def __new__(cls):\n    # with cls._lock:\n    cls._instance = object()\n"
+
+        assert _lock_guarded_assignment_targets_from_source(locked) == {"cls._instance"}
+        assert _lock_guarded_assignment_targets_from_source(unlocked) == set()
+
     def test_the_race_is_actually_run(self):
         """Guard the guard: a singleton already built before the threads start
-        would make the assertion above hold for the wrong reason."""
-        import threading
-
+        would make the identity assertion hold for the wrong reason."""
         from services.tracing_service import TracingService
 
         TracingService.reset_instance()
@@ -382,23 +438,9 @@ class TestDoubleCheckedLocking:
         created = []
         original_new = TracingService.__new__
 
-        def _counting_new(cls):
-            instance = original_new(cls)
-            created.append(id(instance))
-            return instance
+        errors = _run_on_threads(lambda: created.append(id(original_new(TracingService))))
 
-        barrier = threading.Barrier(THREAD_COUNT)
-
-        def _construct():
-            barrier.wait(timeout=5)
-            _counting_new(TracingService)
-
-        threads = [threading.Thread(target=_construct) for _ in range(THREAD_COUNT)]
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join(timeout=10)
-
+        assert not errors, f"errors during concurrent construction: {errors}"
         assert len(created) == THREAD_COUNT, "the threads did not all reach __new__"
         assert len(set(created)) == 1
 

--- a/autobot-backend/web_fetch/fetch_playwright_interface_test.py
+++ b/autobot-backend/web_fetch/fetch_playwright_interface_test.py
@@ -131,14 +131,51 @@ async def test_no_capable_backend_returns_none_not_an_exception():
             assert await _fetch_playwright("https://example.com/", timeout=5.0) is None
 
 
-def test_the_requirements_describe_what_this_caller_needs():
-    """Documented so a later edit cannot quietly widen them."""
-    import inspect
+@pytest.mark.asyncio
+async def test_the_requirements_are_the_ones_actually_handed_to_the_resolver():
+    """A widened requirement set would re-open the #13306 mis-routing.
 
-    src = inspect.getsource(_fetch_playwright)
+    This used to grep ``inspect.getsource(_fetch_playwright)`` for
+    ``Capability.EXTRACT_HTML`` and friends (#13311). The literal appearing in
+    the docstring -- which it does, at length -- satisfied that assertion by
+    itself, so the check could never have failed. Capture what ``get_browser``
+    is called with instead.
+    """
+    seen = {}
 
-    assert "Capability.EXTRACT_HTML" in src, "a parser needs markup, not text"
-    assert "Capability.OUT_OF_PROCESS" in src, "Playwright must stay out of the backend process"
-    assert "ContentFormat.HTML" in src
-    assert str(Capability.EXTRACT_HTML.value) == "extract_html"
-    assert str(ContentFormat.HTML.value) == "html"
+    async def _capture(requires=None, **kwargs):
+        seen["requires"] = requires
+        raise RuntimeError("stop after routing — the assertion is the argument")
+
+    with (
+        patch("web_fetch.fetcher._is_public_url", AsyncMock(return_value=True)),
+        patch("autobot_shared.browser.get_browser", _capture),
+    ):
+        assert await _fetch_playwright("https://example.com/", timeout=5.0) is None
+
+    assert seen["requires"] == {Capability.EXTRACT_HTML, Capability.OUT_OF_PROCESS}, (
+        "a parser needs markup, not text (EXTRACT_HTML), and Playwright must "
+        f"stay out of the backend process (OUT_OF_PROCESS); got {seen['requires']}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_extract_request_asks_for_html_and_carries_the_caller_timeout():
+    """``ContentFormat.HTML`` in the source proved nothing about the request."""
+    captured = {}
+
+    class _Browser:
+        @staticmethod
+        async def extract(request):
+            captured["request"] = request
+            raise RuntimeError("stop after dispatch")
+
+    with (
+        patch("web_fetch.fetcher._is_public_url", AsyncMock(return_value=True)),
+        patch("autobot_shared.browser.get_browser", AsyncMock(return_value=_Browser())),
+    ):
+        assert await _fetch_playwright("https://example.com/", timeout=11.5) is None
+
+    assert captured["request"].format is ContentFormat.HTML
+    assert captured["request"].timeout_seconds == 11.5
+    assert captured["request"].url == "https://example.com/"

--- a/autobot-backend/worker_node_test.py
+++ b/autobot-backend/worker_node_test.py
@@ -9,7 +9,10 @@ Verifies that the refactored execute_task method maintains
 all original functionality while reducing nesting depth.
 """
 
+import ast
+import inspect
 import sys
+import textwrap
 import types
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -180,41 +183,49 @@ class TestWorkerNodeRefactored:
         assert result["status"] == "error"
         assert "parameter" in result["message"].lower()
 
+    # #13311 triage: these two stay source-level. They are *complexity metrics*,
+    # not behavioural contracts asserted by grep — "how deeply nested is this
+    # function" has no runtime observable, so measuring the code is the only
+    # way to measure it. What changed is that they now measure the syntax tree
+    # rather than leading whitespace: a wrapped argument list or a black
+    # reformat used to move the number without changing the nesting at all.
+
+    MAX_BLOCK_DEPTH = 6
+    MAX_STATEMENTS = 100
+
+    @staticmethod
+    def _execute_task_ast() -> ast.AST:
+        return ast.parse(textwrap.dedent(inspect.getsource(WorkerNode.execute_task))).body[0]
+
+    @classmethod
+    def _block_depth(cls, node, depth: int = 0) -> int:
+        """Deepest nesting of control-flow blocks, ignoring line wrapping."""
+        nesting = (ast.If, ast.For, ast.AsyncFor, ast.While, ast.With, ast.AsyncWith, ast.Try)
+        deepest = depth
+        for child in ast.iter_child_nodes(node):
+            child_depth = depth + 1 if isinstance(child, nesting) else depth
+            deepest = max(deepest, cls._block_depth(child, child_depth))
+        return deepest
+
     def test_reduced_nesting_depth(self):
-        """
-        Verify that the refactored execute_task has reduced nesting.
+        """The refactoring goal: nesting well below the original 21 levels."""
+        depth = self._block_depth(self._execute_task_ast())
 
-        This is a structural test to ensure the refactoring goal is met.
-        """
-        import inspect
+        assert depth <= self.MAX_BLOCK_DEPTH, f"execute_task nests {depth} blocks deep (limit {self.MAX_BLOCK_DEPTH})"
 
-        source = inspect.getsource(WorkerNode.execute_task)
-        lines = source.split("\n")
+    def test_the_depth_metric_counts_nesting_not_indentation(self):
+        """Guard the guard: a metric that always returns 0 passes everything."""
+        deep = ast.parse("def f():\n if a:\n  for b in c:\n   while d:\n    pass\n").body[0]
+        wrapped = ast.parse("def f():\n return g(\n  1,\n  2,\n )\n").body[0]
 
-        # Count maximum indentation depth
-        max_indent = 0
-        for line in lines:
-            if line.strip():  # Ignore empty lines
-                indent = len(line) - len(line.lstrip())
-                max_indent = max(max_indent, indent)
-
-        # Maximum nesting should be significantly reduced from original 21
-        # New implementation should have max depth around 4-6
-        assert max_indent <= 24, f"Nesting depth too high: {max_indent} spaces"
+        assert self._block_depth(deep) == 3
+        assert self._block_depth(wrapped) == 0, "line wrapping must not read as nesting"
 
     def test_line_count_reduction(self):
-        """
-        Verify that execute_task method has significantly fewer lines.
+        """Original was 424 lines; the refactor targeted roughly 60."""
+        statements = sum(1 for node in ast.walk(self._execute_task_ast()) if isinstance(node, ast.stmt))
 
-        Original was 424 lines, new version should be ~60 lines.
-        """
-        import inspect
-
-        source = inspect.getsource(WorkerNode.execute_task)
-        lines = [line for line in source.split("\n") if line.strip()]
-
-        # Allow some buffer, but should be dramatically reduced
-        assert len(lines) < 100, f"execute_task method still too long: {len(lines)} lines"
+        assert statements < self.MAX_STATEMENTS, f"execute_task still has {statements} statements"
 
 
 class TestGUIControllerPlatformGate:

--- a/autobot-slm-backend/ansible/roles/service_auth/tasks/configure-enforcement.yml
+++ b/autobot-slm-backend/ansible/roles/service_auth/tasks/configure-enforcement.yml
@@ -35,6 +35,17 @@
   become: true
   notify: restart backend
 
+# #13335: the role declares `service_auth_rate_limit_window` but never wrote it
+# here, so the window came only from backend.env.j2. Both keys of the #13326 pair
+# must be written together or the pair drifts again.
+- name: "ServiceAuth | Set rate limit window"
+  ansible.builtin.lineinfile:
+    path: "{{ service_auth_config_dir }}/service-auth.env"
+    regexp: "^SERVICE_AUTH_RATE_LIMIT_WINDOW="
+    line: "SERVICE_AUTH_RATE_LIMIT_WINDOW={{ service_auth_rate_limit_window }}"
+  become: true
+  notify: restart backend
+
 - name: "ServiceAuth | Set rate limit max failures"
   ansible.builtin.lineinfile:
     path: "{{ service_auth_config_dir }}/service-auth.env"

--- a/autobot-slm-backend/tests/services/test_self_update_systemd_detach_11492.py
+++ b/autobot-slm-backend/tests/services/test_self_update_systemd_detach_11492.py
@@ -646,12 +646,10 @@ async def test_a_detached_run_leaves_both_staged_files_on_disk(tmp_path, monkeyp
 
     assert result["success"] is True
     assert any(name.startswith("autobot_inv_") for name in survivors), (
-        f"#12803: the staged inventory was deleted under a still-starting "
-        f"detached run; survivors={survivors}"
+        f"#12803: the staged inventory was deleted under a still-starting " f"detached run; survivors={survivors}"
     )
     assert len(survivors) >= 2, (
-        f"#12803: the extra-vars file was deleted under a still-starting "
-        f"detached run; survivors={survivors}"
+        f"#12803: the extra-vars file was deleted under a still-starting " f"detached run; survivors={survivors}"
     )
 
 

--- a/autobot-slm-backend/tests/services/test_self_update_systemd_detach_11492.py
+++ b/autobot-slm-backend/tests/services/test_self_update_systemd_detach_11492.py
@@ -37,11 +37,12 @@ from __future__ import annotations
 
 import asyncio
 import importlib.util
+import json
 import os
 import sys
 import time
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -571,27 +572,97 @@ def test_prune_removes_only_files_past_the_ttl(tmp_path, monkeypatch):
     assert not stale.exists()
 
 
-def test_detached_finally_deletes_neither_staged_file(tmp_path):
+async def _run_playbook_capturing_staged_files(tmp_path, monkeypatch, *, detach: bool):
+    """Drive a whole ``execute_playbook`` and report which staged files survive.
+
+    Everything below the staging decision is stubbed: the point is what the
+    ``finally`` block does to the two files, not what Ansible does.
+    """
+    ansible_dir = tmp_path / "ansible"
+    ansible_dir.mkdir()
+    (ansible_dir / "update-all-nodes.yml").write_text("- hosts: all\n", encoding="utf-8")
+    shared = tmp_path / "shared"
+    shared.mkdir(mode=0o700)
+    monkeypatch.setattr(_pe, "SELF_UPDATE_SHARED_DIR", shared)
+    monkeypatch.setattr(_pe, "fetch_deploy_secrets", AsyncMock(return_value={}))
+
+    ex = _executor(ansible_dir)
+    ex.inventory_path = ansible_dir / "slm-nodes.yml"
+
+    async def _fake_inventory(_self, stage_dir=None):
+        path = Path(stage_dir or tmp_path) / "autobot_inv_run.yml"
+        path.write_text("all:\n", encoding="utf-8")
+        return path
+
+    def _fake_extra_vars(extra_vars, uid_tmp_dir=None):
+        # ``services.inventory_builder`` is a MagicMock in this module's loader,
+        # so the real writer produces no file. Write a real one into the same
+        # stage dir: the assertion is what the ``finally`` block does to it.
+        path = Path(uid_tmp_dir or tmp_path) / "autobot_evars_run.json"
+        path.write_text(json.dumps(extra_vars), encoding="utf-8")
+        return path
+
+    monkeypatch.setattr(_pe, "write_temp_extra_vars", _fake_extra_vars)
+    monkeypatch.setattr(_pe.PlaybookExecutor, "_build_dynamic_inventory", _fake_inventory)
+    monkeypatch.setattr(
+        _pe.PlaybookExecutor,
+        "_build_ansible_command",
+        lambda *a, **kw: ["/usr/bin/ansible-playbook", "update-all-nodes.yml"],
+    )
+    monkeypatch.setattr(_pe.PlaybookExecutor, "_build_ansible_env", lambda _self: {"PATH": "/usr/bin"})
+    monkeypatch.setattr(
+        _pe.PlaybookExecutor,
+        "_run_subprocess",
+        AsyncMock(return_value={"returncode": 0, "output": ""}),
+    )
+
+    result = await ex.execute_playbook(
+        "update-all-nodes.yml",
+        extra_vars={"a_secret": "value"},  # forces an extra-vars file into stage_dir
+        detach=detach,
+    )
+    survivors = sorted(f.name for f in shared.iterdir()) if shared.exists() else []
+    return result, survivors
+
+
+@pytest.mark.asyncio
+async def test_a_detached_run_leaves_both_staged_files_on_disk(tmp_path, monkeypatch):
     """The caller must not unlink files the detached payload still owns.
 
-    #12803 reported this as the root cause. It was not — the real cause was the
-    PrivateTmp namespace — but the deletion IS a live hazard now that the
+    #12803 reported this as the root cause. It was not -- the real cause was
+    the PrivateTmp namespace -- but the deletion IS a live hazard now that the
     payload outlives this coroutine by design (Play 1 restarts this service
-    mid-run). Both files must survive, not just the inventory: they are removed
-    by two separate branches in the finally, and guarding only one leaves the
-    extra-vars race intact.
+    mid-run). BOTH files must survive: they are removed by two separate
+    branches, and guarding only one leaves the extra-vars race intact.
+
+    This replaces a source-text check that compared ``str.index`` positions of
+    ``"if detach:"``, ``"dynamic_inv_path.unlink"`` and ``"extra_vars_file.unlink"``
+    inside ``inspect.getsource(execute_playbook)`` (#13311) -- it asserted the
+    *textual order* of three substrings, so it passed for an ``if detach:``
+    belonging to some other statement and broke on any reordering that changed
+    nothing.
     """
-    import inspect
+    result, survivors = await _run_playbook_capturing_staged_files(tmp_path, monkeypatch, detach=True)
 
-    src = inspect.getsource(_pe.PlaybookExecutor.execute_playbook)
-    finally_body = src.split("finally:", 1)[1]
+    assert result["success"] is True
+    assert any(name.startswith("autobot_inv_") for name in survivors), (
+        f"#12803: the staged inventory was deleted under a still-starting "
+        f"detached run; survivors={survivors}"
+    )
+    assert len(survivors) >= 2, (
+        f"#12803: the extra-vars file was deleted under a still-starting "
+        f"detached run; survivors={survivors}"
+    )
 
-    guard = finally_body.index("if detach:")
-    inv_unlink = finally_body.index("dynamic_inv_path.unlink")
-    evars_unlink = finally_body.index("extra_vars_file.unlink")
 
-    # BOTH unlinks must sit after the detach guard, i.e. inside its else branch.
-    assert guard < inv_unlink
-    assert guard < evars_unlink
-    else_branch = finally_body.index("else:")
-    assert else_branch < inv_unlink and else_branch < evars_unlink
+@pytest.mark.asyncio
+async def test_an_attached_run_still_cleans_both_staged_files(tmp_path, monkeypatch):
+    """The mirror: the detach guard must not turn into a permanent leak.
+
+    Attached runs own their payload for the whole call, so nothing may be
+    left behind for ``_prune_stage_dir`` to reclaim later.
+    """
+    result, survivors = await _run_playbook_capturing_staged_files(tmp_path, monkeypatch, detach=False)
+
+    assert result["success"] is True
+    assert survivors == [], f"attached run leaked staged files: {survivors}"

--- a/autobot-slm-backend/tests/services/test_self_update_systemd_detach_11492.py
+++ b/autobot-slm-backend/tests/services/test_self_update_systemd_detach_11492.py
@@ -572,22 +572,24 @@ def test_prune_removes_only_files_past_the_ttl(tmp_path, monkeypatch):
     assert not stale.exists()
 
 
-async def _run_playbook_capturing_staged_files(tmp_path, monkeypatch, *, detach: bool):
-    """Drive a whole ``execute_playbook`` and report which staged files survive.
-
-    Everything below the staging decision is stubbed: the point is what the
-    ``finally`` block does to the two files, not what Ansible does.
-    """
+def _stage_dir_fixture(tmp_path, monkeypatch) -> Path:
+    """A real shared staging dir plus a playbook for the executor to find."""
     ansible_dir = tmp_path / "ansible"
     ansible_dir.mkdir()
     (ansible_dir / "update-all-nodes.yml").write_text("- hosts: all\n", encoding="utf-8")
     shared = tmp_path / "shared"
     shared.mkdir(mode=0o700)
     monkeypatch.setattr(_pe, "SELF_UPDATE_SHARED_DIR", shared)
-    monkeypatch.setattr(_pe, "fetch_deploy_secrets", AsyncMock(return_value={}))
+    return ansible_dir
 
-    ex = _executor(ansible_dir)
-    ex.inventory_path = ansible_dir / "slm-nodes.yml"
+
+def _stub_staged_file_writers(tmp_path, monkeypatch) -> None:
+    """Write real inventory / extra-vars files into the run's stage dir.
+
+    ``services.inventory_builder`` is a MagicMock in this module's loader, so
+    the real writers produce no file at all -- and the assertion is what the
+    ``finally`` block does to those files.
+    """
 
     async def _fake_inventory(_self, stage_dir=None):
         path = Path(stage_dir or tmp_path) / "autobot_inv_run.yml"
@@ -595,15 +597,17 @@ async def _run_playbook_capturing_staged_files(tmp_path, monkeypatch, *, detach:
         return path
 
     def _fake_extra_vars(extra_vars, uid_tmp_dir=None):
-        # ``services.inventory_builder`` is a MagicMock in this module's loader,
-        # so the real writer produces no file. Write a real one into the same
-        # stage dir: the assertion is what the ``finally`` block does to it.
         path = Path(uid_tmp_dir or tmp_path) / "autobot_evars_run.json"
         path.write_text(json.dumps(extra_vars), encoding="utf-8")
         return path
 
+    monkeypatch.setattr(_pe, "fetch_deploy_secrets", AsyncMock(return_value={}))
     monkeypatch.setattr(_pe, "write_temp_extra_vars", _fake_extra_vars)
     monkeypatch.setattr(_pe.PlaybookExecutor, "_build_dynamic_inventory", _fake_inventory)
+
+
+def _stub_ansible_invocation(monkeypatch) -> None:
+    """Stub the command build and the run itself -- neither is under test."""
     monkeypatch.setattr(
         _pe.PlaybookExecutor,
         "_build_ansible_command",
@@ -616,13 +620,23 @@ async def _run_playbook_capturing_staged_files(tmp_path, monkeypatch, *, detach:
         AsyncMock(return_value={"returncode": 0, "output": ""}),
     )
 
+
+async def _run_playbook_capturing_staged_files(tmp_path, monkeypatch, *, detach: bool):
+    """Drive a whole ``execute_playbook`` and report which staged files survive."""
+    ansible_dir = _stage_dir_fixture(tmp_path, monkeypatch)
+    _stub_staged_file_writers(tmp_path, monkeypatch)
+    _stub_ansible_invocation(monkeypatch)
+
+    ex = _executor(ansible_dir)
+    ex.inventory_path = ansible_dir / "slm-nodes.yml"
     result = await ex.execute_playbook(
         "update-all-nodes.yml",
         extra_vars={"a_secret": "value"},  # forces an extra-vars file into stage_dir
         detach=detach,
     )
-    survivors = sorted(f.name for f in shared.iterdir()) if shared.exists() else []
-    return result, survivors
+
+    shared = tmp_path / "shared"
+    return result, (sorted(f.name for f in shared.iterdir()) if shared.exists() else [])
 
 
 @pytest.mark.asyncio

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -125,6 +125,23 @@ SUBAGENT_REFLECTION_ENABLED: bool = (
 SERVICE_AUTH_RATE_LIMIT_MAX_FAILURES_DEFAULT = 10
 SERVICE_AUTH_RATE_LIMIT_WINDOW_DEFAULT = 300
 
+# Service-auth enforcement gate (#13335) - the third drift in this same block.
+# The Ansible role has always written ``true``/``100``; the Pydantic fields
+# defaulted to ``""``/``0.0``, so every install that did not go through Ansible
+# ran the service-auth middleware in LOGGING MODE with the circuit breaker
+# sampling 0% of requests. Unlike #13326 (which failed closed and was loud),
+# this pair failed OPEN and was silent. ``tests/test_service_auth_default_parity``
+# now pins each of these to the Ansible role default.
+SERVICE_AUTH_ENFORCEMENT_MODE_DEFAULT = "true"
+SERVICE_AUTH_CIRCUIT_BREAKER_PERCENTAGE_DEFAULT = 100.0
+
+# Replay window for HMAC-signed service requests (#13335). The Ansible role and
+# ``export_service_keys.py`` have always written ``AUTH_TIMESTAMP_WINDOW``, but
+# no Pydantic field claimed the alias, so ``ServiceAuthManager`` hard-coded 300
+# and the operator-facing knob did nothing. The default matches the role so
+# wiring it in cannot change behaviour on an existing install.
+SERVICE_AUTH_TIMESTAMP_WINDOW_DEFAULT = 300
+
 
 class RedactedSettings(RedactedReprMixin, BaseSettings):
     """Base for every SSOT settings model.
@@ -1880,8 +1897,27 @@ class MiscConfig(RedactedSettings):
     redis_node_id: str = Field(default="", alias="REDIS_NODE_ID")
     redis_port: int = Field(default=0, alias="REDIS_PORT")
     secret_key: str = Field(default="", alias="SECRET_KEY")
-    service_auth_circuit_breaker_percentage: float = Field(default=0.0, alias="SERVICE_AUTH_CIRCUIT_BREAKER_PERCENTAGE")
-    service_auth_enforcement_mode: str = Field(default="", alias="SERVICE_AUTH_ENFORCEMENT_MODE")
+    service_auth_circuit_breaker_percentage: float = Field(
+        default=SERVICE_AUTH_CIRCUIT_BREAKER_PERCENTAGE_DEFAULT,
+        alias="SERVICE_AUTH_CIRCUIT_BREAKER_PERCENTAGE",
+        description=(
+            "Percentage of service-auth-eligible requests the enforcement middleware "
+            "actually checks (0-100). 100 enforces every request; 0 explicitly "
+            "DISABLES the enforcement sampling entirely, so every request passes "
+            "through unchecked - it does not mean 'enforce a little'. Issue #13335."
+        ),
+    )
+    service_auth_enforcement_mode: str = Field(
+        default=SERVICE_AUTH_ENFORCEMENT_MODE_DEFAULT,
+        alias="SERVICE_AUTH_ENFORCEMENT_MODE",
+        description=(
+            "Master switch for service-auth enforcement, compared case-insensitively "
+            "against the literal 'true'. ANY other value - including the empty "
+            "string - explicitly DISABLES enforcement and selects LOGGING MODE: "
+            "unauthenticated service calls are logged and allowed through. "
+            "Issue #13335."
+        ),
+    )
     service_auth_override_token: str = Field(default="", alias="SERVICE_AUTH_OVERRIDE_TOKEN")
     service_auth_rate_limit_max_failures: int = Field(
         default=SERVICE_AUTH_RATE_LIMIT_MAX_FAILURES_DEFAULT,
@@ -1891,6 +1927,16 @@ class MiscConfig(RedactedSettings):
             "before further requests are rejected with HTTP 429. "
             "0 explicitly DISABLES failure rate limiting (service auth itself still runs); "
             "it does not mean 'tolerate nothing'. Issue #13326."
+        ),
+    )
+    service_auth_timestamp_window: int = Field(
+        default=SERVICE_AUTH_TIMESTAMP_WINDOW_DEFAULT,
+        alias="AUTH_TIMESTAMP_WINDOW",
+        description=(
+            "Seconds a signed service request stays valid, in either direction, "
+            "before it is rejected as a replay. 0 accepts no clock skew at all "
+            "and will reject essentially every request; it does not disable the "
+            "replay check. Issue #13335."
         ),
     )
     service_auth_rate_limit_window: int = Field(

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -1929,6 +1929,15 @@ class MiscConfig(RedactedSettings):
             "it does not mean 'tolerate nothing'. Issue #13326."
         ),
     )
+    service_auth_rate_limit_window: int = Field(
+        default=SERVICE_AUTH_RATE_LIMIT_WINDOW_DEFAULT,
+        alias="SERVICE_AUTH_RATE_LIMIT_WINDOW",
+        description=(
+            "Sliding window in seconds over which service-auth failures are counted. "
+            "0 explicitly DISABLES failure rate limiting, since a zero-length window can "
+            "never retain a failure. Issue #13326."
+        ),
+    )
     service_auth_timestamp_window: int = Field(
         default=SERVICE_AUTH_TIMESTAMP_WINDOW_DEFAULT,
         alias="AUTH_TIMESTAMP_WINDOW",
@@ -1937,15 +1946,6 @@ class MiscConfig(RedactedSettings):
             "before it is rejected as a replay. 0 accepts no clock skew at all "
             "and will reject essentially every request; it does not disable the "
             "replay check. Issue #13335."
-        ),
-    )
-    service_auth_rate_limit_window: int = Field(
-        default=SERVICE_AUTH_RATE_LIMIT_WINDOW_DEFAULT,
-        alias="SERVICE_AUTH_RATE_LIMIT_WINDOW",
-        description=(
-            "Sliding window in seconds over which service-auth failures are counted. "
-            "0 explicitly DISABLES failure rate limiting, since a zero-length window can "
-            "never retain a failure. Issue #13326."
         ),
     )
     service_id: str = Field(default="", alias="SERVICE_ID")

--- a/autobot_shared/tests/test_service_auth_default_parity_13335.py
+++ b/autobot_shared/tests/test_service_auth_default_parity_13335.py
@@ -1,0 +1,210 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Ansible/Pydantic default parity for the service_auth field block (#13335).
+
+Three separate defaults in this one block have now drifted from the values the
+``service_auth`` Ansible role writes, and every one of them shipped silently:
+
+* #13326 -- ``max_failures``/``window`` both defaulted to ``0``, so
+  ``len(failures) >= max_failures`` was true for the first request and every
+  service-only route rejected its first caller.  Failed **closed**, and loudly.
+* #13335 -- ``service_auth_enforcement_mode`` defaulted to ``""`` while the
+  middleware tests ``mode.lower() == "true"``, and
+  ``service_auth_circuit_breaker_percentage`` defaulted to ``0.0`` while the
+  breaker treats ``<= 0`` as "sample nothing".  Failed **open**, and silently:
+  any install that did not run the Ansible role had the security gate off.
+
+The durable fix is not the two corrected values -- it is this test.  It reads
+every ``NAME={{ var }}`` assignment the role and the backend env template
+actually emit, resolves ``NAME`` to the Pydantic field that claims it as an
+alias, and asserts the rendered Ansible value validates to that field's
+declared default.  A fourth drift becomes a red test instead of a silent
+misconfiguration, and a new key added to the role with no Pydantic field is
+caught the same way.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any, Iterator, NamedTuple
+
+import pytest
+import yaml
+from pydantic import TypeAdapter
+from pydantic.fields import FieldInfo
+
+from autobot_shared.ssot_config import MiscConfig
+
+# Resolved from this file, NOT from ``ssot_config.PROJECT_ROOT``: that helper
+# walks up looking for a ``.env``, which does not exist inside a git worktree,
+# so it silently returns the main checkout and this test would assert against
+# somebody else's tree (see #13149).
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ROLE_DEFAULTS = REPO_ROOT / "autobot-slm-backend/ansible/roles/service_auth/defaults/main.yml"
+ROLE_TASKS = REPO_ROOT / "autobot-slm-backend/ansible/roles/service_auth/tasks"
+BACKEND_ENV_TEMPLATE = REPO_ROOT / "autobot-slm-backend/ansible/roles/backend/templates/backend.env.j2"
+
+# ``NAME={{ expr }}`` -- both as a bare template line and inside a lineinfile
+# ``line:`` value.  Anchored on the env-var name so prose never matches, and on
+# end-of-value so a composite line (``{{ dir }}/{{ id }}.env``) is skipped
+# rather than silently compared against only its first expression.
+_ASSIGNMENT = re.compile(r'(?m)^\s*(?:line:\s*")?(?P<env>[A-Z][A-Z0-9_]*)=\{\{\s*(?P<expr>[^{}]+?)\s*\}\}"?\s*$')
+_DEFAULT_FILTER = re.compile(r"^default\((?P<literal>.*)\)$")
+
+
+class Assignment(NamedTuple):
+    """One ``ENV_NAME={{ ansible_var | filters }}`` pair found in the role."""
+
+    source: str
+    env: str
+    var: str
+    filters: tuple[str, ...]
+
+
+def _role_defaults() -> dict[str, Any]:
+    return yaml.safe_load(ROLE_DEFAULTS.read_text(encoding="utf-8"))
+
+
+def _parse_assignments(path: Path, declared: frozenset[str]) -> Iterator[Assignment]:
+    """Yield every env assignment in ``path`` fed by a role-declared variable.
+
+    Scoped to ``declared`` on purpose: a template may also reference per-host
+    identity vars (``service_auth_service_id``) that no role default can supply,
+    and those are not a defaults-parity question.
+    """
+    for match in _ASSIGNMENT.finditer(path.read_text(encoding="utf-8")):
+        parts = [p.strip() for p in match.group("expr").split("|")]
+        if parts[0] not in declared:
+            continue
+        yield Assignment(path.name, match.group("env"), parts[0], tuple(parts[1:]))
+
+
+def _all_assignments() -> list[Assignment]:
+    declared = frozenset(_role_defaults())
+    paths = sorted(ROLE_TASKS.glob("*.yml")) + [BACKEND_ENV_TEMPLATE]
+    return [a for path in paths for a in _parse_assignments(path, declared)]
+
+
+def _render(value: Any, filters: tuple[str, ...]) -> str:
+    """Reproduce what Ansible writes into the .env file for ``value``."""
+    rendered = str(value)
+    if "lower" in filters:
+        rendered = rendered.lower()
+    return rendered
+
+
+def _field_for_alias(alias: str) -> tuple[str, FieldInfo] | None:
+    for name, field in MiscConfig.model_fields.items():
+        if field.alias == alias:
+            return name, field
+    return None
+
+
+ASSIGNMENTS = _all_assignments()
+DEFAULTS = _role_defaults()
+
+
+def test_the_parser_actually_found_the_role_assignments() -> None:
+    """Guard the guard: a regex that matches nothing would pass every test."""
+    envs = {a.env for a in ASSIGNMENTS}
+    assert "SERVICE_AUTH_ENFORCEMENT_MODE" in envs
+    assert "SERVICE_AUTH_CIRCUIT_BREAKER_PERCENTAGE" in envs
+    assert len(envs) >= 5, f"only found {sorted(envs)} -- the role writes more than that"
+
+
+def test_every_enforcement_knob_the_role_declares_reaches_the_backend() -> None:
+    """A declared toggle that no task writes is a knob wired to nothing.
+
+    This is how ``service_auth_rate_limit_window`` came to be declared by the
+    role while only the backend env template ever emitted it (#13335).
+    """
+    emitted = {a.var for a in ASSIGNMENTS if a.source != BACKEND_ENV_TEMPLATE.name}
+    expected = {
+        "service_auth_enforcement_mode",
+        "service_auth_circuit_breaker_percentage",
+        "service_auth_rate_limit_window",
+        "service_auth_rate_limit_max_failures",
+        "service_auth_timestamp_window",
+    }
+    assert expected <= emitted, f"role tasks never write: {sorted(expected - emitted)}"
+
+
+@pytest.mark.parametrize("assignment", ASSIGNMENTS, ids=lambda a: f"{a.source}:{a.env}")
+def test_env_key_is_claimed_by_a_pydantic_field(assignment: Assignment) -> None:
+    """Ansible writing a key nobody reads is a knob that silently does nothing."""
+    assert _field_for_alias(assignment.env) is not None, (
+        f"{assignment.source} writes {assignment.env}, but no MiscConfig field "
+        f"claims that alias -- the value is parsed by nobody (this is how "
+        f"AUTH_TIMESTAMP_WINDOW went unread while ServiceAuthManager hard-coded 300)"
+    )
+
+
+@pytest.mark.parametrize("assignment", ASSIGNMENTS, ids=lambda a: f"{a.source}:{a.env}")
+def test_pydantic_default_matches_the_ansible_default(assignment: Assignment) -> None:
+    """The #13326/#13335 drift, as an assertion.
+
+    An install that never ran Ansible must behave exactly like one that did.
+    """
+    resolved = _field_for_alias(assignment.env)
+    if resolved is None:
+        pytest.skip("covered by test_env_key_is_claimed_by_a_pydantic_field")
+    name, field = resolved
+
+    rendered = _render(DEFAULTS[assignment.var], assignment.filters)
+    from_ansible = TypeAdapter(field.annotation).validate_python(rendered)
+
+    assert from_ansible == field.default, (
+        f"MiscConfig.{name} defaults to {field.default!r}, but the service_auth "
+        f"role writes {assignment.env}={rendered!r} (-> {from_ansible!r}). "
+        f"An unmanaged install therefore behaves differently from a managed one."
+    )
+
+
+@pytest.mark.parametrize(
+    "assignment",
+    [a for a in ASSIGNMENTS if any(_DEFAULT_FILTER.match(f) for f in a.filters)],
+    ids=lambda a: f"{a.source}:{a.env}",
+)
+def test_jinja_default_filter_matches_the_role_default(assignment: Assignment) -> None:
+    """``| default(100)`` in the template is a fourth copy of the same number."""
+    literal = next(m.group("literal") for f in assignment.filters if (m := _DEFAULT_FILTER.match(f)))
+    role_value = _render(DEFAULTS[assignment.var], assignment.filters)
+    inline_value = _render(yaml.safe_load(literal), assignment.filters)
+
+    assert inline_value == role_value, (
+        f"{assignment.source} falls back to `default({literal})` for "
+        f"{assignment.env}, but the role default renders as {role_value!r}"
+    )
+
+
+class TestTheCorrectedValuesThemselves:
+    """Pin the two #13335 values directly, so the intent survives a refactor."""
+
+    def test_enforcement_is_on_by_default(self) -> None:
+        """The exact comparison the middleware performs, on the bare default."""
+        assert MiscConfig.model_fields["service_auth_enforcement_mode"].default.lower() == "true"
+
+    def test_circuit_breaker_samples_every_request_by_default(self) -> None:
+        """The breaker treats ``<= 0`` as 'sample nothing' -- i.e. enforce nothing."""
+        assert MiscConfig.model_fields["service_auth_circuit_breaker_percentage"].default >= 100
+
+    @pytest.mark.parametrize(
+        "field_name",
+        [
+            "service_auth_enforcement_mode",
+            "service_auth_circuit_breaker_percentage",
+            "service_auth_rate_limit_max_failures",
+            "service_auth_rate_limit_window",
+            "service_auth_timestamp_window",
+        ],
+    )
+    def test_falsy_meaning_is_documented(self, field_name: str) -> None:
+        """``""``/``0`` meant 'disabled' only by accident of a comparison."""
+        description = MiscConfig.model_fields[field_name].description or ""
+        assert "DISABLES" in description or "does not disable" in description, (
+            f"{field_name} does not state what its falsy value means; that "
+            f"ambiguity is what let three of these defaults drift unnoticed"
+        )


### PR DESCRIPTION
## Thinking Path

`#13311` and `#13335` are the same failure mode seen from two sides: an assertion that
*looks* like a contract but checks a spelling. A `getsource` grep passes when a literal
sits in a dead branch; a Pydantic default that nobody compares to the Ansible default
drifts silently. Both produce green builds over broken behaviour.

So the work was not "delete 16 greps". It was, per file: decide whether the check is a
**behavioural contract** (convert — drive the code, assert what a caller sees) or a
**lint** (keep — but parse, don't substring). Then reintroduce the original defect and
confirm the replacement goes red. A conversion that survives its own bug is worse than
the grep it replaced.

Review found the sharpest case of that: removing the `TracingService` lock left the race
test **green**, because under the GIL 20 threads never interleave the two bytecodes
between the `is None` check and the assignment. The behavioural test was strictly weaker
than the grep it replaced. Whether a critical section is *held* is structural, so it is
now asserted structurally, alongside the race. Both halves are needed; neither is
sufficient.

Converting them found four real gaps the greps had hidden. That is the argument for the
change, not the line count.

## What Changed

### #13335 — service-auth defaults failed **open**

`service_auth_enforcement_mode` defaulted to `""` while the middleware tests
`mode.lower() == "true"`; `service_auth_circuit_breaker_percentage` defaulted to `0.0`
while the breaker treats `<= 0` as "sample nothing". Any install that did not run the
Ansible role had the security gate off, silently. (`#13326` was the same drift in the
same field block, but failed *closed*, and was loud.)

- Both defaults corrected to the Ansible values (`"true"`, `100.0`), as named module
  constants alongside the `#13326` pair.
- Every field in the block now **states what its falsy value means** — these values meant
  "disabled" only by accident of a comparison.
- **The durable fix:** `autobot_shared/tests/test_service_auth_default_parity_13335.py`
  parses every `NAME={{ var }}` the role and the backend env template emit, resolves
  `NAME` to the Pydantic field claiming that alias, and asserts the rendered Ansible
  default validates to the field's declared default. It also checks each Jinja
  `| default(x)` fallback — a fourth copy of the same number — and that every knob the
  role declares is actually written by a task.
- Wired in two things the guard exposed: `AUTH_TIMESTAMP_WINDOW` was written by Ansible
  and by `export_service_keys.py` but **read by nobody** (`ServiceAuthManager` hard-coded
  `300`), and the role declared `service_auth_rate_limit_window` without any task writing
  it. Both now connected; defaults unchanged, so no behaviour change on a managed install.

### #13311 — triage of the 16 files

**Converted to behaviour (12 files).** Each drives the real code path and asserts the
returned object, the recorded call, or the on-disk effect: marketplace source routing ·
`get_llm_service` module resolution · chat-session TTL sent to Redis · device-code
redirect handling · argument-aware risk ordering · provider-key resolution ·
`ContextAnalyzer` delegation · workflow-summary LLM migration · NPU-subscription and
`TracingService` locking · `_fetch_playwright` requirement set · detached-run staged-file
lifecycle.

**Kept as lints, but parsed (5).** Proving the *absence* of a capability, or that a
critical section is held, has no runtime observable — source inspection is the right
tool; the substring matching was not. `remediation_loop_test.py` (read-only capability
guard) · `test_haiku_tier.py` (`:name::type` SQL cast) ·
`test_memory_graph_init_contract_12873.py` (no falsy return path) · `worker_node_test.py`
(nesting depth / statement count) · `thread_safety_test.py` (assignment under `cls._lock`,
added in review). All walk the AST, and each carries a self-check proving the parser
finds a planted violation and stays quiet on a clean sample.

**Out of scope, stated:** `api/api_endpoint_migrations_test.py` (2147 assertions) is
already `pytest.mark.skip`-ed at module level pending its own audit issue, so it is
dormant rather than falsely green. Two files under `autobot-slm-backend/tests/api/` are
held by another session.

### Gaps the conversions exposed (all fixed here)

1. **`device_initiate` / `device_poll` crashed on an un-followed 302.** `allow_redirects=False`
   stops the SSRF bypass, but `device_initiate` only rejected `>= 400` and then indexed
   the absent `device_code`; `device_poll` called `resp.json()` on an HTML redirect body.
   Both raised an unhandled 500. Added `_reject_redirect`, which turns a 3xx into a clean
   502 (`>= 300` would have broken RFC-8628's `authorization_pending`, which arrives as a 400).
2. **`CUSTOM_OPENAI_API_KEY` is gated behind an unrelated setting.** Declared in the vault's
   key set, but only resolved when `CUSTOM_OPENAI_BASE_URL` is also set — and the only
   signal is a DEBUG log. Pinned, with the gate documented in the test rather than excused.
3. **A whole test module was skipping silently.** `remediation_loop_test.py` loaded its
   module from a CWD-relative literal; the loader's `except` turned the resulting
   `FileNotFoundError` into a skip, so every test in the file vanished when pytest ran from
   anywhere but the repo root. Now resolved from `__file__`.
4. **Registry-key coverage was gated behind Postgres.** The check lived in a
   `requires_postgres` module, so it was skipped wherever no disposable Postgres exists.
   Moved to `llm_shared/tests/test_provider_registry_key_coverage.py`.

Also fixed a pre-existing red test found in a file being converted:
`test_detect_application_type_form` supplied one input field against a heuristic requiring
more than three. The heuristic is untouched (lowering it is a product call); the fixture
now clears it, and a second test pins the threshold so it cannot move unnoticed.

### Review round

- **B1** — `api/tests/test_provider_auth_device_poll_limit.py::_FakeResp` had no `status`,
  so `_reject_redirect` raised `AttributeError` on it. **The fake was incomplete, not the
  guard**: `status`/`headers` added to the fake, production left strict, so a real aiohttp
  change cannot go silently un-guarded. The `hasattr(resp, "headers")` check was removed
  for the same reason — it was defensiveness aimed at the wrong attribute.
- **B2** — `test_the_legacy_module_name_does_not_exist` asserted a global
  `sys.path`/`sys.modules` property that conftest's `services.llm_service` stub can
  invalidate: green alone, red in the shard. **Dropped**; re-ran the M3 mutation to confirm
  the remaining three tests still catch it.
- **M1** — added `test_the_singleton_assignment_happens_under_the_lock`, which parses
  `TracingService.__new__` and asserts `cls._instance = ...` sits inside `with cls._lock:`.
- Lint fixes: `os.system` dropped from `FORBIDDEN_IMPORTS` (unreachable — the name is split
  on `.`); the write check widened from `open(mode=...)` to `Path.write_text`/`write_bytes`,
  `os.remove`, `shutil.copy`/`move` and `io.open`; the `test_haiku_tier` docstring claim
  corrected (docstrings *are* `ast.Constant` and still scanned — deliberately, since a
  copy-pasteable SQL example is exactly what propagates); `service_auth_timestamp_window`
  moved back into alphabetical order; four helpers split below 30 lines.

## Verification

Every conversion was proved by reintroducing the original defect and confirming the new
tests fail. Restored and re-run green after each.

| Reintroduced defect | Tests that went red |
|---|---|
| `#13335` + `#13326` defaults, missing timestamp field, missing window task | **13 failed** (full pre-PR state) |
| `#6524` `await _get_catalog()` in both marketplace endpoints | 4 failed |
| `#7047` `from llm_service import LLMService` | 3 failed (re-measured after B2) |
| `#6743` `setex(key, 3600, ...)` | 2 failed |
| `#12278` `allow_redirects=True` in both device-flow POSTs | 2 failed |
| `#7384` allowlist consulted before the argument-aware check | 10 failed |
| `MISTRAL_API_KEY` named in a comment but never resolved | 1 failed (**the old grep would have passed**) |
| `#12873` bare `return` with `return True` left in a comment | 2 failed (**the old grep would have passed**) |
| Feature Envy re-inlined, method name kept in a comment | 1 failed (**the old grep would have passed**) |
| `#513` lock + inner check removed, literals kept in comments | 1 failed, `assert 100 == 5` (**the old grep would have passed**) |
| `#481` lock removed, **no sleep injected** (reviewer's M7) | **1 failed, 5/5 runs** — was 0/5 before this round |
| `#13306` requirement widened to `{OUT_OF_PROCESS}` + `TEXT` | 4 failed |
| `#12803` extra-vars unlink moved outside the detach guard | 1 failed (**textual order unchanged — the old index check would have passed**) |
| `GH#12134` `:name::type` cast restored | 2 failed |
| Aliased `subprocess`, `open(mode="a")`, `Popen` | 6 failed (**all three forms evaded the old substrings**) |
| `Path.write_text` — no `open()`, no `subprocess` | 2 failed (**the pre-review AST check also missed this**) |
| 8 nesting levels re-inlined into `execute_task` | 1 failed |

Seven of those are defects the replaced assertion would have passed. That is the gap
being closed.

The `#13335` row is 13, not the 10 previously stated — the full pre-PR state also fails
the two `AUTH_TIMESTAMP_WINDOW` alias checks and the knob-reachability check. Named list
in the branch history.

Full suites, rebased onto `Dev_new_gui`, after `black`/`isort`:

```
529 passed, 9 skipped   # autobot_shared/tests + 19 backend files
 24 passed              # autobot-slm-backend self-update detach
  0                     # flake8 --max-line-length 120 on all changed files
```

Slowest test 3.4s; nothing near the 10s ceiling. Combined 21-file run repeated 4× green.

**Pre-existing, not introduced, not fixed here:** collecting
`autobot-backend/tests/middleware/` and `autobot-slm-backend/tests/` in one pytest session
fails with `ImportError: cannot import name 'service_auth_enforcement' from 'middleware'`
— both projects ship a top-level `middleware` package. Reproduced unchanged on the base
branch. CI runs the suites separately, so it is a local-invocation hazard only.

## Model Used

claude-opus-5


Closes #13335
Refs #13311
