### PR TITLE
security(deps): close GHSA-52cp-r559-cp3m in slm-frontend + patch brace-expansion in both frontends (#12568)

### DIFF
--- a/autobot-frontend/package-lock.json
+++ b/autobot-frontend/package-lock.json
@@ -6086,16 +6086,16 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {

--- a/autobot-frontend/package.json
+++ b/autobot-frontend/package.json
@@ -86,6 +86,7 @@
   },
   "overrides": {
     "js-yaml": "4.3.0",
+    "brace-expansion": ">=5.0.9",
     "minimatch": ">=9.0.7",
     "uuid": "^14.0.0",
     "qs": ">=6.15.2",

--- a/autobot-slm-frontend/package-lock.json
+++ b/autobot-slm-frontend/package-lock.json
@@ -2007,9 +2007,9 @@
       "license": "MIT"
     },
     "node_modules/@redocly/openapi-core/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3989,16 +3989,16 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/bundle-name": {
@@ -4449,9 +4449,9 @@
       "license": "MIT"
     },
     "node_modules/editorconfig/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5089,9 +5089,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5517,9 +5517,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {

--- a/autobot-slm-frontend/package.json
+++ b/autobot-slm-frontend/package.json
@@ -35,6 +35,11 @@
     "vue-router": "^5.2.0"
   },
   "overrides": {
+    "js-yaml": "4.3.0",
+    "brace-expansion@5": ">=5.0.9",
+    "minimatch@<10": {
+      "brace-expansion": "2.1.4"
+    },
     "openapi-typescript": {
       "typescript": "$typescript"
     }


### PR DESCRIPTION
## Thinking Path

#12568 asked for `js-yaml >= 4.3.0` in `autobot-frontend`. That half already landed on `Dev_new_gui` (`overrides.js-yaml = 4.3.0`, lock at 4.3.0) — but the Dependabot alert for GHSA-52cp-r559-cp3m is **still open**, because it fires on `autobot-slm-frontend/package-lock.json`, which nobody touched. So the issue was never actually resolved repo-wide.

Regenerating the SLM lockfile surfaced a second **HIGH** in the same file, and then in `autobot-frontend` too: `brace-expansion` (GHSA-mh99-v99m-4gvg, GHSA-rgw5-rvv9-x895). Both advisories cover two release lines — `>=2.0.0 <2.1.4` and `>=4.0.0 <5.0.9` — and both frontends were inside them. Fixed in the same PR per Rule 6 (fix pre-existing issues discovered along the way, same PR when in-scope).

The `brace-expansion` fix needed care: a single top-level `>=5.0.9` override would drag `minimatch@5/@9` (which declare `^2.0.x`) across two majors onto a `type: module` package. In `autobot-slm-frontend` the sub-10 minimatch copies are therefore pinned to `2.1.4` via a scoped override; `autobot-frontend` already hoists `minimatch >=9.0.7` to `10.2.5` (which wants `^5`), so a plain top-level bump is correct and sufficient there.

Lockfiles were regenerated with npm 11 (node 24) to match CI's toolchain — npm 10 strips the `libc` metadata npm 11 emits and produced 400+ lines of unrelated churn.

## What Changed

`autobot-slm-frontend/package.json`
- `overrides.js-yaml = 4.3.0` — closes GHSA-52cp-r559-cp3m (Dependabot alert #1100)
- `overrides["brace-expansion@5"] = ">=5.0.9"`
- `overrides["minimatch@<10"].brace-expansion = "2.1.4"` — keeps the `^2.0.x` consumers on their own major

`autobot-frontend/package.json`
- `overrides["brace-expansion"] = ">=5.0.9"`

Both lockfiles regenerated. Resolutions after the change:

| package | autobot-frontend | autobot-slm-frontend |
|---|---|---|
| `js-yaml` | 4.3.0 (unchanged) | 4.2.0 → **4.3.0** |
| `brace-expansion` (root) | 5.0.7 → **5.0.9** | 5.0.7 → **5.0.9** |
| `brace-expansion` (under minimatch 5/9) | n/a | 2.1.2 → **2.1.4** |
| `minimatch` | 10.2.5 (unchanged) | 5.1.9 / 9.0.9 / 10.2.5 (unchanged) |

No production dependency changed version; every bump is a transitive dev-tree patch.

## Verification

```console
$ node -v && npm -v
v24.16.0
11.13.0

$ cd autobot-frontend && npm install --package-lock-only --ignore-scripts && npm audit
found 0 vulnerabilities
$ git diff --stat -- package-lock.json
 autobot-frontend/package-lock.json | 8 ++++----

$ cd ../autobot-slm-frontend && npm install --package-lock-only --ignore-scripts && npm audit
found 0 vulnerabilities
$ git diff --stat -- package-lock.json
 autobot-slm-frontend/package-lock.json | 32 ++++++++++++++++----------------
```

Before the change, `npm audit` reported `1 high severity vulnerability` in **each** frontend. Both are now clean, and the only version lines in either lock diff are the three packages in the table above.

Semver sanity check — no consumer is forced across a major it did not declare:

```console
$ node -e "…" # resolved tree, autobot-slm-frontend
node_modules/minimatch                            10.2.5  → brace-expansion ^5.0.5   → 5.0.9  ✓
node_modules/glob/node_modules/minimatch           9.0.9  → brace-expansion ^2.0.2   → 2.1.4  ✓
node_modules/editorconfig/node_modules/minimatch   9.0.9  → brace-expansion ^2.0.2   → 2.1.4  ✓
node_modules/@redocly/…/node_modules/minimatch     5.1.9  → brace-expansion ^2.0.1   → 2.1.4  ✓
```

Note: a stale `origin/issue-12568` branch survives from closed PR #12569; its content (the `autobot-frontend` js-yaml override) is already in `Dev_new_gui`, so this PR uses `issue-12568-frontend-deps` rather than reusing it.

Closes #12568

## Model Used

Opus 5 (1M context)
