### PR TITLE
ci(docker): give npm ci retry headroom in both frontend build stages (#13783)

### DIFF
--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -5,8 +5,25 @@
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
 
+# #13783: npm's defaults give a registry reset one short retry, and a bare
+# `npm ci` failing takes the whole image build — and with it hardened-smoke-test
+# — down on PRs that touch no frontend file. The runner is a singleton, so
+# several PRs building at once is exactly when the resets appear. Declared once
+# as ARGs and passed into both builder stages via ENV, rather than repeated as
+# `npm config set` per stage.
+ARG NPM_FETCH_RETRIES=5
+ARG NPM_FETCH_RETRY_MINTIMEOUT=20000
+ARG NPM_FETCH_RETRY_MAXTIMEOUT=120000
+
 # ---- Build main frontend ----
 FROM node:20-bookworm-slim AS builder
+
+ARG NPM_FETCH_RETRIES
+ARG NPM_FETCH_RETRY_MINTIMEOUT
+ARG NPM_FETCH_RETRY_MAXTIMEOUT
+ENV NPM_CONFIG_FETCH_RETRIES=$NPM_FETCH_RETRIES \
+    NPM_CONFIG_FETCH_RETRY_MINTIMEOUT=$NPM_FETCH_RETRY_MINTIMEOUT \
+    NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT=$NPM_FETCH_RETRY_MAXTIMEOUT
 
 WORKDIR /app
 
@@ -35,6 +52,15 @@ RUN npm run build
 
 # ---- Build SLM frontend ----
 FROM node:20-bookworm-slim AS slm-builder
+
+# Same retry posture as the main builder (#13783) — a stage does not inherit
+# another stage's ENV, so the ARGs are re-declared rather than assumed.
+ARG NPM_FETCH_RETRIES
+ARG NPM_FETCH_RETRY_MINTIMEOUT
+ARG NPM_FETCH_RETRY_MAXTIMEOUT
+ENV NPM_CONFIG_FETCH_RETRIES=$NPM_FETCH_RETRIES \
+    NPM_CONFIG_FETCH_RETRY_MINTIMEOUT=$NPM_FETCH_RETRY_MINTIMEOUT \
+    NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT=$NPM_FETCH_RETRY_MAXTIMEOUT
 
 WORKDIR /app
 


### PR DESCRIPTION
Closes #13783

## Thinking Path

Found by a red `hardened-smoke-test` on PR #13772 — a backend-only change touching no frontend file.
The cause was `npm error code ECONNRESET` inside `RUN npm ci`, which fails the image build, which
fails the check. Re-running the job with no code change made it pass.

npm's default `fetch-retries` is **2**, verified rather than assumed:

```
$ npm config get fetch-retries
2
```

That is thin for a build that downloads the full dependency tree twice — once per builder stage —
on a **singleton** self-hosted runner where several PRs building at once is exactly the condition
that produces resets.

Two implementation choices worth stating:

- **ENV, not `npm config set`.** The issue suggested either. `npm config set` writes to `~/.npmrc` and
  would have to be repeated verbatim before each `npm ci`; the env form declares the values once as
  global `ARG`s and each stage opts in. The knobs are visible in one place, which is the issue's
  third acceptance criterion.
- **ARGs re-declared per stage.** A stage does not inherit another stage's `ENV`, and a global `ARG`
  is not in scope inside a stage until re-declared. Getting this wrong is silent: the build succeeds
  and the retries simply are not configured. That is what the structural check below exists to catch.

`docker/frontend/Dockerfile` is the only Dockerfile in the repo that runs `npm ci` — checked before
fixing just the one that failed:

```
$ grep -rn "RUN npm ci" --include=Dockerfile* .
docker/frontend/Dockerfile:21
docker/frontend/Dockerfile:52
```

## What Changed

- `docker/frontend/Dockerfile` — three global `ARG`s (`fetch-retries=5`, min 20s, max 120s),
  re-declared and exported as `NPM_CONFIG_*` in both the `builder` and `slm-builder` stages.

## Verification

The env-var names are the ones npm actually reads — the naming is a mechanical uppercase-and-prefix
transform that is easy to get subtly wrong, so it is checked rather than trusted:

```
$ npm config get fetch-retries
2
$ NPM_CONFIG_FETCH_RETRIES=5 npm config get fetch-retries
5
$ NPM_CONFIG_FETCH_RETRY_MINTIMEOUT=20000 npm config get fetch-retry-mintimeout
20000
$ NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT=120000 npm config get fetch-retry-maxtimeout
120000
```

`docker build --check` is unavailable in this environment (no Docker in the WSL distro), so the
per-stage scoping — the part that fails silently — was verified by parsing the Dockerfile and
asserting that every stage containing a `RUN npm ci` also carries all three `NPM_CONFIG_*` values:

```
global ARGs: ['NPM_FETCH_RETRIES', 'NPM_FETCH_RETRY_MINTIMEOUT', 'NPM_FETCH_RETRY_MAXTIMEOUT']
stage builder:     npm ci at line 38 -> OK
stage slm-builder: npm ci at line 78 -> OK
RESULT: every npm ci stage carries the retry env
```

The real proof is this PR's own `hardened-smoke-test`, which builds the modified Dockerfile.

## Model Used

Claude Opus 5 (1M context)
