### PR TITLE
security(chromadb): land CHROMA_SERVER_AUTHN where the unit reads it + make the env file mandatory (#12513)

### DIFF
--- a/autobot-slm-backend/ansible/_shared/tasks/write_chromadb_authn_env.yml
+++ b/autobot-slm-backend/ansible/_shared/tasks/write_chromadb_authn_env.yml
@@ -1,0 +1,74 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+#
+# #12513: render the env file the chroma systemd units actually read.
+#
+# History of the defect this closes. #12534 put the credential straight into the
+# unit as `Environment="CHROMA_SERVER_AUTHN_CREDENTIALS=..."`, wrapped in
+# `{% if chromadb_auth_token %}`. #13462 then generated the token. Both units
+# ALSO carried an `EnvironmentFile=` line, and on the database-role unit that
+# line was `-/opt/autobot/autobot-db-stack/.env` — a path nothing in this
+# repository has ever written, made optional by the leading `-`. The result on a
+# live host: the conditional block rendered empty (the read found no token), the
+# optional env file was absent, systemd tolerated both silently, and chroma came
+# up serving every collection unauthenticated with nothing reporting a failure.
+#
+# So the credential now travels one way only: this file writes it, and the units
+# load exactly this path with a MANDATORY `EnvironmentFile=`. Two properties
+# follow, and both are the point:
+#   * the token is no longer inlined into a 0644 unit, where any local user could
+#     read it — it lands 0600 root:root, and systemd (PID 1, root) reads
+#     EnvironmentFile before dropping to the service user, so the service user
+#     never needs access to it;
+#   * a missing credential file is now a visible start failure rather than a
+#     running-but-unauthenticated service.
+#
+# Callers MUST include `read_chromadb_auth_token.yml` first (it sets
+# `chromadb_auth_token` via their own adopt task) and MUST include this file
+# BEFORE the task that templates the unit and before any start/restart, so the
+# mandatory EnvironmentFile can never point at a file that does not exist yet.
+#
+# Requires from the including role:
+#   chromadb_authn_env_file  — absolute path, must equal the unit's EnvironmentFile
+#   a `restart chromadb` handler
+---
+
+- name: "Ensure the credential directory exists for the chroma authn env file (#12513)"
+  ansible.builtin.file:
+    path: "{{ chromadb_authn_env_file | dirname }}"
+    state: directory
+    mode: "0755"
+    owner: root
+    group: root
+  become: true
+
+# The keys are chromadb's own Settings field names uppercased
+# (chromadb/config.py: `chroma_server_authn_provider`,
+# `chroma_server_authn_credentials`), which is how its pydantic settings read the
+# environment. The provider class ships in chromadb.auth.token_authn alongside
+# the TokenAuthClientProvider that autobot-backend/utils/chromadb_auth.py sets on
+# the client, so both halves come from one module and cannot drift apart.
+#
+# The authn keys are emitted only when a token exists: chroma refuses to start
+# when a provider is configured with empty credentials, so an unset token must
+# leave the file valid-but-empty (dev/local, auth disabled) rather than absent.
+# The FILE is written unconditionally — that is what makes the unit's mandatory
+# EnvironmentFile safe on every path, including a host that has no token yet.
+- name: "Render the ChromaDB server-authn env file (#12513)"
+  ansible.builtin.copy:
+    dest: "{{ chromadb_authn_env_file }}"
+    content: |
+      # Managed by Ansible (#12513) — regenerate via the owning role, do not edit.
+      # Read by systemd (root) for autobot-chromadb before it drops privileges.
+      {% if (chromadb_auth_token | default('') | trim) | length > 0 %}
+      CHROMA_SERVER_AUTHN_PROVIDER=chromadb.auth.token_authn.TokenAuthenticationServerProvider
+      CHROMA_SERVER_AUTHN_CREDENTIALS={{ chromadb_auth_token | trim }}
+      {% endif %}
+    owner: root
+    group: root
+    mode: "0600"
+  become: true
+  no_log: true
+  notify: restart chromadb

--- a/autobot-slm-backend/ansible/roles/ai-stack/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/ai-stack/defaults/main.yml
@@ -31,6 +31,9 @@ chromadb_port: 8100
 # backend_chromadb_auth_token when chroma is co-located here instead of on
 # the db-stack node (#4087 topology).
 chromadb_auth_token: ""
+# Same file, same contract as the redis role: it must equal the unit's
+# EnvironmentFile= line, and it is written before the unit is deployed (#12513).
+chromadb_authn_env_file: /etc/autobot/chromadb.env
 
 # Ollama (remote on backend node - resolved from inventory)
 ollama_host: "{{ backend_host | default(ansible_host) }}"

--- a/autobot-slm-backend/ansible/roles/ai-stack/tasks/code_only.yml
+++ b/autobot-slm-backend/ansible/roles/ai-stack/tasks/code_only.yml
@@ -27,6 +27,14 @@
   no_log: true
   tags: ['ai', 'deploy']
 
+# Same ordering contract as roles/redis/tasks/chromadb.yml: the unit's
+# EnvironmentFile is mandatory, so the file is rendered first (#12513). main.yml
+# includes this file before "Enable and start ChromaDB service", so the ordering
+# holds on the provisioning path too, not just on the updater's code_only path.
+- name: "ChromaDB | Render the server-authn env file the unit reads (#12513)"
+  ansible.builtin.include_tasks: ../../../_shared/tasks/write_chromadb_authn_env.yml
+  tags: ['ai', 'deploy']
+
 - name: Deploy ChromaDB systemd service
   ansible.builtin.template:
     src: autobot-chromadb.service.j2

--- a/autobot-slm-backend/ansible/roles/ai-stack/templates/autobot-chromadb.service.j2
+++ b/autobot-slm-backend/ansible/roles/ai-stack/templates/autobot-chromadb.service.j2
@@ -12,14 +12,21 @@ Group={{ ai_group }}
 WorkingDirectory={{ ai_install_dir }}
 Environment="PATH={{ ai_install_dir }}/venv/bin:/usr/local/bin:/usr/bin:/bin"
 Environment="PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python"
-{% if chromadb_auth_token %}
-# #12513: CHROMA_SERVER_AUTHN_* token auth. Only rendered when
-# chromadb_auth_token is set (group_vars/vault) — chroma fails to start if the
-# provider is configured with no credentials, so this must stay conditional.
-Environment="CHROMA_SERVER_AUTHN_PROVIDER=chromadb.auth.token_authn.TokenAuthenticationServerProvider"
-Environment="CHROMA_SERVER_AUTHN_CREDENTIALS={{ chromadb_auth_token }}"
-{% endif %}
 EnvironmentFile=/etc/autobot/autobot-ai-stack.env
+# #12513: chroma's server-side token auth. The credential is deliberately NOT
+# inlined here as Environment=: this unit is deployed 0644 and world-readable, so
+# an inline value publishes the token to every local user. It arrives instead
+# through the env file below, rendered 0600 root:root by
+# _shared/tasks/write_chromadb_authn_env.yml immediately before this template.
+#
+# No `-` prefix, on purpose. The optional form is exactly why a missing
+# credential produced a running-but-unauthenticated chroma: systemd silently
+# tolerated the absent file and the service came up enforcing nothing. Mandatory
+# turns that into a visible start failure. It is safe because the env file is
+# written unconditionally (with no keys when no token is configured) by the same
+# role, in the task immediately preceding this one, on every path that renders
+# this unit.
+EnvironmentFile={{ chromadb_authn_env_file }}
 ExecStart={{ ai_install_dir }}/venv/bin/chroma run --host {{ chromadb_host }} --port {{ chromadb_port }} --path {{ chromadb_persist_dir }}
 Restart=always
 RestartSec=10

--- a/autobot-slm-backend/ansible/roles/redis/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/redis/defaults/main.yml
@@ -61,7 +61,18 @@ chromadb_port: 8100
 chromadb_install_dir: /opt/autobot/autobot-db-stack/chromadb
 chromadb_data_dir: /opt/autobot/autobot-db-stack/chromadb/data
 # CHROMA_SERVER_AUTHN_* token auth (#12513). Empty (default) = auth disabled,
-# matching pre-#12513 behaviour. Override via group_vars/vault — never commit
-# a real value. Must match backend_chromadb_auth_token (backend role) so the
-# client credentials match the server.
+# matching pre-#12513 behaviour. Normally adopted from the SLM-generated value in
+# slm-secrets.env (see _shared/tasks/read_chromadb_auth_token.yml); override via
+# group_vars/vault only — never commit a real value. Must match
+# backend_chromadb_auth_token (backend role) so the client credential matches the
+# server's.
 chromadb_auth_token: ""
+# The one file the chroma unit loads its server credential from (#12513). This
+# MUST stay equal to the EnvironmentFile= line in
+# templates/autobot-chromadb.service.j2: the unit used to declare an optional
+# `-/opt/autobot/autobot-db-stack/.env` that nothing ever wrote, so a missing
+# credential produced a running-but-unauthenticated chroma instead of a failure.
+# Lives under /etc/autobot with the other credential stores (slm-secrets.env,
+# db-credentials.env) rather than under /opt, which decommission-node.yml and
+# remove-role.yml wipe.
+chromadb_authn_env_file: /etc/autobot/chromadb.env

--- a/autobot-slm-backend/ansible/roles/redis/tasks/chromadb.yml
+++ b/autobot-slm-backend/ansible/roles/redis/tasks/chromadb.yml
@@ -87,6 +87,14 @@
   no_log: true
   tags: ['redis', 'chromadb']
 
+# Must precede the unit template and the start task below: the unit declares a
+# MANDATORY EnvironmentFile at this exact path (#12513), so the file has to exist
+# before systemd is asked to (re)start chroma. Rendered unconditionally — it just
+# carries no authn keys when no token is configured.
+- name: "ChromaDB | Render the server-authn env file the unit reads (#12513)"
+  ansible.builtin.include_tasks: ../../../_shared/tasks/write_chromadb_authn_env.yml
+  tags: ['redis', 'chromadb']
+
 - name: "ChromaDB | Deploy systemd service unit"
   ansible.builtin.template:
     src: autobot-chromadb.service.j2

--- a/autobot-slm-backend/ansible/roles/redis/templates/autobot-chromadb.service.j2
+++ b/autobot-slm-backend/ansible/roles/redis/templates/autobot-chromadb.service.j2
@@ -15,14 +15,20 @@ WorkingDirectory={{ chromadb_install_dir }}
 Environment="PYTHONUNBUFFERED=1"
 Environment="ANONYMIZED_TELEMETRY=FALSE"
 Environment="PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python"
-{% if chromadb_auth_token %}
-# #12513: CHROMA_SERVER_AUTHN_* token auth. Only rendered when
-# chromadb_auth_token is set (group_vars/vault) — chroma fails to start if the
-# provider is configured with no credentials, so this must stay conditional.
-Environment="CHROMA_SERVER_AUTHN_PROVIDER=chromadb.auth.token_authn.TokenAuthenticationServerProvider"
-Environment="CHROMA_SERVER_AUTHN_CREDENTIALS={{ chromadb_auth_token }}"
-{% endif %}
-EnvironmentFile=-/opt/autobot/autobot-db-stack/.env
+# #12513: chroma's server-side token auth. The credential is deliberately NOT
+# inlined here as Environment=: this unit is deployed 0644 and world-readable, so
+# an inline value publishes the token to every local user. It arrives instead
+# through the env file below, rendered 0600 root:root by
+# _shared/tasks/write_chromadb_authn_env.yml immediately before this template.
+#
+# No `-` prefix, on purpose. The optional form is exactly why a missing
+# credential produced a running-but-unauthenticated chroma: systemd silently
+# tolerated the absent file and the service came up enforcing nothing. Mandatory
+# turns that into a visible start failure. It is safe because the env file is
+# written unconditionally (with no keys when no token is configured) by the same
+# role, in the task immediately preceding this one, on every path that renders
+# this unit.
+EnvironmentFile={{ chromadb_authn_env_file }}
 
 ExecStart={{ chromadb_install_dir }}/venv/bin/chroma run \
     --host 0.0.0.0 \

--- a/autobot-slm-backend/tests/test_chromadb_auth_token_provisioned_12513.py
+++ b/autobot-slm-backend/tests/test_chromadb_auth_token_provisioned_12513.py
@@ -266,12 +266,15 @@ def test_unit_environmentfile_path_equals_the_provisioned_path(role):
     )
 
     spec = next(
-        (t.get("ansible.builtin.copy") or t.get("copy") for t in _iter_mappings(_tasks(_WRITE_ENV)) if (t.get("ansible.builtin.copy") or t.get("copy"))),
+        (
+            t.get("ansible.builtin.copy") or t.get("copy")
+            for t in _iter_mappings(_tasks(_WRITE_ENV))
+            if (t.get("ansible.builtin.copy") or t.get("copy"))
+        ),
         None,
     )
     assert spec["dest"].strip() == f"{{{{ {_ENV_FILE_VAR} }}}}", (
-        "the provisioning task must write the very variable the unit reads, not a "
-        "path that merely looks like it"
+        "the provisioning task must write the very variable the unit reads, not a " "path that merely looks like it"
     )
 
     default = _role_defaults(role).get(_ENV_FILE_VAR)
