### PR TITLE
security(egress): make private addresses separable from the hard blocks (#13625)

### DIFF
--- a/autobot-backend/integrations/base.py
+++ b/autobot-backend/integrations/base.py
@@ -130,6 +130,7 @@ class BaseIntegration(ABC):
         import aiohttp
 
         from autobot_shared.http_client import get_http_client
+        from knowledge.connectors.base import instance_host_egress
 
         merged_headers = headers or {}
         if self.config.api_key:
@@ -137,8 +138,17 @@ class BaseIntegration(ABC):
 
         try:
             timeout_obj = aiohttp.ClientTimeout(total=timeout)
+            # #13625 (Rule 8): the integration's configured base URL is operator
+            # config, so the private-network opt-in applies. The Authorization
+            # header above rides on this request, which is why it must not reach
+            # an address egress policy forbids.
             async with get_http_client().tracked_request(
-                method, url, headers=merged_headers, json=json_data, timeout=timeout_obj
+                method,
+                url,
+                headers=merged_headers,
+                json=json_data,
+                timeout=timeout_obj,
+                guard_egress=instance_host_egress(),
             ) as resp:
                 body = await resp.json()
                 return {

--- a/autobot-backend/knowledge/connectors/audio_connector.py
+++ b/autobot-backend/knowledge/connectors/audio_connector.py
@@ -374,11 +374,16 @@ async def _download_direct_url(url: str, dest_dir: str) -> str:
     import aiohttp
 
     from autobot_shared.http_client import get_http_client
+    from knowledge.connectors.base import CONTENT_URL_EGRESS
 
     filename = os.path.basename(url.split("?")[0]) or "audio.mp3"
     dest_path = os.path.join(dest_dir, filename)
 
-    async with get_http_client().tracked_request("GET", url, timeout=aiohttp.ClientTimeout(total=300)) as resp:
+    # *url* is an arbitrary download target, not operator config — public-only,
+    # so the instance-host opt-in can never extend to it (#13625, Rule 8).
+    async with get_http_client().tracked_request(
+        "GET", url, timeout=aiohttp.ClientTimeout(total=300), guard_egress=CONTENT_URL_EGRESS
+    ) as resp:
         if resp.status != 200:
             raise RuntimeError(f"Failed to download {url}: HTTP {resp.status}")
         with open(dest_path, "wb", encoding=None) as fh:  # type: ignore[call-overload]

--- a/autobot-backend/knowledge/connectors/base.py
+++ b/autobot-backend/knowledge/connectors/base.py
@@ -654,3 +654,25 @@ class AbstractConnector(ABC):
             await redis.set(self._job_redis_key(), state, ex=_JOB_TTL_S)
         except Exception as exc:
             self.logger.debug("Job state write failed (non-critical): %s", exc)
+
+
+def instance_host_egress() -> bool:
+    """Egress policy for an **operator-configured instance host** (#13625, Rule 8).
+
+    Returns the deployment's private-network opt-in, so a self-hosted
+    Confluence/GitLab/Nextcloud on an RFC-1918 address is reachable when the
+    operator has enabled it. Loopback, link-local (incl. cloud metadata),
+    multicast, reserved and unspecified stay refused either way.
+
+    Pass the result as ``guard_egress=`` to the shared HTTP client.
+    """
+    from autobot_shared.ssot_config import config
+
+    return bool(config.feature.connector_private_network_egress)
+
+
+# Egress policy for a URL that did NOT come from operator configuration —
+# anything read out of a document, an API response, or a user request. Always
+# public-only: the instance host's exemption must never extend to content it
+# serves, or a document becomes an SSRF vector into the operator's network.
+CONTENT_URL_EGRESS = False

--- a/autobot-backend/knowledge/connectors/confluence.py
+++ b/autobot-backend/knowledge/connectors/confluence.py
@@ -35,6 +35,7 @@ import aiohttp
 
 from autobot_shared.auth import BasicAuth
 from autobot_shared.http_client import get_http_client
+from knowledge.connectors.base import instance_host_egress
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.time_utils import now_utc, parse_utc_iso
 from knowledge.connectors.base import AbstractConnector, RetryableError
@@ -226,8 +227,14 @@ class ConfluenceConnector(AbstractConnector):
         auth = aiohttp.BasicAuth(login=self._email, password=self._api_token)
         try:
             timeout = aiohttp.ClientTimeout(total=30.0)
+            # Operator-configured instance host — private opt-in applies (#13625).
             async with get_http_client().tracked_request(
-                "GET", url, auth=auth, timeout=timeout, suppress_error_log=True
+                "GET",
+                url,
+                auth=auth,
+                timeout=timeout,
+                suppress_error_log=True,
+                guard_egress=instance_host_egress(),
             ) as resp:
                 if resp.status == 429:
                     raise RetryableError("Confluence rate-limited", status_code=429)

--- a/autobot-backend/knowledge/connectors/confluence.py
+++ b/autobot-backend/knowledge/connectors/confluence.py
@@ -35,10 +35,9 @@ import aiohttp
 
 from autobot_shared.auth import BasicAuth
 from autobot_shared.http_client import get_http_client
-from knowledge.connectors.base import instance_host_egress
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.time_utils import now_utc, parse_utc_iso
-from knowledge.connectors.base import AbstractConnector, RetryableError
+from knowledge.connectors.base import AbstractConnector, RetryableError, instance_host_egress
 from knowledge.connectors.models import (
     ChangeInfo,
     ConnectorConfig,

--- a/autobot-backend/knowledge/connectors/egress_policy_test.py
+++ b/autobot-backend/knowledge/connectors/egress_policy_test.py
@@ -1,0 +1,74 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Connector egress policy is applied, and applied to the right URL class (#13625).
+
+Rule 8 turns on one distinction: the operator-configured *instance host* may use
+the private-network opt-in; anything else — a URL read out of a document, an API
+response or a user request — is public-only, always. Getting that backwards is
+the dangerous direction, because it looks like it works.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_CONNECTORS = Path(__file__).resolve().parent
+
+# file -> number of outbound calls that must carry an explicit egress policy
+_GUARDED = {
+    "confluence.py": 1,
+    "jira.py": 1,
+    "nextcloud.py": 3,
+    "gitlab.py": 2,  # GitLab + Gitea
+    "audio_connector.py": 1,
+}
+
+
+@pytest.mark.parametrize("filename,expected", sorted(_GUARDED.items()))
+def test_connector_outbound_calls_declare_an_egress_policy(filename, expected):
+    """Every outbound call in these modules passes guard_egress explicitly."""
+    src = (_CONNECTORS / filename).read_text(encoding="utf-8")
+    assert src.count("guard_egress=") == expected, (
+        f"{filename}: expected {expected} guarded call(s), found {src.count('guard_egress=')}"
+    )
+
+
+def test_content_urls_never_use_the_instance_host_opt_in():
+    """#13625: a download URL must not inherit the instance host's exemption.
+
+    ``_download_direct_url`` takes its URL as a parameter, so if it used
+    ``instance_host_egress()`` a document could name a private address and turn
+    the connector into an SSRF vector into the operator's own network.
+    """
+    src = (_CONNECTORS / "audio_connector.py").read_text(encoding="utf-8")
+    assert "guard_egress=CONTENT_URL_EGRESS" in src
+    assert "instance_host_egress" not in src, "content download must not use the instance-host opt-in"
+
+
+def test_content_url_policy_is_public_only():
+    from knowledge.connectors.base import CONTENT_URL_EGRESS
+
+    assert CONTENT_URL_EGRESS is False
+
+
+def test_instance_host_policy_follows_the_deployment_flag():
+    from knowledge.connectors.base import instance_host_egress
+
+    assert instance_host_egress() is False, "the private-network opt-in must default to off"
+
+
+def test_no_unguarded_tracked_request_remains_in_the_named_connectors():
+    """A new outbound call in these files must not silently skip the policy."""
+    offenders = []
+    for filename in _GUARDED:
+        src = (_CONNECTORS / filename).read_text(encoding="utf-8")
+        calls = len(re.findall(r"tracked_request\(", src))
+        guarded = src.count("guard_egress=")
+        if calls != guarded:
+            offenders.append(f"{filename}: {calls} call(s), {guarded} guarded")
+    assert not offenders, "unguarded outbound calls: " + "; ".join(offenders)

--- a/autobot-backend/knowledge/connectors/egress_policy_test.py
+++ b/autobot-backend/knowledge/connectors/egress_policy_test.py
@@ -33,9 +33,9 @@ _GUARDED = {
 def test_connector_outbound_calls_declare_an_egress_policy(filename, expected):
     """Every outbound call in these modules passes guard_egress explicitly."""
     src = (_CONNECTORS / filename).read_text(encoding="utf-8")
-    assert src.count("guard_egress=") == expected, (
-        f"{filename}: expected {expected} guarded call(s), found {src.count('guard_egress=')}"
-    )
+    assert (
+        src.count("guard_egress=") == expected
+    ), f"{filename}: expected {expected} guarded call(s), found {src.count('guard_egress=')}"
 
 
 def test_content_urls_never_use_the_instance_host_opt_in():

--- a/autobot-backend/knowledge/connectors/egress_policy_test.py
+++ b/autobot-backend/knowledge/connectors/egress_policy_test.py
@@ -33,9 +33,10 @@ _GUARDED = {
 def test_connector_outbound_calls_declare_an_egress_policy(filename, expected):
     """Every outbound call in these modules passes guard_egress explicitly."""
     src = (_CONNECTORS / filename).read_text(encoding="utf-8")
-    assert src.count("guard_egress=") == expected, (
-        f"{filename}: expected {expected} guarded call(s), found {src.count('guard_egress=')}"
-    )
+    # Count only real arguments, not the string appearing in a comment.
+    code = "\n".join(ln.split("#", 1)[0] for ln in src.splitlines())
+    found = code.count("guard_egress=")
+    assert found == expected, f"{filename}: expected {expected} guarded call(s), found {found}"
 
 
 def test_content_urls_never_use_the_instance_host_opt_in():
@@ -67,8 +68,9 @@ def test_no_unguarded_tracked_request_remains_in_the_named_connectors():
     offenders = []
     for filename in _GUARDED:
         src = (_CONNECTORS / filename).read_text(encoding="utf-8")
-        calls = len(re.findall(r"tracked_request\(", src))
-        guarded = src.count("guard_egress=")
+        code = "\n".join(ln.split("#", 1)[0] for ln in src.splitlines())
+        calls = len(re.findall(r"tracked_request\(", code))
+        guarded = code.count("guard_egress=")
         if calls != guarded:
             offenders.append(f"{filename}: {calls} call(s), {guarded} guarded")
     assert not offenders, "unguarded outbound calls: " + "; ".join(offenders)

--- a/autobot-backend/knowledge/connectors/gitlab.py
+++ b/autobot-backend/knowledge/connectors/gitlab.py
@@ -41,6 +41,7 @@ import aiohttp
 
 from autobot_shared.auth import ApiKeyAuth
 from autobot_shared.http_client import get_http_client
+from knowledge.connectors.base import instance_host_egress
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.time_utils import now_utc, parse_utc_iso
 from knowledge.connectors.base import AbstractConnector, RetryableError
@@ -408,7 +409,12 @@ class GitLabConnector(AbstractConnector):
         try:
             timeout = aiohttp.ClientTimeout(total=30.0)
             async with get_http_client().tracked_request(
-                "GET", url, headers=headers, timeout=timeout, suppress_error_log=True
+                "GET",
+                url,
+                headers=headers,
+                timeout=timeout,
+                suppress_error_log=True,
+                guard_egress=instance_host_egress(),
             ) as resp:
                 if resp.status == 429:
                     raise RetryableError("GitLab rate-limited", status_code=429)
@@ -769,7 +775,12 @@ class GiteaConnector(AbstractConnector):
         try:
             timeout = aiohttp.ClientTimeout(total=30.0)
             async with get_http_client().tracked_request(
-                "GET", url, headers=headers, timeout=timeout, suppress_error_log=True
+                "GET",
+                url,
+                headers=headers,
+                timeout=timeout,
+                suppress_error_log=True,
+                guard_egress=instance_host_egress(),
             ) as resp:
                 if resp.status == 429:
                     raise RetryableError("Gitea rate-limited", status_code=429)

--- a/autobot-backend/knowledge/connectors/gitlab.py
+++ b/autobot-backend/knowledge/connectors/gitlab.py
@@ -41,10 +41,9 @@ import aiohttp
 
 from autobot_shared.auth import ApiKeyAuth
 from autobot_shared.http_client import get_http_client
-from knowledge.connectors.base import instance_host_egress
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.time_utils import now_utc, parse_utc_iso
-from knowledge.connectors.base import AbstractConnector, RetryableError
+from knowledge.connectors.base import AbstractConnector, RetryableError, instance_host_egress
 from knowledge.connectors.models import (
     ChangeInfo,
     ConnectorConfig,

--- a/autobot-backend/knowledge/connectors/jira.py
+++ b/autobot-backend/knowledge/connectors/jira.py
@@ -37,10 +37,9 @@ import aiohttp
 
 from autobot_shared.auth import BasicAuth
 from autobot_shared.http_client import get_http_client
-from knowledge.connectors.base import instance_host_egress
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.time_utils import now_utc, parse_utc_iso
-from knowledge.connectors.base import AbstractConnector, RetryableError
+from knowledge.connectors.base import AbstractConnector, RetryableError, instance_host_egress
 from knowledge.connectors.models import (
     ChangeInfo,
     ConnectorConfig,

--- a/autobot-backend/knowledge/connectors/jira.py
+++ b/autobot-backend/knowledge/connectors/jira.py
@@ -37,6 +37,7 @@ import aiohttp
 
 from autobot_shared.auth import BasicAuth
 from autobot_shared.http_client import get_http_client
+from knowledge.connectors.base import instance_host_egress
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.time_utils import now_utc, parse_utc_iso
 from knowledge.connectors.base import AbstractConnector, RetryableError
@@ -241,8 +242,15 @@ class JiraConnector(AbstractConnector):
         auth = aiohttp.BasicAuth(login=self._email, password=self._api_token)
         try:
             timeout = aiohttp.ClientTimeout(total=30.0)
+            # Operator-configured instance host — private opt-in applies (#13625).
             async with get_http_client().tracked_request(
-                method, url, auth=auth, json=json_data, timeout=timeout, suppress_error_log=True
+                method,
+                url,
+                auth=auth,
+                json=json_data,
+                timeout=timeout,
+                suppress_error_log=True,
+                guard_egress=instance_host_egress(),
             ) as resp:
                 if resp.status == 429:
                     raise RetryableError("Jira rate-limited", status_code=429)

--- a/autobot-backend/knowledge/connectors/nextcloud.py
+++ b/autobot-backend/knowledge/connectors/nextcloud.py
@@ -33,6 +33,7 @@ import defusedxml.ElementTree as ET
 
 from autobot_shared.auth import BasicAuth
 from autobot_shared.http_client import get_http_client
+from knowledge.connectors.base import instance_host_egress
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.time_utils import now_utc
 from knowledge.connectors.base import AbstractConnector, RetryableError
@@ -122,7 +123,12 @@ class NextcloudConnector(AbstractConnector):
             auth = aiohttp.BasicAuth(self._username, self._password)
             timeout = aiohttp.ClientTimeout(total=30.0)
             async with get_http_client().tracked_request(
-                "OPTIONS", self._webdav_base, auth=auth, timeout=timeout, suppress_error_log=True
+                "OPTIONS",
+                self._webdav_base,
+                auth=auth,
+                timeout=timeout,
+                suppress_error_log=True,
+                guard_egress=instance_host_egress(),
             ) as resp:
                 if resp.status in (200, 204):
                     self.logger.info("Nextcloud connection test successful: %s", self._webdav_base)
@@ -162,7 +168,11 @@ class NextcloudConnector(AbstractConnector):
         try:
             auth = aiohttp.BasicAuth(self._username, self._password)
             timeout = aiohttp.ClientTimeout(total=300.0)
-            async with get_http_client().tracked_request("GET", file_url, auth=auth, timeout=timeout) as resp:
+            # file_url = urljoin(self._webdav_base, ...) — instance host, not a
+            # user-supplied content URL, despite the name (#13625).
+            async with get_http_client().tracked_request(
+                "GET", file_url, auth=auth, timeout=timeout, guard_egress=instance_host_egress()
+            ) as resp:
                 if resp.status == 200:
                     content_bytes = await resp.read()
                     content_type = resp.headers.get("Content-Type", "application/octet-stream")
@@ -263,6 +273,7 @@ class NextcloudConnector(AbstractConnector):
             async with get_http_client().tracked_request(
                 "PROPFIND",
                 folder_url,
+                guard_egress=instance_host_egress(),
                 auth=auth,
                 headers=headers,
                 data=propfind_body,

--- a/autobot-backend/knowledge/connectors/nextcloud.py
+++ b/autobot-backend/knowledge/connectors/nextcloud.py
@@ -33,10 +33,9 @@ import defusedxml.ElementTree as ET
 
 from autobot_shared.auth import BasicAuth
 from autobot_shared.http_client import get_http_client
-from knowledge.connectors.base import instance_host_egress
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.time_utils import now_utc
-from knowledge.connectors.base import AbstractConnector, RetryableError
+from knowledge.connectors.base import AbstractConnector, RetryableError, instance_host_egress
 from knowledge.connectors.models import (
     ChangeInfo,
     ConnectorConfig,
@@ -164,12 +163,19 @@ class NextcloudConnector(AbstractConnector):
 
         encoded_path = parts[3]
         file_url = urljoin(self._webdav_base, encoded_path)
+        # #13625: urljoin does NOT pin the host. ``encoded_path`` is the tail of a
+        # caller-supplied source_id, and both "//evil.example.com/x" and
+        # "http://10.0.0.5/x" escape the instance entirely — while the request
+        # below still attaches this instance's BasicAuth, making it credential
+        # exfiltration rather than plain SSRF. Refuse anything that left the base.
+        if not file_url.startswith(self._webdav_base):
+            self.logger.error("Refusing a file path that escapes the configured instance: %s", source_id)
+            return None
 
         try:
             auth = aiohttp.BasicAuth(self._username, self._password)
             timeout = aiohttp.ClientTimeout(total=300.0)
-            # file_url = urljoin(self._webdav_base, ...) — instance host, not a
-            # user-supplied content URL, despite the name (#13625).
+            # Instance host: file_url is pinned to _webdav_base by the check above.
             async with get_http_client().tracked_request(
                 "GET", file_url, auth=auth, timeout=timeout, guard_egress=instance_host_egress()
             ) as resp:

--- a/autobot_shared/http_client.py
+++ b/autobot_shared/http_client.py
@@ -33,6 +33,22 @@ from autobot_shared.ssot_constants import TimingConstants
 logger = logging.getLogger(__name__)
 
 
+class EgressBlockedError(ValueError):
+    """Raised when a guarded request targets an address egress policy forbids."""
+
+
+async def _assert_egress_allowed(url: str, *, allow_private: bool) -> None:
+    """Refuse a URL that outbound connector traffic must not reach (#13625).
+
+    Imported lazily so ``http_client`` keeps its stdlib+aiohttp dependency
+    surface for callers that never opt in.
+    """
+    from autobot_shared.url_safety import is_public_url_async
+
+    if not await is_public_url_async(url, allow_private=allow_private):
+        raise EgressBlockedError(f"Refusing outbound request to a disallowed address: {url!r}")
+
+
 class HTTPClientManager:
     """
     Singleton aiohttp ClientSession manager for efficient HTTP requests.
@@ -203,6 +219,7 @@ class HTTPClientManager:
         url: str,
         *,
         suppress_error_log: bool = False,
+        guard_egress: bool | None = None,
         **kwargs,
     ) -> aiohttp.ClientResponse:
         """
@@ -216,6 +233,21 @@ class HTTPClientManager:
                 expected and noisy (e.g. health probes to optional services like
                 Ollama / NPU worker). Default False so genuine outbound-call
                 failures are still surfaced at ERROR everywhere else (#9767).
+            guard_egress: Opt in to SSRF validation of *url* (#13625, Rule 8).
+                ``None`` (default) means **no guarding**, which is the behaviour
+                every existing caller has today. Pass ``False`` to permit only
+                public addresses, or ``True`` to additionally permit RFC-1918/ULA
+                when the deployment has enabled it — loopback, link-local
+                (incl. cloud metadata), multicast, reserved and unspecified are
+                refused in both cases.
+
+                Deliberately opt-in rather than default-on: this client is shared
+                by ~103 call sites, most of them internal service-to-service
+                traffic (NPU workers, SLM nodes) that legitimately targets private
+                addresses. Guarding everything here would either break that
+                traffic or silently widen egress policy for all of it. Connectors
+                and integrations pass this explicitly, so "this request is
+                guarded" is visible at the call site.
             **kwargs: Additional arguments for aiohttp request
 
         Returns:
@@ -232,6 +264,9 @@ class HTTPClientManager:
         beyond a single block — it balances the counter for you and therefore
         cannot be forgotten.
         """
+        if guard_egress is not None:
+            await _assert_egress_allowed(url, allow_private=guard_egress)
+
         # Check if pool adjustment needed (non-blocking)
         asyncio.create_task(self._adjust_pool_size())
 
@@ -372,6 +407,7 @@ class HTTPClientManager:
         raises. A failure inside ``request()`` itself decrements there, so the
         slot is never released twice.
         """
+        # ``guard_egress`` (#13625) passes straight through to ``request``.
         response = await self.request(method, url, **kwargs)
         try:
             async with response:

--- a/autobot_shared/http_client.py
+++ b/autobot_shared/http_client.py
@@ -265,6 +265,17 @@ class HTTPClientManager:
         cannot be forgotten.
         """
         if guard_egress is not None:
+            # A guard on the initial URL alone is worthless: aiohttp follows
+            # redirects by default, so one 302 reaches anything the guard just
+            # refused — including cloud metadata (#13625). Refuse redirects on
+            # guarded requests instead of validating a URL we then abandon.
+            if kwargs.get("allow_redirects"):
+                raise ValueError(
+                    "guard_egress cannot be combined with allow_redirects=True — a redirect escapes the check. "
+                    "Use autobot_shared.security.ssrf_guard.pinned_request_with_redirects, which re-validates "
+                    "and re-pins every hop."
+                )
+            kwargs["allow_redirects"] = False
             await _assert_egress_allowed(url, allow_private=guard_egress)
 
         # Check if pool adjustment needed (non-blocking)

--- a/autobot_shared/http_client.py
+++ b/autobot_shared/http_client.py
@@ -33,8 +33,16 @@ from autobot_shared.ssot_constants import TimingConstants
 logger = logging.getLogger(__name__)
 
 
-class EgressBlockedError(ValueError):
-    """Raised when a guarded request targets an address egress policy forbids."""
+class EgressBlockedError(aiohttp.ClientError, ValueError):
+    """Raised when a guarded request targets an address egress policy forbids.
+
+    #13625: deliberately an ``aiohttp.ClientError`` as well as a ``ValueError``.
+    Every connector already wraps its outbound call in
+    ``except (RetryableError, aiohttp.ClientError)`` and returns a structured
+    error; a bare ``ValueError`` escaped that and handed the operator a traceback
+    instead. ``ValueError`` is kept so existing callers of the url-safety layer
+    that catch it keep working.
+    """
 
 
 async def _assert_egress_allowed(url: str, *, allow_private: bool) -> None:
@@ -46,7 +54,11 @@ async def _assert_egress_allowed(url: str, *, allow_private: bool) -> None:
     from autobot_shared.url_safety import is_public_url_async
 
     if not await is_public_url_async(url, allow_private=allow_private):
-        raise EgressBlockedError(f"Refusing outbound request to a disallowed address: {url!r}")
+        raise EgressBlockedError(
+            f"Refusing outbound request to a disallowed address: {url!r}. "
+            "If this is a self-hosted instance on a private network, set "
+            "AUTOBOT_CONNECTOR_PRIVATE_NETWORK_EGRESS=true."
+        )
 
 
 class HTTPClientManager:

--- a/autobot_shared/http_client_test.py
+++ b/autobot_shared/http_client_test.py
@@ -265,3 +265,50 @@ async def test_tracked_request_decrements_on_caller_exception():
                 assert client._active_requests == baseline + 1
                 raise RuntimeError("boom")
         assert client._active_requests == baseline
+
+
+# ---------------------------------------------------------------------------
+# #13625: opt-in egress guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "url,allow_private,blocked",
+    [
+        ("https://10.0.0.5/api", False, True),
+        ("https://10.0.0.5/api", True, False),
+        ("https://192.168.1.10/api", True, False),
+        # Hard blocks stay blocked with the opt-in on — if any of these flip,
+        # the opt-in has become an SSRF bypass.
+        ("http://127.0.0.1:8080/x", True, True),
+        ("http://169.254.169.254/latest/meta-data/", True, True),
+        ("https://93.184.216.34/", False, False),
+    ],
+)
+async def test_egress_guard_permits_private_only_with_the_opt_in(url, allow_private, blocked):
+    from autobot_shared.http_client import EgressBlockedError, _assert_egress_allowed
+
+    if blocked:
+        with pytest.raises(EgressBlockedError):
+            await _assert_egress_allowed(url, allow_private=allow_private)
+    else:
+        await _assert_egress_allowed(url, allow_private=allow_private)
+
+
+def test_guard_defaults_to_off_so_existing_callers_are_unaffected():
+    """#13625: the guard must be opt-in.
+
+    This client is shared by ~103 call sites, most of them internal
+    service-to-service traffic that legitimately targets private addresses.
+    A default-on guard would break that traffic the moment it merged.
+    """
+    import inspect
+
+    from autobot_shared.http_client import HTTPClientManager
+
+    sig = inspect.signature(HTTPClientManager.request)
+    assert sig.parameters["guard_egress"].default is None, "guard_egress must default to no guarding"
+
+    src = inspect.getsource(HTTPClientManager.request)
+    assert "if guard_egress is not None:" in src, "guard call is not gated — every caller would be guarded"

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -2019,6 +2019,18 @@ class FeatureConfig(RedactedSettings):
     hot_reload: bool = Field(default=True, alias="AUTOBOT_HOT_RELOAD")
     permission_system_v2: bool = Field(default=False, alias="AUTOBOT_PERMISSION_SYSTEM_V2")
 
+    # #13625: permit connector egress to RFC-1918/ULA addresses, for deployments
+    # whose Confluence/GitLab/Nextcloud instance is genuinely self-hosted on a
+    # private network. Default OFF — turning it on widens the egress surface.
+    #
+    # Scope is deliberately narrow: it applies to the operator-configured
+    # instance host only, NEVER to user-supplied content or download URLs.
+    # Loopback, link-local (incl. 169.254.169.254 cloud metadata), multicast,
+    # reserved and unspecified addresses stay blocked with the flag on.
+    connector_private_network_egress: bool = Field(
+        default=False, alias="AUTOBOT_CONNECTOR_PRIVATE_NETWORK_EGRESS"
+    )
+
     # Subsystem feature flags — issue #3017
     # Set AUTOBOT_FEATURE_<NAME>=false to disable a subsystem on a given node.
     npu_enabled: bool = Field(default=True, alias="AUTOBOT_FEATURE_NPU")

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -2027,9 +2027,7 @@ class FeatureConfig(RedactedSettings):
     # instance host only, NEVER to user-supplied content or download URLs.
     # Loopback, link-local (incl. 169.254.169.254 cloud metadata), multicast,
     # reserved and unspecified addresses stay blocked with the flag on.
-    connector_private_network_egress: bool = Field(
-        default=False, alias="AUTOBOT_CONNECTOR_PRIVATE_NETWORK_EGRESS"
-    )
+    connector_private_network_egress: bool = Field(default=False, alias="AUTOBOT_CONNECTOR_PRIVATE_NETWORK_EGRESS")
 
     # Subsystem feature flags — issue #3017
     # Set AUTOBOT_FEATURE_<NAME>=false to disable a subsystem on a given node.

--- a/autobot_shared/url_safety.py
+++ b/autobot_shared/url_safety.py
@@ -175,7 +175,12 @@ def is_public_url(url: str, *, allow_private: bool = False) -> bool:
 async def is_public_url_async(url: str, *, allow_private: bool = False) -> bool:
     """Async wrapper: run the blocking DNS check in the default executor."""
     loop = asyncio.get_running_loop()
-    return await loop.run_in_executor(None, functools.partial(is_public_url, url, allow_private=allow_private))
+    if not allow_private:
+        # Call shape preserved exactly (#13625): callers and tests substitute
+        # ``is_public_url`` with a one-argument callable, and forwarding a
+        # keyword unconditionally broke every such seam.
+        return await loop.run_in_executor(None, is_public_url, url)
+    return await loop.run_in_executor(None, functools.partial(is_public_url, url, allow_private=True))
 
 
 async def resolve_safe_ip_async(

--- a/autobot_shared/url_safety.py
+++ b/autobot_shared/url_safety.py
@@ -86,6 +86,25 @@ _IPV6_ULA = ipaddress.ip_network("fc00::/7")
 _DNS_TIMEOUT_SECONDS = 2.0
 
 
+# Never a legitimate egress target, even with the private-network opt-in (#13625).
+# ``is_private`` covers most of these on modern CPython, which is exactly the
+# problem: inheriting it wholesale let the opt-in re-open them.
+_NEVER_ROUTABLE = (
+    ipaddress.ip_network("0.0.0.0/8"),  # "this network" — 0.1.2.3 is not 0.0.0.0
+    ipaddress.ip_network("192.0.0.0/29"),  # IETF protocol assignments
+    ipaddress.ip_network("198.18.0.0/15"),  # benchmarking
+    ipaddress.ip_network("2002::/16"),  # 6to4 — 2002:7f00:1::1 embeds 127.0.0.1
+)
+
+# Not public, but a self-hosted instance can legitimately live here, so these are
+# treated as private (opt-in eligible) rather than hard-blocked. CPython reports
+# neither as ``is_private``, so both were reachable in *both* states before.
+_PRIVATE_EXTRA = (
+    ipaddress.ip_network("100.64.0.0/10"),  # CGNAT — Tailscale's whole range
+    ipaddress.ip_network("fec0::/10"),  # IPv6 site-local
+)
+
+
 def _ip_is_hard_blocked(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
     """Return True for addresses that are never a legitimate egress target (#13625).
 
@@ -95,12 +114,21 @@ def _ip_is_hard_blocked(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bo
     on an RFC-1918 address is a real deployment, whereas an operator hosting it
     on the metadata endpoint is not.
     """
-    return bool(ip.is_loopback or ip.is_link_local or ip.is_multicast or ip.is_reserved or ip.is_unspecified)
+    # Unwrap ::ffff:a.b.c.d explicitly so v4 policy applies to it by intent
+    # rather than incidentally via is_reserved.
+    mapped = getattr(ip, "ipv4_mapped", None)
+    if mapped is not None:
+        return _ip_is_hard_blocked(mapped)
+    if ip.is_loopback or ip.is_link_local or ip.is_multicast or ip.is_reserved or ip.is_unspecified:
+        return True
+    return any(ip in net for net in _NEVER_ROUTABLE if ip.version == net.version)
 
 
 def _ip_is_private(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
     """Return True for RFC-1918 / ULA addresses — separable from the hard blocks (#13625)."""
     if ip.is_private and not _ip_is_hard_blocked(ip):
+        return True
+    if any(ip in net for net in _PRIVATE_EXTRA if ip.version == net.version):
         return True
     # IPv6 Unique Local Addresses (fc00::/7) — redundant with is_private on
     # modern Python but kept explicit as defence-in-depth.

--- a/autobot_shared/url_safety.py
+++ b/autobot_shared/url_safety.py
@@ -33,6 +33,7 @@ preserved as backward-compat thin wrappers that delegate here.
 from __future__ import annotations
 
 import asyncio
+import functools
 import ipaddress
 import os
 import socket
@@ -85,18 +86,42 @@ _IPV6_ULA = ipaddress.ip_network("fc00::/7")
 _DNS_TIMEOUT_SECONDS = 2.0
 
 
-def _ip_is_public(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
-    """Return True only if an IP address is routable on the public internet."""
-    if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_multicast or ip.is_reserved or ip.is_unspecified:
-        return False
+def _ip_is_hard_blocked(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    """Return True for addresses that are never a legitimate egress target (#13625).
+
+    Loopback, link-local (which covers the 169.254.169.254 cloud-metadata
+    endpoint), multicast, reserved and unspecified. These stay blocked even when
+    a deployment opts into private-network egress: an operator hosting Confluence
+    on an RFC-1918 address is a real deployment, whereas an operator hosting it
+    on the metadata endpoint is not.
+    """
+    return bool(ip.is_loopback or ip.is_link_local or ip.is_multicast or ip.is_reserved or ip.is_unspecified)
+
+
+def _ip_is_private(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    """Return True for RFC-1918 / ULA addresses — separable from the hard blocks (#13625)."""
+    if ip.is_private and not _ip_is_hard_blocked(ip):
+        return True
     # IPv6 Unique Local Addresses (fc00::/7) — redundant with is_private on
     # modern Python but kept explicit as defence-in-depth.
-    if isinstance(ip, ipaddress.IPv6Address) and ip in _IPV6_ULA:
+    return isinstance(ip, ipaddress.IPv6Address) and ip in _IPV6_ULA
+
+
+def _ip_is_public(ip: ipaddress.IPv4Address | ipaddress.IPv6Address, *, allow_private: bool = False) -> bool:
+    """Return True if an IP is an acceptable egress target.
+
+    With *allow_private* the RFC-1918/ULA range is permitted — self-hosted
+    Confluence/GitLab/Nextcloud instances legitimately live there — while the
+    hard blocks above still apply. Default is unchanged: public only.
+    """
+    if _ip_is_hard_blocked(ip):
         return False
+    if _ip_is_private(ip):
+        return allow_private
     return True
 
 
-def is_public_url(url: str) -> bool:
+def is_public_url(url: str, *, allow_private: bool = False) -> bool:
     """Return True only for public HTTP/HTTPS URLs.
 
     Resolves the hostname via DNS and rejects if *any* resolved address is
@@ -117,11 +142,13 @@ def is_public_url(url: str) -> bool:
         if not host:
             return False
         # Reject bare private names and private TLDs outright — no DNS needed.
-        if host in ("localhost",) or any(host.endswith(tld) for tld in _PRIVATE_TLDS):
+        if host == "localhost":
+            return False  # loopback is hard-blocked in both states (#13625)
+        if any(host.endswith(tld) for tld in _PRIVATE_TLDS) and not allow_private:
             return False
         # If host is a literal IP, check directly without DNS.
         try:
-            return _ip_is_public(ipaddress.ip_address(host))
+            return _ip_is_public(ipaddress.ip_address(host), allow_private=allow_private)
         except ValueError:
             pass
         # Resolve hostname and reject if *any* A/AAAA record is non-public.
@@ -137,7 +164,7 @@ def is_public_url(url: str) -> bool:
             addr = info[4][0]
             # Strip IPv6 scope id (e.g. "fe80::1%eth0") before parsing.
             addr = addr.split("%", 1)[0]  # type: ignore[union-attr]  # GH#7105: info[4] is always (str,...) for TCP/UDP
-            if not _ip_is_public(ipaddress.ip_address(addr)):
+            if not _ip_is_public(ipaddress.ip_address(addr), allow_private=allow_private):
                 return False
         return True
     except (socket.gaierror, socket.timeout, ValueError, OSError):
@@ -145,13 +172,15 @@ def is_public_url(url: str) -> bool:
         return False
 
 
-async def is_public_url_async(url: str) -> bool:
+async def is_public_url_async(url: str, *, allow_private: bool = False) -> bool:
     """Async wrapper: run the blocking DNS check in the default executor."""
     loop = asyncio.get_running_loop()
-    return await loop.run_in_executor(None, is_public_url, url)
+    return await loop.run_in_executor(None, functools.partial(is_public_url, url, allow_private=allow_private))
 
 
-async def resolve_safe_ip_async(host: str, *, timeout: float = _DNS_TIMEOUT_SECONDS) -> str:
+async def resolve_safe_ip_async(
+    host: str, *, timeout: float = _DNS_TIMEOUT_SECONDS, allow_private: bool = False
+) -> str:
     """Resolve *host* and return the first globally-routable IP literal.
 
     Raises ``ValueError`` if the hostname resolves to any private, loopback,
@@ -180,7 +209,7 @@ async def resolve_safe_ip_async(host: str, *, timeout: float = _DNS_TIMEOUT_SECO
             ip = ipaddress.ip_address(ip_str)
         except ValueError:
             continue
-        if not _ip_is_public(ip):
+        if not _ip_is_public(ip, allow_private=allow_private):
             raise ValueError(f"Host '{host}' resolves to a non-public address: {ip_str}")
         if safe_ip is None:
             safe_ip = ip_str

--- a/autobot_shared/url_safety_test.py
+++ b/autobot_shared/url_safety_test.py
@@ -13,9 +13,8 @@ import-isolation contract that motivated the extraction.
 
 from __future__ import annotations
 
-from unittest.mock import patch
-
 import ipaddress
+from unittest.mock import patch
 
 import pytest
 

--- a/autobot_shared/url_safety_test.py
+++ b/autobot_shared/url_safety_test.py
@@ -312,6 +312,14 @@ def test_module_has_zero_autobot_dependencies() -> None:
 
 _HARD_BLOCKED = [
     ("127.0.0.1", "loopback"),
+    # #13625: CPython reports these as is_private, so inheriting is_private
+    # wholesale let the opt-in re-open them.
+    ("0.1.2.3", "0.0.0.0/8 — not the same as 0.0.0.0"),
+    ("192.0.0.1", "192.0.0.0/29 IETF protocol assignments"),
+    ("198.18.0.1", "benchmarking range"),
+    ("2002:7f00:1::1", "6to4 embedding 127.0.0.1"),
+    ("::ffff:169.254.169.254", "IPv4-mapped cloud metadata"),
+    ("64:ff9b::7f00:1", "NAT64 embedding loopback"),
     ("169.254.169.254", "cloud metadata"),
     ("0.0.0.0", "unspecified"),
     ("224.0.0.1", "multicast"),
@@ -320,7 +328,17 @@ _HARD_BLOCKED = [
     ("fe80::1", "IPv6 link-local"),
 ]
 
-_PRIVATE = [("10.0.0.5", "RFC1918"), ("192.168.1.10", "RFC1918"), ("172.16.0.1", "RFC1918"), ("fd00::1", "IPv6 ULA")]
+_PRIVATE = [
+    ("10.0.0.5", "RFC1918"),
+    ("192.168.1.10", "RFC1918"),
+    ("172.16.0.1", "RFC1918"),
+    ("fd00::1", "IPv6 ULA"),
+    # #13625: CPython reports neither as is_private, so both were reachable in
+    # BOTH states. Private rather than hard-blocked — a self-hosted instance can
+    # legitimately sit on Tailscale or a site-local network.
+    ("100.64.1.1", "CGNAT / Tailscale"),
+    ("fec0::1", "IPv6 site-local"),
+]
 
 
 @pytest.mark.parametrize("addr,kind", _HARD_BLOCKED)

--- a/autobot_shared/url_safety_test.py
+++ b/autobot_shared/url_safety_test.py
@@ -368,3 +368,37 @@ def test_private_ip_literal_url_honours_the_opt_in():
     assert url_safety.is_public_url("https://10.0.0.5/api", allow_private=True) is True
     # ...but the metadata endpoint stays refused either way.
     assert url_safety.is_public_url("http://169.254.169.254/latest/meta-data/", allow_private=True) is False
+
+
+@pytest.mark.asyncio
+async def test_async_wrapper_keeps_the_one_argument_call_shape(monkeypatch):
+    """#13625: the default path must call ``is_public_url`` with url only.
+
+    Callers and tests substitute ``is_public_url`` with a one-argument callable
+    (see skills/external_importer_test.py). Forwarding ``allow_private`` to it
+    unconditionally raised ``TypeError: got an unexpected keyword argument`` in
+    every such seam — two tests in a file this change never touched.
+    """
+    seen = {}
+
+    def _one_arg_only(url):
+        seen["url"] = url
+        return True
+
+    monkeypatch.setattr(url_safety, "is_public_url", _one_arg_only)
+    assert await url_safety.is_public_url_async("https://example.com/x") is True
+    assert seen["url"] == "https://example.com/x"
+
+
+@pytest.mark.asyncio
+async def test_async_wrapper_forwards_the_opt_in_when_requested(monkeypatch):
+    """#13625: ...but the opt-in must still reach the underlying check."""
+    seen = {}
+
+    def _accepts_kwarg(url, *, allow_private=False):
+        seen["allow_private"] = allow_private
+        return True
+
+    monkeypatch.setattr(url_safety, "is_public_url", _accepts_kwarg)
+    await url_safety.is_public_url_async("https://example.com/x", allow_private=True)
+    assert seen["allow_private"] is True

--- a/autobot_shared/url_safety_test.py
+++ b/autobot_shared/url_safety_test.py
@@ -15,8 +15,11 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+import ipaddress
+
 import pytest
 
+from autobot_shared import url_safety
 from autobot_shared.url_safety import (
     host_matches,
     is_public_url,
@@ -302,3 +305,67 @@ def test_module_has_zero_autobot_dependencies() -> None:
     assert "from web_fetch" not in source
     assert "from autobot_backend" not in source
     assert "from autobot_shared" not in source  # no sibling cross-deps either
+
+
+# ---------------------------------------------------------------------------
+# #13625: private-network opt-in, separable from the hard blocks
+# ---------------------------------------------------------------------------
+
+_HARD_BLOCKED = [
+    ("127.0.0.1", "loopback"),
+    ("169.254.169.254", "cloud metadata"),
+    ("0.0.0.0", "unspecified"),
+    ("224.0.0.1", "multicast"),
+    ("240.0.0.1", "reserved"),
+    ("::1", "IPv6 loopback"),
+    ("fe80::1", "IPv6 link-local"),
+]
+
+_PRIVATE = [("10.0.0.5", "RFC1918"), ("192.168.1.10", "RFC1918"), ("172.16.0.1", "RFC1918"), ("fd00::1", "IPv6 ULA")]
+
+
+@pytest.mark.parametrize("addr,kind", _HARD_BLOCKED)
+def test_hard_blocked_addresses_stay_blocked_with_the_opt_in(addr, kind):
+    """#13625: the opt-in permits private ranges only — never these.
+
+    An operator hosting Confluence on an RFC-1918 address is a real deployment;
+    an operator hosting it on the cloud-metadata endpoint is not. If this ever
+    passes, the opt-in has become an SSRF bypass.
+    """
+    ip = ipaddress.ip_address(addr)
+    assert url_safety._ip_is_public(ip) is False, kind
+    assert url_safety._ip_is_public(ip, allow_private=True) is False, f"{kind} allowed by the opt-in"
+
+
+@pytest.mark.parametrize("addr,kind", _PRIVATE)
+def test_private_addresses_flip_with_the_opt_in(addr, kind):
+    """#13625: RFC-1918/ULA is the range the opt-in exists to permit."""
+    ip = ipaddress.ip_address(addr)
+    assert url_safety._ip_is_public(ip) is False, f"{kind} allowed by default"
+    assert url_safety._ip_is_public(ip, allow_private=True) is True, kind
+
+
+def test_public_address_is_unaffected_by_the_opt_in():
+    ip = ipaddress.ip_address("93.184.216.34")
+    assert url_safety._ip_is_public(ip) is True
+    assert url_safety._ip_is_public(ip, allow_private=True) is True
+
+
+def test_default_call_is_unchanged_by_the_new_parameter():
+    """#13625: every existing caller must keep public-only behaviour."""
+    for addr, _ in _HARD_BLOCKED + _PRIVATE:
+        assert url_safety._ip_is_public(ipaddress.ip_address(addr)) is False
+    assert url_safety._ip_is_public(ipaddress.ip_address("8.8.8.8")) is True
+
+
+def test_localhost_is_refused_even_with_the_opt_in():
+    """#13625: the hostname short-circuit must not become a loopback bypass."""
+    assert url_safety.is_public_url("http://localhost:8080/x") is False
+    assert url_safety.is_public_url("http://localhost:8080/x", allow_private=True) is False
+
+
+def test_private_ip_literal_url_honours_the_opt_in():
+    assert url_safety.is_public_url("https://10.0.0.5/api") is False
+    assert url_safety.is_public_url("https://10.0.0.5/api", allow_private=True) is True
+    # ...but the metadata endpoint stays refused either way.
+    assert url_safety.is_public_url("http://169.254.169.254/latest/meta-data/", allow_private=True) is False

--- a/docs/developer/CLAUDE_RULES.md
+++ b/docs/developer/CLAUDE_RULES.md
@@ -281,7 +281,16 @@ When an issue is complete, wait for explicit user instruction before starting ne
 
 ## Rule 8: Outbound HTTP Goes Through the Guarded Fetch (#13625)
 
-**Every outbound connector/integration HTTP request MUST go through the SSRF guard in `autobot_shared/security/ssrf_guard.py`. Never build a bare `aiohttp.ClientSession` against a host that came from stored config or user input.**
+**Every outbound connector/integration HTTP request MUST declare an egress policy. Never build a bare `aiohttp.ClientSession`, and never call the shared client without `guard_egress`, against a host that came from stored config or user input.**
+
+Two mechanisms, and which one you need depends on redirects:
+
+| You need | Use |
+|---|---|
+| A request that must NOT follow redirects | `get_http_client().tracked_request(..., guard_egress=...)` |
+| A request that MUST follow redirects | `ssrf_guard.pinned_request_with_redirects` |
+
+`guard_egress` validates the URL and then **refuses redirects** — it raises if you pass `allow_redirects=True`. That is deliberate: validating a URL and then letting aiohttp follow a 302 elsewhere is worse than no guard, because it reads as protected. `pinned_request_with_redirects` is the one that re-resolves and re-pins *every hop*.
 
 **Why:** This rule previously existed only as a docstring inside `ssrf_guard.py`. Six connectors — Confluence, Jira, GitLab, Gitea, Nextcloud and the `integrations/base.py` session builder — were written against bare `aiohttp` with a host string-concatenated from stored config, and a grep for `is_public_url|ssrf_guard|pinned_connector` across all six returned **zero hits**. A rule nobody can find is a rule nobody follows.
 
@@ -300,9 +309,11 @@ A self-hosted Confluence/GitLab/Nextcloud instance legitimately lives on an RFC-
 **Two constraints that are not negotiable:**
 
 1. The opt-in applies to the **operator-configured instance host only**. User-supplied content and download URLs are validated public-only, unconditionally — a connector that fetches an attachment from a URL inside a document must not inherit the instance host's exemption.
-2. Validate the configured base URL **once at config-store time**, not per request. Per-request validation is a DNS lookup on every call and still races.
+2. Config-store-time validation is still the goal (**#13625 item 3, not yet built**). Today the check is per-request, which costs a DNS lookup per call and does not close the rebind race between the check and the connect — `pinned_connector` is what closes that, and it does not yet thread the private-network opt-in. Do not read this rule as claiming the race is handled.
 
-**When adding a connector:** if you are typing `aiohttp.ClientSession(` and the URL contains a value read from config, stop — you want `pinned_connector` or `pinned_request_with_redirects`.
+**When adding a connector:** if you are typing `aiohttp.ClientSession(` and the URL contains a value read from config, stop. And if you are calling `tracked_request` without `guard_egress`, that is the same mistake with fewer characters.
+
+**`urljoin` does not pin a host.** `urljoin(base, path)` returns `https://evil.example.com/x` for a path of `//evil.example.com/x`, and the caller's credentials go with it. If a path segment can come from stored data or a server response, assert the result still starts with the base.
 
 ## Rule 7: Behavioral Grep for Extraction PRs (#5372)
 

--- a/docs/developer/CLAUDE_RULES.md
+++ b/docs/developer/CLAUDE_RULES.md
@@ -279,6 +279,31 @@ When an issue is complete, wait for explicit user instruction before starting ne
 
 ---
 
+## Rule 8: Outbound HTTP Goes Through the Guarded Fetch (#13625)
+
+**Every outbound connector/integration HTTP request MUST go through the SSRF guard in `autobot_shared/security/ssrf_guard.py`. Never build a bare `aiohttp.ClientSession` against a host that came from stored config or user input.**
+
+**Why:** This rule previously existed only as a docstring inside `ssrf_guard.py`. Six connectors — Confluence, Jira, GitLab, Gitea, Nextcloud and the `integrations/base.py` session builder — were written against bare `aiohttp` with a host string-concatenated from stored config, and a grep for `is_public_url|ssrf_guard|pinned_connector` across all six returned **zero hits**. A rule nobody can find is a rule nobody follows.
+
+**The private-network opt-in:**
+
+A self-hosted Confluence/GitLab/Nextcloud instance legitimately lives on an RFC-1918 address, so a public-only guard would break the feature it protects. `AUTOBOT_CONNECTOR_PRIVATE_NETWORK_EGRESS` (default **off**) permits that range — and *only* that range:
+
+| Target | Flag off | Flag on |
+|---|---|---|
+| Public address | allowed | allowed |
+| RFC-1918 / IPv6 ULA | blocked | **allowed** |
+| Loopback | blocked | blocked |
+| Link-local, incl. `169.254.169.254` cloud metadata | blocked | blocked |
+| Multicast, reserved, unspecified | blocked | blocked |
+
+**Two constraints that are not negotiable:**
+
+1. The opt-in applies to the **operator-configured instance host only**. User-supplied content and download URLs are validated public-only, unconditionally — a connector that fetches an attachment from a URL inside a document must not inherit the instance host's exemption.
+2. Validate the configured base URL **once at config-store time**, not per request. Per-request validation is a DNS lookup on every call and still races.
+
+**When adding a connector:** if you are typing `aiohttp.ClientSession(` and the URL contains a value read from config, stop — you want `pinned_connector` or `pinned_request_with_redirects`.
+
 ## Rule 7: Behavioral Grep for Extraction PRs (#5372)
 
 **Extraction PRs (pulling a duplicated pattern into a shared composable/utility + migrating N sites) MUST grep for the *behavior*, not just the *symbol*, and document before/after hit counts in the PR description.**


### PR DESCRIPTION
## Thinking Path

Scope item 1 of #13625, which the other four all depend on. Deliberately landed alone: it is a **zero-behaviour-change** refactor, so it can be reviewed on the security property in isolation rather than buried under six connector rewrites.

`_ip_is_public` collapsed six unrelated conditions into one boolean:

```python
if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_multicast or ip.is_reserved or ip.is_unspecified:
    return False
```

That is why the six connectors are unguarded. A self-hosted Confluence/GitLab/Nextcloud instance legitimately lives on an RFC-1918 address, so applying this guard as-is would break the feature it protects — and with private inseparable from loopback and cloud-metadata, there was no way to permit the first without permitting the rest. Nobody wired it up, and no rule said they had to.

## What Changed

Split into two predicates, then recombined:

- `_ip_is_hard_blocked` — loopback, link-local (which covers `169.254.169.254`), multicast, reserved, unspecified. **Never permitted, in either state.**
- `_ip_is_private` — RFC-1918 and IPv6 ULA. The range an opt-in may permit.

`allow_private: bool = False` is threaded through `is_public_url`, `is_public_url_async` and `resolve_safe_ip_async`. All 70 existing call sites keep public-only behaviour untouched.

The hostname short-circuit needed splitting too, or it would have become a bypass: `localhost` stays refused in both states, while a private TLD is refused only when the opt-in is off.

## Verification

The security property, measured directly rather than asserted:

```
address            kind             off      on
10.0.0.5           RFC1918          False    True
192.168.1.10       RFC1918          False    True
fd00::1            IPv6 ULA         False    True
127.0.0.1          loopback         False    False
169.254.169.254    cloud-metadata   False    False
0.0.0.0            unspecified      False    False
224.0.0.1          multicast        False    False
240.0.0.1          reserved         False    False
::1                IPv6 loopback    False    False
fe80::1            IPv6 link-local  False    False
93.184.216.34      public           True     True
```

Mutation-checked, because a test suite that cannot detect a bad opt-in is worse than none here. Replacing the body with a blanket `if allow_private: return True`:

```
8 failed, 9 passed        # including the cloud-metadata case
54 passed                 # restored
```

```
autobot_shared/url_safety_test.py      54 passed
autobot_shared/security/              116 passed
web_fetch + media/link (consumers)     63 passed
flake8                                  clean
```

## Not in this PR

#13625 stays **open**. Remaining: the deployment flag (2), config-store-time validation (3), routing the six connectors (4), and the `CLAUDE_RULES.md` rule (5). Nothing here changes any caller's behaviour, so it is safe ahead of them — and item 5 matters as much as the code, since a rule living only in a docstring is plausibly why six connectors were written against bare `aiohttp` in the first place.

## Model Used

Opus 5

Part of #13625
