### PR TITLE
fix(openapi): stop publishing the Rust regex end anchor, which inverts validation in every JS client

### DIFF
--- a/autobot-slm-backend/scripts/dump_openapi.py
+++ b/autobot-slm-backend/scripts/dump_openapi.py
@@ -29,9 +29,14 @@ for _path in (str(_REPO_ROOT), str(_BACKEND_ROOT)):
 
 
 def main() -> int:
+    from autobot_shared.openapi_schema import normalize_pattern_anchors
     from main import app
 
-    spec = app.openapi()
+    # pydantic >= 2.12 emits the Rust end anchor `\\z` for a Field(pattern=...)
+    # written with `$`. JSON Schema's dialect is ECMA-262, which reads `\\z` as a
+    # literal `z` -- `^(hour|day)\\z` then rejects "hour" and accepts "hourz".
+    # Normalise before the spec becomes a published artifact (#12959 sweep).
+    spec = normalize_pattern_anchors(app.openapi())
     json.dump(spec, sys.stdout, indent=2, sort_keys=True, ensure_ascii=False)
     sys.stdout.write("\n")
     return 0

--- a/autobot-slm-frontend/openapi.json
+++ b/autobot-slm-frontend/openapi.json
@@ -17855,6 +17855,8 @@
             "required": false,
             "schema": {
               "default": 10,
+              "maximum": 100,
+              "minimum": 1,
               "title": "Limit",
               "type": "integer"
             }

--- a/autobot_shared/openapi_schema.py
+++ b/autobot_shared/openapi_schema.py
@@ -1,0 +1,53 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Normalisation applied to every OpenAPI spec this repo publishes.
+
+Both backends dump `app.openapi()` to a checked-in spec that the frontends
+generate types from, and CI regenerates the same spec to prove the committed one
+is fresh. Anything pydantic changes about its JSON-Schema output therefore lands
+directly in a published contract — which is how `\\z` got there.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = ["normalize_pattern_anchors"]
+
+#: pydantic >= 2.12 emits the Rust-regex end anchor for a `Field(pattern=...)`
+#: that was authored with `$`.
+_RUST_END_ANCHOR = "\\z"
+
+
+def normalize_pattern_anchors(node: Any) -> Any:
+    """Rewrite the Rust end anchor back to `$` in JSON-Schema ``pattern`` values.
+
+    JSON Schema's regex dialect is ECMA-262, which has no ``\\z``. Consumers do
+    not reject it — they misread it, which is worse:
+
+        JS   /^(hour|day)\\z/.test("hour")  -> false     (the valid value fails)
+        JS   /^(hour|day)\\z/.test("hourz") -> true      (an invalid value passes)
+        Py   re.match(r"^(hour|day)\\z", …) -> re.error: bad escape \\z
+
+    So a spec carrying it silently inverts validation for every JS client and
+    breaks every Python one. Field authors write ``$``; this restores what they
+    wrote, at the one point where the spec becomes a published artifact.
+
+    Only a *trailing* anchor is rewritten. A ``\\z`` anywhere else is not
+    something pydantic produces, and rewriting it would corrupt a pattern that
+    genuinely means a literal backslash followed by ``z``.
+    """
+    if isinstance(node, dict):
+        return {
+            key: (
+                value[: -len(_RUST_END_ANCHOR)] + "$"
+                if key == "pattern" and isinstance(value, str) and value.endswith(_RUST_END_ANCHOR)
+                else normalize_pattern_anchors(value)
+            )
+            for key, value in node.items()
+        }
+    if isinstance(node, list):
+        return [normalize_pattern_anchors(item) for item in node]
+    return node

