### PR TITLE
test(llc): gate the poll-loop cancellation tests on the API they need (#13727)

### DIFF
--- a/autobot-backend/llc/scheduler/base.py
+++ b/autobot-backend/llc/scheduler/base.py
@@ -52,6 +52,24 @@ logger = logging.getLogger(__name__)
 # single tunable rather than a hard-coded literal per call site (#13210).
 _DRAIN_TIMEOUT_SECONDS = env_float("LLC_SCHEDULER_DRAIN_TIMEOUT_SECONDS", 5.0)
 
+# ``Task.cancelling()`` is Python 3.11+, and honour_pending_cancellation() has no
+# fallback below it: nothing else in asyncio records a cancellation that an
+# ``except`` arm has already masked.  Always True on every supported interpreter
+# — the platform floor is 3.12 (startup_validator._validate_system_requirements)
+# and CI runs 3.14 — so this is not a compatibility shim and must never grow one.
+# A silent fallback would turn the #13085/#13203 guard permanently off and buy
+# every poll loop a full re-armed interval after shutdown, which is the exact bug
+# those issues fixed.
+#
+# It is exported so the tests that exercise the guard can state that dependency
+# instead of failing as though the loop contract had regressed (#13727): on a
+# sub-floor interpreter the missing method surfaces as an AttributeError that
+# escapes _loop, and the five resulting failures read like a cancellation bug.
+SUPPORTS_PENDING_CANCELLATION = hasattr(asyncio.Task, "cancelling")
+PENDING_CANCELLATION_REQUIREMENT = (
+    "requires asyncio.Task.cancelling() (Python 3.11+); the platform floor is 3.12 and CI runs 3.14"
+)
+
 
 def honour_pending_cancellation() -> None:
     """Re-raise a cancellation that the surrounding ``except`` arm masked (#13085).

--- a/autobot-backend/llc/scheduler/community_cluster_scheduler_test.py
+++ b/autobot-backend/llc/scheduler/community_cluster_scheduler_test.py
@@ -27,6 +27,12 @@ already-hardened base instead of re-implementing them a second time; these
 tests exercise that inheritance through the concrete subclass so a future
 change that breaks the wiring (e.g. reintroducing a local except-arm-only
 guard) is caught here.
+
+The inherited guard needs ``asyncio.Task.cancelling()`` (Python 3.11+), so the
+test that exercises it is gated on that capability the same way the base class's
+own tests are — see ``llc/tests/test_poll_loop_scheduler.py`` (#13727).  Nothing
+is skipped on a supported interpreter: the platform floor is 3.12 and CI runs
+3.14.
 """
 
 import asyncio
@@ -36,7 +42,13 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from llc.scheduler.base import PENDING_CANCELLATION_REQUIREMENT, SUPPORTS_PENDING_CANCELLATION
 from llc.scheduler.community_cluster_scheduler import CommunityClusteringScheduler
+
+requires_pending_cancellation = pytest.mark.skipif(
+    not SUPPORTS_PENDING_CANCELLATION,
+    reason=PENDING_CANCELLATION_REQUIREMENT,
+)
 
 
 class _FakeMeshDB:
@@ -86,6 +98,7 @@ class _SwallowingClusterer:
             return []  # driver consumed it; run() reports success
 
 
+@requires_pending_cancellation
 @pytest.mark.asyncio
 async def test_swallowed_cancel_does_not_rearm_a_full_interval() -> None:
     """A masked-and-swallowed cancel must not buy the loop a fresh 6h sleep.

--- a/autobot-backend/llc/tests/test_poll_loop_scheduler.py
+++ b/autobot-backend/llc/tests/test_poll_loop_scheduler.py
@@ -2,14 +2,37 @@
 # SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
-"""Unit tests for PollLoopScheduler base class (GH#9842)."""
+"""Unit tests for PollLoopScheduler base class (GH#9842).
+
+Interpreter dependency (#13727): every test that lets ``_loop`` complete an
+iteration needs ``asyncio.Task.cancelling()``, which exists only on Python 3.11+.
+``honour_pending_cancellation()`` runs once per iteration and has no fallback
+below that, so on a sub-floor interpreter it raises ``AttributeError``, that
+error escapes ``_loop``, and the loop dies after exactly one tick.  The five
+tests marked below then fail with assertions about tick counts and cancelled
+tasks — they read like a regression in the cancellation contract when the only
+thing wrong is the interpreter.  They are skipped there rather than left red,
+because a permanently-red module stops carrying information: a genuine
+regression would look identical and be dismissed for the same reason.
+
+The skip is not coverage loss where it counts.  CI runs 3.14 and the platform
+floor is 3.12 (``startup_validator._validate_system_requirements``), so nothing
+is skipped on any supported interpreter.  The gate is the capability itself, not
+a version number, so it stays correct without tracking release history.  The
+other tests in this module do not depend on it and keep running everywhere.
+"""
 
 import asyncio
 import logging
 
 import pytest
 
-from llc.scheduler.base import PollLoopScheduler
+from llc.scheduler.base import PENDING_CANCELLATION_REQUIREMENT, SUPPORTS_PENDING_CANCELLATION, PollLoopScheduler
+
+requires_pending_cancellation = pytest.mark.skipif(
+    not SUPPORTS_PENDING_CANCELLATION,
+    reason=PENDING_CANCELLATION_REQUIREMENT,
+)
 
 # ---------------------------------------------------------------------------
 # Test double — concrete subclass with a controllable tick
@@ -216,9 +239,14 @@ def test_task_name_falls_back_to_class_name_when_empty() -> None:
 # ---------------------------------------------------------------------------
 
 
+@requires_pending_cancellation
 @pytest.mark.asyncio
 async def test_tick_exception_does_not_kill_loop(caplog: pytest.LogCaptureFixture) -> None:
-    """When _tick() raises, the loop continues (exception is caught and logged)."""
+    """When _tick() raises, the loop continues (exception is caught and logged).
+
+    Needs a second iteration, so it depends on the per-iteration guard being
+    callable — see the module docstring (#13727).
+    """
     sched = _ErrorScheduler(poll_interval=0.0)
     with caplog.at_level(logging.ERROR, logger=_ErrorScheduler.__module__):
         sched.start()
@@ -254,6 +282,7 @@ async def test_tick_exception_logs_class_name(caplog: pytest.LogCaptureFixture) 
 # ---------------------------------------------------------------------------
 
 
+@requires_pending_cancellation
 @pytest.mark.asyncio
 async def test_cancellation_breaks_loop_cleanly() -> None:
     """A bare cancel ends the loop and leaves the scheduler restartable (#13203).
@@ -287,6 +316,7 @@ async def test_cancellation_breaks_loop_cleanly() -> None:
     await sched.aclose()
 
 
+@requires_pending_cancellation
 @pytest.mark.asyncio
 async def test_cancellation_marks_the_task_cancelled() -> None:
     """_loop re-raises CancelledError so the task ends in the cancelled state.
@@ -348,6 +378,7 @@ async def test_masked_cancellation_does_not_start_another_interval() -> None:
     assert sched.tick_count == 1, "the loop must not have started a second tick"
 
 
+@requires_pending_cancellation
 @pytest.mark.asyncio
 async def test_swallowed_cancellation_does_not_start_another_interval() -> None:
     """A tick that *swallows* the masked cancel must not buy a fresh interval.
@@ -464,9 +495,22 @@ async def test_aclose_is_bounded_when_the_task_cannot_be_drained(
     await asyncio.wait_for(asyncio.gather(task, return_exceptions=True), timeout=1.0)
 
 
+@requires_pending_cancellation
 @pytest.mark.asyncio
-async def test_restart_after_aclose_clears_the_stop_event() -> None:
-    """start() re-arms the stop event so a restarted loop is not born stopped."""
+async def test_restart_after_aclose_keeps_ticking() -> None:
+    """A scheduler restarted after aclose() resumes running its tick.
+
+    Scope note (#13727): this proves the restart works end to end, and nothing
+    more.  It was named ``..._clears_the_stop_event`` and documented as covering
+    that contract, but it cannot: at ``poll_interval=0.0`` the inter-poll wait
+    returns immediately whether or not the stop event is still set, so the tick
+    count is identical either way.  Deleting ``start()``'s ``_stop_event.clear()``
+    leaves this test green.  ``test_start_rearms_the_stop_event`` below covers
+    the contract this one was believed to cover.
+
+    Needs a second iteration after the restart, so it depends on the
+    per-iteration guard being callable — see the module docstring.
+    """
     sched = _CountingScheduler(poll_interval=0.0)
     sched.start()
     await sched.aclose()
@@ -477,6 +521,39 @@ async def test_restart_after_aclose_clears_the_stop_event() -> None:
     await sched.aclose()
 
     assert ticks_after_restart >= 2, "restarted loop must keep ticking"
+
+
+@pytest.mark.asyncio
+async def test_start_rearms_the_stop_event() -> None:
+    """start() must clear the stop event, or the restarted loop starves the event loop.
+
+    The corrected contract (#13727).  A stale set event does not make the loop
+    "born stopped" — ``start()`` sets ``_running=True``, so the loop runs.  It
+    makes every inter-poll wait return *without suspending*: awaiting an
+    already-set ``asyncio.Event`` completes synchronously, and on Python 3.12+
+    ``wait_for`` adds no yield of its own (measured: 100 such waits give other
+    tasks zero steps; on 3.10 they got 300).  ``_loop`` would then spin without
+    ever handing control back, starving every other task on the loop — a hung
+    backend, not a pacing nit.
+
+    Asserted on the event itself rather than on tick counts, and before the
+    freshly created task takes its first step, so a regression fails here
+    instead of wedging the suite in the starvation it describes.
+    """
+    sched = _CountingScheduler(poll_interval=9999.0)
+    sched.start()
+    await sched.aclose()
+    assert sched._stop_event.is_set(), "aclose() must leave the stop event signalled"
+
+    sched.start()
+    try:
+        # No await between start() and this assert: the task is scheduled but has
+        # not run, so an unfixed start() cannot starve the loop before we look.
+        assert not sched._stop_event.is_set(), "start() must re-arm the stop event"
+    finally:
+        # Safe even when the assert above fails: the task is cancelled before it
+        # takes its first step, so it never enters _loop and cannot spin.
+        await sched.aclose()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Thinking Path

All 5 failures named in #13727 — and a 6th the issue did not list — are **one root cause**, not five contract mismatches.

`honour_pending_cancellation()` calls `asyncio.Task.cancelling()`, added in **Python 3.11**. Below that it raises `AttributeError`. It runs once per `_loop` iteration and sits *outside* the inner `try`, so the error escapes `_loop` and the loop dies after exactly one tick. The visible symptoms are then tick-count and `task.cancelled()` assertions — indistinguishable from a real regression in the cancellation contract, which is exactly the "red module stops carrying information" problem the issue describes.

Measured across four interpreters with a stdlib-only replica of the five tests:

| Interpreter | `Task.cancelling` | Result |
|---|---|---|
| 3.10.12 | absent | 5 failed / 0 passed |
| 3.11.15 | present | 0 failed / 5 passed |
| 3.12.13 | present | 0 failed / 5 passed |
| 3.14.6 | present | 0 failed / 5 passed |

The platform floor is **3.12** (`startup_validator._validate_system_requirements`) and CI runs **3.14**, so the scheduler code is correct on every supported interpreter and needs no change. The local box runs 3.10, below the floor.

A compatibility shim was considered and rejected: there is no fallback for `Task.cancelling()` — nothing else in asyncio records a cancellation an `except` arm already masked — so a `getattr(..., None)` default would turn the #13085/#13203 guard permanently off and silently buy every poll loop a re-armed interval after shutdown. That is the exact bug those issues fixed. The rejection is written into the comment so it is not "helpfully" added later.

## What Changed

**`llc/scheduler/base.py`** — exports `SUPPORTS_PENDING_CANCELLATION` (a capability check, `hasattr(asyncio.Task, "cancelling")`, not a version number) and `PENDING_CANCELLATION_REQUIREMENT`, so the dependency is stated once rather than duplicated per test module. No behaviour change.

**`llc/tests/test_poll_loop_scheduler.py`** — the 5 affected tests gated on that capability, with the interpreter dependency documented in the module docstring. The other 14 tests are untouched and keep running everywhere.

**`llc/scheduler/community_cluster_scheduler_test.py`** — `test_swallowed_cancel_does_not_rearm_a_full_interval` fails for the identical reason and is **not listed in the issue**; found while sweeping the scheduler package. Same gate, fixed here rather than left behind.

### A test that could not fail

Verifying by deliberate failure (AC 3) turned up a real defect in the module. `test_restart_after_aclose_clears_the_stop_event` claimed to cover `start()`'s `_stop_event.clear()`, but ran at `poll_interval=0.0`, where the inter-poll wait returns immediately whether or not the event is still set. **Deleting `start()`'s `_stop_event.clear()` left it green.**

It is renamed to `test_restart_after_aclose_keeps_ticking` — what it actually proves — with a scope note, and `test_start_rearms_the_stop_event` added for the real contract.

The corrected contract (stated in the new test's docstring): a stale set event does not leave the loop "born stopped" — `start()` sets `_running=True`, so it runs. It makes every inter-poll wait return *without suspending*, because awaiting an already-set `asyncio.Event` completes synchronously and on Python 3.12+ `wait_for` adds no yield of its own. Measured: 100 waits on a set event give other tasks **0** steps on 3.12/3.14, versus 300 on 3.10. `_loop` would spin without ever handing control back — starving the event loop, a hung backend rather than a pacing nit. Reproduced directly: at a realistic interval with `clear()` removed, the probe never returned.

The new test asserts on the event itself, before the freshly created task takes its first step, so a regression **fails** instead of wedging the suite in the very starvation it describes — confirmed: the mutated run fails in 1.45 s.

## Verification

Target modules, Python 3.10 — the 6 failures are gone:

```
$ python3 -m pytest autobot-backend/llc/tests/test_poll_loop_scheduler.py \
                    autobot-backend/llc/scheduler/ -q -p no:randomly
17 passed, 6 skipped in 1.71s
```

Skips are explicit, never silent:

```
SKIPPED [1] .../test_poll_loop_scheduler.py:242: requires asyncio.Task.cancelling()
            (Python 3.11+); the platform floor is 3.12 and CI runs 3.14
```

**No collateral damage** — same wide sweep, this branch vs. untouched base at `319c00127`:

| | failed | passed | skipped |
|---|---|---|---|
| base | 149 | 1438 | 1 |
| this branch | **143** | **1439** | **7** |

−6 failures (exactly the six fixed), +1 pass (the new test), +6 skips. The remaining 143 are pre-existing and unrelated (#13162).

### Verified by deliberate failure, not a green run (AC 3)

Every gated test was confirmed to still catch a real regression on a supported interpreter (3.12 + 3.14), so the gate hides nothing:

| Injected regression | Caught by |
|---|---|
| `honour_pending_cancellation()` call removed from `_loop` | `test_swallowed_cancellation_does_not_start_another_interval` |
| inter-poll wait swallows `CancelledError` instead of re-raising | `test_cancellation_breaks_loop_cleanly`, `test_cancellation_marks_the_task_cancelled` |
| `_loop`'s `finally` no longer clears `_running` | `test_cancellation_breaks_loop_cleanly` |
| failing tick kills the loop (no catch-and-continue) | `test_tick_exception_does_not_kill_loop` |
| `aclose()` no longer clears `_running` via `stop()` | `test_restart_after_aclose_keeps_ticking` |
| `start()`'s `_stop_event.clear()` removed | `test_start_rearms_the_stop_event` (new — the old test stayed green) |

`black --check`, `flake8 --max-line-length=120`, `isort --check-only`: clean.

## Acceptance criteria

- [x] `test_poll_loop_scheduler.py` passes in full on `Dev_new_gui` — 0 failures; on CI's 3.14 nothing is even skipped
- [x] The corrected contract is stated in the test docstring — `test_start_rearms_the_stop_event`, plus the scope note on the renamed test
- [x] Verified by deliberate failure — 6 injected regressions, each caught by a named test

## Discovered, filed separately

The Python floor these tests depend on is declared in `startup_validator._validate_system_requirements`, which has **zero callers repo-wide** — the guard never runs, so nothing stops a sub-floor deployment where every LLC poll loop dies after one tick with an unretrieved `AttributeError`. Out of scope here; filed as its own wire-in issue.

## Model Used

Claude Opus 5 (1M context)

Closes #13727
