### PR TITLE
ci(workflows): skip Cypress binary download in npm ci (#13410)

### DIFF
--- a/.github/workflows/auto-fix-generated-types.yml
+++ b/.github/workflows/auto-fix-generated-types.yml
@@ -72,6 +72,11 @@ jobs:
 
       - name: Install frontend dependencies
         working-directory: autobot-frontend
+        # #13410: no CI job runs Cypress (only `test:e2e` needs the binary), so
+        # skip the ~100MB CDN download — a Cypress CDN 504 must never red out a
+        # required check. Local dev `npm ci` is unaffected and still gets it.
+        env:
+          CYPRESS_INSTALL_BINARY: '0'
         run: npm ci
 
       - name: Regenerate api.ts from authoritative schema

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,6 +255,11 @@ jobs:
         cache-dependency-path: autobot-frontend/package-lock.json
 
     - name: Install frontend dependencies
+      # #13410: no CI job runs Cypress (only `test:e2e` needs the binary), so
+      # skip the ~100MB CDN download — a Cypress CDN 504 must never red out a
+      # required check. Local dev `npm ci` is unaffected and still gets it.
+      env:
+        CYPRESS_INSTALL_BINARY: '0'
       run: |
         cd autobot-frontend
         npm ci

--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -85,6 +85,11 @@ jobs:
 
       - name: Install dependencies
         working-directory: autobot-frontend
+        # #13410: no CI job runs Cypress (only `test:e2e` needs the binary), so
+        # skip the ~100MB CDN download — a Cypress CDN 504 must never red out a
+        # required check. Local dev `npm ci` is unaffected and still gets it.
+        env:
+          CYPRESS_INSTALL_BINARY: '0'
         run: npm ci
 
       - name: Verify generated API types exist (#5209)
@@ -225,6 +230,11 @@ jobs:
 
       - name: Install dependencies
         working-directory: autobot-frontend
+        # #13410: no CI job runs Cypress (only `test:e2e` needs the binary), so
+        # skip the ~100MB CDN download — a Cypress CDN 504 must never red out a
+        # required check. Local dev `npm ci` is unaffected and still gets it.
+        env:
+          CYPRESS_INSTALL_BINARY: '0'
         run: npm ci
 
       - name: Run npm audit
@@ -273,6 +283,11 @@ jobs:
 
       - name: Install dependencies
         working-directory: autobot-frontend
+        # #13410: no CI job runs Cypress (only `test:e2e` needs the binary), so
+        # skip the ~100MB CDN download — a Cypress CDN 504 must never red out a
+        # required check. Local dev `npm ci` is unaffected and still gets it.
+        env:
+          CYPRESS_INSTALL_BINARY: '0'
         run: npm ci
 
       - name: Build application

--- a/.github/workflows/frontend-typecheck-regression.yml
+++ b/.github/workflows/frontend-typecheck-regression.yml
@@ -51,6 +51,11 @@ jobs:
 
       - name: Install dependencies
         working-directory: autobot-frontend
+        # #13410: no CI job runs Cypress (only `test:e2e` needs the binary), so
+        # skip the ~100MB CDN download — a Cypress CDN 504 must never red out a
+        # required check. Local dev `npm ci` is unaffected and still gets it.
+        env:
+          CYPRESS_INSTALL_BINARY: '0'
         run: npm ci --no-audit --no-fund
 
       - name: Run vue-tsc and check error count

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -101,6 +101,11 @@ jobs:
         cache-dependency-path: autobot-frontend/package-lock.json
 
     - name: Install Frontend dependencies
+      # #13410: no CI job runs Cypress (only `test:e2e` needs the binary), so
+      # skip the ~100MB CDN download — a Cypress CDN 504 must never red out a
+      # required check. Local dev `npm ci` is unaffected and still gets it.
+      env:
+        CYPRESS_INSTALL_BINARY: '0'
       run: |
         cd autobot-frontend
         npm ci

--- a/.github/workflows/verify-generated-types.yml
+++ b/.github/workflows/verify-generated-types.yml
@@ -130,6 +130,11 @@ jobs:
 
       - name: Install frontend dependencies
         working-directory: autobot-frontend
+        # #13410: no CI job runs Cypress (only `test:e2e` needs the binary), so
+        # skip the ~100MB CDN download — a Cypress CDN 504 must never red out a
+        # required check. Local dev `npm ci` is unaffected and still gets it.
+        env:
+          CYPRESS_INSTALL_BINARY: '0'
         run: npm ci
 
       - name: Regenerate api.ts from authoritative schema

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -75,6 +75,11 @@ jobs:
 
       - name: Install dependencies
         working-directory: autobot-frontend
+        # #13410: no CI job runs Cypress (only `test:e2e` needs the binary), so
+        # skip the ~100MB CDN download — a Cypress CDN 504 must never red out a
+        # required check. Local dev `npm ci` is unaffected and still gets it.
+        env:
+          CYPRESS_INSTALL_BINARY: '0'
         run: npm ci
 
       # Cache the Playwright browser binaries across runs (#10365). The cold


### PR DESCRIPTION
## Thinking Path

`npm ci` runs Cypress's postinstall, which pulls a ~100MB binary from a third-party CDN. A CDN 504 therefore reds out **required** checks in jobs that never launch Cypress (observed on #13375 and #13379). The download is a third-party dependency sitting in the critical path of a required check.

Rather than trust the reported list, I audited every `npm ci` step by parsing the workflow YAML and inspecting what each job actually runs:

| workflow | job | tree | what it actually runs |
|---|---|---|---|
| auto-fix-generated-types | autofix-types | frontend | `openapi-typescript` |
| ci | frontend-tests | frontend | lint, `vue-tsc`, build, `vitest` |
| frontend-test | unit-tests | frontend | `vue-tsc`, lint, `vitest` |
| frontend-test | security-scan | frontend | `npm audit`, `auditjs` |
| frontend-test | build-test | frontend | `vite build` |
| frontend-typecheck-regression | vue-tsc-baseline | frontend | `vue-tsc` |
| security | dependency-security | frontend | `npm audit` |
| verify-generated-types | verify-generated-types | frontend | `openapi-typescript` |
| visual-regression | visual-regression | frontend | Playwright (not Cypress) |

Two findings changed the shape of the fix:

1. **No workflow in this repo invokes Cypress at all.** `grep -rn "cypress\|test:e2e" .github/workflows/` returns nothing but the comments added here. `test:e2e` is a local-only script, so *every* CI `npm ci` was paying for a binary no job can use. That means step 2 of the plan (a retry loop around a job that genuinely needs the binary) has no applicable target — there is nothing to make retryable.
2. **There are eleven `npm ci` invocations, not eight.** `ci.yml`, `security.yml` and `visual-regression.yml` carry the identical defect and were not in the original list. They are the same one-line shape, so they are fixed here rather than left to fail later.

I also found a **second** trigger for the same download: `autobot-frontend/package.json` declares `"prepare": "cypress install"`, which `npm ci` also runs. An env var that only suppressed the postinstall would have left this second CDN reach in place, so I verified empirically that it covers both (see Verification).

**Why per-step env rather than `.npmrc`:** neither frontend has an `.npmrc` today. Adding one would disable the binary for *everyone*, including a developer running `npm ci` before `npm run test:e2e` locally — it would fix CI by breaking the only workflow that actually needs the binary. Per-step env is scoped to the CI jobs that provably do not use Cypress and leaves local dev untouched. It is also explicit at the point of use.

## What Changed

`CYPRESS_INSTALL_BINARY: '0'` added to the **nine** `npm ci` steps that install the `autobot-frontend` tree, each with a comment referencing this issue:

- `.github/workflows/auto-fix-generated-types.yml` — `autofix-types`
- `.github/workflows/ci.yml` — `frontend-tests`
- `.github/workflows/frontend-test.yml` — `unit-tests`, `security-scan`, `build-test`
- `.github/workflows/frontend-typecheck-regression.yml` — `vue-tsc-baseline`
- `.github/workflows/security.yml` — `dependency-security`
- `.github/workflows/verify-generated-types.yml` — `verify-generated-types`
- `.github/workflows/visual-regression.yml` — `visual-regression`

**Deliberately left alone:**

- `slm-frontend-check.yml` and `verify-generated-types.yml` (`verify-generated-types-slm`) install `autobot-slm-frontend`, which has **no Cypress dependency** — its lockfile's only install scripts are `esbuild` and `fsevents`. There is no CDN reach to remove, and the env var would be a no-op whose comment would mislead the next reader. Say the word if you'd prefer it for uniformity.
- The second `npm ci` match in `frontend-typecheck-regression.yml` is the literal string inside an `echo "... did 'npm ci' run?"` error message, not an install.
- `auto-update-pr-branches.yml` untouched (has no `npm ci`).

No behaviour change to any job: nothing here consumes the Cypress binary.

## Verification

YAML parse on every touched file:

```
$ for f in $(git diff --name-only); do python3 -c "import yaml; yaml.safe_load(open('$f',encoding='utf-8')); print('OK   $f')"; done
OK   .github/workflows/auto-fix-generated-types.yml
OK   .github/workflows/ci.yml
OK   .github/workflows/frontend-test.yml
OK   .github/workflows/frontend-typecheck-regression.yml
OK   .github/workflows/security.yml
OK   .github/workflows/verify-generated-types.yml
OK   .github/workflows/visual-regression.yml
```

Structural audit of every `npm ci` step after the change (parsed from YAML, so it reflects effective config, not grep):

```
workflow                             job                          tree                  CYPRESS_INSTALL_BINARY  runs-cypress
auto-fix-generated-types.yml         autofix-types                autobot-frontend      0                       False
ci.yml                               frontend-tests               autobot-frontend      0                       False
frontend-test.yml                    unit-tests                   autobot-frontend      0                       False
frontend-test.yml                    security-scan                autobot-frontend      0                       False
frontend-test.yml                    build-test                   autobot-frontend      0                       False
frontend-typecheck-regression.yml    vue-tsc-baseline             autobot-frontend      0                       False
security.yml                         dependency-security          autobot-frontend      0                       False
slm-frontend-check.yml               slm-frontend-check           autobot-slm-frontend  <unset>                 False
verify-generated-types.yml           verify-generated-types       autobot-frontend      0                       False
verify-generated-types.yml           verify-generated-types-slm   autobot-slm-frontend  <unset>                 False
visual-regression.yml                visual-regression            autobot-frontend      0                       False
```

`runs-cypress` is `False` for every job, so **no job that needs the binary lost it** — none needs it.

Empirical proof the flag suppresses the download, including via the `prepare` hook. Run in a throwaway directory outside the repo, reproducing both triggers (dependency + `"prepare": "cypress install"`):

```
$ CYPRESS_INSTALL_BINARY=0 npm install --no-audit --no-fund
> prepare
> cypress install

Note: Skipping binary installation: Environment variable CYPRESS_INSTALL_BINARY = 0.

added 169 packages in 9s
```

9s and no binary fetch, and the skip is confirmed for the `prepare` path specifically. The local Cypress binary cache was checked before and after and was not written to.

The repo's `node_modules` was never touched — no `npm ci` was run inside the repo, so the previously disturbed `node_modules/.bin` is unaffected. Working tree is clean apart from the committed workflow files.

**Other network postinstalls (reported, not fixed — out of scope):** the lockfiles' only other install scripts are `esbuild`, `fsevents`, `msw` and `protobufjs`; none reaches a third-party CDN (`esbuild` resolves its binary from an already-downloaded optional dep on the npm registry, `fsevents` is macOS-only, `msw`/`protobufjs` are local file operations). Playwright browsers *are* a large network download, but they are **not** a postinstall — `visual-regression.yml` installs them in an explicit, cache-backed step, so they are already off the `npm ci` path and out of the critical path of the other required checks. No action needed.

Refs #13410

## Model Used

claude-opus-5
