### PR TITLE
fix(backend): register the missing liveness probe and make config injection real (#13162)

### DIFF
--- a/autobot-backend/dependencies.py
+++ b/autobot-backend/dependencies.py
@@ -58,7 +58,10 @@ def get_knowledge_base(config: ConfigManager = Depends(get_config)):
     """
     from knowledge_base import KnowledgeBase as KnowledgeBase
 
-    return KnowledgeBase()
+    # #13162: the resolved config was previously accepted and then discarded —
+    # every request-scoped KnowledgeBase silently read the global singleton,
+    # so a dependency_overrides[get_config] in tests had no effect here.
+    return KnowledgeBase(config_manager=config)
 
 
 def get_llm_interface(config: ConfigManager = Depends(get_config)):
@@ -96,11 +99,11 @@ def get_orchestrator(
     # Lazy import to reduce startup time
     from orchestrator import Orchestrator
 
-    # #6983: Orchestrator.__init__ takes only ``config_mgr``; the previous
-    # call passed three extra args (llm_interface, knowledge_base, diagnostics)
-    # that have no matching parameter — would TypeError at first invocation.
-    # Orchestrator self-instantiates its sub-components from the config.
-    return Orchestrator(config_mgr=config)
+    # #13162: the constructor parameter is now named for the attribute it sets
+    # (``config_manager``), so this provider and get_cached_orchestrator below
+    # finally agree with it. Orchestrator self-instantiates the collaborators
+    # this provider does not supply.
+    return Orchestrator(config_manager=config)
 
 
 def get_security_layer(config: ConfigManager = Depends(get_config)):
@@ -169,7 +172,8 @@ def get_cached_knowledge_base(config: ConfigManager = Depends(get_config)):
     """
     from knowledge_base import KnowledgeBase as KnowledgeBase
 
-    return dependency_cache.get_or_create("knowledge_base", lambda: KnowledgeBase())
+    # #13162: same dropped-config bug as get_knowledge_base above.
+    return dependency_cache.get_or_create("knowledge_base", lambda: KnowledgeBase(config_manager=config))
 
 
 def get_cached_orchestrator(config: ConfigManager = Depends(get_config)):

--- a/autobot-backend/dependency_injection_test.py
+++ b/autobot-backend/dependency_injection_test.py
@@ -43,6 +43,11 @@ class TestDependencyInjection:
             "task_llm": "test_task_llm",
         }
         mock_config.get_nested.return_value = "local"
+        # ConfigManager.get() returns the caller's default for any key the
+        # settings model does not declare (e.g. orchestrator.max_parallel_tasks),
+        # so mirror that instead of handing back bare Mocks that no numeric
+        # consumer can use.
+        mock_config.get.side_effect = lambda key, default=None: default
 
         mock_llm = Mock()
         mock_kb = Mock()
@@ -51,20 +56,22 @@ class TestDependencyInjection:
         # Create orchestrator with injected dependencies
         orchestrator = Orchestrator(
             config_manager=mock_config,
-            llm_interface=mock_llm,
+            llm_service=mock_llm,
             knowledge_base=mock_kb,
             diagnostics=mock_diagnostics,
         )
 
         # Verify dependencies are properly injected
         assert orchestrator.config_manager is mock_config
-        assert orchestrator.llm_interface is mock_llm
+        assert orchestrator.llm_service is mock_llm
         assert orchestrator.knowledge_base is mock_kb
         assert orchestrator.diagnostics is mock_diagnostics
 
-        # Verify config is used correctly
+        # Verify config is used correctly. OrchestratorConfig reads the model
+        # names through get_llm_config() and every orchestrator.* tunable
+        # through get(); it has no get_nested() call to assert on.
         mock_config.get_llm_config.assert_called_once()
-        mock_config.get_nested.assert_called()
+        mock_config.get.assert_called()
 
     def test_orchestrator_backward_compatibility(self):
         """Test that Orchestrator still works without injected dependencies"""
@@ -73,7 +80,7 @@ class TestDependencyInjection:
 
         # Verify that default dependencies are created
         assert orchestrator.config_manager is not None
-        assert orchestrator.llm_interface is not None
+        assert orchestrator.llm_service is not None
         assert orchestrator.knowledge_base is not None
         assert orchestrator.diagnostics is not None
 
