### PR TITLE
fix(backend): stop merge_messages dropping terminal output, plus 3 more scattered defects (#13162)

### DIFF
--- a/autobot-backend/llm_shared/optimization/layer_inference.py
+++ b/autobot-backend/llm_shared/optimization/layer_inference.py
@@ -185,7 +185,7 @@ class LayerInferenceEngine:
         logger.debug("Loading model config for %s", model_name)
         auto_cfg = AutoConfig.from_pretrained(
             model_name, resume_download=True, **kwargs
-        )  # nosec B615 - HuggingFace model loaded by name; revision pinning managed operationally
+        )  # nosec B615  # HuggingFace model loaded by name; revision pinning managed operationally
         cfg_dict: Dict[str, Any] = auto_cfg.to_dict()
         logger.info(
             "Loaded model config for %s: arch=%s",
@@ -461,7 +461,7 @@ class LayerInferenceEngine:
             kwargs["cache_dir"] = self._config.cache_dir
         return AutoTokenizer.from_pretrained(
             self._config.model_name, resume_download=True, **kwargs
-        )  # nosec B615 - HuggingFace model loaded by name; revision pinning managed operationally
+        )  # nosec B615  # HuggingFace model loaded by name; revision pinning managed operationally
 
     def _resolve_checkpoint_path(self) -> str:
         """Return the checkpoint path for the configured model.
@@ -581,11 +581,41 @@ def _move_to_meta(torch: Any, module: Any) -> None:
     Issue #1946.
     """
     meta = torch.device("meta")
-    for param in list(module.parameters()):
-        param.data = torch.empty(param.shape, dtype=param.dtype, device=meta)
+    # remove_duplicate=False so a parameter shared by two submodules is released at
+    # every name it is registered under. The old in-place ``.data`` assignment
+    # reached all aliases through the single deduplicated entry; re-registering
+    # does not, and a missed alias would keep the real tensor — and its memory —
+    # alive, defeating the eviction. The layer is documented as unusable after
+    # eviction, so untying the shared storage here is safe.
+    for param_name, param in list(module.named_parameters(remove_duplicate=False)):
+        if param is not None:
+            _set_parameter(module, torch, param_name, meta, param)
     for buf_name, buf in list(module.named_buffers()):
         if buf is not None:
             _set_buffer(module, torch, buf_name, meta, buf)
+
+
+def _set_parameter(module: Any, torch: Any, name: str, device: Any, param: Any) -> None:
+    """Replace a named parameter with a meta-device empty tensor of the same shape.
+
+    Issue #13162: eviction previously did ``param.data = torch.empty(..., device=meta)``.
+    PyTorch rejects that with ``RuntimeError: Attempted to call variable.set_data(tensor),
+    but variable and tensor have incompatible tensor type`` because a meta tensor carries a
+    different ``TensorImpl`` than a dense one, so ``evict_layer`` raised instead of freeing
+    the layer. Re-registering the parameter — the same shape ``_set_buffer`` already uses
+    for buffers — is the supported way to move one across device types.
+    """
+    parts = name.split(".")
+    container = module
+    for part in parts[:-1]:
+        container = getattr(container, part)
+    container.register_parameter(
+        parts[-1],
+        torch.nn.Parameter(
+            torch.empty(param.shape, dtype=param.dtype, device=device),
+            requires_grad=param.requires_grad,
+        ),
+    )
 
 
 def _set_buffer(module: Any, torch: Any, name: str, device: Any, buf: Any) -> None:

--- a/autobot-backend/services/mcp_run_jwt_propagation_test.py
+++ b/autobot-backend/services/mcp_run_jwt_propagation_test.py
@@ -216,8 +216,10 @@ def test_worker_env_is_provisioned_with_the_signing_secret(monkeypatch):
     client = IsolatedBridgeClient("filesystem_mcp", policy_for("filesystem_mcp"))
     spawn = AsyncMock(return_value=AsyncMock(returncode=None))
 
+    # #13162: asyncio.get_event_loop() raises "no current event loop" on Python
+    # 3.14 (the CI interpreter) once the implicit-loop fallback was removed.
     with patch("asyncio.create_subprocess_exec", spawn):
-        asyncio.get_event_loop().run_until_complete(client.start())
+        asyncio.run(client.start())
 
     env = spawn.call_args.kwargs["env"]
     assert env["RUN_JWT_SECRET"] == TEST_JWT_SECRET
