### PR TITLE
test(sys-modules): scope six leaking stub owners the baseline never saw (#13450)

### DIFF
--- a/autobot-backend/llm_shared/structured_ops_test.py
+++ b/autobot-backend/llm_shared/structured_ops_test.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import json
 import sys
+import types
 from contextlib import contextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -46,6 +47,21 @@ def _mock_llm_service(return_values: list[str]) -> MagicMock:
     responses = [_make_llm_response(v) for v in return_values]
     svc.chat = AsyncMock(side_effect=responses)
     return svc
+
+
+def _stub_semantic_chunker(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
+    """Return the module ``extract()``'s local ``get_semantic_chunker`` import resolves to.
+
+    The real ``utils.semantic_chunker`` drags sentence-transformers in, so a
+    hollow stand-in answers for it when it is absent.  ``monkeypatch.setitem``
+    owns the removal: a bare assignment left the stand-in — and the hollow
+    ``utils`` package under it — shadowing the real on-disk packages for every
+    node the session handled afterwards (#13450).
+    """
+    for name in ("utils", "utils.semantic_chunker"):
+        if name not in sys.modules:
+            monkeypatch.setitem(sys.modules, name, types.ModuleType(name))
+    return sys.modules["utils.semantic_chunker"]
 
 
 @contextmanager
@@ -369,7 +385,7 @@ async def test_validation_error_triggers_retry() -> None:
 
 
 @pytest.mark.asyncio
-async def test_chunk_merge_combines_fields() -> None:
+async def test_chunk_merge_combines_fields(monkeypatch: pytest.MonkeyPatch) -> None:
     """Oversized input is split; per-chunk dicts are merged (last-non-null wins)."""
     from .structured_ops import extract
 
@@ -393,34 +409,19 @@ async def test_chunk_merge_combines_fields() -> None:
     fake_chunker.chunk_text = AsyncMock(return_value=[chunk_a, chunk_b])
 
     ops_mod = sys.modules["llm_shared.structured_ops"]
-    # get_semantic_chunker is a local import inside extract(); ensure the stub
-    # module exists in sys.modules then set the attribute before extract() runs.
-    import types as _types
-
-    if "utils" not in sys.modules:
-        sys.modules["utils"] = _types.ModuleType("utils")
-    if "utils.semantic_chunker" not in sys.modules:
-        sys.modules["utils.semantic_chunker"] = _types.ModuleType("utils.semantic_chunker")
-    chunker_mod = sys.modules["utils.semantic_chunker"]
-    original_gsc = getattr(chunker_mod, "get_semantic_chunker", None)
-    chunker_mod.get_semantic_chunker = MagicMock(return_value=fake_chunker)
-    try:
-        with (
-            _patch_llm_service(svc),
-            patch.object(ops_mod, "EXTRACT_CHUNK_THRESHOLD_CHARS", 5),
-        ):
-            # The chunker is fully mocked, so the input content is irrelevant —
-            # only its length matters (> patched threshold of 5) to trigger the
-            # chunked code path.
-            result = await extract("a" * 10, schema, chunking="auto")
-    finally:
-        if original_gsc is None:
-            try:
-                del chunker_mod.get_semantic_chunker
-            except AttributeError:
-                pass
-        else:
-            chunker_mod.get_semantic_chunker = original_gsc
+    # get_semantic_chunker is a local import inside extract(); the module it
+    # resolves has to carry the attribute before extract() runs. Both the module
+    # entry and the attribute are undone at teardown (#13450).
+    chunker_mod = _stub_semantic_chunker(monkeypatch)
+    monkeypatch.setattr(chunker_mod, "get_semantic_chunker", MagicMock(return_value=fake_chunker), raising=False)
+    with (
+        _patch_llm_service(svc),
+        patch.object(ops_mod, "EXTRACT_CHUNK_THRESHOLD_CHARS", 5),
+    ):
+        # The chunker is fully mocked, so the input content is irrelevant —
+        # only its length matters (> patched threshold of 5) to trigger the
+        # chunked code path.
+        result = await extract("a" * 10, schema, chunking="auto")
 
     assert result["title"] == "Better Title"  # type: ignore[index]
     assert set(result["tags"]) == {"a", "b", "c"}  # type: ignore[index]

--- a/autobot-backend/tests/agents/test_learned_prompt_template_wiring.py
+++ b/autobot-backend/tests/agents/test_learned_prompt_template_wiring.py
@@ -22,26 +22,38 @@ import pytest
 
 # ---------------------------------------------------------------------------
 # Hollow stubs so agents/* can be imported without heavy optional deps.
+#
+# ``agents/agent_orchestration/__init__.py`` eagerly imports the coordinator and
+# executor chain, and ``routing.py`` lazily imports ``.rl_router``; the hollow
+# packages below carry the REAL on-disk ``__path__`` so the two modules this
+# file needs load from disk while that chain stays untouched.
+#
+# They live for exactly the import below and are then taken back out (#13450).
+# Registering them permanently shadowed the real ``agents.agent_orchestration``
+# for every node the session collected afterwards — the #13337 shape, where a
+# stub owned by one directory decides what a sibling gets to import.
 # ---------------------------------------------------------------------------
 _BACKEND_DIR = Path(__file__).resolve().parents[2]
 _ORCH_DIR = _BACKEND_DIR / "agents" / "agent_orchestration"
 
-if "agents" not in sys.modules:
-    _agents_pkg = types.ModuleType("agents")
-    _agents_pkg.__path__ = [str(_BACKEND_DIR / "agents")]  # type: ignore[assignment]
-    _agents_pkg.__package__ = "agents"
-    sys.modules["agents"] = _agents_pkg
 
-if "agents.agent_orchestration" not in sys.modules:
-    _orch_pkg = types.ModuleType("agents.agent_orchestration")
-    _orch_pkg.__path__ = [str(_ORCH_DIR)]  # type: ignore[assignment]
-    _orch_pkg.__package__ = "agents.agent_orchestration"
-    sys.modules["agents.agent_orchestration"] = _orch_pkg
+def _hollow_package(name: str, path: Path | None = None) -> types.ModuleType:
+    """A package object that resolves real submodules without running __init__.py."""
+    module = types.ModuleType(name)
+    module.__package__ = name
+    if path is not None:
+        module.__path__ = [str(path)]  # type: ignore[attr-defined]
+    return module
 
-if "agents.agent_orchestration.rl_router" not in sys.modules:
-    _rl_stub = types.ModuleType("agents.agent_orchestration.rl_router")
-    _rl_stub.RLRouter = type("RLRouter", (), {})  # type: ignore[attr-defined]
-    sys.modules["agents.agent_orchestration.rl_router"] = _rl_stub
+
+_RL_ROUTER_STUB = _hollow_package("agents.agent_orchestration.rl_router")
+_RL_ROUTER_STUB.RLRouter = type("RLRouter", (), {})  # type: ignore[attr-defined]
+
+_IMPORT_STUBS = {
+    "agents": _hollow_package("agents", _BACKEND_DIR / "agents"),
+    "agents.agent_orchestration": _hollow_package("agents.agent_orchestration", _ORCH_DIR),
+    "agents.agent_orchestration.rl_router": _RL_ROUTER_STUB,
+}
 
 # Add backend to sys.path for autobot_shared imports.
 if str(_BACKEND_DIR) not in sys.path:
@@ -49,8 +61,17 @@ if str(_BACKEND_DIR) not in sys.path:
 if str(_BACKEND_DIR.parent / "autobot_shared") not in sys.path:
     sys.path.insert(0, str(_BACKEND_DIR.parent))
 
-from agents.agent_orchestration.routing import AgentRouter  # noqa: E402
-from agents.agent_orchestration.types import AgentCapabilityDescriptor, AgentType  # noqa: E402
+# Only the keys nothing else has already provided are installed, and only those
+# are removed again — a real package that was already loaded always wins.
+_INSTALLED = [_key for _key in _IMPORT_STUBS if _key not in sys.modules]
+for _key in _INSTALLED:
+    sys.modules[_key] = _IMPORT_STUBS[_key]
+try:
+    from agents.agent_orchestration.routing import AgentRouter  # noqa: E402
+    from agents.agent_orchestration.types import AgentCapabilityDescriptor, AgentType  # noqa: E402
+finally:
+    for _key in reversed(_INSTALLED):
+        sys.modules.pop(_key, None)
 
 # ---------------------------------------------------------------------------
 # Fixtures

--- a/autobot-backend/tests/agents/test_topology_routing_wiring.py
+++ b/autobot-backend/tests/agents/test_topology_routing_wiring.py
@@ -22,42 +22,58 @@ import pytest
 # ---------------------------------------------------------------------------
 # Hollow package stubs — ensures agents and agents.agent_orchestration can
 # be imported without pulling in heavy optional deps (llama_index, etc.).
-# Follows the pattern used in test_memory_hooks.py.
+#
+# They live for exactly the import below and are then taken back out (#13450).
+# Registering them permanently shadowed the real ``agents.agent_orchestration``
+# for every node the session collected afterwards; the leak was invisible until
+# ``test_learned_prompt_template_wiring.py`` — same directory, same two keys —
+# stopped installing them first, since only the first writer owns a stub.
 # ---------------------------------------------------------------------------
 _BACKEND_DIR = Path(__file__).resolve().parents[2]
 _ORCH_DIR = _BACKEND_DIR / "agents" / "agent_orchestration"
 
-if "agents" not in sys.modules:
-    _agents_pkg = types.ModuleType("agents")
-    _agents_pkg.__path__ = [str(_BACKEND_DIR / "agents")]  # type: ignore[assignment]
-    _agents_pkg.__package__ = "agents"
-    sys.modules["agents"] = _agents_pkg
 
-if "agents.agent_orchestration" not in sys.modules:
-    _orch_pkg = types.ModuleType("agents.agent_orchestration")
-    _orch_pkg.__path__ = [str(_ORCH_DIR)]  # type: ignore[assignment]
-    _orch_pkg.__package__ = "agents.agent_orchestration"
-    sys.modules["agents.agent_orchestration"] = _orch_pkg
+def _hollow_package(name: str, path: Path | None = None) -> types.ModuleType:
+    """A package object that resolves real submodules without running __init__.py."""
+    module = types.ModuleType(name)
+    module.__package__ = name
+    if path is not None:
+        module.__path__ = [str(path)]  # type: ignore[attr-defined]
+    return module
 
-# Stub out rl_router so routing.py doesn't need it at import time.
-if "agents.agent_orchestration.rl_router" not in sys.modules:
-    _rl_stub = types.ModuleType("agents.agent_orchestration.rl_router")
-    _rl_stub.RLRouter = type("RLRouter", (), {})  # type: ignore[attr-defined]
-    sys.modules["agents.agent_orchestration.rl_router"] = _rl_stub
 
-from agents.agent_orchestration.routing import AgentRouter  # noqa: E402
+# rl_router is stubbed so routing.py never needs the real one at import time.
+_RL_ROUTER_STUB = _hollow_package("agents.agent_orchestration.rl_router")
+_RL_ROUTER_STUB.RLRouter = type("RLRouter", (), {})  # type: ignore[attr-defined]
 
-# Now import the real modules using normal package paths.
-from agents.agent_orchestration.topology import (  # noqa: E402
-    AgentTopology,
-    AgentTopologyDB,
-    InMemoryTopologyDB,
-)
-from agents.agent_orchestration.topology_routing import TopologyAwareRouter  # noqa: E402
-from agents.agent_orchestration.types import (  # noqa: E402
-    AgentCapabilityDescriptor,
-    AgentType,
-)
+_IMPORT_STUBS = {
+    "agents": _hollow_package("agents", _BACKEND_DIR / "agents"),
+    "agents.agent_orchestration": _hollow_package("agents.agent_orchestration", _ORCH_DIR),
+    "agents.agent_orchestration.rl_router": _RL_ROUTER_STUB,
+}
+
+# Only the keys nothing else has already provided are installed, and only those
+# are removed again — a real package that was already loaded always wins.
+_INSTALLED = [_key for _key in _IMPORT_STUBS if _key not in sys.modules]
+for _key in _INSTALLED:
+    sys.modules[_key] = _IMPORT_STUBS[_key]
+try:
+    from agents.agent_orchestration.routing import AgentRouter  # noqa: E402
+
+    # Now import the real modules using normal package paths.
+    from agents.agent_orchestration.topology import (  # noqa: E402
+        AgentTopology,
+        AgentTopologyDB,
+        InMemoryTopologyDB,
+    )
+    from agents.agent_orchestration.topology_routing import TopologyAwareRouter  # noqa: E402
+    from agents.agent_orchestration.types import (  # noqa: E402
+        AgentCapabilityDescriptor,
+        AgentType,
+    )
+finally:
+    for _key in reversed(_INSTALLED):
+        sys.modules.pop(_key, None)
 
 # ---------------------------------------------------------------------------
 # Fixtures

--- a/autobot-backend/tests/security/test_a2a_trust_gate.py
+++ b/autobot-backend/tests/security/test_a2a_trust_gate.py
@@ -10,8 +10,9 @@ all capability checks entirely.  The fix adds a mandatory header check:
 missing header → 401 Unauthorized before any trust evaluation fires.
 
 Import note: a2a.task_manager creates a TaskManager singleton at module
-level (Redis-backed).  We pre-stub it in sys.modules before any import of
-the a2a package to prevent socket connections during test collection.
+level (Redis-backed).  Every import of ``api.a2a`` here happens inside a test
+body, so the stand-in is installed for exactly one test at a time and taken
+back out again — see ``_stub_task_manager``.
 """
 
 from __future__ import annotations
@@ -23,17 +24,32 @@ from unittest.mock import MagicMock
 import pytest
 
 # ---------------------------------------------------------------------------
-# Pre-stub a2a.task_manager so the a2a package can be imported without
-# triggering the module-level TaskManager() Redis initialisation.
+# a2a.task_manager stand-in, so importing the a2a package never triggers the
+# module-level TaskManager() Redis initialisation.
+#
+# Built here but NOT registered here (#13450): installing it at module import
+# time left it in sys.modules for the rest of the session, shadowing the real
+# module for every node collected after this file. Building it once still
+# matters — ``api.a2a`` binds names off it on its first import, and a fresh
+# object per test would move those bindings away from the ones under test.
 # ---------------------------------------------------------------------------
 
-if "a2a.task_manager" not in sys.modules:
-    _tm_stub = types.ModuleType("a2a.task_manager")
-    _tm_stub.__path__ = []  # type: ignore[attr-defined]
-    _tm_stub.TaskManager = MagicMock  # type: ignore[attr-defined]
-    _tm_stub.get_task_manager = MagicMock(return_value=MagicMock())  # type: ignore[attr-defined]
-    _tm_stub.__getattr__ = lambda attr: MagicMock()  # type: ignore[attr-defined]
-    sys.modules["a2a.task_manager"] = _tm_stub
+_TASK_MANAGER_STUB = types.ModuleType("a2a.task_manager")
+_TASK_MANAGER_STUB.__path__ = []  # type: ignore[attr-defined]
+_TASK_MANAGER_STUB.TaskManager = MagicMock  # type: ignore[attr-defined]
+_TASK_MANAGER_STUB.get_task_manager = MagicMock(return_value=MagicMock())  # type: ignore[attr-defined]
+_TASK_MANAGER_STUB.__getattr__ = lambda attr: MagicMock()  # type: ignore[attr-defined]
+
+
+@pytest.fixture(autouse=True)
+def _stub_task_manager(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Answer for ``a2a.task_manager`` while one test runs, and no longer.
+
+    ``monkeypatch.setitem`` restores whatever the key held before — including
+    deleting it again when it held nothing — so nothing this file installs can
+    reach a sibling directory.
+    """
+    monkeypatch.setitem(sys.modules, "a2a.task_manager", _TASK_MANAGER_STUB)
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/tests/test_claude_adapter_wiring.py
+++ b/autobot-backend/tests/test_claude_adapter_wiring.py
@@ -419,13 +419,18 @@ class TestRateLimitDictHandling:
 # Tier 2 — AnthropicProvider integration (skipped if llm_shared not importable)
 # ---------------------------------------------------------------------------
 
-# Inject the anthropic SDK stub before attempting the provider import so that
-# the import itself succeeds even in the minimal test environment.
-if "anthropic" not in sys.modules:
-    _anthr_stub = types.ModuleType("anthropic")
-    _anthr_stub.AsyncAnthropic = MagicMock
-    sys.modules["anthropic"] = _anthr_stub
+# The anthropic SDK stand-in exists only so the provider import below succeeds
+# in the minimal test environment. It answers for the key for exactly that
+# import and is then taken back out (#13450): left registered, it shadowed the
+# real SDK — which CI installs — for every node collected after this file, and
+# every shard reported it as a leak escaping autobot-backend/tests/.
+#
+# ``setdefault`` plus the identity check on the way out means a real, already
+# imported ``anthropic`` is never displaced and never deleted.
+_ANTHROPIC_SDK_STUB = types.ModuleType("anthropic")
+_ANTHROPIC_SDK_STUB.AsyncAnthropic = MagicMock
 
+sys.modules.setdefault("anthropic", _ANTHROPIC_SDK_STUB)
 try:
     from llm_shared.providers.anthropic import AnthropicProvider as _AnthropicProvider  # noqa: E402
     from llm_shared.providers.anthropic import _get_adapter_sync as _get_adapter_sync_fn
@@ -435,6 +440,9 @@ except Exception:
     _AnthropicProvider = None  # type: ignore[assignment,misc]
     _get_adapter_sync_fn = None  # type: ignore[assignment]
     _ANTHROPIC_PROVIDER_AVAILABLE = False
+finally:
+    if sys.modules.get("anthropic") is _ANTHROPIC_SDK_STUB:
+        del sys.modules["anthropic"]
 
 _skip_no_provider = pytest.mark.skipif(
     not _ANTHROPIC_PROVIDER_AVAILABLE,

--- a/autobot-backend/tests/unit/chat_workflow/test_inline_judge.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_inline_judge.py
@@ -27,48 +27,73 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 # ---------------------------------------------------------------------------
-# Stub langchain / langgraph so graph.py can be imported without those packages
-# being installed in the test environment.
+# Stand-ins for langchain / langgraph so graph.py can be exec'd without those
+# packages being installed in the test environment.
+#
+# Built here, registered per test (#13450). ``_load_graph`` runs inside every
+# test, so the window these have to cover is one test — and registering them at
+# module import time instead left them shadowing the real, installed packages
+# for every node the session collected afterwards, which each CI shard that
+# collected this file without a real langgraph import ahead of it reported as
+# a leak escaping autobot-backend/tests/unit/chat_workflow/.
+#
+# One object per key, built once: ``graph.py`` binds names off these on every
+# exec, and a fresh object per test would move the bindings under it.
 # ---------------------------------------------------------------------------
 
 _STUBS = {
-    "langchain_core": types.ModuleType("langchain_core"),
-    "langchain_core.messages": types.ModuleType("langchain_core.messages"),
-    "langchain_core.runnables": types.ModuleType("langchain_core.runnables"),
-    "xxhash": types.ModuleType("xxhash"),
-    "redis": types.ModuleType("redis"),
-    "redis.asyncio": types.ModuleType("redis.asyncio"),
-    "langgraph": types.ModuleType("langgraph"),
-    "langgraph.checkpoint": types.ModuleType("langgraph.checkpoint"),
-    "langgraph.checkpoint.redis": types.ModuleType("langgraph.checkpoint.redis"),
-    "langgraph.checkpoint.redis.aio": types.ModuleType("langgraph.checkpoint.redis.aio"),
-    "langgraph.graph": types.ModuleType("langgraph.graph"),
-    "langgraph.types": types.ModuleType("langgraph.types"),
-    "typing_extensions": types.ModuleType("typing_extensions"),
+    name: types.ModuleType(name)
+    for name in (
+        "langchain_core",
+        "langchain_core.messages",
+        "langchain_core.runnables",
+        "xxhash",
+        "redis",
+        "redis.asyncio",
+        "langgraph",
+        "langgraph.checkpoint",
+        "langgraph.checkpoint.redis",
+        "langgraph.checkpoint.redis.aio",
+        "langgraph.graph",
+        "langgraph.types",
+        "typing_extensions",
+    )
 }
 
-for _name, _stub in _STUBS.items():
-    sys.modules.setdefault(_name, _stub)
+# The names graph.py imports from each module. Applied only where the module
+# answering for the key does not already carry them, so a real package that is
+# installed keeps its own implementation.
+_STUB_ATTRS: dict[str, dict[str, object]] = {
+    "langgraph.graph": {attr: MagicMock() for attr in ("END", "START", "StateGraph")},
+    "langgraph.types": {"interrupt": MagicMock()},
+    "typing_extensions": {"TypedDict": typing.TypedDict},
+    "langchain_core.messages": {
+        attr: MagicMock() for attr in ("HumanMessage", "SystemMessage", "AIMessage", "BaseMessage")
+    },
+    "langchain_core.runnables": {"RunnableConfig": MagicMock()},
+}
 
-for _attr in ("END", "START", "StateGraph"):
-    if not hasattr(sys.modules["langgraph.graph"], _attr):
-        setattr(sys.modules["langgraph.graph"], _attr, MagicMock())
 
-if not hasattr(sys.modules["langgraph.types"], "interrupt"):
-    sys.modules["langgraph.types"].interrupt = MagicMock()
+@pytest.fixture(autouse=True)
+def _stub_langgraph(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Answer for the langchain/langgraph keys while one test runs, and no longer.
 
-if not hasattr(sys.modules["typing_extensions"], "TypedDict"):
-    sys.modules["typing_extensions"].TypedDict = typing.TypedDict
+    ``monkeypatch`` restores every entry and attribute afterwards — deleting the
+    ones that were absent — so nothing this file installs reaches a sibling.
+    """
+    for name, stub in _STUBS.items():
+        if name not in sys.modules:
+            monkeypatch.setitem(sys.modules, name, stub)
+    for name, attrs in _STUB_ATTRS.items():
+        module = sys.modules[name]
+        for attr, value in attrs.items():
+            if not hasattr(module, attr):
+                monkeypatch.setattr(module, attr, value, raising=False)
+    # AsyncRedisSaver must exist so the try/except in graph.py sets
+    # _REDIS_CHECKPOINTER_AVAILABLE=True — set unconditionally, as the real
+    # saver would open a Redis connection.
+    monkeypatch.setattr(sys.modules["langgraph.checkpoint.redis.aio"], "AsyncRedisSaver", MagicMock(), raising=False)
 
-for _attr in ("HumanMessage", "SystemMessage", "AIMessage", "BaseMessage"):
-    if not hasattr(sys.modules["langchain_core.messages"], _attr):
-        setattr(sys.modules["langchain_core.messages"], _attr, MagicMock())
-
-if not hasattr(sys.modules["langchain_core.runnables"], "RunnableConfig"):
-    sys.modules["langchain_core.runnables"].RunnableConfig = MagicMock()
-
-# AsyncRedisSaver must exist so the try/except in graph.py sets _REDIS_CHECKPOINTER_AVAILABLE=True
-sys.modules["langgraph.checkpoint.redis.aio"].AsyncRedisSaver = MagicMock()
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -342,8 +367,13 @@ class TestStructuredOutputInExtractClaims:
         ), "_extract_claims must pass structured_output=True to prevent silent JSON drops"
 
 
-class TestRouteAfterJudge:
-    """route_after_judge must never loop indefinitely (#11013)."""
+class TestRouteAfterJudgeRegenerationCap:
+    """route_after_judge must never loop indefinitely (#11013).
+
+    Renamed off ``TestRouteAfterJudge`` (#13450): a second class of that name
+    rebound the module attribute, so pytest only ever collected this one and
+    the four cases in the class above it were silently dropped from the suite.
+    """
 
     def test_routes_to_generate_for_exactly_one_regen(self) -> None:
         graph_mod = _load_graph()


### PR DESCRIPTION
## Thinking Path

The guard became a ratchet in #13442: an owner that leaks and is not on
`repo_tests/sys_modules_leak_baseline.txt` fails the run. Five owners were absent because
the baseline was generated from only the two invocation shapes CI uses, so every session
with a different path set reported pre-existing debt as a regression — the failure mode
#13398 exists to prevent.

The baseline only shrinks, so none of these could be listed. Each was fixed by binding its
stub to the window that actually needs it, per #13359's pattern
(`autobot-backend/llc/tests/conftest.py`): build the stub objects once so `mock.patch`'s
`getattr` resolution keeps hitting the same object, install only the keys nothing else has
already provided, and remove exactly those again from a `try/finally` or through
`monkeypatch`.

Where the stub was only needed while tests run, `monkeypatch.setitem` is the whole fix —
its undo runs inside `pytest_runtest_protocol`, i.e. before the guard attributes the
node's delta, so the session sees no mutation at all. Only the two files with a
module-level import that genuinely needs the stub keep an install, and they wrap exactly
that import.

A sixth owner appeared the moment the fifth stopped leaking: `setdefault` is
first-writer-wins, so `test_topology_routing_wiring.py` had been invisible behind
`test_learned_prompt_template_wiring.py` for the same two keys. It is fixed the same way,
which is why this PR covers six files rather than five.

The sixth of the five listed owners — `api/multimodal_response_test.py`'s four
`transformers.*` keys — is **not** fixed here. It is not a stub at all, and the analysis
and recommendation are below, left for a decision.

## What Changed

Six test modules; **no production code, no guard change, no baseline change**.

| File | Keys | Window it now uses |
|---|---|---|
| `autobot-backend/llm_shared/structured_ops_test.py` | `utils`, `utils.semantic_chunker` | `monkeypatch.setitem` + `monkeypatch.setattr` inside the one test that needs them |
| `autobot-backend/tests/security/test_a2a_trust_gate.py` | `a2a.task_manager` | autouse fixture; every `api.a2a` import is already inside a test body, so the import-time install was never needed |
| `autobot-backend/tests/unit/chat_workflow/test_inline_judge.py` | 9 × `langchain_core.*` / `langgraph.*` | autouse fixture; `graph.py` is `exec`'d inside every test by `_load_graph`, so one test is the whole window |
| `autobot-backend/tests/agents/test_learned_prompt_template_wiring.py` | `agents.agent_orchestration`, `…rl_router` | `try/finally` around the module-level import |
| `autobot-backend/tests/agents/test_topology_routing_wiring.py` | same two keys | same `try/finally` |
| `autobot-backend/tests/test_claude_adapter_wiring.py` | `anthropic` | `setdefault` + delete-only-if-still-ours around the provider import |

Two details that are load-bearing rather than tidiness:

* **Stub objects are built once, at module level.** Building a `types.ModuleType` mutates
  nothing, so it is safe outside the window; a fresh object per test would move the
  attributes `mock.patch` and the code under test resolve against (#13337's trap).
* **Only the keys this file installed are removed.** `_INSTALLED` / the `setdefault`
  identity check mean a real, already-imported package is never displaced and never
  deleted — including the real `anthropic`, which CI installs.

**Pre-existing test rot fixed in passing** (`test_inline_judge.py`): two classes were
both named `TestRouteAfterJudge`, so the later one rebound the module attribute and the
four cases in the first were silently dropped from the suite. The second is renamed
`TestRouteAfterJudgeRegenerationCap`; collection goes 13 → 17 and all four recovered
cases pass.

## Verification

Every "before" was captured by restoring the six files to `origin/Dev_new_gui` with
`git restore --source=67d47406b` and re-running the identical command.

**Per owner — a session that actually exercises the escape:**

| Owner | Before | After |
|---|---|---|
| `structured_ops_test.py` | `LEAK: … leaves 1 sys.modules key(s) … keys: utils.semantic_chunker` | silent, 60 passed |
| `test_a2a_trust_gate.py` | `LEAK: … keys: a2a.task_manager` (escapes to `tests/services`) | silent, 30 passed |
| `test_learned_prompt_template_wiring.py` | `LEAK: … keys: agents.agent_orchestration, agents.agent_orchestration.rl_router` | silent, 35 passed |
| `test_claude_adapter_wiring.py` | `LEAK: … keys: anthropic` (escapes to `autobot_shared`) | silent, 55 passed |
| `test_inline_judge.py` | `LEAK: … leaves 9 sys.modules key(s) … langchain_core, langgraph, …` | silent, 1423 passed |
| `test_topology_routing_wiring.py` | `LEAK: … keys: agents.agent_orchestration, agents.agent_orchestration.rl_router` | silent, 9 passed |

**The session from the issue, verbatim, `-n auto --dist loadscope`:**

before (files restored to base)
```
LEAK: autobot-backend/llm_shared/structured_ops_test.py leaves 1 sys.modules key(s) …
LEAK: autobot-backend/tests/agents/test_learned_prompt_template_wiring.py leaves 2 …
LEAK: autobot-backend/tests/security/test_a2a_trust_gate.py leaves 1 …
LEAK: autobot-backend/tests/test_claude_adapter_wiring.py leaves 1 …
4 file(s) above are NOT on repo_tests/sys_modules_leak_baseline.txt, so this run fails.
= 39 failed, 11551 passed, 330 skipped, 32 errors in 461.25s =
```

after
```
============================ sys.modules leak guard ============================
11 known leaking file(s), 113 sys.modules key(s), all on repo_tests/sys_modules_leak_baseline.txt — not a failure.
= 40 failed, 11554 passed, 330 skipped, 32 errors in 428.43s =
```

No `LEAK:` line, no `FIXED:` line — **the baseline needs no edit**.

**Both CI shapes, collect-only:**

```
pytest --collect-only -q -p no:randomly --continue-on-collection-errors \
  autobot-backend autobot_shared autobot-tts-worker repo_tests
  → 9 known leaking file(s), 71 keys, all on the baseline. 22706 tests collected.

pytest --collect-only -q -p no:randomly --continue-on-collection-errors autobot-slm-backend
  → 13 known leaking file(s), 19 keys, all on the baseline. 1566 tests collected.
```

**Failure-set diff, before vs after, same command:** `+11554 −11551` passed (the four
recovered `TestRouteAfterJudge` cases, minus one) and exactly one failure that is not in
the before set:

```
FAILED autobot-backend/tests/orchestration/test_causal_error_recovery.py::TestRecoverySystemSmoke::test_recovery_plan_serialization
```

That one is **pre-existing and independent of this PR** — reproduced deterministically on
unmodified files, in a session that contains none of the six:

```
pytest autobot-backend/tests/orchestration/test_causal_error_recovery.py \
       autobot-backend/tests/agents/test_causal_reasoning.py -n 2 --dist loadscope
  → 1 failed, 35 passed          (-n 4 on the same two files: 36 passed)
```

Two baselined `sys.modules` jugglers restore overlapping keys at module teardown; when
the deal puts them on one worker the `MagicMock` stub is back before
`test_recovery_plan_serialization`'s function-local re-import runs, and `to_dict()` dies
with `TypeError: asdict() should be called on dataclass instances`. Filed as **#13457**.
Adding four tests here is enough to shift the deal, which is all this PR did to it.

Lint on all six: `black --check` clean, `flake8` clean, `ruff check` clean. The one
`flake8` finding in `test_topology_routing_wiring.py` (`F401 AgentTopology`) is byte-for-byte
present on `origin/Dev_new_gui` and untouched here.

## Model Used

Sonnet (claude-sonnet-4-6)

---

## Left for a decision: `api/multimodal_response_test.py` and the four `transformers.*` keys

Not fixed here, deliberately. The full analysis is in the issue thread; the short version:

**Where the entries come from.** `multimodal_response_test.py` contains no `sys.modules`
statement, and neither does anything it reaches. `grep` across the whole repo finds **zero**
writes to any `transformers*` key. The chain is
`multimodal_response_test.py:19 → api/multimodal.py:17 → ai_hardware_accelerator.py:44-50`:

```python
# Import transformers models for multi-modal embeddings
try:
    import librosa
    from transformers import CLIPModel, CLIPProcessor, Wav2Vec2Model, Wav2Vec2Processor

    MULTIMODAL_MODELS_AVAILABLE = True
except (ImportError, RuntimeError):
    MULTIMODAL_MODELS_AVAILABLE = False
```

The four entries are produced entirely inside the real library by its own lazy-module
machinery; the guard reports them as `replaced` because the keys already existed when the
`from transformers import …` above materialised them, and it attributes the delta to the
module whose import produced it.

**It is a real dependency, installed in CI.** `requirements-ci/ai-ml.txt:4` pins
`transformers==5.14.1`. It is *not* in the local dev venv, which is why
`_shadows_real_code` filters it out locally and why this owner cannot be reproduced or
verified outside CI.

**Nothing "relies on the entries" that AutoBot could stop relying on.** They are the
library's own module registry, not a stand-in for anything. The only AutoBot state
involved is `MULTIMODAL_MODELS_AVAILABLE`, read at `ai_hardware_accelerator.py:672`.

**Recommendation — treat it as a guard false positive, not a leak.** Nothing is being
stubbed here, so there is no `try/finally` to add: the only production change available is
making the import lazy, which does not remove the delta, it relocates the blame to
whichever test first touches the multi-modal path, and it turns a module-level constant
read elsewhere into a call. That is churn with real blast radius and no fix in it.

The narrow alternative is a one-line refinement in `_classify`: a `replaced` entry whose
**new** object is a real, spec-carrying module the import system loaded is not a stub. It
cannot mask the three leaks the guard exists for — #13320 replaces `sqlalchemy` with a
`MagicMock`, #13324 replaces `autobot_shared` with a `MagicMock`, #13337 replaces `agents`
with a `types.ModuleType`, and all three read as `__spec__ is None` (`Mock.__getattr__`
raises on dunder names, so `getattr(mock, "__spec__", None)` is `None`).

It does have a cost, which is why it is a decision and not a unilateral change: at least
one baselined owner replaces with a **real-loaded** module —
`llm_shared/npu_pipeline_routing_test.py` builds its replacement with
`module_from_spec(spec_from_file_location(...))`, which carries a `__spec__`. Refining
`_classify` would silence it, and the shrink-only rule would then fail every run with
`FIXED: … remove it from …` until its line is deleted. So the change is "refine `_classify`
**and** delete the baseline lines it legitimately retires", which needs the owner's call on
how many lines that is.

Refs #13450
Refs #13361