@@ -305,11 +308,7 @@ def test_the_credential_never_lands_in_the_world_readable_unit(role):
     _, unit_rel = _UNIT_OWNERS[role]
     unit = (_ANSIBLE / "roles" / role / unit_rel).read_text(encoding="utf-8")
 
-    inline = [
-        ln
-        for ln in unit.splitlines()
-        if ln.strip().startswith("Environment=") and "CHROMA_SERVER_AUTHN" in ln
-    ]
+    inline = [ln for ln in unit.splitlines() if ln.strip().startswith("Environment=") and "CHROMA_SERVER_AUTHN" in ln]
     assert not inline, (
         f"roles/{role} inlines the chroma credential into a unit deployed 0644 — every "
         f"local user could read it: {inline}"
@@ -341,7 +340,8 @@ def test_the_env_file_is_rendered_before_the_unit_is(role):
     )
 
     start_at = index(
-        lambda t: "autobot-chromadb" in str((t.get("ansible.builtin.systemd") or t.get("systemd") or {}).get("name", ""))
+        lambda t: "autobot-chromadb"
+        in str((t.get("ansible.builtin.systemd") or t.get("systemd") or {}).get("name", ""))
     )
     if start_at is not None:
         assert write_at < start_at, "chroma is started before its mandatory env file exists"
