### PR TITLE
refactor(tests): migrate the search and agent_loop conftests onto StubSet (#13575)

### DIFF
--- a/autobot-backend/testkit/module_stubs.py
+++ b/autobot-backend/testkit/module_stubs.py
@@ -92,8 +92,40 @@ class StubSet:
         self._binds: List[Tuple[Any, str, Any]] = []
         self._owned: Dict[str, types.ModuleType] = {}
         self._detached: Dict[str, types.ModuleType] = {}
+        # name -> (module we mutated, its previous __path__ or _MISSING)
+        self._paths: List[Tuple[Any, Any]] = []
 
     # -- construction ----------------------------------------------------
+
+    def adopt_package(self, name: str, path: Path) -> types.ModuleType:
+        """Give the session's EXISTING package a real ``__path__``, without replacing it.
+
+        Use this, not :meth:`install_package`, whenever something earlier in the
+        session already planted the package and other modules may hold references
+        to that object.
+
+        The difference is the whole of #13551. ``install_package`` builds a fresh
+        ``ModuleType`` and puts it in ``sys.modules``. If a root conftest already
+        planted ``agent_loop`` and ``agent_loop/tests/`` has since bound
+        ``AgentLoop`` from it, replacing the package object splits identity: the
+        bindings survive, but ``sys.modules`` no longer holds the module that owns
+        them, so ``patch("agent_loop.loop.X")`` re-imports a SECOND copy from disk
+        and patches that one. The real module's globals stay untouched — an inert
+        patch, with production code running unmocked while the test asserts against
+        a mock nothing calls.
+
+        Rule 2 does not apply here: we are not displacing anything. A genuinely
+        file-backed package is adopted as readily as a synthetic one, since all we
+        change is ``__path__``, and that change is recorded and restored.
+        """
+        existing = sys.modules.get(name)
+        if existing is None:
+            return self.install_package(name, path)
+
+        self._paths.append((existing, getattr(existing, "__path__", _MISSING)))
+        existing.__path__ = [str(path)]  # type: ignore[attr-defined]
+        self._bind_on_parent(name, existing)
+        return existing
 
     def install_package(self, name: str, path: Path) -> types.ModuleType:
         """Register *name* as a hollow package whose ``__path__`` is the real dir.
@@ -133,16 +165,32 @@ class StubSet:
                 f"process, which is how #13385 broke autobot_shared.async_compat."
             )
 
-    def real_load(self, name: str, file_path: Path) -> Optional[types.ModuleType]:
+    def real_load(self, name: str, file_path: Path, reuse_if_loaded: bool = True) -> Optional[types.ModuleType]:
         """Execute a real source file and register it under *name*.
 
         Preferred over a mock whenever downstream code imports concrete names
         from the module — a hand-written stand-in silently lacks them (#13385).
+
+        With *reuse_if_loaded* (the default), a module already loaded from this
+        very file is left alone and only re-bound on its parent. Re-executing it
+        would build a second set of class objects while every existing importer
+        keeps referencing the first — the same identity split :meth:`adopt_package`
+        exists to avoid, one level down. Pass ``False`` only when you genuinely
+        want a fresh execution and know nothing holds a reference.
         """
+        if reuse_if_loaded:
+            already = sys.modules.get(name)
+            if already is not None and getattr(already, "__file__", None) == str(file_path):
+                self._bind_on_parent(name, already)
+                return already
+
         self._refuse_if_real(name)
         spec = importlib.util.spec_from_file_location(name, str(file_path))
         if not spec or not spec.loader:
-            return None
+            # Returning None here would leave any placeholder in place and surface
+            # later as a confusing "new sys.modules leak" rather than as the file
+            # being missing, which is what actually went wrong.
+            raise RuntimeError(f"cannot build an import spec for {name!r} from {file_path}")
         module = importlib.util.module_from_spec(spec)
         # No `or name` fallback: a top-level module's __package__ is "", and
         # naming itself would let a relative import inside it resolve against
@@ -238,6 +286,7 @@ class StubSet:
         for name in reversed(list(self._owned)):
             self._put_back(name)
         self._restore_binds()
+        self._restore_paths()
         self._owned.clear()
         self._displaced.clear()
         self._detached.clear()
@@ -256,6 +305,36 @@ class StubSet:
             sys.modules.pop(name, None)
         else:
             sys.modules[name] = previous
+
+    def real_load_package(self, name: str, init_path: Path, package_dir: Path) -> Optional[types.ModuleType]:
+        """:meth:`real_load` an ``__init__.py``, keeping the package's ``__path__``.
+
+        Executing an ``__init__.py`` through a *file* spec yields a module with no
+        ``__path__``, so ``from pkg.sub import X`` stops resolving from disk for
+        everything imported afterwards. Restoring it is not optional, and doing it
+        by hand at each call site is how the three copies of this logic drifted.
+        """
+        module = self.real_load(name, init_path)
+        if module is not None:
+            module.__path__ = [str(package_dir)]  # type: ignore[attr-defined]
+        return module
+
+    def _restore_paths(self) -> None:
+        """Undo ``__path__`` mutations made by :meth:`adopt_package`.
+
+        The leak guard compares ``sys.modules`` *identity*, so it cannot see a
+        mutated ``__path__`` — an unrestored one silently re-enables on-disk
+        resolution of a whole package for every later-collected sibling.
+        """
+        for module, previous in reversed(self._paths):
+            if previous is _MISSING:
+                try:
+                    delattr(module, "__path__")
+                except AttributeError:
+                    pass
+            else:
+                module.__path__ = previous
+        self._paths.clear()
 
     def _restore_binds(self) -> None:
         for parent, attribute, previous in reversed(self._binds):

--- a/autobot-backend/tests/agent_loop/conftest.py
+++ b/autobot-backend/tests/agent_loop/conftest.py
@@ -33,112 +33,63 @@ practice this file only has to fill in whatever is still a stub.
 Issue #6627, #13162.
 """
 
-import importlib.util
-import sys
-import types
 from pathlib import Path
+
+from autobot_shared.logging_manager import get_logger
+from testkit.module_stubs import StubSet
 
 _BACKEND = Path(__file__).parent.parent.parent  # .../autobot-backend
 _AL_DIR = _BACKEND / "agent_loop"
 
-# Only the entries this file actually replaces are saved — restoring keys we
-# never touched is what made the old save/pop/restore cycle destructive.
-_SAVED: dict[str, object] = {}
-_ADDED: set = set()
+_logger = get_logger(__name__)
+_stubs = StubSet()
 
 
-def _bind_on_parent(full_name: str, mod: object) -> None:
-    """Bind *mod* as an attribute of its parent package.
+def _load_best_effort(name: str, rel: str) -> None:
+    """Load *name*, tolerating an import failure but never hiding it.
 
-    Load-bearing for ``unittest.mock.patch`` (#11532/#11618): it resolves
-    ``"agent_loop.loop.X"`` via ``getattr(sys.modules["agent_loop"], "loop")``,
-    NOT via ``sys.modules["agent_loop.loop"]``.  A module registered in
-    ``sys.modules`` by hand — as ``_load_real`` does — never gets that bind
-    from the import machinery, so without this every such patch target either
-    raised ``AttributeError`` or (against the root conftest's catch-all
-    package stub) silently patched a MagicMock.
+    Some of these pull heavy transitive deps (loop.py reaches events/planner/
+    tools) that a lean environment may not satisfy; the tests mock them, so a
+    failure here is survivable. Survivable is not the same as invisible: the
+    previous version swallowed the exception and stashed it in ``sys.modules``
+    under an invented ``_stagnation_load_err_*`` key, which both hid the error
+    and leaked a key nothing would ever clean up (#13575).
+
+    ``StubSet.real_load`` removes the half-executed module and re-raises, so the
+    only thing left to decide here is whether to continue — and to say why.
     """
-    parent, _, child = full_name.rpartition(".")
-    if parent and parent in sys.modules:
-        setattr(sys.modules[parent], child, mod)
-
-
-def _load_real(full_name: str, rel: str) -> None:
-    """Register the REAL module for *full_name*, unless it already is real.
-
-    Re-executing a module that is already loaded from this same file builds a
-    second set of class objects while every importer keeps referencing the
-    first — the identity split that #13162 traced.  An already-real entry is
-    therefore left alone and only (re)bound on its parent.
-    """
-    path = _BACKEND / rel
-    existing = sys.modules.get(full_name)
-    if existing is not None and getattr(existing, "__file__", None) == str(path):
-        _bind_on_parent(full_name, existing)
-        return
-    spec = importlib.util.spec_from_file_location(full_name, str(path))
-    if not spec or not spec.loader:
-        return
-    mod = importlib.util.module_from_spec(spec)
-    mod.__package__ = full_name.rpartition(".")[0] or full_name
-    if existing is None:
-        _ADDED.add(full_name)
-    else:
-        _SAVED.setdefault(full_name, existing)
-    sys.modules[full_name] = mod
     try:
-        spec.loader.exec_module(mod)  # type: ignore[union-attr]
-    except Exception as exc:
-        # Leave partial module in sys.modules so subsequent imports don't retrigger the error
-        sys.modules.setdefault(f"_stagnation_load_err_{full_name}", exc)
-    _bind_on_parent(full_name, mod)
+        _stubs.real_load(name, _BACKEND / rel)
+    except Exception as exc:  # noqa: BLE001 - reported, not swallowed
+        _logger.warning("agent_loop conftest: %s could not be real-loaded (%s); tests must mock it", name, exc)
 
 
-# Reuse the session's ``agent_loop`` package object rather than planting a new
-# one — see the module docstring.  The root conftest already gives it a real
-# ``__path__``; assert that here so ``from agent_loop.X import Y`` resolves the
-# light submodules straight from disk even if this file is the first to need
-# them.
-_pkg = sys.modules.get("agent_loop")
-if _pkg is None:
-    _pkg = types.ModuleType("agent_loop")
-    _pkg.__package__ = "agent_loop"
-    sys.modules["agent_loop"] = _pkg
-    _ADDED.add("agent_loop")
-_pkg.__path__ = [str(_AL_DIR)]  # type: ignore[assignment]
+# adopt_package, NOT install_package: the root conftest already planted
+# ``agent_loop``, and replacing that object is the identity swap #13551 traced.
+_stubs.adopt_package("agent_loop", _AL_DIR)
 
-# Load in dependency order (fingerprint and types have no heavy local deps).
-_load_real("agent_loop.fingerprint", "agent_loop/fingerprint.py")
-_load_real("agent_loop.types", "agent_loop/types.py")
-# loop.py pulls in events/planner/tools — load best-effort; tests mock these.
-_load_real("agent_loop.think_tool", "agent_loop/think_tool.py")
-_load_real("agent_loop.slack_hook", "agent_loop/slack_hook.py")
-_load_real("agent_loop.loop", "agent_loop/loop.py")
+# Dependency order (fingerprint and types have no heavy local deps).
+_load_best_effort("agent_loop.fingerprint", "agent_loop/fingerprint.py")
+_load_best_effort("agent_loop.types", "agent_loop/types.py")
+_load_best_effort("agent_loop.think_tool", "agent_loop/think_tool.py")
+_load_best_effort("agent_loop.slack_hook", "agent_loop/slack_hook.py")
+_load_best_effort("agent_loop.loop", "agent_loop/loop.py")
 
-# MVA-1407: belief state + extractors package — reuse an existing entry for the
-# same identity reason as the parent package above.
-_ext_pkg = sys.modules.get("agent_loop.extractors")
-if _ext_pkg is None:
-    _ext_pkg = types.ModuleType("agent_loop.extractors")
-    _ext_pkg.__package__ = "agent_loop.extractors"
-    sys.modules["agent_loop.extractors"] = _ext_pkg
-    _ADDED.add("agent_loop.extractors")
-_ext_pkg.__path__ = [str(_AL_DIR / "extractors")]  # type: ignore[assignment]
-_pkg.extractors = _ext_pkg  # type: ignore[attr-defined]
-_load_real("agent_loop.extractors.read_file", "agent_loop/extractors/read_file.py")
-_load_real("agent_loop.extractors.run_command", "agent_loop/extractors/run_command.py")
-_load_real("agent_loop.extractors.web_search", "agent_loop/extractors/web_search.py")
-_load_real("agent_loop.extractors", "agent_loop/extractors/__init__.py")
-_load_real("agent_loop.belief_state", "agent_loop/belief_state.py")
+# MVA-1407: belief state + extractors package.
+_stubs.adopt_package("agent_loop.extractors", _AL_DIR / "extractors")
+_load_best_effort("agent_loop.extractors.read_file", "agent_loop/extractors/read_file.py")
+_load_best_effort("agent_loop.extractors.run_command", "agent_loop/extractors/run_command.py")
+_load_best_effort("agent_loop.extractors.web_search", "agent_loop/extractors/web_search.py")
+_stubs.real_load_package("agent_loop.extractors", _AL_DIR / "extractors" / "__init__.py", _AL_DIR / "extractors")
+_load_best_effort("agent_loop.belief_state", "agent_loop/belief_state.py")
 
 
 def pytest_unconfigure(config) -> None:  # noqa: ARG001
     """Undo exactly what this file changed, and nothing else.
 
-    Sweeping every ``agent_loop*`` key out of ``sys.modules`` here would drop
-    submodules other collectors imported on their own during the session.
+    StubSet.restore() reverses sys.modules entries, parent bindings and __path__
+    mutations together. The hand-rolled version let ``_ADDED`` and ``_SAVED``
+    overlap, so popping the added key and then restoring the saved one put a
+    synthetic ``agent_loop.extractors`` straight back (#13575).
     """
-    for k in _ADDED:
-        sys.modules.pop(k, None)
-    for k, v in _SAVED.items():
-        sys.modules[k] = v  # type: ignore[assignment]
+    _stubs.restore()

--- a/autobot-backend/tests/search/conftest.py
+++ b/autobot-backend/tests/search/conftest.py
@@ -39,19 +39,13 @@ All fakes here keep tests fully offline (no real network).
 
 from __future__ import annotations
 
-import importlib.util
-import sys
-import types
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from testkit.module_stubs import StubSet
+
 _BACKEND = Path(__file__).parent.parent.parent  # .../autobot-backend
 _SEARCH_DIR = _BACKEND / "agent_loop" / "search"
-
-# Only the entries this file actually replaces are saved — restoring keys we
-# never touched is what made the old save/pop/restore cycle destructive.
-_SAVED: Dict[str, object] = {}
-_ADDED: set = set()
 
 _SUBMODULES = [
     "base",
@@ -61,96 +55,39 @@ _SUBMODULES = [
     "content_reach_provider",
 ]
 
+_stubs = StubSet()
 
-def _bind_on_parent(full_name: str, mod: object) -> None:
-    """Bind *mod* as an attribute of its parent package.
+# adopt_package, NOT install_package. The root conftest already planted
+# ``agent_loop``; replacing that object is precisely the identity swap #13551
+# traced, and install_package would do exactly that. adopt keeps the session's
+# module and only gives it a real ``__path__``, recorded for restore.
+_stubs.adopt_package("agent_loop", _BACKEND / "agent_loop")
+_stubs.adopt_package("agent_loop.search", _SEARCH_DIR)
 
-    Load-bearing for ``unittest.mock.patch``: it resolves ``"agent_loop.search.X"``
-    via ``getattr(sys.modules["agent_loop"], "search")``, NOT via
-    ``sys.modules["agent_loop.search"]``.  A module registered in ``sys.modules``
-    by hand never gets that bind from the import machinery.
-    """
-    parent, _, child = full_name.rpartition(".")
-    if parent and parent in sys.modules:
-        setattr(sys.modules[parent], child, mod)
-
-
-def _load_real(full_name: str, rel: str) -> None:
-    """Register the REAL module for *full_name*, unless it already is real.
-
-    Re-executing a module that is already loaded from this same file builds a
-    second set of class objects while every importer keeps referencing the
-    first — the identity split #13551 traced.  An already-real entry is
-    therefore left alone and only (re)bound on its parent.
-    """
-    path = _BACKEND / rel
-    existing = sys.modules.get(full_name)
-    if existing is not None and getattr(existing, "__file__", None) == str(path):
-        _bind_on_parent(full_name, existing)
-        return
-    spec = importlib.util.spec_from_file_location(full_name, str(path))
-    if not spec or not spec.loader:
-        return
-    mod = importlib.util.module_from_spec(spec)
-    mod.__package__ = full_name.rpartition(".")[0] or full_name
-    if existing is None:
-        _ADDED.add(full_name)
-    else:
-        _SAVED.setdefault(full_name, existing)
-    sys.modules[full_name] = mod
-    spec.loader.exec_module(mod)  # type: ignore[union-attr]
-    _bind_on_parent(full_name, mod)
-
-
-def _ensure_package(full_name: str, path: Path) -> types.ModuleType:
-    """Return the session's package object for *full_name*, giving it a real ``__path__``.
-
-    Reuses the existing ``sys.modules`` entry rather than planting a new one —
-    see the module docstring.
-    """
-    pkg = sys.modules.get(full_name)
-    if pkg is None:
-        pkg = types.ModuleType(full_name)
-        pkg.__package__ = full_name
-        sys.modules[full_name] = pkg
-        _ADDED.add(full_name)
-    pkg.__path__ = [str(path)]  # type: ignore[attr-defined]
-    _bind_on_parent(full_name, pkg)
-    return pkg
-
-
-_ensure_package("agent_loop", _BACKEND / "agent_loop")
-_ensure_package("agent_loop.search", _SEARCH_DIR)
-
-# Load the search modules in dependency order; already-real entries are reused.
+# Dependency order. real_load reuses an entry already loaded from the same file
+# rather than re-executing it, so an already-real module keeps its identity and
+# is only re-bound on its parent.
 for _submod in _SUBMODULES:
-    _load_real(f"agent_loop.search.{_submod}", f"agent_loop/search/{_submod}.py")
-_load_real("agent_loop.search", "agent_loop/search/__init__.py")
+    _stubs.real_load(f"agent_loop.search.{_submod}", _BACKEND / f"agent_loop/search/{_submod}.py")
 
-# Executing ``__init__.py`` through a file spec yields a module with no
-# ``__path__``; restore it so ``from agent_loop.search.X import Y`` keeps
-# resolving from disk for anything imported after this point.
-_search_pkg = sys.modules["agent_loop.search"]
-_search_pkg.__path__ = [str(_SEARCH_DIR)]  # type: ignore[attr-defined]
+# real_load_package, not real_load: executing __init__.py through a file spec
+# yields a module with no __path__, which stops ``from agent_loop.search.X import Y``
+# resolving from disk for everything imported afterwards.
+_stubs.real_load_package("agent_loop.search", _SEARCH_DIR / "__init__.py", _SEARCH_DIR)
 
-# Attach submodules as attributes on the package so unittest.mock.patch can
-# resolve them via getattr (patch walks the dotted path via attribute access).
 for _submod in _SUBMODULES:
-    _full = f"agent_loop.search.{_submod}"
-    if _full in sys.modules:
-        setattr(_search_pkg, _submod, sys.modules[_full])
+    _stubs.real_load(f"agent_loop.search.{_submod}", _BACKEND / f"agent_loop/search/{_submod}.py")
 
 
 def pytest_unconfigure(config) -> None:  # noqa: ARG001
     """Undo exactly what this file changed, and nothing else.
 
-    Sweeping every ``agent_loop*`` key out of ``sys.modules`` here would drop
-    submodules other collectors imported on their own during the session.
+    StubSet.restore() reverses sys.modules entries, parent bindings and __path__
+    mutations in one place. The hand-rolled version had ``_ADDED`` and ``_SAVED``
+    overlap, so popping the added key and then restoring the saved one put a
+    synthetic ``agent_loop.search`` straight back (#13575).
     """
-    for k in _ADDED:
-        sys.modules.pop(k, None)
-    for k, v in _SAVED.items():
-        sys.modules[k] = v  # type: ignore[assignment]
+    _stubs.restore()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #13575

## Thinking Path

Three near-verbatim copies of the same `sys.modules` wiring — `tests/search/conftest.py`, `tests/agent_loop/conftest.py`, and `testkit/module_stubs.py` (#13451), which was built for exactly this. The copies had already drifted: one wraps `exec_module` in `try/except`, the other does not.

**The migration was not mechanical, and that is the important part.**

`StubSet.install_package` builds a fresh `ModuleType` and puts it in `sys.modules`. That is precisely the identity swap #13551 traced, so porting these files onto it naively would have **reintroduced the bug PR #13564 had just fixed**. Verified directly against the root conftest's `agent_loop`:

```console
root-conftest stub is_real_module -> False        # so rule 2 does NOT refuse
install_package returned the SAME object?  -> False
sys.modules now holds the session's object? -> False
```

Rule 2 only refuses *file-backed* modules. The root conftest's `agent_loop` is synthetic with a real `__path__`, so `install_package` would happily replace it — splitting identity for every module that had already bound a name from it.

So the helper gained the operation these callers actually need, rather than the callers being bent to fit the helper.

## What Changed

**`testkit/module_stubs.py`:**

- **`adopt_package`** — reuse the session's existing package object, only giving it a real `__path__`, recording the previous value for restore. The distinction from `install_package` is the whole of #13551, and it is documented as such at the call site.
- **`real_load(reuse_if_loaded=True)`** — a module already loaded from the same file is left alone and only re-bound on its parent. Re-executing it builds a second set of class objects while every importer keeps referencing the first — the same identity split, one level down.
- **`real_load_package`** — keeps `__path__` when executing an `__init__.py` through a file spec, which otherwise strips it and stops `from pkg.sub import X` resolving from disk for everything imported afterwards. Doing this by hand at each call site is how the copies drifted.
- **A missing spec now raises** instead of returning `None`, so a missing file reads as a missing file rather than as a confusing "new `sys.modules` leak".
- **`__path__` mutations are restored** in `restore()`. This matters more than it looks: the leak guard compares `sys.modules` **identity**, so it cannot see a mutated `__path__`. An unrestored one silently re-enables on-disk resolution of a whole package for every later-collected sibling, invisibly.

**Both conftests** now use `adopt_package` + `real_load` and delegate teardown to `restore()`.

The `agent_loop` conftest keeps its best-effort loading — some of those modules pull heavy transitive deps a lean environment may not satisfy, and the tests mock them — but survivable is not the same as invisible. It previously swallowed the exception and stashed it in `sys.modules` under an invented `_stagnation_load_err_*` key, which both hid the error and leaked a key nothing would ever clean up. Now `StubSet.real_load` removes the half-executed module and re-raises, and the conftest logs and continues.

## Verification

**The residue defect, measured rather than argued.** `_ADDED` and `_SAVED` were not mutually exclusive, so `pytest_unconfigure` popped the added key and then the `_SAVED` restore put the synthetic module straight back. Same command, both trees:

```
BASE:   [..., "agent_loop.search", ...]     <- synthetic module left behind
BRANCH: [...]                               <- gone
```

Everything else in the list is the root conftest's, present in both.

**No regression, including the identity-sensitive cases:**

```console
$ pytest autobot-backend/tests/search                     32 passed   (matches base)
$ pytest autobot-backend/tests/agent_loop autobot-backend/agent_loop
                                                         383 passed
$ pytest ... -k "the three tests #13564 fixed"             3 passed, in the damaging collection order
$ pytest autobot-backend/services/research \
         autobot_shared/tool_catalogue_test.py \
         autobot-backend/tests/search                    102 passed
$ pytest autobot-backend/testkit                          14 passed
```

That fourth command is the risk surface the #13564 review identified as missing from its own scope: `services/research/*` and `tool_catalogue_test.py` patch `agent_loop` targets from outside the trees the change touches, and are exactly where a previously-inert patch becoming effective would surface.

Leak guard reports only the known baseline files — no `LEAK`, no `FIXED`, and the baseline is unchanged.

**Lint** — run under both black versions, since `code-quality.yml` pins `26.3.1` while the CI test venv resolves `26.5.1`:

```console
$ black --check (26.3.1)   3 files would be left unchanged
$ black --check (26.5.1)   3 files would be left unchanged
$ flake8 / bandit / check_nosec_format.py   clean
```

All tests run on the Python 3.14 parity environment from #13574, matching CI.

## Model Used

Claude Opus 5 (1M context)
