### PR TITLE
refactor(memory): move get_memory_manager beside the class it constructs (#13722)

### DIFF
--- a/autobot-backend/memory/__init__.py
+++ b/autobot-backend/memory/__init__.py
@@ -42,7 +42,6 @@ from .cache import LRUCacheManager
 from .compat import (
     LongTermMemoryManager,
     get_long_term_memory_manager,
-    get_memory_manager,
 )
 
 # Enums
@@ -50,7 +49,8 @@ from .enums import MemoryCategory, StorageStrategy, TaskPriority, TaskStatus
 from .essential_story import EssentialStoryGenerator
 
 # Canonical Manager (composes all subsystems above)
-from .manager import MemoryManager
+# #13722: get_memory_manager is canonical and lives beside the class it builds.
+from .manager import MemoryManager, get_memory_manager
 
 # Data Models
 from .models import MemoryEntry, TaskExecutionRecord

--- a/autobot-backend/memory/compat.py
+++ b/autobot-backend/memory/compat.py
@@ -12,7 +12,8 @@ _get_embedding_cache_size, cleanup_old_data) now live on MemoryManager
 directly.
 
 #10666 B2: UnifiedMemoryManager renamed to MemoryManager.
-get_memory_manager() is the canonical factory.
+#13722: get_memory_manager() is the canonical factory and is DEFINED in
+memory/manager.py; this module only re-exports it.
 
 #13690: this module is NOT caller-less, despite a grep for ``memory.compat``
 finding nothing — both production consumers import through the package
@@ -36,7 +37,7 @@ from autobot_shared.logging_manager import get_logger
 from autobot_shared.singleton_factory import lazy_singleton
 
 from .enums import MemoryCategory
-from .manager import MemoryManager
+from .manager import MemoryManager, get_memory_manager  # noqa: F401  (re-exported, #13722)
 from .models import MemoryEntry
 
 logger = get_logger(__name__)
@@ -130,7 +131,9 @@ class LongTermMemoryManager:
 # GLOBAL INSTANCES
 # ============================================================================
 
-get_memory_manager = lazy_singleton(MemoryManager)
+# #13722: get_memory_manager now lives in memory/manager.py, beside the class
+# it constructs. Re-exported here so both import paths keep working — this
+# is the only name in this module that genuinely is a compatibility alias.
 get_long_term_memory_manager = lazy_singleton(LongTermMemoryManager)
 
 

--- a/autobot-backend/memory/compat_production_usage_test.py
+++ b/autobot-backend/memory/compat_production_usage_test.py
@@ -77,3 +77,40 @@ class TestDataPlaneWrappersStayTenanted:
         assert "user_id" in params, f"{method} lost its owner scope"
         assert params["user_id"].kind is inspect.Parameter.KEYWORD_ONLY
         assert params["user_id"].default is inspect.Parameter.empty, "scope must be required"
+
+
+class TestCanonicalFactoryLocation:
+    """#13722: the canonical factory is defined beside what it constructs.
+
+    Its previous home in `compat.py` is why #13690 was filed on a false premise
+    — nobody looks for the canonical factory in a module called "backward
+    compatibility wrappers".
+    """
+
+    def test_it_is_defined_in_manager_not_compat(self):
+        from memory.manager import get_memory_manager
+
+        assert get_memory_manager.__module__ == "memory.manager"
+
+    def test_both_import_paths_still_resolve_to_it(self):
+        """No caller breaks: `compat` re-exports, the package re-exports."""
+        import memory
+        from memory.compat import get_memory_manager as via_compat
+        from memory.manager import get_memory_manager as via_manager
+
+        assert via_compat is via_manager
+        assert memory.get_memory_manager is via_manager
+
+    def test_it_still_returns_the_same_singleton(self):
+        from memory.manager import MemoryManager, get_memory_manager
+
+        first, second = get_memory_manager(), get_memory_manager()
+
+        assert first is second
+        assert isinstance(first, MemoryManager)
+
+    def test_compat_no_longer_claims_to_define_it(self):
+        """The docstring was the thing that misled the #13690 audit."""
+        import memory.compat as compat
+
+        assert "DEFINED in" in (compat.__doc__ or "")

