### PR TITLE
security(llc): scope agent API-key and diary routes to the caller's company (#13771)

### DIFF
--- a/autobot-backend/llc/api/api_keys.py
+++ b/autobot-backend/llc/api/api_keys.py
@@ -32,7 +32,10 @@ _svc = ApiKeyService()
 
 class ApiKeyCreate(BaseModel):
     name: str
-    company_id: str
+    # #13771: the key's company comes from the caller's tenant context. Kept
+    # optional for compatibility with existing clients, and honoured only as an
+    # assertion — a value naming another company is refused, never applied.
+    company_id: Optional[str] = None
 
 
 class ApiKeyRead(BaseModel):
@@ -59,7 +62,13 @@ async def create_api_key(
     _current_user: dict = Depends(get_current_user),
     ctx: TenantContext = Depends(require_org_context),
 ) -> ApiKeyCreated:
-    record, plaintext = await _svc.issue_key(session, agent_id=agent_id, company_id=body.company_id, name=body.name)
+    # #13771: the company a key is minted for is the caller's, never the body's.
+    # ``company_id`` stays in the payload for compatibility, but only as an
+    # assertion — naming another company is refused, not silently honoured.
+    company_id = str(ctx.org_id)
+    if body.company_id and str(body.company_id) != company_id:
+        raise HTTPException(status_code=403, detail="Cannot issue an API key for another company")
+    record, plaintext = await _svc.issue_key(session, agent_id=agent_id, company_id=company_id, name=body.name)
     return ApiKeyCreated(
         id=record.id,
         agent_id=record.agent_id,
@@ -81,7 +90,7 @@ async def revoke_api_key(
     ctx: TenantContext = Depends(require_org_context),
 ) -> None:
     try:
-        await _svc.revoke_key(session, agent_id=agent_id, key_id=key_id)
+        await _svc.revoke_key(session, agent_id=agent_id, key_id=key_id, company_id=str(ctx.org_id))
     except KeyError as exc:
         logger.error("Exception in API handler: %s", exc, exc_info=True)
         raise HTTPException(status_code=404, detail="Internal server error") from exc
@@ -94,5 +103,10 @@ async def list_api_keys(
     _current_user: dict = Depends(get_current_user),
     ctx: TenantContext = Depends(require_org_context),
 ) -> List[ApiKeyRead]:
-    result = await session.execute(select(LLCApiKey).where(LLCApiKey.agent_id == agent_id))
+    result = await session.execute(
+        select(LLCApiKey).where(
+            LLCApiKey.agent_id == agent_id,
+            LLCApiKey.company_id == str(ctx.org_id),  # #13771
+        )
+    )
     return [ApiKeyRead.model_validate(r) for r in result.scalars().all()]

--- a/autobot-backend/llc/api/runs.py
+++ b/autobot-backend/llc/api/runs.py
@@ -178,6 +178,24 @@ async def cancel_run(
     return _run_to_dict(run)
 
 
+async def _agent_belongs_to_org(session: AsyncSession, agent_id: str, org_id: Any) -> bool:
+    """True when *agent_id* has run for *org_id* (#13771).
+
+    ``LLCHeartbeatRun`` is the agent-to-company binding the other routes in this
+    router already scope on; reusing it avoids inventing a second notion of
+    which company an agent belongs to.
+    """
+    result = await session.execute(
+        select(LLCHeartbeatRun.id)
+        .where(
+            LLCHeartbeatRun.agent_id == agent_id,
+            LLCHeartbeatRun.company_id == org_id,
+        )
+        .limit(1)
+    )
+    return result.scalar_one_or_none() is not None
+
+
 @router.get("/{agent_id}/diary", response_model=List[Dict[str, Any]])
 async def get_agent_diary(
     agent_id: str,
@@ -185,6 +203,7 @@ async def get_agent_diary(
     offset: int = Query(0, ge=0),
     date_from: Optional[str] = Query(None, description="ISO date filter start (YYYY-MM-DD)"),
     date_to: Optional[str] = Query(None, description="ISO date filter end (YYYY-MM-DD)"),
+    session: AsyncSession = Depends(get_async_session),
     _current_user: dict = Depends(get_current_user),
     ctx: TenantContext = Depends(require_org_context),
 ) -> List[Dict[str, Any]]:
@@ -192,7 +211,16 @@ async def get_agent_diary(
 
     Reads from the KB via ``AgentDiaryService``.  Supports ``limit``/``offset``
     pagination and optional ``date_from``/``date_to`` filters (inclusive).
+
+    Diary entries carry no tenant dimension of their own, so the agent is bound
+    to a company the same way the sibling run routes above do it (#13771): via
+    ``LLCHeartbeatRun``. An agent that has never run for the caller's company
+    reads as empty rather than 404, so the response cannot be used to probe
+    which agent ids exist elsewhere.
     """
+    if not await _agent_belongs_to_org(session, agent_id, ctx.org_id):
+        return []
+
     try:
         from memory.agent_diary import AgentDiaryService
 

--- a/autobot-backend/llc/services/api_key.py
+++ b/autobot-backend/llc/services/api_key.py
@@ -63,15 +63,24 @@ class ApiKeyService(LLCServiceBase):
         session: AsyncSession,
         agent_id: str,
         key_id: uuid.UUID,
+        *,
+        company_id: Optional[str] = None,
     ) -> None:
-        """Revoke a key (sets revoked_at). Raises KeyError if not found or not owned."""
-        result = await session.execute(
-            select(LLCApiKey).where(
-                LLCApiKey.id == key_id,
-                LLCApiKey.agent_id == agent_id,
-                LLCApiKey.revoked_at.is_(None),
-            )
-        )
+        """Revoke a key (sets revoked_at). Raises KeyError if not found or not owned.
+
+        ``company_id`` is keyword-only and optional so internal callers whose
+        scope is already established stay unchanged (#13771); the HTTP route,
+        where an untrusted agent/key id pair arrives, always passes it. A
+        mismatch raises ``KeyError`` — indistinguishable from "no such key".
+        """
+        conditions = [
+            LLCApiKey.id == key_id,
+            LLCApiKey.agent_id == agent_id,
+            LLCApiKey.revoked_at.is_(None),
+        ]
+        if company_id is not None:
+            conditions.append(LLCApiKey.company_id == str(company_id))
+        result = await session.execute(select(LLCApiKey).where(*conditions))
         record = result.scalar_one_or_none()
         if record is None:
             raise KeyError(f"API key {key_id} not found for agent {agent_id}")

--- a/autobot-backend/llc/tests/test_agent_routes_tenant_scope.py
+++ b/autobot-backend/llc/tests/test_agent_routes_tenant_scope.py
@@ -74,9 +74,7 @@ def test_create_key_uses_caller_company_not_body() -> None:
 
     issue = AsyncMock(return_value=(issued, "llc_plaintext"))
     with patch("llc.services.api_key.ApiKeyService.issue_key", new=issue):
-        response = _make_app("api_keys", _COMPANY_A, session).post(
-            f"/agents/{_AGENT}/api-keys", json={"name": "k"}
-        )
+        response = _make_app("api_keys", _COMPANY_A, session).post(f"/agents/{_AGENT}/api-keys", json={"name": "k"})
 
     assert response.status_code == 201
     assert issue.await_args.kwargs["company_id"] == _COMPANY_A

--- a/autobot-backend/llc/tests/test_agent_routes_tenant_scope.py
+++ b/autobot-backend/llc/tests/test_agent_routes_tenant_scope.py
@@ -1,0 +1,184 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tenant-scope tests for the LLC agent API-key and diary routes (#13771).
+
+All four routes bound ``require_org_context`` and never used it:
+
+  POST   /agents/{agent_id}/api-keys          — minted keys for the body's company
+  DELETE /agents/{agent_id}/api-keys/{key_id} — revoked any company's key
+  GET    /agents/{agent_id}/api-keys          — listed any company's key metadata
+  GET    /agents/{agent_id}/diary             — read any company's agent diary
+"""
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from user_management.services import TenantContext
+
+_USER_ID = uuid.UUID("33333333-3333-3333-3333-333333333333")
+_COMPANY_A = "11111111-1111-1111-1111-111111111111"
+_COMPANY_B = "22222222-2222-2222-2222-222222222222"
+_AGENT = "agent-001"
+
+
+def _make_app(router_name: str, caller_org_id: str, session: AsyncMock):
+    """FastAPI app carrying one LLC agent router with auth/session overridden."""
+    # Deferred imports: must not be at module level (see test_suggest_ac_endpoint.py).
+    from api.user_management.dependencies import get_current_user, require_org_context  # noqa: PLC0415
+    from user_management.database import get_async_session  # noqa: PLC0415
+
+    if router_name == "api_keys":
+        from llc.api.api_keys import router  # noqa: PLC0415
+    else:
+        from llc.api.runs import router  # noqa: PLC0415
+
+    app = FastAPI()
+    app.include_router(router)
+
+    async def _fake_session():
+        yield session
+
+    app.dependency_overrides[get_async_session] = _fake_session
+    app.dependency_overrides[get_current_user] = lambda: {"id": str(_USER_ID), "user_id": str(_USER_ID)}
+    app.dependency_overrides[require_org_context] = lambda: TenantContext(
+        org_id=uuid.UUID(caller_org_id), user_id=_USER_ID, is_platform_admin=False
+    )
+    return TestClient(app)
+
+
+def _where_text(session: AsyncMock) -> str:
+    """Rendered WHERE clause of the last statement the route executed.
+
+    Not the whole statement — ``company_id`` is one of the selected columns, so
+    a full-statement match would pass even with no tenant predicate at all.
+    """
+    return str(session.execute.await_args.args[0].whereclause)
+
+
+# --------------------------------------------------------------- create
+
+
+def test_create_key_uses_caller_company_not_body() -> None:
+    session = AsyncMock()
+    issued = MagicMock()
+    issued.id, issued.agent_id, issued.company_id = uuid.uuid4(), _AGENT, _COMPANY_A
+    issued.name, issued.last_used_at, issued.revoked_at = "k", None, None
+    issued.created_at = datetime.now(timezone.utc)
+
+    issue = AsyncMock(return_value=(issued, "llc_plaintext"))
+    with patch("llc.services.api_key.ApiKeyService.issue_key", new=issue):
+        response = _make_app("api_keys", _COMPANY_A, session).post(
+            f"/agents/{_AGENT}/api-keys", json={"name": "k"}
+        )
+
+    assert response.status_code == 201
+    assert issue.await_args.kwargs["company_id"] == _COMPANY_A
+
+
+def test_create_key_for_another_company_is_403() -> None:
+    """Company B naming company A in the body cannot mint a key for A."""
+    session = AsyncMock()
+    issue = AsyncMock()
+    with patch("llc.services.api_key.ApiKeyService.issue_key", new=issue):
+        response = _make_app("api_keys", _COMPANY_B, session).post(
+            f"/agents/{_AGENT}/api-keys", json={"name": "k", "company_id": _COMPANY_A}
+        )
+
+    assert response.status_code == 403
+    issue.assert_not_awaited()
+
+
+# --------------------------------------------------------------- revoke
+
+
+def test_revoke_key_passes_caller_company() -> None:
+    session = AsyncMock()
+    revoke = AsyncMock()
+    with patch("llc.services.api_key.ApiKeyService.revoke_key", new=revoke):
+        response = _make_app("api_keys", _COMPANY_B, session).delete(f"/agents/{_AGENT}/api-keys/{uuid.uuid4()}")
+
+    assert response.status_code == 204
+    assert revoke.await_args.kwargs["company_id"] == _COMPANY_B
+
+
+def test_revoke_key_outside_company_is_404() -> None:
+    """The service reports a cross-tenant key as missing; the route maps that to 404."""
+    session = AsyncMock()
+    with patch("llc.services.api_key.ApiKeyService.revoke_key", new=AsyncMock(side_effect=KeyError("nope"))):
+        response = _make_app("api_keys", _COMPANY_B, session).delete(f"/agents/{_AGENT}/api-keys/{uuid.uuid4()}")
+
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_revoke_key_service_filters_on_company() -> None:
+    from llc.services.api_key import ApiKeyService  # noqa: PLC0415
+
+    session = AsyncMock()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = None
+    session.execute.return_value = result
+
+    with pytest.raises(KeyError):
+        await ApiKeyService().revoke_key(session, _AGENT, uuid.uuid4(), company_id=_COMPANY_B)
+
+    assert "company_id" in _where_text(session)
+
+
+# --------------------------------------------------------------- list
+
+
+def test_list_keys_filters_on_caller_company() -> None:
+    session = AsyncMock()
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = []
+    session.execute.return_value = result
+
+    response = _make_app("api_keys", _COMPANY_B, session).get(f"/agents/{_AGENT}/api-keys")
+
+    assert response.status_code == 200
+    assert response.json() == []
+    assert "company_id" in _where_text(session)
+
+
+# --------------------------------------------------------------- diary
+
+
+def _diary_session(has_run_in_org: bool) -> AsyncMock:
+    session = AsyncMock()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = uuid.uuid4() if has_run_in_org else None
+    session.execute.return_value = result
+    return session
+
+
+def test_diary_readable_for_own_agent() -> None:
+    session = _diary_session(has_run_in_org=True)
+    entries = [{"content": "did work", "metadata": {"diary_timestamp": "2026-08-09T00:00:00Z"}}]
+
+    with patch("memory.agent_diary.AgentDiaryService.read", new=AsyncMock(return_value=entries)):
+        response = _make_app("runs", _COMPANY_A, session).get(f"/agents/{_AGENT}/diary")
+
+    assert response.status_code == 200
+    assert response.json() == entries
+    assert "company_id" in _where_text(session)
+
+
+def test_diary_of_another_companys_agent_is_empty() -> None:
+    """No heartbeat run binds this agent to the caller's company — no entries, no KB read."""
+    session = _diary_session(has_run_in_org=False)
+    read = AsyncMock(return_value=[{"content": "company A secrets", "metadata": {}}])
+
+    with patch("memory.agent_diary.AgentDiaryService.read", new=read):
+        response = _make_app("runs", _COMPANY_B, session).get(f"/agents/{_AGENT}/diary")
+
+    assert response.status_code == 200
+    assert response.json() == []
+    read.assert_not_awaited()

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -51331,6 +51331,12 @@ export interface paths {
          *
          *     Reads from the KB via ``AgentDiaryService``.  Supports ``limit``/``offset``
          *     pagination and optional ``date_from``/``date_to`` filters (inclusive).
+         *
+         *     Diary entries carry no tenant dimension of their own, so the agent is bound
+         *     to a company the same way the sibling run routes above do it (#13771): via
+         *     ``LLCHeartbeatRun``. An agent that has never run for the caller's company
+         *     reads as empty rather than 404, so the response cannot be used to probe
+         *     which agent ids exist elsewhere.
          */
         get: operations["get_agent_diary_api_llc_agents__agent_id__diary_get"];
         put?: never;

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -56846,7 +56846,7 @@ export interface components {
             /** Name */
             name: string;
             /** Company Id */
-            company_id: string;
+            company_id?: string | null;
         } & {
             [key: string]: unknown;
         };


### PR DESCRIPTION
Closes #13771

## Thinking Path

Four handlers in `llc/api/` bound `require_org_context` and never used the result. They came out of
the AST scan #13756's AC 4 asks for, and they are not all the same severity — one is a cross-tenant
**write**, not a read:

`POST /agents/{agent_id}/api-keys` took the company straight from the request body, so any
authenticated caller could mint a working agent credential scoped to another company and receive the
plaintext once. `revoke_key` filtered on `id` + `agent_id` only (cross-tenant revoke = availability),
and the list query had no company predicate at all.

The diary was the interesting one. Diary entries are KB facts whose metadata carries only
`agent_name` — there is no tenant dimension in the store and no canonical agent→company registry to
consult. Rather than invent a second notion of which company an agent belongs to, this reuses the
binding the sibling routes **in the same router** already scope on: `LLCHeartbeatRun`
(`agent_id` + `company_id`), exactly as `list_runs` and `get_run` do a few lines above.

An unknown agent reads as **empty**, not 404: the endpoint returns a list and already returns `[]`
when the KB read fails, so an empty body is indistinguishable from "this agent has written nothing"
and cannot be used to probe which agent ids exist in other companies.

`findings.py:105 get_policy(_ctx)` also appears in the scan and is deliberately left alone — the
parameter is underscore-named, the dependency is a gate, and the policy it returns is not tenant data.

## What Changed

- `llc/api/api_keys.py`
  - `create_api_key` mints for `ctx.org_id`. `ApiKeyCreate.company_id` becomes optional and is
    honoured only as an assertion — naming another company is **403**, never silently applied.
  - `revoke_api_key` passes `company_id=ctx.org_id`; a cross-tenant key raises `KeyError`, which the
    existing handler already maps to 404.
  - `list_api_keys` filters on `company_id`.
- `llc/services/api_key.py` — `revoke_key` grows a keyword-only, optional `company_id`, matching the
  shape #13704 established on `WorkItemService.get` so existing internal callers are unchanged.
- `llc/api/runs.py` — `get_agent_diary` takes a session and gates on `_agent_belongs_to_org`.
- `autobot-frontend/src/types/generated/api.ts` — `ApiKeyCreate.company_id` regenerated as optional.

## Verification

New route-level tests, two companies each:

```
llc/tests/test_agent_routes_tenant_scope.py ........                     [100%]
8 passed
```

Full LLC suite:

```
1409 passed, 1 skipped, 27 warnings in 60.01s
```

**Mutation check** — reverting all three source files to `origin/Dev_new_gui` and rerunning:

```
FAILED test_create_key_uses_caller_company_not_body
FAILED test_create_key_for_another_company_is_403
FAILED test_revoke_key_passes_caller_company
FAILED test_revoke_key_service_filters_on_company
FAILED test_list_keys_filters_on_caller_company
FAILED test_diary_readable_for_own_agent
FAILED test_diary_of_another_companys_agent_is_empty
7 failed, 1 passed
```

The one that stays green is `test_revoke_key_outside_company_is_404`, which asserts only the route's
`KeyError` → 404 mapping and is expected to hold either way.

Two assertions were tightened after a first mutation run showed them passing unfixed: the list test
now matches on the rendered **WHERE clause** rather than the whole statement (`company_id` is also a
selected column, so a full-statement match passed with no predicate), and the create test now omits
`company_id` from the body entirely instead of sending the caller's own.

The bound-but-unused scan over `llc/api/` on this branch reports only `context.py` (fixed on the
#13756 branch) and the deliberate `findings.get_policy(_ctx)`.

## Model Used

Claude Opus 5 (1M context)
