### PR TITLE
feat(agent): expose spilled tool output as a run-scoped, windowed read tool (#13754)

### DIFF
--- a/autobot-backend/agent_loop/tool_output_spill.py
+++ b/autobot-backend/agent_loop/tool_output_spill.py
@@ -129,11 +129,16 @@ def _excerpt_payload(anchor: str, tool_name: str, payload: str) -> Dict[str, Any
     }
 
 
-def read_spilled(anchor: str) -> str | None:
+def read_spilled(anchor: str, task_id: str | None = None) -> str | None:
     """Return the full spilled output for *anchor*, or None.
 
-    This is what makes the anchor a reference rather than a deletion — the AC
-    requires the agent to be able to retrieve the full output within the run.
+    This is what makes the anchor a reference rather than a deletion.
+
+    ``task_id`` scopes the read to one run (#13754). It is optional so
+    in-process callers that already hold the artifact can omit it, but the
+    agent-facing tool always passes it: without the check, an anchor leaked
+    into one run could read another run's observations, since the anchor alone
+    is a bearer token.
     """
     if not isinstance(anchor, str) or not anchor.startswith(_ANCHOR_PREFIX):
         return None
@@ -141,10 +146,39 @@ def read_spilled(anchor: str) -> str | None:
         path = _artifact_path(anchor)
         if not path.exists():
             return None
-        return json.loads(path.read_text(encoding="utf-8")).get("output")
+        record = json.loads(path.read_text(encoding="utf-8"))
+        if task_id is not None and record.get("task_id") != task_id:
+            logger.warning("Refusing cross-run spilled read for anchor %s (#13754)", anchor)
+            return None
+        return record.get("output")
     except Exception as exc:
         logger.warning("Failed to read spilled output for %s: %s", anchor, exc)
         return None
+
+
+def read_spilled_window(anchor: str, task_id: str, offset: int = 0, limit: int | None = None) -> Dict[str, Any]:
+    """Return a bounded window of a spilled output (#13754).
+
+    A window, not the whole artifact: handing back the full 78,000 chars would
+    undo the offload that put it aside in the first place. Re-reading is a
+    seek, not an undo.
+    """
+    full = read_spilled(anchor, task_id=task_id)
+    if full is None:
+        return {"found": False, "anchor": anchor}
+
+    limit = SPILL_EXCERPT_CHARS if limit is None else max(1, int(limit))
+    offset = max(0, int(offset))
+    window = full[offset : offset + limit]
+    return {
+        "found": True,
+        "anchor": anchor,
+        "offset": offset,
+        "limit": limit,
+        "total_chars": len(full),
+        "content": window,
+        "has_more": offset + limit < len(full),
+    }
 
 
 def spill_results(task_id: str, tool_results: Dict[str, Any]) -> Tuple[Dict[str, Any], int]:
@@ -170,6 +204,7 @@ __all__ = [
     "SPILL_EXCERPT_CHARS",
     "SPILL_THRESHOLD_CHARS",
     "read_spilled",
+    "read_spilled_window",
     "spill_if_oversized",
     "spill_results",
 ]

--- a/autobot-backend/agent_loop/tool_output_spill_test.py
+++ b/autobot-backend/agent_loop/tool_output_spill_test.py
@@ -155,3 +155,68 @@ class TestBatch:
 
 def _raise(*_args, **_kwargs):
     raise OSError("disk full")
+
+
+class TestRunScopedWindowedRead:
+    """#13754: the anchor is a bearer token, so reads must be run-scoped.
+
+    And a re-read must be a seek, not an undo — returning the whole artifact
+    would put back exactly what the offload removed.
+    """
+
+    def test_a_window_is_returned_not_the_whole_artifact(self):
+        big = "I" * 500
+
+        value, _ = spill.spill_if_oversized(TASK, "bash", big)
+        window = spill.read_spilled_window(value["anchor"], TASK, offset=0, limit=50)
+
+        assert window["found"] is True
+        assert len(window["content"]) == 50
+        assert window["total_chars"] == 500
+        assert window["has_more"] is True
+
+    def test_paging_reaches_the_end(self):
+        big = "".join(str(i % 10) for i in range(300))
+
+        value, _ = spill.spill_if_oversized(TASK, "bash", big)
+        first = spill.read_spilled_window(value["anchor"], TASK, offset=0, limit=200)
+        second = spill.read_spilled_window(value["anchor"], TASK, offset=200, limit=200)
+
+        assert first["content"] + second["content"] == big
+        assert second["has_more"] is False
+
+    def test_an_anchor_from_another_run_is_refused(self):
+        """The security case: a leaked anchor must not read another run."""
+        big = "J" * 500
+
+        value, _ = spill.spill_if_oversized(TASK, "bash", big)
+
+        assert spill.read_spilled(value["anchor"], task_id="someone-elses-run") is None
+        assert spill.read_spilled_window(value["anchor"], "someone-elses-run")["found"] is False
+
+    def test_the_owning_run_still_reads_it(self):
+        big = "K" * 500
+
+        value, _ = spill.spill_if_oversized(TASK, "bash", big)
+
+        assert spill.read_spilled(value["anchor"], task_id=TASK) == big
+
+    def test_a_missing_anchor_reports_not_found_rather_than_raising(self):
+        window = spill.read_spilled_window("autobot:spill:x:y:deadbeef", TASK)
+
+        assert window["found"] is False
+
+
+class TestTheExcerptNamesARealTool:
+    def test_the_instruction_matches_the_registered_tool_name(self):
+        """The excerpt tells the model what to call; that name must exist.
+
+        Naming a capability the agent cannot invoke is worse than saying
+        nothing — it invites a call that will fail.
+        """
+        from tools.tool_registry import ToolRegistry
+
+        value, _ = spill.spill_if_oversized(TASK, "bash", "L" * 500)
+
+        assert "read_spilled_output" in value["note"]
+        assert hasattr(ToolRegistry, "read_spilled_output")

--- a/autobot-backend/tools/tool_registry.py
+++ b/autobot-backend/tools/tool_registry.py
@@ -123,6 +123,32 @@ class ToolRegistry:
             "status": result.get("status", "success"),
         }
 
