### PR TITLE
fix(test): stop four test-harness stubs from poisoning shared modules across the session (#13162)

### DIFF
--- a/autobot-backend/conftest.py
+++ b/autobot-backend/conftest.py
@@ -729,10 +729,23 @@ except Exception:
 # modules with Python-3.10-incompatible annotations or missing config keys.
 # Stub these modules so the lightweight types-only tests can collect without
 # needing the full backend stack.
+#
+# ``orchestration.causal_validator`` is deliberately NOT on this list (#13162).
+# It has none of the heavy chain the entries below are here for — its only
+# imports are ``autobot_shared.logging_manager``, ``orchestration.causal_models``
+# (stdlib dataclasses/enum only) and ``orchestration.dag_executor``, both of
+# which every consumer already real-imports. Stubbing it handed
+# ``orchestration/test_causal_executor.py`` a MagicMock ``CausalValidator``, so
+# ``validate_workflow()`` returned a mock whose ``.valid`` was truthy, whose
+# ``errors()``/``warnings()`` had ``len() == 0`` and iterated empty — the whole
+# TestCausalValidator class asserted against mock defaults instead of the real
+# validator (2 tests failed outright, 3 silently asserted nothing, and
+# ``test_validate_no_issues_linear_workflow`` passed for the wrong reason).
+# Same class of harness bug as ``code_intelligence.merge_conflict_resolver``
+# below (#13111).
 for _causal_mod in [
     "orchestration.causal_error_recovery",
     "orchestration.causal_error_analyzer",
-    "orchestration.causal_validator",
     "agent_loop",
     "agent_loop.loop",
     "agent_loop.think_tool",

--- a/autobot-backend/llc/tests/conftest.py
+++ b/autobot-backend/llc/tests/conftest.py
@@ -17,6 +17,7 @@ Fixtures for project-repo API tests (#11129):
   a_project_with_repo — dict with ``id``/``company_id`` of a mock project already linked
 """
 
+import importlib
 import sys
 import types
 import uuid  # noqa: F401 — used in fixture helpers below
@@ -74,6 +75,7 @@ def _snapshot_session_stub_keys() -> dict:
 # = .../autobot-backend, matching the same on-disk-path derivation already
 # used by _shield_codebase_analytics_package below.
 _KNOWLEDGE_DIR = str(Path(__file__).parents[2] / "knowledge")
+_AGENTS_DIR = str(Path(__file__).parents[2] / "agents")
 
 
 def _make_knowledge_stub() -> types.ModuleType:
@@ -213,23 +215,44 @@ def _make_services_stub() -> types.ModuleType:
 
 
 def _make_agents_stub() -> None:
-    """Stub the ``agents`` package to avoid the knowledge/chromadb import chain.
+    """Register a hollow ``agents`` package that never runs ``__init__.py``.
 
     ``autobot_agent_adapter`` imports ``from agents.base_agent import AgentRequest``
     at module level.  Loading ``agents/__init__.py`` eagerly pulls in
     ``kb_librarian_agent`` → ``knowledge_base`` → ``knowledge`` → chromadb chain.
     We short-circuit that by pre-populating sys.modules before any test module
     triggers the import.
+
+    ``__path__`` points at the REAL on-disk ``agents/`` directory — the same
+    "hollow package" pattern already used for ``knowledge`` above (#13107) and
+    for ``api.codebase_analytics`` below.  Python consults ``__path__`` only to
+    locate a submodule that is not already in ``sys.modules``, and it never
+    executes the parent's ``__init__.py`` for a package object that is already
+    registered, so the heavy chain stays untouched while every real
+    ``agents.X`` submodule remains importable.
+
+    An empty ``__path__`` blocked every other real submodule too — notably
+    ``agents.agent_client``, which ``autobot-backend/orchestrator.py`` imports
+    at module level.  Because collection-time imports all happen before any
+    fixture teardown could restore the pre-stub state, that shadowing broke
+    *collection* of files gathered after this package in the same session
+    (reproduced: ``orchestration/plan_steps_e2e_test.py`` fails with
+    ``ModuleNotFoundError: No module named 'agents.agent_client'`` in a
+    combined run, never in isolation) — #13162.
+
+    ``agents/base_agent.py`` is dependency-light (autobot_shared + constants +
+    protocols, no knowledge/chromadb import at module level), so it is
+    real-loaded through the same ``__path__`` rather than replaced by a mock:
+    ``agents/agent_client.py`` does ``from .base_agent import AgentHealth,
+    BaseAgent, ...``, names a hand-written stub module did not carry.
     """
     agents_mod = types.ModuleType("agents")
-    agents_mod.__path__ = []  # type: ignore[attr-defined]
+    agents_mod.__path__ = [_AGENTS_DIR]  # type: ignore[attr-defined]
     agents_mod.__package__ = "agents"
+    agents_mod.__spec__ = None  # type: ignore[attr-defined]
     sys.modules["agents"] = agents_mod
 
-    agents_base = types.ModuleType("agents.base_agent")
-    agents_base.AgentRequest = MagicMock  # type: ignore[attr-defined]
-    agents_base.AgentResponse = MagicMock  # type: ignore[attr-defined]
-    sys.modules["agents.base_agent"] = agents_base
+    importlib.import_module("agents.base_agent")
 
 
 # ``services.llm_service`` is imported at module level by llc/kb/handoff_brief.py
@@ -240,6 +263,19 @@ _make_services_stub()
 # ``agents.base_agent`` is imported by autobot_agent_adapter (GH#8502).
 # Stub it before any test module can trigger the agents/__init__.py chain.
 _make_agents_stub()
+
+# Everything this file installs, captured once so the package-scoped fixture
+# below can RE-install it on every entry into this package — not just remove it
+# on the way out (#13162). CI runs ``-n auto --dist loadscope``, which groups by
+# module, not by package: a worker interleaves llc/tests modules with modules
+# from elsewhere, so the package fixture tears down and sets up repeatedly. The
+# installs above run once, at import time, so a teardown that only restored the
+# pre-stub state left every LATER llc/tests module running against the REAL
+# ``knowledge`` package (reproduced by ordering test_heartbeat_context.py,
+# knowledge/pipeline/cognifiers/cognifiers_test.py, test_sprint_close.py in one
+# run: ``test_kb_summarizer_stub_is_called`` then tries to reach a live Redis
+# and fails with "Failed to initialize knowledge base").
+_INSTALLED_STUBS = {key: sys.modules[key] for key in _SESSION_STUB_KEYS if key in sys.modules}
 
 
 def _shield_codebase_analytics_package() -> None:
@@ -276,8 +312,6 @@ def _shield_codebase_analytics_package() -> None:
     # lookup runs ``getattr(api, "codebase_analytics")`` — resolves to this shield
     # (#11129 P2). Without it, patching a lazily-imported analytics helper raises
     # ``AttributeError: module 'api' has no attribute 'codebase_analytics'``.
-    import importlib  # noqa: PLC0415
-
     importlib.import_module("api").codebase_analytics = pkg  # type: ignore[attr-defined]
 
 
@@ -494,8 +528,8 @@ def _build_llc_app(
 
 @pytest.fixture(scope="package", autouse=True)
 def _restore_session_stubs_after_package():
-    """Restore the module-level ``knowledge``/``agents`` stubs after this
-    package finishes (#13084).
+    """Install the module-level ``knowledge``/``agents`` stubs for the lifetime
+    of this package, and restore the pre-stub state afterwards (#13084/#13162).
 
     The stubs installed above at import time are required for llc/tests/
     itself to collect (chromadb/opentelemetry are unavailable in dev/CI), but
@@ -507,7 +541,14 @@ def _restore_session_stubs_after_package():
     full-suite run, never in isolation). Restoring here — rather than a
     session-scoped hook — ties the fix to exactly the lifetime that needs
     the stub.
+
+    Setup re-installs rather than assuming the import-time install is still in
+    place: with ``--dist loadscope`` this fixture is entered once per contiguous
+    run of llc/tests modules, so on every entry after the first the previous
+    teardown has already handed ``sys.modules`` back to the real packages.
     """
+    for key, stub in _INSTALLED_STUBS.items():
+        sys.modules[key] = stub
     yield
     for key, prior in _PRE_STUB_MODULES.items():
         if prior is None:

--- a/autobot-backend/llc/tests/test_heartbeat_context.py
+++ b/autobot-backend/llc/tests/test_heartbeat_context.py
@@ -81,14 +81,31 @@ async def test_assemble_merges_chunks_from_collections(assembler: LLCRAGAssemble
             "sources": [coll_name],
         }
 
+    # ``assemble`` imports the ChromaDB client lazily inside the function, so the
+    # only seam is ``builtins.__import__``. Two things this shim must get right:
+    #   * hold the ORIGINAL __import__ (``_real_import``) rather than looking the
+    #     name up again at call time — the global lookup resolves to the patch
+    #     itself, so every non-matching import recursed until the stack blew.
+    #     It stayed invisible until Python 3.14 moved linecache's ``import os``
+    #     inside ``updatecache()``: the traceback formatting of any error raised
+    #     under the patch then re-entered the shim (#13162).
+    #   * hand back an AWAITABLE ``get_async_chromadb_client``. A bare MagicMock
+    #     made ``await get_async_chromadb_client()`` raise, so assemble() took its
+    #     graceful-degradation path and returned an EMPTY context — this test
+    #     asserted only ``isinstance(ctx, LLCContext)`` and passed without ever
+    #     reaching the merge it is named for.
+    _real_import = __import__
+    chromadb_stub = MagicMock()
+    chromadb_stub.get_async_chromadb_client = AsyncMock(return_value=MagicMock())
+
+    def _import_with_chromadb_stub(name, *a, **kw):
+        if name == "utils.async_chromadb_client":
+            return chromadb_stub
+        return _real_import(name, *a, **kw)
+
     with (
         patch.object(assembler, "_query_collection", new=fake_query),
-        patch(
-            "builtins.__import__",
-            side_effect=lambda name, *a, **kw: (
-                MagicMock() if name == "utils.async_chromadb_client" else __import__(name, *a, **kw)
-            ),
-        ),
+        patch("builtins.__import__", side_effect=_import_with_chromadb_stub),
     ):
         ctx = await assembler.assemble(
             company_id="co1",
@@ -98,6 +115,9 @@ async def test_assemble_merges_chunks_from_collections(assembler: LLCRAGAssemble
         )
 
     assert isinstance(ctx, LLCContext)
+    # project + agent + company collections, one chunk each, merged in order.
+    assert ctx.sources == ["co1:project:proj1", "co1:agent:agent1", "co1:company"]
+    assert [c["content"] for c in ctx.chunks] == [f"doc from {s}" for s in ctx.sources]
 
 
 @pytest.mark.asyncio

--- a/autobot-backend/tasks/conftest.py
+++ b/autobot-backend/tasks/conftest.py
@@ -81,8 +81,17 @@ def _ensure_stub(name: str) -> types.ModuleType:
 _logging_stub = _ensure_stub("autobot_shared.logging_manager")
 _logging_stub.get_logger = lambda name="autobot", *args, **kwargs: logging.getLogger(name)  # type: ignore[attr-defined]
 
-_async_compat_stub = _ensure_stub("autobot_shared.async_compat")
-_async_compat_stub.run_or_schedule = MagicMock()  # type: ignore[attr-defined]
+# #13162: ``autobot_shared.async_compat`` is deliberately NOT stubbed. It is
+# pure stdlib (asyncio + concurrent.futures), so it imports cleanly with no
+# infrastructure at all — there was never anything for a stub to break the
+# chain on. Worse, ``_ensure_stub`` hands back the ALREADY-IMPORTED real module
+# whenever some earlier import pulled it in (circuit_breaker.py, event_manager.py
+# and ~30 other backend modules import it at module level), so assigning
+# ``run_or_schedule`` here overwrote the real shared helper process-wide, exactly
+# like the GH#12522 ``get_logger`` trap noted above. Every test collected later
+# in that worker got the MagicMock: ``autobot_shared/async_compat_test.py``'s
+# whole file (7/7) failed in CI with ``assert <MagicMock name='mock()'> == 42``
+# and never in isolation.
 
 # type_defs.common is imported by knowledge_tasks.py
 _type_defs = _ensure_stub("type_defs")

--- a/autobot-backend/tests/agent_loop/conftest.py
+++ b/autobot-backend/tests/agent_loop/conftest.py
@@ -9,10 +9,28 @@ autobot-backend/conftest.py stubs ``agent_loop`` (and sub-modules) to break
 the orchestration → agent_loop import chain for orchestration-layer tests.
 Tests in this directory need the *real* implementations.
 
-We swap stubs for real modules at conftest load time and restore them
-via ``pytest_unconfigure`` so sibling test directories are unaffected.
+We replace any remaining stub with the real module at conftest load time and
+restore what we replaced via ``pytest_unconfigure`` so sibling test
+directories are unaffected.
 
-Issue #6627.
+This file must never swap the *package identity* (#13162).  It used to pop
+every ``agent_loop*`` key out of ``sys.modules`` and plant a fresh
+``agent_loop`` module, which is fatal in a full-suite run: pytest imports this
+conftest during collection, long after ``autobot-backend/agent_loop/tests/``
+has already been collected and bound ``AgentLoop`` /
+``PreActionVerifier`` from the *previous* module objects.  Every
+``patch("agent_loop.loop.X")`` in those files then resolved against the new
+package and silently patched a different (or mock) object, so the real
+module's globals stayed untouched — an inert patch.  That is the same hazard
+``tests/orchestration/test_causal_error_recovery.py`` documents for this exact
+package ("popping the parent forced a full real ``agent_loop/__init__``
+re-import that replaced the package identity mid-session").
+
+The root conftest already plants ``agent_loop`` with a REAL ``__path__`` and
+real-loads ``agent_loop.loop`` / ``agent_loop.think_tool`` (#11153), so in
+practice this file only has to fill in whatever is still a stub.
+
+Issue #6627, #13162.
 """
 
 import importlib.util
@@ -23,36 +41,71 @@ from pathlib import Path
 _BACKEND = Path(__file__).parent.parent.parent  # .../autobot-backend
 _AL_DIR = _BACKEND / "agent_loop"
 
-# Keys to save/restore.
-_AGENT_LOOP_KEYS = [k for k in sys.modules if k == "agent_loop" or k.startswith("agent_loop.")]
-_SAVED: dict[str, object] = {k: sys.modules[k] for k in _AGENT_LOOP_KEYS}
+# Only the entries this file actually replaces are saved — restoring keys we
+# never touched is what made the old save/pop/restore cycle destructive.
+_SAVED: dict[str, object] = {}
+_ADDED: set = set()
+
+
+def _bind_on_parent(full_name: str, mod: object) -> None:
+    """Bind *mod* as an attribute of its parent package.
+
+    Load-bearing for ``unittest.mock.patch`` (#11532/#11618): it resolves
+    ``"agent_loop.loop.X"`` via ``getattr(sys.modules["agent_loop"], "loop")``,
+    NOT via ``sys.modules["agent_loop.loop"]``.  A module registered in
+    ``sys.modules`` by hand — as ``_load_real`` does — never gets that bind
+    from the import machinery, so without this every such patch target either
+    raised ``AttributeError`` or (against the root conftest's catch-all
+    package stub) silently patched a MagicMock.
+    """
+    parent, _, child = full_name.rpartition(".")
+    if parent and parent in sys.modules:
+        setattr(sys.modules[parent], child, mod)
 
 
 def _load_real(full_name: str, rel: str) -> None:
-    """Load a Python file directly and register it under *full_name*."""
+    """Register the REAL module for *full_name*, unless it already is real.
+
+    Re-executing a module that is already loaded from this same file builds a
+    second set of class objects while every importer keeps referencing the
+    first — the identity split that #13162 traced.  An already-real entry is
+    therefore left alone and only (re)bound on its parent.
+    """
     path = _BACKEND / rel
+    existing = sys.modules.get(full_name)
+    if existing is not None and getattr(existing, "__file__", None) == str(path):
+        _bind_on_parent(full_name, existing)
+        return
     spec = importlib.util.spec_from_file_location(full_name, str(path))
     if not spec or not spec.loader:
         return
     mod = importlib.util.module_from_spec(spec)
     mod.__package__ = full_name.rpartition(".")[0] or full_name
+    if existing is None:
+        _ADDED.add(full_name)
+    else:
+        _SAVED.setdefault(full_name, existing)
     sys.modules[full_name] = mod
     try:
         spec.loader.exec_module(mod)  # type: ignore[union-attr]
     except Exception as exc:
         # Leave partial module in sys.modules so subsequent imports don't retrigger the error
         sys.modules.setdefault(f"_stagnation_load_err_{full_name}", exc)
+    _bind_on_parent(full_name, mod)
 
 
-# Remove stubs placed by the parent conftest.
-for _k in _AGENT_LOOP_KEYS:
-    sys.modules.pop(_k, None)
-
-# Plant a real package entry so ``from agent_loop.X import Y`` resolves.
-_pkg = types.ModuleType("agent_loop")
+# Reuse the session's ``agent_loop`` package object rather than planting a new
+# one — see the module docstring.  The root conftest already gives it a real
+# ``__path__``; assert that here so ``from agent_loop.X import Y`` resolves the
+# light submodules straight from disk even if this file is the first to need
+# them.
+_pkg = sys.modules.get("agent_loop")
+if _pkg is None:
+    _pkg = types.ModuleType("agent_loop")
+    _pkg.__package__ = "agent_loop"
+    sys.modules["agent_loop"] = _pkg
+    _ADDED.add("agent_loop")
 _pkg.__path__ = [str(_AL_DIR)]  # type: ignore[assignment]
-_pkg.__package__ = "agent_loop"
-sys.modules["agent_loop"] = _pkg
 
 # Load in dependency order (fingerprint and types have no heavy local deps).
 _load_real("agent_loop.fingerprint", "agent_loop/fingerprint.py")
@@ -62,11 +115,15 @@ _load_real("agent_loop.think_tool", "agent_loop/think_tool.py")
 _load_real("agent_loop.slack_hook", "agent_loop/slack_hook.py")
 _load_real("agent_loop.loop", "agent_loop/loop.py")
 
-# MVA-1407: belief state + extractors package
-_ext_pkg = types.ModuleType("agent_loop.extractors")
+# MVA-1407: belief state + extractors package — reuse an existing entry for the
+# same identity reason as the parent package above.
+_ext_pkg = sys.modules.get("agent_loop.extractors")
+if _ext_pkg is None:
+    _ext_pkg = types.ModuleType("agent_loop.extractors")
+    _ext_pkg.__package__ = "agent_loop.extractors"
+    sys.modules["agent_loop.extractors"] = _ext_pkg
+    _ADDED.add("agent_loop.extractors")
 _ext_pkg.__path__ = [str(_AL_DIR / "extractors")]  # type: ignore[assignment]
-_ext_pkg.__package__ = "agent_loop.extractors"
-sys.modules["agent_loop.extractors"] = _ext_pkg
 _pkg.extractors = _ext_pkg  # type: ignore[attr-defined]
 _load_real("agent_loop.extractors.read_file", "agent_loop/extractors/read_file.py")
 _load_real("agent_loop.extractors.run_command", "agent_loop/extractors/run_command.py")
@@ -76,9 +133,12 @@ _load_real("agent_loop.belief_state", "agent_loop/belief_state.py")
 
 
 def pytest_unconfigure(config) -> None:  # noqa: ARG001
-    """Restore the original stub state so other directories are unaffected."""
-    for k in list(sys.modules):
-        if k == "agent_loop" or k.startswith("agent_loop."):
-            sys.modules.pop(k, None)
+    """Undo exactly what this file changed, and nothing else.
+
+    Sweeping every ``agent_loop*`` key out of ``sys.modules`` here would drop
+    submodules other collectors imported on their own during the session.
+    """
+    for k in _ADDED:
+        sys.modules.pop(k, None)
     for k, v in _SAVED.items():
         sys.modules[k] = v  # type: ignore[assignment]


### PR DESCRIPTION
## Thinking Path

#13162 is the gate issue: the Python suite is not a required check, so red tests reach `Dev_new_gui`. This PR clears one slice of that backlog — `autobot_shared/async_compat_test.py`, `autobot-backend/llc/tests/`, `autobot-backend/orchestration/` and `autobot-backend/agent_loop/tests/`.

I started from the CI run on `Dev_new_gui` itself (run 30804896370, all 12 `python-suite` shards) rather than from a local run, because every failure in this group is order-dependent: each one passes when its file is run alone. Pulled the shard logs, extracted the 21 failing node IDs in these four directories, and reproduced each one locally by pairing the failing file with the file whose conftest poisons it.

All 21 turned out to be the same defect in five different places: **a test-harness stub replaces a module that a later-collected test needs for real.** `unittest.mock.patch` resolves `"pkg.mod.NAME"` through `getattr(sys.modules["pkg"], "mod")`, so a stub with a catch-all `__getattr__` — or a package object that was swapped after the test module already imported from it — turns the patch into a no-op against a MagicMock while the real code runs untouched. The assertion then compares against mock defaults: `MagicMock.__len__` is `0`, `__iter__` is empty, and a bare MagicMock is truthy, so some of these tests did not fail loudly, they passed vacuously.

None of the 21 were production bugs. The production code was right in every case; the harness was hiding it. One of the five is a bug in a test's own patch helper, not in a conftest.

I did not touch `llc/scheduler/base.py`. `test_poll_loop_scheduler.py` fails on the dev box with `'_asyncio.Task' object has no attribute 'cancelling'` because `Task.cancelling()` is Python 3.11+ and the box runs 3.10; CI runs 3.14, where it exists, and reports no failure in that file. That is an artifact of the dev box, not a defect.

## What Changed

**`autobot-backend/conftest.py`** — removed `orchestration.causal_validator` from the causal stub list. It has none of the heavy import chain the other entries on that list exist for (it imports `autobot_shared.logging_manager`, `orchestration.causal_models` and `orchestration.dag_executor`, all of which its consumers already real-import). Stubbing it handed `TestCausalValidator` a MagicMock: 2 tests failed on `assert not result.valid`, 3 silently asserted nothing because `result.warnings()` iterated empty, and `test_validate_no_issues_linear_workflow` passed for the wrong reason.

**`autobot-backend/tasks/conftest.py`** — removed the `autobot_shared.async_compat` stub. The module is pure stdlib (`asyncio` + `concurrent.futures`), so there was never an import chain for a stub to break. Worse, `_ensure_stub` returns the already-imported real module when one exists — and roughly 30 backend modules import `async_compat` at module level — so assigning `run_or_schedule` overwrote the real shared helper process-wide. Every test collected later in that worker got the mock, which is why all 7 tests in `autobot_shared/async_compat_test.py` failed in CI and none of them failed alone. This is the one change that touches a shared module's behaviour; its blast radius is measured under Verification below.

**`autobot-backend/tests/agent_loop/conftest.py`** — stopped popping every `agent_loop*` key out of `sys.modules` and planting a fresh package at conftest-import time. pytest imports this conftest during collection, long after `autobot-backend/agent_loop/tests/` has bound `AgentLoop` and `PreActionVerifier` from the previous module objects, so the swap left those tests patching a different object than the one they call. It now reuses the session's package object, skips any submodule already real-loaded from the same file, binds each loaded submodule on its parent so `patch()`'s dotted lookup resolves, and restores only what it actually replaced. This is the hazard `tests/orchestration/test_causal_error_recovery.py` already documents in a comment for this exact package.

**`autobot-backend/llc/tests/conftest.py`** — two fixes.
- The `agents` stub had `__path__ = []`, which blocked every real `agents.*` submodule, not just the heavy ones. `autobot-backend/orchestrator.py` imports `agents.agent_client` at module level, so `orchestration/plan_steps_e2e_test.py` could not even be **collected** in a combined run. It now uses the real on-disk `__path__` — the hollow-package pattern this same file already uses for `knowledge` (#13107) and `api.codebase_analytics` — and real-loads the dependency-light `agents/base_agent.py` instead of substituting a mock module that lacked the names `agent_client` imports.
- The `knowledge`/`agents` stubs were installed once at import time but removed by a package-scoped fixture teardown. CI runs `-n auto --dist loadscope`, which groups by module and interleaves packages within a worker, so after the first teardown the stubs never came back and later llc tests ran against the real `knowledge` package. The fixture now re-installs on setup as well as restoring on teardown.

**`autobot-backend/llc/tests/test_heartbeat_context.py`** — the `builtins.__import__` shim looked the name up again at call time, so it resolved to the patch itself and recursed on every non-matching import. Invisible until Python 3.14 moved linecache's `import os` inside `updatecache()`: formatting the traceback of any error raised under the patch then re-entered the shim and blew the stack. The shim also handed back a non-awaitable client, so `assemble()` always took its graceful-degradation path and returned an empty context — the test asserted only `isinstance(ctx, LLCContext)` and never reached the merge it is named for. Fixed both, and added the assertions on the merged chunks and sources.

## Verification

Environment: `SLM_SECRET_KEY` / `SLM_ENCRYPTION_KEY` set to throwaway values, Python 3.10 dev box.

Assigned group, exactly the command in the brief:

```
python3 -m pytest autobot_shared/async_compat_test.py autobot-backend/llc/tests \
  autobot-backend/orchestration autobot-backend/agent_loop/tests -q \
  -m "not integration and not slow and not distributed and not performance"
```

- before: `1 deselected, 2 warnings, 1 error` — collection aborted on `orchestration/plan_steps_e2e_test.py`; with that error worked around, `10 failed, 1758 passed`
- after: `5 failed, 1763 passed, 1 deselected`

The 5 remaining are all `llc/tests/test_poll_loop_scheduler.py` and are the `Task.cancelling()` 3.10-vs-3.14 artifact described above. Confirmed directly:

```
$ python3.14 -c "import asyncio; print(hasattr(asyncio.Task, 'cancelling'))"
True
$ python3   -c "import asyncio; print(hasattr(asyncio.Task, 'cancelling'))"
False
```

and CI lists no failure in that file.

Per-cluster reproduction, each pairing the failing file with the file that poisons it — every one failed before and passes after:

| Reproduction | Before | After |
|---|---|---|
| `agent_loop/tests` + `tests/agent_loop` | 5 failed, 279 passed | 284 passed |
| `tasks` + `autobot_shared/async_compat_test.py` | 7 failed, 103 passed | 110 passed |
| `orchestration/test_causal_executor.py` | 5 failed, 13 passed | 18 passed |
| `llc/tests/test_heartbeat_context.py` + `knowledge/.../cognifiers_test.py` + `llc/tests/test_sprint_close.py` | 5 failed, 71 passed | 4 failed, 72 passed |

The 4 that remain in the last row are `knowledge/pipeline/cognifiers/cognifiers_test.py`, outside this group's four directories; they are red on `Dev_new_gui` today and are unchanged by this PR (filed separately).

Blast-radius sweep over every directory these harness files can reach — `autobot_shared`, `autobot-backend/tests`, `tasks`, `agents`, `orchestration`, `llc`, `agent_loop` — run identically on the base files and on this branch:

- before: **206** distinct failures/errors, including **20 whole files that could not be collected**
- after: **116**

The recovered collection errors include `orchestration/plan_steps_e2e_test.py`, `agents/base_agents_e2e_test.py`, `agents/kb_librarian_agent_test.py`, `agents/knowledge_retrieval_agent_test.py`, `tests/api/test_knowledge_export_import.py` and 15 more, plus all 35 `tests/test_startup_imports.py::test_agents_module_imports[...]` cases.

Entries present after but not before are the newly-collectable files' own remaining failures (previously masked by the collection error) plus a handful of pre-existing order-dependent tests elsewhere whose xdist worker assignment shifted once ~20 more files started collecting: repeating the sweep produced a different subset of them, and each passes when run alone.

One deliberate behaviour change worth calling out. `llc/tests/test_autobot_agent_adapter.py::test_integration_summarization_agent_reaches_completed` opens with `pytest.importorskip("agents.summarization_agent")`. That skip used to fire because the `agents` stub's empty `__path__` made every submodule unimportable, not because the module was genuinely absent. With the real `__path__` the module imports, the test runs, and it fails on `AUTOBOT_SUMMARIZATION_PROVIDER` not being set — it has no guard of its own for a missing LLM provider. It is `@pytest.mark.integration`, so the PR gate deselects it; the only workflow that selects it back is `marker-tests.yml`, which is dormant and non-blocking. Filed separately rather than weakening the test here. Under the PR gate's marker filter the file is unchanged: `30 passed, 1 deselected`.

Lint on all five changed files, clean:

```
python3 -m isort --settings-path=. --line-length=120 <files>
python3 -m black --line-length=120 <files>
python3 -m flake8 --config=.flake8 <files>     # exit 0
python3 -m bandit -c .bandit <files>           # 0 issues at every severity
```

## Model Used

claude-opus-5[1m]

Closes #13162

> **PARTIAL.** This PR closes only the `autobot_shared/async_compat_test.py` · `llc/tests/` · `orchestration/` · `agent_loop/tests/` slice of #13162. **#13162 stays open** — the required-status-check gate it actually tracks is not addressed here, and other test groups remain red. Do not let this merge close it.
