### PR TITLE
fix(tests): seven single-test failures in the #13162 tail — two production bugs, one stub leak, one flake (#13162)

### DIFF
--- a/autobot-backend/llm_shared/optimization/flash_attention.py
+++ b/autobot-backend/llm_shared/optimization/flash_attention.py
@@ -213,19 +213,31 @@ class GrowingKVCache:
     Args:
         chunk_size: Number of positions to add per growth step.
         device: Torch device for cache tensors.
-        dtype: Torch dtype for cache tensors.
+        dtype: Torch dtype for cache tensors. ``None`` (the default) adopts the
+            dtype of the first tensor stored — see below.
+
+    Issue #13162: ``dtype`` used to default to ``float16`` regardless of what
+    was actually stored. ``_write_entries`` assigns into the cache slice, and
+    that assignment casts silently, so an fp32 model handed this cache fp32
+    keys/values, got them rounded to half precision on the way in, and read
+    back a ``Half`` tensor it could no longer combine with its own ``Float``
+    query without an explicit cast. Only the one value-comparing test caught it
+    (``RuntimeError: Half did not match Float``); every shape-only test passed
+    over the truncation. Adopting the stored dtype keeps an fp16 caller on fp16
+    (unchanged) and stops the silent downcast for everyone else; passing
+    ``dtype`` explicitly still forces a specific precision.
     """
 
     def __init__(
         self,
         chunk_size: int = 256,
         device: torch.device | None = None,
-        dtype: torch.dtype = None,
+        dtype: torch.dtype | None = None,
     ):
         _t = _get_torch()
         self.chunk_size = chunk_size
         self.device = device or _t.device("cuda" if _t.cuda.is_available() else "cpu")
-        self.dtype = dtype if dtype is not None else _t.float16
+        self.dtype = dtype
         self._state = KVCacheState(chunk_size=chunk_size)
 
     @property
@@ -264,7 +276,7 @@ class GrowingKVCache:
             num_heads,
             head_dim,
             device=self.device,
-            dtype=self.dtype,
+            dtype=self.dtype if self.dtype is not None else new_kv.dtype,
         )
 
     def _grow_if_needed(self, new_kv: torch.Tensor, needed: int) -> None:
@@ -284,7 +296,9 @@ class GrowingKVCache:
             num_heads,
             head_dim,
             device=self.device,
-            dtype=self.dtype,
+            # Match what is already allocated: torch.cat rejects mixed dtypes,
+            # and self.dtype is None whenever the cache adopted the stored one.
+            dtype=self._state.cache.dtype,
         )
         self._state.cache = _t.cat([self._state.cache, extension], dim=1)
         logger.debug(

--- a/autobot-backend/llm_shared/optimization/ssm_kernels.py
+++ b/autobot-backend/llm_shared/optimization/ssm_kernels.py
@@ -65,14 +65,25 @@ def elu_feature_map(x: Any) -> Any:
 
     Guarantees strictly-positive features so denominators never vanish.
 
+    Issue #13162: ``elu`` saturates at EXACTLY ``-1.0`` in finite precision
+    (float32: every ``x`` below roughly ``-88``; float16: below roughly ``-12``),
+    so the textbook ``elu(x) + 1`` returns exactly ``0.0`` there and the strict
+    positivity this map exists to provide is lost. A zero feature row makes the
+    linear-attention normaliser ``Σ φ(K)`` vanish, and the kernel then divides
+    by an ``eps`` floor instead of by a real mass — silently turning that
+    query's attention into noise. Lift only the collapsed tail to the smallest
+    positive normal of the working dtype: values that did not saturate are
+    returned bit-identical, so the associative and direct forms still agree.
+
     Args:
         x: Tensor ``[..., dim]``.
 
     Returns:
-        Tensor of the same shape with φ applied elementwise.
+        Tensor of the same shape with φ applied elementwise, strictly > 0.
     """
     torch = _get_torch()
