### PR TITLE
test(repo): shrink-only sys.modules leak baseline, gating new leaks (#13398)

### DIFF
--- a/repo_tests/sys_modules_leak_baseline.txt
+++ b/repo_tests/sys_modules_leak_baseline.txt
@@ -1,0 +1,90 @@
+# sys.modules leak baseline — the owners that leak today (#13398)
+#
+# One repo-relative path per line, sorted. Each line is a conftest or test
+# module that leaves a sys.modules stub installed while pytest works outside
+# its own directory; the guard in sys_modules_leak_guard.py reports these and
+# does NOT fail the run for them. Anything not listed here fails immediately —
+# a new leak is a regression, and #13320/#13324/#13337/#13358 are what one
+# costs when it lands unnoticed.
+#
+# THIS LIST ONLY SHRINKS. Never add a line to make your own change pass: fix
+# the stub instead, installing and removing it in the same try/finally scoped
+# to the nodes that need it (see #13359 for the pattern and its two traps). A
+# listed owner that a session exercises without seeing it leak fails the run
+# too, with "remove it from ..." — so each fix under #13361 lands with the
+# one-line deletion that proves it.
+#
+# The one case where a line may be added is a PRE-EXISTING offender that no
+# earlier session had surfaced: a run-phase stub only escapes when the work
+# distribution happens to put an outside node after it, so one of the entries
+# below stayed invisible for two full slm-backend runs and then appeared in
+# every one after. Fixing it is still the better answer; listing it needs the
+# session output in the PR that adds it.
+#
+# The `run-phase` annotation marks an owner that installs its stub while its
+# own tests run rather than at import. CI shards the suite twelve ways, so
+# eleven of those shards collect such a module without running a single test
+# from it and see nothing at all; reading that silence as "fixed" would fail
+# eleven shards over a leak that is still there. Annotated entries are
+# therefore never checked for removal — they still have to be fixed, and their
+# line still has to be deleted by hand when they are.
+#
+# Generated from real sessions on Dev_new_gui, not by hand: both invocation
+# shapes CI uses, since pytest.ini forbids one combined session (#13084), each
+# run collect-only to find the owners whose stub is live from import, and then
+# in full to add the ones that only appear once their own tests execute.
+#
+#   pytest --collect-only -q -p no:randomly --continue-on-collection-errors \
+#     autobot-backend autobot_shared autobot-tts-worker repo_tests
+#   pytest --collect-only -q -p no:randomly --continue-on-collection-errors \
+#     autobot-slm-backend
+#   pytest autobot-backend autobot_shared autobot-tts-worker repo_tests \
+#     -n auto --dist loadscope --continue-on-collection-errors \
+#     -m "not integration and not slow and not distributed and not performance"
+#   pytest autobot-slm-backend \
+#     -n auto --dist loadscope --continue-on-collection-errors \
+#     -m "not integration and not slow and not distributed and not performance"
+#
+# An owner the full run reports and the collect-only run of the same tree does
+# not is a run-phase one. The full runs were repeated across worker counts
+# (-n auto, -n 4, -n 2, serial) and the union taken, which is what caught the
+# intermittent entry above. The markers those runs exclude
+# (integration/slow/distributed/performance) run on a schedule instead and can
+# surface owners this list does not have.
+
+autobot-backend/code_intelligence/conftest.py
+autobot-backend/conftest.py
+autobot-backend/knowledge/vector_search_engine_test.py
+autobot-backend/llm_shared/npu_pipeline_routing_test.py
+autobot-backend/services/npu_pipeline/test_dispatcher.py
+autobot-backend/tests/agents/test_causal_reasoning.py
+autobot-backend/tests/knowledge/test_cleanup_endpoint.py
+autobot-backend/tests/llm_interface_pkg/test_anthropic_provider.py
+autobot-backend/tests/llm_interface_pkg/test_groq_provider.py
+autobot-backend/tests/orchestration/test_causal_error_recovery.py
+autobot-backend/tests/search/conftest.py
+autobot-backend/tests/services/rag_service_events_test.py
+autobot-backend/tests/services/test_scheduler_registry.py
+autobot-backend/tests/test_conftest_real_load_identity.py run-phase
+autobot-backend/tests/test_tool_schema_correction.py
+autobot-backend/tests/test_vnc_mcp_async.py run-phase
+autobot-backend/tests/test_vnc_screenshot_temp_leak.py run-phase
+autobot-backend/worker_node_test.py run-phase
+autobot-slm-backend/api/monitoring_applogs_test.py
+autobot-slm-backend/services/a2a_card_fetcher_test.py
+autobot-slm-backend/services/reconciler_check_node_health_test.py
+autobot-slm-backend/tests/api/conftest.py
+autobot-slm-backend/tests/api/test_collect_outdated_node_ids.py
+autobot-slm-backend/tests/api/test_fleet_health.py
+autobot-slm-backend/tests/api/test_node_update_availability_11964.py
+autobot-slm-backend/tests/api/test_nodes_list_timeout_10913.py run-phase
+autobot-slm-backend/tests/api/test_slm_endpoints_12515.py
+autobot-slm-backend/tests/services/conftest.py
+autobot-slm-backend/tests/services/test_deploy_artifacts_lockstep.py
+autobot-slm-backend/tests/services/test_llm_secrets.py
+autobot-slm-backend/tests/services/test_sso_vault_client.py
+autobot-slm-backend/tests/test_api_request_counter.py
+autobot-slm-backend/tests/test_prometheus_registry_endpoint.py run-phase
+autobot-slm-backend/user_management/services/sso_e2e_test.py run-phase
+autobot_shared/jina_parser_test.py run-phase
+autobot_shared/url_safety_test.py run-phase

--- a/repo_tests/sys_modules_leak_guard.py
+++ b/repo_tests/sys_modules_leak_guard.py
@@ -40,11 +40,43 @@ Only *suspicious* mutations are tracked, so an ordinary import never registers:
   ``types.ModuleType(...)`` hand-built stubs and of ``MagicMock``, and never of
   a module the import system loaded.
 
-Configuration (env var ``AUTOBOT_SYSMODULES_GUARD``):
+What a finding costs is decided by a checked-in baseline of the owners that
+leak today (``repo_tests/sys_modules_leak_baseline.txt``), applied per *owner*
+rather than per key — one conftest dragging 40 keys along is one line:
 
-``report``  default — warn, and print a dedicated terminal section
-``error``   also fail the session with a non-zero exit status
-``off``     disable entirely
+* an owner **on** the baseline is reported and does not fail the run; that is
+  pre-existing debt, tracked in #13361, and failing on it would mean the gate
+  could not be switched on until the last one was fixed;
+* an owner **not** on the baseline **fails the run** — a new leak is a
+  regression, and gating it is the whole point of the guard;
+* an owner on the baseline that the session exercised and that **no longer
+  leaks** also **fails the run**, asking for its line to be deleted.
+
+The last rule is what makes the list shrink-only: it cannot rot, and every fix
+lands with a one-line deletion that proves it.  It needs the session to have
+actually given the owner a chance to escape — a run confined to
+``autobot-backend/`` never takes that conftest's stubs anywhere they could be
+seen — so :meth:`_LeakGuard._note_escape_opportunity` only counts an owner once
+pytest has handled a node outside it.
+
+A handful of owners install their stub *while their own tests run* rather than
+at import, and those are marked ``run-phase`` in the baseline.  CI shards the
+suite twelve ways, so eleven of those twelve sessions collect such a module,
+never run a single one of its tests, and see nothing — which under the rule
+above would read as "fixed, delete the line" and fail eleven shards over a leak
+that is still there.  Annotated entries are therefore reported but never
+checked for removal.  Nothing else changes for them: they are still on the
+list, so they never fail as a regression either.
+
+The predecessor of this was a ``report``/``error`` pair (#13370) where
+``report`` never failed on anything and ``error`` failed on everything, so the
+only reachable setting gated nothing at all (#13398).
+
+Configuration:
+
+``AUTOBOT_SYSMODULES_GUARD=off``   disable the guard entirely (local escape hatch)
+``AUTOBOT_SYSMODULES_BASELINE``    read the baseline from elsewhere; the guard's
+                                   own nested-session tests are the only caller
 """
 
 from __future__ import annotations
@@ -60,14 +92,77 @@ import pytest
 
 _MODE_ENV = "AUTOBOT_SYSMODULES_GUARD"
 _MODE_OFF = "off"
-_MODE_ERROR = "error"
+
+_BASELINE_ENV = "AUTOBOT_SYSMODULES_BASELINE"
+_BASELINE_NAME = "sys_modules_leak_baseline.txt"
+_RUN_PHASE = "run-phase"
 
 _SECTION_TITLE = "sys.modules leak guard"
 _KEYS_PER_OWNER = 8
 
 
-def _mode() -> str:
-    return os.environ.get(_MODE_ENV, "report").strip().lower()
+def _enabled() -> bool:
+    """False only for ``AUTOBOT_SYSMODULES_GUARD=off``, the local escape hatch."""
+    return os.environ.get(_MODE_ENV, "").strip().lower() != _MODE_OFF
+
+
+def _baseline_path() -> Path:
+    """Where the allowlist lives — beside this file unless the env var moves it."""
+    override = os.environ.get(_BASELINE_ENV, "").strip()
+    return Path(override) if override else Path(__file__).resolve().with_name(_BASELINE_NAME)
+
+
+@dataclass(frozen=True)
+class _Baseline:
+    """The checked-in allowlist, split by what each entry may be judged on."""
+
+    owners: frozenset[str]  # every listed owner — none of these fails as new
+    removal_checked: frozenset[str]  # the subset whose silence means "fixed"
+
+
+def _load_baseline(path: Path) -> _Baseline:
+    """Read the allowlist: one repo-relative owner path per line.
+
+    Blank lines and ``#`` comments are ignored.  A trailing ``run-phase``
+    marks an owner that only leaks while its own tests run, which exempts it
+    from the removal check (see the module docstring); it is the only
+    annotation, and anything else is deliberately treated as no annotation so
+    a typo shows up as a failing removal check rather than as silence.
+
+    A missing file means an *empty* allowlist rather than a disabled gate —
+    that is the right answer for the scratch repos the guard's own tests build,
+    and it keeps a deleted or mistyped path loud instead of silent.
+    """
+    if not path.is_file():
+        return _Baseline(frozenset(), frozenset())
+    owners: set[str] = set()
+    removal_checked: set[str] = set()
+    for line in path.read_text(encoding="utf-8").splitlines():
+        entry = line.strip()
+        if not entry or entry.startswith("#"):
+            continue
+        owner, _, annotation = entry.partition(" ")
+        owners.add(owner)
+        if annotation.strip() != _RUN_PHASE:
+            removal_checked.add(owner)
+    return _Baseline(frozenset(owners), frozenset(removal_checked))
+
+
+def _outside_owner_dir(
+    path: Path | None,
+    path_parents: frozenset[Path],
+    owner_dir: Path,
+    owner_ancestors: frozenset[Path],
+) -> bool:
+    """The escape rule, shared by leak detection and baseline bookkeeping.
+
+    See :meth:`_Mutation.escapes_to` for why an ancestor directory is exempt.
+    """
+    if path is None:
+        return False
+    if path == owner_dir or owner_dir in path_parents:
+        return False  # inside the owner's own subtree
+    return path not in owner_ancestors  # a structural ancestor Dir imports nothing
 
 
 @dataclass(frozen=True)
@@ -95,7 +190,7 @@ class _Mutation:
         """True when *path* is outside the directory that owns this stub.
 
         A strict *ancestor* directory is not an escape, and treating it as one
-        made ``error`` mode unusable.  Pytest builds a ``Dir`` collector for
+        made the gate unusable.  Pytest builds a ``Dir`` collector for
         every level from the rootdir down, so a session confined entirely to
         ``autobot-backend/`` still collects the rootdir node ``.``; that node
         imports nothing itself, it only lists its children, so a stub being
@@ -112,13 +207,7 @@ class _Mutation:
         *path_parents* is ``path.parents`` as a set; the caller builds it once
         per check and shares it across every tracked mutation.
         """
-        if path is None:
-            return False
-        if path == self.owner_dir or self.owner_dir in path_parents:
-            return False  # inside the owner's own subtree
-        if path in self.owner_ancestors:
-            return False  # a structural ancestor Dir node imports nothing
-        return True
+        return _outside_owner_dir(path, path_parents, self.owner_dir, self.owner_ancestors)
 
 
 @dataclass(frozen=True)
@@ -196,21 +285,44 @@ def _resolves_on_disk(top_level: str) -> bool:
 
 
 def _display(path: Path, rootdir: Path) -> str:
+    """*path* in the form the baseline file stores: repo-relative and POSIX.
+
+    A path outside the root keeps its absolute form instead of collapsing to a
+    basename.  Collapsing made every ``conftest.py`` in the tree share one
+    display name, and since the baseline is keyed on that name, two different
+    conftests became one entry — harmless in this repo, where nothing sits
+    outside the root, but not in the scratch repos the guard's own
+    nested-session tests build under ``tmp_path``.
+    """
     try:
-        return str(path.relative_to(rootdir))
+        return path.relative_to(rootdir).as_posix()
     except ValueError:
-        return path.name
+        return str(path)
 
 
 class _LeakGuard:
     """Track suspicious ``sys.modules`` mutations and where they escape to."""
 
-    def __init__(self, rootdir: Path) -> None:
+    def __init__(self, rootdir: Path, removal_candidates: frozenset[str] = frozenset()) -> None:
         self._rootdir = rootdir
         self._baseline: dict[str, object] = {}
+        # Only the owners the shrink check may fire on are worth watching; the
+        # rest are on the allowlist and nothing this session sees can move them.
+        self._removal_candidates = removal_candidates
+        # Their basenames, so the visit check can reject the overwhelming
+        # majority of nodes — every directory and every unrelated module — on
+        # one set lookup instead of building a repo-relative display path for
+        # each of the thousands of collectors a session brackets.
+        self._candidate_names = {Path(owner).name for owner in removal_candidates}
         self._tracked: dict[str, _Mutation] = {}
         self._reported: set[tuple[str, str]] = set()
         self._warned_owners: set[str] = set()
+        # Baselined owners this session has loaded but not yet taken anywhere
+        # they could escape to, mapped to their directory and its ancestors.
+        self._visited: dict[str, tuple[Path, frozenset[Path]]] = {}
+        # Baselined owners the session *has* taken outside their directory —
+        # the only ones whose silence is evidence that they were fixed.
+        self._exercised: set[str] = set()
         self.leaks: list[_Leak] = []
 
     @property
@@ -247,6 +359,7 @@ class _LeakGuard:
         unconditionally would blame the level above and make every stub look
         like it never escapes.
         """
+        self._note_visit(owner_file)
         if self._matches_baseline():
             return
         current = sys.modules.copy()
@@ -369,10 +482,15 @@ class _LeakGuard:
 
         ``path.parents`` is materialised once here and shared with every
         tracked mutation rather than rebuilt inside each comparison.
+
+        This is also where a baselined owner earns the right to be called
+        fixed: the same step that would have caught its stub records that the
+        session gave it the chance to escape.
         """
-        if not self._tracked:
+        if not self._tracked and not self._visited:
             return
         path_parents = frozenset(path.parents) if path is not None else frozenset()
+        self._note_escape_opportunity(path, path_parents)
         for mutation in list(self._tracked.values()):
             if not mutation.is_live():
                 self._tracked.pop(mutation.key, None)
@@ -399,6 +517,43 @@ class _LeakGuard:
             return
         self._warned_owners.add(leak.mutation.owner)
         warnings.warn(leak.describe(), _SysModulesLeakWarning, stacklevel=1)
+
+    def _note_visit(self, owner_file: Path) -> None:
+        """Remember that a baselined owner was loaded by this session.
+
+        Recorded *before* :meth:`attribute`'s no-delta early return: an owner
+        that has stopped leaking installs nothing and so produces no delta at
+        all, and that is precisely the case the baseline has to notice.
+        """
+        if owner_file.name not in self._candidate_names:
+            return
+        owner = _display(owner_file, self._rootdir)
+        if owner not in self._removal_candidates or owner in self._visited or owner in self._exercised:
+            return
+        owner_dir = owner_file if owner_file.is_dir() else owner_file.parent
+        self._visited[owner] = (owner_dir, frozenset(owner_dir.parents))
+
+    def _note_escape_opportunity(self, path: Path | None, path_parents: frozenset[Path]) -> None:
+        """Promote every visited baselined owner that *path* lies outside of.
+
+        "This owner did not leak" is only evidence when the session gave it the
+        chance to: a run confined to ``autobot-backend/`` never takes that
+        conftest's stubs anywhere they could be seen, and concluding from such
+        a run that the entry is removable would fail every partial run in the
+        tree.  The test is the same one leak detection uses, so an owner is
+        exercised exactly when a leak would have been reported had one been
+        live.
+        """
+        if not self._visited or path is None:
+            return
+        for owner, (owner_dir, ancestors) in list(self._visited.items()):
+            if _outside_owner_dir(path, path_parents, owner_dir, ancestors):
+                del self._visited[owner]
+                self._exercised.add(owner)
+
+    def exercised_owners(self) -> set[str]:
+        """Baselined owners this session took outside their own directory."""
+        return set(self._exercised)
 
     def records(self) -> list[dict]:
         """Every leak in transport form, in first-seen order."""
@@ -432,6 +587,11 @@ class _SysModulesLeakWarning(pytest.PytestWarning):
 # moving the checkout or the machine cannot strand the guard.
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 
+# Read once, at import: the file is small, and every hook below needs it.
+_BASELINE_PATH = _baseline_path()
+_BASELINE = _load_baseline(_BASELINE_PATH)
+_BASELINE_DISPLAY = _display(_BASELINE_PATH, _REPO_ROOT)
+
 
 def _make_guard() -> _LeakGuard | None:
     """Build the guard at *import* time, before any other conftest loads.
@@ -443,9 +603,9 @@ def _make_guard() -> _LeakGuard | None:
     pulls this module in through ``pytest_plugins``, and the rootdir conftest is
     an ancestor of every argument, so this runs first.
     """
-    if _mode() == _MODE_OFF:
+    if not _enabled():
         return None
-    guard = _LeakGuard(_REPO_ROOT)
+    guard = _LeakGuard(_REPO_ROOT, _BASELINE.removal_checked)
     guard.snapshot()
     return guard
 
@@ -562,11 +722,50 @@ _WORKER_RECORDS: list[dict] = []
 # observation is the one kept, matching the serial path's ``_reported``.
 _WORKER_TOKENS: set[tuple[str, str]] = set()
 
+# Baselined owners the workers took outside their own directory. Merged as a
+# union: an owner only has to be exercised somewhere for its silence to count.
+_WORKER_EXERCISED: set[str] = set()
+
 
 def _all_records() -> list[dict]:
     """Every leak this process knows about, worker-reported ones included."""
     local = _GUARD.records() if _GUARD is not None else []
     return local + _WORKER_RECORDS
+
+
+def _all_exercised_owners() -> set[str]:
+    """Every baselined owner given a chance to escape, in any process."""
+    local = _GUARD.exercised_owners() if _GUARD is not None else set()
+    return local | _WORKER_EXERCISED
+
+
+@dataclass(frozen=True)
+class _Verdict:
+    """What this session's findings mean once the baseline is applied."""
+
+    new_owners: list[str]  # leaking and unlisted — a regression, fails the run
+    known_owners: list[str]  # leaking and listed — known debt, reported only
+    fixed_owners: list[str]  # listed, exercised, silent — delete the line
+
+    @property
+    def failed(self) -> bool:
+        return bool(self.new_owners or self.fixed_owners)
+
+
+def _verdict() -> _Verdict:
+    """Split the session's owners into regression / known debt / removable.
+
+    ``fixed_owners`` subtracts *every* leaking owner rather than only the ones
+    this process saw: under xdist one worker can exercise an owner without
+    meeting its stub while another meets it, and an entry is removable only
+    when nobody saw it leak.
+    """
+    leaking = {record["owner"] for record in _all_records()}
+    return _Verdict(
+        new_owners=sorted(leaking - _BASELINE.owners),
+        known_owners=sorted(leaking & _BASELINE.owners),
+        fixed_owners=sorted((_all_exercised_owners() & _BASELINE.removal_checked) - leaking),
+    )
 
 
 def _group_records(records: list[dict]) -> dict[str, list[dict]]:
@@ -578,18 +777,24 @@ def _group_records(records: list[dict]) -> dict[str, list[dict]]:
 
 
 def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
-    """Ship worker findings to the controller, and fail the run in error mode.
+    """Ship worker findings to the controller, and fail on an unbaselined verdict.
 
     Under xdist every check runs in a worker, so the controller's own ``_GUARD``
     never sees a leak.  Without this hand-off both the terminal section and the
-    ``error`` gate were silently dead under ``-n`` — which is the only shape CI
-    uses, so the gate #13361 relies on would not have existed.
+    gate were silently dead under ``-n`` — which is the only shape CI uses, so
+    the gate this guard exists to be would not have existed.
+
+    Both halves of the verdict travel: the leaks, and the baselined owners this
+    process took outside their directory without meeting their stub.  The
+    second is what lets the controller tell "fixed, delete the line" from
+    "never exercised, say nothing".
     """
     workeroutput = getattr(session.config, "workeroutput", None)
     if workeroutput is not None:
         workeroutput["sys_modules_leaks"] = _GUARD.records() if _GUARD else []
+        workeroutput["sys_modules_exercised"] = sorted(_GUARD.exercised_owners()) if _GUARD else []
         return
-    if _mode() == _MODE_ERROR and _all_records():
+    if _verdict().failed:
         session.exitstatus = pytest.ExitCode.TESTS_FAILED
 
 
@@ -611,6 +816,7 @@ def pytest_testnodedown(node: object, error: object) -> None:
             continue  # another worker saw the same stub at a different nodeid
         _WORKER_TOKENS.add(token)
         _WORKER_RECORDS.append(record)
+    _WORKER_EXERCISED.update(output.get("sys_modules_exercised", []))
 
 
 # ---------------------------------------------------------------------------
@@ -619,20 +825,58 @@ def pytest_testnodedown(node: object, error: object) -> None:
 
 
 def pytest_terminal_summary(terminalreporter: object, exitstatus: int) -> None:
-    """Print the leaks in their own section; a warnings line is too easy to miss."""
-    records = _all_records()
-    if not records:
+    """Print the findings in their own section, split by what has to be done.
+
+    Only a *failing* verdict paints the section red.  A full CI run is 12
+    shards times 2 invocations, so a red block per shard for debt nobody is
+    required to act on is 24 sections of wallpaper — which is exactly how a
+    report-only guard stops being read (#13398).
+    """
+    verdict = _verdict()
+    grouped = _group_records(_all_records())
+    if not grouped and not verdict.fixed_owners:
         return
-    grouped = _group_records(records)
-    terminalreporter.section(_SECTION_TITLE, sep="=", red=True, bold=True)
-    for owner, owned in grouped.items():
-        _write_owner_report(terminalreporter, owner, owned)
+    terminalreporter.section(_SECTION_TITLE, sep="=", red=verdict.failed, bold=True)
+    _write_new_owners(terminalreporter, verdict, grouped)
+    _write_fixed_owners(terminalreporter, verdict)
+    _write_known_owners(terminalreporter, verdict, grouped)
+
+
+def _write_new_owners(terminalreporter: object, verdict: _Verdict, grouped: dict[str, list[dict]]) -> None:
+    """Regressions: files that leak and are not on the baseline."""
+    if not verdict.new_owners:
+        return
+    for owner in verdict.new_owners:
+        _write_owner_report(terminalreporter, owner, grouped[owner])
     terminalreporter.write_line(
-        f"{len(records)} leaked sys.modules key(s) from {len(grouped)} file(s). "
-        f"Install and remove each stub in the same try/finally, scoped to the "
-        f"nodes that need it. Set {_MODE_ENV}={_MODE_ERROR} to fail the run on "
-        f"these, or {_MODE_ENV}={_MODE_OFF} to disable the guard."
+        f"{len(verdict.new_owners)} file(s) above are NOT on {_BASELINE_DISPLAY}, so this run "
+        f"fails. Install and remove each stub in the same try/finally, scoped to the nodes "
+        f"that need it — do not add a line to the baseline, it only shrinks. "
+        f"{_MODE_ENV}={_MODE_OFF} disables the guard for a local run.",
+        red=True,
     )
+
+
+def _write_fixed_owners(terminalreporter: object, verdict: _Verdict) -> None:
+    """The shrink-only rule: a listed file that no longer leaks must be delisted."""
+    for owner in verdict.fixed_owners:
+        terminalreporter.write_line(
+            f"FIXED: {owner} no longer leaks — remove it from {_BASELINE_DISPLAY}",
+            red=True,
+        )
+
+
+def _write_known_owners(terminalreporter: object, verdict: _Verdict, grouped: dict[str, list[dict]]) -> None:
+    """Known debt (#13361): listed, still leaking, and not a failure."""
+    if not verdict.known_owners:
+        return
+    keys = sum(len(grouped[owner]) for owner in verdict.known_owners)
+    terminalreporter.write_line(
+        f"{len(verdict.known_owners)} known leaking file(s), {keys} sys.modules key(s), all on "
+        f"{_BASELINE_DISPLAY} — not a failure. Fixing one means deleting its line (#13361)."
+    )
+    for owner in verdict.known_owners:
+        terminalreporter.write_line(f"      known: {owner} ({len(grouped[owner])} key(s))")
 
 
 def _write_owner_report(terminalreporter: object, owner: str, records: list[dict]) -> None:

--- a/repo_tests/sys_modules_leak_guard_session_test.py
+++ b/repo_tests/sys_modules_leak_guard_session_test.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
-"""Nested-session cover for the sys.modules leak guard (#13361).
+"""Nested-session cover for the sys.modules leak guard (#13361, #13398).
 
 The unit tests next door drive ``_LeakGuard`` directly.  That is fast and
 precise, but it cannot see any of the three defects review found in the first
@@ -16,8 +16,11 @@ than the classifier:
   the very pattern #13361 tells implementers to adopt — was already in place
   when the baseline snapshot was taken, and the guard reported nothing;
 * detection runs in xdist workers while reporting runs on the controller, so
-  ``AUTOBOT_SYSMODULES_GUARD=error`` was a no-op under ``-n``, which is the only
-  shape CI uses.
+  the exit-status gate was a no-op under ``-n``, which is the only shape CI uses.
+
+The baseline ratchet (#13398) is covered here for exactly the same reason: its
+three transitions are decided in ``pytest_sessionfinish`` from records that,
+under xdist, were produced in another process entirely.
 
 So these tests run real pytest sessions against a scratch repo.  Each builds a
 two-package tree — ``pkg_a`` leaks, ``pkg_b`` is the innocent importer — and
@@ -55,10 +58,36 @@ addopts = -p no:randomly
 # yes — see _resolves_on_disk.
 _VICTIM = "victim"
 
-_IMPORT_TIME_LEAK = f"""
-import sys, types
-sys.modules[{_VICTIM!r}] = types.ModuleType({_VICTIM!r})
-"""
+_BASELINE_FILE = "baseline.txt"
+
+
+def _import_time_leak(victim: str) -> str:
+    """A conftest that stubs *victim* at import time and never puts it back."""
+    return f"import sys, types\nsys.modules[{victim!r}] = types.ModuleType({victim!r})\n"
+
+
+def _restoring_hookwrapper(victim: str) -> str:
+    """The correct pattern: install and restore *victim* in one try/finally."""
+    return f"""
+        import sys, types
+        import pytest
+
+
+        @pytest.hookimpl(hookwrapper=True)
+        def pytest_make_collect_report(collector):
+            prior = sys.modules.get({victim!r})
+            sys.modules[{victim!r}] = types.ModuleType({victim!r})
+            try:
+                yield
+            finally:
+                if prior is None:
+                    sys.modules.pop({victim!r}, None)
+                else:
+                    sys.modules[{victim!r}] = prior
+    """
+
+
+_IMPORT_TIME_LEAK = _import_time_leak(_VICTIM)
 
 # The shape #13361 mandates: install and restore from a hookwrapper. This one
 # is deliberately buggy — it installs but never restores — which is precisely
@@ -101,17 +130,53 @@ def _write(path: Path, text: str) -> None:
     path.write_text(textwrap.dedent(text).lstrip(), encoding="utf-8")
 
 
+def _baseline(repo: Path, *owners: Path) -> None:
+    """Write the scratch repo's allowlist of owners that are allowed to leak.
+
+    Entries are absolute here only because the guard displays paths relative to
+    the *real* repo root, which a ``tmp_path`` scratch repo is outside of; the
+    checked-in baseline is a list of short repo-relative paths.
+    """
+    body = "".join(f"{owner.resolve()}\n" for owner in owners)
+    (repo / _BASELINE_FILE).write_text(f"# scratch-repo baseline\n\n{body}", encoding="utf-8")
+
+
+def _owners_on(stdout: str, marker: str) -> str:
+    """The owner each *marker* line blames, joined — one assertion target.
+
+    All three verdicts print inside one section, so "does pkg_a appear in the
+    output" is not a question worth asking.  Nor is "is pkg_a on a ``LEAK:``
+    line": that line also carries where the stub was first *seen*, which is a
+    sibling package by definition, so a whole-line substring test passes for
+    the innocent party too.  Every line puts the owner first, so the token
+    after the marker is the subject and nothing else is.
+    """
+    subjects = (line.split(marker, 1)[1] for line in stdout.splitlines() if marker in line)
+    return "\n".join(subject.strip().split(" ")[0] for subject in subjects)
+
+
 @pytest.fixture
 def scratch_repo(tmp_path: Path):
-    """Build a minimal two-package repo and return a factory for its conftest."""
+    """Build a minimal two-package repo and return a factory for its conftests."""
     _write(tmp_path / "pytest.ini", _PYTEST_INI)
     _write(tmp_path / "conftest.py", _ROOT_CONFTEST)
     _write(tmp_path / _VICTIM / "__init__.py", "REAL = True\n")
     for pkg in ("pkg_a", "pkg_b"):
         _write(tmp_path / pkg / f"test_{pkg}.py", "def test_ok():\n    assert True\n")
 
-    def seed(leak_source: str) -> Path:
+    def seed(leak_source: str, **extra_packages: str) -> Path:
+        """Write ``pkg_a``'s conftest, plus one package per ``name=source``.
+
+        Each extra package gets its own victim (``victim_pkg_c`` and friends):
+        two conftests stubbing the same key would both be attributed to
+        whichever installed it last, and the multi-owner tests need them told
+        apart.
+        """
         _write(tmp_path / "pkg_a" / "conftest.py", leak_source)
+        for pkg, source in extra_packages.items():
+            _write(tmp_path / pkg / f"test_{pkg}.py", "def test_ok():\n    assert True\n")
+            _write(tmp_path / pkg / "conftest.py", source)
+            _write(tmp_path / f"victim_{pkg}" / "__init__.py", "REAL = True\n")
         return tmp_path
 
     return seed
@@ -129,11 +194,17 @@ def _run_pytest(
     asyncio and friends on every one of these sessions — it keeps each test
     comfortably inside the suite's per-test budget.  ``xdist`` is re-enabled
     explicitly by the callers that need ``-n``.
+
+    The baseline is pointed at the scratch repo rather than left to default: a
+    child reading the checked-in one would be judging ``tmp_path`` owners
+    against ``autobot-backend`` entries.  The file is absent unless the test
+    wrote one, and an absent baseline allows nothing.
     """
     import os
 
     env = dict(os.environ)
     env.pop("AUTOBOT_SYSMODULES_GUARD", None)
+    env["AUTOBOT_SYSMODULES_BASELINE"] = str(cwd / _BASELINE_FILE)
     env["PYTEST_DISABLE_PLUGIN_AUTOLOAD"] = "1"
     env.update(env_extra or {})
     return subprocess.run(
@@ -185,24 +256,7 @@ def test_reports_a_hook_installed_leak_that_never_restores(scratch_repo):
 
 def test_stays_silent_when_the_hookwrapper_restores_properly(scratch_repo):
     """The correct pattern must not be reported — a noisy guard gets disabled."""
-    correct = f"""
-        import sys, types
-        import pytest
-
-
-        @pytest.hookimpl(hookwrapper=True)
-        def pytest_make_collect_report(collector):
-            prior = sys.modules.get({_VICTIM!r})
-            sys.modules[{_VICTIM!r}] = types.ModuleType({_VICTIM!r})
-            try:
-                yield
-            finally:
-                if prior is None:
-                    sys.modules.pop({_VICTIM!r}, None)
-                else:
-                    sys.modules[{_VICTIM!r}] = prior
-    """
-    result = _run_pytest(scratch_repo(correct))
+    result = _run_pytest(scratch_repo(_restoring_hookwrapper(_VICTIM)))
 
     assert "LEAK:" not in result.stdout, result.stdout
     assert result.returncode == 0
@@ -215,9 +269,9 @@ def test_stays_silent_when_the_leaking_package_is_the_whole_session(scratch_repo
     the stub never reaches a sibling and there is nothing to report.  Pytest
     still builds a ``Dir`` collector for every level from the rootdir down,
     including ``.``, and that node used to count as "outside ``pkg_a``/" —
-    which made every clean session fail under ``error`` mode and, because the
-    ancestor node always wins the per-``(key, owner)`` dedupe, replaced the
-    ``first seen at`` sibling with the meaningless ``the collection of .``.
+    which made every clean session fail the gate and, because the ancestor node
+    always wins the per-``(key, owner)`` dedupe, replaced the ``first seen at``
+    sibling with the meaningless ``the collection of .``.
     """
     result = _run_pytest(scratch_repo(_IMPORT_TIME_LEAK), targets=("pkg_a",))
 
@@ -260,6 +314,113 @@ def test_the_guard_does_not_widen_other_pytest_warnings(scratch_repo):
 
 
 # ---------------------------------------------------------------------------
+# #13398 — the shrink-only baseline: new fails, listed passes, fixed delists
+# ---------------------------------------------------------------------------
+
+
+def test_an_unlisted_leak_fails_the_run(scratch_repo):
+    """Transition 1: a leak nobody has signed off on is a regression.
+
+    This is the case the guard exists for and the one its predecessor could not
+    gate: ``report`` exited 0 on it, and ``error`` — which would have caught it
+    — could not be switched on while the known offenders stood.
+    """
+    repo = scratch_repo(_IMPORT_TIME_LEAK)
+    _baseline(repo)  # nothing is allowed to leak
+
+    result = _run_pytest(repo)
+
+    assert "pkg_a/conftest.py" in _owners_on(result.stdout, "LEAK:"), result.stdout
+    assert "NOT on" in result.stdout, result.stdout
+    assert result.returncode == 1, f"an unlisted leak must fail the run, got {result.returncode}"
+
+
+def test_a_listed_leak_is_reported_without_failing(scratch_repo):
+    """Transition 2: known debt stays green, and stays visible.
+
+    Failing on it would mean the gate could not be switched on until the last
+    of #13361's owners was fixed, which is how the previous design stalled.
+    Dressing it up as a regression is the other failure mode: a red block per
+    shard for something nobody is required to act on is how a guard becomes
+    wallpaper.
+    """
+    repo = scratch_repo(_IMPORT_TIME_LEAK)
+    _baseline(repo, repo / "pkg_a" / "conftest.py")
+
+    result = _run_pytest(repo)
+
+    assert "pkg_a/conftest.py" in _owners_on(result.stdout, "known: "), result.stdout
+    assert "LEAK:" not in result.stdout, "known debt must not be reported as a regression"
+    assert result.returncode == 0, result.stdout
+
+
+def test_a_listed_owner_that_no_longer_leaks_must_be_delisted(scratch_repo):
+    """Transition 3: the list only shrinks, so a fixed entry has to go.
+
+    ``pkg_a`` installs and restores properly here while still being listed.
+    Without this rule the baseline decays into a permanent allowlist and each
+    fix lands with nothing to show for it; with it, every fix comes with a
+    one-line deletion that proves the leak is gone.
+    """
+    repo = scratch_repo(_restoring_hookwrapper(_VICTIM))
+    _baseline(repo, repo / "pkg_a" / "conftest.py")
+
+    result = _run_pytest(repo)
+
+    assert "pkg_a/conftest.py" in _owners_on(result.stdout, "FIXED:"), result.stdout
+    assert "remove it from" in result.stdout, result.stdout
+    assert result.returncode == 1, f"a stale baseline entry must fail the run, got {result.returncode}"
+
+
+def test_a_listed_owner_is_not_delisted_by_a_run_that_never_leaves_it(scratch_repo):
+    """Silence only counts once the session gave the stub somewhere to escape to.
+
+    ``pytest pkg_a`` collects nothing outside ``pkg_a``, so the leak it still
+    has is invisible — and concluding "fixed" from that would fail every narrow
+    run in the tree.
+    """
+    repo = scratch_repo(_IMPORT_TIME_LEAK)
+    _baseline(repo, repo / "pkg_a" / "conftest.py")
+
+    result = _run_pytest(repo, targets=("pkg_a",))
+
+    assert "FIXED:" not in result.stdout, result.stdout
+    assert result.returncode == 0, result.stdout
+
+
+def test_a_run_phase_entry_is_never_asked_to_be_delisted(scratch_repo):
+    """A ``run-phase`` entry is exempt from the removal check, and must stay so.
+
+    Such an owner installs its stub while its own tests run, so the eleven CI
+    shards that collect the module without running any of it see nothing at
+    all.  Reading that silence as "fixed" would fail eleven shards over a leak
+    that is still there, so the annotation opts the entry out.  Modelled here
+    with a listed package that never leaks in this session.
+    """
+    repo = scratch_repo(_restoring_hookwrapper(_VICTIM))
+    owner = (repo / "pkg_a" / "conftest.py").resolve()
+    (repo / _BASELINE_FILE).write_text(f"{owner} run-phase\n", encoding="utf-8")
+
+    result = _run_pytest(repo)
+
+    assert "FIXED:" not in result.stdout, result.stdout
+    assert result.returncode == 0, result.stdout
+
+
+def test_an_unlisted_leak_still_fails_when_another_owner_is_listed(scratch_repo):
+    """One listed owner must not buy silence for an unlisted one."""
+    repo = scratch_repo(_IMPORT_TIME_LEAK, pkg_c=_import_time_leak("victim_pkg_c"))
+    _baseline(repo, repo / "pkg_a" / "conftest.py")
+
+    result = _run_pytest(repo, targets=("pkg_a", "pkg_b", "pkg_c"))
+
+    blamed = _owners_on(result.stdout, "LEAK:")
+    assert "pkg_c/conftest.py" in blamed, result.stdout
+    assert "pkg_a" not in blamed, result.stdout
+    assert result.returncode == 1
+
+
+# ---------------------------------------------------------------------------
 # G1 / G3 — the guard must survive xdist, and gate under it
 # ---------------------------------------------------------------------------
 
@@ -284,8 +445,8 @@ def test_a_leak_warning_does_not_crash_the_xdist_controller(scratch_repo):
     assert result.returncode != 3, "exit 3 means the session died before reporting"
 
 
-def test_error_mode_fails_the_run_under_xdist(scratch_repo):
-    """``AUTOBOT_SYSMODULES_GUARD=error`` must gate under ``-n``, not just serially.
+def test_an_unlisted_leak_fails_the_run_under_xdist(scratch_repo):
+    """The gate must hold under ``-n``, not just serially.
 
     Detection happens in the workers; the exit status and the terminal section
     are decided on the controller.  Without the worker->controller hand-off this
@@ -293,19 +454,45 @@ def test_error_mode_fails_the_run_under_xdist(scratch_repo):
     """
     _xdist_or_skip()
     repo = scratch_repo(_IMPORT_TIME_LEAK)
-    result = _run_pytest(
-        repo, "-p", "xdist", "-n", "2", "--dist", "loadscope", env_extra={"AUTOBOT_SYSMODULES_GUARD": "error"}
-    )
+    _baseline(repo)
+
+    result = _run_pytest(repo, "-p", "xdist", "-n", "2", "--dist", "loadscope")
 
     assert "LEAK:" in result.stdout, result.stdout
     assert result.returncode == 1, f"expected a failing exit status, got {result.returncode}"
 
 
-def test_error_mode_fails_the_run_serially(scratch_repo):
-    """The same gate, without xdist — the serial path must keep working."""
-    result = _run_pytest(scratch_repo(_IMPORT_TIME_LEAK), env_extra={"AUTOBOT_SYSMODULES_GUARD": "error"})
+def test_all_three_verdicts_hold_under_xdist(scratch_repo):
+    """The full three-way split in one ``-n 2 --dist loadscope`` session.
 
-    assert "LEAK:" in result.stdout, result.stdout
+    Every input arrives from another process here, and ``FIXED`` is the
+    delicate one: it is the *absence* of a record, so it can only be concluded
+    once the last worker has reported both what it saw and which listed owners
+    it took outside their own directory.
+    """
+    _xdist_or_skip()
+    repo = scratch_repo(
+        _IMPORT_TIME_LEAK,
+        pkg_c=_import_time_leak("victim_pkg_c"),
+        pkg_d=_restoring_hookwrapper("victim_pkg_d"),
+    )
+    _baseline(repo, repo / "pkg_a" / "conftest.py", repo / "pkg_d" / "conftest.py")
+
+    result = _run_pytest(
+        repo,
+        "-p",
+        "xdist",
+        "-n",
+        "2",
+        "--dist",
+        "loadscope",
+        targets=("pkg_a", "pkg_b", "pkg_c", "pkg_d"),
+    )
+
+    assert "pkg_c/conftest.py" in _owners_on(result.stdout, "LEAK:"), result.stdout
+    assert "pkg_a" not in _owners_on(result.stdout, "LEAK:"), result.stdout
+    assert "pkg_a/conftest.py" in _owners_on(result.stdout, "known: "), result.stdout
+    assert "pkg_d/conftest.py" in _owners_on(result.stdout, "FIXED:"), result.stdout
     assert result.returncode == 1
 
 

--- a/repo_tests/sys_modules_leak_guard_session_test.py
+++ b/repo_tests/sys_modules_leak_guard_session_test.py
@@ -330,9 +330,9 @@ def test_an_unlisted_leak_fails_the_run(scratch_repo):
 
     result = _run_pytest(repo)
 
+    assert result.returncode == 1, f"an unlisted leak must fail the run, got {result.returncode}"
     assert "pkg_a/conftest.py" in _owners_on(result.stdout, "LEAK:"), result.stdout
     assert "NOT on" in result.stdout, result.stdout
-    assert result.returncode == 1, f"an unlisted leak must fail the run, got {result.returncode}"
 
 
 def test_a_listed_leak_is_reported_without_failing(scratch_repo):
@@ -349,9 +349,9 @@ def test_a_listed_leak_is_reported_without_failing(scratch_repo):
 
     result = _run_pytest(repo)
 
-    assert "pkg_a/conftest.py" in _owners_on(result.stdout, "known: "), result.stdout
-    assert "LEAK:" not in result.stdout, "known debt must not be reported as a regression"
     assert result.returncode == 0, result.stdout
+    assert "LEAK:" not in result.stdout, "known debt must not be reported as a regression"
+    assert "pkg_a/conftest.py" in _owners_on(result.stdout, "known: "), result.stdout
 
 
 def test_a_listed_owner_that_no_longer_leaks_must_be_delisted(scratch_repo):
@@ -367,9 +367,9 @@ def test_a_listed_owner_that_no_longer_leaks_must_be_delisted(scratch_repo):
 
     result = _run_pytest(repo)
 
-    assert "pkg_a/conftest.py" in _owners_on(result.stdout, "FIXED:"), result.stdout
-    assert "remove it from" in result.stdout, result.stdout
     assert result.returncode == 1, f"a stale baseline entry must fail the run, got {result.returncode}"
+    assert "remove it from" in result.stdout, result.stdout
+    assert "pkg_a/conftest.py" in _owners_on(result.stdout, "FIXED:"), result.stdout
 
 
 def test_a_listed_owner_is_not_delisted_by_a_run_that_never_leaves_it(scratch_repo):
@@ -414,10 +414,10 @@ def test_an_unlisted_leak_still_fails_when_another_owner_is_listed(scratch_repo)
 
     result = _run_pytest(repo, targets=("pkg_a", "pkg_b", "pkg_c"))
 
+    assert result.returncode == 1, result.stdout
     blamed = _owners_on(result.stdout, "LEAK:")
     assert "pkg_c/conftest.py" in blamed, result.stdout
     assert "pkg_a" not in blamed, result.stdout
-    assert result.returncode == 1
 
 
 # ---------------------------------------------------------------------------
@@ -489,11 +489,11 @@ def test_all_three_verdicts_hold_under_xdist(scratch_repo):
         targets=("pkg_a", "pkg_b", "pkg_c", "pkg_d"),
     )
 
+    assert result.returncode == 1, result.stdout
     assert "pkg_c/conftest.py" in _owners_on(result.stdout, "LEAK:"), result.stdout
     assert "pkg_a" not in _owners_on(result.stdout, "LEAK:"), result.stdout
     assert "pkg_a/conftest.py" in _owners_on(result.stdout, "known: "), result.stdout
     assert "pkg_d/conftest.py" in _owners_on(result.stdout, "FIXED:"), result.stdout
-    assert result.returncode == 1
 
 
 def test_survives_a_session_without_pytest_xdist(scratch_repo):

--- a/repo_tests/sys_modules_leak_guard_test.py
+++ b/repo_tests/sys_modules_leak_guard_test.py
@@ -2,12 +2,17 @@
 # SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
-"""Unit cover for the repo-wide sys.modules leak guard (#13337).
+"""Unit cover for the repo-wide sys.modules leak guard (#13337, #13398).
 
 The guard's whole value is that it fires on a real leak and stays silent on
 everything else, so both halves are pinned here.  The classifier and the
 escape rule are exercised directly against a throwaway ``sys.modules`` — no
 nested pytest session, so every test finishes in milliseconds.
+
+The baseline ratchet is covered at both ends: the bookkeeping that decides
+whether a listed owner was given a chance to leak, and the verdict that turns
+that plus the leak records — the workers' included — into an exit status.  The
+end-to-end transitions live in the nested-session tests next door.
 """
 
 from __future__ import annotations
@@ -19,16 +24,21 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
-from repo_tests.sys_modules_leak_guard import _DISK_CACHE, _LeakGuard
+from repo_tests import sys_modules_leak_guard as guard_module
+from repo_tests.sys_modules_leak_guard import _DISK_CACHE, _Baseline, _LeakGuard, _load_baseline
 
 _ROOT = Path("/repo")
 _LLC_CONFTEST = _ROOT / "backend" / "llc" / "tests" / "conftest.py"
 _OTHER_MODULE = _ROOT / "backend" / "initialization" / "lifespan_test.py"
 
+# The same conftest as the guard displays it: repo-relative, the form a
+# baseline line holds.
+_LLC_OWNER = "backend/llc/tests/conftest.py"
+
 
 @pytest.fixture
-def guard(monkeypatch):
-    """A guard over an isolated ``sys.modules`` copy.
+def make_guard(monkeypatch):
+    """Build guards over an isolated ``sys.modules`` copy.
 
     ``_DISK_CACHE`` is pre-seeded so the tests never depend on what happens to
     be installed on the machine running them.
@@ -38,9 +48,19 @@ def guard(monkeypatch):
         "repo_tests.sys_modules_leak_guard._DISK_CACHE",
         dict(_DISK_CACHE, agents=True, autobot_shared=True, celery=True, knowledge=True, _sodium=False),
     )
-    instance = _LeakGuard(_ROOT)
-    instance.snapshot()
-    return instance
+
+    def build(removal_candidates: frozenset[str] = frozenset()) -> _LeakGuard:
+        instance = _LeakGuard(_ROOT, removal_candidates)
+        instance.snapshot()
+        return instance
+
+    return build
+
+
+@pytest.fixture
+def guard(make_guard):
+    """A guard with an empty baseline: nothing is listed, every leak is new."""
+    return make_guard()
 
 
 def _install(name: str, module: object) -> None:
@@ -236,3 +256,176 @@ def test_each_leak_is_reported_once_not_once_per_test(guard):
     _leaks_for(guard, _OTHER_MODULE.parent / "another_test.py")
 
     assert [leak.mutation.key for leak in guard.leaks] == ["agents"]
+
+
+# ---------------------------------------------------------------------------
+# The baseline ratchet: who may be asked to leave the list (#13398)
+# ---------------------------------------------------------------------------
+
+
+def test_a_listed_owner_taken_outside_its_directory_counts_as_exercised(make_guard):
+    """The evidence "this owner no longer leaks" is only collected here.
+
+    The conftest is loaded and installs nothing, and the session then imports a
+    sibling — the moment a stub would have been caught if there had been one.
+    """
+    guard = make_guard(frozenset({_LLC_OWNER}))
+    guard.attribute(_LLC_CONFTEST)
+
+    _leaks_for(guard, _OTHER_MODULE)
+
+    assert guard.exercised_owners() == {_LLC_OWNER}
+
+
+def test_a_listed_owner_is_not_exercised_by_its_own_subtree(make_guard):
+    """``pytest backend/llc/tests`` proves nothing about that directory's stubs."""
+    guard = make_guard(frozenset({_LLC_OWNER}))
+    guard.attribute(_LLC_CONFTEST)
+
+    _leaks_for(guard, _LLC_CONFTEST.parent / "test_something.py")
+
+    assert guard.exercised_owners() == set()
+
+
+def test_a_listed_owner_is_not_exercised_by_an_ancestor_directory(make_guard):
+    """A ``Dir`` collector above the owner imports nothing, so it sees nothing.
+
+    Pytest builds one for every level down to the rootdir on every session,
+    which would otherwise make every run claim every entry was removable.
+    """
+    guard = make_guard(frozenset({_LLC_OWNER}))
+    guard.attribute(_LLC_CONFTEST)
+
+    _leaks_for(guard, _ROOT)
+
+    assert guard.exercised_owners() == set()
+
+
+def test_an_owner_the_session_never_loaded_is_not_exercised(make_guard):
+    """``pytest repo_tests`` must conclude nothing about a backend conftest."""
+    guard = make_guard(frozenset({_LLC_OWNER}))
+
+    _leaks_for(guard, _OTHER_MODULE)
+
+    assert guard.exercised_owners() == set()
+
+
+def test_an_owner_that_is_not_listed_is_never_tracked_for_removal(make_guard):
+    """Only listed owners are watched — the rest are judged on their leaks."""
+    guard = make_guard(frozenset({"backend/other/conftest.py"}))
+    guard.attribute(_LLC_CONFTEST)
+
+    _leaks_for(guard, _OTHER_MODULE)
+
+    assert guard.exercised_owners() == set()
+
+
+def test_a_still_leaking_listed_owner_is_exercised_and_reported(make_guard):
+    """Both signals fire; it is the verdict's subtraction that keeps it listed."""
+    guard = make_guard(frozenset({_LLC_OWNER}))
+    _install("agents", types.ModuleType("agents"))
+    guard.attribute(_LLC_CONFTEST)
+
+    assert _leaks_for(guard, _OTHER_MODULE) == ["agents"]
+    assert guard.exercised_owners() == {_LLC_OWNER}
+
+
+# ---------------------------------------------------------------------------
+# Reading the file, and turning findings into a verdict
+# ---------------------------------------------------------------------------
+
+
+def test_the_baseline_file_ignores_comments_and_blank_lines(tmp_path):
+    """The file carries its own instructions, so comments have to be free."""
+    path = tmp_path / "baseline.txt"
+    path.write_text("# header\n\nbackend/conftest.py\n  backend/x/conftest.py  \n", encoding="utf-8")
+
+    baseline = _load_baseline(path)
+
+    assert baseline.owners == frozenset({"backend/conftest.py", "backend/x/conftest.py"})
+    assert baseline.removal_checked == baseline.owners
+
+
+def test_a_run_phase_entry_is_listed_but_never_checked_for_removal(tmp_path):
+    """It still cannot fail as new; it just cannot be delisted by a shard."""
+    path = tmp_path / "baseline.txt"
+    path.write_text("backend/a_test.py run-phase\nbackend/b_test.py\n", encoding="utf-8")
+
+    baseline = _load_baseline(path)
+
+    assert baseline.owners == frozenset({"backend/a_test.py", "backend/b_test.py"})
+    assert baseline.removal_checked == frozenset({"backend/b_test.py"})
+
+
+def test_a_missing_baseline_file_allows_nothing(tmp_path):
+    """A deleted or mistyped path must not quietly turn the gate into an allowlist."""
+    baseline = _load_baseline(tmp_path / "nope.txt")
+
+    assert baseline == _Baseline(frozenset(), frozenset())
+
+
+def _verdict_over(monkeypatch, listed, *, checked=None, leaking=(), exercised=()):
+    """Drive ``_verdict`` with worker-shaped input and no live guard."""
+    checked = listed if checked is None else checked
+    monkeypatch.setattr(guard_module, "_GUARD", None)
+    monkeypatch.setattr(guard_module, "_BASELINE", _Baseline(frozenset(listed), frozenset(checked)))
+    monkeypatch.setattr(guard_module, "_WORKER_RECORDS", [{"owner": owner} for owner in leaking])
+    monkeypatch.setattr(guard_module, "_WORKER_EXERCISED", set(exercised))
+    return guard_module._verdict()
+
+
+def test_an_unlisted_leak_is_a_regression(monkeypatch):
+    """The transition the previous report/error pair could not gate at all."""
+    verdict = _verdict_over(monkeypatch, listed={"a/conftest.py"}, leaking=("b/conftest.py",))
+
+    assert verdict.new_owners == ["b/conftest.py"]
+    assert verdict.failed
+
+
+def test_a_listed_leak_is_known_debt(monkeypatch):
+    """#13361's owners keep the suite green while they are worked through."""
+    verdict = _verdict_over(monkeypatch, listed={"a/conftest.py"}, leaking=("a/conftest.py",))
+
+    assert verdict.known_owners == ["a/conftest.py"]
+    assert not verdict.failed
+
+
+def test_a_listed_owner_that_was_exercised_and_stayed_silent_must_be_delisted(monkeypatch):
+    """Shrink-only: the fix and the deletion land together or not at all."""
+    verdict = _verdict_over(monkeypatch, listed={"a/conftest.py"}, exercised=("a/conftest.py",))
+
+    assert verdict.fixed_owners == ["a/conftest.py"]
+    assert verdict.failed
+
+
+def test_one_worker_meeting_the_stub_keeps_the_entry_for_every_other(monkeypatch):
+    """The xdist shape: exercised in one worker, caught leaking in another.
+
+    Each worker only sees its own share of the nodes, so a worker that met no
+    stub proves nothing on its own.  Deciding per worker would have deleted
+    entries that are still leaking — and under ``--dist loadscope``, which is
+    the only shape CI runs, there is always more than one.
+    """
+    verdict = _verdict_over(
+        monkeypatch,
+        listed={"a/conftest.py"},
+        leaking=("a/conftest.py",),
+        exercised=("a/conftest.py",),
+    )
+
+    assert verdict.fixed_owners == []
+    assert verdict.known_owners == ["a/conftest.py"]
+    assert not verdict.failed
+
+
+def test_a_run_phase_entry_is_exempt_from_the_removal_check(monkeypatch):
+    """Eleven of twelve CI shards never run such a module — silence means nothing."""
+    verdict = _verdict_over(
+        monkeypatch,
+        listed={"a_test.py"},
+        checked=set(),
+        exercised=("a_test.py",),
+    )
+
+    assert verdict.fixed_owners == []
+    assert not verdict.failed


### PR DESCRIPTION
## Thinking Path

`AUTOBOT_SYSMODULES_GUARD` had two settings and nothing between them: `report`
exited 0 whether it found 62 keys in one file or in eighteen, and `error` failed
on every pre-existing offender, so it could not be switched on until the last of
them was fixed. Neither gated a regression, which is the one thing the guard
exists to do — so a *new* leak landed green, and a full CI run printed 24 red
sections nobody was required to act on.

The fix is a checked-in baseline of the owners that leak today plus `error`
semantics for everything else, keyed on the **owner** (one conftest dragging 40
keys is one line), stored repo-relative and sorted. The third rule — a listed
owner that no longer leaks fails, asking to be delisted — is what keeps the list
from rotting into a permanent allowlist.

Two things that rule had to survive, neither of which is obvious:

* **A partial run proves nothing.** `pytest autobot-backend/api` never takes that
  tree's conftest stubs anywhere they could be seen. So an owner is only judged
  once the session has actually handled a node outside its directory, decided by
  the same escape rule leak detection uses (now a shared `_outside_owner_dir`).
* **A shard is a partial run.** CI splits the suite twelve ways. Nine owners
  install their stub while their *own tests run*, so eleven of those twelve
  shards collect the module, run none of it, see nothing — and under the rule
  above would each demand a deletion for a leak that is still there. Those
  entries carry a `run-phase` annotation and are exempt from the removal check.
  Verified against the extreme case: a session that collects all 22 701 tests and
  runs none reports 14 known owners, zero regressions, zero removals.

The `escapes_to` ancestor false positive is present and fixed in what this builds
on (`repo_tests/sys_modules_leak_guard.py:189-210` — `path in owner_ancestors`
returns False), so no phantom entries were baked in; `_display` now keeps
out-of-root paths absolute, since collapsing them to a basename made every
`conftest.py` one baseline key.

## What Changed

* `repo_tests/sys_modules_leak_baseline.txt` — **new**, 36 owners (9 `run-phase`),
  sorted, with the regeneration commands in its header.
* `repo_tests/sys_modules_leak_guard.py` — `report`/`error` replaced by the
  baseline verdict (`_Verdict`: new / known / fixed); `off` kept as the local
  escape hatch; `AUTOBOT_SYSMODULES_BASELINE` added for the guard's own tests;
  exercised-owner bookkeeping added to `_LeakGuard` and shipped worker→controller
  alongside the leak records; the terminal section is red only when the verdict
  fails.
* `repo_tests/sys_modules_leak_guard_test.py` — 14 unit tests added (bookkeeping,
  file parsing, verdict aggregation including the xdist union).
* `repo_tests/sys_modules_leak_guard_session_test.py` — 6 nested-session tests
  added, 2 renamed off the removed `error` mode.

Detection logic is untouched, and none of the pre-existing owners is fixed here
(that is #13361) or made to fail.

## Verification

**Baseline generation** — from real sessions, both invocation shapes CI uses
(pytest.ini forbids one combined session, #13084), each collect-only and in full:

| session | owners |
|---|---|
| `--collect-only` backend / shared / tts-worker / repo_tests | 14 |
| full run, same paths, `-n auto --dist loadscope` | 20 (14 + 6 run-phase) |
| `--collect-only autobot-slm-backend` | 13 |
| full run, `autobot-slm-backend` | 15-16 (13 + 3 run-phase) |

Union: 36. An owner the full run reports and the collect-only run of the same
tree does not is run-phase. Full runs were repeated across `-n auto`, `-n 4`,
`-n 2` and serial; that caught
`autobot-slm-backend/tests/api/test_nodes_list_timeout_10913.py`, which stayed
invisible for two full runs and then appeared in every one after — noted in the
baseline header as the one case where adding a line is legitimate.

**The baseline holds** (0 regressions, 0 removals demanded in every shape):

```
full backend, -n auto : 20 known leaking file(s), 122 key(s), all on the baseline
full backend, -n 4    : 20 known leaking file(s), 122 key(s), all on the baseline
full slm,     -n auto : 16 known leaking file(s),  24 key(s), all on the baseline
collect-all/run-none  : 14 known (backend) / 13 known (slm), no LEAK, no FIXED
```

**The three transitions, each with its negative control.** New tests run against
the pre-change guard (base `repo_tests/` + the new test file, `python3 -m pytest
repo_tests/sys_modules_leak_guard_session_test.py`):

| transition | test | against the pre-change guard |
|---|---|---|
| new owner fails | `test_an_unlisted_leak_fails_the_run` | FAILED — exit 0 in `report` mode |
| new owner fails under `-n` | `test_an_unlisted_leak_fails_the_run_under_xdist` | FAILED — exit 0 |
| listed owner passes | `test_a_listed_leak_is_reported_without_failing` | FAILED — printed `LEAK:` and no `known:` |
| listed-and-fixed fails | `test_a_listed_owner_that_no_longer_leaks_must_be_delisted` | FAILED — exit 0, no "remove it from" |
| all three at once, `-n 2` | `test_all_three_verdicts_hold_under_xdist` | FAILED — no `FIXED:`/`known:` lines |
| unlisted still fails beside a listed one | `test_an_unlisted_leak_still_fails_when_another_owner_is_listed` | FAILED — exit 0 |

`6 failed, 2 passed` — the two that pass pre-change assert an *absence*
(`test_a_listed_owner_is_not_delisted_by_a_run_that_never_leaves_it`,
`test_a_run_phase_entry_is_never_asked_to_be_delisted`), which a guard that never
fires satisfies trivially; they exist to pin the false-positive rules.

**xdist.** `test_all_three_verdicts_hold_under_xdist` runs `-n 2 --dist loadscope`
over four packages — one listed and leaking, one unlisted and leaking, one listed
and fixed — and asserts each lands on the right line and that the run exits 1.
`FIXED` is the delicate one: it is the absence of a record, so it can only be
concluded after the last worker reports both what it saw and which listed owners
it took outside their own directory.

**Suites.** `242 passed` for all of `repo_tests` (the 25 pre-existing guard tests
included — 23 unchanged, 2 renamed off the removed `error` mode with their
assertions intact), 45 for the two guard files, every test well under 1s. black /
isort / flake8 clean. One collection error in the local runs
(`autobot-backend/security/enterprise/threat_detection/test_learner.py`) is a
missing local `cachetools`, present on the base commit too.

Refs #13398

## Model Used

claude-opus-5
