### PR TITLE
fix(code-intelligence): run whole-tree scans in a separate process so they stop stalling the API (#12866)

### DIFF
--- a/autobot-backend/api/code_intelligence.py
+++ b/autobot-backend/api/code_intelligence.py
@@ -82,6 +82,7 @@ from code_intelligence.security import (
     SecuritySeverity,
     get_vulnerability_types,
 )
+from code_intelligence.shared.process_offload import run_directory_scan, run_isolated
 from code_intelligence.shared.scoring import get_grade_from_score
 from constants.ttl_constants import TTL_5_MINUTES
 from tasks.analytics_tasks import run_security_analysis
@@ -545,7 +546,7 @@ def _filter_antipatterns_by_severity(
 
 
 async def _run_redis_analysis(
-    optimizer: RedisOptimizer,
+    project_root: str,
     path: str,
     exclude_patterns: list | None,
 ) -> list:
@@ -554,8 +555,14 @@ async def _run_redis_analysis(
 
     Issue #620.
 
+    #12866: takes the project root rather than a live ``RedisOptimizer`` so the
+    scan can run in a separate process — a constructed instance is not
+    guaranteed picklable, and the whole point is to keep this pure-Python scan
+    off the API process's GIL. A single-file scan is bounded and stays in a
+    thread; only the whole-tree walk is worth a process hop.
+
     Args:
-        optimizer: RedisOptimizer instance
+        project_root: Root the optimizer is constructed against
         path: Path to analyze
         exclude_patterns: Patterns to exclude from analysis
 
@@ -564,9 +571,13 @@ async def _run_redis_analysis(
     """
     is_file = await asyncio.to_thread(os.path.isfile, path)
     if is_file:
-        return await asyncio.to_thread(optimizer.analyze_file, path)
-    return await asyncio.to_thread(
-        optimizer.analyze_directory,
+        return await run_isolated(
+            RedisOptimizer, {"project_root": project_root}, "analyze_file", path
+        )
+    return await run_isolated(
+        RedisOptimizer,
+        {"project_root": project_root},
+        "analyze_directory",
         path,
         exclude_patterns=exclude_patterns,
     )
@@ -699,8 +710,12 @@ async def analyze_codebase(
     await _validate_path_is_directory(request.path)
 
     try:
-        detector = AntiPatternDetector(exclude_dirs=request.exclude_dirs)
-        report = await asyncio.to_thread(detector.analyze_directory, request.path)
+        report = await run_isolated(
+            AntiPatternDetector,
+            {"exclude_dirs": request.exclude_dirs},
+            "analyze_directory",
+            request.path,
+        )
         report.anti_patterns = _filter_antipatterns_by_severity(
             report.anti_patterns,
             request.min_severity,
@@ -885,8 +900,7 @@ async def get_codebase_health_score(
         raise_invalid_input("path", f"does not exist: {path}")
 
     try:
-        detector = AntiPatternDetector()
-        report = await asyncio.to_thread(detector.analyze_directory, path)
+        report = await run_isolated(AntiPatternDetector, {}, "analyze_directory", path)
 
         # Calculate health score
         score = _calculate_health_score(report.anti_patterns)
@@ -973,14 +987,17 @@ async def analyze_redis_usage_endpoint(
     await _validate_path_exists(request.path)
 
     try:
-        optimizer = RedisOptimizer(project_root=request.path)
         results = await _run_redis_analysis(
-            optimizer,
+            request.path,
             request.path,
             request.exclude_patterns,
         )
         results = _filter_redis_results_by_severity(results, request.min_severity)
 
+        # The scan ran in another process, so summarise through a local instance
+        # carrying the (already severity-filtered) findings — get_summary() reads
+        # self.results (#12866).
+        optimizer = RedisOptimizer(project_root=request.path)
         optimizer.results = results
         summary = optimizer.get_summary()
         response_content = _build_redis_analysis_response(request.path, results, summary)
@@ -1134,8 +1151,9 @@ async def get_redis_usage_health_score(
 
 async def _run_redis_health_analysis(path: str) -> Dict[str, Any]:
     """Run Redis health analysis in a thread. Issue #1034."""
-    optimizer = RedisOptimizer(project_root=path)
-    results = await asyncio.to_thread(optimizer.analyze_directory, path)
+    results = await run_isolated(
+        RedisOptimizer, {"project_root": path}, "analyze_directory", path
+    )
 
     score = _calculate_redis_health_score(results)
     grade = get_grade_from_score(score)
@@ -1194,7 +1212,7 @@ async def security_analyze(
             project_root=request.path,
             exclude_patterns=request.exclude_patterns,
         )
-        results = await asyncio.to_thread(analyzer.analyze_directory)
+        results = await run_directory_scan(analyzer)
         results = _filter_results_by_severity(results, request.min_severity)
         summary = analyzer.get_summary()
 
@@ -1403,7 +1421,7 @@ async def get_security_report(
 
     try:
         analyzer = SecurityAnalyzer(project_root=path)
-        await asyncio.to_thread(analyzer.analyze_directory)
+        await run_directory_scan(analyzer)
         return await _generate_report_response(analyzer, path, format)
 
     except Exception as e:
@@ -1447,7 +1465,7 @@ async def performance_analyze(
             project_root=request.path,
             exclude_patterns=request.exclude_patterns,
         )
-        results = await asyncio.to_thread(analyzer.analyze_directory)
+        results = await run_directory_scan(analyzer)
         results = _filter_results_by_severity(results, request.min_severity)
         summary = analyzer.get_summary()
 
@@ -1598,7 +1616,7 @@ async def get_performance_score(
 
     try:
         analyzer = PerformanceAnalyzer(project_root=path)
-        await asyncio.to_thread(analyzer.analyze_directory)
+        await run_directory_scan(analyzer)
         summary = analyzer.get_summary()
 
         # Get score and grade, generate status using extracted helper
@@ -1654,7 +1672,7 @@ async def get_performance_report(
 
     try:
         analyzer = PerformanceAnalyzer(project_root=path)
-        await asyncio.to_thread(analyzer.analyze_directory)
+        await run_directory_scan(analyzer)
         return await _generate_report_response(analyzer, path, format)
 
     except Exception as e:

--- a/autobot-backend/api/code_intelligence.py
+++ b/autobot-backend/api/code_intelligence.py
@@ -571,9 +571,7 @@ async def _run_redis_analysis(
     """
     is_file = await asyncio.to_thread(os.path.isfile, path)
     if is_file:
-        return await run_isolated(
-            RedisOptimizer, {"project_root": project_root}, "analyze_file", path
-        )
+        return await run_isolated(RedisOptimizer, {"project_root": project_root}, "analyze_file", path)
     return await run_isolated(
         RedisOptimizer,
         {"project_root": project_root},
@@ -1151,9 +1149,7 @@ async def get_redis_usage_health_score(
 
 async def _run_redis_health_analysis(path: str) -> Dict[str, Any]:
     """Run Redis health analysis in a thread. Issue #1034."""
-    results = await run_isolated(
-        RedisOptimizer, {"project_root": path}, "analyze_directory", path
-    )
+    results = await run_isolated(RedisOptimizer, {"project_root": path}, "analyze_directory", path)
 
     score = _calculate_redis_health_score(results)
     grade = get_grade_from_score(score)

--- a/autobot-backend/api/code_intelligence.py
+++ b/autobot-backend/api/code_intelligence.py
@@ -1148,8 +1148,15 @@ async def get_redis_usage_health_score(
 
 
 async def _run_redis_health_analysis(path: str) -> Dict[str, Any]:
-    """Run Redis health analysis in a thread. Issue #1034."""
+    """Run Redis health analysis off the API process. Issue #1034, #12866."""
     results = await run_isolated(RedisOptimizer, {"project_root": path}, "analyze_directory", path)
+
+    # #12866: the scan ran in another process, so its optimizer is gone. Summarise
+    # through a local instance carrying the findings — get_summary() reads
+    # self.results, and reading it off an un-run optimizer returns an empty
+    # by_type map, i.e. a silently empty category_breakdown.
+    optimizer = RedisOptimizer(project_root=path)
+    optimizer.results = results
 
     score = _calculate_redis_health_score(results)
     grade = get_grade_from_score(score)

--- a/autobot-backend/api/code_intelligence_offload_wiring_test.py
+++ b/autobot-backend/api/code_intelligence_offload_wiring_test.py
@@ -1,0 +1,168 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""The process-offload conversion must not drop state the response needs (#12866).
+
+Moving a scan into another process leaves the local scanner object un-run, and
+these endpoints summarise *through* that object. Two ways that goes wrong, both
+silent:
+
+* the scanner is gone entirely and a later line still names it — ``F821``, a
+  500 on the endpoint. Exactly what happened to ``_run_redis_health_analysis``:
+  the conversion removed ``optimizer = RedisOptimizer(...)`` while
+  ``category_breakdown`` still read ``optimizer.get_summary()``. flake8 caught
+  it; nothing here did, because no test called the helper.
+* the scanner survives but is never given the child's findings, so
+  ``get_summary()`` reports an empty scan of a tree that was fully scanned.
+  Nothing raises — the response is well-formed and wrong.
+
+So these call the converted helpers for real, with the scan stubbed, and assert
+the summarised fields actually reflect the findings.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+class _Finding:
+    """Minimal stand-in for a RedisOptimizer result."""
+
+    def __init__(self, file_path: str, severity, opt_type: str):
+        self.file_path = file_path
+        self.severity = severity
+        self.optimization_type = opt_type
+        self.type = opt_type
+
+
+def _redis_findings():
+    from code_intelligence.redis_optimizer import OptimizationSeverity
+
+    return [
+        _Finding("a.py", OptimizationSeverity.HIGH, "pipeline"),
+        _Finding("a.py", OptimizationSeverity.LOW, "ttl"),
+        _Finding("b.py", OptimizationSeverity.HIGH, "pipeline"),
+    ]
+
+
+class _FakeOptimizer:
+    """A RedisOptimizer whose summary is genuinely derived from its findings.
+
+    The real class is a ``MagicMock`` in this harness (conftest stubs the
+    code_intelligence package). Asserting against it is vacuous: every attribute
+    access returns a truthy mock, so ``assert result["category_breakdown"]``
+    passes whether or not the findings were ever handed over. That is the #13111
+    / #13162 harness-bug shape, and it hid this exact regression on the first
+    attempt at this test.
+    """
+
+    def __init__(self, project_root=None):
+        self.project_root = project_root
+        self.results = []
+
+    def get_summary(self):
+        by_type = {}
+        for finding in self.results:
+            by_type[finding.type] = by_type.get(finding.type, 0) + 1
+        return {"by_type": by_type}
+
+
+async def test_redis_health_analysis_summarises_the_offloaded_findings():
+    """The regression that shipped: the helper named a scanner it no longer built.
+
+    ``category_breakdown`` reads ``optimizer.get_summary()``. The conversion
+    removed ``optimizer = RedisOptimizer(...)`` and flake8 caught the F821 — but
+    only after CI ran, because nothing here called the helper. Rebuilding the
+    scanner is not enough either: it must be handed the child's findings, or the
+    field is a well-formed empty dict.
+    """
+    import api.code_intelligence as mod
+
+    findings = _redis_findings()
+
+    with patch.object(mod, "RedisOptimizer", _FakeOptimizer):
+        with patch.object(mod, "run_isolated", return_value=findings) as scan:
+            result = await mod._run_redis_health_analysis("/tmp/example")
+
+    assert scan.await_count == 1, "the scan must go through the process-offload helper"
+
+    assert result["status"] == "success"
+    assert result["total_optimizations"] == 3
+    assert result["files_with_issues"] == 2
+
+    # Derived from the findings, so an un-fed optimizer produces {} and fails here.
+    assert result["category_breakdown"] == {"pipeline": 2, "ttl": 1}, (
+        "category_breakdown does not reflect the findings — the local optimizer was "
+        "never given what the child produced, so get_summary() summarised nothing"
+    )
+
+
+async def test_redis_analysis_offloads_a_directory_scan_by_class_not_instance():
+    """A constructed scanner is not guaranteed picklable; the class and kwargs are."""
+    import api.code_intelligence as mod
+    from code_intelligence.redis_optimizer import RedisOptimizer
+
+    findings = _redis_findings()
+
+    with patch.object(mod, "run_isolated", return_value=findings) as scan:
+        with patch("os.path.isfile", return_value=False):
+            out = await mod._run_redis_analysis("/tmp/example", "/tmp/example", ["venv"])
+
+    assert out == findings
+    cls, init_kwargs, method = scan.await_args.args[:3]
+    assert cls is RedisOptimizer
+    assert init_kwargs == {"project_root": "/tmp/example"}
+    assert method == "analyze_directory"
+    assert scan.await_args.kwargs["exclude_patterns"] == ["venv"]
+
+
+async def test_single_file_redis_analysis_still_reaches_analyze_file():
+    """A bounded single-file scan must not be silently turned into a tree walk."""
+    import api.code_intelligence as mod
+
+    with patch.object(mod, "run_isolated", return_value=[]) as scan:
+        with patch("os.path.isfile", return_value=True):
+            await mod._run_redis_analysis("/tmp/example", "/tmp/example/one.py", None)
+
+    assert scan.await_args.args[2] == "analyze_file"
+
+
+async def test_every_converted_site_still_resolves_its_names():
+    """A cheap tripwire for the F821 class that reached CI.
+
+    Compiling the module is not enough — an undefined name inside a function body
+    only raises when that line runs. This walks the AST of the converted helpers
+    and checks every name they load is either bound locally, a parameter, or a
+    module global.
+    """
+    import ast
+    import builtins
+    import inspect
+
+    import api.code_intelligence as mod
+
+    for func in (mod._run_redis_health_analysis, mod._run_redis_analysis):
+        tree = ast.parse(inspect.getsource(func).lstrip())
+        fn = tree.body[0]
+
+        bound = {a.arg for a in fn.args.args} | {a.arg for a in fn.args.kwonlyargs}
+        for node in ast.walk(fn):
+            if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store):
+                bound.add(node.id)
+            elif isinstance(node, (ast.Import, ast.ImportFrom)):
+                bound.update((a.asname or a.name).split(".")[0] for a in node.names)
+            elif isinstance(node, ast.comprehension):
+                for target in ast.walk(node.target):
+                    if isinstance(target, ast.Name):
+                        bound.add(target.id)
+
+        loaded = {n.id for n in ast.walk(fn) if isinstance(n, ast.Name) and isinstance(n.ctx, ast.Load)}
+        unresolved = loaded - bound - set(vars(mod)) - set(dir(builtins))
+
+        assert not unresolved, (
+            f"{func.__name__} loads names nothing binds: {sorted(unresolved)} — "
+            "the offload conversion removed a scanner a later line still uses"
+        )

--- a/autobot-backend/code_intelligence/shared/process_offload.py
+++ b/autobot-backend/code_intelligence/shared/process_offload.py
@@ -174,9 +174,7 @@ async def run_isolated(
 
     loop = asyncio.get_running_loop()
     try:
-        return await loop.run_in_executor(
-            pool, _call_in_child, cls, init_kwargs, method_name, args, kwargs
-        )
+        return await loop.run_in_executor(pool, _call_in_child, cls, init_kwargs, method_name, args, kwargs)
     except Exception as exc:  # noqa: BLE001
         logger.error("Isolated %s.%s failed in the worker process: %s", cls.__name__, method_name, exc)
         await shutdown_scan_pool()

--- a/autobot-backend/code_intelligence/shared/process_offload.py
+++ b/autobot-backend/code_intelligence/shared/process_offload.py
@@ -1,0 +1,234 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Run a whole-tree analyzer scan in a separate PROCESS (#12866).
+
+``asyncio.to_thread`` moves work off the event *loop* but not off the *GIL*.
+``BaseCodeAnalyzer.analyze_directory`` is pure-Python `re` and `ast` over every
+file in the tree, and neither releases the GIL — so the worker thread holds it in
+long stretches and the loop cannot run. With ``uvicorn --workers 1`` (the
+canonical unit) there is no second worker to absorb requests, so *every* client
+stalls together.
+
+Measured on an idle single-box host, 40 samples of ``/api/service-monitor/vms/status``
+at 4 s intervals:
+
+    min=0.09s   p50=0.85s   p90=12.00s   max=>=12.00s (client ceiling)
+    >2s: 15/40      >5s: 11/40 = 27.5%
+
+while a calm window minutes later served 12/12 in 0.020-0.036 s. The endpoint is
+not slow; the process stalls in bursts. ``py-spy`` caught the cause mid-stall:
+
+    _check_sql_injection (code_intelligence/security/analyzer.py)
+    _regex_analysis      (code_intelligence/shared/analysis_base.py)
+    analyze_directory    (code_intelligence/shared/analysis_base.py)
+    run                  (concurrent/futures/thread.py)
+
+A separate process has its own GIL, so the API process stays responsive for the
+whole scan. That fixes every endpoint at once, with no change to any response
+shape — the alternative (a Celery task per endpoint) would turn five synchronous
+findings responses into enqueue-and-poll and require matching frontend work.
+
+The scan is reconstructed in the child rather than pickled: an analyzer instance
+can hold Redis/ChromaDB handles from semantic analysis, which are not picklable
+and have no business in a scan worker. ``analyze_directory`` is purely regex+AST
+anyway — semantic work lives in ``analyze_directory_async`` — so the child is
+given only ``project_root`` and ``exclude_patterns``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import multiprocessing
+import os
+from concurrent.futures import ProcessPoolExecutor
+from typing import Any, List, Tuple, Type
+
+from autobot_shared.logging_manager import get_logger
+
+logger = get_logger(__name__)
+
+__all__ = ["run_directory_scan", "run_isolated", "shutdown_scan_pool"]
+
+# One worker is enough to keep the API process free; the point is isolation from
+# the GIL, not parallelism within a scan. More workers would multiply RSS (a scan
+# was measured growing the parent 1.58 GB -> 3.14 GB) for no latency win, since
+# analyze_directory is single-threaded.
+_MAX_WORKERS = max(1, int(os.getenv("AUTOBOT_CODE_ANALYSIS_POOL_WORKERS", "2")))
+
+# Recycle workers so a leaked reference inside a scan cannot accumulate across
+# requests. The scans are seconds long, so the respawn cost is noise.
+_MAX_TASKS_PER_CHILD = max(1, int(os.getenv("AUTOBOT_CODE_ANALYSIS_POOL_MAX_TASKS", "8")))
+
+_pool: ProcessPoolExecutor | None = None
+_pool_lock = asyncio.Lock()
+
+#: Set when the pool could not be created. Some container/sandbox configurations
+#: forbid process creation entirely; failing every code-intelligence endpoint
+#: there would be a worse outcome than the stalls this exists to prevent, so the
+#: scan runs in-thread instead. Logged at WARNING once, never silent — a host in
+#: this state still has the #12866 stalls and the log is how that is known.
+_pool_unavailable_reason: str | None = None
+
+
+def _scan_in_child(
+    analyzer_cls: Type[Any],
+    project_root: str | None,
+    exclude_patterns: List[str] | None,
+    directory: str | None,
+) -> Tuple[List[Any], int]:
+    """Reconstruct the analyzer in this process and run the scan.
+
+    Returns ``(results, total_files_scanned)``. Both are needed: the caller's
+    ``get_summary()`` reads ``self.results`` *and* ``self.total_files_scanned``,
+    so returning findings alone would silently report ``files_analyzed`` as the
+    count of distinct files that happened to have a finding.
+    """
+    analyzer = analyzer_cls(
+        project_root=project_root,
+        exclude_patterns=exclude_patterns,
+        use_semantic_analysis=False,
+    )
+    results = analyzer.analyze_directory(directory)
+    return results, analyzer.total_files_scanned
+
+
+async def _get_pool() -> ProcessPoolExecutor | None:
+    """Lazily create the shared pool; ``None`` means run in-thread instead."""
+    global _pool, _pool_unavailable_reason
+
+    if _pool is not None:
+        return _pool
+    if _pool_unavailable_reason is not None:
+        return None
+
+    async with _pool_lock:
+        if _pool is not None:
+            return _pool
+        if _pool_unavailable_reason is not None:
+            return None
+
+        try:
+            kwargs: dict[str, Any] = {
+                "max_workers": _MAX_WORKERS,
+                # "spawn", never "fork": forking a process that already has an
+                # event loop and worker threads copies their state into a child
+                # that never runs them, which deadlocks on any lock held at the
+                # moment of the fork.
+                "mp_context": multiprocessing.get_context("spawn"),
+            }
+            if "max_tasks_per_child" in ProcessPoolExecutor.__init__.__code__.co_varnames:
+                kwargs["max_tasks_per_child"] = _MAX_TASKS_PER_CHILD
+            _pool = ProcessPoolExecutor(**kwargs)
+            logger.info(
+                "Code-analysis process pool started (workers=%d, max_tasks_per_child=%s)",
+                _MAX_WORKERS,
+                kwargs.get("max_tasks_per_child", "unsupported"),
+            )
+            return _pool
+        except (OSError, ValueError, ImportError) as exc:
+            _pool_unavailable_reason = str(exc)
+            logger.warning(
+                "Code-analysis process pool unavailable (%s); falling back to a worker "
+                "thread. Scans will hold the GIL and stall this process for their "
+                "duration — the #12866 symptom is expected on this host.",
+                exc,
+            )
+            return None
+
+
+def _call_in_child(
+    cls: Type[Any],
+    init_kwargs: dict,
+    method_name: str,
+    args: tuple,
+    kwargs: dict,
+) -> Any:
+    """Construct ``cls`` in this process and return one method call's result."""
+    return getattr(cls(**init_kwargs), method_name)(*args, **kwargs)
+
+
+async def run_isolated(
+    cls: Type[Any],
+    init_kwargs: dict,
+    method_name: str,
+    *args: Any,
+    **kwargs: Any,
+) -> Any:
+    """Run one scan method of a freshly constructed ``cls`` in a separate process.
+
+    For scanners that are not ``BaseCodeAnalyzer`` subclasses (``AntiPatternDetector``,
+    ``RedisOptimizer``) and whose callers use only the return value — so there is
+    no instance state to carry back across the process boundary.
+
+    Everything passed must be picklable, which is why the class and its
+    constructor arguments are passed rather than an instance: a live scanner can
+    hold handles that are not.
+    """
+    pool = await _get_pool()
+    target = getattr(cls(**init_kwargs), method_name) if pool is None else None
+
+    if pool is None:
+        return await asyncio.to_thread(lambda: target(*args, **kwargs))
+
+    loop = asyncio.get_running_loop()
+    try:
+        return await loop.run_in_executor(
+            pool, _call_in_child, cls, init_kwargs, method_name, args, kwargs
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.error("Isolated %s.%s failed in the worker process: %s", cls.__name__, method_name, exc)
+        await shutdown_scan_pool()
+        raise
+
+
+async def run_directory_scan(analyzer: Any, directory: str | None = None) -> List[Any]:
+    """Scan a tree without stalling the event loop, and populate ``analyzer``.
+
+    Drop-in for ``await asyncio.to_thread(analyzer.analyze_directory)``: the
+    caller keeps using ``analyzer.get_summary()`` and the returned findings
+    exactly as before.
+    """
+    pool = await _get_pool()
+
+    if pool is None:
+        return await asyncio.to_thread(analyzer.analyze_directory, directory)
+
+    loop = asyncio.get_running_loop()
+    try:
+        results, files_scanned = await loop.run_in_executor(
+            pool,
+            _scan_in_child,
+            type(analyzer),
+            str(analyzer.project_root),
+            list(analyzer.exclude_patterns),
+            directory,
+        )
+    except Exception as exc:  # noqa: BLE001
+        # A child that dies (OOM kill, segfault in a C extension) breaks the
+        # whole pool: every later submission raises BrokenProcessPool. Drop it so
+        # the next request gets a fresh one instead of failing forever.
+        logger.error("Code-analysis scan failed in the worker process: %s", exc)
+        await shutdown_scan_pool()
+        raise
+
+    # The child's analyzer is gone; the caller's must carry its state, or
+    # get_summary() reports an empty scan of a tree that was fully scanned.
+    analyzer.results = results
+    analyzer.total_files_scanned = files_scanned
+    return results
+
+
+async def shutdown_scan_pool() -> None:
+    """Tear the pool down (app shutdown, or after a worker died)."""
+    global _pool
+
+    async with _pool_lock:
+        if _pool is None:
+            return
+        pool, _pool = _pool, None
+
+    # shutdown() joins the worker processes, which blocks — keep it off the loop.
+    await asyncio.to_thread(pool.shutdown, wait=False, cancel_futures=True)
+    logger.info("Code-analysis process pool shut down")

--- a/autobot-backend/code_intelligence/shared/process_offload_test.py
+++ b/autobot-backend/code_intelligence/shared/process_offload_test.py
@@ -1,0 +1,257 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""A whole-tree scan must not stall the event loop (#12866).
+
+``asyncio.to_thread`` moves work off the loop but not off the GIL, and
+``analyze_directory`` is pure-Python `re`/`ast` — neither releases it. With
+``uvicorn --workers 1`` there is no second worker, so every client stalls
+together: 27.5% of the GUI's 5 s status polls exceeded their budget on a healthy
+box and rendered "Backend API — Unreachable".
+
+The load-bearing test is ``test_a_scan_in_a_process_does_not_delay_the_event_loop``.
+It measures how long a 5 ms heartbeat actually takes while a GIL-bound scan runs,
+both ways, and compares them.
+
+Tick *count* was tried first and does not discriminate: CPython hands the GIL
+over every switch interval, so the loop keeps running under ``to_thread`` — it
+just runs late. Latency does discriminate, and reproducibly:
+
+    asyncio.to_thread    median tick 10.7ms   p95 11.3-15.9ms
+    ProcessPoolExecutor  median tick  5.3ms   p95  5.5ms
+
+against a 5 ms request. That per-wakeup tax, compounded across every await in a
+request, is how a 25 ms endpoint became a 12 s one. Everything else here is a
+property of the plumbing — this is the property the issue is about.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from pathlib import Path
+
+import pytest
+
+from code_intelligence.shared import process_offload
+from code_intelligence.shared.process_offload import (
+    run_directory_scan,
+    run_isolated,
+    shutdown_scan_pool,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+class _FakeAnalyzer:
+    """Stands in for a BaseCodeAnalyzer subclass.
+
+    Module-level (not nested in a test) because a spawned child re-imports this
+    module to unpickle the class — a locally defined one is unpicklable.
+    """
+
+    def __init__(self, project_root=None, exclude_patterns=None, use_semantic_analysis=False):
+        self.project_root = Path(project_root) if project_root else Path.cwd()
+        self.exclude_patterns = list(exclude_patterns or [])
+        self.use_semantic_analysis = use_semantic_analysis
+        self.results = []
+        self.total_files_scanned = 0
+
+    def analyze_directory(self, directory=None):
+        self.results = [f"finding:{self.project_root.name}", f"dir:{directory}"]
+        self.total_files_scanned = 7
+        return self.results
+
+    def get_summary(self):
+        return {"total": len(self.results), "files_analyzed": self.total_files_scanned}
+
+
+class _BurnCPU:
+    """A deliberately GIL-bound workload, for the responsiveness test."""
+
+    def __init__(self, project_root=None, exclude_patterns=None, use_semantic_analysis=False):
+        self.project_root = Path(project_root) if project_root else Path.cwd()
+        self.exclude_patterns = list(exclude_patterns or [])
+        self.results = []
+        self.total_files_scanned = 0
+
+    def analyze_directory(self, directory=None):
+        # Pure-Python arithmetic: holds the GIL exactly like a regex scan does.
+        total = 0
+        for i in range(4_000_000):
+            total += i * i
+        self.results = [total]
+        self.total_files_scanned = 1
+        return self.results
+
+
+class _Boom:
+    def __init__(self, **_kwargs):
+        pass
+
+    def analyze_directory(self, directory=None):
+        raise RuntimeError("scan exploded in the child")
+
+
+@pytest.fixture(autouse=True)
+async def _fresh_pool():
+    """Each test gets a pool it can break without affecting the next."""
+    await shutdown_scan_pool()
+    process_offload._pool_unavailable_reason = None
+    yield
+    await shutdown_scan_pool()
+    process_offload._pool_unavailable_reason = None
+
+
+async def test_scan_result_and_file_count_both_cross_the_process_boundary():
+    """Returning findings alone would misreport ``files_analyzed``.
+
+    ``get_summary()`` falls back to counting *distinct files that had a finding*
+    when ``total_files_scanned`` is 0 — so a scan of 7 files reporting 2 findings
+    in 1 file would claim it analysed 1 file. Silently wrong, never raised.
+    """
+    analyzer = _FakeAnalyzer(project_root="/tmp/example")
+
+    results = await run_directory_scan(analyzer)
+
+    assert results == ["finding:example", "dir:None"]
+    assert analyzer.results == results, "the caller's analyzer must carry the child's findings"
+    assert analyzer.total_files_scanned == 7, "the scanned-file count must survive the hop"
+    assert analyzer.get_summary() == {"total": 2, "files_analyzed": 7}
+
+
+async def test_directory_argument_reaches_the_child():
+    analyzer = _FakeAnalyzer(project_root="/tmp/example")
+    await run_directory_scan(analyzer, "/tmp/example/sub")
+    assert analyzer.results[1] == "dir:/tmp/example/sub"
+
+
+async def test_semantic_analysis_is_off_in_the_child():
+    """Semantic analysis holds Redis/ChromaDB handles, which do not pickle.
+
+    ``analyze_directory`` is regex+AST only — the semantic path is
+    ``analyze_directory_async`` — so a worker never needs it, and constructing it
+    there would open connections from a short-lived process.
+    """
+    captured = {}
+
+    class _Recorder(_FakeAnalyzer):
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            super().__init__(**kwargs)
+
+    # Called directly rather than through the pool: the assertion is about the
+    # kwargs the child constructor receives, and a spawned child cannot write
+    # back into this process's dict.
+    process_offload._scan_in_child(_Recorder, "/tmp/example", ["venv"], None)
+
+    assert captured["use_semantic_analysis"] is False
+    assert captured["project_root"] == "/tmp/example"
+    assert captured["exclude_patterns"] == ["venv"]
+
+
+async def _median_tick_delay_during_scan(force_thread: bool) -> float:
+    """Median time a 5 ms heartbeat actually takes while a GIL-bound scan runs."""
+    await shutdown_scan_pool()
+    process_offload._pool_unavailable_reason = "forced for measurement" if force_thread else None
+
+    delays: list[float] = []
+    stop = False
+
+    async def heartbeat():
+        while not stop:
+            started = time.monotonic()
+            await asyncio.sleep(0.005)
+            delays.append(time.monotonic() - started)
+
+    beat = asyncio.create_task(heartbeat())
+    await asyncio.sleep(0.05)
+    await run_directory_scan(_BurnCPU(project_root="/tmp"))  # warm the pool
+    delays.clear()
+
+    await run_directory_scan(_BurnCPU(project_root="/tmp"))
+
+    stop = True
+    beat.cancel()
+    await shutdown_scan_pool()
+    process_offload._pool_unavailable_reason = None
+
+    assert delays, "the heartbeat never ran — measurement is meaningless"
+    return sorted(delays)[len(delays) // 2]
+
+
+async def test_a_scan_in_a_process_does_not_delay_the_event_loop():
+    """The property #12866 is about, measured against the old behaviour.
+
+    Tick *count* does not discriminate: CPython hands the GIL over every switch
+    interval, so the loop still runs — it just runs *late*. Measured here, a 5 ms
+    sleep takes ~10.7 ms under ``asyncio.to_thread`` and ~5.3 ms under the pool.
+    That per-wakeup tax, compounded across a request's awaits, is how a 25 ms
+    endpoint became a 12 s one.
+
+    Compared within the test rather than against a fixed threshold, so a loaded
+    CI runner shifts both numbers together instead of flaking.
+    """
+    in_thread = await _median_tick_delay_during_scan(force_thread=True)
+    in_process = await _median_tick_delay_during_scan(force_thread=False)
+
+    if process_offload._pool_unavailable_reason:
+        pytest.skip(f"process pool unavailable here: {process_offload._pool_unavailable_reason}")
+
+    # Measured ratio is ~0.5; 0.75 leaves headroom while still failing outright
+    # if the scan ever stops being isolated.
+    assert in_process < in_thread * 0.75, (
+        f"a scan still delays the event loop: {in_process * 1000:.1f}ms median tick "
+        f"in-process vs {in_thread * 1000:.1f}ms in-thread — expected a clear improvement"
+    )
+    # And in absolute terms the loop should be barely taxed at all.
+    assert in_process < 0.005 * 1.5, (
+        f"a 5ms heartbeat took {in_process * 1000:.1f}ms median while a scan ran in "
+        "another process — something is still contending for this process"
+    )
+
+
+async def test_run_isolated_forwards_args_and_kwargs():
+    """The non-BaseCodeAnalyzer scanners take positional and keyword arguments."""
+
+    result = await run_isolated(
+        _FakeAnalyzer, {"project_root": "/tmp/example"}, "analyze_directory", "/tmp/example/sub"
+    )
+    assert result == ["finding:example", "dir:/tmp/example/sub"]
+
+
+async def test_a_failed_scan_does_not_poison_every_later_request():
+    """A dead child breaks the whole pool — every later submit raises BrokenProcessPool.
+
+    So the pool is dropped on failure and the next request gets a fresh one.
+    Without this, one OOM-killed scan bricks code-intelligence until restart.
+    """
+    with pytest.raises(RuntimeError):
+        await run_isolated(_Boom, {}, "analyze_directory")
+
+    analyzer = _FakeAnalyzer(project_root="/tmp/example")
+    await run_directory_scan(analyzer)
+    assert analyzer.total_files_scanned == 7, "the pool did not recover after a failed scan"
+
+
+async def test_falls_back_in_thread_when_the_pool_cannot_start():
+    """Some sandboxes forbid process creation.
+
+    Failing every code-intelligence endpoint there would be worse than the stalls
+    this exists to prevent — but the fallback is logged, never silent.
+    """
+    await shutdown_scan_pool()
+    process_offload._pool_unavailable_reason = "forced for test"
+
+    analyzer = _FakeAnalyzer(project_root="/tmp/example")
+    results = await run_directory_scan(analyzer)
+
+    assert results == ["finding:example", "dir:None"]
+    assert analyzer.total_files_scanned == 7, "the in-thread path must populate state too"
+
+
+async def test_shutdown_is_idempotent():
+    """Called from the lifespan and again after a failed scan."""
+    await run_directory_scan(_FakeAnalyzer(project_root="/tmp/example"))
+    await shutdown_scan_pool()
+    await shutdown_scan_pool()
+    assert process_offload._pool is None

--- a/autobot-backend/conftest.py
+++ b/autobot-backend/conftest.py
@@ -796,6 +796,22 @@ _real_load_and_bind(
     backend_root / "code_intelligence" / "shared" / "scoring.py",
 )
 
+# code_intelligence.shared.process_offload real-load (#12866) — api/code_intelligence.py
+# imports run_directory_scan/run_isolated at module level to run whole-tree scans in a
+# separate process instead of a GIL-bound thread. Same situation as scoring above: the
+# package is stubbed, so without this the module import fails outright and every
+# api.code_intelligence import test breaks.
+#
+# Real-loaded rather than stubbed on purpose. A MagicMock here would hand callers a mock
+# that never runs the scan and never populates analyzer.results — the endpoints would
+# "pass" while returning empty findings, which is the #13111 / #13162 harness-bug shape.
+# The module is self-contained: stdlib (asyncio, multiprocessing, concurrent.futures) plus
+# autobot_shared.logging_manager, which every consumer already real-imports.
+_real_load_and_bind(
+    "code_intelligence.shared.process_offload",
+    backend_root / "code_intelligence" / "shared" / "process_offload.py",
+)
+
 # code_intelligence submodule stubs — code_intelligence itself is stubbed above
 # (its __init__ has Python-3.10-incompatible annotations), so submodule imports
 # from api/*.py need their own stubs with the right symbol names.

--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -2004,6 +2004,17 @@ async def cleanup_services(app: FastAPI):
             logger.warning("Background init task raised during cancellation: %s", _bg_init_err)
         logger.info("✅ Phase-2 background init task cancelled before shutdown")
 
+    # #12866: the code-analysis process pool holds spawned children. They are not
+    # daemons, so leaving them behind keeps the unit in "deactivating" until
+    # systemd's timeout expires and SIGKILLs it. Torn down here, before the
+    # thread pool drains, because the shutdown call itself runs in a thread.
+    try:
+        from code_intelligence.shared.process_offload import shutdown_scan_pool
+
+        await shutdown_scan_pool()
+    except Exception as _pool_err:  # noqa: BLE001
+        logger.warning("Code-analysis process pool shutdown raised: %s", _pool_err)
+
     try:
         # GH#9044: Close transcriber DB connection
         transcriber_db = getattr(app.state, "transcriber_db", None)


### PR DESCRIPTION
## Thinking Path

The backend half of #12866, per the owner's decision: a process pool rather than converting seven endpoints to Celery. `asyncio.to_thread` moves work off the event *loop* but not off the *GIL*, and `analyze_directory` is pure-Python `re`/`ast` — neither releases it. With `uvicorn --workers 1` there is no second worker to absorb requests, so every client stalls together. A separate process has its own GIL, which fixes all the endpoints at once with no change to any response shape.

Writing the test is what made this worth doing carefully. My first assertion counted how many times a 5 ms heartbeat ticked during a scan, on the assumption that a blocked loop stops ticking. **It does not.** CPython hands the GIL over every switch interval, so the loop keeps running under `to_thread` — it just runs *late*. That test passed identically before and after the fix, i.e. it proved nothing. Measuring tick *latency* instead separates them cleanly and reproducibly:

```
asyncio.to_thread    median tick 10.7ms   p95 11.3–15.9ms
ProcessPoolExecutor  median tick  5.3ms   p95  5.5ms
```

against a 5 ms request. That per-wakeup tax, compounded across every `await` in a request, is how a 25 ms endpoint became a 12 s one — the mechanism behind the issue's `p90=12.00s` while a calm window served the same endpoint in 0.020–0.036 s.

## What Changed

`code_intelligence/shared/process_offload.py` (new)

- `run_directory_scan(analyzer, directory=None)` — drop-in for `await asyncio.to_thread(analyzer.analyze_directory)`. Returns `(results, total_files_scanned)` from the child and assigns **both** back onto the caller's analyzer. Findings alone would not do: `get_summary()` falls back to counting *distinct files that had a finding* when `total_files_scanned` is 0, so a 7-file scan with 2 findings in 1 file would report `files_analyzed: 1` — wrong, and never raised.
- `run_isolated(cls, init_kwargs, method, *args, **kwargs)` — for `AntiPatternDetector` and `RedisOptimizer`, which are not `BaseCodeAnalyzer` subclasses and whose callers use only the return value.
- The analyzer is **reconstructed** in the child from `project_root`/`exclude_patterns`, not pickled: a live instance can hold Redis/ChromaDB handles from semantic analysis, which do not pickle and have no business in a scan worker. `analyze_directory` is regex+AST only — the semantic path is `analyze_directory_async` — so the child is constructed with `use_semantic_analysis=False`.
- `spawn`, never `fork`: forking a process that already has an event loop and worker threads copies their state into a child that never runs them, deadlocking on any lock held at the moment of the fork.
- A dead child (OOM kill, C-extension segfault) breaks the *whole* pool — every later submission raises `BrokenProcessPool`. The pool is dropped on failure so the next request gets a fresh one; without that, one killed scan bricks code-intelligence until restart.
- Pool creation failure (sandboxes that forbid process creation) falls back to a worker thread, logged at WARNING with the reason. Failing every code-intelligence endpoint there would be worse than the stalls this exists to prevent — but a host in that state still has them, and the log is how that is known.

`api/code_intelligence.py` — eight scan sites converted:

| endpoint | scanner |
|---|---|
| `POST /security/analyze`, `GET /security/report` | `SecurityAnalyzer` |
| `POST /performance/analyze`, `GET /performance/score`, `GET /performance/report` | `PerformanceAnalyzer` |
| `POST /analyze`, `GET /health-score` | `AntiPatternDetector` |
| `POST /redis/analyze`, `GET /redis/health-score` | `RedisOptimizer` |

`_run_redis_analysis` now takes the project root rather than a live `RedisOptimizer`, so the scan can cross the process boundary. Single-**file** scans are left in a thread — bounded work, not worth a process hop.

`initialization/lifespan.py` — the pool is torn down on shutdown, before the thread pool drains (the shutdown call itself runs in a thread). Spawned children are not daemons; leaving them behind holds the unit in `deactivating` until systemd's timeout SIGKILLs it.

## Verification

```console
$ python3 -m pytest autobot-backend/code_intelligence/shared/process_offload_test.py -q
8 passed

$ python3 -m pytest autobot-backend/tests/test_startup_imports.py -q
352 passed

$ python3 -m pytest autobot-backend/api/ -q -k "code_intelligence"
8 passed, 3478 deselected
```

The discriminating measurement, run both ways in one process:

```console
asyncio.to_thread (old)    scan=0.38s ticks=35  median= 10.7ms p95= 15.9ms max= 16.4ms
ProcessPool       (new)    scan=0.36s ticks=67  median=  5.3ms p95=  5.5ms max=  5.6ms
asyncio.to_thread (old)    scan=0.41s ticks=39  median= 10.7ms p95= 11.3ms max= 14.9ms
ProcessPool       (new)    scan=0.33s ticks=61  median=  5.3ms p95=  5.5ms max=  5.8ms
```

`test_a_scan_in_a_process_does_not_delay_the_event_loop` measures both paths within the test and asserts the in-process median is under 75% of the in-thread one (observed ratio ~0.5), so a loaded CI runner shifts both numbers together instead of flaking. It also asserts the absolute: under 1.5× the requested interval.

## A harness bug this would have hit

`autobot-backend/conftest.py` stubs `code_intelligence.shared` as a package and real-loads only `scoring` beneath it, so the new module was invisible to the harness and `test_api_module_imports[api.code_intelligence]` failed outright. Added as a `_real_load_and_bind`, deliberately **not** a stub: a `MagicMock` here would hand callers a mock that never runs the scan and never populates `analyzer.results`, so the endpoints would "pass" while returning empty findings — the #13111 / #13162 harness-bug shape, where a stub makes tests assert against mock defaults.

## Scope

Delivers the backend half. `--workers > 1` (the issue's proposal 4) is **not** here — it is gated on the backend's in-process WebSocket connection state, a separate question.

Deliberately `Refs`, not `Closes`: the frontend half is **#13456**, and #12866 is not delivered until both land. Closure Gate 3 — a subset never closes the issue. Once both merge, #12866 closes with evidence from each.

Refs #12866

## Model Used

Opus 5 (1M context)
