### PR TITLE
fix(memory): make tenant scoping a required argument on the memory data plane (#13688)

### DIFF
--- a/autobot-backend/api/multimodal.py
+++ b/autobot-backend/api/multimodal.py
@@ -77,7 +77,16 @@ def _get_modality_type(modality_str: str) -> ModalityType:
     return modality_mapping.get(modality_str.lower(), ModalityType.TEXT)
 
 
-def _build_image_modal_input(image_data, file, intent: str, question) -> MultiModalInput:
+def _principal_id(current_user: dict | None) -> str | None:
+    """Owner scope for a multi-modal write (#13688).
+
+    Taken from the authenticated principal only — never from the request body,
+    which would let a caller write into another tenant's memory.
+    """
+    return str(current_user.get("user_id")) if current_user and current_user.get("user_id") else None
+
+
+def _build_image_modal_input(image_data, file, intent: str, question, user_id: str | None) -> MultiModalInput:
     """Helper for process_image. Ref: #1088."""
     input_id = f"image_{int(time.time() * 1000)}_{uuid.uuid4().hex[:8]}"
     metadata = {"filename": file.filename, "content_type": file.content_type}
@@ -89,6 +98,7 @@ def _build_image_modal_input(image_data, file, intent: str, question) -> MultiMo
         intent=_get_processing_intent(intent),
         data=image_data,
         metadata=metadata,
+        user_id=user_id,
     )
 
 
