### PR TITLE
ci: let a push to the base branch finish instead of cancelling it (#13432)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,26 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # #13432: cancel superseded PR runs, but let a push to a base branch finish.
+  #
+  # On a pull request a new push makes the previous run obsolete, so cancelling
+  # is right. On a push to Dev_new_gui it meant each merge cancelled the previous
+  # merge's verification, and merges arrive faster than the suite completes: of
+  # the last 39 completed base runs, 26 were cancelled and NONE succeeded. The
+  # base branch was effectively never verified, and measuring the #13162 backlog
+  # repeatedly meant hunting for a run that happened to survive.
+  #
+  # This does not queue unboundedly. With cancel-in-progress false, GitHub keeps
+  # at most one run in progress plus one pending per group — a newly queued run
+  # cancels the previously pending one. So base runs serialise, each completes,
+  # and at most one waits. Under a burst you get a verdict for a recent commit
+  # rather than for every commit, which is the useful half.
+  #
+  # Cost is bounded to GitHub-hosted capacity: every job in THIS workflow is
+  # ubuntu-latest (the twelve python-suite shards included, see the note above
+  # the python-shard job). It adds nothing to the [self-hosted, Linux, X64]
+  # singleton, which other workflows depend on.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 
 permissions:


### PR DESCRIPTION
Closes #13432

## Thinking Path

`ci.yml` cancelled in-progress runs for every event, including pushes to `Dev_new_gui`. Merges arrive faster than the suite completes, so **each merge cancelled the previous merge's verification**.

Measured on the last 39 completed base runs: **26 cancelled, 0 successful.** The base branch was effectively never verified, and measuring the #13162 backlog repeatedly meant hunting for a run that happened to survive. Merge rate is ~20 in 6 hours.

`cancel-in-progress` is now conditional on the event. PRs keep the current behaviour — a new push genuinely makes the previous run obsolete. Pushes to a base branch are allowed to finish.

## What Changed

One line in `.github/workflows/ci.yml`, plus the rationale as a comment:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}   # was: true
```

The group is unchanged. Nothing else in the workflow is touched.

## Two corrections to my own earlier analysis on this issue

**The risk I cited does not exist for this workflow.** I argued against the fix because base runs would queue onto the self-hosted singleton, which had a 60-run backlog that day. **Every job in `ci.yml` is `ubuntu-latest`** — the twelve `python-suite` shards included, as the comment above the `python-shard` job already says. The only `self-hosted` strings in the file are that comment. The self-hosted jobs live in other workflows with their own concurrency, and are untouched.

**The narrower option I suggested does not work.** Job-level `concurrency` on `python-shard` cannot help: workflow-level `cancel-in-progress` cancels the entire run including its jobs, and a job-level group cannot override that.

## Why this does not queue unboundedly

With `cancel-in-progress: false`, GitHub keeps at most **one run in progress plus one pending** per concurrency group — a newly queued run cancels the previously pending one. Base runs serialise, each completes, and at most one waits. Under a burst you get a verdict for a *recent* commit rather than for every commit, which is the useful half of the guarantee and is strictly better than the current zero.

## What this does not change

Required checks are evaluated on the **pull request head**, and PR runs were never cancelled by another session's merge — verified against the last twelve `pull_request` runs, which complete `success`/`failure`; the only cancellations are repeated pushes to the same PR. So this fixes **post-merge verification**, not merge gating. It is not a prerequisite for making `python-suite` required, contrary to what I originally wrote on #13162 and corrected there.

## Verification

```
YAML parses; concurrency.group unchanged
cancel-in-progress: ${{ github.event_name == 'pull_request' }}
jobs: 6, runs-on values: {'ubuntu-latest'}   # nothing lands on the singleton
```

`github.event_name` is a GitHub-controlled context value in a `concurrency` field, not user input in a `run:` block — no injection surface.

The change is one line plus its rationale, and reverts cleanly if the queueing behaviour proves worse than the cancelling.

## Model Used

Claude Opus 5 (1M context)
