### PR TITLE
hardening(database-mcp): read-only gate on /mcp/query, comment denylist outside literals (#13520)

### DIFF
--- a/autobot-backend/api/database_mcp.py
+++ b/autobot-backend/api/database_mcp.py
@@ -113,10 +113,19 @@ BLOCKED_SQL_PATTERNS = [
     r";\s*ALTER\s+",
     r";\s*CREATE\s+",
     r";\s*TRUNCATE\s+",
-    r"--",  # SQL comments
-    r"/\*",  # Block comments
     r"ATTACH\s+DATABASE",
     r"DETACH\s+DATABASE",
+]
+
+# #13520: comment tokens are checked against the query with string literals
+# removed. Checked against the raw text they rejected legitimate queries — a
+# WHERE clause matching a literal '--' or a path containing '/*' is ordinary SQL,
+# not an injection attempt. Kept as a separate list because the relaxation is
+# only safe for these two: the patterns above stay on the raw text, where a
+# stacked statement must be caught wherever it appears.
+BLOCKED_SQL_COMMENT_PATTERNS = [
+    r"--",  # line comment
+    r"/\*",  # block comment
 ]
 
 # Rate limiting
@@ -127,6 +136,54 @@ _rate_limit_lock = asyncio.Lock()
 # Query limits
 MAX_RESULT_ROWS = 1000
 MAX_QUERY_LENGTH = 10000
+
+
+def _is_readonly_statement(sql: str) -> bool:
+    """Does *sql* begin with a statement that cannot modify data? (#13520)
+
+    Deliberately a narrow allow-list rather than a denylist of write verbs: an
+    unrecognised statement is treated as a write, so a SQLite keyword nobody
+    thought of here fails closed.
+    """
+    first = sql.lstrip().split(None, 1)
+    if not first:
+        return False
+    return first[0].upper() in {"SELECT", "WITH", "EXPLAIN", "PRAGMA"}
+
+
+def _strip_sql_string_literals(sql: str) -> str:
+    """Blank out single- and double-quoted spans so comment tokens inside them are ignored (#13520).
+
+    Quoted content is replaced with spaces rather than removed, so the result is
+    the same length as the input and any offsets stay meaningful.
+
+    SQLite escapes a quote by doubling it (``'it''s'``), which this handles
+    naturally: the second quote of the pair opens a new span that the following
+    character closes.
+
+    **Fails closed.** If quoting is unbalanced — an unterminated literal — the
+    original text is returned unchanged, so the caller's comment check still runs
+    over everything. Otherwise a trailing ``'`` would place the rest of the query
+    "inside a literal" and hide exactly what this check exists to find.
+    """
+    out = []
+    quote: str | None = None
+    for char in sql:
+        if quote is None:
+            if char in ("'", '"'):
+                quote = char
+                out.append(" ")
+            else:
+                out.append(char)
+        else:
+            out.append(" ")
+            if char == quote:
+                quote = None
+
+    if quote is not None:
+        return sql
+
+    return "".join(out)
 
 
 def validate_sql_query(sql: str) -> bool:
@@ -147,6 +204,16 @@ def validate_sql_query(sql: str) -> bool:
     for pattern in BLOCKED_SQL_PATTERNS:
         if re.search(pattern, sql, re.IGNORECASE):
             logger.warning("Blocked SQL pattern detected: %s", pattern)
+            return False
+
+    # #13520: comment tokens are checked outside string literals only.
+    # `_strip_sql_string_literals` fails CLOSED — on unbalanced quoting it
+    # returns the text unchanged, so a query that could hide a comment inside an
+    # unterminated literal is still rejected.
+    sql_outside_literals = _strip_sql_string_literals(sql)
+    for pattern in BLOCKED_SQL_COMMENT_PATTERNS:
+        if re.search(pattern, sql_outside_literals, re.IGNORECASE):
+            logger.warning("Blocked SQL comment token detected: %s", pattern)
             return False
 
     # Count semicolons (should be 0 or 1 at the end)
@@ -657,6 +724,18 @@ async def database_query_mcp(request: SQLQueryRequest) -> Metadata:
 
     if not validate_sql_query(request.query):
         raise HTTPException(status_code=400, detail="Query contains blocked patterns or is too long")
+
+    # #13520: /mcp/execute consulted the read-only flag and this path did not.
+    # Harmless in practice — SQLQueryRequest's validator already forbids anything
+    # but SELECT, and the sync executor never commits — but that left the
+    # guarantee resting on one check where it can rest on two independent ones.
+    # A read-only database should refuse a write regardless of which endpoint
+    # asks and regardless of whether a future edit relaxes the validator.
+    if is_database_read_only(request.database) and not _is_readonly_statement(request.query):
+        raise HTTPException(
+            status_code=403,
+            detail=f"Database {request.database} is read-only. Cannot execute modifications.",
+        )
 
     # Get database path
     db_path = get_database_path(request.database)

--- a/autobot-backend/api/database_mcp_query_guards_13520_test.py
+++ b/autobot-backend/api/database_mcp_query_guards_13520_test.py
@@ -1,0 +1,113 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Two guards on the SQL MCP surface (#13520).
+
+Both from the 2026-08-03 SQLi triage, which found **0 confirmed** injection
+findings across 33 reports but noted two things worth tightening in the one file
+that genuinely builds SQL by string interpolation.
+
+**1. The read-only flag was consulted on `/mcp/execute` and not `/mcp/query`.**
+Harmless as it stood — `SQLQueryRequest` already forbids anything but `SELECT`,
+and the sync executor never commits — but it left the guarantee resting on a
+single check. A read-only database should refuse a write regardless of which
+endpoint asks, and regardless of a future edit relaxing the validator.
+
+**2. The comment denylist rejected legitimate queries.** `--` and `/*` were
+matched against the raw query text, so `WHERE note = '--'` or a path literal
+containing `/*` was refused. Usability, not security — but a security control
+that blocks ordinary work gets routed around, which is how it stops being a
+control.
+
+The relaxation only holds if literal-stripping **fails closed**, which is what
+most of these tests are about: an unterminated quote must not let a real comment
+token through.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from api.database_mcp import (
+    _is_readonly_statement,
+    _strip_sql_string_literals,
+    validate_sql_query,
+)
+
+# --- literal stripping ------------------------------------------------------
+
+
+def test_quoted_spans_are_blanked_but_length_is_preserved():
+    out = _strip_sql_string_literals("SELECT * FROM t WHERE a = 'xx'")
+    assert len(out) == len("SELECT * FROM t WHERE a = 'xx'")
+    assert "xx" not in out
+    assert out.startswith("SELECT * FROM t WHERE a = ")
+
+
+def test_a_doubled_quote_escape_is_handled():
+    """SQLite escapes a quote by doubling it: 'it''s'."""
+    out = _strip_sql_string_literals("SELECT 'it''s' AS x")
+    assert "AS x" in out, "the escape ended the literal early and ate the rest"
+
+
+def test_unbalanced_quoting_returns_the_text_unchanged():
+    """Fail closed: otherwise a trailing quote hides everything after it."""
+    sql = "SELECT * FROM t WHERE a = 'unterminated -- DROP"
+    assert _strip_sql_string_literals(sql) == sql
+
+
+# --- the comment relaxation -------------------------------------------------
+
+
+def test_a_comment_token_inside_a_literal_is_allowed():
+    """The usability half: this is ordinary SQL, not an injection."""
+    assert validate_sql_query("SELECT * FROM notes WHERE body = '--'") is True
+    assert validate_sql_query("SELECT * FROM files WHERE path = '/*.py'") is True
+
+
+def test_a_real_line_comment_is_still_blocked():
+    assert validate_sql_query("SELECT * FROM t -- drop everything") is False
+
+
+def test_a_real_block_comment_is_still_blocked():
+    assert validate_sql_query("SELECT * FROM t /* hidden */") is False
+
+
+def test_a_comment_after_an_unterminated_literal_is_still_blocked():
+    """The case that makes fail-closed load-bearing.
+
+    With naive stripping the trailing quote would put `-- ...` "inside a
+    literal" and hide precisely what this check exists to catch.
+    """
+    assert validate_sql_query("SELECT * FROM t WHERE a = 'x -- DROP TABLE t") is False
+
+
+def test_stacked_statements_are_still_blocked_regardless_of_quoting():
+    """Only the comment tokens were relaxed; the rest still match raw text."""
+    assert validate_sql_query("SELECT 1; DROP TABLE users") is False
+    assert validate_sql_query("SELECT 1; DELETE FROM users") is False
+    assert validate_sql_query("SELECT 1 ATTACH DATABASE '/tmp/x' AS y") is False
+
+
+# --- the read-only gate -----------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "sql",
+    ["SELECT 1", "  select 1", "WITH t AS (SELECT 1) SELECT * FROM t", "EXPLAIN SELECT 1", "PRAGMA table_info(x)"],
+)
+def test_read_shapes_are_recognised(sql):
+    assert _is_readonly_statement(sql) is True
+
+
+@pytest.mark.parametrize(
+    "sql", ["DELETE FROM t", "UPDATE t SET a = 1", "INSERT INTO t VALUES (1)", "DROP TABLE t", "VACUUM"]
+)
+def test_write_shapes_are_not(sql):
+    assert _is_readonly_statement(sql) is False
+
+
+def test_an_unrecognised_statement_is_treated_as_a_write():
+    """Allow-list, not denylist: a keyword nobody thought of must fail closed."""
+    assert _is_readonly_statement("REINDEX t") is False
+    assert _is_readonly_statement("") is False
+    assert _is_readonly_statement("   ") is False


### PR DESCRIPTION
## Thinking Path

Two observations from the 2026-08-03 SQLi triage, which found **0 confirmed** injection findings across 33 reports but flagged these in `database_mcp.py` — the one file in either backend that genuinely builds SQL by string interpolation on a raw `sqlite3` cursor.

**Neither was a vulnerability**, and this PR does not claim to fix one. Both are about a control resting on less than it could.

**The read-only flag was consulted on `/mcp/execute` and not `/mcp/query`.** Harmless as it stood: `SQLQueryRequest`'s validator already forbids anything but `SELECT`, and the sync executor never commits. But it left the guarantee resting on one check, where two independent ones cost nothing — and a future edit relaxing the validator would silently remove the only one.

**The comment denylist rejected legitimate queries.** `--` and `/*` were matched against raw query text, so `WHERE note = '--'` or a path literal containing `/*` was refused. That is usability, not security — but a control that blocks ordinary work gets routed around, and then it is not a control.

## What Changed

`autobot-backend/api/database_mcp.py`

**`_is_readonly_statement()`** — deliberately an **allow-list** (`SELECT`, `WITH`, `EXPLAIN`, `PRAGMA`), not a denylist of write verbs. A SQLite keyword nobody enumerated must fail closed; a denylist gets that backwards.

**`_strip_sql_string_literals()`** — blanks quoted spans so comment tokens inside them are ignored. Three things it gets right:

- Quoted content becomes spaces rather than being deleted, so the result is the same length and offsets stay meaningful.
- SQLite's doubled-quote escape (`'it''s'`) falls out naturally — the second quote of the pair opens a span the next character closes.
- **It fails closed.** On unbalanced quoting it returns the input unchanged. Without that, a trailing `'` would place the rest of the query "inside a literal" and hide exactly what the check exists to find.

`BLOCKED_SQL_PATTERNS` splits in two: the stacked-statement and `ATTACH`/`DETACH` patterns still match the **raw** text, since a stacked statement must be caught wherever it appears. Only the two comment tokens move to the literal-stripped text.

## Verification

```console
$ python3 -m pytest autobot-backend/api/database_mcp_query_guards_13520_test.py \
                    autobot-backend/tests/test_startup_imports.py -q
371 passed
```

19 new tests. Invert-tested, each failing on its own regression:

```console
$ # literal-stripping made to fail OPEN on unbalanced quotes
2 failed, 17 passed
$ # read-only check turned into a denylist
1 failed, 18 passed
$ # restored
19 passed
```

The two tests that fail in the first case are the ones that matter: `test_unbalanced_quoting_returns_the_text_unchanged` and `test_a_comment_after_an_unterminated_literal_is_still_blocked`. The relaxation is only safe *because* stripping fails closed, so that property is pinned directly rather than assumed.

`test_stacked_statements_are_still_blocked_regardless_of_quoting` guards the other direction — that relaxing comment tokens did not relax anything else.

## Context

The same triage reviewed this file end to end and found its layering sound: admin-only router dependency, `DATABASE_WHITELIST`, a `SELECT`-only Pydantic validator, a bounded `limit: int`, rate limiting, and `_validate_sql_identifier` + bracket-quoting on its two f-string identifier sites. These two changes add to that rather than repair it.

Closes #13520
Refs #13519

## Model Used

Opus 5 (1M context)
