### PR TITLE
fix(config): type context_summary_ttl_days as int with the documented default (#13386)

### DIFF
--- a/autobot-backend/knowledge/pipeline/cognifiers/context_generator.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/context_generator.py
@@ -48,7 +48,11 @@ class ContextGeneratorCognifier(BaseCognifier):
 
     def __init__(self, model=None, ttl_days=None):
         self.model = model or config.context_model
-        days = ttl_days or int(config.context_summary_ttl_days)
+        # #13386: the config field is typed ``int`` now, so no parse happens
+        # here. It previously read ``int(config.context_summary_ttl_days)`` on a
+        # ``str`` field whose default was "", which made constructing this
+        # cognifier raise anywhere a .env was absent.
+        days = ttl_days or config.context_summary_ttl_days
         self.ttl_seconds = days * 86400
         self.llm = get_llm_service()
 

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -1876,7 +1876,13 @@ class MiscConfig(RedactedSettings):
     content_cache_max_size: int = Field(default=500, alias="CONTENT_CACHE_MAX_SIZE")
     context_enabled: bool = Field(default=False, alias="CONTEXT_ENABLED")
     context_model: str = Field(default="", alias="CONTEXT_MODEL")
-    context_summary_ttl_days: str = Field(default="", alias="CONTEXT_SUMMARY_TTL_DAYS")
+    # #13386: was ``str`` defaulting to "", and its only consumer does
+    # ``int(config.context_summary_ttl_days)`` — so with the variable unset the
+    # cognifier raised ``ValueError: invalid literal for int() with base 10: ''``
+    # on construction. That is every environment without a .env: a fresh clone, a
+    # container build, a git worktree, and CI. 30 is the value .env.example has
+    # documented all along.
+    context_summary_ttl_days: int = Field(default=30, alias="CONTEXT_SUMMARY_TTL_DAYS")
     cuda_cache_disable: bool = Field(default=False, alias="CUDA_CACHE_DISABLE")
     cuda_launch_blocking: str = Field(default="", alias="CUDA_LAUNCH_BLOCKING")
     custom_openai_api_key: str = Field(default="", alias="CUSTOM_OPENAI_API_KEY")


### PR DESCRIPTION
## Thinking Path

#13386 attributes the six red `cognifiers_test.py` tests to `llc/tests/conftest.py` teardown leaving the real `knowledge` package without its imported children, producing:

```
AttributeError: module 'knowledge' has no attribute 'pipeline'
```

**That is not what fails today.** The actual error in the current base run is:

```
autobot-backend/knowledge/pipeline/cognifiers/context_generator.py:51: in __init__
    days = ttl_days or int(config.context_summary_ttl_days)
E   ValueError: invalid literal for int() with base 10: ''
```

Nothing to do with `sys.modules`, import order, or shard composition. The config field is:

```python
context_summary_ttl_days: str = Field(default="", alias="CONTEXT_SUMMARY_TTL_DAYS")
```

Typed `str`, defaulting to `""`, and its **only** consumer wraps it in `int()`. So constructing `ContextGeneratorCognifier` raises anywhere `CONTEXT_SUMMARY_TTL_DAYS` is unset — every fresh clone, container build, git worktree, and CI job. Its numeric neighbours in the same class are already typed properly (`content_cache_max_size: int = Field(default=500, ...)`); this one is the outlier.

`.env.example:375` has documented `CONTEXT_SUMMARY_TTL_DAYS=30` all along, so the intended default was never in doubt.

### Why it looked shard-dependent

On a dev box the tests pass, which is what made this look like a test-isolation problem. The reason is unrelated to isolation: `PROJECT_ROOT` resolution walks up for a `.env`, escapes the worktree, and finds the **main checkout's** `.env` — which defines the variable. CI has no `.env`, so the default `""` applies and `int("")` raises.

That escape is the bug fixed by #13652. Applying that fix makes this failure reproduce on a dev box, which is how I got a local reproduction without `pytest-split`:

```
# in a worktree carrying the #13652 resolver fix (no .env of its own)
6 failed, 51 passed      <- exactly the six CI reports
```

## What Changed

```python
context_summary_ttl_days: int = Field(default=30, alias="CONTEXT_SUMMARY_TTL_DAYS")
```

and the consumer drops its now-redundant parse:

```python
days = ttl_days or config.context_summary_ttl_days
```

`context_generator.py` is the only reader of this field, so the type change has no other call sites. `MiscConfig` is an internal settings class and is not used as a response model, so the OpenAPI contract is unaffected — checked deliberately, given #13572.

## Verification

Both directions, in the worktree that reproduces CI:

```
before:  6 failed, 51 passed        <- matches the CI failure set exactly
after:  57 passed
```

Config resolution, with the `.env` bypassed the way CI sees it:

```
A. no .env, variable unset  -> 30   (ttl_seconds = 2592000)
B. CONTEXT_SUMMARY_TTL_DAYS=7  -> 7
C. CONTEXT_SUMMARY_TTL_DAYS=30 -> 30
```

Regression sweep, including the tests that iterate `MiscConfig.model_fields`:

```
python3 -m pytest -q autobot-backend/knowledge/pipeline/ autobot_shared/ssot_config_test.py
323 passed, 2 skipped

python3 -m pytest -q autobot_shared/tests/test_service_auth_default_parity_13335.py \
                     autobot_shared/tests/test_config_repr_redaction_13325.py \
                     autobot_shared/ssot_config_test.py
172 passed
```

## Scope

This clears the 6 `cognifiers_test.py` failures on `python-suite shard 3/12`. The remaining 3 errors on that shard are `knowledge_base_integration_test.py`, which needs a live Redis (`'KnowledgeBase' object has no attribute 'redis_manager'` after `Failed to initialize Redis connections`) and is a separate concern.

#13386 should stay open or be re-scoped rather than closed by this: its stated mechanism — `llc/tests/conftest.py` teardown not re-binding imported children — was a real observation about that conftest, and `testkit/module_stubs.py`'s `StubSet` already implements the fix (#13596). This PR does not touch it. What this PR shows is that the mechanism is not the cause of *these six failures*.

## Model Used

Opus 5

Refs #13386
