### PR TITLE
fix(services): repair the 54 red results in autobot-backend/services (#13162)

### DIFF
--- a/autobot-backend/services/audit/audit_log_test.py
+++ b/autobot-backend/services/audit/audit_log_test.py
@@ -67,6 +67,10 @@ class TestAuditAction:
             "USER_DELETE",
             "CONFIG_CHANGE",
             "ADMIN_ACTION",
+            "RUN_JWT_MINT",  # run-scoped JWT lifecycle, added after the test was written
+            "RUN_JWT_REVOKE",
+            "RUN_JWT_REFRESH",
+            "DEVICE_JWT_MINT",  # GH#9493
         }
         names = {a.name for a in AuditAction}
         assert required == names

--- a/autobot-backend/services/feedback_tracker_test.py
+++ b/autobot-backend/services/feedback_tracker_test.py
@@ -61,7 +61,7 @@ def test_feedback_was_accepted_property() -> None:
 
 
 @patch("services.feedback_tracker.get_redis_client")
-@patch("services.feedback_tracker.create_engine")
+@patch("services.feedback_tracker.get_async_engine")
 def test_feedback_tracker_initialization(mock_engine, mock_redis) -> None:
     """Test FeedbackTracker initialization."""
     from services.feedback_tracker import FeedbackTracker
@@ -74,15 +74,37 @@ def test_feedback_tracker_initialization(mock_engine, mock_redis) -> None:
 
 
 @patch("services.feedback_tracker.get_redis_client")
-@patch("services.feedback_tracker.create_engine")
+@patch("services.feedback_tracker.get_async_engine")
 def test_record_feedback_creates_record(mock_engine, mock_redis) -> None:
     """Test feedback recording creates database record."""
     from services.feedback_tracker import FeedbackTracker
 
-    # Mock database session
+    # Mock database session. record_feedback opens it with `with
+    # self.SessionLocal() as db:`, so the mock must yield itself from
+    # __enter__ — otherwise `db` is a fresh child mock and the add/commit
+    # assertions below watch an object the code never touched.
     mock_session = MagicMock()
-    mock_engine.return_value.begin.return_value.__enter__.return_value = mock_session
-    mock_redis.return_value = MagicMock()
+    mock_session.__enter__.return_value = mock_session
+
+    # No stored retrain marker, so _check_retrain_threshold takes the
+    # "never retrained" branch instead of parsing a MagicMock as an ISO string.
+    redis_client = MagicMock()
+    redis_client.get.return_value = None
+    mock_redis.return_value = redis_client
+    mock_session.query.return_value.filter.return_value.scalar.return_value = 0
+
+    # pattern_id=1 below sends record_feedback through
+    # _update_pattern_statistics, which does integer arithmetic on the looked-up
+    # pattern — give it a real row rather than a child mock.
+    pattern = CodePattern(
+        id=1,
+        pattern_type="function",
+        language="python",
+        signature="def hello():",
+        times_suggested=4,
+        times_accepted=2,
+    )
+    mock_session.query.return_value.filter.return_value.first.return_value = pattern
 
     tracker = FeedbackTracker()
     tracker.SessionLocal = MagicMock(return_value=mock_session)
@@ -162,12 +184,16 @@ def test_acceptance_rate_after_rejection() -> None:
 
 
 @patch("services.feedback_tracker.get_redis_client")
-@patch("services.feedback_tracker.create_engine")
+@patch("services.feedback_tracker.get_async_engine")
 def test_get_acceptance_metrics(mock_engine, mock_redis) -> None:
     """Test metrics calculation."""
     from services.feedback_tracker import FeedbackTracker
 
+    # get_acceptance_metrics opens the session with `with self.SessionLocal()
+    # as db:` — the mock must yield itself so `db.query(...)` is the mock
+    # chain wired below.
     mock_session = MagicMock()
+    mock_session.__enter__.return_value = mock_session
     mock_redis.return_value = MagicMock()
 
     # Mock query results

--- a/autobot-backend/services/knowledge/test_analyzer_service.py
+++ b/autobot-backend/services/knowledge/test_analyzer_service.py
@@ -48,6 +48,20 @@ _ssot.config.port.chromadb = 8100  # type: ignore[attr-defined]
 # utils / chromadb_client stubs
 _utils_stub = _make_stub("utils")
 _chromadb_stub = _make_stub("utils.chromadb_client")
+# AnalyzerService reaches ChromaDB through knowledge.backends'
+# get_async_default_client(), which lazily imports get_async_chromadb_client
+# from utils.async_chromadb_client (#5316) — not the sync utils.chromadb_client.
+# _make_stub() uses sys.modules.setdefault but returns its own fresh object, so
+# when a sibling test module registered this name first the returned stub is a
+# dangling copy that production code never sees. Read the registered module back.
+_make_stub("utils.async_chromadb_client")
+_async_chromadb_stub = sys.modules["utils.async_chromadb_client"]
+# Injecting a submodule straight into sys.modules does not bind it on the
+# parent package, so mock.patch("utils.async_chromadb_client....") — used by
+# services/rag_service_kb_synthesis_test.py — cannot resolve it. Bind it, and
+# seed the symbol production imports so patch() finds an existing attribute.
+_async_chromadb_stub.get_async_chromadb_client = AsyncMock()  # type: ignore[attr-defined]
+sys.modules["utils"].async_chromadb_client = _async_chromadb_stub  # type: ignore[attr-defined]
 
 # ---------------------------------------------------------------------------
 # Load analyzer_service via importlib to bypass package __init__ imports
