### PR TITLE
fix(orchestrator): repair TestOrchestratorPerformance patch target and the empty plan it was hiding (#13699)

### DIFF
--- a/.session/HANDOFF-issue-13699.md
+++ b/.session/HANDOFF-issue-13699.md
@@ -1,0 +1,33 @@
+# Handoff: issue-13699
+status: complete
+pr: #13731
+base_at_push: 319c00127
+gates: tests=PASS (2/2 target nodes; 10/10 module under -m performance; 364 passed across orchestration/, services/workflow_automation/, services/advanced_workflow/, workflow_templates/, performance_benchmarks_test.py, dependency_injection_test.py)
+needs_rebase_before_merge: no
+remaining:
+blocked_on:
+worktree: .worktrees/issue-13699  (safe to remove after merge)
+
+## What landed
+
+Two commits:
+- `fix(orchestrator)`: `plan_workflow_steps` repointed from the retired `id` /
+  `expected_duration_ms` kwargs to the canonical `WorkflowTask` fields (`task_id` /
+  `estimated_duration_seconds`). Every prior call raised TypeError into the broad
+  handler and returned `[]`. Guard now logs `exc_info=True`.
+- `test(orchestrator)`: `TestOrchestratorPerformance.setup_method` injects the config
+  double via the constructor instead of patching the absent
+  `orchestrator.config_manager`; binds a classification double so the measured path is
+  environment-independent; asserts a real `TaskComplexity` and a non-empty plan.
+
+## Carried forward — NOT done
+
+**#13730** — every remaining caller of `plan_workflow_steps` is still broken:
+- un-awaited async calls at `orchestration/workflow_planner.py:113,219`,
+  `services/workflow_automation/manager.py:75-76`,
+  `services/advanced_workflow/step_generator.py:63`
+- reads of `step.id` / `step.user_approval_required`, absent from `WorkflowTask`
+- `orchestration/plan_steps_e2e_test.py` has no assertions and swallows exceptions
+
+Chat-request workflow planning is dead end-to-end until #13730 lands. Do not close
+#13730 on the strength of this PR — it fixes the planner, not its callers.

--- a/autobot-backend/orchestrator.py
+++ b/autobot-backend/orchestrator.py
@@ -557,50 +557,57 @@ class Orchestrator(_DeprecatedRequestMixin):
             if complexity == TaskComplexity.SIMPLE:
                 return [
                     WorkflowStep(
-                        id="step_1",
+                        task_id="step_1",
                         agent_type="llm",
                         action="generate_response",
                         description="Generate direct response to user query",
                         requires_approval=False,
                         dependencies=[],
                         inputs={"query": user_request},
-                        expected_duration_ms=2000,
+                        estimated_duration_seconds=2.0,
                     )
                 ]
             return [
                 WorkflowStep(
-                    id="step_1",
+                    task_id="step_1",
                     agent_type="analyzer",
                     action="analyze_request",
                     description="Analyze user request",
                     requires_approval=False,
                     dependencies=[],
                     inputs={"query": user_request},
-                    expected_duration_ms=3000,
+                    estimated_duration_seconds=3.0,
                 ),
                 WorkflowStep(
-                    id="step_2",
+                    task_id="step_2",
                     agent_type="executor",
                     action="execute_plan",
                     description="Execute the planned actions",
                     requires_approval=True,
                     dependencies=["step_1"],
                     inputs={"query": user_request},
-                    expected_duration_ms=10000,
+                    estimated_duration_seconds=10.0,
                 ),
                 WorkflowStep(
-                    id="step_3",
+                    task_id="step_3",
                     agent_type="synthesizer",
                     action="synthesize_results",
                     description="Synthesize results",
                     requires_approval=False,
                     dependencies=["step_2"],
                     inputs={"query": user_request},
-                    expected_duration_ms=2000,
+                    estimated_duration_seconds=2.0,
                 ),
             ]
         except Exception as e:
-            logger.error("Failed to plan workflow steps: %s", e)
+            # #13699: this handler turned a constructor mismatch into a silent
+            # empty plan for every caller — `WorkflowStep` has aliased the
+            # canonical `WorkflowTask` since #6951 Phase 2A (`task_id` /
+            # `estimated_duration_seconds`), but the calls above still passed
+            # the retired `id` / `expected_duration_ms`, so every invocation
+            # raised TypeError and was logged as a one-line mystery. Keep the
+            # guard, but make the next such breakage diagnosable.
+            logger.error("Failed to plan workflow steps: %s", e, exc_info=True)
             return []
 
     # ------------------------------------------ workflow planning (canonical path)

--- a/autobot-backend/performance_benchmarks_test.py
+++ b/autobot-backend/performance_benchmarks_test.py
@@ -15,11 +15,13 @@ import tempfile
 import threading
 import time
 from typing import Dict
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import psutil
 import pytest
 
+from autobot_types import TaskComplexity
+from config import ConfigManager
 from knowledge import KnowledgeBase
 from memory import MemoryManager
 from memory.enums import MemoryCategory
@@ -312,9 +314,28 @@ class TestOrchestratorPerformance:
         """Set up test environment"""
         self.benchmark = PerformanceBenchmark()
 
-        with patch("orchestrator.config_manager") as mock_config:
-            mock_config.get_llm_config.return_value = {"orchestrator_llm": "llama3.2:1b"}
-            self.orchestrator = Orchestrator()
+        # #13699: the `orchestrator` module has no `config_manager` attribute to
+        # patch — it imports `get_config_manager` and `Orchestrator.__init__`
+        # takes an injectable `config_manager` (#13162). Patching the absent
+        # name raised AttributeError in setup, so both benchmarks below have
+        # been erroring at collection rather than running. Inject the config
+        # double instead, the same way dependency_injection_test.py does.
+        mock_config = Mock(spec=ConfigManager)
+        mock_config.get_llm_config.return_value = {"orchestrator_llm": "llama3.2:1b"}
+        mock_config.get.side_effect = lambda key, default=None: default
+        self.orchestrator = Orchestrator(config_manager=mock_config)
+
+        # #13699: `GemmaClassificationAgent()` raises AgentConfigurationError
+        # unless AUTOBOT_CLASSIFICATION_PROVIDER is configured, and
+        # `_init_classification_agent` swallows that into
+        # `classification_agent = None`. `classify_request_complexity` then
+        # short-circuits on the None branch, so the benchmark would time an
+        # early return rather than the classification seam — and would time a
+        # different path depending on the environment. Bind a double so the
+        # measured path is the same everywhere and never reaches a provider.
+        self.orchestrator.classification_agent = MagicMock(
+            classify_user_request=AsyncMock(return_value=MagicMock(complexity=TaskComplexity.COMPLEX))
+        )
 
     async def test_orchestrator_task_planning_performance(self):
         """Benchmark orchestrator task planning operations"""
@@ -324,9 +345,12 @@ class TestOrchestratorPerformance:
             "Research network security tools, evaluate them, and provide installation recommendations with approval workflow",
         ]
 