@@ -375,12 +375,12 @@ def test_the_client_reads_the_same_credential_through_ssot_config():
     auth = (Path(__file__).resolve().parents[2] / "autobot-backend" / "utils" / "chromadb_auth.py").read_text(
         encoding="utf-8"
     )
-    assert "_ssot_config.misc.chromadb_auth_token" in auth, (
-        "the client credential must come from ssot_config, not a second env lookup"
-    )
-    assert "chromadb.auth.token_authn.TokenAuthClientProvider" in auth, (
-        "the client provider must be token_authn's, matching the server provider"
-    )
+    assert (
+        "_ssot_config.misc.chromadb_auth_token" in auth
+    ), "the client credential must come from ssot_config, not a second env lookup"
+    assert (
+        "chromadb.auth.token_authn.TokenAuthClientProvider" in auth
+    ), "the client provider must be token_authn's, matching the server provider"
 
     ssot = (Path(__file__).resolve().parents[2] / "autobot_shared" / "ssot_config.py").read_text(encoding="utf-8")
     assert f'alias="{_TOKEN_KEY}"' in ssot, (
@@ -390,6 +390,5 @@ def test_the_client_reads_the_same_credential_through_ssot_config():
 
     backend_env = (_ANSIBLE / "roles" / "backend" / "templates" / "backend.env.j2").read_text(encoding="utf-8")
     assert f"{_TOKEN_KEY}={{{{ backend_chromadb_auth_token }}}}" in backend_env, (
-        "backend.env must carry the token or the client has nothing to send once the "
-        "server starts enforcing"
+        "backend.env must carry the token or the client has nothing to send once the " "server starts enforcing"
     )

--- a/autobot-slm-backend/tests/test_chromadb_auth_token_provisioned_12513.py
+++ b/autobot-slm-backend/tests/test_chromadb_auth_token_provisioned_12513.py
@@ -165,3 +165,231 @@ def test_consumers_keep_their_existing_value_when_the_read_is_empty(role, spec):
             f"roles/{role}: {var} is assigned unconditionally — an empty read would "
             "silently turn auth off on this side"
         )
