### PR TITLE
fix(startup): run the Python floor and disk gate at boot (#13738)

### DIFF
--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -2429,6 +2429,16 @@ def create_lifespan_manager():
         configure_logging()
         logger.info("🚀 AutoBot Backend starting up...")
 
+        # #13738: the interpreter floor and free-disk gate ran nowhere. The
+        # floor is load-bearing — llc/scheduler/base.py calls
+        # asyncio.Task.cancelling() with no fallback, so below it every LLC
+        # poll loop dies after one tick with an AttributeError nothing
+        # retrieves (#13727). This is the first thing after logging so the
+        # failure is legible: refusing to boot beats degrading silently.
+        from startup_validator import enforce_system_requirements
+
+        enforce_system_requirements()
+
         # #11279: run the non-fatal startup file-integrity check (mirrors the
         # autobot-slm-backend lifespan wiring). No-op unless
         # AUTOBOT_INTEGRITY_CHECK_ENABLED=1; logs a WARNING on any manifest

--- a/autobot-backend/startup_validator.py
+++ b/autobot-backend/startup_validator.py
@@ -73,12 +73,15 @@ class StartupValidator:
         """Initialize validator with default validation result and dependency lists."""
         self.result = ValidationResult(success=True)
 
-        # Critical imports that must be available
+        # Critical imports that must be available. ``aioredis`` was listed here
+        # until #13738; it has not been a dependency since the move to
+        # ``redis.asyncio`` and would have reported a permanent false failure the
+        # moment anything ran this validator.
         self.critical_imports = [
             "fastapi",
             "pydantic",
             "redis",
-            "aioredis",
+            "redis.asyncio",
             "jwt",
             "bcrypt",
             "yaml",
@@ -86,25 +89,29 @@ class StartupValidator:
             "logging",
         ]
 
-        # AutoBot modules that should be importable
+        # AutoBot modules that should be importable. These read ``src.*`` until
+        # #13738 — a layout this repository has not used for a long time, so
+        # every entry raised ModuleNotFoundError. Each name below is verified to
+        # import under the backend's own sys.path.
         self.autobot_modules = [
-            "src.unified_config",
-            "src.auth_middleware",
-            "src.security_layer",
-            "src.knowledge_base_factory",
-            "src.knowledge_base",
+            "autobot_shared.ssot_config",
+            "auth_middleware",
+            "security_layer",
+            "knowledge_base_factory",
+            "knowledge_base",
         ]
 
-        # Optional modules (warnings only if missing)
-        # Note: Obsolete chat_workflow_consolidated removed in Issue #567 archive cleanup
+        # Optional modules (warnings only if missing).
+        # Note: Obsolete chat_workflow_consolidated removed in Issue #567 archive cleanup.
+        # ``conversation`` (deprecated in #3831) and ``llm_interface`` (gone) are
+        # not listed: a warning for a module that was deliberately retired is
+        # noise, not a signal.
         self.optional_modules = [
-            "src.agents.kb_librarian_agent",
-            "src.agents.librarian_assistant",
-            "src.agents.llm_failsafe_agent",
-            "src.conversation",
-            "src.async_chat_workflow",
-            "src.llm_interface",
-            "src.circuit_breaker",
+            "agents.kb_librarian_agent",
+            "agents.librarian_assistant",
+            "agents.llm_failsafe_agent",
+            "async_chat_workflow",
+            "circuit_breaker",
         ]
 
         # Services to validate connectivity
@@ -352,6 +359,42 @@ async def validate_startup_dependencies() -> ValidationResult:
     return await validator.validate_all()
 
 
+def validate_system_requirements() -> ValidationResult:
+    """Check the interpreter floor and free disk space (#13738).
+
+    Split out of :meth:`StartupValidator.validate_all` so the boot path can gate
+    on it alone. The rest of ``validate_all`` performs Redis and Ollama round
+    trips, which belong in a health probe rather than in front of every start;
+    this part is pure local inspection and costs nothing.
+
+    The floor is load-bearing rather than advisory: ``llc/scheduler/base.py``
+    calls ``asyncio.Task.cancelling()`` with no fallback, so on a sub-floor
+    interpreter every LLC poll loop dies after one tick with an ``AttributeError``
+    nothing ever retrieves (#13727). Failing loudly at boot is the difference
+    between a clear error and background scheduling that silently does nothing.
+    """
+    validator = StartupValidator()
+    validator._validate_system_requirements()
+    return validator.result
+
+
+def enforce_system_requirements() -> None:
+    """Fail startup when the host cannot support the platform (#13738).
+
+    Raises:
+        RuntimeError: the interpreter is below the floor, or the disk is full.
+            Warnings (low-but-sufficient disk) are logged and do not block boot.
+    """
+    result = validate_system_requirements()
+    for warning in result.warnings:
+        logger.warning("Startup requirement warning: %s", warning)
+    if result.success:
+        return
+    for error in result.errors:
+        logger.error("Startup requirement not met: %s", error)
+    raise RuntimeError("Startup requirements not met: " + "; ".join(result.errors))
+
+
 def validate_import_quickly(module_name: str) -> Tuple[bool, str | None]:
     """Quick import validation for a single module"""
     try:
@@ -381,6 +424,8 @@ async def validate_service_health(service_name: str) -> Tuple[bool, str | None]:
 __all__ = [
     "ValidationResult",
     "StartupValidator",
+    "enforce_system_requirements",
+    "validate_system_requirements",
     "validate_startup_dependencies",
     "validate_import_quickly",
     "validate_service_health",

--- a/autobot-backend/startup_validator_wiring_test.py
+++ b/autobot-backend/startup_validator_wiring_test.py
@@ -25,7 +25,6 @@ from startup_validator import (
     validate_system_requirements,
 )
 
-
 # --------------------------------------------------------------- the gate
 
 
@@ -98,9 +97,7 @@ async def test_the_gate_runs_before_any_service_is_touched(monkeypatch):
     touched = []
     monkeypatch.setattr("startup_validator.sys.version_info", (3, 10, 0))
     for name in ("initialize_critical_services", "initialize_background_services"):
-        monkeypatch.setattr(
-            lifespan_mod, name, lambda *a, _n=name, **kw: touched.append(_n), raising=False
-        )
+        monkeypatch.setattr(lifespan_mod, name, lambda *a, _n=name, **kw: touched.append(_n), raising=False)
 
     with pytest.raises(RuntimeError):
         async with lifespan_mod.create_lifespan_manager()(FastAPI()):

--- a/autobot-backend/startup_validator_wiring_test.py
+++ b/autobot-backend/startup_validator_wiring_test.py
@@ -1,0 +1,130 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""The startup requirement gate actually runs, and its lists are true (#13738).
+
+``StartupValidator`` declared the platform's Python floor and had **zero callers
+repo-wide** — the one guard meant to catch a sub-floor interpreter never ran.
+That floor is load-bearing: ``llc/scheduler/base.py`` calls
+``asyncio.Task.cancelling()`` with no fallback, so below it every LLC poll loop
+dies after one tick with an ``AttributeError`` nothing retrieves (#13727).
+
+Wiring a dormant check is only half the job — a check nobody ran is also a check
+nobody kept true. These tests assert the module lists still import, so the gate
+cannot go back to reporting failures that say nothing about the host.
+"""
+
+import importlib
+
+import pytest
+
+from startup_validator import (
+    StartupValidator,
+    enforce_system_requirements,
+    validate_system_requirements,
+)
+
+
+# --------------------------------------------------------------- the gate
+
+
+def test_the_running_interpreter_passes_its_own_floor():
+    """The suite runs on a supported interpreter, so the gate must be quiet."""
+    assert validate_system_requirements().success
+
+
+def test_a_sub_floor_interpreter_fails_startup_by_name(monkeypatch):
+    """Deliberate failure: below the floor, boot must stop and say why."""
+    monkeypatch.setattr("startup_validator.sys.version_info", (3, 10, 0))
+
+    with pytest.raises(RuntimeError) as caught:
+        enforce_system_requirements()
+
+    message = str(caught.value)
+    assert "3.14" in message, "the error must name the version an operator has to install"
+    assert "Python" in message
+
+
+def test_a_supported_interpreter_boots(monkeypatch):
+    """The other half of the deliberate-failure check — at the floor, it passes."""
+    monkeypatch.setattr("startup_validator.sys.version_info", (3, 14, 0))
+
+    enforce_system_requirements()  # must not raise
+
+
+def test_a_full_disk_stops_startup(monkeypatch):
+    """The floor is not the only dark check — disk space was unwired too."""
+    monkeypatch.setattr("shutil.disk_usage", lambda _path: (100, 100, 0))
+
+    with pytest.raises(RuntimeError, match="disk space"):
+        enforce_system_requirements()
+
+
+def test_low_but_sufficient_disk_warns_without_blocking(monkeypatch, caplog):
+    """A warning must not become a boot failure."""
+    monkeypatch.setattr("shutil.disk_usage", lambda _path: (100, 100, 3 * 1024**3))
+
+    enforce_system_requirements()  # must not raise
+
+    assert any("Low disk space" in r.getMessage() for r in caplog.records)
+
+
+# ------------------------------------------------------------ the wiring
+
+
+def test_the_lifespan_calls_the_gate():
+    """AC 1: the gate is invoked on a real startup path, not just importable."""
+    import inspect  # noqa: PLC0415
+
+    import initialization.lifespan as lifespan_mod  # noqa: PLC0415
+
+    source = inspect.getsource(lifespan_mod.create_lifespan_manager)
+    assert "enforce_system_requirements()" in source
+
+
+@pytest.mark.asyncio
+async def test_the_gate_runs_before_any_service_is_touched(monkeypatch):
+    """A sub-floor host must fail before initialization begins, not part-way in.
+
+    If the gate ran after service startup, the operator would get a Redis or
+    Ollama error and go looking in the wrong place — which is exactly the
+    diagnosis cost #13727 paid.
+    """
+    from fastapi import FastAPI  # noqa: PLC0415
+
+    import initialization.lifespan as lifespan_mod  # noqa: PLC0415
+
+    touched = []
+    monkeypatch.setattr("startup_validator.sys.version_info", (3, 10, 0))
+    for name in ("initialize_critical_services", "initialize_background_services"):
+        monkeypatch.setattr(
+            lifespan_mod, name, lambda *a, _n=name, **kw: touched.append(_n), raising=False
+        )
+
+    with pytest.raises(RuntimeError):
+        async with lifespan_mod.create_lifespan_manager()(FastAPI()):
+            pass
+
+    assert touched == [], "startup proceeded past a host that cannot run the platform"
+
+
+# ------------------------------------------- the lists the gate travels with
+
+
+@pytest.mark.parametrize("module_name", StartupValidator().critical_imports)
+def test_every_declared_critical_import_exists(module_name):
+    """``aioredis`` sat here long after the move to ``redis.asyncio`` (#13738)."""
+    importlib.import_module(module_name)
+
+
+@pytest.mark.parametrize("module_name", StartupValidator().autobot_modules)
+def test_every_declared_autobot_module_exists(module_name):
+    """These read ``src.*`` — a layout the repo has not used in a long time."""
+    importlib.import_module(module_name)
+
+
+@pytest.mark.parametrize("module_name", StartupValidator().optional_modules)
+def test_every_declared_optional_module_exists(module_name):
+    """Optional means "may be absent by configuration", not "was renamed years ago"."""
+    importlib.import_module(module_name)


### PR DESCRIPTION
Closes #13738

## Thinking Path

The obvious fix — call `validate_startup_dependencies()` from the lifespan — **breaks boot**. I tried
the lists it travels with before wiring anything:

```
FAIL src.unified_config          ModuleNotFoundError
FAIL src.auth_middleware         ModuleNotFoundError
FAIL src.security_layer          ModuleNotFoundError
FAIL src.knowledge_base_factory  ModuleNotFoundError
FAIL src.knowledge_base          ModuleNotFoundError
FAIL aioredis                    ModuleNotFoundError
```

Every one of those is a hard error in `validate_all`. A check nobody ran is also a check nobody kept
true: the `src.*` layout is long gone and `aioredis` has not been a dependency since the move to
`redis.asyncio`. Wiring it verbatim would have replaced a silent failure with a backend that refuses
to start, and the error messages would have been about the repo rather than the host.

So the wiring is split by what each half actually is:

- **System requirements** — the Python floor and free disk — is pure local inspection, costs nothing,
  and is the check the issue is about. It runs at boot and is **fatal**.
- **`validate_all()`** additionally does a Redis `PING` and an HTTP GET to Ollama's `/api/tags` with a
  5s timeout. Putting that in front of every start makes Ollama a boot dependency (it is a
  degraded-capability condition, not a reason to refuse to start) and duplicates the existing health
  probes. That belongs behind a diagnostics endpoint — filed as **#13780**, with the reasoning.

The gate is placed immediately after `configure_logging()`, before `initialize_critical_services`. On
a sub-floor host, failing there gives an operator "Python 3.14+ required"; failing later gives them a
Redis error and sends them looking in the wrong place — which is exactly the diagnosis cost #13727
paid.

The lists are corrected in this PR rather than left for #13780. They are what `validate_all` will
report on, and leaving them wrong would hand the next caller a false answer.

## What Changed

- `startup_validator.py`
  - `validate_system_requirements()` — the floor + disk gate alone, as a `ValidationResult`.
  - `enforce_system_requirements()` — raises `RuntimeError` on errors, logs warnings without blocking.
    Low-but-sufficient disk stays a warning; a full disk is fatal.
  - `critical_imports`: `aioredis` → `redis.asyncio`.
  - `autobot_modules`: `src.*` → the real module names, each verified to import.
  - `optional_modules`: `src.*` → real names; `conversation` (deprecated in #3831) and `llm_interface`
    (gone) dropped — a warning about a deliberately retired module is noise, not signal.
- `initialization/lifespan.py` — calls `enforce_system_requirements()` right after logging setup.

The floor constant itself needed no change: it already read 3.14, matching CI, `.python-version`,
mypy, both Dockerfiles and the Ansible roles.

## Verification

```
startup_validator_wiring_test.py                     26 passed
initialization/ + startup_validator_wiring_test.py   50 passed
```

**Deliberate failure, both directions** (the issue's AC 3) — `test_a_sub_floor_interpreter_fails_startup_by_name`
asserts a 3.10 `version_info` raises and that the message names **3.14**, so an operator learns what
to install; `test_a_supported_interpreter_boots` asserts the floor itself passes. The disk gate gets
the same treatment: zero free bytes raises, 3 GB warns and boots.

**Mutation checks**, three separate dimensions:

| Reverted | Result |
|---|---|
| `startup_validator.py` + `lifespan.py` to base | collection error — the helpers do not exist |
| `lifespan.py` only | `2 failed` — both wiring tests |
| `aioredis` / `src.unified_config` restored | `2 failed` — the parametrised list tests |

That last one is the point of the parametrised tests: they are what stops the lists drifting back
into the state that made this check useless.

`test_the_gate_runs_before_any_service_is_touched` drives the real lifespan context manager with a
sub-floor `version_info` and asserts `initialize_critical_services` was never reached — ordering, not
just presence.

## Model Used

Claude Opus 5 (1M context)
