### PR TITLE
fix(codebase-analytics): call-graph endpoint scans every file and reports its real scope (#13468)

### DIFF
--- a/autobot-backend/api/codebase_analytics/endpoints/call_graph.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/call_graph.py
@@ -18,9 +18,11 @@ from fastapi.responses import JSONResponse
 
 from autobot_shared.code_graph import compute_node_id, module_path_from_rel_path
 from autobot_shared.code_graph import resolve_callee as _shared_resolve_callee
+from autobot_shared.env_utils import blank_to_none
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_redis_client
+from autobot_shared.ssot_config import config
 from constants.ttl_constants import TTL_5_MINUTES
 from utils.io_executor import get_analytics_executor
 
@@ -31,6 +33,33 @@ logger = get_logger(__name__)
 # Issue #711: Cache configuration for call graph
 CALL_GRAPH_CACHE_PREFIX = "codebase:call_graph:cache"
 CALL_GRAPH_CACHE_TTL = TTL_5_MINUTES
+
+
+def _resolve_call_graph_max_files() -> int | None:
+    """Max files a call-graph scan analyses; ``None`` means unlimited.
+
+    Issue #13468: previously hardcoded to 300 with no comment, no config, and
+    no acknowledgement in the response that the reported statistics covered
+    8% of a 3,541-file backend. Configurable so a deployment that hits real
+    scan latency/memory limits (#12341) can re-cap without a code change --
+    but ``_build_call_graph_response`` reports ``files_scanned``/``files_total``/
+    ``truncated`` regardless, so the numbers are honest either way.
+    """
+    raw = blank_to_none(config.misc.call_graph_max_files)
+    if raw is None:
+        return None
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning("AUTOBOT_CALL_GRAPH_MAX_FILES=%r is not an integer; scanning all files", raw)
+        return None
+    if value <= 0:
+        logger.warning("AUTOBOT_CALL_GRAPH_MAX_FILES=%d must be positive; scanning all files", value)
+        return None
+    return value
+
+
+CALL_GRAPH_MAX_FILES = _resolve_call_graph_max_files()
 
 
 def _get_cache_key(project_root: str) -> str:
@@ -615,8 +644,11 @@ async def _analyze_python_files(
     Issue #13470: module_path now comes from the canonical
     module_path_from_rel_path (identical output for .py files; shared with
     services/knowledge/code_indexer.py).
+    Issue #13468: no longer slices to 300 files internally -- the caller
+    (``get_call_graph``) decides how much of ``python_files`` to pass in, so
+    it can report the true ``files_scanned``/``files_total`` split.
     """
-    for py_file in python_files[:300]:
+    for py_file in python_files:
         try:
             rel_path = str(py_file.relative_to(project_root))
             module_path = module_path_from_rel_path(rel_path)
@@ -650,19 +682,36 @@ def _build_call_graph_response(
     top_callers: List,
     top_called: List,
     external_calls_count: int = 0,
+    files_scanned: int = 0,
+    files_total: int = 0,
 ) -> dict:
     """Build call graph response dictionary.
 
     Issue #665: Extracted from get_call_graph to reduce function length.
     Issue #713: Added external_calls_count to show filtered library calls.
+    Issue #13468: ``summary`` now states ``files_scanned``/``files_total``/
+    ``truncated`` -- every other statistic in ``summary`` describes exactly
+    ``files_scanned`` files, never silently the whole repo. The node/edge/
+    orphan lists are still capped at 500/2000/500 for response size, but that
+    cap is now disclosed via matching ``*_total``/``*_truncated`` fields
+    rather than silently dropping entries.
     """
     resolved_count = len([e for e in unique_edges if e["resolved"]])
     unresolved_count = len([e for e in unique_edges if not e["resolved"]])
 
     return {
         "status": "success",
-        "call_graph": {"nodes": nodes[:500], "edges": unique_edges[:2000]},
+        "call_graph": {
+            "nodes": nodes[:500],
+            "nodes_total": len(nodes),
+            "nodes_truncated": len(nodes) > 500,
+            "edges": unique_edges[:2000],
+            "edges_total": len(unique_edges),
+            "edges_truncated": len(unique_edges) > 2000,
+        },
         "orphaned_functions": orphaned_nodes[:500],
+        "orphaned_functions_total": len(orphaned_nodes),
+        "orphaned_functions_truncated": len(orphaned_nodes) > 500,
         "summary": {
             "total_functions": len(functions),
             "connected_functions": len(nodes),
@@ -675,6 +724,12 @@ def _build_call_graph_response(
             "resolution_rate": round(resolved_count / max(resolved_count + unresolved_count, 1) * 100, 1),
             "top_callers": top_callers,
             "most_called": top_called,
+            # Issue #13468: scope of the statistics above -- files_scanned may
+            # be less than files_total when AUTOBOT_CALL_GRAPH_MAX_FILES caps
+            # the scan; unset (default) scans every file, so truncated is False.
+            "files_scanned": files_scanned,
+            "files_total": files_total,
+            "truncated": files_scanned < files_total,
         },
         "from_cache": False,
     }
@@ -697,6 +752,11 @@ async def get_call_graph(
     Issue #12330: Scope the scan to the requested source's clone path so one
     project cannot see another's call graph. The cache key is derived from the
     resolved root (path-hashed) so each source keeps a distinct cache entry.
+    Issue #13468: scans every file by default (previously hardcoded to the
+    first 300 while reporting summary statistics as if they were repo-wide).
+    Configurable back down via AUTOBOT_CALL_GRAPH_MAX_FILES for a deployment
+    that needs to bound scan cost; either way the response states exactly
+    how many files it covers.
     """
     project_root = await resolve_scan_root(source_id)
 
@@ -707,11 +767,15 @@ async def get_call_graph(
             return JSONResponse(cached_data)
 
     python_files = await _get_python_files(project_root)
+    files_total = len(python_files)
+    scanned_files = python_files if CALL_GRAPH_MAX_FILES is None else python_files[:CALL_GRAPH_MAX_FILES]
+    files_scanned = len(scanned_files)
+
     functions: Dict[str, Dict] = {}
     call_edges: List[Dict] = []
     external_calls: List[Dict] = []  # Issue #713: Track external library calls
 
-    await _analyze_python_files(python_files, project_root, functions, call_edges, external_calls)
+    await _analyze_python_files(scanned_files, project_root, functions, call_edges, external_calls)
 
     nodes = _build_connected_nodes(functions, call_edges)
     orphaned_nodes = _build_orphaned_nodes(functions, call_edges)
@@ -726,6 +790,8 @@ async def get_call_graph(
         top_callers,
         top_called,
         external_calls_count=len(external_calls),  # Issue #713
+        files_scanned=files_scanned,
+        files_total=files_total,
     )
     await _set_cached_call_graph(str(project_root), response_data)
 

--- a/autobot-backend/api/codebase_analytics/endpoints/call_graph_scope_honesty_test.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/call_graph_scope_honesty_test.py
@@ -1,0 +1,160 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Issue #13468: call-graph endpoint must report the scope it actually scanned.
+
+Previously ``_analyze_python_files`` hardcoded ``python_files[:300]`` with no
+comment, no config, and no acknowledgement in the response -- a 3,541-file
+backend was silently sampled at 8% and every ``summary`` statistic
+(``resolution_rate``, ``total_functions``, orphan counts, top callers/callees)
+was reported as if it described the whole codebase.
+
+These tests pin:
+- ``AUTOBOT_CALL_GRAPH_MAX_FILES`` resolution (default unlimited, validated
+  override), mirroring the established ``chat_history/cache_test.py`` pattern
+  for env-var-driven module constants.
+- ``get_call_graph``'s response states ``files_scanned``/``files_total``/
+  ``truncated`` for whatever scope it actually analysed.
+- ``_build_call_graph_response`` discloses truncation of the node/edge/
+  orphan slices (still capped at 500/2000/500 for response size) via
+  matching ``*_total``/``*_truncated`` fields instead of silently dropping
+  entries.
+"""
+
+import importlib
+import json
+import logging
+import os
+from unittest.mock import AsyncMock
+
+import pytest
+
+from autobot_shared.ssot_config import config
+
+
+def _reload_call_graph_with_env(env_value):
+    """Reload call_graph with a given AUTOBOT_CALL_GRAPH_MAX_FILES value (None = unset)."""
+    if env_value is None:
+        os.environ.pop("AUTOBOT_CALL_GRAPH_MAX_FILES", None)
+    else:
+        config.misc.call_graph_max_files = env_value
+    import api.codebase_analytics.endpoints.call_graph as call_graph_mod
+
+    importlib.reload(call_graph_mod)
+    return call_graph_mod
+
+
+@pytest.fixture(autouse=True)
+def _restore_env():
+    saved = config.misc.call_graph_max_files
+    yield
+    if not saved:
+        os.environ.pop("AUTOBOT_CALL_GRAPH_MAX_FILES", None)
+    else:
+        config.misc.call_graph_max_files = saved
+    import api.codebase_analytics.endpoints.call_graph as call_graph_mod
+
+    importlib.reload(call_graph_mod)
+
+
+class TestResolveCallGraphMaxFiles:
+    """Unit tests for the env-var-driven cap resolution."""
+
+    def test_default_is_unlimited(self):
+        mod = _reload_call_graph_with_env(None)
+        assert mod.CALL_GRAPH_MAX_FILES is None
+
+    def test_env_var_override_accepts_positive_int(self):
+        mod = _reload_call_graph_with_env("42")
+        assert mod.CALL_GRAPH_MAX_FILES == 42
+
+    def test_env_var_non_integer_falls_back_to_unlimited_with_warning(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="api.codebase_analytics.endpoints.call_graph"):
+            mod = _reload_call_graph_with_env("not-a-number")
+        assert mod.CALL_GRAPH_MAX_FILES is None
+        assert any("not an integer" in r.getMessage() for r in caplog.records)
+
+    def test_env_var_zero_or_negative_falls_back_to_unlimited_with_warning(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="api.codebase_analytics.endpoints.call_graph"):
+            mod = _reload_call_graph_with_env("0")
+        assert mod.CALL_GRAPH_MAX_FILES is None
+        assert any("must be positive" in r.getMessage() for r in caplog.records)
+
+
+def _write_fixture_tree(root, count: int) -> None:
+    for i in range(count):
+        (root / f"mod_{i}.py").write_text(f"def fn_{i}():\n    return {i}\n", encoding="utf-8")
+
+
+class TestCallGraphResponseScopeHonesty:
+    """End-to-end: the response must state exactly what it scanned."""
+
+    async def test_unlimited_default_scans_every_file(self, tmp_path, monkeypatch):
+        from api.codebase_analytics.endpoints import call_graph, shared
+
+        root = tmp_path / "proj"
+        root.mkdir()
+        _write_fixture_tree(root, 5)
+
+        monkeypatch.setattr(shared, "resolve_source_root", AsyncMock(return_value=root))
+        monkeypatch.setattr(call_graph, "CALL_GRAPH_MAX_FILES", None)
+
+        resp = await call_graph.get_call_graph(refresh=True, source_id="demo")
+        summary = json.loads(resp.body)["summary"]
+
+        assert summary["files_scanned"] == 5
+        assert summary["files_total"] == 5
+        assert summary["truncated"] is False
+
+    async def test_capped_scan_reports_truncation(self, tmp_path, monkeypatch):
+        from api.codebase_analytics.endpoints import call_graph, shared
+
+        root = tmp_path / "proj"
+        root.mkdir()
+        _write_fixture_tree(root, 5)
+
+        monkeypatch.setattr(shared, "resolve_source_root", AsyncMock(return_value=root))
+        monkeypatch.setattr(call_graph, "CALL_GRAPH_MAX_FILES", 2)
+
+        resp = await call_graph.get_call_graph(refresh=True, source_id="demo")
+        summary = json.loads(resp.body)["summary"]
+
+        # Every other summary statistic must describe files_scanned, not files_total.
+        assert summary["files_scanned"] == 2
+        assert summary["files_total"] == 5
+        assert summary["truncated"] is True
+        assert summary["total_functions"] == 2
+
+
+class TestBuildCallGraphResponseSliceHonesty:
+    """Unit tests for the node/edge/orphan slice truncation metadata."""
+
+    def test_small_result_reports_no_slice_truncation(self):
+        from api.codebase_analytics.endpoints.call_graph import _build_call_graph_response
+
+        functions = {"a": {}, "b": {}}
+        nodes = [{"id": "a"}, {"id": "b"}]
+        data = _build_call_graph_response(functions, nodes, [], [], [], [], files_scanned=1, files_total=1)
+
+        assert data["call_graph"]["nodes_total"] == 2
+        assert data["call_graph"]["nodes_truncated"] is False
+        assert data["call_graph"]["edges_truncated"] is False
+        assert data["orphaned_functions_truncated"] is False
+
+    def test_oversized_result_reports_slice_truncation(self):
+        from api.codebase_analytics.endpoints.call_graph import _build_call_graph_response
+
+        nodes = [{"id": str(i)} for i in range(600)]
+        edges = [{"from": "a", "to": "b", "to_name": "b", "resolved": True} for _ in range(2500)]
+        orphans = [{"id": str(i)} for i in range(501)]
+        data = _build_call_graph_response({}, nodes, orphans, edges, [], [], files_scanned=1, files_total=1)
+
+        assert data["call_graph"]["nodes_total"] == 600
+        assert len(data["call_graph"]["nodes"]) == 500
+        assert data["call_graph"]["nodes_truncated"] is True
+        assert data["call_graph"]["edges_total"] == 2500
+        assert len(data["call_graph"]["edges"]) == 2000
+        assert data["call_graph"]["edges_truncated"] is True
+        assert data["orphaned_functions_total"] == 501
+        assert data["orphaned_functions_truncated"] is True

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -20429,6 +20429,11 @@ export interface paths {
          *     Issue #12330: Scope the scan to the requested source's clone path so one
          *     project cannot see another's call graph. The cache key is derived from the
          *     resolved root (path-hashed) so each source keeps a distinct cache entry.
+         *     Issue #13468: scans every file by default (previously hardcoded to the
+         *     first 300 while reporting summary statistics as if they were repo-wide).
+         *     Configurable back down via AUTOBOT_CALL_GRAPH_MAX_FILES for a deployment
+         *     that needs to bound scan cost; either way the response states exactly
+         *     how many files it covers.
          */
         get: operations["get_call_graph_api_analytics_codebase_analytics_call_graph_get"];
         put?: never;

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -1465,6 +1465,17 @@ class MiscConfig(RedactedSettings):
         alias="AUTOBOT_CACHE_L2_TTL",
         description="L2 Redis LLM response cache TTL in seconds",
     )
+    call_graph_max_files: str = Field(
+        default="",
+        alias="AUTOBOT_CALL_GRAPH_MAX_FILES",
+        description=(
+            "Max Python files the call-graph endpoint AST-scans per request. Empty "
+            "(default) means unlimited -- Issue #13468: the previous hardcoded 300-file "
+            "cap silently analysed 8% of a 3,541-file backend and reported the result as "
+            "repo-wide statistics. Set only if a deployment's scan latency/memory forces "
+            "re-capping; the response always states files_scanned/files_total either way."
+        ),
+    )
     celery_dead_letter_max: str = Field(default="", alias="AUTOBOT_CELERY_DEAD_LETTER_MAX")
     celery_dedup_ttl: str = Field(default="", alias="AUTOBOT_CELERY_DEDUP_TTL")
     celery_max_retries: str = Field(default="", alias="AUTOBOT_CELERY_MAX_RETRIES")


### PR DESCRIPTION
## Thinking Path

Read `call_graph.py` first, as directed — #13490 already migrated node identity and callee resolution onto `autobot_shared/code_graph/` (`identity.py`/`resolver.py`) with zero behaviour change, so this PR does not touch either; it only touches the file-selection cap and the response shape.

`git blame`/`git log -p` traced `python_files[:300]` back to the endpoint's original commit (Nov 2025, #267) — a bare `# Analyze files (limit for performance)` comment, no config, no issue reference, never revisited as the repo grew from a few hundred files to 3,541. There is no documented rationale to preserve; it was an unexamined default that outlived the codebase size it was written for.

The issue's own sequencing text says landing this *after* PR #13466 is what "makes lifting the cap affordable" because #13466 "moves whole-tree scans off the API process." I read #13466's diff to confirm that before trusting it: it converts eight scan sites in `api/code_intelligence.py` (`SecurityAnalyzer`, `PerformanceAnalyzer`, `AntiPatternDetector`, `RedisOptimizer`) to run in `code_intelligence/shared/process_offload.py`'s `ProcessPoolExecutor`. **It never touches `codebase_analytics/call_graph.py`.** The sequencing assumption in #13468 does not hold for this endpoint — the AST-parse loop here still runs inline in the request coroutine, one `await aiofiles.open`/`.read()` per file with synchronous `ast.parse`+visit in between. Lifting the cap without offloading this loop makes a cache-miss request materially slower and more CPU-contending than the interim cost the issue text anticipated. I measured the real cost rather than assuming either way (below), and I am not building the offload adaptation here: `call_graph.py`'s functions are plain module-level code over shared mutable dicts, not a `BaseCodeAnalyzer` subclass, so wiring it through `process_offload.py` is a distinct, reviewable piece of work that belongs with #12341 (which this issue explicitly says to coordinate with, not merge into). I filed the gap with hard numbers on #12341 instead of silently accepting the mismatched premise.

## What Changed

**`autobot-backend/api/codebase_analytics/endpoints/call_graph.py`**
- Removed the hardcoded `python_files[:300]` slice from `_analyze_python_files`; the caller now decides scope.
- `get_call_graph` scans every file by default. `AUTOBOT_CALL_GRAPH_MAX_FILES` (new, `autobot_shared/ssot_config.py` `MiscConfig`) can re-cap it for a deployment that needs to bound cost; unset/blank/non-positive/non-integer all resolve to unlimited, with a warning logged for the latter two (mirrors `chat_history/cache.py`'s `_resolve_chat_session_cache_ttl` pattern exactly).
- `_build_call_graph_response` now always reports `summary.files_scanned` / `summary.files_total` / `summary.truncated` — every other `summary` statistic (`resolution_rate`, `total_functions`, orphan counts, `top_callers`/`most_called`) describes exactly `files_scanned` files, never silently the whole repo.
- The response-size caps (500 nodes / 2000 edges / 500 orphans) are unchanged — a full-repo scan can produce ~56k connected nodes — but are now disclosed via `nodes_total`/`nodes_truncated`, `edges_total`/`edges_truncated`, `orphaned_functions_total`/`orphaned_functions_truncated` instead of silently dropping entries past the cap.
- Redis caching (#711) is untouched, as the issue specifies.

**`autobot_shared/ssot_config.py`** — added `MiscConfig.call_graph_max_files` (`AUTOBOT_CALL_GRAPH_MAX_FILES`). `.env.example` is blocked from direct edits by a repo hook ("use SSOT config"); the field's `description=` is the documentation.

**New test**: `call_graph_scope_honesty_test.py` — cap resolution (default/override/invalid/non-positive), end-to-end scope honesty against a fixture tree (unlimited and capped), and unit coverage of the new slice-truncation fields.

## Verification

Real-scale measurement, same scan root, same code path, only `CALL_GRAPH_MAX_FILES` differs (300 = pre-fix hardcoded behaviour, unlimited = post-fix default), against the monorepo dev-checkout fallback root (4,619 Python files — the endpoint's actual default resolution when no source is registered):

```
BEFORE (cap=300, 2.86s):  files_scanned=300/4620  truncated NOT REPORTED (didn't exist)
  resolution_rate=18.2%  total_functions=4404  orphaned_functions=327

AFTER  (cap=None, 43.24s): files_scanned=4620/4620  truncated=False
  resolution_rate=15.3%  total_functions=60656  orphaned_functions=4583
```

Same numbers, isolated to `autobot-backend/` alone (3,548 files, matching the issue's own count): 300-file cap 2.253s / +10MB RSS vs full tree 29.862s / +140MB RSS. The full end-to-end handler call against the monorepo root measured 47.3s wall / +250MB peak RSS.

`resolution_rate` moved 3 points in the *optimistic* direction under the old sample (18.2% vs the honest 15.3%), `total_functions` was undercounted 13.8x, and `orphaned_functions` 14x (327 vs 4,583) — directly bearing on #1611's historical 465-orphan report the issue cites.

```console
$ python3 -m pytest -q autobot-backend/api/codebase_analytics/ autobot_shared/ssot_config_test.py
288 passed, 7 skipped in 16.87s

$ python3 -m pytest -q autobot-backend/api/codebase_analytics/endpoints/call_graph_scope_honesty_test.py
8 passed in 0.69s

$ python3 -m pytest -q autobot-backend/tests/test_startup_imports.py
352 passed in 12.56s

$ python3 -m pytest -q repo_tests/sys_modules_leak_guard_test.py repo_tests/sys_modules_leak_guard_session_test.py autobot-backend/api/codebase_analytics/ autobot_shared/ssot_config_test.py
341 passed, 7 skipped — 1 known leak (autobot-backend/conftest.py, already on
repo_tests/sys_modules_leak_baseline.txt) — no new unlisted owner; baseline file untouched.

$ python3 -m black --check . && python3 -m ruff check . && python3 -m isort --check-only .
clean on all three changed files
```

No test in the new/existing suite exceeds 10s.

## Left out of scope

- **#13476** (orphaned-function detection wiring) — untouched; its output is now correct because this scans everything, but consuming it elsewhere is that issue's job.
- **#12341** (uncached whole-tree rescans / process-offload pattern) — the AST-parse loop here is not yet moved off the event loop. I filed the concrete numbers and the corrected premise (this endpoint was never in #13466's scope) as a comment on #12341, per this issue's own suggested sequence ("lift/config the cap ... -> revisit caching under #12341 with real full-scan numbers").
- Frontend (`FunctionCallGraph.vue`) does not yet surface the new honesty fields in the UI — additive-only response fields, no breaking change to the existing `summary.resolved_calls`/`unresolved_calls`/`top_callers`/`most_called` consumers I found; left as a follow-up since the issue's verification criteria are about the API response, not the UI.

Refs #13468

## Model Used

Sonnet 5