### PR TITLE
security(llc): apply the bound tenant context in the heartbeat context route (#13756)

### DIFF
--- a/autobot-backend/llc/api/context.py
+++ b/autobot-backend/llc/api/context.py
@@ -52,7 +52,8 @@ async def get_context(
         item_id: Work item UUID
         mode: "thin" or "fat" context mode
         session: DB session
-        ctx: Tenant context
+        ctx: Tenant context — its ``org_id`` scopes the whole assembled
+            context, so another company's item id reads as 404 (#13756)
 
     Returns:
         Dict with assembled context:
@@ -85,6 +86,7 @@ async def get_context(
             agent_id=_current_user.get("id", "unknown"),
             work_item_id=work_item_id,
             context_mode=mode,
+            company_id=str(ctx.org_id),
         )
     except ValueError as e:
         error_msg = str(e)

--- a/autobot-backend/llc/kb/context_builder.py
+++ b/autobot-backend/llc/kb/context_builder.py
@@ -59,6 +59,8 @@ class HeartbeatContextBuilder:
         agent_id: str,
         work_item_id: uuid.UUID,
         context_mode: str = "fat",
+        *,
+        company_id: str,
     ) -> Dict[str, Any]:
         """Build heartbeat context for an agent.
 
@@ -67,17 +69,20 @@ class HeartbeatContextBuilder:
             agent_id: Agent ID
             work_item_id: Work item being checked out
             context_mode: "thin" (minimal) or "fat" (rich, GH#8236)
+            company_id: Caller's tenant scope (#13756). Keyword-only and
+                required — the work item is fetched under this scope, so an
+                item belonging to another company is reported as missing.
 
         Returns:
             Dict with assembled context, ready to compress and store.
 
         Raises:
-            ValueError: If work_item_id not found
+            ValueError: If work_item_id is not found within ``company_id``
         """
         if context_mode == "thin":
-            return await self._build_thin(session, agent_id, work_item_id)
+            return await self._build_thin(session, agent_id, work_item_id, company_id=company_id)
         elif context_mode == "fat":
-            return await self._build_fat(session, agent_id, work_item_id)
+            return await self._build_fat(session, agent_id, work_item_id, company_id=company_id)
         else:
             raise ValueError(f"Unknown context_mode: {context_mode}")
 
@@ -86,13 +91,15 @@ class HeartbeatContextBuilder:
         session: AsyncSession,
         agent_id: str,
         work_item_id: uuid.UUID,
+        *,
+        company_id: str,
     ) -> Dict[str, Any]:
         """Build minimal context for quick heartbeat startup.
 
         Returns:
             Dict with work_item_id, api_base, agent_api_key
         """
-        work_item = await self.work_item_service.get(session, work_item_id)
+        work_item = await self.work_item_service.get(session, work_item_id, company_id=company_id)
         if work_item is None:
             raise ValueError(f"Work item {work_item_id} not found")
 
@@ -107,6 +114,8 @@ class HeartbeatContextBuilder:
         session: AsyncSession,
         agent_id: str,
         work_item_id: uuid.UUID,
+        *,
+        company_id: str,
     ) -> Dict[str, Any]:
         """Build rich context with parallel RAG queries (GH#8236).
 
@@ -118,11 +127,16 @@ class HeartbeatContextBuilder:
             Dict with goal_ancestry, company_context, project_context, agent_memory,
             similar_past_work, acceptance_criteria, work_item_detail
         """
-        work_item = await self.work_item_service.get(session, work_item_id)
+        work_item = await self.work_item_service.get(session, work_item_id, company_id=company_id)
         if work_item is None:
             raise ValueError(f"Work item {work_item_id} not found")
 
-        company_id = str(work_item.company_id)
+        # The scope every downstream RAG/goal lookup runs under is the caller's,
+        # never the fetched row's (#13756). The row is only reachable under that
+        # scope now, so a mismatch means the store ignored the filter.
+        if str(work_item.company_id) != str(company_id):
+            raise ValueError(f"Work item {work_item_id} not found")
+
         project_id = str(work_item.project_id) if work_item.project_id else None
         query_text = f"{work_item.title}\n{work_item.description or ''}"
 

