### PR TITLE
test(mcp): give the LDAP injection test the tmp_root fixture too (#13598)

### DIFF
--- a/autobot-backend/mcp/mcp_security_test.py
+++ b/autobot-backend/mcp/mcp_security_test.py
@@ -92,11 +92,7 @@ def tmp_root_exists():
             shutil.rmtree(root, ignore_errors=True)
             return
         for entry in set(root.iterdir()) - preexisting:
-            (
-                shutil.rmtree(entry, ignore_errors=True)
-                if entry.is_dir()
-                else entry.unlink(missing_ok=True)
-            )
+            (shutil.rmtree(entry, ignore_errors=True) if entry.is_dir() else entry.unlink(missing_ok=True))
 
 
 @pytest.fixture
@@ -132,9 +128,7 @@ def admin_client(app):
 def temp_allowed_dir(tmp_path):
     """Create temporary directory within allowed paths for testing"""
     # Use /tmp/autobot/ which is in ALLOWED_DIRECTORIES
-    test_dir = Path(
-        "/tmp/autobot/test_security"
-    )  # nosec B108  # test/controlled code uses tmpdir intentionally
+    test_dir = Path("/tmp/autobot/test_security")  # nosec B108  # test/controlled code uses tmpdir intentionally
     test_dir.mkdir(parents=True, exist_ok=True)
     yield test_dir
     # Cleanup
@@ -254,8 +248,7 @@ class TestFilesystemMCPPathTraversal:
             response = client.post("/api/filesystem/mcp/read_text_file", json=payload)
             # Should either return 400 (validation error) or 403 (forbidden)
             assert response.status_code in [400, 403, 422], (
-                f"API did not block path traversal: {payload['path']}, "
-                f"status: {response.status_code}"
+                f"API did not block path traversal: {payload['path']}, " f"status: {response.status_code}"
             )
 
 
@@ -648,9 +641,7 @@ class TestMCPSizeLimiting:
         # Try to read 1000 files at once
         file_paths = [f"{TMP_ROOT}/file{i}.txt" for i in range(1000)]
 
-        response = client.post(
-            "/api/filesystem/mcp/read_multiple_files", json={"paths": file_paths}
-        )
+        response = client.post("/api/filesystem/mcp/read_multiple_files", json={"paths": file_paths})
 
         # Should have limits on batch operations
         assert response.status_code in [200, 400, 422]
@@ -797,9 +788,7 @@ class TestSecurityCoverage:
         }
 
         missing = tested_bridges - registered_bridges
-        assert (
-            not missing
-        ), f"Security tests target bridges that are not registered: {sorted(missing)}"
+        assert not missing, f"Security tests target bridges that are not registered: {sorted(missing)}"
 
     def test_critical_attack_vectors_covered(self):
         """Verify all critical attack vectors are tested"""

--- a/autobot-backend/mcp/mcp_security_test.py
+++ b/autobot-backend/mcp/mcp_security_test.py
@@ -92,7 +92,11 @@ def tmp_root_exists():
             shutil.rmtree(root, ignore_errors=True)
             return
         for entry in set(root.iterdir()) - preexisting:
-            (shutil.rmtree(entry, ignore_errors=True) if entry.is_dir() else entry.unlink(missing_ok=True))
+            (
+                shutil.rmtree(entry, ignore_errors=True)
+                if entry.is_dir()
+                else entry.unlink(missing_ok=True)
+            )
 
 
 @pytest.fixture
@@ -128,7 +132,9 @@ def admin_client(app):
 def temp_allowed_dir(tmp_path):
     """Create temporary directory within allowed paths for testing"""
     # Use /tmp/autobot/ which is in ALLOWED_DIRECTORIES
-    test_dir = Path("/tmp/autobot/test_security")  # nosec B108  # test/controlled code uses tmpdir intentionally
+    test_dir = Path(
+        "/tmp/autobot/test_security"
+    )  # nosec B108  # test/controlled code uses tmpdir intentionally
     test_dir.mkdir(parents=True, exist_ok=True)
     yield test_dir
     # Cleanup
@@ -248,7 +254,8 @@ class TestFilesystemMCPPathTraversal:
             response = client.post("/api/filesystem/mcp/read_text_file", json=payload)
             # Should either return 400 (validation error) or 403 (forbidden)
             assert response.status_code in [400, 403, 422], (
-                f"API did not block path traversal: {payload['path']}, " f"status: {response.status_code}"
+                f"API did not block path traversal: {payload['path']}, "
+                f"status: {response.status_code}"
             )
 
 
