### PR TITLE
security(api): stop returning exception type and message to HTTP clients (#13740)

### DIFF
--- a/autobot-backend/utils/error_boundaries/decorators.py
+++ b/autobot-backend/utils/error_boundaries/decorators.py
@@ -248,20 +248,27 @@ def _create_api_error_response(
     error_code = f"{error_code_prefix}_{abs(hash(type(e).__name__)) % 10000:04d}"
     status_code = APIErrorResponse.get_status_code_for_category(category)
 
-    exc_type = type(e).__name__
-    exc_msg = str(e)
-    message = (
-        f"Operation failed ({func_operation}): {exc_type}: {exc_msg}"
-        if exc_msg
-        else f"Operation failed ({func_operation}): {exc_type}"
+    # #13740: the exception's own type and message used to be interpolated into
+    # `message` and repeated in `details`, so any unhandled failure reflected
+    # internals verbatim to the caller. They are logged here — where the
+    # exception is still in scope — against the same trace_id the client
+    # receives, so a report of "trace_id X" still resolves to the real cause.
+    logger.error(
+        "Error in %s: %s: %s (trace_id: %s, code: %s)",
+        func_operation,
+        type(e).__name__,
+        e,
+        trace_id,
+        error_code,
+        exc_info=True,
     )
 
     return APIErrorResponse(
         category=category,
-        message=message,
+        message=APIErrorResponse.get_client_message_for_category(category),
         code=error_code,
         status_code=status_code,
-        details={"operation": func_operation, "exception_type": exc_type, "exception_message": exc_msg},
+        details={"operation": func_operation},
         trace_id=trace_id,
     )
 
@@ -278,14 +285,13 @@ def _raise_or_return_error(error_response: APIErrorResponse):
 
     Returns:
         Error dictionary if FastAPI not available
+
+    Note:
+        The diagnostic log is emitted by :func:`_create_api_error_response`,
+        which still has the exception in scope (#13740). Logging
+        ``error_response.message`` here would now record only the static,
+        client-safe text and lose the cause.
     """
-    logger.error(
-        "Error in %s: %s (trace_id: %s, code: %s)",
-        error_response.details.get("operation", "unknown"),
-        error_response.message,
-        error_response.trace_id,
-        error_response.code,
-    )
     raise HTTPException(status_code=error_response.status_code, detail=error_response.to_dict())
 
 

--- a/autobot-backend/utils/error_boundaries/decorators_disclosure_test.py
+++ b/autobot-backend/utils/error_boundaries/decorators_disclosure_test.py
@@ -1,0 +1,130 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""``with_error_handling`` must not reflect internals to HTTP clients (#13740).
+
+The decorator wraps 1900+ endpoints, so whatever it puts in the response body is
+the API's default disclosure posture. It used to interpolate the caught
+exception's type and message into ``message`` and repeat both under ``details``
+— install paths, DSNs, Redis database indices and ORM column names all reached
+the caller verbatim.
+
+Debuggability is the other half of the contract: these tests also assert the
+cause is still logged, against the trace_id the client is handed.
+"""
+
+import logging
+
+import pytest
+from fastapi import HTTPException
+
+from utils.error_boundaries.decorators import with_error_handling
+from utils.error_boundaries.types import APIErrorResponse, ErrorCategory
+
+# A message shaped like the ones that actually leak here.
+_LEAKY = "could not connect to /opt/autobot/run/redis.sock db=4 user=autobot_admin"
+
+
+@with_error_handling(category=ErrorCategory.SERVER_ERROR, operation="leaky_operation")
+async def _endpoint_that_fails():
+    raise ConnectionError(_LEAKY)
+
+
+@with_error_handling(category=ErrorCategory.SERVER_ERROR, operation="deliberate_operation")
+async def _endpoint_that_raises_http():
+    raise HTTPException(status_code=404, detail="Widget 7 not found")
+
+
+def _body(exc: HTTPException) -> dict:
+    return exc.detail["error"]
+
+
+@pytest.mark.asyncio
+async def test_the_exception_message_does_not_reach_the_client():
+    with pytest.raises(HTTPException) as caught:
+        await _endpoint_that_fails()
+
+    rendered = str(caught.value.detail)
+    assert _LEAKY not in rendered
+    for fragment in ("/opt/autobot", "redis.sock", "db=4", "autobot_admin"):
+        assert fragment not in rendered, fragment
+
+
+@pytest.mark.asyncio
+async def test_the_exception_type_does_not_reach_the_client():
+    """The class name alone still tells a caller which subsystem failed."""
+    with pytest.raises(HTTPException) as caught:
+        await _endpoint_that_fails()
+
+    assert "ConnectionError" not in str(caught.value.detail)
+    assert "exception_type" not in _body(caught.value).get("details", {})
+    assert "exception_message" not in _body(caught.value).get("details", {})
+
+
+@pytest.mark.asyncio
+async def test_the_client_still_gets_a_usable_error():
+    with pytest.raises(HTTPException) as caught:
+        await _endpoint_that_fails()
+
+    body = _body(caught.value)
+    assert caught.value.status_code == 500
+    assert body["message"] == APIErrorResponse.get_client_message_for_category(ErrorCategory.SERVER_ERROR)
+    assert body["details"]["operation"] == "leaky_operation"
+    assert body["trace_id"].startswith("leaky_operation_")
+    assert body["code"].startswith("API_")
+
+
+@pytest.mark.asyncio
+async def test_the_cause_is_still_logged_against_the_same_trace_id(caplog):
+    """No diagnostic capability is lost — it moves from the body to the log."""
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(HTTPException) as caught:
+            await _endpoint_that_fails()
+
+    trace_id = _body(caught.value)["trace_id"]
+    logged = "\n".join(r.getMessage() for r in caplog.records)
+
+    assert _LEAKY in logged, "the cause must survive somewhere"
+    assert "ConnectionError" in logged
+    assert trace_id in logged, "a bug report quoting the trace_id must resolve to this record"
+    assert any(r.exc_info for r in caplog.records), "traceback not captured"
+
+
+@pytest.mark.asyncio
+async def test_a_deliberate_http_exception_is_untouched():
+    """Endpoints that raise their own HTTPException still speak to the caller."""
+    with pytest.raises(HTTPException) as caught:
+        await _endpoint_that_raises_http()
+
+    assert caught.value.status_code == 404
+    assert caught.value.detail == "Widget 7 not found"
+
+
+@pytest.mark.parametrize(
+    ("category", "status"),
+    [
+        (ErrorCategory.VALIDATION, 400),
+        (ErrorCategory.NOT_FOUND, 404),
+        (ErrorCategory.RATE_LIMIT, 429),
+        (ErrorCategory.SERVER_ERROR, 500),
+    ],
+)
+def test_every_category_has_a_static_message(category, status):
+    message = APIErrorResponse.get_client_message_for_category(category)
+    assert message
+    assert APIErrorResponse.get_status_code_for_category(category) == status
+
+
+def test_the_sync_wrapper_is_sanitised_too():
+    """1913 call sites; the sync path must not be the one that still leaks."""
+
+    @with_error_handling(category=ErrorCategory.DATABASE, operation="sync_operation")
+    def _sync_endpoint():
+        raise RuntimeError(_LEAKY)
+
+    with pytest.raises(HTTPException) as caught:
+        _sync_endpoint()
+
+    assert _LEAKY not in str(caught.value.detail)
+    assert "RuntimeError" not in str(caught.value.detail)

--- a/autobot-backend/utils/error_boundaries/types.py
+++ b/autobot-backend/utils/error_boundaries/types.py
@@ -203,6 +203,31 @@ class APIErrorResponse:
         }
         return status_map.get(category, 500)
 
+    @staticmethod
+    def get_client_message_for_category(category: ErrorCategory) -> str:
+        """Return the static, client-safe message for an error category (#13740).
+
+        Deliberately says nothing about *why* the operation failed. An unhandled
+        exception's own text is not curated for disclosure — in this codebase it
+        routinely carries install paths, DSNs, Redis database indices, and ORM
+        table and column names. The diagnostic detail is logged server-side
+        against the response's ``trace_id`` instead, so nothing is lost to
+        whoever is allowed to see it.
+        """
+        message_map = {
+            ErrorCategory.VALIDATION: "The request was not valid.",
+            ErrorCategory.USER_INPUT: "The request was not valid.",
+            ErrorCategory.AUTHENTICATION: "Authentication is required.",
+            ErrorCategory.AUTHORIZATION: "You do not have access to this resource.",
+            ErrorCategory.NOT_FOUND: "The requested resource was not found.",
+            ErrorCategory.CONFLICT: "The request conflicts with the current state.",
+            ErrorCategory.RATE_LIMIT: "Too many requests — try again later.",
+            ErrorCategory.EXTERNAL_SERVICE: "An upstream service failed.",
+            ErrorCategory.SERVICE_UNAVAILABLE: "The service is temporarily unavailable.",
+            ErrorCategory.NETWORK: "The service is temporarily unavailable.",
+        }
+        return message_map.get(category, "The operation failed.")
+
 
 class ErrorBoundaryException(Exception):
     """Custom exception for error boundary system"""


### PR DESCRIPTION
Closes #13740

## Thinking Path

`with_error_handling` wraps 1913 endpoints across 251 files, so whatever it puts in the response body
**is** the API's default disclosure posture. It was interpolating the caught exception's type and
message into `message` and repeating both under `details`, which means any unhandled failure reflected
internals verbatim: install paths from config loaders, DSNs and Redis database indices from connection
errors, table and column names from ORM errors.

One fix in one place, not 1913 fixes.

The part that needed care is **not losing the cause**. The original code logged
`error_response.message` from `_raise_or_return_error` — which, once the message becomes static, would
have recorded nothing useful. So the ERROR log moves up into `_create_api_error_response`, where the
exception object is still in scope, and now carries `exc_info=True` and the same `trace_id` the client
is handed. A bug report quoting a trace id still resolves to the real traceback.

The pattern already exists in this codebase and this makes the framework default match it:
`mcp/autobot_server.py` returns `"Internal error executing tool"`, `api/graph_rag.py` uses
`detail="Graph-RAG search failed"`. Endpoints that raise their own `HTTPException` are untouched — the
decorator re-raises those, so deliberate caller-actionable messages still reach the caller.

Static messages are per-category rather than one blanket string, so a 404 still reads as "not found"
and a 429 as "too many requests" without any of them describing the failure.

## What Changed

- `utils/error_boundaries/types.py` — `APIErrorResponse.get_client_message_for_category`, alongside
  the existing `get_status_code_for_category`.
- `utils/error_boundaries/decorators.py` — `_create_api_error_response` logs type + message +
  traceback against the trace id and returns a response whose `message` is the static per-category
  text and whose `details` carries only `operation`. `_raise_or_return_error` no longer logs.

Nothing consumes `details.exception_type` / `details.exception_message` anywhere in the repo or the
frontends (grepped), so no caller loses a field it was reading.

## Verification

New `utils/error_boundaries/decorators_disclosure_test.py`, using a message shaped like the ones that
actually leak (`could not connect to /opt/autobot/run/redis.sock db=4 user=autobot_admin`):

```
utils/error_boundaries/decorators_disclosure_test.py
10 passed
```

It asserts both halves of the contract — no fragment of the exception reaches the client, **and** the
full text plus traceback lands in the log under the trace id the client received. Sync and async
wrappers are both covered; a deliberate `HTTPException` is asserted to pass through untouched.

Regression sweep over everything that exercises the decorator:

```
utils/error_boundaries/ + autobot_shared/error_boundaries_test.py + api/graph_rag_collection_test.py
47 passed

tests/test_health_probe_data_contract.py, tests/memory_graph/, tests/api/test_reasoning_effort_integration.py,
api/graph_rag_collection_test.py, api/knowledge_grounding_conflicts_decode_test.py, api/batch_jobs_schedules_test.py
159 passed
```

**Mutation check** — reverting `decorators.py` and `types.py` to `origin/Dev_new_gui`:

```
9 failed, 1 passed
```

The one that stays green is `test_a_deliberate_http_exception_is_untouched`, which asserts behaviour
this PR deliberately does not change.

## Model Used

Claude Opus 5 (1M context)
