### PR TITLE
fix(mobile): consume the QR pairing token atomically (#13408)

### DIFF
--- a/autobot-backend/api/mobile_devices.py
+++ b/autobot-backend/api/mobile_devices.py
@@ -32,7 +32,7 @@ from auth_middleware import get_current_user, require_device_jwt
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.monitoring.prometheus_metrics import get_metrics_manager
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import client_getdel, get_redis_client
 from autobot_shared.time_utils import now_utc
 from models.mobile_device import DevicePlatform, MobileDevice
 
@@ -186,9 +186,17 @@ async def pair_device(
         )
 
     key = _redis_challenge_key(body.challenge_token)
-    raw = redis.get(key)
+    # #13408: fetch and consume in ONE atomic operation. This endpoint is
+    # deliberately unauthenticated — the docstring above states that
+    # authentication is delegated to the challenge token — so single-use is not
+    # a nicety here, it is the whole control. A separate GET then DELETE let two
+    # requests presenting the same QR token both read a value before either
+    # deleted it, and both then paired a device against the bound user_id.
+    # ``client_getdel`` issues GETDEL where the client supports it.
+    raw = await client_getdel(redis, key)
     if raw is None:
-        # GH#4463: Record expired/invalid pairing attempts
+        # GH#4463: Record expired/invalid pairing attempts. A loser of the race
+        # now lands here too, which is the correct answer for a consumed token.
         metrics.record_device_pairing_attempt("expired")
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -196,8 +204,6 @@ async def pair_device(
         )
 
     user_id = raw.decode() if isinstance(raw, bytes) else raw
-    # Consume the token — one-time use
-    redis.delete(key)
 
     device = MobileDevice(
         user_id=user_id,

--- a/autobot-backend/tests/integration/test_mobile_pairing.py
+++ b/autobot-backend/tests/integration/test_mobile_pairing.py
@@ -14,6 +14,7 @@ Comprehensive end-to-end tests for the mobile device pairing flow:
 - Security: token encryption, one-time use, user isolation
 """
 
+import asyncio
 import uuid
 from datetime import timedelta
 from fnmatch import fnmatch
@@ -149,6 +150,9 @@ class _FakeRedis:
 
     def __init__(self) -> None:
         self._store: dict[str, tuple[str, float]] = {}
+        # #13408: call counts, so a test can assert that token consumption goes
+        # through the atomic GETDEL rather than a separate GET then DELETE.
+        self.calls: dict[str, int] = {"get": 0, "delete": 0, "getdel": 0}
 
     def _read(self, key: str) -> tuple[str, float] | None:
         entry = self._store.get(key)
@@ -164,11 +168,29 @@ class _FakeRedis:
         return True
 
     def get(self, key: str) -> str | None:
+        self.calls["get"] += 1
         entry = self._read(key)
         return None if entry is None else entry[0]
 
     def delete(self, *keys: str) -> int:
+        self.calls["delete"] += 1
         return sum(1 for key in keys if self._store.pop(key, None) is not None)
+
+    def getdel(self, key: str) -> str | None:
+        """Atomically return a key's value and remove it (Redis 6.2 GETDEL).
+
+        #13408: the real client exposes this and ``client_getdel`` prefers it.
+        A double without it would silently push the code under test down the
+        non-atomic GET+DELETE fallback — the double would then be testing a
+        path production never takes, which is how a single-use control can look
+        covered while the race it exists to prevent goes untested.
+        """
+        self.calls["getdel"] += 1
+        entry = self._read(key)
+        if entry is None:
+            return None
+        del self._store[key]
+        return entry[0]
 
     def ttl(self, key: str) -> int:
         entry = self._read(key)
@@ -734,6 +756,71 @@ async def test_concurrent_pairing_same_token_race_condition(test_client, redis_c
 
     assert response1.status_code == 201
     assert response2.status_code == 400  # Token already consumed
+
+
+@pytest.mark.asyncio
+async def test_pairing_consumes_token_atomically(test_client, redis_client):
+    """The challenge token is consumed with GETDEL, not GET-then-DELETE (#13408).
+
+    ``test_concurrent_pairing_same_token_race_condition`` above cannot catch the
+    race it is named for: ``TestClient`` is synchronous, so the first request has
+    already finished — and deleted the key — before the second begins. The two
+    calls never interleave, and a GET-then-DELETE implementation passes it.
+
+    This asserts the property that actually closes the race: the read and the
+    delete are one operation. With a separate GET and DELETE there is a window
+    in which a second request reads a value the first has not yet removed, and
+    both pair a device against the bound ``user_id`` — on an endpoint that is
+    deliberately unauthenticated, where single-use is the entire control.
+    """
+    qr_response = test_client.get("/api/devices/pair-qr")
+    challenge_token = qr_response.json()["challenge_token"]
+
+    redis_client.calls["get"] = 0
+    redis_client.calls["delete"] = 0
+    redis_client.calls["getdel"] = 0
+
+    response = test_client.post(
+        "/api/devices/pair",
+        json={
+            "challenge_token": challenge_token,
+            "device_name": "Device",
+            "device_token": "token",
+            "platform": "ios",
+        },
+    )
+
+    assert response.status_code == 201
+    assert redis_client.calls["getdel"] == 1, "challenge token was not consumed atomically"
+    assert redis_client.calls["delete"] == 0, "a separate DELETE means the read and delete can interleave"
+
+
+@pytest.mark.asyncio
+async def test_only_one_of_two_interleaved_consumers_wins(redis_client):
+    """Two consumers racing for one token: exactly one gets it (#13408).
+
+    Drives ``client_getdel`` — the primitive the endpoint now uses — directly,
+    concurrently, against the same key. This is the interleaving the endpoint
+    test above cannot produce through a synchronous ``TestClient``.
+
+    Scope, stated precisely: this pins the *primitive*. It does not observe the
+    endpoint, so an endpoint that stopped calling ``client_getdel`` would still
+    pass here — ``test_pairing_consumes_token_atomically`` above is what guards
+    that, and it is the one verified to fail against a GET-then-DELETE
+    implementation. The two are complementary and neither is sufficient alone.
+    """
+    from autobot_shared.redis_client import client_getdel
+
+    key = _redis_challenge_key("race-token")
+    redis_client.setex(key, 300, "user-42")
+
+    results = await asyncio.gather(
+        client_getdel(redis_client, key),
+        client_getdel(redis_client, key),
+    )
+
+    assert sorted(r is None for r in results) == [False, True], f"expected exactly one winner, got {results!r}"
+    assert redis_client.get(key) is None
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #13408

## Thinking Path

`POST /api/devices/pair` read the challenge token with `GET` and removed it with a separate `DELETE`. Between those two calls, a second request presenting the same token reads the same value — and both pair a device against the bound `user_id`.

What makes this more than a tidiness issue is the endpoint's own contract. Its docstring states that no user session is required because *authentication is delegated to the challenge token*. Single-use is therefore not a safeguard around the control; it **is** the control. One QR scan could pair two devices.

`autobot_shared.redis_client.client_getdel` already existed for precisely this shape — it issues `GETDEL` where the client exposes it, falls back where it does not, and handles sync or async clients. So this is a call-site fix, not a new primitive.

## What Changed

| File | Change |
|---|---|
| `api/mobile_devices.py` | `raw = redis.get(key)` + `redis.delete(key)` → `raw = await client_getdel(redis, key)` |
| `tests/integration/test_mobile_pairing.py` | `_FakeRedis.getdel`, call counters, and two new tests |

A loser of the race now receives the same `400` an expired token receives, which is the right answer for a token that has been consumed.

**The test double needed fixing too.** `_FakeRedis` had no `getdel`, so `client_getdel` would have silently taken its GET+DELETE fallback against it — the tests would have exercised a path production never takes, and the single-use control would have *looked* covered while the race it exists to prevent went untested. That is the same failure shape #13162 kept surfacing, so the double now models the real client.

## Verification

```
tests/integration/test_mobile_pairing.py    21 passed
isort · black · flake8 (0) · bandit         clean
```

**Mutation-checked.** Reverting the handler to GET-then-DELETE makes the endpoint test fail:

```
E   AssertionError: challenge token was not consumed atomically
E   assert 0 == 1
FAILED test_pairing_consumes_token_atomically
```

**Scope of each test, stated honestly:**

- `test_pairing_consumes_token_atomically` drives the endpoint and is the one verified to fail against the old implementation.
- `test_only_one_of_two_interleaved_consumers_wins` races two `client_getdel` calls on one key. It pins the **primitive**, not the endpoint — an endpoint that stopped calling `client_getdel` would still pass it. Its docstring says so rather than implying broader coverage. The two are complementary; neither is sufficient alone.

The pre-existing `test_concurrent_pairing_same_token_race_condition` is left in place but does not catch this: `TestClient` is synchronous, so the first request completes — and deletes the key — before the second begins. The calls never interleave, and a GET-then-DELETE implementation passes it.

## Model Used

Claude Opus 5 (1M context)
