### PR TITLE
ci(marker-tests): withhold the nightly cron until the suite is green (#13286)

### DIFF
--- a/.github/workflows/marker-tests.yml
+++ b/.github/workflows/marker-tests.yml
@@ -39,22 +39,31 @@
 name: Marker-excluded Tests
 
 on:
-  schedule:
-    # 03:20 UTC daily — off the */15 dispatch-watchdog and */30 runner-health
-    # slots, and well clear of working-hours PR traffic.
-    #
-    # DORMANT UNTIL THIS FILE REACHES THE DEFAULT BRANCH (#13286). GitHub
-    # registers `schedule` AND `workflow_dispatch` from the DEFAULT branch only.
-    # This file lives on the integration branch and does not exist on the
-    # default branch, so neither trigger can fire: the workflow has produced
-    # ZERO runs of any kind, and `gh run list --workflow=marker-tests.yml`
-    # answers "could not find any workflows named marker-tests.yml" because
-    # GitHub has never registered it. Adding the workflow was therefore only
-    # half of #13286 — a nightly that cannot be scheduled runs exactly as many
-    # marker-excluded tests as no workflow at all, which is the defect the issue
-    # is about. The cron below starts working the moment the integration branch
-    # is promoted; it is kept, not removed, because it is correct.
-    - cron: '20 3 * * *'
+  # SCHEDULE INTENTIONALLY WITHHELD UNTIL THE SUITE IS GREEN (#13286).
+  #
+  # GitHub registers `schedule` AND `workflow_dispatch` from the DEFAULT branch
+  # only. This file lives on the integration branch, so while it stayed there
+  # neither trigger could fire: the workflow produced ZERO runs of any kind, and
+  # `gh run list --workflow=marker-tests.yml` answered "could not find any
+  # workflows named marker-tests.yml" because GitHub had never registered it.
+  #
+  # That changes the moment the integration branch is promoted to the default
+  # branch — the cron would start firing immediately. Its one observed run is
+  # RED (11 failed, 7 passed, 40 errors), so registering it as-is would install
+  # a nightly that fails every night against the default branch. A permanently
+  # red scheduled workflow is not a signal; it is noise that trains everyone to
+  # ignore the one place marker-excluded regressions would show up.
+  #
+  # So the cron is commented rather than deleted — it is correct, and it is what
+  # #13286 exists to deliver. Restore it as the closing step of that issue, once
+  # the 11 failures and 40 collection errors are triaged and the suite is green.
+  # `workflow_dispatch` below stays live, so the suite remains runnable on demand
+  # to verify exactly that.
+  #
+  # schedule:
+  #   # 03:20 UTC daily — off the */15 dispatch-watchdog and */30 runner-health
+  #   # slots, and well clear of working-hours PR traffic.
+  #   - cron: '20 3 * * *'
   workflow_dispatch:
     inputs:
       markers:


### PR DESCRIPTION
Refs #13286, #13389

## Thinking Path

`marker-tests.yml` currently declares a `20 3 * * *` cron. That cron has never fired, and the file says why in its own comment: GitHub registers `schedule` and `workflow_dispatch` from the **default branch only**, and this workflow exists only on `Dev_new_gui`. The workflow has produced zero runs of either kind — `gh run list --workflow=marker-tests.yml` answers *"could not find any workflows named marker-tests.yml"*, because GitHub has never registered it at all.

That is harmless only while the file stays off the default branch. Promoting `Dev_new_gui` to `main` (#13389) registers the cron immediately.

The single observed run of this suite is **red**: 11 failed, 7 passed, 40 errors (#13286). Registering the cron as-is installs a nightly that fails every night against the default branch. That is worse than having no nightly: a permanently red scheduled workflow stops being a signal and becomes noise, and it trains everyone to ignore the one place marker-excluded regressions would surface — which is the exact outcome #13286 was opened to prevent.

So the cron is **commented, not deleted**. It is correct, and restoring it is the closing step of #13286 once the failures are triaged. Deleting it would lose the intent and the carefully-chosen slot; leaving it live would ship a known-failing nightly.

`workflow_dispatch` stays live deliberately, so the suite can still be run on demand to verify progress on those 51 failures.

## What Changed

`.github/workflows/marker-tests.yml` — the `schedule:` block is commented out, with the reasoning and the restore condition recorded inline. `workflow_dispatch`, `push` and `pull_request` triggers are untouched.

No other file changes. The job body, markers and runner are unchanged.

## Verification

The workflow still parses, and `schedule` is genuinely absent from the trigger set rather than present-but-empty (which Actions rejects):

```
$ python3 -c "import yaml; d=yaml.safe_load(open('.github/workflows/marker-tests.yml')); ..."
triggers: ['pull_request', 'push', 'workflow_dispatch']
schedule present: False
```

```
$ git diff --stat
 .github/workflows/marker-tests.yml | 41 +++++++++++++++---------------
 1 file changed, 25 insertions(+), 16 deletions(-)
```

This workflow's `push`/`pull_request` triggers are scoped to its own file, so this PR exercises the changed workflow directly — its result on this PR is the verification that the file is still valid to Actions, not just to a YAML parser.

Restore condition, for whoever closes #13286: uncomment the `schedule:` block once the 11 failures and 40 collection errors are green.

## Model Used

claude-opus-5
