### PR TITLE
fix(test-infra): scope the llc conftest sys.modules stubs and the slm db fixture teardown (#13337, #13329)

### DIFF
--- a/autobot-backend/llc/tests/conftest.py
+++ b/autobot-backend/llc/tests/conftest.py
@@ -45,29 +45,35 @@ from knowledge.backends.memory_adapter import (  # noqa: E402
     InMemoryCollection,
 )
 
-_SESSION_STUB_KEYS = (
+# Every sys.modules key this file owns. The stubs are installed and removed as
+# a set so the package can never hand a half-stubbed import graph to anything
+# collected around it.
+#
+# #13084: these were installed unconditionally at module import time with no
+# restore, so once ``llc/tests/`` was collected in a full-suite run they
+# permanently shadowed the REAL ``knowledge``/``agents`` packages for the rest
+# of the session — breaking genuine consumers collected later (e.g.
+# ``services/research/quarantine_boundary_test.py``'s ``from
+# knowledge.backends import InMemoryClient``, which fails only in a full run,
+# never in isolation).
+#
+# #13337: the package-scoped restore added for #13084 fired only at
+# ``llc/tests`` *teardown*, so the whole collect-plus-run window stayed
+# polluted.  Anything importing ``initialization.lifespan`` inside it died with
+# ``ModuleNotFoundError: No module named 'agents.overseer'`` — already broken
+# for ``pytest autobot-backend/llc/tests autobot-backend/initialization``, and
+# in CI saved only by two undocumented accidents (``initialization`` sorting
+# before ``llc``, and one module-level import in ``lifespan_test.py``).  The
+# stubs are now bound to two explicit windows instead — see ``_ScopedStubs``.
+_SCOPED_STUB_KEYS = (
     "knowledge",
     "knowledge.embedding_cache",
     "knowledge.utils",
+    "knowledge.backends",
     "agents",
     "agents.base_agent",
+    "api.codebase_analytics",
 )
-
-
-def _snapshot_session_stub_keys() -> dict:
-    """Capture the pre-stub sys.modules state for every key this file stubs.
-
-    Issue #13084: these stubs were previously installed unconditionally at
-    module import time with no restore, so once ``llc/tests/`` was collected
-    in a full-suite run they permanently shadowed the REAL ``knowledge``/
-    ``services``/``agents`` packages for the rest of the session — breaking
-    genuine consumers collected later (e.g.
-    ``services/research/quarantine_boundary_test.py``'s
-    ``from knowledge.backends import InMemoryClient``, which fails only in a
-    full run, never in isolation). ``None`` means the key was absent before
-    this file ran.
-    """
-    return {key: sys.modules.get(key) for key in _SESSION_STUB_KEYS}
 
 
 # #13107: __file__ = .../autobot-backend/llc/tests/conftest.py → parents[2]
@@ -109,16 +115,14 @@ def _make_knowledge_stub() -> types.ModuleType:
     return mod
 
 
-def _make_knowledge_submodule_stubs() -> None:
-    """Stub knowledge sub-packages imported by knowledge_base.py."""
+def _make_knowledge_submodule_stubs() -> dict:
+    """Return the knowledge sub-package stubs imported by knowledge_base.py."""
     ec = types.ModuleType("knowledge.embedding_cache")
     ec.EmbeddingCache = MagicMock  # type: ignore[attr-defined]
     ec.get_embedding_cache = AsyncMock(return_value=MagicMock())  # type: ignore[attr-defined]
-    sys.modules["knowledge.embedding_cache"] = ec
 
     ku = types.ModuleType("knowledge.utils")
     ku.sanitize_metadata_for_chromadb = MagicMock(return_value={})  # type: ignore[attr-defined]
-    sys.modules["knowledge.utils"] = ku
 
     # codebase_analytics/storage.py does ``from knowledge.backends import
     # get_async_default_client, get_default_client`` at module level. Without a
@@ -136,7 +140,7 @@ def _make_knowledge_submodule_stubs() -> None:
     # ``services/research/quarantine_boundary_test.py``, which fails only in
     # a full-suite run, never in isolation, because collection-time imports
     # happen before any fixture teardown could restore this stub). Re-exporting
-    # the real classes here means no restore is even needed for this key.
+    # the real classes here means the restore for this key is a formality.
     kb = types.ModuleType("knowledge.backends")
     kb.get_default_client = MagicMock(return_value=MagicMock())  # type: ignore[attr-defined]
     kb.get_async_default_client = AsyncMock(return_value=MagicMock())  # type: ignore[attr-defined]
@@ -144,21 +148,18 @@ def _make_knowledge_submodule_stubs() -> None:
     kb.InMemoryCollection = InMemoryCollection  # type: ignore[attr-defined]
     kb.AsyncInMemoryClient = AsyncInMemoryClient  # type: ignore[attr-defined]
     kb.AsyncInMemoryCollection = AsyncInMemoryCollection  # type: ignore[attr-defined]
-    sys.modules["knowledge.backends"] = kb
+
+    return {
+        "knowledge.embedding_cache": ec,
+        "knowledge.utils": ku,
+        "knowledge.backends": kb,
+    }
 
 
-# #13084: snapshot BEFORE stubbing so the package-scoped fixture below can
-# restore these exact keys once every test under llc/tests/ has run — the
-# stub is required for this package's own collection/tests but must not
-# outlive it (see _snapshot_session_stub_keys docstring).
-_PRE_STUB_MODULES = _snapshot_session_stub_keys()
-
-# The ``knowledge`` module imports lazily but fails when attributes are accessed
-# because chromadb → opentelemetry has a broken dependency in the dev venv.
-# Unconditionally replace with a stub so every lazy ``from knowledge import X``
-# receives our mock instead of triggering the broken chain.
-sys.modules["knowledge"] = _make_knowledge_stub()
-_make_knowledge_submodule_stubs()
+# NOTHING is stubbed at module import time (#13337). pytest pre-loads the
+# conftest of every *initial argument path* before collection starts, so an
+# import-time mutation here is live for the whole session's collection — not
+# just this package's. ``_ScopedStubs`` below installs them instead.
 
 
 def _make_services_stub() -> types.ModuleType:
@@ -212,8 +213,8 @@ def _make_services_stub() -> types.ModuleType:
     return services_mod
 
 
-def _make_agents_stub() -> None:
-    """Stub the ``agents`` package to avoid the knowledge/chromadb import chain.
+def _make_agents_stub() -> dict:
+    """Return ``agents`` stubs that avoid the knowledge/chromadb import chain.
 
     ``autobot_agent_adapter`` imports ``from agents.base_agent import AgentRequest``
     at module level.  Loading ``agents/__init__.py`` eagerly pulls in
@@ -224,26 +225,16 @@ def _make_agents_stub() -> None:
     agents_mod = types.ModuleType("agents")
     agents_mod.__path__ = []  # type: ignore[attr-defined]
     agents_mod.__package__ = "agents"
-    sys.modules["agents"] = agents_mod
 
     agents_base = types.ModuleType("agents.base_agent")
     agents_base.AgentRequest = MagicMock  # type: ignore[attr-defined]
     agents_base.AgentResponse = MagicMock  # type: ignore[attr-defined]
-    sys.modules["agents.base_agent"] = agents_base
+
+    return {"agents": agents_mod, "agents.base_agent": agents_base}
 
 
-# ``services.llm_service`` is imported at module level by llc/kb/handoff_brief.py
-# (merged to Dev_new_gui after issue-8238).  Stub it so the test collection
-# phase does not fail when the full service stack is absent.
-_make_services_stub()
-
-# ``agents.base_agent`` is imported by autobot_agent_adapter (GH#8502).
-# Stub it before any test module can trigger the agents/__init__.py chain.
-_make_agents_stub()
-
-
-def _shield_codebase_analytics_package() -> None:
-    """Register a lightweight package stub for api.codebase_analytics in sys.modules.
+def _make_codebase_analytics_shield() -> types.ModuleType:
+    """Return a lightweight package stub for api.codebase_analytics.
 
     Problem: api/codebase_analytics/__init__.py eagerly imports routes.py which
     chains through tasks/__init__.py → services.audit.audit — a path broken by
@@ -262,26 +253,257 @@ def _shield_codebase_analytics_package() -> None:
     The llc_client fixture installs per-test stubs for source_service and
     source_storage on top of this, and removes them at teardown so the real
     submodules remain available when analytics tests run afterward.
+
+    Built once and cached by ``_stub_modules`` — never rebuilt per install
+    window.  The real submodules this hollow ``__path__`` resolves
+    (``source_storage``, ``storage``, ``endpoints.stats``) bind themselves as
+    attributes of whichever parent object was live when they were first
+    imported, and ``unittest.mock.patch`` reaches them through exactly that
+    attribute.  A fresh parent per window therefore loses the bindings and
+    ``patch("api.codebase_analytics.source_storage.get_source")`` dies with
+    ``AttributeError: module 'api.codebase_analytics' has no attribute
+    'source_storage'`` (#13337).
     """
-    if "api.codebase_analytics" in sys.modules:
-        return  # real package already loaded — leave it intact
     # __file__ = .../autobot-backend/llc/tests/conftest.py → parents[2] = .../autobot-backend
     _pkg_dir = Path(__file__).parents[2] / "api" / "codebase_analytics"
     pkg = types.ModuleType("api.codebase_analytics")
     pkg.__path__ = [str(_pkg_dir)]  # type: ignore[attr-defined]
     pkg.__package__ = "api.codebase_analytics"
-    sys.modules["api.codebase_analytics"] = pkg
-    # Expose as an attribute on the parent ``api`` package so that
-    # ``mock.patch("api.codebase_analytics.<submodule>.<attr>")`` — whose dotted
-    # lookup runs ``getattr(api, "codebase_analytics")`` — resolves to this shield
-    # (#11129 P2). Without it, patching a lazily-imported analytics helper raises
-    # ``AttributeError: module 'api' has no attribute 'codebase_analytics'``.
+    return pkg
+
+
+# ---------------------------------------------------------------------------
+# #13337 — the stubs live exactly as long as this package needs them
+# ---------------------------------------------------------------------------
+
+
+# Packages whose object identity is swapped by install/restore, and whose
+# already-imported children therefore need their parent attribute re-bound.
+_REBIND_PARENTS = ("knowledge", "agents", "api.codebase_analytics")
+
+
+def _rebind_submodules(parent_key: str) -> None:
+    """Bind the direct ``sys.modules`` children of *parent_key* onto its parent.
+
+    Swapping a package object in or out of ``sys.modules`` orphans every child
+    that was imported through the *previous* parent: ``__import__``
+    short-circuits on the cached child entry and never re-runs the
+    parent-attribute bind the import system would normally do.  So
+    ``mock.patch("knowledge.connectors.X")`` — which resolves the dotted path
+    with ``getattr`` — dies with ``AttributeError: module 'knowledge' has no
+    attribute 'connectors'`` for anything the ``llc/tests`` window pulled in
+    through the stub's ``__path__`` (#13337).  Re-doing the bind reproduces
+    exactly what a fresh import would have left behind.
+    """
+    parent = sys.modules.get(parent_key)
+    if parent is None:
+        return
+    prefix = f"{parent_key}."
+    for name, module in list(sys.modules.items()):
+        child = name[len(prefix) :]
+        if module is None or not name.startswith(prefix) or "." in child:
+            continue
+        setattr(parent, child, module)
+
+
+def _rebind_all_submodules() -> None:
+    """Re-bind every swapped package's children (both install and restore)."""
+    for parent_key in _REBIND_PARENTS:
+        _rebind_submodules(parent_key)
+
+
+_STUB_MODULES: dict = {}
+
+
+def _stub_modules() -> dict:
+    """Build this package's stub modules once and hand back the same objects.
+
+    Identity is load-bearing.  ``unittest.mock.patch`` resolves a dotted target
+    by ``getattr`` on the parent module object, and the mocks these stubs carry
+    (``knowledge.get_knowledge_base``, ``agents.base_agent.AgentRequest``, the
+    ``api.codebase_analytics`` submodule bindings) are reached that way.  A
+    fresh object per install window would silently move the patch target away
+    from the object the code under test already holds (#13337).
+    """
+    if not _STUB_MODULES:
+        _STUB_MODULES["knowledge"] = _make_knowledge_stub()
+        _STUB_MODULES.update(_make_knowledge_submodule_stubs())
+        _STUB_MODULES.update(_make_agents_stub())
+        _STUB_MODULES["api.codebase_analytics"] = _make_codebase_analytics_shield()
+    return _STUB_MODULES
+
+
+def _install_scoped_stubs() -> None:
+    """Put this package's stubs into sys.modules, in dependency order.
+
+    ``api.codebase_analytics`` is only shielded when it is absent — a real,
+    fully-imported package always wins.  The parent-package attribute is set so
+    that ``mock.patch("api.codebase_analytics.<submodule>.<attr>")``, whose
+    dotted lookup runs ``getattr(api, "codebase_analytics")``, resolves to the
+    shield (#11129 P2).
+    """
+    stubs = _stub_modules()
+    for key, module in stubs.items():
+        if key == "api.codebase_analytics" and key in sys.modules:
+            continue  # real package already loaded — leave it intact
+        sys.modules[key] = module
+    # services.llm_service is imported at module level by llc/kb/handoff_brief.py
+    # (merged to Dev_new_gui after issue-8238). Guarded per-name, so the root
+    # autobot-backend/conftest.py's richer setup always wins; the attribute
+    # binds it performs are required on every call (see its docstring).
+    _make_services_stub()
     import importlib  # noqa: PLC0415
 
-    importlib.import_module("api").codebase_analytics = pkg  # type: ignore[attr-defined]
+    importlib.import_module("api").codebase_analytics = sys.modules[  # type: ignore[attr-defined]
+        "api.codebase_analytics"
+    ]
+    _rebind_all_submodules()
 
 
-_shield_codebase_analytics_package()
+class _ScopedStubs:
+    """Own the sys.modules stubs for ``llc/tests`` and nothing beyond it.
+
+    Entered once per collector under this directory and once per test run, and
+    exited on the matching event, so the stubs are live for exactly the two
+    windows that need them: importing this package's own test modules, and
+    running its tests.  Everything pytest does in between — collecting any
+    other directory, running any other package's tests — sees the real
+    ``knowledge``/``agents``/``services`` packages.
+
+    Re-entrant and restore-guaranteed: the snapshot is taken on the outermost
+    enter, the install runs under ``try/except`` so a failure part-way through
+    still restores, and ``restore_all`` is a hard reset for the session-teardown
+    safety net.
+    """
+
+    def __init__(self) -> None:
+        self._holders: set[str] = set()
+        self._snapshot: dict | None = None
+        self._api_attr_present = False
+        self._api_attr_prior = None
+
+    def enter(self, holder: str) -> None:
+        """Install the stubs if *holder* is the first to ask for them."""
+        first = not self._holders
+        self._holders.add(holder)
+        if not first:
+            return
+        self._snapshot = {key: sys.modules.get(key) for key in _SCOPED_STUB_KEYS}
+        self._snapshot_api_attr()
+        try:
+            _install_scoped_stubs()
+        except BaseException:
+            self._holders.clear()
+            self._restore()
+            raise
+
+    def exit(self, holder: str) -> None:
+        """Restore sys.modules once the last holder is done."""
+        self._holders.discard(holder)
+        if not self._holders:
+            self._restore()
+
+    def restore_all(self) -> None:
+        """Unconditionally release the stubs (session-teardown safety net)."""
+        self._holders.clear()
+        self._restore()
+
+    def _snapshot_api_attr(self) -> None:
+        """Remember whether ``api.codebase_analytics`` was already bound.
+
+        ``_shield_codebase_analytics_package`` sets the attribute on the real
+        ``api`` package so ``mock.patch("api.codebase_analytics...")`` resolves
+        (#11129 P2); the attribute has to come back off again with the stub.
+        """
+        api_mod = sys.modules.get("api")
+        self._api_attr_present = hasattr(api_mod, "codebase_analytics")
+        self._api_attr_prior = getattr(api_mod, "codebase_analytics", None)
+
+    def _restore_api_attr(self) -> None:
+        api_mod = sys.modules.get("api")
+        if api_mod is None:
+            return
+        if self._api_attr_present:
+            api_mod.codebase_analytics = self._api_attr_prior  # type: ignore[attr-defined]
+        else:
+            api_mod.__dict__.pop("codebase_analytics", None)
+
+    def _restore(self) -> None:
+        snapshot, self._snapshot = self._snapshot, None
+        if snapshot is None:
+            return
+        for key, prior in snapshot.items():
+            if prior is None:
+                sys.modules.pop(key, None)
+            else:
+                sys.modules[key] = prior
+        self._restore_api_attr()
+        _rebind_all_submodules()
+
+
+_SCOPED_STUBS = _ScopedStubs()
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_make_collect_report(collector):
+    """Stub the heavy imports around this directory's own collection, only.
+
+    Directory-scoped — pytest dispatches this through ``collector.ihook``, so it
+    fires only for nodes whose conftest chain includes this file — and it wraps
+    exactly ``collector.collect()``, which is where a ``Module`` node imports
+    its test module.  Nothing else runs inside that call, so the window cannot
+    span a sibling directory.
+
+    ``pytest_collectstart``/``pytest_collectreport`` are *not* usable here, and
+    not merely because of ordering: ``pytest_collectreport`` never fires for a
+    ``Dir`` or ``Package`` node at all.  Only ``Session`` and ``Module`` nodes
+    get one, because the initial-argument node chain is built outside the
+    ``Session.genitems`` recursion that emits the report.  Traced with a probe
+    plugin on ``pytest llc/tests/test_health_probe.py
+    initialization/lifespan_test.py``::
+
+        [start ] Package 'autobot-backend/llc/tests'
+        [start ] Package 'autobot-backend/initialization'
+        [report] ''
+        [start ] Module 'autobot-backend/llc/tests/test_health_probe.py'
+        [report] 'autobot-backend/llc/tests/test_health_probe.py'
+
+    A ``collectstart``/``collectreport`` pair keyed on the package node would
+    therefore install the stubs and **never** restore them — strictly worse
+    than the import-time bug this replaces.
+    """
+    holder = f"collect:{collector.nodeid}"
+    _SCOPED_STUBS.enter(holder)
+    try:
+        yield
+    finally:
+        _SCOPED_STUBS.exit(holder)
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_protocol(item, nextitem):
+    """Stub the heavy imports for the whole of each test under this directory.
+
+    Covers setup, call and teardown — LLC route handlers import ``knowledge``
+    and ``agents`` lazily inside request handling — and restores from a
+    ``finally`` so no failure path can leak the stub into the next test.
+    """
+    holder = f"run:{item.nodeid}"
+    _SCOPED_STUBS.enter(holder)
+    try:
+        yield
+    finally:
+        _SCOPED_STUBS.exit(holder)
+
+
+def pytest_sessionfinish(session, exitstatus) -> None:
+    """Safety net: never let the stubs outlive the session.
+
+    Both windows restore from a ``finally``, but a ``BaseException`` that
+    unwinds past pytest's own hook machinery (``KeyboardInterrupt`` during
+    collection, a worker crash) could still strand the holders set.
+    """
+    _SCOPED_STUBS.restore_all()
 
 
 # ---------------------------------------------------------------------------
@@ -490,30 +712,6 @@ def _build_llc_app(
     _patch_kb.start()
 
     return app, _patch_kb
-
-
-@pytest.fixture(scope="package", autouse=True)
-def _restore_session_stubs_after_package():
-    """Restore the module-level ``knowledge``/``agents`` stubs after this
-    package finishes (#13084).
-
-    The stubs installed above at import time are required for llc/tests/
-    itself to collect (chromadb/opentelemetry are unavailable in dev/CI), but
-    were previously left in ``sys.modules`` for the rest of the pytest
-    session with no restore — shadowing the REAL ``knowledge.backends``
-    package for any test collected afterward in the same worker (reproduced:
-    ``services/research/quarantine_boundary_test.py``'s
-    ``from knowledge.backends import InMemoryClient`` fails only in a
-    full-suite run, never in isolation). Restoring here — rather than a
-    session-scoped hook — ties the fix to exactly the lifetime that needs
-    the stub.
-    """
-    yield
-    for key, prior in _PRE_STUB_MODULES.items():
-        if prior is None:
-            sys.modules.pop(key, None)
-        else:
-            sys.modules[key] = prior
 
 
 @pytest.fixture

--- a/autobot-backend/llc/tests/conftest.py
+++ b/autobot-backend/llc/tests/conftest.py
@@ -480,6 +480,30 @@ def pytest_make_collect_report(collector):
         _SCOPED_STUBS.exit(holder)
 
 
+_THIS_DIR = Path(__file__).parent
+
+
+def _is_ours(item) -> bool:
+    """True when *item* lives under this directory.
+
+    ``pytest_runtest_protocol`` is NOT directory-scoped, unlike every other
+    hook this file implements.  ``Session.pytest_runtestloop`` dispatches it
+    through ``item.config.hook`` — the global relay — not through
+    ``item.ihook``, so a hookwrapper defined in *any* conftest wraps *every*
+    item in the session.  Without this check the stubs were installed around
+    unrelated tests: ``knowledge/facts_metadata_sync_test.py`` lazily imports
+    ``knowledge.utils.sanitize_metadata_for_chromadb`` inside ``update_fact``
+    and got this file's ``MagicMock(return_value={})`` instead of the real
+    sanitiser, failing with ``KeyError: 'collection'``.
+
+    ``pytest_make_collect_report`` needs no such guard: ``collect_one_node``
+    dispatches it through ``collector.ihook``, which is scoped to the
+    collector's own conftest chain.
+    """
+    path = getattr(item, "path", None)
+    return path is not None and _THIS_DIR in Path(str(path)).parents
+
+
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_protocol(item, nextitem):
     """Stub the heavy imports for the whole of each test under this directory.
@@ -488,6 +512,9 @@ def pytest_runtest_protocol(item, nextitem):
     and ``agents`` lazily inside request handling — and restores from a
     ``finally`` so no failure path can leak the stub into the next test.
     """
+    if not _is_ours(item):
+        yield
+        return
     holder = f"run:{item.nodeid}"
     _SCOPED_STUBS.enter(holder)
     try:

--- a/autobot-backend/llc/tests/test_health_probe.py
+++ b/autobot-backend/llc/tests/test_health_probe.py
@@ -451,24 +451,24 @@ async def test_probe_returns_unwired_degraded_with_no_request_context():
 
 
 # NOTE on why the real-lifespan-objects test for this fix lives in
-# initialization/lifespan_test.py instead of here: this is NOT primarily a
-# "safer file placement" choice -- it works today because
-# initialization/lifespan_test.py:19 imports `initialization.lifespan` at
-# MODULE level (eagerly, at collection time), and pytest's default
-# collection order visits `autobot-backend/initialization/` before
-# `autobot-backend/llc/` (plain alphabetical directory order) when both are
-# swept in one run. `initialization.lifespan` and its transitive
-# `api.overseer_handlers -> agents.overseer` chain are therefore already
-# fully imported and cached in sys.modules before llc/tests/conftest.py ever
-# installs its `sys.modules["agents"]` stub (added to dodge the chromadb
-# import chain) -- so the stub has nothing left to shadow for that already
-# -cached module.
+# initialization/lifespan_test.py instead of here: it is a plain locality
+# choice -- that test drives the real lifespan objects, which belong to that
+# module.
 #
-# That invariant is fragile, not structural: (1) it silently breaks if
-# `lifespan_test.py`'s top-level import is ever converted to a lazy
-# in-function import, matching the style this file's own two new tests
-# already use; (2) it is already broken today for anyone who runs
-# `pytest autobot-backend/llc/tests autobot-backend/initialization` (llc
-# first) -- confirmed the ModuleNotFoundError reproduces with that explicit
-# ordering. See GH#13331 PR review (#13336) for the filed follow-up on
-# conftest.py's stub scoping.
+# It used to be a load-bearing workaround. llc/tests/conftest.py installed a
+# `sys.modules["agents"]` stub at import time (to dodge the chromadb import
+# chain) and only restored it at package teardown, so the stub was live for
+# the whole collect-plus-run window. Nothing importing
+# `initialization.lifespan` -> `api.overseer_handlers` -> `agents.overseer`
+# could be collected inside it. A one-run sweep survived only because
+# `initialization` sorts before `llc` alphabetically AND
+# lifespan_test.py:19 imports at MODULE level, so the chain was already
+# cached before the stub landed -- an invariant that broke the moment either
+# changed, and that was already broken for
+# `pytest autobot-backend/llc/tests autobot-backend/initialization`.
+#
+# #13337 removed the workaround's reason to exist: the stubs are now bound to
+# this package's own collect and run windows (see conftest.py's
+# `_ScopedStubs`), so either ordering passes. The repo-wide detector that
+# would catch a future conftest letting a stub escape is tracked separately
+# in #13361.

--- a/autobot-slm-backend/tests/api/conftest.py
+++ b/autobot-slm-backend/tests/api/conftest.py
@@ -69,13 +69,16 @@ if "python_multipart" not in sys.modules:
 # poll would keep spinning for the full window, which is the failure mode being
 # prevented.
 #
-# Deliberately a runtest hook and NOT an autouse fixture.  An autouse fixture
-# that requests monkeypatch registers a finalizer for every test in the package,
-# and that extra teardown step reorders the async session fixture in
-# test_slm_endpoints_12515.py enough to break its ``async with
-# session_factory()`` exit (9 teardown errors).  A hookwrapper adds no fixture
-# and no finalizer, and wraps only the call phase — which is also the correct
-# scope, since the I/O being guarded happens inside the test body.
+# A runtest hook rather than an autouse fixture.  #13320 had no choice: an
+# autouse fixture requesting monkeypatch registers a finalizer for every test in
+# the package, and that reordered the async session fixture in
+# test_slm_endpoints_12515.py enough to break its session close (9 teardown
+# errors).  That tripwire is fixed — the fixture now closes its session
+# explicitly and no longer patches the shared asyncio module, and the module
+# carries an autouse ``finalizer_ordering_guard`` that keeps it fixed (#13329) —
+# so the constraint no longer applies.  The hookwrapper stays because it is
+# still the better scope: it adds no fixture and no finalizer, and wraps only
+# the call phase, which is where the I/O being guarded happens.
 _LIVE_POLL_MESSAGE = (
     "unit test attempted a live component health poll via httpx.AsyncClient. "
     "api.code_sync._wait_component_healthy polls until its timeout window "

--- a/autobot-slm-backend/tests/api/test_slm_endpoints_12515.py
+++ b/autobot-slm-backend/tests/api/test_slm_endpoints_12515.py
@@ -36,6 +36,7 @@ import asyncio
 import contextlib
 import importlib
 import sys
+import types
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -161,6 +162,29 @@ with _real_modules_swapped():
 _PRINCIPAL = {"admin": True, "role": "admin", "sub": "tester"}
 
 
+async def _close_session_and_engine(session, engine) -> None:
+    """Close *session*, then dispose *engine*, without using ``__aexit__``.
+
+    ``AsyncSession.__aexit__`` closes through
+    ``await asyncio.shield(asyncio.create_task(self.close()))``.  Any test in
+    this package that has replaced ``asyncio.create_task`` and whose
+    ``monkeypatch`` undo is ordered *after* this teardown therefore hands
+    ``shield`` a non-awaitable: the close is abandoned mid-flight and the
+    aiosqlite connection stays checked out until the garbage collector
+    terminates it (the ``SAWarning`` behind the xdist controller crash).
+    Registering any fixture finalizer in this package is enough to produce that
+    ordering, which made the old spelling a tripwire rather than a bug (#13329).
+
+    ``AsyncSession.close()`` is a plain coroutine, so awaiting it directly is
+    equivalent and depends on nothing global.  ``engine.dispose()`` runs from a
+    ``finally`` so a failed close can never leave a half-open transport behind.
+    """
+    try:
+        await session.close()
+    finally:
+        await engine.dispose()
+
+
 @pytest.fixture
 async def db():
     """A fresh real in-memory SQLite AsyncSession per test."""
@@ -168,10 +192,58 @@ async def db():
         engine = create_async_engine("sqlite+aiosqlite:///:memory:")
         async with engine.begin() as conn:
             await conn.run_sync(Base.metadata.create_all)
-    session_factory = async_sessionmaker(engine, expire_on_commit=False)
-    async with session_factory() as session:
+    session = async_sessionmaker(engine, expire_on_commit=False)()
+    try:
         yield session
-    await engine.dispose()
+    finally:
+        await _close_session_and_engine(session, engine)
+
+
+# ---------------------------------------------------------------------------
+# #13329 — the finalizer-ordering pin
+# ---------------------------------------------------------------------------
+
+_REAL_CREATE_TASK = asyncio.create_task
+
+
+@pytest.fixture(autouse=True)
+def finalizer_ordering_guard(request, monkeypatch):
+    """Hold this module to the fixture ordering that used to break its teardown.
+
+    ``db`` previously closed its session through
+    ``AsyncSession.__aexit__`` → ``await asyncio.shield(asyncio.create_task(...))``
+    while ``no_bg_tasks`` had ``asyncio.create_task`` replaced on the *shared*
+    ``asyncio`` module.  Requesting ``monkeypatch`` as a parameter here — plus
+    the ``addfinalizer`` below — puts ``monkeypatch``'s undo *underneath* ``db``
+    on the finalizer stack, so the undo runs after ``db`` tears down.  That
+    ordering is what turned the fixture into a tripwire: any fixture finalizer
+    anywhere in ``tests/api`` produced it, and it cost 9 teardown errors plus a
+    leaked aiosqlite connection (#13329).
+
+    Autouse and unconditional on purpose: every test in this module now runs
+    under the ordering, so a regression cannot hide behind a single test case.
+    """
+    request.addfinalizer(lambda: None)
+
+
+async def test_db_teardown_survives_a_replaced_global_create_task(db, monkeypatch):
+    """``db`` must tear down even with a non-awaitable ``asyncio.create_task``.
+
+    ``monkeypatch``'s undo is ordered after ``db``'s teardown (see
+    ``finalizer_ordering_guard``), so the replacement below is still live while
+    the session closes — the exact interpreter state that raised
+    ``TypeError: An asyncio.Future, a coroutine or an awaitable is required``.
+    """
+    monkeypatch.setattr(asyncio, "create_task", lambda *a, **kw: MagicMock())
+    assert db.is_active
+
+
+def test_no_bg_tasks_leaves_the_shared_asyncio_module_untouched(no_bg_tasks):
+    """The background-task patch stays inside ``api.stateful``."""
+    assert asyncio.create_task is _REAL_CREATE_TASK
+    assert _stateful.asyncio is not asyncio
+    assert _stateful.asyncio.create_task is not _REAL_CREATE_TASK
+    assert _stateful.asyncio.wait_for is asyncio.wait_for
 
 
 async def _insert_node(db, node_id: str, ip: str = "10.0.0.10", **overrides) -> Node:
@@ -290,6 +362,26 @@ class TestNodesCrud:
 # ---------------------------------------------------------------------------
 
 
+def _make_no_op_task_asyncio() -> types.ModuleType:
+    """Return an ``asyncio`` stand-in whose ``create_task`` schedules nothing.
+
+    A module object carrying a copy of the real ``asyncio`` namespace, so every
+    other attribute ``api/stateful.py`` reaches for
+    (``create_subprocess_exec``, ``subprocess.PIPE``, ``wait_for``,
+    ``TimeoutError``) keeps its real behaviour.
+    """
+
+    def _fake_create_task(coro=None, *args, **kwargs):
+        if asyncio.iscoroutine(coro):
+            coro.close()
+        return MagicMock()
+
+    shim = types.ModuleType("asyncio")
+    shim.__dict__.update(vars(asyncio))
+    shim.create_task = _fake_create_task  # type: ignore[attr-defined]
+    return shim
+
+
 @pytest.fixture
 def no_bg_tasks(monkeypatch):
     """Neutralise the fire-and-forget ``asyncio.create_task`` background jobs.
@@ -299,14 +391,17 @@ def no_bg_tasks(monkeypatch):
     Scheduling those would either raise (MagicMock isn't a coroutine) or leak
     'never retrieved' task warnings, so replace scheduling with a coroutine-safe
     no-op for the duration of the test.
+
+    #13329: the replacement goes on the *router module's* ``asyncio`` binding,
+    never on the shared ``asyncio`` module itself.  ``monkeypatch.setattr(
+    _stateful.asyncio, "create_task", ...)`` mutated the one ``asyncio`` object
+    the whole process shares — including the copy SQLAlchemy's
+    ``AsyncSession.__aexit__`` calls — so for as long as the undo had not run,
+    every unrelated async teardown in this package got a ``MagicMock`` back from
+    ``create_task``.  Rebinding the name inside ``api.stateful`` keeps the blast
+    radius at exactly the module under test.
     """
-
-    def _fake_create_task(coro=None, *args, **kwargs):
-        if asyncio.iscoroutine(coro):
-            coro.close()
-        return MagicMock()
-
-    monkeypatch.setattr(_stateful.asyncio, "create_task", _fake_create_task)
+    monkeypatch.setattr(_stateful, "asyncio", _make_no_op_task_asyncio())
 
 
 class TestStatefulBackups:


### PR DESCRIPTION
## Thinking Path

Both issues are the same failure mode from two sides: a fixture mutating process-global state whose cleanup is not bound to the scope that needs it. Reproductions were confirmed first, before anything changed.

**Scope note.** This PR originally also carried a repo-wide `sys.modules` leak-detector plugin. Review found three defects in it — one of which reintroduced the exact xdist-controller `INTERNALERROR` that #13320 fixed — so the guard has been split out to its own PR against #13361. The two fixes here were independently verified and carry none of that risk. Rebased onto the current base.

**#13337.** `llc/tests/conftest.py` installed its `sys.modules` stubs at *module import* time. pytest pre-loads the conftest of every initial argument path before collection begins, so the mutation was live for the whole collect-plus-run window, and the only restore was a `scope="package"` fixture firing at the very end.

Getting the scope right took two attempts, and the first was wrong in an instructive way:

1. `pytest_collectstart`/`pytest_collectreport` looked like the natural pair. It is not merely mis-ordered — **`pytest_collectreport` never fires for a `Dir` or `Package` node at all.** Only `Session` and `Module` nodes get one, because the initial-argument node chain is built outside the `Session.genitems` recursion that emits the report. Traced with a probe plugin:

       [start ] Package 'autobot-backend/llc/tests'
       [start ] Package 'autobot-backend/initialization'
       [report] ''
       [start ] Module 'autobot-backend/llc/tests/test_health_probe.py'
       [report] 'autobot-backend/llc/tests/test_health_probe.py'

   A pair keyed on the package node would install the stubs and **never restore them** — strictly worse than the bug being replaced. `pytest_make_collect_report` wraps exactly `collector.collect()`, the call that imports the module, and cannot span a sibling.

2. Scoping alone then broke tests that had been passing. Rebuilding the stub objects per window moves `mock.patch`'s target off the object under test (`AttributeError: module 'api.codebase_analytics' has no attribute 'source_storage'`), and swapping a package in and out of `sys.modules` orphans the children imported through the previous parent (`AttributeError: module 'knowledge' has no attribute 'connectors'`). Both are fixed structurally rather than papered over: stub modules are built once and reused, and `_rebind_submodules` re-points a parent at what the import system already loaded.

3. Verifying against CI's own shards then exposed a third trap, and this one was mine. `pytest_runtest_protocol` is **not** directory-scoped, unlike every other hook this conftest implements: `Session.pytest_runtestloop` dispatches it through `item.config.hook`, the global relay, not through `item.ihook`. So the run-phase hookwrapper wrapped *every* item in the session and installed this package's stubs around unrelated tests. `knowledge/facts_metadata_sync_test.py` lazily imports `knowledge.utils.sanitize_metadata_for_chromadb` inside `update_fact` and got this file's `MagicMock(return_value={})`, failing with `KeyError: 'collection'`. Probing the holder set proved it — while a `knowledge/` test ran, the live holder was `run:autobot-backend/knowledge/facts_metadata_sync_test.py::...`. The wrapper now checks the item's path against this directory. `pytest_make_collect_report` needs no such guard: `collect_one_node` dispatches it through `collector.ihook`.

**#13329.** The `db` fixture was only the victim. The mutation is `no_bg_tasks`, which did `monkeypatch.setattr(_stateful.asyncio, "create_task", ...)` — and `_stateful.asyncio` **is** the one `asyncio` module the whole process shares, including the copy SQLAlchemy's `AsyncSession.__aexit__` reaches for. Requesting `monkeypatch` as a fixture parameter anywhere in the package pulls its undo *underneath* `db` on the finalizer stack, so the undo runs after the session close and `asyncio.shield` gets a `MagicMock`. `--showlocals` confirmed it: `task = <MagicMock id=...>`.

## What Changed

**#13337 — `autobot-backend/llc/tests/conftest.py`**
- Nothing is stubbed at module import time. `_ScopedStubs` installs and restores as a set, from `try/finally`, across two explicit windows: a `pytest_make_collect_report` hookwrapper (this package's own module imports) and a `pytest_runtest_protocol` hookwrapper (setup, call and teardown of its tests). A `pytest_sessionfinish` safety net catches an interrupted collection.
- Stub modules are built once by `_stub_modules()` and reused, so `mock.patch` targets keep their identity across windows. `_rebind_submodules` re-binds direct children onto the live parent on both install and restore.
- Stub factories return mappings instead of writing to `sys.modules` themselves; `_shield_codebase_analytics_package` became `_make_codebase_analytics_shield`. `_make_services_stub` is unchanged and still guarded per name — those keys belong to the backend root conftest and are deliberately not in the scoped set.
- The obsolete `_restore_session_stubs_after_package` fixture is gone; its #13084 rationale is carried into the new code's comments.
- `test_health_probe.py`'s note no longer claims file placement is the mechanism; it records what the mechanism actually was and that it is fixed.

**#13329 — `autobot-slm-backend/tests/api/test_slm_endpoints_12515.py`**
- `no_bg_tasks` rebinds `api.stateful`'s own `asyncio` name to a module-level copy whose `create_task` is a no-op, instead of mutating the shared `asyncio` module. Every other attribute the router uses (`create_subprocess_exec`, `subprocess.PIPE`, `wait_for`, `TimeoutError`) keeps real behaviour.
- The `db` fixture closes its session with `await session.close()` and disposes the engine from a `finally`, so it never routes through `AsyncSession.__aexit__`'s `shield(create_task(...))` and cannot leave a half-open transport.
- An autouse `finalizer_ordering_guard` requests `monkeypatch` as a parameter and registers a no-op finalizer for **every** test in the module, pinning the ordering that produced the 9 errors, plus two explicit regression tests.
- `tests/api/conftest.py`'s comment no longer asserts the now-obsolete constraint that an autouse fixture cannot be used in this package.

## Verification

All runs on the current base (`7316bb035`).

**The ordering that was broken — collection used to abort here.**

Before (base conftest):

    $ pytest autobot-backend/llc/tests autobot-backend/initialization -q
    ERROR collecting autobot-backend/initialization/env_drift_path_test.py
      api/overseer_handlers.py:20: from agents.overseer import OverseerAgent, ...
    E   ModuleNotFoundError: No module named 'agents.overseer'
    !!!! Interrupted: 1 error during collection !!!!

After:

    $ pytest autobot-backend/llc/tests autobot-backend/initialization -q
    5 failed, 1411 passed, 1 skipped, 92 warnings in 595.93s

**The blast radius is wider than the issue describes.** `llc/tests` also poisoned `api/codebase_analytics`, measured on this base by swapping only the conftest:

    base conftest:  33 failed, 1611 passed, 8 skipped in 232.70s
    this branch:     5 failed, 1639 passed, 8 skipped in 270.49s

**28 cross-package failures fixed**, 28 more tests passing. This is what `_stub_modules()` caching and `_rebind_submodules` protect — without them the same run regresses to base with the two `AttributeError`s quoted above.

The 5 remaining failures are pre-existing and unrelated: all in `test_poll_loop_scheduler.py`, all `AttributeError: '_asyncio.Task' object has no attribute 'cancelling'`. Same set on the base conftest, so this branch removes zero passing tests. (`Task.cancelling()` is 3.11+; `llc/scheduler/base.py:75` calls it unguarded, which means the masked-cancel guard silently never works on a 3.10 deployment — a production bug from #13209, being filed separately by review.)

The issue's own repro commands:

    $ pytest initialization/lifespan_test.py llc/tests/test_health_probe.py -q
    48 passed
    $ pytest autobot-backend/initialization autobot-backend/llc/tests/test_health_probe.py -q
    60 passed

**#13329 — reproduced, then fixed.** Bisected with the issue's single-purpose plugin (an autouse fixture taking `monkeypatch` as a parameter); `--showlocals` pinned `task = <MagicMock id='...'>` inside `AsyncSession.__aexit__`.

Before:

    $ pytest .../test_slm_endpoints_12515.py -p mp_probe -q
    16 passed, 9 errors in 9.93s
    E   TypeError: An asyncio.Future, a coroutine or an awaitable is required

After, same plugin still loaded:

    $ pytest .../test_slm_endpoints_12515.py -p mp_probe -q
    31 passed in 19.11s

Zero errors, and `grep -c SAWarning` on that run returns `0` — the "garbage collector is trying to clean up non-checked-in connection" warning that crashed the xdist controller is gone too. The 31 includes the 2 new regression tests, and every test in the module now runs under the autouse finalizer ordering.

Whole package, to confirm the autouse guard trips nothing else:

    $ pytest autobot-slm-backend/tests/api -q --ignore=.../test_scim.py
    364 passed, 4 warnings in 73.49s

`test_scim.py` is excluded because it fails to collect on the **base** tree too (`ModuleNotFoundError: No module named 'services.system_secrets_vault'; 'services' is not a package`) — a separate instance of the same family, not touched here.

No test added here takes more than a second. `black --check`, `isort --check-only` and `flake8` clean on all four changed files.

**The run-phase scoping fix (`2d4a6fa23`) repairs more than it was written for.** Comparing this branch's `python-suite` shards against `Dev_new_gui`'s own run at `8b8767a23` turned up one genuine regression, which led to the `item.config.hook` finding above. Fixing it also cleared failures that were *already red on the base*:

    $ pytest llc/tests/test_sprint_close.py knowledge/knowledge_base_async_test.py \
             knowledge/facts_metadata_sync_test.py -q
    base conftest:   5 failed, 13 passed
    this branch:    18 passed

    $ pytest llc/tests/test_health_probe.py api/agent_usage_test.py \
             agents/base_agents_e2e_test.py -q
    base conftest:  Interrupted: 1 error during collection   (0 tests run)
    this branch:    50 passed

Those last three — `api/agent_usage_test.py` (×2) and `agents/base_agents_e2e_test.py::test_serialization`, all `ImportError: cannot import name ... from 'agents.base_agent' (unknown location)` — are red on `Dev_new_gui`'s shard 1 today and green here.

**Shard-by-shard comparison against the base run.** Base shard 1 and this branch's shard 1 are identical: `11 failed, 1992 passed, 2125 skipped, 4 errors`, same failure list. The remaining base-vs-branch shard deltas are pytest-split reassignment — the split is duration-based, so changing runtimes moves tests between shards. The full `python-suite` is red on `Dev_new_gui` itself (#13162, actively being repaired by the #13349/#13354/#13363/#13367 series) and is not a required check.

## Model Used

claude-opus-4-6 (Opus 5)

Closes #13337, #13329
