### PR TITLE
fix(test-infra): unload only the stubs the knowledge tests installed (#13651)

### DIFF
--- a/autobot-backend/services/knowledge/conftest.py
+++ b/autobot-backend/services/knowledge/conftest.py
@@ -109,13 +109,17 @@ def _reinstall_module_stubs(request):
 
     for name in unloaded:
         previous = displaced[name]
-        if previous is _MISSING:
-            sys.modules.pop(name, None)
-        else:
+        # Put back only a *genuine* module. Restoring a stub this fixture happened
+        # to displace would re-leak it to everything collected afterwards, which is
+        # the failure the unconditional pop was there to prevent in the first place.
+        genuine = previous is not _MISSING and getattr(previous, "__spec__", None) is not None
+        if genuine:
             sys.modules[name] = previous
+        else:
+            sys.modules.pop(name, None)
         parent_name, _, leaf = name.rpartition(".")
         parent = sys.modules.get(parent_name) if parent_name else None
-        if previous is not _MISSING and parent is not None:
+        if genuine and parent is not None:
             setattr(parent, leaf, previous)
         elif restored_parent_attr and parent is not None and hasattr(parent, leaf):
             delattr(parent, leaf)

--- a/autobot-backend/services/knowledge/conftest.py
+++ b/autobot-backend/services/knowledge/conftest.py
@@ -87,8 +87,15 @@ def _reinstall_module_stubs(request):
         yield
         return
 
+    # What each name held before this fixture overwrote it (#13651). Popping
+    # blindly on teardown destroyed a *genuine* module whenever an earlier test
+    # in the session had already imported it for real: the key went absent, the
+    # next importer built a second module object, and the leak guard reported
+    # the swap as "replaced" — genuine displaced by genuine.
+    displaced: Dict[str, Any] = {}
     restored_parent_attr = False
     for name, module in unloaded.items():
+        displaced[name] = sys.modules.get(name, _MISSING)
         sys.modules[name] = module
         # Re-bind on the parent package too — patch() resolves "utils.x.Y" as
         # getattr(sys.modules["utils"], "x") (#11532, #12463).
@@ -101,10 +108,16 @@ def _reinstall_module_stubs(request):
     yield
 
     for name in unloaded:
-        sys.modules.pop(name, None)
+        previous = displaced[name]
+        if previous is _MISSING:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = previous
         parent_name, _, leaf = name.rpartition(".")
         parent = sys.modules.get(parent_name) if parent_name else None
-        if restored_parent_attr and parent is not None and hasattr(parent, leaf):
+        if previous is not _MISSING and parent is not None:
+            setattr(parent, leaf, previous)
+        elif restored_parent_attr and parent is not None and hasattr(parent, leaf):
             delattr(parent, leaf)
 
 

--- a/autobot-backend/services/knowledge/contradiction_detector.py
+++ b/autobot-backend/services/knowledge/contradiction_detector.py
@@ -129,7 +129,14 @@ def _group_chunks(chunks: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]
             continue
         # Pick the most frequent keyword as the group label so chunks that
         # share a common topic word land in the same bucket.
-        label = max(kws, key=lambda k: freq.get(k, 0))
+        #
+        # #13682: the keyword itself breaks frequency ties. ``kws`` is a
+        # frozenset, so without a total order ``max`` returned whichever element
+        # set iteration happened to yield first — which varies with
+        # PYTHONHASHSEED. Two chunks tying on frequency could then be labelled
+        # differently, land in different groups, and never be compared, so the
+        # same KB produced a different contradiction report from run to run.
+        label = max(kws, key=lambda k: (freq.get(k, 0), k))
         groups.setdefault(label, []).append(chunk)
     return groups
 

--- a/autobot-backend/services/knowledge/test_analyzer_service.py
+++ b/autobot-backend/services/knowledge/test_analyzer_service.py
@@ -30,6 +30,7 @@ import pytest
 
 _STUBS: dict = {}
 
+
 def _make_stub(name: str) -> types.ModuleType:
     mod = types.ModuleType(name)
     mod.__path__ = []
@@ -79,6 +80,7 @@ from services.knowledge.analyzer_service import (  # noqa: E402
     get_analyzer_service,
 )
 
+
 # #13435: the stubs above were needed to import analyzer_service, and they are
 # needed again while this module's tests run, because those tests patch through
 # dotted paths such as ``utils.async_chromadb_client.get_async_chromadb_client``
@@ -102,9 +104,7 @@ def _is_stub(name: str) -> bool:
 
 
 _STUBS_UNLOADED_AFTER_IMPORT = {
-    name: sys.modules.pop(name)
-    for name in ("utils.chromadb_client", "utils.async_chromadb_client")
-    if _is_stub(name)
+    name: sys.modules.pop(name) for name in ("utils.chromadb_client", "utils.async_chromadb_client") if _is_stub(name)
 }
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/services/knowledge/test_analyzer_service.py
+++ b/autobot-backend/services/knowledge/test_analyzer_service.py
@@ -29,21 +29,13 @@ import pytest
 # ---------------------------------------------------------------------------
 
 _STUBS: dict = {}
-# #13651: only unload what this module actually installed. ``setdefault``
-# is a no-op when the genuine module is already imported, and popping
-# regardless destroyed it — the next importer built a second module object,
-# breaking identity for anything holding the first.
-_OWNED_STUBS: set = set()
-
 
 def _make_stub(name: str) -> types.ModuleType:
     mod = types.ModuleType(name)
     mod.__path__ = []
     mod.__package__ = name
     _STUBS[name] = mod
-    if name not in sys.modules:
-        sys.modules[name] = mod
-        _OWNED_STUBS.add(name)
+    sys.modules.setdefault(name, mod)
     return mod
 
 
@@ -99,10 +91,20 @@ from services.knowledge.analyzer_service import (  # noqa: E402
 # these exact objects back for the duration of this module's tests and removes
 # them afterwards. The same objects, not fresh ones — analyzer_service captured
 # references at import and a different stub would not be the module it holds.
+# #13651: unload the name only when a *stub* occupies it. ``setdefault`` is a
+# no-op once the genuine module is imported, and the old unconditional pop
+# then destroyed that genuine module — the next importer built a second
+# object, breaking identity for everything holding the first. Keying on the
+# occupant rather than on "did I install it" also keeps the original
+# behaviour of clearing a stub another module in this directory left behind.
+def _is_stub(name: str) -> bool:
+    return name in sys.modules and getattr(sys.modules[name], "__spec__", None) is None
+
+
 _STUBS_UNLOADED_AFTER_IMPORT = {
     name: sys.modules.pop(name)
     for name in ("utils.chromadb_client", "utils.async_chromadb_client")
-    if name in _OWNED_STUBS
+    if _is_stub(name)
 }
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/services/knowledge/test_analyzer_service.py
+++ b/autobot-backend/services/knowledge/test_analyzer_service.py
@@ -30,6 +30,7 @@ import pytest
 
 _STUBS: dict = {}
 
+
 def _make_stub(name: str) -> types.ModuleType:
     mod = types.ModuleType(name)
     mod.__path__ = []
@@ -91,20 +92,10 @@ from services.knowledge.analyzer_service import (  # noqa: E402
 # these exact objects back for the duration of this module's tests and removes
 # them afterwards. The same objects, not fresh ones — analyzer_service captured
 # references at import and a different stub would not be the module it holds.
-# #13651: unload the name only when a *stub* occupies it. ``setdefault`` is a
-# no-op once the genuine module is imported, and the old unconditional pop
-# then destroyed that genuine module — the next importer built a second
-# object, breaking identity for everything holding the first. Keying on the
-# occupant rather than on "did I install it" also keeps the original
-# behaviour of clearing a stub another module in this directory left behind.
-def _is_stub(name: str) -> bool:
-    return name in sys.modules and getattr(sys.modules[name], "__spec__", None) is None
-
-
 _STUBS_UNLOADED_AFTER_IMPORT = {
     name: sys.modules.pop(name)
     for name in ("utils.chromadb_client", "utils.async_chromadb_client")
-    if _is_stub(name)
+    if name in sys.modules
 }
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/services/knowledge/test_analyzer_service.py
+++ b/autobot-backend/services/knowledge/test_analyzer_service.py
@@ -29,6 +29,11 @@ import pytest
 # ---------------------------------------------------------------------------
 
 _STUBS: dict = {}
+# #13651: only unload what this module actually installed. ``setdefault``
+# is a no-op when the genuine module is already imported, and popping
+# regardless destroyed it — the next importer built a second module object,
+# breaking identity for anything holding the first.
+_OWNED_STUBS: set = set()
 
 
 def _make_stub(name: str) -> types.ModuleType:
@@ -36,7 +41,9 @@ def _make_stub(name: str) -> types.ModuleType:
     mod.__path__ = []
     mod.__package__ = name
     _STUBS[name] = mod
-    sys.modules.setdefault(name, mod)
+    if name not in sys.modules:
+        sys.modules[name] = mod
+        _OWNED_STUBS.add(name)
     return mod
 
 
@@ -95,7 +102,7 @@ from services.knowledge.analyzer_service import (  # noqa: E402
 _STUBS_UNLOADED_AFTER_IMPORT = {
     name: sys.modules.pop(name)
     for name in ("utils.chromadb_client", "utils.async_chromadb_client")
-    if name in sys.modules
+    if name in _OWNED_STUBS
 }
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/services/knowledge/test_analyzer_service.py
+++ b/autobot-backend/services/knowledge/test_analyzer_service.py
@@ -85,7 +85,19 @@ _spec = importlib.util.spec_from_file_location("services.knowledge.analyzer_serv
 assert _spec and _spec.loader, "Could not load analyzer_service spec"
 _analyzer_mod = importlib.util.module_from_spec(_spec)
 sys.modules["services.knowledge.analyzer_service"] = _analyzer_mod
-_spec.loader.exec_module(_analyzer_mod)  # type: ignore[union-attr]
+try:
+    _spec.loader.exec_module(_analyzer_mod)  # type: ignore[union-attr]
+except BaseException:  # noqa: BLE001 - re-raised below
+    # #13651: a failed import must not leave our stub installed for the rest of
+    # the session. The guard's own advice is to install and remove in the same
+    # try/finally; without this, an ImportError here is strictly worse than the
+    # old behaviour, which left the genuine module untouched.
+    for _n, _prev in _DISPLACED_BY_STUB.items():
+        if _prev is not _STUB_MISSING:
+            sys.modules[_n] = _prev
+        else:
+            sys.modules.pop(_n, None)
+    raise
 
 from services.knowledge.analyzer_service import (  # noqa: E402
     AnalyzerService,
@@ -113,9 +125,20 @@ _STUBS_UNLOADED_AFTER_IMPORT = {
 
 # Put back whatever those stubs displaced (#13651): a genuine module imported
 # before this one must survive it as the same, unmutated object.
+#
+# The parent attribute is restored alongside the ``sys.modules`` entry. They are
+# two separate channels -- ``mock.patch("utils.async_chromadb_client.X")``
+# resolves via ``getattr(sys.modules["utils"], ...)`` (#11532, #12463), while
+# ``import utils.async_chromadb_client`` reads the key -- and letting them
+# disagree would mean patching a stub while the code under test holds the real
+# module.
 for _n, _prev in _DISPLACED_BY_STUB.items():
     if _prev is not _STUB_MISSING:
         sys.modules[_n] = _prev
+        _parent_name, _, _leaf = _n.rpartition(".")
+        _parent = sys.modules.get(_parent_name) if _parent_name else None
+        if _parent is not None:
+            setattr(_parent, _leaf, _prev)
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/autobot-backend/services/knowledge/test_analyzer_service.py
+++ b/autobot-backend/services/knowledge/test_analyzer_service.py
@@ -29,6 +29,7 @@ import pytest
 # ---------------------------------------------------------------------------
 
 _STUBS: dict = {}
+_STUB_MISSING = object()
 
 
 def _make_stub(name: str) -> types.ModuleType:
@@ -55,6 +56,18 @@ _chromadb_stub = _make_stub("utils.chromadb_client")
 # when a sibling test module registered this name first the returned stub is a
 # dangling copy that production code never sees. Read the registered module back.
 _make_stub("utils.async_chromadb_client")
+
+# #13651: force *our* stub in for the two chromadb names, remembering what it
+# displaced — ``setdefault`` is a no-op once the genuine module is imported, and
+# the mutations below must not land on that genuine module.
+_DISPLACED_BY_STUB = {}
+for _n in ("utils.chromadb_client", "utils.async_chromadb_client"):
+    _registered = sys.modules.get(_n, _STUB_MISSING)
+    if _registered is not _STUBS[_n]:
+        # Only when something else holds the name — rewriting our own stub back
+        # over itself is a no-op the leak guard would still record as a mutation.
+        _DISPLACED_BY_STUB[_n] = _registered
+        sys.modules[_n] = _STUBS[_n]
 _async_chromadb_stub = sys.modules["utils.async_chromadb_client"]
 # Injecting a submodule straight into sys.modules does not bind it on the
 # parent package, so mock.patch("utils.async_chromadb_client....") — used by
@@ -97,6 +110,12 @@ _STUBS_UNLOADED_AFTER_IMPORT = {
     for name in ("utils.chromadb_client", "utils.async_chromadb_client")
     if name in sys.modules
 }
+
+# Put back whatever those stubs displaced (#13651): a genuine module imported
+# before this one must survive it as the same, unmutated object.
+for _n, _prev in _DISPLACED_BY_STUB.items():
+    if _prev is not _STUB_MISSING:
+        sys.modules[_n] = _prev
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/autobot-backend/services/knowledge/test_contradiction_detector.py
+++ b/autobot-backend/services/knowledge/test_contradiction_detector.py
@@ -145,6 +145,25 @@ class TestGroupChunks:
         # At least two groups expected (python group + other)
         assert len(groups) >= 1
 
+    def test_frequency_ties_break_on_the_keyword(self) -> None:
+        """#13682: tied keywords must group identically regardless of hash seed.
+
+        ``kws`` is a frozenset, so ``max`` without a total order returned
+        whichever element set iteration yielded first. Two chunks tying on
+        frequency could be labelled differently, land in different groups and
+        never be compared — the detector then reported no contradiction for
+        input that contained one, differently from run to run.
+        """
+        # "redis" and "data" both occur in both chunks, so their counts tie.
+        chunks = [
+            {"text": "redis caches data redis redis"},
+            {"text": "redis persists data redis redis"},
+        ]
+        groups = _group_chunks(chunks)
+        assert len(groups) == 1, f"tied keywords split across groups: {sorted(groups)}"
+        # The tie-break is the keyword itself, so the label is predictable.
+        assert sorted(groups) == ["redis"]
+
     def test_empty_chunks_go_to_ungrouped(self) -> None:
         chunks = [{"text": ""}, {"text": ""}]
         groups = _group_chunks(chunks)

--- a/autobot-backend/services/knowledge/test_kb_synthesizer.py
+++ b/autobot-backend/services/knowledge/test_kb_synthesizer.py
@@ -29,21 +29,13 @@ import pytest
 # ---------------------------------------------------------------------------
 
 _STUBS: dict = {}
-# #13651: only unload what this module actually installed. ``setdefault``
-# is a no-op when the genuine module is already imported, and popping
-# regardless destroyed it — the next importer built a second module object,
-# breaking identity for anything holding the first.
-_OWNED_STUBS: set = set()
-
 
 def _make_stub(name: str) -> types.ModuleType:
     mod = types.ModuleType(name)
     mod.__path__ = []
     mod.__package__ = name
     _STUBS[name] = mod
-    if name not in sys.modules:
-        sys.modules[name] = mod
-        _OWNED_STUBS.add(name)
+    sys.modules.setdefault(name, mod)
     return mod
 
 
@@ -93,10 +85,20 @@ from services.knowledge.kb_synthesizer import (  # noqa: E402
 # module in the worker, which is how ``utils`` and its children escaped this
 # directory. ``_reinstall_module_stubs`` in this package's conftest puts these
 # exact objects back around this module's tests and removes them afterwards.
+# #13651: unload the name only when a *stub* occupies it. ``setdefault`` is a
+# no-op once the genuine module is imported, and the old unconditional pop
+# then destroyed that genuine module — the next importer built a second
+# object, breaking identity for everything holding the first. Keying on the
+# occupant rather than on "did I install it" also keeps the original
+# behaviour of clearing a stub another module in this directory left behind.
+def _is_stub(name: str) -> bool:
+    return name in sys.modules and getattr(sys.modules[name], "__spec__", None) is None
+
+
 _STUBS_UNLOADED_AFTER_IMPORT = {
     name: sys.modules.pop(name)
     for name in ("utils.chromadb_client", "utils.async_chromadb_client")
-    if name in _OWNED_STUBS
+    if _is_stub(name)
 }
 
 # Private static helpers — in Python 3.10+ staticmethods are plain functions on the class

--- a/autobot-backend/services/knowledge/test_kb_synthesizer.py
+++ b/autobot-backend/services/knowledge/test_kb_synthesizer.py
@@ -30,6 +30,7 @@ import pytest
 
 _STUBS: dict = {}
 
+
 def _make_stub(name: str) -> types.ModuleType:
     mod = types.ModuleType(name)
     mod.__path__ = []
@@ -79,6 +80,7 @@ from services.knowledge.kb_synthesizer import (  # noqa: E402
     get_kb_synthesizer,
 )
 
+
 # #13435: see the matching note in test_analyzer_service.py. The stubs were
 # needed to import kb_synthesizer and are needed again while this module's tests
 # run, but not in between — and "in between" is when pytest imports every other
@@ -96,9 +98,7 @@ def _is_stub(name: str) -> bool:
 
 
 _STUBS_UNLOADED_AFTER_IMPORT = {
-    name: sys.modules.pop(name)
-    for name in ("utils.chromadb_client", "utils.async_chromadb_client")
-    if _is_stub(name)
+    name: sys.modules.pop(name) for name in ("utils.chromadb_client", "utils.async_chromadb_client") if _is_stub(name)
 }
 
 # Private static helpers — in Python 3.10+ staticmethods are plain functions on the class

--- a/autobot-backend/services/knowledge/test_kb_synthesizer.py
+++ b/autobot-backend/services/knowledge/test_kb_synthesizer.py
@@ -29,6 +29,11 @@ import pytest
 # ---------------------------------------------------------------------------
 
 _STUBS: dict = {}
+# #13651: only unload what this module actually installed. ``setdefault``
+# is a no-op when the genuine module is already imported, and popping
+# regardless destroyed it — the next importer built a second module object,
+# breaking identity for anything holding the first.
+_OWNED_STUBS: set = set()
 
 
 def _make_stub(name: str) -> types.ModuleType:
@@ -36,7 +41,9 @@ def _make_stub(name: str) -> types.ModuleType:
     mod.__path__ = []
     mod.__package__ = name
     _STUBS[name] = mod
-    sys.modules.setdefault(name, mod)
+    if name not in sys.modules:
+        sys.modules[name] = mod
+        _OWNED_STUBS.add(name)
     return mod
 
 
@@ -89,7 +96,7 @@ from services.knowledge.kb_synthesizer import (  # noqa: E402
 _STUBS_UNLOADED_AFTER_IMPORT = {
     name: sys.modules.pop(name)
     for name in ("utils.chromadb_client", "utils.async_chromadb_client")
-    if name in sys.modules
+    if name in _OWNED_STUBS
 }
 
 # Private static helpers — in Python 3.10+ staticmethods are plain functions on the class

--- a/autobot-backend/services/knowledge/test_kb_synthesizer.py
+++ b/autobot-backend/services/knowledge/test_kb_synthesizer.py
@@ -29,6 +29,7 @@ import pytest
 # ---------------------------------------------------------------------------
 
 _STUBS: dict = {}
+_STUB_MISSING = object()
 
 
 def _make_stub(name: str) -> types.ModuleType:
@@ -52,6 +53,20 @@ _chromadb_stub = _make_stub("utils.chromadb_client")
 # when a sibling test module registered this name first the returned stub is a
 # dangling copy that production code never sees. Read the registered module back.
 _make_stub("utils.async_chromadb_client")
+
+# #13651: force *our* stub in for the two chromadb names, remembering what it
+# displaced. ``setdefault`` is a no-op once the genuine module is imported, and
+# the lines just below write AsyncMocks onto whatever is registered -- which was
+# the genuine module. Installing our own object means the mutations land on the
+# stub; the restore after the import puts the real module back untouched.
+_DISPLACED_BY_STUB = {}
+for _n in ("utils.chromadb_client", "utils.async_chromadb_client"):
+    _registered = sys.modules.get(_n, _STUB_MISSING)
+    if _registered is not _STUBS[_n]:
+        # Only when something else holds the name — rewriting our own stub back
+        # over itself is a no-op the leak guard would still record as a mutation.
+        _DISPLACED_BY_STUB[_n] = _registered
+        sys.modules[_n] = _STUBS[_n]
 _async_chromadb_stub = sys.modules["utils.async_chromadb_client"]
 # Injecting a submodule straight into sys.modules does not bind it on the
 # parent package, so mock.patch("utils.async_chromadb_client....") — used by
@@ -91,6 +106,12 @@ _STUBS_UNLOADED_AFTER_IMPORT = {
     for name in ("utils.chromadb_client", "utils.async_chromadb_client")
     if name in sys.modules
 }
+
+# Put back whatever those stubs displaced (#13651): a genuine module imported
+# before this one must survive it as the same, unmutated object.
+for _n, _prev in _DISPLACED_BY_STUB.items():
+    if _prev is not _STUB_MISSING:
+        sys.modules[_n] = _prev
 
 # Private static helpers — in Python 3.10+ staticmethods are plain functions on the class
 _cluster_id = KBSynthesizer._cluster_id  # type: ignore[attr-defined]

--- a/autobot-backend/services/knowledge/test_kb_synthesizer.py
+++ b/autobot-backend/services/knowledge/test_kb_synthesizer.py
@@ -84,7 +84,19 @@ _spec = importlib.util.spec_from_file_location("services.knowledge.kb_synthesize
 assert _spec and _spec.loader, "Could not load kb_synthesizer spec"
 _kb_synth_mod = importlib.util.module_from_spec(_spec)
 sys.modules["services.knowledge.kb_synthesizer"] = _kb_synth_mod
-_spec.loader.exec_module(_kb_synth_mod)  # type: ignore[union-attr]
+try:
+    _spec.loader.exec_module(_kb_synth_mod)  # type: ignore[union-attr]
+except BaseException:  # noqa: BLE001 - re-raised below
+    # #13651: a failed import must not leave our stub installed for the rest of
+    # the session. The guard's own advice is to install and remove in the same
+    # try/finally; without this, an ImportError here is strictly worse than the
+    # old behaviour, which left the genuine module untouched.
+    for _n, _prev in _DISPLACED_BY_STUB.items():
+        if _prev is not _STUB_MISSING:
+            sys.modules[_n] = _prev
+        else:
+            sys.modules.pop(_n, None)
+    raise
 
 # Expose the module as an attribute on the package stub so patch() can resolve it
 if "services.knowledge" in sys.modules:
@@ -109,9 +121,20 @@ _STUBS_UNLOADED_AFTER_IMPORT = {
 
 # Put back whatever those stubs displaced (#13651): a genuine module imported
 # before this one must survive it as the same, unmutated object.
+#
+# The parent attribute is restored alongside the ``sys.modules`` entry. They are
+# two separate channels -- ``mock.patch("utils.async_chromadb_client.X")``
+# resolves via ``getattr(sys.modules["utils"], ...)`` (#11532, #12463), while
+# ``import utils.async_chromadb_client`` reads the key -- and letting them
+# disagree would mean patching a stub while the code under test holds the real
+# module.
 for _n, _prev in _DISPLACED_BY_STUB.items():
     if _prev is not _STUB_MISSING:
         sys.modules[_n] = _prev
+        _parent_name, _, _leaf = _n.rpartition(".")
+        _parent = sys.modules.get(_parent_name) if _parent_name else None
+        if _parent is not None:
+            setattr(_parent, _leaf, _prev)
 
 # Private static helpers — in Python 3.10+ staticmethods are plain functions on the class
 _cluster_id = KBSynthesizer._cluster_id  # type: ignore[attr-defined]

--- a/autobot-backend/services/knowledge/test_kb_synthesizer.py
+++ b/autobot-backend/services/knowledge/test_kb_synthesizer.py
@@ -30,6 +30,7 @@ import pytest
 
 _STUBS: dict = {}
 
+
 def _make_stub(name: str) -> types.ModuleType:
     mod = types.ModuleType(name)
     mod.__path__ = []
@@ -85,20 +86,10 @@ from services.knowledge.kb_synthesizer import (  # noqa: E402
 # module in the worker, which is how ``utils`` and its children escaped this
 # directory. ``_reinstall_module_stubs`` in this package's conftest puts these
 # exact objects back around this module's tests and removes them afterwards.
-# #13651: unload the name only when a *stub* occupies it. ``setdefault`` is a
-# no-op once the genuine module is imported, and the old unconditional pop
-# then destroyed that genuine module — the next importer built a second
-# object, breaking identity for everything holding the first. Keying on the
-# occupant rather than on "did I install it" also keeps the original
-# behaviour of clearing a stub another module in this directory left behind.
-def _is_stub(name: str) -> bool:
-    return name in sys.modules and getattr(sys.modules[name], "__spec__", None) is None
-
-
 _STUBS_UNLOADED_AFTER_IMPORT = {
     name: sys.modules.pop(name)
     for name in ("utils.chromadb_client", "utils.async_chromadb_client")
-    if _is_stub(name)
+    if name in sys.modules
 }
 
 # Private static helpers — in Python 3.10+ staticmethods are plain functions on the class

--- a/autobot-backend/services/knowledge/test_lineage_service.py
+++ b/autobot-backend/services/knowledge/test_lineage_service.py
@@ -41,6 +41,7 @@ from services.knowledge.lineage_service import (  # noqa: E402
     get_lineage_service,
 )
 
+
 # #13435: see the matching note in test_analyzer_service.py. ``utils.chromadb_client``
 # is the one stub above that escapes this directory — it is not needed after the
 # import, and leaving it installed poisoned utils/chromadb_auth_test.py and
@@ -57,9 +58,7 @@ def _is_stub(name: str) -> bool:
     return name in sys.modules and getattr(sys.modules[name], "__spec__", None) is None
 
 
-_STUBS_UNLOADED_AFTER_IMPORT = {
-    name: sys.modules.pop(name) for name in ("utils.chromadb_client",) if _is_stub(name)
-}
+_STUBS_UNLOADED_AFTER_IMPORT = {name: sys.modules.pop(name) for name in ("utils.chromadb_client",) if _is_stub(name)}
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/autobot-backend/services/knowledge/test_lineage_service.py
+++ b/autobot-backend/services/knowledge/test_lineage_service.py
@@ -22,6 +22,12 @@ import pytest
 # Stub heavy dependencies before importing lineage_service
 # ---------------------------------------------------------------------------
 
+# #13651: keep hold of the stub objects this module installs. The install below
+# is already guarded, so a genuine module is never displaced — but the unload
+# used to pop the name regardless, deleting a real module it never installed and
+# forcing the next importer to build a second one.
+_OWN_STUBS: dict = {}
+
 for _mod in (
     "autobot_shared",
     "autobot_shared.redis_client",
@@ -34,6 +40,7 @@ for _mod in (
         stub.__path__ = []  # type: ignore[attr-defined]
         stub.__package__ = _mod
         sys.modules[_mod] = stub
+        _OWN_STUBS[_mod] = stub
 
 from services.knowledge.lineage_service import (  # noqa: E402
     LineageService,
@@ -48,7 +55,9 @@ from services.knowledge.lineage_service import (  # noqa: E402
 # ``_reinstall_module_stubs`` in this package's conftest puts it back around this
 # module's own tests and removes it afterwards.
 _STUBS_UNLOADED_AFTER_IMPORT = {
-    name: sys.modules.pop(name) for name in ("utils.chromadb_client",) if name in sys.modules
+    name: sys.modules.pop(name)
+    for name in ("utils.chromadb_client",)
+    if sys.modules.get(name) is _OWN_STUBS.get(name) is not None
 }
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/services/knowledge/test_lineage_service.py
+++ b/autobot-backend/services/knowledge/test_lineage_service.py
@@ -47,18 +47,8 @@ from services.knowledge.lineage_service import (  # noqa: E402
 # utils/chromadb_client_cache_key_test.py, which pass alone and failed in CI.
 # ``_reinstall_module_stubs`` in this package's conftest puts it back around this
 # module's own tests and removes it afterwards.
-# #13651: unload the name only when a *stub* occupies it. ``setdefault`` is a
-# no-op once the genuine module is imported, and the old unconditional pop
-# then destroyed that genuine module — the next importer built a second
-# object, breaking identity for everything holding the first. Keying on the
-# occupant rather than on "did I install it" also keeps the original
-# behaviour of clearing a stub another module in this directory left behind.
-def _is_stub(name: str) -> bool:
-    return name in sys.modules and getattr(sys.modules[name], "__spec__", None) is None
-
-
 _STUBS_UNLOADED_AFTER_IMPORT = {
-    name: sys.modules.pop(name) for name in ("utils.chromadb_client",) if _is_stub(name)
+    name: sys.modules.pop(name) for name in ("utils.chromadb_client",) if name in sys.modules
 }
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/services/knowledge/test_lineage_service.py
+++ b/autobot-backend/services/knowledge/test_lineage_service.py
@@ -22,10 +22,6 @@ import pytest
 # Stub heavy dependencies before importing lineage_service
 # ---------------------------------------------------------------------------
 
-# #13651: only unload what this module actually installed — popping a genuine
-# module it never installed destroyed it for every later importer.
-_OWNED_STUBS: set = set()
-
 for _mod in (
     "autobot_shared",
     "autobot_shared.redis_client",
@@ -38,7 +34,6 @@ for _mod in (
         stub.__path__ = []  # type: ignore[attr-defined]
         stub.__package__ = _mod
         sys.modules[_mod] = stub
-        _OWNED_STUBS.add(_mod)
 
 from services.knowledge.lineage_service import (  # noqa: E402
     LineageService,
@@ -52,8 +47,18 @@ from services.knowledge.lineage_service import (  # noqa: E402
 # utils/chromadb_client_cache_key_test.py, which pass alone and failed in CI.
 # ``_reinstall_module_stubs`` in this package's conftest puts it back around this
 # module's own tests and removes it afterwards.
+# #13651: unload the name only when a *stub* occupies it. ``setdefault`` is a
+# no-op once the genuine module is imported, and the old unconditional pop
+# then destroyed that genuine module — the next importer built a second
+# object, breaking identity for everything holding the first. Keying on the
+# occupant rather than on "did I install it" also keeps the original
+# behaviour of clearing a stub another module in this directory left behind.
+def _is_stub(name: str) -> bool:
+    return name in sys.modules and getattr(sys.modules[name], "__spec__", None) is None
+
+
 _STUBS_UNLOADED_AFTER_IMPORT = {
-    name: sys.modules.pop(name) for name in ("utils.chromadb_client",) if name in _OWNED_STUBS
+    name: sys.modules.pop(name) for name in ("utils.chromadb_client",) if _is_stub(name)
 }
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/services/knowledge/test_lineage_service.py
+++ b/autobot-backend/services/knowledge/test_lineage_service.py
@@ -22,6 +22,10 @@ import pytest
 # Stub heavy dependencies before importing lineage_service
 # ---------------------------------------------------------------------------
 
+# #13651: only unload what this module actually installed — popping a genuine
+# module it never installed destroyed it for every later importer.
+_OWNED_STUBS: set = set()
+
 for _mod in (
     "autobot_shared",
     "autobot_shared.redis_client",
@@ -34,6 +38,7 @@ for _mod in (
         stub.__path__ = []  # type: ignore[attr-defined]
         stub.__package__ = _mod
         sys.modules[_mod] = stub
+        _OWNED_STUBS.add(_mod)
 
 from services.knowledge.lineage_service import (  # noqa: E402
     LineageService,
@@ -48,7 +53,7 @@ from services.knowledge.lineage_service import (  # noqa: E402
 # ``_reinstall_module_stubs`` in this package's conftest puts it back around this
 # module's own tests and removes it afterwards.
 _STUBS_UNLOADED_AFTER_IMPORT = {
-    name: sys.modules.pop(name) for name in ("utils.chromadb_client",) if name in sys.modules
+    name: sys.modules.pop(name) for name in ("utils.chromadb_client",) if name in _OWNED_STUBS
 }
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/services/knowledge/test_synthesis_prompt_evolution.py
+++ b/autobot-backend/services/knowledge/test_synthesis_prompt_evolution.py
@@ -25,9 +25,7 @@ import pytest
 # regardless destroyed it — the next importer built a second module object,
 # breaking identity for anything holding the first.
 _OWNED_STUBS = {
-    _n
-    for _n in ("utils.chromadb_client", "autobot_shared", "autobot_shared.redis_client")
-    if _n not in sys.modules
+    _n for _n in ("utils.chromadb_client", "autobot_shared", "autobot_shared.redis_client") if _n not in sys.modules
 }
 sys.modules.setdefault("utils.chromadb_client", MagicMock())
 sys.modules.setdefault("autobot_shared", MagicMock())

--- a/autobot-backend/services/knowledge/test_synthesis_prompt_evolution.py
+++ b/autobot-backend/services/knowledge/test_synthesis_prompt_evolution.py
@@ -20,7 +20,14 @@ import pytest
 # ---------------------------------------------------------------------------
 # Minimal stubs for optional heavy deps so the module can be imported.
 # ---------------------------------------------------------------------------
-sys.modules.setdefault("utils.chromadb_client", MagicMock())
+# #13651: remember the stub only if this module actually installed it.
+# ``setdefault`` is a no-op once the genuine module is imported, and the unload
+# below used to pop the name regardless — deleting a real module it never
+# installed, so the next importer built a second object.
+_OWN_CHROMADB_STUB = None
+if "utils.chromadb_client" not in sys.modules:
+    _OWN_CHROMADB_STUB = MagicMock()
+    sys.modules["utils.chromadb_client"] = _OWN_CHROMADB_STUB
 sys.modules.setdefault("autobot_shared", MagicMock())
 sys.modules.setdefault("autobot_shared.redis_client", MagicMock())
 
@@ -32,7 +39,9 @@ from services.knowledge.kb_synthesizer import KBSynthesizer  # noqa: E402
 # ``_reinstall_module_stubs`` in this package's conftest puts it back around this
 # module's own tests and removes it afterwards.
 _STUBS_UNLOADED_AFTER_IMPORT = {
-    name: sys.modules.pop(name) for name in ("utils.chromadb_client",) if name in sys.modules
+    name: sys.modules.pop(name)
+    for name in ("utils.chromadb_client",)
+    if _OWN_CHROMADB_STUB is not None and sys.modules.get(name) is _OWN_CHROMADB_STUB
 }
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/services/knowledge/test_synthesis_prompt_evolution.py
+++ b/autobot-backend/services/knowledge/test_synthesis_prompt_evolution.py
@@ -26,6 +26,7 @@ sys.modules.setdefault("autobot_shared.redis_client", MagicMock())
 
 from services.knowledge.kb_synthesizer import KBSynthesizer  # noqa: E402
 
+
 # #13435: see the matching note in test_analyzer_service.py. ``utils.chromadb_client``
 # escapes this directory and poisoned utils/chromadb_auth_test.py and
 # utils/chromadb_client_cache_key_test.py, which pass alone and failed in CI.
@@ -41,9 +42,7 @@ def _is_stub(name: str) -> bool:
     return name in sys.modules and getattr(sys.modules[name], "__spec__", None) is None
 
 
-_STUBS_UNLOADED_AFTER_IMPORT = {
-    name: sys.modules.pop(name) for name in ("utils.chromadb_client",) if _is_stub(name)
-}
+_STUBS_UNLOADED_AFTER_IMPORT = {name: sys.modules.pop(name) for name in ("utils.chromadb_client",) if _is_stub(name)}
 
 # ---------------------------------------------------------------------------
 # _score_synthesis_output

--- a/autobot-backend/services/knowledge/test_synthesis_prompt_evolution.py
+++ b/autobot-backend/services/knowledge/test_synthesis_prompt_evolution.py
@@ -20,13 +20,6 @@ import pytest
 # ---------------------------------------------------------------------------
 # Minimal stubs for optional heavy deps so the module can be imported.
 # ---------------------------------------------------------------------------
-# #13651: only unload what this module actually installed. ``setdefault``
-# is a no-op when the genuine module is already imported, and popping
-# regardless destroyed it — the next importer built a second module object,
-# breaking identity for anything holding the first.
-_OWNED_STUBS = {
-    _n for _n in ("utils.chromadb_client", "autobot_shared", "autobot_shared.redis_client") if _n not in sys.modules
-}
 sys.modules.setdefault("utils.chromadb_client", MagicMock())
 sys.modules.setdefault("autobot_shared", MagicMock())
 sys.modules.setdefault("autobot_shared.redis_client", MagicMock())
@@ -38,8 +31,18 @@ from services.knowledge.kb_synthesizer import KBSynthesizer  # noqa: E402
 # utils/chromadb_client_cache_key_test.py, which pass alone and failed in CI.
 # ``_reinstall_module_stubs`` in this package's conftest puts it back around this
 # module's own tests and removes it afterwards.
+# #13651: unload the name only when a *stub* occupies it. ``setdefault`` is a
+# no-op once the genuine module is imported, and the old unconditional pop
+# then destroyed that genuine module — the next importer built a second
+# object, breaking identity for everything holding the first. Keying on the
+# occupant rather than on "did I install it" also keeps the original
+# behaviour of clearing a stub another module in this directory left behind.
+def _is_stub(name: str) -> bool:
+    return name in sys.modules and getattr(sys.modules[name], "__spec__", None) is None
+
+
 _STUBS_UNLOADED_AFTER_IMPORT = {
-    name: sys.modules.pop(name) for name in ("utils.chromadb_client",) if name in _OWNED_STUBS
+    name: sys.modules.pop(name) for name in ("utils.chromadb_client",) if _is_stub(name)
 }
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/services/knowledge/test_synthesis_prompt_evolution.py
+++ b/autobot-backend/services/knowledge/test_synthesis_prompt_evolution.py
@@ -31,18 +31,8 @@ from services.knowledge.kb_synthesizer import KBSynthesizer  # noqa: E402
 # utils/chromadb_client_cache_key_test.py, which pass alone and failed in CI.
 # ``_reinstall_module_stubs`` in this package's conftest puts it back around this
 # module's own tests and removes it afterwards.
-# #13651: unload the name only when a *stub* occupies it. ``setdefault`` is a
-# no-op once the genuine module is imported, and the old unconditional pop
-# then destroyed that genuine module — the next importer built a second
-# object, breaking identity for everything holding the first. Keying on the
-# occupant rather than on "did I install it" also keeps the original
-# behaviour of clearing a stub another module in this directory left behind.
-def _is_stub(name: str) -> bool:
-    return name in sys.modules and getattr(sys.modules[name], "__spec__", None) is None
-
-
 _STUBS_UNLOADED_AFTER_IMPORT = {
-    name: sys.modules.pop(name) for name in ("utils.chromadb_client",) if _is_stub(name)
+    name: sys.modules.pop(name) for name in ("utils.chromadb_client",) if name in sys.modules
 }
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/services/knowledge/test_synthesis_prompt_evolution.py
+++ b/autobot-backend/services/knowledge/test_synthesis_prompt_evolution.py
@@ -20,6 +20,15 @@ import pytest
 # ---------------------------------------------------------------------------
 # Minimal stubs for optional heavy deps so the module can be imported.
 # ---------------------------------------------------------------------------
+# #13651: only unload what this module actually installed. ``setdefault``
+# is a no-op when the genuine module is already imported, and popping
+# regardless destroyed it — the next importer built a second module object,
+# breaking identity for anything holding the first.
+_OWNED_STUBS = {
+    _n
+    for _n in ("utils.chromadb_client", "autobot_shared", "autobot_shared.redis_client")
+    if _n not in sys.modules
+}
 sys.modules.setdefault("utils.chromadb_client", MagicMock())
 sys.modules.setdefault("autobot_shared", MagicMock())
 sys.modules.setdefault("autobot_shared.redis_client", MagicMock())
@@ -32,7 +41,7 @@ from services.knowledge.kb_synthesizer import KBSynthesizer  # noqa: E402
 # ``_reinstall_module_stubs`` in this package's conftest puts it back around this
 # module's own tests and removes it afterwards.
 _STUBS_UNLOADED_AFTER_IMPORT = {
-    name: sys.modules.pop(name) for name in ("utils.chromadb_client",) if name in sys.modules
+    name: sys.modules.pop(name) for name in ("utils.chromadb_client",) if name in _OWNED_STUBS
 }
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/tests/agents/test_causal_reasoning.py
+++ b/autobot-backend/tests/agents/test_causal_reasoning.py
@@ -43,10 +43,20 @@ from orchestration.causal_error_analyzer import (  # noqa: E402
 
 @pytest.fixture(scope="module", autouse=True)
 def _restore_conftest_stubs():
-    """Restore the displaced parent-conftest stub after this module's tests."""
+    """Restore the displaced parent-conftest stub after this module's tests.
+
+    #13651: only if it was a real module. The parent conftest installs a
+    ``MagicMock`` here purely so the lightweight types-only tests can collect
+    without the heavy import chain (#7431); putting that mock back once this
+    module has successfully imported the genuine module leaves a mock installed
+    for everything collected afterwards, which is the leak the guard reports.
+    Keeping the real module is both correct and cheaper — the import has already
+    happened, so nothing downstream pays for it.
+    """
     yield
     for _sname, _smod in _SAVED_STUBS.items():
-        sys.modules[_sname] = _smod  # type: ignore[assignment]
+        if getattr(_smod, "__spec__", None) is not None:
+            sys.modules[_sname] = _smod  # type: ignore[assignment]
 
 
 from reasoning.causal_reasoning import (

--- a/autobot-backend/tests/agents/test_causal_reasoning.py
+++ b/autobot-backend/tests/agents/test_causal_reasoning.py
@@ -23,9 +23,14 @@ import pytest
 # tests/orchestration/test_causal_error_recovery.py): the parent conftest stubs
 # ``orchestration.causal_error_analyzer`` (#7431) as a MagicMock package, so the
 # TestCausalErrorAnalyzer suite below was exercising a mock (``CausalErrorAnalyzer()``
-# returned MagicMocks).  Displace exactly that stub, import the real module, and
-# restore the displaced stub after this module's tests so sibling type-only tests
-# that patch it by name are unaffected.  Its import chain only needs
+# returned MagicMocks).  Displace exactly that stub and import the real module.
+#
+# #13651: the displaced entry is put back only if it was a real module. The
+# original text here said the mock was restored "so sibling type-only tests that
+# patch it by name are unaffected" — no test under tests/agents/ references
+# ``causal_error_analyzer`` at all, and reinstalling the mock left it installed
+# for everything collected afterwards, which the leak guard reported. Its import
+# chain only needs
 # agent_loop.think_tool / agent_loop.types, which the conftest already real-loads.
 # ---------------------------------------------------------------------------
 _CONFTEST_STUB_NAMES: tuple = ("orchestration.causal_error_analyzer",)

--- a/repo_tests/sys_modules_leak_baseline.txt
+++ b/repo_tests/sys_modules_leak_baseline.txt
@@ -64,12 +64,15 @@ autobot-backend/tests/test_vnc_mcp_async.py run-phase
 autobot-backend/tests/test_vnc_screenshot_temp_leak.py run-phase
 autobot-backend/worker_node_test.py run-phase
 autobot-slm-backend/api/monitoring_applogs_test.py
+autobot-slm-backend/services/a2a_card_fetcher_test.py
 autobot-slm-backend/services/reconciler_check_node_health_test.py
 autobot-slm-backend/tests/api/test_collect_outdated_node_ids.py
 autobot-slm-backend/tests/api/test_fleet_health.py
+autobot-slm-backend/tests/api/test_node_update_availability_11964.py
 autobot-slm-backend/tests/api/test_nodes_list_timeout_10913.py run-phase
 autobot-slm-backend/tests/api/test_slm_endpoints_12515.py
 autobot-slm-backend/tests/services/conftest.py
+autobot-slm-backend/tests/services/test_deploy_artifacts_lockstep.py
 autobot-slm-backend/tests/services/test_llm_secrets.py
 autobot-slm-backend/tests/services/test_sso_vault_client.py
 autobot-slm-backend/tests/test_api_request_counter.py

--- a/repo_tests/sys_modules_leak_baseline.txt
+++ b/repo_tests/sys_modules_leak_baseline.txt
@@ -56,7 +56,6 @@ autobot-backend/code_intelligence/conftest.py
 autobot-backend/conftest.py
 autobot-backend/knowledge/vector_search_engine_test.py
 autobot-backend/llm_shared/npu_pipeline_routing_test.py
-autobot-backend/tests/agents/test_causal_reasoning.py
 autobot-backend/tests/orchestration/test_causal_error_recovery.py
 autobot-backend/tests/services/rag_service_events_test.py
 autobot-backend/tests/test_conftest_real_load_identity.py run-phase
@@ -65,15 +64,12 @@ autobot-backend/tests/test_vnc_mcp_async.py run-phase
 autobot-backend/tests/test_vnc_screenshot_temp_leak.py run-phase
 autobot-backend/worker_node_test.py run-phase
 autobot-slm-backend/api/monitoring_applogs_test.py
-autobot-slm-backend/services/a2a_card_fetcher_test.py
 autobot-slm-backend/services/reconciler_check_node_health_test.py
 autobot-slm-backend/tests/api/test_collect_outdated_node_ids.py
 autobot-slm-backend/tests/api/test_fleet_health.py
-autobot-slm-backend/tests/api/test_node_update_availability_11964.py
 autobot-slm-backend/tests/api/test_nodes_list_timeout_10913.py run-phase
 autobot-slm-backend/tests/api/test_slm_endpoints_12515.py
 autobot-slm-backend/tests/services/conftest.py
-autobot-slm-backend/tests/services/test_deploy_artifacts_lockstep.py
 autobot-slm-backend/tests/services/test_llm_secrets.py
 autobot-slm-backend/tests/services/test_sso_vault_client.py
 autobot-slm-backend/tests/test_api_request_counter.py

--- a/repo_tests/sys_modules_leak_guard.py
+++ b/repo_tests/sys_modules_leak_guard.py
@@ -358,6 +358,38 @@ _MISSING = object()
 _DISK_CACHE: dict[str, bool] = {}
 
 
+def _provided_by_multiple_roots(top_level: str) -> bool:
+    """True when more than one ``sys.path`` entry provides *top_level* (#13651).
+
+    ``autobot-backend`` and ``autobot-slm-backend`` both ship a ``services``
+    package, so the bare name is ambiguous. A genuine module under such a name
+    is not "what Python should hold" — it is whichever backend won the race, and
+    leaving it installed for the other backend's tests is the shadow this guard
+    exists to catch. The synthetic -> genuine exemption must not fire for these.
+    """
+    # Deliberately uncached: ``sys.path`` grows during a session as conftests
+    # insert their roots, so an answer cached before the second backend's root
+    # appeared would be wrong for the rest of the run. Only the rare exemption
+    # path consults this.
+    # Resolve before counting: sys.path routinely holds the same directory twice
+    # (absolute and relative forms, or a rootdir re-inserted by a conftest), and
+    # counting those as separate roots would refuse the exemption for names that
+    # only one source root actually provides.
+    providers: set[str] = set()
+    for entry in sys.path:
+        base = Path(entry or ".")
+        target = base / f"{top_level}.py"
+        if not target.is_file():
+            target = base / top_level
+            if not target.is_dir():
+                continue
+        try:
+            providers.add(str(target.resolve()))
+        except OSError:
+            continue
+    return len(providers) > 1
+
+
 def _resolves_on_disk(top_level: str) -> bool:
     """True when *top_level* names a real module or package somewhere on sys.path.
 
@@ -541,7 +573,7 @@ class _LeakGuard:
         if _is_conftest_module(module):
             return None  # pytest's own bookkeeping, not a stub
         if _is_self_rebind(name, module, previous) and self._is_third_party(module):
-            return None  # a third-party package re-registering itself mid-import  # a package re-registering itself during its own import
+            return None  # a third-party package re-registering itself during its own import
         if previous is _MISSING and self._parent_is_genuine(name):
             return None  # a real package's own shim, not a test's leftover
         if not self._shadows_real_code(name):
@@ -552,7 +584,12 @@ class _LeakGuard:
             # Narrow on purpose: genuine-over-genuine stays reported (#13633), and
             # the newcomer must have a real file so a spec-carrying shim for a
             # deleted submodule cannot pass as genuine (#13599).
-            if _is_synthetic(previous) and not _is_synthetic(module) and _has_real_file(module):
+            if (
+                _is_synthetic(previous)
+                and not _is_synthetic(module)
+                and _has_real_file(module)
+                and not _provided_by_multiple_roots(name.partition(".")[0])
+            ):
                 return None
             return "replaced"
         return "synthetic" if _is_synthetic(module) else None

--- a/repo_tests/sys_modules_leak_guard.py
+++ b/repo_tests/sys_modules_leak_guard.py
@@ -279,6 +279,22 @@ def _previous_kind(previous: object) -> str:
     return "was-genuine"
 
 
+def _has_real_file(module: object) -> bool:
+    """True when *module* was loaded from a file that exists on disk (#13651).
+
+    ``__spec__`` alone is not enough: a package may register a spec-carrying
+    compatibility shim for a submodule it deleted, and those have no file. The
+    exemption below must not fire for one of those.
+    """
+    origin = getattr(module, "__file__", None)
+    if not origin:
+        return False
+    try:
+        return Path(origin).is_file()
+    except (OSError, ValueError):
+        return False
+
+
 def _is_self_rebind(name: str, module: object, previous: object) -> bool:
     """True when *module* is a real package re-registering itself under its own name.
 
@@ -531,6 +547,13 @@ class _LeakGuard:
         if not self._shadows_real_code(name):
             return None
         if previous is not _MISSING:
+            # #13651: a stub giving way to the genuine module is a repair, not a
+            # leak — the key ends up holding exactly what Python should hold.
+            # Narrow on purpose: genuine-over-genuine stays reported (#13633), and
+            # the newcomer must have a real file so a spec-carrying shim for a
+            # deleted submodule cannot pass as genuine (#13599).
+            if _is_synthetic(previous) and not _is_synthetic(module) and _has_real_file(module):
+                return None
             return "replaced"
         return "synthetic" if _is_synthetic(module) else None
 

--- a/repo_tests/sys_modules_leak_guard.py
+++ b/repo_tests/sys_modules_leak_guard.py
@@ -176,6 +176,7 @@ class _Mutation:
     owner_dir: Path
     owner_dir_display: str
     obj_id: int
+    prev_kind: str  # what the key held before, for the leak report (#13651)
     # ``owner_dir.parents`` as a set, built once here rather than on every
     # comparison.  ``Path.parents`` is a lazy sequence with no ``__contains__``,
     # so ``x in path.parents`` walks it and constructs a fresh ``Path`` per
@@ -257,13 +258,41 @@ class _Leak:
             "owner": self.mutation.owner,
             "owner_dir_display": self.mutation.owner_dir_display,
             "observed_at": self.observed_at,
-            "occupant": _occupant(self.mutation.key, self.mutation.obj_id),
+            "occupant": (
+                f"{self.mutation.prev_kind} -> "
+                f"{_occupant(self.mutation.key, self.mutation.obj_id)}"
+            ),
         }
 
 
 def _is_synthetic(module: object) -> bool:
     """True for hand-built module stubs and mocks, false for real imports."""
     return getattr(module, "__spec__", None) is None
+
+
+def _previous_kind(previous: object) -> str:
+    """Describe what a key held before the mutation, for the report (#13651)."""
+    if previous is _MISSING:
+        return "was-absent"
+    if _is_synthetic(previous):
+        return "was-synthetic"
+    return "was-genuine"
+
+
+def _has_real_file(module: object) -> bool:
+    """True when *module* was loaded from a file that exists on disk (#13651).
+
+    ``__spec__`` alone is not enough: a package may register a spec-carrying
+    compatibility shim for a submodule it deleted, and those have no file. The
+    exemption above must not fire for one of those.
+    """
+    origin = getattr(module, "__file__", None)
+    if not origin:
+        return False
+    try:
+        return Path(origin).is_file()
+    except (OSError, ValueError):
+        return False
 
 
 def _is_self_rebind(name: str, module: object, previous: object) -> bool:
@@ -448,6 +477,7 @@ class _LeakGuard:
                 owner_dir=owner_dir,
                 owner_dir_display=owner_dir_display,
                 obj_id=id(module),
+                prev_kind=_previous_kind(previous),
                 owner_ancestors=owner_ancestors,
             )
 
@@ -517,6 +547,20 @@ class _LeakGuard:
         if not self._shadows_real_code(name):
             return None
         if previous is not _MISSING:
+            # #13651: a *stub* giving way to the genuine module is a repair, not
+            # a leak. `sys.modules.setdefault(name, MagicMock())` is a no-op when
+            # the real module is already imported, so on a shard where something
+            # imported it first, the knowledge suite installs no stub at all —
+            # the teardown pops the real module and it is imported again. The
+            # guard then saw a "replacement" whose end state is exactly what
+            # Python should hold, and failed the run for it.
+            #
+            # Narrow on purpose: real-over-real stays reported, because repo code
+            # displacing a genuine module is the case #13633 kept. Only
+            # synthetic -> genuine is exempt, and only when the newcomer really
+            # is genuine (a __spec__ AND a file, so a spec-less shim cannot pass).
+            if _is_synthetic(previous) and not _is_synthetic(module) and _has_real_file(module):
+                return None
             return "replaced"
         return "synthetic" if _is_synthetic(module) else None
 

--- a/repo_tests/sys_modules_leak_guard.py
+++ b/repo_tests/sys_modules_leak_guard.py
@@ -358,46 +358,35 @@ _MISSING = object()
 _DISK_CACHE: dict[str, bool] = {}
 
 
-def _provided_by_multiple_roots(top_level: str) -> bool:
-    """True when more than one ``sys.path`` entry provides *top_level* (#13651).
+def _defined_in_multiple_source_roots(top_level: str, repo_root: Path) -> bool:
+    """True when more than one *source root* defines *top_level*.
 
-    ``autobot-backend`` and ``autobot-slm-backend`` both ship a ``services``
-    package, so the bare name is ambiguous. A genuine module under such a name
-    is not "what Python should hold" — it is whichever backend won the race, and
-    leaving it installed for the other backend's tests is the shadow this guard
-    exists to catch. The synthetic -> genuine exemption must not fire for these.
+    ``autobot-backend`` and ``autobot-slm-backend`` both ship ``services`` and
+    ``api``, so a genuine module under such a bare name is whichever backend won
+    the race — leaving it installed for the other backend's tests is exactly the
+    shadow this guard exists to catch, and the synthetic -> genuine exemption
+    must not fire for it.
+
+    Counted per source root rather than per directory: ``autobot-backend/utils``
+    and ``autobot-backend/tests/utils`` are two definitions of ``utils`` inside
+    the *same* backend, which is not a shadow. Counting directories refused the
+    exemption for ``utils`` on CI while allowing it locally, because only CI had
+    both on ``sys.path`` (#13651). Entries outside the repo are dependencies,
+    not our roots, and are ignored.
     """
-    # Deliberately uncached: ``sys.path`` grows during a session as conftests
-    # insert their roots, so an answer cached before the second backend's root
-    # appeared would be wrong for the rest of the run. Only the rare exemption
-    # path consults this.
-    # Resolve before counting: sys.path routinely holds the same directory twice
-    # (absolute and relative forms, or a rootdir re-inserted by a conftest), and
-    # counting those as separate roots would refuse the exemption for names that
-    # only one source root actually provides.
-    # Only this repo's own source roots count. A dependency shipping a top-level
-    # ``utils`` in site-packages is not the shadow this guards against — CI has
-    # such packages and a dev checkout may not, which would otherwise make the
-    # exemption fire locally and refuse on CI for the very same name.
-    repo_root = Path(__file__).resolve().parents[1]
-    providers: set[str] = set()
+    roots: set[str] = set()
     for entry in sys.path:
         base = Path(entry or ".")
+        if not ((base / f"{top_level}.py").is_file() or (base / top_level).is_dir()):
+            continue
         try:
-            if not base.resolve().is_relative_to(repo_root):
-                continue
+            rel = base.resolve().relative_to(repo_root)
         except (OSError, ValueError):
             continue
-        target = base / f"{top_level}.py"
-        if not target.is_file():
-            target = base / top_level
-            if not target.is_dir():
-                continue
-        try:
-            providers.add(str(target.resolve()))
-        except OSError:
-            continue
-    return len(providers) > 1
+        roots.add(rel.parts[0] if rel.parts else ".")
+        if len(roots) > 1:
+            return True
+    return False
 
 
 def _resolves_on_disk(top_level: str) -> bool:
@@ -603,8 +592,8 @@ class _LeakGuard:
                 # reporting this says why instead of leaving it to be inferred.
                 if not _has_real_file(module):
                     self._exempt_blocked[name] = "no-real-file"
-                elif _provided_by_multiple_roots(name.partition(".")[0]):
-                    self._exempt_blocked[name] = "multi-root"
+                elif _defined_in_multiple_source_roots(name.partition(".")[0], self._rootdir):
+                    self._exempt_blocked[name] = "multi-source-root"
                 else:
                     return None
             return "replaced"

--- a/repo_tests/sys_modules_leak_guard.py
+++ b/repo_tests/sys_modules_leak_guard.py
@@ -279,22 +279,6 @@ def _previous_kind(previous: object) -> str:
     return "was-genuine"
 
 
-def _has_real_file(module: object) -> bool:
-    """True when *module* was loaded from a file that exists on disk (#13651).
-
-    ``__spec__`` alone is not enough: a package may register a spec-carrying
-    compatibility shim for a submodule it deleted, and those have no file. The
-    exemption above must not fire for one of those.
-    """
-    origin = getattr(module, "__file__", None)
-    if not origin:
-        return False
-    try:
-        return Path(origin).is_file()
-    except (OSError, ValueError):
-        return False
-
-
 def _is_self_rebind(name: str, module: object, previous: object) -> bool:
     """True when *module* is a real package re-registering itself under its own name.
 
@@ -547,20 +531,6 @@ class _LeakGuard:
         if not self._shadows_real_code(name):
             return None
         if previous is not _MISSING:
-            # #13651: a *stub* giving way to the genuine module is a repair, not
-            # a leak. `sys.modules.setdefault(name, MagicMock())` is a no-op when
-            # the real module is already imported, so on a shard where something
-            # imported it first, the knowledge suite installs no stub at all —
-            # the teardown pops the real module and it is imported again. The
-            # guard then saw a "replacement" whose end state is exactly what
-            # Python should hold, and failed the run for it.
-            #
-            # Narrow on purpose: real-over-real stays reported, because repo code
-            # displacing a genuine module is the case #13633 kept. Only
-            # synthetic -> genuine is exempt, and only when the newcomer really
-            # is genuine (a __spec__ AND a file, so a spec-less shim cannot pass).
-            if _is_synthetic(previous) and not _is_synthetic(module) and _has_real_file(module):
-                return None
             return "replaced"
         return "synthetic" if _is_synthetic(module) else None
 

--- a/repo_tests/sys_modules_leak_guard.py
+++ b/repo_tests/sys_modules_leak_guard.py
@@ -375,9 +375,19 @@ def _provided_by_multiple_roots(top_level: str) -> bool:
     # (absolute and relative forms, or a rootdir re-inserted by a conftest), and
     # counting those as separate roots would refuse the exemption for names that
     # only one source root actually provides.
+    # Only this repo's own source roots count. A dependency shipping a top-level
+    # ``utils`` in site-packages is not the shadow this guards against — CI has
+    # such packages and a dev checkout may not, which would otherwise make the
+    # exemption fire locally and refuse on CI for the very same name.
+    repo_root = Path(__file__).resolve().parents[1]
     providers: set[str] = set()
     for entry in sys.path:
         base = Path(entry or ".")
+        try:
+            if not base.resolve().is_relative_to(repo_root):
+                continue
+        except (OSError, ValueError):
+            continue
         target = base / f"{top_level}.py"
         if not target.is_file():
             target = base / top_level

--- a/repo_tests/sys_modules_leak_guard.py
+++ b/repo_tests/sys_modules_leak_guard.py
@@ -452,6 +452,8 @@ class _LeakGuard:
         # each of the thousands of collectors a session brackets.
         self._candidate_names = {Path(owner).name for owner in removal_candidates}
         self._tracked: dict[str, _Mutation] = {}
+        # name -> why the synthetic->genuine exemption was refused (#13651)
+        self._exempt_blocked: dict[str, str] = {}
         self._reported: set[tuple[str, str]] = set()
         self._warned_owners: set[str] = set()
         # Baselined owners this session has loaded but not yet taken anywhere
@@ -509,6 +511,7 @@ class _LeakGuard:
         owner_dir_display = _display(owner_dir, self._rootdir)
         owner_ancestors = frozenset(owner_dir.parents)
         for name, module, previous in changed:
+            self._exempt_blocked.pop(name, None)
             kind = self._classify(name, module, previous)
             if kind is None:
                 continue
@@ -519,7 +522,8 @@ class _LeakGuard:
                 owner_dir=owner_dir,
                 owner_dir_display=owner_dir_display,
                 obj_id=id(module),
-                prev_kind=_previous_kind(previous),
+                prev_kind=_previous_kind(previous)
+                + (f" [exempt-refused: {self._exempt_blocked[name]}]" if name in self._exempt_blocked else ""),
                 owner_ancestors=owner_ancestors,
             )
 
@@ -594,13 +598,15 @@ class _LeakGuard:
             # Narrow on purpose: genuine-over-genuine stays reported (#13633), and
             # the newcomer must have a real file so a spec-carrying shim for a
             # deleted submodule cannot pass as genuine (#13599).
-            if (
-                _is_synthetic(previous)
-                and not _is_synthetic(module)
-                and _has_real_file(module)
-                and not _provided_by_multiple_roots(name.partition(".")[0])
-            ):
-                return None
+            if _is_synthetic(previous) and not _is_synthetic(module):
+                # Record which condition refused, so a CI run that keeps
+                # reporting this says why instead of leaving it to be inferred.
+                if not _has_real_file(module):
+                    self._exempt_blocked[name] = "no-real-file"
+                elif _provided_by_multiple_roots(name.partition(".")[0]):
+                    self._exempt_blocked[name] = "multi-root"
+                else:
+                    return None
             return "replaced"
         return "synthetic" if _is_synthetic(module) else None
 


### PR DESCRIPTION
## Thinking Path

`python-suite shard 6/12` failed on every PR with a `sys.modules` leak the guard reported against the knowledge tests. Four earlier diagnoses (all mine) were inferences that did not survive the data, so the first thing this PR added was a **measurement**: a `prev_kind` field naming what each leaked key held *before* the mutation.

It paid for itself immediately by refuting my own theory. CI printed `was-genuine`, not `was-synthetic` — so the exemption I had proposed could never fire, and the real story was different:

```python
sys.modules.setdefault(name, stub)        # no-op once the genuine module is imported
_async_chromadb_stub = sys.modules[name]  # ...so this IS the genuine module
_async_chromadb_stub.get_async_chromadb_client = AsyncMock()   # mutates the real module
...
{name: sys.modules.pop(name) ...}         # then deletes a module it never installed
```

Two distinct bugs. The unconditional `pop` destroyed a genuine module, so the next importer built a second object — that is the leak. And the `AsyncMock` writes landed on the real module, which the `pop` had been accidentally *repairing* by forcing a clean re-import.

That is why every partial fix failed: stop deleting and you expose the mutation (shard 11 went red); keep deleting and the leak stays. Both had to be fixed together.

## What Changed

**The knowledge test modules** save what the name held, force in *their own* stub so mutations land on the stub, and restore the displaced module afterwards — including the parent-package attribute, since `mock.patch("utils.async_chromadb_client.X")` resolves through `getattr(sys.modules["utils"], ...)` while `import` reads the key. Letting those two channels disagree would mean patching a stub while the code under test holds the real module. A failure-path restore keeps a raising import from leaving stubs installed.

`test_lineage_service` / `test_synthesis_prompt_evolution` already guard their installs, so they only needed the narrower rule: unload only what this module installed.

**The guard** gains `prev_kind`, and the exemption that a `synthetic -> genuine` transition is a repair rather than a leak — the key ends up holding exactly what Python should hold. It is deliberately narrow:

- genuine-over-genuine stays reported (#13633)
- the newcomer needs a real file, so a spec-carrying shim for a deleted submodule cannot pass (#13599)
- **it is refused for any name defined in more than one source root.** `autobot-backend` and `autobot-slm-backend` both ship `services` and `api`; a genuine module under such a bare name is whichever backend won the race, and leaving it installed for the other backend's tests is the shadow this guard exists to catch. Counted per source root, not per directory — `autobot-backend/tests/utils` is a second definition of `utils` inside the *same* backend, and counting directories refused the exemption on CI while allowing it locally, because only CI had both on `sys.path`.

**`test_causal_reasoning.py`** no longer reinstalls a `MagicMock` over the genuine module it just imported. Checked before changing it: nothing under `tests/agents/` references `causal_error_analyzer`, so the "sibling tests need the stub" rationale in the old comment was not backed by any file.

**`_group_chunks` (#13682)** — found while clearing the last red. `max()` over a `frozenset` broke frequency ties by set iteration order, so `PYTHONHASHSEED` decided whether two chunks were compared at all. Contradiction scanning was non-reproducible: the same KB could report a contradiction on one run and miss it on the next, silently. Folded in here because shard 6 cannot go green without it; it carries its own issue and commit.

**Baseline** — three `autobot-slm-backend` entries stay (the narrowed exemption correctly refuses `services`); `test_causal_reasoning` is removed because it genuinely no longer leaks.

## Verification

```
python-suite:  12 / 12 shards SUCCESS, aggregate SUCCESS
```

Locally:

```
knowledge suite                       366 passed   (identical to base)
knowledge -> utils                    375 passed, 0 leak reports
repo_tests                            311 passed
tests/agents + tests/orchestration    360 passed
_group_chunks across 5 hash seeds     deterministic
```

Guard still catches what it must — on a known leaker with its baseline line removed, all keys report `was-genuine` so the exemption does not fire and the MagicMock stubs stay reported.

## Review

Reviewed by `code-reviewer`; findings addressed — the exemption narrowed to source roots (its blocking finding), parent-attribute restore, failure-path restore, the stale `test_causal_reasoning` comment, and an E501 from a duplicated comment fragment. Two `_STUB_MISSING` sentinel paths it flagged as unreachable are kept deliberately as the failure-path guard.

## Model Used

Opus 5

Closes #13651, #13682
