### PR TITLE
fix(chat): re-check membership when resolving a bound work item (#13729)

### DIFF
--- a/autobot-backend/api/chat.py
+++ b/autobot-backend/api/chat.py
@@ -1186,7 +1186,12 @@ async def set_session_work_item(
         if item is None:
             raise HTTPException(status_code=404, detail="Work item not found")
 
-    await SessionWorkItemService().set_work_item(session_id, work_item_id, str(ctx.org_id))
+    # #13729: the authorised user is stored with the scope so the resolve path
+    # can confirm the authorisation still holds, instead of trusting it for the
+    # whole TTL after membership is revoked.
+    await SessionWorkItemService().set_work_item(
+        session_id, work_item_id, str(ctx.org_id), user_id=str(ctx.user_id) if ctx.user_id else None
+    )
     return DataResponse(data={"session_id": session_id, "work_item_id": work_item_id})
 
 

--- a/autobot-backend/chat_workflow/session_work_item.py
+++ b/autobot-backend/chat_workflow/session_work_item.py
@@ -24,7 +24,7 @@ tenant predicates added alongside are defence in depth, not the only defence.
 
 import json
 import os
-from typing import Optional, Tuple
+from typing import NamedTuple, Optional
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_mixin import AsyncRedisClientMixin
@@ -35,6 +35,20 @@ logger = get_logger(__name__)
 SESSION_WORK_ITEM_TTL_SECONDS: int = int(os.environ.get("AUTOBOT_SESSION_WORK_ITEM_TTL_SECONDS", str(24 * 3600)))
 
 _KEY = "autobot:session:{session_id}:work_item"
+
+
+class SessionWorkItemBinding(NamedTuple):
+    """What the bind endpoint authorised, as stored (#13729).
+
+    ``user_id`` is carried so the resolve path can re-check membership rather
+    than trusting ``company_id`` for the rest of the TTL. A named tuple, not a
+    plain tuple: it grew a third field, and two-value unpacking at an unfixed
+    call site should fail loudly instead of silently binding the wrong name.
+    """
+
+    work_item_id: Optional[str] = None
+    company_id: Optional[str] = None
+    user_id: Optional[str] = None
 
 
 def apply_work_item(context: "dict | None", work_item_id: Optional[str]) -> "dict | None":
@@ -60,7 +74,13 @@ class SessionWorkItemService(AsyncRedisClientMixin):
 
     _redis_database = "knowledge"
 
-    async def set_work_item(self, session_id: str, work_item_id: str, company_id: str) -> None:
+    async def set_work_item(
+        self,
+        session_id: str,
+        work_item_id: str,
+        company_id: str,
+        user_id: Optional[str] = None,
+    ) -> None:
         """Bind *session_id* to *work_item_id*, recording its verified company.
 
         The company is stored **with** the binding rather than read later from
@@ -72,18 +92,29 @@ class SessionWorkItemService(AsyncRedisClientMixin):
 
         The caller is responsible for having verified ownership of both the
         session and the work item; this stores an already-authorised decision.
+
+        ``user_id`` (#13729) is stored so the resolve path can confirm that
+        authorisation still holds. Without it the binding vouched for the
+        company for the full TTL, so a user removed from the company kept
+        receiving its goal chain for up to 24 hours after losing access.
         """
         if not work_item_id or not str(work_item_id).strip():
             raise ValueError("work_item_id is required")
         if not company_id or not str(company_id).strip():
             raise ValueError("company_id is required — an unscoped binding is not a binding")
-        payload = json.dumps({"work_item_id": str(work_item_id).strip(), "company_id": str(company_id).strip()})
+        payload = json.dumps(
+            {
+                "work_item_id": str(work_item_id).strip(),
+                "company_id": str(company_id).strip(),
+                "user_id": str(user_id).strip() if user_id else None,
+            }
+        )
         redis = await self._get_redis()
         await redis.set(_KEY.format(session_id=session_id), payload, ex=SESSION_WORK_ITEM_TTL_SECONDS)
         logger.info("session_work_item.set session=%s work_item=%s company=%s", session_id, work_item_id, company_id)
 
-    async def get_binding(self, session_id: str) -> Tuple[Optional[str], Optional[str]]:
-        """Return ``(work_item_id, company_id)`` for the session, or ``(None, None)``.
+    async def get_binding(self, session_id: str) -> SessionWorkItemBinding:
+        """Return the session's binding, or an all-``None`` one.
 
         Never raises into chat — a resolution failure leaves L4 silent.
         """
@@ -91,17 +122,20 @@ class SessionWorkItemService(AsyncRedisClientMixin):
             redis = await self._get_redis()
             raw = await redis.get(_KEY.format(session_id=session_id))
             if not raw:
-                return None, None
+                return SessionWorkItemBinding()
             data = json.loads(raw.decode() if isinstance(raw, bytes) else raw)
-            return data.get("work_item_id"), data.get("company_id")
+            return SessionWorkItemBinding(
+                work_item_id=data.get("work_item_id"),
+                company_id=data.get("company_id"),
+                user_id=data.get("user_id"),
+            )
         except Exception as exc:  # defensive; resolution must never break chat
             logger.warning("session_work_item.get failed for session=%s: %s", session_id, exc)
-            return None, None
+            return SessionWorkItemBinding()
 
     async def get_work_item(self, session_id: str) -> Optional[str]:
         """Return just the bound work item id, or ``None``."""
-        work_item_id, _ = await self.get_binding(session_id)
-        return work_item_id
+        return (await self.get_binding(session_id)).work_item_id
 
     async def clear_work_item(self, session_id: str) -> None:
         """Remove the session's work-item binding."""
@@ -112,6 +146,7 @@ class SessionWorkItemService(AsyncRedisClientMixin):
 
 __all__ = [
     "SESSION_WORK_ITEM_TTL_SECONDS",
+    "SessionWorkItemBinding",
     "SessionWorkItemService",
     "apply_work_item",
 ]

--- a/autobot-backend/chat_workflow/session_work_item_test.py
+++ b/autobot-backend/chat_workflow/session_work_item_test.py
@@ -85,9 +85,7 @@ class TestBindingCarriesItsVerifiedCompany:
         svc = SessionWorkItemService()
         redis = MagicMock()
         redis.get = AsyncMock(
-            return_value=json.dumps(
-                {"work_item_id": WORK_ITEM, "company_id": ALICE_CO, "user_id": ALICE}
-            ).encode()
+            return_value=json.dumps({"work_item_id": WORK_ITEM, "company_id": ALICE_CO, "user_id": ALICE}).encode()
         )
 
         with patch.object(SessionWorkItemService, "_get_redis", new_callable=AsyncMock, return_value=redis):

--- a/autobot-backend/chat_workflow/session_work_item_test.py
+++ b/autobot-backend/chat_workflow/session_work_item_test.py
@@ -15,11 +15,16 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from chat_workflow.session_work_item import SessionWorkItemService, apply_work_item
+from chat_workflow.session_work_item import (
+    SessionWorkItemBinding,
+    SessionWorkItemService,
+    apply_work_item,
+)
 
 ALICE_CO = "11111111-1111-1111-1111-111111111111"
 BOB_CO = "22222222-2222-2222-2222-222222222222"
 WORK_ITEM = "33333333-3333-3333-3333-333333333333"
+ALICE = "44444444-4444-4444-4444-444444444444"
 
 
 class TestClientSuppliedValueIsNeverTrusted:
@@ -62,10 +67,12 @@ class TestBindingCarriesItsVerifiedCompany:
         redis.set = AsyncMock()
 
         with patch.object(SessionWorkItemService, "_get_redis", new_callable=AsyncMock, return_value=redis):
-            await svc.set_work_item("s-1", WORK_ITEM, ALICE_CO)
+            await svc.set_work_item("s-1", WORK_ITEM, ALICE_CO, user_id=ALICE)
 
         stored = json.loads(redis.set.await_args.args[1])
-        assert stored == {"work_item_id": WORK_ITEM, "company_id": ALICE_CO}
+        # #13729: the authorised user is stored too, so the resolve path can
+        # re-check membership instead of trusting the company for the full TTL.
+        assert stored == {"work_item_id": WORK_ITEM, "company_id": ALICE_CO, "user_id": ALICE}
 
     @pytest.mark.asyncio
     async def test_a_binding_without_a_company_is_rejected(self):
@@ -77,16 +84,20 @@ class TestBindingCarriesItsVerifiedCompany:
     async def test_get_binding_returns_both_values(self):
         svc = SessionWorkItemService()
         redis = MagicMock()
-        redis.get = AsyncMock(return_value=json.dumps({"work_item_id": WORK_ITEM, "company_id": ALICE_CO}).encode())
+        redis.get = AsyncMock(
+            return_value=json.dumps(
+                {"work_item_id": WORK_ITEM, "company_id": ALICE_CO, "user_id": ALICE}
+            ).encode()
+        )
 
         with patch.object(SessionWorkItemService, "_get_redis", new_callable=AsyncMock, return_value=redis):
-            assert await svc.get_binding("s-1") == (WORK_ITEM, ALICE_CO)
+            assert await svc.get_binding("s-1") == (WORK_ITEM, ALICE_CO, ALICE)
 
     @pytest.mark.asyncio
     async def test_a_redis_failure_leaves_l4_silent_not_broken(self):
         svc = SessionWorkItemService()
         with patch.object(SessionWorkItemService, "_get_redis", side_effect=RuntimeError("redis down")):
-            assert await svc.get_binding("s-1") == (None, None)
+            assert await svc.get_binding("s-1") == (None, None, None)
 
 
 class TestGoalAncestryIsCompanyScoped:
@@ -99,7 +110,7 @@ class TestGoalAncestryIsCompanyScoped:
         with patch(
             "chat_workflow.session_work_item.SessionWorkItemService.get_binding",
             new_callable=AsyncMock,
-            return_value=(None, None),
+            return_value=SessionWorkItemBinding(),
         ):
             with patch("user_management.database.get_async_session_factory", factory):
                 assert await resolve_goal_ancestry("s-1") is None
@@ -113,7 +124,7 @@ class TestGoalAncestryIsCompanyScoped:
         with patch(
             "chat_workflow.session_work_item.SessionWorkItemService.get_binding",
             new_callable=AsyncMock,
-            return_value=("not-a-uuid", ALICE_CO),
+            return_value=SessionWorkItemBinding("not-a-uuid", ALICE_CO, ALICE),
         ):
             with patch("chat_workflow.tiered_context_sources.logger") as log:
                 assert await resolve_goal_ancestry("s-1") is None
@@ -143,13 +154,124 @@ class TestGoalAncestryIsCompanyScoped:
             ),
         }
         with patch.dict("sys.modules", modules):
