### PR TITLE
ci(setup-python): adopt the shared composite action, starting with two workflows (#13517)

### DIFF
--- a/.github/actions/setup-python-ci/action.yml
+++ b/.github/actions/setup-python-ci/action.yml
@@ -50,11 +50,23 @@ runs:
         python-version: ${{ inputs.python-version }}
         cache: 'pip'
 
+    # #13516: every input reaches the shell through `env:`, never inline
+    # `${{ }}` in a `run:` body. Inline interpolation is textual substitution
+    # into the script *before* bash sees it, so a value containing shell
+    # metacharacters becomes code rather than data. The `env:` hop makes it a
+    # variable, which bash cannot re-interpret.
+    #
+    # These were unreachable while this action had no callers (#13517). They are
+    # fixed FIRST precisely so wiring it up cannot turn `pip install -r $X` into
+    # RCE on the runner.
     - name: Compute cache key
       id: cache-key
       shell: bash
+      env:
+        PY_VERSION: ${{ inputs.python-version }}
+        REQ_HASH: ${{ hashFiles('**/requirements*.txt', 'pyproject.toml') }}
       run: |
-        echo "value=python-${{ inputs.python-version }}-pip-${{ hashFiles('**/requirements*.txt', 'pyproject.toml') }}" >> "$GITHUB_OUTPUT"
+        echo "value=python-${PY_VERSION}-pip-${REQ_HASH}" >> "$GITHUB_OUTPUT"
 
     - name: Upgrade pip, setuptools, wheel
       shell: bash
@@ -63,9 +75,16 @@ runs:
     - name: Install requirements file
       if: inputs.requirements-file != ''
       shell: bash
-      run: python -m pip install -r ${{ inputs.requirements-file }} --prefer-binary
+      env:
+        REQ_FILE: ${{ inputs.requirements-file }}
+      run: python -m pip install -r "$REQ_FILE" --prefer-binary
 
     - name: Install extra packages
       if: inputs.extra-packages != ''
       shell: bash
-      run: python -m pip install ${{ inputs.extra-packages }}
+      env:
+        EXTRA_PKGS: ${{ inputs.extra-packages }}
+      # Deliberately unquoted: this input is a space-separated package list and
+      # word-splitting is the intent. The `env:` hop still defeats expression
+      # injection — the value can no longer become shell syntax, only arguments.
+      run: python -m pip install $EXTRA_PKGS

--- a/.github/actions/setup-python-ci/action.yml
+++ b/.github/actions/setup-python-ci/action.yml
@@ -31,6 +31,13 @@ inputs:
     description: 'Space-separated list of additional pip packages to install after requirements-file.'
     required: false
     default: ''
+  cache-dependency-path:
+    description: >-
+      Files whose hashes key pip's download cache. Most callers pin this to their
+      own requirements files; without it setup-python keys on a default glob, so
+      unrelated workflows share and evict each other's cache entries (#13517).
+    required: false
+    default: ''
 
 outputs:
   python-version:
@@ -45,10 +52,14 @@ runs:
   steps:
     - name: Set up Python ${{ inputs.python-version }}
       id: setup
-      uses: actions/setup-python@1d6f8c11a0e30b87a6af51d0d78681a80e55c65a  # v5
+      # #13517: was pinned to a v5 SHA while every workflow in this repo is
+      # already on v7. Adopting the action as-was would have silently
+      # downgraded setup-python across 21 jobs.
+      uses: actions/setup-python@v7
       with:
         python-version: ${{ inputs.python-version }}
         cache: 'pip'
+        cache-dependency-path: ${{ inputs.cache-dependency-path }}
 
     # #13516: every input reaches the shell through `env:`, never inline
     # `${{ }}` in a `run:` body. Inline interpolation is textual substitution

--- a/.github/workflows/constraint-drift.yml
+++ b/.github/workflows/constraint-drift.yml
@@ -39,12 +39,11 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v7
+      # #13517: shared composite action, so the interpreter version, pip cache
+      # and dependency install live in one place rather than 21 copies.
+      - uses: ./.github/actions/setup-python-ci
         with:
-          python-version: '3.14'
-
-      - name: Install guard dependencies
-        run: python3 -m pip install --quiet packaging
+          extra-packages: packaging
 
       - name: Check single-source constraint compliance
         run: python3 scripts/check_constraint_drift.py

--- a/.github/workflows/enforce-precommit.yml
+++ b/.github/workflows/enforce-precommit.yml
@@ -62,15 +62,15 @@ jobs:
           fi
           echo "✓ All required hooks (black, isort, flake8, autoflake, mypy) are configured"
 
+      # #13517: shared composite action (also upgrades pip/setuptools/wheel).
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: ./.github/actions/setup-python-ci
         with:
-          python-version: '3.14'
+          extra-packages: pre-commit
 
-      - name: Install pre-commit
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install pre-commit
+      # #13517: pre-commit is installed by the composite action above via
+      # extra-packages, which also upgrades pip/setuptools/wheel — this step
+      # duplicated both.
 
       - name: Run pre-commit on all files
         run: |

--- a/.github/workflows/phase_validation.yml
+++ b/.github/workflows/phase_validation.yml
@@ -129,8 +129,13 @@ jobs:
         echo "Generating validation dashboard..."
         python3 autobot-infrastructure/shared/scripts/validation_dashboard_generator.py --ci-mode > validation_dashboard.html || echo "Dashboard generation failed"
 
+    # #13516: `github.ref` through `env:`. Not attacker-settable — on
+    # `pull_request` it resolves to `refs/pull/<N>/merge` (a number), and `push`
+    # is branch-filtered — so defence in depth.
     - name: Phase Validation Gate
       shell: bash
+      env:
+        GH_REF: ${{ github.ref }}
       run: |
         set -euo pipefail
         echo "Checking phase validation gate..."
@@ -141,7 +146,7 @@ jobs:
         echo "System maturity: ${MATURITY}%"
 
         # Set minimum maturity threshold for different branches
-        if [ "${{ github.ref }}" == "refs/heads/main" ]; then
+        if [ "$GH_REF" == "refs/heads/main" ]; then
           THRESHOLD=80
           echo "Main branch - requiring ${THRESHOLD}% maturity"
         else

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -343,14 +343,20 @@ jobs:
     - name: Download all security reports
       uses: actions/download-artifact@v8
 
+    # #13516: `github.ref_name` / `github.sha` through `env:`. Neither is
+    # attacker-settable here — on `pull_request` these resolve to the PR number,
+    # not the fork's branch name — so this is defence in depth, fixed as a pair.
     - name: Generate Security Summary
+      env:
+        REF_NAME: ${{ github.ref_name }}
+        COMMIT_SHA: ${{ github.sha }}
       run: |
         {
           echo "# Security Scan Summary"
           echo ""
           echo "**Scan Date:** $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
-          echo "**Branch:** ${{ github.ref_name }}"
-          echo "**Commit:** ${{ github.sha }}"
+          echo "**Branch:** $REF_NAME"
+          echo "**Commit:** $COMMIT_SHA"
           echo ""
         } > security-summary.md
 

--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -28,10 +28,17 @@ jobs:
       pull-requests: write
 
     steps:
+      # #13516: `inputs.confirm` reaches the shell through `env:`, not inline
+      # `${{ }}`. Triggering this needs repo write access, so it is
+      # privilege-equivalent rather than an escalation — but this job holds
+      # `contents: write` (see permissions above), which makes it the one site
+      # in the batch worth fixing on its own merits.
       - name: Validate confirmation
         if: inputs.confirm != 'release'
+        env:
+          CONFIRM: ${{ inputs.confirm }}
         run: |
-          echo "::error::You must type 'release' to confirm. Got: '${{ inputs.confirm }}'"
+          echo "::error::You must type 'release' to confirm. Got: '$CONFIRM'"
           exit 1
 
       - name: Checkout repository


### PR DESCRIPTION
## Thinking Path

Owner decision on #13517: **adopt** `setup-python-ci` in the workflows still calling `actions/setup-python` directly, rather than retiring it.

**Stacked on #13516** (`issue-13516` is this branch's base), on purpose. That PR fixes the three expression-injection sites inside this action. Wiring it up first would have made `pip install -r ${{ inputs.requirements-file }}` reachable — the exact ordering hazard the issue calls out. Merge #13516 first; this rebases cleanly onto `Dev_new_gui` afterwards.

**Deliberately incremental.** 21 workflows call `actions/setup-python` directly. Converting all of them in one PR would touch nearly the whole pipeline in a change no one can review by reading — and a mistake breaks CI broadly. This lands the action's missing capability plus the two workflows whose setup matches it exactly, so the pattern is reviewable in isolation before the rest follow.

## Two things adoption surfaced that would have bitten

**The action was pinned to a `setup-python` v5 SHA** while every workflow in this repo is already on v7. Adopting it as-was would have silently downgraded the Python setup across 21 jobs — a regression delivered *by* a consolidation change, and invisible in the diff of any workflow that adopted it. Now on v7, matching its callers.

**It had no `cache-dependency-path` input**, but 16 of the 21 direct callers set one. Without it, `setup-python` keys pip's cache on a default glob, so unrelated workflows share and evict each other's entries. Adopting it without this would have quietly degraded cache hit rates across the pipeline. Added as an optional input.

## What Changed

`.github/actions/setup-python-ci/action.yml`
- `cache-dependency-path` input, forwarded to `setup-python`
- `actions/setup-python@v5` SHA → `@v7`

**Adopted (2 of 21):**

| workflow | before | after |
|---|---|---|
| `constraint-drift.yml` | `setup-python` + `pip install --quiet packaging` | `setup-python-ci` with `extra-packages: packaging` |
| `enforce-precommit.yml` | `setup-python` + `pip install --upgrade pip` + `pip install pre-commit` | `setup-python-ci` with `extra-packages: pre-commit` |

Both had a separate pip-install step the action already performs — including the `pip`/`setuptools`/`wheel` upgrade — so those steps are removed rather than left duplicating it.

These two were chosen because neither sets `cache-dependency-path`, so the conversion is exact with nothing to reconcile.

## Verification

```console
$ python3 -c 'import yaml; ...'
OK .github/actions/setup-python-ci/action.yml
OK .github/workflows/constraint-drift.yml
OK .github/workflows/enforce-precommit.yml

$ # action inputs after the change
inputs: ['python-version', 'requirements-file', 'extra-packages', 'cache-dependency-path']
uses:   ['actions/setup-python@v7']
```

The real verification is CI itself: both converted workflows run on this PR, so a broken conversion surfaces here rather than after merge.

## Remaining

19 workflows still call `actions/setup-python` directly. **#13517 stays open** with the remainder as a checklist — this is the first tranche, and closure Gate 3 does not close an issue on a subset.

Its description still claims three callers; that gets rewritten to name the real ones when the last tranche lands.

Refs #13517, #13516

## Model Used

Opus 5 (1M context)
