### PR TITLE
test(backend): replace wall-clock threshold assertions with the properties they guard (#13399)

### DIFF
--- a/autobot-backend/api/knowledge_vectorization_test.py
+++ b/autobot-backend/api/knowledge_vectorization_test.py
@@ -226,26 +226,35 @@ class TestJobStatusPolling:
 
     @pytest.mark.asyncio
     async def test_poll_job_with_timeout(self, mock_knowledge_base):
-        """Test polling job with timeout mechanism"""
-        # Simulate job never completing
+        """Polling an unfinished job ends at the timeout deadline, not the poll cap.
+
+        #13399: the old assertion (``elapsed >= timeout_seconds``) timed the
+        test's own ``asyncio.sleep`` calls rather than the loop's exit
+        condition, and failed ``0.40 >= 2`` on a loaded runner. Its deadline
+        branch was also dead code -- ``max_polls`` was always reached first.
+        A virtual clock makes the deadline the only reachable exit.
+        """
         mock_knowledge_base.check_vectorization_job.return_value = {
             "status": "in_progress",
             "progress": 0.5,
         }
+        timeout_seconds = 2.0
+        poll_interval = 0.5
+        max_polls = 100  # High enough that only the deadline can end the loop.
+        now = 0.0
+        timed_out = False
 
-        start_time = datetime.now()
-        timeout_seconds = 2
-        max_polls = 5
-
-        for i in range(max_polls):
-            if (datetime.now() - start_time).total_seconds() > timeout_seconds:
+        for _ in range(max_polls):
+            if now > timeout_seconds:
+                timed_out = True
                 break
-
             await mock_knowledge_base.check_vectorization_job("vec_job_123")
-            await asyncio.sleep(0.5)
+            await asyncio.sleep(0)  # Yield to the loop without wall-clock cost.
+            now += poll_interval
 
-        elapsed = (datetime.now() - start_time).total_seconds()
-        assert elapsed >= timeout_seconds
+        assert timed_out, "polling exhausted max_polls instead of hitting the timeout"
+        expected_polls = int(timeout_seconds / poll_interval) + 1
+        assert mock_knowledge_base.check_vectorization_job.call_count == expected_polls
 
     @pytest.mark.asyncio
     async def test_poll_nonexistent_job(self, mock_knowledge_base):

--- a/autobot-backend/services/device_jwt_test.py
+++ b/autobot-backend/services/device_jwt_test.py
@@ -5,6 +5,7 @@
 """Tests for device JWT service (GH#9493)."""
 
 import os
+import time
 import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -238,35 +239,46 @@ class TestInvalidateDeviceCache:
 
 
 class TestConfigurationDefaults:
-    """Tests for configuration defaults and env var handling."""
+    """Tests for configuration defaults and env var handling.
 
-    def test_default_ttl_is_90_days(self, test_device):
+    The ``exp`` claim is a whole-second integer: ``floor(mint_time) + ttl``.
+    Bounding it by the whole seconds read either side of the mint call is
+    therefore exact, and needs no tolerance. The previous
+    ``abs(exp - time.time() - ttl) < 1`` compared a truncated int against a
+    float and failed (``1.000488 < 1``) whenever the mint landed late enough
+    in a second -- a threshold that was never true with margin (#13399).
+    """
+
+    def test_default_ttl_is_90_days(self, test_device, monkeypatch):
         """Should default to 90-day TTL."""
-        os.environ.pop("DEVICE_JWT_TTL_DAYS", None)
+        default_ttl_seconds = 90 * 24 * 3600
+        monkeypatch.delenv("DEVICE_JWT_TTL_DAYS", raising=False)
+        before = int(time.time())
         token = mint_device_jwt(
             device_id=test_device["device_id"],
             user_id=test_device["user_id"],
         )
+        after = int(time.time())
         claims = decode_jwt(token, os.environ["DEVICE_JWT_SECRET"])
-        # Verify exp is ~90 days in the future (allow 1 second tolerance)
-        import time
+        assert before + default_ttl_seconds <= claims["exp"] <= after + default_ttl_seconds
 
-        expected_exp = time.time() + (90 * 24 * 3600)
-        assert abs(claims["exp"] - expected_exp) < 1
+    def test_custom_ttl_from_env(self, test_device, monkeypatch):
+        """Should use custom TTL from DEVICE_JWT_TTL_DAYS.
 
-    def test_custom_ttl_from_env(self, test_device):
-        """Should use custom TTL from DEVICE_JWT_TTL_DAYS."""
-        os.environ["DEVICE_JWT_TTL_DAYS"] = "30"
+        ``monkeypatch`` (not a trailing ``os.environ.pop``) restores the var:
+        the old cleanup never ran when the assertion failed, leaking a 30-day
+        TTL into every later test in the session (#13399).
+        """
+        custom_ttl_seconds = 30 * 24 * 3600
+        monkeypatch.setenv("DEVICE_JWT_TTL_DAYS", "30")
+        before = int(time.time())
         token = mint_device_jwt(
             device_id=test_device["device_id"],
             user_id=test_device["user_id"],
         )
+        after = int(time.time())
         claims = decode_jwt(token, os.environ["DEVICE_JWT_SECRET"])
-        import time
-
-        expected_exp = time.time() + (30 * 24 * 3600)
-        assert abs(claims["exp"] - expected_exp) < 1
-        os.environ.pop("DEVICE_JWT_TTL_DAYS")
+        assert before + custom_ttl_seconds <= claims["exp"] <= after + custom_ttl_seconds
 
     def test_default_audience(self, test_device):
         """Should default to 'autobot:device' audience."""

--- a/autobot-backend/services/slm_client_test.py
+++ b/autobot-backend/services/slm_client_test.py
@@ -10,6 +10,7 @@ and service JWT minting (#9852).
 import os
 import ssl
 import tempfile
+import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -297,14 +298,19 @@ class TestMintServiceJwt:
         assert "exp" in payload
 
     def test_expiry_roughly_one_hour(self) -> None:
-        """Expiry is within ±5 s of _SERVICE_JWT_TTL_HOURS from now."""
-        import time
+        """exp is _SERVICE_JWT_TTL_HOURS after the mint, to the second.
 
+        Bounded by the whole seconds read either side of the mint rather than
+        an +-5 s tolerance on ``exp - time.time()``: exp is a whole-second
+        claim, so the bound is exact and a loaded runner cannot widen it
+        (#13399).
+        """
+        ttl_secs = int(_SERVICE_JWT_TTL_HOURS * 3600)
+        before = int(time.time())
         token = _mint_service_jwt(_TEST_SECRET)
+        after = int(time.time())
         payload = decode_jwt(token, secret=_TEST_SECRET)
-        expected_ttl_secs = _SERVICE_JWT_TTL_HOURS * 3600
-        actual_remaining = payload["exp"] - time.time()
-        assert abs(actual_remaining - expected_ttl_secs) < 5
+        assert before + ttl_secs <= payload["exp"] <= after + ttl_secs
 
     def test_wrong_secret_fails_decode(self) -> None:
         """Token minted with one secret cannot be decoded with another."""

--- a/autobot-backend/tests/services/test_run_jwt.py
+++ b/autobot-backend/tests/services/test_run_jwt.py
@@ -121,10 +121,17 @@ class TestMintRunJwt:
         monkeypatch.setenv("RUN_JWT_TTL_SECONDS", "60")
         from autobot_shared.auth.jwt_core import decode_jwt
 
+        # exp is a whole-second claim, so bounding it by the whole seconds read
+        # either side of the mint is exact -- unlike the previous 55..65 window
+        # on ``exp - time.time()``, which was a wall-clock budget (#13399).
+        ttl_secs = 60
+        before = int(time.time())
         token = mint_run_jwt(_RUN_ID, _TASK_ID, _AGENT_ID, _TENANT_ID, _SCOPE)
+        after = int(time.time())
         claims = decode_jwt(token, _SECRET, audience="autobot:run-validator")
-        remaining = claims["exp"] - time.time()
-        assert 55 <= remaining <= 65, f"expected ~60s TTL, got {remaining:.0f}s"
+        assert (
+            before + ttl_secs <= claims["exp"] <= after + ttl_secs
+        ), f"expected a {ttl_secs}s TTL, got exp={claims['exp']} against mint window {before}..{after}"
 
     def test_secret_key_not_accepted_as_fallback(self, monkeypatch, _no_audit):
         """SECRET_KEY must not be accepted as a signing secret for run JWTs."""


### PR DESCRIPTION
## Thinking Path

CI queue depth inflates wall-clock (measured: the same shard ran 82.49s quiet vs
132.55s loaded). A test that asserts a fixed time budget then fails for reasons
unrelated to the code, which trains people to re-run rather than read. The fix is
not "widen the number" — it is to ask what each test is actually trying to prove
and assert that instead.

Judged each instance separately:

| Test | What it was really trying to prove | Verdict |
|---|---|---|
| `test_poll_job_with_timeout` | a poll loop stops at its deadline | assertion was incidental **and** self-referential — it timed the test's own sleeps |
| `device_jwt` x2 | `exp` = mint + TTL | tolerance was papering over an int-vs-float comparison; an exact bound exists |
| `slm_client`, `test_run_jwt` | same `exp` = mint + TTL | same one-line judgement |
| `file_locking_test` 0.04s | different files don't serialise | **already fixed on base** — verified, not re-touched |

None of these are real performance properties, so none belongs behind the
`performance` marker. That marker is the right home for genuine budgets, and the
sweep below shows it is currently applied to none of them.

## What Changed

**`autobot-backend/api/knowledge_vectorization_test.py:228`** — asserted
`elapsed >= timeout_seconds` (failed `0.400344 >= 2`). Two defects: it measured
the sleeps the test itself performed rather than any behaviour, and its deadline
branch was dead code — 5 polls x 0.5s could never exceed the 2s deadline, so
`max_polls` always terminated the loop and the timeout path never ran. Now runs
on a virtual clock with `max_polls` raised out of the way, so the deadline is the
only reachable exit; asserts the loop exited *via the timeout* and polled exactly
`timeout/interval + 1` times. Side benefit: 2.5s of real sleeping removed.

**`autobot-backend/services/device_jwt_test.py:255,268`** — both TTL tests
asserted `abs(claims["exp"] - (time.time() + ttl)) < 1`. `exp` is a truncated
whole-second int and the expected value a float read *after* the mint, so the
difference approaches 1.0 as `frac(mint_time)` approaches 1 — the threshold was
never true with margin. `exp` is exactly `floor(mint) + ttl`, so bounding it by
the whole seconds read either side of the call is *exact* and needs no tolerance.

Also: `test_custom_ttl_from_env` cleaned up with a trailing `os.environ.pop`,
which never ran when the assertion failed — so every observed failure leaked
`DEVICE_JWT_TTL_DAYS=30` into the rest of the session. Now `monkeypatch`.

**`autobot-backend/services/slm_client_test.py:307`** (`+-5 s`) and
**`autobot-backend/tests/services/test_run_jwt.py:127`** (`55 <= remaining <= 65`)
carried the identical `exp`-vs-tolerance shape and get the identical exact bound.

**`autobot-backend/utils/file_locking_test.py:420`** (#13366) — **no change
needed.** The 0.04s budget was already replaced by a rendezvous-based
concurrency proof in 3726bc69f (#13340). Verified stable and still able to fail;
evidence below.

## Verification

**Control — the old assertion really does fail, the new one cannot.** 30,000
mints on this build, evaluating both forms against the same token:

```
mints: 30000
OLD  assert abs(exp - (time.time()+ttl)) < 1  -> failures: 10  (worst diff seen: 1.000443)
NEW  assert before+ttl <= exp <= after+ttl    -> failures: 0
```

The worst diff reproduces the reported `1.000488`. ~1-in-3000 per execution is
exactly a flake that shows up a few times across repeated full-suite runs.

**Repeat runs — 240 executions, 0 failures.** `pytest-repeat` is not installed
(no ad-hoc installs), so a shell loop was used. All 6 tests, 20 runs each:

```
=== QUIET  6 tests x 20 runs (120 executions): pass=20 fail=0 ===
=== LOADED 6 tests x 20 runs (120 executions): pass=20 fail=0 ===
```

The loaded pass ran under 44 bounded CPU burners on a 22-core box (2x
oversubscribed, `nice -n 19`, hard `timeout` so they self-terminate). Load
average went 4.65 -> 29.04; every run still passed. Burners confirmed cleaned up.

**Seeded breakages — every test still fails when its property is broken.**
Six seeds, five of them in *production* code:

| Seed | Result |
|---|---|
| `_DEFAULT_TTL_DAYS` 90 -> 89 | `E assert (1785799645 + 7776000) <= 1793489245` FAILED |
| `_ttl_days()` ignores `DEVICE_JWT_TTL_DAYS` | `E assert 1793575653 <= (1785799653 + 2592000)` FAILED |
| `exp` drifts by just **60 s** | both device_jwt tests FAILED (bound is tight) |
| vectorization deadline check disabled | `E AssertionError: polling exhausted max_polls instead of hitting the timeout` |
| poll interval halved | `E AssertionError: assert 9 == 5` |
| `expiry_hours` doubled at the mint call site | `E assert 1785807393 <= (1785800193 + 3600)` FAILED |
| `_ttl()` ignores `RUN_JWT_TTL_SECONDS` | `E AssertionError: expected a 60s TTL, got exp=... window ...` |
| **#13366** per-file locks collapsed to one shared lock | `E AssertionError: Writes to different files are serialized: only 1 of 5 per-file locks were held at the same time` |

All production files restored afterwards (`git status` clean apart from the four
test files).

**Affected files, full run:** `140 passed in 1.85s`. `ruff` clean, `black` clean.

### Repo-wide sweep

AST sweep for assertions comparing a **measured elapsed delta** (a subtraction of
two clock reads) against a numeric literal, across all `*_test.py` / `test_*.py`:

```
TRUE elapsed-vs-literal assertions: 73  |  on PR gate: 73  |  marker-excluded: 0
```

**The headline: zero of the 73 are behind a marker.** `pytest.ini` declares
`performance`, and `ci.yml` deselects `-m "not integration and not slow and not
distributed and not performance"`, with `marker-tests.yml` running the excluded
set on a schedule — but no wall-clock budget assertion carries it. Even
`system_benchmarks_performance_test.py` and `performance_benchmarks_test.py`,
named for it, sit on the PR gate.

Largest concentrations (file:line in the linked comment):

| Count | File |
|---|---|
| 8 | `system_benchmarks_performance_test.py` — **out of scope** here (#13162) |
| 5 | `tests/test_gateway_manager.py` (`elapsed_ms < 50` x5) |
| 5 | `tests/test_new_channel_adapters.py` |
| 4 | `knowledge/knowledge_base_integration_test.py` |
| 3 | `performance_benchmarks_test.py`, `security/security_integration_test.py` |
| 2 | `tests/coordination/test_shared_runtime_bag_integration.py` (50 ms SLA), `utils/concurrency_safety_test.py` (`< 0.05`), `tests/test_run_jwt_denylist_timeout.py` |

Fixed here: the 5 that were the same one-line judgement (all JWT `exp`-vs-literal).
**Not expanded into** — the remaining 68 are a real decision per test (genuine
budget -> mark `performance`; concurrency proxy -> rewrite as a rendezvous like
#13366's; timeout guard -> assert causality). `system_benchmarks_performance_test.py`
is explicitly excluded (pre-existing failures under #13162). Recommend one
follow-up issue for the marker gap, since it is a single systemic decision rather
than 68 independent ones.

Refs #13399, #13366

## Model Used

claude-opus-5
