### PR TITLE
ci(python-suite): collect scripts/ so the checker tests actually run (#13653)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,8 +198,14 @@ jobs:
         # makes whichever backend's file collects first bind that dotted name
         # in sys.modules for the rest of the session, breaking the other
         # backend's own tests.
+        # #13653: `scripts` was absent from this list, so the seven test files
+        # guarding the pre-commit checkers (nosec format, exec bits, token
+        # contrast, websockets cap, api wiring) ran in no workflow at all.
+        # They pass — measured at 118 passed — so this is a wiring fix, not a
+        # quarantine. scripts/lib/*_test.sh are bash and are covered separately
+        # by repo_tests/shell_lib_test.py.
         python -m pytest \
-          autobot-backend autobot_shared autobot-tts-worker repo_tests tools \
+          autobot-backend autobot_shared autobot-tts-worker repo_tests tools scripts \
           -n auto --dist loadscope \
           --splits 12 --group ${{ matrix.shard }} \
           --durations-path .test_durations \


### PR DESCRIPTION
## Thinking Path

`ci.yml` collects a fixed directory list. `scripts` was not in it:

```yaml
autobot-backend autobot_shared autobot-tts-worker repo_tests tools \
```

So seven test files ran in **no workflow at all** — the regression suites for the pre-commit checkers, i.e. the things that decide whether a violation reaches the base branch:

```
scripts/audit_api_wiring_suggestions_test.py   scripts/check_token_contrast_test.py
scripts/audit_api_wiring_test.py               scripts/check_websockets_cap_test.py
scripts/check_nosec_format_test.py             scripts/migrate_ceo_chat_to_sessions_test.py
scripts/check_script_exec_bits_test.py
```

Found while wiring up `scripts/lib/branch-guards_test.sh`, which had the same problem in bash form and had **never been executed by anything** since it was written (that half is fixed on the #13149 migration branch via `repo_tests/shell_lib_test.py`).

## What Changed

One word — `scripts` appended to the backend invocation's directory list, plus a comment recording why.

The **slm-backend invocation is deliberately untouched**. #13084 documents that the two backends must be separate pytest sessions because they define identically-named top-level packages; `scripts` belongs to the first session only.

## Verification

This is a wiring fix, not a quarantine — the tests were already green, they simply never ran:

```
python3 -m pytest -q scripts/
118 passed in 20.26s

python3 -m pytest -q scripts/ -m "not integration and not slow and not distributed and not performance"
118 passed in 16.50s
```

The second run uses CI's exact marker filter, so nothing is deselected into invisibility.

YAML still parses, and the inserted comment is reindented to match its neighbours (8, not 10 — the block is a `run: |` literal where the surrounding comments sit at 8):

```
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"
YAML parses OK
```

## Expected side effect

`.test_durations` has no timings for these 118 tests, so pytest-split will pack them by its unknown-duration fallback and shard boundaries will shift on the first run. That is the same mechanism behind #13637 — a shard can come out empty and exit 5 — which `ci.yml` already tolerates with an explicit `::notice::` (#13638). Regenerating the durations file afterwards will settle the packing.

## Not covered

`check_script_exec_bits_test.py::test_repository_is_currently_clean` asserts against live repository state rather than a fixture, so it can fail for reasons unrelated to the checker. It passes today; worth knowing if it ever goes red.

The broader question — that a curated directory list silently drops whole test trees — is worth a guard asserting every directory containing `*_test.py` appears in the workflow's argument list. Not added here; that is a larger change than wiring in the seven files this issue is about.

## Model Used

Opus 5

Closes #13653
