### PR TITLE
test(llc): convert remaining per-class patch.stopall() teardowns to autouse fixtures (#13678)

### DIFF
--- a/autobot-backend/llc/tests/test_suggest_ac_endpoint.py
+++ b/autobot-backend/llc/tests/test_suggest_ac_endpoint.py
@@ -11,6 +11,7 @@ exercised rather than skipped.
 import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -76,10 +77,20 @@ def _make_app(session_item=None, suggester_result=None, caller_org_id=None):
 # ---------------------------------------------------------------------------
 
 
-class TestSuggestAcEndpoint:
-    def teardown_method(self, _method):
-        patch.stopall()
+@pytest.fixture(autouse=True)
+def _stop_patches():
+    """Undo every patch the app builder starts, for each test in this module.
 
+    Cleanup used to be restated as a ``teardown_method`` on each class, which is
+    cleanup a newly added class can silently omit — exactly how #13674 leaked
+    ``KbCollectionManager.ensure_collection`` into the rest of the session. A
+    module-level autouse fixture cannot be missed (#13678).
+    """
+    yield
+    patch.stopall()
+
+
+class TestSuggestAcEndpoint:
     def test_no_title_no_work_item_id_returns_422(self):
         """Neither title nor work_item_id supplied → 422 from route logic."""
         client = _make_app()

--- a/autobot-backend/llc/tests/test_work_items_idor.py
+++ b/autobot-backend/llc/tests/test_work_items_idor.py
@@ -30,6 +30,7 @@ import uuid
 from typing import Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -245,10 +246,20 @@ def _make_idor_app(
 # ---------------------------------------------------------------------------
 
 
-class TestWorkItemsIdor:
-    def teardown_method(self, _method):
-        patch.stopall()
+@pytest.fixture(autouse=True)
+def _stop_patches():
+    """Undo every patch the app builder starts, for each test in this module.
 
+    Cleanup used to be restated as a ``teardown_method`` on each class, which is
+    cleanup a newly added class can silently omit — exactly how #13674 leaked
+    ``KbCollectionManager.ensure_collection`` into the rest of the session. A
+    module-level autouse fixture cannot be missed (#13678).
+    """
+    yield
+    patch.stopall()
+
+
+class TestWorkItemsIdor:
     # GET own company → 200
     def test_get_own_company_returns_200(self):
         org = str(uuid.uuid4())
@@ -324,11 +335,6 @@ class TestWorkItemsIdorM4:
     Each test follows the same pattern: own company → expected success status,
     cross-tenant → 404.
     """
-
-    def teardown_method(self, _method):
-        from unittest.mock import patch
-
-        patch.stopall()
 
     # --- checkout ---
 


### PR DESCRIPTION
## Thinking Path

#13674 was caused by patch cleanup living in a per-class `teardown_method`: `test_sprints_idor.py` had three classes and only two hooks, so the third leaked `KbCollectionManager.ensure_collection` as an `AsyncMock(return_value=None)` into the rest of the pytest session and reddened `python-suite shard 3/12` from an unrelated file.

Reviewing that fix surfaced two more files with the same shape. **Neither leaks today** — every class in them currently carries a hook — so this is not a bug report but the removal of a trap: the defect appears the moment someone adds a class and does not think about mock teardown, and it surfaces as a failure in a different file on a different shard.

`test_work_items_idor.py` is the one worth pre-empting: its app builder starts roughly 24 patches, against the 5 that caused #13674.

## What Changed

Both files now use the module-level autouse fixture that the majority of `llc/tests/*_idor.py` already use (see `test_boards_idor.py:79-82`):

```python
@pytest.fixture(autouse=True)
def _stop_patches():
    yield
    patch.stopall()
```

- `test_work_items_idor.py` — replaced two `teardown_method` hooks (one of which re-imported `patch` locally).
- `test_suggest_ac_endpoint.py` — replaced one.

An autouse fixture applies to every test in the module regardless of class; a `teardown_method` must be restated on each one. That difference is the entire bug class.

No functional `teardown_method` remains anywhere in `llc/tests/`.

## Verification

```
pytest test_work_items_idor.py test_suggest_ac_endpoint.py            41 passed
pytest -p no:randomly <both> test_kb_collections.py                   51 passed
```

The second command is the ordering that exposed #13674 — a leaked `ensure_collection` stub makes `TestEnsureCollection` fail with `assert None == 'company:...'`.

Full directory, against the same command on base:

```
base:  5 failed, 1388 passed, 1 skipped
this:  5 failed, 1388 passed, 1 skipped
```

The 5 are `test_poll_loop_scheduler.py`, identical before and after and green on CI — local-environment artifacts (local Python 3.10 vs CI 3.14), untouched here.

## Model Used

Opus 5

Closes #13678
