### PR TITLE
docs(security-scan): record the SQLAlchemy-Core rule misfire and cover executescript (#13519)

### DIFF
--- a/.semgrep/rules.yaml
+++ b/.semgrep/rules.yaml
@@ -109,6 +109,11 @@ rules:
           - pattern: $DB.execute("..." + $VAR + "...")
           - pattern: $DB.execute("..." + $VAR)
           - pattern: $DB.execute($VAR + "...")
+          # #13519: executescript takes a whole SQL script and cannot take bound
+          # parameters at all, so interpolation into it is strictly worse than
+          # into execute(). It was the one construction shape this rule missed.
+          - pattern: $DB.executescript(f"...{$VAR}...")
+          - pattern: $DB.executescript("..." % $VAR)
       - pattern-not: $DB.execute(f"PRAGMA table_info([{$VAR}])")
     message: >
       SQL query built with string interpolation/concatenation risks SQL
@@ -118,6 +123,13 @@ rules:
     metadata:
       category: security
       cwe: CWE-89
+      # #13519: this rule matches on how the SQL is CONSTRUCTED, which is why it
+      # is the one worth having. The platform "SQL Injection with FastAPI" rule
+      # matches on taint SHAPE instead: it reported 33 sites, all false positives
+      # (SQLAlchemy Core constructs assembled across statements, which its taint
+      # tracker mistakes for strings), and MISSED api/database_mcp.py — the only
+      # file in either backend that genuinely interpolates SQL. Triage that rule
+      # family as a batch; see docs/developer/CODEQL_SUPPRESSION.md.
 
   # ── Unsafe deserialisation ────────────────────────────────────────────────────
 
@@ -313,3 +325,4 @@ rules:
         - autobot-frontend/src/**
     metadata:
       category: best-practice
+

--- a/docs/developer/CODEQL_SUPPRESSION.md
+++ b/docs/developer/CODEQL_SUPPRESSION.md
@@ -1,4 +1,8 @@
-# CodeQL False-Positive Suppression — How It Actually Works
+# Static-Analysis False-Positive Suppression — How It Actually Works
+
+> Covers **CodeQL** (most of this file) and **Semgrep** (see the second-engine
+> section near the end). The filename stays `CODEQL_SUPPRESSION.md` because
+> `.github/codeql/codeql-config.yml` links to it by path.
 
 > **TL;DR:** Inline `# codeql[query-id]` / `# lgtm[query-id]` comments do **not**
 > dismiss GitHub code-scanning alerts in this repository. They are non-functional.
@@ -79,6 +83,57 @@ API in #12280. Treat them as historical human annotations only. **Do not add new
 ones.** Removing an existing one is a deliberate follow-up task, not a drive-by
 edit: altering or deleting a marked line changes the alert's location fingerprint
 and can transiently **re-open** the dismissed alert until it is re-dismissed.
+
+## Semgrep is a second engine, and it ignores CodeQL suppressions (#13519)
+
+The 2026-08-03 batch made this concrete. Six `filesystem_mcp.py` sites carried
+`# codeql[py/path-injection]` markers, and a **Semgrep** rule ("Path Manipulation
+with aiofiles via fastapi") reported them anyway.
+
+That is expected — CodeQL suppression syntax means nothing to Semgrep — but it
+means **a suppression strategy that covers only one engine looks like it is
+working while doing nothing.** Any decision to suppress must state which engine
+it applies to.
+
+Semgrep in CI runs **only** `.semgrep/rules.yaml`
+([`security.yml`](../../.github/workflows/security.yml)); the community and Pro
+configs need `SEMGREP_APP_TOKEN` and are unavailable there. So a batch citing
+rule names absent from that file did **not** come from this repo's CI, and cannot
+be tuned by editing anything in this repo. Tuning belongs in the platform policy
+that produced it.
+
+### Known systematic misfire: FastAPI SQL-injection rules vs SQLAlchemy Core
+
+**33 of 33 findings in the 2026-08-03 SQLi batch were false positives.** Every
+site executed a SQLAlchemy 2.0 Core/ORM construct — `select()` / `update()` /
+`delete()` assembled with `.where()`, `.order_by()`, `.offset()`, `.limit()`. No
+site built SQL by concatenation or f-string; all request-derived values arrive as
+**bound parameters** via the SQLAlchemy compiler.
+
+The rule fires on the shape `value_from_Query(...) → … → db.execute(var)`. Because
+the query is assembled across several statements (`query = select(...)`, then
+`query = query.where(...)`), the taint tracker loses the fact that the sink is a
+typed expression tree rather than a string, and reports the `db.execute(query)`
+line. **This codebase uses that idiom almost universally**, so the rule produces a
+full batch of false positives on every scan.
+
+The clearest evidence it matches on *shape* rather than on SQL construction:
+`autobot-backend/api/database_mcp.py` is the only file in either backend that
+genuinely builds SQL by string interpolation on a raw `sqlite3` cursor — and it
+was **absent** from the 33. 33 reports on safe ORM code, zero on the one
+string-SQL file.
+
+**Triage this rule family as a batch, not site by site.** A finding against it is
+only interesting if the sink receives a `str`/f-string rather than a construct —
+which is the one thing to check before spending time on it.
+
+### Point scans at `Dev_new_gui`, not `main`
+
+The same batch was scanned against `main`, then ~682 commits behind
+`Dev_new_gui`, so **every line number had to be re-located by content search**.
+Three `code_sync.py` findings landed on a function signature, a `return False`
+and a docstring — lines with no path expression at all. `main` is a strict
+ancestor of `Dev_new_gui`; scanning it reports on code no one is running.
 
 ## References
 


### PR DESCRIPTION
## Thinking Path

#13519 asked to tune the rule that produced 33 false positives. **It cannot be tuned from this repo**, and finding that out changed what the fix is.

CI Semgrep runs **only** `.semgrep/rules.yaml` — `security.yml:201` says so explicitly, because the community and Pro configs need `SEMGREP_APP_TOKEN` and are unavailable there. The rule that fired ("SQL Injection with FastAPI") is not in that file. So the 33-finding batch did not come from this repo's CI, and no edit here suppresses it; that belongs in the platform policy that produced it.

What *can* be fixed here is the two things that made the batch expensive: nobody had written down why the rule misfires, and CI's own coverage had a gap in the direction that actually matters.

## What Changed

**`docs/developer/CODEQL_SUPPRESSION.md`** — a new section on Semgrep as a second engine, covering:

- **CodeQL suppressions mean nothing to Semgrep.** Six `filesystem_mcp.py` sites carried `# codeql[py/path-injection]` and a Semgrep rule reported them anyway. A suppression strategy covering one engine *looks* like it is working while doing nothing.
- **The systematic misfire, with its evidence.** The rule matches the shape `value_from_Query(...) → … → db.execute(var)`; because a query is assembled across statements (`query = select(...)`, then `query = query.where(...)`), the taint tracker loses that the sink is a typed expression tree rather than a string. This codebase uses that idiom almost universally, so the rule produces a full batch every scan. Triage it as a batch — a finding is only interesting if the sink receives a `str`/f-string.
- **Point scans at `Dev_new_gui`.** The batch ran against `main`, ~682 commits behind, so every line number had to be re-located by content; three findings landed on a function signature, a `return False` and a **docstring**.

The file's title widens to "Static-Analysis…"; the filename stays because `.github/codeql/codeql-config.yml` links to it by path.

**`.semgrep/rules.yaml`** — `autobot-sql-string-format` gains `executescript` coverage.

## A duplicate I wrote and then removed

I first added a new `autobot-sql-string-interpolation` rule — then found `autobot-sql-string-format` already covers `execute()` with f-strings, `%` and `+`, including a `pattern-not` for the legitimate `PRAGMA table_info` case. Adding a second rule for the same invariant is the canonical-source violation this codebase keeps paying for, so it is gone; the one genuinely missing shape (`executescript`, which cannot take bound parameters *at all*, making interpolation into it strictly worse than into `execute`) went into the existing rule instead.

That rule is also the answer to the misfire, and the metadata now says why: **it matches on how the SQL is constructed**, so it cannot fire on a `select()` expression tree, and it does fire on the real thing. The platform rule matched on taint shape — reporting 33 safe sites and **missing** `api/database_mcp.py`, the only file in either backend that genuinely interpolates SQL.

## Verification

```console
$ python3 -c 'import yaml; ...'
17 rules, all with id/message/languages

$ # patterns matched by autobot-sql-string-format after the change
   $DB.execute(f"...{$VAR}...")
   $DB.execute("..." % $VAR)
   $DB.execute("..." + $VAR + "...")
   $DB.execute("..." + $VAR)
   $DB.execute($VAR + "...")
   $DB.executescript(f"...{$VAR}...")     <- new
   $DB.executescript("..." % $VAR)        <- new
```

The three existing `executescript` call sites (`conversation_file_manager.py:493`, `transcriber/database.py:125`, `knowledge/pipeline/loaders/sqlite_loader.py:99`) all pass a module constant, so none matches the new patterns — the rule targets interpolation, not the call.

**Not verified by running Semgrep**: it is not installed in this environment, so the rule is checked structurally rather than executed. CI runs it on this PR, which is where a malformed pattern would surface.

## Scope

The platform-side tuning remains open — it is not a repo change. #13519 stays open for it, with the analysis now recorded so the next triage does not re-derive it.

Refs #13519, #13520

## Model Used

Opus 5 (1M context)
