### PR TITLE
ci(frontend): publish the required Unit & Integration Tests context from its own workflow (#13405)

### DIFF
--- a/.github/filters/frontend-paths.yml
+++ b/.github/filters/frontend-paths.yml
@@ -1,0 +1,41 @@
+# Canonical path set for "does this change require the frontend test suite?"
+#
+# SINGLE SOURCE OF TRUTH — do not inline a copy back into either workflow.
+#
+# Two workflows load this file with dorny/paths-filter, and between them they
+# publish exactly one conclusion for the REQUIRED `Unit & Integration Tests`
+# status context:
+#
+#   .github/workflows/frontend-test.yml
+#       job `unit-tests`, self-hosted, runs when `frontend == 'true'`
+#       (the real gate)
+#
+#   .github/workflows/frontend-required-context.yml
+#       job `unit-tests-skip`, ubuntu-latest, runs when `frontend != 'true'`
+#       (reports the context green when the suite does not apply)
+#
+# The two `if:` conditions are exact complements, so the split is only correct
+# while both workflows compute the SAME value for `frontend`. If they ever
+# disagreed in one particular direction — the shim seeing "no frontend change"
+# while frontend-test.yml sees one — a pull request would take the shim's green
+# while the real suite never ran. That is a silent gate bypass, not a flake.
+#
+# Keeping the patterns in one file that both jobs read from the same checkout of
+# the same commit removes that divergence by construction (#13405).
+#
+# The list is also mirrored in frontend-test.yml's `on.push.paths`, because
+# GitHub requires event path filters to be inline. That copy only decides
+# whether a POST-merge run happens on an integration branch; it never gates a
+# required context, so a drift there is visible and harmless. This file remains
+# authoritative.
+frontend:
+  - 'autobot-frontend/**'
+  - '.github/workflows/frontend-test.yml'
+  # The shim workflow gates a required context, so editing it must run the real
+  # suite for the same reason editing frontend-test.yml does.
+  - '.github/workflows/frontend-required-context.yml'
+  # A change to this file changes what "frontend" means for both workflows.
+  - '.github/filters/frontend-paths.yml'
+  # Canonical source for the cross-language parity guard (#13073, #13074):
+  # a port/enum edit here with no frontend edit must still run the suite.
+  - 'autobot_shared/ssot_config.py'

--- a/.github/workflows/frontend-required-context.yml
+++ b/.github/workflows/frontend-required-context.yml
@@ -1,0 +1,103 @@
+# Frontend required-context publisher — #10527, #13405
+#
+# `Unit & Integration Tests` is a REQUIRED status check on the integration
+# branch. Exactly one of two mutually exclusive jobs publishes it:
+#
+#   frontend paths changed   -> `unit-tests` in frontend-test.yml, on the
+#                               self-hosted runner. That is the real gate and
+#                               it stays there (this workflow never reports a
+#                               conclusion in that case).
+#   frontend paths untouched -> `unit-tests-skip` below, on ubuntu-latest.
+#
+# WHY THE SHIM IS ITS OWN WORKFLOW
+#
+# It used to be a job inside frontend-test.yml, which made it useless in the
+# exact outage it was written for. frontend-test.yml declares a WORKFLOW-level
+# concurrency group, and `cancel-in-progress: true` reaps an *in-progress*
+# predecessor but NOT a *queued* one. With the singleton self-hosted runner
+# offline a predecessor never reaches in-progress, so it never yields the group,
+# and every successor run sits in `status: pending` with an empty `jobs` array —
+# indefinitely. A shim cannot report a context from a run that never starts, so
+# the required check went missing and every affected pull request read
+# `mergeable: MERGEABLE` and `statusCheckRollup: SUCCESS` while
+# `mergeStateStatus` read `BLOCKED`, with no failing job to point at.
+#
+# Living in its own file gives the shim its own concurrency scope and a
+# GitHub-hosted runner, so no state of the self-hosted runner can stop the
+# required context from reporting.
+#
+# NO `concurrency:` BLOCK — DELIBERATE. A concurrency group is precisely what
+# broke the shim before. Both jobs here finish in seconds on ubuntu-latest, so
+# cancelling predecessors saves nothing, while any group at all reintroduces a
+# way for this workflow to be gated behind something else. A superseded run
+# simply finishes and publishes against its own, now stale, head SHA — which
+# branch protection does not read.
+#
+# NOT ON THE SELF-HOSTED RUNNER, EVER. Every job here must stay on
+# ubuntu-latest; a self-hosted step in this file would recreate the failure.
+
+name: Frontend Required Context
+
+on:
+  pull_request:
+    # Same branch list as frontend-test.yml, and deliberately NO `paths:`
+    # filter, for the same reason that workflow has none: a path-filtered
+    # required check that never triggers leaves the pull request deadlocked on
+    # "Expected — Waiting for status". Which side publishes the context is
+    # decided by the `changes` job below, never by the event filter.
+    #
+    # `pull_request` only. The shim was never reachable on `push`: that trigger
+    # in frontend-test.yml carries a `paths:` filter, so a push run only exists
+    # when frontend paths changed, and in that case the real `unit-tests` job
+    # publishes the context. Required contexts are evaluated against a pull
+    # request head, which for same-repo branches is only ever written by
+    # `pull_request` runs.
+    branches: [main, develop, 'Dev_*']
+
+permissions:
+  contents: read
+
+jobs:
+  changes:
+    name: Detect changed paths (required context)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      frontend: ${{ steps.filter.outputs.frontend }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4.0.2
+        id: filter
+        with:
+          # A shared file, NOT an inline copy: frontend-test.yml's `changes` job
+          # loads the very same path set from the very same checkout. Two inline
+          # copies could drift, and a drift in one direction — this workflow
+          # deciding "no frontend change" while frontend-test.yml decides there
+          # was one — would hand the pull request the shim's green while the
+          # real suite never ran. One file, one answer.
+          filters: .github/filters/frontend-paths.yml
+
+  unit-tests-skip:
+    # IDENTICAL to the self-hosted job name in frontend-test.yml on purpose:
+    # the required status context is the JOB name, so this reports the same
+    # context from a runner that cannot be starved.
+    name: Unit & Integration Tests
+    needs: changes
+    # Exact complement of `unit-tests` in frontend-test.yml, which is
+    # `needs.changes.outputs.frontend == 'true'`. Both jobs evaluate the same
+    # filter file, for the same event, against the same head — so for any given
+    # pull request exactly one of the two runs and the other is `skipped`.
+    #
+    # Fail-closed: if `changes` errors, `needs` skips this job rather than
+    # reporting green, so a broken detector can never fake a pass.
+    if: needs.changes.outputs.frontend != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: No frontend changes — reporting required context as success
+        run: |
+          echo "No frontend paths changed in this pull request."
+          echo "The frontend Unit & Integration suite does not apply, so the"
+          echo "required 'Unit & Integration Tests' context is reported green"
+          echo "from ubuntu-latest, independently of the self-hosted runner."
+          echo "Path set: .github/filters/frontend-paths.yml (#10527, #13405)."

--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -6,9 +6,16 @@ name: Frontend Testing Suite
 on:
   push:
     branches: [main, develop, 'Dev_*']
+    # Mirror of .github/filters/frontend-paths.yml. GitHub requires event path
+    # filters to be inline, so this copy cannot be shared — but it only decides
+    # whether a POST-merge run happens here, never which job publishes the
+    # required context, so a drift is visible rather than dangerous. The filter
+    # file stays authoritative (#13405).
     paths:
       - 'autobot-frontend/**'
       - '.github/workflows/frontend-test.yml'
+      - '.github/workflows/frontend-required-context.yml'
+      - '.github/filters/frontend-paths.yml'
       # Canonical source for the cross-language parity guard (#13073, #13074):
       # a port/enum edit here with no frontend edit must still run the suite.
       - 'autobot_shared/ssot_config.py'
@@ -19,15 +26,30 @@ on:
     #
     # NOTE: no pull_request.paths filter — this workflow ALWAYS runs on PRs so
     # its required-check context ("Unit & Integration Tests") always reports a
-    # conclusion. A path-filtered required check that never triggers leaves the
-    # PR deadlocked on "Expected — Waiting for status". The real work is gated on
-    # the `changes` job below; when no frontend paths are touched, the
-    # `unit-tests-skip` shim job (same `name:`, ubuntu-latest) reports the
-    # required context green so the PR is never blocked on an unreported check
-    # (#10527). Branch-protection promotion to required is the separate
-    # owner-confirmed follow-up (#10022).
+    # conclusion when the suite applies. A path-filtered required check that
+    # never triggers leaves the PR deadlocked on "Expected — Waiting for
+    # status". The real work is gated on the `changes` job below.
+    #
+    # When no frontend paths are touched the context is reported green by
+    # `unit-tests-skip` in .github/workflows/frontend-required-context.yml — a
+    # SEPARATE workflow, so it shares no concurrency group and no runner with
+    # the self-hosted jobs here (#10527, #13405). Branch-protection promotion to
+    # required is the separate owner-confirmed follow-up (#10022).
     branches: [main, develop, 'Dev_*']
 
+# Only the heavy, self-hosted half of the frontend CI lives in this workflow, so
+# superseding a predecessor is the right default: the runner is a singleton and
+# re-testing a stale head wastes the only machine that can test the new one.
+#
+# KNOWN LIMITATION (#13405): `cancel-in-progress` reaps an *in-progress*
+# predecessor, never a *queued* one. While the self-hosted runner is offline a
+# predecessor never reaches in-progress, so it holds this group and successor
+# runs sit in `status: pending` with an empty `jobs` array until something
+# force-cancels the predecessor. That is survivable HERE because nothing in this
+# workflow is on the critical path of a non-frontend PR any more: the required
+# `Unit & Integration Tests` context is published by frontend-required-context.yml
+# when the suite does not apply, and when it DOES apply a blocked run is a
+# correct block — the tests genuinely have not run.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -51,12 +73,12 @@ jobs:
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4.0.2
         id: filter
         with:
-          filters: |
-            frontend:
-              - 'autobot-frontend/**'
-              - '.github/workflows/frontend-test.yml'
-              # See the push paths above (#13073, #13074).
-              - 'autobot_shared/ssot_config.py'
+          # Shared file, NOT an inline list: frontend-required-context.yml's
+          # `changes` job loads the very same path set. Its shim job and the
+          # `unit-tests` job below carry the same required context name under
+          # exactly complementary conditions, so the split is only correct while
+          # both compute the same answer — one file, one answer (#13405).
+          filters: .github/filters/frontend-paths.yml
 
   # Job 1: Unit and Integration Tests
   unit-tests:
@@ -180,34 +202,19 @@ jobs:
         run: |
           rm -rf autobot-frontend/node_modules || true
 
-  # Job 1b: Skip-success shim for the required "Unit & Integration Tests"
-  # context (#10527).
+  # Job 1b (RELOCATED, not removed): the skip-success shim for the required
+  # "Unit & Integration Tests" context now lives in
+  # .github/workflows/frontend-required-context.yml.
   #
-  # `Unit & Integration Tests` is a REQUIRED status check on Dev_new_gui. The
-  # real `unit-tests` job above runs on the self-hosted runner and only when
-  # frontend paths change. Relying on GitHub's implicit "skipped required job =
-  # pass" was fragile in practice: on non-frontend PRs the context could be left
-  # CANCELLED (concurrency cancel-in-progress) or stuck QUEUED on the singleton
-  # self-hosted runner, neither of which counts as success — permanently
-  # BLOCKING the PR and forcing `--admin` merges.
+  # It still carries the identical job `name:`, still runs on ubuntu-latest and
+  # still fires only when frontend paths did NOT change — the exact complement
+  # of `unit-tests` above, evaluated from the same
+  # .github/filters/frontend-paths.yml. What changed is only WHICH RUN hosts it.
   #
-  # This shim carries the IDENTICAL job `name:` so it reports the same required
-  # context, runs on ubuntu-latest (never contends for / is cancelled by the
-  # self-hosted runner), and fires ONLY when frontend paths did NOT change —
-  # mutually exclusive with the real job's `if:` above. Result: every PR gets
-  # exactly one terminal "Unit & Integration Tests" conclusion — the real gating
-  # tests when frontend changed, an explicit green here when it did not.
-  unit-tests-skip:
-    name: Unit & Integration Tests
-    needs: changes
-    if: needs.changes.outputs.frontend != 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - name: No frontend changes — reporting required context as success
-        run: |
-          echo "No frontend paths changed in this PR."
-          echo "Skipping the frontend Unit & Integration test suite and reporting"
-          echo "the required 'Unit & Integration Tests' context as success (#10527)."
+  # It had to leave this file. A shim cannot report a context from a run that
+  # never starts, and this workflow's run does not start while a `queued`
+  # predecessor holds its concurrency group — the state the singleton
+  # self-hosted runner going offline puts every open PR into (#13405).
 
   # Job 2: Security Scanning
   security-scan:
@@ -312,8 +319,17 @@ jobs:
     name: Test Summary
     runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 15  # #11077: fail fast (self-hosted); not GitHub's 24h default
-    needs: [unit-tests, security-scan, build-test]
-    if: always()
+    needs: [changes, unit-tests, security-scan, build-test]
+    # `always()` so the summary still reports when a test job FAILED, but gated
+    # on the same `changes` output as the jobs it summarises. Without the gate
+    # this was the ONLY job a non-frontend PR placed on the singleton
+    # self-hosted runner, and all it summarised was three skipped jobs —
+    # verified on run 30853514624, where `Test Summary` succeeded on
+    # self-hosted while `Unit & Integration Tests`, `Security Scan` and
+    # `Build Test` were all skipped. While the runner is offline those pointless
+    # jobs are exactly what keeps a superseded run `queued`, and a `queued`
+    # predecessor holds this workflow's concurrency group indefinitely (#13405).
+    if: always() && needs.changes.outputs.frontend == 'true'
 
     steps:
       - name: Download all artifacts


### PR DESCRIPTION
## Thinking Path

`Frontend Testing Suite` declares a **workflow-level** concurrency group. `cancel-in-progress: true` reaps an *in-progress* predecessor; it does **not** reap a *queued* one. When the singleton self-hosted runner goes offline, predecessors never reach in-progress, never yield the group, and successor runs sit in `status: pending` with an **empty `jobs` array** — indefinitely.

The irony this fixes: `frontend-test.yml` already carried a `unit-tests-skip` shim on `ubuntu-latest` whose entire purpose was to publish the REQUIRED `Unit & Integration Tests` context without the self-hosted runner. It works — but only if the **run** starts, and workflow-level concurrency blocks the whole run. So on every affected PR the required context was simply absent, producing `mergeable: MERGEABLE` + `statusCheckRollup: SUCCESS` + `mergeStateStatus: BLOCKED` with nothing red to point at. `rerun` returns `403 This workflow is already running`; only `force-cancel` on the predecessor released it.

**Shape chosen: option 2 (split the publisher into its own workflow), not option 3 (narrow the concurrency group).**

Option 3 — dropping the workflow-level group and putting job-level groups on the heavy jobs — would also let the shim run, with a smaller diff. It was rejected because it leaves the required context *inside* the same run as four self-hosted jobs, so it only holds as long as nothing else can stall that run, and it swaps a well-understood workflow-level semantic for a job-level one on the file that owns a required check. Option 2 makes the property structural instead of circumstantial: the publisher is in a different workflow, on a different runner class, with no concurrency group at all, so there is no mechanism left by which the self-hosted runner's health can withhold the context.

The trade-off is real and is the whole cost of this PR: two workflows must now agree on "did frontend paths change?", and if they ever disagreed in one direction — shim says no, real suite says yes — a PR would take the shim's green while the gate never ran. That is a silent bypass, not a flake. It is addressed by construction below.

I also chose **not** to bundle the watchdog `force-cancel` sweep (fix direction 1) — see "Deliberately not in this PR".

## What Changed

**New — `.github/filters/frontend-paths.yml`**
The `dorny/paths-filter` pattern set, extracted to one file. Both `changes` jobs load it with `filters: .github/filters/frontend-paths.yml` from the same checkout of the same commit, so the two workflows cannot compute different answers — the divergence hazard is removed by construction rather than by discipline. Verified against the pinned action source that a single-line, colon-free input is treated as a file path and that a missing file throws (fail-closed, never a silent empty filter).

Added to the set: the new workflow file and the filter file itself, so editing either runs the real suite — same reasoning that already put `frontend-test.yml` in the list.

**New — `.github/workflows/frontend-required-context.yml`**
`changes` + the relocated `unit-tests-skip`. `pull_request` only, `ubuntu-latest` only, `contents: read` only, and **deliberately no `concurrency:` block** — a concurrency group is the mechanism that broke the shim, both jobs finish in seconds, so a group would buy nothing and reintroduce the only way this workflow could be gated behind something else. Superseded runs simply finish against their own now-stale head SHA, which branch protection does not read.

**`.github/workflows/frontend-test.yml`**
- `changes` now loads the shared filter file instead of an inline copy.
- `unit-tests-skip` removed; a signpost comment records where it went and why it had to leave. The real self-hosted `unit-tests` job is untouched and still publishes the context when frontend paths change.
- `test-summary` gated on `always() && needs.changes.outputs.frontend == 'true'`. It was the **only** job a non-frontend PR placed on the singleton self-hosted runner, and all it summarised was three skipped jobs — evidence below. Those pointless jobs are precisely what keeps a superseded run `queued` while the runner is offline, i.e. the thing that holds the group.
- `on.push.paths` mirrors the filter file, with a comment recording that this copy only decides whether a post-merge run happens and never gates a required context.
- The `concurrency:` block is unchanged, but now carries a comment stating the queued-predecessor limitation explicitly and why it is survivable here.

### How exactly-one conclusion is guaranteed

1. **Complementary conditions, enumerated from the YAML, not by eye.** Exactly two jobs in the entire `.github/workflows/` tree carry the job name `Unit & Integration Tests`. Their conditions are `needs.changes.outputs.frontend == 'true'` and `needs.changes.outputs.frontend != 'true'` — exact complements, so for *any* value (`'true'`, `'false'`, empty, unset) exactly one is selected. Output below.
2. **Same input on both sides.** Both conditions read a value produced by the same action, at the same version, from the same filter file, for the same event and the same head. There is no second copy of the pattern list to drift.
3. **Fail-closed, never fail-open.** If a `changes` job errors, `needs` skips its dependent job rather than reporting green — a broken detector can never fake a pass. If the filter file is missing or malformed the action throws and the job goes red. The only way to lose the shim's green is to also lose the detector, which is visible.
4. **Never zero.** The shim's run has no concurrency group and no self-hosted dependency, so on a non-frontend PR it always starts and always reports. When frontend paths *do* change and the heavy run is blocked, the context is correctly absent — the tests genuinely have not run. That is a correct block, and requirement "do not weaken the gate" is met: the self-hosted `unit-tests` job is still the sole publisher in that case.
5. **The duplicate-name shape is unchanged.** This is not new: today the rollup already carries two entries named `Unit & Integration Tests` — the self-hosted job `SKIPPED` and the shim `SUCCESS` — and PRs merge. Evidence below. The split changes only *which run* hosts the success, not the pair of check runs on the head SHA.

Residual, documented, benign: `dorny/paths-filter` lists PR files via the API at execution time, so if a head moved between the two `changes` jobs they could see different file lists. Both sets of check runs then attach to the superseded SHA, while branch protection reads the current head — which gets its own fresh pair of runs. Not hardened with explicit `base`/`ref` pinning because that switches the action to git-based diffing and would trade a benign stale-SHA case for a shallow-fetch failure mode on a required check.

### Deliberately not in this PR

Teaching `ci-dispatch-watchdog.yml` to `force-cancel` superseded `queued` runs is filed as **#13439** with the full supersession predicate. The watchdog today only *approves* and *publishes statuses*; adding a destructive cancel path is a different risk class, and a wrong predicate would cancel a live required check and block merges repo-wide — the exact failure it exists to prevent. It needs its own review. It is not needed to unblock merges: this PR removes the merge-blocking symptom, #13439 removes the residual stuck state.

Also filed: **#13440** (pre-existing doc drift — `TESTING_FRAMEWORK_SUMMARY.md` documents four frontend CI jobs that do not exist). Not fixed inline to keep this diff reviewable.

## Verification

**1. YAML parses — every file touched**

```
$ python3 -c "import yaml; yaml.safe_load(open(<file>))"
OK   .github/workflows/frontend-test.yml
OK   .github/workflows/frontend-required-context.yml
OK   .github/filters/frontend-paths.yml
```

**2. Publishers of the required context, enumerated from the YAML**

Script walks every file in `.github/workflows/`, parses it, and selects jobs whose `name` equals the context string:

```
=== jobs publishing the check named 'Unit & Integration Tests' ===
  frontend-required-context.yml::unit-tests-skip
      workflow name : Frontend Required Context
      runs-on       : ubuntu-latest
      needs         : changes
      if            : needs.changes.outputs.frontend != 'true'
      triggers      : ['pull_request']
  frontend-test.yml::unit-tests
      workflow name : Frontend Testing Suite
      runs-on       : self-hosted Linux X64
      needs         : changes
      if            : needs.changes.outputs.frontend == 'true'
      triggers      : ['pull_request', 'push']
  total publishers: 2

=== mutual exclusion / totality ===
  exact complements   : True
  -> for any value of needs.changes.outputs.frontend exactly one holds:
       frontend='true'   -> ['unit-tests']
       frontend='false'  -> ['unit-tests-skip']
       frontend=''       -> ['unit-tests-skip']
       frontend='TRUE'   -> ['unit-tests-skip']
       frontend=None     -> ['unit-tests-skip']

=== filter source used by each `changes` job ===
  frontend-test.yml::changes             -> filters: '.github/filters/frontend-paths.yml'
  frontend-required-context.yml::changes -> filters: '.github/filters/frontend-paths.yml'
```

Two publishers, both reading the same filter file, conditions are exact complements.

**3. No job that needs the self-hosted runner was moved off it**

```
=== self-hosted jobs (frontend workflows) ===
  frontend-test.yml             : ['unit-tests', 'security-scan', 'build-test', 'test-summary']
  frontend-required-context.yml : []
```

All four self-hosted jobs stay where they were. The new workflow contains no self-hosted label at all. The only job that changed runner class is the shim, which was already `ubuntu-latest`.

**4. New workflow's triggers cover exactly the cases the old shim covered**

The old shim lived under two workflow triggers:
- `pull_request` to `[main, develop, 'Dev_*']`, **no** `paths:` filter — the new workflow reproduces this branch list and likewise has no `paths:` filter.
- `push` to `[main, develop, 'Dev_*']` **with** a `paths:` filter. A push run only exists when frontend paths changed, in which case `changes` reports `frontend == 'true'` and the shim's `!= 'true'` is false. The shim was therefore never reachable on `push`, so omitting the trigger removes no coverage — and adding it would have created a brand-new `Unit & Integration Tests` check run on integration-branch commits that do not have one today.

Required contexts are evaluated against a PR head, which for same-repo branches is only ever written by `pull_request` runs (the push trigger is scoped to integration branches, not `issue-*`).

**5. The filter-file indirection actually works at the pinned action SHA**

From `dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706` source:

```js
const filtersYaml = isPathInput(filtersInput) ? getConfigFileContent(filtersInput) : filtersInput
function isPathInput(text) { return !(text.includes('\n') || text.includes(':')) }
function getConfigFileContent(configPath) {
  if (!fs.existsSync(configPath)) throw new Error(`Configuration file '${configPath}' not found`)
  ...
}
```

`.github/filters/frontend-paths.yml` contains no newline and no colon, so it is treated as a path; a missing file throws rather than silently yielding an empty filter set. The file parses to exactly one filter, `frontend`, with five string patterns.

**6. `test-summary` really was running on the singleton runner for nothing**

Jobs of a recent non-frontend PR run of `Frontend Testing Suite`:

```
Detect changed paths     | completed/success | labels=ubuntu-latest
Unit & Integration Tests | completed/success | labels=ubuntu-latest
Test Summary             | completed/success | labels=self-hosted,Linux,X64   <-- only self-hosted job that ran
Unit & Integration Tests | completed/skipped | labels=self-hosted,Linux,X64
Security Scan            | completed/skipped | labels=self-hosted,Linux,X64
Build Test               | completed/skipped | labels=self-hosted,Linux,X64
```

**7. The duplicate-name shape is pre-existing and tolerated**

Rollup entries named `Unit & Integration Tests` on a currently-open PR, before this change:

```
Unit & Integration Tests | COMPLETED/SKIPPED | started=…T21:18:43Z
Unit & Integration Tests | COMPLETED/SUCCESS | started=…T21:20:34Z
mergeable/mergeStateStatus: MERGEABLE BEHIND     (BEHIND = strict-mode base drift, not a check failure)
```

**8. The context name is byte-identical to the required check**

Required contexts on the integration branch include `Unit & Integration Tests`; the enumeration in step 2 reads the job `name` values straight from the YAML and both match that string exactly. Nothing was renamed.

**9. Lint**

```
$ pre-commit run actionlint --files .github/workflows/frontend-test.yml .github/workflows/frontend-required-context.yml
Lint GitHub Actions workflow files.......................................Passed

$ pre-commit run --files <the three touched files>
Lint GitHub Actions workflow files ......... Passed
No Tag-Pinned 3rd-Party GitHub Actions ..... Passed
Worktree Branch Guard / Target Branch Guard  Passed
Detect Mass Deletions ...................... Passed
```

Two unrelated hooks (`check_no_deprecated_ansible_facts.py`, `check_canonical_role_names.py`) report "is not executable". That is pre-existing on the base branch — both are mode `100644` in the index, not a local artifact — and is already being fixed elsewhere. Commit was made without `--no-verify`.

Refs #13405

## Model Used

claude-opus-5
