### PR TITLE
fix(test-infra): scope the leak-guard exemptions to third-party packages (#13599)

### DIFF
--- a/repo_tests/sys_modules_leak_guard.py
+++ b/repo_tests/sys_modules_leak_guard.py
@@ -243,6 +243,48 @@ def _is_synthetic(module: object) -> bool:
     return getattr(module, "__spec__", None) is None
 
 
+def _is_self_rebind(name: str, module: object, previous: object) -> bool:
+    """True when *module* is a real package re-registering itself under its own name.
+
+    A package may legitimately replace its own ``sys.modules`` entry while it is
+    importing.  ``transformers`` does exactly this: the entry the import
+    machinery installs is swapped for a ``_LazyModule``, so the key changes
+    object mid-import.  The guard's "replaced" rule was written for a *test*
+    swapping a real module out, and cannot tell the two apart by the fact of
+    replacement alone.
+
+    What separates them is whether the replacement is itself a real module that
+    still knows its own name.  A ``_LazyModule`` keeps a populated ``__spec__``
+    and a ``__name__`` equal to the key.  The three historical leaks do not:
+    ``autobot_shared`` and ``sqlalchemy`` were replaced by bare ``MagicMock``
+    objects and ``agents`` by a ``types.ModuleType`` with no spec — none carries
+    a ``__spec__``, so all three stay reported (#13599).
+
+    The name check matters as well as the spec: aliasing one real module onto a
+    different key (``sys.modules["x"] = real_yaml``) is a genuine swap, and its
+    ``__name__`` would not match, so it is still caught.
+
+    **What was there before matters just as much.** Displacing a conftest stub
+    with the genuine module — which ``tests/agents/test_causal_reasoning.py`` and
+    ``tests/orchestration/test_causal_error_recovery.py`` both do deliberately —
+    also ends with a real, correctly-named module under the key. Judging on the
+    new object alone silences those, and they are exactly the kind of run-phase
+    leak the baseline tracks. A package rebinding itself is distinguished by the
+    *previous* value also being a real spec-carrying module of the same name:
+    the partially-initialised module the import machinery installed moments
+    earlier. Replacing a stub does not satisfy that, because a stub has no spec.
+    """
+    if not isinstance(module, types.ModuleType):
+        return False
+    if getattr(module, "__spec__", None) is None:
+        return False
+    if getattr(module, "__name__", None) != name:
+        return False
+    if not isinstance(previous, types.ModuleType):
+        return False
+    return getattr(previous, "__spec__", None) is not None
+
+
 def _is_conftest_module(module: object) -> bool:
     """True when *module* is a conftest pytest loaded, not a stub of anything.
 
@@ -445,6 +487,8 @@ class _LeakGuard:
             return None
         if _is_conftest_module(module):
             return None  # pytest's own bookkeeping, not a stub
+        if _is_self_rebind(name, module, previous) and self._is_third_party(module):
+            return None  # a third-party package re-registering itself mid-import  # a package re-registering itself during its own import
         if previous is _MISSING and self._parent_is_genuine(name):
             return None  # a real package's own shim, not a test's leftover
         if not self._shadows_real_code(name):
@@ -452,6 +496,26 @@ class _LeakGuard:
         if previous is not _MISSING:
             return "replaced"
         return "synthetic" if _is_synthetic(module) else None
+
+    def _is_third_party(self, module: object) -> bool:
+        """True when *module* is loaded from outside this repository.
+
+        The last discriminator standing. Repo code re-importing a real module
+        over another real module — which ``conftest``'s ``_real_load_and_bind``
+        plus a test's stub displacement produce together — is structurally
+        identical to a package rebinding itself during import: both end with a
+        correctly-named, spec-carrying module replacing another. Only the file
+        location tells them apart, and it is the property that actually matters:
+        the guard exists to police *this repository's* stubs.
+        """
+        origin = getattr(module, "__file__", None)
+        if not origin:
+            return False
+        try:
+            Path(origin).resolve().relative_to(self._rootdir)
+        except ValueError:
+            return True
+        return False
 
     def _parent_is_genuine(self, name: str) -> bool:
         """True when *name* is a **new** child of a real, untouched package (#13450).
@@ -494,7 +558,23 @@ class _LeakGuard:
         parent = sys.modules.get(parent_name)
         if not isinstance(parent, types.ModuleType):
             return False
-        return getattr(parent, "__spec__", None) is not None
+        if getattr(parent, "__spec__", None) is None:
+            return False
+        # The parent must be a third-party distribution, not repo code. Without
+        # this the exemption also covers a conftest stubbing one submodule of a
+        # real repo package — which this repository genuinely does:
+        # ``tests/orchestration/test_causal_error_recovery.py`` leaves spec-less
+        # ``orchestration.causal_error_analyzer`` / ``…causal_error_recovery``
+        # entries under the real ``orchestration`` package, and both are on the
+        # leak baseline. Those must stay reported (#13599).
+        parent_file = getattr(parent, "__file__", None)
+        if not parent_file:
+            return False
+        try:
+            Path(parent_file).resolve().relative_to(self._rootdir)
+        except ValueError:
+            return True  # outside the repo — a third-party package's own shim
+        return False
 
     def _shadows_real_code(self, name: str) -> bool:
         """True when a synthetic entry could be hiding something that exists.
@@ -543,6 +623,9 @@ class _LeakGuard:
             if not mutation.is_live():
                 self._tracked.pop(mutation.key, None)
                 continue
+            if self._now_exempt(mutation.key):
+                self._tracked.pop(mutation.key, None)
+                continue
             if not mutation.escapes_to(path, path_parents):
                 continue
             token = (mutation.key, mutation.owner)
@@ -552,6 +635,28 @@ class _LeakGuard:
             leak = _Leak(mutation=mutation, observed_at=observed_at)
             self.leaks.append(leak)
             self._warn_once_per_owner(leak)
+
+    def _now_exempt(self, key: str) -> bool:
+        """True when a tracked key has since become explicable (#13599).
+
+        Classification happens at the snapshot that first sees a key, and that
+        is sometimes *mid-import* of the package the key belongs to. A
+        ``transformers.*`` compat shim is registered before the parent finishes
+        binding its own ``_LazyModule``, so at classification time the parent is
+        not yet a genuine spec-carrying package and the exemption in
+        :meth:`_classify` cannot apply. Once tracked, a mutation was never
+        revisited, so the entry stayed reportable for the rest of the session
+        even though the reason for suspecting it had evaporated.
+
+        Re-checking here costs one dict lookup per tracked key per node and is
+        what makes the exemption actually reachable. It only ever *removes*
+        suspicion, and only on the same two grounds :meth:`_classify` uses, so
+        it cannot hide a stub that classification would have caught.
+        """
+        module = sys.modules.get(key)
+        if module is None:
+            return False
+        return _is_synthetic(module) and self._parent_is_genuine(key)
 
     def _warn_once_per_owner(self, leak: _Leak) -> None:
         """Warn on the first key each owner leaks, not on all of them.

--- a/repo_tests/sys_modules_leak_guard_test.py
+++ b/repo_tests/sys_modules_leak_guard_test.py
@@ -184,8 +184,32 @@ def test_a_cffi_pseudo_module_is_not_a_stub(guard):
     assert _leaks_for(guard, _OTHER_MODULE) == []
 
 
-def test_a_synthetic_child_of_a_real_package_is_not_reported(guard):
-    """A new spec-less child of an untouched real package is the library's own (#13450).
+def test_a_synthetic_child_of_a_real_REPO_package_is_still_a_stub(guard):
+    """A spec-less child of a real *repo* package is still a leak (#13599).
+
+    #13450 exempted any spec-less child of a genuine parent. That went too far:
+    this repository really does stub one submodule of a real package and leave
+    the parent alone — ``tests/orchestration/test_causal_error_recovery.py``
+    leaves ``orchestration.causal_error_analyzer`` and
+    ``orchestration.causal_error_recovery`` behind, both on the leak baseline —
+    and the exemption silenced them.
+
+    The exemption is now limited to parents loaded from **outside** the repo, so
+    a third-party package's own compat shims are ignored while repo stubs are
+    not. ``knowledge`` here has no ``__file__``, so it is not third-party.
+    """
+    parent = types.ModuleType("knowledge")
+    parent.__spec__ = object()  # type: ignore[assignment]
+    _install("knowledge", parent)
+    guard.snapshot()
+    _install("knowledge.utils", types.ModuleType("knowledge.utils"))
+    guard.attribute(_LLC_CONFTEST)
+
+    assert _leaks_for(guard, _OTHER_MODULE) == ["knowledge.utils"]
+
+
+def test_a_synthetic_child_of_a_third_party_package_is_not_reported(guard, tmp_path):
+    """A spec-less child of an installed distribution is that library's own (#13599).
 
     This asserted the opposite until #13450. The reversal is deliberate and is
     the one detection case that fix trades away, recorded here rather than left
@@ -205,6 +229,7 @@ def test_a_synthetic_child_of_a_real_package_is_not_reported(guard):
     """
     parent = types.ModuleType("knowledge")
     parent.__spec__ = object()  # type: ignore[assignment]
+    parent.__file__ = str(tmp_path / "site-packages" / "knowledge" / "__init__.py")
     _install("knowledge", parent)
     guard.snapshot()
     _install("knowledge.utils", types.ModuleType("knowledge.utils"))


### PR DESCRIPTION
## Thinking Path

`Dev_new_gui` has failed every pipeline run since 2026-08-04 with **zero test failures** — the leak guard alone, reporting four `transformers.*` keys. My previous attempt (#13620) did not fix it, and this PR corrects that.

Three things had to be understood, and I got each wrong once before measuring it:

**1. `transformers` itself is one of the four keys.** It is a real, spec-carrying `_LazyModule` that **rebinds its own `sys.modules` entry** during import. The guard's "replaced" rule was written for a test swapping a real module out and cannot tell the two apart from the replacement alone. Because the parent lands in `_tracked`, #13620's child exemption — which requires an *untracked* parent — could never apply.

**2. Classification happens mid-import.** A `transformers.*` compat shim is registered *before* the parent finishes binding its `_LazyModule`, so at classification time the parent is not yet genuine. A tracked mutation was never revisited, which is why fixing `_classify` alone moved the count 4 → 3 and stopped. A report-time re-check was needed.

**3. "Real module under its own name" is not enough.** `conftest`'s `_real_load_and_bind` plus a test displacing a stub produces exactly that shape for repo code. Judging on the new object alone silenced `agent_loop.think_tool` and `orchestration.causal_error_analyzer`.

## What Changed

Both exemptions are now scoped to **third-party** modules — loaded from outside the repository:

- `_is_self_rebind(name, module, previous)` — a package re-registering itself: real `ModuleType`, populated `__spec__`, `__name__ == key`, **and the previous value also a real spec-carrying module**. Replacing a *stub* does not qualify, because a stub has no spec.
- `_parent_is_genuine` — additionally requires the parent's `__file__` to resolve outside the repo root.
- `_now_exempt` — re-evaluates a tracked key at report time, on the same grounds. It only ever removes suspicion.

The guard exists to police *this repository's* stubs, so file location is not an arbitrary tiebreak — it is the property that actually distinguishes the two populations.

## A correction to #13450

When you chose that fix I told you the blind spot was empty: *"Nothing in this repository does that; both stub lists in `autobot-backend/conftest.py` install the parent alongside the child."* **That was wrong.** `tests/orchestration/test_causal_error_recovery.py` leaves spec-less `orchestration.causal_error_analyzer` and `orchestration.causal_error_recovery` under the real `orchestration` package, and both are on the leak baseline. #13620's rule silenced them.

This PR closes that hole: the exemption no longer covers repo packages at all, so the trade you accepted is narrower than what you agreed to, not wider. The test #13620 added has been reverted to asserting the child **is** reported, with a new sibling covering the third-party case.

## Verification — both directions, on the real reproduction

```
A. the failing reproduction                              LEAK lines: 0   (was 4 keys)
   pytest tests/test_mmr_diversity.py api/multimodal_response_test.py     31 passed

B. baselined run-phase owners must stay reported
   pytest tests/orchestration/test_causal_error_recovery.py \
          tests/agents/test_causal_reasoning.py -n 2 --dist loadscope
   2 known leaking file(s), 4 sys.modules key(s)          — unchanged from before this PR

C. 47 passed   # guard's unit + nested-session suites
D. 281 passed  # repo_tests/
```

Direction B is the check that caught two earlier attempts, including one in this branch that reported 3 keys instead of 4. Verifying the predicate in isolation passed every time and proved nothing.

Closes #13599

## Model Used

Claude Opus 5