-    return torch.nn.functional.elu(x) + 1.0
+    features = torch.nn.functional.elu(x) + 1.0
+    return features.clamp_min(torch.finfo(features.dtype).tiny)
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/media/audio/pipeline_test.py
+++ b/autobot-backend/media/audio/pipeline_test.py
@@ -173,8 +173,17 @@ class TestAudioPipelineAsync:
             }
         )
 
+        # #13162: _whisper_pipeline alone is NOT the seam. _get_whisper_pipeline()
+        # only honours the module global once _WHISPER_LOADED marks the lazy load
+        # as already resolved; while it is False the loader calls hf_pipeline()
+        # and REBINDS _whisper_pipeline over the mock. On a machine with
+        # transformers installed (CI does) that downloaded and instantiated the
+        # real openai/whisper-base model mid-unit-test, which then failed on the
+        # fake bytes with "ffmpeg was not found" and returned the error result --
+        # so this asserted '' == 'test transcription'. Pin the sentinel too.
         with (
             patch("media.audio.pipeline._TRANSFORMERS_AVAILABLE", True),
+            patch("media.audio.pipeline._WHISPER_LOADED", True),
             patch("media.audio.pipeline._whisper_pipeline", mock_whisper),
             patch("os.unlink"),
         ):

--- a/autobot-backend/utils/chromadb_auth_test.py
+++ b/autobot-backend/utils/chromadb_auth_test.py
@@ -12,14 +12,71 @@ Verifies:
   into ``chromadb.config.Settings(...)``.
 """
 
+import importlib
+import importlib.util
 import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Tuple
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-import utils.async_chromadb_client as async_mod
 import utils.chromadb_auth as auth_mod
-import utils.chromadb_client as sync_mod
+
+
+def _load_real_chromadb_modules() -> Tuple[ModuleType, ModuleType]:
+    """Return the real, file-backed sync and async ChromaDB client modules.
+
+    #13162: ``services/knowledge/test_analyzer_service.py`` and
+    ``services/knowledge/test_kb_synthesizer.py`` install permanent
+    ``types.ModuleType`` placeholders for ``utils.chromadb_client`` and
+    ``utils.async_chromadb_client`` into ``sys.modules`` at import time and never
+    remove them (``repo_tests/sys_modules_leak_guard.py`` reports both). They use
+    ``setdefault``, so whichever module pytest imports first wins: in a combined
+    run this file was handed the placeholder, whose ``get_async_chromadb_client``
+    is a bare ``AsyncMock``. Every assertion below then compared one mock against
+    itself -- ``test_async_http_client_sends_token_when_configured`` read a
+    ``Settings.call_args`` that was never populated, and the sibling cache-key
+    test asserted an AsyncMock ``is not`` itself.
+
+    Load the real files under private names when that has happened. The
+    placeholder stays registered, so the modules that installed it keep the
+    object they captured at their own import time.
+    """
+    here = Path(__file__).resolve().parent
+
+    def _real(name: str) -> ModuleType:
+        module = sys.modules.get(f"utils.{name}") or importlib.import_module(f"utils.{name}")
+        if getattr(module, "__file__", None):
+            return module
+        private = f"_real_13162_{name}"
+        cached = sys.modules.get(private)
+        if cached is not None:
+            return cached
+        spec = importlib.util.spec_from_file_location(private, here / f"{name}.py")
+        loaded = importlib.util.module_from_spec(spec)
+        sys.modules[private] = loaded
+        spec.loader.exec_module(loaded)
+        return loaded
+
+    async_module = _real("async_chromadb_client")
+    placeholder = sys.modules.get("utils.async_chromadb_client")
+    # chromadb_client imports utils.async_chromadb_client at module level, so the
+    # real module has to answer that name while chromadb_client executes. Put the
+    # placeholder straight back afterwards.
+    sys.modules["utils.async_chromadb_client"] = async_module
+    try:
+        sync_module = _real("chromadb_client")
+    finally:
+        if placeholder is None:
+            sys.modules.pop("utils.async_chromadb_client", None)
+        else:
+            sys.modules["utils.async_chromadb_client"] = placeholder
+    return sync_module, async_module
+
+
+sync_mod, async_mod = _load_real_chromadb_modules()
 
 
 def test_auth_kwargs_empty_when_token_unset():

--- a/autobot-backend/utils/chromadb_client_cache_key_test.py
+++ b/autobot-backend/utils/chromadb_client_cache_key_test.py
@@ -11,13 +11,68 @@ settings. These tests pin the corrected behaviour: differing settings build
 distinct clients, while a repeated identical call is still a cache hit.
 """
 
