### PR TITLE
security(mcp): validate memory tool arguments and escape RediSearch queries (#13762)

### DIFF
--- a/autobot-backend/api/schemas_knowledge.py
+++ b/autobot-backend/api/schemas_knowledge.py
@@ -4682,6 +4682,69 @@ class GraphRAGPathResponse(BaseModel):
     request_id: str = Field(..., description="Unique request identifier")
 
 
+# #13762: the MCP ``memory.*`` tools reach the same graph as the routes above,
+# but a JSON-RPC caller supplies raw kwargs with no Pydantic in the path. These
+# models give those tools the request contract the REST surface already has —
+# one validation seam, rather than bounds re-implemented per tool. Constraints
+# match GraphRAGPathRequest/GraphRAGSearchRequest deliberately: the same field
+# means the same thing on both surfaces.
+
+
+class MemoryEntityLookupRequest(BaseModel):
+    """Arguments for the ``memory.entity_lookup`` tool. #13762."""
+
+    name: str = Field(..., min_length=1, max_length=200, description="Entity name to look up")
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, v):
+        if not v.strip():
+            raise ValueError("Entity name cannot be empty or whitespace")
+        return v.strip()
+
+
+class MemoryTimelineRequest(BaseModel):
+    """Arguments for the ``memory.timeline`` tool. #13762."""
+
+    entity: str = Field(..., min_length=1, max_length=200, description="Entity name")
+    range: str | None = Field(None, max_length=100, description="ISO-8601 range as 'start/end'")
+
+    @field_validator("entity")
+    @classmethod
+    def validate_entity(cls, v):
+        if not v.strip():
+            raise ValueError("Entity name cannot be empty or whitespace")
+        return v.strip()
+
+
+class MemoryRelatedRequest(BaseModel):
+    """Arguments for the ``memory.related`` tool. #13762."""
+
+    entity: str = Field(..., min_length=1, max_length=200, description="Entity name")
+    depth: int = Field(2, ge=1, le=5, description="Maximum traversal depth (1-5 hops)")
+
+    @field_validator("entity")
+    @classmethod
+    def validate_entity(cls, v):
+        if not v.strip():
+            raise ValueError("Entity name cannot be empty or whitespace")
+        return v.strip()
+
+
+class MemoryVerbatimSearchRequest(BaseModel):
+    """Arguments for the ``memory.verbatim_search`` tool. #13762."""
+
+    query: str = Field(..., min_length=1, max_length=1000, description="Search query string")
+    session_filter: str | None = Field(None, max_length=200, description="Restrict results to this session_id")
+
+    @field_validator("query")
+    @classmethod
+    def validate_query(cls, v):
+        if not v.strip():
+            raise ValueError("Query cannot be empty or whitespace")
+        return v.strip()
+
+
 class GraphRAGHealthResponse(BaseModel):
     """Response model for health check."""
 

--- a/autobot-backend/autobot_memory_graph/queries.py
+++ b/autobot-backend/autobot_memory_graph/queries.py
@@ -17,6 +17,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.security.input_sanitizer import escape_redisearch, escape_redisearch_tag
 
 from .core import AutoBotMemoryGraphCore
 
