### PR TITLE
fix(api): open voice-bundle sessions with a context manager, not the Depends generator (#13364)

### DIFF
--- a/autobot-backend/api/voice_bundle_admin.py
+++ b/autobot-backend/api/voice_bundle_admin.py
@@ -95,9 +95,9 @@ async def get_user_bundle(
     try:
         from sqlalchemy import text  # noqa: PLC0415
 
-        from user_management.database import get_async_session  # noqa: PLC0415
+        from user_management.database import db_session_context  # noqa: PLC0415
 
-        async with get_async_session() as session:
+        async with db_session_context() as session:
             row = await session.execute(
                 text("SELECT bundle_name FROM user_voice_bundle WHERE user_id = :uid"),
                 {"uid": user_id},
@@ -136,9 +136,9 @@ async def set_user_bundle(
     try:
         from sqlalchemy import text  # noqa: PLC0415
 
-        from user_management.database import get_async_session  # noqa: PLC0415
+        from user_management.database import db_session_context  # noqa: PLC0415
 
-        async with get_async_session() as session:
+        async with db_session_context() as session:
             if body.bundle_name is None:
                 # Clear override
                 await session.execute(

--- a/autobot-backend/api/voice_bundle_user.py
+++ b/autobot-backend/api/voice_bundle_user.py
@@ -151,9 +151,9 @@ async def get_user_bundle(
     try:
         from sqlalchemy import text  # noqa: PLC0415
 
-        from user_management.database import get_async_session  # noqa: PLC0415
+        from user_management.database import db_session_context  # noqa: PLC0415
 
-        async with get_async_session() as session:
+        async with db_session_context() as session:
             row = await session.execute(
                 text("SELECT bundle_name FROM user_voice_bundle WHERE user_id = :uid"),
                 {"uid": user_id},
@@ -209,9 +209,9 @@ async def set_user_bundle(
     try:
         from sqlalchemy import text  # noqa: PLC0415
 
-        from user_management.database import get_async_session  # noqa: PLC0415
+        from user_management.database import db_session_context  # noqa: PLC0415
 
-        async with get_async_session() as session:
+        async with db_session_context() as session:
             if body.bundle_name is None:
                 await session.execute(
                     text("DELETE FROM user_voice_bundle WHERE user_id = :uid"),

--- a/autobot-backend/tests/api/test_voice_bundle_user.py
+++ b/autobot-backend/tests/api/test_voice_bundle_user.py
@@ -211,7 +211,7 @@ class TestGetUserBundle:
         """User can get their own bundle assignment."""
         client = _make_client(_USER_ALICE)
 
-        with patch("user_management.database.get_async_session") as mock_session_ctx:
+        with patch("user_management.database.db_session_context") as mock_session_ctx:
             mock_session = AsyncMock(spec=AsyncSession)
             mock_result = MagicMock()
             mock_result.fetchone.return_value = ("voice_extended",)
@@ -229,7 +229,7 @@ class TestGetUserBundle:
         """Admin can get any user's bundle assignment."""
         client = _make_client(_ADMIN)
 
-        with patch("user_management.database.get_async_session") as mock_session_ctx:
+        with patch("user_management.database.db_session_context") as mock_session_ctx:
             mock_session = AsyncMock(spec=AsyncSession)
             mock_result = MagicMock()
             mock_result.fetchone.return_value = ("voice_admin",)
@@ -254,7 +254,7 @@ class TestGetUserBundle:
         """Getting bundle when none assigned returns null."""
         client = _make_client(_USER_ALICE)
 
-        with patch("user_management.database.get_async_session") as mock_session_ctx:
+        with patch("user_management.database.db_session_context") as mock_session_ctx:
             mock_session = AsyncMock(spec=AsyncSession)
             mock_result = MagicMock()
             mock_result.fetchone.return_value = None
@@ -309,7 +309,7 @@ class TestSetUserBundle:
         client = _make_client(_ADMIN)
 
         with (
-            patch("user_management.database.get_async_session") as mock_session_ctx,
+            patch("user_management.database.db_session_context") as mock_session_ctx,
             patch("api.voice_bundle_user.emit") as mock_emit,
         ):
             mock_session = AsyncMock(spec=AsyncSession)
@@ -335,7 +335,7 @@ class TestSetUserBundle:
         client = _make_client(_ADMIN)
 
         with (
-            patch("user_management.database.get_async_session") as mock_session_ctx,
+            patch("user_management.database.db_session_context") as mock_session_ctx,
             patch("api.voice_bundle_user.emit") as mock_emit,
         ):
             mock_session = AsyncMock(spec=AsyncSession)
@@ -380,7 +380,7 @@ class TestSetUserBundle:
         client = _make_client(_SUPERADMIN)
 
         with (
-            patch("user_management.database.get_async_session") as mock_session_ctx,
+            patch("user_management.database.db_session_context") as mock_session_ctx,
             patch("api.voice_bundle_user.emit") as mock_emit,
         ):
             mock_session = AsyncMock(spec=AsyncSession)
@@ -404,7 +404,7 @@ class TestSetUserBundle:
         client = _make_client(_ADMIN)
 
         with (
-            patch("user_management.database.get_async_session") as mock_session_ctx,
+            patch("user_management.database.db_session_context") as mock_session_ctx,
             patch("api.voice_bundle_user.emit") as mock_emit,
         ):
             mock_session = AsyncMock(spec=AsyncSession)
@@ -472,3 +472,52 @@ class TestSuperadminIsNotLockedOut:
         plain = {"role": "user", "user_id": "user-1"}
         assert _check_self_or_admin(MagicMock(), plain, "user-2") is False
         assert _check_self_or_admin(MagicMock(), plain, "user-1") is True
+
+
+class TestSessionAcquisitionIsAContextManager:
+    """#13364: the voice-bundle endpoints must open sessions with a real
+    async context manager.
+
+    Every other test in this file patches the session helper with a mock that
+    implements ``__aenter__``, so they pass whatever the production code calls —
+    which is exactly how this shipped. ``get_async_session`` is an undecorated
+    async *generator* (a FastAPI ``Depends`` dependency); ``async with`` on it
+    raises ``AttributeError: __aenter__``, and the endpoints' ``except
+    Exception`` turned that into an unconditional ``500 Database error``. All
+    four sites were dead on arrival in production and green in CI.
+
+    These tests use the real objects, so they fail if the endpoints go back to
+    the generator.
+    """
+
+    def test_db_session_context_supports_async_with(self):
+        from user_management.database import db_session_context
+
+        cm = db_session_context()
+        assert hasattr(cm, "__aenter__"), "db_session_context must be usable with 'async with'"
+        assert hasattr(cm, "__aexit__")
+
+    def test_get_async_session_does_not_support_async_with(self):
+        """Documents *why* the endpoints must not use it — it is a Depends generator."""
+        from user_management.database import get_async_session
+
+        gen = get_async_session()
+        assert not hasattr(gen, "__aenter__"), (
+            "get_async_session gained __aenter__; if it is now a context manager this test "
+            "and the #13364 comments in the voice-bundle endpoints should be revisited"
+        )
+
+    def test_voice_bundle_endpoints_do_not_async_with_the_generator(self):
+        """Source-level guard: neither module may 'async with' the Depends generator."""
+        from pathlib import Path
+
+        import api.voice_bundle_admin as admin_mod
+        import api.voice_bundle_user as user_mod
+
+        for module in (admin_mod, user_mod):
+            source = Path(module.__file__).read_text(encoding="utf-8")
+            assert "async with get_async_session()" not in source, (
+                f"{Path(module.__file__).name} opens a session with the Depends generator; "
+                "use db_session_context() (#13364)"
+            )
+            assert "async with db_session_context()" in source


### PR DESCRIPTION
Closes #13364

## Thinking Path

Four sites did `async with get_async_session() as session:`. `get_async_session` is an **undecorated async generator** — the FastAPI `Depends` dependency, whose docstring shows it used as `Depends(get_async_session)`. Calling it returns a generator object with no `__aenter__`, so the statement raises `AttributeError` before any query runs. Each endpoint wraps the block in `except Exception` and re-raises `HTTPException(500, "Database error")`, so **all four endpoints returned 500 unconditionally.**

Demonstrated at the primitive level:

```
bare async generator + 'async with'  -> AttributeError: __aenter__
@asynccontextmanager  + 'async with' -> ok
```

**I got the fix wrong on the first attempt and caught it before pushing.** I initially switched to `get_async_session_factory()()`, which works — but the existing tests then failed (43 → 36 passing). Investigating that told me two things: `db_session_context` is the canonical primitive here (decorated `@asynccontextmanager`, documented for exactly this, already used by `api/redis_mcp/rbac.py`), and the tests were patching the session helper all along.

## Why CI never caught this

Every existing test patches the session helper with a `MagicMock` configured with `__aenter__`. The mock satisfies `async with` regardless of what production calls, so the tests passed against code that could not run at all. Same shape #13162 kept turning up: green because it never touches the thing it covers.

## What Changed

| File | Change |
|---|---|
| `api/voice_bundle_admin.py` | 2 sites → `db_session_context()` |
| `api/voice_bundle_user.py` | 2 sites → `db_session_context()` |
| `tests/api/test_voice_bundle_user.py` | patches repointed; new `TestSessionAcquisitionIsAContextManager` |

The two write sites already call `await session.commit()` explicitly, so nothing depends on the generator's implicit commit — I checked that before switching, because `async_sessionmaker`'s context manager rolls back rather than commits, and getting it wrong would have silently discarded writes.

## Verification

```
voice_bundle_admin_test.py + tests/api/test_voice_bundle_user.py   46 passed
  (base, before the change: 43 passed — the 3 new tests are the delta)
isort · black · flake8 (0) · bandit                                clean
```

The new tests use the **real** objects rather than mocks:

- `db_session_context()` exposes `__aenter__`/`__aexit__`
- `get_async_session()` does **not** — this documents why it must not be used here, and fails loudly if that ever changes
- neither endpoint module contains `async with get_async_session(`

**Mutation-checked:** reverting `voice_bundle_user.py` to the generator fails the third test:

```
FAILED ...::test_voice_bundle_endpoints_do_not_async_with_the_generator
```

## Model Used

Claude Opus 5 (1M context)
