### PR TITLE
fix(optimization): trim_to_length must retain the newest positions, not the oldest (#13033)

### DIFF
--- a/autobot-backend/llm_shared/optimization/kv_cache.py
+++ b/autobot-backend/llm_shared/optimization/kv_cache.py
@@ -107,9 +107,7 @@ class KVCacheConfig:
         if self.batch_size < 1:
             raise ValueError(f"batch_size must be >= 1, got {self.batch_size}")
         if self.dtype not in _DTYPE_BYTES:
-            raise ValueError(
-                f"Unsupported dtype '{self.dtype}'. " f"Choose from: {sorted(_DTYPE_BYTES)}"
-            )
+            raise ValueError(f"Unsupported dtype '{self.dtype}'. " f"Choose from: {sorted(_DTYPE_BYTES)}")
 
     @property
     def dtype_bytes(self) -> int:
@@ -352,25 +350,17 @@ class LayerKVCache:
         for name, tensor in (("new_k", new_k), ("new_v", new_v)):
             if tensor.ndim != 4:
                 raise ValueError(
-                    f"{name} must be 4D [batch, seq, heads, head_dim], "
-                    f"got {tensor.ndim}D for layer {layer_idx}"
+                    f"{name} must be 4D [batch, seq, heads, head_dim], " f"got {tensor.ndim}D for layer {layer_idx}"
                 )
             b, _seq, h, d = tensor.shape
             if b != cfg.batch_size:
                 raise ValueError(
-                    f"{name} batch size {b} != config batch_size {cfg.batch_size} "
-                    f"for layer {layer_idx}"
+                    f"{name} batch size {b} != config batch_size {cfg.batch_size} " f"for layer {layer_idx}"
                 )
             if h != cfg.num_heads:
-                raise ValueError(
-                    f"{name} num_heads {h} != config num_heads {cfg.num_heads} "
-                    f"for layer {layer_idx}"
-                )
+                raise ValueError(f"{name} num_heads {h} != config num_heads {cfg.num_heads} " f"for layer {layer_idx}")
             if d != cfg.head_dim:
-                raise ValueError(
-                    f"{name} head_dim {d} != config head_dim {cfg.head_dim} "
-                    f"for layer {layer_idx}"
-                )
+                raise ValueError(f"{name} head_dim {d} != config head_dim {cfg.head_dim} " f"for layer {layer_idx}")
 
     def _allocate_layer_tensors(
         self,
@@ -406,8 +396,7 @@ class LayerKVCache:
         end = start + new_seq
         if end > self._config.max_seq_len:
             raise ValueError(
-                f"KV cache overflow: current={start}, adding={new_seq}, "
-                f"max_seq_len={self._config.max_seq_len}"
+                f"KV cache overflow: current={start}, adding={new_seq}, " f"max_seq_len={self._config.max_seq_len}"
             )
         entry.k[:, start:end, :, :] = new_k
         entry.v[:, start:end, :, :] = new_v
@@ -441,8 +430,7 @@ class KVCacheManager:
         """
         estimated = self.estimate_memory(config)
         logger.info(
-            "Creating KV cache: layers=%d heads=%d head_dim=%d max_seq=%d "
-            "dtype=%s estimated_mb=%.1f",
+            "Creating KV cache: layers=%d heads=%d head_dim=%d max_seq=%d " "dtype=%s estimated_mb=%.1f",
             config.num_layers,
             config.num_heads,
             config.head_dim,

--- a/autobot-backend/llm_shared/optimization/kv_cache.py
+++ b/autobot-backend/llm_shared/optimization/kv_cache.py
@@ -107,7 +107,9 @@ class KVCacheConfig:
         if self.batch_size < 1:
             raise ValueError(f"batch_size must be >= 1, got {self.batch_size}")
         if self.dtype not in _DTYPE_BYTES:
-            raise ValueError(f"Unsupported dtype '{self.dtype}'. " f"Choose from: {sorted(_DTYPE_BYTES)}")
+            raise ValueError(
+                f"Unsupported dtype '{self.dtype}'. " f"Choose from: {sorted(_DTYPE_BYTES)}"
+            )
 
     @property
     def dtype_bytes(self) -> int:
@@ -252,13 +254,23 @@ class LayerKVCache:
         )
 
     def trim_to_length(self, max_len: int) -> None:
-        """Trim all layer caches to at most max_len filled positions.
+        """Retain at most the ``max_len`` **most recent** positions per layer.
 
-        Useful for sliding-window attention or when sequence length exceeds
-        a target budget.  The underlying tensor allocation is unchanged —
-        only the filled_len pointer is moved back.
+        Useful for sliding-window attention or when sequence length exceeds a
+        target budget.  The underlying tensor allocation is unchanged — the
+        retained window is moved to offset 0 and ``filled_len`` follows it.
 
-        Issue #1964.
+        Issue #1964; corrected in #13033.
+
+        This used to set ``entry.filled_len = max_len`` and nothing else, which
+        keeps ``[0, max_len)``.  Storage here is linear and append-only —
+        :meth:`update` writes at ``[filled_len : filled_len + n]`` and
+        :meth:`get` returns ``k[:, :filled_len]`` — so index 0 is the *first*
+        token of the sequence and ``filled_len - 1`` is the most recent.
+        Truncating the pointer therefore discarded exactly the tokens a sliding
+        window exists to keep, and did so silently: the shape was right and the
+        content was the wrong end of the sequence.  No caller could implement a
+        working sliding window on that behaviour.
 
         Args:
             max_len: Maximum number of positions to retain per layer.
@@ -266,16 +278,33 @@ class LayerKVCache:
         if max_len < 0:
             raise ValueError(f"max_len must be >= 0, got {max_len}")
         trimmed_layers = 0
-        for layer_idx, entry in self._entries.items():
+        for entry in self._entries.values():
             if entry.filled_len > max_len:
-                entry.filled_len = max_len
+                self._retain_tail(entry, max_len)
                 trimmed_layers += 1
         if trimmed_layers > 0:
             logger.debug(
-                "LayerKVCache trimmed %d layers to max_len=%d",
+                "LayerKVCache trimmed %d layers to the newest max_len=%d",
                 trimmed_layers,
                 max_len,
             )
+
+    @staticmethod
+    def _retain_tail(entry: "_LayerEntry", max_len: int) -> None:
+        """Move the newest ``max_len`` positions of *entry* down to offset 0.
+
+        ``copy_`` on an explicit source clone rather than a plain slice
+        assignment: source and destination overlap whenever
+        ``max_len > filled_len / 2``, and copying a tensor onto an overlapping
+        view of itself is undefined.  ``max_len == 0`` is handled by the caller's
+        ``>`` comparison only when ``filled_len > 0``, so the slice is never
+        empty here.
+        """
+        start = entry.filled_len - max_len
+        if max_len > 0:
+            entry.k[:, :max_len, :, :].copy_(entry.k[:, start : entry.filled_len, :, :].clone())
+            entry.v[:, :max_len, :, :].copy_(entry.v[:, start : entry.filled_len, :, :].clone())
+        entry.filled_len = max_len
 
     def clear(self) -> None:
         """Release all cached tensors and reset filled lengths.
@@ -323,17 +352,25 @@ class LayerKVCache:
         for name, tensor in (("new_k", new_k), ("new_v", new_v)):
             if tensor.ndim != 4:
                 raise ValueError(
-                    f"{name} must be 4D [batch, seq, heads, head_dim], " f"got {tensor.ndim}D for layer {layer_idx}"
+                    f"{name} must be 4D [batch, seq, heads, head_dim], "
+                    f"got {tensor.ndim}D for layer {layer_idx}"
                 )
             b, _seq, h, d = tensor.shape
             if b != cfg.batch_size:
                 raise ValueError(
-                    f"{name} batch size {b} != config batch_size {cfg.batch_size} " f"for layer {layer_idx}"
+                    f"{name} batch size {b} != config batch_size {cfg.batch_size} "
+                    f"for layer {layer_idx}"
                 )
             if h != cfg.num_heads:
-                raise ValueError(f"{name} num_heads {h} != config num_heads {cfg.num_heads} " f"for layer {layer_idx}")
+                raise ValueError(
+                    f"{name} num_heads {h} != config num_heads {cfg.num_heads} "
+                    f"for layer {layer_idx}"
+                )
             if d != cfg.head_dim:
-                raise ValueError(f"{name} head_dim {d} != config head_dim {cfg.head_dim} " f"for layer {layer_idx}")
+                raise ValueError(
+                    f"{name} head_dim {d} != config head_dim {cfg.head_dim} "
+                    f"for layer {layer_idx}"
+                )
 
     def _allocate_layer_tensors(
         self,
@@ -369,7 +406,8 @@ class LayerKVCache:
         end = start + new_seq
         if end > self._config.max_seq_len:
             raise ValueError(
-                f"KV cache overflow: current={start}, adding={new_seq}, " f"max_seq_len={self._config.max_seq_len}"
+                f"KV cache overflow: current={start}, adding={new_seq}, "
+                f"max_seq_len={self._config.max_seq_len}"
             )
         entry.k[:, start:end, :, :] = new_k
         entry.v[:, start:end, :, :] = new_v
@@ -403,7 +441,8 @@ class KVCacheManager:
         """
         estimated = self.estimate_memory(config)
         logger.info(
-            "Creating KV cache: layers=%d heads=%d head_dim=%d max_seq=%d " "dtype=%s estimated_mb=%.1f",
+            "Creating KV cache: layers=%d heads=%d head_dim=%d max_seq=%d "
+            "dtype=%s estimated_mb=%.1f",
             config.num_layers,
             config.num_heads,
             config.head_dim,

--- a/autobot-backend/llm_shared/optimization/kv_cache_test.py
+++ b/autobot-backend/llm_shared/optimization/kv_cache_test.py
@@ -335,8 +335,15 @@ class TestLayerKVCacheTrim:
         with pytest.raises(ValueError, match="max_len"):
             cache.trim_to_length(-1)
 
-    def test_trim_preserves_content_up_to_limit(self):
-        """After trim, the remaining content should match the original."""
+    def test_trim_retains_the_newest_positions_not_the_oldest(self):
+        """Trim must keep the tail of the sequence (#13033).
+
+        This assertion used to read ``k[:, :6]`` — the *oldest* six — and passed,
+        because the implementation only moved ``filled_len`` back. Both were
+        wrong in the same direction, so the test confirmed the bug instead of
+        catching it. A sliding window needs the most recent positions; keeping
+        the oldest gives a context that never advances.
+        """
         cfg = _make_config(num_heads=2, head_dim=8, max_seq_len=64)
         cache = LayerKVCache(cfg)
         k, v = _make_kv(seq=12, heads=2, head_dim=8)
@@ -346,8 +353,51 @@ class TestLayerKVCacheTrim:
 
         r = cache.get(0)
         assert r is not None
-        assert torch.allclose(r[0], k[:, :6, :, :])
-        assert torch.allclose(r[1], v[:, :6, :, :])
+        assert torch.allclose(r[0], k[:, 6:, :, :])
+        assert torch.allclose(r[1], v[:, 6:, :, :])
+        # And explicitly not the head, so a symmetric window cannot pass by luck.
+        assert not torch.allclose(r[0], k[:, :6, :, :])
+
+    def test_trim_then_update_appends_after_the_retained_window(self):
+        """The write pointer must follow the retained window, not the old end.
+
+        Guards the other half of the fix: if ``filled_len`` were moved without
+        relocating the data (or the reverse), the next ``update()`` would either
+        overwrite live positions or leave a hole of stale tokens between the
+        window and the new ones.
+        """
+        cfg = _make_config(num_heads=2, head_dim=8, max_seq_len=64)
+        cache = LayerKVCache(cfg)
+        k, v = _make_kv(seq=10, heads=2, head_dim=8)
+        cache.update(0, k, v)
+        cache.trim_to_length(4)
+
+        nk, nv = _make_kv(seq=3, heads=2, head_dim=8)
+        cache.update(0, nk, nv)
+
+        r = cache.get(0)
+        assert r is not None and r[0].shape[1] == 7
+        assert torch.allclose(r[0][:, :4, :, :], k[:, 6:, :, :])
+        assert torch.allclose(r[0][:, 4:, :, :], nk)
+
+    def test_trim_with_overlapping_source_and_destination(self):
+        """max_len > filled_len/2 makes the move overlap itself.
+
+        Copying a tensor onto an overlapping view of itself is undefined, so the
+        implementation clones the source first. With seq=10 and max_len=7 the
+        ranges [3:10] and [0:7] overlap across four positions.
+        """
+        cfg = _make_config(num_heads=2, head_dim=8, max_seq_len=64)
+        cache = LayerKVCache(cfg)
+        k, v = _make_kv(seq=10, heads=2, head_dim=8)
+        cache.update(0, k, v)
+
+        cache.trim_to_length(7)
+
+        r = cache.get(0)
+        assert r is not None
+        assert torch.allclose(r[0], k[:, 3:, :, :])
+        assert torch.allclose(r[1], v[:, 3:, :, :])
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Thinking Path

`LayerKVCache.trim_to_length()` did the opposite of what it exists for. Storage is linear and append-only — `update()` writes at `[filled_len : filled_len + n]` and `get()` returns `k[:, :filled_len]` — so index 0 is the *first* token of the sequence and `filled_len - 1` is the most recent. The method only moved the pointer back:

```python
if entry.filled_len > max_len:
    entry.filled_len = max_len
```

That retains `[0, max_len)` — the **oldest** window — and silently drops everything recent. A sliding window needs the newest positions, so every caller got a context anchored at the start of the sequence that never advances. The shape was right and the content was the wrong end, which is why it went unnoticed.

## What Changed

`trim_to_length` now relocates the newest `max_len` positions down to offset 0 before moving `filled_len`, via a small `_retain_tail` helper.

The copy goes through an explicit `.clone()` of the source. Source and destination overlap whenever `max_len > filled_len / 2`, and copying a tensor onto an overlapping view of itself is undefined — that is a real case, not a hypothetical, and it has its own test.

## The existing test was asserting the bug

`test_trim_preserves_content_up_to_limit` read:

```python
cache.trim_to_length(6)
assert torch.allclose(r[0], k[:, :6, :, :])   # the OLDEST six
```

Implementation and test were wrong in the same direction, so the suite confirmed the defect rather than catching it. It is now `test_trim_retains_the_newest_positions_not_the_oldest`, asserting `k[:, 6:]` **and** explicitly asserting the head does *not* match, so a symmetric fixture cannot pass by luck.

Two further tests cover what the fix could plausibly get wrong:

- `test_trim_then_update_appends_after_the_retained_window` — the write pointer must follow the relocated window. Moving data without the pointer (or the reverse) would either overwrite live positions or leave a hole of stale tokens.
- `test_trim_with_overlapping_source_and_destination` — `seq=10`, `max_len=7`, so `[3:10]` and `[0:7]` overlap across four positions.

## Verification

**The tests fail against the old implementation.** Source reverted, tests kept:

```
FAILED ...::test_trim_retains_the_newest_positions_not_the_oldest
FAILED ...::test_trim_then_update_appends_after_the_retained_window
FAILED ...::test_trim_with_overlapping_source_and_destination
3 failed, 4 passed
```

With the fix restored:

```
53 passed          # kv_cache_test.py
341 passed         # autobot-backend/llm_shared/optimization/
```

**These tests are `@requires_torch` and skip without it.** Under the default interpreter they report `28 passed, 25 skipped` and every trim test is in the skipped set — running them there proves nothing. The runs above use an interpreter with `torch 2.13.0+cpu` so the assertions actually execute.

## Scope

This is Step 1 of #13033 (correctness). Step 2 — replacing linear storage with a fixed-capacity circular ring so trimming is a pointer move with no copy — is a separate performance change and is not in this PR, so the issue stays open. The `_write_to_entry` overflow behaviour noted in the issue (raises rather than evicting) is also untouched.

Refs #13033

## Model Used

Claude Opus 5