--- a/autobot-backend/memory/manager.py
+++ b/autobot-backend/memory/manager.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing import Any, Dict, List
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.singleton_factory import lazy_singleton
 
 from .agent_diary import AgentDiaryService
 from .cache import LRUCacheManager
@@ -957,4 +958,22 @@ class MemoryManager:
         return True
 
 
-__all__ = ["MemoryManager"]
+def get_memory_manager() -> MemoryManager:
+    """Return the shared MemoryManager singleton — the canonical factory (#13722).
+
+    Defined here, beside the class it constructs, rather than in ``compat.py``.
+    It was never a compatibility shim: ``task_execution_tracker.py:52`` uses it
+    in production and #10666 B2 named it canonical. Only its location was
+    legacy, and that location is why #13690 was filed on the false premise that
+    ``compat.py`` had no production callers — nobody looks for the canonical
+    factory in a module called "backward compatibility wrappers".
+
+    ``memory.compat`` re-exports this name, so both import paths keep working.
+    """
+    return _get_memory_manager_singleton()
+
+
+_get_memory_manager_singleton = lazy_singleton(MemoryManager)
+
+
+__all__ = ["MemoryManager", "get_memory_manager"]


### PR DESCRIPTION
## Thinking Path

`get_memory_manager` was defined in `memory/compat.py`, a module whose docstring opens "Backward Compatibility Wrappers — Drop-in replacements for legacy APIs". It is not one. #10666 B2 explicitly named it *the canonical factory*, and `task_execution_tracker.py:52` uses it in production.

That mislocation had a measurable cost, which is why this is worth fixing rather than tolerating: **it is why #13690 was filed on a false premise.** That issue asserted `memory/compat.py` had no production callers, because the grep looked for `memory.compat` — and nobody thinks to check whether the canonical factory lives in a module called "compat". The location defeated the search.

## What Changed

- `get_memory_manager` is defined in `memory/manager.py`, beside the class it constructs.
- `memory/compat.py` re-exports it. That import is now the only thing in the module that genuinely *is* a compatibility alias.
- `memory/__init__.py` imports it from the canonical location rather than through the shim.
- `compat.py`'s docstring no longer claims to define a factory it doesn't.

`LongTermMemoryManager` stays where it is — it genuinely is a legacy wrapper, and `orchestrator.py:142` still uses it as a lifecycle object (established in #13690).

## Verification

```
$ python3 -m pytest memory/ tests/memory/ -q -p no:randomly
245 passed

black / isort / flake8 → clean
```

No caller changed. Both import paths resolve to the same object, asserted rather than assumed:

- `test_both_import_paths_still_resolve_to_it` — `memory.compat.get_memory_manager is memory.manager.get_memory_manager is memory.get_memory_manager`.
- `test_it_is_defined_in_manager_not_compat` — checks `__module__`, so re-exporting cannot make this pass falsely.
- `test_it_still_returns_the_same_singleton` — the behaviour `tests/memory/test_compat_singletons.py` already depends on.
- `test_compat_no_longer_claims_to_define_it` — the docstring was the artefact that misled the #13690 audit, so it gets an assertion too.

### Acceptance criteria

- [x] Defined outside `compat.py`, next to what it constructs.
- [x] `from memory import …`, `from memory.manager import …` and `from memory.compat import …` all still work — no caller breaks.
- [x] `tests/memory/test_compat_singletons.py` passes unchanged (it imports via `memory.compat`, which is exactly the path the re-export preserves).
- [x] `compat.py`'s docstring no longer claims a canonical factory it does not define.

## Model Used

Claude Opus 5 (1M context)

Closes #13722
Follows from #13690
