### PR TITLE
fix(tests): root-cause four order-dependent CI test failures (#13162)

### DIFF
--- a/autobot-backend/agent_loop/tests/test_pre_action_verifier.py
+++ b/autobot-backend/agent_loop/tests/test_pre_action_verifier.py
@@ -18,6 +18,7 @@ the full loop integration (verifier result shown at the approval gate).
 
 from __future__ import annotations
 
+import sys
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -34,6 +35,34 @@ from agent_loop.pre_action_verifier import (
     _parse_probability,
     _parse_rationale,
     _threshold_for_tool,
+)
+
+# ---------------------------------------------------------------------------
+# Module-identity anchor for patching (#13162).
+#
+# ``patch("agent_loop.pre_action_verifier.X")`` resolves its target by walking
+# the dotted path with ``getattr`` — ``getattr(sys.modules["agent_loop"],
+# "pre_action_verifier")``. The backend root conftest plants ``agent_loop`` as a
+# package stub whose catch-all ``__getattr__`` returns a fresh MagicMock for ANY
+# name, and sibling conftests (tests/search, tests/agent_loop) replace or pop
+# ``agent_loop*`` entries during collection. Whenever the submodule binding is
+# lost, that string form silently patches a mock — or a SECOND module object
+# re-imported from disk — while the class this file imported keeps reading its
+# own untouched globals. The patch then does nothing and the assertion falls
+# through to whatever the unpatched code returns: in CI all three
+# VERIFIER_ENABLED/_select_verifier_provider tests reported PASS because the
+# real module ran with no LLM provider configured.
+#
+# Anchoring on the module that actually owns ``PreActionVerifier`` and patching
+# it with ``patch.object`` removes the getattr walk entirely. The identity
+# assertion turns any future module-identity split into a loud failure at import
+# instead of a silent green test.
+# ---------------------------------------------------------------------------
+
+_PAV = sys.modules[PreActionVerifier.__module__]
+assert _PAV.PreActionVerifier is PreActionVerifier, (
+    "agent_loop.pre_action_verifier was loaded twice — sys.modules holds a different "
+    "module object than the one this test imported from; patches would be inert."
 )
 
 # ---------------------------------------------------------------------------
@@ -144,7 +173,7 @@ class TestParsing:
 class TestVerifierDisabled:
     @pytest.mark.asyncio
     async def test_verifier_disabled_returns_skip(self):
-        with patch("agent_loop.pre_action_verifier.VERIFIER_ENABLED", False):
+        with patch.object(_PAV, "VERIFIER_ENABLED", False):
             v = PreActionVerifier()
             result = await v.verify("write_file", {"path": "/etc/passwd"}, "test")
         assert result.verdict == VerifierVerdict.SKIP
@@ -169,11 +198,12 @@ class TestVerifierBlocksPlausibleButWrong:
         provider.chat_completion.return_value = _make_llm_response(_REFUTE_RESPONSE)
 
         with (
-            patch(
-                "agent_loop.pre_action_verifier._select_verifier_provider",
+            patch.object(
+                _PAV,
+                "_select_verifier_provider",
                 new=AsyncMock(return_value=provider),
             ),
-            patch("agent_loop.pre_action_verifier.VERIFIER_ENABLED", True),
+            patch.object(_PAV, "VERIFIER_ENABLED", True),
         ):
             v = PreActionVerifier(actor_provider="ollama")
             result = await v.verify(
@@ -199,11 +229,12 @@ class TestVerifierBlocksPlausibleButWrong:
         provider.chat_completion.return_value = _make_llm_response(_PASS_RESPONSE)
 
         with (
-            patch(
-                "agent_loop.pre_action_verifier._select_verifier_provider",
+            patch.object(
+                _PAV,
+                "_select_verifier_provider",
                 new=AsyncMock(return_value=provider),
             ),
-            patch("agent_loop.pre_action_verifier.VERIFIER_ENABLED", True),
+            patch.object(_PAV, "VERIFIER_ENABLED", True),
         ):
             v = PreActionVerifier(actor_provider="ollama")
             result = await v.verify(
@@ -243,7 +274,7 @@ class TestDistinctProvider:
 
         with (
             patch("llm_shared.provider_registry.get_provider_registry", return_value=mock_registry),
-            patch("agent_loop.pre_action_verifier.VERIFIER_ENABLED", True),
+            patch.object(_PAV, "VERIFIER_ENABLED", True),
         ):
             from agent_loop.pre_action_verifier import _select_verifier_provider
 
@@ -335,7 +366,7 @@ class TestLoopIntegration:
         loop._record_verifier_verdict = AsyncMock()
         loop._request_approval = AsyncMock(return_value=True)
 
-        with patch("agent_loop.pre_action_verifier.HARD_BLOCK", True):
+        with patch.object(_PAV, "HARD_BLOCK", True):
             result = await loop._check_approvals([{"tool_name": "bash", "args": {}}])
 
         loop._request_approval.assert_not_called()
@@ -358,7 +389,7 @@ class TestLoopIntegration:
         # Human approves
         loop._request_approval = AsyncMock(return_value=True)
 
-        with patch("agent_loop.pre_action_verifier.HARD_BLOCK", False):
+        with patch.object(_PAV, "HARD_BLOCK", False):
             result = await loop._check_approvals([{"tool_name": "bash", "args": {}}])
 
         # Human approved, so no error returned
@@ -426,12 +457,13 @@ class TestPanel:
             return provider
 
         with (
-            patch(
-                "agent_loop.pre_action_verifier._select_verifier_provider",
+            patch.object(
+                _PAV,
+                "_select_verifier_provider",
                 side_effect=_side_effect,
             ),
-            patch("agent_loop.pre_action_verifier.VERIFIER_ENABLED", True),
-            patch("agent_loop.pre_action_verifier.PANEL_QUORUM", 2),
+            patch.object(_PAV, "VERIFIER_ENABLED", True),
+            patch.object(_PAV, "PANEL_QUORUM", 2),
         ):
             v = PreActionVerifier()
             result = await v.verify(
@@ -452,12 +484,13 @@ class TestPanel:
         provider_pass.chat_completion.return_value = _make_llm_response(_PASS_RESPONSE)
 
         with (
-            patch(
-                "agent_loop.pre_action_verifier._select_verifier_provider",
+            patch.object(
+                _PAV,
+                "_select_verifier_provider",
                 new=AsyncMock(return_value=provider_pass),
             ),
-            patch("agent_loop.pre_action_verifier.VERIFIER_ENABLED", True),
-            patch("agent_loop.pre_action_verifier.PANEL_QUORUM", 2),
+            patch.object(_PAV, "VERIFIER_ENABLED", True),
+            patch.object(_PAV, "PANEL_QUORUM", 2),
         ):
             v = PreActionVerifier()
             result = await v.verify(

--- a/autobot-backend/conftest.py
+++ b/autobot-backend/conftest.py
@@ -879,25 +879,49 @@ if "code_intelligence.cross_language_patterns" not in sys.modules:
     _ci_clp_stub.CrossLanguagePatternDetector = MagicMock()  # type: ignore[attr-defined]
     sys.modules["code_intelligence.cross_language_patterns"] = _ci_clp_stub
 
+
+def _stub_symbols(name: str, **symbols) -> types.ModuleType:
+    """Return the ``sys.modules`` entry for *name*, decorating it ONLY if it is a stub.
+
+    #13162: these three blocks used to read
+    ``sys.modules.get(name) or _make_pkg_stub(name)`` and then assign MagicMocks
+    unconditionally. When the real module was already imported — anything loaded
+    earlier in this conftest can pull ``orchestration/__init__.py``, whose line
+    ``from .causal_error_recovery import CausalErrorRecovery, RecoveryPlan, ...``
+    imports the genuine module — that assignment silently REPLACED real classes
+    in a real module's globals. The module then keeps executing its own code
+    against mocks: ``recommend_recovery()`` runs for real, logs a real pattern
+    hash, and returns ``RecoveryPlan(...)`` — a MagicMock. Callers see
+    ``plan.error_type`` as a mock and ``plan.causal_chain.encode()`` blows up in
+    ``hashlib.md5`` with "object supporting the buffer API required".
+
+    A module loaded from a file has ``__file__``; the package stubs built by
+    ``_make_pkg_stub`` never do. Decorating only the latter keeps the stub
+    contract (orchestration's import must resolve) without ever mutating real code.
+    """
+    existing = sys.modules.get(name)
+    if existing is not None and getattr(existing, "__file__", None) is not None:
+        return existing  # real module — never overwrite its symbols
+    stub = existing if existing is not None else _make_pkg_stub(name)
+    for _sym_name, _sym_value in symbols.items():
+        setattr(stub, _sym_name, _sym_value)
+    sys.modules[name] = stub
+    return stub
+
+
 # Ensure CausalErrorRecovery / RecoveryPlan / get_recovery_recommender are
 # resolvable from the stub so orchestration/__init__.py's wildcard import
 # (`from .causal_error_recovery import CausalErrorRecovery, ...`) succeeds.
-_cer_stub = sys.modules.get("orchestration.causal_error_recovery") or _make_pkg_stub(
-    "orchestration.causal_error_recovery"
+_stub_symbols(
+    "orchestration.causal_error_recovery",
+    CausalErrorRecovery=MagicMock(),
+    RecoveryPlan=MagicMock(),
+    get_recovery_recommender=MagicMock(),
 )
-_cer_stub.CausalErrorRecovery = MagicMock()  # type: ignore[attr-defined]
-_cer_stub.RecoveryPlan = MagicMock()  # type: ignore[attr-defined]
-_cer_stub.get_recovery_recommender = MagicMock()  # type: ignore[attr-defined]
-sys.modules["orchestration.causal_error_recovery"] = _cer_stub
 
-_cea_stub = sys.modules.get("orchestration.causal_error_analyzer") or _make_pkg_stub(
-    "orchestration.causal_error_analyzer"
-)
-_cea_stub.CausalErrorAnalysis = MagicMock()  # type: ignore[attr-defined]
-sys.modules["orchestration.causal_error_analyzer"] = _cea_stub
+_stub_symbols("orchestration.causal_error_analyzer", CausalErrorAnalysis=MagicMock())
 
-_al_stub = sys.modules.get("agent_loop") or _make_pkg_stub("agent_loop")
-_al_stub.AgentLoop = MagicMock()  # type: ignore[attr-defined]
+_al_stub = _stub_symbols("agent_loop", AgentLoop=MagicMock())
 # Give the injected stub a REAL __path__ so the package's light submodules
 # (types, belief_state, pre_action_verifier, slack_hook, …) resolve on-demand from
 # disk for the in-package agent_loop/ tests (#11153) — WITHOUT running agent_loop/

--- a/autobot-backend/tests/content_reach/test_url_guard.py
+++ b/autobot-backend/tests/content_reach/test_url_guard.py
@@ -457,6 +457,12 @@ async def test_trafilatura_robots_disabled_env_passes(monkeypatch):
     monkeypatch.setattr(guard_mod, "_is_public_url_async", _always_public)
     monkeypatch.setattr(guard_mod, "_RESPECT_ROBOTS", False)
 
+    # TrafilaturaBackend.fetch() gates on _import_trafilatura() BEFORE it
+    # extracts, so patching the extraction seam alone is not enough: on a
+    # runner without the optional `trafilatura` wheel the gate raises
+    # BackendError before client.get is ever reached (#13162). Patch both
+    # module seams so this guard test stays independent of that optional dep.
+    monkeypatch.setattr(wp_mod, "_import_trafilatura", lambda: object())
     monkeypatch.setattr(wp_mod, "_trafilatura_extract", lambda html: "extracted text")
 
     mock_response = MagicMock()
@@ -494,6 +500,8 @@ async def test_trafilatura_public_allowed_url_reaches_fetch(monkeypatch):
         return True
 
     monkeypatch.setattr(guard_mod, "_robots_is_allowed", _allowed)
+    # Same optional-dependency gate as above (#13162).
+    monkeypatch.setattr(wp_mod, "_import_trafilatura", lambda: object())
     monkeypatch.setattr(wp_mod, "_trafilatura_extract", lambda html: "article body")
 
     mock_response = MagicMock()

--- a/autobot-backend/tests/integration/test_mobile_pairing.py
+++ b/autobot-backend/tests/integration/test_mobile_pairing.py
@@ -16,6 +16,8 @@ Comprehensive end-to-end tests for the mobile device pairing flow:
 
 import uuid
 from datetime import timedelta
+from fnmatch import fnmatch
+from time import monotonic
 from typing import AsyncGenerator
 
 import pytest
@@ -29,7 +31,6 @@ from api.mobile_devices import _QR_CHALLENGE_TTL_SECONDS, _redis_challenge_key
 from api.mobile_devices import router as mobile_router
 from api.user_management.dependencies import get_db_session
 from auth_middleware import get_current_user
-from autobot_shared.redis_client import get_redis_client
 from autobot_shared.time_utils import now_utc
 from models.mobile_device import MobileDevice
 from user_management.models.base import Base
@@ -135,28 +136,105 @@ def test_client(test_db_session, test_user):
     return TestClient(app)
 
 
-@pytest.fixture
-def redis_client():
-    """Get Redis client for test."""
-    client = get_redis_client(database="main")
-    if client is None:
-        pytest.skip("Redis not available")
-    return client
+class _FakeRedis:
+    """In-process stand-in for the sync Redis client the pairing endpoints use.
+
+    Implements exactly the surface ``api/mobile_devices.py`` touches — ``setex``
+    / ``get`` / ``delete`` — plus ``ttl`` and ``scan_iter`` for the assertions in
+    this file, with genuine expiry semantics (monotonic deadlines) and the
+    ``decode_responses=True`` string values the production client is configured
+    with. That keeps every behaviour under test real: one-time-use consumption,
+    expiry, per-user binding and cross-request key visibility.
+    """
+
+    def __init__(self) -> None:
+        self._store: dict[str, tuple[str, float]] = {}
+
+    def _read(self, key: str) -> tuple[str, float] | None:
+        entry = self._store.get(key)
+        if entry is None:
+            return None
+        if entry[1] <= monotonic():
+            del self._store[key]
+            return None
+        return entry
+
+    def setex(self, key: str, ttl_seconds: int, value: str) -> bool:
+        self._store[key] = (str(value), monotonic() + int(ttl_seconds))
+        return True
+
+    def get(self, key: str) -> str | None:
+        entry = self._read(key)
+        return None if entry is None else entry[0]
+
+    def delete(self, *keys: str) -> int:
+        return sum(1 for key in keys if self._store.pop(key, None) is not None)
+
+    def ttl(self, key: str) -> int:
+        entry = self._read(key)
+        # Redis returns -2 for a missing key, -1 for a key with no expiry.
+        return -2 if entry is None else max(1, int(entry[1] - monotonic()))
+
+    def scan_iter(self, match: str = "*"):
+        return iter([key for key in list(self._store) if fnmatch(key, match)])
+
+
+class _FakeAsyncRedis:
+    """Async view over the same store, for callers that await their client.
+
+    ``DELETE /api/devices/{id}`` invalidates the device-JWT cache through
+    ``services.device_jwt.invalidate_device_cache``, which awaits
+    ``get_async_redis_client()``. Left unbound that dials the configured Redis
+    host and burns the full connect/retry budget — ~30 s in
+    ``test_unpair_device_success`` alone — before falling through its
+    ``if redis is None`` branch, so the invalidation was never actually
+    exercised. Sharing the sync double's store keeps it exercised and instant.
+    """
+
+    def __init__(self, sync_client: "_FakeRedis") -> None:
+        self._sync = sync_client
+
+    async def get(self, key: str) -> str | None:
+        return self._sync.get(key)
+
+    async def setex(self, key: str, ttl_seconds: int, value: str) -> bool:
+        return self._sync.setex(key, ttl_seconds, value)
+
+    async def delete(self, *keys: str) -> int:
+        return self._sync.delete(*keys)
 
 
 @pytest.fixture(autouse=True)
-def cleanup_redis(redis_client):
-    """Clean up Redis keys before and after each test."""
-    # Clean before
-    pattern = "autobot:mobile_pair_challenge:*"
-    for key in redis_client.scan_iter(match=pattern):
-        redis_client.delete(key)
+def redis_client(monkeypatch):
+    """Bind the pairing endpoints to a deterministic in-process Redis double.
 
-    yield
+    #13162: this fixture used to hand back ``get_redis_client(database="main")``
+    and ``pytest.skip`` when it returned ``None``. That guard cannot detect the
+    only failure mode that actually occurs in CI — the backend test harness
+    stubs ``autobot_shared.redis_client``, so the call returns a truthy
+    ``MagicMock`` rather than ``None``. The suite then ran against a mock whose
+    ``get()`` answers every lookup with a fresh ``MagicMock``: the challenge
+    token never round-tripped, and ``POST /pair`` wrote a ``MagicMock`` into the
+    ``user_id`` column, so SQLite rejected the INSERT and seven tests reported
+    500-vs-201. Locally the same guard skipped all nineteen, so the pairing
+    endpoints were verified in neither environment.
 
-    # Clean after
-    for key in redis_client.scan_iter(match=pattern):
-        redis_client.delete(key)
+    Injecting the double removes the ambient dependency entirely and pins the
+    name the router resolves (``api.mobile_devices`` binds ``get_redis_client``
+    at import), so the tests exercise the real endpoint logic everywhere.
+    """
+    import api.mobile_devices as mobile_devices_module
+    import services.device_jwt as device_jwt_module
+
+    client = _FakeRedis()
+    async_client = _FakeAsyncRedis(client)
+
+    async def _get_async_client(**_kwargs):
+        return async_client
+
+    monkeypatch.setattr(mobile_devices_module, "get_redis_client", lambda **_kwargs: client)
+    monkeypatch.setattr(device_jwt_module, "get_async_redis_client", _get_async_client)
+    return client
 
 
 # =============================================================================

--- a/autobot-backend/tests/orchestration/test_causal_error_recovery.py
+++ b/autobot-backend/tests/orchestration/test_causal_error_recovery.py
@@ -90,6 +90,29 @@ from services.failure_pattern_detector import (  # noqa: E402
     FailurePatternDetector,
 )
 
+# ---------------------------------------------------------------------------
+# Real-symbol anchor (#13162).
+#
+# Displacing the stubs above is only half the contract: the names this module
+# imported must still be the REAL ones when the tests run. If anything replaces
+# a symbol in the loaded module's globals with a MagicMock (the shape the root
+# conftest's stub decoration used to have), the real ``recommend_recovery()``
+# keeps running but returns ``RecoveryPlan(...)`` as a mock — ``plan.error_type``
+# compares a MagicMock against a string, and ``plan.causal_chain.encode()``
+# reaches ``hashlib.md5`` as a non-buffer. Both were live CI failures whose
+# tracebacks pointed at production code that was in fact behaving correctly.
+#
+# Assert the identity once, at import, so any future clobber is a single loud
+# error here instead of two misleading failures deep inside the recovery system.
+# ---------------------------------------------------------------------------
+
+_CER = sys.modules["orchestration.causal_error_recovery"]
+assert _CER.RecoveryPlan is RecoveryPlan and _CER.CausalErrorRecovery is CausalErrorRecovery, (
+    "orchestration.causal_error_recovery symbols were replaced after import — "
+    "the module in sys.modules no longer matches what this test imported, so the "
+    "recovery system under test would be exercised through mocks."
+)
+
 
 @pytest.fixture(scope="module", autouse=True)
 def _restore_conftest_stubs():


### PR DESCRIPTION
## Thinking Path

Fourteen failures across four files in the python-suite shards for head `617528929`. All four files pass locally on a bare run, so the first step was pulling the shard logs and reading the actual tracebacks rather than re-running locally and declaring them green.

Every one of them turned out to be a harness defect, and three of the four are the same family: a `MagicMock` standing in for something real, in a way the test could not detect.

- **Mobile pairing.** The `redis_client` fixture skipped when `get_redis_client()` returned `None`. But the backend conftest stubs `autobot_shared.redis_client`, so in CI the call returns a truthy `MagicMock` — the guard cannot fire. The suite then ran against a mock whose `get()` answers every lookup with a fresh `MagicMock`, so the QR challenge token never round-tripped and `POST /pair` wrote a `MagicMock` into the `user_id` column. SQLite rejected the INSERT: `Error binding parameter 2: type 'MagicMock' is not supported`, surfacing as `assert 500 == 201`. Locally the same guard skipped all nineteen tests. The pairing endpoints were therefore verified in **neither** environment.
- **Pre-action verifier.** All three failures logged `pre_action_verifier: no provider available — skipping` and returned `PASS`, including the test that patches `VERIFIER_ENABLED` to `False` and expects `SKIP`. Both patches were inert. `patch("agent_loop.pre_action_verifier.X")` resolves its target by walking the dotted path with `getattr`, and the root conftest plants `agent_loop` as a package stub whose catch-all `__getattr__` mints a `MagicMock` for any name — so whenever the submodule binding is lost, the patch lands on a mock while the real module keeps reading its own untouched globals. Reproduced directly: under a poisoned parent the string form leaves the real module at `True` while `patch.object` correctly sets `False`.
- **Causal error recovery.** `plan.error_type` was a `MagicMock` even though the captured log shows the *real* `recommend_recovery()` ran and computed a real pattern hash. The only construct in the tree that can produce that is `conftest.py`'s stub decoration: it read `sys.modules.get(name) or _make_pkg_stub(name)` and then assigned `MagicMock()`s unconditionally, so when the real module was already imported it replaced `RecoveryPlan` / `CausalErrorRecovery` **inside a real module's globals**. The second failure is the same object one step later — `plan.causal_chain.encode()` reaching `hashlib.md5` as a non-buffer.
- **URL guard.** Purely an optional dependency: `trafilatura` is one of the 25 requirements absent on the runner, and `TrafilaturaBackend.fetch()` gates on `_import_trafilatura()` *before* extracting, so both guard tests raised `BackendError` before `client.get` was ever reached. The tests already patch the `_trafilatura_extract` seam; they simply missed the import seam next to it.

No production defect was found behind any of the fourteen — the endpoints and the recovery system behave correctly; the tests were being lied to. That is itself the finding worth recording, since three of these files were reporting green for the wrong reason or not running at all.

## What Changed

**`autobot-backend/conftest.py`** — shared module, blast radius measured below. The three stub-decoration blocks (`orchestration.causal_error_recovery`, `orchestration.causal_error_analyzer`, `agent_loop`) now go through one `_stub_symbols()` helper that refuses to touch a module loaded from a file. A stub built by `_make_pkg_stub` has no `__file__`; a real module does. The stub contract that `orchestration/__init__.py`'s import depends on is unchanged — only the ability to overwrite real symbols is removed.

**`tests/integration/test_mobile_pairing.py`** — the ambient-Redis fixture is replaced by an in-process double with genuine semantics (`setex` / `get` / `delete` / `ttl` / `scan_iter`, monotonic expiry deadlines, `decode_responses=True` string values), injected on the names the router and `services.device_jwt` actually resolve. Nothing is skipped, nothing is marked, and every behaviour the file claims to cover — one-time-use consumption, expiry, per-user binding, cross-request key visibility — is now genuinely exercised. `test_unpair_device_success` also stops burning ~30 s dialling an unreachable Redis host through `invalidate_device_cache`, which had been falling through its `if redis is None` branch without ever invalidating anything.

**`agent_loop/tests/test_pre_action_verifier.py`** — the ten string patch targets become `patch.object` against the module that owns `PreActionVerifier`, plus an import-time identity assertion so a future module-identity split fails loudly instead of passing green.

**`tests/orchestration/test_causal_error_recovery.py`** — an import-time anchor asserting the symbols it imported are still the ones in `sys.modules`, so a residual clobber is one clear error rather than two misleading failures deep inside the recovery system.

**`tests/content_reach/test_url_guard.py`** — both guard tests patch `_import_trafilatura` alongside the `_trafilatura_extract` seam they already patched.

## Verification

Four target files, `-m "not integration and not slow and not distributed and not performance"`:

```
before (CI shards, head 617528929): 84 passed, 7 failed
before (local):                     72 passed, 19 skipped
after  (local):                     91 passed in 2.78s
```

The `trafilatura` failure was reproduced locally with an import hook that mimics the runner's dependency set. Against the unmodified tree it reproduced the CI traceback exactly (`content_reach.base.BackendError: trafilatura not installed`, same file and line); after the fix the file is 27 passed with the wheel blocked.

The inert-patch mechanism was reproduced directly: with the `agent_loop` parent binding dropped, `patch("agent_loop.pre_action_verifier.VERIFIER_ENABLED", False)` leaves the real module reading `True`, while `patch.object` on the owning module reads `False`.

Blast radius for the shared conftest change — `autobot-backend/tests`, `orchestration`, `agent_loop`, `api`, 4 workers, `--dist loadscope`:

```
7908 passed, 2266 skipped, 4 failed in 168.98s
```

The four failures are `tests/unit/knowledge/connectors/test_gitlab_connector.py` (`AttributeError: module 'knowledge.connectors.gitlab' does not have the attribute '_store_ts'`), confirmed identical on the **unmodified** conftest — pre-existing and unrelated.

Lint on all five files: `isort` and `black` clean, `flake8 --config=.flake8` exit 0, `bandit -c .bandit` no issues at any severity.

Two items found along the way and deliberately left out of scope, to be filed separately:

- `tests/content_reach/sources/test_web_page.py::test_trafilatura_fetch_maps_extracted_text` fails in CI for exactly the same optional-dependency reason and needs the same one-line seam patch.
- `pair_device` consumes the QR challenge token with a non-atomic `get` then `delete`, leaving a replay window between the two. The canonical `client_getdel` helper already exists in `autobot_shared.redis_client`. `test_concurrent_pairing_same_token_race_condition` cannot detect this because `TestClient` serialises the two requests.

## Model Used

Claude Opus 4.5

Closes #13162

> **PARTIAL.** This PR fixes fourteen failures across four files. #13162 covers the whole standing Python-suite failure set and **stays open** until the remaining files are addressed.