+        # #13699: neither benchmarked entry point routes through
+        # `llm_service` today — classification goes via `classification_agent`
+        # and `plan_workflow_steps` is pure step construction. The double stays
+        # as a guard so no iteration can reach a real provider if that changes,
+        # and `chat` is an AsyncMock because it is awaited when it is called.
         with patch.object(self.orchestrator, "llm_service") as mock_llm:
-            # #13162: llm_service.chat is awaited by the orchestrator, so the
-            # double must be an AsyncMock.
             mock_llm.chat = AsyncMock(return_value=MagicMock(content="Mock orchestrator response", error=None))
 
             for request in test_requests:
@@ -343,9 +367,14 @@ class TestOrchestratorPerformance:
 
                     self.benchmark.end_measurement()
 
-                    # Verify planning results
-                    assert complexity is not None
+                    # Verify planning results. #13699: `isinstance(steps, list)`
+                    # alone passes on the empty list every unavailable-types
+                    # branch returns, which is how this body could have looked
+                    # meaningful while measuring nothing. Assert the plan is
+                    # real and that classification produced a TaskComplexity.
+                    assert isinstance(complexity, TaskComplexity)
                     assert isinstance(steps, list)
+                    assert steps, f"Planning produced no steps for: {request[:50]}..."
 
                 stats = self.benchmark.get_statistics()
 
@@ -380,9 +409,11 @@ class TestOrchestratorPerformance:
             results = await asyncio.gather(*tasks)
             total_time = time.perf_counter() - start_time
 
-            # Verify all workflows completed
+            # Verify all workflows completed. #13699: a step count of 0 is not a
+            # completed workflow, so assert the plans were non-empty rather than
+            # merely integer-shaped.
             assert len(results) == count
-            assert all(isinstance(r, int) for r in results)
+            assert all(isinstance(r, int) and r > 0 for r in results)
 
             self.benchmark.get_statistics()
 


### PR DESCRIPTION
Closes #13699

## Thinking Path