+import importlib
+import importlib.util
 import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Tuple
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-import utils.async_chromadb_client as async_mod
-import utils.chromadb_client as sync_mod
+
+def _load_real_chromadb_modules() -> Tuple[ModuleType, ModuleType]:
+    """Return the real, file-backed sync and async ChromaDB client modules.
+
+    #13162: ``services/knowledge/test_analyzer_service.py`` and
+    ``services/knowledge/test_kb_synthesizer.py`` install permanent
+    ``types.ModuleType`` placeholders for ``utils.chromadb_client`` and
+    ``utils.async_chromadb_client`` into ``sys.modules`` at import time and never
+    remove them (``repo_tests/sys_modules_leak_guard.py`` reports both). They use
+    ``setdefault``, so whichever module pytest imports first wins: in a combined
+    run this file was handed the placeholder, whose ``get_async_chromadb_client``
+    is a bare ``AsyncMock``. ``test_async_allow_reset_returns_different_client``
+    then asserted that one AsyncMock return value ``is not`` itself -- it was
+    measuring the mock, never the cache key.
+
+    Load the real files under private names when that has happened. The
+    placeholder stays registered, so the modules that installed it keep the
+    object they captured at their own import time.
+    """
+    here = Path(__file__).resolve().parent
+
+    def _real(name: str) -> ModuleType:
+        module = sys.modules.get(f"utils.{name}") or importlib.import_module(f"utils.{name}")
+        if getattr(module, "__file__", None):
+            return module
+        private = f"_real_13162_{name}"
+        cached = sys.modules.get(private)
+        if cached is not None:
+            return cached
+        spec = importlib.util.spec_from_file_location(private, here / f"{name}.py")
+        loaded = importlib.util.module_from_spec(spec)
+        sys.modules[private] = loaded
+        spec.loader.exec_module(loaded)
+        return loaded
+
+    async_module = _real("async_chromadb_client")
+    placeholder = sys.modules.get("utils.async_chromadb_client")
+    # chromadb_client imports utils.async_chromadb_client at module level, so the
+    # real module has to answer that name while chromadb_client executes. Put the
+    # placeholder straight back afterwards.
+    sys.modules["utils.async_chromadb_client"] = async_module
+    try:
+        sync_module = _real("chromadb_client")
+    finally:
+        if placeholder is None:
+            sys.modules.pop("utils.async_chromadb_client", None)
+        else:
+            sys.modules["utils.async_chromadb_client"] = placeholder
+    return sync_module, async_module
+
+
+sync_mod, async_mod = _load_real_chromadb_modules()
 
 
 def _stub_chromadb():

--- a/autobot-backend/utils/concurrency_safety_test.py
+++ b/autobot-backend/utils/concurrency_safety_test.py
@@ -15,10 +15,12 @@ Date: 2025-10-24
 import asyncio
 import json
 import os
+import statistics
 import tempfile
 import time
 from unittest.mock import AsyncMock, Mock
 
+import aiofiles
 import pytest
 
 # Test Issue 3: Terminal Output Buffer Race
@@ -370,29 +372,71 @@ class TestPerformance:
 
     @pytest.mark.asyncio
     async def test_atomic_write_overhead(self):