--- a/autobot_shared/tests/test_openapi_pattern_anchors.py
+++ b/autobot_shared/tests/test_openapi_pattern_anchors.py
@@ -1,0 +1,152 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Published OpenAPI specs must not carry the Rust regex end anchor.
+
+pydantic >= 2.12 emits ``\\z`` in JSON Schema for a ``Field(pattern=...)`` the
+author wrote with ``$``. JSON Schema's regex dialect is ECMA-262, which has no
+``\\z`` — so consumers do not reject the spec, they misread it:
+
+    JS   /^(hour|day)\\z/.test("hour")  -> False   the valid value fails
+    JS   /^(hour|day)\\z/.test("hourz") -> True    an invalid value passes
+    Py   re.match(r"^(hour|day)\\z", …) -> re.error: bad escape \\z
+
+Both measured. Validation is inverted for every JS client and impossible for
+every Python one, from a spec that looks fine in review.
+
+Surfaced by `verify-generated-types-slm` failing on a PR that touched no schema:
+the committed spec had ``$`` and a fresh dump produced ``\\z``, so CI reported
+"generated types are stale". Regenerating would have made CI green by publishing
+the broken contract. Normalising at the dump instead keeps the artifact portable
+and the check meaningful.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from autobot_shared.openapi_schema import normalize_pattern_anchors
+
+_REPO = Path(__file__).resolve().parents[2]
+_SLM_SPEC = _REPO / "autobot-slm-frontend" / "openapi.json"
+
+
+def test_trailing_rust_anchor_becomes_dollar():
+    assert normalize_pattern_anchors({"pattern": "^(hour|day)\\z"}) == {"pattern": "^(hour|day)$"}
+
+
+def test_nested_and_listed_schemas_are_reached():
+    spec = {
+        "components": {
+            "schemas": {
+                "A": {"properties": {"x": {"pattern": "^a\\z"}}},
+                "B": {"anyOf": [{"pattern": "^b\\z"}, {"pattern": "^c$"}]},
+            }
+        }
+    }
+    out = normalize_pattern_anchors(spec)
+    assert out["components"]["schemas"]["A"]["properties"]["x"]["pattern"] == "^a$"
+    assert [s["pattern"] for s in out["components"]["schemas"]["B"]["anyOf"]] == ["^b$", "^c$"]
+
+
+def test_already_normalized_patterns_are_untouched():
+    """Idempotence matters: CI regenerates and diffs, so a second pass must be a no-op."""
+    spec = {"pattern": "^(hour|day)$"}
+    assert normalize_pattern_anchors(normalize_pattern_anchors(spec)) == spec
+
+
+def test_non_pattern_keys_and_values_are_untouched():
+    spec = {"description": "ends with \\z", "default": 10, "enum": ["a\\z"]}
+    assert normalize_pattern_anchors(spec) == spec
+
+
+def test_a_literal_backslash_z_mid_pattern_survives():
+    """Only a trailing anchor is rewritten — pydantic never emits one elsewhere.
+
+    Rewriting a mid-pattern occurrence would corrupt a pattern that genuinely
+    means a literal backslash followed by ``z``.
+    """
+    spec = {"pattern": "^a\\zb$"}
+    assert normalize_pattern_anchors(spec) == spec
+
+
+def test_committed_slm_spec_carries_no_rust_anchor():
+    """The published artifact itself, not just the helper."""
+    if not _SLM_SPEC.is_file():
+        pytest.skip(f"{_SLM_SPEC} not present")
+
+    offending = [
+        (path, value)
+        for path, value in _iter_patterns(json.loads(_SLM_SPEC.read_text(encoding="utf-8")))
+        if value.endswith("\\z")
+    ]
+    assert not offending, (
+        "the committed SLM OpenAPI spec publishes Rust end anchors, which every JS "
+        "consumer misreads and every Python one refuses to compile:\n  "
+        + "\n  ".join(f"{p}: {v}" for p, v in offending)
+    )
+
+
+def test_every_committed_pattern_compiles_as_a_python_regex():
+    """A pattern no consumer can compile is not a constraint, it is a landmine."""
+    if not _SLM_SPEC.is_file():
+        pytest.skip(f"{_SLM_SPEC} not present")
+
+    broken = []
+    for path, value in _iter_patterns(json.loads(_SLM_SPEC.read_text(encoding="utf-8"))):
+        try:
+            re.compile(value)
+        except re.error as exc:
+            broken.append(f"{path}: {value!r} -> {exc}")
+
+    assert not broken, "uncompilable patterns in the published spec:\n  " + "\n  ".join(broken)
+
+
+def test_both_dump_paths_normalize():
+    """CI regenerates via audit_api_wiring.py and diffs against dump_openapi.py output.
+
+    If only one normalises, every PR touching the SLM backend is reported as
+    having stale generated types — which is exactly how this was found.
+    """
+    for script in ("autobot-slm-backend/scripts/dump_openapi.py", "scripts/audit_api_wiring.py"):
+        text = (_REPO / script).read_text(encoding="utf-8")
+        assert "normalize_pattern_anchors(app.openapi())" in text, (
+            f"{script} dumps app.openapi() without normalising; the two dump paths "
+            "must produce byte-identical specs or the freshness check is meaningless"
+        )
+
+
+def test_rust_anchor_is_genuinely_unusable_in_python():
+    """Pins the premise, so nobody 'simplifies' this away as cosmetic."""
+    with pytest.raises(re.error):
+        re.compile("^(hour|day)\\z")
+
+
+def test_node_reads_the_rust_anchor_as_a_literal_z():
+    """The JS half of the premise — silent, which is why it matters more."""
+    node = subprocess.run(["node", "--version"], capture_output=True)
+    if node.returncode != 0:
+        pytest.skip("node not available")
+
+    script = 'const r=/^(hour|day)\\z/;console.log(r.test("hour"),r.test("hourz"))'
+    out = subprocess.run(["node", "-e", script], capture_output=True, text=True, timeout=60)
+    assert out.stdout.strip() == "false true", (
+        "expected the valid value to fail and the invalid one to pass; got " + out.stdout.strip()
+    )
+
+
+def _iter_patterns(node, path="$"):
+    """Yield ``(json_path, pattern)`` for every ``pattern`` string in the spec."""
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if key == "pattern" and isinstance(value, str):
+                yield f"{path}.{key}", value
+            else:
+                yield from _iter_patterns(value, f"{path}.{key}")
+    elif isinstance(node, list):
+        for index, item in enumerate(node):
+            yield from _iter_patterns(item, f"{path}[{index}]")

