### PR TITLE
test(connectors): migrate scheduler leader-election tests onto the extracted lease (#13162)

### DIFF
--- a/autobot-backend/knowledge/connectors/scheduler_test.py
+++ b/autobot-backend/knowledge/connectors/scheduler_test.py
@@ -175,8 +175,7 @@ class TestConnectorSchedulerRedis:
 
     async def test_stop_removes_redis_key(self):
         store = {
-            _SCHEDULE_PREFIX
-            + "c1": json.dumps({"connector_id": "c1", "schedule": "*/5", "interval_seconds": 300})
+            _SCHEDULE_PREFIX + "c1": json.dumps({"connector_id": "c1", "schedule": "*/5", "interval_seconds": 300})
         }
         mock_redis, store = _make_redis_mock(store)
 
@@ -226,8 +225,7 @@ class TestConnectorSchedulerRedis:
     async def test_stop_all_does_not_delete_redis_keys(self):
         """stop_all cancels local asyncio tasks but leaves Redis schedules intact."""
         store = {
-            _SCHEDULE_PREFIX
-            + "c1": json.dumps({"connector_id": "c1", "schedule": "*/5", "interval_seconds": 300})
+            _SCHEDULE_PREFIX + "c1": json.dumps({"connector_id": "c1", "schedule": "*/5", "interval_seconds": 300})
         }
         mock_redis, _ = _make_redis_mock(store)
 
@@ -254,12 +252,9 @@ class TestConnectorSchedulerRedis:
     async def test_restart_simulation_rehydrate(self):
         """Simulates worker restart: new scheduler leader picks up existing Redis schedules."""
         store = {
+            _SCHEDULE_PREFIX + "c1": json.dumps({"connector_id": "c1", "schedule": "*/5", "interval_seconds": 300}),
             _SCHEDULE_PREFIX
-            + "c1": json.dumps({"connector_id": "c1", "schedule": "*/5", "interval_seconds": 300}),
-            _SCHEDULE_PREFIX
-            + "c2": json.dumps(
-                {"connector_id": "c2", "schedule": "@hourly", "interval_seconds": 3600}
-            ),
+            + "c2": json.dumps({"connector_id": "c2", "schedule": "@hourly", "interval_seconds": 3600}),
         }
         mock_redis, _ = _make_redis_mock(store)
 

--- a/autobot-backend/knowledge/connectors/scheduler_test.py
+++ b/autobot-backend/knowledge/connectors/scheduler_test.py
@@ -175,7 +175,8 @@ class TestConnectorSchedulerRedis:
 
     async def test_stop_removes_redis_key(self):
         store = {
-            _SCHEDULE_PREFIX + "c1": json.dumps({"connector_id": "c1", "schedule": "*/5", "interval_seconds": 300})
+            _SCHEDULE_PREFIX
+            + "c1": json.dumps({"connector_id": "c1", "schedule": "*/5", "interval_seconds": 300})
         }
         mock_redis, store = _make_redis_mock(store)
 
@@ -225,7 +226,8 @@ class TestConnectorSchedulerRedis:
     async def test_stop_all_does_not_delete_redis_keys(self):
         """stop_all cancels local asyncio tasks but leaves Redis schedules intact."""
         store = {
-            _SCHEDULE_PREFIX + "c1": json.dumps({"connector_id": "c1", "schedule": "*/5", "interval_seconds": 300})
+            _SCHEDULE_PREFIX
+            + "c1": json.dumps({"connector_id": "c1", "schedule": "*/5", "interval_seconds": 300})
         }
         mock_redis, _ = _make_redis_mock(store)
 
@@ -234,7 +236,11 @@ class TestConnectorSchedulerRedis:
             return_value=mock_redis,
         ):
             scheduler = ConnectorScheduler()
-            scheduler._is_leader = True
+            # start() gates on self._lease.is_leader (scheduler.py:129) — the
+            # flag moved onto the lease with the election logic (#13162), so
+            # setting scheduler._is_leader left the gate closed and no local
+            # task was ever created.
+            scheduler._lease._is_leader = True
             await scheduler.start("c1", "*/5")
             assert "c1" in scheduler._tasks
 