--- a/autobot-backend/llc/services/work_item_service.py
+++ b/autobot-backend/llc/services/work_item_service.py
@@ -28,7 +28,7 @@ import asyncio
 import logging
 import uuid
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, Dict, List, Optional, Sequence, Union
 
 from sqlalchemy import select, text
 from sqlalchemy.exc import OperationalError, ProgrammingError
@@ -303,7 +303,11 @@ class WorkItemService(LLCServiceBase):
         return item
 
     async def get(
-        self, session: AsyncSession, work_item_id: str, *, company_id: Optional[str] = None
+        self,
+        session: AsyncSession,
+        work_item_id: Union[str, uuid.UUID],
+        *,
+        company_id: Optional[str] = None,
     ) -> Optional[LLCWorkItem]:
         """Fetch a work item, optionally scoped to a company (#13704).
 
@@ -311,8 +315,12 @@ class WorkItemService(LLCServiceBase):
         whose scope is already established stay unchanged; the chat prompt path,
         which is the one place an untrusted id arrives, always passes it. A
         mismatch returns ``None`` — indistinguishable from "no such item".
+
+        ``work_item_id`` accepts a ``UUID`` as well as a string (#13756): the
+        heartbeat context path holds a parsed ``UUID`` and #13704's unconditional
+        ``uuid.UUID(work_item_id)`` raised ``AttributeError`` on it.
         """
-        stmt = select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id))
+        stmt = select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(str(work_item_id)))
         if company_id is not None:
             stmt = stmt.where(LLCWorkItem.company_id == uuid.UUID(str(company_id)))
         result = await session.execute(stmt)

