### PR TITLE
fix(ansible): give the database role a builtin update route (#13535)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
+++ b/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
@@ -1532,6 +1532,128 @@
         msg: "{{ inventory_hostname }} updated"
 
 # =============================================================================
+# PLAY 2b: Update Database Nodes
+# =============================================================================
+# #13535: the database role had NO builtin update route. Play 2 targets the
+# `infrastructure` group, and `database` is not one of its children — so nothing
+# code-sync / self-update ran ever touched a database host, and roles/redis had
+# no code-only task file for a play to apply even if it had. That is why the
+# #12513 chroma-auth work merged in #13462/#13537 "looked deployed" while the
+# host was unchanged: the #12959 failure shape, one role further along.
+#
+# A separate play rather than adding `database` to the `infrastructure` group:
+# that group is Play 2's host list, and Play 2 is a backend/frontend/worker
+# update — package installs, npm builds, alembic migrations, a backend .env
+# regeneration. None of it is designed for a database node, and all of it is
+# guarded by `'<component>' in group_names` checks a database node would skip
+# anyway. Targeting `database` directly runs the one thing that node needs and
+# nothing else.
+#
+# Placed AFTER Play 2, deliberately. Play 2 regenerates backend.env with the
+# chroma CLIENT token and restarts the backend; this play then switches the
+# chroma SERVER to enforcing. The reverse order would enable server-side auth
+# while the backend still ran without the credential — every RAG call 401s for
+# the length of Play 2. Same ordering the ai-stack chroma unit already follows
+# inside Play 2 (backend tasks first, ai-stack code_only last).
+- name: "Play 2b - Update Database Nodes"
+  hosts: database
+  gather_facts: false
+  # Consistent with Play 2: a database node that fails to take the update must
+  # stop the rollout rather than leave the fleet diverged (#10026).
+  any_errors_fatal: true
+
+  tasks:
+    - name: "[PLAY 2b] Starting Database Node Update"
+      ansible.builtin.debug:
+        msg:
+          - "======================================================="
+          - "  PLAY 2b: Database Node Update (role-owned files)"
+          - "======================================================="
+          - "  Target: {{ inventory_hostname }}"
+
+    # Applies the role's code_only task file — the systemd override, the backup
+    # script and the ChromaDB credential file + unit — NEVER the full role,
+    # whose provisioning half (the redis-stack package, service accounts, the
+    # data directory and its recursive chown, the chroma venv and its package
+    # installs) must not re-run on an already-installed box.
+    #
+    # `apply: {become: true}` because this play sets no play-level become, and a
+    # bare `become` on include_role makes ansible reject the WHOLE playbook
+    # ("'become' is not a valid attribute for a IncludeRole"), breaking every
+    # self-update rather than just the task (#12886).
+    - name: "[PLAY 2b] Database | Deploy role-owned service files (#13535)"
+      ansible.builtin.include_role:
+        name: redis
+        tasks_from: code_only
+        apply:
+          become: true
+      tags: [database, redis, chromadb, deploy]
+
+    # Flush here rather than letting the handlers fall to the end of the play.
+    # #12886 recorded both halves of why that matters: queued handlers are
+    # DISCARDED when a later task aborts the play, and a handler that never ran
+    # leaves a host holding a new credential file that nothing has read yet.
+    # Flushing immediately after the only task that notifies makes the restart
+    # part of the delivery instead of a hope, and keeps it before the assertions
+    # below — which check the running unit, not the file on disk.
+    - name: "[PLAY 2b] Database | Apply pending restarts before verifying (#13535)"
+      ansible.builtin.meta: flush_handlers
+
+    # =========================================================================
+    # #12959 post-update delivery assertion.
+    #
+    # The expensive part of #13462 was not the missing fix — it was that the
+    # update REPORTED SUCCESS while delivering nothing, so the chroma-auth work
+    # was closed against a mechanism that could not deliver it and the symptom
+    # was re-diagnosed later. This asserts an invariant the include above just
+    # guaranteed, so a failure means delivery silently regressed.
+    #
+    # `executable: /bin/bash` is load-bearing (#12907): ansible.builtin.shell
+    # runs under /bin/sh, which is dash on these hosts, and dash aborts on
+    # `set -o pipefail` before the first echo — leaving the evidence empty and
+    # every assertion gated on it silently skipped.
+    # =========================================================================
+    - name: "[PLAY 2b] Verify | Collect ChromaDB delivery evidence (#12513, #13535)"
+      ansible.builtin.shell:
+        cmd: |
+          set -uo pipefail
+          envfile=$(systemctl cat autobot-chromadb 2>/dev/null \
+            | sed -n 's/^EnvironmentFile=//p' | head -1)
+          echo "envfile_declared=$(test -n "$envfile" && echo 1 || echo 0)"
+          echo "envfile_optional=$(case "$envfile" in -*) echo 1 ;; *) echo 0 ;; esac)"
+          echo "envfile_present=$(test -n "$envfile" \
+            && test -f "${envfile#-}" && echo 1 || echo 0)"
+      args:
+        executable: /bin/bash
+      register: chromadb_delivery_evidence
+      become: true
+      changed_when: false
+      failed_when: false
+      tags: [database, chromadb, verify]
+
+    - name: "[PLAY 2b] Verify | ChromaDB unit carries its credential file (#12513, #13535)"
+      ansible.builtin.assert:
+        that:
+          # rendered by roles/redis code_only above, from the unit template
+          - "'envfile_declared=1' in chromadb_delivery_evidence.stdout"
+          # `EnvironmentFile=-` is why a missing credential ran unauthenticated
+          - "'envfile_optional=0' in chromadb_delivery_evidence.stdout"
+          # written by _shared/tasks/write_chromadb_authn_env.yml
+          - "'envfile_present=1' in chromadb_delivery_evidence.stdout"
+        fail_msg: >-
+          #13535: the update ran green but roles/redis code_only did not deliver
+          the ChromaDB credential file the unit mandates — chroma is running
+          unauthenticated or cannot start. Evidence:
+          {{ chromadb_delivery_evidence.stdout | default('(none)') }}.
+        success_msg: "ChromaDB unit + credential file delivered (#12513)"
+      when: chromadb_delivery_evidence.stdout | default('') | trim | length > 0
+      tags: [database, chromadb, verify]
+
+    - name: "[PLAY 2b] Database Node Update Complete"
+      ansible.builtin.debug:
+        msg: "{{ inventory_hostname }} updated"
+
+# =============================================================================
 # PLAY 3: Verify + Cleanup
 # =============================================================================
 - name: "Play 3 - Verify & Cleanup"

--- a/autobot-slm-backend/ansible/roles/redis/tasks/chromadb.yml
+++ b/autobot-slm-backend/ansible/roles/redis/tasks/chromadb.yml
@@ -71,41 +71,11 @@
   become: true
   tags: ['redis', 'chromadb']
 
-# #12513: the unit template only emits CHROMA_SERVER_AUTHN_* when
-# chromadb_auth_token is non-empty, and its default is "" — so chroma ran
-# unauthenticated on every deployment. Read the shared token the SLM generates,
-# so the server credential matches the one the backend sends. Never generate one
-# here: two independent generators produce two values and a total RAG outage.
-- name: "ChromaDB | Read the shared auth token from slm-secrets.env (#12513)"
-  ansible.builtin.include_tasks: ../../../_shared/tasks/read_chromadb_auth_token.yml
-  tags: ['redis', 'chromadb']
-
-- name: "ChromaDB | Adopt the SLM-managed auth token when present (#12513)"
-  ansible.builtin.set_fact:
-    chromadb_auth_token: "{{ _chromadb_auth_token_read }}"
-  when: (_chromadb_auth_token_read | default('') | trim) | length > 0
-  no_log: true
-  tags: ['redis', 'chromadb']
-
-# Must precede the unit template and the start task below: the unit declares a
-# MANDATORY EnvironmentFile at this exact path (#12513), so the file has to exist
-# before systemd is asked to (re)start chroma. Rendered unconditionally — it just
-# carries no authn keys when no token is configured.
-- name: "ChromaDB | Render the server-authn env file the unit reads (#12513)"
-  ansible.builtin.include_tasks: ../../../_shared/tasks/write_chromadb_authn_env.yml
-  tags: ['redis', 'chromadb']
-
-- name: "ChromaDB | Deploy systemd service unit"
-  ansible.builtin.template:
-    src: autobot-chromadb.service.j2
-    dest: /etc/systemd/system/autobot-chromadb.service
-    mode: "0644"
-  become: true
-  notify:
-    - reload systemd
-    - restart chromadb
-  tags: ['redis', 'chromadb']
-
+# #13535: the token read, the credential file and the unit template moved to
+# code_only.yml, which main.yml includes BEFORE importing this file — so the
+# mandatory EnvironmentFile (#12513) is already on disk by the time the service
+# is started below, on the provisioning path and the updater's path alike.
+# Repeating them here would give the fix two definitions and let them drift.
 - name: "ChromaDB | Enable and start service"
   ansible.builtin.systemd:
     name: autobot-chromadb

--- a/autobot-slm-backend/ansible/roles/redis/tasks/code_only.yml
+++ b/autobot-slm-backend/ansible/roles/redis/tasks/code_only.yml
@@ -1,0 +1,109 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+---
+# The database role's service files that carry code changes: the Redis Stack
+# systemd override, the backup script, and the ChromaDB credential file + unit.
+# Split out of main.yml / chromadb.yml (#13535) so the builtin updater can
+# deliver them without re-running provisioning (apt, the redis-stack package,
+# service accounts, the chroma venv and its package installs, data directories).
+#
+# This role had NO delivery path at all before #13535: update-all-nodes.yml's
+# Play 2 targets the `infrastructure` group, which does not contain `database`,
+# and this role had no code-only task file for a play to apply. So the #12513
+# chroma-auth work merged in #13462/#13537 could not reach a database host —
+# the same silent "merged but never applied" shape as #12959.
+#
+# The chroma token read is part of this file, not an optional extra. The unit
+# template emits its credential through `chromadb_authn_env_file` only, and the
+# role default for `chromadb_auth_token` is "". Rendering the unit on the update
+# path without reading the SLM-managed token would redeploy chroma with
+# authentication SILENTLY DISABLED — undoing #12513 on every update, with
+# nothing failing.
+#
+# DELIBERATELY EXCLUDED — every artifact whose content depends on
+# `redis_password`: /etc/redis-stack.conf (`requirepass`) and the redis_exporter
+# unit (`REDIS_PASSWORD`). `redis_password` resolves from `vault_redis_password`
+# (roles/redis/vars/main.yml), which no inventory in this repository defines, so
+# a code-only render would emit both files WITHOUT the credential. On a host
+# that has one, that silently strips authentication from the live data store —
+# the exact class of regression this whole delivery mechanism exists to prevent.
+# /etc/redis-stack.conf additionally depends on the TLS stat facts registered by
+# _shared/tasks/stat_tls_certs.yml, so rendering it without them silently drops
+# every tls-* directive. Both need a guaranteed variable source before they can
+# join the update path; until then they stay on the provisioning path only.
+#
+# Handlers (`reload systemd`, `restart redis-stack`, `restart chromadb`) live in
+# the role, so this file is only usable via include_role/import_role.
+
+- name: "Redis | Create systemd override directory"
+  ansible.builtin.file:
+    path: /etc/systemd/system/redis-stack-server.service.d
+    state: directory
+    mode: '0755'
+  become: true
+  tags: ['redis', 'systemd']
+
+# Content comes entirely from roles/redis/vars/main.yml (redis_memory_limit,
+# redis_port), so a re-render on an unchanged host reports `ok` and the
+# restart handler never fires. Restarting the live data store on every update
+# would otherwise drop every client connection in the fleet.
+- name: "Redis | Configure systemd service override"
+  ansible.builtin.template:
+    src: redis-stack-override.conf.j2
+    dest: /etc/systemd/system/redis-stack-server.service.d/override.conf
+    mode: '0644'
+  become: true
+  notify:
+    - reload systemd
+    - restart redis-stack
+  tags: ['redis', 'systemd']
+
+# A shell script rendered from a role template — worker code by any other name,
+# and the same shape that left the TTS worker four days stale in #12886.
+- name: "Redis | Create backup script"
+  ansible.builtin.template:
+    src: redis-backup.sh.j2
+    dest: /usr/local/bin/redis-backup.sh
+    mode: '0755'
+    owner: root
+    group: root
+  become: true
+  tags: ['redis', 'backup']
+
+# #12513: the unit carries its credential through a MANDATORY EnvironmentFile,
+# and the role default for the token is "". Read the shared token the SLM
+# generates so the server credential matches the one the backend sends. Never
+# generate one here: two independent generators produce two values and a total
+# RAG outage.
+- name: "ChromaDB | Read the shared auth token from slm-secrets.env (#12513)"
+  ansible.builtin.include_tasks: ../../../_shared/tasks/read_chromadb_auth_token.yml
+  tags: ['redis', 'chromadb']
+
+- name: "ChromaDB | Adopt the SLM-managed auth token when present (#12513)"
+  ansible.builtin.set_fact:
+    chromadb_auth_token: "{{ _chromadb_auth_token_read }}"
+  when: (_chromadb_auth_token_read | default('') | trim) | length > 0
+  no_log: true
+  tags: ['redis', 'chromadb']
+
+# Must precede the unit template below, and main.yml includes this file before
+# chromadb.yml starts the service: the unit declares a MANDATORY
+# EnvironmentFile at this exact path (#12513), so the file has to exist before
+# systemd is asked to (re)start chroma. Rendered unconditionally — it just
+# carries no authn keys when no token is configured.
+- name: "ChromaDB | Render the server-authn env file the unit reads (#12513)"
+  ansible.builtin.include_tasks: ../../../_shared/tasks/write_chromadb_authn_env.yml
+  tags: ['redis', 'chromadb']
+
+- name: "ChromaDB | Deploy systemd service unit"
+  ansible.builtin.template:
+    src: autobot-chromadb.service.j2
+    dest: /etc/systemd/system/autobot-chromadb.service
+    mode: "0644"
+  become: true
+  notify:
+    - reload systemd
+    - restart chromadb
+  tags: ['redis', 'chromadb']

--- a/autobot-slm-backend/ansible/roles/redis/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/redis/tasks/main.yml
@@ -199,24 +199,15 @@
   when: not _redis_service_file.stat.exists
   tags: ['redis', 'systemd']
 
-- name: "Redis | Create systemd override directory"
-  file:
-    path: /etc/systemd/system/redis-stack-server.service.d
-    state: directory
-    mode: '0755'
-  become: true
-  tags: ['redis', 'systemd']
-
-- name: "Redis | Configure systemd service override"
-  template:
-    src: redis-stack-override.conf.j2
-    dest: /etc/systemd/system/redis-stack-server.service.d/override.conf
-    mode: '0644'
-  become: true
-  notify:
-    - reload systemd
-    - restart redis-stack
-  tags: ['redis', 'systemd']
+# #13535: the systemd override, the backup script and the ChromaDB credential
+# file + unit are defined once, in code_only.yml, so the builtin updater can
+# deliver them without dragging this file's provisioning half (apt, the
+# redis-stack package, service accounts, the chroma venv) onto the update path.
+# Included HERE so the override lands before "Enable and start Redis Stack"
+# below, and the chroma credential file lands before chromadb.yml starts the
+# service — the unit's EnvironmentFile is mandatory (#12513).
+- name: "Redis | Deploy role-owned service files (#13535)"
+  ansible.builtin.include_tasks: code_only.yml
 
 - name: "Redis | Enable and start Redis Stack"
   systemd:
@@ -248,16 +239,6 @@
     owner: autobot
     group: autobot
     mode: '0755'
-  become: true
-  tags: ['redis', 'backup']
-
-- name: "Redis | Create backup script"
-  template:
-    src: redis-backup.sh.j2
-    dest: /usr/local/bin/redis-backup.sh
-    mode: '0755'
-    owner: root
-    group: root
   become: true
   tags: ['redis', 'backup']
 

--- a/autobot-slm-backend/tests/test_chromadb_auth_token_provisioned_12513.py
+++ b/autobot-slm-backend/tests/test_chromadb_auth_token_provisioned_12513.py
@@ -39,7 +39,10 @@ _TOKEN_KEY = "AUTOBOT_CHROMADB_AUTH_TOKEN"
 #: `backend` renders the client credential; the other two render the chroma unit.
 _CONSUMERS = {
     "backend": ("tasks/main.yml", "backend_chromadb_auth_token"),
-    "redis": ("tasks/chromadb.yml", "chromadb_auth_token"),
+    # #13535 moved redis's read into code_only.yml for the same reason #13460
+    # moved ai-stack's: the database role had no delivery path at all, so this
+    # fix could not reach a database host.
+    "redis": ("tasks/code_only.yml", "chromadb_auth_token"),
     # #13460 moved ai-stack's read into code_only.yml, alongside the chroma unit
     # it feeds, so the builtin updater delivers both together. Rendering that
     # unit without the read would redeploy chroma with auth SILENTLY DISABLED —
@@ -188,7 +191,7 @@ _WRITE_ENV = _ANSIBLE / "_shared" / "tasks" / "write_chromadb_authn_env.yml"
 #: Roles that render the chroma unit → (task file that must render the env file,
 #: relative path of the unit template).
 _UNIT_OWNERS = {
-    "redis": ("tasks/chromadb.yml", "templates/autobot-chromadb.service.j2"),
+    "redis": ("tasks/code_only.yml", "templates/autobot-chromadb.service.j2"),  # #13535
     "ai-stack": ("tasks/code_only.yml", "templates/autobot-chromadb.service.j2"),
 }
 
@@ -367,6 +370,33 @@ def test_ai_stack_starts_chroma_only_after_including_the_render():
     assert include_at < start_at, (
         "roles/ai-stack/tasks/main.yml starts chroma before code_only.yml renders the "
         "mandatory env file — the service would fail to start on a fresh node"
+    )
+
+
+def test_redis_starts_chroma_only_after_including_the_render():
+    """redis keeps the render in code_only.yml; main.yml must include it first.
+
+    The start task stayed in ``tasks/chromadb.yml`` when #13535 split the render
+    out, so the ordering that makes the mandatory EnvironmentFile safe is now a
+    property of ``main.yml``: the include has to come before the import that
+    starts the service, or a fresh database node comes up with chroma unable to
+    start at all.
+    """
+    tasks = _tasks(_ANSIBLE / "roles" / "redis" / "tasks" / "main.yml")
+    include_at = next(
+        (i for i, t in enumerate(tasks) if "code_only.yml" in str(t.get("ansible.builtin.include_tasks", ""))),
+        None,
+    )
+    chromadb_at = next(
+        (i for i, t in enumerate(tasks) if "chromadb.yml" in str(t.get("ansible.builtin.import_tasks", ""))),
+        None,
+    )
+    assert include_at is not None, "roles/redis/tasks/main.yml no longer includes code_only.yml"
+    assert chromadb_at is not None, "roles/redis/tasks/main.yml no longer imports chromadb.yml"
+    assert include_at < chromadb_at, (
+        "roles/redis/tasks/main.yml imports chromadb.yml (which starts the service) "
+        "before code_only.yml renders the mandatory env file — chroma would fail to "
+        "start on a fresh database node"
     )
 
 

--- a/autobot-slm-backend/tests/test_update_all_applies_roles_12959.py
+++ b/autobot-slm-backend/tests/test_update_all_applies_roles_12959.py
@@ -60,6 +60,11 @@ MANAGED_COMPONENT_ROLES = {
     "browser": "browser",
     "tts-worker": "tts-worker",
     "postgresql": "postgresql",
+    # #13535: the database node. Its role owns the Redis systemd override, the
+    # backup script and the ChromaDB unit + credential file, and the updater had
+    # no play that reached it at all — `infrastructure` (Play 2's host list) does
+    # not contain `database`.
+    "database": "redis",
 }
 
 #: Components with a delivery path today. Each entry is a regression guard: the
@@ -72,6 +77,7 @@ DELIVERED = {
     "npu-worker": {"code_only"},  # #13460
     "frontend": {"code_only"},  # #13460
     "browser": {"code_only"},  # #13460
+    "database": {"code_only"},  # #13535
 }
 
 #: Task-name substrings that mean provisioning. None may appear in a task file

--- a/autobot-slm-backend/tests/test_updater_reaches_database_nodes_13535.py
+++ b/autobot-slm-backend/tests/test_updater_reaches_database_nodes_13535.py
@@ -1,0 +1,175 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""The builtin updater must reach database nodes at all (#13535).
+
+`update-all-nodes.yml` is the playbook behind code-sync / self-update — the only
+updater a GUI user can reach. Its node play targets the `infrastructure` group,
+and `database` is not one of that group's children. `roles/redis` also had no
+code-only task file, so even a play that did reach the node had nothing to
+apply. Both halves were missing, which is why the ChromaDB authentication work
+(#12513, #13462, #13537) merged green, closed, and left the host untouched — the
+#12959 "merged but never applied" shape, one role further along.
+
+The fix is a play that targets `database` directly. Adding `database` to
+`infrastructure` was considered and rejected: that group is the node play's host
+list, and the node play is a backend/frontend/worker update (package installs,
+npm builds, alembic migrations, a backend `.env` regeneration) that was never
+designed to run against a data store.
+
+What is asserted here is the property that made the gap invisible: *some* play
+reaches database hosts, and it applies `roles/redis` through a task file that
+carries no provisioning. Every assertion is a regression guard for a defect that
+already shipped once.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+_ANSIBLE = Path(__file__).resolve().parents[1] / "ansible"
+_PLAYBOOK = _ANSIBLE / "playbooks" / "update-all-nodes.yml"
+_ROLE = _ANSIBLE / "roles" / "redis"
+_CODE_ONLY = _ROLE / "tasks" / "code_only.yml"
+
+#: Host patterns that resolve to database nodes. `redis` is the inventory alias
+#: whose only child is `database` (inventory/production.yml, hosts.yml).
+_DATABASE_PATTERNS = {"database", "redis"}
+
+#: Task-name substrings that mean provisioning — the same contract
+#: test_update_all_applies_roles_12959.py enforces for every other role.
+_PROVISIONING_MARKERS = ("venv", "pip install", "pre-download", "service account", "apt")
+
+
+def _plays() -> list[dict]:
+    return [p for p in yaml.safe_load(_PLAYBOOK.read_text(encoding="utf-8")) if isinstance(p, dict)]
+
+
+def _tasks(path: Path) -> list:
+    return yaml.safe_load(path.read_text(encoding="utf-8")) or []
+
+
+def _iter_mappings(node):
+    if isinstance(node, dict):
+        yield node
+        for value in node.values():
+            yield from _iter_mappings(value)
+    elif isinstance(node, list):
+        for item in node:
+            yield from _iter_mappings(item)
+
+
+def _database_plays() -> list[dict]:
+    """Plays whose host pattern reaches a database node."""
+    matched = []
+    for play in _plays():
+        tokens = {tok.strip() for tok in str(play.get("hosts", "")).replace(",", ":").split(":")}
+        if tokens & _DATABASE_PATTERNS:
+            matched.append(play)
+    return matched
+
+
+def test_the_role_has_a_code_only_task_file():
+    """Without one, no play can deliver a change to a database node."""
+    assert _CODE_ONLY.is_file(), (
+        f"{_CODE_ONLY} missing — roles/redis owns the Redis systemd override, the "
+        "backup script and the ChromaDB unit + credential file, and none of them "
+        "can reach a host without a code-only task file to apply (#13535)"
+    )
+
+
+def test_a_play_targets_database_hosts():
+    """The gap was structural: no play in the updater named these nodes."""
+    assert _database_plays(), (
+        "update-all-nodes.yml has no play targeting database nodes — code-sync / "
+        "self-update cannot deliver anything to the database role, exactly the "
+        "state #13535 reports"
+    )
+
+
+def test_the_database_play_applies_the_role_through_code_only():
+    """Full-role application would drag provisioning onto the update path."""
+    applied = set()
+    for play in _database_plays():
+        for task in _iter_mappings(play.get("tasks") or []):
+            include = task.get("ansible.builtin.include_role") or task.get("include_role")
+            if isinstance(include, dict) and include.get("name") == "redis":
+                applied.add(include.get("tasks_from"))
+        for entry in play.get("roles") or []:
+            name = entry.get("role") or entry.get("name") if isinstance(entry, dict) else entry
+            if name == "redis":
+                applied.add(None)
+
+    assert "code_only" in applied, (
+        "no play targeting database nodes applies roles/redis with "
+        f"tasks_from=code_only (found: {sorted(str(a) for a in applied)}) — a fix "
+        "merged into that role stays inert on every database host (#12959)"
+    )
+    assert None not in applied, (
+        "a database play applies roles/redis in FULL — that re-runs the redis-stack "
+        "package install, the service accounts, the data directory chown and the "
+        "chroma venv build on every self-update"
+    )
+
+
+def test_delivery_does_not_depend_on_the_infrastructure_group():
+    """The rejected alternative, pinned.
+
+    Adding `database` to `infrastructure` would have routed database nodes
+    through the backend/frontend/worker play. Delivery must come from a play that
+    names the database nodes itself, so the route survives regardless of how the
+    `infrastructure` group is composed in any given inventory.
+    """
+    routes = [p for p in _database_plays() if "infrastructure" not in str(p.get("hosts", ""))]
+    assert routes, (
+        "the only play reaching database nodes does so via the `infrastructure` "
+        "group — delivery then depends on an inventory grouping that the static "
+        "inventory does not have, which is how #13535 stayed invisible"
+    )
+
+
+def test_code_only_carries_no_provisioning():
+    """A task file that re-provisions turns every self-update into a reinstall."""
+    names = " ".join(str(t.get("name", "")) for t in _tasks(_CODE_ONLY) if isinstance(t, dict)).lower()
+    for marker in _PROVISIONING_MARKERS:
+        assert marker not in names, (
+            f"roles/redis/tasks/code_only.yml: provisioning task ({marker!r}) leaked "
+            "onto the update path — it must stay in main.yml"
+        )
+
+
+def test_code_only_renders_nothing_that_carries_the_redis_password():
+    """A code-only render must not be able to strip the data store's credential.
+
+    ``redis_password`` resolves from ``vault_redis_password``
+    (roles/redis/vars/main.yml), which no inventory in this repository defines.
+    Rendering ``redis-stack.conf.j2`` or ``redis_exporter.service.j2`` on the
+    update path would therefore emit both files WITHOUT the credential — silently
+    removing authentication from a live data store on every update. Those two
+    stay on the provisioning path until the variable has a guaranteed source.
+    """
+    rendered = {
+        str((t.get("ansible.builtin.template") or t.get("template") or {}).get("src", ""))
+        for t in _iter_mappings(_tasks(_CODE_ONLY))
+    } - {""}
+
+    offenders = {src for src in rendered if "redis_password" in (_ROLE / "templates" / src).read_text(encoding="utf-8")}
+    assert not offenders, (
+        f"roles/redis/tasks/code_only.yml renders {sorted(offenders)}, whose content "
+        "depends on redis_password — an update-path render emits them without the "
+        "credential and silently disables Redis authentication"
+    )
+
+
+def test_main_includes_code_only_rather_than_duplicating_it():
+    """One definition, two callers — the #12886 / #12959 contract."""
+    includes = [
+        str(t.get("ansible.builtin.include_tasks", "")) for t in _iter_mappings(_tasks(_ROLE / "tasks" / "main.yml"))
+    ]
+    assert any("code_only.yml" in inc for inc in includes), (
+        "roles/redis/tasks/main.yml must include code_only.yml, not repeat its "
+        "tasks — an inline copy is how the provisioning and update paths drift"
+    )


### PR DESCRIPTION
## Thinking Path

The database role had no builtin update route, and it was missing on **both** sides:

1. The updater's node play targets the `infrastructure` group, whose children are
   `slm, backend, frontend, npu, aiml, browser, llm, reserved` — `database` is not among them.
2. Unlike five other roles, `roles/redis` had no `code_only.yml`, so even a play that did
   reach the node would have had nothing to apply short of the full role.

That is why the ChromaDB authentication work appeared deployed while the host was unchanged:
the exact "merged but never applied" shape #12959 was opened for, one role further along.

**Wiring choice — a separate play targeting `database`, not a new member of `infrastructure`.**
That group *is* the node play's host list, and that play is a backend/frontend/worker update:
package installs, npm builds, alembic migrations, a backend `.env` regeneration. None of it is
designed for a data store, and all of it is guarded by `'<component>' in group_names` checks a
database node would skip anyway — so joining the group would add risk without adding delivery.
Targeting `database` directly runs the one thing the node needs and nothing else. It also keeps
the route independent of inventory composition: the group exists in the static inventory, in the
node-registry inventory the updater generates, and in the alias inventories.

**Placed after the node play, deliberately.** That play regenerates the backend env with the
chroma *client* credential and restarts the backend; this play then switches the chroma *server*
to enforcing. The reverse order would enable server-side auth while the backend still ran without
the credential — every retrieval call rejected for the length of the node play. Same ordering the
co-located AI-stack chroma unit already follows.

**Excluded from the code-only pass — every artifact whose content depends on `redis_password`.**
The Redis Stack config renders `requirepass` and the exporter unit renders a password env var,
both from a vault variable that no inventory in this repository defines. A code-only render would
emit them *without* the credential, silently removing authentication from a live data store on
every update. The config additionally gates its TLS directives on stat facts registered by a task
that stays on the provisioning path, so rendering it there would also drop every TLS directive.
Both need a guaranteed variable source before they can join the update path; until then they stay
provisioning-only. This is the "deliver the smallest safe subset rather than force it" case, and
it is pinned by a test so the boundary cannot erode silently.

## What Changed

**New: the role's code-only task file** — the service files that carry changes, and nothing else:
the Redis Stack systemd override (+ its drop-in directory), the backup script rendered from a role
template, and the ChromaDB block: shared token read, adopt-when-non-empty, credential file render,
unit template. Ordering inside the file preserves the #12513 contract — read before write, write
before the unit that declares the credential file as mandatory.

**Deliberately NOT run on a code-only pass**, with reasons:

| Excluded | Why |
|---|---|
| Repo key/list add, cache refresh, package install | Provisioning: network-dependent, can break an installed box |
| System group + user creation, group membership | Account provisioning; one-time |
| Data directory creation and its recursive ownership pass | Data-volume setup; a recursive pass over a live dataset on every update |
| Kernel tunable for background saves | Host tuning; one-time |
| Firewall rules (data port, insight port, exporter scrape) | Host provisioning; reloads the firewall on every update |
| Conffile restore via package reinstall | Recovery path; a package reinstall is not an update action |
| Enable/start the data store, readiness poll | Service enablement + a retry loop that can stall the run for minutes |
| Backup directory creation, cron schedule | Provisioning; the script creates its own directory at run time |
| Exporter user, binary download and extraction, scrape firewall rule | Provisioning: downloads a release archive |
| Data store config file | Renders the auth directive from an undefined vault variable → silently strips authentication; also gates TLS on stat facts absent from this path |
| Exporter unit | Same credential-bearing conditional |
| ChromaDB install/data directories, venv enforcement, venv creation, package installs, ownership fix | Provisioning; the venv-version enforcement is explicitly destructive (rebuilds the venv) |
| ChromaDB enable/start | Stays on the provisioning path; the update path restarts through the role's handler instead |

**Tasks that assume first install** — the venv-version enforcement (rebuilds the environment),
the conffile restore (package reinstall), and the recursive data-directory ownership pass are the
three that are safe once and not repeatedly. All three are excluded.

**Wiring:** a new play targeting database nodes applies the role through the code-only task file
with `apply: {become: true}` (a bare `become` on a dynamic role include makes ansible reject the
whole playbook, breaking every self-update), flushes handlers immediately so the restart is part
of delivery rather than a queued hope that a later failure discards, then asserts fail-closed that
the deployed unit declares a **mandatory** credential file and that the file exists — the three
states that distinguish "delivered", "pre-fix optional env file", and "no unit at all".

**One definition, two callers:** the role's `main.yml` now includes the new file (before the data
store starts, and before the import that starts ChromaDB), and the ChromaDB task file no longer
repeats the moved tasks. The provisioning path and the update path cannot drift.

**Guards:** a new test module pins the properties that made the gap invisible — a play reaches
database nodes, it applies the role through a code-only file, delivery does not depend on the
`infrastructure` group, the file carries no provisioning, it renders nothing credential-bearing,
and `main.yml` includes rather than duplicates. The two existing contract tests were extended:
the delivery-path registry gains the database component, and the ChromaDB auth contract follows
the read/render into its new home plus a new ordering assertion.

**The inventory is unchanged** — no group membership was edited.

## Verification

**Inventory group unchanged (before == after):**

```
$ git diff --name-only -- autobot-slm-backend/ansible/inventory/ | wc -l
0
```

The group's children are byte-identical to the base branch: `slm, backend, frontend, npu, aiml,
browser, llm, reserved`. `database` is still not a member — the rejected alternative was not taken.

**Patterned on the five existing code-only files:**

| Existing | Shape adopted |
|---|---|
| `roles/ai-stack/tasks/code_only.yml` | The chroma read → adopt → render-env → unit-template sequence and its ordering contract, copied verbatim in structure |
| `roles/tts-worker/tasks/code_only.yml` | Header rationale, `main.yml` includes rather than repeats, handlers stay in the role |
| `roles/npu-worker/tasks/code_only.yml` | Template-only tasks that notify handlers; provisioning left behind |
| `roles/browser/tasks/code_only.yml` | Per-task tags, `become: true` on templates, guards preserved |
| `roles/frontend/tasks/code_only.yml` | Explicit "deliberately NOT" note for what is excluded and why |

Mine matches all five: copyright header, `---`, a header comment stating what it delivers, what it
excludes and why, and that handlers live in the role; template/include tasks only; no provisioning;
included by `main.yml` rather than duplicated.

**Syntax check on the modified playbook:**

```
$ ansible-playbook -i <inventory> playbooks/update-all-nodes.yml --syntax-check
playbook: playbooks/update-all-nodes.yml
```

Also clean on the role-application playbook that applies this role in full.

**YAML parse on every file touched:**

```
OK    7 top-level entries  roles/redis/tasks/code_only.yml
OK   26 top-level entries  roles/redis/tasks/main.yml
OK    7 top-level entries  roles/redis/tasks/chromadb.yml
OK    5 top-level entries  playbooks/update-all-nodes.yml
```

Plays now resolve to: `localhost`, `slm_server`, `infrastructure`, **`database`**, `localhost`.

**Include chain — a code-only pass on a database host reaches the merged ChromaDB tasks:**

```
playbooks/update-all-nodes.yml:1558   - name: "Play 2b - Update Database Nodes"
playbooks/update-all-nodes.yml:1559     hosts: database
playbooks/update-all-nodes.yml:1585       ansible.builtin.include_role:
playbooks/update-all-nodes.yml:1586         name: redis
playbooks/update-all-nodes.yml:1587         tasks_from: code_only
  -> roles/redis/tasks/code_only.yml:81   include_tasks: ../../../_shared/tasks/read_chromadb_auth_token.yml
  -> roles/redis/tasks/code_only.yml:97   include_tasks: ../../../_shared/tasks/write_chromadb_authn_env.yml
  -> roles/redis/tasks/code_only.yml:102  template: src: autobot-chromadb.service.j2   (notify: reload systemd, restart chromadb)
  -> playbooks/update-all-nodes.yml:1599  meta: flush_handlers   (the restart runs here, not at end of play)
```

All three relative targets resolve to real files. The provisioning path shares the same definition:
`roles/redis/tasks/main.yml:210` includes it, before `:212` starts the data store and before
`:262` imports the ChromaDB tasks that start that service.

**Delivery assertion validated against all three states** it must distinguish (mandatory + file
present → pass; pre-fix optional env file → fail; no unit → fail).

**Tests — 96 passed:**

```
tests/test_updater_reaches_database_nodes_13535.py .......                (new, 7)
tests/test_chromadb_auth_token_provisioned_12513.py ........................ (25)
tests/test_update_all_applies_roles_12959.py ...........................    (29)
tests/test_updater_refreshes_tts_worker_12886.py ........
tests/test_updater_reconciles_credentials_12907.py .............
tests/test_updater_browser_port_and_backend_unit.py ......
======================== 85 passed in 62.72s ========================

autobot-backend/tests/migrations/test_ansible_migration_contract.py ...........
============================== 11 passed in 4.56s ==============================
```

`black --check` and `isort --check-only` clean on all touched Python.

**Follow-up filed:** the data store config file and the exporter unit still have no delivery path,
because both render a credential from a variable with no guaranteed source on the update path.
Making them deliverable needs that variable resolved first — tracked separately, not forced here.

Refs #13535

## Model Used

claude-opus-5
