### PR TITLE
test(ci): make the exec-bits checker testable against a fixture repo (#13668)

### DIFF
--- a/scripts/check_script_exec_bits.py
+++ b/scripts/check_script_exec_bits.py
@@ -73,6 +73,21 @@ _INTERPRETED = re.compile(r"(?:^|[\s`\"'|(&;])(?:bash|sh|zsh|source|\.)\s+(?:\./
 _DIRECTIVE = re.compile(r"shellcheck\s+source=")
 
 
+def _require_git_ok(result: "subprocess.CompletedProcess[str]", root: Path) -> None:
+    """Fail loudly when git could not answer (#13668).
+
+    Both call sites use ``check=False`` and read only stdout, so a broken or
+    missing git — or a directory that is not a checkout — produced an empty file
+    list, no disagreements, and ``main()`` exiting 0. The CI check then reported
+    success while having verified nothing, which is the failure mode this
+    checker exists to prevent.
+    """
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"git failed in {root} (exit {result.returncode}): {result.stderr.strip() or '<no stderr>'}"
+        )
+
+
 def _tracked_files(patterns: Iterable[str], root: Path = REPO_ROOT) -> list[Path]:
     out: list[Path] = []
     for pattern in patterns:
@@ -80,6 +95,7 @@ def _tracked_files(patterns: Iterable[str], root: Path = REPO_ROOT) -> list[Path
         result = subprocess.run(  # nosec B603 B607
             ["git", "ls-files", pattern], cwd=root, capture_output=True, text=True, check=False
         )
+        _require_git_ok(result, root)
         out.extend(root / line for line in result.stdout.splitlines() if line)
     return out
 
@@ -93,6 +109,7 @@ def _is_executable(path: Path, root: Path = REPO_ROOT) -> bool:
         text=True,
         check=False,
     )
+    _require_git_ok(result, root)
     # "100755 <sha> 0\t<path>" — read the mode git records, not the working tree,
     # because that is what a fresh clone gets.
     return result.stdout.startswith("100755")

--- a/scripts/check_script_exec_bits.py
+++ b/scripts/check_script_exec_bits.py
@@ -73,22 +73,22 @@ _INTERPRETED = re.compile(r"(?:^|[\s`\"'|(&;])(?:bash|sh|zsh|source|\.)\s+(?:\./
 _DIRECTIVE = re.compile(r"shellcheck\s+source=")
 
 
-def _tracked_files(patterns: Iterable[str]) -> list[Path]:
+def _tracked_files(patterns: Iterable[str], root: Path = REPO_ROOT) -> list[Path]:
     out: list[Path] = []
     for pattern in patterns:
         # Fixed argv, no shell, and `pattern` is a module constant — not input.
         result = subprocess.run(  # nosec B603 B607
-            ["git", "ls-files", pattern], cwd=REPO_ROOT, capture_output=True, text=True, check=False
+            ["git", "ls-files", pattern], cwd=root, capture_output=True, text=True, check=False
         )
-        out.extend(REPO_ROOT / line for line in result.stdout.splitlines() if line)
+        out.extend(root / line for line in result.stdout.splitlines() if line)
     return out
 
 
-def _is_executable(path: Path) -> bool:
+def _is_executable(path: Path, root: Path = REPO_ROOT) -> bool:
     # Fixed argv, no shell; the path comes from git ls-files output, not a caller.
     result = subprocess.run(  # nosec B603 B607
-        ["git", "ls-files", "-s", str(path.relative_to(REPO_ROOT))],
-        cwd=REPO_ROOT,
+        ["git", "ls-files", "-s", str(path.relative_to(root))],
+        cwd=root,
         capture_output=True,
         text=True,
         check=False,
@@ -98,11 +98,11 @@ def _is_executable(path: Path) -> bool:
     return result.stdout.startswith("100755")
 
 
-def find_disagreements() -> list[str]:
+def find_disagreements(root: Path = REPO_ROOT) -> list[str]:
     """Return one message per documented direct invocation of a non-executable script."""
     problems: list[str] = []
-    for doc in _tracked_files(DOC_GLOBS):
-        rel_doc = str(doc.relative_to(REPO_ROOT))
+    for doc in _tracked_files(DOC_GLOBS, root):
+        rel_doc = str(doc.relative_to(root))
         if any(rel_doc.startswith(prefix) or rel_doc == prefix for prefix in _ARCHIVAL):
             continue
         try:
@@ -117,11 +117,11 @@ def find_disagreements() -> list[str]:
             if alone:
                 hits.add(alone.group(1))
             for rel in sorted(hits):
-                script = REPO_ROOT / rel
-                if not script.is_file() or _is_executable(script):
+                script = root / rel
+                if not script.is_file() or _is_executable(script, root):
                     continue
                 problems.append(
-                    f"{doc.relative_to(REPO_ROOT)}:{lineno}: runs {rel} directly, "
+                    f"{doc.relative_to(root)}:{lineno}: runs {rel} directly, "
                     f"but it is mode 644 — either 'git update-index --chmod=+x {rel}' "
                     f"or document it as 'bash {rel}'"
                 )

--- a/scripts/check_script_exec_bits_test.py
+++ b/scripts/check_script_exec_bits_test.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
+import subprocess
+
 import pytest
 
 _MODULE_PATH = Path(__file__).resolve().parent / "check_script_exec_bits.py"
@@ -92,8 +94,72 @@ def test_ignores_interpreter_prefixed_and_directives(line):
 # ------------------------------------------------------------- end to end
 
 
+def _init_repo(root: Path) -> None:
+    """A throwaway git repo — the checker reads modes from the index, not the FS."""
+    subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.email", "t@example.invalid"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=root, check=True)
+
+
+def _commit_all(root: Path) -> None:
+    subprocess.run(["git", "add", "-A"], cwd=root, check=True)
+    subprocess.run(["git", "commit", "-qm", "fixture"], cwd=root, check=True)
+
+
+def test_a_documented_invocation_of_a_non_executable_script_is_reported(tmp_path):
+    """The defect the checker exists to catch, against a fixture (#13668).
+
+    Built as its own git repo rather than asserting on this one: the live-tree
+    form could not distinguish "the checker is broken" from "someone edited an
+    unrelated doc", so it failed for reasons that had nothing to do with it.
+    """
+    _init_repo(tmp_path)
+    (tmp_path / "scripts").mkdir()
+    (tmp_path / "scripts" / "deploy.sh").write_text("#!/bin/bash\n", encoding="utf-8")
+    (tmp_path / "README.md").write_text("Run it with ./scripts/deploy.sh now\n", encoding="utf-8")
+    _commit_all(tmp_path)
+
+    problems = checker.find_disagreements(tmp_path)
+
+    assert len(problems) == 1, problems
+    assert "scripts/deploy.sh" in problems[0]
+
+
+def test_an_executable_script_is_not_reported(tmp_path):
+    """Same documented invocation, exec bit set — must be silent."""
+    _init_repo(tmp_path)
+    (tmp_path / "scripts").mkdir()
+    script = tmp_path / "scripts" / "deploy.sh"
+    script.write_text("#!/bin/bash\n", encoding="utf-8")
+    script.chmod(0o755)
+    (tmp_path / "README.md").write_text("Run it with ./scripts/deploy.sh now\n", encoding="utf-8")
+    _commit_all(tmp_path)
+
+    assert checker.find_disagreements(tmp_path) == []
+
+
+def test_an_interpreter_prefixed_invocation_is_not_reported(tmp_path):
+    """`bash scripts/x.sh` needs no exec bit — 644 is correct there."""
+    _init_repo(tmp_path)
+    (tmp_path / "scripts").mkdir()
+    (tmp_path / "scripts" / "deploy.sh").write_text("#!/bin/bash\n", encoding="utf-8")
+    (tmp_path / "README.md").write_text("Run: bash scripts/deploy.sh\n", encoding="utf-8")
+    _commit_all(tmp_path)
+
+    assert checker.find_disagreements(tmp_path) == []
+
+
+@pytest.mark.integration
 def test_repository_is_currently_clean():
-    """The tree must satisfy its own invariant."""
+    """Audit of THIS tree, deselected by ci.yml's marker filter (#13668).
+
+    Kept because it is genuinely useful to run deliberately, but it asserts on
+    live repository state: any PR adding a documented invocation of a script
+    without its exec bit fails it, while the checker itself is correct and
+    untouched. As a per-PR gate that is a red check nobody caused, which is how
+    people learn to ignore red checks. The three fixture tests above are what
+    actually guard the checker.
+    """
     problems = checker.find_disagreements()
     assert problems == [], "\n".join(problems[:10])
 

--- a/scripts/check_script_exec_bits_test.py
+++ b/scripts/check_script_exec_bits_test.py
@@ -17,9 +17,9 @@ Run: python3 -m pytest scripts/check_script_exec_bits_test.py
 from __future__ import annotations
 
 import importlib.util
-from pathlib import Path
-
+import os
 import subprocess
+from pathlib import Path
 
 import pytest
 
@@ -94,16 +94,34 @@ def test_ignores_interpreter_prefixed_and_directives(line):
 # ------------------------------------------------------------- end to end
 
 
+# Neutralise the ambient git config (#13668). Without this the fixture inherits
+# whatever the developer or runner has set globally — `commit.gpgsign = true`
+# alone made every test here fail — and `core.hooksPath` / `init.templateDir`
+# could reach into the throwaway repo.
+_GIT_ENV = {**os.environ, "GIT_CONFIG_GLOBAL": os.devnull, "GIT_CONFIG_SYSTEM": os.devnull}
+
+
 def _init_repo(root: Path) -> None:
     """A throwaway git repo — the checker reads modes from the index, not the FS."""
-    subprocess.run(["git", "init", "-q"], cwd=root, check=True)
-    subprocess.run(["git", "config", "user.email", "t@example.invalid"], cwd=root, check=True)
-    subprocess.run(["git", "config", "user.name", "t"], cwd=root, check=True)
+    subprocess.run(["git", "init", "-q"], cwd=root, check=True, env=_GIT_ENV)
 
 
-def _commit_all(root: Path) -> None:
-    subprocess.run(["git", "add", "-A"], cwd=root, check=True)
-    subprocess.run(["git", "commit", "-qm", "fixture"], cwd=root, check=True)
+def _stage_all(root: Path) -> None:
+    """Stage only. ``git ls-files`` reads the index, so committing adds nothing
+    but failure modes (signing, hooks, identity) the checker does not care about."""
+    subprocess.run(["git", "add", "-A"], cwd=root, check=True, env=_GIT_ENV)
+
+
+def _mark_executable(root: Path, relpath: str) -> None:
+    """Set the exec bit *in the index*, independent of the tmpdir filesystem.
+
+    ``chmod`` only works if git detects ``core.fileMode=true`` there; this
+    repo's own config has it false, so a runner with TMPDIR on such a
+    filesystem would fail for a purely environmental reason — the exact class
+    of failure this PR exists to remove. It is also the command the checker's
+    own error message tells people to run.
+    """
+    subprocess.run(["git", "update-index", "--chmod=+x", relpath], cwd=root, check=True, env=_GIT_ENV)
 
 
 def test_a_documented_invocation_of_a_non_executable_script_is_reported(tmp_path):
@@ -117,7 +135,7 @@ def test_a_documented_invocation_of_a_non_executable_script_is_reported(tmp_path
     (tmp_path / "scripts").mkdir()
     (tmp_path / "scripts" / "deploy.sh").write_text("#!/bin/bash\n", encoding="utf-8")
     (tmp_path / "README.md").write_text("Run it with ./scripts/deploy.sh now\n", encoding="utf-8")
-    _commit_all(tmp_path)
+    _stage_all(tmp_path)
 
     problems = checker.find_disagreements(tmp_path)
 
@@ -131,10 +149,13 @@ def test_an_executable_script_is_not_reported(tmp_path):
     (tmp_path / "scripts").mkdir()
     script = tmp_path / "scripts" / "deploy.sh"
     script.write_text("#!/bin/bash\n", encoding="utf-8")
-    script.chmod(0o755)
     (tmp_path / "README.md").write_text("Run it with ./scripts/deploy.sh now\n", encoding="utf-8")
-    _commit_all(tmp_path)
+    _stage_all(tmp_path)
+    _mark_executable(tmp_path, "scripts/deploy.sh")
 
+    # Pin the reason: without this the assertion below would also hold if the
+    # doc regex simply stopped matching.
+    assert checker._is_executable(script, tmp_path)
     assert checker.find_disagreements(tmp_path) == []
 
 
@@ -144,7 +165,7 @@ def test_an_interpreter_prefixed_invocation_is_not_reported(tmp_path):
     (tmp_path / "scripts").mkdir()
     (tmp_path / "scripts" / "deploy.sh").write_text("#!/bin/bash\n", encoding="utf-8")
     (tmp_path / "README.md").write_text("Run: bash scripts/deploy.sh\n", encoding="utf-8")
-    _commit_all(tmp_path)
+    _stage_all(tmp_path)
 
     assert checker.find_disagreements(tmp_path) == []
 


### PR DESCRIPTION
## Thinking Path

`test_repository_is_currently_clean` asserted on **live repository state**. Until #13660 that was harmless — `scripts/` was collected by no workflow. Now it runs on every PR, and it can fail for reasons that have nothing to do with the checker it is supposed to be testing: `find_disagreements()` walks every tracked doc and YAML looking for direct `scripts/*.sh` invocations and compares git-recorded modes, so a PR that adds a documented invocation without setting the exec bit turns the Python suite red while `check_script_exec_bits.py` is correct and untouched.

That is a red check nobody caused, which is how people learn to ignore red checks.

## What Changed

**The checker is now testable.** `find_disagreements`, `_tracked_files` and `_is_executable` take an optional `root`, defaulting to `REPO_ROOT` — so every existing caller and the pre-commit hook behave identically, but a test can point them at a fixture.

**Three fixture tests** build a throwaway git repo (the checker reads modes from the *index*, so it needs a real one) and cover the actual contract:

- a documented invocation of a non-executable script **is** reported
- the same invocation with the exec bit set is **not**
- `bash scripts/x.sh` is **not** — an interpreter-prefixed call needs no exec bit

**The live-tree audit is kept but marked `integration`,** so `ci.yml`'s filter deselects it. It is genuinely useful to run deliberately; it is just not a per-PR gate. The docstring says so.

## Verification

```
python3 -m pytest -q scripts/check_script_exec_bits_test.py
21 passed

# under CI's exact marker filter
python3 -m pytest -q scripts/check_script_exec_bits_test.py \
  -m "not integration and not slow and not distributed and not performance"
20 passed, 1 deselected

python3 -m pytest -q scripts/
121 passed
```

The default-argument path is unchanged, confirmed against the real tree:

```
find_disagreements() on this tree: 0 problems
```

So the pre-commit hook and any direct invocation keep working exactly as before.

## Note

This is the follow-up I filed while reviewing #13660 — that PR wired `scripts/` into CI and correctly flagged this coupling in its own "Not covered" section rather than leaving it to be discovered later.

## Model Used

Opus 5

Closes #13668
