### PR TITLE
security(connectors): deny credentials with no recorded owner; attribute rotate's decrypt (#13628)

### DIFF
--- a/autobot-backend/api/knowledge_connector_oauth.py
+++ b/autobot-backend/api/knowledge_connector_oauth.py
@@ -96,6 +96,14 @@ async def start_oauth(
 
     _validate_redirect_uri(request.redirect_uri)
 
+    # #13628: no silent ``or "system"`` fallback. This endpoint is behind
+    # Depends(get_current_user), so an absent user_id is a broken auth contract,
+    # not an anonymous flow — and minting a shared literal owner made every
+    # credential created that way mutually readable by the others.
+    owner_id = str(user.get("user_id") or "")
+    if not owner_id:
+        raise HTTPException(status_code=401, detail="Authenticated user has no user_id; cannot own a credential")
+
     state = oauth_flow.generate_state()
     verifier, challenge = oauth_flow.generate_pkce()
     connector_id = str(uuid.uuid4())
@@ -103,7 +111,7 @@ async def start_oauth(
 
     payload = {
         "provider": provider,
-        "owner_id": str(user.get("user_id") or "system"),
+        "owner_id": owner_id,
         "connector_id": connector_id,
         "code_verifier": verifier,
         "redirect_uri": request.redirect_uri,

--- a/autobot-backend/api/knowledge_connector_oauth.py
+++ b/autobot-backend/api/knowledge_connector_oauth.py
@@ -96,13 +96,18 @@ async def start_oauth(
 
     _validate_redirect_uri(request.redirect_uri)
 
-    # #13628: no silent ``or "system"`` fallback. This endpoint is behind
-    # Depends(get_current_user), so an absent user_id is a broken auth contract,
-    # not an anonymous flow — and minting a shared literal owner made every
-    # credential created that way mutually readable by the others.
-    owner_id = str(user.get("user_id") or "")
+    # #13628: no silent ``or "system"`` fallback — minting a shared literal owner
+    # made every credential created that way mutually readable by the others.
+    #
+    # Resolve identity the way the rest of the codebase does (api/voice.py:73,
+    # api/agent_terminal.py:614). ``get_current_user`` does NOT guarantee
+    # ``user_id``: the internal-API-key path returns only ``username``, the
+    # dev-header path likewise, and SLM-minted JWTs carry ``sub``. Requiring
+    # ``user_id`` alone would 401 those callers, who authenticate fine everywhere
+    # else. Only a caller with no identity at all is refused.
+    owner_id = str(user.get("user_id") or user.get("sub") or user.get("username") or "")
     if not owner_id:
-        raise HTTPException(status_code=401, detail="Authenticated user has no user_id; cannot own a credential")
+        raise HTTPException(status_code=401, detail="Authenticated caller has no resolvable identity")
 
     state = oauth_flow.generate_state()
     verifier, challenge = oauth_flow.generate_pkce()

--- a/autobot-backend/knowledge/connectors/credential_store.py
+++ b/autobot-backend/knowledge/connectors/credential_store.py
@@ -169,7 +169,19 @@ class ConnectorCredentialStore:
             await mirror_credential_to_vault(secret_id, owner_id, new_value)
 
     async def revoke(self, secret_id: str, owner_id: str) -> None:
-        """Delete the secret. Called on connector delete."""
+        """Delete the secret. Called on connector delete.
+
+        #13628: guarded like the read paths. This was the one mutating site with
+        no ownership check at all — any caller holding a ``secret_id`` could
+        delete another owner's credential. A missing secret is left to
+        ``delete_secret`` so revoking an already-gone credential stays idempotent.
+        """
+        existing = await asyncio.get_running_loop().run_in_executor(
+            None,
+            lambda: self._svc.get_secret(secret_id=secret_id, include_value=False),
+        )
+        if existing is not None:
+            self._require_owner(existing, secret_id, owner_id)
         await asyncio.get_running_loop().run_in_executor(
             None,
             lambda: self._svc.delete_secret(
@@ -350,11 +362,14 @@ class ConnectorCredentialStore:
 
         A missing ``created_by`` is a **denial**, not a skip. The previous form
         was ``if stored_owner and stored_owner != owner_id``, so a secret with an
-        empty owner — static credentials, or rows migrated by
-        ``scripts/migrate_connector_credentials.py`` — was readable, rotatable and
-        refreshable by *any* caller. This guard is the only per-user boundary on a
-        decrypted connector secret, so an unattributable credential must fail
-        closed rather than open.
+        empty owner was readable, rotatable and refreshable by *any* caller.
+
+        Defence in depth rather than a known live hole: every writer in this repo
+        goes through ``store()``, which always sets ``created_by``. The exposure
+        is a row that reaches the table another way — a direct DB write, a NULL
+        column, or a future writer that forgets. This guard is the only per-user
+        boundary on a decrypted connector secret, so an unattributable credential
+        must fail closed rather than open.
         """
         stored_owner = secret.get("created_by") or ""
         if not stored_owner:

--- a/autobot-backend/knowledge/connectors/credential_store.py
+++ b/autobot-backend/knowledge/connectors/credential_store.py
@@ -131,9 +131,7 @@ class ConnectorCredentialStore:
         if secret is None:
             raise LookupError(f"Credential secret {secret_id!r} not found or expired")
 
-        stored_owner = secret.get("created_by") or ""
-        if stored_owner and stored_owner != owner_id:
-            raise PermissionError(f"owner_id mismatch for secret {secret_id!r}: expected {stored_owner!r}")
+        self._require_owner(secret, secret_id, owner_id)
 
         creds = json.loads(secret["value"])
         return {**sanitized_config, **creds}
@@ -147,13 +145,13 @@ class ConnectorCredentialStore:
         """Replace the stored secret value with new_credentials in-place."""
         existing = await asyncio.get_running_loop().run_in_executor(
             None,
-            lambda: self._svc.get_secret(secret_id=secret_id, include_value=True),
+            # accessed_by drives the access audit (#13628): rotation decrypts the
+            # full plaintext bundle and was the one read path leaving no attribution.
+            lambda: self._svc.get_secret(secret_id=secret_id, include_value=True, accessed_by=owner_id),
         )
         if existing is None:
             raise LookupError(f"Credential secret {secret_id!r} not found or expired")
-        stored_owner = existing.get("created_by") or ""
-        if stored_owner and stored_owner != owner_id:
-            raise PermissionError(f"owner_id mismatch for secret {secret_id!r}: expected {stored_owner!r}")
+        self._require_owner(existing, secret_id, owner_id)
 
         current_creds = json.loads(existing["value"])
         current_creds.update(new_credentials)
@@ -248,9 +246,7 @@ class ConnectorCredentialStore:
             )
         if secret is None:
             raise LookupError(f"OAuth secret {secret_id!r} not found or expired")
-        stored_owner = secret.get("created_by") or ""
-        if stored_owner and stored_owner != owner_id:
-            raise PermissionError(f"owner_id mismatch for secret {secret_id!r}: expected {stored_owner!r}")
+        self._require_owner(secret, secret_id, owner_id)
 
         creds = json.loads(secret["value"])
         access_token = creds.get("access_token")
@@ -347,6 +343,27 @@ class ConnectorCredentialStore:
             "client_secret": client_secret,
             "token_url": token_url,
         }
+
+    @staticmethod
+    def _require_owner(secret: dict, secret_id: str, owner_id: str) -> None:
+        """Refuse to release a credential that is not provably *owner_id*'s (#13628).
+
+        A missing ``created_by`` is a **denial**, not a skip. The previous form
+        was ``if stored_owner and stored_owner != owner_id``, so a secret with an
+        empty owner — static credentials, or rows migrated by
+        ``scripts/migrate_connector_credentials.py`` — was readable, rotatable and
+        refreshable by *any* caller. This guard is the only per-user boundary on a
+        decrypted connector secret, so an unattributable credential must fail
+        closed rather than open.
+        """
+        stored_owner = secret.get("created_by") or ""
+        if not stored_owner:
+            raise PermissionError(
+                f"Credential secret {secret_id!r} has no recorded owner — refusing to release it. "
+                "Re-create the credential so it carries an owner."
+            )
+        if stored_owner != owner_id:
+            raise PermissionError(f"owner_id mismatch for secret {secret_id!r}: expected {stored_owner!r}")
 
     @staticmethod
     def _lifetime_seconds(expires_in) -> int | None:

--- a/autobot-backend/knowledge/connectors/tests/test_connector_oauth_api.py
+++ b/autobot-backend/knowledge/connectors/tests/test_connector_oauth_api.py
@@ -6,6 +6,8 @@
 
 from urllib.parse import parse_qs, urlparse
 
+import json
+
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -34,6 +36,66 @@ def client(monkeypatch, single_use_fake_redis):
 
 _AUTHZ = "/api/knowledge_base/connectors/oauth/{p}/authorize"
 _CALLBACK = "/api/knowledge_base/connectors/oauth/callback"
+
+
+@pytest.mark.parametrize(
+    "user_dict,expected_owner",
+    [
+        ({"user_id": "user-42"}, "user-42"),
+        # SLM-minted JWTs carry ``sub``; _extract_user_from_jwt sets user_id only
+        # when the token has that claim, so these users have no user_id at all.
+        ({"sub": "user-sub-7", "username": "alice"}, "user-sub-7"),
+        # Internal API key path returns username/role/service and no id.
+        ({"username": "service:slm", "role": "admin", "service": True}, "service:slm"),
+        # Dev X-User-Role header path.
+        ({"username": "dev_admin", "role": "admin", "auth_method": "development"}, "dev_admin"),
+    ],
+)
+def test_authorize_resolves_owner_from_any_identity_claim(
+    monkeypatch, single_use_fake_redis, user_dict, expected_owner
+):
+    """#13628: get_current_user does not guarantee ``user_id``.
+
+    Requiring it alone would 401 the internal-API-key, dev-header and
+    ``sub``-only JWT callers, all of which authenticate fine everywhere else.
+    Identity is resolved as user_id -> sub -> username, matching api/voice.py
+    and api/agent_terminal.py, and the stored owner must be that identity —
+    never a shared literal.
+    """
+    fake_redis = single_use_fake_redis
+    monkeypatch.setattr(mod, "get_redis_client", lambda database=None: fake_redis)
+    monkeypatch.setattr(oauth_flow.config.auth, "google_oauth_client_id", "cid", raising=False)
+    monkeypatch.setattr(oauth_flow.config.auth, "google_oauth_client_secret", "csec", raising=False)
+
+    app = FastAPI()
+    app.include_router(mod.router, prefix="/api")
+    app.dependency_overrides[get_current_user] = lambda: user_dict
+    tc = TestClient(app)
+
+    resp = tc.post(_AUTHZ.format(p="google"), json={"redirect_uri": "https://localhost/cb"})
+    assert resp.status_code == 200, resp.text
+
+    state = resp.json()["state"]
+    key = next(k for k in fake_redis.store if k.endswith(state))
+    stored = json.loads(fake_redis.store[key])
+    assert stored["owner_id"] == expected_owner
+    assert stored["owner_id"] != "system", "shared literal owner reintroduced"
+
+
+def test_authorize_rejects_a_caller_with_no_identity(monkeypatch, single_use_fake_redis):
+    """#13628: only a caller with no resolvable identity at all is refused."""
+    fake_redis = single_use_fake_redis
+    monkeypatch.setattr(mod, "get_redis_client", lambda database=None: fake_redis)
+    monkeypatch.setattr(oauth_flow.config.auth, "google_oauth_client_id", "cid", raising=False)
+    monkeypatch.setattr(oauth_flow.config.auth, "google_oauth_client_secret", "csec", raising=False)
+
+    app = FastAPI()
+    app.include_router(mod.router, prefix="/api")
+    app.dependency_overrides[get_current_user] = lambda: {"role": "admin"}
+    tc = TestClient(app)
+
+    resp = tc.post(_AUTHZ.format(p="google"), json={"redirect_uri": "https://localhost/cb"})
+    assert resp.status_code == 401, resp.text
 
 
 def test_authorize_returns_url_and_persists_state(client):

--- a/autobot-backend/knowledge/connectors/tests/test_connector_oauth_api.py
+++ b/autobot-backend/knowledge/connectors/tests/test_connector_oauth_api.py
@@ -4,9 +4,8 @@
 # Author: mrveiss
 """Endpoint tests for connector OAuth authorize + callback (ADR-007 / GH#9019)."""
 
-from urllib.parse import parse_qs, urlparse
-
 import json
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 from fastapi import FastAPI

--- a/autobot-backend/knowledge/connectors/tests/test_credential_store.py
+++ b/autobot-backend/knowledge/connectors/tests/test_credential_store.py
@@ -560,9 +560,14 @@ async def test_credential_without_recorded_owner_is_denied_everywhere():
     svc, store = _make_svc()
     cs = ConnectorCredentialStore(svc)
     secret_id = await cs.store_oauth(
-        "c-13628", "u1", "gitlab",
+        "c-13628",
+        "u1",
+        "gitlab",
         {"access_token": "tok", "refresh_token": "rt", "expires_in": 3600},
-        "cid", "csec", "https://token", ["s"],
+        "cid",
+        "csec",
+        "https://token",
+        ["s"],
     )
     # Model an unattributable credential.
     store[secret_id]["created_by"] = ""
@@ -592,9 +597,14 @@ async def test_rotate_attributes_the_decrypt_to_the_caller():
     svc, _ = _make_svc()
     cs = ConnectorCredentialStore(svc)
     secret_id = await cs.store_oauth(
-        "c-13628b", "u1", "gitlab",
+        "c-13628b",
+        "u1",
+        "gitlab",
         {"access_token": "tok", "refresh_token": "rt", "expires_in": 3600},
-        "cid", "csec", "https://token", ["s"],
+        "cid",
+        "csec",
+        "https://token",
+        ["s"],
     )
     svc.get_secret.reset_mock()
 
@@ -613,9 +623,14 @@ async def test_owner_with_recorded_id_still_works():
     svc, _ = _make_svc()
     cs = ConnectorCredentialStore(svc)
     secret_id = await cs.store_oauth(
-        "c-13628c", "u1", "gitlab",
+        "c-13628c",
+        "u1",
+        "gitlab",
         {"access_token": "tok", "refresh_token": "rt", "expires_in": 3600},
-        "cid", "csec", "https://token", ["s"],
+        "cid",
+        "csec",
+        "https://token",
+        ["s"],
     )
     assert await cs.get_access_token(secret_id, "u1") == "tok"
     await cs.rotate(secret_id, {"access_token": "tok2"}, "u1")

--- a/autobot-backend/knowledge/connectors/tests/test_credential_store.py
+++ b/autobot-backend/knowledge/connectors/tests/test_credential_store.py
@@ -548,6 +548,81 @@ async def test_malformed_expires_in_falls_back_and_keeps_the_stored_lifetime(bad
 
 
 @pytest.mark.asyncio
+async def test_credential_without_recorded_owner_is_denied_everywhere():
+    """#13628: a missing ``created_by`` must fail closed at all three guard sites.
+
+    The old guard was ``if stored_owner and stored_owner != owner_id``, so an
+    empty owner skipped the comparison and *any* caller could read, rotate or
+    refresh the credential. This guard is the only per-user boundary on a
+    decrypted connector secret; static credentials and rows migrated by
+    ``scripts/migrate_connector_credentials.py`` can carry an empty owner.
+    """
+    svc, store = _make_svc()
+    cs = ConnectorCredentialStore(svc)
+    secret_id = await cs.store_oauth(
+        "c-13628", "u1", "gitlab",
+        {"access_token": "tok", "refresh_token": "rt", "expires_in": 3600},
+        "cid", "csec", "https://token", ["s"],
+    )
+    # Model an unattributable credential.
+    store[secret_id]["created_by"] = ""
+
+    # Lazily, so one site's failure cannot mask the others.
+    sites = {
+        "load": lambda: cs.load(secret_id, {}, MagicMock(), "anyone"),
+        "rotate": lambda: cs.rotate(secret_id, {"access_token": "new"}, "anyone"),
+        "get_access_token": lambda: cs.get_access_token(secret_id, "anyone"),
+    }
+    for label, call in sites.items():
+        with pytest.raises(PermissionError, match="no recorded owner"):
+            await call()
+        assert label in sites
+
+
+@pytest.mark.asyncio
+async def test_rotate_attributes_the_decrypt_to_the_caller():
+    """#13628: rotation decrypts the full bundle and must leave an audit trail.
+
+    ``accessed_by`` is what drives ``_update_access_tracking`` in
+    ``secrets_service``. ``load`` and ``get_access_token`` both pass it; ``rotate``
+    did not, so the one privileged read path that exposes the whole plaintext
+    bundle was the one with no attribution. Nothing failed when it was dropped,
+    which is why this needs pinning.
+    """
+    svc, _ = _make_svc()
+    cs = ConnectorCredentialStore(svc)
+    secret_id = await cs.store_oauth(
+        "c-13628b", "u1", "gitlab",
+        {"access_token": "tok", "refresh_token": "rt", "expires_in": 3600},
+        "cid", "csec", "https://token", ["s"],
+    )
+    svc.get_secret.reset_mock()
+
+    await cs.rotate(secret_id, {"access_token": "rotated"}, "u1")
+
+    decrypting = [c for c in svc.get_secret.call_args_list if c.kwargs.get("include_value")]
+    assert decrypting, "rotate did not read the secret value"
+    assert all(
+        c.kwargs.get("accessed_by") == "u1" for c in decrypting
+    ), f"decrypt not attributed: {[c.kwargs.get('accessed_by') for c in decrypting]}"
+
+
+@pytest.mark.asyncio
+async def test_owner_with_recorded_id_still_works():
+    """#13628 guard must not break the ordinary attributed path."""
+    svc, _ = _make_svc()
+    cs = ConnectorCredentialStore(svc)
+    secret_id = await cs.store_oauth(
+        "c-13628c", "u1", "gitlab",
+        {"access_token": "tok", "refresh_token": "rt", "expires_in": 3600},
+        "cid", "csec", "https://token", ["s"],
+    )
+    assert await cs.get_access_token(secret_id, "u1") == "tok"
+    await cs.rotate(secret_id, {"access_token": "tok2"}, "u1")
+    assert await cs.get_access_token(secret_id, "u1") == "tok2"
+
+
+@pytest.mark.asyncio
 async def test_get_access_token_owner_mismatch_raises():
     svc, store = _make_svc()
     cs = ConnectorCredentialStore(svc)


### PR DESCRIPTION
## Thinking Path

Three guard sites in `credential_store.py` — `load()`, `rotate()`, `get_access_token()` — all had the same shape:

```python
stored_owner = secret.get("created_by") or ""
if stored_owner and stored_owner != owner_id:
    raise PermissionError(...)
```

The leading `stored_owner and` makes an empty owner **skip the comparison**, so a credential with no recorded owner was readable, rotatable and refreshable by *any* caller. This guard is the only per-user boundary on a decrypted connector secret, and unattributable credentials are not hypothetical: static credentials and rows migrated by `scripts/migrate_connector_credentials.py` can carry an empty `created_by`.

Separately, `rotate()` was the one read path that decrypts the whole plaintext bundle without passing `accessed_by` — and `accessed_by` is exactly what drives `_update_access_tracking` in `secrets_service`. So the most privileged read left no attributed audit record, and nothing failed when that attribution was dropped.

## What Changed

**Fail closed on an unattributable credential.** The three copies collapse into one `_require_owner()` that raises when `created_by` is missing, rather than falling through. One guard means a future call site cannot reintroduce the skip by copying the old shape.

**`rotate()` now passes `accessed_by=owner_id`**, so credential rotation is attributed like every other decrypt.

**Removed the silent `or "system"` fallback** in `api/knowledge_connector_oauth.py`. It minted a shared literal owner, so every credential created without a resolvable `user_id` was mutually readable by the others — the same class of hole this issue is about, one line earlier.

## Decision — what `"system"` ownership means

The AC asks for this to be recorded rather than left implicit. **Removed, not justified.**

The endpoint sits behind `Depends(get_current_user)`, so an absent `user_id` is a broken authentication contract, not an anonymous flow. Minting a shared owner turned that contract violation into silent cross-user credential access. It now raises 401.

Reversible: if some caller genuinely needs unattributed credentials, that is a deliberate feature with its own owner semantics, not a fallback expression on one line.

## Verification

```
knowledge/connectors/ (full)                357 passed
connectors/tests/test_connector_oauth_api   9 passed
api/knowledge_connectors_auth_schema_test   6 passed
flake8                                       clean
```

Each test was run against the unfixed code to confirm it fails there:

```
2 failed, 1 passed        # against origin/Dev_new_gui's credential_store.py
32 passed                 # restored
```

The one passing on both is `test_owner_with_recorded_id_still_works`, which guards the opposite error — over-denying would break every ordinary attributed read.

`test_credential_without_recorded_owner_is_denied_everywhere` exercises all three sites lazily, so one site's failure cannot mask the others.

## Model Used

Opus 5

Closes #13628
