### PR TITLE
fix(frontend): stop reading a stalled status poll as a fleet outage (#12866)

### DIFF
--- a/autobot-frontend/src/composables/__tests__/useSystemStatus.staleState.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useSystemStatus.staleState.test.ts
@@ -1,0 +1,144 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// GH#12866: a stalled status probe told the user nothing true.
+//
+// The panel replaced its eight service rows with three placeholders and the
+// text "Backend API — Unreachable", so a backend that was healthy and merely
+// GIL-starved for 12s presented as a fleet outage: Redis, Ollama, the NPU
+// worker and the AI stack all vanished from the list, and the one row left
+// asserted unreachability on a single-box deployment with no network to be
+// unreachable across.
+//
+// What the probe failure actually establishes is that the CURRENT state is
+// unknown. The last observed state is still the best information available, so
+// it is shown, stamped, and marked stale — never dropped, and never re-asserted
+// as live.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const fetchWithFallback = vi.fn()
+
+vi.mock('@/utils/ApiEndpointMapper.js', () => ({
+  default: { fetchWithFallback: (...a: unknown[]) => fetchWithFallback(...a) },
+}))
+vi.mock('@/utils/debugUtils', () => ({
+  createLogger: () => ({ warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() }),
+}))
+vi.mock('@/config/ssot-config', () => ({ getApiBase: () => '/api' }))
+vi.mock('@/composables/usePollingJob', () => ({
+  usePollingJob: () => ({ start: vi.fn(), stop: vi.fn() }),
+}))
+
+import { useSystemStatus } from '../useSystemStatus'
+
+const STALLED = new Error('timeout of 12000ms exceeded')
+
+function jsonOk(body: unknown) {
+  return { ok: true, status: 200, fallback: false, json: async () => body, text: async () => '' }
+}
+
+/** A healthy poll: two VMs from /vms/status, two services from /services. */
+function healthyFleet(url: string) {
+  if (url.includes('/vms/status')) {
+    return Promise.resolve(
+      jsonOk({
+        vms: [
+          { name: 'AI Stack (ChromaDB)', status: 'online', message: 'Running' },
+          { name: 'NPU Worker', status: 'online', message: 'Running' },
+        ],
+      }),
+    )
+  }
+  if (url.includes('/services')) {
+    return Promise.resolve(
+      jsonOk({ services: { redis: { status: 'healthy', health: 'Connected' } } }),
+    )
+  }
+  return Promise.resolve(jsonOk({ status: 'ok' }))
+}
+
+describe('useSystemStatus stale-state presentation (GH#12866)', () => {
+  beforeEach(() => {
+    fetchWithFallback.mockReset()
+  })
+
+  it('keeps the last observed services when a later poll stalls', async () => {
+    fetchWithFallback.mockImplementation((url: string) => healthyFleet(url))
+    const { refreshSystemStatus, systemServices } = useSystemStatus()
+    await refreshSystemStatus()
+
+    expect(systemServices.value.map((s) => s.name)).toEqual(
+      expect.arrayContaining(['AI Stack (ChromaDB)', 'NPU Worker', 'Redis']),
+    )
+
+    // Now the backend stalls: status probes time out, /api/health still answers.
+    fetchWithFallback.mockImplementation((url: string) =>
+      url.includes('/health') ? Promise.resolve(jsonOk({ status: 'ok' })) : Promise.reject(STALLED),
+    )
+    await refreshSystemStatus()
+
+    const names = systemServices.value.map((s) => s.name)
+    expect(names).toEqual(expect.arrayContaining(['AI Stack (ChromaDB)', 'NPU Worker', 'Redis']))
+  })
+
+  it('marks the retained rows as last-known rather than re-asserting them as live', async () => {
+    fetchWithFallback.mockImplementation((url: string) => healthyFleet(url))
+    const { refreshSystemStatus, systemServices } = useSystemStatus()
+    await refreshSystemStatus()
+
+    fetchWithFallback.mockImplementation((url: string) =>
+      url.includes('/health') ? Promise.resolve(jsonOk({ status: 'ok' })) : Promise.reject(STALLED),
+    )
+    await refreshSystemStatus()
+
+    const redis = systemServices.value.find((s) => s.name === 'Redis')
+    expect(redis?.statusText).toContain('last known')
+    // A green row from a previous poll must not read as a live green row.
+    expect(redis?.status).toBe('warning')
+  })
+
+  it('stamps the Backend API row with when the shown status was observed', async () => {
+    fetchWithFallback.mockImplementation((url: string) => healthyFleet(url))
+    const { refreshSystemStatus, systemServices } = useSystemStatus()
+    await refreshSystemStatus()
+
+    fetchWithFallback.mockImplementation((url: string) =>
+      url.includes('/health') ? Promise.resolve(jsonOk({ status: 'ok' })) : Promise.reject(STALLED),
+    )
+    await refreshSystemStatus()
+
+    const backend = systemServices.value.find((s) => s.name === 'Backend API')
+    expect(backend?.statusText).toContain('Degraded')
+    expect(backend?.statusText).toMatch(/status as of \d{1,2}[:.]\d{2}/)
+  })
+
+  it('omits the stamp on a first-ever poll, having observed nothing to stamp', async () => {
+    fetchWithFallback.mockImplementation((url: string) =>
+      url.includes('/health') ? Promise.resolve(jsonOk({ status: 'ok' })) : Promise.reject(STALLED),
+    )
+    const { refreshSystemStatus, systemServices } = useSystemStatus()
+    await refreshSystemStatus()
+
+    const backend = systemServices.value.find((s) => s.name === 'Backend API')
+    expect(backend?.statusText).toContain('Degraded')
+    expect(backend?.statusText).not.toContain('status as of')
+  })
+
+  it('does not resurrect a stale snapshot as if it were current once polls recover', async () => {
+    fetchWithFallback.mockImplementation((url: string) => healthyFleet(url))
+    const { refreshSystemStatus, systemServices } = useSystemStatus()
+    await refreshSystemStatus()
+
+    fetchWithFallback.mockImplementation((url: string) =>
+      url.includes('/health') ? Promise.resolve(jsonOk({ status: 'ok' })) : Promise.reject(STALLED),
+    )
+    await refreshSystemStatus()
+
+    fetchWithFallback.mockImplementation((url: string) => healthyFleet(url))
+    await refreshSystemStatus()
+
+    const redis = systemServices.value.find((s) => s.name === 'Redis')
+    expect(redis?.statusText).not.toContain('last known')
+    expect(redis?.status).toBe('healthy')
+  })
+})

--- a/autobot-frontend/src/composables/useSystemStatus.ts
+++ b/autobot-frontend/src/composables/useSystemStatus.ts
@@ -25,6 +25,18 @@ const STATUS_POLL_INTERVAL_MS = 15000
 // long budget here would just re-add the delay the status probes already hit.
 const BACKEND_HEALTH_TIMEOUT_MS = 3000
 
+// GH#12866: budget for the two service-monitor probes. Was 5000, which sat
+// *inside* the backend's measured latency distribution rather than above it:
+// 40 samples on an idle single-box host gave p50=0.85s but p90=12s, so 11/40
+// polls (27.5%) blew the budget while the backend was healthy and merely
+// GIL-starved. A budget below p90 does not measure reachability, it measures
+// whether a stall happened to be in progress.
+//
+// 12s clears the measured p90 and still lands inside the 15s poll cadence, so a
+// slow poll cannot overlap the next one. It is not a fix for the stalls — that
+// is the backend half of #12866 — only for reading them as an outage.
+const STATUS_PROBE_TIMEOUT_MS = 12000
+
 // ---------------------------------------------------------------------------
 // Types & Interfaces
 // ---------------------------------------------------------------------------
@@ -221,7 +233,7 @@ async function fetchVmStatus(): Promise<[SystemService[], boolean]> {
     const vmResponse =
       await apiEndpointMapper.fetchWithFallback(
         `${getApiBase()}/service-monitor/vms/status`,
-        { timeout: 5000 },
+        { timeout: STATUS_PROBE_TIMEOUT_MS },
       ) as FallbackResponse
     const vmData: VmStatusResponse = await vmResponse.json()
 
@@ -271,7 +283,7 @@ async function fetchServiceStatus(): Promise<[SystemService[], boolean]> {
     const resp =
       await apiEndpointMapper.fetchWithFallback(
         `${getApiBase()}/service-monitor/services`,
-        { timeout: 5000 },
+        { timeout: STATUS_PROBE_TIMEOUT_MS },
       ) as FallbackResponse
     const data: ServicesResponse = await resp.json()
 
@@ -300,6 +312,47 @@ async function fetchServiceStatus(): Promise<[SystemService[], boolean]> {
   }
 
   return [services, hadError]
+}
+
+// ---------------------------------------------------------------------------
+// Helper: stale-state presentation (GH#12866)
+// ---------------------------------------------------------------------------
+
+/** `HH:MM` in the viewer's locale, for the "as of" stamp. */
+function asOf(at: Date): string {
+  return at.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+}
+
+/**
+ * Wording for the Backend API row when a status probe failed.
+ *
+ * GH#12866: the original text asserted unreachability for every probe failure.
+ * On a single-box deployment there is no network to be unreachable across, so
+ * that reading was not merely imprecise, it was wrong — the honest states are
+ * "slow" and "stale", and only a failed /api/health means "down".
+ */
+function describeProbeFailure(reachable: boolean, at: Date | null): string {
+  const stamp = at ? ` — status as of ${asOf(at)}` : ''
+  return reachable
+    ? `Degraded — status checks timed out, backend responding${stamp}`
+    : `Unreachable — service status unknown${stamp}`
+}
+
+/**
+ * The last observed rows, re-labelled as stale rather than re-asserted as current.
+ *
+ * Status is downgraded to `warning` because a green row from four minutes ago
+ * must not read as a live green row; the text carries the reason.
+ */
+function staleCopyOf(previous: SystemService[] | null): SystemService[] {
+  if (!previous) return []
+  return previous
+    .filter((s) => s.name !== 'Backend API' && s.name !== 'Frontend' && s.name !== 'WebSocket')
+    .map((s) => ({
+      name: s.name,
+      status: 'warning' as const,
+      statusText: `${s.statusText} (last known)`,
+    }))
 }
 
 // ---------------------------------------------------------------------------
@@ -343,6 +396,14 @@ export function useSystemStatus(): UseSystemStatusReturn {
   const systemServices = ref<SystemService[]>([...DEFAULT_SERVICES])
 
   const showSystemStatus = ref(false)
+
+  // GH#12866: the last per-service snapshot that came from a successful poll,
+  // and when it was taken. A stalled probe means the current state is UNKNOWN,
+  // not that seven services went down — so the panel keeps showing what it last
+  // actually observed, stamped, instead of replacing eight rows with three
+  // placeholders that read as "everything else disappeared".
+  const lastGoodServices = ref<SystemService[] | null>(null)
+  const lastGoodAt = ref<Date | null>(null)
 
   // ---- Computed-like getters ----
 
@@ -422,10 +483,13 @@ export function useSystemStatus(): UseSystemStatusReturn {
           {
             name: 'Backend API',
             status: 'warning',
-            statusText: reachable
-              ? 'Degraded — status checks timed out, backend responding'
-              : 'Unreachable — service status unknown',
+            statusText: describeProbeFailure(reachable, lastGoodAt.value),
           },
+          // GH#12866: keep the last observed rows rather than dropping to a
+          // three-row placeholder. The probe failing says nothing about Redis,
+          // Ollama or the NPU worker — their state is simply as of the stamp
+          // above. Dropping them made a slow poll look like a fleet outage.
+          ...staleCopyOf(lastGoodServices.value),
           { name: 'Frontend', status: 'healthy', statusText: 'Connected' },
           { name: 'WebSocket', status: 'healthy', statusText: 'Connected' },
         ]
@@ -449,6 +513,11 @@ export function useSystemStatus(): UseSystemStatusReturn {
       ]
 
       systemServices.value = deduplicateServices(combined)
+
+      // GH#12866: this poll actually observed the fleet — remember it, so the
+      // next stalled poll can show it stamped instead of showing nothing.
+      lastGoodServices.value = systemServices.value.map((s) => ({ ...s }))
+      lastGoodAt.value = new Date()
 
       const hasErrors = systemServices.value.some(
         (s) => s.status === 'error',


### PR DESCRIPTION
## Thinking Path

#12866 has two independent halves: the backend stalls (a GIL-bound scan starving the event loop), and the GUI's reading of those stalls as an outage. This PR closes the second. The first is an architecture decision and is asked on the issue.

Part of the frontend half already landed — `isBackendReachable()` confirms against `/api/health`, so a stalled probe reports "Degraded" rather than "Unreachable". Two of the issue's proposals were still open, and they turn out to be the ones the user actually sees.

**The probe budget was inside the latency distribution, not above it.** 5000 ms against a measured p50 of 0.85 s but p90 of 12 s means the budget was not measuring reachability — it was sampling whether a stall happened to be in progress, which is why 27.5% of polls tripped it on a healthy box.

**The bigger problem was what the panel did next.** On any probe failure it replaced its eight rows with three placeholders. Redis, Ollama, the NPU worker and the AI stack did not go amber — they *disappeared*, and the single row left behind asserted unreachability. On a single-box deployment there is no network to be unreachable across, so the panel was showing a fleet outage that could not physically have happened. A probe timeout establishes exactly one thing: the current state is unknown. The last observed state is still the best information available.

## What Changed

`autobot-frontend/src/composables/useSystemStatus.ts`

- `STATUS_PROBE_TIMEOUT_MS = 12000` replaces two hardcoded `timeout: 5000`. Clears the measured p90 and stays inside the 15 s poll cadence, so a slow poll cannot overlap its successor.
- `lastGoodServices` / `lastGoodAt` — the last snapshot from a poll that actually observed the fleet.
- On probe failure the panel now shows those rows, downgraded to `warning` and suffixed `(last known)`, with the Backend API row stamped `— status as of HH:MM`. A green row from four minutes ago must not render as a live green row, and it must not vanish either.
- `describeProbeFailure()` / `staleCopyOf()` — the stale-presentation rules, isolated and unit-testable.
- No stamp on a first-ever poll: there is nothing observed to stamp, and inventing one would be a lie about a state never seen.

`useSystemStatus.staleState.test.ts` (new, 5 tests) covers: retention across a stall, stale labelling, the stamp format, the no-history case, and — the one that matters most — that a recovered poll drops the stale snapshot instead of leaving it on screen as if current.

## Verification

```console
$ npx vitest run src/composables/__tests__/useSystemStatus.staleState.test.ts \
                src/composables/__tests__/useSystemStatus.reachability.test.ts
 ✓ useSystemStatus.reachability.test.ts (4 tests)
 ✓ useSystemStatus.staleState.test.ts   (5 tests)
 Test Files  2 passed (2)
      Tests  9 passed (9)

$ npx eslint src/composables/useSystemStatus.ts \
             src/composables/__tests__/useSystemStatus.staleState.test.ts
(no output)

$ npx vue-tsc --noEmit -p tsconfig.json | grep useSystemStatus
(no output)
```

The four pre-existing reachability tests still pass unchanged, so the Degraded-vs-Unreachable distinction is intact.

## Scope not delivered

The backend half — proposals 1 and 4 on the issue — is **not** in this PR and #12866 stays open.

Proposal 1 (get CPU-bound analysis out of the API process) is larger than the issue's wording suggests. `run_security_analysis` is already wired for `GET /security/score`, but seven further endpoints still run a whole-tree scan on the request path: `POST /security/analyze`, `GET /security/report`, `POST /performance/analyze`, `GET /performance/score`, `GET /performance/report`, `POST /analyze`, `GET /health-score`. Only the security one has a Celery task; the rest would need new ones, and each conversion turns a synchronous findings response into enqueue-and-poll — a contract change for `useCodeIntelScores.ts`. The alternative the issue's own diagnosis points at ("`asyncio.to_thread` is not a substitute for a separate process") is a process pool, which fixes all eight sites at once with no contract change, but `analyze_directory` mutates `self.results` / `self.total_files_scanned` that `get_summary()` then reads, so it needs those returned and assigned back across the process boundary.

Proposal 4 (`--workers > 1`) is gated on the backend's in-process WebSocket connection state.

Both are asked on the issue. This PR deliberately does not pick one.

Refs #12866

## Model Used

Opus 5 (1M context)