+
+
+# ---------------------------------------------------------------------------
+# Post-deploy round two (#12513): the token was provisioned and chroma still
+# answered an unauthenticated create_collection with 200.
+#
+# The credential was written into the unit as `Environment=`, wrapped in
+# `{% if chromadb_auth_token %}`, and the unit's only env-file input on the
+# database role was `EnvironmentFile=-/opt/autobot/autobot-db-stack/.env` — a
+# path nothing in this repository writes, made OPTIONAL by the leading `-`. So
+# both routes for the credential were no-ops and systemd reported success:
+# `systemctl cat autobot-chromadb | grep -c CHROMA_SERVER_AUTHN` → 0.
+#
+# The tests below pin the three properties that make that unrepresentable:
+# one provisioned path, equal on both sides; a MANDATORY EnvironmentFile; and the
+# file written before anything starts the unit.
+# ---------------------------------------------------------------------------
+
+_WRITE_ENV = _ANSIBLE / "_shared" / "tasks" / "write_chromadb_authn_env.yml"
+
+#: Roles that render the chroma unit → (task file that must render the env file,
+#: relative path of the unit template).
+_UNIT_OWNERS = {
+    "redis": ("tasks/chromadb.yml", "templates/autobot-chromadb.service.j2"),
+    "ai-stack": ("tasks/code_only.yml", "templates/autobot-chromadb.service.j2"),
+}
+
+#: chromadb's own pydantic Settings field names, uppercased — that is how it
+#: reads the environment (chromadb/config.py: chroma_server_authn_provider /
+#: chroma_server_authn_credentials). Guessing these is the whole failure mode.
+_SERVER_KEYS = ("CHROMA_SERVER_AUTHN_PROVIDER", "CHROMA_SERVER_AUTHN_CREDENTIALS")
+
+_ENV_FILE_VAR = "chromadb_authn_env_file"
+
+
+def _role_defaults(role: str) -> dict:
+    return yaml.safe_load((_ANSIBLE / "roles" / role / "defaults" / "main.yml").read_text(encoding="utf-8"))
+
+
+def _tasks(path: Path) -> list:
+    return yaml.safe_load(path.read_text(encoding="utf-8")) or []
+
+
+def _env_file_lines(unit_text: str) -> list:
+    return [ln.strip() for ln in unit_text.splitlines() if ln.strip().startswith("EnvironmentFile=")]
+
+
+def test_the_env_file_task_emits_the_keys_chromadb_actually_reads():
+    """The keys must be chromadb's Settings field names, not plausible ones."""
+    copy_task = next(
+        (t for t in _iter_mappings(_tasks(_WRITE_ENV)) if (t.get("ansible.builtin.copy") or t.get("copy"))),
+        None,
+    )
+    assert copy_task is not None, f"{_WRITE_ENV} no longer renders the env file"
+
+    spec = copy_task.get("ansible.builtin.copy") or copy_task["copy"]
+    content = str(spec.get("content", ""))
+    for key in _SERVER_KEYS:
+        assert f"{key}=" in content, f"the rendered env file omits {key}; chroma would enforce nothing"
+
+    assert "chromadb.auth.token_authn.TokenAuthenticationServerProvider" in content, (
+        "the server provider must be chromadb's token_authn class — the same module that "
+        "ships the TokenAuthClientProvider the backend sets, so the two cannot drift"
+    )
+    # Empty credentials with a provider configured is a chroma boot crash, so the
+    # keys stay conditional even though the FILE is unconditional.
+    assert "chromadb_auth_token" in content and "{% if" in content, (
+        "the authn keys must be gated on a non-empty token — a provider with empty "
+        "credentials crashes chroma at startup"
+    )
+    assert spec.get("mode") == "0600", (
+        "the credential file must not be readable beyond root; systemd reads "
+        "EnvironmentFile as PID 1 before dropping privileges, so 0600 root:root suffices"
+    )
+
+
+def test_the_env_file_is_written_unconditionally():
+    """A conditional file plus a mandatory EnvironmentFile would brick startup."""
+    copy_task = next(
+        (t for t in _iter_mappings(_tasks(_WRITE_ENV)) if (t.get("ansible.builtin.copy") or t.get("copy"))),
+        None,
+    )
+    assert copy_task.get("when") is None, (
+        "the env file must be rendered on every run, token or not — the units declare it "
+        "as a MANDATORY EnvironmentFile, so a skipped render is a failed start"
+    )
+
+
+@pytest.mark.parametrize("role", sorted(_UNIT_OWNERS))
+def test_unit_environmentfile_path_equals_the_provisioned_path(role):
+    """The exact mismatch #13462 hit: token written where the unit does not read."""
+    _, unit_rel = _UNIT_OWNERS[role]
+    unit = (_ANSIBLE / "roles" / role / unit_rel).read_text(encoding="utf-8")
+
+    declared = [ln for ln in _env_file_lines(unit) if _ENV_FILE_VAR in ln]
+    assert declared == [f"EnvironmentFile={{{{ {_ENV_FILE_VAR} }}}}"], (
+        f"roles/{role} unit must load the credential from {{{{ {_ENV_FILE_VAR} }}}} verbatim; "
+        f"found {declared or _env_file_lines(unit)}"
+    )
+
+    spec = next(
+        (t.get("ansible.builtin.copy") or t.get("copy") for t in _iter_mappings(_tasks(_WRITE_ENV)) if (t.get("ansible.builtin.copy") or t.get("copy"))),
+        None,
+    )
+    assert spec["dest"].strip() == f"{{{{ {_ENV_FILE_VAR} }}}}", (
+        "the provisioning task must write the very variable the unit reads, not a "
+        "path that merely looks like it"
+    )
+
+    default = _role_defaults(role).get(_ENV_FILE_VAR)
+    assert default, f"roles/{role}/defaults/main.yml does not define {_ENV_FILE_VAR}"
+    assert default.startswith("/"), "the credential path must be absolute"
+
+
+def test_both_unit_owners_resolve_to_one_credential_file():
+    paths = {role: _role_defaults(role)[_ENV_FILE_VAR] for role in _UNIT_OWNERS}
+    assert len(set(paths.values())) == 1, (
+        f"the two chroma-owning roles point at different credential files ({paths}) — "
+        "a node that changes owner would silently lose its server credential"
+    )
+
+
+@pytest.mark.parametrize("role", sorted(_UNIT_OWNERS))
+def test_environmentfile_is_mandatory_not_optional(role):
+    """`EnvironmentFile=-` is why a missing credential ran unauthenticated."""
+    _, unit_rel = _UNIT_OWNERS[role]
+    unit = (_ANSIBLE / "roles" / role / unit_rel).read_text(encoding="utf-8")
+
+    for line in _env_file_lines(unit):
+        assert not line.startswith("EnvironmentFile=-"), (
+            f"roles/{role} declares an OPTIONAL env file ({line}) — systemd tolerates it "
+            "missing, so chroma starts with no authentication and nothing reports a failure"
+        )
+
+
+@pytest.mark.parametrize("role", sorted(_UNIT_OWNERS))
+def test_the_credential_never_lands_in_the_world_readable_unit(role):
+    _, unit_rel = _UNIT_OWNERS[role]
+    unit = (_ANSIBLE / "roles" / role / unit_rel).read_text(encoding="utf-8")
+
+    inline = [
+        ln
+        for ln in unit.splitlines()
+        if ln.strip().startswith("Environment=") and "CHROMA_SERVER_AUTHN" in ln
+    ]
+    assert not inline, (
+        f"roles/{role} inlines the chroma credential into a unit deployed 0644 — every "
+        f"local user could read it: {inline}"
+    )
+
+
+@pytest.mark.parametrize("role", sorted(_UNIT_OWNERS))
+def test_the_env_file_is_rendered_before_the_unit_is(role):
+    """Mandatory EnvironmentFile + late provisioning = a bricked fresh install."""
+    tasks_rel, _ = _UNIT_OWNERS[role]
+    tasks = _tasks(_ANSIBLE / "roles" / role / tasks_rel)
+
+    def index(predicate):
+        return next((i for i, t in enumerate(tasks) if predicate(t)), None)
+
+    write_at = index(lambda t: "write_chromadb_authn_env.yml" in str(t.get("ansible.builtin.include_tasks", "")))
+    read_at = index(lambda t: "read_chromadb_auth_token.yml" in str(t.get("ansible.builtin.include_tasks", "")))
+    unit_at = index(
+        lambda t: "autobot-chromadb.service.j2"
+        in str((t.get("ansible.builtin.template") or t.get("template") or {}).get("src", ""))
+    )
+
+    assert write_at is not None, f"roles/{role}/{tasks_rel} never renders the credential file"
+    assert unit_at is not None, f"roles/{role}/{tasks_rel} no longer renders the chroma unit"
+    assert read_at < write_at, "the token must be read before the file that carries it is written"
+    assert write_at < unit_at, (
+        f"roles/{role}/{tasks_rel} renders the unit before the env file it mandates — a "
+        "restart between the two would fail to start chroma at all"
+    )
+
+    start_at = index(
+        lambda t: "autobot-chromadb" in str((t.get("ansible.builtin.systemd") or t.get("systemd") or {}).get("name", ""))
+    )
+    if start_at is not None:
+        assert write_at < start_at, "chroma is started before its mandatory env file exists"
+
+
+def test_ai_stack_starts_chroma_only_after_including_the_render():
+    """ai-stack keeps the render in code_only.yml; main.yml must include it first."""
+    tasks = _tasks(_ANSIBLE / "roles" / "ai-stack" / "tasks" / "main.yml")
+    include_at = next(
+        (i for i, t in enumerate(tasks) if "code_only.yml" in str(t.get("ansible.builtin.include_tasks", ""))),
+        None,
+    )
+    start_at = next(
+        (
+            i
+            for i, t in enumerate(tasks)
+            if "autobot-chromadb" in str((t.get("ansible.builtin.systemd") or t.get("systemd") or {}).get("name", ""))
+            and str((t.get("ansible.builtin.systemd") or t.get("systemd") or {}).get("state", "")) == "started"
+        ),
+        None,
+    )
+    assert include_at is not None and start_at is not None
+    assert include_at < start_at, (
+        "roles/ai-stack/tasks/main.yml starts chroma before code_only.yml renders the "
+        "mandatory env file — the service would fail to start on a fresh node"
+    )
+
+
+def test_the_client_reads_the_same_credential_through_ssot_config():
+    """Server authn without a wired client is an outage, not a fix."""
+    auth = (Path(__file__).resolve().parents[2] / "autobot-backend" / "utils" / "chromadb_auth.py").read_text(
+        encoding="utf-8"
+    )
+    assert "_ssot_config.misc.chromadb_auth_token" in auth, (
+        "the client credential must come from ssot_config, not a second env lookup"
+    )
+    assert "chromadb.auth.token_authn.TokenAuthClientProvider" in auth, (
+        "the client provider must be token_authn's, matching the server provider"
+    )
+
+    ssot = (Path(__file__).resolve().parents[2] / "autobot_shared" / "ssot_config.py").read_text(encoding="utf-8")
+    assert f'alias="{_TOKEN_KEY}"' in ssot, (
+        f"ssot_config.misc.chromadb_auth_token must alias {_TOKEN_KEY} — the same key "
+        "slm-secrets.env and backend.env carry, or the client sends nothing"
+    )
+
+    backend_env = (_ANSIBLE / "roles" / "backend" / "templates" / "backend.env.j2").read_text(encoding="utf-8")
+    assert f"{_TOKEN_KEY}={{{{ backend_chromadb_auth_token }}}}" in backend_env, (
+        "backend.env must carry the token or the client has nothing to send once the "
+        "server starts enforcing"
+    )


