### PR TITLE
fix(memory): reconnect the L2 memory graph (#13686)

### DIFF
--- a/autobot-backend/chat_workflow/llm_handler.py
+++ b/autobot-backend/chat_workflow/llm_handler.py
@@ -766,7 +766,6 @@ NEVER teach commands - ALWAYS execute them.""" + lang_instruction
         use_knowledge: bool = True,
         language: str = None,
         lightweight_mode: bool = False,
-        work_item_id: str | None = None,
     ) -> Dict[str, Any]:
         """Prepare LLM request parameters including endpoint, model, and prompt.
 
@@ -774,10 +773,6 @@ NEVER teach commands - ALWAYS execute them.""" + lang_instruction
         Issue MVA-1992: lightweight_mode bypasses RAG/memory for trivial queries.
         Issue #11585: session.metadata["model_override"] (per-request/per-conversation
         choice) takes priority over the global config default.
-        Issue #13687: work_item_id is the governed identity lifted by
-        build_governed_identity (GH#11160); it is what maps a turn to a goal so
-        L4 GoalAncestry can render. None means "no goal linked" — L4 stays silent
-        and no goal query is issued.
         """
         selected_model = self._get_selected_model(
             session.metadata.get("model_override") if session and session.metadata else None
@@ -812,15 +807,11 @@ NEVER teach commands - ALWAYS execute them.""" + lang_instruction
                 from chat_history.layers import TIERED_CONTEXT_ENABLED, TieredContextBuilder
 
                 if TIERED_CONTEXT_ENABLED:
-                    # Issues #13686/#13687: L2 and L4 were structurally unable to
-                    # render — the memory graph was read off an object that never
-                    # had it, and goal ancestry was never passed at all. Both
-                    # inputs are now resolved from their owners; both degrade to
-                    # None without failing the turn.
-                    from chat_workflow.tiered_context_sources import (
-                        resolve_goal_ancestry,
-                        resolve_memory_graph,
-                    )
+                    # Issue #13686: the memory graph was read off an object that
+                    # never had it, so L2 returned "" on every turn. It now comes
+                    # from the manager that owns it, and degrades to None rather
+                    # than failing the turn.
+                    from chat_workflow.tiered_context_sources import resolve_memory_graph
 
                     tiered_ctx = await TieredContextBuilder().build(
                         user_message=message,
@@ -828,7 +819,6 @@ NEVER teach commands - ALWAYS execute them.""" + lang_instruction
                         session_id=session.session_id,
                         memory_graph=await resolve_memory_graph(),
                         knowledge_service=self.knowledge_service if use_knowledge else None,
-                        goal_ancestry=await resolve_goal_ancestry(work_item_id),
                     )
                     if tiered_ctx:
                         system_prompt = tiered_ctx + "\n\n" + system_prompt

--- a/autobot-backend/chat_workflow/llm_handler.py
+++ b/autobot-backend/chat_workflow/llm_handler.py
@@ -766,6 +766,7 @@ NEVER teach commands - ALWAYS execute them.""" + lang_instruction
         use_knowledge: bool = True,
         language: str = None,
         lightweight_mode: bool = False,
+        work_item_id: str | None = None,
     ) -> Dict[str, Any]:
         """Prepare LLM request parameters including endpoint, model, and prompt.
 
@@ -773,6 +774,10 @@ NEVER teach commands - ALWAYS execute them.""" + lang_instruction
         Issue MVA-1992: lightweight_mode bypasses RAG/memory for trivial queries.
         Issue #11585: session.metadata["model_override"] (per-request/per-conversation
         choice) takes priority over the global config default.
+        Issue #13687: work_item_id is the governed identity lifted by
+        build_governed_identity (GH#11160); it is what maps a turn to a goal so
+        L4 GoalAncestry can render. None means "no goal linked" — L4 stays silent
+        and no goal query is issued.
         """
         selected_model = self._get_selected_model(
             session.metadata.get("model_override") if session and session.metadata else None
@@ -807,12 +812,23 @@ NEVER teach commands - ALWAYS execute them.""" + lang_instruction
                 from chat_history.layers import TIERED_CONTEXT_ENABLED, TieredContextBuilder
 
                 if TIERED_CONTEXT_ENABLED:
+                    # Issues #13686/#13687: L2 and L4 were structurally unable to
+                    # render — the memory graph was read off an object that never
+                    # had it, and goal ancestry was never passed at all. Both
+                    # inputs are now resolved from their owners; both degrade to
+                    # None without failing the turn.
+                    from chat_workflow.tiered_context_sources import (
+                        resolve_goal_ancestry,
+                        resolve_memory_graph,
+                    )
+
                     tiered_ctx = await TieredContextBuilder().build(
                         user_message=message,
                         model_name=selected_model,
                         session_id=session.session_id,
-                        memory_graph=getattr(self, "memory_graph", None),
+                        memory_graph=await resolve_memory_graph(),
                         knowledge_service=self.knowledge_service if use_knowledge else None,
+                        goal_ancestry=await resolve_goal_ancestry(work_item_id),
                     )
                     if tiered_ctx:
                         system_prompt = tiered_ctx + "\n\n" + system_prompt

--- a/autobot-backend/chat_workflow/manager.py
+++ b/autobot-backend/chat_workflow/manager.py
@@ -3364,19 +3364,8 @@ before summarizing.
         except Exception as e:
             logger.warning("[MVA-1992] Complexity routing failed, defaulting to full mode: %s", e)
 
-        # GH#11160/#13687: lift the governed work item from the request context with
-        # the same canonical extractor _create_llm_iteration_context uses, so the
-        # goal-ancestry lookup and the approval seam can never disagree on which
-        # work item a turn belongs to.
-        _, prompt_work_item_id, _ = build_governed_identity(context or {}, session.session_id)
-
         llm_params = await self._prepare_llm_request_params(
-            session,
-            message,
-            use_knowledge=use_knowledge,
-            language=language,
-            lightweight_mode=lightweight_mode,
-            work_item_id=prompt_work_item_id,
+            session, message, use_knowledge=use_knowledge, language=language, lightweight_mode=lightweight_mode
         )
         # MVA-1993: Store lightweight_mode in params for response metadata
         llm_params["lightweight_mode_used"] = lightweight_mode

--- a/autobot-backend/chat_workflow/manager.py
+++ b/autobot-backend/chat_workflow/manager.py
@@ -3364,8 +3364,19 @@ before summarizing.
         except Exception as e:
             logger.warning("[MVA-1992] Complexity routing failed, defaulting to full mode: %s", e)
 
+        # GH#11160/#13687: lift the governed work item from the request context with
+        # the same canonical extractor _create_llm_iteration_context uses, so the
+        # goal-ancestry lookup and the approval seam can never disagree on which
+        # work item a turn belongs to.
+        _, prompt_work_item_id, _ = build_governed_identity(context or {}, session.session_id)
+
         llm_params = await self._prepare_llm_request_params(
-            session, message, use_knowledge=use_knowledge, language=language, lightweight_mode=lightweight_mode
+            session,
+            message,
+            use_knowledge=use_knowledge,
+            language=language,
+            lightweight_mode=lightweight_mode,
+            work_item_id=prompt_work_item_id,
         )
         # MVA-1993: Store lightweight_mode in params for response metadata
         llm_params["lightweight_mode_used"] = lightweight_mode

--- a/autobot-backend/chat_workflow/tiered_context_prompt_test.py
+++ b/autobot-backend/chat_workflow/tiered_context_prompt_test.py
@@ -1,0 +1,159 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""End-to-end prompt capture for the reconnected L2/L4 layers (#13686, #13687).
+
+The unit tests in ``tiered_context_sources_test.py`` prove the resolvers return
+the right objects. These prove the *prompt the model actually receives* now
+contains the blocks those objects feed — which is what both acceptance criteria
+ask for, and what could not happen before the fix.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _handler_with_tiered_context_on():
+    """Build a bare LLMHandlerMixin for prompt assembly.
+
+    Mirrors ``tests/test_lightweight_mode.py`` — every collaborator the method
+    touches is mocked, so a bare instance exercises the real prompt assembly.
+    """
+    from chat_workflow.llm_handler import LLMHandlerMixin
+
+    handler = LLMHandlerMixin.__new__(LLMHandlerMixin)
+    handler.knowledge_service = None
+    handler._get_selected_model = MagicMock(return_value="test-model")
+    handler._get_ollama_endpoint_for_model = MagicMock(return_value="http://test")
+    handler._get_system_prompt = MagicMock(return_value="SYSTEM")
+    handler._build_conversation_context = MagicMock(return_value="")
+    handler._build_full_prompt = MagicMock(return_value="Full prompt")
+    handler._discover_ollama_from_slm = AsyncMock(return_value=None)
+    return handler
+
+
+def _tiered_context_on():
+    """Turn the #5066 feature flag on for the duration of a test.
+
+    The flag is resolved from SSOT config at import time
+    (``chat_history/layers.py:46``), so an env-var reload cannot flip it. The
+    production call site re-imports the name from the module on every turn, so
+    patching the module attribute is what the running code actually reads.
+    """
+    return patch("chat_history.layers.TIERED_CONTEXT_ENABLED", True)
+
+
+async def _capture_system_prompt(handler, session, message):
+    """Run _prepare_llm_request_params under the flag and return the system prompt."""
+    with _tiered_context_on(), patch(
+        "chat_workflow.llm_handler._emit_before_prompt_build", new_callable=AsyncMock
+    ):
+        with patch(
+            "chat_workflow.llm_handler._emit_system_prompt_ready",
+            new_callable=AsyncMock,
+            side_effect=lambda prompt, _session: prompt,
+        ):
+            with patch(
+                "chat_workflow.llm_handler._emit_after_prompt_build",
+                new_callable=AsyncMock,
+                return_value="Full prompt",
+            ):
+                with patch(
+                    "chat_workflow.llm_handler._emit_full_prompt_ready",
+                    new_callable=AsyncMock,
+                    return_value="Full prompt",
+                ):
+                    params = await handler._prepare_llm_request_params(
+                        session,
+                        message,
+                        use_knowledge=False,
+                        work_item_id=getattr(session, "_work_item_id", None),
+                    )
+    return params["system_prompt"]
+
+
+def _session(work_item_id=None):
+    session = MagicMock()
+    session.session_id = "s-1"
+    session.conversation_history = []
+    session.metadata = {}
+    session._work_item_id = work_item_id
+    return session
+
+
+class TestL2RendersInPrompt:
+    @pytest.mark.asyncio
+    async def test_known_entity_renders_related_context_block(self):
+        """AC #13686: flag on + a known entity -> '## Related Context' in the prompt."""
+        graph = MagicMock()
+        graph.search_entities = AsyncMock(
+            return_value=[{"name": "Redis", "description": "in-memory store used for sessions"}]
+        )
+        chm = MagicMock()
+        chm.memory_graph = graph
+
+        handler = _handler_with_tiered_context_on()
+        with patch(
+            "utils.resource_factory.ResourceFactory.get_initialized_chat_history_manager",
+            return_value=chm,
+        ):
+            prompt = await _capture_system_prompt(handler, _session(), "How does Redis hold sessions?")
+
+        assert "## Related Context" in prompt
+        assert "in-memory store used for sessions" in prompt
+
+    @pytest.mark.asyncio
+    async def test_absent_graph_degrades_and_turn_completes(self):
+        """AC #13686: graph unavailable -> no L2 block, turn still completes."""
+        handler = _handler_with_tiered_context_on()
+
+        with patch(
+            "utils.resource_factory.ResourceFactory.get_initialized_chat_history_manager",
+            return_value=None,
+        ):
+            prompt = await _capture_system_prompt(handler, _session(), "How does Redis hold sessions?")
+
+        assert "## Related Context" not in prompt
+        assert "SYSTEM" in prompt
+
+
+class TestL4RendersInPrompt:
+    @pytest.mark.asyncio
+    async def test_linked_goal_renders_goal_ancestry_block(self):
+        """AC #13687: flag on + a session linked to a goal -> '## Goal Ancestry'."""
+        chain = [
+            {"id": "1", "title": "Ship the platform", "level": "vision", "status": "active"},
+            {"id": "2", "title": "Wake the context stack", "level": "objective", "status": "active"},
+        ]
+        handler = _handler_with_tiered_context_on()
+
+        with patch(
+            "utils.resource_factory.ResourceFactory.get_initialized_chat_history_manager",
+            return_value=None,
+        ):
+            with patch(
+                "chat_workflow.tiered_context_sources.resolve_goal_ancestry",
+                new_callable=AsyncMock,
+                return_value=chain,
+            ):
+                prompt = await _capture_system_prompt(handler, _session("wi-1"), "status?")
+
+        assert "## Goal Ancestry" in prompt
+        assert "Wake the context stack" in prompt
+
+    @pytest.mark.asyncio
+    async def test_unlinked_session_renders_no_goal_block(self):
+        """AC #13687: no linked goal -> no L4 block (and no goal query)."""
+        handler = _handler_with_tiered_context_on()
+
+        with patch(
+            "utils.resource_factory.ResourceFactory.get_initialized_chat_history_manager",
+            return_value=None,
+        ):
+            with patch("user_management.database.get_async_session_factory") as factory:
+                prompt = await _capture_system_prompt(handler, _session(None), "status?")
+
+        assert "## Goal Ancestry" not in prompt
+        factory.assert_not_called()

--- a/autobot-backend/chat_workflow/tiered_context_prompt_test.py
+++ b/autobot-backend/chat_workflow/tiered_context_prompt_test.py
@@ -47,9 +47,7 @@ def _tiered_context_on():
 
 async def _capture_system_prompt(handler, session, message):
     """Run _prepare_llm_request_params under the flag and return the system prompt."""
-    with _tiered_context_on(), patch(
-        "chat_workflow.llm_handler._emit_before_prompt_build", new_callable=AsyncMock
-    ):
+    with _tiered_context_on(), patch("chat_workflow.llm_handler._emit_before_prompt_build", new_callable=AsyncMock):
         with patch(
             "chat_workflow.llm_handler._emit_system_prompt_ready",
             new_callable=AsyncMock,

--- a/autobot-backend/chat_workflow/tiered_context_prompt_test.py
+++ b/autobot-backend/chat_workflow/tiered_context_prompt_test.py
@@ -2,12 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
-"""End-to-end prompt capture for the reconnected L2/L4 layers (#13686, #13687).
+"""End-to-end prompt capture for the reconnected L2 layer (#13686).
 
-The unit tests in ``tiered_context_sources_test.py`` prove the resolvers return
-the right objects. These prove the *prompt the model actually receives* now
-contains the blocks those objects feed — which is what both acceptance criteria
-ask for, and what could not happen before the fix.
+``tiered_context_sources_test.py`` proves the resolver returns the graph the
+manager owns. These prove the *prompt the model actually receives* now contains
+the block that graph feeds — which is the acceptance criterion, and what could
+not happen before the fix.
 """
 
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -69,17 +69,15 @@ async def _capture_system_prompt(handler, session, message):
                         session,
                         message,
                         use_knowledge=False,
-                        work_item_id=getattr(session, "_work_item_id", None),
                     )
     return params["system_prompt"]
 
 
-def _session(work_item_id=None):
+def _session():
     session = MagicMock()
     session.session_id = "s-1"
     session.conversation_history = []
     session.metadata = {}
-    session._work_item_id = work_item_id
     return session
 
 
@@ -117,43 +115,3 @@ class TestL2RendersInPrompt:
 
         assert "## Related Context" not in prompt
         assert "SYSTEM" in prompt
-
-
-class TestL4RendersInPrompt:
-    @pytest.mark.asyncio
-    async def test_linked_goal_renders_goal_ancestry_block(self):
-        """AC #13687: flag on + a session linked to a goal -> '## Goal Ancestry'."""
-        chain = [
-            {"id": "1", "title": "Ship the platform", "level": "vision", "status": "active"},
-            {"id": "2", "title": "Wake the context stack", "level": "objective", "status": "active"},
-        ]
-        handler = _handler_with_tiered_context_on()
-
-        with patch(
-            "utils.resource_factory.ResourceFactory.get_initialized_chat_history_manager",
-            return_value=None,
-        ):
-            with patch(
-                "chat_workflow.tiered_context_sources.resolve_goal_ancestry",
-                new_callable=AsyncMock,
-                return_value=chain,
-            ):
-                prompt = await _capture_system_prompt(handler, _session("wi-1"), "status?")
-
-        assert "## Goal Ancestry" in prompt
-        assert "Wake the context stack" in prompt
-
-    @pytest.mark.asyncio
-    async def test_unlinked_session_renders_no_goal_block(self):
-        """AC #13687: no linked goal -> no L4 block (and no goal query)."""
-        handler = _handler_with_tiered_context_on()
-
-        with patch(
-            "utils.resource_factory.ResourceFactory.get_initialized_chat_history_manager",
-            return_value=None,
-        ):
-            with patch("user_management.database.get_async_session_factory") as factory:
-                prompt = await _capture_system_prompt(handler, _session(None), "status?")
-
-        assert "## Goal Ancestry" not in prompt
-        factory.assert_not_called()

--- a/autobot-backend/chat_workflow/tiered_context_sources.py
+++ b/autobot-backend/chat_workflow/tiered_context_sources.py
@@ -2,26 +2,23 @@
 # SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
-"""Data sources for the tiered L0-L4 context stack (#5066, GH#6469).
+"""Data sources for the tiered L0-L4 context stack (#5066).
 
 The layers in :mod:`chat_history.layers` are pure renderers — they read what the
-caller puts in the context dict and render nothing when it is absent. Two of
-them were therefore permanently silent in production because the call site never
-supplied their input:
+caller puts in the context dict and render nothing when it is absent. L2
+OnDemand was therefore permanently silent in production: `llm_handler` read
+``memory_graph`` off the chat *workflow* manager, which has no such attribute
+(#13686). The graph lives on the chat *history* manager.
 
-* **L2 OnDemand** (#13686) read ``memory_graph`` off the chat *workflow* manager,
-  which has no such attribute. The graph lives on the chat *history* manager.
-* **L4 GoalAncestry** (#13687) was never passed a ``goal_ancestry`` argument at
-  all, so ``should_load(None)`` was always False.
-
-This module owns the resolution of both inputs so the fix is testable without
-constructing a ``ChatWorkflowManager``, and so neither resolver can take a
-prompt-building turn down: both return None on any failure.
+L4 GoalAncestry is still dark, deliberately. Wiring it needs a server-side
+session→work-item binding that does not exist yet, and a tenant-scoped goal
+lookup — see the follow-up issue referenced from #13687. Sourcing the work item
+from the client-supplied request context would have made an unscoped
+cross-tenant read out of a rendering fix.
 """
 
 from __future__ import annotations
 
-import uuid
 from typing import Any
 
 from autobot_shared.logging_manager import get_logger
@@ -51,47 +48,4 @@ async def resolve_memory_graph() -> Any | None:
         return None
 
 
-async def resolve_goal_ancestry(work_item_id: str | None) -> list | None:
-    """Return the root-first goal ancestry chain for a work item, or None (#13687).
-
-    ``work_item_id`` is the governed identity already lifted from the request
-    context by ``build_governed_identity`` (GH#11160). A turn that carries no
-    work item is the common case: it must cost **no** DB round-trip, which is
-    why the falsy check comes before the session factory.
-
-    Returns None (never raises) so a goal-lookup failure leaves L4 silent
-    instead of failing the turn.
-    """
-    if not work_item_id:
-        return None
-    try:
-        return await _query_goal_ancestry(work_item_id)
-    except Exception as exc:
-        logger.warning("Goal ancestry lookup failed for work item %s: %s", work_item_id, exc)
-        return None
-
-
-async def _query_goal_ancestry(work_item_id: str) -> list | None:
-    """Resolve work item -> goal_id -> ancestry chain against the LLC store.
-
-    Split from :func:`resolve_goal_ancestry` to keep the imports lazy (the LLC
-    stack is optional at import time) and both functions inside the 30-line
-    limit.
-    """
-    from llc.services.goal import GoalService
-    from llc.services.work_item_service import WorkItemService
-    from user_management.database import get_async_session_factory
-
-    factory = get_async_session_factory()
-    async with factory() as session:
-        work_item = await WorkItemService().get(session, work_item_id)
-        goal_id = getattr(work_item, "goal_id", None) if work_item else None
-        if not goal_id:
-            return None
-        if not isinstance(goal_id, uuid.UUID):
-            goal_id = uuid.UUID(str(goal_id))
-        chain = await GoalService().get_goal_ancestry_for_work_item(session, goal_id)
-        return chain or None
-
-
-__all__ = ["resolve_memory_graph", "resolve_goal_ancestry"]
+__all__ = ["resolve_memory_graph"]

--- a/autobot-backend/chat_workflow/tiered_context_sources.py
+++ b/autobot-backend/chat_workflow/tiered_context_sources.py
@@ -1,0 +1,97 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Data sources for the tiered L0-L4 context stack (#5066, GH#6469).
+
+The layers in :mod:`chat_history.layers` are pure renderers — they read what the
+caller puts in the context dict and render nothing when it is absent. Two of
+them were therefore permanently silent in production because the call site never
+supplied their input:
+
+* **L2 OnDemand** (#13686) read ``memory_graph`` off the chat *workflow* manager,
+  which has no such attribute. The graph lives on the chat *history* manager.
+* **L4 GoalAncestry** (#13687) was never passed a ``goal_ancestry`` argument at
+  all, so ``should_load(None)`` was always False.
+
+This module owns the resolution of both inputs so the fix is testable without
+constructing a ``ChatWorkflowManager``, and so neither resolver can take a
+prompt-building turn down: both return None on any failure.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from autobot_shared.logging_manager import get_logger
+
+logger = get_logger(__name__)
+
+
+async def resolve_memory_graph() -> Any | None:
+    """Return the app's initialised memory graph, or None (#13686).
+
+    Reads ``.memory_graph`` off the process-wide ``ChatHistoryManager`` — the
+    object that constructs and owns it (``chat_history/base.py:244``) behind an
+    idempotent init and the ``memory_graph_enabled`` gate. No graph is
+    constructed here; when the manager is absent or its graph failed to
+    initialise, L2 degrades to an empty string exactly as designed.
+    """
+    try:
+        from utils.resource_factory import ResourceFactory
+
+        chm = ResourceFactory.get_initialized_chat_history_manager()
+        if chm is None:
+            logger.debug("Memory graph unavailable: no initialised ChatHistoryManager")
+            return None
+        return getattr(chm, "memory_graph", None)
+    except Exception as exc:
+        logger.warning("Memory graph resolution failed: %s", exc)
+        return None
+
+
+async def resolve_goal_ancestry(work_item_id: str | None) -> list | None:
+    """Return the root-first goal ancestry chain for a work item, or None (#13687).
+
+    ``work_item_id`` is the governed identity already lifted from the request
+    context by ``build_governed_identity`` (GH#11160). A turn that carries no
+    work item is the common case: it must cost **no** DB round-trip, which is
+    why the falsy check comes before the session factory.
+
+    Returns None (never raises) so a goal-lookup failure leaves L4 silent
+    instead of failing the turn.
+    """
+    if not work_item_id:
+        return None
+    try:
+        return await _query_goal_ancestry(work_item_id)
+    except Exception as exc:
+        logger.warning("Goal ancestry lookup failed for work item %s: %s", work_item_id, exc)
+        return None
+
+
+async def _query_goal_ancestry(work_item_id: str) -> list | None:
+    """Resolve work item -> goal_id -> ancestry chain against the LLC store.
+
+    Split from :func:`resolve_goal_ancestry` to keep the imports lazy (the LLC
+    stack is optional at import time) and both functions inside the 30-line
+    limit.
+    """
+    from llc.services.goal import GoalService
+    from llc.services.work_item_service import WorkItemService
+    from user_management.database import get_async_session_factory
+
+    factory = get_async_session_factory()
+    async with factory() as session:
+        work_item = await WorkItemService().get(session, work_item_id)
+        goal_id = getattr(work_item, "goal_id", None) if work_item else None
+        if not goal_id:
+            return None
+        if not isinstance(goal_id, uuid.UUID):
+            goal_id = uuid.UUID(str(goal_id))
+        chain = await GoalService().get_goal_ancestry_for_work_item(session, goal_id)
+        return chain or None
+
+
+__all__ = ["resolve_memory_graph", "resolve_goal_ancestry"]

--- a/autobot-backend/chat_workflow/tiered_context_sources_test.py
+++ b/autobot-backend/chat_workflow/tiered_context_sources_test.py
@@ -1,0 +1,204 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for the tiered-context data sources (#13686, #13687).
+
+These cover the two structural breaks that made L2 and L4 unable to render:
+the memory graph was read off an object that never had it, and goal ancestry
+was never passed at the only production call site.
+"""
+
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from chat_workflow.tiered_context_sources import resolve_goal_ancestry, resolve_memory_graph
+
+# ---------------------------------------------------------------------------
+# #13686 — memory graph resolution
+# ---------------------------------------------------------------------------
+
+
+class TestResolveMemoryGraph:
+    @pytest.mark.asyncio
+    async def test_returns_the_managers_own_graph_instance(self):
+        """The graph handed to L2 must be the *same object* the manager owns.
+
+        This is the #13686 regression: the old call site read
+        ``getattr(self, "memory_graph", None)`` off the workflow manager, which
+        has no such attribute, so L2 always received None.
+        """
+        graph = MagicMock(name="AutoBotMemoryGraph")
+        chm = MagicMock()
+        chm.memory_graph = graph
+
+        with patch(
+            "utils.resource_factory.ResourceFactory.get_initialized_chat_history_manager",
+            return_value=chm,
+        ):
+            resolved = await resolve_memory_graph()
+
+        assert resolved is graph
+
+    @pytest.mark.asyncio
+    async def test_constructs_no_second_memory_graph(self):
+        """Resolution must never build its own AutoBotMemoryGraph."""
+        chm = MagicMock()
+        chm.memory_graph = MagicMock()
+
+        with patch(
+            "utils.resource_factory.ResourceFactory.get_initialized_chat_history_manager",
+            return_value=chm,
+        ):
+            with patch("autobot_memory_graph.AutoBotMemoryGraph") as graph_cls:
+                await resolve_memory_graph()
+
+        graph_cls.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_degrades_to_none_without_a_manager(self):
+        """No initialised manager (pre-startup, or outside an app) -> None."""
+        with patch(
+            "utils.resource_factory.ResourceFactory.get_initialized_chat_history_manager",
+            return_value=None,
+        ):
+            assert await resolve_memory_graph() is None
+
+    @pytest.mark.asyncio
+    async def test_degrades_to_none_when_graph_init_failed(self):
+        """A manager whose graph failed to initialise leaves memory_graph None."""
+        chm = MagicMock()
+        chm.memory_graph = None
+
+        with patch(
+            "utils.resource_factory.ResourceFactory.get_initialized_chat_history_manager",
+            return_value=chm,
+        ):
+            assert await resolve_memory_graph() is None
+
+    @pytest.mark.asyncio
+    async def test_resolution_failure_is_non_fatal(self):
+        """A raising accessor must not take the turn down."""
+        with patch(
+            "utils.resource_factory.ResourceFactory.get_initialized_chat_history_manager",
+            side_effect=RuntimeError("boom"),
+        ):
+            assert await resolve_memory_graph() is None
+
+
+# ---------------------------------------------------------------------------
+# #13687 — goal ancestry resolution
+# ---------------------------------------------------------------------------
+
+
+def _install_llc_stubs(work_item, ancestry, session_factory_probe):
+    """Patch the lazily-imported LLC surface with controllable doubles."""
+    goal_service = MagicMock()
+    goal_service.get_goal_ancestry_for_work_item = AsyncMock(return_value=ancestry)
+    work_item_service = MagicMock()
+    work_item_service.get = AsyncMock(return_value=work_item)
+
+    goal_mod = MagicMock()
+    goal_mod.GoalService = MagicMock(return_value=goal_service)
+    wi_mod = MagicMock()
+    wi_mod.WorkItemService = MagicMock(return_value=work_item_service)
+    db_mod = MagicMock()
+    db_mod.get_async_session_factory = session_factory_probe
+
+    return (
+        patch.dict(
+            sys.modules,
+            {
+                "llc.services.goal": goal_mod,
+                "llc.services.work_item_service": wi_mod,
+                "user_management.database": db_mod,
+            },
+        ),
+        goal_service,
+        work_item_service,
+    )
+
+
+def _session_factory_probe():
+    """A session factory that records whether it was ever called."""
+    session_cm = MagicMock()
+    session_cm.__aenter__ = AsyncMock(return_value=MagicMock())
+    session_cm.__aexit__ = AsyncMock(return_value=False)
+    factory = MagicMock(return_value=session_cm)
+    return MagicMock(return_value=factory)
+
+
+class TestResolveGoalAncestry:
+    @pytest.mark.asyncio
+    async def test_no_work_item_issues_no_query(self):
+        """AC #13687: a turn with no linked goal must not touch the DB at all."""
+        probe = _session_factory_probe()
+        ctx, _, _ = _install_llc_stubs(MagicMock(), [], probe)
+
+        with ctx:
+            assert await resolve_goal_ancestry(None) is None
+            assert await resolve_goal_ancestry("") is None
+
+        probe.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_returns_root_first_chain_for_linked_goal(self):
+        import uuid
+
+        goal_id = uuid.uuid4()
+        work_item = MagicMock()
+        work_item.goal_id = goal_id
+        chain = [
+            {"id": "1", "title": "Ship the platform", "level": "vision", "status": "active"},
+            {"id": "2", "title": "Wake the context stack", "level": "objective", "status": "active"},
+        ]
+        ctx, goal_service, wi_service = _install_llc_stubs(work_item, chain, _session_factory_probe())
+
+        with ctx:
+            result = await resolve_goal_ancestry("wi-123")
+
+        assert result == chain
+        wi_service.get.assert_awaited_once()
+        assert goal_service.get_goal_ancestry_for_work_item.await_args.args[1] == goal_id
+
+    @pytest.mark.asyncio
+    async def test_work_item_without_goal_returns_none(self):
+        work_item = MagicMock()
+        work_item.goal_id = None
+        ctx, goal_service, _ = _install_llc_stubs(work_item, [], _session_factory_probe())
+
+        with ctx:
+            assert await resolve_goal_ancestry("wi-123") is None
+
+        goal_service.get_goal_ancestry_for_work_item.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_missing_work_item_returns_none(self):
+        ctx, goal_service, _ = _install_llc_stubs(None, [], _session_factory_probe())
+
+        with ctx:
+            assert await resolve_goal_ancestry("wi-404") is None
+
+        goal_service.get_goal_ancestry_for_work_item.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_empty_chain_returns_none_so_l4_stays_silent(self):
+        import uuid
+
+        work_item = MagicMock()
+        work_item.goal_id = uuid.uuid4()
+        ctx, _, _ = _install_llc_stubs(work_item, [], _session_factory_probe())
+
+        with ctx:
+            assert await resolve_goal_ancestry("wi-123") is None
+
+    @pytest.mark.asyncio
+    async def test_lookup_failure_is_non_fatal(self):
+        """AC #13687: a goal-lookup failure completes the turn without L4."""
+        probe = MagicMock(side_effect=RuntimeError("db down"))
+        ctx, _, _ = _install_llc_stubs(MagicMock(), [], probe)
+
+        with ctx:
+            assert await resolve_goal_ancestry("wi-123") is None

--- a/autobot-backend/chat_workflow/tiered_context_sources_test.py
+++ b/autobot-backend/chat_workflow/tiered_context_sources_test.py
@@ -2,81 +2,105 @@
 # SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
-"""Tests for the tiered-context data sources (#13686, #13687).
+"""Memory-graph resolution for the tiered context stack (#13686).
 
-These cover the two structural breaks that made L2 and L4 unable to render:
-the memory graph was read off an object that never had it, and goal ancestry
-was never passed at the only production call site.
+L2 OnDemand could never render: the graph was read off ``ChatWorkflowManager``,
+which has no such attribute, so ``getattr(..., None)`` always won and the layer
+returned "" on its first branch.
+
+These exercise the real accessor against a seeded ``app_state`` rather than
+patching the accessor itself — patching it would assert only that a mock
+returns a mock, and would leave the one line carrying the fix unexecuted.
 """
 
-import sys
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from chat_workflow.tiered_context_sources import resolve_goal_ancestry, resolve_memory_graph
+from chat_workflow.tiered_context_sources import resolve_memory_graph
+from utils.resource_factory import ResourceFactory
 
-# ---------------------------------------------------------------------------
-# #13686 — memory graph resolution
-# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def app_state():
+    """Yield the real process-wide app_state dict, restored afterwards."""
+    from initialization.lifespan import app_state as state
+
+    original = state.get("chat_history_manager")
+    yield state
+    state["chat_history_manager"] = original
+
+
+class TestInitializedManagerAccessor:
+    def test_returns_the_manager_the_app_registered(self, app_state):
+        """Exercises the real lookup: app_state -> manager."""
+        manager = MagicMock(name="ChatHistoryManager")
+        app_state["chat_history_manager"] = manager
+
+        assert ResourceFactory.get_initialized_chat_history_manager() is manager
+
+    def test_returns_none_before_startup_registers_one(self, app_state):
+        app_state["chat_history_manager"] = None
+
+        assert ResourceFactory.get_initialized_chat_history_manager() is None
+
+    def test_never_constructs_a_manager(self, app_state):
+        """The accessor must not pay for (or duplicate) a ChatHistoryManager."""
+        app_state["chat_history_manager"] = None
+
+        with patch("chat_history.ChatHistoryManager") as manager_cls:
+            assert ResourceFactory.get_initialized_chat_history_manager() is None
+
+        manager_cls.assert_not_called()
 
 
 class TestResolveMemoryGraph:
-    @pytest.mark.asyncio
-    async def test_returns_the_managers_own_graph_instance(self):
-        """The graph handed to L2 must be the *same object* the manager owns.
+    def test_resolves_the_graph_owned_by_the_registered_manager(self, app_state):
+        """AC #13686: the graph reaching L2 is the same instance the manager owns.
 
-        This is the #13686 regression: the old call site read
-        ``getattr(self, "memory_graph", None)`` off the workflow manager, which
-        has no such attribute, so L2 always received None.
+        End-to-end through the real accessor — not a patched one — so the fix
+        line itself is executed.
         """
         graph = MagicMock(name="AutoBotMemoryGraph")
-        chm = MagicMock()
-        chm.memory_graph = graph
+        manager = MagicMock()
+        manager.memory_graph = graph
+        app_state["chat_history_manager"] = manager
 
-        with patch(
-            "utils.resource_factory.ResourceFactory.get_initialized_chat_history_manager",
-            return_value=chm,
-        ):
-            resolved = await resolve_memory_graph()
+        import asyncio
 
-        assert resolved is graph
+        assert asyncio.run(resolve_memory_graph()) is graph
 
     @pytest.mark.asyncio
-    async def test_constructs_no_second_memory_graph(self):
-        """Resolution must never build its own AutoBotMemoryGraph."""
-        chm = MagicMock()
-        chm.memory_graph = MagicMock()
+    async def test_constructs_no_second_memory_graph(self, app_state):
+        """AC #13686: no new AutoBotMemoryGraph is introduced.
 
-        with patch(
-            "utils.resource_factory.ResourceFactory.get_initialized_chat_history_manager",
-            return_value=chm,
-        ):
-            with patch("autobot_memory_graph.AutoBotMemoryGraph") as graph_cls:
-                await resolve_memory_graph()
+        Patches the class where it is actually constructed — on ChatHistoryBase
+        (``chat_history.base.AutoBotMemoryGraph``) — so the assertion can fail.
+        """
+        manager = MagicMock()
+        manager.memory_graph = MagicMock()
+        app_state["chat_history_manager"] = manager
+
+        with patch("chat_history.base.AutoBotMemoryGraph") as graph_cls:
+            await resolve_memory_graph()
 
         graph_cls.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_degrades_to_none_without_a_manager(self):
+    async def test_degrades_to_none_without_a_manager(self, app_state):
         """No initialised manager (pre-startup, or outside an app) -> None."""
-        with patch(
-            "utils.resource_factory.ResourceFactory.get_initialized_chat_history_manager",
-            return_value=None,
-        ):
-            assert await resolve_memory_graph() is None
+        app_state["chat_history_manager"] = None
+
+        assert await resolve_memory_graph() is None
 
     @pytest.mark.asyncio
-    async def test_degrades_to_none_when_graph_init_failed(self):
+    async def test_degrades_to_none_when_graph_init_failed(self, app_state):
         """A manager whose graph failed to initialise leaves memory_graph None."""
-        chm = MagicMock()
-        chm.memory_graph = None
+        manager = MagicMock()
+        manager.memory_graph = None
+        app_state["chat_history_manager"] = manager
 
-        with patch(
-            "utils.resource_factory.ResourceFactory.get_initialized_chat_history_manager",
-            return_value=chm,
-        ):
-            assert await resolve_memory_graph() is None
+        assert await resolve_memory_graph() is None
 
     @pytest.mark.asyncio
     async def test_resolution_failure_is_non_fatal(self):
@@ -86,119 +110,3 @@ class TestResolveMemoryGraph:
             side_effect=RuntimeError("boom"),
         ):
             assert await resolve_memory_graph() is None
-
-
-# ---------------------------------------------------------------------------
-# #13687 — goal ancestry resolution
-# ---------------------------------------------------------------------------
-
-
-def _install_llc_stubs(work_item, ancestry, session_factory_probe):
-    """Patch the lazily-imported LLC surface with controllable doubles."""
-    goal_service = MagicMock()
-    goal_service.get_goal_ancestry_for_work_item = AsyncMock(return_value=ancestry)
-    work_item_service = MagicMock()
-    work_item_service.get = AsyncMock(return_value=work_item)
-
-    goal_mod = MagicMock()
-    goal_mod.GoalService = MagicMock(return_value=goal_service)
-    wi_mod = MagicMock()
-    wi_mod.WorkItemService = MagicMock(return_value=work_item_service)
-    db_mod = MagicMock()
-    db_mod.get_async_session_factory = session_factory_probe
-
-    return (
-        patch.dict(
-            sys.modules,
-            {
-                "llc.services.goal": goal_mod,
-                "llc.services.work_item_service": wi_mod,
-                "user_management.database": db_mod,
-            },
-        ),
-        goal_service,
-        work_item_service,
-    )
-
-
-def _session_factory_probe():
-    """A session factory that records whether it was ever called."""
-    session_cm = MagicMock()
-    session_cm.__aenter__ = AsyncMock(return_value=MagicMock())
-    session_cm.__aexit__ = AsyncMock(return_value=False)
-    factory = MagicMock(return_value=session_cm)
-    return MagicMock(return_value=factory)
-
-
-class TestResolveGoalAncestry:
-    @pytest.mark.asyncio
-    async def test_no_work_item_issues_no_query(self):
-        """AC #13687: a turn with no linked goal must not touch the DB at all."""
-        probe = _session_factory_probe()
-        ctx, _, _ = _install_llc_stubs(MagicMock(), [], probe)
-
-        with ctx:
-            assert await resolve_goal_ancestry(None) is None
-            assert await resolve_goal_ancestry("") is None
-
-        probe.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_returns_root_first_chain_for_linked_goal(self):
-        import uuid
-
-        goal_id = uuid.uuid4()
-        work_item = MagicMock()
-        work_item.goal_id = goal_id
-        chain = [
-            {"id": "1", "title": "Ship the platform", "level": "vision", "status": "active"},
-            {"id": "2", "title": "Wake the context stack", "level": "objective", "status": "active"},
-        ]
-        ctx, goal_service, wi_service = _install_llc_stubs(work_item, chain, _session_factory_probe())
-
-        with ctx:
-            result = await resolve_goal_ancestry("wi-123")
-
-        assert result == chain
-        wi_service.get.assert_awaited_once()
-        assert goal_service.get_goal_ancestry_for_work_item.await_args.args[1] == goal_id
-
-    @pytest.mark.asyncio
-    async def test_work_item_without_goal_returns_none(self):
-        work_item = MagicMock()
-        work_item.goal_id = None
-        ctx, goal_service, _ = _install_llc_stubs(work_item, [], _session_factory_probe())
-
-        with ctx:
-            assert await resolve_goal_ancestry("wi-123") is None
-
-        goal_service.get_goal_ancestry_for_work_item.assert_not_awaited()
-
-    @pytest.mark.asyncio
-    async def test_missing_work_item_returns_none(self):
-        ctx, goal_service, _ = _install_llc_stubs(None, [], _session_factory_probe())
-
-        with ctx:
-            assert await resolve_goal_ancestry("wi-404") is None
-
-        goal_service.get_goal_ancestry_for_work_item.assert_not_awaited()
-
-    @pytest.mark.asyncio
-    async def test_empty_chain_returns_none_so_l4_stays_silent(self):
-        import uuid
-
-        work_item = MagicMock()
-        work_item.goal_id = uuid.uuid4()
-        ctx, _, _ = _install_llc_stubs(work_item, [], _session_factory_probe())
-
-        with ctx:
-            assert await resolve_goal_ancestry("wi-123") is None
-
-    @pytest.mark.asyncio
-    async def test_lookup_failure_is_non_fatal(self):
-        """AC #13687: a goal-lookup failure completes the turn without L4."""
-        probe = MagicMock(side_effect=RuntimeError("db down"))
-        ctx, _, _ = _install_llc_stubs(MagicMock(), [], probe)
-
-        with ctx:
-            assert await resolve_goal_ancestry("wi-123") is None

--- a/autobot-backend/utils/resource_factory.py
+++ b/autobot-backend/utils/resource_factory.py
@@ -91,6 +91,30 @@ class ResourceFactory:
         return get_orchestrator_sync()
 
     @staticmethod
+    def get_initialized_chat_history_manager():
+        """Return the process-wide ChatHistoryManager, or None — never constructs one.
+
+        Issue #13686: request-free callers (the chat workflow manager runs outside
+        any request scope) need the *same* manager the app initialised at startup,
+        because that is the object that owns the initialised ``memory_graph``
+        (``chat_history/base.py:166`` → ``_init_memory_graph``). Constructing a
+        second manager would build a second ``AutoBotMemoryGraph``, which is
+        exactly the duplicate-concept outcome #13686 forbids.
+
+        ``initialization.lifespan.app_state`` is the canonical request-free mirror
+        of ``app.state`` (written at ``lifespan.py:160``, already read this way by
+        ``api/system.py``). Returns None before startup completes or outside an
+        app process, so callers must degrade rather than assume.
+        """
+        try:
+            from initialization.lifespan import app_state
+
+            return app_state.get("chat_history_manager")
+        except Exception as exc:  # pragma: no cover - import guard only
+            logger.debug("No process-wide ChatHistoryManager available: %s", exc)
+            return None
+
+    @staticmethod
     async def get_chat_history_manager(request: Request = None):
         """Get or create ChatHistoryManager instance with app.state caching"""
         try:
@@ -100,6 +124,14 @@ class ResourceFactory:
                 if chm is not None:
                     logger.debug("Using pre-initialized ChatHistoryManager from app.state")
                     return chm
+
+            # Issue #13686: before paying for a construction, check the request-free
+            # singleton mirror. Without this, every request-less caller silently got
+            # its own manager (and its own memory graph) instead of the app's.
+            existing = ResourceFactory.get_initialized_chat_history_manager()
+            if existing is not None:
+                logger.debug("Using pre-initialized ChatHistoryManager from app_state mirror")
+                return existing
 
             # Fallback to module-level import and creation
             from chat_history import ChatHistoryManager

--- a/autobot-backend/utils/resource_factory.py
+++ b/autobot-backend/utils/resource_factory.py
@@ -125,14 +125,6 @@ class ResourceFactory:
                     logger.debug("Using pre-initialized ChatHistoryManager from app.state")
                     return chm
 
-            # Issue #13686: before paying for a construction, check the request-free
-            # singleton mirror. Without this, every request-less caller silently got
-            # its own manager (and its own memory graph) instead of the app's.
-            existing = ResourceFactory.get_initialized_chat_history_manager()
-            if existing is not None:
-                logger.debug("Using pre-initialized ChatHistoryManager from app_state mirror")
-                return existing
-
             # Fallback to module-level import and creation
             from chat_history import ChatHistoryManager
 


### PR DESCRIPTION
## Thinking Path

Originally this closed #13686 **and** #13687. Review killed the #13687 half, correctly, and the
PR is now scoped to #13686 alone.

The L4 wiring was both ineffective and unsafe:

- The `work_item_id` it depended on is read from `api/chat.py:1479` — `request_data.get("context", {})`,
  a raw client JSON bag. Neither `WorkItemService.get` (`llc/services/work_item_service.py:305`)
  nor `GoalService.get` (`llc/services/goal.py:114`) filters on `company_id`, though both models
  carry it. Any authenticated user could have posted `{"context": {"work_item_id": "<any uuid>"}}`
  and had another company's goal chain rendered into their prompt. I introduced that; it is gone.
- Independently, no server-side code ever sets `work_item_id` for a chat turn — grep finds only
  readers. So L4 would have stayed dark anyway, and my AC checkbox was ticked on a test that
  injected the id straight into a private method. That was not evidence.

Respecified as **#13704**, which states the two prerequisites: a server-side session→work-item
binding, and tenant-scoped lookups. **#13687 stays open**, blocked on it.

What remains is the #13686 fix, which is real. `getattr(self, "memory_graph", None)` on a
`ChatWorkflowManager` — a class whose four bases never define it — meant an `AttributeError` that
would have surfaced on the first run was converted into a silent empty string. L2 has returned
`""` on every turn since it was merged.

Sourcing it correctly needed one non-obvious thing: `ResourceFactory.get_chat_history_manager`
returns the app's manager only when handed a `Request`, and the chat workflow manager runs outside
request scope. The request-free path *constructs a new manager* → `initialize()` →
`_init_memory_graph()` → a **second** `AutoBotMemoryGraph`, exactly what #13686 forbids. Hence a
non-constructing accessor.

## What Changed

**`utils/resource_factory.py`** — one new method, `get_initialized_chat_history_manager()`:
returns the process-wide manager from `initialization.lifespan.app_state` (the canonical
request-free mirror written at `lifespan.py:160`, already read this way by `api/system.py:310`),
or `None`. Never constructs.

Review also flagged my first version for changing `get_chat_history_manager()` itself to consult
that mirror — unnecessary for this fix, behaviour-changing for every request-scoped caller, and
untested. Dropped.

**`chat_workflow/tiered_context_sources.py`** (new) — `resolve_memory_graph()`. Reads
`.memory_graph` off the initialised manager, constructs nothing, returns `None` on any failure so
L2 degrades because the graph is off rather than because the attribute never existed.

**`chat_workflow/llm_handler.py`** — `memory_graph=` now comes from the resolver.

`chat_history/layers.py` untouched.

## Verification

```
$ python3 -m pytest chat_workflow/tiered_context_sources_test.py chat_workflow/tiered_context_prompt_test.py -q
10 passed in 4.18s

$ python3 -m pytest chat_workflow/ chat_history/ tests/test_lightweight_mode.py tests/test_goal_ancestry_layer.py -q -p no:randomly
487 passed in 23.18s

$ python3 -m flake8 --config=.flake8 chat_workflow/ utils/resource_factory.py
0
```

### Test rework prompted by review

The first test set proved less than it appeared to, and I've fixed all three problems:

- Every test patched `get_initialized_chat_history_manager` itself, so the one line carrying the
  fix never executed — the "same instance" AC was asserting that a mock returns a mock. Tests now
  seed the real `initialization.lifespan.app_state` and call through the real accessor.
- `test_constructs_no_second_memory_graph` patched `autobot_memory_graph.AutoBotMemoryGraph`,
  which `resolve_memory_graph` never imports — the assertion could not fail. It now patches
  `chat_history.base.AutoBotMemoryGraph`, where the graph is actually constructed.
- The L4 tests are gone with the L4 code.

### Acceptance criteria — #13686 only

- [x] Flag on + a known entity → non-empty `## Related Context` in the captured prompt
      (`test_known_entity_renders_related_context_block`).
- [x] The graph reaching `Layer2OnDemand` is the same instance the manager owns, asserted with
      `is` through the real accessor (`test_resolves_the_graph_owned_by_the_registered_manager`).
- [x] Degradation path — graph unavailable → L2 returns `""`, turn completes.
- [x] No new `AutoBotMemoryGraph` construction, asserted where it is really built.

**#13687 is NOT delivered by this PR** and is not closed by it.

### Known, filed rather than folded in

- **#13704** — the L4 binding + tenant scoping described above.
- **Two live `AutoBotMemoryGraph` instances** (pre-existing): `lifespan.py:1163` builds one into
  `app.state.memory_graph`; `chat_history/base.py:244` builds another on the manager. This PR
  constructs neither and the one it reads is initialised before use, but which is canonical
  deserves its own issue — filing separately.

## Model Used

Claude Opus 5 (1M context)

Closes #13686
Part of #13685
