### PR TITLE
fix(tests): drop the sqlalchemy stubs that abort autobot_shared collection (#13758)

### DIFF
--- a/autobot_shared/auth/test_slm_permission_parity.py
+++ b/autobot_shared/auth/test_slm_permission_parity.py
@@ -7,7 +7,8 @@ SLM permission parity tests (GH #6511).
 
 Placed in autobot_shared/auth/ so they run WITHOUT the autobot-slm-backend
 conftest.py stubs (which MagicMock user_management.models and sqlalchemy).
-Instead, the SLM role module is loaded directly from its file path.
+Instead, the SLM role module is loaded directly from its file path, with a
+real sqlalchemy — see ``_load_slm_role_module`` and #13758.
 
 Guarantees:
 - SYSTEM_PERMISSIONS covers every value in the canonical Permission enum.
@@ -17,10 +18,7 @@ Guarantees:
 """
 
 import importlib.util
-import sys
-import types
 from pathlib import Path
-from unittest.mock import MagicMock
 
 import pytest
 
@@ -30,60 +28,34 @@ _SLM_ROOT = Path(__file__).parent.parent.parent / "autobot-slm-backend"
 
 
 def _load_slm_role_module():
-    """Load user_management/models/role.py directly without executing any __init__.py."""
+    """Load ``user_management/models/role.py`` from the SLM backend by path.
+
+    No ``sys.modules`` stubbing (#13758). This function used to install a dummy
+    ``user_management.models.base`` and a ``MagicMock`` ``sqlalchemy`` so that
+    the ORM class declarations *this file once contained* would not need a real
+    engine. #12647 turned the SLM module into a pure re-export shim, and from
+    that point the stubs were not protecting the load — they were breaking it:
+    the shim imports ``autobot_shared.user_management.models.role``, whose
+    package ``__init__`` reaches ``base.py`` and evaluates
+    ``class Base(AsyncAttrs, DeclarativeBase)`` against the mocked
+    ``sqlalchemy``, producing ``TypeError: metaclass conflict`` at **collection**
+    time. A collection error aborts the whole run, so this one file could mask
+    the other 1486 tests in the package.
+
+    The by-path load is kept rather than replaced with a plain import: it is
+    what proves the SLM shim itself resolves, and the SLM backend's own
+    ``user_management`` package must not shadow the shared one on ``sys.path``.
+    """
     role_path = _SLM_ROOT / "user_management" / "models" / "role.py"
     if not role_path.exists():
         return None
 
-    # Build minimal stubs so role.py's ORM class declarations don't fail.
-    # role.py does: class Permission(Base, TimestampMixin) — we need real
-    # classes (not MagicMock) as bases to avoid metaclass conflicts.
-    class _DummyBase:
-        pass
-
-    class _DummyMixin:
-        pass
-
-    _base_mod = types.ModuleType("user_management.models.base")
-    _base_mod.Base = _DummyBase  # type: ignore[attr-defined]
-    _base_mod.TimestampMixin = _DummyMixin  # type: ignore[attr-defined]
-    _base_mod.TenantMixin = _DummyMixin  # type: ignore[attr-defined]
-
-    # SQLAlchemy stubs — only needed for column decorators, not for constants.
-    _sa_stub = MagicMock()
-    _sa_orm_stub = MagicMock()
-    _sa_pg_stub = MagicMock()
-
-    stub_overrides: dict[str, object] = {
-        "user_management.models.base": _base_mod,
-        "sqlalchemy": _sa_stub,
-        "sqlalchemy.orm": _sa_orm_stub,
-        "sqlalchemy.ext": MagicMock(),
-        "sqlalchemy.ext.asyncio": MagicMock(),
-        "sqlalchemy.dialects": MagicMock(),
-        "sqlalchemy.dialects.postgresql": _sa_pg_stub,
-    }
-
-    saved: dict[str, object] = {}
-    for name, stub in stub_overrides.items():
-        saved[name] = sys.modules.get(name, _SENTINEL)
-        sys.modules[name] = stub  # type: ignore[assignment]
-
     spec = importlib.util.spec_from_file_location("_slm_role_isolated", role_path)
     mod = importlib.util.module_from_spec(spec)
-    try:
-        spec.loader.exec_module(mod)
-    finally:
-        for name, original in saved.items():
-            if original is _SENTINEL:
-                sys.modules.pop(name, None)
-            else:
-                sys.modules[name] = original  # type: ignore[assignment]
-
+    spec.loader.exec_module(mod)
     return mod
 
 
-_SENTINEL = object()
 _slm_role = _load_slm_role_module()
 
 
@@ -215,3 +187,35 @@ def test_slm_role_permissions_align_with_shared(slm_role):
             + "\n".join(lines)
             + "\nUpdate SYSTEM_ROLES in user_management/models/role.py to match."
         )
+
+
+# ---------------------------------------------------------------------------
+# The shim itself — #12647 / #13758
+# ---------------------------------------------------------------------------
+
+
+def test_slm_role_module_re_exports_the_shared_objects(slm_role):
+    """The SLM module is a re-export shim; nothing else guarded that it stayed one.
+
+    If it ever grows a second copy of these constants, the parity tests above
+    would still pass while the two backends silently diverged — they would be
+    comparing the copy against itself. Identity, not equality, is the assertion.
+    """
+    import autobot_shared.user_management.models.role as shared_role  # noqa: PLC0415
+
+    assert slm_role.SYSTEM_PERMISSIONS is shared_role.SYSTEM_PERMISSIONS
+    assert slm_role.SYSTEM_ROLES is shared_role.SYSTEM_ROLES
+    assert slm_role.Role is shared_role.Role
+    assert slm_role.Permission is shared_role.Permission
+
+
+def test_the_shim_loads_against_a_real_sqlalchemy(slm_role):
+    """#13758: the stubbed load raised TypeError at import time and aborted collection.
+
+    Reaching this test at all means the module executed; asserting on the ORM
+    base makes it explicit that a real ``DeclarativeBase`` — not a MagicMock —
+    was in play, which is the condition that used to fail.
+    """
+    from sqlalchemy.orm import DeclarativeBase  # noqa: PLC0415
+
+    assert issubclass(slm_role.Role, DeclarativeBase)


### PR DESCRIPTION
Closes #13758

## Thinking Path

The issue's hypothesis was that the by-path load causes two module identities of `DeclarativeBase`.
It is simpler and more specific than that: **the test's own stubs are the cause**, and they became the
cause without anyone touching the test.

`_load_slm_role_module` installed a `MagicMock` over `sqlalchemy` (plus a dummy
`user_management.models.base`) before executing the SLM `role.py`. That was correct when `role.py`
*declared ORM classes* — the stubs let the column decorators run without an engine. **#12647 turned
that file into a pure re-export shim**: it now does nothing but

```python
from autobot_shared.user_management.models.role import (SYSTEM_PERMISSIONS, SYSTEM_ROLES, ...)
```

which pulls in `autobot_shared/user_management/models/__init__.py` → `base.py` →
`class Base(AsyncAttrs, DeclarativeBase)` — evaluated against the **mocked** `sqlalchemy`. Two
MagicMock attributes as bases is exactly what `TypeError: metaclass conflict` means. From #12647
onward the stubs were not protecting the load; they were the only thing breaking it.

So the answer to the issue's third acceptance criterion: the by-path load is **not** inherently
unsafe here, and the two `user_management` packages do coexist — because the SLM shim no longer
imports `user_management.*` at all. Verified directly:

```
$ python -c "<load role.py by path, no stubs>; ..."
loaded by path, no stubs: ['Permission', 'Role', 'RolePermission', 'SYSTEM_PERMISSIONS', 'SYSTEM_ROLES', 'UserRole']
SYSTEM_PERMISSIONS is shared object: True
SYSTEM_ROLES is shared object: True
Role is shared Role: True
```

The by-path load is kept rather than replaced with a plain import — it is what proves the SLM shim
itself resolves and that the SLM backend's `user_management` package does not shadow the shared one.

## What Changed

- `autobot_shared/auth/test_slm_permission_parity.py`
  - `_load_slm_role_module` loads the shim with a **real** sqlalchemy; the stub install/restore
    machinery and the now-unused `sys` / `types` / `MagicMock` imports are gone.
  - Two new guards. `test_slm_role_module_re_exports_the_shared_objects` asserts **identity**, not
    equality — nothing else checked that the shim stayed a shim, and if it ever regrew its own copy of
    these constants, the parity tests would keep passing while comparing the copy against itself.
    `test_the_shim_loads_against_a_real_sqlalchemy` asserts `Role` is a real `DeclarativeBase`
    subclass, making the condition that used to fail explicit rather than implied by "it collected".

No production code changed.

## Verification

Collection, the acceptance criterion (before: `1486 tests collected, 1 error` + `Interrupted`):

```
$ venv/bin/python -m pytest autobot_shared/ -q -p no:randomly --collect-only
1496 tests collected in 2.16s
```

Full package:

```
$ venv/bin/python -m pytest autobot_shared/ -q -p no:randomly
1496 passed, 26 warnings in 24.08s
```

**Deliberate-failure check** — the drift detector must still detect drift. Adding a `DIVERGENCE_PROBE`
member to the shared `Permission` enum without seeding it anywhere:

```
FAILED test_every_permission_assigned_to_at_least_one_role
FAILED test_admin_role_contains_all_permissions
FAILED test_slm_admin_role_covers_all_shared_permissions
3 failed, 7 passed
```

Including the SLM-side assertion, so the parity comparison is genuinely live and not passing by
construction. Reverted after the check.

## Model Used

Claude Opus 5 (1M context)
