### PR TITLE
refactor(enums): alias AlertSeverity and ErrorSeverity to the canonical Severity (#13597)

### DIFF
--- a/autobot-backend/utils/error_boundaries/types.py
+++ b/autobot-backend/utils/error_boundaries/types.py
@@ -14,6 +14,8 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Dict
 
+from autobot_shared.status_enums import Severity
+
 # Module-level tuples for error type classification (from original module)
 CRITICAL_ERROR_TYPES = (SystemExit, KeyboardInterrupt, MemoryError)
 HIGH_SEVERITY_ERROR_TYPES = (ConnectionError, TimeoutError, OSError)
@@ -23,13 +25,23 @@ RETRY_ERROR_TYPES = (ConnectionError, TimeoutError)
 SYSTEM_RESTART_ERROR_TYPES = (MemoryError, SystemExit)
 
 
-class ErrorSeverity(Enum):
-    """Error severity levels"""
-
-    LOW = "low"
-    MEDIUM = "medium"
-    HIGH = "high"
-    CRITICAL = "critical"
+# Error severity levels (#13597).
+#
+# This was a local `Enum` declaring LOW/MEDIUM/HIGH/CRITICAL — an exact subset of
+# the canonical `Severity`, same base class, no added behaviour. `Severity`'s own
+# docstring records that #6689 collapsed 10+ severity enums into it; this one and
+# `utils.monitoring_alerts.AlertSeverity` were missed.
+#
+# Kept as an alias rather than removed, so every existing `ErrorSeverity.HIGH`
+# call site keeps working and keeps meaning the same member. Same pattern the
+# canonical module already uses for `WorkflowStatus = TaskStatus`.
+#
+# The alias exposes three members the local enum did not have (UNKNOWN, INFO,
+# MINIMAL). Nothing iterates this enum or takes its length, and both severity
+# mappings that exist (`_max_retries_for_severity` in agent_loop/loop.py and the
+# emoji/tier maps in monitoring_alerts.py) are `.get(..., default)` lookups, so
+# the extra members are inert rather than a behaviour change.
+ErrorSeverity = Severity
 
 
 def classify_error(error: Exception) -> ErrorSeverity:

--- a/autobot-backend/utils/monitoring_alerts.py
+++ b/autobot-backend/utils/monitoring_alerts.py
@@ -17,6 +17,7 @@ from typing import Any, Dict, List, Tuple
 from autobot_shared.alert_cooldown import AlertCooldownManager, AlertTier
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.singleton_factory import lazy_singleton
+from autobot_shared.status_enums import Severity
 from constants.threshold_constants import TimingConstants
 from constants.ttl_constants import TTL_7_DAYS
 
@@ -38,13 +39,18 @@ def _severity_to_tier(severity) -> AlertTier:
     return _SEVERITY_TO_TIER.get(key, AlertTier.ROUTINE)
 
 
-class AlertSeverity(Enum):
-    """Alert severity levels"""
-
-    LOW = "low"
-    MEDIUM = "medium"
-    HIGH = "high"
-    CRITICAL = "critical"
+# Alert severity levels (#13597).
+#
+# Was a local `Enum` with LOW/MEDIUM/HIGH/CRITICAL — an exact subset of the
+# canonical `Severity`, identical base class, no added behaviour. Aliased rather
+# than removed so existing `AlertSeverity.HIGH` call sites keep working, matching
+# the `WorkflowStatus = TaskStatus` precedent in the canonical module.
+#
+# `_SEVERITY_TO_TIER` above and the emoji map in `LogNotificationChannel` are
+# both `.get(..., default)` lookups keyed on the four original members, so the
+# three additional ones (UNKNOWN, INFO, MINIMAL) fall through to the existing
+# defaults instead of raising.
+AlertSeverity = Severity
 
 
 class AlertStatus(Enum):


### PR DESCRIPTION
## Thinking Path

`autobot_shared/status_enums.py` is the canonical enum home, and `Severity`'s own docstring records that #6689 collapsed 10+ severity enums into it — naming `IssueSeverity`, `DFASeverity`, `ImpactLevel`, `CostLevel`, `DebtSeverity`, `RiskLevel`. Two were missed: `AlertSeverity` and `ErrorSeverity`, both still declaring `LOW/MEDIUM/HIGH/CRITICAL` locally. This finishes that consolidation for the two exact duplicates.

The module already establishes the pattern to use — `WorkflowStatus = TaskStatus` on line 70 — so this follows it rather than inventing one.

**Aliased, not deleted.** Every `ErrorSeverity.HIGH` / `AlertSeverity.CRITICAL` call site keeps working and keeps resolving to the same member object, so no consumer had to be touched.

## What Changed

Two files. Each local `class …Severity(Enum)` becomes an alias to the canonical `Severity`, with the reasoning recorded inline.

- `autobot-backend/utils/error_boundaries/types.py` — `ErrorSeverity = Severity`
- `autobot-backend/utils/monitoring_alerts.py` — `AlertSeverity = Severity`

`from enum import Enum` stays in both: `ErrorCategory` and `RecoveryStrategy` in the first, `AlertStatus` in the second still need it.

## Why this is safe rather than merely plausible

The alias exposes three members the local enums did not have (`UNKNOWN`, `INFO`, `MINIMAL`). That is only inert if nothing depends on the member set, so I checked rather than assumed:

- **Nothing iterates either enum.** No `for … in AlertSeverity`, `list(...)`, `len(...)`, or `__members__` access anywhere in `autobot-backend/` or `autobot_shared/`.
- **Every severity-keyed mapping is a `.get(…, default)` lookup**, so unmapped members fall through instead of raising:
  - `agent_loop/loop.py:1829` `_max_retries_for_severity` → `mapping.get(severity, self.config.max_consecutive_errors)`
  - `utils/monitoring_alerts.py` `_severity_to_tier` → `_SEVERITY_TO_TIER.get(key, AlertTier.ROUTINE)`
  - `utils/monitoring_alerts.py` `LogNotificationChannel.send_alert` → `severity_emoji.get(alert.severity, "⚠️")`
- **Both were plain `Enum`, same as canonical `Severity`** (not `str, Enum`), so comparison and identity semantics are unchanged, and neither module read `.value` off those members in a way that would pin a serialisation shape.

## Verification

Identity is preserved, which is what the existing `is` assertions depend on:

```
ErrorSeverity is Severity: True
HIGH value: high | identity ok: True
classify_error(OSError()) -> Severity.HIGH
```

Every module importing either name still imports cleanly:

```
  ok   utils.monitoring_alerts
  ok   agent_loop.loop
  ok   utils.error_boundaries.boundary_manager
  ok   utils.error_boundaries.types
  ok   utils.error_boundaries.__init__
```

Directly affected tests, then the surrounding suites:

```
21 passed in 0.40s        # tests/agent_loop/test_error_severity.py + utils/monitoring_alerts_test.py
745 passed, 14 skipped in 287.39s   # autobot-backend/utils/ + autobot-backend/tests/agent_loop/
```

## Scope — #13597 stays open

This delivers item 1 of three. Deliberately not closing, because partial delivery does not close an issue:

- **Item 2** — 119 bare `"severity": "<literal>"` dict entries that bypass enums entirely. Larger and needs care to separate in-process values from external scanner output, which is wire data and should stay a string.
- **Item 3** — `status_enums.py` is internally inconsistent: seven plain `Enum` against two `str, Enum`. Two serialisation behaviours in one module is a trap, but picking one is a decision with its own blast radius.

Also unchanged on purpose: `ValidationSeverity`, `CheckSeverity` and `ReviewSeverity` are **not** duplicates — they encode an outcome (`SUCCESS`), a gate action (`BLOCK`) and a review taxonomy (`SUGGESTION`) respectively. Folding them in would lose meaning; #13597 records that explicitly so nobody "finishes the job" by mistake.

Refs #13597

## Model Used

Claude Opus 5
