### PR TITLE
fix(memory-graph): label the property-graph mirror from the stored relation type (#13452)

### DIFF
--- a/autobot-backend/autobot_memory_graph/core.py
+++ b/autobot-backend/autobot_memory_graph/core.py
@@ -90,6 +90,13 @@ IDENTITY_RELATION_TYPES: Set[str] = {
     "has_participant",  # Issue #608 - Session has User
     "performed_by",  # Issue #608 - Activity performed by User
     "used_secret",  # Issue #608 - Activity used Secret
+    # #13452: user_session.py has always written these two, but neither was
+    # ever declared, so create_relation_by_id raised ValueError on both and
+    # create_chat_session_entity re-raised it — leaving a half-built graph with
+    # "owns" written and nothing else. get_user_sessions and the activity
+    # listing then filtered on names that could never match.
+    "has_session",  # Issue #608 - User has Session
+    "has_activity",  # Issue #608 - Session has Activity
 }
 
 RELATION_TYPES: Set[str] = CORE_RELATION_TYPES | IDENTITY_RELATION_TYPES
@@ -99,6 +106,11 @@ RELATION_TYPES: Set[str] = CORE_RELATION_TYPES | IDENTITY_RELATION_TYPES
 # while relations already stored under one keep resolving.
 RELATION_TYPE_ALIASES: Dict[str, str] = {
     "relates_to": "related_to",  # knowledge-base spelling before #13452
+    # Same concept as "used_secret" (Activity → Secret) in a different tense.
+    # "used_secret" is the declared #608 name but had no writer; "uses_secret"
+    # is what user_session.py actually emits. Mapped rather than added, so the
+    # vocabulary does not carry two spellings of one relation (#13452).
+    "uses_secret": "used_secret",  # nosec B105  # relation name, not a credential
 }
 
 

--- a/autobot-backend/autobot_memory_graph/property_graph_mixin.py
+++ b/autobot-backend/autobot_memory_graph/property_graph_mixin.py
@@ -114,6 +114,13 @@ class PropertyGraphMixin:
             metadata=metadata,
         )
         if relation:
+            # #13452: label the property-graph edge with the type that was
+            # actually stored, not the caller's raw spelling. super() folds
+            # aliases onto the canonical name, so using relation_type here wrote
+            # "related_to" into Redis JSON but "pg:adj:out:<id>:RELATES_TO" into
+            # the adjacency index — two stores silently disagreeing, and nothing
+            # canonicalises the index later.
+            edge_label = relation.get("type", relation_type).upper()
             edge_props: Dict[str, Any] = {"strength": str(strength)}
             if metadata:
                 for k, v in metadata.items():
@@ -127,14 +134,14 @@ class PropertyGraphMixin:
                     await self.graph.add_edge(
                         from_entity_data["id"],
                         to_entity_data["id"],
-                        relation_type.upper(),
+                        edge_label,
                         edge_props,
                     )
                     if bidirectional:
                         await self.graph.add_edge(
                             to_entity_data["id"],
                             from_entity_data["id"],
-                            relation_type.upper(),
+                            edge_label,
                             edge_props,
                         )
             except Exception as exc:

--- a/autobot-backend/autobot_memory_graph/relation_vocabulary_test.py
+++ b/autobot-backend/autobot_memory_graph/relation_vocabulary_test.py
@@ -251,3 +251,117 @@ class TestMemoryGraphRoundTrip:
         graph, _ = self._graph([{"to": "id-b", "from": "id-a", "type": "related_to"}])
 
         assert await graph.invalidate_relation("id-a", "relates_to", "id-b") is True
