### PR TITLE
fix(test-infra): stop the leak guard reporting a real package's own shims (#13450, #13599)

### DIFF
--- a/repo_tests/sys_modules_leak_guard.py
+++ b/repo_tests/sys_modules_leak_guard.py
@@ -82,6 +82,7 @@ Configuration:
 from __future__ import annotations
 
 import os
+import types
 import sys
 import warnings
 from dataclasses import dataclass
@@ -422,7 +423,9 @@ class _LeakGuard:
         actually changed.
         """
         previous_of = self._baseline.get
-        changed = [name for name, module in current.items() if previous_of(name, _MISSING) is not module]
+        changed = [
+            name for name, module in current.items() if previous_of(name, _MISSING) is not module
+        ]
         return [(name, current[name], previous_of(name, _MISSING)) for name in changed]
 
     def _classify(self, name: str, module: object, previous: object) -> str | None:
@@ -442,11 +445,56 @@ class _LeakGuard:
             return None
         if _is_conftest_module(module):
             return None  # pytest's own bookkeeping, not a stub
+        if previous is _MISSING and self._parent_is_genuine(name):
+            return None  # a real package's own shim, not a test's leftover
         if not self._shadows_real_code(name):
             return None
         if previous is not _MISSING:
             return "replaced"
         return "synthetic" if _is_synthetic(module) else None
+
+    def _parent_is_genuine(self, name: str) -> bool:
+        """True when *name* is a **new** child of a real, untouched package (#13450).
+
+        ``_is_synthetic`` asks whether a ``sys.modules`` entry lacks a
+        ``__spec__``.  That correctly describes a hand-built stub — and it also
+        describes something else the guard was never meant to police: a real
+        distribution registering a shim for one of its own submodules.
+
+        ``transformers==5.14.1`` does exactly that.  It *removed*
+        ``tokenization_utils``, ``tokenization_utils_fast`` and
+        ``image_processing_utils_fast`` and installs spec-less compatibility
+        objects under the old names; the files do not exist on disk.  Measured,
+        those entries are indistinguishable from ``types.ModuleType("x")`` by
+        ``__spec__``, ``__file__``, ``__loader__`` and object type alike, so no
+        attribute of the entry itself can separate the two cases.
+
+        What does separate them is **ownership of the parent**.  A library's
+        shim always sits under its own real, spec-carrying package.  A leaked
+        stub replaces the package itself, which is why all three historical
+        leaks — ``sqlalchemy``, ``autobot_shared``, ``agents`` — are unaffected:
+        stubbing a package drops the parent's ``__spec__``, and this returns
+        False for them and for their children.
+
+        The parent must also not be tracked. If the session installed the parent
+        as a stub, its children are that stub's business and stay reportable
+        however genuine the parent looks.
+
+        **The trade this makes, stated plainly:** a test that stubs only a
+        submodule while leaving the real parent intact is no longer caught —
+        ``sys.modules["json.decoder"] = MagicMock()`` with ``json`` untouched.
+        Nothing in this repository does that; both stub lists in
+        ``autobot-backend/conftest.py`` install the parent alongside the child.
+        Accepted deliberately (#13450) to stop the guard reddening every base
+        run over a library's own bookkeeping.
+        """
+        parent_name, _, _ = name.rpartition(".")
+        if not parent_name or parent_name in self._tracked:
+            return False
+        parent = sys.modules.get(parent_name)
+        if not isinstance(parent, types.ModuleType):
+            return False
+        return getattr(parent, "__spec__", None) is not None
 
     def _shadows_real_code(self, name: str) -> bool:
         """True when a synthetic entry could be hiding something that exists.
@@ -528,7 +576,11 @@ class _LeakGuard:
         if owner_file.name not in self._candidate_names:
             return
         owner = _display(owner_file, self._rootdir)
-        if owner not in self._removal_candidates or owner in self._visited or owner in self._exercised:
+        if (
+            owner not in self._removal_candidates
+            or owner in self._visited
+            or owner in self._exercised
+        ):
             return
         owner_dir = owner_file if owner_file.is_dir() else owner_file.parent
         self._visited[owner] = (owner_dir, frozenset(owner_dir.parents))
@@ -617,7 +669,9 @@ def pytest_configure(config: pytest.Config) -> None:
     """Keep the guard's warnings visible even under a strict filter set."""
     if _GUARD is None:
         return
-    config.addinivalue_line("filterwarnings", f"always::{__name__}.{_SysModulesLeakWarning.__name__}")
+    config.addinivalue_line(
+        "filterwarnings", f"always::{__name__}.{_SysModulesLeakWarning.__name__}"
+    )
 
 
 def pytest_plugin_registered(plugin: object, manager: object) -> None:
@@ -842,7 +896,9 @@ def pytest_terminal_summary(terminalreporter: object, exitstatus: int) -> None:
     _write_known_owners(terminalreporter, verdict, grouped)
 
 
-def _write_new_owners(terminalreporter: object, verdict: _Verdict, grouped: dict[str, list[dict]]) -> None:
+def _write_new_owners(
+    terminalreporter: object, verdict: _Verdict, grouped: dict[str, list[dict]]
+) -> None:
     """Regressions: files that leak and are not on the baseline."""
     if not verdict.new_owners:
         return
@@ -866,7 +922,9 @@ def _write_fixed_owners(terminalreporter: object, verdict: _Verdict) -> None:
         )
 
 
-def _write_known_owners(terminalreporter: object, verdict: _Verdict, grouped: dict[str, list[dict]]) -> None:
+def _write_known_owners(
+    terminalreporter: object, verdict: _Verdict, grouped: dict[str, list[dict]]
+) -> None:
     """Known debt (#13361): listed, still leaking, and not a failure."""
     if not verdict.known_owners:
         return

--- a/repo_tests/sys_modules_leak_guard_test.py
+++ b/repo_tests/sys_modules_leak_guard_test.py
@@ -46,7 +46,14 @@ def make_guard(monkeypatch):
     monkeypatch.setattr(sys, "modules", dict(sys.modules))
     monkeypatch.setattr(
         "repo_tests.sys_modules_leak_guard._DISK_CACHE",
-        dict(_DISK_CACHE, agents=True, autobot_shared=True, celery=True, knowledge=True, _sodium=False),
+        dict(
+            _DISK_CACHE,
+            agents=True,
+            autobot_shared=True,
+            celery=True,
+            knowledge=True,
+            _sodium=False,
+        ),
     )
 
     def build(removal_candidates: frozenset[str] = frozenset()) -> _LeakGuard:
@@ -177,8 +184,25 @@ def test_a_cffi_pseudo_module_is_not_a_stub(guard):
     assert _leaks_for(guard, _OTHER_MODULE) == []
 
 
-def test_a_synthetic_child_of_a_real_package_is_still_a_stub(guard):
-    """Stubbing one submodule of real code is a leak like any other."""
+def test_a_synthetic_child_of_a_real_package_is_not_reported(guard):
+    """A new spec-less child of an untouched real package is the library's own (#13450).
+
+    This asserted the opposite until #13450. The reversal is deliberate and is
+    the one detection case that fix trades away, recorded here rather than left
+    implicit.
+
+    The reason: ``transformers==5.14.1`` *removed* ``tokenization_utils`` and two
+    siblings and installs spec-less compatibility objects under the old names —
+    the files are not on disk. By ``__spec__``, ``__file__``, ``__loader__`` and
+    object type those entries are identical to ``types.ModuleType("x")``, so no
+    property of the entry can tell a library's shim from a test's leftover. The
+    guard reported them on every base-branch run, against a test module that
+    references neither ``transformers`` nor ``sys.modules``, while the suite
+    itself was green (#13599).
+
+    Ownership of the parent is what separates the two, and it keeps every real
+    leak caught — see the test below.
+    """
     parent = types.ModuleType("knowledge")
     parent.__spec__ = object()  # type: ignore[assignment]
     _install("knowledge", parent)
@@ -186,7 +210,22 @@ def test_a_synthetic_child_of_a_real_package_is_still_a_stub(guard):
     _install("knowledge.utils", types.ModuleType("knowledge.utils"))
     guard.attribute(_LLC_CONFTEST)
 
-    assert _leaks_for(guard, _OTHER_MODULE) == ["knowledge.utils"]
+    assert _leaks_for(guard, _OTHER_MODULE) == []
+
+
+def test_a_synthetic_child_is_still_a_stub_when_the_parent_is_stubbed_too(guard):
+    """The exemption must not cover a package the session itself replaced (#13450).
+
+    This is the shape all three historical leaks took — ``sqlalchemy``,
+    ``autobot_shared``, ``agents`` — a stubbed package dragging its children
+    along. Stubbing a package drops the parent's ``__spec__``, so the parent is
+    not genuine and both it and its children stay reportable.
+    """
+    _install("knowledge", types.ModuleType("knowledge"))  # no __spec__ — a stub
+    _install("knowledge.utils", types.ModuleType("knowledge.utils"))
+    guard.attribute(_LLC_CONFTEST)
+
+    assert _leaks_for(guard, _OTHER_MODULE) == ["knowledge", "knowledge.utils"]
 
 
 def test_a_restored_stub_stops_being_reported(guard):
@@ -338,7 +377,9 @@ def test_a_still_leaking_listed_owner_is_exercised_and_reported(make_guard):
 def test_the_baseline_file_ignores_comments_and_blank_lines(tmp_path):
     """The file carries its own instructions, so comments have to be free."""
     path = tmp_path / "baseline.txt"
-    path.write_text("# header\n\nbackend/conftest.py\n  backend/x/conftest.py  \n", encoding="utf-8")
+    path.write_text(
+        "# header\n\nbackend/conftest.py\n  backend/x/conftest.py  \n", encoding="utf-8"
+    )
 
     baseline = _load_baseline(path)
 


### PR DESCRIPTION
## Thinking Path

`Dev_new_gui` has failed every `AutoBot CI/CD Pipeline` run since 2026-08-04 — all twelve `python-suite` shards — with **zero test failures**. `2070 passed / 497 passed / 0 FAILED`; the non-zero exit was the leak guard alone, reporting four `transformers.*` keys against `autobot-backend/api/multimodal_response_test.py`, a file containing neither `transformers` nor `sys.modules`.

Measured cause: `transformers==5.14.1` **removed** `tokenization_utils`, `tokenization_utils_fast` and `image_processing_utils_fast` and installs spec-less compatibility objects under the old names. The files are not on disk:

```
site-packages/transformers/tokenization_utils.py            MISSING
transformers.tokenization_utils:  type=module  __spec__=False
```

So `_is_synthetic` — `__spec__ is None` — was *correct* about them. They really are synthetic. They are simply not a test's leftover.

**No attribute of the entry can separate the two cases**, which I established before proposing a fix rather than after:

```
transformers.tokenization_utils  spec=False  file_on_disk=False  type=module
MagicMock stub                   spec=False  file_on_disk=False  type=MagicMock
hand-built ModuleType stub       spec=False  file_on_disk=False  type=module
```

`__file__`, `__loader__` and object type all fail. A `__file__`-based patch was the obvious fix and does not work.

## What Changed

Ownership of the **parent** is what separates them. A library's shim sits under its own real, spec-carrying package; a leaked stub replaces the package itself.

`_parent_is_genuine` exempts a **new** key whose parent is a live `ModuleType` carrying a `__spec__` and is **not itself tracked** as a stub. Scoped to new keys only — a *replacement* under a genuine parent is still a test swapping something out, and stays reported.

The tracked-parent condition is what keeps the historical leaks caught: stubbing a package drops the parent's `__spec__`, so `sqlalchemy`, `autobot_shared` and `agents` and all their children remain reportable.

## Verified against both populations, with real transformers installed

```
FALSE POSITIVE (must now be exempt):
  transformers.tokenization_utils            exempt=True
  transformers.tokenization_utils_fast       exempt=True
TRUE POSITIVES (must stay reportable):
  sqlalchemy         exempt=False      agents        exempt=False
  sqlalchemy.orm     exempt=False      agents.core   exempt=False
  autobot_shared     exempt=False
```

## The trade, stated plainly

A test that stubs **only a submodule** while leaving the real parent intact is no longer caught — `sys.modules["json.decoder"] = MagicMock()` with `json` untouched. Nothing in this repository does that: both stub lists in `autobot-backend/conftest.py` install the parent alongside the child (`_PKG_STUBS` ships `sqlalchemy` with `sqlalchemy.ext`, `sqlalchemy.orm`, …).

This was put to the owner as an explicit either/or against three alternatives (baseline the keys, make the guard non-blocking, leave it) and this option was chosen.

**An existing test asserted the opposite** — `test_a_synthetic_child_of_a_real_package_is_still_a_stub`. It now asserts the new behaviour under a renamed, documented form, with a new sibling pinning the case that must *not* change: a stubbed parent still drags its children into the report.

## Verification

```
46 passed     # sys_modules_leak_guard_test.py + sys_modules_leak_guard_session_test.py
276 passed    # repo_tests/
```

Closes #13599

## Model Used

Claude Opus 5
