### PR TITLE
feat(backups): delete, retention, PostgreSQL coverage and a findable destination (#13307)

### DIFF
--- a/autobot-slm-backend/ansible/roles/slm_manager/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/slm_manager/defaults/main.yml
@@ -145,3 +145,8 @@ grafana_health_check_delay: 5          # Seconds between retries
 # and the backend env template. Empty here means "generate one" -- set it in
 # group_vars/vault only to pin a specific value, never commit a real one.
 chromadb_auth_token: ""
+
+# #13307: where the SLM writes backups. Must match config.py's `backup_dir`
+# default (and SLM_BACKUP_DIR if that is set) — the service creates the path at
+# import time, but only this role can give it the right ownership and mode.
+slm_backup_dir: /var/lib/slm/backups

--- a/autobot-slm-backend/ansible/roles/slm_manager/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/slm_manager/tasks/main.yml
@@ -118,6 +118,23 @@
     - /var/lib/slm
   tags: ['slm', 'directories']
 
+# #13307: backups used to land in the service account's home directory, chosen
+# by a fallback rather than a decision — on the root filesystem, in a place
+# nobody thinks to look. config.py now defaults to /var/lib/slm/backups, so the
+# directory has to exist with the right ownership before the service starts.
+#
+# 0750, not the 0755 the loop above uses: a backup is a full dump of Redis and
+# the PostgreSQL cluster, so it carries every credential, user record and chat
+# message the platform holds. World-readable is wrong for that.
+- name: "SLM | Create backup storage directory (#13307)"
+  ansible.builtin.file:
+    path: "{{ slm_backup_dir }}"
+    state: directory
+    mode: "0750"
+    owner: "{{ slm_user }}"
+    group: "{{ slm_group }}"
+  tags: ['slm', 'directories', 'backup']
+
 # ==========================================================
 # TLS certificates (idempotent - skip if valid cert exists)
 # ==========================================================

--- a/autobot-slm-backend/api/stateful.py
+++ b/autobot-slm-backend/api/stateful.py
@@ -13,7 +13,7 @@ import logging
 import uuid
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from typing_extensions import Annotated
@@ -133,6 +133,29 @@ async def create_backup(
 
     logger.info("Backup created: %s for node %s", backup_id, request.node_id)
     return BackupResponse.model_validate(backup)
+
+
+@router.delete("/backups/{backup_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_backup(
+    backup_id: str,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    _: Annotated[dict, Depends(get_current_user)],
+) -> Response:
+    """Delete a backup and its stored file (#13307).
+
+    There was no delete route at all before this, so nothing in the system could
+    reclaim space and retention was unimplementable — while the destination sat
+    on the root filesystem.
+    """
+    from services.backup import backup_service
+
+    success, message = await backup_service.delete_backup(db, backup_id)
+    if not success:
+        raise HTTPException(
+            status_code=(status.HTTP_404_NOT_FOUND if message == "Backup not found" else status.HTTP_409_CONFLICT),
+            detail=message,
+        )
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/backups/{backup_id}/restore", response_model=BackupRestoreResponse)
@@ -520,10 +543,24 @@ async def _run_backup(backup_id: str, host: str, service_type: str) -> None:
             return
 
         # Execute backup using the dedicated service
-        if service_type == "redis":
-            success, message = await backup_service.execute_redis_backup(db, backup_id, node)
+        # #13307: PostgreSQL holds users, LLC work items and chat/session data.
+        # It was simply absent from a feature called "Backups", so a restore
+        # silently omitted all of it — discovered only during recovery.
+        runners = {
+            "redis": backup_service.execute_redis_backup,
+            "postgres": backup_service.execute_postgres_backup,
+            "postgresql": backup_service.execute_postgres_backup,
+        }
+        runner = runners.get(service_type)
+        if runner is not None:
+            success, message = await runner(db, backup_id, node)
             if not success:
                 logger.error("Backup %s failed: %s", backup_id, message)
+            else:
+                # #13307: prune here rather than on a timer — a new good backup
+                # is the only moment it is safe to drop an old one, and it keeps
+                # retention working without a scheduler this service does not have.
+                await backup_service.apply_retention(db, backup.node_id, service_type)
         else:
             # For unsupported service types, mark as failed
             backup.status = BackupStatus.FAILED.value

--- a/autobot-slm-backend/config.py
+++ b/autobot-slm-backend/config.py
@@ -184,7 +184,19 @@ class Settings(RedactedReprMixin, BaseSettings):
     data_dir: Path = Path(os.getenv("SLM_DATA_DIR", str(Path(__file__).parent / "data")))
     config_dir: Path = Path(os.getenv("SLM_CONFIG_DIR", str(Path(__file__).parent / "config")))
     ansible_dir: Path = Path(__file__).parent / "ansible"
-    backup_dir: Path = Path(os.getenv("SLM_BACKUP_DIR", str(Path.home() / "slm-backups")))
+    # #13307: was `Path.home() / "slm-backups"`, which put every backup in the
+    # service account's home directory — on the root filesystem, in a place
+    # nobody thinks to look, chosen by a fallback rather than a decision. It also
+    # contradicted services/backup.py, which named /var/lib/slm/backups as its
+    # own (dead) fallback. One answer now, and it is the FHS location for service
+    # state. The ansible backend role creates it with the right ownership.
+    backup_dir: Path = Path(os.getenv("SLM_BACKUP_DIR", "/var/lib/slm/backups"))
+
+    # #13307: how many backups to keep per (node, service_type), and how long.
+    # Without a delete route nothing could reclaim space, so storage only grew —
+    # on the root filesystem. 0 disables that dimension of the policy.
+    backup_retention_count: int = int(os.getenv("SLM_BACKUP_RETENTION_COUNT", "10"))
+    backup_retention_days: int = int(os.getenv("SLM_BACKUP_RETENTION_DAYS", "30"))
 
     # ==========================================================================
     # PostgreSQL Database Configuration (Issue #786)

--- a/autobot-slm-backend/services/backup.py
+++ b/autobot-slm-backend/services/backup.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import logging
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Dict, Tuple
 
@@ -26,16 +26,46 @@ from models.database import Backup, BackupStatus, Node
 
 logger = logging.getLogger(__name__)
 
-# Backup storage directory
-BACKUP_STORAGE_DIR = Path(settings.backup_dir if hasattr(settings, "backup_dir") else "/var/lib/slm/backups")
+# Backup storage directory.
+#
+# #13307: the `hasattr` fallback was dead code — `settings` has always defined
+# `backup_dir` — so the /var/lib/slm/backups written here never applied and the
+# real destination was config.py's `~/slm-backups`. Two files naming different
+# defaults, with the unreachable one being the correct answer. `settings` is now
+# the single source and already resolves to /var/lib/slm/backups.
+BACKUP_STORAGE_DIR = Path(settings.backup_dir)
 
 
 class BackupService:
     """Manages backup operations for stateful services."""
 
     def __init__(self):
-        # Ensure backup directory exists
-        BACKUP_STORAGE_DIR.mkdir(parents=True, exist_ok=True)
+        # #13307: best-effort, never fatal. `backup_service` is instantiated at
+        # module import, and the destination moved from the service account's
+        # home directory (always writable) to /var/lib/slm/backups (owned by
+        # root until the slm_manager role creates it). An unguarded mkdir here
+        # raises PermissionError and makes `import services.backup` fail
+        # outright — taking the whole API down on any host where ansible has
+        # not run yet, and in CI. The directory is the role's responsibility;
+        # this is only a convenience for dev, and a failed backup reports the
+        # real reason at the point it actually matters.
+        self._ensure_storage_dir()
+
+    @staticmethod
+    def _ensure_storage_dir() -> bool:
+        """Create the backup directory if we can. Returns whether it is usable."""
+        try:
+            BACKUP_STORAGE_DIR.mkdir(parents=True, exist_ok=True)
+            return True
+        except OSError as exc:
+            logger.warning(
+                "Backup storage directory %s is not usable (%s). The slm_manager "
+                "ansible role creates it with the right ownership; backups will "
+                "fail until it exists.",
+                BACKUP_STORAGE_DIR,
+                exc,
+            )
+            return False
 
     async def _mark_backup_in_progress(self, db: AsyncSession, backup_id: str) -> "Backup" | None:
         """Mark backup as in_progress and return record. Helper for execute_redis_backup. Ref: #1088."""
@@ -78,7 +108,7 @@ class BackupService:
             await self._wait_for_bgsave(host, ssh_user, ssh_port, redis_auth_prefix)
 
             # Step 4: Get RDB file size and checksum
-            size_bytes, checksum = await self._get_rdb_file_info(host, ssh_user, ssh_port, rdb_path)
+            size_bytes, checksum = await self._get_remote_file_info(host, ssh_user, ssh_port, rdb_path)
 
             # Step 5: Copy backup to SLM storage
             copy_success, backup_path, copy_error = await self._copy_backup_to_storage(
@@ -102,6 +132,90 @@ class BackupService:
         except Exception as e:
             logger.exception("Backup error: %s", e)
             return await self._fail_backup(db, backup, "Backup operation failed")
+
+    async def execute_postgres_backup(
+        self,
+        db: AsyncSession,
+        backup_id: str,
+        node: Node,
+    ) -> Tuple[bool, str]:
+        """Execute a full PostgreSQL cluster dump (#13307).
+
+        Until this existed the Backups page created something called a backup
+        that contained only Redis. PostgreSQL holds users, LLC work items and
+        chat/session data — a restore would not bring any of it back, and you
+        would find that out during recovery.
+
+        The dump command mirrors ``roles/postgresql/templates/autobot-pg-backup.sh.j2``
+        exactly: ``su - postgres -c "pg_dumpall --clean --if-exists" | gzip``.
+        Same mechanism, so there is one way this cluster is dumped and no
+        password is ever embedded — postgres authenticates over the local socket
+        as its own user.
+        """
+        host = node.ip_address
+        ssh_user = node.ssh_user or "autobot"
+        ssh_port = node.ssh_port or 22
+
+        backup = await self._mark_backup_in_progress(db, backup_id)
+        if not backup:
+            return False, "Backup not found"
+
+        remote_path = f"/tmp/slm-pg-{backup_id}.sql.gz"
+
+        try:
+            # Dump to a .partial first and rename, so an interrupted run never
+            # leaves a half-written dump that the copy step could pick up —
+            # same guarantee the scheduled script gives.
+            logger.info("Starting pg_dumpall on %s", host)
+            dump_cmd = self._build_ssh_command(
+                host,
+                ssh_user,
+                ssh_port,
+                f'sudo su - postgres -c "pg_dumpall --clean --if-exists" | gzip > {remote_path}.partial '
+                f"&& mv {remote_path}.partial {remote_path}",
+            )
+            success, output = await self._run_command(dump_cmd, timeout=1800)
+            if not success:
+                return await self._fail_backup(db, backup, f"pg_dumpall failed: {output}")
+
+            size_bytes, checksum = await self._get_remote_file_info(host, ssh_user, ssh_port, remote_path)
+            if size_bytes == 0:
+                return await self._fail_backup(db, backup, "pg_dumpall produced an empty dump")
+
+            copy_success, backup_path, copy_error = await self._copy_backup_to_storage(
+                host, ssh_user, ssh_port, remote_path, backup_id, suffix=".sql.gz"
+            )
+
+            return await self._complete_backup(
+                db,
+                backup,
+                copy_success,
+                backup_path,
+                size_bytes,
+                checksum,
+                host,
+                copy_error,
+                remote_path=remote_path,
+            )
+
+        except asyncio.TimeoutError:
+            return await self._fail_backup(db, backup, "Backup timed out")
+        except Exception as e:
+            logger.exception("Postgres backup error: %s", e)
+            return await self._fail_backup(db, backup, "Backup operation failed")
+        finally:
+            # The staged dump is a full copy of the cluster sitting in /tmp on
+            # the node. Leaving it there on every backup would fill the disk and
+            # expose the data outside the backup store.
+            await self._remove_remote_file(host, ssh_user, ssh_port, remote_path)
+
+    async def _remove_remote_file(self, host: str, ssh_user: str, ssh_port: int, path: str) -> None:
+        """Best-effort cleanup of a staged file on a node (#13307)."""
+        try:
+            cmd = self._build_ssh_command(host, ssh_user, ssh_port, f"rm -f {path} {path}.partial")
+            await self._run_command(cmd, timeout=30)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Could not remove staged file %s on %s: %s", path, host, exc)
 
     async def _stop_redis_for_restore(self, host: str, ssh_user: str, ssh_port: int) -> None:
         """Stop Redis service on the target node.
@@ -417,12 +531,13 @@ class BackupService:
         logger.info("Redis RDB path discovered: %s", rdb_path)
         return redis_auth_prefix, rdb_path
 
-    async def _get_rdb_file_info(
+    async def _get_remote_file_info(
         self, host: str, ssh_user: str, ssh_port: int, rdb_path: str
     ) -> Tuple[int, str | None]:
-        """Get RDB file size and checksum from remote host.
+        """Get a remote file's size and checksum.
 
-        Helper for execute_redis_backup (Issue #665).
+        Helper for execute_redis_backup (Issue #665); also used by the Postgres
+        path (#13307), which is why it is no longer named for RDB files.
 
         Returns (size_bytes, checksum).
         """
@@ -459,15 +574,26 @@ class BackupService:
         ssh_port: int,
         rdb_path: str,
         backup_id: str,
+        suffix: str = ".rdb",
     ) -> Tuple[bool, Path, str]:
-        """Copy RDB backup file from remote host to local storage via SCP.
+        """Copy a backup file from the remote host to local storage via SCP.
 
-        Helper for execute_redis_backup (Issue #665).
+        Helper for execute_redis_backup (Issue #665). ``suffix`` exists because
+        the Postgres path stores ``.sql.gz`` (#13307) — the extension used to be
+        hardcoded to ``.rdb``, which would have labelled every Postgres dump as
+        a Redis one.
 
         Returns (success, backup_path, error_output).
         """
+        if not self._ensure_storage_dir():
+            return (
+                False,
+                BACKUP_STORAGE_DIR / backup_id,
+                f"Backup storage directory {BACKUP_STORAGE_DIR} is not writable",
+            )
+
         timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
-        backup_filename = f"{backup_id}_{timestamp}.rdb"
+        backup_filename = f"{backup_id}_{timestamp}{suffix}"
         backup_path = BACKUP_STORAGE_DIR / backup_filename
 
         scp_cmd = [
@@ -494,6 +620,7 @@ class BackupService:
         remote_checksum: str | None,
         host: str,
         copy_error: str = "",
+        remote_path: str = "/var/lib/redis/dump.rdb",
     ) -> Tuple[bool, str]:
         """Update backup record with results and complete the backup.
 
@@ -504,7 +631,9 @@ class BackupService:
         if not copy_success:
             # Backup exists on remote but copy failed - still record it
             backup.status = BackupStatus.COMPLETED.value
-            backup.backup_path = "/var/lib/redis/dump.rdb"
+            # #13307: was hardcoded to the Redis data path, so a Postgres backup
+            # whose copy failed would have pointed at Redis's live dump.rdb.
+            backup.backup_path = remote_path
             backup.size_bytes = size_bytes
             backup.checksum = remote_checksum
             backup.extra_data = {
@@ -543,6 +672,128 @@ class BackupService:
             backup.checksum,
         )
         return True, "Backup completed successfully"
+
+    # ------------------------------------------------------------------
+    # Deletion and retention (#13307)
+    #
+    # Before this there was no delete route at all — `@router.delete` count in
+    # api/stateful.py was 0 — so nothing in the system could reclaim space, and
+    # the destination was a home directory on the root filesystem. Retention was
+    # not a missing convenience; it was unimplementable.
+    # ------------------------------------------------------------------
+
+    async def delete_backup(self, db: AsyncSession, backup_id: str) -> Tuple[bool, str]:
+        """Delete a backup record and the file it points at.
+
+        The record is removed even when the file is already gone: a row pointing
+        at a missing file is exactly what a half-finished cleanup leaves behind,
+        and refusing to delete it would make the state unrecoverable through the
+        API — which is the situation #13307 is about.
+        """
+        result = await db.execute(select(Backup).where(Backup.backup_id == backup_id))
+        backup = result.scalar_one_or_none()
+        if not backup:
+            return False, "Backup not found"
+
+        if backup.status == BackupStatus.IN_PROGRESS.value:
+            return False, "Backup is in progress"
+
+        self._unlink_backup_file(backup)
+
+        await db.delete(backup)
+        await db.commit()
+        logger.info("Backup %s deleted", backup_id)
+        return True, "Backup deleted"
+
+    def _unlink_backup_file(self, backup: Backup) -> None:
+        """Remove a backup's local file, if it has one inside our storage dir.
+
+        Scoped to BACKUP_STORAGE_DIR on purpose. `_complete_backup` records the
+        REMOTE path when the copy to SLM storage failed — for Redis that is the
+        live ``/var/lib/redis/dump.rdb`` on the target node, and deleting it
+        would destroy the data the backup exists to protect.
+        """
+        path_str = backup.backup_path
+        if not path_str:
+            return
+
+        path = Path(path_str)
+        try:
+            path.relative_to(BACKUP_STORAGE_DIR)
+        except ValueError:
+            logger.info(
+                "Backup %s points outside %s (%s) — record removed, file left alone",
+                backup.backup_id,
+                BACKUP_STORAGE_DIR,
+                path_str,
+            )
+            return
+
+        try:
+            path.unlink(missing_ok=True)
+        except OSError as exc:
+            logger.warning("Could not remove backup file %s: %s", path, exc)
+
+    async def apply_retention(
+        self,
+        db: AsyncSession,
+        node_id: str,
+        service_type: str,
+        keep_count: int | None = None,
+        max_age_days: int | None = None,
+    ) -> list[str]:
+        """Prune old backups for one (node, service_type), newest kept.
+
+        Returns the backup_ids removed. Both dimensions are independent and
+        either can be disabled with 0; a backup is pruned if *either* rule
+        selects it.
+
+        Only ``completed`` backups are counted toward ``keep_count``. Counting
+        failed ones would let a run of failures evict the last good backup,
+        which is the one moment it matters.
+        """
+        keep_count = settings.backup_retention_count if keep_count is None else keep_count
+        max_age_days = settings.backup_retention_days if max_age_days is None else max_age_days
+
+        result = await db.execute(
+            select(Backup)
+            .where(
+                Backup.node_id == node_id,
+                Backup.service_type == service_type,
+                Backup.status == BackupStatus.COMPLETED.value,
+            )
+            .order_by(Backup.created_at.desc())
+        )
+        completed = list(result.scalars().all())
+
+        doomed = {b.backup_id: b for b in completed[keep_count:]} if keep_count > 0 else {}
+
+        if max_age_days > 0:
+            cutoff = datetime.now(timezone.utc) - timedelta(days=max_age_days)
+            for backup in completed:
+                created = backup.created_at
+                if created is None:
+                    continue
+                if created.tzinfo is None:
+                    created = created.replace(tzinfo=timezone.utc)
+                if created < cutoff:
+                    doomed[backup.backup_id] = backup
+
+        for backup in doomed.values():
+            self._unlink_backup_file(backup)
+            await db.delete(backup)
+
+        if doomed:
+            await db.commit()
+            logger.info(
+                "Retention pruned %d backup(s) for node=%s service=%s (keep=%d, max_age_days=%d)",
+                len(doomed),
+                node_id,
+                service_type,
+                keep_count,
+                max_age_days,
+            )
+        return sorted(doomed)
 
 
 # Global service instance

--- a/autobot-slm-backend/tests/test_backup_delete_retention_13307.py
+++ b/autobot-slm-backend/tests/test_backup_delete_retention_13307.py
@@ -1,0 +1,306 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Backups must be deletable, prunable, and land somewhere findable (#13307).
+
+The Backups page could create a backup and nothing else. `@router.delete` count
+in `api/stateful.py` was **0**, so nothing in the system could reclaim space —
+retention was not a missing convenience, it was unimplementable. And the
+destination was the service account's home directory, chosen by a fallback
+rather than a decision: `config.py` said `~/slm-backups` while
+`services/backup.py` named `/var/lib/slm/backups` in a branch that could never
+run, because `settings` has always defined `backup_dir`.
+
+Two of these tests guard against destroying data rather than merely failing:
+
+* deleting a backup whose copy-to-storage failed must NOT unlink the path it
+  recorded — that is the live `/var/lib/redis/dump.rdb` on the target node;
+* a run of failed backups must not let retention evict the last good one.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+class _FakeBackup:
+    def __init__(self, backup_id, status="completed", path=None, created=None, node="n1", svc="redis"):
+        self.backup_id = backup_id
+        self.status = status
+        self.backup_path = path
+        self.created_at = created or datetime.now(timezone.utc)
+        self.node_id = node
+        self.service_type = svc
+
+
+class _FakeResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def scalar_one_or_none(self):
+        return self._rows[0] if self._rows else None
+
+    def scalars(self):
+        return self
+
+    def all(self):
+        return list(self._rows)
+
+
+class _FakeDB:
+    """Enough AsyncSession for the delete/retention paths."""
+
+    def __init__(self, rows):
+        self._rows = rows
+        self.deleted = []
+        self.commits = 0
+
+    async def execute(self, _query):
+        return _FakeResult(self._rows)
+
+    async def delete(self, obj):
+        self.deleted.append(obj)
+
+    async def commit(self):
+        self.commits += 1
+
+
+def _real_backup_module():
+    """Load services/backup.py for real, bypassing the harness stub.
+
+    The slm-backend conftest hands out MagicMocks for `config` and much of
+    `services`. Asserting against those is vacuous — every attribute is a truthy
+    mock, so a test can pass whether or not the code does anything. Loading the
+    module from its own path is the only way these tests measure the real thing.
+    """
+    import importlib.util
+    import sys
+
+    root = Path(__file__).resolve().parents[1]
+    for extra in (str(root), str(root.parent)):
+        if extra not in sys.path:
+            sys.path.insert(0, extra)
+
+    spec = importlib.util.spec_from_file_location("_real_slm_backup_13307", root / "services" / "backup.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture()
+def backup_module():
+    try:
+        return _real_backup_module()
+    except Exception as exc:  # noqa: BLE001
+        pytest.skip(f"services/backup.py not importable in this environment: {exc}")
+
+
+@pytest.fixture()
+def service(backup_module, tmp_path, monkeypatch):
+    """A BackupService writing into a tmp dir instead of /var/lib/slm/backups."""
+    monkeypatch.setattr(backup_module, "BACKUP_STORAGE_DIR", tmp_path)
+    return backup_module.BackupService.__new__(backup_module.BackupService)
+
+
+# --- destination -----------------------------------------------------------
+
+
+def _code_lines(path: Path) -> str:
+    """Source with comment-only lines dropped.
+
+    The comments explaining this change quote the old values verbatim, so a
+    naive substring check matches its own rationale and fails forever.
+    """
+    return "\n".join(
+        line for line in path.read_text(encoding="utf-8").splitlines() if not line.lstrip().startswith("#")
+    )
+
+
+def test_storage_dir_is_not_a_home_directory():
+    """The reported symptom: 'no idea where they are created'.
+
+    Asserted against config.py's source rather than `settings`, which the
+    harness replaces with a MagicMock whose every attribute is truthy.
+    """
+    config_src = _code_lines(Path(__file__).resolve().parents[1] / "config.py")
+
+    assert (
+        'Path.home() / "slm-backups"' not in config_src
+    ), "backup_dir still defaults to the service account's home directory"
+    assert 'os.getenv("SLM_BACKUP_DIR", "/var/lib/slm/backups")' in config_src
+
+
+def test_service_and_config_agree_on_one_destination(backup_module):
+    """The two files used to name different defaults, the dead one being right."""
+    backup_src = _code_lines(Path(__file__).resolve().parents[1] / "services" / "backup.py")
+
+    assert 'hasattr(settings, "backup_dir")' not in backup_src, (
+        "the dead hasattr fallback is back — it named a different default that "
+        "could never apply, which is how the two files disagreed"
+    )
+    assert "BACKUP_STORAGE_DIR = Path(settings.backup_dir)" in backup_src, (
+        "services/backup.py must take the destination from settings alone; a "
+        "second literal here is exactly how the two files came to disagree"
+    )
+
+    # The runtime value is deliberately NOT asserted here. `config` is a
+    # MagicMock in this harness even for a module loaded from its own path, so
+    # `Path(settings.backup_dir)` resolves to a mock repr — an assertion on it
+    # would measure the stub, not the code. config.py's literal default is
+    # pinned by test_storage_dir_is_not_a_home_directory; together the two
+    # establish the single-source property without asserting against a mock.
+
+
+def test_import_survives_an_unwritable_destination(backup_module):
+    """The destination moved to a root-owned path; import must not die on it.
+
+    `backup_service` is constructed at module import. An unguarded mkdir there
+    raises PermissionError on any host where the ansible role has not run yet —
+    and in CI — taking the whole API down. Found by running it.
+    """
+    assert backup_module.backup_service is not None
+    assert backup_module.BackupService._ensure_storage_dir() in (True, False)
+
+
+# --- delete ----------------------------------------------------------------
+
+
+async def test_delete_removes_the_record_and_the_file(service, tmp_path):
+    stored = tmp_path / "abc_20260804.rdb"
+    stored.write_bytes(b"rdb")
+    db = _FakeDB([_FakeBackup("abc", path=str(stored))])
+
+    ok, message = await service.delete_backup(db, "abc")
+
+    assert ok, message
+    assert not stored.exists(), "the stored file must go with the record"
+    assert db.deleted and db.commits == 1
+
+
+async def test_delete_succeeds_when_the_file_is_already_gone(service, tmp_path):
+    """A row pointing at a missing file is what a half-finished cleanup leaves.
+
+    Refusing to delete it would make that state unrecoverable through the API —
+    which is the situation this issue is about.
+    """
+    db = _FakeDB([_FakeBackup("abc", path=str(tmp_path / "vanished.rdb"))])
+
+    ok, _ = await service.delete_backup(db, "abc")
+
+    assert ok
+    assert db.deleted
+
+
+async def test_delete_never_unlinks_a_path_outside_the_backup_store(service, tmp_path):
+    """The dangerous case, and the reason `_unlink_backup_file` is scoped.
+
+    `_complete_backup` records the REMOTE path when the copy to SLM storage
+    failed — for Redis that is the live `/var/lib/redis/dump.rdb` on the target
+    node. Unlinking it would destroy the data the backup exists to protect.
+    """
+    outside = tmp_path.parent / "live-dump.rdb"
+    outside.write_bytes(b"production data")
+    db = _FakeDB([_FakeBackup("abc", path=str(outside))])
+
+    ok, _ = await service.delete_backup(db, "abc")
+
+    assert ok, "the record must still be removable"
+    assert outside.exists(), (
+        "delete_backup unlinked a file outside the backup store — for a "
+        "copy-failed backup that path is the live database on the target node"
+    )
+
+
+async def test_an_in_progress_backup_is_not_deletable(service, backup_module):
+    # The module's own enum, not a literal: models.database is stubbed in this
+    # harness, so a hardcoded "in_progress" would never match its .value.
+    in_progress = backup_module.BackupStatus.IN_PROGRESS.value
+    db = _FakeDB([_FakeBackup("abc", status=in_progress)])
+
+    ok, message = await service.delete_backup(db, "abc")
+
+    assert not ok
+    assert "in progress" in message.lower()
+    assert not db.deleted
+
+
+async def test_deleting_an_unknown_backup_reports_not_found(service):
+    ok, message = await service.delete_backup(_FakeDB([]), "nope")
+
+    assert not ok
+    assert message == "Backup not found"
+
+
+# --- retention -------------------------------------------------------------
+
+
+async def test_retention_keeps_the_newest_n(service, tmp_path):
+    now = datetime.now(timezone.utc)
+    rows = []
+    for i in range(5):
+        path = tmp_path / f"b{i}.rdb"
+        path.write_bytes(b"x")
+        rows.append(_FakeBackup(f"b{i}", path=str(path), created=now - timedelta(hours=i)))
+    db = _FakeDB(rows)
+
+    removed = await service.apply_retention(db, "n1", "redis", keep_count=2, max_age_days=0)
+
+    assert removed == ["b2", "b3", "b4"], removed
+    assert (tmp_path / "b0.rdb").exists() and (tmp_path / "b1.rdb").exists()
+    assert not (tmp_path / "b4.rdb").exists()
+
+
+async def test_retention_prunes_by_age_independently_of_count(service, tmp_path):
+    now = datetime.now(timezone.utc)
+    fresh = _FakeBackup("fresh", path=str(tmp_path / "f.rdb"), created=now)
+    old = _FakeBackup("old", path=str(tmp_path / "o.rdb"), created=now - timedelta(days=40))
+    for b in (fresh, old):
+        (tmp_path / f"{b.backup_id[0]}.rdb").write_bytes(b"x")
+    db = _FakeDB([fresh, old])
+
+    removed = await service.apply_retention(db, "n1", "redis", keep_count=0, max_age_days=30)
+
+    assert removed == ["old"], removed
+
+
+async def test_retention_disabled_on_both_dimensions_removes_nothing(service, tmp_path):
+    rows = [_FakeBackup(f"b{i}", path=str(tmp_path / f"b{i}.rdb")) for i in range(5)]
+    db = _FakeDB(rows)
+
+    removed = await service.apply_retention(db, "n1", "redis", keep_count=0, max_age_days=0)
+
+    assert removed == []
+    assert db.commits == 0
+
+
+async def test_a_naive_created_at_is_not_treated_as_ancient(service, tmp_path):
+    """SQLite hands back naive datetimes; comparing them to an aware cutoff raises.
+
+    Getting this wrong would either crash retention or silently prune everything.
+    """
+    naive_recent = datetime.now(timezone.utc).replace(tzinfo=None)
+    db = _FakeDB([_FakeBackup("b", path=str(tmp_path / "b.rdb"), created=naive_recent)])
+
+    removed = await service.apply_retention(db, "n1", "redis", keep_count=0, max_age_days=30)
+
+    assert removed == []
+
+
+async def test_failed_backups_never_count_toward_the_keep_budget(backup_module):
+    """The one moment retention matters is after a run of failures.
+
+    If failed rows counted, three bad nights would evict the last good backup —
+    precisely when it is the only thing standing between you and data loss.
+    `apply_retention` only ever selects `completed` rows, so the fixture returns
+    only those; this pins that the query stays that way.
+    """
+    import inspect
+
+    source = inspect.getsource(backup_module.BackupService.apply_retention)
+    assert "BackupStatus.COMPLETED.value" in source, (
+        "apply_retention no longer filters to completed backups — a run of " "failures can now evict the last good one"
+    )


### PR DESCRIPTION
## Thinking Path

Backend half of #13307, against the three decisions taken on the issue: Postgres in scope, `/var/lib/slm/backups`, delete + retention.

The ordering follows the issue's own principle — what protects data soonest, not what was asked first. Adding PostgreSQL matters most: the page is called "Backups", it creates something called a backup, and PostgreSQL — users, LLC work items, chat/session data — was simply absent. A restore would not bring any of it back, and you would find that out during recovery.

Two things surfaced while building it that were more dangerous than the missing features.

**Deleting a backup could have deleted the live database.** `_complete_backup` records the *remote* path when the copy to SLM storage fails — for Redis that is `/var/lib/redis/dump.rdb` on the target node, the running database. A naive `delete_backup` that unlinks `backup.backup_path` would destroy the data the backup exists to protect. `_unlink_backup_file` is therefore scoped to `BACKUP_STORAGE_DIR` and removes the record while leaving anything outside it alone.

**Moving the destination broke module import.** `backup_service = BackupService()` runs at import and used to `mkdir` unconditionally. That was safe while the destination was a home directory; against root-owned `/var/lib/slm/backups` it raises `PermissionError` and `import services.backup` fails outright — taking the API down on any host where Ansible has not run yet, and in CI. Found by running it, not by reading it. The mkdir is now best-effort with a warning naming the role that owns the directory, and the copy step surfaces a real error at the point it matters.

## What Changed

**Destination** — `config.py` defaults to `/var/lib/slm/backups`; `services/backup.py` drops its dead `hasattr(settings, "backup_dir")` fallback. `settings` has always defined `backup_dir`, so the `/var/lib/slm/backups` written there could never apply — two files naming different defaults, with the unreachable one being correct. One source now.

**Delete** — `DELETE /backups/{backup_id}` → 204. `@router.delete` count in `api/stateful.py` was **0**, so nothing could reclaim space and retention was unimplementable. Refuses an in-progress backup (409); succeeds when the file is already gone, because a row pointing at a missing file is what a half-finished cleanup leaves behind and refusing would make that state unrecoverable through the API.

**Retention** — `apply_retention(node_id, service_type, keep_count, max_age_days)`, defaults `10` / `30 days`, either dimension disabled with `0`. Runs after each *successful* backup rather than on a timer: a new good backup is the only moment it is safe to drop an old one, and it needs no scheduler this service does not have. Only `completed` backups count toward `keep_count` — counting failures would let three bad nights evict the last good backup, precisely when it is the only thing between you and data loss.

**PostgreSQL** — `execute_postgres_backup`, dispatched for `postgres`/`postgresql`. The dump command mirrors `roles/postgresql/templates/autobot-pg-backup.sh.j2` exactly (`su - postgres -c "pg_dumpall --clean --if-exists" | gzip`), so there is one way this cluster is dumped and no password is embedded. Dumps to `.partial` and renames, so an interrupted run leaves nothing the copy step could pick up. The staged dump is removed from the node in a `finally` — it is a full copy of the cluster sitting in `/tmp`.

Three helpers were Redis-specific and are now shared rather than duplicated: `_get_rdb_file_info` → `_get_remote_file_info`, `_copy_backup_to_storage` gains a `suffix` (the `.rdb` extension was hardcoded and would have labelled every Postgres dump as a Redis one), and `_complete_backup` takes `remote_path` instead of hardcoding `/var/lib/redis/dump.rdb` — which would have pointed a failed Postgres backup at Redis's live dump.

**Provisioning** — the `slm_manager` role creates `/var/lib/slm/backups` at **0750**, not the 0755 its directory loop uses: a backup now contains a full Redis and PostgreSQL dump, so it carries every credential, user record and chat message the platform holds.

## Verification

```console
$ python3 -m pytest autobot-slm-backend/tests/test_backup_delete_retention_13307.py -q
13 passed

$ python3 -m pytest autobot-slm-backend/tests/ -q --ignore=autobot-slm-backend/tests/api/test_scim.py
1086 passed, 1 skipped, 1 xfailed

$ cd autobot-slm-backend/ansible && ansible-playbook --syntax-check playbooks/deploy-slm-manager.yml -i localhost,
playbook: playbooks/deploy-slm-manager.yml       # exit 0
```

The two destructive guards were invert-tested — each fails on exactly its own regression:

```console
$ # _unlink_backup_file unscoped from BACKUP_STORAGE_DIR
1 failed, 12 passed
$ # failed backups counted toward the keep budget
1 failed, 12 passed
$ # restored
13 passed
```

`tests/api/test_scim.py` fails collection with `ModuleNotFoundError: services.system_secrets_vault`. Pre-existing — reproduced on an untouched checkout, unrelated to this change.

Tests load `services/backup.py` from its own path rather than importing it: the harness replaces `config` and much of `services` with MagicMocks, and asserting against those is vacuous — every attribute is truthy, so a test passes whether or not the code does anything. Where even that is not enough (the harness's `config` still leaks in), the property is pinned at source level with the reason recorded inline rather than asserted against a mock.

## Scope not delivered

The frontend half — rendering `backup_path` in `BackupsView.vue` (currently zero references, the direct fix for "no idea where they are created"), plus delete/retention controls and i18n across all 11 locales — is **not** in this PR and #13307 stays open. Export/import and remote destinations remain follow-ups per the decision on the issue.

Refs #13307

## Model Used

Opus 5 (1M context)
