### PR TITLE
test(connectors): patch _load_ts/_store_ts on the instance, not as module attributes (#13559)

### DIFF
--- a/autobot-backend/tests/unit/knowledge/connectors/test_gitlab_connector.py
+++ b/autobot-backend/tests/unit/knowledge/connectors/test_gitlab_connector.py
@@ -239,8 +239,12 @@ async def test_gitlab_detect_changes_full_sync():
 
     with (
         patch.object(connector, "_gl_get", side_effect=fake_gl_get),
-        patch("knowledge.connectors.gitlab._load_ts", return_value=None),
-        patch("knowledge.connectors.gitlab._store_ts"),
+        # #13559: _load_ts/_store_ts are coroutines on AbstractConnector
+        # (connectors/base.py:272,293), not module-level functions in
+        # gitlab.py. Patching them by dotted string raised AttributeError,
+        # so four tests errored instead of exercising the sync path.
+        patch.object(connector, "_load_ts", AsyncMock(return_value=None)),
+        patch.object(connector, "_store_ts", AsyncMock()),
     ):
         changes = await connector.detect_changes(since=None)
 
@@ -276,7 +280,7 @@ async def test_gitlab_fetch_issue_content():
 
     with (
         patch.object(connector, "_gl_get", side_effect=fake_gl_get),
-        patch("knowledge.connectors.gitlab._store_ts"),
+        patch.object(connector, "_store_ts", AsyncMock()),
     ):
         result = await connector.fetch_content(source_id)
 
@@ -308,7 +312,7 @@ async def test_gitlab_fetch_mr_content():
 
     with (
         patch.object(connector, "_gl_get", side_effect=fake_gl_get),
-        patch("knowledge.connectors.gitlab._store_ts"),
+        patch.object(connector, "_store_ts", AsyncMock()),
     ):
         result = await connector.fetch_content(source_id)
 
@@ -438,7 +442,7 @@ async def test_gitea_fetch_issue_content():
 
     with (
         patch.object(connector, "_gitea_get", side_effect=fake_gitea_get),
-        patch("knowledge.connectors.gitlab._store_ts"),
+        patch.object(connector, "_store_ts", AsyncMock()),
     ):
         result = await connector.fetch_content(source_id)
 


### PR DESCRIPTION
## Thinking Path

Triaged three test-infra issues together by running each one's own stated reproduction rather than reading the code. Two turned out to be **already fixed** and were closed with evidence and no code; the third was real and is fixed here.

## What Changed

**#13559 — `test_gitlab_connector` patched methods that do not exist as module attributes.**

```
E  AttributeError: <module 'knowledge.connectors.gitlab'> does not have the attribute '_load_ts'
E  AttributeError: <module 'knowledge.connectors.gitlab'> does not have the attribute '_store_ts'
4 failed, 21 passed
```

`_load_ts` and `_store_ts` are coroutines on `AbstractConnector` (`connectors/base.py:272,293`), reached as `self._load_ts(...)`. The tests patched them by dotted string against `gitlab.py`, where no such attribute exists, so four tests errored on the patch instead of exercising the incremental-sync path they were written for.

Repointed to `patch.object(connector, ...)` with `AsyncMock`, matching the `patch.object(connector, "_gl_get", ...)` already used two lines above at each site.

```
25 passed          # test_gitlab_connector.py, was 4 failed / 21 passed
79 passed          # tests/unit/knowledge/connectors/
```

## Closed separately — already fixed, verified not assumed

**#13360** — `respond_tool_test`: 2 failures plus a live DNS lookup from a unit test.

```
13 passed, 7 warnings      # was 2 failed, 10 passed
```

Fixed by `57c8b0698` (PR #13402), which added `patch("chat_workflow.tool_handler._try_mcp_dispatch", AsyncMock(return_value=None))` at line 246. That is also what removes the DNS lookup — the unknown-tool path no longer reaches `MCPDispatcher`'s cache refresh. Confirmed by re-running with `--log-cli-level=WARNING` and grepping for `HTTP request failed` / `Name or service not known` / `MCPDispatcher`: no matches.

**#13457** — `test_recovery_plan_serialization` failing whenever `test_causal_reasoning` shared an xdist worker. Its deterministic reproduction now passes:

```
pytest .../test_causal_error_recovery.py .../test_causal_reasoning.py -n 2 --dist loadscope
36 passed
```

Both modules remain on the leak baseline and are still reported as known entries — that is #13361, not this.

## Not closed, deliberately

**#13455** and **#13344** both describe *intermittent* failures and pass on a single run. A single green run does not disprove intermittency, and stress-running them here was not viable — each invocation costs ~6s of conftest import, so a meaningful sample exceeded the time budget. They stay open rather than being closed on weak evidence.

Closes #13559

## Model Used

Claude Opus 5