+
+
+class TestPropertyGraphMirrorLabel:
+    """The property-graph mirror must carry the same label the JSON store did.
+
+    PropertyGraphMixin.create_relation is the live override (first in
+    AutoBotMemoryGraph's MRO), so every write goes through it. It calls
+    super().create_relation, which canonicalises, then mirrors the edge into the
+    property graph. Labelling that edge from the caller's raw spelling persisted
+    "related_to" in Redis JSON but RELATES_TO in the pg:adj:* index — a
+    divergence nothing canonicalises later (#13452).
+    """
+
+    @staticmethod
+    def _graph():
+        graph = AutoBotMemoryGraph()
+        graph._initialized = True
+        graph.redis_client = Mock()
+        graph._resolve_entity_ids = AsyncMock(return_value=("id-a", "id-b"))
+        graph._store_outgoing_relation = AsyncMock()
+        graph._store_incoming_relation = AsyncMock()
+        graph.get_entity = AsyncMock(
+            side_effect=lambda **kw: {"id": "id-a" if kw.get("entity_name") == "A" else "id-b"}
+        )
+        property_graph = Mock()
+        property_graph.add_edge = AsyncMock(return_value="edge-1")
+        graph._property_graph = property_graph
+        return graph, property_graph
+
+    async def test_alias_write_mirrors_the_canonical_label(self):
+        graph, property_graph = self._graph()
+
+        await graph.create_relation("A", "B", relation_type="relates_to")
+
+        property_graph.add_edge.assert_awaited_once()
+        assert property_graph.add_edge.await_args.args[2] == "RELATED_TO"
+
+    async def test_bidirectional_reverse_edge_uses_the_canonical_label_too(self):
+        graph, property_graph = self._graph()
+
+        await graph.create_relation("A", "B", relation_type="relates_to", bidirectional=True)
+
+        assert property_graph.add_edge.await_count == 2
+        for call in property_graph.add_edge.await_args_list:
+            assert call.args[2] == "RELATED_TO"
+
+    async def test_canonical_write_is_unchanged(self):
+        graph, property_graph = self._graph()
+
+        await graph.create_relation("A", "B", relation_type="depends_on")
+
+        assert property_graph.add_edge.await_args.args[2] == "DEPENDS_ON"
+
+    async def test_mirror_label_matches_what_the_json_store_recorded(self):
+        """The two stores must agree by construction, not by coincidence."""
+        graph, property_graph = self._graph()
+
+        relation = await graph.create_relation("A", "B", relation_type="relates_to")
+
+        assert property_graph.add_edge.await_args.args[2] == relation["type"].upper()
+
+
+class TestUserSessionVocabulary:
+    """has_session / has_activity / uses_secret must be writable (#13452).
+
+    None of the three was declared, so create_relation_by_id raised ValueError
+    on every one. create_chat_session_entity re-raises, so chat-session creation
+    failed outright after "owns" had already been written — a half-built graph —
+    and get_user_sessions then filtered on names that could never match.
+    """
+
+    @pytest.mark.parametrize("relation_type", ["owns", "has_session", "has_participant"])
+    def test_session_relations_are_declared(self, relation_type):
+        assert relation_type in RELATION_TYPES
+
+    @pytest.mark.parametrize("relation_type", ["has_activity", "performed_by"])
+    def test_activity_relations_are_declared(self, relation_type):
+        assert relation_type in RELATION_TYPES
+
+    def test_uses_secret_maps_onto_the_declared_tense(self):
+        """ "used_secret" is the declared #608 name but had no writer;
+        "uses_secret" is what user_session.py emits. One relation, one spelling."""
+        assert canonical_relation_type("uses_secret") == "used_secret"
+        assert "uses_secret" not in RELATION_TYPES
+
+    def test_session_relations_are_identity_tier_not_knowledge_base(self):
+        for relation_type in ("has_session", "has_activity"):
+            assert relation_type in IDENTITY_RELATION_TYPES
+            assert relation_type not in KB_RELATION_TYPES
+
+    async def test_create_relation_by_id_accepts_every_user_session_type(self):
+        """The three writers in user_session.py must all reach storage."""
+        graph = AutoBotMemoryGraph()
+        graph._initialized = True
+        graph.redis_client = Mock()
+        graph._store_outgoing_relation = AsyncMock()
+        graph._store_incoming_relation = AsyncMock()
+
+        for relation_type in ("has_session", "has_activity", "uses_secret"):
+            assert await graph.create_relation_by_id("id-a", "id-b", relation_type) is True
+
+    async def test_get_relations_filter_matches_what_user_session_writes(self):
+        """get_user_sessions filters on ["owns", "has_session"] (#13452)."""
+        graph = AutoBotMemoryGraph()
+        graph._initialized = True
+        graph.redis_client = Mock()
+        graph._get_outgoing_relations = AsyncMock(
+            return_value=[{"to": "sess-1", "type": "has_session"}, {"to": "sec-1", "type": "used_secret"}]
+        )
+        graph._get_incoming_relations = AsyncMock(return_value=[])
+
+        result = await graph.get_relations("user-1", relation_types=["owns", "has_session"], direction="outgoing")
+
+        assert len(result["relations"]) == 1

