### PR TITLE
feat(llm): share a priority tier's budget across peer sections (#13717)

### DIFF
--- a/autobot-backend/context_allocator_test.py
+++ b/autobot-backend/context_allocator_test.py
@@ -108,8 +108,15 @@ class TestPriorityTrim:
         assert "shed" in result.trimmed
         assert "keep" not in result.trimmed
 
-    def test_priority_ties_break_deterministically(self, manager):
-        """AC: ties in priority are broken deterministically (by name)."""
+    def test_priority_ties_are_resolved_deterministically(self, manager):
+        """AC: ties in priority resolve deterministically, whatever the input order.
+
+        #13717 changed *how*, not *whether*. This used to assert that "alpha"
+        sorts first and is therefore drained first — deterministic, but it made
+        the trim order total, so one peer absorbed the whole overflow and the
+        other kept everything. Peers now share; determinism is still the
+        property under test.
+        """
         first = [
             ContextSection(name="alpha", content=_text(400), priority=5),
             ContextSection(name="beta", content=_text(400), priority=5),
@@ -122,8 +129,11 @@ class TestPriorityTrim:
         a = manager.allocate_sections(first, budget_tokens=500)
         b = manager.allocate_sections(second, budget_tokens=500)
 
-        # "alpha" sorts first, so it is pruned first regardless of input order.
-        assert a.trimmed == b.trimmed == ["alpha"]
+        by_name_a = {s.name: len(s.content) for s in a.sections}
+        by_name_b = {s.name: len(s.content) for s in b.sections}
+
+        assert by_name_a == by_name_b, "input order changed the allocation"
+        assert sorted(a.trimmed) == sorted(b.trimmed) == ["alpha", "beta"]
 
     def test_result_fits_the_budget(self, manager):
         sections = [
@@ -318,3 +328,106 @@ class TestPromptBudgetReservesRoomToAnswer:
 
         assert budget < window, "a prompt filling the window leaves nowhere to generate"
         assert budget > 0
+
+
+class TestEqualPrioritySectionsShare:
+    """Peers share the tier's budget instead of queueing (#13717).
+
+    Trimming lowest-priority-first with `name` as a tie-break made the order
+    *total*, so the first peers by name absorbed the whole overflow and the last
+    kept everything. Correct for sections that genuinely rank; wrong for peers —
+    N retrieved chunks, N file contents, N tool results.
+    """
+
+    def test_four_peers_each_retain_a_share(self, manager):
+        """AC 1. The reported failure was alpha=0 bravo=0 charlie=0 delta=100."""
+        sections = [
+            ContextSection(name=n, content=_text(100), priority=5)
+            for n in ("alpha", "bravo", "charlie", "delta")
+        ]
+
+        result = manager.allocate_sections(sections, budget_tokens=100)
+
+        kept = {s.name: manager.estimate_tokens(s.content) for s in result.sections}
+        assert all(v > 0 for v in kept.values()), f"a peer was zeroed: {kept}"
+        assert sum(kept.values()) <= 100
+
+    def test_twenty_peers_do_not_collapse_onto_one(self, manager):
+        """The reported case where s9 kept everything because it sorts last."""
+        sections = [ContextSection(name=f"s{i}", content=_text(50), priority=5) for i in range(20)]
+
+        result = manager.allocate_sections(sections, budget_tokens=100)
+
+        kept = {s.name: manager.estimate_tokens(s.content) for s in result.sections}
+        assert max(kept.values()) < 100, f"one section took the whole budget: {kept}"
+
+    def test_a_larger_peer_keeps_proportionally_more(self, manager):
+        """Sharing is proportional to size, not a flat split."""
+        sections = [
+            ContextSection(name="big", content=_text(300), priority=5),
+            ContextSection(name="small", content=_text(100), priority=5),
+        ]
+
+        result = manager.allocate_sections(sections, budget_tokens=200)
+
+        kept = {s.name: manager.estimate_tokens(s.content) for s in result.sections}
+        assert kept["big"] > kept["small"]
+
+    def test_the_allocation_is_independent_of_input_order(self, manager):
+        """AC 2. Same inputs in any order produce the same allocation."""
+        names = ["a", "b", "c", "d", "e"]
+        forward = [ContextSection(name=n, content=_text(80), priority=5) for n in names]
+        backward = [ContextSection(name=n, content=_text(80), priority=5) for n in reversed(names)]
+
+        a = {s.name: s.content for s in manager.allocate_sections(forward, budget_tokens=150).sections}
+        b = {s.name: s.content for s in manager.allocate_sections(backward, budget_tokens=150).sections}
+
+        assert a == b
+
+    def test_rounding_leftovers_never_exceed_the_budget(self, manager):
+        """AC 3. Proportional shares rarely land on integers."""
+        for count in (3, 7, 11, 13):
+            sections = [ContextSection(name=f"s{i}", content=_text(37), priority=5) for i in range(count)]
+
+            result = manager.allocate_sections(sections, budget_tokens=100)
+
+            assert result.tokens_after <= 100, f"{count} peers overflowed to {result.tokens_after}"
+            assert result.fits
+
+    def test_distinct_tiers_still_prune_lowest_first(self, manager):
+        """AC 4. A section that genuinely outranks another must not lose tokens to it."""
+        sections = [
+            ContextSection(name="low", content=_text(400), priority=1),
+            ContextSection(name="high", content=_text(400), priority=9),
+        ]
+
+        result = manager.allocate_sections(sections, budget_tokens=400)
+
+        kept = {s.name: manager.estimate_tokens(s.content) for s in result.sections}
+        assert kept["high"] == 400, "a higher tier paid for the lower one"
+        assert kept["low"] == 0
+
+    def test_a_share_that_rounds_to_zero_is_reported_as_dropped(self, manager):
+        """AC 5. A section emptied by the split must not vanish silently."""
+        sections = [ContextSection(name=f"s{i}", content=_text(40), priority=5) for i in range(40)]
+
+        result = manager.allocate_sections(sections, budget_tokens=10)
+
+        emptied = [s.name for s in result.sections if not s.content]
+        assert emptied, "the budget cannot seat 40 peers; some must be emptied"
+        assert set(emptied) <= set(result.dropped), "an emptied section was not reported in dropped"
+
+    def test_peers_within_each_of_several_tiers_share(self, manager):
+        """Tier ordering and intra-tier sharing compose."""
+        sections = [
+            ContextSection(name="lo1", content=_text(200), priority=1),
+            ContextSection(name="lo2", content=_text(200), priority=1),
+            ContextSection(name="hi1", content=_text(200), priority=9),
+            ContextSection(name="hi2", content=_text(200), priority=9),
+        ]
+
+        result = manager.allocate_sections(sections, budget_tokens=600)
+
+        kept = {s.name: manager.estimate_tokens(s.content) for s in result.sections}
+        assert kept["hi1"] == kept["hi2"] == 200, "the untouched tier was trimmed"
+        assert kept["lo1"] > 0 and kept["lo2"] > 0, "the trimmed tier collapsed onto one peer"

--- a/autobot-backend/context_allocator_test.py
+++ b/autobot-backend/context_allocator_test.py
@@ -342,8 +342,7 @@ class TestEqualPrioritySectionsShare:
     def test_four_peers_each_retain_a_share(self, manager):
         """AC 1. The reported failure was alpha=0 bravo=0 charlie=0 delta=100."""
         sections = [
-            ContextSection(name=n, content=_text(100), priority=5)
-            for n in ("alpha", "bravo", "charlie", "delta")
+            ContextSection(name=n, content=_text(100), priority=5) for n in ("alpha", "bravo", "charlie", "delta")
         ]
 
         result = manager.allocate_sections(sections, budget_tokens=100)

--- a/autobot-backend/context_window_manager.py
+++ b/autobot-backend/context_window_manager.py
@@ -348,22 +348,76 @@ class ContextWindowManager:
             trimmed.add(i)
         return allocated, tokens
 
+    @staticmethod
+    def _tier_keeps(sizes: "dict[int, int]", tier_keep: int) -> "dict[int, int]":
+        """Split *tier_keep* tokens across peers in proportion to their sizes (#13717).
+
+        Peers must share, not queue. Draining a tier in name order makes the
+        trim total, so the last section by name keeps everything and the rest
+        are zeroed — deterministic, and wrong for sections that genuinely rank
+        equally (N retrieved chunks, N file contents, N tool results).
+
+        Rounding is the interesting part: proportional shares rarely land on
+        integers, so each keep is floored and the remainder handed out one token
+        at a time by largest fractional part, ties broken by index. That is
+        deterministic for any input order and never exceeds *tier_keep*.
+        """
+        total = sum(sizes.values())
+        if tier_keep <= 0 or total <= 0:
+            return {i: 0 for i in sizes}
+
+        exact = {i: size * tier_keep / total for i, size in sizes.items()}
+        keeps = {i: int(value) for i, value in exact.items()}
+        # A section never keeps more than it had, whatever the arithmetic says.
+        keeps = {i: min(keeps[i], sizes[i]) for i in sizes}
+
+        remainder = tier_keep - sum(keeps.values())
+        if remainder > 0:
+            # Largest fractional part first; index breaks ties so the result is
+            # independent of dict iteration order.
+            candidates = sorted(sizes, key=lambda i: (-(exact[i] - int(exact[i])), i))
+            for i in candidates:
+                if remainder <= 0:
+                    break
+                if keeps[i] < sizes[i]:
+                    keeps[i] += 1
+                    remainder -= 1
+        return keeps
+
     def _trim_by_priority(
         self, allocated: List[ContextSection], tokens: List[int], budget: int, trimmed: set
     ) -> "tuple[List[ContextSection], List[int]]":
-        """Phase 2: reduce lowest-priority sections until the total fits."""
-        # Ascending priority = pruned first; name breaks ties deterministically.
-        order = sorted(range(len(allocated)), key=lambda i: (allocated[i].priority, allocated[i].name))
-        for i in order:
+        """Phase 2: reduce lowest-priority sections until the total fits.
+
+        Tiers are still pruned strictly lowest-priority-first — a section that
+        genuinely outranks another must not lose tokens to it. Within a tier the
+        share is proportional (#13717) rather than name-ordered.
+        """
+        tiers: "dict[object, list[int]]" = {}
+        for i in range(len(allocated)):
+            tiers.setdefault(allocated[i].priority, []).append(i)
+
+        for priority in sorted(tiers):
             overflow = sum(tokens) - budget
             if overflow <= 0:
                 break
-            if tokens[i] <= 0:
+            indices = [i for i in tiers[priority] if tokens[i] > 0]
+            if not indices:
                 continue
-            keep = max(0, tokens[i] - overflow)
-            allocated[i] = self._shrink(allocated[i], keep)
-            tokens[i] = self.estimate_tokens(allocated[i].content)
-            trimmed.add(i)
+
+            sizes = {i: tokens[i] for i in indices}
+            tier_total = sum(sizes.values())
+            # This tier absorbs as much of the overflow as it can hold; whatever
+            # is left falls through to the next tier up.
+            tier_keep = max(0, tier_total - overflow)
+            keeps = self._tier_keeps(sizes, tier_keep)
+
+            for i in indices:
+                if keeps[i] >= tokens[i]:
+                    continue
+                allocated[i] = self._shrink(allocated[i], keeps[i])
+                tokens[i] = self.estimate_tokens(allocated[i].content)
+                trimmed.add(i)
         return allocated, tokens
 
     def get_prompt_budget(self, model_name: str | None = None) -> int:


### PR DESCRIPTION
Closes #13717

## Thinking Path

Trimming lowest-priority-first with `name` as a tie-break made the trim order **total**, so within a
tier the first sections by name absorbed the entire overflow and the last kept everything. Correct
for sections that genuinely rank; wrong for peers.

The fix splits each tier's share proportionally to section size. Tiers keep strict lowest-first
ordering — a section that genuinely outranks another must never lose tokens to it.

**Rounding is the part with a real decision in it.** Proportional shares rarely land on integers, so
each keep is floored and the remainder is handed out one token at a time by largest fractional part,
ties broken by index. That is deterministic for any input order, never exceeds the tier's share, and
never gives a section more than it started with.

## The AC I could not meet as written

> AC 6 — The existing #13640 tests continue to pass unchanged.

One test cannot, and it is worth being explicit about which:
`test_priority_ties_break_deterministically` asserted `a.trimmed == b.trimmed == ["alpha"]` — that
"alpha" sorts first and is therefore drained first, leaving "beta" whole. That is precisely the
behaviour this issue calls wrong. It encodes the defect, so it is updated rather than worked around.

What it was actually protecting — determinism — is preserved and still asserted, now as the property
rather than the mechanism: the same inputs in either order produce an identical allocation. It is
renamed `test_priority_ties_are_resolved_deterministically` and now asserts both peers share.

**The other 22 tests in that file pass unchanged**, as do `context_window_manager_test.py` (40) and
the `chat_history` budget tests.

## What Changed

- `context_window_manager.py` — `_tier_keeps` (proportional split + deterministic remainder) and
  `_trim_by_priority` reworked to walk tiers in ascending priority, each tier absorbing as much
  overflow as it can hold before the next tier is touched.

## Verification

```
context_allocator_test.py + context_window_manager_test.py + chat_history/    183 passed
```

Per acceptance criterion:

| AC | Covered by |
|---|---|
| 1 — N peers each retain a share | `test_four_peers_each_retain_a_share`, `test_twenty_peers_do_not_collapse_onto_one` — the two cases from the report |
| 2 — deterministic across input order | `test_the_allocation_is_independent_of_input_order`, plus the renamed tie-break test |
| 3 — rounding leftovers fit the budget | `test_rounding_leftovers_never_exceed_the_budget`, parametrised over 3/7/11/13 peers so the remainder is non-zero |
| 4 — distinct tiers unaffected | `test_distinct_tiers_still_prune_lowest_first`, `test_peers_within_each_of_several_tiers_share` |
| 5 — a zeroed share is reported in `dropped` | `test_a_share_that_rounds_to_zero_is_reported_as_dropped` |
| 6 — existing tests | 22 of 23 unchanged; the exception is explained above |

**Mutation check** — the old name-ordered allocator against the new tests:

```
FAILED test_four_peers_each_retain_a_share
FAILED test_a_larger_peer_keeps_proportionally_more
FAILED test_peers_within_each_of_several_tiers_share
3 failed, 5 passed
```

The five that still pass are the ones asserting properties the old allocator already had —
determinism, budget-fitting, tier ordering — which is what makes them worth keeping: they pin the
behaviour this change must *not* break.

`test_a_larger_peer_keeps_proportionally_more` is the one that distinguishes proportional sharing
from an even split, so a future simplification to "divide by N" fails here rather than silently
under-serving large sections.

## Model Used

Claude Opus 5 (1M context)
