### PR TITLE
fix(agents): keep distributed_management_test.py off a live Redis (#13449)

### DIFF
--- a/autobot-backend/agents/agent_orchestration/distributed_management_test.py
+++ b/autobot-backend/agents/agent_orchestration/distributed_management_test.py
@@ -28,22 +28,66 @@ from .types import CircuitState, DistributedAgentInfo
 
 _PERSISTENCE_MODULE = "agents.agent_orchestration.distributed_management"
 
+# Every Redis-backed helper distributed_management imports. The state_persistence
+# six write task state; the services.task_claim four run SET NX EX / EXISTS / two
+# Lua scripts against ``task:claim:{task_id}``.
+_PERSISTENCE_NAMES = (
+    "persist_task_assigned",
+    "persist_task_progress",
+    "persist_task_reassignment",
+    "delete_task_state",
+    "delete_task_timing_state",
+)
+
+# #13449: the claim helpers default to "granted"/"alive" — the values a first
+# claimant gets. The denied path has one explicit test of its own
+# (test_add_active_task_denied_when_claim_is_held) and full coverage against a
+# real claim in tests/integration/test_task_claim_race.py; nothing else in this
+# file asserts claim semantics, and letting these reach Redis made six cases
+# fight over the single key ``task:claim:t1``.
+_CLAIM_DEFAULTS = {
+    "claim_task": True,
+    "release_claim": True,
+    "renew_claim": True,
+    "is_claim_alive": True,
+}
+
+
+def _external_mocks() -> dict:
+    """AsyncMock replacements for every Redis call this module can make."""
+    mocks = {name: AsyncMock() for name in _PERSISTENCE_NAMES}
+    mocks["load_task_state"] = AsyncMock(return_value=({}, {}, {}))
+    for name, result in _CLAIM_DEFAULTS.items():
+        mocks[name] = AsyncMock(return_value=result)
+    return mocks
+
+
+@pytest.fixture(autouse=True)
+def _no_live_redis():
+    """Keep every case in this file in memory (#13449).
+
+    ``_patch_persistence()`` below covers the tests that opt into it, but
+    ``_detect_and_steal_stale_tasks`` and ``_reassign_task`` are exercised
+    without it, and both reach Redis: the first probes ``is_claim_alive`` for
+    every task whose in-memory timestamps look fresh, the second persists the
+    reassignment. Whether that mattered used to depend on which module won the
+    ``autobot_shared.redis_client`` import race (#13446) — with the genuine
+    client, a missing claim key reads as "not alive", the task is stolen, and
+    ``assert count == 0`` becomes ``assert 1 == 0``.
+    """
+    with patch.multiple(_PERSISTENCE_MODULE, **_external_mocks()):
+        yield
+
 
 @asynccontextmanager
 async def _patch_persistence():
     """Patch all state_persistence async helpers to AsyncMock no-ops.
 
     Returns a dict of mock objects keyed by function name so callers can
-    inspect call counts / arguments.
+    inspect call counts / arguments. Re-patches on top of the autouse fixture
+    above so each caller gets its own, freshly-zeroed handles.
     """
-    mocks = {
-        "persist_task_assigned": AsyncMock(),
-        "persist_task_progress": AsyncMock(),
-        "persist_task_reassignment": AsyncMock(),
-        "delete_task_state": AsyncMock(),
-        "delete_task_timing_state": AsyncMock(),
-        "load_task_state": AsyncMock(return_value=({}, {}, {})),
-    }
+    mocks = _external_mocks()
     with patch.multiple(_PERSISTENCE_MODULE, **mocks):
         yield mocks
 
@@ -365,6 +409,23 @@ class TestTaskTrackingIntegration:
             assert "t1" in mgr._task_assigned_at
             assert before <= mgr._task_assigned_at["t1"] <= after
             mocks["persist_task_assigned"].assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_add_active_task_denied_when_claim_is_held(self):
+        """A denied claim records nothing and tells the caller to stand down.
+
+        The autouse fixture grants every claim, so this is the case that proves
+        ``add_active_task`` still consults ``claim_task`` at all (#13449) — and
+        that the double-pickup guard (GH#6468) survives the patching.
+        """
+        async with _patch_persistence() as mocks:
+            mgr = _make_manager()
+            _register_agent(mgr, "a1")
+            with patch(f"{_PERSISTENCE_MODULE}.claim_task", AsyncMock(return_value=False)):
+                assert await mgr.add_active_task("a1", "t1") is False
+            assert "t1" not in mgr._task_assigned_at
+            assert "t1" not in mgr.distributed_agents["a1"].active_tasks
+            mocks["persist_task_assigned"].assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_remove_active_task_clears_all_tracking(self):


### PR DESCRIPTION
## Thinking Path

Refs #13449.

`distributed_management_test.py` drives `DistributedAgentManager` without isolating the
Redis keys it touches. Six cases claim the same task id, `"t1"`, and `_patch_persistence()`
— the file's own helper — patches the six `state_persistence` coroutines but none of the
four `services.task_claim` ones. `add_active_task()` starts with a real `SET NX EX`, so the
first case to run wins `task:claim:t1` and every later one is denied for the rest of the TTL.

Reproduced deterministically before changing anything, with a throwaway plugin that points
`services.task_claim.get_async_redis_client` at a `fakeredis` server — that is exactly the
state #13446 produces when the genuine client wins the import race *and* the server answers,
without touching any real service:

    $ pytest agents/agent_orchestration/distributed_management_test.py -p live_claim_redis -q
    FAILED ...TestDetectAndStealStaleTasks::test_steals_multiple_stale_tasks_across_agents
    FAILED ...TestDetectAndStealStaleTasks::test_grace_period_prevents_stealing
    FAILED ...TestDetectAndStealStaleTasks::test_max_reassignments_stops_stealing
    FAILED ...TestRedisPersistence::test_add_active_task_persists_to_redis
    4 failed, 43 passed in 127.18s

Two notes on that list. It is **wider than the issue reports**: the issue names two
`TestDetectAndStealStaleTasks` cases plus `TestTaskTrackingIntegration::test_add_active_task_
records_assigned_at`, but *which* of the six `"t1"` claimants fails is decided by which one
runs first — the winner passes and the losers fail, so the failing set moves with the order.
And a third `_detect_and_steal_stale_tasks` case fails for the same reason as the two named:
`test_steals_multiple_stale_tasks_across_agents` has a deliberately fresh task whose
`is_claim_alive` probe reads a key that was never written, so it is stolen as well and the
count comes out 3 instead of 2. All five cases in that class reach the live probe; only the
two whose expected count happens to be unaffected survive.

Whether patching is the right answer, or a fake Redis: **no test in this file asserts claim
semantics**. The module docstring says "Most tests are pure in-memory; Redis calls are patched
to AsyncMock", the `TestCollectStaleTasks` docstring says the claim probe is patched so its
cases "exercise the in-memory timestamp thresholds only", and the double-pickup guard has its
own coverage in `tests/integration/test_task_claim_race.py`, which is marked `integration` and
already runs against `fakeredis` on purpose. So the calls are patched here — with one addition
so that "patched away" does not mean "untested": the denied path now has an explicit case.

## What Changed

`autobot-backend/agents/agent_orchestration/distributed_management_test.py` only. No
production file is touched.

- `_external_mocks()` builds the `AsyncMock` set for **every** Redis-backed helper
  `distributed_management` imports: the five `persist_*`/`delete_*` coroutines plus
  `load_task_state`, and the four `services.task_claim` ones (`claim_task`, `release_claim`,
  `renew_claim`, `is_claim_alive`) defaulting to granted/alive.
- A module-scoped autouse fixture `_no_live_redis` installs that set for every case in the
  file. `_patch_persistence()` was not enough on its own: `_detect_and_steal_stale_tasks` and
  `_reassign_task` are exercised without it and reach Redis anyway — the first probes
  `is_claim_alive` for every task whose in-memory timestamps look fresh, the second persists
  the reassignment.
- `_patch_persistence()` keeps its signature and its returned handles, and now builds them
  from `_external_mocks()`, so a caller that inspects `mocks["persist_task_assigned"]` still
  gets its own freshly-zeroed mock, re-patched on top of the autouse set.
- New `TestTaskTrackingIntegration::test_add_active_task_denied_when_claim_is_held`: with
  `claim_task` returning False, `add_active_task` must return False, record no
  `_task_assigned_at`, add nothing to the agent's `active_tasks` and never await
  `persist_task_assigned`. This is the case that proves the double-pickup guard (GH#6468)
  survives the patching — without it, granting every claim would make the guard untested.
- The four `with self._patch_claim_alive():` blocks in `TestCollectStaleTasks` are left in
  place. They are redundant against the autouse default but state the precondition their
  class docstring documents, and `test_expired_redis_claim_marks_fresh_task_stale` still
  overrides it with `alive=False`.

## Verification

All runs on `Dev_new_gui` @ 68abf2b1b. No AutoBot service was started or stopped; no Redis
was started, stopped or written to.

**The reproduction, after.** Same plugin, same command as above:

    48 passed in 2.17s

**In isolation** — 47 tests / 121.82s before, 48 tests / 2.32s after. The 121s was #13446
bleeding in (two 60s `TestReassignTask` calls spending the async client's retry budget):

    before:  47 passed in 121.82s
    after:   48 passed in 2.32s

**With Redis unreachable**, client pointed at a closed port via env, no service touched:

    $ AUTOBOT_REDIS_HOST=127.0.0.1 AUTOBOT_REDIS_PORT=6399 pytest .../distributed_management_test.py -q
    48 passed in 2.76s

Same result and same speed as the reachable run, which is the point: the file no longer cares.
Both directions of the import race are covered — the `fakeredis` plugin run is the "real
client, server answers" side, this one is "real client, nothing there".

**CI's shape**, `-n auto --dist loadscope` over the whole `agents/` tree, unit markers only:

    base:    1 failed, 405 passed, 22 warnings in 184.76s
    branch:  1 failed, 406 passed, 22 warnings in 197.56s

+1 test is the new denied-path case. The one failure is pre-existing and unrelated —
`rl_router_test.py::TestEpsilonGreedy::test_exploit_when_epsilon_is_zero`, which fails
identically on the base file and passes when its own file runs alone (22 passed), i.e. an
ordering flake of the #13399 family, not something this branch introduces.

**The guards still bite.** Each property was broken in the production module, one at a time,
and the file re-run (every seed reverted afterwards; `git diff` shows only the test file):

| Seeded breakage in `distributed_management.py` | Result |
|---|---|
| `add_active_task`: ignore the `claim_task` result | `FAILED ...test_add_active_task_denied_when_claim_is_held` — `assert True is False` |
| `_collect_stale_tasks`: drop the `is_claim_alive` check | `FAILED ...test_expired_redis_claim_marks_fresh_task_stale` |
| `_is_task_stale`: ignore `grace_period_seconds` | `FAILED ...test_task_beyond_timeout_but_within_grace_is_not_stale`, `FAILED ...test_grace_period_prevents_stealing` |

**sys.modules leak guard** — unchanged, no new owner, no `FIXED:` line, baseline untouched:

    1 known leaking file(s), 61 sys.modules key(s), all on repo_tests/sys_modules_leak_baseline.txt
          known: autobot-backend/conftest.py (61 key(s))

**Lint**: `black --check`, `isort --check-only`, `flake8 --config=.flake8` all clean on the
changed file. No test in it exceeds 10s; every added function is under 30 lines.

**Scope note.** This is deliberately *not* combined with the #13446 fix. That one rewrites how
`autobot-backend/conftest.py` owns `sys.modules["autobot_shared.redis_client"]` and is felt by
every backend test; this one is a single test file's own patching gap. They also have to be
separable to stay honest: once #13446 lands, `get_async_redis_client()` answers None here and
`claim_task` fails open, so these six cases pass *by luck* again and the fix in this PR would
be unverifiable. Proving it needs a session where the claim is real, which is what the
`fakeredis` plugin above provides.

## Model Used

claude-opus-5