--- a/docs/architecture/MEMORY_GRAPH_CHAT_INTEGRATION.md
+++ b/docs/architecture/MEMORY_GRAPH_CHAT_INTEGRATION.md
@@ -336,7 +336,7 @@ Entity not found, creating new entity for session: {session_id}
 
 2. **Automatic Relationship Creation**:
    - Link conversations to mentioned bugs/features
-   - Create "relates_to" relations automatically
+   - Create "related_to" relations automatically
    - Track conversation dependencies
 
 3. **Advanced Metadata Extraction**:

--- a/docs/design/MEMORY_GRAPH_SEARCH_ARCHITECTURE.md
+++ b/docs/design/MEMORY_GRAPH_SEARCH_ARCHITECTURE.md
@@ -144,7 +144,7 @@ User Query: "What bugs did we fix today?"
 │   - Updated API calls in frontend components                │
 │   - Deployed to Frontend VM (<frontend-ip>)                 │
 │ Created: 2025-10-03 09:15                                    │
-│ Relations: [relates_to: API Documentation Update]           │
+│ Relations: [related_to: API Documentation Update]           │
 └─────────────────────────────────────────────────────────────┘
                          ↓
          ┌───────────────────────────────────┐

--- a/docs/features/MEMORY_GRAPH_SEMANTIC_SEARCH.md
+++ b/docs/features/MEMORY_GRAPH_SEMANTIC_SEARCH.md
@@ -301,7 +301,7 @@ class Entity:
     observations: List[str]
     created_at: datetime
     updated_at: datetime
-    relations: List[Dict[str, str]]  # [{"to": "entity_name", "type": "relates_to"}]
+    relations: List[Dict[str, str]]  # [{"to": "entity_name", "type": "related_to"}]
     metadata: Dict[str, Any]
 
 @dataclass
@@ -1165,7 +1165,7 @@ context = await memory_search.get_conversation_context(
             {"id": "API Documentation Update", "type": "documentation"}
         ],
         "edges": [
-            {"from": "System Status Bug Fix", "to": "API Documentation Update", "type": "relates_to"}
+            {"from": "System Status Bug Fix", "to": "API Documentation Update", "type": "related_to"}
         ]
     }
 }


### PR DESCRIPTION
## Thinking Path

Follow-up to #13547, which merged into `Dev_new_gui` as `14a1e7400` while this work was in review. `Closes #13452` does not fire on the base branch, so #13452 is still open — and correctly so, because review of #13547 found two things it had not covered. This PR finishes them.

### A third store, and #13547 is what made the divergence reachable

#13547 established one canonical relation vocabulary and folded the legacy `relates_to` spelling onto `related_to` on write. It normalised **two** stores on the read side — the knowledge base and the memory graph's JSON relations. There is a **third**.

`PropertyGraphMixin.create_relation` is the live override: it is first in `AutoBotMemoryGraph`'s MRO (`__init__.py:64`), so every `POST /api/memory/relations` goes through it. It calls `super().create_relation(...)`, which canonicalises, and then mirrored the edge into the property graph using the caller's **raw** spelling:

```python
relation = await super().create_relation(..., relation_type=relation_type, ...)   # stores "related_to"
await self.graph.add_edge(from_id, to_id, relation_type.upper(), edge_props)      # writes "RELATES_TO"
```

So a relation created as `relates_to` landed in Redis JSON as `related_to` but in the adjacency index as `pg:adj:out:<id>:RELATES_TO` (`property_graph.py:52`, `:303`) — unreachable via `get_neighbors(relation="RELATED_TO")` (`:390`).

**This is a regression #13547 introduced, not an inherited bug.** Before it, the alias raised inside `super()` and nothing was written anywhere. After it, the write succeeds and the two stores disagree silently.

Blast radius today is low — no production caller filters `get_neighbors` by relation — but it persists divergent labels into an index nothing will canonicalise later, which is the expensive kind of low-blast-radius bug. The fix labels the edge from `relation["type"]`, the value that was actually stored, so the stores agree **by construction** rather than by coincidence.

### A fourth live instance of the defect class, fixed rather than deferred

