### PR TITLE
test(mcp): fix the never-importable subscriptions test and colocate it (#13662)

### DIFF
--- a/autobot-backend/services/mcp_subscription_manager_test.py
+++ b/autobot-backend/services/mcp_subscription_manager_test.py
@@ -86,7 +86,7 @@ async def test_file_watcher():
     manager = MCPSubscriptionManager()
 
     # Create a temporary file
-    with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.txt') as f:
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".txt") as f:
         temp_path = f.name
         f.write("Initial content\n")
 
@@ -143,6 +143,7 @@ async def main():
     except Exception as e:
         print(f"\n❌ Test failed: {e}")
         import traceback
+
         traceback.print_exc()
         return 1
 

--- a/autobot-backend/services/mcp_subscription_manager_test.py
+++ b/autobot-backend/services/mcp_subscription_manager_test.py
@@ -11,7 +11,13 @@ import asyncio
 import tempfile
 from pathlib import Path
 
-from autobot-backend.services.mcp_subscription_manager import (
+# #13662: this file lived at the repository root and imported
+# `autobot-backend.services.mcp_subscription_manager`. A hyphen is not valid
+# in a module path, so it raised SyntaxError and had never run since #9275
+# introduced it — the repository root is in neither of ci.yml's pytest
+# collection lists, so nothing ever tried to import it. Moved here to sit
+# beside its subject, inside a directory CI actually collects.
+from services.mcp_subscription_manager import (
     MCPSubscriptionManager,
     _uri_to_channel,
 )


### PR DESCRIPTION
## Thinking Path

`test_mcp_subscriptions.py` sat at the repository root and could not be imported by any Python:

```python
  File "test_mcp_subscriptions.py", line 14
    from autobot-backend.services.mcp_subscription_manager import (
                ^
SyntaxError: invalid syntax
```

A hyphen is not valid in a module path. The file arrived in **#9275** (`feat(mcp): implement resource subscriptions for real-time updates`), so that feature shipped with a test file that has **never executed a single assertion**. The SPDX backfill (#10127) later edited it, so tooling has walked over the file without anything noticing it does not parse.

Nothing caught it because the repository root appears in neither of `ci.yml`'s pytest collection lists. Found while enumerating that gap for #13653.

## What Changed

Two things, both minimal:

1. `from autobot-backend.services.mcp_subscription_manager import (...)` → `from services.mcp_subscription_manager import (...)`.
2. Moved to `autobot-backend/services/mcp_subscription_manager_test.py` — beside its subject, matching the repository's colocated `*_test.py` convention, and inside a directory CI actually collects.

A comment records the history so the odd provenance is not mysterious later.

## Verification

I expected this to be the tip of a larger pile — a test unrun since 2026 seemed unlikely to still be correct. Measured instead of assumed, and it was wrong to worry: the subject module is intact (`_uri_to_channel` at `mcp_subscription_manager.py:35`, `MCPSubscriptionManager` at line 50) and all **12 assertions across 2 async tests** pass with nothing but the import corrected.

```text
python3 -m pytest -q autobot-backend/services/mcp_subscription_manager_test.py
2 passed in 4.18s

python3 -m pytest -q autobot-backend/services/ -k mcp
89 passed, 2142 deselected
```

No references to the old path remain:

```text
git grep -n test_mcp_subscriptions   ->   (nothing)
```

So this is not rotten coverage needing a rewrite; it is working coverage that has been invisible for its entire life.

## Note

The file doubles as a runnable script — `main()`, 28 `print()` calls, and `if __name__ == "__main__": exit(asyncio.run(main()))`. Left intact: pytest captures the prints, and the two `async def test_*` functions run directly under `asyncio_mode=auto`. Stripping the script scaffolding would be a separate, larger change with no functional benefit.

Related: #13653 (the collection gap, 25 further uncollected files) · #13660 (adds `scripts/` to the list)

## Model Used

Opus 5

Closes #13662
