### PR TITLE
fix(tests): run the 215 tests under tools/, and make the codemod test collectable (#13368)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,7 @@ jobs:
         # in sys.modules for the rest of the session, breaking the other
         # backend's own tests.
         python -m pytest \
-          autobot-backend autobot_shared autobot-tts-worker repo_tests \
+          autobot-backend autobot_shared autobot-tts-worker repo_tests tools \
           -n auto --dist loadscope \
           --splits 12 --group ${{ matrix.shard }} \
           --durations-path .test_durations \

--- a/pytest.ini
+++ b/pytest.ini
@@ -43,6 +43,12 @@ testpaths =
     autobot-tts-worker
     autobot_shared
     repo_tests
+    # #13368: `tools/` holds 215 passing tests (lint checkers, codemods) that
+    # nothing ran — it was absent here, so CI collected none of them and a
+    # broken one could not be noticed. Its own tests import via the package
+    # path (`tools.lint.*`, `tools.codemods.*`), which resolves because both
+    # `tools/__init__.py` files call pkgutil.extend_path (#13086).
+    tools
 # #7082: dropped `*.e2e_test.py` / `*.integration_test.py` (dotted) — they
 # break pytest's path-to-module conversion. Files renamed to `*_e2e_test.py`
 # / `*_integration_test.py` / `*_performance_test.py` (underscore form),

--- a/tools/codemods/test_parse_api_response_vue_migration.py
+++ b/tools/codemods/test_parse_api_response_vue_migration.py
@@ -11,7 +11,7 @@ files, these tests catch regressions in the transform logic.
 
 import textwrap
 
-from parse_api_response_vue_migration import transform
+from tools.codemods.parse_api_response_vue_migration import transform
 
 
 def _dedent(s: str) -> str:


### PR DESCRIPTION
Closes #13368

## Thinking Path

The issue describes two defects. Only one of them still exists, and finding that out changed what this PR is.

**The `sys.path` precedence bug is already fixed** — by #13349, not by me. It added `pkgutil.extend_path` to `autobot-backend/tools/__init__.py` (citing this exact problem under #13086), so both `tools/` directories now merge into one logical package and `tools.lint` resolves whichever one Python binds first. I had already written and tested the precedence hardening when my own regression test passed against the *unfixed* runner — which made no sense until I re-measured and found the ground had moved. **I reverted it rather than ship a fix for a defect that no longer reproduces.**

**The codemod test is still uncollectable**, and underneath it sat something larger: `tools/` was in neither `pytest.ini`'s `testpaths` nor CI's invocation. **215 tests ran nowhere.** Not failing — absent.

## What Changed

| File | Change |
|---|---|
| `pytest.ini` | `tools` added to `testpaths`, with a comment recording why |
| `.github/workflows/ci.yml` | `tools` added to the backend pytest invocation |
| `tools/codemods/test_parse_api_response_vue_migration.py` | bare sibling import → package path |

`--import-mode=importlib` (which `pytest.ini` sets) does not put a test's own directory on `sys.path`, so `from parse_api_response_vue_migration import transform` could never resolve. The package path is how `repo_tests` already reaches `tools.lint.*`.

That test's docstring says it exists to catch regressions "if this codemod is ever rerun on a new batch of files" — the intent was live even though the test was not.

## Verification

```
tools/                                                         215 passed
tools/ + repo_tests                                            468 passed
autobot_shared + autobot-tts-worker + repo_tests + tools      1939 passed
```

The last run excludes `autobot_shared/auth/test_slm_permission_parity.py`, which fails collection with a SQLAlchemy metaclass `TypeError` on this box. **Confirmed pre-existing:** the identical error occurs on base with the identical command *without* `tools/`. It is a Python-3.10-only artifact of the locally installed SQLAlchemy; CI runs 3.14.

## Model Used

Claude Opus 5 (1M context)
