### PR TITLE
security(ci): make the frontend Security Scan fail on high-severity advisories (#13400)

### DIFF
--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -244,12 +244,74 @@ jobs:
           CYPRESS_INSTALL_BINARY: '0'
         run: npm ci
 
+      # #13400: this step GATES. `npm audit --audit-level=high` runs without
+      # `|| true`, so a high or critical advisory in the frontend lockfile fails
+      # the job on purpose — that is the whole point of the check's name.
+      #
+      # The backlog was measured at 0 advisories (every severity) across 1191
+      # dependencies immediately before the gate was armed, so arming it broke
+      # no open PR and required no triage campaign.
+      #
+      # Do NOT re-add `|| true` here to clear a red build. A red on this step
+      # means a real advisory reached package-lock.json; the fix is to bump the
+      # dependency (dependabot raises those PRs). If an advisory ever has no
+      # published fix and the gate has to yield, change it deliberately and
+      # record why on #13400 — do not silence it as an infra flake.
       - name: Run npm audit
         working-directory: autobot-frontend
         run: |
-          npm audit --audit-level=high || true
+          # Machine-readable report first, non-blocking: a non-zero exit here
+          # only means advisories exist, which the gate at the end is what
+          # reports. This is also the artifact uploaded below.
           npm audit --json > audit-results.json || true
 
+          # #13400: surface the counts in the job summary so the result is
+          # readable from the checks tab without downloading the artifact.
+          # Parsing failures must not fail the job — only the gate may.
+          node --input-type=commonjs -e '
+            const fs = require("fs");
+            const order = ["critical", "high", "moderate", "low", "info"];
+            const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+            let lines;
+            try {
+              const report = JSON.parse(fs.readFileSync("audit-results.json", "utf8"));
+              const counts = (report.metadata || {}).vulnerabilities || {};
+              const total = order.reduce((sum, key) => sum + (counts[key] || 0), 0);
+              lines = [
+                "## Frontend dependency audit",
+                "",
+                total === 0
+                  ? "No known advisories in autobot-frontend."
+                  : "npm audit reported " + total + " advisory record(s).",
+                "",
+                "| Severity | Count |",
+                "| --- | --- |",
+              ].concat(
+                order.map((key) => "| " + key + " | " + (counts[key] || 0) + " |"),
+                ["", "High and critical advisories fail this job (#13400)."]
+              );
+            } catch (error) {
+              lines = [
+                "## Frontend dependency audit",
+                "",
+                "Could not parse audit-results.json: " + error.message,
+              ];
+            }
+            try {
+              fs.appendFileSync(summaryPath, lines.join("\n") + "\n", "utf8");
+            } catch (error) {
+              console.log("Could not write job summary: " + error.message);
+            }
+          '
+
+          # THE GATE — deliberately not suffixed with `|| true`.
+          npm audit --audit-level=high
+
+      # Stays non-blocking by design (#13400): auditjs queries a third-party
+      # network service (OSS Index) whose availability is outside this repo's
+      # control, and its data duplicates the npm advisory feed the gate above
+      # already enforces. It is kept for the extra signal in the log, not as a
+      # second gate — an outage here must never red out the check.
       - name: Run dependency vulnerability scan
         working-directory: autobot-frontend
         run: |


### PR DESCRIPTION
## Thinking Path

The `Security Scan` job ended every scanning step in `|| true`. The only steps that could fail it were checkout, setup-node, `npm ci` and the artifact upload — so a red always meant infrastructure and a green meant nothing about vulnerabilities. `audit-results.json` was uploaded with 30-day retention and read by nothing.

#13400 offered two defensible fixes: **gate** on findings, or **rename** to report-only. The choice turns entirely on the size of the existing backlog, so I measured it before writing anything:

```
$ npm audit --audit-level=high --prefix autobot-frontend
found 0 vulnerabilities

$ npm audit --json --prefix autobot-frontend | jq .metadata
"vulnerabilities": { "info": 0, "low": 0, "moderate": 0, "high": 0, "critical": 0, "total": 0 }
"dependencies":    { "prod": 298, "dev": 827, "optional": 150, "peer": 1, "total": 1191 }
```

**Zero advisories at every severity across 1191 dependencies.**

That inverts the expected answer. The brief's reasoning for report-only was that gating "would fail every PR until someone triages the existing backlog, which blocks the repo on unrelated work" — a sound argument whose entire premise is a non-empty backlog. At zero, gating fails no PR, requires no triage, and blocks nothing. Renaming would have been the *weaker* fix: it makes the check honest about being useless, where gating makes it useful. Dependabot is evidently keeping this tree clean already (#13515, #13523, #13524 landed this week); the gate's job is to keep it that way, and it costs nothing to arm today.

So: gate. The report-only path is recorded in #13542 rather than discarded, along with the three conditions that would justify revisiting it — chiefly an advisory with no published fix, since `--audit-level` is the only lever and there is no per-advisory ignore.

## What Changed

`.github/workflows/frontend-test.yml`, `security-scan` job, one step:

- **`npm audit --audit-level=high` now runs without `|| true`** and is the last command in the step, so a high or critical advisory fails the job. This is the only exit code that was un-swallowed.
- **The JSON dump stays non-blocking** (`npm audit --json > audit-results.json || true`) and still feeds the uploaded artifact, which keeps its `if: always()` and so still uploads when the gate fails.
- **`auditjs` stays non-blocking**, now with a comment explaining why: it queries a third-party network service (OSS Index) whose outages must not red out the check, and its data duplicates the npm advisory feed the gate already enforces.
- **Severity counts are written to `$GITHUB_STEP_SUMMARY`** as a markdown table, so the result is readable from the checks tab without downloading the artifact (#13400 AC2). Written *before* the gate runs, so the counts are visible on failure too — which is when they matter most. Wrapped in try/catch: a malformed report or an unwritable summary path degrades to a note and never fails the job, because only the gate may.
- **A comment records the decision** (#13400 AC3), including the measured backlog and an explicit instruction not to restore `|| true` to clear a red build, with the ordered fallbacks if the gate ever has to yield.

The job `name:` is deliberately left as `Security Scan`. Gating makes the name defensible, which was the complaint; renaming was the *other* remedy, not an addition to this one. That said, the name still overclaims scope — it audits npm dependencies only, no SAST, no secret scanning — so a precise rename is proposed in #13542 as its own reversible change rather than bundled here.

No `${{ }}` interpolation was added anywhere in the step.

## Verification

**YAML parses and the job structure is intact:**
```
$ python3 -c "import yaml; d=yaml.safe_load(open('.github/workflows/frontend-test.yml')); ..."
job name: Security Scan
 step: Checkout code / Setup Node.js / Install dependencies / Run npm audit
 step: Run dependency vulnerability scan / Upload security scan results / Cleanup
```

**The step's `run:` block was extracted from the parsed YAML and executed** against a stubbed `npm` so the real logic — not a paraphrase — was exercised offline.

*Clean tree (the real `npm audit --json` output, 0 advisories):*
```
found 0 vulnerabilities
=== STEP EXIT: 0 ===
## Frontend dependency audit
No known advisories in autobot-frontend.
| Severity | Count |  →  critical 0, high 0, moderate 0, low 0, info 0
High and critical advisories fail this job (#13400).
```

*Same report with `high: 2, critical: 1` injected — proving the gate can actually fail:*
```
3 high/critical
=== STEP EXIT: 1 ===
## Frontend dependency audit
npm audit reported 3 advisory record(s).
| Severity | Count |  →  critical 1, high 2, moderate 0, low 0, info 0
```
Step exit flips 0 → 1, **and the summary is still written** because it precedes the gate. This is the behaviour the old job structurally could not produce.

*Malformed `audit-results.json`:*
```
## Frontend dependency audit
Could not parse audit-results.json: Unexpected token 'o', "not json at all" is not valid JSON
```
Degrades to a note; the node block does not fail the step.

**Shell-quoting safety:** the `node -e '...'` script contains no single quotes (verified — only the two delimiters), so the single-quoted argument cannot be broken out of. `--input-type=commonjs` is explicit because `autobot-frontend/package.json` declares `"type": "module"`; the script uses `require`, and the flag pins CommonJS regardless of future `--eval` default changes.

**No interpolation added:** `git diff | grep "^+" | grep -c '\${{'` → `0`.

**Rename risk checked** (for #13542, not acted on here) — `Security Scan` is not a required context:
```
$ gh api repos/:owner/:repo/branches/Dev_new_gui/protection --jq '.required_status_checks.contexts'
["smoke-test","code-quality","startup-import-smoke","Unit & Integration Tests",
 "No open blocks-merge issues reference this PR","No commit trailers",
 "verify-generated-types","migration-matrix","verify-precommit-config","api-wiring"]
```

**Independently confirmed against GitHub's own alert data.** The push warned of 20 open advisories on the default branch, which would contradict my measurement if any landed on the gated tree. They do not — grouped by manifest:

```
$ gh api "repos/:owner/:repo/dependabot/alerts?state=open&per_page=100" \
    --jq '.[] | [.security_advisory.severity, .dependency.package.ecosystem, .dependency.manifest_path] | @tsv' | sort | uniq -c | sort -rn
      9 high     pip   pyproject.toml
      5 medium   pip   pyproject.toml
      1 high     pip   requirements-ci/security.txt
      1 high     pip   requirements-ci.txt
      1 high     pip   autobot-infrastructure/shared/mcp/tools/knowledge-base-mcp/uv.lock
      1 high     npm   autobot-slm-frontend/package-lock.json
      1 critical pip   requirements-ci/storage.txt
      1 critical pip   requirements-ci.txt
```

19 of 20 are `pip`; the single `npm` alert is in **`autobot-slm-frontend`**, not the `autobot-frontend` tree this job gates. Zero alerts against the gated manifest — the gate will be green on merge.

Two things fall out of that table, both recorded on #13543 rather than pulled into this PR:
- The pip backlog is emphatically **not** zero (2 critical, 10 high), which is exactly why Python gating needed to be a separate, measured piece of work instead of being bundled here.
- **`autobot-slm-frontend/package-lock.json` is audited by nothing in CI** — this job and `security.yml` both `cd autobot-frontend` — and it is the one manifest currently carrying a high npm advisory.

**Follow-ups filed:**
- **#13542** — records the report-only path not taken, its revisit triggers, and the proposed rename.
- **#13543** — the same defect, larger, in `.github/workflows/security.yml`: `Dependency Security Scan` and `Static Application Security Testing (SAST)` swallow every scanner's exit code (pip-audit, safety, npm audit, bandit, semgrep, flake8). Filed separately because the Python backlog is very unlikely to be zero and must be measured and triaged on its own.

## Model Used

Claude Opus 5 (1M context)

Closes #13400