@@ -291,8 +293,8 @@ def test_env_only_deployment_mints_verifies_and_provisions(monkeypatch):
         assert _resolve_run_jwt_secret() == "dedicated-run-jwt-key"
         token = MCPDispatcher._mint_bridge_jwt("filesystem_mcp", "read_file")
         assert token is not None, "#13265 degraded to forwarding None"
+        # #13162: see test_worker_env_is_provisioned_with_the_signing_secret —
+        # asyncio.get_event_loop() no longer creates a loop on Python 3.14.
         with patch.object(worker_entrypoint, "_JWT_ENFORCE", True):
-            claims = asyncio.get_event_loop().run_until_complete(
-                worker_entrypoint._validate_run_jwt_param({"run_jwt": token})
-            )
+            claims = asyncio.run(worker_entrypoint._validate_run_jwt_param({"run_jwt": token}))
     assert claims["scope"] == ["mcp:filesystem"]

--- a/autobot-backend/tools/respond_tool_test.py
+++ b/autobot-backend/tools/respond_tool_test.py
@@ -12,6 +12,8 @@ Tests verify:
 4. Regular execute_command tools still work as before
 """
 
+from unittest.mock import AsyncMock, patch
+
 import pytest
 
 # Test fixtures for tool call parsing
@@ -63,7 +65,14 @@ class TestRespondToolParsing:
         assert tool_calls[0]["params"]["break_loop"] is False
 
     def test_parse_mixed_tool_calls(self):
-        """Test parsing both execute_command and respond tools."""
+        """A respond that trails an execute_command is deferred, not returned.
+
+        Issue #716 constrains a turn to a single execute_command so the agent sees
+        the command's real output before it decides anything else. The trailing
+        respond here claims "Found 10 files" before ``ls -la`` has run, so
+        honouring it would break_loop on a fabricated answer. #13162: this test
+        asserted the pre-#716 behaviour and expected both calls back.
+        """
         from chat_workflow.tool_handler import ToolHandlerMixin
 
         handler = ToolHandlerMixin()
@@ -76,9 +85,29 @@ Now the final summary:
 """
         tool_calls = handler._parse_tool_calls(text)
 
-        assert len(tool_calls) == 2
+        assert len(tool_calls) == 1
         assert tool_calls[0]["name"] == "execute_command"
-        assert tool_calls[1]["name"] == "respond"
+        assert tool_calls[0]["params"]["command"] == "ls -la"
+        assert not any(call["name"] == "respond" for call in tool_calls)
+
+    def test_parse_respond_before_command_is_kept(self):
+        """The #716 cut-off is the command, so a respond ahead of it survives.
+
+        Guards the boundary of the rule above: parsing stops AT the first
+        execute_command, it does not discard everything but that call.
+        """
+        from chat_workflow.tool_handler import ToolHandlerMixin
+
+        handler = ToolHandlerMixin()
+
+        text = """<TOOL_CALL name="respond" params='{"text":"Working on it","break_loop":false}'>Ack</TOOL_CALL>
+<TOOL_CALL name="execute_command" params='{"command":"ls -la"}'>List files</TOOL_CALL>
+<TOOL_CALL name="execute_command" params='{"command":"rm -rf /tmp/x"}'>Second command</TOOL_CALL>
+"""
+        tool_calls = handler._parse_tool_calls(text)
+
+        assert [call["name"] for call in tool_calls] == ["respond", "execute_command"]
+        assert tool_calls[1]["params"]["command"] == "ls -la"
 
     def test_parse_respond_tool_with_newlines_in_text(self):
         """Test respond tool with newlines in the text parameter."""
@@ -197,8 +226,15 @@ class TestRespondToolProcessing:
         assert break_loop_result[0] is False  # break_loop=False
 
     @pytest.mark.asyncio
-    async def test_process_unknown_tool_skipped(self):
-        """Test that unknown tools are skipped (not processed)."""
+    async def test_process_unknown_tool_reports_error_to_agent(self):
+        """An unregistered tool is reported back to the agent, never swallowed.
+
+        Issue #2305/#2310 replaced the original silent skip: a dropped tool call
+        left the agent looping on the same invalid name with no signal about why.
+        #13162: this test still asserted the pre-#2305 silence. The MCP registry is
+        patched out so the assertion covers the unknown-tool path deterministically
+        rather than depending on a bridge lookup over the network.
+        """
         from chat_workflow.tool_handler import ToolHandlerMixin
 
         handler = ToolHandlerMixin()
