### PR TITLE
feat(agent-loop): enforce repetition and stagnation guards at the live tool seam (#13590)

### DIFF
--- a/autobot-backend/agent_loop/loop.py
+++ b/autobot-backend/agent_loop/loop.py
@@ -128,6 +128,23 @@ class AgentLoop:
     runtime effect until a production caller instantiates ``AgentLoop``. Treat
     this as a library of parts + a reference implementation, not a live code
     path, when reasoning about what actually runs.
+
+    MIRRORED IN PRODUCTION (#13590) — these guards now also run at the live
+    seam, so changing them here alone is no longer the whole story:
+
+    - ``max_identical_tool_calls`` → ``chat_workflow/tool_handler.py``
+      ``_enforce_repetition``, via ``autobot_shared/repetition_guard.py``. The
+      production counter keys on ``(call fingerprint, result hash)`` rather than
+      the call alone, so a polling loop whose result moves is not halted.
+    - ``halt_on_stagnation`` / ``stagnation_window`` /
+      ``min_observation_novelty`` → the same seam, same module, reusing
+      ``fingerprint.compute_novel_token_ratio``.
+    - ``AUTOBOT_GUARD_PROFILE`` and the per-guard env overrides in
+      ``guard_profile.py`` therefore now govern production for these fields.
+
+    STILL UNPORTED: everything else in the guard stack — schema self-correction
+    (``max_schema_retries``), the approval workflow fields, and the belief-state
+    and planning machinery — remains dormant here.
     """
 
     def __init__(

--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -3133,7 +3133,7 @@ class ToolHandlerMixin:
         ctx: "LLMIterationContext" | None,
         execution_results: list[dict[str, Any]],
     ) -> WorkflowMessage | None:
-        """Halt an agent re-issuing the same call for the same result (#13590).
+        """Halt a looping or stagnating agent at the live seam (#13590).
 
         The guard existed in ``agent_loop/`` and ran nowhere; the live path had
         only a prompt sentence and a counter for *malformed* calls. Counting is
@@ -3147,22 +3147,36 @@ class ToolHandlerMixin:
         """
         from autobot_shared.repetition_guard import (  # noqa: PLC0415
             REPETITION_STATE_KEY,
+            STAGNATION_STATE_KEY,
             repetition_halt_reason,
+            stagnation_halt_reason,
         )
 
         if ctx is None:
             return None
-        state = ctx.context.setdefault(REPETITION_STATE_KEY, {})
-        reason = repetition_halt_reason(tool_call, execution_results, state)
+
+        rep_state = ctx.context.setdefault(REPETITION_STATE_KEY, {})
+        reason = repetition_halt_reason(tool_call, execution_results, rep_state)
+        halt_kind = "repetition_halt"
+
+        if reason is None:
+            # Repetition catches one call re-issued; stagnation catches a run of
+            # different calls whose results say nothing new. Distinct reasons,
+            # because "you are repeating a call" and "you are learning nothing"
+            # ask the agent for different corrections.
+            stag_state = ctx.context.setdefault(STAGNATION_STATE_KEY, {})
+            reason = stagnation_halt_reason(execution_results, stag_state)
+            halt_kind = "stagnation_halt"
+
         if reason is None:
             return None
 
         name = tool_call.get("name", "")
-        execution_results.append({"tool": name, "status": "error", "error": reason, "repetition_halt": True})
+        execution_results.append({"tool": name, "status": "error", "error": reason, halt_kind: True})
         return WorkflowMessage(
             type="error",
             content=reason,
-            metadata={"tool": name, "error": True, "repetition_halt": True},
+            metadata={"tool": name, "error": True, halt_kind: True},
         )
 
     def _enforce_work_item_approval(

--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -3127,6 +3127,44 @@ class ToolHandlerMixin:
             metadata={"tool": name, "error": True, "fact_forcing": True},
         )
 
+    def _enforce_repetition(
+        self,
+        tool_call: dict[str, Any],
+        ctx: "LLMIterationContext" | None,
+        execution_results: list[dict[str, Any]],
+    ) -> WorkflowMessage | None:
+        """Halt an agent re-issuing the same call for the same result (#13590).
+
+        The guard existed in ``agent_loop/`` and ran nowhere; the live path had
+        only a prompt sentence and a counter for *malformed* calls. Counting is
+        keyed on ``(call fingerprint, result hash)``, so a polling loop whose
+        result moves is never halted — only a call reproducing a result it
+        already has.
+
+        State lives on ``ctx.context``, which is per-turn and per-session; the
+        seam is concurrent across sessions, so nothing here may be module-global.
+        A missing ``ctx`` is a no-op, matching the other enforcers.
+        """
+        from autobot_shared.repetition_guard import (  # noqa: PLC0415
+            REPETITION_STATE_KEY,
+            repetition_halt_reason,
+        )
+
+        if ctx is None:
+            return None
+        state = ctx.context.setdefault(REPETITION_STATE_KEY, {})
+        reason = repetition_halt_reason(tool_call, execution_results, state)
+        if reason is None:
+            return None
+
+        name = tool_call.get("name", "")
+        execution_results.append({"tool": name, "status": "error", "error": reason, "repetition_halt": True})
+        return WorkflowMessage(
+            type="error",
+            content=reason,
+            metadata={"tool": name, "error": True, "repetition_halt": True},
+        )
+
     def _enforce_work_item_approval(
         self,
         tool_call: dict[str, Any],
@@ -3223,6 +3261,16 @@ class ToolHandlerMixin:
         approval_msg = self._enforce_work_item_approval(tool_call, ctx, execution_results)
         if approval_msg is not None:
             yield approval_msg
+            return
+
+        # #13590: halt a stagnating agent — same tool, same args, same result —
+        # at the profile's max_identical_tool_calls. Placed last of the
+        # enforcers so a call blocked for a *policy* reason above is not also
+        # counted as repetition; those blocks are the agent being stopped, not
+        # the agent looping.
+        repetition_msg = self._enforce_repetition(tool_call, ctx, execution_results)
+        if repetition_msg is not None:
+            yield repetition_msg
             return
 
         # GH#11568: sandboxed Python composition tool (main-chat only).

--- a/autobot-backend/tests/unit/chat_workflow/test_tool_handler_builtin_route.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_tool_handler_builtin_route.py
@@ -121,7 +121,10 @@ async def test_uniform_gate_resets_invalid_call_counter() -> None:
     the four replaced branches."""
     mixin, calls = _mixin(), []
     mixin._handle_web_search_tool = _recording_handler(calls, "web_search")
-    ctx = SimpleNamespace(consecutive_invalid_tool_calls=2)
+    # `context` mirrors LLMIterationContext's own field: the seam's guards keep
+    # their per-turn state there (#11178 fact-forcing, #13590 repetition), so a
+    # double without it no longer stands in for a real ctx.
+    ctx = SimpleNamespace(consecutive_invalid_tool_calls=2, context={})
 
     messages = [
         msg

--- a/autobot-backend/tests/unit/chat_workflow/test_tool_handler_repetition_guard.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_tool_handler_repetition_guard.py
@@ -1,0 +1,122 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Dispatch-level repetition enforcement (#13590).
+
+Proves the repetition guard — previously only in the dormant `agent_loop` path —
+now fires on the real production tool-dispatch seam
+(`ToolHandlerMixin._dispatch_tool_call` via `_enforce_repetition`).
+
+The unit-level behaviour of the counter lives in
+`autobot_shared/repetition_guard_test.py`. What is asserted here is the seam
+wiring: that the guard is reached, that its state is per-turn, and that
+`AUTOBOT_GUARD_PROFILE` reaches it — the control that has read as hardening
+while changing nothing in production.
+"""
+
+import os
+from dataclasses import dataclass, field
+from typing import Any, Dict
+from unittest.mock import patch
+
+import pytest
+
+from chat_workflow.tool_handler import ToolHandlerMixin
+
+
+def _mixin() -> ToolHandlerMixin:
+    return ToolHandlerMixin.__new__(ToolHandlerMixin)
+
+
+@dataclass
+class _Ctx:
+    """Stand-in for LLMIterationContext — the guard only touches `.context`."""
+
+    context: Dict[str, Any] = field(default_factory=dict)
+
+
+def _call(name: str = "read_file", **args: Any) -> Dict[str, Any]:
+    return {"name": name, "params": args or {"path": "/tmp/a"}}
+
+
+def _result(tool: str, value: str) -> Dict[str, Any]:
+    return {"tool": tool, "status": "ok", "result": value}
+
+
+def _drive(mixin, ctx, results, times, tool="read_file"):
+    """Issue *times* identical calls; return the first halt message, if any."""
+    for _ in range(times):
+        msg = mixin._enforce_repetition(_call(tool), ctx, results)
+        if msg is not None:
+            return msg
+    return None
+
+
+def test_the_guard_is_reached_from_the_dispatch_seam() -> None:
+    """`_dispatch_tool_call` must actually call it — a guard nothing invokes is #13590 again."""
+    import inspect
+
+    source = inspect.getsource(ToolHandlerMixin._dispatch_tool_call)
+
+    assert "_enforce_repetition(" in source
+
+
+def test_repeated_identical_calls_with_an_unchanged_result_halt() -> None:
+    ctx, results = _Ctx(), [_result("read_file", "same")]
+
+    msg = _drive(_mixin(), ctx, results, times=10)
+
+    assert msg is not None
+    assert msg.type == "error"
+    assert msg.metadata.get("repetition_halt") is True
+    assert results[-1]["repetition_halt"] is True
+    assert results[-1]["status"] == "error"
+
+
+def test_a_polling_loop_is_not_halted() -> None:
+    """The result moves every turn — this is progress, not repetition."""
+    mixin, ctx, results = _mixin(), _Ctx(), []
+
+    for tick in range(12):
+        results.append(_result("check_build", f"step {tick}"))
+        assert mixin._enforce_repetition(_call("check_build"), ctx, results) is None
+
+
+def test_without_a_context_the_guard_is_a_no_op() -> None:
+    """Matches every other enforcer at this seam; per-turn state has nowhere to live."""
+    assert _mixin()._enforce_repetition(_call(), None, [_result("read_file", "same")]) is None
+
+
+def test_state_is_per_turn_not_module_global() -> None:
+    """The seam is concurrent across sessions; counters must not pool."""
+    mixin, results = _mixin(), [_result("read_file", "same")]
+    session_a, session_b = _Ctx(), _Ctx()
+
+    assert _drive(mixin, session_a, results, times=10) is not None
+    assert mixin._enforce_repetition(_call(), session_b, results) is None, "session B inherited A's count"
+
+
+def test_the_guard_stores_its_state_under_a_namespaced_key() -> None:
+    """`ctx.context` is shared with other guards — collisions would be silent."""
+    from autobot_shared.repetition_guard import REPETITION_STATE_KEY
+
+    ctx = _Ctx(context={"_fact_forcing_investigated": set()})
+    _mixin()._enforce_repetition(_call(), ctx, [_result("read_file", "x")])
+
+    assert REPETITION_STATE_KEY in ctx.context
+    assert ctx.context["_fact_forcing_investigated"] == set(), "another guard's state was clobbered"
+
+
+@pytest.mark.parametrize(("profile", "identical_calls"), [("strict", 2), ("minimal", 5)])
+def test_the_active_profile_changes_live_behaviour(profile: str, identical_calls: int) -> None:
+    """AUTOBOT_GUARD_PROFILE=strict must demonstrably halt sooner than minimal."""
+    mixin, results = _mixin(), [_result("read_file", "same")]
+
+    with patch.dict(os.environ, {"AUTOBOT_GUARD_PROFILE": profile}, clear=False):
+        os.environ.pop("AUTOBOT_GUARD_MAX_IDENTICAL", None)
+        ctx = _Ctx()
+        # One call short of the profile's threshold must still be allowed …
+        assert _drive(mixin, ctx, results, times=identical_calls - 1) is None
+        # … and the next one halts.
+        assert mixin._enforce_repetition(_call(), ctx, results) is not None

--- a/autobot-backend/tests/unit/chat_workflow/test_tool_handler_repetition_guard.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_tool_handler_repetition_guard.py
@@ -120,3 +120,27 @@ def test_the_active_profile_changes_live_behaviour(profile: str, identical_calls
         assert _drive(mixin, ctx, results, times=identical_calls - 1) is None
         # … and the next one halts.
         assert mixin._enforce_repetition(_call(), ctx, results) is not None
+
+
+def test_a_stagnation_run_halts_with_a_distinct_reason() -> None:
+    """Different calls, nothing learned — a separate halt from repetition."""
+    mixin, ctx = _mixin(), _Ctx()
+    results = [{"tool": f"t{i}", "status": "ok", "result": "the same words over and over"} for i in range(12)]
+
+    with patch.dict(os.environ, {"AUTOBOT_GUARD_PROFILE": "strict"}, clear=False):
+        msg = mixin._enforce_repetition(_call("something_new"), ctx, results)
+
+    assert msg is not None
+    assert msg.metadata.get("stagnation_halt") is True
+    assert msg.metadata.get("repetition_halt") is None, "the two halts must stay distinguishable"
+
+
+def test_a_productive_run_is_not_halted_as_stagnant() -> None:
+    mixin, ctx = _mixin(), _Ctx()
+    results = [
+        {"tool": f"t{i}", "status": "ok", "result": f"entirely distinct finding {i} about subsystem {i}"}
+        for i in range(12)
+    ]
+
+    with patch.dict(os.environ, {"AUTOBOT_GUARD_PROFILE": "strict"}, clear=False):
+        assert mixin._enforce_repetition(_call("something_new"), ctx, results) is None

--- a/autobot_shared/repetition_guard.py
+++ b/autobot_shared/repetition_guard.py
@@ -1,0 +1,159 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Repetition guard for the production tool seam (#13590).
+
+The guard machinery existed in ``agent_loop/`` and ran nowhere: the live path's
+only countermeasure was a sentence in the system prompt
+(``chat_workflow/manager.py``: "Do NOT repeat commands already executed"), and
+the only counter was ``consecutive_invalid_tool_calls``, which counts
+*malformed* calls rather than repeated valid ones. An agent calling the same
+tool with the same arguments forever was stopped only by the iteration ceiling.
+
+**The counter key is a pair: (call fingerprint, result hash).** Counting calls
+alone would halt a polling loop, which is a legitimate pattern — the same call
+re-issued until the result moves. Keying on the pair means the count resets the
+moment the result changes, so polling survives any threshold and only a call
+literally reproducing a result it already has is halted. That is the definition
+of the failure this guard exists for.
+
+Thresholds come from ``agent_loop.guard_profile`` rather than new environment
+variables, so ``AUTOBOT_GUARD_PROFILE`` finally governs the live path — it has
+read as a hardening control while changing nothing in production.
+
+State is passed in by the caller and lives on the per-turn
+``LLMIterationContext``; nothing here is module-global, because the seam is
+concurrent across sessions.
+"""
+
+from typing import Any, Dict, Optional, Tuple
+
+from autobot_shared.logging_manager import get_logger
+
+logger = get_logger(__name__)
+
+# Key under which the caller stores this guard's per-turn state.
+REPETITION_STATE_KEY = "_repetition_guard"
+
+# Tools whose whole purpose is to be re-issued until something changes. A
+# changing result already exempts them via the pair key; this covers the case
+# where the result is legitimately identical between polls.
+POLLABLE_TOOLS = frozenset({"sleep", "wait", "poll", "check_status"})
+
+
+def _canonical_args(tool_call: Dict[str, Any]) -> Any:
+    """Return the argument bag under whichever key this call site used."""
+    return tool_call.get("params") or tool_call.get("arguments") or {}
+
+
+def call_fingerprint(tool_call: Dict[str, Any]) -> str:
+    """Stable hash of ``(tool name, canonical args)``."""
+    from agent_loop.fingerprint import content_hash  # noqa: PLC0415
+
+    return content_hash([tool_call.get("name", ""), _canonical_args(tool_call)])
+
+
+def last_result_hash(tool_name: str, execution_results: list) -> Optional[str]:
+    """Hash of the most recent result recorded for *tool_name*, or ``None``.
+
+    Reads the results the seam has already collected this turn rather than
+    requiring a post-dispatch hook, so the guard stays a single pre-dispatch
+    check like every other ``_enforce_*`` at this seam.
+    """
+    from agent_loop.fingerprint import content_hash  # noqa: PLC0415
+
+    for entry in reversed(execution_results or []):
+        if isinstance(entry, dict) and entry.get("tool") == tool_name:
+            return content_hash(entry.get("result", entry.get("error", "")))
+    return None
+
+
+def max_identical_tool_calls() -> int:
+    """Resolve the active threshold from the guard profile (#13590).
+
+    Falls back to the dataclass default when the profile carries no override —
+    ``standard`` deliberately carries none, so it reproduces those defaults.
+    """
+    from agent_loop.guard_profile import resolve_guard_config_overrides  # noqa: PLC0415
+    from agent_loop.types import AgentLoopConfig  # noqa: PLC0415
+
+    overrides = resolve_guard_config_overrides()
+    value = overrides.get("max_identical_tool_calls", AgentLoopConfig.max_identical_tool_calls)
+    try:
+        return max(1, int(value))  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return AgentLoopConfig.max_identical_tool_calls
+
+
+def register_call(
+    tool_call: Dict[str, Any],
+    execution_results: list,
+    state: Dict[str, Tuple[str, int]],
+) -> int:
+    """Record this call against *state* and return its repetition count.
+
+    ``state`` maps a call fingerprint to ``(last result hash, count)``. A call
+    whose previous result differs from the one before it resets the count to 1 —
+    that is what keeps a polling loop alive.
+    """
+    fingerprint = call_fingerprint(tool_call)
+    result_hash = last_result_hash(tool_call.get("name", ""), execution_results)
+
+    previous = state.get(fingerprint)
+    if previous is None:
+        state[fingerprint] = (result_hash or "", 1)
+        return 1
+
+    previous_hash, count = previous
+    if result_hash is not None and result_hash != previous_hash:
+        # The result moved — this is progress, not repetition.
+        state[fingerprint] = (result_hash, 1)
+        return 1
+
+    count += 1
+    state[fingerprint] = (previous_hash, count)
+    return count
+
+
+def repetition_halt_reason(
+    tool_call: Dict[str, Any],
+    execution_results: list,
+    state: Dict[str, Tuple[str, int]],
+    threshold: Optional[int] = None,
+) -> Optional[str]:
+    """Return a user-facing halt reason, or ``None`` to let the call proceed.
+
+    The message names the tool and the count because a silent iteration-cap exit
+    is not actionable — "stopped: repeating the same call" is.
+    """
+    tool_name = tool_call.get("name", "")
+    if tool_name in POLLABLE_TOOLS:
+        return None
+
+    limit = max_identical_tool_calls() if threshold is None else threshold
+    count = register_call(tool_call, execution_results, state)
+    if count < limit:
+        return None
+
+    logger.warning(
+        "repetition_guard: halting %s after %d identical call(s) with an unchanged result",
+        tool_name,
+        count,
+    )
+    return (
+        f"Stopped: '{tool_name}' has been called {count} times with the same arguments "
+        f"and the same result. Repeating it will not produce new information — "
+        f"try a different approach, or explain what you need."
+    )
+
+
+__all__ = [
+    "POLLABLE_TOOLS",
+    "REPETITION_STATE_KEY",
+    "call_fingerprint",
+    "last_result_hash",
+    "max_identical_tool_calls",
+    "register_call",
+    "repetition_halt_reason",
+]

--- a/autobot_shared/repetition_guard.py
+++ b/autobot_shared/repetition_guard.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
-"""Repetition guard for the production tool seam (#13590).
+"""Repetition and stagnation guards for the production tool seam (#13590).
 
 The guard machinery existed in ``agent_loop/`` and ran nowhere: the live path's
 only countermeasure was a sentence in the system prompt
@@ -33,8 +33,9 @@ from autobot_shared.logging_manager import get_logger
 
 logger = get_logger(__name__)
 
-# Key under which the caller stores this guard's per-turn state.
+# Keys under which the caller stores each guard's per-turn state.
 REPETITION_STATE_KEY = "_repetition_guard"
+STAGNATION_STATE_KEY = "_stagnation_guard"
 
 # Tools whose whole purpose is to be re-issued until something changes. A
 # changing result already exempts them via the pair key; this covers the case
@@ -148,12 +149,88 @@ def repetition_halt_reason(
     )
 
 
+def _stagnation_config() -> tuple:
+    """Resolve ``(enabled, window, min_novelty)`` from the guard profile."""
+    from agent_loop.guard_profile import resolve_guard_config_overrides  # noqa: PLC0415
+    from agent_loop.types import AgentLoopConfig  # noqa: PLC0415
+
+    overrides = resolve_guard_config_overrides()
+
+    def _get(field: str):
+        return overrides.get(field, getattr(AgentLoopConfig, field))
+
+    try:
+        window = max(2, int(_get("stagnation_window")))
+        novelty = float(_get("min_observation_novelty"))
+    except (TypeError, ValueError):
+        window = AgentLoopConfig.stagnation_window
+        novelty = AgentLoopConfig.min_observation_novelty
+    return bool(_get("halt_on_stagnation")), window, novelty
+
+
+def stagnation_halt_reason(
+    execution_results: list,
+    state: Dict[str, Any],
+) -> Optional[str]:
+    """Return a halt reason when recent results stop carrying new information.
+
+    Repetition catches an agent re-issuing one call. This catches the other
+    shape: a run of *different* calls whose results say nothing new — the agent
+    is moving but not learning, and the iteration cap is the only thing that
+    would stop it.
+
+    Novelty is the fraction of tokens in a result absent from everything seen
+    before it this turn, so the vocabulary accumulates and a genuinely new
+    result scores high however it is phrased. The halt fires only once the
+    window is full, so a short turn is never judged on two observations.
+    """
+    from agent_loop.fingerprint import compute_novel_token_ratio  # noqa: PLC0415
+
+    enabled, window, min_novelty = _stagnation_config()
+    if not enabled:
+        return None
+
+    seen_tokens: set = state.setdefault("seen_tokens", set())
+    ratios: list = state.setdefault("ratios", [])
+    counted: int = state.get("counted", 0)
+
+    # Score only results not yet scored, so repeated calls into this function
+    # within one turn do not re-score the same observation.
+    fresh = (execution_results or [])[counted:]
+    for entry in fresh:
+        payload = entry.get("result", entry.get("error", "")) if isinstance(entry, dict) else entry
+        ratios.append(compute_novel_token_ratio(payload, seen_tokens))
+    state["counted"] = counted + len(fresh)
+
+    if len(ratios) < window:
+        return None
+
+    recent = ratios[-window:]
+    average = sum(recent) / len(recent)
+    if average >= min_novelty:
+        return None
+
+    logger.warning(
+        "stagnation_guard: halting — mean novelty %.3f over the last %d results is below %.3f",
+        average,
+        window,
+        min_novelty,
+    )
+    return (
+        f"Stopped: the last {window} tool results carried almost no new information "
+        f"(novelty {average:.1%}, below the {min_novelty:.0%} threshold). Continuing "
+        f"would repeat what is already known — change approach, or say what is blocking."
+    )
+
+
 __all__ = [
     "POLLABLE_TOOLS",
     "REPETITION_STATE_KEY",
+    "STAGNATION_STATE_KEY",
     "call_fingerprint",
     "last_result_hash",
     "max_identical_tool_calls",
     "register_call",
     "repetition_halt_reason",
+    "stagnation_halt_reason",
 ]

--- a/autobot_shared/repetition_guard_test.py
+++ b/autobot_shared/repetition_guard_test.py
@@ -1,0 +1,171 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for the production repetition guard (#13590).
+
+The guard exists to stop an agent burning the iteration budget on a call that
+cannot produce new information. The hard part is not the counting — it is *not*
+halting the legitimate patterns, so most of these assert the guard staying out
+of the way.
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from autobot_shared.repetition_guard import (
+    call_fingerprint,
+    last_result_hash,
+    max_identical_tool_calls,
+    register_call,
+    repetition_halt_reason,
+)
+
+
+def _call(name="read_file", **args):
+    return {"name": name, "params": args or {"path": "/tmp/a"}}
+
+
+def _result(tool, value):
+    return {"tool": tool, "status": "ok", "result": value}
+
+
+# ----------------------------------------------------------- fingerprinting
+
+
+def test_same_tool_and_args_fingerprint_identically():
+    assert call_fingerprint(_call(path="/a")) == call_fingerprint(_call(path="/a"))
+
+
+def test_different_args_fingerprint_differently():
+    assert call_fingerprint(_call(path="/a")) != call_fingerprint(_call(path="/b"))
+
+
+def test_argument_order_does_not_change_the_fingerprint():
+    """Canonical hashing — key order is not a semantic difference."""
+    a = {"name": "t", "params": {"x": 1, "y": 2}}
+    b = {"name": "t", "params": {"y": 2, "x": 1}}
+
+    assert call_fingerprint(a) == call_fingerprint(b)
+
+
+def test_both_argument_key_spellings_are_read():
+    """The seam passes `params` at some call sites and `arguments` at others."""
+    assert call_fingerprint({"name": "t", "params": {"x": 1}}) == call_fingerprint(
+        {"name": "t", "arguments": {"x": 1}}
+    )
+
+
+def test_last_result_hash_reads_the_most_recent_entry_for_that_tool():
+    results = [_result("read_file", "old"), _result("other", "x"), _result("read_file", "new")]
+
+    assert last_result_hash("read_file", results) != last_result_hash("read_file", results[:1])
+    assert last_result_hash("absent", results) is None
+
+
+# ------------------------------------------------------------- the halt
+
+
+def test_an_identical_call_with_an_unchanged_result_halts_at_the_threshold():
+    state, results = {}, [_result("read_file", "same")]
+
+    assert repetition_halt_reason(_call(), results, state, threshold=3) is None
+    assert repetition_halt_reason(_call(), results, state, threshold=3) is None
+    reason = repetition_halt_reason(_call(), results, state, threshold=3)
+
+    assert reason is not None
+    assert "read_file" in reason, "the reason must name the tool — a silent halt is not actionable"
+
+
+def test_the_halt_reason_says_what_to_do_next():
+    state, results = {}, [_result("read_file", "same")]
+    for _ in range(2):
+        repetition_halt_reason(_call(), results, state, threshold=2)
+    reason = repetition_halt_reason(_call(), results, state, threshold=2)
+
+    assert "different approach" in reason or "explain" in reason
+
+
+# ------------------------------------------- the patterns it must NOT halt
+
+
+def test_a_polling_loop_against_a_changing_result_is_never_halted():
+    """The whole reason the key is a pair. A single-counter guard breaks this."""
+    state, results = {}, []
+
+    for tick in range(10):
+        results.append(_result("check_build", f"progress {tick}"))
+        assert repetition_halt_reason(_call("check_build"), results, state, threshold=2) is None
+
+
+def test_the_count_resets_when_the_result_finally_moves():
+    state, results = {}, [_result("read_file", "same")]
+    repetition_halt_reason(_call(), results, state, threshold=3)
+    repetition_halt_reason(_call(), results, state, threshold=3)
+
+    results.append(_result("read_file", "CHANGED"))
+
+    assert repetition_halt_reason(_call(), results, state, threshold=3) is None, "a moved result is progress"
+
+
+def test_different_arguments_are_counted_separately():
+    state, results = {}, [_result("read_file", "same")]
+
+    for path in ("/a", "/b", "/c", "/d"):
+        assert repetition_halt_reason(_call(path=path), results, state, threshold=2) is None
+
+
+def test_an_explicitly_pollable_tool_is_exempt():
+    state, results = {}, [_result("sleep", "ok")]
+
+    for _ in range(5):
+        assert repetition_halt_reason({"name": "sleep", "params": {}}, results, state, threshold=2) is None
+
+
+# ------------------------------------------------------- profile plumbing
+
+
+def test_the_threshold_comes_from_the_guard_profile():
+    """AUTOBOT_GUARD_PROFILE has read as a hardening control while changing nothing."""
+    with patch.dict(os.environ, {"AUTOBOT_GUARD_PROFILE": "strict"}, clear=False):
+        strict = max_identical_tool_calls()
+    with patch.dict(os.environ, {"AUTOBOT_GUARD_PROFILE": "minimal"}, clear=False):
+        minimal = max_identical_tool_calls()
+
+    assert strict < minimal, "strict must halt sooner than minimal"
+
+
+def test_an_unknown_profile_falls_back_rather_than_raising():
+    with patch.dict(os.environ, {"AUTOBOT_GUARD_PROFILE": "nonsense"}, clear=False):
+        assert max_identical_tool_calls() >= 1
+
+
+def test_the_per_guard_env_override_wins():
+    with patch.dict(
+        os.environ, {"AUTOBOT_GUARD_PROFILE": "strict", "AUTOBOT_GUARD_MAX_IDENTICAL": "7"}, clear=False
+    ):
+        assert max_identical_tool_calls() == 7
+
+
+@pytest.mark.parametrize("raw", ["0", "-3", "not-a-number"])
+def test_a_nonsense_threshold_never_disables_the_guard(raw):
+    """A threshold below 1 would halt every first call or none at all."""
+    with patch.dict(os.environ, {"AUTOBOT_GUARD_MAX_IDENTICAL": raw}, clear=False):
+        assert max_identical_tool_calls() >= 1
+
+
+# ----------------------------------------------------------- concurrency
+
+
+def test_two_sessions_do_not_share_counters():
+    """State is caller-owned; two turns must not pool into one counter."""
+    session_a, session_b = {}, {}
+    results = [_result("read_file", "same")]
+
+    for _ in range(2):
+        repetition_halt_reason(_call(), results, session_a, threshold=3)
+
+    assert repetition_halt_reason(_call(), results, session_b, threshold=3) is None
+    assert register_call(_call(), results, session_b) == 2, "session B counted session A's calls"

--- a/autobot_shared/repetition_guard_test.py
+++ b/autobot_shared/repetition_guard_test.py
@@ -53,9 +53,7 @@ def test_argument_order_does_not_change_the_fingerprint():
 
 def test_both_argument_key_spellings_are_read():
     """The seam passes `params` at some call sites and `arguments` at others."""
-    assert call_fingerprint({"name": "t", "params": {"x": 1}}) == call_fingerprint(
-        {"name": "t", "arguments": {"x": 1}}
-    )
+    assert call_fingerprint({"name": "t", "params": {"x": 1}}) == call_fingerprint({"name": "t", "arguments": {"x": 1}})
 
 
 def test_last_result_hash_reads_the_most_recent_entry_for_that_tool():
@@ -143,9 +141,7 @@ def test_an_unknown_profile_falls_back_rather_than_raising():
 
 
 def test_the_per_guard_env_override_wins():
-    with patch.dict(
-        os.environ, {"AUTOBOT_GUARD_PROFILE": "strict", "AUTOBOT_GUARD_MAX_IDENTICAL": "7"}, clear=False
-    ):
+    with patch.dict(os.environ, {"AUTOBOT_GUARD_PROFILE": "strict", "AUTOBOT_GUARD_MAX_IDENTICAL": "7"}, clear=False):
         assert max_identical_tool_calls() == 7
 
 
@@ -229,7 +225,7 @@ def test_an_observation_is_scored_once_across_repeated_checks():
 
 
 def test_the_two_halts_give_different_reasons():
-    """"Repeating a call" and "learning nothing" ask for different corrections."""
+    """ "Repeating a call" and "learning nothing" ask for different corrections."""
     from autobot_shared.repetition_guard import stagnation_halt_reason
 
     rep_state, results = {}, [_result("read_file", "same")]

--- a/autobot_shared/repetition_guard_test.py
+++ b/autobot_shared/repetition_guard_test.py
@@ -169,3 +169,73 @@ def test_two_sessions_do_not_share_counters():
 
     assert repetition_halt_reason(_call(), results, session_b, threshold=3) is None
     assert register_call(_call(), results, session_b) == 2, "session B counted session A's calls"
+
+
+# ----------------------------------------------------------- stagnation
+
+
+def _low_novelty_results(n, text="the same words over and over"):
+    return [_result(f"tool_{i}", text) for i in range(n)]
+
+
+def test_a_run_of_uninformative_results_halts():
+    """Different calls, nothing learned — the other shape of a stuck agent."""
+    with patch.dict(os.environ, {"AUTOBOT_GUARD_PROFILE": "strict"}, clear=False):
+        from autobot_shared.repetition_guard import stagnation_halt_reason
+
+        reason = stagnation_halt_reason(_low_novelty_results(12), {})
+
+    assert reason is not None
+    assert "new information" in reason
+
+
+def test_results_that_keep_saying_something_new_are_not_halted():
+    from autobot_shared.repetition_guard import stagnation_halt_reason
+
+    varied = [_result(f"t{i}", f"entirely distinct finding number {i} about subsystem {i}") for i in range(12)]
+
+    with patch.dict(os.environ, {"AUTOBOT_GUARD_PROFILE": "strict"}, clear=False):
+        assert stagnation_halt_reason(varied, {}) is None
+
+
+def test_a_short_turn_is_never_judged_stagnant():
+    """The window must fill first — two observations are not a trend."""
+    from autobot_shared.repetition_guard import stagnation_halt_reason
+
+    with patch.dict(os.environ, {"AUTOBOT_GUARD_PROFILE": "strict"}, clear=False):
+        assert stagnation_halt_reason(_low_novelty_results(2), {}) is None
+
+
+def test_the_minimal_profile_disables_the_stagnation_halt():
+    """`minimal` sets halt_on_stagnation False — the profile must reach here."""
+    from autobot_shared.repetition_guard import stagnation_halt_reason
+
+    with patch.dict(os.environ, {"AUTOBOT_GUARD_PROFILE": "minimal"}, clear=False):
+        os.environ.pop("AUTOBOT_GUARD_STAGNATION_HALT", None)
+        assert stagnation_halt_reason(_low_novelty_results(12), {}) is None
+
+
+def test_an_observation_is_scored_once_across_repeated_checks():
+    """The guard is called per dispatch; re-scoring would skew the window."""
+    from autobot_shared.repetition_guard import stagnation_halt_reason
+
+    state, results = {}, _low_novelty_results(3)
+    with patch.dict(os.environ, {"AUTOBOT_GUARD_PROFILE": "strict"}, clear=False):
+        stagnation_halt_reason(results, state)
+        first = state["counted"]
+        stagnation_halt_reason(results, state)
+
+    assert state["counted"] == first == 3
+
+
+def test_the_two_halts_give_different_reasons():
+    """"Repeating a call" and "learning nothing" ask for different corrections."""
+    from autobot_shared.repetition_guard import stagnation_halt_reason
+
+    rep_state, results = {}, [_result("read_file", "same")]
+    for _ in range(3):
+        rep = repetition_halt_reason(_call(), results, rep_state, threshold=2)
+    with patch.dict(os.environ, {"AUTOBOT_GUARD_PROFILE": "strict"}, clear=False):
+        stag = stagnation_halt_reason(_low_novelty_results(12), {})
+
+    assert rep and stag and rep != stag


### PR DESCRIPTION
Closes #13590

## Thinking Path

The guard machinery was well built and ran nowhere. The live seam's only countermeasure was a prompt
sentence, and `consecutive_invalid_tool_calls` counts *malformed* calls, not repeated valid ones.

**The design question is not the counting — it is not halting the legitimate patterns.** A naive
identical-call counter breaks polling, which is the same call re-issued until the result moves. So the
counter keys on `(call fingerprint, result hash)`: the count resets the moment the result changes, and
only a call literally reproducing a result it already has is halted.

That key also has a practical consequence — it means the guard can be a **single pre-dispatch check**
like every other `_enforce_*` at this seam, with no post-dispatch hook. `execution_results` already
carries this turn's results, so the previous result for a fingerprint is readable at call time.

**Placement.** `_enforce_repetition` runs *last* of the enforcers. A call blocked above for a policy
reason (forbidden work, config protection, fact-forcing, approval) is the agent being stopped, not the
agent looping — counting those as repetition would halt a turn for the wrong reason.

**Stagnation is a second shape, not the same one.** Repetition catches one call re-issued; stagnation
catches a run of *different* calls whose results say nothing new — the agent moving but not learning.
They emit distinct reasons because "you are repeating a call" and "you are learning nothing" ask for
different corrections. Novelty reuses `fingerprint.compute_novel_token_ratio`, and the halt only fires
once the window is full, so a short turn is never judged on two observations.

No new guard vocabulary and no new env vars: thresholds resolve through
`guard_profile.resolve_guard_config_overrides`, so `AUTOBOT_GUARD_PROFILE` finally governs the live
path. It has read as a hardening control while changing nothing in production.

## What Changed

- `autobot_shared/repetition_guard.py` — `repetition_halt_reason` (pair-keyed) and
  `stagnation_halt_reason` (novelty over a rolling window). State is caller-owned; nothing
  module-global, because the seam is concurrent across sessions.
- `chat_workflow/tool_handler.py` — `_enforce_repetition`, wired into `_dispatch_tool_call`, storing
  per-turn state on `ctx.context` under namespaced keys.
- `agent_loop/loop.py` — PRODUCTION STATUS docstring records which guards are now mirrored and which
  remain dormant (AC 6).

## Verification

```
autobot_shared/repetition_guard_test.py                              24 passed
tests/unit/chat_workflow/test_tool_handler_repetition_guard.py       10 passed
chat_workflow/ + agent_loop/ + the seam test                        590 passed
```

Per acceptance criterion:

| AC | Covered by |
|---|---|
| 1 — identical calls + identical results halt at the profile threshold | `test_repeated_identical_calls_with_an_unchanged_result_halt` |
| 2 — `strict` demonstrably changes live behaviour | `test_the_active_profile_changes_live_behaviour[strict-2]` / `[minimal-5]`, driving the real `_enforce_repetition` |
| 3 — low-novelty run halts with a distinct reason | `test_a_stagnation_run_halts_with_a_distinct_reason` (asserts `stagnation_halt` set and `repetition_halt` **not** set) |
| 4 — a polling loop is not halted | `test_a_polling_loop_is_not_halted`, 12 ticks against a moving result |
| 5 — guard state is per-session | `test_state_is_per_turn_not_module_global` + `test_two_sessions_do_not_share_counters` |
| 6 — PRODUCTION STATUS updated | the docstring, listing mirrored *and* still-unported guards |

**Mutation check** — degrading the pair key to a call-only counter, i.e. the naive guard:

```
FAILED test_a_polling_loop_against_a_changing_result_is_never_halted
FAILED test_the_count_resets_when_the_result_finally_moves
2 failed, 22 passed
```

Those two tests are exactly the reason the key is a pair. Separately, removing the call from
`_dispatch_tool_call` fails `test_the_guard_is_reached_from_the_dispatch_seam` — a guard nothing
invokes is #13590 all over again, so the wiring is asserted rather than assumed.

`ctx.context` is shared with other guards, so
`test_the_guard_stores_its_state_under_a_namespaced_key` asserts the fact-forcing state alongside it
is untouched — a key collision there would be silent.

## Follow-on

This lands the pair-key that **#13764** is blocked on. That issue proposes lowering the
`max_identical_tool_calls` default 3 → 2, and states the sequencing constraint that at a
call-fingerprint-only key, 2 is aggressive. With the pair key in place, that constraint is satisfied.
This PR does **not** change the default — that is #13764's own call.

## Model Used

Claude Opus 5 (1M context)