@@ -80,16 +81,21 @@ class QueryOperationsMixin:
         Returns:
             RediSearch query string
         """
+        # #13762: every value here is caller-supplied. Unescaped, punctuation is
+        # read as query syntax — a term stops being a term and becomes a field
+        # selector, a wildcard, or a boolean operator. The MCP surface reaches
+        # this without the Pydantic bounds the REST surface applies, so the
+        # escaping lives here rather than depending on every caller validating.
         query_parts = []
         if entity_type:
-            query_parts.append(f"@type:{{{entity_type}}}")
+            query_parts.append(f"@type:{{{escape_redisearch_tag(entity_type)}}}")
         if status:
-            query_parts.append(f"@status:{{{status}}}")
+            query_parts.append(f"@status:{{{escape_redisearch_tag(status)}}}")
         if tags:
-            tag_filter = "|".join(tags)
+            tag_filter = "|".join(escape_redisearch_tag(tag) for tag in tags)
             query_parts.append(f"@tags:{{{tag_filter}}}")
         if query and query != "*":
-            query_parts.append(f"({query})")
+            query_parts.append(f"({escape_redisearch(query)})")
         return " ".join(query_parts) if query_parts else "*"
 
     async def _execute_redis_search(

--- a/autobot-backend/mcp/autobot_server.py
+++ b/autobot-backend/mcp/autobot_server.py
@@ -45,6 +45,8 @@ import secrets
 import time
 from typing import Any, Dict, List, Optional, Tuple
 
+from pydantic import ValidationError as PydanticValidationError
+
 from autobot_shared.auth.jwt_core import JWTDecodeError, JWTExpiredError
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_async_redis_client
@@ -634,7 +636,11 @@ class AutoBotMCPServer:
             elapsed = time.monotonic() - t0
             logger.info("mcp tool_call tool=%s elapsed=%.3fs", tool_name, elapsed)
             return _ok({"content": [{"type": "text", "text": json.dumps(result, default=str)}]}, req_id)
-        except TypeError as exc:
+        except (TypeError, PydanticValidationError) as exc:
+            # #13762: a handler that validates its arguments through a request
+            # model raises ValidationError, which is an invalid-arguments error
+            # (-32602), not an internal one. Without this it fell to -32603 and
+            # read to the caller as a server fault.
             logger.warning("mcp bad_arguments tool=%s error=%s", tool_name, exc)
             return _err(-32602, f"Invalid arguments: {exc}", req_id)
         except Exception as exc:
@@ -685,8 +691,10 @@ class AutoBotMCPServer:
     # ------------------------------------------------------------------
 
     async def _memory_entity_lookup(self, name: str) -> Any:
+        from api.schemas_knowledge import MemoryEntityLookupRequest
         from autobot_memory_graph import AutoBotMemoryGraph
 
+        name = MemoryEntityLookupRequest(name=name).name
         graph = AutoBotMemoryGraph()
         await graph.initialize()
         entity = await graph.get_entity(entity_name=name, include_relations=True)
@@ -695,8 +703,11 @@ class AutoBotMCPServer:
         return entity
 
     async def _memory_timeline(self, entity: str, range: str | None = None) -> Any:
+        from api.schemas_knowledge import MemoryTimelineRequest
         from autobot_memory_graph import AutoBotMemoryGraph
 
+        args = MemoryTimelineRequest(entity=entity, range=range)
+        entity, range = args.entity, args.range
         graph = AutoBotMemoryGraph()
         await graph.initialize()
         base = await graph.get_entity(entity_name=entity, include_relations=True)
@@ -733,9 +744,14 @@ class AutoBotMCPServer:
         return {"entity": base, "timeline": neighbours, "count": len(neighbours)}
 
     async def _memory_related(self, entity: str, depth: int = 2) -> Any:
+        from api.schemas_knowledge import MemoryRelatedRequest
         from autobot_memory_graph import AutoBotMemoryGraph
 
-        depth = max(1, min(depth, 5))
+        # #13762: the entity name was unbounded. ``depth`` keeps its existing
+        # clamp rather than becoming a rejection, so the model's ge/le is the
+        # declared contract and the clamp is what enforces it.
+        args = MemoryRelatedRequest(entity=entity, depth=max(1, min(depth, 5)))
+        entity, depth = args.entity, args.depth
         graph = AutoBotMemoryGraph()
         await graph.initialize()
 
@@ -782,19 +798,21 @@ class AutoBotMCPServer:
 
         Delegates to AutoBotMemoryGraph.find_path so name resolution and path
         serialisation are not duplicated against the Graph-RAG ``/path``
-        endpoint. ``max_depth`` is clamped the way ``memory.related`` clamps
-        depth — an untrusted caller must not be able to request an unbounded
-        traversal.
+        endpoint. #13762 extends that to the input contract: the arguments go
+        through ``GraphRAGPathRequest``, the same model the REST route binds, so
+        the two surfaces cannot drift on what a valid request is. ``max_depth``
+        stays clamped rather than rejected — an untrusted caller must not be
+        able to request an unbounded traversal, but asking for too much is not
+        an error the way an unbounded entity name is.
         """
