### PR TITLE
refactor(security): route audio-path containment through the canonical helper (#13518)

### DIFF
--- a/autobot-backend/transcriber/routes/recordings.py
+++ b/autobot-backend/transcriber/routes/recordings.py
@@ -27,6 +27,7 @@ from fastapi import (
 from fastapi.responses import StreamingResponse
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.security.path_validator import validate_path
 from transcriber.database import Database
 from transcriber.deps import DEFAULT_USER, can_access, get_db
 from transcriber.models import RecordingOut
@@ -165,18 +166,30 @@ async def delete_recording(recording_id: int, request: Request, db: Database = D
 def _resolve_audio_path(filepath: str, upload_dir: Path) -> Path:
     """Resolve and validate an audio filepath is within the upload directory.
 
-    Raises HTTPException(404) on path-traversal attempts, symlinks, or missing files.
+    Raises HTTPException(404) on path-traversal attempts or missing files.
+
+    #13518: was a second, hand-rolled implementation of path containment
+    (``resolve()`` + ``relative_to()``). It was correct, but it would not have
+    inherited future hardening of ``path_validator.py`` — the drift that makes
+    two implementations of one invariant expensive. Now delegates to the
+    canonical helper, which does the same realpath + containment check against
+    an allow-list of roots.
+
+    The old body also rejected symlinks explicitly. **That check could never
+    fire**: it ran on the output of ``.resolve()``, which follows symlinks, so
+    the value tested is always the target and never a link
+    (``Path(link).resolve().is_symlink()`` is ``False`` for both live and
+    dangling links). Its intent is satisfied anyway — a symlink pointing outside
+    the upload directory resolves to a path that fails the containment check,
+    and one pointing inside is harmless. Dropped rather than carried across, so
+    nobody folds dead code into the shared helper.
     """
-    resolved_upload = upload_dir.resolve()
     try:
-        resolved_file = Path(filepath).resolve()
-        resolved_file.relative_to(resolved_upload)  # raises ValueError on traversal
-    except (ValueError, OSError):
+        resolved_file = validate_path(filepath, allowed_roots=[str(upload_dir)])
+    except ValueError:
         logger.warning("Path traversal or invalid path rejected: %r", filepath)
         raise HTTPException(404, "Audio file not found")
-    if resolved_file.is_symlink():
-        logger.warning("Symlink rejected: %r", str(resolved_file))
-        raise HTTPException(404, "Audio file not found")
+
     if not resolved_file.is_file():
         raise HTTPException(404, "Audio file not found")
     return resolved_file

--- a/autobot-backend/transcriber/tests/test_audio_path_containment_13518.py
+++ b/autobot-backend/transcriber/tests/test_audio_path_containment_13518.py
@@ -1,0 +1,145 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Audio paths stay inside the upload directory, via the canonical helper (#13518).
+
+`_resolve_audio_path` was a second, hand-rolled implementation of path
+containment — `resolve()` + `relative_to()` — alongside
+`autobot_shared/security/path_validator.py`, which 30+ call sites use. It was
+correct, but a second implementation of one invariant does not inherit the
+shared one's future hardening.
+
+It also carried an explicit symlink rejection that a scan triage described as
+making it *stronger* than the canonical helper. **That check could never fire.**
+It ran on the output of `.resolve()`, which follows symlinks, so the value tested
+is always the target and never a link. `test_the_symlink_check_it_replaced_was_dead_code`
+pins that, because the claim is plausible enough to be re-added by someone
+reading the old code.
+
+Containment against symlinks holds regardless, and for a better reason: a link
+pointing outside the upload directory resolves to a path that fails the
+containment check, and one pointing inside is harmless.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from fastapi import HTTPException  # noqa: E402
+
+from transcriber.routes.recordings import _resolve_audio_path  # noqa: E402
+
+
+@pytest.fixture()
+def upload_dir(tmp_path):
+    d = tmp_path / "uploads"
+    d.mkdir()
+    return d
+
+
+def test_a_file_inside_the_upload_dir_resolves(upload_dir):
+    audio = upload_dir / "take-1.wav"
+    audio.write_bytes(b"RIFF")
+
+    assert _resolve_audio_path(str(audio), upload_dir) == audio.resolve()
+
+
+def test_a_path_outside_the_upload_dir_is_rejected(upload_dir, tmp_path):
+    outside = tmp_path / "elsewhere.wav"
+    outside.write_bytes(b"RIFF")
+
+    with pytest.raises(HTTPException) as exc:
+        _resolve_audio_path(str(outside), upload_dir)
+    assert exc.value.status_code == 404
+
+
+def test_traversal_out_of_the_upload_dir_is_rejected(upload_dir, tmp_path):
+    escaped = tmp_path / "secret.wav"
+    escaped.write_bytes(b"RIFF")
+
+    with pytest.raises(HTTPException) as exc:
+        _resolve_audio_path(str(upload_dir / ".." / "secret.wav"), upload_dir)
+    assert exc.value.status_code == 404
+
+
+def test_a_symlink_escaping_the_upload_dir_is_rejected(upload_dir, tmp_path):
+    """The case the deleted `is_symlink()` check was reaching for.
+
+    Containment catches it without a dedicated check: `realpath` follows the
+    link, and the *target* is what must fall under the upload directory.
+    """
+    outside = tmp_path / "outside.wav"
+    outside.write_bytes(b"RIFF")
+    link = upload_dir / "innocent.wav"
+    link.symlink_to(outside)
+
+    with pytest.raises(HTTPException) as exc:
+        _resolve_audio_path(str(link), upload_dir)
+    assert exc.value.status_code == 404
+
+
+def test_a_symlink_staying_inside_the_upload_dir_is_allowed(upload_dir):
+    """Harmless, and the old blanket rejection would have been wrong to block it."""
+    real = upload_dir / "real.wav"
+    real.write_bytes(b"RIFF")
+    link = upload_dir / "alias.wav"
+    link.symlink_to(real)
+
+    assert _resolve_audio_path(str(link), upload_dir) == real.resolve()
+
+
+def test_a_missing_file_is_rejected(upload_dir):
+    with pytest.raises(HTTPException) as exc:
+        _resolve_audio_path(str(upload_dir / "gone.wav"), upload_dir)
+    assert exc.value.status_code == 404
+
+
+def test_a_directory_is_not_accepted_as_audio(upload_dir):
+    (upload_dir / "subdir").mkdir()
+
+    with pytest.raises(HTTPException) as exc:
+        _resolve_audio_path(str(upload_dir / "subdir"), upload_dir)
+    assert exc.value.status_code == 404
+
+
+def test_the_symlink_check_it_replaced_was_dead_code(tmp_path):
+    """Pins why the explicit `is_symlink()` rejection was dropped, not ported.
+
+    A triage described it as making the hand-rolled helper stronger than the
+    canonical one. It ran *after* `.resolve()`, which follows symlinks — so the
+    value tested is the target, never the link. Recorded here because the claim
+    is plausible enough that someone reading the old code would re-add it.
+    """
+    real = tmp_path / "real.wav"
+    real.write_bytes(b"RIFF")
+    link = tmp_path / "link.wav"
+    link.symlink_to(real)
+
+    assert link.is_symlink() is True, "the link itself is a symlink"
+    assert (
+        Path(str(link)).resolve().is_symlink() is False
+    ), "resolve() follows symlinks, so the old check could never fire"
+
+    dangling = tmp_path / "dangling.wav"
+    dangling.symlink_to(tmp_path / "nope.wav")
+    assert (
+        Path(str(dangling)).resolve().is_symlink() is False
+    ), "not even a dangling link survives resolve() as a symlink"
+
+
+def test_it_delegates_to_the_canonical_helper_rather_than_re_implementing():
+    """The point of the change: one implementation of path containment."""
+    import inspect
+
+    from transcriber.routes import recordings
+
+    source = inspect.getsource(recordings._resolve_audio_path)
+
+    assert "validate_path(" in source, (
+        "_resolve_audio_path no longer delegates to path_validator — a second "
+        "implementation will not inherit the shared helper's hardening"
+    )
+    assert ".relative_to(" not in source, "containment is re-implemented locally again"


### PR DESCRIPTION
## Thinking Path

`_resolve_audio_path` was the one genuine competing implementation of path containment in the backend — hand-rolled `resolve()` + `relative_to()` alongside `autobot_shared/security/path_validator.py`, which 30+ call sites use. Correct, but a second implementation of one invariant does not inherit the shared one's future hardening.

The triage that surfaced it said the local version was *stronger in one respect*: it rejected symlinks explicitly, which the canonical helper does not. My plan was to fold that check into `validate_relative_path` so everyone got it.

**The check could never fire.** It ran on the output of `.resolve()`, which follows symlinks — so the value tested is always the target, never a link:

```console
$ link.is_symlink()                      -> True     # the link itself
$ Path(str(link)).resolve().is_symlink() -> False    # what the code actually tested
$ Path(str(dangling)).resolve().is_symlink() -> False
```

So there was nothing to fold in. Folding it would have moved dead code into a helper used at 30+ sites, and given every one of them a check that reads like protection and provides none.

Its **intent** is satisfied anyway, for a better reason than an explicit check: a symlink pointing outside the upload directory resolves to a path that fails containment, and one pointing inside is harmless. The old blanket rejection would in fact have been wrong to block the second case.

## What Changed

`autobot-backend/transcriber/routes/recordings.py` — `_resolve_audio_path` delegates to `validate_path(filepath, allowed_roots=[upload_dir])`, keeping its `HTTPException(404)` translation and the `is_file()` check. The dead `is_symlink()` branch is dropped rather than carried across, with the reasoning recorded at the call site so it is not re-added.

`validate_path` rather than `validate_relative_path`: the filepath comes from a **DB row** and may be absolute, and `validate_relative_path` joins a segment onto a base — an absolute segment would discard the base entirely. `validate_path` takes a full path and checks it against allowed roots, which is the shape this call site actually has.

## Verification

```console
$ python3 -m pytest autobot-backend/transcriber/ autobot-backend/tests/test_startup_imports.py -q
462 passed, 1 skipped
```

9 new tests. Invert-tested — replacing the delegation with a bare `Path(filepath).resolve()` fails 4 of them:

```console
$ # containment removed
4 failed, 5 passed
$ # restored
110 passed, 1 skipped
```

Two of the new tests exist specifically because of the wrong claim:

- `test_a_symlink_escaping_the_upload_dir_is_rejected` — the case the deleted check was reaching for, still caught, by containment.
- `test_the_symlink_check_it_replaced_was_dead_code` — pins the `resolve()`-follows-symlinks behaviour directly. The "it was stronger" reading is plausible enough that someone looking at the old code would re-add it; this makes that argument fail a test rather than a review.

## Not in this PR

The issue's second item — Pydantic field validators named `validate_path` / `validate_path_pattern` in `schemas_system.py` and `schemas_knowledge.py` creating grep collisions with the containment helper. Renaming public validator methods touches schema classes and is a different kind of risk from this change; #13518 stays open for it.

Refs #13518

## Model Used

Opus 5 (1M context)
