### PR TITLE
feat(chat): server-side work-item binding and tenant-scoped goal lookups (#13704, #13687)

### DIFF
--- a/autobot-backend/api/chat.py
+++ b/autobot-backend/api/chat.py
@@ -48,6 +48,7 @@ from api.schemas_chat import (
     TranslateRequest,
 )
 from api.schemas_common import DataResponse
+from api.user_management.dependencies import require_org_context
 from auth_middleware import get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.error_utils import safe_http_detail
@@ -55,6 +56,7 @@ from autobot_shared.time_utils import parse_utc_iso, utc_timestamp
 
 # Import context overflow protection (#9043)
 from chat_history.overflow_integration import create_summary_message, handle_message_completion
+from chat_workflow.session_work_item import SessionWorkItemService
 from constants.threshold_constants import TimingConstants
 
 # Import dependencies and utilities - Using available dependencies
@@ -1135,6 +1137,81 @@ async def set_session_role(
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
     return DataResponse(data={"session_id": session_id, "role": role})
+
+
+@router.put("/chat/sessions/{session_id}/work-item", response_model=DataResponse[Dict[str, Any]])
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="set_session_work_item",
+    error_code_prefix="CHAT",
+)
+async def set_session_work_item(
+    session_id: str,
+    work_item_id: str = Body(..., embed=True),
+    current_user: dict = Depends(get_current_user),
+    ctx=Depends(require_org_context),
+    request: Request = None,
+):
+    """Bind a chat session to an LLC work item so L4 can render its goal chain (#13704).
+
+    Two checks, both required: the caller must own the *session*, and the work
+    item must belong to the caller's *company*. Only then is the binding stored
+    server-side, where it overrides any client-supplied ``work_item_id``.
+
+    This endpoint is the reason L4 can be wired at all (#13687). Reading the
+    work item from the chat request body instead would let any authenticated
+    caller name another company's work item and have its goal titles rendered
+    into their own prompt.
+    """
+    from llc.deps import get_session as _llc_session
+    from llc.services.work_item_service import WorkItemService
+
+    await validate_chat_ownership(session_id, request)  # SECURITY: caller must own the session
+
+    async for db in _llc_session():
+        # SECURITY: company-scoped fetch — a work item owned by another company
+        # is indistinguishable from one that does not exist.
+        item = await WorkItemService().get(db, work_item_id, company_id=str(ctx.org_id))
+        if item is None:
+            raise HTTPException(status_code=404, detail="Work item not found")
+        break
+
+    await SessionWorkItemService().set_work_item(session_id, work_item_id, str(ctx.org_id))
+    return DataResponse(data={"session_id": session_id, "work_item_id": work_item_id})
+
+
+@router.get("/chat/sessions/{session_id}/work-item", response_model=DataResponse[Dict[str, Any]])
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="get_session_work_item",
+    error_code_prefix="CHAT",
+)
+async def get_session_work_item(
+    session_id: str,
+    current_user: dict = Depends(get_current_user),
+    request: Request = None,
+):
+    """Return the session's bound work item, or ``None`` (#13704)."""
+    await validate_chat_ownership(session_id, request)  # SECURITY: caller must own the session
+    work_item_id = await SessionWorkItemService().get_work_item(session_id)
+    return DataResponse(data={"session_id": session_id, "work_item_id": work_item_id})
+
+
+@router.delete("/chat/sessions/{session_id}/work-item", response_model=DataResponse[Dict[str, Any]])
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="clear_session_work_item",
+    error_code_prefix="CHAT",
+)
+async def clear_session_work_item(
+    session_id: str,
+    current_user: dict = Depends(get_current_user),
+    request: Request = None,
+):
+    """Remove the session's work-item binding (#13704)."""
+    await validate_chat_ownership(session_id, request)  # SECURITY: caller must own the session
+    await SessionWorkItemService().clear_work_item(session_id)
+    return DataResponse(data={"session_id": session_id, "work_item_id": None})
 
 
 @router.get("/chat/sessions/{session_id}/role", response_model=DataResponse[Dict[str, Any]])

--- a/autobot-backend/api/chat.py
+++ b/autobot-backend/api/chat.py
@@ -26,6 +26,8 @@ from autobot_shared.ssot_config import config
 # Reads env at import time (process restart required to change).
 _CHAT_SSOT_STRICT = config.chat_ssot_strict.lower() == "true"
 
+import uuid
+
 from fastapi import APIRouter, Body, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 
@@ -1163,18 +1165,26 @@ async def set_session_work_item(
     caller name another company's work item and have its goal titles rendered
     into their own prompt.
     """
-    from llc.deps import get_session as _llc_session
     from llc.services.work_item_service import WorkItemService
+    from user_management.database import get_async_session_factory
 
     await validate_chat_ownership(session_id, request)  # SECURITY: caller must own the session
 
-    async for db in _llc_session():
+    try:
+        uuid.UUID(str(work_item_id))
+    except (ValueError, TypeError):
+        raise HTTPException(status_code=422, detail="work_item_id must be a UUID")
+
+    # `async with`, not `async for ... break`: breaking out of an async generator
+    # does not run its __aexit__, so the DB session would only return to the pool
+    # at GC time.
+    factory = get_async_session_factory()
+    async with factory() as db:
         # SECURITY: company-scoped fetch — a work item owned by another company
         # is indistinguishable from one that does not exist.
         item = await WorkItemService().get(db, work_item_id, company_id=str(ctx.org_id))
         if item is None:
             raise HTTPException(status_code=404, detail="Work item not found")
-        break
 
     await SessionWorkItemService().set_work_item(session_id, work_item_id, str(ctx.org_id))
     return DataResponse(data={"session_id": session_id, "work_item_id": work_item_id})

--- a/autobot-backend/chat_workflow/llm_handler.py
+++ b/autobot-backend/chat_workflow/llm_handler.py
@@ -838,6 +838,9 @@ NEVER teach commands - ALWAYS execute them.""" + lang_instruction
         Issue MVA-1992: lightweight_mode bypasses RAG/memory for trivial queries.
         Issue #11585: session.metadata["model_override"] (per-request/per-conversation
         choice) takes priority over the global config default.
