### PR TITLE
fix(tests): stop tests/search conftest swapping agent_loop package identity (#13551)

### DIFF
--- a/autobot-backend/tests/search/conftest.py
+++ b/autobot-backend/tests/search/conftest.py
@@ -7,8 +7,32 @@
 The root ``autobot-backend/conftest.py`` stubs ``agent_loop`` (and submodules)
 to break orchestration import chains. These tests need the *real*
 ``agent_loop.search`` package, so — mirroring ``tests/agent_loop/conftest.py``
-(#6627) — we plant a real package entry and load the search modules directly,
-restoring the stubs afterwards so sibling directories are unaffected.
+(#6627) — we fill in whatever is still a stub and restore exactly that
+afterwards, so sibling directories are unaffected.
+
+This file must never swap the *package identity* (#13551).  It used to pop
+every ``agent_loop*`` key out of ``sys.modules`` and plant a fresh
+``agent_loop`` module.  That is harmless when this directory is named on the
+command line — pytest loads initial conftests before importing any test module
+— and fatal in a full-suite run, where pytest imports this conftest during the
+collection of ``autobot-backend/tests/search`` long after
+``autobot-backend/agent_loop/tests/`` has already imported and bound
+``AgentLoop`` / ``PreActionVerifier`` from the *previous* module objects.
+Those bindings survive the pop, but ``sys.modules`` no longer holds the module
+that owns them, so every later ``patch("agent_loop.loop._bus_publish_event")``
+and ``patch.object(_PAV, "HARD_BLOCK")`` re-imported a SECOND ``agent_loop.loop``
+from disk and patched that one.  The real module's globals stayed untouched:
+an inert patch that leaves the production code running unmocked while the test
+asserts against a mock nothing ever calls.  Three tests failed loudly on it
+(``test_finalize_task_emits_agent_abstained_event``,
+``test_belief_cache_hit_event_published``,
+``test_hard_block_prevents_approval_request``) and every other patch of an
+``agent_loop`` target in the same session was silently inert.  Same hazard
+``tests/agent_loop/conftest.py`` documents for this exact package (#13162).
+
+The root conftest already plants ``agent_loop`` with a REAL ``__path__``, so
+the light ``agent_loop.search`` submodules resolve from disk on their own; this
+file only has to replace entries that are still stubs.
 
 All fakes here keep tests fully offline (no real network).
 """
@@ -24,59 +48,107 @@ from typing import Any, Dict, List, Optional
 _BACKEND = Path(__file__).parent.parent.parent  # .../autobot-backend
 _SEARCH_DIR = _BACKEND / "agent_loop" / "search"
 
-_AGENT_LOOP_KEYS = [k for k in sys.modules if k == "agent_loop" or k.startswith("agent_loop.")]
-_SAVED: Dict[str, object] = {k: sys.modules[k] for k in _AGENT_LOOP_KEYS}
+# Only the entries this file actually replaces are saved — restoring keys we
+# never touched is what made the old save/pop/restore cycle destructive.
+_SAVED: Dict[str, object] = {}
+_ADDED: set = set()
+
+_SUBMODULES = [
+    "base",
+    "registry",
+    "searxng_provider",
+    "brave_provider",
+    "content_reach_provider",
+]
+
+
+def _bind_on_parent(full_name: str, mod: object) -> None:
+    """Bind *mod* as an attribute of its parent package.
+
+    Load-bearing for ``unittest.mock.patch``: it resolves ``"agent_loop.search.X"``
+    via ``getattr(sys.modules["agent_loop"], "search")``, NOT via
+    ``sys.modules["agent_loop.search"]``.  A module registered in ``sys.modules``
+    by hand never gets that bind from the import machinery.
+    """
+    parent, _, child = full_name.rpartition(".")
+    if parent and parent in sys.modules:
+        setattr(sys.modules[parent], child, mod)
 
 
 def _load_real(full_name: str, rel: str) -> None:
-    """Load a Python file directly and register it under *full_name*."""
+    """Register the REAL module for *full_name*, unless it already is real.
+
+    Re-executing a module that is already loaded from this same file builds a
+    second set of class objects while every importer keeps referencing the
+    first — the identity split #13551 traced.  An already-real entry is
+    therefore left alone and only (re)bound on its parent.
+    """
     path = _BACKEND / rel
+    existing = sys.modules.get(full_name)
+    if existing is not None and getattr(existing, "__file__", None) == str(path):
+        _bind_on_parent(full_name, existing)
+        return
     spec = importlib.util.spec_from_file_location(full_name, str(path))
     if not spec or not spec.loader:
         return
     mod = importlib.util.module_from_spec(spec)
     mod.__package__ = full_name.rpartition(".")[0] or full_name
+    if existing is None:
+        _ADDED.add(full_name)
+    else:
+        _SAVED.setdefault(full_name, existing)
     sys.modules[full_name] = mod
     spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    _bind_on_parent(full_name, mod)
 
 
-# Drop any stubs planted by the parent conftest.
-for _k in _AGENT_LOOP_KEYS:
-    sys.modules.pop(_k, None)
+def _ensure_package(full_name: str, path: Path) -> types.ModuleType:
+    """Return the session's package object for *full_name*, giving it a real ``__path__``.
 
-# Plant a real ``agent_loop`` package WITHOUT running its heavy __init__.
-_pkg = types.ModuleType("agent_loop")
-_pkg.__path__ = [str(_BACKEND / "agent_loop")]  # type: ignore[assignment]
-_pkg.__package__ = "agent_loop"
-sys.modules["agent_loop"] = _pkg
+    Reuses the existing ``sys.modules`` entry rather than planting a new one —
+    see the module docstring.
+    """
+    pkg = sys.modules.get(full_name)
+    if pkg is None:
+        pkg = types.ModuleType(full_name)
+        pkg.__package__ = full_name
+        sys.modules[full_name] = pkg
+        _ADDED.add(full_name)
+    pkg.__path__ = [str(path)]  # type: ignore[attr-defined]
+    _bind_on_parent(full_name, pkg)
+    return pkg
 
-# Plant the search sub-package and load its modules in dependency order.
-_search_pkg = types.ModuleType("agent_loop.search")
-_search_pkg.__path__ = [str(_SEARCH_DIR)]  # type: ignore[assignment]
-_search_pkg.__package__ = "agent_loop.search"
-sys.modules["agent_loop.search"] = _search_pkg
-_pkg.search = _search_pkg  # type: ignore[attr-defined]
 
-_load_real("agent_loop.search.base", "agent_loop/search/base.py")
-_load_real("agent_loop.search.registry", "agent_loop/search/registry.py")
-_load_real("agent_loop.search.searxng_provider", "agent_loop/search/searxng_provider.py")
-_load_real("agent_loop.search.brave_provider", "agent_loop/search/brave_provider.py")
-_load_real("agent_loop.search.content_reach_provider", "agent_loop/search/content_reach_provider.py")
+_ensure_package("agent_loop", _BACKEND / "agent_loop")
+_ensure_package("agent_loop.search", _SEARCH_DIR)
+
+# Load the search modules in dependency order; already-real entries are reused.
+for _submod in _SUBMODULES:
+    _load_real(f"agent_loop.search.{_submod}", f"agent_loop/search/{_submod}.py")
 _load_real("agent_loop.search", "agent_loop/search/__init__.py")
+
+# Executing ``__init__.py`` through a file spec yields a module with no
+# ``__path__``; restore it so ``from agent_loop.search.X import Y`` keeps
+# resolving from disk for anything imported after this point.
+_search_pkg = sys.modules["agent_loop.search"]
+_search_pkg.__path__ = [str(_SEARCH_DIR)]  # type: ignore[attr-defined]
 
 # Attach submodules as attributes on the package so unittest.mock.patch can
 # resolve them via getattr (patch walks the dotted path via attribute access).
-for _submod in ["base", "registry", "searxng_provider", "brave_provider", "content_reach_provider"]:
+for _submod in _SUBMODULES:
     _full = f"agent_loop.search.{_submod}"
     if _full in sys.modules:
         setattr(_search_pkg, _submod, sys.modules[_full])
 
 
 def pytest_unconfigure(config) -> None:  # noqa: ARG001
-    """Restore the original stub state so other directories are unaffected."""
-    for k in list(sys.modules):
-        if k == "agent_loop" or k.startswith("agent_loop."):
-            sys.modules.pop(k, None)
+    """Undo exactly what this file changed, and nothing else.
+
+    Sweeping every ``agent_loop*`` key out of ``sys.modules`` here would drop
+    submodules other collectors imported on their own during the session.
+    """
+    for k in _ADDED:
+        sys.modules.pop(k, None)
     for k, v in _SAVED.items():
         sys.modules[k] = v  # type: ignore[assignment]
 

--- a/repo_tests/sys_modules_leak_baseline.txt
+++ b/repo_tests/sys_modules_leak_baseline.txt
@@ -58,7 +58,6 @@ autobot-backend/knowledge/vector_search_engine_test.py
 autobot-backend/llm_shared/npu_pipeline_routing_test.py
 autobot-backend/tests/agents/test_causal_reasoning.py
 autobot-backend/tests/orchestration/test_causal_error_recovery.py
-autobot-backend/tests/search/conftest.py
 autobot-backend/tests/services/rag_service_events_test.py
 autobot-backend/tests/test_conftest_real_load_identity.py run-phase
 autobot-backend/tests/test_tool_schema_correction.py


### PR DESCRIPTION
## Thinking Path

Batch A of #13551 is three failing tests in three different files:

- `agent_loop/tests/test_abstention.py::test_finalize_task_emits_agent_abstained_event` — `Expected _bus_publish_event to have been awaited once. Awaited 0 times.`
- `agent_loop/tests/test_belief_cache.py::test_belief_cache_hit_event_published` — `assert 0 == 1`
- `agent_loop/tests/test_pre_action_verifier.py::TestLoopIntegration::test_hard_block_prevents_approval_request` — `Expected 'mock' to not have been called. Called 1 times.`

The umbrella flagged them as "plausibly one shared event-plumbing cause". They are one cause, but it is not event plumbing — it is package identity.

All three pass in isolation, and the whole `agent_loop/` tree passes on its own (159 passed). What the three actually share is not the event bus; it is that each one **patches a name that lives in the `agent_loop` package**:

```
patch("agent_loop.loop._bus_publish_event", ...)   # abstention, belief_cache
patch.object(_PAV, "HARD_BLOCK", True)             # pre_action_verifier
```

`autobot-backend/tests/search/conftest.py` popped **every** `agent_loop*` key out of `sys.modules` at conftest-import time and planted a brand-new `agent_loop` module:

```
for _k in _AGENT_LOOP_KEYS:
    sys.modules.pop(_k, None)
_pkg = types.ModuleType("agent_loop")
sys.modules["agent_loop"] = _pkg
```

That is harmless when this directory is named on the command line — pytest loads initial conftests before importing any test module, so everything binds against the new package and stays consistent. That is also why the three tests look green in every narrow local invocation. It is fatal in a full-suite run, the shape CI uses: pytest imports that conftest while **collecting** `autobot-backend/tests/search`, long after `autobot-backend/agent_loop/tests/` has already imported and bound `AgentLoop` and `PreActionVerifier` from the *previous* module objects.

Those bindings survive the pop. `sys.modules` no longer holds the module that owns them. So when the test finally runs, `mock.patch` walks the dotted path, finds no `loop` attribute on the freshly planted package, re-imports `agent_loop.loop` **from disk as a second module object**, and patches that copy. The real module's globals are never touched. The patch is inert: production code runs unmocked while the test asserts against a mock nothing will ever call.

That accounts for all three symptoms exactly, including the third one's shape. `_check_approvals` reads `HARD_BLOCK` through a deliberately late, function-local import:

```
from agent_loop.pre_action_verifier import HARD_BLOCK
if HARD_BLOCK:
    ...
```

With the identity split that import resolves the *second* module, whose `HARD_BLOCK` is the pristine `False`. The hard-block branch is skipped, the soft-block branch escalates to a human, and `_request_approval` is called once — precisely what CI reported, down to the `verifier_rationale` payload recorded in the call.

**Which was wrong, the product or the test: neither.** All three tests encode the correct expectation, and `agent_loop/loop.py` behaves correctly. The defect is in the test harness — one conftest destroying a package identity that other, already-collected tests depend on. That is why the fix is a conftest change, and why no assertion is touched.

The three red tests are not the important part. In the same session **every** patch of an `agent_loop` target was silently inert; three failed loudly and the rest asserted against unpatched production code and reported green. `agent_loop/tests/test_pre_action_verifier.py` already carries a long header documenting this exact hazard, and `tests/agent_loop/conftest.py` was already rewritten under #13162 to the non-destructive pattern. `tests/search/conftest.py` was the remaining offender, and the repo's own `sys.modules` leak guard had already listed it on `repo_tests/sys_modules_leak_baseline.txt` — a file whose header states it only ever shrinks and that fixing an owner means deleting its line.

## What Changed

**`autobot-backend/tests/search/conftest.py`** — rewritten to the non-destructive pattern `tests/agent_loop/conftest.py` already uses:

- Never pops `agent_loop*` keys and never plants a replacement package. `_ensure_package()` reuses the session's existing package object and only guarantees it has a real `__path__`.
- `_load_real()` leaves an entry alone when it is already the real module loaded from the same file, so no module is re-executed into a second set of objects.
- `_bind_on_parent()` binds each submodule as an attribute of its parent, because `mock.patch` resolves `"agent_loop.search.X"` by `getattr` walk, not by `sys.modules` lookup.
- `pytest_unconfigure` restores exactly the keys this file added or replaced, instead of sweeping every `agent_loop*` key — sweeping dropped submodules other collectors had imported on their own.
- Re-applies `__path__` after `agent_loop/search/__init__.py` is executed through a file spec, which otherwise yields a package with no `__path__`.
- The offline HTTP fakes (`FakeResponse`, `FakeHTTPClient`) are unchanged.

**`repo_tests/sys_modules_leak_baseline.txt`** — the `autobot-backend/tests/search/conftest.py` line is deleted. The guard requires it: a listed owner that a session exercises without seeing it leak fails the run.

No production file is modified. No assertion is weakened, no test skipped, no matcher broadened.

## Verification

Environment: `SLM_SECRET_KEY` / `SLM_ENCRYPTION_KEY` set to throwaway values. Local Python is 3.10, CI runs 3.14; the bug reproduces on both once the collection order matches, so it was diagnosed and fixed locally against the CI log for cross-checking.

### Reproducing the CI failure locally

The three tests pass in isolation and pass when `tests/search` is named on the command line, because pytest then loads that conftest before any test module imports. Reproducing CI needs the collection order CI actually has — `tests/search/conftest.py` imported *during* collection, after `agent_loop/tests/` is already bound.

Baseline, at the commit this branch forks from:

```
$ python3 -m pytest autobot-backend/agent_loop autobot-backend/tests -q \
    --continue-on-collection-errors \
    -m "not integration and not slow and not distributed and not performance"

FAILED autobot-backend/agent_loop/tests/test_abstention.py::test_finalize_task_emits_agent_abstained_event
FAILED autobot-backend/agent_loop/tests/test_belief_cache.py::test_belief_cache_hit_event_published
FAILED autobot-backend/agent_loop/tests/test_pre_action_verifier.py::TestLoopIntegration::test_hard_block_prevents_approval_request
FAILED autobot-backend/tests/test_injection_detection.py::TestPerformance::test_performance_on_large_context
FAILED autobot-backend/tests/unit/knowledge/connectors/test_gitlab_connector.py::test_gitea_fetch_issue_content
FAILED autobot-backend/tests/unit/knowledge/connectors/test_gitlab_connector.py::test_gitlab_detect_changes_full_sync
FAILED autobot-backend/tests/unit/knowledge/connectors/test_gitlab_connector.py::test_gitlab_fetch_issue_content
FAILED autobot-backend/tests/unit/knowledge/connectors/test_gitlab_connector.py::test_gitlab_fetch_mr_content
==== 8 failed, 6292 passed, 142 skipped, 157 warnings in 490.75s (0:08:10) =====
```

All three Batch A tests reproduce with the same assertion text CI reports. The other five are pre-existing and unrelated — see "Discovered, not fixed".

The failure mode is confirmed directly, not inferred. A probe comparing the module the test holds against the one live in `sys.modules` at run time shows the split:

```
held_modname            = agent_loop.loop
held class globals      = 133133924558656    <- module the test's AgentLoop came from
sys.modules[...loop]    = 98581787591648     <- module mock.patch re-imported and patched
```

### After the fix

Same three tests, same reproducing shape, narrowed for readability:

```
$ python3 -m pytest autobot-backend/agent_loop/tests autobot-backend/tests \
    <--ignore for every tests/ subdir except search> -q

autobot-backend/agent_loop/tests/test_abstention.py ...........          [ 11%]
autobot-backend/agent_loop/tests/test_belief_cache.py .................. [ 31%]
autobot-backend/agent_loop/tests/test_first_turn_priming.py ......       [ 38%]
autobot-backend/agent_loop/tests/test_pre_action_verifier.py ........... [ 50%]
..............                                                           [ 65%]
autobot-backend/tests/search/test_brave_provider.py ......               [ 71%]
autobot-backend/tests/search/test_content_reach_provider.py ..........   [ 82%]
autobot-backend/tests/search/test_registry.py .........                  [ 92%]
autobot-backend/tests/search/test_searxng_provider.py .......            [100%]

============================== 92 passed in 4.72s ==============================
```

The same invocation on base gives `3 failed, 89 passed`. All 32 `tests/search` tests the old conftest existed to support still pass.

### No regression — full failure-set comparison

The whole `autobot-backend/agent_loop/` + `autobot-backend/tests/` tree, run identically on base and on this branch, failure sets sorted and diffed:

```
$ diff base_fails.txt branch_fails.txt
1,3d0
< FAILED autobot-backend/agent_loop/tests/test_abstention.py::test_finalize_task_emits_agent_abstained_event
< FAILED autobot-backend/agent_loop/tests/test_belief_cache.py::test_belief_cache_hit_event_published
< FAILED autobot-backend/agent_loop/tests/test_pre_action_verifier.py::TestLoopIntegration::test_hard_block_prevents_approval_request
```

Base: `8 failed, 6292 passed, 142 skipped`. Branch: `5 failed, 6295 passed, 142 skipped`.

Exactly the three target tests move from red to green. Nothing else changes state in either direction — which also rules out the risk this fix carries, that a patch which had been silently inert becomes effective and exposes a test that was passing for the wrong reason.

The `agent_loop/` tree alone is green on both: `159 passed`.

### Leak guard

The guard no longer reports this conftest as an owner, which is what justifies deleting its baseline line. Base:

```
5 known leaking file(s), 10 sys.modules key(s) ...
      known: autobot-backend/tests/agents/test_causal_reasoning.py (1 key(s))
      known: autobot-backend/tests/orchestration/test_causal_error_recovery.py (3 key(s))
      known: autobot-backend/tests/search/conftest.py (4 key(s))
      known: autobot-backend/tests/services/rag_service_events_test.py (1 key(s))
      known: autobot-backend/tests/test_tool_schema_correction.py (1 key(s))
```

Branch:

```
4 known leaking file(s), 6 sys.modules key(s) ...
      known: autobot-backend/tests/agents/test_causal_reasoning.py (1 key(s))
      known: autobot-backend/tests/orchestration/test_causal_error_recovery.py (3 key(s))
      known: autobot-backend/tests/services/rag_service_events_test.py (1 key(s))
      known: autobot-backend/tests/test_tool_schema_correction.py (1 key(s))
```

`repo_tests` plus the identity guard that covers this class of bug and the orchestration tests that document the same hazard for this package:

```
$ python3 -m pytest repo_tests \
    autobot-backend/tests/test_conftest_real_load_identity.py \
    autobot-backend/tests/orchestration -q
======================= 506 passed, 2 warnings in 46.24s =======================
```

### Discovered, not fixed

Both are pre-existing on base, outside Batch A's scope, filed rather than folded in:

- **#13559** — `tests/unit/knowledge/connectors/test_gitlab_connector.py` patches `_load_ts` / `_store_ts` as module-level names on `knowledge.connectors.gitlab`, but they are base-class instance methods (13 `self._load_ts(...)` / `self._store_ts(...)` call sites). `mock.patch` raises rather than no-opping, so 4 tests error at `__enter__` and the incremental-sync checkpoint path they were written to cover has never actually run.
- **#13560** — `tests/test_injection_detection.py::TestPerformance::test_performance_on_large_context` asserts an absolute 250ms CPU budget, so it is red on any host slower than the reference box while staying green in CI. Also notes that `TestPerformance` is a class name, not a marker, so `-m "not performance"` does not deselect it.

Neither is one of the 13 singletons in #13551.

## Model Used

Claude Opus 4.6

Refs #13551