@@ -88,15 +95,17 @@ class TestDependencyInjection:
         mock_config.get_llm_config.return_value = {
             "unified": {"embedding": {"providers": {"ollama": {"selected_model": "test_embed"}}}}
         }
-        mock_config.get.return_value = {"redis": {"host": "test_host", "port": 6379}}
+        mock_config.get.side_effect = lambda key, default=None: default
 
         # Create knowledge base with injected config
         kb = KnowledgeBase(config_manager=mock_config)
 
-        # Verify config is properly injected and used
+        # Verify config is properly injected and used. KnowledgeBase reads its
+        # Redis/ChromaDB settings through ConfigManager.get(); the embedding
+        # model it once resolved via get_llm_config() now comes from ssot_config
+        # inside the async _configure_llama_index step, not from construction.
         assert kb.config_manager is mock_config
-        mock_config.get_llm_config.assert_called_once()
-        mock_config.get_nested.assert_called()
+        mock_config.get.assert_called()
 
     def test_knowledge_base_backward_compatibility(self):
         """Test that KnowledgeBase still works without injected config"""
@@ -108,52 +117,25 @@ class TestDependencyInjection:
         assert isinstance(kb.config_manager, ConfigManager)
 
     def test_diagnostics_with_dependencies(self):
-        """Test that Diagnostics can be created with injected dependencies"""
-        # Create mock dependencies
-        mock_config = Mock(spec=ConfigManager)
-        # Mock the reliability stats file path to a non-existent file
-        mock_config.get_nested.side_effect = lambda key, default=None: {
-            "data.reliability_stats_file": "/tmp/test_reliability_stats.json",  # nosec B108 - test/controlled code uses tmpdir intentionally
-            "diagnostics.enabled": True,
-            "diagnostics.use_llm_for_analysis": True,
-            "diagnostics.use_web_search_for_analysis": False,
-            "diagnostics.auto_apply_fixes": False,
-        }.get(key, default)
+        """Test that Diagnostics can be created with injected dependencies.
 
+        Diagnostics reads no ConfigManager keys at construction: the
+        ``diagnostics.*`` settings that models/settings.py declares
+        (enabled, use_llm_for_analysis, use_web_search_for_analysis,
+        auto_apply_fixes) are not reachable through ConfigManager at all --
+        it exposes no ``diagnostics`` section, so every one of those lookups
+        can only ever return the caller's default. Asserting a config read
+        here would therefore be asserting fake wiring; the contract that
+        matters, and that dependencies.get_diagnostics depends on, is that the
+        injected instances are the ones held.
+        """
+        mock_config = Mock(spec=ConfigManager)
         mock_llm = Mock()
 
-        # Create a minimal reliability stats file for the test
-        import json
-        import os
-        import tempfile
+        diagnostics = Diagnostics(config_manager=mock_config, llm_service=mock_llm)
 
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
-            json.dump({}, f)
-            temp_file = f.name
-
-        try:
-            # Update mock to use the temp file
-            mock_config.get_nested.side_effect = lambda key, default=None: {
-                "data.reliability_stats_file": temp_file,
-                "diagnostics.enabled": True,
-                "diagnostics.use_llm_for_analysis": True,
-                "diagnostics.use_web_search_for_analysis": False,
-                "diagnostics.auto_apply_fixes": False,
-            }.get(key, default)
-
-            # Create diagnostics with injected dependencies
-            diagnostics = Diagnostics(config_manager=mock_config, llm_interface=mock_llm)
-
-            # Verify dependencies are properly injected
-            assert diagnostics.config_manager is mock_config
-            assert diagnostics.llm_interface is mock_llm
-
-            # Verify config is used correctly
-            mock_config.get_nested.assert_called()
-
-        finally:
-            # Clean up temp file
-            os.unlink(temp_file)
+        assert diagnostics.config_manager is mock_config
+        assert diagnostics.llm_service is mock_llm
 
     def test_diagnostics_backward_compatibility(self):
         """Test that Diagnostics still works without injected dependencies"""
@@ -162,7 +144,7 @@ class TestDependencyInjection:
 
         # Verify that default dependencies are created
         assert diagnostics.config_manager is not None