### PR DESCRIPTION
## Thinking Path

The post-deploy check on #12513 showed the token was provisioned and chroma still answered an unauthenticated `create_collection` with `200`, with `systemctl cat autobot-chromadb | grep -c CHROMA_SERVER_AUTHN` → `0`.

Tracing where the credential was *supposed* to arrive turned up **two** routes into the chroma unit, and both were silent no-ops.

**Route 1 — inline `Environment=`, conditional.** Both unit templates carried:

```jinja
{% if chromadb_auth_token %}
Environment="CHROMA_SERVER_AUTHN_PROVIDER=..."
Environment="CHROMA_SERVER_AUTHN_CREDENTIALS={{ chromadb_auth_token }}"
{% endif %}
```

`chromadb_auth_token` is adopted from the shared read, which is deliberately allowed to come back empty. Empty read → the block renders to nothing → a perfectly valid unit with no authentication, and nothing distinguishes that from "auth intentionally off". It also put a live credential into a file deployed `mode: "0644"`, readable by every local user.

**Route 2 — the env file, dangling and optional.** The database-role unit declared `EnvironmentFile=-<db-stack>/.env`. Grepping the whole repository for that path returns exactly one hit: the template that declares it. **Nothing has ever written it.** The leading `-` made it optional, so systemd tolerated the absence without a word.

