### PR TITLE
fix(lint): keep prose out of the nosec test-id list (#13521)

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -219,6 +219,9 @@ jobs:
     - name: Check script exec bits agree with how the docs invoke them (#13355)
       run: python3 scripts/check_script_exec_bits.py
 
+    - name: Check nosec annotations keep prose out of the test-id list (#13521)
+      run: python3 scripts/check_nosec_format.py
+
     - name: Check for unused imports with autoflake
       run: |
         python3 -m autoflake --check --recursive \

--- a/autobot-backend/a2a/pii_pipeline.py
+++ b/autobot-backend/a2a/pii_pipeline.py
@@ -50,7 +50,7 @@ class PIIAction(str, Enum):
     BLOCK = "block"  # Reject the entire outbound send
     REDACT = "redact"  # Replace with [REDACTED:type]
     HASH = "hash"  # Replace with SHA-256 prefix (non-reversible)
-    PASS = "pass"  # nosec B105 - enum value for PII handling policy, not a password
+    PASS = "pass"  # nosec B105  # enum value for PII handling policy, not a password
 
 
 class PIIType(str, Enum):
@@ -66,7 +66,7 @@ class PIIType(str, Enum):
     INTERNAL_HOSTNAME = "INTERNAL_HOSTNAME"
     CUSTOMER_ID = "CUSTOMER_ID"
     HIGH_ENTROPY_STRING = "HIGH_ENTROPY_STRING"
-    BEARER_TOKEN = "BEARER_TOKEN"  # nosec B105 - enum value for PII type, not a credential
+    BEARER_TOKEN = "BEARER_TOKEN"  # nosec B105  # enum value for PII type, not a credential
     PRIVATE_IP = "PRIVATE_IP"
 
 

--- a/autobot-backend/agent_loop/pre_action_verifier.py
+++ b/autobot-backend/agent_loop/pre_action_verifier.py
@@ -131,7 +131,7 @@ def _threshold_for_tool(tool_name: str) -> float:
 class VerifierVerdict(str, Enum):
     """Decision produced by the adversarial verifier."""
 
-    PASS = "PASS"  # nosec B105 - verifier verdict label, not a credential; no flaw found — allow
+    PASS = "PASS"  # nosec B105  # verifier verdict label, not a credential; no flaw found — allow
     BLOCK = "BLOCK"  # Flaw found — block or escalate to human.
     SKIP = "SKIP"  # Verifier disabled or unavailable — allow through.
 

--- a/autobot-backend/agent_loop/test_loop_repetition.py
+++ b/autobot-backend/agent_loop/test_loop_repetition.py
@@ -131,12 +131,16 @@ def test_hash_dict_args_unchanged():
     """Dict args continue to produce the same stable hash as before the fix."""
     tool = _make_tool(
         "read_file",
-        {"path": "/tmp/x", "encoding": "utf-8"},  # nosec B108 - test/controlled code uses tmpdir intentionally
+        {"path": "/tmp/x", "encoding": "utf-8"},  # nosec B108  # test/controlled code uses tmpdir intentionally
     )
     expected_canonical = json.dumps(
         {
             "n": "read_file",
-            "a": {"path": "/tmp/x", "encoding": "utf-8"},  # nosec B108 - test/controlled code uses tmpdir intentionally
+            "a": {
+                # test/controlled code uses tmpdir intentionally
+                "path": "/tmp/x",  # nosec B108
+                "encoding": "utf-8",
+            },
         },
         sort_keys=True,
     )

--- a/autobot-backend/agents/agent_models_e2e_test.py
+++ b/autobot-backend/agents/agent_models_e2e_test.py
@@ -14,7 +14,7 @@ reports which resolved models are actually pulled; that probe is operator
 diagnostics, not an assertion, so it stays out of the test function.
 """
 
-import subprocess  # nosec B404 - fixed argv, no shell, operator diagnostics only
+import subprocess  # nosec B404  # fixed argv, no shell, operator diagnostics only
 import sys
 
 from autobot_shared.ssot_config import config
@@ -53,7 +53,7 @@ def test_agent_models_resolve():
 def _available_ollama_models() -> set[str]:
     """Return model names reported by a local Ollama install (empty when absent)."""
     try:
-        result = subprocess.run(  # nosec B603 - fixed argv, shell=False
+        result = subprocess.run(  # nosec B603  # fixed argv, shell=False
             ["ollama", "list"],
             capture_output=True,
             text=True,

--- a/autobot-backend/agents/agent_orchestration/rl_router.py
+++ b/autobot-backend/agents/agent_orchestration/rl_router.py
@@ -126,8 +126,8 @@ class RLRouter(AsyncRedisClientMixin):
 
         import random
 
-        if random.random() < epsilon:  # nosec B311 - RL epsilon-greedy exploration, not cryptographic
-            agent_id = random.choice(available_agents)  # nosec B311 - non-crypto random selection for RL
+        if random.random() < epsilon:  # nosec B311  # RL epsilon-greedy exploration, not cryptographic
+            agent_id = random.choice(available_agents)  # nosec B311  # non-crypto random selection for RL
             logger.debug("RL explore: state=%s agent=%s eps=%.3f", state_key, agent_id, epsilon)
         else:
             agent_id = await self._greedy_select(state_key, available_agents)
@@ -247,7 +247,7 @@ class RLRouter(AsyncRedisClientMixin):
                 best_agents = [agent]
             elif q == best_q:
                 best_agents.append(agent)
-        return random.choice(best_agents)  # nosec B311 - RL tie-breaking selection, not cryptographic
+        return random.choice(best_agents)  # nosec B311  # RL tie-breaking selection, not cryptographic
 
     async def _agent_confidence(self, state_key: str, agent_id: str) -> float:
         """Map Q-value to confidence in [0.6, 1.0]."""

--- a/autobot-backend/agents/system_command_agent.py
+++ b/autobot-backend/agents/system_command_agent.py
@@ -306,7 +306,7 @@ class SystemCommandAgent(StandardizedAgent):
                 if result["exit_code"] == 0:
                     logger.info("Detected package manager: %s", pm_name)
                     return pm_name
-            except Exception:  # nosec B112 - intentional: skip failing PMs
+            except Exception:  # nosec B112  # intentional: skip failing PMs
                 continue
 
         return None

--- a/autobot-backend/agents/web_researcher.py
+++ b/autobot-backend/agents/web_researcher.py
@@ -244,9 +244,9 @@ class BrowserFingerprint:
         return {
             "user_agent": random.choice(
                 self.USER_AGENTS
-            ),  # nosec B311 - browser fingerprint sampling, not cryptographic
-            "viewport": random.choice(self.VIEWPORTS),  # nosec B311 - non-crypto viewport selection
-            "timezone": random.choice(  # nosec B311 - non-crypto timezone selection
+            ),  # nosec B311  # browser fingerprint sampling, not cryptographic
+            "viewport": random.choice(self.VIEWPORTS),  # nosec B311  # non-crypto viewport selection
+            "timezone": random.choice(  # nosec B311  # non-crypto timezone selection
                 [
                     "America/New_York",
                     "America/Los_Angeles",
@@ -256,14 +256,14 @@ class BrowserFingerprint:
             ),
             "language": random.choice(
                 ["en-US,en", "en-GB,en", "en-CA,en"]
-            ),  # nosec B311 - non-crypto language selection
+            ),  # nosec B311  # non-crypto language selection
             "platform": random.choice(
                 ["Win32", "MacIntel", "Linux x86_64"]
-            ),  # nosec B311 - non-crypto platform selection
+            ),  # nosec B311  # non-crypto platform selection
             "webgl_vendor": random.choice(
                 ["Intel Inc.", "NVIDIA Corporation", "AMD"]
-            ),  # nosec B311 - non-crypto vendor selection
-            "hardware_concurrency": random.choice([4, 8, 12, 16]),  # nosec B311 - non-crypto concurrency selection
+            ),  # nosec B311  # non-crypto vendor selection
+            "hardware_concurrency": random.choice([4, 8, 12, 16]),  # nosec B311  # non-crypto concurrency selection
         }
 
     def get_fingerprint(self) -> Dict[str, Any]:
@@ -891,7 +891,7 @@ class WebResearcher:
     async def _random_delay(self, min_seconds: float, max_seconds: float):
         """Add random delay to mimic human behavior."""
         await asyncio.sleep(
-            random.uniform(min_seconds, max_seconds)  # nosec B311 - human behavior simulation delay, not cryptographic
+            random.uniform(min_seconds, max_seconds)  # nosec B311  # human behavior simulation delay, not cryptographic
         )
 
     # -------------------------------------------------------------------

--- a/autobot-backend/ai_hardware_accelerator.py
+++ b/autobot-backend/ai_hardware_accelerator.py
@@ -623,7 +623,7 @@ class AIHardwareAccelerator:
 
         self.clip_processor = CLIPProcessor.from_pretrained(
             "openai/clip-vit-base-patch32", resume_download=True
-        )  # nosec B615 - HuggingFace model loaded by name; revision pinning managed operationally
+        )  # nosec B615  # HuggingFace model loaded by name; revision pinning managed operationally
         self.clip_model = CLIPModel.from_pretrained(  # nosec B615
             "openai/clip-vit-base-patch32",
             torch_dtype=(torch.float16 if torch.cuda.is_available() else torch.float32),
@@ -641,7 +641,7 @@ class AIHardwareAccelerator:
 
         self.wav2vec_processor = Wav2Vec2Processor.from_pretrained(
             "facebook/wav2vec2-base-960h", resume_download=True
-        )  # nosec B615 - HuggingFace model loaded by name; revision pinning managed operationally
+        )  # nosec B615  # HuggingFace model loaded by name; revision pinning managed operationally
         self.wav2vec_model = Wav2Vec2Model.from_pretrained(  # nosec B615
             "facebook/wav2vec2-base-960h",
             torch_dtype=(torch.float16 if torch.cuda.is_available() else torch.float32),

--- a/autobot-backend/api/analytics_evolution.py
+++ b/autobot-backend/api/analytics_evolution.py
@@ -889,7 +889,7 @@ def _aggregate_by_granularity(data: List[Dict[str, Any]], granularity: str) -> L
 
             aggregated[key].append(point)
         except Exception:
-            continue  # nosec B112 - Skipping malformed data points is intentional
+            continue  # nosec B112  # Skipping malformed data points is intentional
 
     # Average values for each period
     result = []
@@ -939,23 +939,27 @@ def _create_demo_data_point(current: datetime, start: datetime, base_score: floa
     return {
         "timestamp": current.isoformat(),
         "overall_score": min(
-            100, max(0, base_score + trend + random.uniform(-3, 3))  # nosec B311 - analytics variance noise, not
+            100, max(0, base_score + trend + random.uniform(-3, 3))  # nosec B311  # analytics variance noise, not
         ),
         "maintainability": min(
-            100, max(0, 75 + trend * 0.8 + random.uniform(-2, 2))  # nosec B311 - analytics variance noise
+            100, max(0, 75 + trend * 0.8 + random.uniform(-2, 2))  # nosec B311  # analytics variance noise
         ),
         "testability": min(
-            100, max(0, 65 + trend * 0.5 + random.uniform(-2, 2))  # nosec B311 - analytics variance noise
+            100, max(0, 65 + trend * 0.5 + random.uniform(-2, 2))  # nosec B311  # analytics variance noise
         ),
         "documentation": min(
-            100, max(0, 60 + trend * 0.3 + random.uniform(-2, 2))  # nosec B311 - analytics variance noise
+            100, max(0, 60 + trend * 0.3 + random.uniform(-2, 2))  # nosec B311  # analytics variance noise
         ),
         "complexity": min(
-            100, max(0, 80 + trend * 0.6 + random.uniform(-2, 2))  # nosec B311 - analytics variance noise
+            100, max(0, 80 + trend * 0.6 + random.uniform(-2, 2))  # nosec B311  # analytics variance noise
         ),
-        "security": min(100, max(0, 78 + trend * 0.4 + random.uniform(-1, 1))),  # nosec B311 - analytics variance noise
+        "security": min(
+            # analytics variance noise
+            100,
+            max(0, 78 + trend * 0.4 + random.uniform(-1, 1)),  # nosec B311
+        ),
         "performance": min(
-            100, max(0, 72 + trend * 0.7 + random.uniform(-2, 2))  # nosec B311 - analytics variance noise
+            100, max(0, 72 + trend * 0.7 + random.uniform(-2, 2))  # nosec B311  # analytics variance noise
         ),
         "total_files": 350 + days_elapsed,
         "total_lines": 65000 + days_elapsed * 100,

--- a/autobot-backend/api/analytics_precommit.py
+++ b/autobot-backend/api/analytics_precommit.py
@@ -102,7 +102,7 @@ _config_lock = threading.Lock()
 def get_staged_files() -> list[str]:
     """Get list of staged files from git."""
     try:
-        result = subprocess.run(  # nosec B603 B607 - fixed argv, no user input
+        result = subprocess.run(  # nosec B603 B607  # fixed argv, no user input
             ["git", "diff", "--cached", "--name-only", "--diff-filter=ACMR"],
             capture_output=True,
             text=True,
@@ -120,7 +120,7 @@ def get_file_content(filepath: str) -> str | None:
     """Get content of a file."""
     try:
         # Try to get staged content first
-        result = subprocess.run(  # nosec B603 B607 - fixed argv, no user input
+        result = subprocess.run(  # nosec B603 B607  # fixed argv, no user input
             ["git", "show", f":{filepath}"],
             capture_output=True,
             text=True,
@@ -659,7 +659,7 @@ async def get_summary(
     if total_checks == 0:
         return {
             "total_runs": 0,
-            "pass_rate": 0,  # nosec B105 - dict key 'pass_rate' with numeric value, not a password
+            "pass_rate": 0,  # nosec B105  # dict key 'pass_rate' with numeric value, not a password
             "average_duration_ms": 0,
             "common_issues": [],
         }

--- a/autobot-backend/api/auth.py
+++ b/autobot-backend/api/auth.py
@@ -564,7 +564,7 @@ def _decode_refresh_token(token: str) -> Dict:
     mw = get_auth_middleware()
     token_alg = _peek_alg(token)
     try:
-        if token_alg == "RS256":  # nosec B105 - JWT algorithm identifier, not a credential
+        if token_alg == "RS256":  # nosec B105  # JWT algorithm identifier, not a credential
             payload = decode_jwt_no_verify_exp(
                 token,
                 public_key=mw.jwt_public_key,
@@ -712,7 +712,7 @@ async def validate_token(
     # Step 2: try decode ignoring expiry to distinguish expired vs. invalid
     token_alg = _peek_alg(token)
     try:
-        if token_alg == "RS256":  # nosec B105 - JWT algorithm identifier, not a credential
+        if token_alg == "RS256":  # nosec B105  # JWT algorithm identifier, not a credential
             expired_payload = decode_jwt_no_verify_exp(token, public_key=mw.jwt_public_key, algorithms=["RS256"])
         else:
             expired_payload = decode_jwt_no_verify_exp(token, secret=mw.jwt_secret, algorithms=["HS256"])

--- a/autobot-backend/api/batch_jobs_schedules_test.py
+++ b/autobot-backend/api/batch_jobs_schedules_test.py
@@ -227,7 +227,7 @@ _real_load_schemas_workflows()
 _pkg_stub("constants")
 _leaf_stub(
     "constants.path_constants",
-    PATH=types.SimpleNamespace(PROJECT_ROOT="/tmp"),  # nosec B108 - test/controlled code uses tmpdir intentionally
+    PATH=types.SimpleNamespace(PROJECT_ROOT="/tmp"),  # nosec B108  # test/controlled code uses tmpdir intentionally
 )
 _leaf_stub("constants.threshold_constants", TimingConstants=MagicMock())
 

--- a/autobot-backend/api/chat_phase2_test.py
+++ b/autobot-backend/api/chat_phase2_test.py
@@ -168,7 +168,7 @@ class TestDiskWriteBeforeRedis:
                 pass
 
             def _get_chats_directory(self):
-                return "/tmp/chat_test"  # nosec B108 - test/controlled code uses tmpdir intentionally
+                return "/tmp/chat_test"  # nosec B108  # test/controlled code uses tmpdir intentionally
 
             async def _ensure_chats_directory_exists(self, _):
                 pass
@@ -196,7 +196,7 @@ class TestDiskWriteBeforeRedis:
 
         with patch(
             "autobot_shared.security.path_validator.validate_relative_path",
-            return_value="/tmp/s.json",  # nosec B108 - test/controlled code uses tmpdir intentionally
+            return_value="/tmp/s.json",  # nosec B108  # test/controlled code uses tmpdir intentionally
         ):
             await mgr.save_session("sess-xyz")
 

--- a/autobot-backend/api/codebase_analytics/analyzers.py
+++ b/autobot-backend/api/codebase_analytics/analyzers.py
@@ -74,7 +74,7 @@ _JS_API_PATH_RE = re.compile(r'[\'"`](/api/[^\'"` ]+)[\'"`]')
 
 # Issue #380: Module-level frozensets for file operation safety patterns
 _LOG_INDICATORS = frozenset({"log", "logs", ".log", "logging", "debug", "trace"})
-# nosec B108 - These are string patterns for detection, not actual temp directory usage
+# nosec B108  # These are string patterns for detection, not actual temp directory usage
 _TEMP_INDICATORS = frozenset({"tmp", "temp", "tempfile", "temporary", "/tmp/"})  # nosec B108
 _SAFE_FILE_TYPES = frozenset(
     {
@@ -776,8 +776,8 @@ def _extract_class_info(node: ast.ClassDef) -> Dict:
 DEFAULT_HARDCODE_SEVERITY: Dict[str, str] = {
     "ip": "high",
     "api_key": "high",
-    "password": "high",  # nosec B105 - dict mapping security field names to severity labels, not a password
-    "secret": "high",  # nosec B105 - dict mapping security field names to severity labels, not a secret
+    "password": "high",  # nosec B105  # dict mapping security field names to severity labels, not a password
+    "secret": "high",  # nosec B105  # dict mapping security field names to severity labels, not a secret
     "port": "medium",
     "url": "medium",
     "api_path": "low",

--- a/autobot-backend/api/database_mcp.py
+++ b/autobot-backend/api/database_mcp.py
@@ -286,8 +286,13 @@ def _list_tables_sync(db_path: Path) -> list[dict]:
             # validate_sql_identifier enforces an allowlist as defence-in-depth.
             validate_sql_identifier(table_name, "table name")
             # Bare-assign the SQL so the nosec/nosemgrep stay on the flagged line:
-            # black would split `cursor.execute(f"...")  # nosec` and orphan the
-            # comment onto the `)` line, defeating the suppression (#9489).
+            # black would split a call spanning several lines and orphan the
+            # suppression comment onto the closing paren, defeating it (#9489).
+            #
+            # #13521: this explanation deliberately avoids writing the literal
+            # suppression token followed by prose — bandit parses any such
+            # occurrence as a test-id list and warns once per following word,
+            # even inside a comment that is only talking about it.
             count_sql = f"SELECT COUNT(*) FROM [{table_name}]"  # nosec B608  # nosemgrep: python.lang.security.audit.formatted-sql-query.formatted-sql-query,python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query  # noqa: E501
             cursor.execute(count_sql)
             row_count = cursor.fetchone()[0]

--- a/autobot-backend/api/knowledge_search_aggregator.py
+++ b/autobot-backend/api/knowledge_search_aggregator.py
@@ -721,7 +721,7 @@ async def _get_fact_relations_for_graph(kb: Any, fact_ids: List[str], max_relati
 
             if len(relations) >= max_relations:
                 break
-        except Exception:  # nosec B112 - continue on single fact failure is intentional
+        except Exception:  # nosec B112  # continue on single fact failure is intentional
             continue
 
     return relations

--- a/autobot-backend/api/provider_auth.py
+++ b/autobot-backend/api/provider_auth.py
@@ -305,7 +305,7 @@ async def oauth_initiate(
         authorize_url=req.authorize_url,
         token_url=req.token_url,
         client_id_setting="",
-        client_secret_setting="",  # nosec B106 - setting NAME (empty), not a secret value
+        client_secret_setting="",  # nosec B106  # setting NAME (empty), not a secret value
         default_scopes=scopes or (),
     )
 
@@ -367,7 +367,7 @@ async def oauth_callback(
         authorize_url="",
         token_url=token_url,
         client_id_setting="",
-        client_secret_setting="",  # nosec B106 - setting NAME (empty), not a secret value
+        client_secret_setting="",  # nosec B106  # setting NAME (empty), not a secret value
     )
 
     try:
@@ -378,7 +378,7 @@ async def oauth_callback(
         resp = await exchange_code(
             provider_cfg,
             stored["client_id"],
-            "",  # nosec B106 - PKCE public client: no client_secret
+            "",  # nosec B106  # PKCE public client: no client_secret
             req.code,
             req.redirect_uri,
             stored["verifier"],

--- a/autobot-backend/api/schemas_analytics.py
+++ b/autobot-backend/api/schemas_analytics.py
@@ -2652,7 +2652,7 @@ class NodeType(str, Enum):
     RAISE = "raise"
     BREAK = "break"
     CONTINUE = "continue"
-    PASS = "pass"  # nosec B105 - CFG statement type enum value, not a password
+    PASS = "pass"  # nosec B105  # CFG statement type enum value, not a password
 
 
 class EdgeType(str, Enum):

--- a/autobot-backend/api/schemas_system.py
+++ b/autobot-backend/api/schemas_system.py
@@ -3503,9 +3503,9 @@ class SecretType(str, Enum):
     """Secret type enumeration."""
 
     SSH_KEY = "ssh_key"
-    PASSWORD = "password"  # nosec B105 - enum value  # nosemgrep: autobot-hardcoded-secret-key  # nosemgrep
+    PASSWORD = "password"  # nosec B105  # enum value  # nosemgrep: autobot-hardcoded-secret-key  # nosemgrep
     API_KEY = "api_key"  # nosemgrep: autobot-hardcoded-secret-key  # nosemgrep
-    TOKEN = "token"  # nosec B105 - enum value  # nosemgrep: autobot-hardcoded-secret-key  # nosemgrep
+    TOKEN = "token"  # nosec B105  # enum value  # nosemgrep: autobot-hardcoded-secret-key  # nosemgrep
     CERTIFICATE = "certificate"
     DATABASE_URL = "database_url"
     INFRASTRUCTURE_HOST = "infrastructure_host"

--- a/autobot-backend/api/settings_sync_test.py
+++ b/autobot-backend/api/settings_sync_test.py
@@ -115,7 +115,7 @@ class TestAtomicWriteJson:
             data = {
                 "backend": {
                     "server_host": "0.0.0.0"
-                }  # nosec B104 - intentional bind to all interfaces for service/test
+                }  # nosec B104  # intentional bind to all interfaces for service/test
             }
             await _atomic_write_json(target, data)
             assert target.exists()

--- a/autobot-backend/api/simple_terminal_e2e_test.py
+++ b/autobot-backend/api/simple_terminal_e2e_test.py
@@ -90,7 +90,7 @@ async def test_simple_terminal():
                                 output_received = True
                             elif (
                                 cmd.startswith("cd /tmp")
-                                and "/tmp" in content  # nosec B108 - test/controlled code uses tmpdir intentionally
+                                and "/tmp" in content  # nosec B108  # test/controlled code uses tmpdir intentionally
                             ):
                                 print("✅ cd command worked!")  # noqa: print
                                 output_received = True

--- a/autobot-backend/api/vnc_humanization.py
+++ b/autobot-backend/api/vnc_humanization.py
@@ -32,8 +32,8 @@ def humanize_click_position(x: int, y: int, radius: int = 5) -> Tuple[int, int]:
     """
     offset_x = random.randint(
         -radius, radius
-    )  # nosec B311 - mouse position jitter for UI humanization, not cryptographic
-    offset_y = random.randint(-radius, radius)  # nosec B311 - mouse position jitter for UI humanization
+    )  # nosec B311  # mouse position jitter for UI humanization, not cryptographic
+    offset_y = random.randint(-radius, radius)  # nosec B311  # mouse position jitter for UI humanization
     return (max(0, x + offset_x), max(0, y + offset_y))
 
 
@@ -44,7 +44,7 @@ def humanize_typing_speed() -> float:
     Returns:
         Random delay between 0.05s and 0.15s (typical human typing speed)
     """
-    return random.uniform(0.05, 0.15)  # nosec B311 - keystroke timing simulation, not cryptographic
+    return random.uniform(0.05, 0.15)  # nosec B311  # keystroke timing simulation, not cryptographic
 
 
 def humanize_action_delay() -> float:
@@ -54,7 +54,7 @@ def humanize_action_delay() -> float:
     Returns:
         Random delay between 0.1s and 0.3s (human reaction time)
     """
-    return random.uniform(0.1, 0.3)  # nosec B311 - human reaction time simulation, not cryptographic
+    return random.uniform(0.1, 0.3)  # nosec B311  # human reaction time simulation, not cryptographic
 
 
 def humanize_mouse_movement_delay() -> float:
@@ -64,7 +64,7 @@ def humanize_mouse_movement_delay() -> float:
     Returns:
         Random delay between 0.01s and 0.03s for smooth movement
     """
-    return random.uniform(0.01, 0.03)  # nosec B311 - mouse movement delay simulation, not cryptographic
+    return random.uniform(0.01, 0.03)  # nosec B311  # mouse movement delay simulation, not cryptographic
 
 
 def simulate_mouse_curve(x1: int, y1: int, x2: int, y2: int, steps: int = 10) -> list[Tuple[int, int]]:
@@ -111,7 +111,7 @@ def simulate_mouse_curve(x1: int, y1: int, x2: int, y2: int, steps: int = 10) ->
                 # Sine wave for smooth curve
                 curve_amount = math.sin(t * math.pi) * random.uniform(
                     2, 8
-                )  # nosec B311 - mouse path curve simulation, not cryptographic
+                )  # nosec B311  # mouse path curve simulation, not cryptographic
 
                 x += int(perp_x * curve_amount)
                 y += int(perp_y * curve_amount)
@@ -130,8 +130,8 @@ def humanize_key_press_timing() -> Tuple[float, float]:
         - press_duration: How long the key is held down (0.05-0.12s)
         - release_delay: Delay before next action (0.03-0.08s)
     """
-    press_duration = random.uniform(0.05, 0.12)  # nosec B311 - key press timing simulation, not cryptographic
-    release_delay = random.uniform(0.03, 0.08)  # nosec B311 - key release timing simulation, not cryptographic
+    press_duration = random.uniform(0.05, 0.12)  # nosec B311  # key press timing simulation, not cryptographic
+    release_delay = random.uniform(0.03, 0.08)  # nosec B311  # key release timing simulation, not cryptographic
     return (press_duration, release_delay)
 
 
@@ -144,7 +144,7 @@ def should_add_human_pause() -> bool:
     Returns:
         True if a pause should be added (20% chance), False otherwise
     """
-    return random.random() < 0.2  # nosec B311 - stochastic pause decision for UI humanization, not cryptographic
+    return random.random() < 0.2  # nosec B311  # stochastic pause decision for UI humanization, not cryptographic
 
 
 def humanize_pause_duration() -> float:
@@ -154,4 +154,4 @@ def humanize_pause_duration() -> float:
     Returns:
         Random pause between 0.5s and 2.0s
     """
-    return random.uniform(0.5, 2.0)  # nosec B311 - human thinking pause duration, not cryptographic
+    return random.uniform(0.5, 2.0)  # nosec B311  # human thinking pause duration, not cryptographic

--- a/autobot-backend/api/vnc_manager.py
+++ b/autobot-backend/api/vnc_manager.py
@@ -81,7 +81,7 @@ def is_vnc_running() -> bool:
     """Check if VNC server is running on the canonical desktop display."""
     try:
         # Check for Xtigervnc process on the canonical display (Issue #11579)
-        result = subprocess.run(  # nosec B603 B607 - fixed argv, no user input
+        result = subprocess.run(  # nosec B603 B607  # fixed argv, no user input
             ["pgrep", "-f", f"Xtigervnc {NetworkConstants.DESKTOP_DISPLAY}"],
             capture_output=True,
             timeout=5,
@@ -97,7 +97,7 @@ def _launch_websockify() -> None:
     """Start websockify daemon for noVNC access (TLS-only, proxied by nginx). Ref: #2735."""
     websockify_bind = f"{NetworkConstants.LOCALHOST_NAME}:{NetworkConstants.VNC_PORT}"
     vnc_target = f"{NetworkConstants.LOCALHOST_NAME}:5901"
-    subprocess.Popen(  # nosec B603 B607 - fixed argv, no user input
+    subprocess.Popen(  # nosec B603 B607  # fixed argv, no user input
         [
             "/usr/bin/websockify",
             "--web",
@@ -133,7 +133,7 @@ def start_vnc_server() -> Dict[str, str]:
         }
 
     try:
-        result = subprocess.run(  # nosec B603 B607 - fixed argv, no user input
+        result = subprocess.run(  # nosec B603 B607  # fixed argv, no user input
             [
                 "/usr/bin/vncserver",
                 NetworkConstants.DESKTOP_DISPLAY,
@@ -555,7 +555,7 @@ async def _run_screenshot_capture(argv: list):
     Each command carries a 10s timeout and there are two of them, so running
     these inline blocked the loop for up to 20s per failed capture.
     """
-    return await asyncio.to_thread(  # nosec B603 B607 - fixed argv, no user input
+    return await asyncio.to_thread(  # nosec B603 B607  # fixed argv, no user input
         subprocess.run,
         argv,
         capture_output=True,
@@ -635,7 +635,7 @@ async def vnc_clipboard_sync(
     """
     try:
         # Use xclip to set clipboard content
-        proc = subprocess.Popen(  # nosec B603 B607 - fixed argv, no user input
+        proc = subprocess.Popen(  # nosec B603 B607  # fixed argv, no user input
             ["xclip", "-selection", "clipboard"],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
@@ -750,7 +750,7 @@ async def get_connection_quality_metrics(
 
     # Get websockify process info
     try:
-        result = subprocess.run(  # nosec B603 B607 - fixed argv, no user input
+        result = subprocess.run(  # nosec B603 B607  # fixed argv, no user input
             ["pgrep", "-a", "websockify"],
             capture_output=True,
             text=True,
@@ -830,7 +830,7 @@ def _get_desktop_info() -> Dict[str, str]:
 
     # Screen resolution
     try:
-        result = subprocess.run(  # nosec B603 B607 - fixed argv, no user input
+        result = subprocess.run(  # nosec B603 B607  # fixed argv, no user input
             ["xdpyinfo"],
             capture_output=True,
             text=True,
@@ -849,7 +849,7 @@ def _get_desktop_info() -> Dict[str, str]:
 
     # Active window
     try:
-        result = subprocess.run(  # nosec B603 B607 - fixed argv, no user input
+        result = subprocess.run(  # nosec B603 B607  # fixed argv, no user input
             ["xdotool", "getactivewindow", "getwindowname"],
             capture_output=True,
             text=True,
@@ -863,7 +863,7 @@ def _get_desktop_info() -> Dict[str, str]:
 
     # Window count
     try:
-        result = subprocess.run(  # nosec B603 B607 - fixed argv, no user input
+        result = subprocess.run(  # nosec B603 B607  # fixed argv, no user input
             ["wmctrl", "-l"],
             capture_output=True,
             text=True,
@@ -889,7 +889,7 @@ def _get_process_list() -> List[Dict[str, str]]:
 
     try:
         # Get process list with their display usage
-        result = subprocess.run(  # nosec B603 B607 - fixed argv, no user input
+        result = subprocess.run(  # nosec B603 B607  # fixed argv, no user input
             ["ps", "aux"],
             capture_output=True,
             text=True,

--- a/autobot-backend/api/vnc_mcp.py
+++ b/autobot-backend/api/vnc_mcp.py
@@ -496,7 +496,7 @@ async def desktop_mouse_click_mcp(request: DesktopMouseClickRequest) -> Metadata
     button_map = {"left": "1", "middle": "2", "right": "3"}
     button_num = button_map.get(request.button, "1")
 
-    result = await asyncio.to_thread(  # nosec B603 B607 - fixed argv, validated by _run_xdotool_cmd
+    result = await asyncio.to_thread(  # nosec B603 B607  # fixed argv, validated by _run_xdotool_cmd
         _run_xdotool_cmd, ["mousemove", str(request.x), str(request.y), "click", button_num]
     )
 
@@ -532,7 +532,7 @@ async def desktop_keyboard_type_mcp(request: DesktopKeyboardTypeRequest) -> Meta
             "muted": True,
         }
 
-    result = await asyncio.to_thread(  # nosec B603 B607 - fixed argv, validated by _run_xdotool_cmd
+    result = await asyncio.to_thread(  # nosec B603 B607  # fixed argv, validated by _run_xdotool_cmd
         _run_xdotool_cmd, ["type", "--", request.text]
     )
 
@@ -567,7 +567,7 @@ async def desktop_special_key_mcp(request: DesktopSpecialKeyRequest) -> Metadata
             "muted": True,
         }
 
-    result = await asyncio.to_thread(  # nosec B603 B607 - fixed argv, validated by _run_xdotool_cmd
+    result = await asyncio.to_thread(  # nosec B603 B607  # fixed argv, validated by _run_xdotool_cmd
         _run_xdotool_cmd, ["key", request.key]
     )
 
@@ -583,7 +583,7 @@ async def _run_capture_command(argv: list):
     """Run one screenshot capture command off the event loop. Issue #10785."""
     import subprocess  # nosec B404
 
-    return await asyncio.to_thread(  # nosec B603 B607 - fixed argv, no user input
+    return await asyncio.to_thread(  # nosec B603 B607  # fixed argv, no user input
         subprocess.run,
         argv,
         capture_output=True,
@@ -681,7 +681,7 @@ async def desktop_observe_state_mcp(request: DesktopObserveStateRequest) -> Meta
 
     # Get screen resolution
     try:
-        result = await asyncio.to_thread(  # nosec B603 B607 - fixed argv, no user input
+        result = await asyncio.to_thread(  # nosec B603 B607  # fixed argv, no user input
             subprocess.run,
             ["xdpyinfo"],
             capture_output=True,
@@ -701,7 +701,7 @@ async def desktop_observe_state_mcp(request: DesktopObserveStateRequest) -> Meta
 
     # Get active window info
     try:
-        result = await asyncio.to_thread(  # nosec B603 B607 - fixed argv, no user input
+        result = await asyncio.to_thread(  # nosec B603 B607  # fixed argv, no user input
             subprocess.run,
             ["xdotool", "getactivewindow", "getwindowname"],
             capture_output=True,

--- a/autobot-backend/api/whatsapp_test.py
+++ b/autobot-backend/api/whatsapp_test.py
@@ -48,11 +48,11 @@ class TestSignatureVerification:
 
     def test_valid_signature_accepted(self):
         body = b'{"object":"whatsapp_business_account"}'
-        secret = "top-secret"  # nosec B105 - test fixture
+        secret = "top-secret"  # nosec B105  # test fixture
         assert verify_webhook_signature(body, self._sign(body, secret), secret) is True
 
     def test_tampered_body_rejected(self):
-        secret = "top-secret"  # nosec B105 - test fixture
+        secret = "top-secret"  # nosec B105  # test fixture
         sig = self._sign(b"original", secret)
         assert verify_webhook_signature(b"tampered", sig, secret) is False
 
@@ -226,7 +226,7 @@ class TestRoundTripSignatureOverRealPayload:
     """End-to-end: a signed Meta payload verifies and flattens to one message."""
 
     def test_signed_payload_verifies_and_flattens(self):
-        secret = "app-secret"  # nosec B105 - test fixture
+        secret = "app-secret"  # nosec B105  # test fixture
         payload = {
             "entry": [
                 {

--- a/autobot-backend/api/workflow_secrets.py
+++ b/autobot-backend/api/workflow_secrets.py
@@ -193,7 +193,7 @@ async def update_workflow_secret(
     return WorkflowSecretMetadata(
         id="",
         name=name,
-        secret_type="",  # nosec B106 - empty string for unset secret_type field, not a credential value
+        secret_type="",  # nosec B106  # empty string for unset secret_type field, not a credential value
         scope="workflow",
     )
 

--- a/autobot-backend/async_baseline_performance_test.py
+++ b/autobot-backend/async_baseline_performance_test.py
@@ -294,7 +294,7 @@ class AsyncBaselineTest:
         fail_count = 0
 
         # Create temp directory for test files
-        test_dir = Path("/tmp/autobot_baseline_test")  # nosec B108 - test/controlled code uses tmpdir intentionally
+        test_dir = Path("/tmp/autobot_baseline_test")  # nosec B108  # test/controlled code uses tmpdir intentionally
         test_dir.mkdir(parents=True, exist_ok=True)
 
         async def mixed_io_operation(redis_client, op_id):

--- a/autobot-backend/autobot_memory_graph/secrets.py
+++ b/autobot-backend/autobot_memory_graph/secrets.py
@@ -229,7 +229,7 @@ class SecretManagementMixin:
         if scope and secret_scope != scope:
             return False
 
-        if secret_scope == "session" and session_id:  # nosec B105 - scope enum value
+        if secret_scope == "session" and session_id:  # nosec B105  # scope enum value
             if secret.get("metadata", {}).get("session_id") != session_id:
                 return False
 

--- a/autobot-backend/chat_history/context_overflow.py
+++ b/autobot-backend/chat_history/context_overflow.py
@@ -23,7 +23,7 @@ from autobot_shared.redis_utils import decode_redis_value
 logger = get_logger(__name__)
 
 # Redis key prefixes
-_TOKEN_TRACKER_KEY_PREFIX = "chat:tokens:"  # nosec B105 - Redis key prefix, not a password
+_TOKEN_TRACKER_KEY_PREFIX = "chat:tokens:"  # nosec B105  # Redis key prefix, not a password
 _SUMMARY_MARKER_KEY_PREFIX = "chat:summary_marker:"
 
 # Default thresholds (can be overridden)

--- a/autobot-backend/chat_workflow/manager.py
+++ b/autobot-backend/chat_workflow/manager.py
@@ -1848,7 +1848,7 @@ class ChatWorkflowManager(
             consecutive_invalid_tool_calls,
         )
         _reminder = (
-            f"\n**[SYSTEM] TOOL NAME CORRECTION REQUIRED:**\n"  # nosec B608 - prompt template, not SQL
+            f"\n**[SYSTEM] TOOL NAME CORRECTION REQUIRED:**\n"  # nosec B608  # prompt template, not SQL
             f"Your last {consecutive_invalid_tool_calls} tool call(s) used invalid tool names. "
             "You MUST use ONLY the following tool names:\n"
             "- execute_command: Run shell commands\n"
@@ -1871,7 +1871,7 @@ class ChatWorkflowManager(
             "- delegate: Delegate a subtask to a subordinate agent\n"
             "- respond: Signal task completion with a final message\n"
             "Do NOT invent new tool names. Use ONLY the names listed above.\n\n"
-        )  # nosec B608 - prompt template, not SQL; consecutive_invalid_tool_calls is an int counter
+        )  # nosec B608  # prompt template, not SQL; consecutive_invalid_tool_calls is an int counter
         return _reminder
 
     def _get_continuation_instructions(

--- a/autobot-backend/circuit_breaker.py
+++ b/autobot-backend/circuit_breaker.py
@@ -666,7 +666,7 @@ if __name__ == "__main__":
             """Example flaky service that fails 60% of the time."""
             import random
 
-            if random.random() < 0.6:  # nosec B311 - simulated failure rate for demo/testing purposes
+            if random.random() < 0.6:  # nosec B311  # simulated failure rate for demo/testing purposes
                 raise ConnectionError("Service unavailable")
             return "Service response"
 

--- a/autobot-backend/code_analysis/auto-tools/logging_standardizer.py
+++ b/autobot-backend/code_analysis/auto-tools/logging_standardizer.py
@@ -520,7 +520,7 @@ Import statement has been added: `import {{ devLog }} from '@/utils/devLogger.js
             output_file: Optional path override for the markdown report file
         """
         report_content += (
-            "\n## Next Steps\n"  # nosec B608 - markdown report text, not SQL
+            "\n## Next Steps\n"  # nosec B608  # markdown report text, not SQL
             "1. **Test Development Mode**: Verify logs appear in browser console during development\n"
             "2. **Test Production Build**: Confirm logs are silent in production build\n"
             "3. **Update Build Config**: Ensure NODE_ENV is properly set for different environments\n"

--- a/autobot-backend/code_analysis/scripts/analyze_critical_env_vars.py
+++ b/autobot-backend/code_analysis/scripts/analyze_critical_env_vars.py
@@ -156,7 +156,7 @@ class CriticalEnvAnalyzer:
             "network_hosts": [],
             "network_ports": [],
             "api_urls": [],
-            "file_paths": ["/dev/null", "/tmp"],  # nosec B108 - test/controlled code uses tmpdir intentionally
+            "file_paths": ["/dev/null", "/tmp"],  # nosec B108  # test/controlled code uses tmpdir intentionally
             "timeouts": ["0", "1"],
             "redis_config": [],
         }

--- a/autobot-backend/code_analysis/src/ownership_analyzer.py
+++ b/autobot-backend/code_analysis/src/ownership_analyzer.py
@@ -350,7 +350,7 @@ class OwnershipAnalyzer:
         try:
             relative_path = str(file_path.relative_to(root))
 
-            result = subprocess.run(  # nosec B603 B607 - fixed git argv; file_path is a Path object, no shell
+            result = subprocess.run(  # nosec B603 B607  # fixed git argv; file_path is a Path object, no shell
                 ["git", "blame", "--line-porcelain", str(file_path)],
                 capture_output=True,
                 text=True,

--- a/autobot-backend/code_embedding_generator.py
+++ b/autobot-backend/code_embedding_generator.py
@@ -122,10 +122,10 @@ class CodeEmbeddingGenerator:
 
             self.tokenizer = AutoTokenizer.from_pretrained(
                 self.model_name, resume_download=True
-            )  # nosec B615 - HuggingFace model loaded by name; revision pinning managed operationally
+            )  # nosec B615  # HuggingFace model loaded by name; revision pinning managed operationally
             self.model = AutoModel.from_pretrained(
                 self.model_name, resume_download=True
-            )  # nosec B615 - HuggingFace model loaded by name; revision pinning managed operationally
+            )  # nosec B615  # HuggingFace model loaded by name; revision pinning managed operationally
 
             if self.npu_available:
                 self._convert_to_openvino()

--- a/autobot-backend/code_intelligence/analytics_infrastructure.py
+++ b/autobot-backend/code_intelligence/analytics_infrastructure.py
@@ -516,7 +516,7 @@ class AnalyticsInfrastructureMixin:
         if self._redis_client:
             try:
                 await self._redis_client.close()
-            except Exception:  # nosec B110 - cleanup ignores close errors
+            except Exception:  # nosec B110  # cleanup ignores close errors
                 logger.debug("Suppressed exception in try block", exc_info=True)
             self._redis_client = None
         logger.info("Infrastructure resources cleaned up")

--- a/autobot-backend/code_intelligence/bug_predictor.py
+++ b/autobot-backend/code_intelligence/bug_predictor.py
@@ -29,7 +29,7 @@ Issue #554: Enhanced with Vector/Redis/LLM infrastructure:
 
 import asyncio
 import re
-import subprocess  # nosec B404 - required for git operations
+import subprocess  # nosec B404  # required for git operations
 import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -773,7 +773,7 @@ class BugPredictor(_BaseClass):
         self._change_freq_cache = {}
         self._change_freq_cache_time = time.monotonic()
         try:
-            result = subprocess.run(  # nosec B603 B607 - fixed git argv, no user input
+            result = subprocess.run(  # nosec B603 B607  # fixed git argv, no user input
                 [
                     "git",
                     "log",
@@ -845,7 +845,7 @@ class BugPredictor(_BaseClass):
             for kw in self.bug_keywords:
                 grep_args.extend(["--grep", kw])
 
-            result = subprocess.run(  # nosec B603 B607 - fixed git argv, no user input
+            result = subprocess.run(  # nosec B603 B607  # fixed git argv, no user input
                 [
                     "git",
                     "log",

--- a/autobot-backend/code_intelligence/code_review_engine.py
+++ b/autobot-backend/code_intelligence/code_review_engine.py
@@ -26,7 +26,7 @@ Issue #554: Enhanced with Vector/Redis/LLM infrastructure:
 """
 
 import re
-import subprocess  # nosec B404 - code review tools require subprocess
+import subprocess  # nosec B404  # code review tools require subprocess
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
@@ -876,7 +876,7 @@ class CodeReviewEngine(_BaseClass):
                     logger.warning("Rejected invalid git diff argument: %s", arg)
                     return ""
             cmd = ["git", "diff"] + split_args
-            result = subprocess.run(  # nosec B603 - argv validated by _VALID_GIT_DIFF_ARG_RE above
+            result = subprocess.run(  # nosec B603  # argv validated by _VALID_GIT_DIFF_ARG_RE above
                 cmd,
                 capture_output=True,
                 text=True,

--- a/autobot-backend/code_intelligence/fingerprinting/similarity.py
+++ b/autobot-backend/code_intelligence/fingerprinting/similarity.py
@@ -60,7 +60,7 @@ class SimilarityCalculator:
             "structural": 0.5,
             "token": 0.3,
             "feature": 0.2,
-        }  # nosec B105 - similarity metric weights dict, 'token' key is code token type not a credential
+        }  # nosec B105  # similarity metric weights dict, 'token' key is code token type not a credential
         similarity = (
             weights["structural"] * structural_sim + weights["token"] * token_sim + weights["feature"] * feature_sim
         )

--- a/autobot-backend/code_intelligence/fingerprinting/types.py
+++ b/autobot-backend/code_intelligence/fingerprinting/types.py
@@ -34,7 +34,7 @@ class FingerprintType(Enum):
     AST_STRUCTURAL = "ast_structural"  # Based on AST structure
     AST_NORMALIZED = "ast_normalized"  # Normalized identifiers
     SEMANTIC = "semantic"  # Based on data/control flow
-    TOKEN_SEQUENCE = "token_sequence"  # nosec B105 - enum value for fingerprint strategy type, not a credential
+    TOKEN_SEQUENCE = "token_sequence"  # nosec B105  # enum value for fingerprint strategy type, not a credential
 
 
 class CloneSeverity(Enum):

--- a/autobot-backend/code_intelligence/llm_pattern_analysis/types.py
+++ b/autobot-backend/code_intelligence/llm_pattern_analysis/types.py
@@ -90,7 +90,9 @@ class OptimizationCategory(Enum):
     PROMPT_ENGINEERING = "prompt_engineering"
     CACHING = "caching"
     BATCHING = "batching"
-    TOKEN_OPTIMIZATION = "token_optimization"  # nosec B105 - enum value for LLM optimization strategy, not a credential
+    TOKEN_OPTIMIZATION = (
+        "token_optimization"  # nosec B105  # enum value for LLM optimization strategy, not a credential
+    )
     MODEL_SELECTION = "model_selection"
     RETRY_STRATEGY = "retry_strategy"
     PARALLEL_PROCESSING = "parallel_processing"

--- a/autobot-backend/code_intelligence/pattern_analysis/regex_detector.py
+++ b/autobot-backend/code_intelligence/pattern_analysis/regex_detector.py
@@ -417,7 +417,7 @@ class RegexPatternDetector:
                 # Pattern substitution
                 return "re.sub(r'pattern', 'replacement', text)"
 
-        except Exception:  # nosec B110 - fallback to default suggestion
+        except Exception:  # nosec B110  # fallback to default suggestion
             logger.debug("Suppressed exception in try block", exc_info=True)
 
         return "re.sub(r'pattern', 'replacement', text)"

--- a/autobot-backend/code_intelligence/precommit_analyzer.py
+++ b/autobot-backend/code_intelligence/precommit_analyzer.py
@@ -18,7 +18,7 @@ Parent Epic: #217 - Advanced Code Intelligence
 
 import concurrent.futures
 import re
-import subprocess  # nosec B404 - controlled git process execution
+import subprocess  # nosec B404  # controlled git process execution
 import time
 from dataclasses import dataclass, field
 from enum import Enum
@@ -374,7 +374,7 @@ class PrecommitAnalyzer:
     def get_staged_files(self) -> List[str]:
         """Get list of files staged for commit."""
         try:
-            result = subprocess.run(  # nosec B603 B607 - fixed git argv, no user input
+            result = subprocess.run(  # nosec B603 B607  # fixed git argv, no user input
                 ["git", "diff", "--cached", "--name-only", "--diff-filter=ACMR"],
                 capture_output=True,
                 text=True,
@@ -392,7 +392,7 @@ class PrecommitAnalyzer:
         """Get content of a staged file."""
         try:
             # Try to get staged content first (what will be committed)
-            result = subprocess.run(  # nosec B603 B607 - fixed git argv, no user input
+            result = subprocess.run(  # nosec B603 B607  # fixed git argv, no user input
                 ["git", "show", f":{filepath}"],
                 capture_output=True,
                 text=True,

--- a/autobot-backend/code_intelligence/security/constants.py
+++ b/autobot-backend/code_intelligence/security/constants.py
@@ -51,7 +51,7 @@ class VulnerabilityType(Enum):
     TEMPLATE_INJECTION = "template_injection"
 
     # Sensitive Data Exposure (OWASP A02:2021)
-    # nosec B105 - These are vulnerability TYPE NAMES, not actual secrets
+    # nosec B105  # These are vulnerability TYPE NAMES, not actual secrets
     HARDCODED_SECRET = "hardcoded_secret"  # nosec B105
     HARDCODED_PASSWORD = "hardcoded_password"  # nosec B105
     HARDCODED_API_KEY = "hardcoded_api_key"  # nosec B105
@@ -94,7 +94,7 @@ class VulnerabilityType(Enum):
     INTEGER_OVERFLOW_RISK = "integer_overflow_risk"
 
     # Authentication Issues
-    # nosec B105 - These are vulnerability TYPE NAMES, not actual secrets
+    # nosec B105  # These are vulnerability TYPE NAMES, not actual secrets
     WEAK_PASSWORD_POLICY = "weak_password_policy"  # nosec B105
     MISSING_RATE_LIMITING = "missing_rate_limiting"
     SESSION_FIXATION_RISK = "session_fixation_risk"

--- a/autobot-backend/command_manual_manager.py
+++ b/autobot-backend/command_manual_manager.py
@@ -725,7 +725,7 @@ class CommandManualManager:
         try:
             result = subprocess.run(
                 ["man", command_name], capture_output=True, text=True, timeout=10
-            )  # nosec B603 B607 - command_name validated by _VALID_COMMAND_NAME_RE above
+            )  # nosec B603 B607  # command_name validated by _VALID_COMMAND_NAME_RE above
 
             if result.returncode == 0:
                 return result.stdout

--- a/autobot-backend/config/config_test.py
+++ b/autobot-backend/config/config_test.py
@@ -127,7 +127,7 @@ TEST_RESPONSES = {
     "yes_no": ["y", "n", "yes", "no"],
     "choices": ["1", "2", "3", "4", "5"],
     "commands": ["help", "status", "exit", "quit"],
-    "files": ["test.txt", "/tmp/test", "example.json"],  # nosec B108 - test/controlled code uses tmpdir intentionally
+    "files": ["test.txt", "/tmp/test", "example.json"],  # nosec B108  # test/controlled code uses tmpdir intentionally
     "names": ["test_user", "admin", "user"],
     "urls": [
         "http://localhost:8080",

--- a/autobot-backend/config/defaults.py
+++ b/autobot-backend/config/defaults.py
@@ -256,7 +256,11 @@ def _get_simple_configs() -> Dict[str, Any]:
             "log_file_path": "logs/autobot.log",
         },
         "network": {
-            "share": {"username": None, "password": None}  # nosec B105 - default config with None values; real password
+            "share": {
+                "username": None,
+                # Default config carries None; the real password comes from config.
+                "password": None,  # nosec B105
+            }
         },
     }
 

--- a/autobot-backend/config/validation_test.py
+++ b/autobot-backend/config/validation_test.py
@@ -28,7 +28,7 @@ def _base_config(**overrides: Any) -> Dict[str, Any]:
     """Return a minimal valid config, with optional dot-notation overrides applied."""
     cfg: Dict[str, Any] = {
         "backend": {
-            "server_host": "0.0.0.0",  # nosec B104 - intentional bind to all interfaces for service/test
+            "server_host": "0.0.0.0",  # nosec B104  # intentional bind to all interfaces for service/test
             "server_port": 8001,
         },
         "memory": {

--- a/autobot-backend/context_window_manager.py
+++ b/autobot-backend/context_window_manager.py
@@ -121,7 +121,7 @@ class ContextWindowManager:
             "token_estimation": {
                 "chars_per_token": 4,
                 "safety_margin": 0.9,
-            },  # nosec B105 - config dict; 'token_estimation' refers to LLM token counting, not a credential
+            },  # nosec B105  # config dict; 'token_estimation' refers to LLM token counting, not a credential
         }
 
     def set_model(self, model_name: str):

--- a/autobot-backend/conversation_file_manager.py
+++ b/autobot-backend/conversation_file_manager.py
@@ -995,7 +995,7 @@ class ConversationFileManager:
             JOIN session_file_associations sfa ON cf.file_id = sfa.file_id
             WHERE sfa.session_id = ? {deleted_filter}
             ORDER BY sfa.associated_at DESC
-            """,  # nosec B608 - deleted_filter is a hardcoded constant
+            """,  # nosec B608  # deleted_filter is a hardcoded constant
             (session_id,),
         ) as cursor:
             rows = await cursor.fetchall()
@@ -1075,7 +1075,7 @@ class ConversationFileManager:
             # Issue #397: Batch SQL delete using IN clause
             placeholders = ",".join("?" * len(file_ids))
             await connection.execute(
-                f"DELETE FROM conversation_files WHERE file_id IN ({placeholders})",  # nosec B608 - parameterized ?
+                f"DELETE FROM conversation_files WHERE file_id IN ({placeholders})",  # nosec B608  # parameterized ?
                 file_ids,
             )
         else:
@@ -1086,7 +1086,7 @@ class ConversationFileManager:
                 UPDATE conversation_files
                 SET is_deleted = 1, deleted_at = CURRENT_TIMESTAMP
                 WHERE file_id IN ({placeholders})
-                """,  # nosec B608 - parameterized placeholders, not string interpolation
+                """,  # nosec B608  # parameterized placeholders, not string interpolation
                 file_ids,
             )
             logger.info("Soft deleted %d files in batch", len(file_ids))

--- a/autobot-backend/conversation_file_manager_init_test.py
+++ b/autobot-backend/conversation_file_manager_init_test.py
@@ -421,7 +421,7 @@ class TestSchemaIntegrityVerification:
         for table in expected_tables:
             rows = await async_sqlite_query(
                 db_path_str, f"SELECT COUNT(*) FROM {table}"
-            )  # nosec B608 - table names from fixed test allowlist above, no user input
+            )  # nosec B608  # table names from fixed test allowlist above, no user input
             count = rows[0][0]
             logger.info(f"✓ Table '{table}' queryable (count: {count})")
 
@@ -435,7 +435,7 @@ class TestSchemaIntegrityVerification:
         for view in expected_views:
             rows = await async_sqlite_query(
                 db_path_str, f"SELECT COUNT(*) FROM {view}"
-            )  # nosec B608 - view names from fixed test allowlist above, no user input
+            )  # nosec B608  # view names from fixed test allowlist above, no user input
             count = rows[0][0]
             logger.info(f"✓ View '{view}' queryable (count: {count})")
 

--- a/autobot-backend/events/artifacts_test.py
+++ b/autobot-backend/events/artifacts_test.py
@@ -227,7 +227,7 @@ class TestArtifactSerializationValidation:
             build_artifact(
                 ArtifactType.DEPLOYMENT_LOG,
                 "deployed ok",
-                file_path="/tmp/log",  # nosec B108 - test/controlled code uses tmpdir intentionally
+                file_path="/tmp/log",  # nosec B108  # test/controlled code uses tmpdir intentionally
             ),
         ]
         _validate_artifact_serialization(arts)

--- a/autobot-backend/gui_controller.py
+++ b/autobot-backend/gui_controller.py
@@ -102,7 +102,7 @@ class GUIController:
     def _is_canonical_display_active(self) -> bool:
         """Check whether an X server is already listening on the canonical display."""
         try:
-            result = subprocess.run(  # nosec B603 B607 - fixed argv, no user input
+            result = subprocess.run(  # nosec B603 B607  # fixed argv, no user input
                 ["pgrep", "-f", f"Xtigervnc {CANONICAL_DISPLAY}"],
                 capture_output=True,
                 timeout=5,
@@ -257,7 +257,7 @@ class GUIController:
         """
         try:
             result = await asyncio.to_thread(
-                subprocess.run,  # nosec B603 B607 - fixed argv, app_title passed as a single arg (no shell)
+                subprocess.run,  # nosec B603 B607  # fixed argv, app_title passed as a single arg (no shell)
                 ["/usr/bin/xdotool", "search", "--name", app_title, "windowactivate"],
                 capture_output=True,
                 timeout=5,
@@ -309,7 +309,7 @@ class GUIController:
 
                 result = subprocess.run(
                     ["which", "kex"], capture_output=True, text=True
-                )  # nosec B603 B607 - fixed argv, probing kex availability
+                )  # nosec B603 B607  # fixed argv, probing kex availability
                 if result.stdout.strip():
                     logger.info("Kex is available. If GUI fails, consider starting " "a Kex session.")
                     return True

--- a/autobot-backend/hardware_acceleration.py
+++ b/autobot-backend/hardware_acceleration.py
@@ -11,7 +11,7 @@ Optimizes model execution across different hardware targets.
 
 import os
 import platform
-import subprocess  # nosec B404 - hardware detection requires subprocess
+import subprocess  # nosec B404  # hardware detection requires subprocess
 from typing import Any, Dict
 
 import psutil
@@ -141,7 +141,7 @@ class HardwareAccelerationManager:
         try:
             result = subprocess.run(
                 ["lspci"], capture_output=True, text=True, timeout=5
-            )  # nosec B603 B607 - fixed lspci argv, no user input
+            )  # nosec B603 B607  # fixed lspci argv, no user input
             if result.returncode == 0:
                 output = result.stdout.lower()
                 if any(keyword in output for keyword in NPU_HARDWARE_KEYWORDS):
@@ -170,7 +170,7 @@ class HardwareAccelerationManager:
     def _check_nvidia_gpu(self) -> bool:
         """Check for NVIDIA GPU via nvidia-smi. Issue #620."""
         try:
-            result = subprocess.run(  # nosec B603 B607 - fixed nvidia-smi argv, no user input
+            result = subprocess.run(  # nosec B603 B607  # fixed nvidia-smi argv, no user input
                 ["nvidia-smi", "--query-gpu=name", "--format=csv,noheader"],
                 capture_output=True,
                 text=True,
@@ -186,7 +186,7 @@ class HardwareAccelerationManager:
     def _check_amd_gpu(self) -> bool:
         """Check for AMD GPU via rocm-smi. Issue #620."""
         try:
-            result = subprocess.run(  # nosec B603 B607 - fixed rocm-smi argv, no user input
+            result = subprocess.run(  # nosec B603 B607  # fixed rocm-smi argv, no user input
                 ["rocm-smi", "--showproductname"],
                 capture_output=True,
                 text=True,
@@ -202,7 +202,7 @@ class HardwareAccelerationManager:
     def _check_intel_gpu(self) -> bool:
         """Check for Intel GPU via intel_gpu_top. Issue #620."""
         try:
-            result = subprocess.run(  # nosec B603 B607 - fixed intel_gpu_top argv, no user input
+            result = subprocess.run(  # nosec B603 B607  # fixed intel_gpu_top argv, no user input
                 ["intel_gpu_top", "-l"], capture_output=True, text=True, timeout=3
             )
             if result.returncode == 0:
@@ -215,7 +215,7 @@ class HardwareAccelerationManager:
     def _check_gpu_via_lspci(self) -> bool:
         """Check for GPU hardware via lspci command. Issue #620."""
         try:
-            result = subprocess.run(  # nosec B603 B607 - fixed lspci argv, no user input
+            result = subprocess.run(  # nosec B603 B607  # fixed lspci argv, no user input
                 ["lspci", "-nn"], capture_output=True, text=True, timeout=5
             )
             if result.returncode == 0:
@@ -293,7 +293,7 @@ class HardwareAccelerationManager:
         }
 
         try:
-            result = subprocess.run(  # nosec B603 B607 - fixed nvidia-smi argv, no user input
+            result = subprocess.run(  # nosec B603 B607  # fixed nvidia-smi argv, no user input
                 [
                     "nvidia-smi",
                     "--query-gpu=name,memory.total",
@@ -649,7 +649,7 @@ class HardwareAccelerationManager:
         # Add GPU status if available (Issue #315: uses helper for parsing)
         if self.gpu_available:
             try:
-                result = subprocess.run(  # nosec B603 B607 - fixed nvidia-smi argv, no user input
+                result = subprocess.run(  # nosec B603 B607  # fixed nvidia-smi argv, no user input
                     [
                         "nvidia-smi",
                         "--query-gpu=utilization.gpu,memory.used,memory.total",

--- a/autobot-backend/integrations/desktop_tracking_test.py
+++ b/autobot-backend/integrations/desktop_tracking_test.py
@@ -100,7 +100,7 @@ class TestDesktopTracking:
         result = await track_screenshot_capture(
             db=mock_db,
             user_id=user_id,
-            screenshot_path="/tmp/screenshot.png",  # nosec B108 - test/controlled code uses tmpdir intentionally
+            screenshot_path="/tmp/screenshot.png",  # nosec B108  # test/controlled code uses tmpdir intentionally
         )
 
         assert result == activity_id
@@ -109,7 +109,7 @@ class TestDesktopTracking:
         assert call_kwargs["action"] == "screenshot"
         assert (
             call_kwargs["screenshot_path"]
-            == "/tmp/screenshot.png"  # nosec B108 - test/controlled code uses tmpdir intentionally
+            == "/tmp/screenshot.png"  # nosec B108  # test/controlled code uses tmpdir intentionally
         )
 
     @patch("integrations.desktop_tracking.track_desktop_activity")

--- a/autobot-backend/integrations/file_tracking.py
+++ b/autobot-backend/integrations/file_tracking.py
@@ -28,7 +28,7 @@ def _resolve_file_type(path: str) -> str | None:
         path_obj = Path(path)
         if path_obj.suffix:
             file_type = path_obj.suffix.lstrip(".")
-    except Exception:  # nosec B110 - silently handle invalid paths
+    except Exception:  # nosec B110  # silently handle invalid paths
         logger.debug("Suppressed exception in try block", exc_info=True)
     return file_type
 

--- a/autobot-backend/intelligence/os_detector.py
+++ b/autobot-backend/intelligence/os_detector.py
@@ -233,7 +233,7 @@ class OSDetector:
             is_root=is_root,
             is_wsl=is_wsl,
             package_manager=package_manager,
-            shell=shell,  # nosec B604 - dataclass field assignment
+            shell=shell,  # nosec B604  # dataclass field assignment
             capabilities=capabilities,
         )
 
@@ -325,7 +325,7 @@ class OSDetector:
                     return "microsoft" in content or "wsl" in content
         except OSError as e:
             logger.debug("Failed to read /proc/version: %s", e)
-        except Exception:  # nosec B110 - WSL detection fallback
+        except Exception:  # nosec B110  # WSL detection fallback
             logger.debug("Suppressed exception in try block", exc_info=True)
 
         return False

--- a/autobot-backend/knowledge/activity_types.py
+++ b/autobot-backend/knowledge/activity_types.py
@@ -236,7 +236,7 @@ class SecretUsage(BaseModel):
     model_config = ConfigDict(
         json_schema_extra={
             "example": {
-                "secret_id": "660e8400-e29b-41d4-a716-446655440001",  # nosec B105 - UUID example value in JSON schema,
+                "secret_id": "660e8400-e29b-41d4-a716-446655440001",  # nosec B105  # UUID example value in JSON schema,
                 "user_id": "550e8400-e29b-41d4-a716-446655440000",
                 "activity_type": "terminal",
                 "activity_id": "770e8400-e29b-41d4-a716-446655440002",

--- a/autobot-backend/knowledge/activity_types_test.py
+++ b/autobot-backend/knowledge/activity_types_test.py
@@ -241,14 +241,14 @@ class TestDesktopActivity:
         activity = DesktopActivity(
             user_id=user_id,
             action="screenshot",
-            screenshot_path="/tmp/screenshot_123.png",  # nosec B108 - test/controlled code uses tmpdir intentionally
+            screenshot_path="/tmp/screenshot_123.png",  # nosec B108  # test/controlled code uses tmpdir intentionally
             metadata={"width": 1920, "height": 1080},
         )
 
         assert activity.action == "screenshot"
         assert (
             activity.screenshot_path
-            == "/tmp/screenshot_123.png"  # nosec B108 - test/controlled code uses tmpdir intentionally
+            == "/tmp/screenshot_123.png"  # nosec B108  # test/controlled code uses tmpdir intentionally
         )
         assert activity.metadata["width"] == 1920
 

--- a/autobot-backend/knowledge/connectors/audio_connector_test.py
+++ b/autobot-backend/knowledge/connectors/audio_connector_test.py
@@ -73,8 +73,8 @@ def test_source_id_stable():
 def test_source_id_differs_for_different_sources():
     assert _source_id_for(
         "/tmp/a.mp3"
-    ) != _source_id_for(  # nosec B108 - test/controlled code uses tmpdir intentionally
-        "/tmp/b.mp3"  # nosec B108 - test/controlled code uses tmpdir intentionally
+    ) != _source_id_for(  # nosec B108  # test/controlled code uses tmpdir intentionally
+        "/tmp/b.mp3"  # nosec B108  # test/controlled code uses tmpdir intentionally
     )
 
 

--- a/autobot-backend/knowledge/connectors/connector_batch_b_test.py
+++ b/autobot-backend/knowledge/connectors/connector_batch_b_test.py
@@ -73,7 +73,7 @@ def _config(extra: dict | None = None) -> ConnectorConfig:
         "connector_id": "test-id",
         "connector_type": "file_server",
         "name": "test",
-        "config": {"base_path": "/tmp/test"},  # nosec B108 - test/controlled code uses tmpdir intentionally
+        "config": {"base_path": "/tmp/test"},  # nosec B108  # test/controlled code uses tmpdir intentionally
     }
     if extra:
         base.update(extra)

--- a/autobot-backend/knowledge/connectors/credential_store.py
+++ b/autobot-backend/knowledge/connectors/credential_store.py
@@ -210,7 +210,7 @@ class ConnectorCredentialStore:
             None,
             lambda: self._svc.create_secret(
                 name=name,
-                secret_type="connector_oauth_token",  # nosec B106 - SecretType label, not a credential
+                secret_type="connector_oauth_token",  # nosec B106  # SecretType label, not a credential
                 value=value,
                 scope="user",
                 created_by=owner_id,
@@ -223,7 +223,7 @@ class ConnectorCredentialStore:
                 owner_id,
                 value,
                 name=name,
-                secret_type="connector_oauth_token",  # nosec B106 - SecretType label, not a credential
+                secret_type="connector_oauth_token",  # nosec B106  # SecretType label, not a credential
             )
         return result["id"]
 

--- a/autobot-backend/knowledge/connectors/oauth_flow.py
+++ b/autobot-backend/knowledge/connectors/oauth_flow.py
@@ -58,7 +58,7 @@ OAUTH_PROVIDERS: dict = {
     "google": OAuthProvider(
         name="google",
         authorize_url="https://accounts.google.com/o/oauth2/v2/auth",
-        token_url="https://oauth2.googleapis.com/token",  # nosec B106 - OAuth token endpoint URL, not a credential
+        token_url="https://oauth2.googleapis.com/token",  # nosec B106  # OAuth token endpoint URL, not a credential
         client_id_setting="google_oauth_client_id",
         client_secret_setting="google_oauth_client_secret",
         default_scopes=("https://www.googleapis.com/auth/drive.readonly",),
@@ -68,7 +68,7 @@ OAUTH_PROVIDERS: dict = {
     "microsoft": OAuthProvider(
         name="microsoft",
         authorize_url="https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
-        token_url="https://login.microsoftonline.com/common/oauth2/v2.0/token",  # nosec B106 - token endpoint URL
+        token_url="https://login.microsoftonline.com/common/oauth2/v2.0/token",  # nosec B106  # token endpoint URL
         client_id_setting="microsoft_oauth_client_id",
         client_secret_setting="microsoft_oauth_client_secret",
         # offline_access is required for Microsoft to issue a refresh token.
@@ -77,7 +77,7 @@ OAUTH_PROVIDERS: dict = {
     "gitlab": OAuthProvider(
         name="gitlab",
         authorize_url="https://gitlab.com/oauth/authorize",
-        token_url="https://gitlab.com/oauth/token",  # nosec B106 - OAuth token endpoint URL, not a credential
+        token_url="https://gitlab.com/oauth/token",  # nosec B106  # OAuth token endpoint URL, not a credential
         client_id_setting="gitlab_oauth_client_id",
         client_secret_setting="gitlab_oauth_client_secret",
         default_scopes=("read_api", "read_repository"),

--- a/autobot-backend/knowledge/rag_benchmarks.py
+++ b/autobot-backend/knowledge/rag_benchmarks.py
@@ -56,7 +56,7 @@ class TestRAGQueryBenchmarks:
     def mock_embeddings(self):
         """Generate mock embedding vectors"""
         # Simulate 384-dimensional embeddings (all-MiniLM-L6-v2 style)
-        return [[random.random() for _ in range(384)] for _ in range(100)]  # nosec B311 - mock embedding vectors for
+        return [[random.random() for _ in range(384)] for _ in range(100)]  # nosec B311  # mock embedding vectors for
 
     @pytest.fixture
     def mock_documents(self):
@@ -67,7 +67,7 @@ class TestRAGQueryBenchmarks:
                 "content": f"This is test document {i} with some content for testing RAG retrieval performance.",
                 "metadata": {"source": "test", "page": i},
                 "embedding": [
-                    random.random() for _ in range(384)  # nosec B311 - mock embedding for benchmark, not cryptographic
+                    random.random() for _ in range(384)  # nosec B311  # mock embedding for benchmark, not cryptographic
                 ],
             }
             for i in range(1000)
@@ -78,7 +78,7 @@ class TestRAGQueryBenchmarks:
         import numpy as np
 
         query_vector = np.array(
-            [random.random() for _ in range(384)]  # nosec B311 - mock query vector for benchmark, not cryptographic
+            [random.random() for _ in range(384)]  # nosec B311  # mock query vector for benchmark, not cryptographic
         )
         doc_vectors = np.array(mock_embeddings[:50])
 
@@ -112,7 +112,7 @@ class TestRAGQueryBenchmarks:
         import random
 
         query_vector = [
-            random.random() for _ in range(384)  # nosec B311 - mock query vector for benchmark, not cryptographic
+            random.random() for _ in range(384)  # nosec B311  # mock query vector for benchmark, not cryptographic
         ]
         documents = mock_documents
 

--- a/autobot-backend/llc/adapters/subprocess_base.py
+++ b/autobot-backend/llc/adapters/subprocess_base.py
@@ -41,7 +41,7 @@ logger = get_logger(__name__)
 SIGTERM_GRACE_SECONDS = 10
 ADAPTER_TIMEOUT_SECONDS = 3600  # per-adapter default (preserves current behavior)
 DEFAULT_TIMEOUT_SECONDS = 3600  # fallback when a state file omits timeout_seconds
-DEFAULT_OUTPUT_DIR = "/tmp"  # nosec B108 - test/controlled code uses tmpdir intentionally
+DEFAULT_OUTPUT_DIR = "/tmp"  # nosec B108  # test/controlled code uses tmpdir intentionally
 
 # Per-user CLI install locations that a systemd service account's PATH typically
 # does NOT include (GH#12478). Checked, in order, after a bare `shutil.which()`

--- a/autobot-backend/llc/tests/test_artifact_ingestor.py
+++ b/autobot-backend/llc/tests/test_artifact_ingestor.py
@@ -169,7 +169,7 @@ async def test_ingest_returns_false_for_missing_product(ingestor, mock_session):
 @pytest.mark.asyncio
 async def test_ingest_skips_binary_storage_path(ingestor, mock_session):
     product = _make_product(
-        storage_path="/tmp/binary.png"  # nosec B108 - test/controlled code uses tmpdir intentionally
+        storage_path="/tmp/binary.png"  # nosec B108  # test/controlled code uses tmpdir intentionally
     )
     mock_scalar = MagicMock()
     mock_scalar.scalar_one_or_none = MagicMock(return_value=product)
@@ -234,7 +234,7 @@ async def test_ingest_all_pending_counts_only_successful(ingestor, mock_session)
         _make_product(work_item_id=item_id, content_text="ok"),
         _make_product(
             work_item_id=item_id,
-            storage_path="/tmp/img.png",  # nosec B108 - test/controlled code uses tmpdir intentionally
+            storage_path="/tmp/img.png",  # nosec B108  # test/controlled code uses tmpdir intentionally
         ),
     ]
     mock_scalars = MagicMock()

--- a/autobot-backend/llc/tests/test_attachments.py
+++ b/autobot-backend/llc/tests/test_attachments.py
@@ -30,7 +30,7 @@ _AGENT = str(uuid.uuid4())
 def _make_row(
     filename: str = "notes.txt",
     size_bytes: int = 10,
-    storage_path: str = "/tmp/fake.txt",  # nosec B108 - test/controlled code uses tmpdir intentionally
+    storage_path: str = "/tmp/fake.txt",  # nosec B108  # test/controlled code uses tmpdir intentionally
     text_extracted: bool = True,
     extracted_text: str = "hello",
 ) -> MagicMock:

--- a/autobot-backend/llm_shared/optimization/layer_inference_test.py
+++ b/autobot-backend/llm_shared/optimization/layer_inference_test.py
@@ -119,8 +119,8 @@ class TestLayerInferenceConfig:
 
     def test_cache_dir_accepted(self):
         """cache_dir string should be stored on the config."""
-        cfg = _make_config(cache_dir="/tmp/models")  # nosec B108 - test/controlled code uses tmpdir intentionally
-        assert cfg.cache_dir == "/tmp/models"  # nosec B108 - test/controlled code uses tmpdir intentionally
+        cfg = _make_config(cache_dir="/tmp/models")  # nosec B108  # test/controlled code uses tmpdir intentionally
+        assert cfg.cache_dir == "/tmp/models"  # nosec B108  # test/controlled code uses tmpdir intentionally
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/llm_shared/optimization/model_inspector.py
+++ b/autobot-backend/llm_shared/optimization/model_inspector.py
@@ -265,7 +265,7 @@ def _inspect_via_config(model_name: str) -> ModelInfo | None:
     try:
         cfg = transformers.AutoConfig.from_pretrained(
             model_name, resume_download=True
-        )  # nosec B615 - HuggingFace model loaded by name; revision pinning managed operationally
+        )  # nosec B615  # HuggingFace model loaded by name; revision pinning managed operationally
         param_count = _count_params_via_skeleton(cfg, transformers, accelerate)
         if param_count is None:
             logger.debug("model_inspector: using formula fallback for %s", model_name)

--- a/autobot-backend/llm_shared/optimization/rate_limiter.py
+++ b/autobot-backend/llm_shared/optimization/rate_limiter.py
@@ -154,7 +154,7 @@ class RateLimitHandler:
 
         # Add jitter to prevent thundering herd
         jitter = (
-            base_delay * self.config.jitter_factor * random.random()  # nosec B311 - jitter to prevent thundering herd,
+            base_delay * self.config.jitter_factor * random.random()  # nosec B311  # jitter to prevent thundering herd,
         )
 
         return base_delay + jitter

--- a/autobot-backend/llm_shared/provider_auth.py
+++ b/autobot-backend/llm_shared/provider_auth.py
@@ -52,7 +52,7 @@ from autobot_shared.logging_manager import get_logger
 logger = get_logger(__name__)
 
 # Vault secret type tag for all provider-auth tokens stored via EnvelopeSecretsService.
-PROVIDER_AUTH_SECRET_TYPE = "provider_auth_token"  # nosec B105 - vault type tag, not a credential
+PROVIDER_AUTH_SECRET_TYPE = "provider_auth_token"  # nosec B105  # vault type tag, not a credential
 
 # Grace window before expiry at which a refresh is proactively triggered (seconds).
 _REFRESH_GRACE_SECONDS = 300
@@ -444,7 +444,7 @@ class DeviceCodeAuth(ProviderAuthStrategy):
             provider_name=self._provider_name,
             token_url=self._token_url,
             client_id=self._client_id,
-            client_secret="",  # nosec B106 - device-code token refresh is public (no secret)
+            client_secret="",  # nosec B106  # device-code token refresh is public (no secret)
             owner_vault_str=self._owner_vault_str,
             subject=self._subject,
         )

--- a/autobot-backend/mcp/autobot_mcp_main.py
+++ b/autobot-backend/mcp/autobot_mcp_main.py
@@ -25,7 +25,7 @@ from mcp.autobot_server import AutoBotMCPServer
 async def main() -> None:
     server = AutoBotMCPServer()
     if "--http" in sys.argv:
-        host = "0.0.0.0"  # nosec B104 - intentional bind to all interfaces for service/test
+        host = "0.0.0.0"  # nosec B104  # intentional bind to all interfaces for service/test
         port = 8200
         args = sys.argv[1:]
         if "--host" in args:

--- a/autobot-backend/mcp/autobot_server.py
+++ b/autobot-backend/mcp/autobot_server.py
@@ -810,7 +810,7 @@ class AutoBotMCPServer:
     async def serve_http(
         self,
         host: str = "0.0.0.0",
-        port: int = 8200,  # nosec B104 - intentional bind to all interfaces for service/test
+        port: int = 8200,  # nosec B104  # intentional bind to all interfaces for service/test
     ) -> None:
         """Run an aiohttp server accepting ``POST /mcp/tool`` requests."""
         from aiohttp import web

--- a/autobot-backend/mcp/mcp_security_test.py
+++ b/autobot-backend/mcp/mcp_security_test.py
@@ -37,7 +37,7 @@ from autobot_shared.ssot_config import config
 # shell placeholders that Python never expands, so the "legitimate path" cases
 # asserted against paths that exist nowhere.
 PROJECT_ROOT = str(config.base_dir).rstrip("/")
-TMP_ROOT = "/tmp/autobot"  # nosec B108 - matches the bridge's own whitelist entry
+TMP_ROOT = "/tmp/autobot"  # nosec B108  # matches the bridge's own whitelist entry
 
 
 @pytest.fixture
@@ -73,7 +73,7 @@ def admin_client(app):
 def temp_allowed_dir(tmp_path):
     """Create temporary directory within allowed paths for testing"""
     # Use /tmp/autobot/ which is in ALLOWED_DIRECTORIES
-    test_dir = Path("/tmp/autobot/test_security")  # nosec B108 - test/controlled code uses tmpdir intentionally
+    test_dir = Path("/tmp/autobot/test_security")  # nosec B108  # test/controlled code uses tmpdir intentionally
     test_dir.mkdir(parents=True, exist_ok=True)
     yield test_dir
     # Cleanup

--- a/autobot-backend/memory/storage/general_storage.py
+++ b/autobot-backend/memory/storage/general_storage.py
@@ -125,7 +125,7 @@ class GeneralStorage:
             WHERE {' AND '.join(where_clauses)}
             ORDER BY timestamp DESC
             LIMIT ?
-        """  # nosec B608 - clause strings are hardcoded literals; only values are parameterized
+        """  # nosec B608  # clause strings are hardcoded literals; only values are parameterized
         values.append(limit)
 
         try:

--- a/autobot-backend/memory/storage/task_storage.py
+++ b/autobot-backend/memory/storage/task_storage.py
@@ -168,7 +168,7 @@ class TaskStorage:
         if not set_clauses:
             return False
 
-        query = f"UPDATE task_execution_history SET {', '.join(set_clauses)} WHERE task_id = ?"  # nosec B608 - column
+        query = f"UPDATE task_execution_history SET {', '.join(set_clauses)} WHERE task_id = ?"  # nosec B608  # column
         values.append(task_id)
 
         try:
@@ -231,7 +231,7 @@ class TaskStorage:
             {where_clause}
             ORDER BY created_at DESC
             LIMIT ?
-        """  # nosec B608 - where_clause built from hardcoded literal strings; only values parameterized
+        """  # nosec B608  # where_clause built from hardcoded literal strings; only values parameterized
         values.append(limit)
 
         try:

--- a/autobot-backend/migrations/db_url.py
+++ b/autobot-backend/migrations/db_url.py
@@ -37,7 +37,7 @@ def get_url() -> str:
             default_host="autobot-postgres",
             default_user="autobot",
             default_db="autobot",
-            password_default="autobot",  # nosec B106 — dev-env placeholder, not a real credential
+            password_default="autobot",  # nosec B106  # dev-env placeholder, not a real credential
         )
 
 

--- a/autobot-backend/minimal_backend_test.py
+++ b/autobot-backend/minimal_backend_test.py
@@ -74,5 +74,5 @@ if __name__ == "__main__":
         app,
         host="0.0.0.0",
         port=8001,
-        log_level="info",  # nosec B104 - intentional bind to all interfaces for service/test
+        log_level="info",  # nosec B104  # intentional bind to all interfaces for service/test
     )

--- a/autobot-backend/models/secret.py
+++ b/autobot-backend/models/secret.py
@@ -35,12 +35,12 @@ class SecretType(str, Enum):
 
     SSH_KEY = "ssh_key"
     # nosemgrep: autobot-hardcoded-secret-key
-    PASSWORD = "password"  # nosec B105 - enum value, not actual password
+    PASSWORD = "password"  # nosec B105  # enum value, not actual password
     # nosemgrep: autobot-hardcoded-secret-key
     API_KEY = "api_key"
     # nosemgrep: autobot-hardcoded-secret-key
-    TOKEN = "token"  # nosec B105 - enum value, not actual token
-    OAUTH_REFRESH_TOKEN = "oauth_refresh_token"  # nosec B105 - enum value
+    TOKEN = "token"  # nosec B105  # enum value, not actual token
+    OAUTH_REFRESH_TOKEN = "oauth_refresh_token"  # nosec B105  # enum value
     CERTIFICATE = "certificate"
     DATABASE_URL = "database_url"
     INFRASTRUCTURE_HOST = "infrastructure_host"

--- a/autobot-backend/multimodal_processor/processors/vision.py
+++ b/autobot-backend/multimodal_processor/processors/vision.py
@@ -101,7 +101,7 @@ class VisionProcessor(BaseModalProcessor):
             self.logger.info("Loading CLIP model...")
             self.clip_model = CLIPModel.from_pretrained(
                 "openai/clip-vit-base-patch32", resume_download=True
-            ).to(  # nosec B615 - HuggingFace model loaded by name; revision pinning managed operationally
+            ).to(  # nosec B615  # HuggingFace model loaded by name; revision pinning managed operationally
                 self.device
             )
             self.clip_processor = CLIPProcessor.from_pretrained(  # nosec B615

--- a/autobot-backend/multimodal_processor/processors/voice.py
+++ b/autobot-backend/multimodal_processor/processors/voice.py
@@ -117,7 +117,7 @@ class VoiceProcessor(BaseModalProcessor):
             self.logger.info("Loading Whisper model...")
             self.whisper_processor = WhisperProcessor.from_pretrained(
                 "openai/whisper-base", resume_download=True
-            )  # nosec B615 - HuggingFace model loaded by name; revision pinning managed operationally
+            )  # nosec B615  # HuggingFace model loaded by name; revision pinning managed operationally
             self.whisper_model = WhisperForConditionalGeneration.from_pretrained(  # nosec B615
                 "openai/whisper-base",
                 torch_dtype=(torch.float16 if torch.cuda.is_available() else torch.float32),

--- a/autobot-backend/pki/configurator.py
+++ b/autobot-backend/pki/configurator.py
@@ -81,7 +81,7 @@ async def _write_tls_config_to_redis(conn, tls_config: str) -> None:
         conn: AsyncSSH connection
         tls_config: TLS configuration content to write
     """
-    temp_config = "/tmp/redis-tls.conf"  # nosec B108 - Temp file for Redis TLS config
+    temp_config = "/tmp/redis-tls.conf"  # nosec B108  # Temp file for Redis TLS config
     async with conn.start_sftp_client() as sftp:
         async with sftp.open(temp_config, "w", encoding="utf-8") as f:
             await f.write(tls_config)

--- a/autobot-backend/pki/distributor.py
+++ b/autobot-backend/pki/distributor.py
@@ -321,7 +321,7 @@ class CertificateDistributor:
         content = await asyncio.to_thread(local_path.read_bytes)
 
         # Write to temporary location
-        temp_path = f"/tmp/{local_path.name}"  # nosec B108 - remote VM temp dir
+        temp_path = f"/tmp/{local_path.name}"  # nosec B108  # remote VM temp dir
         async with conn.start_sftp_client() as sftp:
             async with sftp.open(temp_path, "wb") as f:
                 await f.write(content)

--- a/autobot-backend/pki/generator.py
+++ b/autobot-backend/pki/generator.py
@@ -13,7 +13,7 @@ Inspired by oVirt's ovirt-engine-pki-ca-create and ovirt-engine-pki-enroll.
 """
 
 import os
-import subprocess  # nosec B404 - Required for PKI certificate generation
+import subprocess  # nosec B404  # Required for PKI certificate generation
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import List, Tuple
@@ -42,7 +42,7 @@ def _run_openssl_command(cmd: List[str], operation: str, context: str = "") -> T
     try:
         subprocess.run(
             cmd, check=True, capture_output=True
-        )  # nosec B603 - cmd is openssl argv built by callers using hardcoded arg lists
+        )  # nosec B603  # cmd is openssl argv built by callers using hardcoded arg lists
         return True, None
     except subprocess.CalledProcessError as e:
         error_msg = e.stderr.decode() if e.stderr else str(e)
@@ -264,7 +264,7 @@ class CertificateGenerator:
         try:
             subprocess.run(
                 key_cmd, check=True, capture_output=True
-            )  # nosec B603 - key_cmd is fixed openssl argv built above
+            )  # nosec B603  # key_cmd is fixed openssl argv built above
             os.chmod(ca_key, 0o600)
             return True
         except subprocess.CalledProcessError as e:
@@ -305,7 +305,7 @@ class CertificateGenerator:
         try:
             subprocess.run(
                 cert_cmd, check=True, capture_output=True
-            )  # nosec B603 - cert_cmd is fixed openssl argv built above
+            )  # nosec B603  # cert_cmd is fixed openssl argv built above
             os.chmod(ca_cert, 0o644)
             logger.info(f"CA certificate generated: {ca_cert}")
             return True
@@ -497,7 +497,7 @@ class CertificateGenerator:
         ]
         verify_result = subprocess.run(
             verify_cmd, capture_output=True
-        )  # nosec B603 - verify_cmd is fixed openssl argv built above
+        )  # nosec B603  # verify_cmd is fixed openssl argv built above
         return verify_result.returncode == 0
 
     def get_certificate_status(self, cert_path: Path) -> CertificateStatus:
@@ -518,7 +518,7 @@ class CertificateGenerator:
             ]
             result = subprocess.run(
                 cmd, capture_output=True, check=True
-            )  # nosec B603 - cmd is fixed openssl argv built above
+            )  # nosec B603  # cmd is fixed openssl argv built above
             output = result.stdout.decode()
 
             subject, issuer, expires_at = self._parse_certificate_output(output)

--- a/autobot-backend/secure_command_executor_test.py
+++ b/autobot-backend/secure_command_executor_test.py
@@ -33,7 +33,7 @@ class TestSecurityPolicy:
 
         # Check that allowed paths include common directories
         assert Path.home() in policy.allowed_paths
-        assert Path("/tmp") in policy.allowed_paths  # nosec B108 - test/controlled code uses tmpdir intentionally
+        assert Path("/tmp") in policy.allowed_paths  # nosec B108  # test/controlled code uses tmpdir intentionally
 
         # #7147: dangerous_patterns moved off SecurityPolicy in #765 — they
         # now live in security.command_patterns.DANGEROUS_PATTERNS (the

--- a/autobot-backend/secure_sandbox_executor.py
+++ b/autobot-backend/secure_sandbox_executor.py
@@ -727,7 +727,7 @@ class SecureSandboxExecutor:
             container_config["volumes"] = config.volumes
         else:
             # Default volumes
-            container_config["tmpfs"] = {  # nosec B108 - container tmpfs mounts
+            container_config["tmpfs"] = {  # nosec B108  # container tmpfs mounts
                 "/tmp": "size=50M,mode=1777",
                 "/sandbox/tmp": "size=50M,mode=1777",
             }

--- a/autobot-backend/security/content_firewall.py
+++ b/autobot-backend/security/content_firewall.py
@@ -94,7 +94,7 @@ class ContentSource(str, Enum):
 class FirewallAction(str, Enum):
     """Action taken by the firewall."""
 
-    PASS = "pass"  # nosec B105 - firewall-action label, not a credential; safe → content returned as-is
+    PASS = "pass"  # nosec B105  # firewall-action label, not a credential; safe → content returned as-is
     QUARANTINE = "quarantine"  # Suspicious — stripped content returned + flagged
     BLOCK = "block"  # High risk — content withheld; caller should abort
     ESCALATE = "escalate"  # High risk + escalation enabled — human approval requested

--- a/autobot-backend/security/enterprise/security_policy_manager.py
+++ b/autobot-backend/security/enterprise/security_policy_manager.py
@@ -36,7 +36,7 @@ class PolicyType(Enum):
     """Types of security policies"""
 
     ACCESS_CONTROL = "access_control"
-    PASSWORD_POLICY = "password_policy"  # nosec B105 - enum value for security policy type, not a password
+    PASSWORD_POLICY = "password_policy"  # nosec B105  # enum value for security policy type, not a password
     SESSION_MANAGEMENT = "session_management"
     DATA_PROTECTION = "data_protection"
     NETWORK_SECURITY = "network_security"

--- a/autobot-backend/security/enterprise/sso_integration.py
+++ b/autobot-backend/security/enterprise/sso_integration.py
@@ -202,7 +202,7 @@ class SSOIntegrationFramework:
             # OAuth2/OpenID Connect configuration
             "oauth2": {
                 "default_scope": ["openid", "profile", "email"],
-                "token_endpoint_auth_method": "client_secret_post",  # nosec B105 - OAuth2 protocol parameter name, not
+                "token_endpoint_auth_method": "client_secret_post",  # nosec B105  # OAuth2 protocol parameter name, not
                 "response_type": "code",
                 "grant_type": "authorization_code",
             },
@@ -220,7 +220,7 @@ class SSOIntegrationFramework:
                 "sign_assertions": True,
                 "require_encryption": True,
                 "max_clock_skew_seconds": 300,
-                "token_lifetime_minutes": 60,  # nosec B105 - config key for token TTL in minutes, not a credential
+                "token_lifetime_minutes": 60,  # nosec B105  # config key for token TTL in minutes, not a credential
             },
         }
 

--- a/autobot-backend/security/enterprise/threat_detection/engine.py
+++ b/autobot-backend/security/enterprise/threat_detection/engine.py
@@ -12,7 +12,7 @@ Issue #378: Added threading locks for file operations to prevent race conditions
 """
 
 import asyncio
-import pickle  # nosec B403 - internal profile storage only
+import pickle  # nosec B403  # internal profile storage only
 import threading
 from collections import defaultdict, deque
 from datetime import timedelta

--- a/autobot-backend/services/agent_secrets_integration.py
+++ b/autobot-backend/services/agent_secrets_integration.py
@@ -331,7 +331,7 @@ class AgentSecretsIntegration:
             List of SSH key dictionaries with id, name, value, scope, description
         """
         ssh_keys = []
-        keys = self.secrets_service.list_secrets(  # nosec B106 - secret type filter
+        keys = self.secrets_service.list_secrets(  # nosec B106  # secret type filter
             scope=scope,
             chat_id=chat_id,
             secret_type="ssh_key",
@@ -420,7 +420,7 @@ class AgentSecretsIntegration:
                         return full_secret["value"]
 
         # Try general scope
-        secrets = self.secrets_service.list_secrets(  # nosec B106 - secret type filter
+        secrets = self.secrets_service.list_secrets(  # nosec B106  # secret type filter
             scope="general",
             secret_type="api_key",
         )

--- a/autobot-backend/services/autoresearch/meta_agent_test.py
+++ b/autobot-backend/services/autoresearch/meta_agent_test.py
@@ -53,11 +53,11 @@ def test_metapatch_to_dict_keys() -> None:
     patch = MetaPatch(
         patch_id="abc",
         target_path="/tmp/foo.py",
-        generation=3,  # nosec B108 - test/controlled code uses tmpdir intentionally
+        generation=3,  # nosec B108  # test/controlled code uses tmpdir intentionally
     )
     d = patch.to_dict()
     assert d["patch_id"] == "abc"
-    assert d["target_path"] == "/tmp/foo.py"  # nosec B108 - test/controlled code uses tmpdir intentionally
+    assert d["target_path"] == "/tmp/foo.py"  # nosec B108  # test/controlled code uses tmpdir intentionally
     assert d["generation"] == 3
     assert "has_changes" in d
 
@@ -65,7 +65,7 @@ def test_metapatch_to_dict_keys() -> None:
 def test_metapatch_from_dict_roundtrip() -> None:
     original = MetaPatch(
         patch_id="roundtrip-id",
-        target_path="/tmp/foo.py",  # nosec B108 - test/controlled code uses tmpdir intentionally
+        target_path="/tmp/foo.py",  # nosec B108  # test/controlled code uses tmpdir intentionally
         original_content="x = 1\n",
         modified_content="x = 2\n",
         rationale="test",

--- a/autobot-backend/services/autoresearch/meta_eval_harness_test.py
+++ b/autobot-backend/services/autoresearch/meta_eval_harness_test.py
@@ -37,7 +37,7 @@ def _make_patch(
 ) -> MetaPatch:
     return MetaPatch(
         patch_id=patch_id,
-        target_path="/tmp/module.py",  # nosec B108 - test/controlled code uses tmpdir intentionally
+        target_path="/tmp/module.py",  # nosec B108  # test/controlled code uses tmpdir intentionally
         original_content=original,
         modified_content=modified,
         rationale="test change",
@@ -124,7 +124,7 @@ async def test_evaluate_patch_no_changes_skips() -> None:
     archive = Archive()
     patch = MetaPatch(
         patch_id="same",
-        target_path="/tmp/module.py",  # nosec B108 - test/controlled code uses tmpdir intentionally
+        target_path="/tmp/module.py",  # nosec B108  # test/controlled code uses tmpdir intentionally
         original_content="x = 1\n",
         modified_content="x = 1",  # stripped equal
     )

--- a/autobot-backend/services/autoresearch/run_experiment.py
+++ b/autobot-backend/services/autoresearch/run_experiment.py
@@ -66,7 +66,7 @@ def main() -> int:
     cmd = [sys.executable, train_script] + _build_train_args()
     logger.info("Running: %s", " ".join(cmd))
 
-    result = subprocess.run(  # nosec B603 - cmd uses sys.executable with fixed train_script; _build_train_args returns
+    result = subprocess.run(  # nosec B603  # cmd uses sys.executable with fixed train_script; _build_train_args returns
         cmd,
         capture_output=True,
         text=True,

--- a/autobot-backend/services/device_jwt.py
+++ b/autobot-backend/services/device_jwt.py
@@ -61,7 +61,7 @@ from services.audit.audit import AuditAction, audit_record
 
 logger = get_logger(__name__)
 
-_ENV_SECRET = "DEVICE_JWT_SECRET"  # nosec B105 - environment variable name constant, not a hardcoded secret
+_ENV_SECRET = "DEVICE_JWT_SECRET"  # nosec B105  # environment variable name constant, not a hardcoded secret
 _ENV_TTL_DAYS = "DEVICE_JWT_TTL_DAYS"
 _ENV_CACHE_TTL = "DEVICE_JWT_CACHE_TTL"
 _ENV_AUDIENCE = "DEVICE_JWT_AUDIENCE"

--- a/autobot-backend/services/device_token_service.py
+++ b/autobot-backend/services/device_token_service.py
@@ -45,7 +45,7 @@ def create_device_jwt(
         "user_id": str(user_id),
         "scope": scope,
         "platform": platform,
-        "token_type": "device",  # nosec B105 - JWT claim type value, not a credential
+        "token_type": "device",  # nosec B105  # JWT claim type value, not a credential
         "iat": datetime.datetime.now(tz=timezone.utc).isoformat(),
     }
 

--- a/autobot-backend/services/execution/claude_code_backend.py
+++ b/autobot-backend/services/execution/claude_code_backend.py
@@ -296,7 +296,7 @@ class ClaudeCodeBackend(ExecutionBackend):
         event_stream: Any = None,
         mcp_host: str = _DEFAULT_MCP_HOST,
         mcp_port: int = _DEFAULT_MCP_PORT,
-        mcp_token: str = "",  # nosec B107 - optional token; resolved from config when empty
+        mcp_token: str = "",  # nosec B107  # optional token; resolved from config when empty
         use_sdk: bool = False,
     ) -> None:
         super().__init__(BackendType.LOCAL)  # reuse LOCAL slot; manager keys by instance
@@ -634,7 +634,7 @@ def build_claude_code_backend(
     event_stream: Any = None,
     mcp_host: str = _DEFAULT_MCP_HOST,
     mcp_port: int = _DEFAULT_MCP_PORT,
-    mcp_token: str = "",  # nosec B107 - optional token; resolved from config when empty
+    mcp_token: str = "",  # nosec B107  # optional token; resolved from config when empty
     use_sdk: bool = False,
 ) -> ClaudeCodeBackend:
     """Factory used by the execution-manager registry.

--- a/autobot-backend/services/execution/snapshot_index.py
+++ b/autobot-backend/services/execution/snapshot_index.py
@@ -37,7 +37,7 @@ def _resolve_storage_path() -> Path:
         )
         raw = _DEFAULT_SNAPSHOT_PATH
     path = Path(raw)
-    if str(path).startswith("/tmp"):  # nosec B108 - intentional check to warn operator about non-persistent tmp path
+    if str(path).startswith("/tmp"):  # nosec B108  # intentional check to warn operator about non-persistent tmp path
         logger.warning(
             "Snapshot storage path %s is under /tmp — snapshots will not survive a host restart. "
             "Set AUTOBOT_SNAPSHOT_STORAGE_PATH to a persistent directory (e.g. /opt/autobot/snapshots).",

--- a/autobot-backend/services/execution/ssh_backend.py
+++ b/autobot-backend/services/execution/ssh_backend.py
@@ -144,7 +144,7 @@ class SSHBackend(ExecutionBackend):
             # Try a simple command
             stdin, stdout, stderr = client.exec_command(
                 "true"
-            )  # nosec B601 - hardcoded literal command in health check, not user input
+            )  # nosec B601  # hardcoded literal command in health check, not user input
             stdout.channel.recv_exit_status()
             return True
         except Exception as e:

--- a/autobot-backend/services/fast_document_scanner.py
+++ b/autobot-backend/services/fast_document_scanner.py
@@ -406,7 +406,7 @@ class FastDocumentScanner:
             # Fallback to subprocess (slower but more reliable)
             try:
                 result = (
-                    subprocess.run(  # nosec B603 B607 - fixed 'man' binary; command comes from parsed man-page path
+                    subprocess.run(  # nosec B603 B607  # fixed 'man' binary; command comes from parsed man-page path
                         ["man", command],
                         capture_output=True,
                         text=True,

--- a/autobot-backend/services/knowledge/autonomous_loop.py
+++ b/autobot-backend/services/knowledge/autonomous_loop.py
@@ -563,20 +563,20 @@ class AutonomousLoopRunner:
 
             fallback = []
             for _ in range(min(3, self.max_variants)):
-                sem_w = round(random.uniform(0.5, 0.9), 2)  # nosec B311 - UCB1 exploration weight, not cryptographic
+                sem_w = round(random.uniform(0.5, 0.9), 2)  # nosec B311  # UCB1 exploration weight, not cryptographic
                 fallback.append(
                     {
                         "hybrid_weight_semantic": sem_w,
                         "hybrid_weight_keyword": round(1.0 - sem_w, 2),
                         "diversity_threshold": round(
-                            random.uniform(0.1, 0.8), 2  # nosec B311 - diversity sampling, not cryptographic
+                            random.uniform(0.1, 0.8), 2  # nosec B311  # diversity sampling, not cryptographic
                         ),
                         "ucb1_exploration_constant": round(
-                            random.uniform(0.5, 3.0), 2  # nosec B311 - UCB1 exploration constant, not cryptographic
+                            random.uniform(0.5, 3.0), 2  # nosec B311  # UCB1 exploration constant, not cryptographic
                         ),
                         "max_results_per_stage": random.choice(
                             [5, 10, 20, 30]
-                        ),  # nosec B311 - variant selection for autonomous loop, not cryptographic
+                        ),  # nosec B311  # variant selection for autonomous loop, not cryptographic
                     }
                 )
             logger.info("AutonomousLoop[%s] HYPOTHESIZE: using %d fallback variants", run_id, len(fallback))

--- a/autobot-backend/services/knowledge/test_doc_indexer.py
+++ b/autobot-backend/services/knowledge/test_doc_indexer.py
@@ -52,8 +52,8 @@ _path_constants = _make_stub("constants.path_constants")
 
 
 class _FakePATH:
-    DATA_DIR = Path("/tmp/test_autobot_data")  # nosec B108 - test/controlled code uses tmpdir intentionally
-    PROJECT_ROOT = Path("/tmp/test_autobot_root")  # nosec B108 - test/controlled code uses tmpdir intentionally
+    DATA_DIR = Path("/tmp/test_autobot_data")  # nosec B108  # test/controlled code uses tmpdir intentionally
+    PROJECT_ROOT = Path("/tmp/test_autobot_root")  # nosec B108  # test/controlled code uses tmpdir intentionally
 
 
 _path_constants.PATH = _FakePATH()  # type: ignore[attr-defined]
@@ -104,7 +104,7 @@ _MODULE = "services.knowledge.doc_indexer"
 def _make_service(
     initialized: bool = True,
     collection_count: int = 0,
-    root_dir: Path = Path("/tmp/test_autobot_root"),  # nosec B108 - test/controlled code uses tmpdir intentionally
+    root_dir: Path = Path("/tmp/test_autobot_root"),  # nosec B108  # test/controlled code uses tmpdir intentionally
 ) -> DocIndexerService:
     """Build a DocIndexerService with pre-wired mocks."""
     svc = DocIndexerService.__new__(DocIndexerService)

--- a/autobot-backend/services/knowledge/test_doc_indexer_dim_mismatch.py
+++ b/autobot-backend/services/knowledge/test_doc_indexer_dim_mismatch.py
@@ -50,8 +50,8 @@ _path_constants = _make_stub("constants.path_constants")
 
 
 class _FakePATH:
-    DATA_DIR = Path("/tmp/test_autobot_data")  # nosec B108 - test/controlled code uses tmpdir intentionally
-    PROJECT_ROOT = Path("/tmp/test_autobot_root")  # nosec B108 - test/controlled code uses tmpdir intentionally
+    DATA_DIR = Path("/tmp/test_autobot_data")  # nosec B108  # test/controlled code uses tmpdir intentionally
+    PROJECT_ROOT = Path("/tmp/test_autobot_root")  # nosec B108  # test/controlled code uses tmpdir intentionally
 
 
 _path_constants.PATH = _FakePATH()  # type: ignore[attr-defined]

--- a/autobot-backend/services/man_page_parser.py
+++ b/autobot-backend/services/man_page_parser.py
@@ -418,7 +418,7 @@ class ManPageParser:
         """Helper for parse_man_page_with_subprocess. Ref: #1088."""
         _validate_man_args(command, section)
         cmd = ["man", section, command]
-        return subprocess.run(  # nosec B603 - args validated by _validate_man_args above; cmd is fixed 'man' binary
+        return subprocess.run(  # nosec B603  # args validated by _validate_man_args above; cmd is fixed 'man' binary
             cmd,
             capture_output=True,
             text=True,
@@ -502,7 +502,7 @@ class ManPageParser:
                 logger.warning("Invalid command name for summary: %s", command)
                 return ""
             cmd = ["man", "-k", f"^{command}$"]
-            proc = subprocess.run(  # nosec B603 - command validated by _VALID_COMMAND_RE above; 'man' is fixed binary
+            proc = subprocess.run(  # nosec B603  # command validated by _VALID_COMMAND_RE above; 'man' is fixed binary
                 cmd,
                 capture_output=True,
                 text=True,

--- a/autobot-backend/services/mcp_isolated_runtime_test.py
+++ b/autobot-backend/services/mcp_isolated_runtime_test.py
@@ -68,7 +68,7 @@ class TestIsolatedBridgeClient:
             new=AsyncMock(return_value=fake_proc),
         ):
             result = await client.call_tool(
-                "read_file", {"path": "/tmp/x"}  # nosec B108 - test/controlled code uses tmpdir intentionally
+                "read_file", {"path": "/tmp/x"}  # nosec B108  # test/controlled code uses tmpdir intentionally
             )
         assert result["success"] is True
         assert result["result"] == {"ok": 1}
@@ -247,7 +247,7 @@ class TestConcurrentRequestIds:
             await asyncio.gather(
                 *[
                     client.call_tool("read_file", {"path": f"/tmp/f{i}"}) for i in range(self._N)
-                ]  # nosec B108 - test/controlled code uses tmpdir intentionally
+                ]  # nosec B108  # test/controlled code uses tmpdir intentionally
             )
 
         # Filter out the "shutdown" or "ping" requests emitted by _ensure_alive
@@ -284,7 +284,7 @@ class TestConcurrentRequestIds:
         ):
             tool_coros = [
                 client.call_tool("list_dir", {"path": f"/tmp/{i}"})
-                for i in range(half)  # nosec B108 - test/controlled code uses tmpdir intentionally
+                for i in range(half)  # nosec B108  # test/controlled code uses tmpdir intentionally
             ]
             health_coros = [client.health_check() for _ in range(half)]
             await asyncio.gather(*tool_coros, *health_coros)

--- a/autobot-backend/services/mesh_brain/mesh_db.py
+++ b/autobot-backend/services/mesh_brain/mesh_db.py
@@ -171,7 +171,7 @@ class MeshDB:
             updates.append("origin = :origin")
             params["origin"] = origin
         sql = text(
-            f"UPDATE mesh_edges SET {', '.join(updates)} WHERE id = :edge_id::uuid"  # nosec B608 - column names are
+            f"UPDATE mesh_edges SET {', '.join(updates)} WHERE id = :edge_id::uuid"  # nosec B608  # column names are
         )
         async with self.engine.begin() as conn:
             await conn.execute(sql, params)

--- a/autobot-backend/services/npu_pipeline/dispatcher.py
+++ b/autobot-backend/services/npu_pipeline/dispatcher.py
@@ -29,8 +29,8 @@ from services.npu_pipeline.shard_planner import ShardAssignment
 logger = get_logger(__name__)
 
 WORKER_TIMEOUT_S = 30
-FORWARD_PASS_PATH = "/forward"  # nosec B105 - HTTP API path constant, not a password
-TOKEN_STREAM_PATH = "/generate"  # nosec B105 - HTTP API path constant for LLM token streaming, not a credential
+FORWARD_PASS_PATH = "/forward"  # nosec B105  # HTTP API path constant, not a password
+TOKEN_STREAM_PATH = "/generate"  # nosec B105  # HTTP API path constant for LLM token streaming, not a credential
 
 
 class WorkerDropError(Exception):

--- a/autobot-backend/services/npu_worker_manager.py
+++ b/autobot-backend/services/npu_worker_manager.py
@@ -510,7 +510,7 @@ class NPUWorkerManager(AsyncInitializable):
                 return  # nothing to probe
             model_id = random.choice(
                 models_list
-            )  # nosec B311 - random probe selection for health check, not cryptographic
+            )  # nosec B311  # random probe selection for health check, not cryptographic
         except Exception as e:
             logger.debug("Pulse-probe: could not fetch models for worker %s: %s", worker_id, e)
             return
@@ -651,7 +651,7 @@ class NPUWorkerManager(AsyncInitializable):
                         logger.debug("Pulse-probe error for worker %s: %s", worker_id, e)
 
                 # Jitter: ±20 % of base_interval
-                jitter = base_interval * 0.2 * (random.random() * 2 - 1)  # nosec B311 - interval jitter to prevent
+                jitter = base_interval * 0.2 * (random.random() * 2 - 1)  # nosec B311  # interval jitter to prevent
                 await asyncio.sleep(max(base_interval + jitter, 60))
 
             except asyncio.CancelledError:

--- a/autobot-backend/services/provider_key_vault.py
+++ b/autobot-backend/services/provider_key_vault.py
@@ -131,7 +131,7 @@ async def capture_provider_key(
             session,
             owner_vault=_SYSTEM_VAULT,
             name=name,
-            secret_type="api_key",  # nosec B106 - SecretType label, not a credential
+            secret_type="api_key",  # nosec B106  # SecretType label, not a credential
             plaintext=plaintext.encode("utf-8"),
             created_by=created_by,
         )

--- a/autobot-backend/services/rs256_revocation.py
+++ b/autobot-backend/services/rs256_revocation.py
@@ -53,7 +53,7 @@ async def revoke_authority_token_jti(token: str) -> bool:
         JWTDecodeError: Token is malformed and the jti cannot be extracted.
     """
     alg = _peek_alg(token)
-    if alg != "RS256":  # nosec B105 - JWT algorithm identifier string, not a credential
+    if alg != "RS256":  # nosec B105  # JWT algorithm identifier string, not a credential
         raise JWTDecodeError(f"revoke_authority_token_jti: expected RS256 token, got alg={alg!r}")
 
     mw = get_auth_middleware()

--- a/autobot-backend/services/run_jwt.py
+++ b/autobot-backend/services/run_jwt.py
@@ -83,7 +83,7 @@ class JWTRefreshConflictError(Exception):
 
 logger = get_logger(__name__)
 
-_ENV_SECRET = "RUN_JWT_SECRET"  # nosec B105 - environment variable name constant, not a hardcoded secret
+_ENV_SECRET = "RUN_JWT_SECRET"  # nosec B105  # environment variable name constant, not a hardcoded secret
 _ENV_TTL = "RUN_JWT_TTL_SECONDS"
 _ENV_AUDIENCE = "RUN_JWT_AUDIENCE"
 _ENV_FAIL_OPEN = "RUN_JWT_REDIS_FAIL_OPEN"

--- a/autobot-backend/services/secrets_service.py
+++ b/autobot-backend/services/secrets_service.py
@@ -26,7 +26,7 @@ logger = get_logger(__name__)
 # Canonical singleton; avoids routing through config/__init__ lazy alias (Issue #3829)
 config_manager = _get_config_manager()
 
-_INSERT_SECRET_SQL = (  # nosec B105 - parameterized SQL constant for INSERT; all values bound via ? placeholders
+_INSERT_SECRET_SQL = (  # nosec B105  # parameterized SQL constant for INSERT; all values bound via ? placeholders
     "INSERT INTO secrets ("
     "id, name, description, secret_type, encrypted_value, "
     "scope, chat_id, created_at, updated_at, expires_at, created_by, metadata"
@@ -465,7 +465,7 @@ class SecretsService:
         params.append(now_utc().isoformat())
         params.append(secret_id)
 
-        query = f"UPDATE secrets SET {', '.join(updates)} WHERE id = ? AND is_active = 1"  # nosec B608 - column names
+        query = f"UPDATE secrets SET {', '.join(updates)} WHERE id = ? AND is_active = 1"  # nosec B608  # column names
 
         conn = sqlite3.connect(self.db_path)
         cursor = conn.cursor()

--- a/autobot-backend/services/security_tool_parsers.py
+++ b/autobot-backend/services/security_tool_parsers.py
@@ -12,7 +12,7 @@ Issue: #260
 """
 
 import re
-import xml.etree.ElementTree as ET  # nosec B405 - parsing trusted nmap output
+import xml.etree.ElementTree as ET  # nosec B405  # parsing trusted nmap output
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any
@@ -209,7 +209,7 @@ class NmapParser(BaseToolParser):
         result = self._create_output(scan_type="xml")
 
         try:
-            root = ET.fromstring(xml_output)  # nosec B314 - parsing trusted nmap output
+            root = ET.fromstring(xml_output)  # nosec B314  # parsing trusted nmap output
 
             # Get scan info
             if root.get("args"):

--- a/autobot-backend/services/simple_pty.py
+++ b/autobot-backend/services/simple_pty.py
@@ -137,7 +137,7 @@ class SimplePTY:
             bash_cmd.append("--login")
             logger.info(f"Starting login shell for session {self.session_id} (loads profile files)")
         self.process = (
-            subprocess.Popen(  # nosec B603 - bash_cmd is ["/bin/bash"] with optional --login; fixed absolute path
+            subprocess.Popen(  # nosec B603  # bash_cmd is ["/bin/bash"] with optional --login; fixed absolute path
                 bash_cmd,
                 stdin=slave_fd,
                 stdout=slave_fd,

--- a/autobot-backend/services/task_workspace.py
+++ b/autobot-backend/services/task_workspace.py
@@ -210,7 +210,7 @@ def release(
     # keep_on_failure is True the directory can still be evicted later.
     (workspace_dir / _ACTIVE_LOCK_FILENAME).unlink(missing_ok=True)
     try:
-        subprocess.run(  # nosec B603 B607 - fixed git argv; workspace_dir is a validated Path object
+        subprocess.run(  # nosec B603 B607  # fixed git argv; workspace_dir is a validated Path object
             ["git", "worktree", "remove", "--force", str(workspace_dir)],
             cwd=str(root),
             check=True,
@@ -220,7 +220,7 @@ def release(
         # Best-effort branch deletion — ignore failures (e.g. branch pushed / not
         # found). Cleanup/eviction passes force_branch=False → ``-d`` keeps a
         # branch with unmerged commits rather than force-dropping it (GH#11059).
-        subprocess.run(  # nosec B603 B607 - fixed git argv; branch name constructed from task_id
+        subprocess.run(  # nosec B603 B607  # fixed git argv; branch name constructed from task_id
             ["git", "branch", "-D" if force_branch else "-d", branch],
             cwd=str(root),
             check=False,
@@ -341,7 +341,7 @@ async def release_for_task(
 def _git_add_worktree(root: Path, workspace_dir: Path, branch: str) -> None:
     """Run git worktree add, handling pre-existing branch/directory gracefully."""
     try:
-        subprocess.run(  # nosec B603 B607 - fixed git argv; branch and workspace_dir are validated Path/str values
+        subprocess.run(  # nosec B603 B607  # fixed git argv; branch and workspace_dir are validated Path/str values
             ["git", "worktree", "add", "-b", branch, str(workspace_dir)],
             cwd=str(root),
             check=True,
@@ -353,7 +353,7 @@ def _git_add_worktree(root: Path, workspace_dir: Path, branch: str) -> None:
         # Branch already exists from a previous partial allocation — reuse it
         if "already exists" in stderr:
             try:
-                subprocess.run(  # nosec B603 B607 - fixed git argv; branch and workspace_dir are validated Path/str
+                subprocess.run(  # nosec B603 B607  # fixed git argv; branch and workspace_dir are validated Path/str
                     ["git", "worktree", "add", str(workspace_dir), branch],
                     cwd=str(root),
                     check=True,

--- a/autobot-backend/services/telegram_bot_service.py
+++ b/autobot-backend/services/telegram_bot_service.py
@@ -23,9 +23,9 @@ logger = get_logger(__name__)
 
 # Redis keys for storing Telegram bot config
 TELEGRAM_BOT_TOKEN_KEY = (
-    "autobot:settings:telegram_bot_token"  # nosec B105 - Redis key name for storing the token, not the token itself
+    "autobot:settings:telegram_bot_token"  # nosec B105  # Redis key name for storing the token, not the token itself
 )
-TELEGRAM_WEBHOOK_SECRET_KEY = "autobot:settings:telegram_webhook_secret"  # nosec B105 - Redis key name for storing the
+TELEGRAM_WEBHOOK_SECRET_KEY = "autobot:settings:telegram_webhook_secret"  # nosec B105  # Redis key name for storing the
 
 # Sentinel prefix for encrypted values (backward compatibility)
 _ENCRYPTED_PREFIX = "enc:"

--- a/autobot-backend/services/terminal_secrets_service.py
+++ b/autobot-backend/services/terminal_secrets_service.py
@@ -33,7 +33,7 @@ from autobot_shared.logging_manager import get_logger
 
 import asyncio
 import os
-import subprocess  # nosec B404 - Required for SSH key validation
+import subprocess  # nosec B404  # Required for SSH key validation
 import tempfile
 import threading
 from dataclasses import dataclass, field
@@ -280,7 +280,7 @@ class TerminalSecretsService:
         """
         try:
             # Try to read key without passphrase using ssh-keygen
-            result = subprocess.run(  # nosec B603 B607 - fixed ssh-keygen argv for passphrase check; key_path is an
+            result = subprocess.run(  # nosec B603 B607  # fixed ssh-keygen argv for passphrase check; key_path is an
                 ["ssh-keygen", "-y", "-P", "", "-f", key_path],
                 capture_output=True,
                 timeout=5,

--- a/autobot-backend/services/tool_output_filter.py
+++ b/autobot-backend/services/tool_output_filter.py
@@ -261,7 +261,7 @@ def tee_and_hint(raw: str, slug: str, exit_code: int, mode: str = "failures") ->
     if len(raw) <= 500:
         return None
     safe_slug = re.sub(r"[^\w-]", "_", slug)[:60]
-    checksum = hashlib.md5(raw.encode("utf-8"), usedforsecurity=False).hexdigest()[:8]  # nosec B324 - noqa: S324
+    checksum = hashlib.md5(raw.encode("utf-8"), usedforsecurity=False).hexdigest()[:8]  # nosec B324  # noqa: S324
     filename = f"{safe_slug}.{checksum}.txt"
     try:
         _TEE_DIR.mkdir(parents=True, exist_ok=True)

--- a/autobot-backend/services/trigger_service.py
+++ b/autobot-backend/services/trigger_service.py
@@ -78,7 +78,7 @@ _KEY_PREFIX = "workflows:trigger:"
 _INDEX_KEY = "workflows:triggers:index"
 _BY_WORKFLOW_PREFIX = "workflows:triggers:by_workflow:"
 _SECRET_PREFIX = (
-    "workflows:trigger_secret:"  # nosec B105 - Redis key prefix for webhook secrets, not a hardcoded secret
+    "workflows:trigger_secret:"  # nosec B105  # Redis key prefix for webhook secrets, not a hardcoded secret
 )
 
 
@@ -289,7 +289,7 @@ def _normalize_dow_field(field: str) -> str:
         if re.fullmatch(r"\*/\d+", token):
             return token
         # Scalar
-        return "0" if token == "7" else token  # nosec B105 - 'token' is a cron field token (string segment), not a
+        return "0" if token == "7" else token  # nosec B105  # 'token' is a cron field token (string segment), not a
 
     # Split on comma, normalize each part, rejoin
     return ",".join(_replace_token(part) for part in field.split(","))

--- a/autobot-backend/services/url_validator_test.py
+++ b/autobot-backend/services/url_validator_test.py
@@ -188,7 +188,7 @@ class TestResolveSafeIP:
                     6,
                     "",
                     ("0.0.0.0", 0),
-                )  # nosec B104 - intentional bind to all interfaces for service/test
+                )  # nosec B104  # intentional bind to all interfaces for service/test
             ]
             mock_loop.return_value.getaddrinfo = mock_getaddrinfo
 

--- a/autobot-backend/services/whatsapp_service.py
+++ b/autobot-backend/services/whatsapp_service.py
@@ -33,12 +33,12 @@ from integrations.whatsapp_integration import WhatsAppIntegration
 logger = get_logger(__name__)
 
 # Redis keys for storing WhatsApp channel config (key names, not secrets)
-WHATSAPP_ACCESS_TOKEN_KEY = "autobot:settings:whatsapp_access_token"  # nosec B105 - Redis key name
-WHATSAPP_APP_SECRET_KEY = "autobot:settings:whatsapp_app_secret"  # nosec B105 - Redis key name
-WHATSAPP_VERIFY_TOKEN_KEY = "autobot:settings:whatsapp_verify_token"  # nosec B105 - Redis key name
-WHATSAPP_PHONE_NUMBER_ID_KEY = "autobot:settings:whatsapp_phone_number_id"  # nosec B105 - Redis key name
-WHATSAPP_BUSINESS_ACCOUNT_ID_KEY = "autobot:settings:whatsapp_business_account_id"  # nosec B105 - Redis key name
-WHATSAPP_BASE_URL_KEY = "autobot:settings:whatsapp_base_url"  # nosec B105 - Redis key name
+WHATSAPP_ACCESS_TOKEN_KEY = "autobot:settings:whatsapp_access_token"  # nosec B105  # Redis key name
+WHATSAPP_APP_SECRET_KEY = "autobot:settings:whatsapp_app_secret"  # nosec B105  # Redis key name
+WHATSAPP_VERIFY_TOKEN_KEY = "autobot:settings:whatsapp_verify_token"  # nosec B105  # Redis key name
+WHATSAPP_PHONE_NUMBER_ID_KEY = "autobot:settings:whatsapp_phone_number_id"  # nosec B105  # Redis key name
+WHATSAPP_BUSINESS_ACCOUNT_ID_KEY = "autobot:settings:whatsapp_business_account_id"  # nosec B105  # Redis key name
+WHATSAPP_BASE_URL_KEY = "autobot:settings:whatsapp_base_url"  # nosec B105  # Redis key name
 
 # Sentinel prefix for encrypted values (backward compatibility with plaintext)
 _ENCRYPTED_PREFIX = "enc:"

--- a/autobot-backend/services/workflow_secret_service.py
+++ b/autobot-backend/services/workflow_secret_service.py
@@ -77,7 +77,7 @@ class WorkflowSecretService:
         name: str,
         value: str,
         owner_id: str,
-        secret_type: str = "api_key",  # nosec B107 - secret_type category, not a password
+        secret_type: str = "api_key",  # nosec B107  # secret_type category, not a password
         workflow_id: str | None = None,
         description: str | None = None,
     ) -> Dict:

--- a/autobot-backend/slash_command_handler.py
+++ b/autobot-backend/slash_command_handler.py
@@ -1028,9 +1028,9 @@ No secrets found.
 
         type_emojis = {
             "ssh_key": "🔑",
-            "password": "🔒",  # nosec B105 - UI emoji mapping for secret type labels, not a password
+            "password": "🔒",  # nosec B105  # UI emoji mapping for secret type labels, not a password
             "api_key": "🔌",
-            "token": "🎫",  # nosec B105 - UI emoji mapping for token type label, not a credential
+            "token": "🎫",  # nosec B105  # UI emoji mapping for token type label, not a credential
             "certificate": "📜",
             "database_url": "🗄️",
             "other": "📦",

--- a/autobot-backend/system_integration.py
+++ b/autobot-backend/system_integration.py
@@ -12,7 +12,7 @@ and converting HTML/Markdown content via the optional markdownify dep.
 import json
 import os
 import platform
-import subprocess  # nosec B404 - required for system commands
+import subprocess  # nosec B404  # required for system commands
 from typing import Any, Dict, List
 
 from autobot_shared.logging_manager import get_logger
@@ -98,7 +98,7 @@ class SystemIntegration:
                 capture_output=True,
                 text=True,
                 check=True,
-                shell=shell,  # nosec B602 - shell=False by default, caller controls
+                shell=shell,  # nosec B602  # shell=False by default, caller controls
             )
             # Cache stripped values to avoid repeated calls (Issue #624)
             stdout_stripped = result.stdout.strip() if result.stdout else ""
@@ -313,7 +313,7 @@ class SystemIntegration:
         # This is similar to execute_shell_command in worker_node,
         # but kept here for abstraction and potential future OS-specific
         # enhancements (e.g., direct API calls instead of shell)
-        return self._run_command([command], shell=True)  # nosec B604 - internal command execution
+        return self._run_command([command], shell=True)  # nosec B604  # internal command execution
 
     def get_process_info(self, process_name: str | None = None, pid: int | None = None) -> Dict[str, Any]:
         """

--- a/autobot-backend/tasks/knowledge_tasks.py
+++ b/autobot-backend/tasks/knowledge_tasks.py
@@ -13,7 +13,7 @@ Issue #424: Added periodic task for incremental man page updates.
 import asyncio
 import fnmatch
 import os
-import subprocess  # nosec B404 - used for internal script execution only
+import subprocess  # nosec B404  # used for internal script execution only
 import sys
 import time
 from pathlib import Path
@@ -85,7 +85,7 @@ def _run_indexing_subprocess() -> dict:
     dict.  On non-zero exit returns a 'failed' dict; on success returns a
     'success' dict with commands_indexed and total_facts.
     """
-    result = subprocess.run(  # nosec B603 - uses sys.executable with fixed internal script path
+    result = subprocess.run(  # nosec B603  # uses sys.executable with fixed internal script path
         [sys.executable, "scripts/utilities/index_all_man_pages.py"],
         capture_output=True,
         text=True,

--- a/autobot-backend/tests/api/test_auth_validate_rbac.py
+++ b/autobot-backend/tests/api/test_auth_validate_rbac.py
@@ -60,7 +60,7 @@ def _make_mw(payload: dict | None = None, session: dict | None = None) -> MagicM
     mw.verify_jwt_token.return_value = payload
     mw.get_session.return_value = session
     mw.jwt_public_key = "fake-pub-key"
-    mw.jwt_secret = "fake-secret"  # nosec B105 - test value only
+    mw.jwt_secret = "fake-secret"  # nosec B105  # test value only
     return mw
 
 

--- a/autobot-backend/tests/integration/mcp_isolation/test_mcp_bridge_isolation.py
+++ b/autobot-backend/tests/integration/mcp_isolation/test_mcp_bridge_isolation.py
@@ -285,7 +285,7 @@ class TestWorkerRestartOnCrash:
 
         with patch("asyncio.create_subprocess_exec", new=spawn):
             result = await client.call_tool(
-                "read_file", {"path": "/tmp/x"}  # nosec B108 - test/controlled code uses tmpdir intentionally
+                "read_file", {"path": "/tmp/x"}  # nosec B108  # test/controlled code uses tmpdir intentionally
             )
 
         assert spawn.await_count == 1, "Should have spawned exactly one new worker"
@@ -394,7 +394,7 @@ class TestCircuitBreakerOnPersistentFailures:
         client = IsolatedBridgeClient("filesystem_mcp", _make_policy())
         with patch("asyncio.create_subprocess_exec", new=AsyncMock(return_value=eof_proc)):
             result = await client.call_tool(
-                "read_file", {"path": "/tmp/z"}  # nosec B108 - test/controlled code uses tmpdir intentionally
+                "read_file", {"path": "/tmp/z"}  # nosec B108  # test/controlled code uses tmpdir intentionally
             )
 
         assert result["success"] is False

--- a/autobot-backend/tests/memory/test_working_memory.py
+++ b/autobot-backend/tests/memory/test_working_memory.py
@@ -171,7 +171,7 @@ def test_manager_exposes_working_memory_property():
     from memory.manager import MemoryManager
 
     mgr = MemoryManager(
-        db_path="/tmp/test_wm_manager.db"  # nosec B108 - test/controlled code uses tmpdir intentionally
+        db_path="/tmp/test_wm_manager.db"  # nosec B108  # test/controlled code uses tmpdir intentionally
     )
     svc = mgr.working_memory
     assert isinstance(svc, WorkingMemoryService)

--- a/autobot-backend/tests/test_exceptions_canonical.py
+++ b/autobot-backend/tests/test_exceptions_canonical.py
@@ -108,9 +108,9 @@ class TestInstantiation:
         err = exc.FileOperationError(
             "io fail",
             file_path="/tmp/x",
-            operation="read",  # nosec B108 - test/controlled code uses tmpdir intentionally
+            operation="read",  # nosec B108  # test/controlled code uses tmpdir intentionally
         )
-        assert err.file_path == "/tmp/x"  # nosec B108 - test/controlled code uses tmpdir intentionally
+        assert err.file_path == "/tmp/x"  # nosec B108  # test/controlled code uses tmpdir intentionally
         assert err.operation == "read"
 
     def test_internal_error_safe_message(self):

--- a/autobot-backend/tests/test_health_probe_data_contract.py
+++ b/autobot-backend/tests/test_health_probe_data_contract.py
@@ -247,7 +247,7 @@ _real_load_schemas_workflows()
 _pkg_stub("constants")
 _leaf_stub(
     "constants.path_constants",
-    PATH=types.SimpleNamespace(PROJECT_ROOT="/tmp"),  # nosec B108 - test/controlled code uses tmpdir intentionally
+    PATH=types.SimpleNamespace(PROJECT_ROOT="/tmp"),  # nosec B108  # test/controlled code uses tmpdir intentionally
 )
 _leaf_stub("constants.threshold_constants", TimingConstants=MagicMock())
 

--- a/autobot-backend/tests/unit/chat_workflow/test_code_exec.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_code_exec.py
@@ -595,7 +595,7 @@ def test_shim_emits_monotonic_ids_and_correlates():
     from chat_workflow.code_exec.shim_codegen import generate_shim_module
 
     ns: dict = {}
-    exec(generate_shim_module(["web_search"]), ns)  # nosec B102 — generated trusted shim under test
+    exec(generate_shim_module(["web_search"]), ns)  # nosec B102  # generated trusted shim under test
     assert ns["_next_id"]() == 1
     assert ns["_next_id"]() == 2  # monotonic, not a constant tool-name id
     # Correlation: a reply keyed by id is retrievable by that id, out of arrival order.

--- a/autobot-backend/tests/unit/web_fetch/test_site_mapper.py
+++ b/autobot-backend/tests/unit/web_fetch/test_site_mapper.py
@@ -80,7 +80,7 @@ class TestParseUrlset:
     def test_extracts_all_locs(self) -> None:
         import xml.etree.ElementTree as ET
 
-        root = ET.fromstring(_URLSET_XML)  # nosec B314 - test code uses controlled/trusted XML data
+        root = ET.fromstring(_URLSET_XML)  # nosec B314  # test code uses controlled/trusted XML data
         urls = _parse_urlset(root)
         assert urls == ["https://example.com/", "https://example.com/about", "https://example.com/contact"]
 
@@ -88,7 +88,7 @@ class TestParseUrlset:
         import xml.etree.ElementTree as ET
 
         xml = '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></urlset>'
-        root = ET.fromstring(xml)  # nosec B314 - test code uses controlled/trusted XML data
+        root = ET.fromstring(xml)  # nosec B314  # test code uses controlled/trusted XML data
         assert _parse_urlset(root) == []
 
 
@@ -96,7 +96,7 @@ class TestParseSitemapindex:
     def test_extracts_child_locs(self) -> None:
         import xml.etree.ElementTree as ET
 
-        root = ET.fromstring(_SITEMAPINDEX_XML)  # nosec B314 - test code uses controlled/trusted XML data
+        root = ET.fromstring(_SITEMAPINDEX_XML)  # nosec B314  # test code uses controlled/trusted XML data
         locs = _parse_sitemapindex(root)
         assert locs == [
             "https://example.com/sitemap-posts.xml",

--- a/autobot-backend/tools/code_interpreter.py
+++ b/autobot-backend/tools/code_interpreter.py
@@ -55,7 +55,8 @@ def execute_code(code: str, timeout_seconds: int = 30) -> Dict[str, Any]:
             tmp.write(code)
             tmp_path = tmp.name
 
-        result = subprocess.run(  # nosec B603 - uses sys.executable; tmp_path is a controlled temp file written by this process
+        # uses sys.executable; tmp_path is a controlled temp file written by this process
+        result = subprocess.run(  # nosec B603
             [sys.executable, tmp_path],
             capture_output=True,
             timeout=timeout_seconds,

--- a/autobot-backend/tools/parallel/executor_artifacts_test.py
+++ b/autobot-backend/tools/parallel/executor_artifacts_test.py
@@ -31,20 +31,20 @@ class TestArtifactCapture:
         executor = ParallelToolExecutor(tool_dispatcher=AsyncMock(), config=MagicMock())
         call = ToolCall(
             tool_name="edit_file",
-            arguments={"file_path": "/tmp/test.py"},  # nosec B108 - test/controlled code uses tmpdir intentionally
+            arguments={"file_path": "/tmp/test.py"},  # nosec B108  # test/controlled code uses tmpdir intentionally
         )
         capture = executor._capture_pre_state(call)
-        assert capture.filepath == "/tmp/test.py"  # nosec B108 - test/controlled code uses tmpdir intentionally
+        assert capture.filepath == "/tmp/test.py"  # nosec B108  # test/controlled code uses tmpdir intentionally
 
     def test_file_modifying_tool_captures_path_alias(self):
         """File-modifying tools also check 'path' argument key"""
         executor = ParallelToolExecutor(tool_dispatcher=AsyncMock(), config=MagicMock())
         call = ToolCall(
             tool_name="create_file",
-            arguments={"path": "/tmp/new.txt"},  # nosec B108 - test/controlled code uses tmpdir intentionally
+            arguments={"path": "/tmp/new.txt"},  # nosec B108  # test/controlled code uses tmpdir intentionally
         )
         capture = executor._capture_pre_state(call)
-        assert capture.filepath == "/tmp/new.txt"  # nosec B108 - test/controlled code uses tmpdir intentionally
+        assert capture.filepath == "/tmp/new.txt"  # nosec B108  # test/controlled code uses tmpdir intentionally
 
 
 class TestBuildArtifacts:
@@ -55,10 +55,10 @@ class TestBuildArtifacts:
         executor = ParallelToolExecutor(tool_dispatcher=AsyncMock(), config=MagicMock())
         call = ToolCall(
             tool_name="edit_file",
-            arguments={"file_path": "/tmp/test.py"},  # nosec B108 - test/controlled code uses tmpdir intentionally
+            arguments={"file_path": "/tmp/test.py"},  # nosec B108  # test/controlled code uses tmpdir intentionally
         )
         capture = _ArtifactCapture(
-            filepath="/tmp/test.py"  # nosec B108 - test/controlled code uses tmpdir intentionally
+            filepath="/tmp/test.py"  # nosec B108  # test/controlled code uses tmpdir intentionally
         )
         artifacts = executor._build_artifacts(call, capture, {})
         assert len(artifacts) >= 1
@@ -69,10 +69,10 @@ class TestBuildArtifacts:
         executor = ParallelToolExecutor(tool_dispatcher=AsyncMock(), config=MagicMock())
         call = ToolCall(
             tool_name="edit_file",
-            arguments={"file_path": "/tmp/test.py"},  # nosec B108 - test/controlled code uses tmpdir intentionally
+            arguments={"file_path": "/tmp/test.py"},  # nosec B108  # test/controlled code uses tmpdir intentionally
         )
         capture = _ArtifactCapture(
-            filepath="/tmp/test.py"  # nosec B108 - test/controlled code uses tmpdir intentionally
+            filepath="/tmp/test.py"  # nosec B108  # test/controlled code uses tmpdir intentionally
         )
         result = {"original": "line 1\n", "content": "line 1 modified\n"}
         artifacts = executor._build_artifacts(call, capture, result)
@@ -105,10 +105,10 @@ class TestBuildArtifacts:
         executor = ParallelToolExecutor(tool_dispatcher=AsyncMock(), config=MagicMock())
         call = ToolCall(
             tool_name="edit_file",
-            arguments={"file_path": "/tmp/test.py"},  # nosec B108 - test/controlled code uses tmpdir intentionally
+            arguments={"file_path": "/tmp/test.py"},  # nosec B108  # test/controlled code uses tmpdir intentionally
         )
         capture = _ArtifactCapture(
-            filepath="/tmp/test.py"  # nosec B108 - test/controlled code uses tmpdir intentionally
+            filepath="/tmp/test.py"  # nosec B108  # test/controlled code uses tmpdir intentionally
         )
         result = {"original": "before\n", "content": "after\n"}
 
@@ -139,7 +139,7 @@ class TestPublishObservationWithArtifacts:
         action_event = MagicMock(event_id="action-123")
         call = ToolCall(
             tool_name="edit_file",
-            arguments={"file_path": "/tmp/test.py"},  # nosec B108 - test/controlled code uses tmpdir intentionally
+            arguments={"file_path": "/tmp/test.py"},  # nosec B108  # test/controlled code uses tmpdir intentionally
         )
         # Create a valid artifact using build_artifact to ensure JSON serializability
         artifacts = [
@@ -147,7 +147,7 @@ class TestPublishObservationWithArtifacts:
                 artifact_type=ArtifactType.FILE_CHANGE,
                 content="test change",
                 label="test.py",
-                file_path="/tmp/test.py",  # nosec B108 - test/controlled code uses tmpdir intentionally
+                file_path="/tmp/test.py",  # nosec B108  # test/controlled code uses tmpdir intentionally
             )
         ]
 

--- a/autobot-backend/utils/activity_tracker_test.py
+++ b/autobot-backend/utils/activity_tracker_test.py
@@ -225,12 +225,12 @@ class TestDesktopActivityTracking:
             db=mock_db,
             user_id=user_id,
             action="screenshot",
-            screenshot_path="/tmp/screenshot_123.png",  # nosec B108 - test/controlled code uses tmpdir intentionally
+            screenshot_path="/tmp/screenshot_123.png",  # nosec B108  # test/controlled code uses tmpdir intentionally
         )
 
         assert isinstance(activity_id, uuid.UUID)
         activity_model = mock_db.add.call_args[0][0]
         assert (
             "/tmp/screenshot_123.png"
-            in activity_model.screenshot_path  # nosec B108 - test/controlled code uses tmpdir intentionally
+            in activity_model.screenshot_path  # nosec B108  # test/controlled code uses tmpdir intentionally
         )

--- a/autobot-backend/utils/advanced_cache_manager.py
+++ b/autobot-backend/utils/advanced_cache_manager.py
@@ -701,7 +701,7 @@ class AdvancedCacheManager:
                 entry = json.loads(cached_data)
                 timestamp = entry.get("timestamp", 0)
                 keys_with_time.append((timestamp, key))
-            except Exception:  # nosec B112 - intentional skip on parse errors
+            except Exception:  # nosec B112  # intentional skip on parse errors
                 continue
 
         return keys_with_time

--- a/autobot-backend/utils/branch_metrics_test.py
+++ b/autobot-backend/utils/branch_metrics_test.py
@@ -74,7 +74,7 @@ class TestBranchMetricsCollector:
     def collector(self):
         """Create a collector instance."""
         return BranchMetricsCollector(
-            repo_path="/tmp/test-repo",  # nosec B108 - test/controlled code uses tmpdir intentionally
+            repo_path="/tmp/test-repo",  # nosec B108  # test/controlled code uses tmpdir intentionally
             base_branch="Dev_new_gui",
             stale_threshold_days=30,
         )
@@ -82,7 +82,7 @@ class TestBranchMetricsCollector:
     @pytest.mark.asyncio
     async def test_initialization(self, collector):
         """Test collector initialization."""
-        assert collector.repo_path == "/tmp/test-repo"  # nosec B108 - test/controlled code uses tmpdir intentionally
+        assert collector.repo_path == "/tmp/test-repo"  # nosec B108  # test/controlled code uses tmpdir intentionally
         assert collector.base_branch == "Dev_new_gui"
         assert collector.stale_threshold_days == 30
 

--- a/autobot-backend/utils/chromadb_client.py
+++ b/autobot-backend/utils/chromadb_client.py
@@ -21,7 +21,7 @@ async variants to prevent event loop blocking. See Issue #369.
 from __future__ import annotations
 
 import json
-import pickle  # nosec B403 — reading ChromaDB internal pickle files only
+import pickle  # nosec B403  # reading ChromaDB internal pickle files only
 import sqlite3
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Tuple

--- a/autobot-backend/utils/common.py
+++ b/autobot-backend/utils/common.py
@@ -407,7 +407,7 @@ class DatabaseUtils:
             # strict allowlist (letters/digits/underscore) before interpolation
             # so metacharacters can never reach the SQL engine. (#12284, #2845)
             safe_table = validate_sql_identifier(table_name, "table name")
-            query = f"SELECT COUNT(*) FROM {safe_table}"  # nosec B608 - identifier allowlisted
+            query = f"SELECT COUNT(*) FROM {safe_table}"  # nosec B608  # identifier allowlisted
             cursor = conn.cursor()
             cursor.execute(query)
             result = cursor.fetchone()

--- a/autobot-backend/utils/display_utils.py
+++ b/autobot-backend/utils/display_utils.py
@@ -119,7 +119,7 @@ class DisplayDetector:
         try:
             result = subprocess.run(
                 ["xrandr", "--query"], capture_output=True, text=True, timeout=5
-            )  # nosec B603 B607 - fixed argv, system display tool
+            )  # nosec B603 B607  # fixed argv, system display tool
             if result.returncode != 0:
                 return None
 
@@ -140,7 +140,7 @@ class DisplayDetector:
         try:
             result = subprocess.run(
                 ["xdpyinfo"], capture_output=True, text=True, timeout=5
-            )  # nosec B603 B607 - fixed argv, system display info tool
+            )  # nosec B603 B607  # fixed argv, system display info tool
             if result.returncode != 0:
                 return None
 
@@ -163,7 +163,7 @@ class DisplayDetector:
             # Try wlr-randr (for wlroots-based compositors)
             result = subprocess.run(
                 ["wlr-randr"], capture_output=True, text=True, timeout=5
-            )  # nosec B603 B607 - fixed argv, Wayland compositor display tool
+            )  # nosec B603 B607  # fixed argv, Wayland compositor display tool
             if result.returncode != 0:
                 return None
 
@@ -217,7 +217,7 @@ class DisplayDetector:
     def _detect_macos_resolution(self) -> Tuple[int, int]:
         """Detect resolution on macOS (Issue #315 - refactored)."""
         try:
-            result = subprocess.run(  # nosec B603 B607 - fixed argv, macOS system display profiler
+            result = subprocess.run(  # nosec B603 B607  # fixed argv, macOS system display profiler
                 ["system_profiler", "SPDisplaysDataType"],
                 capture_output=True,
                 text=True,
@@ -259,7 +259,7 @@ class DisplayDetector:
 
             result = subprocess.run(
                 powershell_cmd, capture_output=True, text=True, timeout=10
-            )  # nosec B603 - fixed PowerShell script with no user-controlled input
+            )  # nosec B603  # fixed PowerShell script with no user-controlled input
 
             if result.returncode == 0:
                 import json

--- a/autobot-backend/utils/encoding_utils.py
+++ b/autobot-backend/utils/encoding_utils.py
@@ -13,7 +13,7 @@ Created: 2025-10-31
 
 import json
 import re
-import subprocess  # nosec B404 - required for shell detection
+import subprocess  # nosec B404  # required for shell detection
 from pathlib import Path
 from typing import Any, List
 
@@ -193,7 +193,7 @@ def run_command_utf8(cmd: str | List[str], **kwargs) -> subprocess.CompletedProc
     kwargs["text"] = True
     kwargs["errors"] = kwargs.get("errors", "replace")
 
-    return subprocess.run(cmd, **kwargs)  # nosec B603 - encoding wrapper; callers own argv safety
+    return subprocess.run(cmd, **kwargs)  # nosec B603  # encoding wrapper; callers own argv safety
 
 
 def strip_ansi_codes(text: str) -> str:

--- a/autobot-backend/utils/entity_resolver.py
+++ b/autobot-backend/utils/entity_resolver.py
@@ -536,7 +536,7 @@ class EntityResolver:
                 totals["processing_time"] += history.get("processing_time", 0)
                 totals["entities_processed"] += history.get("total_original", 0)
                 totals["entities_resolved"] += history.get("total_canonical", 0)
-            except Exception:  # nosec B112 - skip malformed JSON entries
+            except Exception:  # nosec B112  # skip malformed JSON entries
                 continue
         return totals
 

--- a/autobot-backend/utils/error_boundary_examples.py
+++ b/autobot-backend/utils/error_boundary_examples.py
@@ -61,11 +61,11 @@ async def fetch_external_data(url: str) -> Dict[str, Any]:
     import random
 
     # Simulate network errors
-    if random.random() < 0.3:  # nosec B311 - simulated failure rate for error boundary example, not cryptographic
+    if random.random() < 0.3:  # nosec B311  # simulated failure rate for error boundary example, not cryptographic
         raise ConnectionError(f"Failed to connect to {url}")
 
     # Simulate timeout
-    if random.random() < 0.2:  # nosec B311 - simulated failure rate for error boundary example, not cryptographic
+    if random.random() < 0.2:  # nosec B311  # simulated failure rate for error boundary example, not cryptographic
         raise TimeoutError(f"Timeout connecting to {url}")
 
     # Return mock data

--- a/autobot-backend/utils/gpu_optimization/gpu_detection.py
+++ b/autobot-backend/utils/gpu_optimization/gpu_detection.py
@@ -53,7 +53,7 @@ def _check_nvidia_gpu() -> str | None:
     spawning a second nvidia-smi subprocess.
     """
     try:
-        result = subprocess.run(  # nosec B603 B607 - fixed nvidia-smi argv for GPU detection
+        result = subprocess.run(  # nosec B603 B607  # fixed nvidia-smi argv for GPU detection
             ["nvidia-smi", "--query-gpu=name", "--format=csv,noheader"],
             capture_output=True,
             text=True,
@@ -73,7 +73,7 @@ def _check_nvidia_gpu() -> str | None:
 def _check_amd_gpu() -> bool:
     """Check if an AMD GPU is available via rocm-smi or sysfs."""
     try:
-        result = subprocess.run(  # nosec B603 B607 - fixed rocm-smi argv for AMD GPU detection
+        result = subprocess.run(  # nosec B603 B607  # fixed rocm-smi argv for AMD GPU detection
             ["rocm-smi", "--showid"],
             capture_output=True,
             text=True,
@@ -104,7 +104,7 @@ def _check_apple_gpu() -> Dict[str, Any] | None:
     if platform.system() != "Darwin":
         return None
     try:
-        result = subprocess.run(  # nosec B603 B607 - fixed system_profiler argv for macOS GPU detection
+        result = subprocess.run(  # nosec B603 B607  # fixed system_profiler argv for macOS GPU detection
             ["system_profiler", "SPDisplaysDataType", "-json"],
             capture_output=True,
             text=True,
@@ -231,7 +231,7 @@ def _detect_nvidia_capabilities(
     capabilities.vendor = "nvidia"
     gpu_name = _nvidia_gpu_name
     try:
-        result = subprocess.run(  # nosec B603 B607 - fixed nvidia-smi argv for NVIDIA capability detection
+        result = subprocess.run(  # nosec B603 B607  # fixed nvidia-smi argv for NVIDIA capability detection
             [
                 "nvidia-smi",
                 "--query-gpu=memory.total,cuda_version",
@@ -265,7 +265,7 @@ def _detect_amd_capabilities(
 ) -> GPUCapabilities:
     """Detect AMD GPU capabilities via rocm-smi."""
     try:
-        result = subprocess.run(  # nosec B603 B607 - fixed rocm-smi argv for AMD GPU name detection
+        result = subprocess.run(  # nosec B603 B607  # fixed rocm-smi argv for AMD GPU name detection
             ["rocm-smi", "--showproductname"],
             capture_output=True,
             text=True,
@@ -277,7 +277,7 @@ def _detect_amd_capabilities(
                     capabilities.name = line.strip()
                     break
 
-        mem_result = subprocess.run(  # nosec B603 B607 - fixed rocm-smi argv for AMD VRAM detection
+        mem_result = subprocess.run(  # nosec B603 B607  # fixed rocm-smi argv for AMD VRAM detection
             ["rocm-smi", "--showmeminfo", "vram"],
             capture_output=True,
             text=True,
@@ -357,7 +357,7 @@ def _get_macos_system_memory_gb() -> float:
     Issue #2014: Apple Silicon shares system RAM with GPU.
     """
     try:
-        result = subprocess.run(  # nosec B603 B607 - fixed sysctl argv for macOS memory size
+        result = subprocess.run(  # nosec B603 B607  # fixed sysctl argv for macOS memory size
             ["sysctl", "-n", "hw.memsize"],
             capture_output=True,
             text=True,

--- a/autobot-backend/utils/gpu_vector_search.py
+++ b/autobot-backend/utils/gpu_vector_search.py
@@ -105,7 +105,7 @@ class VectorSearchConfig:
     ivfpq_m_pq: int = 96  # sub-vectors for PQ (dim/8)
     ivfpq_nbits: int = 8  # bits per sub-code
     ivfpq_nprobe: int = 64  # cells to probe at search time
-    ivfpq_index_dir: str = "/tmp/autobot_faiss_indexes"  # nosec B108 - test/controlled code uses tmpdir intentionally
+    ivfpq_index_dir: str = "/tmp/autobot_faiss_indexes"  # nosec B108  # test/controlled code uses tmpdir intentionally
     ivfpq_min_vectors: int = 100_000  # threshold to activate IVFPQ
 
     # Persistence

--- a/autobot-backend/utils/graceful_degradation.py
+++ b/autobot-backend/utils/graceful_degradation.py
@@ -475,7 +475,7 @@ class GracefulDegradationManager:
         """Simulate occasional failures for testing"""
         import random
 
-        return random.random() < 0.1  # nosec B311 - simulated failure rate for testing, not cryptographic
+        return random.random() < 0.1  # nosec B311  # simulated failure rate for testing, not cryptographic
 
     async def _record_success(self):
         """Record a successful request (thread-safe)"""

--- a/autobot-backend/utils/hardware_metrics.py
+++ b/autobot-backend/utils/hardware_metrics.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
-import subprocess  # nosec B404 - Required for nvidia-smi GPU queries
+import subprocess  # nosec B404  # Required for nvidia-smi GPU queries
 import time
 from collections import defaultdict, deque
 from dataclasses import asdict, dataclass, field
@@ -221,7 +221,7 @@ class HardwarePerformanceMonitor:
     def _check_gpu_availability(self) -> bool:
         """Check if NVIDIA GPU is available and accessible"""
         try:
-            result = subprocess.run(  # nosec B603 B607 - fixed nvidia-smi argv, no user input
+            result = subprocess.run(  # nosec B603 B607  # fixed nvidia-smi argv, no user input
                 ["nvidia-smi", "--query-gpu=name", "--format=csv,noheader"],
                 capture_output=True,
                 text=True,
@@ -306,7 +306,7 @@ class HardwarePerformanceMonitor:
 
         try:
             # Extended nvidia-smi query for comprehensive metrics
-            result = subprocess.run(  # nosec B603 B607 - fixed nvidia-smi argv, no user input
+            result = subprocess.run(  # nosec B603 B607  # fixed nvidia-smi argv, no user input
                 [
                     "nvidia-smi",
                     "--query-gpu=name,memory.used,memory.total,utilization.gpu,"

--- a/autobot-backend/utils/long_running_operations/checkpoint_manager.py
+++ b/autobot-backend/utils/long_running_operations/checkpoint_manager.py
@@ -10,7 +10,7 @@ Handles checkpoint save/load/resume functionality.
 """
 
 import json
-import pickle  # nosec B403 - pickle used for internal checkpoint serialization only
+import pickle  # nosec B403  # pickle used for internal checkpoint serialization only
 from datetime import datetime, timezone
 from typing import Any, Dict, List
 

--- a/autobot-backend/utils/long_running_operations_framework.py
+++ b/autobot-backend/utils/long_running_operations_framework.py
@@ -236,7 +236,7 @@ async def _execute_single_test(
     )
 
     await asyncio.sleep(TimingConstants.SHORT_DELAY)  # Simulate test execution
-    test_passed = random.random() > 0.1  # nosec B311 - simulated test pass rate for demo, not cryptographic
+    test_passed = random.random() > 0.1  # nosec B311  # simulated test pass rate for demo, not cryptographic
 
     test_result = _create_test_result(test_file, test_passed, 0.5)
     return test_result, test_passed

--- a/autobot-backend/utils/performance_monitoring/hardware.py
+++ b/autobot-backend/utils/performance_monitoring/hardware.py
@@ -24,7 +24,7 @@ class HardwareDetector:
     def check_gpu_availability() -> bool:
         """Check if NVIDIA GPU is available and accessible."""
         try:
-            result = subprocess.run(  # nosec B603 B607 - fixed nvidia-smi argv for GPU availability check
+            result = subprocess.run(  # nosec B603 B607  # fixed nvidia-smi argv for GPU availability check
                 ["nvidia-smi", "--query-gpu=name", "--format=csv,noheader"],
                 capture_output=True,
                 text=True,

--- a/autobot-backend/utils/redis_immediate_test.py
+++ b/autobot-backend/utils/redis_immediate_test.py
@@ -104,7 +104,7 @@ async def _cleanup_redis_client(client: redis.Redis | None) -> None:
     if client:
         try:
             await asyncio.to_thread(client.close)
-        except Exception:  # nosec B110 - cleanup errors are non-critical
+        except Exception:  # nosec B110  # cleanup errors are non-critical
             pass
 
 

--- a/autobot-backend/utils/terminal_input_handler_test.py
+++ b/autobot-backend/utils/terminal_input_handler_test.py
@@ -105,7 +105,7 @@ class TestTerminalInputHandler:
             ("Do you want to continue? (y/n)", "y"),
             ("Enter your choice (1-3):", "1"),
             ("Please enter a command:", "help"),
-            ("Enter file path:", "/tmp/test_file"),  # nosec B108 - test/controlled code uses tmpdir intentionally
+            ("Enter file path:", "/tmp/test_file"),  # nosec B108  # test/controlled code uses tmpdir intentionally
             ("What is your name?", "test_user"),
             ("Enter port number:", "8080"),
             ("Enter hostname:", "localhost"),

--- a/autobot-backend/utils/timeout_migration_examples.py
+++ b/autobot-backend/utils/timeout_migration_examples.py
@@ -750,14 +750,14 @@ class ExistingOperationMigrator:
 
     def _run_single_test(self, test_file: Path) -> Dict[str, Any]:
         """Run a single test file (placeholder implementation)"""
-        import subprocess  # nosec B404 - controlled pytest execution
+        import subprocess  # nosec B404  # controlled pytest execution
         import time
 
         start_time = time.time()
 
         try:
             # Run pytest on single file
-            result = subprocess.run(  # nosec B603 B607 - sys.executable with fixed pytest args, no user input
+            result = subprocess.run(  # nosec B603 B607  # sys.executable with fixed pytest args, no user input
                 ["python", "-m", "pytest", str(test_file), "-v"],
                 capture_output=True,
                 text=True,

--- a/autobot-backend/voice_processing/providers/lv/late_provider.py
+++ b/autobot-backend/voice_processing/providers/lv/late_provider.py
@@ -36,7 +36,7 @@ class LateProvider(SpeechProvider):
     def _check_availability(self):
         """Check if LATE binary is available."""
         try:
-            result = subprocess.run(  # nosec B603 - fixed argv [binary, "--version"]; binary path is from env var
+            result = subprocess.run(  # nosec B603  # fixed argv [binary, "--version"]; binary path is from env var
                 [self.late_binary, "--version"],
                 capture_output=True,
                 text=True,
@@ -110,12 +110,14 @@ class LateProvider(SpeechProvider):
             JSON output string or None on failure
         """
         try:
-            result = subprocess.run(  # nosec B603 - cmd is [late_binary + fixed flags]; callers construct argv, no user
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=300,  # 5 minute timeout
-                encoding="utf-8",
+            result = (
+                subprocess.run(  # nosec B603  # cmd is [late_binary + fixed flags]; callers construct argv, no user
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    timeout=300,  # 5 minute timeout
+                    encoding="utf-8",
+                )
             )
 
             if result.returncode != 0:

--- a/autobot-backend/web_fetch/site_mapper.py
+++ b/autobot-backend/web_fetch/site_mapper.py
@@ -21,7 +21,7 @@ from autobot_shared.logging_manager import get_logger
 
 from __future__ import annotations
 
-import xml.etree.ElementTree as ET  # nosec B405 — sitemap XML from crawled URLs; XXE risk accepted
+import xml.etree.ElementTree as ET  # nosec B405  # sitemap XML from crawled URLs; XXE risk accepted
 from typing import List
 from urllib.parse import urlparse
 
@@ -109,7 +109,7 @@ def _parse_sitemapindex(root: ET.Element) -> List[str]:
 def _safe_parse(xml_text: str, source_url: str) -> ET.Element | None:
     """Parse XML defensively; log a warning and return None on any error."""
     try:
-        return ET.fromstring(xml_text)  # nosec B314 — sitemap XML from crawled URLs; XXE risk accepted
+        return ET.fromstring(xml_text)  # nosec B314  # sitemap XML from crawled URLs; XXE risk accepted
     except ET.ParseError as exc:
         logger.warning("sitemap XML parse error for %s: %s", source_url, exc)
         return None

--- a/autobot-backend/worker_node.py
+++ b/autobot-backend/worker_node.py
@@ -13,7 +13,7 @@ import asyncio
 import json
 import os
 import platform
-import subprocess  # nosec B404 - required for GPU detection
+import subprocess  # nosec B404  # required for GPU detection
 import sys
 from typing import Any, Dict
 
@@ -195,7 +195,7 @@ class WorkerNode:
         """Get detailed GPU information using nvidia-smi."""
         try:
             nvidia_smi_output = (
-                subprocess.check_output(  # nosec B603 B607 - fixed nvidia-smi argv, no user input
+                subprocess.check_output(  # nosec B603 B607  # fixed nvidia-smi argv, no user input
                     [
                         "nvidia-smi",
                         "--query-gpu=name,memory.total,memory.used,memory.free," "utilization.gpu,utilization.memory",

--- a/autobot-backend/workers/audit_tasks.py
+++ b/autobot-backend/workers/audit_tasks.py
@@ -19,7 +19,7 @@ Beat pidfile MUST NOT reside on tmpfs (/run/autobot/ is wiped on reboot).
 import json
 import os
 import re
-import subprocess  # nosec B404 — internal git/gh CLI calls only
+import subprocess  # nosec B404  # internal git/gh CLI calls only
 import sys
 from datetime import datetime, timezone
 from pathlib import Path

--- a/autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/agent.py
+++ b/autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/agent.py
@@ -404,7 +404,7 @@ class SLMAgent:
                     placeholders = ",".join("?" * len(ids))
                     query = (
                         "UPDATE event_buffer SET synced = 1 "
-                        f"WHERE id IN ({placeholders})"  # nosec B608 - only
+                        f"WHERE id IN ({placeholders})"  # nosec B608  # only
                     )
                     conn.execute(query, ids)
                     conn.commit()

--- a/autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/health_collector.py
+++ b/autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/health_collector.py
@@ -14,7 +14,7 @@ import logging
 import os
 import platform
 import socket
-import subprocess  # nosec B404 - required for systemctl interaction
+import subprocess  # nosec B404  # required for systemctl interaction
 import time
 import urllib.request
 from datetime import datetime
@@ -125,7 +125,7 @@ class HealthCollector:
     def check_service(self, service_name: str) -> Dict:
         """Check systemd service status."""
         try:
-            result = subprocess.run(  # nosec B603 B607 - fixed systemctl argv; service_name is validated by caller
+            result = subprocess.run(  # nosec B603 B607  # fixed systemctl argv; service_name is validated by caller
                 ["systemctl", "is-active", service_name],
                 capture_output=True,
                 text=True,
@@ -198,7 +198,7 @@ class HealthCollector:
 
     def _run_systemctl_list_units(self) -> str | None:
         """Run systemctl list-units command. Issue #620."""
-        result = subprocess.run(  # nosec B603 B607 - fixed systemctl argv for service enumeration
+        result = subprocess.run(  # nosec B603 B607  # fixed systemctl argv for service enumeration
             [
                 "systemctl",
                 "list-units",
@@ -261,7 +261,7 @@ class HealthCollector:
         details = {}
         try:
             # Get service properties
-            result = subprocess.run(  # nosec B603 B607 - fixed systemctl argv; service_name is a discovered unit name
+            result = subprocess.run(  # nosec B603 B607  # fixed systemctl argv; service_name is a discovered unit name
                 [
                     "systemctl",
                     "show",
@@ -300,7 +300,7 @@ class HealthCollector:
         can display why a service failed without requiring SSH.
         """
         try:
-            result = subprocess.run(  # nosec B603 B607 - fixed journalctl argv; service_name is a discovered unit name
+            result = subprocess.run(  # nosec B603 B607  # fixed journalctl argv; service_name is a discovered unit name
                 [
                     "journalctl",
                     "-u",
@@ -406,7 +406,7 @@ class HealthCollector:
         if not url:
             return {}
         try:
-            with urllib.request.urlopen(  # nosec B310 - fixed local http:// URL, not user input
+            with urllib.request.urlopen(  # nosec B310  # fixed local http:// URL, not user input
                 url, timeout=APP_HEALTH_TIMEOUT_SECONDS
             ) as resp:
                 payload = json.loads(resp.read().decode("utf-8"))

--- a/autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/port_scanner.py
+++ b/autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/port_scanner.py
@@ -9,7 +9,7 @@ Detects listening TCP ports on the local system.
 """
 
 import logging
-import subprocess  # nosec B404 - subprocess used with fixed commands for system inspection
+import subprocess  # nosec B404  # subprocess used with fixed commands for system inspection
 from dataclasses import dataclass
 from typing import List
 
@@ -128,7 +128,7 @@ def get_listening_ports() -> List[PortInfo]:
 
     try:
         # ss -tlnp: TCP, listening, numeric, show process
-        result = subprocess.run(  # nosec B603 B607 - fixed ss argv for port scanning, no user input
+        result = subprocess.run(  # nosec B603 B607  # fixed ss argv for port scanning, no user input
             ["ss", "-tlnp"],
             capture_output=True,
             text=True,
@@ -167,7 +167,7 @@ def _get_ports_netstat() -> List[PortInfo]:
     ports = []
 
     try:
-        result = subprocess.run(  # nosec B603 B607 - fixed netstat argv for port scanning, no user input
+        result = subprocess.run(  # nosec B603 B607  # fixed netstat argv for port scanning, no user input
             ["netstat", "-tlnp"],
             capture_output=True,
             text=True,

--- a/autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/role_detector.py
+++ b/autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/role_detector.py
@@ -13,7 +13,7 @@ Detects installed roles on the local system based on:
 
 import json
 import logging
-import subprocess  # nosec B404 - subprocess used for systemctl status checks
+import subprocess  # nosec B404  # subprocess used for systemctl status checks
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List
@@ -132,7 +132,7 @@ class RoleDetector:
     def _check_service(self, service_name: str) -> bool:
         """Check if a systemd service is running."""
         try:
-            result = subprocess.run(  # nosec B603 B607 - fixed systemctl argv; service_name is a configured role name
+            result = subprocess.run(  # nosec B603 B607  # fixed systemctl argv; service_name is a configured role name
                 ["systemctl", "is-active", service_name],
                 capture_output=True,
                 text=True,

--- a/autobot-slm-backend/api/llm_config.py
+++ b/autobot-slm-backend/api/llm_config.py
@@ -56,7 +56,7 @@ class LLMConfig(BaseModel):
     active_provider: str = "ollama"
     providers: List[LLMProviderConfig] = []
     # Ollama server settings (pushed via Ansible)
-    ollama_host: str = "0.0.0.0"  # nosec B104 - intentional bind to all interfaces for service/test
+    ollama_host: str = "0.0.0.0"  # nosec B104  # intentional bind to all interfaces for service/test
     ollama_port: int = 11434
     gpu_models: List[str] = []
     cpu_models: List[str] = []
@@ -154,7 +154,7 @@ async def _load_llm_config(db: AsyncSession) -> LLMConfig:
         providers=providers,
         ollama_host=rows.get(
             "llm_ollama_host", "0.0.0.0"
-        ),  # nosec B104 - intentional bind to all interfaces for service/test
+        ),  # nosec B104  # intentional bind to all interfaces for service/test
         ollama_port=int(rows.get("llm_ollama_port", "11434")),
         gpu_models=gpu_models,
         cpu_models=cpu_models,

--- a/autobot-slm-backend/api/nodes.py
+++ b/autobot-slm-backend/api/nodes.py
@@ -1668,7 +1668,7 @@ async def _prepare_node_extra_data(node_data: NodeCreate) -> dict | None:
         try:
             return {
                 "ssh_password": encrypt_data(node_data.ssh_password),
-                "ssh_password_encrypted": True,  # nosec B105 - boolean flag, not a password; actual password value is
+                "ssh_password_encrypted": True,  # nosec B105  # boolean flag, not a password; actual password value is
             }
         except Exception as e:
             logger.error("Failed to encrypt SSH password: %s", e)

--- a/autobot-slm-backend/api/nodes_execution_test.py
+++ b/autobot-slm-backend/api/nodes_execution_test.py
@@ -334,7 +334,7 @@ class TestValidateCommandFindArgs:
         """_validate_find_args raises HTTP 400 for blocked flags when called directly."""
         with pytest.raises(HTTPException) as exc_info:
             _validate_find_args(
-                ["find", "/tmp", "-delete"]  # nosec B108 - test/controlled code uses tmpdir intentionally
+                ["find", "/tmp", "-delete"]  # nosec B108  # test/controlled code uses tmpdir intentionally
             )
         assert exc_info.value.status_code == 400
 

--- a/autobot-slm-backend/api/secrets.py
+++ b/autobot-slm-backend/api/secrets.py
@@ -36,7 +36,7 @@ from services.system_secrets_vault import delete_vault_copy, retrieve_secret
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/secrets", tags=["secrets"])
 
-HF_TOKEN_KEY = "hf_token"  # nosec B105 - secret-store key name, not a credential
+HF_TOKEN_KEY = "hf_token"  # nosec B105  # secret-store key name, not a credential
 HF_REJECTED_DETAIL = (
     "HuggingFace rejected this token (401): it appears invalid or revoked. "
     "Generate a new token at https://huggingface.co/settings/tokens and try again."

--- a/autobot-slm-backend/config.py
+++ b/autobot-slm-backend/config.py
@@ -226,7 +226,7 @@ class Settings(RedactedReprMixin, BaseSettings):
     db_pool_recycle: int = int(os.getenv("SLM_DB_POOL_RECYCLE", str(_SSOT_POOL_RECYCLE)))
 
     # Server
-    host: str = "0.0.0.0"  # nosec B104 — bound behind nginx reverse proxy
+    host: str = "0.0.0.0"  # nosec B104  # bound behind nginx reverse proxy
     port: int = 8000
     debug: bool = False
 

--- a/autobot-slm-backend/main.py
+++ b/autobot-slm-backend/main.py
@@ -507,7 +507,7 @@ async def _ensure_internal_api_key() -> None:
     from models.database import SystemSecret
     from services.encryption import encrypt_data
 
-    key_name = "autobot_internal_api_key"  # nosec B105 - secret-store key name, not a credential
+    key_name = "autobot_internal_api_key"  # nosec B105  # secret-store key name, not a credential
     async with db_service.session() as db:
         result = await db.execute(select(SystemSecret).where(SystemSecret.key == key_name))
         if result.scalar_one_or_none() is not None:
@@ -537,7 +537,7 @@ async def _ensure_scim_bearer_token() -> None:
     from models.database import SystemSecret
     from services.encryption import encrypt_data
 
-    key_name = "scim_bearer_token"  # nosec B105 - secret-store key name, not a credential
+    key_name = "scim_bearer_token"  # nosec B105  # secret-store key name, not a credential
     async with db_service.session() as db:
         from sqlalchemy import select
 

--- a/autobot-slm-backend/models/database.py
+++ b/autobot-slm-backend/models/database.py
@@ -651,7 +651,7 @@ class SecretCategory(str, enum.Enum):
     """System secret category enumeration (#1417)."""
 
     SYSTEM = "system"
-    API_TOKEN = "api_token"  # nosec B105 - enum value for secret category type, not a credential
+    API_TOKEN = "api_token"  # nosec B105  # enum value for secret category type, not a credential
     SERVICE = "service"
 
 

--- a/autobot-slm-backend/monitoring/advanced_apm_system.py
+++ b/autobot-slm-backend/monitoring/advanced_apm_system.py
@@ -187,7 +187,7 @@ class PerformanceTracker:
 
     def _generate_trace_id(self) -> str:
         """Generate unique trace ID for request correlation."""
-        return hashlib.md5(  # nosec B324 - not used for security
+        return hashlib.md5(  # nosec B324  # not used for security
             f"{time.time()}{threading.current_thread().ident}".encode()
         ).hexdigest()[:16]
 
@@ -410,7 +410,7 @@ class AdvancedAPMSystem:
                 complexity = "complex"
 
             # Generate query hash for tracking
-            query_hash = hashlib.md5(  # nosec B324 - not used for security
+            query_hash = hashlib.md5(  # nosec B324  # not used for security
                 f"{database}:{operation}:{table}".encode()
             ).hexdigest()[:12]
 

--- a/autobot-slm-backend/monitoring/performance_dashboard.py
+++ b/autobot-slm-backend/monitoring/performance_dashboard.py
@@ -690,7 +690,7 @@ class PerformanceDashboard:
         # Start the web server
         runner = web.AppRunner(self.app)
         await runner.setup()
-        bind_host = "0.0.0.0"  # nosec B104: dashboard bind
+        bind_host = "0.0.0.0"  # nosec B104  # dashboard bind
         site = web.TCPSite(runner, bind_host, self.port)
         await site.start()
 

--- a/autobot-slm-backend/services/ansible_secrets.py
+++ b/autobot-slm-backend/services/ansible_secrets.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 # backend_jwt_secret so AUTOBOT_JWT_SECRET == SLM_SECRET_KEY (same #7689 pattern as
 # SLM_AUTH_TOKEN). Adding it to this DB-keyed map would never resolve.
 _SECRET_TO_ANSIBLE_VAR: dict[str, str] = {
-    "hf_token": "tts_hf_token",  # nosec B105 - dict maps secret DB key names to Ansible variable names, not credential
+    "hf_token": "tts_hf_token",  # nosec B105  # dict maps secret DB key names to Ansible variable names, not credential
     "autobot_internal_api_key": "autobot_internal_api_key",
 }
 

--- a/autobot-slm-backend/services/auth.py
+++ b/autobot-slm-backend/services/auth.py
@@ -188,7 +188,7 @@ class AuthService:
         )
         return TokenResponse(
             access_token=access_token,
-            token_type="bearer",  # nosec B106 - standard OAuth2 token type
+            token_type="bearer",  # nosec B106  # standard OAuth2 token type
             expires_in=settings.access_token_expire_minutes * 60,
         )
 

--- a/autobot-slm-backend/services/jwks_verifier.py
+++ b/autobot-slm-backend/services/jwks_verifier.py
@@ -212,7 +212,7 @@ async def verify_authority_token(token: str) -> Optional[Dict[str, Any]]:
     fetch_timeout = settings.jwks_fetch_timeout_seconds
 
     token_alg = _peek_alg(token)
-    if token_alg != "RS256":  # nosec B105 - JWT algorithm identifier, not a credential
+    if token_alg != "RS256":  # nosec B105  # JWT algorithm identifier, not a credential
         # Called with a non-RS256 token — logic error in caller
         logger.warning("verify_authority_token called with non-RS256 token (alg=%r)", token_alg)
         return None

--- a/autobot-slm-backend/services/replication.py
+++ b/autobot-slm-backend/services/replication.py
@@ -368,7 +368,7 @@ class ReplicationService:
         source_result = await db.execute(select(Node).where(Node.node_id == replication.source_node_id))
         source_node = source_result.scalar_one_or_none()
 
-        redis_password = ""  # nosec B105 - empty initial value; real password fetched via _get_redis_password() below
+        redis_password = ""  # nosec B105  # empty initial value; real password fetched via _get_redis_password() below
         if source_node:
             redis_password = await self._get_redis_password(
                 source_node.ip_address,

--- a/autobot-slm-backend/services/security_posture_auditor.py
+++ b/autobot-slm-backend/services/security_posture_auditor.py
@@ -65,7 +65,7 @@ SENSITIVE_PORTS: "dict[int, tuple[str, str]]" = {
 }
 
 _LOOPBACK_ADDRESSES = frozenset({"127.0.0.1", "::1", "localhost"})
-_WILDCARD_ADDRESSES = frozenset({"0.0.0.0", "*", "::"})  # nosec B104 - detection allowlist, not a bind
+_WILDCARD_ADDRESSES = frozenset({"0.0.0.0", "*", "::"})  # nosec B104  # detection allowlist, not a bind
 
 # Module-level background-task state (mirrors schedule_executor.py).
 _auditor_running = False

--- a/autobot-slm-backend/services/system_secrets_vault.py
+++ b/autobot-slm-backend/services/system_secrets_vault.py
@@ -55,13 +55,13 @@ logger = logging.getLogger(__name__)
 
 #: Auth-bootstrap credential — gates access to the vault this module talks to.
 #: Migrating it would create a confused-deputy cycle; see module docstring.
-IRREDUCIBLE_KEYS: frozenset[str] = frozenset({"autobot_internal_api_key"})  # nosec B105 - key name, not a credential
+IRREDUCIBLE_KEYS: frozenset[str] = frozenset({"autobot_internal_api_key"})  # nosec B105  # key name, not a credential
 
 #: SSO provider secrets already have a dedicated migration path (#10153).
 _SSO_KEY_PREFIX = "sso:provider:"
 
 #: Vault secret-type label for system_secrets rows imported by this module.
-_SECRET_TYPE = "system-secret"  # nosec B105 - type label, not a credential
+_SECRET_TYPE = "system-secret"  # nosec B105  # type label, not a credential
 
 
 def is_migratable(key: str) -> bool:

--- a/autobot-slm-backend/slm/agent/agent.py
+++ b/autobot-slm-backend/slm/agent/agent.py
@@ -404,7 +404,7 @@ class SLMAgent:
                     placeholders = ",".join("?" * len(ids))
                     query = (
                         "UPDATE event_buffer SET synced = 1 "
-                        f"WHERE id IN ({placeholders})"  # nosec B608 - only
+                        f"WHERE id IN ({placeholders})"  # nosec B608  # only
                     )
                     conn.execute(query, ids)
                     conn.commit()

--- a/autobot-slm-backend/slm/agent/health_collector.py
+++ b/autobot-slm-backend/slm/agent/health_collector.py
@@ -14,7 +14,7 @@ import logging
 import os
 import platform
 import socket
-import subprocess  # nosec B404 - required for systemctl interaction
+import subprocess  # nosec B404  # required for systemctl interaction
 import time
 import urllib.request
 from datetime import datetime
@@ -125,7 +125,7 @@ class HealthCollector:
     def check_service(self, service_name: str) -> Dict:
         """Check systemd service status."""
         try:
-            result = subprocess.run(  # nosec B603 B607 - fixed systemctl argv; service_name is validated by caller
+            result = subprocess.run(  # nosec B603 B607  # fixed systemctl argv; service_name is validated by caller
                 ["systemctl", "is-active", service_name],
                 capture_output=True,
                 text=True,
@@ -198,7 +198,7 @@ class HealthCollector:
 
     def _run_systemctl_list_units(self) -> str | None:
         """Run systemctl list-units command. Issue #620."""
-        result = subprocess.run(  # nosec B603 B607 - fixed systemctl argv for service enumeration
+        result = subprocess.run(  # nosec B603 B607  # fixed systemctl argv for service enumeration
             [
                 "systemctl",
                 "list-units",
@@ -261,7 +261,7 @@ class HealthCollector:
         details = {}
         try:
             # Get service properties
-            result = subprocess.run(  # nosec B603 B607 - fixed systemctl argv; service_name is a discovered unit name
+            result = subprocess.run(  # nosec B603 B607  # fixed systemctl argv; service_name is a discovered unit name
                 [
                     "systemctl",
                     "show",
@@ -300,7 +300,7 @@ class HealthCollector:
         can display why a service failed without requiring SSH.
         """
         try:
-            result = subprocess.run(  # nosec B603 B607 - fixed journalctl argv; service_name is a discovered unit name
+            result = subprocess.run(  # nosec B603 B607  # fixed journalctl argv; service_name is a discovered unit name
                 [
                     "journalctl",
                     "-u",
@@ -406,7 +406,7 @@ class HealthCollector:
         if not url:
             return {}
         try:
-            with urllib.request.urlopen(  # nosec B310 - fixed local http:// URL, not user input
+            with urllib.request.urlopen(  # nosec B310  # fixed local http:// URL, not user input
                 url, timeout=APP_HEALTH_TIMEOUT_SECONDS
             ) as resp:
                 payload = json.loads(resp.read().decode("utf-8"))

--- a/autobot-slm-backend/slm/agent/port_scanner.py
+++ b/autobot-slm-backend/slm/agent/port_scanner.py
@@ -9,7 +9,7 @@ Detects listening TCP ports on the local system.
 """
 
 import logging
-import subprocess  # nosec B404 - subprocess used with fixed commands for system inspection
+import subprocess  # nosec B404  # subprocess used with fixed commands for system inspection
 from dataclasses import dataclass
 from typing import List
 
@@ -128,7 +128,7 @@ def get_listening_ports() -> List[PortInfo]:
 
     try:
         # ss -tlnp: TCP, listening, numeric, show process
-        result = subprocess.run(  # nosec B603 B607 - fixed ss argv for port scanning, no user input
+        result = subprocess.run(  # nosec B603 B607  # fixed ss argv for port scanning, no user input
             ["ss", "-tlnp"],
             capture_output=True,
             text=True,
@@ -167,7 +167,7 @@ def _get_ports_netstat() -> List[PortInfo]:
     ports = []
 
     try:
-        result = subprocess.run(  # nosec B603 B607 - fixed netstat argv for port scanning, no user input
+        result = subprocess.run(  # nosec B603 B607  # fixed netstat argv for port scanning, no user input
             ["netstat", "-tlnp"],
             capture_output=True,
             text=True,

--- a/autobot-slm-backend/slm/agent/role_detector.py
+++ b/autobot-slm-backend/slm/agent/role_detector.py
@@ -13,7 +13,7 @@ Detects installed roles on the local system based on:
 
 import json
 import logging
-import subprocess  # nosec B404 - subprocess used for systemctl status checks
+import subprocess  # nosec B404  # subprocess used for systemctl status checks
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List
@@ -132,7 +132,7 @@ class RoleDetector:
     def _check_service(self, service_name: str) -> bool:
         """Check if a systemd service is running."""
         try:
-            result = subprocess.run(  # nosec B603 B607 - fixed systemctl argv; service_name is a configured role name
+            result = subprocess.run(  # nosec B603 B607  # fixed systemctl argv; service_name is a configured role name
                 ["systemctl", "is-active", service_name],
                 capture_output=True,
                 text=True,

--- a/autobot-slm-backend/tests/services/test_extra_vars_file_11735.py
+++ b/autobot-slm-backend/tests/services/test_extra_vars_file_11735.py
@@ -65,7 +65,7 @@ def _load_playbook_executor():
 
 def test_written_file_is_0600_and_round_trips(tmp_path):
     ib = _load_inventory_builder()
-    vars_in = {"tts_hf_token": "hf_dummy_value", "plain": "x"}  # nosec B106 - test fixture, not a credential
+    vars_in = {"tts_hf_token": "hf_dummy_value", "plain": "x"}  # nosec B106  # test fixture, not a credential
     path = ib.write_temp_extra_vars(vars_in, uid_tmp_dir=str(tmp_path))
     try:
         mode = stat.S_IMODE(path.stat().st_mode)
@@ -95,10 +95,10 @@ def test_unique_file_per_call(tmp_path):
 def _build_command(extra_vars_file):
     pe = _load_playbook_executor()
     executor = pe.PlaybookExecutor.__new__(pe.PlaybookExecutor)  # skip __init__ (env probing)
-    executor.inventory_path = Path("/tmp/inv.yml")  # nosec B108 - test fixture path
+    executor.inventory_path = Path("/tmp/inv.yml")  # nosec B108  # test fixture path
     executor._find_ansible_playbook = lambda: "ansible-playbook"
     return executor._build_ansible_command(
-        Path("/tmp/play.yml"),  # nosec B108 - test fixture path
+        Path("/tmp/play.yml"),  # nosec B108  # test fixture path
         limit=["node-1"],
         tags=None,
         extra_vars_file=extra_vars_file,
@@ -107,13 +107,13 @@ def _build_command(extra_vars_file):
 
 
 def test_command_uses_at_file_reference():
-    cmd = _build_command(Path("/tmp/evars.json"))  # nosec B108 - test fixture path
+    cmd = _build_command(Path("/tmp/evars.json"))  # nosec B108  # test fixture path
     assert "-e" in cmd
     assert "@/tmp/evars.json" in cmd
 
 
 def test_no_key_value_pairs_in_argv():
-    cmd = _build_command(Path("/tmp/evars.json"))  # nosec B108 - test fixture path
+    cmd = _build_command(Path("/tmp/evars.json"))  # nosec B108  # test fixture path
     joined = " ".join(cmd)
     assert "=" not in joined.replace("@/tmp/evars.json", ""), f"argv leaks key=value: {cmd}"
 

--- a/autobot-slm-backend/user_management/services/llm_secrets.py
+++ b/autobot-slm-backend/user_management/services/llm_secrets.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 
 # The only sensitive field in an LLM provider config entry.
 _SENSITIVE_FIELD = "api_key"
-_SECRET_TYPE = "llm-api-key"  # nosec B105 - type label, not a hardcoded secret
+_SECRET_TYPE = "llm-api-key"  # nosec B105  # type label, not a hardcoded secret
 _VAULT_ID_KEY = "api_key_vault_id"
 
 

--- a/autobot-slm-backend/user_management/services/sso_secrets.py
+++ b/autobot-slm-backend/user_management/services/sso_secrets.py
@@ -47,7 +47,7 @@ SENSITIVE_FIELDS: list[str] = ["client_secret", "bind_password"]
 # Vault secret type label stored with each secret entry. This is a category
 # label for the `secret_type` API field, NOT a credential — Bandit B105 fires
 # only because the variable name contains "SECRET".
-_SECRET_TYPE = "sso-credential"  # nosec B105 - type label, not a hardcoded secret
+_SECRET_TYPE = "sso-credential"  # nosec B105  # type label, not a hardcoded secret
 
 
 def _vault_name(provider_id: uuid.UUID, field: str) -> str:

--- a/autobot-slm-backend/user_management/services/sso_service.py
+++ b/autobot-slm-backend/user_management/services/sso_service.py
@@ -135,7 +135,7 @@ class SSOService(BaseService):
             },
             SSOProviderType.GOOGLE_WORKSPACE.value: {
                 "authorize_url": "https://accounts.google.com/o/oauth2/v2/auth",
-                "token_url": "https://oauth2.googleapis.com/token",  # nosec B105 - OAuth2 public token endpoint URL,
+                "token_url": "https://oauth2.googleapis.com/token",  # nosec B105  # OAuth2 public token endpoint URL,
                 "userinfo_url": "https://openidconnect.googleapis.com/v1/userinfo",
                 "scope": "openid email profile",
                 # Google does NOT support RP-initiated OIDC end_session (no end_session_endpoint
@@ -145,7 +145,8 @@ class SSOService(BaseService):
             },
             SSOProviderType.GITHUB.value: {
                 "authorize_url": "https://github.com/login/oauth/authorize",
-                "token_url": "https://github.com/login/oauth/access_token",  # nosec B105 - OAuth2 public token endpoint
+                # OAuth2 public token endpoint
+                "token_url": "https://github.com/login/oauth/access_token",  # nosec B105
                 "userinfo_url": "https://api.github.com/user",
                 "scope": "user:email read:user",
                 # GitHub OAuth2 (not OIDC) — no standard end_session_endpoint

--- a/autobot_shared/network_constants.py
+++ b/autobot_shared/network_constants.py
@@ -158,11 +158,11 @@ class NetworkConstants(metaclass=_LazyConfigMeta):
     LOCALHOST_IP: str = "127.0.0.1"
     LOCALHOST_IPV6: str = "::1"  # IPv6 loopback address
     LOCALHOST_NAME: str = "localhost"
-    BIND_ALL_INTERFACES: str = "0.0.0.0"  # nosec B104 - intentional for servers
+    BIND_ALL_INTERFACES: str = "0.0.0.0"  # nosec B104  # intentional for servers
 
     # === Loopback/Local IP sets for O(1) membership checks (#625) ===
     # Use these frozensets instead of inline lists for `in` checks
-    # nosec B104 - These contain intentional bind-all-interfaces for loopback checking
+    # nosec B104  # These contain intentional bind-all-interfaces for loopback checking
     LOOPBACK_IPS: frozenset = frozenset({"127.0.0.1", "localhost", "0.0.0.0", "::1"})  # nosec B104
     LOOPBACK_IPS_V4: frozenset = frozenset({"127.0.0.1", "localhost", "0.0.0.0"})  # nosec B104
 

--- a/autobot_shared/network_utils.py
+++ b/autobot_shared/network_utils.py
@@ -56,7 +56,7 @@ def get_local_ips() -> set:
 
     # Enumerate all interface IPs via ``ip addr``
     try:
-        result = subprocess.run(  # nosec B603 B607 - fixed ip argv for interface enumeration, no user input
+        result = subprocess.run(  # nosec B603 B607  # fixed ip argv for interface enumeration, no user input
             ["ip", "-4", "addr", "show"],
             capture_output=True,
             text=True,

--- a/autobot_shared/retry_mechanism.py
+++ b/autobot_shared/retry_mechanism.py
@@ -140,7 +140,7 @@ class RetryMechanism:
             delay = self.config.base_delay * (self.config.backoff_multiplier ** (attempt - 1))
             # Add random jitter ±20%
             jitter_factor = (
-                1.0 + (random.random() - 0.5) * 0.4  # nosec B311 - backoff jitter to prevent thundering herd, not
+                1.0 + (random.random() - 0.5) * 0.4  # nosec B311  # backoff jitter to prevent thundering herd, not
             )
             delay *= jitter_factor
         else:
@@ -149,7 +149,7 @@ class RetryMechanism:
         # Apply jitter if enabled and not using jittered backoff
         if self.config.jitter and self.config.strategy != RetryStrategy.JITTERED_BACKOFF:
             jitter_factor = (
-                1.0 + (random.random() - 0.5) * 0.2  # nosec B311 - delay jitter to prevent thundering herd, not
+                1.0 + (random.random() - 0.5) * 0.2  # nosec B311  # delay jitter to prevent thundering herd, not
             )
             delay *= jitter_factor
 
@@ -560,7 +560,7 @@ if __name__ == "__main__":
             """Example flaky network call that may fail randomly."""
             import random
 
-            if random.random() < 0.7:  # nosec B311 - simulated failure rate for retry example, not cryptographic
+            if random.random() < 0.7:  # nosec B311  # simulated failure rate for retry example, not cryptographic
                 raise ConnectionError("Network error")
             return "Success!"
 
@@ -577,7 +577,7 @@ if __name__ == "__main__":
             """Example operation that may timeout randomly."""
             import random
 
-            if random.random() < 0.5:  # nosec B311 - simulated failure rate for retry example, not cryptographic
+            if random.random() < 0.5:  # nosec B311  # simulated failure rate for retry example, not cryptographic
                 raise TimeoutError("Operation timed out")
             return "Operation completed"
 

--- a/autobot_shared/security/path_validator.py
+++ b/autobot_shared/security/path_validator.py
@@ -24,7 +24,7 @@ from typing import Sequence
 
 _DEFAULT_ALLOWED_ROOTS: tuple[str, ...] = (
     "/opt/autobot",
-    "/tmp",  # nosec B108 - test/controlled code uses tmpdir intentionally
+    "/tmp",  # nosec B108  # test/controlled code uses tmpdir intentionally
 )
 
 # Characters rejected outright in sandbox-relative user paths (Issue #326).

--- a/autobot_shared/security/path_validator_test.py
+++ b/autobot_shared/security/path_validator_test.py
@@ -57,7 +57,7 @@ class TestValidatePath:
     def test_null_byte_raises(self) -> None:
         """Null byte in path raises ValueError."""
         with pytest.raises(ValueError, match="empty or contains null bytes"):
-            validate_path("/tmp/file\x00.txt")  # nosec B108 - test/controlled code uses tmpdir intentionally
+            validate_path("/tmp/file\x00.txt")  # nosec B108  # test/controlled code uses tmpdir intentionally
 
     def test_must_exist_with_nonexistent_path(self, tmp_path) -> None:
         """must_exist=True with nonexistent path raises ValueError."""
@@ -112,11 +112,11 @@ class TestValidatePath:
 
     def test_default_allowed_roots_used_when_none(self) -> None:
         """When allowed_roots is None, _DEFAULT_ALLOWED_ROOTS is used."""
-        assert "/tmp" in _DEFAULT_ALLOWED_ROOTS  # nosec B108 - test/controlled code uses tmpdir intentionally
+        assert "/tmp" in _DEFAULT_ALLOWED_ROOTS  # nosec B108  # test/controlled code uses tmpdir intentionally
         result = validate_path(
             "/tmp/test_path_validator_check"
-        )  # nosec B108 - test/controlled code uses tmpdir intentionally
-        assert str(result).startswith("/tmp")  # nosec B108 - test/controlled code uses tmpdir intentionally
+        )  # nosec B108  # test/controlled code uses tmpdir intentionally
+        assert str(result).startswith("/tmp")  # nosec B108  # test/controlled code uses tmpdir intentionally
 
     def test_symlink_escape(self, tmp_path) -> None:
         """Symlink pointing outside base directory is caught by realpath."""
@@ -159,14 +159,14 @@ class TestValidateRelativePath:
     def test_empty_segment_raises(self) -> None:
         """Empty segment raises ValueError."""
         with pytest.raises(ValueError, match="empty or contains null bytes"):
-            validate_relative_path("", "/tmp/base")  # nosec B108 - test/controlled code uses tmpdir intentionally
+            validate_relative_path("", "/tmp/base")  # nosec B108  # test/controlled code uses tmpdir intentionally
 
     def test_null_byte_in_segment_raises(self) -> None:
         """Null byte in segment raises ValueError."""
         with pytest.raises(ValueError, match="empty or contains null bytes"):
             validate_relative_path(
                 "file\x00.txt", "/tmp/base"
-            )  # nosec B108 - test/controlled code uses tmpdir intentionally
+            )  # nosec B108  # test/controlled code uses tmpdir intentionally
 
     def test_absolute_path_as_segment(self, tmp_path) -> None:
         """Absolute path as segment escapes base and raises."""

--- a/autobot_shared/security/sql_identifier.py
+++ b/autobot_shared/security/sql_identifier.py
@@ -14,7 +14,7 @@ Usage:
     from autobot_shared.security.sql_identifier import validate_sql_identifier
 
     safe_table = validate_sql_identifier(table_name, "table name")
-    query = f"SELECT COUNT(*) FROM {safe_table}"  # nosec B608 - identifier allowlisted
+    query = f"SELECT COUNT(*) FROM {safe_table}"  # nosec B608  # identifier allowlisted
 """
 
 from __future__ import annotations

--- a/autobot_shared/ssot_constants.py
+++ b/autobot_shared/ssot_constants.py
@@ -59,7 +59,7 @@ ERR_TEMPLATE_NOT_FOUND = "Template not found"
 ERR_WORKFLOW_NOT_FOUND = "Workflow not found"
 ERR_EXPERIMENT_NOT_FOUND = "Experiment not found"
 ERR_INVALID_CREDENTIALS = "Invalid username or password"
-ERR_INVALID_TOKEN = "Invalid token"  # nosec B105 - user-facing error message string, not a credential
+ERR_INVALID_TOKEN = "Invalid token"  # nosec B105  # user-facing error message string, not a credential
 
 
 # ============================================================================

--- a/autobot_shared/user_management/models/audit.py
+++ b/autobot_shared/user_management/models/audit.py
@@ -130,7 +130,7 @@ class AuditAction:
     LOGIN_SUCCESS = "login_success"
     LOGIN_FAILED = "login_failed"
     LOGOUT = "logout"
-    PASSWORD_CHANGED = "password_changed"  # nosec B105 - enum value, not a credential
+    PASSWORD_CHANGED = "password_changed"  # nosec B105  # enum value, not a credential
     PASSWORD_RESET_REQUESTED = "password_reset_requested"  # nosec B105
     PASSWORD_RESET_COMPLETED = "password_reset_completed"  # nosec B105
 

--- a/scripts/check_nosec_format.py
+++ b/scripts/check_nosec_format.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Fail when a ``# nosec`` annotation puts prose where bandit expects test IDs (#13521).
+
+Bandit parses **everything** after ``nosec`` as a whitespace-separated list of
+test IDs. A trailing explanation therefore becomes a list of bogus IDs and
+bandit warns once per word::
+
+    },  # nose<c> B105 - config dict; 'token_estimation' refers to counting
+
+    WARNING Test in comment: config is not a test name or id, ignoring
+    WARNING Test in comment: dict is not a test name or id, ignoring
+    WARNING Test in comment: token_estimation is not a test name or id, ignoring
+
+That matters because ``code-quality.yml`` runs bandit with no severity floor,
+so its output is expected to be silent, and ``scripts/pr-preflight.sh`` treats
+a non-empty bandit run as a failure. The result was a papercut that recurred:
+it fired in three separate PRs on one day, each fixed a single file at a time.
+
+The accepted forms keep the explanation and cost nothing::
+
+    x = "auth:"  # nose<c> B105  # not a credential, a key prefix
+    # Not a credential, a key prefix.
+    x = "auth:"  # nose<c> B105
+
+Both are silent and both still suppress. Verified rather than assumed — the
+``- prose`` form emits 6 warnings on a one-line file, the two above emit 0.
+
+Note the subtle consequence of the old form: ``# nose<c> B105 - explanation`` is
+not as narrowly scoped as its author intended, because the parser discards the
+unrecognised extras. It reads as scoped while behaving as ``# nose<c> B105``.
+
+Exit code:
+  0 — every annotation is well-formed
+  1 — at least one carries prose where IDs belong
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# The suppression token followed by test IDs, then a separator and prose. The separator is
+# what distinguishes this from a legitimate multi-ID annotation (``# nose<c> B603
+# B607``), and from the accepted ``# nose<c> B105  # prose`` form, where the second
+# ``#`` ends bandit's parse.
+_MALFORMED = re.compile(r"#\s*nosec\s+(?:[A-Z]\d+)(?:[,\s]+[A-Z]\d+)*\s*[-–—:]\s+\S")
+
+# A bare suppression token with prose and no IDs at all — same failure, no ID to keep.
+_MALFORMED_BARE = re.compile(r"#\s*nosec\s+(?![A-Z]\d+\b)(?!#)[A-Za-z]")
+
+_MAX_REPORTED = 15
+
+
+def _tracked_python_files() -> list[Path]:
+    # Fixed argv, no shell, no caller input.
+    result = subprocess.run(  # nosec B603 B607
+        ["git", "ls-files", "*.py"], cwd=REPO_ROOT, capture_output=True, text=True, check=False
+    )
+    return [REPO_ROOT / line for line in result.stdout.splitlines() if line]
+
+
+def find_malformed() -> list[str]:
+    """Return one message per annotation bandit would mis-parse."""
+    problems: list[str] = []
+    for path in _tracked_python_files():
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except (OSError, UnicodeDecodeError):
+            continue
+        for lineno, line in enumerate(lines, 1):
+            if _MALFORMED.search(line) or _MALFORMED_BARE.search(line):
+                problems.append(
+                    f"{path.relative_to(REPO_ROOT)}:{lineno}: prose follows the test IDs — "
+                    f"bandit reads each word as a test id. Use '# nosec <IDS>  # <prose>'."
+                )
+    return problems
+
+
+def main() -> int:
+    problems = find_malformed()
+    for problem in problems[:_MAX_REPORTED]:
+        print(problem)
+    if len(problems) > _MAX_REPORTED:
+        print(f"... and {len(problems) - _MAX_REPORTED} more")
+    if problems:
+        print(f"\n{len(problems)} malformed '# nosec' annotation(s) (#13521)")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_nosec_format_test.py
+++ b/scripts/check_nosec_format_test.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for scripts/check_nosec_format.py (#13521).
+
+The checker must fire on the form bandit mis-parses and stay silent on the two
+that work. Getting that boundary wrong in either direction is costly: a false
+negative lets the warnings back in, and a false positive would push people to
+delete the explanations, which are the useful part of a suppression.
+
+Run: python3 -m pytest scripts/check_nosec_format_test.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_MODULE_PATH = Path(__file__).resolve().parent / "check_nosec_format.py"
+_spec = importlib.util.spec_from_file_location("check_nosec_format", _MODULE_PATH)
+checker = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(checker)  # type: ignore[union-attr]
+
+# #13521: this file must not contain a literal suppression token followed by
+# prose. Bandit scans test files too, so spelling the fixtures out would emit
+# exactly the warnings this checker exists to prevent — the checker's own tests
+# would be the last remaining violation. The token is assembled at runtime.
+_N = "# nose" + "c"
+
+
+def _flagged(line: str) -> bool:
+    return bool(checker._MALFORMED.search(line) or checker._MALFORMED_BARE.search(line))
+
+
+# ------------------------------------------------------------------ malformed
+
+
+@pytest.mark.parametrize(
+    "suffix",
+    [
+        "B105 - not a credential",
+        "B105 — em dash variant",
+        "B105: colon variant",
+        "B603 B607 - fixed argv, no shell",
+        "B603,B607 - comma separated ids",
+        "because it is fine",  # no ids at all, straight to prose
+    ],
+)
+def test_flags_prose_after_the_ids(suffix):
+    line = f"value = compute()  {_N} {suffix}"
+    assert _flagged(line), f"should be flagged: {line!r}"
+
+
+# ---------------------------------------------------------------- well-formed
+
+
+@pytest.mark.parametrize(
+    "suffix",
+    [
+        "B105",
+        "B105  # not a credential, a key prefix",
+        "B603 B607",
+        "B603 B607  # fixed argv, no shell",
+        "",  # bare token, no ids, no prose
+        "B608  # nosemgrep: python.lang.security.audit  # noqa: E501",
+    ],
+)
+def test_accepts_the_working_forms(suffix):
+    """The second '#' ends bandit's parse, so the explanation costs nothing."""
+    line = f"value = compute()  {_N} {suffix}".rstrip()
+    assert not _flagged(line), f"should NOT be flagged: {line!r}"
+
+
+# ------------------------------------------------------------------ end to end
+
+
+def test_repository_is_currently_clean():
+    problems = checker.find_malformed()
+    assert problems == [], "\n".join(problems[:10])

--- a/scripts/pr-preflight.sh
+++ b/scripts/pr-preflight.sh
@@ -210,17 +210,35 @@ else
       fail "isort -- run: python3 -m isort --settings-path=. --line-length=120 ${PY[*]}"
     fi
 
-    if python3 -m flake8 --config=.flake8 "${PY[@]}" >/dev/null 2>&1; then
+    # #13521: flake8 checks a file named explicitly on the command line even when
+    # .flake8 excludes it, so passing changed files by path made this stricter
+    # than CI -- which lints whole directories and therefore honours `exclude`.
+    # That produced failures on pre-existing findings in excluded trees
+    # (code_analysis, tools, scripts, tests...) that CI never sees. Drop the same
+    # directories here so the gate matches the gate it is meant to predict.
+    FLAKE_EXCLUDES=$(awk '/^exclude *=/{f=1;next} /^[a-z_-]+ *=/{f=0} f' .flake8 \
+                     | sed 's/#.*//' | tr -d ' ,' | grep -vE '^\*|^$' | tr '\n' '|' | sed 's/|$//')
+    mapfile -t PY_LINT < <(printf '%s\n' "${PY[@]}" \
+                           | grep -vE "(^|/)(${FLAKE_EXCLUDES})(/|$)" || true)
+
+    if [ "${#PY_LINT[@]}" -eq 0 ]; then
+      note "flake8 -- every changed Python file is in .flake8's exclude list"
+    elif python3 -m flake8 --config=.flake8 "${PY_LINT[@]}" >/dev/null 2>&1; then
       pass "flake8 --config=.flake8"
     else
       fail "flake8 --config=.flake8"
-      python3 -m flake8 --config=.flake8 "${PY[@]}" 2>&1 | head -15 | sed 's/^/        /'
+      python3 -m flake8 --config=.flake8 "${PY_LINT[@]}" 2>&1 | head -15 | sed 's/^/        /'
     fi
 
     # code-quality.yml runs bandit with NO severity floor -- stricter than the
     # medium-and-up filter used elsewhere. A B105 on a constant named *_PREFIX
     # is the classic false positive; annotate it with "# nosec B105".
-    BANDIT_OUT=$(python3 -m bandit -c .bandit -q "${PY[@]}" 2>&1)
+    # #13521: "nosec encountered (Bxxx), but no failed test" is bandit telling
+    # you a suppression is unnecessary, not that this change is unsafe. It is a
+    # property of the file you happened to touch, and blocking on it would stop
+    # anyone editing a file that carries a stale suppression. Reported by the
+    # dedicated sweep instead; a real finding still says "Issue:".
+    BANDIT_OUT=$(python3 -m bandit -c .bandit -q "${PY[@]}" 2>&1 | grep -v "nosec encountered")
     if [ -z "$BANDIT_OUT" ]; then
       pass "bandit -c .bandit (no severity floor, as CI runs it)"
     else


### PR DESCRIPTION
Closes #13521

## Thinking Path

Bandit parses **everything** after the suppression token as a whitespace-separated list of test IDs, so a trailing explanation becomes a list of bogus IDs and it warns once per word. One line in `context_window_manager.py` produced three warnings; `slash_command_handler.py` produced twenty.

That matters because `code-quality.yml` runs bandit with **no severity floor**, so its output is expected to be silent, and `scripts/pr-preflight.sh` treats a non-empty bandit run as failure. It was a papercut that recurred — it fired in **three separate PRs on one day** (#13438, #13434, #13495), each fixed one file at a time by whoever happened to be editing it. Three of 390.

I verified the target form before applying it to anything: the old form emits 6 warnings on a one-line file; `# nosec B105  # prose` and the preceding-comment form both emit **0 and still suppress**.

## What Changed

| Change | Detail |
|---|---|
| 390 annotations, 191 files | `# nosec B105 - prose` → `# nosec B105  # prose` |
| `api/database_mcp.py` | a prose comment *discussing* the token had to be reworded — bandit cannot tell it from a real annotation |
| `scripts/check_nosec_format.py` + test | new; 13 tests; wired into `code-quality.yml` |
| `scripts/pr-preflight.sh` | two false-failure fixes, below |

Four separator variants were present (`-`, en dash, em dash, `:`); all handled.

## What the rewrite exposed

**Three suppressions were orphaned by black.** Adding two characters pushed three lines past 120, black reflowed them, and the `# nosec` landed on the closing-bracket line — detached from the expression it protected. Bandit immediately reported findings that had been suppressed moments earlier.

That is precisely the hazard `database_mcp.py` documents from #9489. Those three now put the prose on its own line *above* the statement, where black cannot move it. **Verified: orphan count is 38 on base and 38 on this branch — zero files made worse.**

**Investigating them found 38 already orphaned on base**, suppressing nothing. Filed as **#13528** rather than fixed here — clearing the 390 warnings is what made them visible.

## Two false failures in my own pre-flight script

Both would have blocked anyone editing an affected file, so they are fixed here:

- **bandit** — `nosec encountered, but no failed test` reports an *unnecessary* suppression in a file you happened to touch, not a defect in your change. Identical count on base and branch (42 vs 42).
- **flake8** — the script passed changed files by path, and flake8 lints an explicitly-named file even when `.flake8` excludes it. CI lints whole directories and therefore honours `exclude`. The script was stricter than the gate it exists to predict, failing on pre-existing findings in `code_analysis/` that CI never sees. It now drops the same excluded directories.

## Verification

```
malformed annotations remaining         0
bandit "Test in comment"                0  across autobot-backend, autobot_shared,
                                           autobot-slm-backend, scripts, tools
                                           (was 286 in autobot-backend/api alone)
suppressions still effective            identical issue counts, base vs branch
194 rewritten files parsed with ast     0 syntax errors
430 annotations, per-file id multisets  0 files changed their id set
orphaned suppressions                   38 base / 38 branch — no regression
flake8 findings on changed files        27 base / 27 branch, none unique to branch
a2a + utils + api + config + repo_tests + scripts   2516 passed
checker tests                           13 passed
```

The per-file multiset comparison matters: a rewrite that silently dropped a test ID would widen a suppression without anyone noticing.

## Model Used

Claude Opus 5 (1M context)
