### PR TITLE
fix(webhook): authenticate Telegram webhook before body parse (#13162)

### DIFF
--- a/autobot-backend/api/telegram_bot.py
+++ b/autobot-backend/api/telegram_bot.py
@@ -244,7 +244,37 @@ async def _route_to_chat_and_reply(request: Request, unified_message: Any) -> No
     )
 
 
-@router.post("/telegram/webhook")
+async def verify_telegram_secret(request: Request) -> None:
+    """Authenticate a Telegram webhook call (MVA-2074, GH#9657 fail-closed).
+
+    Declared as a route dependency rather than an in-body check so the secret is
+    verified *before* FastAPI validates the request body: an unauthenticated
+    caller must not be able to probe the payload schema with a 422, and a request
+    that arrives while no webhook secret is stored must fail closed with 503
+    whatever its body looks like.
+    """
+    stored_secret = await get_telegram_webhook_secret()
+    if not stored_secret:
+        logger.error("Telegram webhook secret not configured - failing closed")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Webhook authentication not configured",
+        )
+
+    request_secret = request.headers.get("X-Telegram-Bot-Api-Secret-Token")
+    if not request_secret:
+        logger.warning("Telegram webhook authentication failed - missing secret header")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing authentication header",
+        )
+
+    if not secrets.compare_digest(request_secret, stored_secret):
+        logger.warning("Telegram webhook authentication failed - invalid secret token")
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
+
+
+@router.post("/telegram/webhook", dependencies=[Depends(verify_telegram_secret)])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="telegram_webhook",
@@ -260,7 +290,9 @@ async def telegram_webhook(
     This endpoint is called by Telegram servers when a message is sent to the bot.
     Messages are normalized via TelegramAdapter and routed to AutoBot chat.
 
-    Security: Verifies X-Telegram-Bot-Api-Secret-Token header matches stored secret.
+    Security: Verifies the X-Telegram-Bot-Api-Secret-Token header matches the
+    stored secret, enforced by the ``verify_telegram_secret`` route dependency
+    so authentication runs before the request body is parsed.
 
     Args:
         request: FastAPI request (for header access)
@@ -270,27 +302,6 @@ async def telegram_webhook(
         200 OK to acknowledge receipt
     """
     try:
-        # Verify webhook secret token (MVA-2074 security requirement, GH#9657 fail-closed fix)
-        stored_secret = await get_telegram_webhook_secret()
-        if not stored_secret:
-            logger.error("Telegram webhook secret not configured - failing closed")
-            raise HTTPException(
-                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                detail="Webhook authentication not configured",
-            )
-
-        request_secret = request.headers.get("X-Telegram-Bot-Api-Secret-Token")
-        if not request_secret:
-            logger.warning("Telegram webhook authentication failed - missing secret header")
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Missing authentication header",
-            )
-
-        if request_secret != stored_secret:
-            logger.warning("Telegram webhook authentication failed - invalid secret token")
-            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
-
         # Extract message from update
         message = update.get("message")
         if not message:

--- a/autobot-backend/api/webhook_authentication_security_test.py
+++ b/autobot-backend/api/webhook_authentication_security_test.py
@@ -19,11 +19,34 @@ Target coverage: 100% of authentication paths
 """
 
 import os
+from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi import status
 from fastapi.testclient import TestClient
+
+# Repository root — this file lives at <root>/autobot-backend/api/.
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+WEBHOOK_AUTH_DOC = PROJECT_ROOT / "docs" / "security" / "WEBHOOK_AUTHENTICATION.md"
+
+
+@pytest.fixture(scope="module")
+def client():
+    """TestClient over the real backend application.
+
+    Built through ``app_factory.create_app`` rather than ``from main import app``:
+    the repo root ships a deprecated ``main.py`` shim that exposes no ``app``, and
+    it wins over ``autobot-backend/main.py`` because ``pytest.ini`` puts ``.``
+    ahead of ``autobot-backend`` on ``pythonpath``.
+
+    Module-scoped so the app is built once and, critically, outside the
+    ``patch.dict(os.environ, ..., clear=True)`` blocks the tests below use — the
+    app must not be constructed with a wiped environment.
+    """
+    from app_factory import create_app
+
+    return TestClient(create_app())
 
 
 class TestTelegramWebhookAuthentication:
@@ -49,7 +72,7 @@ class TestTelegramWebhookAuthentication:
         }
 
     @pytest.mark.asyncio
-    async def test_telegram_webhook_fails_closed_when_secret_not_configured(self, valid_telegram_update):
+    async def test_telegram_webhook_fails_closed_when_secret_not_configured(self, client, valid_telegram_update):
         """
         CRITICAL: Telegram webhook MUST return 503 when secret not configured.
         This is the core fail-closed fix from GH#9657.
@@ -60,10 +83,6 @@ class TestTelegramWebhookAuthentication:
             "api.telegram_bot.get_telegram_webhook_secret",
             return_value=None,
         ):
-            from main import app
-
-            client = TestClient(app)
-
             response = client.post(
                 "/api/telegram/webhook",
                 json=valid_telegram_update,
@@ -75,7 +94,7 @@ class TestTelegramWebhookAuthentication:
             assert "not configured" in response.json()["detail"].lower()
 
     @pytest.mark.asyncio
-    async def test_telegram_webhook_returns_401_when_header_missing(self, valid_telegram_update):
+    async def test_telegram_webhook_returns_401_when_header_missing(self, client, valid_telegram_update):
         """
         Security: Telegram webhook MUST return 401 when X-Telegram-Bot-Api-Secret-Token missing.
         """
@@ -83,10 +102,6 @@ class TestTelegramWebhookAuthentication:
             "api.telegram_bot.get_telegram_webhook_secret",
             return_value="test_secret_123",
         ):
-            from main import app
-
-            client = TestClient(app)
-
             # Send request WITHOUT secret header
             response = client.post(
                 "/api/telegram/webhook",
@@ -98,7 +113,7 @@ class TestTelegramWebhookAuthentication:
             assert "missing" in response.json()["detail"].lower()
 
     @pytest.mark.asyncio
-    async def test_telegram_webhook_returns_403_when_secret_invalid(self, valid_telegram_update):
+    async def test_telegram_webhook_returns_403_when_secret_invalid(self, client, valid_telegram_update):
         """
         Security: Telegram webhook MUST return 403 when secret is incorrect.
         """
@@ -106,10 +121,6 @@ class TestTelegramWebhookAuthentication:
             "api.telegram_bot.get_telegram_webhook_secret",
             return_value="correct_secret_123",
         ):
-            from main import app
-
-            client = TestClient(app)
-
             # Send request with WRONG secret
             response = client.post(
                 "/api/telegram/webhook",
@@ -124,7 +135,7 @@ class TestTelegramWebhookAuthentication:
             assert "forbidden" in response.json()["detail"].lower()
 
     @pytest.mark.asyncio
-    async def test_telegram_webhook_succeeds_with_valid_authentication(self, valid_telegram_update):
+    async def test_telegram_webhook_succeeds_with_valid_authentication(self, client, valid_telegram_update):
         """
         Security: Telegram webhook MUST accept request with valid authentication.
         """
@@ -147,11 +158,6 @@ class TestTelegramWebhookAuthentication:
                     },
                 )()
             )
-
-            from main import app
-
-            client = TestClient(app)
-
             # Send request with CORRECT secret
             response = client.post(
                 "/api/telegram/webhook",
@@ -194,17 +200,15 @@ class TestAlertManagerWebhookAuthentication:
         }
 
     @pytest.mark.asyncio
-    async def test_alertmanager_webhook_fails_closed_when_secret_not_configured(self, valid_alertmanager_payload):
+    async def test_alertmanager_webhook_fails_closed_when_secret_not_configured(
+        self, client, valid_alertmanager_payload
+    ):
         """
         CRITICAL: AlertManager webhook MUST return 503 when secret not configured.
         This prevents unauthenticated alert injection (GH#9657).
         """
         # Clear ALERTMANAGER_WEBHOOK_SECRET env var
         with patch.dict(os.environ, {}, clear=True):
-            from main import app
-
-            client = TestClient(app)
-
             response = client.post(
                 "/api/webhook/alertmanager",
                 json=valid_alertmanager_payload,
@@ -216,15 +220,11 @@ class TestAlertManagerWebhookAuthentication:
             assert "not configured" in response.json()["detail"].lower()
 
     @pytest.mark.asyncio
-    async def test_alertmanager_webhook_returns_401_when_header_missing(self, valid_alertmanager_payload):
+    async def test_alertmanager_webhook_returns_401_when_header_missing(self, client, valid_alertmanager_payload):
         """
         Security: AlertManager webhook MUST return 401 when X-AlertManager-Secret missing.
         """
         with patch.dict(os.environ, {"ALERTMANAGER_WEBHOOK_SECRET": "test_secret_789"}):
-            from main import app
-
-            client = TestClient(app)
-
             # Send request WITHOUT secret header
             response = client.post(
                 "/api/webhook/alertmanager",
@@ -236,15 +236,11 @@ class TestAlertManagerWebhookAuthentication:
             assert "missing" in response.json()["detail"].lower()
 
     @pytest.mark.asyncio
-    async def test_alertmanager_webhook_returns_403_when_secret_invalid(self, valid_alertmanager_payload):
+    async def test_alertmanager_webhook_returns_403_when_secret_invalid(self, client, valid_alertmanager_payload):
         """
         Security: AlertManager webhook MUST return 403 when secret is incorrect.
         """
         with patch.dict(os.environ, {"ALERTMANAGER_WEBHOOK_SECRET": "correct_secret_789"}):
-            from main import app
-
-            client = TestClient(app)
-
             # Send request with WRONG secret
             response = client.post(
                 "/api/webhook/alertmanager",
@@ -259,7 +255,7 @@ class TestAlertManagerWebhookAuthentication:
             assert "invalid" in response.json()["detail"].lower()
 
     @pytest.mark.asyncio
-    async def test_alertmanager_webhook_succeeds_with_valid_authentication(self, valid_alertmanager_payload):
+    async def test_alertmanager_webhook_succeeds_with_valid_authentication(self, client, valid_alertmanager_payload):
         """
         Security: AlertManager webhook MUST accept request with valid authentication.
         """
@@ -268,11 +264,6 @@ class TestAlertManagerWebhookAuthentication:
             patch("api.alertmanager_webhook.ws_manager") as mock_ws,
         ):
             mock_ws.broadcast_update = AsyncMock()
-
-            from main import app
-
-            client = TestClient(app)
-
             # Send request with CORRECT secret
             response = client.post(
                 "/api/webhook/alertmanager",
@@ -307,39 +298,34 @@ class TestWebhookSecurityDocumentation:
         assert docstring is not None
         assert "security" in docstring.lower() or "gh#9657" in docstring.lower()
 
-    def test_env_example_documents_telegram_webhook_secret(self):
-        """Verify .env.example documents TELEGRAM_WEBHOOK_SECRET"""
-        env_example_path = "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}/.env.example"
-        if not os.path.exists(env_example_path):
-            pytest.skip(".env.example not found")
+    def test_operator_docs_document_telegram_webhook_secret(self):
+        """The Telegram webhook secret must be documented for operators.
 
-        with open(env_example_path, "r", encoding="utf-8") as f:
-            content = f.read()
+        Replaces a pair of tests that read
+        ``"${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}/.env.example"`` —
+        shell syntax Python never expands, so the file was never found and both
+        tests always skipped (#13149 class of defect). They also asserted the
+        wrong premise: the Telegram secret is not an environment variable at all,
+        it is generated per bot and stored server-side. The canonical operator
+        reference is asserted instead, resolved from this file's own location.
+        """
+        content = WEBHOOK_AUTH_DOC.read_text(encoding="utf-8")
 
-        # Should document the Telegram webhook secret requirement
-        assert "TELEGRAM_WEBHOOK_SECRET" in content or "telegram" in content.lower() and "webhook" in content.lower()
+        assert "X-Telegram-Bot-Api-Secret-Token" in content
+        assert "503 Service Unavailable" in content
 
-    def test_env_example_documents_alertmanager_webhook_secret(self):
-        """Verify .env.example documents ALERTMANAGER_WEBHOOK_SECRET"""
-        env_example_path = "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}/.env.example"
-        if not os.path.exists(env_example_path):
-            pytest.skip(".env.example not found")
+    def test_operator_docs_document_alertmanager_webhook_secret(self):
+        """The AlertManager webhook secret must be documented for operators."""
+        content = WEBHOOK_AUTH_DOC.read_text(encoding="utf-8")
 
-        with open(env_example_path, "r", encoding="utf-8") as f:
-            content = f.read()
-
-        # Should document the AlertManager webhook secret requirement
-        assert (
-            "ALERTMANAGER_WEBHOOK_SECRET" in content
-            or "alertmanager" in content.lower()
-            and "webhook" in content.lower()
-        )
+        assert "ALERTMANAGER_WEBHOOK_SECRET" in content
+        assert "X-AlertManager-Secret" in content
 
 
 class TestWebhookSecurityRegression:
     """Regression tests to prevent re-introduction of fail-open vulnerability"""
 
-    def test_telegram_webhook_does_not_return_200_when_secret_unset(self):
+    def test_telegram_webhook_does_not_return_200_when_secret_unset(self, client):
         """
         REGRESSION: Ensure Telegram webhook NEVER returns 200 when secret unset.
         This was the original vulnerability in GH#9657.
@@ -348,10 +334,6 @@ class TestWebhookSecurityRegression:
             "api.telegram_bot.get_telegram_webhook_secret",
             return_value=None,
         ):
-            from main import app
-
-            client = TestClient(app)
-
             response = client.post(
                 "/api/telegram/webhook",
                 json={"update_id": 1, "message": {"message_id": 1}},
@@ -362,15 +344,46 @@ class TestWebhookSecurityRegression:
             # MUST be 503 (fail-closed)
             assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
 
-    def test_alertmanager_webhook_does_not_return_200_when_secret_unset(self):
+    @pytest.mark.parametrize(
+        "body",
+        [None, [1, 2, 3], {"not": "an update"}],
+        ids=["no-body", "wrong-type", "unexpected-shape"],
+    )
+    def test_telegram_webhook_authenticates_before_parsing_body(self, client, body):
+        """
+        REGRESSION: authentication MUST run before FastAPI validates the body.
+
+        With the check inside the handler, an unauthenticated caller who sent a
+        body FastAPI rejected got a 422 schema error instead of failing closed —
+        an unauthenticated payload-schema oracle. Auth is now a route dependency,
+        so every unauthenticated shape fails closed regardless of the body.
+        """
+        with patch("api.telegram_bot.get_telegram_webhook_secret", return_value=None):
+            response = client.post("/api/telegram/webhook", json=body)
+
+        assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+        assert "not configured" in response.json()["detail"].lower()
+
+    @pytest.mark.parametrize(
+        "body",
+        [None, [1, 2, 3], {"not": "an alert"}],
+        ids=["no-body", "wrong-type", "unexpected-shape"],
+    )
+    def test_alertmanager_webhook_authenticates_before_parsing_body(self, client, body):
+        """
+        REGRESSION: AlertManager authentication MUST run before body validation.
+        """
+        with patch.dict(os.environ, {}, clear=True):
+            response = client.post("/api/webhook/alertmanager", json=body)
+
+        assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+        assert "not configured" in response.json()["detail"].lower()
+
+    def test_alertmanager_webhook_does_not_return_200_when_secret_unset(self, client):
         """
         REGRESSION: Ensure AlertManager webhook NEVER returns 200 when secret unset.
         """
         with patch.dict(os.environ, {}, clear=True):
-            from main import app
-
-            client = TestClient(app)
-
             response = client.post(
                 "/api/webhook/alertmanager",
                 json={

--- a/autobot-backend/llc/tests/test_autobot_agent_adapter.py
+++ b/autobot-backend/llc/tests/test_autobot_agent_adapter.py
@@ -16,6 +16,7 @@ import asyncio
 import logging
 import sys
 import types
+from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -24,10 +25,13 @@ import pytest
 # ──────────────────────────────────────────────────────────────────────────────
 # Stub agents/* so importing autobot_agent_adapter doesn't pull the full chain.
 # autobot_agent_adapter only needs `AgentRequest` from agents.base_agent.
+# #13162: ``__path__`` points at the real ``agents`` directory so only
+# ``agents/__init__.py`` is bypassed — an empty ``__path__`` here would make
+# every ``agents.<submodule>`` import fail for the rest of the worker.
 # ──────────────────────────────────────────────────────────────────────────────
 if "agents" not in sys.modules:
     _agents_stub = types.ModuleType("agents")
-    _agents_stub.__path__ = []
+    _agents_stub.__path__ = [str(Path(__file__).resolve().parents[2] / "agents")]
     _agents_stub.__package__ = "agents"
     sys.modules["agents"] = _agents_stub
 
@@ -253,6 +257,8 @@ async def test_invoke_returns_run_id_then_completed():
     await asyncio.sleep(0)
 
     status = await adapter.status({}, run_id)
+    # status() must honour the LLCAdapter contract, not just carry the right value.
+    assert isinstance(status, AdapterRunStatus)
     assert status.status == LLCRunStatus.COMPLETED
     assert status.exit_code == 0
 
@@ -501,6 +507,7 @@ async def test_cost_forwarded_to_budget_service():
             budget_session_factory=session_factory,
         )
         run_id = await adapter.invoke({}, {"title": "T", "agent_id": "agent-xyz"})
+        assert isinstance(run_id, str) and run_id
         await asyncio.sleep(0.05)
 
         MockBS.return_value.ingest_cost_event.assert_called_once()

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -1905,7 +1905,9 @@ export interface paths {
          *     This endpoint is called by Telegram servers when a message is sent to the bot.
          *     Messages are normalized via TelegramAdapter and routed to AutoBot chat.
          *
-         *     Security: Verifies X-Telegram-Bot-Api-Secret-Token header matches stored secret.
+         *     Security: Verifies the X-Telegram-Bot-Api-Secret-Token header matches the
+         *     stored secret, enforced by the ``verify_telegram_secret`` route dependency
+         *     so authentication runs before the request body is parsed.
          *
          *     Args:
          *         request: FastAPI request (for header access)

--- a/docs/security/WEBHOOK_AUTHENTICATION.md
+++ b/docs/security/WEBHOOK_AUTHENTICATION.md
@@ -38,30 +38,42 @@ X-Telegram-Bot-Api-Secret-Token: <secret_token>
 | Header invalid | `403 Forbidden` | Reject request |
 | Header valid | `200 OK` | Process webhook |
 
-**Implementation:**
+**Implementation:** `autobot-backend/api/telegram_bot.py` — `verify_telegram_secret`,
+declared as a route dependency (`dependencies=[Depends(verify_telegram_secret)]`)
+so it runs *before* FastAPI parses the body.
+
 ```python
-# autobot-backend/api/telegram_bot.py:264-280
+async def verify_telegram_secret(request: Request) -> None:
+    stored_secret = await get_telegram_webhook_secret()
+    if not stored_secret:
+        logger.error("Telegram webhook secret not configured - failing closed")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Webhook authentication not configured",
+        )
 
-stored_secret = await get_telegram_webhook_secret()
-if not stored_secret:
-    logger.error("Telegram webhook secret not configured - failing closed")
-    raise HTTPException(
-        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-        detail="Webhook authentication not configured",
-    )
+    request_secret = request.headers.get("X-Telegram-Bot-Api-Secret-Token")
+    if not request_secret:
+        logger.warning("Telegram webhook authentication failed - missing secret header")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing authentication header",
+        )
 
-request_secret = request.headers.get("X-Telegram-Bot-Api-Secret-Token")
-if not request_secret:
-    logger.warning("Telegram webhook authentication failed - missing secret header")
-    raise HTTPException(
-        status_code=status.HTTP_401_UNAUTHORIZED,
-        detail="Missing authentication header",
-    )
-
-if request_secret != stored_secret:
-    logger.warning("Telegram webhook authentication failed - invalid secret token")
-    raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
+    if not secrets.compare_digest(request_secret, stored_secret):
+        logger.warning("Telegram webhook authentication failed - invalid secret token")
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
 ```
+
+Two properties this shape guarantees (#13162):
+
+- **Authentication precedes body validation.** While the check lived inside the
+  handler, an unauthenticated caller whose body FastAPI rejected received a
+  `422` schema error instead of `503`/`401` — a payload-schema oracle available
+  without credentials. As a dependency it fails closed for any body.
+- **Constant-time comparison.** `secrets.compare_digest` replaces `!=`, which
+  short-circuits on the first differing byte and leaks the secret to a timing
+  oracle. This matches the AlertManager webhook.
 
 ### 2. AlertManager Webhook (`/api/webhook/alertmanager`)
 


### PR DESCRIPTION
## Thinking Path

Assigned the two red files `autobot-backend/api/webhook_authentication_security_test.py` (10 CI failures) and `autobot-backend/security/security_integration_test.py` (3 CI failures) from the #13162 cluster. Measured a local baseline first — `10 failed, 19 passed, 2 skipped` — then treated every failure as a suspected production bug until proven otherwise.

Two of the four root causes turned out to be real defects in shipped code, one of them a security defect in an authentication path.

**Telegram webhook authenticated after FastAPI parsed the body.** The secret check lived inside the handler body, below `update: Dict[str, Any] = Body(...)`. FastAPI validates the body before the handler runs, so an unauthenticated caller whose body failed validation got a `422` schema error rather than `503`/`401`. That is a payload-schema oracle reachable with no credentials, and a fail-closed hole for any request that never reached the handler. Measured against the pre-fix code:

```
no secret configured + valid body : 503   (correct)
no secret configured + empty body : 422   (auth never ran)
no secret configured + bad body   : 422   (auth never ran)
```

The AlertManager webhook next door had already been moved to a route dependency for exactly this reason and behaved correctly under the same probe. The Telegram endpoint had not. It now uses the same shape.

**Telegram webhook compared the secret with `!=`.** Python string inequality short-circuits on the first differing byte, which leaks the stored secret to a timing oracle. The AlertManager webhook already used `secrets.compare_digest`; the Telegram one did not.

**`llc/tests/conftest.py` poisoned the `agents` package for the whole xdist worker.** `_make_agents_stub` installed `sys.modules["agents"]` with `__path__ = []` and never restored it, so every later `import agents.<submodule>` in that worker raised `ModuleNotFoundError`. That is the cause of the 3 `security_integration_test.py` failures — CI reported `RuntimeError: AUTOBOT_FEATURE_ROUTERS_STRICT=1 — 1 feature router(s) failed to load: development_speedup`, and the captured log named the import error as `No module named 'agents.development_speedup_agent'`. Reproduced locally by running an LLC test file ahead of `security_integration_test.py`; the identical error appeared. This file already carries two fixes of the same class (`#13107`, `#13084`) for its `knowledge` stub — the `agents` stub had been missed.

**`from main import app` resolved to the deprecated repo-root shim.** `pytest.ini` sets `pythonpath = . autobot-backend autobot_shared`, so `main` is the root deprecation stub, which exposes no `app`. All ten webhook tests died at import — a test bug, not a production one.

**Two documentation tests could never fail.** Both built their path as a literal Python string joining an unexpanded `${AUTOBOT_PROJECT_ROOT:-...}` shell default to `/.env.example`. Python does not expand shell syntax, so `os.path.exists` was always `False` and both always skipped — the `#13149` class of defect. They also encoded a false premise: the Telegram secret is not an environment variable at all, it is generated per bot and stored server-side by `POST /api/telegram/config`.

## What Changed

**Production — `autobot-backend/api/telegram_bot.py`**

- Extracted `verify_telegram_secret(request)` and wired it as `dependencies=[Depends(verify_telegram_secret)]` on `POST /telegram/webhook`, so authentication runs before the body is read. Status codes are unchanged: `503` unconfigured, `401` header missing, `403` header wrong.
- Replaced `request_secret != stored_secret` with `secrets.compare_digest`.

**Shared test harness — called out explicitly, outside the two assigned files**

- `autobot-backend/llc/tests/conftest.py` — `_make_agents_stub` now points `__path__` at the real `agents` directory and never replaces an already-imported `agents`. Only `agents/__init__.py` (and its chromadb chain) is still bypassed; every real submodule resolves. This changes behaviour for any test that runs after an LLC test in the same worker, which is the point of the fix.
- `autobot-backend/llc/tests/test_autobot_agent_adapter.py` — the same empty-`__path__` `agents` stub, fixed identically. It is currently inert (its own conftest installs `agents` first) but is the same latent landmine. Two pre-existing `flake8` findings in this file blocked the pre-flight gate once the file was touched; both are wired in rather than deleted — `AdapterRunStatus` now asserts the `status()` return type against the `LLCAdapter` contract, and the discarded `run_id` is asserted to be a non-empty string.

**Tests — `autobot-backend/api/webhook_authentication_security_test.py`**

- One module-scoped `client` fixture builds the app via `app_factory.create_app()`. Module scope is also correctness, not just speed: the app must not be constructed inside the `patch.dict(os.environ, ..., clear=True)` blocks these tests use.
- The two documentation tests now assert against `docs/security/WEBHOOK_AUTHENTICATION.md`, resolved from the test file's own location, and check facts that are true and load-bearing: the header names and the fail-closed status. Renamed off the `env_example` premise.
- Added six parametrized regression tests — `no-body`, `wrong-type`, `unexpected-shape`, per webhook — asserting that an unauthenticated request fails closed with `503` whatever its body looks like. These fail against the previous Telegram handler.

**Docs — `docs/security/WEBHOOK_AUTHENTICATION.md`**

The quoted Telegram snippet was stale: it showed the in-handler check and the `!=` comparison. Replaced with the dependency form and `secrets.compare_digest`, plus a short note on the two properties that shape guarantees.

No test was skipped, xfailed, or weakened. The two tests that used to skip now assert unconditionally.

## Verification

Assigned command, both files:

```
export SLM_SECRET_KEY=throwaway SLM_ENCRYPTION_KEY=x
python3 -m pytest autobot-backend/api/webhook_authentication_security_test.py \
  autobot-backend/security/security_integration_test.py \
  -q -p no:cacheprovider -m "not integration and not slow and not distributed and not performance"
```

| | before | after |
|---|---|---|
| failed | 10 | 0 |
| passed | 19 | 37 |
| skipped | 2 | 0 |

Every one of the 10 baseline failures was `ImportError: cannot import name 'app' from 'main'`.

The `agents` poisoning fix, proved directly:

```
# stub with __path__ = []  (the shipped state)
ModuleNotFoundError: No module named 'agents.development_speedup_agent'   <- exact CI message

# stub with __path__ = [<repo>/autobot-backend/agents]  (this PR)
import OK -> autobot-backend/agents/development_speedup_agent.py
```

End to end, running an LLC test file ahead of `security_integration_test.py`:

- before — collection aborts, `ModuleNotFoundError: No module named 'agents.overseer'`
- after — collection succeeds; under `AUTOBOT_FEATURE_ROUTERS_STRICT=1` the `development_speedup` import error changes from `No module named 'agents.development_speedup_agent'` to `cannot import name 'BaseClient' from 'knowledge.backends'`, i.e. the `agents` poisoning is gone

That residual is a dev-box artifact, not a CI one: this machine is missing 19 of 69 requirements (chromadb, transformers, torch), so the `knowledge.backends` stub cannot re-export the real names. On CI those packages are installed, which is why CI reported exactly one failed router (`development_speedup`) and not five. Without `AUTOBOT_FEATURE_ROUTERS_STRICT`, which is what the assigned command runs, all 17 `security_integration_test.py` tests pass locally.

No regression in the modules touched by the shared fix — `test_autobot_agent_adapter.py` plus `telegram_bot_test.py`: `40 passed, 1 skipped`.

Lint on the changed files:

```
isort   — clean
black   — clean
flake8  — clean
bandit  — No issues identified (no severity floor)
```

`scripts/pr-preflight.sh --issue 13162` prints **pre-flight clean**.

One operator-facing gap found and not fixed here: `ALERTMANAGER_WEBHOOK_SECRET` is a real environment variable the webhook fail-closes on, and it is absent from `.env.example`, so an operator hitting a `503` has nothing to grep for. Filed as #13382 rather than bundled into a security fix.

## Model Used

claude-opus-5[1m]

Closes #13162

> **PARTIAL.** This PR fixes only the two files it was scoped to — `autobot-backend/api/webhook_authentication_security_test.py` and `autobot-backend/security/security_integration_test.py`. #13162 tracks roughly 450 red tests across the suite and **stays open**; sibling PRs are working other groups in parallel. Do not let the `Closes` keyword auto-close it on merge.
