### PR TITLE
fix(ansible): reference a requirements file that exists, and guard host patterns (#13744, #13745)

### DIFF
--- a/.github/workflows/ansible-file-references.yml
+++ b/.github/workflows/ansible-file-references.yml
@@ -43,7 +43,9 @@ jobs:
       # and dependency install live in one place rather than 21 copies.
       - uses: ./.github/actions/setup-python-ci
         with:
-          extra-packages: pytest
+          # pytest.ini sets --asyncio-mode=auto, so the plugin is required even
+          # though these tests are synchronous.
+          extra-packages: pytest pytest-asyncio
 
       - name: Check ansible plays reference files that exist
         run: python3 scripts/check_ansible_file_references.py

--- a/.github/workflows/ansible-file-references.yml
+++ b/.github/workflows/ansible-file-references.yml
@@ -43,9 +43,10 @@ jobs:
       # and dependency install live in one place rather than 21 copies.
       - uses: ./.github/actions/setup-python-ci
         with:
-          # pytest.ini sets --asyncio-mode=auto, so the plugin is required even
-          # though these tests are synchronous.
-          extra-packages: pytest pytest-asyncio
+          # pyyaml: the guard parses inventories. pytest-asyncio: pytest.ini sets
+          # --asyncio-mode=auto, so the plugin is required even though these
+          # tests are synchronous.
+          extra-packages: pyyaml pytest pytest-asyncio
 
       - name: Check ansible plays reference files that exist
         run: python3 scripts/check_ansible_file_references.py

--- a/.github/workflows/ansible-file-references.yml
+++ b/.github/workflows/ansible-file-references.yml
@@ -1,0 +1,52 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+#
+# Ansible repo-path reference guard (#13744).
+#
+# The deploy syncs the repository to /opt/autobot/src/, so a play referencing a
+# path under that prefix is referencing a repo path. `deploy-native-services.yml`
+# installed the NPU worker from /opt/autobot/src/docker/npu-worker/requirements.txt
+# — a directory that has never existed here — and nothing caught it, because a
+# wrong path in a play is only discovered by running the play on a host.
+#
+# This turns "the documented deploy command cannot work" into a failing check on
+# the PR that breaks it, rather than an error the next operator finds.
+#
+# Security: no untrusted event data is interpolated into run: commands.
+
+name: ansible-file-references
+
+on:
+  pull_request:
+    paths:
+      - '**/ansible/**/*.yml'
+      - '**/ansible/**/*.yaml'
+      - 'scripts/check_ansible_file_references.py'
+      - '.github/workflows/ansible-file-references.yml'
+  push:
+    branches: [Dev_new_gui]
+    paths:
+      - '**/ansible/**/*.yml'
+      - '**/ansible/**/*.yaml'
+      - 'scripts/check_ansible_file_references.py'
+
+permissions:
+  contents: read
+
+jobs:
+  ansible-file-references:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      # #13517: shared composite action, so the interpreter version, pip cache
+      # and dependency install live in one place rather than 21 copies.
+      - uses: ./.github/actions/setup-python-ci
+        with:
+          extra-packages: pytest
+
+      - name: Check ansible plays reference files that exist
+        run: python3 scripts/check_ansible_file_references.py
+
+      - name: Guard the guard
+        run: python3 -m pytest scripts/check_ansible_file_references_test.py -q

--- a/autobot-slm-backend/ansible/playbooks/deploy-native-services.yml
+++ b/autobot-slm-backend/ansible/playbooks/deploy-native-services.yml
@@ -367,9 +367,17 @@
         creates: /opt/autobot/venv/bin/activate
       become_user: autobot-service
 
+    # #13744: this read docker/npu-worker/requirements.txt, a path that has
+    # never existed in the repo, so the documented native NPU deploy
+    # (SERVICE_MANAGEMENT.md: `--tags npu`) could not install anything.
+    # autobot-npu-worker/ is the native source tree — the sibling under
+    # autobot-infrastructure/.../docker/ is the container recipe, and carries
+    # the whole web stack this play installs separately. The file's relative
+    # `-e ../autobot_shared` and `-c ../constraints/shared.txt` resolve because
+    # the task above syncs the full source tree to /opt/autobot/src/.
     - name: Install Python dependencies for NPU Worker
       pip:
-        requirements: /opt/autobot/src/docker/npu-worker/requirements.txt
+        requirements: /opt/autobot/src/autobot-npu-worker/requirements.txt
         virtualenv: /opt/autobot/venv
         virtualenv_python: python3.11
       become_user: autobot-service

--- a/scripts/check_ansible_file_references.py
+++ b/scripts/check_ansible_file_references.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
-"""Guard: Ansible plays only reference repo files that exist (#13744).
+"""Guard: Ansible plays reference files and host groups that exist (#13744, #13745).
 
 ``deploy-native-services.yml`` installed the NPU worker from
 ``/opt/autobot/src/docker/npu-worker/requirements.txt`` — a path that has never
@@ -17,12 +17,25 @@ without an inventory or a host. Anything else — templated values, host paths,
 role-relative lookups — is skipped rather than guessed at, because a guard that
 reports false positives gets switched off.
 
+A second failure mode shares the shape (#13745): a play whose ``hosts:`` pattern
+matches no group is **skipped silently** — the run reports ``ok=0 changed=0`` for
+that play and exits 0, which reads as success. A group defined by no inventory at
+all can only ever do nothing, so it is checked here too.
+
+Deliberately "at least one inventory", not "every inventory": five are shipped
+and they describe different topologies, so a play that legitimately has no target
+in one of them is not a defect. ``ansible.cfg`` configures no default inventory —
+every invocation passes ``-i`` explicitly — so there is no single one to check
+against.
+
 Run from the repo root:  python3 scripts/check_ansible_file_references.py
 """
 
 import pathlib
 import re
 import sys
+
+import yaml
 
 # The deploy syncs the repo to this prefix, so what follows it is a repo path.
 _DEPLOYED_SRC_PREFIX = "/opt/autobot/src/"
@@ -35,6 +48,21 @@ _EXCLUDE_DIRS = (".worktrees", ".git", "node_modules", "__pycache__")
 _ASSIGNMENT = re.compile(
     r"^\s*(?P<key>" + "|".join(_FILE_KEYS) + r")\s*:\s*(?P<value>\S+)\s*$",
 )
+
+_HOSTS = re.compile(r"^\s*hosts:\s*(?P<pattern>\S+)\s*$")
+
+# Patterns Ansible resolves without an inventory group of that name.
+_IMPLICIT_GROUPS = frozenset({"all", "localhost", "*", "127.0.0.1"})
+
+# Patterns supplied by the caller at run time rather than by a shipped
+# inventory. Each entry needs a tracking issue: a bare name here is
+# indistinguishable from the silent-skip bug this guard exists to catch, so the
+# allowlist records *why* it is not one rather than hiding it.
+#   `target` — slm-service-control.yml / slm-service-logs.yml, the SLM remote
+#   service-control path. No shipped inventory defines it and no in-repo caller
+#   passes one; whether it should become `{{ target }}` (loud failure) is a
+#   remote-execution decision tracked in #13786.
+_RUNTIME_SUPPLIED_PATTERNS = frozenset({"target"})
 
 
 def _ansible_files(root: pathlib.Path) -> list[pathlib.Path]:
@@ -72,30 +100,148 @@ def _referenced_repo_paths(text: str) -> list[tuple[int, str, str]]:
     return hits
 
 
+def _groups_in(node, acc: set) -> None:
+    """Collect every group **and host** name declared in a parsed inventory.
+
+    ``hosts:`` in a play accepts a host name as readily as a group name, so
+    collecting only groups reports every host-targeted play as broken. A guard
+    that cries wolf gets switched off, so both are gathered.
+    """
+    if not isinstance(node, dict):
+        return
+    for key, value in node.items():
+        if key == "vars":
+            continue
+        if key == "hosts":
+            if isinstance(value, dict):
+                acc.update(value.keys())
+            continue
+        if key == "children":
+            _groups_in(value, acc)
+            continue
+        acc.add(key)
+        if isinstance(value, dict):
+            _groups_in(value, acc)
+
+
+def _inventory_paths(root: pathlib.Path) -> list[pathlib.Path]:
+    """Every shipped inventory: the ``inventory/`` tree and ``inventory*`` files.
+
+    Both forms are in use — ``ansible/inventory/hosts.yml`` and a sibling
+    ``ansible/inventory.yml`` — and missing either makes plays that target the
+    other look broken.
+    """
+    seen = {}
+    for pattern in ("inventory/*.y*ml", "inventory*.y*ml", "inventory*.ini"):
+        for path in root.rglob(pattern):
+            rel_parts = path.relative_to(root).parts
+            if any(part in _EXCLUDE_DIRS for part in rel_parts):
+                continue
+            seen[path] = None
+    return sorted(seen)
+
+
+def _ini_groups(text: str) -> set:
+    """Group names from an INI-format inventory (``[group]`` headers)."""
+    return {
+        m.group(1).split(":")[0]
+        for line in text.splitlines()
+        if (m := re.match(r"^\s*\[([^\]]+)\]\s*$", line))
+    }
+
+
+def inventory_groups(root: pathlib.Path) -> dict[str, set]:
+    """Return ``{inventory path: {group and host names}}`` for every inventory."""
+    found = {}
+    for path in _inventory_paths(root):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        acc: set = set()
+        if path.suffix == ".ini":
+            acc = _ini_groups(text)
+        else:
+            try:
+                parsed = yaml.safe_load(text)
+            except yaml.YAMLError:
+                # An inventory this script cannot parse is not evidence of a bad
+                # play; skip it rather than reporting every pattern as unresolved.
+                continue
+            _groups_in(parsed, acc)
+        if acc:
+            found[str(path.relative_to(root))] = acc
+    return found
+
+
+def _host_patterns(text: str) -> list[tuple[int, str]]:
+    """Return ``(line_no, pattern)`` for each play's ``hosts:`` declaration."""
+    return [
+        (line_no, match.group("pattern").strip("\"'"))
+        for line_no, line in enumerate(text.splitlines(), 1)
+        if (match := _HOSTS.match(line))
+    ]
+
+
+def _unresolvable_hosts(text: str, all_groups: set) -> list[tuple[int, str]]:
+    """Host patterns that no shipped inventory defines."""
+    unresolved = []
+    for line_no, pattern in _host_patterns(text):
+        if pattern in _IMPLICIT_GROUPS or "{{" in pattern or "$" in pattern:
+            continue
+        if pattern in _RUNTIME_SUPPLIED_PATTERNS:
+            continue
+        # A pattern may be a union/intersection expression; every named part
+        # must come from somewhere.
+        names = [n for n in re.split(r"[:,&!]", pattern) if n and n not in _IMPLICIT_GROUPS]
+        if any(name not in all_groups for name in names):
+            unresolved.append((line_no, pattern))
+    return unresolved
+
+
 def main() -> int:
     """Report every deployed-src reference with no matching repo path."""
     root = pathlib.Path(".").resolve()
-    violations = []
-    checked = 0
+    inventories = inventory_groups(root)
+    all_groups = set().union(*inventories.values()) if inventories else set()
+
+    path_violations, host_violations = [], []
+    paths_checked = hosts_checked = 0
 
     for play in _ansible_files(root):
         try:
             text = play.read_text(encoding="utf-8")
         except OSError:
             continue
+        rel_play = play.relative_to(root)
         for line_no, key, rel in _referenced_repo_paths(text):
-            checked += 1
+            paths_checked += 1
             if not (root / rel).exists():
-                violations.append(f"{play.relative_to(root)}:{line_no}: {key} -> {rel} does not exist in the repo")
+                path_violations.append(f"{rel_play}:{line_no}: {key} -> {rel} does not exist in the repo")
+        hosts_checked += len(_host_patterns(text))
+        for line_no, pattern in _unresolvable_hosts(text, all_groups):
+            host_violations.append(f"{rel_play}:{line_no}: hosts: {pattern} — no inventory defines it")
 
-    if violations:
+    if path_violations:
         print("Ansible plays reference repo paths that do not exist:")
-        print("\n".join(f"  {v}" for v in violations))
+        print("\n".join(f"  {v}" for v in path_violations))
         print("\nThe deploy syncs the repo to /opt/autobot/src/, so each of these")
         print("resolves to a repo path. A wrong one fails on a host, not in CI.")
+
+    if host_violations:
+        print("Ansible plays target host groups no inventory defines:")
+        print("\n".join(f"  {v}" for v in host_violations))
+        print("\nA play whose pattern matches nothing is skipped silently —")
+        print("ok=0 changed=0, exit 0 — which reads as a successful deploy.")
+
+    if path_violations or host_violations:
         return 1
 
-    print(f"check_ansible_file_references: {checked} deployed-src reference(s) resolve.")
+    print(
+        f"check_ansible_file_references: {paths_checked} deployed-src reference(s) resolve; "
+        f"{hosts_checked} host pattern(s) resolve against {len(inventories)} inventor"
+        f"{'y' if len(inventories) == 1 else 'ies'}."
+    )
     return 0
 
 

--- a/scripts/check_ansible_file_references.py
+++ b/scripts/check_ansible_file_references.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Guard: Ansible plays only reference repo files that exist (#13744).
+
+``deploy-native-services.yml`` installed the NPU worker from
+``/opt/autobot/src/docker/npu-worker/requirements.txt`` — a path that has never
+existed in this repository. Nothing caught it, because a wrong path in a play is
+only discovered by running the play on a host, and the failure surfaces as a
+deploy error rather than as a broken reference.
+
+Scope is deliberately narrow: paths under the deployed source root
+(``/opt/autobot/src/...``) map one-to-one onto repo paths, so they can be checked
+without an inventory or a host. Anything else — templated values, host paths,
+role-relative lookups — is skipped rather than guessed at, because a guard that
+reports false positives gets switched off.
+
+Run from the repo root:  python3 scripts/check_ansible_file_references.py
+"""
+
+import pathlib
+import re
+import sys
+
+# The deploy syncs the repo to this prefix, so what follows it is a repo path.
+_DEPLOYED_SRC_PREFIX = "/opt/autobot/src/"
+
+# Keys whose value is a path to a file the repo is expected to provide.
+_FILE_KEYS = ("requirements", "src", "chdir", "creates")
+
+_EXCLUDE_DIRS = (".worktrees", ".git", "node_modules", "__pycache__")
+
+_ASSIGNMENT = re.compile(
+    r"^\s*(?P<key>" + "|".join(_FILE_KEYS) + r")\s*:\s*(?P<value>\S+)\s*$",
+)
+
+
+def _ansible_files(root: pathlib.Path) -> list[pathlib.Path]:
+    """Every playbook and task file, excluding worktrees and vendored trees.
+
+    Exclusions are matched against the path **relative to root**: the checkout
+    itself may live under a directory named in ``_EXCLUDE_DIRS`` (a git worktree
+    at ``.worktrees/<branch>/`` is the normal case here), and matching the
+    absolute path would silently exclude the entire repository.
+    """
+    found = []
+    for path in root.rglob("*.y*ml"):
+        rel_parts = path.relative_to(root).parts
+        if any(part in _EXCLUDE_DIRS for part in rel_parts):
+            continue
+        if "ansible" in rel_parts:
+            found.append(path)
+    return sorted(found)
+
+
+def _referenced_repo_paths(text: str) -> list[tuple[int, str, str]]:
+    """Return ``(line_no, key, repo_relative_path)`` for deployed-src references."""
+    hits = []
+    for line_no, line in enumerate(text.splitlines(), 1):
+        match = _ASSIGNMENT.match(line)
+        if not match:
+            continue
+        value = match.group("value").strip("\"'")
+        if not value.startswith(_DEPLOYED_SRC_PREFIX):
+            continue
+        # A templated segment cannot be resolved statically; skip rather than guess.
+        if "{{" in value or "$" in value:
+            continue
+        hits.append((line_no, match.group("key"), value[len(_DEPLOYED_SRC_PREFIX) :]))
+    return hits
+
+
+def main() -> int:
+    """Report every deployed-src reference with no matching repo path."""
+    root = pathlib.Path(".").resolve()
+    violations = []
+    checked = 0
+
+    for play in _ansible_files(root):
+        try:
+            text = play.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        for line_no, key, rel in _referenced_repo_paths(text):
+            checked += 1
+            if not (root / rel).exists():
+                violations.append(f"{play.relative_to(root)}:{line_no}: {key} -> {rel} does not exist in the repo")
+
+    if violations:
+        print("Ansible plays reference repo paths that do not exist:")
+        print("\n".join(f"  {v}" for v in violations))
+        print("\nThe deploy syncs the repo to /opt/autobot/src/, so each of these")
+        print("resolves to a repo path. A wrong one fails on a host, not in CI.")
+        return 1
+
+    print(f"check_ansible_file_references: {checked} deployed-src reference(s) resolve.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_ansible_file_references_test.py
+++ b/scripts/check_ansible_file_references_test.py
@@ -230,3 +230,43 @@ def test_deploy_native_services_resolves_everywhere_it_needs_to():
     unresolved = guard._unresolvable_hosts(play.read_text(encoding="utf-8"), all_groups)
 
     assert unresolved == [], f"deploy-native-services targets undefined groups: {unresolved}"
+
+
+# ------------------------------------------------ the job that runs the guard
+
+
+def test_the_workflow_installs_every_third_party_import_the_guard_needs():
+    """CI must not be the thing that discovers a missing dependency.
+
+    This job went red twice for exactly that: once for `pytest-asyncio`
+    (pytest.ini sets --asyncio-mode=auto) and once for `pyyaml` (the guard parses
+    inventories). Both were a full CI round-trip to learn something checkable here.
+    """
+    import ast  # noqa: PLC0415
+
+    repo_root = pathlib.Path(__file__).resolve().parents[1]
+    workflow = repo_root / ".github/workflows/ansible-file-references.yml"
+    if not workflow.exists():  # pragma: no cover - repo layout guard
+        pytest.skip("workflow not present")
+
+    declared = set()
+    for line in workflow.read_text(encoding="utf-8").splitlines():
+        if "extra-packages:" in line:
+            declared.update(line.split("extra-packages:", 1)[1].split())
+
+    stdlib = set(sys.stdlib_module_names)
+    imported = set()
+    for source in (_SCRIPT, pathlib.Path(__file__)):
+        for node in ast.walk(ast.parse(source.read_text(encoding="utf-8"))):
+            if isinstance(node, ast.Import):
+                imported.update(alias.name.split(".")[0] for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+                imported.add(node.module.split(".")[0])
+
+    # Distribution names differ from import names for some packages.
+    dist_for = {"yaml": "pyyaml", "pytest": "pytest"}
+    local = {_SCRIPT.stem}
+    third_party = {m for m in imported - stdlib - local if not m.startswith("_")}
+
+    missing = {m for m in third_party if dist_for.get(m, m) not in declared}
+    assert not missing, f"the workflow does not install: {sorted(missing)}"

--- a/scripts/check_ansible_file_references_test.py
+++ b/scripts/check_ansible_file_references_test.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for the Ansible repo-path reference guard (#13744).
+
+The bug this guards against — a play installing from
+``/opt/autobot/src/docker/npu-worker/requirements.txt``, which never existed —
+survived because a wrong path in a play only fails on a host. A guard for it is
+worth nothing unless it can actually fail, so these tests assert both directions
+and the discovery step, which is where the first draft silently checked nothing.
+"""
+
+import pathlib
+import subprocess
+import sys
+
+import pytest
+
+_SCRIPT = pathlib.Path(__file__).parent / "check_ansible_file_references.py"
+sys.path.insert(0, str(_SCRIPT.parent))
+
+import check_ansible_file_references as guard  # noqa: E402
+
+
+def _play(tmp_path: pathlib.Path, body: str) -> pathlib.Path:
+    """Write a play at a realistic ansible/ location under *tmp_path*."""
+    play_dir = tmp_path / "component" / "ansible" / "playbooks"
+    play_dir.mkdir(parents=True)
+    path = play_dir / "deploy.yml"
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+# ----------------------------------------------------------------- discovery
+
+
+def test_a_checkout_inside_an_excluded_directory_is_still_scanned(tmp_path):
+    """The repo may live at .worktrees/<branch>/ — exclusions are relative.
+
+    Matching ``_EXCLUDE_DIRS`` against the absolute path excluded the whole
+    repository and made the guard report "0 references" while passing.
+    """
+    root = tmp_path / ".worktrees" / "issue-1"
+    _play(root, "- hosts: all\n")
+
+    assert guard._ansible_files(root), "the guard scanned nothing from inside a worktree"
+
+
+def test_vendored_trees_are_still_skipped(tmp_path):
+    _play(tmp_path / "node_modules" / "pkg", "- hosts: all\n")
+
+    assert guard._ansible_files(tmp_path) == []
+
+
+def test_only_ansible_paths_are_scanned(tmp_path):
+    other = tmp_path / "compose"
+    other.mkdir()
+    (other / "docker-compose.yml").write_text("services: {}\n", encoding="utf-8")
+
+    assert guard._ansible_files(tmp_path) == []
+
+
+# ---------------------------------------------------------------- extraction
+
+
+def test_a_deployed_src_reference_is_extracted():
+    text = "    - pip:\n        requirements: /opt/autobot/src/autobot-npu-worker/requirements.txt\n"
+
+    assert guard._referenced_repo_paths(text) == [(2, "requirements", "autobot-npu-worker/requirements.txt")]
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "        requirements: /etc/somewhere/else/requirements.txt",
+        "        src: {{ project_root }}/requirements.txt",
+        "        src: ${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}/",
+    ],
+)
+def test_paths_that_cannot_be_resolved_statically_are_skipped(line):
+    """A guard that reports false positives gets switched off."""
+    assert guard._referenced_repo_paths(line + "\n") == []
+
+
+# ------------------------------------------------------------- end-to-end
+
+
+def _run(cwd: pathlib.Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT)],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_a_missing_referenced_file_fails(tmp_path):
+    _play(
+        tmp_path,
+        "- hosts: all\n  tasks:\n    - pip:\n        requirements: /opt/autobot/src/docker/npu-worker/requirements.txt\n",
+    )
+
+    result = _run(tmp_path)
+
+    assert result.returncode == 1
+    assert "docker/npu-worker/requirements.txt" in result.stdout
+
+
+def test_a_present_referenced_file_passes(tmp_path):
+    (tmp_path / "autobot-npu-worker").mkdir()
+    (tmp_path / "autobot-npu-worker" / "requirements.txt").write_text("numpy\n", encoding="utf-8")
+    _play(
+        tmp_path,
+        "- hosts: all\n  tasks:\n    - pip:\n        requirements: /opt/autobot/src/autobot-npu-worker/requirements.txt\n",
+    )
+
+    result = _run(tmp_path)
+
+    assert result.returncode == 0, result.stdout
+    assert "1 deployed-src reference(s) resolve" in result.stdout
+
+
+def test_the_real_repository_passes():
+    """The guard must be green on the tree it ships with."""
+    repo_root = pathlib.Path(__file__).resolve().parents[1]
+    result = _run(repo_root)
+
+    assert result.returncode == 0, result.stdout
+    # And it must be checking something — "0 references" would be a guard that cannot fail.
+    assert "0 deployed-src reference(s)" not in result.stdout

--- a/scripts/check_ansible_file_references_test.py
+++ b/scripts/check_ansible_file_references_test.py
@@ -131,3 +131,102 @@ def test_the_real_repository_passes():
     assert result.returncode == 0, result.stdout
     # And it must be checking something — "0 references" would be a guard that cannot fail.
     assert "0 deployed-src reference(s)" not in result.stdout
+
+
+# ------------------------------------------------- host patterns (#13745)
+
+
+def _inventory(tmp_path: pathlib.Path, body: str, name: str = "hosts.yml") -> None:
+    inv = tmp_path / "component" / "ansible" / "inventory"
+    inv.mkdir(parents=True, exist_ok=True)
+    (inv / name).write_text(body, encoding="utf-8")
+
+
+def test_a_group_no_inventory_defines_is_reported(tmp_path):
+    """A play targeting nothing is skipped silently — ok=0, exit 0, reads as success."""
+    _inventory(tmp_path, "all:\n  children:\n    frontend:\n      hosts:\n        web-1: {}\n")
+    _play(tmp_path, "- name: Deploy\n  hosts: browser\n  tasks: []\n")
+
+    result = _run(tmp_path)
+
+    assert result.returncode == 1
+    assert "hosts: browser" in result.stdout
+
+
+def test_a_group_defined_by_any_inventory_resolves(tmp_path):
+    """Several inventories ship, describing different topologies.
+
+    A play with no target in one of them is not a defect, so the rule is
+    "at least one", not "every".
+    """
+    _inventory(tmp_path, "all:\n  children:\n    frontend:\n      hosts:\n        web-1: {}\n")
+    _inventory(tmp_path, "all:\n  children:\n    browser:\n      hosts:\n        br-1: {}\n", name="production.yml")
+    _play(tmp_path, "- name: Deploy\n  hosts: browser\n  tasks: []\n")
+
+    assert _run(tmp_path).returncode == 0
+
+
+def test_an_alias_group_resolves(tmp_path):
+    """#2515 aliases exist so production.yml's names resolve in hosts.yml.
+
+    #13745 read only the `children:` block and reported these as undefined.
+    """
+    _inventory(
+        tmp_path,
+        "all:\n  children:\n    npu_workers:\n      hosts:\n        npu-1: {}\n\nnpu:\n  children:\n    npu_workers:\n",
+    )
+    _play(tmp_path, "- name: Deploy\n  hosts: npu\n  tasks: []\n")
+
+    assert _run(tmp_path).returncode == 0
+
+
+def test_a_host_name_is_a_valid_target(tmp_path):
+    """`hosts:` accepts a host as readily as a group.
+
+    Collecting only groups reported 13 host-targeted plays as broken — a guard
+    that cries wolf gets switched off.
+    """
+    _inventory(tmp_path, "all:\n  children:\n    backend:\n      hosts:\n        autobot-backend: {}\n")
+    _play(tmp_path, "- name: Diagnose\n  hosts: autobot-backend\n  tasks: []\n")
+
+    assert _run(tmp_path).returncode == 0
+
+
+def test_a_sibling_inventory_file_is_read(tmp_path):
+    """Both `ansible/inventory/hosts.yml` and `ansible/inventory.yml` are in use."""
+    ansible_dir = tmp_path / "component" / "ansible"
+    ansible_dir.mkdir(parents=True)
+    (ansible_dir / "inventory.yml").write_text(
+        "all:\n  children:\n    autobot:\n      hosts:\n        node-1: {}\n", encoding="utf-8"
+    )
+    _play(tmp_path, "- name: Logging\n  hosts: autobot\n  tasks: []\n")
+
+    assert _run(tmp_path).returncode == 0
+
+
+@pytest.mark.parametrize("pattern", ["all", "localhost", "{{ target_group }}", "$SOME_VAR"])
+def test_patterns_needing_no_inventory_group_are_skipped(pattern, tmp_path):
+    _inventory(tmp_path, "all:\n  children:\n    frontend:\n      hosts:\n        web-1: {}\n")
+    _play(tmp_path, f"- name: Play\n  hosts: {pattern}\n  tasks: []\n")
+
+    assert _run(tmp_path).returncode == 0
+
+
+def test_the_allowlist_is_documented_with_a_tracking_issue():
+    """An unexplained allowlist entry is indistinguishable from the bug it hides."""
+    source = _SCRIPT.read_text(encoding="utf-8")
+    block = source.split("_RUNTIME_SUPPLIED_PATTERNS")[0]
+    assert "#13786" in block, "each allowlisted pattern needs a tracking issue beside it"
+
+
+def test_deploy_native_services_resolves_everywhere_it_needs_to():
+    """#13745's own example: `npu` and `aiml` do resolve, via the #2515 aliases."""
+    repo_root = pathlib.Path(__file__).resolve().parents[1]
+    play = repo_root / "autobot-slm-backend/ansible/playbooks/deploy-native-services.yml"
+    if not play.exists():  # pragma: no cover - repo layout guard
+        pytest.skip("playbook not present")
+
+    all_groups = set().union(*guard.inventory_groups(repo_root).values())
+    unresolved = guard._unresolvable_hosts(play.read_text(encoding="utf-8"), all_groups)
+
+    assert unresolved == [], f"deploy-native-services targets undefined groups: {unresolved}"


### PR DESCRIPTION
Closes #13744, #13745

## Thinking Path

The issue asked which of the two candidate requirements files is canonical and suggested the role
(`roles/npu-worker`) as the reference. The role turns out not to answer it — it installs an **inline
package list**, not a requirements file:

```yaml
- name: Install OpenVINO and dependencies
  ansible.builtin.pip:
    name: [openvino>=2024.0, openvino-dev, numpy, pillow, transformers, optimum[openvino]]
```

So the choice is between the two files on their own merits. `autobot-npu-worker/requirements.txt` is
the **native** source tree — minimal, exactly the NPU surface (`openvino`, `torch`, `numpy`,
`-e ../autobot_shared`). The sibling under `autobot-infrastructure/.../docker/` is the **container**
recipe and carries the whole web stack (fastapi, uvicorn, redis, pytest) that this play installs
separately a few tasks later. A play named `deploy-native-services.yml` takes the native one.

Its relative directives resolve on the host because the preceding task syncs the whole repo:
`/opt/autobot/src/autobot-npu-worker/requirements.txt` → `../autobot_shared` is
`/opt/autobot/src/autobot_shared`, `../constraints/shared.txt` is
`/opt/autobot/src/constraints/shared.txt`. Both land.

**The guard is the more valuable half.** A wrong path in a play is only discovered by running the
play on a host, so it fails as a deploy error rather than a broken reference. The check exploits the
one thing that makes this statically decidable: the deploy syncs the repo to `/opt/autobot/src/`, so
a path under that prefix **is** a repo path. Templated and host-absolute paths are skipped rather
than guessed at — a guard that reports false positives gets switched off.

## What Changed

- `autobot-slm-backend/ansible/playbooks/deploy-native-services.yml` — installs from
  `/opt/autobot/src/autobot-npu-worker/requirements.txt`.
- `scripts/check_ansible_file_references.py` + `..._test.py` — the guard and its tests.
- `.github/workflows/ansible-file-references.yml` — runs both, on any `ansible/**` yml change.

## Verification

**Deliberate failure** (the issue's AC 3) — restoring the original bogus path:

```
$ python3 scripts/check_ansible_file_references.py
Ansible plays reference repo paths that do not exist:
  autobot-slm-backend/ansible/playbooks/deploy-native-services.yml:380: requirements -> docker/npu-worker/requirements.txt does not exist in the repo
exit=1
```

and with the fix in place:

```
check_ansible_file_references: 1 deployed-src reference(s) resolve.
exit=0
```

```
scripts/check_ansible_file_references_test.py    10 passed
```

**The first draft of this guard was broken and passed.** It reported `0 deployed-src reference(s)
resolve` — green, and checking nothing. `_EXCLUDE_DIRS` was matched against the **absolute** path,
and this checkout lives at `.worktrees/issue-13744/`, so every file in the repository was excluded.
Exclusions are now matched relative to the root, and
`test_a_checkout_inside_an_excluded_directory_is_still_scanned` covers exactly that. The end-to-end
test also asserts the output does **not** say `0 deployed-src reference(s)`, so a future change that
silently stops discovering plays fails rather than passes.

Only one reference in the repo is statically resolvable today — the one this PR fixes. That is the
honest number, and the guard says it out loud on every run rather than reporting a bare "OK".

---

## #13745 — the same silent-failure class, and a correction

Folded in here because it is the same playbook, the same guard file and the same workflow; a separate
PR would conflict on all three.

**The issue's specific claim does not reproduce.** It reports `hosts: npu` and `hosts: aiml` as
undefined in `inventory/hosts.yml`. Both *are* defined — by the `#2515` cross-inventory alias block
at the bottom of that file, which the issue's table missed by reading only the `children:` section:

```yaml
# Cross-inventory aliases (#2515)
aiml:
  children:
    ai_stack:
npu:
  children:
    npu_workers:
```

Resolving every `hosts:` pattern in the playbook against all shipped inventories:

```
  line    8  hosts: all      -> RESOLVES in hosts-router, hosts, localhost, production, slm-nodes
  line   55  hosts: database -> RESOLVES in hosts-router, hosts, production, slm-nodes
  line  183  hosts: frontend -> RESOLVES in hosts-router, hosts, production, slm-nodes
  line  317  hosts: npu      -> RESOLVES in hosts-router, hosts, production, slm-nodes
  line  481  hosts: aiml     -> RESOLVES in hosts-router, hosts, production, slm-nodes
  line  666  hosts: browser  -> RESOLVES in production, slm-nodes
  line  770  hosts: all      -> RESOLVES in ... (all five)
```

So **AC 1 already held** and no playbook edit was needed. AC 2 and AC 3 are the real deliverable, and
they are the half that keeps holding: the guard now also resolves `hosts:` patterns, and
`test_deploy_native_services_resolves_everywhere_it_needs_to` pins this specific conclusion so a
future inventory edit that breaks it fails here rather than on a host.

The rule is **"at least one inventory"**, not "every". Five ship, describing different topologies
(`hosts.yml` has no browser node; `production.yml` does), and `ansible.cfg` configures no default —
every invocation passes `-i` explicitly. Requiring every inventory to cover every play would report
correct configurations as broken.

**Two rounds of false positives, both fixed rather than tolerated:**

- Collecting only *group* names reported 13 host-targeted plays (`hosts: autobot-backend`) as broken.
  `hosts:` accepts a host as readily as a group, so both are gathered now.
- Reading only `inventory/*.yml` missed the sibling `ansible/inventory.yml` and the INI inventory,
  which made `hosts: autobot` and `hosts: monitoring_vm` look undefined. Discovery now covers 8
  inventories; the count is printed on every run so a silent drop in coverage is visible.

**One genuine finding survived** — `slm-service-control.yml` and `slm-service-logs.yml` target a
`target` group no inventory defines and no in-repo caller supplies, so the documented restart command
restarts nothing and reports success. That is a remote-execution contract decision I cannot make
without seeing the caller, so it is filed as **#13786** and allowlisted with the issue number beside
it. `test_the_allowlist_is_documented_with_a_tracking_issue` asserts the reference stays there — an
unexplained allowlist entry is indistinguishable from the bug the guard exists to catch.

Final state:

```
check_ansible_file_references: 1 deployed-src reference(s) resolve; 216 host pattern(s) resolve against 8 inventories.
exit=0

scripts/check_ansible_file_references_test.py    21 passed
```

The earlier CI red on this PR was my own workflow step, not the guard: the repo's `pytest.ini` sets
`--asyncio-mode=auto`, and I had installed only `pytest`. `pytest-asyncio` is now in the job's
`extra-packages`.

## Model Used

Claude Opus 5 (1M context)
