### PR TITLE
security(ssrf): drop credential headers on cross-origin redirect hops (#13624)

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -34,6 +34,20 @@ query-filters:
       3) For ssh: resolve_safe_ip_async() blocks RFC1918/loopback/link-local ranges
       The validation happens before any use in _run_git(). See #MVA-2605.
   - exclude:
+      id: py/full-ssrf
+      files: autobot_shared/security/ssrf_guard.py
+    reason: >-
+      This module IS the SSRF guard. Both outbound call sites (fetch_safe_url,
+      pinned_request_with_redirects) are immediately preceded by
+      pinned_connector(url), which runs resolve_safe_ip on that exact URL and pins
+      the resolved public IP into the connector's resolver, defeating DNS-rebind.
+      pinned_request_with_redirects additionally sets allow_redirects=False and
+      re-validates every hop itself rather than letting aiohttp follow one.
+      CodeQL models the caller-supplied URL as reaching the request and cannot
+      see the guard in between. Pre-existing on main (alerts 1042/1045, both
+      dismissed as false positives); surfaced as "new" on #13624 only because
+      that PR edits the line. See #13624.
+  - exclude:
       id: py/path-injection
     paths:
       - autobot-backend/transcriber/upload_security.py

--- a/autobot_shared/security/ssrf_guard.py
+++ b/autobot_shared/security/ssrf_guard.py
@@ -129,6 +129,103 @@ async def pinned_connector(url: str) -> aiohttp.TCPConnector:
     return aiohttp.TCPConnector(resolver=resolver, use_dns_cache=False)
 
 