-            with patch(
-                "chat_workflow.session_work_item.SessionWorkItemService.get_binding",
-                new_callable=AsyncMock,
-                return_value=(WORK_ITEM, ALICE_CO),
+            with (
+                patch(
+                    "chat_workflow.session_work_item.SessionWorkItemService.get_binding",
+                    new_callable=AsyncMock,
+                    return_value=SessionWorkItemBinding(WORK_ITEM, ALICE_CO, ALICE),
+                ),
+                # Authorisation has its own tests below; this one is about scope
+                # reaching both lookups.
+                patch(
+                    "chat_workflow.tiered_context_sources._authorisation_still_holds",
+                    new_callable=AsyncMock,
+                    return_value=True,
+                ),
             ):
                 result = await resolve_goal_ancestry("s-1")
 
         assert result == [{"title": "Ship", "level": "vision"}]
         assert wi_svc.get.await_args.kwargs["company_id"] == ALICE_CO
         assert goal_svc.get_goal_ancestry_for_work_item.await_args.kwargs["company_id"] == ALICE_CO
+
+
+class TestBindingAuthorisationIsRecheckedPerTurn:
+    """#13729: the stored company was trusted for the whole TTL.
+
+    Nothing re-checked membership at resolve time and nothing invalidated a
+    binding when membership changed, so a user removed from a company kept
+    receiving its goal chain for up to ``SESSION_WORK_ITEM_TTL_SECONDS``.
+    """
+
+    @staticmethod
+    def _bound(work_item=WORK_ITEM, company=ALICE_CO, user=ALICE):
+        return patch(
+            "chat_workflow.session_work_item.SessionWorkItemService.get_binding",
+            new_callable=AsyncMock,
+            return_value=SessionWorkItemBinding(work_item, company, user),
+        )
+
+    @staticmethod
+    def _membership(is_member: bool, is_admin: bool = False):
+        """Patch the membership lookup and the current platform-admin flag."""
+        session_cm = MagicMock()
+        session_cm.__aenter__ = AsyncMock(return_value=MagicMock())
+        session_cm.__aexit__ = AsyncMock(return_value=False)
+        svc = MagicMock()
+        svc.is_member = AsyncMock(return_value=is_member)
+        return (
+            patch.dict(
+                "sys.modules",
+                {
+                    "llc.services.membership_service": MagicMock(MembershipService=MagicMock(return_value=svc)),
+                    "user_management.database": MagicMock(
+                        get_async_session_factory=MagicMock(return_value=MagicMock(return_value=session_cm))
+                    ),
+                },
+            ),
+            patch(
+                "chat_workflow.tiered_context_sources._is_platform_admin",
+                new_callable=AsyncMock,
+                return_value=is_admin,
+            ),
+            svc,
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_revoked_member_gets_no_chain_on_the_next_turn(self):
+        """Bind, revoke, resolve -> empty chain. Not at TTL expiry."""
+        from chat_workflow.tiered_context_sources import resolve_goal_ancestry
+
+        modules, admin, svc = self._membership(is_member=False)
+        query = AsyncMock(return_value=[{"title": "Ship"}])
+        with self._bound(), modules, admin:
+            with patch("chat_workflow.tiered_context_sources._query_goal_ancestry", query):
+                assert await resolve_goal_ancestry("s-1") is None
+
+        svc.is_member.assert_awaited_once()
+        query.assert_not_awaited(), "the goal walk ran despite revoked membership"
+
+    @pytest.mark.asyncio
+    async def test_a_current_member_still_gets_the_chain(self):
+        from chat_workflow.tiered_context_sources import resolve_goal_ancestry
+
+        modules, admin, _svc = self._membership(is_member=True)
+        query = AsyncMock(return_value=[{"title": "Ship"}])
+        with self._bound(), modules, admin:
+            with patch("chat_workflow.tiered_context_sources._query_goal_ancestry", query):
+                assert await resolve_goal_ancestry("s-1") == [{"title": "Ship"}]
+
+    @pytest.mark.asyncio
+    async def test_a_platform_admin_keeps_access_without_membership(self):
+        """get_tenant_context lets an admin bind a company they are not in."""
+        from chat_workflow.tiered_context_sources import resolve_goal_ancestry
+
+        modules, admin, _svc = self._membership(is_member=False, is_admin=True)
+        query = AsyncMock(return_value=[{"title": "Ship"}])
+        with self._bound(), modules, admin:
+            with patch("chat_workflow.tiered_context_sources._query_goal_ancestry", query):
+                assert await resolve_goal_ancestry("s-1") == [{"title": "Ship"}]
+
+    @pytest.mark.asyncio
+    async def test_a_binding_written_before_13729_is_refused(self):
+        """Pre-fix bindings carry no user, so the claim cannot be verified."""
+        from chat_workflow.tiered_context_sources import resolve_goal_ancestry
+
+        query = AsyncMock()
+        with self._bound(user=None):
+            with patch("chat_workflow.tiered_context_sources._query_goal_ancestry", query):
+                assert await resolve_goal_ancestry("s-1") is None
+
+        query.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_malformed_id_costs_no_membership_query(self):
+        """A client-shaped mistake must not buy a DB round-trip."""
+        from chat_workflow.tiered_context_sources import resolve_goal_ancestry
+
+        recheck = AsyncMock(return_value=True)
+        with self._bound(work_item="not-a-uuid"):
+            with patch("chat_workflow.tiered_context_sources._authorisation_still_holds", recheck):
+                assert await resolve_goal_ancestry("s-1") is None
+
+        recheck.assert_not_awaited()

--- a/autobot-backend/chat_workflow/tiered_context_prompt_test.py
+++ b/autobot-backend/chat_workflow/tiered_context_prompt_test.py
@@ -14,6 +14,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from chat_workflow.session_work_item import SessionWorkItemBinding
+
 
 def _handler_with_tiered_context_on():
     """Build a bare LLMHandlerMixin for prompt assembly.
@@ -140,12 +142,24 @@ class TestL4RendersInPromptViaTheBinding:
             with patch(
                 "chat_workflow.session_work_item.SessionWorkItemService.get_binding",
                 new_callable=AsyncMock,
-                return_value=("wi-1", "company-a"),
+                return_value=SessionWorkItemBinding(
+                    "33333333-3333-3333-3333-333333333333", "company-a", "user-a"
+                ),
             ):
-                with patch(
-                    "chat_workflow.tiered_context_sources._query_goal_ancestry",
-                    new_callable=AsyncMock,
-                    return_value=chain,
+                # #13729: the per-turn membership re-check has its own tests in
+                # session_work_item_test.py; here it is a seam so this test stays
+                # about what reaches the prompt.
+                with (
+                    patch(
+                        "chat_workflow.tiered_context_sources._authorisation_still_holds",
+                        new_callable=AsyncMock,
+                        return_value=True,
+                    ),
+                    patch(
+                        "chat_workflow.tiered_context_sources._query_goal_ancestry",
+                        new_callable=AsyncMock,
+                        return_value=chain,
+                    ),
                 ):
                     prompt = await _capture_system_prompt(handler, _session(), "what is the status")
 
@@ -163,7 +177,7 @@ class TestL4RendersInPromptViaTheBinding:
             with patch(
                 "chat_workflow.session_work_item.SessionWorkItemService.get_binding",
                 new_callable=AsyncMock,
-                return_value=(None, None),
+                return_value=SessionWorkItemBinding(),
             ):
                 prompt = await _capture_system_prompt(handler, _session(), "what is the status")
 

--- a/autobot-backend/chat_workflow/tiered_context_prompt_test.py
+++ b/autobot-backend/chat_workflow/tiered_context_prompt_test.py
@@ -142,9 +142,7 @@ class TestL4RendersInPromptViaTheBinding:
             with patch(
                 "chat_workflow.session_work_item.SessionWorkItemService.get_binding",
                 new_callable=AsyncMock,
-                return_value=SessionWorkItemBinding(
-                    "33333333-3333-3333-3333-333333333333", "company-a", "user-a"
-                ),
+                return_value=SessionWorkItemBinding("33333333-3333-3333-3333-333333333333", "company-a", "user-a"),
             ):
                 # #13729: the per-turn membership re-check has its own tests in
                 # session_work_item_test.py; here it is a seam so this test stays

--- a/autobot-backend/chat_workflow/tiered_context_sources.py
+++ b/autobot-backend/chat_workflow/tiered_context_sources.py
@@ -71,13 +71,81 @@ async def resolve_goal_ancestry(session_id: str) -> list | None:
     try:
         from chat_workflow.session_work_item import SessionWorkItemService
 
-        work_item_id, company_id = await SessionWorkItemService().get_binding(session_id)
+        binding = await SessionWorkItemService().get_binding(session_id)
+        work_item_id, company_id = binding.work_item_id, binding.company_id
         if not work_item_id or not company_id:
+            return None
+        # Reject a malformed id before the membership round-trip (#13729): a
+        # client-shaped mistake should not cost a query.
+        if not _is_uuid(work_item_id):
+            logger.debug("Ignoring malformed work_item_id for goal ancestry: %r", work_item_id)
+            return None
+        if not await _authorisation_still_holds(company_id, binding.user_id):
             return None
         return await _query_goal_ancestry(str(work_item_id), company_id)
     except Exception as exc:
         logger.warning("Goal ancestry lookup failed for work item %s: %s", work_item_id, exc)
         return None
+
+
+def _is_uuid(value: str) -> bool:
+    """True when *value* parses as a UUID."""
+    try:
+        uuid.UUID(str(value))
+        return True
+    except (ValueError, TypeError):
+        return False
+
+
+async def _authorisation_still_holds(company_id: str, user_id: str | None) -> bool:
+    """Re-check the bound user's access to *company_id* at resolve time (#13729).
+
+    The binding recorded a decision the bind endpoint made, and nothing expired
+    it before ``SESSION_WORK_ITEM_TTL_SECONDS`` — so a user removed from the
+    company kept receiving its goal chain for up to a day. This closes that
+    window at the cost of one indexed membership lookup, and only on sessions
+    that actually have a binding.
+
+    Bindings written before #13729 carry no ``user_id``. They are refused rather
+    than grandfathered: they expire within the TTL, and the alternative is to
+    keep honouring exactly the unverifiable claim this fixes.
+
+    A platform admin may bind a company they are not a member of, so the current
+    admin flag is checked too — read from the database, never from the stored
+    binding, so losing admin takes effect on the next turn as well.
+    """
+    if not user_id:
+        logger.debug("Goal ancestry: binding predates user recording (#13729); treating as unauthorised")
+        return False
+
+    from llc.services.membership_service import MembershipService
+    from user_management.database import get_async_session_factory
+
+    factory = get_async_session_factory()
+    async with factory() as session:
+        if await MembershipService().is_member(session, company_id, user_id):
+            return True
+        if await _is_platform_admin(session, user_id):
+            return True
+
+    logger.info("Goal ancestry: user %s is no longer scoped to company %s; chain withheld", user_id, company_id)
+    return False
+
+
+async def _is_platform_admin(session, user_id: str) -> bool:
+    """Return the user's *current* platform-admin flag (#13729)."""
+    import uuid as _uuid  # noqa: PLC0415
+
+    from sqlalchemy import select  # noqa: PLC0415
+
+    from user_management.models import User  # noqa: PLC0415
+
+    try:
+        parsed = _uuid.UUID(str(user_id))
+    except (ValueError, TypeError):
+        return False
+    result = await session.execute(select(User.is_platform_admin).where(User.id == parsed))
+    return bool(result.scalar_one_or_none())
 
 
 async def _query_goal_ancestry(work_item_id: str, company_id: str | None) -> list | None:
@@ -86,11 +154,10 @@ async def _query_goal_ancestry(work_item_id: str, company_id: str | None) -> lis
     Split out to keep the LLC imports lazy (the stack is optional at import
     time) and both functions inside the 30-line limit.
     """
-    try:
-        uuid.UUID(work_item_id)
-    except (ValueError, TypeError):
+    if not _is_uuid(work_item_id):
         # A malformed id is a client-shaped problem, not a system failure —
-        # debug, not a per-turn warning.
+        # debug, not a per-turn warning. Also checked by the caller, before the
+        # membership round-trip; kept here for any direct caller.
         logger.debug("Ignoring malformed work_item_id for goal ancestry: %r", work_item_id)
         return None
 


### PR DESCRIPTION
Closes #13729

## Thinking Path

Option 1 from the issue — re-check membership at resolve time — with one thing the issue's framing
did not cover: **`resolve_goal_ancestry(session_id)` has no user.** The binding stored
`(work_item_id, company_id)`, and the call site passes only a session id, so there was nothing to
check membership *of*.

Threading a user through `llm_handler` → `TieredContextBuilder` → the resolver would touch three
layers to carry a value the bind endpoint already holds. Instead the binding records **who** was
authorised alongside **what** — the same reasoning that put `company_id` there in #13704, applied one
field further. The resolve path then re-checks that specific user's membership, and no signature
above it changes.

`MembershipService.is_member` already exists, so no new mechanism. (The issue pointed at
`_check_org_membership` in `api/user_management/dependencies.py`; importing an API-layer private from
`chat_workflow` would be the wrong direction, and the LLC service is the canonical one.)

**Two cases the issue did not name, both of which would have made this wrong:**

1. **Platform admins.** `get_tenant_context` lets a platform admin bind a company they are not a
   member of. A membership-only check would silently kill L4 for them. The admin flag is therefore
   also checked — read from the **database**, never from the stored binding, so losing admin takes
   effect on the next turn too rather than reintroducing the same staleness for a smaller group.
2. **Pre-fix bindings.** Those carry no `user_id`. They are **refused**, not grandfathered: they
   expire within the TTL anyway, and grandfathering means continuing to honour exactly the
   unverifiable claim this fixes.

Ordering matters for cost: the malformed-id guard moved ahead of the membership lookup, so a
client-shaped mistake does not buy a DB round-trip. Unbound sessions — the common case — still cost
nothing, as before.

## What Changed

- `chat_workflow/session_work_item.py` — `SessionWorkItemBinding` NamedTuple (three fields);
  `set_work_item` takes and stores `user_id`. Named tuple rather than a plain 3-tuple so a missed
  two-value unpack fails loudly instead of binding the wrong name.
- `chat_workflow/tiered_context_sources.py` — `_authorisation_still_holds` (membership, then current
  platform-admin flag) gates the goal walk; `_is_uuid` shared by the caller and `_query_goal_ancestry`.
- `api/chat.py` — the bind endpoint records `ctx.user_id`.

## Verification

```
chat_workflow/ (whole package)      401 passed
```

The issue's AC 2 is `test_a_revoked_member_gets_no_chain_on_the_next_turn` — bind, revoke, resolve →
`None`, and `_query_goal_ancestry` asserted **not awaited**, so the walk does not run and then get
discarded. Alongside it: a current member still gets the chain, a platform admin without membership
keeps access, a pre-#13729 binding is refused, and a malformed id costs no membership query.

**Mutation check** — deleting the two-line re-check from `resolve_goal_ancestry`:

```
FAILED TestBindingAuthorisationIsRecheckedPerTurn::test_a_revoked_member_gets_no_chain_on_the_next_turn
FAILED TestBindingAuthorisationIsRecheckedPerTurn::test_a_binding_written_before_13729_is_refused
2 failed, 13 passed
```

Existing tests were updated for the new binding shape rather than worked around. One of them
(`tiered_context_prompt_test`) used `"wi-1"` as a work-item id; that no longer survives the
malformed-id guard now running earlier, so it uses a real UUID — worth noting because it means the
guard is live on the real prompt path, not just in unit isolation.

AC 3 does not apply: the TTL is unchanged, because option 1 was implemented rather than option 3.

## Model Used

Claude Opus 5 (1M context)