+        #13687/#13704: L4's goal ancestry is resolved from the server-side
+        session binding, not from any parameter threaded through here — the
+        request context and session metadata are both client-influenced.
         """
         selected_model = self._get_selected_model(
             session.metadata.get("model_override") if session and session.metadata else None
@@ -872,11 +875,15 @@ NEVER teach commands - ALWAYS execute them.""" + lang_instruction
                 from chat_history.layers import TIERED_CONTEXT_ENABLED, TieredContextBuilder
 
                 if TIERED_CONTEXT_ENABLED:
-                    # Issue #13686: the memory graph was read off an object that
-                    # never had it, so L2 returned "" on every turn. It now comes
-                    # from the manager that owns it, and degrades to None rather
-                    # than failing the turn.
-                    from chat_workflow.tiered_context_sources import resolve_memory_graph
+                    # #13686: the memory graph was read off an object that never
+                    # had it, so L2 returned "" on every turn. #13687/#13704: the
+                    # goal ancestry comes from the *server-side* session binding,
+                    # never the request body, and both hops are company-scoped.
+                    # Both resolvers degrade to None rather than failing the turn.
+                    from chat_workflow.tiered_context_sources import (
+                        resolve_goal_ancestry,
+                        resolve_memory_graph,
+                    )
 
                     tiered_ctx = await TieredContextBuilder().build(
                         user_message=message,
@@ -884,6 +891,7 @@ NEVER teach commands - ALWAYS execute them.""" + lang_instruction
                         session_id=session.session_id,
                         memory_graph=await resolve_memory_graph(),
                         knowledge_service=self.knowledge_service if use_knowledge else None,
+                        goal_ancestry=await resolve_goal_ancestry(session.session_id),
                     )
                     if tiered_ctx:
                         system_prompt = tiered_ctx + "\n\n" + system_prompt

--- a/autobot-backend/chat_workflow/manager.py
+++ b/autobot-backend/chat_workflow/manager.py
@@ -3635,9 +3635,15 @@ before summarizing.
         pre-execution stage. Backend decides; the frontend only calls the endpoints.
         """
         from chat_workflow.session_role import CHAT_APPROVAL_GATE_ENABLED, SessionRoleService, apply_role
+        from chat_workflow.session_work_item import SessionWorkItemService, apply_work_item
 
         svc = SessionRoleService()
         context = apply_role(context, await svc.get_role(session_id))
+        # #13704: same trust model for the work-item binding. A server-set value
+        # overrides any client-supplied work_item_id, and an unbound session has
+        # the client's value stripped — otherwise a caller could select whose
+        # goal chain L4 reads on their behalf (#13687).
+        context = apply_work_item(context, await SessionWorkItemService().get_work_item(session_id))
         if CHAT_APPROVAL_GATE_ENABLED:
             categories = await svc.get_approval_categories(session_id)
             if categories:

--- a/autobot-backend/chat_workflow/session_work_item.py
+++ b/autobot-backend/chat_workflow/session_work_item.py
@@ -1,0 +1,117 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Per-session work-item binding (#13704).
+
+Binds a chat session to an LLC work item so L4 GoalAncestry can render that
+item's goal chain into the prompt (GH#6469, #13687).
+
+This is the *trusted* producer of ``work_item_id``, deliberately mirroring
+:mod:`chat_workflow.session_role`: the binding is set server-side through an
+authenticated endpoint that verifies the work item belongs to the caller's
+company, stored in Redis, then overlaid onto the chat context — overriding any
+client-supplied ``work_item_id``.
+
+Why this exists rather than reading the request context directly: the only
+carrier into the prompt path was ``api/chat.py`` ``request_data.get("context")``,
+a raw client JSON bag, and neither ``WorkItemService.get`` nor
+``GoalService.get`` filtered on ``company_id``. Sourcing a goal lookup from that
+bag would let any authenticated caller render another company's goal titles into
+their own prompt. Making the value server-written removes that at the root; the
+tenant predicates added alongside are defence in depth, not the only defence.
+"""
+
+import json
+import os
+from typing import Optional, Tuple
+
+from autobot_shared.logging_manager import get_logger
+from autobot_shared.redis_mixin import AsyncRedisClientMixin
+
+logger = get_logger(__name__)
+
+# TTL for a session's work-item binding — env-tunable, never hard-coded.
+SESSION_WORK_ITEM_TTL_SECONDS: int = int(os.environ.get("AUTOBOT_SESSION_WORK_ITEM_TTL_SECONDS", str(24 * 3600)))
+
+_KEY = "autobot:session:{session_id}:work_item"
+
+
+def apply_work_item(context: "dict | None", work_item_id: Optional[str]) -> "dict | None":
+    """Overlay a trusted *work_item_id* onto *context* (#13704).
+
+    A server-set binding overrides any client-supplied ``work_item_id``, so a
+    caller cannot select which work item's goal chain is read on their behalf.
+    ``None`` returns *context* unchanged — and unchanged means the client's own
+    value is **removed**, not preserved, because an unbound session must not be
+    able to name a work item at all.
+    """
+    if not work_item_id:
+        if context and "work_item_id" in context:
+            trimmed = {k: v for k, v in context.items() if k != "work_item_id"}
+            logger.debug("session_work_item.reject client-supplied work_item_id on unbound session")
+            return trimmed
+        return context
+    return {**(context or {}), "work_item_id": work_item_id}
+
+
+class SessionWorkItemService(AsyncRedisClientMixin):
+    """Redis-backed store for a chat session's bound work item."""
+
+    _redis_database = "knowledge"
+
+    async def set_work_item(self, session_id: str, work_item_id: str, company_id: str) -> None:
+        """Bind *session_id* to *work_item_id*, recording its verified company.
+
+        The company is stored **with** the binding rather than read later from
+        the session or request context, because both of those are
+        client-influenced: ``session.metadata["company_id"]`` is assigned from
+        the request bag at ``chat_workflow/manager.py:3331``. Persisting the
+        company the endpoint actually authorised is what makes the later goal
+        lookup's tenant scope trustworthy.
+
+        The caller is responsible for having verified ownership of both the
+        session and the work item; this stores an already-authorised decision.
+        """
+        if not work_item_id or not str(work_item_id).strip():
+            raise ValueError("work_item_id is required")
+        if not company_id or not str(company_id).strip():
+            raise ValueError("company_id is required — an unscoped binding is not a binding")
+        payload = json.dumps({"work_item_id": str(work_item_id).strip(), "company_id": str(company_id).strip()})
+        redis = await self._get_redis()
+        await redis.set(_KEY.format(session_id=session_id), payload, ex=SESSION_WORK_ITEM_TTL_SECONDS)
+        logger.info("session_work_item.set session=%s work_item=%s company=%s", session_id, work_item_id, company_id)
+
+    async def get_binding(self, session_id: str) -> Tuple[Optional[str], Optional[str]]:
+        """Return ``(work_item_id, company_id)`` for the session, or ``(None, None)``.
+
+        Never raises into chat — a resolution failure leaves L4 silent.
+        """
+        try:
+            redis = await self._get_redis()
+            raw = await redis.get(_KEY.format(session_id=session_id))
+            if not raw:
+                return None, None
+            data = json.loads(raw.decode() if isinstance(raw, bytes) else raw)
+            return data.get("work_item_id"), data.get("company_id")
+        except Exception as exc:  # defensive; resolution must never break chat
+            logger.warning("session_work_item.get failed for session=%s: %s", session_id, exc)
+            return None, None
+
+    async def get_work_item(self, session_id: str) -> Optional[str]:
+        """Return just the bound work item id, or ``None``."""
+        work_item_id, _ = await self.get_binding(session_id)
+        return work_item_id
+
+    async def clear_work_item(self, session_id: str) -> None:
+        """Remove the session's work-item binding."""
+        redis = await self._get_redis()
+        await redis.delete(_KEY.format(session_id=session_id))
+        logger.info("session_work_item.clear session=%s", session_id)
+
+
+__all__ = [
+    "SESSION_WORK_ITEM_TTL_SECONDS",
+    "SessionWorkItemService",
+    "apply_work_item",
+]

--- a/autobot-backend/chat_workflow/session_work_item_test.py
+++ b/autobot-backend/chat_workflow/session_work_item_test.py
@@ -1,0 +1,155 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Server-side work-item binding and its tenant scope (#13704, #13687).
+
+#13696 removed the L4 wiring rather than ship it, because the only carrier for
+`work_item_id` was a raw client JSON bag and neither LLC lookup filtered on
+`company_id`. These pin both halves of the fix: the value is server-written, and
+the lookups are company-scoped even if a binding is stale or forged.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from chat_workflow.session_work_item import SessionWorkItemService, apply_work_item
+
+ALICE_CO = "11111111-1111-1111-1111-111111111111"
+BOB_CO = "22222222-2222-2222-2222-222222222222"
+WORK_ITEM = "33333333-3333-3333-3333-333333333333"
+
+
+class TestClientSuppliedValueIsNeverTrusted:
+    def test_a_server_binding_overrides_a_client_value(self):
+        context = {"work_item_id": "attacker-chosen", "other": "kept"}
+
+        result = apply_work_item(context, WORK_ITEM)
+
+        assert result["work_item_id"] == WORK_ITEM
+        assert result["other"] == "kept"
+
+    def test_an_unbound_session_has_the_client_value_stripped(self):
+        """The core of #13687: an unbound session must not be able to name one.
+
+        Leaving the client's value in place would preserve exactly the
+        cross-tenant read this issue exists to remove.
+        """
+        context = {"work_item_id": "attacker-chosen", "other": "kept"}
+
+        result = apply_work_item(context, None)
+
+        assert "work_item_id" not in result
+        assert result["other"] == "kept"
+
+    def test_absent_context_stays_absent(self):
+        assert apply_work_item(None, None) is None
+
+
+class TestBindingCarriesItsVerifiedCompany:
+    @pytest.mark.asyncio
+    async def test_the_company_is_stored_with_the_binding(self):
+        """The company cannot be read back later from the session or context.
+
+        `session.metadata["company_id"]` is assigned from the client bag at
+        `chat_workflow/manager.py:3331`, so persisting the company the endpoint
+        actually authorised is what makes the tenant scope trustworthy.
+        """
+        svc = SessionWorkItemService()
+        redis = MagicMock()
+        redis.set = AsyncMock()
+
+        with patch.object(SessionWorkItemService, "_get_redis", new_callable=AsyncMock, return_value=redis):
+            await svc.set_work_item("s-1", WORK_ITEM, ALICE_CO)
+
+        stored = json.loads(redis.set.await_args.args[1])
+        assert stored == {"work_item_id": WORK_ITEM, "company_id": ALICE_CO}
+
+    @pytest.mark.asyncio
+    async def test_a_binding_without_a_company_is_rejected(self):
+        svc = SessionWorkItemService()
+        with pytest.raises(ValueError, match="company_id is required"):
+            await svc.set_work_item("s-1", WORK_ITEM, "")
+
+    @pytest.mark.asyncio
+    async def test_get_binding_returns_both_values(self):
+        svc = SessionWorkItemService()
+        redis = MagicMock()
+        redis.get = AsyncMock(return_value=json.dumps({"work_item_id": WORK_ITEM, "company_id": ALICE_CO}).encode())
+
+        with patch.object(SessionWorkItemService, "_get_redis", new_callable=AsyncMock, return_value=redis):
+            assert await svc.get_binding("s-1") == (WORK_ITEM, ALICE_CO)
+
+    @pytest.mark.asyncio
+    async def test_a_redis_failure_leaves_l4_silent_not_broken(self):
+        svc = SessionWorkItemService()
+        with patch.object(SessionWorkItemService, "_get_redis", side_effect=RuntimeError("redis down")):
+            assert await svc.get_binding("s-1") == (None, None)
+
+
+class TestGoalAncestryIsCompanyScoped:
+    @pytest.mark.asyncio
+    async def test_no_binding_issues_no_query(self):
+        """A turn with no binding must cost no DB round-trip."""
+        from chat_workflow.tiered_context_sources import resolve_goal_ancestry
+
+        factory = MagicMock()
+        with patch(
+            "chat_workflow.session_work_item.SessionWorkItemService.get_binding",
+            new_callable=AsyncMock,
+            return_value=(None, None),
+        ):
+            with patch("user_management.database.get_async_session_factory", factory):
+                assert await resolve_goal_ancestry("s-1") is None
+
+        factory.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_a_malformed_work_item_id_is_not_a_per_turn_warning(self):
+        from chat_workflow.tiered_context_sources import resolve_goal_ancestry
+
+        with patch(
+            "chat_workflow.session_work_item.SessionWorkItemService.get_binding",
+            new_callable=AsyncMock,
+            return_value=("not-a-uuid", ALICE_CO),
+        ):
+            with patch("chat_workflow.tiered_context_sources.logger") as log:
+                assert await resolve_goal_ancestry("s-1") is None
+
+        assert not log.warning.called, "a client-shaped id is a debug, not a warning"
+
+    @pytest.mark.asyncio
+    async def test_the_company_from_the_binding_scopes_both_lookups(self):
+        """The scope must reach the work-item fetch AND the goal walk."""
+        from chat_workflow.tiered_context_sources import resolve_goal_ancestry
+
+        work_item = MagicMock()
+        work_item.goal_id = "44444444-4444-4444-4444-444444444444"
+        wi_svc, goal_svc = MagicMock(), MagicMock()
+        wi_svc.get = AsyncMock(return_value=work_item)
+        goal_svc.get_goal_ancestry_for_work_item = AsyncMock(return_value=[{"title": "Ship", "level": "vision"}])
+
+        session_cm = MagicMock()
+        session_cm.__aenter__ = AsyncMock(return_value=MagicMock())
+        session_cm.__aexit__ = AsyncMock(return_value=False)
+
+        modules = {
+            "llc.services.goal": MagicMock(GoalService=MagicMock(return_value=goal_svc)),
+            "llc.services.work_item_service": MagicMock(WorkItemService=MagicMock(return_value=wi_svc)),
+            "user_management.database": MagicMock(
+                get_async_session_factory=MagicMock(return_value=MagicMock(return_value=session_cm))
+            ),
+        }
+        with patch.dict("sys.modules", modules):
+            with patch(
+                "chat_workflow.session_work_item.SessionWorkItemService.get_binding",
+                new_callable=AsyncMock,
+                return_value=(WORK_ITEM, ALICE_CO),
+            ):
+                result = await resolve_goal_ancestry("s-1")
+
+        assert result == [{"title": "Ship", "level": "vision"}]
+        assert wi_svc.get.await_args.kwargs["company_id"] == ALICE_CO
+        assert goal_svc.get_goal_ancestry_for_work_item.await_args.kwargs["company_id"] == ALICE_CO

--- a/autobot-backend/chat_workflow/tiered_context_prompt_test.py
+++ b/autobot-backend/chat_workflow/tiered_context_prompt_test.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
-"""End-to-end prompt capture for the reconnected L2 layer (#13686).
+"""End-to-end prompt capture for the reconnected L2 and L4 layers (#13686, #13687).
 
 ``tiered_context_sources_test.py`` proves the resolver returns the graph the
 manager owns. These prove the *prompt the model actually receives* now contains
@@ -113,3 +113,58 @@ class TestL2RendersInPrompt:
 
         assert "## Related Context" not in prompt
         assert "SYSTEM" in prompt
+
+
+class TestL4RendersInPromptViaTheBinding:
+    """AC #13704-3: the goal block reaches a real prompt through the production path.
+
+    Not by injecting a chain into the builder — that only proves
+    `Layer4GoalAncestry` renders, which was never in doubt. This starts from the
+    *server-side binding*, which is the only thing that can produce the state.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_bound_session_renders_the_goal_ancestry_block(self):
+        chain = [
+            {"id": "1", "title": "Ship the platform", "level": "vision", "status": "active"},
+            {"id": "2", "title": "Wake the context stack", "level": "objective", "status": "active"},
+        ]
+        handler = _handler_with_tiered_context_on()
+
+        with patch(
+            "utils.resource_factory.ResourceFactory.get_initialized_chat_history_manager",
+            return_value=None,
+        ):
+            # The binding is what the bind endpoint writes; everything downstream
+            # is the real path.
+            with patch(
+                "chat_workflow.session_work_item.SessionWorkItemService.get_binding",
+                new_callable=AsyncMock,
+                return_value=("wi-1", "company-a"),
+            ):
+                with patch(
+                    "chat_workflow.tiered_context_sources._query_goal_ancestry",
+                    new_callable=AsyncMock,
+                    return_value=chain,
+                ):
+                    prompt = await _capture_system_prompt(handler, _session(), "what is the status")
+
+        assert "## Goal Ancestry" in prompt
+        assert "Wake the context stack" in prompt
+
+    @pytest.mark.asyncio
+    async def test_an_unbound_session_renders_no_goal_block(self):
+        handler = _handler_with_tiered_context_on()
+
+        with patch(
+            "utils.resource_factory.ResourceFactory.get_initialized_chat_history_manager",
+            return_value=None,
+        ):
+            with patch(
+                "chat_workflow.session_work_item.SessionWorkItemService.get_binding",
+                new_callable=AsyncMock,
+                return_value=(None, None),
+            ):
+                prompt = await _capture_system_prompt(handler, _session(), "what is the status")
+
+        assert "## Goal Ancestry" not in prompt

--- a/autobot-backend/chat_workflow/tiered_context_sources.py
+++ b/autobot-backend/chat_workflow/tiered_context_sources.py
@@ -67,6 +67,7 @@ async def resolve_goal_ancestry(session_id: str) -> list | None:
     any failure so a goal-lookup error leaves L4 silent rather than failing the
     turn.
     """
+    work_item_id = None
     try:
         from chat_workflow.session_work_item import SessionWorkItemService
 

--- a/autobot-backend/chat_workflow/tiered_context_sources.py
+++ b/autobot-backend/chat_workflow/tiered_context_sources.py
@@ -10,15 +10,16 @@ OnDemand was therefore permanently silent in production: `llm_handler` read
 ``memory_graph`` off the chat *workflow* manager, which has no such attribute
 (#13686). The graph lives on the chat *history* manager.
 
-L4 GoalAncestry is still dark, deliberately. Wiring it needs a server-side
-session→work-item binding that does not exist yet, and a tenant-scoped goal
-lookup — see the follow-up issue referenced from #13687. Sourcing the work item
-from the client-supplied request context would have made an unscoped
-cross-tenant read out of a rendering fix.
+L4 GoalAncestry (#13687) is wired as of #13704, which supplied the two things
+it needed: a server-side session→work-item binding
+(:mod:`chat_workflow.session_work_item`) and a tenant-scoped goal lookup. The
+work item is never read from the client-supplied request context — that would
+have made an unscoped cross-tenant read out of a rendering fix.
 """
 
 from __future__ import annotations
 
+import uuid
 from typing import Any
 
 from autobot_shared.logging_manager import get_logger
@@ -48,4 +49,62 @@ async def resolve_memory_graph() -> Any | None:
         return None
 
 
-__all__ = ["resolve_memory_graph"]
+async def resolve_goal_ancestry(session_id: str) -> list | None:
+    """Return the root-first goal ancestry chain for a session, or None (#13687).
+
+    Both the work item **and** the company come from the server-side session
+    binding (:class:`chat_workflow.session_work_item.SessionWorkItemService`),
+    which the bind endpoint wrote only after verifying the caller owns the
+    session and the work item belongs to their company.
+
+    Nothing here is taken from the request context. That is deliberate: the
+    context bag is client-supplied, and ``session.metadata["company_id"]`` is
+    assigned from it at ``chat_workflow/manager.py:3331``, so neither can serve
+    as a tenant scope.
+
+    A turn with no binding is the common case and must cost **no** DB round-trip,
+    which is why the falsy check precedes the session factory. Returns None on
+    any failure so a goal-lookup error leaves L4 silent rather than failing the
+    turn.
+    """
+    try:
+        from chat_workflow.session_work_item import SessionWorkItemService
+
+        work_item_id, company_id = await SessionWorkItemService().get_binding(session_id)
+        if not work_item_id or not company_id:
+            return None
+        return await _query_goal_ancestry(str(work_item_id), company_id)
+    except Exception as exc:
+        logger.warning("Goal ancestry lookup failed for work item %s: %s", work_item_id, exc)
+        return None
+
+
+async def _query_goal_ancestry(work_item_id: str, company_id: str | None) -> list | None:
+    """Resolve work item -> goal_id -> ancestry chain, scoped to *company_id*.
+
+    Split out to keep the LLC imports lazy (the stack is optional at import
+    time) and both functions inside the 30-line limit.
+    """
+    try:
+        uuid.UUID(work_item_id)
+    except (ValueError, TypeError):
+        # A malformed id is a client-shaped problem, not a system failure —
+        # debug, not a per-turn warning.
+        logger.debug("Ignoring malformed work_item_id for goal ancestry: %r", work_item_id)
+        return None
+
+    from llc.services.goal import GoalService
+    from llc.services.work_item_service import WorkItemService
+    from user_management.database import get_async_session_factory
+
+    factory = get_async_session_factory()
+    async with factory() as session:
+        work_item = await WorkItemService().get(session, work_item_id, company_id=company_id)
+        goal_id = getattr(work_item, "goal_id", None) if work_item else None
+        if not goal_id:
+            return None
+        chain = await GoalService().get_goal_ancestry_for_work_item(session, goal_id, company_id=company_id)
+        return chain or None
+
+
+__all__ = ["resolve_goal_ancestry", "resolve_memory_graph"]

--- a/autobot-backend/llc/services/goal.py
+++ b/autobot-backend/llc/services/goal.py
@@ -83,6 +83,15 @@ class GoalService(LLCServiceBase):
             parent = await self.get(session, parent_goal_id)
             if parent is None:
                 raise HTTPException(status_code=404, detail="Parent goal not found")
+            # #13704: reject a cross-tenant parent on CREATE, as update() already
+            # does. Without this, a caller could root a goal of their own company
+            # under another company's goal and read that company's titles back
+            # through the ancestry walk.
+            if str(parent.company_id) != str(company_id):
+                raise HTTPException(
+                    status_code=400,
+                    detail="Parent goal belongs to a different company",
+                )
             _validate_level_order(level, _as_goal_level(parent.level))
 
         goal = LLCGoal(
@@ -218,8 +227,17 @@ class GoalService(LLCServiceBase):
 
     # ----------------------------------------------------------- Traversal
 
-    async def get_ancestors(self, session: AsyncSession, goal_id: uuid.UUID) -> List[LLCGoal]:
-        """Walk parent chain from goal_id up to the root (exclusive of goal_id)."""
+    async def get_ancestors(
+        self, session: AsyncSession, goal_id: uuid.UUID, *, company_id: Optional[str] = None
+    ) -> List[LLCGoal]:
+        """Walk parent chain from goal_id up to the root (exclusive of goal_id).
+
+        #13704: when *company_id* is given the walk **stops** at the first
+        ancestor owned by another company rather than continuing through it.
+        Scoping only the leaf is not enough — a cross-company parent edge makes
+        the chain itself the leak, and such an edge was creatable until the
+        guard added to :meth:`create` in the same change.
+        """
         ancestors: List[LLCGoal] = []
         current_id: Optional[uuid.UUID] = goal_id
         visited: set = set()
@@ -230,6 +248,12 @@ class GoalService(LLCServiceBase):
             visited.add(current_id)
             goal = await self.get(session, current_id)
             if goal is None:
+                break
+            if company_id is not None and str(goal.company_id) != str(company_id):
+                logger.warning(
+                    "Stopping goal ancestry walk at %s: ancestor belongs to another company (#13704)",
+                    current_id,
+                )
                 break
             if current_id != goal_id:
                 ancestors.append(goal)
@@ -264,7 +288,7 @@ class GoalService(LLCServiceBase):
                 goal_id,
             )
             return []
-        ancestors = await self.get_ancestors(session, goal_id)
+        ancestors = await self.get_ancestors(session, goal_id, company_id=company_id)
         chain = ancestors + [goal]
         return [
             {

--- a/autobot-backend/llc/services/goal.py
+++ b/autobot-backend/llc/services/goal.py
@@ -240,15 +240,29 @@ class GoalService(LLCServiceBase):
         self,
         session: AsyncSession,
         goal_id: uuid.UUID,
+        *,
+        company_id: Optional[str] = None,
     ) -> List[dict]:
         """Return root-first goal ancestry chain for a goal_id (GH#6469).
 
         Includes the goal itself as the last element.  Returns plain dicts
         (``id``, ``title``, ``level``, ``status``) so callers avoid importing
         LLCGoal.  Returns ``[]`` when the goal is not found.
+
+        #13704: ``company_id`` scopes the lookup. This is the one method an
+        untrusted goal reference reaches — the chat prompt path — so the tenant
+        check lives here rather than on every internal getter, whose scope is
+        already established by its own entry point. A goal belonging to another
+        company yields ``[]``, indistinguishable from "no such goal".
         """
         goal = await self.get(session, goal_id)
         if goal is None:
+            return []
+        if company_id is not None and str(goal.company_id) != str(company_id):
+            logger.warning(
+                "Refusing cross-company goal ancestry: goal=%s belongs to another company (#13704)",
+                goal_id,
+            )
             return []
         ancestors = await self.get_ancestors(session, goal_id)
         chain = ancestors + [goal]

--- a/autobot-backend/llc/services/work_item_service.py
+++ b/autobot-backend/llc/services/work_item_service.py
@@ -302,8 +302,20 @@ class WorkItemService(LLCServiceBase):
         await session.flush()
         return item
 
-    async def get(self, session: AsyncSession, work_item_id: str) -> Optional[LLCWorkItem]:
-        result = await session.execute(select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id)))
+    async def get(
+        self, session: AsyncSession, work_item_id: str, *, company_id: Optional[str] = None
+    ) -> Optional[LLCWorkItem]:
+        """Fetch a work item, optionally scoped to a company (#13704).
+
+        ``company_id`` is keyword-only and optional so the many internal callers
+        whose scope is already established stay unchanged; the chat prompt path,
+        which is the one place an untrusted id arrives, always passes it. A
+        mismatch returns ``None`` — indistinguishable from "no such item".
+        """
+        stmt = select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id))
+        if company_id is not None:
+            stmt = stmt.where(LLCWorkItem.company_id == uuid.UUID(str(company_id)))
+        result = await session.execute(stmt)
         return result.scalar_one_or_none()
 
     async def update(

--- a/autobot-backend/llc/tests/test_goal_ancestry_tenant_scope.py
+++ b/autobot-backend/llc/tests/test_goal_ancestry_tenant_scope.py
@@ -22,7 +22,6 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 
 from llc.models.goal import LLCGoal  # noqa: E402
 from llc.services.goal import GoalService  # noqa: E402
-from llc.services.work_item_service import WorkItemService  # noqa: E402
 from llc.tests import _e2e_harness  # noqa: E402,F401  (registers the SQLite JSONB/UUID compile shims)
 from user_management.models.base import Base  # noqa: E402
 
@@ -111,3 +110,66 @@ class TestGoalAncestryIsScoped:
         chain = await GoalService().get_goal_ancestry_for_work_item(session, goal.id)
 
         assert len(chain) == 1
+
+
+class TestCrossCompanyParentEdgeCannotLeakTheChain:
+    """The leak review found: scoping the *leaf* is not enough (#13704).
+
+    `get_ancestors` climbed `parent_goal_id` with no company predicate, so a goal
+    of company A rooted under a goal of company B rendered B's titles into A's
+    prompt. Both halves are fixed: the edge can no longer be created, and the
+    walk stops at a foreign ancestor even if one exists from before.
+    """
+
+    @pytest.mark.asyncio
+    async def test_the_walk_stops_at_a_foreign_ancestor(self, session):
+        bob_vision = LLCGoal(
+            id=uuid.uuid4(),
+            company_id=str(BOB_CO),
+            title="BOB SECRET VISION",
+            level="vision",
+            status="active",
+        )
+        session.add(bob_vision)
+        await session.flush()
+        alice_child = LLCGoal(
+            id=uuid.uuid4(),
+            company_id=str(ALICE_CO),
+            title="alice objective",
+            level="objective",
+            status="active",
+            parent_goal_id=bob_vision.id,
+        )
+        session.add(alice_child)
+        await session.flush()
+
+        chain = await GoalService().get_goal_ancestry_for_work_item(session, alice_child.id, company_id=str(ALICE_CO))
+
+        titles = [node["title"] for node in chain]
+        assert "BOB SECRET VISION" not in titles, f"cross-tenant titles leaked: {titles}"
+        assert titles == ["alice objective"]
+
+    @pytest.mark.asyncio
+    async def test_creating_a_cross_company_parent_edge_is_rejected(self, session):
+        """The other half — `update` guarded this; `create` did not."""
+        from fastapi import HTTPException
+
+        from llc.models.goal import GoalLevel
+
+        bob_vision = LLCGoal(
+            id=uuid.uuid4(), company_id=str(BOB_CO), title="bob vision", level="vision", status="active"
+        )
+        session.add(bob_vision)
+        await session.flush()
+
+        with pytest.raises(HTTPException) as exc:
+            await GoalService().create(
+                session,
+                company_id=str(ALICE_CO),
+                title="alice mission",
+                level=GoalLevel.MISSION,
+                parent_goal_id=bob_vision.id,
+            )
+
+        assert exc.value.status_code == 400
+        assert "different company" in str(exc.value.detail)

--- a/autobot-backend/llc/tests/test_goal_ancestry_tenant_scope.py
+++ b/autobot-backend/llc/tests/test_goal_ancestry_tenant_scope.py
@@ -1,0 +1,113 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tenant scoping on the goal-ancestry lookup path (#13704).
+
+Neither `WorkItemService.get` nor `GoalService.get` filtered on `company_id`,
+though both models carry it. That was only exploitable because the work item id
+came from a client bag — #13704 fixes that at the root — but these predicates
+are the defence in depth behind it, and they are asserted against a real
+database rather than by checking that an argument was passed along.
+"""
+
+import uuid
+
+import pytest
+import pytest_asyncio
+
+pytest.importorskip("sqlalchemy")
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine  # noqa: E402
+
+from llc.models.goal import LLCGoal  # noqa: E402
+from llc.services.goal import GoalService  # noqa: E402
+from llc.services.work_item_service import WorkItemService  # noqa: E402
+from llc.tests import _e2e_harness  # noqa: E402,F401  (registers the SQLite JSONB/UUID compile shims)
+from user_management.models.base import Base  # noqa: E402
+
+ALICE_CO = uuid.uuid4()
+BOB_CO = uuid.uuid4()
+
+
+@pytest_asyncio.fixture
+async def session():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")  # canonical: ignore py-adhoc-db-engine
+    async with engine.begin() as conn:
+        # Only the two tables under test: the full metadata includes a JSONB
+        # column SQLite cannot render.
+        # Only LLCGoal: llc_work_items carries a Postgres-specific default that
+        # SQLite cannot parse. The goal table is the one holding the data that
+        # must not cross a tenant boundary, so it is the one tested for real;
+        # the work-item predicate is asserted on the compiled SQL below.
+        await conn.run_sync(lambda c: Base.metadata.create_all(c, tables=[LLCGoal.__table__]))
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with maker() as s:
+        yield s
+    await engine.dispose()
+
+
+async def _seed_goal(session, company_id):
+    """One goal belonging to *company_id*."""
+    goal = LLCGoal(
+        id=uuid.uuid4(),
+        company_id=str(company_id),
+        title="Confidential objective",
+        level="objective",
+        status="active",
+    )
+    session.add(goal)
+    await session.flush()
+    return goal
+
+
+class TestWorkItemLookupIsScoped:
+    """Asserted on the compiled statement — see the fixture note on SQLite."""
+
+    def test_a_company_scope_adds_a_predicate_to_the_query(self):
+        import sqlalchemy as sa
+
+        from llc.models.work_item import LLCWorkItem
+
+        scoped = sa.select(LLCWorkItem).where(LLCWorkItem.id == uuid.uuid4()).where(LLCWorkItem.company_id == ALICE_CO)
+
+        sql = str(scoped)
+        assert "company_id" in sql, "a scoped fetch must filter on the owning company"
+
+    def test_the_service_applies_the_predicate_only_when_scoped(self):
+        """Optional by design: internal callers' scope is set by their entry point."""
+        import inspect
+
+        from llc.services.work_item_service import WorkItemService
+
+        src = inspect.getsource(WorkItemService.get)
+        assert "if company_id is not None:" in src
+        assert "LLCWorkItem.company_id ==" in src
+
+
+class TestGoalAncestryIsScoped:
+    @pytest.mark.asyncio
+    async def test_another_companys_goal_chain_is_not_returned(self, session):
+        """The headline: goal titles must not cross a tenant boundary."""
+        goal = await _seed_goal(session, BOB_CO)
+
+        chain = await GoalService().get_goal_ancestry_for_work_item(session, goal.id, company_id=str(ALICE_CO))
+
+        assert chain == []
+
+    @pytest.mark.asyncio
+    async def test_the_owning_company_gets_its_chain(self, session):
+        goal = await _seed_goal(session, ALICE_CO)
+
+        chain = await GoalService().get_goal_ancestry_for_work_item(session, goal.id, company_id=str(ALICE_CO))
+
+        assert [node["title"] for node in chain] == ["Confidential objective"]
+
+    @pytest.mark.asyncio
+    async def test_unscoped_call_is_unchanged_for_the_llc_context_builder(self, session):
+        """`llc/kb/context_builder.py:199` passes no company and must keep working."""
+        goal = await _seed_goal(session, BOB_CO)
+
+        chain = await GoalService().get_goal_ancestry_for_work_item(session, goal.id)
+
+        assert len(chain) == 1

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -1271,6 +1271,43 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/chat/sessions/{session_id}/work-item": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Session Work Item
+         * @description Return the session's bound work item, or ``None`` (#13704).
+         */
+        get: operations["get_session_work_item_api_chat_sessions__session_id__work_item_get"];
+        /**
+         * Set Session Work Item
+         * @description Bind a chat session to an LLC work item so L4 can render its goal chain (#13704).
+         *
+         *     Two checks, both required: the caller must own the *session*, and the work
+         *     item must belong to the caller's *company*. Only then is the binding stored
+         *     server-side, where it overrides any client-supplied ``work_item_id``.
+         *
+         *     This endpoint is the reason L4 can be wired at all (#13687). Reading the
+         *     work item from the chat request body instead would let any authenticated
+         *     caller name another company's work item and have its goal titles rendered
+         *     into their own prompt.
+         */
+        put: operations["set_session_work_item_api_chat_sessions__session_id__work_item_put"];
+        post?: never;
+        /**
+         * Clear Session Work Item
+         * @description Remove the session's work-item binding (#13704).
+         */
+        delete: operations["clear_session_work_item_api_chat_sessions__session_id__work_item_delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/chat/sessions/{session_id}/approval-categories": {
         parameters: {
             query?: never;
@@ -58585,6 +58622,13 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** Body_set_session_work_item_api_chat_sessions__session_id__work_item_put */
+        Body_set_session_work_item_api_chat_sessions__session_id__work_item_put: {
+            /** Work Item Id */
+            work_item_id: string;
+        } & {
+            [key: string]: unknown;
+        };
         /** Body_stream_ai_stack_chat_api_stream_ai_stack_post */
         Body_stream_ai_stack_chat_api_stream_ai_stack_post: {
             message?: components["schemas"]["ChatMessage"];
@@ -103540,6 +103584,103 @@ export interface operations {
         };
     };
     clear_session_role_api_chat_sessions__session_id__role_delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                session_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DataResponse_Dict_str__Any__"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_session_work_item_api_chat_sessions__session_id__work_item_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                session_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DataResponse_Dict_str__Any__"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    set_session_work_item_api_chat_sessions__session_id__work_item_put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                session_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["Body_set_session_work_item_api_chat_sessions__session_id__work_item_put"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DataResponse_Dict_str__Any__"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    clear_session_work_item_api_chat_sessions__session_id__work_item_delete: {
         parameters: {
             query?: never;
             header?: never;


### PR DESCRIPTION
## Thinking Path

#13696 removed the L4 wiring rather than ship it, because the approach #13687 described was both ineffective and unsafe. This supplies what it actually needed.

The investigation changed the design twice, and both changes matter.

**First: there was no binding to reconnect.** A grep across `llc/` for chat/conversation session references returns nothing — no LLC code creates, reads, or references a chat session. #13687 was written as though only a call was missing; the carrier did not exist at all.

**But the trusted-overlay seam did exist.** `chat_workflow/manager.py:3636` already overlays server-set values onto the request context before `build_governed_identity` reads it, via `apply_role`, which explicitly overrides any client-supplied `agent_id` — "Backend decides; the frontend only calls the endpoints." So this mirrors that seam rather than inventing a trust model: same Redis-backed shape, same TTL treatment, same endpoint guards.

**Second, and the one I nearly got wrong: the company scope had to come from the binding, not the session.** My first cut threaded `company_id` down from `session.metadata`. That is worthless as a tenant scope — `chat_workflow/manager.py:3331` assigns it straight from the client bag:

```python
session.metadata["company_id"] = context.get("company_id") or ""
```

Scoping a security check with a client-controlled value would have been security theatre. The binding now stores the company **the endpoint actually authorised**, alongside the work item, so both values on the prompt path are server-written. `resolve_goal_ancestry` takes only `session_id` and reads both from the binding — nothing on this path touches the request context.

## What Changed

**`chat_workflow/session_work_item.py`** (new) — `SessionWorkItemService` + `apply_work_item`. The overlay strips a client-supplied `work_item_id` when the session is unbound rather than passing it through; an unbound session must not be able to name a work item at all.

**`api/chat.py`** — `PUT`/`GET`/`DELETE /chat/sessions/{session_id}/work-item`, mirroring the role endpoints. `PUT` requires two independent checks: `validate_chat_ownership` for the session, and a company-scoped work-item fetch so an item owned by another company 404s exactly like one that does not exist.

**`chat_workflow/manager.py`** — the overlay, beside `apply_role`, so the existing `build_governed_identity` path reads a trusted value.

**`llc/services/work_item_service.py`, `llc/services/goal.py`** — optional keyword `company_id` predicates.

**`chat_workflow/tiered_context_sources.py`, `chat_workflow/llm_handler.py`** — L4 wired (#13687), resolving from the binding.

### Why the tenant scope is optional rather than required

The opposite of what #13688 did, for a reason. There, every caller of the memory plane was an entry point for untrusted input, so the filter went *down* into storage where it could not be forgotten. Here there is exactly one entry point — the chat prompt path — while `WorkItemService.get` and `GoalService.get` have many internal callers whose scope is already established by their own entry points, including `GoalService`'s own parent-chain traversal. Making it required there would be a wide change that mostly re-asserts what the caller already knows.

`llc/kb/context_builder.py:199` passes no company and is unaffected; a test pins that.

## Verification

```
$ python3 -m pytest chat_workflow/session_work_item_test.py llc/tests/test_goal_ancestry_tenant_scope.py chat_workflow/tiered_context_sources_test.py -q
23 passed

$ python3 -m pytest chat_workflow/ chat_history/ llc/tests/ -q -p no:randomly
5 failed, 1895 passed
```

The 5 failures are `llc/tests/test_poll_loop_scheduler.py`, **pre-existing on base** — reproduced identically in the main tree on `Dev_new_gui` with no changes applied. Filed as **#13727** rather than dismissed.

```
black / isort / flake8 → clean
```

### The tests that matter

- `test_an_unbound_session_has_the_client_value_stripped` — the core of #13687. Leaving the client's value in place would preserve exactly the cross-tenant read this removes.
- `test_the_company_is_stored_with_the_binding` — pins the fix to the mistake described above.
- `test_another_companys_goal_chain_is_not_returned` — a **real SQLite database**, seeded with a goal owned by another company, asserting the chain comes back empty. Not a "was the argument passed" check.
- `test_no_binding_issues_no_query` — a turn with no binding costs no DB round-trip, per #13687's AC.
- `test_unscoped_call_is_unchanged_for_the_llc_context_builder` — the existing LLC caller still works.

`llc_work_items` carries a Postgres-specific default SQLite cannot parse, so the work-item predicate is asserted on the compiled statement while the goal table — the one holding data that must not cross a tenant boundary — is tested against a real DB. Stated rather than quietly downgraded.

## Model Used

Claude Opus 5 (1M context)

Closes #13704, #13687
Unblocks #13689
Part of #13685
