### PR TITLE
refactor(schemas): rename field validators off the containment-helper name (#13518)

### DIFF
--- a/autobot-backend/api/schema_validator_names_13518_test.py
+++ b/autobot-backend/api/schema_validator_names_13518_test.py
@@ -1,0 +1,99 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Field validators must not be named after the path-containment helper (#13518).
+
+Two Pydantic field validators were called `validate_path` and
+`validate_path_pattern` — the same names as the canonical containment helpers in
+`autobot_shared/security/path_validator.py`. Neither performs containment:
+`FileOperation.path` is a shape check on a request field that resolves nothing,
+and `SearchCategoriesByPathRequest.path_pattern` validates a *category* pattern's
+character set with no filesystem path involved.
+
+The cost was a readability trap with security consequences. Auditing path
+handling starts with `grep "def validate_path"`; before this, that returned two
+false hits alongside the real helper, and a reviewer skimming the list could
+easily conclude a call site was already covered by containment when it was not.
+
+Renaming is only worth doing if it stays done, so this pins both properties: the
+validators still enforce what they always did, and the helper's name is once
+again unique to the helper.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pydantic")
+
+from pydantic import ValidationError  # noqa: E402
+
+from api.schemas_knowledge import SearchCategoriesByPathRequest  # noqa: E402
+from api.schemas_system import FileOperation  # noqa: E402
+
+# --- the validators still do their job --------------------------------------
+
+
+def test_a_traversal_path_is_still_rejected():
+    with pytest.raises(ValidationError):
+        FileOperation(path="../etc/passwd")
+
+
+def test_an_absolute_path_is_still_rejected():
+    with pytest.raises(ValidationError):
+        FileOperation(path="/etc/passwd")
+
+
+def test_an_empty_path_is_still_rejected():
+    with pytest.raises(ValidationError):
+        FileOperation(path="")
+
+
+def test_an_ordinary_relative_path_is_still_accepted():
+    assert FileOperation(path="notes/today.md").path == "notes/today.md"
+
+
+def test_a_category_pattern_is_still_normalised_and_checked():
+    assert SearchCategoriesByPathRequest(path_pattern="  Docs/API  ").path_pattern == "docs/api"
+
+    with pytest.raises(ValidationError):
+        SearchCategoriesByPathRequest(path_pattern="docs/../etc")
+
+
+# --- the name is the point --------------------------------------------------
+
+
+def test_the_containment_helper_name_is_unique_to_the_helper():
+    """`grep "def validate_path"` must find the helper and nothing else.
+
+    That grep is the first move when auditing path handling. Two false hits made
+    it possible to read a schema validator as containment coverage it never
+    provided.
+    """
+    import subprocess
+    from pathlib import Path
+
+    repo = Path(__file__).resolve().parents[2]
+    # Anchored to a real definition. An unanchored search also matches this
+    # file's own prose and the grep argument below, which would make the test
+    # fail on its own text.
+    out = subprocess.run(
+        [
+            "grep",
+            "-rnE",
+            "--include=*.py",
+            r"^\s*def validate_path",
+            str(repo / "autobot-backend"),
+            str(repo / "autobot_shared"),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    hits = [ln for ln in out.stdout.splitlines() if ln.strip()]
+
+    assert len(hits) == 1, (
+        "`def validate_path` should match only the canonical containment helper; "
+        "extra hits make a path-handling audit read schema validators as "
+        "containment:\n  " + "\n  ".join(hits)
+    )
+    assert "path_validator.py" in hits[0], hits[0]

--- a/autobot-backend/api/schemas_knowledge.py
+++ b/autobot-backend/api/schemas_knowledge.py
@@ -2129,8 +2129,14 @@ class SearchCategoriesByPathRequest(BaseModel):
 
     @field_validator("path_pattern")
     @classmethod
-    def validate_path_pattern(cls, v):
-        """Validate path pattern format."""
+    def normalise_category_path_pattern(cls, v):
+        """Validate path pattern format.
+
+        #13518: renamed off ``validate_path_pattern`` for the same reason as
+        ``reject_traversal_in_path`` in schemas_system.py — it grepped as a
+        path-containment helper and is not one. This validates a *category*
+        pattern's character set; no filesystem path is involved.
+        """
         v = v.lower().strip()
         # Remove trailing asterisk for validation
         check_pattern = v.rstrip("*")

--- a/autobot-backend/api/schemas_system.py
+++ b/autobot-backend/api/schemas_system.py
@@ -3197,8 +3197,16 @@ class FileOperation(BaseModel):
 
     @field_validator("path")
     @classmethod
-    def validate_path(cls, v):
-        """Validate path to prevent directory traversal attacks."""
+    def reject_traversal_in_path(cls, v):
+        """Validate path to prevent directory traversal attacks.
+
+        #13518: renamed off ``validate_path``. That is the name of the canonical
+        containment helper in ``autobot_shared/security/path_validator.py``, so
+        a reviewer grepping it to audit path handling got this field validator
+        as a false hit. This is a shape check on a request field, not
+        containment — it never resolves anything and must not be mistaken for
+        the helper.
+        """
         if not v or ".." in v or v.startswith("/"):
             raise ValueError("Invalid path")
         return v


### PR DESCRIPTION
## Thinking Path

#13518's second item, deferred from #13527 because renaming public validator methods is a different kind of risk from swapping a helper's implementation.

Two Pydantic field validators were named `validate_path` and `validate_path_pattern` — the same names as the canonical containment helpers in `autobot_shared/security/path_validator.py`. Neither performs containment:

- `FileOperation.path` is a shape check on a request field (`".." in v or v.startswith("/")`). It resolves nothing.
- `SearchCategoriesByPathRequest.path_pattern` validates a **category** pattern's character set. No filesystem path is involved.

The cost is a readability trap with security consequences. Auditing path handling starts with `grep "def validate_path"` — that is literally how the 2026-08-03 triage mapped the helper landscape. Before this it returned three hits, two of which look like containment and are not. A reviewer skimming that list could conclude a call site was covered when it was not.

## What Changed

| file | before | after |
|---|---|---|
| `api/schemas_system.py:3200` | `validate_path` | `reject_traversal_in_path` |
| `api/schemas_knowledge.py:2132` | `validate_path_pattern` | `normalise_category_path_pattern` |

Names chosen to say what each actually does, so neither reads as containment again. Both carry a docstring line recording why they were renamed — otherwise the next person "fixes" the naming back to something generic.

**No behaviour change.** Pydantic binds `@field_validator("path")` by the decorator's field argument, not the method name, and neither method was referenced anywhere outside its class (checked before renaming).

## Verification

```console
$ python3 -m pytest autobot-backend/api/schema_validator_names_13518_test.py \
                    autobot-backend/tests/test_startup_imports.py -q
358 passed
```

Six new tests. Five pin that the validators still enforce exactly what they did — traversal, absolute paths and empty strings still rejected; ordinary relative paths still accepted; category patterns still lower-cased, stripped and character-checked. Renaming a validator that silently stopped running is the obvious failure mode here, so that is what they check.

The sixth pins the point of the change:

```console
$ # collision reintroduced (validator renamed back to validate_path)
1 failed, 5 passed
$ # restored
358 passed
```

That test greps for `^\s*def validate_path` and asserts exactly one hit, in `path_validator.py`. It is anchored to a definition on purpose: an unanchored search matches the test file's own prose and its grep argument, so the first version failed on its own text.

## Scope

This completes #13518 — the helper consolidation landed in #13527, and this is the naming half.

Closes #13518

## Model Used

Opus 5 (1M context)
