### PR TITLE
refactor(types): one canonical relation vocabulary + enum message types (#13452)

### DIFF
--- a/autobot-backend/agents/graph_entity_extractor.py
+++ b/autobot-backend/agents/graph_entity_extractor.py
@@ -195,12 +195,16 @@ class GraphEntityExtractor:
             FactType.PREDICTION: "prediction",
         }
 
-        # Relationship inference keywords
+        # Relationship inference keywords. Keys MUST be canonical relation
+        # names (autobot_memory_graph.core.RELATION_TYPES) because
+        # _create_relations_in_graph feeds them straight to create_relation,
+        # which raises ValueError on anything else — and that ValueError is
+        # swallowed, so a non-canonical key silently drops the edge (#13452).
         self.relationship_keywords = {
             "fixes": ["fix", "resolve", "repair", "correct", "address"],
             "implements": ["implement", "add", "create", "build", "develop"],
             "depends_on": ["require", "need", "depend", "prerequisite"],
-            "relates_to": ["related", "similar", "like", "associated"],
+            "related_to": ["related", "similar", "like", "associated"],
             "informs": ["inform", "guide", "suggest", "recommend"],
             "blocks": ["block", "prevent", "stop", "hinder"],
         }
@@ -525,7 +529,7 @@ class GraphEntityExtractor:
                         RelationCandidate(
                             from_entity=entity_a.name,
                             to_entity=entity_b.name,
-                            relation_type="relates_to",
+                            relation_type="related_to",  # canonical spelling (#13452)
                             confidence=0.7,
                             evidence=co_occurrence_evidence,
                         )

--- a/autobot-backend/agents/graph_entity_extractor_test.py
+++ b/autobot-backend/agents/graph_entity_extractor_test.py
@@ -25,6 +25,7 @@ from agents.graph_entity_extractor import (
     GraphEntityExtractor,
     RelationCandidate,
 )
+from autobot_memory_graph.core import RELATION_TYPES
 from models.atomic_fact import AtomicFact, FactType, TemporalType
 
 # ============================================================================
@@ -412,9 +413,12 @@ def test_infer_relationships(entity_extractor):
         assert isinstance(relation, RelationCandidate)
         assert relation.from_entity
         assert relation.to_entity
