### PR TITLE
security(ci): route workflow inputs through env: instead of inline interpolation (#13516)

### DIFF
--- a/.github/actions/setup-python-ci/action.yml
+++ b/.github/actions/setup-python-ci/action.yml
@@ -50,11 +50,23 @@ runs:
         python-version: ${{ inputs.python-version }}
         cache: 'pip'
 
+    # #13516: every input reaches the shell through `env:`, never inline
+    # `${{ }}` in a `run:` body. Inline interpolation is textual substitution
+    # into the script *before* bash sees it, so a value containing shell
+    # metacharacters becomes code rather than data. The `env:` hop makes it a
+    # variable, which bash cannot re-interpret.
+    #
+    # These were unreachable while this action had no callers (#13517). They are
+    # fixed FIRST precisely so wiring it up cannot turn `pip install -r $X` into
+    # RCE on the runner.
     - name: Compute cache key
       id: cache-key
       shell: bash
+      env:
+        PY_VERSION: ${{ inputs.python-version }}
+        REQ_HASH: ${{ hashFiles('**/requirements*.txt', 'pyproject.toml') }}
       run: |
-        echo "value=python-${{ inputs.python-version }}-pip-${{ hashFiles('**/requirements*.txt', 'pyproject.toml') }}" >> "$GITHUB_OUTPUT"
+        echo "value=python-${PY_VERSION}-pip-${REQ_HASH}" >> "$GITHUB_OUTPUT"
 
     - name: Upgrade pip, setuptools, wheel
       shell: bash
@@ -63,9 +75,16 @@ runs:
     - name: Install requirements file
       if: inputs.requirements-file != ''
       shell: bash
-      run: python -m pip install -r ${{ inputs.requirements-file }} --prefer-binary
+      env:
+        REQ_FILE: ${{ inputs.requirements-file }}
+      run: python -m pip install -r "$REQ_FILE" --prefer-binary
 
     - name: Install extra packages
       if: inputs.extra-packages != ''
       shell: bash
-      run: python -m pip install ${{ inputs.extra-packages }}
+      env:
+        EXTRA_PKGS: ${{ inputs.extra-packages }}
+      # Deliberately unquoted: this input is a space-separated package list and
+      # word-splitting is the intent. The `env:` hop still defeats expression
+      # injection — the value can no longer become shell syntax, only arguments.
+      run: python -m pip install $EXTRA_PKGS

--- a/.github/workflows/phase_validation.yml
+++ b/.github/workflows/phase_validation.yml
@@ -129,8 +129,13 @@ jobs:
         echo "Generating validation dashboard..."
         python3 autobot-infrastructure/shared/scripts/validation_dashboard_generator.py --ci-mode > validation_dashboard.html || echo "Dashboard generation failed"
 
+    # #13516: `github.ref` through `env:`. Not attacker-settable — on
+    # `pull_request` it resolves to `refs/pull/<N>/merge` (a number), and `push`
+    # is branch-filtered — so defence in depth.
     - name: Phase Validation Gate
       shell: bash
+      env:
+        GH_REF: ${{ github.ref }}
       run: |
         set -euo pipefail
         echo "Checking phase validation gate..."
@@ -141,7 +146,7 @@ jobs:
         echo "System maturity: ${MATURITY}%"
 
         # Set minimum maturity threshold for different branches
-        if [ "${{ github.ref }}" == "refs/heads/main" ]; then
+        if [ "$GH_REF" == "refs/heads/main" ]; then
           THRESHOLD=80
           echo "Main branch - requiring ${THRESHOLD}% maturity"
         else

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -343,14 +343,20 @@ jobs:
     - name: Download all security reports
       uses: actions/download-artifact@v8
 
+    # #13516: `github.ref_name` / `github.sha` through `env:`. Neither is
+    # attacker-settable here — on `pull_request` these resolve to the PR number,
+    # not the fork's branch name — so this is defence in depth, fixed as a pair.
     - name: Generate Security Summary
+      env:
+        REF_NAME: ${{ github.ref_name }}
+        COMMIT_SHA: ${{ github.sha }}
       run: |
         {
           echo "# Security Scan Summary"
           echo ""
           echo "**Scan Date:** $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
-          echo "**Branch:** ${{ github.ref_name }}"
-          echo "**Commit:** ${{ github.sha }}"
+          echo "**Branch:** $REF_NAME"
+          echo "**Commit:** $COMMIT_SHA"
           echo ""
         } > security-summary.md
 

--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -28,10 +28,17 @@ jobs:
       pull-requests: write
 
     steps:
+      # #13516: `inputs.confirm` reaches the shell through `env:`, not inline
+      # `${{ }}`. Triggering this needs repo write access, so it is
+      # privilege-equivalent rather than an escalation — but this job holds
+      # `contents: write` (see permissions above), which makes it the one site
+      # in the batch worth fixing on its own merits.
       - name: Validate confirmation
         if: inputs.confirm != 'release'
+        env:
+          CONFIRM: ${{ inputs.confirm }}
         run: |
-          echo "::error::You must type 'release' to confirm. Got: '${{ inputs.confirm }}'"
+          echo "::error::You must type 'release' to confirm. Got: '$CONFIRM'"
           exit 1
 
       - name: Checkout repository


### PR DESCRIPTION
## Thinking Path

Six sites across four files interpolated `\${{ }}` directly into `run:` bodies. Inline interpolation is textual substitution into the script *before* bash sees it, so a value carrying shell metacharacters becomes code rather than data. The `env:` hop makes it a variable, which bash cannot re-interpret.

**None are fork-reachable, and I checked that specifically rather than assuming.** The two contexts that carry an attacker-chosen branch name — `github.head_ref` and `github.event.pull_request.head.ref` — appear in **no** `run:` body in this repo. The flagged `github.ref` / `github.ref_name` resolve to `refs/pull/<N>/merge` on `pull_request` (a PR number, not a branch name) and are branch-filtered on `push`. So this is hardening, and the ordering below reflects that.

## What Changed

| file | site | why it ranks where it does |
|---|---|---|
| `sync-main-to-dev.yml:34` | `inputs.confirm` | needs repo write to trigger, so privilege-equivalent — but the **only one whose job holds `contents: write`** |
| `setup-python-ci/action.yml:66` | `inputs.requirements-file` | worst *sink* — unquoted, feeding a command |
| `setup-python-ci/action.yml:71` | `inputs.extra-packages` | same |
| `setup-python-ci/action.yml:57` | `inputs.python-version` | weaker sink (an `echo`) |
| `phase_validation.yml:144` | `github.ref` | defence in depth |
| `security.yml:352-353` | `github.ref_name`, `github.sha` | defence in depth, fixed as a pair |

The three `setup-python-ci` sites are currently unreachable — that action has zero callers (#13517). They are fixed **first, on purpose**: wiring it up with a `head_ref`-derived input would turn `pip install -r $REQ_FILE` into RCE on the runner.

`extra-packages` stays **unquoted** after the `env:` hop. It is a space-separated package list and word-splitting is the intent; the indirection still defeats expression injection, because the value can no longer become shell syntax — only arguments.

The pattern matches what this repo already does in `pr-issue-validation.yml:28-32`.

## Verification

```console
$ python3 -c 'import yaml; ...'   # all four files
OK .github/workflows/sync-main-to-dev.yml
OK .github/workflows/phase_validation.yml
OK .github/workflows/security.yml
OK .github/actions/setup-python-ci/action.yml
```

Inline `\${{ }}` remaining inside a `run:` body, per file:

```
sync-main-to-dev.yml: 2      <- see below
phase_validation.yml: 0
security.yml:         0
setup-python-ci:      0
```

## The two remaining matches, deliberately left

`sync-main-to-dev.yml:64-65` interpolate `steps.check.outputs.behind`. The scan did not flag them and they are safe: that output is `$(git rev-list --count origin/Dev_new_gui..origin/main)` (`:54`) — an integer produced by the workflow itself, with no path from any request. Hoisting them would be scope creep past the issue; a reviewer will notice them, so this records why they stayed.

Closes #13516
Refs #13517

## Model Used

Opus 5 (1M context)