### PR TITLE
test(llc): skip the summarization integration test on the real precondition (#13387)

### DIFF
--- a/autobot-backend/llc/tests/test_autobot_agent_adapter.py
+++ b/autobot-backend/llc/tests/test_autobot_agent_adapter.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import sys
 import types
 from pathlib import Path
@@ -606,6 +607,12 @@ def test_llcadapter_protocol_satisfied():
     assert isinstance(adapter, LLCAdapter)
 
 
+# #13387: mirrors SummarizationAgent.AGENT_ID. Kept as a literal rather than
+# imported, because importing the agent here would re-introduce exactly the
+# module-availability coupling this test is being freed from.
+SUMMARIZATION_AGENT_ID = "summarization"
+
+
 # ──────────────────────────────────────────────────────────────────────────────
 # Integration: dispatch SummarizationAgent stub on a work item (needs live LLM)
 # ──────────────────────────────────────────────────────────────────────────────
@@ -622,7 +629,22 @@ async def test_integration_summarization_agent_reaches_completed():
     Verifies the run record reaches ``COMPLETED`` (maps to GH#8227's
     "succeeded" language; GH#8261 unified both into ``LLCRunStatus.COMPLETED``).
     """
-    pytest.importorskip("agents.summarization_agent", reason="Real agent module not available in unit test env")
+    # #13387: skip on what this test actually needs — a configured LLM provider —
+    # rather than on whether a module imports.
+    #
+    # It used to call ``pytest.importorskip("agents.summarization_agent")``. Until
+    # #13385 that always fired, but for the wrong reason: llc/tests/conftest.py
+    # installed an ``agents`` stub with ``__path__ = []``, so every ``agents.*``
+    # submodule was unimportable. Once that was fixed the module imports fine and
+    # the test proceeds to fail on ``AgentConfigurationError`` instead — because
+    # ``SummarizationAgent.__init__`` calls ``get_agent_provider_explicit``, which
+    # reads ``AUTOBOT_SUMMARIZATION_PROVIDER`` and raises when it is unset.
+    #
+    # An importable module was never the precondition; it only happened to
+    # coincide with one while a harness bug hid the real dependency.
+    provider_var = f"AUTOBOT_{SUMMARIZATION_AGENT_ID.upper()}_PROVIDER"
+    if not os.environ.get(provider_var):
+        pytest.skip(f"needs a configured LLM provider: {provider_var} is not set")
     adapter = AutoBotAgentAdapter({"agent_class": "agents.summarization_agent.SummarizationAgent"})
     context = {
         "title": "Summarize the widget documentation",


### PR DESCRIPTION
Closes #13387

## Thinking Path

The test guarded itself with `pytest.importorskip("agents.summarization_agent")`, but an importable module was never its precondition. `SummarizationAgent.__init__` calls `get_agent_provider_explicit(AGENT_ID)`, which reads `AUTOBOT_SUMMARIZATION_PROVIDER` and raises `AgentConfigurationError` when unset.

The two only coincided because of a harness bug: `llc/tests/conftest.py` installed an `agents` stub with `__path__ = []`, so every `agents.*` submodule was unimportable and the skip always fired. #13385 fixed that stub — at which point the module imports fine and the test proceeds to fail on the provider. **The guard had been standing in for a dependency it never actually checked**, and only looked correct while something else was broken.

## What Changed

`importorskip` → a skip on the environment variable that genuinely gates the test, with a reason that says so.

`AGENT_ID` is mirrored as a module constant rather than imported from the agent, because importing it here would re-introduce exactly the module-availability coupling this change removes.

## Verification

Both directions, since a skip that never runs proves nothing:

```
$ pytest -m integration -rs                       # provider unset
SKIPPED [1] ...:647: needs a configured LLM provider:
            AUTOBOT_SUMMARIZATION_PROVIDER is not set

$ AUTOBOT_SUMMARIZATION_PROVIDER=ollama pytest -m integration
1 failed        # runs, then fails on the absent live LLM — correct
```

The second is the important one: with the variable set the test **proceeds past the guard**, so the guard is no longer masking the real dependency.

```
llc/tests/                                  31 passed
isort · black · flake8 (0) · bandit         clean
```

The `integration` marker is unchanged, so CI's unit selection deselects it either way. The value is that an integration run now skips honestly rather than for a reason that stopped being true.

## Model Used

Claude Opus 5 (1M context)
