### PR TITLE
test(suite): fix four of the five Batch B singleton failures (#13551)

### DIFF
--- a/autobot-backend/api/self_capabilities_integration_test.py
+++ b/autobot-backend/api/self_capabilities_integration_test.py
@@ -11,6 +11,7 @@ GET /api/capabilities endpoint is accessible and returns the expected structure.
 
 import pytest
 from fastapi import FastAPI
+from fastapi.openapi.utils import get_openapi
 from fastapi.testclient import TestClient
 
 from api.self_capabilities import router
@@ -164,12 +165,19 @@ def test_self_capabilities_unique_paths_count(client: TestClient):
 
 
 def test_self_capabilities_endpoint_registration(app: FastAPI):
-    """Verify that the router was properly registered with the app."""
-    # Check that the app has the capabilities route
-    routes = [route for route in app.routes if "/capabilities" in route.path]
-    assert len(routes) > 0, "Expected /api/capabilities route to be registered"
+    """Verify that the router was properly registered with the app.
 
-    # Verify the route method
-    assert any(
-        "GET" in str(route.methods) for route in routes if "/capabilities" in route.path
-    ), "Expected GET method on /api/capabilities"
+    Read the route table through ``get_openapi()`` rather than walking
+    ``app.routes`` directly (#13551). From fastapi>=0.139 ``include_router()``
+    no longer flattens its routes onto ``app.routes`` — it leaves a lazy
+    ``_IncludedRouter`` wrapper with no ``.path``, so the old walk raised
+    ``AttributeError`` on the pinned fastapi and, once guarded with
+    ``hasattr``, would have silently found nothing instead. ``get_openapi()``
+    is FastAPI's own supported view of the same table and is exactly what the
+    router under test uses, so it stays correct across versions.
+    """
+    schema = get_openapi(title=app.title, version=app.version, description=app.description or "", routes=app.routes)
+    paths = {path: item for path, item in schema.get("paths", {}).items() if "/capabilities" in path}
+    assert paths, f"Expected /api/capabilities route to be registered; got {sorted(schema.get('paths', {}))}"
+
+    assert any("get" in item for item in paths.values()), f"Expected GET method on /api/capabilities; got {paths}"

--- a/autobot-backend/system_integration_test.py
+++ b/autobot-backend/system_integration_test.py
@@ -265,7 +265,20 @@ class TestSystemPerformance:
         self.client = TestClient(self.app)
 
     def test_api_response_times(self):
-        """Test API response times are reasonable"""
+        """Test API response times are reasonable.
+
+        #13551: the first request into a freshly built app pays one-time costs
+        that have nothing to do with per-request latency — dependency graph
+        resolution, lazily imported handler modules, the first middleware pass.
+        Measured on a quiet dev box that first call takes ~0.30s against ~0.02s
+        for every later one; on a loaded CI runner it reached 1.22s and failed
+        this 1.0s budget. Timing the cold call measured start-up, not the API.
+
+        Warm each endpoint once and time the second call, so the budget applies
+        to the steady-state latency it was written for. The budget itself is
+        unchanged and the ~0.02s steady state leaves it two orders of magnitude
+        of headroom, so this stays a real assertion rather than a timing lottery.
+        """
         import time
 
         endpoints = [
@@ -276,15 +289,19 @@ class TestSystemPerformance:
         ]
 
         for endpoint in endpoints:
+            warmup = self.client.get(endpoint)
+            assert warmup.status_code == 200, f"Endpoint {endpoint} failed with {warmup.status_code}"
+
+        for endpoint in endpoints:
             start_time = time.time()
             response = self.client.get(endpoint)
             end_time = time.time()
 
             duration = end_time - start_time
 
+            assert response.status_code == 200, f"Endpoint {endpoint} failed with {response.status_code}"
             # API calls should be fast (under 1 second)
             assert duration < 1.0, f"Endpoint {endpoint} took {duration:.2f}s"
-            assert response.status_code == 200, f"Endpoint {endpoint} failed with {response.status_code}"
 
     def test_memory_usage_stability(self):
         """Test memory usage doesn't grow excessively"""

--- a/autobot-backend/tests/orchestration/test_causal_error_recovery.py
+++ b/autobot-backend/tests/orchestration/test_causal_error_recovery.py
@@ -83,6 +83,7 @@ from orchestration.causal_error_analyzer import (  # noqa: E402
 from orchestration.causal_error_recovery import (  # noqa: E402
     CausalErrorRecovery,
     RecoveryAction,
+    RecoveryAction_,
     RecoveryPlan,
 )
 from services.failure_pattern_detector import (  # noqa: E402
@@ -113,10 +114,26 @@ assert _CER.RecoveryPlan is RecoveryPlan and _CER.CausalErrorRecovery is CausalE
     "recovery system under test would be exercised through mocks."
 )
 
+# The real modules this file just imported, captured once so the fixture below can
+# re-install them (#13551). Teardown puts the conftest stubs back, and CI runs
+# pytest-xdist with ``--dist loadscope``: each CLASS in this file is its own scope
+# group, so one worker can run a class here, finalise the module fixture, run
+# something else, then run another class of this same file. On that second entry
+# the fixture used to set up with the stubs reinstalled — module-level names stayed
+# real (they are bound already), but any RUN-time
+# ``from orchestration.causal_error_recovery import …`` resolved against the stub
+# and handed the test a MagicMock. That is how a genuine ``RecoveryPlan`` ended up
+# holding mock ``recommended_actions`` and died inside the real ``to_dict()`` with
+# "asdict() should be called on dataclass instances".
+_REAL_MODULES: dict[str, object] = {name: sys.modules[name] for name in _CONFTEST_STUB_NAMES if name in sys.modules}
+
 
 @pytest.fixture(scope="module", autouse=True)
 def _restore_conftest_stubs():
-    """Restore the displaced parent-conftest stubs after this module's tests.
+    """Install the real modules for this module's tests, restore the stubs after.
+
+    Setup and teardown are symmetric so the fixture is re-entrant: see
+    ``_REAL_MODULES`` above for why re-entry happens under ``--dist loadscope``.
 
     #11796: the old teardown also popped every key our module-scope imports
     happened to add (``_KEYS_OUR_IMPORTS_ADDED``) — but this fixture tears
@@ -131,6 +148,8 @@ def _restore_conftest_stubs():
     sibling type-only orchestration tests patch by name; everything else
     stays as the run left it.
     """
+    for _name, _mod in _REAL_MODULES.items():
+        sys.modules[_name] = _mod  # type: ignore[assignment]
     yield
     for _name, _mod in _SAVED_STUBS.items():
         if _name.startswith("orchestration."):
@@ -669,8 +688,6 @@ class TestRecoverySystemSmoke:
     @pytest.mark.asyncio
     async def test_recovery_plan_serialization(self):
         """Test that recovery plans can be serialized/deserialized."""
-        from orchestration.causal_error_recovery import RecoveryAction_
-
         plan = RecoveryPlan(
             error_id="test_1",
             error_type="TimeoutError",

--- a/autobot_shared/openapi_schema.py
+++ b/autobot_shared/openapi_schema.py
@@ -29,7 +29,13 @@ def normalize_pattern_anchors(node: Any) -> Any:
 
         JS   /^(hour|day)\\z/.test("hour")  -> false     (the valid value fails)
         JS   /^(hour|day)\\z/.test("hourz") -> true      (an invalid value passes)
-        Py   re.match(r"^(hour|day)\\z", …) -> re.error: bad escape \\z
+        Py   re.match(r"^(hour|day)\\z", …) -> re.error  (3.10-3.12)
+        Py   re.match(r"^(hour|day)\\z", "hour\\n") -> None   (3.14; `$` matches)
+
+    Newer interpreters accept ``\\z`` as a synonym of ``\\Z``, so on those the
+    Python breakage turns silent rather than disappearing (#13551). This rewrite
+    is a string comparison and never compiles the pattern, so it is unaffected
+    by which interpreter runs it.
 
     So a spec carrying it silently inverts validation for every JS client and
     breaks every Python one. Field authors write ``$``; this restores what they

--- a/autobot_shared/tests/test_openapi_pattern_anchors.py
+++ b/autobot_shared/tests/test_openapi_pattern_anchors.py
@@ -8,10 +8,16 @@ author wrote with ``$``. JSON Schema's regex dialect is ECMA-262, which has no
 
     JS   /^(hour|day)\\z/.test("hour")  -> False   the valid value fails
     JS   /^(hour|day)\\z/.test("hourz") -> True    an invalid value passes
-    Py   re.match(r"^(hour|day)\\z", …) -> re.error: bad escape \\z
+    Py   re.match(r"^(hour|day)\\z", …) -> re.error: bad escape \\z   (3.10-3.12)
+    Py   re.match(r"^(hour|day)\\z", "hour\\n") -> None                (3.14)
 
-Both measured. Validation is inverted for every JS client and impossible for
-every Python one, from a spec that looks fine in review.
+All measured. Validation is inverted for every JS client and, on the
+interpreters that reject ``\\z``, impossible for every Python one — from a spec
+that looks fine in review. Newer interpreters accept ``\\z`` as a synonym of
+``\\Z``, so there the Python half stops raising and starts silently disagreeing
+with the ``$`` the author wrote instead; see
+``test_rust_anchor_is_genuinely_unusable_in_python``. The normalisation is
+required either way, and the guard that enforces it never compiles a pattern.
 
 Surfaced by `verify-generated-types-slm` failing on a PR that touched no schema:
 the committed spec had ``$`` and a fresh dump produced ``\\z``, so CI reported
@@ -121,9 +127,41 @@ def test_both_dump_paths_normalize():
 
 
 def test_rust_anchor_is_genuinely_unusable_in_python():
-    """Pins the premise, so nobody 'simplifies' this away as cosmetic."""
-    with pytest.raises(re.error):
-        re.compile("^(hour|day)\\z")
+    """Pins the premise, so nobody 'simplifies' this away as cosmetic.
+
+    The premise outlived the assertion that expressed it (#13551). This used to
+    require ``re.compile`` to raise, which was true when written and stopped
+    being true: newer interpreters accept ``\\z`` as a synonym of ``\\Z``
+    (measured here: 3.10, 3.11 and 3.12 raise; 3.14 compiles). The contract is
+    still broken on those interpreters, just silently — ``$`` also matches
+    before a trailing newline and ``\\z`` never does, so a value the schema
+    author meant to accept is rejected instead.
+
+    Asserted behaviourally rather than by version, because the exact boundary
+    cannot be pinned from the interpreters available here and a wrong constant
+    would re-break this the same way. Whichever branch the interpreter takes,
+    the statement is the same and always load-bearing: a Rust ``\\z`` anchor
+    never behaves like the ``$`` it replaced.
+
+    ``normalize_pattern_anchors`` itself is unaffected — it is a string-level
+    ``endswith`` rewrite that never compiles the pattern — and the guard that
+    actually keeps ``\\z`` out of the published spec is
+    ``test_committed_slm_spec_carries_no_rust_anchor``, which scans the
+    artifact directly. Neither depends on ``re`` rejecting anything.
+    """
+    try:
+        rust_anchored = re.compile("^(hour|day)\\z")
+    except re.error:
+        rust_anchored = None
+
+    intended = re.compile("^(hour|day)$")
+    assert intended.match("hour\n") is not None, "premise: the `$` the author wrote accepts a trailing newline"
+
+    assert rust_anchored is None or rust_anchored.match("hour\n") is None, (
+        "a Rust `\\z` anchor must never behave like the `$` it replaced: it either "
+        "fails to compile, or compiles and rejects a value `$` accepts. If it ever "
+        "matches identically, re-derive why this spec is normalised at all."
+    )
 
 
 def test_node_reads_the_rust_anchor_as_a_literal_z():


### PR DESCRIPTION
## Thinking Path

Batch B of #13551 — five failing tests in five unrelated subsystems. **Four are fixed here. The fifth is deferred, with the reason and the blocker filed.**

All five pass on Python 3.10 in isolation, so the baseline came from the CI log of the last base `ci.yml` run to complete without cancellation (all twelve `python-suite` shards confirmed `completed` before reading). Everything was then re-measured on a local Python 3.14.6 virtualenv built the same way `.github/actions/setup-python-suite` builds CI's — same interpreter, same dependency set (`fastapi 0.141.1`, `pydantic 2.13.4`) — so every claim below is reproduced locally rather than inferred from a log.

| # | test | root cause | verdict |
|---|---|---|---|
| 1 | `ssot_config_test::test_project_root_exists` | `.env` is git-ignored, so the marker walk finds nothing in a checkout and the root falls through to the packaged install location | **product bug — deferred, blocked by #13572** |
| 2 | `test_openapi_pattern_anchors::test_rust_anchor_is_genuinely_unusable_in_python` | newer interpreters accept `\z`; the assertion pinned an expectation the language later invalidated | test bug |
| 3 | `self_capabilities_integration_test::test_self_capabilities_endpoint_registration` | walks `app.routes` for `.path`; `fastapi>=0.139` leaves lazy `_IncludedRouter` wrappers there | test bug |
| 4 | `system_integration_test::test_api_response_times` | times the **first** request into a fresh app, so it measures start-up, not per-request latency | test bug |
| 5 | `test_causal_error_recovery::test_recovery_plan_serialization` | the module's stub-swap fixture restores stubs on teardown but never re-installs the real modules on setup, and it re-enters under `--dist loadscope` | **product bug (test harness)** |

### Why #1 is not in this PR

It is the same *family* as #13149 — root resolution defaulting to the live install — but **not one of the 60 `${AUTOBOT_PROJECT_ROOT:-…}` string literals** that issue enumerates, so its acceptance criterion (`git grep 'AUTOBOT_PROJECT_ROOT:-' -- '*.py'` returns 0) would never have caught it. `_find_project_root` walks upward for a `.env`; `.env` is git-ignored, so a fresh clone, a container build and every CI job find none and fall through to the packaged install location, which does not exist on a runner.

The fix is small and was implemented and verified on all three branches — then **reverted**, because it cannot land alone. Pushing it turned `verify-generated-types` red:

```
--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -73712,7 +73712,7 @@
-             * @default <packaged-install-root>
+             * @default <the CI runner's checkout path>
              repo_path: string;
```

**19 OpenAPI schema defaults are absolute paths derived from `PROJECT_ROOT`** and are published in the committed frontend contract. They look stable today only because the resolver is broken in a way that yields a constant. Correct the resolver and the contract starts carrying the generating machine's path; regenerating `api.ts` to make the gate green would have committed exactly that — green CI, worse artifact.

Fixing 19 contract defaults and regenerating the published frontend types is a different-risk change from a batch of test fixes, so it is **#13572** with full evidence and an ordering, rather than bundled here. Once that lands, the resolver fix closes this test and part of #13149 / #13357.

This is reported rather than worked around: `test_project_root_exists` stays red on this branch, and no assertion was relaxed to hide it.

### On #2 — the premise, and whether the guard it protects is still sound

Measured across every interpreter on this box:

```
py3.10: re.error: bad escape \z at position 11
py3.11: re.error: bad escape \z at position 11
py3.12: re.error: bad escape \z at position 11
py3.14: compiles; match "hour\n" -> None
```

So the expectation was correct when written and the language invalidated it — 3.14 accepts `\z` as a synonym of `\Z`. (No 3.13 available here, so the exact boundary is deliberately not asserted; see below.)

The important question is whether the **guard** silently broke, not just the test. It did not: `normalize_pattern_anchors` is a string-level `endswith` rewrite that never compiles a pattern, and the guard that keeps `\z` out of the published artifact is `test_committed_slm_spec_carries_no_rust_anchor`, which scans the committed spec directly. Both are interpreter-independent. `test_every_committed_pattern_compiles_as_a_python_regex` no longer catches `\z` on 3.14, but that was never its job — it catches *any* uncompilable pattern, and `\z` specifically is covered by the dedicated scan. Nothing needed repairing in the product; only the premise's expression.

The rewritten assertion is **behavioural, not version-gated**. A `sys.version_info >= (3, 14)` constant would be a guess (untestable here) and would re-break this the same way. Instead it asserts the invariant that holds on every interpreter: a Rust `\z` anchor never behaves like the `$` it replaced — it either fails to compile, or compiles and rejects a value `$` accepts. Both docstrings that stated the Python half as unconditional were corrected too, so the canonical explanation no longer misleads.

### On #4 — threshold or defect?

Defect in what the test measures, not in the API. Per-request wall clock on a quiet box:

```
round0 /api/security/status              0.302s   <-- first request into the app
round0 /api/security/pending-approvals   0.019s
round1 /api/security/status              0.020s
round2 /api/security/status              0.024s
```

The first call is ~15x every later one — dependency-graph resolution, lazily imported handler modules, first middleware pass. On a loaded runner it reached 1.22s. Steady state is ~0.02s, two orders of magnitude inside the 1.0s budget.

So this is **not** an unrealistic threshold and it was **not** reclassified as `performance`: it can be made deterministic by warming each endpoint once and timing the second call. The budget is untouched and now applies to the steady-state latency it was written for. The status-code assertion also moved ahead of the timing assertion, so a broken endpoint reports as broken rather than as slow.

## What Changed

**`autobot_shared/tests/test_openapi_pattern_anchors.py`** — the anchor premise is asserted behaviourally instead of by exception, with the measured per-version results recorded. Module docstring corrected.

**`autobot_shared/openapi_schema.py`** — docstring only: it stated the Python failure as unconditional `re.error`. No behaviour change; the rewrite is a string comparison.

**`autobot-backend/api/self_capabilities_integration_test.py`** — registration is read through `get_openapi(routes=app.routes)`, FastAPI's own supported view of the route table and exactly what the router under test uses, instead of walking `app.routes` for `.path`. Guarding the walk with `hasattr` was rejected: on the pinned FastAPI it would have found nothing and passed vacuously. Same conclusion `scripts/audit_api_wiring.py` already reached for websocket routes.

**`autobot-backend/system_integration_test.py`** — warm-up pass before the timed pass; assertion order corrected.

**`autobot-backend/tests/orchestration/test_causal_error_recovery.py`** — `_restore_conftest_stubs` is made symmetric: it now re-installs the real modules on setup, not only the stubs on teardown. `RecoveryAction_` is hoisted to the module-level import so it is bound at import time like every other symbol in the file.

## Verification

`SLM_SECRET_KEY` / `SLM_ENCRYPTION_KEY` set to throwaway values. Unless stated otherwise every run below uses the local Python 3.14.6 virtualenv that mirrors CI.

### Before — from the CI shard logs (all twelve shards `completed`)

```
FAILED autobot_shared/ssot_config_test.py::TestProjectRoot::test_project_root_exists
  E   AssertionError: assert False
  E    +  where exists = PosixPath('<packaged-install-root>').exists

FAILED autobot_shared/tests/test_openapi_pattern_anchors.py::test_rust_anchor_is_genuinely_unusable_in_python
  [gw1] linux -- Python 3.14.6
      with pytest.raises(re.error):
  E   Failed: DID NOT RAISE PatternError

FAILED autobot-backend/api/self_capabilities_integration_test.py::test_self_capabilities_endpoint_registration
  AttributeError: '_IncludedRouter' object has no attribute 'path'

FAILED autobot-backend/system_integration_test.py::TestSystemPerformance::test_api_response_times
  AssertionError: Endpoint /api/security/status took 1.22s

FAILED autobot-backend/tests/orchestration/test_causal_error_recovery.py::TestRecoverySystemSmoke::test_recovery_plan_serialization
  autobot-backend/orchestration/causal_error_recovery.py:101: in to_dict
      "recommended_actions": [asdict(a) for a in self.recommended_actions],
  E   TypeError: asdict() should be called on dataclass instances
```

### #3 — `_IncludedRouter` reproduced locally, not inferred

```
$ python -c "import fastapi; print(fastapi.__version__)"
0.141.1

$ python -c "<build the same app the fixture builds>"
app.routes types: ['Route', '_IncludedRouter']
routes with .path: 4
```

The old comprehension iterated *every* entry, including the wrapper — hence the `AttributeError`. Four routes are still reachable via `.path`, which is why an `hasattr` guard would have passed while silently checking the wrong set.

### #5 — deterministic reproduction, before and after, on 3.14

The fixture re-enters whenever a worker leaves this module and returns, which `--dist loadscope` makes routine because each class is its own scope group. Reproduced without xdist by ordering the node ids:

```
$ python -m pytest \
    ".../test_causal_error_recovery.py::TestCausalErrorRecovery" \
    ".../test_success_criteria.py" \
    ".../test_causal_error_recovery.py::TestRecoverySystemSmoke" -q

# base:
    "recommended_actions": [asdict(a) for a in self.recommended_actions],
/usr/lib/python3.14/dataclasses.py:1503: in asdict
    raise TypeError("asdict() should be called on dataclass instances")
1 failed, 28 passed, 5 warnings in 0.76s

# this branch:
29 passed, 5 warnings in 0.76s
```

That traceback matches the CI one line for line, including the `dataclasses.py:1503` frame.

### #1 — the deferred one, and why passing locally proves nothing

It passes on this box for a reason that is itself the bug (#13357):

```
worktree             : <this worktree>
PROJECT_ROOT         : <the main checkout, outside the worktree>
inside worktree?     : False
.env in worktree?    : False
.env at PROJECT_ROOT : True
```

The walk escapes the tree and finds a neighbouring checkout's `.env`. On a CI runner there is no `.env` anywhere above, so the same walk falls through to the packaged install location — which is what the CI traceback shows.

### After — the four fixed tests, on 3.14

```
$ python -m pytest autobot_shared/tests/test_openapi_pattern_anchors.py \
                   autobot_shared/ssot_config_test.py::TestProjectRoot -q
12 passed in 1.06s

$ python -m pytest autobot-backend/api/self_capabilities_integration_test.py \
                   autobot-backend/system_integration_test.py::TestSystemPerformance -q
12 passed, 2027 warnings in 47.56s
```

### No regression — full-package failure sets, base vs branch

Both trees run with CI's own invocation shape (`--dist loadscope`, `-m "not integration and not slow and not distributed and not performance"`), base measured in a separate pristine checkout of the merge target.

```
autobot_shared -- Python 3.14, CI dependency set
  base:   1 failed, 1434 passed, 11 errors in 52.82s
  branch:    1435 passed,          11 errors in 48.66s

  only on base:   test_openapi_pattern_anchors.py::test_rust_anchor_is_genuinely_unusable_in_python
  only on branch: (none)

  The 11 errors are identical on both trees and pre-existing.
```

```
autobot-backend -- Python 3.10, 18562 tests either way, identical totals
  base:   35 failed, 18527 passed, 2485 skipped, 2 xfailed, 4 errors in 1276s
  branch: 32 failed, 18530 passed, 2485 skipped, 2 xfailed, 4 errors in 1287s

  only on base (fixed here):
    tests/orchestration/test_causal_error_recovery.py::TestRecoverySystemSmoke::test_recovery_plan_serialization

  only on base (NOT touched by this branch -- see note):
    agents/agent_orchestration/rl_router_test.py::TestEpsilonGreedy::test_exploit_when_epsilon_is_zero
    services/slm_link_probe_test.py::TestProbe::test_probe_is_registered_under_a_known_name
    tests/content_reach/test_boot_wiring.py::test_health_import_registers_probe

  only on branch:
    llc/tests/test_human_claims.py::TestHumanUnclaim::test_unclaim_clears_fields_and_sets_ready
```

The four unrelated movements are `--dist loadscope` order sensitivity, not this branch. Three moved in the *pass* direction on a branch that touches nothing near them (`rl_router_test` is itself a known-failing Batch C item of #13551), which is only possible if the failure set shifts run to run. `test_human_claims` patches `llc.services.work_item_service.get_async_redis_client` by name — the module-identity-dependent patch this repo's conftest documents at length — and it passes in isolation on **both** trees:

```
$ python3 -m pytest autobot-backend/llc/tests/test_human_claims.py -q
branch: 9 passed in 1.72s
base:   9 passed in 1.22s
```

## Found, not fixed

- **#13572** (filed) — 19 OpenAPI schema defaults publish the generating machine's absolute paths into the committed frontend contract. Non-reproducible artifact plus disclosure of the server's filesystem layout. **Blocks item 1 above**; carries the measured fix (`default_factory` is omitted from JSON Schema while the runtime default is unchanged), the ordering, and a request for a gate.
- **#13558** (filed) — `POST /api/batch-jobs/load` is dead: it imports `fast_app_factory_fix`, which does not exist in the repo, and `_find_route_handler` walks `app.routes` for `.path` guarded by `hasattr`, so on the pinned `fastapi>=0.141.1` it silently reports every endpoint as not found. Same premise as item 3, but a production call site where the guard converts the crash into silence.
- **#13149** (commented) — `autobot-backend/pki/config.py` carries a second, duplicate `_find_project_root` with the same install-location fallback; belongs to that issue's Task 1 consolidation.
- **#13357** (commented) — the `.env` walk is still unbounded, so a worktree inherits the neighbouring checkout's `.env`, as measured above.

## Model Used

Claude Opus 4.6

Refs #13551