So the credential's declared destination and its actual destination were different files, and the optional-file semantics converted that mismatch into a running-but-unauthenticated service instead of a startup failure.

**Ordering, before touching the `-`.** Making the env file mandatory is only safe if provisioning always precedes start. Checked every path that renders or starts the unit:

| Path | Order |
|---|---|
| `roles/redis/tasks/chromadb.yml` | read → adopt → **render env file** → template unit → `systemd: started` |
| `roles/ai-stack/tasks/code_only.yml` | read → adopt → **render env file** → template unit |
| `roles/ai-stack/tasks/main.yml` | include `code_only.yml` → `Enable and start ChromaDB service` |
| updater node play | pre-existing restart-by-name runs *before* the `code_only` include, i.e. against the still-optional on-disk unit on the first run; from then on the file already exists |

The render is inserted between the token read and the unit template on both role paths, so the file cannot be newer than the unit that requires it. It is also written **unconditionally** — only its *contents* are conditional — so a host with no token still gets a valid (key-less) file and starts. That is what makes the mandatory form safe, and it is pinned by a test.

Provider choice unchanged: token authn, as #13462 started. Client side needed no change; verified rather than assumed.

## What Changed

**New — `ansible/_shared/tasks/write_chromadb_authn_env.yml`**
Renders one credential file, `/etc/autobot/chromadb.env`, `0600 root:root`. systemd reads `EnvironmentFile` as PID 1 before dropping to the service user, so the service account never needs access. Keys are chromadb's own `Settings` field names uppercased, and are emitted only when a token exists (a provider with empty credentials crashes chroma at boot). Placed under the credential directory that already holds the other stores rather than under the install tree, which `decommission-node.yml` and `remove-role.yml` wipe.