-        assert diagnostics.llm_interface is not None
+        assert diagnostics.llm_service is not None
 
         # Verify they are the expected types
         assert isinstance(diagnostics.config_manager, ConfigManager)
@@ -199,7 +181,7 @@ class TestDependencyInjection:
         orchestrator = Orchestrator(config_manager=config)
         assert isinstance(orchestrator, Orchestrator)
         assert hasattr(orchestrator, "config_manager")
-        assert hasattr(orchestrator, "llm_interface")
+        assert hasattr(orchestrator, "llm_service")
         assert hasattr(orchestrator, "knowledge_base")
         assert hasattr(orchestrator, "diagnostics")
 
@@ -213,7 +195,7 @@ class TestDependencyInjection:
             "task_llm": "test_task_llm",
         }
         mock_config.get_nested.return_value = "local"
-        mock_config.get.return_value = {"redis": {"host": "test_host", "port": 6379}}
+        mock_config.get.side_effect = lambda key, default=None: default
 
         # Create components with mock config
         orchestrator = Orchestrator(config_manager=mock_config)
@@ -225,9 +207,11 @@ class TestDependencyInjection:
         assert kb.config_manager is mock_config
         assert diagnostics.config_manager is mock_config
 
-        # Verify config methods are called on the injected instance
+        # Verify config methods are called on the injected instance. Both
+        # Orchestrator and KnowledgeBase read their settings through get();
+        # neither reaches for the module-level ConfigManager any more.
         assert mock_config.get_llm_config.called
-        assert mock_config.get_nested.called
+        assert mock_config.get.called
 
 
 if __name__ == "__main__":

--- a/autobot-backend/diagnostics.py
+++ b/autobot-backend/diagnostics.py
@@ -11,7 +11,7 @@ import asyncio
 import gc
 import logging
 import platform
-import subprocess  # nosec B404 - controlled system diagnostics
+import subprocess  # nosec B404  # controlled system diagnostics
 import sys
 import time
 from datetime import datetime, timezone
