### PR TITLE
fix(llc): warn when a replay transcript is missing or unreadable (#13622)

### DIFF
--- a/autobot-backend/llc/scheduler/heartbeat_scheduler.py
+++ b/autobot-backend/llc/scheduler/heartbeat_scheduler.py
@@ -768,7 +768,18 @@ async def _record_run_for_replay(
                     output_text = raw[-_REPLAY_OUTPUT_CAP:] if len(raw) > _REPLAY_OUTPUT_CAP else raw
                     recorded_events = parse_jsonl_events(raw)
                 except OSError:
-                    pass
+                    logger.warning(
+                        "Could not read transcript for replay (run_id: %s) — recording the run without output",
+                        run_id,
+                    )
+            elif output_file:
+                # A configured transcript path that does not exist is currently
+                # indistinguishable from an empty transcript: the replay record is
+                # written either way, with no output and no trace of why.
+                logger.warning(
+                    "Transcript file for replay does not exist (run_id: %s) — recording the run without output",
+                    run_id,
+                )
 
         svc = RunReplayService()
         await svc.record_run(


### PR DESCRIPTION
## Thinking Path

Lands the substantive change from **#13622** by @Miriam-R-coder, as a separate commit.

`_record_run_for_replay` guards the transcript read with:

```python
if output_file and _os.path.exists(output_file):
    try:
        raw = await _asyncio.to_thread(_read_file_text, output_file)
        ...
    except OSError:
        pass
```

There is no `else`, so a configured transcript path that does not exist produces a replay record with no output and no trace of why — indistinguishable from a genuinely empty transcript. The adjacent `except OSError: pass` has the same shape: an unreadable transcript is swallowed entirely.

The original PR could not be merged as-is: its head branch was `main` rather than a topic branch off `Dev_new_gui`, so 9 of its 10 changed files were unrelated `main` ↔ `Dev_new_gui` dependency drift, and it was conflicting. Untangling that is not a reasonable thing to ask of an outside contributor, so the fix is landed here with credit and #13622 is closed with an explanation.

## What Changed

Both silent paths now log:

- transcript path configured but absent → warn, then record the run without output
- transcript present but unreadable → warn instead of `pass`

Two deliberate differences from the original patch:

- **`run_id` is logged, not the file path.** Internal filesystem paths do not belong in logs (project rule), and `run_id` is what actually lets an operator find the run.
- The `except OSError` branch is filled in too. It is the same defect one line down, and leaving it would have fixed the reported half of a two-part silent failure.

## Verification

```
llc/tests -k "heartbeat or replay"     86 passed
llc/tests (full)                        5 failed, 1388 passed, 1 skipped
flake8                                  clean
```

The 5 are `test_poll_loop_scheduler.py`, identical on base with the same command and green on CI — local-environment artifacts (local Python 3.10 vs CI 3.14), untouched here.

## Model Used

Opus 5

Closes #13622