@@ -248,9 +254,12 @@ class TestConnectorSchedulerRedis:
     async def test_restart_simulation_rehydrate(self):
         """Simulates worker restart: new scheduler leader picks up existing Redis schedules."""
         store = {
-            _SCHEDULE_PREFIX + "c1": json.dumps({"connector_id": "c1", "schedule": "*/5", "interval_seconds": 300}),
             _SCHEDULE_PREFIX
-            + "c2": json.dumps({"connector_id": "c2", "schedule": "@hourly", "interval_seconds": 3600}),
+            + "c1": json.dumps({"connector_id": "c1", "schedule": "*/5", "interval_seconds": 300}),
+            _SCHEDULE_PREFIX
+            + "c2": json.dumps(
+                {"connector_id": "c2", "schedule": "@hourly", "interval_seconds": 3600}
+            ),
         }
         mock_redis, _ = _make_redis_mock(store)
 
@@ -294,11 +303,11 @@ class TestConnectorSchedulerRedis:
         mock_redis, _ = _make_redis_mock(store)
 
         with patch(
-            "knowledge.connectors.scheduler.get_async_redis_client",
+            "autobot_shared.leader_lease.get_async_redis_client",
             return_value=mock_redis,
         ):
             scheduler = ConnectorScheduler()
-            won = await scheduler._try_acquire_or_refresh()
+            won = await scheduler._lease.try_acquire_or_refresh()
 
         assert won is True
         assert _LEADER_KEY in store
@@ -309,13 +318,13 @@ class TestConnectorSchedulerRedis:
         mock_redis, _ = _make_redis_mock(store)
 
         with patch(
-            "knowledge.connectors.scheduler.get_async_redis_client",
+            "autobot_shared.leader_lease.get_async_redis_client",
             return_value=mock_redis,
         ):
             a = ConnectorScheduler()
             b = ConnectorScheduler()
-            assert await a._try_acquire_or_refresh() is True
-            assert await b._try_acquire_or_refresh() is False
+            assert await a._lease.try_acquire_or_refresh() is True
+            assert await b._lease.try_acquire_or_refresh() is False
 
     async def test_leader_refresh_succeeds(self):
         """The current leader can refresh its own key."""
@@ -323,15 +332,15 @@ class TestConnectorSchedulerRedis:
         mock_redis, _ = _make_redis_mock(store)
 
         with patch(
-            "knowledge.connectors.scheduler.get_async_redis_client",
+            "autobot_shared.leader_lease.get_async_redis_client",
             return_value=mock_redis,
         ):
             scheduler = ConnectorScheduler()
             # Acquire
-            await scheduler._try_acquire_or_refresh()
-            scheduler._is_leader = True
+            await scheduler._lease.try_acquire_or_refresh()
+            scheduler._lease._is_leader = True
             # Refresh
-            refreshed = await scheduler._try_acquire_or_refresh()
+            refreshed = await scheduler._lease.try_acquire_or_refresh()
 
         assert refreshed is True
 
@@ -341,14 +350,14 @@ class TestConnectorSchedulerRedis:
         mock_redis, _ = _make_redis_mock(store)
 
         with patch(
-            "knowledge.connectors.scheduler.get_async_redis_client",
+            "autobot_shared.leader_lease.get_async_redis_client",
             return_value=mock_redis,
         ):
             scheduler = ConnectorScheduler()
-            scheduler._is_leader = True
+            scheduler._lease._is_leader = True
             # Plant another worker's ID in the key
             store[_LEADER_KEY] = "other-worker-9999"
-            result = await scheduler._try_acquire_or_refresh()
+            result = await scheduler._lease.try_acquire_or_refresh()
 
         assert result is False
 
@@ -362,28 +371,31 @@ class TestConnectorSchedulerRedis:
         mock_redis, _ = _make_redis_mock(store)
 
         with patch(
-            "knowledge.connectors.scheduler.get_async_redis_client",
+            "autobot_shared.leader_lease.get_async_redis_client",
             return_value=mock_redis,
         ):
             worker_a = ConnectorScheduler()
             worker_b = ConnectorScheduler()
