### PR TITLE
feat(shared): canonical project_root() and fix the worktree-escape it exposed (#13149)

### DIFF
--- a/autobot-backend/pki/config.py
+++ b/autobot-backend/pki/config.py
@@ -23,8 +23,6 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 from autobot_shared.paths import project_root
 from autobot_shared.secret_redaction import RedactedReprMixin
 from autobot_shared.ssot_config import TLSMode  # noqa: F401 — canonical enum
-from autobot_shared.ssot_config import config
-
 
 # #13149: this module carried its own ``.env``-walk copy of the project-root
 # search. It had no checkout step, so from a source tree with no ``.env`` it

--- a/autobot-backend/pki/config.py
+++ b/autobot-backend/pki/config.py
@@ -20,21 +20,18 @@ from typing import ClassVar, Dict, FrozenSet, List
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from autobot_shared.paths import project_root
 from autobot_shared.secret_redaction import RedactedReprMixin
 from autobot_shared.ssot_config import TLSMode  # noqa: F401 — canonical enum
 from autobot_shared.ssot_config import config
 
 
-def _find_project_root() -> Path:
-    """Find the project root directory containing .env file."""
-    current = Path(__file__).resolve()
-    for parent in [current] + list(current.parents):
-        if (parent / ".env").exists():
-            return parent
-    return Path(config.base_dir)
-
-
-PROJECT_ROOT = _find_project_root()
+# #13149: this module carried its own ``.env``-walk copy of the project-root
+# search. It had no checkout step, so from a source tree with no ``.env`` it
+# resolved to the deployed install and pointed PKI's certificate paths at
+# production — the same failure #13646 fixed for ``ssot_config`` and #13092 for
+# ``run_agent.sh``. It now shares the one implementation.
+PROJECT_ROOT = project_root()
 
 
 class CertificateType(str, Enum):

--- a/autobot_shared/env_drift_detector.py
+++ b/autobot_shared/env_drift_detector.py
@@ -38,6 +38,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List
 
+from autobot_shared.paths import project_root
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -332,21 +334,18 @@ def _resolve_env_path(env_path: str | None) -> Path:
     if env_path:
         return Path(env_path).resolve()
 
-    # Mirror ssot_config._find_project_root() logic
-    import os
-
-    current = Path(__file__).resolve()
-    for candidate in [current] + list(current.parents):
-        if (candidate / ".env").exists():
-            return candidate / ".env"
+    # #13149: this was a hand-copied mirror of ssot_config's project-root walk,
+    # and it drifted — it never gained the checkout step, so from a source tree
+    # with no ``.env`` it reported drift against the deployed install's file.
+    # ``project_root()`` is the one implementation both now share.
+    #
     # ssot-config-exempt: bootstrap, before config is available.
-    # #12782: the `/ ".env"` join used to sit inside this trailing comment, so
-    # the fallback returned the DIRECTORY. _parse_env_file then failed with
+    # #12782: the `/ ".env"` join used to sit inside a trailing comment, so the
+    # fallback returned the DIRECTORY. _parse_env_file then failed with
     # IsADirectoryError, swallowed it into an empty dict, and every SSOT key was
     # reported missing -- "194 drifted, (194 SSOT keys, 0 .env keys)" on a host
-    # whose .env actually held 93 keys.
-    base = Path(os.environ.get("AUTOBOT_BASE_DIR", "/opt/autobot"))
-    return base / ".env"
+    # whose .env actually held 93 keys. Keep the join on the return itself.
+    return project_root() / ".env"
 
 
 def _emit_drift_warnings(report: DriftReport) -> None:

--- a/autobot_shared/paths.py
+++ b/autobot_shared/paths.py
@@ -22,7 +22,6 @@ one implementation rather than two that can drift.
 from __future__ import annotations
 
 import os
-from functools import lru_cache
 from pathlib import Path
 
 #: Markers that identify a source checkout root and nothing below it. Both must
@@ -48,7 +47,6 @@ def is_checkout_root(path: Path) -> bool:
     return all((path / marker).exists() for marker in CHECKOUT_MARKERS)
 
 
-@lru_cache(maxsize=1)
 def project_root() -> Path:
     """Resolve the project root: explicit env, configured deployment, checkout, install.
 
@@ -74,19 +72,22 @@ def project_root() -> Path:
     deployment case: an install has a ``.env`` and no ``.git``, so it matches on
     the ``.env`` arm before any checkout marker is ever seen.
 
-    Cached: the answer cannot change within a process, and the walk touches the
-    filesystem once per ancestor. Call ``project_root.cache_clear()`` in tests
-    that manipulate the environment.
+    Deliberately **not** cached. Caching looks free — the answer rarely changes
+    within a process — but it silently defeats any caller that sets
+    ``AUTOBOT_PROJECT_ROOT`` or ``AUTOBOT_BASE_DIR`` after the first call, which
+    is exactly what the drift detector's own fallback test does. The walk is a
+    handful of ``stat`` calls against a short ancestor chain; hidden state is
+    the more expensive of the two.
     """
     return resolve_project_root(Path(__file__).resolve())
 
 
 def resolve_project_root(start: Path) -> Path:
-    """The uncached resolution, walking upward from *start*.
+    """The resolution itself, walking upward from *start*.
 
     Split out from :func:`project_root` so the walk can be exercised against a
-    temporary directory tree — the cached entry point is pinned to this file's
-    own location and cannot be pointed at a fixture.
+    temporary directory tree — the entry point is pinned to this file's own
+    location and cannot be pointed at a fixture.
     """
     configured = os.environ.get(PROJECT_ROOT_ENV)
     if configured:

--- a/autobot_shared/paths.py
+++ b/autobot_shared/paths.py
@@ -1,0 +1,99 @@
+"""Canonical project-root resolution for Python code (#13149).
+
+Every call site used to paste the shell placeholder
+``"${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}"`` into a Python string
+literal. Python does not expand shell syntax inside string literals, so those
+paths resolved to a *literal directory name* — reads missed and ``mkdir``
+either failed on the missing parent or created a junk tree actually named
+``${AUTOBOT_PROJECT_ROOT:-``.
+
+That defect was fixed once for ``sys.path`` manipulation (#4945) and once for a
+single shell script (#13092), but neither fix propagated, because there was no
+shared way to ask "where is the project root?". This module is that way.
+
+Deliberately **stdlib-only**. ``autobot_shared.ssot_config`` is the natural home
+for the logic and already owned it, but importing it pulls in pydantic and
+builds every settings model — far too heavy for the standalone tooling scripts
+that make up most of the call sites, and a circular import for
+``ssot_config`` itself. ``ssot_config`` now delegates here, so there is exactly
+one implementation rather than two that can drift.
+"""
+
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from pathlib import Path
+
+#: Markers that identify a source checkout root and nothing below it. Both must
+#: be present: ``autobot_shared`` alone also matches the package directory's own
+#: parent in some layouts, and ``.git`` alone would match an unrelated repo if
+#: this package were ever vendored into one.
+#:
+#: ``.git`` is tested with ``exists()`` rather than ``is_dir()`` on purpose — in
+#: a ``git worktree`` it is a *file* pointing at the real git directory, and
+#: this repository's whole workflow runs from worktrees.
+CHECKOUT_MARKERS = (".git", "autobot_shared")
+
+#: Environment variable naming an explicit project root. This is the same name
+#: the shell scripts honour, so exporting it once governs both languages.
+PROJECT_ROOT_ENV = "AUTOBOT_PROJECT_ROOT"
+
+#: Where a deployed install lives when nothing else identifies the root.
+DEFAULT_INSTALL_ROOT = "/opt/autobot"
+
+
+def is_checkout_root(path: Path) -> bool:
+    """True when *path* looks like the root of a source checkout."""
+    return all((path / marker).exists() for marker in CHECKOUT_MARKERS)
+
+
+@lru_cache(maxsize=1)
+def project_root() -> Path:
+    """Resolve the project root: explicit env, configured deployment, checkout, install.
+
+    Resolution order, first match wins:
+
+    1. ``AUTOBOT_PROJECT_ROOT`` — an operator saying so outranks any inference,
+       and matches what the shell scripts already do.
+    2. Walking up from this file, the nearest ancestor that either holds a
+       ``.env`` (a configured deployment) **or** looks like a source checkout.
+    3. ``AUTOBOT_BASE_DIR``/``/opt/autobot`` — the deployed install.
+
+    Step 2 is a *single* walk on purpose, and a checkout root is a hard
+    boundary. The two-pass form — all ancestors for ``.env``, then all
+    ancestors for the checkout markers — looks equivalent and is not: this
+    repository's worktrees live at ``<main-tree>/.worktrees/<name>/`` and are
+    git-ignored, so a worktree has no ``.env`` of its own. The ``.env`` pass
+    would climb straight past the worktree root and match the **main tree's**
+    ``.env``, resolving every worktree's project root to the main checkout.
+    Since the whole workflow runs from worktrees, that pointed each one's
+    config, log and results paths at another tree (#13149).
+
+    Stopping at the first checkout root also bounds the walk correctly for the
+    deployment case: an install has a ``.env`` and no ``.git``, so it matches on
+    the ``.env`` arm before any checkout marker is ever seen.
+
+    Cached: the answer cannot change within a process, and the walk touches the
+    filesystem once per ancestor. Call ``project_root.cache_clear()`` in tests
+    that manipulate the environment.
+    """
+    return resolve_project_root(Path(__file__).resolve())
+
+
+def resolve_project_root(start: Path) -> Path:
+    """The uncached resolution, walking upward from *start*.
+
+    Split out from :func:`project_root` so the walk can be exercised against a
+    temporary directory tree — the cached entry point is pinned to this file's
+    own location and cannot be pointed at a fixture.
+    """
+    configured = os.environ.get(PROJECT_ROOT_ENV)
+    if configured:
+        return Path(configured).resolve()
+
+    for parent in [start] + list(start.parents):
+        if (parent / ".env").exists() or is_checkout_root(parent):
+            return parent
+
+    return Path(os.environ.get("AUTOBOT_BASE_DIR", DEFAULT_INSTALL_ROOT))

--- a/autobot_shared/paths.py
+++ b/autobot_shared/paths.py
@@ -89,6 +89,8 @@ def resolve_project_root(start: Path) -> Path:
     temporary directory tree — the entry point is pinned to this file's own
     location and cannot be pointed at a fixture.
     """
+    # ssot-config-exempt: bootstrap — this module resolves the root that
+    # ssot_config itself needs, so it cannot import config.
     configured = os.environ.get(PROJECT_ROOT_ENV)
     if configured:
         return Path(configured).resolve()
@@ -97,4 +99,6 @@ def resolve_project_root(start: Path) -> Path:
         if (parent / ".env").exists() or is_checkout_root(parent):
             return parent
 
+    # ssot-config-exempt: bootstrap self-reference (carried from the
+    # implementation this replaced, landed in #13646).
     return Path(os.environ.get("AUTOBOT_BASE_DIR", DEFAULT_INSTALL_ROOT))

--- a/autobot_shared/paths_test.py
+++ b/autobot_shared/paths_test.py
@@ -1,0 +1,129 @@
+"""Tests for canonical project-root resolution (#13149)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from autobot_shared.paths import (
+    PROJECT_ROOT_ENV,
+    is_checkout_root,
+    project_root,
+    resolve_project_root,
+)
+
+
+def _make_checkout(root: Path) -> Path:
+    """Build a directory that satisfies both checkout markers."""
+    (root / "autobot_shared").mkdir(parents=True)
+    (root / ".git").mkdir()
+    return root
+
+
+class TestExplicitEnvironment:
+    """AUTOBOT_PROJECT_ROOT outranks every form of inference."""
+
+    def test_env_var_wins(self, tmp_path, monkeypatch) -> None:
+        checkout = _make_checkout(tmp_path / "checkout")
+        override = tmp_path / "elsewhere"
+        override.mkdir()
+        monkeypatch.setenv(PROJECT_ROOT_ENV, str(override))
+
+        assert resolve_project_root(checkout / "pkg" / "mod.py") == override
+
+    def test_unset_env_falls_through_to_the_walk(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.delenv(PROJECT_ROOT_ENV, raising=False)
+        checkout = _make_checkout(tmp_path / "checkout")
+
+        assert resolve_project_root(checkout / "pkg" / "mod.py") == checkout
+
+
+class TestWorktreeBoundary:
+    """A checkout root stops the walk — the regression this module was written for.
+
+    Worktrees live at ``<main-tree>/.worktrees/<name>/`` and are git-ignored, so
+    they carry no ``.env``. A two-pass walk (every ancestor for ``.env``, then
+    every ancestor for the markers) escaped the worktree and matched the main
+    tree's ``.env``, resolving every worktree to the wrong checkout.
+    """
+
+    def test_worktree_does_not_escape_to_the_main_tree(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.delenv(PROJECT_ROOT_ENV, raising=False)
+
+        main = _make_checkout(tmp_path / "main")
+        (main / ".env").write_text("X=1\n", encoding="utf-8")
+
+        # A worktree: both markers (.git is a FILE here), and deliberately no .env.
+        worktree = tmp_path / "main" / ".worktrees" / "issue-1"
+        (worktree / "autobot_shared").mkdir(parents=True)
+        (worktree / ".git").write_text("gitdir: /elsewhere\n", encoding="utf-8")
+        assert not (worktree / ".env").exists()
+
+        resolved = resolve_project_root(worktree / "autobot_shared" / "mod.py")
+
+        assert resolved == worktree, "worktree escaped to the main tree"
+        assert resolved != main
+
+
+class TestDeployedInstall:
+    """The case that must still be caught: a configured install has no .git."""
+
+    def test_env_file_matches_without_checkout_markers(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.delenv(PROJECT_ROOT_ENV, raising=False)
+
+        install = tmp_path / "opt" / "autobot"
+        (install / "autobot_shared").mkdir(parents=True)
+        (install / ".env").write_text("X=1\n", encoding="utf-8")
+        assert not (install / ".git").exists()
+
+        assert resolve_project_root(install / "autobot_shared" / "mod.py") == install
+
+    def test_nearest_ancestor_wins_over_a_higher_one(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.delenv(PROJECT_ROOT_ENV, raising=False)
+
+        outer = _make_checkout(tmp_path / "outer")
+        inner = _make_checkout(tmp_path / "outer" / "nested")
+
+        assert resolve_project_root(inner / "pkg" / "mod.py") == inner
+        assert inner != outer
+
+    def test_falls_back_to_the_install_location(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.delenv(PROJECT_ROOT_ENV, raising=False)
+        monkeypatch.setenv("AUTOBOT_BASE_DIR", "/srv/autobot-test")
+
+        bare = tmp_path / "bare"
+        bare.mkdir()
+
+        assert resolve_project_root(bare / "mod.py") == Path("/srv/autobot-test")
+
+
+class TestCheckoutMarkers:
+    """Both markers are required; ``.git`` may be a file."""
+
+    def test_clone_and_worktree_both_recognised(self, tmp_path) -> None:
+        clone = _make_checkout(tmp_path / "clone")
+
+        worktree = tmp_path / "worktree"
+        (worktree / "autobot_shared").mkdir(parents=True)
+        (worktree / ".git").write_text("gitdir: /elsewhere\n", encoding="utf-8")
+
+        assert is_checkout_root(clone) is True
+        assert is_checkout_root(worktree) is True
+
+    def test_either_marker_alone_is_insufficient(self, tmp_path) -> None:
+        git_only = tmp_path / "other-repo"
+        (git_only / ".git").mkdir(parents=True)
+        pkg_only = tmp_path / "vendored"
+        (pkg_only / "autobot_shared").mkdir(parents=True)
+
+        assert is_checkout_root(git_only) is False
+        assert is_checkout_root(pkg_only) is False
+
+
+class TestLiveResolution:
+    """The cached entry point resolves this very checkout."""
+
+    def test_resolves_to_a_real_directory_holding_this_package(self) -> None:
+        root = project_root()
+
+        assert root.exists()
+        assert (root / "autobot_shared" / "paths.py").exists()

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -50,61 +50,17 @@ from pydantic import AliasChoices, Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from autobot_shared.env_utils import env_int_clamped
+from autobot_shared.paths import project_root
 from autobot_shared.secret_redaction import RedactedReprMixin
 
-# Determine project root for .env file location
-#: Markers that identify a source checkout root and nothing below it. Both must
-#: be present: ``autobot_shared`` alone also matches the package directory's own
-#: parent in some layouts, and ``.git`` alone would match an unrelated repo if
-#: this package were ever vendored into one.
-#:
-#: ``.git`` is tested with ``exists()`` rather than ``is_dir()`` on purpose — in
-#: a ``git worktree`` it is a *file* pointing at the real git directory, and
-#: this repository's whole workflow runs from worktrees.
-_CHECKOUT_MARKERS = (".git", "autobot_shared")
-
-
-def _is_checkout_root(path: Path) -> bool:
-    """True when *path* looks like the root of a source checkout."""
-    return all((path / marker).exists() for marker in _CHECKOUT_MARKERS)
-
-
-def _find_project_root() -> Path:
-    """Resolve the project root: configured deployment, then checkout, then install.
-
-    The ``.env`` walk comes first and is unchanged — a deployment that has been
-    configured should always win.
-
-    The checkout step is new (#13572 step 2, #13149). ``.env`` is git-ignored, so
-    *every* fresh clone, container build and CI job fell straight through to the
-    install-location fallback and set ``PROJECT_ROOT`` to a directory that does
-    not exist there. That produced two failures at once: it failed
-    ``ssot_config_test.py::TestProjectRoot::test_project_root_exists`` on the
-    base branch, and it pointed the ~20 ``env_file=str(PROJECT_ROOT / ".env")``
-    declarations in this module at production configuration from a source tree.
-
-    This could not land before #13572. Nineteen JSON-Schema defaults were derived
-    from ``PROJECT_ROOT``, so correcting the resolver made the published OpenAPI
-    contract carry the runner's checkout path and turned ``verify-generated-types``
-    red. Those defaults are now factories and absent from the schema, so moving
-    ``PROJECT_ROOT`` no longer moves the contract.
-    """
-    current = Path(__file__).resolve()
-    candidates = [current] + list(current.parents)
-
-    for parent in candidates:
-        if (parent / ".env").exists():
-            return parent
-
-    for parent in candidates:
-        if _is_checkout_root(parent):
-            return parent
-
-    # Fallback to runtime location (env var or /opt/autobot)
-    return Path(os.environ.get("AUTOBOT_BASE_DIR", "/opt/autobot"))  # ssot-config-exempt: bootstrap self-reference
-
-
-PROJECT_ROOT = _find_project_root()
+# Determine project root for .env file location.
+#
+# The resolution itself lives in ``autobot_shared.paths`` (#13149) so that the
+# 50-odd standalone tooling scripts that also need the project root can ask for
+# it without importing this module, which builds every pydantic settings model.
+# Keeping one implementation is the point: the same defect was fixed in
+# isolation twice (#4945, #13092) and both times failed to propagate.
+PROJECT_ROOT = project_root()
 
 # Default model constants - single source of truth for fallback values (#2553)
 # These are used when .env doesn't specify a value.

--- a/autobot_shared/ssot_config_test.py
+++ b/autobot_shared/ssot_config_test.py
@@ -515,13 +515,13 @@ class TestCheckoutRootDetection:
 
     def test_recognises_a_normal_clone(self, tmp_path) -> None:
         """A clone has .git as a directory."""
-        from autobot_shared.ssot_config import _is_checkout_root
+        from autobot_shared.paths import is_checkout_root
 
         root = tmp_path / "clone"
         (root / "autobot_shared").mkdir(parents=True)
         (root / ".git").mkdir()
 
-        assert _is_checkout_root(root) is True
+        assert is_checkout_root(root) is True
 
     def test_recognises_a_git_worktree(self, tmp_path) -> None:
         """In a worktree .git is a FILE, not a directory.
@@ -529,13 +529,13 @@ class TestCheckoutRootDetection:
         Tested explicitly because this repository's whole workflow runs from
         worktrees, and an ``is_dir()`` check would have excluded every one.
         """
-        from autobot_shared.ssot_config import _is_checkout_root
+        from autobot_shared.paths import is_checkout_root
 
         root = tmp_path / "worktree"
         (root / "autobot_shared").mkdir(parents=True)
         (root / ".git").write_text("gitdir: /elsewhere\n", encoding="utf-8")
 
-        assert _is_checkout_root(root) is True
+        assert is_checkout_root(root) is True
 
     def test_requires_both_markers(self, tmp_path) -> None:
         """Either marker alone is not enough.
@@ -544,19 +544,19 @@ class TestCheckoutRootDetection:
         vendored into; ``autobot_shared`` alone matches ordinary parent
         directories in some layouts.
         """
-        from autobot_shared.ssot_config import _is_checkout_root
+        from autobot_shared.paths import is_checkout_root
 
         git_only = tmp_path / "other-repo"
         (git_only / ".git").mkdir(parents=True)
         pkg_only = tmp_path / "vendored"
         (pkg_only / "autobot_shared").mkdir(parents=True)
 
-        assert _is_checkout_root(git_only) is False
-        assert _is_checkout_root(pkg_only) is False
+        assert is_checkout_root(git_only) is False
+        assert is_checkout_root(pkg_only) is False
 
     def test_a_configured_env_still_wins(self, tmp_path) -> None:
         """The .env walk keeps priority — a configured deployment is authoritative."""
-        from autobot_shared import ssot_config
+        from autobot_shared import paths
 
         # Both markers AND a .env: the .env branch is checked first, so a
         # deployment that has been configured is never overridden by detection.
@@ -565,5 +565,5 @@ class TestCheckoutRootDetection:
         (root / ".git").mkdir()
         (root / ".env").write_text("X=1\n", encoding="utf-8")
 
-        assert ssot_config._is_checkout_root(root) is True
+        assert paths.is_checkout_root(root) is True
         assert (root / ".env").exists()

--- a/autobot_shared/ssot_config_test.py
+++ b/autobot_shared/ssot_config_test.py
@@ -554,16 +554,46 @@ class TestCheckoutRootDetection:
         assert is_checkout_root(git_only) is False
         assert is_checkout_root(pkg_only) is False
 
-    def test_a_configured_env_still_wins(self, tmp_path) -> None:
-        """The .env walk keeps priority — a configured deployment is authoritative."""
-        from autobot_shared import paths
+    def test_a_configured_checkout_resolves_to_itself(self, tmp_path) -> None:
+        """A directory holding both a .env and the markers resolves to itself.
 
-        # Both markers AND a .env: the .env branch is checked first, so a
-        # deployment that has been configured is never overridden by detection.
+        Note the rule is **nearest ancestor wins**, not ".env is searched before
+        the markers". The resolver makes a single pass and returns the first
+        ancestor satisfying *either* condition (#13149); the two-pass form it
+        replaced is what let a worktree escape to the main tree's ``.env``.
+        Where both signals sit in the same directory — an ordinary configured
+        checkout — the two orderings agree, which is what this pins.
+        """
+        from autobot_shared.paths import is_checkout_root, resolve_project_root
+
         root = tmp_path / "deployed"
         (root / "autobot_shared").mkdir(parents=True)
         (root / ".git").mkdir()
         (root / ".env").write_text("X=1\n", encoding="utf-8")
 
-        assert paths.is_checkout_root(root) is True
-        assert (root / ".env").exists()
+        assert is_checkout_root(root) is True
+        assert resolve_project_root(root / "autobot_shared" / "mod.py") == root
+
+    def test_a_nearer_checkout_beats_a_farther_env(self, tmp_path, monkeypatch) -> None:
+        """The case the old two-pass walk got wrong, asserted on resolution.
+
+        An outer directory carries the ``.env``; an inner one carries only the
+        markers. Walking every ancestor for ``.env`` first would return the
+        outer directory — which is exactly how every worktree resolved to the
+        main checkout before #13149.
+        """
+        from autobot_shared.paths import PROJECT_ROOT_ENV, resolve_project_root
+
+        monkeypatch.delenv(PROJECT_ROOT_ENV, raising=False)
+
+        outer = tmp_path / "main"
+        (outer / "autobot_shared").mkdir(parents=True)
+        (outer / ".git").mkdir()
+        (outer / ".env").write_text("X=1\n", encoding="utf-8")
+
+        inner = outer / ".worktrees" / "issue-1"
+        (inner / "autobot_shared").mkdir(parents=True)
+        (inner / ".git").write_text("gitdir: /elsewhere\n", encoding="utf-8")
+        assert not (inner / ".env").exists()
+
+        assert resolve_project_root(inner / "autobot_shared" / "mod.py") == inner


### PR DESCRIPTION
Task 1 of #13149 — the canonical Python accessor and the consolidation of every duplicate implementation of it. The 57 string-literal call sites and the CI gate follow in the next PR; see *Scope* below for why they are split.

## Thinking Path

#13149 says both failure classes exist because "each call site re-invents root resolution", and proposes a new `autobot_shared.paths.project_root()`.

Auditing first changed the shape of the work. `ssot_config.PROJECT_ROOT` **already was** a correct resolver — #13646 landed the checkout step days ago. Adding a second accessor beside it would have created exactly the duplication the issue is about, so the logic moved into a stdlib-only module and `ssot_config` now delegates to it. One implementation, not two.

Moving it surfaced two more copies the issue did not list:

- `autobot-backend/pki/config.py` had its own `_find_project_root()` with **no checkout step**. From a source tree with no `.env` it resolved to the deployed install, pointing PKI's certificate paths at production — the same defect #13646 fixed for `ssot_config` and #13092 for `run_agent.sh`.
- `autobot_shared/env_drift_detector.py` carried a hand-copied walk, commented "Mirror ssot_config._find_project_root() logic". It had drifted the same way, so drift was reported against the deployed install's `.env` from a checkout.

Both now share the one implementation. (A fourth ad-hoc computation, `Path(__file__).parent.parent` in `run_code_analysis.py`, is a local `sys.path` bootstrap and is left to the migration PR.)

## The bug this found

Writing the resolver as the issue specified — env var, then a `.env` walk, then a checkout-marker walk — reproduced a live defect on the base branch:

```
project_root() from .worktrees/issue-13149  ->  /…/AutoBot-AI          # the MAIN tree
```

Worktrees live at `<main-tree>/.worktrees/<name>/` and are git-ignored, so a worktree has no `.env`. The `.env` pass climbs straight past the worktree root and matches the **main tree's** `.env`. Since this repository's entire workflow runs from worktrees, every one of them resolved its project root — and therefore its config, log and results paths — to a different tree.

The fix is one walk instead of two, with a checkout root as a hard boundary:

```python
for parent in [start] + list(start.parents):
    if (parent / ".env").exists() or is_checkout_root(parent):
        return parent
```

```
project_root() from .worktrees/issue-13149  ->  /…/AutoBot-AI/.worktrees/issue-13149
```

This does not change CI, which checks out directly: no `.env`, markers at the root, so both forms return the repository root. It changes local worktree runs, which were wrong.

## What Changed

- **`autobot_shared/paths.py`** (new) — `project_root()`, `resolve_project_root(start)`, `is_checkout_root()`. Stdlib-only, so the standalone tooling scripts that make up most of the remaining call sites can import it without pulling in pydantic and building every settings model.
- **`ssot_config.py`** — `_find_project_root` / `_is_checkout_root` / `_CHECKOUT_MARKERS` removed; `PROJECT_ROOT = project_root()`.
- **`pki/config.py`**, **`env_drift_detector.py`** — duplicate walks replaced with the shared call.
- **`paths_test.py`** (new) — 9 tests.
- **`ssot_config_test.py`** — the 6 `_is_checkout_root` references repointed at the canonical name.

`AUTOBOT_PROJECT_ROOT` now takes precedence, matching what the shell scripts already do. It is set by exactly one thing in the repo — the `distributed.env.j2` deployment template — and is unset in CI, so nothing changes there.

**Not cached.** The first draft used `lru_cache`; it passed alone and failed in the full run, because a cached root silently defeats any caller that sets `AUTOBOT_BASE_DIR` afterwards — which `env_drift_detector_path_test.py` does. The walk is a handful of `stat` calls; the hidden state cost more than it saved.

## Verification

```
python3 -m pytest -q autobot_shared/ autobot-backend/pki/
1467 passed, 1 warning in 22.45s
```

Both directions of the worktree fix are pinned in `paths_test.py`:

- `TestWorktreeBoundary` — the reproduction: a worktree under a main tree that *does* have `.env` must resolve to itself.
- `TestDeployedInstall::test_env_file_matches_without_checkout_markers` — the case that must still work: an install with `.env` and no `.git` still resolves via the `.env` arm.

Live check from this worktree, before and after, is quoted above.

## Scope

Deliberately **not** in this PR:

- the 57 `${AUTOBOT_PROJECT_ROOT:-…}` string literals across 41 files (issue Tasks 2 and 3);
- the CI gate (issue Task 1) — it cannot land green until those 57 are migrated, so it ships with them;
- the 36 shell scripts (Task 4) and the YAML audit (Task 5).

Counts differ from the issue's: **57 occurrences in 41 files**, not 60 in 40, and **36** shell files, not 34. Two of the 57 are prose — a comment in `mcp_security_test.py` and a docstring in `webhook_authentication_security_test.py` — not defects, and they need the gate to distinguish them from real path literals.

#13149 stays open until Tasks 2-5 land.

## Model Used

Opus 5

Refs #13149
