### PR TITLE
fix(voice): pre-roll audio against a below-real-time TTS worker + make the real-time factor observable (#12460)

### DIFF
--- a/autobot-backend/services/tts_client.py
+++ b/autobot-backend/services/tts_client.py
@@ -99,24 +99,38 @@ def _wav_duration_seconds(wav_bytes: bytes) -> float:
 
 
 class _SynthesisThroughput:
-    """Audio produced vs wall time for one synthesis (#12460).
+    """Audio produced vs the time the worker spent producing it (#12460).
 
     Time-to-first-audio was fixed in #13215, but a worker that then sustains
     below real time starves the player and stutters anyway. The real-time factor
     is the number that separates those two failures, and nothing was recording
     it, so a worker running at 0.2x looked healthy on every dashboard.
+
+    Only the intervals the worker is actually generating in are counted. This
+    is an async generator feeding a WebSocket and a StreamingResponse, so it is
+    suspended at each ``yield`` for as long as the consumer takes to forward the
+    chunk. Billing that back-pressure to the worker would fire the
+    below-real-time alert against a healthy one whenever a client is slow.
     """
 
     def __init__(self, route: str) -> None:
         self.route = route
-        self._started = time.monotonic()
+        self._producing_seconds = 0.0
         self._audio_seconds = 0.0
         self._first_chunk_seconds: float | None = None
+        self._mark: float | None = None
+
+    def start(self) -> None:
+        """Open a production interval — before a request, and after each yield."""
+        self._mark = time.monotonic()
 
     def observe(self, wav_bytes: bytes) -> None:
-        """Fold one delivered WAV payload into the measurement."""
+        """Close the production interval this payload arrived on."""
+        if self._mark is not None:
+            self._producing_seconds += time.monotonic() - self._mark
+            self._mark = None
         if self._first_chunk_seconds is None:
-            self._first_chunk_seconds = time.monotonic() - self._started
+            self._first_chunk_seconds = self._producing_seconds
         self._audio_seconds += _wav_duration_seconds(wav_bytes)
 
     def report(self) -> None:
@@ -126,7 +140,7 @@ class _SynthesisThroughput:
         first chunk, or an unparseable payload) carries no rate and is skipped
         rather than recorded as a 0.0x outlier.
         """
-        wall_seconds = time.monotonic() - self._started
+        wall_seconds = self._producing_seconds
         if self._audio_seconds <= 0 or wall_seconds <= 0:
             return
         try:
@@ -259,8 +273,10 @@ class TTSClient:
 
         Throughput is measured across whichever route serves the utterance and
         reported once on exit (#12460) — including when a caller abandons the
-        stream mid-utterance, since audio-produced over wall-time is still the
-        worker's real rate.
+        stream mid-utterance, since audio-produced over generation-time is still
+        the worker's real rate. The clock covers only the intervals the worker
+        is generating in: it starts after the capability probe has resolved, and
+        restarts after each yield so a slow consumer is not billed to the worker.
         """
         throughput = _SynthesisThroughput("stream")
         try:
@@ -268,6 +284,7 @@ class TTSClient:
             if not self._streaming_known_absent():
                 degraded = self._stream_absent_until > 0.0
                 try:
+                    throughput.start()
                     async with aclosing(self.synthesize_stream(text, voice_id=voice_id, language=language)) as stream:
                         async for chunk in stream:
                             if not emitted and degraded:
@@ -278,6 +295,7 @@ class TTSClient:
                             emitted = True
                             throughput.observe(chunk)
                             yield chunk
+                            throughput.start()
                     return
                 except TTSStreamUnsupported as e:
                     if emitted:
@@ -290,6 +308,7 @@ class TTSClient:
                         STREAM_PROBE_TTL,
                     )
             throughput.route = "blob"
+            throughput.start()
             whole = await self.synthesize(text, voice_id=voice_id, language=language)
             throughput.observe(whole)
             yield whole

--- a/autobot-backend/services/tts_client.py
+++ b/autobot-backend/services/tts_client.py
@@ -118,6 +118,8 @@ class _SynthesisThroughput:
         self._producing_seconds = 0.0
         self._audio_seconds = 0.0
         self._first_chunk_seconds: float | None = None
+        self._first_chunk_audio = 0.0
+        self._chunks = 0
         self._mark: float | None = None
 
     def start(self) -> None:
@@ -129,9 +131,15 @@ class _SynthesisThroughput:
         if self._mark is not None:
             self._producing_seconds += time.monotonic() - self._mark
             self._mark = None
+        duration = _wav_duration_seconds(wav_bytes)
+        self._chunks += 1
         if self._first_chunk_seconds is None:
+            # The first interval is connect + upload + model warm-up, not
+            # generation rate. It is time-to-first-audio, and it is reported as
+            # exactly that below rather than folded into the factor.
             self._first_chunk_seconds = self._producing_seconds
-        self._audio_seconds += _wav_duration_seconds(wav_bytes)
+            self._first_chunk_audio = duration
+        self._audio_seconds += duration
 
     def report(self) -> None:
         """Emit the metrics and warn when the worker ran below real time.
@@ -140,29 +148,49 @@ class _SynthesisThroughput:
         first chunk, or an unparseable payload) carries no rate and is skipped
         rather than recorded as a 0.0x outlier.
         """
-        wall_seconds = self._producing_seconds
-        if self._audio_seconds <= 0 or wall_seconds <= 0:
+        # Steady-state rate: drop the warm-up interval and the audio it produced,
+        # so this measures the same thing the client's pre-roll measures. A
+        # single-chunk synthesis (the whole-utterance route) has no steady state
+        # to isolate, so its one interval is the only rate available.
+        if self._chunks > 1 and self._first_chunk_seconds is not None:
+            audio_seconds = self._audio_seconds - self._first_chunk_audio
+            wall_seconds = self._producing_seconds - self._first_chunk_seconds
+        else:
+            audio_seconds = self._audio_seconds
+            wall_seconds = self._producing_seconds
+        # Latency telemetry stands on its own — a payload we could not measure
+        # the duration of still tells us how long the caller waited.
+        if self._first_chunk_seconds is not None:
+            self._record_first_chunk(self._first_chunk_seconds)
+        if audio_seconds <= 0 or wall_seconds <= 0:
             return
         try:
             # Lazy import to avoid a circular dependency with prometheus_metrics.
             from autobot_shared.monitoring.prometheus_metrics import get_metrics_manager
 
             metrics = get_metrics_manager()
-            metrics.record_tts_synthesis(self.route, self._audio_seconds, wall_seconds)
-            if self._first_chunk_seconds is not None:
-                metrics.record_tts_first_chunk(self.route, self._first_chunk_seconds)
+            metrics.record_tts_synthesis(self.route, audio_seconds, wall_seconds)
         except Exception:
             logger.debug("TTS throughput metrics unavailable", exc_info=True)
-        factor = self._audio_seconds / wall_seconds
+        factor = audio_seconds / wall_seconds
         if factor < REALTIME_FACTOR_FLOOR:
             logger.warning(
                 "TTS synthesis ran below real time: %.2fx (%.1fs of audio in %.1fs via %s) — "
                 "streamed playback drains faster than the worker fills it",
                 factor,
-                self._audio_seconds,
+                audio_seconds,
                 wall_seconds,
                 self.route,
             )
+
+    def _record_first_chunk(self, seconds: float) -> None:
+        """Report time-to-first-audio, independent of whether a rate was derived."""
+        try:
+            from autobot_shared.monitoring.prometheus_metrics import get_metrics_manager
+
+            get_metrics_manager().record_tts_first_chunk(self.route, seconds)
+        except Exception:
+            logger.debug("TTS first-chunk metrics unavailable", exc_info=True)
 
 
 class TTSStreamUnsupported(RuntimeError):

--- a/autobot-backend/services/tts_client.py
+++ b/autobot-backend/services/tts_client.py
@@ -17,7 +17,9 @@ Usage:
 """
 
 import asyncio
+import io
 import time
+import wave
 from collections.abc import AsyncIterator
 from contextlib import aclosing
 
@@ -26,6 +28,7 @@ import aiohttp
 from autobot_shared.env_utils import blank_to_none
 from autobot_shared.http_client import get_http_client
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.monitoring.metrics.tts import REALTIME_FACTOR_FLOOR
 from autobot_shared.ssot_config import config, get_config
 from autobot_shared.ssot_constants import TTL_5_MINUTES
 
@@ -74,6 +77,78 @@ def _resolve_stream_probe_ttl() -> int:
 STREAM_PROBE_TTL = _resolve_stream_probe_ttl()
 
 _client_instance: "TTSClient | None" = None
+
+
+def _wav_duration_seconds(wav_bytes: bytes) -> float:
+    """Return the playable length of a WAV payload, or 0.0 if it cannot be read.
+
+    Used to measure synthesis throughput (#12460). The worker's streamed chunks
+    are complete mini-WAVs, so each one carries the header this needs. Anything
+    unparseable contributes nothing rather than raising: telemetry must never be
+    able to break audio delivery.
+    """
+    try:
+        with wave.open(io.BytesIO(wav_bytes), "rb") as wav:
+            frame_rate = wav.getframerate()
+            if frame_rate <= 0:
+                return 0.0
+            return wav.getnframes() / float(frame_rate)
+    except Exception:
+        logger.debug("Unparseable WAV payload; excluded from throughput", exc_info=True)
+        return 0.0
+
+
+class _SynthesisThroughput:
+    """Audio produced vs wall time for one synthesis (#12460).
+
+    Time-to-first-audio was fixed in #13215, but a worker that then sustains
+    below real time starves the player and stutters anyway. The real-time factor
+    is the number that separates those two failures, and nothing was recording
+    it, so a worker running at 0.2x looked healthy on every dashboard.
+    """
+
+    def __init__(self, route: str) -> None:
+        self.route = route
+        self._started = time.monotonic()
+        self._audio_seconds = 0.0
+        self._first_chunk_seconds: float | None = None
+
+    def observe(self, wav_bytes: bytes) -> None:
+        """Fold one delivered WAV payload into the measurement."""
+        if self._first_chunk_seconds is None:
+            self._first_chunk_seconds = time.monotonic() - self._started
+        self._audio_seconds += _wav_duration_seconds(wav_bytes)
+
+    def report(self) -> None:
+        """Emit the metrics and warn when the worker ran below real time.
+
+        A synthesis that produced no measurable audio (cancelled before the
+        first chunk, or an unparseable payload) carries no rate and is skipped
+        rather than recorded as a 0.0x outlier.
+        """
+        wall_seconds = time.monotonic() - self._started
+        if self._audio_seconds <= 0 or wall_seconds <= 0:
+            return
+        try:
+            # Lazy import to avoid a circular dependency with prometheus_metrics.
+            from autobot_shared.monitoring.prometheus_metrics import get_metrics_manager
+
+            metrics = get_metrics_manager()
+            metrics.record_tts_synthesis(self.route, self._audio_seconds, wall_seconds)
+            if self._first_chunk_seconds is not None:
+                metrics.record_tts_first_chunk(self.route, self._first_chunk_seconds)
+        except Exception:
+            logger.debug("TTS throughput metrics unavailable", exc_info=True)
+        factor = self._audio_seconds / wall_seconds
+        if factor < REALTIME_FACTOR_FLOOR:
+            logger.warning(
+                "TTS synthesis ran below real time: %.2fx (%.1fs of audio in %.1fs via %s) — "
+                "streamed playback drains faster than the worker fills it",
+                factor,
+                self._audio_seconds,
+                wall_seconds,
+                self.route,
+            )
 
 
 class TTSStreamUnsupported(RuntimeError):
@@ -181,32 +256,45 @@ class TTSClient:
         Callers get one uniform contract regardless of how current the worker
         is, which is what keeps a worker/backend skew from turning into
         silence (WebSocket path) or a hard 404 (HTTP path).
+
+        Throughput is measured across whichever route serves the utterance and
+        reported once on exit (#12460) — including when a caller abandons the
+        stream mid-utterance, since audio-produced over wall-time is still the
+        worker's real rate.
         """
-        emitted = False
-        if not self._streaming_known_absent():
-            degraded = self._stream_absent_until > 0.0
-            try:
-                async with aclosing(self.synthesize_stream(text, voice_id=voice_id, language=language)) as stream:
-                    async for chunk in stream:
-                        if not emitted and degraded:
-                            # Recovery is otherwise silent, leaving an operator
-                            # unable to tell which route is in use (#13215 review).
-                            logger.info("TTS worker now serves /tts/synthesize/stream; streaming resumed")
-                            self._stream_absent_until = 0.0
-                        emitted = True
-                        yield chunk
-                return
-            except TTSStreamUnsupported as e:
-                if emitted:
-                    raise  # cannot restart mid-utterance without repeating audio
-                self._stream_absent_until = time.monotonic() + STREAM_PROBE_TTL
-                logger.warning(
-                    "TTS worker does not serve /tts/synthesize/stream (%s); using the "
-                    "whole-utterance route for the next %ds",
-                    e,
-                    STREAM_PROBE_TTL,
-                )
-        yield await self.synthesize(text, voice_id=voice_id, language=language)
+        throughput = _SynthesisThroughput("stream")
+        try:
+            emitted = False
+            if not self._streaming_known_absent():
+                degraded = self._stream_absent_until > 0.0
+                try:
+                    async with aclosing(self.synthesize_stream(text, voice_id=voice_id, language=language)) as stream:
+                        async for chunk in stream:
+                            if not emitted and degraded:
+                                # Recovery is otherwise silent, leaving an operator
+                                # unable to tell which route is in use (#13215 review).
+                                logger.info("TTS worker now serves /tts/synthesize/stream; streaming resumed")
+                                self._stream_absent_until = 0.0
+                            emitted = True
+                            throughput.observe(chunk)
+                            yield chunk
+                    return
+                except TTSStreamUnsupported as e:
+                    if emitted:
+                        raise  # cannot restart mid-utterance without repeating audio
+                    self._stream_absent_until = time.monotonic() + STREAM_PROBE_TTL
+                    logger.warning(
+                        "TTS worker does not serve /tts/synthesize/stream (%s); using the "
+                        "whole-utterance route for the next %ds",
+                        e,
+                        STREAM_PROBE_TTL,
+                    )
+            throughput.route = "blob"
+            whole = await self.synthesize(text, voice_id=voice_id, language=language)
+            throughput.observe(whole)
+            yield whole
+        finally:
+            throughput.report()
 
     async def clone_voice(self, text: str, reference_audio: bytes) -> bytes:
         """Send text + reference audio to TTS worker; returns WAV bytes."""

--- a/autobot-backend/services/tts_client_test.py
+++ b/autobot-backend/services/tts_client_test.py
@@ -17,11 +17,14 @@ dial out for real.
 """
 
 import asyncio
+import io
+import logging
+import wave
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from services.tts_client import STREAM_PROBE_TTL, TTSClient
+from services.tts_client import STREAM_PROBE_TTL, TTSClient, _wav_duration_seconds
 
 
 class _FakeStreamReader:
@@ -268,3 +271,150 @@ async def test_stream_or_synthesize_does_not_mask_worker_failures():
     # type: only 404/405 may degrade to the blocking endpoint.
     assert type(exc.value) is RuntimeError
     assert not any(u.endswith(BLOCKING_URL_SUFFIX) for u in mock_client.requested_urls)
+
+
+# ---------------------------------------------------------------------------
+# Synthesis throughput telemetry (#12460)
+# ---------------------------------------------------------------------------
+#
+# #13215 fixed time-to-first-audio; this is the next constraint. Once streaming
+# starts, a worker that sustains below real time starves the player and the
+# audio stutters. The real-time factor separates those two failures and nothing
+# consumed it, so a worker running at 0.2x looked healthy everywhere.
+
+
+def _real_wav(seconds: float, frame_rate: int = 24000) -> bytes:
+    """Build a real, parseable mono 16-bit WAV of the given playable length."""
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wav:
+        wav.setnchannels(1)
+        wav.setsampwidth(2)
+        wav.setframerate(frame_rate)
+        wav.writeframes(b"\x00\x00" * int(seconds * frame_rate))
+    return buf.getvalue()
+
+
+def test_wav_duration_seconds_reads_a_real_wav():
+    """Chunk duration comes from the WAV header, so throughput is measurable."""
+    assert _wav_duration_seconds(_real_wav(0.25)) == pytest.approx(0.25)
+
+
+def test_wav_duration_seconds_returns_zero_for_unparseable_audio():
+    """Telemetry must never be able to break audio delivery."""
+    assert _wav_duration_seconds(b"not-a-wav-at-all") == 0.0
+
+
+@pytest.mark.asyncio
+async def test_stream_or_synthesize_warns_and_records_below_real_time(caplog):
+    """A worker producing 1s of audio in 4s is recorded at 0.25x and warned about."""
+    chunks = [_real_wav(0.5), _real_wav(0.5)]
+    mock_client = _make_routing_http_client({STREAM_URL_SUFFIX: (200, _framed(chunks))})
+    clock = _FakeClock()
+    recorded: list = []
+
+    def _advance_on_chunk(*_args, **_kwargs):
+        # Step the clock on every read so the 1.0s of audio below measures as
+        # having taken several wall-seconds to produce.
+        clock.now += 2.0
+        return clock.now
+
+    metrics = MagicMock()
+    metrics.record_tts_synthesis = MagicMock(side_effect=lambda *a: recorded.append(a))
+
+    with (
+        patch("services.tts_client.get_http_client", return_value=mock_client),
+        patch("services.tts_client.time.monotonic", side_effect=_advance_on_chunk),
+        patch(
+            "autobot_shared.monitoring.prometheus_metrics.get_metrics_manager",
+            return_value=metrics,
+        ),
+        caplog.at_level(logging.WARNING, logger="services.tts_client"),
+    ):
+        tts_client = TTSClient()
+        received = [c async for c in tts_client.stream_or_synthesize("hello")]
+
+    assert received == chunks
+    assert len(recorded) == 1
+    route, audio_seconds, wall_seconds = recorded[0]
+    assert route == "stream"
+    assert audio_seconds == pytest.approx(1.0)
+    assert audio_seconds / wall_seconds < 1.0
+    assert "below real time" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_stream_or_synthesize_does_not_warn_at_or_above_real_time(caplog):
+    """A worker keeping up is recorded but must not raise a throughput warning."""
+    chunks = [_real_wav(2.0)]
+    mock_client = _make_routing_http_client({STREAM_URL_SUFFIX: (200, _framed(chunks))})
+    clock = _FakeClock()
+    metrics = MagicMock()
+
+    def _advance_slightly(*_args, **_kwargs):
+        clock.now += 0.25
+        return clock.now
+
+    with (
+        patch("services.tts_client.get_http_client", return_value=mock_client),
+        patch("services.tts_client.time.monotonic", side_effect=_advance_slightly),
+        patch(
+            "autobot_shared.monitoring.prometheus_metrics.get_metrics_manager",
+            return_value=metrics,
+        ),
+        caplog.at_level(logging.WARNING, logger="services.tts_client"),
+    ):
+        tts_client = TTSClient()
+        received = [c async for c in tts_client.stream_or_synthesize("hello")]
+
+    assert received == chunks
+    metrics.record_tts_synthesis.assert_called_once()
+    assert "below real time" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_stream_or_synthesize_skips_telemetry_when_no_audio_is_measurable():
+    """Unparseable payloads carry no rate; they must not land as a 0.0x outlier."""
+    mock_client = _make_routing_http_client({STREAM_URL_SUFFIX: (200, _framed([b"RIFF-not-real"]))})
+    metrics = MagicMock()
+
+    with (
+        patch("services.tts_client.get_http_client", return_value=mock_client),
+        patch(
+            "autobot_shared.monitoring.prometheus_metrics.get_metrics_manager",
+            return_value=metrics,
+        ),
+    ):
+        tts_client = TTSClient()
+        received = [c async for c in tts_client.stream_or_synthesize("hello")]
+
+    assert received == [b"RIFF-not-real"]
+    metrics.record_tts_synthesis.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_stream_or_synthesize_labels_the_whole_utterance_route():
+    """A stale worker's blob route is measured too, labelled 'blob' not 'stream'."""
+    mock_client = _make_routing_http_client(
+        {
+            STREAM_URL_SUFFIX: (404, b""),
+            BLOCKING_URL_SUFFIX: (200, _real_wav(1.0)),
+        }
+    )
+    recorded: list = []
+    metrics = MagicMock()
+    metrics.record_tts_synthesis = MagicMock(side_effect=lambda *a: recorded.append(a))
+
+    with (
+        patch("services.tts_client.get_http_client", return_value=mock_client),
+        patch(
+            "autobot_shared.monitoring.prometheus_metrics.get_metrics_manager",
+            return_value=metrics,
+        ),
+    ):
+        tts_client = TTSClient()
+        async for _ in tts_client.stream_or_synthesize("hello"):
+            pass
+
+    assert len(recorded) == 1
+    assert recorded[0][0] == "blob"
+    assert recorded[0][1] == pytest.approx(1.0)

--- a/autobot-backend/services/tts_client_test.py
+++ b/autobot-backend/services/tts_client_test.py
@@ -337,7 +337,9 @@ async def test_stream_or_synthesize_warns_and_records_below_real_time(caplog):
     assert len(recorded) == 1
     route, audio_seconds, wall_seconds = recorded[0]
     assert route == "stream"
-    assert audio_seconds == pytest.approx(1.0)
+    # Steady state only: the first chunk and the warm-up interval that produced
+    # it are excluded, so 1.0s of audio over two chunks is recorded as 0.5s.
+    assert audio_seconds == pytest.approx(0.5)
     assert audio_seconds / wall_seconds < 1.0
     assert "below real time" in caplog.text
 
@@ -460,7 +462,59 @@ async def test_stream_or_synthesize_does_not_bill_consumer_backpressure_to_the_w
 
     assert len(recorded) == 1
     _route, audio_seconds, wall_seconds = recorded[0]
-    assert audio_seconds == pytest.approx(2.0)
+    # Steady state: the first chunk's 1.0s and its warm-up interval drop out.
+    assert audio_seconds == pytest.approx(1.0)
     # 20s of consumer time excluded: the worker is recorded at its real 2.0x.
     assert audio_seconds / wall_seconds == pytest.approx(2.0)
     assert "below real time" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_stream_or_synthesize_excludes_warm_up_from_the_rate(caplog):
+    """Model warm-up is time-to-first-audio, not generation rate (#12460).
+
+    A worker that takes 3s to load state and then generates faster than real
+    time is healthy. Folding the warm-up into the factor reports it at 0.375x
+    and fires TTSSynthesisBelowRealTime — and it would disagree with the client,
+    which measures its own rate from the second chunk on for the same reason.
+    """
+    chunks = [_real_wav(1.0), _real_wav(1.0), _real_wav(1.0)]
+    mock_client = _make_routing_http_client({STREAM_URL_SUFFIX: (200, _framed(chunks))})
+    clock = _FakeClock()
+    recorded: list = []
+    first_chunk: list = []
+    reads = {"n": 0}
+
+    def _monotonic() -> float:
+        # Reads run: probe, start(), observe(chunk1), start(), observe(chunk2)...
+        # The 3rd read closes the start()->first-chunk interval, so that is the
+        # warm-up; every other interval costs 0.5s of real generation.
+        reads["n"] += 1
+        clock.now += 3.0 if reads["n"] == 3 else 0.5
+        return clock.now
+
+    metrics = MagicMock()
+    metrics.record_tts_synthesis = MagicMock(side_effect=lambda *a: recorded.append(a))
+    metrics.record_tts_first_chunk = MagicMock(side_effect=lambda *a: first_chunk.append(a))
+
+    with (
+        patch("services.tts_client.get_http_client", return_value=mock_client),
+        patch("services.tts_client.time.monotonic", _monotonic),
+        patch(
+            "autobot_shared.monitoring.prometheus_metrics.get_metrics_manager",
+            return_value=metrics,
+        ),
+        caplog.at_level(logging.WARNING, logger="services.tts_client"),
+    ):
+        tts_client = TTSClient()
+        async for _ in tts_client.stream_or_synthesize("hello"):
+            pass
+
+    assert len(recorded) == 1
+    _route, audio_seconds, wall_seconds = recorded[0]
+    # Warm-up dropped: 2 remaining chunks of 1.0s over 2 x 0.5s of generation.
+    assert audio_seconds == pytest.approx(2.0)
+    assert audio_seconds / wall_seconds == pytest.approx(2.0)
+    assert "below real time" not in caplog.text
+    # ...and the warm-up is still reported, as the latency it actually is.
+    assert first_chunk and first_chunk[0][1] == pytest.approx(3.0)

--- a/autobot-backend/services/tts_client_test.py
+++ b/autobot-backend/services/tts_client_test.py
@@ -418,3 +418,49 @@ async def test_stream_or_synthesize_labels_the_whole_utterance_route():
     assert len(recorded) == 1
     assert recorded[0][0] == "blob"
     assert recorded[0][1] == pytest.approx(1.0)
+
+
+@pytest.mark.asyncio
+async def test_stream_or_synthesize_does_not_bill_consumer_backpressure_to_the_worker(caplog):
+    """A slow consumer must not make a healthy worker look below real time.
+
+    This is an async generator feeding a WebSocket and a StreamingResponse, so
+    it sits suspended at each ``yield`` for as long as the client takes to
+    forward the chunk. Here the worker produces 2.0s of audio in 1.0s (a healthy
+    2.0x) while the consumer spends 20s forwarding it. Counting that consumer
+    time would report 0.09x and fire TTSSynthesisBelowRealTime against a worker
+    that is keeping up fine.
+    """
+    chunks = [_real_wav(1.0), _real_wav(1.0)]
+    mock_client = _make_routing_http_client({STREAM_URL_SUFFIX: (200, _framed(chunks))})
+    clock = _FakeClock()
+    recorded: list = []
+
+    def _monotonic() -> float:
+        # Every read costs 0.5s, so each start()->observe() production interval
+        # measures 0.5s: 1.0s of generation for 2.0s of audio.
+        clock.now += 0.5
+        return clock.now
+
+    metrics = MagicMock()
+    metrics.record_tts_synthesis = MagicMock(side_effect=lambda *a: recorded.append(a))
+
+    with (
+        patch("services.tts_client.get_http_client", return_value=mock_client),
+        patch("services.tts_client.time.monotonic", _monotonic),
+        patch(
+            "autobot_shared.monitoring.prometheus_metrics.get_metrics_manager",
+            return_value=metrics,
+        ),
+        caplog.at_level(logging.WARNING, logger="services.tts_client"),
+    ):
+        tts_client = TTSClient()
+        async for _ in tts_client.stream_or_synthesize("hello"):
+            clock.now += 10.0
+
+    assert len(recorded) == 1
+    _route, audio_seconds, wall_seconds = recorded[0]
+    assert audio_seconds == pytest.approx(2.0)
+    # 20s of consumer time excluded: the worker is recorded at its real 2.0x.
+    assert audio_seconds / wall_seconds == pytest.approx(2.0)
+    assert "below real time" not in caplog.text

--- a/autobot-backend/services/tts_metrics_test.py
+++ b/autobot-backend/services/tts_metrics_test.py
@@ -1,0 +1,90 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for TTS synthesis throughput metrics (#12460).
+
+The real-time factor is what separates "speech starts late" (fixed in #13215)
+from "speech stutters": below 1.0x the player drains its buffer faster than the
+worker refills it. These tests pin that the factor is computed, exported, and
+that the below-real-time counter only moves when it should.
+"""
+
+from __future__ import annotations
+
+from prometheus_client import CollectorRegistry
+
+from autobot_shared.monitoring.metrics.tts import REALTIME_FACTOR_FLOOR, TTSMetricsRecorder
+
+
+def _sample(registry: CollectorRegistry, name: str, **labels: str) -> float | None:
+    """Return one exported sample value, or None when it was never recorded."""
+    return registry.get_sample_value(name, labels or None)
+
+
+class TestTTSMetricsRecorder:
+    """TTSMetricsRecorder throughput recording."""
+
+    def test_below_real_time_synthesis_is_counted_and_exported(self) -> None:
+        """3.4s of audio in 15s is 0.22x — the measured stutter case from #12460."""
+        registry = CollectorRegistry()
+        recorder = TTSMetricsRecorder(registry)
+
+        recorder.record_synthesis("stream", audio_seconds=3.36, wall_seconds=15.03)
+
+        assert _sample(registry, "autobot_tts_synthesis_total", route="stream") == 1.0
+        assert _sample(registry, "autobot_tts_synthesis_below_realtime_total", route="stream") == 1.0
+        factor = _sample(registry, "autobot_tts_realtime_factor_last", route="stream")
+        assert factor is not None
+        assert factor < REALTIME_FACTOR_FLOOR
+
+    def test_real_time_synthesis_does_not_move_the_below_real_time_counter(self) -> None:
+        """A worker keeping up is counted as a synthesis but not as a shortfall."""
+        registry = CollectorRegistry()
+        recorder = TTSMetricsRecorder(registry)
+
+        recorder.record_synthesis("stream", audio_seconds=4.0, wall_seconds=2.0)
+
+        assert _sample(registry, "autobot_tts_synthesis_total", route="stream") == 1.0
+        assert _sample(registry, "autobot_tts_synthesis_below_realtime_total", route="stream") is None
+        assert _sample(registry, "autobot_tts_realtime_factor_last", route="stream") == 2.0
+
+    def test_zero_duration_is_counted_but_carries_no_factor(self) -> None:
+        """A synthesis that produced no measurable audio must not land as a 0.0x outlier."""
+        registry = CollectorRegistry()
+        recorder = TTSMetricsRecorder(registry)
+
+        recorder.record_synthesis("stream", audio_seconds=0.0, wall_seconds=5.0)
+
+        assert _sample(registry, "autobot_tts_synthesis_total", route="stream") == 1.0
+        assert _sample(registry, "autobot_tts_realtime_factor_last", route="stream") is None
+        assert _sample(registry, "autobot_tts_synthesis_below_realtime_total", route="stream") is None
+
+    def test_routes_are_tracked_separately(self) -> None:
+        """The streaming and whole-utterance routes have different throughput profiles."""
+        registry = CollectorRegistry()
+        recorder = TTSMetricsRecorder(registry)
+
+        recorder.record_synthesis("stream", audio_seconds=1.0, wall_seconds=5.0)
+        recorder.record_synthesis("blob", audio_seconds=4.0, wall_seconds=1.0)
+
+        assert _sample(registry, "autobot_tts_realtime_factor_last", route="stream") == 0.2
+        assert _sample(registry, "autobot_tts_realtime_factor_last", route="blob") == 4.0
+
+    def test_first_chunk_latency_is_observed(self) -> None:
+        """Time-to-first-audio stays visible alongside the throughput it trades against."""
+        registry = CollectorRegistry()
+        recorder = TTSMetricsRecorder(registry)
+
+        recorder.record_first_chunk_latency("stream", 0.8)
+
+        assert _sample(registry, "autobot_tts_first_chunk_seconds_count", route="stream") == 1.0
+
+    def test_negative_first_chunk_latency_is_ignored(self) -> None:
+        """A clock that went backwards must not corrupt the latency histogram."""
+        registry = CollectorRegistry()
+        recorder = TTSMetricsRecorder(registry)
+
+        recorder.record_first_chunk_latency("stream", -1.0)
+
+        assert _sample(registry, "autobot_tts_first_chunk_seconds_count", route="stream") is None

--- a/autobot-frontend/src/composables/__tests__/useVoiceOutput.preroll.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useVoiceOutput.preroll.test.ts
@@ -292,30 +292,26 @@ describe('useVoiceOutput — adaptive pre-roll for a below-real-time worker (#12
     expect(isSpeaking.value).toBe(true)
   })
 
-  it('does not force-release while the worker is still producing — the stall timer is not a cap', async () => {
-    // Calibrate on real timers: sendChunk drains the decode chain via a real
-    // macrotask, which a fake clock would never fire.
+  it('starts speaking within the wait budget rather than buffering indefinitely', async () => {
     await calibrate(0.25)
     const scheduledAfterCalibration = scheduledStarts
     ctxTime = 1000
+    endAllScheduled()
 
-    vi.useFakeTimers()
-    try {
-      // A 180-char reply targets the 8s cap; filling it at 0.25x legitimately
-      // takes ~32s. A total-duration timer would force-release mid-fill and
-      // hand back exactly the stutter this feature exists to remove.
-      serverSend({ type: 'tts_start', text: 'x'.repeat(180) })
-      for (let i = 0; i < 6; i++) {
-        clockMs += 4000
-        serverSend({ type: 'tts_audio', data: B64, chunk: i })
-        await vi.advanceTimersByTimeAsync(4000)
-      }
+    // Chunks trickle in every 4s (0.0625x live). The wall-clock bound caps the
+    // target at MAX_WAIT*r, so the buffer that must accumulate is small and
+    // speech starts inside the budget instead of after the whole reply.
+    serverSend({ type: 'tts_start', text: 'x'.repeat(180) })
+    const before = clockMs
+    await sendChunk(0)
+    await sendChunk(4000)
+    await sendChunk(4000)
 
-      // 24s of wall clock, well past a 20s one-shot timer, and still holding.
-      expect(scheduledStarts).toBe(scheduledAfterCalibration)
-    } finally {
-      vi.useRealTimers()
-    }
+    expect(scheduledStarts).toBeGreaterThan(scheduledAfterCalibration)
+    // Because the wait is bounded at 8s and the stall watchdog only fires after
+    // 10s of silence, filling the lead-in can never outlast the watchdog — so
+    // it can only ever fire on a genuine stall, never as a duration cap.
+    expect(clockMs - before).toBeLessThanOrEqual(8000)
   })
 
   it('releases held audio when the worker genuinely stalls', async () => {
@@ -338,6 +334,62 @@ describe('useVoiceOutput — adaptive pre-roll for a below-real-time worker (#12
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  it('bounds the WAIT, not just the buffer — a 0.09x worker must not buy 90s of silence', async () => {
+    // 0.09x is the slowest rate measured in #12460.
+    await calibrate(0.09)
+    const scheduledAfterCalibration = scheduledStarts
+    ctxTime = 1000
+    endAllScheduled()
+
+    // A 180-char reply: the derived lead-in is (1 - 0.09) * 10.8s = 9.8s, capped
+    // to 8 audio-seconds. Filling 8s at 0.09x would take ~90s of silence. The
+    // wall-clock bound caps the buffer at MAX_WAIT*r = 0.72s instead.
+    serverSend({ type: 'tts_start', text: 'x'.repeat(180) })
+    await sendChunk(0)
+    await sendChunk(2778)
+    await sendChunk(2778)
+
+    // 0.75s buffered clears the 0.72s bound: speech starts inside the wait
+    // budget rather than a minute and a half later.
+    expect(scheduledStarts).toBe(scheduledAfterCalibration + 3)
+  })
+
+  it('a chunk decoded after its utterance ended is not folded into the next one', async () => {
+    await calibrate(0.25)
+    const scheduledAfterCalibration = scheduledStarts
+    ctxTime = 1000
+    endAllScheduled()
+
+    // Last chunk of utterance A is still decoding when tts_end and the next
+    // tts_start arrive — the real ordering, since decodeAudioData is async.
+    clockMs += 1000
+    serverSend({ type: 'tts_audio', data: B64, chunk: 9 })
+    serverSend({ type: 'tts_end' })
+    serverSend({ type: 'tts_start', text: 'twenty chars exactly' })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    // It belongs to the reply already playing, so it goes straight to the
+    // timeline instead of being held with — and skewing the rate of — utterance B.
+    expect(scheduledStarts).toBe(scheduledAfterCalibration + 1)
+  })
+
+  it('recovers its target after a transient arrival gap instead of ratcheting to the cap', async () => {
+    await calibrate(0.5)
+    const scheduledAfterCalibration = scheduledStarts
+    ctxTime = 1000
+    endAllScheduled()
+
+    serverSend({ type: 'tts_start', text: 'x'.repeat(60) })
+    await sendChunk(0)
+    // One long stall, then the worker catches up at a healthy rate.
+    await sendChunk(6000)
+    for (let i = 0; i < 8; i++) await sendChunk(120)
+
+    // The cumulative rate recovers, so the target falls back and the audio is
+    // released. A one-way ratchet pinned it at the cap for the whole utterance.
+    expect(scheduledStarts).toBeGreaterThan(scheduledAfterCalibration)
   })
 
   it('does not schedule held audio onto a context suspended during the hold', async () => {

--- a/autobot-frontend/src/composables/__tests__/useVoiceOutput.preroll.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useVoiceOutput.preroll.test.ts
@@ -108,13 +108,23 @@ class FakeWebSocket {
   onerror: ((e: unknown) => void) | null = null
   onclose: (() => void) | null = null
   onmessage: ((e: { data: string }) => void) | null = null
-  constructor(_url: string) {
-    lastSocket = this
+  constructor() {
     setTimeout(() => this.onopen?.(), 0)
   }
   send() {}
   close() {}
 }
+
+// Constructed through a factory rather than recording `this` inside the
+// constructor, which trips oxlint's no-this-alias. `new` on a function that
+// returns an object yields that object, so the composable's `new WebSocket(url)`
+// still gets a FakeWebSocket.
+function FakeWebSocketFactory(): FakeWebSocket {
+  const socket = new FakeWebSocket()
+  lastSocket = socket
+  return socket
+}
+FakeWebSocketFactory.OPEN = 1
 
 const B64 = btoa('fake-audio-bytes')
 
@@ -163,7 +173,7 @@ describe('useVoiceOutput — adaptive pre-roll for a below-real-time worker (#12
     originalAudioContext = (globalThis as Record<string, unknown>).AudioContext
     originalWebSocket = (globalThis as Record<string, unknown>).WebSocket
     ;(globalThis as Record<string, unknown>).AudioContext = FakeAudioContext
-    ;(globalThis as Record<string, unknown>).WebSocket = FakeWebSocket
+    ;(globalThis as Record<string, unknown>).WebSocket = FakeWebSocketFactory
 
     // Fresh module instance per test: the measured production rate is carried in
     // module state by design, so tests must not inherit each other's.

--- a/autobot-frontend/src/composables/__tests__/useVoiceOutput.preroll.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useVoiceOutput.preroll.test.ts
@@ -1,0 +1,252 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+//
+// #12460: the TTS worker sustains well below real time on a loaded host (19 of
+// 19 measured syntheses at 0.09x-0.83x). Gapless scheduling assumes chunks
+// arrive at least as fast as they play, so every late chunk was re-anchored to
+// ctx.currentTime and the listener heard ~250ms of speech per gap — the
+// reported stutter.
+//
+// These tests drive the real WebSocket path (tts_start / tts_audio / tts_end)
+// and assert the adaptive pre-roll: nothing is held until a production rate has
+// been measured, a below-real-time rate buys a lead-in before playback starts,
+// the tail is always flushed, and a barge-in drops what is held.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { ref } from 'vue'
+
+vi.mock('@/composables/useToast', () => ({
+  useToast: () => ({
+    showToast: vi.fn(),
+    toasts: { value: [] },
+    removeToast: vi.fn(),
+    clearAllToasts: vi.fn(),
+  }),
+}))
+
+vi.mock('@/composables/useVoiceProfiles', () => ({
+  useVoiceProfiles: () => ({
+    voices: ref([{ id: 'v1' }]),
+    fetchVoices: vi.fn(),
+    effectiveVoiceId: ref('v1'),
+  }),
+}))
+
+vi.mock('@/composables/usePreferences', () => ({
+  usePreferences: () => ({ language: ref('en') }),
+}))
+
+vi.mock('@/utils/fetchWithAuth', () => ({ fetchWithAuth: vi.fn() }))
+
+vi.mock('@/config/ssot-config', () => ({
+  getApiBase: () => '/api',
+  getBackendWsUrl: () => 'ws://test',
+}))
+
+vi.mock('@/utils/debugUtils', () => ({
+  createLogger: () => ({ error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() }),
+}))
+
+// ── Controllable fakes ─────────────────────────────────────────────────────
+let clockMs = 1_700_000_000_000
+let ctxTime = 0
+let chunkDurationSec = 0.25
+let scheduledStarts = 0
+
+class FakeBufferSource {
+  buffer: unknown = null
+  onended: (() => void) | null = null
+  connect() {}
+  start() {
+    scheduledStarts++
+  }
+  stop() {}
+}
+
+class FakeAudioContext {
+  destination = {}
+  state = 'running'
+  get currentTime() {
+    return ctxTime
+  }
+  async resume() {}
+  async decodeAudioData() {
+    return { duration: chunkDurationSec }
+  }
+  createBufferSource() {
+    return new FakeBufferSource()
+  }
+  createGain() {
+    return { gain: { value: 1 }, connect() {} }
+  }
+}
+
+// Captures the socket useVoiceOutput opens so tests can push server frames.
+let lastSocket: FakeWebSocket | null = null
+
+class FakeWebSocket {
+  static OPEN = 1
+  readyState = 1
+  onopen: (() => void) | null = null
+  onerror: ((e: unknown) => void) | null = null
+  onclose: (() => void) | null = null
+  onmessage: ((e: { data: string }) => void) | null = null
+  constructor(_url: string) {
+    lastSocket = this
+    setTimeout(() => this.onopen?.(), 0)
+  }
+  send() {}
+  close() {}
+}
+
+const B64 = btoa('fake-audio-bytes')
+
+type VoiceOutputModule = typeof import('../useVoiceOutput')
+let useVoiceOutput: VoiceOutputModule['useVoiceOutput']
+
+/** Push a server frame through the captured socket. */
+function serverSend(msg: Record<string, unknown>): void {
+  lastSocket?.onmessage?.({ data: JSON.stringify(msg) })
+}
+
+/** Deliver one audio chunk `advanceMs` after the previous one. */
+async function sendChunk(advanceMs = 1000): Promise<void> {
+  clockMs += advanceMs
+  serverSend({ type: 'tts_audio', data: B64, chunk: 1 })
+  // A macrotask boundary drains the whole decode/schedule microtask chain.
+  await new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+/**
+ * Run one utterance whose chunks arrive at `rtf` audio-seconds per wall-second,
+ * so the composable carries that production rate into the next utterance.
+ */
+async function calibrate(rtf: number, chunks = 3): Promise<void> {
+  serverSend({ type: 'tts_start', text: 'calibration utterance' })
+  await sendChunk(0)
+  for (let i = 1; i < chunks; i++) {
+    await sendChunk((chunkDurationSec / rtf) * 1000)
+  }
+  serverSend({ type: 'tts_end' })
+}
+
+describe('useVoiceOutput — adaptive pre-roll for a below-real-time worker (#12460)', () => {
+  let originalAudioContext: unknown
+  let originalWebSocket: unknown
+
+  beforeEach(async () => {
+    clockMs += 60_000
+    ctxTime = 0
+    chunkDurationSec = 0.25
+    scheduledStarts = 0
+    lastSocket = null
+    vi.spyOn(Date, 'now').mockImplementation(() => clockMs)
+    originalAudioContext = (globalThis as Record<string, unknown>).AudioContext
+    originalWebSocket = (globalThis as Record<string, unknown>).WebSocket
+    ;(globalThis as Record<string, unknown>).AudioContext = FakeAudioContext
+    ;(globalThis as Record<string, unknown>).WebSocket = FakeWebSocket
+
+    // Fresh module instance per test: the measured production rate is carried in
+    // module state by design, so tests must not inherit each other's.
+    vi.resetModules()
+    const mod = await import('../useVoiceOutput')
+    useVoiceOutput = mod.useVoiceOutput
+
+    // Open the socket the composable owns.
+    const unsubscribe = useVoiceOutput().subscribeVoiceMessages(() => {})
+    await vi.waitFor(() => expect(lastSocket).not.toBeNull())
+    unsubscribe()
+  })
+
+  afterEach(() => {
+    useVoiceOutput().stopSpeaking()
+    ;(globalThis as Record<string, unknown>).AudioContext = originalAudioContext
+    ;(globalThis as Record<string, unknown>).WebSocket = originalWebSocket
+    vi.restoreAllMocks()
+  })
+
+  it('holds nothing on the first utterance — no measured rate, so first-audio latency is unchanged', async () => {
+    serverSend({ type: 'tts_start', text: 'a reasonably long first sentence to speak' })
+    await sendChunk(0)
+    expect(scheduledStarts).toBe(1)
+    await sendChunk(4000)
+    expect(scheduledStarts).toBe(2)
+  })
+
+  it('pre-rolls the next utterance once the worker is measured below real time', async () => {
+    // 0.25x: 0.25s of audio per 1s of wall clock.
+    await calibrate(0.25)
+    const scheduledAfterCalibration = scheduledStarts
+    // Let the calibration audio finish so it contributes no lead-in.
+    ctxTime = 1000
+
+    // 20 chars * 0.06 s/char = 1.2s estimated audio; target = (1 - 0.25) * 1.2 = 0.9s.
+    serverSend({ type: 'tts_start', text: 'twenty chars exactly' })
+    await sendChunk(0)
+    await sendChunk(1000)
+    await sendChunk(1000)
+    // 0.75s buffered — still short of the 0.9s lead-in, so nothing plays yet.
+    expect(scheduledStarts).toBe(scheduledAfterCalibration)
+
+    await sendChunk(1000)
+    // 1.0s buffered clears the target: every held chunk is released at once.
+    expect(scheduledStarts).toBe(scheduledAfterCalibration + 4)
+  })
+
+  it('flushes the tail on tts_end even when the lead-in target was never reached', async () => {
+    await calibrate(0.25)
+    const scheduledAfterCalibration = scheduledStarts
+    ctxTime = 1000
+
+    serverSend({ type: 'tts_start', text: 'twenty chars exactly' })
+    await sendChunk(0)
+    await sendChunk(1000)
+    expect(scheduledStarts).toBe(scheduledAfterCalibration)
+
+    serverSend({ type: 'tts_end' })
+    expect(scheduledStarts).toBe(scheduledAfterCalibration + 2)
+  })
+
+  it('drops held audio on stopSpeaking() so barge-in is immediate', async () => {
+    await calibrate(0.25)
+    const scheduledAfterCalibration = scheduledStarts
+    ctxTime = 1000
+
+    serverSend({ type: 'tts_start', text: 'twenty chars exactly' })
+    await sendChunk(0)
+    await sendChunk(1000)
+    expect(scheduledStarts).toBe(scheduledAfterCalibration)
+
+    useVoiceOutput().stopSpeaking()
+    serverSend({ type: 'tts_end' })
+    // The superseded reply is never spoken, not even by the tail flush.
+    expect(scheduledStarts).toBe(scheduledAfterCalibration)
+  })
+
+  it('does not pre-roll when the worker sustains real time', async () => {
+    // 2x: audio is produced twice as fast as it plays, so no lead-in is needed.
+    await calibrate(2.0)
+    const scheduledAfterCalibration = scheduledStarts
+    ctxTime = 1000
+
+    serverSend({ type: 'tts_start', text: 'twenty chars exactly' })
+    await sendChunk(0)
+    expect(scheduledStarts).toBe(scheduledAfterCalibration + 1)
+  })
+
+  it('counts audio still scheduled ahead as lead-in, so a follow-on sentence is not delayed twice', async () => {
+    await calibrate(0.25)
+    const scheduledAfterCalibration = scheduledStarts
+    // The playhead has not moved, so the calibration utterance's 3 x 0.25s are
+    // still queued ahead of it — 0.75s of real lead-in the next sentence inherits.
+    ctxTime = 0
+
+    serverSend({ type: 'tts_start', text: 'twenty chars exactly' })
+    // 0.75s ahead + this 0.25s chunk clears the 0.9s target on the FIRST chunk,
+    // instead of waiting out the full lead-in a second time.
+    await sendChunk(0)
+    expect(scheduledStarts).toBe(scheduledAfterCalibration + 1)
+  })
+})

--- a/autobot-frontend/src/composables/__tests__/useVoiceOutput.preroll.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useVoiceOutput.preroll.test.ts
@@ -17,9 +17,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { ref } from 'vue'
 
+const mockShowToast = vi.fn()
+
 vi.mock('@/composables/useToast', () => ({
   useToast: () => ({
-    showToast: vi.fn(),
+    showToast: mockShowToast,
     toasts: { value: [] },
     removeToast: vi.fn(),
     clearAllToasts: vi.fn(),
@@ -52,8 +54,10 @@ vi.mock('@/utils/debugUtils', () => ({
 // ── Controllable fakes ─────────────────────────────────────────────────────
 let clockMs = 1_700_000_000_000
 let ctxTime = 0
+let ctxState: 'running' | 'suspended' = 'running'
 let chunkDurationSec = 0.25
 let scheduledStarts = 0
+let liveSources: FakeBufferSource[] = []
 
 class FakeBufferSource {
   buffer: unknown = null
@@ -61,13 +65,24 @@ class FakeBufferSource {
   connect() {}
   start() {
     scheduledStarts++
+    // Stays "playing" until a test ends it, mirroring a real source node.
+    liveSources.push(this)
   }
   stop() {}
 }
 
+/** Finish every scheduled source, as the real timeline would on playout. */
+function endAllScheduled(): void {
+  const sources = liveSources
+  liveSources = []
+  for (const source of sources) source.onended?.()
+}
+
 class FakeAudioContext {
   destination = {}
-  state = 'running'
+  get state() {
+    return ctxState
+  }
   get currentTime() {
     return ctxTime
   }
@@ -139,8 +154,10 @@ describe('useVoiceOutput — adaptive pre-roll for a below-real-time worker (#12
   beforeEach(async () => {
     clockMs += 60_000
     ctxTime = 0
+    ctxState = 'running'
     chunkDurationSec = 0.25
     scheduledStarts = 0
+    liveSources = []
     lastSocket = null
     vi.spyOn(Date, 'now').mockImplementation(() => clockMs)
     originalAudioContext = (globalThis as Record<string, unknown>).AudioContext
@@ -236,17 +253,130 @@ describe('useVoiceOutput — adaptive pre-roll for a below-real-time worker (#12
     expect(scheduledStarts).toBe(scheduledAfterCalibration + 1)
   })
 
-  it('counts audio still scheduled ahead as lead-in, so a follow-on sentence is not delayed twice', async () => {
+  it('credits scheduled-ahead audio at the production rate, not at its full duration', async () => {
     await calibrate(0.25)
     const scheduledAfterCalibration = scheduledStarts
     // The playhead has not moved, so the calibration utterance's 3 x 0.25s are
-    // still queued ahead of it — 0.75s of real lead-in the next sentence inherits.
+    // still queued ahead of it: A = 0.75s.
     ctxTime = 0
 
+    // Target is 0.9s. While those 0.75s play out the worker adds only r*A =
+    // 0.1875s, NOT 0.75s — crediting A at full value would release here, one
+    // chunk in, with 0.25s buffered against a 1.2s utterance, and starve.
     serverSend({ type: 'tts_start', text: 'twenty chars exactly' })
-    // 0.75s ahead + this 0.25s chunk clears the 0.9s target on the FIRST chunk,
-    // instead of waiting out the full lead-in a second time.
     await sendChunk(0)
-    expect(scheduledStarts).toBe(scheduledAfterCalibration + 1)
+    expect(scheduledStarts).toBe(scheduledAfterCalibration)
+    await sendChunk(1000)
+    expect(scheduledStarts).toBe(scheduledAfterCalibration)
+
+    // 0.75s buffered + 0.1875s credited clears 0.9s — one chunk sooner than the
+    // four needed with no audio queued ahead, which is the real benefit.
+    await sendChunk(1000)
+    expect(scheduledStarts).toBe(scheduledAfterCalibration + 3)
+  })
+
+  it('keeps isSpeaking true while holding, so the mic is not reopened mid-reply', async () => {
+    await calibrate(0.25)
+    ctxTime = 1000
+    endAllScheduled()
+    const { isSpeaking } = useVoiceOutput()
+    // Calibration audio has played out; nothing is sounding.
+    expect(isSpeaking.value).toBe(false)
+
+    serverSend({ type: 'tts_start', text: 'twenty chars exactly' })
+    await sendChunk(0)
+
+    // The reply is buffering, not finished. A false here fires
+    // watch(isSpeaking) in useVoiceConversation, which expires the TTS echo
+    // cooldown and reopens the mic while AutoBot is still about to speak.
+    expect(isSpeaking.value).toBe(true)
+  })
+
+  it('does not force-release while the worker is still producing — the stall timer is not a cap', async () => {
+    // Calibrate on real timers: sendChunk drains the decode chain via a real
+    // macrotask, which a fake clock would never fire.
+    await calibrate(0.25)
+    const scheduledAfterCalibration = scheduledStarts
+    ctxTime = 1000
+
+    vi.useFakeTimers()
+    try {
+      // A 180-char reply targets the 8s cap; filling it at 0.25x legitimately
+      // takes ~32s. A total-duration timer would force-release mid-fill and
+      // hand back exactly the stutter this feature exists to remove.
+      serverSend({ type: 'tts_start', text: 'x'.repeat(180) })
+      for (let i = 0; i < 6; i++) {
+        clockMs += 4000
+        serverSend({ type: 'tts_audio', data: B64, chunk: i })
+        await vi.advanceTimersByTimeAsync(4000)
+      }
+
+      // 24s of wall clock, well past a 20s one-shot timer, and still holding.
+      expect(scheduledStarts).toBe(scheduledAfterCalibration)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('releases held audio when the worker genuinely stalls', async () => {
+    await calibrate(0.25)
+    const scheduledAfterCalibration = scheduledStarts
+    ctxTime = 1000
+
+    vi.useFakeTimers()
+    try {
+      serverSend({ type: 'tts_start', text: 'x'.repeat(180) })
+      clockMs += 1000
+      serverSend({ type: 'tts_audio', data: B64, chunk: 0 })
+      await vi.advanceTimersByTimeAsync(1)
+      expect(scheduledStarts).toBe(scheduledAfterCalibration)
+
+      // No further chunk — the watchdog plays what is buffered rather than
+      // stranding it.
+      await vi.advanceTimersByTimeAsync(11_000)
+      expect(scheduledStarts).toBe(scheduledAfterCalibration + 1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not schedule held audio onto a context suspended during the hold', async () => {
+    await calibrate(0.25)
+    const scheduledAfterCalibration = scheduledStarts
+    ctxTime = 1000
+    endAllScheduled()
+
+    serverSend({ type: 'tts_start', text: 'twenty chars exactly' })
+    await sendChunk(0)
+    await sendChunk(1000)
+
+    // The tab was backgrounded while the reply buffered. Starting sources on a
+    // frozen timeline never fires onended, which is how the indicator used to
+    // stick (#12503) — take the gesture-unlock exit instead.
+    ctxState = 'suspended'
+    const { isSpeaking } = useVoiceOutput()
+    serverSend({ type: 'tts_end' })
+
+    expect(scheduledStarts).toBe(scheduledAfterCalibration)
+    expect(isSpeaking.value).toBe(false)
+    expect(mockShowToast).toHaveBeenCalledWith(expect.any(String), 'info')
+  })
+
+  it('a superseded reply mid-hold is dropped by speak(), not spoken first', async () => {
+    await calibrate(0.25)
+    const scheduledAfterCalibration = scheduledStarts
+    ctxTime = 1000
+
+    serverSend({ type: 'tts_start', text: 'twenty chars exactly' })
+    await sendChunk(0)
+    await sendChunk(1000)
+    expect(scheduledStarts).toBe(scheduledAfterCalibration)
+
+    // A new one-shot utterance supersedes the held reply. speak()'s stop guard
+    // must fire even though nothing is on the timeline yet, or _beginUtterance's
+    // release speaks the superseded audio first — the #12502 failure.
+    await useVoiceOutput().speak('a replacement utterance', true)
+
+    expect(scheduledStarts).toBe(scheduledAfterCalibration)
   })
 })

--- a/autobot-frontend/src/composables/__tests__/useVoiceOutput.preroll.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useVoiceOutput.preroll.test.ts
@@ -424,6 +424,76 @@ describe('useVoiceOutput — adaptive pre-roll for a below-real-time worker (#12
     expect(mockShowToast).toHaveBeenCalledWith(expect.any(String), 'info')
   })
 
+  it('keeps isSpeaking true when the previous sentence drains while the next pre-rolls', async () => {
+    await calibrate(0.25)
+    ctxTime = 1000
+    const { isSpeaking } = useVoiceOutput()
+
+    serverSend({ type: 'tts_start', text: 'twenty chars exactly' })
+    await sendChunk(0)
+    expect(isSpeaking.value).toBe(true)
+
+    // The previous sentence's audio finishes while this one is still buffering.
+    // Clearing isSpeaking here fires watch(isSpeaking) in useVoiceConversation,
+    // which reopens the mic in the gap between sentences.
+    endAllScheduled()
+    expect(isSpeaking.value).toBe(true)
+  })
+
+  it('ignores a nonsense rate from two chunks arriving coalesced', async () => {
+    await calibrate(0.25)
+    const scheduledAfterCalibration = scheduledStarts
+    ctxTime = 1000
+    endAllScheduled()
+
+    serverSend({ type: 'tts_start', text: 'twenty chars exactly' })
+    await sendChunk(0)
+    // 2ms apart: a cumulative rate of ~125x. Trusting it drops the target to 0
+    // and releases the pre-roll for the rest of the utterance.
+    await sendChunk(2)
+    expect(scheduledStarts).toBe(scheduledAfterCalibration)
+  })
+
+  it('drops chunks still decoding when a stop lands, so no fragment is spoken', async () => {
+    await calibrate(2.0)
+    const scheduledAfterCalibration = scheduledStarts
+    ctxTime = 1000
+    endAllScheduled()
+    const { isSpeaking, stopSpeaking } = useVoiceOutput()
+
+    // Chunk dispatched, then barge-in before its decode resolves.
+    serverSend({ type: 'tts_start', text: 'twenty chars exactly' })
+    clockMs += 100
+    serverSend({ type: 'tts_audio', data: B64, chunk: 1 })
+    stopSpeaking()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(scheduledStarts).toBe(scheduledAfterCalibration)
+    expect(isSpeaking.value).toBe(false)
+  })
+
+  it('retains held audio across a suspend instead of losing the reply opening', async () => {
+    await calibrate(0.25)
+    const scheduledAfterCalibration = scheduledStarts
+    ctxTime = 1000
+    endAllScheduled()
+
+    serverSend({ type: 'tts_start', text: 'twenty chars exactly' })
+    await sendChunk(0)
+    await sendChunk(1000)
+
+    // Backgrounded mid-hold: the release cannot schedule, but the audio is the
+    // opening of the reply and must survive until the context is unlocked.
+    ctxState = 'suspended'
+    serverSend({ type: 'tts_end' })
+    expect(scheduledStarts).toBe(scheduledAfterCalibration)
+
+    // Once unlocked, the retained audio still plays.
+    ctxState = 'running'
+    await sendChunk(1000)
+    expect(scheduledStarts).toBeGreaterThan(scheduledAfterCalibration)
+  })
+
   it('a superseded reply mid-hold is dropped by speak(), not spoken first', async () => {
     await calibrate(0.25)
     const scheduledAfterCalibration = scheduledStarts

--- a/autobot-frontend/src/composables/useVoiceOutput.ts
+++ b/autobot-frontend/src/composables/useVoiceOutput.ts
@@ -78,9 +78,15 @@ let _activeChunkCount = 0
 // worker adds only r*A. Extending the derivation over A + D of playout gives
 // B >= (1 - r) * D - r * A, so scheduled-ahead audio is credited at r*A.
 const _RTF_TARGET = 1.0
-// Upper bound on the lead-in, so a very slow worker degrades to "a bit late"
-// rather than "silent for the length of the reply".
+// Upper bound on the lead-in in AUDIO-seconds.
 const _PREROLL_MAX_SEC = 8
+// ...and the bound that actually caps latency. Buffering B audio-seconds at rate
+// r costs B/r of WALL time, so an audio-seconds cap alone is not a wait bound: at
+// the 0.09x measured in #12460 an 8s target is ~90s of silence before speech.
+// Affordable buffer within this wait is MAX_WAIT*r, so the slowest workers buy
+// less lead-in rather than an unbounded delay — they stutter, and the
+// below-real-time alert is what surfaces the real problem.
+const _PREROLL_MAX_WAIT_SEC = 8
 // Stall watchdog, NOT a cap on filling the lead-in: filling T audio-seconds at
 // rate r legitimately takes T/r wall-seconds, so a total-duration timer would
 // force-release exactly the slow workers this exists for. Re-armed on every held
@@ -103,6 +109,9 @@ let _utteranceEstimateSec = 0
 // Rate this utterance is being sized against — the carried rate, lowered if the
 // utterance turns out to be producing even more slowly than that.
 let _utteranceRtf = 0
+// Bumped per utterance so a chunk that finishes decoding after its own
+// utterance ended is not folded into the next one's buffer or rate.
+let _utteranceSeq = 0
 let _prerollTimer: ReturnType<typeof setTimeout> | null = null
 // Arrival wall-clock of this utterance's FIRST chunk. Time-to-first-chunk is
 // model warm-up, not production rate, so the rate is measured from chunk 2 on.
@@ -446,8 +455,10 @@ function _recordRtfSample(sample: number): void {
 
 /** Lead-in needed for `estimateSec` of audio produced at `rtf` (#12460). */
 function _prerollTargetSec(rtf: number, estimateSec: number): number {
-  if (rtf >= _RTF_TARGET) return 0
-  return Math.min(_PREROLL_MAX_SEC, Math.max(0, (1 - rtf) * estimateSec))
+  if (rtf >= _RTF_TARGET || rtf <= 0) return 0
+  const derived = (1 - rtf) * estimateSec
+  // Bounded by audio-seconds AND by what fits in the wall-clock wait budget.
+  return Math.max(0, Math.min(derived, _PREROLL_MAX_SEC, _PREROLL_MAX_WAIT_SEC * rtf))
 }
 
 /**
@@ -459,6 +470,7 @@ function _beginUtterance(text: string): void {
   // explicit stop discards it.
   _releasePending()
   _resetPreroll()
+  _utteranceSeq++
   const rtf = _measuredRtf
   if (rtf === null) return
   _utteranceRtf = rtf
@@ -466,7 +478,9 @@ function _beginUtterance(text: string): void {
   _utterancePrerollSec = _prerollTargetSec(rtf, _utteranceEstimateSec)
   if (_utterancePrerollSec <= 0) return
   _utteranceHolding = true
-  _armStallTimer()
+  // The watchdog is armed by the first held chunk, NOT here: a slow first chunk
+  // would otherwise fire it against an empty buffer, and that release clears
+  // _utteranceHolding — silently disabling pre-roll for the whole utterance.
 }
 
 /**
@@ -497,6 +511,7 @@ function _endUtterance(): void {
  * utterance at the observed production rate.
  */
 async function _scheduleGaplessChunk(arrayBuffer: ArrayBuffer): Promise<void> {
+  const seq = _utteranceSeq
   const ctx = _getOrCreateContext()
   if (ctx.state === 'suspended') {
     // A resume() from the WS onmessage handler is not a user gesture; try once,
@@ -513,6 +528,16 @@ async function _scheduleGaplessChunk(arrayBuffer: ArrayBuffer): Promise<void> {
   }
 
   const audioBuffer = await ctx.decodeAudioData(arrayBuffer.slice(0))
+
+  if (seq !== _utteranceSeq) {
+    // Decoding is genuinely async, so the previous utterance's last chunk often
+    // resolves after the next tts_start. It belongs to the reply already being
+    // played — schedule it straight through rather than holding it with, and
+    // skewing the rate of, an utterance it is not part of.
+    _scheduleBuffer(ctx, audioBuffer)
+    return
+  }
+
   const liveRtf = _observeChunkRate(audioBuffer.duration)
 
   if (!_utteranceHolding) {
@@ -527,14 +552,13 @@ async function _scheduleGaplessChunk(arrayBuffer: ArrayBuffer): Promise<void> {
   // expiring the TTS echo cooldown and reopening the mic mid-reply.
   isSpeaking.value = true
   _armStallTimer()
-  if (liveRtf !== null && liveRtf < _utteranceRtf) {
-    // This utterance is producing even slower than the carried rate predicted —
-    // raise its target rather than start into a stream that will still starve.
+  if (liveRtf !== null) {
+    // Track the live rate in both directions. _observeChunkRate is cumulative
+    // over the utterance, so it is already smooth; ratcheting it downward instead
+    // let one transient arrival gap pin the target at the cap for the rest of
+    // the utterance with no way to recover.
     _utteranceRtf = liveRtf
-    _utterancePrerollSec = Math.max(
-      _utterancePrerollSec,
-      _prerollTargetSec(liveRtf, _utteranceEstimateSec)
-    )
+    _utterancePrerollSec = _prerollTargetSec(liveRtf, _utteranceEstimateSec)
   }
   if (_leadSec(_utteranceRtf) >= _utterancePrerollSec) _releasePending()
 }

--- a/autobot-frontend/src/composables/useVoiceOutput.ts
+++ b/autobot-frontend/src/composables/useVoiceOutput.ts
@@ -97,6 +97,11 @@ const _PREROLL_STALL_MS = 10_000
 const _SEC_PER_CHAR = 0.06
 // Weight of the newest per-utterance sample in the carried real-time factor.
 const _RTF_SMOOTHING = 0.3
+// Shortest window a production rate may be derived from. Two chunks that
+// arrive coalesced a few ms apart otherwise compute as ~100x, drive the
+// target to zero and release the pre-roll for good — the mirror image of the
+// transient gap already handled below.
+const _RTF_MIN_WINDOW_SEC = 0.5
 
 // Carried production rate in audio-seconds per wall-second; null until measured.
 let _measuredRtf: number | null = null
@@ -112,11 +117,19 @@ let _utteranceRtf = 0
 // Bumped per utterance so a chunk that finishes decoding after its own
 // utterance ended is not folded into the next one's buffer or rate.
 let _utteranceSeq = 0
+// Bumped by every explicit stop, so a chunk decoded after a barge-in is
+// dropped rather than spoken as a fragment of the superseded reply.
+let _stopSeq = 0
 let _prerollTimer: ReturnType<typeof setTimeout> | null = null
 // Arrival wall-clock of this utterance's FIRST chunk. Time-to-first-chunk is
 // model warm-up, not production rate, so the rate is measured from chunk 2 on.
 let _rtfFirstChunkAt = 0
 let _rtfProducedSec = 0
+// Arrival of the LAST observed chunk. The carried rate is measured to here, not
+// to tts_end: the final chunk is often still decoding when the utterance ends,
+// so measuring to "now" left its arrival interval in the window with its audio
+// missing and biased the worker slow.
+let _rtfLastChunkAt = 0
 
 // Single shared WebSocket to /api/voice/stream (#6788).
 // Was: useVoiceOutput + useVoiceConversation each opened their own socket to the
@@ -278,7 +291,10 @@ function _stopCurrentAudio(): void {
   _speakQueue.length = 0
   _speakController?.abort()
   // #12460: audio still inside the pre-roll buffer belongs to the superseded
-  // reply — dropping it here is what makes barge-in immediate.
+  // reply — dropping it here is what makes barge-in immediate. Bumping the stop
+  // sequence also discards chunks still being decoded, which no flag could
+  // otherwise reach.
+  _stopSeq++
   _resetPreroll()
   if (_currentSource) {
     try { _currentSource.stop() } catch { /* already stopped */ }
@@ -344,6 +360,7 @@ function _resetPreroll(): void {
   _utteranceRtf = 0
   _rtfFirstChunkAt = 0
   _rtfProducedSec = 0
+  _rtfLastChunkAt = 0
 }
 
 /**
@@ -382,7 +399,10 @@ function _scheduleBuffer(ctx: AudioContext, audioBuffer: AudioBuffer): void {
     _activeChunkCount--
     if (_activeChunkCount <= 0) {
       _activeChunkCount = 0
-      isSpeaking.value = false
+      // Not idle if the NEXT sentence is already buffering: clearing here fires
+      // watch(isSpeaking) in useVoiceConversation, which reopens the mic in the
+      // gap between sentences (#12460).
+      if (!_utteranceHolding) isSpeaking.value = false
     }
   }
 
@@ -411,8 +431,14 @@ function _releasePending(): void {
   if (ctx.state === 'suspended') {
     // The context was running when these chunks were held but the tab has been
     // backgrounded since. Starting sources on a frozen timeline never fires
-    // onended, which is exactly how the indicator used to stick (#12503) — take
-    // the same exit every other playback path takes instead.
+    // onended, which is exactly how the indicator used to stick (#12503).
+    // Put them back rather than discarding them: this can be up to the whole
+    // lead-in, i.e. the opening of the reply. The next chunk, the end of the
+    // utterance, or an explicit stop retries or clears them — no timer is
+    // re-armed here, so a still-suspended context cannot spin.
+    _pendingBuffers = buffers
+    _pendingSec = buffers.reduce((total, buffer) => total + buffer.duration, 0)
+    _utteranceHolding = true
     _armGestureUnlock()
     _notifyTapToEnableAudio()
     if (_activeChunkCount <= 0) isSpeaking.value = false
@@ -437,13 +463,14 @@ function _armStallTimer(): void {
  */
 function _observeChunkRate(durationSec: number): number | null {
   const now = Date.now()
+  _rtfLastChunkAt = now
   if (_rtfFirstChunkAt === 0) {
     _rtfFirstChunkAt = now
     return null
   }
   _rtfProducedSec += durationSec
   const elapsedSec = (now - _rtfFirstChunkAt) / 1000
-  if (elapsedSec <= 0) return null
+  if (elapsedSec < _RTF_MIN_WINDOW_SEC) return null
   return _rtfProducedSec / elapsedSec
 }
 
@@ -490,12 +517,16 @@ function _beginUtterance(text: string): void {
  */
 function _endUtterance(): void {
   _releasePending()
-  const elapsedSec = _rtfFirstChunkAt > 0 ? (Date.now() - _rtfFirstChunkAt) / 1000 : 0
+  const elapsedSec =
+    _rtfFirstChunkAt > 0 && _rtfLastChunkAt > _rtfFirstChunkAt
+      ? (_rtfLastChunkAt - _rtfFirstChunkAt) / 1000
+      : 0
   if (elapsedSec > 0 && _rtfProducedSec > 0) {
     _recordRtfSample(_rtfProducedSec / elapsedSec)
   }
   _rtfFirstChunkAt = 0
   _rtfProducedSec = 0
+  _rtfLastChunkAt = 0
   _utterancePrerollSec = 0
   _utteranceEstimateSec = 0
   _utteranceRtf = 0
@@ -512,6 +543,7 @@ function _endUtterance(): void {
  */
 async function _scheduleGaplessChunk(arrayBuffer: ArrayBuffer): Promise<void> {
   const seq = _utteranceSeq
+  const stopSeq = _stopSeq
   const ctx = _getOrCreateContext()
   if (ctx.state === 'suspended') {
     // A resume() from the WS onmessage handler is not a user gesture; try once,
@@ -528,6 +560,13 @@ async function _scheduleGaplessChunk(arrayBuffer: ArrayBuffer): Promise<void> {
   }
 
   const audioBuffer = await ctx.decodeAudioData(arrayBuffer.slice(0))
+
+  if (stopSeq !== _stopSeq) {
+    // A stop / barge-in landed while this chunk was decoding. It belongs to a
+    // reply the user has already dismissed, so it is dropped outright — playing
+    // it would speak a fragment and flip isSpeaking back on after stopSpeaking().
+    return
+  }
 
   if (seq !== _utteranceSeq) {
     // Decoding is genuinely async, so the previous utterance's last chunk often

--- a/autobot-frontend/src/composables/useVoiceOutput.ts
+++ b/autobot-frontend/src/composables/useVoiceOutput.ts
@@ -53,6 +53,52 @@ let _scheduledSources: AudioBufferSourceNode[] = []
 let _nextStartTime = 0
 let _activeChunkCount = 0
 
+// ── #12460: adaptive pre-roll so a below-real-time worker still plays smoothly ──
+//
+// Gapless scheduling only holds while the worker produces audio at least as fast
+// as it is consumed. On a loaded host it does not: 19 of 19 measured syntheses
+// ran at 0.09x-0.83x real time. Each chunk is then already late when it arrives,
+// _scheduleGaplessChunk re-anchors it to ctx.currentTime, and the listener hears
+// ~250ms of speech per gap — the reported stutter.
+//
+// Fix: hold decoded chunks until enough audio is buffered for the REST of the
+// utterance to play out continuously. For an utterance of D audio-seconds
+// produced at r audio-seconds per wall-second, playback that starts with B
+// seconds buffered stays gapless iff B >= (1 - r) * D — consumed time t must
+// never exceed produced audio B + r*t, and the binding case is t = D.
+//
+// D is estimated from the utterance text; r is measured from chunk arrivals and
+// carried ACROSS utterances, because it is a property of the worker and its host,
+// not of the sentence. With no measurement yet (first utterance of a session) or
+// a worker at/above real time, nothing is held back and the #13215 first-audio
+// latency is untouched.
+const _RTF_TARGET = 1.0
+// Upper bound on the lead-in, so a very slow worker degrades to "a bit late"
+// rather than "silent for the length of the reply".
+const _PREROLL_MAX_SEC = 8
+// Safety net: release held audio even if the utterance never signals its end
+// (socket dropped mid-stream, worker stalled) so chunks can never be stranded.
+const _PREROLL_TIMEOUT_MS = 20_000
+// Audio-seconds per character, used to size D before any audio exists. Measured
+// on the deploy in #12460: 49 chars -> ~3.3s, 209 chars -> ~11.4s of audio.
+const _SEC_PER_CHAR = 0.06
+// Weight of the newest per-utterance sample in the carried real-time factor.
+const _RTF_SMOOTHING = 0.3
+
+// Carried production rate in audio-seconds per wall-second; null until measured.
+let _measuredRtf: number | null = null
+// Decoded chunks held back during the current utterance's lead-in.
+let _pendingBuffers: AudioBuffer[] = []
+let _pendingSec = 0
+let _utteranceHolding = false
+let _utterancePrerollSec = 0
+let _utteranceEstimateSec = 0
+let _prerollTimer: ReturnType<typeof setTimeout> | null = null
+// Arrival wall-clock of this utterance's FIRST chunk. Time-to-first-chunk is
+// model warm-up, not production rate, so the rate is measured from chunk 2 on.
+let _rtfFirstChunkAt = 0
+let _rtfProducedSec = 0
+
 // Single shared WebSocket to /api/voice/stream (#6788).
 // Was: useVoiceOutput + useVoiceConversation each opened their own socket to the
 // same endpoint, causing diverging backend state machines and dropped TTS on the
@@ -212,6 +258,9 @@ function _stopCurrentAudio(): void {
   // drain loop stops instead of continuing to speak a superseded reply.
   _speakQueue.length = 0
   _speakController?.abort()
+  // #12460: audio still inside the pre-roll buffer belongs to the superseded
+  // reply — dropping it here is what makes barge-in immediate.
+  _resetPreroll()
   if (_currentSource) {
     try { _currentSource.stop() } catch { /* already stopped */ }
     _currentSource = null
@@ -262,28 +311,34 @@ async function _playAudioBuffer(arrayBuffer: ArrayBuffer): Promise<void> {
   })
 }
 
-/**
- * Schedule an audio chunk for gapless playback on the AudioContext timeline (#1527).
- * Instead of awaiting each chunk sequentially (which causes gaps during decode),
- * we decode immediately and schedule at the next available time slot.
- */
-async function _scheduleGaplessChunk(arrayBuffer: ArrayBuffer): Promise<void> {
-  const ctx = _getOrCreateContext()
-  if (ctx.state === 'suspended') {
-    // A resume() from the WS onmessage handler is not a user gesture; try once,
-    // then bail if the context stays suspended (#12503).
-    await ctx.resume().catch((e) => logger.warn('AudioContext resume failed:', e))
+/** Discard the pre-roll buffer and its timer without playing anything (#12460). */
+function _resetPreroll(): void {
+  if (_prerollTimer) {
+    clearTimeout(_prerollTimer)
+    _prerollTimer = null
   }
-  if (ctx.state === 'suspended') {
-    // Autoplay policy still blocks playback — no audio will be heard. Re-arm a
-    // one-time gesture listener + surface a hint, and DON'T set isSpeaking so the
-    // indicator can't stick with no sound (#12503).
-    _armGestureUnlock()
-    _notifyTapToEnableAudio()
-    return
-  }
+  _pendingBuffers = []
+  _pendingSec = 0
+  _utteranceHolding = false
+  _utterancePrerollSec = 0
+  _utteranceEstimateSec = 0
+  _rtfFirstChunkAt = 0
+  _rtfProducedSec = 0
+}
 
-  const audioBuffer = await ctx.decodeAudioData(arrayBuffer.slice(0))
+/**
+ * Audio already committed to the listener: what is still scheduled ahead on the
+ * AudioContext timeline, plus what is held in the pre-roll buffer (#12460).
+ * Chunks queued behind a previous sentence inherit its remaining playout as
+ * lead-in, so back-to-back sentences rarely wait at all.
+ */
+function _leadSec(): number {
+  const ahead = _audioContext ? Math.max(0, _nextStartTime - _audioContext.currentTime) : 0
+  return ahead + _pendingSec
+}
+
+/** Place one decoded buffer on the gapless timeline (#1527). */
+function _scheduleBuffer(ctx: AudioContext, audioBuffer: AudioBuffer): void {
   const source = ctx.createBufferSource()
   source.buffer = audioBuffer
 
@@ -315,6 +370,135 @@ async function _scheduleGaplessChunk(arrayBuffer: ArrayBuffer): Promise<void> {
   // RUNNING context — never before decode/resume — so the indicator reflects
   // real audio and a suspended/failed chunk cannot leave it stuck on.
   isSpeaking.value = true
+}
+
+/** Hand every held chunk to the timeline and stop holding back (#12460). */
+function _releasePending(): void {
+  if (_prerollTimer) {
+    clearTimeout(_prerollTimer)
+    _prerollTimer = null
+  }
+  _utteranceHolding = false
+  if (_pendingBuffers.length === 0) {
+    _pendingSec = 0
+    return
+  }
+  const ctx = _getOrCreateContext()
+  const buffers = _pendingBuffers
+  _pendingBuffers = []
+  _pendingSec = 0
+  for (const buffer of buffers) _scheduleBuffer(ctx, buffer)
+}
+
+/**
+ * Fold one chunk into the production-rate measurement and return the live rate
+ * for this utterance, or null while it is not yet measurable (#12460).
+ */
+function _observeChunkRate(durationSec: number): number | null {
+  const now = Date.now()
+  if (_rtfFirstChunkAt === 0) {
+    _rtfFirstChunkAt = now
+    return null
+  }
+  _rtfProducedSec += durationSec
+  const elapsedSec = (now - _rtfFirstChunkAt) / 1000
+  if (elapsedSec <= 0) return null
+  return _rtfProducedSec / elapsedSec
+}
+
+/** Blend an utterance's measured production rate into the carried one (#12460). */
+function _recordRtfSample(sample: number): void {
+  _measuredRtf =
+    _measuredRtf === null ? sample : _measuredRtf + _RTF_SMOOTHING * (sample - _measuredRtf)
+}
+
+/** Lead-in needed for `estimateSec` of audio produced at `rtf` (#12460). */
+function _prerollTargetSec(rtf: number, estimateSec: number): number {
+  if (rtf >= _RTF_TARGET) return 0
+  return Math.min(_PREROLL_MAX_SEC, Math.max(0, (1 - rtf) * estimateSec))
+}
+
+/**
+ * Open an utterance: decide from the carried real-time factor whether its audio
+ * must be pre-rolled before playback starts (#12460).
+ */
+function _beginUtterance(text: string): void {
+  // A previous utterance's held audio is never dropped on a boundary — only an
+  // explicit stop discards it.
+  _releasePending()
+  _resetPreroll()
+  const rtf = _measuredRtf
+  if (rtf === null) return
+  _utteranceEstimateSec = text.trim().length * _SEC_PER_CHAR
+  _utterancePrerollSec = _prerollTargetSec(rtf, _utteranceEstimateSec)
+  if (_utterancePrerollSec <= 0) return
+  _utteranceHolding = true
+  _prerollTimer = setTimeout(() => {
+    _prerollTimer = null
+    logger.warn('TTS pre-roll timed out; playing what is buffered')
+    _releasePending()
+  }, _PREROLL_TIMEOUT_MS)
+}
+
+/**
+ * Close an utterance: flush whatever is still held — a short utterance may never
+ * reach its lead-in target, and its tail must still be spoken (#12460) — then
+ * carry the measured production rate to the next utterance.
+ */
+function _endUtterance(): void {
+  _releasePending()
+  const elapsedSec = _rtfFirstChunkAt > 0 ? (Date.now() - _rtfFirstChunkAt) / 1000 : 0
+  if (elapsedSec > 0 && _rtfProducedSec > 0) {
+    _recordRtfSample(_rtfProducedSec / elapsedSec)
+  }
+  _rtfFirstChunkAt = 0
+  _rtfProducedSec = 0
+  _utterancePrerollSec = 0
+  _utteranceEstimateSec = 0
+}
+
+/**
+ * Schedule an audio chunk for gapless playback on the AudioContext timeline (#1527).
+ * Instead of awaiting each chunk sequentially (which causes gaps during decode),
+ * we decode immediately and schedule at the next available time slot.
+ *
+ * #12460: while the utterance is pre-rolling, the decoded chunk is held instead,
+ * and everything held is released the moment the lead-in covers the rest of the
+ * utterance at the observed production rate.
+ */
+async function _scheduleGaplessChunk(arrayBuffer: ArrayBuffer): Promise<void> {
+  const ctx = _getOrCreateContext()
+  if (ctx.state === 'suspended') {
+    // A resume() from the WS onmessage handler is not a user gesture; try once,
+    // then bail if the context stays suspended (#12503).
+    await ctx.resume().catch((e) => logger.warn('AudioContext resume failed:', e))
+  }
+  if (ctx.state === 'suspended') {
+    // Autoplay policy still blocks playback — no audio will be heard. Re-arm a
+    // one-time gesture listener + surface a hint, and DON'T set isSpeaking so the
+    // indicator can't stick with no sound (#12503).
+    _armGestureUnlock()
+    _notifyTapToEnableAudio()
+    return
+  }
+
+  const audioBuffer = await ctx.decodeAudioData(arrayBuffer.slice(0))
+  const liveRtf = _observeChunkRate(audioBuffer.duration)
+
+  if (!_utteranceHolding) {
+    _scheduleBuffer(ctx, audioBuffer)
+    return
+  }
+
+  _pendingBuffers.push(audioBuffer)
+  _pendingSec += audioBuffer.duration
+  if (liveRtf !== null) {
+    // This utterance is producing even slower than the carried rate predicted —
+    // raise its target rather than start into a stream that will still starve.
+    const liveTarget = _prerollTargetSec(liveRtf, _utteranceEstimateSec)
+    if (liveTarget > _utterancePrerollSec) _utterancePrerollSec = liveTarget
+  }
+  if (_leadSec() >= _utterancePrerollSec) _releasePending()
 }
 
 /** Decode base64 audio and schedule for gapless playback (#1527). */
@@ -411,8 +595,15 @@ function _connectTtsWs(): Promise<WebSocket> {
         return
       }
       // Internal: audio playback owned here.
-      if (msg.type === 'tts_audio' && msg.data) {
+      if (msg.type === 'tts_start') {
+        // #12460: the utterance's text sizes its pre-roll before any audio exists.
+        _beginUtterance(typeof msg.text === 'string' ? msg.text : '')
+      } else if (msg.type === 'tts_audio' && msg.data) {
         void _playAudioChunkFromBase64(msg.data)
+      } else if (msg.type === 'tts_end') {
+        // #12460: the backend sends tts_end even on a mid-stream failure, so this
+        // is also what guarantees held audio is never stranded.
+        _endUtterance()
       } else if (msg.type === 'error') {
         logger.warn('Voice WS server error:', msg.message)
       }
@@ -523,7 +714,15 @@ async function _synthesizeAndPlay(text: string, signal: AbortSignal): Promise<vo
     // sounding when this resolves, so isSpeaking is left to the per-source
     // onended handler — clearing it here would drop the indicator (and fire
     // watch(isSpeaking)) while audio is mid-utterance.
-    await _playFramedAudioStream(response.body)
+    // #12460: the end of the framed body IS the end of the utterance, so the
+    // pre-roll is closed in `finally` — an abort or a truncated stream must
+    // still flush whatever was held rather than swallow it.
+    _beginUtterance(text)
+    try {
+      await _playFramedAudioStream(response.body)
+    } finally {
+      _endUtterance()
+    }
     return
   }
   const blob = await response.blob()

--- a/autobot-frontend/src/composables/useVoiceOutput.ts
+++ b/autobot-frontend/src/composables/useVoiceOutput.ts
@@ -72,13 +72,20 @@ let _activeChunkCount = 0
 // not of the sentence. With no measurement yet (first utterance of a session) or
 // a worker at/above real time, nothing is held back and the #13215 first-audio
 // latency is untouched.
+//
+// Audio still scheduled ahead of the playhead is lead-in too, but it is NOT
+// worth its own duration: while A seconds of an earlier sentence play out, the
+// worker adds only r*A. Extending the derivation over A + D of playout gives
+// B >= (1 - r) * D - r * A, so scheduled-ahead audio is credited at r*A.
 const _RTF_TARGET = 1.0
 // Upper bound on the lead-in, so a very slow worker degrades to "a bit late"
 // rather than "silent for the length of the reply".
 const _PREROLL_MAX_SEC = 8
-// Safety net: release held audio even if the utterance never signals its end
-// (socket dropped mid-stream, worker stalled) so chunks can never be stranded.
-const _PREROLL_TIMEOUT_MS = 20_000
+// Stall watchdog, NOT a cap on filling the lead-in: filling T audio-seconds at
+// rate r legitimately takes T/r wall-seconds, so a total-duration timer would
+// force-release exactly the slow workers this exists for. Re-armed on every held
+// chunk, it only fires when the worker has genuinely stopped producing.
+const _PREROLL_STALL_MS = 10_000
 // Audio-seconds per character, used to size D before any audio exists. Measured
 // on the deploy in #12460: 49 chars -> ~3.3s, 209 chars -> ~11.4s of audio.
 const _SEC_PER_CHAR = 0.06
@@ -93,6 +100,9 @@ let _pendingSec = 0
 let _utteranceHolding = false
 let _utterancePrerollSec = 0
 let _utteranceEstimateSec = 0
+// Rate this utterance is being sized against — the carried rate, lowered if the
+// utterance turns out to be producing even more slowly than that.
+let _utteranceRtf = 0
 let _prerollTimer: ReturnType<typeof setTimeout> | null = null
 // Arrival wall-clock of this utterance's FIRST chunk. Time-to-first-chunk is
 // model warm-up, not production rate, so the rate is measured from chunk 2 on.
@@ -322,19 +332,21 @@ function _resetPreroll(): void {
   _utteranceHolding = false
   _utterancePrerollSec = 0
   _utteranceEstimateSec = 0
+  _utteranceRtf = 0
   _rtfFirstChunkAt = 0
   _rtfProducedSec = 0
 }
 
 /**
- * Audio already committed to the listener: what is still scheduled ahead on the
- * AudioContext timeline, plus what is held in the pre-roll buffer (#12460).
- * Chunks queued behind a previous sentence inherit its remaining playout as
- * lead-in, so back-to-back sentences rarely wait at all.
+ * Lead-in credited to this utterance (#12460): what is held in the pre-roll
+ * buffer, plus what the worker will produce while audio already scheduled ahead
+ * plays out — r*A, not A. Crediting scheduled-ahead audio at full value would
+ * release a follow-on sentence far too early, since a sentence queued behind
+ * 5 seconds of playout still only gains 5*r seconds of production from it.
  */
-function _leadSec(): number {
+function _leadSec(rtf: number): number {
   const ahead = _audioContext ? Math.max(0, _nextStartTime - _audioContext.currentTime) : 0
-  return ahead + _pendingSec
+  return _pendingSec + rtf * ahead
 }
 
 /** Place one decoded buffer on the gapless timeline (#1527). */
@@ -387,7 +399,27 @@ function _releasePending(): void {
   const buffers = _pendingBuffers
   _pendingBuffers = []
   _pendingSec = 0
+  if (ctx.state === 'suspended') {
+    // The context was running when these chunks were held but the tab has been
+    // backgrounded since. Starting sources on a frozen timeline never fires
+    // onended, which is exactly how the indicator used to stick (#12503) — take
+    // the same exit every other playback path takes instead.
+    _armGestureUnlock()
+    _notifyTapToEnableAudio()
+    if (_activeChunkCount <= 0) isSpeaking.value = false
+    return
+  }
   for (const buffer of buffers) _scheduleBuffer(ctx, buffer)
+}
+
+/** (Re)arm the stall watchdog for the current hold (#12460). */
+function _armStallTimer(): void {
+  if (_prerollTimer) clearTimeout(_prerollTimer)
+  _prerollTimer = setTimeout(() => {
+    _prerollTimer = null
+    logger.warn('TTS pre-roll stalled; playing what is buffered')
+    _releasePending()
+  }, _PREROLL_STALL_MS)
 }
 
 /**
@@ -429,15 +461,12 @@ function _beginUtterance(text: string): void {
   _resetPreroll()
   const rtf = _measuredRtf
   if (rtf === null) return
+  _utteranceRtf = rtf
   _utteranceEstimateSec = text.trim().length * _SEC_PER_CHAR
   _utterancePrerollSec = _prerollTargetSec(rtf, _utteranceEstimateSec)
   if (_utterancePrerollSec <= 0) return
   _utteranceHolding = true
-  _prerollTimer = setTimeout(() => {
-    _prerollTimer = null
-    logger.warn('TTS pre-roll timed out; playing what is buffered')
-    _releasePending()
-  }, _PREROLL_TIMEOUT_MS)
+  _armStallTimer()
 }
 
 /**
@@ -455,6 +484,7 @@ function _endUtterance(): void {
   _rtfProducedSec = 0
   _utterancePrerollSec = 0
   _utteranceEstimateSec = 0
+  _utteranceRtf = 0
 }
 
 /**
@@ -492,13 +522,21 @@ async function _scheduleGaplessChunk(arrayBuffer: ArrayBuffer): Promise<void> {
 
   _pendingBuffers.push(audioBuffer)
   _pendingSec += audioBuffer.duration
-  if (liveRtf !== null) {
+  // #12460: the reply IS being spoken — it is buffering, not finished. Leaving
+  // isSpeaking false here would fire watch(isSpeaking) in useVoiceConversation,
+  // expiring the TTS echo cooldown and reopening the mic mid-reply.
+  isSpeaking.value = true
+  _armStallTimer()
+  if (liveRtf !== null && liveRtf < _utteranceRtf) {
     // This utterance is producing even slower than the carried rate predicted —
     // raise its target rather than start into a stream that will still starve.
-    const liveTarget = _prerollTargetSec(liveRtf, _utteranceEstimateSec)
-    if (liveTarget > _utterancePrerollSec) _utterancePrerollSec = liveTarget
+    _utteranceRtf = liveRtf
+    _utterancePrerollSec = Math.max(
+      _utterancePrerollSec,
+      _prerollTargetSec(liveRtf, _utteranceEstimateSec)
+    )
   }
-  if (_leadSec() >= _utterancePrerollSec) _releasePending()
+  if (_leadSec(_utteranceRtf) >= _utterancePrerollSec) _releasePending()
 }
 
 /** Decode base64 audio and schedule for gapless playback (#1527). */
@@ -792,7 +830,10 @@ export function useVoiceOutput() {
   // sequential fallback queue so sentences never abort each other (#12502).
   async function speak(text: string, force?: boolean): Promise<void> {
     if ((!force && !voiceOutputEnabled.value) || !text.trim()) return
-    if (isSpeaking.value) _stopCurrentAudio()
+    // #12460: a superseded reply may be mid-pre-roll rather than mid-playback.
+    // Without the holding check the stop is skipped, and _beginUtterance's
+    // release then speaks the superseded audio first — the #12502 failure.
+    if (isSpeaking.value || _utteranceHolding) _stopCurrentAudio()
 
     // #9999: surface a clear message instead of failing silently when the
     // deployment has no TTS voices installed.

--- a/autobot-infrastructure/shared/docker/monitoring/prometheus.yml
+++ b/autobot-infrastructure/shared/docker/monitoring/prometheus.yml
@@ -17,7 +17,11 @@ alerting:
   alertmanagers: []
 
 rule_files:
-  - "alerts-chat-ssot.yml"  # Phase 4 (#7590): SSOT cardinality + disk file alerts
+  # Absolute + globbed: Prometheus resolves a relative rule path against its
+  # working directory (the TSDB dir), not the config directory, so the previous
+  # bare filename never matched and NO rules loaded (#12460). The glob also means
+  # a new alerts-*.yml file needs no config change.
+  - "/etc/prometheus/alerts-*.yml"
 
 scrape_configs:
   # Prometheus self-monitoring

--- a/autobot-monitoring/alerts-tts-throughput.yml
+++ b/autobot-monitoring/alerts-tts-throughput.yml
@@ -1,0 +1,72 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+#
+# Issue #12460: TTS worker throughput alerts.
+#
+# The real-time factor — audio-seconds of speech produced per wall-second of
+# synthesis — decides whether streamed playback can run without stuttering.
+# Below 1.0x the player drains its buffer faster than the worker refills it, so
+# the listener hears speech in fragments. #13215 fixed time-to-first-audio; this
+# is the separate constraint that first-audio latency cannot compensate for.
+#
+# The client compensates by pre-rolling a lead-in proportional to the measured
+# factor, which trades latency for continuity — so a sustained shortfall shows
+# up to the user as a growing delay before speech, not as an outage. That is
+# exactly why it needs an alert rather than a dashboard nobody opens.
+---
+
+groups:
+  - name: tts_throughput_recording
+    interval: 1m
+    rules:
+      # Share of syntheses that could not keep up with playback, over 15m.
+      - record: autobot_tts_below_realtime_ratio
+        expr: >
+          sum(rate(autobot_tts_synthesis_below_realtime_total[15m]))
+          /
+          clamp_min(sum(rate(autobot_tts_synthesis_total[15m])), 0.001)
+
+      # Median real-time factor across routes — the headline throughput number.
+      - record: autobot_tts_realtime_factor_p50
+        expr: >
+          histogram_quantile(
+            0.5,
+            sum(rate(autobot_tts_realtime_factor_bucket[15m])) by (le)
+          )
+
+  - name: tts_throughput_alerts
+    interval: 1m
+    rules:
+      # Most syntheses failing to reach real time means every reply is either
+      # stuttering or waiting out a long pre-roll.
+      - alert: TTSSynthesisBelowRealTime
+        expr: autobot_tts_below_realtime_ratio > 0.5
+        for: 15m
+        labels:
+          severity: warning
+          component: voice
+        annotations:
+          summary: "TTS worker is producing audio slower than it plays back"
+          description: >
+            {{ $value | humanizePercentage }} of TTS syntheses in the last 15 minutes
+            ran below 1.0x real time. Streamed playback cannot be continuous at this
+            rate. Check host load on the TTS node first — the worker is usually
+            starved rather than saturated — then voice acceleration and model size.
+          runbook_url: "https://github.com/mrveiss/AutoBot-AI/issues/12460"
+
+      # A collapsed factor is a different failure from an occasional slow one:
+      # at 0.25x the pre-roll hits its cap and speech is audibly late regardless.
+      - alert: TTSRealTimeFactorCollapsed
+        expr: autobot_tts_realtime_factor_p50 < 0.5
+        for: 10m
+        labels:
+          severity: critical
+          component: voice
+        annotations:
+          summary: "TTS real-time factor has collapsed below 0.5x"
+          description: >
+            Median real-time factor is {{ $value }}, so a 4-second sentence takes
+            more than 8 seconds to synthesize. The client pre-roll caps out at this
+            point and voice output is effectively unusable.
+          runbook_url: "https://github.com/mrveiss/AutoBot-AI/issues/12460"

--- a/autobot-monitoring/prometheus.yml
+++ b/autobot-monitoring/prometheus.yml
@@ -17,8 +17,11 @@ alerting:
   alertmanagers: []
 
 rule_files:
-  - "alerts-chat-ssot.yml"  # Phase 4 (#7590): SSOT cardinality + disk file alerts
-  - "alerts-tts-throughput.yml"  # #12460: TTS real-time factor below playback speed
+  # Absolute + globbed: Prometheus resolves a relative rule path against its
+  # working directory (the TSDB dir), not the config directory, so the previous
+  # bare filename never matched and NO rules loaded (#12460). The glob also means
+  # a new alerts-*.yml file needs no config change.
+  - "/etc/prometheus/alerts-*.yml"
 
 scrape_configs:
   # Prometheus self-monitoring

--- a/autobot-monitoring/prometheus.yml
+++ b/autobot-monitoring/prometheus.yml
@@ -18,6 +18,7 @@ alerting:
 
 rule_files:
   - "alerts-chat-ssot.yml"  # Phase 4 (#7590): SSOT cardinality + disk file alerts
+  - "alerts-tts-throughput.yml"  # #12460: TTS real-time factor below playback speed
 
 scrape_configs:
   # Prometheus self-monitoring

--- a/autobot-slm-backend/ansible/roles/monitoring/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/monitoring/defaults/main.yml
@@ -39,6 +39,10 @@ grafana_group: "grafana"
 # Installation directories
 prometheus_install_dir: "/opt/prometheus"
 prometheus_config_dir: "/etc/prometheus"
+
+# #12460: fail the play when no alerts-*.yml is found rather than installing
+# zero rules silently. Set false only for a node that intentionally ships none.
+prometheus_alert_rules_required: true
 prometheus_data_dir: "/var/lib/prometheus"
 grafana_data_dir: "/var/lib/grafana"
 

--- a/autobot-slm-backend/ansible/roles/monitoring/tasks/prometheus.yml
+++ b/autobot-slm-backend/ansible/roles/monitoring/tasks/prometheus.yml
@@ -64,6 +64,37 @@
     mode: "0644"
   notify: Restart prometheus
 
+# #12460: the alert rules live in the repo under autobot-monitoring/ and were
+# never installed, so `rule_files` had nothing to point at on a fleet host.
+# Copied from the deployed checkout rather than duplicated into the role, so the
+# repo stays the single source for every alert.
+- name: Create Prometheus rules directory
+  ansible.builtin.file:
+    path: "{{ prometheus_config_dir }}/rules"
+    state: directory
+    owner: "{{ prometheus_user }}"
+    group: "{{ prometheus_group }}"
+    mode: "0755"
+
+- name: Find Prometheus alert rules in the repo
+  ansible.builtin.find:
+    paths: "{{ autobot_repo_dir }}/autobot-monitoring"
+    patterns: "alerts-*.yml"
+  register: _prometheus_alert_rules
+
+- name: Install Prometheus alert rules
+  ansible.builtin.copy:
+    src: "{{ item.path }}"
+    dest: "{{ prometheus_config_dir }}/rules/{{ item.path | basename }}"
+    remote_src: true
+    owner: "{{ prometheus_user }}"
+    group: "{{ prometheus_group }}"
+    mode: "0644"
+  loop: "{{ _prometheus_alert_rules.files }}"
+  loop_control:
+    label: "{{ item.path | basename }}"
+  notify: Restart prometheus
+
 - name: Create Prometheus systemd service
   ansible.builtin.template:
     src: prometheus.service.j2

--- a/autobot-slm-backend/ansible/roles/monitoring/tasks/prometheus.yml
+++ b/autobot-slm-backend/ansible/roles/monitoring/tasks/prometheus.yml
@@ -82,6 +82,20 @@
     patterns: "alerts-*.yml"
   register: _prometheus_alert_rules
 
+# `find` returns an empty list for a missing directory without failing, so a
+# monitoring-only node with no repo checkout would report green while installing
+# zero alerts — the same silent no-op this change exists to remove. Fail loudly
+# instead; a node that legitimately ships no rules sets the flag below.
+- name: Assert Prometheus alert rules were found
+  ansible.builtin.assert:
+    that: _prometheus_alert_rules.files | length > 0
+    fail_msg: >-
+      No alerts-*.yml found under {{ autobot_repo_dir }}/autobot-monitoring.
+      Prometheus would start with rule_files pointing at an empty directory and
+      no alert would ever fire. Check autobot_repo_dir, or set
+      prometheus_alert_rules_required=false for a node that intentionally has none.
+  when: prometheus_alert_rules_required | bool
+
 - name: Install Prometheus alert rules
   ansible.builtin.copy:
     src: "{{ item.path }}"

--- a/autobot-slm-backend/ansible/roles/monitoring/templates/prometheus.yml.j2
+++ b/autobot-slm-backend/ansible/roles/monitoring/templates/prometheus.yml.j2
@@ -12,7 +12,11 @@ global:
 alerting:
   alertmanagers: []
 
-rule_files: []
+rule_files:
+  # #12460: was [], so no alert rule ever loaded on a fleet deployment —
+  # including the #7590 chat-SSOT rules. Populated from the repo's
+  # autobot-monitoring/alerts-*.yml by the 'Install Prometheus alert rules' task.
+  - "{{ prometheus_config_dir }}/rules/*.yml"
 
 scrape_configs:
   # Prometheus self-monitoring

--- a/autobot_shared/monitoring/metrics/__init__.py
+++ b/autobot_shared/monitoring/metrics/__init__.py
@@ -13,6 +13,7 @@ Extended with FrontendMetricsRecorder for RUM metrics (Issue #476).
 Extended with MCPWorkerMetricsRecorder for worker restart budget tracking (Issue #4109).
 Extended with VoiceRealtimeMetricsRecorder for Realtime WebRTC session metrics (Issue #7421).
 Extended with MobileDeviceMetricsRecorder for mobile device pairing metrics (GH#4463).
+Extended with TTSMetricsRecorder for TTS synthesis throughput metrics (Issue #12460).
 
 Package Structure:
 - base.py: Base recorder class with shared functionality
@@ -60,6 +61,9 @@ from .redis import RedisMetricsRecorder
 from .service_health import ServiceHealthMetricsRecorder
 from .system import SystemMetricsRecorder
 from .task import TaskMetricsRecorder
+
+# Issue #12460: TTS worker synthesis throughput (real-time factor)
+from .tts import TTSMetricsRecorder
 from .voice_realtime import VoiceRealtimeMetricsRecorder
 from .websocket import WebSocketMetricsRecorder
 from .workflow import WorkflowMetricsRecorder
@@ -90,6 +94,8 @@ __all__ = [
     "MCPWorkerMetricsRecorder",
     # Issue #7421: Voice Realtime WebRTC session metrics
     "VoiceRealtimeMetricsRecorder",
+    # Issue #12460: TTS synthesis throughput metrics
+    "TTSMetricsRecorder",
     # GH#4463: Mobile device pairing and push notification metrics
     "MobileDeviceMetricsRecorder",
 ]

--- a/autobot_shared/monitoring/metrics/tts.py
+++ b/autobot_shared/monitoring/metrics/tts.py
@@ -1,0 +1,84 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""TTS synthesis throughput metrics.
+
+Issue #12460 — the TTS worker's real-time factor (audio-seconds produced per
+wall-second) decides whether streamed speech can play without stuttering: below
+1.0x the player drains its buffer faster than the worker refills it. The factor
+was computable from the worker log all along and nothing consumed it, so a
+worker sustaining 0.2x looked healthy on every dashboard. These metrics make it
+observable and alertable.
+"""
+
+from prometheus_client import Counter, Gauge, Histogram
+
+from .base import BaseMetricsRecorder
+
+# Real-time factor below which streamed playback cannot keep up (#12460).
+REALTIME_FACTOR_FLOOR = 1.0
+
+
+class TTSMetricsRecorder(BaseMetricsRecorder):
+    """Recorder for TTS worker synthesis throughput metrics."""
+
+    def _init_metrics(self) -> None:
+        self.synthesis_total = Counter(
+            "autobot_tts_synthesis_total",
+            "Total TTS syntheses completed",
+            ["route"],
+            registry=self.registry,
+        )
+        self.below_realtime_total = Counter(
+            "autobot_tts_synthesis_below_realtime_total",
+            "TTS syntheses that produced audio slower than it plays back",
+            ["route"],
+            registry=self.registry,
+        )
+        self.realtime_factor = Histogram(
+            "autobot_tts_realtime_factor",
+            "Audio-seconds of speech produced per wall-second of synthesis",
+            ["route"],
+            # Bucketed around the 1.0 floor; the low buckets match the 0.09x-0.83x
+            # range measured on a loaded host in #12460.
+            buckets=[0.1, 0.25, 0.5, 0.75, 1.0, 1.5, 2.0, 4.0, 8.0],
+            registry=self.registry,
+        )
+        self.realtime_factor_last = Gauge(
+            "autobot_tts_realtime_factor_last",
+            "Real-time factor of the most recent TTS synthesis",
+            ["route"],
+            registry=self.registry,
+        )
+        self.first_chunk_seconds = Histogram(
+            "autobot_tts_first_chunk_seconds",
+            "Wall-seconds from synthesis request to the first audio chunk",
+            ["route"],
+            buckets=[0.25, 0.5, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0],
+            registry=self.registry,
+        )
+
+    def record_synthesis(self, route: str, audio_seconds: float, wall_seconds: float) -> None:
+        """Record one completed synthesis and its real-time factor.
+
+        A non-positive duration on either side carries no rate information, so it
+        is counted but not folded into the factor.
+        """
+        self.synthesis_total.labels(route=route).inc()
+        if audio_seconds <= 0 or wall_seconds <= 0:
+            return
+        factor = audio_seconds / wall_seconds
+        self.realtime_factor.labels(route=route).observe(factor)
+        self.realtime_factor_last.labels(route=route).set(factor)
+        if factor < REALTIME_FACTOR_FLOOR:
+            self.below_realtime_total.labels(route=route).inc()
+
+    def record_first_chunk_latency(self, route: str, seconds: float) -> None:
+        """Record how long the caller waited for the first audio chunk."""
+        if seconds < 0:
+            return
+        self.first_chunk_seconds.labels(route=route).observe(seconds)
+
+
+__all__ = ["TTSMetricsRecorder", "REALTIME_FACTOR_FLOOR"]

--- a/autobot_shared/monitoring/prometheus_metrics.py
+++ b/autobot_shared/monitoring/prometheus_metrics.py
@@ -50,6 +50,7 @@ from .metrics import (
     ServiceHealthMetricsRecorder,
     SystemMetricsRecorder,
     TaskMetricsRecorder,
+    TTSMetricsRecorder,
     VoiceRealtimeMetricsRecorder,
     WebSocketMetricsRecorder,
     WorkflowMetricsRecorder,
@@ -131,6 +132,8 @@ class PrometheusMetricsManager:
         self._mobile_device = MobileDeviceMetricsRecorder(self.registry)
         # Issue #10778: Initialize HTTP API request counter recorder
         self._api_requests = ApiRequestsMetricsRecorder(self.registry)
+        # Issue #12460: Initialize TTS synthesis throughput recorder
+        self._tts = TTSMetricsRecorder(self.registry)
 
     # =========================================================================
     # Core Infrastructure Metrics Initialization
@@ -850,6 +853,29 @@ class PrometheusMetricsManager:
             count: Number of active devices
         """
         self._mobile_device.set_active_device_count(platform, count)
+
+    # =========================================================================
+    # TTS Synthesis Throughput Metrics (Issue #12460)
+    # =========================================================================
+
+    def record_tts_synthesis(self, route: str, audio_seconds: float, wall_seconds: float) -> None:
+        """Record a completed TTS synthesis and its real-time factor.
+
+        Args:
+            route: Worker route used - "stream" or "blob"
+            audio_seconds: Duration of the speech that was produced
+            wall_seconds: Wall-clock time the worker took to produce it
+        """
+        self._tts.record_synthesis(route, audio_seconds, wall_seconds)
+
+    def record_tts_first_chunk(self, route: str, seconds: float) -> None:
+        """Record the wait for the first audio chunk of a synthesis.
+
+        Args:
+            route: Worker route used - "stream" or "blob"
+            seconds: Wall-clock seconds from request to first chunk
+        """
+        self._tts.record_first_chunk_latency(route, seconds)
 
     # =========================================================================
     # Metrics Export

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -714,7 +714,9 @@ services:
       - "127.0.0.1:9090:9090"
     volumes:
       - prometheus_data:/prometheus
-      - ./autobot-monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      # Whole directory, not just prometheus.yml: the alerts-*.yml rule files
+      # sit beside it and were otherwise absent from the container (#12460).
+      - ./autobot-monitoring:/etc/prometheus:ro
     command:
       - --config.file=/etc/prometheus/prometheus.yml
       - --storage.tsdb.path=/prometheus


### PR DESCRIPTION
Refs #12460

> Deliberately `Refs`, not `Closes`. Two of the reopen's three directions ship
> here, but the acceptance claim is host behaviour — "the stutter is gone" — and
> that needs the real-time factor observed on the live deploy, not merge
> evidence. #12460 stays open until then.

## Thinking Path

#12460 was reopened because voice output stutters again. The mechanism changed
but the outcome did not: #13215 fixed **time-to-first-audio** by moving the voice
path onto the streaming route, and that fix holds. The constraint now is
**throughput** — 19 of 19 measured syntheses ran at 0.09x-0.83x real time.

`_scheduleGaplessChunk` schedules the first chunk at `ctx.currentTime` and every
later one at the end of its predecessor. When the worker produces slower than
playback consumes, each chunk is already late on arrival, `startTime` falls back
to `now`, and a gap opens between the previous chunk's end and this one's start.
At 0.21x that is ~250ms of speech followed by ~1s of silence, repeatedly — which
is exactly the reported stutter. Starting earlier cannot fix a stream that
cannot sustain itself, so the fix has to trade latency for continuity.

The lead-in needed is derivable rather than a guessed constant. For an utterance
of `D` audio-seconds produced at `r` audio-seconds per wall-second, playback that
begins with `B` seconds buffered stays gapless iff consumed time never exceeds
produced audio — `t <= B + r*t` for all `t <= D` — which binds at `t = D` and
gives **`B >= (1 - r) * D`**. `D` is estimated from the utterance text; `r` is
measured from chunk arrivals and carried between utterances, because it is a
property of the worker and its host, not of the sentence.

The second half is observability. The worker log already computed the real-time
factor on every synthesis and nothing consumed it, so a worker sustaining 0.2x
looked healthy on every dashboard — the reopen was diagnosed by hand from logs.

## What Changed

**Frontend — adaptive pre-roll (`useVoiceOutput.ts`)**

- Decoded chunks are held in a pre-roll buffer until the lead-in covers the rest
  of the utterance at the measured rate, then released onto the same gapless
  timeline as before.
- Utterance boundaries come from the existing protocol: `tts_start` (which
  already carries the text) and `tts_end` on the WebSocket path, and the framed
  response body on the HTTP path.
- **Nothing is held when it should not be:** no measured rate yet (first
  utterance of a session) or a worker at/above real time → zero delay, so
  #13215's first-audio win is untouched.
- Audio scheduled ahead of the playhead counts toward the lead-in, but at `r*A`
  rather than its full duration: while `A` seconds of an earlier sentence play
  out, the worker only adds `r*A`. A follow-on sentence therefore waits less,
  but is not released early into a stream that would still starve.
- The lead-in is capped (8s) and backed by a **stall** watchdog re-armed on every
  held chunk. A total-duration timer would be wrong: filling `T` audio-seconds at
  rate `r` legitimately takes `T/r` wall-seconds, so it would force-release
  exactly the slow workers this exists for.
- `isSpeaking` stays true through a hold — the reply is buffering, not finished.
  A false there fires `watch(isSpeaking)` in `useVoiceConversation`, expiring the
  TTS echo cooldown and reopening the mic mid-reply.
- Held audio is never scheduled onto a context suspended during the hold; that
  path takes the same gesture-unlock exit as every other playback path (#12503).
- `tts_end` always flushes what is held — a short utterance that never reaches
  its target is still spoken in full.
- `stopSpeaking()` / barge-in drops held audio, and `speak()`'s stop guard checks
  the holding state, so a superseded reply is dropped rather than spoken first.

**Backend — real-time factor telemetry**

- `TTSMetricsRecorder` (`autobot_shared/monitoring/metrics/tts.py`) exports
  `autobot_tts_realtime_factor` (histogram + last-value gauge),
  `autobot_tts_synthesis_below_realtime_total`, and
  `autobot_tts_first_chunk_seconds`, labelled by worker route.
- `tts_client.stream_or_synthesize` measures audio produced against the time the
  worker spent producing it, across whichever route served the utterance —
  including the stale-worker blob fallback — and logs a WARNING below 1.0x. The
  clock starts after the capability probe resolves and restarts after each
  `yield`: this generator feeds a WebSocket and a `StreamingResponse`, so billing
  consumer back-pressure to the worker would alert on a healthy one. Chunk duration is read from the WAV
  header; an unparseable payload contributes 0 and is skipped rather than
  recorded as a 0.0x outlier, so telemetry can never break audio delivery.
- `alerts-tts-throughput.yml` alerts on a sustained below-real-time ratio and on
  a collapsed median factor.

**Monitoring — making rule files load at all (pre-existing, fixed here)**

The new alert file would have loaded nowhere, and neither did the #7590
chat-SSOT rules already in the repo. Three independent breaks:

- Prometheus resolves a **relative** `rule_files` path against its working
  directory (the TSDB dir), not the config directory — so the bare filename never
  matched. Now an absolute glob, which also means a new `alerts-*.yml` needs no
  config change.
- `docker-compose.yml` mounted only `prometheus.yml`, so the sibling rule files
  were not in the container at all. Now mounts the directory that holds both.
- The fleet template hardcoded `rule_files: []` and the role shipped no rules.
  The role now installs the repo's `alerts-*.yml` into
  `{{ prometheus_config_dir }}/rules/` from the deployed checkout, so the repo
  stays the single source for every alert.

## Verification

Frontend — 11 new tests, plus every existing voice suite:

```
✓ src/composables/__tests__/useVoiceOutput.preroll.test.ts     (11 tests)
✓ src/composables/__tests__/useVoiceOutput.playback.test.ts     (5 tests)
✓ src/composables/__tests__/useVoiceOutput.streaming.test.ts    (4 tests)
✓ src/composables/__tests__/useVoiceOutput.test.ts              (8 tests)
✓ src/composables/__tests__/useVoiceConversation.test.ts        (5 tests)
✓ src/utils/__tests__/ttsSentences.test.ts                      (4 tests)

Test Files  6 passed (6)
     Tests  37 passed (37)
```

The pre-roll tests drive the real WebSocket frames and pin the regression: after
calibrating the worker at 0.25x, three chunks (0.75s buffered) must NOT play
against a 0.9s target, and the fourth releases all four at once. Without the
fix each chunk schedules on arrival and the first assertion fails.

Backend — 13 new tests (7 client + 6 recorder), plus the voice suites:

```
services/tts_metrics_test.py ......                     (6 passed)
services/tts_client_test.py ................            (16 passed)
monitoring/prometheus_metrics_test.py .......           (34 passed, 2 skipped)

api/voice_stream_test.py, api/voice_latency_test.py,
tests/test_voice_503_guard.py, tests/test_voice_realtime_telemetry.py
→ 91 passed, 2 skipped
```

Lint and types clean on every touched file:

```
flake8 --max-line-length=120 <6 python files>   → exit 0
npx vue-tsc --noEmit -p tsconfig.app.json       → no output
npx eslint useVoiceOutput.ts + preroll.test.ts  → no output
yaml.safe_load(alerts-tts-throughput.yml, prometheus.yml) → ok
```

Closure gates:

```
✅ autobot_shared/monitoring/metrics/tts.py — 24 callers
✅ All new modules have callers — ready to merge.
✅ Gate 2 clear: no forward-tracking references to #12460.
```

**Pre-existing failures, not from this branch:** the 4 `api/voice_integration_test.py`
tests dial a live deployment and fail identically on untouched `Dev_new_gui`
(`319c0012` → same 4 failed, 6 passed).

**Not verified here:** the real-time factor on the live host. The measurement and
the alert are code, but confirming the pre-roll ends the audible stutter needs
host evidence, so **#12460 stays open** pending that.

## Review round

A high-effort review of the first commit returned seven defects; all are fixed in
`1c458af4` and each is pinned by a test:

1. Scheduled-ahead audio credited at full duration instead of `r*A` — released a
   follow-on sentence early into a stream that would still starve.
2. The 20s timer was a total-duration cap, force-releasing paragraph-length
   replies below ~0.4x mid-fill.
3. `isSpeaking` false through a hold reopened the mic mid-reply.
4. `speak()`'s stop guard missed a hold, so a superseded reply was spoken first.
5. The alert rules loaded nowhere (three independent breaks, above).
6. `_releasePending()` could schedule onto a suspended context and stick the
   indicator.
7. The backend throughput clock billed the capability probe and consumer
   back-pressure to the worker.

## Scope note

The reopen listed three directions. Two are delivered above. The third — the host
sitting at load ~20 on 22 cores while the TTS process uses ~6.3% CPU, i.e.
starved rather than saturating — is host-side, overlaps the crash-loop churn in
#4090, and is not a code change in this repo. It is called out rather than
silently dropped.

## Model Used

Claude Opus 5 (1M context)