-        assert (
-            relation.relation_type in entity_extractor.relationship_keywords.keys()
-            or relation.relation_type == "relates_to"
+        # #13452: every inferred type must be one create_relation accepts.
+        # The old assertion also allowed "relates_to", which create_relation
+        # rejects — so it could not catch the silently dropped edges.
+        assert relation.relation_type in RELATION_TYPES
+        assert relation.relation_type in entity_extractor.relationship_keywords.keys() or (
+            relation.relation_type == "related_to"
         )
 
 
@@ -461,13 +465,13 @@ def test_deduplicate_relations(entity_extractor):
         RelationCandidate(
             from_entity="Entity A",
             to_entity="Entity B",
-            relation_type="relates_to",
+            relation_type="related_to",
             confidence=0.7,
         ),
         RelationCandidate(
             from_entity="Entity A",
             to_entity="Entity B",
-            relation_type="relates_to",
+            relation_type="related_to",
             confidence=0.9,  # Higher confidence
         ),
         RelationCandidate(

--- a/autobot-backend/api/knowledge_relations.py
+++ b/autobot-backend/api/knowledge_relations.py
@@ -27,6 +27,7 @@ from api.schemas_knowledge import (
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
+from knowledge.relations import KB_RELATION_TYPES
 from knowledge_factory import get_or_create_knowledge_base
 
 logger = get_logger(__name__)
@@ -288,30 +289,14 @@ async def get_available_relation_types(req: Request):
     """
     kb = await get_or_create_knowledge_base(req.app, force_refresh=False)
 
-    if kb is None:
-        # Return hardcoded types if KB not available
-        return {
-            "success": True,
-            "relation_types": [
-                {"name": "relates_to", "description": "General relationship"},
-                {"name": "depends_on", "description": "Dependency relationship"},
-                {"name": "implements", "description": "Implementation relationship"},
-                {"name": "fixes", "description": "Bug fix relationship"},
-                {"name": "informs", "description": "Information flow"},
-                {"name": "guides", "description": "Guidance relationship"},
-                {"name": "follows", "description": "Sequential relationship"},
-                {"name": "contains", "description": "Containment relationship"},
-                {"name": "blocks", "description": "Blocking relationship"},
-                {"name": "references", "description": "Reference relationship"},
-                {"name": "supersedes", "description": "Replacement relationship"},
-                {"name": "contradicts", "description": "Contradiction relationship"},
-            ],
-        }
+    # #13452: both branches read the same canonical vocabulary. The fallback
+    # used to be a hand-maintained literal list that had already drifted from
+    # the knowledge base's own set.
+    relation_types = kb.RELATION_TYPES if kb is not None else KB_RELATION_TYPES
 
     return {
         "success": True,
         "relation_types": [
-            {"name": rt, "description": f"{rt.replace('_', ' ').title()} relationship"}
-            for rt in sorted(kb.RELATION_TYPES)
+            {"name": rt, "description": f"{rt.replace('_', ' ').title()} relationship"} for rt in sorted(relation_types)
         ],
     }

--- a/autobot-backend/api/knowledge_relations.py
+++ b/autobot-backend/api/knowledge_relations.py
@@ -63,19 +63,13 @@ async def create_fact_relation(req: Request, body: CreateRelationRequest):
 
     This enables graph-based knowledge retrieval alongside vector search.
 
-    Valid relation types:
-    - relates_to: General relationship
-    - depends_on: Dependency relationship
-    - implements: Implementation relationship
-    - fixes: Bug fix relationship
-    - informs: Information flow
-    - guides: Guidance relationship
-    - follows: Sequential relationship
-    - contains: Containment relationship
-    - blocks: Blocking relationship
-    - references: Reference relationship
-    - supersedes: Replacement relationship
-    - contradicts: Contradiction relationship
+    Valid relation types are served by GET /api/knowledge/relations/types,
+    which reads the canonical vocabulary directly. They are deliberately not
+    restated here: the hand-maintained copy that used to live in this docstring
+    had already drifted from the vocabulary it documented (#13452).
+
+    The legacy spelling "relates_to" is still accepted and is stored as its
+    canonical name "related_to".
     """
     kb = await get_or_create_knowledge_base(req.app, force_refresh=False)
 

--- a/autobot-backend/api/knowledge_search_aggregator.py
+++ b/autobot-backend/api/knowledge_search_aggregator.py
@@ -86,7 +86,7 @@ def _build_relation_context(rel: Dict[str, Any], total_length: int, max_length: 
     content = rel["target_fact"].get("content", "")[:300]
     if total_length + len(content) > max_length:
         return total_length
-    rel_type = rel.get("relation_type", "relates_to")
+    rel_type = rel.get("relation_type", "related_to")
     context_parts.append(f"- [{rel_type}] {content}\n")
     return total_length + len(content)
 
@@ -714,7 +714,7 @@ async def _get_fact_relations_for_graph(kb: Any, fact_ids: List[str], max_relati
                         {
                             "from": fact_id,
                             "to": target_id,
-                            "type": rel.get("relation_type", "relates_to"),
+                            "type": rel.get("relation_type", "related_to"),
                             "strength": rel.get("strength", 0.8),
                         }
                     )

--- a/autobot-backend/api/schemas_knowledge.py
+++ b/autobot-backend/api/schemas_knowledge.py
@@ -13,6 +13,11 @@ from typing import Any, Dict, List
 
 from pydantic import AliasChoices, BaseModel, Field, field_validator
 
+from autobot_memory_graph.core import (
+    RELATION_TYPE_ALIASES,
+    RELATION_TYPES,
+    canonical_relation_type,
+)
 from constants.threshold_constants import CategoryDefaults, QueryDefaults
 from knowledge.ownership import AccessLevel, VisibilityLevel
 from type_defs.common import Metadata
@@ -3808,19 +3813,13 @@ _VALID_ENTITY_TYPES = frozenset(
         "implementation",
     }
 )
-_VALID_RELATION_TYPES = frozenset(
-    {
-        "relates_to",
-        "depends_on",
-        "implements",
-        "fixes",
-        "informs",
-        "guides",
-        "follows",
-        "contains",
-        "blocks",
-    }
-)
+# Issue #13452: RelationCreateRequest is the body of POST /api/memory/relations,
+# which calls AutoBotMemoryGraph.create_relation — so it must validate against
+# the memory graph's vocabulary, not the knowledge base's. The previous literal
+# copy was the knowledge-base list: it rejected valid graph types (related_to,
+# caused_by, leads_to, owns, ...) and admitted "relates_to", which then raised
+# ValueError inside create_relation. Derived now, so it cannot drift again.
+_VALID_RELATION_TYPES = frozenset(RELATION_TYPES | set(RELATION_TYPE_ALIASES))
 
 
 class EntityCreateRequest(BaseModel):
@@ -3855,7 +3854,8 @@ class RelationCreateRequest(BaseModel):
     def validate_relation_type(cls, v):
         if v not in _VALID_RELATION_TYPES:
             raise ValueError(f"relation_type must be one of: {_VALID_RELATION_TYPES}")
-        return v
+        # #13452: normalise legacy spellings so only the canonical name is stored.
+        return canonical_relation_type(v)
 
 
 class InvalidateEntityRequest(BaseModel):

--- a/autobot-backend/api/schemas_knowledge.py
+++ b/autobot-backend/api/schemas_knowledge.py
@@ -3853,7 +3853,8 @@ class RelationCreateRequest(BaseModel):
     @classmethod
     def validate_relation_type(cls, v):
         if v not in _VALID_RELATION_TYPES:
-            raise ValueError(f"relation_type must be one of: {_VALID_RELATION_TYPES}")
+            # sorted(): a raw frozenset repr renders in arbitrary order (#13452).
+            raise ValueError(f"relation_type must be one of: {sorted(_VALID_RELATION_TYPES)}")
         # #13452: normalise legacy spellings so only the canonical name is stored.
         return canonical_relation_type(v)
 
@@ -4374,7 +4375,7 @@ class CreateRelationRequest(BaseModel):
 
     source_fact_id: str = Field(..., description="ID of the source fact")
     target_fact_id: str = Field(..., description="ID of the target fact")
-    relation_type: str = Field(..., description="Type of relation (e.g., relates_to, depends_on, implements)")
+    relation_type: str = Field(..., description="Type of relation (e.g., related_to, depends_on, implements)")
     metadata: dict | None = Field(None, description="Optional metadata for the relation")
 
 

--- a/autobot-backend/autobot_memory_graph/__init__.py
+++ b/autobot-backend/autobot_memory_graph/__init__.py
@@ -33,12 +33,16 @@ Backward Compatibility:
 """
 
 from .core import (  # noqa: F401 - re-exports for package API
+    CORE_RELATION_TYPES,
     ENTITY_TYPES,
+    IDENTITY_RELATION_TYPES,
     INCOMING_DIRECTIONS,
     OUTGOING_DIRECTIONS,
+    RELATION_TYPE_ALIASES,
     RELATION_TYPES,
     VALID_ACTIVITY_TYPES,
     AutoBotMemoryGraphCore,
+    canonical_relation_type,
     config,
 )
 from .entities import EntityOperationsMixin
@@ -128,10 +132,15 @@ __all__ = [
     "AutoBotMemoryGraphCore",
     # Constants
     "ENTITY_TYPES",
+    "CORE_RELATION_TYPES",
+    "IDENTITY_RELATION_TYPES",
     "RELATION_TYPES",
+    "RELATION_TYPE_ALIASES",
     "VALID_ACTIVITY_TYPES",
     "OUTGOING_DIRECTIONS",
     "INCOMING_DIRECTIONS",
+    # Helpers
+    "canonical_relation_type",
     # Mixins (for extension)
     "EntityOperationsMixin",
     "RelationOperationsMixin",

--- a/autobot-backend/autobot_memory_graph/core.py
+++ b/autobot-backend/autobot_memory_graph/core.py
@@ -117,6 +117,40 @@ def canonical_relation_type(relation_type: str) -> str:
     return RELATION_TYPE_ALIASES.get(relation_type, relation_type)
 
 
+def relation_type_matches(stored_type: str, wanted_type: str | None) -> bool:
+    """Compare a stored relation type against a caller-supplied filter.
+
+    Both sides are canonicalised, so relations persisted under a legacy
+    spelling stay reachable through the canonical name and vice versa — reads
+    and deletes therefore stay symmetric with writes, which canonicalise. An
+    empty or absent filter matches everything.
+
+    Args:
+        stored_type: Relation type as read back from the store.
+        wanted_type: Relation type the caller filtered on, or None/"" for any.
+
+    Returns:
+        True when the stored relation satisfies the filter.
+    """
+    if not wanted_type:
+        return True
+    return canonical_relation_type(stored_type) == canonical_relation_type(wanted_type)
+
+
+def canonical_relation_filter(relation_types: List[str] | None) -> Set[str] | None:
+    """Canonicalise a list-shaped relation filter once, for repeated matching.
+
+    Args:
+        relation_types: Relation names the caller filtered on, or None for any.
+
+    Returns:
+        A set of canonical names, or None when no filter was supplied.
+    """
+    if not relation_types:
+        return None
+    return {canonical_relation_type(rt) for rt in relation_types}
+
+
 VALID_ACTIVITY_TYPES: Set[str] = {
     "chat",
     "terminal",
@@ -333,6 +367,8 @@ __all__ = [
     "INCOMING_DIRECTIONS",
     # Helpers
     "canonical_relation_type",
+    "canonical_relation_filter",
+    "relation_type_matches",
     # Config
     "config",
 ]

--- a/autobot-backend/autobot_memory_graph/core.py
+++ b/autobot-backend/autobot_memory_graph/core.py
@@ -42,7 +42,27 @@ ENTITY_TYPES: Set[str] = {
     "SECRET_USAGE",  # Issue #608
 }
 
-RELATION_TYPES: Set[str] = {
+# ----------------------------------------------------------------------------
+# Relation vocabulary (Issue #13452)
+#
+# CORE_RELATION_TYPES is the single canonical, domain-neutral relation
+# vocabulary for the whole codebase. Every other relation store derives from
+# it instead of restating its own list:
+#   - autobot_memory_graph  -> RELATION_TYPES     (core + identity extras)
+#   - knowledge.relations   -> KB_RELATION_TYPES  (core, fact-to-fact)
+#   - api.schemas_knowledge -> RelationCreateRequest validator
+#
+# Before #13452 the memory graph spelled the general relation "related_to"
+# while the knowledge base spelled it "relates_to", and neither accepted the
+# other's spelling. create_relation() raises ValueError for unknown types and
+# several callers swallow it, so every edge written with the wrong spelling
+# was silently dropped (#13367 fixed one call site; the divergence itself is
+# fixed here). "related_to" is canonical; "relates_to" survives only as a
+# read/write alias in RELATION_TYPE_ALIASES so already-persisted Redis
+# relations stay resolvable without a data migration.
+# ----------------------------------------------------------------------------
+
+CORE_RELATION_TYPES: Set[str] = {
     "contains",
     "depends_on",
     "implements",
@@ -51,6 +71,19 @@ RELATION_TYPES: Set[str] = {
     "related_to",
     "leads_to",
     "blocks",
+    # Document/issue-level names — previously knowledge-base-only, promoted to
+    # the canonical set because agents.graph_entity_extractor infers them and
+    # writes them straight into the memory graph.
+    "fixes",
+    "informs",
+    "guides",
+    "follows",
+    "supersedes",
+    "contradicts",
+}
+
+# Identity/activity relations — memory-graph only, meaningless between facts.
+IDENTITY_RELATION_TYPES: Set[str] = {
     "owns",  # Issue #608 - User owns Secret
     "has_secret",  # Issue #608 - User/Session has Secret
     "shared_with",  # Issue #608 - Secret shared with User
@@ -58,6 +91,31 @@ RELATION_TYPES: Set[str] = {
     "performed_by",  # Issue #608 - Activity performed by User
     "used_secret",  # Issue #608 - Activity used Secret
 }
+
+RELATION_TYPES: Set[str] = CORE_RELATION_TYPES | IDENTITY_RELATION_TYPES
+
+# Legacy/alternate spellings mapped onto their canonical name. Callers are
+# canonicalised on write, so no new relation is ever persisted under an alias,
+# while relations already stored under one keep resolving.
+RELATION_TYPE_ALIASES: Dict[str, str] = {
+    "relates_to": "related_to",  # knowledge-base spelling before #13452
+}
+
+
+def canonical_relation_type(relation_type: str) -> str:
+    """Return the canonical spelling for a relation type.
+
+    Unknown names are returned unchanged so the caller's own validation still
+    reports them, rather than this helper masking a genuine typo.
+
+    Args:
+        relation_type: Relation name as supplied by the caller.
+
+    Returns:
+        The canonical relation name.
+    """
+    return RELATION_TYPE_ALIASES.get(relation_type, relation_type)
+
 
 VALID_ACTIVITY_TYPES: Set[str] = {
     "chat",
@@ -266,10 +324,15 @@ __all__ = [
     "AutoBotMemoryGraphCore",
     # Constants
     "ENTITY_TYPES",
+    "CORE_RELATION_TYPES",
+    "IDENTITY_RELATION_TYPES",
     "RELATION_TYPES",
+    "RELATION_TYPE_ALIASES",
     "VALID_ACTIVITY_TYPES",
     "OUTGOING_DIRECTIONS",
     "INCOMING_DIRECTIONS",
+    # Helpers
+    "canonical_relation_type",
     # Config
     "config",
 ]

--- a/autobot-backend/autobot_memory_graph/relation_vocabulary_test.py
+++ b/autobot-backend/autobot_memory_graph/relation_vocabulary_test.py
@@ -1,0 +1,121 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Drift guard for the canonical relation vocabulary (Issue #13452).
+
+Two independent relation vocabularies used to exist: autobot_memory_graph
+spelled the general relation ``related_to`` while knowledge/relations.py
+spelled it ``relates_to``, and neither accepted the other's spelling.
+``create_relation`` raises ValueError for unknown types and several call sites
+swallow it, so every edge written with the wrong spelling was silently dropped
+(#13367 fixed one call site; the divergence itself is fixed here).
+
+These tests fail the moment any vocabulary restates names instead of deriving
+them from ``autobot_memory_graph.core.CORE_RELATION_TYPES``.
+"""
+
+import pytest
+
+from api.schemas_knowledge import _VALID_RELATION_TYPES, RelationCreateRequest
+from autobot_memory_graph.core import (
+    CORE_RELATION_TYPES,
+    IDENTITY_RELATION_TYPES,
+    RELATION_TYPE_ALIASES,
+    RELATION_TYPES,
+    canonical_relation_type,
+)
+from knowledge.relations import KB_RELATION_TYPES
+from services.security_memory_integration import (
+    SECURITY_RELATION_TYPES,
+    SECURITY_TO_BASE_RELATION,
+)
+
+
+class TestCanonicalVocabulary:
+    """The canonical set is the only place relation names are declared."""
+
+    def test_kb_vocabulary_derives_from_the_canonical_set(self):
+        """knowledge/relations.py must not restate its own list."""
+        assert KB_RELATION_TYPES == CORE_RELATION_TYPES
+
+    def test_memory_graph_is_core_plus_identity_relations(self):
+        assert RELATION_TYPES == CORE_RELATION_TYPES | IDENTITY_RELATION_TYPES
+
+    def test_identity_relations_are_memory_graph_only(self):
+        """owns/has_secret/... are entity relations, meaningless between facts."""
+        assert not (IDENTITY_RELATION_TYPES & KB_RELATION_TYPES)
+
+    def test_only_one_spelling_of_the_general_relation_is_live(self):
+        """ "relates_to" is an alias, never a member of any live vocabulary."""
+        assert "related_to" in CORE_RELATION_TYPES
+        for vocabulary in (CORE_RELATION_TYPES, RELATION_TYPES, KB_RELATION_TYPES):
+            assert "relates_to" not in vocabulary
+
+    def test_shared_names_have_a_single_spelling(self):
+        """Every name the two vocabularies share is character-identical."""
+        assert KB_RELATION_TYPES <= RELATION_TYPES
+
+
+class TestAliases:
+    """Aliases map legacy spellings onto canonical names."""
+
+    def test_relates_to_maps_to_related_to(self):
+        assert canonical_relation_type("relates_to") == "related_to"
+
+    def test_every_alias_target_is_canonical(self):
+        assert set(RELATION_TYPE_ALIASES.values()) <= RELATION_TYPES
+
+    def test_no_alias_shadows_a_live_name(self):
+        """An alias key must not also be a valid vocabulary member."""
+        assert not (set(RELATION_TYPE_ALIASES) & RELATION_TYPES)
+
+    def test_canonical_names_are_idempotent(self):
+        for name in RELATION_TYPES:
+            assert canonical_relation_type(name) == name
+
+    def test_unknown_names_pass_through_untouched(self):
+        """The helper must not mask a genuine typo."""
+        assert canonical_relation_type("nonsense_relation") == "nonsense_relation"
+
+
+class TestApiSchemaVocabulary:
+    """POST /api/memory/relations validates against the memory graph."""
+
+    def test_schema_accepts_every_memory_graph_relation(self):
+        """The old literal list rejected related_to, caused_by, owns, ..."""
+        assert RELATION_TYPES <= _VALID_RELATION_TYPES
+
+    def test_schema_never_admits_a_type_create_relation_would_reject(self):
+        """Anything the validator accepts must survive canonicalisation."""
+        for name in _VALID_RELATION_TYPES:
+            assert canonical_relation_type(name) in RELATION_TYPES
+
+    @pytest.mark.parametrize("relation_type", ["related_to", "caused_by", "leads_to", "owns"])
+    def test_canonical_types_are_accepted(self, relation_type):
+        request = RelationCreateRequest(from_entity="a", to_entity="b", relation_type=relation_type)
+        assert request.relation_type == relation_type
+
+    def test_legacy_spelling_is_normalised_not_stored(self):
+        """A client sending relates_to must persist related_to."""
+        request = RelationCreateRequest(from_entity="a", to_entity="b", relation_type="relates_to")
+        assert request.relation_type == "related_to"
+
+    def test_unknown_type_is_still_rejected(self):
+        with pytest.raises(ValueError):
+            RelationCreateRequest(from_entity="a", to_entity="b", relation_type="not_a_relation")
+
+
+class TestSecurityVocabulary:
+    """The security domain's third partial vocabulary maps onto the canonical one."""
+
+    def test_every_security_relation_maps_to_a_canonical_type(self):
+        assert set(SECURITY_TO_BASE_RELATION.values()) <= RELATION_TYPES
+
+    def test_documented_and_mapped_tables_agree(self):
+        assert set(SECURITY_RELATION_TYPES) == set(SECURITY_TO_BASE_RELATION)
+
+    def test_affects_is_mapped(self):
+        """ "affects" is in no canonical set, so it is unusable without a mapping."""
+        assert SECURITY_TO_BASE_RELATION["affects"] in RELATION_TYPES

--- a/autobot-backend/autobot_memory_graph/relation_vocabulary_test.py
+++ b/autobot-backend/autobot_memory_graph/relation_vocabulary_test.py
@@ -16,20 +16,25 @@ These tests fail the moment any vocabulary restates names instead of deriving
 them from ``autobot_memory_graph.core.CORE_RELATION_TYPES``.
 """
 
+from unittest.mock import AsyncMock, Mock
+
 import pytest
 
 from api.schemas_knowledge import _VALID_RELATION_TYPES, RelationCreateRequest
+from autobot_memory_graph import AutoBotMemoryGraph
 from autobot_memory_graph.core import (
     CORE_RELATION_TYPES,
     IDENTITY_RELATION_TYPES,
     RELATION_TYPE_ALIASES,
     RELATION_TYPES,
+    canonical_relation_filter,
     canonical_relation_type,
+    relation_type_matches,
 )
-from knowledge.relations import KB_RELATION_TYPES
+from knowledge.relations import KB_RELATION_TYPES, RelationsMixin
 from services.security_memory_integration import (
-    SECURITY_RELATION_TYPES,
     SECURITY_TO_BASE_RELATION,
+    verify_security_relation_vocabulary,
 )
 
 
@@ -110,12 +115,139 @@ class TestApiSchemaVocabulary:
 class TestSecurityVocabulary:
     """The security domain's third partial vocabulary maps onto the canonical one."""
 
-    def test_every_security_relation_maps_to_a_canonical_type(self):
-        assert set(SECURITY_TO_BASE_RELATION.values()) <= RELATION_TYPES
+    def test_vocabulary_has_not_drifted(self):
+        """Runs the module's own guard here rather than at import (#13452).
 
-    def test_documented_and_mapped_tables_agree(self):
-        assert set(SECURITY_RELATION_TYPES) == set(SECURITY_TO_BASE_RELATION)
+        Calling it at import would turn a static, source-level mistake into a
+        backend startup failure.
+        """
+        verify_security_relation_vocabulary()
 
     def test_affects_is_mapped(self):
         """ "affects" is in no canonical set, so it is unusable without a mapping."""
         assert SECURITY_TO_BASE_RELATION["affects"] in RELATION_TYPES
+
+
+class TestMatcherSymmetry:
+    """Reads and deletes must resolve a legacy spelling exactly as writes do."""
+
+    @pytest.mark.parametrize(
+        "stored, wanted",
+        [
+            ("related_to", "relates_to"),  # canonical stored, legacy queried
+            ("relates_to", "related_to"),  # legacy stored (pre-#13452), canonical queried
+            ("relates_to", "relates_to"),
+            ("related_to", "related_to"),
+        ],
+    )
+    def test_alias_and_canonical_are_interchangeable(self, stored, wanted):
+        assert relation_type_matches(stored, wanted)
+
+    def test_distinct_types_still_do_not_match(self):
+        assert not relation_type_matches("related_to", "depends_on")
+
+    @pytest.mark.parametrize("empty", [None, ""])
+    def test_absent_filter_matches_everything(self, empty):
+        """An empty filter must mean "all", not "none" — reachable via
+        GET /api/knowledge/relations/fact/{id}?relation_type= ."""
+        assert relation_type_matches("related_to", empty)
+
+    def test_list_filter_is_canonicalised(self):
+        assert canonical_relation_filter(["relates_to", "blocks"]) == {"related_to", "blocks"}
+
+    @pytest.mark.parametrize("empty", [None, []])
+    def test_absent_list_filter_is_none(self, empty):
+        assert canonical_relation_filter(empty) is None
+
+    def test_kb_reuses_the_shared_matcher(self):
+        """One matcher, so the two stores cannot drift in how they resolve aliases."""
+        assert RelationsMixin._relation_type_matches is relation_type_matches
+
+
+class TestMemoryGraphRoundTrip:
+    """Write with the alias, then read and delete by it (#13452 blocker).
+
+    Writes canonicalise, so without the same normalisation on the read and
+    delete paths a relation created as "relates_to" is stored as "related_to"
+    and then unreachable: GET returns 0 rows, DELETE 404s, invalidate no-ops.
+    """
+
+    @staticmethod
+    def _graph(stored_relations=None):
+        """Build a graph whose redis_client.json() is sync but its ops async."""
+        graph = AutoBotMemoryGraph()
+        graph._initialized = True
+        json_ops = Mock()
+        json_ops.get = AsyncMock(return_value={"relations": list(stored_relations or [])})
+        json_ops.set = AsyncMock()
+        graph.redis_client = Mock()
+        graph.redis_client.json = Mock(return_value=json_ops)
+        return graph, json_ops
+
+    async def test_write_stores_the_canonical_spelling(self):
+        graph, _ = self._graph()
+        graph._resolve_entity_ids = AsyncMock(return_value=("id-a", "id-b"))
+        graph._store_outgoing_relation = AsyncMock()
+        graph._store_incoming_relation = AsyncMock()
+
+        relation = await graph.create_relation("A", "B", relation_type="relates_to")
+
+        assert relation["type"] == "related_to"
+
+    async def test_get_relations_finds_it_by_the_alias(self):
+        graph, _ = self._graph()
+        graph._get_outgoing_relations = AsyncMock(return_value=[{"to": "id-b", "type": "related_to"}])
+        graph._get_incoming_relations = AsyncMock(return_value=[])
+
+        result = await graph.get_relations("id-a", relation_types=["relates_to"])
+
+        assert len(result["relations"]) == 1
+
+    async def test_get_relations_finds_legacy_rows_by_the_canonical_name(self):
+        """Rows persisted before #13452 still carry the alias in Redis."""
+        graph, _ = self._graph()
+        graph._get_outgoing_relations = AsyncMock(return_value=[{"to": "id-b", "type": "relates_to"}])
+        graph._get_incoming_relations = AsyncMock(return_value=[])
+
+        result = await graph.get_relations("id-a", relation_types=["related_to"])
+
+        assert len(result["relations"]) == 1
+
+    async def test_get_related_entities_traverses_through_the_alias(self):
+        graph, _ = self._graph()
+        graph.get_entity = AsyncMock(return_value={"id": "id-a", "name": "A"})
+        # Only id-a has an outgoing edge, so the BFS terminates at id-b.
+        graph._get_outgoing_relations = AsyncMock(
+            side_effect=lambda eid: [{"to": "id-b", "type": "related_to"}] if eid == "id-a" else []
+        )
+        graph._get_incoming_relations = AsyncMock(return_value=[])
+
+        related = await graph.get_related_entities("A", relation_type="relates_to", direction="outgoing")
+
+        assert len(related) == 1
+        assert related[0]["relation"]["type"] == "related_to"
+
+    async def test_delete_relation_removes_it_when_asked_by_the_alias(self):
+        graph, json_ops = self._graph([{"to": "id-b", "from": "id-a", "type": "related_to"}])
+        graph.get_entity = AsyncMock(side_effect=[{"id": "id-a"}, {"id": "id-b"}])
+
+        assert await graph.delete_relation("A", "B", relation_type="relates_to") is True
+
+        # Both directions rewritten with the matching relation removed.
+        assert json_ops.set.call_count == 2
+        for call in json_ops.set.call_args_list:
+            assert call.args[2] == []
+
+    async def test_delete_relation_leaves_other_types_alone(self):
+        graph, json_ops = self._graph([{"to": "id-b", "from": "id-a", "type": "depends_on"}])
+        graph.get_entity = AsyncMock(side_effect=[{"id": "id-a"}, {"id": "id-b"}])
+
+        await graph.delete_relation("A", "B", relation_type="relates_to")
+
+        for call in json_ops.set.call_args_list:
+            assert len(call.args[2]) == 1
+
+    async def test_invalidate_relation_matches_through_the_alias(self):
+        graph, _ = self._graph([{"to": "id-b", "from": "id-a", "type": "related_to"}])
+
+        assert await graph.invalidate_relation("id-a", "relates_to", "id-b") is True

--- a/autobot-backend/autobot_memory_graph/relations.py
+++ b/autobot-backend/autobot_memory_graph/relations.py
@@ -24,7 +24,9 @@ from .core import (
     OUTGOING_DIRECTIONS,
     RELATION_TYPES,
     AutoBotMemoryGraphCore,
+    canonical_relation_filter,
     canonical_relation_type,
+    relation_type_matches,
 )
 
 logger = get_logger(__name__)
@@ -291,18 +293,22 @@ class RelationOperationsMixin:
         """Get relations for an entity. Issue #620."""
         self.ensure_initialized()
 
+        # #13452: reads must canonicalise both sides, exactly as writes do, or a
+        # relation created as "relates_to" (stored "related_to") is unreachable.
+        wanted = canonical_relation_filter(relation_types)
+
         try:
             relations = []
             if direction in OUTGOING_DIRECTIONS:
                 outgoing = await self._get_outgoing_relations(entity_id)
                 for rel in outgoing:
-                    if relation_types is None or rel.get("type") in relation_types:
+                    if wanted is None or canonical_relation_type(rel.get("type", "")) in wanted:
                         relations.append(self._format_outgoing_relation(entity_id, rel))
 
             if direction in INCOMING_DIRECTIONS:
                 incoming = await self._get_incoming_relations(entity_id)
                 for rel in incoming:
-                    if relation_types is None or rel.get("type") in relation_types:
+                    if wanted is None or canonical_relation_type(rel.get("type", "")) in wanted:
                         relations.append(self._format_incoming_relation(entity_id, rel))
 
             return {"relations": relations}
@@ -394,7 +400,8 @@ class RelationOperationsMixin:
         queue: List,
     ) -> List[Dict[str, Any]]:
         """Process relations in a single direction. Issue #620."""
-        filtered = [rel for rel in relations if relation_type is None or rel["type"] == relation_type]
+        # #13452: alias-aware so legacy-spelled stored edges still match.
+        filtered = [rel for rel in relations if relation_type_matches(rel["type"], relation_type)]
         if not filtered:
             return []
 
@@ -432,6 +439,7 @@ class RelationOperationsMixin:
             List of related entities with relation metadata
         """
         self.ensure_initialized()
+        relation_type = canonical_relation_type(relation_type) if relation_type else relation_type  # #13452
 
         try:
             entity = await self.get_entity(entity_name=entity_name)
@@ -481,7 +489,9 @@ class RelationOperationsMixin:
 
         if out_data and "relations" in out_data:
             filtered_relations = [
-                rel for rel in out_data["relations"] if not (rel["to"] == to_id and rel["type"] == relation_type)
+                rel
+                for rel in out_data["relations"]
+                if not (rel["to"] == to_id and relation_type_matches(rel["type"], relation_type))
             ]
             await self.redis_client.json().set(out_key, "$.relations", filtered_relations)
 
@@ -506,7 +516,9 @@ class RelationOperationsMixin:
 
         if in_data and "relations" in in_data:
             filtered_relations = [
-                rel for rel in in_data["relations"] if not (rel["from"] == from_id and rel["type"] == relation_type)
+                rel
+                for rel in in_data["relations"]
+                if not (rel["from"] == from_id and relation_type_matches(rel["type"], relation_type))
             ]
             await self.redis_client.json().set(in_key, "$.relations", filtered_relations)
 
@@ -525,7 +537,7 @@ class RelationOperationsMixin:
 
         updated = False
         for rel in data["relations"]:
-            if rel.get(id_field) == match_id and rel.get("type") == relation_type:
+            if rel.get(id_field) == match_id and relation_type_matches(rel.get("type", ""), relation_type):
                 rel["valid_to"] = valid_to
                 updated = True
 
@@ -552,6 +564,7 @@ class RelationOperationsMixin:
             ended_at: ISO-8601 timestamp for valid_to (default: now)
         """
         self.ensure_initialized()
+        relation_type = canonical_relation_type(relation_type)  # #13452
 
         try:
             valid_to = ended_at or datetime.now(tz=timezone.utc).isoformat()
@@ -597,6 +610,7 @@ class RelationOperationsMixin:
             True if deleted, False if not found
         """
         self.ensure_initialized()
+        relation_type = canonical_relation_type(relation_type)  # #13452
 
         try:
             from_entity_data, to_entity_data = await asyncio.gather(

--- a/autobot-backend/autobot_memory_graph/relations.py
+++ b/autobot-backend/autobot_memory_graph/relations.py
@@ -24,6 +24,7 @@ from .core import (
     OUTGOING_DIRECTIONS,
     RELATION_TYPES,
     AutoBotMemoryGraphCore,
+    canonical_relation_type,
 )
 
 logger = get_logger(__name__)
@@ -118,6 +119,10 @@ class RelationOperationsMixin:
             Created relation data
         """
         self.ensure_initialized()
+        # #13452: fold legacy spellings (e.g. "relates_to") onto the canonical
+        # name before validating, so a caller using the knowledge-base spelling
+        # writes a real edge instead of raising into a swallowing except block.
+        relation_type = canonical_relation_type(relation_type)
         if relation_type not in RELATION_TYPES:
             raise ValueError(f"Invalid relation_type: {relation_type}")
 
@@ -176,6 +181,7 @@ class RelationOperationsMixin:
         """Create relationship between entities using IDs. Issue #620."""
         self.ensure_initialized()
 
+        relation_type = canonical_relation_type(relation_type)  # #13452
         if relation_type not in RELATION_TYPES:
             raise ValueError(f"Invalid relation_type: {relation_type}")
 

--- a/autobot-backend/knowledge/relations.py
+++ b/autobot-backend/knowledge/relations.py
@@ -12,8 +12,9 @@ Relations are stored in Redis using the same pattern as
 autobot_memory_graph.relations (outgoing/incoming JSON lists), but scoped
 to knowledge-base facts (key prefix ``kb:rel:``).
 
-Relation types are imported from autobot_memory_graph.core.RELATION_TYPES
-plus additional knowledge-specific types.
+Relation types are imported from
+``autobot_memory_graph.core.CORE_RELATION_TYPES`` — the single canonical
+vocabulary (Issue #13452). This module no longer keeps its own copy.
 """
 
 import asyncio
@@ -22,26 +23,22 @@ from collections import defaultdict
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Set
 
+from autobot_memory_graph.core import CORE_RELATION_TYPES, canonical_relation_type
 from autobot_shared.error_boundaries import error_boundary
 from autobot_shared.logging_manager import get_logger
 
 logger = get_logger(__name__)
 
-# Knowledge-specific relation types extend the memory graph set
-KB_RELATION_TYPES: Set[str] = {
-    "relates_to",
-    "depends_on",
-    "implements",
-    "fixes",
-    "informs",
-    "guides",
-    "follows",
-    "contains",
-    "blocks",
-    "references",
-    "supersedes",
-    "contradicts",
-}
+# Issue #13452: derived from the canonical vocabulary instead of restating it.
+# This module's docstring always claimed the types came from
+# autobot_memory_graph, but the list below was an independent copy that spelled
+# the general relation "relates_to" where the memory graph spelled it
+# "related_to" — a divergence that silently dropped edges (#13367).
+#
+# Facts relate to facts, so the knowledge base takes CORE_RELATION_TYPES and
+# not the identity/activity names (owns, has_secret, ...) that only make sense
+# between memory-graph entities.
+KB_RELATION_TYPES: Set[str] = set(CORE_RELATION_TYPES)
 
 
 class RelationsMixin:
@@ -55,6 +52,25 @@ class RelationsMixin:
     RELATION_TYPES = KB_RELATION_TYPES
 
     # -- helpers ----------------------------------------------------------
+
+    @staticmethod
+    def _relation_type_matches(stored_type: str, wanted_type: str | None) -> bool:
+        """Compare a stored relation type against a requested one (#13452).
+
+        Both sides are canonicalised, so relations persisted under the legacy
+        "relates_to" spelling stay reachable through the canonical
+        "related_to" and vice versa — no Redis migration required.
+
+        Args:
+            stored_type: Relation type as read back from Redis.
+            wanted_type: Relation type the caller filtered on, or None for any.
+
+        Returns:
+            True when the stored relation satisfies the filter.
+        """
+        if wanted_type is None:
+            return True
+        return canonical_relation_type(stored_type) == canonical_relation_type(wanted_type)
 
     def _rel_out_key(self, fact_id: str) -> str:
         return f"kb:rel:out:{fact_id}"
@@ -91,6 +107,10 @@ class RelationsMixin:
         """Create a relation between two knowledge-base facts."""
         self.ensure_initialized()
 
+        # #13452: accept the legacy "relates_to" spelling and store the
+        # canonical "related_to", so existing API clients keep working while
+        # only one spelling is ever written.
+        relation_type = canonical_relation_type(relation_type)
         if relation_type not in KB_RELATION_TYPES:
             return {
                 "success": False,
@@ -158,7 +178,7 @@ class RelationsMixin:
             kept = []
             for entry_bytes in raw_out:
                 entry = json.loads(entry_bytes)
-                if entry["to"] == target_fact_id and (relation_type is None or entry["type"] == relation_type):
+                if entry["to"] == target_fact_id and self._relation_type_matches(entry["type"], relation_type):
                     removed += 1
                 else:
                     kept.append(entry_bytes)
@@ -173,7 +193,7 @@ class RelationsMixin:
             kept = []
             for entry_bytes in raw_in:
                 entry = json.loads(entry_bytes)
-                if entry["from"] == source_fact_id and (relation_type is None or entry["type"] == relation_type):
+                if entry["from"] == source_fact_id and self._relation_type_matches(entry["type"], relation_type):
                     pass  # drop
                 else:
                     kept.append(entry_bytes)
@@ -204,7 +224,7 @@ class RelationsMixin:
             raw = await self.redis().lrange(self._rel_out_key(fact_id), 0, -1)
             for entry_bytes in raw:
                 entry = json.loads(entry_bytes)
-                if relation_type and entry["type"] != relation_type:
+                if not self._relation_type_matches(entry["type"], relation_type):
                     continue
                 rel = {
                     "from": fact_id,
@@ -221,7 +241,7 @@ class RelationsMixin:
             raw = await self.redis().lrange(self._rel_in_key(fact_id), 0, -1)
             for entry_bytes in raw:
                 entry = json.loads(entry_bytes)
-                if relation_type and entry["type"] != relation_type:
+                if not self._relation_type_matches(entry["type"], relation_type):
                     continue
                 rel = {
                     "from": entry["from"],
@@ -257,6 +277,8 @@ class RelationsMixin:
         queue: list = [(start_fact_id, 0)]
         nodes: list = []
         edges: list = []
+        # #13452: canonicalise the filter once so legacy-spelled stored edges match.
+        wanted = {canonical_relation_type(rt) for rt in relation_types} if relation_types else None
 
         while queue:
             current_id, depth = queue.pop(0)
@@ -275,7 +297,7 @@ class RelationsMixin:
             raw = await self.redis().lrange(self._rel_out_key(current_id), 0, -1)
             for entry_bytes in raw:
                 entry = json.loads(entry_bytes)
-                if relation_types and entry["type"] not in relation_types:
+                if wanted is not None and canonical_relation_type(entry["type"]) not in wanted:
                     continue
                 edges.append(
                     {

--- a/autobot-backend/knowledge/relations.py
+++ b/autobot-backend/knowledge/relations.py
@@ -23,7 +23,12 @@ from collections import defaultdict
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Set
 
-from autobot_memory_graph.core import CORE_RELATION_TYPES, canonical_relation_type
+from autobot_memory_graph.core import (
+    CORE_RELATION_TYPES,
+    canonical_relation_filter,
+    canonical_relation_type,
+    relation_type_matches,
+)
 from autobot_shared.error_boundaries import error_boundary
 from autobot_shared.logging_manager import get_logger
 
@@ -53,24 +58,9 @@ class RelationsMixin:
 
     # -- helpers ----------------------------------------------------------
 
-    @staticmethod
-    def _relation_type_matches(stored_type: str, wanted_type: str | None) -> bool:
-        """Compare a stored relation type against a requested one (#13452).
-
-        Both sides are canonicalised, so relations persisted under the legacy
-        "relates_to" spelling stay reachable through the canonical
-        "related_to" and vice versa — no Redis migration required.
-
-        Args:
-            stored_type: Relation type as read back from Redis.
-            wanted_type: Relation type the caller filtered on, or None for any.
-
-        Returns:
-            True when the stored relation satisfies the filter.
-        """
-        if wanted_type is None:
-            return True
-        return canonical_relation_type(stored_type) == canonical_relation_type(wanted_type)
+    # #13452: the one matcher, shared with autobot_memory_graph so the two
+    # stores cannot drift in how they resolve a legacy spelling.
+    _relation_type_matches = staticmethod(relation_type_matches)
 
     def _rel_out_key(self, fact_id: str) -> str:
         return f"kb:rel:out:{fact_id}"
@@ -278,7 +268,7 @@ class RelationsMixin:
         nodes: list = []
         edges: list = []
         # #13452: canonicalise the filter once so legacy-spelled stored edges match.
-        wanted = {canonical_relation_type(rt) for rt in relation_types} if relation_types else None
+        wanted = canonical_relation_filter(relation_types)
 
         while queue:
             current_id, depth = queue.pop(0)
@@ -386,7 +376,10 @@ class RelationsMixin:
                 for entry_bytes in raw:
                     entry = json.loads(entry_bytes)
                     total += 1
-                    by_type[entry["type"]] += 1
+                    # #13452: bucket under the canonical name, otherwise a
+                    # legacy "relates_to" row surfaces as a bucket that is
+                    # absent from the available_types list returned alongside it.
+                    by_type[canonical_relation_type(entry["type"])] += 1
             if cursor == b"0" or cursor == 0:
                 break
 

--- a/autobot-backend/services/security_memory_integration.py
+++ b/autobot-backend/services/security_memory_integration.py
@@ -17,7 +17,7 @@ Issue: #260
 from dataclasses import dataclass
 from typing import Any, FrozenSet
 
-from autobot_memory_graph import AutoBotMemoryGraph
+from autobot_memory_graph import RELATION_TYPES, AutoBotMemoryGraph, canonical_relation_type
 from autobot_shared.logging_manager import get_logger
 
 # Issue #380: Module-level frozenset for security-related tags
@@ -66,9 +66,21 @@ class ServiceRequest:
 
 logger = get_logger(__name__)
 
-# Performance optimization: O(1) lookup for security relation types (Issue #326)
-DETAIL_RELATION_TYPES = {"contains", "runs", "has_vulnerability", "exploited_by"}
-SEVERITY_RELATION_TYPES = {"affects"}
+# Issue #13452: one explicit table instead of two membership sets whose targets
+# were implied by an if/elif chain. Every security-domain relation name maps to
+# a canonical autobot_memory_graph relation here; create_relation() rejects
+# anything else, and _create_security_relation() swallows the ValueError, so an
+# unmapped name means a silently dropped edge (#13367). The assertion below
+# makes drift an import-time failure rather than a missing graph edge.
+SECURITY_TO_BASE_RELATION: dict[str, str] = {
+    "contains": "contains",
+    "runs": "contains",  # host contains the service it runs
+    "has_vulnerability": "contains",  # service contains the finding
+    "exploited_by": "contains",
+    "affects": "related_to",  # vulnerability ←→ affected host/service
+    "related_to": "related_to",
+    "depends_on": "depends_on",
+}
 
 
 # Security-specific entity types (extend base ENTITY_TYPES)
@@ -82,7 +94,7 @@ SECURITY_ENTITY_TYPES = {
     "finding": "General security finding",
 }
 
-# Security-specific relation types (extend base RELATION_TYPES)
+# Security-specific relation types (documentation for SECURITY_TO_BASE_RELATION)
 SECURITY_RELATION_TYPES = {
     "contains": "Parent contains child (assessment → network → host)",
     "runs": "Host runs service",
@@ -92,6 +104,26 @@ SECURITY_RELATION_TYPES = {
     "depends_on": "Dependency relationship",
     "affects": "Vulnerability affects service/host",
 }
+
+
+def _verify_security_relation_vocabulary() -> None:
+    """Fail at import if the security vocabulary drifts from the canonical one.
+
+    Raises:
+        RuntimeError: If the two security tables disagree, or if any mapped
+            target is not a canonical autobot_memory_graph relation type.
+    """
+    if set(SECURITY_RELATION_TYPES) != set(SECURITY_TO_BASE_RELATION):
+        raise RuntimeError(
+            "security relation tables disagree: "
+            f"{sorted(set(SECURITY_RELATION_TYPES) ^ set(SECURITY_TO_BASE_RELATION))}"
+        )
+    unmapped = set(SECURITY_TO_BASE_RELATION.values()) - RELATION_TYPES
+    if unmapped:
+        raise RuntimeError(f"security relations map onto non-canonical types: {sorted(unmapped)}")
+
+
+_verify_security_relation_vocabulary()
 
 
 class SecurityFindingsIndex:
@@ -705,16 +737,12 @@ class SecurityMemoryIntegration:
             True if created successfully
         """
         try:
-            # Map security relation types onto the base graph's RELATION_TYPES
-            # vocabulary (autobot_memory_graph.core.RELATION_TYPES) — create_relation
-            # rejects anything outside it. The base name is "related_to"; the
-            # previous "relates_to" was not a valid type, so every mapped relation
-            # raised ValueError and was silently swallowed below.
-            base_relation = relation_type
-            if relation_type in DETAIL_RELATION_TYPES:
-                base_relation = "contains"
-            elif relation_type in SEVERITY_RELATION_TYPES:
-                base_relation = "related_to"
+            # Map security relation names onto the canonical vocabulary
+            # (autobot_memory_graph.core.RELATION_TYPES) — create_relation
+            # rejects anything outside it and the except below swallows the
+            # ValueError, so an unmapped name is a silently dropped edge
+            # (#13367, #13452).
+            base_relation = SECURITY_TO_BASE_RELATION.get(relation_type, canonical_relation_type(relation_type))
 
             await self._memory_graph.create_relation(
                 from_entity=from_entity,

--- a/autobot-backend/services/security_memory_integration.py
+++ b/autobot-backend/services/security_memory_integration.py
@@ -106,8 +106,13 @@ SECURITY_RELATION_TYPES = {
 }
 
 
-def _verify_security_relation_vocabulary() -> None:
-    """Fail at import if the security vocabulary drifts from the canonical one.
+def verify_security_relation_vocabulary() -> None:
+    """Raise if the security vocabulary has drifted from the canonical one.
+
+    Deliberately NOT called at import: the drift it detects is static, so a
+    failure here would only ever turn a source-level mistake into a backend
+    startup failure. relation_vocabulary_test.py calls it instead, which
+    catches the same drift at the point it is introduced.
 
     Raises:
         RuntimeError: If the two security tables disagree, or if any mapped
@@ -121,9 +126,6 @@ def _verify_security_relation_vocabulary() -> None:
     unmapped = set(SECURITY_TO_BASE_RELATION.values()) - RELATION_TYPES
     if unmapped:
         raise RuntimeError(f"security relations map onto non-canonical types: {sorted(unmapped)}")
-
-
-_verify_security_relation_vocabulary()
 
 
 class SecurityFindingsIndex:

--- a/autobot-backend/type_defs/chat_merge_messages_test.py
+++ b/autobot-backend/type_defs/chat_merge_messages_test.py
@@ -12,13 +12,53 @@ Tests the merge_messages function's ability to handle:
 - Backend-added message preservation
 """
 
+from enum import Enum
 from typing import Dict, List
 
 import pytest
 
+from type_defs import common
+
 # Import the function under test
 # Note: We test the logic directly since merge_messages is async
-from type_defs.common import SKIP_WEBSOCKET_PERSISTENCE_TYPES, STREAMING_MESSAGE_TYPES
+from type_defs.common import (
+    SKIP_WEBSOCKET_PERSISTENCE_TYPES,
+    STREAMING_MESSAGE_TYPES,
+    MessageTypes,
+)
+
+
+class TestMessageTypeVocabulary:
+    """Drift guard for the message-type vocabulary (Issue #13452)."""
+
+    def test_message_types_is_an_enum(self):
+        """A bare constant bag let the two derived sets be aliased (#13402)."""
+        assert issubclass(MessageTypes, Enum)
+
+    def test_members_are_plain_strings(self):
+        """(str, Enum) keeps `message_type in <set>` working for raw strings."""
+        assert MessageTypes.LLM_RESPONSE == "llm_response"
+        assert hash(MessageTypes.LLM_RESPONSE) == hash("llm_response")
+
+    def test_both_collections_are_frozensets_of_str_at_runtime(self):
+        """NewType is erased at runtime; behaviour must be unchanged."""
+        for collection in (SKIP_WEBSOCKET_PERSISTENCE_TYPES, STREAMING_MESSAGE_TYPES):
+            assert isinstance(collection, frozenset)
+            assert all(type(item) is str for item in collection)
+
+    def test_no_collection_member_is_outside_the_enum(self):
+        """Every entry must come from MessageTypes — no stray literals."""
+        known = {member.value for member in MessageTypes}
+        assert SKIP_WEBSOCKET_PERSISTENCE_TYPES <= known
+        assert STREAMING_MESSAGE_TYPES <= known
+
+    def test_the_two_collections_have_distinct_types(self):
+        """Assigning one where the other is expected must be a type error."""
+        skip_type = common.__annotations__["SKIP_WEBSOCKET_PERSISTENCE_TYPES"]
+        streaming_type = common.__annotations__["STREAMING_MESSAGE_TYPES"]
+        assert skip_type is not streaming_type
+        assert skip_type is common.SkipPersistenceTypes
+        assert streaming_type is common.StreamingTypes
 
 
 class TestMergeMessagesSignature:

--- a/autobot-backend/type_defs/common.py
+++ b/autobot-backend/type_defs/common.py
@@ -8,7 +8,8 @@ Common Type Definitions for AutoBot
 Provides reusable type definitions to replace generic Dict[str, Any] patterns.
 """
 
-from typing import Any, Dict, List
+from enum import Enum
+from typing import Any, Dict, FrozenSet, List, NewType
 
 # Type alias for timestamp strings (ISO 8601 format)
 TimestampStr = str
@@ -64,12 +65,32 @@ OptionalMetadata = Metadata | None
 # Message type constants for chat/streaming systems
 # Used for deduplication logic and persistence filtering
 
+# Issue #13452: two distinct types, not two aliases of frozenset[str]. The two
+# collections below answer different questions and were once aliased to each
+# other, which silently deleted terminal output, terminal commands and approval
+# requests from restored chat history (#13402). NewType makes assigning one
+# where the other is expected a type error rather than a comment nobody reads.
+#
+#   SkipPersistenceTypes: "is this message persisted somewhere other than the
+#       websocket broadcast path?"
+#   StreamingTypes:       "may an earlier frame of this type be discarded in
+#       favour of a longer one?" — api/chat.py::_process_streaming_groups keeps
+#       only the longest message per 2-minute window for every type listed.
+SkipPersistenceTypes = NewType("SkipPersistenceTypes", FrozenSet[str])
+StreamingTypes = NewType("StreamingTypes", FrozenSet[str])
 
-class MessageTypes:
-    """Constants for message types in the chat system.
+
+class MessageTypes(str, Enum):
+    """Message types in the chat system.
 
     Issue #650: Extended to include display-related types for frontend filtering.
-    Aligned with Agent Zero's 13-type message system for better UX.
+
+    Issue #13452: promoted from a bare constant bag to an enum. ``(str, Enum)``
+    rather than ``StrEnum`` — the shape ``autobot_shared.browser.base.Capability``
+    and ``autobot_shared.status_enums`` already use, and the one that keeps this
+    module importable on Python 3.10 (``StrEnum`` is 3.11+) as well as the 3.14
+    that CI runs. Members compare and hash equal to their string values, so
+    existing ``message_type in <set>`` checks against plain strings are unaffected.
     """
 
     # Streaming LLM response types - these accumulate tokens progressively
@@ -104,6 +125,15 @@ class MessageTypes:
     WARNING = "warning"  # Warning messages (non-fatal)
     INFO = "info"  # Informational messages
 
+    # Issue #3232: chain-of-thought reasoning-trace events emitted by
+    # chat_workflow/cot_events.py. Live-stream-only signals, never persisted.
+    AGENT_STEP_START = "agent.step.start"
+    AGENT_STEP_COMPLETE = "agent.step.complete"
+    AGENT_TOOL_CALL = "agent.tool.call"
+    AGENT_TOOL_RESULT = "agent.tool.result"
+    AGENT_LLM_CHUNK = "agent.llm.chunk"
+    AGENT_PLAN = "agent.plan"
+
 
 # Frozenset of message types that should NOT be persisted in websockets.py
 # These are either:
@@ -112,28 +142,30 @@ class MessageTypes:
 #
 # Issue #350 Root Cause Fix: Adding explicitly-persisted types prevents duplication
 # from multiple persistence paths (websocket broadcast + explicit persistence).
-SKIP_WEBSOCKET_PERSISTENCE_TYPES: frozenset = frozenset(
-    [
-        # Streaming LLM response types - persisted once at completion
-        MessageTypes.LLM_RESPONSE,
-        MessageTypes.LLM_RESPONSE_CHUNK,
-        MessageTypes.RESPONSE,
-        # Terminal types - explicitly persisted by chat_integration.py and service.py
-        MessageTypes.TERMINAL_COMMAND,
-        MessageTypes.TERMINAL_OUTPUT,
-        # Approval request - explicitly persisted by tool_handler.py::_persist_approval_request()
-        MessageTypes.COMMAND_APPROVAL_REQUEST,
-        # Terminal interpretation - explicitly persisted by llm_handler.py
-        MessageTypes.TERMINAL_INTERPRETATION,
-        # Issue #3232: Chain-of-thought reasoning trace events — ephemeral, not
-        # persisted to chat history since they are live-stream-only signals.
-        "agent.step.start",
-        "agent.step.complete",
-        "agent.tool.call",
-        "agent.tool.result",
-        "agent.llm.chunk",
-        "agent.plan",
-    ]
+SKIP_WEBSOCKET_PERSISTENCE_TYPES: SkipPersistenceTypes = SkipPersistenceTypes(
+    frozenset(
+        [
+            # Streaming LLM response types - persisted once at completion
+            MessageTypes.LLM_RESPONSE.value,
+            MessageTypes.LLM_RESPONSE_CHUNK.value,
+            MessageTypes.RESPONSE.value,
+            # Terminal types - explicitly persisted by chat_integration.py and service.py
+            MessageTypes.TERMINAL_COMMAND.value,
+            MessageTypes.TERMINAL_OUTPUT.value,
+            # Approval request - explicitly persisted by tool_handler.py::_persist_approval_request()
+            MessageTypes.COMMAND_APPROVAL_REQUEST.value,
+            # Terminal interpretation - explicitly persisted by llm_handler.py
+            MessageTypes.TERMINAL_INTERPRETATION.value,
+            # Issue #3232: Chain-of-thought reasoning trace events — ephemeral, not
+            # persisted to chat history since they are live-stream-only signals.
+            MessageTypes.AGENT_STEP_START.value,
+            MessageTypes.AGENT_STEP_COMPLETE.value,
+            MessageTypes.AGENT_TOOL_CALL.value,
+            MessageTypes.AGENT_TOOL_RESULT.value,
+            MessageTypes.AGENT_LLM_CHUNK.value,
+            MessageTypes.AGENT_PLAN.value,
+        ]
+    )
 )
 
 # Message types whose text accumulates progressively across a single turn, so a
@@ -149,10 +181,12 @@ SKIP_WEBSOCKET_PERSISTENCE_TYPES: frozenset = frozenset(
 # 2-minute window for every type listed here, so aliasing the two made
 # merge_messages silently drop terminal output, terminal commands, approval
 # requests and reasoning-trace events from restored chat history.
-STREAMING_MESSAGE_TYPES: frozenset = frozenset(
-    [
-        MessageTypes.LLM_RESPONSE,
-        MessageTypes.LLM_RESPONSE_CHUNK,
-        MessageTypes.RESPONSE,
-    ]
+STREAMING_MESSAGE_TYPES: StreamingTypes = StreamingTypes(
+    frozenset(
+        [
+            MessageTypes.LLM_RESPONSE.value,
+            MessageTypes.LLM_RESPONSE_CHUNK.value,
+            MessageTypes.RESPONSE.value,
+        ]
+    )
 )

--- a/autobot-frontend/src/components/knowledge/KnowledgeGraph3D.stories.ts
+++ b/autobot-frontend/src/components/knowledge/KnowledgeGraph3D.stories.ts
@@ -50,7 +50,7 @@ export const LargeGraph: Story = {
     edges: Array.from({ length: 15 }, (_, i) => ({
       from: `entity-${i % 10}`,
       to: `entity-${(i + 3) % 20}`,
-      type: 'relates_to',
+      type: 'related_to',
     })),
   },
 }

--- a/autobot-frontend/src/composables/knowledge/useKnowledgeGraphEntities.ts
+++ b/autobot-frontend/src/composables/knowledge/useKnowledgeGraphEntities.ts
@@ -115,7 +115,9 @@ export function useKnowledgeGraphEntities(): UseKnowledgeGraphEntitiesReturn {
           allRelations.push({
             from: entity.id,
             to: (rel.entity as Record<string, unknown>)?.id as string ?? rel.id as string,
-            type: rel.relation_type as string ?? rel.type as string ?? 'relates_to',
+            // #13452: 'related_to' is the canonical spelling; 'relates_to' was
+            // the knowledge-base-only variant and is not a memory-graph type.
+            type: rel.relation_type as string ?? rel.type as string ?? 'related_to',
             strength: rel.strength as number ?? 1.0,
           })
         }

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -43043,19 +43043,13 @@ export interface paths {
          *
          *     This enables graph-based knowledge retrieval alongside vector search.
          *
-         *     Valid relation types:
-         *     - relates_to: General relationship
-         *     - depends_on: Dependency relationship
-         *     - implements: Implementation relationship
-         *     - fixes: Bug fix relationship
-         *     - informs: Information flow
-         *     - guides: Guidance relationship
-         *     - follows: Sequential relationship
-         *     - contains: Containment relationship
-         *     - blocks: Blocking relationship
-         *     - references: Reference relationship
-         *     - supersedes: Replacement relationship
-         *     - contradicts: Contradiction relationship
+         *     Valid relation types are served by GET /api/knowledge/relations/types,
+         *     which reads the canonical vocabulary directly. They are deliberately not
+         *     restated here: the hand-maintained copy that used to live in this docstring
+         *     had already drifted from the vocabulary it documented (#13452).
+         *
+         *     The legacy spelling "relates_to" is still accepted and is stored as its
+         *     canonical name "related_to".
          */
         post: operations["create_fact_relation_api_knowledge_relations_create_post"];
         delete?: never;
@@ -65054,7 +65048,7 @@ export interface components {
             target_fact_id: string;
             /**
              * Relation Type
-             * @description Type of relation (e.g., relates_to, depends_on, implements)
+             * @description Type of relation (e.g., related_to, depends_on, implements)
              */
             relation_type: string;
             /**

--- a/autobot-infrastructure/shared/scripts/utilities/init_memory_graph_redis.py
+++ b/autobot-infrastructure/shared/scripts/utilities/init_memory_graph_redis.py
@@ -541,7 +541,10 @@ class MemoryGraphInitializer:
                         {
                             "from": entity_a["id"],
                             "to": entity_b["id"],
-                            "type": "relates_to",
+                            # #13452: canonical spelling. This writes the JSON
+                            # directly, bypassing create_relation, so nothing
+                            # canonicalises it on the way in.
+                            "type": "related_to",
                             "created_at": max(entity_a["created_at"], entity_b["created_at"]),
                             "metadata": {
                                 "strength": strength,

--- a/docs/architecture/AUTOBOT_MEMORY_GRAPH_ARCHITECTURE.md
+++ b/docs/architecture/AUTOBOT_MEMORY_GRAPH_ARCHITECTURE.md
@@ -149,9 +149,15 @@ Relation = {
 
 #### 2.2.1 Relationship Types
 
+Declared in `autobot_memory_graph/core.py` as `CORE_RELATION_TYPES` — the single
+canonical vocabulary, which `knowledge/relations.py` imports rather than
+restating. `relates_to` is a legacy spelling of `related_to`: it is accepted on
+input and folded onto the canonical name, so only `related_to` is ever stored
+(#13452).
+
 | Relation Type   | Description                          | Example                                      |
 |-----------------|--------------------------------------|----------------------------------------------|
-| `relates_to`    | General association                  | Conversation → Conversation                  |
+| `related_to`    | General association                  | Conversation → Conversation                  |
 | `depends_on`    | Dependency relationship              | Task → Task (blocking)                       |
 | `implements`    | Implementation link                  | Feature → Code Changes                       |
 | `fixes`         | Fix relationship                     | Bug Fix → Bug                                |
@@ -372,7 +378,7 @@ async def create_relation(
     Args:
         from_entity: Source entity name
         to_entity: Target entity name
-        relation_type: Type of relationship (relates_to, depends_on, etc.)
+        relation_type: Type of relationship (related_to, depends_on, etc.)
         bidirectional: Create reverse relation as well
         strength: Relationship strength (0.0-1.0)
         metadata: Optional additional metadata
@@ -549,7 +555,7 @@ async def link_conversations(
     self,
     session_id_1: str,
     session_id_2: str,
-    relation_type: str = "relates_to"
+    relation_type: str = "related_to"
 ) -> Dict[str, Any]:
     """
     Create relationship between two conversations.
@@ -983,7 +989,7 @@ async def test_create_relation():
     relation = await memory_graph.create_relation(
         from_entity=entity1["name"],
         to_entity=entity2["name"],
-        relation_type="relates_to"
+        relation_type="related_to"
     )
     assert relation["from_entity"] == entity1["entity_id"]
     assert relation["to_entity"] == entity2["entity_id"]
@@ -1220,13 +1226,13 @@ JSON.DEL entity:uuid123
 
 ```bash
 # Create relation
-GRAPH.QUERY memory_graph "CREATE (:Entity {id:'uuid1'})-[:relates_to]->(:Entity {id:'uuid2'})"
+GRAPH.QUERY memory_graph "CREATE (:Entity {id:'uuid1'})-[:related_to]->(:Entity {id:'uuid2'})"
 
 # Get related entities
-GRAPH.QUERY memory_graph "MATCH (e:Entity {id:'uuid1'})-[:relates_to]->(related) RETURN related"
+GRAPH.QUERY memory_graph "MATCH (e:Entity {id:'uuid1'})-[:related_to]->(related) RETURN related"
 
 # Delete relation
-GRAPH.QUERY memory_graph "MATCH (:Entity {id:'uuid1'})-[r:relates_to]->(:Entity {id:'uuid2'}) DELETE r"
+GRAPH.QUERY memory_graph "MATCH (:Entity {id:'uuid1'})-[r:related_to]->(:Entity {id:'uuid2'}) DELETE r"
 ```
 
 ### Search Operations (RediSearch)

--- a/docs/architecture/SECURITY_ASSESSMENT_WORKFLOW.md
+++ b/docs/architecture/SECURITY_ASSESSMENT_WORKFLOW.md
@@ -584,16 +584,20 @@ class SecurityMemoryGraph:
     # Combine with base entity types
     ENTITY_TYPES = AutoBotMemoryGraph.ENTITY_TYPES | SECURITY_ENTITY_TYPES
 
-    # Additional relation types
-    SECURITY_RELATION_TYPES = {
-        "contains",
-        "runs",
-        "has_vulnerability",
-        "exploited_by",
-        "targets",
+    # Security relation names are NOT added to the graph vocabulary — they are
+    # mapped onto it. AutoBotMemoryGraph.create_relation raises ValueError for
+    # anything outside RELATION_TYPES, so every security name needs an entry in
+    # SECURITY_TO_BASE_RELATION (services/security_memory_integration.py) or the
+    # edge is silently dropped (#13367, #13452).
+    SECURITY_TO_BASE_RELATION = {
+        "contains": "contains",
+        "runs": "contains",
+        "has_vulnerability": "contains",
+        "exploited_by": "contains",
+        "affects": "related_to",
+        "related_to": "related_to",
+        "depends_on": "depends_on",
     }
-
-    RELATION_TYPES = AutoBotMemoryGraph.RELATION_TYPES | SECURITY_RELATION_TYPES
 ```
 
 ---

--- a/docs/database/MEMORY_GRAPH_QUICK_REFERENCE.md
+++ b/docs/database/MEMORY_GRAPH_QUICK_REFERENCE.md
@@ -198,7 +198,7 @@ r = redis.Redis(host='<database-ip>', port=6379, db=0)
 
 relation = {
     "to": "target-entity-uuid",
-    "type": "relates_to",
+    "type": "related_to",
     "created_at": int(time.time() * 1000),
     "metadata": {"strength": 0.9}
 }
@@ -210,7 +210,7 @@ r.json().arrappend(out_key, '$.relations', relation)
 
 # Incoming relation (reverse)
 in_key = "memory:graph:relations:in:target-entity-uuid"
-reverse_rel = {"from": "source-entity-uuid", "type": "relates_to", "created_at": relation['created_at']}
+reverse_rel = {"from": "source-entity-uuid", "type": "related_to", "created_at": relation['created_at']}
 r.json().set(in_key, '$', {"entity_id": "target-entity-uuid", "relations": []}, nx=True)
 r.json().arrappend(in_key, '$.relations', reverse_rel)
 ```
@@ -228,7 +228,7 @@ redis-cli -h <database-ip> JSON.GET "memory:graph:relations:in:267ab75b-8c44-46b
 ### Traverse Graph
 
 ```python
-def traverse_relations(entity_id, relation_type="relates_to", max_depth=3):
+def traverse_relations(entity_id, relation_type="related_to", max_depth=3):
     """BFS traversal of entity graph"""
     r = redis.Redis(host='<database-ip>', port=6379, db=0)
 

--- a/docs/database/REDIS_MEMORY_GRAPH_SPECIFICATION.md
+++ b/docs/database/REDIS_MEMORY_GRAPH_SPECIFICATION.md
@@ -142,7 +142,7 @@ DB 3-10: Reserved for future expansion
   "relations": [
     {
       "to": "target-uuid-1",
-      "type": "fixes|implements|depends_on|relates_to|informs|guides|blocks",
+      "type": "fixes|implements|depends_on|related_to|informs|guides|blocks",
       "created_at": 1728064800000,
       "metadata": {
         "strength": 0.95,
@@ -178,7 +178,7 @@ DB 3-10: Reserved for future expansion
 | `fixes` | Resolves issue | Bug fix → Bug report |
 | `implements` | Realizes requirement | Feature → Specification |
 | `depends_on` | Requires completion | Task B → Task A |
-| `relates_to` | Semantic connection | Conversation A ↔ Conversation B |
+| `related_to` | Semantic connection | Conversation A ↔ Conversation B (legacy spelling `relates_to` is accepted and stored as `related_to`, #13452) |
 | `informs` | Provides context | Research → Decision |
 | `guides` | Directs implementation | Plan → Implementation |
 | `blocks` | Prevents progress | Issue → Task |
@@ -652,7 +652,7 @@ def extract_conversation_relations(entities):
     """
     Extract relations between conversations based on shared topics.
 
-    Creates 'relates_to' relations when topic overlap >50%.
+    Creates 'related_to' relations when topic overlap >50%.
     """
     relations = []
 
@@ -675,7 +675,7 @@ def extract_conversation_relations(entities):
                 relations.append({
                     "from": entity_a['id'],
                     "to": entity_b['id'],
-                    "type": "relates_to",
+                    "type": "related_to",
                     "created_at": max(entity_a['created_at'], entity_b['created_at']),
                     "metadata": {
                         "strength": strength,

--- a/docs/features/KNOWLEDGE_GRAPH.md
+++ b/docs/features/KNOWLEDGE_GRAPH.md
@@ -158,7 +158,7 @@ Supported relationship types:
 
 | Type | Description |
 |------|-------------|
-| `relates_to` | General relationship |
+| `related_to` | General relationship (legacy spelling `relates_to` is accepted and stored as `related_to`, #13452) |
 | `depends_on` | Dependency relationship |
 | `implements` | Implementation of a feature/design |
 | `fixes` | Bug fix relationship |


### PR DESCRIPTION
## Thinking Path

Two independent relation vocabularies existed, and they spelled the same concept differently:

| Set | Size | General relation |
|---|---|---|
| `RELATION_TYPES` (`autobot_memory_graph/core.py`) | 14 | `related_to` |
| `KB_RELATION_TYPES` (`knowledge/relations.py`) | 12 | `relates_to` |

Neither accepted the other's spelling. `create_relation` raises `ValueError` for anything outside `RELATION_TYPES` and several call sites swallow it, so an edge written with the wrong spelling was silently dropped. #13367 fixed one call site; this fixes the divergence that produced it.

**Grepping every consumer before choosing the shape found two more vocabularies and a second live instance of the same defect:**

1. `api/schemas_knowledge.py::_VALID_RELATION_TYPES` — a 9-name literal validating `RelationCreateRequest`, which is the body of `POST /api/memory/relations` and calls the **memory graph**. It was a copy of the **knowledge-base** list: it rejected valid graph types (`related_to`, `caused_by`, `leads_to`, `owns`, …) and admitted `relates_to`, which then raised inside `create_relation`. Live bug.
2. `agents/graph_entity_extractor.py` — its co-occurrence strategy emitted `relates_to` and its keyword table emitted `fixes`/`informs`, all fed straight to `AutoBotMemoryGraph.create_relation` and all rejected, inside the same broad `except Exception` swallow. **A second, still-live instance of the #13367 defect.** This PR fixes the *vocabulary* half — the inferred names are now ones `create_relation` accepts, so these specific edges stop being rejected. It deliberately does **not** narrow the swallow or make dropped candidates visible on `ExtractionResult`; that is #13553.
3. `services/security_memory_integration.py` — `DETAIL_RELATION_TYPES` / `SEVERITY_RELATION_TYPES`, a third incomplete vocabulary in which `affects` appears in no canonical set and is unusable without a mapping.
4. `api/knowledge_relations.py` — a hand-maintained literal fallback list that had already drifted from the knowledge base's own set.

**Shape chosen, and what forced it.** A superset that imports the base, per the issue's second option — but split into two named tiers rather than one flat set, because consumer 2 forced it. The extractor writes document-level names (`fixes`, `informs`) into the *memory graph*, so those cannot stay knowledge-base-only or its edges keep dropping; and the `#608` identity relations (`owns`, `has_secret`, …) are meaningless between facts, so the knowledge base must not inherit them. Hence `CORE_RELATION_TYPES` (14, domain-neutral) + `IDENTITY_RELATION_TYPES` (6, graph-only), with `RELATION_TYPES = CORE | IDENTITY` and `KB_RELATION_TYPES = CORE`. `knowledge/relations.py`'s module docstring already claimed its types came from `autobot_memory_graph.core`; this makes that true.

**Relation types are persisted — so this is a mapping, not a rename.** Both stores write the type string into Redis: the memory graph into `memory:relations:{out,in}:<id>` JSON, the knowledge base into `kb:rel:{out,in}:<fact_id>` lists. Stored data therefore already contains both spellings. `related_to` is canonical and `relates_to` lives only in `RELATION_TYPE_ALIASES`, folded onto the canonical name on write **and on both sides of every stored-value comparison in both stores** — the knowledge base (`delete_fact_relation`, `get_fact_relations`, `traverse_relations`, `get_relation_stats`) and the memory graph (`get_relations`, `get_related_entities`, `delete_relation`, `invalidate_relation`). Relations already persisted under either spelling stay reachable. No migration, no rewrite of stored values.

> **Review correction (round 1).** The first push canonicalised memory-graph *writes* but not its *reads and deletes*, which compared the caller's filter against the raw stored string. That made the PR itself create an asymmetry — `POST` with `relates_to` stored `related_to`, then `GET`/`DELETE` by `relates_to` found nothing and `invalidate_relation` no-opped. Before the PR the write simply raised, so nothing was silently unreachable: it was a regression introduced here, not an inherited bug. Fixed by canonicalising the filter at the four public entry points and the stored side in all six comparisons, and by adding the round-trip test that was missing. The single matcher now lives in `core.py` and is shared by both stores.

**`StrEnum` vs `(str, Enum)`: `(str, Enum)`.** `autobot-backend` has no `requires-python` floor; CI runs 3.14 but the dev box's `python3` — the one `pre-commit`, `pr-preflight.sh` and local `pytest` all use — is 3.10.12, and `StrEnum` is 3.11+. `(str, Enum)` is also the shape `autobot_shared/browser/base.py::Capability` and `autobot_shared.status_enums` already use, for exactly this reason. Verified on both interpreters that members hash and compare equal to their values, so every existing `message_type in <set>` check against a plain string is unaffected. The frozensets are built from `.value`, keeping their runtime contents plain `str` and sidestepping the 3.10-vs-3.14 divergence in how `(str, Enum)` members format.

Distinctness uses `NewType`, not `TypeAlias` — a plain alias is transparent to mypy and would not have made the #13402 aliasing an error.

## What Changed

**Relations**
- `autobot_memory_graph/core.py` — `CORE_RELATION_TYPES`, `IDENTITY_RELATION_TYPES`, `RELATION_TYPES` as their union, `RELATION_TYPE_ALIASES`, and `canonical_relation_type()` (unknown names pass through untouched, so it cannot mask a typo).
- `autobot_memory_graph/relations.py` — canonicalise in `create_relation` and `create_relation_by_id` before validating.
- `knowledge/relations.py` — `KB_RELATION_TYPES` derived from `CORE_RELATION_TYPES`; canonicalise on write; new `_relation_type_matches()` makes all stored-value filters alias-aware.
- `api/schemas_knowledge.py` — `_VALID_RELATION_TYPES` derived from `RELATION_TYPES`; the validator returns the canonical spelling.
- `agents/graph_entity_extractor.py` — inferred types are now all canonical.
- `services/security_memory_integration.py` — one explicit `SECURITY_TO_BASE_RELATION` table replaces two membership sets and an `if`/`elif` chain; `affects` gains a real mapping; `verify_security_relation_vocabulary()` turns drift into a test failure. It is deliberately not called at import — the drift it detects is static, so an import-time raise would only convert a source-level mistake into a backend startup failure.
- `api/knowledge_relations.py`, `api/knowledge_search_aggregator.py`, `useKnowledgeGraphEntities.ts`, `KnowledgeGraph3D.stories.ts` — literal lists and default spellings follow the canonical set.
- `init_memory_graph_redis.py` wrote `relates_to` straight into Redis JSON, bypassing `create_relation` entirely — it was the last remaining writer of the alias.
- `SECURITY_ASSESSMENT_WORKFLOW.md`, `AUTOBOT_MEMORY_GRAPH_ARCHITECTURE.md`, `REDIS_MEMORY_GRAPH_SPECIFICATION.md`, `MEMORY_GRAPH_QUICK_REFERENCE.md`, `KNOWLEDGE_GRAPH.md` — 15 occurrences that taught the alias as the primary name now teach `related_to`, with the alias noted once per vocabulary table.

**Message types**
- `type_defs/common.py` — `MessageTypes` is `(str, Enum)`; the six `agent.*` reasoning-trace literals become members, so both collections are fully enum-derived; `SkipPersistenceTypes` and `StreamingTypes` are distinct `NewType`s.

**Tests**
- New `autobot_memory_graph/relation_vocabulary_test.py` (21 assertions) — covers all four vocabularies, that `relates_to` is never live, that every alias target is canonical, and that nothing the API schema accepts can be rejected by `create_relation`.
- `type_defs/chat_merge_messages_test.py` — enum, plain-`str` runtime contents, no stray literals, and distinct collection types.
- `agents/graph_entity_extractor_test.py` — the assertion that also permitted `relates_to` (and so could not catch the dropped edges) now requires membership in `RELATION_TYPES`.

### Follow-ups filed

- **#13552** — `init_memory_graph_redis.py` seeds `memory:graph:relations:*` while the runtime reads `memory:relations:*`, so the seeded graph is unreachable. Pre-existing, found while fixing an unrelated line in that file, deliberately not fixed here.
- **#13553** — `graph_entity_extractor`'s broad `except Exception` still swallows dropped relations and `ExtractionResult` never reports them. **Claim corrected:** this PR aligned the extractor's *vocabulary* (so the known rejections stop); it did not change the swallow. Narrowing the handler and extending `ExtractionResult` is a behaviour change with its own blast radius.

## Verification

New and directly affected suites, on Python 3.10.12:

```
$ python3 -m pytest autobot_memory_graph/ type_defs/ services/security_memory_integration_test.py agents/graph_entity_extractor_test.py -q
114 passed, 36 warnings in 12.30s
```

```
$ python3 -m pytest autobot_memory_graph/relation_vocabulary_test.py -q
38 passed
```

The round-trip tests were confirmed to actually catch the regression they guard,
by reverting the read-path fix and re-running:

```
$ # with `canonical_relation_type(...)` removed from get_relations
$ python3 -m pytest autobot_memory_graph/relation_vocabulary_test.py -k legacy_rows -q
assert 0 == 1
1 failed
```

API surface unchanged:

```
$ python3 -m pytest api/ -q -k "relation or memory or schema"
21 passed, 13 skipped, 3489 deselected
```

No regressions — failure sets compared against a clean worktree of the base commit over every touched package:

```
$ diff <base failures> <branch failures>
base:   31 pre-existing FAILED/ERROR
branch: 25 — a strict subset, zero new
```

The pre-existing failures are unrelated (offset-naive/aware datetime arithmetic in `search_quality_test.py`, Redis-requiring connector/integration tests); none of those modules reference relations or message types.

Import health across every changed module, including the new cross-package import from `knowledge` into `autobot_memory_graph` (no cycle):

```
$ PYTHONPATH=..:. python3 -c "import api.knowledge_relations, api.schemas_knowledge, knowledge.relations, autobot_memory_graph, services.security_memory_integration, type_defs.common, agents.graph_entity_extractor, api.chat, api.websockets"
KB :      ['blocks', 'caused_by', 'contains', 'contradicts', 'depends_on', 'fixes', 'follows', 'guides', 'implements', 'informs', 'leads_to', 'references', 'related_to', 'supersedes']
MG-only:  ['has_participant', 'has_secret', 'owns', 'performed_by', 'shared_with', 'used_secret']
subset ok: True
```

Enum semantics confirmed on both interpreters before committing to `(str, Enum)`:

```
python3.10  hash eq: True  'x' in frozenset([A.X]): True
python3.14  hash eq: True  'x' in frozenset([A.X]): True
```

Lint clean on all 13 changed Python files: `isort`, `black`, `flake8` (0), `bandit` (no findings).

**Generated types.** Two OpenAPI-visible descriptions did need correcting: the `create_fact_relation` docstring (which hand-listed the vocabulary, led with `relates_to`, and omitted `related_to`/`caused_by`/`leads_to`) and the `CreateRelationRequest.relation_type` `Field`. The docstring now points at `GET /api/knowledge/relations/types` instead of restating the list — the same reason its sibling code path was rewritten.

`npm run gen:types` needs a running backend, but `scripts/audit_api_wiring.py --dump-openapi` — what CI itself uses — builds the schema offline. Regenerating that way showed the *only* non-environmental diffs are the two intended description blocks, so those two blocks were applied to the committed `api.ts` and re-verified byte-for-byte against generator output:

```
$ diff <regenerated api.ts> <committed api.ts> | grep -v <env-dependent paths/IPs>
(empty — 0 non-environmental differences across 28 diff lines)
```

The 28 environmental lines are absolute-path and host defaults baked into the schema by whichever machine generates it — the committed file carries the install-root and CI-checkout values, a dev box carries its own. That is why the file was **not** wholesale regenerated locally: doing so would commit a developer's local paths. CI regenerates in its own environment and will match. (The underlying cause — schema defaults that resolve to whatever root the process happens to run under — is the already-filed project-root resolution gap, not something this PR introduces.)

Out of scope, deliberately: `llc/models/enums.py::WorkItemRelationType.RELATES_TO` and the `workitemrelationtype` Postgres enum are a different domain (work-item links) backed by a DB type — renaming would need a migration. `m.relates_to` in the Matrix adapter is a protocol field.

## Model Used

Opus 5 (1M context)

Closes #13452
