### PR TITLE
security(deploy): gate LimitCORE behind the core-capture opt-in (#13047)

### DIFF
--- a/autobot-slm-backend/ansible/roles/backend/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend/defaults/main.yml
@@ -44,6 +44,12 @@ backend_stop_timeout_sec: 45
 # the broken state stays visible either way — see tasks/core_capture.yml.
 backend_core_capture: false
 backend_core_dir: /var/lib/autobot/cores
+# #13047: was relied on solely through an inline Jinja `default('infinity')` in
+# the unit template, so the one tunable controlling how much process memory may
+# be written to disk was invisible to anyone reading defaults/ — where every
+# other knob in this role is documented. Only consulted when
+# backend_core_capture is true; the unit omits LimitCORE entirely otherwise.
+backend_core_limit: infinity
 
 # Celery worker settings (Issue #863)
 celery_concurrency: 4  # Number of worker processes

--- a/autobot-slm-backend/ansible/roles/backend/templates/autobot-backend.service.j2
+++ b/autobot-slm-backend/ansible/roles/backend/templates/autobot-backend.service.j2
@@ -41,9 +41,24 @@ Environment="PYTHONFAULTHANDLER=1"
 # #12777: systemd defaults RLIMIT_CORE to 0, so without this NO core is written
 # even once core_pattern points somewhere real — the capture opt-in
 # (backend_core_capture, roles/backend/tasks/core_capture.yml) would silently
-# produce nothing. Harmless while capture is off: the kernel still has nowhere
-# to put the core.
-LimitCORE={{ backend_core_limit | default('infinity') }}
+# produce nothing.
+#
+# #13047: gated on that same opt-in. It used to be emitted unconditionally, on
+# the reasoning that it is "harmless while capture is off: the kernel still has
+# nowhere to put the core". That holds only on a node whose core_pattern pipes
+# to a MISSING handler — the specific broken state of the #12777 node this was
+# tested against, not a general property. `systemd-coredump` is the distro
+# default on Ubuntu, Debian and Fedora, so on a stock node the unit flipped from
+# "never writes a core" to "writes a full process-memory image on every abort".
+#
+# That image contains AUTOBOT_JWT_SECRET, DB credentials, provider API keys and
+# Redis credentials in cleartext, written where the coredump handler decides and
+# retained by its policy — covered by none of this repo's redaction paths. #12777
+# also documents this process aborting every ~25-55 minutes, so it is an
+# unbounded disk-fill vector on the same nodes.
+{% if backend_core_capture | default(false) | bool %}
+LimitCORE={{ backend_core_limit }}
+{% endif %}
 EnvironmentFile={{ backend_code_dir | default(backend_install_dir) }}/.env
 EnvironmentFile=-{{ service_auth_keys_dir | default('/etc/autobot/service-keys') }}/{{ service_auth_service_id | default('main-backend') }}.env
 # MVA-1633: Validate env vars before starting to prevent silent crashes

--- a/autobot-slm-backend/tests/test_backend_service_faulthandler_12777.py
+++ b/autobot-slm-backend/tests/test_backend_service_faulthandler_12777.py
@@ -47,6 +47,10 @@ def _render(**overrides) -> str:
     # the stdlib equivalents so the real template renders outside Ansible.
     env.filters["dirname"] = os.path.dirname
     env.filters["basename"] = os.path.basename
+    # `bool` is likewise Ansible-only. #13047 gates LimitCORE on
+    # `backend_core_capture | default(false) | bool`, so every render in this
+    # file needs it — without it the template raises before any assertion runs.
+    env.filters["bool"] = lambda v: str(v).strip().lower() in ("true", "yes", "1", "on")
     return env.get_template("autobot-backend.service.j2").render(**{**_CTX, **overrides})
 
 
@@ -88,14 +92,58 @@ def _yaml_text(relative: str) -> str:
     return (_ROLE_DIR / relative).read_text(encoding="utf-8")
 
 
-def test_unit_grants_a_core_limit():
-    """systemd defaults RLIMIT_CORE to 0 — without this no core is ever written."""
-    assert "LimitCORE=" in _render()
+def test_unit_grants_a_core_limit_when_capture_is_enabled():
+    """systemd defaults RLIMIT_CORE to 0 — without this no core is ever written.
+
+    #13047 narrowed this to the opt-in. It previously asserted the limit was
+    granted on EVERY render, which is the defect the issue is about, not a
+    property worth keeping.
+    """
+    assert "LimitCORE=" in _render(backend_core_capture=True)
 
 
-def test_core_limit_is_overridable():
-    """A node that must not write cores can cap it without editing the template."""
-    assert "LimitCORE=0" in _render(backend_core_limit="0")
+def test_no_core_limit_is_granted_by_default():
+    """The #13047 defect: a stock node was given permission to dump memory.
+
+    The old reasoning was that the limit is "harmless while capture is off"
+    because the kernel has nowhere to put the core. That holds only where
+    core_pattern pipes to a MISSING handler — the broken state of the #12777
+    node this was tested on. `systemd-coredump` is the distro default on Ubuntu,
+    Debian and Fedora, so a stock node went from never writing a core to writing
+    a full process-memory image on every abort — containing AUTOBOT_JWT_SECRET,
+    DB credentials and provider API keys in cleartext.
+    """
+    assert "LimitCORE" not in _render()
+
+
+def test_an_undefined_capture_flag_grants_nothing():
+    """An inventory that predates the opt-in must fail closed, not open."""
+    rendered = _render()
+    assert "LimitCORE" not in rendered
+
+
+def test_core_limit_is_overridable_when_capture_is_enabled():
+    """A node that captures cores can still cap their size without editing the template."""
+    assert "LimitCORE=0" in _render(backend_core_capture=True, backend_core_limit="0")
+
+
+def test_the_core_limit_is_declared_in_defaults():
+    """#13047: it existed only as an inline Jinja `default('infinity')`.
+
+    That made the one knob controlling how much process memory may be written to
+    disk invisible in defaults/, where every other tunable in this role is
+    documented.
+    """
+    assert "backend_core_limit:" in _yaml_text("defaults/main.yml")
+
+
+def test_the_crash_diagnostic_survives_with_capture_off():
+    """Gating the limit must not gate faulthandler — they solve different halves.
+
+    faulthandler is what makes a native abort printable at all (#12777) and is
+    not a memory-disclosure risk; only the core dump is.
+    """
+    assert 'Environment="PYTHONFAULTHANDLER=1"' in _render()
 
 
 def test_core_capture_is_opt_in():


### PR DESCRIPTION
## Thinking Path

`LimitCORE` was emitted unconditionally, on the reasoning recorded in the template:

> Harmless while capture is off: the kernel still has nowhere to put the core.

That holds only on a node whose `core_pattern` pipes to a **missing** handler — the specific broken state of the #12777 node this was tested against, not a general property. `systemd-coredump` is the distro default on Ubuntu, Debian and Fedora. On a stock node the unit flipped from *never writes a core* to *writes a full process-memory image on every abort*.

The backend holds `AUTOBOT_JWT_SECRET`, DB credentials, provider API keys and Redis credentials decrypted in memory. A core is a verbatim image of that, written where the coredump handler decides, retained by its policy, and covered by none of this repo's redaction paths. #12777 also documents this process aborting every ~25–55 minutes, which makes it an unbounded disk-fill vector on the same nodes.

Latent, not active — it needs a node whose core handling works, which is exactly why it would never surface on the node it was tested against.

## What Changed

`roles/backend/templates/autobot-backend.service.j2` — `LimitCORE` is now inside `{% if backend_core_capture | default(false) | bool %}`, matching how `core_capture.yml` already gates the `sysctl` write and the core directory. `default(false)` means an inventory predating the opt-in **fails closed**.

`roles/backend/defaults/main.yml` — `backend_core_limit: infinity` declared. It previously existed only as an inline Jinja `default('infinity')`, so the one knob controlling how much process memory may be written to disk was invisible in `defaults/`, where every other tunable in this role is documented.

**`Environment="PYTHONFAULTHANDLER=1"` is untouched and still unconditional.** The two halves of #12777 solve different problems: faulthandler makes a native abort printable at all and discloses nothing, while the core dump is the memory-disclosure risk. Gating both would have re-broken the crash diagnostics this template exists for — there is a test asserting it survives.

## Two existing tests asserted the defect

`test_unit_grants_a_core_limit` asserted `LimitCORE=` appears in **every** render, and `test_core_limit_is_overridable` rendered an override with capture off. Both encoded precisely the behaviour #13047 identifies as the bug, so they are rewritten to be capture-aware rather than deleted — the property they were reaching for is real, it was just scoped too widely.

`_render` also needed Ansible's `bool` filter registered; without it the template raises before any assertion runs, which failed all nine existing tests in that file.

## Verification

Rendered three ways:

```console
capture OFF (the default)  -> (no LimitCORE emitted)
capture ON  (opt-in)       -> LimitCORE=infinity
capture var undefined      -> (no LimitCORE emitted)
```

```console
$ python3 -m pytest autobot-slm-backend/tests/ -q --ignore=…/test_scim.py
1099 passed, 1 skipped

$ cd autobot-slm-backend/ansible && ansible-playbook --syntax-check \
    playbooks/update-all-nodes.yml playbooks/deploy-full.yml -i localhost,
playbook: playbooks/update-all-nodes.yml
playbook: playbooks/deploy-full.yml
```

13 tests in the file now (9 before). Both halves invert-tested:

```console
$ # LimitCORE ungated again (the shipped defect)
2 failed, 11 passed
$ # defaults declaration removed
1 failed, 12 passed
$ # restored
13 passed
```

`test_the_crash_diagnostic_survives_with_capture_off` passes in both directions on purpose — it guards the thing this change could plausibly have broken.

`tests/api/test_scim.py` fails collection with `ModuleNotFoundError: services.system_secrets_vault` — pre-existing, reproduced on an untouched checkout.

## Delivery

`roles/backend/tasks/unit_only.yml` renders this template and the builtin updater applies it (#12777/#12959), so this reaches deployed hosts on the next self-update rather than only on a full provision.

Closes #13047

## Model Used

Opus 5 (1M context)