@@ -124,7 +134,7 @@ async def process_image(
         if len(image_data) == 0:
             raise HTTPException(status_code=400, detail="Empty image file")
 
-        modal_input = _build_image_modal_input(image_data, file, intent, question)
+        modal_input = _build_image_modal_input(image_data, file, intent, question, _principal_id(current_user))
 
         # Process with unified processor
         result = await processor.process(modal_input)
@@ -196,6 +206,7 @@ async def process_audio(
             intent=_get_processing_intent(intent),
             data=audio_data,
             metadata=metadata,
+            user_id=_principal_id(current_user),
         )
 
         # Process with unified processor
@@ -257,6 +268,7 @@ async def process_text(
             intent=_get_processing_intent(request.intent),
             data=request.text,
             metadata=request.metadata or {},
+            user_id=_principal_id(current_user),
         )
 
         # Process with unified processor
@@ -506,17 +518,18 @@ def _extract_model_availability_flags(model_availability: dict) -> tuple:
     return vision_available, voice_available
 
 
-def _create_text_input(text: str, intent: str) -> MultiModalInput:
+def _create_text_input(text: str, intent: str, user_id: str | None) -> MultiModalInput:
     """Create MultiModalInput for text data (Issue #398: extracted)."""
     return MultiModalInput(
         input_id=f"text_{int(time.time() * 1000)}",
         modality_type=ModalityType.TEXT,
         intent=_get_processing_intent(intent),
         data=text,
+        user_id=user_id,
     )
 
 
-async def _create_image_input(image_file: UploadFile, intent: str) -> MultiModalInput:
+async def _create_image_input(image_file: UploadFile, intent: str, user_id: str | None) -> MultiModalInput:
     """Create MultiModalInput for image file (Issue #398: extracted)."""
     image_data = await image_file.read()
     return MultiModalInput(
@@ -525,10 +538,11 @@ async def _create_image_input(image_file: UploadFile, intent: str) -> MultiModal
         intent=_get_processing_intent(intent),
         data=image_data,
         metadata={"filename": image_file.filename},
+        user_id=user_id,
     )
 
 
-async def _create_audio_input(audio_file: UploadFile, intent: str) -> MultiModalInput:
+async def _create_audio_input(audio_file: UploadFile, intent: str, user_id: str | None) -> MultiModalInput:
     """Create MultiModalInput for audio file (Issue #398: extracted)."""
     audio_data = await audio_file.read()
     return MultiModalInput(
@@ -537,6 +551,7 @@ async def _create_audio_input(audio_file: UploadFile, intent: str) -> MultiModal
         intent=_get_processing_intent(intent),
         data=audio_data,
         metadata={"filename": audio_file.filename},
+        user_id=user_id,
     )
 
 
@@ -545,18 +560,19 @@ async def _collect_modal_inputs(
     image_file: UploadFile | None,
     audio_file: UploadFile | None,
     intent: str,
+    user_id: str | None,
 ) -> List[MultiModalInput]:
     """Collect all modal inputs from form data (Issue #398: extracted)."""
     inputs = []
 
     if text:
-        inputs.append(_create_text_input(text, intent))
+        inputs.append(_create_text_input(text, intent, user_id))
 
     if image_file:
-        inputs.append(await _create_image_input(image_file, intent))
+        inputs.append(await _create_image_input(image_file, intent, user_id))
 
     if audio_file:
-        inputs.append(await _create_audio_input(audio_file, intent))
+        inputs.append(await _create_audio_input(audio_file, intent, user_id))
 
     return inputs
 
@@ -566,6 +582,7 @@ def _create_combined_input(
     image_file: UploadFile | None,
     audio_file: UploadFile | None,
     intent: str,
+    user_id: str | None,
 ) -> MultiModalInput:
     """Create combined MultiModalInput for fusion (Issue #398: extracted)."""
     return MultiModalInput(
@@ -578,6 +595,7 @@ def _create_combined_input(
             "audio": audio_file.filename if audio_file else None,
             "text_preview": text[:100] if text else None,
         },
+        user_id=user_id,
     )
 
 
@@ -603,7 +621,7 @@ async def combine_multimodal_inputs(
 
     try:
         # Collect all modal inputs using helper
-        inputs = await _collect_modal_inputs(text, image_file, audio_file, intent)
+        inputs = await _collect_modal_inputs(text, image_file, audio_file, intent, _principal_id(current_user))
 
         if not inputs:
             raise HTTPException(status_code=400, detail="At least one input modality required")
@@ -612,7 +630,7 @@ async def combine_multimodal_inputs(
         results = [await processor.process(modal_input) for modal_input in inputs]
 
         # Create combined input and process fusion
-        combined_input = _create_combined_input(text, image_file, audio_file, intent)
+        combined_input = _create_combined_input(text, image_file, audio_file, intent, _principal_id(current_user))
         fusion_result = await processor._process_combined(combined_input)
 
         processing_time = time.time() - start_time

--- a/autobot-backend/api/multimodal.py
+++ b/autobot-backend/api/multimodal.py
@@ -35,6 +35,7 @@ from api.system_health import ComponentHealth, register_health_probe
 from auth_middleware import get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.principal import resolve_principal_id
 from multimodal_processor import (
     ModalityType,
     MultiModalInput,
@@ -80,10 +81,15 @@ def _get_modality_type(modality_str: str) -> ModalityType:
 def _principal_id(current_user: dict | None) -> str | None:
     """Owner scope for a multi-modal write (#13688).
 
+    Delegates to the canonical claim resolver rather than reading ``user_id``
+    directly: that claim is optional, so reading it alone dropped every
+    principal minted without it and split one user across two owner silos
+    depending on which endpoint wrote the row.
+
     Taken from the authenticated principal only — never from the request body,
     which would let a caller write into another tenant's memory.
     """
-    return str(current_user.get("user_id")) if current_user and current_user.get("user_id") else None
+    return resolve_principal_id(current_user)
 
 
 def _build_image_modal_input(image_data, file, intent: str, question, user_id: str | None) -> MultiModalInput:
@@ -621,7 +627,8 @@ async def combine_multimodal_inputs(
 
     try:
         # Collect all modal inputs using helper
-        inputs = await _collect_modal_inputs(text, image_file, audio_file, intent, _principal_id(current_user))
+        owner = _principal_id(current_user)
+        inputs = await _collect_modal_inputs(text, image_file, audio_file, intent, owner)
 
         if not inputs:
             raise HTTPException(status_code=400, detail="At least one input modality required")
@@ -630,7 +637,7 @@ async def combine_multimodal_inputs(
         results = [await processor.process(modal_input) for modal_input in inputs]
 
         # Create combined input and process fusion
-        combined_input = _create_combined_input(text, image_file, audio_file, intent, _principal_id(current_user))
+        combined_input = _create_combined_input(text, image_file, audio_file, intent, owner)
         fusion_result = await processor._process_combined(combined_input)
 
         processing_time = time.time() - start_time

--- a/autobot-backend/api/task_memory.py
+++ b/autobot-backend/api/task_memory.py
@@ -13,7 +13,7 @@ import asyncio
 from datetime import datetime, timezone
 from typing import List
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 
 from api.schemas_agent import (
     MemoryActiveTasksResponse,
@@ -33,6 +33,7 @@ from api.schemas_knowledge import (
     TaskCreateRequest,
     TaskUpdateRequest,
 )
+from auth_middleware import get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.singleton_factory import lazy_singleton
@@ -231,16 +232,31 @@ async def update_task(task_id: str, request: TaskUpdateRequest):
     operation="add_markdown_reference",
     error_code_prefix="MEMORY",
 )
-async def add_markdown_reference(task_id: str, request: MarkdownReferenceRequest):
-    """Add markdown file reference to a task."""
+async def add_markdown_reference(
+    task_id: str,
+    request: MarkdownReferenceRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    """Add markdown file reference to a task.
+
+    #13688: the reference is stored as a general memory row, which is now
+    owner-scoped. The owner comes from the authenticated principal — taking it
+    from ``MarkdownReferenceRequest`` would let a caller write into another
+    user's memory.
+    """
     try:
         memory_manager, _ = await _get_managers()
+
+        owner = current_user.get("id") or current_user.get("user_id") or current_user.get("sub")
+        if not owner:
+            raise HTTPException(status_code=401, detail="User identity required")
 
         success = await asyncio.to_thread(
             memory_manager.add_markdown_reference,
             task_id=request.task_id,
             markdown_file_path=request.markdown_file_path,
             reference_type=request.reference_type,
+            user_id=str(owner),
         )
 
         if not success:

--- a/autobot-backend/api/task_memory.py
+++ b/autobot-backend/api/task_memory.py
@@ -36,6 +36,7 @@ from api.schemas_knowledge import (
 from auth_middleware import get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.principal import resolve_principal_id
 from autobot_shared.singleton_factory import lazy_singleton
 from markdown_reference_system import MarkdownReferenceSystem
 from memory import MemoryManager, TaskPriority, TaskStatus
@@ -247,13 +248,13 @@ async def add_markdown_reference(
     try:
         memory_manager, _ = await _get_managers()
 
-        owner = current_user.get("id") or current_user.get("user_id") or current_user.get("sub")
+        owner = resolve_principal_id(current_user)
         if not owner:
             raise HTTPException(status_code=401, detail="User identity required")
 
         success = await asyncio.to_thread(
             memory_manager.add_markdown_reference,
-            task_id=request.task_id,
+            task_id=task_id,
             markdown_file_path=request.markdown_file_path,
             reference_type=request.reference_type,
             user_id=str(owner),

--- a/autobot-backend/auth_middleware.py
+++ b/autobot-backend/auth_middleware.py
@@ -25,6 +25,7 @@ from autobot_shared.auth.jwt_core import (
 )
 from autobot_shared.auth.permissions import is_admin_role
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.principal import resolve_principal_id  # noqa: F401  (re-exported, #13688)
 from autobot_shared.singleton_factory import lazy_singleton
 from autobot_shared.ssot_config import config as ssot_config
 from autobot_shared.time_utils import parse_utc_iso

--- a/autobot-backend/computer_vision/screen_analyzer.py
+++ b/autobot-backend/computer_vision/screen_analyzer.py
@@ -22,6 +22,7 @@ import numpy as np
 from autobot_shared.logging_manager import get_logger
 from desktop_streaming_manager import get_desktop_streaming
 from memory import TaskPriority
+from memory.storage.general_storage import SYSTEM_OWNER
 from multimodal_processor import (
     ModalityType,
     MultiModalInput,
@@ -202,6 +203,10 @@ class ScreenAnalyzer:
             intent=ProcessingIntent.SCREEN_ANALYSIS,
             data=screenshot,
             metadata={"session_id": session_id},
+            # #13688: screen analysis is system-initiated — there is no human
+            # requester to attribute it to. Without an owner the result would be
+            # silently dropped by _store_result rather than persisted.
+            user_id=SYSTEM_OWNER,
         )
 
     def _create_audio_input(self, context_audio: bytes, session_id: str | None) -> MultiModalInput:
@@ -212,6 +217,7 @@ class ScreenAnalyzer:
             intent=ProcessingIntent.VOICE_COMMAND,
             data=context_audio,
             metadata={"session_id": session_id, "context": "screen_analysis"},
+            user_id=SYSTEM_OWNER,
         )
 
     async def _combine_multimodal_results(self, processing_results: List[Any], session_id: str | None) -> Any | None:
@@ -221,6 +227,7 @@ class ScreenAnalyzer:
             modality_type=ModalityType.COMBINED,
             intent=ProcessingIntent.SCREEN_ANALYSIS,
             data="",
+            user_id=SYSTEM_OWNER,
             metadata={
                 "image_result": processing_results[0].result_data,
                 "audio_result": processing_results[1].result_data,

--- a/autobot-backend/memory/compat.py
+++ b/autobot-backend/memory/compat.py
@@ -50,20 +50,28 @@ class LongTermMemoryManager:
         self,
         category: str,
         content: str,
+        *,
+        user_id: str,
         metadata: Dict | None = None,
         embedding: bytes | None = None,
     ) -> int:
-        """Map old API to canonical MemoryManager."""
+        """Map old API to canonical MemoryManager.
+
+        #13688: the owner scope is required here too — this wrapper must not
+        become the one place where an untenanted write is still reachable.
+        """
         try:
             cat = MemoryCategory[category.upper()]
         except (KeyError, AttributeError):
             cat = category  # Use as-is if not in enum
-        return await self._manager.store_memory(cat, content, metadata, embedding=embedding)
+        return await self._manager.store_memory(
+            cat, content, user_id=user_id, metadata=metadata, embedding=embedding
+        )
 
     async def retrieve_memories(
-        self, category: str, filters: Dict | None = None, limit: int = 100
+        self, category: str, filters: Dict | None = None, limit: int = 100, *, user_id: str
     ) -> List[MemoryEntry]:
-        """Map old API to canonical MemoryManager."""
+        """Map old API to canonical MemoryManager (#13688: owner-scoped)."""
         filters = filters or {}
         try:
             cat = MemoryCategory[category.upper()]
@@ -71,20 +79,21 @@ class LongTermMemoryManager:
             cat = category
         return await self._manager.retrieve_memories(
             cat,
+            user_id=user_id,
             limit=limit,
             start_date=filters.get("start_date"),
             end_date=filters.get("end_date"),
             reference_path=filters.get("reference_path"),
         )
 
-    async def search_by_metadata(self, metadata_query: Dict) -> List[MemoryEntry]:
+    async def search_by_metadata(self, metadata_query: Dict, *, user_id: str) -> List[MemoryEntry]:
         """Search by metadata (limited: converts values to a text query).
 
         WARNING: Does NOT perform true metadata key/value matching.
         Results may include false positives.
         """
         query = " ".join(str(v) for v in metadata_query.values())
-        return await self._manager.search_memories(query)
+        return await self._manager.search_memories(query, user_id=user_id)
 
     async def initialize(self) -> None:
         """Initialize the underlying storage (called by orchestrator on startup)."""
@@ -95,9 +104,9 @@ class LongTermMemoryManager:
         """Cleanup hook called by orchestrator on shutdown (no-op)."""
         logger.info("LongTermMemoryManager cleanup complete")
 
-    async def search_relevant_context(self, query: str) -> List[MemoryEntry]:
-        """Search memories for context relevant to the given query."""
-        return await self._manager.search_memories(query)
+    async def search_relevant_context(self, query: str, *, user_id: str) -> List[MemoryEntry]:
+        """Search one owner's memories for context relevant to the given query."""
+        return await self._manager.search_memories(query, user_id=user_id)
 
     async def cleanup_old_memories(self, retention_days: int | None = None) -> int:
         """Cleanup old memories."""

--- a/autobot-backend/memory/compat.py
+++ b/autobot-backend/memory/compat.py
@@ -64,9 +64,7 @@ class LongTermMemoryManager:
             cat = MemoryCategory[category.upper()]
         except (KeyError, AttributeError):
             cat = category  # Use as-is if not in enum
-        return await self._manager.store_memory(
-            cat, content, user_id=user_id, metadata=metadata, embedding=embedding
-        )
+        return await self._manager.store_memory(cat, content, user_id=user_id, metadata=metadata, embedding=embedding)
 
     async def retrieve_memories(
         self, category: str, filters: Dict | None = None, limit: int = 100, *, user_id: str

--- a/autobot-backend/memory/compat.py
+++ b/autobot-backend/memory/compat.py
@@ -13,6 +13,21 @@ directly.
 
 #10666 B2: UnifiedMemoryManager renamed to MemoryManager.
 get_memory_manager() is the canonical factory.
+
+#13690: this module is NOT caller-less, despite a grep for ``memory.compat``
+finding nothing — both production consumers import through the package
+re-export in ``memory/__init__.py``:
+
+* ``orchestrator.py:142`` constructs ``LongTermMemoryManager`` and calls
+  ``initialize()``/``cleanup()`` on it. Its data-plane methods have no
+  production callers, but they remain tenanted (#13688) so a future caller
+  inherits the scoping rather than re-opening that gap.
+* ``task_execution_tracker.py:52`` uses ``get_memory_manager()``, which is the
+  canonical factory and not a compatibility shim at all — only its location in
+  this module is legacy.
+
+Do not treat this file as dead. ``memory/compat_production_usage_test.py``
+pins the coupling.
 """
 
 from typing import Dict, List

--- a/autobot-backend/memory/compat_production_usage_test.py
+++ b/autobot-backend/memory/compat_production_usage_test.py
@@ -1,0 +1,79 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""`memory/compat.py` has live production callers (#13690).
+
+#13690 was filed on the premise that this module had none. That was wrong: the
+grep looked for `memory.compat`, and both production callers import through the
+package re-export at `memory/__init__.py:42`, which leaves no textual trace of
+the originating module.
+
+`tests/memory/test_compat_singletons.py` covers the factories in isolation.
+These pin the *production* coupling, so the next audit that considers this
+module dead has to contend with a failing test rather than a silent grep.
+"""
+
+import inspect
+
+import pytest
+
+
+class TestLiveProductionCallers:
+    def test_orchestrator_constructs_the_legacy_wrapper(self):
+        """orchestrator.py:142 — the live consumer the original grep missed."""
+        import orchestrator
+
+        source = inspect.getsource(orchestrator)
+        assert "LongTermMemoryManager()" in source
+        assert "from memory import LongTermMemoryManager" in source
+
+    def test_task_tracker_uses_the_canonical_factory(self):
+        """task_execution_tracker.py:52 — get_memory_manager is not legacy."""
+        import task_execution_tracker
+
+        source = inspect.getsource(task_execution_tracker)
+        assert "get_memory_manager" in source
+
+    def test_the_factories_are_re_exported_from_the_package(self):
+        """This re-export is why a `memory.compat` grep finds nothing."""
+        import memory
+
+        assert memory.get_memory_manager is not None
+        assert memory.LongTermMemoryManager is not None
+
+
+class TestLifecycleSurfaceIsWhatOrchestratorNeeds:
+    """orchestrator calls exactly two methods; both must keep working.
+
+    #13688 changed the signatures of the data-plane methods this wrapper wraps.
+    Nothing broke precisely because the live consumer touches neither — these
+    assert that stays true.
+    """
+
+    @pytest.mark.parametrize("method", ["initialize", "cleanup"])
+    def test_lifecycle_methods_take_no_owner_argument(self, method):
+        from memory.compat import LongTermMemoryManager
+
+        params = inspect.signature(getattr(LongTermMemoryManager, method)).parameters
+        assert "user_id" not in params, f"{method} is lifecycle, not a data-plane call"
+
+
+class TestDataPlaneWrappersStayTenanted:
+    """The dormant methods must not lose their scoping while unused (#13688).
+
+    They have no production callers today. If one appears it should inherit the
+    tenancy rather than re-open the gap #13688 closed.
+    """
+
+    @pytest.mark.parametrize(
+        "method",
+        ["store_memory", "retrieve_memories", "search_by_metadata", "search_relevant_context"],
+    )
+    def test_owner_scope_is_required_and_keyword_only(self, method):
+        from memory.compat import LongTermMemoryManager
+
+        params = inspect.signature(getattr(LongTermMemoryManager, method)).parameters
+        assert "user_id" in params, f"{method} lost its owner scope"
+        assert params["user_id"].kind is inspect.Parameter.KEYWORD_ONLY
+        assert params["user_id"].default is inspect.Parameter.empty, "scope must be required"

--- a/autobot-backend/memory/general_storage_tenancy_test.py
+++ b/autobot-backend/memory/general_storage_tenancy_test.py
@@ -1,0 +1,235 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tenant scoping on the general memory data plane (#13688).
+
+Before this, ``store_memory``/``retrieve_memories``/``search_memories`` took no
+owner argument at all, and ``search_memories(query)`` returned whatever the
+storage layer matched — every owner's rows. Tenancy was enforced only in the
+layers above (``memory/transparency.py``, the working-memory key allowlist), so
+isolation depended on every call site remembering to filter.
+
+These tests hold the shape: the filter lives in the storage layer, the scope is
+a required argument, and no query can be constructed without one.
+"""
+
+import sqlite3
+from datetime import datetime, timezone
+
+import pytest
+
+from memory.enums import MemoryCategory
+from memory.manager import MemoryManager
+from memory.models import MemoryEntry
+from memory.storage.general_storage import LEGACY_UNSCOPED_OWNER, GeneralStorage
+
+ALICE = "user-alice"
+BOB = "user-bob"
+
+
+@pytest.fixture
+async def storage(tmp_path):
+    store = GeneralStorage(tmp_path / "memory.db")
+    await store.initialize()
+    return store
+
+
+@pytest.fixture
+async def manager(tmp_path):
+    mgr = MemoryManager(db_path=str(tmp_path / "unified.db"), enable_cache=False)
+    await mgr._ensure_initialized()
+    return mgr
+
+
+def _entry(user_id, content="a private note", category=MemoryCategory.FACT):
+    return MemoryEntry(
+        id=None,
+        category=category,
+        content=content,
+        metadata={"secret": content},
+        timestamp=datetime.now(tz=timezone.utc),
+        user_id=user_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# The filter lives in the storage layer
+# ---------------------------------------------------------------------------
+
+
+class TestStorageLayerIsolation:
+    @pytest.mark.asyncio
+    async def test_search_cannot_return_another_owners_entry(self, storage):
+        """The #13688 headline: search was unfiltered and returned everyone's rows."""
+        await storage.store(_entry(ALICE, "alice deployment key"))
+        await storage.store(_entry(BOB, "bob deployment key"))
+
+        results = await storage.search(ALICE, "deployment key")
+
+        assert len(results) == 1
+        assert results[0].user_id == ALICE
+        assert "bob" not in results[0].content
+
+    @pytest.mark.asyncio
+    async def test_search_matching_metadata_still_cannot_cross_owners(self, storage):
+        """The owner predicate brackets the content-OR-metadata match."""
+        await storage.store(_entry(BOB, "bob secret"))
+
+        assert await storage.search(ALICE, "bob secret") == []
+
+    @pytest.mark.asyncio
+    async def test_retrieve_cannot_return_another_owners_entry(self, storage):
+        await storage.store(_entry(ALICE, "alice fact"))
+        await storage.store(_entry(BOB, "bob fact"))
+
+        results = await storage.retrieve(ALICE, MemoryCategory.FACT, {"limit": 100})
+
+        assert [r.user_id for r in results] == [ALICE]
+
+    @pytest.mark.asyncio
+    async def test_query_without_a_scope_cannot_be_constructed(self, storage):
+        """A blank or missing scope is a ValueError/TypeError, never a full-tenant query."""
+        for blank in ("", "   ", None):
+            with pytest.raises(ValueError):
+                await storage.search(blank, "anything")
+            with pytest.raises(ValueError):
+                await storage.retrieve(blank, MemoryCategory.FACT, {"limit": 10})
+
+        with pytest.raises(TypeError):
+            await storage.search("only-a-query")  # type: ignore[call-arg]
+
+    @pytest.mark.asyncio
+    async def test_write_without_a_scope_is_rejected(self, storage):
+        with pytest.raises(ValueError):
+            await storage.store(_entry(None))
+        with pytest.raises(ValueError):
+            await storage.store(_entry("  "))
+
+
+# ---------------------------------------------------------------------------
+# The scope is a first-class column, not metadata
+# ---------------------------------------------------------------------------
+
+
+class TestScopeIsFirstClass:
+    @pytest.mark.asyncio
+    async def test_user_id_is_a_column_not_a_metadata_key(self, storage, tmp_path):
+        await storage.store(_entry(ALICE, "alice fact"))
+
+        with sqlite3.connect(tmp_path / "memory.db") as conn:
+            columns = {row[1] for row in conn.execute("PRAGMA table_info(memory_entries)")}
+            stored_user, stored_meta = conn.execute("SELECT user_id, metadata_json FROM memory_entries").fetchone()
+
+        assert "user_id" in columns
+        assert stored_user == ALICE
+        assert "user-alice" not in (stored_meta or "")
+
+    @pytest.mark.asyncio
+    async def test_round_trip_preserves_the_owner(self, storage):
+        await storage.store(_entry(ALICE, "alice fact"))
+        [entry] = await storage.retrieve(ALICE, MemoryCategory.FACT, {"limit": 10})
+        assert entry.user_id == ALICE
+
+
+# ---------------------------------------------------------------------------
+# Pre-#13688 databases keep their rows
+# ---------------------------------------------------------------------------
+
+
+class TestLegacyDatabaseMigration:
+    @pytest.mark.asyncio
+    async def test_existing_rows_survive_and_are_parked_not_leaked(self, tmp_path):
+        """No data loss: legacy rows are preserved under a reserved owner.
+
+        They must not surface for a real user, and must not be deleted.
+        """
+        db = tmp_path / "legacy.db"
+        with sqlite3.connect(db) as conn:
+            conn.execute("""
+                CREATE TABLE memory_entries (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    category TEXT NOT NULL,
+                    content TEXT NOT NULL,
+                    metadata_json TEXT,
+                    timestamp TIMESTAMP NOT NULL,
+                    reference_path TEXT,
+                    embedding BLOB
+                )
+            """)
+            conn.execute(
+                "INSERT INTO memory_entries (category, content, timestamp) VALUES (?, ?, ?)",
+                ("fact", "pre-existing row", datetime.now(tz=timezone.utc)),
+            )
+
+        storage = GeneralStorage(db)
+        await storage.initialize()
+
+        assert await storage.search(ALICE, "pre-existing") == []
+        parked = await storage.search(LEGACY_UNSCOPED_OWNER, "pre-existing")
+        assert len(parked) == 1
+        assert parked[0].content == "pre-existing row"
+
+    @pytest.mark.asyncio
+    async def test_migration_is_idempotent(self, tmp_path):
+        storage = GeneralStorage(tmp_path / "twice.db")
+        await storage.initialize()
+        await storage.store(_entry(ALICE, "alice fact"))
+        await storage.initialize()
+
+        assert len(await storage.search(ALICE, "alice fact")) == 1
+
+
+# ---------------------------------------------------------------------------
+# The manager API requires the scope
+# ---------------------------------------------------------------------------
+
+
+class TestManagerApiRequiresScope:
+    @pytest.mark.asyncio
+    async def test_search_memories_is_owner_scoped(self, manager):
+        await manager.store_memory(MemoryCategory.FACT, "alice note", user_id=ALICE)
+        await manager.store_memory(MemoryCategory.FACT, "bob note", user_id=BOB)
+
+        assert [e.user_id for e in await manager.search_memories("note", user_id=ALICE)] == [ALICE]
+
+    @pytest.mark.asyncio
+    async def test_retrieve_memories_is_owner_scoped(self, manager):
+        await manager.store_memory(MemoryCategory.FACT, "alice note", user_id=ALICE)
+        await manager.store_memory(MemoryCategory.FACT, "bob note", user_id=BOB)
+
+        results = await manager.retrieve_memories(MemoryCategory.FACT, user_id=BOB, limit=100)
+
+        assert [e.user_id for e in results] == [BOB]
+
+    @pytest.mark.asyncio
+    async def test_omitting_the_scope_is_a_type_error(self, manager):
+        """AC: omitting the scope is a TypeError, not a silent full-tenant query."""
+        with pytest.raises(TypeError):
+            await manager.store_memory(MemoryCategory.FACT, "unowned")  # type: ignore[call-arg]
+        with pytest.raises(TypeError):
+            await manager.retrieve_memories(MemoryCategory.FACT)  # type: ignore[call-arg]
+        with pytest.raises(TypeError):
+            await manager.search_memories("anything")  # type: ignore[call-arg]
+
+    @pytest.mark.asyncio
+    async def test_blank_scope_is_a_value_error(self, manager):
+        with pytest.raises(ValueError):
+            await manager.store_memory(MemoryCategory.FACT, "unowned", user_id="")
+        with pytest.raises(ValueError):
+            await manager.search_memories("anything", user_id="   ")
+
+    @pytest.mark.asyncio
+    async def test_correctly_scoped_caller_sees_no_behaviour_change(self, manager):
+        """AC: no behaviour change for a correctly-scoped caller."""
+        entry_id = await manager.store_memory(
+            MemoryCategory.FACT,
+            "AutoBot supports multi-modal AI",
+            user_id=ALICE,
+            metadata={"source": "documentation"},
+        )
+        assert isinstance(entry_id, int)
+
+        [entry] = await manager.retrieve_memories(MemoryCategory.FACT, user_id=ALICE, limit=10)
+        assert entry.content == "AutoBot supports multi-modal AI"
+        assert entry.metadata == {"source": "documentation"}

--- a/autobot-backend/memory/general_storage_tenancy_test.py
+++ b/autobot-backend/memory/general_storage_tenancy_test.py
@@ -233,3 +233,72 @@ class TestManagerApiRequiresScope:
         [entry] = await manager.retrieve_memories(MemoryCategory.FACT, user_id=ALICE, limit=10)
         assert entry.content == "AutoBot supports multi-modal AI"
         assert entry.metadata == {"source": "documentation"}
+
+
+# ---------------------------------------------------------------------------
+# Review findings on PR #13698
+# ---------------------------------------------------------------------------
+
+
+class TestReservedOwnerCannotBeWritten:
+    @pytest.mark.asyncio
+    async def test_legacy_owner_is_rejected_as_a_write_scope(self, storage):
+        """Writing under the reserved id would re-create the unscoped bucket."""
+        with pytest.raises(ValueError, match="reserved"):
+            await storage.store(_entry(LEGACY_UNSCOPED_OWNER))
+
+    @pytest.mark.asyncio
+    async def test_legacy_owner_is_still_readable(self, storage):
+        """Reads must keep accepting it or parked rows become unreachable."""
+        assert await storage.search(LEGACY_UNSCOPED_OWNER, "anything") == []
+
+
+class TestScopeNormalisation:
+    @pytest.mark.asyncio
+    async def test_surrounding_whitespace_does_not_split_a_tenant(self, storage):
+        await storage.store(_entry(f"  {ALICE}  ", "alice note"))
+
+        assert len(await storage.search(ALICE, "alice note")) == 1
+        [entry] = await storage.retrieve(ALICE, MemoryCategory.FACT, {"limit": 10})
+        assert entry.user_id == ALICE
+
+
+class TestConcurrentMigration:
+    @pytest.mark.asyncio
+    async def test_two_initializers_racing_on_a_legacy_db_both_succeed(self, tmp_path):
+        """A second worker must not die on 'duplicate column name' at startup.
+
+        PRAGMA and ALTER are not one transaction and the asyncio lock guards
+        only one process, so the loser has to treat the column already existing
+        as success.
+        """
+        import asyncio
+
+        db = tmp_path / "legacy_race.db"
+        with sqlite3.connect(db) as conn:
+            conn.execute("""
+                CREATE TABLE memory_entries (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    category TEXT NOT NULL,
+                    content TEXT NOT NULL,
+                    metadata_json TEXT,
+                    timestamp TIMESTAMP NOT NULL,
+                    reference_path TEXT,
+                    embedding BLOB
+                )
+            """)
+            conn.execute(
+                "INSERT INTO memory_entries (category, content, timestamp) VALUES (?, ?, ?)",
+                ("fact", "pre-existing row", datetime.now(tz=timezone.utc)),
+            )
+
+        results = await asyncio.gather(
+            *[GeneralStorage(db).initialize() for _ in range(6)],
+            return_exceptions=True,
+        )
+
+        failures = [r for r in results if isinstance(r, Exception)]
+        assert not failures, f"concurrent initialize must not raise: {failures}"
+
+        parked = await GeneralStorage(db).search(LEGACY_UNSCOPED_OWNER, "pre-existing")
+        assert len(parked) == 1

--- a/autobot-backend/memory/general_storage_tenancy_test.py
+++ b/autobot-backend/memory/general_storage_tenancy_test.py
@@ -302,3 +302,36 @@ class TestConcurrentMigration:
 
         parked = await GeneralStorage(db).search(LEGACY_UNSCOPED_OWNER, "pre-existing")
         assert len(parked) == 1
+
+
+class TestRetentionDoesNotEatParkedRows:
+    @pytest.mark.asyncio
+    async def test_cleanup_old_exempts_pre_migration_rows(self, tmp_path):
+        """The migration preserves legacy rows; the first sweep must not undo that."""
+        db = tmp_path / "legacy_retention.db"
+        with sqlite3.connect(db) as conn:
+            conn.execute("""
+                CREATE TABLE memory_entries (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    category TEXT NOT NULL,
+                    content TEXT NOT NULL,
+                    metadata_json TEXT,
+                    timestamp TIMESTAMP NOT NULL,
+                    reference_path TEXT,
+                    embedding BLOB
+                )
+            """)
+            conn.execute(
+                "INSERT INTO memory_entries (category, content, timestamp) VALUES (?, ?, ?)",
+                ("fact", "pre-existing row", datetime(2020, 1, 1, tzinfo=timezone.utc)),
+            )
+
+        storage = GeneralStorage(db)
+        await storage.initialize()
+        await storage.store(_entry(ALICE, "recent alice row"))
+
+        deleted = await storage.cleanup_old(0)
+
+        assert deleted == 1, "the owned row expires; the parked one must not"
+        parked = await storage.search(LEGACY_UNSCOPED_OWNER, "pre-existing")
+        assert len(parked) == 1

--- a/autobot-backend/memory/manager.py
+++ b/autobot-backend/memory/manager.py
@@ -211,10 +211,11 @@ class MemoryManager:
         ... )
         >>> await manager.log_task(record)
 
-        >>> # General memory
+        >>> # General memory — user_id is required (#13688)
         >>> await manager.store_memory(
         ...     MemoryCategory.FACT,
         ...     "AutoBot supports multi-modal AI",
+        ...     user_id="user-42",
         ...     metadata={"source": "documentation"}
         ... )
 
@@ -404,6 +405,8 @@ class MemoryManager:
         self,
         category: MemoryCategory | str,
         content: str,
+        *,
+        user_id: str,
         metadata: Dict | None = None,
         reference_path: str | None = None,
         embedding: bytes | None = None,
@@ -414,6 +417,8 @@ class MemoryManager:
         Args:
             category: Memory category (MemoryCategory enum or string)
             content: Memory content
+            user_id: Owner scope (#13688). Keyword-only and required — omitting
+                     it is a TypeError, never a silent untenanted write.
             metadata: Optional metadata dictionary
             reference_path: Optional reference to markdown file
             embedding: Optional embedding vector (bytes)
@@ -422,7 +427,8 @@ class MemoryManager:
             Entry ID
 
         Raises:
-            ValueError: If category or content is empty/invalid
+            TypeError: If user_id is omitted
+            ValueError: If user_id, category or content is empty/invalid
         """
         if isinstance(category, str) and (not category or not category.strip()):
             raise ValueError("category cannot be empty string")
@@ -437,22 +443,29 @@ class MemoryManager:
             timestamp=datetime.now(tz=timezone.utc),
             reference_path=reference_path,
             embedding=embedding,
+            user_id=user_id,
         )
         return await self._general_storage.store(entry)
 
     async def retrieve_memories(
         self,
         category: MemoryCategory | str,
+        *,
+        user_id: str,
         limit: int = 100,
         start_date: datetime | None = None,
         end_date: datetime | None = None,
         reference_path: str | None = None,
     ) -> List[MemoryEntry]:
         """
-        Retrieve memories by category and filters.
+        Retrieve one owner's memories by category and filters.
+
+        Args:
+            user_id: Owner scope (#13688). Keyword-only and required.
 
         Raises:
-            ValueError: If limit is invalid or date range is invalid
+            TypeError: If user_id is omitted
+            ValueError: If user_id is blank, limit is invalid, or the date range is invalid
         """
         if limit <= 0:
             raise ValueError("limit must be positive")
@@ -467,12 +480,21 @@ class MemoryManager:
             "end_date": end_date,
             "reference_path": reference_path,
         }
-        return await self._general_storage.retrieve(category, filters)
+        return await self._general_storage.retrieve(user_id, category, filters)
 
-    async def search_memories(self, query: str) -> List[MemoryEntry]:
-        """Search memories by content or metadata."""
+    async def search_memories(self, query: str, *, user_id: str) -> List[MemoryEntry]:
+        """Search one owner's memories by content or metadata.
+
+        Args:
+            user_id: Owner scope (#13688). Keyword-only and required — this is
+                     the method that previously returned every owner's rows.
+
+        Raises:
+            TypeError: If user_id is omitted
+            ValueError: If user_id is blank
+        """
         await self._ensure_initialized()
-        return await self._general_storage.search(query)
+        return await self._general_storage.search(user_id, query)
 
     async def cleanup_old_memories(self, retention_days: int | None = None) -> int:
         """Remove memories older than retention period. Returns number deleted."""
@@ -529,12 +551,16 @@ class MemoryManager:
         """
         if not isinstance(data, MemoryEntry):
             raise TypeError("GENERAL_MEMORY strategy requires MemoryEntry")
+        # #13688: the entry carries its own owner; the strategy path must not
+        # become a way to write an unscoped row. A MemoryEntry without a
+        # user_id raises in store_memory, exactly like the direct API.
         return await self.store_memory(
             data.category,
             data.content,
-            data.metadata,
-            data.reference_path,
-            data.embedding,
+            user_id=data.user_id,
+            metadata=data.metadata,
+            reference_path=data.reference_path,
+            embedding=data.embedding,
         )
 
     def _store_cached(self, data: Any) -> str:
@@ -804,10 +830,16 @@ class MemoryManager:
         task_id: str,
         markdown_file_path: str,
         reference_type: str = "documentation",
+        *,
+        user_id: str,
     ) -> bool:
         """Store a markdown-file reference against a task (sync wrapper).
 
         Do NOT call from async code — use await store_memory() directly instead.
+
+        Args:
+            user_id: Owner scope (#13688). Required — this writes a general
+                     memory row like every other path into the plane.
         """
         from .enums import MemoryCategory
 
@@ -821,6 +853,7 @@ class MemoryManager:
             self.store_memory(
                 MemoryCategory.FACT,
                 content,
+                user_id=user_id,
                 metadata=metadata,
                 reference_path=markdown_file_path,
             )
@@ -889,10 +922,17 @@ class MemoryManager:
         content_type: str,
         embedding_model: str,
         embedding_vector: List[float],
+        *,
+        user_id: str,
     ) -> bool:
         """Persist an embedding vector as a general memory entry (sync wrapper).
 
         Do NOT call from async code — use await store_memory() directly instead.
+
+        Args:
+            user_id: Owner scope (#13688). Required — this method writes a
+                     general memory row, so it cannot be the one remaining path
+                     that produces an unscoped entry.
         """
         import json as _json
 
@@ -908,6 +948,7 @@ class MemoryManager:
             self.store_memory(
                 MemoryCategory.FACT,
                 content,
+                user_id=user_id,
                 metadata=metadata,
                 embedding=embedding_bytes,
             )

--- a/autobot-backend/memory/memory_package_test.py
+++ b/autobot-backend/memory/memory_package_test.py
@@ -20,6 +20,9 @@ from pathlib import Path
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
+# #13688: the general memory plane is owner-scoped; tests must name an owner.
+TEST_USER = "test-user"
+
 from memory import (
     LongTermMemoryManager,
     MemoryCategory,
@@ -100,6 +103,7 @@ async def test_3_general_memory_storage():
         entry_id = await manager.store_memory(
             MemoryCategory.FACT,
             "AutoBot supports multi-modal AI",
+            user_id=TEST_USER,
             metadata={"source": "test", "confidence": 0.95},
         )
         assert entry_id > 0, f"Expected entry_id > 0, got {entry_id}"
@@ -108,16 +112,17 @@ async def test_3_general_memory_storage():
         await manager.store_memory(
             MemoryCategory.STATE,
             "System initialized",
+            user_id=TEST_USER,
             metadata={"component": "orchestrator"},
         )
 
         # Retrieve memories by category
-        facts = await manager.retrieve_memories(MemoryCategory.FACT, limit=10)
+        facts = await manager.retrieve_memories(MemoryCategory.FACT, user_id=TEST_USER, limit=10)
         assert len(facts) == 1, f"Expected 1 fact, got {len(facts)}"
         assert facts[0].content == "AutoBot supports multi-modal AI"
         assert facts[0].metadata["confidence"] == 0.95
 
-        states = await manager.retrieve_memories(MemoryCategory.STATE, limit=10)
+        states = await manager.retrieve_memories(MemoryCategory.STATE, user_id=TEST_USER, limit=10)
         assert len(states) == 1, f"Expected 1 state, got {len(states)}"
 
     print("✅ PASSED: General memory storage works correctly")  # noqa: print
@@ -177,6 +182,7 @@ async def test_5_strategy_pattern():
             content="Strategy pattern works",
             metadata={"test": True},
             timestamp=datetime.now(),
+            user_id=TEST_USER,
         )
         entry_id = await manager.store(entry, StorageStrategy.GENERAL_MEMORY)
         assert entry_id > 0
@@ -243,12 +249,13 @@ async def test_7_backward_compatibility_longterm():
         entry_id = await manager.store_memory(
             "task",  # Old API used strings
             "Test content",
+            user_id=TEST_USER,
             metadata={"test": True},
         )
         assert entry_id > 0
 
         # Retrieve with old API
-        memories = await manager.retrieve_memories("task", limit=10)
+        memories = await manager.retrieve_memories("task", limit=10, user_id=TEST_USER)
         assert len(memories) == 1
         assert memories[0].content == "Test content"
 
@@ -299,7 +306,7 @@ async def test_9_statistics():
         )
         await manager.log_task(task)
 
-        await manager.store_memory(MemoryCategory.FACT, "Test fact", metadata={})
+        await manager.store_memory(MemoryCategory.FACT, "Test fact", user_id=TEST_USER, metadata={})
 
         manager.cache_put("test", "value")
 

--- a/autobot-backend/memory/models.py
+++ b/autobot-backend/memory/models.py
@@ -122,6 +122,10 @@ class MemoryEntry:
     timestamp: datetime
     reference_path: str | None = None
     embedding: bytes | None = None
+    # #13688: owner scope as a first-class field, never buried in `metadata`.
+    # Defaulted so existing keyword construction stays valid, but GeneralStorage
+    # rejects a write without it — the write path cannot silently go unscoped.
+    user_id: str | None = None
 
 
 __all__ = [

--- a/autobot-backend/memory/protocols.py
+++ b/autobot-backend/memory/protocols.py
@@ -47,18 +47,23 @@ class IGeneralStorage(Protocol):
 
     Implementing classes must provide category-based storage
     with metadata search capabilities.
+
+    #13688: reads are owner-scoped. Implementations must apply ``user_id`` as a
+    query predicate rather than trusting callers to filter afterwards.
     """
 
     async def store(self, entry: MemoryEntry) -> int:
-        """Store a memory entry"""
+        """Store a memory entry (must carry a ``user_id``)"""
         ...
 
-    async def retrieve(self, category: MemoryCategory | str, filters: Dict[str, Any]) -> List[MemoryEntry]:
-        """Retrieve memories by category and filters"""
+    async def retrieve(
+        self, user_id: str, category: MemoryCategory | str, filters: Dict[str, Any]
+    ) -> List[MemoryEntry]:
+        """Retrieve one owner's memories by category and filters"""
         ...
 
-    async def search(self, query: str) -> List[MemoryEntry]:
-        """Search memories by content/metadata"""
+    async def search(self, user_id: str, query: str) -> List[MemoryEntry]:
+        """Search one owner's memories by content/metadata"""
         ...
 
     async def cleanup_old(self, retention_days: int) -> int:

--- a/autobot-backend/memory/storage/general_storage.py
+++ b/autobot-backend/memory/storage/general_storage.py
@@ -114,7 +114,8 @@ class GeneralStorage:
         if "user_id" in columns:
             return
         await conn.execute(
-            f"ALTER TABLE memory_entries ADD COLUMN user_id TEXT NOT NULL DEFAULT '{LEGACY_UNSCOPED_OWNER}'"  # nosec B608
+            "ALTER TABLE memory_entries ADD COLUMN user_id TEXT NOT NULL "
+            f"DEFAULT '{LEGACY_UNSCOPED_OWNER}'"  # nosec B608
         )
         logger.info(
             "Migrated memory_entries: added user_id; pre-existing rows parked under %s (#13688)",

--- a/autobot-backend/memory/storage/general_storage.py
+++ b/autobot-backend/memory/storage/general_storage.py
@@ -28,6 +28,13 @@ logger = get_logger(__name__)
 # into the first caller's results). Not a valid owner for new writes.
 LEGACY_UNSCOPED_OWNER = "__unscoped__"
 
+# Owner for system-initiated work that has no human requester — scheduled scans,
+# background analysis (#13688). Unlike LEGACY_UNSCOPED_OWNER this is *writable*:
+# refusing the write instead would discard real results, moving the data loss
+# the migration was written to avoid from the read path to the write path. It is
+# still an isolated silo, so it never surfaces in a user's results.
+SYSTEM_OWNER = "__system__"
+
 
 def _require_user_id(user_id: str, *, for_write: bool = False) -> str:
     """Validate a caller-supplied owner scope (#13688).
@@ -75,7 +82,7 @@ class GeneralStorage:
         """Initialize memory entries table"""
         try:
             async with self._get_connection() as conn:
-                await conn.execute(f"""
+                await conn.execute("""
                     CREATE TABLE IF NOT EXISTS memory_entries (
                         id INTEGER PRIMARY KEY AUTOINCREMENT,
                         category TEXT NOT NULL,
@@ -84,9 +91,11 @@ class GeneralStorage:
                         timestamp TIMESTAMP NOT NULL,
                         reference_path TEXT,
                         embedding BLOB,
-                        user_id TEXT NOT NULL DEFAULT '{LEGACY_UNSCOPED_OWNER}'
+                        user_id TEXT NOT NULL
                     )
-                """)  # nosec B608  # interpolates a module constant, never caller input
+                """)  # #13688: no DEFAULT here — a fresh table must reject an
+                # ownerless INSERT outright. The default exists only on the
+                # ALTER path, where pre-migration rows genuinely have no owner.
 
                 await self._migrate_add_user_id(conn)
 
@@ -320,4 +329,4 @@ class GeneralStorage:
         )
 
 
-__all__ = ["GeneralStorage", "LEGACY_UNSCOPED_OWNER"]
+__all__ = ["GeneralStorage", "LEGACY_UNSCOPED_OWNER", "SYSTEM_OWNER"]

--- a/autobot-backend/memory/storage/general_storage.py
+++ b/autobot-backend/memory/storage/general_storage.py
@@ -21,12 +21,36 @@ from ..models import MemoryEntry
 
 logger = get_logger(__name__)
 
+# Owner assigned to rows that predate tenant scoping (#13688). Rows written
+# before this column existed have no recoverable owner, so they are parked under
+# a reserved id rather than deleted (they stay queryable by asking for this id
+# explicitly) and rather than attributed to a real user (which would leak them
+# into the first caller's results). Not a valid owner for new writes.
+LEGACY_UNSCOPED_OWNER = "__unscoped__"
+
+
+def _require_user_id(user_id: str) -> str:
+    """Validate a caller-supplied owner scope (#13688).
+
+    Raises:
+        ValueError: when the scope is missing, blank, or the reserved legacy id
+                    used as a write target.
+    """
+    if not isinstance(user_id, str) or not user_id.strip():
+        raise ValueError("user_id is required — memory queries cannot be unscoped")
+    return user_id
+
 
 class GeneralStorage:
     """
     General purpose storage implementation (IGeneralStorage)
 
     Responsibility: Manage category-based memory in SQLite database
+
+    Tenancy (#13688): every row carries a first-class ``user_id`` column and
+    every read applies it as a WHERE predicate. The scope is a required
+    argument on each method, so an unscoped query cannot be constructed here —
+    isolation does not depend on a call site remembering to filter.
     """
 
     def __init__(self, db_path: str | Path):
@@ -42,7 +66,7 @@ class GeneralStorage:
         """Initialize memory entries table"""
         try:
             async with self._get_connection() as conn:
-                await conn.execute("""
+                await conn.execute(f"""
                     CREATE TABLE IF NOT EXISTS memory_entries (
                         id INTEGER PRIMARY KEY AUTOINCREMENT,
                         category TEXT NOT NULL,
@@ -50,9 +74,12 @@ class GeneralStorage:
                         metadata_json TEXT,
                         timestamp TIMESTAMP NOT NULL,
                         reference_path TEXT,
-                        embedding BLOB
+                        embedding BLOB,
+                        user_id TEXT NOT NULL DEFAULT '{LEGACY_UNSCOPED_OWNER}'
                     )
-                """)
+                """)  # nosec B608  # interpolates a module constant, never caller input
+
+                await self._migrate_add_user_id(conn)
 
                 # Indexes for common queries
                 await conn.execute("""
@@ -63,15 +90,41 @@ class GeneralStorage:
                     CREATE INDEX IF NOT EXISTS idx_memory_timestamp
                     ON memory_entries(timestamp)
                 """)
+                # #13688: every read filters on user_id first, so it leads the index.
+                await conn.execute("""
+                    CREATE INDEX IF NOT EXISTS idx_memory_user_category
+                    ON memory_entries(user_id, category)
+                """)
 
                 await conn.commit()
         except aiosqlite.Error as e:
             logger.error("Failed to initialize general storage: %s", e)
             raise RuntimeError(f"General storage initialization failed: {e}")
 
+    async def _migrate_add_user_id(self, conn) -> None:
+        """Add the user_id column to a pre-#13688 database, preserving all rows.
+
+        Databases created before tenant scoping have no user_id column. SQLite
+        allows ADD COLUMN with a non-null default, so existing rows are parked
+        under LEGACY_UNSCOPED_OWNER instead of being dropped or rewritten — the
+        no-data-loss rule. They remain readable by querying that owner.
+        """
+        cursor = await conn.execute("PRAGMA table_info(memory_entries)")
+        columns = {row[1] for row in await cursor.fetchall()}
+        if "user_id" in columns:
+            return
+        await conn.execute(
+            f"ALTER TABLE memory_entries ADD COLUMN user_id TEXT NOT NULL DEFAULT '{LEGACY_UNSCOPED_OWNER}'"  # nosec B608
+        )
+        logger.info(
+            "Migrated memory_entries: added user_id; pre-existing rows parked under %s (#13688)",
+            LEGACY_UNSCOPED_OWNER,
+        )
+
     async def store(self, entry: MemoryEntry) -> int:
-        """Store memory entry"""
+        """Store memory entry. The entry must carry an owner (#13688)."""
         category_value = entry.category.value if isinstance(entry.category, MemoryCategory) else entry.category
+        user_id = _require_user_id(entry.user_id)
 
         try:
             async with self._get_connection() as conn:
@@ -79,8 +132,8 @@ class GeneralStorage:
                     """
                     INSERT INTO memory_entries (
                         category, content, metadata_json, timestamp,
-                        reference_path, embedding
-                    ) VALUES (?, ?, ?, ?, ?, ?)
+                        reference_path, embedding, user_id
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?)
                 """,
                     (
                         category_value,
@@ -89,6 +142,7 @@ class GeneralStorage:
                         entry.timestamp,
                         entry.reference_path,
                         entry.embedding,
+                        user_id,
                     ),
                 )
                 await conn.commit()
@@ -99,12 +153,18 @@ class GeneralStorage:
             logger.error("Failed to store memory entry: %s", e)
             raise RuntimeError(f"Failed to store memory entry: {e}")
 
-    async def retrieve(self, category: MemoryCategory | str, filters: Dict[str, Any]) -> List[MemoryEntry]:
-        """Retrieve memories by category and filters"""
+    async def retrieve(
+        self, user_id: str, category: MemoryCategory | str, filters: Dict[str, Any]
+    ) -> List[MemoryEntry]:
+        """Retrieve one owner's memories by category and filters (#13688).
+
+        ``user_id`` is required and applied as a WHERE predicate here, so no
+        caller can construct a cross-owner query.
+        """
         category_value = category.value if isinstance(category, MemoryCategory) else category
 
-        where_clauses = ["category = ?"]
-        values = [category_value]
+        where_clauses = ["user_id = ?", "category = ?"]
+        values = [_require_user_id(user_id), category_value]
 
         if filters.get("start_date"):
             where_clauses.append("timestamp >= ?")
@@ -138,19 +198,24 @@ class GeneralStorage:
             logger.error("Failed to retrieve memory entries: %s", e)
             raise RuntimeError(f"Failed to retrieve memory entries: {e}")
 
-    async def search(self, query: str) -> List[MemoryEntry]:
-        """Search memories by content or metadata"""
+    async def search(self, user_id: str, query: str) -> List[MemoryEntry]:
+        """Search one owner's memories by content or metadata (#13688).
+
+        The owner predicate is bracketed around the content/metadata OR so a
+        match on either column still cannot cross an owner boundary.
+        """
+        owner = _require_user_id(user_id)
         try:
             async with self._get_connection() as conn:
                 conn.row_factory = aiosqlite.Row
                 cursor = await conn.execute(
                     """
                     SELECT * FROM memory_entries
-                    WHERE content LIKE ? OR metadata_json LIKE ?
+                    WHERE user_id = ? AND (content LIKE ? OR metadata_json LIKE ?)
                     ORDER BY timestamp DESC
                     LIMIT 100
                 """,
-                    (f"%{query}%", f"%{query}%"),
+                    (owner, f"%{query}%", f"%{query}%"),
                 )
 
                 rows = await cursor.fetchall()
@@ -213,7 +278,8 @@ class GeneralStorage:
             timestamp=(parse_utc_iso(row["timestamp"]) if isinstance(row["timestamp"], str) else row["timestamp"]),
             reference_path=row["reference_path"],
             embedding=row["embedding"],
+            user_id=row["user_id"],
         )
 
 
-__all__ = ["GeneralStorage"]
+__all__ = ["GeneralStorage", "LEGACY_UNSCOPED_OWNER"]

--- a/autobot-backend/memory/storage/general_storage.py
+++ b/autobot-backend/memory/storage/general_storage.py
@@ -246,12 +246,24 @@ class GeneralStorage:
             raise RuntimeError(f"Failed to search memory entries: {e}")
 
     async def cleanup_old(self, retention_days: int) -> int:
-        """Remove entries older than retention period"""
+        """Remove entries older than retention period, across all owners.
+
+        Operator-scope by design: retention is a storage policy, not a tenant
+        query, so this is the one method that spans owners deliberately.
+
+        #13688: rows parked under LEGACY_UNSCOPED_OWNER are exempt. They are by
+        definition older than any retention window, so without this the first
+        sweep after the upgrade would delete every pre-migration row — silent
+        data loss caused by the migration that was supposed to preserve them.
+        """
         cutoff = datetime.now(tz=timezone.utc) - timedelta(days=retention_days)
 
         try:
             async with self._get_connection() as conn:
-                cursor = await conn.execute("DELETE FROM memory_entries WHERE timestamp < ?", (cutoff,))
+                cursor = await conn.execute(
+                    "DELETE FROM memory_entries WHERE timestamp < ? AND user_id != ?",
+                    (cutoff, LEGACY_UNSCOPED_OWNER),
+                )
                 await conn.commit()
 
                 deleted = cursor.rowcount
@@ -268,7 +280,12 @@ class GeneralStorage:
             raise RuntimeError(f"Failed to cleanup old memory entries: {e}")
 
     async def get_stats(self) -> Dict[str, Any]:
-        """Get storage statistics"""
+        """Get storage statistics across all owners.
+
+        #13688: operator-scope aggregate, deliberately not tenant-filtered — it
+        returns counts only, never content. A per-owner variant should be added
+        if this is ever surfaced to end users rather than to operators.
+        """
         try:
             async with self._get_connection() as conn:
                 conn.row_factory = aiosqlite.Row

--- a/autobot-backend/memory/storage/general_storage.py
+++ b/autobot-backend/memory/storage/general_storage.py
@@ -29,16 +29,25 @@ logger = get_logger(__name__)
 LEGACY_UNSCOPED_OWNER = "__unscoped__"
 
 
-def _require_user_id(user_id: str) -> str:
+def _require_user_id(user_id: str, *, for_write: bool = False) -> str:
     """Validate a caller-supplied owner scope (#13688).
 
+    Returns the *stripped* value: " alice" and "alice" must not become separate
+    silos through a stray space.
+
+    ``for_write`` additionally rejects LEGACY_UNSCOPED_OWNER. Reads must keep
+    accepting it so parked pre-migration rows stay retrievable, but a write
+    under it would re-create the shared unscoped bucket this issue removes.
+
     Raises:
-        ValueError: when the scope is missing, blank, or the reserved legacy id
-                    used as a write target.
+        ValueError: when the scope is missing, blank, or (on a write) reserved.
     """
     if not isinstance(user_id, str) or not user_id.strip():
         raise ValueError("user_id is required — memory queries cannot be unscoped")
-    return user_id
+    scoped = user_id.strip()
+    if for_write and scoped == LEGACY_UNSCOPED_OWNER:
+        raise ValueError(f"{LEGACY_UNSCOPED_OWNER!r} is reserved for pre-migration rows and cannot be written")
+    return scoped
 
 
 class GeneralStorage:
@@ -113,10 +122,21 @@ class GeneralStorage:
         columns = {row[1] for row in await cursor.fetchall()}
         if "user_id" in columns:
             return
-        await conn.execute(
-            "ALTER TABLE memory_entries ADD COLUMN user_id TEXT NOT NULL "
-            f"DEFAULT '{LEGACY_UNSCOPED_OWNER}'"  # nosec B608
-        )
+        try:
+            await conn.execute(
+                "ALTER TABLE memory_entries ADD COLUMN user_id TEXT NOT NULL "
+                f"DEFAULT '{LEGACY_UNSCOPED_OWNER}'"  # nosec B608
+            )
+        except aiosqlite.OperationalError as exc:
+            # The PRAGMA and the ALTER are not one transaction, and the asyncio
+            # lock above this only guards a single process. Two workers coming
+            # up together against the same DB both see the column missing and
+            # both ALTER; the loser must treat "already there" as success, not
+            # as a fatal startup error.
+            if "duplicate column name" not in str(exc).lower():
+                raise
+            logger.debug("memory_entries.user_id already added by a concurrent initializer (#13688)")
+            return
         logger.info(
             "Migrated memory_entries: added user_id; pre-existing rows parked under %s (#13688)",
             LEGACY_UNSCOPED_OWNER,
@@ -125,7 +145,7 @@ class GeneralStorage:
     async def store(self, entry: MemoryEntry) -> int:
         """Store memory entry. The entry must carry an owner (#13688)."""
         category_value = entry.category.value if isinstance(entry.category, MemoryCategory) else entry.category
-        user_id = _require_user_id(entry.user_id)
+        user_id = _require_user_id(entry.user_id, for_write=True)
 
         try:
             async with self._get_connection() as conn:

--- a/autobot-backend/memory_consolidation_test.py
+++ b/autobot-backend/memory_consolidation_test.py
@@ -16,10 +16,10 @@ sys.path.append(str(Path(__file__).parent))
 
 from markdown_reference_system import MarkdownReferenceSystem
 from memory import MemoryCategory, MemoryManager, TaskPriority
+from task_execution_tracker import TaskExecutionTracker
 
 # #13688: the general memory plane is owner-scoped; tests must name an owner.
 TEST_USER = "test-user"
-from task_execution_tracker import TaskExecutionTracker
 
 
 async def test_memory_consolidation_system():

--- a/autobot-backend/memory_consolidation_test.py
+++ b/autobot-backend/memory_consolidation_test.py
@@ -16,6 +16,9 @@ sys.path.append(str(Path(__file__).parent))
 
 from markdown_reference_system import MarkdownReferenceSystem
 from memory import MemoryCategory, MemoryManager, TaskPriority
+
+# #13688: the general memory plane is owner-scoped; tests must name an owner.
+TEST_USER = "test-user"
 from task_execution_tracker import TaskExecutionTracker
 
 
@@ -104,7 +107,9 @@ async def test_memory_consolidation_system():
     # Add markdown reference if README exists
     readme_path = Path("README.md")
     if readme_path.exists():
-        memory_manager.add_markdown_reference(integration_task_id, str(readme_path), "project_documentation")
+        memory_manager.add_markdown_reference(
+        integration_task_id, str(readme_path), "project_documentation", user_id=TEST_USER
+    )
         print(f"✅ Added markdown reference: README.md -> {integration_task_id}")  # noqa: print  # noqa: print
 
     # Complete integration task
@@ -145,13 +150,14 @@ async def test_embedding_system():
         content_type="test_document",
         embedding_model="test_model",
         embedding_vector=test_embedding,
+        user_id=TEST_USER,
     )
 
     if success:
         print("✅ Embedding stored successfully")  # noqa: print
 
         # Retrieve embedding (store_embedding persists it as a FACT-category memory entry)
-        entries = await memory_manager.retrieve_memories(MemoryCategory.FACT, limit=10)
+        entries = await memory_manager.retrieve_memories(MemoryCategory.FACT, user_id=TEST_USER, limit=10)
         stored_entry = next(
             (
                 entry

--- a/autobot-backend/memory_consolidation_test.py
+++ b/autobot-backend/memory_consolidation_test.py
@@ -108,9 +108,9 @@ async def test_memory_consolidation_system():
     readme_path = Path("README.md")
     if readme_path.exists():
         memory_manager.add_markdown_reference(
-        integration_task_id, str(readme_path), "project_documentation", user_id=TEST_USER
-    )
-        print(f"✅ Added markdown reference: README.md -> {integration_task_id}")  # noqa: print  # noqa: print
+            integration_task_id, str(readme_path), "project_documentation", user_id=TEST_USER
+        )
+        print(f"✅ Added markdown reference: README.md -> {integration_task_id}")  # noqa: print
 
     # Complete integration task
     memory_manager.complete_task(integration_task_id)

--- a/autobot-backend/multimodal_processor/models.py
+++ b/autobot-backend/multimodal_processor/models.py
@@ -27,6 +27,10 @@ class MultiModalInput:
     data: Any  # Flexible data field for any input type
     metadata: Dict[str, Any] = field(default_factory=dict)
     timestamp: float = field(default_factory=time.time)
+    # #13688: owner of this input, carried as a first-class field rather than a
+    # metadata key so the memory write below it can be tenant-scoped. Set from
+    # the authenticated principal at the API boundary.
+    user_id: str | None = None
 
 
 @dataclass
@@ -43,3 +47,7 @@ class ProcessingResult:
     processing_time: float
     error_message: str | None = None
     metadata: Dict[str, Any] = field(default_factory=dict)
+    # #13688: stamped from the originating input in MultiModalProcessor.process
+    # so every result knows whose it is without each of the 25 construction
+    # sites having to remember.
+    user_id: str | None = None

--- a/autobot-backend/multimodal_processor/multimodal_owner_scope_test.py
+++ b/autobot-backend/multimodal_processor/multimodal_owner_scope_test.py
@@ -1,0 +1,72 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Owner scoping on the multi-modal memory write (#13688).
+
+`_store_result` wrote a general memory row with no owner. After the plane
+required one, this call site would have raised a TypeError into a handler that
+only warns — every processing result would have stopped persisting silently.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from multimodal_processor.models import ModalityType, ProcessingIntent, ProcessingResult
+from multimodal_processor.processor import MultiModalProcessor
+
+
+def _result(user_id=None):
+    return ProcessingResult(
+        result_id="r-1",
+        input_id="i-1",
+        modality_type=ModalityType.TEXT,
+        intent=ProcessingIntent.DECISION_MAKING,
+        success=True,
+        confidence=0.9,
+        result_data={},
+        processing_time=0.1,
+        user_id=user_id,
+    )
+
+
+@pytest.fixture
+def processor():
+    return MultiModalProcessor()
+
+
+class TestOwnerReachesTheWrite:
+    @pytest.mark.asyncio
+    async def test_owner_is_passed_to_store_memory(self, processor):
+        with patch.object(processor.memory_manager, "store_memory", new_callable=AsyncMock) as store:
+            await processor._store_result(_result(user_id="user-42"))
+
+        store.assert_awaited_once()
+        assert store.await_args.kwargs["user_id"] == "user-42"
+
+    @pytest.mark.asyncio
+    async def test_owner_is_not_buried_in_metadata(self, processor):
+        """#13688: the scope is a first-class argument, not a metadata key."""
+        with patch.object(processor.memory_manager, "store_memory", new_callable=AsyncMock) as store:
+            await processor._store_result(_result(user_id="user-42"))
+
+        assert "user_id" not in store.await_args.kwargs["metadata"]
+
+
+class TestUnownedResultIsNotPersisted:
+    @pytest.mark.asyncio
+    async def test_unowned_result_skips_the_write(self, processor):
+        with patch.object(processor.memory_manager, "store_memory", new_callable=AsyncMock) as store:
+            await processor._store_result(_result(user_id=None))
+
+        store.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_the_skip_is_logged_not_silent(self, processor):
+        """The failure this replaces was a swallowed TypeError. Say it out loud."""
+        with patch.object(processor.memory_manager, "store_memory", new_callable=AsyncMock):
+            with patch.object(processor, "logger") as log:
+                await processor._store_result(_result(user_id=None))
+
+        assert any("#13688" in str(c.args[0]) for c in log.warning.call_args_list if c.args)

--- a/autobot-backend/multimodal_processor/multimodal_owner_scope_test.py
+++ b/autobot-backend/multimodal_processor/multimodal_owner_scope_test.py
@@ -70,3 +70,86 @@ class TestUnownedResultIsNotPersisted:
                 await processor._store_result(_result(user_id=None))
 
         assert any("#13688" in str(c.args[0]) for c in log.warning.call_args_list if c.args)
+
+
+# ---------------------------------------------------------------------------
+# Gaps surfaced by re-review of PR #13698
+# ---------------------------------------------------------------------------
+
+
+class TestPrincipalClaimResolution:
+    """N1: reading `user_id` alone missed every principal minted without it.
+
+    `_extract_user_from_jwt` sets `user_id` only when the token carries that
+    claim, but always sets `sub`. Resolving the optional claim dropped rows and
+    split one user across two owner silos depending on which endpoint wrote.
+    """
+
+    @pytest.mark.parametrize(
+        "principal,expected",
+        [
+            ({"id": "3f2c", "user_id": "u-42", "sub": "alice"}, "3f2c"),
+            ({"user_id": "u-42", "sub": "alice"}, "u-42"),
+            ({"sub": "alice"}, "alice"),
+            ({}, None),
+            (None, None),
+        ],
+    )
+    def test_claim_order_matches_the_repo_standard(self, principal, expected):
+        from autobot_shared.principal import resolve_principal_id
+
+        assert resolve_principal_id(principal) == expected
+
+    def test_the_two_endpoints_resolve_the_same_owner(self):
+        """Same principal must not land in two silos."""
+        from autobot_shared.principal import resolve_principal_id
+
+        principal = {"sub": "alice"}
+
+        # api.multimodal._principal_id and api.task_memory both delegate here,
+        # so one principal can no longer land in two owner silos.
+        assert resolve_principal_id(principal) == "alice"
+
+
+class TestProcessStampsTheOwner:
+    @pytest.mark.asyncio
+    async def test_process_stamps_the_result_from_the_input(self):
+        """The stamp is what carries the owner to _store_result."""
+        from multimodal_processor.models import ModalityType, MultiModalInput, ProcessingIntent
+        from multimodal_processor.processor import MultiModalProcessor
+
+        proc = MultiModalProcessor()
+        modal_input = MultiModalInput(
+            input_id="i-1",
+            modality_type=ModalityType.TEXT,
+            intent=ProcessingIntent.DECISION_MAKING,
+            data="hello",
+            user_id="user-7",
+        )
+
+        with patch.object(proc, "_route_to_processor", new_callable=AsyncMock) as route:
+            route.return_value = _result(user_id=None)
+            with patch.object(proc.memory_manager, "store_memory", new_callable=AsyncMock) as store:
+                result = await proc.process(modal_input)
+
+        assert result.user_id == "user-7"
+        assert store.await_args.kwargs["user_id"] == "user-7"
+
+
+class TestSystemInitiatedWorkIsPersisted:
+    @pytest.mark.asyncio
+    async def test_a_system_owned_result_is_stored_not_dropped(self):
+        """N3: system-initiated work has no human requester.
+
+        Dropping it would move the data loss the migration was written to avoid
+        from the read path to the write path.
+        """
+        from memory.storage.general_storage import SYSTEM_OWNER
+
+        proc = MultiModalProcessor()
+
+        with patch.object(proc.memory_manager, "store_memory", new_callable=AsyncMock) as store:
+            await proc._store_result(_result(user_id=SYSTEM_OWNER))
+
+        store.assert_awaited_once()
+        assert store.await_args.kwargs["user_id"] == SYSTEM_OWNER

--- a/autobot-backend/multimodal_processor/multimodal_system_integration_test.py
+++ b/autobot-backend/multimodal_processor/multimodal_system_integration_test.py
@@ -307,6 +307,9 @@ class TestUnifiedMultiModalSystem:
             modality_type=ModalityType.TEXT,
             intent=ProcessingIntent.DECISION_MAKING,
             data="test decision context",
+            # #13688: the memory plane refuses unowned writes, so a stored
+            # result must carry the owner of the input that produced it.
+            user_id="test-user",
         )
 
         # Issue #10626 replaced the non-existent MemoryManager.store_task()

--- a/autobot-backend/multimodal_processor/processor.py
+++ b/autobot-backend/multimodal_processor/processor.py
@@ -159,6 +159,12 @@ class MultiModalProcessor:
             # Update statistics
             self._update_stats(result)
 
+            # #13688: stamp the owner from the input in one place, so the memory
+            # write is tenant-scoped without touching every ProcessingResult
+            # construction site.
+            if result.user_id is None:
+                result.user_id = input_data.user_id
+
             # Store result in memory
             await self._store_result(result)
 
@@ -534,9 +540,21 @@ class MultiModalProcessor:
             # use store_memory() with EXECUTION category instead.
             from memory.enums import MemoryCategory
 
+            if not result.user_id:
+                # #13688: the plane refuses unowned writes. Say so loudly — the
+                # old behaviour was an untenanted row, and the failure mode this
+                # replaces was a swallowed TypeError that silently stopped
+                # persisting every result.
+                self.logger.warning(
+                    "Not persisting multi-modal result %s: no owner on the input (#13688)",
+                    result.result_id,
+                )
+                return
+
             await self.memory_manager.store_memory(
                 category=MemoryCategory.EXECUTION,
                 content=f"Multi-modal processing: {result.modality_type.value}",
+                user_id=result.user_id,
                 metadata={
                     "result_id": result.result_id,
                     "task_type": "multimodal_processing",

--- a/autobot-backend/performance_benchmarks_test.py
+++ b/autobot-backend/performance_benchmarks_test.py
@@ -28,6 +28,9 @@ from memory.enums import MemoryCategory
 from orchestrator import Orchestrator
 from services.llm_service import LLMService
 
+# #13688: the general memory plane is owner-scoped; tests must name an owner.
+TEST_USER = "test-user"
+
 # #13162: every test in this module asserts a wall-clock budget
 # (``avg_duration``/``total_time``) or an RSS delta — there is not one
 # functional-only test here. That makes the module a benchmark suite, so it
@@ -433,6 +436,7 @@ class TestMemorySystemPerformance:
                 await self.memory_manager.store_memory(
                     category=MemoryCategory.EXECUTION,
                     content=entry["content"],
+                    user_id=TEST_USER,
                     metadata={"test_id": i, "context": entry["context"]},
                 )
 
@@ -464,6 +468,7 @@ class TestMemorySystemPerformance:
             await self.memory_manager.store_memory(
                 category=categories[i % len(categories)],
                 content=f"Test memory {i}",
+                user_id=TEST_USER,
                 metadata={"test_id": i, "context": "performance_test"},
             )
 
@@ -473,7 +478,7 @@ class TestMemorySystemPerformance:
             for _ in range(10):
                 self.benchmark.start_measurement()
 
-                results = await self.memory_manager.retrieve_memories(category=category, limit=10)
+                results = await self.memory_manager.retrieve_memories(category=category, user_id=TEST_USER, limit=10)
 
                 self.benchmark.end_measurement()
 

--- a/autobot-backend/task_execution_tracker.py
+++ b/autobot-backend/task_execution_tracker.py
@@ -358,9 +358,11 @@ class TaskExecutionTracker:
             agent_counts[agent_type] = agent_counts.get(agent_type, 0) + 1
         return agent_counts
 
-    def add_markdown_reference(self, task_id: str, markdown_file: str, ref_type: str = "documentation"):
-        """Add markdown reference to a task"""
-        return self.memory_manager.add_markdown_reference(task_id, markdown_file, ref_type)
+    def add_markdown_reference(
+        self, task_id: str, markdown_file: str, ref_type: str = "documentation", *, user_id: str
+    ):
+        """Add markdown reference to a task (#13688: owner-scoped)"""
+        return self.memory_manager.add_markdown_reference(task_id, markdown_file, ref_type, user_id=user_id)
 
     def store_task_embedding(
         self,
@@ -368,13 +370,16 @@ class TaskExecutionTracker:
         content: str,
         embedding_model: str,
         embedding_vector: List[float],
+        *,
+        user_id: str,
     ):
-        """Store embedding for task-related content"""
+        """Store embedding for task-related content (#13688: owner-scoped)"""
         return self.memory_manager.store_embedding(
             content=content,
             content_type=f"task_{task_id}",
             embedding_model=embedding_model,
             embedding_vector=embedding_vector,
+            user_id=user_id,
         )
 
     def _aggregate_task_stats(self, history: List[TaskExecutionRecord]) -> Dict[str, Dict[str, Any]]:
@@ -563,13 +568,15 @@ class TaskExecutionContext:
             metadata=self.metadata.copy(),
         )
 
-    def add_markdown_reference(self, markdown_file: str, ref_type: str = "documentation"):
-        """Add markdown file reference to current task"""
-        return self.tracker.add_markdown_reference(self.task_id, markdown_file, ref_type)
+    def add_markdown_reference(self, markdown_file: str, ref_type: str = "documentation", *, user_id: str):
+        """Add markdown file reference to current task (#13688: owner-scoped)"""
+        return self.tracker.add_markdown_reference(self.task_id, markdown_file, ref_type, user_id=user_id)
 
-    def store_embedding(self, content: str, embedding_model: str, embedding_vector: List[float]):
-        """Store embedding related to current task"""
-        return self.tracker.store_task_embedding(self.task_id, content, embedding_model, embedding_vector)
+    def store_embedding(self, content: str, embedding_model: str, embedding_vector: List[float], *, user_id: str):
+        """Store embedding related to current task (#13688: owner-scoped)"""
+        return self.tracker.store_task_embedding(
+            self.task_id, content, embedding_model, embedding_vector, user_id=user_id
+        )
 
 
 get_task_tracker = lazy_singleton(TaskExecutionTracker)

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -40333,6 +40333,11 @@ export interface paths {
         /**
          * Add Markdown Reference
          * @description Add markdown file reference to a task.
+         *
+         *     #13688: the reference is stored as a general memory row, which is now
+         *     owner-scoped. The owner comes from the authenticated principal — taking it
+         *     from ``MarkdownReferenceRequest`` would let a caller write into another
+         *     user's memory.
          */
         post: operations["add_markdown_reference_api_task_memory_tasks__task_id__markdown_reference_post"];
         delete?: never;

--- a/autobot_shared/principal.py
+++ b/autobot_shared/principal.py
@@ -1,0 +1,44 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Canonical resolution of an authenticated principal's owner id (#13688).
+
+Lives in ``autobot_shared`` deliberately: it is a pure dict read with no
+imports, needed by both the API layer and the memory data plane, and it must
+stay importable without dragging in the config/Redis chain that
+``auth_middleware`` pulls at import time.
+
+Before this, call sites each picked their own claim order — the repo carried
+roughly six competing variants. Reading the wrong one is not cosmetic: the
+``user_id`` claim is set only when a token carries it
+(``auth_middleware._extract_user_from_jwt``), while ``sub`` is set
+unconditionally, so a call site keying on ``user_id`` alone silently drops
+principals and can file one user's rows under two different owners.
+"""
+
+from typing import Any, Dict, Optional
+
+# Claim order: `id` (user_management records) → `user_id` (optional JWT claim)
+# → `sub` (always present on a JWT principal).
+_CLAIM_ORDER = ("id", "user_id", "sub")
+
+
+def resolve_principal_id(current_user: Optional[Dict[str, Any]]) -> Optional[str]:
+    """Return the principal's owner id, or None when it has no user identity.
+
+    None is returned for internal service keys and dev-header auth, which are
+    authenticated but are not a *user*. Callers decide what that means — a 401
+    for a user-facing endpoint, or a system-owned write for background work.
+    It is never a valid owner scope.
+    """
+    if not current_user:
+        return None
+    for claim in _CLAIM_ORDER:
+        value = current_user.get(claim)
+        if value:
+            return str(value)
+    return None
+
+
+__all__ = ["resolve_principal_id"]


### PR DESCRIPTION
## Thinking Path

The plane had no owner argument anywhere: not on the write path, not on the reads.
`search_memories(query)` handed the query straight to `_general_storage.search(query)` and
returned the result unfiltered — every owner's rows, to any caller that reached it.

There is no known live leak, and the reason matters for how this was fixed. Tenancy is enforced
*above* the plane (`memory/transparency.py`, #10554, with cross-user list/delete rejection proven
by `memory_privacy_test.py`) and *beside* it (the working-memory key allowlist, hardened after the
IDOR finding). None of that is on the plane itself. So the defect is a shape defect: isolation
depended on every present and future call site remembering to filter, and could be undone by one
new caller that forgot.

That is why the fix is not "add a filter to the three methods". The filter went **down** into
`GeneralStorage`, where `user_id` is a required parameter of `retrieve()`/`search()` — a query
without a scope cannot be constructed there at all. The manager methods take it keyword-only with
no default, so omitting it is a `TypeError` at the call, not a silent full-tenant read.

Vocabulary is reused, not invented: `user_id`, which is what `transparency.py` keys every one of
its five stores on. No second notion of "owner" enters the subsystem.

### What the type checker could not tell me, and the tests did

Grepping the three named methods finds two callers. Running the suite found **five** more paths
that write into the same plane and would each have become a surviving unscoped writer:

1. the `GENERAL_MEMORY` strategy path (`store()` → `_store_general_memory`),
2. `store_embedding()`,
3. `add_markdown_reference()`,
4. `TaskExecutionTracker.store_task_embedding()` / `.add_markdown_reference()`,
5. the `TaskContext` wrappers over (4).

All five now require the scope. Fixing only the three named methods would have left the plane
writable without an owner through four other doors — the exact failure this issue is about.

## What Changed

**`memory/storage/general_storage.py`** — where the guarantee lives
- `user_id TEXT NOT NULL` column + `idx_memory_user_category` (owner leads the index, since every
  read filters on it first).
- `retrieve(user_id, category, filters)` and `search(user_id, query)` — scope required, applied as
  a WHERE predicate. In `search` the owner predicate **brackets** the content-OR-metadata match
  (`user_id = ? AND (content LIKE ? OR metadata_json LIKE ?)`), so a metadata hit cannot cross an
  owner boundary.
- `store()` validates `entry.user_id`.
- `_migrate_add_user_id()` — `ALTER TABLE ADD COLUMN` with a non-null default for pre-#13688
  databases. Existing rows are **parked** under a reserved `__unscoped__` owner: not deleted (no
  data loss) and not attributed to a real user (which would leak them into the first caller's
  results). They stay readable by asking for that owner explicitly.

**`memory/manager.py`** — `user_id` keyword-only and required on all three methods, plus the four
other writer paths listed above.

**`memory/models.py`** — `user_id` as a first-class `MemoryEntry` field, never a `metadata` key.

**`memory/protocols.py`** — `IGeneralStorage` now states that implementations must apply the scope
as a predicate rather than trusting callers to filter afterwards.

**`memory/compat.py`** — threaded through so the wrapper cannot be the one place an untenanted
write is still reachable. This is deliberately the *minimum* to keep it working; #13690 decides
its fate (find the missing caller vs. record the completed migration) and is sequenced after this.

## Verification

14 new tests, including the leak proof the AC asks for at the storage layer:

```
$ python3 -m pytest memory/general_storage_tenancy_test.py -q
14 passed in 1.84s
```

Full memory package plus every suite that touches the changed writers:

```
$ python3 -m pytest memory/ memory_consolidation_test.py performance_benchmarks_test.py -q -p no:randomly
188 passed, 2 errors in 5.56s
```

The 2 errors are `TestOrchestratorPerformance`, pre-existing on base and unrelated
(`orchestrator` has no attribute `config_manager`). Confirmed by running the same node on
`Dev_new_gui` with no changes applied — identical error. Filed separately rather than absorbed here.

Rebased onto `origin/Dev_new_gui` after base moved mid-session; re-ran the above at the new base,
same result. No conflict markers in any changed file.

### Acceptance criteria

- [x] All three methods require a scope; omitting it is a `TypeError`, not a silent full-tenant
      query — `test_omitting_the_scope_is_a_type_error`; blank/whitespace is a `ValueError`
      (`test_blank_scope_is_a_value_error`).
- [x] The filter is applied in `_general_storage`, evidenced by a test that constructs a query
      **directly at the storage layer** and cannot retrieve another owner's entry —
      `test_retrieve_cannot_return_another_owners_entry`, and
      `test_query_without_a_scope_cannot_be_constructed`.
- [x] `search_memories` cannot return another owner's memories —
      `test_search_cannot_return_another_owners_entry`, plus
      `test_search_matching_metadata_still_cannot_cross_owners` for the metadata-match path.
- [x] The scope is a first-class field, not in `metadata` — `test_user_id_is_a_column_not_a_metadata_key`
      asserts the column exists via `PRAGMA table_info` and that the owner is absent from
      `metadata_json`.
- [x] No behaviour change for a correctly-scoped caller —
      `test_correctly_scoped_caller_sees_no_behaviour_change`.

Plus, beyond the ACs: `test_existing_rows_survive_and_are_parked_not_leaked` and
`test_migration_is_idempotent` cover the upgrade path, since this changes a live schema.

## Model Used

Claude Opus 5 (1M context)

Closes #13688
Part of #13685
