### PR TITLE
test(pytest): declare the e2e and high_priority markers (#13549)

### DIFF
--- a/autobot-backend/services/redis_service_management_e2e_test.py
+++ b/autobot-backend/services/redis_service_management_e2e_test.py
@@ -19,6 +19,7 @@ import sys
 from pathlib import Path
 
 import pytest
+from playwright.async_api import Error as PlaywrightError
 from playwright.async_api import async_playwright, expect
 
 # Add project root to path
@@ -56,9 +57,19 @@ def backend_url():
 
 @pytest.fixture
 async def browser_context():
-    """Create browser context for E2E testing."""
+    """Create browser context for E2E testing.
+
+    The Chromium binary is a separate download (`playwright install`), not a pip
+    dependency, so a checkout with playwright installed can still have no browser
+    to launch. That is a missing optional dependency, which skips — the same rule
+    the repo applies to `pytest.importorskip`. Without this the fixture raises and
+    every test here reports as an error rather than a skip (#13549).
+    """
     async with async_playwright() as p:
-        browser = await p.chromium.launch(headless=True)
+        try:
+            browser = await p.chromium.launch(headless=True)
+        except PlaywrightError as exc:
+            pytest.skip(f"no Chromium available for Playwright: {exc}")
         context = await browser.new_context(
             viewport={"width": 1280, "height": 720},
             record_video_dir="tests/results/videos/",  # Record videos for debugging

--- a/autobot-backend/services/redis_service_management_e2e_test.py
+++ b/autobot-backend/services/redis_service_management_e2e_test.py
@@ -55,6 +55,12 @@ def backend_url():
     return ServiceURLs.BACKEND_API
 
 
+def _is_missing_browser(exc: PlaywrightError) -> bool:
+    """True only when Chromium was never downloaded, not for any other launch failure."""
+    message = str(exc)
+    return "Executable doesn't exist" in message or "playwright install" in message
+
+
 @pytest.fixture
 async def browser_context():
     """Create browser context for E2E testing.
@@ -64,12 +70,20 @@ async def browser_context():
     to launch. That is a missing optional dependency, which skips — the same rule
     the repo applies to `pytest.importorskip`. Without this the fixture raises and
     every test here reports as an error rather than a skip (#13549).
+
+    Only the missing-binary case skips. `playwright.async_api.Error` is the root
+    of the whole hierarchy — `TimeoutError` is a subclass of it — so catching the
+    class would also swallow a crashed browser, a launch timeout, an EACCES on
+    the executable and a sandbox failure, leaving these tests structurally
+    incapable of failing at launch. Anything else is re-raised.
     """
     async with async_playwright() as p:
         try:
             browser = await p.chromium.launch(headless=True)
         except PlaywrightError as exc:
-            pytest.skip(f"no Chromium available for Playwright: {exc}")
+            if not _is_missing_browser(exc):
+                raise
+            pytest.skip(f"Chromium is not downloaded for Playwright: {exc}")
         context = await browser.new_context(
             viewport={"width": 1280, "height": 720},
             record_video_dir="tests/results/videos/",  # Record videos for debugging

--- a/pytest.ini
+++ b/pytest.ini
@@ -21,7 +21,7 @@ markers =
     migration_gate: Alembic migration-path tests requiring a disposable Postgres (#10001/#10026)
     xdist_group: pytest-xdist group marker — tests with the same group run on the same worker
     e2e: End-to-end tests exercising a full service stack (#13549)
-    high_priority: Tests covering behaviour whose regression is release-blocking (#13549)
+    high_priority: Release-blocking security and test-coverage assertions (#13549)
     llm_judge: LLM-judged quality assertions — skipped unless AUTOBOT_LLM_JUDGE_TESTS=1 and a provider is configured (#11521)
 
 # Test discovery - colocated tests live next to source files (#734)

--- a/pytest.ini
+++ b/pytest.ini
@@ -20,6 +20,8 @@ markers =
     real_kb: Tests that run against a real (in-memory) ChromaDB instance
     migration_gate: Alembic migration-path tests requiring a disposable Postgres (#10001/#10026)
     xdist_group: pytest-xdist group marker — tests with the same group run on the same worker
+    e2e: End-to-end tests exercising a full service stack (#13549)
+    high_priority: Tests covering behaviour whose regression is release-blocking (#13549)
     llm_judge: LLM-judged quality assertions — skipped unless AUTOBOT_LLM_JUDGE_TESTS=1 and a provider is configured (#11521)
 
 # Test discovery - colocated tests live next to source files (#734)


### PR DESCRIPTION
Closes #13549

## Thinking Path

Found while measuring what is left of the Python suite red for #13162, on the first base `ci.yml` run to complete without being cancelled since #13541 landed. All 12 `python-suite` shards reported `completed` (confirmed before reading logs — queued shards return empty logs, and "0 failures" then looks identical to green).

Of **84** test-level failures on base, **48 were one cause**: two markers used but never declared under `pytest.ini`'s `markers =`, with `--strict-markers` in `addopts`.

```
ERROR autobot-backend/services/redis_service_management_e2e_test.py - Failed: 'e2e' not found in `markers` configuration option          x24
ERROR autobot-backend/mcp/mcp_security_test.py               - Failed: 'high_priority' not found in `markers` configuration option       x24
```

The `e2e` half is the interesting one, because it looks like it should already be excluded. `redis_service_management_e2e_test.py` carries `pytestmark = pytest.mark.integration`, and CI runs `-m "not integration and not slow and not distributed and not performance"` — the module was *meant* never to run. But `--strict-markers` is evaluated at **collection**, before `-m` deselection ever applies. An undeclared marker on a module CI intends to skip still fails the whole shard. Declaring markers is not optional for excluded tests, and that is the part worth remembering.

## What Changed

- `pytest.ini` — declare `e2e` and `high_priority` alongside the existing nine.
- `autobot-backend/services/redis_service_management_e2e_test.py` — the Playwright `browser_context` fixture now skips instead of raising when no Chromium is downloaded.

On the second change: the Chromium binary comes from a separate `playwright install` step, not from pip, so a checkout can have the library and no browser. That is a missing **optional dependency**, which skips — the same rule the repo already applies via `pytest.importorskip`. Before this, the fixture raised and all ten tests reported as errors rather than skips. The module's own comment already anticipated the case ("a bare checkout has no downloaded browser and no fleet"); it just had no code behind it.

**Review round.** The first revision caught `playwright.async_api.Error`, which review correctly flagged as too broad — it is the root of the whole hierarchy:

```console
$ python3 -c "from playwright.async_api import Error, TimeoutError; print(issubclass(TimeoutError, Error))"
True
```

So a crashed browser, a launch timeout, an EACCES on the executable and a sandbox failure would all have become skips, leaving these ten tests structurally incapable of failing at launch. That is a swallowed error, and the same silently-green shape this campaign exists to unwind. Only the missing-binary case skips now:

```
skip   missing binary   OK
skip   install hint     OK
RAISE  launch timeout   OK
RAISE  browser crash    OK
RAISE  permissions      OK
```

Review also flagged that the `high_priority` description did not match its only use — `TestSecurityCoverage` in `mcp_security_test.py`, whose own docstring reads "Meta-tests to verify security test coverage". Reworded to coverage assertions rather than product behaviour.

Review independently confirmed the blast radius: `pytest_collection_modifyitems` does not exist anywhere in the repo, and none of the 23 conftests use `get_closest_marker` / `iter_markers` / `add_marker`, so there is no marker-keyed logic for these names to start matching once declared.

## Verification

Blast radius is exactly two tracked files — nothing else in the repo uses either marker:

```console
$ git ls-files '*.py' | xargs grep -lE 'mark\.(e2e|high_priority)'
autobot-backend/mcp/mcp_security_test.py
autobot-backend/services/redis_service_management_e2e_test.py
```

Under CI's exact selection, both files together:

```console
$ python3 -m pytest autobot-backend/services/redis_service_management_e2e_test.py \
      autobot-backend/mcp/mcp_security_test.py -q \
      -m "not integration and not slow and not distributed and not performance"
35 passed, 10 deselected, 83 warnings in 184.50s
```

**0 errors, was 48.** The 24 `mcp_security` tests now actually run, and pass; the `e2e` ones are deselected by `-m not integration`, as was always intended.

The skip guard, running the e2e file directly with no browser downloaded:

```console
$ python3 -m pytest autobot-backend/services/redis_service_management_e2e_test.py -q
ssssssssss
10 skipped in 11.69s
```

Was 10 errors (`BrowserType.launch: Executable doesn't exist`).

`pr-preflight.sh` prints `pre-flight clean`.

## Model Used

Claude Opus 5 (1M context)