-        """Measure atomic write overhead vs direct write"""
+        """Measure atomic write overhead vs direct write.
+
+        #13162: this used to assert a fixed 500ms wall-clock budget for a
+        SINGLE atomic write, and CI measured 743.26ms. Nothing about the write
+        got slower — ``_atomic_write`` is five thread-pool round-trips
+        (mkstemp, flock, the aiofiles write, os.replace, unlink) whose cost is
+        hand-off latency rather than work, so on a runner executing twelve
+        pytest shards that each run ``-n auto`` the absolute number reports
+        machine contention, not the write.
+
+        The docstring already named the right property: overhead *versus a
+        direct write*. So measure that directly. The plain ``aiofiles`` write
+        and the atomic write are interleaved in one loop, so both see the same
+        contention window, and the ratio of their medians is what gets
+        asserted. Load inflates both sides together and cancels; a real
+        regression — a synchronous call, an fsync per chunk, a lost executor —
+        moves only the atomic side and still fails the test.
+        """
         from chat_history import ChatHistoryManager
 
         # Create manager BEFORE timing (exclude initialization overhead)
         manager = ChatHistoryManager()
         await manager.initialize()
 
+        rounds = 15
+        content = '{"test": "data"}' * 100  # ~1.5KB
+
         with tempfile.TemporaryDirectory() as tmpdir:
-            target_file = os.path.join(tmpdir, "perf.json")
-            content = '{"test": "data"}' * 100  # ~1.5KB
+            direct_target = os.path.join(tmpdir, "direct.json")
+            atomic_target = os.path.join(tmpdir, "atomic.json")
 
-            # Warmup run to exclude first-time overhead
-            await manager._atomic_write(target_file + ".warmup", content)
+            # Warmup both paths to exclude first-time executor start-up cost
+            async with aiofiles.open(direct_target, "w", encoding="utf-8") as handle:
+                await handle.write(content)
+            await manager._atomic_write(atomic_target, content)
 
-            # Measure atomic write time (excluding initialization)
-            start = time.time()
-            await manager._atomic_write(target_file, content)
-            atomic_time = time.time() - start
+            direct_samples = []
+            atomic_samples = []
+            for _ in range(rounds):
+                start = time.perf_counter()
+                async with aiofiles.open(direct_target, "w", encoding="utf-8") as handle:
+                    await handle.write(content)
+                direct_samples.append(time.perf_counter() - start)
 
-            # Should be <500ms (realistic threshold for async I/O with variable system load)
-            # Note: Includes async I/O, fcntl locking, and filesystem operations
-            # The race condition fix is correct - this test verifies reasonable performance
-            assert atomic_time < 0.5, f"Atomic write {atomic_time*1000:.2f}ms > 500ms"
+                start = time.perf_counter()
+                await manager._atomic_write(atomic_target, content)
+                atomic_samples.append(time.perf_counter() - start)
+
+            # The atomic write must have produced the same content, not just
+            # spent time — a fast write of nothing is not a passing result.
+            with open(atomic_target, "r", encoding="utf-8") as fh:
+                assert fh.read() == content
+
+        direct = statistics.median(direct_samples)
+        atomic = statistics.median(atomic_samples)
+
+        # _atomic_write makes five executor round-trips against the plain
+        # write's one, so a few multiples is the floor; measured 2.5x. The
+        # bound leaves headroom for a contended runner without leaving room
+        # for a newly added blocking call.
+        max_overhead_ratio = 15.0
+        assert atomic <= direct * max_overhead_ratio, (
+            f"Atomic write {atomic*1000:.2f}ms is {atomic / direct:.1f}x a plain write "
+            f"({direct*1000:.2f}ms), limit {max_overhead_ratio}x"
+        )
 
 
 if __name__ == "__main__":

