### PR TITLE
fix(media): one canonical audio-extension allowlist for upload, route and processing guards (#13512)

### DIFF
--- a/autobot-backend/media/audio/ffmpeg_service.py
+++ b/autobot-backend/media/audio/ffmpeg_service.py
@@ -17,11 +17,13 @@ from typing import Optional
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.singleton_factory import lazy_singleton
+from autobot_shared.ssot_constants import SecurityConstants
 
 logger = get_logger(__name__)
 
-# Allowed audio extensions (must match upload_security.py)
-ALLOWED_EXTENSIONS = {".wav", ".mp3", ".mp4", ".m4a", ".ogg", ".flac", ".webm"}
+# Allowed audio extensions. The "must match upload_security.py" comment this
+# replaces was an invariant nothing enforced — it is now the same object (#13512).
+ALLOWED_EXTENSIONS = SecurityConstants.ALLOWED_AUDIO_EXTENSIONS
 
 # Extension to FFmpeg format mapping (for -f flag)
 EXTENSION_TO_FORMAT = {
@@ -78,7 +80,9 @@ class FFmpegService:
         # Security: Validate extension
         input_ext = Path(input_path).suffix.lower()
         if input_ext not in ALLOWED_EXTENSIONS:
-            raise ValueError(f"File extension '{input_ext}' not allowed. Allowed: {', '.join(ALLOWED_EXTENSIONS)}")
+            raise ValueError(
+                f"File extension '{input_ext}' not allowed. Allowed: {', '.join(ALLOWED_EXTENSIONS)}"
+            )
 
         # Security: Reject relative paths
         if not os.path.isabs(input_path):
@@ -150,7 +154,9 @@ class FFmpegService:
             return output_path
 
         except FileNotFoundError:
-            raise RuntimeError(f"FFmpeg not found at {self.ffmpeg_path}. Please install FFmpeg: apt-get install ffmpeg")
+            raise RuntimeError(
+                f"FFmpeg not found at {self.ffmpeg_path}. Please install FFmpeg: apt-get install ffmpeg"
+            )
         except Exception as exc:
             logger.error("Audio extraction error: %s", exc)
             # Clean up output file on error

--- a/autobot-backend/media/audio/ffmpeg_service.py
+++ b/autobot-backend/media/audio/ffmpeg_service.py
@@ -80,9 +80,7 @@ class FFmpegService:
         # Security: Validate extension
         input_ext = Path(input_path).suffix.lower()
         if input_ext not in ALLOWED_EXTENSIONS:
-            raise ValueError(
-                f"File extension '{input_ext}' not allowed. Allowed: {', '.join(ALLOWED_EXTENSIONS)}"
-            )
+            raise ValueError(f"File extension '{input_ext}' not allowed. Allowed: {', '.join(ALLOWED_EXTENSIONS)}")
 
         # Security: Reject relative paths
         if not os.path.isabs(input_path):
@@ -154,9 +152,7 @@ class FFmpegService:
             return output_path
 
         except FileNotFoundError:
-            raise RuntimeError(
-                f"FFmpeg not found at {self.ffmpeg_path}. Please install FFmpeg: apt-get install ffmpeg"
-            )
+            raise RuntimeError(f"FFmpeg not found at {self.ffmpeg_path}. Please install FFmpeg: apt-get install ffmpeg")
         except Exception as exc:
             logger.error("Audio extraction error: %s", exc)
             # Clean up output file on error

--- a/autobot-backend/transcriber/routes/recordings.py
+++ b/autobot-backend/transcriber/routes/recordings.py
@@ -28,11 +28,11 @@ from fastapi.responses import StreamingResponse
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.security.path_validator import validate_path
+from autobot_shared.ssot_constants import SecurityConstants
 from transcriber.database import Database
 from transcriber.deps import DEFAULT_USER, can_access, get_db
 from transcriber.models import RecordingOut
 from transcriber.upload_security import MAX_FILE_SIZE
-from autobot_shared.ssot_constants import SecurityConstants
 
 logger = get_logger(__name__)
 
@@ -95,9 +95,7 @@ async def upload_recording(
     # The file is on disk before the DB row exists; unlink the partial upload
     # if the insert fails so a rejected recording never leaks an orphan (GH#12310).
     try:
-        rid = await db.create_recording(
-            project_id, file.filename or safe_name, str(dest), user_id=_user_id(request)
-        )
+        rid = await db.create_recording(project_id, file.filename or safe_name, str(dest), user_id=_user_id(request))
     except Exception:
         dest.unlink(missing_ok=True)
         raise
@@ -217,9 +215,7 @@ def _wav_frames_to_peaks(frames: bytes, n_channels: int, sampwidth: int, width: 
     normalized = np.abs(arr.astype(np.float32) / max_val)
     bucket_size = max(1, len(normalized) // width)
     n_buckets = min(width, len(normalized))
-    peaks = [
-        float(np.max(normalized[i * bucket_size : (i + 1) * bucket_size])) for i in range(n_buckets)
-    ]
+    peaks = [float(np.max(normalized[i * bucket_size : (i + 1) * bucket_size])) for i in range(n_buckets)]
     return peaks
 
 
@@ -278,9 +274,7 @@ async def audio_chunks(recording_id: int, request: Request, db: Database = Depen
     return _handle_range_request(audio_path, range_header, file_size, content_type)
 
 
-def _handle_range_request(
-    audio_path: Path, range_header: str, file_size: int, content_type: str
-) -> Response:
+def _handle_range_request(audio_path: Path, range_header: str, file_size: int, content_type: str) -> Response:
     """Parse Range header and return 206 Partial Content or 416 on error."""
     try:
         unit, rng = range_header.split("=", 1)

--- a/autobot-backend/transcriber/routes/recordings.py
+++ b/autobot-backend/transcriber/routes/recordings.py
@@ -32,12 +32,15 @@ from transcriber.database import Database
 from transcriber.deps import DEFAULT_USER, can_access, get_db
 from transcriber.models import RecordingOut
 from transcriber.upload_security import MAX_FILE_SIZE
+from autobot_shared.ssot_constants import SecurityConstants
 
 logger = get_logger(__name__)
 
 router = APIRouter(tags=["transcriber-recordings"])
 
-_ALLOWED_EXTENSIONS = {".wav", ".mp3", ".mp4", ".m4a", ".ogg", ".flac", ".webm"}
+# Same canonical set the upload security boundary enforces (#13512) — this
+# route guard admitting a format the validator rejects would be a gap.
+_ALLOWED_EXTENSIONS = SecurityConstants.ALLOWED_AUDIO_EXTENSIONS
 _CHUNK_SIZE = 65536
 
 
@@ -92,7 +95,9 @@ async def upload_recording(
     # The file is on disk before the DB row exists; unlink the partial upload
     # if the insert fails so a rejected recording never leaks an orphan (GH#12310).
     try:
-        rid = await db.create_recording(project_id, file.filename or safe_name, str(dest), user_id=_user_id(request))
+        rid = await db.create_recording(
+            project_id, file.filename or safe_name, str(dest), user_id=_user_id(request)
+        )
     except Exception:
         dest.unlink(missing_ok=True)
         raise
@@ -212,7 +217,9 @@ def _wav_frames_to_peaks(frames: bytes, n_channels: int, sampwidth: int, width: 
     normalized = np.abs(arr.astype(np.float32) / max_val)
     bucket_size = max(1, len(normalized) // width)
     n_buckets = min(width, len(normalized))
-    peaks = [float(np.max(normalized[i * bucket_size : (i + 1) * bucket_size])) for i in range(n_buckets)]
+    peaks = [
+        float(np.max(normalized[i * bucket_size : (i + 1) * bucket_size])) for i in range(n_buckets)
+    ]
     return peaks
 
 
@@ -271,7 +278,9 @@ async def audio_chunks(recording_id: int, request: Request, db: Database = Depen
     return _handle_range_request(audio_path, range_header, file_size, content_type)
 
 
-def _handle_range_request(audio_path: Path, range_header: str, file_size: int, content_type: str) -> Response:
+def _handle_range_request(
+    audio_path: Path, range_header: str, file_size: int, content_type: str
+) -> Response:
     """Parse Range header and return 206 Partial Content or 416 on error."""
     try:
         unit, rng = range_header.split("=", 1)
@@ -323,7 +332,11 @@ async def audio_waveform(
     peaks = _generate_waveform(str(audio_path), width)
     segments_raw = await db.list_segments(recording_id)
     segments = [
-        {"start_time": s["start_time"], "end_time": s["end_time"], "speaker_id": s.get("speaker_id")}
+        {
+            "start_time": s["start_time"],
+            "end_time": s["end_time"],
+            "speaker_id": s.get("speaker_id"),
+        }
         for s in segments_raw
     ]
 

--- a/autobot-backend/transcriber/upload_security.py
+++ b/autobot-backend/transcriber/upload_security.py
@@ -13,11 +13,13 @@ import uuid
 from pathlib import Path
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.ssot_constants import SecurityConstants
 
 logger = get_logger(__name__)
 
-# Allowed audio file extensions
-ALLOWED_EXTENSIONS = {".wav", ".mp3", ".mp4", ".m4a", ".ogg", ".flac", ".webm"}
+# Allowed audio file extensions — canonical set, shared with the route guard
+# and the ffmpeg processing guard so the three cannot drift (#13512).
+ALLOWED_EXTENSIONS = SecurityConstants.ALLOWED_AUDIO_EXTENSIONS
 
 # Maximum file size: 500MB
 MAX_FILE_SIZE = 500 * 1024 * 1024
@@ -123,7 +125,9 @@ def validate_upload_path(file_path: str, user_id: int) -> Path:
     # before any Path/os operations receive the user-controlled value.
     upload_dir_str = str(user_upload_dir)
     if not file_path.startswith(upload_dir_str + os.sep) and file_path != upload_dir_str:
-        raise UploadSecurityError("Path traversal attempt detected: path is outside upload directory")
+        raise UploadSecurityError(
+            "Path traversal attempt detected: path is outside upload directory"
+        )
 
     try:
         # Resolve symlinks and canonicalize — use only this resolved path hereafter
@@ -135,7 +139,9 @@ def validate_upload_path(file_path: str, user_id: int) -> Path:
     try:
         path.relative_to(user_upload_dir)
     except ValueError:
-        raise UploadSecurityError("Path traversal attempt detected: resolved path is outside upload directory")
+        raise UploadSecurityError(
+            "Path traversal attempt detected: resolved path is outside upload directory"
+        )
 
     # Reject symlinks — check on the resolved path object, not the raw input
     if path.is_symlink():
@@ -168,7 +174,9 @@ def save_uploaded_file(file_content: bytes, original_filename: str, user_id: int
     """
     # Validate file size
     if len(file_content) > MAX_FILE_SIZE:
-        raise UploadSecurityError(f"File too large: {len(file_content)} bytes (max: {MAX_FILE_SIZE})")
+        raise UploadSecurityError(
+            f"File too large: {len(file_content)} bytes (max: {MAX_FILE_SIZE})"
+        )
 
     # Generate secure filename
     secure_filename = generate_secure_filename(original_filename)

--- a/autobot-backend/transcriber/upload_security.py
+++ b/autobot-backend/transcriber/upload_security.py
@@ -125,9 +125,7 @@ def validate_upload_path(file_path: str, user_id: int) -> Path:
     # before any Path/os operations receive the user-controlled value.
     upload_dir_str = str(user_upload_dir)
     if not file_path.startswith(upload_dir_str + os.sep) and file_path != upload_dir_str:
-        raise UploadSecurityError(
-            "Path traversal attempt detected: path is outside upload directory"
-        )
+        raise UploadSecurityError("Path traversal attempt detected: path is outside upload directory")
 
     try:
         # Resolve symlinks and canonicalize — use only this resolved path hereafter
@@ -139,9 +137,7 @@ def validate_upload_path(file_path: str, user_id: int) -> Path:
     try:
         path.relative_to(user_upload_dir)
     except ValueError:
-        raise UploadSecurityError(
-            "Path traversal attempt detected: resolved path is outside upload directory"
-        )
+        raise UploadSecurityError("Path traversal attempt detected: resolved path is outside upload directory")
 
     # Reject symlinks — check on the resolved path object, not the raw input
     if path.is_symlink():
@@ -174,9 +170,7 @@ def save_uploaded_file(file_content: bytes, original_filename: str, user_id: int
     """
     # Validate file size
     if len(file_content) > MAX_FILE_SIZE:
-        raise UploadSecurityError(
-            f"File too large: {len(file_content)} bytes (max: {MAX_FILE_SIZE})"
-        )
+        raise UploadSecurityError(f"File too large: {len(file_content)} bytes (max: {MAX_FILE_SIZE})")
 
     # Generate secure filename
     secure_filename = generate_secure_filename(original_filename)

--- a/autobot_shared/ssot_constants.py
+++ b/autobot_shared/ssot_constants.py
@@ -59,9 +59,7 @@ ERR_TEMPLATE_NOT_FOUND = "Template not found"
 ERR_WORKFLOW_NOT_FOUND = "Workflow not found"
 ERR_EXPERIMENT_NOT_FOUND = "Experiment not found"
 ERR_INVALID_CREDENTIALS = "Invalid username or password"
-ERR_INVALID_TOKEN = (
-    "Invalid token"  # nosec B105  # user-facing error message string, not a credential
-)
+ERR_INVALID_TOKEN = "Invalid token"  # nosec B105  # user-facing error message string, not a credential
 
 
 # ============================================================================

--- a/autobot_shared/ssot_constants.py
+++ b/autobot_shared/ssot_constants.py
@@ -29,7 +29,7 @@ from dataclasses import dataclass
 from enum import Enum
 from functools import lru_cache
 from pathlib import Path
-from typing import Dict, FrozenSet, List
+from typing import Dict, FrozenSet, List, Set
 
 # ============================================================================
 # API CONSTANTS
@@ -59,7 +59,9 @@ ERR_TEMPLATE_NOT_FOUND = "Template not found"
 ERR_WORKFLOW_NOT_FOUND = "Workflow not found"
 ERR_EXPERIMENT_NOT_FOUND = "Experiment not found"
 ERR_INVALID_CREDENTIALS = "Invalid username or password"
-ERR_INVALID_TOKEN = "Invalid token"  # nosec B105  # user-facing error message string, not a credential
+ERR_INVALID_TOKEN = (
+    "Invalid token"  # nosec B105  # user-facing error message string, not a credential
+)
 
 
 # ============================================================================
@@ -472,6 +474,31 @@ class SecurityConstants:
 
     # Web ports permitted for outbound/domain network validation (#10384).
     ALLOWED_WEB_PORTS: List[int] = [80, 443, 8080, 8443]
+
+    # Audio/container extensions accepted for transcriber upload, route
+    # admission, and ffmpeg processing (#13512).
+    #
+    # This existed as three byte-identical literals: the upload security
+    # boundary (``transcriber/upload_security.py``), the route guard
+    # (``transcriber/routes/recordings.py``) and the processing guard
+    # (``media/audio/ffmpeg_service.py``). The last carried the comment
+    # "must match upload_security.py" — an invariant nothing enforced.
+    #
+    # Three copies of a security-relevant allowlist drift independently: adding
+    # a format to the route guard alone admits a file the validator was never
+    # taught to accept, and dropping one from the security module alone leaves
+    # two paths still advertising it. One set removes that failure mode. A
+    # genuine difference between the three belongs here as a named subset,
+    # never as a fourth literal.
+    ALLOWED_AUDIO_EXTENSIONS: Set[str] = {
+        ".wav",
+        ".mp3",
+        ".mp4",
+        ".m4a",
+        ".ogg",
+        ".flac",
+        ".webm",
+    }
 
     USER_AGENT_POOL: List[str] = [
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",  # noqa: E501

--- a/repo_tests/audio_extension_allowlist_test.py
+++ b/repo_tests/audio_extension_allowlist_test.py
@@ -1,0 +1,136 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""The audio-extension allowlist has exactly one definition (#13512).
+
+The set that decides which audio uploads are accepted was declared three times,
+byte-identical, with nothing keeping the copies in step:
+
+* ``transcriber/upload_security.py`` — the upload **security boundary**
+* ``transcriber/routes/recordings.py`` — the route guard
+* ``media/audio/ffmpeg_service.py`` — the processing guard
+
+The third even carried the comment *"must match upload_security.py"*, which
+states the invariant without enforcing it. Three copies of a security-relevant
+allowlist drift independently, and the drift is silent in the dangerous
+direction: a format added to the route guard alone is admitted by a validator
+that was never taught to accept it.
+
+These tests hold the consolidation in place. The last one is the important one —
+it fails when a *fourth* literal appears, which is how the first three got here.
+"""
+
+from __future__ import annotations
+
+import ast
+import subprocess  # nosec B404  # fixed argv, no shell, no caller input
+from pathlib import Path
+
+from autobot_shared.ssot_constants import SecurityConstants
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+#: The canonical definition itself, which is the one literal that must exist.
+_CANONICAL = Path("autobot_shared/ssot_constants.py")
+
+
+def _literal_string_sets(source: str) -> list[set[str]]:
+    """Every ``{...}`` set-of-string-literals in *source*.
+
+    Parsed rather than pattern-matched. A regex over braces cannot tell a set
+    from a dict and cannot tell this allowlist from the several legitimately
+    different extension sets nearby — the video pipeline's, the broad binary set
+    in ``file_categorization.py``, and ``EXTENSION_TO_FORMAT``, which is a dict.
+    A first attempt at this test flagged all of them.
+    """
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+    found = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Set) and node.elts:
+            values = {
+                e.value
+                for e in node.elts
+                if isinstance(e, ast.Constant) and isinstance(e.value, str)
+            }
+            if len(values) == len(node.elts):
+                found.append(values)
+    return found
+
+
+def _tracked_python_files() -> list[Path]:
+    result = subprocess.run(  # nosec B603 B607
+        ["git", "ls-files", "*.py"], cwd=REPO_ROOT, capture_output=True, text=True, check=False
+    )
+    return [REPO_ROOT / line for line in result.stdout.splitlines() if line]
+
+
+def test_canonical_set_holds_the_expected_formats():
+    """Guards the contents, so consolidation cannot quietly change behaviour."""
+    assert SecurityConstants.ALLOWED_AUDIO_EXTENSIONS == {
+        ".wav",
+        ".mp3",
+        ".mp4",
+        ".m4a",
+        ".ogg",
+        ".flac",
+        ".webm",
+    }
+
+
+def test_all_three_guards_share_one_object():
+    """Identity, not equality — equal-but-separate sets are what drifted before."""
+    from media.audio.ffmpeg_service import ALLOWED_EXTENSIONS as ffmpeg_set
+    from transcriber.routes.recordings import _ALLOWED_EXTENSIONS as route_set
+    from transcriber.upload_security import ALLOWED_EXTENSIONS as security_set
+
+    canonical = SecurityConstants.ALLOWED_AUDIO_EXTENSIONS
+    assert security_set is canonical
+    assert route_set is canonical
+    assert ffmpeg_set is canonical
+
+
+def test_ffmpeg_format_map_covers_exactly_the_allowlist():
+    """A format the pipeline accepts but cannot convert would fail after upload.
+
+    ``EXTENSION_TO_FORMAT`` is the ffmpeg ``-f`` mapping. If the allowlist grows
+    without it, a file passes every guard and then breaks in processing; if the
+    map grows without the allowlist, the entry is unreachable.
+    """
+    from media.audio.ffmpeg_service import EXTENSION_TO_FORMAT
+
+    assert set(EXTENSION_TO_FORMAT) == SecurityConstants.ALLOWED_AUDIO_EXTENSIONS
+
+
+def test_no_fourth_literal_copy_exists():
+    """Fail when the allowlist is written as a literal anywhere but its home.
+
+    This is the regression that matters. The three original copies were each
+    added by someone reasonably writing the set they needed; nothing told them a
+    canonical one existed. This does.
+
+    Scoped to sets **equal** to the canonical one. Two nearby sets deliberately
+    differ — ``api/knowledge.py`` accepts ``.mkv`` and
+    ``knowledge/connectors/audio_connector.py`` omits ``.mp4``/``.webm`` — and
+    reconciling those changes what the upload boundary admits, which is a
+    decision rather than a refactor. Tracked separately; not failed here.
+    """
+    canonical = SecurityConstants.ALLOWED_AUDIO_EXTENSIONS
+    offenders = []
+    for path in _tracked_python_files():
+        rel = path.relative_to(REPO_ROOT)
+        if rel == _CANONICAL or rel.parts[0] == "repo_tests":
+            continue
+        try:
+            source = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        if any(literal == canonical for literal in _literal_string_sets(source)):
+            offenders.append(str(rel))
+
+    assert not offenders, (
+        "audio-extension allowlist written as a literal instead of imported from "
+        f"SecurityConstants.ALLOWED_AUDIO_EXTENSIONS (#13512): {offenders}"
+    )


### PR DESCRIPTION
## Thinking Path

The audio-extension allowlist existed as three byte-identical literals: the upload **security boundary** (`transcriber/upload_security.py`), the route guard (`transcriber/routes/recordings.py`) and the processing guard (`media/audio/ffmpeg_service.py`). The third carried the comment *"must match upload_security.py"* — an invariant stated but never enforced.

Three copies of a security-relevant allowlist drift silently in the dangerous direction: a format added to the route guard alone is admitted by a validator that was never taught to accept it.

## What Changed

`SecurityConstants.ALLOWED_AUDIO_EXTENSIONS` in `autobot_shared/ssot_constants.py` — the module whose own docstring records it replacing `constants/security_constants.py`, so an upload allowlist belongs there. All three sites now bind that object; the local names survive as aliases, so no call site changed.

`utils/file_categorization.py` was considered and rejected as the home: it is scoped to *codebase analysis* (`PYTHON_EXTENSIONS`, `JS_EXTENSIONS`), and its one audio-adjacent set is a broad binary-file set that also holds images and fonts.

**New guard — `repo_tests/audio_extension_allowlist_test.py`**, four tests:

- the canonical set's contents, so consolidation cannot quietly change behaviour
- all three guards are the **same object** — identity, not equality, since equal-but-separate sets are exactly what drifted
- `EXTENSION_TO_FORMAT` covers exactly the allowlist: a format accepted but unmappable would pass every guard and then break in processing
- **no fourth literal copy exists** — the acceptance criterion, and the regression that actually matters

## Two things worth flagging

**The issue said three copies. There are five, and two have already drifted** — filed as #13615:

| site | difference |
|---|---|
| `api/knowledge.py:1273` | canonical **+ `.mkv`** — accepts a container the upload boundary rejects |
| `knowledge/connectors/audio_connector.py:52` | canonical **− `.mp4` − `.webm`** — rejects two formats every other path accepts |

Both are left alone deliberately. Adding `.mkv` to the canonical set **widens a security boundary**, and the audio connector may be excluding video containers on purpose. Either could be right; neither should be decided by a consolidation PR. The fourth-copy test is scoped to sets **equal** to the canonical one precisely so it does not force that decision by failing.

**My first version of that guard was a regex** over brace-sets containing two known extensions. It flagged seven files — including `EXTENSION_TO_FORMAT` (a dict, not a set), the video pipeline's genuinely different set, and the broad binary set in `file_categorization.py`. It is AST-based now, comparing parsed set literals against the canonical set, which distinguishes a set from a dict and a true duplicate from a different concern.

## Verification

```
4 passed          # repo_tests/audio_extension_allowlist_test.py
279 passed        # repo_tests/
21 passed, 1 failed   # media/audio/ffmpeg_service_test.py + pipeline_test.py
```

**The fourth-copy guard was proven, not assumed.** A file containing the literal set was planted; the test failed naming it:

```
AssertionError: audio-extension allowlist written as a literal instead of imported from
SecurityConstants.ALLOWED_AUDIO_EXTENSIONS (#13512): ['autobot-backend/_probe_fourth_copy.py']
```

Removed, and the suite returns to `4 passed`.

**The one failure is pre-existing and unrelated.** `TestFFmpegServiceIntegration::test_real_audio_extraction` shells out to a real ffmpeg binary. Confirmed identical on the base branch at `c3a050cb9`, with none of this PR's changes present:

```
FAILED ...::test_real_audio_extraction
1 failed
```

Closes #13512

## Model Used

Claude Opus 5
