### PR TITLE
fix(frontend): move the js-yaml override off the vulnerable pin (#13723)

### DIFF
--- a/autobot-frontend/package-lock.json
+++ b/autobot-frontend/package-lock.json
@@ -3271,6 +3271,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@redocly/openapi-core/node_modules/js-yaml": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/@ricky0123/vad-web": {
       "version": "0.0.30",
       "resolved": "https://registry.npmjs.org/@ricky0123/vad-web/-/vad-web-0.0.30.tgz",
@@ -9642,29 +9665,6 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
-    },
-    "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
     },
     "node_modules/jsbn": {
       "version": "0.1.1",

--- a/autobot-frontend/package.json
+++ b/autobot-frontend/package.json
@@ -85,7 +85,7 @@
     "wavesurfer.js": "^7.12.11"
   },
   "overrides": {
-    "js-yaml": "4.3.0",
+    "js-yaml": "~4.3.1",
     "brace-expansion": ">=5.0.9",
     "minimatch": ">=9.0.7",
     "uuid": "^14.0.0",


### PR DESCRIPTION
Closes #13723

## Thinking Path

The advisory was not coming from a transitive dependency we could not reach — it was coming from
**our own override**. `autobot-frontend/package.json` already pinned:

```json
"overrides": { "js-yaml": "4.3.0", ... }
```

and the advisory's vulnerable range is `4.0.0 - 4.3.0`. The pin sat on the last vulnerable version,
so every `npm audit fix` had nothing to do: the override was forcing the exact version being flagged.
That is why the issue reported "`npm audit fix` is reported as sufficient" and it never was.

`>=4.3.1` was the first thing I tried and it resolves to **5.2.3** — a major bump forced onto
`@redocly/openapi-core@1.34.18`, which declares `js-yaml: 4.3.0`. Clean audit, unnecessary risk. Pinned
`~4.3.1` instead: the smallest move off the vulnerable range, staying on the 4.x API redocly expects.

Two of the three advisories in the issue are already gone from the current tree — only the js-yaml
pair (`js-yaml` itself and `@redocly/openapi-core`, flagged solely for depending on it) remained.

## What Changed

- `autobot-frontend/package.json` — `js-yaml` override `4.3.0` → `~4.3.1`.
- `autobot-frontend/package-lock.json` — regenerated; js-yaml resolves to 4.3.1 under
  `@redocly/openapi-core`. Dev-dependency tree only.

## Verification

Against a real install (`npm ci`), not just the lock tree:

```
$ npm audit --audit-level=high
found 0 vulnerabilities

$ cat node_modules/@redocly/openapi-core/node_modules/js-yaml/package.json | grep version
  "version": "4.3.1",
```

`@redocly/openapi-core` still loads and the js-yaml API it uses is intact under 4.3.1:

```
$ node -e "..."
redocly loaded, exports: 64
js-yaml version ok, load: {"a":1,"b":[2,3]}
dump: "x: 1\n"
Schema/Type present: true true
```

`Unit & Integration Tests` and `Build Test` in the Frontend Testing Suite are the remaining gate; they
were green before this change and this touches no application code.

## Model Used

Claude Opus 5 (1M context)