--- a/scripts/audit_api_wiring.py
+++ b/scripts/audit_api_wiring.py
@@ -55,6 +55,14 @@ from collections import defaultdict
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Imported here, not inside the dump helpers: each of them prepends a backend
+# dir to sys.path and chdirs into it, and the repo root is not on sys.path when
+# this script runs as `python3 scripts/audit_api_wiring.py` — so a late import
+# fails with "No module named 'autobot_shared'" and takes the whole dump with it.
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+from autobot_shared.openapi_schema import normalize_pattern_anchors  # noqa: E402
 BACKEND = REPO_ROOT / "autobot-backend"
 # #12381: the SLM control-plane backend (autobot-slm-backend, :8000) mounts
 # its own '/api'-prefixed route table, entirely separate from autobot-backend
@@ -135,7 +143,10 @@ def dump_openapi(out_path: str) -> int:
         from app_factory import create_app  # type: ignore
 
         app = create_app()
-        spec = app.openapi()
+        # Same anchor normalisation as the SLM path below — the main backend has
+        # no Field(pattern=…) today, so this is prophylactic, not a fix. It is
+        # here so the first one added does not silently publish `\z`.
+        spec = normalize_pattern_anchors(app.openapi())
         # FastAPI omits WebSocket routes from OpenAPI — record them in a
         # custom key so the audit can verify /api/ws* style frontend calls
         # against the real route table instead of flagging them (GH#9864).
@@ -176,7 +187,10 @@ def dump_slm_openapi(out_path: str) -> int:
     try:
         from main import app  # type: ignore
 
-        spec = app.openapi()
+        # Must match autobot-slm-backend/scripts/dump_openapi.py exactly: CI
+        # regenerates through THIS path and diffs against the file the other
+        # path produced, so any divergence is reported as stale generated types.
+        spec = normalize_pattern_anchors(app.openapi())
         # Same runtime+static WebSocket union as dump_openapi() (GH#9864, #12381).
         ws = _runtime_websocket_paths(app) | static_websocket_paths(SLM_BACKEND)
         spec["x-websocket-paths"] = sorted(ws)


### PR DESCRIPTION
## Thinking Path

`verify-generated-types-slm` failed on PR #13454 — a PR that touches Ansible, tests and docs, and no schema at all. It ran only because the path filter matched `autobot-slm-backend/`, and it reported "generated types are stale" with a diff of 19 `pattern` values:

