### PR TITLE
fix(backend): repair template workflow creation, migration default, two test seams (#13162)

### DIFF
--- a/autobot-backend/database/migrations/001_create_conversation_files.py
+++ b/autobot-backend/database/migrations/001_create_conversation_files.py
@@ -56,11 +56,17 @@ class ConversationFilesMigration:
 
         Args:
             data_dir: Directory for database files (default: PATH.DATA_DIR)
-            schema_dir: Directory containing schema files (default: PATH.DATABASE_DIR / "schemas")
+            schema_dir: Directory containing schema files
+                (default: PATH.BACKEND_DIR / "database" / "schemas")
             db_path: Full path to database file (optional, overrides data_dir/conversation_files.db)
         """
         self.data_dir = data_dir or PATH.DATA_DIR
-        self.schema_dir = schema_dir or PATH.DATABASE_DIR / "schemas"
+        # #13162: was ``PATH.DATABASE_DIR``, which PathConstants has never
+        # defined — every construction without an explicit ``schema_dir``
+        # (both module entrypoints below, and the two migration tests) died
+        # with AttributeError before reaching any SQL. The schema files live
+        # under the backend package, so derive the directory from BACKEND_DIR.
+        self.schema_dir = schema_dir or PATH.BACKEND_DIR / "database" / "schemas"
 
         # Allow custom database path OR use default in data_dir
         if db_path:
@@ -455,8 +461,11 @@ class ConversationFilesMigration:
                 for view in views:
                     # Identifier can't be a bind param; quote it (SQLite rules)
                     # so any metacharacter is treated as a name, not SQL. (#12284)
+                    # The identifier is safely quoted, so B608 does not apply here.
+                    # Prose after "nosec" is parsed by bandit as further test ids
+                    # and warns on every word, so the id stands alone. (#13162)
                     stmt = f"DROP VIEW IF EXISTS {_quote_sqlite_identifier(view)}"
-                    cursor.execute(stmt)  # nosec B608 - identifier safely quoted
+                    cursor.execute(stmt)  # nosec B608
                     logger.info(f"Dropped view: {view}")
 
                 # Drop tables (in reverse dependency order)
@@ -472,8 +481,9 @@ class ConversationFilesMigration:
                 for table in tables_to_drop:
                     # Names come from the hardcoded allowlist above; quote them
                     # (SQLite rules) as defence-in-depth against injection. (#12284)
+                    # Bare B608 for the same reason as the view drop above. (#13162)
                     stmt = f"DROP TABLE IF EXISTS {_quote_sqlite_identifier(table)}"
-                    cursor.execute(stmt)  # nosec B608 - identifier safely quoted
+                    cursor.execute(stmt)  # nosec B608
                     logger.info(f"Dropped table: {table}")
 
                 self.connection.commit()

--- a/autobot-backend/security/threat_detection_refactor_test.py
+++ b/autobot-backend/security/threat_detection_refactor_test.py
@@ -53,8 +53,21 @@ def sample_event():
 
 @pytest.fixture
 def sample_events_list():
-    """Create a list of sample events"""
-    base_time = now_utc()
+    """Create a list of sample events.
+
+    The base time is pinned to the most recent 12:30 UTC rather than "now"
+    (#13162). ``EventHistory.count_off_hours_activity`` classifies any event
+    before 06:00 UTC as off-hours over the whole retained deque, with no time
+    window, so anchoring the twenty-three "business hours" events to the wall
+    clock made ``test_event_history_count_off_hours_activity`` count 28
+    instead of 5 on every run started between 00:00 and 05:59 UTC — a quarter
+    of the day. Pinning the anchor keeps every event in the past, inside the
+    24-hour windows the frequency queries use, and makes the off-hours and
+    high-risk counts independent of when the suite runs.
+    """
+    base_time = now_utc().replace(hour=12, minute=30, second=0, microsecond=0)
+    if base_time > now_utc():
+        base_time -= timedelta(days=1)
     events = []
 
     # Create variety of events
@@ -89,7 +102,7 @@ def sample_events_list():
 
     # Add off-hours activity
     for i in range(5):
-        early_morning = now_utc().replace(hour=3, minute=i)
+        early_morning = base_time.replace(hour=3, minute=i)
         events.append(
             {
                 "user_id": "test_user",

--- a/autobot-backend/tests/content_reach/sources/test_web_page.py
+++ b/autobot-backend/tests/content_reach/sources/test_web_page.py
@@ -67,6 +67,10 @@ async def test_trafilatura_fetch_maps_extracted_text(monkeypatch):
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=False)
 
+    # fetch() gates on _import_trafilatura() BEFORE the extraction seam, so on a
+    # runner without the optional `trafilatura` wheel the gate raises BackendError
+    # before _trafilatura_extract is ever reached (#13407). Patch both seams.
+    monkeypatch.setattr(wp_mod, "_import_trafilatura", lambda: object())
     monkeypatch.setattr(wp_mod, "_trafilatura_extract", lambda html: "Extracted article text")
 
     from content_reach.sources.web_page import TrafilaturaBackend
@@ -96,6 +100,10 @@ async def test_trafilatura_fetch_none_extraction_raises(monkeypatch):
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=False)
 
+    # Both seams: without the _import_trafilatura patch this test passes
+    # vacuously on a runner lacking `trafilatura` — the BackendError it asserts
+    # would come from the import gate, never from the None extraction (#13407).
+    monkeypatch.setattr(wp_mod, "_import_trafilatura", lambda: object())
     monkeypatch.setattr(wp_mod, "_trafilatura_extract", lambda html: None)
 
     from content_reach.sources.web_page import TrafilaturaBackend
@@ -120,6 +128,8 @@ async def test_trafilatura_fetch_empty_extraction_raises(monkeypatch):
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=False)
 
+    # Both seams — same vacuous-pass hazard as the None-extraction case (#13407).
+    monkeypatch.setattr(wp_mod, "_import_trafilatura", lambda: object())
     monkeypatch.setattr(wp_mod, "_trafilatura_extract", lambda html: "   ")
 
     from content_reach.sources.web_page import TrafilaturaBackend
@@ -154,6 +164,9 @@ async def test_trafilatura_fetch_httpx_error_raises_backend_error(monkeypatch):
     """httpx.HTTPError raised by client.get() → BackendError (not raw httpx error)."""
     from content_reach.sources import web_page as wp_mod
 
+    # Both seams — otherwise the asserted BackendError can come from the import
+    # gate instead of the httpx error this test is about (#13407).
+    monkeypatch.setattr(wp_mod, "_import_trafilatura", lambda: object())
     monkeypatch.setattr(wp_mod, "_trafilatura_extract", lambda html: "text")
 
     mock_client = AsyncMock()

--- a/autobot-backend/workflow_templates/manager.py
+++ b/autobot-backend/workflow_templates/manager.py
@@ -98,15 +98,25 @@ class WorkflowTemplateManager:
         # Create workflow steps from template
         workflow_steps = []
         for step in template.steps:
+            # #13162: template steps are canonical ``WorkflowTask`` instances
+            # since the #6951 Phase 2A migration, which renamed ``id`` ->
+            # ``task_id`` and ``expected_duration_ms`` ->
+            # ``estimated_duration_seconds``. These two reads were never
+            # updated, so this method raised AttributeError on its first step
+            # for every template — taking /templates/{id}/create-workflow,
+            # /templates/{id}/preview and /templates/{id}/execute down with it.
+            # The emitted key names stay as they are: ``_convert_template_steps``
+            # in api/templates.py and the frontend WorkflowStep type both read
+            # ``step_id`` and ``expected_duration_ms`` (milliseconds).
             workflow_step = {
-                "step_id": step.id,
+                "step_id": step.task_id,
                 "agent_type": step.agent_type,
                 "action": self._substitute_variables(step.action, variables),
                 "description": self._substitute_variables(step.description, variables),
                 "requires_approval": step.requires_approval,
                 "dependencies": step.dependencies.copy(),
                 "inputs": step.inputs.copy() if step.inputs else {},
-                "expected_duration_ms": step.expected_duration_ms,
+                "expected_duration_ms": int(step.estimated_duration_seconds * 1000),
                 "status": "pending",
             }
             workflow_steps.append(workflow_step)


### PR DESCRIPTION
## Thinking Path

The assignment named ten single-failing test files measured against head `617528929`. Roughly twenty merges have landed since, so the first step was to discard the stale numbers and measure again on `origin/Dev_new_gui`:

```
191 passed, 3 failed, 1 skipped   (194 collected across the ten files)
```

Six of the ten are green here, and stay green in full-directory context (`api/` 1344 passed, `services/` 2168 passed, `agents/agent_orchestration/` 83 passed, `security/` 218 passed) — so no order-dependent failure reproduces for them on this box. A seventh, `security/threat_detection_refactor_test.py`, never executes locally at all: scikit-learn is one of the 19 optional deps absent here, so the whole module `importorskip`s.

That left three failures outright, plus two leads worth chasing rather than filing as "not reproducible":

1. The `trafilatura` import-seam gap already filed as **#13407** — reproducible here without uninstalling anything, by blocking the module with a `sys.meta_path` hook.
2. The skipped threat-detection file — its fixture is built from `now_utc()`, which is exactly the shape that produces one or two failures in some CI runs and not others. That is testable without scikit-learn by loading `models.py` directly and replaying the fixture against a simulated clock.

Both leads were real. Two of the three outright failures turned out to be production defects, not test defects.

The auth/transport angle was checked deliberately: nothing of the auth-bypass or timing-oracle class appears in `presence_ws_router_test.py` or `slm_client_test.py`. Both files are green and neither the router nor the client showed a comparable ordering or comparison defect on inspection.

No shared-module change was needed. `autobot_shared/ssot_config_test.py` is green and untouched, and the `PathConstants` defect was repaired on the consumer side using the existing `PATH.BACKEND_DIR` constant rather than by adding a new attribute to the shared class — so the blast radius is one backend module, not `autobot_shared`.

## What Changed

**Production bug — `workflow_templates/manager.py`.** `create_workflow_from_template()` read `step.id` and `step.expected_duration_ms`. Template steps became canonical `WorkflowTask` instances in the #6951 Phase 2A migration, which renamed those fields to `task_id` and `estimated_duration_seconds`. These two reads were never updated, so the method raised `AttributeError` on its **first** step for every one of the 18 templates. Three API endpoints call it, and all three were returning 500:

- `POST /api/templates/templates/{id}/create-workflow`
- `GET  /api/templates/templates/{id}/preview`
- `POST /api/templates/templates/{id}/execute`

Fixed the two reads and converted seconds to the milliseconds the emitted key promises. The emitted key *names* are deliberately unchanged — `_convert_template_steps` in `api/templates.py` and the frontend `WorkflowStep` type both read `step_id` and `expected_duration_ms`.

**Production bug — `database/migrations/001_create_conversation_files.py`.** The default `schema_dir` was `PATH.DATABASE_DIR / "schemas"`, and `PathConstants` has never defined `DATABASE_DIR`. Every construction without an explicit `schema_dir` died with `AttributeError` before touching any SQL — that is both module entrypoints (`run_migration()`, `rollback_migration()`) and the two migration tests. The schema files live under the backend package, so the default now derives from `PATH.BACKEND_DIR`.

While in that file, the two `# nosec B608 - identifier safely quoted` annotations were tidied. Bandit parses everything after `nosec` as further test ids and emits a warning per word, which makes a no-severity-floor bandit run non-silent for anyone touching the file. The prose moved to its own comment line; the id now stands alone.

**Test bug — `tests/content_reach/sources/test_web_page.py`.** `TrafilaturaBackend.fetch()` gates on `_import_trafilatura()` *before* reaching the `_trafilatura_extract` seam the tests patch, so on a runner without the optional `trafilatura` wheel the gate raises `BackendError` first. One test failed outright; **three more were passing vacuously**, asserting a `BackendError` that came from the import gate rather than from the None-extraction, empty-extraction and httpx-error paths each was written to cover. All four now patch both seams, matching the fix #13406 applied to the sibling tests in `tests/content_reach/test_url_guard.py`.

**Test bug — `security/threat_detection_refactor_test.py`.** `sample_events_list` anchored its twenty-three "business hours" events to `now_utc()`. `EventHistory.count_off_hours_activity` classifies anything before 06:00 UTC as off-hours across the whole retained deque, with no time window — so on any run started between 00:00 and 05:59 UTC those events counted as off-hours too, and `test_event_history_count_off_hours_activity` saw 28 instead of 5. That is a quarter of the day. The anchor is now the most recent 12:30 UTC, which keeps every event in the past and inside the 24-hour frequency windows.

No test was skipped, xfailed or weakened; no workaround, TODO or swallowed exception was added.

## Verification

Baseline on `origin/Dev_new_gui`, the ten scoped files:

```
autobot-backend/conversation_file_manager_init_test.py ....FF..
autobot-backend/workflow_templates/workflow_templates_e2e_test.py .F...
...
FAILED conversation_file_manager_init_test.py::TestSchemaIntegrityVerification::test_integrity_verification_fails_missing_table
FAILED conversation_file_manager_init_test.py::TestSchemaMigrationFramework::test_schema_migration_framework
  E   AttributeError: 'PathConstants' object has no attribute 'DATABASE_DIR'
FAILED workflow_templates/workflow_templates_e2e_test.py::test_template_creation
  E   AttributeError: 'WorkflowTask' object has no attribute 'id'
3 failed, 191 passed, 1 skipped in 22.87s
```

After:

```
194 passed, 1 skipped in 22.57s
```

All 18 templates exercised through the repaired method:

```
templates exercised OK: 18
sample: {'step_id': 'fetch_releases', 'agent_type': 'community_growth', ...,
         'expected_duration_ms': 10000, 'status': 'pending'}
```

The trafilatura failure reproduced locally under a `sys.meta_path` hook that blocks the module, matching the CI traceback in #13407 exactly:

```
content_reach/sources/web_page.py:80: in fetch
    _import_trafilatura()
E   ModuleNotFoundError: No module named 'trafilatura'
E   content_reach.base.BackendError: trafilatura not installed
1 failed, 11 passed, 1 skipped
```

and after the fix, the same blocked-module run:

```
12 passed, 1 skipped in 0.72s
```

The off-hours fixture was replayed against the real `EventHistory` for 120 simulated clock positions covering every hour and every minute boundary of the day. Old fixture:

```
UTC hour 00:30 -> off_hours= 28 (expect 5) FAIL
...
UTC hour 05:30 -> off_hours= 28 (expect 5) FAIL
UTC hour 06:30 -> off_hours=  5 (expect 5) PASS
...
count_off_hours_activity == 5 FAILS at UTC hours: [0, 1, 2, 3, 4, 5]
-> 6/24 of the day = 25% of runs
```

Repaired fixture, checking every assertion the count-based tests make (`off_hours == 5`, `high_risk == 3`, `filter_by_user == 28`, risk score in range, no future-dated events), plus `count_recent_failures == 6`:

```
simulated 'now' values checked: 120
PASS - every assertion holds at every hour and minute of the day
```

Order-dependence swept in full-directory context, all green:

```
autobot-backend/api/                          1344 passed, 2124 skipped
autobot-backend/services/                     2168 passed,   12 skipped
autobot-backend/agents/agent_orchestration/     83 passed
autobot-backend/security/                      218 passed,    1 skipped, 2 xfailed
```

Lint, all four touched files:

```
isort   - no changes
black   - 4 files left unchanged
flake8  - 0
bandit  - No issues identified (no severity floor)
```

Environment note: this box runs Python 3.10 and lacks 19 of the optional deps CI installs on 3.14. `security/threat_detection_refactor_test.py` therefore stays fully skipped here — its fixture defect was proven against the real `EventHistory` implementation loaded directly, not through pytest. For the six files that are green here, no failure could be reproduced in any ordering tried; if they are still red in CI the cause is 3.14-specific and outside what this box can observe.

## Model Used

Opus 5 (1M context)

Closes #13162
Closes #13407

> **PARTIAL.** #13162 is the *gate* issue — the Python suite is still not a required status check on `Dev_new_gui`, and this PR does not touch branch protection. It clears four failures from the long tail that motivated the issue. **#13162 stays open.** #13407 is fully delivered and does close here.
