### PR TITLE
docs(ci): correct setup-python-ci's caller list, which named files that never used it (#13517)

### DIFF
--- a/.github/actions/setup-python-ci/action.yml
+++ b/.github/actions/setup-python-ci/action.yml
@@ -5,8 +5,26 @@
 # Composite action: Setup Python + install CI dependencies (GH#7086)
 #
 # Encapsulates the repeated "setup Python + pip bootstrap + install deps"
-# pattern shared across ci.yml, code-quality.yml, and other workflows.
-# Eliminates ~15 lines of duplicated YAML per job.
+# pattern, so the interpreter version, pip cache and dependency install live in
+# one place rather than a copy per workflow.
+#
+# #13517: this previously claimed to be "shared across ci.yml, code-quality.yml,
+# and other workflows" while having ZERO callers — neither of those files used
+# it, and nothing else did either. A description that names callers it does not
+# have is worse than none: it reads as load-bearing shared infrastructure, so
+# nobody checks, and the three expression-injection sites it carried (#13516)
+# sat unreviewed because the file looked established.
+#
+# Current callers (keep this list honest — it is the only thing standing between
+# this file and being orphaned again):
+#   api-wiring.yml            enforce-precommit.yml   migration-gate.yml
+#   auto-fix-formatting.yml   marker-tests.yml        startup-import-smoke.yml
+#   canonical-audit.yml       constraint-drift.yml    coverage.yml
+#
+# 12 workflows still call actions/setup-python directly. Converting them is
+# worthwhile but not required for this action to be legitimate — each needs its
+# own cache-dependency-path carried across, which is why it is going in
+# tranches rather than one sweep.
 #
 # Usage:
 #   - uses: ./.github/actions/setup-python-ci


### PR DESCRIPTION
## Thinking Path

Last unticked box on #13517: *"If adopted: correct the description to name its real callers."*

The header claimed the action was "shared across ci.yml, code-quality.yml, and other workflows" while having **zero** callers — and neither of those two files used it even after adoption began. That is worse than no description: it reads as load-bearing shared infrastructure, so nobody checks it, which is a large part of why the three expression-injection sites it carried (#13516) sat unreviewed. The file *looked* established.

## What Changed

Description only. It now:

- says what the action is for without claiming callers it does not have
- lists the **nine real callers**, with a note that keeping the list honest is the only thing standing between this file and being orphaned again
- records that 12 workflows still call `actions/setup-python` directly, and that converting them is worthwhile but **not required for this action to be legitimate** — which is the distinction the original description got wrong in the other direction

## Verification

```console
$ python3 -c 'import yaml; ...'
parses OK; name = Setup Python CI

$ # callers, derived rather than asserted
api-wiring.yml            enforce-precommit.yml   migration-gate.yml
auto-fix-formatting.yml   marker-tests.yml        startup-import-smoke.yml
canonical-audit.yml       constraint-drift.yml    coverage.yml
```

No behaviour change — comments and `description:` text only.

## Closing #13517

All four boxes now: #13516 landed, adopt-or-retire was decided (adopt), the description names its real callers, and the retire branch does not apply.

Converting the remaining 12 direct callers was **my own added scope**, not one of this issue's criteria — its complaint was "orphaned, zero callers, docstring claims three", and that is resolved. The remaining conversions continue as ordinary tech-debt without an issue holding them open.

Closes #13517
Refs #13516

## Model Used

Opus 5 (1M context)
