### PR TITLE
feat(knowledge): reverse-BFS impact analysis over the resolved code graph (#13471)

### DIFF
--- a/autobot-backend/services/knowledge/code_indexer.py
+++ b/autobot-backend/services/knowledge/code_indexer.py
@@ -141,6 +141,7 @@ def _record_call_edge(
             "current_class": current_class,
             "kind": "calls",
             "source_path": source_path,
+            "line": node.start_point[0] + 1,  # call site, not the callee's def line (#13471)
         }
     )
 
@@ -592,6 +593,9 @@ def _build_edge_metadata(source_id: str, edge: dict, resolved: ResolvedCall, rel
         "resolved": resolved.resolved,
         "candidate_count": resolved.candidate_count,
         "source_path": rel_path,
+        # #13471: call-site line within source_path, consumed by impact analysis
+        # to report "where do I click" instead of the callee's definition line.
+        "call_line": edge.get("line", 0),
     }
 
 

--- a/autobot-backend/services/knowledge/impact_analysis.py
+++ b/autobot-backend/services/knowledge/impact_analysis.py
@@ -1,0 +1,199 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Reverse-BFS impact analysis over the resolved code graph (#13471).
+
+"What breaks if I change this" — a depth-limited reverse walk of the ``calls``
+edges persisted by ``code_indexer.py`` (#13469): starting from a node id, find
+every node that transitively calls it. ``find_callers()`` (``code_indexer.py``)
+is one hop; this module is the transitive closure on top of it.
+
+Binding decisions this module implements (closed gate #13482):
+  - Q1: code and memory graphs stay separate. This module never touches
+    ``autobot_memory_graph`` — it only reads the ChromaDB collection
+    ``code_indexer`` already writes edge/node documents into.
+  - Q2: coverage is reported as a resolved/unresolved **count**, never an
+    invented confidence score. See ``ImpactResult.resolved_edge_count`` /
+    ``unresolved_edge_count``.
+
+Honesty requirements this module exists to satisfy (#13471):
+  - Ambiguous edges (2+ suffix-match candidates, #13470's
+    ``resolve_callee_by_suffix``) are never silently followed (that would be
+    guessing which candidate the call actually reaches) nor silently dropped
+    (that would under-report impact and look confident doing it) — they are
+    surfaced in ``ImpactResult.skipped_edges`` with the reason.
+  - Cycles are real in call graphs (mutual recursion, etc.) and are handled by
+    never re-expanding an already-visited node — the walk still records the
+    edge that closes the cycle, it just does not loop on it forever.
+  - Depth is bounded (``AUTOBOT_IMPACT_ANALYSIS_MAX_DEPTH``, default below) and
+    the bound is always reported: a capped walk sets ``depth_capped=True`` and
+    lists the un-expanded frontier, so it never reports as if it were
+    complete (the #13468 defect this issue explicitly calls out avoiding).
+"""
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any
+
+from autobot_shared.env_utils import blank_to_none
+from autobot_shared.logging_manager import get_logger
+from autobot_shared.ssot_config import config
+from services.knowledge.code_indexer import find_callers
+
+logger = get_logger(__name__)
+
+# Reverse-BFS hop limit. Not hard-coded per-call — env-overridable via
+# AUTOBOT_IMPACT_ANALYSIS_MAX_DEPTH (see chat_history/cache.py for the same
+# pattern). 6 hops covers realistic caller chains without the walk degrading
+# into a near-repo-wide scan on a densely connected symbol.
+_DEFAULT_MAX_DEPTH = 6
+
+
+def _resolve_max_depth() -> int:
+    """Return the configured reverse-BFS hop limit, falling back safely."""
+    raw = blank_to_none(config.misc.impact_analysis_max_depth)
+    if raw is None:
+        return _DEFAULT_MAX_DEPTH
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning(
+            "AUTOBOT_IMPACT_ANALYSIS_MAX_DEPTH=%r is not an integer; falling back to %d",
+            raw,
+            _DEFAULT_MAX_DEPTH,
+        )
+        return _DEFAULT_MAX_DEPTH
+    if value <= 0:
+        logger.warning(
+            "AUTOBOT_IMPACT_ANALYSIS_MAX_DEPTH=%d must be positive; falling back to %d",
+            value,
+            _DEFAULT_MAX_DEPTH,
+        )
+        return _DEFAULT_MAX_DEPTH
+    return value
+
+
+_MAX_DEPTH = _resolve_max_depth()
+
+
+@dataclass
+class ImpactResult:
+    """Outcome of one reverse-BFS impact walk, honest about its own coverage (#13471).
+
+    ``resolved_edge_count``/``unresolved_edge_count`` are the coverage pair
+    #13482 Q2 requires in place of a confidence score: how many incoming
+    edges were actually traversed versus how many existed but could not be
+    (ambiguous or otherwise unresolved), for every node this walk reached.
+    """
+
+    root_id: str
+    seed_ids: list[str] = field(default_factory=list)
+    reached: list[str] = field(default_factory=list)
+    edges: list[dict[str, Any]] = field(default_factory=list)
+    skipped_edges: list[dict[str, Any]] = field(default_factory=list)
+    max_depth: int = 0
+    depth_reached: int = 0
+    depth_capped: bool = False
+    depth_capped_frontier: list[str] = field(default_factory=list)
+
+    @property
+    def resolved_edge_count(self) -> int:
+        return len(self.edges)
+
+    @property
+    def unresolved_edge_count(self) -> int:
+        return len(self.skipped_edges)
+
+
+async def _find_member_ids(collection: Any, root_id: str) -> list[str]:
+    """Return *root_id*'s own member function/method node ids (#13471).
+
+    Seeding the walk with these as well as *root_id* itself means a caller
+    that binds to ``Class.method`` rather than ``Class`` is still reachable.
+    A member's id is always ``f"{parent_id}.{node_name}"`` by construction
+    (``compute_node_id``), so this needs only the ``node_name`` out of each
+    matching node's metadata — no dependency on the ``ids`` array a
+    ``collection.get(where=...)`` call also returns.
+    """
+    result = await asyncio.to_thread(
+        collection.get,
+        where={"$and": [{"record_type": {"$eq": "node"}}, {"parent": {"$eq": root_id}}]},
+        include=["metadatas"],
+    )
+    metas = result.get("metadatas") or []
+    return [f"{root_id}.{m['node_name']}" for m in metas if m.get("node_name")]
+
+
+async def _find_skipped_edges(collection: Any, node_id: str) -> list[dict[str, Any]]:
+    """Ambiguous/unresolved edges whose raw call name matches *node_id*'s bare name.
+
+    Never followed — resolving one would mean guessing which of several
+    candidates (or, for a zero-candidate edge, which nonexistent one) the
+    call actually reaches — but never dropped either: each is a real call
+    site that might be calling *node_id*, and the graph says so honestly
+    instead of pretending the incoming-edge count is complete (#13471).
+    """
+    bare_name = node_id.rsplit(".", 1)[-1]
+    result = await asyncio.to_thread(
+        collection.get,
+        where={
+            "$and": [
+                {"record_type": {"$eq": "edge"}},
+                {"target_name": {"$eq": bare_name}},
+                {"resolved": {"$eq": False}},
+            ]
+        },
+        include=["metadatas"],
+    )
+    return list(result.get("metadatas") or [])
+
+
+async def _expand_frontier(collection: Any, frontier: list[str], visited: set[str], result: ImpactResult) -> list[str]:
+    """One BFS hop: pull callers of every node in *frontier*.
+
+    Records every traversed edge and every skipped (ambiguous/unresolved)
+    near-miss regardless of whether the caller turns out to be new, so a
+    cycle edge (caller already visited) is still visible in the result even
+    though it does not re-expand the walk.
+    """
+    next_frontier: list[str] = []
+    for node_id in frontier:
+        for edge in await find_callers(collection, node_id):
+            result.edges.append(edge)
+            source_id = edge.get("source_id")
+            if source_id and source_id not in visited:
+                visited.add(source_id)
+                result.reached.append(source_id)
+                next_frontier.append(source_id)
+        result.skipped_edges.extend(await _find_skipped_edges(collection, node_id))
+    return next_frontier
+
+
+async def find_impact(collection: Any, root_id: str, max_depth: int | None = None) -> ImpactResult:
+    """Reverse-BFS from *root_id*: what transitively calls it (#13471).
+
+    Seeds with *root_id* plus its own members, then walks incoming ``calls``
+    edges hop by hop. An already-visited node is never re-expanded, so a
+    cycle (A calls B, B calls A) terminates instead of looping — the edge
+    that closes the cycle is still recorded in ``edges``. Stops when the
+    frontier empties naturally or *max_depth* hops are exhausted; the latter
+    sets ``depth_capped=True`` with the un-expanded frontier so a truncated
+    walk is never mistaken for a complete one.
+    """
+    depth_limit = max_depth if max_depth is not None else _MAX_DEPTH
+    seeds = [root_id] + [m for m in await _find_member_ids(collection, root_id) if m != root_id]
+    result = ImpactResult(root_id=root_id, seed_ids=seeds, max_depth=depth_limit)
+
+    visited = set(seeds)
+    frontier = seeds
+    depth = 0
+    while frontier:
+        if depth >= depth_limit:
+            result.depth_capped = True
+            result.depth_capped_frontier = frontier
+            break
+        frontier = await _expand_frontier(collection, frontier, visited, result)
+        depth += 1
+    result.depth_reached = depth
+    return result

--- a/autobot-backend/services/knowledge/impact_analysis_test.py
+++ b/autobot-backend/services/knowledge/impact_analysis_test.py
@@ -1,0 +1,233 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Unit tests for reverse-BFS impact analysis (#13471).
+
+Every test indexes a small fixture repo with :class:`CodeIndexer` against a
+minimal in-memory ChromaDB-collection stand-in (real ``get(where=...)``
+semantics, not a call-recording mock) so the transitive impact set asserted
+against is the *actual* persisted graph, not a hand-built one — the true
+transitive set is known by construction of each fixture.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+tree_sitter_available = True
+try:
+    import tree_sitter_python  # noqa: F401
+except ImportError:
+    tree_sitter_available = False
+
+requires_tree_sitter = pytest.mark.skipif(not tree_sitter_available, reason="tree-sitter-python not installed")
+
+from services.knowledge.code_indexer import CodeIndexer
+from services.knowledge.impact_analysis import find_impact
+
+
+class _FakeCollection:
+    """Minimal in-memory ChromaDB-collection stand-in with real upsert/get(where=)
+    semantics (equality plus ``$and``/``$eq``) — the same query shapes
+    ``code_indexer``/``impact_analysis`` issue.
+
+    ``autobot-backend/conftest.py`` stubs the real ``chromadb`` package with a
+    MagicMock for the whole suite (#MVA-1119 — the real client hangs at
+    import time without a local server), so a test wanting real query
+    *behaviour* needs its own implementation. Unlike ``code_indexer_test.py``'s
+    ``_FakeCollection``, this one filters ``ids`` by *where* too (matching the
+    real ChromaDB contract) — this module never reads the ``ids`` array, but a
+    stale unfiltered one is a trap for the next reader who does.
+    """
+
+    def __init__(self) -> None:
+        self._records: dict[str, dict] = {}
+
+    def upsert(self, ids: list[str], embeddings: list, documents: list[str], metadatas: list[dict]) -> None:
+        for nid, meta in zip(ids, metadatas):
+            self._records[nid] = meta
+
+    def get(self, where: dict | None = None, include: list[str] | None = None) -> dict:
+        matched = [(nid, meta) for nid, meta in self._records.items() if _fake_where_matches(meta, where)]
+        return {"ids": [nid for nid, _ in matched], "metadatas": [meta for _, meta in matched]}
+
+
+def _fake_where_matches(meta: dict, where: dict | None) -> bool:
+    if not where:
+        return True
+    if "$and" in where:
+        return all(_fake_where_matches(meta, clause) for clause in where["$and"])
+    return all(meta.get(key) == (val["$eq"] if isinstance(val, dict) else val) for key, val in where.items())
+
+
+def _make_indexer(collection: _FakeCollection, tmp_path: Path) -> CodeIndexer:
+    embed_model = MagicMock()
+    embed_model.get_text_embedding = MagicMock(side_effect=lambda text: [float(len(text) % 7)] * 4)
+    return CodeIndexer(collection=collection, embed_model=embed_model, cache_file=tmp_path / ".cache.json")
+
+
+# ---------------------------------------------------------------------------
+# Exact transitive impact set, known by construction of the fixture.
+# ---------------------------------------------------------------------------
+
+
+@requires_tree_sitter
+@pytest.mark.asyncio
+async def test_find_impact_exact_transitive_set(tmp_path) -> None:
+    """a_leaf.target_fn <- b_caller_a.caller_one <- c_caller_b.caller_two <-
+    d_caller_c.caller_three is the only chain in this fixture;
+    e_other.unrelated calls nothing and must not appear.
+
+    Filenames are prefixed a../b../c../d.. so ``CodeIndexer`` (which resolves
+    a call's target against ids known *so far* in its single alphabetical
+    pass — see ``_seed_known_ids_from_collection``) processes each callee's
+    file before the file that calls it; this is the same ordering
+    ``code_indexer_test.py::test_find_callers_traversal`` relies on, not a
+    property of this module.
+    """
+    (tmp_path / "a_leaf.py").write_bytes(b"def target_fn() -> None:\n    pass\n")
+    (tmp_path / "b_caller_a.py").write_bytes(b"def caller_one() -> None:\n    target_fn()\n")
+    (tmp_path / "c_caller_b.py").write_bytes(b"def caller_two() -> None:\n    caller_one()\n")
+    (tmp_path / "d_caller_c.py").write_bytes(b"def caller_three() -> None:\n    caller_two()\n")
+    (tmp_path / "e_other.py").write_bytes(b"def unrelated() -> None:\n    pass\n")
+
+    collection = _FakeCollection()
+    indexer = _make_indexer(collection, tmp_path)
+    result = await indexer.index_directory(str(tmp_path))
+    assert result.failed == 0
+
+    impact = await find_impact(collection, root_id="a_leaf.target_fn", max_depth=5)
+
+    assert set(impact.reached) == {"b_caller_a.caller_one", "c_caller_b.caller_two", "d_caller_c.caller_three"}
+    assert impact.resolved_edge_count == 3
+    assert impact.unresolved_edge_count == 0
+    assert impact.depth_capped is False
+
+
+@requires_tree_sitter
+@pytest.mark.asyncio
+async def test_find_impact_seeds_members_so_method_callers_reachable(tmp_path) -> None:
+    """Asking about the class must still find a caller that only invokes one
+    of its methods (#13471's binding requirement: seed root + members)."""
+    (tmp_path / "a_widget.py").write_bytes(b"class Widget:\n" b"    def render(self) -> None:\n" b"        pass\n")
+    (tmp_path / "b_caller_d.py").write_bytes(b"def caller_four() -> None:\n" b"    w = Widget()\n" b"    w.render()\n")
+
+    collection = _FakeCollection()
+    indexer = _make_indexer(collection, tmp_path)
+    result = await indexer.index_directory(str(tmp_path))
+    assert result.failed == 0
+
+    impact = await find_impact(collection, root_id="a_widget.Widget", max_depth=5)
+
+    assert "b_caller_d.caller_four" in impact.reached
+    assert "a_widget.Widget.render" in impact.seed_ids
+    assert "a_widget.Widget" in impact.seed_ids
+
+
+# ---------------------------------------------------------------------------
+# Cycles — the graph is not a DAG (mutual recursion terminates and reports).
+# ---------------------------------------------------------------------------
+
+
+@requires_tree_sitter
+@pytest.mark.asyncio
+async def test_find_impact_handles_cycles(tmp_path) -> None:
+    """func_a calls func_b and func_b calls func_a. The walk must terminate
+    (the test itself would hang past its timeout otherwise) and must still
+    report the edge that closes the cycle."""
+    (tmp_path / "cyclic.py").write_bytes(
+        b"def func_a() -> None:\n" b"    func_b()\n\n" b"def func_b() -> None:\n" b"    func_a()\n"
+    )
+
+    collection = _FakeCollection()
+    indexer = _make_indexer(collection, tmp_path)
+    result = await indexer.index_directory(str(tmp_path))
+    assert result.failed == 0
+
+    impact = await find_impact(collection, root_id="cyclic.func_a", max_depth=5)
+
+    assert impact.reached == ["cyclic.func_b"]
+    assert impact.depth_capped is False
+    assert impact.resolved_edge_count == 2
+    pairs = {(e["source_id"], e["target_id"]) for e in impact.edges}
+    assert pairs == {("cyclic.func_b", "cyclic.func_a"), ("cyclic.func_a", "cyclic.func_b")}
+
+
+# ---------------------------------------------------------------------------
+# Ambiguous/unresolved edges are reported, never silently followed or dropped.
+# ---------------------------------------------------------------------------
+
+
+@requires_tree_sitter
+@pytest.mark.asyncio
+async def test_find_impact_reports_ambiguous_edge_not_silently_dropped(tmp_path) -> None:
+    """Two functions named ``process`` exist; a caller with no import context
+    calling ``process()`` cannot be resolved to either — it must show up in
+    ``skipped_edges``, not in ``reached`` (not followed) and not vanish
+    (not dropped). Filenames prefixed a../b../c.. so both ``process``
+    definitions are known before ``c_caller_amb.py`` resolves its call —
+    otherwise the ambiguity (2 candidates) would look like a 0-candidate
+    unresolved call instead (see the ordering note on the exact-set test)."""
+    (tmp_path / "a_process_one.py").write_bytes(b"def process() -> None:\n    pass\n")
+    (tmp_path / "b_process_two.py").write_bytes(b"def process() -> None:\n    pass\n")
+    (tmp_path / "c_caller_amb.py").write_bytes(b"def call_process() -> None:\n    process()\n")
+
+    collection = _FakeCollection()
+    indexer = _make_indexer(collection, tmp_path)
+    result = await indexer.index_directory(str(tmp_path))
+    assert result.failed == 0
+
+    impact = await find_impact(collection, root_id="a_process_one.process", max_depth=3)
+
+    assert impact.reached == []
+    assert impact.resolved_edge_count == 0
+    assert impact.unresolved_edge_count == 1
+    skipped = impact.skipped_edges[0]
+    assert skipped["source_id"] == "c_caller_amb.call_process"
+    assert skipped["target_name"] == "process"
+    assert skipped["origin"] == "ambiguous"
+    assert skipped["candidate_count"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Depth cap — a truncated walk must say so, not report as if it were complete.
+# ---------------------------------------------------------------------------
+
+
+@requires_tree_sitter
+@pytest.mark.asyncio
+async def test_find_impact_depth_cap_is_visible(tmp_path) -> None:
+    """A 4-hop chain, walked with max_depth=2, must reach only the first two
+    hops and clearly flag that hops 3-4 were never examined. The same
+    fixture walked without a cap proves hops 3-4 do exist, so the cut is the
+    depth limit, not a fixture-wiring gap. Filenames prefixed a../e.. so each
+    callee's file is indexed before its caller's (see the ordering note on
+    the exact-set test)."""
+    (tmp_path / "a_leaf2.py").write_bytes(b"def target_fn2() -> None:\n    pass\n")
+    (tmp_path / "b_hop1.py").write_bytes(b"def hop_one() -> None:\n    target_fn2()\n")
+    (tmp_path / "c_hop2.py").write_bytes(b"def hop_two() -> None:\n    hop_one()\n")
+    (tmp_path / "d_hop3.py").write_bytes(b"def hop_three() -> None:\n    hop_two()\n")
+    (tmp_path / "e_hop4.py").write_bytes(b"def hop_four() -> None:\n    hop_three()\n")
+
+    collection = _FakeCollection()
+    indexer = _make_indexer(collection, tmp_path)
+    result = await indexer.index_directory(str(tmp_path))
+    assert result.failed == 0
+
+    capped = await find_impact(collection, root_id="a_leaf2.target_fn2", max_depth=2)
+    assert set(capped.reached) == {"b_hop1.hop_one", "c_hop2.hop_two"}
+    assert capped.depth_capped is True
+    assert capped.depth_capped_frontier == ["c_hop2.hop_two"]
+    assert capped.max_depth == 2
+    assert capped.depth_reached == 2
+
+    uncapped = await find_impact(collection, root_id="a_leaf2.target_fn2", max_depth=10)
+    assert set(uncapped.reached) == {
+        "b_hop1.hop_one",
+        "c_hop2.hop_two",
+        "d_hop3.hop_three",
+        "e_hop4.hop_four",
+    }
+    assert uncapped.depth_capped is False

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -1561,6 +1561,14 @@ class MiscConfig(RedactedSettings):
     )
     hnsw_search_ef: str = Field(default="", alias="AUTOBOT_HNSW_SEARCH_EF")
     hnsw_space: str = Field(default="", alias="AUTOBOT_HNSW_SPACE")
+    impact_analysis_max_depth: str = Field(
+        default="",
+        alias="AUTOBOT_IMPACT_ANALYSIS_MAX_DEPTH",
+        description=(
+            "Reverse-BFS hop limit for code-graph impact analysis (#13471). "
+            "A truncated walk reports depth_capped=True rather than silently stopping."
+        ),
+    )
     inference_profiling: str = Field(default="", alias="AUTOBOT_INFERENCE_PROFILING")
     input_timeout: int = Field(default=0, alias="AUTOBOT_INPUT_TIMEOUT")
     internal_api_key: str = Field(default="", alias="AUTOBOT_INTERNAL_API_KEY")


### PR DESCRIPTION
## Thinking Path

#13471 asks for the transitive version of `find_callers()` (#13469, merged as PR #13490): given a symbol, what could a change to it affect. The closed gate #13482 binds two decisions this design has to honor: Q1 — code and memory graphs stay separate (no `autobot_memory_graph` involvement, only the ChromaDB collection `code_indexer` already writes into); Q2 — coverage is a resolved/unresolved **count**, never an invented confidence score.

The graph is incomplete by construction (#13491: no import parsing, so cross-module resolution is suffix-scan-only), so a naive reverse-BFS that just calls `find_callers()` hop by hop and stops at whatever it doesn't find would under-report impact while looking complete — the same defect #13468 targets on the forward side. Three specific honesty requirements drove the design:

- **Ambiguous edges** (2+ suffix-match candidates) must not be silently followed (guessing) or silently dropped (under-reporting). Design: a resolved-only reverse walk via `find_callers()` (exact `target_id` match) for the confirmed edge set, plus a second query per visited node — `record_type=="edge" AND target_name==<bare name> AND resolved==False` — that surfaces every ambiguous/unresolved call whose raw name matches a reached node, without adding it to the confirmed impact set. These land in `ImpactResult.skipped_edges`.
- **Cycles** are real (mutual recursion, etc.). The walk tracks a `visited` set and never re-expands an already-visited node, so a cycle edge is still recorded (it shows up in `edges`) but does not re-queue its source, guaranteeing termination without assuming a DAG.
- **Depth** is bounded by `AUTOBOT_IMPACT_ANALYSIS_MAX_DEPTH` (module-level constant, env-overridable, same pattern as `chat_history/cache.py`'s TTL resolver — never hard-coded). A capped walk sets `depth_capped=True` and lists the un-expanded frontier (`depth_capped_frontier`), so a truncated result can never be mistaken for a complete one.

Member seeding (`find_callers` only knows about exact ids): a caller binding to `Class.method` rather than `Class` needs the walk seeded with the class's own member function/method ids, not just the class id itself — implemented via a `parent==root_id` node-metadata query, reconstructing each member's id as `f"{root_id}.{node_name}"` (no dependency on the `ids` array `collection.get()` returns, since `compute_node_id` guarantees that shape by construction).

One pre-existing gap discovered along the way: `code_indexer.py`'s persisted edges carried no line number at all, only the source file path — so "report the call site" (an explicit proposed-capability line in the issue: "not the callee's own definition line") had no data to draw on. Fixed in-scope (CLAUDE.md Rule 6): `_record_call_edge` now captures the call node's own line, and `_build_edge_metadata` persists it as `call_line`.

## What Changed

- **New** `autobot-backend/services/knowledge/impact_analysis.py`:
  - `find_impact(collection, root_id, max_depth=None) -> ImpactResult` — the reverse-BFS entry point.
  - `ImpactResult` — `root_id`, `seed_ids`, `reached`, `edges` (traversed, resolved), `skipped_edges` (ambiguous/unresolved near-misses, never dropped), `max_depth`, `depth_reached`, `depth_capped`, `depth_capped_frontier`, plus `resolved_edge_count`/`unresolved_edge_count` properties — the coverage pair #13482 Q2 requires instead of a score.
  - `_find_member_ids`, `_find_skipped_edges`, `_expand_frontier` — all `collection.get(where=...)` metadata-only queries, same query shape `find_callers()` already uses.
  - `AUTOBOT_IMPACT_ANALYSIS_MAX_DEPTH` config knob, default 6 hops, resolved once at import into a module-level constant.
- **`autobot_shared/ssot_config.py`** — `MiscConfig.impact_analysis_max_depth` field (`AUTOBOT_IMPACT_ANALYSIS_MAX_DEPTH` alias).
- **`autobot-backend/services/knowledge/code_indexer.py`** — `_record_call_edge` now captures the call site's own line; `_build_edge_metadata` persists it as `call_line` on every edge document. Both functions stay ≤30 lines.
- **New** `autobot-backend/services/knowledge/impact_analysis_test.py` — 5 tests against a real, tree-sitter-extracted fixture repo per test (not hand-built graphs): exact transitive set, member-seeding, cycle termination, ambiguous-edge reporting, depth-cap visibility (capped vs. uncapped on the same fixture).
- Not touched: `api/codebase_analytics/endpoints/call_graph.py` (#13468, parallel work).

## Verification

New tests (skip locally — `tree-sitter-python` isn't installed in this sandbox, same as every pre-existing `@requires_tree_sitter` test in `code_indexer_test.py`; per project policy, optional test deps are never ad-hoc `pip install`ed):
```
$ pytest autobot-backend/services/knowledge/impact_analysis_test.py -v
5 skipped (tree-sitter-python not installed)
```

To get real (non-skipped) execution evidence without installing anything, the same 5 fixtures were run as a temporary pytest module (deleted before this commit — never part of the repo) that hand-builds the exact `{"nodes": [...], "edges": [...]}` shape `extract_python()` produces (verified against `_store_node`/`_record_call_edge`) and feeds it straight into the real, unmodified `CodeIndexer._index_extraction()` and then `find_impact()` — the identical code path the skipped tests exercise, minus only the tree-sitter parse step itself:
```
5 passed in 0.21s
test_scenario_exact_transitive_set: reached=['b_caller_a.caller_one','c_caller_b.caller_two','d_caller_c.caller_three']
test_scenario_members_seeded: reached=['b_caller_d.caller_four'] seed_ids=['a_widget.Widget','a_widget.Widget.render']
test_scenario_cycle: terminated, reached=['cyclic.func_b'], pairs={('cyclic.func_b','cyclic.func_a'),('cyclic.func_a','cyclic.func_b')}
test_scenario_ambiguous_reported: skipped_edges=[{'source_id':'c_caller_amb.call_process','origin':'ambiguous','candidate_count':2,...}]
test_scenario_depth_cap: capped=['b_hop1.hop_one','c_hop2.hop_two'] uncapped=[...all 4 hops...]
```

Existing suites unaffected:
```
$ pytest autobot-backend/services/knowledge/code_indexer_test.py autobot-backend/services/knowledge/impact_analysis_test.py autobot_shared/code_graph/ -v
30 passed, 20 skipped (tree-sitter, pre-existing)

$ pytest autobot-backend/services/knowledge/ autobot_shared/code_graph/ autobot_shared/ssot_config_test.py -q
424 passed, 20 skipped

sys.modules leak guard: 1 known leaking file(s), all on repo_tests/sys_modules_leak_baseline.txt (autobot-backend/conftest.py, pre-existing) — no new unlisted owner
$ git diff --stat repo_tests/sys_modules_leak_baseline.txt
(empty)
```

Function length (ast-based, ≤30 lines) on every touched/new function:
```
$ python3 -c "... ast.walk over impact_analysis.py and code_indexer.py ..."
OK  (max: find_impact 27 lines)
```

All test runtimes ≤1.5s; well under the 10s ceiling.

## Model Used

Sonnet 5