### PR TITLE
fix(backend): repair threat analyzers, watch-folder ingest and three tests (#13551)

### DIFF
--- a/autobot-backend/agents/agent_orchestration/rl_router_test.py
+++ b/autobot-backend/agents/agent_orchestration/rl_router_test.py
@@ -155,6 +155,11 @@ class TestEpsilonGreedy:
 
         agents = ["chat", "code_generation", "research"]
         for _ in range(10):
+            # select_agent() ends with _decay_epsilon(), which floors epsilon at
+            # _EPSILON_MIN — so a single plant only holds for the first draw and
+            # the remaining nine ran with 5% exploration, failing ~21% of runs
+            # (#13551). Re-plant so every draw exercises the greedy path.
+            store[_KEY("rl:router:epsilon")] = b"0.0"
             agent_id, _, _ = await router.select_agent("write code", agents)
             assert agent_id == "code_generation"
 

--- a/autobot-backend/knowledge/connectors/connector_resilience_test.py
+++ b/autobot-backend/knowledge/connectors/connector_resilience_test.py
@@ -441,7 +441,14 @@ class TestWebCrawlerSyncCheckpoint:
 
     @pytest.mark.asyncio
     async def test_crawled_seeds_written_to_checkpoint(self):
-        """Each successfully crawled seed must be written to checkpoint."""
+        """Each successfully crawled seed must be written to checkpoint.
+
+        #12843 made checkpointing derive from the crawl *results*, not from the
+        pending-seed list, so a seed the crawl never fetched is deliberately not
+        checkpointed. The fake below therefore returns a fetch result per seed —
+        the shape of a backend that finished them. Returning nothing at all (as
+        this test used to) now correctly checkpoints nothing (#13551).
+        """
         from knowledge.connectors.web_crawler import _url_to_source_id
 
         seed_a = "https://a.example.com"
@@ -452,7 +459,7 @@ class TestWebCrawlerSyncCheckpoint:
         self.conn._clear_checkpoint = AsyncMock()
 
         async def _fake_crawl(**kwargs):
-            return []
+            return [MagicMock(url=url, content="", metadata={}) for url in kwargs.get("seed_urls", [])]
 
         self.conn.crawl = _fake_crawl
 
@@ -461,6 +468,42 @@ class TestWebCrawlerSyncCheckpoint:
         checkpointed = {call.args[0] for call in self.conn._write_checkpoint.call_args_list}
         assert _url_to_source_id(seed_a) in checkpointed
         assert _url_to_source_id(seed_b) in checkpointed
+
+    @pytest.mark.asyncio
+    async def test_unfetched_seeds_are_not_checkpointed(self):
+        """A seed with no fetch result must NOT be checkpointed (#12843).
+
+        crawl() stops dispatching once max_pages is exhausted; checkpointing a
+        seed it never reached would mark it done and make the next incremental
+        sync skip it permanently.
+
+        Two files pin this one contract: #12843 also added
+        tests/unit/knowledge/connectors/test_web_crawler.py::TestSync::
+        test_sync_only_checkpoints_crawled_seeds, which drives the same
+        guarantee through _crawl_seed and a max_pages budget.
+        This one covers it from the sync()/crawl() boundary these
+        TestWebCrawlerSyncCheckpoint cases share. Change both together.
+        """
+        from knowledge.connectors.web_crawler import _url_to_source_id
+
+        seed_a = "https://a.example.com"
+        seed_b = "https://b.example.com"
+
+        self.conn._read_checkpoint = AsyncMock(return_value=set())
+        self.conn._write_checkpoint = AsyncMock()
+        self.conn._clear_checkpoint = AsyncMock()
+
+        async def _fake_crawl(**kwargs):
+            # Budget exhausted after the first seed.
+            return [MagicMock(url=seed_a, content="", metadata={})]
+
+        self.conn.crawl = _fake_crawl
+
+        await self.conn.sync(incremental=True)
+
+        checkpointed = {call.args[0] for call in self.conn._write_checkpoint.call_args_list}
+        assert _url_to_source_id(seed_a) in checkpointed
+        assert _url_to_source_id(seed_b) not in checkpointed
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/knowledge/kb_optimization_test.py
+++ b/autobot-backend/knowledge/kb_optimization_test.py
@@ -11,6 +11,8 @@ import os
 import sys
 import time
 
+import pytest
+
 from autobot_shared.ssot_config import config
 
 # Add AutoBot to path
@@ -68,14 +70,29 @@ The architecture supports distributed deployment scenarios where multiple AutoBo
 """
 
 
+@pytest.mark.integration
 async def test_knowledge_base_optimization():
-    """Test knowledge base with GPU optimization."""
+    """Test knowledge base with GPU optimization.
+
+    Requires a fully initialised KnowledgeBase (Redis 'knowledge' database plus
+    ChromaDB): without one, get_knowledge_base() raises RuntimeError. It cannot
+    run on the PR unit gate, where no such stack exists, so it is marked
+    integration (#13551).
+
+    Be clear about where that puts it: marker-tests.yml owns the excluded
+    markers, but its cron is commented out — "SCHEDULE INTENTIONALLY WITHHELD
+    UNTIL THE SUITE IS GREEN (#13286)" — leaving workflow_dispatch as the only
+    live trigger. So this test now runs on manual dispatch and nowhere else,
+    until #13286 turns the schedule on. Coverage loss is nil regardless: the
+    body contains no assertions at all, so it could only ever fail on
+    infrastructure, never on a regression. It is listed on #13286's triage.
+    """
     print("🧪 Testing AutoBot Knowledge Base with GPU Optimization")  # noqa: print
     print("=" * 60)  # noqa: print
 
     # Initialize knowledge base
     print("📚 Initializing knowledge base...")  # noqa: print
-    kb = get_knowledge_base()
+    kb = await get_knowledge_base()
 
     # Check if GPU optimization is active
     print("\n🔍 Checking optimization status...")  # noqa: print

--- a/autobot-backend/security/enterprise/threat_detection/analyzers/api_abuse.py
+++ b/autobot-backend/security/enterprise/threat_detection/analyzers/api_abuse.py
@@ -55,7 +55,9 @@ class APIAbuseAnalyzer(ThreatAnalyzer):
         """
         confidence = min(1.0, len(threats) * 0.4 + 0.3)
         threat_level = ThreatLevel.HIGH if "bulk_data_download" in threats else ThreatLevel.MEDIUM
-        base_fields = event.get_threat_base_fields()
+        # Overrides go through get_threat_base_fields so the key appears once
+        # in the ThreatEvent call (#13551).
+        base_fields = event.get_threat_base_fields(action="api_request")
 
         return ThreatEvent(
             event_id=event.generate_threat_id("api_abuse"),
@@ -63,7 +65,6 @@ class APIAbuseAnalyzer(ThreatAnalyzer):
             threat_category=ThreatCategory.API_ABUSE,
             threat_level=threat_level,
             confidence_score=confidence,
-            action="api_request",
             details={
                 "abuse_patterns": threats,
                 "request_rate": recent_requests,

--- a/autobot-backend/security/enterprise/threat_detection/analyzers/brute_force.py
+++ b/autobot-backend/security/enterprise/threat_detection/analyzers/brute_force.py
@@ -32,7 +32,9 @@ class BruteForceAnalyzer(ThreatAnalyzer):
             confidence = min(1.0, recent_failures / threshold)
 
             # Issue #372: Use SecurityEvent methods to reduce feature envy
-            base_fields = event.get_threat_base_fields()
+            # Overrides go through get_threat_base_fields so the key appears once
+            # in the ThreatEvent call (#13551).
+            base_fields = event.get_threat_base_fields(action="authentication", resource="login")
 
             return ThreatEvent(
                 event_id=event.generate_threat_id("brute_force"),
@@ -40,8 +42,6 @@ class BruteForceAnalyzer(ThreatAnalyzer):
                 threat_category=ThreatCategory.BRUTE_FORCE,
                 threat_level=ThreatLevel.HIGH,
                 confidence_score=confidence,
-                action="authentication",  # Override base action
-                resource="login",  # Override base resource
                 details={
                     "failed_attempts": recent_failures,
                     "time_window_minutes": window_minutes,

--- a/autobot-backend/security/enterprise/threat_detection/analyzers/malicious_file.py
+++ b/autobot-backend/security/enterprise/threat_detection/analyzers/malicious_file.py
@@ -91,7 +91,9 @@ class MaliciousFileAnalyzer(ThreatAnalyzer):
         threat_level = ThreatLevel.CRITICAL if any("malicious_content" in t for t in threats) else ThreatLevel.HIGH
 
         # Issue #372: Use SecurityEvent methods to reduce feature envy
-        base_fields = event.get_threat_base_fields()
+        # Overrides go through get_threat_base_fields so the key appears once
+        # in the ThreatEvent call (#13551).
+        base_fields = event.get_threat_base_fields(resource=filename)
 
         return ThreatEvent(
             event_id=event.generate_threat_id("malicious_file"),
@@ -99,7 +101,6 @@ class MaliciousFileAnalyzer(ThreatAnalyzer):
             threat_category=ThreatCategory.MALICIOUS_UPLOAD,
             threat_level=threat_level,
             confidence_score=confidence,
-            resource=filename,  # Override base resource
             details={
                 "detected_threats": threats,
                 "filename": filename,

--- a/autobot-backend/security/enterprise/threat_detection/engine.py
+++ b/autobot-backend/security/enterprise/threat_detection/engine.py
@@ -47,6 +47,7 @@ from .models import (
     ThreatEvent,
     UserProfile,
 )
+from .types import SEVERITY_PRIORITY
 
 logger = get_logger(__name__)
 
@@ -417,9 +418,13 @@ class ThreatDetectionEngine:
 
     async def _process_detected_threat(self, detected_threats: List[ThreatEvent]) -> ThreatEvent:
         """Process detected threats and update statistics. Issue #620."""
+        # #13551: ThreatLevel values are plain strings with no ordering, so
+        # ranking on `.value` compared them alphabetically — "medium" > "high" >
+        # "critical" — and a MEDIUM anomaly outranked a CRITICAL injection.
+        # SEVERITY_PRIORITY (#315) is the canonical severity ordering.
         primary_threat = max(
             detected_threats,
-            key=lambda t: (t.threat_level.value, t.confidence_score),
+            key=lambda t: (SEVERITY_PRIORITY.get(t.threat_level.value, 0), t.confidence_score),
         )
 
         self.stats["threats_detected"] += 1

--- a/autobot-backend/security/enterprise/threat_detection/models.py
+++ b/autobot-backend/security/enterprise/threat_detection/models.py
@@ -111,12 +111,20 @@ class SecurityEvent:
 
     # === Issue #372: Feature Envy Reduction Methods ===
 
-    def get_threat_base_fields(self) -> Dict:
+    def get_threat_base_fields(self, **overrides) -> Dict:
         """Get base fields for ThreatEvent creation (Issue #372 - reduces feature envy).
 
         Returns dict with common fields needed when creating a ThreatEvent from this event.
+
+        Args:
+            **overrides: Field values that replace the event-derived defaults.
+                Analyzers that need a fixed ``action``/``resource`` must pass it
+                here rather than as a second keyword to ``ThreatEvent(...)``:
+                splatting this dict AND repeating the key raised
+                ``TypeError: got multiple values for keyword argument`` at the
+                exact moment a threat was detected (#13551).
         """
-        return {
+        fields = {
             "timestamp": self.timestamp,
             "user_id": self.user_id,
             "source_ip": self.source_ip,
@@ -124,6 +132,8 @@ class SecurityEvent:
             "resource": self.resource,
             "raw_event": self.raw_event,
         }
+        fields.update(overrides)
+        return fields
 
     def generate_threat_id(self, prefix: str) -> str:
         """Generate a unique threat ID based on this event (Issue #372 - reduces feature envy)."""

--- a/autobot-backend/services/kb_folder_watcher.py
+++ b/autobot-backend/services/kb_folder_watcher.py
@@ -449,7 +449,12 @@ class KBFolderWatcherService:
             # Ingest into KB
             from knowledge_base import get_knowledge_base
 
-            kb = get_knowledge_base()
+            # get_knowledge_base is a coroutine function. Calling it without
+            # await produced a coroutine, so every ingest raised
+            # AttributeError: 'coroutine' object has no attribute 'add_fact'
+            # into the handler below — watch-folder ingestion never once
+            # succeeded, it only incremented the error counter (#13551).
+            kb = await get_knowledge_base()
             await kb.add_fact(
                 content=content,
                 category=config.category,

--- a/autobot-backend/services/slm_client_test.py
+++ b/autobot-backend/services/slm_client_test.py
@@ -143,6 +143,11 @@ class TestCreatePermissiveSslContext:
         assert ctx.verify_mode != ssl.CERT_NONE
 
 
+# Placeholder operator token for WS tests. _ws_connect_and_listen only checks
+# that a token exists before connecting, so the value is never validated.
+_WS_TOKEN_PLACEHOLDER = "placeholder-not-a-credential"  # nosec B105  # test fixture, never validated
+
+
 class TestSLMClientReconnectBackoff:
     """Tests for exponential backoff in the WebSocket reconnect loop (#4664)."""
 
@@ -235,6 +240,13 @@ class TestSLMClientReconnectBackoff:
     async def test_ssl_error_logged_not_raised(self) -> None:
         """SSL errors are caught and logged, not re-raised from _ws_connect_and_listen."""
         client = self._make_client()
+        # An explicit token keeps the test hermetic. Without one,
+        # _ws_connect_and_listen falls back to _get_slm_signing_secret(), which
+        # reads ambient deployment config: on a host with a populated .env it
+        # proceeded to websockets.connect, but on a bare CI runner it logged a
+        # warning and returned before reaching the code under test, so the
+        # assertion below failed for a reason unrelated to SSL handling (#13551).
+        client.auth_token = _WS_TOKEN_PLACEHOLDER
         client._shutdown = True  # Don't loop
 
         ssl_error = ssl.SSLCertVerificationError("CERTIFICATE_VERIFY_FAILED")


### PR DESCRIPTION
## Thinking Path

Batch C of #13551 is five failures in five different subsystems. All five pass or
skip in isolation on the dev box (Python 3.10), so the baseline came from the
CI shard logs of the last uncancelled base `ci.yml` run — all twelve
`python-suite` shards confirmed `completed` before their logs were read.

Reading the real tracebacks rather than the test names changed the picture: the
failing assertion was the symptom in only one of the five. Four were product
defects, two of them in security-relevant code.

The brute-force failure deserves the sharpest statement. The traceback does not
land in the backward-compatibility shim; it lands in
`analyzers/brute_force.py:37`, inside `ThreatEvent(...)`. The analyzer raises
`TypeError` at the exact moment it decides an attack is happening. Detection
itself was broken, not the shim. Chasing that further found two more analyzers
with the identical defect and a fourth, independent defect in how the engine
picks which detected threat to act on.

`#13551`'s two knowledge items were checked for collision with the session that
owns the knowledge cluster: no other branch touches either file, and neither
change reaches shared knowledge infrastructure.

## What Changed

**Product — threat detection (security).**

`SecurityEvent.get_threat_base_fields()` returns a dict that already contains
`action` and `resource`. Three of the six analyzers splatted that dict *and*
passed `action=` / `resource=` again to override it:

- `brute_force.py` — both keys
- `api_abuse.py` — `action`
- `malicious_file.py` — `resource`

Every one raised `TypeError: ThreatEvent() got multiple values for keyword
argument` the moment its threshold was crossed. `_run_analyzers` does not catch
analyzer exceptions, so the error propagated out of `analyze_event` to the
caller. Brute-force, API-abuse and malicious-upload detection could not produce
a finding at all. Overrides now pass through `get_threat_base_fields(**overrides)`
so each key appears exactly once.

Only the brute-force path had a test. The other two were never covered — filed
as a follow-up.

**Product — threat severity ranking (security).**

`_process_detected_threat` selected the primary threat with
`key=lambda t: (t.threat_level.value, t.confidence_score)`. `ThreatLevel` is a
plain `Enum` of unordered strings, so `max` compared them alphabetically:
`medium > low > high > critical`. A MEDIUM behavioural anomaly outranked a
CRITICAL command injection, and the response actions executed against the wrong
threat. `SEVERITY_PRIORITY` — the canonical severity ordering added in #315 —
already existed in the same package and was simply not used here. It is now.

This is what still failed the brute-force test after the `TypeError` was fixed:
by the sixth failed login a behavioural profile exists, so BEHAVIORAL_ANOMALY
(MEDIUM) and BRUTE_FORCE (HIGH) both fire, and the alphabetical key returned the
MEDIUM one.

**Product — knowledge-base folder ingestion.**

`services/kb_folder_watcher.py` called the coroutine function
`get_knowledge_base()` without `await`, then `await kb.add_fact(...)` on the
coroutine. Every ingest raised `AttributeError` into the surrounding handler,
which logged it and incremented the folder's error counter. Watch-folder
ingestion has never succeeded. A sweep of every importer of the async factory
found this to be the only production call site missing the `await`.

**Tests.**

- `rl_router_test.py` — `test_exploit_when_epsilon_is_zero` planted
  `epsilon=0.0` once, but `select_agent` ends in `_decay_epsilon()`, which
  floors epsilon at `_EPSILON_MIN` (0.05). Only the first of ten draws ran
  greedily; the rest carried a 5% exploration chance each. Re-planting before
  every draw. All ten assertions kept, none weakened.
- `slm_client_test.py` — `test_ssl_error_logged_not_raised` constructed a client
  with no `auth_token`, so `_ws_connect_and_listen` fell through to
  `_get_slm_signing_secret()`, which reads ambient deployment config. Where that
  config is populated the test reached the SSL path; on a bare runner the method
  logged a warning and returned before `websockets.connect` was ever called. The
  test now supplies a token. The product is correct here and unchanged: the SSL
  error is caught, logged at ERROR, and not re-raised.
- `connector_resilience_test.py` — `test_crawled_seeds_written_to_checkpoint`
  predates #12843, which deliberately made checkpointing derive from crawl
  *results* instead of the pending-seed list, because seeds beyond the
  `max_pages` budget are never fetched and checkpointing them drops them
  permanently. The test's fake crawl returned no results, so under the current
  (correct) contract nothing should be checkpointed. The fake now returns a
  result per seed. A new test, `test_unfetched_seeds_are_not_checkpointed`, pins
  the #12843 direction so the old expectation cannot creep back.
- `kb_optimization_test.py` — two problems. The missing `await` on
  `get_knowledge_base()` is the reported symptom, and it is fixed. But the test
  also needs a live Redis `knowledge` database and ChromaDB, which the PR unit
  gate does not provide; with the `await` in place it fails with
  `RuntimeError: Failed to initialize knowledge base` instead. It is marked
  `integration`.

  **Being precise about where that leaves it,** because an earlier revision of
  this PR overstated it: the `integration` marker hands the test to
  `marker-tests.yml`, but that workflow's cron is commented out — *"SCHEDULE
  INTENTIONALLY WITHHELD UNTIL THE SUITE IS GREEN (#13286)"* — leaving
  `workflow_dispatch` as its only live trigger, and #13286 (*"Marker-excluded
  tests run in no workflow at all"*) is still open. So this test now runs on
  manual dispatch and nowhere else until #13286 lands. It is added to that
  issue's triage list so it is not lost.

  The marker is still the right call, on two grounds that do not depend on the
  schedule. It cannot be made hermetic — `get_knowledge_base` raises without a
  live Redis `knowledge` database. And the coverage delta is exactly zero: the
  body contains **no assertions at all**, it prints and returns a dict, so it
  could only ever have failed on infrastructure, never on a regression. Leaving
  it on the unit gate buys a permanent red, not a signal.

## Verification

Environment: `SLM_SECRET_KEY` / `SLM_ENCRYPTION_KEY` set to throwaway values.

**Baseline, from the CI shard logs** (all twelve shards `completed`):

```
FAILED .../rl_router_test.py::TestEpsilonGreedy::test_exploit_when_epsilon_is_zero
  - AssertionError: assert 'chat' == 'code_generation'
FAILED .../threat_detection_refactor_test.py::...::test_engine_brute_force_detection
  - TypeError: ...ThreatEvent() got multiple values for keyword argument 'action'
FAILED .../slm_client_test.py::TestSLMClientReconnectBackoff::test_ssl_error_logged_not_raised
  - AssertionError: assert False
FAILED .../connector_resilience_test.py::...::test_crawled_seeds_written_to_checkpoint
  - AssertionError: assert '93d446a9...' in set()
FAILED .../kb_optimization_test.py::test_knowledge_base_optimization
  - AttributeError: 'coroutine' object has no attribute 'get_stats'
```

**Re-verified on Python 3.14**, on the CI-parity venv from #13574 — which has
`scikit-learn`, so the threat-detection module actually runs rather than
skipping. Base checkout, the four tests that reproduce off-CI:

```
E   TypeError: ...ThreatEvent() got multiple values for keyword argument 'action'
E   AssertionError: assert '93d446a9d8ca42b500faf019713f245e' in set()
E   AttributeError: 'coroutine' object has no attribute 'get_stats'
3 failed, 1 passed in 1.67s
```

Same four on this branch:

```
threat_detection_refactor_test.py::...::test_engine_brute_force_detection PASSED
rl_router_test.py::TestEpsilonGreedy::test_exploit_when_epsilon_is_zero      PASSED
slm_client_test.py::...::test_ssl_error_logged_not_raised                   PASSED
connector_resilience_test.py::...::test_crawled_seeds_written_to_checkpoint  PASSED
4 passed in 1.85s
```

All five files together on 3.14: `121 passed, 1 deselected in 6.10s`.

(The SSL test passes on base here because this box has a populated ambient
config — the whole point of that fix. The env-blanked reproduction below is what
matches a bare runner.)

**Threat detection under Python 3.10.** `scikit-learn` is absent from the 3.10
interpreter, so `threat_detection_refactor_test.py` skips there. The engine was
driven directly with the sklearn symbols stubbed, reproducing the test's event
sequence — this is what isolated the second defect:

Before — `TypeError: ThreatEvent() got multiple values for keyword argument 'action'`.

After the duplicate-keyword fix but before the ordering fix:

```
BRUTE FORCE: ThreatCategory.BEHAVIORAL_ANOMALY | action= authentication | resource= login
```

After both fixes:

```
BRUTE FORCE: ThreatCategory.BRUTE_FORCE | level= ThreatLevel.HIGH | action= authentication | resource= login
API ABUSE: ThreatCategory.API_ABUSE | action= api_request
MALICIOUS FILE: ThreatCategory.MALICIOUS_UPLOAD | resource= evil.exe
```

**rl_router flake rate**, 200 and 500 in-process repetitions of the test body:

```
before: failures: 42/200 = 21.0%
after:  AFTER FIX failures: 0/500
```

**SSL path**, with the signing secret blanked to match a bare runner:

```
signing secret resolves to: None
PRE-FIX  logger.error.called = False | logger.warning.called = True
POST-FIX logger.error.called = True | call = call('Unexpected WebSocket error: %s', SSLCertVerificationError('CERTIFICATE_VERIFY_FAILED'))
```

**The five files together**, under the PR gate's marker expression:

```
92 passed, 1 skipped, 1 deselected in 42.46s
```

(1 skipped = the sklearn-gated threat-detection module; 1 deselected = the
newly-`integration` KB benchmark.)

**Regression check.** Full failure sets for every package touched —
`autobot-backend/security`, `autobot-backend/services`,
`autobot-backend/agents/agent_orchestration`,
`autobot-backend/knowledge/connectors` and the KB benchmark — compared between a
clean checkout of the base branch and this branch under the PR gate's marker
expression:

On Python 3.14 (CI parity):

```
base:   12 failed, 2869 passed, 20 skipped, 36 deselected, 2 xfailed in 147.15s
branch:  9 failed, 2872 passed, 20 skipped, 37 deselected, 2 xfailed in 138.93s
```

The failure sets differ by exactly three entries, all removals, no additions:

```
- FAILED .../connector_resilience_test.py::TestWebCrawlerSyncCheckpoint::test_crawled_seeds_written_to_checkpoint
- FAILED .../kb_optimization_test.py::test_knowledge_base_optimization
- FAILED .../threat_detection_refactor_test.py::...::test_engine_brute_force_detection
```

No test that passed on base fails on this branch. The `+3 passed` accounts for
the repaired brute-force test, the repaired checkpoint test, and the new
`test_unfetched_seeds_are_not_checkpointed`; the `+1 deselected` is the KB
benchmark moving to the `integration` set. The remaining 9 failures are
pre-existing and untouched by this change.

The same comparison on Python 3.10 gives the same verdict with one fewer
removal (`11 failed → 9 failed`, +2 passed) because the threat-detection module
skips there for want of `scikit-learn`, plus one collection `error` identical on
both sides (`test_learner.py` needs `cachetools`, absent from the 3.10
interpreter and present in CI).

## Model Used

Claude Opus 5 (1M context)

---

Refs #13551