--- a/autobot-backend/llc/tests/test_context_endpoint_tenant_scope.py
+++ b/autobot-backend/llc/tests/test_context_endpoint_tenant_scope.py
@@ -1,0 +1,106 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tenant-scope tests for GET /api/llc/agent/context/{item_id} (#13756).
+
+The route bound ``require_org_context`` but never applied it, so any
+authenticated caller could read another company's work item, its goal
+ancestry and its KB context by supplying the item UUID.
+"""
+
+import uuid
+from typing import Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from user_management.services import TenantContext
+
+_USER_ID = uuid.UUID("33333333-3333-3333-3333-333333333333")
+_COMPANY_A = "11111111-1111-1111-1111-111111111111"
+_COMPANY_B = "22222222-2222-2222-2222-222222222222"
+
+
+def _make_item(company_id: str) -> MagicMock:
+    item = MagicMock()
+    item.id = uuid.uuid4()
+    item.company_id = company_id
+    item.project_id = None
+    item.goal_id = uuid.uuid4()
+    item.title = "Company A private item"
+    item.description = "Confidential"
+    item.status = "todo"
+    item.priority = "high"
+    item.acceptance_criteria = "Never leaks"
+    return item
+
+
+def _make_app(caller_org_id: str, item: MagicMock):
+    """FastAPI app for the context route, with a scope-honouring item store."""
+    # Deferred imports: must not be at module level (see test_suggest_ac_endpoint.py).
+    from api.user_management.dependencies import get_current_user, require_org_context  # noqa: PLC0415
+    from llc.api.context import router as context_router  # noqa: PLC0415
+    from user_management.database import get_async_session  # noqa: PLC0415
+
+    app = FastAPI()
+    app.include_router(context_router)
+
+    async def _fake_session():
+        yield AsyncMock()
+
+    def _fake_user() -> dict:
+        return {"id": str(_USER_ID), "user_id": str(_USER_ID)}
+
+    def _fake_tenant() -> TenantContext:
+        return TenantContext(org_id=uuid.UUID(caller_org_id), user_id=_USER_ID, is_platform_admin=False)
+
+    app.dependency_overrides[get_async_session] = _fake_session
+    app.dependency_overrides[get_current_user] = _fake_user
+    app.dependency_overrides[require_org_context] = _fake_tenant
+
+    async def _scoped_get(_session, work_item_id, *, company_id: Optional[str] = None):
+        """Stand in for the DB: the row is only visible under its own company."""
+        if str(work_item_id) != str(item.id):
+            return None
+        if company_id is not None and str(company_id) != item.company_id:
+            return None
+        return item
+
+    return app, _scoped_get
+
+
+@pytest.mark.parametrize("mode", ["fat", "thin"])
+def test_own_company_item_is_readable(mode: str) -> None:
+    item = _make_item(_COMPANY_A)
+    app, scoped_get = _make_app(_COMPANY_A, item)
+
+    with (
+        patch("llc.services.work_item_service.WorkItemService.get", new=AsyncMock(side_effect=scoped_get)),
+        patch("llc.services.goal.GoalService.get_goal_ancestry_for_work_item", new=AsyncMock(return_value=[])),
+        patch("llc.kb.rag_assembler.LLCRAGAssembler.assemble", new=AsyncMock(side_effect=Exception("no KB"))),
+    ):
+        response = TestClient(app).get(f"/agent/context/{item.id}?mode={mode}")
+
+    assert response.status_code == 200
+    assert response.json()["work_item_id"] == str(item.id)
+
+
+@pytest.mark.parametrize("mode", ["fat", "thin"])
+def test_other_companys_item_is_404(mode: str) -> None:
+    """Company B's caller supplying company A's item UUID gets 404, no ancestry."""
+    item = _make_item(_COMPANY_A)
+    app, scoped_get = _make_app(_COMPANY_B, item)
+    ancestry = AsyncMock(return_value=[{"id": "g1", "title": "Company A goal"}])
+
+    with (
+        patch("llc.services.work_item_service.WorkItemService.get", new=AsyncMock(side_effect=scoped_get)),
+        patch("llc.services.goal.GoalService.get_goal_ancestry_for_work_item", new=ancestry),
+    ):
+        response = TestClient(app).get(f"/agent/context/{item.id}?mode={mode}")
+
+    assert response.status_code == 404
+    assert "Company A" not in response.text
+    ancestry.assert_not_awaited()

--- a/autobot-backend/llc/tests/test_heartbeat_context.py
+++ b/autobot-backend/llc/tests/test_heartbeat_context.py
@@ -165,6 +165,7 @@ async def test_build_fat_returns_required_keys(builder: HeartbeatContextBuilder)
         agent_id="agent1",
         work_item_id=work_item_id,
         context_mode="fat",
+        company_id="co1",
     )
 
     assert "work_item_id" in result
@@ -186,6 +187,7 @@ async def test_build_thin_returns_minimal_keys(builder: HeartbeatContextBuilder)
         agent_id="agent1",
         work_item_id=work_item_id,
         context_mode="thin",
+        company_id="co1",
     )
 
     assert "work_item_id" in result
@@ -201,6 +203,7 @@ async def test_build_unknown_mode_raises(builder: HeartbeatContextBuilder) -> No
             agent_id="agent1",
             work_item_id=uuid.uuid4(),
             context_mode="superduper",
+            company_id="co1",
         )
 
 
@@ -215,6 +218,7 @@ async def test_build_fat_missing_work_item_raises(builder: HeartbeatContextBuild
             agent_id="agent1",
             work_item_id=uuid.uuid4(),
             context_mode="fat",
+            company_id="co1",
         )
 
 
@@ -234,6 +238,7 @@ async def test_build_fat_with_goal_ancestry(builder: HeartbeatContextBuilder) ->
         agent_id="agent1",
         work_item_id=wi.id,
         context_mode="fat",
+        company_id="co1",
     )
 
     builder.goal_service.get_goal_ancestry_for_work_item.assert_called_once_with(session, goal_id)
@@ -252,6 +257,7 @@ async def test_build_fat_rag_failure_graceful(builder: HeartbeatContextBuilder) 
         agent_id="agent1",
         work_item_id=uuid.uuid4(),
         context_mode="fat",
+        company_id="co1",
     )
 
     assert result["company_context"] == {"chunks": [], "sources": []}
@@ -268,6 +274,107 @@ async def test_build_fat_parallel_queries_invoked(builder: HeartbeatContextBuild
         agent_id="agent1",
         work_item_id=wi.id,
         context_mode="fat",
+        company_id="co1",
     )
 
     assert builder.rag_assembler.assemble.call_count >= 2
+
+
+# --------------------------------------------- Tenant scoping (#13756)
+
+
+@pytest.fixture
+def scoped_builder() -> HeartbeatContextBuilder:
+    """Builder whose work_item_service honours the ``company_id`` filter.
+
+    ``AsyncMock`` returns its canned value regardless of arguments, which would
+    hide the very filter under test, so the fake applies the scope itself.
+    """
+    rag = AsyncMock(spec=LLCRAGAssembler)
+    rag.assemble.return_value = LLCContext(
+        company_id="co1",
+        profile=AssemblerProfile.HEARTBEAT,
+        chunks=[],
+        sources=[],
+        metadata={},
+    )
+    goal_svc = AsyncMock()
+    goal_svc.get_goal_ancestry_for_work_item.return_value = [{"id": "g1", "title": "Secret goal"}]
+
+    owned = _make_work_item(company_id="co1", goal_id=uuid.uuid4())
+
+    async def _scoped_get(_session, _work_item_id, *, company_id=None):
+        if company_id is not None and str(company_id) != owned.company_id:
+            return None
+        return owned
+
+    work_svc = AsyncMock()
+    work_svc.get.side_effect = _scoped_get
+
+    builder = HeartbeatContextBuilder(
+        rag_assembler=rag,
+        goal_service=goal_svc,
+        work_item_service=work_svc,
+    )
+    builder.owned_item = owned  # type: ignore[attr-defined]
+    return builder
+
+
+@pytest.mark.parametrize("mode", ["fat", "thin"])
+@pytest.mark.asyncio
+async def test_build_forwards_company_scope_to_fetch(scoped_builder: HeartbeatContextBuilder, mode: str) -> None:
+    """No build path reaches work_item_service.get without an explicit scope."""
+    await scoped_builder.build(
+        session=AsyncMock(),
+        agent_id="agent1",
+        work_item_id=scoped_builder.owned_item.id,  # type: ignore[attr-defined]
+        context_mode=mode,
+        company_id="co1",
+    )
+
+    assert scoped_builder.work_item_service.get.await_args.kwargs["company_id"] == "co1"
+
+
+@pytest.mark.parametrize("mode", ["fat", "thin"])
+@pytest.mark.asyncio
+async def test_build_rejects_other_companys_item(scoped_builder: HeartbeatContextBuilder, mode: str) -> None:
+    """Company B's token asking for company A's item id gets "not found" (-> 404)."""
+    with pytest.raises(ValueError, match="not found"):
+        await scoped_builder.build(
+            session=AsyncMock(),
+            agent_id="agent1",
+            work_item_id=scoped_builder.owned_item.id,  # type: ignore[attr-defined]
+            context_mode=mode,
+            company_id="co2",
+        )
+
+    scoped_builder.goal_service.get_goal_ancestry_for_work_item.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_build_fat_rejects_row_whose_company_differs(builder: HeartbeatContextBuilder) -> None:
+    """Defence in depth: a row that slipped past the filter is still refused."""
+    builder.work_item_service.get.return_value = _make_work_item(company_id="co1")
+
+    with pytest.raises(ValueError, match="not found"):
+        await builder.build(
+            session=AsyncMock(),
+            agent_id="agent1",
+            work_item_id=uuid.uuid4(),
+            context_mode="fat",
+            company_id="co2",
+        )
+
+    builder.goal_service.get_goal_ancestry_for_work_item.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_build_requires_company_id(builder: HeartbeatContextBuilder) -> None:
+    """The scope is not optional — omitting it is a TypeError, not a silent leak."""
+    with pytest.raises(TypeError):
+        await builder.build(
+            session=AsyncMock(),
+            agent_id="agent1",
+            work_item_id=uuid.uuid4(),
+            context_mode="fat",
+        )

--- a/autobot-backend/llc/tests/test_work_item.py
+++ b/autobot-backend/llc/tests/test_work_item.py
@@ -198,3 +198,39 @@ class TestListByProject:
         mock_session._db_result.scalars.return_value.all.return_value = items
         result = await service.list_by_project(mock_session, company_id=str(uuid.uuid4()))
         assert len(result) == 2
+
+
+# ------------------------------------------------- get() id handling (#13756)
+
+
+@pytest.mark.asyncio
+async def test_get_accepts_uuid_work_item_id() -> None:
+    """#13704's ``uuid.UUID(work_item_id)`` raised AttributeError on a UUID.
+
+    The heartbeat context path holds an already-parsed ``UUID``, so an
+    unconditional re-parse turned every call into a 500.
+    """
+    item = _make_item()
+    session = AsyncMock()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = item
+    session.execute.return_value = result
+
+    fetched = await WorkItemService().get(session, item.id)
+
+    assert fetched is item
+
+
+@pytest.mark.asyncio
+async def test_get_scopes_by_company_when_given() -> None:
+    """The company filter reaches the query, not just the signature."""
+    item = _make_item()
+    session = AsyncMock()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = item
+    session.execute.return_value = result
+
+    await WorkItemService().get(session, item.id, company_id=str(item.company_id))
+
+    rendered = str(session.execute.await_args.args[0])
+    assert "company_id" in rendered

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -51090,7 +51090,8 @@ export interface paths {
          *         item_id: Work item UUID
          *         mode: "thin" or "fat" context mode
          *         session: DB session
-         *         ctx: Tenant context
+         *         ctx: Tenant context — its ``org_id`` scopes the whole assembled
+         *             context, so another company's item id reads as 404 (#13756)
          *
          *     Returns:
          *         Dict with assembled context:


### PR DESCRIPTION
Closes #13756

## Thinking Path

`GET /api/llc/agent/context/{item_id}` bound `require_org_context` and then never used it.
`HeartbeatContextBuilder.build()` took no company scope at all, so both build paths fetched the
work item unscoped and then derived `company_id` **from the fetched row** — every downstream RAG,
goal-ancestry and KB lookup followed the *item's* company rather than the caller's. The item UUID
is the only thing needed, and it is not a secret.

The scoping primitive already existed: #13704 gave `WorkItemService.get` a keyword-only
`company_id`. It threaded that through the chat prompt path but not through this one. So the fix is
to make the builder require a scope rather than to invent a new mechanism.

Two things surfaced while doing it, both dealt with here:

1. **The route was returning 500, not data.** #13704's `uuid.UUID(work_item_id)` is unconditional,
   and this path holds an already-parsed `UUID`, so every call raised
   `AttributeError: 'UUID' object has no attribute 'replace'`. Confirmed against the interpreter.
   The fix normalises with `str()` — exactly what the same method already does for `company_id`.
2. **Four more bound-but-unused `require_org_context` handlers** (AC 4's scan). They are a genuinely
   different blast radius — one of them changes API-key issuance semantics — so they are filed as
   **#13771** rather than folded in. `findings.get_policy(_ctx)` also appears in the scan but its
   parameter is underscore-named: the dependency is a gate, the policy is not tenant data.

## What Changed

- `llc/kb/context_builder.py` — `build()` / `_build_thin()` / `_build_fat()` take a keyword-only,
  **required** `company_id`. Omitting it is a `TypeError`, not a silent leak. `_build_fat` no longer
  derives the scope from the fetched row; it also refuses a row whose `company_id` disagrees with
  the caller's, as defence in depth if a store ever ignores the filter.
- `llc/api/context.py` — passes `ctx.org_id`. A cross-tenant id now raises `ValueError` inside the
  builder, which the existing handler already maps to **404** (not 403) — indistinguishable from
  "no such item", matching the convention `WorkItemService.get` documents.
- `llc/services/work_item_service.py` — `get()` accepts `str | UUID` (see Thinking Path #1).
- Tests: endpoint-level two-company IDOR tests for both modes, builder-level scope-forwarding and
  rejection tests, and two service tests covering the UUID regression and the company predicate.

## Verification

`llc/tests/test_context_endpoint_tenant_scope.py` — company B asking for company A's item:

```
llc/tests/test_context_endpoint_tenant_scope.py ....                     [100%]
4 passed
```

Full LLC suite, unchanged elsewhere:

```
1413 passed, 1 skipped, 29 warnings in 57.31s
```

**Mutation check** (a green test proves nothing until it can fail): removing `company_id=company_id`
from the fetch and neutering the mismatch guard turns the suite red on exactly the new tests, then
green again once restored:

```
FAILED llc/tests/test_heartbeat_context.py::test_build_forwards_company_scope_to_fetch[fat]
FAILED llc/tests/test_heartbeat_context.py::test_build_forwards_company_scope_to_fetch[thin]
FAILED llc/tests/test_heartbeat_context.py::test_build_rejects_other_companys_item[fat]
FAILED llc/tests/test_heartbeat_context.py::test_build_rejects_other_companys_item[thin]
FAILED llc/tests/test_heartbeat_context.py::test_build_fat_rejects_row_whose_company_differs
5 failed, 11 passed
```

AC 4's scan over `llc/api/` after the change reports no bound-but-unused `require_org_context` for
`context.py`; the four remaining hits are tracked in #13771.

## Model Used

Claude Opus 5 (1M context)
