### PR TITLE
fix(testkit): enforce rule 2 in reattach and correct the mock rationale (#13555)

### DIFF
--- a/autobot-backend/testkit/module_stubs.py
+++ b/autobot-backend/testkit/module_stubs.py
@@ -66,13 +66,18 @@ _MISSING = object()
 
 
 def _is_real_module(module: Any) -> bool:
-    """True only for a genuine, file-backed module — never for a mock.
+    """True only for a genuine, file-backed module — never for a stand-in.
 
-    ``getattr(MagicMock(), "__file__")`` auto-creates a truthy attribute, so a
-    truthiness test reads every mock as a real module. That is the same vacuous
-    -mock trap #13162 kept turning up, and it fired here immediately: the root
-    conftest plants ``agent_loop`` as a MagicMock, and rule 2 refused to stub it.
-    Requiring a genuine ``str`` path is what distinguishes the two.
+    The check is ``isinstance(..., str)`` rather than a truthiness test because
+    a module carrying a PEP-562 module-level ``__getattr__`` shim answers *every*
+    attribute, dunders included, so ``getattr(module, "__file__", None)`` hands
+    back a truthy ``MagicMock`` and a truthiness test reads the stand-in as a
+    real module.
+
+    Note this is specifically about module-level ``__getattr__``. A bare
+    ``MagicMock`` is *not* the hazard: ``Mock.__getattr__`` rejects dunder names,
+    so ``getattr(MagicMock(), "__file__", None)`` is ``None`` and would classify
+    correctly either way. Only a genuine ``str`` path proves a real module.
     """
     return isinstance(getattr(module, "__file__", None), str)
 
@@ -93,9 +98,33 @@ class StubSet:
     def install_package(self, name: str, path: Path) -> types.ModuleType:
         """Register *name* as a hollow package whose ``__path__`` is the real dir.
 
-        Refuses to displace a real, file-backed module (rule 2). Returns the
-        module now registered under *name*.
+        Refuses to displace a real, file-backed module (rule 2). Always returns
+        *our* module for *name*, never whatever happens to occupy the slot: a
+        caller decorates the return value, and handing back a foreign module
+        means those attributes land somewhere nothing will ever read.
+
+        Re-installing a name we already own reuses the same module object rather
+        than building a second one. A second object would be silently discarded
+        by :meth:`reattach`, which restores from ``_detached`` — so anything the
+        caller patched onto it would be invisible for the whole run.
         """
+        self._refuse_if_real(name)
+
+        module = self._owned.get(name)
+        if module is None:
+            module = types.ModuleType(name)
+            module.__path__ = [str(path)]  # type: ignore[attr-defined]
+            module.__package__ = name
+            self._owned[name] = module
+
+        self._displaced.setdefault(name, sys.modules.get(name, _MISSING))
+        self._detached.pop(name, None)
+        sys.modules[name] = module
+        self._bind_on_parent(name, module)
+        return module
+
+    def _refuse_if_real(self, name: str) -> None:
+        """Rule 2, enforced at every point that writes ``sys.modules``."""
         existing = sys.modules.get(name)
         if existing is not None and _is_real_module(existing):
             raise RuntimeError(
@@ -103,17 +132,6 @@ class StubSet:
                 f"{existing.__file__}. Stubbing it would replace it for the whole "
                 f"process, which is how #13385 broke autobot_shared.async_compat."
             )
-        if existing is not None and name in self._owned:
-            return existing
-
-        module = types.ModuleType(name)
-        module.__path__ = [str(path)]  # type: ignore[attr-defined]
-        module.__package__ = name
-        self._displaced.setdefault(name, sys.modules.get(name, _MISSING))
-        sys.modules[name] = module
-        self._owned[name] = module
-        self._bind_on_parent(name, module)
-        return module
 
     def real_load(self, name: str, file_path: Path) -> Optional[types.ModuleType]:
         """Execute a real source file and register it under *name*.
@@ -121,15 +139,28 @@ class StubSet:
         Preferred over a mock whenever downstream code imports concrete names
         from the module — a hand-written stand-in silently lacks them (#13385).
         """
+        self._refuse_if_real(name)
         spec = importlib.util.spec_from_file_location(name, str(file_path))
         if not spec or not spec.loader:
             return None
         module = importlib.util.module_from_spec(spec)
-        module.__package__ = name.rpartition(".")[0] or name
+        # No `or name` fallback: a top-level module's __package__ is "", and
+        # naming itself would let a relative import inside it resolve against
+        # itself instead of raising.
+        module.__package__ = name.rpartition(".")[0]
         self._displaced.setdefault(name, sys.modules.get(name, _MISSING))
         sys.modules[name] = module
-        spec.loader.exec_module(module)
         self._owned[name] = module
+        try:
+            spec.loader.exec_module(module)
+        except BaseException:
+            # CPython removes a half-initialized module on import failure; a
+            # helper that leaves one behind is strictly worse than a plain
+            # import, and leaves the leak guard (#13361) blaming the importing
+            # file for a key nobody owns.
+            self._owned.pop(name, None)
+            self._put_back(name)
+            raise
         self._bind_on_parent(name, module)
         return module
 
@@ -168,19 +199,48 @@ class StubSet:
         and the attribute is silently never set — which surfaces later as
         ``AttributeError: module 'agent_loop' has no attribute 'search'``.
         ``detach`` walks in reverse for the same reason, mirrored.
+
+        Rule 2 is enforced here too, and this is the point where it actually
+        matters. ``install_package`` checks at conftest import, when nothing is
+        imported yet; ``reattach`` runs *after* pytest has imported the whole
+        session, so it is the call that can genuinely find a real module in the
+        slot. Overwriting it here would then make ``restore`` pop the real
+        module — rule 2 enforced only in the safe window is rule 2 not enforced.
+
+        What we displace is recorded by plain assignment, not ``setdefault``, so
+        ``restore`` undoes the *most recent* attach rather than a stale one.
         """
+        if self._owned and not self._detached:
+            raise RuntimeError(
+                "reattach() before detach(): there is nothing to reinstall, but "
+                "restore() will still uninstall at teardown, so the stubs would "
+                "vanish permanently after the first scope. Call detach() once "
+                "the importing is done (rule 5)."
+            )
         for name in self._owned:
             module = self._detached.get(name)
             if module is None:
                 continue
+            self._refuse_if_real(name)
+            current = sys.modules.get(name, _MISSING)
+            self._displaced[name] = current
             sys.modules[name] = module
             self._bind_on_parent(name, module)
 
     def restore(self) -> None:
-        """Return ``sys.modules`` to what it was before this StubSet existed."""
+        """Return ``sys.modules`` to what it was before this StubSet existed.
+
+        Clears the bookkeeping afterwards. Leaving ``_owned``/``_displaced``
+        populated makes every later ``restore()`` re-pop the same keys, which is
+        how a legitimately re-imported module gets destroyed by a teardown that
+        should have been a no-op.
+        """
         for name in reversed(list(self._owned)):
             self._put_back(name)
         self._restore_binds()
+        self._owned.clear()
+        self._displaced.clear()
+        self._detached.clear()
 
     def _put_back(self, name: str) -> None:
         """Restore one key to its pre-StubSet value, removing it only if it was absent.
@@ -217,12 +277,18 @@ class StubSet:
         Pair with :meth:`detach` at conftest import time: the stubs exist while
         the module imports its subject, vanish while pytest collects everything
         else, and come back only for the tests that need them.
+
+        Teardown is :meth:`detach`, not :meth:`restore` — the symmetric, repeatable
+        counterpart of ``reattach``. ``restore`` is terminal: it clears the
+        bookkeeping, so a second scope would find nothing to reinstall and the
+        stubs would be gone for the rest of the run. That failure is silent,
+        which is exactly the kind this helper exists to stop.
         """
 
         @pytest.fixture(scope=scope, autouse=True)
         def _reattach_stubs() -> Iterator[None]:
             self.reattach()
             yield
-            self.restore()
+            self.detach()
 
         return _reattach_stubs

--- a/autobot-backend/testkit/module_stubs_test.py
+++ b/autobot-backend/testkit/module_stubs_test.py
@@ -13,6 +13,7 @@ Run: python3 -m pytest autobot-backend/testkit/module_stubs_test.py
 
 from __future__ import annotations
 
+import importlib
 import sys
 import types
 from pathlib import Path
@@ -48,6 +49,23 @@ def test_installed_package_keeps_a_real_path(clean_modules):
     stubs.restore()
 
 
+def test_a_real_submodule_imports_through_the_hollow_package(clean_modules, tmp_path):
+    """The point of rule 1, asserted on behaviour rather than on __path__.
+
+    The package's own __init__.py is bypassed — here it raises, to prove it was
+    never executed — while a genuine sibling submodule still imports (#13383).
+    """
+    (tmp_path / "__init__.py").write_text("raise AssertionError('__init__ must be bypassed')\n", encoding="utf-8")
+    (tmp_path / "leaf.py").write_text("VALUE = 'imported through the stub'\n", encoding="utf-8")
+
+    stubs = StubSet()
+    stubs.install_package("scratchpkg", tmp_path)
+    leaf = importlib.import_module("scratchpkg.leaf")
+
+    assert leaf.VALUE == "imported through the stub"
+    stubs.restore()
+
+
 # --------------------------------------- rule 2: never displace a real module
 
 
@@ -57,11 +75,18 @@ def test_refuses_to_displace_a_real_module():
         stubs.install_package("json", _REAL_DIR)
 
 
-def test_a_mock_is_not_mistaken_for_a_real_module(clean_modules):
-    """getattr(MagicMock(), "__file__") is truthy — a truthiness test reads every
-    mock as a real module. That fired the first time this helper ran."""
+def test_a_module_level_getattr_shim_is_not_mistaken_for_a_real_module(clean_modules):
+    """A PEP-562 module-level __getattr__ answers dunders too, so __file__ comes
+    back a truthy MagicMock and a truthiness test would read the shim as real.
+
+    A bare MagicMock is deliberately NOT the case under test: Mock.__getattr__
+    rejects dunder names, so its __file__ is None and either check classifies it
+    correctly. Only the module-level shim distinguishes the two.
+    """
     placeholder = types.ModuleType("scratchpkg")
     placeholder.__getattr__ = lambda _name: MagicMock()  # type: ignore[attr-defined]
+    assert getattr(placeholder, "__file__", None), "premise: the shim answers __file__ truthily"
+    assert getattr(MagicMock(), "__file__", None) is None, "premise: a bare mock does not"
     sys.modules["scratchpkg"] = placeholder
 
     stubs = StubSet()
@@ -69,6 +94,71 @@ def test_a_mock_is_not_mistaken_for_a_real_module(clean_modules):
     assert sys.modules["scratchpkg"] is not placeholder
     stubs.restore()
     assert sys.modules["scratchpkg"] is placeholder
+
+
+def test_reattach_refuses_to_displace_a_module_imported_while_detached(clean_modules, tmp_path):
+    """Rule 2 enforced only in the safe window is rule 2 not enforced.
+
+    install_package checks at conftest import, when nothing is imported yet.
+    reattach runs after pytest has imported the whole session — it is the call
+    that can actually find a real module in the slot, and overwriting it there
+    would make restore() pop the real module for the rest of the process.
+    """
+    stubs = StubSet()
+    stubs.install_package("scratchpkg", _REAL_DIR)
+    stubs.detach()
+
+    real = tmp_path / "scratchpkg.py"
+    real.write_text("VALUE = 'the real one'\n", encoding="utf-8")
+    spec = importlib.util.spec_from_file_location("scratchpkg", str(real))
+    genuine = importlib.util.module_from_spec(spec)
+    sys.modules["scratchpkg"] = genuine
+    spec.loader.exec_module(genuine)
+
+    with pytest.raises(RuntimeError, match="refusing to stub"):
+        stubs.reattach()
+    assert sys.modules["scratchpkg"] is genuine, "the real module must survive"
+
+
+def test_reattach_without_detach_is_refused(clean_modules):
+    """A no-op reattach paired with a real teardown makes the stubs vanish after
+    the first scope, silently. Better to say so than to half-work."""
+    stubs = StubSet()
+    stubs.install_package("scratchpkg", _REAL_DIR)
+    with pytest.raises(RuntimeError, match="before detach"):
+        stubs.reattach()
+    stubs.restore()
+
+
+def test_reinstall_after_detach_reuses_the_same_object(clean_modules):
+    """reattach restores from _detached, so a second object built for the same
+    name is silently discarded and anything patched onto it is never seen."""
+    stubs = StubSet()
+    first = stubs.install_package("scratchpkg", _REAL_DIR)
+    stubs.detach()
+    second = stubs.install_package("scratchpkg", _REAL_DIR)
+    assert second is first
+    second.marker = "patched by the caller"  # type: ignore[attr-defined]
+
+    stubs.detach()
+    stubs.reattach()
+    assert getattr(sys.modules["scratchpkg"], "marker", None) == "patched by the caller"
+    stubs.restore()
+
+
+def test_real_load_leaves_nothing_behind_when_the_module_raises(clean_modules, tmp_path):
+    """CPython removes a half-initialized module on import failure. A helper that
+    leaves one behind is strictly worse than a plain import, and hands the leak
+    guard a key nobody owns."""
+    source = tmp_path / "boom.py"
+    source.write_text("raise ValueError('boom')\n", encoding="utf-8")
+
+    stubs = StubSet()
+    stubs.install_package("scratchpkg", tmp_path)
+    with pytest.raises(ValueError, match="boom"):
+        stubs.real_load("scratchpkg.leaf", source)
+    assert "scratchpkg.leaf" not in sys.modules
+    stubs.restore()
 
 
 # ----------------------------------------------- rule 3: bind on the parent


### PR DESCRIPTION
Closes #13555

Code review of PR #13546 arrived after that PR had already merged. It found seven defects in the helper plus a documented rationale that is factually wrong. This lands the fixes rather than leaving them on a merged branch.

## Thinking Path

The one that matters: **`reattach()` bypassed rule 2, in exactly the window where rule 2 matters.**

`install_package` refuses to displace a real, file-backed module — that is rule 2, and it exists because a helper that returned whatever was already in `sys.modules` let a test break `autobot_shared.async_compat.run_or_schedule` process-wide (#13385). But that check runs at conftest **import** time, when nothing is imported yet.

`reattach()` runs *after* pytest has imported the whole session. It is the call that can genuinely find a real module in the slot — and it assigned `sys.modules[name]` unconditionally. So a module legitimately imported during the detached window was silently replaced by the stub, and `restore()` then read `_displaced[name] is _MISSING` and **popped the real module** for the rest of the process.

Rule 2 enforced only in the safe window is rule 2 not enforced. #13385 reintroduced two methods away from the check that prevents it.

## What Changed

`reattach()` now applies the same refusal, and records what it displaced by plain assignment rather than `setdefault`, so `restore()` undoes the *most recent* attach instead of a stale one. The refusal is factored into `_refuse_if_real`, called from every path that writes `sys.modules`.

Six more, each now pinned by a test:

| was | now |
|---|---|
| `real_load` inserted into `sys.modules` before `exec_module` and recorded `_owned` after, leaking a half-initialized module when the file raised | put back and re-raise — CPython removes it on failure, so the helper was strictly worse than a plain `import`, and handed the leak guard (#13361) a key nobody owned |
| `install_package` after `detach()` built a **second** object for the same name, while `reattach()` restores from `_detached` — anything patched onto it was invisible for the whole run | reuses the owned object |
| `fixture()` paired `reattach` with `restore`; `restore` is terminal, so a second scope found nothing to reinstall and the stubs vanished silently | teardown is `detach`, the repeatable counterpart; `reattach` before any `detach` now raises instead of no-opping |
| `install_package` returned whatever occupied the slot | returns our own module, so a caller cannot decorate a foreign one |
| `real_load` set `__package__` to the module's own name for a top-level load | `""`, so a relative import raises instead of resolving against itself |
| `restore()` left `_owned`/`_displaced` populated, so a later `restore` re-popped the same keys | clears them |

### The rationale that was wrong

#13546 claimed `getattr(MagicMock(), "__file__")` auto-creates a truthy attribute. It does not — `Mock.__getattr__` rejects dunder names:

```console
$ python3 -c "from unittest.mock import MagicMock; print(getattr(MagicMock(), '__file__', None))"
None
```

The real hazard is a **PEP-562 module-level `__getattr__` shim**, which answers dunders and hands back a truthy `MagicMock`. The test named `test_a_mock_is_not_mistaken_for_a_real_module` actually built that shim, not a MagicMock — so the test was right and the explanation was not. `isinstance(..., str)` remains the correct implementation. Renamed to `test_a_module_level_getattr_shim_is_not_mistaken_for_a_real_module`, with both premises now asserted rather than described:

```python
assert getattr(placeholder, "__file__", None), "premise: the shim answers __file__ truthily"
assert getattr(MagicMock(), "__file__", None) is None, "premise: a bare mock does not"
```

### Test gap closed

The rule-1 test asserted only `module.__path__ == [...]` — it never imported a real submodule *through* the hollow package, which is the behaviour rule 1 exists for. The new test writes an `__init__.py` that **raises**, to prove it is bypassed, and asserts a sibling submodule still imports.

## Verification

```console
$ python3 -m pytest autobot-backend/testkit autobot-backend/tests/search -q
      known: autobot-backend/tests/search/conftest.py (1 key(s))
46 passed, 1 warning
```

14 in `testkit` (was 9) + 32 in `tests/search`, matching base. Each new test fails against the merged revision and passes here.

`flake8`, `isort`, `black`, `bandit` clean on both files. `pr-preflight.sh` prints `pre-flight clean`.

### Not a defect — checked and cleared

Review traced the `_binds` stack for a suspected double-append across repeated detach/reattach cycles. It is sound: `_restore_binds` unwinds reversed then clears, so duplicates cancel, and `detach` clears the stack before the next `reattach` refills it. No change made there.

## Model Used

Claude Opus 5 (1M context)
