### PR TITLE
test(infra): stop nine test modules leaking sys.modules stubs (#13361)

### DIFF
--- a/autobot-backend/services/npu_pipeline/test_dispatcher.py
+++ b/autobot-backend/services/npu_pipeline/test_dispatcher.py
@@ -18,6 +18,8 @@ import pytest
 # root conftest installs for services.npu_pipeline.*.
 _PKG_DIR = Path(__file__).parent
 
+_MISSING = object()
+
 
 def _load_module(name: str, filename: str):
     # Probe __dict__ rather than using hasattr: the root conftest's package
@@ -35,8 +37,37 @@ def _load_module(name: str, filename: str):
     return mod
 
 
-_shard_planner = _load_module("services.npu_pipeline.shard_planner", "shard_planner.py")
-_dispatcher_mod = _load_module("services.npu_pipeline.dispatcher", "dispatcher.py")
+def _load_real_modules():
+    """Real-load both modules, then hand ``sys.modules`` back untouched (#13361).
+
+    The registrations are needed only while the two files execute:
+    ``dispatcher.py`` resolves ``from services.npu_pipeline.shard_planner import
+    ShardAssignment`` at exec time, and the module object itself has to be in
+    ``sys.modules`` before its own body runs. Afterwards every symbol the tests
+    need is bound below, so keeping the entries buys nothing and costs the rest
+    of the session: they replaced the root conftest's package stubs for every
+    later-collected module, which is the escape #13361 tracks.
+    """
+    prior = {key: sys.modules.get(key, _MISSING) for key in _REAL_LOAD_KEYS}
+    try:
+        return (
+            _load_module("services.npu_pipeline.shard_planner", "shard_planner.py"),
+            _load_module("services.npu_pipeline.dispatcher", "dispatcher.py"),
+        )
+    finally:
+        for key, module in prior.items():
+            if module is _MISSING:
+                sys.modules.pop(key, None)
+            else:
+                sys.modules[key] = module
+
+
+_REAL_LOAD_KEYS = (
+    "services.npu_pipeline.shard_planner",
+    "services.npu_pipeline.dispatcher",
+)
+
+_shard_planner, _dispatcher_mod = _load_real_modules()
 
 LayerRange = _shard_planner.LayerRange
 ShardAssignment = _shard_planner.ShardAssignment

--- a/autobot-backend/services/npu_pipeline/test_dispatcher.py
+++ b/autobot-backend/services/npu_pipeline/test_dispatcher.py
@@ -20,6 +20,11 @@ _PKG_DIR = Path(__file__).parent
 
 _MISSING = object()
 
+_REAL_LOAD_KEYS = (
+    "services.npu_pipeline.shard_planner",
+    "services.npu_pipeline.dispatcher",
+)
+
 
 def _load_module(name: str, filename: str):
     # Probe __dict__ rather than using hasattr: the root conftest's package
@@ -61,11 +66,6 @@ def _load_real_modules():
             else:
                 sys.modules[key] = module
 
-
-_REAL_LOAD_KEYS = (
-    "services.npu_pipeline.shard_planner",
-    "services.npu_pipeline.dispatcher",
-)
 
 _shard_planner, _dispatcher_mod = _load_real_modules()
 

--- a/autobot-backend/tests/knowledge/search_components/reranking_staleness_test.py
+++ b/autobot-backend/tests/knowledge/search_components/reranking_staleness_test.py
@@ -28,6 +28,23 @@ from knowledge.search_components.reranking import (
 # =============================================================================
 
 
+def _staleness_propagator():
+    """Return the real ``staleness_propagator`` module for ``patch.object``.
+
+    #13361: ``patch("services.mesh_brain.staleness_propagator.get_staleness_score")``
+    is inert here. ``mock._importer`` walks the dotted path with ``getattr``
+    starting from ``sys.modules["services"]``, which the backend conftest
+    registers as a package stub with a catch-all ``__getattr__``; every step
+    therefore hands back a fresh throwaway mock and the patch lands on it
+    instead of on the module the code imports. Importing the leaf directly
+    bypasses the stub's ``__getattr__`` — the same ``_real_load_and_bind``
+    problem written up in ``tests/services/rag_service_events_test.py`` (#11248).
+    """
+    import services.mesh_brain.staleness_propagator as propagator  # noqa: PLC0415
+
+    return propagator
+
+
 def _make_result(chunk_id: str, score: float = 0.5, content: str = "text") -> dict:
     return {"chunk_id": chunk_id, "score": score, "content": content}
 
@@ -180,11 +197,23 @@ class TestFetchStalenessMap:
 
         mock_redis = AsyncMock()
 
-        # Patch at the source modules because _fetch_staleness_map uses lazy imports
+        # Patch at the source modules because _fetch_staleness_map uses lazy imports.
+        # #13361: the target is ``get_async_redis_client`` — the SYNC
+        # ``get_redis_client`` this used to name is not what the method calls, so
+        # the patch was inert and the real async client ran, reaching the
+        # configured Redis host. That only looked fine because two test modules
+        # in the sibling ``tests/knowledge`` directory rebound
+        # ``redis.asyncio.Redis`` to a ``MagicMock`` on the real module and never
+        # put it back; with those stubs gone the client spends its full retry
+        # budget and hands back nothing.
         with (
-            patch("autobot_shared.redis_client.get_redis_client", return_value=mock_redis),
             patch(
-                "services.mesh_brain.staleness_propagator.get_staleness_score",
+                "autobot_shared.redis_client.get_async_redis_client",
+                new=AsyncMock(return_value=mock_redis),
+            ),
+            patch.object(
+                _staleness_propagator(),
+                "get_staleness_score",
                 new=AsyncMock(side_effect=lambda r, doc_id: 0.7 if doc_id == "doc-A" else 0.0),
             ),
         ):
@@ -202,8 +231,8 @@ class TestFetchStalenessMap:
         weights = RerankWeights(staleness=0.3)
 
         with patch(
-            "autobot_shared.redis_client.get_redis_client",
-            side_effect=RuntimeError("Redis unavailable"),
+            "autobot_shared.redis_client.get_async_redis_client",
+            new=AsyncMock(side_effect=RuntimeError("Redis unavailable")),
         ):
             staleness_map = await reranker._fetch_staleness_map(results, weights)
 
@@ -226,9 +255,13 @@ class TestFetchStalenessMap:
         mock_redis = MagicMock()
 
         with (
-            patch("autobot_shared.redis_client.get_redis_client", return_value=mock_redis),
             patch(
-                "services.mesh_brain.staleness_propagator.get_staleness_score",
+                "autobot_shared.redis_client.get_async_redis_client",
+                new=AsyncMock(return_value=mock_redis),
+            ),
+            patch.object(
+                _staleness_propagator(),
+                "get_staleness_score",
                 side_effect=_fake_get_staleness,
             ),
         ):

--- a/autobot-backend/tests/knowledge/test_cleanup_endpoint.py
+++ b/autobot-backend/tests/knowledge/test_cleanup_endpoint.py
@@ -10,47 +10,34 @@ Verifies:
 - dry_run=False returns fixes_applied, issues_details=None
 - Empty KB returns zeroed counts
 
-Heavy dependencies (Redis, ChromaDB, llama_index) are stubbed via
-sys.modules patching so these tests run without a live backend.
+``knowledge.bulk`` is imported directly; it needs no stubbing (#13361).
 """
 
 from __future__ import annotations
 
 import json
-import sys
-import types
 from unittest.mock import MagicMock
 
 import pytest
 
-# ---------------------------------------------------------------------------
-# Stub heavy imports before pulling in knowledge.bulk
-# ---------------------------------------------------------------------------
+from knowledge.bulk import BulkOperationsMixin
 
-for _mod in (
-    "llama_index",
-    "llama_index.core",
-    "llama_index.vector_stores",
-    "llama_index.vector_stores.chroma",
-    "llama_index.llms",
-    "llama_index.llms.ollama",
-    "llama_index.embeddings",
-    "llama_index.embeddings.ollama",
-    "chromadb",
-    "redis",
-    "redis.asyncio",
-):
-    sys.modules.setdefault(_mod, types.ModuleType(_mod))
+# #13361: eleven ``sys.modules`` stubs used to stand here — the eight
+# ``llama_index.*`` names, ``chromadb``, ``redis`` and ``redis.asyncio`` — all
+# installed at import time and never removed, so they escaped into every module
+# collected after this one.  None of them was needed: ``knowledge/bulk.py``
+# imports only ``autobot_shared`` at module level and keeps ``redis``/``aioredis``
+# under ``if TYPE_CHECKING``, while all three packages are hard requirements and
+# therefore importable for real.
+#
+# The two lines after the stub loop were the damaging ones and no ``sys.modules``
+# guard could see them: ``setdefault`` returns the REAL ``redis`` module whenever
+# an earlier import already loaded it, and the code then rebound
+# ``redis.RedisError`` to bare ``Exception`` and ``redis.Redis`` /
+# ``redis.asyncio.Redis`` to ``MagicMock`` on that real module, permanently, for
+# every test in the session.  See the PR for the four provider tests whose
+# runtime silently depended on it.
 
-# Minimal stubs for symbols referenced at module load
-_redis_mod = sys.modules["redis"]
-_redis_mod.RedisError = Exception  # type: ignore[attr-defined]
-_redis_mod.Redis = MagicMock  # type: ignore[attr-defined]
-
-_aioredis_mod = sys.modules["redis.asyncio"]
-_aioredis_mod.Redis = MagicMock  # type: ignore[attr-defined]
-
-from knowledge.bulk import BulkOperationsMixin  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Fake composed KB that drives BulkOperationsMixin without a real Redis

--- a/autobot-backend/tests/knowledge/test_facts_dedup.py
+++ b/autobot-backend/tests/knowledge/test_facts_dedup.py
@@ -8,52 +8,26 @@ Tests for semantic duplicate guard on individual fact writes — Issue #3788.
 Verifies that store_fact() skips near-duplicate content above the configured
 threshold, allows content below threshold, and handles edge cases correctly.
 
-Heavy dependencies (llama_index, chromadb, aioredis, redis) are stubbed via
-sys.modules patching so the test suite can run without the full backend stack.
+No stubbing is needed: every module below imports for real (#13361).
 """
 
-import sys
-import types
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+import knowledge.facts as facts_module
 from knowledge.facts import FactsMixin
 from tests.helpers.fake_kb import FactsFakeKB
 
-# ---------------------------------------------------------------------------
-# Stub out heavy dependencies before importing knowledge.facts
-# ---------------------------------------------------------------------------
-
-_llama_core = types.ModuleType("llama_index.core")
-_llama_core.Document = MagicMock
-_llama_core.Settings = MagicMock()
-_llama_index = types.ModuleType("llama_index")
-
-sys.modules.setdefault("llama_index", _llama_index)
-sys.modules.setdefault("llama_index.core", _llama_core)
-sys.modules.setdefault("llama_index.vector_stores", types.ModuleType("llama_index.vector_stores"))
-sys.modules.setdefault("llama_index.vector_stores.chroma", types.ModuleType("llama_index.vector_stores.chroma"))
-sys.modules.setdefault("chromadb", types.ModuleType("chromadb"))
-sys.modules.setdefault("redis", types.ModuleType("redis"))
-sys.modules.setdefault("aioredis", types.ModuleType("aioredis"))
-
-# knowledge.utils is imported lazily inside _vectorize_fact_in_chromadb
-_knowledge_utils = types.ModuleType("knowledge.utils")
-_knowledge_utils.sanitize_metadata_for_chromadb = lambda m: m
-sys.modules.setdefault("knowledge.utils", _knowledge_utils)
-
-# services.content_fingerprint is imported lazily inside _prepare_fact_metadata
-_svc_fp = types.ModuleType("services.content_fingerprint")
-_svc_fp.compute_fingerprint = lambda c: "fp-test"
-sys.modules.setdefault("services.content_fingerprint", _svc_fp)
-
-# services.npu_client is imported lazily inside _get_npu_client_cached
-_svc_npu = types.ModuleType("services.npu_client")
-_svc_npu.get_npu_client = MagicMock()
-sys.modules.setdefault("services.npu_client", _svc_npu)
-
-import knowledge.facts as facts_module  # noqa: E402 — must follow sys.modules patches
+# #13361: a block of eleven ``sys.modules.setdefault`` stubs used to sit here —
+# llama_index.*, chromadb, redis, aioredis, knowledge.utils,
+# services.content_fingerprint, services.npu_client — installed at import time
+# and never removed. They never did anything for this file even before that:
+# ``from knowledge.facts import FactsMixin`` ran three lines ABOVE them, so the
+# import they claimed to protect had already completed. What they did do was
+# escape, and their owner only became visible once the identical block in
+# ``test_cleanup_endpoint.py`` (which sorts first and won the setdefault race)
+# was removed in this same change.
 
 _THRESHOLD = 0.92
 

--- a/autobot-backend/tests/knowledge/test_stats_dedup.py
+++ b/autobot-backend/tests/knowledge/test_stats_dedup.py
@@ -12,45 +12,26 @@ Tests:
 3. Core numbers emitted by both endpoints originate from the same dict, so they
    cannot drift independently.
 
-Heavy transitive deps (Redis, ChromaDB, llama_index, FastAPI request context)
-are stubbed via sys.modules and AsyncMock so no live infrastructure is needed.
+The FastAPI request context is an AsyncMock; nothing else needs standing in
+for, so no live infrastructure is required either (#13361).
 """
 
 from __future__ import annotations
 
-import sys
-import types
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-# ---------------------------------------------------------------------------
-# Stub heavy modules BEFORE any knowledge/* or api/* import
-# ---------------------------------------------------------------------------
+from services.knowledge.stats_service import fetch_kb_core_stats
 
-for _mod_name in (
-    "llama_index",
-    "llama_index.core",
-    "llama_index.vector_stores",
-    "llama_index.vector_stores.chroma",
-    "llama_index.llms",
-    "llama_index.llms.ollama",
-    "llama_index.embeddings",
-    "llama_index.embeddings.ollama",
-    "chromadb",
-    "redis",
-    "redis.asyncio",
-):
-    sys.modules.setdefault(_mod_name, types.ModuleType(_mod_name))
-
-# Redis stubs need concrete attributes
-_redis_mod = sys.modules["redis"]
-_redis_mod.RedisError = Exception  # type: ignore[attr-defined]
-_redis_mod.Redis = MagicMock  # type: ignore[attr-defined]
-_redis_mod.asyncio = sys.modules["redis.asyncio"]  # type: ignore[attr-defined]
-sys.modules["redis.asyncio"].Redis = MagicMock  # type: ignore[attr-defined]
-
-from services.knowledge.stats_service import fetch_kb_core_stats  # noqa: E402
+# #13361: eleven ``sys.modules.setdefault`` stubs used to precede this import —
+# the eight llama_index names, chromadb, redis and redis.asyncio — plus four
+# lines that rebound ``RedisError``/``Redis``/``asyncio`` on whatever object
+# ``setdefault`` handed back. That object is the REAL redis module whenever an
+# earlier import already loaded it, so those four lines silently replaced
+# ``redis.Redis`` and ``redis.asyncio.Redis`` with ``MagicMock`` for the whole
+# session — a mutation no sys.modules guard can see, and one other tests were
+# unknowingly relying on. ``stats_service`` needs none of it.
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/autobot-backend/tests/llm_interface_pkg/conftest.py
+++ b/autobot-backend/tests/llm_interface_pkg/conftest.py
@@ -1,0 +1,44 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Keep the provider unit tests in this package off the network (#13361).
+
+``BaseProvider.chat_completion`` takes a token from the cross-worker rate
+limiter (#8170) before every call, and that limiter reaches Redis.  The
+provider tests here drive fully mocked SDK clients and assert nothing about
+rate limiting, so whether Redis answers is none of their business — but until
+now it decided how long they took.
+
+They were fast only by accident.  ``tests/knowledge/test_cleanup_endpoint.py``
+rebound ``redis.Redis`` and ``redis.asyncio.Redis`` to ``MagicMock`` **on the
+real module objects** at import time and never put them back, so any session
+that collected it handed every later test an instantly-answering Redis.  With
+that gone (#13361) the four ``chat_completion`` tests in this package each
+spend the client's full connect-and-retry budget — measured at 30s apiece,
+120s per session — before the limiter gives up and allows the call.
+
+The fixture makes the limiter's Redis lookup fail immediately, which is the
+documented "Redis unavailable -> allow all" path of
+``LLMCrossWorkerRateLimiter``, not a bypass of it: ``acquire()`` and
+``try_acquire()`` run for real and the fallback they already implement is
+what answers.  Nothing is installed in ``sys.modules``, and ``monkeypatch``
+undoes the attribute at teardown, so this cannot become the next #13361.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def offline_llm_rate_limiter(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make the cross-worker rate limiter take its Redis-unavailable path."""
+
+    async def _no_redis(_self: object) -> None:
+        raise ConnectionError("Redis is deliberately unavailable in provider unit tests (#13361)")
+
+    monkeypatch.setattr(
+        "llm_shared.cross_worker_rate_limiter.LLMCrossWorkerRateLimiter._get_redis",
+        _no_redis,
+    )

--- a/autobot-backend/tests/llm_interface_pkg/test_anthropic_provider.py
+++ b/autobot-backend/tests/llm_interface_pkg/test_anthropic_provider.py
@@ -11,39 +11,13 @@ calls are made.
 
 from __future__ import annotations
 
-import sys
-import types
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-# ---------------------------------------------------------------------------
-# Minimal stubs so the module can be imported without the real anthropic SDK
-# or the full autobot runtime.
-# ---------------------------------------------------------------------------
-
-
-def _make_anthropic_stub():
-    """Return a minimal ``anthropic`` module stub."""
-    stub = types.ModuleType("anthropic")
-    stub.AsyncAnthropic = MagicMock
-    sys.modules["anthropic"] = stub
-    return stub
-
-
-def _make_xxhash_stub():
-    stub = types.ModuleType("xxhash")
-    stub.xxh64 = MagicMock(return_value=MagicMock(hexdigest=MagicMock(return_value="0" * 16)))
-    sys.modules["xxhash"] = stub
-
-
-_make_anthropic_stub()
-_make_xxhash_stub()
-
-
-from llm_shared.models import LLMRequest  # noqa: E402
-from llm_shared.providers.anthropic import (  # noqa: E402  (import after stub)
+from llm_shared.models import LLMRequest
+from llm_shared.providers.anthropic import (
     AnthropicProvider,
     _build_api_kwargs,
     _extract_content_pair,
@@ -51,6 +25,21 @@ from llm_shared.providers.anthropic import (  # noqa: E402  (import after stub)
     _extract_think_tag_content,
     _strip_think_blocks,
 )
+
+# #13361: this module used to install ``sys.modules`` stubs for ``anthropic``
+# and ``xxhash`` before the imports below, and never removed them.  Both are
+# hard requirements in ``autobot-backend/requirements.txt`` and therefore
+# always importable, so the stubs stood in for nothing — while leaking into
+# every later test in the session.  The ``xxhash`` one was the damaging half:
+# ``llm_shared/cache.py`` does a module-level ``import xxhash`` and keys the
+# LLM cache with ``xxhash.xxh64(...).hexdigest()``, and the stub answered every
+# input with the same 16 zeros, so any cache test collected afterwards scored
+# a hit on the first key it looked up.
+#
+# Nothing here needs either package at import time either: ``AnthropicProvider``
+# imports ``anthropic`` lazily inside ``_ensure_client()``, and every test below
+# assigns ``provider._client`` directly, so that branch never runs.
+
 
 # ---------------------------------------------------------------------------
 # _strip_think_blocks

--- a/autobot-backend/tests/llm_interface_pkg/test_groq_provider.py
+++ b/autobot-backend/tests/llm_interface_pkg/test_groq_provider.py
@@ -11,38 +11,22 @@ are made.
 
 from __future__ import annotations
 
-import sys
-import types
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-# ---------------------------------------------------------------------------
-# Minimal stubs so the module can be imported without the real groq SDK
-# or the full autobot runtime.
-# ---------------------------------------------------------------------------
+from llm_shared.models import LLMRequest
+from llm_shared.providers.groq import GroqProvider
 
+# #13361: the ``groq`` and ``xxhash`` ``sys.modules`` stubs this module used to
+# install at import time are gone, together with the leak they left behind.
+# Neither is reachable from the imports below — ``GroqProvider`` imports ``groq``
+# lazily inside ``_create_client()``, which no test here triggers because every
+# one assigns ``provider._client`` itself — and ``xxhash`` is a hard requirement
+# that is always importable.  The ``xxhash`` stand-in returned a constant digest
+# for every input, so leaving it live collapsed the LLM cache key space for
+# every test that ran afterwards in the same session.
 
-def _make_groq_stub():
-    """Return a minimal ``groq`` module stub."""
-    stub = types.ModuleType("groq")
-    stub.AsyncGroq = MagicMock
-    sys.modules["groq"] = stub
-    return stub
-
-
-def _make_xxhash_stub():
-    stub = types.ModuleType("xxhash")
-    stub.xxh64 = MagicMock(return_value=MagicMock(hexdigest=MagicMock(return_value="0" * 16)))
-    sys.modules["xxhash"] = stub
-
-
-_make_groq_stub()
-_make_xxhash_stub()
-
-
-from llm_shared.models import LLMRequest  # noqa: E402
-from llm_shared.providers.groq import GroqProvider  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/autobot-backend/tests/services/test_scheduler_registry.py
+++ b/autobot-backend/tests/services/test_scheduler_registry.py
@@ -17,11 +17,40 @@ from pathlib import Path
 # Import scheduler_registry directly to avoid services/__init__.py pulling in
 # ai_stack_client (which transitively imports autobot_shared modules that require
 # Python 3.11+ when using the | union syntax without 'from __future__ import annotations').
+#
+# #13361: the sys.modules registration below is bracketed by a try/finally so it
+# lasts exactly as long as the module body needs it.
 _REGISTRY_PATH = Path(__file__).parent.parent.parent / "services" / "scheduler_registry.py"
-_spec = importlib.util.spec_from_file_location("services.scheduler_registry", _REGISTRY_PATH)
-_mod = importlib.util.module_from_spec(_spec)  # type: ignore[arg-type]
-sys.modules["services.scheduler_registry"] = _mod  # register before exec so @dataclass resolves
-_spec.loader.exec_module(_mod)  # type: ignore[union-attr]
+_REGISTRY_KEY = "services.scheduler_registry"
+
+_MISSING = object()
+
+
+def _load_registry_module():
+    """Execute scheduler_registry.py and leave ``sys.modules`` as it was found.
+
+    The entry has to exist *while* the module executes — ``@dataclass`` resolves
+    ``ScheduledJob``'s annotations through ``sys.modules[__name__]`` — but not one
+    moment longer. Leaving it behind replaced whatever the backend conftest had
+    registered under this name for the rest of the session, which is the escape
+    #13361 is about; the module object this returns keeps working either way,
+    because every name the tests use is read off it directly below.
+    """
+    spec = importlib.util.spec_from_file_location(_REGISTRY_KEY, _REGISTRY_PATH)
+    mod = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+    prior = sys.modules.get(_REGISTRY_KEY, _MISSING)
+    sys.modules[_REGISTRY_KEY] = mod
+    try:
+        spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    finally:
+        if prior is _MISSING:
+            sys.modules.pop(_REGISTRY_KEY, None)
+        else:
+            sys.modules[_REGISTRY_KEY] = prior  # type: ignore[assignment]
+    return mod
+
+
+_mod = _load_registry_module()
 REGISTRY = _mod.REGISTRY
 ScheduledJob = _mod.ScheduledJob
 # GH#12836: pulled from the registry so the valid-runtime set and the

--- a/autobot_shared/jina_parser_test.py
+++ b/autobot_shared/jina_parser_test.py
@@ -53,24 +53,41 @@ def test_title_without_blank_separator_returns_full_content_as_body() -> None:
     assert body == raw
 
 
+def _reimport_source(key: str) -> str:
+    """Import *key* from scratch and return its source, restoring sys.modules.
+
+    #13361: the re-import is the point of the test — it proves the module loads
+    with nothing but the stdlib behind it — but the replacement module object it
+    leaves under *key* is not. Anything that already imported from the original
+    keeps a symbol the live module no longer owns, which is the identity split
+    that silently made ``mock.patch`` inert in #13162. Install and restore in the
+    same ``try/finally``, so the fresh import lasts exactly one statement.
+    """
+    import importlib  # noqa: PLC0415
+    import sys  # noqa: PLC0415
+
+    cached = sys.modules.pop(key, None)
+    try:
+        module = importlib.import_module(key)
+        with open(module.__file__, encoding="utf-8") as handle:
+            return handle.read()
+    finally:
+        if cached is not None:
+            sys.modules[key] = cached
+
+
 def test_extracted_module_has_zero_backend_dependencies() -> None:
     """The whole point of #7460: the parser must import without pulling in
     autobot-backend's heavy chain. This test imports
     ``autobot_shared.jina_parser`` in a fresh context and confirms its
     transitive imports are stdlib-only.
     """
-    import importlib
-    import sys
-
-    # Drop any cached version
-    sys.modules.pop("autobot_shared.jina_parser", None)
-    mod = importlib.import_module("autobot_shared.jina_parser")
-
     # The module's transitive imports should be stdlib-only.
     # (re, typing, __future__) — zero autobot-backend / autobot_shared deps
     # beyond the future-import. We assert by checking the module doesn't
     # import anything from media.link or knowledge.
-    src = open(mod.__file__, encoding="utf-8").read()  # noqa: SIM115
-    assert "from media.link" not in src
-    assert "from knowledge" not in src
-    assert "from autobot_shared" not in src  # no sibling cross-deps either
+    source = _reimport_source("autobot_shared.jina_parser")
+
+    assert "from media.link" not in source
+    assert "from knowledge" not in source
+    assert "from autobot_shared" not in source  # no sibling cross-deps either

--- a/autobot_shared/url_safety_test.py
+++ b/autobot_shared/url_safety_test.py
@@ -269,18 +269,36 @@ def test_host_matches_false(host: str, domain: str) -> None:
     assert host_matches(host, domain) is False
 
 
+def _reimport_source(key: str) -> str:
+    """Import *key* from scratch and return its source, restoring sys.modules.
+
+    #13361: the re-import is the point of the test — it proves the module loads
+    with nothing but the stdlib behind it — but the replacement module object it
+    leaves under *key* is not. Anything that already imported from the original
+    keeps a symbol the live module no longer owns, which is the identity split
+    that silently made ``mock.patch`` inert in #13162. Install and restore in the
+    same ``try/finally``, so the fresh import lasts exactly one statement.
+    """
+    import importlib  # noqa: PLC0415
+    import sys  # noqa: PLC0415
+
+    cached = sys.modules.pop(key, None)
+    try:
+        module = importlib.import_module(key)
+        with open(module.__file__, encoding="utf-8") as handle:
+            return handle.read()
+    finally:
+        if cached is not None:
+            sys.modules[key] = cached
+
+
 def test_module_has_zero_autobot_dependencies() -> None:
     """The extracted module must NOT import from ``media.link``,
     ``web_fetch``, or anywhere else inside autobot — that's the cycle-
     breaking contract."""
-    import importlib
-    import sys
+    source = _reimport_source("autobot_shared.url_safety")
 
-    sys.modules.pop("autobot_shared.url_safety", None)
-    mod = importlib.import_module("autobot_shared.url_safety")
-
-    src = open(mod.__file__, encoding="utf-8").read()  # noqa: SIM115
-    assert "from media" not in src
-    assert "from web_fetch" not in src
-    assert "from autobot_backend" not in src
-    assert "from autobot_shared" not in src  # no sibling cross-deps either
+    assert "from media" not in source
+    assert "from web_fetch" not in source
+    assert "from autobot_backend" not in source
+    assert "from autobot_shared" not in source  # no sibling cross-deps either

--- a/repo_tests/sys_modules_leak_baseline.txt
+++ b/repo_tests/sys_modules_leak_baseline.txt
@@ -56,15 +56,10 @@ autobot-backend/code_intelligence/conftest.py
 autobot-backend/conftest.py
 autobot-backend/knowledge/vector_search_engine_test.py
 autobot-backend/llm_shared/npu_pipeline_routing_test.py
-autobot-backend/services/npu_pipeline/test_dispatcher.py
 autobot-backend/tests/agents/test_causal_reasoning.py
-autobot-backend/tests/knowledge/test_cleanup_endpoint.py
-autobot-backend/tests/llm_interface_pkg/test_anthropic_provider.py
-autobot-backend/tests/llm_interface_pkg/test_groq_provider.py
 autobot-backend/tests/orchestration/test_causal_error_recovery.py
 autobot-backend/tests/search/conftest.py
 autobot-backend/tests/services/rag_service_events_test.py
-autobot-backend/tests/services/test_scheduler_registry.py
 autobot-backend/tests/test_conftest_real_load_identity.py run-phase
 autobot-backend/tests/test_tool_schema_correction.py
 autobot-backend/tests/test_vnc_mcp_async.py run-phase
@@ -86,5 +81,3 @@ autobot-slm-backend/tests/services/test_sso_vault_client.py
 autobot-slm-backend/tests/test_api_request_counter.py
 autobot-slm-backend/tests/test_prometheus_registry_endpoint.py run-phase
 autobot-slm-backend/user_management/services/sso_e2e_test.py run-phase
-autobot_shared/jina_parser_test.py run-phase
-autobot_shared/url_safety_test.py run-phase


### PR DESCRIPTION
## Thinking Path

`Refs #13361`.

#13361 lists 36 leaking owners. This PR takes one slice, chosen by a single rule:

> **a baseline owner that is a plain test module (never a conftest) whose `sys.modules` mutation is self-contained — a bootstrap it needs only while its own module body executes, or a pop-and-reimport one test needs only while it runs — so the fix lives inside the file itself: a `try/finally`, or deletion where the dependency it stood in for is a hard requirement that is always importable.**

That deliberately excludes the conftests and the "real-load over a parent-conftest stub" family, where deciding whether the real module or the stub owns the name afterwards is a design call, not a mechanical one. `autobot-backend/conftest.py` (61 keys) is out of scope by instruction and deserves its own change.

Two owners were not on the baseline and could not have been: `sys.modules.setdefault` is first-writer-wins, and `test_cleanup_endpoint.py` sorts first, so it owned the eight `llama_index.*` keys that `test_facts_dedup.py` and `test_stats_dedup.py` would otherwise have installed. Removing its block made them the owner and the guard failed the run until they were fixed too — the ratchet working exactly as designed.

## What Changed

**Removed outright** — the dependency stood in for is in `autobot-backend/requirements.txt` and imports for real, and nothing in the module's own import chain reaches it:

| Owner | Keys it leaked |
|---|---|
| `autobot-backend/tests/llm_interface_pkg/test_anthropic_provider.py` | `anthropic` |
| `autobot-backend/tests/llm_interface_pkg/test_groq_provider.py` | `xxhash` |
| `autobot-backend/tests/knowledge/test_cleanup_endpoint.py` | 8 × `llama_index.*` |
| `autobot-backend/tests/knowledge/test_facts_dedup.py` | 4 × `llama_index.*` |
| `autobot-backend/tests/knowledge/test_stats_dedup.py` | 4 × `llama_index.*` |

`knowledge/bulk.py` imports only `autobot_shared` at module level and keeps `redis`/`aioredis` under `TYPE_CHECKING`; `AnthropicProvider`/`GroqProvider` import their SDK lazily inside `_ensure_client`/`_create_client`, which no test reaches because every one assigns `provider._client` itself. `test_facts_dedup.py`'s block never did anything even before: `from knowledge.facts import FactsMixin` ran three lines *above* it.

**Bracketed in a `try/finally`** — the registration is needed only while the module body runs, and every symbol the tests use is bound off the returned object:

| Owner | Keys it leaked |
|---|---|
| `autobot-backend/services/npu_pipeline/test_dispatcher.py` | `services.npu_pipeline.shard_planner`, `.dispatcher` |
| `autobot-backend/tests/services/test_scheduler_registry.py` | `services.scheduler_registry` |
| `autobot_shared/jina_parser_test.py` | `autobot_shared.jina_parser` |
| `autobot_shared/url_safety_test.py` | `autobot_shared.url_safety` |

The last two pop a module and re-import it to prove it loads with nothing but the stdlib behind it. The re-import is the point of the test; the replacement object it left under the name was not.

**Seven baseline lines deleted.** The two dedup modules were never listed, so they have no line to delete.

### Three tests were passing for the wrong reason

`test_cleanup_endpoint.py` and `test_stats_dedup.py` did not only add `sys.modules` entries. They also ran

```python
_redis_mod = sys.modules["redis"]            # setdefault returns the REAL module
_redis_mod.RedisError = Exception            # ...if anything imported it first
_redis_mod.Redis = MagicMock
sys.modules["redis.asyncio"].Redis = MagicMock
```

That is an attribute mutation on a real module object. No `sys.modules` guard can see it, it was never restored, and two sibling suites were living off it:

* the four `chat_completion` tests in `tests/llm_interface_pkg/` — `BaseProvider.chat_completion` takes a token from the cross-worker rate limiter (#8170), which reaches Redis. Without the clobbered client each spends the full connect-and-retry budget: **30.10s apiece, 120s per session**. Fixed with `tests/llm_interface_pkg/conftest.py`, an autouse fixture that makes the limiter's Redis lookup fail immediately — its own documented "Redis unavailable → allow all" path, not a bypass: `acquire()` and `try_acquire()` still run for real.
* `tests/knowledge/search_components/reranking_staleness_test.py` — patched `autobot_shared.redis_client.get_redis_client`, but `_fetch_staleness_map` calls `get_async_redis_client`. The patch was inert; the real client ran and reached the configured host. Its second patch was inert too: `mock._importer` walks `services.mesh_brain.staleness_propagator` with `getattr` from the backend conftest's `services` package stub, whose catch-all `__getattr__` hands back a throwaway mock at every step, so `get_staleness_score` was never replaced and the real one answered `1.0`. Both targets corrected; the file goes from **1 failed in 30.8s** to **13 passed in 0.20s**.

The general form of the Redis half — the backend conftest's `autobot_shared.redis_client` stub is installed only `if ... not in sys.modules`, so whether unit tests open a socket depends on import order — is filed as **#13446** with measurements (`test_claim_verifier.py`: 121s for 56 tests on unmodified `Dev_new_gui`).

## Verification

Identical serial session on both sides — the nine owners plus `repo_tests/sys_modules_leak_guard_test.py` as an outside node, ordered so every owner has a node outside its own directory after it.

**Before** (`origin/Dev_new_gui`, clean worktree):

```
============================ sys.modules leak guard ============================
      known: autobot-backend/conftest.py (61 key(s))
      known: autobot-backend/services/npu_pipeline/test_dispatcher.py (2 key(s))
      known: autobot-backend/tests/knowledge/test_cleanup_endpoint.py (8 key(s))
      known: autobot-backend/tests/llm_interface_pkg/test_anthropic_provider.py (1 key(s))
      known: autobot-backend/tests/llm_interface_pkg/test_groq_provider.py (1 key(s))
      known: autobot-backend/tests/services/test_scheduler_registry.py (1 key(s))
      known: autobot_shared/jina_parser_test.py (1 key(s))
      known: autobot_shared/url_safety_test.py (1 key(s))
======================= 163 passed, 77 warnings in 2.65s =======================
```

**After** (this branch, same arguments):

```
============================ sys.modules leak guard ============================
      known: autobot-backend/conftest.py (61 key(s))
======================= 163 passed, 72 warnings in 2.81s =======================
```

Seven owners silent; only the out-of-scope conftest is left.

The two dedup modules are invisible in that shape (`test_cleanup_endpoint.py` wins the `setdefault` race), so they get their own pair, with an empty baseline so the keys print:

```
### BEFORE (base) — dedup pair, empty baseline
LEAK: autobot-backend/tests/knowledge/test_facts_dedup.py leaves 4 sys.modules key(s) installed outside autobot-backend/tests/knowledge/
      keys: llama_index, llama_index.core, llama_index.vector_stores, llama_index.vector_stores.chroma
LEAK: autobot-backend/tests/knowledge/test_stats_dedup.py leaves 4 sys.modules key(s) installed outside autobot-backend/tests/knowledge/
      keys: llama_index.llms, llama_index.llms.ollama, llama_index.embeddings, llama_index.embeddings.ollama
======================= 43 passed, 74 warnings in 1.54s ========================

### AFTER (branch), same arguments
LEAK: autobot-backend/conftest.py leaves 61 sys.modules key(s) …   (out of scope)
======================= 43 passed, 72 warnings in 1.60s ========================
```

**Guard suite** — `pytest -q -p no:randomly repo_tests`: `242 passed in 8.67s`.

**Every touched file in isolation** — proof that none of them depends on another module's stub, and none is over 10s:

```
autobot_shared/jina_parser_test.py                                6 passed in 0.13s
autobot_shared/url_safety_test.py                                39 passed in 0.46s
autobot-backend/services/npu_pipeline/test_dispatcher.py          5 passed in 0.66s
autobot-backend/tests/knowledge/test_cleanup_endpoint.py         10 passed in 0.71s
autobot-backend/tests/knowledge/test_facts_dedup.py               9 passed in 0.38s
autobot-backend/tests/knowledge/test_stats_dedup.py               6 passed in 2.34s
.../knowledge/search_components/reranking_staleness_test.py      13 passed in 0.22s
autobot-backend/tests/llm_interface_pkg/test_anthropic_provider.py  41 passed in 0.27s
autobot-backend/tests/llm_interface_pkg/test_groq_provider.py     8 passed in 0.23s
autobot-backend/tests/services/test_scheduler_registry.py        11 passed in 0.12s
```

**CI's shape** — `-n auto --dist loadscope`, markers excluded, over the touched trees:

```
pytest -q -p no:randomly -n auto --dist loadscope \
  -m "not integration and not slow and not distributed and not performance" \
  autobot-backend/tests/llm_interface_pkg autobot-backend/tests/services \
  autobot-backend/services/npu_pipeline autobot_shared repo_tests

============================ sys.modules leak guard ============================
2 known leaking file(s), 62 sys.modules key(s), all on the baseline — not a failure.
      known: autobot-backend/conftest.py (61 key(s))
      known: autobot-backend/tests/services/rag_service_events_test.py (1 key(s))
================ 2596 passed, 26 warnings in 179.13s (0:02:59) =================
```

The whole `tests/llm_interface_pkg/` package: **242 passed in 3.18s**, against 120s+ before.

## Model Used

Sonnet (claude-opus-5)