@@ -207,19 +243,30 @@ class TestRespondToolProcessing:
         tool_calls = [{"name": "unknown_tool", "params": {"foo": "bar"}, "description": "Unknown"}]
 
         messages = []
-        async for item in handler._process_tool_calls(
-            tool_calls,
-            "session_1",
-            "terminal_1",
-            "http://localhost:11434",
-            "llama3",  # canonical: ignore py-hardcoded-url — test fixture/mock URL, not an executable default
-        ):
-            if not isinstance(item, tuple):
-                messages.append(item)
+        with patch("chat_workflow.tool_handler._try_mcp_dispatch", AsyncMock(return_value=None)):
+            async for item in handler._process_tool_calls(
+                tool_calls,
+                "session_1",
+                "terminal_1",
+                "http://localhost:11434",
+                "llama3",  # canonical: ignore py-hardcoded-url — test fixture/mock URL, not an executable default
+            ):
+                if not isinstance(item, tuple):
+                    messages.append(item)
 
-        # No messages should be yielded for unknown tools
-        # Only the final tuple is yielded
-        assert len(messages) == 0
+        errors = [m for m in messages if m.type == "error"]
+        assert len(errors) == 1, "the agent must be told the tool does not exist"
+        assert "unknown_tool" in errors[0].content
+        assert errors[0].metadata["message_type"] == "unknown_tool"
+        assert errors[0].metadata["tool_name"] == "unknown_tool"
+
+        # The failure is recorded so the iteration's summary reflects it.
+        summaries = [m for m in messages if "execution_results" in (m.metadata or {})]
+        assert len(summaries) == 1
+        results = summaries[0].metadata["execution_results"]
+        assert [r["tool"] for r in results] == ["unknown_tool"]
+        assert results[0]["status"] == "error"
+        assert summaries[0].metadata["successful_commands"] == 0
 
 
 class TestBreakLoopIntegration:

--- a/autobot-backend/training/completion_trainer.py
+++ b/autobot-backend/training/completion_trainer.py
@@ -80,7 +80,10 @@ class CompletionTrainer:
         self.model: CompletionModel | None = None
         self.optimizer: optim.Optimizer | None = None
         self.criterion = nn.CrossEntropyLoss(ignore_index=0)
-        self.evaluator = CompletionEvaluator(device=self.device)
+        # Issue #13162: the evaluator's accuracy metric is sized by the model's
+        # vocabulary, which is only known once the data loaders are built, so it
+        # is constructed alongside the model rather than here.
+        self.evaluator: CompletionEvaluator | None = None
 
         # Training state
         self.current_epoch = 0
@@ -106,6 +109,7 @@ class CompletionTrainer:
         # Initialize model with vocabulary size
         self.model = CompletionModel(vocab_size=vocab_size).to(self.device)
         self.optimizer = optim.AdamW(self.model.parameters(), lr=1e-4)
+        self.evaluator = CompletionEvaluator(vocab_size=vocab_size, device=self.device)
 
         logger.info(f"Model initialized with vocab_size={vocab_size}")
         logger.info(f"Total parameters: " f"{sum(p.numel() for p in self.model.parameters()):,}")
@@ -306,6 +310,9 @@ class CompletionTrainer:
         config = checkpoint["model_config"]
         self.model = CompletionModel.from_config(config).to(self.device)
         self.model.load_state_dict(checkpoint["model_state_dict"])
+        # Issue #13162: a resumed run validates too, so the evaluator has to be
+        # rebuilt for the restored model's vocabulary.
+        self.evaluator = CompletionEvaluator(vocab_size=config["vocab_size"], device=self.device)
 
         # Restore optimizer
         self.optimizer = optim.AdamW(self.model.parameters())

--- a/autobot-backend/training/completion_trainer_test.py
+++ b/autobot-backend/training/completion_trainer_test.py
@@ -171,16 +171,23 @@ def test_completion_model_config():
 
 def test_evaluator_initialization():
     """Test evaluator initialization."""
-    evaluator = CompletionEvaluator(device="cpu")
+    evaluator = CompletionEvaluator(vocab_size=100, device="cpu")
 
     assert evaluator.device == "cpu"
