### PR TITLE
fix(ci): cap the branch auto-updater at one PR per sweep and move it off the self-hosted runner (#13426, #13401)

### DIFF
--- a/.github/workflows/auto-update-pr-branches.yml
+++ b/.github/workflows/auto-update-pr-branches.yml
@@ -26,26 +26,54 @@ on:
 
 jobs:
   auto-update:
-    runs-on: [self-hosted, linux]
-    timeout-minutes: 15  # #11077: fail fast (self-hosted); not GitHub's 24h default
+    # #13401: ubuntu-latest, NOT the singleton self-hosted runner.
+    #
+    # `strict: true` on Dev_new_gui means a PR cannot merge while its branch is
+    # behind, and this job is the only thing that clears "behind". Pinning it to
+    # the self-hosted runner put the recovery mechanism inside the failure domain
+    # it recovers from: when that runner went offline on 2026-08-03, every open
+    # PR fell behind, none could merge, and the sweep that would have fixed them
+    # could not start. The repository deadlocked until a human intervened.
+    #
+    # This is the same reasoning ci-dispatch-watchdog.yml already states for
+    # itself: "a watchdog that queues behind the outage it exists to report is
+    # useless." The sibling approve-refreshed-runs job below was already
+    # ubuntu-latest for exactly this reason; only this job was pinned.
+    #
+    # Nothing here needs the self-hosted host: the steps are `gh pr list`,
+    # `gh api compare` and `gh api update-branch` — REST calls against
+    # github.com, no build, no test, no local toolchain.
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
       pull-requests: write
 
     steps:
-      - name: Install GitHub CLI
-        run: |
-          if ! command -v gh &> /dev/null; then
-            curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
-            echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-            sudo apt update
-            sudo apt install gh -y
-          fi
-
+      # gh is preinstalled on GitHub-hosted runners, so the self-hosted install
+      # dance (apt keyring + sudo) is no longer needed (#13401).
       - name: Update out-of-date PR branches
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
+          # #13426: how many stale branches one sweep may refresh.
+          #
+          # Dev_new_gui has `strict: true` (require branches up to date before
+          # merging), so AT MOST ONE updated PR can merge before the next base
+          # landing makes the rest stale again. Refreshing N branches to land 1
+          # therefore costs N × ~25 runs (#13388) and discards N-1 of them —
+          # and it gets worse as the backlog grows, so the queue slows down
+          # exactly when it is busiest.
+          #
+          # It also un-approves work: the ruleset sets
+          # dismiss_stale_reviews_on_push, so every branch this sweep touches
+          # loses its approving review and has to be re-approved.
+          #
+          # 1 is the correct default under `strict: true`: refresh the next
+          # merge candidate, let it land, and let the push it produces refresh
+          # the one after. Raise this only if `strict` is relaxed, where
+          # refreshing several at once becomes useful rather than wasted.
+          MAX_BRANCH_UPDATES: '1'
         run: |
           echo "Dev_new_gui was updated — checking open PRs for staleness..."
 
@@ -109,6 +137,20 @@ jobs:
           fi
 
           echo "PRs behind Dev_new_gui: $(echo "$OUTDATED" | tr '\n' ' ')"
+
+          # #13426: refresh at most MAX_BRANCH_UPDATES of them, oldest PR first.
+          # Under `strict: true` only one can merge per base landing, so the
+          # rest would be re-staled before they were ever mergeable. Oldest-first
+          # (lowest PR number) keeps the queue FIFO instead of starving whichever
+          # PR happens to sort last.
+          TOTAL_OUTDATED=$(echo "$OUTDATED" | tr ' ' '\n' | grep -c '[0-9]' || true)
+          OUTDATED=$(echo "$OUTDATED" | tr ' ' '\n' | grep '[0-9]' | sort -n | head -n "$MAX_BRANCH_UPDATES")
+          DEFERRED=$((TOTAL_OUTDATED - $(echo "$OUTDATED" | grep -c '[0-9]' || true)))
+          if [ "$DEFERRED" -gt 0 ]; then
+            # Say what was skipped. A cap that silently drops work reads as
+            # "everything was refreshed" when it was not.
+            echo "Refreshing $MAX_BRANCH_UPDATES of $TOTAL_OUTDATED; deferring $DEFERRED to the next base push (#13426)."
+          fi
 
           UPDATED=0
           FAILED=0


### PR DESCRIPTION
Refs #13426, #13401

## Thinking Path

The queue used to drain in ~20 minutes. Today it stopped draining at all. The cause is not the runner and not any single slow job — it is an amplification in this workflow.

`auto-update-pr-branches.yml` refreshes **every** outdated open PR on every push to `Dev_new_gui`. Branch protection sets `strict: true`, so **at most one** of those PRs can merge before the next base landing makes all the others stale again. Cost per merge is therefore:

```
N × ~25 runs        (N = open PRs; ~25 runs per head movement, #13388)
```

rather than `~25`. At N=13 that is ~325 runs to land one PR — and because N grows with the backlog, the system slows down precisely when it is busiest. Measured today: one sweep took the queue from ~25 to **167 queued / 17 in progress**, where it stayed for over half an hour.

That work is not merely redundant, it is *discarded*: everything except the one PR that lands is invalidated seconds later. I checked whether any of it was duplicate runs that could be reaped instead — a repo-wide scan for older-SHA runs on the same `(workflow, branch)` found **0**. It is all genuinely triggered and genuinely wasted.

There is a second cost. The ruleset sets `dismiss_stale_reviews_on_push: true`, so the update push **dismisses the approving review** of every branch it touches. Refreshing 13 PRs to land 1 dismisses 13 approvals to gain one merge.

Separately, and more seriously, this job was pinned to `[self-hosted, linux]` — putting the recovery mechanism inside the failure domain it recovers from. When the singleton runner went offline today, every open PR fell behind, `strict: true` refused all of them, and the sweep that would have cleared "behind" could not start. The repository deadlocked with 13 green-but-unmergeable PRs.

## What Changed

`.github/workflows/auto-update-pr-branches.yml`, two changes to one job:

1. **`MAX_BRANCH_UPDATES: '1'`** — a sweep now refreshes at most one stale branch, oldest PR number first (FIFO, so nothing starves). It logs what it deferred rather than silently dropping it. Configurable, with the reasoning recorded inline: `1` is correct *because* `strict: true` is on, and the value should be raised if that is ever relaxed.

2. **`runs-on: ubuntu-latest`** (was `[self-hosted, linux]`) — this is #13401. The job only runs `gh pr list`, `gh api compare` and `gh api update-branch`: REST calls, no build, no test, no local toolchain. The sibling `approve-refreshed-runs` job in this same file was already `ubuntu-latest` for exactly this reason; only this job was pinned. `ci-dispatch-watchdog.yml` states the principle in its own header — *"a watchdog that queues behind the outage it exists to report is useless."*

The now-redundant "Install GitHub CLI" step (apt keyring + `sudo`) is removed, since `gh` is preinstalled on GitHub-hosted runners.

## Verification

Capping logic exercised directly, including edge cases:

```
$ MAX_BRANCH_UPDATES=1 OUTDATED=" 13381 13359 13395 13377"
total=4 selected=[13359] deferred=3
  would update #13359

$ in=[ 13359]  total=1 sel=[13359] deferred=0     # single PR: no spurious "deferred"
$ in=[]        total=0 sel=[]      deferred=0     # nothing outdated: clean no-op
```

Oldest-first confirmed — `13359` selected out of `{13381, 13359, 13395, 13377}`.

Workflow still parses, and both jobs are now GitHub-hosted:

```
auto-update:            runs-on=ubuntu-latest  steps=['Update out-of-date PR branches']
approve-refreshed-runs: runs-on=ubuntu-latest  steps=['(uses)', 'Approve parked runs and publish dispatch state']
```

No `sudo`/`apt` remains in the job.

## What this does not change

The sweep still runs on every base push, so deferred PRs are picked up on the next landing — which is exactly when they could next merge anyway. Nothing is stranded; the refresh order is serialised to match the merge order that `strict: true` already enforces.

This does not reintroduce #12801 or #12818: the listing still avoids `mergeStateStatus` (lazily computed, `UNKNOWN` right after a push) and still uses `compare/{base}...{head}`, which is accurate at push time.

## Model Used

claude-opus-5
