### PR TITLE
perf(optimization): memory-map the checkpoint once instead of deserialising it per layer per token (#13031)

### DIFF
--- a/autobot-backend/llm_shared/optimization/layer_inference.py
+++ b/autobot-backend/llm_shared/optimization/layer_inference.py
@@ -77,9 +77,7 @@ class LayerInferenceConfig:
         if not self.model_name:
             raise ValueError("model_name must not be empty")
         if self.compression not in _VALID_COMPRESSIONS:
-            raise ValueError(
-                f"compression must be one of {sorted(_VALID_COMPRESSIONS)}, got '{self.compression}'"
-            )
+            raise ValueError(f"compression must be one of {sorted(_VALID_COMPRESSIONS)}, got '{self.compression}'")
         if self.max_seq_len < 1:
             raise ValueError(f"max_seq_len must be >= 1, got {self.max_seq_len}")
         if self.batch_size < 1:
@@ -182,8 +180,7 @@ class LayerInferenceEngine:
             from transformers import AutoConfig  # noqa: PLC0415
         except ImportError as exc:
             raise ImportError(
-                "transformers is required for load_model_config. "
-                "Install with: pip install transformers>=4.40.0"
+                "transformers is required for load_model_config. " "Install with: pip install transformers>=4.40.0"
             ) from exc
 
         kwargs: Dict[str, Any] = {}
@@ -192,9 +189,7 @@ class LayerInferenceEngine:
 
         logger.debug("Loading model config for %s", model_name)
         # HuggingFace model loaded by name; revision pinning managed operationally.
-        auto_cfg = AutoConfig.from_pretrained(
-            model_name, resume_download=True, **kwargs
-        )  # nosec B615
+        auto_cfg = AutoConfig.from_pretrained(model_name, resume_download=True, **kwargs)  # nosec B615
         cfg_dict: Dict[str, Any] = auto_cfg.to_dict()
         logger.info(
             "Loaded model config for %s: arch=%s",
@@ -221,14 +216,10 @@ class LayerInferenceEngine:
         Returns:
             Ordered list of transformer layer name strings.
         """
-        num_layers = (
-            config.get("num_hidden_layers") or config.get("n_layer") or config.get("num_layers")
-        )
+        num_layers = config.get("num_hidden_layers") or config.get("n_layer") or config.get("num_layers")
 
         if num_layers is None:
-            logger.warning(
-                "Could not determine num_hidden_layers from config — returning ['model']"
-            )
+            logger.warning("Could not determine num_hidden_layers from config — returning ['model']")
             return ["model"]
 
         model_type: str = str(config.get("model_type", "")).lower()
@@ -414,11 +405,7 @@ class LayerInferenceEngine:
         if not layers:
             raise ValueError("layers must not be empty")
 
-        hidden = (
-            input_ids.float()
-            if input_ids.dtype not in (torch.float16, torch.float32)
-            else input_ids
-        )
+        hidden = input_ids.float() if input_ids.dtype not in (torch.float16, torch.float32) else input_ids
 
         for layer in layers:
             out = layer(hidden)
@@ -471,8 +458,7 @@ class LayerInferenceEngine:
             from transformers import AutoTokenizer  # noqa: PLC0415
         except (ImportError, RuntimeError) as exc:
             raise ImportError(
-                "transformers is required for generate. "
-                "Install with: pip install transformers>=4.40.0"
+                "transformers is required for generate. " "Install with: pip install transformers>=4.40.0"
             ) from exc
 
         t_start = time.monotonic()
@@ -533,9 +519,7 @@ class LayerInferenceEngine:
         if self._config.cache_dir:
             kwargs["cache_dir"] = self._config.cache_dir
         # HuggingFace model loaded by name; revision pinning managed operationally.
-        return AutoTokenizer.from_pretrained(
-            self._config.model_name, resume_download=True, **kwargs
-        )  # nosec B615
+        return AutoTokenizer.from_pretrained(self._config.model_name, resume_download=True, **kwargs)  # nosec B615
 
     def _resolve_checkpoint_path(self) -> str:
         """Return the checkpoint path for the configured model.

--- a/autobot-backend/llm_shared/optimization/layer_inference.py
+++ b/autobot-backend/llm_shared/optimization/layer_inference.py
@@ -77,7 +77,9 @@ class LayerInferenceConfig:
         if not self.model_name:
             raise ValueError("model_name must not be empty")
         if self.compression not in _VALID_COMPRESSIONS:
-            raise ValueError(f"compression must be one of {sorted(_VALID_COMPRESSIONS)}, got '{self.compression}'")
+            raise ValueError(
+                f"compression must be one of {sorted(_VALID_COMPRESSIONS)}, got '{self.compression}'"
+            )
         if self.max_seq_len < 1:
             raise ValueError(f"max_seq_len must be >= 1, got {self.max_seq_len}")
         if self.batch_size < 1:
@@ -136,6 +138,11 @@ class LayerInferenceEngine:
 
     def __init__(self, config: LayerInferenceConfig) -> None:
         self._config = config
+        # #13031: one memory-mapped handle per checkpoint, reused across every
+        # load_layer call. Without it the generate() loop re-deserialised the
+        # whole file once per layer per token — 2,048 times for a 32-layer model
+        # producing 64 tokens.
+        self._mapped_checkpoints: Dict[str, Any] = {}
         logger.info(
             "LayerInferenceEngine initialised: model=%s compression=%s device=%s max_seq=%d",
             config.model_name,
@@ -175,7 +182,8 @@ class LayerInferenceEngine:
             from transformers import AutoConfig  # noqa: PLC0415
         except ImportError as exc:
             raise ImportError(
-                "transformers is required for load_model_config. " "Install with: pip install transformers>=4.40.0"
+                "transformers is required for load_model_config. "
+                "Install with: pip install transformers>=4.40.0"
             ) from exc
 
         kwargs: Dict[str, Any] = {}
@@ -184,7 +192,9 @@ class LayerInferenceEngine:
 
         logger.debug("Loading model config for %s", model_name)
         # HuggingFace model loaded by name; revision pinning managed operationally.
-        auto_cfg = AutoConfig.from_pretrained(model_name, resume_download=True, **kwargs)  # nosec B615
+        auto_cfg = AutoConfig.from_pretrained(
+            model_name, resume_download=True, **kwargs
+        )  # nosec B615
         cfg_dict: Dict[str, Any] = auto_cfg.to_dict()
         logger.info(
             "Loaded model config for %s: arch=%s",
@@ -211,10 +221,14 @@ class LayerInferenceEngine:
         Returns:
             Ordered list of transformer layer name strings.
         """
-        num_layers = config.get("num_hidden_layers") or config.get("n_layer") or config.get("num_layers")
+        num_layers = (
+            config.get("num_hidden_layers") or config.get("n_layer") or config.get("num_layers")
+        )
 
         if num_layers is None:
-            logger.warning("Could not determine num_hidden_layers from config — returning ['model']")
+            logger.warning(
+                "Could not determine num_hidden_layers from config — returning ['model']"
+            )
             return ["model"]
 
         model_type: str = str(config.get("model_type", "")).lower()
@@ -231,6 +245,61 @@ class LayerInferenceEngine:
     # ------------------------------------------------------------------
     # Layer load / evict
     # ------------------------------------------------------------------
+
+    def _checkpoint(self, torch: Any, state_dict_path: str) -> Dict[str, Any]:
+        """Return the checkpoint's tensors, memory-mapped and cached per path.
+
+        ``mmap=True`` makes ``torch.load`` map the file rather than deserialise
+        it: the returned dict holds tensor views backed by the file on disk, and
+        only the bytes a caller actually reads are paged in. Selecting one
+        layer's keys therefore touches one layer's weights, which is what makes
+        peak memory bounded by the largest single layer as this module's
+        docstring promises — the previous full ``torch.load`` materialised every
+        parameter and then discarded all but one layer's.
+
+        Caching the handle is what removes the per-token cost. It is cheap to
+        hold precisely because it is a mapping and not a copy: the pages are
+        clean and the kernel can reclaim them under pressure.
+
+        The fallback path is deliberately **not** cached. Legacy (non-zipfile)
+        checkpoints cannot be mapped, and there the dict is a real in-RAM copy —
+        keeping it would trade this issue's problem for the one the module was
+        written to avoid.
+        """
+        cached = self._mapped_checkpoints.get(state_dict_path)
+        if cached is not None:
+            return cached
+        try:
+            mapped = torch.load(state_dict_path, map_location="cpu", weights_only=True, mmap=True)
+        except (RuntimeError, ValueError, TypeError) as exc:
+            logger.warning(
+                "Checkpoint %s cannot be memory-mapped (%s) — falling back to a full load. "
+                "Peak memory is the whole model and the load repeats per layer (#13031).",
+                state_dict_path,
+                exc,
+            )
+            return torch.load(state_dict_path, map_location="cpu", weights_only=True)
+        self._mapped_checkpoints[state_dict_path] = mapped
+        return mapped
+
+    def release_checkpoints(self) -> None:
+        """Drop cached memory-mapped checkpoints so their mappings can close.
+
+        Call when a model is swapped out.
+
+        Note that on a **CPU** device this does not necessarily unmap anything
+        immediately: ``_build_layer_module`` ends in ``module.to(device)``, which
+        is a no-op when the tensors are already on CPU, so those parameters
+        still alias the mapped file. Refcounting keeps the mapping alive for as
+        long as any live layer references it, so dropping the cache here is safe
+        either way — it releases the mapping once the last layer holding it is
+        evicted. On CUDA the ``.to()`` genuinely copies and the mapping is
+        released as soon as this returns.
+        """
+        count = len(self._mapped_checkpoints)
+        self._mapped_checkpoints.clear()
+        if count:
+            logger.debug("Released %d memory-mapped checkpoint(s)", count)
 
     def load_layer(self, layer_name: str, state_dict_path: str) -> Any:
         """Load a single transformer layer's weights onto the configured device.
@@ -260,7 +329,7 @@ class LayerInferenceEngine:
         logger.debug("Loading layer '%s' from %s", layer_name, state_dict_path)
         t0 = time.monotonic()
 
-        full_sd: Dict[str, Any] = torch.load(state_dict_path, map_location="cpu", weights_only=True)
+        full_sd = self._checkpoint(torch, state_dict_path)
         prefix = layer_name + "."
         layer_sd = {k[len(prefix) :]: v for k, v in full_sd.items() if k.startswith(prefix)}
 
@@ -345,7 +414,11 @@ class LayerInferenceEngine:
         if not layers:
             raise ValueError("layers must not be empty")
 
-        hidden = input_ids.float() if input_ids.dtype not in (torch.float16, torch.float32) else input_ids
+        hidden = (
+            input_ids.float()
+            if input_ids.dtype not in (torch.float16, torch.float32)
+            else input_ids
+        )
 
         for layer in layers:
             out = layer(hidden)
@@ -398,7 +471,8 @@ class LayerInferenceEngine:
             from transformers import AutoTokenizer  # noqa: PLC0415
         except (ImportError, RuntimeError) as exc:
             raise ImportError(
-                "transformers is required for generate. " "Install with: pip install transformers>=4.40.0"
+                "transformers is required for generate. "
+                "Install with: pip install transformers>=4.40.0"
             ) from exc
 
         t_start = time.monotonic()
@@ -459,7 +533,9 @@ class LayerInferenceEngine:
         if self._config.cache_dir:
             kwargs["cache_dir"] = self._config.cache_dir
         # HuggingFace model loaded by name; revision pinning managed operationally.
-        return AutoTokenizer.from_pretrained(self._config.model_name, resume_download=True, **kwargs)  # nosec B615
+        return AutoTokenizer.from_pretrained(
+            self._config.model_name, resume_download=True, **kwargs
+        )  # nosec B615
 
     def _resolve_checkpoint_path(self) -> str:
         """Return the checkpoint path for the configured model.

--- a/autobot-backend/llm_shared/optimization/layer_inference_test.py
+++ b/autobot-backend/llm_shared/optimization/layer_inference_test.py
@@ -119,12 +119,8 @@ class TestLayerInferenceConfig:
 
     def test_cache_dir_accepted(self):
         """cache_dir string should be stored on the config."""
-        cfg = _make_config(
-            cache_dir="/tmp/models"
-        )  # nosec B108  # test/controlled code uses tmpdir intentionally
-        assert (
-            cfg.cache_dir == "/tmp/models"
-        )  # nosec B108  # test/controlled code uses tmpdir intentionally
+        cfg = _make_config(cache_dir="/tmp/models")  # nosec B108  # test/controlled code uses tmpdir intentionally
+        assert cfg.cache_dir == "/tmp/models"  # nosec B108  # test/controlled code uses tmpdir intentionally
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/llm_shared/optimization/layer_inference_test.py
+++ b/autobot-backend/llm_shared/optimization/layer_inference_test.py
@@ -119,8 +119,12 @@ class TestLayerInferenceConfig:
 
     def test_cache_dir_accepted(self):
         """cache_dir string should be stored on the config."""
-        cfg = _make_config(cache_dir="/tmp/models")  # nosec B108  # test/controlled code uses tmpdir intentionally
-        assert cfg.cache_dir == "/tmp/models"  # nosec B108  # test/controlled code uses tmpdir intentionally
+        cfg = _make_config(
+            cache_dir="/tmp/models"
+        )  # nosec B108  # test/controlled code uses tmpdir intentionally
+        assert (
+            cfg.cache_dir == "/tmp/models"
+        )  # nosec B108  # test/controlled code uses tmpdir intentionally
 
 
 # ---------------------------------------------------------------------------
@@ -232,6 +236,88 @@ class TestLoadEvictCycle:
             # Module should have at least one parameter
             params = list(module.parameters())
             assert len(params) >= 1
+        finally:
+            os.unlink(path)
+
+    def test_checkpoint_is_read_once_across_many_layer_loads(self):
+        """The file must be deserialised once per path, not once per load (#13031).
+
+        This is the whole point of the issue: ``generate()`` calls
+        ``load_layer`` once per layer per token, so a 32-layer model producing
+        64 tokens used to hit ``torch.load`` 2,048 times on the same file.
+        """
+        engine = _make_engine()
+        names = [f"model.layers.{i}" for i in range(4)]
+        sd = {}
+        for name in names:
+            sd.update(_tiny_state_dict(name))
+        with tempfile.NamedTemporaryFile(suffix=".pt", delete=False) as f:
+            path = f.name
+        try:
+            _write_state_dict(sd, path)
+            real_load = torch.load
+            calls = []
+
+            def counting_load(*args, **kwargs):
+                calls.append(kwargs.get("mmap", False))
+                return real_load(*args, **kwargs)
+
+            with patch.object(torch, "load", side_effect=counting_load):
+                for _ in range(3):  # stand in for successive generated tokens
+                    for name in names:
+                        engine.load_layer(name, path)
+
+            assert len(calls) == 1, f"expected 1 deserialisation, got {len(calls)}"
+            assert calls[0] is True, "checkpoint should be opened with mmap=True"
+        finally:
+            os.unlink(path)
+
+    def test_mmap_failure_falls_back_and_does_not_cache(self):
+        """A checkpoint that cannot be mapped must still load — and not be cached.
+
+        Caching the fallback would keep a full in-RAM copy of the model, which
+        is the failure mode this module exists to avoid; re-reading is the lesser
+        evil, so the fallback deliberately reloads each time.
+        """
+        engine = _make_engine()
+        layer_name = "model.layers.0"
+        sd = _tiny_state_dict(layer_name)
+        with tempfile.NamedTemporaryFile(suffix=".pt", delete=False) as f:
+            path = f.name
+        try:
+            _write_state_dict(sd, path)
+            real_load = torch.load
+
+            def no_mmap(*args, **kwargs):
+                if kwargs.pop("mmap", False):
+                    raise RuntimeError("mmap unsupported for this checkpoint")
+                return real_load(*args, **kwargs)
+
+            with patch.object(torch, "load", side_effect=no_mmap):
+                first = engine.load_layer(layer_name, path)
+                second = engine.load_layer(layer_name, path)
+
+            assert isinstance(first, torch.nn.Module)
+            assert isinstance(second, torch.nn.Module)
+            assert engine._mapped_checkpoints == {}
+        finally:
+            os.unlink(path)
+
+    def test_release_checkpoints_drops_the_cache(self):
+        """release_checkpoints clears cached mappings so a swap can reclaim them."""
+        engine = _make_engine()
+        layer_name = "model.layers.0"
+        sd = _tiny_state_dict(layer_name)
+        with tempfile.NamedTemporaryFile(suffix=".pt", delete=False) as f:
+            path = f.name
+        try:
+            _write_state_dict(sd, path)
+            engine.load_layer(layer_name, path)
+            assert engine._mapped_checkpoints
+
+            engine.release_checkpoints()
+
+            assert engine._mapped_checkpoints == {}
         finally:
             os.unlink(path)
 


### PR DESCRIPTION
## Thinking Path

`LayerInferenceEngine` exists so a model larger than VRAM can run — its docstring promises memory "bounded by the largest single layer rather than the full model". `load_layer` did the opposite:

```python
full_sd = torch.load(state_dict_path, map_location="cpu", weights_only=True)
layer_sd = {k[len(prefix):]: v for k, v in full_sd.items() if k.startswith(prefix)}
```

Every parameter of every layer was deserialised into RAM, then all but one layer's keys discarded (**D1**). And because `generate()` calls `_run_layer_loop` per token, and that calls `load_layer` per layer, a 32-layer model producing 64 tokens did this **2,048 times** on the same file (**D2**).

Both fall out of one change: map the file instead of reading it, and keep the mapping.

## What Changed

`torch.load(..., mmap=True)` returns tensor views backed by the file rather than a materialised copy, so selecting one layer's keys touches one layer's bytes — which is what actually makes the docstring's claim true. The mapping is cached per path on the engine, so the file is opened once no matter how many layers or tokens follow.

- `_checkpoint()` — maps and caches, one entry per checkpoint path.
- `release_checkpoints()` — drops the cache when a model is swapped out.

**The fallback is deliberately not cached.** Legacy non-zipfile checkpoints cannot be mapped; there the dict is a real in-RAM copy, and holding it would trade this issue's problem for exactly the one the module exists to avoid. That path re-reads and logs a warning naming the checkpoint.

## One thing worth knowing about CPU

`_build_layer_module` ends in `module.to(device)`, which is a **no-op** when the tensors are already on CPU. So with `device="cpu"` the layer's parameters still alias the mapped file rather than being copies. That is fine — refcounting keeps the mapping alive while any layer references it, and paging is precisely what bounds memory — but it means `release_checkpoints()` does not necessarily unmap immediately on CPU. It does on CUDA, where `.to()` genuinely copies. This is stated in the method's docstring rather than left for the next reader to discover.

## Verification

**The tests fail against the old implementation.** Source reverted, tests kept:

```
FAILED ...::test_checkpoint_is_read_once_across_many_layer_loads
FAILED ...::test_mmap_failure_falls_back_and_does_not_cache
FAILED ...::test_release_checkpoints_drops_the_cache
3 failed
```

With the fix:

```
47 passed          # layer_inference_test.py
342 passed         # autobot-backend/llm_shared/optimization/
```

The load-count test patches `torch.load` and drives 4 layers × 3 tokens — 12 `load_layer` calls — then asserts **exactly one** deserialisation, and that it used `mmap=True`. Under the old code that assertion sees 12.

**These tests need real torch.** Under the default interpreter this file's tensor tests skip, so the runs above use an interpreter with `torch 2.13.0+cpu`; `mmap=` has been a `torch.load` parameter since 2.1.

## Scope

D1 and D2 from #13031 only. The issue's remaining note — that there is no eviction policy or bounded layer cache — is untouched, so #13031 stays open. Sibling #13033 (trim retains the wrong window) is PR #13607.

Refs #13031

## Model Used

Claude Opus 5