+        from api.schemas_knowledge import GraphRAGPathRequest
         from autobot_memory_graph import AutoBotMemoryGraph
 
         allowed_directions = ("outgoing", "incoming", "both")
         if direction not in allowed_directions:
             return {"error": "Invalid direction", "direction": direction, "allowed": list(allowed_directions)}
 
-        graph = AutoBotMemoryGraph()
-        await graph.initialize()
-        return await graph.find_path(
+        args = GraphRAGPathRequest(
             from_entity=from_entity,
             to_entity=to_entity,
             relation=relation,
@@ -802,11 +820,23 @@ class AutoBotMCPServer:
             direction=direction,
         )
 
+        graph = AutoBotMemoryGraph()
+        await graph.initialize()
+        return await graph.find_path(
+            from_entity=args.from_entity,
+            to_entity=args.to_entity,
+            relation=args.relation,
+            max_depth=args.max_depth,
+            direction=args.direction,
+        )
+
     async def _memory_verbatim_search(self, query: str, session_filter: str | None = None) -> Any:
+        from api.schemas_knowledge import MemoryVerbatimSearchRequest
         from memory.verbatim_store import VerbatimStore
 
+        args = MemoryVerbatimSearchRequest(query=query, session_filter=session_filter)
         store = VerbatimStore()
-        results = await store.search(query, session_filter=session_filter)
+        results = await store.search(args.query, session_filter=args.session_filter)
         return {"results": results, "count": len(results)}
 
     # ------------------------------------------------------------------

--- a/autobot-backend/mcp/autobot_server_test.py
+++ b/autobot-backend/mcp/autobot_server_test.py
@@ -479,3 +479,94 @@ async def test_memory_path_dispatches_end_to_end():
     content = json.loads(resp["result"]["content"][0]["text"])
     assert content["found"] is True
     assert content["hops"] == 1
+
+
+# ---------------------------------------------------------------------------
+# memory.* argument validation — #13762
+#
+# The REST surface bounds these strings with Pydantic; the MCP surface passed
+# them straight through to a RediSearch query that does no escaping.
+# ---------------------------------------------------------------------------
+
+
+_OVER_LONG = "x" * 5000
+
+
+@pytest.mark.asyncio
+async def test_over_long_entity_name_is_invalid_arguments_not_an_internal_error():
+    """#13762: JSON-RPC -32602, and the traversal never starts."""
+    server = make_server()
+    fake_graph = AsyncMock()
+
+    with patch("autobot_memory_graph.AutoBotMemoryGraph", return_value=fake_graph):
+        resp = await server.handle_request(
+            "tools/call",
+            {"name": "memory.path", "arguments": {"from_entity": _OVER_LONG, "to_entity": "B"}},
+            VALID_TOKEN,
+        )
+
+    assert resp["error"]["code"] == -32602, resp
+    fake_graph.find_path.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("tool", "arguments"),
+    [
+        ("memory.entity_lookup", {"name": _OVER_LONG}),
+        ("memory.timeline", {"entity": _OVER_LONG}),
+        ("memory.related", {"entity": _OVER_LONG}),
+        ("memory.verbatim_search", {"query": _OVER_LONG}),
+    ],
+)
+async def test_every_memory_tool_bounds_its_strings(tool, arguments):
+    """#13762: the bound is on the seam, not re-implemented per tool.
+
+    The message is asserted too, not just the code: these handlers already
+    returned -32602 for an over-long string by *accidentally* raising TypeError
+    deeper in the traversal, so the code alone does not distinguish "rejected at
+    the boundary" from "blew up halfway through".
+    """
+    server = make_server()
+    fake_graph = AsyncMock()
+
+    with (
+        patch("autobot_memory_graph.AutoBotMemoryGraph", return_value=fake_graph),
+        patch("memory.verbatim_store.VerbatimStore", return_value=AsyncMock()),
+    ):
+        resp = await server.handle_request("tools/call", {"name": tool, "arguments": arguments}, VALID_TOKEN)
+
+    assert resp["error"]["code"] == -32602, resp
+    assert "String should have at most" in resp["error"]["message"], resp
+    fake_graph.initialize.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_whitespace_only_entity_name_is_rejected():
+    """A name that is only whitespace is not a name — REST already refuses it."""
+    server = make_server()
+    fake_graph = AsyncMock()
+
+    with patch("autobot_memory_graph.AutoBotMemoryGraph", return_value=fake_graph):
+        resp = await server.handle_request(
+            "tools/call",
+            {"name": "memory.entity_lookup", "arguments": {"name": "   "}},
+            VALID_TOKEN,
+        )
+
+    assert resp["error"]["code"] == -32602, resp
+    fake_graph.get_entity.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_valid_arguments_still_reach_the_graph():
+    """The bound must not turn ordinary lookups into errors."""
+    server = make_server()
+    fake_graph = AsyncMock()
+    fake_graph.get_entity = AsyncMock(return_value={"id": "e1", "name": "Redis Config"})
+
+    with patch("autobot_memory_graph.AutoBotMemoryGraph", return_value=fake_graph):
+        result = await server._memory_entity_lookup("  Redis Config  ")
+
+    assert result["name"] == "Redis Config"
+    fake_graph.get_entity.assert_awaited_once_with(entity_name="Redis Config", include_relations=True)

