### PR TITLE
ci(setup-python): adopt the shared composite action in seven more workflows (#13517)

### DIFF
--- a/.github/workflows/api-wiring.yml
+++ b/.github/workflows/api-wiring.yml
@@ -81,10 +81,8 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v7
+        uses: ./.github/actions/setup-python-ci
         with:
-          python-version: '3.14'
-          cache: 'pip'
           cache-dependency-path: |
             requirements*.txt
             autobot-backend/requirements*.txt

--- a/.github/workflows/auto-fix-formatting.yml
+++ b/.github/workflows/auto-fix-formatting.yml
@@ -30,10 +30,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v7
-        with:
-          python-version: '3.14'
-          cache: 'pip'
+        uses: ./.github/actions/setup-python-ci
 
       - name: Install formatters
         run: |

--- a/.github/workflows/canonical-audit.yml
+++ b/.github/workflows/canonical-audit.yml
@@ -22,9 +22,7 @@ jobs:
         with:
           fetch-depth: 1
 
-      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
-        with:
-          python-version: "3.14"
+      - uses: ./.github/actions/setup-python-ci
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -130,9 +130,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Python 3.14
-        uses: actions/setup-python@v7
-        with:
-          python-version: '3.14'
+        uses: ./.github/actions/setup-python-ci
 
       # Only coverage is needed: this job reads data files and the checked-out
       # sources, it never imports the application.

--- a/.github/workflows/marker-tests.yml
+++ b/.github/workflows/marker-tests.yml
@@ -123,10 +123,8 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: ./.github/actions/setup-python-ci
         with:
-          python-version: '3.14'
-          cache: 'pip'
           cache-dependency-path: |
             requirements*.txt
             autobot-backend/requirements*.txt

--- a/.github/workflows/migration-gate.yml
+++ b/.github/workflows/migration-gate.yml
@@ -97,10 +97,8 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v7
+        uses: ./.github/actions/setup-python-ci
         with:
-          python-version: '3.14'
-          cache: 'pip'
           cache-dependency-path: .github/workflows/migration-gate.yml
 
       - name: Install migration-test dependencies

--- a/.github/workflows/startup-import-smoke.yml
+++ b/.github/workflows/startup-import-smoke.yml
@@ -66,10 +66,8 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v7
+        uses: ./.github/actions/setup-python-ci
         with:
-          python-version: '3.14'
-          cache: 'pip'
           cache-dependency-path: |
             requirements*.txt
             autobot-backend/requirements*.txt


### PR DESCRIPTION
## Thinking Path

Second tranche of #13517. Tranche 1 (#13525) landed the action's missing `cache-dependency-path` input and the two workflows whose setup matched it exactly; this converts seven more, taking the direct callers of `actions/setup-python` from 19 to 12.

Still deliberately incremental. Each conversion has to carry the caller's own cache paths across, and getting that silently wrong degrades cache hit rates without failing anything — so these are verified individually rather than pattern-replaced in bulk.

## What Changed

**No `cache-dependency-path` — exact conversions:**

| workflow | note |
|---|---|
| `auto-fix-formatting.yml` | had `cache: 'pip'`, which the action already does |
| `canonical-audit.yml` | was pinned to a `v7.0.0` SHA; now inherits the action's pin |
| `coverage.yml` | the second setup in the file; the first already uses `setup-python-suite` |

**Cache paths carried across verbatim:**

| workflow | `cache-dependency-path` |
|---|---|
| `api-wiring.yml` | `requirements*.txt`, `autobot-backend/…`, `autobot-slm-backend/…` |
| `migration-gate.yml` | `.github/workflows/migration-gate.yml` (keys on the workflow itself — its deps are inline, not in a requirements file) |
| `startup-import-smoke.yml` | `requirements*.txt`, `autobot-backend/requirements*.txt` |
| `marker-tests.yml` | same pair |

## Verification

Each conversion is checked by parsing the result and comparing the cache paths against what the file had before — not by trusting the edit:

```console
OK  api-wiring.yml: ['requirements*.txt', 'autobot-backend/requirements*.txt', 'autobot-slm-backend/requirements*.txt']
OK  migration-gate.yml: ['.github/workflows/migration-gate.yml']
OK  startup-import-smoke.yml: ['requirements*.txt', 'autobot-backend/requirements*.txt']
OK  marker-tests.yml: ['requirements*.txt', 'autobot-backend/requirements*.txt']
OK  auto-fix-formatting.yml: (none)
OK  canonical-audit.yml: (none)
OK  coverage.yml: (none)

all 7 conversions preserve their cache paths and leave no direct setup-python
```

The check also asserts each file ends with **exactly one** `setup-python-ci` step and **no** remaining `actions/setup-python@` — so a partial conversion that left both in place would fail rather than pass quietly.

All seven workflows run on this PR, which is the real test: a broken conversion surfaces here, not after merge.

## Remaining

12 direct callers left. The tail is the awkward part and is deliberately not in this PR:

- `llc-contract.yml`, `security.yml`, `verify-generated-types.yml` each have **two** setup blocks in different jobs
- `ci.yml`, `code-quality.yml`, `co-located-smoke.yml`, `frontend-codegen-drift.yml`, `phase_validation.yml`, `slm-migration-gate.yml`, `trajectory-eval.yml`, `unwired-tracker-audit.yml`, `auto-fix-generated-types.yml`

**#13517 stays open** — closure Gate 3 does not close an issue on a subset.

Refs #13517

## Model Used

Opus 5 (1M context)