--- a/autobot-backend/voice_processing/providers/test_registry.py
+++ b/autobot-backend/voice_processing/providers/test_registry.py
@@ -29,6 +29,15 @@ from voice_processing.providers.generic_provider import GenericProvider
 from voice_processing.providers.lv.late_provider import LateProvider
 from voice_processing.providers.lv.tilde_provider import TildeProvider
 
+# #13162: TestGlobalRegistry::test_get_speech_provider_convenience asserts that
+# get_speech_provider("lv") resolves against the GLOBAL registry, but nothing in
+# this module ever populated it -- the assertion ran against an empty registry
+# and returned None. registry_init is the production seam that fills it (its
+# import-time initialize_providers() call is what initialization/lifespan.py
+# invokes at startup), so importing it here is what makes the global-registry
+# assertion below measure the real thing instead of an empty dict.
+from voice_processing.providers import registry_init  # noqa: F401  isort:skip
+
 
 class MockProvider(SpeechProvider):
     """Mock provider for testing."""


### PR DESCRIPTION
## Thinking Path

The dispatch listed eight files with one or two failures each from a CI run that was ~20 merges stale, so the first job was to measure rather than trust it. Two things fell out of that:

1. **A clean local baseline is nearly useless here.** This box runs Python 3.10 without `torch` or `transformers`; CI runs 3.14 with both. Six of the eight files either skip entirely or take a different branch locally. A clean local run showed **1 failure**, not 9.
2. **The campaign's own CI shard logs were still on disk.** Grepping them for the eight files produced the real, per-test failure list with tracebacks — including the captured log lines that made each root cause unambiguous (`'MagicMock' object can't be awaited`, `Loading weights: 245/245`, `ffmpeg was not found`, `elu_feature_map(...) = tensor([0.0000, 0.3679, ...])`).

From there every failure was traced to a cause rather than a symptom, and each was reproduced on this box wherever the environment allowed. Four of the nine were tests measuring a `MagicMock` instead of the code under test — the vacuous-pass shape this campaign keeps finding — and two were genuine production defects that only one value-comparing test in each file was positioned to catch.

Two of those nine (`embedding_test.py`) were fixed at source by #13359 while this was in progress. That was caught by re-measuring after the rebase, so the change staged for that file was dropped rather than committed and the file is untouched here — see #13436 for the before/after.

Two production modules are touched (`ssm_kernels.py`, `flash_attention.py`). Blast radius was measured, not assumed: `elu_feature_map` has one production caller (`LinearAttentionKernel.forward`, via `self._phi`) and the clamp is a no-op for every non-saturated value; `GrowingKVCache` has exactly one production construction site (`FlashAttentionV2.__init__`), which passes no `dtype`, so an fp16 caller is bit-for-bit unchanged.

Leaks and bugs whose sources are outside this PR's file list were filed rather than fixed, and the affected tests were made immune instead: **#13435** (open), **#13437** (open), **#13436** (verified fixed by #13359 and closed).

## What Changed

### Production bugs — the test was right, the code was wrong

**`llm_shared/optimization/ssm_kernels.py` — `elu_feature_map` was not strictly positive.**
`elu` saturates at exactly `-1.0` in finite precision (float32: every `x` below roughly `-88`), so `elu(x) + 1` returns exactly `0.0` there. A zero feature row makes the linear-attention normaliser `Σ φ(K)` vanish, and the kernel divides by its `eps` floor instead of by real mass — that query's attention becomes noise. Fix clamps the collapsed tail to `torch.finfo(dtype).tiny`; every value that did not saturate is returned bit-identical, so the associative and direct forms still agree.

**`llm_shared/optimization/flash_attention.py` — `GrowingKVCache` silently downcast to fp16.**
`dtype` defaulted to `float16` regardless of what was stored. `_write_entries` assigns into the cache slice and that assignment casts silently, so an fp32 caller handed over `Float` keys/values, got them rounded to half precision on the way in, and read back a `Half` tensor it could no longer combine with its own `Float` query. `dtype=None` now adopts the dtype of the first tensor stored, growth matches what is already allocated, and an explicit `dtype` still forces a precision.

### Stub leaks — tests that were measuring a mock

**`utils/chromadb_auth_test.py`, `utils/chromadb_client_cache_key_test.py`.**
`services/knowledge/test_analyzer_service.py` and `test_kb_synthesizer.py` install permanent `sys.modules` placeholders for `utils.chromadb_client` and `utils.async_chromadb_client` at import time and never remove them. `sys.modules` is first-writer-wins, and the async client is only ever imported lazily inside functions, so the placeholder won — its `get_async_chromadb_client` is a bare `AsyncMock`. Both files now real-load the modules under private names when the registered entry is not file-backed; the placeholder stays where it is. Leak filed as **#13435**.

**`code_intelligence/pattern_analysis/embedding_test.py` — no change, and that is the finding.**
Its two CI failures were the same shape: `llc/tests/conftest.py` installed `sys.modules["knowledge.embedding_cache"]` with `EmbeddingCache = ` the `MagicMock` **class**, `analyzer.py` bound it at import, both awaits raised, the broad `except` swallowed it, and `_generate_embedding` returned its 768-float hash pseudo-embedding. `isinstance` kept passing throughout because `MagicMock` really is a class — which is why only two of seven tests noticed. #13359 landed mid-review and binds those stubs to their own collect/run windows; re-measuring after the rebase showed the reproduction passing with the file untouched, so the defensive real-load staged for it was dropped. Filed and closed as **#13436**.

### Test bugs

**`media/audio/pipeline_test.py`** — patching `_whisper_pipeline` is not the seam. `_get_whisper_pipeline` only honours the module global once `_WHISPER_LOADED` marks the lazy load resolved; while it is `False` the loader calls `hf_pipeline()` and rebinds over the mock. CI has `transformers`, so this downloaded and instantiated the real `openai/whisper-base` mid-unit-test. Pin the sentinel too.

**`voice_processing/providers/test_registry.py`** — the global-registry test asserted `get_speech_provider("lv") is not None` against a registry nothing had populated. `registry_init` is the production seam that fills it (its import-time `initialize_providers()` call is what `lifespan.py` invokes at startup).

### Flake

**`utils/concurrency_safety_test.py::TestPerformance::test_atomic_write_overhead`** asserted a fixed 500 ms wall-clock budget for one write and measured 743.26 ms on CI. Nothing got slower: `_atomic_write` is five thread-pool round-trips whose cost is hand-off latency, so on a runner executing twelve shards that each run `-n auto` the number reports contention. The docstring already named the right property — overhead *versus a direct write* — so that is what is measured now: a plain `aiofiles` write and the atomic write interleaved in one loop, both seeing the same contention window, asserting the ratio of medians. Load inflates both sides together and cancels; a regression moves only the atomic side. The written content is verified too, so a fast write of nothing cannot pass.

## Verification

Baseline measured on this branch's merge base, **not** the stale numbers in the dispatch:

```
$ export SLM_SECRET_KEY=throwaway SLM_ENCRYPTION_KEY=x
$ python3 -m pytest <the eight files> -q -p no:cacheprovider \
    -m "not integration and not slow and not distributed and not performance"