+    assert evaluator.vocab_size == 100
     assert evaluator.accuracy is not None
     assert evaluator.mrr is not None
 
 
+def test_evaluator_rejects_non_positive_vocab_size():
+    """Issue #13162: the metric size must come from the model, not a constant."""
+    with pytest.raises(ValueError, match="vocab_size must be positive"):
+        CompletionEvaluator(vocab_size=0, device="cpu")
+
+
 def test_evaluator_update():
     """Test evaluator metric updates."""
-    evaluator = CompletionEvaluator(device="cpu")
+    evaluator = CompletionEvaluator(vocab_size=100, device="cpu")
 
     # Create dummy predictions and targets
     logits = torch.randn(2, 10, 100)  # [batch, seq_len, vocab]
@@ -199,7 +206,7 @@ def test_evaluator_update():
 
 def test_evaluator_reset():
     """Test evaluator reset."""
-    evaluator = CompletionEvaluator(device="cpu")
+    evaluator = CompletionEvaluator(vocab_size=100, device="cpu")
 
     # Update with dummy data
     logits = torch.randn(2, 10, 100)
@@ -252,7 +259,14 @@ def test_model_training_mode():
 
 
 def test_model_gradient_flow():
-    """Test gradient flow through model."""
+    """Gradients reach every parameter on the path the training loss drives.
+
+    Issue #13162: this asserted that a logits-only loss reaches *all* parameters.
+    It cannot. ``forward()`` bypasses ``self.attention`` entirely when no
+    pattern_embeddings are supplied, and ``self.confidence_layer`` contributes to
+    the confidence output only, which a cross-entropy-over-logits loss does not
+    touch. Those two branches are covered by the test below instead.
+    """
     model = CompletionModel(vocab_size=1000, embedding_dim=128, hidden_dim=256)
     model.train()
 
@@ -269,9 +283,39 @@ def test_model_gradient_flow():
     # Backward pass
     loss.backward()
 
-    # Check gradients exist
-    for param in model.parameters():
-        assert param.grad is not None
+    trained_path = ("embedding", "lstm", "output_layer")
+    checked = 0
+    for name, param in model.named_parameters():
+        if name.startswith(trained_path):
+            assert param.grad is not None, f"{name} received no gradient"
+            checked += 1
+    assert checked > 0, "no parameters matched the trained path"
+
+
+def test_model_gradient_flow_through_optional_branches():
+    """The attention and confidence branches are differentiable when driven.
+
+    Issue #13162: they carry no gradient under the trainer's current objective —
+    ``completion_trainer.train_epoch`` calls ``model(input_ids)`` with no pattern
+    embeddings and takes cross-entropy over logits alone — so this pins that the
+    branches are correctly wired and the gap is in the objective, not the model.
+    """
+    hidden_dim = 256
+    model = CompletionModel(vocab_size=1000, embedding_dim=128, hidden_dim=hidden_dim)
+    model.train()
+
+    input_ids = torch.randint(0, 1000, (2, 10))
+    targets = torch.randint(0, 1000, (2, 10))
+    pattern_embeddings = torch.randn(2, 5, hidden_dim * 2)
+
+    logits, confidence = model(input_ids, pattern_embeddings=pattern_embeddings)
+
+    criterion = torch.nn.CrossEntropyLoss()
+    loss = criterion(logits.view(-1, 1000), targets.view(-1)) + confidence.mean()
+    loss.backward()
+
+    for name, param in model.named_parameters():
+        assert param.grad is not None, f"{name} received no gradient"
 
 
 def test_mrr_metric():

--- a/autobot-backend/training/evaluator.py
+++ b/autobot-backend/training/evaluator.py
@@ -98,17 +98,30 @@ class CompletionEvaluator:
     Computes accuracy, MRR, Hit@K metrics on validation set.
     """
 
-    def __init__(self, device: str = "cpu"):
+    def __init__(self, vocab_size: int, device: str = "cpu"):
         """
         Initialize evaluator.
 
         Args:
+            vocab_size: Size of the evaluated model's vocabulary. Must equal the
+                model's ``vocab_size``; torchmetrics rejects a logits tensor whose
+                class dimension differs from ``num_classes``.
             device: Device for computation (cpu/cuda)
