### PR TITLE
chore(time): retire the Z-shim migration plan and its three remaining sites (#13755)

### DIFF
--- a/autobot-backend/integrations/microsoft365_integration.py
+++ b/autobot-backend/integrations/microsoft365_integration.py
@@ -81,9 +81,14 @@ def _validate_datetime_iso(value: str, name: str = "datetime") -> str:
         ValueError: If datetime format is invalid
     """
     try:
-        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        # #13755: no ``Z`` shim — fromisoformat parses the suffix natively on
+        # the 3.14 floor. ``TypeError`` replaces the ``AttributeError`` that a
+        # non-string used to raise from ``.replace()``, so it is caught here:
+        # this validates an OData filter value, and an uncaught exception would
+        # escape as a 500 rather than the intended ValueError.
+        dt = datetime.fromisoformat(value)
         return dt.isoformat()
-    except (ValueError, AttributeError) as exc:
+    except (ValueError, TypeError) as exc:
         raise ValueError(f"{name} must be valid ISO-8601 format") from exc
 
 

--- a/autobot-slm-backend/api/security.py
+++ b/autobot-slm-backend/api/security.py
@@ -849,9 +849,12 @@ def _parse_openssl_date(raw: str | None) -> datetime | None:
             continue
     # Last resort: try ISO-8601 for already-formatted inputs
     try:
-        dt = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        # #13755: no ``Z`` shim — parsed natively since 3.11. ``TypeError``
+        # joins the catch because it is what a non-string now raises, where
+        # ``.replace()`` used to raise AttributeError.
+        dt = datetime.fromisoformat(raw)
         return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
-    except ValueError:
+    except (ValueError, TypeError):
         return None
 
 

--- a/autobot_shared/time_utils.py
+++ b/autobot_shared/time_utils.py
@@ -19,15 +19,6 @@ Selection rule
     (e.g. ``2026-04-18T19:34:50.123456+00:00``).
     Round-trips via ``datetime.fromisoformat`` on Python 3.10+.
 
-``utc_timestamp_z()`` — **DEPRECATED — legacy compatibility only.**
-    Returns ``Z``-suffix ISO-8601 with second precision
-    (e.g. ``2026-04-18T19:34:50Z``). Retained ONLY because
-    ``services/workflow_versioning.py`` writes records in this format
-    historically. The audit confirmed zero internal parsers consume
-    those records, so a future migration of that producer is safe and
-    will allow this helper to be deleted.
-    **Do not call from new code.**
-
 Migration plan (#5169 part C)
 -----------------------------
 
@@ -35,12 +26,20 @@ Migration plan (#5169 part C)
 2. ✅ Audit + canonicalization decision (this PR)
 3. ✅ Migrated 57 direct ``datetime.utcnow().isoformat()`` sites
    to ``utc_timestamp()`` — tracked by #5178
-4. ⏳ Migrate ``workflow_versioning._utc_now`` → ``utc_timestamp``
-   (after step 3, requires either tolerant readers or one-time
-   data migration of stored Z records)
+4. ✅ Migrated ``workflow_versioning._utc_now`` → ``utc_timestamp``
+   (``services/workflow_versioning.py`` now imports it under that alias)
 5. ✅ Deleted ``utc_timestamp_z()`` (after step 4)
-6. ⏳ Python 3.11+ upgrade — drops the 9 ``.replace("Z", "+00:00")``
-   workaround sites since 3.11 ``fromisoformat`` accepts ``Z`` natively
+6. ✅ Python 3.11+ upgrade — the ``.replace("Z", "+00:00")`` shim sites are
+   gone. ``fromisoformat`` has accepted a ``Z`` suffix natively since 3.11
+   and the platform runs 3.14 in CI, both Dockerfiles and every Ansible
+   role. Closed by #13755; the step stayed marked pending for four minor
+   versions after its precondition cleared, which is how the recorded count of
+   nine drifted from the three that were actually left.
+
+This plan is complete. A step still marked pending after its blocker has
+cleared stops being a plan and becomes noise — if a future step is added here,
+retire it when it lands rather than leaving the next reader to re-derive the
+state, as #13755 had to.
 """
 
 from datetime import datetime, timezone
@@ -107,7 +106,7 @@ def parse_utc_iso(value: str) -> datetime:
 
     Accepts three forms:
     - ``+00:00`` offset (canonical, produced by :func:`utc_timestamp`)
-    - ``Z`` suffix (legacy, produced by :func:`utc_timestamp_z`)
+    - ``Z`` suffix (legacy producers, and external ones such as Notion and git)
     - **Naive** (no offset/suffix) — assumed UTC and tagged as such
 
     Use this in consumer code that compares parsed timestamps against
@@ -118,13 +117,17 @@ def parse_utc_iso(value: str) -> datetime:
 
     Raises ``ValueError`` on non-string or malformed input — matches the
     ``datetime.fromisoformat`` exception surface adopters expect (#5464).
-    Non-string inputs previously escaped as ``AttributeError`` from the
-    inner ``.replace()`` call, slipping past the common
-    ``except (ValueError, TypeError)`` adopter pattern.
+    Non-string inputs previously escaped as ``AttributeError`` from an inner
+    ``.replace()`` call, slipping past the common
+    ``except (ValueError, TypeError)`` adopter pattern. The explicit
+    ``isinstance`` check is what preserves that surface now that the
+    ``.replace()`` is gone (#13755).
     """
     if not isinstance(value, str):
         raise ValueError(f"parse_utc_iso: expected str, got {type(value).__name__}")
-    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    # #13755: no ``Z`` shim — fromisoformat has parsed the suffix natively
+    # since 3.11 and the platform floor is 3.14 (enforced at boot, #13738).
+    parsed = datetime.fromisoformat(value)
     if parsed.tzinfo is None:
         parsed = parsed.replace(tzinfo=timezone.utc)
     return parsed

--- a/autobot_shared/time_utils_test.py
+++ b/autobot_shared/time_utils_test.py
@@ -8,6 +8,8 @@ these tests pin the invariants so future format changes fail loudly.
 
 from datetime import datetime, timedelta, timezone
 
+import pytest
+
 from autobot_shared.time_utils import (
     now_utc,
     parse_utc_iso,
@@ -175,3 +177,72 @@ def test_parse_utc_iso_non_string_does_not_raise_attribute_error() -> None:
         )
     except ValueError:
         pass  # expected
+
+
+# --------------------------------------------- Z shim removal (#13755)
+
+
+class TestZSuffixParsesWithoutAShim:
+    """The ``.replace("Z", "+00:00")`` shim is gone (#13755).
+
+    ``fromisoformat`` has accepted a ``Z`` suffix natively since 3.11 and the
+    platform floor is 3.14, enforced at boot (#13738). These assert the
+    behaviour the shim used to provide still holds, so its removal is not taken
+    on trust.
+    """
+
+    @pytest.mark.parametrize(
+        ("raw", "expected_offset"),
+        [
+            ("2026-01-01T00:00:00Z", timezone.utc),
+            ("2026-01-01T00:00:00.123456Z", timezone.utc),
+            ("2026-01-01T00:00:00+00:00", timezone.utc),
+            ("2026-01-01T12:30:00+02:00", timedelta(hours=2)),
+        ],
+    )
+    def test_offset_bearing_input_keeps_its_offset(self, raw, expected_offset):
+        parsed = parse_utc_iso(raw)
+
+        assert parsed.tzinfo is not None
+        expected = expected_offset if isinstance(expected_offset, timezone) else timezone(expected_offset)
+        assert parsed.utcoffset() == expected.utcoffset(None)
+
+    def test_a_z_suffixed_instant_equals_its_offset_spelling(self):
+        """The two spellings must not drift now that neither is rewritten."""
+        assert parse_utc_iso("2026-01-01T00:00:00Z") == parse_utc_iso("2026-01-01T00:00:00+00:00")
+
+    def test_a_naive_timestamp_is_still_tagged_utc(self):
+        """Input without a suffix is unaffected by the shim's removal."""
+        parsed = parse_utc_iso("2026-01-01T00:00:00")
+
+        assert parsed.tzinfo is timezone.utc
+
+    def test_a_non_string_still_raises_value_error(self):
+        """The isinstance check is now the only thing preserving this surface.
+
+        The shim's ``.replace()`` used to raise AttributeError on a non-string;
+        without the explicit check, ``fromisoformat`` would raise TypeError and
+        slip past the ``except (ValueError, TypeError)`` adopters were told to
+        write in #5464.
+        """
+        for bad in (123, None, ["2026-01-01T00:00:00Z"]):
+            with pytest.raises(ValueError):
+                parse_utc_iso(bad)
+
+    def test_malformed_input_still_raises_value_error(self):
+        with pytest.raises(ValueError):
+            parse_utc_iso("not-a-timestamp")
+
+    def test_the_migration_plan_has_no_expired_pending_step(self):
+        """A ⏳ step whose blocker cleared is noise, and this one sat for four
+        minor versions. The docstring count also has to match the code."""
+        import autobot_shared.time_utils as module  # noqa: PLC0415
+
+        assert "⏳" not in module.__doc__, "a pending step survived its precondition"
+
+        # Only the API section is checked for the deleted helper: the migration
+        # plan legitimately records "Deleted utc_timestamp_z()" as history, and
+        # asserting on the whole docstring would forbid saying so.
+        api_section = module.__doc__.split("Migration plan")[0]
+        assert "utc_timestamp_z" not in api_section, "the API docs describe a helper that was deleted"
+        assert not hasattr(module, "utc_timestamp_z"), "the helper is documented as deleted but still exists"

--- a/docs/developer/audits/datetime-parsing-audit.md
+++ b/docs/developer/audits/datetime-parsing-audit.md
@@ -12,7 +12,7 @@
 | `2026-04-18T19:34:50Z` | `utc_timestamp_z()` | ❌ **raises `ValueError`** | 0 files (write-only producer) |
 | `2026-04-18T19:34:50` (naive) | `datetime.utcnow().isoformat()` | ✅ accepts (returns naive) | tracked separately by [#5178](https://github.com/mrveiss/AutoBot-AI/issues/5178) |
 
-**Decision (Part C)**: canonicalize on `+00:00`. Mark `utc_timestamp_z()` deprecated. Plan a Python 3.11 upgrade so the 9 explicit Z-shim sites become redundant. No on-disk data migration required — the only Z-suffix producer (`workflow_versioning`) has zero internal parsers.
+**Decision (Part C)**: canonicalize on `+00:00`. Mark `utc_timestamp_z()` deprecated. Plan a Python 3.11 upgrade so the 9 explicit Z-shim sites become redundant. **Resolved (#13755):** the platform runs 3.14, `utc_timestamp_z()` is deleted, and all Z-shim sites are gone. No on-disk data migration required — the only Z-suffix producer (`workflow_versioning`) has zero internal parsers.
 
 ---
 
@@ -62,7 +62,7 @@ tests/        3 files
 | [`api/analytics_conversation.py:40,52,495`](autobot-backend/api/analytics_conversation.py) | 40, 52, 495 | conversation record |
 | [`api/chat.py:140`](autobot-backend/api/chat.py) | 140 | chat record |
 
-**These 9 files are safe under either format.** The shim is defensive: it was added because external APIs (Notion, git, Redis writes from older AutoBot versions) sometimes emit `Z`. Once we canonicalize on `+00:00` AND upgrade to Python 3.11+, the shim becomes redundant but harmless.
+**These 9 files are safe under either format.** The shim was defensive: it was added because external APIs (Notion, git, Redis writes from older AutoBot versions) sometimes emit `Z`. Both preconditions are now met, so the shim was removed in #13755 — external `Z` producers are still tolerated, by `fromisoformat` itself rather than by a preprocessing step. Six of the nine sites had already gone by other routes; the remaining three were removed together.
 
 #### Class B — unguarded (assumes `+00:00` or naive)
 
@@ -142,7 +142,7 @@ This was changed in Python 3.11 — `fromisoformat` accepts both forms natively 
 Rationale:
 1. **No on-disk migration risk.** The only `Z`-format producer (`workflow_versioning`) has zero internal parsers. We can deprecate `utc_timestamp_z()` without touching any record.
 2. **86% of parsers are already only-`+00:00`-compatible.** They work today because all our internal producers emit `+00:00` or naive. Choosing `+00:00` aligns the rule with what the codebase already does.
-3. **The Z-shim is a workaround, not a feature.** 9 files preprocess `Z`→`+00:00` defensively because external APIs (Notion, git, etc.) emit `Z`. After Python 3.11 upgrade, the shim is redundant. Designing internal producers around an external-API quirk is the wrong direction.
+3. **The Z-shim was a workaround, not a feature.** 9 files preprocessed `Z`→`+00:00` defensively because external APIs (Notion, git, etc.) emit `Z`. The upgrade landed and the shim is gone (#13755). Designing internal producers around an external-API quirk is the wrong direction.
 4. **`+00:00` is what `datetime.now(timezone.utc).isoformat()` produces by default.** Picking the Python idiomatic form means new code is correct without thinking about format.
 
 ### Implementation plan
@@ -152,10 +152,10 @@ Rationale:
 | 1. Document selection rule (Part A) | ✅ Done — PR #5176 | — |
 | 2. Mark `utc_timestamp_z()` as `@deprecated` in docstring | ✅ This PR | — |
 | 3. Migrate 57 direct `datetime.utcnow().isoformat()` sites to `utc_timestamp()` | Tracked by [#5178](https://github.com/mrveiss/AutoBot-AI/issues/5178) | — |
-| 4. Migrate `workflow_versioning._utc_now` consumer to `utc_timestamp()` | Future PR — only after step 3 | — |
-| 5. Delete `utc_timestamp_z()` from `time_utils.py` | After step 4 | — |
-| 6. Plan Python 3.11+ upgrade | Separate issue (#5169 follow-up) | — |
-| 7. Drop the 9 Z-shim workarounds (no longer needed after step 6) | Final cleanup | — |
+| 4. Migrate `workflow_versioning._utc_now` consumer to `utc_timestamp()` | ✅ Done — imports it as `_utc_now` | — |
+| 5. Delete `utc_timestamp_z()` from `time_utils.py` | ✅ Done | — |
+| 6. Plan Python 3.11+ upgrade | ✅ Done — the platform runs 3.14, enforced at boot (#13738) | — |
+| 7. Drop the 9 Z-shim workarounds (no longer needed after step 6) | ✅ Done — [#13755](https://github.com/mrveiss/AutoBot-AI/issues/13755) | — |
 
 ### What this PR does (closes #5169)
 
@@ -170,7 +170,7 @@ Steps 3–7 are tracked as separate issues (#5178 + future). #5169 itself is clo
 - Does not migrate any of the 57 direct-usage sites — that's #5178
 - Does not delete `utc_timestamp_z()` — premature; it's still the canonical alias for `workflow_versioning`'s on-disk format until step 4
 - Does not bump Python to 3.11 — that's a separate scope
-- Does not touch the 9 Z-shim sites — they remain defensive against external APIs even after canonicalization
+- Does not touch the 9 Z-shim sites — they remain defensive against external APIs even after canonicalization (removed later, in #13755, once the interpreter floor made them redundant)
 
 ---
 


### PR DESCRIPTION
Closes #13755

## Thinking Path

The issue asks for the migration plan to be re-established rather than trusted, so the first move was
to check every claim in it. Three were wrong in a way that mattered:

- **Step 4 (⏳) is actually done.** `services/workflow_versioning.py:46` reads
  `from autobot_shared.time_utils import utc_timestamp as _utc_now`. Step 5 (✅, "after step 4") was
  therefore not the contradiction it looked like.
- **`utc_timestamp_z()` no longer exists**, but the module's API section still documented it as
  "DEPRECATED — legacy compatibility only… Retained ONLY because…". `parse_utc_iso`'s docstring also
  pointed at it with a `:func:` reference that could not resolve.
- **Nine sites, three in code** — as the issue found.

The open question the issue names — is the shim in `parse_utc_iso` redundant, or deliberate tolerance
for external producers that emit `Z`? — has a measurable answer:

```
python 3.14.6
  raw      '2026-01-01T00:00:00Z'         -> 2026-01-01 00:00:00+00:00
  shimmed  '2026-01-01T00:00:00Z'         -> 2026-01-01 00:00:00+00:00
  raw      '2026-01-01T00:00:00.123456Z'  -> 2026-01-01 00:00:00.123456+00:00
  raw      '2026-01-01T00:00:00z'         -> ValueError   (shimmed: also ValueError)
```

The shim changes no outcome, including the lowercase case, which fails either way. External `Z`
producers are still tolerated — by `fromisoformat` itself rather than by a preprocessing step — so the
tolerance is preserved, not dropped.

**The part that is not just deletion.** `.replace()` on a non-string raises `AttributeError`;
`fromisoformat` on a non-string raises `TypeError`. Removing the shim silently moves every site's
exception surface. That is the exact hazard #5464 documented for `parse_utc_iso`, so each site was
handled rather than assumed:

| Site | Handling |
|---|---|
| `time_utils.parse_utc_iso` | already guards with `isinstance` — surface unchanged; the docstring now says that check is what preserves it |
| `microsoft365_integration._validate_datetime_iso` | catch widened `AttributeError` → `TypeError`. It validates an **OData filter** value; an uncaught `TypeError` would escape as a 500 instead of the intended `ValueError` |
| `autobot-slm-backend/api/security.py` | same widening, returning `None` as before |

I deliberately did **not** route the two non-canonical sites through `parse_utc_iso`, despite the
reuse rule. `parse_utc_iso` tags naive input as UTC; `_validate_datetime_iso` re-emits
`dt.isoformat()` into an outbound Graph API filter, so a naive local time would silently acquire
`+00:00`. That is a semantic change to a query filter and is not what this issue asks for.

## What Changed

- `autobot_shared/time_utils.py` — steps 4 and 6 marked done with the evidence; the deleted helper's
  API entry and the dangling `:func:` reference removed; shim removed from `parse_utc_iso`.
- `autobot-backend/integrations/microsoft365_integration.py`, `autobot-slm-backend/api/security.py` —
  shim removed, catches widened.
- `docs/developer/audits/datetime-parsing-audit.md` — all three references plus rows 4–7 of the
  action table.

## Verification

**AC 4 — deliberate failure, both directions.** `Z`-suffixed input still parses, equals its `+00:00`
spelling, naive input is unaffected, and non-string/malformed input still raises `ValueError`:

```
autobot_shared/time_utils_test.py + time_utils_rfc3339_test.py    30 passed
autobot_shared/ (whole package)                                 1505 passed
integrations/ -k microsoft                                        12 passed
```

The two sites with no focused test were exercised directly:

```
  m365 '2026-01-01T00:00:00Z'      -> '2026-01-01T00:00:00+00:00'
  m365 '2026-01-01T00:00:00.5Z'    -> '2026-01-01T00:00:00.500000+00:00'
  m365 '2026-01-01T00:00:00+02:00' -> '2026-01-01T00:00:00+02:00'
  m365 123 / None / 'not-a-time'   -> ValueError (as intended)
```

**AC 1 + AC 3** are enforced, not just performed: `test_the_migration_plan_has_no_expired_pending_step`
asserts the docstring carries no pending marker and that the API section does not describe a helper
that no longer exists — cross-checked against `hasattr`, so docs and code cannot drift apart again.

Two things that test caught while being written, both worth noting because they are the failure mode
this issue is about:

- My own explanatory prose used the pending glyph, so the guard fired on the very sentence explaining
  why nothing should be pending. Reworded.
- The first assertion forbade `utc_timestamp_z` anywhere in the docstring, which would have banned
  step 5 from recording that it was deleted. Scoped to the API section instead.

**AC 2** is satisfied vacuously: no `.replace("Z", …)` survives in shipped code. The only remaining
matches are prose — the plan entry describing the removal, and a test docstring citing the old form.

## Model Used

Claude Opus 5 (1M context)
