### PR TITLE
test(kb): make the GPU chunker and KB stats tests able to fail (#13563)

### DIFF
--- a/autobot-backend/knowledge/gpu_kb_integration_test.py
+++ b/autobot-backend/knowledge/gpu_kb_integration_test.py
@@ -1,171 +1,77 @@
 #!/usr/bin/env python3
 # Copyright 2025-2026 mrveiss
 # SPDX-License-Identifier: Apache-2.0
+"""GPU semantic chunker + knowledge base integration (#13563).
+
+Both tests here used to be unfailable. Each wrapped its body in a bare
+``except Exception`` and returned ``True``/``False``; pytest ignores a test's
+return value, so every run reported success no matter what happened. That hid
+two real defects for as long as the file has existed:
+
+* ``test_chunker_optimization`` imported ``get_semantic_chunker`` from
+  ``knowledge_base``, which **never exported it** — the module re-exports only
+  ``KnowledgeBase``, ``get_knowledge_base``, ``EmbeddingCache``,
+  ``get_embedding_cache`` and ``_sanitize_metadata_for_chromadb``. The import
+  raised ``ImportError`` on every run and the ``except`` swallowed it. The real
+  accessor lives in ``utils.semantic_chunker_gpu``.
+* ``test_kb_stats`` called the coroutine ``get_knowledge_base()`` without
+  ``await`` (#13563), so it used a coroutine object as if it were the knowledge
+  base. Same defect class as the two fixed under #13551.
+
+They now assert instead of returning, so a regression fails the run.
 """
-Simple test to verify GPU-optimized semantic chunking integration with knowledge base
-"""
 
-import asyncio
-import sys
-import time
+import pytest
 
-from autobot_shared.ssot_config import config
+from utils.semantic_chunker_gpu import get_gpu_semantic_chunker
 
-# Add AutoBot to path
-sys.path.insert(0, config.project_root)
+# Long enough that chunking has something to divide, short enough to stay fast.
+SAMPLE_TEXT = (
+    "AutoBot is an advanced Linux administration platform designed for intelligent automation. "
+    "The system utilizes AI technologies to manage Linux environments efficiently. "
+    "Through machine learning and natural language processing it interprets system requirements. "
+    "The platform provides autonomous decision-making for routine administrative tasks. "
+    "Security and reliability are paramount in its architectural design. "
+) * 3
 
 
 async def test_chunker_optimization():
-    """Test that the optimized chunker is being used."""
-    print("🔧 Testing Semantic Chunker GPU Optimization Integration")  # noqa: print
-    print("=" * 60)  # noqa: print
+    """The GPU chunker is reachable and actually chunks text.
 
-    try:
-        # Test import and functionality
-        print("📦 Testing chunker import...")  # noqa: print
-        from knowledge_base import get_semantic_chunker
+    Hermetic: ``get_gpu_semantic_chunker()`` needs no Redis and no ChromaDB, so
+    this belongs on the PR unit gate. Verified by running it against a clean
+    environment where ``get_knowledge_base()`` fails.
+    """
+    chunker = get_gpu_semantic_chunker()
 
-        chunker = get_semantic_chunker()
-        chunker_type = type(chunker).__name__
+    # The GPU implementation is what this file exists to cover — assert the
+    # identity rather than accepting whatever the factory happens to return.
+    assert type(chunker).__name__ == "GPUSemanticChunker"
+    assert hasattr(chunker, "gpu_batch_size")
+    assert hasattr(chunker, "get_performance_stats")
 
-        print(f"  ✅ Active chunker: {chunker_type}")  # noqa: print
-        print(f"  📍 Module: {chunker.__class__.__module__}")  # noqa: print
+    chunks = await chunker.chunk_text(SAMPLE_TEXT)
 
-        # Check optimization features
-        optimization_features = []
-        if hasattr(chunker, "get_performance_stats"):
-            optimization_features.append("Performance Stats")
-        if hasattr(chunker, "gpu_batch_size"):
-            optimization_features.append(f"GPU Batch Size: {chunker.gpu_batch_size}")
-        if hasattr(chunker, "_gpu_memory_pool_initialized"):
-            optimization_features.append("GPU Memory Pool")
-        if hasattr(chunker, "chunk_text_optimized"):
-            optimization_features.append("Optimized Chunking Method")
-
-        if optimization_features:
-            print("  🚀 Optimization features detected:")  # noqa: print
-            for feature in optimization_features:
-                print(f"    - {feature}")  # noqa: print
-        else:
-            print("  ⚠️  No optimization features detected")  # noqa: print
-
-        # Test chunking performance
-        print("\n⚡ Testing chunking performance...")  # noqa: print
-        test_text = """
-        AutoBot is an advanced Linux administration platform designed for intelligent automation.
-        The system utilizes cutting-edge AI technologies to manage Linux environments efficiently.
-        Through machine learning and natural language processing, AutoBot can understand complex system requirements.
-        The platform provides autonomous decision-making capabilities for routine administrative tasks.
-        Security and reliability are paramount in AutoBot's architectural design.
-        """ * 3  # Make text longer for meaningful test
-
-        start_time = time.time()
-
-        if hasattr(chunker, "chunk_text_optimized"):
-            # Use optimized method
-            chunks = await chunker.chunk_text_optimized(test_text)
-            method_used = "GPU-Optimized"
-        elif hasattr(chunker, "chunk_text"):
-            # Use standard async method
-            chunks = await chunker.chunk_text(test_text)
-            method_used = "Standard Async"
-        else:
-            print("  ❌ No suitable chunking method found")  # noqa: print
-            return False
-
-        processing_time = time.time() - start_time
-
-        print("  📊 Results:")  # noqa: print
-        print(f"    - Method used: {method_used}")  # noqa: print
-        print(f"    - Processing time: {processing_time:.3f}s")  # noqa: print
-        print(f"    - Chunks created: {len(chunks)}")  # noqa: print
-        print(f"    - Text length: {len(test_text)} characters")  # noqa: print
-
-        if len(chunks) > 0:
-            sentences_estimated = len(test_text.split("."))
-            sentences_per_sec = sentences_estimated / processing_time if processing_time > 0 else 0
-            print(f"    - Performance: {sentences_per_sec:.1f} sentences/sec")  # noqa: print
-
-            # Show first chunk as example
-            first_chunk = chunks[0]
-            print("  📝 Sample chunk:")  # noqa: print
-            print(f"    - Content: {first_chunk.content[:100]}...")  # noqa: print
-            if hasattr(first_chunk, "metadata"):
-                optimization_info = first_chunk.metadata.get("optimization_version", "none")
-                print(f"    - Optimization: {optimization_info}")  # noqa: print
-
-        return True
-
-    except Exception as e:
-        print(f"❌ Test failed: {e}")  # noqa: print
-        import traceback
-
-        traceback.print_exc()
-        return False
+    assert chunks, "chunker returned no chunks for a multi-sentence document"
+    assert all(chunk.content for chunk in chunks), "a chunk was produced with empty content"
 
 
+@pytest.mark.integration
 async def test_kb_stats():
-    """Test knowledge base statistics."""
-    print("\n📊 Testing Knowledge Base Statistics...")  # noqa: print
+    """Knowledge base statistics are reachable and well-formed.
 
-    try:
-        from knowledge_base import get_knowledge_base
+    Requires a fully initialised KnowledgeBase (Redis ``knowledge`` database plus
+    ChromaDB): without one ``get_knowledge_base()`` raises
+    ``RuntimeError: Failed to initialize knowledge base``. It cannot run on the
+    PR unit gate, so it is marked ``integration`` — the same treatment
+    ``kb_optimization_test.py`` received under #13551.
+    """
+    from knowledge_base import get_knowledge_base
 
-        kb = get_knowledge_base()
-        stats = await kb.get_stats()
+    kb = await get_knowledge_base()
+    stats = await kb.get_stats()
 
-        print("  📈 Knowledge Base Stats:")  # noqa: print
-        print(f"    - Total Vectors: {stats.get('total_vectors', 0)}")  # noqa: print
-        print(f"    - Total Chunks: {stats.get('total_chunks', 0)}")  # noqa: print
-        print(f"    - Total Documents: {stats.get('total_documents', 0)}")  # noqa: print
-        print(f"    - Redis Connected: {stats.get('redis_connected', False)}")  # noqa: print
-        print(f"    - Index Available: {stats.get('index_available', False)}")  # noqa: print
-
-        return stats.get("total_vectors", 0) > 0
-
-    except Exception as e:
-        print(f"  ❌ Stats test failed: {e}")  # noqa: print
-        return False
-
-
-if __name__ == "__main__":
-
-    async def main():
-        print("🚀 AutoBot Phase 9 - GPU Optimization Integration Test")  # noqa: print
-        print("=" * 70)  # noqa: print
-
-        # Test chunker optimization
-        chunker_success = await test_chunker_optimization()
-
-        # Test KB stats
-        stats_success = await test_kb_stats()
-
-        # Final results
-        print("\n" + "=" * 70)  # noqa: print
-        print("📋 TEST RESULTS SUMMARY")  # noqa: print
-        print("=" * 70)  # noqa: print
-
-        if chunker_success:
-            print("✅ Semantic chunker optimization: WORKING")  # noqa: print
-        else:
-            print("❌ Semantic chunker optimization: FAILED")  # noqa: print
-
-        if stats_success:
-            print("✅ Knowledge base statistics: WORKING")  # noqa: print
-        else:
-            print("❌ Knowledge base statistics: FAILED")  # noqa: print
-
-        overall_success = chunker_success and stats_success
-
-        if overall_success:
-            print("\n🎉 SUCCESS: GPU optimization integration is working!")  # noqa: print
-            print("  - GPU-optimized semantic chunker active")  # noqa: print
-            print("  - Knowledge base connected and functional")  # noqa: print
-            print("  - Phase 9 hardware optimization deployed")  # noqa: print
-        else:
-            print("\n⚠️  PARTIAL SUCCESS: Some components may need attention")  # noqa: print
-
-        return overall_success
-
-    success = asyncio.run(main())
-    sys.exit(0 if success else 1)
+    assert isinstance(stats, dict)
+    for key in ("total_vectors", "total_chunks", "total_documents"):
+        assert key in stats, f"stats missing '{key}'"
+        assert isinstance(stats[key], int), f"stats['{key}'] is not an int"


### PR DESCRIPTION
## Thinking Path

The issue asks for one `await`. Adding it alone would have achieved nothing, because **neither test in this file could fail.** Each wrapped its body in a bare `except Exception` and returned `True`/`False`, and pytest ignores a test's return value — so every run reported success regardless of what happened inside.

That hid two defects, not one:

**1. `test_chunker_optimization` imported a function that does not exist.**

```python
from knowledge_base import get_semantic_chunker   # ImportError, every run
```

`knowledge_base.py` is a compatibility shim re-exporting exactly five names — `KnowledgeBase`, `get_knowledge_base`, `EmbeddingCache`, `get_embedding_cache`, `_sanitize_metadata_for_chromadb` — and its `__getattr__` raises `AttributeError` for anything else. `get_semantic_chunker` was never among them; a repo-wide search finds it only under `utils/`. So this test has raised `ImportError` for its entire existence and reported green.

**2. `test_kb_stats` called the coroutine without `await`** — the reported defect, same class as the two fixed under #13551.

## What Changed

Both tests now assert instead of returning, so a regression fails the run.

- **`test_chunker_optimization`** points at the real accessor, `utils.semantic_chunker_gpu.get_gpu_semantic_chunker`. That is the one this file is about: the checks it was already making — `gpu_batch_size`, `get_performance_stats` — are `GPUSemanticChunker`'s. It asserts the concrete type rather than accepting whatever the factory returns, then chunks a document and asserts non-empty chunks with non-empty content.
- **`test_kb_stats`** gains the `await`, plus assertions on the shape of the returned stats.

The dead `chunk_text_optimized` branch is gone — measured, that attribute does not exist on `GPUSemanticChunker`, so it was unreachable. `chunk_text` is the real method. The `__main__` demo runner is also gone: pytest is the runner, and the block only existed to print a summary of the return values that made these tests unfailable.

## Marker split — measured, not assumed

The issue left this open ("leave it on the unit gate if it passes hermetically or mark it `integration`"). Both paths were run against a clean environment:

```
get_gpu_semantic_chunker() -> GPUSemanticChunker, chunk_text() -> chunks   # no Redis, no ChromaDB
get_knowledge_base()       -> RuntimeError: Failed to initialize knowledge base
```

So the chunker test stays on the unit gate and `test_kb_stats` is marked `integration` — the same treatment `kb_optimization_test.py` received under #13551, for the same reason.

## Verification

```
1 passed, 1 deselected      # -m "not integration", i.e. how the PR gate runs it
1 failed, 1 passed          # full selection: test_kb_stats fails without the live stack
E   RuntimeError: Failed to initialize knowledge base
```

That failure is the point: the test can now fail. Previously it passed in both configurations while executing nothing.

Wider run of the directory, unit selection: `1073 passed, 14 failed`. **None of the failures are in this file** — they are in `connectors/scheduler_test.py` (6), `search_quality_test.py` (4), `code_semantic_search_test.py` (4) and `knowledge_base_integration_test.py` (3 errors), the pre-existing knowledge-cluster tail tracked under #13162.

Refs #13563

## Model Used

Claude Opus 5