@@ -566,8 +573,20 @@ class TestMCPInputValidation:
                 # read outside the whitelist; /etc/passwd is the payload's target.
                 assert "root:" not in response.text, f"Traversal succeeded for payload: {payload!r}"
 
-    def test_ldap_injection_attempts(self, client):
-        """Test LDAP injection protection (if applicable)"""
+    def test_ldap_injection_attempts(self, client, tmp_root_exists):
+        """Test LDAP injection protection (if applicable).
+
+        Takes ``tmp_root_exists`` for the same reason
+        ``test_sql_injection_attempts`` does (#13598): this posts
+        ``{"path": TMP_ROOT}`` to ``search_files``, which pre-checks
+        ``os.path.exists`` and answers 404 before the pattern is used. On a
+        runner without that directory the endpoint returned a correct 404 and
+        the assertion below — which deliberately excludes 404 — failed.
+
+        Missed when #13598 was fixed: that issue named the SQL and Unicode
+        tests, and this third instance was found only when the base branch went
+        red on it.
+        """
         ldap_payloads = [
             "*)(uid=*))(|(uid=*",
             "admin)(&(password=*))",
@@ -580,7 +599,10 @@ class TestMCPInputValidation:
                 "/api/filesystem/mcp/search_files",
                 json={"path": TMP_ROOT, "pattern": payload},
             )
+            # 404 stays excluded: the directory exists, so a 404 would mean the
+            # pre-check fired anyway and no LDAP payload was ever exercised.
             assert response.status_code in [200, 400, 422]
+            assert response.status_code < 500, f"payload crashed the endpoint: {payload}"
 
 
 # ============================================================================
@@ -626,7 +648,9 @@ class TestMCPSizeLimiting:
         # Try to read 1000 files at once
         file_paths = [f"{TMP_ROOT}/file{i}.txt" for i in range(1000)]
 
-        response = client.post("/api/filesystem/mcp/read_multiple_files", json={"paths": file_paths})
+        response = client.post(
+            "/api/filesystem/mcp/read_multiple_files", json={"paths": file_paths}
+        )
 
         # Should have limits on batch operations
         assert response.status_code in [200, 400, 422]
@@ -773,7 +797,9 @@ class TestSecurityCoverage:
         }
 
         missing = tested_bridges - registered_bridges
-        assert not missing, f"Security tests target bridges that are not registered: {sorted(missing)}"
+        assert (
+            not missing
+        ), f"Security tests target bridges that are not registered: {sorted(missing)}"
 
     def test_critical_attack_vectors_covered(self):
         """Verify all critical attack vectors are tested"""


### PR DESCRIPTION
## Thinking Path

**This is a miss in my own fix.** PR #13612 (#13598) fixed `test_sql_injection_attempts` and `test_unicode_normalization_attacks` for the missing-`TMP_ROOT` 404, but left `test_ldap_injection_attempts` — which has the identical shape. It reddened the base branch on run `31014724462`:

```
FAILED autobot-backend/mcp/mcp_security_test.py::TestMCPInputValidation::test_ldap_injection_attempts
assert 404 in [200, 400, 422]
 +  where 404 = <Response [404 Not Found]>.status_code
```

Same endpoint, same `{"path": TMP_ROOT}`, same `os.path.exists` pre-check answering 404 before the payload is used, and the same assertion list that deliberately excludes 404.

The original issue named the SQL and Unicode tests, and I fixed exactly those instead of sweeping the file for the pattern. Fixing the instances an issue lists rather than the class it describes is what let this through.

## What Changed

`test_ldap_injection_attempts` now takes `tmp_root_exists`, matching its two siblings, plus a `< 500` assertion so a payload that crashes the endpoint is distinguishable from one that is rejected.

**I swept the rest of the file rather than fixing only the reported test.** Every other `TMP_ROOT` reference either targets a *file* path — where 404 is the correct answer for a missing file and the assertion lists include it — or is rejected at validation before any filesystem check. `test_null_byte_injection` is the clearest of those: it asserts `[400, 403, 422]` with no 404, and passes because null bytes never reach the existence probe. `test_ldap_injection_attempts` was the only remaining test posting `path: TMP_ROOT` to `search_files`.

## Verification

**Reproduced the CI failure locally** by moving `/tmp/autobot` aside, against the unmodified test:

```
FAILED ...::test_ldap_injection_attempts
1 failed
```

With the fix, under that same fresh-runner condition:

```
1 passed
```

And with the directory present, all three injection tests together:

```
4 passed
```

`/tmp/autobot` was restored to its original contents afterwards.

Refs #13598

## Model Used

Claude Opus 5
