### PR TITLE
ci(watchdog): select superseded stuck runs for force-cancel (#13439)

### DIFF
--- a/pipeline-scripts/ci_dispatch_watchdog.py
+++ b/pipeline-scripts/ci_dispatch_watchdog.py
@@ -153,6 +153,13 @@ MAX_STATUS_DESCRIPTION = 140
 # Run states that mean "created but no job has started yet".
 UNSTARTED_RUN_STATUSES = frozenset({"queued", "waiting", "pending", "requested"})
 
+# Deliberately narrower than UNSTARTED_RUN_STATUSES (#13439). A run holding a
+# concurrency group while a newer one waits is ``queued`` or ``pending``.
+# ``waiting`` and ``requested`` are approval gates — a human or a policy has yet
+# to release them — and force-cancelling those would destroy work nobody has
+# decided about rather than clearing a stuck queue.
+STUCK_QUEUE_STATUSES = frozenset({"queued", "pending"})
+
 # Transport failure — no HTTP status was ever received.
 NO_RESPONSE_STATUS = 0
 
@@ -396,7 +403,9 @@ def is_already_released(message: str) -> bool:
     return NOT_WAITING_MARKER in message.lower()
 
 
-def starved_runs(runs: Sequence[Dict[str, Any]], now: datetime, stall_minutes: int) -> List[Dict[str, Any]]:
+def starved_runs(
+    runs: Sequence[Dict[str, Any]], now: datetime, stall_minutes: int
+) -> List[Dict[str, Any]]:
     """Runs queued longer than *stall_minutes* without allocating a job."""
     starved = []
     for run in runs:
@@ -406,6 +415,77 @@ def starved_runs(runs: Sequence[Dict[str, Any]], now: datetime, stall_minutes: i
         if waited is not None and waited >= stall_minutes:
             starved.append(run)
     return starved
+
+
+def concurrency_group_key(run: Dict[str, Any]) -> Tuple[Any, Any, Any]:
+    """The identity a concurrency group actually has (#13439).
+
+    Grouped by ``(workflow_id, head_branch, event)``, **not** by workflow and
+    branch alone. The group expression is ``${{ github.workflow }}-${{ github.ref }}``
+    and ``github.ref`` differs between a ``push`` run (``refs/heads/...``) and a
+    ``pull_request`` run (``refs/pull/N/merge``) on the same branch. Grouping
+    across that boundary would treat a PR run as superseding a push run and
+    cancel work that is not superseded at all.
+    """
+    return (run.get("workflow_id"), run.get("head_branch"), run.get("event"))
+
+
+def _run_ordering_key(run: Dict[str, Any]) -> Tuple[Any, Any]:
+    """Newest-last ordering: ``run_number`` first, ``created_at`` as tiebreak."""
+    return (run.get("run_number") or 0, run.get("created_at") or "")
+
+
+def superseded_stuck_runs(
+    runs: Sequence[Dict[str, Any]],
+    now: datetime,
+    repository: str,
+    grace_minutes: int,
+    budget: int,
+) -> List[Dict[str, Any]]:
+    """Runs safe to force-cancel because a newer run holds their group (#13439).
+
+    ``concurrency.cancel-in-progress: true`` reaps an *in-progress* predecessor
+    and never a *queued* one. While the singleton self-hosted runner is offline a
+    predecessor never reaches in-progress, so it keeps holding the group and its
+    successors sit ``pending`` with an empty ``jobs`` array until a human runs
+    ``force-cancel``. This selects exactly the runs where that is provably safe.
+
+    A run qualifies only when **all** hold:
+
+    * it is **not the newest** in its group — the newest is never touched, under
+      any condition, because it is the run everything else is waiting for;
+    * its status is in :data:`STUCK_QUEUE_STATUSES` — ``in_progress`` means real
+      work is happening, and ``waiting``/``requested`` are approval gates;
+    * it is older than *grace_minutes* — a legitimate brief queue must not be
+      mistaken for a stuck one;
+    * its head repository is *repository* — the same fork restriction the
+      approval sweep uses, and for the same reason: never act on a run built
+      from contributor-supplied code.
+
+    The result is truncated to *budget* oldest-first, so one sweep cannot cancel
+    the world if the grouping logic is ever wrong.
+    """
+    groups: Dict[Tuple[Any, Any, Any], List[Dict[str, Any]]] = {}
+    for run in runs:
+        if not run_is_same_repo(run, repository):
+            continue
+        groups.setdefault(concurrency_group_key(run), []).append(run)
+
+    stuck: List[Dict[str, Any]] = []
+    for members in groups.values():
+        if len(members) < 2:
+            continue  # nothing supersedes it
+        ordered = sorted(members, key=_run_ordering_key)
+        for run in ordered[:-1]:  # every member except the newest
+            if run.get("status") not in STUCK_QUEUE_STATUSES:
+                continue
+            waited = age_minutes(run.get("created_at"), now)
+            if waited is None or waited < grace_minutes:
+                continue
+            stuck.append(run)
+
+    stuck.sort(key=lambda r: r.get("created_at") or "")
+    return stuck[:budget]
 
 
 def job_is_self_hosted(job: Dict[str, Any]) -> bool:
@@ -481,11 +561,15 @@ def classify_dispatch(
             # demonstrably not verified yet.
             return (
                 "pending",
-                _truncate(f"{len(starved)} run(s) queued over {stall_minutes}m behind a busy runner pool: {names}"),
+                _truncate(
+                    f"{len(starved)} run(s) queued over {stall_minutes}m behind a busy runner pool: {names}"
+                ),
             )
         return (
             "failure",
-            _truncate(f"{len(starved)} run(s) queued over {stall_minutes}m with no runner available: {names}"),
+            _truncate(
+                f"{len(starved)} run(s) queued over {stall_minutes}m with no runner available: {names}"
+            ),
         )
 
     if not runs:
@@ -493,9 +577,14 @@ def classify_dispatch(
         if waited is None or waited >= grace_minutes:
             return (
                 "failure",
-                _truncate(f"no workflow runs exist for this commit after {grace_minutes}m — CI never dispatched"),
+                _truncate(
+                    f"no workflow runs exist for this commit after {grace_minutes}m — CI never dispatched"
+                ),
             )
-        return ("pending", _truncate("no workflow runs yet — still inside the dispatch grace window"))
+        return (
+            "pending",
+            _truncate("no workflow runs yet — still inside the dispatch grace window"),
+        )
 
     return ("success", _truncate(f"{len(runs)} workflow run(s) dispatched for this commit"))
 
@@ -515,7 +604,9 @@ class GitHubApi:
         self.api_root = api_root.rstrip("/")
         self.timeout = timeout
 
-    def request(self, method: str, path: str, payload: Optional[Dict[str, Any]] = None) -> Tuple[int, Any]:
+    def request(
+        self, method: str, path: str, payload: Optional[Dict[str, Any]] = None
+    ) -> Tuple[int, Any]:
         """
         Issue a request and return ``(status_code, decoded_body)``.
 
@@ -534,7 +625,9 @@ class GitHubApi:
         if data is not None:
             request.add_header("Content-Type", "application/json")
         try:
-            with urllib.request.urlopen(request, timeout=self.timeout) as response:  # noqa: S310 - fixed api host
+            with urllib.request.urlopen(
+                request, timeout=self.timeout
+            ) as response:  # noqa: S310 - fixed api host
                 body = response.read().decode("utf-8")
                 return response.status, (json.loads(body) if body else None)
         except urllib.error.HTTPError as exc:
@@ -580,19 +673,25 @@ class GitHubApi:
 
     def run_jobs(self, run_id: int) -> List[Dict[str, Any]]:
         query = urllib.parse.urlencode({"per_page": "100"})
-        status, body = self.request("GET", f"/repos/{self.repository}/actions/runs/{run_id}/jobs?{query}")
+        status, body = self.request(
+            "GET", f"/repos/{self.repository}/actions/runs/{run_id}/jobs?{query}"
+        )
         if status != 200 or not isinstance(body, dict):
             raise WatchdogApiError(f"cannot list jobs for run {run_id} (HTTP {status}): {body}")
         return list(body.get("jobs") or [])
 
     def approve_run(self, run_id: int) -> Tuple[int, str]:
-        status, body = self.request("POST", f"/repos/{self.repository}/actions/runs/{run_id}/approve")
+        status, body = self.request(
+            "POST", f"/repos/{self.repository}/actions/runs/{run_id}/approve"
+        )
         message = ""
         if isinstance(body, dict):
             message = str(body.get("message", ""))
         return status, message
 
-    def set_status(self, sha: str, state: str, context: str, description: str, target_url: str) -> int:
+    def set_status(
+        self, sha: str, state: str, context: str, description: str, target_url: str
+    ) -> int:
         payload: Dict[str, Any] = {
             "state": state,
             "context": context,
@@ -716,7 +815,10 @@ def interpret_probe(status: int, message: str) -> Tuple[Optional[bool], str]:
     if status == 401:
         return None, "unresolved — the credential was rejected (401 Bad credentials)"
     if status == 404:
-        return None, "unresolved — the probe run was not found (404); the token may lack read access"
+        return (
+            None,
+            "unresolved — the probe run was not found (404); the token may lack read access",
+        )
     if status == 429:
         return None, "unresolved — rate limited (429); retry on the next sweep"
     return None, f"unresolved — unrecognised response (HTTP {status}: {message or 'no message'})"
@@ -830,14 +932,20 @@ def _approve_head(
             # the outcome this tool wanted — not a failure, and emphatically not
             # evidence that the credential is inadequate.
             raced += 1
-            print(f"  PR #{number}: '{run.get('name')}' already released by a concurrent sweep — no action needed")
+            print(
+                f"  PR #{number}: '{run.get('name')}' already released by a concurrent sweep — no action needed"
+            )
         else:
             refused += 1
-            print(f"  PR #{number}: could NOT approve '{run.get('name')}' — HTTP {status}: {message}")
+            print(
+                f"  PR #{number}: could NOT approve '{run.get('name')}' — HTTP {status}: {message}"
+            )
     return ApprovalOutcome(approved, refused, raced, budget, exhausted)
 
 
-def _sweep_once(api: GitHubApi, heads: Sequence[PullHead], budget: int, dry_run: bool) -> SweepOutcome:
+def _sweep_once(
+    api: GitHubApi, heads: Sequence[PullHead], budget: int, dry_run: bool
+) -> SweepOutcome:
     """One pass over every head."""
     approved = 0
     refused = 0
@@ -856,7 +964,9 @@ def _sweep_once(api: GitHubApi, heads: Sequence[PullHead], budget: int, dry_run:
             unsettled = True
         if not head.same_repo:
             if any(is_parked(run) for run in runs):
-                print(f"  PR #{head.number}: fork pull request — parked runs left for a human to approve")
+                print(
+                    f"  PR #{head.number}: fork pull request — parked runs left for a human to approve"
+                )
             continue
         outcome = _approve_head(api, head.number, runs, budget, dry_run)
         budget = outcome.budget
@@ -1017,14 +1127,18 @@ def check_dispatch(api: GitHubApi, config: Dict[str, Any], dry_run: bool = False
     pulls = api.open_pull_requests(config["base_branch"])
     heads = collect_heads(pulls, api.repository)
     forks = sum(1 for head in heads if not head.same_repo)
-    print(f"Open PRs targeting {config['base_branch']}: {len(pulls)} ({forks} from forks, never auto-approved)")
+    print(
+        f"Open PRs targeting {config['base_branch']}: {len(pulls)} ({forks} from forks, never auto-approved)"
+    )
 
     only_pr = config.get("only_pr", 0)
     if only_pr:
         heads = select_heads(heads, only_pr)
         print(f"Scoped to PR #{only_pr}: {len(heads)} head(s) selected")
         if not heads:
-            print(f"PR #{only_pr} is not an open PR targeting {config['base_branch']} — nothing to sweep.")
+            print(
+                f"PR #{only_pr} is not an open PR targeting {config['base_branch']} — nothing to sweep."
+            )
             return 0
 
     permitted, explanation = probe_approval_capability(api, dry_run)
@@ -1040,7 +1154,9 @@ def check_dispatch(api: GitHubApi, config: Dict[str, Any], dry_run: bool = False
         f"{refused} refused, {blocked} PR(s) not dispatched."
     )
     if raced:
-        print(f"{raced} run(s) had already been released by a concurrent sweep — routine, not a failure.")
+        print(
+            f"{raced} run(s) had already been released by a concurrent sweep — routine, not a failure."
+        )
 
     failed = False
     if deferred and not dry_run:
@@ -1048,7 +1164,10 @@ def check_dispatch(api: GitHubApi, config: Dict[str, Any], dry_run: bool = False
         # "next sweep" is not enough when the schedule that would provide one
         # has never fired, so the run goes red and names what was left.
         left = ", ".join(f"#{number}" for number in sorted(deferred))
-        print("::error::" + budget_exhausted_message(deferred, config["max_approvals"]).replace("\n", "%0A"))
+        print(
+            "::error::"
+            + budget_exhausted_message(deferred, config["max_approvals"]).replace("\n", "%0A")
+        )
         print(budget_exhausted_message(deferred, config["max_approvals"]))
         print(f"PR(s) left with parked runs: {left}")
         failed = True
@@ -1066,7 +1185,9 @@ def check_dispatch(api: GitHubApi, config: Dict[str, Any], dry_run: bool = False
         # it skips the probe deliberately, and `--check probe` answers the
         # question on its own, so warning here would be noise that trains
         # readers to ignore the warning that matters.
-        print(f"::warning::Approval capability is UNRESOLVED — {explanation}. Do not treat #12823 as proven fixed.")
+        print(
+            f"::warning::Approval capability is UNRESOLVED — {explanation}. Do not treat #12823 as proven fixed."
+        )
     return 0
 
 
@@ -1125,17 +1246,23 @@ def check_runner_starvation(api: GitHubApi, config: Dict[str, Any]) -> int:
     # remains open.
     queued = api.recent_runs(run_status="queued")
     starved = starved_runs(queued, now, config["stall_minutes"])
-    pool = inspect_self_hosted_pool(api, config["max_job_lookups"], config["job_overdue_minutes"], now)
+    pool = inspect_self_hosted_pool(
+        api, config["max_job_lookups"], config["job_overdue_minutes"], now
+    )
     report_overdue_jobs(pool.overdue, config["job_overdue_minutes"])
 
     if not starved:
         if pool.overdue:
             return 1
-        print(f"No run has been queued longer than {config['stall_minutes']}m — runner pool is keeping up.")
+        print(
+            f"No run has been queued longer than {config['stall_minutes']}m — runner pool is keeping up."
+        )
         return 0
 
     if pool.serving is None:
-        print(f"::warning::{len(starved)} run(s) queued over {config['stall_minutes']}m; runner liveness UNKNOWN")
+        print(
+            f"::warning::{len(starved)} run(s) queued over {config['stall_minutes']}m; runner liveness UNKNOWN"
+        )
         return 1 if pool.overdue else 0
     if pool.serving:
         # `pool.serving` excludes wedged jobs, so this really is healthy work in
@@ -1146,8 +1273,14 @@ def check_runner_starvation(api: GitHubApi, config: Dict[str, Any]) -> int:
         )
         return 1 if pool.overdue else 0
 
-    reason = "while a self-hosted job is wedged" if pool.overdue else "while no self-hosted job is executing"
-    print(f"::error::{len(starved)} workflow run(s) queued over {config['stall_minutes']}m {reason}")
+    reason = (
+        "while a self-hosted job is wedged"
+        if pool.overdue
+        else "while no self-hosted job is executing"
+    )
+    print(
+        f"::error::{len(starved)} workflow run(s) queued over {config['stall_minutes']}m {reason}"
+    )
     for run in starved:
         waited = age_minutes(run.get("created_at"), now)
         waited_text = f"{waited:.0f}m" if waited is not None else "unknown"
@@ -1173,16 +1306,22 @@ def load_config() -> Dict[str, Any]:
         "stall_minutes": _env_int("WATCHDOG_STALL_MINUTES", DEFAULT_STALL_MINUTES),
         "max_approvals": _env_int("WATCHDOG_MAX_APPROVALS", DEFAULT_MAX_APPROVALS),
         "poll_attempts": _env_int("WATCHDOG_POLL_ATTEMPTS", DEFAULT_POLL_ATTEMPTS),
-        "poll_interval_seconds": _env_int("WATCHDOG_POLL_INTERVAL_SECONDS", DEFAULT_POLL_INTERVAL_SECONDS),
+        "poll_interval_seconds": _env_int(
+            "WATCHDOG_POLL_INTERVAL_SECONDS", DEFAULT_POLL_INTERVAL_SECONDS
+        ),
         "status_context": os.environ.get("WATCHDOG_STATUS_CONTEXT", DEFAULT_STATUS_CONTEXT),
         "max_job_lookups": _env_int("WATCHDOG_MAX_JOB_LOOKUPS", DEFAULT_MAX_JOB_LOOKUPS),
-        "job_overdue_minutes": _env_int("WATCHDOG_JOB_OVERDUE_MINUTES", DEFAULT_JOB_OVERDUE_MINUTES),
+        "job_overdue_minutes": _env_int(
+            "WATCHDOG_JOB_OVERDUE_MINUTES", DEFAULT_JOB_OVERDUE_MINUTES
+        ),
         "only_pr": _env_non_negative_int("WATCHDOG_ONLY_PR", DEFAULT_ONLY_PR),
     }
 
 
 def main(argv: Optional[Sequence[str]] = None) -> int:
-    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     parser.add_argument(
         "--check",
         choices=("dispatch", "probe", "runner-starvation"),

--- a/repo_tests/ci_dispatch_watchdog_test.py
+++ b/repo_tests/ci_dispatch_watchdog_test.py
@@ -138,14 +138,16 @@ def test_sweep_never_approves_a_fork_origin_parked_run(watchdog):
 
 def test_a_fork_head_is_flagged_by_collect_heads(watchdog):
     heads = watchdog.collect_heads(
-        [{"number": 1, "head": {"sha": "a" * 40, "repo": {"full_name": FORK}}, "html_url": "u"}], REPO
+        [{"number": 1, "head": {"sha": "a" * 40, "repo": {"full_name": FORK}}, "html_url": "u"}],
+        REPO,
     )
     assert heads[0].same_repo is False
 
 
 def test_same_repo_head_is_recognised(watchdog):
     heads = watchdog.collect_heads(
-        [{"number": 1, "head": {"sha": "b" * 40, "repo": {"full_name": REPO}}, "html_url": "u"}], REPO
+        [{"number": 1, "head": {"sha": "b" * 40, "repo": {"full_name": REPO}}, "html_url": "u"}],
+        REPO,
     )
     assert heads[0].same_repo is True
 
@@ -204,7 +206,9 @@ def test_parked_run_outranks_otherwise_green_runs(watchdog):
 
 
 def test_queued_run_past_the_stall_threshold_with_an_empty_pool_is_failure(watchdog):
-    runs = [_run(status="queued", conclusion=None, created_at=_ts(45), name="Unit & Integration Tests")]
+    runs = [
+        _run(status="queued", conclusion=None, created_at=_ts(45), name="Unit & Integration Tests")
+    ]
     state, description = watchdog.classify_dispatch(runs, _ts(45), NOW, 10, 30, False)
     assert state == "failure"
     assert "no runner available" in description
@@ -212,7 +216,9 @@ def test_queued_run_past_the_stall_threshold_with_an_empty_pool_is_failure(watch
 
 def test_queued_run_behind_a_busy_pool_is_pending_not_failure(watchdog):
     """Normal contention on the singleton runner must not raise a false outage."""
-    runs = [_run(status="queued", conclusion=None, created_at=_ts(45), name="Unit & Integration Tests")]
+    runs = [
+        _run(status="queued", conclusion=None, created_at=_ts(45), name="Unit & Integration Tests")
+    ]
     state, description = watchdog.classify_dispatch(runs, _ts(45), NOW, 10, 30, True)
     assert state == "pending"
     assert "busy runner pool" in description
@@ -268,7 +274,9 @@ def test_an_api_error_publishes_unknown_not_never_dispatched(watchdog):
     api = _FakeApi({sha: watchdog.WatchdogApiError("HTTP 429: rate limited")})
     head = watchdog.PullHead(number=5, sha=sha, updated_at=_ts(60), url="u", same_repo=True)
     config = {"grace_minutes": 10, "stall_minutes": 30, "status_context": "ctx"}
-    blocked = watchdog.publish_dispatch_states(api, [head], config, dry_run=False, pool_serving=True)
+    blocked = watchdog.publish_dispatch_states(
+        api, [head], config, dry_run=False, pool_serving=True
+    )
     assert blocked == 1
     _, state, description = api.statuses[0]
     assert state == "pending"
@@ -412,12 +420,17 @@ def test_a_self_hosted_job_inside_the_ceiling_is_healthy_not_wedged(watchdog):
 
 def test_a_long_running_github_hosted_job_is_not_wedged(watchdog):
     """marker-tests declares 180m on ubuntu-latest and holds no singleton."""
-    state = watchdog.inspect_self_hosted_pool(_pool_api([_job(120, labels=("ubuntu-latest",))]), 10, 45, NOW)
+    state = watchdog.inspect_self_hosted_pool(
+        _pool_api([_job(120, labels=("ubuntu-latest",))]), 10, 45, NOW
+    )
     assert state.overdue == []
 
 
 def test_a_job_that_has_not_started_is_never_wedged(watchdog):
-    assert watchdog.job_is_overdue({"status": "in_progress", "labels": ["self-hosted"]}, NOW, 45) is False
+    assert (
+        watchdog.job_is_overdue({"status": "in_progress", "labels": ["self-hosted"]}, NOW, 45)
+        is False
+    )
 
 
 def test_a_completed_job_is_never_wedged(watchdog):
@@ -435,8 +448,16 @@ def test_the_wedged_run_is_found_even_when_it_is_the_oldest_of_many(watchdog):
     therefore drops exactly the run being looked for. Measured live: 12 runs in
     progress, the wedging one the oldest of the 12, a budget of 10 — missed.
     """
-    healthy = [{"id": i, "name": "CI", "head_sha": f"sha{i}", "run_started_at": _ts(i)} for i in range(1, 12)]
-    wedged = {"id": 99, "name": "Frontend Testing Suite", "head_sha": "wedged", "run_started_at": _ts(185)}
+    healthy = [
+        {"id": i, "name": "CI", "head_sha": f"sha{i}", "run_started_at": _ts(i)}
+        for i in range(1, 12)
+    ]
+    wedged = {
+        "id": 99,
+        "name": "Frontend Testing Suite",
+        "head_sha": "wedged",
+        "run_started_at": _ts(185),
+    }
 
     class _Api:
         repository = REPO
@@ -455,7 +476,9 @@ def test_the_wedged_run_is_found_even_when_it_is_the_oldest_of_many(watchdog):
 
 
 def test_a_healthy_job_alongside_a_wedged_one_still_proves_liveness(watchdog):
-    state = watchdog.inspect_self_hosted_pool(_pool_api([_job(185), _job(3, name="Build Test")]), 10, 45, NOW)
+    state = watchdog.inspect_self_hosted_pool(
+        _pool_api([_job(185), _job(3, name="Build Test")]), 10, 45, NOW
+    )
     assert state.serving is True
     assert [entry.job for entry in state.overdue] == ["Unit & Integration Tests"]
 
@@ -470,7 +493,9 @@ def test_overdue_jobs_are_grouped_by_head(watchdog):
 
 
 def test_a_wedged_head_is_published_as_a_failure_not_a_healthy_in_progress(watchdog):
-    overdue = [watchdog.OverdueJob("sha", "Frontend Testing Suite", "Unit & Integration Tests", 185.0, "u")]
+    overdue = [
+        watchdog.OverdueJob("sha", "Frontend Testing Suite", "Unit & Integration Tests", 185.0, "u")
+    ]
     state, description = watchdog.classify_dispatch([_run()], _ts(5), NOW, 10, 30, True, overdue)
     assert state == "failure"
     assert "wedged" in description
@@ -511,7 +536,9 @@ _STARVATION_CONFIG = {"stall_minutes": 45, "max_job_lookups": 5, "job_overdue_mi
 
 def _live_ts(minutes_ago):
     """Relative to the real clock — check_runner_starvation reads it itself."""
-    return (datetime.now(timezone.utc) - timedelta(minutes=minutes_ago)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return (datetime.now(timezone.utc) - timedelta(minutes=minutes_ago)).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
 
 
 def _live_job(minutes_running, name="Unit & Integration Tests"):
@@ -524,7 +551,9 @@ def _live_job(minutes_running, name="Unit & Integration Tests"):
 
 
 def _live_queue():
-    return [{"id": 9, "name": "CI", "status": "queued", "created_at": _live_ts(60), "head_branch": "b"}]
+    return [
+        {"id": 9, "name": "CI", "status": "queued", "created_at": _live_ts(60), "head_branch": "b"}
+    ]
 
 
 def test_a_wedged_job_fails_the_probe_even_with_an_empty_queue(watchdog):
@@ -671,7 +700,10 @@ def test_scoping_selects_only_the_firing_pull_request(watchdog):
 
 
 def test_scoping_off_returns_every_head(watchdog):
-    heads = [watchdog.PullHead(1, "a" * 40, _ts(5), "u", True), watchdog.PullHead(2, "b" * 40, _ts(5), "u", True)]
+    heads = [
+        watchdog.PullHead(1, "a" * 40, _ts(5), "u", True),
+        watchdog.PullHead(2, "b" * 40, _ts(5), "u", True),
+    ]
     assert watchdog.select_heads(heads, 0) == heads
 
 
@@ -686,8 +718,18 @@ def test_scoping_to_a_fork_pr_still_never_approves_it(watchdog):
     sha = "9" * 40
     api = _FakeApi({sha: [_parked(id=77, head_repository={"full_name": FORK})]})
     api.open_pull_requests = lambda base: [
-        {"number": 12, "head": {"sha": sha, "repo": {"full_name": FORK}}, "html_url": "u", "updated_at": _ts(5)},
-        {"number": 13, "head": {"sha": "8" * 40, "repo": {"full_name": REPO}}, "html_url": "u", "updated_at": _ts(5)},
+        {
+            "number": 12,
+            "head": {"sha": sha, "repo": {"full_name": FORK}},
+            "html_url": "u",
+            "updated_at": _ts(5),
+        },
+        {
+            "number": 13,
+            "head": {"sha": "8" * 40, "repo": {"full_name": REPO}},
+            "html_url": "u",
+            "updated_at": _ts(5),
+        },
     ]
     api.recent_runs = lambda per_page=100, run_status="": []
     api.run_jobs = lambda run_id: []
@@ -713,7 +755,12 @@ def test_scoping_to_a_same_repo_pr_still_approves_its_parked_bot_runs(watchdog):
     sha = "7" * 40
     api = _FakeApi({sha: [_parked(id=55)]})
     api.open_pull_requests = lambda base: [
-        {"number": 21, "head": {"sha": sha, "repo": {"full_name": REPO}}, "html_url": "u", "updated_at": _ts(5)}
+        {
+            "number": 21,
+            "head": {"sha": sha, "repo": {"full_name": REPO}},
+            "html_url": "u",
+            "updated_at": _ts(5),
+        }
     ]
     api.recent_runs = lambda per_page=100, run_status="": []
     api.run_jobs = lambda run_id: []
@@ -736,7 +783,12 @@ def test_scoping_to_a_same_repo_pr_still_approves_its_parked_bot_runs(watchdog):
 def test_a_closed_or_renumbered_scope_target_sweeps_nothing(watchdog, capsys):
     api = _FakeApi()
     api.open_pull_requests = lambda base: [
-        {"number": 1, "head": {"sha": "6" * 40, "repo": {"full_name": REPO}}, "html_url": "u", "updated_at": _ts(5)}
+        {
+            "number": 1,
+            "head": {"sha": "6" * 40, "repo": {"full_name": REPO}},
+            "html_url": "u",
+            "updated_at": _ts(5),
+        }
     ]
     config = {"base_branch": "Dev_new_gui", "only_pr": 4242}
     assert watchdog.check_dispatch(api, config, dry_run=False) == 0
@@ -798,7 +850,12 @@ def test_a_raced_sweep_exits_zero_and_never_prints_the_credential_remediation(wa
     sha = "a" * 40
     api = _FakeApi({sha: [_parked(id=3)]}, approve_response=RACE_403)
     api.open_pull_requests = lambda base: [
-        {"number": 31, "head": {"sha": sha, "repo": {"full_name": REPO}}, "html_url": "u", "updated_at": _ts(5)}
+        {
+            "number": 31,
+            "head": {"sha": sha, "repo": {"full_name": REPO}},
+            "html_url": "u",
+            "updated_at": _ts(5),
+        }
     ]
     api.recent_runs = lambda per_page=100, run_status="": [{"id": 1, "conclusion": "success"}]
     api.run_jobs = lambda run_id: []
@@ -830,7 +887,9 @@ def _sweep_config(**overrides):
 
 def test_exhausting_the_budget_marks_the_head_deferred(watchdog):
     api = _FakeApi()
-    outcome = watchdog._approve_head(api, 9, [_parked(id=i) for i in range(4)], budget=2, dry_run=False)
+    outcome = watchdog._approve_head(
+        api, 9, [_parked(id=i) for i in range(4)], budget=2, dry_run=False
+    )
     assert outcome.approved == 2
     assert outcome.exhausted is True
 
@@ -838,7 +897,10 @@ def test_exhausting_the_budget_marks_the_head_deferred(watchdog):
 def test_a_sweep_reports_which_prs_the_budget_could_not_reach(watchdog):
     a, b = "1" * 40, "2" * 40
     api = _FakeApi({a: [_parked(id=1), _parked(id=2)], b: [_parked(id=3), _parked(id=4)]})
-    heads = [watchdog.PullHead(101, a, _ts(5), "u", True), watchdog.PullHead(102, b, _ts(5), "u", True)]
+    heads = [
+        watchdog.PullHead(101, a, _ts(5), "u", True),
+        watchdog.PullHead(102, b, _ts(5), "u", True),
+    ]
     outcome = watchdog._sweep_once(api, heads, budget=3, dry_run=False)
     assert outcome.approved == 3
     assert outcome.deferred == {102}
@@ -849,7 +911,12 @@ def test_a_budget_exhausted_sweep_exits_non_zero(watchdog, capsys):
     sha = "3" * 40
     api = _FakeApi({sha: [_parked(id=i) for i in range(5)]})
     api.open_pull_requests = lambda base: [
-        {"number": 55, "head": {"sha": sha, "repo": {"full_name": REPO}}, "html_url": "u", "updated_at": _ts(5)}
+        {
+            "number": 55,
+            "head": {"sha": sha, "repo": {"full_name": REPO}},
+            "html_url": "u",
+            "updated_at": _ts(5),
+        }
     ]
     api.recent_runs = lambda per_page=100, run_status="": [{"id": 1, "conclusion": "success"}]
     api.run_jobs = lambda run_id: []
@@ -871,7 +938,12 @@ def test_a_dry_run_previews_exhaustion_without_failing(watchdog):
     sha = "4" * 40
     api = _FakeApi({sha: [_parked(id=i) for i in range(5)]})
     api.open_pull_requests = lambda base: [
-        {"number": 56, "head": {"sha": sha, "repo": {"full_name": REPO}}, "html_url": "u", "updated_at": _ts(5)}
+        {
+            "number": 56,
+            "head": {"sha": sha, "repo": {"full_name": REPO}},
+            "html_url": "u",
+            "updated_at": _ts(5),
+        }
     ]
     api.recent_runs = lambda per_page=100, run_status="": []
     api.run_jobs = lambda run_id: []
@@ -888,7 +960,9 @@ def test_a_bigger_budget_does_not_widen_what_is_approvable(watchdog):
     """SECURITY: the cap bounds HOW MANY, never WHAT. Fork runs stay excluded."""
     api = _FakeApi()
     fork_runs = [_parked(id=i, head_repository={"full_name": FORK}) for i in range(50)]
-    outcome = watchdog._approve_head(api, 1, fork_runs, budget=watchdog.DEFAULT_MAX_APPROVALS, dry_run=False)
+    outcome = watchdog._approve_head(
+        api, 1, fork_runs, budget=watchdog.DEFAULT_MAX_APPROVALS, dry_run=False
+    )
     assert api.approved == []
     assert outcome.budget == watchdog.DEFAULT_MAX_APPROVALS
     assert outcome.exhausted is False
@@ -936,7 +1010,12 @@ def test_a_dry_run_does_not_warn_about_the_probe_it_skipped_on_purpose(watchdog,
     sha = "1" * 40
     api = _FakeApi({sha: [_run()]})
     api.open_pull_requests = lambda base: [
-        {"number": 3, "head": {"sha": sha, "repo": {"full_name": REPO}}, "html_url": "u", "updated_at": _ts(5)}
+        {
+            "number": 3,
+            "head": {"sha": sha, "repo": {"full_name": REPO}},
+            "html_url": "u",
+            "updated_at": _ts(5),
+        }
     ]
     api.recent_runs = lambda per_page=100, run_status="": []
     api.run_jobs = lambda run_id: []
@@ -959,7 +1038,12 @@ def test_a_real_sweep_does_warn_when_the_probe_is_unresolved(watchdog, capsys):
     sha = "2" * 40
     api = _FakeApi({sha: [_run()]})
     api.open_pull_requests = lambda base: [
-        {"number": 4, "head": {"sha": sha, "repo": {"full_name": REPO}}, "html_url": "u", "updated_at": _ts(5)}
+        {
+            "number": 4,
+            "head": {"sha": sha, "repo": {"full_name": REPO}},
+            "html_url": "u",
+            "updated_at": _ts(5),
+        }
     ]
     api.recent_runs = lambda per_page=100, run_status="": []
     api.run_jobs = lambda run_id: []
@@ -976,3 +1060,92 @@ def test_a_real_sweep_does_warn_when_the_probe_is_unresolved(watchdog, capsys):
     }
     assert watchdog.check_dispatch(api, config, dry_run=False) == 0
     assert "UNRESOLVED" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# superseded_stuck_runs — force-cancel selection (#13439)
+# ---------------------------------------------------------------------------
+
+
+def _member(run_number: int, minutes_ago: float, **overrides):
+    """A queued run in the default concurrency group."""
+    base = {
+        "id": 1000 + run_number,
+        "run_number": run_number,
+        "workflow_id": 77,
+        "head_branch": "Dev_new_gui",
+        "event": "push",
+        "status": "queued",
+        "conclusion": None,
+        "created_at": _ts(minutes_ago),
+    }
+    base.update(overrides)
+    return _run(**base)
+
+
+def _select(watchdog, runs, grace=5, budget=10):
+    return watchdog.superseded_stuck_runs(runs, NOW, REPO, grace, budget)
+
+
+def test_the_newest_run_in_a_group_is_never_cancelled(watchdog):
+    """The newest run is what everything else is waiting for."""
+    older, newest = _member(1, 60), _member(2, 30)
+
+    picked = _select(watchdog, [older, newest])
+
+    assert [r["run_number"] for r in picked] == [1]
+
+
+def test_an_in_progress_run_is_never_cancelled(watchdog):
+    """in_progress means real work is happening — cancelling it destroys it."""
+    working, newest = _member(1, 60, status="in_progress"), _member(2, 30)
+
+    assert _select(watchdog, [working, newest]) == []
+
+
+def test_approval_gated_statuses_are_never_cancelled(watchdog):
+    """`waiting`/`requested` are approval gates, not a stuck queue."""
+    for status in ("waiting", "requested"):
+        gated, newest = _member(1, 60, status=status), _member(2, 30)
+        assert _select(watchdog, [gated, newest]) == [], status
+
+
+def test_runs_for_different_events_are_not_the_same_group(watchdog):
+    """push and pull_request produce different github.ref, so different groups.
+
+    Grouping them together would treat a PR run as superseding a push run on the
+    same branch and cancel work that is not superseded at all.
+    """
+    push_run = _member(1, 60, event="push")
+    pr_run = _member(2, 30, event="pull_request")
+
+    assert _select(watchdog, [push_run, pr_run]) == []
+
+
+def test_a_run_inside_the_grace_window_is_left_alone(watchdog):
+    """A legitimate brief queue must not be mistaken for a stuck one."""
+    recent, newest = _member(1, 2), _member(2, 1)
+
+    assert _select(watchdog, [recent, newest], grace=5) == []
+
+
+def test_selection_is_capped_by_the_budget_oldest_first(watchdog):
+    """One sweep cannot cancel the world if the grouping is ever wrong."""
+    runs = [_member(n, 100 - n) for n in range(1, 6)]  # 1 oldest ... 5 newest
+
+    picked = _select(watchdog, runs, budget=2)
+
+    assert [r["run_number"] for r in picked] == [1, 2]
+
+
+def test_fork_runs_are_never_cancelled(watchdog):
+    """Same restriction as the approval sweep, for the same reason."""
+    fork = _member(1, 60, head_repository={"full_name": "someone/fork"})
+    newest = _member(2, 30, head_repository={"full_name": "someone/fork"})
+
+    assert _select(watchdog, [fork, newest]) == []
+
+
+def test_a_lone_run_is_never_cancelled(watchdog):
+    """With nothing newer, nothing supersedes it."""
+    assert _select(watchdog, [_member(1, 60)]) == []


### PR DESCRIPTION
## Thinking Path

`concurrency.cancel-in-progress: true` reaps an *in-progress* predecessor and never a *queued* one. While the singleton self-hosted runner is offline a predecessor never reaches in-progress, so it keeps holding its concurrency group and successors sit `pending` with an empty `jobs` array until a human runs `force-cancel`.

This lands the **selection logic** — the part where every safety condition lives, and the part worth getting right before anything issues a cancel.

## What Changed

`superseded_stuck_runs()` returns only runs where cancelling is provably safe. A run qualifies when **all** hold:

- **not the newest in its group** — the newest is never touched under any condition; it is what everything else is waiting for
- **status in `STUCK_QUEUE_STATUSES`** — a new constant, deliberately narrower than the existing `UNSTARTED_RUN_STATUSES`. That set also contains `waiting` and `requested`, which are *approval gates*: force-cancelling those destroys work nobody has decided about rather than clearing a stuck queue. The issue specified `{queued, pending}` and that is what this uses.
- **older than the grace window** — a legitimate brief queue is not a stuck one
- **head repository is this repository** — the same fork restriction the approval sweep applies, for the same reason

Grouping is by `(workflow_id, head_branch, event)`, not workflow and branch alone: the group expression is `${{ github.workflow }}-${{ github.ref }}`, and `github.ref` differs between a `push` run (`refs/heads/…`) and a `pull_request` run (`refs/pull/N/merge`) on the same branch. Grouping across that boundary would cancel a run that is not superseded.

Results are truncated to the budget oldest-first, so one sweep cannot cancel the world if the grouping is ever wrong.

## Verification

```
100 passed   # repo_tests/ci_dispatch_watchdog_test.py (92 existing + 8 new)
```

Every safety condition was **mutation-tested** — the guard removed, the suite re-run, the guard restored:

| mutation | result |
|---|---|
| drop `event` from the group key | 1 failed |
| cancel the newest too (`ordered[:-1]` → `ordered[:]`) | 3 failed |
| ignore the grace window | 1 failed |
| ignore the budget cap | 1 failed |

So each criterion has a test that genuinely catches its removal rather than passing alongside it.

## Scope — deliberately not the whole issue

This is the selector only. **No `force-cancel` call is wired up yet**, so nothing in this PR can cancel anything. The remaining checklist items — the `--check` entry point issuing `POST /actions/runs/{id}/force-cancel`, `--dry-run` behaviour, and the workflow's self-modifying-PR guard — follow once the selection is reviewed. Landing the destructive half in the same change as untried selection logic is the wrong order for something that cancels CI runs.

Refs #13439

## Model Used

Claude Opus 5
