### PR TITLE
docs(process): red-CI hard merge gate + scope decision-asking to interactive sessions (#13665)

### DIFF
--- a/.session/HANDOFF-issue-13665.md
+++ b/.session/HANDOFF-issue-13665.md
@@ -1,0 +1,9 @@
+# Handoff: issue-13665
+status: complete
+pr: #13666
+base_at_push: 6fa09d97f
+gates: docs-only — wiring=N/A duplication=N/A tests=N/A
+needs_rebase_before_merge: no
+remaining:
+  - code-reviewer pass not dispatched (session was instructed not to spawn agents unprompted)
+worktree: .worktrees/issue-13665  (safe to remove after merge)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,7 @@ Correctness → Speed → Maintainability. No wasted motion. No speculative work
 - **Commit format:** `<type>(scope): <description> (#issue-number)`
 - **Security reviews are findings-first:** read the diff only, emit a severity/`file:line`/issue/fix table within 3 tool calls, verify *after* — never explore before the table lands (skill: `secreview`)
 - **Long analyses go to a file, not the response:** research/audit/comparison output is written to `docs/research/<topic>.md` (or `docs/audit/`) incrementally as it is produced; the reply is the path plus a short summary — an interrupted or token-capped response must never lose the work
+- **Red CI never merges:** a failing required check is root-caused and fixed, never merged past — filing a tracking issue is not a substitute. Can't fix now → label the PR `blocked` with a root-cause writeup and move on ([`CLAUDE_REVIEW.md`](docs/developer/CLAUDE_REVIEW.md) "Red CI Never Merges")
 - **Never `--no-verify`** — PostToolUse hook auto-formats `.py`
 - **Protected branches:** `main`/`master` blocked by pre-commit hook → use `issue-*` or `hotfix-*`
 - **PR template headings:** `Thinking Path` · `What Changed` · `Verification` · `Model Used`

--- a/docs/developer/CLAUDE_REVIEW.md
+++ b/docs/developer/CLAUDE_REVIEW.md
@@ -39,8 +39,42 @@ After agents complete:
    - Syntax: `npm run lint` / `python -m black --check`
    - Imports: `python -c 'import <module>'` for each modified file
    - Call sites: grep for removed/renamed functions
-4. **Merge:** each PR to `Dev_new_gui`
+4. **Merge:** each PR to `Dev_new_gui` — only with every required check green (see "Red CI Never Merges")
 5. **Verify count:** PR count should be 0 after all merges
+
+---
+
+## Red CI Never Merges (#13665)
+
+A red required check is a merge blocker, not an input to a judgement call. **Filing
+a tracking issue for a failing check and merging anyway is forbidden** — that is the
+exact anti-pattern this gate exists to stop (an api-wiring audit failed, got an issue
+filed against it, and the PR merged regardless; the audit was failing for a real
+reason).
+
+The check is telling you the change is wrong, or that the check is wrong. Both are
+root causes and both are yours to fix:
+
+1. **Confirm it is actually red**, not queued. Queued checks on the singleton
+   self-hosted runner are not failures — see "CI Diagnosis" below and verify the
+   verdict against the head SHA from `gh api repos/{owner}/{repo}/pulls/N --jq
+   '.head.sha'`, sorting check-runs by `started_at` (array order is not chronological,
+   so a stale FAILURE can sit next to the real SUCCESS).
+2. **Absence is not success.** A PR reporting "19 success, 0 failures" is still
+   blocked if a required context never reported at all. Count reported contexts
+   against `gh api repos/{owner}/{repo}/branches/Dev_new_gui/protection --jq
+   '.required_status_checks.contexts[]'`.
+3. **Root-cause and fix it** in the same PR. If the check itself is wrong, fix the
+   check — in the same PR or a fast-follow that lands first.
+4. **If it genuinely cannot be fixed now:** label the PR `blocked`, post a
+   one-paragraph root-cause writeup on it, and move to the next issue. Do not merge,
+   do not `--admin` past it, and do not interrupt a `/loop` to ask about it.
+
+Three failed attempts on the same red check is an escalation, not a fourth attempt:
+post the findings on the issue and move on.
+
+**Applies identically in autonomous `/loop` mode.** The loop merges what is green;
+red means the tick moves to the next non-colliding issue, never to a workaround.
 
 ---
 


### PR DESCRIPTION
## Thinking Path

A `/insights` review surfaced two recurring process failures. Auditing before writing showed
one suggested fix was already shipped and two were genuinely missing:

- The findings-first `secreview` skill the report recommended **already exists** (`7b617f542`,
  2026-07-29) — no action needed there.
- **No rule anywhere forbids merging past a red required check.** `CLAUDE_REVIEW.md` step 4
  was literally `**Merge:** each PR to Dev_new_gui` with no CI precondition, and the existing
  `Merge-Blocking Findings Gate` covers *filed issues* blocking a merge, not *red checks*.
  A session had filed a tracking issue against a failing api-wiring audit and merged anyway.
- **`Ask decisions immediately` contradicted the loop protocol.** The loop doc already says
  the right thing ("asking means posting, not waiting"), but it is a topic-gated doc while
  the contradicting rule is always resident — so the resident rule won and a `/loop` got
  interrupted for a question the protocol had already answered.

Fixed by amending the existing sections rather than forking new rule text, so there is one
statement of each rule.

## What Changed

- `docs/developer/CLAUDE_REVIEW.md` — new **Red CI Never Merges** gate: confirm red vs. queued
  against the head SHA (check-run array order is not chronological), count reported contexts
  against branch protection because absence is not success, root-cause and fix, and if it
  truly cannot be fixed now label the PR `blocked` with a writeup and move on. Explicitly
  names the anti-pattern (tracking issue as a merge workaround) and states it applies
  identically in `/loop` mode. Merge-checklist step 4 now carries the precondition.
- `CLAUDE.md` — one-line Workflow Quick Rule pointing at the new gate.

Owner's private global config (`~/.claude/CLAUDE.md`, not in this repo) was updated in the
same session to scope `Ask decisions immediately` to interactive sessions and add the
never-interrupt-a-loop rule.

## Verification

Docs-only change; no code paths touched.

```
$ git diff --stat HEAD~1
 CLAUDE.md                       |  1 +
 docs/developer/CLAUDE_REVIEW.md | 36 +++++++++++++++++++++++++++++++++++-
 2 files changed, 36 insertions(+), 1 deletion(-)
```

Audit-before-writing evidence (no duplicate rule already present):

```
$ grep -rn "merge past\|red CI\|failing check\|never merge" docs/developer/*.md CLAUDE.md
docs/developer/CLAUDE_WORKFLOW.md:236: ... (a passing mention of "a red CI test", not a rule)
```

Only one pre-existing hit, and it is prose about interpreter parity — not a merge rule. The
`blocked` label and the `--admin` escape hatch referenced in the new gate both already exist
in the workflow docs, so no new vocabulary was introduced.

## Model Used

Claude Opus 5 (1M context)

Closes #13665