+
+        Raises:
+            ValueError: If vocab_size is not positive.
         """
+        if vocab_size <= 0:
+            raise ValueError(f"vocab_size must be positive, got {vocab_size}")
+
         self.device = device
+        self.vocab_size = vocab_size
 
         # Initialize metrics
-        self.accuracy = Accuracy(task="multiclass", num_classes=10000).to(device)
+        # Issue #13162: num_classes was hardcoded to 10000 while the model's vocab
+        # size comes from the tokenizer, so validate() raised ValueError on every
+        # run whose vocabulary was not exactly 10000 tokens.
+        self.accuracy = Accuracy(task="multiclass", num_classes=vocab_size).to(device)
         self.mrr = MeanReciprocalRank().to(device)
         self.hit_at_1 = HitAtK(k=1).to(device)
         self.hit_at_5 = HitAtK(k=5).to(device)
@@ -134,8 +147,10 @@ class CompletionEvaluator:
         last_logits = logits[:, -1, :]  # [batch, vocab_size]
         last_targets = targets[:, -1]  # [batch]
 
-        # Get top-k predictions
-        _, top_preds = torch.topk(last_logits, k=10, dim=-1)  # [batch, 10]
+        # Get top-k predictions. torch.topk raises when k exceeds the class
+        # dimension, so a vocabulary smaller than 10 tokens must not be a crash.
+        top_k = min(10, last_logits.size(-1))
+        _, top_preds = torch.topk(last_logits, k=top_k, dim=-1)  # [batch, top_k]
 
         # Update accuracy (top-1)
         self.accuracy.update(last_logits, last_targets)

--- a/autobot-backend/type_defs/chat_merge_messages_test.py
+++ b/autobot-backend/type_defs/chat_merge_messages_test.py
@@ -18,7 +18,7 @@ import pytest
 
 # Import the function under test
 # Note: We test the logic directly since merge_messages is async
-from type_defs.common import STREAMING_MESSAGE_TYPES
+from type_defs.common import SKIP_WEBSOCKET_PERSISTENCE_TYPES, STREAMING_MESSAGE_TYPES
 
 
 class TestMergeMessagesSignature:
@@ -30,6 +30,26 @@ class TestMergeMessagesSignature:
         assert "llm_response_chunk" in STREAMING_MESSAGE_TYPES
         assert "response" in STREAMING_MESSAGE_TYPES
         assert len(STREAMING_MESSAGE_TYPES) == 3
+
+    def test_streaming_types_are_not_the_persistence_skip_list(self):
+        """Issue #13162: the two sets must stay distinct.
+
+        Aliasing STREAMING_MESSAGE_TYPES to SKIP_WEBSOCKET_PERSISTENCE_TYPES made
+        api/chat.py treat terminal output, approval requests and reasoning-trace
+        events as token-accumulating streams, so merge_messages kept only the
+        longest one per 2-minute window and dropped the rest.
+        """
+        assert STREAMING_MESSAGE_TYPES < SKIP_WEBSOCKET_PERSISTENCE_TYPES
+        for never_streaming in (
+            "terminal_command",
+            "terminal_output",
+            "command_approval_request",
+            "terminal_interpretation",
+            "agent.step.start",
+            "agent.tool.result",
+        ):
+            assert never_streaming in SKIP_WEBSOCKET_PERSISTENCE_TYPES
+            assert never_streaming not in STREAMING_MESSAGE_TYPES
 
     def test_message_id_signature_priority(self):
         """Test that message ID takes priority for signature."""

--- a/autobot-backend/type_defs/common.py
+++ b/autobot-backend/type_defs/common.py
@@ -136,5 +136,23 @@ SKIP_WEBSOCKET_PERSISTENCE_TYPES: frozenset = frozenset(
     ]
 )
 
-# Backwards compatibility alias (deprecated - use SKIP_WEBSOCKET_PERSISTENCE_TYPES)
-STREAMING_MESSAGE_TYPES = SKIP_WEBSOCKET_PERSISTENCE_TYPES
+# Message types whose text accumulates progressively across a single turn, so a
+# later frame supersedes an earlier one with the same timestamp + sender.
+#
+# Issue #13162: this MUST stay a strict subset of SKIP_WEBSOCKET_PERSISTENCE_TYPES
+# and must NOT be aliased to it. The two sets answer different questions:
+#   - SKIP_WEBSOCKET_PERSISTENCE_TYPES: "is this persisted somewhere else?"
+#     (true for terminal/approval types, which their own handlers persist)
+#   - STREAMING_MESSAGE_TYPES: "may an earlier frame of this type be discarded
+#     in favour of a longer one?" (true ONLY for token-accumulating LLM output)
+# api/chat.py::_process_streaming_groups keeps just the longest message per
+# 2-minute window for every type listed here, so aliasing the two made
+# merge_messages silently drop terminal output, terminal commands, approval
+# requests and reasoning-trace events from restored chat history.
+STREAMING_MESSAGE_TYPES: frozenset = frozenset(
+    [
+        MessageTypes.LLM_RESPONSE,
+        MessageTypes.LLM_RESPONSE_CHUNK,
+        MessageTypes.RESPONSE,
+    ]
+)

--- a/autobot-backend/voice_processing/language_detection.py
+++ b/autobot-backend/voice_processing/language_detection.py
@@ -10,11 +10,48 @@ Part of Issue MVA-2185.
 """
 
 import os