--- a/autobot-backend/tests/memory_graph/test_redisearch_escaping_13762.py
+++ b/autobot-backend/tests/memory_graph/test_redisearch_escaping_13762.py
@@ -1,0 +1,104 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""RediSearch query building treats caller strings as data (#13762).
+
+``_build_redis_search_query`` interpolated every value into the query with no
+escaping, so caller punctuation was read as query syntax. The MCP surface
+reaches this without the Pydantic bounds the REST surface applies, which is why
+the escaping belongs here rather than depending on each caller validating.
+
+Two escapers, deliberately: a TAG value must match exactly, so separators are
+escaped there; free text is split on separators, so escaping them there would
+turn every multi-word search into one phrase token that matches nothing.
+"""
+
+import pytest
+
+from autobot_shared.security.input_sanitizer import escape_redisearch, escape_redisearch_tag
+
+
+@pytest.fixture
+def build():
+    """The query builder, bound to a stand-in so no Redis connection is needed."""
+    from autobot_memory_graph.queries import QueryOperationsMixin  # noqa: PLC0415
+
+    return QueryOperationsMixin._build_redis_search_query.__get__(object())
+
+
+# ------------------------------------------------------- free-text query
+
+
+def test_a_crafted_field_selector_cannot_escape_the_term(build):
+    """`@type:{...}` in the query must not override the entity_type filter."""
+    rendered = build("@type:{secret}")
+
+    assert "@type:{secret}" not in rendered
+    assert rendered == "(\\@type:\\{secret\\})"
+
+
+@pytest.mark.parametrize("operator", ["|", "*", "~", "%", "(", ")", "[", "]", "@", "{", "}"])
+def test_every_structural_operator_is_neutralised(build, operator):
+    rendered = build(f"safe{operator}term")
+    assert f"safe\\{operator}term" in rendered
+
+
+def test_a_bare_wildcard_inside_a_term_cannot_force_a_full_scan(build):
+    assert build("a*") == "(a\\*)"
+
+
+# --------------------------------------- free text must keep working
+
+
+def test_multi_word_search_is_unchanged(build):
+    """Escaping whitespace would make this one phrase token and match nothing."""
+    assert build("redis config timeout") == "(redis config timeout)"
+
+
+@pytest.mark.parametrize("query", ["Host: 10.0.0.5", "real-time factor", "severity:high", "what?", "a, b; c"])
+def test_ordinary_punctuation_is_left_to_the_tokenizer(build, query):
+    """These characters split terms; escaping them changes what matches."""
+    assert build(query) == f"({query})"
+
+
+def test_no_filters_is_match_all(build):
+    assert build("*") == "*"
+    assert build("") == "*"
+
+
+# ------------------------------------------------------------ TAG filters
+
+
+def test_entity_type_cannot_close_its_own_tag_and_add_a_filter(build):
+    rendered = build("*", entity_type="person}|@status:{leaked")
+
+    assert "person}|@status:{leaked" not in rendered
+    assert rendered == "@type:{person\\}\\|\\@status\\:\\{leaked}"
+
+
+def test_status_filter_is_escaped(build):
+    assert build("*", status="ok|admin") == "@status:{ok\\|admin}"
+
+
+def test_tag_filter_escapes_each_tag_but_keeps_the_or_separator(build):
+    rendered = build("*", tags=["red team", "blue|team"])
+
+    # One real separator between the two tags …
+    assert rendered == "@tags:{red\\ team|blue\\|team}"
+    # … and the '|' inside a value is escaped, so it cannot add a third tag.
+    assert rendered.count("|") == 2
+
+
+def test_tag_values_escape_whitespace_but_free_text_does_not():
+    """The two escapers differ on exactly one thing, and that is the point."""
+    assert escape_redisearch_tag("red team") == "red\\ team"
+    assert escape_redisearch("red team") == "red team"
+
+
+def test_escape_redisearch_leaves_ordinary_text_alone():
+    assert escape_redisearch("redis config") == "redis config"
+
+
+def test_filters_and_query_compose(build):
+    assert build("timeout", entity_type="incident") == "@type:{incident} (timeout)"

--- a/autobot_shared/security/input_sanitizer.py
+++ b/autobot_shared/security/input_sanitizer.py
@@ -91,7 +91,7 @@ def sanitize_ldap_dn(value: str) -> str:
 # grouping, boolean OR, wildcards, fuzzy/optional modifiers, phrases. A caller
 # string carrying these stops being a search term and becomes query syntax
 # (#13762).
-_REDISEARCH_STRUCTURAL: frozenset[str] = frozenset("@{}[]()|*~%^\"\\")
+_REDISEARCH_STRUCTURAL: frozenset[str] = frozenset('@{}[]()|*~%^"\\')
 
 # Everything else RediSearch's tokenizer treats as a separator. Escaping these
 # is required inside a TAG filter, where the value must match exactly, and

--- a/autobot_shared/security/input_sanitizer.py
+++ b/autobot_shared/security/input_sanitizer.py
@@ -12,6 +12,8 @@ Usage:
     from autobot_shared.security.input_sanitizer import (
         sanitize_shell_arg,
         sanitize_ldap_filter,
+        escape_redisearch,
+        escape_redisearch_tag,
         escape_regex,
         validate_url,
     )
@@ -81,6 +83,43 @@ def sanitize_ldap_dn(value: str) -> str:
     for ch in value:
         result.append(_LDAP_DN_ESCAPE_MAP.get(ch, ch))
     return "".join(result)
+
+
+# ── RediSearch ───────────────────────────────────────────────────────
+
+# Characters that change a RediSearch query's *structure*: field selection,
+# grouping, boolean OR, wildcards, fuzzy/optional modifiers, phrases. A caller
+# string carrying these stops being a search term and becomes query syntax
+# (#13762).
+_REDISEARCH_STRUCTURAL: frozenset[str] = frozenset("@{}[]()|*~%^\"\\")
+
+# Everything else RediSearch's tokenizer treats as a separator. Escaping these
+# is required inside a TAG filter, where the value must match exactly, and
+# wrong in free text, where they simply split terms.
+_REDISEARCH_SEPARATORS: frozenset[str] = frozenset(",.<>':;!#$&-+=/? \t\n")
+
+
+def escape_redisearch(value: str) -> str:
+    """Escape a free-text RediSearch query so it cannot alter the query itself.
+
+    Only structural characters are escaped. Whitespace and ordinary punctuation
+    are deliberately left alone: RediSearch splits terms on them, so escaping
+    them would turn every multi-word search into a single phrase token that
+    matches nothing — a silent regression in every search box rather than a
+    security fix.
+    """
+    return "".join(f"\\{ch}" if ch in _REDISEARCH_STRUCTURAL else ch for ch in value)
+
+
+def escape_redisearch_tag(value: str) -> str:
+    """Escape a value used inside a RediSearch ``TAG`` filter (``@field:{...}``).
+
+    A TAG value must match the indexed tag exactly, so separators are escaped
+    here as well as structural characters — an unescaped ``|`` or ``}`` would
+    otherwise end the value and start another tag.
+    """
+    special = _REDISEARCH_STRUCTURAL | _REDISEARCH_SEPARATORS
+    return "".join(f"\\{ch}" if ch in special else ch for ch in value)
 
 
 # ── Regex ────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #13762

## Thinking Path

Two independent gaps, fixed at the two seams rather than per tool.

**Arguments.** The REST surface bounds these strings with Pydantic; the MCP surface handed raw
JSON-RPC kwargs straight to the graph. The fix routes each `memory.*` handler through a request
model — `memory.path` through `GraphRAGPathRequest`, the very model the REST route binds, so the two
surfaces cannot drift on what a valid request is. `ValidationError` now maps to `-32602`; previously
it would have fallen through to `-32603` and read to the caller as a server fault.

`max_depth`/`depth` stay **clamped** rather than rejected. Asking for too many hops is not the same
kind of error as an unbounded entity name, and the issue's own table already ticks clamping as
correct — this preserves existing behaviour for callers who pass a large depth.

**Escaping.** The interesting part. Escaping *everything* RediSearch treats as special is the obvious
move and it is wrong: whitespace is a term separator, so a blanket escaper turns `redis config
timeout` into a single phrase token that matches nothing. That would have been a silent regression in
every search box, shipped as a security fix. Same for `.`, `-`, `:` and friends — RediSearch's
tokenizer splits on them when indexing, so escaping them produces tokens that can never match.

So there are two escapers, and the difference between them is the whole point:

- `escape_redisearch` — free text. Escapes only what changes the query's **structure**:
  `@ { } [ ] ( ) | * ~ % ^ " \`. `Host: 10.0.0.5`, `real-time factor` and `what?` all render
  byte-identically to today.
- `escape_redisearch_tag` — values inside `@field:{...}`, where the value must match exactly, so
  separators are escaped as well. An unescaped `}` or `|` would otherwise close the tag and start
  another filter.

Both live in `autobot_shared/security/input_sanitizer.py` alongside the LDAP and regex escapers,
which is where this repository already keeps escaping helpers.

The escaping sits in `_build_redis_search_query` rather than in the MCP handlers, per the issue: the
guarantee must not depend on every caller validating first.

## What Changed

- `autobot_shared/security/input_sanitizer.py` — `escape_redisearch` and `escape_redisearch_tag`.
- `autobot-backend/autobot_memory_graph/queries.py` — `_build_redis_search_query` escapes the query,
  `entity_type`, `status` and each tag.
- `autobot-backend/api/schemas_knowledge.py` — request models for the four MCP-only memory tools,
  next to the Graph-RAG models, with constraints matching them field for field.
- `autobot-backend/mcp/autobot_server.py` — every `memory.*` handler validates through its model;
  `_dispatch_tool` maps `ValidationError` to `-32602`.

## Verification

```
tests/memory_graph/ mcp/ autobot_memory_graph/ autobot_shared/security/
444 passed, 2205 warnings in 63.15s
```

**Mutation check** — reverting `queries.py` and `autobot_server.py` to `origin/Dev_new_gui`:

```
21 failed, 42 passed
```

That run also caught a **false pass**: `memory.timeline` and `memory.related` already returned
`-32602` for an over-long name, by accidentally raising `TypeError` deeper in the traversal when the
mocked graph was iterated. The code alone could not tell "rejected at the boundary" from "blew up
halfway through", so those assertions now also require the Pydantic message and that
`graph.initialize` was never called. With that tightening, all four tools fail on the unfixed code:

```
FAILED test_every_memory_tool_bounds_its_strings[memory.entity_lookup-arguments0]
FAILED test_every_memory_tool_bounds_its_strings[memory.timeline-arguments1]
FAILED test_every_memory_tool_bounds_its_strings[memory.related-arguments2]
FAILED test_every_memory_tool_bounds_its_strings[memory.verbatim_search-arguments3]
```

Regression guards for the escaping decision are explicit tests, not comments —
`test_multi_word_search_is_unchanged` and `test_ordinary_punctuation_is_left_to_the_tokenizer`
(parametrised over `Host: 10.0.0.5`, `real-time factor`, `severity:high`, `what?`, `a, b; c`) fail if
anyone later widens the free-text escape set.

No generated-types change: the new models back MCP tools, not routes, so they do not enter the
OpenAPI schema.

## Model Used

Claude Opus 5 (1M context)
