### PR TITLE
security(connectors): derive the connector owner from the authenticated caller (#13702)

### DIFF
--- a/autobot-backend/api/knowledge_connectors.py
+++ b/autobot-backend/api/knowledge_connectors.py
@@ -34,7 +34,7 @@ from typing import Any, Dict, List
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from redis.exceptions import RedisError
 
-from auth_middleware import check_admin_permission
+from auth_middleware import check_admin_permission, get_current_user
 from autobot_shared.auth import validate_config_against_schema
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
@@ -246,6 +246,10 @@ async def _cfg_with_credentials(cfg: ConnectorConfig, auth_cls: type | None) -> 
     """
     if not cfg.secret_id or auth_cls is None or not hasattr(auth_cls, "__sensitive_fields__"):
         return cfg
+    # #13702: reads keep the "system" fallback deliberately. Rows created before
+    # the write path was fixed already carry that owner; dropping it here would
+    # orphan them rather than protect anything. Migrating those rows to a real
+    # owner is the remaining half of #13702.
     owner_id = cfg.owner_id or "system"
     import dataclasses
 
@@ -398,7 +402,7 @@ async def list_connectors():
     operation="create_connector",
     error_code_prefix="KNOWLEDGE_CONNECTORS",
 )
-async def create_connector(request: CreateConnectorRequest):
+async def create_connector(request: CreateConnectorRequest, user: dict = Depends(get_current_user)):
     """Create a new connector, test the connection, and persist the config."""
     if request.connector_type not in _SUPPORTED_TYPES:
         raise HTTPException(
@@ -428,7 +432,18 @@ async def create_connector(request: CreateConnectorRequest):
                 )
 
     # ADR-007: extract sensitive credential fields and store encrypted.
-    owner_id = getattr(request, "owner_id", None) or "system"
+    # #13702: fall back to the authenticated caller, never to a shared literal.
+    # ``or "system"`` gave every connector created without an explicit owner the
+    # same owner_id, so `_require_owner` (#13628) compared "system" against
+    # "system" and two distinct admins passed each other's ownership check.
+    #
+    # Identity resolved user_id -> sub -> username, matching api/voice.py:73 —
+    # ``get_current_user`` does not guarantee ``user_id``: the internal-API-key
+    # path returns only ``username``, and SLM-minted JWTs carry ``sub``.
+    caller_id = str(user.get("user_id") or user.get("sub") or user.get("username") or "")
+    owner_id = getattr(request, "owner_id", None) or caller_id
+    if not owner_id:
+        raise HTTPException(status_code=401, detail="Authenticated caller has no resolvable identity")
     safe_config = request.config
     secret_id: str | None = None
     # OAuth flow already stored the token bundle (store_oauth) and handed back a

--- a/autobot-backend/api/knowledge_connectors_auth_schema_test.py
+++ b/autobot-backend/api/knowledge_connectors_auth_schema_test.py
@@ -25,6 +25,10 @@ from unittest.mock import patch
 
 import pytest
 
+# #13702: create_connector derives the credential owner from the authenticated
+# caller; a direct call must supply one or it 401s, same as a real request.
+_TEST_USER = {"user_id": "admin-1"}
+
 import knowledge.connectors.confluence  # noqa: F401 — register confluence
 import knowledge.connectors.jira  # noqa: F401 — register jira
 import knowledge.connectors.slack  # noqa: F401 — register slack
@@ -170,7 +174,7 @@ async def _create_via_api(request: CreateConnectorRequest, http_client_patch_tar
         patch.object(mod, "_save_connector", _fake_save),
         patch(http_client_patch_target, return_value=fake_client),
     ):
-        result = await mod.create_connector(request)
+        result = await mod.create_connector(request, user=_TEST_USER)
     return result, saved["cfg"]
 
 

--- a/autobot-backend/api/knowledge_connectors_create_test.py
+++ b/autobot-backend/api/knowledge_connectors_create_test.py
@@ -14,6 +14,10 @@ resolved at invocation time via ``get_access_token`` (ADR-007 §10).
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
+# #13702: create_connector derives the credential owner from the authenticated
+# caller; a direct call must supply one or it 401s, same as a real request.
+_TEST_USER = {"user_id": "admin-1"}
 from fastapi import HTTPException
 
 import knowledge.connectors.gdrive  # noqa: F401 — register gdrive
@@ -40,7 +44,7 @@ async def test_create_rejects_unknown_type():
     """An unregistered connector_type still 422s."""
     req = CreateConnectorRequest(connector_type="no_such_type", name="x")
     with pytest.raises(HTTPException) as exc:
-        await mod.create_connector(req)
+        await mod.create_connector(req, user=_TEST_USER)
     assert exc.value.status_code == 422
 
 
@@ -72,7 +76,7 @@ async def test_create_gdrive_with_oauth_secret_attaches_by_reference():
         patch.object(mod, "_save_connector", _fake_save),
         patch.object(mod, "_maybe_schedule", AsyncMock()),
     ):
-        result = await mod.create_connector(req)
+        result = await mod.create_connector(req, user=_TEST_USER)
 
     # secret attached by reference; credentials never re-stored.
     store.store.assert_not_called()
@@ -81,7 +85,9 @@ async def test_create_gdrive_with_oauth_secret_attaches_by_reference():
     assert cfg.auth_type == mod._OAUTH_AUTH_TYPE
     assert cfg.connector_type == "gdrive"
     # OAuth resolver produced a live access token for the connection test.
-    store.get_access_token.assert_awaited_once_with("sec-oauth-123", "system")
+    # #13702: owner is the authenticated caller now, not a shared "system"
+    # literal — two admins previously collided on the same owner_id.
+    store.get_access_token.assert_awaited_once_with("sec-oauth-123", "admin-1")
     assert result["connector_id"]
     # secret_id is internal — never echoed in the public config.
     assert "secret_id" not in result["config"]
@@ -115,7 +121,7 @@ async def test_create_onedrive_with_oauth_secret_attaches_by_reference():
         patch.object(mod, "_save_connector", _fake_save),
         patch.object(mod, "_maybe_schedule", AsyncMock()),
     ):
-        result = await mod.create_connector(req)
+        result = await mod.create_connector(req, user=_TEST_USER)
 
     # secret attached by reference; credentials never re-stored.
     store.store.assert_not_called()
@@ -124,7 +130,9 @@ async def test_create_onedrive_with_oauth_secret_attaches_by_reference():
     assert cfg.auth_type == mod._OAUTH_AUTH_TYPE
     assert cfg.connector_type == "onedrive"
     # OAuth resolver produced a live access token for the connection test.
-    store.get_access_token.assert_awaited_once_with("sec-oauth-456", "system")
+    # #13702: owner is the authenticated caller now, not a shared "system"
+    # literal — two admins previously collided on the same owner_id.
+    store.get_access_token.assert_awaited_once_with("sec-oauth-456", "admin-1")
     assert result["connector_id"]
     # secret_id is internal — never echoed in the public config.
     assert "secret_id" not in result["config"]
@@ -152,3 +160,70 @@ async def test_oauth_full_config_injects_token_into_bearer_field():
     assert full["token"] == "tok-abc"
     assert full["source_type"] == "mydrive"
     store.get_access_token.assert_awaited_once_with("sec-1", "user-1")
+
+
+def _oauth_create_request():
+    """A create request that attaches an existing OAuth secret by reference."""
+    return mod.CreateConnectorRequest(
+        connector_type="gdrive",
+        name="My Drive",
+        config={"source_type": "mydrive", "sync_subfolders": True},
+        secret_id="sec-oauth-123",
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "user_dict,expected_owner",
+    [
+        ({"user_id": "admin-1"}, "admin-1"),
+        # get_current_user does not guarantee user_id: SLM-minted JWTs carry
+        # ``sub``, and the internal-API-key path returns only ``username``.
+        ({"sub": "admin-sub", "username": "alice"}, "admin-sub"),
+        ({"username": "service:slm", "role": "admin", "service": True}, "service:slm"),
+    ],
+)
+async def test_connector_owner_is_the_authenticated_caller(user_dict, expected_owner):
+    """#13702: distinct callers must not collide on a shared "system" owner.
+
+    ``_require_owner`` (#13628) compares the stored ``created_by`` against the
+    caller's ``owner_id``. When every ownerless create minted the literal
+    "system", two distinct admins passed each other's ownership check — the
+    guard worked exactly as designed and was handed the wrong identity.
+    """
+    store = MagicMock()
+    store.store = AsyncMock()
+    store.get_access_token = AsyncMock(return_value="live-access-token")
+    healthy = MagicMock()
+    healthy.test_connection = AsyncMock(return_value=True)
+
+    with (
+        patch.object(mod, "get_credential_store", return_value=store),
+        patch.object(mod, "_load_or_create_instance", AsyncMock(return_value=healthy)),
+        patch.object(mod, "_save_connector", AsyncMock()),
+        patch.object(mod, "_maybe_schedule", AsyncMock()),
+    ):
+        await mod.create_connector(_oauth_create_request(), user=user_dict)
+
+    seen = store.get_access_token.await_args[0][1]
+    assert seen == expected_owner, f"owner was {seen!r}, expected {expected_owner!r}"
+    assert seen != "system", "shared literal owner reintroduced"
+
+
+@pytest.mark.asyncio
+async def test_connector_create_refuses_a_caller_with_no_identity():
+    """#13702: no identity means no owner — refuse rather than invent one."""
+    store = MagicMock()
+    store.get_access_token = AsyncMock(return_value="tok")
+    healthy = MagicMock()
+    healthy.test_connection = AsyncMock(return_value=True)
+
+    with (
+        patch.object(mod, "get_credential_store", return_value=store),
+        patch.object(mod, "_load_or_create_instance", AsyncMock(return_value=healthy)),
+        patch.object(mod, "_save_connector", AsyncMock()),
+        patch.object(mod, "_maybe_schedule", AsyncMock()),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await mod.create_connector(_oauth_create_request(), user={"role": "admin"})
+    assert exc.value.status_code == 401


### PR DESCRIPTION
## Thinking Path

`api/knowledge_connectors.py:431` minted a shared literal owner on the REST connector-create path:

```python
owner_id = getattr(request, "owner_id", None) or "system"
```

`_require_owner` (#13628) compares a credential's stored `created_by` against the caller's `owner_id`. When every ownerless create resolved to `"system"`, two distinct callers compared `"system"` against `"system"` and passed each other's ownership check. The guard worked exactly as designed and was handed the wrong identity.

**Severity, stated accurately:** the router carries `dependencies=[Depends(check_admin_permission)]`, so this needs two *admins*, not two arbitrary users. That is narrower than #13702's original framing. It is still a real isolation gap — connector credentials are per-owner, and admins are distinct principals — but it is not an unauthenticated hole.

The endpoint had no user identity in scope at all: `check_admin_permission` returns `bool`, so the owner could only come from the request body.

## What Changed

`create_connector` now takes `user: dict = Depends(get_current_user)` and derives the owner from the authenticated caller, falling back to the body's `owner_id` if one was supplied (existing admin-provisioning behaviour) and refusing with 401 when neither yields an identity.

Identity is resolved `user_id -> sub -> username`, matching `api/voice.py:73` and `api/agent_terminal.py:614`. `get_current_user` does **not** guarantee `user_id` — the internal-API-key path returns only `username`, and SLM-minted JWTs carry `sub`. Requiring `user_id` alone would 401 callers that authenticate fine everywhere else; that exact mistake was caught in review on #13700 and is not repeated here.

## The read sites are deliberately unchanged

`:249`, `:598`, `:629` keep `cfg.owner_id or "system"`. Rows created before this fix already carry that owner, so dropping the fallback would orphan them rather than protect anything. Annotated in place. Migrating those rows is the remaining half of #13702, which therefore **stays open**.

## Verification

```
knowledge/connectors/ + api connector tests    387 passed
flake8 / isort                                  clean
```

Every new test was run against the original `or "system"` to confirm it fails there:

```
4 failed, 6 deselected     # against the reinstated bug
16 passed                  # restored
```

Coverage is parametrised over the three identity shapes `get_current_user` actually returns — `user_id`, `sub`-only, and the service dict — plus a no-identity case asserting 401.

Two pre-existing tests **asserted the bug**: `store.get_access_token.assert_awaited_once_with("sec-oauth-123", "system")`. They now assert the caller's real identity, which is the behaviour change this PR exists to make.

## Model Used

Opus 5

Part of #13702
