### PR TITLE
fix(chat): stop reporting a still-actionable approval as a failed command (#13481)

### DIFF
--- a/autobot-backend/chat_workflow/approval_still_pending_test.py
+++ b/autobot-backend/chat_workflow/approval_still_pending_test.py
@@ -1,0 +1,107 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""A turn that stops waiting must not call a live approval a failed command (#13481).
+
+`_handle_approval_failure` reported two different outcomes identically, as
+``type="error"``:
+
+* the user **denied** the command — a real, final failure;
+* the turn's poll budget ran out with **no decision** — not a failure at all.
+
+The second case emitted ``Approval timeout for command: ls -la``, which says the
+command failed. It had neither failed nor run, and the user could still make it
+run. Verified against the code rather than assumed:
+
+* the poll timing out does not clear the pending approval —
+  ``clear_pending_and_resume()`` is called only on the approve/deny paths
+  (``services/agent_terminal/service.py:456,602``);
+* ``AgentTerminalService._approve_command_internal`` executes the command on
+  approve with no coroutine waiting, then broadcasts over ``events.bus``.
+
+So approving afterwards still runs it. The message was the bug, and it is what
+made #13216 read as "approving afterwards does not run it".
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+def _handler():
+    """The handler under test, constructed without its heavy collaborators.
+
+    ``_handle_approval_failure`` is a pure function of its two arguments — it
+    touches no instance state — so a bare subclass instance avoids dragging in
+    the terminal service, Ollama client and chat-history manager that the real
+    composing class builds in ``__init__``.
+    """
+    from chat_workflow.tool_handler import ToolHandlerMixin
+
+    class _Handler(ToolHandlerMixin):
+        pass
+
+    return _Handler()
+
+
+async def test_a_denial_is_still_reported_as_a_failure():
+    """The real failure case must not get softened by this change."""
+    msg, text = _handler()._handle_approval_failure("rm -rf /tmp/x", {"error": "denied by user"})
+
+    assert msg.type == "error"
+    assert msg.metadata["error"] is True
+    assert "denied by user" in msg.content
+    assert "❌" in text
+
+
+async def test_no_decision_is_not_reported_as_an_error():
+    """The regression: a pending approval rendered as a failed command."""
+    msg, text = _handler()._handle_approval_failure("ls -la", None)
+
+    assert msg.type != "error", (
+        "a turn giving up on waiting is not a command failure — the approval is "
+        "still pending and approving it still executes the command"
+    )
+    assert "failed" not in msg.content.lower()
+    assert "❌" not in text
+
+
+async def test_no_decision_says_the_approval_is_still_actionable():
+    """The user has to be able to tell that approving still does something."""
+    msg, text = _handler()._handle_approval_failure("ls -la", None)
+
+    assert "ls -la" in msg.content
+    assert "approving it will run the command" in msg.content.lower()
+    assert msg.metadata["approval_still_actionable"] is True
+    assert msg.metadata["message_type"] == "approval_still_pending"
+    assert "still waiting" in text.lower()
+
+
+async def test_the_legacy_timeout_flag_is_preserved():
+    """Consumers keying on ``metadata['timeout']`` must not break.
+
+    Its meaning narrows — "this turn stopped waiting", not "the approval
+    expired" — but dropping it would silently change behaviour for anything
+    already branching on it.
+    """
+    msg, _ = _handler()._handle_approval_failure("ls -la", None)
+    assert msg.metadata["timeout"] is True
+
+
+async def test_no_approval_expiry_knob_exists():
+    """The wait budget bounds the turn, never the approval's life (#13216).
+
+    An expiry knob here would re-create the defect: an approval discarded as a
+    side effect of how long a coroutine lived. If a real expiry policy is ever
+    wanted it belongs with the approval's storage, with its own message.
+    """
+    import chat_workflow.tool_handler as mod
+
+    expiry_names = [
+        name for name in dir(mod) if "APPROVAL" in name and ("EXPIR" in name or "TTL" in name or "MAX_AGE" in name)
+    ]
+    assert not expiry_names, (
+        f"an approval-expiry knob appeared in tool_handler: {expiry_names} — "
+        "the turn's wait budget must not double as the approval's lifetime"
+    )

--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -53,6 +53,18 @@ CODEEXEC_MAX_SCRIPT_RETRIES: int = env_int("AUTOBOT_CODEEXEC_MAX_SCRIPT_RETRIES"
 # (design §3.1) is CODEEXEC_READONLY_TOOLS, imported above from the single
 # tool-policy classification source (readonly ⊆ injectable; sensitive excluded).
 # Approval-wait polling knobs (mirrors terminal-command approval loop).
+#
+# #13481: this is how long THIS TURN waits, not how long the approval lives.
+# The distinction was invisible before and is the whole of #13216's confusion:
+# the approval is persisted, and approving after this budget still executes the
+# command. Exhausting it means "stop holding the request/generator open", never
+# "the command failed" and never "the approval expired".
+#
+# There is deliberately NO approval-expiry knob here. The reported expectation —
+# that approval should not expire — is the behaviour, so nothing discards a
+# pending approval on a timer. A real expiry policy, if ever wanted, belongs
+# next to the approval's own storage with its own message ("this approval
+# expired, re-request it"), not as a side effect of how long a coroutine lives.
 CODEEXEC_APPROVAL_WAIT_SECONDS: int = env_int("AUTOBOT_CODEEXEC_APPROVAL_WAIT_SECONDS", default=1800)
 CODEEXEC_APPROVAL_POLL_SECONDS: int = env_int("AUTOBOT_CODEEXEC_APPROVAL_POLL_SECONDS", default=2)
 
@@ -1607,7 +1619,21 @@ class ToolHandlerMixin:
     ) -> tuple[WorkflowMessage, str]:
         """Issue #665: Extracted from _handle_approval_workflow to reduce function length.
 
-        Handle approval denial or timeout.
+        Handle approval denial, or this turn giving up on waiting for a decision.
+
+        #13481: those two are NOT the same outcome and used to be reported
+        identically, as ``type="error"``. A denial is a real, final failure. The
+        no-decision case is not a failure at all — the approval is still pending
+        and still executable:
+
+        * the poll timing out does not clear it (``clear_pending_and_resume()``
+          runs only on the approve/deny paths);
+        * ``AgentTerminalService._approve_command_internal`` executes on approve
+          with no coroutine waiting, so approving later still runs the command.
+
+        So ``Approval timeout for command: ls -la`` claimed a command had failed
+        when it had neither failed nor run, and the user could still make it run.
+        That wording is what made the reported behaviour unreadable.
 
         Returns:
             Tuple of (WorkflowMessage, additional_text)
@@ -1622,15 +1648,27 @@ class ToolHandlerMixin:
                 ),
                 f"\n\n❌ {error}",
             )
-        else:
-            return (
-                WorkflowMessage(
-                    type="error",
-                    content=f"Approval timeout for command: {command}",
-                    metadata={"command": command, "timeout": True},
-                ),
-                f"\n\n⏱️ Approval timeout for command: {command}",
-            )
+
+        still_pending = (
+            f"Still waiting on your approval for: `{command}`\n"
+            "This turn stopped waiting, but the request is still open — "
+            "approving it will run the command."
+        )
+        return (
+            WorkflowMessage(
+                type="response",
+                content=still_pending,
+                metadata={
+                    "command": command,
+                    "message_type": "approval_still_pending",
+                    # #13481: kept so existing consumers keying on it keep working,
+                    # but it now means "this turn stopped waiting", not "expired".
+                    "timeout": True,
+                    "approval_still_actionable": True,
+                },
+            ),
+            f"\n\n⏳ {still_pending}",
+        )
 
     async def _handle_approval_workflow(
         self,


### PR DESCRIPTION
## Thinking Path

#13216 reports that a command approval "expires after 30 minutes and cannot be honoured late", and that approving afterwards does not run the command. I started building the durability fix the issue proposes — and reading the rest of the code showed most of it already exists. The full correction is on #13216; the part that matters here:

- **`pending_approval` is persisted.** `SessionManager._persist_session` writes it to Redis, and `get_session` loads it back (`session_manager.py:307`, commented "CRITICAL: Restore pending approvals").
- **The timeout does not clear it.** `clear_pending_and_resume()` runs only on the approve/deny paths (`service.py:456,602`) — never on timeout.
- **Approving already executes, with no coroutine waiting.** `AgentTerminalService._approve_command_internal` → `_execute_approved_command`, then a broadcast over `events.bus` and a `command_approval_response` in chat history.

So within the session's lifetime the command **does** run on a late approval. What the user sees is `Approval timeout for command: ls -la`, emitted as `type="error"` — a message that says the command failed. It had neither failed nor run, and they could still make it run. The message was the bug.

That is the whole of this PR. The genuine durability defect that remains — a Redis `TTL_1_HOUR` on the session that nothing refreshes while an approval is pending, after which approve returns `Session not found` — is #13478, and the missing fold-back of a late result into the chat turn is #13479.

## What Changed

`chat_workflow/tool_handler.py`

- `_handle_approval_failure` now separates **denied** (a real, final failure — unchanged, still `type="error"`) from **no decision within this turn's budget**, which becomes a `type="response"` message naming the command and saying that approving it will still run it.
- `metadata` gains `message_type: "approval_still_pending"` and `approval_still_actionable: True`. The legacy `timeout: True` flag is **kept** — its meaning narrows to "this turn stopped waiting" rather than "the approval expired", but dropping it would silently change behaviour for anything already branching on it. (Nothing in the repo or the frontend currently does; kept anyway, since the flag is part of the emitted contract.)
- `CODEEXEC_APPROVAL_WAIT_SECONDS` is documented as bounding **the turn**, not the approval. There is deliberately no approval-expiry knob: the reported expectation is that approval should not expire, and a real expiry policy belongs with the approval's storage and its own message, never as a side effect of how long a coroutine lives.

## Verification

```console
$ python3 -m pytest autobot-backend/chat_workflow/ -q
351 passed

$ python3 -m pytest autobot-backend/chat_workflow/approval_still_pending_test.py \
                    autobot-backend/tests/test_startup_imports.py -q
357 passed
```

Invert-tested — restoring the previous `type="error"` / "Approval timeout" branch fails exactly the two tests that exist for it, and nothing else:

```console
$ # pre-fix behaviour restored
2 failed, 3 passed
$ # fix restored
5 passed
```

The denial path is covered separately (`test_a_denial_is_still_reported_as_a_failure`) so this change cannot soften a real failure — that test passes in both directions, which is the point of having it.

Checked for consumers before changing the wording: nothing in `autobot-backend/` or `autobot-frontend/src` keys on the `Approval timeout` string, and no frontend code branches on this message's `metadata.timeout`.

## Scope

Closes #13481 only. #13478 (the 1-hour Redis TTL, and the restore path being unreachable from the approve endpoint) and #13479 (delivering a late result back into the chat turn) are separate and still open — #13216 stays open as the umbrella.

Closes #13481
Refs #13216

## Model Used

Opus 5 (1M context)