@@ -96,7 +110,7 @@ def _make_chromadb_client(collection: AsyncMock) -> AsyncMock:
 def _patch_chromadb(analyzer: AnalyzerService, collection: AsyncMock) -> None:
     """Inject a mock ChromaDB client into analyzer._get_collection path."""
     client = _make_chromadb_client(collection)
-    _chromadb_stub.get_async_chromadb_client = AsyncMock(return_value=client)
+    _async_chromadb_stub.get_async_chromadb_client = AsyncMock(return_value=client)
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/services/knowledge/test_contradiction_detector.py
+++ b/autobot-backend/services/knowledge/test_contradiction_detector.py
@@ -207,12 +207,12 @@ class TestContradictionDetectorScan:
     @pytest.fixture()
     def mock_llm(self):
         llm = AsyncMock()
-        llm.chat_completion = AsyncMock()
+        llm.chat = AsyncMock()
         return llm
 
     @pytest.mark.asyncio
     async def test_scan_finds_contradictions(self, mock_llm) -> None:
-        mock_llm.chat_completion.return_value = _llm_response(_contradiction_json(pairs=1, gaps=["gap1"]))
+        mock_llm.chat.return_value = _llm_response(_contradiction_json(pairs=1, gaps=["gap1"]))
         detector = ContradictionDetector(llm_interface=mock_llm)
         # Both chunks share the rare keyword "redis" so they land in the same group
         chunks = [
@@ -230,7 +230,7 @@ class TestContradictionDetectorScan:
         report = await detector.scan([])
         assert report.contradictions == []
         assert report.gaps == []
-        mock_llm.chat_completion.assert_not_called()
+        mock_llm.chat.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_scan_single_chunk_skips_group(self, mock_llm) -> None:
@@ -240,11 +240,11 @@ class TestContradictionDetectorScan:
         chunks = [{"text": "zzzmultiworduniquexyz topic content"}]
         report = await detector.scan(chunks)
         assert report.contradictions == []
-        mock_llm.chat_completion.assert_not_called()
+        mock_llm.chat.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_scan_llm_error_skips_group(self, mock_llm) -> None:
-        mock_llm.chat_completion.return_value = _llm_response("", error="timeout")
+        mock_llm.chat.return_value = _llm_response("", error="timeout")
         detector = ContradictionDetector(llm_interface=mock_llm)
         chunks = [
             {"text": "database stores data efficiently"},
@@ -255,7 +255,7 @@ class TestContradictionDetectorScan:
 
     @pytest.mark.asyncio
     async def test_scan_llm_returns_none_skips_group(self, mock_llm) -> None:
-        mock_llm.chat_completion.return_value = None
+        mock_llm.chat.return_value = None
         detector = ContradictionDetector(llm_interface=mock_llm)
         chunks = [
             {"text": "redis stores data in memory"},
@@ -267,9 +267,7 @@ class TestContradictionDetectorScan:
     @pytest.mark.asyncio
     async def test_scan_deduplicated_gaps(self, mock_llm) -> None:
         """Gaps returned from multiple groups should be deduplicated."""
-        mock_llm.chat_completion.return_value = _llm_response(
-            json.dumps({"contradictions": [], "gaps": ["missing auth docs"]})
-        )
+        mock_llm.chat.return_value = _llm_response(json.dumps({"contradictions": [], "gaps": ["missing auth docs"]}))
         detector = ContradictionDetector(llm_interface=mock_llm)
         # Create two groups of similar-but-distinct keywords
         chunks = [
@@ -284,7 +282,7 @@ class TestContradictionDetectorScan:
 
     @pytest.mark.asyncio
     async def test_scan_checked_at_is_utc(self, mock_llm) -> None:
-        mock_llm.chat_completion.return_value = _llm_response(json.dumps({"contradictions": [], "gaps": []}))
+        mock_llm.chat.return_value = _llm_response(json.dumps({"contradictions": [], "gaps": []}))
         detector = ContradictionDetector(llm_interface=mock_llm)
         report = await detector.scan([])
         assert report.checked_at.tzinfo is not None

--- a/autobot-backend/services/knowledge/test_doc_indexer.py
+++ b/autobot-backend/services/knowledge/test_doc_indexer.py
@@ -61,13 +61,22 @@ _path_constants.PATH = _FakePATH()  # type: ignore[attr-defined]
 # Load doc_indexer bypassing the services package __init__ (which needs the
 # full stack).  Using spec_from_file_location keeps the module name canonical
 # so patch() paths work correctly.
+# Reuse the module object if a sibling test file
+# (test_doc_indexer_dim_mismatch.py) already loaded it — see the matching note
+# there. Re-loading would swap sys.modules out from under whichever file
+# imported first, leaving that file's patch() targets pointing at a different
+# module object than its imported helpers close over.
 _BACKEND_ROOT = Path(__file__).parent.parent.parent  # autobot-backend/
-_DOC_INDEXER_PATH = Path(__file__).parent / "doc_indexer.py"
-_spec = importlib.util.spec_from_file_location("services.knowledge.doc_indexer", str(_DOC_INDEXER_PATH))
-assert _spec and _spec.loader, "Could not load doc_indexer spec"
-_doc_indexer_mod = importlib.util.module_from_spec(_spec)
-sys.modules["services.knowledge.doc_indexer"] = _doc_indexer_mod
-_spec.loader.exec_module(_doc_indexer_mod)  # type: ignore[union-attr]
+_existing_doc_indexer = sys.modules.get("services.knowledge.doc_indexer")
+if _existing_doc_indexer is not None and _existing_doc_indexer.__dict__.get("__file__"):
+    _doc_indexer_mod = _existing_doc_indexer
+else:
+    _DOC_INDEXER_PATH = Path(__file__).parent / "doc_indexer.py"
+    _spec = importlib.util.spec_from_file_location("services.knowledge.doc_indexer", str(_DOC_INDEXER_PATH))
+    assert _spec and _spec.loader, "Could not load doc_indexer spec"
+    _doc_indexer_mod = importlib.util.module_from_spec(_spec)
+    sys.modules["services.knowledge.doc_indexer"] = _doc_indexer_mod
+    _spec.loader.exec_module(_doc_indexer_mod)  # type: ignore[union-attr]
 
 # Ensure the package stub exposes doc_indexer as an attribute so patch()
 # can resolve "services.knowledge.doc_indexer.<name>" correctly.

--- a/autobot-backend/services/knowledge/test_doc_indexer_dim_mismatch.py
+++ b/autobot-backend/services/knowledge/test_doc_indexer_dim_mismatch.py
@@ -56,12 +56,23 @@ class _FakePATH:
 
 _path_constants.PATH = _FakePATH()  # type: ignore[attr-defined]
 
-_DOC_INDEXER_PATH = Path(__file__).parent / "doc_indexer.py"
-_spec = importlib.util.spec_from_file_location("services.knowledge.doc_indexer", str(_DOC_INDEXER_PATH))
-assert _spec and _spec.loader, "Could not load doc_indexer spec"
-_doc_indexer_mod = importlib.util.module_from_spec(_spec)
-sys.modules["services.knowledge.doc_indexer"] = _doc_indexer_mod
-_spec.loader.exec_module(_doc_indexer_mod)  # type: ignore[union-attr]
+# Reuse the module object if a sibling test file (test_doc_indexer.py) already
+# loaded it. pytest imports every test module during collection, so an
+# unconditional re-load here would replace
+# sys.modules["services.knowledge.doc_indexer"] behind that file's back: its
+# already-imported helpers would keep the OLD module's globals while its
+# patch("services.knowledge.doc_indexer.X") calls resolved against the NEW
+# one, making those patches inert.
+_existing_doc_indexer = sys.modules.get("services.knowledge.doc_indexer")
+if _existing_doc_indexer is not None and _existing_doc_indexer.__dict__.get("__file__"):
+    _doc_indexer_mod = _existing_doc_indexer
+else:
+    _DOC_INDEXER_PATH = Path(__file__).parent / "doc_indexer.py"
+    _spec = importlib.util.spec_from_file_location("services.knowledge.doc_indexer", str(_DOC_INDEXER_PATH))
+    assert _spec and _spec.loader, "Could not load doc_indexer spec"
+    _doc_indexer_mod = importlib.util.module_from_spec(_spec)
+    sys.modules["services.knowledge.doc_indexer"] = _doc_indexer_mod
+    _spec.loader.exec_module(_doc_indexer_mod)  # type: ignore[union-attr]
 
 if "services.knowledge" in sys.modules:
     sys.modules["services.knowledge"].doc_indexer = _doc_indexer_mod  # type: ignore[attr-defined]

--- a/autobot-backend/services/knowledge/test_kb_synthesizer.py
+++ b/autobot-backend/services/knowledge/test_kb_synthesizer.py
@@ -48,7 +48,17 @@ _ssot.config.port.chromadb = 8100  # type: ignore[attr-defined]
 # utils / chromadb_client stubs (loaded lazily inside methods — stub at import time)
 _utils_stub = _make_stub("utils")
 _chromadb_stub = _make_stub("utils.chromadb_client")
-_async_chromadb_stub = _make_stub("utils.async_chromadb_client")
+# _make_stub() uses sys.modules.setdefault but returns its own fresh object, so
+# when a sibling test module registered this name first the returned stub is a
+# dangling copy that production code never sees. Read the registered module back.
+_make_stub("utils.async_chromadb_client")
+_async_chromadb_stub = sys.modules["utils.async_chromadb_client"]
+# Injecting a submodule straight into sys.modules does not bind it on the
+# parent package, so mock.patch("utils.async_chromadb_client....") — used by
+# services/rag_service_kb_synthesis_test.py — cannot resolve it. Bind it, and
+# seed the symbol production imports so patch() finds an existing attribute.
+_async_chromadb_stub.get_async_chromadb_client = AsyncMock()  # type: ignore[attr-defined]
+sys.modules["utils"].async_chromadb_client = _async_chromadb_stub  # type: ignore[attr-defined]
 
 # ---------------------------------------------------------------------------
 # Load kb_synthesizer via importlib to bypass package __init__ imports
@@ -152,8 +162,10 @@ async def test_get_collection_creates_once() -> None:
     client = _make_chromadb_client(col)
 
     synth = KBSynthesizer(llm_service=_make_llm())
-    # Patch the lazily-imported symbol inside utils.chromadb_client stub
-    _chromadb_stub.get_async_chromadb_client = AsyncMock(return_value=client)
+    # knowledge.backends.get_async_default_client() lazily imports
+    # get_async_chromadb_client from utils.async_chromadb_client (#5316), so the
+    # mock belongs on that stub — not on the sync utils.chromadb_client one.
+    _async_chromadb_stub.get_async_chromadb_client = AsyncMock(return_value=client)
 
     c1 = await synth._get_collection()
     c2 = await synth._get_collection()

--- a/autobot-backend/services/mcp_worker_metrics_test.py
+++ b/autobot-backend/services/mcp_worker_metrics_test.py
@@ -40,10 +40,14 @@ class TestMCPWorkerMetricsRecorder:
         recorder.record_restart_budget_exhaustion("filesystem_mcp")
         recorder.record_restart_budget_exhaustion("filesystem_mcp")
 
-        # Verify counter was incremented
+        # Verify counter was incremented. prometheus_client strips the `_total`
+        # suffix from the metric *family* name and keeps it on the sample, so
+        # assert on the sample that actually carries the value.
         metrics = registry.collect()
         metric_dict = {m.name: m for m in metrics}
-        assert "autobot_mcp_worker_restart_budget_exhaustion_total" in metric_dict
+        assert "autobot_mcp_worker_restart_budget_exhaustion" in metric_dict
+        samples = {s.name: s.value for s in metric_dict["autobot_mcp_worker_restart_budget_exhaustion"].samples}
+        assert samples["autobot_mcp_worker_restart_budget_exhaustion_total"] == 2
 
     def test_record_crash_interval(self) -> None:
         """Record crash interval records to histogram."""

--- a/autobot-backend/services/npu_pipeline/test_dispatcher.py
+++ b/autobot-backend/services/npu_pipeline/test_dispatcher.py
@@ -20,8 +20,13 @@ _PKG_DIR = Path(__file__).parent
 
 
 def _load_module(name: str, filename: str):
-    if name in sys.modules and hasattr(sys.modules[name], "__file__"):
-        return sys.modules[name]
+    # Probe __dict__ rather than using hasattr: the root conftest's package
+    # stubs define a module-level __getattr__ that answers EVERY attribute
+    # with a MagicMock, so hasattr(stub, "__file__") is always True and the
+    # stub would be handed back instead of the real module.
+    existing = sys.modules.get(name)
+    if existing is not None and existing.__dict__.get("__file__"):
+        return existing
     spec = importlib.util.spec_from_file_location(name, str(_PKG_DIR / filename))
     mod = importlib.util.module_from_spec(spec)
     mod.__package__ = "services.npu_pipeline"
@@ -75,7 +80,7 @@ async def test_happy_path_three_workers():
 
     call_log: List[str] = []
 
-    async def mock_post(url, json=None):
+    def mock_post(url, json=None):
         resp = AsyncMock()
         resp.raise_for_status = MagicMock()
         if "/forward" in url:
@@ -123,7 +128,7 @@ async def test_worker_drop_mid_pass_failover():
 
     import aiohttp as _aiohttp
 
-    async def mock_post(url, json=None):
+    def mock_post(url, json=None):
         resp = AsyncMock()
         resp.raise_for_status = MagicMock()
 
@@ -172,7 +177,7 @@ async def test_worker_drop_no_peer_raises():
 
     import aiohttp as _aiohttp
 
-    async def mock_post(url, json=None):
+    def mock_post(url, json=None):
         raise _aiohttp.ClientConnectionError("worker0 down")
 
     session_mock = MagicMock()
@@ -195,7 +200,7 @@ async def test_single_worker_produces_tokens():
     """Single-worker plan: worker is both first and last, produces tokens."""
     plan = _make_plan("w0")
 
-    async def mock_post(url, json=None):
+    def mock_post(url, json=None):
         assert "/generate" in url, f"Expected /generate, got {url}"
         resp = AsyncMock()
         resp.raise_for_status = MagicMock()

--- a/autobot-backend/services/rag_integration_test.py
+++ b/autobot-backend/services/rag_integration_test.py
@@ -41,6 +41,29 @@ def _reset_rag_config_singleton():
     reset_rag_config()
 
 
+@pytest.fixture(autouse=True)
+def _isolate_hash_cache(tmp_path, monkeypatch):
+    """Isolate the doc-indexer hash cache from ambient on-disk state (#12673).
+
+    ``RAGService._filter_stale_chunks`` reads ``doc_indexer.HASH_CACHE_FILE``
+    through a module-level TTL memo.  Without isolation the suite picks up the
+    real ``data/.doc_index_hashes.json`` that exists on any machine where the
+    indexer has run, so the provenance filter drops every test-double chunk.
+    Point the cache at an absent tmp path and reset the memo around each test.
+    """
+    import services.rag_service as rag_mod
+
+    monkeypatch.setattr(
+        "services.knowledge.doc_indexer.HASH_CACHE_FILE",
+        tmp_path / "absent_doc_index_hashes.json",
+    )
+    rag_mod._hash_cache_memo = {}
+    rag_mod._hash_cache_loaded_at = 0.0
+    yield
+    rag_mod._hash_cache_memo = {}
+    rag_mod._hash_cache_loaded_at = 0.0
+
+
 class TestKnowledgeBaseAdapter:
     """Tests for KnowledgeBaseAdapter unified interface."""
 
@@ -289,8 +312,14 @@ class TestRAGService:
         assert reranked[0]["rerank_score"] == 0.95
         assert reranked[1]["rerank_score"] == 0.6
 
-    def test_cache_management(self) -> None:
-        """Test result caching functionality."""
+    @pytest.mark.asyncio
+    async def test_cache_management(self) -> None:
+        """Test result caching functionality.
+
+        The cache helpers are coroutines guarded by an asyncio lock, so they
+        must be awaited — calling them synchronously only built coroutine
+        objects and asserted nothing about the cache.
+        """
         mock_kb = Mock()
         mock_kb.__class__.__name__ = "KnowledgeBase"
 
@@ -298,15 +327,15 @@ class TestRAGService:
 
         # Add to cache
         test_results = ([Mock()], RAGMetrics())
-        service._add_to_cache("test_key", test_results)
+        await service._add_to_cache("test_key", test_results)
 
         # Retrieve from cache
-        cached = service._get_from_cache("test_key")
+        cached = await service._get_from_cache("test_key")
         assert cached is not None
 
         # Clear cache
-        service.clear_cache()
-        cached_after_clear = service._get_from_cache("test_key")
+        await service.clear_cache()
+        cached_after_clear = await service._get_from_cache("test_key")
         assert cached_after_clear is None
 
 
@@ -343,15 +372,20 @@ class TestCrossEncoderReranking:
         assert reranked[0].rerank_score is not None
 
     @pytest.mark.asyncio
-    @patch("advanced_rag_optimizer.CrossEncoder")
-    async def test_cross_encoder_integration(self, mock_cross_encoder_class) -> None:
-        """Test cross-encoder model integration."""
+    @patch("knowledge.search_components.reranking.get_cross_encoder")
+    async def test_cross_encoder_integration(self, mock_get_cross_encoder) -> None:
+        """Test cross-encoder model integration.
+
+        Since #1549 the model comes from the process-wide
+        ``knowledge.search_components.reranking.get_cross_encoder()`` singleton;
+        ``advanced_rag_optimizer`` no longer imports ``CrossEncoder`` itself.
+        """
         from advanced_rag_optimizer import AdvancedRAGOptimizer
 
         # Mock cross-encoder predict
         mock_ce = Mock()
         mock_ce.predict.return_value = [0.9, 0.6]  # Relevance scores
-        mock_cross_encoder_class.return_value = mock_ce
+        mock_get_cross_encoder.return_value = mock_ce
 
         optimizer = AdvancedRAGOptimizer()
 
@@ -419,8 +453,11 @@ class TestKBSynthesisSchemaCache:
                 "services.knowledge.synthesis_schema_loader.load_synthesis_schema",
                 return_value=mock_schema,
             ) as mock_loader,
+            # get_async_chromadb_client lives in utils.async_chromadb_client
+            # since #5316; the sync utils.chromadb_client never defined it, so
+            # the old target could only resolve against a leftover test stub.
             patch(
-                "utils.chromadb_client.get_async_chromadb_client",
+                "utils.async_chromadb_client.get_async_chromadb_client",
                 AsyncMock(return_value=chromadb_client),
             ),
         ):

--- a/autobot-backend/services/redis_listeners_e2e_test.py
+++ b/autobot-backend/services/redis_listeners_e2e_test.py
@@ -10,10 +10,21 @@ import json
 import sys
 import time
 
+import pytest
 import redis
 
 from autobot_shared.redis_client import get_redis_client
-from config import config as global_config_manager
+from config import unified_config_manager as global_config_manager
+
+# This module is a manual end-to-end script, not a unit test: every function
+# needs a live Redis plus a running orchestrator to consume the published
+# messages, prints its result instead of asserting, and returns a bool for
+# main()'s summary. Same shape and same rationale as
+# security/security_api_e2e_test.py — the `integration` marker matches the
+# filename and is already excluded by the two
+# `-m "not integration and not slow and not distributed and not performance"`
+# invocations in .github/workflows/ci.yml.
+pytestmark = pytest.mark.integration
 
 
 def test_worker_capabilities():

--- a/autobot-backend/services/redis_service_management_e2e_test.py
+++ b/autobot-backend/services/redis_service_management_e2e_test.py
@@ -31,6 +31,15 @@ from constants.network_constants import ServiceURLs
 logging.basicConfig(level=logging.INFO)
 logger = get_logger(__name__)
 
+# Every test here drives a real Chromium through Playwright against a live
+# frontend VM and backend API, so it cannot run without that external stack
+# (a bare checkout has no downloaded browser and no fleet). Same rationale as
+# security/security_api_e2e_test.py — the `integration` marker matches the
+# filename and is already excluded by the two
+# `-m "not integration and not slow and not distributed and not performance"`
+# invocations in .github/workflows/ci.yml.
+pytestmark = pytest.mark.integration
+
 
 # Fixtures
 @pytest.fixture(scope="session")

--- a/autobot-backend/services/security_memory_integration.py
+++ b/autobot-backend/services/security_memory_integration.py
@@ -505,14 +505,14 @@ class SecurityMemoryIntegration:
         await self._create_security_relation(
             from_entity=f"Host: {host_ip}",
             to_entity=entity_name,
-            relation_type="relates_to",
+            relation_type="affects",
         )
         if affected_port and affected_service:
             service_entity = f"Service: {host_ip}:{affected_port}/tcp ({affected_service})"
             await self._create_security_relation(
                 from_entity=service_entity,
                 to_entity=entity_name,
-                relation_type="relates_to",
+                relation_type="affects",
             )
 
     async def _store_vulnerability_in_memory(
@@ -705,12 +705,16 @@ class SecurityMemoryIntegration:
             True if created successfully
         """
         try:
-            # Map security relation types to base types
+            # Map security relation types onto the base graph's RELATION_TYPES
+            # vocabulary (autobot_memory_graph.core.RELATION_TYPES) — create_relation
+            # rejects anything outside it. The base name is "related_to"; the
+            # previous "relates_to" was not a valid type, so every mapped relation
+            # raised ValueError and was silently swallowed below.
             base_relation = relation_type
             if relation_type in DETAIL_RELATION_TYPES:
                 base_relation = "contains"
             elif relation_type in SEVERITY_RELATION_TYPES:
-                base_relation = "relates_to"
+                base_relation = "related_to"
 
             await self._memory_graph.create_relation(
                 from_entity=from_entity,

--- a/autobot-backend/services/security_memory_integration_test.py
+++ b/autobot-backend/services/security_memory_integration_test.py
@@ -112,10 +112,13 @@ class TestSecurityMemoryIntegration(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(call_args[1]["metadata"]["port"], 80)
             self.assertEqual(call_args[1]["metadata"]["type"], "service")
 
+            # The security-layer "runs" type is mapped onto the base graph's
+            # RELATION_TYPES vocabulary before it reaches create_relation —
+            # AutoBotMemoryGraph rejects anything outside that set.
             self.mock_memory_graph.create_relation.assert_called_once_with(
                 from_entity="Host: 192.168.1.10",
                 to_entity="Service: 192.168.1.10:80/tcp (http)",
-                relation_type="runs",
+                relation_type="contains",
                 strength=1.0,
             )
 
@@ -150,6 +153,12 @@ class TestSecurityMemoryIntegration(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(call_args[1]["metadata"]["type"], "vulnerability")
 
             self.assertEqual(self.mock_memory_graph.create_relation.call_count, 2)
+            # Both relations must reach the graph under a type it accepts.
+            # "relates_to" is not in autobot_memory_graph RELATION_TYPES, so
+            # emitting it made create_relation raise and silently drop every
+            # vulnerability edge.
+            for call in self.mock_memory_graph.create_relation.call_args_list:
+                self.assertEqual(call.kwargs["relation_type"], "related_to")
             mock_index.assert_called_once()
             self.assertIn("CVE-2024-1234", result["name"])
 
@@ -176,10 +185,10 @@ class TestSecurityMemoryIntegration(unittest.IsolatedAsyncioTestCase):
             await self.integration.create_host_entity(assessment_id="test-001", ip="10.0.0.1", status="up")
 
             mock_index.assert_called_once()
-            call_args = mock_index.call_args
-            self.assertIn("host_test-001_10.0.0.1", call_args[0][0])
-            self.assertIn("Host 10.0.0.1", call_args[0][1])
-            self.assertEqual(call_args[0][2]["type"], "host")
+            call_kwargs = mock_index.call_args.kwargs
+            self.assertIn("host_test-001_10.0.0.1", call_kwargs["finding_id"])
+            self.assertIn("Host 10.0.0.1", call_kwargs["text"])
+            self.assertEqual(call_kwargs["metadata"]["type"], "host")
 
     async def test_chromadb_failure_doesnt_break_flow(self) -> None:
         """Test ChromaDB errors are handled gracefully."""

--- a/autobot-backend/services/semantic_analyzer.py
+++ b/autobot-backend/services/semantic_analyzer.py
@@ -41,7 +41,10 @@ class SemanticAnalyzer:
     AUTOBOT_PATTERNS = {
         "ssot_config": re.compile(r"from autobot_shared\.ssot_config import"),
         "redis_client": re.compile(r"from autobot_shared\.redis_client import"),
-        "logger": re.compile(r"logger = logging\.getLogger\(__name__\)"),
+        # AutoBot's canonical logger is autobot_shared.logging_manager.get_logger,
+        # never stdlib logging.getLogger — matching the stdlib form made this
+        # detector dead against the entire codebase.
+        "logger": re.compile(r"logger = get_logger\(__name__\)"),
         "router": re.compile(r"router = APIRouter\("),
         "vue_composable": re.compile(r"export (function |const )use[A-Z]"),
     }
@@ -173,7 +176,7 @@ class SemanticAnalyzer:
             suggestions.append("from autobot_shared.redis_client import get_redis_client")
 
         if "logger" in context_patterns:
-            suggestions.append("import logging")
+            suggestions.append("from autobot_shared.logging_manager import get_logger")
 
         # Framework-based suggestions
         if "fastapi" in self.detected_frameworks:

--- a/autobot-backend/services/semantic_analyzer_test.py
+++ b/autobot-backend/services/semantic_analyzer_test.py
@@ -237,7 +237,7 @@ def test_suggest_imports_for_logger() -> None:
     patterns = ["logger"]
     suggestions = analyzer.suggest_imports(patterns)
 
-    assert any("logging" in s for s in suggestions)
+    assert any("from autobot_shared.logging_manager import get_logger" == s for s in suggestions)
 
 
 def test_suggest_imports_for_fastapi() -> None:

--- a/autobot-backend/services/terminal_history_service_test.py
+++ b/autobot-backend/services/terminal_history_service_test.py
@@ -4,7 +4,7 @@
 # Author: mrveiss
 """Tests for terminal history service."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -25,16 +25,17 @@ class TestTerminalHistoryService:
 
     @pytest.fixture
     def service(self, mock_redis):
-        """Create history service with mocked Redis."""
-        with patch(
-            "autobot_shared.redis_client.get_async_redis_client",
-            new=AsyncMock(return_value=mock_redis),
-        ):
-            from services.terminal_history_service import TerminalHistoryService
+        """Create history service with mocked Redis.
 
-            svc = TerminalHistoryService()
-            svc.redis = mock_redis
-            return svc
+        TerminalHistoryService gets its client from AsyncRedisClientMixin, which
+        caches on ``_redis`` and returns it from ``_get_redis()``. Seeding that
+        attribute is what keeps the service off a real connection.
+        """
+        from services.terminal_history_service import TerminalHistoryService
+
+        svc = TerminalHistoryService()
+        svc._redis = mock_redis
+        return svc
 
     @pytest.mark.asyncio
     async def test_add_command(self, service, mock_redis) -> None:

--- a/autobot-backend/utils/resource_factory.py
+++ b/autobot-backend/utils/resource_factory.py
@@ -103,13 +103,17 @@ class ResourceFactory:
 
             # Fallback to module-level import and creation
             from chat_history import ChatHistoryManager
-            from config import config as global_config_manager
+
+            # `config.config` is the SSOT AutoBotConfig proxy — it has neither
+            # get_redis_config() nor get_nested(). The config *manager* is the
+            # canonical holder of both, as every other call site uses.
+            from config import unified_config_manager
 
             logger.info("Creating new ChatHistoryManager instance (expensive operation)")
 
-            redis_config = global_config_manager.get_redis_config()
+            redis_config = unified_config_manager.get_redis_config()
             chm = ChatHistoryManager(
-                history_file=global_config_manager.get_nested("data.chat_history_file", "data/chat_history.json"),
+                history_file=unified_config_manager.get_nested("data.chat_history_file", "data/chat_history.json"),
                 use_redis=redis_config.get("enabled", False),
                 redis_host=redis_config.get("host", NetworkConstants.LOCALHOST_NAME),
                 redis_port=redis_config.get("port", NetworkConstants.REDIS_PORT),


### PR DESCRIPTION
## Thinking Path

`autobot-backend/services` was the largest red block under #13162. I measured a
baseline first rather than trusting the older "~45 failures" number, because
shared-module fixes had landed in between:

```
44 failed, 2127 passed, 12 skipped, 20 deselected, 10 errors in 309.18s
```

I then grouped the 54 red results into fifteen clusters and diagnosed each one
before touching anything, asking the same question every time: is the test
encoding a wrong assumption, or is it correctly reporting a broken product?

Four clusters turned out to be real production defects. Each had the same
shape — a refactor moved a name, nothing re-checked the call site, and the
failure mode was silent because it sat behind a broad `except` or behind a
regex that simply never matched:

- `semantic_analyzer` classified `logger = logging.getLogger(__name__)` as an
  *AutoBot* convention. AutoBot's canonical logger is
  `autobot_shared.logging_manager.get_logger`, so the detector never fired on a
  single file in this repo, and `suggest_imports` proposed the stdlib import
  that CLAUDE.md bans. The test asserting `"logger" in patterns` was right.
- `security_memory_integration` emitted `relates_to`. The memory graph's
  vocabulary spells it `related_to`, and `create_relation` raises `ValueError`
  on anything outside that set. So every vulnerability-to-host and
  vulnerability-to-service relation raised, got swallowed by
  `_create_security_relation`'s `except Exception`, and was logged as a
  warning. The graph has been quietly missing all vulnerability edges. The
  unit test never caught it because it mocks `create_relation`, which accepts
  anything.
- `utils/resource_factory` aliased the SSOT config *proxy* as the config
  *manager* and then called `get_redis_config()` / `get_nested()` on it.
  Neither exists there. Every other call site in the tree uses
  `unified_config_manager`. This one is outside `services/` — see the callout
  below.
- `redis_listeners_e2e_test` carried the same wrong alias, which is how I found
  the `resource_factory` one.

The remaining eleven clusters were genuinely stale tests, and I say why for
each in "What Changed". Three of them were not stale assertions but *module
identity* bugs — `patch()` targets silently resolving to a different object
than the code under test — which is worth calling out because they made tests
pass or fail depending on collection order rather than on behaviour.

Two files needed classification rather than repair: a Playwright suite that
drives a real browser against a live frontend VM and backend, and a
print-only Redis pub/sub script that needs a live Redis plus a running
orchestrator to consume its messages. Neither can run in a bare checkout.
I did not weaken them — I marked them `integration`, exactly as
`security/security_api_e2e_test.py` already is, with the same rationale, and
fixed the config bug inside the Redis one so it actually works when it does
run. Nothing was skipped, xfailed, or loosened to get green.

## What Changed

### Production fixes (the test was right, the code was wrong)

| File | Defect | Effect |
|---|---|---|
| `services/semantic_analyzer.py` | `AUTOBOT_PATTERNS["logger"]` matched the stdlib `logging.getLogger` form; `suggest_imports` proposed `import logging` | Detector was dead against the whole codebase and steered completions toward the banned pattern. Now matches `get_logger(__name__)` and suggests `autobot_shared.logging_manager` |
| `services/security_memory_integration.py` | `relates_to` is not in the memory graph's `RELATION_TYPES` (`related_to` is) | Every vulnerability relation raised and was swallowed — those edges never reached the graph. Vulnerability relations now emit the declared `affects` security type, which maps onto `related_to`; `SEVERITY_RELATION_TYPES` stops being dead code |
| `utils/resource_factory.py` | `from config import config as global_config_manager`, then `.get_redis_config()` / `.get_nested()` | The SSOT proxy has neither — live `AttributeError` whenever `ChatHistoryManager` is built off `app.state`. Now uses `unified_config_manager` |
| `services/redis_listeners_e2e_test.py` | same wrong config alias | Script raised before reaching Redis |

> **Shared-module callout:** `utils/resource_factory.py` is the one change
> outside `autobot-backend/services/`. It is a one-line alias correction found
> via the identical bug in a `services/` test, it matches every other call site
> in the tree, and `autobot-backend/utils` stays green (528 passed).

### Test fixes — stale after a refactor that already landed

- **`audit/audit_log_test.py`** — the exact-match enum guard predates four JWT
  actions (`RUN_JWT_MINT/REVOKE/REFRESH`, `DEVICE_JWT_MINT` from GH#9493). Added
  them rather than relaxing `==` to `<=`, so the guard keeps its strength.
- **`feedback_tracker_test.py`** — patched `create_engine`, removed by #10570
  when the tracker moved to the canonical async engine's `sync_engine`. Also
  its session mocks never returned themselves from `__enter__`, so
  `with self.SessionLocal() as db:` handed the code a different object than
  the assertions watched. Wired a real `CodePattern` row and a Redis double so
  the test now exercises the statistics and retrain paths instead of dying in
  them.
- **`terminal_history_service_test.py`** — injected `svc.redis`; the service
  uses `AsyncRedisClientMixin`, which caches on `_redis`. The old attribute was
  inert, so the tests were hitting a real connection and timing out through
  five retries.
- **`knowledge/test_contradiction_detector.py`** — mocked `llm.chat_completion`;
  production calls `llm.chat`. The `AsyncMock` auto-attribute made
  `response.error` truthy, so every scan took the "LLM error" branch and
  returned empty. Two `assert_not_called()` checks were passing vacuously and
  now mean something.
- **`knowledge/test_analyzer_service.py`, `knowledge/test_kb_synthesizer.py`,
  `rag_integration_test.py`** — attached ChromaDB mocks to
  `utils.chromadb_client`; since #5316 production imports
  `get_async_chromadb_client` from `utils.async_chromadb_client`. The sync
  module never defined that symbol at all, so one patch target could only ever
  resolve against a leftover stub.
- **`rag_integration_test.py` cross-encoder** — patched
  `advanced_rag_optimizer.CrossEncoder`, gone since #1549 moved the model to
  the process-wide `knowledge.search_components.reranking.get_cross_encoder()`
  singleton.
- **`rag_integration_test.py` cache** — called the async cache helpers
  synchronously, so it only built coroutine objects and asserted nothing.
- **`mcp_worker_metrics_test.py`** — asserted a metric *family* name carrying
  the `_total` suffix that `prometheus_client` moves onto the sample. Now
  asserts the sample and its value (2), which is a stronger check.

### Test fixes — module identity, i.e. `patch()` hitting the wrong object

- **`npu_pipeline/test_dispatcher.py`** — its loader guarded with
  `hasattr(mod, "__file__")` to detect "real module already loaded", but the
  root conftest's package stubs define a module-level `__getattr__` that
  answers *every* attribute with a `MagicMock`, so the guard was always true
  and the stub was handed back. All five tests were exercising a `MagicMock`,
  not `PipelineDispatcher`. Probing `__dict__` fixes it. Separately, the
  session double returned a coroutine from `post()`, which cannot back an
  `async with` — real aiohttp returns a context manager there.
- **`knowledge/test_doc_indexer.py` + `test_doc_indexer_dim_mismatch.py`** —
  both re-loaded `services.knowledge.doc_indexer` into `sys.modules`
  unconditionally. pytest imports every test module during collection, so the
  second one clobbered the first: its imported helpers kept the *old* module's
  globals while its `patch("services.knowledge.doc_indexer.X")` calls resolved
  against the *new* one. Every such patch was inert — which is why the hash
  cache tests were writing to the real data dir and reading each other's state.
  `test_doc_indexer.py` alone passed 84/84; together they lost 8. Both now
  reuse an already-loaded module.
- **ChromaDB stubs** — injected into `sys.modules` without being bound on the
  parent `utils` package, so `patch("utils.async_chromadb_client....")` in
  `rag_service_kb_synthesis_test.py` could not resolve them. Also `_make_stub`
  returns its own fresh object even when `setdefault` kept an existing one, so
  a sibling test file's stub was a dangling copy production never saw.

### Test fixes — ambient state and classification

- **`rag_integration_test.py`** — added the hash-cache isolation fixture that
  `tests/services/rag_service_events_test.py` already carries (#12673).
  `_filter_stale_chunks` reads `doc_indexer.HASH_CACHE_FILE` through a
  module-level TTL memo, so on any machine where the indexer has run the
  provenance filter dropped every test-double chunk.
- **`redis_listeners_e2e_test.py`, `redis_service_management_e2e_test.py`** —
  marked `integration`, matching `security/security_api_e2e_test.py` and the CI
  marker expression. Both need external infrastructure no checkout has.

## Verification

Baseline on the rebased branch, before any edit:

```
$ export SLM_SECRET_KEY=... SLM_ENCRYPTION_KEY=...
$ PYTHONPATH="$PWD/autobot-backend:$PWD" python3 -m pytest autobot-backend/services -q \
    -p no:cacheprovider -m "not integration and not slow and not distributed and not performance"

44 failed, 2127 passed, 12 skipped, 20 deselected, 84 warnings, 10 errors in 309.18s
```

After, on the same command, rebased onto the current base:

```
2168 passed, 12 skipped, 33 deselected in 149.25s
```

The arithmetic closes exactly: 2127 -> 2168 is +41 newly passing, and
20 -> 33 deselected is the +13 e2e results (3 Redis pub/sub, 10 Playwright)
now correctly classified. 41 + 13 = 54 = the 44 failures plus 10 errors.

Adjacent suites for the modules touched outside their own tests:

```
$ python3 -m pytest autobot-backend/utils autobot-backend/services/context_analyzer_test.py -q \
    -m "not integration and not slow and not distributed and not performance"
528 passed, 14 skipped, 2 deselected
```

(One pre-existing wall-clock flake, `concurrency_safety_test.py::TestPerformance::test_atomic_write_overhead`,
tripped once while other suites ran concurrently and passes on its own in 30.77s.
It is unrelated to this change — the diff does not touch atomic writes.)

Lint gates, CI's exact flags, all changed files:

```
$ python3 -m isort --settings-path=. --line-length=120 <files>   # clean
$ python3 -m black  --line-length=120 <files>                    # clean
$ python3 -m flake8 --config=.flake8 <files>                     # exit 0
$ python3 -m bandit -c .bandit <files>                           # No issues identified (no severity floor)
$ bash scripts/pr-preflight.sh --issue 13162 ...                 # pre-flight clean
```

## Model Used

Claude Opus 5 (1M context)

Closes #13162

> **PARTIAL — #13162 stays open.** This PR only covers
> `autobot-backend/services/`. Issue #13162 tracks the whole red Python suite;
> sibling PRs cover `api/` and `tests/`, and the issue must remain open until
> every area is green and the Python suite is promoted to a required check.
