### PR TITLE
ci: tolerate an empty pytest-split shard instead of failing the run (#13637)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,6 +224,16 @@ jobs:
         # trees run in 336s without it and 35m11s with it, while pytest's own
         # --durations reported every one of the 25 slowest tests under 10s. It
         # is the wrong thing to pay for on every PR.
+        # #13637: pytest exits 5 for "no tests collected". Under --splits 12
+        # that is a scheduling artefact rather than a result — .test_durations_slm
+        # describes 1501 tests against 1644 collected, so pytest-split packs
+        # unevenly and the later groups come out empty. Measured: group 1 took
+        # 497 of 1644 while groups 8-12 took none, and `bash -e` then failed the
+        # step, reddening the base branch on runs with zero test failures.
+        #
+        # The empty shard is announced rather than silently swallowed, and 5 is
+        # the only tolerated code. Fixing the packing is the real repair.
+        set +e
         python -m pytest \
           autobot-slm-backend \
           -n auto --dist loadscope \
@@ -234,6 +244,13 @@ jobs:
           --durations=25 \
           --durations-min=10.0 \
           -q
+        status=$?
+        set -e
+        if [ "$status" -eq 5 ]; then
+          echo "::notice::autobot-slm-backend shard ${{ matrix.shard }}/12 collected no tests (pytest exit 5) — empty split group, see #13637"
+          exit 0
+        fi
+        exit "$status"
 
     - name: Run integration tests
       # Shard 1 only — this suite is selected by DIRECTORY, not by the split, so


### PR DESCRIPTION
## Thinking Path

`python-suite` shards fail with **exit code 5** — pytest's "no tests collected" — because the `autobot-slm-backend` split leaves later groups empty. On base run `31010699951` (`b44e66a12`), shards 9, 10, 11 and 12 failed this way with **no test summary line at all** and **zero test failures**:

```
##[error]Process completed with exit code 5.
============================ 34 warnings in 11.72s ============================
```

`bash -e` turns that into a failed step and a red base branch.

Reproduced locally:

```
pytest autobot-slm-backend --splits 12 --group N --durations-path .test_durations_slm -q --collect-only

group 1   497/1644 tests collected (1147 deselected)
group 8   no tests collected (1644 deselected)
group 9   no tests collected
group 10  no tests collected
group 12  no tests collected
```

**The marker filter is not the cause** — dropping `-m "not integration and not slow …"` changes nothing, group 10 still collects zero. The deselection comes from `pytest-split` itself. `.test_durations_slm` holds 1501 entries against 1644 collected tests, so the packing is computed from figures that no longer describe the suite.

## What Changed

The slm-backend step tolerates exit 5 and nothing else. The shard is **announced** via `::notice::` rather than silently swallowed, so an empty group stays visible in the run summary.

This is the smaller of the two fixes and it stops the bleeding. **The real repair is the uneven packing** — regenerating `.test_durations_slm` against the current suite, or reducing `--splits` for a 1644-test tree — which is tracked in #13637 and not attempted here.

## Verification

The step's shell was extracted from the parsed YAML and exercised against all three outcomes, substituting the pytest invocation with a subshell returning each code:

```
pytest returns 5 (empty shard)   -> step exit 0   + ::notice:: emitted
pytest returns 1 (real failure)  -> step exit 1
pytest returns 0 (normal pass)   -> step exit 0
```

The first simulation I wrote replaced the invocation with a bare `exit 5`, which terminates the script before `status=$?` runs and wrongly reported the guard as broken. A subshell is what actually models a command returning a code.

`yaml.safe_load` parses the workflow, and the step's indentation matches the surrounding block (8-space base, 10-space continuations) — verified by `repr()` on the lines rather than by eye, after a display prefix in my own shell output misled me about the base indent twice.

Refs #13637

## Model Used

Claude Opus 5