The reported symptom was a bad patch target: `TestOrchestratorPerformance.setup_method`
patches `orchestrator.config_manager`, which the module does not define. It imports
`get_config_manager`, and `Orchestrator.__init__` takes an injectable `config_manager`
(#13162) — so the fix is constructor injection, matching `dependency_injection_test.py`.

That made both nodes run. But the issue's real concern was *fake coverage*, so I checked
whether the bodies now measure anything. They did not, for two further reasons:

1. `GemmaClassificationAgent()` raises `AgentConfigurationError` unless a classification
   provider is configured, and `_init_classification_agent` swallows that into
   `classification_agent = None`. `classify_request_complexity` then short-circuits on the
   None branch — so the benchmark timed an early return, and timed a *different* path
   depending on the environment.
2. `assert isinstance(steps, list)` passes on the empty list. Asserting a non-empty plan
   instead turned the test red and exposed a live production bug:
   `plan_workflow_steps` returned `[]` on **every** call. `WorkflowStep` has aliased
   `autobot_shared.workflow.WorkflowTask` since #6951 Phase 2A (`task_id` /
   `estimated_duration_seconds`), but the method still passed the retired `id` /
   `expected_duration_ms`, so each invocation raised `TypeError` into the broad handler.
   `workflow_templates/types.py:29-31` documents the invariant that "every
   `WorkflowStep(task_id=..., ...)` call site constructs a real `WorkflowTask`" — this was
   the one site never migrated.

So the issue was two layers deep: the tests could not run, and the method they cover
produced nothing.

## What Changed

**`autobot-backend/orchestrator.py`**
- `plan_workflow_steps`: three construction sites repointed from `id` /
  `expected_duration_ms` to the canonical `task_id` / `estimated_duration_seconds`.
- The `except` guard now logs `exc_info=True`, so a future constructor mismatch is
  diagnosable rather than a one-line mystery that silently empties every plan.

**`autobot-backend/performance_benchmarks_test.py`**
- `setup_method`: injects the config double through the constructor instead of patching an
  absent module attribute.
- Binds a classification double so the measured path is identical in every environment and
  never reaches a provider.
- Asserts a real `TaskComplexity` and a non-empty plan; the concurrent test asserts step
  counts are `> 0` rather than merely integer-shaped.
- Corrects the stale `#13162` comment claiming these entry points route through
  `llm_service` — they do not; the double stays only as a provider guard.

## Verification

Before — both nodes error at setup, so neither body ever ran:

```
$ python3 -m pytest performance_benchmarks_test.py::TestOrchestratorPerformance -q -p no:randomly
performance_benchmarks_test.py EE                                        [100%]
E   AttributeError: <module 'orchestrator' ...> does not have the attribute 'config_manager'
============================== 2 errors in 2.58s ===============================
```

After:

```
$ python3 -m pytest performance_benchmarks_test.py::TestOrchestratorPerformance -q -p no:randomly
============================== 2 passed in 1.23s ===============================
```

**AC 2 — assertions execute, proven by deliberate failure**, not by a green run. Each of
the four assertions was inverted in turn and each fired:

```
E   AssertionError: DELIBERATE: complexity assert reached
E   AssertionError: DELIBERATE: planning budget assert reached
E   AssertionError: DELIBERATE: results assert reached
E   AssertionError: DELIBERATE: concurrent budget assert reached
```

The strongest evidence is unsynthetic: the new `assert steps` failed for real against the
pre-fix orchestrator, which is how the empty-plan bug was found:

```
E   AssertionError: Planning produced no steps for: List files in current directory...
E   assert []
ERROR orchestrator: Failed to plan workflow steps: WorkflowTask.__init__() got an
      unexpected keyword argument 'id'
```

**AC 3 — no non-existent patch target.** The only remaining `patch` in the class is
`patch.object(self.orchestrator, "llm_service")`, an attribute set in `_init_core_components`.

Whole module under the marker CI selects, plus a regression sweep over every area the
orchestrator change touches:

```
$ python3 -m pytest -m performance performance_benchmarks_test.py -q
============================== 10 passed in 3.78s ==============================

$ python3 -m pytest orchestration/ services/workflow_automation/ services/advanced_workflow/ \
    workflow_templates/ performance_benchmarks_test.py dependency_injection_test.py -q -p no:randomly
======================= 364 passed, 4 warnings in 14.22s =======================
```

Note: local Python is 3.10 and 19/69 backend deps are absent, so this is not a CI proxy —
CI is the authority on the full suite.

## Discovered — out of scope, filed as #13730

Fixing the method exposed that **every remaining caller of it is still broken**, two ways:
all four production call sites invoke the async planning API without `await` (the benchmark
repaired here is the only awaited caller in the tree), and they read `step.id` /
`step.user_approval_required`, which `WorkflowTask` does not define. Also
`orchestration/plan_steps_e2e_test.py` has no assertions and swallows every exception — it
passed throughout the entire period the method returned nothing.

That is a caller-side migration across four modules with real behavioural blast radius, so
it is not bundled here. Chat-request workflow planning is dead end-to-end until #13730
lands; this PR fixes the planner itself and the tests that cover it.

## Model Used

Claude Opus 5 (1M context)
