### PR TITLE
fix(api): repair the 48 red tests under autobot-backend/api, 7 of them real bugs (#13162)

### DIFF
--- a/autobot-backend/api/alertmanager_webhook.py
+++ b/autobot-backend/api/alertmanager_webhook.py
@@ -10,9 +10,10 @@ Security: GH#9657 - Added webhook authentication (fail-closed)
 """
 
 import os
+import secrets
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, HTTPException, Request, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 
 from api.monitoring import ws_manager
 from api.schemas_system import (
@@ -29,47 +30,60 @@ logger = get_logger(__name__)
 router = APIRouter(prefix="/webhook", tags=["webhooks"])
 
 
-@router.post("/alertmanager", response_model=AlertManagerWebhookReceiveResponse)
+async def verify_alertmanager_secret(request: Request) -> None:
+    """Authenticate an AlertManager webhook call (GH#9657, fail-closed).
+
+    Declared as a route dependency rather than an in-body check so the secret
+    is verified *before* FastAPI validates the request body: an unauthenticated
+    caller must not be able to probe the payload schema, and a request that
+    arrives while ALERTMANAGER_WEBHOOK_SECRET is unset must fail closed with
+    503 whatever its body looks like.
+    """
+    webhook_secret = os.environ.get("ALERTMANAGER_WEBHOOK_SECRET")
+    if not webhook_secret:
+        logger.error("AlertManager webhook secret not configured - failing closed")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Webhook authentication not configured",
+        )
+
+    request_secret = request.headers.get("X-AlertManager-Secret")
+    if not request_secret:
+        logger.warning("AlertManager webhook authentication failed - missing secret header")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing authentication header",
+        )
+
+    if not secrets.compare_digest(request_secret, webhook_secret):
+        logger.warning("AlertManager webhook authentication failed - invalid secret")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Invalid authentication credentials",
+        )
+
+
+@router.post(
+    "/alertmanager",
+    response_model=AlertManagerWebhookReceiveResponse,
+    dependencies=[Depends(verify_alertmanager_secret)],
+)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="receive_alertmanager_webhook",
     error_code_prefix="ALERTMANAGER_WEBHOOK",
 )
-async def receive_alertmanager_webhook(payload: AlertManagerWebhook, request: Request):
+async def receive_alertmanager_webhook(payload: AlertManagerWebhook):
     """
     Receive alerts from Prometheus AlertManager
 
     Phase 3 (Issue #346): AlertManager → WebSocket integration
     Replaces MonitoringAlertsManager's WebSocket notification channel
 
-    Security (GH#9657): Requires X-AlertManager-Secret header authentication.
-    Fails closed when ALERTMANAGER_WEBHOOK_SECRET is not configured.
+    Security (GH#9657): Requires X-AlertManager-Secret header authentication,
+    enforced by the ``verify_alertmanager_secret`` route dependency.
     """
     try:
-        # Verify webhook secret (GH#9657 fail-closed authentication)
-        webhook_secret = os.environ.get("ALERTMANAGER_WEBHOOK_SECRET")
-        if not webhook_secret:
-            logger.error("AlertManager webhook secret not configured - failing closed")
-            raise HTTPException(
-                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                detail="Webhook authentication not configured",
-            )
-
-        request_secret = request.headers.get("X-AlertManager-Secret")
-        if not request_secret:
-            logger.warning("AlertManager webhook authentication failed - missing secret header")
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Missing authentication header",
-            )
-
-        if request_secret != webhook_secret:
-            logger.warning("AlertManager webhook authentication failed - invalid secret")
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="Invalid authentication credentials",
-            )
-
         logger.info(
             f"Received AlertManager webhook: {len(payload.alerts)} alerts "
             f"(status: {payload.status}, receiver: {payload.receiver})"
@@ -85,6 +99,8 @@ async def receive_alertmanager_webhook(payload: AlertManagerWebhook, request: Re
             "timestamp": datetime.now(tz=timezone.utc).isoformat(),
         }
 
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error("Failed to process AlertManager webhook: %s", e, exc_info=True)
         raise HTTPException(

--- a/autobot-backend/api/chat_embed_test.py
+++ b/autobot-backend/api/chat_embed_test.py
@@ -17,20 +17,39 @@ from fastapi.testclient import TestClient
 
 @pytest.fixture
 def mock_redis():
-    """Mock Redis client for rate limiting tests."""
+    """Mock Redis client for rate limiting tests.
+
+    ``RateLimiter.acquire`` performs the check-and-record atomically in a Lua
+    script (Issue #9610), so ``eval`` — not ``zcount``/``pipeline`` — is the
+    call the endpoint's rate-limit decision hinges on. It returns 1 (allowed)
+    here; tests that exercise the limit set it to 0. ``zcount`` /
+    ``zrangebyscore`` still back ``get_retry_after_seconds``.
+    """
     mock = AsyncMock()
+    mock.eval = AsyncMock(return_value=1)
     mock.zcount = AsyncMock(return_value=0)
+    mock.zrangebyscore = AsyncMock(return_value=[])
     mock.zadd = AsyncMock(return_value=1)
     mock.zremrangebyscore = AsyncMock(return_value=0)
     mock.expire = AsyncMock(return_value=True)
-    mock.pipeline = MagicMock()
-    pipe_mock = AsyncMock()
-    pipe_mock.zadd = MagicMock(return_value=pipe_mock)
-    pipe_mock.zremrangebyscore = MagicMock(return_value=pipe_mock)
-    pipe_mock.expire = MagicMock(return_value=pipe_mock)
-    pipe_mock.execute = AsyncMock(return_value=[1, 0, True])
-    mock.pipeline.return_value = pipe_mock
     return mock
+
+
+@pytest.fixture(autouse=True)
+def restore_chat_embed_module():
+    """Reload api.chat_embed after every test in this module.
+
+    Several tests reload the module under a patched environment to pick up its
+    import-time origin/proxy allowlists. Without this teardown the reloaded
+    module — with origin enforcement still switched on — leaked into every
+    later test, which then got 403s from an endpoint they never configured.
+    """
+    yield
+    import importlib
+
+    import api.chat_embed
+
+    importlib.reload(api.chat_embed)
 
 
 @pytest.fixture
@@ -78,7 +97,9 @@ async def test_embed_message_rate_limit_allows_under_threshold(client, mock_redi
 @pytest.mark.asyncio
 async def test_embed_message_rate_limit_blocks_exceeded(client, mock_redis):
     """Rate limiter blocks requests when threshold exceeded."""
-    # Mock zcount to return count over limit (20 req/min for anonymous tier)
+    # Lua script reports "rate limited"; zcount/zrangebyscore feed Retry-After
+    # (25 requests recorded against the 20 req/min anonymous tier).
+    mock_redis.eval = AsyncMock(return_value=0)
     mock_redis.zcount = AsyncMock(return_value=25)
     mock_redis.zrangebyscore = AsyncMock(return_value=[("1000.0", 1000.0)])
 
@@ -97,6 +118,7 @@ async def test_embed_message_rate_limit_blocks_exceeded(client, mock_redis):
 @pytest.mark.asyncio
 async def test_embed_preflight_rate_limit(client, mock_redis):
     """Preflight requests are also rate limited."""
+    mock_redis.eval = AsyncMock(return_value=0)
     mock_redis.zcount = AsyncMock(return_value=25)
     mock_redis.zrangebyscore = AsyncMock(return_value=[("1000.0", 1000.0)])
 
@@ -197,10 +219,15 @@ async def test_origin_allowlist_allows_configured_origin(client, mock_redis):
 
 
 @pytest.mark.asyncio
-async def test_client_ip_extraction_from_x_forwarded_for(client, mock_redis):
-    """Client IP is correctly extracted from X-Forwarded-For header."""
+async def test_client_ip_extraction_ignores_untrusted_x_forwarded_for(client, mock_redis):
+    """No trusted proxies configured → the rate-limit key uses the peer IP.
+
+    Honouring X-Forwarded-For from an untrusted peer would let any caller
+    reset their own bucket by rotating the header, so the limiter must key on
+    the direct connection instead (GH#9117).
+    """
     with patch("autobot_shared.rate_limiter.get_async_redis_client", new=AsyncMock(return_value=mock_redis)):
-        # X-Forwarded-For can have multiple IPs, first one is client
+        # X-Forwarded-For can have multiple IPs; none of them may be trusted here
         response = client.post(
             "/api/chats/embed/message",
             json={"message": "Hello"},
@@ -208,8 +235,11 @@ async def test_client_ip_extraction_from_x_forwarded_for(client, mock_redis):
         )
 
     assert response.status_code == 200
-    # Verify the rate limiter was called with the first IP
-    mock_redis.pipeline.assert_called()
+    # The rate limiter ran, and keyed on the peer rather than the spoofable header
+    mock_redis.eval.assert_called()
+    rate_limit_key = mock_redis.eval.call_args.args[2]
+    assert rate_limit_key.startswith("autobot:rl:embed:")
+    assert "203.0.113.5" not in rate_limit_key
 
 
 @pytest.mark.asyncio

--- a/autobot-backend/api/ide_integration_test.py
+++ b/autobot-backend/api/ide_integration_test.py
@@ -57,11 +57,15 @@ def sample_context():
 
 
 @pytest.mark.anyio
-@patch("api.ide_integration.context_analyzer")
-@patch("api.ide_integration.redis_client")
-async def test_completion_caching(mock_redis, mock_analyzer, engine, sample_request, sample_context):
+@patch("api.ide_integration._get_context_analyzer")
+@patch("api.ide_integration._get_redis_client")
+async def test_completion_caching(mock_get_redis, mock_get_analyzer, engine, sample_request, sample_context):
     """Test completion result caching."""
-    # Setup mocks
+    # Setup mocks — the module reaches Redis and the analyzer through lazy
+    # singleton accessors, so the accessor is patched and its return value
+    # is the client the engine actually talks to.
+    mock_redis = mock_get_redis.return_value
+    mock_analyzer = mock_get_analyzer.return_value
     mock_redis.get.return_value = None
     mock_analyzer.analyze.return_value = sample_context
 
@@ -94,12 +98,17 @@ async def test_completion_caching(mock_redis, mock_analyzer, engine, sample_requ
 
 @pytest.mark.anyio
 @patch("api.ide_integration.HAS_ML", True)
-@patch("api.ide_integration.context_analyzer")
-@patch("api.ide_integration.redis_client")
-@patch("api.ide_integration.trainer")
-async def test_ml_completions(mock_trainer, mock_redis, mock_analyzer, engine, sample_request, sample_context):
+@patch("api.ide_integration._get_context_analyzer")
+@patch("api.ide_integration._get_redis_client")
+@patch("api.ide_integration._get_trainer")
+async def test_ml_completions(
+    mock_get_trainer, mock_get_redis, mock_get_analyzer, engine, sample_request, sample_context
+):
     """Test ML-based completions."""
     # Setup mocks
+    mock_trainer = mock_get_trainer.return_value
+    mock_redis = mock_get_redis.return_value
+    mock_analyzer = mock_get_analyzer.return_value
     mock_redis.get.return_value = None
     mock_analyzer.analyze.return_value = sample_context
 
@@ -121,11 +130,13 @@ async def test_ml_completions(mock_trainer, mock_redis, mock_analyzer, engine, s
 
 
 @pytest.mark.anyio
-@patch("api.ide_integration.context_analyzer")
-@patch("api.ide_integration.redis_client")
-async def test_pattern_completions(mock_redis, mock_analyzer, engine, sample_request, sample_context):
+@patch("api.ide_integration._get_context_analyzer")
+@patch("api.ide_integration._get_redis_client")
+async def test_pattern_completions(mock_get_redis, mock_get_analyzer, engine, sample_request, sample_context):
     """Test pattern-based completions."""
     # Setup mocks
+    mock_redis = mock_get_redis.return_value
+    mock_analyzer = mock_get_analyzer.return_value
     mock_redis.get.return_value = None
 
     # Context with logging import to trigger logging completions
@@ -178,11 +189,13 @@ def test_completion_ranking(engine):
 
 
 @pytest.mark.anyio
-@patch("api.ide_integration.context_analyzer")
-@patch("api.ide_integration.redis_client")
-async def test_completion_max_limit(mock_redis, mock_analyzer, engine, sample_context):
+@patch("api.ide_integration._get_context_analyzer")
+@patch("api.ide_integration._get_redis_client")
+async def test_completion_max_limit(mock_get_redis, mock_get_analyzer, engine, sample_context):
     """Test completion result limit."""
     # Setup mocks
+    mock_redis = mock_get_redis.return_value
+    mock_analyzer = mock_get_analyzer.return_value
     mock_redis.get.return_value = None
     mock_analyzer.analyze.return_value = sample_context
 
@@ -201,14 +214,19 @@ async def test_completion_max_limit(mock_redis, mock_analyzer, engine, sample_co
 
 
 @pytest.mark.anyio
-@patch("api.ide_integration.context_analyzer")
-@patch("api.ide_integration.redis_client")
-@patch("api.ide_integration.trainer")
-async def test_ml_timeout_fallback(mock_trainer, mock_redis, mock_analyzer, engine, sample_request, sample_context):
+@patch("api.ide_integration._get_context_analyzer")
+@patch("api.ide_integration._get_redis_client")
+@patch("api.ide_integration._get_trainer")
+async def test_ml_timeout_fallback(
+    mock_get_trainer, mock_get_redis, mock_get_analyzer, engine, sample_request, sample_context
+):
     """Test fallback to patterns when ML times out."""
     import time
 
     # Setup mocks
+    mock_trainer = mock_get_trainer.return_value
+    mock_redis = mock_get_redis.return_value
+    mock_analyzer = mock_get_analyzer.return_value
     mock_redis.get.return_value = None
     mock_analyzer.analyze.return_value = sample_context
 
@@ -252,11 +270,13 @@ def test_pattern_relevance_filtering(engine):
 
 
 @pytest.mark.anyio
-@patch("api.ide_integration.context_analyzer")
-@patch("api.ide_integration.redis_client")
-async def test_completion_performance(mock_redis, mock_analyzer, engine, sample_request, sample_context):
+@patch("api.ide_integration._get_context_analyzer")
+@patch("api.ide_integration._get_redis_client")
+async def test_completion_performance(mock_get_redis, mock_get_analyzer, engine, sample_request, sample_context):
     """Test completion response time."""
     # Setup mocks
+    mock_redis = mock_get_redis.return_value
+    mock_analyzer = mock_get_analyzer.return_value
     mock_redis.get.return_value = None
     mock_analyzer.analyze.return_value = sample_context
 

--- a/autobot-backend/api/infrastructure_integration_test.py
+++ b/autobot-backend/api/infrastructure_integration_test.py
@@ -4,17 +4,25 @@
 """
 Integration Test Suite for Infrastructure API
 Tests all endpoints, CRUD operations, and database performance features
+
+Every check here drives a *running* backend over HTTP (and, for the worker
+check, its on-disk log), so the whole module carries the ``integration``
+marker: the unit selection (``-m "not integration"``) must skip it rather
+than fail against a backend that is not up.
 """
 
 import sys
 from pathlib import Path
 
+import pytest
 import requests
 
 # Add project root to path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from constants.network_constants import ServiceURLs
+
+pytestmark = pytest.mark.integration
 
 BASE_URL = f"{ServiceURLs.BACKEND_API}/api/iac"
 
@@ -82,8 +90,14 @@ def test_create_host():
     return data["id"]
 
 
-def test_get_host_details(host_id):
-    """Test 6: Get Host Details (Relationship Loading)"""
+def check_host_details(host_id):
+    """Test 6: Get Host Details (Relationship Loading).
+
+    Takes the id produced by test_create_host, so it is a step of the main()
+    flow rather than a standalone test — collected as one, pytest read the
+    argument as a request for a "host_id" fixture that does not exist and
+    errored every run.
+    """
     response = requests.get(f"{BASE_URL}/hosts/{host_id}")  # nosec B113
     data = response.json()
     print("✅ Test 6: Get Host Details - PASSED")  # noqa: print
@@ -103,8 +117,8 @@ def test_list_hosts_after_create():
     return True
 
 
-def test_delete_host(host_id):
-    """Test 8: Delete Test Host"""
+def check_delete_host(host_id):
+    """Test 8: Delete Test Host (step of the main() flow — see check_host_details)."""
     response = requests.delete(f"{BASE_URL}/hosts/{host_id}")  # nosec B113
     print("✅ Test 8: Delete Host - PASSED")  # noqa: print
     print(f"   HTTP Status: {response.status_code}")  # noqa: print
@@ -159,11 +173,11 @@ def main():
         host_id = test_create_host()
         if host_id:
             print()  # noqa: print
-            test_get_host_details(host_id)
+            check_host_details(host_id)
             print()  # noqa: print
             test_list_hosts_after_create()
             print()  # noqa: print
-            test_delete_host(host_id)
+            check_delete_host(host_id)
             print()  # noqa: print
 
         # Worker status

--- a/autobot-backend/api/knowledge_api_integration_test.py
+++ b/autobot-backend/api/knowledge_api_integration_test.py
@@ -24,6 +24,21 @@ import pytest
 
 
 @pytest.fixture
+def backend_url():
+    """Base URL the HTTP client is bound to.
+
+    Every request in this module patches ``aiohttp.ClientSession.get``, so no
+    traffic leaves the process — the session still needs a syntactically valid
+    base URL though. It used to come from a conftest that only covers
+    autobot-infrastructure/, so under this tree the fixture simply did not
+    exist and every test in the file errored at setup.
+    """
+    from constants.network_constants import ServiceURLs
+
+    return ServiceURLs.BACKEND_LOCAL
+
+
+@pytest.fixture
 async def api_client(backend_url):
     """Create async HTTP client for API testing"""
     async with aiohttp.ClientSession(base_url=backend_url) as session:

--- a/autobot-backend/api/knowledge_search_scoped.py
+++ b/autobot-backend/api/knowledge_search_scoped.py
@@ -159,6 +159,12 @@ async def scoped_search(
             kb.ownership_manager,
         )
 
+    except HTTPException:
+        # Deliberate status codes (503 "knowledge base not available",
+        # 500 "search not available") must reach the caller unchanged —
+        # collapsing them into a generic 500 hid a retryable outage behind
+        # a fatal-looking error.
+        raise
     except Exception as e:
         logger.error("Error in scoped search: %s", e)
         raise HTTPException(status_code=500, detail="Internal server error")
@@ -258,6 +264,8 @@ async def scoped_rag_search(
             scoped_results=scoped_results,
         )
 
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error("Error in scoped RAG search: %s", e)
         raise HTTPException(status_code=500, detail="Internal server error")
@@ -311,6 +319,8 @@ async def get_accessible_scopes(request: Request, current_user: User = Depends(g
             "accessible_scopes": scopes,
         }
 
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error("Error getting accessible scopes: %s", e)
         raise HTTPException(status_code=500, detail="Internal server error")

--- a/autobot-backend/api/knowledge_search_scoped_test.py
+++ b/autobot-backend/api/knowledge_search_scoped_test.py
@@ -214,27 +214,42 @@ async def test_scoped_search_post_filter_removes_inaccessible():
 
 # ---------------------------------------------------------------------------
 # knowledge/search.py — ChromaDB where filter threading
+# The KB search implementation is the SearchMixin class; there has never been
+# a KnowledgeSearcher, which is what these two tests used to import.
+#
+# search() prefers the VectorSearchEngine and only reaches _query_chromadb on
+# the documented fallback, so the engine is stubbed out to raise — otherwise
+# these assertions depend on a live Redis/embedding stack being unreachable.
 # ---------------------------------------------------------------------------
+
+
+def _make_bare_searcher():
+    """Build a SearchMixin with just the attributes the basic path touches."""
+    from knowledge.search import SearchMixin
+
+    searcher = SearchMixin.__new__(SearchMixin)
+    searcher._tag_filter = None
+    searcher._keyword_searcher = None
+    searcher._hybrid_searcher = None
+    # Mock vector_store so ensure_initialized and _validate pass
+    searcher.vector_store = MagicMock()
+    return searcher
 
 
 @pytest.mark.asyncio
 async def test_search_passes_filters_to_query_chromadb():
-    """KnowledgeSearcher.search() threads filters= to _query_chromadb via where=."""
-    from knowledge.search import KnowledgeSearcher
-
-    searcher = KnowledgeSearcher.__new__(KnowledgeSearcher)
-    searcher._tag_filter = None
-    searcher._keyword_searcher = None
-    searcher._hybrid_searcher = None
-
-    # Mock vector_store so ensure_initialized and _validate pass
-    searcher.vector_store = MagicMock()
+    """SearchMixin.search() threads filters= to _query_chromadb via where=."""
+    searcher = _make_bare_searcher()
 
     where_filter = {"owner_id": "u1"}
     query_embedding = [0.1] * 768
     chromadb_result = {"documents": [[]], "metadatas": [[]], "distances": [[]]}
 
     with (
+        patch(
+            "knowledge.search.get_vector_search_engine",
+            new=AsyncMock(side_effect=RuntimeError("engine offline")),
+        ),
         patch.object(
             searcher,
             "ensure_initialized",
@@ -258,18 +273,16 @@ async def test_search_passes_filters_to_query_chromadb():
 @pytest.mark.asyncio
 async def test_search_no_filters_omits_where():
     """When filters=None, _query_chromadb is called without where."""
-    from knowledge.search import KnowledgeSearcher
-
-    searcher = KnowledgeSearcher.__new__(KnowledgeSearcher)
-    searcher._tag_filter = None
-    searcher._keyword_searcher = None
-    searcher._hybrid_searcher = None
-    searcher.vector_store = MagicMock()
+    searcher = _make_bare_searcher()
 
     query_embedding = [0.1] * 768
     chromadb_result = {"documents": [[]], "metadatas": [[]], "distances": [[]]}
 
     with (
+        patch(
+            "knowledge.search.get_vector_search_engine",
+            new=AsyncMock(side_effect=RuntimeError("engine offline")),
+        ),
         patch.object(searcher, "ensure_initialized"),
         patch.object(
             searcher,

--- a/autobot-backend/api/redis_mcp/rbac.py
+++ b/autobot-backend/api/redis_mcp/rbac.py
@@ -125,10 +125,42 @@ _ACCESS_TO_TAG: dict[ToolAccess, str] = {
 }
 
 
+# Privilege ordering of the capability tags. A bundle admits every tag at or
+# below its own ceiling, so the ranking is what makes "voice_safe ⊆
+# voice_extended ⊆ voice_admin" hold.
+_TAG_PRIVILEGE_RANK: dict[str, int] = {
+    "read": 0,
+    "scoped_write": 1,
+    "full": 2,
+    "approval": 2,
+}
+
+
 def get_tool_capability_tag(tool_name: str, is_admin: bool) -> str:
     """Return the capability tag for a tool given the user's role."""
     access = get_tool_access(tool_name, is_admin)
     return _ACCESS_TO_TAG.get(access, "blocked")
+
+
+def get_bundle_capability_tag(tool_name: str) -> str:
+    """Return the role-independent capability tag used for bundle membership.
+
+    Bundle membership must never shrink when a caller is promoted to admin —
+    a promotion may only add tools. The access matrix deliberately grants
+    admins a *higher* level on write tools (``redis_set`` is SCOPED_WRITE for
+    a user but FULL_WRITE for an admin), so keying membership off the per-role
+    tag dropped every write tool out of ``voice_extended`` for admins while a
+    plain user kept them. Membership therefore uses the least-privileged
+    non-blocked tag across roles; whether the caller may use the tool at all
+    stays with the per-role BLOCKED gate in ``filter_tools_for_bundle``.
+    """
+    entry = TOOL_ACCESS_MATRIX.get(tool_name)
+    if entry is None:
+        return "blocked"
+    tags = [_ACCESS_TO_TAG[access] for access in entry if access is not ToolAccess.BLOCKED]
+    if not tags:
+        return "blocked"
+    return min(tags, key=lambda tag: _TAG_PRIVILEGE_RANK[tag])
 
 
 def filter_tools_for_bundle(
@@ -154,8 +186,9 @@ def filter_tools_for_bundle(
     for tool in tools:
         if tool in denied:
             continue
-        tag = get_tool_capability_tag(tool, is_admin)
-        if tag in allowed_tags:
+        if get_tool_access(tool, is_admin) is ToolAccess.BLOCKED:
+            continue
+        if get_bundle_capability_tag(tool) in allowed_tags:
             result.append(tool)
     logger.debug(
         "voice_bundle bundle=%s is_admin=%s tools_in=%d tools_out=%d",
@@ -189,12 +222,17 @@ async def resolve_bundle_for_user(user_id: str, role: str = "user") -> tuple[str
 
     Resolution values: 'user_override' | 'role_default' | 'global_env'
     """
-    # 1. Check per-user DB override
+    # 1. Check per-user DB override.
+    # This used to import `database.session`, a module that does not exist —
+    # the resulting ImportError was swallowed by the except below, so the
+    # per-user override (GH#8605) never took effect and every caller silently
+    # fell through to the role default.
     try:
-        from database.session import get_async_session  # noqa: PLC0415
         from sqlalchemy import text  # noqa: PLC0415
 
-        async with get_async_session() as session:
+        from user_management.database import db_session_context  # noqa: PLC0415
+
+        async with db_session_context() as session:
             row = await session.execute(
                 text("SELECT bundle_name FROM user_voice_bundle WHERE user_id = :uid"),
                 {"uid": str(user_id)},

--- a/autobot-backend/api/settings.py
+++ b/autobot-backend/api/settings.py
@@ -732,13 +732,17 @@ _SYNC_MAX_PAYLOAD_BYTES: int = 256 * 1024  # 256 KiB
 def _exceeds_depth(obj: Any, current_depth: int = 0) -> bool:
     """Return True when *obj* exceeds ``_SYNC_MAX_DEPTH`` nesting levels.
 
-    Only recurses into dict values; non-dict values always return False.
+    Only dict nesting counts towards the depth: the scalar stored at the
+    bottom of a chain of dicts is a value, not another level.  Testing the
+    limit before the ``isinstance`` check counted that leaf as one extra
+    level, so a payload nested exactly ``_SYNC_MAX_DEPTH`` deep — the depth
+    the 400 response advertises as permitted — was rejected (Issue #3881).
     """
+    if not isinstance(obj, dict):
+        return False
     if current_depth > _SYNC_MAX_DEPTH:
         return True
-    if isinstance(obj, dict):
-        return any(_exceeds_depth(v, current_depth + 1) for v in obj.values())
-    return False
+    return any(_exceeds_depth(v, current_depth + 1) for v in obj.values())
 
 
 def _compute_flat_diff(before: dict, after: dict, prefix: str = "") -> dict:

--- a/autobot-backend/api/settings_hardware_priority_test.py
+++ b/autobot-backend/api/settings_hardware_priority_test.py
@@ -77,9 +77,22 @@ class TestHardwarePriorityEndpoint:
     def test_patch_returns_200_with_valid_payload(self):
         app = _make_app()
 
+        from hardware_acceleration import AccelerationType
+
         fake_config = {"hardware": {"acceleration": {"priority_order": ["npu", "gpu", "cpu"]}}}
         mock_hw = MagicMock()
         mock_hw.update_priorities = MagicMock()
+        # The endpoint echoes back the order the manager actually applied, read
+        # from current_config["priority_order"] (AccelerationType members, in
+        # availability order). A bare MagicMock iterates as empty, which is what
+        # made this assertion see [] instead of the requested ordering.
+        mock_hw.current_config = {
+            "priority_order": [
+                AccelerationType.GPU,
+                AccelerationType.NPU,
+                AccelerationType.CPU,
+            ]
+        }
         mock_revision = MagicMock()
         mock_revision.create_revision = AsyncMock()
 

--- a/autobot-backend/api/user_management/users.py
+++ b/autobot-backend/api/user_management/users.py
@@ -387,14 +387,18 @@ async def change_password(
     """Change user password with rate limiting and session invalidation."""
     rate_limiter = PasswordChangeRateLimiter()
 
-    # Check rate limit before attempting password change
+    # Check rate limit before attempting password change.
+    # The limiter's message carries the caller-facing retry window ("Too many
+    # attempts. Try again in N minutes.") and discloses nothing sensitive, so
+    # it is returned verbatim — the previous "Internal server error" detail
+    # contradicted the 429 status and stripped the retry guidance.
     try:
         await rate_limiter.check_rate_limit(user_id)
-    except RateLimitExceeded:
+    except RateLimitExceeded as exc:
         raise HTTPException(
             status_code=status.HTTP_429_TOO_MANY_REQUESTS,
-            detail="Internal server error",
-        )
+            detail=str(exc),
+        ) from exc
 
     try:
         # Extract current token to preserve this session

--- a/autobot-backend/api/voice_bundle_admin_test.py
+++ b/autobot-backend/api/voice_bundle_admin_test.py
@@ -2,7 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
-"""Tests for per-user voice bundle assignment (GH#8605)."""
+"""Tests for per-user voice bundle assignment (GH#8605).
+
+resolve_bundle_for_user opens its own session through the canonical
+``user_management.database.db_session_context`` async context manager, so
+that is the patch target here — the old ``database.session`` target named a
+module that has never existed in this tree.
+"""
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -25,7 +31,7 @@ async def test_resolve_bundle_user_override():
     mock_session.__aexit__ = AsyncMock(return_value=False)
     mock_session.execute = AsyncMock(return_value=mock_row)
 
-    with patch("database.session.get_async_session", return_value=mock_session):
+    with patch("user_management.database.db_session_context", return_value=mock_session):
         bundle, resolution = await resolve_bundle_for_user("user-123", role="user")
 
     assert bundle == "voice_extended"
@@ -44,7 +50,7 @@ async def test_resolve_bundle_role_default_admin():
     mock_session.__aexit__ = AsyncMock(return_value=False)
     mock_session.execute = AsyncMock(return_value=mock_row)
 
-    with patch("database.session.get_async_session", return_value=mock_session):
+    with patch("user_management.database.db_session_context", return_value=mock_session):
         bundle, resolution = await resolve_bundle_for_user("admin-1", role="admin")
 
     assert bundle == "voice_admin"
@@ -66,7 +72,7 @@ async def test_resolve_bundle_global_env_fallback():
     import os
 
     with (
-        patch("database.session.get_async_session", return_value=mock_session),
+        patch("user_management.database.db_session_context", return_value=mock_session),
         patch.dict(os.environ, {"AUTOBOT_VOICE_TOOLSETS": "voice_extended"}),
     ):
         bundle, resolution = await resolve_bundle_for_user("user-99", role="unknown_role")
@@ -80,7 +86,7 @@ async def test_resolve_bundle_db_failure_falls_through():
     """DB failure should not crash — falls through to role default."""
     from api.redis_mcp.rbac import resolve_bundle_for_user
 
-    with patch("database.session.get_async_session", side_effect=Exception("DB down")):
+    with patch("user_management.database.db_session_context", side_effect=Exception("DB down")):
         bundle, resolution = await resolve_bundle_for_user("user-42", role="user")
 
     assert bundle == "voice_safe"

--- a/autobot-backend/code_analysis/src/anti_pattern_detector.py
+++ b/autobot-backend/code_analysis/src/anti_pattern_detector.py
@@ -592,7 +592,7 @@ class AntiPatternDetector:
 
         for pattern in patterns:
             for file_path in root.glob(pattern):
-                if file_path.is_file() and not self._should_skip(file_path, exclude_set):
+                if file_path.is_file() and not self._should_skip(file_path, exclude_set, root):
                     try:
                         module_info = await self._parse_file(str(file_path))
                         if module_info:
@@ -610,12 +610,34 @@ class AntiPatternDetector:
                 if imported in self.modules:
                     self.modules[imported].is_imported_by.add(module.name)
 
-    def _should_skip(self, file_path: Path, exclude_patterns: "frozenset[str] | List[str]") -> bool:
+    @staticmethod
+    def _path_for_exclusion(file_path: Path, root: Path | None) -> str:
+        """Render *file_path* relative to *root* for exclusion matching.
+
+        Exclusion patterns ("tests/", "venv", "test_", ...) describe locations
+        *inside* the analyzed tree. Matching them against the absolute path
+        made the scan depend on where that tree happens to live: a checkout
+        below a directory named e.g. ``venv`` or ``test_runs`` matched every
+        pattern and silently excluded the whole codebase.
+        """
+        if root is None:
+            return str(file_path)
+        try:
+            return str(file_path.relative_to(root))
+        except ValueError:
+            return str(file_path)
+
+    def _should_skip(
+        self,
+        file_path: Path,
+        exclude_patterns: "frozenset[str] | List[str]",
+        root: Path | None = None,
+    ) -> bool:
         """Check if file should be skipped.
 
         Issue #510: Accepts frozenset for O(1) membership check.
         """
-        path_str = str(file_path)
+        path_str = self._path_for_exclusion(file_path, root)
         return any(pattern in path_str for pattern in exclude_patterns)
 
     async def _parse_file(self, file_path: str) -> ModuleInfo | None:
@@ -1860,8 +1882,7 @@ class AntiPatternDetector:
         # Collect all Python source files (non-test) under root_path.
         py_files: List[Path] = []
         for f in root.rglob("*.py"):
-            path_str = str(f)
-            if any(pat in path_str for pat in _DEFAULT_EXCLUDE_PATTERNS):
+            if self._should_skip(f, _DEFAULT_EXCLUDE_PATTERNS, root):
                 continue
             py_files.append(f)
 

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -28566,8 +28566,8 @@ export interface paths {
          *     Phase 3 (Issue #346): AlertManager → WebSocket integration
          *     Replaces MonitoringAlertsManager's WebSocket notification channel
          *
-         *     Security (GH#9657): Requires X-AlertManager-Secret header authentication.
-         *     Fails closed when ALERTMANAGER_WEBHOOK_SECRET is not configured.
+         *     Security (GH#9657): Requires X-AlertManager-Secret header authentication,
+         *     enforced by the ``verify_alertmanager_secret`` route dependency.
          */
         post: operations["receive_alertmanager_webhook_api_webhook_alertmanager_post"];
         delete?: never;

--- a/pytest.ini
+++ b/pytest.ini
@@ -12,6 +12,7 @@ pythonpath = . autobot-backend autobot_shared
 # Test markers
 markers =
     integration: Integration tests that may require external services
+    requires_backend: Tests written against a running backend API (autobot-infrastructure harness)
     slow: Tests that take a long time to run
     distributed: Tests for distributed multi-VM scenarios
     performance: Performance and load tests


### PR DESCRIPTION
## Thinking Path

`autobot-backend/api` was measured first, not assumed: **33 failed + 15 collection errors, 1266 passed** on top of `origin/Dev_new_gui`.

Every failure was then diagnosed to a root cause before anything was touched, and the question asked each time was *which side is wrong*. Seven of the twelve clusters turned out to be production defects the tests had been reporting correctly — a depth guard that rejected the depth it advertised, a 429 that answered `Internal server error`, three endpoints that collapsed their own deliberate status codes into 500, a per-user override wired to a module that does not exist, a bundle filter that removed tools when a user was promoted to admin, and a code scanner that excluded whole trees depending on where they were checked out. Those were fixed in the code. The rest were tests still written against interfaces the code had moved on from, and those were re-pointed with the reason recorded in each case.

No test was skipped, xfailed, or loosened to make it pass. The one module that gained a marker (`infrastructure_integration_test.py`) drives a live backend over HTTP in every single check — `integration` is its correct classification, not an escape hatch, and it was never green in a unit run.

## What Changed

### Production bugs (test was right, code was wrong)

| File | Defect | Impact |
|---|---|---|
| `api/settings.py` | `_exceeds_depth` tested the limit *before* the `isinstance` check, so the scalar at the bottom of a dict chain counted as one more level | Config-sync payloads nested exactly to the advertised maximum were rejected with 400 by the guard that claims to permit that depth |
| `api/user_management/users.py` | The password-change 429 hardcoded `detail="Internal server error"` | Status and body contradicted each other, and the limiter's retry window ("try again in N minutes") never reached the caller |
| `api/knowledge_search_scoped.py` | Blanket `except Exception` in all three endpoints swallowed the `HTTPException`s raised inside them | A knowledge-base outage surfaced as a fatal 500 instead of the retryable 503 the code raises |
| `api/alertmanager_webhook.py` | Same blanket `except` turned the fail-closed 503, the 401 and the 403 into 500s | Callers could not tell "not configured" from "unauthorized" from a genuine server fault |
| `api/alertmanager_webhook.py` | Auth ran *inside* the handler, i.e. after FastAPI validated the body | An unauthenticated caller could probe the payload schema, and a request arriving while the secret was unset got 422 rather than failing closed. Auth is now a route dependency, and the secret comparison is constant-time |
| `api/redis_mcp/rbac.py` | `resolve_bundle_for_user` imported `database.session` — a module that does not exist in this tree — and the `ImportError` was swallowed by the `except` below it | The per-user voice bundle override has **never once taken effect**; every caller silently fell through to the role default. Now uses the canonical `db_session_context` |
| `api/redis_mcp/rbac.py` | Bundle membership keyed off the *per-role* capability tag, while the access matrix deliberately grants admins a *higher* level on write tools | Promoting a user to admin **removed** every write tool from their `voice_extended` bundle. Membership now uses the least-privileged non-blocked tag across roles, with the per-role BLOCKED gate applied separately, so a promotion can only ever add tools |
| `code_analysis/src/anti_pattern_detector.py` | Exclusion patterns matched against the **absolute** path instead of the path relative to the analysis root | Any tree living below a directory whose name contains a pattern (`venv`, `tests/`, `test_`, …) had every file excluded and the scan returned nothing — which is exactly why the unwired-tracker detector reported zero findings |

> **Shared module touched:** `code_analysis/src/anti_pattern_detector.py` is outside `api/`. It is the module `api/codebase_analytics/unwired_tracker_test.py` exercises, and the bug is the direct cause of that failure. Its own three test modules were re-run and stay green.

### Test bugs (test encoded a wrong assumption)

| File | Wrong assumption | Correction |
|---|---|---|
| `chat_embed_test.py` | Mocked `zcount`/`pipeline`; `RateLimiter.acquire` has been a single atomic Lua `eval` since the concurrency fix, so the limiter never saw the mocked counts and never blocked | Mock `eval`; assert the limiter keyed on the peer rather than the spoofable `X-Forwarded-For` |
| `chat_embed_test.py` | The origin-allowlist tests `importlib.reload` the module and never undo it, leaving enforcement on for three later tests | Teardown fixture reloads the module after every test |
| `ide_integration_test.py` | Patched module-level `redis_client` / `context_analyzer` / `trainer`, replaced by lazy singleton accessors | Patch `_get_redis_client` / `_get_context_analyzer` / `_get_trainer` |
| `knowledge_search_scoped_test.py` | Imported `KnowledgeSearcher`, a class that has never existed | The class is `SearchMixin`; the ChromaDB assertions now stub the vector search engine so they exercise the documented fallback instead of depending on a live stack being unreachable |
| `voice_bundle_admin_test.py` | Patched the same nonexistent `database.session` | Patch the canonical `db_session_context` |
| `settings_hardware_priority_test.py` | Mocked manager had no `current_config`; the endpoint echoes the order it *applied*, and a bare `MagicMock` iterates as empty | Give the mock a realistic `current_config` |
| `knowledge_api_integration_test.py` | Needed a `backend_url` fixture that only exists in the `autobot-infrastructure` conftest, so all 13 tests errored at setup | Fixture defined locally from `ServiceURLs`; every request in the file is already patched, so nothing leaves the process |
| `infrastructure_integration_test.py` | A live-backend HTTP script collected as unit tests, two of whose steps take the id from the create step and were read as a missing `host_id` fixture | Module marked `integration`; the two flow steps are helpers of `main()`, which still calls them |
| `pytest.ini` | `requires_backend` was used but never registered, against `--strict-markers` | Registered |

## Verification

Baseline on `origin/Dev_new_gui`, exact CI selection:

```
$ PYTHONPATH="$PWD/autobot-backend:$PWD" python3 -m pytest autobot-backend/api -q \
    -m "not integration and not slow and not distributed and not performance"
33 failed, 1266 passed, 2126 skipped, 11 deselected, 15 errors in 481.58s
```

After:

```
1305 passed, 2126 skipped, 18 deselected, 93 warnings in 551.03s (0:09:11)
```

Zero failures, zero errors. The count reconciles: 1266 + 33 + 15 = 1314; 1305 passed + 7 newly deselected (the live-backend module) + 2 collected steps turned into `main()` helpers = 1314.

Regression check on everything outside `api/` that touches the changed production modules:

```
$ python3 -m pytest autobot-backend/tests/api/test_voice_bundle_user.py \
    autobot-backend/code_analysis/src/anti_pattern_detector_runtime_risk_test.py \
    autobot-backend/code_analysis/src/anti_pattern_detector_lsp_test.py \
    autobot-backend/code_analysis/src/anti_pattern_detector_consolidation_test.py \
    autobot-backend/tests/test_concurrency_global_locks.py
78 passed in 122.61s
```

Lint, all 13 changed Python files, CI's exact flags:

```
$ python3 -m isort --settings-path=. --line-length=120 <files>   # clean
$ python3 -m black --line-length=120 <files>                     # 13 files left unchanged
$ python3 -m flake8 --config=.flake8 <files>                     # exit 0
$ python3 -m bandit -c .bandit <files>                           # No issues identified
```

### Discovered, not fixed here

`api/voice_bundle_admin.py` and `api/voice_bundle_user.py` do `async with get_async_session() as session` at four sites. `get_async_session` is a bare async generator (the FastAPI dependency), not an async context manager — `async with` on it raises `AttributeError: __aenter__`, verified directly. Both call sites wrap it in `try/except`, so the GET and PUT bundle-assignment endpoints answer `500 Database error` unconditionally. The same class of defect as the `rbac.py` fix in this PR, but its tests live under `tests/` which another change is editing concurrently, so it gets its own issue rather than a collision here.

## Model Used

Claude Opus 4.5

Closes #13162

> **This is a PARTIAL delivery.** #13162 covers the whole Python suite; this PR only makes `autobot-backend/api/` green. The issue stays **open** until the remaining directories are red-free.
