### PR TITLE
test-infra(leak-guard): report what actually occupies each leaked key (#13651)

### DIFF
--- a/repo_tests/sys_modules_leak_guard.py
+++ b/repo_tests/sys_modules_leak_guard.py
@@ -211,6 +211,28 @@ class _Mutation:
         return _outside_owner_dir(path, path_parents, self.owner_dir, self.owner_ancestors)
 
 
+def _occupant(key: str, expected_obj_id: int) -> str:
+    """Describe whatever currently sits at *key*, for the leak report (#13651).
+
+    The report names the file blamed for a key and the test that witnessed it,
+    but not *what object* is parked there — so a reader cannot tell an
+    unremoved stub from a real module someone re-imported over the top, and
+    every diagnosis of #13651 so far has been an inference about exactly that.
+
+    Cheap and total: this runs only when a leak is already being printed.
+    """
+    module = sys.modules.get(key)
+    if module is None:
+        return "absent-at-report-time"
+
+    same = "same-object" if id(module) == expected_obj_id else "REPLACED-since"
+    kind = type(module).__name__
+    origin = getattr(module, "__file__", None)
+    spec = "spec" if getattr(module, "__spec__", None) is not None else "no-spec"
+    where = origin if origin else "no-__file__"
+    return f"{same}, {kind}, {spec}, {where}"
+
+
 @dataclass(frozen=True)
 class _Leak:
     """A live mutation observed while pytest worked outside its owner."""
@@ -235,6 +257,7 @@ class _Leak:
             "owner": self.mutation.owner,
             "owner_dir_display": self.mutation.owner_dir_display,
             "observed_at": self.observed_at,
+            "occupant": _occupant(self.mutation.key, self.mutation.obj_id),
         }
 
 
@@ -1050,6 +1073,10 @@ def _write_owner_report(terminalreporter: object, owner: str, records: list[dict
         f"{first['owner_dir_display']}/ — first seen at {first['observed_at']}",
         red=True,
     )
+    for record in records[:_KEYS_PER_OWNER]:
+        occupant = record.get("occupant")
+        if occupant:
+            terminalreporter.write_line(f"      {record['key']}: {occupant}", red=True)
     keys = [record["key"] for record in records]
     shown = ", ".join(keys[:_KEYS_PER_OWNER])
     overflow = len(keys) - _KEYS_PER_OWNER


### PR DESCRIPTION
## Thinking Path

Four separate diagnoses of #13651 have been wrong, all of them inferences about the same missing fact: **what object is actually parked at the leaked key**. The report names the file blamed and the test that witnessed it, but not the occupant — so a reader cannot distinguish "the stub was never removed" from "something re-installed one after teardown", and those two point at opposite fixes.

This adds the occupant to the report instead of guessing at it again. It is not scaffolding to be reverted: the information is useful for any leak, not just this one.

## What Changed

`_occupant(key, expected_obj_id)` in `repo_tests/sys_modules_leak_guard.py`, surfaced through `_Leak.as_record()` so it survives the xdist worker→controller hop, and printed one line per key under the existing `LEAK:` heading.

It reports four things: whether the object is the same one the guard recorded or was **replaced since**, its type, whether it carries a `__spec__`, and its `__file__`.

Runs only when a leak is already being printed, so it costs nothing on a green run.

## Verification

Silent when there is nothing to report:

```
python3 -m pytest -q repo_tests/     ->  311 passed
```

Fires with provenance when a leak is real — verified by temporarily removing a known leaker from the baseline, then restoring it:

```
LEAK: autobot-backend/tests/orchestration/test_causal_error_recovery.py leaves 3 sys.modules key(s) ...
      orchestration.causal_error_recovery: REPLACED-since, module, no-spec, <MagicMock id='...'>
      orchestration.causal_error_analyzer: REPLACED-since, module, no-spec, <MagicMock id='...'>
      agent_loop.think_tool:               same-object, module, spec, .../autobot-backend/agent_loop/think_tool.py
```

That output already earns its place beyond #13651: two of those keys hold MagicMock stubs replaced after the guard recorded them, while the third is a **real module with a spec that is still the original object** — a materially different situation the current report cannot express, and which a reader would otherwise lump in with the stubs.

## What this is for

`python-suite shard 6/12` is the only remaining red on the base (2000 passed, 0 test failures, exit 1 from the guard alone). One run with this merged says whether `utils.chromadb_client` is still the stub `services/knowledge/` installed — meaning the package teardown never ran — or has been replaced since, meaning something re-installs it afterwards. Those are the two competing theories, and this reads the answer rather than inferring it.

No fix for the leak itself is included. Deliberately: three fixes were shipped or proposed on reasoning alone and all three were wrong, and I have since added a fourth piece of reasoning — that the `utils/` tests co-own the key — which was also wrong and is retracted on the issue. The next change to that conftest should follow from the output above.

## Model Used

Opus 5

Refs #13651
