### PR TITLE
fix(orchestration): await the planning API and read canonical WorkflowTask fields (#13730)

### DIFF
--- a/.session/HANDOFF-issue-13730.md
+++ b/.session/HANDOFF-issue-13730.md
@@ -1,0 +1,35 @@
+# Handoff: issue-13730
+status: complete
+pr: #13752
+base_at_push: (rebased onto origin/Dev_new_gui after #13728)
+gates: tests=PASS (6/6 target; 995 passed across orchestration/, tests/orchestration/, services/workflow_automation/, services/advanced_workflow/, workflow_templates/, chat_workflow/, performance_benchmarks_test.py, dependency_injection_test.py)
+needs_rebase_before_merge: no
+remaining:
+blocked_on:
+worktree: .worktrees/issue-13730  (safe to remove after merge)
+
+## What landed
+
+Two commits:
+- `fix(orchestration)`: awaits added at all four planning call sites;
+  `get_plan_summary` converted to `async def`; attribute reads moved to canonical
+  `WorkflowTask` names (`task_id`, `requires_approval`); `manager.py` handler logs
+  `exc_info`. Dict keys left alone on purpose — they are `workflow_planner`'s own
+  contract with `create_plan_summary_for_approval` (line 267).
+- `test(orchestration)`: `plan_steps_e2e_test.py` rewritten with real assertions;
+  new `tests/orchestration/test_planning_caller_wiring.py` drives all four callers
+  with a real `Orchestrator`.
+
+## Live impact fixed
+
+`api/workflow.py:290` and `services/workflow_automation/routes.py:258` both reach
+`create_workflow_from_chat_request`. It returned `None` for every request, and
+`api/workflow.py:292` maps that to **HTTP 500**. Chat-driven workflow creation was
+returning 500 on every call.
+
+## Carried forward — NOT done
+
+**#13751** — `WorkflowPlanner.plan_workflow_steps_with_agents` and `get_plan_summary`
+have zero callers. Corrected and tested here, but unwired: agent-assigned planning and
+plan preview are unreachable from any production path. Do not close #13751 on the
+strength of this PR.

--- a/autobot-backend/orchestration/plan_steps_e2e_test.py
+++ b/autobot-backend/orchestration/plan_steps_e2e_test.py
@@ -1,36 +1,61 @@
 #!/usr/bin/env python3
 # Copyright 2025-2026 mrveiss
 # SPDX-License-Identifier: Apache-2.0
+"""End-to-end coverage for ``Orchestrator.plan_workflow_steps``.
 
-import sys
-from pathlib import Path
+#13730: this file used to print a step count inside a bare ``except Exception``
+and assert nothing at all, so it reported success for the entire period
+``plan_workflow_steps`` returned an empty list on every call (#13699). It now
+asserts the plan it claims to exercise, and reads the canonical
+``WorkflowTask`` field names whose absence broke every caller.
+"""
 
-sys.path.append(str(Path(__file__).parent))
+import asyncio
 
+from autobot_shared.workflow import WorkflowTask
 from orchestrator import Orchestrator, TaskComplexity
 
+# ``TaskComplexity.RESEARCH`` / ``INSTALL`` / ``SECURITY_SCAN`` all carry the
+# value "complex", which makes them Enum *aliases* of ``COMPLEX`` rather than
+# distinct members. SIMPLE and COMPLEX are therefore the only two plans that
+# exist; the previous four-element list exercised COMPLEX three times.
+EXPECTED_STEP_COUNT = {TaskComplexity.SIMPLE: 1, TaskComplexity.COMPLEX: 3}
 
-def test_plan_workflow_steps():
+
+async def test_plan_workflow_steps_returns_a_real_plan():
+    """Every complexity produces a populated plan of canonical WorkflowTasks."""
     orchestrator = Orchestrator()
 
-    # Test each complexity level
-    complexities = [
-        TaskComplexity.SIMPLE,
-        TaskComplexity.RESEARCH,
-        TaskComplexity.INSTALL,
-        TaskComplexity.COMPLEX,
-    ]
+    for complexity, expected in EXPECTED_STEP_COUNT.items():
+        steps = await orchestrator.plan_workflow_steps("test message", complexity)
 
-    for complexity in complexities:
-        try:
-            steps = orchestrator.plan_workflow_steps("test message", complexity)
-            print(f"{complexity.value}: {len(steps)} steps")  # noqa: print
-        except Exception as e:
-            print(f"{complexity.value}: ERROR - {e}")  # noqa: print
-            import traceback
+        assert len(steps) == expected, f"{complexity.value}: expected {expected} steps, got {len(steps)}"
+        assert all(isinstance(step, WorkflowTask) for step in steps)
 
-            traceback.print_exc()
+        # Canonical names only — the retired ``id`` / ``user_approval_required``
+        # are exactly what every caller was still reading (#13730).
+        assert [step.task_id for step in steps] == [f"step_{i + 1}" for i in range(expected)]
+        assert all(step.action for step in steps)
+        assert all(isinstance(step.requires_approval, bool) for step in steps)
+        assert all(step.inputs.get("query") == "test message" for step in steps)
+        assert all(step.estimated_duration_seconds > 0 for step in steps)
+
+
+async def test_complex_plan_dependencies_resolve_within_the_plan():
+    """Dependency ids must name real tasks — callers build their edges from them."""
+    orchestrator = Orchestrator()
+    steps = await orchestrator.plan_workflow_steps("test message", TaskComplexity.COMPLEX)
+
+    task_ids = {step.task_id for step in steps}
+    for step in steps:
+        for dependency in step.dependencies:
+            assert dependency in task_ids, f"{step.task_id} depends on unknown task {dependency}"
+
+    # The COMPLEX plan is a chain, so at least one edge must exist; a plan with
+    # no dependencies at all would mean the ordering contract was lost.
+    assert any(step.dependencies for step in steps)
 
 
 if __name__ == "__main__":
-    test_plan_workflow_steps()
+    asyncio.run(test_plan_workflow_steps_returns_a_real_plan())
+    asyncio.run(test_complex_plan_dependencies_resolve_within_the_plan())

--- a/autobot-backend/orchestration/workflow_planner.py
+++ b/autobot-backend/orchestration/workflow_planner.py
@@ -109,8 +109,10 @@ class WorkflowPlanner:
         # GH#7357: consult trajectory store for similar solved tasks
         await self._annotate_context_with_trajectories(user_request, context)
 
-        # Get base workflow steps from original orchestrator
-        base_steps = self.base_orchestrator.plan_workflow_steps(user_request, complexity)
+        # Get base workflow steps from original orchestrator.
+        # #13730: coroutine function — without await the loop below iterated a
+        # coroutine object rather than the plan.
+        base_steps = await self.base_orchestrator.plan_workflow_steps(user_request, complexity)
 
         steps_with_agents = []
 
@@ -124,13 +126,16 @@ class WorkflowPlanner:
                 required_capabilities=required_capabilities,
             )
 
+            # #13730: dict keys are this module's own contract (consumed by
+            # create_plan_summary_for_approval) and stay as they are; only the
+            # attribute reads move to the canonical WorkflowTask names.
             assigned_step = {
-                "id": step.id,
+                "id": step.task_id,
                 "agent_type": step.agent_type,
                 "assigned_agent": assigned_agent,
                 "action": step.action,
                 "inputs": step.inputs,
-                "user_approval_required": step.user_approval_required,
+                "user_approval_required": step.requires_approval,
                 "dependencies": step.dependencies or [],
                 "required_capabilities": list(required_capabilities),
                 "estimated_duration": self.estimate_step_duration(step.action, assigned_agent),
@@ -196,13 +201,19 @@ class WorkflowPlanner:
 
         return estimated_duration
 
-    def get_plan_summary(
+    async def get_plan_summary(
         self,
         user_request: str,
         context: Dict[str, Any] | None = None,
     ) -> Dict[str, Any]:
         """
         Get workflow plan summary without executing.
+
+        #13730: was ``def``, calling the orchestrator's coroutine planning API
+        without awaiting it — ``complexity.value`` and ``len(base_steps)`` both
+        operated on coroutine objects. Now ``async def`` so the awaits are legal.
+        This method currently has no callers; it is corrected rather than
+        removed, and the wiring gap is tracked separately.
 
         Args:
             user_request: The user's request to plan
@@ -214,10 +225,10 @@ class WorkflowPlanner:
         context = context or {}
 
         # Classify complexity
-        complexity = self.base_orchestrator.classify_request_complexity(user_request)
+        complexity = await self.base_orchestrator.classify_request_complexity(user_request)
 
-        # Get base steps synchronously (no agent assignment yet)
-        base_steps = self.base_orchestrator.plan_workflow_steps(user_request, complexity)
+        # Get base steps (no agent assignment yet)
+        base_steps = await self.base_orchestrator.plan_workflow_steps(user_request, complexity)
 
         return {
             "request": user_request,
@@ -225,10 +236,10 @@ class WorkflowPlanner:
             "total_steps": len(base_steps),
             "steps": [
                 {
-                    "id": step.id,
+                    "id": step.task_id,
                     "action": step.action,
                     "agent_type": step.agent_type,
-                    "requires_approval": step.user_approval_required,
+                    "requires_approval": step.requires_approval,
                     "dependencies": step.dependencies or [],
                 }
                 for step in base_steps

--- a/autobot-backend/services/advanced_workflow/step_generator.py
+++ b/autobot-backend/services/advanced_workflow/step_generator.py
@@ -59,8 +59,10 @@ class StepGenerator:
                 TaskComplexity.SIMPLE,
             )
 
-            # Issue #321: Use delegation method to reduce message chains
-            base_steps = self.enhanced_orchestrator.plan_workflow_steps(user_request, complexity)
+            # Issue #321: Use delegation method to reduce message chains.
+            # #13730: plan_workflow_steps is a coroutine function; without await
+            # the enumerate() below iterated a coroutine and raised TypeError.
+            base_steps = await self.enhanced_orchestrator.plan_workflow_steps(user_request, complexity)
 
             # Convert to smart steps with AI enhancements
             smart_steps = []

--- a/autobot-backend/services/workflow_automation/manager.py
+++ b/autobot-backend/services/workflow_automation/manager.py
@@ -71,9 +71,12 @@ class WorkflowAutomationManager:
     async def create_workflow_from_chat_request(self, user_request: str, session_id: str) -> str | None:
         """Create automated workflow from natural language chat request"""
         try:
-            # Use orchestrator to analyze request and create workflow steps
-            complexity = self.orchestrator.classify_request_complexity(user_request)
-            base_steps = self.orchestrator.plan_workflow_steps(user_request, complexity)
+            # Use orchestrator to analyze request and create workflow steps.
+            # #13730: both are coroutine functions — without await this bound
+            # coroutine objects, the enumerate() below raised TypeError, and the
+            # handler turned every chat request into a silent `return None`.
+            complexity = await self.orchestrator.classify_request_complexity(user_request)
+            base_steps = await self.orchestrator.plan_workflow_steps(user_request, complexity)
 
             # Convert orchestrator steps to workflow steps
             workflow_steps = []
@@ -83,8 +86,13 @@ class WorkflowAutomationManager:
                     command=self._extract_command_from_step(step),
                     description=step.action,
                     explanation=f"This step is part of: {user_request}",
-                    requires_confirmation=step.user_approval_required,
-                    dependencies=[f"step_{j+1}" for j in range(i) if base_steps[j].id in (step.dependencies or [])],
+                    # #13730: canonical WorkflowTask names — `requires_approval`
+                    # and `task_id`; the retired `user_approval_required` / `id`
+                    # would have raised AttributeError once the await landed.
+                    requires_confirmation=step.requires_approval,
+                    dependencies=[
+                        f"step_{j+1}" for j in range(i) if base_steps[j].task_id in (step.dependencies or [])
+                    ],
                 )
                 workflow_steps.append(workflow_step)
 
@@ -101,7 +109,11 @@ class WorkflowAutomationManager:
             return None
 
         except Exception as e:
-            logger.error("Failed to create workflow from chat request: %s", e)
+            # #13730: this handler is what made the un-awaited planning calls
+            # invisible — a TypeError became a plain `return None`, so both HTTP
+            # routes reported "no workflow" instead of an error. Contract keeps
+            # returning None, but the cause is now in the log.
+            logger.error("Failed to create workflow from chat request: %s", e, exc_info=True)
             return None
 
     def _extract_command_from_step(self, step) -> str:

--- a/autobot-backend/tests/orchestration/test_planning_caller_wiring.py
+++ b/autobot-backend/tests/orchestration/test_planning_caller_wiring.py
@@ -1,0 +1,115 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Regression cover for the callers of the orchestrator's planning API (#13730).
+
+Every caller of ``plan_workflow_steps`` / ``classify_request_complexity`` bound
+the coroutine without awaiting it and then read ``step.id`` /
+``step.user_approval_required`` — names the canonical ``WorkflowTask`` does not
+define. Nothing in the suite noticed, because the only caller-level test
+asserted nothing and the live caller swallowed the TypeError into ``return
+None``.
+
+These tests drive each caller with a **real** ``Orchestrator``, so a regression
+to either failure mode (missing await, or a retired field name) fails here
+rather than silently returning nothing in production.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from orchestrator import Orchestrator, TaskComplexity
+
+
+@pytest.fixture
+def orchestrator():
+    """A real Orchestrator — the point is to exercise the true task contract."""
+    return Orchestrator()
+
+
+async def test_plan_workflow_steps_with_agents_returns_assigned_steps(orchestrator):
+    """The planner awaits the plan and projects canonical fields into its dicts."""
+    from orchestration.workflow_planner import WorkflowPlanner
+
+    planner = WorkflowPlanner(
+        base_orchestrator=orchestrator,
+        agent_registry={},
+        find_best_agent_callback=lambda **kwargs: "test-agent",
+    )
+    # Trajectory lookup is advisory (GH#7357) and not under test here.
+    planner._annotate_context_with_trajectories = AsyncMock(return_value=None)
+
+    steps = await planner.plan_workflow_steps_with_agents("install docker", TaskComplexity.COMPLEX, {})
+
+    assert len(steps) == 3, f"expected the COMPLEX plan to survive agent assignment, got {steps}"
+    assert [step["id"] for step in steps] == ["step_1", "step_2", "step_3"]
+    assert all(step["assigned_agent"] == "test-agent" for step in steps)
+    assert all(step["status"] == "planned" for step in steps)
+    # step_2 requires approval in the COMPLEX plan; the projection must carry it.
+    assert [step["user_approval_required"] for step in steps] == [False, True, False]
+
+
+async def test_get_plan_summary_returns_a_populated_summary(orchestrator):
+    """get_plan_summary was sync while the API it calls is async (#13730)."""
+    from orchestration.workflow_planner import WorkflowPlanner
+
+    planner = WorkflowPlanner(
+        base_orchestrator=orchestrator,
+        agent_registry={},
+        find_best_agent_callback=lambda **kwargs: None,
+    )
+
+    summary = await planner.get_plan_summary("install docker")
+
+    assert summary["request"] == "install docker"
+    assert summary["complexity"] == TaskComplexity.COMPLEX.value
+    assert summary["total_steps"] == len(summary["steps"]) > 0
+    assert [step["id"] for step in summary["steps"]] == ["step_1", "step_2", "step_3"]
+    assert all(isinstance(step["requires_approval"], bool) for step in summary["steps"])
+
+
+async def test_create_workflow_from_chat_request_builds_steps(orchestrator):
+    """The live HTTP path: a chat request must yield a workflow, not None."""
+    from services.workflow_automation.manager import WorkflowAutomationManager
+
+    # __init__ wires messenger/executor/controller/template_manager, none of
+    # which this method touches. Build the instance without them and inject only
+    # the two collaborators the body actually uses.
+    manager = object.__new__(WorkflowAutomationManager)
+    manager.orchestrator = orchestrator
+    manager.create_automated_workflow = AsyncMock(return_value="workflow-1")
+
+    workflow_id = await manager.create_workflow_from_chat_request("install docker", "session-1")
+
+    # Before #13730 this returned None: enumerate() over a coroutine raised
+    # TypeError straight into the handler.
+    assert workflow_id == "workflow-1"
+
+    manager.create_automated_workflow.assert_awaited_once()
+    steps = manager.create_automated_workflow.await_args.kwargs["steps"]
+    assert len(steps) == 3
+    assert [step.step_id for step in steps] == ["step_1", "step_2", "step_3"]
+    assert all(step.command for step in steps)
+    # step_2 is the approval gate, and its dependency on step_1 must have been
+    # resolved through task_id — the retired `.id` read is what broke this.
+    assert [step.requires_confirmation for step in steps] == [False, True, False]
+    assert steps[1].dependencies == ["step_1"]
+
+
+async def test_generate_smart_steps_awaits_the_plan(orchestrator):
+    """SmartStepGenerator iterated a coroutine before #13730."""
+    from services.advanced_workflow.step_generator import StepGenerator
+
+    generator = StepGenerator(enhanced_orchestrator=orchestrator)
+    generator._generate_alternatives = AsyncMock(return_value=[])
+    generator._add_intelligent_bookends = AsyncMock(side_effect=lambda steps, _analysis: steps)
+
+    smart_steps = await generator.generate_smart_steps(
+        "install docker",
+        {"primary_intent": "configuration", "complexity": "complex"},
+        {},
+    )
+
+    assert len(smart_steps) == 3
+    assert [step.step_id for step in smart_steps] == ["smart_1", "smart_2", "smart_3"]
+    assert all(step.command for step in smart_steps)


### PR DESCRIPTION
Closes #13730

## Thinking Path

#13699 fixed `plan_workflow_steps` itself. This is the caller half, and mapping it first
changed what the fix had to be.

Three of the four call sites sit in `async def` — a plain missing `await`. The fourth,
`WorkflowPlanner.get_plan_summary`, is `def`, calling an async API and then running
`complexity.value` and `len(base_steps)` against coroutine objects. It needed to become
`async def`, which is safe because it has no callers (see #13751).

Reachability turned out to matter more than the count of sites:

| Entry point | Reachable from |
|---|---|
| `create_workflow_from_chat_request` | **LIVE** — `api/workflow.py:290` and `services/workflow_automation/routes.py:258` |
| `generate_smart_steps` | `services/advanced_workflow/coordinator.py:97` |
| `plan_workflow_steps_with_agents` | nothing |
| `get_plan_summary` | nothing |

So there is a real user-facing failure, not just latent rot. On the live path,
`for i, step in enumerate(base_steps)` iterated a coroutine, raised `TypeError` into the
broad handler at `manager.py:103`, and returned `None` — and `api/workflow.py:292` turns a
falsy `workflow_id` into **HTTP 500**. Every chat-driven workflow request has been
answering 500.

The retired field reads were the second, independent failure: `step.id` and
`step.user_approval_required` have not existed on `WorkflowTask` since #6951 Phase 2A, so
these sites would have raised `AttributeError` even with the awaits added. Both had to move
together or the fix would have looked done and stayed broken.

## What Changed

**`services/workflow_automation/manager.py`** (live path)
- `await` on both `classify_request_complexity` and `plan_workflow_steps`.
- `step.user_approval_required` → `step.requires_approval`; `base_steps[j].id` → `.task_id`.
- The handler that hid all of this now logs `exc_info=True`. The `-> str | None` contract is
  unchanged, since both routes already branch on a falsy id.

**`orchestration/workflow_planner.py`**
- `await` in `plan_workflow_steps_with_agents`; canonical attribute reads.
- `get_plan_summary` becomes `async def` with both awaits and canonical reads.
- **Dict keys are deliberately untouched.** `"id"` and `"user_approval_required"` are this
  module's own contract with `create_plan_summary_for_approval`, which reads
  `step.get("user_approval_required")` at line 267. Only the attribute *sources* moved;
  renaming the keys would have rippled into that consumer for no benefit.

**`orchestration/plan_steps_e2e_test.py`** — rewritten. It printed a step count inside a
bare `except Exception` and asserted nothing, so it passed for the entire period the method
returned `[]`. Now asserts step counts, canonical field names, and that dependency ids
resolve within the plan. Its "four complexity levels" were really two:
`RESEARCH`/`INSTALL`/`SECURITY_SCAN` all carry the value `"complex"`, making them Enum
*aliases* of `COMPLEX`, so it exercised COMPLEX three times. It now covers SIMPLE and
COMPLEX and documents why.

**`tests/orchestration/test_planning_caller_wiring.py`** — new. Drives all four callers with
a **real** `Orchestrator` rather than a stub, so the field-name contract is genuinely
exercised; a stub with invented attributes would defeat the purpose.

## Verification

```
$ python3 -m pytest tests/orchestration/test_planning_caller_wiring.py orchestration/plan_steps_e2e_test.py -q -p no:randomly
6 passed in 1.39s
```

**Every fix proven to be load-bearing.** Each of the seven changes was reverted in
isolation and the suite re-run — all seven fail, so none of these tests can pass against the
broken code:

| Reverted | Result |
|---|---|
| `await` on `manager.py` plan call | FAILED |
| `step.requires_approval` → `user_approval_required` | FAILED |
| `base_steps[j].task_id` → `.id` | FAILED |
| `await` on `workflow_planner.py:113` | FAILED |
| `"id": step.task_id` → `step.id` | FAILED |
| `async def get_plan_summary` → `def` | ERROR |
| `await` on `step_generator.py:63` | FAILED |

Full regression sweep over every area touched:

```
$ python3 -m pytest orchestration/ tests/orchestration/ services/workflow_automation/ \
    services/advanced_workflow/ workflow_templates/ chat_workflow/ \
    performance_benchmarks_test.py dependency_injection_test.py -q -p no:randomly
995 passed, 78 warnings in 75.04s
```

The `sys.modules` leak guard reports only its known baseline entry; the new test file adds
none.

Local Python is 3.10 with 19/69 backend deps absent, so this is not a CI proxy — CI is the
authority on the full suite.

## Discovered — filed as #13751

`plan_workflow_steps_with_agents` and `get_plan_summary` have **zero callers** anywhere.
They are not stubs: the former is the only code joining a base plan to capability-based
agent assignment and TrajectoryStore lookup (GH#7357), the latter the only plan-preview
path. Their unreachability is also why two of the four bugs fixed here survived — no
runtime signal could ever point at code nothing executes. Per the standing rule they are
corrected and kept, not removed; wiring them is #13751.

## Model Used

Claude Opus 5 (1M context)
