### PR TITLE
fix(test-infra): stop backend unit tests reaching a live Redis by import order (#13446)

### DIFF
--- a/autobot-backend/conftest.py
+++ b/autobot-backend/conftest.py
@@ -11,6 +11,7 @@ Author: mrveiss
 """
 
 import asyncio
+import functools
 import os
 import sys
 import types
@@ -261,6 +262,181 @@ for _svc_mod in [
         # return a MagicMock and cause a UsageError during test collection.
         _svc_stub.pytest_plugins = []  # type: ignore[attr-defined]
         sys.modules[_svc_mod] = _svc_stub
+
+# ---------------------------------------------------------------------------
+# autobot_shared.redis_client stand-in (#13446)
+# ---------------------------------------------------------------------------
+# Backend unit tests must never open a Redis socket. ``get_async_redis_client()``
+# spends the client's full retry budget before giving up — 60s per call, 121s for
+# the 56 Redis-agnostic tests in tests/services/test_claim_verifier.py.
+#
+# The stand-in used to be installed 400 lines below, and only ``if
+# "autobot_shared.redis_client" not in sys.modules``, which made "does this unit
+# test talk to a live Redis" a function of who imported first: collection order,
+# and under ``-n auto --dist loadscope`` whichever files the worker was handed.
+# This file also defeated its own guard — the real-load of
+# services.tool_output_filter directly below reaches
+# autobot_shared.logging_manager -> config.registry._get_redis(), which imports
+# the genuine module, so the guard could never fire on this path.
+#
+# It is now installed unconditionally, and released again, for exactly the four
+# windows that belong to this directory (the #13359 pattern): this file's own
+# real-loads, pytest_configure's real-loads, the collection of each backend test
+# module, and the run of each backend test. Outside them the genuine module is
+# put back, because autobot_shared/'s own tests exercise it for real in the same
+# CI invocation (#13084) and several of them install their own stub only ``if it
+# is not already there`` — leaving the key empty flips those on.
+_REDIS_CLIENT_KEY = "autobot_shared.redis_client"
+
+
+def _import_real_redis_client() -> types.ModuleType | None:
+    """Import the genuine module once, before the first window opens.
+
+    Importing it opens no socket — that only happens when something *calls*
+    ``get_redis_client()``, and every such call site this directory reaches runs
+    inside a window, where the stand-in answers None. Having it loaded gives the
+    stand-in something to delegate to, and gives each window the module the rest
+    of the session expects to find rather than an empty key.
+    """
+    import importlib as _rc_il
+
+    try:
+        return _rc_il.import_module(_REDIS_CLIENT_KEY)
+    except Exception:  # bare env without the redis package — stand-in only
+        return None
+
+
+def _make_redis_client_standin(real: types.ModuleType | None) -> types.ModuleType:
+    """Build the socket-free ``autobot_shared.redis_client`` stand-in.
+
+    Only the two connection factories are replaced. Everything else — the
+    ``RedisConnectionManager`` class, the enums, the statistics dataclasses —
+    delegates to *real*, because backend tests do use them: e.g.
+    monitoring/redis_prometheus_metrics_test.py drives the genuine
+    ``RedisConnectionManager`` with a mocked metrics manager, and a MagicMock in
+    its place turns every assertion into a tautology.
+
+    Built once and reused by every window so ``mock.patch`` targets keep their
+    identity across them (#13359).
+    """
+    mod = types.ModuleType(_REDIS_CLIENT_KEY)
+
+    async def _get_async_redis_client(*_a, **_k):
+        # A coroutine returning None, so callers take their documented "Redis
+        # unavailable" branch instead of awaiting a MagicMock (TypeError).
+        return None
+
+    def _get_redis_client(*_a, **_k):
+        # A real callable returning None, NOT a MagicMock:
+        # config.registry._fetch_from_redis() treats any truthy client as usable
+        # and would hand that MagicMock straight back as a config *value*.
+        return None
+
+    def _delegate(attr: str):
+        # Dunders are answered by the module object itself or not at all — a
+        # MagicMock __path__ would make the import system treat this as a
+        # package.
+        if not attr.startswith("__") and real is not None:
+            try:
+                return getattr(real, attr)
+            except AttributeError:
+                pass
+        if attr.startswith("__"):
+            raise AttributeError(attr)
+        return MagicMock()
+
+    # Carry the genuine signature and docstring across, so introspection keeps
+    # working: utils/redis_consolidation_test.py asserts get_redis_client's
+    # parameter defaults and the "CANONICAL" line in its docstring.
+    # ``update_wrapper`` also sets ``__wrapped__``, which is what makes
+    # ``inspect.signature`` report the real one.
+    for _name, _fn in (
+        ("get_async_redis_client", _get_async_redis_client),
+        ("get_redis_client", _get_redis_client),
+    ):
+        _genuine = getattr(real, _name, None) if real is not None else None
+        setattr(mod, _name, _fn if _genuine is None else functools.update_wrapper(_fn, _genuine))
+    mod.__getattr__ = _delegate  # type: ignore[attr-defined]
+    return mod
+
+
+class _ScopedRedisClient:
+    """Own ``sys.modules["autobot_shared.redis_client"]`` for this directory only.
+
+    Re-entrant: the snapshot is taken on the outermost enter and put back when
+    the last holder leaves, so a nested window (pytest_configure inside the
+    import window) cannot restore early. Every caller installs and removes from
+    the same ``try/finally``.
+    """
+
+    def __init__(self) -> None:
+        self._holders: set[str] = set()
+        self._snapshot: tuple | None = None
+
+    def enter(self, holder: str) -> None:
+        """Install the stand-in if *holder* is the first to ask for it."""
+        first = not self._holders
+        self._holders.add(holder)
+        if not first:
+            return
+        pkg = sys.modules.get("autobot_shared")
+        self._snapshot = (
+            _REDIS_CLIENT_KEY in sys.modules,
+            sys.modules.get(_REDIS_CLIENT_KEY),
+            pkg is not None and "redis_client" in pkg.__dict__,
+            getattr(pkg, "redis_client", None),
+        )
+        self._bind(_REDIS_CLIENT_STANDIN)
+
+    def exit(self, holder: str) -> None:
+        """Put the previous module back once the last holder is done."""
+        self._holders.discard(holder)
+        if not self._holders:
+            self._restore()
+
+    def restore_all(self) -> None:
+        """Unconditionally release the stand-in (session-teardown safety net)."""
+        self._holders.clear()
+        self._restore()
+
+    def _restore(self) -> None:
+        snapshot, self._snapshot = self._snapshot, None
+        if snapshot is None:
+            return
+        had_mod, prior_mod, had_attr, prior_attr = snapshot
+        if had_mod:
+            sys.modules[_REDIS_CLIENT_KEY] = prior_mod
+        else:
+            sys.modules.pop(_REDIS_CLIENT_KEY, None)
+        pkg = sys.modules.get("autobot_shared")
+        if pkg is None:
+            return
+        if had_attr:
+            pkg.redis_client = prior_attr  # type: ignore[attr-defined]
+        else:
+            pkg.__dict__.pop("redis_client", None)
+
+    @staticmethod
+    def _bind(mod: types.ModuleType) -> None:
+        """Install *mod* and bind it on the parent package.
+
+        The parent bind is load-bearing: ``patch("autobot_shared.redis_client.X")``
+        resolves through ``getattr(autobot_shared, "redis_client")`` (#11661),
+        which a bare ``sys.modules`` assignment never sets.
+        """
+        sys.modules[_REDIS_CLIENT_KEY] = mod
+        pkg = sys.modules.get("autobot_shared")
+        if pkg is not None:
+            pkg.redis_client = mod  # type: ignore[attr-defined]
+
+
+_REDIS_CLIENT_STANDIN = _make_redis_client_standin(_import_real_redis_client())
+_SCOPED_REDIS = _ScopedRedisClient()
+
+# Window 1 of 4 — every module-level real-load below binds whichever
+# ``get_async_redis_client`` it finds into its own globals and keeps it for the
+# rest of the session. Closed at the end of this file's module-level code.
+_SCOPED_REDIS.enter("conftest-import")
 
 # #11248: tool_output_filter is lightweight (stdlib + yaml + autobot_shared; Redis
 # is only touched lazily inside methods, not at import), so its unit tests exercise
@@ -683,22 +859,6 @@ if "auth_middleware" not in sys.modules:
     _auth_stub.__getattr__ = lambda attr: MagicMock()  # type: ignore[attr-defined]
     sys.modules["auth_middleware"] = _auth_stub
 
-# autobot_shared.redis_client stub — provides get_async_redis_client as a
-# proper coroutine returning None so that rate-limiters and other callers that
-# do ``redis = await get_async_redis_client()`` fall back to in-process logic
-# instead of awaiting a MagicMock (which raises TypeError).
-if "autobot_shared.redis_client" not in sys.modules:
-    pass
-
-    _redis_client_mod = types.ModuleType("autobot_shared.redis_client")
-
-    async def _get_async_redis_client_stub(*_a, **_k):
-        return None
-
-    _redis_client_mod.get_async_redis_client = _get_async_redis_client_stub  # type: ignore[attr-defined]
-    _redis_client_mod.__getattr__ = lambda attr: MagicMock()  # type: ignore[attr-defined]
-    sys.modules["autobot_shared.redis_client"] = _redis_client_mod
-
 # autobot_shared.redis_management stubs — the real package tries to open
 # sockets at import time; tests must not do that.
 for _redis_sub in [
@@ -1043,6 +1203,10 @@ if "models" not in sys.modules:
 # and no __init__.py side-effects like find_spec() would cause.
 
 
+# End of window 1 (#13446) — nothing below this line runs at import time.
+_SCOPED_REDIS.exit("conftest-import")
+
+
 def _parse_requirements(path: Path) -> list[str]:
     """Return package names declared in a requirements.txt file."""
     names: list[str] = []
@@ -1245,9 +1409,16 @@ def pytest_configure(config):  # noqa: ANN001
     Real-loading here ensures ``sys.modules["services.llm_cost_tracker"]`` is the
     same object as ``_check_pricing_staleness.__globals__`` so patch() is effective.
     """
-    _real_load_and_bind("services.llm_api_key_service", backend_root / "services" / "llm_api_key_service.py")
-    _real_load_and_bind("services.llm_cost_tracker", backend_root / "services" / "llm_cost_tracker.py")
-    _real_load_light_services()
+    # Window 2 of 4 (#13446): these modules import autobot_shared.redis_client at
+    # module top — the paragraph above says so — and bind what they find there
+    # for the rest of the session.
+    _SCOPED_REDIS.enter("configure")
+    try:
+        _real_load_and_bind("services.llm_api_key_service", backend_root / "services" / "llm_api_key_service.py")
+        _real_load_and_bind("services.llm_cost_tracker", backend_root / "services" / "llm_cost_tracker.py")
+        _real_load_light_services()
+    finally:
+        _SCOPED_REDIS.exit("configure")
 
 
 # #12463: cascade hardening for manually-installed stub modules.
@@ -1317,3 +1488,73 @@ def pytest_collectreport(report) -> None:  # noqa: ANN001
             if _mod is not None and not _looks_like_uninitialized_stub(_mod):
                 continue  # healthy real module — leave it cached, don't re-run its import
             sys.modules.pop(_name, None)
+
+
+# ---------------------------------------------------------------------------
+# Windows 3 and 4 of the redis_client stand-in (#13446)
+# ---------------------------------------------------------------------------
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_make_collect_report(collector):  # noqa: ANN001, ANN201
+    """Window 3: hold the stand-in around this directory's own module imports.
+
+    Directory-scoped — pytest dispatches this through ``collector.ihook``, so it
+    fires only for nodes whose conftest chain includes this file — and it wraps
+    exactly ``collector.collect()``, the call in which a ``Module`` node imports
+    its test file, and with it every production module that binds
+    ``get_async_redis_client`` into its own globals at import time.
+
+    ``pytest_collectstart``/``pytest_collectreport`` cannot serve here:
+    ``pytest_collectreport`` never fires for a ``Dir`` or ``Package`` node, so a
+    pair keyed on one would install the stand-in and never restore it (#13359).
+    """
+    holder = f"collect:{collector.nodeid}"
+    _SCOPED_REDIS.enter(holder)
+    try:
+        yield
+    finally:
+        _SCOPED_REDIS.exit(holder)
+
+
+def _is_backend_item(item) -> bool:  # noqa: ANN001
+    """True when *item* lives under autobot-backend/.
+
+    ``pytest_runtest_protocol`` is NOT directory-scoped, unlike
+    ``pytest_make_collect_report``: ``Session.pytest_runtestloop`` dispatches it
+    through ``item.config.hook``, the global relay, so a hookwrapper defined in
+    any conftest wraps every item in the session (#13359). Without this check
+    the stand-in would be live while autobot_shared/'s own Redis tests run.
+    """
+    path = getattr(item, "path", None)
+    return path is not None and backend_root in Path(str(path)).parents
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_protocol(item, nextitem):  # noqa: ANN001, ANN201
+    """Window 4: hold the stand-in for setup, call and teardown of each test here.
+
+    Needed on top of window 3 because several callers import the client lazily
+    inside a function — ``config.registry._get_redis()`` does ``from
+    autobot_shared.redis_client import get_redis_client`` on every call — so the
+    name is resolved when the test runs, not when its module was imported.
+    """
+    if not _is_backend_item(item):
+        yield
+        return
+    holder = f"run:{item.nodeid}"
+    _SCOPED_REDIS.enter(holder)
+    try:
+        yield
+    finally:
+        _SCOPED_REDIS.exit(holder)
+
+
+def pytest_sessionfinish(session, exitstatus) -> None:  # noqa: ANN001
+    """Safety net: never let the stand-in outlive the session.
+
+    Every window restores from a ``finally``, but a ``BaseException`` unwinding
+    past pytest's hook machinery (KeyboardInterrupt during collection, a worker
+    crash) could still strand the holders set.
+    """
+    _SCOPED_REDIS.restore_all()

--- a/autobot-backend/tests/test_redis_client_standin.py
+++ b/autobot-backend/tests/test_redis_client_standin.py
@@ -1,0 +1,75 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Backend unit tests never open a Redis socket (#13446).
+
+Whether they did used to depend on who imported ``autobot_shared.redis_client``
+first — collection order, and under ``-n auto --dist loadscope`` whichever files
+the worker happened to be handed. When the genuine module won that race, every
+``await get_async_redis_client()`` spent the client's full retry budget: 60s per
+call, 121s for the 56 Redis-agnostic tests in
+``tests/services/test_claim_verifier.py``.
+
+The backend root conftest now installs a stand-in for exactly the four windows
+that belong to that directory. These tests assert both halves of the contract
+from inside one of them: the connection factories hand back None, and every
+other attribute is still the genuine module's object rather than a MagicMock.
+"""
+
+import sys
+import time
+
+import pytest
+
+_KEY = "autobot_shared.redis_client"
+
+
+def test_module_in_scope_is_the_standin():
+    """``sys.modules`` holds the stand-in while a backend test runs.
+
+    A bare ``types.ModuleType`` has no ``__file__``; the genuine module does.
+    """
+    mod = sys.modules.get(_KEY)
+    assert mod is not None, f"{_KEY} is not installed at all"
+    assert mod.__name__ == _KEY
+    assert getattr(mod, "__file__", None) is None, "the genuine module is live — no window opened"
+
+
+async def test_async_factory_returns_none_without_a_socket():
+    """The documented "Redis unavailable" answer, immediately."""
+    from autobot_shared.redis_client import get_async_redis_client
+
+    started = time.monotonic()
+    assert await get_async_redis_client() is None
+    assert await get_async_redis_client(database="main") is None
+    # A genuine client spends its retry budget before giving up. The stand-in
+    # cannot take a measurable amount of time, so this doubles as the assertion
+    # that no connection was attempted.
+    assert time.monotonic() - started < 1.0
+
+
+def test_sync_factory_returns_none_not_a_mock():
+    """The sync factory needs the same treatment as the async one.
+
+    ``config.registry._fetch_from_redis()`` treats any truthy client as usable
+    and would hand a MagicMock straight back as a configuration *value*.
+    """
+    from autobot_shared.redis_client import get_redis_client
+
+    assert get_redis_client() is None
+    assert get_redis_client(database="main") is None
+
+
+def test_unrelated_attributes_are_the_genuine_ones():
+    """Only the two factories are replaced; everything else delegates.
+
+    ``monitoring/redis_prometheus_metrics_test.py`` drives the real
+    ``RedisConnectionManager`` with a mocked metrics manager — a MagicMock in
+    its place turns each of its assertions into a tautology.
+    """
+    pytest.importorskip("redis")
+    from autobot_shared.redis_client import RedisConnectionManager
+
+    assert isinstance(RedisConnectionManager, type)
+    assert RedisConnectionManager.__module__.startswith("autobot_shared.redis_management")


### PR DESCRIPTION
## Thinking Path

Refs #13446.

**The conditional was never a decision — and the file defeated its own guard.** `git blame`
puts `if "autobot_shared.redis_client" not in sys.modules:` in #8098, which added twelve
stubs to this conftest in one commit, every one of them behind the same `if … not in
sys.modules` idiom. Nothing in that PR is about Redis specifically; the guard is boilerplate,
not a carve-out for a test that wants the genuine client.

Then it never fired anyway. Traced with an import hook on a clean checkout:

    autobot-backend/conftest.py:270  _real_load_and_bind("services.tool_output_filter", …)
      services/tool_output_filter.py:29   get_logger(__name__)
        autobot_shared/logging_manager.py:37   _get_config_manager()
          autobot-backend/config/registry.py:169  _get_redis()
            → import autobot_shared.redis_client        # the genuine module, line 270

That is ~400 lines *above* the guard at line 690, so on the ordinary path the real module was
always in `sys.modules` by the time the guard ran and the stand-in was never installed. Which
module wins is decided by whatever ran before — collection order, and under `-n auto --dist
loadscope` whichever files the worker was handed.

**What the 60s actually is.** Not a refused connection: the configured host is the unresolved
placeholder shipped in the default config, so every call burns the async client's full
5-attempt retry budget on DNS. Visible with the base conftest:

    Error checking Redis readiness for 'main': Error -2 connecting to <placeholder-host>:6379. Name or service not known.   (×5)
    create_async_pool[main] failed after 5 attempts

Two such calls before the circuit breaker opens = 120s, which is the whole of
`test_claim_verifier.py`'s 121s. A locally-reachable Redis makes no difference, and neither
does pointing the client at a closed port — both measured below.

**Why the fix is scoped and not unconditional.** The obvious change — drop the condition —
was built and measured first, and it breaks the tree CI runs in the *same* invocation
(#13084 forbids splitting them): `autobot_shared/`'s own tests exercise the genuine module,
and several install their own stub only *if the key is empty*, so emptying it flips those on:

    unconditional install:  7 failed, 243 passed, 44 errors   (delta_engine_test, alert_cooldown_test:
                            "cannot import name 'get_redis_client' … (unknown location)")
    base:                 294 passed in 128.67s

So the stand-in is installed and released for exactly the four windows that belong to this
directory (the #13359 pattern), and outside them the genuine module is put back rather than
the key left empty — restoring an *empty* key is what unmasked
`autobot_shared/rate_limiter_test.py`'s own latent `setdefault` stub and produced a brand-new
unlisted leak owner in an intermediate build of this change.

**Why it is a façade rather than a MagicMock.** Only the two connection factories are
replaced; every other attribute delegates to the genuine module. Backend tests do use those:
`monitoring/redis_prometheus_metrics_test.py` drives the real `RedisConnectionManager` (7
tests turned into tautologies with a MagicMock in its place), and
`utils/redis_consolidation_test.py` asserts `get_redis_client`'s parameter defaults and the
"CANONICAL" line of its docstring — which is why the two replacements carry the genuine
signature and `__doc__` via `functools.update_wrapper`. Both were caught by the full-suite A/B
below, not by inspection.

**Scope, stated explicitly.** This does not change which keys `autobot-backend/conftest.py`
leaves in `sys.modules` — measured at 42 escaping keys on base and on this branch — and makes
no attempt at its leak (#13361). It also does not touch `.github/workflows/`, the guard, or
the baseline.

## What Changed

**`autobot-backend/conftest.py`**

- `_import_real_redis_client()` imports the genuine module once, before the first window.
  Importing opens no socket — only *calling* a factory does, and every such call site this
  directory reaches now runs inside a window.
- `_make_redis_client_standin(real)` builds the stand-in once and reuses it, so `mock.patch`
  targets keep their identity across windows (#13359). `get_async_redis_client` is a coroutine
  returning None; `get_redis_client` is a real callable returning None — deliberately not the
  catch-all MagicMock, because `config.registry._fetch_from_redis()` treats any truthy client
  as usable and would hand that mock back as a configuration *value*. Both carry the genuine
  signature and docstring. Everything else delegates to the real module; dunders raise
  `AttributeError` instead of yielding a mock, so a MagicMock `__path__` cannot make the import
  system treat the stand-in as a package.
- `_ScopedRedisClient` owns the key: re-entrant, snapshot on the outermost `enter`, restore
  (module *and* the `autobot_shared.redis_client` parent-package attribute) when the last
  holder leaves. Four windows, each installing and removing from the same `try/finally`:
  1. this file's module-level real-loads,
  2. `pytest_configure`'s real-loads — its own docstring already says those modules import the
     client at module top,
  3. `pytest_make_collect_report`, where a `Module` node imports its test file and with it
     every production module that binds `get_async_redis_client` into its globals,
  4. `pytest_runtest_protocol`, for lazy per-call imports such as
     `config.registry._get_redis()`.
  Window 4 is guarded by `_is_backend_item()`: `pytest_runtest_protocol` is dispatched through
  `item.config.hook`, the global relay, so without it the stand-in would be live while
  `autobot_shared/`'s Redis tests run — the third trap #13359 documents.
- `pytest_sessionfinish` is a safety net for a `BaseException` unwinding past the hook
  machinery.
- The old `if … not in sys.modules` block is gone; nothing else in the file moved.

**`autobot-backend/tests/test_redis_client_standin.py`** (new) — four tests asserting the
contract from inside a window: the installed module is the stand-in, both factories answer
None in under a second, and a non-replaced attribute (`RedisConnectionManager`) is still the
genuine class.

## Verification

All runs on `Dev_new_gui` @ 68abf2b1b, A/B by swapping only `conftest.py` in one worktree. No
AutoBot service was started or stopped; no Redis was started or stopped.

**Timings — the headline and the order flip.** Identical commands, conftest swapped:

| Shape | base | this branch |
|---|---|---|
| A. `test_claim_verifier.py` alone | **56 passed in 121.21s** | **56 passed in 0.82s** |
| B. same, client pointed at a closed port via env | 56 passed in 120.92s | 56 passed in 0.75s |
| C. backend first, then `autobot_shared/redis_management` | 100 passed in 121.66s | 100 passed in 1.40s |
| D. `autobot_shared/redis_management` first, then backend | 100 passed in 152.64s | 100 passed in 1.35s |
| E. `tests/services` + `agents/agent_orchestration`, `-n auto --dist loadscope` | 753 passed in 153.02s | 753 passed in 39.52s |

C and D are the same two directories in the two orders — the flip the issue is about. On base
the outcome differs by 31s between them; on this branch they are within 0.05s of each other,
which is the actual fix: the answer no longer depends on who imported first.

**No socket, proven twice.** B above is the timing form. The direct form is the new guard
file, run against each conftest:

    this branch:  4 passed in 0.61s
    base:         2 failed, 2 passed in 62.42s
                  FAILED test_module_in_scope_is_the_standin
                  FAILED test_async_factory_returns_none_without_a_socket
                  ERROR ... Error -2 connecting to <placeholder-host>:6379. Name or service not known.  (×5)
                  ERROR ... create_async_pool[main] failed after 5 attempts

The two tests that fail on base are exactly the two that assert no connection is attempted,
and they fail *with the connection attempt in the log* — the property is guarded, and the
guard bites when it breaks. (The other two pass on base: the genuine sync factory also returns
None when Redis is unreachable, and `RedisConnectionManager` is genuine either way.)

**The tree that must keep the real module.** `autobot_shared/`'s Redis tests plus the two
backend files that use the real client, one session, CI's own combined shape:

    base:         294 passed in 128.67s
    this branch:  294 passed in 7.86s

Same 294, 16× faster. This is the run that rejected the unconditional install (7 failed, 44
errors) and the empty-key restore (2 collection errors + a new unlisted leak owner).

**Full CI-shaped suite**, `pytest autobot-backend autobot_shared autobot-tts-worker repo_tests
-n auto --dist loadscope`, unit markers only:

    base, run 1:  28 failed, 20146 passed, 2477 skipped, 4 errors in 913.38s
    base, run 2:  42 failed, 20132 passed, 2477 skipped, 4 errors in 785.52s
    this branch:  32 failed, 20146 passed, 2477 skipped, 4 errors in 522.89s

**43% faster.** On failures: the two base runs of the *same* commit differ from each other by
17 entries — `--dist loadscope` composes shards from worker availability, so which
order-sensitive test lands where moves every run. Against the union of both base runs, this
branch has 3 entries neither base run produced: `llc/tests/test_atomic_checkout.py`,
`llc/tests/test_human_claims.py`, `tests/test_pty_read_loop_fd_setsize_13219.py` — all three
pass in isolation (`23 passed in 0.63s`), and the llc tree A/B'd directly under loadscope is
byte-identical:

    llc + a2a, base:    7 failed, 1748 passed in 166.06s
    llc + a2a, branch:  7 failed, 1748 passed in  73.40s

Two genuine regressions *were* found this way and are fixed in the diff:
`utils/redis_consolidation_test.py`'s two introspection tests (signature + docstring), which
is why `functools.update_wrapper` is there. An earlier build also lost
`monitoring/redis_prometheus_metrics_test.py`'s 7 tests, which is why the stand-in delegates
instead of mocking.

**sys.modules leak guard** — baseline untouched, no new owner, no `FIXED:` line:

    base:    13 known leaking file(s), 113 keys — known: autobot-backend/conftest.py (42 key(s))
    branch:  13 known leaking file(s), 115 keys — known: autobot-backend/conftest.py (42 key(s))

Same 13 owners, and **this conftest's escaping-key count is unchanged at 42**. The +2 is
`tests/test_conftest_real_load_identity.py` reported at 3 keys instead of 1; A/B'd in a
controlled two-file session with `AUTOBOT_SYSMODULES_BASELINE` pointed at an empty file, both
conftests leak *the same three keys* (`code_intelligence.anti_pattern_detector`,
`agent_loop.loop`, `agent_loop.think_tool`) — base run 1 simply never gave two of them an
escape opportunity. The unlisted owners the full run reports are the
`services/knowledge/*` chromadb family, present on both base runs too (11 / 9 / 11) and
already filed as #13435 and #13450.

**Lint**: `black --check`, `isort --check-only`, `flake8 --config=.flake8` clean on both
changed files. Every added function is under 30 lines; no test in the new file exceeds 1s.

**Not combined with #13449** (PR #13484): that one is a single test file's own patching gap,
this one changes how the root backend conftest owns a `sys.modules` key and is felt by every
backend test — different blast radius, different review. They also have to stay separable to
stay honest: once this lands, `claim_task` fails open in that file and its six colliding cases
pass by luck, so its fix would be unverifiable if the two were merged together.

## Model Used

claude-opus-5
