### PR TITLE
test(slm): stub services.system_secrets_vault so SCIM tests collect (#13581, #13362)

### DIFF
--- a/autobot-slm-backend/tests/api/test_scim.py
+++ b/autobot-slm-backend/tests/api/test_scim.py
@@ -83,6 +83,12 @@ def _load_scim_module():
         "models.database": MagicMock(),
         "services.database": MagicMock(),
         "services.encryption": MagicMock(),
+        # #13581/#13362: scim.py also imports services.system_secrets_vault.
+        # Without a stub the loader resolves the real parent, which is shadowed
+        # under pytest by autobot-slm-backend/api/services.py, and the whole
+        # module errors at collection with "'services' is not a package" — so
+        # SCIM had no test coverage at all rather than a failing test.
+        "services.system_secrets_vault": MagicMock(),
         "user_management.database": MagicMock(),
         "user_management.models": MagicMock(),
         "user_management.models.sso": MagicMock(),
@@ -312,7 +318,11 @@ class TestScimCreateUser:
         mock_svc.deactivate_user = AsyncMock()
 
         fields = _scim._extract_scim_user_fields(
-            {"userName": "ghost", "emails": [{"value": "ghost@example.com", "primary": True}], "active": False}
+            {
+                "userName": "ghost",
+                "emails": [{"value": "ghost@example.com", "primary": True}],
+                "active": False,
+            }
         )
         assert fields["active"] is False
 


### PR DESCRIPTION
## Thinking Path

`autobot-slm-backend/tests/api/test_scim.py` errored at collection, so **SCIM had zero test coverage** — not a failing test, no test at all. Two open issues describe it: #13581 and #13362.

```
E   ModuleNotFoundError: No module named 'services.system_secrets_vault'; 'services' is not a package
```

The message points at a package problem, and both `autobot-backend/services/` and `autobot-slm-backend/services/` are proper packages with `__init__.py` — so that reading is a dead end. The real cause is narrower.

The test loads `api/scim.py` through an explicit `spec.loader.exec_module`, stubbing its dependencies in `sys.modules` first. That stub list covers `services.database` and `services.encryption` but **not** `services.system_secrets_vault`, which `scim.py:33` also imports. With no stub, the loader resolves the real parent — which under pytest is shadowed by `autobot-slm-backend/api/services.py`, a module rather than a package. Hence "not a package".

## What Changed

One entry added to the existing stub dict, matching the pattern already used for every other `services.*` dependency in that file.

## Verification

```
20 passed              # tests/api/test_scim.py — previously 0 collected, 1 error
1148 passed, 1 skipped # autobot-slm-backend/tests/
```

I also checked this was the *only* file in that state, rather than assuming:

```
autobot-slm-backend/tests/  --collect-only   -> this was the sole ERROR
autobot-backend/            --collect-only   -> 21287 tests collected, no errors
```

Closes #13581, #13362

## Model Used

Claude Opus 5
