### PR TITLE
test-infra: drop the slm api conftest from the leak baseline, it no longer leaks (#13599)

### DIFF
--- a/repo_tests/sys_modules_leak_baseline.txt
+++ b/repo_tests/sys_modules_leak_baseline.txt
@@ -67,7 +67,6 @@ autobot-backend/worker_node_test.py run-phase
 autobot-slm-backend/api/monitoring_applogs_test.py
 autobot-slm-backend/services/a2a_card_fetcher_test.py
 autobot-slm-backend/services/reconciler_check_node_health_test.py
-autobot-slm-backend/tests/api/conftest.py
 autobot-slm-backend/tests/api/test_collect_outdated_node_ids.py
 autobot-slm-backend/tests/api/test_fleet_health.py
 autobot-slm-backend/tests/api/test_node_update_availability_11964.py


### PR DESCRIPTION
## Thinking Path

`#13633` fixed the leak guard's false positive, and the base run on `da1d38ef0` confirms that half worked — shard 2 shows **`LEAK lines: 0`** and **`FAILED tests: 0`**, where every previous run reported four `transformers.*` keys.

The shard still exited 1, from a later step:

```
Run unit tests — slm-backend   ->  11 passed ... exit code 1

============================ sys.modules leak guard ============================
FIXED: autobot-slm-backend/tests/api/conftest.py no longer leaks —
       remove it from repo_tests/sys_modules_leak_baseline.txt
```

That is the shrink-only ratchet doing its job, not a new defect. Exempting third-party shims means that conftest's remaining entries were all `transformers.*`, so it stopped leaking entirely — and an owner on the baseline that no longer leaks **fails the run, asking for its line to be deleted**. This PR deletes it.

## What Changed

One line removed from `repo_tests/sys_modules_leak_baseline.txt`. 27 owners remain.

This is the mechanism working exactly as the guard's docstring describes: *"every fix lands with a one-line deletion that proves it."*

## Verification

```
384 passed   # autobot-slm-backend/tests/api/ — no FIXED, no LEAK, exit 0
281 passed   # repo_tests/
```

Checked every failing shard (2, 3, 4, 7, 11) for `FIXED:` owners, not just the first — `autobot-slm-backend/tests/api/conftest.py` is the only one, so no other baseline line is stale.

## On #13599

Still open. Two of its three parts are now demonstrably fixed — the false positive is gone and the ratchet consequence is handled — but the closing evidence is a **green base run**, and I am not claiming that until one reports. I closed this issue prematurely once on merge evidence and had to reopen it; the base branch is the only thing that settles it.

Refs #13599

## Model Used

Claude Opus 5