**Both chroma unit templates** (`roles/redis`, `roles/ai-stack`)
Inline `Environment="CHROMA_SERVER_AUTHN_*"` removed — the credential no longer lands in a world-readable unit. Both now load the same provisioned path via a **mandatory** `EnvironmentFile=` (no `-`). The dangling `-<db-stack>/.env` declaration is gone; nothing wrote it, so nothing is lost.

**Both role task files** — the render is included immediately after the token read and immediately before the unit template.

**Both role defaults** — `chromadb_authn_env_file`, resolving to the same path in both roles.

**Tests** — 13 added to `test_chromadb_auth_token_provisioned_12513.py` (10 → 23).

Not touched: the compose path already drives both keys atomically off a single variable, and the client wiring was already correct.

## Verification

**The mismatch, before and after.** Unit's declared path vs. the path provisioning writes:

```console
$ git show origin/Dev_new_gui:...roles/redis/templates/autobot-chromadb.service.j2 | grep EnvironmentFile
EnvironmentFile=-<db-stack>/.env
$ git grep -l '<db-stack>/\.env' origin/Dev_new_gui -- '*.yml' '*.j2'
...roles/redis/templates/autobot-chromadb.service.j2      # only the declaration; no writer

$ grep EnvironmentFile ...roles/redis/templates/autobot-chromadb.service.j2       # after
EnvironmentFile={{ chromadb_authn_env_file }}
$ grep -A1 'dest:' ...(_shared)/write_chromadb_authn_env.yml                       # after
dest: {{ chromadb_authn_env_file }}
```

