### PR TITLE
fix(test-infra): stop the knowledge service stubs leaking utils into the session (#13435)

### DIFF
--- a/autobot-backend/services/knowledge/conftest.py
+++ b/autobot-backend/services/knowledge/conftest.py
@@ -1,0 +1,134 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Restore the module stubs the knowledge service tests install at import time.
+
+#13435: four test modules here — ``test_analyzer_service``,
+``test_kb_synthesizer``, ``test_doc_indexer`` and
+``test_doc_indexer_dim_mismatch`` — stub heavy dependencies before importing
+their subject, because each loads its module through ``importlib`` to bypass
+``services/knowledge/__init__.py``. Installing those stubs is necessary. What
+was missing is the other half: nothing put ``sys.modules`` back, so ``utils``,
+``utils.chromadb_client`` and ``utils.async_chromadb_client`` stayed stubbed for
+every test collected afterwards in the same worker.
+
+The consequences were real, and were previously patched at the far end instead
+of here: ``utils/chromadb_auth_test.py`` and
+``utils/chromadb_client_cache_key_test.py`` failed in CI while passing alone
+(worked around in #13438), and ``services/rag_service_kb_synthesis_test.py``
+still does (#13386). The `sys.modules` leak guard (#13361) now fails the run on
+it, which is what surfaced this.
+
+**Why this lives in conftest rather than in a helper the tests import.**
+``pytest.ini`` sets ``--import-mode=importlib``, which does not put a test's own
+directory on ``sys.path`` — a sibling module is therefore not importable from
+these files (the same trap #13368 records for ``tools/codemods``). pytest does
+load a directory's ``conftest.py`` before it imports the test modules beside it,
+so this module runs first and can capture the pre-stub state without the four
+files needing to change at all.
+
+Restoration is package-scoped, not module-scoped: the four modules share
+``utils`` and its children, so tearing down after the first would pull the stub
+out from under the other three.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Any, Dict
+
+import pytest
+
+# The names these four modules install via their own ``_make_stub`` helpers.
+# Listed explicitly rather than diffed against a full ``sys.modules`` snapshot:
+# a diff would also revert legitimate imports performed by tests that run in
+# between, which is a much larger and less predictable blast radius.
+_STUBBED_NAMES = (
+    "autobot_shared.ssot_config",
+    "utils",
+    "utils.chromadb_client",
+    "utils.async_chromadb_client",
+    "constants",
+    "constants.path_constants",
+)
+
+_MISSING = object()
+
+# Captured at conftest import — before pytest imports the test modules in this
+# directory, therefore before any of them installs a stub.
+_PRE_STUB_STATE: Dict[str, Any] = {name: sys.modules.get(name, _MISSING) for name in _STUBBED_NAMES}
+
+# ``utils.async_chromadb_client`` is also bound as an attribute on the ``utils``
+# package so ``mock.patch("utils.async_chromadb_client....")`` can resolve it
+# (#11532, #12463). Injecting into ``sys.modules`` alone does not do that, so
+# the attribute has to be restored separately from the module entry.
+_PRE_STUB_UTILS_ATTR: Any = (
+    getattr(sys.modules["utils"], "async_chromadb_client", _MISSING) if "utils" in sys.modules else _MISSING
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _reinstall_module_stubs(request):
+    """Re-install a module's unloaded stubs for the duration of its own tests.
+
+    A test module here unloads its stubs immediately after using them to import
+    its subject (``_STUBS_UNLOADED_AFTER_IMPORT``), so nothing is left installed
+    while pytest imports the rest of the session's modules — that import phase
+    is when the leak was escaping. The stubs are still required *during* the
+    module's tests, which patch dotted paths resolved through ``sys.modules``,
+    so they go back in here and come out again straight afterwards.
+
+    Module-scoped: each module owns exactly the names it unloaded, so two
+    modules stubbing the same name cannot tear down each other's.
+    """
+    unloaded = getattr(request.module, "_STUBS_UNLOADED_AFTER_IMPORT", None)
+    if not unloaded:
+        yield
+        return
+
+    restored_parent_attr = False
+    for name, module in unloaded.items():
+        sys.modules[name] = module
+        # Re-bind on the parent package too — patch() resolves "utils.x.Y" as
+        # getattr(sys.modules["utils"], "x") (#11532, #12463).
+        parent_name, _, leaf = name.rpartition(".")
+        parent = sys.modules.get(parent_name) if parent_name else None
+        if parent is not None:
+            setattr(parent, leaf, module)
+            restored_parent_attr = True
+
+    yield
+
+    for name in unloaded:
+        sys.modules.pop(name, None)
+        parent_name, _, leaf = name.rpartition(".")
+        parent = sys.modules.get(parent_name) if parent_name else None
+        if restored_parent_attr and parent is not None and hasattr(parent, leaf):
+            delattr(parent, leaf)
+
+
+@pytest.fixture(scope="package", autouse=True)
+def _restore_knowledge_stubs():
+    """Put the remaining import-time stubs back once this package is done.
+
+    Covers the names the test modules still leave installed after import —
+    ``autobot_shared.ssot_config``, ``utils``, ``constants`` and its child —
+    which the leak guard's baseline does not list for this directory.
+    """
+    yield
+
+    utils_mod = sys.modules.get("utils")
+    if utils_mod is not None:
+        if _PRE_STUB_UTILS_ATTR is _MISSING:
+            if hasattr(utils_mod, "async_chromadb_client"):
+                delattr(utils_mod, "async_chromadb_client")
+        else:
+            utils_mod.async_chromadb_client = _PRE_STUB_UTILS_ATTR
+
+    for name in reversed(_STUBBED_NAMES):
+        previous = _PRE_STUB_STATE[name]
+        if previous is _MISSING:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = previous

--- a/autobot-backend/services/knowledge/test_analyzer_service.py
+++ b/autobot-backend/services/knowledge/test_analyzer_service.py
@@ -80,6 +80,24 @@ from services.knowledge.analyzer_service import (  # noqa: E402
     get_analyzer_service,
 )
 
+# #13435: the stubs above were needed to import analyzer_service, and they are
+# needed again while this module's tests run, because those tests patch through
+# dotted paths such as ``utils.async_chromadb_client.get_async_chromadb_client``
+# which resolve via ``sys.modules``. They are NOT needed in between — and
+# "in between" is when every other test module in the worker gets imported, so
+# leaving them installed is what leaked ``utils`` and its children across the
+# session (the leak guard added in #13361 now fails the run on it).
+#
+# Unload them here; ``_reinstall_module_stubs`` in this package's conftest puts
+# these exact objects back for the duration of this module's tests and removes
+# them afterwards. The same objects, not fresh ones — analyzer_service captured
+# references at import and a different stub would not be the module it holds.
+_STUBS_UNLOADED_AFTER_IMPORT = {
+    name: sys.modules.pop(name)
+    for name in ("utils.chromadb_client", "utils.async_chromadb_client")
+    if name in sys.modules
+}
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/autobot-backend/services/knowledge/test_kb_synthesizer.py
+++ b/autobot-backend/services/knowledge/test_kb_synthesizer.py
@@ -80,6 +80,18 @@ from services.knowledge.kb_synthesizer import (  # noqa: E402
     get_kb_synthesizer,
 )
 
+# #13435: see the matching note in test_analyzer_service.py. The stubs were
+# needed to import kb_synthesizer and are needed again while this module's tests
+# run, but not in between — and "in between" is when pytest imports every other
+# module in the worker, which is how ``utils`` and its children escaped this
+# directory. ``_reinstall_module_stubs`` in this package's conftest puts these
+# exact objects back around this module's tests and removes them afterwards.
+_STUBS_UNLOADED_AFTER_IMPORT = {
+    name: sys.modules.pop(name)
+    for name in ("utils.chromadb_client", "utils.async_chromadb_client")
+    if name in sys.modules
+}
+
 # Private static helpers — in Python 3.10+ staticmethods are plain functions on the class
 _cluster_id = KBSynthesizer._cluster_id  # type: ignore[attr-defined]
 _read_docs = KBSynthesizer._read_docs  # type: ignore[attr-defined]

--- a/autobot-backend/services/knowledge/test_lineage_service.py
+++ b/autobot-backend/services/knowledge/test_lineage_service.py
@@ -41,6 +41,16 @@ from services.knowledge.lineage_service import (  # noqa: E402
     get_lineage_service,
 )
 
+# #13435: see the matching note in test_analyzer_service.py. ``utils.chromadb_client``
+# is the one stub above that escapes this directory — it is not needed after the
+# import, and leaving it installed poisoned utils/chromadb_auth_test.py and
+# utils/chromadb_client_cache_key_test.py, which pass alone and failed in CI.
+# ``_reinstall_module_stubs`` in this package's conftest puts it back around this
+# module's own tests and removes it afterwards.
+_STUBS_UNLOADED_AFTER_IMPORT = {
+    name: sys.modules.pop(name) for name in ("utils.chromadb_client",) if name in sys.modules
+}
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/autobot-backend/services/knowledge/test_synthesis_prompt_evolution.py
+++ b/autobot-backend/services/knowledge/test_synthesis_prompt_evolution.py
@@ -26,6 +26,15 @@ sys.modules.setdefault("autobot_shared.redis_client", MagicMock())
 
 from services.knowledge.kb_synthesizer import KBSynthesizer  # noqa: E402
 
+# #13435: see the matching note in test_analyzer_service.py. ``utils.chromadb_client``
+# escapes this directory and poisoned utils/chromadb_auth_test.py and
+# utils/chromadb_client_cache_key_test.py, which pass alone and failed in CI.
+# ``_reinstall_module_stubs`` in this package's conftest puts it back around this
+# module's own tests and removes it afterwards.
+_STUBS_UNLOADED_AFTER_IMPORT = {
+    name: sys.modules.pop(name) for name in ("utils.chromadb_client",) if name in sys.modules
+}
+
 # ---------------------------------------------------------------------------
 # _score_synthesis_output
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #13435

## Thinking Path

The `sys.modules` leak guard (#13361) started failing runs on this directory, which is how a long-standing leak finally became visible. Five modules under `services/knowledge/` install stubs at import time and never remove them.

The interesting part is *when* the stubs are needed. They are needed at import — each module loads its subject through `importlib` to bypass `services/knowledge/__init__.py`. They are needed again while that module's own tests run, because those tests patch dotted paths like `utils.async_chromadb_client.get_async_chromadb_client`, which `unittest.mock.patch` resolves through `sys.modules`. They are **not** needed in between — and "in between" is precisely when pytest imports every other module in the worker. That gap is the leak.

So the fix is not "restore at teardown". A package-scoped teardown is too late: pytest imports all modules during collection, before any fixture runs, and the guard reports the leak at the *import* of the next file. The stubs have to be gone during the import phase and present during the run phase.

**Two things I tried first and discarded**, recorded so the next person does not repeat them:

- A shared helper module the tests import. `pytest.ini` sets `--import-mode=importlib`, which does not put a test's own directory on `sys.path`, so a sibling module is not importable from these files — the same trap #13368 records for `tools/codemods`. The conftest works because pytest loads a directory's `conftest.py` *before* importing the test modules beside it.
- A package-scoped `sys.modules` restore. Correct in shape, too late in time, per the collection-order point above.

## What Changed

| File | Change |
|---|---|
| `services/knowledge/conftest.py` | **New.** `_reinstall_module_stubs` — module-scoped autouse fixture that re-installs a module's unloaded stubs around its own tests, re-binding each on its parent package (`patch()` resolves `pkg.mod.NAME` via `getattr`, #11532/#12463). Plus a package-scoped restore for the import-time names that remain. |
| `test_analyzer_service.py` | Unloads `utils.chromadb_client`, `utils.async_chromadb_client` after import |
| `test_kb_synthesizer.py` | Same two |
| `test_lineage_service.py` | Unloads `utils.chromadb_client` |
| `test_synthesis_prompt_evolution.py` | Unloads `utils.chromadb_client` |

Each module records what it unloaded in `_STUBS_UNLOADED_AFTER_IMPORT`; the fixture restores those exact objects, because each subject module captured references at import and a fresh stub would not be the module it holds.

The guard reports one owner per run, so these were found by re-running after each fix — `test_lineage_service` and `test_synthesis_prompt_evolution` only appeared once the first two were clean.

## Verification

```
services/knowledge/ + the three previously-poisoned victims
  before:  LEAK ... keys: utils.chromadb_client, utils.async_chromadb_client   (guard fails the run)
  after:   380 passed, 12 skipped   — guard silent
  on base: 380 passed, 12 skipped   — identical

services/ + utils/  (-n 4 --dist loadscope, CI marker filter)
  2687 passed, 26 skipped, 0 failed
```

`services/knowledge/` alone gives `365 passed` on both base and branch, so nothing changed for the directory in isolation.

**One failure I chased down and did not cause.** An early combined run showed `test_contradiction_detector::test_scan_finds_contradictions` failing. Base gives `380 passed` on that same command, and my branch gives `380 passed` on three consecutive runs — it is intermittent, roughly 1 in 5, and filed as **#13455** rather than left to be mistaken for a regression from this PR.

## Model Used

Claude Opus 5 (1M context)
