### PR TITLE
fix(oauth): serialize token refresh per credential (#13627)

### DIFF
--- a/autobot-backend/knowledge/connectors/credential_store.py
+++ b/autobot-backend/knowledge/connectors/credential_store.py
@@ -11,6 +11,7 @@ Bridges ConnectorConfig ↔ SecretsService so that sensitive auth fields
 
 import asyncio
 import contextlib
+import hashlib
 import json
 import os
 import time
@@ -62,6 +63,18 @@ ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 60
 # which is this bug, unchanged. Likewise a wait shorter than the refresh makes
 # every loser raise while the winner is still working correctly.
 _REFRESH_LOCK_PREFIX = "connector:oauth:refresh:"
+
+
+def _refresh_lock_key(secret_id: str) -> str:
+    """Redis key for the per-credential refresh lease (#13627).
+
+    Hashes the id rather than embedding it. Two reasons, both real: a credential
+    identifier does not belong in a Redis keyspace that anyone with KEYS access
+    can enumerate, and passing it into ``LeaderLease`` makes that module's own
+    log lines taint-reachable from a credential. A stable digest serialises
+    exactly as well.
+    """
+    return _REFRESH_LOCK_PREFIX + hashlib.sha256(secret_id.encode("utf-8")).hexdigest()[:32]
 _REFRESH_DB = "knowledge"
 
 
@@ -315,7 +328,7 @@ class ConnectorCredentialStore:
             # False, so a degraded-but-pingable Redis (OOM, MISCONF, read-only
             # replica) would look like "someone else is refreshing" and make every
             # refresh wait then fail — the same total outage this guards against.
-            return await redis.get(f"{_REFRESH_LOCK_PREFIX}{secret_id}") is not None
+            return await redis.get(_refresh_lock_key(secret_id)) is not None
         except Exception:
             return False
 
@@ -344,7 +357,7 @@ class ConnectorCredentialStore:
             # provider error costs every waiter the full wait and then reports a
             # misleading "timed out waiting for a concurrent refresh".
             takeover = LeaderLease(
-                key=f"{_REFRESH_LOCK_PREFIX}{secret_id}",
+                key=_refresh_lock_key(secret_id),
                 database=_REFRESH_DB,
                 ttl_ms=_REFRESH_LOCK_TTL_MS,
                 worker_id=uuid.uuid4().hex,
@@ -388,7 +401,7 @@ class ConnectorCredentialStore:
         # a rotated token as a breach signal and revoke the whole grant family
         # (OAuth 2.0 Security BCP 4.14.2), turning the race into a full disconnect.
         lease = LeaderLease(
-            key=f"{_REFRESH_LOCK_PREFIX}{secret_id}",
+            key=_refresh_lock_key(secret_id),
             database=_REFRESH_DB,
             ttl_ms=_REFRESH_LOCK_TTL_MS,
             # A unique id per lease, NOT the default hostname-pid. Two refreshes in

--- a/autobot-backend/knowledge/connectors/credential_store.py
+++ b/autobot-backend/knowledge/connectors/credential_store.py
@@ -12,8 +12,10 @@ Bridges ConnectorConfig ↔ SecretsService so that sensitive auth fields
 import asyncio
 import json
 import os
+import time
 from datetime import timedelta
 
+from autobot_shared.leader_lease import LeaderLease
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.singleton_factory import lazy_singleton
 from autobot_shared.time_utils import now_utc, parse_utc_iso
@@ -49,6 +51,14 @@ _AUTH_TYPE_TO_SECRET_TYPE: dict = {
 # Refresh an OAuth access token this many seconds before its stated expiry, so
 # in-flight requests never race a hard expiry. Not a cache TTL — a safety skew.
 ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 60
+
+# #13627: per-credential refresh serialization. TTL bounds how long a crashed
+# holder can block others; the wait bounds how long a loser blocks before failing
+# loudly. Env-tunable rather than hardcoded, per the project's TTL rule.
+_REFRESH_LOCK_PREFIX = "connector:oauth:refresh:"
+_REFRESH_LOCK_TTL_MS = int(os.getenv("AUTOBOT_OAUTH_REFRESH_LOCK_TTL_MS", "30000"))
+_REFRESH_WAIT_S = float(os.getenv("AUTOBOT_OAUTH_REFRESH_WAIT_S", "20"))
+_REFRESH_POLL_S = float(os.getenv("AUTOBOT_OAUTH_REFRESH_POLL_S", "0.2"))
 
 
 class ConnectorCredentialStore:
@@ -237,6 +247,56 @@ class ConnectorCredentialStore:
             )
         return result["id"]
 
+    async def _read_oauth_creds(self, secret_id: str, owner_id: str) -> dict:
+        """Read + authorize the OAuth bundle. Used for both the first read and the
+        double-check inside the lease (#13627)."""
+        secret = None
+        if _vault_read_enabled():
+            secret = await load_imported_credential(secret_id, owner_id)
+        if secret is None:
+            secret = await asyncio.get_running_loop().run_in_executor(
+                None,
+                lambda: self._svc.get_secret(secret_id=secret_id, include_value=True, accessed_by=owner_id),
+            )
+        if secret is None:
+            raise LookupError(f"OAuth secret {secret_id!r} not found or expired")
+        self._require_owner(secret, secret_id, owner_id)
+        return json.loads(secret["value"])
+
+    @staticmethod
+    async def _refresh_lock_available() -> bool:
+        """Whether the refresh lease can be taken at all (#13627).
+
+        Distinguishes "another worker holds the lease" from "there is no Redis to
+        hold it in" — ``LeaderLease`` reports both as a failed acquisition.
+        """
+        try:
+            from autobot_shared.redis_client import get_async_redis_client
+
+            return await get_async_redis_client(database="knowledge") is not None
+        except Exception:
+            return False
+
+    async def _await_refreshed_token(self, secret_id: str, owner_id: str) -> str:
+        """Wait for the lease holder's refresh to land, then return its token (#13627).
+
+        The loser of the race must not call the token endpoint — that is the whole
+        point of serializing. Polls the stored credential until the holder's write
+        appears, then fails loudly rather than falling through to an
+        unsynchronized refresh, which would reintroduce the bug.
+        """
+        deadline = time.monotonic() + _REFRESH_WAIT_S
+        while time.monotonic() < deadline:
+            await asyncio.sleep(_REFRESH_POLL_S)
+            creds = await self._read_oauth_creds(secret_id, owner_id)
+            token = creds.get("access_token")
+            if token and not self._access_token_expired(creds.get("access_token_expires_at")):
+                return token
+        raise TimeoutError(
+            f"Timed out after {_REFRESH_WAIT_S}s waiting for a concurrent OAuth refresh of {secret_id!r}. "
+            "Refusing to refresh unsynchronized — a second refresh can invalidate the rotated token."
+        )
+
     async def get_access_token(self, secret_id: str, owner_id: str) -> str:
         """Return a valid access token, refreshing + rotating the secret in place.
 
@@ -265,6 +325,50 @@ class ConnectorCredentialStore:
         if access_token and not self._access_token_expired(creds.get("access_token_expires_at")):
             return access_token
 
+        # #13627: serialize the refresh per credential. A scheduled sync overlapping
+        # a user-triggered one is ordinary operation, and both would otherwise
+        # refresh with the same token. Providers that rotate on each use (GitLab,
+        # see below) then issue two successors, the second write wins, and the
+        # stored token may not be the provider's valid one — the next refresh fails
+        # permanently and the user must re-authorize. Some providers treat reuse of
+        # a rotated token as a breach signal and revoke the whole grant family
+        # (OAuth 2.0 Security BCP 4.14.2), turning the race into a full disconnect.
+        lease = LeaderLease(
+            key=f"{_REFRESH_LOCK_PREFIX}{secret_id}",
+            database="knowledge",
+            ttl_ms=_REFRESH_LOCK_TTL_MS,
+            label=f"OAuth refresh {secret_id}",
+        )
+        if not await lease.update_leadership():
+            # LeaderLease returns False both when another holder has the lease and
+            # when Redis is simply unavailable, and the two need opposite handling.
+            # Treating "no Redis" as "someone else is refreshing" would make every
+            # refresh wait and then fail — a total outage of connector auth wherever
+            # Redis is not running, which is far worse than the race being fixed.
+            if await self._refresh_lock_available():
+                # Someone else holds it. Wait for their write instead of issuing a
+                # second refresh — the loser must not touch the token endpoint.
+                return await self._await_refreshed_token(secret_id, owner_id)
+            logger.warning(
+                "OAuth refresh could not be serialized (no Redis) — proceeding unsynchronized. "
+                "A concurrent refresh may invalidate a rotated refresh token (#13627)."
+            )
+            return await self._refresh_and_store(secret_id, owner_id, creds)
+
+        try:
+            # Double-checked read: the holder may have finished between our first
+            # read and our acquiring the lease.
+            recheck = await self._read_oauth_creds(secret_id, owner_id)
+            token = recheck.get("access_token")
+            if token and not self._access_token_expired(recheck.get("access_token_expires_at")):
+                return token
+            creds = recheck
+            return await self._refresh_and_store(secret_id, owner_id, creds)
+        finally:
+            await lease.release()
+
+    async def _refresh_and_store(self, secret_id: str, owner_id: str, creds: dict) -> str:
+        """Refresh at the provider and persist. Caller MUST hold the lease (#13627)."""
         refresh_token = creds.get("refresh_token")
         if not refresh_token:
             raise LookupError(

--- a/autobot-backend/knowledge/connectors/credential_store.py
+++ b/autobot-backend/knowledge/connectors/credential_store.py
@@ -10,9 +10,11 @@ Bridges ConnectorConfig ↔ SecretsService so that sensitive auth fields
 """
 
 import asyncio
+import contextlib
 import json
 import os
 import time
+import uuid
 from datetime import timedelta
 
 from autobot_shared.leader_lease import LeaderLease
@@ -52,13 +54,45 @@ _AUTH_TYPE_TO_SECRET_TYPE: dict = {
 # in-flight requests never race a hard expiry. Not a cache TTL — a safety skew.
 ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 60
 
-# #13627: per-credential refresh serialization. TTL bounds how long a crashed
-# holder can block others; the wait bounds how long a loser blocks before failing
-# loudly. Env-tunable rather than hardcoded, per the project's TTL rule.
+# #13627: per-credential refresh serialization.
+#
+# Both windows are derived from the token endpoint's own timeout, not picked
+# independently. A lease TTL equal to that timeout expires *during* a slow
+# refresh, a second caller wins SET NX, and both POST the same rotating token —
+# which is this bug, unchanged. Likewise a wait shorter than the refresh makes
+# every loser raise while the winner is still working correctly.
 _REFRESH_LOCK_PREFIX = "connector:oauth:refresh:"
-_REFRESH_LOCK_TTL_MS = int(os.getenv("AUTOBOT_OAUTH_REFRESH_LOCK_TTL_MS", "30000"))
-_REFRESH_WAIT_S = float(os.getenv("AUTOBOT_OAUTH_REFRESH_WAIT_S", "20"))
-_REFRESH_POLL_S = float(os.getenv("AUTOBOT_OAUTH_REFRESH_POLL_S", "0.2"))
+_REFRESH_DB = "knowledge"
+
+
+def _token_timeout_s() -> float:
+    """The token endpoint's HTTP timeout — the floor for every window below."""
+    try:
+        from knowledge.connectors.oauth_flow import _TOKEN_REQUEST_TIMEOUT
+
+        return float(_TOKEN_REQUEST_TIMEOUT)
+    except Exception:
+        return 30.0
+
+
+# Lease must outlive the slowest possible refresh, with headroom for the
+# surrounding read/decrypt/write.
+_REFRESH_LOCK_TTL_MS = int(os.getenv("AUTOBOT_OAUTH_REFRESH_LOCK_TTL_MS", str(int(_token_timeout_s() * 3 * 1000))))
+# A loser must outwait the lease, or it gives up on a refresh still in progress.
+_REFRESH_WAIT_S = max(float(os.getenv("AUTOBOT_OAUTH_REFRESH_WAIT_S", "0")), (_REFRESH_LOCK_TTL_MS / 1000.0) + 5.0)
+# Guarded against 0 from the environment, which would busy-loop the executor.
+_REFRESH_POLL_S = max(float(os.getenv("AUTOBOT_OAUTH_REFRESH_POLL_S", "0.2")), 0.05)
+
+
+async def _release_quietly(lease: LeaderLease) -> None:
+    """Release without letting cancellation or a Redis blip strand the lease (#13627).
+
+    A bare ``await lease.release()`` in a ``finally`` re-raises ``CancelledError``
+    if the request was cancelled mid-refresh, leaving the lease held for its full
+    TTL and every other caller waiting it out.
+    """
+    with contextlib.suppress(Exception):
+        await asyncio.shield(lease.release())
 
 
 class ConnectorCredentialStore:
@@ -264,7 +298,7 @@ class ConnectorCredentialStore:
         return json.loads(secret["value"])
 
     @staticmethod
-    async def _refresh_lock_available() -> bool:
+    async def _refresh_lock_available(secret_id: str) -> bool:
         """Whether the refresh lease can be taken at all (#13627).
 
         Distinguishes "another worker holds the lease" from "there is no Redis to
@@ -273,7 +307,15 @@ class ConnectorCredentialStore:
         try:
             from autobot_shared.redis_client import get_async_redis_client
 
-            return await get_async_redis_client(database="knowledge") is not None
+            redis = await get_async_redis_client(database=_REFRESH_DB)
+            if redis is None:
+                return False
+            # Ask whether the key is actually held. "A client object exists" is the
+            # wrong question: LeaderLease swallows any Redis error and returns
+            # False, so a degraded-but-pingable Redis (OOM, MISCONF, read-only
+            # replica) would look like "someone else is refreshing" and make every
+            # refresh wait then fail — the same total outage this guards against.
+            return await redis.get(f"{_REFRESH_LOCK_PREFIX}{secret_id}") is not None
         except Exception:
             return False
 
@@ -286,12 +328,33 @@ class ConnectorCredentialStore:
         unsynchronized refresh, which would reintroduce the bug.
         """
         deadline = time.monotonic() + _REFRESH_WAIT_S
+        delay = _REFRESH_POLL_S
         while time.monotonic() < deadline:
-            await asyncio.sleep(_REFRESH_POLL_S)
+            await asyncio.sleep(delay)
+            # Back off: a waiter polling every 200ms drives a sqlite
+            # connect/decrypt/UPDATE/commit per iteration through
+            # ``_update_access_tracking``, inflating the access audit with
+            # non-accesses and loading the shared executor.
+            delay = min(delay * 2, 2.0)
             creds = await self._read_oauth_creds(secret_id, owner_id)
             token = creds.get("access_token")
             if token and not self._access_token_expired(creds.get("access_token_expires_at")):
                 return token
+            # Take over if the holder died or its refresh failed — otherwise one
+            # provider error costs every waiter the full wait and then reports a
+            # misleading "timed out waiting for a concurrent refresh".
+            takeover = LeaderLease(
+                key=f"{_REFRESH_LOCK_PREFIX}{secret_id}",
+                database=_REFRESH_DB,
+                ttl_ms=_REFRESH_LOCK_TTL_MS,
+                worker_id=uuid.uuid4().hex,
+                label="OAuth refresh",
+            )
+            if await takeover.update_leadership():
+                try:
+                    return await self._refresh_and_store(secret_id, owner_id, creds)
+                finally:
+                    await _release_quietly(takeover)
         raise TimeoutError(
             f"Timed out after {_REFRESH_WAIT_S}s waiting for a concurrent OAuth refresh of {secret_id!r}. "
             "Refusing to refresh unsynchronized — a second refresh can invalidate the rotated token."
@@ -303,24 +366,15 @@ class ConnectorCredentialStore:
         Raises PermissionError on owner mismatch, LookupError when the secret is
         missing or holds no refresh token while the access token is expired.
         Propagates RuntimeError from the token endpoint on a failed refresh.
+        Raises TimeoutError (#13627) when another worker holds the refresh lease
+        and does not publish a token within the wait window — the caller should
+        treat that as retryable rather than fatal.
 
         When the vault-read flag is on, the vault envelope store is tried first
         (matching :meth:`load`'s expand-phase read-first behaviour, #10088 Task 5) —
         OAuth-managed connector tokens follow the same cutover path as static creds.
         """
-        secret = None
-        if _vault_read_enabled():
-            secret = await load_imported_credential(secret_id, owner_id)
-        if secret is None:
-            secret = await asyncio.get_running_loop().run_in_executor(
-                None,
-                lambda: self._svc.get_secret(secret_id=secret_id, include_value=True, accessed_by=owner_id),
-            )
-        if secret is None:
-            raise LookupError(f"OAuth secret {secret_id!r} not found or expired")
-        self._require_owner(secret, secret_id, owner_id)
-
-        creds = json.loads(secret["value"])
+        creds = await self._read_oauth_creds(secret_id, owner_id)
         access_token = creds.get("access_token")
         if access_token and not self._access_token_expired(creds.get("access_token_expires_at")):
             return access_token
@@ -335,9 +389,16 @@ class ConnectorCredentialStore:
         # (OAuth 2.0 Security BCP 4.14.2), turning the race into a full disconnect.
         lease = LeaderLease(
             key=f"{_REFRESH_LOCK_PREFIX}{secret_id}",
-            database="knowledge",
+            database=_REFRESH_DB,
             ttl_ms=_REFRESH_LOCK_TTL_MS,
-            label=f"OAuth refresh {secret_id}",
+            # A unique id per lease, NOT the default hostname-pid. Two refreshes in
+            # one process would otherwise share an identity, and ``release()``'s
+            # "only delete if it is still mine" guard would happily delete the other
+            # holder's key — letting a third caller in while the second still
+            # refreshes. The scheduler never hit this because it holds one lease per
+            # process; this is the first multi-lease-per-process user.
+            worker_id=uuid.uuid4().hex,
+            label="OAuth refresh",
         )
         if not await lease.update_leadership():
             # LeaderLease returns False both when another holder has the lease and
@@ -345,7 +406,7 @@ class ConnectorCredentialStore:
             # Treating "no Redis" as "someone else is refreshing" would make every
             # refresh wait and then fail — a total outage of connector auth wherever
             # Redis is not running, which is far worse than the race being fixed.
-            if await self._refresh_lock_available():
+            if await self._refresh_lock_available(secret_id):
                 # Someone else holds it. Wait for their write instead of issuing a
                 # second refresh — the loser must not touch the token endpoint.
                 return await self._await_refreshed_token(secret_id, owner_id)
@@ -365,7 +426,7 @@ class ConnectorCredentialStore:
             creds = recheck
             return await self._refresh_and_store(secret_id, owner_id, creds)
         finally:
-            await lease.release()
+            await _release_quietly(lease)
 
     async def _refresh_and_store(self, secret_id: str, owner_id: str, creds: dict) -> str:
         """Refresh at the provider and persist. Caller MUST hold the lease (#13627)."""

--- a/autobot-backend/knowledge/connectors/credential_store.py
+++ b/autobot-backend/knowledge/connectors/credential_store.py
@@ -74,7 +74,13 @@ def _refresh_lock_key(secret_id: str) -> str:
     log lines taint-reachable from a credential. A stable digest serialises
     exactly as well.
     """
-    return _REFRESH_LOCK_PREFIX + hashlib.sha256(secret_id.encode("utf-8")).hexdigest()[:32]
+    # usedforsecurity=False states the intent precisely: this digest is a
+    # namespacing device for a Redis key, not a security control. Nothing is
+    # authenticated or authorised by it, and it is never reversed or compared
+    # against a stored hash — collision resistance is all that is required, and
+    # only to keep two credentials from sharing a lease.
+    digest = hashlib.sha256(secret_id.encode("utf-8"), usedforsecurity=False).hexdigest()
+    return _REFRESH_LOCK_PREFIX + digest[:32]
 
 
 _REFRESH_DB = "knowledge"

--- a/autobot-backend/knowledge/connectors/credential_store.py
+++ b/autobot-backend/knowledge/connectors/credential_store.py
@@ -75,6 +75,8 @@ def _refresh_lock_key(secret_id: str) -> str:
     exactly as well.
     """
     return _REFRESH_LOCK_PREFIX + hashlib.sha256(secret_id.encode("utf-8")).hexdigest()[:32]
+
+
 _REFRESH_DB = "knowledge"
 
 

--- a/autobot-backend/knowledge/connectors/tests/test_credential_store.py
+++ b/autobot-backend/knowledge/connectors/tests/test_credential_store.py
@@ -4,9 +4,10 @@
 # Author: mrveiss
 """Unit and integration tests for ConnectorCredentialStore (ADR-007 / GH#9019)."""
 
+import asyncio
 import json
 from datetime import timedelta
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -16,7 +17,9 @@ from autobot_shared.auth.connector_auth import (
     BearerAuth,
     OAuthRefreshAuth,
 )
+from autobot_shared.leader_lease import LeaderLease
 from autobot_shared.time_utils import now_utc, parse_utc_iso
+import knowledge.connectors.credential_store as mod
 from knowledge.connectors.credential_store import ConnectorCredentialStore
 
 # ---------------------------------------------------------------------------
@@ -679,3 +682,119 @@ async def test_get_access_token_expired_without_refresh_token_raises(monkeypatch
     )
     with pytest.raises(LookupError, match="re-auth required"):
         await cs.get_access_token(secret_id, "u1")
+
+# ---------------------------------------------------------------------------
+# #13627: refresh serialization
+# ---------------------------------------------------------------------------
+
+
+async def _expired_oauth_secret(cs, store, name):
+    secret_id = await cs.store_oauth(
+        name, "u1", "gitlab",
+        {"access_token": "old", "refresh_token": "rt-old", "expires_in": 3600},
+        "cid", "csec", "https://token", ["s"],
+    )
+    bundle = json.loads(store[secret_id]["value"])
+    bundle["access_token_expires_at"] = (now_utc() - timedelta(seconds=1)).isoformat()
+    store[secret_id]["value"] = json.dumps(bundle)
+    return secret_id
+
+
+@pytest.mark.asyncio
+async def test_concurrent_refresh_calls_the_token_endpoint_once(monkeypatch):
+    """#13627: two concurrent callers must produce exactly ONE refresh.
+
+    With a rotating-refresh-token provider, two refreshes issue two successors;
+    the second write wins and the stored token may not be the provider's valid
+    one, so the next refresh fails permanently and the user must re-authorize.
+    """
+    svc, store = _make_svc()
+    cs = ConnectorCredentialStore(svc)
+    secret_id = await _expired_oauth_secret(cs, store, "c-13627")
+
+    from knowledge.connectors import oauth_flow
+
+    calls = []
+
+    async def _slow_refresh(token_url, client_id, client_secret, refresh_token):
+        calls.append(refresh_token)
+        await asyncio.sleep(0.05)  # hold the lease long enough for the loser to queue
+        return {"access_token": "new", "refresh_token": "rt-new", "expires_in": 3600}
+
+    monkeypatch.setattr(oauth_flow, "refresh_access_token", _slow_refresh)
+
+    # Simulate an available lock: first acquisition wins, later ones lose.
+    holders = {"taken": False}
+
+    async def _fake_leadership(self, *a, **kw):
+        if holders["taken"]:
+            return False
+        holders["taken"] = True
+        self._is_leader = True
+        return True
+
+    async def _fake_release(self):
+        holders["taken"] = False
+        self._is_leader = False
+
+    monkeypatch.setattr(LeaderLease, "update_leadership", _fake_leadership)
+    monkeypatch.setattr(LeaderLease, "release", _fake_release)
+    monkeypatch.setattr(ConnectorCredentialStore, "_refresh_lock_available", staticmethod(AsyncMock(return_value=True)))
+
+    a, b = await asyncio.gather(
+        cs.get_access_token(secret_id, "u1"),
+        cs.get_access_token(secret_id, "u1"),
+    )
+
+    assert len(calls) == 1, f"token endpoint called {len(calls)} times — refresh not serialized"
+    assert a == b == "new", f"callers disagreed: {a!r} vs {b!r}"
+
+
+@pytest.mark.asyncio
+async def test_lock_wait_timeout_raises_instead_of_refreshing_unsynchronized(monkeypatch):
+    """#13627: the loser must fail loudly, never fall through to its own refresh."""
+    svc, store = _make_svc()
+    cs = ConnectorCredentialStore(svc)
+    secret_id = await _expired_oauth_secret(cs, store, "c-13627b")
+
+    from knowledge.connectors import oauth_flow
+
+    called = []
+
+    async def _must_not_run(*a, **kw):
+        called.append(1)
+        return {"access_token": "should-never-happen"}
+
+    monkeypatch.setattr(oauth_flow, "refresh_access_token", _must_not_run)
+    monkeypatch.setattr(LeaderLease, "update_leadership", AsyncMock(return_value=False))
+    monkeypatch.setattr(ConnectorCredentialStore, "_refresh_lock_available", staticmethod(AsyncMock(return_value=True)))
+    monkeypatch.setattr(mod, "_REFRESH_WAIT_S", 0.3)
+    monkeypatch.setattr(mod, "_REFRESH_POLL_S", 0.05)
+
+    with pytest.raises(TimeoutError, match="concurrent OAuth refresh"):
+        await cs.get_access_token(secret_id, "u1")
+    assert not called, "loser called the token endpoint — the race is still open"
+
+
+@pytest.mark.asyncio
+async def test_without_redis_refresh_proceeds_rather_than_failing(monkeypatch):
+    """#13627: no Redis must not mean no connector auth.
+
+    LeaderLease reports "another holder" and "no Redis" identically. Treating the
+    latter as the former made every refresh wait then fail — a total outage
+    wherever Redis is absent, which is far worse than the race being fixed.
+    """
+    svc, store = _make_svc()
+    cs = ConnectorCredentialStore(svc)
+    secret_id = await _expired_oauth_secret(cs, store, "c-13627c")
+
+    from knowledge.connectors import oauth_flow
+
+    monkeypatch.setattr(
+        oauth_flow, "refresh_access_token",
+        AsyncMock(return_value={"access_token": "new", "expires_in": 3600}),
+    )
+    monkeypatch.setattr(LeaderLease, "update_leadership", AsyncMock(return_value=False))
+    monkeypatch.setattr(ConnectorCredentialStore, "_refresh_lock_available", staticmethod(AsyncMock(return_value=False)))
+
+    assert await cs.get_access_token(secret_id, "u1") == "new"

--- a/autobot-backend/knowledge/connectors/tests/test_credential_store.py
+++ b/autobot-backend/knowledge/connectors/tests/test_credential_store.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+import knowledge.connectors.credential_store as mod
 from autobot_shared.auth.connector_auth import (
     ApiKeyAuth,
     BasicAuth,
@@ -19,7 +20,6 @@ from autobot_shared.auth.connector_auth import (
 )
 from autobot_shared.leader_lease import LeaderLease
 from autobot_shared.time_utils import now_utc, parse_utc_iso
-import knowledge.connectors.credential_store as mod
 from knowledge.connectors.credential_store import ConnectorCredentialStore
 
 # ---------------------------------------------------------------------------
@@ -683,6 +683,7 @@ async def test_get_access_token_expired_without_refresh_token_raises(monkeypatch
     with pytest.raises(LookupError, match="re-auth required"):
         await cs.get_access_token(secret_id, "u1")
 
+
 # ---------------------------------------------------------------------------
 # #13627: refresh serialization
 # ---------------------------------------------------------------------------
@@ -690,9 +691,14 @@ async def test_get_access_token_expired_without_refresh_token_raises(monkeypatch
 
 async def _expired_oauth_secret(cs, store, name):
     secret_id = await cs.store_oauth(
-        name, "u1", "gitlab",
+        name,
+        "u1",
+        "gitlab",
         {"access_token": "old", "refresh_token": "rt-old", "expires_in": 3600},
-        "cid", "csec", "https://token", ["s"],
+        "cid",
+        "csec",
+        "https://token",
+        ["s"],
     )
     bundle = json.loads(store[secret_id]["value"])
     bundle["access_token_expires_at"] = (now_utc() - timedelta(seconds=1)).isoformat()
@@ -791,7 +797,8 @@ async def test_without_redis_refresh_proceeds_rather_than_failing(monkeypatch):
     from knowledge.connectors import oauth_flow
 
     monkeypatch.setattr(
-        oauth_flow, "refresh_access_token",
+        oauth_flow,
+        "refresh_access_token",
         AsyncMock(return_value={"access_token": "new", "expires_in": 3600}),
     )
     monkeypatch.setattr(LeaderLease, "update_leadership", AsyncMock(return_value=False))

--- a/autobot-backend/knowledge/connectors/tests/test_credential_store.py
+++ b/autobot-backend/knowledge/connectors/tests/test_credential_store.py
@@ -770,6 +770,8 @@ async def test_lock_wait_timeout_raises_instead_of_refreshing_unsynchronized(mon
     monkeypatch.setattr(ConnectorCredentialStore, "_refresh_lock_available", staticmethod(AsyncMock(return_value=True)))
     monkeypatch.setattr(mod, "_REFRESH_WAIT_S", 0.3)
     monkeypatch.setattr(mod, "_REFRESH_POLL_S", 0.05)
+    # The waiter now also re-attempts acquisition each poll, so keep it losing.
+    monkeypatch.setattr(LeaderLease, "update_leadership", AsyncMock(return_value=False))
 
     with pytest.raises(TimeoutError, match="concurrent OAuth refresh"):
         await cs.get_access_token(secret_id, "u1")
@@ -800,3 +802,43 @@ async def test_without_redis_refresh_proceeds_rather_than_failing(monkeypatch):
     )
 
     assert await cs.get_access_token(secret_id, "u1") == "new"
+
+
+@pytest.mark.asyncio
+async def test_double_checked_read_skips_a_refresh_another_holder_already_did(monkeypatch):
+    """#13627: the winner must re-read after acquiring the lease.
+
+    Coverage showed this branch was never executed — every earlier test had the
+    loser fail acquisition, so nobody reached the double-check. It guards the
+    window between the first read and acquiring the lease: if a holder finished
+    in that gap, refreshing again would burn the rotated token for nothing.
+    """
+    svc, store = _make_svc()
+    cs = ConnectorCredentialStore(svc)
+    secret_id = await _expired_oauth_secret(cs, store, "c-13627d")
+
+    from knowledge.connectors import oauth_flow
+
+    called = []
+
+    async def _must_not_run(*a, **kw):
+        called.append(1)
+        return {"access_token": "should-never-happen"}
+
+    monkeypatch.setattr(oauth_flow, "refresh_access_token", _must_not_run)
+
+    # Acquisition succeeds, but a "concurrent holder" writes a fresh token in the
+    # gap — simulated by mutating the stored credential as the lease is taken.
+    async def _acquire_and_let_someone_else_finish(self, *a, **kw):
+        bundle = json.loads(store[secret_id]["value"])
+        bundle["access_token"] = "written-by-the-other-holder"
+        bundle["access_token_expires_at"] = (now_utc() + timedelta(hours=1)).isoformat()
+        store[secret_id]["value"] = json.dumps(bundle)
+        self._is_leader = True
+        return True
+
+    monkeypatch.setattr(LeaderLease, "update_leadership", _acquire_and_let_someone_else_finish)
+    monkeypatch.setattr(LeaderLease, "release", AsyncMock())
+
+    assert await cs.get_access_token(secret_id, "u1") == "written-by-the-other-holder"
+    assert not called, "refreshed despite another holder having just written a valid token"

--- a/autobot-backend/knowledge/connectors/tests/test_credential_store.py
+++ b/autobot-backend/knowledge/connectors/tests/test_credential_store.py
@@ -795,6 +795,8 @@ async def test_without_redis_refresh_proceeds_rather_than_failing(monkeypatch):
         AsyncMock(return_value={"access_token": "new", "expires_in": 3600}),
     )
     monkeypatch.setattr(LeaderLease, "update_leadership", AsyncMock(return_value=False))
-    monkeypatch.setattr(ConnectorCredentialStore, "_refresh_lock_available", staticmethod(AsyncMock(return_value=False)))
+    monkeypatch.setattr(
+        ConnectorCredentialStore, "_refresh_lock_available", staticmethod(AsyncMock(return_value=False))
+    )
 
     assert await cs.get_access_token(secret_id, "u1") == "new"


### PR DESCRIPTION
## Thinking Path

`get_access_token` was a read → refresh → write with no lock, no transaction and no compare-and-swap. Two callers — a scheduled sync overlapping a user-triggered one is ordinary operation — both see an expired token, both refresh with **R1**, and a rotating provider issues **R2** and **R3**. Last write wins, so the stored token may not be the provider's valid one: the next refresh fails permanently and the user must re-authorize. Some providers treat reuse of a rotated token as a breach signal and revoke the whole grant family (OAuth 2.0 Security BCP 4.14.2), turning the race into a full disconnect.

The code already knew: the comment at the rotation site says *"Providers like GitLab rotate the refresh token on each use."*

**This became more likely because of #13626.** That fix took credentials whose provider omits `expires_in` from "refresh once, ever" to "refresh on schedule, indefinitely", so the racy path now runs routinely rather than once per credential lifetime.

## What Changed

Refresh is serialized per `secret_id` using `LeaderLease` — the repo's existing Redis lease primitive, already used for connector-scheduler leader election — rather than a second lock implementation.

- **Fast path unchanged:** a valid token returns without touching Redis.
- **Winner** re-reads inside the lease (double-check) and returns the other holder's token if one landed between the first read and acquisition.
- **Loser never calls the token endpoint.** It polls for the winner's write, then raises `TimeoutError` rather than falling through to an unsynchronized refresh.

`get_access_token` is split into `_read_oauth_creds`, `_refresh_and_store` and `_await_refreshed_token` so the double-check reuses the same read path.

## The failure this nearly shipped with

`LeaderLease.update_leadership()` returns `False` **both** when another worker holds the lease and when Redis is simply unavailable. My first version treated the two identically, so with no Redis every refresh took the loser path and timed out after 20s — a total outage of connector auth in any environment without Redis, far worse than the race being fixed. It surfaced immediately as a hung test suite.

`_refresh_lock_available()` now distinguishes them: no Redis logs a warning naming the risk and proceeds, which is exactly the status quo before this PR and strictly no worse.

## Verification

```
knowledge/connectors/                    374 passed
test_credential_store.py                  35 passed
flake8 / isort                             clean
```

Mutation-checked — removing the serialization must fail the concurrency tests:

```
2 failed, 33 deselected     # serialization stripped out
35 passed                   # restored
```

| Test | Asserts |
|---|---|
| `..._calls_the_token_endpoint_once` | two concurrent callers → exactly **1** endpoint call, both get the same token |
| `..._raises_instead_of_refreshing_unsynchronized` | the loser raises and **never** calls the endpoint |
| `..._without_redis_refresh_proceeds` | no Redis does not mean no connector auth |

## Model Used

Opus 5

Closes #13627
