### PR TITLE
fix(ci): resolve hardcoded developer paths from __file__ and gate regressions (#13409)

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -166,6 +166,53 @@ jobs:
     - name: Block print/console regressions (#1082, #6785)
       run: bash pipeline-scripts/check-pre-commit-hook-pr.sh pre-commit-no-print-console
 
+    - name: Block developer absolute-path regressions (#13409, #13149)
+      run: |
+        set -euo pipefail
+        # An absolute /home/<developer>/... path in tracked source only ever
+        # resolves on the machine it was written on. #13409 fixed four such
+        # files: one was a guard test that raised FileNotFoundError on every
+        # CI run, three pointed into a worktree that had been deleted.
+        # Full-tree scan (not changed-files-only): the tree is clean as of
+        # #13409, so any new hit is a genuine regression.
+        #
+        # ALLOWED_HOMES — deployment/CI service accounts that legitimately
+        # appear as absolute paths in playbooks, units and container images.
+        # Templated homes (/home/{{ ansible_user }}, /home/$USER) never match
+        # the username character class and need no exemption.
+        ALLOWED_HOMES='autobot|kali|user|ubuntu|runner|vagrant|sandbox|node'
+        # ALLOWED_FILES — synthetic fixtures, plus one generated third-party
+        # config tracked by mistake (#13429). Do NOT extend this list to work
+        # around a real violation.
+        ALLOWED_FILES='^(\.paperclip/config\.json|autobot-frontend/src/components/audit/AuditTimeline\.stories\.ts|pipeline-scripts/test_audit_unwired_trackers\.py):'
+        PATTERN="(^|[^A-Za-z0-9_])/home/(?!(?:${ALLOWED_HOMES})[/\"'[:space:]]|\{)[A-Za-z0-9._-]+/"
+        set +e
+        raw=$(git grep -nIP "$PATTERN" -- \
+          '*.py' '*.sh' '*.bash' '*.ts' '*.tsx' '*.vue' '*.js' '*.mjs' '*.cjs' \
+          '*.yml' '*.yaml' '*.json' '*.toml' '*.ini' '*.cfg' '*.j2' '*.conf')
+        rc=$?
+        set -e
+        if [ "$rc" -gt 1 ]; then
+          echo "git grep failed (exit $rc) — PCRE (-P) support missing or bad pattern"
+          exit 1
+        fi
+        violations=""
+        if [ -n "$raw" ]; then
+          violations=$(printf '%s\n' "$raw" | grep -vE "${ALLOWED_FILES}" || true)
+        fi
+        if [ -n "$violations" ]; then
+          echo "$violations"
+          echo ""
+          echo "⚠️ Hardcoded developer absolute path(s) detected in tracked source"
+          echo "Resolve paths from __file__ instead, e.g."
+          echo "  Path(__file__).resolve().parents[N] / 'sub' / 'dir'"
+          echo "Do NOT use autobot_shared.ssot_config.PROJECT_ROOT for this — its"
+          echo ".env marker-walk escapes git worktrees and resolves to the wrong"
+          echo "checkout (#13357)."
+          exit 1
+        fi
+        echo "No hardcoded developer absolute paths found."
+
     - name: Check design-token contrast meets WCAG AA (#12730)
       run: python3 scripts/check_token_contrast.py
 

--- a/autobot-backend/api/presence_ws_router_test.py
+++ b/autobot-backend/api/presence_ws_router_test.py
@@ -9,6 +9,8 @@ Issue #4257: Verify that presence_ws router is properly registered
 in the feature routers configuration.
 """
 
+from pathlib import Path
+
 import pytest
 from fastapi import FastAPI
 
@@ -68,13 +70,16 @@ class TestPresenceWSConfiguration:
 
     def test_router_registered_in_feature_routers_config(self):
         """Test that presence_ws is properly registered in FEATURE_ROUTER_CONFIGS."""
-        # Read the configuration directly from the file
-        config_file = (
-            "/home/martins/AutoBot-Ai/AutoBot-AI/autobot-backend/initialization/router_registry/feature_routers.py"
-        )
+        # Resolve the config relative to THIS file so the guard runs anywhere
+        # (CI checkout, worktree, container) — #13409.
+        # autobot_shared.ssot_config.PROJECT_ROOT is deliberately NOT used: it
+        # walks up looking for a .env, which a git worktree has none of, so it
+        # silently resolves to the main checkout instead (#13357).
+        backend_root = Path(__file__).resolve().parents[1]
+        config_file = backend_root / "initialization" / "router_registry" / "feature_routers.py"
 
-        with open(config_file, "r", encoding="utf-8") as f:
-            content = f.read()
+        assert config_file.is_file(), f"feature_routers.py not found at {config_file}"
+        content = config_file.read_text(encoding="utf-8")
 
         # Verify presence_ws is in the file
         assert "api.presence_ws" in content, "api.presence_ws not found in config"

--- a/autobot-slm-backend/ansible/playbooks/deploy-slm-manager.yml
+++ b/autobot-slm-backend/ansible/playbooks/deploy-slm-manager.yml
@@ -28,7 +28,7 @@
 #
 # When GitHub is unreachable from SLM, pass controller_repo_root to push
 # the local checkout to SLM before provisioning (#3604):
-#   ansible-playbook ... -e "controller_repo_root=/home/martins/AutoBot-Ai/AutoBot-AI"
+#   ansible-playbook ... -e "controller_repo_root=/path/to/AutoBot-AI"
 ---
 - name: Deploy SLM Manager
   hosts: slm_server

--- a/autobot-slm-backend/ansible/playbooks/sync-code-source.yml
+++ b/autobot-slm-backend/ansible/playbooks/sync-code-source.yml
@@ -14,7 +14,7 @@
 #
 # Usage (from dev machine):
 #   ansible-playbook -i inventory/hosts.yml playbooks/sync-code-source.yml \
-#       -e "controller_repo_root=/home/martins/AutoBot-Ai/AutoBot-AI"
+#       -e "controller_repo_root=/path/to/AutoBot-AI"
 #
 # When imported by deploy-slm-manager.yml the variable is set automatically
 # via the playbook vars block at the top of that file.

--- a/check_syntax.py
+++ b/check_syntax.py
@@ -1,30 +1,65 @@
 #!/usr/bin/env python3
 # Copyright 2025-2026 mrveiss
 # SPDX-License-Identifier: Apache-2.0
-"""Check Python syntax of modified files."""
+"""Byte-compile Python files to check them for syntax errors.
+
+Usage::
+
+    python3 check_syntax.py                       # default MCP metrics file set
+    python3 check_syntax.py path/a.py path/b.py   # explicit file list
+
+Paths are resolved against the repository root derived from ``__file__``
+(#13409) — the default list previously used absolute paths into a developer
+worktree that no longer exists, so this script could not run at all.
+"""
 
 import py_compile
 import sys
+from pathlib import Path
+from typing import List
 
-files_to_check = [
-    "/home/martins/AutoBot-Ai/AutoBot-AI/.worktrees/issue-4109/autobot_shared/monitoring/metrics/mcp_worker.py",
-    "/home/martins/AutoBot-Ai/AutoBot-AI/.worktrees/issue-4109/autobot_shared/monitoring/metrics/__init__.py",
-    "/home/martins/AutoBot-Ai/AutoBot-AI/.worktrees/issue-4109/autobot_shared/monitoring/prometheus_metrics.py",
-    "/home/martins/AutoBot-Ai/AutoBot-AI/.worktrees/issue-4109/autobot-backend/services/mcp_isolated_runtime.py",
-]
+_REPO_ROOT = Path(__file__).resolve().parent
 
-all_ok = True
-for filepath in files_to_check:
+# Default set: the MCP metrics modules this script was written to guard.
+DEFAULT_FILES = (
+    "autobot_shared/monitoring/metrics/mcp_worker.py",
+    "autobot_shared/monitoring/metrics/__init__.py",
+    "autobot_shared/monitoring/prometheus_metrics.py",
+    "autobot-backend/services/mcp_isolated_runtime.py",
+)
+
+
+def resolve_targets(argv: List[str]) -> List[Path]:
+    """Return the files to compile: explicit argv, else the default set."""
+    if argv:
+        return [Path(arg) if Path(arg).is_absolute() else _REPO_ROOT / arg for arg in argv]
+    return [_REPO_ROOT / rel for rel in DEFAULT_FILES]
+
+
+def compile_file(path: Path) -> bool:
+    """Byte-compile ``path``; report and return success."""
+    rel = path.relative_to(_REPO_ROOT) if path.is_relative_to(_REPO_ROOT) else path
+    if not path.is_file():
+        print(f"✗ {rel}: file not found")  # noqa: print
+        return False
     try:
-        py_compile.compile(filepath, doraise=True)
-        print(f"✓ {filepath}")
-    except py_compile.PyCompileError as e:
-        print(f"✗ {filepath}: {e}")
-        all_ok = False
+        py_compile.compile(str(path), doraise=True)
+    except py_compile.PyCompileError as exc:
+        print(f"✗ {rel}: {exc}")  # noqa: print
+        return False
+    print(f"✓ {rel}")  # noqa: print
+    return True
 
-if all_ok:
-    print("\nAll files have valid Python syntax!")
-    sys.exit(0)
-else:
-    print("\nSome files have syntax errors!")
-    sys.exit(1)
+
+def main(argv: List[str]) -> int:
+    """Compile every target; return 0 when all have valid syntax."""
+    results = [compile_file(path) for path in resolve_targets(argv)]
+    if all(results):
+        print("\nAll files have valid Python syntax!")  # noqa: print
+        return 0
+    print("\nSome files have syntax errors!")  # noqa: print
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/repo_tests/code-review-hardening-test.sh
+++ b/repo_tests/code-review-hardening-test.sh
@@ -6,8 +6,11 @@
 
 set -euo pipefail
 
-SKILL_FILE="/home/martins/.claude/plugins/marketplaces/claude-plugins-official/plugins/code-review/commands/code-review.md"
-AGENT_FILE="/home/martins/.claude/plugins/marketplaces/claude-plugins-official/plugins/pr-review-toolkit/agents/code-reviewer.md"
+# Plugin files live outside the repo; derive from $HOME so this runs for any
+# developer rather than one workstation (#13409). Override with PLUGIN_ROOT.
+PLUGIN_ROOT="${PLUGIN_ROOT:-${HOME}/.claude/plugins/marketplaces/claude-plugins-official/plugins}"
+SKILL_FILE="${PLUGIN_ROOT}/code-review/commands/code-review.md"
+AGENT_FILE="${PLUGIN_ROOT}/pr-review-toolkit/agents/code-reviewer.md"
 
 echo "=== Code Review Hardening Test ==="
 echo

--- a/test_imports.py
+++ b/test_imports.py
@@ -1,35 +1,54 @@
 #!/usr/bin/env python3
 # Copyright 2025-2026 mrveiss
 # SPDX-License-Identifier: Apache-2.0
-"""Quick import test for MCP metrics implementation."""
+"""Quick import smoke check for the MCP metrics implementation.
 
+Standalone diagnostic: run ``python3 test_imports.py`` to confirm the MCP
+metrics/runtime modules import cleanly without spinning up pytest.
+
+Package roots are resolved from ``__file__`` (#13409) — this script previously
+pointed at a developer worktree that no longer exists, so it could not run at
+all. The module bodies are guarded behind ``main()`` so a stray ``pytest .``
+collecting this ``test_*.py`` filename cannot trip its ``sys.exit``.
+"""
+
+import importlib
 import sys
+from pathlib import Path
 
-sys.path.insert(0, "/home/martins/AutoBot-Ai/AutoBot-AI/.worktrees/issue-4109/autobot-backend")
-sys.path.insert(0, "/home/martins/AutoBot-Ai/AutoBot-AI/.worktrees/issue-4109/autobot_shared")
+_REPO_ROOT = Path(__file__).resolve().parent
 
-try:
-    from monitoring.metrics.mcp_worker import MCPWorkerMetricsRecorder
+for _package_root in ("autobot-backend", "autobot_shared"):
+    sys.path.insert(0, str(_REPO_ROOT / _package_root))
 
-    print("✓ MCPWorkerMetricsRecorder imported successfully")
-except Exception as e:
-    print(f"✗ Failed to import MCPWorkerMetricsRecorder: {e}")
-    sys.exit(1)
+# (module path, attribute) pairs the MCP metrics work depends on.
+CHECKS = (
+    ("monitoring.metrics.mcp_worker", "MCPWorkerMetricsRecorder"),
+    ("monitoring.prometheus_metrics", "get_metrics_manager"),
+    ("services.mcp_isolated_runtime", "IsolatedBridgeClient"),
+)
 
-try:
-    from monitoring.prometheus_metrics import get_metrics_manager
 
-    print("✓ get_metrics_manager imported successfully")
-except Exception as e:
-    print(f"✗ Failed to import get_metrics_manager: {e}")
-    sys.exit(1)
+def check_import(module_path: str, attribute: str) -> bool:
+    """Import ``attribute`` from ``module_path``; report and return success."""
+    try:
+        module = importlib.import_module(module_path)
+        getattr(module, attribute)
+    except Exception as exc:  # noqa: BLE001 - diagnostic reports any failure
+        print(f"✗ Failed to import {attribute}: {exc}")  # noqa: print
+        return False
+    print(f"✓ {attribute} imported successfully")  # noqa: print
+    return True
 
-try:
-    from services.mcp_isolated_runtime import IsolatedBridgeClient
 
-    print("✓ IsolatedBridgeClient imported successfully")
-except Exception as e:
-    print(f"✗ Failed to import IsolatedBridgeClient: {e}")
-    sys.exit(1)
+def main() -> int:
+    """Run every import check; return 0 when all succeed."""
+    results = [check_import(module, attr) for module, attr in CHECKS]
+    if not all(results):
+        return 1
+    print("\nAll imports successful!")  # noqa: print
+    return 0
 
-print("\nAll imports successful!")
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/verify_causal_extractor.py
+++ b/verify_causal_extractor.py
@@ -6,23 +6,32 @@ Quick verification script for CausalRelationshipExtractor.
 Tests the core functionality without requiring full pytest infrastructure.
 """
 
+# isort: skip_file
+# Import order is load-bearing: sys.path must gain the package roots and the
+# optional LLM provider must be stubbed BEFORE the knowledge.pipeline imports
+# below. Re-sorting them to the top makes this script unrunnable.
+
 import sys
+from pathlib import Path
 from types import ModuleType
 from uuid import uuid4
 
-# Stub dependencies
+# Resolve package roots from __file__ (#13409) — this previously hardcoded a
+# developer workstation's absolute path and could only run on one machine.
+_REPO_ROOT = Path(__file__).resolve().parent
+sys.path.insert(0, str(_REPO_ROOT))
+sys.path.insert(0, str(_REPO_ROOT / "autobot-backend"))
+
+# Stub the optional LLM provider — this script exercises the NLP path only.
 _mock_llm_mod = ModuleType("llm_interface_pkg")
 _mock_llm_mod.LLMInterface = type("LLMInterface", (), {})
 sys.modules.setdefault("llm_interface_pkg", _mock_llm_mod)
 
-_mock_shared = ModuleType("autobot_shared")
-_mock_redis_mod = ModuleType("autobot_shared.redis_client")
-_mock_redis_mod.get_redis_client = lambda *a, **kw: None
-sys.modules.setdefault("autobot_shared", _mock_shared)
-sys.modules.setdefault("autobot_shared.redis_client", _mock_redis_mod)
-
-# Now import our modules
-sys.path.insert(0, "/home/martins/AutoBot-Ai/AutoBot-AI/autobot-backend")
+# autobot_shared is imported for real. It used to be replaced by a bare
+# ModuleType stub, which is not a package, so every downstream
+# `from autobot_shared.<sub> import ...` broke once knowledge.pipeline started
+# importing logging_manager and rate_limiter. The real client degrades to a
+# warning when no broker is reachable, which is fine for this offline check.
 
 from knowledge.pipeline.cognifiers.causal_relationship_extractor import (
     CausalRelationshipExtractor,
@@ -34,7 +43,7 @@ from knowledge.pipeline.base import PipelineContext
 
 def test_nlp_extraction():
     """Test NLP-based causal extraction."""
-    print("\n=== Testing NLP Extraction ===")
+    print("\n=== Testing NLP Extraction ===")  # noqa: print
     extractor = CausalRelationshipExtractor(mode="nlp")
 
     test_cases = [
@@ -49,18 +58,18 @@ def test_nlp_extraction():
         edges = extractor._nlp_extract_chunk(chunk, uuid4())
 
         if edges:
-            print(f"✓ '{text}'")
-            print(f"  → Found {len(edges)} edge(s)")
+            print(f"✓ '{text}'")  # noqa: print
+            print(f"  → Found {len(edges)} edge(s)")  # noqa: print
             for edge in edges:
-                print(f"    - {edge.source_name} {edge.effect_type} {edge.target_name}")
-                print(f"      Confidence: {edge.confidence}")
+                print(f"    - {edge.source_name} {edge.effect_type} {edge.target_name}")  # noqa: print
+                print(f"      Confidence: {edge.confidence}")  # noqa: print
         else:
-            print(f"✓ '{text}' (no edges - expected for basic pattern matching)")
+            print(f"✓ '{text}' (no edges - expected for basic pattern matching)")  # noqa: print
 
 
 def test_correlation_rejection():
     """Test that correlations are rejected."""
-    print("\n=== Testing Correlation Rejection ===")
+    print("\n=== Testing Correlation Rejection ===")  # noqa: print
     extractor = CausalRelationshipExtractor(mode="nlp")
 
     correlation_texts = [
@@ -74,14 +83,14 @@ def test_correlation_rejection():
         edges = extractor._nlp_extract_chunk(chunk, uuid4())
 
         if not edges:
-            print(f"✓ Correctly rejected correlation: '{text}'")
+            print(f"✓ Correctly rejected correlation: '{text}'")  # noqa: print
         else:
-            print(f"⚠ WARNING: Accepted correlation as causal: '{text}'")
+            print(f"⚠ WARNING: Accepted correlation as causal: '{text}'")  # noqa: print
 
 
 def test_causal_edge_model():
     """Test CausalEdge model and formatting."""
-    print("\n=== Testing CausalEdge Model ===")
+    print("\n=== Testing CausalEdge Model ===")  # noqa: print
 
     edge = CausalEdge(
         source_name="cache_ttl",
@@ -92,35 +101,35 @@ def test_causal_edge_model():
         evidence_text="Shorter TTLs reduce query latency by forcing fresh data retrieval.",
     )
 
-    print(f"✓ CausalEdge created successfully")
-    print(f"  - source: {edge.source_name}")
-    print(f"  - target: {edge.target_name}")
-    print(f"  - effect_type: {edge.effect_type}")
-    print(f"  - condition: {edge.condition}")
-    print(f"  - confidence: {edge.confidence}")
-    print(f"  - Human-readable: {edge.to_causal_string()}")
+    print(f"✓ CausalEdge created successfully")  # noqa: print
+    print(f"  - source: {edge.source_name}")  # noqa: print
+    print(f"  - target: {edge.target_name}")  # noqa: print
+    print(f"  - effect_type: {edge.effect_type}")  # noqa: print
+    print(f"  - condition: {edge.condition}")  # noqa: print
+    print(f"  - confidence: {edge.confidence}")  # noqa: print
+    print(f"  - Human-readable: {edge.to_causal_string()}")  # noqa: print
 
 
 def test_mode_selection():
     """Test automatic mode selection."""
-    print("\n=== Testing Mode Selection ===")
+    print("\n=== Testing Mode Selection ===")  # noqa: print
 
     extractor = CausalRelationshipExtractor(mode="auto", nlp_threshold=100)
 
     # Small chunk set
     small_chunks = [ProcessedChunk(content=f"Text {i}", document_id=uuid4(), chunk_index=i) for i in range(10)]
     mode = extractor._select_mode(small_chunks)
-    print(f"✓ Mode for 10 chunks: {mode} (expected: llm)")
+    print(f"✓ Mode for 10 chunks: {mode} (expected: llm)")  # noqa: print
 
     # Large chunk set
     large_chunks = [ProcessedChunk(content=f"Text {i}", document_id=uuid4(), chunk_index=i) for i in range(150)]
     mode = extractor._select_mode(large_chunks)
-    print(f"✓ Mode for 150 chunks: {mode} (expected: nlp)")
+    print(f"✓ Mode for 150 chunks: {mode} (expected: nlp)")  # noqa: print
 
 
 def test_confidence_filtering():
     """Test confidence score filtering."""
-    print("\n=== Testing Confidence Filtering ===")
+    print("\n=== Testing Confidence Filtering ===")  # noqa: print
 
     extractor = CausalRelationshipExtractor(mode="llm", min_confidence=0.8)
 
@@ -144,21 +153,21 @@ def test_confidence_filtering():
     chunk = ProcessedChunk(content="test", document_id=uuid4(), chunk_index=0)
     edges = extractor._convert_to_causal_edges(raw_edges, chunk, uuid4())
 
-    print(f"✓ Input: {len(raw_edges)} raw edges (one above, one below 0.8 threshold)")
-    print(f"  → Filtered: {len(edges)} edges")
+    print(f"✓ Input: {len(raw_edges)} raw edges (one above, one below 0.8 threshold)")  # noqa: print
+    print(f"  → Filtered: {len(edges)} edges")  # noqa: print
     for edge in edges:
-        print(f"    - {edge.source_name} {edge.effect_type} {edge.target_name}")
-        print(f"      Confidence: {edge.confidence}")
+        print(f"    - {edge.source_name} {edge.effect_type} {edge.target_name}")  # noqa: print
+        print(f"      Confidence: {edge.confidence}")  # noqa: print
 
     if len(edges) == 1 and edges[0].confidence >= 0.8:
-        print("✓ Confidence filtering working correctly")
+        print("✓ Confidence filtering working correctly")  # noqa: print
     else:
-        print("⚠ WARNING: Confidence filtering not working as expected")
+        print("⚠ WARNING: Confidence filtering not working as expected")  # noqa: print
 
 
 def test_pipeline_context_integration():
     """Test integration with PipelineContext."""
-    print("\n=== Testing PipelineContext Integration ===")
+    print("\n=== Testing PipelineContext Integration ===")  # noqa: print
 
     ctx = PipelineContext()
     ctx.document_id = uuid4()
@@ -172,7 +181,7 @@ def test_pipeline_context_integration():
 
     # Simulate having causal_edges attribute
     if hasattr(ctx, "causal_edges"):
-        print("✓ PipelineContext has causal_edges attribute")
+        print("✓ PipelineContext has causal_edges attribute")  # noqa: print
 
         edge = CausalEdge(
             source_name="cache",
@@ -180,17 +189,17 @@ def test_pipeline_context_integration():
             effect_type="REDUCES",
         )
         ctx.causal_edges.append(edge)
-        print(f"✓ Successfully added edge to context")
-        print(f"  → Total edges in context: {len(ctx.causal_edges)}")
+        print(f"✓ Successfully added edge to context")  # noqa: print
+        print(f"  → Total edges in context: {len(ctx.causal_edges)}")  # noqa: print
     else:
-        print("⚠ WARNING: PipelineContext missing causal_edges attribute")
+        print("⚠ WARNING: PipelineContext missing causal_edges attribute")  # noqa: print
 
 
 def main():
     """Run all verification tests."""
-    print("=" * 60)
-    print("CausalRelationshipExtractor Verification")
-    print("=" * 60)
+    print("=" * 60)  # noqa: print
+    print("CausalRelationshipExtractor Verification")  # noqa: print
+    print("=" * 60)  # noqa: print
 
     try:
         test_causal_edge_model()
@@ -200,12 +209,12 @@ def main():
         test_confidence_filtering()
         test_pipeline_context_integration()
 
-        print("\n" + "=" * 60)
-        print("✓ All verification tests passed!")
-        print("=" * 60)
+        print("\n" + "=" * 60)  # noqa: print
+        print("✓ All verification tests passed!")  # noqa: print
+        print("=" * 60)  # noqa: print
         return 0
     except Exception as e:
-        print(f"\n❌ Verification failed: {e}")
+        print(f"\n❌ Verification failed: {e}")  # noqa: print
         import traceback
 
         traceback.print_exc()


### PR DESCRIPTION
Refs #13409

## Thinking Path

The four files shared one defect but not one severity, so I ordered the work by blast radius.

`presence_ws_router_test.py` came first because it fails every CI run. It reads a router-registry file to assert a router is registered — a guard. Opening that file by absolute path meant it only ever reported "this is not the author's workstation". Worse than red: on the one machine where the path resolves, it reads *that* checkout rather than the one under test, so it is a false green there.

I proved that rather than assuming it. Removing the registration from the branch's own checkout left the old test passing — it was reading a different tree entirely — while the fixed test failed with the intended assertion. That is the property the guard was written to check, restored.

`PROJECT_ROOT` was rejected on purpose. It locates the root by walking up for a `.env` marker, and a git worktree has none, so from inside one it silently returns the primary checkout (#13357) — the same class of bug, re-introduced through a helper. `__file__` is the only anchor that cannot drift.

For the three root scripts the project rule is finish, don't discard. Two pointed into a working tree deleted long ago and could not execute at all; the third pointed at a fixed backend path. All three are repaired and were each run to completion. Repairing them surfaced two further faults that had been hidden behind the unreachable paths — see below. One is superseded by real suite coverage; per the rule I have said so with evidence and left it in place rather than deciding its fate unilaterally.

The gate matters more than the four fixes, because it is what stops the next one. Scoping it took the most care. A blanket ban on absolute home paths flags 589 lines across 190 files, nearly all legitimate: deployment and CI service-account homes in playbooks and container images, plus vendored third-party documentation. So the gate allows service-account homes and templated homes, scans source and config extensions only, and carries three narrow file exemptions. I checked what it would flag across the whole tree before settling it, then cleared the remaining real violations so it can run in full-tree mode instead of the weaker changed-files-only mode the neighbouring steps use.

## What Changed

**The CI failure**

- `autobot-backend/api/presence_ws_router_test.py` — the registry path now resolves from `Path(__file__).resolve().parents[1]`, with an explicit existence assertion so a future move fails readably instead of as a bare `FileNotFoundError`. A comment records why `PROJECT_ROOT` is not used here.

**The three scripts (all repaired, none deleted)**

- `test_imports.py` — roots derived from `__file__`; checks became a data-driven table with the body behind `main()`, so its `test_*.py` filename cannot trip a `sys.exit` during a stray collection run.
- `check_syntax.py` — default file list is now repository-relative; accepts explicit file arguments, and reports missing files instead of passing silently over them.
- `verify_causal_extractor.py` — package roots derived from `__file__`; `# isort: skip_file` records that its import order is load-bearing.

**Two pre-existing faults the repair exposed**

- `verify_causal_extractor.py` replaced `autobot_shared` with a bare `ModuleType` stub. A `ModuleType` is not a package, so every downstream `from autobot_shared.<sub> import ...` failed once `knowledge.pipeline` began importing `logging_manager` and `rate_limiter`. The real package is imported now; only the optional LLM provider stays stubbed. This was invisible while the script could not reach its imports at all.
- The script reports `PipelineContext missing causal_edges attribute`. That is real — `PipelineContext` has no such field, so the causal extractor's output has nowhere to go. Out of scope here; filed as #13430 with the fix direction.

**The gate**

- `.github/workflows/code-quality.yml` — new `Block developer absolute-path regressions` step alongside the existing `Block ...` family. Full-tree scan; fails on an absolute path into a developer home in tracked source, and prints the `__file__` fix plus the `PROJECT_ROOT` warning. A `git grep` failure is distinguished from a clean scan so an unsupported-regex error cannot be mistaken for a pass.

**Cleared so the gate can run full-tree**

- `autobot-slm-backend/ansible/playbooks/{sync-code-source,deploy-slm-manager}.yml` — usage comments show a generic example root.
- `repo_tests/code-review-hardening-test.sh` — plugin paths derive from `$HOME` with a `PLUGIN_ROOT` override, so it runs for any developer rather than one workstation.

**Exemptions, and why**

| Exempted | Why |
|---|---|
| `autobot-frontend/src/components/audit/AuditTimeline.stories.ts` | Storybook fixture — a synthetic home path is the point of the fixture |
| `pipeline-scripts/test_audit_unwired_trackers.py` | Unit-test fixture simulating a repo root; the literal is the test input |
| `.paperclip/config.json` | Tracked but machine-generated — see below |

Service-account homes (`autobot`, `kali`, `user`, `ubuntu`, `runner`, `vagrant`, `sandbox`, `node`) stay allowed: they are real deployment targets, not workstations. Templated homes never match the username character class and need no exemption. A prose match reading `root/home/parent` is excluded structurally by requiring a non-word character before the path.

**On `.paperclip/config.json`** — checked rather than fixed blindly, as asked. It **is** tracked, and it **is** generated: its own header declares `"source": "configure"`. It arrived as a drive-by in an unrelated feature commit and holds five machine paths including a master-key file location. The likely fix is to stop tracking it, which is a deletion of tracked content and an owner decision, so it is exempted with a pointer to #13429 rather than changed here. That issue's acceptance criteria include removing this exemption.

**Left in place, flagged for the owner** — `test_imports.py` is genuinely superseded. Its three import checks are each covered by the real suite: `MCPWorkerMetricsRecorder` by `autobot-backend/services/mcp_worker_metrics_test.py`, `IsolatedBridgeClient` by `mcp_isolated_runtime_test.py` and `mcp_run_jwt_propagation_test.py`, `get_metrics_manager` by `monitoring/prometheus_metrics_test.py` among others. It is repaired and working regardless; retiring it is the owner's call, not mine. The other two are not superseded — `verify_causal_extractor.py` is named as the feature's verification entry point in its changelog entry.

## Verification

Repaired test, run from the branch worktree — the case `PROJECT_ROOT` would have broken:

```
rootdir: <checkout>/.worktrees/issue-13409
collected 7 items
autobot-backend/api/presence_ws_router_test.py .......                   [100%]
============================== 7 passed in 0.27s ===============================
```

Path resolution stays inside the worktree, where `PROJECT_ROOT` escapes it:

```
worktree cwd      : <checkout>/.worktrees/issue-13409
PROJECT_ROOT      : <primary checkout>
same tree?        : False
```

Also cwd-independent — same 7 passed invoked from an unrelated directory by absolute path.

The guard is no longer inert. Removing the registration from the branch's own checkout, then running the single guard test against it:

```
--- PRE-FIX test against the sabotaged worktree config ---
1 passed
  ^ FALSE GREEN: registration is gone, guard says fine

--- POST-FIX test against the same sabotaged worktree config ---
E   AssertionError: api.presence_ws not found in config
1 failed
  ^ correctly fails
```

Each repaired script run to completion:

```
== B) test_imports.py ==
✓ MCPWorkerMetricsRecorder imported successfully
✓ get_metrics_manager imported successfully
✓ IsolatedBridgeClient imported successfully
All imports successful!            exit=0

== C) check_syntax.py ==
✓ autobot_shared/monitoring/metrics/mcp_worker.py
✓ autobot_shared/monitoring/metrics/__init__.py
✓ autobot_shared/monitoring/prometheus_metrics.py
✓ autobot-backend/services/mcp_isolated_runtime.py
All files have valid Python syntax! exit=0

== D) verify_causal_extractor.py ==
✓ All verification tests passed!   exit=0
```

New gate step, extracted from the workflow YAML and executed verbatim — seeded violation then clean tree:

```
################ 1) SEEDED VIOLATION ################
seeded_violation_check.py:2:SEED = "<absolute developer path>"

⚠️ Hardcoded developer absolute path(s) detected in tracked source
Resolve paths from __file__ instead, e.g.
  Path(__file__).resolve().parents[N] / 'sub' / 'dir'
Do NOT use autobot_shared.ssot_config.PROJECT_ROOT for this — its
.env marker-walk escapes git worktrees and resolves to the wrong
checkout (#13357).
STEP EXIT=1

################ 2) CLEAN TREE ################
No hardcoded developer absolute paths found.
STEP EXIT=0
```

It also catches the original pre-fix content when that is restored, so it would have blocked this landing.

Workflow parses, and the lint gates that run on the touched files are clean:

```
yaml.safe_load OK
black:     4 files would be left unchanged
isort:     clean (skip_file honoured)
flake8:    0
autoflake: No issues detected (all 4 files)
print/console hook: No print()/console.* violations found
bash -n repo_tests/code-review-hardening-test.sh: OK
PLUGIN_ROOT override honoured
```

## Model Used

claude-opus-5