### PR TITLE
test(knowledge): re-point the Redis-pool tests at the surface that exists (#13657)

### DIFF
--- a/autobot-backend/knowledge/knowledge_base_integration_test.py
+++ b/autobot-backend/knowledge/knowledge_base_integration_test.py
@@ -54,7 +54,7 @@ class TestKnowledgeBaseRedisIntegration:
         """Test that Redis connection is properly established"""
         # Verify connection exists
         assert kb._aioredis_client is not None
-        assert kb.redis_manager is not None
+        assert kb.redis_client is not None
 
         # Verify connection works with ping
         result = await kb.redis().ping()
@@ -404,23 +404,39 @@ class TestKnowledgeBaseRedisIntegration:
 
 
 class TestKnowledgeBaseAsyncRedisManagerIntegration:
-    """Integration tests for AsyncRedisManager integration"""
+    """Redis-pool and resilience coverage for the knowledge base.
+
+    Named for ``AsyncRedisManager``, which no longer exists: ``utils/
+    async_redis_manager.py`` was deleted in the Nov 2025 Redis consolidation and
+    its last compatibility shim removed by #12649/#12667, which migrated the
+    surviving caller onto ``autobot_shared.redis_client``. These tests kept
+    asserting ``kb.redis_manager``, an attribute ``KnowledgeBase`` has not had
+    since — so they did not fail, they **errored at fixture setup**, which reads
+    like an environment problem rather than dead code (#13657).
+
+    Re-pointed at the surface that actually exists (``kb.redis_client``) rather
+    than retired: the intent — that the knowledge base's Redis usage is pooled
+    and survives failures — is still worth covering.
+    """
 
     @pytest.fixture
     async def kb(self):
-        """Create KnowledgeBase with AsyncRedisManager"""
+        """Create a KnowledgeBase with its Redis client initialised."""
         kb = KnowledgeBase()
         await kb._ensure_redis_initialized()
 
-        if not kb.redis_manager:
-            pytest.skip("AsyncRedisManager not available")
+        # getattr, not attribute access: a bare `kb.redis_client` raises when the
+        # attribute is absent, so the skip below could never fire — that is
+        # exactly how three tests turned into three errors.
+        if not getattr(kb, "redis_client", None):
+            pytest.skip("Redis unavailable — these exercise a live connection")
 
         yield kb
 
     @pytest.mark.asyncio
-    async def test_async_redis_manager_initialized(self, kb):
-        """Test that AsyncRedisManager is properly initialized"""
-        assert kb.redis_manager is not None
+    async def test_redis_client_initialized(self, kb):
+        """The knowledge base exposes an initialised Redis client."""
+        assert kb.redis_client is not None
         assert kb._aioredis_client is not None
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Thinking Path

`TestKnowledgeBaseAsyncRedisManagerIntegration` asserted `kb.redis_manager`, an attribute `KnowledgeBase` does not have. `AsyncRedisManager` does not exist anywhere in the codebase — `utils/async_redis_manager.py` was deleted in the Nov 2025 Redis consolidation, and its last compatibility shim was removed by **#12649/#12667**, whose commit message records that it migrated the surviving caller onto `autobot_shared.redis_client`. These tests were simply never cleaned up alongside it.

They did not fail — they **errored at fixture setup**, because the guard read the attribute directly:

```python
if not kb.redis_manager:          # raises; never reaches pytest.skip
    pytest.skip("AsyncRedisManager not available")
```

An error at setup reads like an environment problem, which is why this survived: it looked like "needs a live Redis" rather than "targets a class that was deleted". I mis-read it that way myself for several passes.

Re-pointed rather than retired, per the recommendation on #13657: the intent — that the knowledge base's Redis usage is pooled and survives failures — is still worth covering, and the consolidation was meant to preserve it.

## What Changed

- `kb.redis_manager` → `kb.redis_client`, the surface that exists (`knowledge/base.py:341`, `get_redis_client(database="knowledge")`).
- `test_async_redis_manager_initialized` → `test_redis_client_initialized`.
- The fixture guard now uses `getattr(kb, "redis_client", None)`, so it can actually fire. A bare attribute access is what turned a skip into an error.
- Line 57's stale `assert kb.redis_manager is not None` in a different class, same treatment.
- A docstring recording the provenance, so the class name no longer implies a component that was removed.

`redis_manager` now appears twice in the file, both inside that explanatory docstring.

## Verification

Both directions, on a clean checkout of base with no Redis running:

```
before:  19 skipped, 3 errors
after:   22 skipped, 0 errors
```

The three now skip with `Redis unavailable — these exercise a live connection`.

Worth noting this is not a swallow: the other classes in this same file already skip with `Redis not available` when the connection is absent. The AsyncRedisManager class was the outlier that errored instead, and this makes it consistent with the file's own established pattern.

## Effect on CI

Clears the last 3 errors on `python-suite shard 3/12`. Together with #13656 (which removed that shard's 6 cognifiers failures), shard 3 should now be clean — leaving `shard 6` and its `sys.modules` leak guard (#13651) as the only remaining base red.

## Model Used

Opus 5

Closes #13657