+# Headers that authenticate the caller. Dropped when a redirect crosses to a
+# different origin, so a 302 to an attacker-controlled *public* host cannot
+# harvest them (#13624). Per-hop IP pinning already blocks redirects to private
+# addresses; it does nothing about this case.
+#
+# An explicit list, deliberately not a pattern: ``*-token``/``*-key`` would also
+# strip ``idempotency-key`` and ``x-correlation-id``, which are not credentials.
+_CREDENTIAL_HEADERS = frozenset(
+    {
+        # fetch-spec set
+        "authorization",
+        "proxy-authorization",
+        "cookie",
+        "cookie2",
+        # widely used provider auth headers
+        "x-api-key",
+        "api-key",
+        "apikey",
+        "x-auth-token",
+        "auth-token",
+        "x-auth-key",
+        "x-access-token",
+        "access-token",
+        "x-session-token",
+        "x-csrf-token",
+        "x-xsrf-token",
+        "private-token",
+        "x-private-token",
+        "job-token",
+        "x-goog-api-key",
+        "x-amz-security-token",
+        "x-ms-client-request-id",
+        "x-functions-key",
+        "x-shopify-access-token",
+        "x-figma-token",
+        "x-airtable-api-key",
+        "x-sentry-auth",
+        "x-vault-token",
+        "x-subscription-token",
+        "x-registry-auth",
+        "dd-api-key",
+        "circle-token",
+    }
+)
+
+# Describe a request body; meaningless once a redirect rewrites the method to
+# GET, and dropped then, mirroring the fetch spec.
+_BODY_HEADERS = frozenset(
+    {
+        "content-encoding",
+        "content-language",
+        "content-length",
+        "content-location",
+        "content-type",
+        "transfer-encoding",
+    }
+)
+
+_DEFAULT_PORTS = {"http": 80, "https": 443, "ws": 80, "wss": 443}
+
+
+def _origin(url: str) -> tuple:
+    """Scheme/host/port triple, with the scheme's default port made explicit."""
+    parsed = urlparse(url)
+    scheme = (parsed.scheme or "").lower()
+    host = (parsed.hostname or "").lower()
+    return scheme, host, parsed.port or _DEFAULT_PORTS.get(scheme)
+
+
+def _headers_for_hop(headers: dict | None, from_url: str, to_url: str, *, drop_body: bool) -> dict | None:
+    """Headers to send on the next hop, minus anything it must not receive (#13624)."""
+    if not headers:
+        return headers
+    cross_origin = _origin(from_url) != _origin(to_url)
+    if not cross_origin and not drop_body:
+        return headers
+    kept = {}
+    for name, value in headers.items():
+        lowered = name.lower()
+        if cross_origin and lowered in _CREDENTIAL_HEADERS:
+            continue
+        if drop_body and lowered in _BODY_HEADERS:
+            continue
+        kept[name] = value
+    return kept
+
+
+def _method_for_hop(method: str, status: int) -> str:
+    """The method the next hop uses, following the fetch spec's rewrite rules."""
+    upper = method.upper()
+    if status == 303 and upper != "HEAD":
+        return "GET"
+    if status in (301, 302) and upper == "POST":
+        return "GET"
+    return method
+
+
 @asynccontextmanager
 async def pinned_request_with_redirects(
     method: str,
@@ -163,11 +260,15 @@ async def pinned_request_with_redirects(
     their own sessions immediately after reading the ``Location`` header.
     """
     current_url = url
+    current_method = method
+    current_headers = headers
     for _ in range(max_redirects + 1):
         connector = await pinned_connector(current_url)
         session = aiohttp.ClientSession(connector=connector, timeout=timeout)
         try:
-            resp = await session.request(method, current_url, headers=headers, allow_redirects=False, ssl=ssl)
+            resp = await session.request(
+                current_method, current_url, headers=current_headers, allow_redirects=False, ssl=ssl
+            )
         except Exception:
             await session.close()
             raise
@@ -180,9 +281,16 @@ async def pinned_request_with_redirects(
                 await session.close()
             return
 
+        status = resp.status
         await resp.release()
         await session.close()
-        current_url = urljoin(current_url, location)
+        next_url = urljoin(current_url, location)
+        next_method = _method_for_hop(current_method, status)
+        current_headers = _headers_for_hop(
+            current_headers, current_url, next_url, drop_body=next_method != current_method
+        )
+        current_method = next_method
+        current_url = next_url
 
     raise SSRFError(f"exceeded max_redirects={max_redirects} while fetching {url!r}")
 

--- a/autobot_shared/security/ssrf_guard.py
+++ b/autobot_shared/security/ssrf_guard.py
@@ -266,6 +266,11 @@ async def pinned_request_with_redirects(
         connector = await pinned_connector(current_url)
         session = aiohttp.ClientSession(connector=connector, timeout=timeout)
         try:
+            # SSRF mitigated: pinned_connector(current_url) above runs the real
+            # resolve_safe_ip guard on THIS hop's URL and pins the resolved public
+            # IP (defeats DNS-rebind); redirects are disabled so every hop is
+            # re-validated here rather than followed by aiohttp.
+            # codeql[py/full-ssrf] (#13624, pattern from #12278)
             resp = await session.request(
                 current_method, current_url, headers=current_headers, allow_redirects=False, ssl=ssl
             )

--- a/autobot_shared/security/ssrf_guard.py
+++ b/autobot_shared/security/ssrf_guard.py
@@ -270,8 +270,10 @@ async def pinned_request_with_redirects(
             # resolve_safe_ip guard on THIS hop's URL and pins the resolved public
             # IP (defeats DNS-rebind); redirects are disabled so every hop is
             # re-validated here rather than followed by aiohttp.
-            # (#13624, pattern from #12278)
-            resp = await session.request(  # codeql[py/full-ssrf]
+            # py/full-ssrf here is a false positive; inline codeql[...] comments do
+            # NOT dismiss alerts (#12307), so it is handled in
+            # .github/codeql/codeql-config.yml instead.
+            resp = await session.request(
                 current_method, current_url, headers=current_headers, allow_redirects=False, ssl=ssl
             )
         except Exception:

--- a/autobot_shared/security/ssrf_guard.py
+++ b/autobot_shared/security/ssrf_guard.py
@@ -270,8 +270,8 @@ async def pinned_request_with_redirects(
             # resolve_safe_ip guard on THIS hop's URL and pins the resolved public
             # IP (defeats DNS-rebind); redirects are disabled so every hop is
             # re-validated here rather than followed by aiohttp.
-            # codeql[py/full-ssrf] (#13624, pattern from #12278)
-            resp = await session.request(
+            # (#13624, pattern from #12278)
+            resp = await session.request(  # codeql[py/full-ssrf]
                 current_method, current_url, headers=current_headers, allow_redirects=False, ssl=ssl
             )
         except Exception:

--- a/autobot_shared/security/ssrf_guard_test.py
+++ b/autobot_shared/security/ssrf_guard_test.py
@@ -406,6 +406,142 @@ async def test_pinned_request_with_redirects_no_redirect_returns_response() -> N
     assert resolver_result[0]["hostname"] == "real.example.com"
 
 
+def _two_hop(location, hop2_host="real2.example.com"):
+    """Canned 302 -> 200 pair plus per-hop DNS answers."""
+    return (
+        [
+            [(2, 1, 6, "", ("93.184.216.34", 0))],
+            [(2, 1, 6, "", ("8.8.4.4", 0))],
+        ],
+        _make_fake_session_class(
+            [
+                _make_fake_response(302, {"Location": location}),
+                _make_fake_response(200, {"Content-Type": "text/html"}),
+            ]
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_cross_origin_redirect_drops_credential_headers() -> None:
+    """#13624: a 302 to a foreign origin must not carry the caller's credentials.
+
+    Per-hop IP pinning already refuses redirects to *private* addresses; it does
+    nothing about a redirect to an attacker-controlled *public* host, which is
+    the credential-exfiltration case.
+    """
+    per_hop_infos, (fake_cls, calls) = _two_hop("https://evil.example.net/collect")
+    sent = {
+        "Authorization": "Bearer super-secret",
+        "Cookie": "session=abc",
+        "X-Api-Key": "k-123",
+        "Accept": "text/html",
+    }
+
+    with (
+        patch("autobot_shared.url_safety.socket.getaddrinfo", side_effect=per_hop_infos),
+        patch("aiohttp.ClientSession", fake_cls),
+    ):
+        async with pinned_request_with_redirects("GET", "https://real.example.com/start", headers=sent) as resp:
+            assert resp.status == 200
+
+    hop2 = calls[1]["kwargs"]["headers"]
+    assert "Authorization" not in hop2, "credential replayed to a foreign origin"
+    assert "Cookie" not in hop2
+    assert "X-Api-Key" not in hop2
+    # Non-credential headers still travel.
+    assert hop2["Accept"] == "text/html"
+    # The caller's own dict must not be mutated.
+    assert sent["Authorization"] == "Bearer super-secret"
+
+
+@pytest.mark.asyncio
+async def test_same_origin_redirect_keeps_credential_headers() -> None:
+    """#13624: stripping must be scoped to origin changes, or same-host redirects break."""
+    per_hop_infos, (fake_cls, calls) = _two_hop("https://real.example.com/final")
+
+    with (
+        patch("autobot_shared.url_safety.socket.getaddrinfo", side_effect=per_hop_infos),
+        patch("aiohttp.ClientSession", fake_cls),
+    ):
+        async with pinned_request_with_redirects(
+            "GET", "https://real.example.com/start", headers={"Authorization": "Bearer keep-me"}
+        ) as resp:
+            assert resp.status == 200
+
+    assert calls[1]["kwargs"]["headers"]["Authorization"] == "Bearer keep-me"
+
+
+@pytest.mark.asyncio
+async def test_credential_looking_header_that_is_not_a_credential_survives() -> None:
+    """#13624: the list is explicit for a reason.
+
+    A ``*-token``/``*-key`` pattern would also strip ``idempotency-key`` and
+    ``x-correlation-id``, which are not credentials and whose loss silently
+    changes request semantics.
+    """
+    per_hop_infos, (fake_cls, calls) = _two_hop("https://evil.example.net/collect")
+    sent = {"Idempotency-Key": "abc-123", "X-Correlation-Id": "cid-9", "Authorization": "Bearer s"}
+
+    with (
+        patch("autobot_shared.url_safety.socket.getaddrinfo", side_effect=per_hop_infos),
+        patch("aiohttp.ClientSession", fake_cls),
+    ):
+        async with pinned_request_with_redirects("GET", "https://real.example.com/start", headers=sent) as resp:
+            assert resp.status == 200
+
+    hop2 = calls[1]["kwargs"]["headers"]
+    assert hop2["Idempotency-Key"] == "abc-123"
+    assert hop2["X-Correlation-Id"] == "cid-9"
+    assert "Authorization" not in hop2
+
+
+@pytest.mark.asyncio
+async def test_cross_port_and_cross_scheme_count_as_cross_origin() -> None:
+    """#13624: origin is scheme+host+port, not host alone."""
+    for location in ("https://real.example.com:8443/x", "http://real.example.com/x"):
+        per_hop_infos, (fake_cls, calls) = _two_hop(location)
+        with (
+            patch("autobot_shared.url_safety.socket.getaddrinfo", side_effect=per_hop_infos),
+            patch("aiohttp.ClientSession", fake_cls),
+        ):
+            async with pinned_request_with_redirects(
+                "GET", "https://real.example.com/start", headers={"Authorization": "Bearer s"}
+            ) as resp:
+                assert resp.status == 200
+        assert "Authorization" not in calls[1]["kwargs"]["headers"], location
+
+
+@pytest.mark.asyncio
+async def test_303_rewrites_method_to_get_and_drops_body_headers() -> None:
+    """#13624: a method rewrite makes the body headers meaningless (fetch spec)."""
+    per_hop_infos = [
+        [(2, 1, 6, "", ("93.184.216.34", 0))],
+        [(2, 1, 6, "", ("8.8.4.4", 0))],
+    ]
+    fake_cls, calls = _make_fake_session_class(
+        [
+            _make_fake_response(303, {"Location": "https://real.example.com/result"}),
+            _make_fake_response(200, {}),
+        ]
+    )
+    sent = {"Content-Type": "application/json", "Content-Length": "17", "Accept": "*/*"}
+
+    with (
+        patch("autobot_shared.url_safety.socket.getaddrinfo", side_effect=per_hop_infos),
+        patch("aiohttp.ClientSession", fake_cls),
+    ):
+        async with pinned_request_with_redirects("POST", "https://real.example.com/start", headers=sent) as resp:
+            assert resp.status == 200
+
+    assert calls[0]["method"] == "POST"
+    assert calls[1]["method"] == "GET", "303 must rewrite the method"
+    hop2 = calls[1]["kwargs"]["headers"]
+    assert "Content-Type" not in hop2
+    assert "Content-Length" not in hop2
+    assert hop2["Accept"] == "*/*"
+
+
 @pytest.mark.asyncio
 async def test_pinned_request_with_redirects_follows_redirect_with_per_hop_pin() -> None:
     """A same-origin 302 is followed; the second hop is independently resolved + pinned."""


### PR DESCRIPTION
## Thinking Path

`pinned_request_with_redirects` re-resolves and re-pins every hop — that part is solid, and is why a redirect to a *private* address is refused. But the caller's `headers` dict was passed unchanged while `current_url` moved:

```python
resp = await session.request(method, current_url, headers=headers, allow_redirects=False, ssl=ssl)
...
current_url = urljoin(current_url, location)
```

So a 302 to an attacker-controlled **public** host was followed with the caller's `Authorization` / API key still attached. IP pinning does nothing about that case, and this function exists precisely for the callers that follow redirects over content the agent does not control — `web_fetch` and `media/link/pipeline`.

## What Changed

Credential headers are dropped when a hop changes **origin** (scheme, host, or port — not host alone), and body headers are dropped when a redirect rewrites the method to GET, mirroring the fetch spec.

The list is explicit, deliberately not a pattern. `*-token`/`*-key` would also strip `idempotency-key` and `x-correlation-id`, which are not credentials and whose loss silently changes request semantics. It covers the fetch-spec set plus ~25 provider auth headers actually in use.

Method rewriting follows the spec: 303 rewrites anything but HEAD to GET; 301/302 rewrite POST to GET. Previously the method was reused verbatim on every hop, so a 303 kept POSTing.

The caller's dict is never mutated — a filtered copy is built only when a hop actually needs one, so the same-origin path allocates nothing.

## Verification

```
autobot_shared/security/            116 passed
autobot-backend/media/link/          56 passed   (caller)
autobot-backend/web_fetch/            7 passed   (caller)
flake8                                clean
```

Each test was run against the **vulnerable** code to confirm it fails there, rather than assumed meaningful:

```
4 failed, 1 passed        # against origin/Dev_new_gui's ssrf_guard.py
36 passed                 # restored
```

The one that passes on both is `test_same_origin_redirect_keeps_credential_headers` — it guards the opposite error, over-stripping, which would break every same-host redirect.

Covered:

| Test | Asserts |
|---|---|
| `cross_origin_..._drops_credential_headers` | `Authorization`/`Cookie`/`X-Api-Key` absent on hop 2; `Accept` still present; caller's dict unmutated |
| `same_origin_..._keeps_credential_headers` | same-host hop still authenticates |
| `credential_looking_header_that_is_not_a_credential_survives` | `Idempotency-Key`, `X-Correlation-Id` survive a cross-origin hop |
| `cross_port_and_cross_scheme_count_as_cross_origin` | `:8443` and `http://` both count as cross-origin |
| `303_rewrites_method_to_get_and_drops_body_headers` | POST→GET, `Content-Type`/`Content-Length` dropped |

## Model Used

Opus 5

Closes #13624
