### PR TITLE
fix(security): move nosec annotations off closing brackets onto the flagged expression (#13528)

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -219,7 +219,7 @@ jobs:
     - name: Check script exec bits agree with how the docs invoke them (#13355)
       run: python3 scripts/check_script_exec_bits.py
 
-    - name: Check nosec annotations keep prose out of the test-id list (#13521)
+    - name: Check nosec annotations reach bandit intact (#13521, #13528)
       run: python3 scripts/check_nosec_format.py
 
     - name: Check for unused imports with autoflake

--- a/autobot-backend/agents/web_researcher.py
+++ b/autobot-backend/agents/web_researcher.py
@@ -242,9 +242,8 @@ class BrowserFingerprint:
     def _generate_fingerprint(self) -> Dict[str, Any]:
         """Generate randomized browser fingerprint."""
         return {
-            "user_agent": random.choice(
-                self.USER_AGENTS
-            ),  # nosec B311  # browser fingerprint sampling, not cryptographic
+            # Browser fingerprint sampling, not cryptographic.
+            "user_agent": random.choice(self.USER_AGENTS),  # nosec B311
             "viewport": random.choice(self.VIEWPORTS),  # nosec B311  # non-crypto viewport selection
             "timezone": random.choice(  # nosec B311  # non-crypto timezone selection
                 [
@@ -254,15 +253,12 @@ class BrowserFingerprint:
                     "Europe/Berlin",
                 ]
             ),
-            "language": random.choice(
-                ["en-US,en", "en-GB,en", "en-CA,en"]
-            ),  # nosec B311  # non-crypto language selection
-            "platform": random.choice(
-                ["Win32", "MacIntel", "Linux x86_64"]
-            ),  # nosec B311  # non-crypto platform selection
-            "webgl_vendor": random.choice(
-                ["Intel Inc.", "NVIDIA Corporation", "AMD"]
-            ),  # nosec B311  # non-crypto vendor selection
+            # Non-crypto language selection.
+            "language": random.choice(["en-US,en", "en-GB,en", "en-CA,en"]),  # nosec B311
+            # Non-crypto platform selection.
+            "platform": random.choice(["Win32", "MacIntel", "Linux x86_64"]),  # nosec B311
+            # Non-crypto vendor selection.
+            "webgl_vendor": random.choice(["Intel Inc.", "NVIDIA Corporation", "AMD"]),  # nosec B311
             "hardware_concurrency": random.choice([4, 8, 12, 16]),  # nosec B311  # non-crypto concurrency selection
         }
 

--- a/autobot-backend/ai_hardware_accelerator.py
+++ b/autobot-backend/ai_hardware_accelerator.py
@@ -621,9 +621,10 @@ class AIHardwareAccelerator:
         """
         torch = _get_torch()
 
-        self.clip_processor = CLIPProcessor.from_pretrained(
+        # HuggingFace model loaded by name; revision pinning managed operationally.
+        self.clip_processor = CLIPProcessor.from_pretrained(  # nosec B615
             "openai/clip-vit-base-patch32", resume_download=True
-        )  # nosec B615  # HuggingFace model loaded by name; revision pinning managed operationally
+        )
         self.clip_model = CLIPModel.from_pretrained(  # nosec B615
             "openai/clip-vit-base-patch32",
             torch_dtype=(torch.float16 if torch.cuda.is_available() else torch.float32),
@@ -639,9 +640,10 @@ class AIHardwareAccelerator:
         """
         torch = _get_torch()
 
-        self.wav2vec_processor = Wav2Vec2Processor.from_pretrained(
+        # HuggingFace model loaded by name; revision pinning managed operationally.
+        self.wav2vec_processor = Wav2Vec2Processor.from_pretrained(  # nosec B615
             "facebook/wav2vec2-base-960h", resume_download=True
-        )  # nosec B615  # HuggingFace model loaded by name; revision pinning managed operationally
+        )
         self.wav2vec_model = Wav2Vec2Model.from_pretrained(  # nosec B615
             "facebook/wav2vec2-base-960h",
             torch_dtype=(torch.float16 if torch.cuda.is_available() else torch.float32),

--- a/autobot-backend/api/settings_sync_test.py
+++ b/autobot-backend/api/settings_sync_test.py
@@ -114,8 +114,9 @@ class TestAtomicWriteJson:
             target = Path(tmpdir) / "settings.json"
             data = {
                 "backend": {
-                    "server_host": "0.0.0.0"
-                }  # nosec B104  # intentional bind to all interfaces for service/test
+                    # Intentional bind to all interfaces for service/test.
+                    "server_host": "0.0.0.0"  # nosec B104
+                }
             }
             await _atomic_write_json(target, data)
             assert target.exists()

--- a/autobot-backend/api/vnc_humanization.py
+++ b/autobot-backend/api/vnc_humanization.py
@@ -30,9 +30,8 @@ def humanize_click_position(x: int, y: int, radius: int = 5) -> Tuple[int, int]:
     Returns:
         Tuple of (humanized_x, humanized_y) with random offset applied
     """
-    offset_x = random.randint(
-        -radius, radius
-    )  # nosec B311  # mouse position jitter for UI humanization, not cryptographic
+    # Mouse position jitter for UI humanization, not cryptographic.
+    offset_x = random.randint(-radius, radius)  # nosec B311
     offset_y = random.randint(-radius, radius)  # nosec B311  # mouse position jitter for UI humanization
     return (max(0, x + offset_x), max(0, y + offset_y))
 
@@ -109,9 +108,8 @@ def simulate_mouse_curve(x1: int, y1: int, x2: int, y2: int, steps: int = 10) ->
                 perp_y = dx / length
 
                 # Sine wave for smooth curve
-                curve_amount = math.sin(t * math.pi) * random.uniform(
-                    2, 8
-                )  # nosec B311  # mouse path curve simulation, not cryptographic
+                # Mouse path curve simulation, not cryptographic.
+                curve_amount = math.sin(t * math.pi) * random.uniform(2, 8)  # nosec B311
 
                 x += int(perp_x * curve_amount)
                 y += int(perp_y * curve_amount)

--- a/autobot-backend/chat_workflow/manager.py
+++ b/autobot-backend/chat_workflow/manager.py
@@ -1847,8 +1847,9 @@ class ChatWorkflowManager(
             "[Issue #2310] Injecting available-tools reminder after %d consecutive invalid tool calls",
             consecutive_invalid_tool_calls,
         )
+        # Prompt template, not SQL; consecutive_invalid_tool_calls is an int counter.
         _reminder = (
-            f"\n**[SYSTEM] TOOL NAME CORRECTION REQUIRED:**\n"  # nosec B608  # prompt template, not SQL
+            f"\n**[SYSTEM] TOOL NAME CORRECTION REQUIRED:**\n"  # nosec B608
             f"Your last {consecutive_invalid_tool_calls} tool call(s) used invalid tool names. "
             "You MUST use ONLY the following tool names:\n"
             "- execute_command: Run shell commands\n"
@@ -1871,7 +1872,7 @@ class ChatWorkflowManager(
             "- delegate: Delegate a subtask to a subordinate agent\n"
             "- respond: Signal task completion with a final message\n"
             "Do NOT invent new tool names. Use ONLY the names listed above.\n\n"
-        )  # nosec B608  # prompt template, not SQL; consecutive_invalid_tool_calls is an int counter
+        )
         return _reminder
 
     def _get_continuation_instructions(

--- a/autobot-backend/code_embedding_generator.py
+++ b/autobot-backend/code_embedding_generator.py
@@ -120,12 +120,10 @@ class CodeEmbeddingGenerator:
         def _load_sync():
             from transformers import AutoModel, AutoTokenizer
 
-            self.tokenizer = AutoTokenizer.from_pretrained(
-                self.model_name, resume_download=True
-            )  # nosec B615  # HuggingFace model loaded by name; revision pinning managed operationally
-            self.model = AutoModel.from_pretrained(
-                self.model_name, resume_download=True
-            )  # nosec B615  # HuggingFace model loaded by name; revision pinning managed operationally
+            # HuggingFace model loaded by name; revision pinning managed operationally.
+            self.tokenizer = AutoTokenizer.from_pretrained(self.model_name, resume_download=True)  # nosec B615
+            # HuggingFace model loaded by name; revision pinning managed operationally.
+            self.model = AutoModel.from_pretrained(self.model_name, resume_download=True)  # nosec B615
 
             if self.npu_available:
                 self._convert_to_openvino()

--- a/autobot-backend/code_intelligence/fingerprinting/similarity.py
+++ b/autobot-backend/code_intelligence/fingerprinting/similarity.py
@@ -58,9 +58,10 @@ class SimilarityCalculator:
         # Weighted average
         weights = {
             "structural": 0.5,
-            "token": 0.3,
+            # Similarity metric weights dict, 'token' key is code token type not a credential.
+            "token": 0.3,  # nosec B105
             "feature": 0.2,
-        }  # nosec B105  # similarity metric weights dict, 'token' key is code token type not a credential
+        }
         similarity = (
             weights["structural"] * structural_sim + weights["token"] * token_sim + weights["feature"] * feature_sim
         )

--- a/autobot-backend/command_manual_manager.py
+++ b/autobot-backend/command_manual_manager.py
@@ -723,9 +723,10 @@ class CommandManualManager:
             return None
 
         try:
-            result = subprocess.run(
+            # command_name validated by _VALID_COMMAND_NAME_RE above.
+            result = subprocess.run(  # nosec B603 B607
                 ["man", command_name], capture_output=True, text=True, timeout=10
-            )  # nosec B603 B607  # command_name validated by _VALID_COMMAND_NAME_RE above
+            )
 
             if result.returncode == 0:
                 return result.stdout

--- a/autobot-backend/context_window_manager.py
+++ b/autobot-backend/context_window_manager.py
@@ -119,9 +119,10 @@ class ContextWindowManager:
                 },
             },
             "token_estimation": {
-                "chars_per_token": 4,
+                # Config dict; 'token_estimation' refers to LLM token counting, not a credential.
+                "chars_per_token": 4,  # nosec B105
                 "safety_margin": 0.9,
-            },  # nosec B105  # config dict; 'token_estimation' refers to LLM token counting, not a credential
+            },
         }
 
     def set_model(self, model_name: str):

--- a/autobot-backend/conversation_file_manager_init_test.py
+++ b/autobot-backend/conversation_file_manager_init_test.py
@@ -420,8 +420,10 @@ class TestSchemaIntegrityVerification:
 
         for table in expected_tables:
             rows = await async_sqlite_query(
-                db_path_str, f"SELECT COUNT(*) FROM {table}"
-            )  # nosec B608  # table names from fixed test allowlist above, no user input
+                db_path_str,
+                # Table names come from the fixed test allowlist above, no user input.
+                f"SELECT COUNT(*) FROM {table}",  # nosec B608
+            )
             count = rows[0][0]
             logger.info(f"✓ Table '{table}' queryable (count: {count})")
 
@@ -434,8 +436,10 @@ class TestSchemaIntegrityVerification:
 
         for view in expected_views:
             rows = await async_sqlite_query(
-                db_path_str, f"SELECT COUNT(*) FROM {view}"
-            )  # nosec B608  # view names from fixed test allowlist above, no user input
+                db_path_str,
+                # View names come from the fixed test allowlist above, no user input.
+                f"SELECT COUNT(*) FROM {view}",  # nosec B608
+            )
             count = rows[0][0]
             logger.info(f"✓ View '{view}' queryable (count: {count})")
 

--- a/autobot-backend/gui_controller.py
+++ b/autobot-backend/gui_controller.py
@@ -307,9 +307,8 @@ class GUIController:
             try:
                 import subprocess
 
-                result = subprocess.run(
-                    ["which", "kex"], capture_output=True, text=True
-                )  # nosec B603 B607  # fixed argv, probing kex availability
+                # Fixed argv, probing kex availability.
+                result = subprocess.run(["which", "kex"], capture_output=True, text=True)  # nosec B603 B607
                 if result.stdout.strip():
                     logger.info("Kex is available. If GUI fails, consider starting " "a Kex session.")
                     return True

--- a/autobot-backend/hardware_acceleration.py
+++ b/autobot-backend/hardware_acceleration.py
@@ -139,9 +139,8 @@ class HardwareAccelerationManager:
     def _check_npu_via_lspci(self) -> bool:
         """Check for NPU hardware via lspci command."""
         try:
-            result = subprocess.run(
-                ["lspci"], capture_output=True, text=True, timeout=5
-            )  # nosec B603 B607  # fixed lspci argv, no user input
+            # Fixed lspci argv, no user input.
+            result = subprocess.run(["lspci"], capture_output=True, text=True, timeout=5)  # nosec B603 B607
             if result.returncode == 0:
                 output = result.stdout.lower()
                 if any(keyword in output for keyword in NPU_HARDWARE_KEYWORDS):

--- a/autobot-backend/llm_shared/optimization/layer_inference.py
+++ b/autobot-backend/llm_shared/optimization/layer_inference.py
@@ -183,9 +183,8 @@ class LayerInferenceEngine:
             kwargs["cache_dir"] = self._config.cache_dir
 
         logger.debug("Loading model config for %s", model_name)
-        auto_cfg = AutoConfig.from_pretrained(
-            model_name, resume_download=True, **kwargs
-        )  # nosec B615  # HuggingFace model loaded by name; revision pinning managed operationally
+        # HuggingFace model loaded by name; revision pinning managed operationally.
+        auto_cfg = AutoConfig.from_pretrained(model_name, resume_download=True, **kwargs)  # nosec B615
         cfg_dict: Dict[str, Any] = auto_cfg.to_dict()
         logger.info(
             "Loaded model config for %s: arch=%s",
@@ -459,9 +458,8 @@ class LayerInferenceEngine:
         kwargs: Dict[str, Any] = {"use_fast": True}
         if self._config.cache_dir:
             kwargs["cache_dir"] = self._config.cache_dir
-        return AutoTokenizer.from_pretrained(
-            self._config.model_name, resume_download=True, **kwargs
-        )  # nosec B615  # HuggingFace model loaded by name; revision pinning managed operationally
+        # HuggingFace model loaded by name; revision pinning managed operationally.
+        return AutoTokenizer.from_pretrained(self._config.model_name, resume_download=True, **kwargs)  # nosec B615
 
     def _resolve_checkpoint_path(self) -> str:
         """Return the checkpoint path for the configured model.

--- a/autobot-backend/llm_shared/optimization/model_inspector.py
+++ b/autobot-backend/llm_shared/optimization/model_inspector.py
@@ -263,9 +263,8 @@ def _inspect_via_config(model_name: str) -> ModelInfo | None:
         return None
 
     try:
-        cfg = transformers.AutoConfig.from_pretrained(
-            model_name, resume_download=True
-        )  # nosec B615  # HuggingFace model loaded by name; revision pinning managed operationally
+        # HuggingFace model loaded by name; revision pinning managed operationally.
+        cfg = transformers.AutoConfig.from_pretrained(model_name, resume_download=True)  # nosec B615
         param_count = _count_params_via_skeleton(cfg, transformers, accelerate)
         if param_count is None:
             logger.debug("model_inspector: using formula fallback for %s", model_name)

--- a/autobot-backend/multimodal_processor/processors/voice.py
+++ b/autobot-backend/multimodal_processor/processors/voice.py
@@ -115,9 +115,10 @@ class VoiceProcessor(BaseModalProcessor):
         try:
             # Load Whisper model for speech recognition
             self.logger.info("Loading Whisper model...")
-            self.whisper_processor = WhisperProcessor.from_pretrained(
+            # HuggingFace model loaded by name; revision pinning managed operationally.
+            self.whisper_processor = WhisperProcessor.from_pretrained(  # nosec B615
                 "openai/whisper-base", resume_download=True
-            )  # nosec B615  # HuggingFace model loaded by name; revision pinning managed operationally
+            )
             self.whisper_model = WhisperForConditionalGeneration.from_pretrained(  # nosec B615
                 "openai/whisper-base",
                 torch_dtype=(torch.float16 if torch.cuda.is_available() else torch.float32),

--- a/autobot-backend/pki/generator.py
+++ b/autobot-backend/pki/generator.py
@@ -40,9 +40,8 @@ def _run_openssl_command(cmd: List[str], operation: str, context: str = "") -> T
         Tuple of (success: bool, error_message: str | None)
     """
     try:
-        subprocess.run(
-            cmd, check=True, capture_output=True
-        )  # nosec B603  # cmd is openssl argv built by callers using hardcoded arg lists
+        # cmd is openssl argv built by callers using hardcoded arg lists.
+        subprocess.run(cmd, check=True, capture_output=True)  # nosec B603
         return True, None
     except subprocess.CalledProcessError as e:
         error_msg = e.stderr.decode() if e.stderr else str(e)
@@ -262,9 +261,8 @@ class CertificateGenerator:
         ]
 
         try:
-            subprocess.run(
-                key_cmd, check=True, capture_output=True
-            )  # nosec B603  # key_cmd is fixed openssl argv built above
+            # key_cmd is fixed openssl argv built above.
+            subprocess.run(key_cmd, check=True, capture_output=True)  # nosec B603
             os.chmod(ca_key, 0o600)
             return True
         except subprocess.CalledProcessError as e:
@@ -303,9 +301,8 @@ class CertificateGenerator:
         ]
 
         try:
-            subprocess.run(
-                cert_cmd, check=True, capture_output=True
-            )  # nosec B603  # cert_cmd is fixed openssl argv built above
+            # cert_cmd is fixed openssl argv built above.
+            subprocess.run(cert_cmd, check=True, capture_output=True)  # nosec B603
             os.chmod(ca_cert, 0o644)
             logger.info(f"CA certificate generated: {ca_cert}")
             return True
@@ -495,9 +492,8 @@ class CertificateGenerator:
             str(self.config.ca_cert_path),
             str(cert_path),
         ]
-        verify_result = subprocess.run(
-            verify_cmd, capture_output=True
-        )  # nosec B603  # verify_cmd is fixed openssl argv built above
+        # verify_cmd is fixed openssl argv built above.
+        verify_result = subprocess.run(verify_cmd, capture_output=True)  # nosec B603
         return verify_result.returncode == 0
 
     def get_certificate_status(self, cert_path: Path) -> CertificateStatus:
@@ -516,9 +512,8 @@ class CertificateGenerator:
                 "-issuer",
                 "-dates",
             ]
-            result = subprocess.run(
-                cmd, capture_output=True, check=True
-            )  # nosec B603  # cmd is fixed openssl argv built above
+            # cmd is fixed openssl argv built above.
+            result = subprocess.run(cmd, capture_output=True, check=True)  # nosec B603
             output = result.stdout.decode()
 
             subject, issuer, expires_at = self._parse_certificate_output(output)

--- a/autobot-backend/services/execution/ssh_backend.py
+++ b/autobot-backend/services/execution/ssh_backend.py
@@ -142,9 +142,8 @@ class SSHBackend(ExecutionBackend):
         try:
             client = await self._get_ssh_client()
             # Try a simple command
-            stdin, stdout, stderr = client.exec_command(
-                "true"
-            )  # nosec B601  # hardcoded literal command in health check, not user input
+            # Hardcoded literal command in health check, not user input.
+            stdin, stdout, stderr = client.exec_command("true")  # nosec B601
             stdout.channel.recv_exit_status()
             return True
         except Exception as e:

--- a/autobot-backend/services/knowledge/autonomous_loop.py
+++ b/autobot-backend/services/knowledge/autonomous_loop.py
@@ -574,9 +574,8 @@ class AutonomousLoopRunner:
                         "ucb1_exploration_constant": round(
                             random.uniform(0.5, 3.0), 2  # nosec B311  # UCB1 exploration constant, not cryptographic
                         ),
-                        "max_results_per_stage": random.choice(
-                            [5, 10, 20, 30]
-                        ),  # nosec B311  # variant selection for autonomous loop, not cryptographic
+                        # Variant selection for autonomous loop, not cryptographic.
+                        "max_results_per_stage": random.choice([5, 10, 20, 30]),  # nosec B311
                     }
                 )
             logger.info("AutonomousLoop[%s] HYPOTHESIZE: using %d fallback variants", run_id, len(fallback))

--- a/autobot-backend/services/mcp_isolated_runtime_test.py
+++ b/autobot-backend/services/mcp_isolated_runtime_test.py
@@ -246,8 +246,10 @@ class TestConcurrentRequestIds:
         ):
             await asyncio.gather(
                 *[
-                    client.call_tool("read_file", {"path": f"/tmp/f{i}"}) for i in range(self._N)
-                ]  # nosec B108  # test/controlled code uses tmpdir intentionally
+                    # Test/controlled code uses tmpdir intentionally.
+                    client.call_tool("read_file", {"path": f"/tmp/f{i}"})  # nosec B108
+                    for i in range(self._N)
+                ]
             )
 
         # Filter out the "shutdown" or "ping" requests emitted by _ensure_alive
@@ -283,8 +285,9 @@ class TestConcurrentRequestIds:
             new=AsyncMock(return_value=fake_proc),
         ):
             tool_coros = [
-                client.call_tool("list_dir", {"path": f"/tmp/{i}"})
-                for i in range(half)  # nosec B108  # test/controlled code uses tmpdir intentionally
+                # Test/controlled code uses tmpdir intentionally.
+                client.call_tool("list_dir", {"path": f"/tmp/{i}"})  # nosec B108
+                for i in range(half)
             ]
             health_coros = [client.health_check() for _ in range(half)]
             await asyncio.gather(*tool_coros, *health_coros)

--- a/autobot-backend/services/npu_worker_manager.py
+++ b/autobot-backend/services/npu_worker_manager.py
@@ -508,9 +508,8 @@ class NPUWorkerManager(AsyncInitializable):
             models_list = models_data.get("models", [])
             if not models_list:
                 return  # nothing to probe
-            model_id = random.choice(
-                models_list
-            )  # nosec B311  # random probe selection for health check, not cryptographic
+            # Random probe selection for health check, not cryptographic.
+            model_id = random.choice(models_list)  # nosec B311
         except Exception as e:
             logger.debug("Pulse-probe: could not fetch models for worker %s: %s", worker_id, e)
             return

--- a/autobot-backend/services/url_validator_test.py
+++ b/autobot-backend/services/url_validator_test.py
@@ -187,8 +187,9 @@ class TestResolveSafeIP:
                     socket.SOCK_STREAM,
                     6,
                     "",
-                    ("0.0.0.0", 0),
-                )  # nosec B104  # intentional bind to all interfaces for service/test
+                    # Intentional bind to all interfaces for service/test.
+                    ("0.0.0.0", 0),  # nosec B104
+                )
             ]
             mock_loop.return_value.getaddrinfo = mock_getaddrinfo
 

--- a/autobot-backend/utils/display_utils.py
+++ b/autobot-backend/utils/display_utils.py
@@ -117,9 +117,8 @@ class DisplayDetector:
     def _try_xrandr(self) -> Tuple[int, int] | None:
         """Try to get resolution using xrandr (X11) (Issue #315 - refactored)."""
         try:
-            result = subprocess.run(
-                ["xrandr", "--query"], capture_output=True, text=True, timeout=5
-            )  # nosec B603 B607  # fixed argv, system display tool
+            # Fixed argv, system display tool.
+            result = subprocess.run(["xrandr", "--query"], capture_output=True, text=True, timeout=5)  # nosec B603 B607
             if result.returncode != 0:
                 return None
 
@@ -138,9 +137,8 @@ class DisplayDetector:
     def _try_xdpyinfo(self) -> Tuple[int, int] | None:
         """Try to get resolution using xdpyinfo (X11) (Issue #315 - refactored)."""
         try:
-            result = subprocess.run(
-                ["xdpyinfo"], capture_output=True, text=True, timeout=5
-            )  # nosec B603 B607  # fixed argv, system display info tool
+            # Fixed argv, system display info tool.
+            result = subprocess.run(["xdpyinfo"], capture_output=True, text=True, timeout=5)  # nosec B603 B607
             if result.returncode != 0:
                 return None
 
@@ -161,9 +159,8 @@ class DisplayDetector:
         """Try to get resolution on Wayland (Issue #315 - refactored)."""
         try:
             # Try wlr-randr (for wlroots-based compositors)
-            result = subprocess.run(
-                ["wlr-randr"], capture_output=True, text=True, timeout=5
-            )  # nosec B603 B607  # fixed argv, Wayland compositor display tool
+            # Fixed argv, Wayland compositor display tool.
+            result = subprocess.run(["wlr-randr"], capture_output=True, text=True, timeout=5)  # nosec B603 B607
             if result.returncode != 0:
                 return None
 
@@ -257,9 +254,8 @@ class DisplayDetector:
                 "Select-Object Width, Height | ConvertTo-Json",
             ]
 
-            result = subprocess.run(
-                powershell_cmd, capture_output=True, text=True, timeout=10
-            )  # nosec B603  # fixed PowerShell script with no user-controlled input
+            # Fixed PowerShell script with no user-controlled input.
+            result = subprocess.run(powershell_cmd, capture_output=True, text=True, timeout=10)  # nosec B603
 
             if result.returncode == 0:
                 import json

--- a/autobot-slm-backend/api/llm_config.py
+++ b/autobot-slm-backend/api/llm_config.py
@@ -153,8 +153,10 @@ async def _load_llm_config(db: AsyncSession) -> LLMConfig:
         active_provider=rows.get("llm_active_provider", "ollama"),
         providers=providers,
         ollama_host=rows.get(
-            "llm_ollama_host", "0.0.0.0"
-        ),  # nosec B104  # intentional bind to all interfaces for service/test
+            "llm_ollama_host",
+            # Intentional bind to all interfaces for service/test.
+            "0.0.0.0",  # nosec B104
+        ),
         ollama_port=int(rows.get("llm_ollama_port", "11434")),
         gpu_models=gpu_models,
         cpu_models=cpu_models,

--- a/autobot_shared/security/path_validator_test.py
+++ b/autobot_shared/security/path_validator_test.py
@@ -114,8 +114,9 @@ class TestValidatePath:
         """When allowed_roots is None, _DEFAULT_ALLOWED_ROOTS is used."""
         assert "/tmp" in _DEFAULT_ALLOWED_ROOTS  # nosec B108  # test/controlled code uses tmpdir intentionally
         result = validate_path(
-            "/tmp/test_path_validator_check"
-        )  # nosec B108  # test/controlled code uses tmpdir intentionally
+            # Test/controlled code uses tmpdir intentionally.
+            "/tmp/test_path_validator_check"  # nosec B108
+        )
         assert str(result).startswith("/tmp")  # nosec B108  # test/controlled code uses tmpdir intentionally
 
     def test_symlink_escape(self, tmp_path) -> None:
@@ -165,8 +166,10 @@ class TestValidateRelativePath:
         """Null byte in segment raises ValueError."""
         with pytest.raises(ValueError, match="empty or contains null bytes"):
             validate_relative_path(
-                "file\x00.txt", "/tmp/base"
-            )  # nosec B108  # test/controlled code uses tmpdir intentionally
+                "file\x00.txt",
+                # Test/controlled code uses tmpdir intentionally.
+                "/tmp/base",  # nosec B108
+            )
 
     def test_absolute_path_as_segment(self, tmp_path) -> None:
         """Absolute path as segment escapes base and raises."""

--- a/scripts/check_nosec_format.py
+++ b/scripts/check_nosec_format.py
@@ -3,7 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
-"""Fail when a ``# nosec`` annotation puts prose where bandit expects test IDs (#13521).
+"""Fail when a ``# nosec`` annotation is unusable to bandit (#13521, #13528).
+
+Two shapes are rejected. The first puts prose where bandit expects test IDs; the
+second strands the annotation on a line that carries no expression.
 
 Bandit parses **everything** after ``nosec`` as a whitespace-separated list of
 test IDs. A trailing explanation therefore becomes a list of bogus IDs and
@@ -33,9 +36,34 @@ Note the subtle consequence of the old form: ``# nose<c> B105 - explanation`` is
 not as narrowly scoped as its author intended, because the parser discards the
 unrecognised extras. It reads as scoped while behaving as ``# nose<c> B105``.
 
+Orphaned annotations (#13528)
+-----------------------------
+
+The second shape sits on a line carrying only closing punctuation::
+
+    "security": min(
+        100, max(0, 78 + trend * 0.4 + random.uniform(-1, 1))
+    ),  # nose<c> B311  # analytics variance noise
+
+Bandit matches an annotation against the *parent* of the flagged node
+(``node_visitor.visit_Str``) or against the node itself, so whether a closing
+bracket is still inside that range is an accident of how the expression nests.
+Measured on this tree: 36 of 40 such annotations happened to land inside the
+range and 4 did not — those 4 findings were being reported and ignored. Every
+one of them is one ``black`` run away from breaking, which is how they got
+there: #9489 split lines that grew too long and carried the comment down.
+
+The fix keeps both halves where they cannot drift apart::
+
+    # Analytics variance noise, not cryptographic.
+    "security": min(100, max(0, 78 + trend * 0.4 + random.uniform(-1, 1))),  # nose<c> B311
+
+A comment already on its own line is not reflowed, and the bare annotation is
+short enough that it no longer pushes the statement past the line limit.
+
 Exit code:
   0 — every annotation is well-formed
-  1 — at least one carries prose where IDs belong
+  1 — at least one carries prose where IDs belong, or sits on a closing bracket
 """
 
 from __future__ import annotations
@@ -56,6 +84,15 @@ _MALFORMED = re.compile(r"#\s*nosec\s+(?:[A-Z]\d+)(?:[,\s]+[A-Z]\d+)*\s*[-–—
 # A bare suppression token with prose and no IDs at all — same failure, no ID to keep.
 _MALFORMED_BARE = re.compile(r"#\s*nosec\s+(?![A-Z]\d+\b)(?!#)[A-Za-z]")
 
+# An annotation stranded on a line that carries only closing punctuation (#13528).
+_ORPHANED = re.compile(r"^\s*[\)\]\},]+\s*(?:,\s*)?#\s*nosec\b")
+
+_MALFORMED_HINT = "prose follows the test IDs — bandit reads each word as a test id. Use '# nosec <IDS>  # <prose>'."
+_ORPHANED_HINT = (
+    "annotation sits on closing punctuation, not on the flagged expression. Put the prose on its own "
+    "line above the statement and a bare '# nosec <IDS>' on the line bandit reports."
+)
+
 _MAX_REPORTED = 15
 
 
@@ -67,8 +104,8 @@ def _tracked_python_files() -> list[Path]:
     return [REPO_ROOT / line for line in result.stdout.splitlines() if line]
 
 
-def find_malformed() -> list[str]:
-    """Return one message per annotation bandit would mis-parse."""
+def _scan(is_bad, hint: str) -> list[str]:
+    """Return one ``path:lineno: hint`` message per line ``is_bad`` accepts."""
     problems: list[str] = []
     for path in _tracked_python_files():
         try:
@@ -76,22 +113,37 @@ def find_malformed() -> list[str]:
         except (OSError, UnicodeDecodeError):
             continue
         for lineno, line in enumerate(lines, 1):
-            if _MALFORMED.search(line) or _MALFORMED_BARE.search(line):
-                problems.append(
-                    f"{path.relative_to(REPO_ROOT)}:{lineno}: prose follows the test IDs — "
-                    f"bandit reads each word as a test id. Use '# nosec <IDS>  # <prose>'."
-                )
+            if is_bad(line):
+                problems.append(f"{path.relative_to(REPO_ROOT)}:{lineno}: {hint}")
     return problems
 
 
+def _is_malformed(line: str) -> bool:
+    return bool(_MALFORMED.search(line) or _MALFORMED_BARE.search(line))
+
+
+def _is_orphaned(line: str) -> bool:
+    return bool(_ORPHANED.match(line))
+
+
+def find_malformed() -> list[str]:
+    """Return one message per annotation bandit would mis-parse."""
+    return _scan(_is_malformed, _MALFORMED_HINT)
+
+
+def find_orphaned() -> list[str]:
+    """Return one message per annotation stranded on closing punctuation."""
+    return _scan(_is_orphaned, _ORPHANED_HINT)
+
+
 def main() -> int:
-    problems = find_malformed()
+    problems = find_malformed() + find_orphaned()
     for problem in problems[:_MAX_REPORTED]:
         print(problem)
     if len(problems) > _MAX_REPORTED:
         print(f"... and {len(problems) - _MAX_REPORTED} more")
     if problems:
-        print(f"\n{len(problems)} malformed '# nosec' annotation(s) (#13521)")
+        print(f"\n{len(problems)} unusable '# nosec' annotation(s) (#13521, #13528)")
         return 1
     return 0
 

--- a/scripts/check_nosec_format_test.py
+++ b/scripts/check_nosec_format_test.py
@@ -3,12 +3,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
-"""Tests for scripts/check_nosec_format.py (#13521).
+"""Tests for scripts/check_nosec_format.py (#13521, #13528).
 
-The checker must fire on the form bandit mis-parses and stay silent on the two
+The checker must fire on the forms bandit cannot use and stay silent on the ones
 that work. Getting that boundary wrong in either direction is costly: a false
 negative lets the warnings back in, and a false positive would push people to
 delete the explanations, which are the useful part of a suppression.
+
+Two defects are covered: prose where the test IDs belong (#13521), and an
+annotation stranded on a line of closing punctuation (#13528).
 
 Run: python3 -m pytest scripts/check_nosec_format_test.py
 """
@@ -33,7 +36,11 @@ _N = "# nose" + "c"
 
 
 def _flagged(line: str) -> bool:
-    return bool(checker._MALFORMED.search(line) or checker._MALFORMED_BARE.search(line))
+    return checker._is_malformed(line)
+
+
+def _orphaned(line: str) -> bool:
+    return checker._is_orphaned(line)
 
 
 # ------------------------------------------------------------------ malformed
@@ -75,9 +82,52 @@ def test_accepts_the_working_forms(suffix):
     assert not _flagged(line), f"should NOT be flagged: {line!r}"
 
 
+# -------------------------------------------------------------------- orphaned
+
+
+@pytest.mark.parametrize(
+    "head",
+    [
+        ")  ",
+        "),  ",
+        "]  ",
+        "],  ",
+        "}  ",
+        "},  ",
+        ")}]  ",  # nested close, single line
+        "        )  ",  # indented
+    ],
+)
+def test_flags_annotations_on_closing_punctuation(head):
+    """The flagged expression is on an earlier line, so the annotation misses it."""
+    line = f"{head}{_N} B311"
+    assert _orphaned(line), f"should be flagged: {line!r}"
+
+
+def test_flags_orphan_carrying_prose_too():
+    line = f"),  {_N} B311  # analytics variance noise"
+    assert _orphaned(line), f"should be flagged: {line!r}"
+
+
+@pytest.mark.parametrize(
+    "line_body",
+    [
+        "value = compute()  {n} B311",  # annotation rides the expression
+        "    self.x = choice(items)  {n} B311",  # indented, still an expression
+        "result = fn(  {n} B603 B607",  # opening bracket, node starts here
+        "    {n} B311",  # standalone comment line, nothing closed on it
+        ")  # closing bracket with an unrelated comment",
+        ")",  # bare closing bracket
+    ],
+)
+def test_accepts_annotations_that_reach_the_expression(line_body):
+    line = line_body.format(n=_N)
+    assert not _orphaned(line), f"should NOT be flagged: {line!r}"
+
+
 # ------------------------------------------------------------------ end to end
 
 
 def test_repository_is_currently_clean():
-    problems = checker.find_malformed()
+    problems = checker.find_malformed() + checker.find_orphaned()
     assert problems == [], "\n".join(problems[:10])


### PR DESCRIPTION
Closes #13528

## Thinking Path

The issue says these annotations "suppress nothing". That is the right fix but
not quite the right diagnosis, and the difference mattered for how the change
had to be verified, so I measured it before touching anything.

Bandit does not match a `# nosec` to its own line only. `tester._get_nosecs_from_contexts`
takes the union of the annotation on the finding's own line and any annotation
inside `context["linerange"]` — and for a string finding, `node_visitor.visit_Str`
sets that range from the *parent* node, not the string. So whether a closing
bracket still falls inside the range is an accident of how the expression nests.

I probed all 40, one at a time: strip the annotation, re-run bandit, see whether
the finding appears. 36 landed inside the range and were doing real work. 4 did
not, and their findings were being reported and ignored:

| site | id | what was reported |
|---|---|---|
| `conversation_file_manager_init_test.py:423` | B608 | `hardcoded_sql_expressions` |
| `conversation_file_manager_init_test.py:437` | B608 | `hardcoded_sql_expressions` |
| `mcp_isolated_runtime_test.py:249` | B108 | `hardcoded_tmp_directory` |
| `url_validator_test.py:190` | B104 | `hardcoded_bind_all_interfaces` |

The 4 are all f-strings: the flagged `Constant` hangs off a `JoinedStr` that ends
before the bracket line. The 36 that worked are calls and dict literals whose
parent happens to span the bracket. Same source shape, opposite outcome — which
is exactly why none of them should be left there. And every one of the 36 is one
formatter run from joining the 4, since that is how they got there: black split
lines that grew too long once prose was appended, carrying the comment down
(#9489).

Because the annotations mostly worked, "no NEW bandit findings" was the gate that
mattered. A careless move would have silently un-suppressed 36 sites.

## What Changed

**40 annotations across 24 files** now sit on the line bandit itself reports —
found by running bandit per site, not by guessing — with the explanation on its
own line above. Black does not reflow a comment that is already on its own line,
and the bare annotation is short enough not to push the statement past 120.

Two adjacent defects of the same family, fixed in place rather than filed and left:

- `mcp_isolated_runtime_test.py:288` carried its annotation on the comprehension's
  `for` clause instead of the call — same failure, but not on a bracket, so the
  orphan scan never saw it. It was one of the 5 findings CI was ignoring.
- `chat_workflow/manager.py:1874` duplicated an annotation that already sat
  correctly on the flagged string 23 lines above. Folded into that one; the
  duplicate's extra detail is preserved in the explanation.

No suppression was weakened, narrowed, or removed. Nothing was silenced that was
not already annotated as intentional.

`scripts/check_nosec_format.py` gains the orphan check beside the existing prose
check, sharing one scan helper. Its tests keep assembling the annotation token at
runtime (`_N = "# nose" + "c"`) — the checker greps raw lines, so a literal
fixture would make the checker's own tests the last violation. The `code-quality.yml`
step is renamed to cover both defects.

## Verification

Orphan count, detection regex from the issue, over every tracked `.py`:

```
before:  TOTAL orphans: 40 across 24 files
after:   TOTAL orphans: 0 across 0 files
```

**Bandit — no new findings.** Every changed file, HEAD version vs branch version,
run twice: once with the repo `.bandit`, once with every skip disabled so ids that
`.bandit` skips (B104/B108/B601) are exercised too. Compared as a multiset of test
ids, since line numbers move:

```
files with NEW bandit findings: 0
```

Five findings that were previously reported and unsuppressed are now correctly
suppressed:

```
conversation_file_manager_init_test.py  FIXED={'B608': 2}
mcp_isolated_runtime_test.py            FIXED={'B108': 2}
url_validator_test.py                   FIXED={'B104': 1}
```

**Per-annotation proof.** In the fixed tree, each annotation was stripped one at a
time and bandit re-run. An annotation that stopped covering its finding would show
as a no-op:

```
LIVE=46 NOOP=0
```

46 covers every annotation in the 24 touched files, not only the 40 moved. Each
one reveals its finding on its own line, i.e. it now sits exactly on the flagged
expression:

```
LIVE autobot-backend/pki/generator.py:44   B603      -> reveals [[44, 'B603']]
LIVE autobot-backend/utils/display_utils.py:121 B603 B607 -> reveals [[121, 'B603'], [121, 'B607']]
LIVE autobot-backend/services/url_validator_test.py:191 B104 -> reveals [[191, 'B104']]
```

**Checker gate.** One fixed file put back to its pre-fix state:

```
$ git show HEAD:autobot-backend/pki/generator.py > autobot-backend/pki/generator.py
$ python3 scripts/check_nosec_format.py
autobot-backend/pki/generator.py:45: annotation sits on closing punctuation, not on the flagged expression. ...
autobot-backend/pki/generator.py:267: ...
autobot-backend/pki/generator.py:308: ...
autobot-backend/pki/generator.py:500: ...
autobot-backend/pki/generator.py:521: ...

5 unusable '# nosec' annotation(s) (#13521, #13528)
EXIT=1

$ # restored
$ python3 scripts/check_nosec_format.py
EXIT=0
```

**Checker tests:**

```
$ python3 -m pytest scripts/check_nosec_format_test.py -q
28 passed in 4.54s
```

**flake8**, same config and same file list, HEAD version vs branch version:

```
before: 0
after:  0
```

Repo-wide bandit after the change reports `Total lines skipped (#nosec): 0` and
344 issues skipped by specific id — every annotation is id-scoped, none blanket.

## Model Used

Claude Opus 5 (1M context)
