### PR TITLE
fix(security): consolidate SQL identifier validator, fix regex trailing-newline anchor (#13393)

### DIFF
--- a/autobot-backend/api/analytics_bug_prediction.py
+++ b/autobot-backend/api/analytics_bug_prediction.py
@@ -1127,7 +1127,7 @@ def _get_flat_heatmap_data(files: list) -> list:
 )
 async def get_risk_heatmap(
     admin_check: bool = Depends(check_admin_permission),
-    grouping: str = Query("directory", pattern="^(directory|module|flat)\z"),
+    grouping: str = Query("directory", pattern=r"^(directory|module|flat)\z"),
     path: str = Query(".", description="Path to analyze"),
     include_pattern: str = Query("*.py", description="File pattern to include"),
     limit: int = Query(100, ge=1, le=300),
@@ -1177,7 +1177,7 @@ async def get_risk_heatmap(
 )
 async def get_prediction_trends(
     admin_check: bool = Depends(check_admin_permission),
-    period: str = Query("30d", pattern="^(7d|30d|90d)\z"),
+    period: str = Query("30d", pattern=r"^(7d|30d|90d)\z"),
 ) -> dict[str, Any]:
     """
     Get historical bug prediction accuracy trends.

--- a/autobot-backend/api/analytics_bug_prediction.py
+++ b/autobot-backend/api/analytics_bug_prediction.py
@@ -1127,7 +1127,7 @@ def _get_flat_heatmap_data(files: list) -> list:
 )
 async def get_risk_heatmap(
     admin_check: bool = Depends(check_admin_permission),
-    grouping: str = Query("directory", pattern="^(directory|module|flat)$"),
+    grouping: str = Query("directory", pattern="^(directory|module|flat)\z"),
     path: str = Query(".", description="Path to analyze"),
     include_pattern: str = Query("*.py", description="File pattern to include"),
     limit: int = Query(100, ge=1, le=300),
@@ -1177,7 +1177,7 @@ async def get_risk_heatmap(
 )
 async def get_prediction_trends(
     admin_check: bool = Depends(check_admin_permission),
-    period: str = Query("30d", pattern="^(7d|30d|90d)$"),
+    period: str = Query("30d", pattern="^(7d|30d|90d)\z"),
 ) -> dict[str, Any]:
     """
     Get historical bug prediction accuracy trends.

--- a/autobot-backend/api/analytics_code_review.py
+++ b/autobot-backend/api/analytics_code_review.py
@@ -723,7 +723,7 @@ async def get_review_history(
 )
 async def get_review_metrics(
     admin_check: bool = Depends(check_admin_permission),
-    period: str = Query("30d", pattern="^(7d|30d|90d)$"),
+    period: str = Query("30d", pattern="^(7d|30d|90d)\z"),
     source_id: str | None = Query(None, description="Project source ID to scope analysis"),
 ) -> dict[str, Any]:
     """

--- a/autobot-backend/api/analytics_code_review.py
+++ b/autobot-backend/api/analytics_code_review.py
@@ -723,7 +723,7 @@ async def get_review_history(
 )
 async def get_review_metrics(
     admin_check: bool = Depends(check_admin_permission),
-    period: str = Query("30d", pattern="^(7d|30d|90d)\z"),
+    period: str = Query("30d", pattern=r"^(7d|30d|90d)\z"),
     source_id: str | None = Query(None, description="Project source ID to scope analysis"),
 ) -> dict[str, Any]:
     """

--- a/autobot-backend/api/analytics_quality.py
+++ b/autobot-backend/api/analytics_quality.py
@@ -1359,7 +1359,7 @@ def _calculate_trend_statistics(scores: list) -> dict:
     error_code_prefix="ANALYTICS_QUALITY",
 )
 async def get_quality_trends(
-    period: str = Query("30d", pattern="^(7d|14d|30d|90d)\z"),
+    period: str = Query("30d", pattern=r"^(7d|14d|30d|90d)\z"),
     metric: str | None = Query(None, description="Specific metric to trend"),
     admin_check: bool = Depends(check_admin_permission),
     source_id: str | None = Query(None, description="Project source ID to scope analysis"),
@@ -1579,7 +1579,7 @@ async def drill_down_category(
     error_code_prefix="ANALYTICS_QUALITY",
 )
 async def export_quality_report(
-    format: str = Query("json", pattern="^(json|csv|pdf)\z"),
+    format: str = Query("json", pattern=r"^(json|csv|pdf)\z"),
     admin_check: bool = Depends(check_admin_permission),
 ) -> JSONResponse:
     """

--- a/autobot-backend/api/analytics_quality.py
+++ b/autobot-backend/api/analytics_quality.py
@@ -1359,7 +1359,7 @@ def _calculate_trend_statistics(scores: list) -> dict:
     error_code_prefix="ANALYTICS_QUALITY",
 )
 async def get_quality_trends(
-    period: str = Query("30d", pattern="^(7d|14d|30d|90d)$"),
+    period: str = Query("30d", pattern="^(7d|14d|30d|90d)\z"),
     metric: str | None = Query(None, description="Specific metric to trend"),
     admin_check: bool = Depends(check_admin_permission),
     source_id: str | None = Query(None, description="Project source ID to scope analysis"),
@@ -1579,7 +1579,7 @@ async def drill_down_category(
     error_code_prefix="ANALYTICS_QUALITY",
 )
 async def export_quality_report(
-    format: str = Query("json", pattern="^(json|csv|pdf)$"),
+    format: str = Query("json", pattern="^(json|csv|pdf)\z"),
     admin_check: bool = Depends(check_admin_permission),
 ) -> JSONResponse:
     """

--- a/autobot-backend/api/database_mcp.py
+++ b/autobot-backend/api/database_mcp.py
@@ -36,6 +36,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.security.sql_identifier import validate_sql_identifier
 from autobot_shared.time_utils import now_utc
 from services.mcp_bridge_manifest import MCPBridgeManifest
 from type_defs.common import Metadata
@@ -71,32 +72,6 @@ router = APIRouter(
 
 # Issue #380: Module-level tuple for allowed DML operations
 _ALLOWED_DML_OPERATIONS = ("INSERT", "UPDATE", "DELETE")
-
-# Issue #2845: Allowlist pattern for SQL identifiers (table and column names)
-_SQL_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
-
-
-def _validate_sql_identifier(name: str, label: str = "identifier") -> str:
-    """Validate a SQL identifier (table or column name) against an allowlist pattern.
-
-    Only permits names composed of ASCII letters, digits, and underscores, starting
-    with a letter or underscore. This prevents SQL injection when user-supplied identifiers
-    are interpolated into query strings. (#2845)
-
-    Args:
-        name: The identifier to validate.
-        label: Human-readable label used in the error message.
-
-    Returns:
-        The validated name unchanged.
-
-    Raises:
-        ValueError: If the name contains characters outside the allowed set.
-    """
-    if not _SQL_IDENTIFIER_RE.match(name):
-        raise ValueError(f"Invalid SQL {label} '{name}': only letters, digits, and underscores allowed")
-    return name
-
 
 # Security Configuration
 
@@ -308,8 +283,8 @@ def _list_tables_sync(db_path: Path) -> list[dict]:
         for (table_name,) in tables:
             # table_name originates from sqlite_master (system catalogue), not user input.
             # SQLite does not support parameterised identifiers; f-string is unavoidable.
-            # _validate_sql_identifier enforces an allowlist as defence-in-depth.
-            _validate_sql_identifier(table_name, "table name")
+            # validate_sql_identifier enforces an allowlist as defence-in-depth.
+            validate_sql_identifier(table_name, "table name")
             # Bare-assign the SQL so the nosec/nosemgrep stay on the flagged line:
             # black would split `cursor.execute(f"...")  # nosec` and orphan the
             # comment onto the `)` line, defeating the suppression (#9489).
@@ -334,9 +309,9 @@ def _describe_schema_sync(db_path: Path, table: str | None) -> dict:
         schemas = {}
 
         if table:
-            # table is validated by _validate_sql_identifier (allowlist) above.
+            # table is validated by validate_sql_identifier (allowlist) above.
             # PRAGMA does not accept parameterised identifiers in SQLite.
-            _validate_sql_identifier(table, "table name")
+            validate_sql_identifier(table, "table name")
             pragma_sql = f"PRAGMA table_info([{table}])"  # nosec B608  # nosemgrep: python.lang.security.audit.formatted-sql-query.formatted-sql-query,python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query  # noqa: E501
             cursor.execute(pragma_sql)
             columns = cursor.fetchall()
@@ -356,9 +331,9 @@ def _describe_schema_sync(db_path: Path, table: str | None) -> dict:
             tables = cursor.fetchall()
 
             for (table_name,) in tables:
-                # table_name from sqlite_master; _validate_sql_identifier enforces allowlist.
+                # table_name from sqlite_master; validate_sql_identifier enforces allowlist.
                 # PRAGMA does not support ? parameters in SQLite.
-                _validate_sql_identifier(table_name, "table name")
+                validate_sql_identifier(table_name, "table name")
                 pragma_sql = f"PRAGMA table_info([{table_name}])"  # nosec B608  # nosemgrep: python.lang.security.audit.formatted-sql-query.formatted-sql-query,python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query  # noqa: E501
                 cursor.execute(pragma_sql)
                 columns = cursor.fetchall()
@@ -405,8 +380,8 @@ def _get_db_statistics_sync(db_path: Path) -> dict:
         for (table_name,) in tables:
             # table_name from sqlite_master (system catalogue), not user input.
             # SQLite does not support parameterised identifiers; f-string unavoidable.
-            # _validate_sql_identifier enforces an allowlist as defence-in-depth.
-            _validate_sql_identifier(table_name, "table name")
+            # validate_sql_identifier enforces an allowlist as defence-in-depth.
+            validate_sql_identifier(table_name, "table name")
             count_sql = f"SELECT COUNT(*) FROM [{table_name}]"  # nosec B608  # nosemgrep: python.lang.security.audit.formatted-sql-query.formatted-sql-query,python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query  # noqa: E501
             cursor.execute(count_sql)
             total_rows += cursor.fetchone()[0]

--- a/autobot-backend/api/image_generation.py
+++ b/autobot-backend/api/image_generation.py
@@ -39,9 +39,9 @@ router = APIRouter(tags=["image-generation", "media"])
 
 class ImageGenerationRequest(BaseModel):
     prompt: str = Field(..., min_length=1, max_length=4000)
-    provider: str = Field("dalle", pattern="^(dalle|flux|stable_diffusion)\z")
+    provider: str = Field("dalle", pattern=r"^(dalle|flux|stable_diffusion)\z")
     size: Optional[str] = Field(None)
-    quality: Optional[str] = Field(None, pattern="^(standard|hd)\z")
+    quality: Optional[str] = Field(None, pattern=r"^(standard|hd)\z")
     n: Optional[int] = Field(None, ge=1, le=4)
     negative_prompt: Optional[str] = Field(None, max_length=2000)
 

--- a/autobot-backend/api/image_generation.py
+++ b/autobot-backend/api/image_generation.py
@@ -39,9 +39,9 @@ router = APIRouter(tags=["image-generation", "media"])
 
 class ImageGenerationRequest(BaseModel):
     prompt: str = Field(..., min_length=1, max_length=4000)
-    provider: str = Field("dalle", pattern="^(dalle|flux|stable_diffusion)$")
+    provider: str = Field("dalle", pattern="^(dalle|flux|stable_diffusion)\z")
     size: Optional[str] = Field(None)
-    quality: Optional[str] = Field(None, pattern="^(standard|hd)$")
+    quality: Optional[str] = Field(None, pattern="^(standard|hd)\z")
     n: Optional[int] = Field(None, ge=1, le=4)
     negative_prompt: Optional[str] = Field(None, max_length=2000)
 

--- a/autobot-backend/api/knowledge_collaboration.py
+++ b/autobot-backend/api/knowledge_collaboration.py
@@ -453,7 +453,7 @@ async def unshare_knowledge(
     entity_id: str,
     request: Request,
     current_user: Dict = Depends(get_current_user),
-    entity_type: str = Query(..., pattern="^(user|group)\z"),
+    entity_type: str = Query(..., pattern=r"^(user|group)\z"),
 ):
     """Revoke access to a knowledge fact from a user or group.
 

--- a/autobot-backend/api/knowledge_collaboration.py
+++ b/autobot-backend/api/knowledge_collaboration.py
@@ -453,7 +453,7 @@ async def unshare_knowledge(
     entity_id: str,
     request: Request,
     current_user: Dict = Depends(get_current_user),
-    entity_type: str = Query(..., pattern="^(user|group)$"),
+    entity_type: str = Query(..., pattern="^(user|group)\z"),
 ):
     """Revoke access to a knowledge fact from a user or group.
 

--- a/autobot-backend/api/knowledge_collections.py
+++ b/autobot-backend/api/knowledge_collections.py
@@ -136,7 +136,7 @@ async def create_collection(
 )
 async def list_collections(
     pagination: PaginationParams = Depends(),
-    sort_by: str = Query(default="name", pattern="^(name|created_at|fact_count)\z"),
+    sort_by: str = Query(default="name", pattern=r"^(name|created_at|fact_count)\z"),
     req: Request = None,
 ):
     """

--- a/autobot-backend/api/knowledge_collections.py
+++ b/autobot-backend/api/knowledge_collections.py
@@ -136,7 +136,7 @@ async def create_collection(
 )
 async def list_collections(
     pagination: PaginationParams = Depends(),
-    sort_by: str = Query(default="name", pattern="^(name|created_at|fact_count)$"),
+    sort_by: str = Query(default="name", pattern="^(name|created_at|fact_count)\z"),
     req: Request = None,
 ):
     """

--- a/autobot-backend/api/knowledge_grounding.py
+++ b/autobot-backend/api/knowledge_grounding.py
@@ -222,12 +222,12 @@ async def verify_claim(
 async def list_conflicts(
     status: str = Query(
         "pending",
-        pattern="^(pending|resolved|inconclusive)$",
+        pattern="^(pending|resolved|inconclusive)\z",
         description="Filter by resolution status",
     ),
     severity: str | None = Query(
         None,
-        pattern="^(low|medium|high)$",
+        pattern="^(low|medium|high)\z",
         description="Filter by severity",
     ),
     limit: int = Query(
@@ -429,7 +429,7 @@ async def resolve_conflict(
 async def get_stats(
     period: str = Query(
         "24h",
-        pattern="^(1h|24h|7d|30d)$",
+        pattern="^(1h|24h|7d|30d)\z",
         description="Time period for stats",
     ),
     current_user: str = Depends(check_admin_permission),

--- a/autobot-backend/api/knowledge_grounding.py
+++ b/autobot-backend/api/knowledge_grounding.py
@@ -222,12 +222,12 @@ async def verify_claim(
 async def list_conflicts(
     status: str = Query(
         "pending",
-        pattern="^(pending|resolved|inconclusive)\z",
+        pattern=r"^(pending|resolved|inconclusive)\z",
         description="Filter by resolution status",
     ),
     severity: str | None = Query(
         None,
-        pattern="^(low|medium|high)\z",
+        pattern=r"^(low|medium|high)\z",
         description="Filter by severity",
     ),
     limit: int = Query(
@@ -429,7 +429,7 @@ async def resolve_conflict(
 async def get_stats(
     period: str = Query(
         "24h",
-        pattern="^(1h|24h|7d|30d)\z",
+        pattern=r"^(1h|24h|7d|30d)\z",
         description="Time period for stats",
     ),
     current_user: str = Depends(check_admin_permission),

--- a/autobot-backend/api/memory.py
+++ b/autobot-backend/api/memory.py
@@ -1087,7 +1087,7 @@ async def get_related_entities(
     entity_id: str = Path(..., description="Entity UUID"),
     admin_check: bool = Depends(check_admin_permission),
     relation_type: str | None = Query(None, description="Filter by relation type"),
-    direction: str = Query("both", pattern="^(outgoing|incoming|both)$", description="Relation direction"),
+    direction: str = Query("both", pattern="^(outgoing|incoming|both)\z", description="Relation direction"),
     max_depth: int = Query(1, ge=1, le=3, description="Relationship traversal depth (1-3)"),
     memory_graph: AutoBotMemoryGraph = Depends(get_memory_graph),
 ) -> JSONResponse:

--- a/autobot-backend/api/memory.py
+++ b/autobot-backend/api/memory.py
@@ -1087,7 +1087,7 @@ async def get_related_entities(
     entity_id: str = Path(..., description="Entity UUID"),
     admin_check: bool = Depends(check_admin_permission),
     relation_type: str | None = Query(None, description="Filter by relation type"),
-    direction: str = Query("both", pattern="^(outgoing|incoming|both)\z", description="Relation direction"),
+    direction: str = Query("both", pattern=r"^(outgoing|incoming|both)\z", description="Relation direction"),
     max_depth: int = Query(1, ge=1, le=3, description="Relationship traversal depth (1-3)"),
     memory_graph: AutoBotMemoryGraph = Depends(get_memory_graph),
 ) -> JSONResponse:

--- a/autobot-backend/api/monitoring.py
+++ b/autobot-backend/api/monitoring.py
@@ -1040,7 +1040,7 @@ async def update_performance_threshold(
 )
 async def export_metrics(
     admin_check: bool = Depends(check_admin_permission),
-    format: str = Query("json", pattern="^(json|csv)\z"),
+    format: str = Query("json", pattern=r"^(json|csv)\z"),
     time_range_hours: int = Query(1, ge=1, le=168),  # Max 1 week
 ):
     """Export performance metrics in JSON or CSV format. Issue #744: Requires admin authentication."""

--- a/autobot-backend/api/monitoring.py
+++ b/autobot-backend/api/monitoring.py
@@ -1040,7 +1040,7 @@ async def update_performance_threshold(
 )
 async def export_metrics(
     admin_check: bool = Depends(check_admin_permission),
-    format: str = Query("json", pattern="^(json|csv)$"),
+    format: str = Query("json", pattern="^(json|csv)\z"),
     time_range_hours: int = Query(1, ge=1, le=168),  # Max 1 week
 ):
     """Export performance metrics in JSON or CSV format. Issue #744: Requires admin authentication."""

--- a/autobot-backend/api/schemas_agent.py
+++ b/autobot-backend/api/schemas_agent.py
@@ -1349,7 +1349,7 @@ class RoleAssignmentResponse(BaseModel):
 
 
 class RoleUpdateRequest(BaseModel):
-    role: str = Field(..., description="Role name: admin, user, or readonly", pattern="^(admin|user|readonly)\z")
+    role: str = Field(..., description="Role name: admin, user, or readonly", pattern=r"^(admin|user|readonly)\z")
 
 
 class RoleUpdateResponse(BaseModel):

--- a/autobot-backend/api/schemas_agent.py
+++ b/autobot-backend/api/schemas_agent.py
@@ -1349,7 +1349,7 @@ class RoleAssignmentResponse(BaseModel):
 
 
 class RoleUpdateRequest(BaseModel):
-    role: str = Field(..., description="Role name: admin, user, or readonly", pattern="^(admin|user|readonly)$")
+    role: str = Field(..., description="Role name: admin, user, or readonly", pattern="^(admin|user|readonly)\z")
 
 
 class RoleUpdateResponse(BaseModel):

--- a/autobot-backend/api/schemas_analytics.py
+++ b/autobot-backend/api/schemas_analytics.py
@@ -1798,7 +1798,7 @@ class SessionCostResponse(BaseModel):
 class BudgetAlertRequest(BaseModel):
     name: str = Field(..., description="Alert name")
     threshold_usd: float = Field(..., gt=0, description="Budget threshold in USD")
-    period: str = Field(..., pattern="^(daily|weekly|monthly)$", description="Alert period")
+    period: str = Field(..., pattern="^(daily|weekly|monthly)\z", description="Alert period")
     notify_at_percent: List[int] = Field(default=[50, 75, 90, 100])
     enabled: bool = Field(default=True)
 

--- a/autobot-backend/api/schemas_analytics.py
+++ b/autobot-backend/api/schemas_analytics.py
@@ -1798,7 +1798,7 @@ class SessionCostResponse(BaseModel):
 class BudgetAlertRequest(BaseModel):
     name: str = Field(..., description="Alert name")
     threshold_usd: float = Field(..., gt=0, description="Budget threshold in USD")
-    period: str = Field(..., pattern="^(daily|weekly|monthly)\z", description="Alert period")
+    period: str = Field(..., pattern=r"^(daily|weekly|monthly)\z", description="Alert period")
     notify_at_percent: List[int] = Field(default=[50, 75, 90, 100])
     enabled: bool = Field(default=True)
 

--- a/autobot-backend/api/schemas_chat.py
+++ b/autobot-backend/api/schemas_chat.py
@@ -498,7 +498,7 @@ class ChatMessage(BaseModel):
     content: str = Field(..., min_length=1, max_length=50000, description="Message content")
     role: str = Field(
         default=CategoryDefaults.ROLE_USER,
-        pattern="^(user|assistant|system)\z",
+        pattern=r"^(user|assistant|system)\z",
         description="Message role",
     )
     session_id: str = Field(..., description="Chat session ID")
@@ -529,7 +529,7 @@ class ChatMessage(BaseModel):
     )
     reasoning_effort: str | None = Field(
         None,
-        pattern="^(low|medium|high|auto)\z",
+        pattern=r"^(low|medium|high|auto)\z",
         description="Per-conversation reasoning effort override (low, medium, high, auto). "
         "Overrides the user's account-level default. Omit to use the user default. "
         "When 'auto' or absent the provider's own defaults are used (#9017).",

--- a/autobot-backend/api/schemas_chat.py
+++ b/autobot-backend/api/schemas_chat.py
@@ -498,7 +498,7 @@ class ChatMessage(BaseModel):
     content: str = Field(..., min_length=1, max_length=50000, description="Message content")
     role: str = Field(
         default=CategoryDefaults.ROLE_USER,
-        pattern="^(user|assistant|system)$",
+        pattern="^(user|assistant|system)\z",
         description="Message role",
     )
     session_id: str = Field(..., description="Chat session ID")
@@ -529,7 +529,7 @@ class ChatMessage(BaseModel):
     )
     reasoning_effort: str | None = Field(
         None,
-        pattern="^(low|medium|high|auto)$",
+        pattern="^(low|medium|high|auto)\z",
         description="Per-conversation reasoning effort override (low, medium, high, auto). "
         "Overrides the user's account-level default. Omit to use the user default. "
         "When 'auto' or absent the provider's own defaults are used (#9017).",

--- a/autobot-backend/api/schemas_knowledge.py
+++ b/autobot-backend/api/schemas_knowledge.py
@@ -4230,7 +4230,7 @@ class AddUrlRequest(BaseModel):
 
     url: str = Field(..., min_length=1, max_length=2000, description="URL to fetch")
     title: str = Field(default="", max_length=500, description="Document title")
-    method: str = Field(default="fetch", pattern="^(fetch|raw)$", description="Fetch method")
+    method: str = Field(default="fetch", pattern="^(fetch|raw)\z", description="Fetch method")
     category: str = Field(default="web", max_length=100, description="Category")
     tags: List[str] = Field(default_factory=list, description="Tags")
     board_id: str | None = Field(
@@ -4253,7 +4253,7 @@ class AudioIngestRequest(BaseModel):
     category: str = Field(default="audio", max_length=100)
     tags: List[str] = Field(default_factory=list)
     whisper_model: str = Field(
-        default="base", pattern="^(tiny|base|small|medium|large|large-v2|large-v3)$", description="Whisper model size"
+        default="base", pattern="^(tiny|base|small|medium|large|large-v2|large-v3)\z", description="Whisper model size"
     )
     language: str | None = Field(default=None, max_length=10, description="ISO-639-1 language hint")
 
@@ -4288,9 +4288,9 @@ class DocsBrowseRequest(BaseModel):
     page: int = Field(default=1, ge=1, le=1000, description="Page number")
     page_size: int = Field(default=20, ge=1, le=100, description="Results per page")
     sort_by: str = Field(
-        default="indexed_at", pattern="^(indexed_at|title|category|file_path)$", description="Sort field"
+        default="indexed_at", pattern="^(indexed_at|title|category|file_path)\z", description="Sort field"
     )
-    sort_order: str = Field(default="desc", pattern="^(asc|desc)$", description="Sort order")
+    sort_order: str = Field(default="desc", pattern="^(asc|desc)\z", description="Sort order")
 
 
 class OrgKnowledgeConfigPayload(BaseModel):
@@ -4894,7 +4894,7 @@ class ScopedSearchRequest(BaseModel):
     top_k: int = Field(default=10, ge=1, le=100, description="Maximum results")
     mode: str = Field(
         default="hybrid",
-        pattern="^(semantic|keyword|hybrid|auto)$",
+        pattern="^(semantic|keyword|hybrid|auto)\z",
         description="Search mode",
     )
     category: str | None = Field(default=None, description="Filter by category")

--- a/autobot-backend/api/schemas_knowledge.py
+++ b/autobot-backend/api/schemas_knowledge.py
@@ -4230,7 +4230,7 @@ class AddUrlRequest(BaseModel):
 
     url: str = Field(..., min_length=1, max_length=2000, description="URL to fetch")
     title: str = Field(default="", max_length=500, description="Document title")
-    method: str = Field(default="fetch", pattern="^(fetch|raw)\z", description="Fetch method")
+    method: str = Field(default="fetch", pattern=r"^(fetch|raw)\z", description="Fetch method")
     category: str = Field(default="web", max_length=100, description="Category")
     tags: List[str] = Field(default_factory=list, description="Tags")
     board_id: str | None = Field(
@@ -4253,7 +4253,7 @@ class AudioIngestRequest(BaseModel):
     category: str = Field(default="audio", max_length=100)
     tags: List[str] = Field(default_factory=list)
     whisper_model: str = Field(
-        default="base", pattern="^(tiny|base|small|medium|large|large-v2|large-v3)\z", description="Whisper model size"
+        default="base", pattern=r"^(tiny|base|small|medium|large|large-v2|large-v3)\z", description="Whisper model size"
     )
     language: str | None = Field(default=None, max_length=10, description="ISO-639-1 language hint")
 
@@ -4288,9 +4288,9 @@ class DocsBrowseRequest(BaseModel):
     page: int = Field(default=1, ge=1, le=1000, description="Page number")
     page_size: int = Field(default=20, ge=1, le=100, description="Results per page")
     sort_by: str = Field(
-        default="indexed_at", pattern="^(indexed_at|title|category|file_path)\z", description="Sort field"
+        default="indexed_at", pattern=r"^(indexed_at|title|category|file_path)\z", description="Sort field"
     )
-    sort_order: str = Field(default="desc", pattern="^(asc|desc)\z", description="Sort order")
+    sort_order: str = Field(default="desc", pattern=r"^(asc|desc)\z", description="Sort order")
 
 
 class OrgKnowledgeConfigPayload(BaseModel):
@@ -4894,7 +4894,7 @@ class ScopedSearchRequest(BaseModel):
     top_k: int = Field(default=10, ge=1, le=100, description="Maximum results")
     mode: str = Field(
         default="hybrid",
-        pattern="^(semantic|keyword|hybrid|auto)\z",
+        pattern=r"^(semantic|keyword|hybrid|auto)\z",
         description="Search mode",
     )
     category: str | None = Field(default=None, description="Filter by category")

--- a/autobot-backend/api/schemas_system.py
+++ b/autobot-backend/api/schemas_system.py
@@ -1546,7 +1546,7 @@ class ThresholdUpdate(BaseModel):
     category: str
     metric: str
     threshold: float
-    comparison: str = Field(..., pattern="^(gt|lt|eq)$")
+    comparison: str = Field(..., pattern="^(gt|lt|eq)\z")
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/api/schemas_system.py
+++ b/autobot-backend/api/schemas_system.py
@@ -1546,7 +1546,7 @@ class ThresholdUpdate(BaseModel):
     category: str
     metric: str
     threshold: float
-    comparison: str = Field(..., pattern="^(gt|lt|eq)\z")
+    comparison: str = Field(..., pattern=r"^(gt|lt|eq)\z")
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/api/users.py
+++ b/autobot-backend/api/users.py
@@ -37,27 +37,27 @@ class UserPreferences(BaseModel):
 
     reasoning_effort: str = Field(
         "auto",
-        pattern="^(low|medium|high|auto)\z",
+        pattern=r"^(low|medium|high|auto)\z",
         description="Default reasoning effort level (low, medium, high, auto)",
     )
     theme: str = Field(
         "dark",
-        pattern="^(dark|light|system)\z",
+        pattern=r"^(dark|light|system)\z",
         description="Base theme mode (dark, light, system)",
     )
     accent_color: str = Field(
         "blue",
-        pattern="^(blue|green|purple|orange|pink|teal|indigo|red)\z",
+        pattern=r"^(blue|green|purple|orange|pink|teal|indigo|red)\z",
         description="Accent color preset",
     )
     layout_density: str = Field(
         "comfortable",
-        pattern="^(compact|comfortable|spacious)\z",
+        pattern=r"^(compact|comfortable|spacious)\z",
         description="Layout density (compact, comfortable, spacious)",
     )
     font_size: str = Field(
         "medium",
-        pattern="^(small|medium|large)\z",
+        pattern=r"^(small|medium|large)\z",
         description="Base font size (small, medium, large)",
     )
     theme_preset: str = Field(

--- a/autobot-backend/api/users.py
+++ b/autobot-backend/api/users.py
@@ -37,27 +37,27 @@ class UserPreferences(BaseModel):
 
     reasoning_effort: str = Field(
         "auto",
-        pattern="^(low|medium|high|auto)$",
+        pattern="^(low|medium|high|auto)\z",
         description="Default reasoning effort level (low, medium, high, auto)",
     )
     theme: str = Field(
         "dark",
-        pattern="^(dark|light|system)$",
+        pattern="^(dark|light|system)\z",
         description="Base theme mode (dark, light, system)",
     )
     accent_color: str = Field(
         "blue",
-        pattern="^(blue|green|purple|orange|pink|teal|indigo|red)$",
+        pattern="^(blue|green|purple|orange|pink|teal|indigo|red)\z",
         description="Accent color preset",
     )
     layout_density: str = Field(
         "comfortable",
-        pattern="^(compact|comfortable|spacious)$",
+        pattern="^(compact|comfortable|spacious)\z",
         description="Layout density (compact, comfortable, spacious)",
     )
     font_size: str = Field(
         "medium",
-        pattern="^(small|medium|large)$",
+        pattern="^(small|medium|large)\z",
         description="Base font size (small, medium, large)",
     )
     theme_preset: str = Field(

--- a/autobot-backend/api/video_generation.py
+++ b/autobot-backend/api/video_generation.py
@@ -74,10 +74,10 @@ _PROVIDER_ENV = {"runway": "RUNWAY_API_KEY", "sora": "SORA_API_KEY", "kling": "K
 
 class VideoGenerationRequest(BaseModel):
     prompt: str = Field(..., min_length=1, max_length=4000)
-    provider: str = Field("runway", pattern="^(runway|sora|kling)\z")
+    provider: str = Field("runway", pattern=r"^(runway|sora|kling)\z")
     duration: int = Field(5, ge=1, le=20)
     resolution: Optional[str] = Field(None)
-    aspect_ratio: Optional[str] = Field(None, pattern="^(16:9|9:16|1:1)\z")
+    aspect_ratio: Optional[str] = Field(None, pattern=r"^(16:9|9:16|1:1)\z")
 
 
 class VideoJobResponse(BaseModel):

--- a/autobot-backend/api/video_generation.py
+++ b/autobot-backend/api/video_generation.py
@@ -74,10 +74,10 @@ _PROVIDER_ENV = {"runway": "RUNWAY_API_KEY", "sora": "SORA_API_KEY", "kling": "K
 
 class VideoGenerationRequest(BaseModel):
     prompt: str = Field(..., min_length=1, max_length=4000)
-    provider: str = Field("runway", pattern="^(runway|sora|kling)$")
+    provider: str = Field("runway", pattern="^(runway|sora|kling)\z")
     duration: int = Field(5, ge=1, le=20)
     resolution: Optional[str] = Field(None)
-    aspect_ratio: Optional[str] = Field(None, pattern="^(16:9|9:16|1:1)$")
+    aspect_ratio: Optional[str] = Field(None, pattern="^(16:9|9:16|1:1)\z")
 
 
 class VideoJobResponse(BaseModel):

--- a/autobot-backend/knowledge/schemas/rag.py
+++ b/autobot-backend/knowledge/schemas/rag.py
@@ -157,7 +157,7 @@ class RunBenchmarkRequest(BaseModel):
     split: str = Field(
         ...,
         description="Which portion to benchmark: 'dev', 'test', or 'all'.",
-        pattern="^(dev|test|all)$",
+        pattern="^(dev|test|all)\z",
     )
     k: int = Field(default=5, ge=1, le=50, description="Top-k results per query.")
 
@@ -170,7 +170,7 @@ class RetrievalContextRequest(BaseModel):
 
     query: str = Field(..., min_length=1, max_length=2000, description="Generation query")
     collection_id: str | None = Field(default=None, description="Target collection identifier")
-    mode: str = Field(default="auto", pattern="^(auto|rag|cag|kag)$", description="Retrieval mode")
+    mode: str = Field(default="auto", pattern="^(auto|rag|cag|kag)\z", description="Retrieval mode")
     model: str | None = Field(default=None, description="Active model name for budget calculation")
 
 

--- a/autobot-backend/knowledge/schemas/rag.py
+++ b/autobot-backend/knowledge/schemas/rag.py
@@ -157,7 +157,7 @@ class RunBenchmarkRequest(BaseModel):
     split: str = Field(
         ...,
         description="Which portion to benchmark: 'dev', 'test', or 'all'.",
-        pattern="^(dev|test|all)\z",
+        pattern=r"^(dev|test|all)\z",
     )
     k: int = Field(default=5, ge=1, le=50, description="Top-k results per query.")
 
@@ -170,7 +170,7 @@ class RetrievalContextRequest(BaseModel):
 
     query: str = Field(..., min_length=1, max_length=2000, description="Generation query")
     collection_id: str | None = Field(default=None, description="Target collection identifier")
-    mode: str = Field(default="auto", pattern="^(auto|rag|cag|kag)\z", description="Retrieval mode")
+    mode: str = Field(default="auto", pattern=r"^(auto|rag|cag|kag)\z", description="Retrieval mode")
     model: str | None = Field(default=None, description="Active model name for budget calculation")
 
 

--- a/autobot-backend/routers/code_completion.py
+++ b/autobot-backend/routers/code_completion.py
@@ -158,7 +158,7 @@ async def list_patterns(
     category: str | None = Query(None),
     page: int = Query(1, ge=1),
     page_size: int = Query(20, ge=1, le=100),
-    sort_by: str = Query("frequency", pattern="^(frequency|acceptance_rate|created_at)$"),
+    sort_by: str = Query("frequency", pattern="^(frequency|acceptance_rate|created_at)\z"),
 ):
     """
     List extracted patterns with filtering and pagination.

--- a/autobot-backend/routers/code_completion.py
+++ b/autobot-backend/routers/code_completion.py
@@ -158,7 +158,7 @@ async def list_patterns(
     category: str | None = Query(None),
     page: int = Query(1, ge=1),
     page_size: int = Query(20, ge=1, le=100),
-    sort_by: str = Query("frequency", pattern="^(frequency|acceptance_rate|created_at)\z"),
+    sort_by: str = Query("frequency", pattern=r"^(frequency|acceptance_rate|created_at)\z"),
 ):
     """
     List extracted patterns with filtering and pagination.

--- a/autobot-backend/services/autoresearch/routes.py
+++ b/autobot-backend/services/autoresearch/routes.py
@@ -57,7 +57,7 @@ class SubmitScoreRequest(BaseModel):
 
 
 class ApprovalDecisionRequest(BaseModel):
-    decision: str = Field(..., pattern="^(approved|rejected)$")
+    decision: str = Field(..., pattern="^(approved|rejected)\z")
 
 
 class SynthesizeRequest(BaseModel):

--- a/autobot-backend/services/autoresearch/routes.py
+++ b/autobot-backend/services/autoresearch/routes.py
@@ -57,7 +57,7 @@ class SubmitScoreRequest(BaseModel):
 
 
 class ApprovalDecisionRequest(BaseModel):
-    decision: str = Field(..., pattern="^(approved|rejected)\z")
+    decision: str = Field(..., pattern=r"^(approved|rejected)\z")
 
 
 class SynthesizeRequest(BaseModel):

--- a/autobot-backend/utils/async_database_pool.py
+++ b/autobot-backend/utils/async_database_pool.py
@@ -11,7 +11,6 @@ Pool sizes are coordinated via SSOT config (#2860).
 """
 
 import asyncio
-import re
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -21,6 +20,7 @@ from typing import Any, Dict
 import aiosqlite
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.security.sql_identifier import validate_sql_identifier
 
 # Import shared database helpers (Issue #292 - Eliminate duplicate code)
 from constants.threshold_constants import TimingConstants
@@ -413,31 +413,6 @@ async def async_transaction(pool: AsyncSQLiteConnectionPool):
             raise
 
 
-_SQL_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
-
-
-def _validate_sql_identifier(name: str, label: str = "identifier") -> str:
-    """Validate a SQL identifier (table or column name) against an allowlist pattern.
-
-    Only permits names composed of ASCII letters, digits, and underscores, starting
-    with a letter or underscore. This prevents SQL injection via identifier interpolation
-    in f-string query construction. (#2845)
-
-    Args:
-        name: The identifier to validate.
-        label: Human-readable label used in the error message.
-
-    Returns:
-        The validated name unchanged.
-
-    Raises:
-        ValueError: If the name contains characters outside the allowed set.
-    """
-    if not _SQL_IDENTIFIER_RE.match(name):
-        raise ValueError(f"Invalid SQL {label} '{name}': only letters, digits, and underscores allowed")
-    return name
-
-
 # Batch operation helpers
 class AsyncBatchOperations:
     """Helper class for efficient batch database operations."""
@@ -460,9 +435,9 @@ class AsyncBatchOperations:
             data: List of tuples with data to insert
             batch_size: Number of records per batch
         """
-        _validate_sql_identifier(table, "table name")
+        validate_sql_identifier(table, "table name")
         for col in columns:
-            _validate_sql_identifier(col, "column name")
+            validate_sql_identifier(col, "column name")
         placeholders = ", ".join(["?" for _ in columns])
         column_names = ", ".join(columns)
         query = f"INSERT INTO {table} ({column_names}) VALUES ({placeholders})"  # nosec B608
@@ -492,10 +467,10 @@ class AsyncBatchOperations:
             data: List of tuples with (set_values..., where_value)
             batch_size: Number of records per batch
         """
-        _validate_sql_identifier(table, "table name")
+        validate_sql_identifier(table, "table name")
         for col in set_columns:
-            _validate_sql_identifier(col, "column name")
-        _validate_sql_identifier(where_column, "column name")
+            validate_sql_identifier(col, "column name")
+        validate_sql_identifier(where_column, "column name")
         set_clause = ", ".join([f"{col} = ?" for col in set_columns])
         query = f"UPDATE {table} SET {set_clause} WHERE {where_column} = ?"  # nosec B608
 

--- a/autobot-backend/utils/common.py
+++ b/autobot-backend/utils/common.py
@@ -11,37 +11,14 @@ functionality across the codebase.
 
 import json
 import logging
-import re
 import sqlite3
 from pathlib import Path
 from typing import Any, Dict
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.security.sql_identifier import validate_sql_identifier
 
 logger = get_logger(__name__)
-
-_SQL_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
-
-
-def _validate_sql_identifier(name: str, label: str = "identifier") -> str:
-    """Validate a SQL identifier (table or column name) against an allowlist pattern.
-
-    Only permits names composed of ASCII letters, digits, and underscores, starting
-    with a letter or underscore. Prevents SQL injection via identifier interpolation. (#2845)
-
-    Args:
-        name: The identifier to validate.
-        label: Human-readable label used in the error message.
-
-    Returns:
-        The validated name unchanged.
-
-    Raises:
-        ValueError: If the name contains characters outside the allowed set.
-    """
-    if not _SQL_IDENTIFIER_RE.match(name):
-        raise ValueError(f"Invalid SQL {label} '{name}': only letters, digits, and underscores allowed")
-    return name
 
 
 def _is_path_in_allowed_dir(path_obj: Path, allowed_dirs: list) -> bool:
@@ -429,7 +406,7 @@ class DatabaseUtils:
             # A table name cannot be a bind parameter; validate it against a
             # strict allowlist (letters/digits/underscore) before interpolation
             # so metacharacters can never reach the SQL engine. (#12284, #2845)
-            safe_table = _validate_sql_identifier(table_name, "table name")
+            safe_table = validate_sql_identifier(table_name, "table name")
             query = f"SELECT COUNT(*) FROM {safe_table}"  # nosec B608 - identifier allowlisted
             cursor = conn.cursor()
             cursor.execute(query)

--- a/autobot-backend/utils/sql_injection_hardening_test.py
+++ b/autobot-backend/utils/sql_injection_hardening_test.py
@@ -8,15 +8,19 @@ Covers the fixes for CodeQL/semgrep ``autobot-sql-string-format`` alerts
 against a strict allowlist (SQLite value queries) or safely quoted/escaped
 (SQLite/MySQL identifier grammar) so SQL metacharacters are treated as data,
 never executed.
+
+Direct unit tests for the allowlist validator itself now live alongside its
+single shared implementation at
+``autobot_shared/security/sql_identifier_test.py`` (#13393). This module keeps
+only the tests that exercise the validator indirectly through
+``DatabaseUtils`` and the migration-quoting helper.
 """
 
 import importlib.util
 import sqlite3
 from pathlib import Path
 
-import pytest
-
-from utils.common import DatabaseUtils, _validate_sql_identifier
+from utils.common import DatabaseUtils
 
 # Payload containing SQL metacharacters that must never be executed.
 INJECTION = "widgets; DROP TABLE widgets;--"
@@ -54,13 +58,6 @@ def test_get_table_row_count_treats_metacharacters_as_data():
         assert remaining == 3
     finally:
         conn.close()
-
-
-def test_validate_sql_identifier_rejects_metacharacters():
-    """The allowlist validator raises on any non-identifier character."""
-    with pytest.raises(ValueError):
-        _validate_sql_identifier(INJECTION, "table name")
-    assert _validate_sql_identifier("valid_name_1", "table name") == "valid_name_1"
 
 
 def _load_migration_module():

--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -23,7 +23,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urlparse
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import FileResponse
 from pydantic import BaseModel
 from sqlalchemy import func
@@ -3587,7 +3587,7 @@ async def get_fleet_sync_job_status(
 @router.get("/fleet/jobs", response_model=List[FleetSyncJobStatus])
 async def list_fleet_sync_jobs(
     _: Annotated[dict, Depends(get_current_user)],
-    limit: int = 10,
+    limit: int = Query(10, ge=1, le=100),
 ) -> List[FleetSyncJobStatus]:
     """
     List recent fleet sync jobs (Issue #741 Phase 8).

--- a/autobot-slm-backend/api/errors.py
+++ b/autobot-slm-backend/api/errors.py
@@ -556,7 +556,7 @@ async def clear_errors(
 async def create_test_error(
     db: Annotated[AsyncSession, Depends(get_db)],
     user: Annotated[dict, Depends(get_current_user)],
-    severity: str = Query("error", pattern="^(error|critical)\z"),
+    severity: str = Query("error", pattern=r"^(error|critical)\z"),
 ) -> TestErrorResponse:
     """Generate test error for validation."""
     event_id = f"test-{uuid.uuid4().hex[:12]}"
@@ -683,7 +683,7 @@ async def get_error_timeline(
     db: Annotated[AsyncSession, Depends(get_db)],
     _: Annotated[dict, Depends(get_current_user)],
     hours: int = Query(24, ge=1, le=168),
-    interval: str = Query("hour", pattern="^(hour|day)\z"),
+    interval: str = Query("hour", pattern=r"^(hour|day)\z"),
 ) -> TimelineResponse:
     """Get error timeline data."""
     now = datetime.now(timezone.utc)

--- a/autobot-slm-backend/api/errors.py
+++ b/autobot-slm-backend/api/errors.py
@@ -556,7 +556,7 @@ async def clear_errors(
 async def create_test_error(
     db: Annotated[AsyncSession, Depends(get_db)],
     user: Annotated[dict, Depends(get_current_user)],
-    severity: str = Query("error", pattern="^(error|critical)$"),
+    severity: str = Query("error", pattern="^(error|critical)\z"),
 ) -> TestErrorResponse:
     """Generate test error for validation."""
     event_id = f"test-{uuid.uuid4().hex[:12]}"
@@ -683,7 +683,7 @@ async def get_error_timeline(
     db: Annotated[AsyncSession, Depends(get_db)],
     _: Annotated[dict, Depends(get_current_user)],
     hours: int = Query(24, ge=1, le=168),
-    interval: str = Query("hour", pattern="^(hour|day)$"),
+    interval: str = Query("hour", pattern="^(hour|day)\z"),
 ) -> TimelineResponse:
     """Get error timeline data."""
     now = datetime.now(timezone.utc)

--- a/autobot-slm-backend/api/orchestration.py
+++ b/autobot-slm-backend/api/orchestration.py
@@ -131,7 +131,7 @@ class FleetServicesResponse(BaseModel):
 class ServiceCategoryUpdate(BaseModel):
     """Request to update service category."""
 
-    category: str = Field(..., pattern="^(autobot|system)$")
+    category: str = Field(..., pattern="^(autobot|system)\z")
 
 
 # =============================================================================

--- a/autobot-slm-backend/api/orchestration.py
+++ b/autobot-slm-backend/api/orchestration.py
@@ -131,7 +131,7 @@ class FleetServicesResponse(BaseModel):
 class ServiceCategoryUpdate(BaseModel):
     """Request to update service category."""
 
-    category: str = Field(..., pattern="^(autobot|system)\z")
+    category: str = Field(..., pattern=r"^(autobot|system)\z")
 
 
 # =============================================================================

--- a/autobot-slm-backend/api/performance.py
+++ b/autobot-slm-backend/api/performance.py
@@ -138,7 +138,7 @@ class AlertRuleCreateRequest(BaseModel):
     name: str
     description: str | None = None
     metric_type: str
-    condition: str = Field(pattern="^(gt|lt|gte|lte|eq)$")
+    condition: str = Field(pattern="^(gt|lt|gte|lte|eq)\z")
     threshold: float
     duration_seconds: int = 300
     severity: str = "warning"
@@ -153,7 +153,7 @@ class AlertRuleUpdateRequest(BaseModel):
     name: str | None = None
     description: str | None = None
     metric_type: str | None = None
-    condition: str | None = Field(None, pattern="^(gt|lt|gte|lte|eq)$")
+    condition: str | None = Field(None, pattern="^(gt|lt|gte|lte|eq)\z")
     threshold: float | None = None
     duration_seconds: int | None = None
     severity: str | None = None

--- a/autobot-slm-backend/api/performance.py
+++ b/autobot-slm-backend/api/performance.py
@@ -138,7 +138,7 @@ class AlertRuleCreateRequest(BaseModel):
     name: str
     description: str | None = None
     metric_type: str
-    condition: str = Field(pattern="^(gt|lt|gte|lte|eq)\z")
+    condition: str = Field(pattern=r"^(gt|lt|gte|lte|eq)\z")
     threshold: float
     duration_seconds: int = 300
     severity: str = "warning"
@@ -153,7 +153,7 @@ class AlertRuleUpdateRequest(BaseModel):
     name: str | None = None
     description: str | None = None
     metric_type: str | None = None
-    condition: str | None = Field(None, pattern="^(gt|lt|gte|lte|eq)\z")
+    condition: str | None = Field(None, pattern=r"^(gt|lt|gte|lte|eq)\z")
     threshold: float | None = None
     duration_seconds: int | None = None
     severity: str | None = None

--- a/autobot-slm-backend/models/schemas.py
+++ b/autobot-slm-backend/models/schemas.py
@@ -899,7 +899,7 @@ class RestartAllServicesRequest(BaseModel):
 
     category: str | None = Field(
         None,
-        pattern="^(autobot|system|all)$",
+        pattern="^(autobot|system|all)\z",
         description="Category of services to restart. 'all' or null restarts all services.",
     )
     exclude_services: List[str] = Field(
@@ -930,7 +930,7 @@ class RestartAllServicesResponse(BaseModel):
 class ServiceCategoryUpdate(BaseModel):
     """Request to update service category."""
 
-    category: str = Field(..., pattern="^(autobot|system)$")
+    category: str = Field(..., pattern="^(autobot|system)\z")
 
 
 class FleetServiceStatus(BaseModel):
@@ -1160,7 +1160,7 @@ class EligibleNodesResponse(BaseModel):
 class VNCCredentialCreate(BaseModel):
     """Create VNC credential for a node."""
 
-    vnc_type: str = Field(default="desktop", pattern="^(desktop|browser|custom)$")
+    vnc_type: str = Field(default="desktop", pattern="^(desktop|browser|custom)\z")
     name: str | None = Field(None, description="Optional friendly name for the credential")
     password: str = Field(..., min_length=1, description="VNC password (will be encrypted)")
     port: int | None = Field(None, ge=1, le=65535, description="websockify port")
@@ -1742,7 +1742,7 @@ class NodeSyncRequest(BaseModel):
     """Request to sync code to a node."""
 
     restart: bool = True
-    strategy: str = Field(default="graceful", pattern="^(immediate|graceful|manual)$")
+    strategy: str = Field(default="graceful", pattern="^(immediate|graceful|manual)\z")
 
 
 class NodeSyncResponse(BaseModel):
@@ -1758,7 +1758,7 @@ class FleetSyncRequest(BaseModel):
     """Request to sync code to multiple nodes."""
 
     node_ids: List[str] | None = None
-    strategy: str = Field(default="rolling", pattern="^(immediate|graceful|manual|rolling)$")
+    strategy: str = Field(default="rolling", pattern="^(immediate|graceful|manual|rolling)\z")
     batch_size: int = Field(default=1, ge=1, le=10)
     restart: bool = True
 
@@ -1838,9 +1838,9 @@ class ScheduleCreate(BaseModel):
     name: str = Field(..., min_length=1, max_length=100)
     cron_expression: str = Field(..., min_length=9, max_length=100)
     enabled: bool = True
-    target_type: str = Field(default="all", pattern="^(all|specific|tag)$")
+    target_type: str = Field(default="all", pattern="^(all|specific|tag)\z")
     target_nodes: List[str] | None = None
-    restart_strategy: str = Field(default="graceful", pattern="^(immediate|graceful|manual)$")
+    restart_strategy: str = Field(default="graceful", pattern="^(immediate|graceful|manual)\z")
     restart_after_sync: bool = True
 
 
@@ -1850,9 +1850,9 @@ class ScheduleUpdate(BaseModel):
     name: str | None = Field(None, min_length=1, max_length=100)
     cron_expression: str | None = Field(None, min_length=9, max_length=100)
     enabled: bool | None = None
-    target_type: str | None = Field(None, pattern="^(all|specific|tag)$")
+    target_type: str | None = Field(None, pattern="^(all|specific|tag)\z")
     target_nodes: List[str] | None = None
-    restart_strategy: str | None = Field(None, pattern="^(immediate|graceful|manual)$")
+    restart_strategy: str | None = Field(None, pattern="^(immediate|graceful|manual)\z")
     restart_after_sync: bool | None = None
 
 
@@ -1934,7 +1934,7 @@ class NodeConfigSetRequest(BaseModel):
     """Request to set a configuration value."""
 
     value: str
-    value_type: str = Field(default="string", pattern="^(string|int|bool|json)$")
+    value_type: str = Field(default="string", pattern="^(string|int|bool|json)\z")
 
 
 class NodeConfigBulkResponse(BaseModel):
@@ -1968,7 +1968,7 @@ class ServiceConflictCreateRequest(BaseModel):
     service_a: str = Field(..., min_length=1, max_length=128)
     service_b: str = Field(..., min_length=1, max_length=128)
     reason: str | None = None
-    conflict_type: str = Field(default="port", pattern="^(port|dependency|resource)$")
+    conflict_type: str = Field(default="port", pattern="^(port|dependency|resource)\z")
 
 
 class ServiceConflictListResponse(BaseModel):
@@ -2018,10 +2018,10 @@ class AgentResponse(BaseModel):
 class AgentCreateRequest(BaseModel):
     """Request to create an agent."""
 
-    agent_id: str = Field(..., min_length=1, max_length=64, pattern="^[a-z0-9-]+$")
+    agent_id: str = Field(..., min_length=1, max_length=64, pattern="^[a-z0-9-]+\z")
     name: str = Field(..., min_length=1, max_length=128)
     description: str | None = None
-    llm_provider: str = Field(..., pattern="^(ollama|openai|anthropic|vllm)$")
+    llm_provider: str = Field(..., pattern="^(ollama|openai|anthropic|vllm)\z")
     llm_endpoint: str | None = None
     llm_model: str = Field(..., min_length=1, max_length=64)
     llm_api_key: str | None = None  # Will be encrypted before storage
@@ -2037,7 +2037,7 @@ class AgentUpdateRequest(BaseModel):
 
     name: str | None = Field(default=None, min_length=1, max_length=128)
     description: str | None = None
-    llm_provider: str | None = Field(default=None, pattern="^(ollama|openai|anthropic|vllm)$")
+    llm_provider: str | None = Field(default=None, pattern="^(ollama|openai|anthropic|vllm)\z")
     llm_endpoint: str | None = None
     llm_model: str | None = Field(default=None, min_length=1, max_length=64)
     llm_api_key: str | None = None  # Will be encrypted before storage

--- a/autobot-slm-backend/models/schemas.py
+++ b/autobot-slm-backend/models/schemas.py
@@ -899,7 +899,7 @@ class RestartAllServicesRequest(BaseModel):
 
     category: str | None = Field(
         None,
-        pattern="^(autobot|system|all)\z",
+        pattern=r"^(autobot|system|all)\z",
         description="Category of services to restart. 'all' or null restarts all services.",
     )
     exclude_services: List[str] = Field(
@@ -930,7 +930,7 @@ class RestartAllServicesResponse(BaseModel):
 class ServiceCategoryUpdate(BaseModel):
     """Request to update service category."""
 
-    category: str = Field(..., pattern="^(autobot|system)\z")
+    category: str = Field(..., pattern=r"^(autobot|system)\z")
 
 
 class FleetServiceStatus(BaseModel):
@@ -1160,7 +1160,7 @@ class EligibleNodesResponse(BaseModel):
 class VNCCredentialCreate(BaseModel):
     """Create VNC credential for a node."""
 
-    vnc_type: str = Field(default="desktop", pattern="^(desktop|browser|custom)\z")
+    vnc_type: str = Field(default="desktop", pattern=r"^(desktop|browser|custom)\z")
     name: str | None = Field(None, description="Optional friendly name for the credential")
     password: str = Field(..., min_length=1, description="VNC password (will be encrypted)")
     port: int | None = Field(None, ge=1, le=65535, description="websockify port")
@@ -1742,7 +1742,7 @@ class NodeSyncRequest(BaseModel):
     """Request to sync code to a node."""
 
     restart: bool = True
-    strategy: str = Field(default="graceful", pattern="^(immediate|graceful|manual)\z")
+    strategy: str = Field(default="graceful", pattern=r"^(immediate|graceful|manual)\z")
 
 
 class NodeSyncResponse(BaseModel):
@@ -1758,7 +1758,7 @@ class FleetSyncRequest(BaseModel):
     """Request to sync code to multiple nodes."""
 
     node_ids: List[str] | None = None
-    strategy: str = Field(default="rolling", pattern="^(immediate|graceful|manual|rolling)\z")
+    strategy: str = Field(default="rolling", pattern=r"^(immediate|graceful|manual|rolling)\z")
     batch_size: int = Field(default=1, ge=1, le=10)
     restart: bool = True
 
@@ -1838,9 +1838,9 @@ class ScheduleCreate(BaseModel):
     name: str = Field(..., min_length=1, max_length=100)
     cron_expression: str = Field(..., min_length=9, max_length=100)
     enabled: bool = True
-    target_type: str = Field(default="all", pattern="^(all|specific|tag)\z")
+    target_type: str = Field(default="all", pattern=r"^(all|specific|tag)\z")
     target_nodes: List[str] | None = None
-    restart_strategy: str = Field(default="graceful", pattern="^(immediate|graceful|manual)\z")
+    restart_strategy: str = Field(default="graceful", pattern=r"^(immediate|graceful|manual)\z")
     restart_after_sync: bool = True
 
 
@@ -1850,9 +1850,9 @@ class ScheduleUpdate(BaseModel):
     name: str | None = Field(None, min_length=1, max_length=100)
     cron_expression: str | None = Field(None, min_length=9, max_length=100)
     enabled: bool | None = None
-    target_type: str | None = Field(None, pattern="^(all|specific|tag)\z")
+    target_type: str | None = Field(None, pattern=r"^(all|specific|tag)\z")
     target_nodes: List[str] | None = None
-    restart_strategy: str | None = Field(None, pattern="^(immediate|graceful|manual)\z")
+    restart_strategy: str | None = Field(None, pattern=r"^(immediate|graceful|manual)\z")
     restart_after_sync: bool | None = None
 
 
@@ -1934,7 +1934,7 @@ class NodeConfigSetRequest(BaseModel):
     """Request to set a configuration value."""
 
     value: str
-    value_type: str = Field(default="string", pattern="^(string|int|bool|json)\z")
+    value_type: str = Field(default="string", pattern=r"^(string|int|bool|json)\z")
 
 
 class NodeConfigBulkResponse(BaseModel):
@@ -1968,7 +1968,7 @@ class ServiceConflictCreateRequest(BaseModel):
     service_a: str = Field(..., min_length=1, max_length=128)
     service_b: str = Field(..., min_length=1, max_length=128)
     reason: str | None = None
-    conflict_type: str = Field(default="port", pattern="^(port|dependency|resource)\z")
+    conflict_type: str = Field(default="port", pattern=r"^(port|dependency|resource)\z")
 
 
 class ServiceConflictListResponse(BaseModel):
@@ -2018,10 +2018,10 @@ class AgentResponse(BaseModel):
 class AgentCreateRequest(BaseModel):
     """Request to create an agent."""
 
-    agent_id: str = Field(..., min_length=1, max_length=64, pattern="^[a-z0-9-]+\z")
+    agent_id: str = Field(..., min_length=1, max_length=64, pattern=r"^[a-z0-9-]+\z")
     name: str = Field(..., min_length=1, max_length=128)
     description: str | None = None
-    llm_provider: str = Field(..., pattern="^(ollama|openai|anthropic|vllm)\z")
+    llm_provider: str = Field(..., pattern=r"^(ollama|openai|anthropic|vllm)\z")
     llm_endpoint: str | None = None
     llm_model: str = Field(..., min_length=1, max_length=64)
     llm_api_key: str | None = None  # Will be encrypted before storage
@@ -2037,7 +2037,7 @@ class AgentUpdateRequest(BaseModel):
 
     name: str | None = Field(default=None, min_length=1, max_length=128)
     description: str | None = None
-    llm_provider: str | None = Field(default=None, pattern="^(ollama|openai|anthropic|vllm)\z")
+    llm_provider: str | None = Field(default=None, pattern=r"^(ollama|openai|anthropic|vllm)\z")
     llm_endpoint: str | None = None
     llm_model: str | None = Field(default=None, min_length=1, max_length=64)
     llm_api_key: str | None = None  # Will be encrypted before storage

--- a/autobot_shared/security/__init__.py
+++ b/autobot_shared/security/__init__.py
@@ -20,6 +20,7 @@ from autobot_shared.security.password_weakness import check_password_weakness
 from autobot_shared.security.path_validator import validate_path, validate_relative_path
 from autobot_shared.security.redaction import redact_mapping, redact_text
 from autobot_shared.security.safe_response import safe_error_response
+from autobot_shared.security.sql_identifier import validate_sql_identifier
 from autobot_shared.security.ssrf_guard import (
     SSRFError,
     fetch_safe_url,
@@ -43,4 +44,5 @@ __all__ = [
     "check_password_weakness",
     "redact_text",
     "redact_mapping",
+    "validate_sql_identifier",
 ]

--- a/autobot_shared/security/sql_identifier.py
+++ b/autobot_shared/security/sql_identifier.py
@@ -1,0 +1,48 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+SQL identifier allowlist validator (#2845, #13393).
+
+SQLite/other engines cannot bind table or column names as query parameters,
+so identifiers that must be interpolated into an f-string query need an
+allowlist check first. This is the single shared implementation - previously
+three verbatim, module-private copies existed in the backend (#13393).
+
+Usage:
+    from autobot_shared.security.sql_identifier import validate_sql_identifier
+
+    safe_table = validate_sql_identifier(table_name, "table name")
+    query = f"SELECT COUNT(*) FROM {safe_table}"  # nosec B608 - identifier allowlisted
+"""
+
+from __future__ import annotations
+
+import re
+
+# `\Z` (not `$`) anchors strictly to end-of-string: Python's `$` also matches
+# immediately before a trailing newline, so "users\n" would otherwise pass
+# this allowlist despite containing a character outside [A-Za-z0-9_] (#13393).
+_SQL_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*\Z")
+
+
+def validate_sql_identifier(name: str, label: str = "identifier") -> str:
+    """Validate a SQL identifier (table or column name) against an allowlist pattern.
+
+    Only permits names composed of ASCII letters, digits, and underscores, starting
+    with a letter or underscore. Prevents SQL injection via identifier interpolation. (#2845)
+
+    Args:
+        name: The identifier to validate.
+        label: Human-readable label used in the error message.
+
+    Returns:
+        The validated name unchanged.
+
+    Raises:
+        ValueError: If the name contains characters outside the allowed set.
+    """
+    if not _SQL_IDENTIFIER_RE.match(name):
+        raise ValueError(f"Invalid SQL {label} '{name}': only letters, digits, and underscores allowed")
+    return name

--- a/autobot_shared/security/sql_identifier_test.py
+++ b/autobot_shared/security/sql_identifier_test.py
@@ -1,0 +1,38 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Unit tests for the shared SQL identifier allowlist validator (#2845, #13393).
+
+Moved from ``autobot-backend/utils/sql_injection_hardening_test.py`` when
+``validate_sql_identifier`` was consolidated into a single public helper
+(#13393). Covers CodeQL/semgrep ``autobot-sql-string-format`` alerts: identifiers
+that cannot be bound as parameters are validated against a strict allowlist
+before f-string interpolation.
+"""
+
+import pytest
+
+from autobot_shared.security.sql_identifier import validate_sql_identifier
+
+# Payload containing SQL metacharacters that must never be executed.
+INJECTION = "widgets; DROP TABLE widgets;--"
+
+
+def test_validate_sql_identifier_rejects_metacharacters():
+    """The allowlist validator raises on any non-identifier character."""
+    with pytest.raises(ValueError):
+        validate_sql_identifier(INJECTION, "table name")
+    assert validate_sql_identifier("valid_name_1", "table name") == "valid_name_1"
+
+
+def test_validate_sql_identifier_rejects_trailing_newline():
+    """A trailing newline must be rejected, not accepted via `$` end-of-string
+    semantics (#13393): Python's `$` matches before a final newline, so a
+    `$`-anchored pattern would let "users\\n" through despite the newline
+    falling outside [A-Za-z0-9_]. The validator uses `\\Z` instead.
+    """
+    with pytest.raises(ValueError):
+        validate_sql_identifier("users\n", "table name")
+    with pytest.raises(ValueError):
+        validate_sql_identifier("users\n\n", "table name")


### PR DESCRIPTION
## Thinking Path
Two real defects surfaced while triaging 33 SQL-injection scanner false positives: (1) `_validate_sql_identifier` exists as three verbatim, module-private copies (`utils/common.py`, `utils/async_database_pool.py`, `api/database_mcp.py`) that nothing can import and that duplicate hardening effort; (2) all four `$`-anchored allowlist/pattern regexes match before a trailing newline under Python's `re` module, so `"users\n"` passes an allowlist meant to reject anything outside `[A-Za-z0-9_]`.

Before writing the fix I checked how the anchor behaves in each actual runtime engine, since the two call sites use different regex engines:
- The three `_validate_sql_identifier` copies use Python's `re` module directly → `$` really does match before a trailing newline there, confirmed with a live regex comparison (below). `\Z` is the correct, behavior-changing fix.
- `code_completion.py`'s `sort_by` `Query(..., pattern=...)` and the rest of the sweep go through **Pydantic v2's default Rust `regex` crate**, not Python's `re`. I verified with an ad hoc `FastAPI` `TestClient` app (no AutoBot service started) that the *current* `pattern="^...$"` already returns 422 for `sort_by=frequency%0A` — the Rust engine's `$` doesn't have Python's trailing-newline quirk, so this specific 500 does not currently reproduce. I also confirmed that using `\Z` verbatim (as literally suggested in the issue) raises `pydantic_core.SchemaError: unrecognized escape sequence` at import time for any Pydantic model using it — that would have taken down every router that imports `code_completion.py` at startup. The Rust-regex-crate equivalent for "strict end of haystack" is lowercase `\z`, which I verified compiles under Pydantic and preserves current (already-422) behavior.

Given that, the sweep fix is applied as a correctness/intent fix and forward-compatibility hardening (a real, supported Pydantic knob — `model_config = ConfigDict(regex_engine="python-re")` — would reintroduce the Python-`re` trailing-newline gap for all of these fields if ever flipped), not as a currently-exploitable-500 fix. That distinction is called out explicitly below and in the PR so it isn't mistaken for "silently patched a live 500."

## What Changed
- **New shared helper**: `autobot_shared/security/sql_identifier.py` — public `validate_sql_identifier(name, label)`, `\Z`-anchored (Python `re` semantics, behaviorally different from `$`).
- **Call sites switched then copies removed** (order: switch all three, verify, then delete — never leaving a dangling reference):
  - `autobot-backend/utils/common.py` — removed local `_SQL_IDENTIFIER_RE`/`_validate_sql_identifier` + now-unused `import re`; `DatabaseUtils.get_table_row_count` imports and calls the shared `validate_sql_identifier`.
  - `autobot-backend/utils/async_database_pool.py` — same removal; `AsyncBatchOperations.batch_insert`/`batch_update` (5 call sites) now use the shared helper.
  - `autobot-backend/api/database_mcp.py` — same removal (kept `import re`, still used for `BLOCKED_SQL_PATTERNS` matching); 4 call sites (`_list_tables_sync`, `_describe_schema_sync` x2, `_get_db_statistics_sync`) now use the shared helper.
- **Tests**: `autobot-backend/utils/sql_injection_hardening_test.py`'s direct validator test moved to `autobot_shared/security/sql_identifier_test.py` (alongside the new home), extended with a trailing-newline regression case. The backend test file keeps only the tests that exercise the validator indirectly (`DatabaseUtils`, migration-quoting).
- **`autobot-backend/routers/code_completion.py:161`**: `sort_by` `Query` pattern changed from `pattern="^(frequency|acceptance_rate|created_at)$"` to `...\z` (see Thinking Path for why `\z`, not the literal `\Z` from the issue).
- **Sweep results** — 54 total `pattern="^...$"` FastAPI `Query`/`Field` declarations across 22 files, all the exact same one-character shape (nothing "larger" found — the only other `pattern=` hits, `pattern=""` and `pattern="*.py"`, are unrelated glob/default values, not regexes). All 54 fixed to `\z`:
  `autobot-backend/{routers/code_completion.py, knowledge/schemas/rag.py, api/schemas_system.py, api/schemas_agent.py, api/analytics_quality.py, api/knowledge_grounding.py, api/schemas_knowledge.py, api/schemas_chat.py, api/video_generation.py, api/analytics_bug_prediction.py, api/users.py, api/schemas_analytics.py, api/knowledge_collections.py, api/memory.py, api/monitoring.py, api/image_generation.py, api/knowledge_collaboration.py, api/analytics_code_review.py, services/autoresearch/routes.py}`, `autobot-slm-backend/{models/schemas.py, api/performance.py, api/orchestration.py, api/errors.py}`.
- **`autobot-slm-backend/api/code_sync.py`**: `GET /fleet/jobs`'s `limit` parameter had no bound at all (plain `int = 10`); added `Query(10, ge=1, le=100)` matching the `llc/api/runs.py` convention, plus the `Query` import it needed.
- `database_mcp.py` — no other changes; it remains the reviewed, adequately-defended raw-`sqlite3` file per the issue's explicit scope.

## Verification
Trailing-newline regex comparison (old `$` vs new `\Z`, pure Python `re`):
```
input        old ($)   new (\Z)
'users'      True      True
'users\n'    True      False
'users\nx'   False     False
'users\n\n'  False     False
```
Shared helper directly:
```
>>> validate_sql_identifier("users\n", "table name")
ValueError: Invalid SQL table name 'users\n': only letters, digits, and underscores allowed
```
`?sort_by=frequency%0A` via a standalone `FastAPI` `TestClient` app (no AutoBot service started), old vs new pattern:
```
OLD pattern, sort_by='frequency\n' -> status: 422 {'detail': [...'string_pattern_mismatch'...]}
NEW pattern, sort_by='frequency\n' -> status: 422 {'detail': [...'string_pattern_mismatch'...]}
```
(Confirms the 500 doesn't currently reproduce under Pydantic v2's Rust regex engine — see Thinking Path — and that the `\z` fix preserves the already-correct 422.)

All 54 Pydantic patterns re-verified to compile under Pydantic/pydantic-core after the change (`create_model` smoke test), and all 22 touched modules + `code_sync.py` import cleanly with no `SchemaError`.

Tests:
```
autobot-backend/utils/sql_injection_hardening_test.py ... 3 passed
autobot_shared/security/sql_identifier_test.py ... 2 passed
autobot_shared/security/ (full dir) ... 111 passed
autobot-backend/api/{analytics_quality,video_generation,analytics_code_review}_test.py ... 50 passed
```
No remaining references to the deleted private symbol:
```
$ grep -rn "_validate_sql_identifier" --include=*.py .
autobot_shared/security/sql_identifier_test.py:22:def test_validate_sql_identifier_rejects_metacharacters():
autobot_shared/security/sql_identifier_test.py:29:def test_validate_sql_identifier_rejects_trailing_newline():
```
(only the moved/renamed test functions match the substring; the actual `_validate_sql_identifier` symbol and its `_SQL_IDENTIFIER_RE` are gone from all three former private copies.)

`ruff check` and `black --check` clean on every touched file.

Refs #13393

## Model Used
Sonnet