Same variable on both sides, resolved from the same role default — `test_unit_environmentfile_path_equals_the_provisioned_path` fails if they ever diverge.

**The rendered file carries the keys chromadb actually reads.** Cited, not guessed — chromadb 1.5.5 `config.py` declares `chroma_server_authn_provider` (l.205) and `chroma_server_authn_credentials` (l.207); pydantic settings read those as the uppercased names:

```console
$ CHROMA_SERVER_AUTHN_PROVIDER=chromadb.auth.token_authn.TokenAuthenticationServerProvider \
  CHROMA_SERVER_AUTHN_CREDENTIALS=probe python3 -c "..."
provider = chromadb.auth.token_authn.TokenAuthenticationServerProvider
credentials set = True
server class: True     # chromadb.auth.token_authn.TokenAuthenticationServerProvider
client class: True     # chromadb.auth.token_authn.TokenAuthClientProvider
```

Rendering the task's content template both ways:

```
=== dest === {{ chromadb_authn_env_file }} | mode 0600 | owner root

=== with a token ===
CHROMA_SERVER_AUTHN_PROVIDER=chromadb.auth.token_authn.TokenAuthenticationServerProvider
CHROMA_SERVER_AUTHN_CREDENTIALS=<token>

=== without a token (dev/local) ===
(comments only — valid file, no keys, chroma starts unauthenticated as before)
```

**Rendered units:**

```
# database role
EnvironmentFile=/etc/autobot/chromadb.env

# ai/ml role
EnvironmentFile=/etc/autobot/autobot-ai-stack.env
EnvironmentFile=/etc/autobot/chromadb.env
```

No `Environment=` line carries a credential in either.

**Client picks up the same credential from `ssot_config`.** `chroma_client_auth_kwargs()` reads `_ssot_config.misc.chromadb_auth_token` (field alias `AUTOBOT_CHROMADB_AUTH_TOKEN`), returns `chroma_client_auth_provider` + `chroma_client_auth_credentials`, and is merged at all three `HttpClient` sites (sync client, async client, `cli/doctor`). The backend role renders the same key into `backend.env` from the same shared read. Both provider classes come from one chromadb module, so they cannot drift. Pinned by `test_the_client_reads_the_same_credential_through_ssot_config`.

**Tests — and proof they discriminate.** Against this branch:

```console
$ python3 -m pytest autobot-slm-backend/tests/test_chromadb_auth_token_provisioned_12513.py -q
23 passed in 1.30s
```

Restoring only the two pre-fix unit templates and re-running:

```console
5 failed, 18 passed
FAILED ...::test_unit_environmentfile_path_equals_the_provisioned_path[ai-stack]
FAILED ...::test_unit_environmentfile_path_equals_the_provisioned_path[redis]
FAILED ...::test_environmentfile_is_mandatory_not_optional[redis]
FAILED ...::test_the_credential_never_lands_in_the_world_readable_unit[ai-stack]
FAILED ...::test_the_credential_never_lands_in_the_world_readable_unit[redis]
```

Each failure names the exact defect the post-deploy check hit.

**Lint.** `ansible-lint` and `yamllint` are not installed in this environment and no ad-hoc installs are permitted, so validation was PyYAML `safe_load` on all five touched YAML files (all parse) plus a long-line scan — the only lines over 120 chars in the touched files are pre-existing and untouched.

**Not verified here:** nothing was run against any host, and no service was started or stopped. The behaviour change is structural and lands on the next role deploy.

## Follow-ups filed

- **#13535** — the database role has no builtin update route: the updater's node play targets a host group that excludes it, and unlike five other roles it has no `code_only.yml`. That is why a repo-side fix to this unit could not be delivered by the update path. Deliberately not fixed here: adding the group changes what else runs on those nodes.
- **#13536** — the shared credential store is never distributed off the manager node, so on a multi-host fleet the shared read returns empty everywhere else and chroma authn stays off with nothing reporting it. This PR makes a *missing file* loud; an *empty credential* is still silent, and making it fail would brick legitimately auth-less installs.

Refs #12513, #13462, #12264.

## Model Used

claude-opus-5