### PR TITLE
ci(workflows): path-filter six non-required workflows to cut per-PR run count (#13388)

### DIFF
--- a/.github/workflows/ai-security-review.yml
+++ b/.github/workflows/ai-security-review.yml
@@ -26,6 +26,16 @@ name: AI Security Review
 on:
   pull_request:
     branches: [ main, Dev_new_gui ]
+    # #13388: SAFE — advisory only, never a required context (see header), so a
+    # run that never starts cannot block a merge. Mirrors the `reviewable` filter
+    # in `changes` below exactly; previously every docs-only pull request paid a
+    # checkout and a queue slot only to skip `review`. Keep the two lists in sync.
+    paths:
+      - 'autobot-backend/**/*.py'
+      - 'autobot-slm-backend/**/*.py'
+      - 'autobot_shared/**/*.py'
+      - 'ansible/**'
+      - '.github/workflows/ai-security-review.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,30 @@ on:
     # regressions were only discovered once already on the shared branch
     # (#10691). main kept for promotion PRs.
     branches: [ main, Dev_new_gui ]
+    # #13388: SAFE because this workflow publishes NO required status context.
+    # Branch protection on Dev_new_gui requires exactly ten contexts and none of
+    # them is produced here (`python-suite` is explicitly not one of them —
+    # #13162), so a run that is never created cannot leave a pull request waiting
+    # on a context that never reports. Any workflow here that DOES publish one of
+    # the ten deliberately has no `pull_request.paths` filter.
+    #
+    # This list is the exact UNION of the `python` and `frontend` filters in the
+    # `changes` job below, which together gate every job that does real work
+    # (`python-shard`, `python-suite`, `frontend-tests`; `deployment-check` is
+    # branch-gated to push and `notify` only summarises). So a pull request whose
+    # files match none of these already ran nothing but `changes` and `notify` —
+    # this filter removes the empty run itself, not any test coverage.
+    #
+    # Keep in sync with the `changes` job filters below: a pattern added there
+    # must be added here too, or the run that would evaluate it never starts.
+    paths:
+      - '**/*.py'
+      - '**/requirements*.txt'
+      - 'requirements-ci/**'
+      - 'pyproject.toml'
+      - 'autobot_shared/pyproject.toml'
+      - 'autobot-frontend/**'
+      - '.github/workflows/ci.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/hardened-smoke-test.yml
+++ b/.github/workflows/hardened-smoke-test.yml
@@ -11,6 +11,23 @@ on:
   pull_request:
     branches:
       - Dev_new_gui
+    # #13388: SAFE — this workflow publishes `hardened-smoke-test`, which is NOT
+    # one of the ten required contexts (the required `smoke-test` comes from
+    # docker-smoke-test.yml, which is deliberately left unfiltered).
+    #
+    # `paths-ignore` rather than `paths` ON PURPOSE. This job builds all three
+    # images and starts the hardened compose overlay, so almost any source,
+    # dependency, Dockerfile or compose edit can legitimately break it and an
+    # allow-list would eventually miss one. An ignore-list inverts the risk: the
+    # run still happens for everything except changes that are purely
+    # documentation, which cannot alter a container's runtime behaviour. GitHub
+    # skips the run only when EVERY changed file matches, so a pull request
+    # mixing docs with code still runs the full smoke test.
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '.claude/**'
+      - '.github/ISSUE_TEMPLATE/**'
   schedule:
     - cron: '0 11 * * 0'  # Every Sunday at 11 AM UTC (offset from regular smoke test)
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,6 +9,28 @@ on:
     branches: [ main, dev, Dev_new_gui ]
   pull_request:
     branches: [ main, Dev_new_gui ]  # Issue #6597: Semgrep blocks merge on all feature PRs
+    # #13388: SAFE — this workflow publishes no required status context (none of
+    # the ten on Dev_new_gui comes from here), so skipping the run cannot deadlock
+    # a pull request on a check that never reports.
+    #
+    # Exact UNION of the `python` and `deps` filters in `changes` below, which
+    # gate `dependency-security` and `static-analysis`. `compliance-check` is
+    # ungated but only greps the three backend package trees and writes counts to
+    # the step summary — it has no failure path, so losing it on a pull request
+    # that touches none of those trees removes no signal.
+    #
+    # The `schedule:` trigger below is NOT affected by path filters, so the daily
+    # full scan still covers everything unconditionally.
+    paths:
+      - 'autobot-backend/**/*.py'
+      - 'autobot-slm-backend/**/*.py'
+      - 'autobot_shared/**/*.py'
+      - '**/requirements*.txt'
+      - 'requirements-ci/**'
+      - 'pyproject.toml'
+      - 'autobot_shared/pyproject.toml'
+      - 'autobot-frontend/package*.json'
+      - '.github/workflows/security.yml'
   schedule:
     # Run security scans daily at 2 AM UTC
     - cron: '0 2 * * *'

--- a/.github/workflows/slm-frontend-check.yml
+++ b/.github/workflows/slm-frontend-check.yml
@@ -18,6 +18,14 @@ on:
       - '.github/workflows/slm-frontend-check.yml'
   pull_request:
     branches: [main, develop, 'Dev_*']
+    # #13388: SAFE — "SLM Frontend Check" is NOT one of the ten required contexts
+    # on Dev_new_gui, so this workflow may skip its run entirely. (The header note
+    # above about a path-filtered required check deadlocking a pull request is why
+    # the job-level self-skip exists; it applies to required contexts, and this is
+    # not one.) Mirrors the `slm_frontend` filter in `changes` below.
+    paths:
+      - 'autobot-slm-frontend/**'
+      - '.github/workflows/slm-frontend-check.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ssot-coverage.yml
+++ b/.github/workflows/ssot-coverage.yml
@@ -16,6 +16,18 @@ on:
     branches: [ main, Dev_new_gui, develop ]
   pull_request:
     branches: [ main, Dev_new_gui, develop ]
+    # #13388: SAFE — "SSOT Configuration Compliance" is not a required context.
+    # pipeline-scripts/detect-hardcoded-values.sh scans with
+    # `grep -rn --include="*.py" --include="*.ts" --include="*.vue"` and nothing
+    # else, so a pull request touching none of those three extensions cannot
+    # change the violation count this workflow reports. The script itself and this
+    # file are included because either can change the verdict.
+    paths:
+      - '**/*.py'
+      - '**/*.ts'
+      - '**/*.vue'
+      - 'pipeline-scripts/detect-hardcoded-values.sh'
+      - '.github/workflows/ssot-coverage.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Thinking Path

Refs #13388.

Inventoried all 57 workflows from parsed YAML: 41 trigger on `pull_request`, 16 never do. Cross-checked the ten required contexts against live branch protection (`gh api .../branches/Dev_new_gui/protection`) rather than trusting the issue text — they match exactly.

The inventory produced the decisive split. Eleven workflows publish the ten required contexts; the other thirty do not. Most of the required ones **already** gate their expensive job behind a `changes` job using `dorny/paths-filter`, so on a docs-only PR the heavy work is already skipped — what remains is the run wrapper itself. An event-level `paths:` on those is exactly the #13441 failure mode, and it would not even reduce run count, because a complementary skip-shim run must replace the filtered one. So they were left alone.

That leaves the non-required workflows, where an event filter deletes the run outright with no gate consequence. Six qualified.

One modelling correction worth recording, because it changed the plan: a job skipped by a false `if:` still publishes a `skipped` conclusion, which branch protection accepts. The deadlock happens only when the **workflow run is never created**, so the property to preserve is "every required context has at least one *created run* containing a job of that name" — not "the job executes".

## What Changed

Six workflows, none of which publishes a required context, gained a `pull_request` path filter. Each filter is the exact superset of what that workflow's own `changes` job already gates on, so no job that used to run stops running — only the empty run around it disappears.

| Workflow | Filter | Basis |
|---|---|---|
| `ci.yml` | `paths` | exact union of its own `python` + `frontend` filters; gates all 12 `python-suite` shards |
| `security.yml` | `paths` | exact union of its own `python` + `deps` filters; `schedule` trigger unaffected |
| `ai-security-review.yml` | `paths` | mirrors its `reviewable` filter |
| `slm-frontend-check.yml` | `paths` | mirrors its `slm_frontend` filter |
| `ssot-coverage.yml` | `paths` | the three extensions its detector actually greps |
| `hardened-smoke-test.yml` | `paths-ignore` | pure-documentation diffs only |

`hardened-smoke-test.yml` uses `paths-ignore` deliberately: it builds all three images and starts the hardened compose overlay, so an allow-list would eventually miss a legitimately affecting path. An ignore-list inverts that risk — it still runs for everything except diffs that are purely documentation, and GitHub skips only when *every* changed file matches, so a docs+code PR still runs it. It was also the only one of the six with no job-level gating at all, so it ran its full ~9-13 min build on every docs-only PR.

**Deliberately not filtered.** The eleven required-context publishers: `api-wiring`, `code-quality`, `docker-smoke-test`, `enforce-precommit`, `frontend-required-context`, `frontend-test`, `migration-gate`, `no-commit-trailers`, `pr-blocking-findings`, `startup-import-smoke`, `verify-generated-types`. Also untouched: `auto-update-pr-branches.yml` (out of scope), `ci-dispatch-watchdog` (infrastructure safety net), and the PR-metadata checks `pr-issue-validation` / `pr-template-check` / `pr-queue-gate` / `dependabot-retarget`, which inspect the PR itself rather than a diff, so a path filter is meaningless for them.

No `concurrency:` block was added, removed or altered anywhere (#13405, #13384). The diff is purely additive: 93 lines, all filters and their rationale.

## Verification

`yaml.safe_load` on all six, plus the repo's pinned `actionlint` v1.7.12:

```
Lint GitHub Actions workflow files.......................................Passed
```

**Required-context enumeration, from parsed YAML.** A simulator implementing GitHub's path-glob semantics (`*` not crossing `/`, `**` crossing, `!` negation last-match-wins) evaluates event filters, each workflow's `changes` job filters, and every job `if:`, then counts terminal conclusions per required context. Baseline validation: it reproduces the issue's measurement (25 runs on a backend-only synchronize).

All four scenarios, before and after:

```
diff <(before) <(after)
=== IDENTICAL: required-context conclusions unchanged in all 4 scenarios ===
```

Every one of the ten gets `conclusions>=1` (never a deadlock) and `executing<=1` (never a duplicate gate) for docs-only, backend-only, frontend-only and mixed. Sample, docs-only after:

```
[OK] Unit & Integration Tests    conclusions=2 executing=1  frontend-required-context::unit-tests-skip[runs], frontend-test::unit-tests[SKIPPED]
[OK] api-wiring                  conclusions=2 executing=1  api-wiring::api-wiring[SKIPPED], api-wiring::api-wiring-skip[runs]
[OK] migration-matrix            conclusions=1 executing=0  migration-gate::migration-matrix[SKIPPED]
[OK] smoke-test                  conclusions=1 executing=1  docker-smoke-test::smoke-test[runs]
```

Since no filtered workflow publishes a required context, the invariant holds by construction as well as by measurement.

**Run count per `synchronize`:**

| Scenario | Before | After |
|---|---|---|
| docs-only | 21 | **15** |
| frontend-only | 24 | **21** |
| backend-only | 25 | **24** |
| mixed | 27 | **26** |

**Honest assessment against the target.** The issue asked for under 10 on a docs-only PR; this reaches 15, and 15 is the floor for a path-filtering approach. Eleven of the residual runs are the required-context publishers, which cannot be event-filtered without either deadlocking the PR or swapping in an equal number of shim runs; the other four are PR-metadata checks with no diff to filter on. Going below 15 requires *consolidating* required contexts into fewer workflows — a restructure of the merge gate itself, which is a different and much riskier change than this one. Correctness of the gate outranks run count, so that is left for a follow-up rather than attempted here.

The wall-clock effect is larger than the run-count delta suggests, since the removed runs include the ones that actually did work on a docs-only PR (recent observed wall-clock: Hardened Smoke Test 9-13 min, CI/CD Pipeline 8-14 min, Security Scanning 4-11 min).

## Model Used

claude-opus-4-6-20260213