-            # Give distinct IDs so they behave as separate workers
-            worker_a._worker_id = "host-a-1"
-            worker_b._worker_id = "host-b-2"
+            # Give distinct IDs so they behave as separate workers.
+            # The id moved onto the lease with the election logic (#13162):
+            # setting it on the scheduler left both workers sharing the
+            # lease-generated default, so A's stale refresh wrongly succeeded.
+            worker_a._lease.worker_id = "host-a-1"
+            worker_b._lease.worker_id = "host-b-2"
 
             # Worker A acquires leadership
-            assert await worker_a._try_acquire_or_refresh() is True
-            worker_a._is_leader = True
+            assert await worker_a._lease.try_acquire_or_refresh() is True
+            worker_a._lease._is_leader = True
 
             # Simulate GC pause: lock expires then worker B re-acquires atomically
             del store[_LEADER_KEY]
-            assert await worker_b._try_acquire_or_refresh() is True
-            worker_b._is_leader = True
+            assert await worker_b._lease.try_acquire_or_refresh() is True
+            worker_b._lease._is_leader = True
 
             # Worker A refresh MUST fail — it no longer holds the key
-            assert await worker_a._try_acquire_or_refresh() is False
+            assert await worker_a._lease.try_acquire_or_refresh() is False
             # Worker B refresh MUST succeed — it is the rightful leader
-            assert await worker_b._try_acquire_or_refresh() is True
+            assert await worker_b._lease.try_acquire_or_refresh() is True
 
 
 async def _sleeper(done: asyncio.Event) -> None:


### PR DESCRIPTION
## Thinking Path

`connectors/scheduler_test.py` had 6 failures on `Dev_new_gui`:

```
AttributeError: 'ConnectorScheduler' object has no attribute '_try_acquire_or_refresh'
AssertionError: assert 'c1' in {}
```

Not a product bug — the tests are stale after a refactor. Leader election was extracted into `autobot_shared/leader_lease.py` (`LeaderLease.try_acquire_or_refresh`), and `ConnectorScheduler` now delegates through `self._lease`. Three things moved with it, and the tests followed none of them:

| moved | tests still used |
|---|---|
| the method → `LeaderLease.try_acquire_or_refresh` | `scheduler._try_acquire_or_refresh()` |
| the leadership flag → `lease._is_leader` (gate at `scheduler.py:129` reads `self._lease.is_leader`) | `scheduler._is_leader` |
| the worker identity → `lease.worker_id` (used in the refresh Lua) | `scheduler._worker_id` |
| the Redis lookup → `autobot_shared.leader_lease.get_async_redis_client` | patched `knowledge.connectors.scheduler.get_async_redis_client` |

The `worker_id` one is the subtle failure: setting it on the scheduler left both workers sharing the lease-generated default, so worker A's *stale* refresh succeeded and the dual-leader test passed the wrong way round.

## What Changed

Tests only — no production code. The migration is scoped to the five leader-election tests.

**That scoping was the whole difficulty.** My first attempt replaced the patch target file-wide and went from 6 failures to **7**: the reconcile and lifecycle tests legitimately patch the *scheduler's* Redis, because `_reconcile_schedules` still calls it directly. Only the election block talks to the lease. I reverted and re-applied from the first leader-election test onward.

## Verification

```
23 passed   # connectors/scheduler_test.py — was 6 failed, 17 passed
```

## What is still red in the knowledge cluster

Measured on this branch, so `search_quality_test.py`'s 4 are the datetime bug fixed separately in #13649:

| file | count | cause |
|---|---|---|
| `search_quality_test.py` | 4 | naive/aware datetimes — **#13649** |
| `code_semantic_search_test.py` | 4 | **passes 12/12 in isolation**, fails only in the full-directory run — test isolation, not a product bug |
| `knowledge_base_integration_test.py` | 3 errors | `Redis client initialization returned None` — needs a live Redis; belongs behind the `integration` marker |

So this PR plus #13649 clears 16 of the cluster's failures. The remaining 7 are two further distinct causes, neither of which is what this issue's title describes.

Refs #13162

## Model Used

Claude Opus 5