+import re
 from typing import Optional
 
 from autobot_shared.logging_manager import get_logger
 
 logger = get_logger(__name__)
+
+# Short language codes, matched per whole filename token rather than as a raw
+# substring. Issue #13162: the previous "_lv_" / "_en_" substring test required a
+# separator on BOTH sides, so the most common real-world spellings — a trailing
+# code before the extension such as "audio_LV.wav" or "meeting_EN.wav", and a
+# leading code such as "lv_recording.wav" — were never recognised and the caller
+# silently fell back to English. Token matching also keeps a bare code from
+# firing inside an unrelated word ("envelope.wav" must not read as English).
+_LANGUAGE_CODE_TOKENS: dict = {
+    "lv": frozenset({"lv", "lat", "latvian", "latviesu"}),
+    "en": frozenset({"en", "eng", "english"}),
+}
+
+# Unambiguous full language names, still matched as substrings so a filename that
+# runs the name together with other text ("myenglishnotes.wav") keeps working.
+_LANGUAGE_NAME_SUBSTRINGS: dict = {
+    "lv": ("latvian", "latviešu", "latviesu"),
+    "en": ("english",),
+}
+
+# Text handed to the detector once a filename hint resolves. The detector works on
+# text, not on codes, so each hint maps to a short sample in that language.
+_HINT_TEXT_SAMPLES: dict = {
+    "lv": "latviešu valoda",
+    "en": "english language",
+}
+
+_FILENAME_TOKEN_SPLIT = re.compile(r"[^a-z0-9]+")
+
+
+def _filename_tokens(filename: str) -> set:
+    """Split a filename into lowercase alphanumeric tokens.
+
+    ``"meeting_EN.wav"`` -> ``{"meeting", "en", "wav"}``.
+    """
+    return {token for token in _FILENAME_TOKEN_SPLIT.split(filename.lower()) if token}
 
 
 class LanguageDetectionService:
