### PR TITLE
security(files): reject upload filenames carrying a path component (#13394)

### DIFF
--- a/autobot-backend/api/files.py
+++ b/autobot-backend/api/files.py
@@ -44,6 +44,7 @@ from autobot_shared.security.path_validator import (
     SANDBOX_INVALID_PATH_CHARACTERS,
     SandboxPathError,
     resolve_within_sandbox,
+    validate_relative_path,
 )
 from constants.error_constants import (
     ERR_DIRECTORY_NOT_FOUND,
@@ -286,19 +287,9 @@ def is_safe_file(filename: str) -> bool:
     if any(char in filename for char in _DANGEROUS_FILENAME_CHARS):
         return False
 
-    # An uploaded filename is a bare name, never a path (#13394). Anything with a
-    # directory component — "../x", "a/b", or an absolute "/etc/x" — is rejected.
-    #
-    # Without this the checks below are trivially bypassed rather than merely
-    # weak: _DANGEROUS_FILENAMES compares whole strings, so a directory prefix
-    # defeats it, and Path(...).suffix reads only the last component, so any
-    # prefix still presents an allowed extension.
-    #
-    # Backslash is rejected explicitly because Path.name is platform-dependent:
-    # on POSIX "dir\\evil.py" is a single valid component, so the Path.name
-    # comparison alone lets it through. It is not a POSIX escape, but the name is
-    # a separator to any Windows-side or path-splitting consumer downstream, and
-    # filesystem_mcp already rejects it for the same reason (#13162).
+    # An uploaded filename is a bare name, never a path (#13394). Backslash is
+    # checked explicitly because Path.name is platform-dependent — on POSIX
+    # "dir\\evil.py" is one valid component (#13162).
     if "/" in filename or "\\" in filename or Path(filename).name != filename:
         return False
 
@@ -658,23 +649,13 @@ async def upload_file(
     # Issue #358: mkdir in thread to avoid blocking
     await run_in_file_executor(lambda: target_dir.mkdir(parents=True, exist_ok=True))
 
-    # Prepare target file path (#13394).
-    #
-    # Deliberately NOT `target_dir / file.filename`. Validating the directory says
-    # nothing about the joined result, and pathlib's join is hostile here: a
-    # traversing name resolves outside the sandbox, and an ABSOLUTE name discards
-    # `target_dir` entirely ( Path('/sandbox') / '/etc/passwd' -> '/etc/passwd' ).
-    # The post-write relative_to() below cannot catch either, because it is purely
-    # lexical — it does not normalise '..' and so does not raise — and it runs only
-    # after the bytes are already on disk.
-    #
-    # is_safe_file() already rejects any non-bare filename; re-resolving the joined
-    # path through the shared sandbox resolver keeps containment true even if that
-    # check is later relaxed or the join refactored, and covers symlinked escapes
-    # that a '..' comparison would miss (it resolves via os.path.realpath).
-    target_file = validate_and_resolve_path(
-        "/".join(part for part in (path.strip("/"), file.filename) if part)
-    )
+    # Not `target_dir / file.filename`: pathlib's join is hostile here, and an
+    # ABSOLUTE filename discards target_dir outright. Resolve via realpath so
+    # containment holds for symlinks too (#13394).
+    try:
+        target_file = validate_relative_path(file.filename, target_dir)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid filename")
 
     # Write file (Issue #281: uses helper)
     await _write_upload_file(target_file, content, overwrite)

--- a/autobot-backend/api/files.py
+++ b/autobot-backend/api/files.py
@@ -286,6 +286,22 @@ def is_safe_file(filename: str) -> bool:
     if any(char in filename for char in _DANGEROUS_FILENAME_CHARS):
         return False
 
+    # An uploaded filename is a bare name, never a path (#13394). Anything with a
+    # directory component — "../x", "a/b", or an absolute "/etc/x" — is rejected.
+    #
+    # Without this the checks below are trivially bypassed rather than merely
+    # weak: _DANGEROUS_FILENAMES compares whole strings, so a directory prefix
+    # defeats it, and Path(...).suffix reads only the last component, so any
+    # prefix still presents an allowed extension.
+    #
+    # Backslash is rejected explicitly because Path.name is platform-dependent:
+    # on POSIX "dir\\evil.py" is a single valid component, so the Path.name
+    # comparison alone lets it through. It is not a POSIX escape, but the name is
+    # a separator to any Windows-side or path-splitting consumer downstream, and
+    # filesystem_mcp already rejects it for the same reason (#13162).
+    if "/" in filename or "\\" in filename or Path(filename).name != filename:
+        return False
+
     if len(filename) > 255:
         return False
 
@@ -642,8 +658,23 @@ async def upload_file(
     # Issue #358: mkdir in thread to avoid blocking
     await run_in_file_executor(lambda: target_dir.mkdir(parents=True, exist_ok=True))
 
-    # Prepare target file path
-    target_file = target_dir / file.filename
+    # Prepare target file path (#13394).
+    #
+    # Deliberately NOT `target_dir / file.filename`. Validating the directory says
+    # nothing about the joined result, and pathlib's join is hostile here: a
+    # traversing name resolves outside the sandbox, and an ABSOLUTE name discards
+    # `target_dir` entirely ( Path('/sandbox') / '/etc/passwd' -> '/etc/passwd' ).
+    # The post-write relative_to() below cannot catch either, because it is purely
+    # lexical — it does not normalise '..' and so does not raise — and it runs only
+    # after the bytes are already on disk.
+    #
+    # is_safe_file() already rejects any non-bare filename; re-resolving the joined
+    # path through the shared sandbox resolver keeps containment true even if that
+    # check is later relaxed or the join refactored, and covers symlinked escapes
+    # that a '..' comparison would miss (it resolves via os.path.realpath).
+    target_file = validate_and_resolve_path(
+        "/".join(part for part in (path.strip("/"), file.filename) if part)
+    )
 
     # Write file (Issue #281: uses helper)
     await _write_upload_file(target_file, content, overwrite)

--- a/autobot-backend/api/files_upload_path_test.py
+++ b/autobot-backend/api/files_upload_path_test.py
@@ -13,11 +13,13 @@ for the substring ``is_safe_file``, which stays green whether or not the
 function actually rejects a traversing name.
 """
 
+import os
 from pathlib import Path
 
 import pytest
 
 from api.files import is_safe_file
+from autobot_shared.security.path_validator import validate_relative_path
 
 # Extensions the endpoint allows; each escape below therefore clears the
 # extension allowlist and is stopped only by the path-component check.
@@ -33,7 +35,6 @@ _ALLOWED_SUFFIX = ".py"
         "subdir/evil.py",
         "./evil.py",
         "/etc/passwd.py",
-        "/opt/autobot/autobot-backend/api/health.py",
         "..\\evil.py",
         "dir\\evil.py",
     ],
@@ -41,6 +42,57 @@ _ALLOWED_SUFFIX = ".py"
 def test_rejects_filenames_carrying_a_directory_component(filename):
     """Any multi-segment or absolute name is refused."""
     assert is_safe_file(filename) is False
+
+
+# --- layer 2: containment of the resolved target ---------------------------
+#
+# is_safe_file is only the first layer. The endpoint additionally resolves the
+# filename against the validated directory. These tests exercise that second
+# layer directly, because layer 1 passing says nothing about it: an earlier
+# revision of this fix routed layer 2 through the sandbox *path* resolver, which
+# applies a lexical ".." / "~" substring rejection. That is correct for a path
+# and wrong for a filename — it 400'd every legitimate name below while layer 1
+# and its tests stayed green.
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "..leading-dots.py",
+        "my..file.py",
+        "~notes.md",
+        "backup~.txt",
+        "draft~1.txt",
+        "report..final.md",
+        "...rc.yml",
+    ],
+)
+def test_layer_two_accepts_legitimate_names_containing_dots_or_tilde(filename, tmp_path):
+    """`..` and `~` inside a bare filename are ordinary characters, not traversal."""
+    resolved = validate_relative_path(filename, tmp_path)
+    assert resolved.parent == Path(os.path.realpath(tmp_path))
+    assert resolved.name == filename
+
+
+@pytest.mark.parametrize(
+    "filename",
+    ["../evil.py", "../../etc/passwd.py", "/etc/passwd.py", "sub/../../evil.py"],
+)
+def test_layer_two_rejects_escapes(filename, tmp_path):
+    """Containment is enforced on the resolved path, not on the string."""
+    with pytest.raises(ValueError):
+        validate_relative_path(filename, tmp_path)
+
+
+def test_layer_two_rejects_symlink_escape(tmp_path):
+    """realpath resolution catches an escape a '..' comparison would miss."""
+    outside = tmp_path.parent / "outside_target.py"
+    outside.write_text("x", encoding="utf-8")
+    sandbox = tmp_path / "sandbox"
+    sandbox.mkdir()
+    (sandbox / "link.py").symlink_to(outside)
+    with pytest.raises(ValueError):
+        validate_relative_path("link.py", sandbox)
 
 
 @pytest.mark.parametrize(

--- a/autobot-backend/api/files_upload_path_test.py
+++ b/autobot-backend/api/files_upload_path_test.py
@@ -1,0 +1,79 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Upload filenames must be bare names, never paths (#13394).
+
+The upload endpoint validated its target *directory* and then joined the
+client-supplied filename to it unchecked. Four guards each missed a filename
+carrying a directory component, and the post-write containment check was
+lexical, so it neither normalised ``..`` nor ran before the write.
+
+These tests exercise the rejection directly rather than asserting on source
+text — the pre-existing coverage for this endpoint only grepped ``files.py``
+for the substring ``is_safe_file``, which stays green whether or not the
+function actually rejects a traversing name.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from api.files import is_safe_file
+
+# Extensions the endpoint allows; each escape below therefore clears the
+# extension allowlist and is stopped only by the path-component check.
+_ALLOWED_SUFFIX = ".py"
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "../evil.py",
+        "../../evil.py",
+        "../../../../etc/passwd.py",
+        "subdir/evil.py",
+        "./evil.py",
+        "/etc/passwd.py",
+        "/opt/autobot/autobot-backend/api/health.py",
+        "..\\evil.py",
+        "dir\\evil.py",
+    ],
+)
+def test_rejects_filenames_carrying_a_directory_component(filename):
+    """Any multi-segment or absolute name is refused."""
+    assert is_safe_file(filename) is False
+
+
+@pytest.mark.parametrize(
+    "filename",
+    ["report.py", "notes.txt", "a-b_c.1.py", "..leading-dots.py"],
+)
+def test_accepts_bare_filenames(filename):
+    """A plain name in the allowed-extension set still uploads."""
+    assert is_safe_file(filename) is True
+
+
+def test_absolute_filename_would_discard_the_sandbox_root():
+    """Documents why the directory check alone was never sufficient.
+
+    ``pathlib`` join semantics make an absolute filename escape without any
+    ``..`` at all: the left operand is discarded outright.
+    """
+    sandbox = Path("/opt/sandbox")
+    assert sandbox / "/etc/passwd" == Path("/etc/passwd")
+    assert str(sandbox / "../../etc/passwd").startswith(str(sandbox))
+
+
+def test_post_write_relative_to_does_not_normalise_traversal():
+    """Documents why the trailing containment check could not catch it.
+
+    ``Path.relative_to`` is lexical: it does not resolve ``..``, so a
+    traversing path stays 'relative to' the sandbox and raises nothing.
+    """
+    sandbox = Path("/opt/sandbox")
+    escaped = sandbox / "../../etc/passwd"
+    assert escaped.relative_to(sandbox) == Path("../../etc/passwd")
+
+
+def test_extension_allowlist_alone_is_bypassed_by_a_prefix():
+    """``Path.suffix`` reads only the final component."""
+    assert Path("../../../../etc/passwd.py").suffix == _ALLOWED_SUFFIX


### PR DESCRIPTION
Refs #13394

## Thinking Path

The upload endpoint validated its target **directory** and then joined the client-supplied **filename** to it unchecked:

```python
target_dir = validate_and_resolve_path(path)   # validated
target_file = target_dir / file.filename       # not validated
```

`file.filename` is Starlette's verbatim `Content-Disposition` value. Four guards each miss a name carrying a directory component:

- `_DANGEROUS_FILENAME_CHARS` is `{< > " | ? * NUL CR LF}` — no `/`, no `\`, no `..`
- `_DANGEROUS_FILENAMES` compares the **whole string**, so any directory prefix defeats it
- `Path(filename).suffix` reads only the final component, so a prefixed name still presents an allowed extension
- the post-write `relative_to(SANDBOXED_ROOT)` is purely lexical — it does not normalise `..`, so it raises nothing — and it runs **after** the bytes are on disk

`pathlib` join semantics make this worse than ordinary traversal. An **absolute** filename discards the base outright, so no `..` is needed at all:

```
>>> Path('/opt/sandbox') / '/etc/passwd'
PosixPath('/etc/passwd')
>>> (Path('/opt/sandbox') / '../../etc/passwd').relative_to('/opt/sandbox')
PosixPath('../../etc/passwd')          # no exception
```

Fixed in two layers. Layer 1 alone closes it; layer 2 keeps the invariant true if the join is ever refactored, and covers symlinked escapes that a `..` comparison cannot see.

**Choosing the right layer-2 helper mattered more than it looked.** The first revision resolved the *joined string* through `resolve_within_sandbox`, the sandbox **path** resolver. That applies a lexical `..`/`~` substring rejection, which is correct for a path and wrong for a filename — it 400'd every legitimate name containing those characters. Review caught it; see Verification.

## What Changed

**`autobot-backend/api/files.py`**

1. `is_safe_file` rejects any filename with a directory component — `"/" in filename or "\\" in filename or Path(filename).name != filename`.

   Backslash is checked explicitly because `Path.name` is platform-dependent: on POSIX `"dir\evil.py"` is one valid component, so the `Path.name` comparison alone lets it through. My first version of this guard had exactly that hole — the new tests caught it. `filesystem_mcp` already rejects it for the same reason (#13162).

2. The upload target is resolved with `validate_relative_path(file.filename, target_dir)`, which does `os.path.realpath` containment **without** the lexical filter, raising `ValueError` → 400 on escape.

**`autobot-backend/api/files_upload_path_test.py`** — new, 27 tests. The pre-existing coverage for this endpoint only grepped `files.py` for the substring `is_safe_file`, which stays green whether or not that function rejects anything.

## Verification

```
$ python3 -m pytest autobot-backend/api/files_upload_path_test.py -q
27 passed in 0.79s
```

Reconstructed the pre-fix `is_safe_file` and ran both against the same inputs — the guard is doing the work:

```
'../../../../etc/passwd.py'                    pre-fix=True   now=False
'/opt/.../api/health.py'                       pre-fix=True   now=False
'subdir/evil.py'                               pre-fix=True   now=False
'../evil.py'                                   pre-fix=True   now=False
```

**Correcting this PR's earlier claim.** It previously stated that `..leading-dots.py` still uploads, citing `is_safe_file`. That was true of layer 1 and **false of the endpoint** — the first revision's layer 2 rejected it, and the test asserting it passed only because it never exercised layer 2. Measured, previous revision vs now:

```
filename                     previous revision                             now
report.py                    OK report.py                                  OK report.py
..leading-dots.py            400 path traversal not allowed                OK ..leading-dots.py
my..file.py                  400 path traversal not allowed                OK my..file.py
~notes.md                    400 path traversal not allowed                OK ~notes.md
backup~.txt                  400 path traversal not allowed                OK backup~.txt
...rc.yml                    400 path traversal not allowed                OK ...rc.yml
../evil.py                   400 path traversal not allowed                400 segment escapes base directory
/etc/passwd.py               OK passwd.py                                  400 segment escapes base directory
```

Note the last row: the previous revision silently rewrote an absolute filename into a nested path under the sandbox rather than rejecting it. Layer 1 blocked it regardless, but the new helper refuses it outright.

Layer 2 now has direct coverage — legitimate `..`/`~` names, escapes, and a symlink escape (`sub/link.py -> outside`, caught by realpath, which a `..` comparison would miss).

Formatting matches CI (`black --line-length=120 --target-version py312`): `2 files would be left unchanged`. flake8 clean.

## Scope

One endpoint. `api/sandbox_files.py` exposes no upload path and is unaffected.

Found while triaging a scanner batch reported against `main`; most of it was false positives (`filesystem_mcp.py` 6/6 guarded, `code_sync.py` 6/6 clear — its `component` argument must be a member of a 9-element `frozenset`). This one was real.

Deliberately not absorbed, filed separately: extracting a shared `validate_bare_filename()` that `filesystem_mcp.py` could also use, and converging `recordings.py`'s symlink-*rejecting* resolver with the shared symlink-*resolving* one (#13397) — that is a semantic decision, not a refactor.

Known nit: `is_safe_file` is 38 lines and `upload_file` 59, both above the ≤30 guideline. Both exceeded it before this change (32 and ~57); shrinking them means restructuring pre-existing code, which does not belong in a security fix.

## Model Used

claude-opus-5