FAILED autobot-backend/voice_processing/providers/test_registry.py::TestGlobalRegistry::test_get_speech_provider_convenience
1 failed, 62 passed, 48 skipped in 349.57s
```

Only one of the nine reproduces in a clean local run — the other eight need Python 3.14, `torch`, `transformers`, or a specific collection order. Per-failure environment is stated below.

After:

```
63 passed, 48 skipped in 177.82s
```

Adversarial orders that reproduce the CI-only failures on this box:

```
# stub leak #13435 — before: 8 errors, after:
$ python3 -m pytest services/knowledge/test_analyzer_service.py \
    services/knowledge/test_kb_synthesizer.py \
    utils/chromadb_auth_test.py utils/chromadb_client_cache_key_test.py -q
61 passed

# and the same pairing re-run with the BASE version of those two files,
# after the rebase — the leak is still live, so the fix is still load-bearing:
19 passed, 8 errors
```

Both poisoning modules still pass in that run, so the real-load is contained.

The #13436 pairing, before and after #13359 landed:

```
# on 651fec341 (pre-rebase base), unmodified embedding_test.py
$ python3 -m pytest code_intelligence/pattern_analysis/embedding_test.py \
    llc/tests/test_goals.py -q
2 failed, 28 passed      # object MagicMock can't be used in 'await' expression