`user_session.py` writes `has_session` (:124), `has_activity` (:222) and `uses_secret` (:244). None was ever declared, so `create_relation_by_id` raised `ValueError` on all three — and `create_chat_session_entity` (:181) **re-raises**, so memory-graph chat-session creation failed outright *after* `owns` had already been written, leaving a half-built graph. `get_user_sessions` (:322) then filtered on `["owns", "has_session"]` and activity listing (:398) on `["has_activity"]`, neither of which could ever match.

This is pre-existing — base `RELATION_TYPES` lacked these names too — so it is not a regression from #13547.

**Decision: fixed here, not deferred.** The semantics are exactly the tier #13547 defined. `has_session` (User → Session) and `has_activity` (Session → Activity) sit beside the `#608` names `owns`, `has_secret`, `has_participant` and `performed_by` that `IDENTITY_RELATION_TYPES` already holds. Deferring a three-line vocabulary addition out of the sweep that exists to eliminate exactly this defect would leave the job visibly half-done, and the failure mode is not cosmetic — it is a half-built graph on every chat-session creation.

**`uses_secret` got different treatment, deliberately.** It is the same relation as the already-declared `used_secret` (Activity → Secret) in a different tense — and a grep showed `used_secret` has **zero writers and zero readers**, while `uses_secret` is what the code actually emits. Adding both would put two spellings of one relation into the vocabulary, which is precisely the defect #13452 exists to remove. So it is an **alias** (`uses_secret` → `used_secret`), reusing the machinery #13547 built: the declared `#608` name stays canonical, the real writer keeps working, and only one spelling is ever stored.

## What Changed

- `autobot_memory_graph/property_graph_mixin.py` — the mirrored edge is labelled from the stored relation type, for both the forward and the `bidirectional` reverse edge.
- `autobot_memory_graph/core.py` — `has_session` and `has_activity` join `IDENTITY_RELATION_TYPES`; `uses_secret` becomes an alias of `used_secret`.
- `autobot_memory_graph/relation_vocabulary_test.py` — two new classes (below).
- Three docs still teaching the alias in prose and examples: `MEMORY_GRAPH_CHAT_INTEGRATION.md`, `MEMORY_GRAPH_SEARCH_ARCHITECTURE.md`, `MEMORY_GRAPH_SEMANTIC_SEARCH.md`. This completes the sweep #13547 started (five docs there, three here).

`docs/planning/issue-55-*.md` still mentions the alias and is **deliberately untouched**: those are dated completion records of what the vocabulary *was*. Rewriting them would falsify a historical record rather than fix a doc anyone reads for current behaviour.

## Verification

`TestPropertyGraphMirrorLabel` (4 tests) asserts the adjacency label is canonical for an alias write, for the bidirectional reverse edge, that a canonical write is unchanged, and that the label equals what the JSON store recorded. `TestUserSessionVocabulary` (7 tests) covers all three `user_session.py` writers reaching storage and the `get_user_sessions` filter matching what is written.

```
$ python3 -m pytest autobot_memory_graph/ type_defs/ services/security_memory_integration_test.py agents/graph_entity_extractor_test.py -q
127 passed, 36 warnings in 3.06s          # Python 3.10
127 passed, 39 warnings in 3.42s          # Python 3.14 (CI-parity venv, #13574)
```

The new tests were confirmed to actually catch the bug they guard, by reverting the fix and re-running:

```
$ # with `edge_label = relation_type.upper()` restored
$ python3 -m pytest autobot_memory_graph/relation_vocabulary_test.py -k PropertyGraphMirror -q
AssertionError: assert 'RELATES_TO' == 'RELATED_TO'
3 failed, 1 passed
```

Sweep over every `relation_type="..."` literal in `autobot-backend`, resolving each against `RELATION_TYPES`, the alias map and `SECURITY_TO_BASE_RELATION`. The only unresolved name is a negative-test fixture:

```
UNRESOLVED 'not_a_relation': ['autobot-backend/autobot_memory_graph/relation_vocabulary_test.py']
```

Lint clean on all changed Python files: `black`, `isort`, `flake8` (0), `bandit` (0 findings — the one `# nosec B105` is on `"uses_secret": "used_secret"`, a relation name bandit reads as a credential).

No OpenAPI-visible text changed, so `verify-generated-types` sees no drift.

## Model Used

Opus 5 (1M context)

Closes #13452
