### PR TITLE
fix(memory): stop L3 duplicating the chat path's RAG retrieval (#13742)

### DIFF
--- a/autobot-backend/chat_workflow/l3_no_duplicate_retrieval_test.py
+++ b/autobot-backend/chat_workflow/l3_no_duplicate_retrieval_test.py
@@ -1,0 +1,146 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""L3 must not duplicate the chat path's RAG retrieval (#13742).
+
+Found by the #13689 A/B — the first run in which L3 could fire at all. Both
+`Layer3DeepSearch.render` and `_retrieve_knowledge_context` call
+`knowledge_service.conversation_aware_retrieve` with the same query, so enabling
+the tiered stack meant two vector searches per qualifying turn and the same
+chunks twice in the prompt.
+
+This was the sole blocker keeping `tiered_context_enabled` off.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from chat_workflow.llm_handler import LLMHandlerMixin
+
+KB_CONTEXT = "## Knowledge Base\nDeploy runbook: run code-sync from the maintenance page."
+
+
+def _handler(knowledge_service):
+    handler = LLMHandlerMixin.__new__(LLMHandlerMixin)
+    handler.knowledge_service = knowledge_service
+    handler._get_selected_model = MagicMock(return_value="test-model")
+    handler._get_ollama_endpoint_for_model = MagicMock(return_value="http://test")
+    handler._get_system_prompt = MagicMock(return_value="SYSTEM")
+    handler._build_conversation_context = MagicMock(return_value="")
+    handler._build_full_prompt = MagicMock(return_value="Full prompt")
+    handler._discover_ollama_from_slm = AsyncMock(return_value=None)
+    return handler
+
+
+def _knowledge_service():
+    svc = MagicMock()
+    svc.conversation_aware_retrieve = AsyncMock(return_value=(KB_CONTEXT, [{"content": "chunk"}], None, None))
+    return svc
+
+
+def _session():
+    session = MagicMock()
+    session.session_id = "s-1"
+    session.conversation_history = []
+    session.metadata = {}
+    return session
+
+
+async def _run_turn(handler, message):
+    """Drive the real prompt-preparation path with the tiered flag on."""
+    with (
+        patch("chat_history.layers.TIERED_CONTEXT_ENABLED", True),
+        patch("chat_workflow.llm_handler._emit_before_prompt_build", new_callable=AsyncMock),
+    ):
+        with patch(
+            "chat_workflow.llm_handler._emit_system_prompt_ready",
+            new_callable=AsyncMock,
+            side_effect=lambda prompt, _s: prompt,
+        ):
+            with patch(
+                "chat_workflow.llm_handler._emit_after_prompt_build",
+                new_callable=AsyncMock,
+                return_value="Full prompt",
+            ):
+                with patch(
+                    "chat_workflow.llm_handler._emit_full_prompt_ready",
+                    new_callable=AsyncMock,
+                    return_value="Full prompt",
+                ):
+                    return await handler._prepare_llm_request_params(_session(), message, use_knowledge=True)
+
+
+class TestSingleRetrievalPerTurn:
+    @pytest.mark.asyncio
+    async def test_a_retrieval_keyword_turn_retrieves_exactly_once(self):
+        """The headline: 'search ...' triggers L3 *and* the main RAG path.
+
+        Before #13742 this was two identical vector searches.
+        """
+        svc = _knowledge_service()
+        handler = _handler(svc)
+
+        with patch(
+            "utils.resource_factory.ResourceFactory.get_initialized_chat_history_manager",
+            return_value=None,
+        ):
+            await _run_turn(handler, "search the kb for the deploy runbook")
+
+        assert svc.conversation_aware_retrieve.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_a_plain_turn_also_retrieves_exactly_once(self):
+        """No retrieval keyword: L3 would not fire anyway. Guards the fix
+        against regressing the ordinary path."""
+        svc = _knowledge_service()
+        handler = _handler(svc)
+
+        with patch(
+            "utils.resource_factory.ResourceFactory.get_initialized_chat_history_manager",
+            return_value=None,
+        ):
+            await _run_turn(handler, "how are you")
+
+        assert svc.conversation_aware_retrieve.await_count == 1
+
+
+class TestKnowledgeStillReachesThePrompt:
+    @pytest.mark.asyncio
+    async def test_the_tiered_block_no_longer_carries_a_kb_copy(self):
+        """Removing the duplicate must remove the *copy*, not the content.
+
+        The main path still owns retrieval — and unlike the tiered copy, its
+        result passes through budget_grounded_context for trimming and citation
+        rebinding (#3770/#10837). What must not survive is a second copy inside
+        the tiered block, which escaped that budgeting entirely.
+        """
+        svc = _knowledge_service()
+        handler = _handler(svc)
+
+        with patch(
+            "utils.resource_factory.ResourceFactory.get_initialized_chat_history_manager",
+            return_value=None,
+        ):
+            params = await _run_turn(handler, "search the kb for the deploy runbook")
+
+        # The tiered context is prepended to the system prompt; the KB copy that
+        # L3 used to inject would appear there.
+        assert KB_CONTEXT not in params["system_prompt"]
+        assert svc.conversation_aware_retrieve.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_l3_keeps_its_own_retrieval_path_for_other_callers(self):
+        """The layer is unchanged — only this call site stops feeding it.
+
+        A caller with no separate RAG stage still gets L3's retrieval.
+        """
+        from chat_history.layers import Layer3DeepSearch
+
+        svc = _knowledge_service()
+
+        rendered = await Layer3DeepSearch().render({"user_message": "search for the runbook", "knowledge_service": svc})
+
+        assert rendered == KB_CONTEXT
+        assert svc.conversation_aware_retrieve.await_count == 1

