### PR TITLE
fix(ansible): give the NPU worker its own venv and guard the shared one (#13746)

### DIFF
--- a/.github/workflows/ansible-role-facts-test.yml
+++ b/.github/workflows/ansible-role-facts-test.yml
@@ -27,6 +27,12 @@ on:
       - 'autobot-slm-backend/ansible/update-all-nodes.yml'
       - 'autobot-slm-backend/ansible/roles/*/tasks/clean.yml'
       - 'autobot-slm-backend/ansible/roles/_shared/tasks/**'
+      # #13746: the venv-producer guard reads every play and role task file,
+      # so it has to trigger on them — otherwise the check cannot fire on the
+      # change that breaks it.
+      - 'autobot-slm-backend/ansible/playbooks/**'
+      - 'autobot-slm-backend/ansible/roles/**'
+      - 'autobot-slm-backend/ansible/tests/**'
       - 'autobot-slm-backend/ansible/tests/**'
       - '.github/workflows/ansible-role-facts-test.yml'
   push:
@@ -42,6 +48,12 @@ on:
       - 'autobot-slm-backend/ansible/update-all-nodes.yml'
       - 'autobot-slm-backend/ansible/roles/*/tasks/clean.yml'
       - 'autobot-slm-backend/ansible/roles/_shared/tasks/**'
+      # #13746: the venv-producer guard reads every play and role task file,
+      # so it has to trigger on them — otherwise the check cannot fire on the
+      # change that breaks it.
+      - 'autobot-slm-backend/ansible/playbooks/**'
+      - 'autobot-slm-backend/ansible/roles/**'
+      - 'autobot-slm-backend/ansible/tests/**'
       - 'autobot-slm-backend/ansible/tests/**'
 
 jobs:
@@ -74,6 +86,14 @@ jobs:
         working-directory: autobot-slm-backend/ansible
         run: |
           python3 tests/check_role_facts_synced.py
+
+      # #13746: three producers built /opt/autobot/venv with two interpreters.
+      # Co-location puts them on one host, and the loser's site-packages
+      # survives — a native ImportError at startup, never a deploy error.
+      - name: Check no venv path has two interpreters
+        working-directory: autobot-slm-backend/ansible
+        run: |
+          python3 tests/check_venv_producers.py
 
       - name: "Run clean.yml include_tasks loops test (#7058)"
         working-directory: autobot-slm-backend/ansible

--- a/autobot-slm-backend/ansible/playbooks/deploy-native-services.yml
+++ b/autobot-slm-backend/ansible/playbooks/deploy-native-services.yml
@@ -317,6 +317,11 @@
   hosts: npu
   become: true
 
+  vars:
+    # Matches roles/npu-worker's npu_install_dir (#13746) so the role-based and
+    # playbook-based NPU paths build the same venv rather than two.
+    npu_venv: /opt/autobot/autobot-npu-worker/venv
+
   tasks:
     # Python 3.11 pinned: OpenVINO/NPU runtime has no 3.14 wheels (do not bump with the rest of the fleet)
     - name: Install Python dependencies for NPU Worker
@@ -361,10 +366,26 @@
         group: autobot-service
         recurse: true
 
+    # #13746: this built /opt/autobot/venv — the same path the aiml play builds
+    # with python3.14 and roles/backend_services builds with python3.14. On a
+    # co-located host the last producer wins and rewrites pyvenv.cfg over
+    # site-packages built by the other interpreter; the failure is a native
+    # ImportError at worker startup, so the deploy still reports success.
+    # roles/npu-worker already uses its own {{ npu_install_dir }}/venv — this
+    # matches it. The 3.11 interpreter is deliberate and out of scope here;
+    # moving the NPU worker to 3.14 is #13747.
+    - name: Enforce the target interpreter on any existing NPU venv
+      ansible.builtin.include_role:
+        name: python314
+        tasks_from: ensure_venv_version
+      vars:
+        venv_path: "{{ npu_venv }}"
+        venv_python: python3.11
+
     - name: Create Python virtual environment for NPU Worker
-      shell: python3.11 -m venv /opt/autobot/venv
+      shell: "python3.11 -m venv {{ npu_venv }}"
       args:
-        creates: /opt/autobot/venv/bin/activate
+        creates: "{{ npu_venv }}/bin/activate"
       become_user: autobot-service
 
     # #13744: this read docker/npu-worker/requirements.txt, a path that has
@@ -378,7 +399,7 @@
     - name: Install Python dependencies for NPU Worker
       pip:
         requirements: /opt/autobot/src/autobot-npu-worker/requirements.txt
-        virtualenv: /opt/autobot/venv
+        virtualenv: "{{ npu_venv }}"
         virtualenv_python: python3.11
       become_user: autobot-service
       environment:
@@ -390,7 +411,7 @@
         name:
           - openvino[pytorch,tensorflow]
           - openvino-dev[pytorch,tensorflow]
-        virtualenv: /opt/autobot/venv
+        virtualenv: "{{ npu_venv }}"
       become_user: autobot-service
       environment:
         PIP_DEFAULT_TIMEOUT: "120"
@@ -440,11 +461,11 @@
           User=autobot-service
           Group=autobot-service
           WorkingDirectory=/opt/autobot/src
-          Environment="PATH=/opt/autobot/venv/bin:$PATH"
+          Environment="PATH={{ npu_venv }}/bin:$PATH"
           Environment="PYTHONPATH=/opt/autobot/src"
           Environment="OPENVINO_LOG_LEVEL=ERROR"
           Environment="NPU_LOG_LEVEL=INFO"
-          ExecStart=/opt/autobot/venv/bin/python -m src.npu_worker.main
+          ExecStart={{ npu_venv }}/bin/python -m src.npu_worker.main
           Restart=always
           RestartSec=10
           StandardOutput=syslog
@@ -513,12 +534,26 @@
         group: autobot-service
         recurse: true
 
+    # #13746: a bare shell with no guard re-pointed an existing venv of a
+    # different minor version, leaving site-packages built by the old
+    # interpreter in place. ensure_venv_version removes a mismatched venv so
+    # this rebuilds it, and `creates:` makes the matching case a no-op.
+    - name: Enforce the target interpreter on any existing venv
+      ansible.builtin.include_role:
+        name: python314
+        tasks_from: ensure_venv_version
+      vars:
+        venv_path: /opt/autobot/venv
+        venv_python: python3.14
+
     - name: Create Python virtual environment
       shell: |
         cd /opt/autobot
         python3.14 -m venv venv
         source venv/bin/activate
         pip install --upgrade pip setuptools wheel
+      args:
+        creates: /opt/autobot/venv/bin/activate
       become_user: autobot-service
       environment:
         PIP_DEFAULT_TIMEOUT: "120"

--- a/autobot-slm-backend/ansible/tests/check_venv_producers.py
+++ b/autobot-slm-backend/ansible/tests/check_venv_producers.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Guard: one venv path is never built by two interpreters (#13746).
+
+Three producers built ``/opt/autobot/venv`` — ``roles/backend_services`` and the
+``aiml`` play with python3.14, the ``npu`` play with python3.11. Co-location is a
+supported layout (the role-facts test inventory covers a single host carrying
+several roles), so those producers can land on one machine. The last one to run
+rewrites ``pyvenv.cfg`` while ``site-packages`` still holds binaries built by the
+other interpreter.
+
+That failure never surfaces as a deploy error. It surfaces as a native-extension
+``ImportError`` at service startup, long after Ansible reported success — which
+is why this is checked statically rather than left to a smoke test.
+
+Run from the ansible directory:  python3 tests/check_venv_producers.py
+"""
+
+import pathlib
+import re
+import sys
+
+_EXCLUDE_DIRS = (".worktrees", ".git", "node_modules", "__pycache__")
+
+# `python3.14 -m venv <path>`, in a shell: or command: line. The path runs to
+# end of line rather than \S+ because it is often a Jinja expression containing
+# spaces (`{{ npu_install_dir }}/venv`), which \S+ truncates to `{{`.
+_SHELL_VENV = re.compile(r"(?P<py>python3\.\d+)\s+-m\s+venv\s+(?P<path>.+?)\s*$")
+# A `cd` earlier in the same shell block makes the venv argument relative.
+_CD = re.compile(r"^\s*cd\s+(?P<dir>\S+)\s*$")
+# The pip module's explicit pairing of a venv with an interpreter.
+_VIRTUALENV = re.compile(r"^\s*virtualenv:\s*(?P<path>\S+)\s*$")
+_VIRTUALENV_PY = re.compile(r"^\s*virtualenv_python:\s*(?P<py>\S+)\s*$")
+
+
+def _clean(value: str) -> str:
+    """Normalise a venv path so the same target compares equal everywhere.
+
+    Quotes are stripped, and whitespace inside a Jinja expression is collapsed —
+    `{{ npu_install_dir }}/venv` and `{{npu_install_dir}}/venv` are one path.
+    """
+    value = value.strip().strip("\"'").strip()
+    return re.sub(r"\{\{\s*(.*?)\s*\}\}", r"{{\1}}", value)
+
+
+def _resolve(path: str, cwd: str | None) -> str:
+    """Make a venv argument absolute using the `cd` that preceded it."""
+    if path.startswith("/") or path.startswith("{{") or cwd is None:
+        return path
+    return f"{cwd.rstrip('/')}/{path}"
+
+
+def _ansible_yaml(root: pathlib.Path) -> list[pathlib.Path]:
+    return sorted(
+        p
+        for p in root.rglob("*.y*ml")
+        if not any(part in _EXCLUDE_DIRS for part in p.relative_to(root).parts)
+    )
+
+
+def venv_producers(root: pathlib.Path) -> dict[str, set]:
+    """Return ``{venv path: {(interpreter, "file:line")}}`` for every producer."""
+    producers: dict[str, set] = {}
+    for path in _ansible_yaml(root):
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except OSError:
+            continue
+        rel = path.relative_to(root)
+        pending_venv = None
+        cwd = None
+        for line_no, line in enumerate(lines, 1):
+            if match := _CD.match(line):
+                cwd = _clean(match.group("dir"))
+            if match := _SHELL_VENV.search(line):
+                venv = _resolve(_clean(match.group("path")), cwd)
+                producers.setdefault(venv, set()).add((match.group("py"), f"{rel}:{line_no}"))
+            if match := _VIRTUALENV.match(line):
+                pending_venv = (_clean(match.group("path")), line_no)
+            elif (match := _VIRTUALENV_PY.match(line)) and pending_venv:
+                venv, venv_line = pending_venv
+                producers.setdefault(venv, set()).add((_clean(match.group("py")), f"{rel}:{venv_line}"))
+                pending_venv = None
+    return producers
+
+
+def main() -> int:
+    """Fail when any venv path is claimed by more than one interpreter."""
+    root = pathlib.Path(".").resolve()
+    producers = venv_producers(root)
+
+    conflicts = {
+        venv: sites for venv, sites in producers.items() if len({py for py, _ in sites}) > 1
+    }
+
+    if conflicts:
+        print("A venv path is built by more than one interpreter:")
+        for venv, sites in sorted(conflicts.items()):
+            print(f"  {venv}")
+            for py, where in sorted(sites, key=lambda s: s[1]):
+                print(f"    {py:<12} {where}")
+        print("\nCo-location puts these on one host, where the last producer rewrites")
+        print("pyvenv.cfg over site-packages built by the other. The failure is a")
+        print("native ImportError at startup, not a deploy error.")
+        return 1
+
+    print(f"check_venv_producers: {len(producers)} venv path(s), each with a single interpreter.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/autobot-slm-backend/ansible/tests/check_venv_producers.py
+++ b/autobot-slm-backend/ansible/tests/check_venv_producers.py
@@ -55,9 +55,7 @@ def _resolve(path: str, cwd: str | None) -> str:
 
 def _ansible_yaml(root: pathlib.Path) -> list[pathlib.Path]:
     return sorted(
-        p
-        for p in root.rglob("*.y*ml")
-        if not any(part in _EXCLUDE_DIRS for part in p.relative_to(root).parts)
+        p for p in root.rglob("*.y*ml") if not any(part in _EXCLUDE_DIRS for part in p.relative_to(root).parts)
     )
 
 
@@ -92,9 +90,7 @@ def main() -> int:
     root = pathlib.Path(".").resolve()
     producers = venv_producers(root)
 
-    conflicts = {
-        venv: sites for venv, sites in producers.items() if len({py for py, _ in sites}) > 1
-    }
+    conflicts = {venv: sites for venv, sites in producers.items() if len({py for py, _ in sites}) > 1}
 
     if conflicts:
         print("A venv path is built by more than one interpreter:")


### PR DESCRIPTION
Closes #13746

## Thinking Path

The issue lists this as depending on #13745. That dependency is gone: #13745's premise turned out not
to reproduce — `npu` and `aiml` both resolve via the `#2515` alias block in `inventory/hosts.yml` — so
there was no group fix to wait on.

The fix follows what the repo already decided. `roles/npu-worker` uses `{{ npu_install_dir }}/venv`
(`/opt/autobot/autobot-npu-worker/venv`); only the playbook wrote the NPU venv into the shared path.
So the playbook moves to match the role rather than the reverse, and `/opt/autobot/venv` is left to
its 3.14 producers.

**The 3.11 interpreter stays.** Moving the NPU worker to 3.14 is #13747, with its own blockers. This
issue is about the *collision*, and once the NPU venv has its own path a 3.11 venv there and a 3.14
venv at the shared path are no longer in conflict.

Moving the venv means the systemd unit moves with it — `Environment="PATH=..."` and `ExecStart` both
referenced `/opt/autobot/venv/bin`, so a path change without them would have produced a unit pointing
at a venv nothing builds.

For the `aiml` play, `ensure_venv_version.yml` already exists in `roles/python314` and its module
comment describes this exact failure ("a venv built on the wrong Python survives forever because the
role's own `creates:`-guarded create task only checks existence, never version"). It is included
rather than reimplemented, and a `creates:` guard makes the matching case a no-op.

## What Changed

- `deploy-native-services.yml`
  - `npu_venv: /opt/autobot/autobot-npu-worker/venv` as a play var; the create task, both pip tasks,
    and the systemd unit's `PATH`/`ExecStart` all use it.
  - Both the `npu` and `aiml` plays include `python314/ensure_venv_version` before creating, so a venv
    of the wrong minor version is removed and rebuilt rather than silently re-pointed.
  - The `aiml` create task gains the `creates:` guard it never had.
- `autobot-slm-backend/ansible/tests/check_venv_producers.py` — a static guard.
- `.github/workflows/ansible-role-facts-test.yml` — runs it, **and** its `paths:` filters are widened.

## Verification

**AC 1 + AC 3.** The guard checks the property directly, so co-location needs no test fleet — which
host these plays land on is irrelevant if no path has two interpreters:

```
$ python3 tests/check_venv_producers.py
check_venv_producers: 9 venv path(s), each with a single interpreter.
exit=0
```

**Deliberate failure** — the same guard against the unfixed playbook:

```
A venv path is built by more than one interpreter:
  /opt/autobot/venv
    python3.11   playbooks/deploy-native-services.yml:365
    python3.11   playbooks/deploy-native-services.yml:373
    python3.14   playbooks/deploy-native-services.yml:511
    python3.14   roles/backend_services/tasks/main.yml:49
exit=1
```

That is the issue's table, reproduced by the check rather than by hand — and it found a fourth
producer the issue did not list (`deploy-native-services.yml:373`, the pip task's
`virtualenv_python`).

**AC 2** — `ensure_venv_version` removes a mismatched venv so the create task rebuilds it; a matching
venv is a `creates:` no-op. Neither path silently re-points.

Two things the first draft got wrong, both caught before pushing:

- The path regex used `\S+`, which truncates `{{ npu_install_dir }}/venv` to `{{` — collapsing eight
  unrelated venvs into one phantom conflict. Paths now run to end of line and Jinja whitespace is
  normalised.
- `cd /opt/autobot` followed by `python3.14 -m venv venv` recorded the path as `venv`. Relative
  arguments now resolve against the preceding `cd`.

The workflow's `paths:` filter did not include `playbooks/**` or `roles/**`, so the new step would
never have run on a change that breaks it — a check that cannot fire. Widened, and verified that each
file this PR touches now matches the filter.

## Model Used

Claude Opus 5 (1M context)
