### PR TITLE
fix(deploy): give ai-stack, npu-worker, frontend and browser a delivery path (#13460)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
+++ b/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
@@ -1468,6 +1468,54 @@
         - tts_stream_route.rc | default(1) == 0
       tags: [tts, verify]
 
+    # =========================================================================
+    # #13460: the last four components whose role-owned files the updater could
+    # not deliver. Each applies its role's code_only task file — the service
+    # units, worker code and configs that carry changes — never the full role,
+    # whose provisioning half (apt, venv, OpenVINO, Playwright downloads, npm)
+    # must not re-run on an already-installed box.
+    #
+    # `apply: {become: true}` on every one: this play sets no play-level become,
+    # and a bare `become` on include_role makes ansible reject the WHOLE playbook
+    # ("'become' is not a valid attribute for a IncludeRole"), breaking every
+    # self-update rather than just the task (#12886).
+    # =========================================================================
+    - name: "[PLAY 2] AI Stack | Deploy role-owned service files (#13460)"
+      ansible.builtin.include_role:
+        name: ai-stack
+        tasks_from: code_only
+        apply:
+          become: true
+      when: "'aiml' in group_names"
+      tags: [ai-stack, deploy]
+
+    - name: "[PLAY 2] NPU | Deploy role-owned service files (#13460)"
+      ansible.builtin.include_role:
+        name: npu-worker
+        tasks_from: code_only
+        apply:
+          become: true
+      when: "'npu' in group_names"
+      tags: [npu, npu-worker, deploy]
+
+    - name: "[PLAY 2] Frontend | Deploy role-owned nginx config (#13460)"
+      ansible.builtin.include_role:
+        name: frontend
+        tasks_from: code_only
+        apply:
+          become: true
+      when: "'frontend' in group_names"
+      tags: [frontend, nginx, deploy]
+
+    - name: "[PLAY 2] Browser | Deploy role-owned service files (#13460)"
+      ansible.builtin.include_role:
+        name: browser
+        tasks_from: code_only
+        apply:
+          become: true
+      when: "'browser' in group_names"
+      tags: [browser, deploy]
+
     - name: "[PLAY 2] Node Update Complete"
       debug:
         msg: "{{ inventory_hostname }} updated"

--- a/autobot-slm-backend/ansible/roles/ai-stack/tasks/code_only.yml
+++ b/autobot-slm-backend/ansible/roles/ai-stack/tasks/code_only.yml
@@ -1,0 +1,46 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+---
+# The service files that carry code changes: the ChromaDB and AI Stack systemd
+# units. Split out of main.yml (#13460) so the builtin updater can deliver unit
+# changes without re-running provisioning (venv, model downloads, pip installs).
+#
+# The chroma token read is part of this file, not an optional extra. The unit
+# template emits CHROMA_SERVER_AUTHN_* only when `chromadb_auth_token` is
+# non-empty, and its role default is "". Rendering the unit on the update path
+# without reading the SLM-managed token would redeploy chroma with authentication
+# SILENTLY DISABLED — undoing #12513 on every update, with nothing failing.
+#
+# Handlers (`reload systemd`, `restart chromadb`, `restart ai-stack`) live in the
+# role, so this file is only usable via include_role/import_role.
+
+- name: "ChromaDB | Read the shared auth token from slm-secrets.env (#12513)"
+  ansible.builtin.include_tasks: ../../../_shared/tasks/read_chromadb_auth_token.yml
+  tags: ['ai', 'deploy']
+
+- name: "ChromaDB | Adopt the SLM-managed auth token when present (#12513)"
+  ansible.builtin.set_fact:
+    chromadb_auth_token: "{{ _chromadb_auth_token_read }}"
+  when: (_chromadb_auth_token_read | default('') | trim) | length > 0
+  no_log: true
+  tags: ['ai', 'deploy']
+
+- name: Deploy ChromaDB systemd service
+  ansible.builtin.template:
+    src: autobot-chromadb.service.j2
+    dest: /etc/systemd/system/autobot-chromadb.service
+    mode: "0644"
+  notify:
+    - reload systemd
+    - restart chromadb
+
+- name: Deploy AI Stack API systemd service
+  ansible.builtin.template:
+    src: autobot-ai-stack.service.j2
+    dest: /etc/systemd/system/autobot-ai-stack.service
+    mode: "0644"
+  notify:
+    - reload systemd
+    - restart ai-stack

--- a/autobot-slm-backend/ansible/roles/ai-stack/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/ai-stack/tasks/main.yml
@@ -232,34 +232,13 @@
 # #12513: see roles/redis/tasks/chromadb.yml — same read, same reason. Whichever
 # of the two roles owns chroma on this topology must land the same credential the
 # backend sends, so both defer to the SLM-generated value.
-- name: "ChromaDB | Read the shared auth token from slm-secrets.env (#12513)"
-  ansible.builtin.include_tasks: ../../../_shared/tasks/read_chromadb_auth_token.yml
+# #13460: these service files are defined once, in code_only.yml, so the
+# builtin updater can deliver them without re-running provisioning. Copying
+# them into the playbook instead is the inline-vs-role duplication that made
+# this role undeliverable in the first place (#12959).
+- name: "AI Stack | Deploy service files"
+  ansible.builtin.include_tasks: code_only.yml
   tags: ['ai', 'deploy']
-
-- name: "ChromaDB | Adopt the SLM-managed auth token when present (#12513)"
-  ansible.builtin.set_fact:
-    chromadb_auth_token: "{{ _chromadb_auth_token_read }}"
-  when: (_chromadb_auth_token_read | default('') | trim) | length > 0
-  no_log: true
-  tags: ['ai', 'deploy']
-
-- name: Deploy ChromaDB systemd service
-  ansible.builtin.template:
-    src: autobot-chromadb.service.j2
-    dest: /etc/systemd/system/autobot-chromadb.service
-    mode: "0644"
-  notify:
-    - reload systemd
-    - restart chromadb
-
-- name: Deploy AI Stack API systemd service
-  ansible.builtin.template:
-    src: autobot-ai-stack.service.j2
-    dest: /etc/systemd/system/autobot-ai-stack.service
-    mode: "0644"
-  notify:
-    - reload systemd
-    - restart ai-stack
 
 - name: Enable and start ChromaDB service
   ansible.builtin.systemd:

--- a/autobot-slm-backend/ansible/roles/browser/tasks/code_only.yml
+++ b/autobot-slm-backend/ansible/roles/browser/tasks/code_only.yml
@@ -1,0 +1,49 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+---
+# The service files that carry code changes: the worker env and the VNC /
+# Playwright systemd units. Split out of main.yml (#13460) so the builtin updater
+# can deliver unit changes without re-running provisioning (apt, Playwright
+# browser downloads, VNC password setup).
+#
+# The VNC tasks keep their original `install_vnc` / `node_roles` guards: a node
+# that does not run VNC must not acquire a VNC unit just because it was updated.
+#
+# Handlers (`reload systemd`, `restart vnc`, `restart playwright`) live in the
+# role, so this file is only usable via include_role/import_role.
+
+- name: "Browser | Deploy /etc/autobot/autobot-browser-worker.env"
+  ansible.builtin.template:
+    src: autobot-browser-worker.env.j2
+    dest: /etc/autobot/autobot-browser-worker.env
+    mode: "0640"
+    owner: root
+    group: "{{ browser_group }}"
+  tags: ['browser', 'config']
+
+- name: "Browser | Create VNC systemd service"
+  ansible.builtin.template:
+    src: vnc.service.j2
+    dest: /etc/systemd/system/autobot-vnc.service
+    mode: '0644'
+  become: true
+  when:
+    - install_vnc | default(false)
+    - node_roles is not defined or 'vnc' in node_roles
+  notify:
+    - reload systemd
+    - restart vnc
+  tags: ['browser', 'systemd', 'vnc']
+
+- name: "Browser | Create Playwright systemd service"
+  ansible.builtin.template:
+    src: playwright.service.j2
+    dest: /etc/systemd/system/autobot-playwright.service
+    mode: '0644'
+  become: true
+  notify:
+    - reload systemd
+    - restart playwright
+  tags: ['browser', 'systemd']

--- a/autobot-slm-backend/ansible/roles/browser/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/browser/tasks/main.yml
@@ -43,14 +43,9 @@
     group: root
   tags: ['browser', 'config']
 
-- name: "Browser | Deploy /etc/autobot/autobot-browser-worker.env"
-  ansible.builtin.template:
-    src: autobot-browser-worker.env.j2
-    dest: /etc/autobot/autobot-browser-worker.env
-    mode: "0640"
-    owner: root
-    group: "{{ browser_group }}"
-  tags: ['browser', 'config']
+# #13460: this env file is now defined once, in code_only.yml, alongside the
+# playwright unit that consumes it via EnvironmentFile= — so the updater delivers
+# both together. Nothing between here and that include reads the file.
 
 # ============================================================
 # Sync browser worker code from code_source
@@ -278,29 +273,12 @@
     - browser_vnc_password.stdout | default('') | length > 0
   tags: ['browser', 'vnc']
 
-- name: "Browser | Create VNC systemd service"
-  template:
-    src: vnc.service.j2
-    dest: /etc/systemd/system/autobot-vnc.service
-    mode: '0644'
-  become: true
-  when:
-    - install_vnc | default(false)
-    - node_roles is not defined or 'vnc' in node_roles
-  notify:
-    - reload systemd
-    - restart vnc
-  tags: ['browser', 'systemd', 'vnc']
-
-- name: "Browser | Create Playwright systemd service"
-  template:
-    src: playwright.service.j2
-    dest: /etc/systemd/system/autobot-playwright.service
-    mode: '0644'
-  become: true
-  notify:
-    - reload systemd
-    - restart playwright
+# #13460: these service files are defined once, in code_only.yml, so the
+# builtin updater can deliver them without re-running provisioning. Copying
+# them into the playbook instead is the inline-vs-role duplication that made
+# this role undeliverable in the first place (#12959).
+- name: "Browser | Deploy service units"
+  ansible.builtin.include_tasks: code_only.yml
   tags: ['browser', 'systemd']
 
 - name: "Browser | Configure firewall - Allow VNC"

--- a/autobot-slm-backend/ansible/roles/frontend/tasks/code_only.yml
+++ b/autobot-slm-backend/ansible/roles/frontend/tasks/code_only.yml
@@ -1,0 +1,31 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+---
+# The config that carries changes on an update: the nginx site. Split out of
+# main.yml (#13460) so the builtin updater can deliver nginx-config changes
+# without re-running provisioning (node install, npm ci, vite build).
+#
+# Deliberately NOT the frontend build. update-all-nodes.yml already deploys
+# frontend code and rebuilds it inline; adding a second build here would run it
+# twice per update.
+#
+# The co-location guard is preserved: when the frontend shares a host with the
+# SLM, SLM nginx serves both and this site must not be written (#2829).
+#
+# Handlers (`test nginx config`, `restart nginx`) live in the role, so this file
+# is only usable via include_role/import_role.
+
+- name: "Frontend | Configure nginx"
+  ansible.builtin.template:
+    src: nginx-frontend.conf.j2
+    dest: /etc/nginx/sites-available/autobot-frontend
+    mode: '0644'
+    backup: true
+  become: true
+  notify:
+    - test nginx config
+    - restart nginx
+  when: not (slm_colocated_frontend | default(false) | bool)
+  tags: ['frontend', 'nginx']

--- a/autobot-slm-backend/ansible/roles/frontend/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/frontend/tasks/main.yml
@@ -257,17 +257,12 @@
   tags: ['frontend', 'nginx']
 
 # Skip nginx config when co-located with SLM — SLM nginx handles both (#2829)
-- name: "Frontend | Configure nginx"
-  template:
-    src: nginx-frontend.conf.j2
-    dest: /etc/nginx/sites-available/autobot-frontend
-    mode: '0644'
-    backup: true
-  become: true
-  notify:
-    - test nginx config
-    - restart nginx
-  when: not (slm_colocated_frontend | default(false) | bool)
+# #13460: these service files are defined once, in code_only.yml, so the
+# builtin updater can deliver them without re-running provisioning. Copying
+# them into the playbook instead is the inline-vs-role duplication that made
+# this role undeliverable in the first place (#12959).
+- name: "Frontend | Deploy nginx config"
+  ansible.builtin.include_tasks: code_only.yml
   tags: ['frontend', 'nginx']
 
 - name: "Frontend | Enable nginx site"

--- a/autobot-slm-backend/ansible/roles/npu-worker/tasks/code_only.yml
+++ b/autobot-slm-backend/ansible/roles/npu-worker/tasks/code_only.yml
@@ -1,0 +1,48 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+---
+# The service files that carry code changes: the worker script, its .env and its
+# systemd unit. Split out of main.yml (#13460) so the builtin updater can refresh
+# a deployed NPU worker without re-running provisioning.
+#
+# npu-worker.py.j2 is *worker code* rendered from a template — the same shape as
+# the TTS worker that served four-day-old code in #12886, and the reason this
+# role was the sharpest case in #13460.
+#
+# Everything main.yml does around these — the service account, the venv, the
+# OpenVINO install — is provisioning: slow, network-dependent, and able to break
+# a box that is already correctly installed. main.yml includes this file rather
+# than repeating it, so there is exactly one definition of "deploy the NPU
+# service files".
+#
+# Handlers (`restart npu-worker`, `reload systemd`) live in the role, so this
+# file is only usable via include_role/import_role — which is intended.
+
+- name: Deploy NPU worker script
+  ansible.builtin.template:
+    src: npu-worker.py.j2
+    dest: "{{ npu_install_dir }}/npu-worker.py"
+    mode: "0755"
+    owner: "{{ npu_user }}"
+    group: "{{ npu_group }}"
+  notify: restart npu-worker
+
+- name: Deploy NPU worker configuration
+  ansible.builtin.template:
+    src: npu-worker.env.j2
+    dest: "{{ npu_install_dir }}/.env"
+    mode: "0600"
+    owner: "{{ npu_user }}"
+    group: "{{ npu_group }}"
+  notify: restart npu-worker
+
+- name: Deploy NPU worker systemd service
+  ansible.builtin.template:
+    src: autobot-npu-worker.service.j2
+    dest: /etc/systemd/system/autobot-npu-worker.service
+    mode: "0644"
+  notify:
+    - reload systemd
+    - restart npu-worker

--- a/autobot-slm-backend/ansible/roles/npu-worker/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/npu-worker/tasks/main.yml
@@ -217,32 +217,12 @@
     - npu_install_openvino | default(true)
     - _openvino_check.rc != 0
 
-- name: Deploy NPU worker script
-  ansible.builtin.template:
-    src: npu-worker.py.j2
-    dest: "{{ npu_install_dir }}/npu-worker.py"
-    mode: "0755"
-    owner: "{{ npu_user }}"
-    group: "{{ npu_group }}"
-  notify: restart npu-worker
-
-- name: Deploy NPU worker configuration
-  ansible.builtin.template:
-    src: npu-worker.env.j2
-    dest: "{{ npu_install_dir }}/.env"
-    mode: "0600"
-    owner: "{{ npu_user }}"
-    group: "{{ npu_group }}"
-  notify: restart npu-worker
-
-- name: Deploy NPU worker systemd service
-  ansible.builtin.template:
-    src: autobot-npu-worker.service.j2
-    dest: /etc/systemd/system/autobot-npu-worker.service
-    mode: "0644"
-  notify:
-    - reload systemd
-    - restart npu-worker
+# #13460: these service files are defined once, in code_only.yml, so the
+# builtin updater can deliver them without re-running provisioning. Copying
+# them into the playbook instead is the inline-vs-role duplication that made
+# this role undeliverable in the first place (#12959).
+- name: "NPU Worker | Deploy service files"
+  ansible.builtin.include_tasks: code_only.yml
 
 - name: Check if UFW is installed
   ansible.builtin.command: which ufw

--- a/autobot-slm-backend/tests/test_chromadb_auth_token_provisioned_12513.py
+++ b/autobot-slm-backend/tests/test_chromadb_auth_token_provisioned_12513.py
@@ -40,7 +40,11 @@ _TOKEN_KEY = "AUTOBOT_CHROMADB_AUTH_TOKEN"
 _CONSUMERS = {
     "backend": ("tasks/main.yml", "backend_chromadb_auth_token"),
     "redis": ("tasks/chromadb.yml", "chromadb_auth_token"),
-    "ai-stack": ("tasks/main.yml", "chromadb_auth_token"),
+    # #13460 moved ai-stack's read into code_only.yml, alongside the chroma unit
+    # it feeds, so the builtin updater delivers both together. Rendering that
+    # unit without the read would redeploy chroma with auth SILENTLY DISABLED —
+    # which is precisely why this test follows the read rather than the file.
+    "ai-stack": ("tasks/code_only.yml", "chromadb_auth_token"),
 }
 
 

--- a/autobot-slm-backend/tests/test_update_all_applies_roles_12959.py
+++ b/autobot-slm-backend/tests/test_update_all_applies_roles_12959.py
@@ -28,12 +28,15 @@ that every role owning deployed artifacts exposes a code/config-only task file
 (`env_only`, `unit_only`, `code_only`, `credentials_reconcile`) which the updater
 applies, and which contains no provisioning. One implementation, two callers.
 
-`test_every_managed_component_has_an_application_path` stays
-``xfail(strict=True)`` while four components still have none: it keeps the suite
-green, and the moment the gap closes it XPASSes — which strict xfail reports as a
-FAILURE, forcing whoever fixed it to delete the marker. A baseline would instead
-quietly absorb the fix and keep claiming the problem is still there (the #12894
-lesson).
+`test_every_managed_component_has_an_application_path` was
+``xfail(strict=True)`` while four components had none. #13460 closed that gap and
+the test XPASSed — which strict xfail reports as a FAILURE, forcing the marker's
+removal. That is exactly what the marker was for, and why it was never replaced
+with a baseline: a baseline would have quietly absorbed the fix and kept claiming
+the problem was still there (the #12894 lesson).
+
+Every managed component now has a delivery path, so this asserts a property that
+holds rather than one that is aspirational.
 """
 
 import pathlib
@@ -65,6 +68,10 @@ DELIVERED = {
     "backend": {"env_only", "unit_only"},  # #12871, #12777
     "tts-worker": {"code_only"},  # #12886
     "postgresql": {"credentials_reconcile"},  # #12907
+    "ai-stack": {"code_only"},  # #13460
+    "npu-worker": {"code_only"},  # #13460
+    "frontend": {"code_only"},  # #13460
+    "browser": {"code_only"},  # #13460
 }
 
 #: Task-name substrings that mean provisioning. None may appear in a task file
@@ -158,12 +165,6 @@ def test_applied_task_files_exist_and_carry_no_provisioning(component, task_file
             )
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="#13460: ai-stack, npu-worker, frontend and browser own systemd units and env "
-    "templates but expose no code/config-only task file, so a fix in any of them is still "
-    "inert on hosts (#12959). When all four gain one this XPASSes — delete this marker then.",
-)
 def test_every_managed_component_has_an_application_path():
     """Every managed component's role must be reachable from the updater.
 


### PR DESCRIPTION
## Thinking Path

The last four components whose role-owned files the builtin updater could not deliver. Each gets a `code_only.yml` — the established shape from `roles/tts-worker` (#12886) — applied by `update-all-nodes.yml`, so a change to a systemd unit, worker script or config actually reaches a host.

Two things needed care rather than mechanical extraction.

**`ai-stack` would have silently disabled ChromaDB auth.** `autobot-chromadb.service.j2` emits `CHROMA_SERVER_AUTHN_*` only when `chromadb_auth_token` is non-empty, and the role default is `""`. Extracting only the *template* tasks into `code_only.yml` would have rendered that unit on every update with the token unread — redeploying chroma with **authentication off**, undoing #12513, with nothing failing and no log to notice. So the #12513 token read is part of `code_only.yml`, not left behind in `main.yml`.

**`browser` had a real duplicate after extraction.** `autobot-browser-worker.env.j2` was rendered in `main.yml` *and* in the new `code_only.yml`, to the same destination — exactly the inline-vs-role duplication #12959 is about, reintroduced by my own change. Removed from `main.yml`; its only consumer is `playwright.service.j2`'s `EnvironmentFile=`, which `code_only.yml` renders immediately after it, and nothing between the two positions reads the file.

(`npu-worker.env.j2` appears in both files and is **not** a duplicate: `main.yml` writes `/etc/autobot/autobot-npu-worker.env`, `code_only.yml` writes `{{ npu_install_dir }}/.env`. Same template, two destinations, both intentional.)

## What Changed

| role | code_only.yml delivers |
|---|---|
| `ai-stack` | chroma token read (#12513) + `autobot-chromadb.service` + `autobot-ai-stack.service` |
| `npu-worker` | `npu-worker.py` (worker **code** from a template), `.env`, `autobot-npu-worker.service` |
| `browser` | `autobot-browser-worker.env`, `autobot-vnc.service`, `autobot-playwright.service` |
| `frontend` | `nginx-frontend.conf` |

Each `main.yml` now *includes* its `code_only.yml` rather than repeating the tasks, so there is one definition per component. Original guards are preserved verbatim — browser's `install_vnc` / `node_roles` (a node that does not run VNC must not acquire a VNC unit because it was updated) and frontend's `slm_colocated_frontend` (#2829).

`frontend/code_only.yml` deliberately excludes the vite build: `update-all-nodes.yml` already deploys frontend code and rebuilds it inline, so including it here would build twice per update.

`playbooks/update-all-nodes.yml` — four `include_role` tasks in PLAY 2, each `when: '<group>' in group_names` and each with `apply: {become: true}`. A bare `become` on `include_role` makes ansible reject the *whole* playbook, breaking every self-update rather than one task (#12886).

**`test_every_managed_component_has_an_application_path` XPASSed, so its `xfail(strict=True)` marker is gone** — which is exactly what that marker was for. All four components move into `DELIVERED`, so the passing regression guard now covers seven components instead of three.

## Verification

```console
$ python3 -m pytest autobot-slm-backend/tests/ -q --ignore=autobot-slm-backend/tests/api/test_scim.py
1095 passed, 1 skipped

$ cd autobot-slm-backend/ansible && ansible-playbook --syntax-check \
    playbooks/update-all-nodes.yml playbooks/deploy-full.yml -i localhost,
playbook: playbooks/update-all-nodes.yml
playbook: playbooks/deploy-full.yml
```

Guards invert-tested — each fails on its own regression:

```console
$ # npu-worker include removed
2 failed, 22 passed
$ # browser/code_only.yml deleted (include points at a missing file)
1 failed, 23 passed
$ # restored
24 passed
```

No provisioning leaked onto the update path — `venv`, `pip install`, `apt`, `npm ci`, downloads and service-account creation appear in these files **only inside comments** explaining what must not run:

```console
$ grep -icE "^\s*[^#].*(venv|pip install|apt|npm ci|download|service account)" */tasks/code_only.yml
0 0 0 0
```

`tests/api/test_scim.py` fails collection with `ModuleNotFoundError: services.system_secrets_vault` — pre-existing, reproduced on an untouched checkout.

One of my own earlier tests caught the ai-stack move: `test_consumer_roles_read_the_token_and_never_generate_one` asserts the chroma read lives in the consumer role and correctly failed when it moved file. Updated to follow it, with the reason recorded inline rather than the assertion loosened.

## Scope

This closes the last gap in #12959's proposal 1: every managed component now has a delivery path through the builtin updater.

Closes #13460
Refs #12959

## Model Used

Opus 5 (1M context)
