### PR TITLE
ci: attribute bot pushes to a human token so their runs are not parked (#13791)

### DIFF
--- a/.github/workflows/auto-fix-formatting.yml
+++ b/.github/workflows/auto-fix-formatting.yml
@@ -27,7 +27,14 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ github.head_ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # #13791: prefer a token attributed to a human. Pushing with the
+          # default GITHUB_TOKEN attributes the commit to github-actions[bot],
+          # and this repository's fork-PR policy (all_external_contributors)
+          # treats that bot as external — so every run the push triggers is
+          # created with conclusion=action_required and never starts. Falls back
+          # to GITHUB_TOKEN so this workflow keeps working before the secret is
+          # configured; the runs simply park as they do today.
+          token: ${{ secrets.AUTOBOT_PUSH_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Set up Python 3.12
         uses: ./.github/actions/setup-python-ci

--- a/.github/workflows/auto-fix-generated-types.yml
+++ b/.github/workflows/auto-fix-generated-types.yml
@@ -34,7 +34,14 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ github.head_ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # #13791: prefer a token attributed to a human. Pushing with the
+          # default GITHUB_TOKEN attributes the commit to github-actions[bot],
+          # and this repository's fork-PR policy (all_external_contributors)
+          # treats that bot as external — so every run the push triggers is
+          # created with conclusion=action_required and never starts. Falls back
+          # to GITHUB_TOKEN so this workflow keeps working before the secret is
+          # configured; the runs simply park as they do today.
+          token: ${{ secrets.AUTOBOT_PUSH_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Set up Python 3.14
         uses: actions/setup-python@v7

--- a/.github/workflows/auto-update-pr-branches.yml
+++ b/.github/workflows/auto-update-pr-branches.yml
@@ -54,7 +54,9 @@ jobs:
       # dance (apt keyring + sudo) is no longer needed (#13401).
       - name: Update out-of-date PR branches
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # #13791: see auto-fix-formatting.yml — a human-attributed token
+          # keeps the runs this update triggers out of action_required.
+          GH_TOKEN: ${{ secrets.AUTOBOT_PUSH_TOKEN || secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           # #13426: how many stale branches one sweep may refresh.
           #
@@ -205,7 +207,7 @@ jobs:
 
       - name: Approve parked runs and publish dispatch state
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.AUTOBOT_PUSH_TOKEN || secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           WATCHDOG_BASE_BRANCH: Dev_new_gui
         run: python3 pipeline-scripts/ci_dispatch_watchdog.py --check dispatch

--- a/docs/developer/CI_BOT_ATTRIBUTION.md
+++ b/docs/developer/CI_BOT_ATTRIBUTION.md
@@ -1,0 +1,86 @@
+# Why CI runs park, and the token that stops it (#13791)
+
+## Symptom
+
+A pull request shows a handful of checks — often just `semgrep-cloud-platform/scan` —
+and reads as green. It has not been tested: the rest of its workflow runs were
+created with `conclusion=action_required` and never started.
+
+Counting the checks is the tell. A PR with 50+ checks ran; a PR with 1 did not.
+
+## Cause
+
+The repository's fork-PR policy is `all_external_contributors`:
+
+```
+$ gh api repos/mrveiss/AutoBot-AI/actions/permissions/fork-pr-contributor-approval
+{"approval_policy":"all_external_contributors"}
+```
+
+That policy is correct and should stay. This is a public repository that accepts
+fork pull requests, and `pull_request` jobs run on a **self-hosted** runner —
+so an unapproved fork run would execute contributor-supplied code on the owner's
+machine.
+
+The problem is that the policy also catches `github-actions[bot]`. Any workflow
+that pushes with the default `GITHUB_TOKEN` attributes its commit to that bot,
+and every run the push triggers is treated as external and parked:
+
+```
+issue-13590:  49 runs  actor=mrveiss              -> ran
+              23 runs  actor=github-actions[bot]  -> all parked
+```
+
+The owner is never the problem. Their own pushes dispatch normally.
+
+## Fix
+
+Workflows that push prefer `AUTOBOT_PUSH_TOKEN`, falling back to `GITHUB_TOKEN`:
+
+```yaml
+token: ${{ secrets.AUTOBOT_PUSH_TOKEN || secrets.GITHUB_TOKEN }}
+```
+
+The fallback matters: without the secret configured the workflows behave exactly
+as they do today rather than failing, so this change is safe to land before the
+secret exists.
+
+### Configuring the secret
+
+A fine-grained personal access token scoped to this repository:
+
+| Permission | Level |
+|---|---|
+| Contents | Read and write |
+| Pull requests | Read and write |
+| Workflows | Read and write (only if a pushed change touches `.github/workflows/`) |
+
+Store it as the repository secret `AUTOBOT_PUSH_TOKEN`.
+
+### Applies to
+
+- `.github/workflows/auto-fix-formatting.yml`
+- `.github/workflows/auto-fix-generated-types.yml`
+- `.github/workflows/auto-update-pr-branches.yml`
+
+## The safety net
+
+`ci-dispatch-watchdog.yml` sweeps parked runs every 15 minutes and approves only
+those whose head repository is this repository **and** whose triggering actor is
+the bot — fork PRs are never approved, only reported.
+
+That cron only fires from the **default branch**. The workflow must therefore
+exist on `main`, not only on `Dev_new_gui`; until it does, the schedule never
+runs and the sweep is limited to `push` and `pull_request` events:
+
+```
+$ gh api .../workflows/ci-dispatch-watchdog.yml/runs --jq '[.workflow_runs[].event]|group_by(.)|map({event:.[0],n:length})'
+[{"event":"pull_request","n":73},{"event":"push","n":27}]     # schedule: 0
+```
+
+## What not to do
+
+Do not relax the policy to `first_time_contributors` to make parking stop. It
+would let a returning external contributor run code on the self-hosted runner
+without approval — which is the exact exposure `all_external_contributors`
+exists to prevent, and the repository has live fork pull requests today.


### PR DESCRIPTION
Part of #13791 (the attribution half; the watchdog-on-main half is a separate PR against `main`).

## Thinking Path

The obvious fix — relax `all_external_contributors` — is the one I did **not** take. That policy is
what stops a fork pull request executing contributor code on the self-hosted runner, and there is a
live external fork PR today (#13720). Loosening it would trade a real security boundary for a
convenience.

The parking is not caused by the policy being too strict. It is caused by pushes being attributed to
`github-actions[bot]`, which the policy then correctly treats as external:

```
issue-13590:  49 runs  actor=mrveiss              -> ran
              23 runs  actor=github-actions[bot]  -> all parked
```

So the fix is at the source: give the pushing workflows a token attributed to a human.

**The fallback is the part that makes this safe to land now.**
`${{ secrets.AUTOBOT_PUSH_TOKEN || secrets.GITHUB_TOKEN }}` means the workflows behave exactly as
they do today until the secret is configured — no failure, no behaviour change, just the same parking
as before. Landing it before the secret exists is therefore risk-free, and the fix activates the
moment the secret appears.

## What Changed

- `auto-fix-formatting.yml`, `auto-fix-generated-types.yml` — checkout token.
- `auto-update-pr-branches.yml` — both `GH_TOKEN` and `GITHUB_TOKEN`.
- `docs/developer/CI_BOT_ATTRIBUTION.md` — the symptom, the check-count tell, the token's required
  scopes, and why relaxing the policy is the wrong fix.

## Verification

All three workflows parse:

```
auto-fix-formatting.yml       -> parses
auto-fix-generated-types.yml  -> parses
auto-update-pr-branches.yml   -> parses
```

The diagnosis is reproducible from the API rather than inferred:

```
$ gh api repos/mrveiss/AutoBot-AI/actions/permissions/fork-pr-contributor-approval
{"approval_policy":"all_external_contributors"}

$ gh api repos/mrveiss/AutoBot-AI/pulls/13789 --jq '{assoc:.author_association, is_fork:.head.repo.fork}'
{"assoc":"OWNER","is_fork":false}
```

Owner-authored, same-repo, not a fork — so the fork policy was never about the owner.

**After the secret is configured**, the check is a bot push producing runs that dispatch: a PR whose
branch is refreshed by `auto-update-pr-branches` should show its full check set rather than one.

## Model Used

Claude Opus 5 (1M context)
