### PR TITLE
test(audit): key the zrange mock by date so the time-range test survives UTC midnight (#13680)

### DIFF
--- a/autobot-backend/services/audit_logger_test.py
+++ b/autobot-backend/services/audit_logger_test.py
@@ -296,7 +296,16 @@ class TestAuditLoggerQuery:
         )
         pipe = _make_pipeline_mock()
         redis = _make_redis_mock(pipe)
-        redis.zrange = AsyncMock(return_value=[entry.to_json().encode()])
+        # #13680: answer only for the key matching this entry's own date.
+        # ``query`` walks one ``audit:log:<date>`` key per UTC day in the window,
+        # so a date-agnostic mock returned the entry twice whenever ``now +- 1h``
+        # straddled UTC midnight — reddening this test for an hour every day.
+        # Keying the mock also makes the per-date lookup an actual assertion
+        # rather than something the test silently ignores.
+        async def _zrange_by_date(key, *_args, **_kwargs):
+            return [entry.to_json().encode()] if key == f"audit:log:{entry.date}" else []
+
+        redis.zrange = AsyncMock(side_effect=_zrange_by_date)
 
         with patch(
             "services.audit_logger.get_async_redis_client",

--- a/autobot-backend/services/audit_logger_test.py
+++ b/autobot-backend/services/audit_logger_test.py
@@ -296,6 +296,7 @@ class TestAuditLoggerQuery:
         )
         pipe = _make_pipeline_mock()
         redis = _make_redis_mock(pipe)
+
         # #13680: answer only for the key matching this entry's own date.
         # ``query`` walks one ``audit:log:<date>`` key per UTC day in the window,
         # so a date-agnostic mock returned the entry twice whenever ``now +- 1h``


### PR DESCRIPTION
## Thinking Path

`python-suite shard 5/12` went red on #13673 with a failure that had nothing to do with that PR:

```
FAILED services/audit_logger_test.py::TestAuditLoggerQuery::test_query_time_range_parses_json_entries
       - AssertionError: assert 2 == 1
```

Shard 5 is green on #13672 and #13679, which sit on the same base — so the obvious read was "another regression of mine". It is not. The test fails **on `Dev_new_gui` with no changes at all**, and only for about an hour a day.

`AuditLogger.query` walks one Redis key per UTC date in the window:

```python
current_date = query_ctx.start_time.date()
end_date = query_ctx.end_time.date()
while current_date <= end_date:
    key = f"audit:log:{date_str}"
    results = await audit_db.zrange(key, start_score, end_score, withscores=False)
```

The test asks for `now - 1h` .. `now + 1h` and mocks `zrange` date-agnostically, so when that window straddles UTC midnight the loop runs twice, the mock returns the same entry for both keys, and the single-entry assertion sees 2. **The production code is correct** — it is querying two genuinely different keys. The mock was the wrong part.

The three PRs did not differ; only the wall-clock time they ran at did.

## What Changed

The mock answers only for the key matching the entry's own date:

```python
async def _zrange_by_date(key, *_args, **_kwargs):
    return [entry.to_json().encode()] if key == f"audit:log:{entry.date}" else []
```

This also turns the per-date keying into something the test actually asserts. Previously a regression in the `while current_date <= end_date` loop would have gone unnoticed here, because every key returned the same payload.

## Verification

Run **inside** the window that reproduces the bug, which is the only run that proves anything:

```
$ date -u
23:10 UTC          # now + 1h crosses into the next date

$ pytest -q "services/audit_logger_test.py::TestAuditLoggerQuery"    2 passed
$ pytest -q services/audit_logger_test.py                            15 passed
```

Mutation-checked, so the new assertion is not merely passing by luck — breaking the date key in the production loop must fail the test:

```
key = f"audit:log:{date_str}"  ->  key = "audit:log:BROKEN"      1 failed
restored                                                          1 passed
```

(My first mutation attempt silently matched nothing and "passed"; the result above is from the corrected one.)

## Model Used

Opus 5

Closes #13680