```diff
-              "pattern": "^(hour|day)$",
+              "pattern": "^(hour|day)\z",
```

The committed spec was not stale. **pydantic ≥ 2.12 emits the Rust-regex end anchor `\z` for a `Field(pattern=...)` the author wrote with `$`.** The obvious response — regenerate and commit, exactly as the failure message instructs — would have made CI green by publishing a broken contract, so I checked what `\z` actually means to a consumer first.

JSON Schema's regex dialect is ECMA-262, which has no `\z`:

```console
$ node -e 'const r=/^(hour|day)\z/; console.log(r.test("hour"), r.test("hourz"))'
false true

$ python3 -c 'import re; re.match(r"^(hour|day)\z", "hour")'
re.error: bad escape \z at position 11
```

Every JS client silently **inverts** the constraint — the valid value fails, an invalid one passes — and every Python client refuses to compile it. This is not cosmetic drift; it is a validation contract that is wrong in a way review cannot see, because the spec looks fine and the pattern looks fine.

So the fix is at the dump, not in the committed artifact: normalise the anchor at the single point where `app.openapi()` becomes a published file. The spec stays portable, the committed file stays correct, and the freshness check goes back to meaning what it says.

## What Changed

`autobot_shared/openapi_schema.py` (new) — `normalize_pattern_anchors()`, rewriting a **trailing** `\z` to `$` in `pattern` values. Only trailing: pydantic emits it nowhere else, and rewriting a mid-pattern occurrence would corrupt a pattern that genuinely means a literal backslash followed by `z`.

Applied at all three dump sites:
- `autobot-slm-backend/scripts/dump_openapi.py` — what `npm run gen:types:openapi` runs
- `scripts/audit_api_wiring.py::dump_slm_openapi` — what **CI** regenerates through
- `scripts/audit_api_wiring.py::dump_openapi` — the main backend; it has no `Field(pattern=…)` today, so this is prophylactic, so the first one added does not silently publish `\z`

Both SLM paths must normalise, not one: CI diffs the output of one against the file produced by the other, so a divergence is reported as stale generated types on every PR touching the SLM backend.

The import sits at module scope in `audit_api_wiring.py`. Both dump helpers `chdir` into a backend and prepend it to `sys.path`, and the repo root is not on `sys.path` under `python3 scripts/audit_api_wiring.py` — a late import dies with `No module named 'autobot_shared'` and takes the whole dump with it. Found by running it.

`autobot-slm-frontend/openapi.json` — two lines, the only **genuine** drift once the noise was gone: `maximum: 100` / `minimum: 1` on a `Limit` query parameter, a real backend change never regenerated. `api.ts` regenerates unchanged (numeric bounds do not surface in TS types).

## Verification

Both dump paths now produce the committed spec exactly:

```console
$ python3 scripts/audit_api_wiring.py --dump-slm-openapi /tmp/ci-dump.json
[dump-slm-openapi] wrote 304 paths (+26 websocket)

$ python3 -c "…strip x-websocket-paths, compare…"
CI dump == committed spec: True
rust anchors in CI dump: 0

$ cd autobot-slm-frontend && npm run gen:types:openapi && git diff --stat openapi.json
 autobot-slm-frontend/openapi.json | 2 ++      # the Limit bounds, nothing else
```

```console
$ python3 -m pytest autobot_shared/tests/test_openapi_pattern_anchors.py \
                    scripts/audit_api_wiring_test.py -q
22 passed
```

The 10 new tests pin the helper (nesting, lists, idempotence — CI regenerates and diffs, so a second pass must be a no-op — non-`pattern` keys, mid-pattern survival), the published artifact (no `\z`, and **every** committed pattern compiles under Python `re`), that both dump paths normalise, and the two premises themselves: `re.error` on the Python side, `false true` on the JS side. The premises are pinned so nobody later "simplifies" this away as cosmetic.

## Why this is its own PR

It unblocks every PR that touches `autobot-slm-backend/` — the check is path-filtered, so it is `SKIPPED` on most PRs and nobody saw it. Bundling a generated-spec change into an unrelated deploy PR would also have made both harder to review.

Closes #13465

Refs #12959

## Model Used

Opus 5 (1M context)