### PR TITLE
fix(code-intelligence): a failed embedding cache write no longer discards the embedding (#13437)

### DIFF
--- a/autobot-backend/code_intelligence/pattern_analysis/analyzer.py
+++ b/autobot-backend/code_intelligence/pattern_analysis/analyzer.py
@@ -560,7 +560,8 @@ class CodePatternAnalyzer:
                     lines = f.readlines()
                     file_count += 1
                     line_count += len(lines)
-            except Exception:  # nosec B110 - file read errors ignored
+            # File read errors are ignored: an unreadable file is skipped, not fatal.
+            except Exception:  # nosec B110
                 logger.debug("Suppressed exception in try block", exc_info=True)
 
         return file_count, line_count
@@ -1015,29 +1016,47 @@ class CodePatternAnalyzer:
             except Exception as e:
                 logger.warning("Embedding cache read failed, generating fresh: %s", e)
 
+            # #13437: generation and the cache write are separately guarded.
+            # They were in one try/except, so a failed cache write discarded a
+            # perfectly good embedding and fell through to the hash fallback —
+            # poisoning code_patterns similarity search with a vector that
+            # encodes nothing about the code. The cache is an optimisation; its
+            # failure must never change the value returned.
+            embedding = None
             try:
                 from services.npu_client import generate_embedding_with_fallback
 
                 embedding = await generate_embedding_with_fallback(code, model_name=EMBEDDING_MODEL)
-                if embedding:
-                    await self._embedding_cache.put(code, embedding, model=EMBEDDING_MODEL)
-                    return embedding
-                logger.warning("Embedding generation returned no vector, using hash fallback")
             except Exception as e:
                 logger.warning("Embedding generation failed, using hash fallback: %s", e)
 
-        # Last-resort fallback: hash-based pseudo-embedding, ONLY reached when
-        # the real embedding infrastructure is genuinely unavailable/failed.
+            if embedding:
+                try:
+                    await self._embedding_cache.put(code, embedding, model=EMBEDDING_MODEL)
+                except Exception as e:
+                    logger.warning("Embedding cache write failed, returning the embedding anyway: %s", e)
+                return embedding
+
+            logger.warning("Embedding generation returned no vector, using hash fallback")
+
+        # Last-resort fallback, ONLY reached when the real embedding
+        # infrastructure is genuinely unavailable or failed.
+        return self._hash_pseudo_embedding(code)
+
+    @staticmethod
+    def _hash_pseudo_embedding(code: str) -> List[float]:
+        """Deterministic stand-in vector derived from ``sha256(code)``.
+
+        Encodes nothing semantic — two functions that do the same thing in
+        different words are as far apart as two unrelated ones. It exists so
+        callers get a well-shaped vector when embedding infrastructure is
+        unavailable, never as a substitute for one (#12407, #13437).
+        """
         import hashlib
 
         hash_bytes = hashlib.sha256(code.encode()).digest()
-        # Convert to list of floats (768 dimensions to match nomic-embed-text)
-        embedding = []
-        for i in range(768):
-            byte_idx = i % 32
-            embedding.append((hash_bytes[byte_idx] - 128) / 128.0)
-
-        return embedding
+        # 768 dimensions to match nomic-embed-text.
+        return [(hash_bytes[i % 32] - 128) / 128.0 for i in range(768)]
 
 
 async def analyze_codebase_patterns(

--- a/autobot-backend/code_intelligence/pattern_analysis/embedding_test.py
+++ b/autobot-backend/code_intelligence/pattern_analysis/embedding_test.py
@@ -190,3 +190,57 @@ class TestGenerateEmbeddingHashFallback:
             result = await analyzer._generate_embedding(code)
 
         assert len(result) == 768
+
+
+class TestCacheWriteFailureDoesNotDiscardTheEmbedding:
+    """#13437: the cache is an optimisation — its failure must not change the result.
+
+    Generation and the cache write shared one ``try/except Exception``, so a
+    failing ``EmbeddingCache.put`` threw away a perfectly good vector and
+    returned the SHA-256 pseudo-embedding instead. Every pattern written while
+    the cache misbehaved was indexed under a vector encoding nothing about the
+    code, silently degrading ``code_patterns`` similarity search.
+
+    This is the third defect of this shape in this one function — #12407 (a
+    nonexistent method swallowed by the same broad except) and #12374 before
+    it. The tests above cover generation; this covers the write.
+    """
+
+    async def test_returns_the_real_embedding_when_the_cache_write_fails(self, pa, analyzer):
+        code = "def cache_write_boom(): return 3"
+        analyzer._embedding_cache.put = AsyncMock(side_effect=RuntimeError("cache down"))
+
+        with patch.object(
+            npu_client_module,
+            "generate_embedding_with_fallback",
+            new=AsyncMock(return_value=FAKE_EMBEDDING),
+        ):
+            result = await analyzer._generate_embedding(code)
+
+        assert result == FAKE_EMBEDDING, "a failed cache write discarded the real embedding"
+        assert len(result) != 768, "fell through to the SHA-256 pseudo-embedding"
+
+    async def test_still_falls_back_when_generation_itself_fails(self, pa, analyzer):
+        """The fallback must remain reachable — this narrows the except, not removes it."""
+        code = "def generation_boom(): return 4"
+
+        with patch.object(
+            npu_client_module,
+            "generate_embedding_with_fallback",
+            new=AsyncMock(side_effect=RuntimeError("npu down")),
+        ):
+            result = await analyzer._generate_embedding(code)
+
+        assert len(result) == 768, "hash fallback should still be used when generation fails"
+
+    async def test_still_falls_back_when_generation_returns_nothing(self, pa, analyzer):
+        code = "def generation_empty(): return 5"
+
+        with patch.object(
+            npu_client_module,
+            "generate_embedding_with_fallback",
+            new=AsyncMock(return_value=None),
+        ):
+            result = await analyzer._generate_embedding(code)
+
+        assert len(result) == 768


### PR DESCRIPTION
Closes #13437

## Thinking Path

`_generate_embedding` wrapped generation **and** the cache write in one `try/except Exception`:

```python
embedding = await generate_embedding_with_fallback(...)
if embedding:
    await self._embedding_cache.put(...)   # same try
    return embedding
```

A failing `EmbeddingCache.put` therefore discarded a perfectly good vector and fell through to the SHA-256 pseudo-embedding. What makes it costly is that it fails *invisibly* — a well-shaped 768-dimension vector still comes back, so nothing errors. Every pattern written while the cache misbehaved was indexed under a vector encoding nothing about the code, quietly degrading `code_patterns` similarity search.

The cache is an optimisation. Its failure must never change the value returned.

**This is the third defect of this shape in this one function.** #12374 and #12407 were both a broad `except` swallowing something and silently substituting the pseudo-embedding. The existing test file was written for #12407 — it covers generation thoroughly and the write not at all, which is exactly the gap this fell through.

## What Changed

| File | Change |
|---|---|
| `pattern_analysis/analyzer.py` | Generation and cache write guarded separately; `_hash_pseudo_embedding` extracted |
| `pattern_analysis/embedding_test.py` | Three tests: cache-write failure, generation failure, generation returning nothing |

A cache-write failure now logs and returns the real embedding. The hash fallback is reached only when generation itself fails or yields nothing — two of the new tests pin that, because this narrows the `except`, it does not remove it.

**Function length.** The change pushed `_generate_embedding` to 43 code lines against the repo's 30-line rule (it was 31 before). Extracting `_hash_pseudo_embedding` brings it to 34, with a 5-line helper — and lets the fallback's docstring say plainly that it encodes nothing semantic, which is the property that makes silently returning it harmful.

## Verification

```
code_intelligence/pattern_analysis/embedding_test.py    10 passed  (was 7)
isort · black · flake8 (0)                              clean
```

**Mutation-checked.** Restoring the combined `try` fails the new test:

```
FAILED ...::TestCacheWriteFailureDoesNotDiscardTheEmbedding::test_returns_the_real_embedding_when_the_cache_write_fails
```

The two fallback tests pass under that mutation as well as after the fix, which is correct — they guard a path the change deliberately preserves.

## Model Used

Claude Opus 5 (1M context)
