### PR TITLE
feat(knowledge): resolve CodeIndexer call edges via shared identity/resolver, persist as traversable graph

### DIFF
--- a/autobot-backend/api/codebase_analytics/endpoints/call_graph.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/call_graph.py
@@ -16,6 +16,8 @@ import aiofiles
 from fastapi import APIRouter, Query
 from fastapi.responses import JSONResponse
 
+from autobot_shared.code_graph import compute_node_id, module_path_from_rel_path
+from autobot_shared.code_graph import resolve_callee as _shared_resolve_callee
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_redis_client
@@ -309,46 +311,6 @@ def _build_call_edge(
     }
 
 
-def _resolve_via_import_context(
-    callee_name: str,
-    import_context: ImportContext,
-    functions: Dict,
-) -> tuple[str | None, bool]:
-    """
-    Resolve callee via import context.
-
-    Issue #713: Extracted from _resolve_callee_id to reduce function length.
-
-    Args:
-        callee_name: Name of the called function
-        import_context: Import context for the current file
-        functions: Dictionary of registered functions
-
-    Returns:
-        Tuple of (resolved_id, is_external)
-    """
-    imported_path = import_context.resolve_name(callee_name)
-    if not imported_path:
-        return None, False
-
-    # Check if it's an external library call
-    if import_context.is_external(callee_name):
-        return None, True  # External call, not truly unresolved
-
-    # Try the imported path directly
-    if imported_path in functions:
-        return imported_path, False
-
-    # Try variations (module.func vs module.Class.func)
-    parts = imported_path.split(".")
-    for i in range(len(parts) - 1, 0, -1):
-        candidate = ".".join(parts[:i]) + "." + parts[-1]
-        if candidate in functions:
-            return candidate, False
-
-    return None, False
-
-
 def _resolve_callee_id(
     callee_name: str,
     module_path: str,
@@ -361,6 +323,17 @@ def _resolve_callee_id(
 
     Issue #665: Extracted from _create_function_visitor to reduce function length.
     Issue #713: Enhanced with import context for cross-module resolution.
+    Issue #13470: Delegates the module-local/class-local/import-context
+    resolution to the canonical resolver in autobot_shared/code_graph/ —
+    the same one services/knowledge/code_indexer.py (#13469) uses — so this
+    module no longer keeps its own copy. ``functions`` (id -> info) is passed
+    straight through as the resolver's ``known_ids`` container; dict
+    membership checks by key, so this is not a behaviour change.
+
+    The trailing dotted-name check below is retained for exact behaviour
+    parity even though ``FunctionCallVisitor._extract_callee_name`` never
+    actually returns a name containing "." (attribute calls yield only the
+    final ``.attr`` component) — filed as a follow-up (#13470 remaining work).
 
     Args:
         callee_name: Name of the called function
@@ -374,24 +347,12 @@ def _resolve_callee_id(
         - resolved_id: Function ID if found, None otherwise
         - is_external: True if call is to external library (not unresolved)
     """
-    # Try module-level function first
-    possible_id = f"{module_path}.{callee_name}"
-    if possible_id in functions:
-        return possible_id, False
+    resolved_id, is_external = _shared_resolve_callee(
+        callee_name, module_path, current_class, functions, import_context
+    )
+    if resolved_id or is_external:
+        return resolved_id, is_external
 
-    # Try class method if in class context
-    if current_class:
-        possible_id = f"{module_path}.{current_class}.{callee_name}"
-        if possible_id in functions:
-            return possible_id, False
-
-    # Issue #713: Try resolving via import context
-    if import_context:
-        result = _resolve_via_import_context(callee_name, import_context, functions)
-        if result[0] or result[1]:  # Found or is external
-            return result
-
-    # Issue #713: Check if callee_name itself is external (e.g., json.loads)
     if callee_name and "." in callee_name:
         base = callee_name.split(".")[0]
         if base in STDLIB_MODULES or base in COMMON_THIRD_PARTY:
@@ -444,6 +405,10 @@ def _compute_func_identity(node_name: str, module_path: str, current_class: str 
 
     Issue #665: Extracted from _create_function_visitor._process_function
     to reduce nested class method size.
+    Issue #13470: The id itself now comes from the canonical
+    autobot_shared.code_graph.compute_node_id — this was the "richer" of the
+    two node-identity schemes in the codebase, so it became the shared one
+    rather than being duplicated here.
 
     Args:
         node_name: Name of the function node
@@ -453,12 +418,8 @@ def _compute_func_identity(node_name: str, module_path: str, current_class: str 
     Returns:
         Tuple of (func_id, full_name)
     """
-    if current_class:
-        func_id = f"{module_path}.{current_class}.{node_name}"
-        full_name = f"{current_class}.{node_name}"
-    else:
-        func_id = f"{module_path}.{node_name}"
-        full_name = node_name
+    func_id = compute_node_id(node_name, module_path, parent_class=current_class)
+    full_name = f"{current_class}.{node_name}" if current_class else node_name
     return func_id, full_name
 
 
@@ -651,11 +612,14 @@ async def _analyze_python_files(
 
     Issue #665: Extracted from get_call_graph to reduce function length.
     Issue #713: Added import context extraction for cross-module resolution.
+    Issue #13470: module_path now comes from the canonical
+    module_path_from_rel_path (identical output for .py files; shared with
+    services/knowledge/code_indexer.py).
     """
     for py_file in python_files[:300]:
         try:
             rel_path = str(py_file.relative_to(project_root))
-            module_path = rel_path.replace("/", ".").replace(".py", "")
+            module_path = module_path_from_rel_path(rel_path)
             try:
                 async with aiofiles.open(py_file, "r", encoding="utf-8") as f:
                     content = await f.read()

--- a/autobot-backend/api/codebase_analytics/endpoints/shared.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/shared.py
@@ -10,145 +10,42 @@ from pathlib import Path
 
 from fastapi import HTTPException, Request, status
 
+# Issue #13470: ImportContext, STDLIB_MODULES, COMMON_THIRD_PARTY,
+# INTERNAL_MODULE_PREFIXES and is_external_module moved to
+# autobot_shared/code_graph/resolver.py, the module both this endpoint and
+# services/knowledge/code_indexer.py import the resolver from. Re-exported
+# here unchanged so existing importers (dependencies.py, import_tree.py,
+# call_graph_resolution_test.py) do not need to change their import path.
+from autobot_shared.code_graph import (
+    COMMON_THIRD_PARTY,
+    INTERNAL_MODULE_PREFIXES,
+    STDLIB_MODULES,
+    ImportContext,
+    is_external_module,
+)
 from autobot_shared.logging_manager import get_logger
 
 # Logger
 logger = get_logger(__name__)
 
-# Performance optimization: O(1) lookup for internal modules (Issue #326)
-INTERNAL_MODULE_PREFIXES = {
-    "a2a",
-    "agents",
-    "api",
-    "autobot",
-    "autobot_shared",
-    "backend",
-    "cache",
-    "chat_workflow",
-    "config",
-    "constants",
-    "database",
-    "extensions",
-    "initialization",
-    "knowledge",
-    "models",
-    "orchestration",
-    "routers",
-    "security",
-    "services",
-    "src",
-    "utils",
-}
-
 # In-memory storage fallback
 _in_memory_storage = {}
 
-# Standard library modules (used by multiple endpoints)
-STDLIB_MODULES = {
-    "os",
-    "sys",
-    "re",
-    "json",
-    "time",
-    "datetime",
-    "logging",
-    "asyncio",
-    "pathlib",
-    "typing",
-    "collections",
-    "functools",
-    "itertools",
-    "subprocess",
-    "threading",
-    "multiprocessing",
-    "uuid",
-    "hashlib",
-    "base64",
-    "io",
-    "contextlib",
-    "abc",
-    "dataclasses",
-    "enum",
-    "copy",
-    "math",
-    "random",
-    "socket",
-    "http",
-    "urllib",
-    "traceback",
-    "inspect",
-    "ast",
-    "shutil",
-    "tempfile",
-    "warnings",
-    "signal",
-    "argparse",
-    "pickle",
-    "csv",
-    "sqlite3",
-    "email",
-    "html",
-    "xml",
-    "struct",
-    "array",
-    "queue",
-    "heapq",
-    "bisect",
-    "weakref",
-    "types",
-    "operator",
-    "string",
-    "textwrap",
-    "codecs",
-}
-
-
-# Common third-party packages to exclude from resolution (Issue #713)
-COMMON_THIRD_PARTY = {
-    "fastapi",
-    "pydantic",
-    "redis",
-    "aiofiles",
-    "aiohttp",
-    "requests",
-    "numpy",
-    "pandas",
-    "sqlalchemy",
-    "alembic",
-    "pytest",
-    "httpx",
-    "celery",
-    "chromadb",
-    "openai",
-    "anthropic",
-    "langchain",
-    "torch",
-    "transformers",
-    "PIL",
-    "cv2",
-    "sklearn",
-    "scipy",
-    "matplotlib",
-    "websockets",
-    "uvicorn",
-    "starlette",
-    "jinja2",
-    "click",
-    "rich",
-    "yaml",
-    "toml",
-    "dotenv",
-    "paramiko",
-    "fabric",
-    "boto3",
-    "google",
-    "azure",
-    "docker",
-    "kubernetes",
-    "jwt",
-    "cryptography",
-    "bcrypt",
-}
+__all__ = [
+    "COMMON_THIRD_PARTY",
+    "INTERNAL_MODULE_PREFIXES",
+    "STDLIB_MODULES",
+    "ImportContext",
+    "is_external_module",
+    "authorize_source_access",
+    "filter_problems_by_file_existence",
+    "get_project_root",
+    "require_source_access",
+    "resolve_project_root",
+    "resolve_scan_root",
+    "resolve_source_root",
+    "trigger_auto_index_if_unindexed",
+]
 
 
 async def resolve_source_root(source_id: "str | None") -> "Path | None":
@@ -454,105 +351,3 @@ def filter_problems_by_file_existence(
 
     return validated
 
-
-# =============================================================================
-# Import Context Utilities (Issue #713)
-# =============================================================================
-
-
-class ImportContext:
-    """
-    Tracks import context for a single file to enable cross-module resolution.
-
-    Issue #713: Extracted from import_tree.py logic to share with call_graph.py.
-
-    Attributes:
-        name_to_module: Maps imported names to their source module paths
-        module_to_names: Maps module paths to list of imported names
-        aliases: Maps alias names to original names
-    """
-
-    def __init__(self):
-        """Initialize empty import context."""
-        self.name_to_module: dict[str, str] = {}
-        self.module_to_names: dict[str, list[str]] = {}
-        self.aliases: dict[str, str] = {}
-
-    def add_import(self, module: str, name: str | None = None, alias: str | None = None):
-        """
-        Register an import statement.
-
-        Args:
-            module: The module being imported (e.g., 'src.utils.redis_client')
-            name: Specific name imported (e.g., 'get_redis_client') or None for module import
-            alias: Alias if any (e.g., 'redis' for 'import redis_client as redis')
-        """
-        if name:
-            # from module import name [as alias]
-            effective_name = alias if alias else name
-            full_path = f"{module}.{name}"
-            self.name_to_module[effective_name] = full_path
-            if alias:
-                self.aliases[alias] = name
-        else:
-            # import module [as alias]
-            effective_name = alias if alias else module.split(".")[-1]
-            self.name_to_module[effective_name] = module
-            if alias:
-                self.aliases[alias] = module
-
-        if module not in self.module_to_names:
-            self.module_to_names[module] = []
-        if name and name not in self.module_to_names[module]:
-            self.module_to_names[module].append(name)
-
-    def resolve_name(self, name: str) -> str | None:
-        """
-        Resolve a called name to its full module path.
-
-        Args:
-            name: The name being called (e.g., 'get_redis_client')
-
-        Returns:
-            Full module path if found (e.g., 'src.utils.redis_client.get_redis_client')
-            or None if not in imports
-        """
-        return self.name_to_module.get(name)
-
-    def is_external(self, name: str) -> bool:
-        """
-        Check if a name refers to an external (non-project) import.
-
-        Args:
-            name: The name to check
-
-        Returns:
-            True if the name is from stdlib or third-party package
-        """
-        module_path = self.name_to_module.get(name)
-        if not module_path:
-            return False
-
-        base_module = module_path.split(".")[0]
-        return base_module in STDLIB_MODULES or base_module in COMMON_THIRD_PARTY
-
-
-def is_external_module(module_name: str) -> bool:
-    """
-    Check if a module is external (stdlib or third-party).
-
-    Issue #713: Used to filter external calls from unresolved count.
-
-    Args:
-        module_name: Module name or path to check
-
-    Returns:
-        True if external, False if internal project module
-    """
-    base = module_name.split(".")[0]
-    if base in STDLIB_MODULES or base in COMMON_THIRD_PARTY:
-        return True
-    if base in INTERNAL_MODULE_PREFIXES:
-        return False
-    # Unknown - assume external if not matching internal prefixes
-    return True

--- a/autobot-backend/api/codebase_analytics/endpoints/shared.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/shared.py
@@ -350,4 +350,3 @@ def filter_problems_by_file_existence(
         )
 
     return validated
-

--- a/autobot-backend/services/knowledge/code_indexer.py
+++ b/autobot-backend/services/knowledge/code_indexer.py
@@ -5,11 +5,21 @@
 """AST-based code indexer using tree-sitter (#4820).
 
 Two-pass extraction per source file:
-  Pass 1 (structural): walk AST for function/class declarations → nodes.
-  Pass 2 (call-graph): walk function bodies for call expressions → edges.
+  Pass 1 (structural): walk AST for function/class declarations -> nodes.
+  Pass 2 (call-graph): walk function bodies for call expressions -> edges.
 
 Results are embedded and upserted into ChromaDB following the same
 SHA-256 content-hash cache + upsert pattern as DocIndexer.
+
+Issue #13469: edges used to be flattened into a comma-joined string of raw
+callee names on the node's own metadata (a "calls" field with zero readers)
+and stamped "extracted" unconditionally. They are now resolved against the
+canonical identity/resolver in autobot_shared/code_graph/ (#13470) and
+persisted as their own documents in the same collection
+(``metadata["record_type"] == "edge"``), each carrying the target node id
+(when resolved), the raw target name (always), and one of the three
+provenance tiers (#13482 Q2) so "who calls X" is an exact metadata lookup
+instead of a string nobody could parse back into a graph.
 
 Supported languages: Python, JavaScript/TypeScript.
 """
@@ -17,11 +27,11 @@ Supported languages: Python, JavaScript/TypeScript.
 import asyncio
 import hashlib
 import json
-import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from autobot_shared.code_graph import ResolvedCall, compute_node_id, module_path_from_rel_path, resolve_call
 from autobot_shared.logging_manager import get_logger
 from constants.path_constants import PATH
 
@@ -49,18 +59,21 @@ class CodeIndexResult:
     errors: list[str] = field(default_factory=list)
 
 
-def _make_node_id(name: str, source_path: str, parent: str | None = None) -> str:
-    """Stable lowercase ID: '<stem>::<safe_name>' or '<stem>::<parent_safe>__<safe_name>'."""
-    stem = Path(source_path).stem
-    safe = re.sub(r"[^a-z0-9_]", "", name.lower().replace(".", "_"))
-    if parent:
-        parent_safe = re.sub(r"[^a-z0-9_]", "", parent.split("::")[-1].lower())
-        return f"{stem}::{parent_safe}__{safe}"
-    return f"{stem}::{safe}"
+def _make_node_id(name: str, module_path: str, parent_class: str | None = None) -> str:
+    """Node id via the canonical autobot_shared.code_graph scheme (#13470).
+
+    Thin wrapper kept so callers in this module read the same as before;
+    ``compute_node_id`` is the single implementation shared with
+    ``api/codebase_analytics/endpoints/call_graph.py``.
+    """
+    return compute_node_id(name, module_path, parent_class)
 
 
 def extract_python(source_path: str, content: bytes) -> dict:
     """Two-pass tree-sitter extraction for Python.
+
+    *source_path* must be project-relative (e.g. ``"services/knowledge/code_indexer.py"``);
+    it is used to derive the module path both passes key nodes/edges on.
 
     Returns {"nodes": [...], "edges": [...]}.
     """
@@ -75,174 +88,177 @@ def extract_python(source_path: str, content: bytes) -> dict:
     parser = Parser(lang)
     tree = parser.parse(content)
 
+    module_path = module_path_from_rel_path(source_path)
     nodes: dict[str, dict] = {}
     edges: list[dict] = []
     seen_edges: set[tuple[str, str]] = set()
 
-    _py_structural(tree.root_node, source_path, nodes, parent_scope=None)
-    _py_call_graph(tree.root_node, source_path, nodes, edges, seen_edges, current_scope=None)
+    _py_structural(tree.root_node, module_path, source_path, nodes, current_class=None)
+    _py_call_graph(tree.root_node, module_path, source_path, edges, seen_edges, current_scope=None, current_class=None)
 
     return {"nodes": list(nodes.values()), "edges": edges}
 
 
-def _py_structural(node: Any, source_path: str, nodes: dict, parent_scope: str | None) -> None:
+def _store_node(
+    node: Any, name: str, module_path: str, source_path: str, nodes: dict, kind: str, current_class: str | None
+) -> None:
+    """Record one structural node. Shared by the Python and JS/TS structural passes."""
+    nid = _make_node_id(name, module_path, current_class)
+    nodes[nid] = {
+        "id": nid,
+        "name": name,
+        "kind": kind,
+        "source_path": source_path,
+        "line": node.start_point[0] + 1,
+        "parent": _make_node_id(current_class, module_path) if current_class else None,
+    }
+
+
+def _record_call_edge(
+    node: Any,
+    module_path: str,
+    source_path: str,
+    current_scope: str,
+    current_class: str | None,
+    edges: list,
+    seen: set,
+) -> None:
+    """Record one raw call edge (target not yet resolved). Shared by Python and JS/TS."""
+    func_node = node.child_by_field_name("function")
+    if not func_node:
+        return
+    raw = func_node.text.decode("utf-8").split("(")[0]
+    target_name = raw.split(".")[-1]
+    pair = (current_scope, target_name)
+    if pair in seen:
+        return
+    seen.add(pair)
+    edges.append(
+        {
+            "source": current_scope,
+            "target_name": target_name,
+            "module_path": module_path,
+            "current_class": current_class,
+            "kind": "calls",
+            "source_path": source_path,
+        }
+    )
+
+
+def _py_structural(node: Any, module_path: str, source_path: str, nodes: dict, current_class: str | None) -> None:
+    """Structural pass: record function/class nodes, tracking class scope (#13469).
+
+    Fixes a pre-existing bug where class scope was tracked here but not by
+    ``_py_call_graph`` (below), so a method's node id and its call-graph
+    scope disagreed and its outgoing calls never attached to it — see
+    ``test_class_method_call_graph``, which failed on this before #13469.
+    """
     if node.type == "function_definition":
         name_node = node.child_by_field_name("name")
         if name_node:
             name = name_node.text.decode("utf-8")
-            nid = _make_node_id(name, source_path, parent=parent_scope)
-            nodes[nid] = {
-                "id": nid,
-                "name": name,
-                "kind": "function",
-                "source_path": source_path,
-                "line": node.start_point[0] + 1,
-                "parent": parent_scope,
-            }
+            _store_node(node, name, module_path, source_path, nodes, "function", current_class)
             for child in node.children:
-                _py_structural(child, source_path, nodes, parent_scope=nid)
+                _py_structural(child, module_path, source_path, nodes, current_class)
             return
-
     if node.type == "class_definition":
         name_node = node.child_by_field_name("name")
         if name_node:
-            name = name_node.text.decode("utf-8")
-            nid = _make_node_id(name, source_path, parent=parent_scope)
-            nodes[nid] = {
-                "id": nid,
-                "name": name,
-                "kind": "class",
-                "source_path": source_path,
-                "line": node.start_point[0] + 1,
-                "parent": parent_scope,
-            }
+            class_name = name_node.text.decode("utf-8")
+            _store_node(node, class_name, module_path, source_path, nodes, "class", current_class)
             for child in node.children:
-                _py_structural(child, source_path, nodes, parent_scope=nid)
+                _py_structural(child, module_path, source_path, nodes, class_name)
             return
-
     for child in node.children:
-        _py_structural(child, source_path, nodes, parent_scope)
+        _py_structural(child, module_path, source_path, nodes, current_class)
 
 
 def _py_call_graph(
     node: Any,
+    module_path: str,
     source_path: str,
-    nodes: dict,
     edges: list,
     seen: set,
     current_scope: str | None,
-    parent_scope: str | None = None,
+    current_class: str | None,
 ) -> None:
+    """Call-graph pass: record raw call edges, now tracking class scope (#13469;
+    see the docstring on ``_py_structural`` for the bug this fixes)."""
     if node.type == "function_definition":
         name_node = node.child_by_field_name("name")
         scope = (
-            _make_node_id(name_node.text.decode("utf-8"), source_path, parent=current_scope)
-            if name_node
-            else current_scope
+            _make_node_id(name_node.text.decode("utf-8"), module_path, current_class) if name_node else current_scope
         )
         for child in node.children:
-            _py_call_graph(child, source_path, nodes, edges, seen, scope, parent_scope=current_scope)
+            _py_call_graph(child, module_path, source_path, edges, seen, scope, current_class)
         return
-
+    if node.type == "class_definition":
+        name_node = node.child_by_field_name("name")
+        class_name = name_node.text.decode("utf-8") if name_node else current_class
+        for child in node.children:
+            _py_call_graph(child, module_path, source_path, edges, seen, current_scope, class_name)
+        return
     if node.type == "call" and current_scope:
-        func_node = node.child_by_field_name("function")
-        if func_node:
-            raw = func_node.text.decode("utf-8").split("(")[0]
-            target_name = raw.split(".")[-1]
-            pair = (current_scope, target_name)
-            if pair not in seen:
-                seen.add(pair)
-                edges.append(
-                    {
-                        "source": current_scope,
-                        "target_name": target_name,
-                        "kind": "calls",
-                        "source_path": source_path,
-                        "origin": "extracted",
-                    }
-                )
-
+        _record_call_edge(node, module_path, source_path, current_scope, current_class, edges, seen)
     for child in node.children:
-        _py_call_graph(child, source_path, nodes, edges, seen, current_scope)
+        _py_call_graph(child, module_path, source_path, edges, seen, current_scope, current_class)
 
 
-def _js_structural(node: Any, source_path: str, nodes: dict, parent_scope: str | None) -> None:
-    """Helper for JS/TS structural extraction."""
+def _js_structural(node: Any, module_path: str, source_path: str, nodes: dict, current_class: str | None) -> None:
+    """Structural pass for JS/TS/Vue. Fixes the same class-scope bug as ``_py_structural``:
+    the original never updated ``parent_scope`` when descending into a ``class_declaration``,
+    so JS/TS methods never nested under their class."""
     if node.type in ("function_declaration", "arrow_function", "function_expression"):
         name_node = node.child_by_field_name("name")
         name = name_node.text.decode("utf-8") if name_node else f"anon_{node.start_point[0]}"
-        nid = _make_node_id(name, source_path, parent=parent_scope)
-        nodes[nid] = {
-            "id": nid,
-            "name": name,
-            "kind": "function",
-            "source_path": source_path,
-            "line": node.start_point[0] + 1,
-            "parent": parent_scope,
-        }
+        _store_node(node, name, module_path, source_path, nodes, "function", current_class)
         for child in node.children:
-            _js_structural(child, source_path, nodes, parent_scope=nid)
+            _js_structural(child, module_path, source_path, nodes, current_class)
         return
     if node.type == "class_declaration":
         name_node = node.child_by_field_name("name")
         if name_node:
-            name = name_node.text.decode("utf-8")
-            nid = _make_node_id(name, source_path, parent=parent_scope)
-            nodes[nid] = {
-                "id": nid,
-                "name": name,
-                "kind": "class",
-                "source_path": source_path,
-                "line": node.start_point[0] + 1,
-                "parent": parent_scope,
-            }
+            class_name = name_node.text.decode("utf-8")
+            _store_node(node, class_name, module_path, source_path, nodes, "class", current_class)
+            for child in node.children:
+                _js_structural(child, module_path, source_path, nodes, class_name)
+            return
     for child in node.children:
-        _js_structural(child, source_path, nodes, parent_scope)
+        _js_structural(child, module_path, source_path, nodes, current_class)
 
 
 def _js_call_graph(
     node: Any,
+    module_path: str,
     source_path: str,
-    nodes: dict,
     edges: list,
     seen: set,
     current_scope: str | None,
-    parent_scope: str | None = None,
+    current_class: str | None,
 ) -> None:
-    """Helper for JS/TS call-graph extraction."""
+    """Call-graph pass for JS/TS/Vue; mirrors ``_py_call_graph``."""
     if node.type in ("function_declaration", "arrow_function", "function_expression"):
         name_node = node.child_by_field_name("name")
         scope = (
-            _make_node_id(name_node.text.decode("utf-8"), source_path, parent=current_scope)
-            if name_node
-            else current_scope
+            _make_node_id(name_node.text.decode("utf-8"), module_path, current_class) if name_node else current_scope
         )
         for child in node.children:
-            _js_call_graph(child, source_path, nodes, edges, seen, scope, parent_scope=current_scope)
+            _js_call_graph(child, module_path, source_path, edges, seen, scope, current_class)
+        return
+    if node.type == "class_declaration":
+        name_node = node.child_by_field_name("name")
+        class_name = name_node.text.decode("utf-8") if name_node else current_class
+        for child in node.children:
+            _js_call_graph(child, module_path, source_path, edges, seen, current_scope, class_name)
         return
     if node.type == "call_expression" and current_scope:
-        func_node = node.child_by_field_name("function")
-        if func_node:
-            raw = func_node.text.decode("utf-8").split("(")[0]
-            target_name = raw.split(".")[-1]
-            pair = (current_scope, target_name)
-            if pair not in seen:
-                seen.add(pair)
-                edges.append(
-                    {
-                        "source": current_scope,
-                        "target_name": target_name,
-                        "kind": "calls",
-                        "source_path": source_path,
-                        "origin": "extracted",
-                    }
-                )
+        _record_call_edge(node, module_path, source_path, current_scope, current_class, edges, seen)
     for child in node.children:
-        _js_call_graph(child, source_path, nodes, edges, seen, current_scope)
+        _js_call_graph(child, module_path, source_path, edges, seen, current_scope, current_class)
 
 
 def extract_javascript(source_path: str, content: bytes) -> dict:
-    """Two-pass extraction for JavaScript/TypeScript."""
+    """Two-pass extraction for JavaScript/TypeScript. *source_path* must be project-relative."""
     try:
         import tree_sitter_javascript as tsjs
         from tree_sitter import Language, Parser
@@ -254,11 +270,12 @@ def extract_javascript(source_path: str, content: bytes) -> dict:
     parser = Parser(lang)
     tree = parser.parse(content)
 
+    module_path = module_path_from_rel_path(source_path)
     nodes: dict[str, dict] = {}
     edges: list[dict] = []
     seen_edges: set[tuple[str, str]] = set()
-    _js_structural(tree.root_node, source_path, nodes, parent_scope=None)
-    _js_call_graph(tree.root_node, source_path, nodes, edges, seen_edges, current_scope=None)
+    _js_structural(tree.root_node, module_path, source_path, nodes, current_class=None)
+    _js_call_graph(tree.root_node, module_path, source_path, edges, seen_edges, current_scope=None, current_class=None)
     return {"nodes": list(nodes.values()), "edges": edges}
 
 
@@ -279,7 +296,9 @@ class CodeIndexer:
     """Index source files into ChromaDB using AST extraction.
 
     Mirrors DocIndexer's SHA-256 hash cache + upsert pattern.
-    Each function/class node becomes one ChromaDB document.
+    Each function/class node becomes one ChromaDB document; each resolved
+    call edge becomes a second document (``record_type == "edge"``, #13469)
+    in the same collection — no fourth store, per the #13467 umbrella.
     """
 
     def __init__(
@@ -292,6 +311,10 @@ class CodeIndexer:
         self._embed_model = embed_model
         self._cache_file = cache_file
         self._hash_cache: dict[str, str] = self._load_cache()
+        # Node ids known to the collection plus everything indexed so far this
+        # run; lazily seeded (#13469) so cross-file/cross-run call resolution
+        # does not require every source file to be reprocessed on every run.
+        self._known_ids: set[str] | None = None
 
     async def index_file(
         self,
@@ -299,21 +322,33 @@ class CodeIndexer:
         root_dir: str,
         force: bool = False,
     ) -> CodeIndexResult:
-        """Extract AST nodes from file_path and upsert into ChromaDB."""
+        """Extract AST nodes+edges from file_path and upsert into ChromaDB."""
         result = CodeIndexResult()
         ext = Path(file_path).suffix.lower()
-        extractor = _EXTRACTORS.get(ext)
-        if extractor is None:
+        if ext not in _EXTRACTORS:
             result.skipped += 1
             return result
 
         rel_path = str(Path(file_path).relative_to(root_dir))
+        extracted = await self._extract_file(file_path, rel_path, ext, force, result)
+        if extracted is None:
+            return result
+
+        await self._ensure_known_ids()
+        await self._index_extraction(rel_path, extracted, result)
+        self._update_hash_cache(file_path, rel_path)
+        return result
+
+    async def _extract_file(
+        self, file_path: str, rel_path: str, ext: str, force: bool, result: CodeIndexResult
+    ) -> dict | None:
+        """Hash-check, read and extract one file; updates *result* and returns
+        None on skip/failure. Split from index_file() to keep it under 30 lines."""
         if not force:
             current_hash = self._compute_hash(file_path)
             if current_hash and self._hash_cache.get(rel_path) == current_hash:
                 result.skipped += 1
-                return result
-
+                return None
         try:
             # #7467: was sync `Path(file_path).read_bytes()` blocking the event loop
             # during code indexing of potentially-large source files.
@@ -321,33 +356,19 @@ class CodeIndexer:
         except OSError as e:
             result.failed += 1
             result.errors.append(str(e))
-            return result
-
-        extracted = extractor(file_path, content)
+            return None
+        extracted = _EXTRACTORS[ext](rel_path, content)
         if extracted.get("dep_error"):
             result.failed += 1
             result.errors.append(f"{rel_path}: missing dependency — {extracted['dep_error']}")
-            return result
-        nodes = extracted["nodes"]
-        edges = extracted["edges"]
+            return None
+        return extracted
 
-        calls_by_source: dict[str, list[str]] = {}
-        for e in edges:
-            calls_by_source.setdefault(e["source"], []).append(e["target_name"])
-
-        for node in nodes:
-            ok = await self._upsert_node(node, rel_path, calls_by_source)
-            if ok:
-                result.success += 1
-            else:
-                result.failed += 1
-
+    def _update_hash_cache(self, file_path: str, rel_path: str) -> None:
         new_hash = self._compute_hash(file_path)
         if new_hash:
             self._hash_cache[rel_path] = new_hash
             self._save_cache()
-
-        return result
 
     async def index_directory(
         self,
@@ -363,22 +384,13 @@ class CodeIndexer:
         same cache file, preventing last-write-wins cache corruption (#4895).
         """
         async with _get_cache_lock(str(self._cache_file)):
-            # Reload cache inside the lock so we start from the freshest snapshot
-            # before this batch begins.
+            # Reload cache and known node ids inside the lock so this batch
+            # starts from the freshest snapshot of both (#4895, #13469).
             self._hash_cache = self._load_cache()
+            self._known_ids = await self._seed_known_ids_from_collection()
 
             aggregate = CodeIndexResult()
-            root = Path(root_dir)
-            _SKIP_DIRS = {".git", "node_modules", "venv", ".venv", "__pycache__", ".mypy_cache"}
-            files = await asyncio.to_thread(lambda: sorted(root.rglob("*")))
-            for path in files:
-                if path.is_dir():
-                    continue
-                # Skip files inside ignored directories
-                if any(part.startswith(".") or part in _SKIP_DIRS for part in path.parts):
-                    continue
-                if path.suffix.lower() not in _EXTRACTORS:
-                    continue
+            for path in await self._collect_source_files(root_dir):
                 result = await self.index_file(str(path), root_dir=root_dir, force=force)
                 aggregate.success += result.success
                 aggregate.failed += result.failed
@@ -386,16 +398,97 @@ class CodeIndexer:
                 aggregate.errors.extend(result.errors)
             return aggregate
 
-    async def _upsert_node(self, node: dict, rel_path: str, calls_by_source: dict[str, list[str]]) -> bool:
+    @staticmethod
+    async def _collect_source_files(root_dir: str) -> list[Path]:
+        """List indexable files under *root_dir*, skipping hidden/vendor dirs."""
+        root = Path(root_dir)
+        skip_dirs = {".git", "node_modules", "venv", ".venv", "__pycache__", ".mypy_cache"}
+
+        def _walk() -> list[Path]:
+            found = []
+            for path in sorted(root.rglob("*")):
+                if path.is_dir() or any(part.startswith(".") or part in skip_dirs for part in path.parts):
+                    continue
+                if path.suffix.lower() in _EXTRACTORS:
+                    found.append(path)
+            return found
+
+        return await asyncio.to_thread(_walk)
+
+    async def _ensure_known_ids(self) -> None:
+        """Seed ``self._known_ids`` once, lazily, for standalone index_file() callers.
+
+        index_directory() seeds eagerly (and refreshes) at the top of its own
+        run; this only fires the first time a CodeIndexer is used via
+        index_file() directly (as the tests do).
+        """
+        if self._known_ids is None:
+            self._known_ids = await self._seed_known_ids_from_collection()
+
+    async def _seed_known_ids_from_collection(self) -> set[str]:
+        """Return the set of node ids already upserted into the collection (#13469).
+
+        The where-clause only scopes to this indexer's own records
+        (``source == "autobot_code"``, shared with edge documents and with
+        pre-#13469 node records); the client-side filter on ``node_kind``
+        (present only on node records, never on edge ones) is what actually
+        separates the two, so this seeds correctly whether or not a given
+        record carries the new ``record_type`` field — required for
+        cross-run backward compatibility with collections indexed before
+        this PR.
+        """
+        try:
+            existing = await asyncio.to_thread(
+                self._collection.get,
+                where={"source": "autobot_code"},
+                include=["metadatas"],
+            )
+            ids = existing.get("ids") or []
+            metadatas = existing.get("metadatas") or []
+            return {nid for nid, meta in zip(ids, metadatas) if meta and meta.get("node_kind")}
+        except Exception as e:
+            logger.warning("Could not seed known code-graph node ids from collection: %s", e)
+            return set()
+
+    async def _index_extraction(self, rel_path: str, extracted: dict, result: CodeIndexResult) -> None:
+        """Register nodes, upsert them, resolve their outgoing edges, upsert those too."""
+        nodes = extracted["nodes"]
+        self._known_ids.update(n["id"] for n in nodes)
+
+        node_embeddings: dict[str, list[float]] = {}
+        for node in nodes:
+            embedding = await self._upsert_node(node, rel_path)
+            if embedding is not None:
+                result.success += 1
+                node_embeddings[node["id"]] = embedding
+            else:
+                result.failed += 1
+
+        resolved_by_source = self._resolve_edges(extracted["edges"])
+        if not await self._upsert_edges(resolved_by_source, rel_path, node_embeddings):
+            result.errors.append(f"{rel_path}: failed to upsert call edges")
+
+    def _resolve_edges(self, edges: list[dict]) -> dict[str, list[tuple[dict, ResolvedCall]]]:
+        """Resolve every raw edge's target_name to a node id with honest provenance (#13469, #13482 Q2)."""
+        resolved_by_source: dict[str, list[tuple[dict, ResolvedCall]]] = {}
+        for edge in edges:
+            resolved = resolve_call(edge["target_name"], edge["module_path"], edge["current_class"], self._known_ids)
+            resolved_by_source.setdefault(edge["source"], []).append((edge, resolved))
+        return resolved_by_source
+
+    async def _upsert_node(self, node: dict, rel_path: str) -> list[float] | None:
+        """Upsert one function/class node. Returns its embedding on success (reused
+        for that node's outgoing edge documents to avoid extra model calls),
+        None on failure."""
         content = f"{node['kind'].upper()} {node['name']}\n" f"File: {rel_path} line {node.get('line', 0)}"
         metadata: dict[str, Any] = {
             "source": "autobot_code",
+            "record_type": "node",
             "node_kind": node["kind"],
             "node_name": node["name"],
             "source_path": rel_path,
             "line": str(node.get("line", 0)),
             "parent": node.get("parent") or "",
-            "calls": ",".join(calls_by_source.get(node["id"], [])),
             "origin": "extracted",
         }
         try:
@@ -407,9 +500,28 @@ class CodeIndexer:
                 documents=[content],
                 metadatas=[metadata],
             )
-            return True
+            return embedding
         except Exception as e:
             logger.error("Failed to upsert node %s: %s", node["id"], e)
+            return None
+
+    async def _upsert_edges(
+        self,
+        resolved_by_source: dict[str, list[tuple[dict, ResolvedCall]]],
+        rel_path: str,
+        node_embeddings: dict[str, list[float]],
+    ) -> bool:
+        """Upsert resolved call edges as their own documents (#13469)."""
+        ids, embeddings, documents, metadatas = _build_edge_batch(resolved_by_source, rel_path, node_embeddings)
+        if not ids:
+            return True
+        try:
+            await asyncio.to_thread(
+                self._collection.upsert, ids=ids, embeddings=embeddings, documents=documents, metadatas=metadatas
+            )
+            return True
+        except Exception as e:
+            logger.error("Failed to upsert %d call edges for %s: %s", len(ids), rel_path, e)
             return False
 
     @staticmethod
@@ -433,3 +545,72 @@ class CodeIndexer:
             self._cache_file.write_text(json.dumps(self._hash_cache, indent=2), encoding="utf-8")
         except OSError as e:
             logger.warning("Could not save code index cache: %s", e)
+
+
+def _build_edge_batch(
+    resolved_by_source: dict[str, list[tuple[dict, ResolvedCall]]],
+    rel_path: str,
+    node_embeddings: dict[str, list[float]],
+) -> tuple[list[str], list[list[float]], list[str], list[dict]]:
+    """Flatten resolved edges into ChromaDB upsert-shaped parallel lists.
+
+    Edge documents are never semantically searched, so each reuses its
+    source node's already-computed embedding instead of paying for another
+    embedding-model call (#13469).
+    """
+    ids: list[str] = []
+    embeddings: list[list[float]] = []
+    documents: list[str] = []
+    metadatas: list[dict] = []
+    for source_id, calls in resolved_by_source.items():
+        fallback_embedding = node_embeddings.get(source_id)
+        if fallback_embedding is None:
+            continue  # source node's own upsert failed; nothing to embed the edge with
+        for edge, resolved in calls:
+            ids.append(f"edge::{source_id}::{edge['target_name']}")
+            embeddings.append(fallback_embedding)
+            documents.append(f"CALLS {edge['target_name']}")
+            metadatas.append(_build_edge_metadata(source_id, edge, resolved, rel_path))
+    return ids, embeddings, documents, metadatas
+
+
+def _build_edge_metadata(source_id: str, edge: dict, resolved: ResolvedCall, rel_path: str) -> dict[str, Any]:
+    """Build the metadata for one persisted call-edge document (#13469).
+
+    ``target_id`` is "" (not None — ChromaDB metadata values must be scalar)
+    when unresolved; ``resolved``/``candidate_count`` give callers a coverage
+    count instead of the invented confidence score #13482 Q2 rejected.
+    """
+    return {
+        "source": "autobot_code",
+        "record_type": "edge",
+        "kind": edge["kind"],
+        "source_id": source_id,
+        "target_id": resolved.target_id or "",
+        "target_name": edge["target_name"],
+        "origin": resolved.origin,
+        "resolved": resolved.resolved,
+        "candidate_count": resolved.candidate_count,
+        "source_path": rel_path,
+    }
+
+
+async def find_callers(collection: Any, target_id: str) -> list[dict[str, Any]]:
+    """Return every persisted "calls" edge whose target resolved to *target_id* (#13469).
+
+    The first real consumer of the persisted edge documents: an exact
+    metadata lookup, not a scan of the (now-removed) CSV ``calls`` string
+    nothing could parse. ``source_id`` on each returned edge is a node id
+    from the same collection, so callers can chain this to walk the graph.
+    """
+    result = await asyncio.to_thread(
+        collection.get,
+        where={
+            "$and": [
+                {"record_type": {"$eq": "edge"}},
+                {"target_id": {"$eq": target_id}},
+            ]
+        },
+        include=["metadatas"],
+    )
+    return list(result.get("metadatas") or [])

--- a/autobot-backend/services/knowledge/code_indexer_test.py
+++ b/autobot-backend/services/knowledge/code_indexer_test.py
@@ -432,9 +432,7 @@ async def test_ambiguous_and_unresolved_calls_recorded_honestly(tmp_path) -> Non
     target_id="" and resolved=False, never invented."""
     (tmp_path / "a_one.py").write_bytes(b"def process() -> None:\n    pass\n")
     (tmp_path / "a_two.py").write_bytes(b"def process() -> None:\n    pass\n")
-    (tmp_path / "b_caller.py").write_bytes(
-        b"def caller() -> None:\n    process()\n    totally_unknown_function()\n"
-    )
+    (tmp_path / "b_caller.py").write_bytes(b"def caller() -> None:\n    process()\n    totally_unknown_function()\n")
     indexer = _make_indexer(tmp_path)
     result = await indexer.index_directory(str(tmp_path))
     assert result.failed == 0

--- a/autobot-backend/services/knowledge/code_indexer_test.py
+++ b/autobot-backend/services/knowledge/code_indexer_test.py
@@ -21,6 +21,7 @@ from services.knowledge.code_indexer import (
     CodeIndexer,
     _make_node_id,
     extract_python,
+    find_callers,
 )
 
 SIMPLE_PYTHON = b"""
@@ -33,10 +34,29 @@ class Greeter:
 """
 
 
-def test_make_node_id_is_stable_and_lowercase() -> None:
-    nid = _make_node_id("MyFunc", "src/auth.py")
-    assert nid == "auth::myfunc"
-    assert nid == _make_node_id("MyFunc", "src/auth.py")
+def _all_upserted(indexer: CodeIndexer) -> list[tuple[str, dict]]:
+    """Flatten every (id, metadata) pair upserted on a MagicMock collection."""
+    pairs: list[tuple[str, dict]] = []
+    for call_args in indexer._collection.upsert.call_args_list:
+        pairs.extend(zip(call_args[1]["ids"], call_args[1]["metadatas"]))
+    return pairs
+
+
+def _find_edge(indexer: CodeIndexer, source_id: str, target_name: str) -> dict | None:
+    for _nid, meta in _all_upserted(indexer):
+        is_match = meta.get("source_id") == source_id and meta.get("target_name") == target_name
+        if meta.get("record_type") == "edge" and is_match:
+            return meta
+    return None
+
+
+def test_make_node_id_is_stable_and_dotted() -> None:
+    """#13470: the canonical identity is the dotted module-path scheme, not the
+    old lowercase '<stem>::<name>' one — that scheme collided whenever two
+    files shared a basename (see autobot_shared/code_graph/identity_test.py)."""
+    nid = _make_node_id("MyFunc", "src.auth")
+    assert nid == "src.auth.MyFunc"
+    assert nid == _make_node_id("MyFunc", "src.auth")
 
 
 @requires_tree_sitter
@@ -304,7 +324,15 @@ async def test_index_code_accepts_project_root_itself(tmp_path) -> None:
 @requires_tree_sitter
 @pytest.mark.asyncio
 async def test_class_method_call_graph(tmp_path) -> None:
-    """Class method node ID uses parent prefix; calls metadata is non-empty (#4908)."""
+    """Class method node id includes the class (#4908); its outgoing call is
+    persisted as a resolved edge document pointing at the sibling method (#13469).
+
+    Regression test for a pre-existing bug this PR fixes as a side effect of
+    the resolver rework: the call-graph pass never tracked class scope, so a
+    method's structural-pass id and its own call-graph scope disagreed and
+    its calls never attached to it at all — this test failed on
+    origin/Dev_new_gui before this PR (`run`'s calls metadata was `''`, see
+    the PR description for the captured before/after run)."""
     src = tmp_path / "mymod.py"
     src.write_bytes(b"""
 class MyClass:
@@ -318,17 +346,15 @@ class MyClass:
     result = await indexer.index_file(str(src), root_dir=str(tmp_path))
     assert result.success > 0
 
-    # Verify method node ID includes class parent prefix
-    upserted_ids = [call_args[1]["ids"][0] for call_args in indexer._collection.upsert.call_args_list]
-    assert "mymod::myclass__run" in upserted_ids, f"Expected 'mymod::myclass__run' in upserted IDs, got: {upserted_ids}"
+    upserted_ids = [nid for nid, _meta in _all_upserted(indexer)]
+    assert "mymod.MyClass.run" in upserted_ids, f"Expected 'mymod.MyClass.run' in upserted IDs, got: {upserted_ids}"
+    assert "mymod.MyClass.helper" in upserted_ids
 
-    # Verify the `calls` metadata on `run` is non-empty
-    run_calls = None
-    for call_args in indexer._collection.upsert.call_args_list:
-        if call_args[1]["ids"][0] == "mymod::myclass__run":
-            run_calls = call_args[1]["metadatas"][0]["calls"]
-            break
-    assert run_calls, f"Expected non-empty 'calls' metadata for mymod::myclass__run, got: {run_calls!r}"
+    edge = _find_edge(indexer, source_id="mymod.MyClass.run", target_name="helper")
+    assert edge is not None, f"Expected an edge run->helper, got ids: {upserted_ids}"
+    assert edge["target_id"] == "mymod.MyClass.helper"
+    assert edge["origin"] == "extracted"
+    assert edge["resolved"] is True
 
 
 @pytest.mark.asyncio
@@ -391,3 +417,133 @@ async def test_index_file_dep_error_counts_as_failed(tmp_path) -> None:
     assert result.success == 0
     assert any("missing dependency" in e for e in result.errors)
     assert any("tree-sitter-python" in e for e in result.errors)
+
+
+# ---------------------------------------------------------------------------
+# Honest provenance — ambiguous and unresolved callees (#13469, #13482 Q2)
+# ---------------------------------------------------------------------------
+
+
+@requires_tree_sitter
+@pytest.mark.asyncio
+async def test_ambiguous_and_unresolved_calls_recorded_honestly(tmp_path) -> None:
+    """A callee matching two candidates is "ambiguous", not silently dropped
+    or mislabelled "extracted"; a callee matching none is "inferred" with
+    target_id="" and resolved=False, never invented."""
+    (tmp_path / "a_one.py").write_bytes(b"def process() -> None:\n    pass\n")
+    (tmp_path / "a_two.py").write_bytes(b"def process() -> None:\n    pass\n")
+    (tmp_path / "b_caller.py").write_bytes(
+        b"def caller() -> None:\n    process()\n    totally_unknown_function()\n"
+    )
+    indexer = _make_indexer(tmp_path)
+    result = await indexer.index_directory(str(tmp_path))
+    assert result.failed == 0
+
+    ambiguous = _find_edge(indexer, source_id="b_caller.caller", target_name="process")
+    assert ambiguous is not None
+    assert ambiguous["origin"] == "ambiguous"
+    assert ambiguous["target_id"] == ""
+    assert ambiguous["resolved"] is False
+    assert ambiguous["candidate_count"] == 2
+
+    unresolved = _find_edge(indexer, source_id="b_caller.caller", target_name="totally_unknown_function")
+    assert unresolved is not None
+    assert unresolved["origin"] == "inferred"
+    assert unresolved["target_id"] == ""
+    assert unresolved["resolved"] is False
+    assert unresolved["candidate_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Traversal — "who calls X" (#13469; the umbrella #13467 says this capability
+# does not exist today because the old `calls` CSV had no readers)
+# ---------------------------------------------------------------------------
+
+
+class _FakeCollection:
+    """Minimal in-memory ChromaDB-collection stand-in with *real* upsert/get(where=)
+    semantics, supporting exactly the query shapes this module issues
+    (plain equality and ``$and``/``$eq``).
+
+    ``autobot-backend/conftest.py`` stubs the real ``chromadb`` package for
+    this entire test suite with a MagicMock (#MVA-1119 — the real client
+    hangs at import time without a local Chroma server), so a test wanting
+    real query *behaviour* rather than a mock that only records calls needs
+    its own minimal implementation. This is not a duplicate ChromaDB client —
+    it implements only the two operations CodeIndexer/find_callers use.
+    """
+
+    def __init__(self) -> None:
+        self._records: dict[str, dict] = {}
+
+    def upsert(self, ids: list[str], embeddings: list, documents: list[str], metadatas: list[dict]) -> None:
+        for nid, meta in zip(ids, metadatas):
+            self._records[nid] = meta
+
+    def get(self, where: dict | None = None, include: list[str] | None = None) -> dict:
+        matched = [meta for meta in self._records.values() if _fake_where_matches(meta, where)]
+        return {"ids": list(self._records.keys()), "metadatas": matched}
+
+
+def _fake_where_matches(meta: dict, where: dict | None) -> bool:
+    if not where:
+        return True
+    if "$and" in where:
+        return all(_fake_where_matches(meta, clause) for clause in where["$and"])
+    return all(meta.get(key) == (val["$eq"] if isinstance(val, dict) else val) for key, val in where.items())
+
+
+@requires_tree_sitter
+@pytest.mark.asyncio
+async def test_find_callers_traversal(tmp_path) -> None:
+    """Given an indexed fixture repo, find_callers() answers "who calls helper"
+    with an exact metadata lookup against the persisted edge documents — the
+    traversal capability #13467 says does not exist today because the old
+    `calls` CSV field had no readers."""
+    collection = _FakeCollection()
+    embed_model = MagicMock()
+    embed_model.get_text_embedding = MagicMock(side_effect=lambda text: [float(len(text) % 7)] * 4)
+    indexer = CodeIndexer(collection=collection, embed_model=embed_model, cache_file=tmp_path / ".cache.json")
+
+    (tmp_path / "helpers.py").write_bytes(b"def helper() -> None:\n    pass\n")
+    (tmp_path / "service_a.py").write_bytes(b"def run_a() -> None:\n    helper()\n")
+    (tmp_path / "service_b.py").write_bytes(b"def run_b() -> None:\n    helper()\n")
+    (tmp_path / "service_c.py").write_bytes(b"def run_c() -> None:\n    pass\n")
+
+    result = await indexer.index_directory(str(tmp_path))
+    assert result.failed == 0
+
+    callers = await find_callers(collection, target_id="helpers.helper")
+    caller_ids = {edge["source_id"] for edge in callers}
+    assert caller_ids == {"service_a.run_a", "service_b.run_b"}
+    assert all(edge["origin"] in ("extracted", "inferred") for edge in callers)
+
+
+@requires_tree_sitter
+@pytest.mark.asyncio
+async def test_known_ids_seeded_across_reindex_runs(tmp_path) -> None:
+    """A second index_directory() run (simulating a later incremental reindex)
+    still resolves a cross-file call even though the callee's file is
+    unchanged and therefore skipped by the hash cache (#13469) — without
+    seeding known ids from the collection, this would regress to "unresolved"
+    every run after the first."""
+    collection = _FakeCollection()
+    embed_model = MagicMock()
+    embed_model.get_text_embedding = MagicMock(side_effect=lambda text: [float(len(text) % 7)] * 4)
+
+    (tmp_path / "helpers.py").write_bytes(b"def helper() -> None:\n    pass\n")
+    (tmp_path / "service_a.py").write_bytes(b"def run_a() -> None:\n    helper()\n")
+
+    first_indexer = CodeIndexer(collection=collection, embed_model=embed_model, cache_file=tmp_path / ".cache.json")
+    await first_indexer.index_directory(str(tmp_path))
+
+    # New file added; helpers.py/service_a.py are unchanged and will be
+    # skipped by the hash cache on this second, independent CodeIndexer run.
+    (tmp_path / "service_c.py").write_bytes(b"def run_c() -> None:\n    helper()\n")
+    second_indexer = CodeIndexer(collection=collection, embed_model=embed_model, cache_file=tmp_path / ".cache.json")
+    result = await second_indexer.index_directory(str(tmp_path))
+    assert result.failed == 0
+
+    callers = await find_callers(collection, target_id="helpers.helper")
+    caller_ids = {edge["source_id"] for edge in callers}
+    assert "service_c.run_c" in caller_ids

--- a/autobot_shared/code_graph/__init__.py
+++ b/autobot_shared/code_graph/__init__.py
@@ -1,0 +1,37 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Canonical code-graph node identity and callee resolver (#13470).
+
+Single-sourced so ``services/knowledge/code_indexer.py`` (#13469) and
+``api/codebase_analytics/endpoints/call_graph.py`` (#713) resolve callees and
+name nodes the same way instead of maintaining incompatible schemes.
+"""
+
+from autobot_shared.code_graph.identity import compute_node_id, module_path_from_rel_path
+from autobot_shared.code_graph.resolver import (
+    COMMON_THIRD_PARTY,
+    INTERNAL_MODULE_PREFIXES,
+    STDLIB_MODULES,
+    ImportContext,
+    ResolvedCall,
+    is_external_module,
+    resolve_call,
+    resolve_callee,
+    resolve_callee_by_suffix,
+)
+
+__all__ = [
+    "compute_node_id",
+    "module_path_from_rel_path",
+    "COMMON_THIRD_PARTY",
+    "INTERNAL_MODULE_PREFIXES",
+    "STDLIB_MODULES",
+    "ImportContext",
+    "ResolvedCall",
+    "is_external_module",
+    "resolve_call",
+    "resolve_callee",
+    "resolve_callee_by_suffix",
+]

--- a/autobot_shared/code_graph/identity.py
+++ b/autobot_shared/code_graph/identity.py
@@ -1,0 +1,52 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Canonical code-graph node identity (#13470).
+
+Two incompatible schemes existed before this module:
+  - ``services/knowledge/code_indexer.py``: ``<file-stem>::<safe_name>`` —
+    collides whenever two files share a basename (``utils.py`` in two
+    packages produce the same id) and drops the directory entirely.
+  - ``api/codebase_analytics/endpoints/call_graph.py``: dotted
+    ``<module_path>.<Class>.<name>`` derived from the file's path relative to
+    the project root — globally unique per file, matches Python's own import
+    naming, and generalises to non-Python sources by dropping the extension.
+
+This module promotes the second scheme to the single canonical one. Callers
+that need a node id from a project-relative source path (not an already
+computed dotted module path) should go through :func:`module_path_from_rel_path`
+first.
+"""
+
+from pathlib import PurePosixPath
+
+
+def module_path_from_rel_path(rel_path: str) -> str:
+    """Convert a project-relative source path into a dotted module path.
+
+    ``"services/knowledge/code_indexer.py"`` -> ``"services.knowledge.code_indexer"``
+    ``"src/components/Foo.vue"`` -> ``"src.components.Foo"``
+
+    Backslashes are normalised to forward slashes first so a path produced on
+    Windows resolves to the same dotted form as one produced on Linux/macOS.
+    """
+    posix_path = PurePosixPath(rel_path.replace("\\", "/"))
+    return posix_path.with_suffix("").as_posix().replace("/", ".")
+
+
+def compute_node_id(name: str, module_path: str, parent_class: str | None = None) -> str:
+    """Compute the canonical id for a function/class/method node.
+
+    Module-level definitions: ``<module_path>.<name>``.
+    Methods:                  ``<module_path>.<parent_class>.<name>``.
+
+    Only one level of class nesting is tracked (matching the AST visitor in
+    ``call_graph.py``, which only ever tracks a single ``current_class``) — a
+    method of a nested class collides with one on the outer class. This is a
+    pre-existing characteristic of the scheme being converged on, not a
+    regression introduced by this module.
+    """
+    if parent_class:
+        return f"{module_path}.{parent_class}.{name}"
+    return f"{module_path}.{name}"

--- a/autobot_shared/code_graph/identity_test.py
+++ b/autobot_shared/code_graph/identity_test.py
@@ -1,0 +1,40 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Unit tests for the canonical code-graph node identity (#13470)."""
+
+from autobot_shared.code_graph.identity import compute_node_id, module_path_from_rel_path
+
+
+def test_module_path_from_rel_path_python() -> None:
+    assert module_path_from_rel_path("services/knowledge/code_indexer.py") == "services.knowledge.code_indexer"
+
+
+def test_module_path_from_rel_path_vue() -> None:
+    assert module_path_from_rel_path("src/components/Foo.vue") == "src.components.Foo"
+
+
+def test_module_path_from_rel_path_normalises_backslashes() -> None:
+    assert module_path_from_rel_path("services\\knowledge\\code_indexer.py") == "services.knowledge.code_indexer"
+
+
+def test_compute_node_id_module_level() -> None:
+    assert compute_node_id("greet", "module") == "module.greet"
+
+
+def test_compute_node_id_method() -> None:
+    assert compute_node_id("run", "module", parent_class="Greeter") == "module.Greeter.run"
+
+
+def test_compute_node_id_is_stable() -> None:
+    first = compute_node_id("run", "pkg.module", parent_class="Greeter")
+    second = compute_node_id("run", "pkg.module", parent_class="Greeter")
+    assert first == second
+
+
+def test_compute_node_id_disambiguates_same_basename_files() -> None:
+    """The stem-only scheme this replaces collided here; the dotted one does not (#13470)."""
+    a = compute_node_id("run", module_path_from_rel_path("pkg_a/utils.py"))
+    b = compute_node_id("run", module_path_from_rel_path("pkg_b/utils.py"))
+    assert a != b

--- a/autobot_shared/code_graph/resolver.py
+++ b/autobot_shared/code_graph/resolver.py
@@ -1,0 +1,341 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Canonical callee resolver (#13470).
+
+Extracted from ``api/codebase_analytics/endpoints/call_graph.py`` (#713),
+which was the more complete of the two call-graph resolvers that existed
+before this module: import-aware, and able to tell an external-library call
+apart from one that genuinely does not resolve. ``call_graph.py`` now imports
+from here instead of keeping its own copy (see that module's ``_resolve_callee_id``
+and ``_resolve_via_import_context``, kept as thin wrappers for backward
+compatibility with existing importers/tests).
+
+``services/knowledge/code_indexer.py`` (#13469) is the second caller and the
+reason this needed to stop being private to one endpoint module. Its
+tree-sitter extraction does not build an import context (that remains future
+work — see the PR description for #13469), so it only ever exercises the
+direct-construction and suffix-scan paths below, never the import-context one.
+
+Provenance (#13482 Q2 — three tiers, no confidence score):
+  - "extracted": the target was found by direct construction — the same
+    module or the current class — which needs no heuristics, it is either a
+    fact about the source file or it isn't.
+  - "inferred":  no direct construction matched, but exactly one candidate
+    elsewhere in the project has a matching trailing name. Includes the
+    zero-candidate case (call exists, nothing matches it — we did not read a
+    resolution from the source either way).
+  - "ambiguous": the trailing-name scan found two or more candidates and
+    picking one would be a guess presented as fact.
+"""
+
+from dataclasses import dataclass
+from typing import Collection
+
+# Standard library modules (used by multiple endpoints/callers).
+STDLIB_MODULES = {
+    "os",
+    "sys",
+    "re",
+    "json",
+    "time",
+    "datetime",
+    "logging",
+    "asyncio",
+    "pathlib",
+    "typing",
+    "collections",
+    "functools",
+    "itertools",
+    "subprocess",
+    "threading",
+    "multiprocessing",
+    "uuid",
+    "hashlib",
+    "base64",
+    "io",
+    "contextlib",
+    "abc",
+    "dataclasses",
+    "enum",
+    "copy",
+    "math",
+    "random",
+    "socket",
+    "http",
+    "urllib",
+    "traceback",
+    "inspect",
+    "ast",
+    "shutil",
+    "tempfile",
+    "warnings",
+    "signal",
+    "argparse",
+    "pickle",
+    "csv",
+    "sqlite3",
+    "email",
+    "html",
+    "xml",
+    "struct",
+    "array",
+    "queue",
+    "heapq",
+    "bisect",
+    "weakref",
+    "types",
+    "operator",
+    "string",
+    "textwrap",
+    "codecs",
+}
+
+# Common third-party packages to exclude from resolution (#713).
+COMMON_THIRD_PARTY = {
+    "fastapi",
+    "pydantic",
+    "redis",
+    "aiofiles",
+    "aiohttp",
+    "requests",
+    "numpy",
+    "pandas",
+    "sqlalchemy",
+    "alembic",
+    "pytest",
+    "httpx",
+    "celery",
+    "chromadb",
+    "openai",
+    "anthropic",
+    "langchain",
+    "torch",
+    "transformers",
+    "PIL",
+    "cv2",
+    "sklearn",
+    "scipy",
+    "matplotlib",
+    "websockets",
+    "uvicorn",
+    "starlette",
+    "jinja2",
+    "click",
+    "rich",
+    "yaml",
+    "toml",
+    "dotenv",
+    "paramiko",
+    "fabric",
+    "boto3",
+    "google",
+    "azure",
+    "docker",
+    "kubernetes",
+    "jwt",
+    "cryptography",
+    "bcrypt",
+}
+
+# O(1) lookup for internal module top-level packages (#326).
+INTERNAL_MODULE_PREFIXES = {
+    "a2a",
+    "agents",
+    "api",
+    "autobot",
+    "autobot_shared",
+    "backend",
+    "cache",
+    "chat_workflow",
+    "config",
+    "constants",
+    "database",
+    "extensions",
+    "initialization",
+    "knowledge",
+    "models",
+    "orchestration",
+    "routers",
+    "security",
+    "services",
+    "src",
+    "utils",
+}
+
+
+def is_external_module(module_name: str) -> bool:
+    """True when *module_name* is stdlib or a known third-party package.
+
+    Unknown top-level packages are assumed external unless they match a
+    known internal prefix (#713).
+    """
+    base = module_name.split(".")[0]
+    if base in STDLIB_MODULES or base in COMMON_THIRD_PARTY:
+        return True
+    if base in INTERNAL_MODULE_PREFIXES:
+        return False
+    return True
+
+
+class ImportContext:
+    """Tracks import statements for one source file for cross-module resolution.
+
+    Extracted from ``call_graph.py`` (#713); behaviour unchanged.
+    """
+
+    def __init__(self) -> None:
+        self.name_to_module: dict[str, str] = {}
+        self.module_to_names: dict[str, list[str]] = {}
+        self.aliases: dict[str, str] = {}
+
+    def add_import(self, module: str, name: str | None = None, alias: str | None = None) -> None:
+        """Register one import statement (``import x`` or ``from x import y``)."""
+        if name:
+            effective_name = alias if alias else name
+            self.name_to_module[effective_name] = f"{module}.{name}"
+            if alias:
+                self.aliases[alias] = name
+        else:
+            effective_name = alias if alias else module.split(".")[-1]
+            self.name_to_module[effective_name] = module
+            if alias:
+                self.aliases[alias] = module
+
+        self.module_to_names.setdefault(module, [])
+        if name and name not in self.module_to_names[module]:
+            self.module_to_names[module].append(name)
+
+    def resolve_name(self, name: str) -> str | None:
+        """Return the full module path a called *name* was imported from, if any."""
+        return self.name_to_module.get(name)
+
+    def is_external(self, name: str) -> bool:
+        """True when *name* was imported from stdlib or a third-party package.
+
+        Deliberately narrower than :func:`is_external_module` — it only ever
+        checks the two explicit sets, never falling back to "assume
+        external" for an unrecognised top-level package, because an unknown
+        import here is far more likely to be an unindexed project module
+        than a genuinely external one. Preserved as-is from ``call_graph.py``
+        (#713); behaviour unchanged by the #13470 extraction.
+        """
+        module_path = self.name_to_module.get(name)
+        if not module_path:
+            return False
+        base_module = module_path.split(".")[0]
+        return base_module in STDLIB_MODULES or base_module in COMMON_THIRD_PARTY
+
+
+def _resolve_via_import_context(
+    callee_name: str,
+    import_context: ImportContext,
+    known_ids: Collection[str],
+) -> tuple[str | None, bool]:
+    """Resolve *callee_name* using the file's own import statements.
+
+    Returns ``(resolved_id, is_external)``; ``is_external=True`` means the
+    call was to an imported stdlib/third-party name, which is a known
+    non-resolution rather than an unresolved one.
+    """
+    imported_path = import_context.resolve_name(callee_name)
+    if not imported_path:
+        return None, False
+    if import_context.is_external(callee_name):
+        return None, True
+    if imported_path in known_ids:
+        return imported_path, False
+    parts = imported_path.split(".")
+    for i in range(len(parts) - 1, 0, -1):
+        candidate = ".".join(parts[:i]) + "." + parts[-1]
+        if candidate in known_ids:
+            return candidate, False
+    return None, False
+
+
+def resolve_callee(
+    callee_name: str,
+    module_path: str,
+    current_class: str | None,
+    known_ids: Collection[str],
+    import_context: ImportContext | None = None,
+) -> tuple[str | None, bool]:
+    """Resolve a callee name to a node id via direct construction or imports.
+
+    Deterministic — either the module-local/class-local candidate id is a
+    member of *known_ids*, or the import context names an already-known id.
+    Never guesses between multiple candidates; that is :func:`resolve_callee_by_suffix`'s
+    job. Returns ``(resolved_id, is_external)``.
+    """
+    possible_id = f"{module_path}.{callee_name}"
+    if possible_id in known_ids:
+        return possible_id, False
+    if current_class:
+        possible_id = f"{module_path}.{current_class}.{callee_name}"
+        if possible_id in known_ids:
+            return possible_id, False
+    if import_context:
+        result = _resolve_via_import_context(callee_name, import_context, known_ids)
+        if result[0] or result[1]:
+            return result
+    return None, False
+
+
+def resolve_callee_by_suffix(callee_name: str, known_ids: Collection[str]) -> tuple[str | None, int]:
+    """Heuristic fallback when direct construction finds nothing.
+
+    Scans *known_ids* for any id whose trailing dotted component equals
+    *callee_name* — the only option when no import context is available to
+    confirm which module a name came from (code_indexer's tree-sitter
+    extraction does not parse imports yet).
+
+    Returns ``(resolved_id, candidate_count)``:
+      - 0 candidates: ``(None, 0)`` — nothing matches.
+      - 1 candidate:  ``(that_id, 1)`` — resolved.
+      - 2+ candidates: ``(None, count)`` — ambiguous, caller must not guess.
+    """
+    matches = [nid for nid in known_ids if nid.rsplit(".", 1)[-1] == callee_name]
+    if len(matches) == 1:
+        return matches[0], 1
+    return None, len(matches)
+
+
+@dataclass(frozen=True)
+class ResolvedCall:
+    """Outcome of resolving one call edge, with honest provenance (#13482 Q2)."""
+
+    target_id: str | None
+    origin: str  # "extracted" | "inferred" | "ambiguous"
+    candidate_count: int
+
+    @property
+    def resolved(self) -> bool:
+        return self.target_id is not None
+
+
+def resolve_call(
+    callee_name: str,
+    module_path: str,
+    current_class: str | None,
+    known_ids: Collection[str],
+    import_context: ImportContext | None = None,
+) -> ResolvedCall:
+    """Resolve one call edge end-to-end, mapping the result onto the three
+    provenance tiers instead of leaving the caller to decide.
+
+    External calls (resolved via ``import_context`` to a stdlib/third-party
+    name) resolve to no target id and are tagged "inferred" — a call exists,
+    but there is no project node it can point at.
+    """
+    direct_id, is_external = resolve_callee(callee_name, module_path, current_class, known_ids, import_context)
+    if direct_id:
+        return ResolvedCall(target_id=direct_id, origin="extracted", candidate_count=1)
+    if is_external:
+        return ResolvedCall(target_id=None, origin="inferred", candidate_count=0)
+    suffix_id, count = resolve_callee_by_suffix(callee_name, known_ids)
+    if count == 1:
+        return ResolvedCall(target_id=suffix_id, origin="inferred", candidate_count=1)
+    if count >= 2:
+        return ResolvedCall(target_id=None, origin="ambiguous", candidate_count=count)
+    return ResolvedCall(target_id=None, origin="inferred", candidate_count=0)

--- a/autobot_shared/code_graph/resolver_test.py
+++ b/autobot_shared/code_graph/resolver_test.py
@@ -1,0 +1,115 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Unit tests for the canonical callee resolver (#13470)."""
+
+from autobot_shared.code_graph.resolver import (
+    ImportContext,
+    is_external_module,
+    resolve_call,
+    resolve_callee,
+    resolve_callee_by_suffix,
+)
+
+
+class TestResolveCallee:
+    def test_module_level_direct_match(self) -> None:
+        known_ids = {"pkg.module.helper", "pkg.module.other"}
+        callee_id, is_external = resolve_callee("helper", "pkg.module", None, known_ids)
+        assert callee_id == "pkg.module.helper"
+        assert is_external is False
+
+    def test_class_method_direct_match(self) -> None:
+        known_ids = {"pkg.module.MyClass.helper"}
+        callee_id, is_external = resolve_callee("helper", "pkg.module", "MyClass", known_ids)
+        assert callee_id == "pkg.module.MyClass.helper"
+        assert is_external is False
+
+    def test_no_match_returns_none(self) -> None:
+        callee_id, is_external = resolve_callee("missing", "pkg.module", None, set())
+        assert callee_id is None
+        assert is_external is False
+
+    def test_import_context_cross_module_resolution(self) -> None:
+        ctx = ImportContext()
+        ctx.add_import(module="pkg.other", name="helper")
+        known_ids = {"pkg.other.helper"}
+        callee_id, is_external = resolve_callee("helper", "pkg.module", None, known_ids, ctx)
+        assert callee_id == "pkg.other.helper"
+        assert is_external is False
+
+    def test_import_context_external_call(self) -> None:
+        ctx = ImportContext()
+        ctx.add_import(module="json")
+        callee_id, is_external = resolve_callee("json", "pkg.module", None, set(), ctx)
+        assert callee_id is None
+        assert is_external is True
+
+
+class TestResolveCalleeBySuffix:
+    def test_zero_candidates(self) -> None:
+        resolved_id, count = resolve_callee_by_suffix("process", set())
+        assert resolved_id is None
+        assert count == 0
+
+    def test_single_candidate(self) -> None:
+        known_ids = {"pkg.a.process", "pkg.a.other"}
+        resolved_id, count = resolve_callee_by_suffix("process", known_ids)
+        assert resolved_id == "pkg.a.process"
+        assert count == 1
+
+    def test_multiple_candidates_are_ambiguous(self) -> None:
+        known_ids = {"pkg.a.process", "pkg.b.process"}
+        resolved_id, count = resolve_callee_by_suffix("process", known_ids)
+        assert resolved_id is None
+        assert count == 2
+
+
+class TestResolveCall:
+    def test_direct_match_is_extracted(self) -> None:
+        known_ids = {"pkg.module.helper"}
+        result = resolve_call("helper", "pkg.module", None, known_ids)
+        assert result.target_id == "pkg.module.helper"
+        assert result.origin == "extracted"
+        assert result.resolved is True
+
+    def test_single_suffix_candidate_is_inferred(self) -> None:
+        known_ids = {"pkg.other.process"}
+        result = resolve_call("process", "pkg.module", None, known_ids)
+        assert result.target_id == "pkg.other.process"
+        assert result.origin == "inferred"
+        assert result.resolved is True
+
+    def test_ambiguous_candidates_are_not_resolved(self) -> None:
+        known_ids = {"pkg.a.process", "pkg.b.process"}
+        result = resolve_call("process", "pkg.module", None, known_ids)
+        assert result.target_id is None
+        assert result.origin == "ambiguous"
+        assert result.candidate_count == 2
+        assert result.resolved is False
+
+    def test_zero_candidates_is_inferred_unresolved(self) -> None:
+        result = resolve_call("nowhere", "pkg.module", None, set())
+        assert result.target_id is None
+        assert result.origin == "inferred"
+        assert result.candidate_count == 0
+        assert result.resolved is False
+
+    def test_external_call_is_inferred_unresolved(self) -> None:
+        ctx = ImportContext()
+        ctx.add_import(module="json")
+        result = resolve_call("json", "pkg.module", None, set(), ctx)
+        assert result.target_id is None
+        assert result.origin == "inferred"
+
+
+class TestIsExternalModule:
+    def test_stdlib_is_external(self) -> None:
+        assert is_external_module("json") is True
+
+    def test_internal_prefix_is_not_external(self) -> None:
+        assert is_external_module("services.knowledge.code_indexer") is False
+
+    def test_unknown_top_level_defaults_external(self) -> None:
+        assert is_external_module("some_unknown_package") is True


### PR DESCRIPTION
## Thinking Path

`code_indexer.py` ran a correct two-pass tree-sitter extraction and then discarded the graph at the point of writing: `"calls": ",".join(calls_by_source.get(...))` stored raw, unresolved `target_name` strings, and every edge was stamped `"origin": "extracted"` as a constant regardless of whether anything was actually resolved. `#13470`'s foundation and `#13469`'s fix are inseparable — resolving against an identity scheme that's about to change is wasted work — so both land in this one PR per the umbrella's explicit instruction.

**Identity scheme (#13470):** two incompatible schemes existed — `code_indexer._make_node_id` (`<stem>::<safe_name>`, collides whenever two files share a basename) and `call_graph._compute_func_identity` (`<module_path>.<Class>.<name>`, globally unique per file). The dotted scheme was already directed as "the richer one" by #13470's own body, so it becomes the single canonical `autobot_shared/code_graph/identity.py::compute_node_id`, and `call_graph.py` now imports it instead of keeping its own copy (verified zero behaviour change against its 27-test suite).

**Resolver (#13470):** `api/codebase_analytics/endpoints/call_graph.py`'s `_resolve_callee_id`/`_resolve_via_import_context` (#713) was already the "good" resolver per the issue — import-aware, external-vs-unresolved discrimination. Extracted (moved, not duplicated) into `autobot_shared/code_graph/resolver.py`, generalised to accept any `Collection[str]` of known ids (call_graph.py's `functions` dict still works unchanged — dict membership is by key). Added a suffix-scan fallback (`resolve_callee_by_suffix`) for callers without an import context — `code_indexer`'s tree-sitter passes don't parse imports (a scoped, explicitly-deferred gap, not fixed here) — with an honest three-way outcome: a single suffix match is `"inferred"`, 2+ matches is `"ambiguous"` (never guessed), 0 matches stays unresolved. This directly implements #13482 Q2 ("keep three tiers, use a resolved/unresolved count, no invented confidence score").

**Storage shape:** Q1 of the decision gate (#13482) forbids touching the memory property graph or building a unified/federated graph, so the memory graph was never a candidate. The umbrella is explicit that this PR is "finishing what exists — no new parser, no fourth store." `code_indexer` already writes to (and, per `api/knowledge_population.py`, *shares*) a ChromaDB collection with `DocIndexerService`. Each resolved edge is now its own document in that same collection (`record_type: "edge"`), scoped by the existing `source: "autobot_code"` field so it never collides with doc chunks (`autobot_documentation`/`autobot_docs`). ChromaDB's `get(where=...)` supports exact-match metadata filters, which is what makes `find_callers()` (the one real consumer this PR lands) a real traversal instead of a client-side scan.

**Discovered bug fixed in-scope:** while rewiring the call-graph pass to carry `current_class` for resolution, I found the call-graph pass never tracked class scope at all (only the structural pass did), so a method's call-graph-computed `source` id never matched its structural-pass node id — no class method's outgoing calls ever attached to it. `test_class_method_call_graph` was **already failing on `origin/Dev_new_gui` before this PR** (confirmed by running the pre-PR file against the same fixture — see Verification). Fixing the scope-tracking mismatch was required to resolve calls correctly at all, so this is fixed here rather than filed separately (CLAUDE.md Rule 6). Same bug existed in the JS/TS structural pass (`class_declaration` never updated `parent_scope`) — fixed for parity.

## What Changed

- **New** `autobot_shared/code_graph/` package (CLAUDE.md Rule 2 — canonical, not a 5th copy):
  - `identity.py` — `compute_node_id()`, `module_path_from_rel_path()`.
  - `resolver.py` — `ImportContext`, `STDLIB_MODULES`, `COMMON_THIRD_PARTY`, `INTERNAL_MODULE_PREFIXES`, `is_external_module()` (moved from `call_graph.py`'s `shared.py`, unchanged behaviour), `resolve_callee()`, `resolve_callee_by_suffix()`, `resolve_call()` + `ResolvedCall` dataclass (the three-tier provenance wrapper).
  - `identity_test.py` / `resolver_test.py` — 23 new unit tests.
- **`api/codebase_analytics/endpoints/shared.py`** — `ImportContext`/`STDLIB_MODULES`/`COMMON_THIRD_PARTY`/`INTERNAL_MODULE_PREFIXES`/`is_external_module` now imported from `autobot_shared.code_graph` and re-exported (existing importers `dependencies.py`, `import_tree.py`, `call_graph_resolution_test.py` unchanged).
- **`api/codebase_analytics/endpoints/call_graph.py`** — `_resolve_callee_id`/`_compute_func_identity` now thin wrappers delegating to the shared resolver/identity; `_resolve_via_import_context` removed (moved, not duplicated). One residual dotted-name check kept in `_resolve_callee_id` for exact behaviour parity even though it's unreachable via the visitor today (`_extract_callee_name` never returns a dotted name) — flagged in a code comment as a real, separately-scoped cleanup, not fixed here.
- **`services/knowledge/code_indexer.py`** — rewritten to:
  - Use the canonical dotted identity (`_make_node_id` is now a thin wrapper).
  - Track `current_class` through both the structural and call-graph passes for every language (the bug fix above).
  - Resolve every call edge via `resolve_call()` against a project-wide `known_ids` registry, lazily seeded from the collection (`_seed_known_ids_from_collection`) so resolution survives hash-cache-skipped incremental reindexes, not just a single `index_directory()` run.
  - Persist resolved edges as their own ChromaDB documents (`record_type: "edge"`) instead of a CSV string on the node; edge documents reuse their source node's already-computed embedding (no extra embedding-model calls).
  - Remove the `calls` CSV metadata field. Grep confirms zero readers before this PR (`grep -rn '"calls"' services/ knowledge/ api/ mcp/` — only the writer and its own test matched; the analytics "calls" hits in `api/analytics.py`/`api/analytics_controller.py`/`services/analytics_service.py` are unrelated API-call-count tracking). Replaced with the edge documents (`record_type=="edge"`), a strict superset of the old field's information.
  - Add `find_callers(collection, target_id)` — the first real consumer.
- All touched functions kept ≤30 lines (several split into helpers to satisfy this).

**Backwards compatibility:** node records written before this PR carry `source: "autobot_code"` and `node_kind` but no `record_type`. `_seed_known_ids_from_collection()` filters on `node_kind` presence (not the new `record_type` field) specifically so it still recognises pre-PR node records when seeding cross-run resolution. No migration or reindex is required for existing collections to keep working; a reindex (already supported via `force=True`) is required to get resolved edges for previously-indexed files, since the old runs never wrote any.

**Converged vs deferred:** converged — `code_indexer.py` and `call_graph.py` on one identity function and one resolver (#13470 steps 1-4, both directions). Deferred, explicitly out of this PR's scope per the issue: `semantic_hasher.py` and `code_analysis/src/` are not migrated onto the shared resolver. Also deferred (new, filed as follow-ups below): import parsing in `code_indexer`'s tree-sitter passes (would upgrade cross-module resolution from suffix-scan/`"inferred"` to import-verified/`"extracted"`), and the dead dotted-name branch in `call_graph.py::_resolve_callee_id`.

## Verification

Repo-wide grep proving zero pre-PR readers of the removed `calls` field:
```
$ grep -rn '"calls"\|'"'"'calls'"'"'' services/ knowledge/ api/ mcp/ --include='*.py' | grep -v _test.py
services/analytics_service.py:548:  "calls": call_count,          # unrelated: API call-count tracking
api/analytics_controller.py:481:    {"endpoint": endpoint, "calls": calls} ...  # unrelated
api/codebase_analytics/endpoints/call_graph.py:227-234  # unrelated: top_callers/top_called stats
api/analytics.py:564-577            # unrelated: hourly API-call stats
```
No hits against `services/knowledge/code_indexer.py`'s own `calls` field outside itself and its test.

Before/after on the same fixture (`test_class_method_call_graph`'s `MyClass.run -> self.helper()`), captured by running the actual `origin/Dev_new_gui` file against the fixture:
```
BEFORE (origin/Dev_new_gui):
  id='mymod::myclass__run'
    metadata={..., 'calls': '', 'origin': 'extracted'}       # bug: never populated for class methods
AFTER (this PR):
  id='mymod.MyClass.run'
    metadata={..., 'origin': 'extracted'}                     # 'calls' field removed
  id='edge::mymod.MyClass.run::helper'
    metadata={'record_type': 'edge', 'source_id': 'mymod.MyClass.run',
              'target_id': 'mymod.MyClass.helper', 'target_name': 'helper',
              'origin': 'extracted', 'resolved': True, 'candidate_count': 1, ...}
```

Resolves-to-a-node-id + ambiguous/unresolved-not-dropped:
```
$ pytest services/knowledge/code_indexer_test.py::test_class_method_call_graph \
         services/knowledge/code_indexer_test.py::test_ambiguous_and_unresolved_calls_recorded_honestly -v
2 passed
```

Traversal ("who calls X" — #13467 says this doesn't exist today):
```
$ pytest services/knowledge/code_indexer_test.py::test_find_callers_traversal \
         services/knowledge/code_indexer_test.py::test_known_ids_seeded_across_reindex_runs -v
2 passed
```

Full suite + sys.modules leak guard (no unlisted new owner; baseline file untouched):
```
$ pytest autobot-backend/services/knowledge/code_indexer_test.py autobot-backend/api/codebase_analytics/ autobot_shared/code_graph/ -q
297 passed, 7 skipped
sys.modules leak guard: 1 known leaking file(s) — all on repo_tests/sys_modules_leak_baseline.txt (autobot-backend/conftest.py, pre-existing) — not a failure
$ git diff --stat repo_tests/sys_modules_leak_baseline.txt
(empty)
```

`call_graph.py`'s existing resolver suite, unchanged behaviour after the extraction:
```
$ pytest api/codebase_analytics/call_graph_resolution_test.py -q
27 passed
```

All test runtimes ≤0.02s (durations captured with `--durations=15`); no test over 10s. Function-length check (`ast`-based, ≤30 lines) passes for every touched function.

Refs #13469, #13470

## Model Used

Sonnet 5