@@ -41,8 +41,30 @@ class PerformanceOptimizedDiagnostics:
     Enhanced diagnostics with performance monitoring and timeout optimization
     """
 
-    def __init__(self):
-        """Initialize performance diagnostics with monitoring settings and Redis."""
+    def __init__(self, config_manager=None, llm_service=None):
+        """Initialize performance diagnostics with injected or default dependencies.
+
+        Nothing here reads a ConfigManager key: the ``diagnostics.*`` settings
+        declared in models/settings.py are not reachable through ConfigManager,
+        which exposes no ``diagnostics`` section (recorded on #12750). The
+        manager is held so callers such as dependencies.get_diagnostics can
+        supply one and so the class stops reaching for the global singleton.
+
+        Args:
+            config_manager: ConfigManager for this instance (#13162). Falls back
+                to the application-wide singleton so existing zero-arg callers
+                keep working.
+            llm_service: LLMService used for failure analysis. Falls back to the
+                shared singleton.
+        """
+        # Imported lazily: config.manager and services.llm_service both sit
+        # above this module in the startup import graph.
+        from config.manager import get_config_manager
+        from services.llm_service import get_llm_service
+
+        self.config_manager = config_manager or get_config_manager()
+        self.llm_service = llm_service or get_llm_service()
+
         # Performance monitoring settings (Issue #376 - use named constants)
         self.max_user_permission_timeout = float(TimingConstants.SHORT_TIMEOUT)
         self.permission_retry_attempts = RetryConfig.MIN_RETRIES
@@ -106,7 +128,7 @@ class PerformanceOptimizedDiagnostics:
     def _get_gpu_info(self) -> Dict[str, Any]:
         """Get GPU information for performance monitoring"""
         try:
-            result = subprocess.run(  # nosec B603 B607 - fixed nvidia-smi argv, no user input
+            result = subprocess.run(  # nosec B603 B607  # fixed nvidia-smi argv, no user input
                 [
                     "nvidia-smi",
                     "--query-gpu=name,memory.total,memory.used,utilization.gpu",

--- a/autobot-backend/initialization/endpoints.py
+++ b/autobot-backend/initialization/endpoints.py
@@ -227,6 +227,26 @@ def register_root_endpoints(app: FastAPI) -> None:
             **status,
         }
 
+    @app.get("/api/hello")
+    @with_error_handling(category=ErrorCategory.SYSTEM)
+    async def root_hello():
+        """Dependency-free liveness probe (#13162).
+
+        The readiness helpers in the E2E suites and the operator diagnostic
+        scripts have always polled this path to decide whether the backend has
+        finished booting, but it was never registered on the real app — only on
+        the standalone minimal_backend_test fixture. Every one of those probes
+        therefore waited for a 200 that could not arrive.
+
+        Deliberately touches no Redis, database or config so that it answers
+        while the rest of startup is still in progress.
+        """
+        return {
+            "message": "AutoBot backend is running",
+            "status": "ok",
+            "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+        }
+
     @app.get("/api/version")
     @with_error_handling(category=ErrorCategory.SYSTEM)
     async def root_version():
@@ -248,7 +268,7 @@ def register_root_endpoints(app: FastAPI) -> None:
     logger.info(
         "Root endpoints registered: /api/health, /api/health/ai-stack, "
         "/api/health/circuit-breakers, /api/health/celery-dead-letter, "
-        "/api/version, /.well-known/agent.json"
+        "/api/hello, /api/version, /.well-known/agent.json"
     )
 
 

--- a/autobot-backend/knowledge/_composed.py
+++ b/autobot-backend/knowledge/_composed.py
@@ -51,8 +51,9 @@ class KnowledgeBase(
 ):
     """Unified Knowledge Base composed from 14 specialised mixins."""
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, config_manager=None):
+        """Compose the knowledge base, optionally with an injected ConfigManager (#13162)."""
+        super().__init__(config_manager=config_manager)
         logger.debug("KnowledgeBase instance created (composed from 14 mixins)")
 
     async def initialize(self) -> bool:

--- a/autobot-backend/knowledge/base.py
+++ b/autobot-backend/knowledge/base.py
@@ -39,8 +39,6 @@ from utils.knowledge_base_timeouts import kb_timeouts
 if TYPE_CHECKING:
     pass
 
-config = get_config_manager()
-
 logger = get_logger(__name__)
 
 
@@ -86,17 +84,17 @@ class KnowledgeBaseCore:
         self.redis_port = ssot_config.port.redis
         self.redis_password = ssot_config.redis.password
         self.redis_db = DATABASE_MAPPING["knowledge"]  # (#2670)
-        self.redis_index_name = config.get("redis.indexes.knowledge_base", "llama_index")
+        self.redis_index_name = self.config_manager.get("redis.indexes.knowledge_base", "llama_index")
 
     def _init_chromadb_config(self) -> None:
         """Initialize ChromaDB configuration (Issue #398: extracted)."""
-        self.chromadb_path = config.get("memory.chromadb.path", "data/chromadb")
-        self.chromadb_collection = config.get("memory.chromadb.collection_name", "autobot_memory")
+        self.chromadb_path = self.config_manager.get("memory.chromadb.path", "data/chromadb")
+        self.chromadb_collection = self.config_manager.get("memory.chromadb.collection_name", "autobot_memory")
         # Issue #72: HNSW parameters optimized for 545K+ vectors
-        self.hnsw_space = config.get("memory.chromadb.hnsw.space", "cosine")
-        self.hnsw_construction_ef = config.get("memory.chromadb.hnsw.construction_ef", 300)
-        self.hnsw_search_ef = config.get("memory.chromadb.hnsw.search_ef", 100)
-        self.hnsw_m = config.get("memory.chromadb.hnsw.M", 32)
+        self.hnsw_space = self.config_manager.get("memory.chromadb.hnsw.space", "cosine")
+        self.hnsw_construction_ef = self.config_manager.get("memory.chromadb.hnsw.construction_ef", 300)
+        self.hnsw_search_ef = self.config_manager.get("memory.chromadb.hnsw.search_ef", 100)
+        self.hnsw_m = self.config_manager.get("memory.chromadb.hnsw.M", 32)
         # Issue #8155: SQ8 scalar quantization — opt-in via AUTOBOT_HNSW_QUANTIZATION_TYPE=sq.
         # Empty string (default) disables quantization (safe for ChromaDB 1.5.x which rejects
         # the key; non-empty value is added to hnsw_metadata and tried at collection creation).
@@ -122,11 +120,22 @@ class KnowledgeBaseCore:
         # Issue #8391: VectorWriteBuffer (started in lifespan after ChromaDB init)
         self._write_buffer = None
 
-    def __init__(self):
-        """Initialize instance variables only (Issue #398: refactored)."""
+    def __init__(self, config_manager=None):
+        """Initialize instance variables only (Issue #398: refactored).
+
+        Args:
+            config_manager: ConfigManager to read Redis/ChromaDB settings from
+                (#13162). Falls back to the application-wide singleton, so the
+                many zero-arg callers keep working unchanged.
+        """
         # Call super().__init__() to ensure mixin __init__ methods are called
-        # This is critical for SearchMixin to initialize _query_processor
+        # This is critical for SearchMixin to initialize _query_processor.
+        # Deliberately not forwarding config_manager: the remaining mixins in
+        # the MRO take no constructor arguments.
         super().__init__()
+
+        # Must precede _init_redis_config/_init_chromadb_config, which read it.
+        self.config_manager = config_manager or get_config_manager()
 
         self.initialized = False
         self.initialization_lock = asyncio.Lock()

--- a/autobot-backend/middleware/service_auth_enforcement.py
+++ b/autobot-backend/middleware/service_auth_enforcement.py
@@ -39,6 +39,7 @@ EXEMPT_PATHS: List[str] = [
     # Health and version endpoints
     PATH_HEALTH,  # Health check (no /api prefix)
     PATH_API_HEALTH,  # API health check
+    "/api/hello",  # Liveness probe used by the readiness helpers (#13162)
     "/api/version",  # Version information
     # User-facing chat and conversation endpoints
     "/api/chat",
@@ -251,7 +252,7 @@ def _should_enforce_by_circuit_breaker() -> bool:
         return True
     if pct <= 0:
         return False
-    return random.randint(1, 100) <= pct  # nosec B311 - percentage-based sampling gate, not cryptographic
+    return random.randint(1, 100) <= pct  # nosec B311  # percentage-based sampling gate, not cryptographic
 
 
 def _rate_limit_settings() -> tuple[int, int]:

--- a/autobot-backend/middleware/service_auth_logging.py
+++ b/autobot-backend/middleware/service_auth_logging.py
@@ -45,6 +45,7 @@ class ServiceAuthLoggingMiddleware(BaseHTTPMiddleware):
         skip_paths = [
             PATH_HEALTH,  # Health check (no prefix)
             PATH_API_HEALTH,  # General health check
+            "/api/hello",  # Liveness probe (#13162)
             "/api/version",  # Version info
             "/docs",  # API documentation
             "/openapi.json",  # OpenAPI spec

--- a/autobot-backend/orchestrator.py
+++ b/autobot-backend/orchestrator.py
@@ -41,6 +41,7 @@ from autobot_shared.logging_manager import get_logger
 from autobot_shared.workflow import ExecutionStrategy
 from config.manager import get_config_manager as _get_config_manager
 from constants.threshold_constants import LLMDefaults, TimingConstants
+from diagnostics import get_performance_diagnostics
 from memory import LongTermMemoryManager
 
 # Issue #5040 / #10666 B3: multi-agent imports (consolidated into orchestration)
@@ -95,9 +96,6 @@ from utils.agent_selection import reserve_agent as _reserve_agent
 
 logger = get_logger("orchestrator")
 
-# Canonical singleton; avoids routing through config/__init__ lazy alias (Issue #3829)
-config_manager = _get_config_manager()
-
 # Import KnowledgeBase for enhanced features
 try:
     from knowledge_base import KnowledgeBase
@@ -133,11 +131,14 @@ class Orchestrator(_DeprecatedRequestMixin):
 
     # ------------------------------------------------------------------ init
 
-    def _init_core_components(self, config_mgr) -> None:
-        self.config_manager = config_mgr or _get_config_manager()
+    def _init_core_components(self, config_manager, llm_service, diagnostics) -> None:
+        self.config_manager = config_manager or _get_config_manager()
         self.config = OrchestratorConfig(self.config_manager)
         # #6983: migrated from LLMInterface to LLMService (#3185 missed this caller)
-        self.llm_service = get_llm_service()
+        self.llm_service = llm_service or get_llm_service()
+        # #13162: diagnostics is a first-class injectable collaborator; the
+        # default is the canonical lazy singleton rather than a fresh instance.
+        self.diagnostics = diagnostics or get_performance_diagnostics()
         self.memory_manager = LongTermMemoryManager()
         self.agent_manager = AgentManager()
 
@@ -155,7 +156,7 @@ class Orchestrator(_DeprecatedRequestMixin):
             "average_response_time": 0,
         }
 
-    def _init_components(self) -> None:
+    def _init_components(self, knowledge_base) -> None:
         self.agent_registry: Dict[str, AgentProfile] = {}
         # GH #6820: AgentCapabilityRegistry — structured profile store with capability-based lookup.
         # Runs alongside the plain-dict self.agent_registry for structured queries.
@@ -164,7 +165,15 @@ class Orchestrator(_DeprecatedRequestMixin):
         self._profile_registry = AgentCapabilityRegistry(initialize_defaults=False)
         self.workflow_documentation: Dict[str, WorkflowDocumentation] = {}
         self.agent_interactions: List[AgentInteraction] = []
-        self.knowledge_base = KnowledgeBase() if KNOWLEDGE_BASE_AVAILABLE else None
+        # #13162: honour an injected KnowledgeBase and hand the (possibly
+        # injected) ConfigManager to the default instance instead of letting it
+        # reach for the global singleton.
+        if knowledge_base is not None:
+            self.knowledge_base = knowledge_base
+        elif KNOWLEDGE_BASE_AVAILABLE:
+            self.knowledge_base = KnowledgeBase(config_manager=self.config_manager)
+        else:
+            self.knowledge_base = None
         self.knowledge_extraction_enabled = KNOWLEDGE_BASE_AVAILABLE
         self.auto_doc_enabled = True
         self.workflow_metrics = {
@@ -242,10 +251,22 @@ class Orchestrator(_DeprecatedRequestMixin):
             max_parallel_tasks=self.config.max_parallel_tasks,
         )
 
-    def __init__(self, config_mgr=None):
-        self._init_core_components(config_mgr)
+    def __init__(self, config_manager=None, llm_service=None, knowledge_base=None, diagnostics=None):
+        """Build an Orchestrator, optionally with injected collaborators (#13162).
+
+        Args:
+            config_manager: ConfigManager to read orchestrator settings from.
+                Falls back to the application-wide singleton.
+            llm_service: LLMService used for model calls. Falls back to the
+                shared singleton.
+            knowledge_base: KnowledgeBase used for auto-documentation. Falls
+                back to a new instance bound to ``config_manager``.
+            diagnostics: Diagnostics collaborator. Falls back to the canonical
+                lazy singleton.
+        """
+        self._init_core_components(config_manager, llm_service, diagnostics)
         self._init_task_state()
-        self._init_components()
+        self._init_components(knowledge_base)
         self._init_classification_agent()
         self._initialize_default_agents()
         self._init_strategy_components()
@@ -329,7 +350,10 @@ class Orchestrator(_DeprecatedRequestMixin):
             )
             return
         logger.warning("⚠️ Orchestrator model '%s' test failed", self.config.orchestrator_llm_model)
-        fallback_model = config_manager.get_default_llm_model()
+        # #13162: was the module-level singleton, which silently ignored an
+        # injected ConfigManager — the fallback model came from global config
+        # even when the caller supplied its own.
+        fallback_model = self.config_manager.get_default_llm_model()
         if await self._validate_llm_model(fallback_model):
             logger.info("✅ Using fallback model: %s", fallback_model)
             self.config.orchestrator_llm_model = fallback_model

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -118,6 +118,35 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/hello": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Root Hello
+         * @description Dependency-free liveness probe (#13162).
+         *
+         *     The readiness helpers in the E2E suites and the operator diagnostic
+         *     scripts have always polled this path to decide whether the backend has
+         *     finished booting, but it was never registered on the real app — only on
+         *     the standalone minimal_backend_test fixture. Every one of those probes
+         *     therefore waited for a 200 that could not arrive.
+         *
+         *     Deliberately touches no Redis, database or config so that it answers
+         *     while the rest of startup is still in progress.
+         */
+        get: operations["root_hello_api_hello_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/version": {
         parameters: {
             query?: never;
@@ -101821,6 +101850,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    root_hello_api_hello_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
                 };
             };
         };


### PR DESCRIPTION
## Thinking Path

Three startup/wiring test files were red. Because these tests exercise boot and
dependency wiring rather than business logic, the working hypothesis was that a
failure means a genuinely broken import or a genuinely unwired dependency. That
held for 7 of the 9 local failures.

**`/api/hello` (1 failure).** `system_integration_test.py` asserts four basic
endpoints are routable. Three were; `/api/hello` returned 404. Grepping for the
path found it defined only in `minimal_backend_test.py`, a standalone dev
fixture -- never on the app that `create_app()` builds. Five consumers poll it
as the canonical "is the backend up" probe: the readiness gates in
`api/security_endpoints_e2e_test.py` and `api/live_workflow_e2e_test.py` (both
wait for a 200 before starting), plus `diagnose_backend.py`,
`check_backend_status.py` and `demo_workflow_system.py`. All five were waiting
on a response that could not arrive. The endpoint was missing, not the test.

**Dependency injection (8 failures).** `dependency_injection_test.py` asserts
`Orchestrator`, `KnowledgeBase` and `Diagnostics` accept an injected
`config_manager`. None of them did. The decisive evidence that the test was
right and the code wrong is `dependencies.py`: its FastAPI providers *already*
call all three with `config_manager=`, so four of them were broken -- two
raising `TypeError` on first invocation, two silently discarding the config they
were handed. `#6983` had fixed one such provider by bending the caller to the
class's odd parameter name (`config_mgr`) rather than the class to its own
attribute name (`self.config_manager`), and missed the rest.

Tracing the injection through turned up one more live defect: the orchestrator
read its LLM fallback model from the module-level config singleton, ignoring any
injected manager.

Four test assertions did name APIs the code does not call. Those were corrected
to the API each class actually uses -- the injection claim they exist to prove is
preserved in every case.

One assertion deserves its own note, because the tempting fix was the wrong one.
`test_diagnostics_with_dependencies` asserted a `get_nested` read and built a
temp reliability-stats file to feed it. The obvious move was to wire
`DiagnosticsSettings.auto_apply_fixes` (declared in `models/settings.py`, read
by nothing) into the permission prompt it documents. Checking first showed why
that would have been fake: `ConfigManager.to_dict()` exposes no `diagnostics`
section at all, so `get_nested("diagnostics.auto_apply_fixes", False)` can only
ever return the default. Wiring it would have shipped a knob that is
unreachable by construction. The wiring was reverted and the finding recorded on
#12750 instead.

## What Changed

**Missing liveness endpoint**

- `initialization/endpoints.py` -- registered `/api/hello` alongside `/api/version`.
  The handler touches no Redis, database or config, so it answers while the rest
  of startup is still in progress, which is what a readiness gate needs.
- `middleware/service_auth_enforcement.py`, `middleware/service_auth_logging.py`
  -- added the path to both service-auth exemption lists, matching how
  `/api/version` is treated, so the probes get a 200 rather than a 401.

**Dependency injection made real**

- `orchestrator.py` -- `__init__(config_manager=, llm_service=, knowledge_base=,
  diagnostics=)`. `config_mgr` renamed to match the attribute it has always set;
  the other three collaborators are now injectable and default to the canonical
  singletons. Also removed the module-level `ConfigManager` global.
- `knowledge/base.py`, `knowledge/_composed.py` --
  `__init__(config_manager=None)`. The seven Redis/ChromaDB settings now read
  through the injected manager; the module-level global they used is removed.
  `config_manager` is deliberately not forwarded up the MRO -- the remaining
  mixins take no constructor arguments.
- `diagnostics.py` -- `__init__(config_manager=, llm_service=)`.
- `dependencies.py` -- `get_knowledge_base` and `get_cached_knowledge_base` now
  pass the config they resolve instead of dropping it; `get_orchestrator` uses
  the corrected parameter name. `get_diagnostics` and `get_cached_orchestrator`
  needed no edit -- their existing calls became valid once the constructors did.

**Production bug fixed on the way**

- `orchestrator.py` `_ensure_working_llm_model` read the fallback model from the
  module-level singleton, silently ignoring an injected `ConfigManager`. Now
  reads `self.config_manager`.

**Test-side corrections** (corrected, not weakened -- each still proves the
injected instance is the one consulted)

- `llm_interface` -> `llm_service` on `Orchestrator` and `Diagnostics`. `#3185`
  retired `LLMInterface` in favour of `LLMService`; resurrecting the old name
  would re-introduce an alias the repo deliberately removed.
- `KnowledgeBase` asserted `get_llm_config`/`get_nested`. It reads its settings
  through `get()`; embedding-model resolution moved into the async
  `_configure_llama_index` step. Now asserts `get()`.
- `Orchestrator` asserted `get_nested`. `OrchestratorConfig` uses
  `get_llm_config()` plus `get()`. Now asserts `get()`.
- `Diagnostics` asserted `get_nested`. No `diagnostics` section is reachable
  through `ConfigManager`, so the test now asserts the contract
  `dependencies.get_diagnostics` actually needs -- the injected instances are the
  ones held. Reasoning is recorded in the test docstring.
- The mock `ConfigManager` returned bare `Mock`s from `get()`, which no numeric
  consumer can use -- `asyncio.Semaphore(Mock)` raised `TypeError`. The real
  manager returns the caller's default for keys the settings model does not
  declare, so the mock now mirrors that.

## Verification

```
SLM_SECRET_KEY=throwaway SLM_ENCRYPTION_KEY=x python3 -m pytest \
  autobot-backend/system_integration_test.py \
  autobot-backend/dependency_injection_test.py \
  autobot-backend/tests/test_startup_imports.py \
  -q -p no:cacheprovider \
  -m "not integration and not slow and not distributed and not performance"

before:  9 failed, 368 passed
after:            377 passed
```

Endpoint reachable unauthenticated through the real app:

```
PROBE /api/hello 200 {'message': 'AutoBot backend is running', 'status': 'ok', ...}
PROBE /api/version 200
PROBE /api/system/health 200
```

No regression in the blast radius. Every number below is a pair: the same
command run in a worktree checked out at the base commit, then on this branch.

```
autobot-backend/orchestration              5 failed / 303 passed   base and branch
autobot-backend/tests/middleware          53 passed               branch
autobot-backend/initialization            24 passed               branch

the five knowledge files that carry the suite's failures
(code_semantic_search, kb_optimization, search_quality,
 connectors/scheduler, connectors/connector_resilience)
                                          12 failed / 108 passed  base and branch
```

The knowledge failures are pre-existing and unrelated -- Redis-dependent leader
election and connector checkpoints, plus search-quality date filters. None of
them touch `KnowledgeBaseCore.__init__`.

A whole-directory `autobot-backend/knowledge` run reports 16 failures rather
than 12 (four more appear only under full-suite ordering); it is reported here
at file granularity because the whole-directory run at the base commit had to be
abandoned after exceeding its timeout twice under load.

Lint clean on all nine changed files: `isort`, `black`, `flake8` (0 findings),
`bandit -c .bandit` (no issues identified, no severity floor).

Local Python is 3.10 and CI runs 3.14. CI reported 16/8/4 for these three files;
locally the baseline was 1/8/0. The 8 `dependency_injection_test.py` failures
reproduce exactly and are fixed. `system_integration_test.py` has exactly 16 test
functions, so CI's 16 is a total wipeout of that file -- consistent with
`create_app()` failing at `setup_method` under 3.14, a single root cause distinct
from the `/api/hello` routing bug fixed here. The 3.14-only failures could not be
reproduced: that interpreter is present on the dev box but has no project
dependencies installed, and installing them ad hoc is not permitted.
`python3.14 -m compileall` over `api/`, `agents/`, `initialization/`,
`app_factory.py` and `main.py` is clean, so the remaining 3.14 failures are
import- or runtime-level, not syntax.

## Model Used

Claude Opus 5 (1M context)

Closes #13162

> **PARTIAL.** This PR fixes only the three files it was scoped to
> (`system_integration_test.py`, `dependency_injection_test.py`,
> `tests/test_startup_imports.py`). #13162 covers the whole red Python suite and
> **stays open** -- sibling PRs are repairing the other groups, and the
> Python-3.14-only failures in `system_integration_test.py` and
> `tests/test_startup_imports.py` are not addressed here.