# on 3c3371133 (post-rebase base), same unmodified file
30 passed, 5 warnings in 2.42s
```

Timing property, measured standalone and again under the pytest harness:

```
direct median 1.305ms  atomic median 3.277ms  ratio 2.51x   (standalone)
MEASURED direct=2.612ms atomic=6.589ms ratio=2.52x          (under pytest)
```

against a 15x bound — roughly 6x headroom, and stable because both sides move together.

`elu` saturation reproduced in float32, matching the CI tensor exactly:

```
phi           : [  0.  0.36787945  1.  2.  101.]
all > 0       : False
clamped       : [1.1754944e-38 3.6787945e-01 1.0 2.0 1.01e+02]
all > 0       : True
unchanged tail: True
```

**Per failure — CI, local, or both:**

| Test | Fails where | Class | Root cause |
|---|---|---|---|
| `test_registry::test_get_speech_provider_convenience` | both | test bug | global registry never populated; `registry_init` not imported |
| `pipeline_test::test_process_impl_with_mock_whisper` | CI only (needs `transformers`) | test bug | `_WHISPER_LOADED` unpatched → real Whisper rebinds over the mock |
| `chromadb_auth_test::test_async_http_client_sends_token_when_configured` | CI + reproduced locally by pairing | test bug (leak #13435) | `utils.async_chromadb_client` was a leaked placeholder |
| `chromadb_client_cache_key_test::test_async_allow_reset_returns_different_client` | CI + reproduced locally by pairing | test bug (leak #13435) | same; compared an `AsyncMock` against itself |
| `embedding_test::test_calls_generate_embedding_with_fallback_with_real_model` | was CI + local pairing; **already fixed by #13359** | test bug (leak #13436, closed) | `EmbeddingCache` was the `MagicMock` class |
| `embedding_test::test_does_not_fall_through_to_hash_embedding_on_success` | was CI + local pairing; **already fixed by #13359** | test bug (leak #13436, closed) | same |
| `ssm_kernels_test::test_elu_feature_map_is_positive` | CI only (needs `torch`) | **production bug** | `elu(x)+1` returns exactly `0.0` on saturation |
| `flash_attention_test::test_preserves_existing_data` | CI only (needs `torch`) | **production bug** | KV cache forced fp16, silently downcasting fp32 input |
| `concurrency_safety_test::test_atomic_write_overhead` | CI only | environment artifact | absolute wall-clock budget under 12-shard contention |

The two `torch` tests cannot be run on this box — no `torch`, and the conftest stub makes the whole class skip. Both are fixed from the recorded CI traceback plus a float32 reproduction of the saturation, and neither is claimed as locally verified.

Lint, all eight files:

```
isort   — clean
black   — 8 files left unchanged
flake8  — 0
bandit  — No issues identified (no severity floor)
```

Filed along the way, cross-linked back to this PR: **#13435** (open), **#13437** (open), **#13436** (closed — fixed by #13359, with the measurement).

## Model Used

Claude Opus 5 (1M context)

Closes #13162

> **PARTIAL.** This closes seven of the nine failures listed above, across seven files; the remaining two were fixed at source by #13359 before this landed. #13162 covers the whole red Python suite and **stays open** — do not let this PR's merge close it.
