### PR TITLE
fix(deps): bump dompurify past the XSS advisory (#13667)

### DIFF
--- a/autobot-frontend/package-lock.json
+++ b/autobot-frontend/package-lock.json
@@ -3243,9 +3243,9 @@
       "license": "MIT"
     },
     "node_modules/@redocly/openapi-core": {
-      "version": "1.34.17",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.17.tgz",
-      "integrity": "sha512-wsV2keCt6B806XpSdezbWZ9aFJYf14YVh+XQf0ESt7M90yqVuxH9//PxvtC70sgj9OCkRM3nRaLfu4MsGQZRig==",
+      "version": "1.34.18",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.18.tgz",
+      "integrity": "sha512-UyKIm0wTPw5BcY7Z2PkbK1Ma260um96LSBWXHrdSMe+ZV0EPMyDfAcUcjjm3qEiGST9OK/1TriekdPCZkn4Q3A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3254,7 +3254,7 @@
         "colorette": "1.4.0",
         "https-proxy-agent": "7.0.6",
         "js-levenshtein": "1.1.6",
-        "js-yaml": "4.2.0",
+        "js-yaml": "4.3.0",
         "minimatch": "5.1.9",
         "pluralize": "8.0.0",
         "yaml-ast-parser": "0.0.43"
@@ -7401,9 +7401,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"


### PR DESCRIPTION
## Thinking Path

`Security Scan` began failing on every PR between 2026-08-05 and 2026-08-07 with no code change — two advisories were published in that window (#13667). This clears the one that can be fixed without a breaking change, and escalates the one that cannot.

## What Changed

`autobot-frontend/package-lock.json` only, via `npm audit fix --package-lock-only`:

```
dompurify              3.4.12 -> 3.4.13
@redocly/openapi-core  1.34.17 -> 1.34.18
```

The DOMPurify advisory (`GHSA-55q2-fjhq-7xh7`, IN_PLACE hook removal leaving a detached subtree executable) is cleared:

```
before:  1 moderate, 2 high
after:   2 high          dompurify present in findings: False
```

Lockfile-only, patch-level, no `package.json` change.

## What is NOT fixed, and why I did not force it

`js-yaml` and `@redocly/openapi-core` remain. Both need **major** bumps:

```
js-yaml                4.3.0    -> 5.x   (vulnerable range 4.0.0 - 4.3.0)
@redocly/openapi-core  1.34.18  -> 2.x   (vulnerable range 1.34.8 - 1.34.18)
```

`CVE-2026-59870`'s fix was **not backported** to js-yaml 4.x, so there is no patch-level escape. And the dependency chain is the problem:

```
openapi-typescript -> @redocly/openapi-core -> js-yaml
```

`openapi-typescript` is what generates `autobot-frontend/src/types/generated/api.ts`, guarded by the **required** `verify-generated-types` check. A major bump of that toolchain can legitimately change generated output, which would turn a required check red — and the whole point of #13666's gate is that a red required check blocks. Doing that unilaterally to silence a non-required check would be the wrong trade.

`npm audit fix --force` would cross those majors. I have not run it.

**This needs a decision:** accept a major bump of the OpenAPI type toolchain and re-verify the generated contract, or accept the two high advisories until upstream backports. `autobot-slm-frontend` carries the same `js-yaml 4.3.0` and would need the same treatment.

## Verification

```
npm audit  (autobot-frontend)
  before: {'moderate': 1, 'high': 2, 'total': 3}
  after:  {'high': 2, 'total': 2}
```

No `package.json` change, so no dependency contract moved; `Security Scan` will still report the two high advisories until the decision above is made.

## Model Used

Opus 5

Refs #13667
