### PR TITLE
test(repo): sys.modules leak guard — xdist-safe, and gating under -n (#13361)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -15,3 +15,10 @@ from pathlib import Path
 _REPO_ROOT = str(Path(__file__).parent)
 if _REPO_ROOT not in sys.path:
     sys.path.insert(0, _REPO_ROOT)
+
+# Repo-wide sys.modules leak guard (#13337). Declared here — the rootdir
+# conftest is the only conftest where ``pytest_plugins`` is still legal in
+# pytest >= 9 — and loaded after the sys.path insert above, so ``repo_tests``
+# resolves. The plugin registers before any other conftest, which is what lets
+# it attribute each one's sys.modules delta.
+pytest_plugins = ["repo_tests.sys_modules_leak_guard"]

--- a/repo_tests/sys_modules_leak_guard.py
+++ b/repo_tests/sys_modules_leak_guard.py
@@ -479,6 +479,18 @@ def pytest_runtest_protocol(item: pytest.Item, nextitem: object) -> Iterator[Non
     ``pytest_runtest_setup`` alone only ever *checked*; nothing attributed what
     a run-phase hookwrapper installed, so a stub created for the run window and
     never restored was invisible.  Outermost again, for the same reason.
+
+    Caveat on the owner: during the run phase it is ``item.path``, the module
+    the test lives in.  A stub installed lazily *while a test runs* but
+    originating from a fixture defined in a conftest further up is therefore
+    blamed on whichever directory happened to be executing rather than on the
+    conftest that defines the fixture, and the reported directory can be
+    narrower than the one the stub really belongs to.  The report still names
+    a real key and a real observation point, so it stays actionable, and no
+    such case has been observed — the collection phase attributes conftest
+    fixtures to the conftest, which is where this shape would normally land.
+    Fixing it properly means tracing a stub back to the frame that installed
+    it, which costs far more than the guard is worth.
     """
     if _GUARD is None:
         yield

--- a/repo_tests/sys_modules_leak_guard.py
+++ b/repo_tests/sys_modules_leak_guard.py
@@ -154,8 +154,13 @@ def _is_conftest_module(module: object) -> bool:
     repo in the default import mode).
     """
     origin = getattr(module, "__file__", None)
-    return bool(origin) and Path(str(origin)).name == "conftest.py"
+    return bool(origin) and os.path.basename(str(origin)) == "conftest.py"
 
+
+# Distinguishes "this key was absent from the baseline" from "it was present
+# and bound to ``None``" — ``sys.modules[name] = None`` is legal and is used to
+# block an import, so ``None`` cannot serve as the missing marker.
+_MISSING = object()
 
 _DISK_CACHE: dict[str, bool] = {}
 
@@ -193,7 +198,7 @@ class _LeakGuard:
 
     def __init__(self, rootdir: Path) -> None:
         self._rootdir = rootdir
-        self._baseline: dict[str, int] = {}
+        self._baseline: dict[str, object] = {}
         self._tracked: dict[str, _Mutation] = {}
         self._reported: set[tuple[str, str]] = set()
         self._warned_owners: set[str] = set()
@@ -207,6 +212,12 @@ class _LeakGuard:
     def snapshot(self) -> None:
         """Re-baseline. Everything after this point is attributable.
 
+        The baseline stores the module objects and comparison is by identity.
+        Building ``{name: id(mod)}`` instead ran a Python-level comprehension
+        over every entry ``sys.modules`` holds — ~3600 in an
+        ``autobot-backend`` session — on every collector and every test, and
+        measured 1.028 ms against 0.087 ms for the plain copy.
+
         ``sys.modules.copy()`` and never a live view: ``dict.copy()`` is a
         single C-level operation and cannot be torn, whereas iterating
         ``sys.modules.items()`` races with any import happening on another
@@ -215,7 +226,7 @@ class _LeakGuard:
         changed size during iteration`` raised inside a hook, which under xdist
         kills the worker and takes the session down with ``INTERNALERROR``.
         """
-        self._baseline = {name: id(mod) for name, mod in sys.modules.copy().items()}
+        self._baseline = sys.modules.copy()
 
     def attribute(self, owner_file: Path) -> None:
         """Record the suspicious part of the delta since the last snapshot.
@@ -227,10 +238,16 @@ class _LeakGuard:
         unconditionally would blame the level above and make every stub look
         like it never escapes.
         """
+        current = sys.modules.copy()
+        changed = self._changed_since(current)
+        self._baseline = current
+        if not changed:
+            return
         owner = _display(owner_file, self._rootdir)
         owner_dir = owner_file if owner_file.is_dir() else owner_file.parent
-        for name, module in sys.modules.copy().items():
-            kind = self._classify(name, module)
+        owner_dir_display = _display(owner_dir, self._rootdir)
+        for name, module, previous in changed:
+            kind = self._classify(name, module, previous)
             if kind is None:
                 continue
             self._tracked[name] = _Mutation(
@@ -238,21 +255,47 @@ class _LeakGuard:
                 kind=kind,
                 owner=owner,
                 owner_dir=owner_dir,
-                owner_dir_display=_display(owner_dir, self._rootdir),
+                owner_dir_display=owner_dir_display,
                 obj_id=id(module),
             )
-        self.snapshot()
 
-    def _classify(self, name: str, module: object) -> str | None:
-        """Return ``"replaced"``/``"synthetic"`` for a suspicious new entry."""
-        previous = self._baseline.get(name)
-        if previous == id(module):
+    def _changed_since(self, current: dict[str, object]) -> list[tuple[str, object, object]]:
+        """Entries that are new or now bound to a different object.
+
+        This loop is the whole plugin's hot path, so it stays free of Python
+        calls: a C-level ``dict.get`` and an identity compare per entry.
+        Handing every module to ``_classify`` instead called it 443,487 times
+        for a 103-test session, since only a handful of keys ever change while
+        the scan is over all ~3600.
+        """
+        baseline = self._baseline
+        changed = []
+        for name, module in current.items():
+            previous = baseline.get(name, _MISSING)
+            if previous is not module:
+                changed.append((name, module, previous))
+        return changed
+
+    def _classify(self, name: str, module: object, previous: object) -> str | None:
+        """Return ``"replaced"``/``"synthetic"`` for a suspicious changed entry.
+
+        *previous* is what the baseline had bound to *name*, or ``_MISSING``
+        when the key is new.  It is passed in rather than looked up because
+        the caller has already re-baselined by the time this runs.
+
+        The first test is an equivalence, not a new rule: a brand-new key
+        holding a module with a ``__spec__`` is an ordinary import, which the
+        final line already answered ``None`` for.  Answering it up front skips
+        a ``__file__`` probe and a ``sys.path`` walk for the large majority of
+        changed entries, which are exactly that.
+        """
+        if previous is _MISSING and not _is_synthetic(module):
             return None
         if _is_conftest_module(module):
             return None  # pytest's own bookkeeping, not a stub
         if not self._shadows_real_code(name):
             return None
-        if previous is not None:
+        if previous is not _MISSING:
             return "replaced"
         return "synthetic" if _is_synthetic(module) else None
 
@@ -396,12 +439,18 @@ def pytest_make_collect_report(collector: pytest.Collector) -> Iterator[None]:
     ``tryfirst`` is load-bearing, not a tidiness flag.  The pattern this guard
     tells implementers to adopt — install and restore from a
     ``pytest_make_collect_report`` hookwrapper — puts the *leaking* conftest's
-    wrapper somewhere in the same chain.  Without ``tryfirst`` pluggy can order
-    that wrapper outside this one, so the stub is already installed by the time
-    ``snapshot()`` runs, lands in the baseline, and produces an empty delta:
-    the guard reports nothing for exactly the shape it is meant to police.
-    Outermost means the snapshot is taken before any inner wrapper installs
-    anything, and the attribution after every inner wrapper has restored.
+    wrapper somewhere in the same chain, and this one has to be outermost so
+    that ``attribute()`` runs after every inner wrapper has had its chance to
+    restore: the correct pattern then leaves an empty delta and the buggy one
+    does not.  ``check()`` correspondingly has to run before any inner wrapper
+    installs anything, or the guard reacts to a stub that is about to be put
+    back.
+
+    There is no re-baseline here.  ``attribute()`` ends by re-baselining, so
+    an explicit ``snapshot()`` at this point only re-copied ``sys.modules`` a
+    third time per node — the profile showed ``snapshot`` at 270 calls against
+    ``attribute``'s 136 — and it *discarded* anything imported between the
+    previous node's attribution and this one instead of attributing it.
 
     Every collector is bracketed, not just ``pytest.Module``.  A ``Dir`` or
     ``Package`` node is where a hook-installed stub is created, so skipping
@@ -417,7 +466,6 @@ def pytest_make_collect_report(collector: pytest.Collector) -> Iterator[None]:
     path = Path(str(collector.path))
     phase = "the collection of" if path.is_dir() else "the import of"
     _GUARD.check(path, f"{phase} {_display(path, _GUARD.rootdir)}")
-    _GUARD.snapshot()
     try:
         yield
     finally:
@@ -437,7 +485,6 @@ def pytest_runtest_protocol(item: pytest.Item, nextitem: object) -> Iterator[Non
         return
     path = Path(str(item.path)) if item.path else None
     _GUARD.check(path, f"the test {item.nodeid}")
-    _GUARD.snapshot()
     try:
         yield
     finally:

--- a/repo_tests/sys_modules_leak_guard.py
+++ b/repo_tests/sys_modules_leak_guard.py
@@ -1,0 +1,514 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Repo-wide pytest plugin: catch ``sys.modules`` stubs that escape their directory.
+
+Three conftest/test-module stub leaks were found in two days, all the same
+shape — a module-level ``sys.modules`` mutation whose cleanup was not
+guaranteed on every path — and each one produced failures that looked like
+product bugs somewhere else entirely:
+
+* ``autobot-backend/llc/tests/conftest.py`` installed an ``agents`` stub at
+  import time and restored it only at package teardown, so anything importing
+  ``initialization.lifespan`` inside that window died with
+  ``ModuleNotFoundError: No module named 'agents.overseer'`` (#13337);
+* ``autobot-slm-backend/conftest.py`` stubbed ``sqlalchemy`` as a ``MagicMock``
+  in every process including the xdist **controller**, which then crashed with
+  ``INTERNALERROR`` while rebuilding a worker warning and lost an entire
+  session's results (#13320);
+* two RBAC test modules replaced ``autobot_shared`` with a bare ``MagicMock``
+  and never restored it because ``exec_module()`` raised before the restore
+  line, producing **13 of 14** apparent security-cluster failures (#13324).
+
+The rule this plugin enforces is the one all three break:
+
+    A stub installed by a conftest or test module under directory *D* must not
+    still be live while pytest imports or runs anything outside *D*.
+
+That rule is deliberately narrow.  A conftest legitimately stubs heavy
+dependencies for its own subtree — ``autobot-backend/conftest.py`` does it for
+the whole backend — and this plugin says nothing about those, because the owner
+directory covers every node they affect.  It fires only when a stub reaches
+across into a sibling.
+
+Only *suspicious* mutations are tracked, so an ordinary import never registers:
+
+* **replaced** — the key was already in ``sys.modules`` bound to a different
+  object, i.e. something swapped a real module out;
+* **synthetic** — the new entry has no ``__spec__``, which is true of
+  ``types.ModuleType(...)`` hand-built stubs and of ``MagicMock``, and never of
+  a module the import system loaded.
+
+Configuration (env var ``AUTOBOT_SYSMODULES_GUARD``):
+
+``report``  default — warn, and print a dedicated terminal section
+``error``   also fail the session with a non-zero exit status
+``off``     disable entirely
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import warnings
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+_MODE_ENV = "AUTOBOT_SYSMODULES_GUARD"
+_MODE_OFF = "off"
+_MODE_ERROR = "error"
+
+_SECTION_TITLE = "sys.modules leak guard"
+_KEYS_PER_OWNER = 8
+
+
+def _mode() -> str:
+    return os.environ.get(_MODE_ENV, "report").strip().lower()
+
+
+@dataclass(frozen=True)
+class _Mutation:
+    """A suspicious ``sys.modules`` entry and the file that installed it."""
+
+    key: str
+    kind: str  # "replaced" or "synthetic"
+    owner: str  # display path of the conftest / test module
+    owner_dir: Path
+    owner_dir_display: str
+    obj_id: int
+
+    def is_live(self) -> bool:
+        """True while the installed object is still the one in ``sys.modules``."""
+        return id(sys.modules.get(self.key)) == self.obj_id
+
+    def escapes_to(self, path: Path | None) -> bool:
+        """True when *path* is outside the directory that owns this stub."""
+        if path is None:
+            return False
+        return self.owner_dir not in path.parents and path != self.owner_dir
+
+
+@dataclass(frozen=True)
+class _Leak:
+    """A live mutation observed while pytest worked outside its owner."""
+
+    mutation: _Mutation
+    observed_at: str
+
+    def describe(self) -> str:
+        return (
+            f"sys.modules[{self.mutation.key!r}] was {self.mutation.kind} by "
+            f"{self.mutation.owner} and is STILL INSTALLED while pytest handles "
+            f"{self.observed_at} — outside {self.mutation.owner_dir_display}/. "
+            f"Install and remove the stub in the same try/finally, scoped to the "
+            f"nodes that need it."
+        )
+
+    def as_record(self) -> dict:
+        """A plain-dict form that survives the xdist worker->controller hop."""
+        return {
+            "key": self.mutation.key,
+            "kind": self.mutation.kind,
+            "owner": self.mutation.owner,
+            "owner_dir_display": self.mutation.owner_dir_display,
+            "observed_at": self.observed_at,
+        }
+
+
+def _is_synthetic(module: object) -> bool:
+    """True for hand-built module stubs and mocks, false for real imports."""
+    return getattr(module, "__spec__", None) is None
+
+
+def _is_conftest_module(module: object) -> bool:
+    """True when *module* is a conftest pytest loaded, not a stub of anything.
+
+    Without ``--import-mode=importlib`` pytest registers every ``conftest.py``
+    under the bare name ``conftest``, so each new one *replaces* the last and
+    looks exactly like a module swap.  It is pytest's own bookkeeping and must
+    never be reported (caught by the nested-session tests, which run a scratch
+    repo in the default import mode).
+    """
+    origin = getattr(module, "__file__", None)
+    return bool(origin) and Path(str(origin)).name == "conftest.py"
+
+
+_DISK_CACHE: dict[str, bool] = {}
+
+
+def _resolves_on_disk(top_level: str) -> bool:
+    """True when *top_level* names a real module or package somewhere on sys.path.
+
+    Deliberately a filesystem probe and not ``importlib.util.find_spec``:
+    ``find_spec`` imports parent packages and consults ``sys.modules``, which
+    would both re-run the very import machinery this guard watches and simply
+    find the stub.  Results are cached — a session asks about a few dozen names.
+    """
+    cached = _DISK_CACHE.get(top_level)
+    if cached is not None:
+        return cached
+    found = False
+    for entry in sys.path:
+        base = Path(entry or ".")
+        if (base / f"{top_level}.py").is_file() or (base / top_level).is_dir():
+            found = True
+            break
+    _DISK_CACHE[top_level] = found
+    return found
+
+
+def _display(path: Path, rootdir: Path) -> str:
+    try:
+        return str(path.relative_to(rootdir))
+    except ValueError:
+        return path.name
+
+
+class _LeakGuard:
+    """Track suspicious ``sys.modules`` mutations and where they escape to."""
+
+    def __init__(self, rootdir: Path) -> None:
+        self._rootdir = rootdir
+        self._baseline: dict[str, int] = {}
+        self._tracked: dict[str, _Mutation] = {}
+        self._reported: set[tuple[str, str]] = set()
+        self._warned_owners: set[str] = set()
+        self.leaks: list[_Leak] = []
+
+    def snapshot(self) -> None:
+        """Re-baseline. Everything after this point is attributable.
+
+        ``sys.modules.copy()`` and never a live view: ``dict.copy()`` is a
+        single C-level operation and cannot be torn, whereas iterating
+        ``sys.modules.items()`` races with any import happening on another
+        thread.  The suite has plenty — the analytics/celery task tests spawn
+        them — and the loser of that race is a ``RuntimeError: dictionary
+        changed size during iteration`` raised inside a hook, which under xdist
+        kills the worker and takes the session down with ``INTERNALERROR``.
+        """
+        self._baseline = {name: id(mod) for name, mod in sys.modules.copy().items()}
+
+    def attribute(self, owner_file: Path) -> None:
+        """Record the suspicious part of the delta since the last snapshot.
+
+        *owner_file* may be a file (a conftest or a test module) or a directory
+        (a ``Dir``/``Package`` collector, which is where a hook-installed stub
+        is attributed).  The owning *directory* is the file's parent in the
+        first case and the path itself in the second — taking ``.parent``
+        unconditionally would blame the level above and make every stub look
+        like it never escapes.
+        """
+        owner = _display(owner_file, self._rootdir)
+        owner_dir = owner_file if owner_file.is_dir() else owner_file.parent
+        for name, module in sys.modules.copy().items():
+            kind = self._classify(name, module)
+            if kind is None:
+                continue
+            self._tracked[name] = _Mutation(
+                key=name,
+                kind=kind,
+                owner=owner,
+                owner_dir=owner_dir,
+                owner_dir_display=_display(owner_dir, self._rootdir),
+                obj_id=id(module),
+            )
+        self.snapshot()
+
+    def _classify(self, name: str, module: object) -> str | None:
+        """Return ``"replaced"``/``"synthetic"`` for a suspicious new entry."""
+        previous = self._baseline.get(name)
+        if previous == id(module):
+            return None
+        if _is_conftest_module(module):
+            return None  # pytest's own bookkeeping, not a stub
+        if not self._shadows_real_code(name):
+            return None
+        if previous is not None:
+            return "replaced"
+        return "synthetic" if _is_synthetic(module) else None
+
+    def _shadows_real_code(self, name: str) -> bool:
+        """True when a synthetic entry could be hiding something that exists.
+
+        Two families of ``sys.modules`` entry look exactly like a hand-built
+        stub — no ``__spec__``, no ``__loader__``, no ``__file__`` — but are
+        nothing of the kind: C-extension pseudo-modules registered by cffi and
+        Cython (``_openssl``, ``cython_runtime``, ``_cython_3_2_1``) and
+        extension submodules (``_sodium.lib``, ``xml.parsers.expat.errors``).
+
+        What separates a stub from those is not how it was built but what it
+        stands in front of: a stub shadows a real module that is installed, so
+        some other test can import the wrong thing.  Nothing is importable
+        under those extension names, so nothing can be shadowed, and a stub for
+        a package that is not installed at all (``torch`` here) cannot break an
+        importer either.  Submodules follow their parent.
+
+        The same test gates *replacements*, not just synthetic entries.  A test
+        that loads a script through ``spec_from_file_location`` under a
+        made-up top-level name and re-registers it per run
+        (``zero_downtime_deploy_under_test``) reads as a replacement, but there
+        is no such module on disk for it to shadow, so nothing can collide with
+        it.  The three historical leaks all shadow installed packages
+        (``sqlalchemy``, ``autobot_shared``, ``agents``) and are unaffected.
+        """
+        parent_name, _, _ = name.rpartition(".")
+        if parent_name:
+            return parent_name in self._tracked or _resolves_on_disk(parent_name)
+        return _resolves_on_disk(name)
+
+    def check(self, path: Path | None, observed_at: str) -> None:
+        """Report every tracked stub still live while pytest works on *path*."""
+        for mutation in list(self._tracked.values()):
+            if not mutation.is_live():
+                self._tracked.pop(mutation.key, None)
+                continue
+            if not mutation.escapes_to(path):
+                continue
+            token = (mutation.key, mutation.owner)
+            if token in self._reported:
+                continue
+            self._reported.add(token)
+            leak = _Leak(mutation=mutation, observed_at=observed_at)
+            self.leaks.append(leak)
+            self._warn_once_per_owner(leak)
+
+    def _warn_once_per_owner(self, leak: _Leak) -> None:
+        """Warn on the first key each owner leaks, not on all of them.
+
+        One escaping conftest routinely drags dozens of keys with it
+        (``autobot-backend/conftest.py`` alone leaks 60+ into ``repo_tests``),
+        and a warning per key buries the finding it is meant to surface.  The
+        full key list still reaches the terminal section.
+        """
+        if leak.mutation.owner in self._warned_owners:
+            return
+        self._warned_owners.add(leak.mutation.owner)
+        warnings.warn(leak.describe(), _SysModulesLeakWarning, stacklevel=1)
+
+    def records(self) -> list[dict]:
+        """Every leak in transport form, in first-seen order."""
+        return [leak.as_record() for leak in self.leaks]
+
+
+class _SysModulesLeakWarning(pytest.PytestWarning):
+    """Emitted when a conftest stub is live outside the directory that owns it.
+
+    Its ``__module__`` must stay honest.  xdist rebuilds worker warnings on the
+    controller through ``unserialize_warning_message``, which does
+    ``getattr(importlib.import_module(module), class_name)`` on the pair the
+    worker sent.  Claiming ``__module__ = "pytest"`` sends
+    ``("pytest", "_SysModulesLeakWarning")``, the controller raises
+    ``AttributeError: module 'pytest' has no attribute
+    '_SysModulesLeakWarning'``, the node goes down and the session dies with
+    ``INTERNALERROR`` — the very #13320 failure mode this guard exists to
+    prevent, reintroduced by the guard.  The real module is importable on the
+    controller (the rootdir conftest loads this plugin there too), so the
+    honest pair round-trips.  Subclass-based ``filterwarnings`` entries such as
+    ``always::pytest.PytestWarning`` match on the class hierarchy and are
+    unaffected by ``__module__``.
+    """
+
+
+# ---------------------------------------------------------------------------
+# pytest hooks
+# ---------------------------------------------------------------------------
+
+# The repo root, derived from this file's own location — never hard-coded, so
+# moving the checkout or the machine cannot strand the guard.
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _make_guard() -> _LeakGuard | None:
+    """Build the guard at *import* time, before any other conftest loads.
+
+    ``pytest_configure`` is far too late: pytest loads the conftest of every
+    initial argument path during ``pytest_load_initial_conftests``, which runs
+    before configure, so a guard created there would miss exactly the
+    import-time conftest mutations it exists to catch.  The rootdir conftest
+    pulls this module in through ``pytest_plugins``, and the rootdir conftest is
+    an ancestor of every argument, so this runs first.
+    """
+    if _mode() == _MODE_OFF:
+        return None
+    guard = _LeakGuard(_REPO_ROOT)
+    guard.snapshot()
+    return guard
+
+
+_GUARD: _LeakGuard | None = _make_guard()
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Keep the guard's warnings visible even under a strict filter set."""
+    if _GUARD is None:
+        return
+    config.addinivalue_line("filterwarnings", "always::pytest.PytestWarning")
+
+
+def pytest_plugin_registered(plugin: object, manager: object) -> None:
+    """Attribute the ``sys.modules`` delta of a freshly-imported conftest.
+
+    conftest modules are registered as plugins the moment they finish
+    executing, and pytest imports them one at a time, so the delta since the
+    previous attribution point belongs to this file.
+    """
+    if _GUARD is None:
+        return
+    origin = getattr(plugin, "__file__", None)
+    if not origin or Path(origin).name != "conftest.py":
+        return
+    _GUARD.attribute(Path(origin))
+
+
+@pytest.hookimpl(hookwrapper=True, tryfirst=True)
+def pytest_make_collect_report(collector: pytest.Collector) -> Iterator[None]:
+    """Bracket every collector: check before it runs, attribute what it added.
+
+    ``tryfirst`` is load-bearing, not a tidiness flag.  The pattern this guard
+    tells implementers to adopt — install and restore from a
+    ``pytest_make_collect_report`` hookwrapper — puts the *leaking* conftest's
+    wrapper somewhere in the same chain.  Without ``tryfirst`` pluggy can order
+    that wrapper outside this one, so the stub is already installed by the time
+    ``snapshot()`` runs, lands in the baseline, and produces an empty delta:
+    the guard reports nothing for exactly the shape it is meant to police.
+    Outermost means the snapshot is taken before any inner wrapper installs
+    anything, and the attribution after every inner wrapper has restored.
+
+    Every collector is bracketed, not just ``pytest.Module``.  A ``Dir`` or
+    ``Package`` node is where a hook-installed stub is created, so skipping
+    those left the guard blind to them.
+
+    The check runs *before* ``collector.collect()`` because that is the moment
+    a leaked stub does its damage: it is the import that fails, and the failure
+    names the importing module rather than the conftest responsible.
+    """
+    if _GUARD is None:
+        yield
+        return
+    path = Path(str(collector.path))
+    phase = "the collection of" if path.is_dir() else "the import of"
+    _GUARD.check(path, f"{phase} {_display(path, _GUARD._rootdir)}")
+    _GUARD.snapshot()
+    try:
+        yield
+    finally:
+        _GUARD.attribute(path)
+
+
+@pytest.hookimpl(hookwrapper=True, tryfirst=True)
+def pytest_runtest_protocol(item: pytest.Item, nextitem: object) -> Iterator[None]:
+    """Bracket each test the same way — a stub can escape after collection too.
+
+    ``pytest_runtest_setup`` alone only ever *checked*; nothing attributed what
+    a run-phase hookwrapper installed, so a stub created for the run window and
+    never restored was invisible.  Outermost again, for the same reason.
+    """
+    if _GUARD is None:
+        yield
+        return
+    path = Path(str(item.path)) if item.path else None
+    _GUARD.check(path, f"the test {item.nodeid}")
+    _GUARD.snapshot()
+    try:
+        yield
+    finally:
+        if path is not None:
+            _GUARD.attribute(path)
+
+
+# ---------------------------------------------------------------------------
+# xdist: detection happens in the workers, reporting happens on the controller
+# ---------------------------------------------------------------------------
+
+# Records collected from workers. Empty in a serial run, where the controller
+# and the detector are the same process and ``_GUARD.records()`` is used.
+_WORKER_RECORDS: list[dict] = []
+
+
+def _all_records() -> list[dict]:
+    """Every leak this process knows about, worker-reported ones included."""
+    local = _GUARD.records() if _GUARD is not None else []
+    return local + _WORKER_RECORDS
+
+
+def _group_records(records: list[dict]) -> dict[str, list[dict]]:
+    """Records bucketed by the file that installed them, in first-seen order."""
+    grouped: dict[str, list[dict]] = {}
+    for record in records:
+        grouped.setdefault(record["owner"], []).append(record)
+    return grouped
+
+
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+    """Ship worker findings to the controller, and fail the run in error mode.
+
+    Under xdist every check runs in a worker, so the controller's own ``_GUARD``
+    never sees a leak.  Without this hand-off both the terminal section and the
+    ``error`` gate were silently dead under ``-n`` — which is the only shape CI
+    uses, so the gate #13361 relies on would not have existed.
+    """
+    workeroutput = getattr(session.config, "workeroutput", None)
+    if workeroutput is not None:
+        workeroutput["sys_modules_leaks"] = _GUARD.records() if _GUARD else []
+        return
+    if _mode() == _MODE_ERROR and _all_records():
+        session.exitstatus = pytest.ExitCode.TESTS_FAILED
+
+
+@pytest.hookimpl(optionalhook=True)
+def pytest_testnodedown(node: object, error: object) -> None:
+    """Merge one worker's findings into the controller's list.
+
+    ``optionalhook`` is mandatory here: ``pytest_testnodedown`` is an xdist
+    hookspec, so on any run where pytest-xdist is not installed pluggy's
+    ``check_pending()`` raises ``PluginValidationError: unknown hook`` and
+    takes the whole session down at collection.  Several CI jobs install bare
+    pytest (see pytest.ini's note on the xdist-less jobs), so without this the
+    guard would break them all.
+    """
+    output = getattr(node, "workeroutput", None) or {}
+    for record in output.get("sys_modules_leaks", []):
+        if record not in _WORKER_RECORDS:
+            _WORKER_RECORDS.append(record)
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+def pytest_terminal_summary(terminalreporter: object, exitstatus: int) -> None:
+    """Print the leaks in their own section; a warnings line is too easy to miss."""
+    records = _all_records()
+    if not records:
+        return
+    grouped = _group_records(records)
+    terminalreporter.section(_SECTION_TITLE, sep="=", red=True, bold=True)
+    for owner, owned in grouped.items():
+        _write_owner_report(terminalreporter, owner, owned)
+    terminalreporter.write_line(
+        f"{len(records)} leaked sys.modules key(s) from {len(grouped)} file(s). "
+        f"Install and remove each stub in the same try/finally, scoped to the "
+        f"nodes that need it. Set {_MODE_ENV}={_MODE_ERROR} to fail the run on "
+        f"these, or {_MODE_ENV}={_MODE_OFF} to disable the guard."
+    )
+
+
+def _write_owner_report(terminalreporter: object, owner: str, records: list[dict]) -> None:
+    """Print one offender: who, how far it reached, and which keys."""
+    first = records[0]
+    terminalreporter.write_line(
+        f"LEAK: {owner} leaves {len(records)} sys.modules key(s) installed outside "
+        f"{first['owner_dir_display']}/ — first seen at {first['observed_at']}",
+        red=True,
+    )
+    keys = [record["key"] for record in records]
+    shown = ", ".join(keys[:_KEYS_PER_OWNER])
+    overflow = len(keys) - _KEYS_PER_OWNER
+    if overflow > 0:
+        shown = f"{shown} … (+{overflow} more)"
+    terminalreporter.write_line(f"      keys: {shown}")

--- a/repo_tests/sys_modules_leak_guard.py
+++ b/repo_tests/sys_modules_leak_guard.py
@@ -86,10 +86,30 @@ class _Mutation:
         return id(sys.modules.get(self.key)) == self.obj_id
 
     def escapes_to(self, path: Path | None) -> bool:
-        """True when *path* is outside the directory that owns this stub."""
+        """True when *path* is outside the directory that owns this stub.
+
+        A strict *ancestor* directory is not an escape, and treating it as one
+        made ``error`` mode unusable.  Pytest builds a ``Dir`` collector for
+        every level from the rootdir down, so a session confined entirely to
+        ``autobot-backend/`` still collects the rootdir node ``.``; that node
+        imports nothing itself, it only lists its children, so a stub being
+        live while it runs reaches nothing.  Reporting it fired on every clean
+        session, and — because :meth:`_LeakGuard.check` dedupes per
+        ``(key, owner)`` and the ancestor node always runs first — it also
+        stole the ``first seen at`` slot from the sibling that actually
+        inherited the stub, discarding the actionable half of the report.
+
+        Only *directories* are exempted.  A file sitting directly in an
+        ancestor directory is never a member of ``owner_dir.parents``, so
+        sibling modules one level up are still checked.
+        """
         if path is None:
             return False
-        return self.owner_dir not in path.parents and path != self.owner_dir
+        if path == self.owner_dir or self.owner_dir in path.parents:
+            return False  # inside the owner's own subtree
+        if path in self.owner_dir.parents:
+            return False  # a structural ancestor Dir node imports nothing
+        return True
 
 
 @dataclass(frozen=True)
@@ -178,6 +198,11 @@ class _LeakGuard:
         self._reported: set[tuple[str, str]] = set()
         self._warned_owners: set[str] = set()
         self.leaks: list[_Leak] = []
+
+    @property
+    def rootdir(self) -> Path:
+        """The repo root every reported path is displayed relative to."""
+        return self._rootdir
 
     def snapshot(self) -> None:
         """Re-baseline. Everything after this point is attributable.
@@ -346,7 +371,7 @@ def pytest_configure(config: pytest.Config) -> None:
     """Keep the guard's warnings visible even under a strict filter set."""
     if _GUARD is None:
         return
-    config.addinivalue_line("filterwarnings", "always::pytest.PytestWarning")
+    config.addinivalue_line("filterwarnings", f"always::{__name__}.{_SysModulesLeakWarning.__name__}")
 
 
 def pytest_plugin_registered(plugin: object, manager: object) -> None:
@@ -391,7 +416,7 @@ def pytest_make_collect_report(collector: pytest.Collector) -> Iterator[None]:
         return
     path = Path(str(collector.path))
     phase = "the collection of" if path.is_dir() else "the import of"
-    _GUARD.check(path, f"{phase} {_display(path, _GUARD._rootdir)}")
+    _GUARD.check(path, f"{phase} {_display(path, _GUARD.rootdir)}")
     _GUARD.snapshot()
     try:
         yield
@@ -427,6 +452,13 @@ def pytest_runtest_protocol(item: pytest.Item, nextitem: object) -> Iterator[Non
 # Records collected from workers. Empty in a serial run, where the controller
 # and the detector are the same process and ``_GUARD.records()`` is used.
 _WORKER_RECORDS: list[dict] = []
+
+# ``(key, owner)`` of every record already merged.  Each worker checks the same
+# stub against its own share of the nodes, so the same escape arrives from
+# several of them with a different ``observed_at``; a full-dict comparison
+# treats those as distinct and inflates the reported key count.  The first
+# observation is the one kept, matching the serial path's ``_reported``.
+_WORKER_TOKENS: set[tuple[str, str]] = set()
 
 
 def _all_records() -> list[dict]:
@@ -472,8 +504,11 @@ def pytest_testnodedown(node: object, error: object) -> None:
     """
     output = getattr(node, "workeroutput", None) or {}
     for record in output.get("sys_modules_leaks", []):
-        if record not in _WORKER_RECORDS:
-            _WORKER_RECORDS.append(record)
+        token = (record["key"], record["owner"])
+        if token in _WORKER_TOKENS:
+            continue  # another worker saw the same stub at a different nodeid
+        _WORKER_TOKENS.add(token)
+        _WORKER_RECORDS.append(record)
 
 
 # ---------------------------------------------------------------------------

--- a/repo_tests/sys_modules_leak_guard.py
+++ b/repo_tests/sys_modules_leak_guard.py
@@ -247,6 +247,8 @@ class _LeakGuard:
         unconditionally would blame the level above and make every stub look
         like it never escapes.
         """
+        if self._matches_baseline():
+            return
         current = sys.modules.copy()
         changed = self._changed_since(current)
         self._baseline = current
@@ -269,6 +271,26 @@ class _LeakGuard:
                 obj_id=id(module),
                 owner_ancestors=owner_ancestors,
             )
+
+    def _matches_baseline(self) -> bool:
+        """True when nothing in ``sys.modules`` moved since the last baseline.
+
+        Most collectors import nothing — every ``Class`` node, every directory
+        that only lists its children — and this answers them with one C-level
+        dict comparison instead of a copy plus a Python pass over every entry
+        (0.065 ms against 0.390 ms at 3600 entries).  Under xdist every worker
+        collects the whole suite, so this is the guard's most repeated call.
+
+        CPython compares dict values with an identity short-circuit, so equal
+        entries never reach a user-defined ``__eq__``.  A *differing* entry
+        can, a Python ``__eq__`` can release the GIL, and a concurrent import
+        then makes the comparison raise; falling back to ``False`` runs the
+        full copy-and-scan below, which is the correct answer either way.
+        """
+        try:
+            return sys.modules == self._baseline
+        except Exception:  # noqa: BLE001 - any failure just means "do the full scan"
+            return False
 
     def _changed_since(self, current: dict[str, object]) -> list[tuple[str, object, object]]:
         """Entries that are new or now bound to a different object.

--- a/repo_tests/sys_modules_leak_guard.py
+++ b/repo_tests/sys_modules_leak_guard.py
@@ -80,12 +80,18 @@ class _Mutation:
     owner_dir: Path
     owner_dir_display: str
     obj_id: int
+    # ``owner_dir.parents`` as a set, built once here rather than on every
+    # comparison.  ``Path.parents`` is a lazy sequence with no ``__contains__``,
+    # so ``x in path.parents`` walks it and constructs a fresh ``Path`` per
+    # level; at ~66 tracked stubs times ~1200 checks that was 640k throwaway
+    # ``Path`` objects and the single most expensive thing the guard did.
+    owner_ancestors: frozenset[Path]
 
     def is_live(self) -> bool:
         """True while the installed object is still the one in ``sys.modules``."""
         return id(sys.modules.get(self.key)) == self.obj_id
 
-    def escapes_to(self, path: Path | None) -> bool:
+    def escapes_to(self, path: Path | None, path_parents: frozenset[Path]) -> bool:
         """True when *path* is outside the directory that owns this stub.
 
         A strict *ancestor* directory is not an escape, and treating it as one
@@ -102,12 +108,15 @@ class _Mutation:
         Only *directories* are exempted.  A file sitting directly in an
         ancestor directory is never a member of ``owner_dir.parents``, so
         sibling modules one level up are still checked.
+
+        *path_parents* is ``path.parents`` as a set; the caller builds it once
+        per check and shares it across every tracked mutation.
         """
         if path is None:
             return False
-        if path == self.owner_dir or self.owner_dir in path.parents:
+        if path == self.owner_dir or self.owner_dir in path_parents:
             return False  # inside the owner's own subtree
-        if path in self.owner_dir.parents:
+        if path in self.owner_ancestors:
             return False  # a structural ancestor Dir node imports nothing
         return True
 
@@ -246,6 +255,7 @@ class _LeakGuard:
         owner = _display(owner_file, self._rootdir)
         owner_dir = owner_file if owner_file.is_dir() else owner_file.parent
         owner_dir_display = _display(owner_dir, self._rootdir)
+        owner_ancestors = frozenset(owner_dir.parents)
         for name, module, previous in changed:
             kind = self._classify(name, module, previous)
             if kind is None:
@@ -257,24 +267,28 @@ class _LeakGuard:
                 owner_dir=owner_dir,
                 owner_dir_display=owner_dir_display,
                 obj_id=id(module),
+                owner_ancestors=owner_ancestors,
             )
 
     def _changed_since(self, current: dict[str, object]) -> list[tuple[str, object, object]]:
         """Entries that are new or now bound to a different object.
 
-        This loop is the whole plugin's hot path, so it stays free of Python
-        calls: a C-level ``dict.get`` and an identity compare per entry.
-        Handing every module to ``_classify`` instead called it 443,487 times
-        for a 103-test session, since only a handful of keys ever change while
-        the scan is over all ~3600.
+        This is the whole plugin's hot path — one pass over every entry
+        ``sys.modules`` holds, on every collector and every test — so it stays
+        free of Python-level calls: a C ``dict.get`` and an identity compare
+        per entry, inside a comprehension rather than a statement loop
+        (measured 0.290 ms against 0.385 ms at 3600 entries).  Handing every
+        module to ``_classify`` instead called it 443,487 times for a
+        103-test session, since only a handful of keys ever change while the
+        scan has to cover all of them.
+
+        The bindings are gathered in a second pass because the first has to
+        stay as narrow as possible and the second runs over the 0-5 names that
+        actually changed.
         """
-        baseline = self._baseline
-        changed = []
-        for name, module in current.items():
-            previous = baseline.get(name, _MISSING)
-            if previous is not module:
-                changed.append((name, module, previous))
-        return changed
+        previous_of = self._baseline.get
+        changed = [name for name, module in current.items() if previous_of(name, _MISSING) is not module]
+        return [(name, current[name], previous_of(name, _MISSING)) for name in changed]
 
     def _classify(self, name: str, module: object, previous: object) -> str | None:
         """Return ``"replaced"``/``"synthetic"`` for a suspicious changed entry.
@@ -329,12 +343,19 @@ class _LeakGuard:
         return _resolves_on_disk(name)
 
     def check(self, path: Path | None, observed_at: str) -> None:
-        """Report every tracked stub still live while pytest works on *path*."""
+        """Report every tracked stub still live while pytest works on *path*.
+
+        ``path.parents`` is materialised once here and shared with every
+        tracked mutation rather than rebuilt inside each comparison.
+        """
+        if not self._tracked:
+            return
+        path_parents = frozenset(path.parents) if path is not None else frozenset()
         for mutation in list(self._tracked.values()):
             if not mutation.is_live():
                 self._tracked.pop(mutation.key, None)
                 continue
-            if not mutation.escapes_to(path):
+            if not mutation.escapes_to(path, path_parents):
                 continue
             token = (mutation.key, mutation.owner)
             if token in self._reported:

--- a/repo_tests/sys_modules_leak_guard_session_test.py
+++ b/repo_tests/sys_modules_leak_guard_session_test.py
@@ -1,0 +1,257 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Nested-session cover for the sys.modules leak guard (#13361).
+
+The unit tests next door drive ``_LeakGuard`` directly.  That is fast and
+precise, but it cannot see any of the three defects review found in the first
+cut of this plugin, because every one of them lives in the *plumbing* rather
+than the classifier:
+
+* the warning class lied about its ``__module__``, so xdist's controller-side
+  ``unserialize_warning_message`` blew up and took the whole session down with
+  ``INTERNALERROR`` — the exact #13320 failure mode the guard exists to prevent;
+* the collect hookwrapper was not ``tryfirst``, so a *hook-installed* stub —
+  the very pattern #13361 tells implementers to adopt — was already in place
+  when the baseline snapshot was taken, and the guard reported nothing;
+* detection runs in xdist workers while reporting runs on the controller, so
+  ``AUTOBOT_SYSMODULES_GUARD=error`` was a no-op under ``-n``, which is the only
+  shape CI uses.
+
+So these tests run real pytest sessions against a scratch repo.  Each builds a
+two-package tree — ``pkg_a`` leaks, ``pkg_b`` is the innocent importer — and
+asserts on the child session's own output.  Kept small deliberately: every test
+here finishes in a couple of seconds.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+_GUARD_MODULE = "repo_tests.sys_modules_leak_guard"
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_TIMEOUT = 120
+
+_ROOT_CONFTEST = f"""
+import sys
+sys.path.insert(0, {str(_REPO_ROOT)!r})
+pytest_plugins = ["{_GUARD_MODULE}"]
+"""
+
+_PYTEST_INI = """
+[pytest]
+python_files = test_*.py
+addopts = -p no:randomly
+"""
+
+# The name the leaking conftest shadows. A real package of this name is written
+# into the scratch repo so the guard's "does this shadow anything?" probe says
+# yes — see _resolves_on_disk.
+_VICTIM = "victim"
+
+_IMPORT_TIME_LEAK = f"""
+import sys, types
+sys.modules[{_VICTIM!r}] = types.ModuleType({_VICTIM!r})
+"""
+
+# The shape #13361 mandates: install and restore from a hookwrapper. This one
+# is deliberately buggy — it installs but never restores — which is precisely
+# the regression the guard has to be able to see.
+_HOOK_INSTALLED_LEAK = f"""
+import sys, types
+import pytest
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_make_collect_report(collector):
+    sys.modules[{_VICTIM!r}] = types.ModuleType({_VICTIM!r})
+    yield
+"""
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(text).lstrip(), encoding="utf-8")
+
+
+@pytest.fixture
+def scratch_repo(tmp_path: Path):
+    """Build a minimal two-package repo and return a factory for its conftest."""
+    _write(tmp_path / "pytest.ini", _PYTEST_INI)
+    _write(tmp_path / "conftest.py", _ROOT_CONFTEST)
+    _write(tmp_path / _VICTIM / "__init__.py", "REAL = True\n")
+    for pkg in ("pkg_a", "pkg_b"):
+        _write(tmp_path / pkg / f"test_{pkg}.py", "def test_ok():\n    assert True\n")
+
+    def seed(leak_source: str) -> Path:
+        _write(tmp_path / "pkg_a" / "conftest.py", leak_source)
+        return tmp_path
+
+    return seed
+
+
+def _run_pytest(cwd: Path, *args: str, env_extra: dict | None = None) -> subprocess.CompletedProcess:
+    """Run a child pytest session in *cwd* and capture everything it printed.
+
+    Plugin autoload is off so the child does not pay for coverage, anyio,
+    asyncio and friends on every one of these sessions — it keeps each test
+    comfortably inside the suite's per-test budget.  ``xdist`` is re-enabled
+    explicitly by the callers that need ``-n``.
+    """
+    import os
+
+    env = dict(os.environ)
+    env.pop("AUTOBOT_SYSMODULES_GUARD", None)
+    env["PYTEST_DISABLE_PLUGIN_AUTOLOAD"] = "1"
+    env.update(env_extra or {})
+    return subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "-q",
+            "--no-header",
+            "-p",
+            "no:cacheprovider",
+            "pkg_a",
+            "pkg_b",
+            *args,
+        ],
+        cwd=str(cwd),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=_TIMEOUT,
+        check=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# G2 — the guard must see the pattern it tells everyone to adopt
+# ---------------------------------------------------------------------------
+
+
+def test_reports_an_import_time_leak(scratch_repo):
+    """The original shape: a conftest mutating sys.modules at import."""
+    result = _run_pytest(scratch_repo(_IMPORT_TIME_LEAK))
+
+    assert "LEAK:" in result.stdout, result.stdout
+    assert _VICTIM in result.stdout
+
+
+def test_reports_a_hook_installed_leak_that_never_restores(scratch_repo):
+    """A hookwrapper that installs but forgets to restore must still be caught.
+
+    This is the regression shape for every conftest converted to the pattern
+    #13361 mandates.  Before ``tryfirst``, the leaking wrapper ran outside the
+    guard's, its stub landed in the baseline, and this produced zero LEAK lines.
+    """
+    result = _run_pytest(scratch_repo(_HOOK_INSTALLED_LEAK))
+
+    assert "LEAK:" in result.stdout, result.stdout
+    assert _VICTIM in result.stdout
+
+
+def test_stays_silent_when_the_hookwrapper_restores_properly(scratch_repo):
+    """The correct pattern must not be reported — a noisy guard gets disabled."""
+    correct = f"""
+        import sys, types
+        import pytest
+
+
+        @pytest.hookimpl(hookwrapper=True)
+        def pytest_make_collect_report(collector):
+            prior = sys.modules.get({_VICTIM!r})
+            sys.modules[{_VICTIM!r}] = types.ModuleType({_VICTIM!r})
+            try:
+                yield
+            finally:
+                if prior is None:
+                    sys.modules.pop({_VICTIM!r}, None)
+                else:
+                    sys.modules[{_VICTIM!r}] = prior
+    """
+    result = _run_pytest(scratch_repo(correct))
+
+    assert "LEAK:" not in result.stdout, result.stdout
+    assert result.returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# G1 / G3 — the guard must survive xdist, and gate under it
+# ---------------------------------------------------------------------------
+
+
+def _xdist_or_skip() -> None:
+    pytest.importorskip("xdist", reason="pytest-xdist is required for the controller tests")
+
+
+def test_a_leak_warning_does_not_crash_the_xdist_controller(scratch_repo):
+    """The warning must round-trip worker -> controller.
+
+    xdist rebuilds worker warnings on the controller by importing the module
+    the worker named.  A dishonest ``__module__`` makes that ``getattr`` fail,
+    the node goes down, and the entire session is lost to ``INTERNALERROR`` —
+    losing every result, which is #13320 all over again.
+    """
+    _xdist_or_skip()
+    result = _run_pytest(scratch_repo(_IMPORT_TIME_LEAK), "-p", "xdist", "-n", "2", "--dist", "loadscope")
+
+    assert "INTERNALERROR" not in result.stdout + result.stderr, result.stdout + result.stderr
+    assert "_SysModulesLeakWarning" not in result.stderr
+    assert result.returncode != 3, "exit 3 means the session died before reporting"
+
+
+def test_error_mode_fails_the_run_under_xdist(scratch_repo):
+    """``AUTOBOT_SYSMODULES_GUARD=error`` must gate under ``-n``, not just serially.
+
+    Detection happens in the workers; the exit status and the terminal section
+    are decided on the controller.  Without the worker->controller hand-off this
+    passed cleanly with no section printed.
+    """
+    _xdist_or_skip()
+    repo = scratch_repo(_IMPORT_TIME_LEAK)
+    result = _run_pytest(
+        repo, "-p", "xdist", "-n", "2", "--dist", "loadscope", env_extra={"AUTOBOT_SYSMODULES_GUARD": "error"}
+    )
+
+    assert "LEAK:" in result.stdout, result.stdout
+    assert result.returncode == 1, f"expected a failing exit status, got {result.returncode}"
+
+
+def test_error_mode_fails_the_run_serially(scratch_repo):
+    """The same gate, without xdist — the serial path must keep working."""
+    result = _run_pytest(scratch_repo(_IMPORT_TIME_LEAK), env_extra={"AUTOBOT_SYSMODULES_GUARD": "error"})
+
+    assert "LEAK:" in result.stdout, result.stdout
+    assert result.returncode == 1
+
+
+def test_survives_a_session_without_pytest_xdist(scratch_repo):
+    """The guard must not take down a run that has no xdist at all.
+
+    ``pytest_testnodedown`` is an xdist hookspec.  Declared without
+    ``optionalhook``, pluggy's ``check_pending()`` rejects it as an unknown
+    hook and kills the session at collection with ``PluginValidationError`` —
+    on every CI job that installs bare pytest.  These child sessions run with
+    plugin autoload disabled and no ``-p xdist``, which is exactly that shape.
+    """
+    result = _run_pytest(scratch_repo(_IMPORT_TIME_LEAK))
+
+    assert "PluginValidationError" not in result.stdout, result.stdout
+    assert "INTERNALERROR" not in result.stdout
+    assert "LEAK:" in result.stdout
+
+
+def test_off_mode_disables_everything(scratch_repo):
+    """The escape hatch has to actually escape."""
+    result = _run_pytest(scratch_repo(_IMPORT_TIME_LEAK), env_extra={"AUTOBOT_SYSMODULES_GUARD": "off"})
+
+    assert "LEAK:" not in result.stdout
+    assert result.returncode == 0

--- a/repo_tests/sys_modules_leak_guard_session_test.py
+++ b/repo_tests/sys_modules_leak_guard_session_test.py
@@ -96,7 +96,12 @@ def scratch_repo(tmp_path: Path):
     return seed
 
 
-def _run_pytest(cwd: Path, *args: str, env_extra: dict | None = None) -> subprocess.CompletedProcess:
+def _run_pytest(
+    cwd: Path,
+    *args: str,
+    env_extra: dict | None = None,
+    targets: tuple[str, ...] = ("pkg_a", "pkg_b"),
+) -> subprocess.CompletedProcess:
     """Run a child pytest session in *cwd* and capture everything it printed.
 
     Plugin autoload is off so the child does not pay for coverage, anyio,
@@ -119,8 +124,7 @@ def _run_pytest(cwd: Path, *args: str, env_extra: dict | None = None) -> subproc
             "--no-header",
             "-p",
             "no:cacheprovider",
-            "pkg_a",
-            "pkg_b",
+            *targets,
             *args,
         ],
         cwd=str(cwd),
@@ -181,6 +185,37 @@ def test_stays_silent_when_the_hookwrapper_restores_properly(scratch_repo):
 
     assert "LEAK:" not in result.stdout, result.stdout
     assert result.returncode == 0
+
+
+def test_stays_silent_when_the_leaking_package_is_the_whole_session(scratch_repo):
+    """A leak that reaches nobody is not a leak — not even the rootdir node.
+
+    ``pkg_a`` leaks at import time, but the session collects nothing else, so
+    the stub never reaches a sibling and there is nothing to report.  Pytest
+    still builds a ``Dir`` collector for every level from the rootdir down,
+    including ``.``, and that node used to count as "outside ``pkg_a``/" —
+    which made every clean session fail under ``error`` mode and, because the
+    ancestor node always wins the per-``(key, owner)`` dedupe, replaced the
+    ``first seen at`` sibling with the meaningless ``the collection of .``.
+    """
+    result = _run_pytest(scratch_repo(_IMPORT_TIME_LEAK), targets=("pkg_a",))
+
+    assert "LEAK:" not in result.stdout, result.stdout
+    assert result.returncode == 0, result.stdout
+
+
+def test_the_first_sighting_names_the_sibling_not_the_rootdir(scratch_repo):
+    """``first seen at`` is the actionable half of the report — it must be real.
+
+    The rootdir ``Dir`` node is collected before any sibling, so while it
+    counted as an escape it always claimed this slot and pointed every
+    offender at ``.`` instead of at the package that inherited the stub.
+    """
+    result = _run_pytest(scratch_repo(_IMPORT_TIME_LEAK))
+
+    assert "LEAK:" in result.stdout, result.stdout
+    assert "first seen at the collection of ." not in result.stdout, result.stdout
+    assert "pkg_b" in result.stdout, result.stdout
 
 
 # ---------------------------------------------------------------------------

--- a/repo_tests/sys_modules_leak_guard_session_test.py
+++ b/repo_tests/sys_modules_leak_guard_session_test.py
@@ -75,6 +75,27 @@ def pytest_make_collect_report(collector):
 """
 
 
+# An ini that silences one PytestWarning subclass. The guard appends its own
+# entry to "filterwarnings" and the last matching entry wins, so a guard filter
+# written against a base class would override this and un-silence it.
+_PYTEST_INI_WITH_IGNORE = """
+[pytest]
+python_files = test_*.py
+addopts = -p no:randomly
+filterwarnings =
+    ignore::pytest.PytestUnknownMarkWarning
+"""
+
+_UNKNOWN_MARK_TEST = """
+import pytest
+
+
+@pytest.mark.a_marker_nobody_registered
+def test_ok():
+    assert True
+"""
+
+
 def _write(path: Path, text: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(textwrap.dedent(text).lstrip(), encoding="utf-8")
@@ -216,6 +237,26 @@ def test_the_first_sighting_names_the_sibling_not_the_rootdir(scratch_repo):
     assert "LEAK:" in result.stdout, result.stdout
     assert "first seen at the collection of ." not in result.stdout, result.stdout
     assert "pkg_b" in result.stdout, result.stdout
+
+
+def test_the_guard_does_not_widen_other_pytest_warnings(scratch_repo):
+    """The guard must not change warning behaviour for the rest of the suite.
+
+    ``addinivalue_line`` appends to ``filterwarnings`` and the last matching
+    entry wins, so an entry written against ``pytest.PytestWarning`` silently
+    overrode any ini-level ``ignore`` of *any* subclass of it and flipped
+    every pytest warning from "once per location" to "always".  The guard's
+    entry names only its own warning class, so this repo's
+    ``ignore::pytest.PytestUnknownMarkWarning`` still holds.
+    """
+    repo = scratch_repo(_IMPORT_TIME_LEAK)
+    _write(repo / "pytest.ini", _PYTEST_INI_WITH_IGNORE)
+    _write(repo / "pkg_b" / "test_pkg_b.py", _UNKNOWN_MARK_TEST)
+
+    result = _run_pytest(repo)
+
+    assert "PytestUnknownMarkWarning" not in result.stdout, result.stdout
+    assert "LEAK:" in result.stdout, result.stdout  # the guard is still active
 
 
 # ---------------------------------------------------------------------------

--- a/repo_tests/sys_modules_leak_guard_test.py
+++ b/repo_tests/sys_modules_leak_guard_test.py
@@ -1,0 +1,238 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Unit cover for the repo-wide sys.modules leak guard (#13337).
+
+The guard's whole value is that it fires on a real leak and stays silent on
+everything else, so both halves are pinned here.  The classifier and the
+escape rule are exercised directly against a throwaway ``sys.modules`` — no
+nested pytest session, so every test finishes in milliseconds.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+import warnings
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from repo_tests.sys_modules_leak_guard import _DISK_CACHE, _LeakGuard
+
+_ROOT = Path("/repo")
+_LLC_CONFTEST = _ROOT / "backend" / "llc" / "tests" / "conftest.py"
+_OTHER_MODULE = _ROOT / "backend" / "initialization" / "lifespan_test.py"
+
+
+@pytest.fixture
+def guard(monkeypatch):
+    """A guard over an isolated ``sys.modules`` copy.
+
+    ``_DISK_CACHE`` is pre-seeded so the tests never depend on what happens to
+    be installed on the machine running them.
+    """
+    monkeypatch.setattr(sys, "modules", dict(sys.modules))
+    monkeypatch.setattr(
+        "repo_tests.sys_modules_leak_guard._DISK_CACHE",
+        dict(_DISK_CACHE, agents=True, autobot_shared=True, celery=True, knowledge=True, _sodium=False),
+    )
+    instance = _LeakGuard(_ROOT)
+    instance.snapshot()
+    return instance
+
+
+def _install(name: str, module: object) -> None:
+    sys.modules[name] = module  # type: ignore[assignment]
+
+
+def _leaks_for(guard: _LeakGuard, path: Path) -> list[str]:
+    """Run a check with warnings suppressed and return the leaked keys."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        guard.check(path, f"the import of {path.name}")
+    return [leak.mutation.key for leak in guard.leaks]
+
+
+# ---------------------------------------------------------------------------
+# It fires on the three leak shapes that actually happened
+# ---------------------------------------------------------------------------
+
+
+def test_reports_a_synthetic_top_level_stub_reaching_a_sibling(guard):
+    """The #13337 shape: an ``agents`` stub live while a sibling is imported."""
+    _install("agents", types.ModuleType("agents"))
+    guard.attribute(_LLC_CONFTEST)
+
+    assert _leaks_for(guard, _OTHER_MODULE) == ["agents"]
+
+
+def test_reports_a_replaced_real_module(guard):
+    """The #13324 shape: ``autobot_shared`` swapped for a bare MagicMock."""
+    _install("autobot_shared", types.ModuleType("autobot_shared"))
+    guard.snapshot()
+    _install("autobot_shared", MagicMock())
+    guard.attribute(_LLC_CONFTEST)
+
+    assert _leaks_for(guard, _OTHER_MODULE) == ["autobot_shared"]
+
+
+def test_the_message_names_the_key_the_owner_and_the_importer(guard):
+    """A silent or vague guard is worthless — the report must be actionable."""
+    _install("agents", types.ModuleType("agents"))
+    guard.attribute(_LLC_CONFTEST)
+    _leaks_for(guard, _OTHER_MODULE)
+
+    described = guard.leaks[0].describe()
+    assert "'agents'" in described
+    assert "backend/llc/tests/conftest.py" in described
+    assert "lifespan_test.py" in described
+
+
+def test_a_leak_raises_a_pytest_warning(guard):
+    """The warning is the machine-readable half of "report loudly"."""
+    _install("agents", types.ModuleType("agents"))
+    guard.attribute(_LLC_CONFTEST)
+
+    with pytest.warns(pytest.PytestWarning, match="agents"):
+        guard.check(_OTHER_MODULE, "the import of lifespan_test.py")
+
+
+# ---------------------------------------------------------------------------
+# It stays silent on everything that is not a leak
+# ---------------------------------------------------------------------------
+
+
+def test_a_stub_used_only_inside_its_own_directory_is_not_a_leak(guard):
+    """Scoped stubs are the correct pattern and must never be reported."""
+    _install("agents", types.ModuleType("agents"))
+    guard.attribute(_LLC_CONFTEST)
+
+    sibling = _LLC_CONFTEST.parent / "test_something.py"
+    assert _leaks_for(guard, sibling) == []
+
+
+def test_a_parent_directorys_stub_covers_its_whole_subtree(guard):
+    """``autobot-backend/conftest.py`` legitimately stubs for everything below."""
+    backend_conftest = _ROOT / "backend" / "conftest.py"
+    _install("celery", types.ModuleType("celery"))
+    guard.attribute(backend_conftest)
+
+    assert _leaks_for(guard, _OTHER_MODULE) == []
+
+
+def test_an_ordinary_import_is_never_reported(guard, tmp_path):
+    """A module the import system loaded has a ``__spec__`` and is left alone."""
+    real = types.ModuleType("some_real_module")
+    real.__spec__ = object()  # type: ignore[assignment]
+    real.__file__ = str(tmp_path / "some_real_module.py")
+    _install("some_real_module", real)
+    guard.attribute(_LLC_CONFTEST)
+
+    assert _leaks_for(guard, _OTHER_MODULE) == []
+
+
+def test_extension_pseudo_submodules_are_not_stubs(guard):
+    """``_sodium.lib``/``xml.parsers.expat.errors`` have no spec but are real."""
+    parent = types.ModuleType("_sodium")
+    parent.__spec__ = object()  # type: ignore[assignment]
+    _install("_sodium", parent)
+    guard.snapshot()
+    _install("_sodium.lib", types.ModuleType("_sodium.lib"))
+    guard.attribute(_LLC_CONFTEST)
+
+    assert _leaks_for(guard, _OTHER_MODULE) == []
+
+
+def test_a_cffi_pseudo_module_is_not_a_stub(guard):
+    """``_openssl`` is specless, loaderless and fileless — and not a stub.
+
+    Nothing named ``_openssl`` exists on ``sys.path``, so it shadows nothing
+    and reporting it would be pure noise.
+    """
+    _install("_openssl", types.ModuleType("_openssl"))
+    guard.attribute(_LLC_CONFTEST)
+
+    assert _leaks_for(guard, _OTHER_MODULE) == []
+
+
+def test_a_synthetic_child_of_a_real_package_is_still_a_stub(guard):
+    """Stubbing one submodule of real code is a leak like any other."""
+    parent = types.ModuleType("knowledge")
+    parent.__spec__ = object()  # type: ignore[assignment]
+    _install("knowledge", parent)
+    guard.snapshot()
+    _install("knowledge.utils", types.ModuleType("knowledge.utils"))
+    guard.attribute(_LLC_CONFTEST)
+
+    assert _leaks_for(guard, _OTHER_MODULE) == ["knowledge.utils"]
+
+
+def test_a_restored_stub_stops_being_reported(guard):
+    """Once the owner puts the real module back there is nothing to report."""
+    _install("agents", types.ModuleType("agents"))
+    guard.attribute(_LLC_CONFTEST)
+    del sys.modules["agents"]
+
+    assert _leaks_for(guard, _OTHER_MODULE) == []
+
+
+class _MutatingModules(dict):
+    """A ``sys.modules`` stand-in that grows while its live view is iterated.
+
+    Reproduces deterministically what a background thread importing during a
+    snapshot does: iterating the live view and inserting mid-way is exactly the
+    condition CPython raises ``RuntimeError: dictionary changed size during
+    iteration`` on.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.counter = 0
+
+    def items(self):
+        for index, pair in enumerate(super().items()):
+            if index == 1:
+                self.counter += 1
+                super().__setitem__(f"late_import_{self.counter}", types.ModuleType("late"))
+            yield pair
+
+
+def _mutating_modules() -> _MutatingModules:
+    return _MutatingModules({f"mod_{n}": types.ModuleType(f"mod_{n}") for n in range(6)})
+
+
+def test_the_mutating_stand_in_really_reproduces_the_race():
+    """Control: iterating this stand-in's live view must raise, or the next test proves nothing."""
+    with pytest.raises(RuntimeError, match="changed size during iteration"):
+        list(_mutating_modules().items())
+
+
+def test_snapshotting_survives_a_concurrent_import(monkeypatch):
+    """``snapshot``/``attribute`` must copy ``sys.modules`` before iterating.
+
+    Iterating a live ``sys.modules`` view races with any import on another
+    thread — the suite's analytics and celery task tests spawn them — and the
+    loser gets ``RuntimeError`` raised inside a pytest hook.  Under xdist that
+    kills the worker and takes the whole session down with ``INTERNALERROR``:
+    observed as ``1 failed, 224 passed`` plus ``INTERNALERROR`` where the same
+    run without the guard gives ``1 failed, 255 passed``.
+    """
+    mutating = _mutating_modules()
+    monkeypatch.setattr(sys, "modules", mutating)
+
+    instance = _LeakGuard(_ROOT)
+    instance.snapshot()
+    instance.attribute(_LLC_CONFTEST)
+
+
+def test_each_leak_is_reported_once_not_once_per_test(guard):
+    """Thousands of duplicate lines would bury the finding."""
+    _install("agents", types.ModuleType("agents"))
+    guard.attribute(_LLC_CONFTEST)
+
+    _leaks_for(guard, _OTHER_MODULE)
+    _leaks_for(guard, _OTHER_MODULE.parent / "another_test.py")
+
+    assert [leak.mutation.key for leak in guard.leaks] == ["agents"]


### PR DESCRIPTION
## Thinking Path

Split out of PR #13359 on review. That PR carried two verified fixes plus this detector; the detector had three defects, one of which red-lined the python-suite gate, so the fixes landed on their own and the guard came here. Everything below is the guard only.

The rule it enforces is the one all four known instances of this family break:

> A stub installed by a conftest or test module under directory *D* must not still be live while pytest imports or runs anything outside *D*.

Deliberately narrow. A conftest legitimately stubbing heavy dependencies for its own subtree is never reported, because the owner directory covers every node it affects. It fires only when a stub reaches into a sibling.

**Review found three defects; building the tests that would have caught them found two more.** All five are fixed and pinned. The common thread review identified was exact: the original 12 tests all drove `_LeakGuard` directly, so nothing in the *plumbing* was covered. Every one of the five lives in the plumbing.

**G1 — the guard reintroduced the failure it exists to prevent.** `_SysModulesLeakWarning.__module__ = "pytest"` was a display convenience. xdist rebuilds worker warnings on the controller via `unserialize_warning_message` → `getattr(importlib.import_module(module), class_name)`, so the lie sent `("pytest", "_SysModulesLeakWarning")` and the controller died:

    AttributeError: module 'pytest' has no attribute '_SysModulesLeakWarning'
    [gw0] node down
    exit=3          # no results at all

That is #13320 verbatim — the incident this guard's own docstring cites as its justification. Removed; subclass-based `filterwarnings` entries match on the class hierarchy and never needed it.

**G2 — the guard was blind to the pattern it mandates.** `pytest_make_collect_report` was a plain `hookwrapper`, so pluggy could order a leaking conftest's wrapper *outside* it: the stub was already installed when `snapshot()` ran, landed in the baseline, and produced an empty delta. Combined with an early-return for every non-`pytest.Module` collector — which is where a hook-installed stub is actually created — a faithful reproduction of the #13361 shape produced **zero** LEAK lines. Now `tryfirst=True` (outermost, so the snapshot precedes any inner install and the attribution follows every inner restore), every collector bracketed, `owner_dir` is the path itself for a directory node, and `pytest_runtest_protocol` is a wrapper too — `pytest_runtest_setup` only ever *checked*, never attributed.

**G3 — `error` mode was a no-op under xdist.** Detection runs in workers; the exit status and terminal section are decided on the controller, where `_GUARD.leaks` is empty. Serial gave `exit=1` with the section; `-n 2` gave `exit=0` and nothing printed — and `-n` is the only shape CI uses. Now leaks travel as plain dicts through `config.workeroutput` and are merged by `pytest_testnodedown`.

**G4 (found by the new tests) — the guard broke every xdist-less run.** `pytest_testnodedown` is an xdist hookspec. Declared without `optionalhook`, pluggy's `check_pending()` rejects it and kills the session at collection with `PluginValidationError: unknown hook`. pytest.ini notes that several CI jobs install bare pytest, so this would have broken all of them. Fixed with `@pytest.hookimpl(optionalhook=True)`.

**G5 (found by re-running the real suite) — a race that killed xdist workers.** `snapshot()` iterated a live `sys.modules` view. The analytics and celery task tests spawn threads that import, and the loser of that race gets `RuntimeError: dictionary changed size during iteration` raised inside a hook — which under xdist kills the worker and takes the session down. Observed as `1 failed, 224 passed` + `INTERNALERROR` where the same run without the guard gives `1 failed, 255 passed`. Now `sys.modules.copy()` first, in both `snapshot()` and `attribute()`; `dict.copy()` is a single C-level operation and cannot be torn.

Two false positives were also eliminated against the real tree. pytest registers every `conftest.py` under the bare name `conftest` without `--import-mode=importlib`, so each new one *replaces* the last — its own bookkeeping, never a stub. And the `replaced` branch bypassed the "does this shadow anything real?" test, flagging `zero_downtime_deploy_under_test`, a name a test invents via `spec_from_file_location` and that exists nowhere on disk. Both gates now apply uniformly; all four historical leaks shadow installed packages (`sqlalchemy`, `autobot_shared`, `agents`, `chromadb`) and are unaffected.

## What Changed

**`repo_tests/sys_modules_leak_guard.py` (new)**
- Attributes each conftest's and each test module's `sys.modules` delta, tracks only *replaced* or *synthetic* entries that could shadow something which actually exists on disk, and reports any still live while pytest works outside the owner's directory.
- Reports loudly: a `PytestWarning` (once per owner, not once per key) plus a dedicated red terminal section naming the offending keys, the owning file and the observing import. Grouped per owner, so one escaping conftest is 2 lines rather than 62.
- `AUTOBOT_SYSMODULES_GUARD=error` fails the session, serially and under xdist; `=off` disables it. Default is report-only because the guard immediately finds the pre-existing #13361 leak.
- Built at *import* time, not in `pytest_configure` — initial-argument conftests load before configure, and those are exactly the mutations worth catching.
- C-extension pseudo-modules (`_openssl`, `cython_runtime`, `_sodium.lib`) are indistinguishable from hand-built stubs by attribute, so the discriminator is whether the name resolves on `sys.path` at all. A stub for something not installed shadows nothing.

**`conftest.py`** — registers the plugin from the rootdir conftest, the only conftest where `pytest_plugins` is still legal in pytest ≥ 9, and an ancestor of every argument so it registers before any other conftest.

**`repo_tests/sys_modules_leak_guard_test.py` (new, 14 tests)** — classifier and escape rule against an isolated `sys.modules`, plus the race regression with a control test proving the stand-in reproduces it.

**`repo_tests/sys_modules_leak_guard_session_test.py` (new, 8 tests)** — real child pytest sessions against a scratch two-package repo (`pkg_a` leaks, `pkg_b` imports). This is the layer that was missing.

## Verification

**G1 — xdist controller.** Before: `INTERNALERROR ... AttributeError: module 'pytest' has no attribute '_SysModulesLeakWarning'`, `exit=3`, no results. After, same command:

    $ pytest autobot-backend/tasks repo_tests -q -n 2 --dist loadscope
    1 failed, 255 passed, 9 warnings, 12 errors in 22.27s
    exit=1

Identical to the same command with `AUTOBOT_SYSMODULES_GUARD=off` (`1 failed, 255 passed, 12 errors, exit=1`) and to the base tree with no guard at all (`1 failed, 255 passed, 12 errors, exit=1`). The guard now costs nothing. (That 1 failure and the 12 errors are the pre-existing #13361 leak and are why this PR does not turn on `error` mode.)

**G2 — the mandated pattern is visible.** In the scratch repo, a conftest that installs from a `pytest_make_collect_report` hookwrapper and never restores previously produced 0 LEAK lines. `test_reports_a_hook_installed_leak_that_never_restores` now passes, and `test_stays_silent_when_the_hookwrapper_restores_properly` confirms the *correct* pattern is not reported (a noisy guard gets switched off).

**G3 — the gate is real under xdist.**

    $ AUTOBOT_SYSMODULES_GUARD=error pytest autobot-backend/tasks -q -n 2 --dist loadscope
    LEAK: autobot-backend/conftest.py leaves 62 sys.modules key(s) installed outside autobot-backend/
          keys: chromadb, chromadb.api, ... (+54 more)
    103 passed, 8 warnings in 20.80s
    exit=1

Section printed, non-zero exit, while the tests themselves passed. Pinned by `test_error_mode_fails_the_run_under_xdist` and its serial twin.

**G5 — negative control.** Re-seeding the live-view iteration makes the race test fail with the exact production symptom, and restoring the fix makes it pass:

    seeded:   E   RuntimeError: dictionary changed size during iteration
              1 failed, 13 passed
    restored: 14 passed

**Suites.**

    $ pytest repo_tests/sys_modules_leak_guard_test.py repo_tests/sys_modules_leak_guard_session_test.py -q
    22 passed in 4.27s

    $ pytest repo_tests -q                              -> 219 passed in 8.44s
    $ pytest repo_tests -q -n 2 --dist loadscope        -> 219 passed in 8.86s, exit=0

Slowest test is 1.42s — the child sessions run with plugin autoload disabled, so none approach the 10s budget. `black --check`, `isort --check-only`, `flake8` clean on all four files.

**What it finds today.** On `pytest autobot-backend/tasks repo_tests` it names #13361 directly: `autobot-backend/conftest.py` leaves 62 keys installed outside `autobot-backend/`, first observed at the import of a `repo_tests` module. CI runs exactly those paths in one invocation.

### Settles the open question in #13361

#13361 asks whether #13086 / PR #13349 (the `tools.__init__` `extend_path` fix) makes this leak harmless or merely masks it. Measured on this branch, with #13349 now in the base:

    $ pytest autobot-backend/tasks repo_tests -q -n 2 --dist loadscope
    322 passed, exit=0          # the 12 tools.lint collection errors are gone
    ... but the guard still reports all 62 leaked keys, unchanged

And `tools` is **not** among the 62 keys — filtering the reported key list for `tools` / `tools.*` returns nothing.

So it is possibility 1 in that issue's wording: the two are **independent**. #13349 fixed the `tools.lint` symptom by making the name resolve under `--import-mode=importlib` regardless of which package binds first; the 62-key leak is untouched and remains a latent hazard for the other 61 names — two of which (`models`, `services`) are exactly the names `pytest.ini` warns collide between the two backends. No merge-order dependency between them.

Guard on versus `AUTOBOT_SYSMODULES_GUARD=off` on that command: both `322 passed, exit=0`. The guard costs nothing on a clean run.

## Model Used

claude-opus-4-6 (Opus 5)

Refs #13361, #13337