@@ -110,13 +147,14 @@ class LanguageDetectionService:
             Text sample or None
         """
         # Check filename for language hints - prefer filename_hint if provided
-        filename = (filename_hint or os.path.basename(audio_path)).lower()
+        filename = filename_hint or os.path.basename(audio_path)
+        lowered = filename.lower()
+        tokens = _filename_tokens(filename)
 
-        if "latvian" in filename or "_lv_" in filename or "_lat_" in filename:
-            return "latviešu valoda"  # Latvian text sample
-
-        if "english" in filename or "_en_" in filename:
-            return "english language"
+        for lang_code, code_tokens in _LANGUAGE_CODE_TOKENS.items():
+            names = _LANGUAGE_NAME_SUBSTRINGS[lang_code]
+            if tokens & code_tokens or any(name in lowered for name in names):
+                return _HINT_TEXT_SAMPLES[lang_code]
 
         # If no hints in filename, we'd use a fast speech-to-text model here
         # For now, default to None (caller will use default language)

--- a/autobot-backend/voice_processing/test_language_detection.py
+++ b/autobot-backend/voice_processing/test_language_detection.py
@@ -139,8 +139,11 @@ class TestFilenamePatterns:
 
             try:
                 sample = await service._extract_text_sample(temp_path)
-                # Should detect Latvian hint
-                assert sample is not None or "_lv_" in temp_path.lower()
+                # #13162: every listed pattern must resolve. The previous
+                # "or '_lv_' in path" clause passed vacuously for the patterns
+                # that already contained a separator on both sides, hiding the
+                # fact that a trailing code ("audio_LV.wav") never matched.
+                assert sample == "latviešu valoda", f"no Latvian hint from {pattern}"
             finally:
                 os.unlink(temp_path)
 
@@ -161,7 +164,8 @@ class TestFilenamePatterns:
 
             try:
                 sample = await service._extract_text_sample(temp_path)
-                # Should detect English hint
-                assert sample is not None or "_en_" in temp_path.lower()
+                # #13162: see test_latvian_patterns — the escape-hatch clause
+                # made "meeting_EN.wav" pass without ever matching.
+                assert sample == "english language", f"no English hint from {pattern}"
             finally:
                 os.unlink(temp_path)


### PR DESCRIPTION
## Thinking Path

Six scattered python-suite files accounted for 15 failures in the CI run for the
current `Dev_new_gui` head, spread across all 12 shards. I pulled the shard logs
and pinned the exact error for each of the 15 before changing anything, because
only 7 of them reproduce on a Python 3.10 box without torch.

Reproduction split:

| File | Reproduces locally? | Why |
|---|---|---|
| `type_defs/chat_merge_messages_test.py` | yes (3) | pure-python |
| `voice_processing/test_language_detection.py` | yes (2) | pure-python |
| `tools/respond_tool_test.py` | yes (2) | pure-python |
| `training/completion_trainer_test.py` | no (3) | whole module skips, torch not installed |
| `llm_shared/optimization/layer_inference_test.py` | no (3) | torch-gated via `requires_torch` |
| `services/mcp_run_jwt_propagation_test.py` | no (2) | Python 3.14-only API removal |

For each failure I asked whether the test or the code was wrong. Four were the
code. The most serious one is silent chat-history data loss, and it was hiding
behind a comment that called the constant a backwards-compatibility alias.

`STREAMING_MESSAGE_TYPES` had been aliased to `SKIP_WEBSOCKET_PERSISTENCE_TYPES`.
Those two sets answer different questions — "is this persisted somewhere else?"
versus "may an earlier frame of this type be discarded in favour of a longer
one?" — and only the second is safe to feed to
`api/chat.py::_process_streaming_groups`, which keeps just the longest message
per 2-minute window and drops the rest of the group. Through the alias that
reaper was applied to `terminal_output`, `terminal_command`,
`command_approval_request`, `terminal_interpretation` and six `agent.*`
reasoning-trace types, so restoring a session quietly deleted terminal output
and approval requests that shared a 2-minute window. The test asserting
`len(...) == 3` was right the whole time.

`mcp_run_jwt_propagation_test.py` is auth-adjacent, so I read the surrounding
auth path rather than only the two failures. **No auth defect found.**
`worker_entrypoint._handle_request` validates the run JWT before it reads
`params["tool"]` or dispatches — auth precedes body handling, not the reverse.
`services/run_jwt.py` delegates HMAC verification to PyJWT and contains no `==`
secret comparison, so there is no timing oracle. The `RUN_JWT_REDIS_FAIL_OPEN`
switch is default-closed and raises unless an operator explicitly opts in. The
two failures are purely `asyncio.get_event_loop()` raising on Python 3.14.

Deliberately untouched: `services/rag_service_kb_synthesis_test.py` (order-dependent
conftest defect on #13386) and
`voice_processing/providers/test_registry.py::test_get_speech_provider_convenience`,
which fails identically on the unmodified base and in CI — pre-existing, outside
these six files.

## What Changed

**Production fixes (4):**

1. `type_defs/common.py` — `STREAMING_MESSAGE_TYPES` restored to its own
   3-member frozenset instead of aliasing the persistence-skip list. **Blast
   radius measured, not assumed:** a repo-wide grep shows exactly two non-test
   consumers — `api/chat.py:70` imports `STREAMING_MESSAGE_TYPES` and
   `api/websockets.py:25` imports `SKIP_WEBSOCKET_PERSISTENCE_TYPES`. The
   persistence set is unchanged, so `websockets.py` behaviour is identical;
   only `chat.py`'s merge is affected, which is the fix.

2. `llm_shared/optimization/layer_inference.py` — `_move_to_meta` assigned
   `param.data` across device types. PyTorch rejects that
   (`RuntimeError: ... incompatible tensor type`) because a meta tensor carries a
   different `TensorImpl`, so `evict_layer()` raised instead of freeing the
   layer. Parameters are now re-registered via a new `_set_parameter`, mirroring
   the `_set_buffer` helper the same function already used for buffers.
   `remove_duplicate=False` preserves the old in-place semantics for parameters
   shared between submodules, which re-registration would otherwise miss.
   `_move_to_meta` is private to this module; the separate
   `meta_eviction.evict_layer_to_meta` uses `nn.Module.to("meta")` and is not
   affected.

3. `training/evaluator.py` + `training/completion_trainer.py` —
   `CompletionEvaluator` hardcoded `num_classes=10000` while `CompletionModel`
   takes its vocabulary from the tokenizer, so `validate()` raised `ValueError`
   on every run whose vocabulary was not exactly 10000 tokens. `vocab_size` is
   now a required argument, and the evaluator is built where the vocabulary is
   known: alongside the model in `prepare_data`, and again in `load_checkpoint`
   so a resumed run can validate. `topk` is clamped to the class dimension.
   The only caller is `completion_trainer.py`.

4. `voice_processing/language_detection.py` — the `"_lv_"` / `"_en_"` hint test
   required a separator on *both* sides, so `audio_LV.wav` and `meeting_EN.wav`
   never matched and `transcriber/orchestrator.py:72`, which passes the real
   upload filename, fell back to English. Codes now match per filename token;
   full language names still match as substrings, so the change is strictly
   additive and no filename that resolved before stops resolving.

**Test fixes (3 files):**

5. `tools/respond_tool_test.py` — two assertions predated the behaviour under
   test. #716 stops parsing at the first `execute_command`, so a trailing
   `respond` is deferred; honouring it would `break_loop` on an answer the model
   wrote before the command ran. #2305/#2310 replaced the silent unknown-tool
   skip with an error reported back to the agent. Both now assert the current
   contract, plus a new case pinning that a `respond` *ahead* of the command
   still survives. The MCP lookup is patched so the unknown-tool path no longer
   makes a DNS call.

6. `services/mcp_run_jwt_propagation_test.py` — `asyncio.get_event_loop()`
   replaced with `asyncio.run()`.

7. `training/completion_trainer_test.py` — `test_model_gradient_flow` asserted a
   logits-only loss reaches *every* parameter. It cannot: `forward()` bypasses
   `self.attention` when no pattern embeddings are supplied, and
   `confidence_layer` feeds only the confidence output. Split into the trained
   path plus a new case that drives both optional branches, proving they are
   differentiable and that the gap is in the training objective.

Also removed two vacuous assertions in `test_language_detection.py` whose
`or "_lv_" in path` clause passed without the detection ever running.

## Verification

Six target files, before:

```
7 failed, 58 passed, 29 skipped
```

(local; the other 8 CI failures are torch- or 3.14-gated, with their exact CI
errors pulled from the shard logs.)

After:

```
67 passed, 29 skipped, 2 warnings in 2.85s
```

No regressions in the consumers of the changed shared modules:

```
autobot-backend/api -k "chat or merge or websocket or message"
  116 passed, 111 skipped, 3232 deselected

autobot-backend/chat_workflow autobot-backend/tools services/mcp_run_jwt_propagation_test.py
  431 passed

autobot-backend/transcriber voice_processing type_defs llm_shared/optimization training
  491 passed, 101 skipped, 1 failed  <- the 1 is test_registry.py, pre-existing on
                                        the unmodified base and failing in CI too
```

Lint on all 10 changed files: isort and black clean, `flake8 --config=.flake8`
returns 0, `bandit -c .bandit` reports **no issues identified** at any severity.

**Honest limitation:** this box has Python 3.10 and no torch, so the 8
torch-gated and 3.14-gated failures across `layer_inference_test`,
`completion_trainer_test` and `mcp_run_jwt_propagation_test` are fixed by
reasoning from the exact CI error plus PyTorch/asyncio semantics, and are
**verified only by CI**, not locally. The 29 local skips are those tests.

## Model Used

claude-opus-5[1m]

---

Closes #13162

> **PARTIAL.** This PR fixes 15 of the ~450 failures behind #13162 — the six
> scattered files it was scoped to. **#13162 stays open.** It also excludes
> `services/rag_service_kb_synthesis_test.py` (3 failures, tracked on #13386)
> and the pre-existing `voice_processing/providers/test_registry.py` failure,
> both out of scope here.