--- a/autobot-backend/chat_workflow/llm_handler.py
+++ b/autobot-backend/chat_workflow/llm_handler.py
@@ -890,7 +890,19 @@ NEVER teach commands - ALWAYS execute them.""" + lang_instruction
                         model_name=selected_model,
                         session_id=session.session_id,
                         memory_graph=await resolve_memory_graph(),
-                        knowledge_service=self.knowledge_service if use_knowledge else None,
+                        # #13742: deliberately NOT self.knowledge_service. The RAG
+                        # path below (:914) retrieves for every use_knowledge turn
+                        # via the same conversation_aware_retrieve L3 would call,
+                        # then applies budget_grounded_context for trimming and
+                        # citation rebinding (#3770/#10837). Handing L3 the service
+                        # here bought a second identical vector search and the same
+                        # chunks twice in the prompt — with the copy inside the
+                        # tiered block escaping that budgeting entirely.
+                        #
+                        # L3 keeps its retrieval path for callers that have no
+                        # separate RAG stage; at this call site the main path owns
+                        # retrieval, so L3 correctly stays silent.
+                        knowledge_service=None,
                         goal_ancestry=await resolve_goal_ancestry(session.session_id),
                     )
                     if tiered_ctx:


### PR DESCRIPTION
## Thinking Path

This was the **sole blocker** keeping `tiered_context_enabled` off, found by the #13689 A/B — which is exactly what that issue exists to do, and why it could only surface now: L3 could not fire at all until #13686/#13687 landed.

Two code paths called the same retrieval, on the same turn, with the same query:

- `chat_workflow/llm_handler.py:914` → `_retrieve_knowledge_context` → `conversation_aware_retrieve`
- `Layer3DeepSearch.render` → `conversation_aware_retrieve`

With the flag on, any message containing a retrieval keyword (`find`, `search`, `tell me about`, …) meant **two vector searches** and **the same chunks twice in the prompt**.

The asymmetry decided the fix. The main path's result passes through `budget_grounded_context`, which trims to the model budget and rebinds citations to the subset the model actually saw (#3770/#10837). The tiered copy skipped all of that — so the duplicate was not merely redundant, it was the *worse* of the two copies, spending context the budgeter never saw.

So the main path keeps ownership of retrieval, and the tiered builder is no longer handed a `knowledge_service` at this call site.

## What Changed

One argument at `chat_workflow/llm_handler.py:905`, with the reasoning recorded inline so the next reader does not "helpfully" pass the service back in.

`Layer3DeepSearch` is **unchanged**. It keeps its own retrieval path for any caller without a separate RAG stage; only this call site stops feeding it. A test pins that, so the layer does not quietly become dead code.

## Verification

Asserted by **call count**, not by reading:

```
$ python3 -m pytest chat_workflow/l3_no_duplicate_retrieval_test.py -q
4 passed
```

- `test_a_retrieval_keyword_turn_retrieves_exactly_once` — `"search the kb for the deploy runbook"` triggers both L3's condition and the main path. `await_count == 1`.
- `test_a_plain_turn_also_retrieves_exactly_once` — guards against regressing the ordinary path while fixing the keyword one.
- `test_the_tiered_block_no_longer_carries_a_kb_copy` — the KB content is absent from the tiered block in the assembled system prompt.
- `test_l3_keeps_its_own_retrieval_path_for_other_callers` — the layer still retrieves when given a service directly.

No regressions:

```
$ python3 -m pytest chat_workflow/ chat_history/ -q -p no:randomly
508 passed

black / isort / flake8 → clean
```

### Acceptance criteria

- [x] A retrieval-keyword turn with the flag on performs **one** KB retrieval, proven by a call count.
- [x] The prompt does not contain the same retrieved chunk twice.
- [x] `budget_grounded_context` trimming and citation rebinding still apply — the surviving copy is the one that goes through them.
- [ ] Before/after latency measurement — not included. The A/B harness mocks the knowledge service, so a meaningful retrieval-latency number needs a live backend. The saving is one full vector search per qualifying turn; I would rather state that than publish a mocked figure as if it were real.

## Sequencing note

This unblocks flipping `tiered_context_enabled`, but **the flip is not in this PR**. #13749 (the A/B record) is still open and its config comment says "stay OFF pending #13742". Flipping here would leave that comment false at merge time — the same class of mistake as the parked-row policy in #13732, where the documentation asserted something the code did not do.

Correct order: merge #13749, then a small PR flips the flag and updates the record to say why it changed. Recorded on #13689.

## Model Used

Claude Opus 5 (1M context)

Closes #13742
Unblocks the flag decision in #13689 · part of #13685
