### PR TITLE
fix(api-contract): keep absolute filesystem paths out of OpenAPI schema defaults (#13572)

### DIFF
--- a/.github/workflows/verify-generated-types.yml
+++ b/.github/workflows/verify-generated-types.yml
@@ -121,6 +121,18 @@ jobs:
           # exactly what the live server serves to `npm run gen:types`.
           python -c "import json; s=json.load(open('openapi.raw.json')); s.pop('x-websocket-paths', None); json.dump(s, open('openapi.json','w'))"
 
+      # #13572: reject absolute-path schema defaults here, where the contract has
+      # just been built, rather than paying for a second app.openapi().
+      #
+      # This runs BEFORE the diff below on purpose. An absolute-path default makes
+      # the contract host-dependent, so it surfaces as a spurious generated-types
+      # diff on whichever runner regenerated it — an unactionable failure that has
+      # already happened twice (#13357). Failing here names the offending field.
+      - name: Check no schema default is an absolute filesystem path (#13572)
+        run: |
+          export PYTHONPATH="$PWD:$PWD/autobot-backend:${PYTHONPATH:-}"
+          python scripts/check_openapi_absolute_defaults.py --contract openapi.raw.json
+
       - name: Set up Node.js
         uses: actions/setup-node@v7
         with:

--- a/autobot-backend/api/codebase_analytics/endpoints/pattern_analysis.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/pattern_analysis.py
@@ -48,19 +48,11 @@ class PatternAnalysisRequest(BaseModel):
         default=None,
         description="#1772: source_id for API consistency",
     )
-    enable_clone_detection: bool = Field(
-        default=True, description="Enable clone/duplicate detection"
-    )
-    enable_anti_pattern_detection: bool = Field(
-        default=True, description="Enable anti-pattern detection"
-    )
-    enable_regex_detection: bool = Field(
-        default=True, description="Enable regex optimization detection"
-    )
+    enable_clone_detection: bool = Field(default=True, description="Enable clone/duplicate detection")
+    enable_anti_pattern_detection: bool = Field(default=True, description="Enable anti-pattern detection")
+    enable_regex_detection: bool = Field(default=True, description="Enable regex optimization detection")
     enable_complexity_analysis: bool = Field(default=True, description="Enable complexity analysis")
-    similarity_threshold: float = Field(
-        default=0.8, ge=0.0, le=1.0, description="Similarity threshold for clustering"
-    )
+    similarity_threshold: float = Field(default=0.8, ge=0.0, le=1.0, description="Similarity threshold for clustering")
 
 
 class PatternAnalysisStatus(BaseModel):
@@ -146,9 +138,7 @@ async def _clear_checkpoint(task_id: str) -> None:
 
 
 @router.post("/patterns/analyze", response_model=PatternAnalysisStatus)
-async def start_pattern_analysis(
-    request: PatternAnalysisRequest, http_request: Request
-) -> PatternAnalysisStatus:
+async def start_pattern_analysis(request: PatternAnalysisRequest, http_request: Request) -> PatternAnalysisStatus:
     """Enqueue code pattern analysis as a Celery task (GH#6505, GH#8436)."""
     # #12375: source_id arrives in the request BODY here, so the router-level
     # require_source_access dependency (which reads path/query params only)
@@ -193,9 +183,7 @@ async def get_analysis_result(task_id: str) -> Dict[str, Any]:
     if task is None:
         raise HTTPException(status_code=404, detail=f"Analysis task {task_id} not found")
     if task["status"] != "completed":
-        raise HTTPException(
-            status_code=400, detail=f"Analysis not complete. Status: {task['status']}"
-        )
+        raise HTTPException(status_code=400, detail=f"Analysis not complete. Status: {task['status']}")
     return task.get("result") or {}
 
 
@@ -214,12 +202,7 @@ async def list_analysis_tasks() -> Dict[str, Any]:
     from celery_app import celery_app
 
     active = await asyncio.to_thread(lambda: celery_app.control.inspect().active() or {})
-    analytics_tasks = [
-        t
-        for worker_tasks in active.values()
-        for t in worker_tasks
-        if "pattern" in t.get("name", "")
-    ]
+    analytics_tasks = [t for worker_tasks in active.values() for t in worker_tasks if "pattern" in t.get("name", "")]
     return {"tasks": analytics_tasks, "count": len(analytics_tasks)}
 
 
@@ -238,10 +221,7 @@ async def clear_all_tasks() -> Dict[str, str]:
 
     active = await asyncio.to_thread(lambda: celery_app.control.inspect().active() or {})
     analytics_task_ids = [
-        t["id"]
-        for worker_tasks in active.values()
-        for t in worker_tasks
-        if t.get("name", "").startswith("analytics.")
+        t["id"] for worker_tasks in active.values() for t in worker_tasks if t.get("name", "").startswith("analytics.")
     ]
     for task_id in analytics_task_ids:
         await asyncio.to_thread(celery_app.control.revoke, task_id, terminate=True)
@@ -250,9 +230,7 @@ async def clear_all_tasks() -> Dict[str, str]:
 
 @router.get("/patterns/summary", response_model=PatternSummary)
 async def get_pattern_summary(
-    path: str = Query(
-        default_factory=lambda: str(PATH.PROJECT_ROOT), description="Path to analyze"
-    ),
+    path: str = Query(default_factory=lambda: str(PATH.PROJECT_ROOT), description="Path to analyze"),
 ) -> PatternSummary:
     """Get a quick summary of patterns in the codebase.
 
@@ -285,9 +263,7 @@ async def get_pattern_summary(
 
 @router.post("/patterns/summary/analyze")
 async def start_pattern_summary_analysis(
-    path: str = Query(
-        default_factory=lambda: str(PATH.PROJECT_ROOT), description="Path to analyze"
-    ),
+    path: str = Query(default_factory=lambda: str(PATH.PROJECT_ROOT), description="Path to analyze"),
 ):
     """Enqueue pattern summary analysis as a Celery task (GH#6505)."""
     result = run_pattern_summary_analysis.delay(path)
@@ -314,9 +290,7 @@ async def clear_stuck_summary_tasks(
 
 @router.get("/patterns/duplicates")
 async def get_duplicate_patterns(
-    path: str = Query(
-        default_factory=lambda: str(PATH.PROJECT_ROOT), description="Path to analyze"
-    ),
+    path: str = Query(default_factory=lambda: str(PATH.PROJECT_ROOT), description="Path to analyze"),
     limit: int = Query(default=20, ge=1, le=100, description="Maximum results"),
 ) -> List[Dict[str, Any]]:
     """Get duplicate code patterns in the codebase.
@@ -345,9 +319,7 @@ async def get_duplicate_patterns(
 
 @router.get("/patterns/regex-opportunities")
 async def get_regex_opportunities(
-    path: str = Query(
-        default_factory=lambda: str(PATH.PROJECT_ROOT), description="Path to analyze"
-    ),
+    path: str = Query(default_factory=lambda: str(PATH.PROJECT_ROOT), description="Path to analyze"),
     limit: int = Query(default=20, ge=1, le=100, description="Maximum results"),
 ) -> List[Dict[str, Any]]:
     """Get regex optimization opportunities.
@@ -376,9 +348,7 @@ async def get_regex_opportunities(
 
 @router.get("/patterns/complexity-hotspots")
 async def get_complexity_hotspots(
-    path: str = Query(
-        default_factory=lambda: str(PATH.PROJECT_ROOT), description="Path to analyze"
-    ),
+    path: str = Query(default_factory=lambda: str(PATH.PROJECT_ROOT), description="Path to analyze"),
     limit: int = Query(default=20, ge=1, le=100, description="Maximum results"),
     min_complexity: int = Query(
         default=QueryDefaults.DEFAULT_SEARCH_LIMIT,
@@ -405,9 +375,7 @@ async def get_complexity_hotspots(
         report = await analyzer.analyze_directory(path)
 
         # Filter by minimum complexity
-        filtered = [
-            h for h in report.complexity_hotspots if h.cyclomatic_complexity >= min_complexity
-        ]
+        filtered = [h for h in report.complexity_hotspots if h.cyclomatic_complexity >= min_complexity]
 
         return [ch.to_dict() for ch in filtered[:limit]]
 
@@ -418,9 +386,7 @@ async def get_complexity_hotspots(
 
 @router.get("/patterns/refactoring-suggestions")
 async def get_refactoring_suggestions(
-    path: str = Query(
-        default_factory=lambda: str(PATH.PROJECT_ROOT), description="Path to analyze"
-    ),
+    path: str = Query(default_factory=lambda: str(PATH.PROJECT_ROOT), description="Path to analyze"),
     limit: int = Query(default=20, ge=1, le=100, description="Maximum results"),
 ) -> List[Dict[str, Any]]:
     """Get prioritized refactoring suggestions.
@@ -438,9 +404,7 @@ async def get_refactoring_suggestions(
 
         # Generate refactoring suggestions
         generator = RefactoringSuggestionGenerator()
-        all_patterns = (
-            report.duplicate_patterns + report.regex_opportunities + report.complexity_hotspots
-        )
+        all_patterns = report.duplicate_patterns + report.regex_opportunities + report.complexity_hotspots
         suggestions = generator.generate_suggestions(all_patterns)
 
         return [s.to_dict() for s in suggestions[:limit]]
@@ -452,9 +416,7 @@ async def get_refactoring_suggestions(
 
 @router.get("/patterns/report")
 async def get_pattern_report(
-    path: str = Query(
-        default_factory=lambda: str(PATH.PROJECT_ROOT), description="Path to analyze"
-    ),
+    path: str = Query(default_factory=lambda: str(PATH.PROJECT_ROOT), description="Path to analyze"),
     format: str = Query(default="json", description="Output format: json or markdown"),
 ) -> Any:
     """Generate a comprehensive pattern analysis report.
@@ -484,9 +446,7 @@ async def get_pattern_report(
 
 @router.get("/patterns/storage/stats")
 async def get_pattern_storage_stats(
-    source_id: str | None = Query(
-        default=None, description="Code source to scope stats to (Issue #12384)"
-    ),
+    source_id: str | None = Query(default=None, description="Code source to scope stats to (Issue #12384)"),
 ) -> Dict[str, Any]:
     """Get statistics about stored patterns in ChromaDB.
 
@@ -570,9 +530,7 @@ def _aggregate_pattern_metadata(metadatas: List[Dict]) -> Dict[str, Any]:
 
 @router.get("/patterns/cached-summary")
 async def get_cached_pattern_summary(
-    source_id: str | None = Query(
-        default=None, description="Code source to scope the summary to (Issue #12384)"
-    ),
+    source_id: str | None = Query(default=None, description="Code source to scope the summary to (Issue #12384)"),
 ) -> Dict[str, Any]:
     """Get cached pattern summary from ChromaDB without re-analyzing.
 
@@ -594,9 +552,7 @@ async def get_cached_pattern_summary(
         if collection is None:
             return _build_empty_pattern_summary()
 
-        where_filter = _build_chromadb_where_filter(
-            pattern_type=None, severity=None, source_id=source_id
-        )
+        where_filter = _build_chromadb_where_filter(pattern_type=None, severity=None, source_id=source_id)
 
         # Get metadata for aggregation (limit to 2000 for performance)
         sample = await collection.get(
@@ -711,18 +667,14 @@ def _format_pattern_results(
 async def get_cached_patterns(
     pattern_type: str | None = Query(None, description="Filter by pattern type"),
     severity: str | None = Query(None, description="Filter by severity"),
-    source_id: str | None = Query(
-        default=None, description="Code source to scope results to (Issue #12384)"
-    ),
+    source_id: str | None = Query(default=None, description="Code source to scope results to (Issue #12384)"),
     limit: int = Query(
         default=QueryDefaults.DEFAULT_PAGE_SIZE,
         ge=1,
         le=200,
         description="Maximum results",
     ),
-    offset: int = Query(
-        default=QueryDefaults.DEFAULT_OFFSET, ge=0, description="Offset for pagination"
-    ),
+    offset: int = Query(default=QueryDefaults.DEFAULT_OFFSET, ge=0, description="Offset for pagination"),
 ) -> Dict[str, Any]:
     """Get cached patterns from ChromaDB with filtering and pagination.
 
@@ -782,9 +734,7 @@ async def get_cached_patterns(
 
 @router.post("/patterns/storage/clear")
 async def clear_pattern_storage(
-    source_id: str | None = Query(
-        default=None, description="Code source to scope the clear to (Issue #12408)"
-    ),
+    source_id: str | None = Query(default=None, description="Code source to scope the clear to (Issue #12408)"),
 ) -> Dict[str, str]:
     """Clear stored patterns for a single source from ChromaDB.
 
@@ -815,9 +765,7 @@ async def clear_pattern_storage(
 async def search_similar_patterns_endpoint(
     code: str = Query(..., description="Code snippet to find similar patterns for"),
     pattern_type: str | None = Query(None, description="Filter by pattern type"),
-    source_id: str | None = Query(
-        default=None, description="Code source to scope results to (Issue #12384)"
-    ),
+    source_id: str | None = Query(default=None, description="Code source to scope results to (Issue #12384)"),
     limit: int = Query(
         default=QueryDefaults.DEFAULT_SEARCH_LIMIT,
         ge=1,

--- a/autobot-backend/api/codebase_analytics/endpoints/pattern_analysis.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/pattern_analysis.py
@@ -41,18 +41,26 @@ class PatternAnalysisRequest(BaseModel):
     """Request model for pattern analysis."""
 
     path: str = Field(
-        default=str(PATH.PROJECT_ROOT),
+        default_factory=lambda: str(PATH.PROJECT_ROOT),
         description="Path to analyze (defaults to project root)",
     )
     source_id: str | None = Field(
         default=None,
         description="#1772: source_id for API consistency",
     )
-    enable_clone_detection: bool = Field(default=True, description="Enable clone/duplicate detection")
-    enable_anti_pattern_detection: bool = Field(default=True, description="Enable anti-pattern detection")
-    enable_regex_detection: bool = Field(default=True, description="Enable regex optimization detection")
+    enable_clone_detection: bool = Field(
+        default=True, description="Enable clone/duplicate detection"
+    )
+    enable_anti_pattern_detection: bool = Field(
+        default=True, description="Enable anti-pattern detection"
+    )
+    enable_regex_detection: bool = Field(
+        default=True, description="Enable regex optimization detection"
+    )
     enable_complexity_analysis: bool = Field(default=True, description="Enable complexity analysis")
-    similarity_threshold: float = Field(default=0.8, ge=0.0, le=1.0, description="Similarity threshold for clustering")
+    similarity_threshold: float = Field(
+        default=0.8, ge=0.0, le=1.0, description="Similarity threshold for clustering"
+    )
 
 
 class PatternAnalysisStatus(BaseModel):
@@ -138,7 +146,9 @@ async def _clear_checkpoint(task_id: str) -> None:
 
 
 @router.post("/patterns/analyze", response_model=PatternAnalysisStatus)
-async def start_pattern_analysis(request: PatternAnalysisRequest, http_request: Request) -> PatternAnalysisStatus:
+async def start_pattern_analysis(
+    request: PatternAnalysisRequest, http_request: Request
+) -> PatternAnalysisStatus:
     """Enqueue code pattern analysis as a Celery task (GH#6505, GH#8436)."""
     # #12375: source_id arrives in the request BODY here, so the router-level
     # require_source_access dependency (which reads path/query params only)
@@ -183,7 +193,9 @@ async def get_analysis_result(task_id: str) -> Dict[str, Any]:
     if task is None:
         raise HTTPException(status_code=404, detail=f"Analysis task {task_id} not found")
     if task["status"] != "completed":
-        raise HTTPException(status_code=400, detail=f"Analysis not complete. Status: {task['status']}")
+        raise HTTPException(
+            status_code=400, detail=f"Analysis not complete. Status: {task['status']}"
+        )
     return task.get("result") or {}
 
 
@@ -202,7 +214,12 @@ async def list_analysis_tasks() -> Dict[str, Any]:
     from celery_app import celery_app
 
     active = await asyncio.to_thread(lambda: celery_app.control.inspect().active() or {})
-    analytics_tasks = [t for worker_tasks in active.values() for t in worker_tasks if "pattern" in t.get("name", "")]
+    analytics_tasks = [
+        t
+        for worker_tasks in active.values()
+        for t in worker_tasks
+        if "pattern" in t.get("name", "")
+    ]
     return {"tasks": analytics_tasks, "count": len(analytics_tasks)}
 
 
@@ -221,7 +238,10 @@ async def clear_all_tasks() -> Dict[str, str]:
 
     active = await asyncio.to_thread(lambda: celery_app.control.inspect().active() or {})
     analytics_task_ids = [
-        t["id"] for worker_tasks in active.values() for t in worker_tasks if t.get("name", "").startswith("analytics.")
+        t["id"]
+        for worker_tasks in active.values()
+        for t in worker_tasks
+        if t.get("name", "").startswith("analytics.")
     ]
     for task_id in analytics_task_ids:
         await asyncio.to_thread(celery_app.control.revoke, task_id, terminate=True)
@@ -230,7 +250,9 @@ async def clear_all_tasks() -> Dict[str, str]:
 
 @router.get("/patterns/summary", response_model=PatternSummary)
 async def get_pattern_summary(
-    path: str = Query(default=str(PATH.PROJECT_ROOT), description="Path to analyze"),
+    path: str = Query(
+        default_factory=lambda: str(PATH.PROJECT_ROOT), description="Path to analyze"
+    ),
 ) -> PatternSummary:
     """Get a quick summary of patterns in the codebase.
 
@@ -263,7 +285,9 @@ async def get_pattern_summary(
 
 @router.post("/patterns/summary/analyze")
 async def start_pattern_summary_analysis(
-    path: str = Query(default=str(PATH.PROJECT_ROOT), description="Path to analyze"),
+    path: str = Query(
+        default_factory=lambda: str(PATH.PROJECT_ROOT), description="Path to analyze"
+    ),
 ):
     """Enqueue pattern summary analysis as a Celery task (GH#6505)."""
     result = run_pattern_summary_analysis.delay(path)
@@ -290,7 +314,9 @@ async def clear_stuck_summary_tasks(
 
 @router.get("/patterns/duplicates")
 async def get_duplicate_patterns(
-    path: str = Query(default=str(PATH.PROJECT_ROOT), description="Path to analyze"),
+    path: str = Query(
+        default_factory=lambda: str(PATH.PROJECT_ROOT), description="Path to analyze"
+    ),
     limit: int = Query(default=20, ge=1, le=100, description="Maximum results"),
 ) -> List[Dict[str, Any]]:
     """Get duplicate code patterns in the codebase.
@@ -319,7 +345,9 @@ async def get_duplicate_patterns(
 
 @router.get("/patterns/regex-opportunities")
 async def get_regex_opportunities(
-    path: str = Query(default=str(PATH.PROJECT_ROOT), description="Path to analyze"),
+    path: str = Query(
+        default_factory=lambda: str(PATH.PROJECT_ROOT), description="Path to analyze"
+    ),
     limit: int = Query(default=20, ge=1, le=100, description="Maximum results"),
 ) -> List[Dict[str, Any]]:
     """Get regex optimization opportunities.
@@ -348,7 +376,9 @@ async def get_regex_opportunities(
 
 @router.get("/patterns/complexity-hotspots")
 async def get_complexity_hotspots(
-    path: str = Query(default=str(PATH.PROJECT_ROOT), description="Path to analyze"),
+    path: str = Query(
+        default_factory=lambda: str(PATH.PROJECT_ROOT), description="Path to analyze"
+    ),
     limit: int = Query(default=20, ge=1, le=100, description="Maximum results"),
     min_complexity: int = Query(
         default=QueryDefaults.DEFAULT_SEARCH_LIMIT,
@@ -375,7 +405,9 @@ async def get_complexity_hotspots(
         report = await analyzer.analyze_directory(path)
 
         # Filter by minimum complexity
-        filtered = [h for h in report.complexity_hotspots if h.cyclomatic_complexity >= min_complexity]
+        filtered = [
+            h for h in report.complexity_hotspots if h.cyclomatic_complexity >= min_complexity
+        ]
 
         return [ch.to_dict() for ch in filtered[:limit]]
 
@@ -386,7 +418,9 @@ async def get_complexity_hotspots(
 
 @router.get("/patterns/refactoring-suggestions")
 async def get_refactoring_suggestions(
-    path: str = Query(default=str(PATH.PROJECT_ROOT), description="Path to analyze"),
+    path: str = Query(
+        default_factory=lambda: str(PATH.PROJECT_ROOT), description="Path to analyze"
+    ),
     limit: int = Query(default=20, ge=1, le=100, description="Maximum results"),
 ) -> List[Dict[str, Any]]:
     """Get prioritized refactoring suggestions.
@@ -404,7 +438,9 @@ async def get_refactoring_suggestions(
 
         # Generate refactoring suggestions
         generator = RefactoringSuggestionGenerator()
-        all_patterns = report.duplicate_patterns + report.regex_opportunities + report.complexity_hotspots
+        all_patterns = (
+            report.duplicate_patterns + report.regex_opportunities + report.complexity_hotspots
+        )
         suggestions = generator.generate_suggestions(all_patterns)
 
         return [s.to_dict() for s in suggestions[:limit]]
@@ -416,7 +452,9 @@ async def get_refactoring_suggestions(
 
 @router.get("/patterns/report")
 async def get_pattern_report(
-    path: str = Query(default=str(PATH.PROJECT_ROOT), description="Path to analyze"),
+    path: str = Query(
+        default_factory=lambda: str(PATH.PROJECT_ROOT), description="Path to analyze"
+    ),
     format: str = Query(default="json", description="Output format: json or markdown"),
 ) -> Any:
     """Generate a comprehensive pattern analysis report.
@@ -446,7 +484,9 @@ async def get_pattern_report(
 
 @router.get("/patterns/storage/stats")
 async def get_pattern_storage_stats(
-    source_id: str | None = Query(default=None, description="Code source to scope stats to (Issue #12384)"),
+    source_id: str | None = Query(
+        default=None, description="Code source to scope stats to (Issue #12384)"
+    ),
 ) -> Dict[str, Any]:
     """Get statistics about stored patterns in ChromaDB.
 
@@ -530,7 +570,9 @@ def _aggregate_pattern_metadata(metadatas: List[Dict]) -> Dict[str, Any]:
 
 @router.get("/patterns/cached-summary")
 async def get_cached_pattern_summary(
-    source_id: str | None = Query(default=None, description="Code source to scope the summary to (Issue #12384)"),
+    source_id: str | None = Query(
+        default=None, description="Code source to scope the summary to (Issue #12384)"
+    ),
 ) -> Dict[str, Any]:
     """Get cached pattern summary from ChromaDB without re-analyzing.
 
@@ -552,7 +594,9 @@ async def get_cached_pattern_summary(
         if collection is None:
             return _build_empty_pattern_summary()
 
-        where_filter = _build_chromadb_where_filter(pattern_type=None, severity=None, source_id=source_id)
+        where_filter = _build_chromadb_where_filter(
+            pattern_type=None, severity=None, source_id=source_id
+        )
 
         # Get metadata for aggregation (limit to 2000 for performance)
         sample = await collection.get(
@@ -667,14 +711,18 @@ def _format_pattern_results(
 async def get_cached_patterns(
     pattern_type: str | None = Query(None, description="Filter by pattern type"),
     severity: str | None = Query(None, description="Filter by severity"),
-    source_id: str | None = Query(default=None, description="Code source to scope results to (Issue #12384)"),
+    source_id: str | None = Query(
+        default=None, description="Code source to scope results to (Issue #12384)"
+    ),
     limit: int = Query(
         default=QueryDefaults.DEFAULT_PAGE_SIZE,
         ge=1,
         le=200,
         description="Maximum results",
     ),
-    offset: int = Query(default=QueryDefaults.DEFAULT_OFFSET, ge=0, description="Offset for pagination"),
+    offset: int = Query(
+        default=QueryDefaults.DEFAULT_OFFSET, ge=0, description="Offset for pagination"
+    ),
 ) -> Dict[str, Any]:
     """Get cached patterns from ChromaDB with filtering and pagination.
 
@@ -734,7 +782,9 @@ async def get_cached_patterns(
 
 @router.post("/patterns/storage/clear")
 async def clear_pattern_storage(
-    source_id: str | None = Query(default=None, description="Code source to scope the clear to (Issue #12408)"),
+    source_id: str | None = Query(
+        default=None, description="Code source to scope the clear to (Issue #12408)"
+    ),
 ) -> Dict[str, str]:
     """Clear stored patterns for a single source from ChromaDB.
 
@@ -765,7 +815,9 @@ async def clear_pattern_storage(
 async def search_similar_patterns_endpoint(
     code: str = Query(..., description="Code snippet to find similar patterns for"),
     pattern_type: str | None = Query(None, description="Filter by pattern type"),
-    source_id: str | None = Query(default=None, description="Code source to scope results to (Issue #12384)"),
+    source_id: str | None = Query(
+        default=None, description="Code source to scope results to (Issue #12384)"
+    ),
     limit: int = Query(
         default=QueryDefaults.DEFAULT_SEARCH_LIMIT,
         ge=1,

--- a/autobot-backend/api/files.py
+++ b/autobot-backend/api/files.py
@@ -475,8 +475,7 @@ def _validate_upload_file(file: UploadFile, content: bytes) -> None:
     detected_mime = mimetypes.guess_type(file.filename)[0]
     if detected_mime and file.content_type and file.content_type != detected_mime:
         logger.warning(
-            f"MIME type mismatch for {file.filename}: "
-            f"declared={file.content_type}, detected={detected_mime}"
+            f"MIME type mismatch for {file.filename}: " f"declared={file.content_type}, detected={detected_mime}"
         )
 
 
@@ -547,9 +546,7 @@ def _log_upload_audit(
     )
 
 
-async def _delete_file_item(
-    target_path: Path, path: str, security_layer, user_data: dict, request: Request
-) -> dict:
+async def _delete_file_item(target_path: Path, path: str, security_layer, user_data: dict, request: Request) -> dict:
     """
     Delete a single file and log audit.
 
@@ -861,9 +858,7 @@ async def _validate_rename_paths(source_path: Path, new_name: str) -> Path:
     operation="rename_file_or_directory",
     error_code_prefix="FILES",
 )
-async def rename_file_or_directory(
-    request: Request, path: str = Form(...), new_name: str = Form(...)
-):
+async def rename_file_or_directory(request: Request, path: str = Form(...), new_name: str = Form(...)):
     """
     Rename a file or directory within the sandbox.
 
@@ -1267,9 +1262,7 @@ def _entry_to_file_item(entry: Path) -> dict:
         }
 
 
-@router.get(
-    "", summary="List directory for SLM admin file browser", response_model=AdminFileListResponse
-)
+@router.get("", summary="List directory for SLM admin file browser", response_model=AdminFileListResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="admin_list_directory",

--- a/autobot-backend/api/files.py
+++ b/autobot-backend/api/files.py
@@ -19,7 +19,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import aiofiles
-from fastapi import APIRouter, File, Form, HTTPException, Request, UploadFile
+from fastapi import APIRouter, File, Form, HTTPException, Query, Request, UploadFile
 from fastapi.responses import FileResponse
 from fastapi.security import HTTPBearer
 
@@ -475,7 +475,8 @@ def _validate_upload_file(file: UploadFile, content: bytes) -> None:
     detected_mime = mimetypes.guess_type(file.filename)[0]
     if detected_mime and file.content_type and file.content_type != detected_mime:
         logger.warning(
-            f"MIME type mismatch for {file.filename}: " f"declared={file.content_type}, detected={detected_mime}"
+            f"MIME type mismatch for {file.filename}: "
+            f"declared={file.content_type}, detected={detected_mime}"
         )
 
 
@@ -546,7 +547,9 @@ def _log_upload_audit(
     )
 
 
-async def _delete_file_item(target_path: Path, path: str, security_layer, user_data: dict, request: Request) -> dict:
+async def _delete_file_item(
+    target_path: Path, path: str, security_layer, user_data: dict, request: Request
+) -> dict:
     """
     Delete a single file and log audit.
 
@@ -858,7 +861,9 @@ async def _validate_rename_paths(source_path: Path, new_name: str) -> Path:
     operation="rename_file_or_directory",
     error_code_prefix="FILES",
 )
-async def rename_file_or_directory(request: Request, path: str = Form(...), new_name: str = Form(...)):
+async def rename_file_or_directory(
+    request: Request, path: str = Form(...), new_name: str = Form(...)
+):
     """
     Rename a file or directory within the sandbox.
 
@@ -1216,6 +1221,10 @@ _ADMIN_ALLOWED_DIRS = (
 )
 _ADMIN_MAX_READ_BYTES = 1 * 1024 * 1024  # 1 MB cap for inline reads
 
+#: Directory the admin browser opens on when the caller supplies no path.
+#: Referenced through a factory at the endpoint so it never reaches the schema.
+_ADMIN_DEFAULT_BROWSE_DIR = "/home/autobot"  # noqa: ssot-path
+
 
 def _validate_admin_path(path: str) -> Path:
     """Resolve and validate an absolute path for the SLM admin file browser.
@@ -1258,13 +1267,21 @@ def _entry_to_file_item(entry: Path) -> dict:
         }
 
 
-@router.get("", summary="List directory for SLM admin file browser", response_model=AdminFileListResponse)
+@router.get(
+    "", summary="List directory for SLM admin file browser", response_model=AdminFileListResponse
+)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="admin_list_directory",
     error_code_prefix="FILES",
 )
-async def admin_list_directory(path: str = "/home/autobot") -> dict:  # noqa: ssot-path
+async def admin_list_directory(
+    # #13572: default_factory keeps this out of the published OpenAPI schema.
+    # As a plain default it was dumped into the contract and shipped in the
+    # committed frontend types, disclosing the service account's home directory
+    # to every API consumer. Runtime behaviour is unchanged.
+    path: str = Query(default_factory=lambda: _ADMIN_DEFAULT_BROWSE_DIR),
+) -> dict:
     """List directory contents at an absolute path.
 
     No auth required — accessible via /autobot-api/ nginx proxy (Issue #984).
@@ -1282,7 +1299,11 @@ async def admin_list_directory(path: str = "/home/autobot") -> dict:  # noqa: ss
         raise HTTPException(status_code=403, detail="Permission denied")
 
 
-@router.get("/read", summary="Read file content for SLM admin file browser", response_model=AdminFileReadResponse)
+@router.get(
+    "/read",
+    summary="Read file content for SLM admin file browser",
+    response_model=AdminFileReadResponse,
+)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="admin_read_file",

--- a/autobot-backend/api/schemas_code.py
+++ b/autobot-backend/api/schemas_code.py
@@ -1496,7 +1496,9 @@ class MCPPromptTemplate(BaseModel):
 
     name: str = Field(..., description="Prompt template name")
     description: str | None = Field(None, description="Template description")
-    arguments: List[Dict[str, Any]] = Field(default_factory=list, description="Template arguments schema")
+    arguments: List[Dict[str, Any]] = Field(
+        default_factory=list, description="Template arguments schema"
+    )
 
 
 class FilesystemResourcesListResponse(BaseModel):
@@ -2454,7 +2456,17 @@ class OAIModelListResponse(BaseModel):
 # git_mcp.py request schemas (#6042)
 # ---------------------------------------------------------------------------
 
-_GIT_DEFAULT_REPO_PATH = str(PROJECT_ROOT)
+
+# #13572: a factory, not a constant. As a plain default this value was dumped
+# into the OpenAPI schema and published in the committed frontend types, so the
+# contract carried whichever absolute path the generating machine resolved.
+# A default_factory is invisible to JSON Schema while the runtime default is
+# unchanged — the same form schemas_analytics.py:1084 already uses.
+def _git_default_repo_path() -> str:
+    """Return the server's project root, resolved per request."""
+    return str(PROJECT_ROOT)
+
+
 _GIT_MAX_LOG_ENTRIES = 100
 _GIT_SAFE_PATH_RE = re.compile(r"^[a-zA-Z0-9_\-./]+$")
 _GIT_SHELL_METACHAR_RE = re.compile(r"[;&|`$]")
@@ -2465,14 +2477,16 @@ _GIT_FULL_REF_RE = re.compile(r"^[a-zA-Z0-9_\-./^~:]+$")
 class GitStatusRequest(BaseModel):
     """Git status request model"""
 
-    repo_path: str = Field(default=_GIT_DEFAULT_REPO_PATH, description="Repository path (must be whitelisted)")
+    repo_path: str = Field(
+        default_factory=_git_default_repo_path, description="Repository path (must be whitelisted)"
+    )
     short: bool | None = Field(default=False, description="Use short format output")
 
 
 class GitLogRequest(BaseModel):
     """Git log request model"""
 
-    repo_path: str = Field(default=_GIT_DEFAULT_REPO_PATH, description="Repository path")
+    repo_path: str = Field(default_factory=_git_default_repo_path, description="Repository path")
     max_count: int | None = Field(
         default=QueryDefaults.DEFAULT_SEARCH_LIMIT,
         ge=1,
@@ -2507,7 +2521,7 @@ class GitLogRequest(BaseModel):
 class GitDiffRequest(BaseModel):
     """Git diff request model"""
 
-    repo_path: str = Field(default=_GIT_DEFAULT_REPO_PATH, description="Repository path")
+    repo_path: str = Field(default_factory=_git_default_repo_path, description="Repository path")
     staged: bool | None = Field(default=False, description="Show staged changes only")
     file_path: str | None = Field(default=None, description="Diff specific file")
     commit: str | None = Field(default=None, description="Compare with specific commit")
@@ -2544,14 +2558,14 @@ class GitDiffRequest(BaseModel):
 class GitBranchRequest(BaseModel):
     """Git branch request model"""
 
-    repo_path: str = Field(default=_GIT_DEFAULT_REPO_PATH, description="Repository path")
+    repo_path: str = Field(default_factory=_git_default_repo_path, description="Repository path")
     all_branches: bool | None = Field(default=False, description="Show remote branches too")
 
 
 class GitBlameRequest(BaseModel):
     """Git blame request model"""
 
-    repo_path: str = Field(default=_GIT_DEFAULT_REPO_PATH, description="Repository path")
+    repo_path: str = Field(default_factory=_git_default_repo_path, description="Repository path")
     file_path: str = Field(..., description="File to blame")
     line_start: int | None = Field(default=None, ge=1, description="Starting line number")
     line_end: int | None = Field(default=None, ge=1, description="Ending line number")
@@ -2580,7 +2594,7 @@ class GitBlameRequest(BaseModel):
 class GitShowRequest(BaseModel):
     """Git show request model"""
 
-    repo_path: str = Field(default=_GIT_DEFAULT_REPO_PATH, description="Repository path")
+    repo_path: str = Field(default_factory=_git_default_repo_path, description="Repository path")
     ref: str = Field(default="HEAD", description="Commit or ref to show (default: HEAD)")
 
     @field_validator("ref")
@@ -2648,8 +2662,12 @@ class CodeIntelAnalysisRequest(BaseModel):
     code: str | None = Field(default=None, description="Inline code to analyze")
     language: str | None = Field(default=None, description="Language of the inline code")
     filename: str | None = Field(default=None, description="Virtual filename for inline code")
-    include_suggestions: bool | None = Field(default=None, description="Whether to include improvement suggestions")
-    exclude_dirs: list | None = Field(default=None, description="Directories to exclude from analysis")
+    include_suggestions: bool | None = Field(
+        default=None, description="Whether to include improvement suggestions"
+    )
+    exclude_dirs: list | None = Field(
+        default=None, description="Directories to exclude from analysis"
+    )
     min_severity: str | None = Field(default=None, description="Minimum severity level to include")
 
 
@@ -2670,9 +2688,12 @@ class RedisAnalysisRequest(BaseModel):
     """Request model for Redis optimization analysis."""
 
     path: str = Field(..., description="Directory or file path to analyze for Redis optimizations")
-    exclude_patterns: list | None = Field(default=None, description="Glob patterns to exclude from analysis")
+    exclude_patterns: list | None = Field(
+        default=None, description="Glob patterns to exclude from analysis"
+    )
     min_severity: str | None = Field(
-        default=None, description="Minimum severity level to include (info, low, medium, high, critical)"
+        default=None,
+        description="Minimum severity level to include (info, low, medium, high, critical)",
     )
 
 
@@ -2690,7 +2711,8 @@ class SecurityAnalysisRequest(BaseModel):
         default=None, description="Patterns to exclude from analysis (e.g., ['test_*', 'venv'])"
     )
     min_severity: str | None = Field(
-        default=None, description="Minimum severity level to include (info, low, medium, high, critical)"
+        default=None,
+        description="Minimum severity level to include (info, low, medium, high, critical)",
     )
 
 
@@ -2704,7 +2726,9 @@ class PerformanceAnalysisRequest(BaseModel):
     """Request model for performance analysis."""
 
     path: str = Field(..., description="Directory path to analyze for performance issues")
-    exclude_patterns: list | None = Field(default=None, description="Patterns to exclude from analysis")
+    exclude_patterns: list | None = Field(
+        default=None, description="Patterns to exclude from analysis"
+    )
     min_severity: str | None = Field(default=None, description="Minimum severity level to include")
 
 
@@ -2735,7 +2759,9 @@ class SQLQueryRequest(BaseModel):
 
     database: str = Field(..., description="Database name from whitelist")
     query: str = Field(..., description="SQL SELECT query (parameterized)")
-    params: List[Any] | None = Field(default=None, description="Query parameters for ? placeholders")
+    params: List[Any] | None = Field(
+        default=None, description="Query parameters for ? placeholders"
+    )
     limit: int | None = Field(
         default=100,
         ge=1,
@@ -2757,7 +2783,9 @@ class SQLExecuteRequest(BaseModel):
 
     database: str = Field(..., description="Database name from whitelist")
     statement: str = Field(..., description="SQL statement (INSERT/UPDATE/DELETE)")
-    params: List[Any] | None = Field(default=None, description="Statement parameters for ? placeholders")
+    params: List[Any] | None = Field(
+        default=None, description="Statement parameters for ? placeholders"
+    )
 
     @field_validator("statement")
     @classmethod
@@ -2803,7 +2831,9 @@ class ConflictResolutionRequest(BaseModel):
             "accept_ours, accept_theirs, manual_review"
         ),
     )
-    safe_mode: bool = Field(default=True, description="Enable safe mode (require review for complex conflicts)")
+    safe_mode: bool = Field(
+        default=True, description="Enable safe mode (require review for complex conflicts)"
+    )
     validate: bool = Field(default=True, description="Validate resolved code for syntax errors")
 
 
@@ -2830,7 +2860,9 @@ class AntiPatternAnalysisRequest(BaseModel):
     """Request model for anti-pattern analysis."""
 
     root_path: str = Field(default=".", description="Root path to analyze")
-    patterns: List[str] = Field(default=["**/*.py"], description="Glob patterns for files to include")
+    patterns: List[str] = Field(
+        default=["**/*.py"], description="Glob patterns for files to include"
+    )
     exclude_patterns: List[str] = Field(
         default=[
             "__pycache__",

--- a/autobot-backend/api/schemas_code.py
+++ b/autobot-backend/api/schemas_code.py
@@ -1496,9 +1496,7 @@ class MCPPromptTemplate(BaseModel):
 
     name: str = Field(..., description="Prompt template name")
     description: str | None = Field(None, description="Template description")
-    arguments: List[Dict[str, Any]] = Field(
-        default_factory=list, description="Template arguments schema"
-    )
+    arguments: List[Dict[str, Any]] = Field(default_factory=list, description="Template arguments schema")
 
 
 class FilesystemResourcesListResponse(BaseModel):
@@ -2477,9 +2475,7 @@ _GIT_FULL_REF_RE = re.compile(r"^[a-zA-Z0-9_\-./^~:]+$")
 class GitStatusRequest(BaseModel):
     """Git status request model"""
 
-    repo_path: str = Field(
-        default_factory=_git_default_repo_path, description="Repository path (must be whitelisted)"
-    )
+    repo_path: str = Field(default_factory=_git_default_repo_path, description="Repository path (must be whitelisted)")
     short: bool | None = Field(default=False, description="Use short format output")
 
 
@@ -2662,12 +2658,8 @@ class CodeIntelAnalysisRequest(BaseModel):
     code: str | None = Field(default=None, description="Inline code to analyze")
     language: str | None = Field(default=None, description="Language of the inline code")
     filename: str | None = Field(default=None, description="Virtual filename for inline code")
-    include_suggestions: bool | None = Field(
-        default=None, description="Whether to include improvement suggestions"
-    )
-    exclude_dirs: list | None = Field(
-        default=None, description="Directories to exclude from analysis"
-    )
+    include_suggestions: bool | None = Field(default=None, description="Whether to include improvement suggestions")
+    exclude_dirs: list | None = Field(default=None, description="Directories to exclude from analysis")
     min_severity: str | None = Field(default=None, description="Minimum severity level to include")
 
 
@@ -2688,9 +2680,7 @@ class RedisAnalysisRequest(BaseModel):
     """Request model for Redis optimization analysis."""
 
     path: str = Field(..., description="Directory or file path to analyze for Redis optimizations")
-    exclude_patterns: list | None = Field(
-        default=None, description="Glob patterns to exclude from analysis"
-    )
+    exclude_patterns: list | None = Field(default=None, description="Glob patterns to exclude from analysis")
     min_severity: str | None = Field(
         default=None,
         description="Minimum severity level to include (info, low, medium, high, critical)",
@@ -2726,9 +2716,7 @@ class PerformanceAnalysisRequest(BaseModel):
     """Request model for performance analysis."""
 
     path: str = Field(..., description="Directory path to analyze for performance issues")
-    exclude_patterns: list | None = Field(
-        default=None, description="Patterns to exclude from analysis"
-    )
+    exclude_patterns: list | None = Field(default=None, description="Patterns to exclude from analysis")
     min_severity: str | None = Field(default=None, description="Minimum severity level to include")
 
 
@@ -2759,9 +2747,7 @@ class SQLQueryRequest(BaseModel):
 
     database: str = Field(..., description="Database name from whitelist")
     query: str = Field(..., description="SQL SELECT query (parameterized)")
-    params: List[Any] | None = Field(
-        default=None, description="Query parameters for ? placeholders"
-    )
+    params: List[Any] | None = Field(default=None, description="Query parameters for ? placeholders")
     limit: int | None = Field(
         default=100,
         ge=1,
@@ -2783,9 +2769,7 @@ class SQLExecuteRequest(BaseModel):
 
     database: str = Field(..., description="Database name from whitelist")
     statement: str = Field(..., description="SQL statement (INSERT/UPDATE/DELETE)")
-    params: List[Any] | None = Field(
-        default=None, description="Statement parameters for ? placeholders"
-    )
+    params: List[Any] | None = Field(default=None, description="Statement parameters for ? placeholders")
 
     @field_validator("statement")
     @classmethod
@@ -2831,9 +2815,7 @@ class ConflictResolutionRequest(BaseModel):
             "accept_ours, accept_theirs, manual_review"
         ),
     )
-    safe_mode: bool = Field(
-        default=True, description="Enable safe mode (require review for complex conflicts)"
-    )
+    safe_mode: bool = Field(default=True, description="Enable safe mode (require review for complex conflicts)")
     validate: bool = Field(default=True, description="Validate resolved code for syntax errors")
 
 
@@ -2860,9 +2842,7 @@ class AntiPatternAnalysisRequest(BaseModel):
     """Request model for anti-pattern analysis."""
 
     root_path: str = Field(default=".", description="Root path to analyze")
-    patterns: List[str] = Field(
-        default=["**/*.py"], description="Glob patterns for files to include"
-    )
+    patterns: List[str] = Field(default=["**/*.py"], description="Glob patterns for files to include")
     exclude_patterns: List[str] = Field(
         default=[
             "__pycache__",

--- a/autobot-backend/api/schemas_workflows.py
+++ b/autobot-backend/api/schemas_workflows.py
@@ -1362,17 +1362,13 @@ class ImportWorkflowRequest(BaseModel):
         ...,
         description="WorkflowExportFormat.to_dict() payload produced by the export endpoint.",
     )
-    session_id: str | None = Field(
-        default=None, description="Session to associate with the imported workflow."
-    )
+    session_id: str | None = Field(default=None, description="Session to associate with the imported workflow.")
 
 
 class CloneWorkflowRequest(BaseModel):
     """Request body for cloning a shared workflow (#2165)."""
 
-    session_id: str | None = Field(
-        default=None, description="Session to associate with the cloned workflow."
-    )
+    session_id: str | None = Field(default=None, description="Session to associate with the cloned workflow.")
 
 
 # ---------------------------------------------------------------------------
@@ -1419,10 +1415,7 @@ _WORKFLOW_SECRET_NAME_RE = re.compile(r"^[a-zA-Z0-9_\-\.]+$")
 def _validate_workflow_secret_name(name: str) -> str:
     """Reject names containing characters outside the safe set. Issue #2153."""
     if not _WORKFLOW_SECRET_NAME_RE.match(name):
-        raise ValueError(
-            "Secret name must contain only alphanumeric characters, "
-            "underscores, hyphens, and dots"
-        )
+        raise ValueError("Secret name must contain only alphanumeric characters, " "underscores, hyphens, and dots")
     return name
 
 
@@ -1711,9 +1704,7 @@ class CreateChatBrowserRequest(BaseModel):
 class CodebaseIndexingRequest(BaseModel):
     """Request model for codebase indexing operations."""
 
-    codebase_path: str = Field(
-        default_factory=lambda: str(PATH.PROJECT_ROOT), description="Path to codebase to index"
-    )
+    codebase_path: str = Field(default_factory=lambda: str(PATH.PROJECT_ROOT), description="Path to codebase to index")
     file_patterns: List[str] = Field(
         default=["*.py", "*.js", "*.vue", "*.ts", "*.jsx", "*.tsx"],
         description="File patterns to include",
@@ -1727,12 +1718,8 @@ class CodebaseIndexingRequest(BaseModel):
 class TestSuiteRequest(BaseModel):
     """Request model for comprehensive test suite operations."""
 
-    test_path: str = Field(
-        default_factory=lambda: str(PATH.TESTS_DIR), description="Path to test directory"
-    )
-    test_patterns: List[str] = Field(
-        default=["test_*.py", "*_test.py"], description="Test file patterns"
-    )
+    test_path: str = Field(default_factory=lambda: str(PATH.TESTS_DIR), description="Path to test directory")
+    test_patterns: List[str] = Field(default=["test_*.py", "*_test.py"], description="Test file patterns")
     test_types: List[str] = Field(
         default=["unit", "integration", "performance"],
         description="Types of tests to run",
@@ -1748,9 +1735,7 @@ class KnowledgeBaseRequest(BaseModel):
     source_paths: List[str] = Field(
         default_factory=lambda: [str(PATH.PROJECT_ROOT)], description="Paths to populate from"
     )
-    document_types: List[str] = Field(
-        default=["code", "docs", "config"], description="Document types to include"
-    )
+    document_types: List[str] = Field(default=["code", "docs", "config"], description="Document types to include")
     chunk_size: int = Field(default=1000, description="Chunk size for text processing")
     overlap: int = Field(default=200, description="Overlap between chunks")
     force_reindex: bool = Field(default=False, description="Force reindexing of existing documents")
@@ -1760,9 +1745,7 @@ class KnowledgeBaseRequest(BaseModel):
 class SecurityScanRequest(BaseModel):
     """Request model for security scan operations."""
 
-    scan_paths: List[str] = Field(
-        default_factory=lambda: [str(PATH.PROJECT_ROOT)], description="Paths to scan"
-    )
+    scan_paths: List[str] = Field(default_factory=lambda: [str(PATH.PROJECT_ROOT)], description="Paths to scan")
     scan_types: List[str] = Field(
         default=["vulnerability", "dependency", "secrets"],
         description="Types of security scans",
@@ -1948,9 +1931,7 @@ class GitHubConnectionTestRequest(BaseModel):
     """Request body for testing a GitHub token."""
 
     token: str = Field(..., description="GitHub Personal Access Token")
-    base_url: str | None = Field(
-        None, description="Custom GitHub API base URL (e.g. GitHub Enterprise)"
-    )
+    base_url: str | None = Field(None, description="Custom GitHub API base URL (e.g. GitHub Enterprise)")
 
 
 class GitHubReviewRequest(BaseModel):
@@ -2377,12 +2358,8 @@ class VCSProviderInfo(BaseModel):
     id: str = Field(..., description="Provider identifier")
     name: str = Field(..., description="Provider display name")
     description: str = Field(..., description="Provider description")
-    required_settings: List[str] = Field(
-        default_factory=list, description="Required configuration settings"
-    )
-    optional_settings: List[str] = Field(
-        default_factory=list, description="Optional configuration settings"
-    )
+    required_settings: List[str] = Field(default_factory=list, description="Required configuration settings")
+    optional_settings: List[str] = Field(default_factory=list, description="Optional configuration settings")
 
 
 # ---------------------------------------------------------------------------
@@ -2423,25 +2400,15 @@ class SequentialThinkingRequest(BaseModel):
     """Request model for sequential thinking tool."""
 
     thought: str = Field(..., description="Current thinking step and analysis")
-    thought_number: int = Field(
-        ..., ge=1, le=MAX_THOUGHT_COUNT, description="Current thought number in sequence"
-    )
-    total_thoughts: int = Field(
-        ..., ge=1, le=MAX_THOUGHT_COUNT, description="Estimated total thoughts needed"
-    )
+    thought_number: int = Field(..., ge=1, le=MAX_THOUGHT_COUNT, description="Current thought number in sequence")
+    total_thoughts: int = Field(..., ge=1, le=MAX_THOUGHT_COUNT, description="Estimated total thoughts needed")
     next_thought_needed: bool = Field(..., description="Whether another thought step is needed")
 
     is_revision: bool | None = Field(False, description="Whether this revises previous thinking")
-    revises_thought: int | None = Field(
-        None, ge=1, description="Which thought is being reconsidered"
-    )
-    branch_from_thought: int | None = Field(
-        None, ge=1, description="Branching point thought number"
-    )
+    revises_thought: int | None = Field(None, ge=1, description="Which thought is being reconsidered")
+    branch_from_thought: int | None = Field(None, ge=1, description="Branching point thought number")
     branch_id: str | None = Field(None, description="Branch identifier")
-    needs_more_thoughts: bool | None = Field(
-        False, description="If more thoughts are needed beyond initial estimate"
-    )
+    needs_more_thoughts: bool | None = Field(False, description="If more thoughts are needed beyond initial estimate")
 
     session_id: str | None = Field("default", description="Thinking session identifier")
 
@@ -2639,9 +2606,7 @@ class HTTPPostRequest(HTTPRequestBase):
     """POST request model."""
 
     json_body: _HTTPClientJSONObject | None = Field(default=None, description="JSON request body")
-    form_data: Dict[str, str] | None = Field(
-        default=None, description="Form data (mutually exclusive with json_body)"
-    )
+    form_data: Dict[str, str] | None = Field(default=None, description="Form data (mutually exclusive with json_body)")
 
 
 class HTTPPutRequest(HTTPRequestBase):
@@ -2653,9 +2618,7 @@ class HTTPPutRequest(HTTPRequestBase):
 class HTTPPatchRequest(HTTPRequestBase):
     """PATCH request model."""
 
-    json_body: _HTTPClientJSONObject | None = Field(
-        default=None, description="JSON request body for partial update"
-    )
+    json_body: _HTTPClientJSONObject | None = Field(default=None, description="JSON request body for partial update")
 
 
 class HTTPDeleteRequest(HTTPRequestBase):

--- a/autobot-backend/api/schemas_workflows.py
+++ b/autobot-backend/api/schemas_workflows.py
@@ -1362,13 +1362,17 @@ class ImportWorkflowRequest(BaseModel):
         ...,
         description="WorkflowExportFormat.to_dict() payload produced by the export endpoint.",
     )
-    session_id: str | None = Field(default=None, description="Session to associate with the imported workflow.")
+    session_id: str | None = Field(
+        default=None, description="Session to associate with the imported workflow."
+    )
 
 
 class CloneWorkflowRequest(BaseModel):
     """Request body for cloning a shared workflow (#2165)."""
 
-    session_id: str | None = Field(default=None, description="Session to associate with the cloned workflow.")
+    session_id: str | None = Field(
+        default=None, description="Session to associate with the cloned workflow."
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -1415,7 +1419,10 @@ _WORKFLOW_SECRET_NAME_RE = re.compile(r"^[a-zA-Z0-9_\-\.]+$")
 def _validate_workflow_secret_name(name: str) -> str:
     """Reject names containing characters outside the safe set. Issue #2153."""
     if not _WORKFLOW_SECRET_NAME_RE.match(name):
-        raise ValueError("Secret name must contain only alphanumeric characters, " "underscores, hyphens, and dots")
+        raise ValueError(
+            "Secret name must contain only alphanumeric characters, "
+            "underscores, hyphens, and dots"
+        )
     return name
 
 
@@ -1704,7 +1711,9 @@ class CreateChatBrowserRequest(BaseModel):
 class CodebaseIndexingRequest(BaseModel):
     """Request model for codebase indexing operations."""
 
-    codebase_path: str = Field(default=str(PATH.PROJECT_ROOT), description="Path to codebase to index")
+    codebase_path: str = Field(
+        default_factory=lambda: str(PATH.PROJECT_ROOT), description="Path to codebase to index"
+    )
     file_patterns: List[str] = Field(
         default=["*.py", "*.js", "*.vue", "*.ts", "*.jsx", "*.tsx"],
         description="File patterns to include",
@@ -1718,8 +1727,12 @@ class CodebaseIndexingRequest(BaseModel):
 class TestSuiteRequest(BaseModel):
     """Request model for comprehensive test suite operations."""
 
-    test_path: str = Field(default=str(PATH.TESTS_DIR), description="Path to test directory")
-    test_patterns: List[str] = Field(default=["test_*.py", "*_test.py"], description="Test file patterns")
+    test_path: str = Field(
+        default_factory=lambda: str(PATH.TESTS_DIR), description="Path to test directory"
+    )
+    test_patterns: List[str] = Field(
+        default=["test_*.py", "*_test.py"], description="Test file patterns"
+    )
     test_types: List[str] = Field(
         default=["unit", "integration", "performance"],
         description="Types of tests to run",
@@ -1732,8 +1745,12 @@ class TestSuiteRequest(BaseModel):
 class KnowledgeBaseRequest(BaseModel):
     """Request model for knowledge base operations."""
 
-    source_paths: List[str] = Field(default=[str(PATH.PROJECT_ROOT)], description="Paths to populate from")
-    document_types: List[str] = Field(default=["code", "docs", "config"], description="Document types to include")
+    source_paths: List[str] = Field(
+        default_factory=lambda: [str(PATH.PROJECT_ROOT)], description="Paths to populate from"
+    )
+    document_types: List[str] = Field(
+        default=["code", "docs", "config"], description="Document types to include"
+    )
     chunk_size: int = Field(default=1000, description="Chunk size for text processing")
     overlap: int = Field(default=200, description="Overlap between chunks")
     force_reindex: bool = Field(default=False, description="Force reindexing of existing documents")
@@ -1743,7 +1760,9 @@ class KnowledgeBaseRequest(BaseModel):
 class SecurityScanRequest(BaseModel):
     """Request model for security scan operations."""
 
-    scan_paths: List[str] = Field(default=[str(PATH.PROJECT_ROOT)], description="Paths to scan")
+    scan_paths: List[str] = Field(
+        default_factory=lambda: [str(PATH.PROJECT_ROOT)], description="Paths to scan"
+    )
     scan_types: List[str] = Field(
         default=["vulnerability", "dependency", "secrets"],
         description="Types of security scans",
@@ -1929,7 +1948,9 @@ class GitHubConnectionTestRequest(BaseModel):
     """Request body for testing a GitHub token."""
 
     token: str = Field(..., description="GitHub Personal Access Token")
-    base_url: str | None = Field(None, description="Custom GitHub API base URL (e.g. GitHub Enterprise)")
+    base_url: str | None = Field(
+        None, description="Custom GitHub API base URL (e.g. GitHub Enterprise)"
+    )
 
 
 class GitHubReviewRequest(BaseModel):
@@ -2356,8 +2377,12 @@ class VCSProviderInfo(BaseModel):
     id: str = Field(..., description="Provider identifier")
     name: str = Field(..., description="Provider display name")
     description: str = Field(..., description="Provider description")
-    required_settings: List[str] = Field(default_factory=list, description="Required configuration settings")
-    optional_settings: List[str] = Field(default_factory=list, description="Optional configuration settings")
+    required_settings: List[str] = Field(
+        default_factory=list, description="Required configuration settings"
+    )
+    optional_settings: List[str] = Field(
+        default_factory=list, description="Optional configuration settings"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -2398,15 +2423,25 @@ class SequentialThinkingRequest(BaseModel):
     """Request model for sequential thinking tool."""
 
     thought: str = Field(..., description="Current thinking step and analysis")
-    thought_number: int = Field(..., ge=1, le=MAX_THOUGHT_COUNT, description="Current thought number in sequence")
-    total_thoughts: int = Field(..., ge=1, le=MAX_THOUGHT_COUNT, description="Estimated total thoughts needed")
+    thought_number: int = Field(
+        ..., ge=1, le=MAX_THOUGHT_COUNT, description="Current thought number in sequence"
+    )
+    total_thoughts: int = Field(
+        ..., ge=1, le=MAX_THOUGHT_COUNT, description="Estimated total thoughts needed"
+    )
     next_thought_needed: bool = Field(..., description="Whether another thought step is needed")
 
     is_revision: bool | None = Field(False, description="Whether this revises previous thinking")
-    revises_thought: int | None = Field(None, ge=1, description="Which thought is being reconsidered")
-    branch_from_thought: int | None = Field(None, ge=1, description="Branching point thought number")
+    revises_thought: int | None = Field(
+        None, ge=1, description="Which thought is being reconsidered"
+    )
+    branch_from_thought: int | None = Field(
+        None, ge=1, description="Branching point thought number"
+    )
     branch_id: str | None = Field(None, description="Branch identifier")
-    needs_more_thoughts: bool | None = Field(False, description="If more thoughts are needed beyond initial estimate")
+    needs_more_thoughts: bool | None = Field(
+        False, description="If more thoughts are needed beyond initial estimate"
+    )
 
     session_id: str | None = Field("default", description="Thinking session identifier")
 
@@ -2604,7 +2639,9 @@ class HTTPPostRequest(HTTPRequestBase):
     """POST request model."""
 
     json_body: _HTTPClientJSONObject | None = Field(default=None, description="JSON request body")
-    form_data: Dict[str, str] | None = Field(default=None, description="Form data (mutually exclusive with json_body)")
+    form_data: Dict[str, str] | None = Field(
+        default=None, description="Form data (mutually exclusive with json_body)"
+    )
 
 
 class HTTPPutRequest(HTTPRequestBase):
@@ -2616,7 +2653,9 @@ class HTTPPutRequest(HTTPRequestBase):
 class HTTPPatchRequest(HTTPRequestBase):
     """PATCH request model."""
 
-    json_body: _HTTPClientJSONObject | None = Field(default=None, description="JSON request body for partial update")
+    json_body: _HTTPClientJSONObject | None = Field(
+        default=None, description="JSON request body for partial update"
+    )
 
 
 class HTTPDeleteRequest(HTTPRequestBase):

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -62556,9 +62556,8 @@ export interface components {
             /**
              * Codebase Path
              * @description Path to codebase to index
-             * @default /home/runner/work/AutoBot-AI/AutoBot-AI
              */
-            codebase_path: string;
+            codebase_path?: string;
             /**
              * File Patterns
              * @description File patterns to include
@@ -73706,9 +73705,8 @@ export interface components {
             /**
              * Repo Path
              * @description Repository path
-             * @default /opt/autobot
              */
-            repo_path: string;
+            repo_path?: string;
             /**
              * File Path
              * @description File to blame
@@ -73735,9 +73733,8 @@ export interface components {
             /**
              * Repo Path
              * @description Repository path
-             * @default /opt/autobot
              */
-            repo_path: string;
+            repo_path?: string;
             /**
              * All Branches
              * @description Show remote branches too
@@ -73755,9 +73752,8 @@ export interface components {
             /**
              * Repo Path
              * @description Repository path
-             * @default /opt/autobot
              */
-            repo_path: string;
+            repo_path?: string;
             /**
              * Staged
              * @description Show staged changes only
@@ -73987,9 +73983,8 @@ export interface components {
             /**
              * Repo Path
              * @description Repository path
-             * @default /opt/autobot
              */
-            repo_path: string;
+            repo_path?: string;
             /**
              * Max Count
              * @description Maximum number of commits (1-100)
@@ -74077,9 +74072,8 @@ export interface components {
             /**
              * Repo Path
              * @description Repository path
-             * @default /opt/autobot
              */
-            repo_path: string;
+            repo_path?: string;
             /**
              * Ref
              * @description Commit or ref to show (default: HEAD)
@@ -74097,9 +74091,8 @@ export interface components {
             /**
              * Repo Path
              * @description Repository path (must be whitelisted)
-             * @default /opt/autobot
              */
-            repo_path: string;
+            repo_path?: string;
             /**
              * Short
              * @description Use short format output
@@ -76399,11 +76392,8 @@ export interface components {
             /**
              * Source Paths
              * @description Paths to populate from
-             * @default [
-             *       "/home/runner/work/AutoBot-AI/AutoBot-AI"
-             *     ]
              */
-            source_paths: string[];
+            source_paths?: string[];
             /**
              * Document Types
              * @description Document types to include
@@ -84635,9 +84625,8 @@ export interface components {
             /**
              * Path
              * @description Path to analyze (defaults to project root)
-             * @default /home/runner/work/AutoBot-AI/AutoBot-AI
              */
-            path: string;
+            path?: string;
             /**
              * Source Id
              * @description #1772: source_id for API consistency
@@ -91275,11 +91264,8 @@ export interface components {
             /**
              * Scan Paths
              * @description Paths to scan
-             * @default [
-             *       "/home/runner/work/AutoBot-AI/AutoBot-AI"
-             *     ]
              */
-            scan_paths: string[];
+            scan_paths?: string[];
             /**
              * Scan Types
              * @description Types of security scans
@@ -96477,9 +96463,8 @@ export interface components {
             /**
              * Test Path
              * @description Path to test directory
-             * @default /home/runner/work/AutoBot-AI/AutoBot-AI/autobot-backend
              */
-            test_path: string;
+            test_path?: string;
             /**
              * Test Patterns
              * @description Test file patterns

--- a/scripts/check_openapi_absolute_defaults.py
+++ b/scripts/check_openapi_absolute_defaults.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Fail when a JSON-Schema ``default`` in the OpenAPI contract is an absolute path (#13572).
+
+A schema ``default`` is baked into the published contract and shipped in the
+committed frontend types. When that default is an absolute filesystem path it
+does two things, both bad:
+
+1. **It makes the contract host-dependent.** The value is whatever the machine
+   that last generated it resolved, so ``verify-generated-types`` starts failing
+   for reasons unrelated to any API change. #13357 already records this
+   happening twice — "a generated-types regeneration twice picked up the build
+   machine's absolute paths as schema defaults".
+2. **It discloses the server's filesystem layout** to every API consumer.
+
+The fix at each site is ``default_factory`` instead of ``default``. Pydantic and
+FastAPI both omit a factory from the generated schema while the runtime default
+is unchanged, so this costs nothing:
+
+    # publishes the path
+    repo_path: str = Field(default=str(PROJECT_ROOT))
+
+    # identical at runtime, absent from the schema
+    repo_path: str = Field(default_factory=lambda: str(PROJECT_ROOT))
+
+This checker exists because nothing else stops the next one. #13572 fixed 21
+sites; two of them were not in that issue's own list of 19 and were found only
+by dumping the contract and looking — which is what this script automates.
+
+Exit code:
+  0 — no absolute-path defaults
+  1 — at least one, or the contract could not be dumped
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess  # nosec B404  # fixed argv, no shell, no caller input
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Iterator, Tuple
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+#: Values that are absolute but carry no host-specific information. ``/`` alone
+#: is meaningless as a disclosure and shows up as a legitimate URL-path default.
+_ALLOWED = {"/"}
+
+
+def _walk_defaults(node: Any, path: str = "") -> Iterator[Tuple[str, str]]:
+    """Yield ``(json_path, value)`` for every string default under *node*.
+
+    List-valued defaults are flattened: ``default=[str(PROJECT_ROOT)]`` leaks
+    exactly as much as the scalar form, and two of the sites in #13572 were of
+    that shape.
+    """
+    if isinstance(node, dict):
+        if "default" in node:
+            value = node["default"]
+            for item in value if isinstance(value, list) else [value]:
+                if isinstance(item, str):
+                    yield path, item
+        for key, value in node.items():
+            yield from _walk_defaults(value, f"{path}.{key}")
+    elif isinstance(node, list):
+        for index, value in enumerate(node):
+            yield from _walk_defaults(value, f"{path}[{index}]")
+
+
+def _is_absolute_path(value: str) -> bool:
+    """True when *value* looks like an absolute filesystem path, not a URL path.
+
+    A URL route (``/api/health``) is a legitimate default and is not a
+    disclosure. The distinction used here is that a filesystem path names a real
+    directory on this machine — which is precisely the property that makes it
+    host-dependent, and therefore the one worth rejecting.
+    """
+    if value in _ALLOWED or not value.startswith("/"):
+        return False
+    return Path(value).exists()
+
+
+def _dump_openapi(target: Path) -> bool:
+    """Dump the backend OpenAPI contract to *target*. True on success."""
+    result = subprocess.run(  # nosec B603  # fixed argv, no shell
+        [
+            sys.executable,
+            str(REPO_ROOT / "scripts" / "audit_api_wiring.py"),
+            "--dump-openapi",
+            str(target),
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0 or not target.exists() or target.stat().st_size == 0:
+        print("Could not dump the OpenAPI contract:")
+        print((result.stderr or result.stdout or "")[-2000:])
+        return False
+    return True
+
+
+def _load_contract(argv: list[str]) -> dict | None:
+    """Return the contract, reusing a pre-dumped file when one is given.
+
+    ``--contract <path>`` exists so CI does not pay for a second dump:
+    ``verify-generated-types.yml`` already builds ``app.openapi()`` and writes it
+    out, and that build is the expensive part of the job.
+    """
+    if "--contract" in argv:
+        given = Path(argv[argv.index("--contract") + 1])
+        if not given.exists():
+            print(f"--contract given but not found: {given}")
+            return None
+        return json.loads(given.read_text(encoding="utf-8"))
+    with tempfile.TemporaryDirectory() as tmp:
+        target = Path(tmp) / "openapi.json"
+        if not _dump_openapi(target):
+            return None
+        return json.loads(target.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Dump (or load) the contract and reject absolute-path schema defaults."""
+    contract = _load_contract(argv if argv is not None else sys.argv[1:])
+    if contract is None:
+        return 1
+
+    offenders = [(p, v) for p, v in _walk_defaults(contract) if _is_absolute_path(v)]
+    if not offenders:
+        return 0
+
+    for json_path, value in offenders[:15]:
+        print(f"{json_path.lstrip('.')}: default is an absolute path -> {value}")
+    if len(offenders) > 15:
+        print(f"... and {len(offenders) - 15} more")
+    print(
+        f"\n{len(offenders)} absolute-path schema default(s) (#13572). "
+        "Use default_factory=lambda: ... — same runtime value, absent from the schema."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Thinking Path

A JSON-Schema `default` is baked into the published contract and shipped in the committed frontend types. When that default is an absolute filesystem path it does two things: it makes the contract depend on whichever machine last generated it, and it discloses the server's filesystem layout to every API consumer.

The fix per site is `default_factory` instead of `default` — Pydantic and FastAPI both omit a factory from the generated schema while the runtime default is unchanged. `schemas_analytics.py:1084` already used that form; it had simply never been applied elsewhere.

## What Changed

**21 defaults converted**, not the 19 in the issue:

| file | kind | count |
|---|---|---|
| `codebase_analytics/endpoints/pattern_analysis.py` | `Query(default=…)` | 8 |
| `schemas_code.py` | `Field(default=…)` on the six `Git*Request` models | 6 |
| `schemas_workflows.py` | `Field(default=…)`, incl. two list-valued | 4 |
| `files.py` | function default on `admin_list_directory` | 1 |

`_GIT_DEFAULT_REPO_PATH` became `_git_default_repo_path()`, since a factory needs a callable.

**Two sites were not on the issue's list**, and I only found them by dumping the contract and looking rather than trusting the enumeration:

- `TestSuiteRequest.test_path` — derives from `PATH.TESTS_DIR`, not `PROJECT_ROOT`, so a `PROJECT_ROOT` grep missed it. It was resolving to my **worktree checkout path**, which is exactly the host-dependence the issue predicted, already happening.
- `GET /api/files` — `admin_list_directory(path: str = "/home/autobot")`, a hardcoded service-account home directory published as a query-parameter default.

Two of the workflow defaults were `default=[str(PATH.PROJECT_ROOT)]`. A list-valued default leaks exactly as much as a scalar one, and a naive pattern skips it.

**New gate — `scripts/check_openapi_absolute_defaults.py`** (step 3 of the issue). It dumps the contract, walks every `default` including inside lists, and rejects any value that is an absolute path *and* exists on disk — that last test is what separates a filesystem path from a legitimate URL-route default like `/api/health`.

It takes `--contract <path>` so CI reuses the dump `verify-generated-types` already performs; building `app.openapi()` is the expensive part of that job and doing it twice would be waste. The step is placed **before** the diff deliberately: an absolute-path default surfaces there as a spurious generated-types diff on whichever runner regenerated it, which is an unactionable failure that has already happened twice (#13357). Failing earlier names the offending field.

## Verification

**Against the acceptance criterion**, before and after:

```
absolute-path JSON-Schema defaults in the dumped OpenAPI: 2   # before
absolute-path JSON-Schema defaults now: 0                     # after
```

**The gate catches a reintroduction.** Reverting one field to `default=`:

```
components.schemas.CodebaseIndexingRequest.properties.codebase_path:
    default is an absolute path -> /home/martins/…/.worktrees/issue-13572
1 absolute-path schema default(s) (#13572).
exit=1
```

Restored, `exit=0`. It also flags exactly the two extras when pointed at the pre-fix dump.

```
128 passed, 656 skipped     # autobot-backend/api/ -k "files or workflow or pattern or schemas_code"
YAML parses OK              # verify-generated-types.yml, step lands in the right job and order
```

## api.ts is not regenerated here

`node_modules` is absent locally and installing it ad hoc is not something I'll do, so `api.ts` is left for `auto-fix-generated-types` to regenerate in its py3.14 environment and commit — the order of work the issue specifies. **Expect `verify-generated-types` to be red until that lands**; the diff is the 21 removed defaults, which is the intended change.

## Scope

Steps 1 and 3 of #13572. Step 2 — the `_find_project_root` resolver fix — is a separate change and is what this unblocks, so the issue stays open.

`git_mcp.py`'s `DEFAULT_REPO_PATH` is untouched on purpose. Those are hand-written MCP `input_schema` dicts carried in a free-form `Metadata` field, so they are response data rather than JSON-Schema defaults and do not reach `api.ts`. They are still a runtime disclosure in the tools listing, but removing the advertised default without a confirmed server-side fallback would change behaviour for MCP clients — a different risk, and not covered by this issue's acceptance.

Refs #13572

## Model Used

Claude Opus 5
