### PR TITLE
fix(approval): interpret an approved command exactly once (#13480)

### DIFF
--- a/autobot-backend/chat_workflow/interpretation_claim_13480_test.py
+++ b/autobot-backend/chat_workflow/interpretation_claim_13480_test.py
@@ -1,0 +1,196 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""An approved command must be interpreted exactly once (#13480).
+
+Two paths interpreted the same result, and **both persist**:
+
+* the approve path — `interpret_terminal_command` (non-streaming) →
+  `_save_to_chat_history`, one `terminal_interpretation` message
+  (`llm_handler.py:1079`, the only occurrence of that type in the codebase);
+* the chat turn — `_handle_approved_command` streams `WorkflowMessage` chunks,
+  and `_build_workflow_message_batch` (`manager.py:3010`) persists **every**
+  message a turn produces.
+
+So an approved command with a watcher cost two LLM calls and put two
+explanations of one command in the conversation.
+
+The fix is a claim the polling turn holds. The dangerous half is releasing it:
+if the claim outlives the poller, the approve path keeps skipping while nobody
+is listening, and a late approval produces no interpretation at all — silently
+re-breaking #13479 in the exact case it exists for. Hence a `finally`, and hence
+the tests below covering timeout, early close and exception, not just the happy
+path.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+def _handler(service):
+    from chat_workflow.tool_handler import ToolHandlerMixin
+
+    class _Handler(ToolHandlerMixin):
+        pass
+
+    h = _Handler()
+    h.terminal_tool = MagicMock()
+    h.terminal_tool.agent_terminal_service = service
+    h.terminal_tool.get_session_info = AsyncMock(return_value=None)
+    return h
+
+
+def _service():
+    service = MagicMock()
+    service.set_live_turn_interpreting = AsyncMock()
+    return service
+
+
+def _claims(service):
+    """(session_id, live) for every claim call, in order."""
+    return [c.args for c in service.set_live_turn_interpreting.call_args_list]
+
+
+# --- the session marker -----------------------------------------------------
+
+
+async def test_an_unmarked_approval_is_interpreted_by_the_approve_path():
+    """The safe default: absent marker means the approve path owns it.
+
+    Believing a turn is present when it has gone is the failure that leaves
+    nobody interpreting, so the default must lean the other way.
+    """
+    from services.agent_terminal.models import AgentTerminalSession
+    from services.command_approval_manager import AgentRole
+
+    s = AgentTerminalSession(session_id="s1", agent_id="a", agent_role=AgentRole.CHAT_AGENT, conversation_id="c1")
+    s.pending_approval = {"command": "ls -la"}
+
+    assert s.has_live_turn_interpreting() is False
+
+
+async def test_marking_a_session_with_no_pending_approval_is_a_no_op():
+    """Creating the dict here would fabricate an approval nobody requested."""
+    from services.agent_terminal.models import AgentTerminalSession
+    from services.command_approval_manager import AgentRole
+
+    s = AgentTerminalSession(session_id="s1", agent_id="a", agent_role=AgentRole.CHAT_AGENT, conversation_id="c1")
+    s.set_live_turn_interpreting(True)
+
+    assert s.pending_approval is None
+    assert s.has_live_turn_interpreting() is False
+
+
+async def test_the_marker_round_trips_on_a_pending_approval():
+    from services.agent_terminal.models import AgentTerminalSession
+    from services.command_approval_manager import AgentRole
+
+    s = AgentTerminalSession(session_id="s1", agent_id="a", agent_role=AgentRole.CHAT_AGENT, conversation_id="c1")
+    s.pending_approval = {"command": "ls -la"}
+
+    s.set_live_turn_interpreting(True)
+    assert s.has_live_turn_interpreting() is True
+    s.set_live_turn_interpreting(False)
+    assert s.has_live_turn_interpreting() is False
+
+
+# --- claim lifecycle around the poller --------------------------------------
+
+
+async def test_the_turn_claims_interpretation_while_polling():
+    service = _service()
+    handler = _handler(service)
+
+    async for _ in handler._poll_for_approval("term-1", "ls -la", max_wait_time=0.02, poll_interval=0.01):
+        pass
+
+    assert ("term-1", True) in _claims(service), "the polling turn never claimed interpretation"
+
+
+async def test_the_claim_is_released_when_the_poll_times_out():
+    """The regression that would silently re-break #13479."""
+    service = _service()
+    handler = _handler(service)
+
+    async for _ in handler._poll_for_approval("term-1", "ls -la", max_wait_time=0.02, poll_interval=0.01):
+        pass
+
+    assert _claims(service)[-1] == ("term-1", False), (
+        "a timed-out poller left its claim set — the approve path would keep "
+        "skipping while nobody is listening, so a late approval produces nothing"
+    )
+
+
+async def test_the_claim_is_released_when_the_consumer_stops_early():
+    """`_handle_pending_approval` breaks out as soon as a decision lands.
+
+    Closing a generator raises GeneratorExit at the suspension point, so only a
+    `finally` releases here — code placed after the loop never runs.
+    """
+    service = _service()
+    handler = _handler(service)
+
+    gen = handler._poll_for_approval("term-1", "ls -la", max_wait_time=5, poll_interval=0.01)
+    await gen.__anext__()
+    await gen.aclose()
+
+    assert _claims(service)[-1] == ("term-1", False), "an early-closed poller leaked its claim"
+
+
+async def test_the_claim_is_released_even_if_claiming_never_worked():
+    """A service without the method must not break the turn or leak state."""
+    service = MagicMock(spec=[])  # no set_live_turn_interpreting
+    handler = _handler(service)
+
+    async for _ in handler._poll_for_approval("term-1", "ls -la", max_wait_time=0.02, poll_interval=0.01):
+        pass  # must simply not raise
+
+
+async def test_a_failing_claim_does_not_fail_the_turn():
+    """Losing the claim costs a duplicate interpretation, not the user's turn."""
+    service = _service()
+    service.set_live_turn_interpreting = AsyncMock(side_effect=RuntimeError("redis down"))
+    handler = _handler(service)
+
+    async for _ in handler._poll_for_approval("term-1", "ls -la", max_wait_time=0.02, poll_interval=0.01):
+        pass  # must not raise
+
+
+# --- the approve path's half ------------------------------------------------
+
+
+async def test_the_approve_path_skips_when_a_turn_holds_the_claim():
+    from services.agent_terminal.service import AgentTerminalService
+
+    svc = AgentTerminalService.__new__(AgentTerminalService)
+    svc.chat_workflow_manager = MagicMock()
+    svc.chat_workflow_manager.interpret_terminal_command = AsyncMock()
+
+    session = MagicMock()
+    session.has_live_turn_interpreting.return_value = True
+
+    await svc._interpret_approved_command(session, "ls -la", {"stdout": "x"})
+
+    svc.chat_workflow_manager.interpret_terminal_command.assert_not_awaited()
+
+
+async def test_the_approve_path_interprets_when_no_turn_holds_the_claim():
+    """The late-approval case — this is what #13479 depends on."""
+    from services.agent_terminal.service import AgentTerminalService
+
+    svc = AgentTerminalService.__new__(AgentTerminalService)
+    svc.chat_workflow_manager = MagicMock()
+    svc.chat_workflow_manager.interpret_terminal_command = AsyncMock()
+
+    session = MagicMock()
+    session.has_live_turn_interpreting.return_value = False
+    session.has_conversation.return_value = True
+    session.conversation_id = "conv-1"
+
+    await svc._interpret_approved_command(session, "ls -la", {"stdout": "x", "return_code": 0})
+
+    svc.chat_workflow_manager.interpret_terminal_command.assert_awaited_once()

--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -1465,25 +1465,55 @@ class ToolHandlerMixin:
         elapsed_time = 0
         poll_count = 0
 
-        while elapsed_time < max_wait_time:
-            await asyncio.sleep(poll_interval)
-            elapsed_time += poll_interval
-            poll_count += 1
+        # #13480: claim interpretation for this turn. The approve path skips its
+        # own interpretation while this is set, so the same command is not
+        # interpreted twice — two LLM calls, two persisted interpretations.
+        await self._claim_interpretation(terminal_session_id, True)
 
-            try:
-                session_info = await self.terminal_tool.get_session_info(terminal_session_id)
-                self._log_polling_status(poll_count, session_info, elapsed_time)
+        try:
+            while elapsed_time < max_wait_time:
+                await asyncio.sleep(poll_interval)
+                elapsed_time += poll_interval
+                poll_count += 1
 
-                result_data, status_msg, should_break = self._check_approval_completion(
-                    session_info, command, elapsed_time, max_wait_time
-                )
-                if should_break:
-                    yield (result_data, status_msg)
-                    return
-            except Exception as check_error:
-                logger.error("Error checking approval status: %s", check_error)
+                try:
+                    session_info = await self.terminal_tool.get_session_info(terminal_session_id)
+                    self._log_polling_status(poll_count, session_info, elapsed_time)
 
-        yield (None, None)
+                    result_data, status_msg, should_break = self._check_approval_completion(
+                        session_info, command, elapsed_time, max_wait_time
+                    )
+                    if should_break:
+                        yield (result_data, status_msg)
+                        return
+                except Exception as check_error:
+                    logger.error("Error checking approval status: %s", check_error)
+
+            yield (None, None)
+        finally:
+            # Load-bearing, and the reason this is a `finally` rather than a line
+            # after the loop: the claim MUST be released on every exit — timeout,
+            # decision, an exception, or the consumer closing this generator
+            # early (GeneratorExit runs finally). A leaked claim means the approve
+            # path keeps skipping while no turn is listening, so a late approval
+            # produces no interpretation at all — silently re-breaking #13479 in
+            # exactly the case it was filed for.
+            await self._claim_interpretation(terminal_session_id, False)
+
+    async def _claim_interpretation(self, terminal_session_id: str, live: bool) -> None:
+        """Mark/unmark this turn as the interpreter for a pending approval (#13480).
+
+        Never raises: failing to claim only costs a duplicate interpretation,
+        and failing to release is already guarded by the approve path treating an
+        absent marker as "interpret". Neither is worth failing the turn over.
+        """
+        service = getattr(self.terminal_tool, "agent_terminal_service", None)
+        if service is None or not hasattr(service, "set_live_turn_interpreting"):
+            return
+        try:
+            await service.set_live_turn_interpreting(terminal_session_id, live)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Could not %s interpretation claim: %s", "set" if live else "release", exc)
 
     async def _handle_pending_approval(
         self,

--- a/autobot-backend/services/agent_terminal/models.py
+++ b/autobot-backend/services/agent_terminal/models.py
@@ -128,6 +128,34 @@ class AgentTerminalSession:
             "agent_role": self.agent_role.value,
         }
 
+    def set_live_turn_interpreting(self, live: bool) -> None:
+        """Record whether a chat turn is polling this approval (#13480).
+
+        Both the approve path and the polling chat turn used to interpret the
+        same command, so an approved command with a watcher cost two LLM calls
+        and persisted two interpretations. This marks which one is present so
+        exactly one of them does it.
+
+        No-op without a pending approval: there is nothing to interpret, and
+        creating the dict here would fabricate an approval that was never
+        requested.
+        """
+        if self.pending_approval is None:
+            return
+        self.pending_approval["live_turn_interpreting"] = bool(live)
+
+    def has_live_turn_interpreting(self) -> bool:
+        """Is a chat turn currently going to interpret this command's result?
+
+        Defaults to False, which is the safe direction: an unmarked approval
+        means the approve path interprets, so a late approval still produces
+        something. The dangerous default is the other one — believing a turn is
+        present when it has gone, which leaves nobody interpreting at all.
+        """
+        if not self.pending_approval:
+            return False
+        return bool(self.pending_approval.get("live_turn_interpreting"))
+
     def has_pending_approval(self) -> bool:
         """Check if session has pending approval (Issue #372)."""
         return self.pending_approval is not None

--- a/autobot-backend/services/agent_terminal/service.py
+++ b/autobot-backend/services/agent_terminal/service.py
@@ -612,7 +612,24 @@ class AgentTerminalService:
         }
 
     async def _interpret_approved_command(self, session: AgentTerminalSession, command: str, result: Metadata) -> None:
-        """Interpret approved command results with workflow manager (Issue #281: extracted)."""
+        """Interpret approved command results with workflow manager (Issue #281: extracted).
+
+        #13480: skipped when a chat turn is still polling this approval — it
+        streams its own interpretation of the same result, and both paths
+        persist, so running both meant two LLM calls and two interpretations of
+        one command in the conversation.
+
+        The skip is deliberately conditional on a marker the poller clears in a
+        `finally`. If the turn has gone, the marker is gone and this runs — which
+        is what makes a late approval produce anything at all (#13479).
+        """
+        if session.has_live_turn_interpreting():
+            logger.info(
+                "[#13480] Skipping approve-path interpretation for %s — a live chat turn owns it",
+                command[:50],
+            )
+            return
+
         if session.has_conversation() and self.chat_workflow_manager:
             try:
                 await self.chat_workflow_manager.interpret_terminal_command(
@@ -828,6 +845,21 @@ class AgentTerminalService:
     # ============================================================================
     # Approval Workflow (delegated to ApprovalHandler)
     # ============================================================================
+
+    async def set_live_turn_interpreting(self, session_id: str, live: bool) -> None:
+        """Register/withdraw a chat turn as the interpreter for a pending approval (#13480).
+
+        Exposed as a service method so the chat turn never reaches into
+        `pending_approval` directly, and so the change is persisted — the approve
+        path may well read the session back from Redis rather than from memory.
+        """
+        session = await self.get_session(session_id)
+        if not session:
+            return
+
+        session.set_live_turn_interpreting(live)
+        if self.redis_client:
+            await self.session_manager._persist_session(session)
 
     async def approve_command(
         self,


### PR DESCRIPTION
## Thinking Path

Last of the #13216 children. I filed this as "exactly-once **execution**"; tracing the code showed execution is already exactly-once — `approve_command` holds a per-session lock and rejects a second approve, and the chat poll path never executes, it only interprets a result the approve path produced. What runs twice is the interpretation, and **both paths persist**:

| path | mode | persisted as |
|---|---|---|
| `interpret_terminal_command` (approve) | non-streaming | `terminal_interpretation` via `_save_to_chat_history` (`llm_handler.py:1079`) |
| `_handle_approved_command` (chat turn) | streaming | every `WorkflowMessage`, via `_build_workflow_message_batch` (`manager.py:3010`) |

So an approved command with someone watching cost two LLM calls and put two explanations of it in the conversation. Retitled the issue to match.

Neither path can simply stop. The approve path must interpret when nothing is listening — that is what makes a late approval produce anything (#13479). The chat turn must interpret when someone *is* watching, or they lose live streaming and wait for a poll. So: **whoever is present owns it**, decided by a claim rather than by timing.

**The dangerous half is the release, not the claim.** If the claim outlives the poller, the approve path keeps skipping while nobody is listening, and a late approval produces no interpretation at all — silently re-breaking #13479 in the exact case it was filed for. That is why the release is a `finally` and why most of the tests are about exits rather than the happy path.

## What Changed

`services/agent_terminal/models.py` — `set_live_turn_interpreting()` / `has_live_turn_interpreting()` on the session. Marking a session with no pending approval is a **no-op**: creating the dict there would fabricate an approval nobody requested. `has_` defaults to **False**, which is the safe direction — an unmarked approval means the approve path interprets, so a late approval still produces something. The dangerous default is the other one.

`services/agent_terminal/service.py`
- `set_live_turn_interpreting(session_id, live)` — a service method so the chat turn never reaches into `pending_approval` directly, and so the change is **persisted**: the approve path may read the session back from Redis rather than from memory.
- `_interpret_approved_command` returns early when a turn holds the claim.

`chat_workflow/tool_handler.py` — `_poll_for_approval` claims on entry and releases in `finally`. `_claim_interpretation` never raises: failing to claim costs a duplicate interpretation, failing to release is already covered by the absent-marker default, and neither is worth failing a user's turn over.

## Verification

```console
$ python3 -m pytest autobot-backend/chat_workflow/ autobot-backend/services/agent_terminal/ \
                    autobot-backend/tests/test_startup_imports.py -q
721 passed
```

Both halves invert-tested, each failing on exactly its own regression:

```console
$ # release moved out of `finally` (leaks the claim on early close)
1 failed, 9 passed
$ # approve path stops checking the claim (the duplicate returns)
1 failed, 9 passed
$ # restored
10 passed
```

The exit paths are covered individually because they fail differently:

- **timeout** — the poll budget runs out with no decision;
- **early close** — `_handle_pending_approval` stops consuming as soon as a decision lands, which raises `GeneratorExit` at the suspension point, so only a `finally` releases; code after the loop never runs;
- **claim unavailable** — a service without the method must not break the turn;
- **claim raises** — a Redis failure must not fail the turn either.

`test_the_approve_path_interprets_when_no_turn_holds_the_claim` is the guard for #13479: it passes in both directions of the invert-test, which is the point of having it.

## Scope

This is the last open child of #13216. With #13481 (a live approval no longer reported as a failed command), #13478 (the 1-hour Redis TTL) and #13479 (traced and closed — the result does arrive, via the 30 s message poller), the umbrella can close once this lands.

Closes #13480
Refs #13216

## Model Used

Opus 5 (1M context)
