### PR TITLE
test(llc): stop leaking _make_app's patches past the test that started them (#13674)

### DIFF
--- a/autobot-backend/llc/tests/test_sprints_idor.py
+++ b/autobot-backend/llc/tests/test_sprints_idor.py
@@ -41,6 +41,7 @@ import uuid
 from typing import Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -276,6 +277,21 @@ def _make_app(
     return TestClient(app, raise_server_exceptions=True)
 
 
+@pytest.fixture(autouse=True)
+def _stop_make_app_patches():
+    """Undo every patch ``_make_app`` starts, for each test in this module.
+
+    ``_make_app`` is called from test bodies, not from a fixture, so it has no
+    teardown of its own.  Cleanup used to live in a per-class
+    ``teardown_method``; a class added without one leaked
+    ``KbCollectionManager.ensure_collection`` as an ``AsyncMock(return_value=None)``
+    into the rest of the pytest session (#13674).  Doing it here means a new
+    class cannot reintroduce that.
+    """
+    yield
+    patch.stopall()
+
+
 # ---------------------------------------------------------------------------
 # Tests: company_id-keyed routes
 # ---------------------------------------------------------------------------
@@ -283,9 +299,6 @@ def _make_app(
 
 class TestSprintsIdorCompanyRoutes:
     """Routes that take company_id in the URL path."""
-
-    def teardown_method(self, _method):
-        patch.stopall()
 
     # -- list portfolios --
 
@@ -345,9 +358,6 @@ class TestSprintsIdorCompanyRoutes:
 
 
 class TestSprintsIdorTimeline:
-    def teardown_method(self, _method):
-        patch.stopall()
-
     def test_get_project_timeline_own_company_returns_200(self):
         org = str(uuid.uuid4())
         client = _make_app(caller_org_id=org, project_company_id=org)


### PR DESCRIPTION
## Thinking Path

`python-suite shard 3/12` failed with two tests I had previously taken to zero:

```
FAILED llc/tests/test_kb_collections.py::TestEnsureCollection::test_creates_collection
       - AssertionError: assert None == 'company:00000000-0000-0000-0000-000000000001'
FAILED llc/tests/test_kb_collections.py::TestEnsureCollection::test_raises_on_chroma_error
       - Failed: DID NOT RAISE RuntimeError
```

`ensure_collection` returns its collection name or raises `RuntimeError` — it has no path that returns `None` quietly. So the method under test was not the real one. Grepping every writer of that attribute found one shaped exactly like the symptom:

```python
patch("llc.kb.collections.KbCollectionManager.ensure_collection",
      new=AsyncMock(return_value=None)).start()
```

`return_value=None` explains the first failure; a mock that cannot raise explains the second.

That `.start()` is one of five in `_make_app`, none of which is stopped. Cleanup lived in a `teardown_method` defined on **two of the file's three** classes — `TestSprintsCreateIgnoresBodyCompanyId` has none, and being last in the module, its patches survive to the end of the session.

It does not reproduce in a plain directory run because `test_kb_collections` sorts before `test_sprints_idor`. Under `xdist --dist loadscope` the module-to-worker assignment can invert that on a single worker, which is what shard 3 hit.

This is **not** the `sys.modules` leak of #13651/#13386. Nothing is left in `sys.modules`; the residue is a patched class attribute, which that guard does not and cannot observe.

## What Changed

Replaced the two duplicated `teardown_method` hooks with a single module-scoped autouse fixture calling `patch.stopall()` after every test.

The duplication *was* the defect: cleanup that must be restated per class is cleanup a new class can silently omit, which is exactly what happened. One autouse fixture cannot be missed, and it also covers the other four leaked patches (`SprintPlanningService.get_capacity` / `get_velocity_history` / `get_burndown`, `WorkProductService.list_indexed_by_project`) that were leaking the same way with less visible consequences.

## Verification

The failing order, before and after:

```
before: pytest -p no:randomly test_sprints_idor.py test_kb_collections.py  ->  2 failed, 20 passed
after:  pytest -p no:randomly test_sprints_idor.py test_kb_collections.py  ->  22 passed
```

The file still passes alone:

```
pytest test_sprints_idor.py     ->  12 passed
```

Full directory, against the same command on base:

```
base:  5 failed, 1388 passed, 1 skipped
this:  5 failed, 1388 passed, 1 skipped
```

The 5 are `test_poll_loop_scheduler.py`, identical before and after and green on CI — local-environment artifacts (local Python 3.10 vs CI 3.14), not touched by this change.

## Model Used

Opus 5

Closes #13674