+    async def read_spilled_output(
+        self, anchor: str, task_id: str, offset: int = 0, limit: int | None = None
+    ) -> Dict[str, Any]:
+        """Read a window of a tool output that was spilled out of context (#13754).
+
+        #13692 step 1 writes oversized tool results aside and leaves a bounded
+        excerpt plus an anchor in context. The excerpt's note tells the model to
+        call this tool — so until it existed, the instruction named a capability
+        the agent could not invoke, which is worse than saying nothing.
+
+        Scoped to *task_id*: an anchor is a bearer token, so one leaked into a
+        different run must not read that run's observations.
+
+        Returns a window rather than the whole artifact — handing back the full
+        output would undo the offload. Page with *offset* while ``has_more``.
+        """
+        from agent_loop.tool_output_spill import read_spilled_window
+
+        window = read_spilled_window(anchor, task_id, offset=offset, limit=limit)
+        return {
+            "tool_name": "read_spilled_output",
+            "tool_args": {"anchor": anchor, "offset": offset, "limit": limit},
+            "result": window,
+            "status": "success" if window.get("found") else "not_found",
+        }
+
     async def query_system_information(self) -> Dict[str, Any]:
         """Query system information."""
         task = self._create_base_task("system_query_info")


### PR DESCRIPTION
## Thinking Path

#13692 step 1 spills oversized tool output and leaves an excerpt whose note says:

```
Output truncated to 2000 of 78000 chars. Read the full output with the
read_spilled_output tool using anchor 'autobot:spill:...'.
```

**That tool did not exist.** The excerpt named a capability the agent could not invoke — worse than saying nothing, because it invites a call that fails and teaches the model the anchor is useless.

Two constraints made this more than a wrapper, and both were identified before writing code:

**Run scoping.** An anchor is a bearer token. `read_spilled` validated only the anchor's *shape*, so an anchor that leaked into a different run — via a shared log, a copied prompt, a retried task — could read that run's observations. Reads now take a `task_id` and refuse a mismatch.

**Windowed reads.** Returning the whole artifact would undo the offload that put it aside. A 78,000-char re-read is exactly the thing step 1 exists to prevent, so `read_spilled_window` pages with `offset`/`limit` and reports `has_more`. Re-reading is a seek, not an undo.

## What Changed

- `agent_loop/tool_output_spill.py` — `read_spilled` gains an optional `task_id` scope; new `read_spilled_window` returns a bounded page.
- `tools/tool_registry.py` — `read_spilled_output(anchor, task_id, offset, limit)`, following the registry's existing method shape.

`task_id` is optional on `read_spilled` so in-process callers that already hold the artifact can omit it; the **agent-facing tool always passes it**. That asymmetry is deliberate and documented — the untrusted caller is the one that gets checked.

## Verification

```
$ python3 -m pytest agent_loop/tool_output_spill_test.py -q
20 passed

$ python3 -m pytest agent_loop/ tools/ -q -p no:randomly
247 passed

black / isort / flake8 → clean
```

### Acceptance criteria

- [x] An agent can call the tool named in the excerpt text and get the output.
- [x] An anchor from a different run is refused — `test_an_anchor_from_another_run_is_refused` proves both `read_spilled` and `read_spilled_window` reject it, and `test_the_owning_run_still_reads_it` proves the check is not simply always-deny.
- [x] Returns a bounded window with offset/limit rather than the entire artifact — `test_paging_reaches_the_end` reassembles the original across two pages and asserts `has_more` clears.
- [x] The excerpt's instruction text matches the tool's real name — `test_the_instruction_matches_the_registered_tool_name` asserts both the string in the note and `hasattr(ToolRegistry, "read_spilled_output")`, so the two cannot drift apart again.

That last test is the one I would keep if I could keep only one. The defect this PR fixes was precisely a mismatch between what the prompt promised and what existed.

## Model Used

Claude Opus 5 (1M context)

Closes #13754
Completes #13692 step 1 · part of #13685
