### PR TITLE
ci(watchdog): put the dispatch watchdog on main so its cron actually fires (#13791)

### DIFF
--- a/.github/workflows/ci-dispatch-watchdog.yml
+++ b/.github/workflows/ci-dispatch-watchdog.yml
@@ -1,0 +1,164 @@
+# CI dispatch watchdog — #12823, #13045
+#
+# Guards the two ways a pull request ends up reading as "waiting for CI" with
+# nothing actually queued:
+#
+#   #12823  auto-update-pr-branches refreshes stale PR branches with the default
+#           GITHUB_TOKEN, so the merge commit is pushed as github-actions[bot].
+#           The repository's fork-PR approval policy treats that bot as an
+#           external contributor, so every run it triggers is created with
+#           conclusion=action_required and never starts. The head commit then
+#           carries zero executed checks, and `gh pr checks` reports nothing at
+#           all — not pending, not failing. Tooling that reads "no failures" as
+#           "ready" will happily merge it.
+#
+#   #13045  While the singleton self-hosted runner pool is empty, runs are
+#           created but never allocate a job. A required context never reports,
+#           `commits/{sha}/status` stays pending forever, and the PR shows
+#           "19 success / 0 failures" while being structurally unmergeable.
+#
+# This workflow approves what it is permitted to approve, and — regardless of
+# whether approval succeeds — publishes a `ci-dispatch-watchdog` commit status
+# on every open PR head. Absence of CI therefore becomes a visible, named,
+# non-green context instead of silence.
+#
+# FORK SAFETY: `POST /actions/runs/{id}/approve` is the approve-a-fork-run
+# endpoint. This repository is public, takes fork pull requests, and runs
+# `pull_request` jobs on the self-hosted runner, so approving a fork run would
+# execute contributor-supplied code on the owner's machine — the very thing the
+# `all_external_contributors` policy exists to stop. The sweep therefore
+# approves only runs whose head repository is this repository AND whose
+# triggering actor is the branch-update bot. Fork pull requests get a published
+# status; they never get an approval.
+#
+# runs-on is ubuntu-latest on every job by design: the self-hosted runner is a
+# singleton, and a watchdog that queues behind the outage it exists to report
+# is useless.
+
+name: CI Dispatch Watchdog
+
+on:
+  schedule:
+    # Every 15 minutes. Scheduled runs are attributed to the repository, not to
+    # github-actions[bot] as a contributor, so this workflow itself is never
+    # subject to the approval policy it repairs.
+    #
+    # LIVE as of #13791. GitHub only dispatches `schedule` from the DEFAULT
+    # branch, so for the first 100 runs of this workflow — 73 `pull_request`,
+    # 27 `push`, zero `schedule` — the cron did nothing: the file existed only
+    # on Dev_new_gui. It is now also on `main`, which is what makes the sweep
+    # periodic rather than incidental.
+    #
+    # Keep this copy in sync with the Dev_new_gui one. The push and
+    # pull_request hooks below are still not redundant: they catch a PR head
+    # parking within seconds rather than up to 15 minutes later.
+    - cron: '*/15 * * * *'
+  push:
+    branches: [Dev_new_gui]
+  workflow_dispatch:
+  pull_request:
+    # A PR head moving is the moment its CI either dispatches or parks, so the
+    # sweep runs then rather than waiting for the next base push. Previously
+    # this trigger was filtered to the watchdog's own files, which made it a
+    # self-test and nothing more.
+    #
+    # This does NOT replace the push/`needs:` hooks, and cannot: the #12823
+    # parking is caused by github-actions[bot] pushing a merge commit to a PR
+    # head, and the `synchronize` event that push raises is itself attributed to
+    # the bot — so a watchdog run triggered by it would be parked awaiting the
+    # very approval it exists to grant. The bot case is repaired by the
+    # `approve-refreshed-runs` job in auto-update-pr-branches.yml. What this
+    # trigger adds is immediate coverage for every OTHER way a head moves.
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  # Never cancel a sweep in flight — a half-finished sweep leaves some PRs
+  # without a published status, which is the exact condition being guarded.
+  group: ci-dispatch-watchdog
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  actions: write
+  statuses: write
+  pull-requests: read
+
+jobs:
+  watchdog:
+    name: Approve parked runs and publish dispatch state
+    # Fork pull requests are skipped outright rather than run read-only.
+    # A `pull_request` run from a fork gets a read-only GITHUB_TOKEN, so the
+    # approval-capability probe would come back "token lacks permission" and
+    # fail the job — a permanent red check on every fork PR reporting a
+    # condition that is correct and expected. Skipping also means no
+    # fork-supplied copy of this workflow is ever executed by a job holding
+    # `actions: write`. Fork PRs still get a published status from the
+    # scheduled and base-push sweeps, which run from this repository.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+
+      # Answers "may this workflow's GITHUB_TOKEN approve a parked run?" and
+      # nothing else. It POSTs approve against a run that already succeeded,
+      # which GitHub rejects on state grounds, so it has no side effect and is
+      # safe on an unreviewed branch. It is a separate step from the sweep
+      # because --dry-run deliberately issues no approve request and so cannot
+      # answer the question — the omission that made an earlier self-test report
+      # "probe skipped" while the job passed.
+      - name: Report approval capability
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: python3 pipeline-scripts/ci_dispatch_watchdog.py --check probe
+
+      - name: Sweep open PRs
+        if: ${{ !cancelled() }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          WATCHDOG_BASE_BRANCH: Dev_new_gui
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          if [ "$EVENT_NAME" != "pull_request" ]; then
+            python3 pipeline-scripts/ci_dispatch_watchdog.py --check dispatch
+            exit 0
+          fi
+
+          # A `pull_request` job executes the workflow and the script AS THEY
+          # EXIST ON THE PR HEAD. That is safe precisely when the PR does not
+          # touch them: the code then byte-matches the reviewed copy on the base
+          # branch. When the PR DOES touch them, the sweep drops to --dry-run,
+          # so unreviewed watchdog code never reaches `approve` or `statuses`
+          # while holding write permission. The listing failing is treated as
+          # self-modification — fail closed, never open.
+          SELF_MODIFYING=yes
+          if CHANGED=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" \
+                --paginate --jq '.[].filename'); then
+            case "$CHANGED" in
+              *ci_dispatch_watchdog*|*ci-dispatch-watchdog*) SELF_MODIFYING=yes ;;
+              *) SELF_MODIFYING=no ;;
+            esac
+          else
+            echo "Could not list changed files — treating this PR as self-modifying."
+          fi
+
+          if [ "$SELF_MODIFYING" = "yes" ]; then
+            echo "PR #$PR_NUMBER modifies the watchdog — self-test only, no writes."
+            python3 pipeline-scripts/ci_dispatch_watchdog.py --check dispatch --dry-run
+          else
+            # Scoped to the firing PR: a full-queue sweep costs
+            # poll_attempts+2 API calls per open PR, which on every PR event
+            # would consume the shared 1,000/hour GITHUB_TOKEN budget. The
+            # schedule and base-push sweeps still cover every head.
+            echo "Sweeping PR #$PR_NUMBER only."
+            WATCHDOG_ONLY_PR="$PR_NUMBER" \
+              python3 pipeline-scripts/ci_dispatch_watchdog.py --check dispatch
+          fi

--- a/pipeline-scripts/ci_dispatch_watchdog.py
+++ b/pipeline-scripts/ci_dispatch_watchdog.py
@@ -1,0 +1,1360 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""
+CI dispatch watchdog for AutoBot.
+
+Two distinct failure modes leave a pull request reading as "waiting for CI"
+forever while nothing is actually queued. Both surface identically to any
+tooling that summarises check conclusions (``statusCheckRollup == null``,
+"19 success / 0 failures"), and neither produces a signal of its own:
+
+1. **Parked runs (#12823).** ``auto-update-pr-branches`` refreshes stale PR
+   branches through ``PUT /pulls/{n}/update-branch``. With the default
+   ``GITHUB_TOKEN`` the resulting merge commit is authored and pushed by
+   ``github-actions[bot]``. The repository's fork-PR approval policy
+   (``all_external_contributors``) treats that bot as an external
+   contributor, so every ``pull_request`` run it triggers is created with
+   ``conclusion=action_required`` and never starts. The PR then carries a
+   head commit with *no executed checks at all*.
+
+2. **Undispatched / starved runs (#13045).** When the singleton self-hosted
+   runner pool is empty, runs are created but never allocate a job. They sit
+   at ``status=queued`` with ``jobs: []`` indefinitely, so a required context
+   never reports and ``commits/{sha}/status`` stays ``pending`` forever.
+   ``POST /actions/runs/{id}/approve`` cannot help these — they are not
+   waiting for approval, they are waiting for hardware.
+
+This module handles both:
+
+* ``--check dispatch`` — probes whether the caller's token may approve
+  workflow runs at all, approves the parked runs belonging to the current
+  head commit of each open *same-repository* PR (bounded), and then publishes
+  a commit status on every open PR head describing the dispatch state. A PR
+  whose CI never dispatched therefore carries a visible, named, non-green
+  context instead of silently reading as ready.
+* ``--check probe`` — prints nothing but the credential verdict. It POSTs
+  ``approve`` against a run that already succeeded, which GitHub rejects on
+  state grounds, so it changes nothing and is safe to run from an unreviewed
+  branch. This exists because ``--dry-run`` deliberately issues no approve
+  request and therefore cannot answer the question at all.
+* ``--check runner-starvation`` — reports runs that have been queued past a
+  threshold while no self-hosted job is executing, and separately reports
+  self-hosted jobs still executing well past the longest timeout any job in
+  this repository declares. The ``/actions/runners`` administration endpoint
+  returns ``403 Resource not accessible by integration`` for ``GITHUB_TOKEN``,
+  so runner liveness is inferred from ``GET /actions/runs/{id}/jobs`` labels
+  instead.
+
+A third failure mode joins those two, and it is the reason the second one is
+not sufficient on its own (#13341). A job can WEDGE rather than end: the
+required ``Unit & Integration Tests`` context ran for over three hours against
+a declared ``timeout-minutes: 30``, because GitHub enforces that timeout from
+the runner side and a runner that has stopped making progress never receives
+the cancellation. The consequences compound — the job holds a required context
+that no merge can proceed without, and it holds the singleton self-hosted
+runner that every other job needs.
+
+It is also INVISIBLE. An in-progress check is rendered exactly like a healthy
+one, so nothing distinguishes "running" from "wedged" but elapsed time. Worse,
+a wedged job makes the starvation probe read the pool as ALIVE: a hung job is
+``status=in_progress`` on a ``self-hosted`` label, which is precisely the
+signal ``self_hosted_pool_is_serving`` treats as proof of health. Queued work
+piling up behind it is then reported as "contention, not an outage" — a false
+negative in exactly the scenario the probe exists for. Overdue jobs are
+therefore excluded from the liveness verdict AND reported in their own right.
+
+**Fork safety.** ``POST /actions/runs/{id}/approve`` is GitHub's
+*approve-a-fork-pull-request-run* endpoint: releasing gated fork runs is its
+entire purpose. This repository is public, receives fork pull requests, sets
+``all_external_contributors`` deliberately, and runs several
+``pull_request`` jobs on a self-hosted runner. Auto-approving a fork run would
+therefore execute contributor-controlled code — ``npm ci`` and its lifecycle
+scripts among it — on the owner's own machine, which is exactly what the
+approval policy exists to prevent. Approval is consequently restricted to runs
+whose head repository is this repository AND whose triggering actor is the
+branch-update bot. Fork pull requests still receive a published *status*; they
+never receive an approval.
+
+Usage:
+    pipeline-scripts/ci_dispatch_watchdog.py --check dispatch
+    pipeline-scripts/ci_dispatch_watchdog.py --check dispatch --dry-run
+    pipeline-scripts/ci_dispatch_watchdog.py --check probe
+    pipeline-scripts/ci_dispatch_watchdog.py --check runner-starvation
+
+Environment:
+    GITHUB_TOKEN                     required — API credential
+    GITHUB_REPOSITORY                required — "owner/repo"
+    GITHUB_API_URL                   API root (default https://api.github.com)
+    WATCHDOG_BASE_BRANCH             PR base to watch (default Dev_new_gui)
+    WATCHDOG_GRACE_MINUTES           age before "no runs at all" is a failure
+    WATCHDOG_STALL_MINUTES           age before a job-less queued run is a failure
+    WATCHDOG_MAX_APPROVALS           per-sweep approval cap (blast-radius guard; exceeding it fails)
+    WATCHDOG_POLL_ATTEMPTS           re-list attempts while runs appear
+    WATCHDOG_POLL_INTERVAL_SECONDS   delay between those attempts
+    WATCHDOG_STATUS_CONTEXT          commit status context name
+    WATCHDOG_MAX_JOB_LOOKUPS         runs inspected for runner liveness per check
+    WATCHDOG_JOB_OVERDUE_MINUTES     runtime after which a self-hosted job is wedged
+    WATCHDOG_ONLY_PR                 sweep just this PR number (default: every open PR)
+
+Exit codes:
+    0  nothing wrong, or everything wrong was repaired
+    1  the sweep finished with parked runs still outstanding. Two distinct
+       causes, reported separately because they need different fixes:
+
+       * an approval was REFUSED on permission grounds — the credential cannot
+         release parked runs (see ``REMEDIATION``); or
+       * the per-sweep approval cap was EXHAUSTED before the queue was clear
+         (see ``budget_exhausted_message``). Nothing was refused and the
+         credential is fine; there were simply more parked runs than one sweep
+         is allowed to release.
+
+       A third case is deliberately NOT a failure: an approve attempt that
+       comes back "not waiting for approval" means a concurrent sweep already
+       released the run. That is the outcome this tool wants, and it is the
+       exact message ``interpret_probe`` reads as proof the credential is
+       permitted, so counting it as a refusal used to make a benign race print
+       a demand to relax repository security settings. See
+       ``is_already_released``.
+    2  internal error: configuration missing, or the API could not be reached
+       at all. Never used for "the API answered and the answer was bad news".
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import socket
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
+from typing import Any, Dict, List, NamedTuple, Optional, Sequence, Set, Tuple
+
+# GitHub returns this message when the *token* lacks `actions: write`.
+PERMISSION_DENIED_MARKER = "resource not accessible"
+# ...and this one when the token is fine but the run is in the wrong state.
+# Seeing it proves the credential may approve runs.
+NOT_WAITING_MARKER = "not waiting for approval"
+
+# The only actor whose parked runs this tool releases. Runs parked for any other
+# reason are reported, never approved — see the fork-safety note above.
+UPDATE_BOT_LOGIN = "github-actions[bot]"
+
+# A job carrying this label ran on the self-hosted pool.
+SELF_HOSTED_LABEL = "self-hosted"
+
+# GitHub truncates commit-status descriptions beyond this length.
+MAX_STATUS_DESCRIPTION = 140
+
+# Run states that mean "created but no job has started yet".
+UNSTARTED_RUN_STATUSES = frozenset({"queued", "waiting", "pending", "requested"})
+
+# Deliberately narrower than UNSTARTED_RUN_STATUSES (#13439). A run holding a
+# concurrency group while a newer one waits is ``queued`` or ``pending``.
+# ``waiting`` and ``requested`` are approval gates — a human or a policy has yet
+# to release them — and force-cancelling those would destroy work nobody has
+# decided about rather than clearing a stuck queue.
+STUCK_QUEUE_STATUSES = frozenset({"queued", "pending"})
+
+# Transport failure — no HTTP status was ever received.
+NO_RESPONSE_STATUS = 0
+
+DEFAULT_API_ROOT = "https://api.github.com"
+DEFAULT_BASE_BRANCH = "Dev_new_gui"
+DEFAULT_GRACE_MINUTES = 10
+DEFAULT_STALL_MINUTES = 45
+# Sized from measurement, not preference. A single base merge parks every run
+# on every open PR, and the run count carried by one head in this repository was
+# measured at 20, 22, 24 and 27 across four PRs on 2026-08-02 — call it 27, the
+# worst observed. Ten open PRs is comfortably above the working queue seen since
+# the PR queue limit was removed and well below the 25 that pr-queue-gate treats
+# as a runaway, so 27 x 10 clears a realistic queue in ONE pass.
+#
+# The old value of 30 was below the cost of a SINGLE merge with two PRs open, so
+# every sweep on a real queue stopped part-way and promised a "next sweep" that
+# the never-firing schedule could not provide. Observed: 30 approved, 0 refused,
+# 4 PRs left parked.
+#
+# It remains a blast-radius guard, and exhausting it is now a hard error rather
+# than a line of log. Worst case it spends 270 of the 1,000/hour GITHUB_TOKEN
+# budget, which is only reached when ten PRs were genuinely just parked — the
+# one moment that spend is worth making.
+DEFAULT_MAX_APPROVALS = 270
+DEFAULT_POLL_ATTEMPTS = 3
+DEFAULT_POLL_INTERVAL_SECONDS = 20
+DEFAULT_STATUS_CONTEXT = "ci-dispatch-watchdog"
+# Runs inspected per check. Raised from 10 (#13341): the repository was measured
+# carrying 12 concurrently in-progress runs, so a budget of 10 could not reach
+# the whole set — and the run that matters is the one it dropped. See
+# `inspect_self_hosted_pool` for why the ORDER of that budget is the real fix.
+DEFAULT_MAX_JOB_LOOKUPS = 25
+# A self-hosted job still executing after this long is wedged, not slow (#13341).
+#
+# Derived, not chosen: every self-hosted job in .github/workflows declares
+# `timeout-minutes` of 30 or less (frontend-test's unit-tests and build-test at
+# 30, security-scan at 20, test-summary at 15, auto-update-pr-branches at 15).
+# 45 is therefore the largest declared ceiling in the repository plus a 50%
+# margin, so no job that is merely slow can reach it while still inside its own
+# declared limit. The case this catches is the one GitHub's own enforcement
+# missed: 3h05m against a declared 30m.
+DEFAULT_JOB_OVERDUE_MINUTES = 45
+# 0 means "every open PR"; a PR number narrows the sweep to that one head.
+DEFAULT_ONLY_PR = 0
+DEFAULT_REQUEST_TIMEOUT_SECONDS = 30
+# GitHub's maximum page size. Listing runs is one call whatever the size, so the
+# full page is taken and the expensive per-run job lookups are budgeted instead.
+MAX_RUNS_PER_PAGE = 100
+
+
+class WatchdogError(RuntimeError):
+    """Base for every error this module raises deliberately."""
+
+
+class WatchdogConfigError(WatchdogError):
+    """Raised when required environment configuration is absent or unusable."""
+
+
+class WatchdogApiError(WatchdogError):
+    """
+    Raised when the API answered with something unusable.
+
+    This is deliberately distinct from "the API answered and said there are no
+    runs". Conflating the two is how a single rate-limit window turns into
+    "CI never dispatched" printed against every open pull request.
+    """
+
+
+class PullHead(NamedTuple):
+    """The properties of an open pull request this tool acts on."""
+
+    number: int
+    sha: str
+    updated_at: Optional[str]
+    url: str
+    # False for a pull request opened from a fork. Such heads are reported but
+    # never approved — see the fork-safety note in the module docstring.
+    same_repo: bool
+
+
+def _env_int(name: str, default: int) -> int:
+    """Read a positive integer from the environment, falling back to *default*."""
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise WatchdogConfigError(f"{name} must be an integer, got {raw!r}") from exc
+    if value <= 0:
+        raise WatchdogConfigError(f"{name} must be positive, got {value}")
+    return value
+
+
+class ApprovalOutcome(NamedTuple):
+    """What one head's approval pass did. ``raced`` is benign, ``refused`` is not."""
+
+    approved: int = 0
+    refused: int = 0
+    raced: int = 0
+    budget: int = 0
+    exhausted: bool = False
+
+
+class OverdueJob(NamedTuple):
+    """A self-hosted job still executing long past any declared timeout."""
+
+    head_sha: str
+    workflow: str
+    job: str
+    elapsed_minutes: float
+    url: str
+
+    def describe(self) -> str:
+        return f"{self.workflow} / {self.job} running {self.elapsed_minutes:.0f}m"
+
+
+class PoolState(NamedTuple):
+    """
+    What one inspection of the self-hosted pool established.
+
+    ``serving`` is ``None`` when the answer could not be established at all, so
+    the caller can say "unknown" rather than inventing a verdict. It is ``True``
+    only when a self-hosted job is executing *within* a plausible runtime —
+    a wedged job is deliberately not evidence of health (#13341).
+    """
+
+    serving: Optional[bool]
+    overdue: List[OverdueJob]
+
+
+class SweepOutcome(NamedTuple):
+    """Totals for one pass over every head, plus the PRs the budget could not reach."""
+
+    approved: int = 0
+    refused: int = 0
+    raced: int = 0
+    budget: int = 0
+    unsettled: bool = False
+    touched: Set[str] = frozenset()  # type: ignore[assignment]
+    deferred: Set[int] = frozenset()  # type: ignore[assignment]
+
+
+def _env_non_negative_int(name: str, default: int) -> int:
+    """
+    Read a non-negative integer from the environment.
+
+    Separate from :func:`_env_int` because zero is meaningful here — it is how
+    ``WATCHDOG_ONLY_PR`` says "every open PR" — while every threshold read by
+    ``_env_int`` would be nonsense at zero.
+    """
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise WatchdogConfigError(f"{name} must be an integer, got {raw!r}") from exc
+    if value < 0:
+        raise WatchdogConfigError(f"{name} must not be negative, got {value}")
+    return value
+
+
+def parse_ts(value: Optional[str]) -> Optional[datetime]:
+    """Parse a GitHub ISO-8601 timestamp into an aware UTC datetime."""
+    if not value:
+        return None
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def age_minutes(value: Optional[str], now: datetime) -> Optional[float]:
+    """Minutes elapsed between the timestamp *value* and *now*."""
+    parsed = parse_ts(value)
+    if parsed is None:
+        return None
+    return (now - parsed).total_seconds() / 60.0
+
+
+def is_parked(run: Dict[str, Any]) -> bool:
+    """True when the run was created but requires manual approval to start."""
+    return run.get("conclusion") == "action_required"
+
+
+def is_unstarted(run: Dict[str, Any]) -> bool:
+    """True when the run exists but has not allocated a job yet."""
+    return run.get("status") in UNSTARTED_RUN_STATUSES
+
+
+def run_is_same_repo(run: Dict[str, Any], repository: str) -> bool:
+    """True when the run's head branch lives in *repository* rather than a fork."""
+    head_repository = run.get("head_repository") or {}
+    return str(head_repository.get("full_name") or "") == repository
+
+
+def is_approvable(run: Dict[str, Any], repository: str) -> Tuple[bool, str]:
+    """
+    Decide whether this tool may release *run*, and say why not when it may not.
+
+    Two conditions, both required. The head must live in this repository:
+    ``approve`` exists to release gated FORK runs, and this repository is
+    public, takes fork pull requests, and executes ``pull_request`` jobs on a
+    self-hosted runner, so approving a fork run would run contributor-supplied
+    code on the owner's machine. And the run must have been parked because the
+    branch-update bot pushed it — a run parked for any other reason was parked
+    by a policy decision this tool has no business overriding.
+    """
+    if not is_parked(run):
+        return False, "not parked"
+    if not run_is_same_repo(run, repository):
+        origin = (run.get("head_repository") or {}).get("full_name") or "unknown"
+        return False, f"fork pull request from {origin} — gated on purpose, never auto-approved"
+    actor = (run.get("triggering_actor") or {}).get("login") or ""
+    if actor != UPDATE_BOT_LOGIN:
+        return False, f"parked for actor {actor or 'unknown'}, not the branch-update bot"
+    return True, ""
+
+
+def is_already_released(message: str) -> bool:
+    """
+    True when an approve attempt failed only because the run was already released.
+
+    ``interpret_probe`` treats this exact message as PROOF the credential may
+    approve — a token without permission is rejected on permission grounds
+    instead. Counting it as a refusal therefore contradicts the probe in the
+    same log, and refusals drive the credential remediation, so a benign race
+    printed an instruction to relax repository security settings.
+
+    The race is routine, not exceptional: two base pushes seconds apart each
+    chain a sweep, and the second one POSTs approve against runs the first has
+    already released.
+    """
+    return NOT_WAITING_MARKER in message.lower()
+
+
+def starved_runs(
+    runs: Sequence[Dict[str, Any]], now: datetime, stall_minutes: int
+) -> List[Dict[str, Any]]:
+    """Runs queued longer than *stall_minutes* without allocating a job."""
+    starved = []
+    for run in runs:
+        if not is_unstarted(run):
+            continue
+        waited = age_minutes(run.get("created_at"), now)
+        if waited is not None and waited >= stall_minutes:
+            starved.append(run)
+    return starved
+
+
+def concurrency_group_key(run: Dict[str, Any]) -> Tuple[Any, Any, Any]:
+    """The identity a concurrency group actually has (#13439).
+
+    Grouped by ``(workflow_id, head_branch, event)``, **not** by workflow and
+    branch alone. The group expression is ``${{ github.workflow }}-${{ github.ref }}``
+    and ``github.ref`` differs between a ``push`` run (``refs/heads/...``) and a
+    ``pull_request`` run (``refs/pull/N/merge``) on the same branch. Grouping
+    across that boundary would treat a PR run as superseding a push run and
+    cancel work that is not superseded at all.
+    """
+    return (run.get("workflow_id"), run.get("head_branch"), run.get("event"))
+
+
+def _run_ordering_key(run: Dict[str, Any]) -> Tuple[Any, Any]:
+    """Newest-last ordering: ``run_number`` first, ``created_at`` as tiebreak."""
+    return (run.get("run_number") or 0, run.get("created_at") or "")
+
+
+def superseded_stuck_runs(
+    runs: Sequence[Dict[str, Any]],
+    now: datetime,
+    repository: str,
+    grace_minutes: int,
+    budget: int,
+) -> List[Dict[str, Any]]:
+    """Runs safe to force-cancel because a newer run holds their group (#13439).
+
+    ``concurrency.cancel-in-progress: true`` reaps an *in-progress* predecessor
+    and never a *queued* one. While the singleton self-hosted runner is offline a
+    predecessor never reaches in-progress, so it keeps holding the group and its
+    successors sit ``pending`` with an empty ``jobs`` array until a human runs
+    ``force-cancel``. This selects exactly the runs where that is provably safe.
+
+    A run qualifies only when **all** hold:
+
+    * it is **not the newest** in its group — the newest is never touched, under
+      any condition, because it is the run everything else is waiting for;
+    * its status is in :data:`STUCK_QUEUE_STATUSES` — ``in_progress`` means real
+      work is happening, and ``waiting``/``requested`` are approval gates;
+    * it is older than *grace_minutes* — a legitimate brief queue must not be
+      mistaken for a stuck one;
+    * its head repository is *repository* — the same fork restriction the
+      approval sweep uses, and for the same reason: never act on a run built
+      from contributor-supplied code.
+
+    The result is truncated to *budget* oldest-first, so one sweep cannot cancel
+    the world if the grouping logic is ever wrong.
+    """
+    groups: Dict[Tuple[Any, Any, Any], List[Dict[str, Any]]] = {}
+    for run in runs:
+        if not run_is_same_repo(run, repository):
+            continue
+        groups.setdefault(concurrency_group_key(run), []).append(run)
+
+    stuck: List[Dict[str, Any]] = []
+    for members in groups.values():
+        if len(members) < 2:
+            continue  # nothing supersedes it
+        ordered = sorted(members, key=_run_ordering_key)
+        for run in ordered[:-1]:  # every member except the newest
+            if run.get("status") not in STUCK_QUEUE_STATUSES:
+                continue
+            waited = age_minutes(run.get("created_at"), now)
+            if waited is None or waited < grace_minutes:
+                continue
+            stuck.append(run)
+
+    stuck.sort(key=lambda r: r.get("created_at") or "")
+    return stuck[:budget]
+
+
+def job_is_self_hosted(job: Dict[str, Any]) -> bool:
+    """True when this job was dispatched to the self-hosted pool."""
+    labels = [str(label).lower() for label in (job.get("labels") or [])]
+    return SELF_HOSTED_LABEL in labels
+
+
+def job_is_overdue(job: Dict[str, Any], now: datetime, overdue_minutes: int) -> bool:
+    """
+    True when a self-hosted job has been executing past the point of plausibility.
+
+    Only self-hosted jobs qualify. A GitHub-hosted job that overruns costs
+    billable minutes and nothing else; a self-hosted one holds the singleton
+    machine that every other job in the repository is waiting for, which is what
+    turns one wedged frontend check into a repository-wide merge freeze.
+    """
+    if job.get("status") != "in_progress" or not job_is_self_hosted(job):
+        return False
+    elapsed = age_minutes(job.get("started_at"), now)
+    return elapsed is not None and elapsed >= overdue_minutes
+
+
+def _truncate(text: str) -> str:
+    if len(text) <= MAX_STATUS_DESCRIPTION:
+        return text
+    return text[: MAX_STATUS_DESCRIPTION - 1] + "…"
+
+
+def classify_dispatch(
+    runs: Sequence[Dict[str, Any]],
+    head_pushed_at: Optional[str],
+    now: datetime,
+    grace_minutes: int,
+    stall_minutes: int,
+    pool_serving: bool = True,
+    overdue: Sequence[OverdueJob] = (),
+) -> Tuple[str, str]:
+    """
+    Decide the commit-status state for one PR head.
+
+    Returns ``(state, description)`` where *state* is a GitHub commit-status
+    state. The watchdog never reports ``success`` for a head whose CI has not
+    demonstrably dispatched, so "no failures" can never be mistaken for
+    "verified" (#12823 option 3, #13045 property 1).
+
+    A wedged job is reported as a failure for the same reason (#13341). Until
+    now an in-progress required check was rendered identically whether it was
+    working or hung, so the only way to tell was for a human to notice the clock
+    — which on 2026-08-03 took three hours. Naming it in a commit status makes
+    the difference visible on the pull request itself.
+    """
+    parked = [run for run in runs if is_parked(run)]
+    if parked:
+        names = ", ".join(sorted({str(run.get("name", "?")) for run in parked})[:3])
+        return (
+            "failure",
+            _truncate(f"{len(parked)} run(s) parked awaiting approval and never started: {names}"),
+        )
+
+    if overdue:
+        names = ", ".join(sorted(entry.describe() for entry in overdue)[:2])
+        return (
+            "failure",
+            _truncate(f"{len(overdue)} job(s) wedged far past their declared timeout: {names}"),
+        )
+
+    starved = starved_runs(runs, now, stall_minutes)
+    if starved:
+        names = ", ".join(sorted({str(run.get("name", "?")) for run in starved})[:3])
+        if pool_serving:
+            # Contention, not an outage — still never green, because the head is
+            # demonstrably not verified yet.
+            return (
+                "pending",
+                _truncate(
+                    f"{len(starved)} run(s) queued over {stall_minutes}m behind a busy runner pool: {names}"
+                ),
+            )
+        return (
+            "failure",
+            _truncate(
+                f"{len(starved)} run(s) queued over {stall_minutes}m with no runner available: {names}"
+            ),
+        )
+
+    if not runs:
+        waited = age_minutes(head_pushed_at, now)
+        if waited is None or waited >= grace_minutes:
+            return (
+                "failure",
+                _truncate(
+                    f"no workflow runs exist for this commit after {grace_minutes}m — CI never dispatched"
+                ),
+            )
+        return (
+            "pending",
+            _truncate("no workflow runs yet — still inside the dispatch grace window"),
+        )
+
+    return ("success", _truncate(f"{len(runs)} workflow run(s) dispatched for this commit"))
+
+
+class GitHubApi:
+    """Minimal GitHub REST client — stdlib only, no extra CI dependency."""
+
+    def __init__(
+        self,
+        token: str,
+        repository: str,
+        api_root: str = DEFAULT_API_ROOT,
+        timeout: int = DEFAULT_REQUEST_TIMEOUT_SECONDS,
+    ) -> None:
+        self.token = token
+        self.repository = repository
+        self.api_root = api_root.rstrip("/")
+        self.timeout = timeout
+
+    def request(
+        self, method: str, path: str, payload: Optional[Dict[str, Any]] = None
+    ) -> Tuple[int, Any]:
+        """
+        Issue a request and return ``(status_code, decoded_body)``.
+
+        A transport failure (DNS, TLS, connection reset, timeout) returns status
+        ``NO_RESPONSE_STATUS`` rather than escaping as a traceback. An uncaught
+        ``URLError`` would exit the process with code 1, which this module
+        documents as "parked runs could not be approved" — a completely
+        different condition, reported with no remediation text.
+        """
+        url = path if path.startswith("http") else f"{self.api_root}/{path.lstrip('/')}"
+        data = json.dumps(payload).encode("utf-8") if payload is not None else None
+        request = urllib.request.Request(url=url, method=method, data=data)
+        request.add_header("Authorization", f"Bearer {self.token}")
+        request.add_header("Accept", "application/vnd.github+json")
+        request.add_header("X-GitHub-Api-Version", "2022-11-28")
+        if data is not None:
+            request.add_header("Content-Type", "application/json")
+        try:
+            with urllib.request.urlopen(
+                request, timeout=self.timeout
+            ) as response:  # noqa: S310 - fixed api host
+                body = response.read().decode("utf-8")
+                return response.status, (json.loads(body) if body else None)
+        except urllib.error.HTTPError as exc:
+            body = exc.read().decode("utf-8", errors="replace")
+            try:
+                decoded: Any = json.loads(body) if body else None
+            except json.JSONDecodeError:
+                decoded = {"message": body}
+            return exc.code, decoded
+        except (urllib.error.URLError, socket.timeout, OSError) as exc:
+            return NO_RESPONSE_STATUS, {"message": f"transport failure: {exc}"}
+
+    def _list_runs(self, params: Dict[str, str], context: str) -> List[Dict[str, Any]]:
+        query = urllib.parse.urlencode(params)
+        status, body = self.request("GET", f"/repos/{self.repository}/actions/runs?{query}")
+        if status != 200 or not isinstance(body, dict):
+            raise WatchdogApiError(f"cannot list {context} (HTTP {status}): {body}")
+        return list(body.get("workflow_runs") or [])
+
+    def open_pull_requests(self, base: str) -> List[Dict[str, Any]]:
+        query = urllib.parse.urlencode({"state": "open", "base": base, "per_page": "100"})
+        status, body = self.request("GET", f"/repos/{self.repository}/pulls?{query}")
+        if status != 200 or not isinstance(body, list):
+            raise WatchdogApiError(f"cannot list open PRs (HTTP {status}): {body}")
+        return body
+
+    def runs_for_sha(self, sha: str) -> List[Dict[str, Any]]:
+        """
+        Runs attached to one head commit.
+
+        Raises rather than returning ``[]`` on an API error: an empty list is
+        interpreted downstream as "CI never dispatched", which is a specific and
+        alarming claim that must never be made on the strength of a rate-limit
+        response.
+        """
+        return self._list_runs({"head_sha": sha, "per_page": "100"}, f"runs for {sha[:12]}")
+
+    def recent_runs(self, per_page: int = 100, run_status: str = "") -> List[Dict[str, Any]]:
+        params = {"per_page": str(per_page)}
+        if run_status:
+            params["status"] = run_status
+        return self._list_runs(params, f"recent runs (status={run_status or 'any'})")
+
+    def run_jobs(self, run_id: int) -> List[Dict[str, Any]]:
+        query = urllib.parse.urlencode({"per_page": "100"})
+        status, body = self.request(
+            "GET", f"/repos/{self.repository}/actions/runs/{run_id}/jobs?{query}"
+        )
+        if status != 200 or not isinstance(body, dict):
+            raise WatchdogApiError(f"cannot list jobs for run {run_id} (HTTP {status}): {body}")
+        return list(body.get("jobs") or [])
+
+    def approve_run(self, run_id: int) -> Tuple[int, str]:
+        status, body = self.request(
+            "POST", f"/repos/{self.repository}/actions/runs/{run_id}/approve"
+        )
+        message = ""
+        if isinstance(body, dict):
+            message = str(body.get("message", ""))
+        return status, message
+
+    def set_status(
+        self, sha: str, state: str, context: str, description: str, target_url: str
+    ) -> int:
+        payload: Dict[str, Any] = {
+            "state": state,
+            "context": context,
+            "description": description,
+        }
+        if target_url:
+            payload["target_url"] = target_url
+        status, _ = self.request("POST", f"/repos/{self.repository}/statuses/{sha}", payload)
+        return status
+
+
+def inspect_self_hosted_pool(
+    api: GitHubApi,
+    max_lookups: int,
+    overdue_minutes: int = DEFAULT_JOB_OVERDUE_MINUTES,
+    now: Optional[datetime] = None,
+) -> PoolState:
+    """
+    Establish whether the SELF-HOSTED pool is healthy, and name what is wedged.
+
+    Any in-progress run used to count as liveness, which made the verdict
+    near-permanently true: ``code-quality``, ``ci.yml`` and this very watchdog's
+    own quarter-hourly cron all run on GitHub-hosted runners, so "something is
+    executing" says nothing about the singleton machine that #13045 is about.
+    Liveness is therefore established from job labels — the closest signal to
+    ``/actions/runners`` that a workflow token is allowed to read.
+
+    A second false reading is corrected here (#13341). A job that has WEDGED is
+    still ``in_progress`` on a ``self-hosted`` label, so on the old rule the
+    hung job that was blocking every merge would itself have been read as proof
+    the pool was healthy, and the queue stacking up behind it dismissed as
+    "contention, not an outage". An overdue job is consequently excluded from
+    the liveness verdict and returned separately so it can be reported as the
+    fault it is. This costs no extra API call: the job listing that establishes
+    liveness is the same listing that finds the overdue jobs.
+
+    ``serving`` is ``None`` when the answer could not be established at all.
+    """
+    now = now or datetime.now(timezone.utc)
+    overdue: List[OverdueJob] = []
+    try:
+        # Ask for a full page and choose which runs to spend the job-lookup
+        # budget on here, rather than letting the API's ordering choose.
+        running = api.recent_runs(per_page=MAX_RUNS_PER_PAGE, run_status="in_progress")
+    except WatchdogApiError as exc:
+        print(f"  runner liveness unknown: {exc}")
+        return PoolState(None, overdue)
+    # OLDEST FIRST — the correction that makes this detector able to fire at all
+    # (#13341). `GET /actions/runs` returns newest-first, and a wedged run is by
+    # definition the OLDEST in-progress run, so truncating the newest N to the
+    # lookup budget drops precisely the run being looked for. Measured on this
+    # repository: 12 runs in progress, and the wedging `Frontend Testing Suite`
+    # run was the oldest of the 12 — outside a budget of 10. The unit tests
+    # passed throughout, because a synthetic listing has nothing to truncate.
+    # Sorting costs nothing: it is the same single listing call.
+    running.sort(key=lambda run: str(run.get("run_started_at") or run.get("created_at") or ""))
+    serving = False
+    for run in running[:max_lookups]:
+        try:
+            jobs = api.run_jobs(int(run["id"]))
+        except WatchdogApiError as exc:
+            print(f"  runner liveness partial: {exc}")
+            continue
+        for job in jobs:
+            if job.get("status") != "in_progress" or not job_is_self_hosted(job):
+                continue
+            if job_is_overdue(job, now, overdue_minutes):
+                elapsed = age_minutes(job.get("started_at"), now) or 0.0
+                overdue.append(
+                    OverdueJob(
+                        head_sha=str(run.get("head_sha") or ""),
+                        workflow=str(run.get("name") or "?"),
+                        job=str(job.get("name") or "?"),
+                        elapsed_minutes=elapsed,
+                        url=str(job.get("html_url") or _run_url(api.repository, run)),
+                    )
+                )
+                continue
+            serving = True
+    return PoolState(serving, overdue)
+
+
+def self_hosted_pool_is_serving(api: GitHubApi, max_lookups: int) -> Optional[bool]:
+    """Liveness alone, for callers that do not need the overdue detail."""
+    return inspect_self_hosted_pool(api, max_lookups).serving
+
+
+def overdue_by_head(overdue: Sequence[OverdueJob]) -> Dict[str, List[OverdueJob]]:
+    """Group wedged jobs by the head commit whose PR they are blocking."""
+    grouped: Dict[str, List[OverdueJob]] = {}
+    for entry in overdue:
+        if entry.head_sha:
+            grouped.setdefault(entry.head_sha, []).append(entry)
+    return grouped
+
+
+def interpret_probe(status: int, message: str) -> Tuple[Optional[bool], str]:
+    """
+    Turn an ``approve`` response for a run that is NOT awaiting approval into a
+    verdict about the *credential*.
+
+    A token that holds ``actions: write`` is rejected on state grounds
+    ("This workflow run is not waiting for approval"); a token that does not is
+    rejected on permission grounds ("Resource not accessible by integration").
+
+    Anything else returns ``None`` — unresolved. Returning ``True`` for an
+    unrecognised response would mean a bad credential, a 404, a rate-limit
+    window or an HTML error page all read as "permitted", which is precisely
+    the fail-open this module exists to argue against. The caller must treat
+    ``None`` as "no verdict", never as "fine".
+    """
+    lowered = message.lower()
+    if PERMISSION_DENIED_MARKER in lowered:
+        return False, "token lacks permission to approve workflow runs"
+    if NOT_WAITING_MARKER in lowered:
+        return True, "token may approve workflow runs (rejected on run state, not permission)"
+    if status in (200, 201, 204):
+        return True, "token may approve workflow runs (approval accepted)"
+    if status == NO_RESPONSE_STATUS:
+        return None, f"unresolved — the API could not be reached ({message or 'no detail'})"
+    if status == 401:
+        return None, "unresolved — the credential was rejected (401 Bad credentials)"
+    if status == 404:
+        return (
+            None,
+            "unresolved — the probe run was not found (404); the token may lack read access",
+        )
+    if status == 429:
+        return None, "unresolved — rate limited (429); retry on the next sweep"
+    return None, f"unresolved — unrecognised response (HTTP {status}: {message or 'no message'})"
+
+
+def probe_approval_capability(api: GitHubApi, dry_run: bool = False) -> Tuple[Optional[bool], str]:
+    """
+    Establish whether this credential may approve runs, without side effects.
+
+    Two details that both silently defeated earlier versions:
+
+    * The candidate listing must select ``status=success``, not
+      ``status=completed``. A parked run IS ``status=completed`` (with
+      ``conclusion=action_required``), so on a repository carrying hundreds of
+      parked runs every entry on the "recent completed" page is parked, every
+      candidate is filtered out, and the probe reports nothing at all.
+    * A dry run performs no approval call, so it cannot probe either. It says so
+      rather than pretending the question was answered.
+    """
+    if dry_run:
+        return None, "probe skipped: --dry-run issues no approve request"
+    try:
+        runs = api.recent_runs(per_page=20, run_status="success")
+    except WatchdogApiError as exc:
+        return None, f"probe unresolved: {exc}"
+    candidates = [run for run in runs if not is_parked(run)]
+    if not candidates:
+        return None, "probe unresolved: no successful run available to probe against"
+    status, message = api.approve_run(int(candidates[0]["id"]))
+    return interpret_probe(status, message)
+
+
+REMEDIATION = (
+    "Parked runs cannot be approved with this credential. Every merge to the base branch will keep "
+    "freezing open PRs until one of the following is chosen:\n"
+    "  (a) relax the repository Actions setting 'Require approval for all external contributors' to "
+    "'Require approval for first-time contributors', so pushes attributed to the update bot dispatch "
+    "normally; or\n"
+    "  (b) run auto-update-pr-branches with a credential that is a repository collaborator "
+    "(a GitHub App installation token or PAT stored as a secret); or\n"
+    "  (c) retire the automatic branch update and refresh PR branches from the PR page instead.\n"
+    "Until then this watchdog marks affected PRs with a failing commit status so none of them can "
+    "read as ready."
+)
+
+
+def budget_exhausted_message(deferred: Set[int], cap: int) -> str:
+    """Explain a partial sweep in terms of the cap, not the credential."""
+    return (
+        f"The per-sweep approval cap ({cap}) was reached with parked runs still outstanding on "
+        f"{len(deferred)} pull request(s). Those runs are STILL PARKED and their PRs still carry no "
+        "executed checks.\n"
+        "This is not a permissions problem — nothing was refused. Either raise WATCHDOG_MAX_APPROVALS, "
+        "or approve the remainder from the Actions tab.\n"
+        "Do not rely on 'the next sweep': the only triggers are a push to the base branch and a "
+        "schedule that does not dispatch while this workflow is absent from the default branch."
+    )
+
+
+def _run_url(repository: str, run: Dict[str, Any]) -> str:
+    return str(run.get("html_url") or f"https://github.com/{repository}/actions")
+
+
+def needs_another_look(runs: Sequence[Dict[str, Any]]) -> bool:
+    """
+    True when this head warrants re-listing after a short wait.
+
+    A head with NO runs at all is the interesting case: immediately after
+    ``update-branch`` returns, the runs it triggers have not materialised yet,
+    so an empty result means "too early", not "nothing to approve". A head that
+    already has runs and no parked ones is genuinely settled.
+    """
+    if not runs:
+        return True
+    return any(is_parked(run) for run in runs)
+
+
+def _approve_head(
+    api: GitHubApi, number: int, runs: Sequence[Dict[str, Any]], budget: int, dry_run: bool
+) -> ApprovalOutcome:
+    """Approve the eligible parked runs of one head."""
+    approved = 0
+    refused = 0
+    raced = 0
+    exhausted = False
+    for run in runs:
+        eligible, reason = is_approvable(run, api.repository)
+        if not eligible:
+            if is_parked(run):
+                print(f"  PR #{number}: leaving '{run.get('name')}' parked — {reason}")
+            continue
+        if budget <= 0:
+            # Named, counted and escalated by the caller. "Deferring to the next
+            # sweep" is only true if a next sweep happens, and the schedule that
+            # was supposed to guarantee one has never fired.
+            print(f"  PR #{number}: approval budget exhausted, deferring to the next sweep")
+            exhausted = True
+            break
+        # Decremented on a dry run too, so the preview reflects the cap a real
+        # sweep would hit rather than promising more than it would do.
+        budget -= 1
+        if dry_run:
+            print(f"  PR #{number}: would approve '{run.get('name')}' ({run['id']})")
+            continue
+        status, message = api.approve_run(int(run["id"]))
+        if status in (200, 201, 204):
+            approved += 1
+            print(f"  PR #{number}: approved '{run.get('name')}' ({run['id']})")
+        elif is_already_released(message):
+            # A concurrent sweep got there first. The run is released, which is
+            # the outcome this tool wanted — not a failure, and emphatically not
+            # evidence that the credential is inadequate.
+            raced += 1
+            print(
+                f"  PR #{number}: '{run.get('name')}' already released by a concurrent sweep — no action needed"
+            )
+        else:
+            refused += 1
+            print(
+                f"  PR #{number}: could NOT approve '{run.get('name')}' — HTTP {status}: {message}"
+            )
+    return ApprovalOutcome(approved, refused, raced, budget, exhausted)
+
+
+def _sweep_once(
+    api: GitHubApi, heads: Sequence[PullHead], budget: int, dry_run: bool
+) -> SweepOutcome:
+    """One pass over every head."""
+    approved = 0
+    refused = 0
+    raced = 0
+    unsettled = False
+    touched: Set[str] = set()
+    deferred: Set[int] = set()
+    for head in heads:
+        try:
+            runs = api.runs_for_sha(head.sha)
+        except WatchdogApiError as exc:
+            print(f"  PR #{head.number}: cannot inspect runs — {exc}")
+            unsettled = True
+            continue
+        if needs_another_look(runs):
+            unsettled = True
+        if not head.same_repo:
+            if any(is_parked(run) for run in runs):
+                print(
+                    f"  PR #{head.number}: fork pull request — parked runs left for a human to approve"
+                )
+            continue
+        outcome = _approve_head(api, head.number, runs, budget, dry_run)
+        budget = outcome.budget
+        if outcome.approved:
+            touched.add(head.sha)
+        if outcome.exhausted:
+            deferred.add(head.number)
+        approved += outcome.approved
+        refused += outcome.refused
+        raced += outcome.raced
+    return SweepOutcome(approved, refused, raced, budget, unsettled, touched, deferred)
+
+
+def sweep_parked_runs(
+    api: GitHubApi, heads: Sequence[PullHead], config: Dict[str, Any], dry_run: bool
+) -> Tuple[int, int, int, Set[str], Set[int]]:
+    """
+    Approve parked runs across every head, re-listing while any head is unsettled.
+
+    The wait is per attempt, not per head, so total added latency is bounded by
+    ``poll_attempts * poll_interval_seconds`` however many PRs are open.
+    """
+    approved = 0
+    refused = 0
+    raced = 0
+    touched: Set[str] = set()
+    deferred: Set[int] = set()
+    budget = config["max_approvals"]
+    for attempt in range(config["poll_attempts"]):
+        outcome = _sweep_once(api, heads, budget, dry_run)
+        budget = outcome.budget
+        approved += outcome.approved
+        refused += outcome.refused
+        raced += outcome.raced
+        touched |= outcome.touched
+        # Only the LAST pass decides what was left behind: an earlier pass may
+        # have deferred a PR that a later one, with budget freed by nothing
+        # needing approval, went on to clear.
+        deferred = set(outcome.deferred)
+        last_attempt = attempt + 1 >= config["poll_attempts"]
+        # Stop once nothing is outstanding, on a dry run (which changes nothing,
+        # so a second look is pointless), once approval was refused (retrying a
+        # permission failure only delays the report), or once the budget is
+        # gone (further passes cannot approve anything).
+        if not outcome.unsettled or dry_run or refused or budget <= 0 or last_attempt:
+            break
+        time.sleep(config["poll_interval_seconds"])
+    return approved, refused, raced, touched, deferred
+
+
+def collect_heads(pulls: Sequence[Dict[str, Any]], repository: str) -> List[PullHead]:
+    """Reduce the PR listing to the heads this tool acts on, flagging fork origins."""
+    heads: List[PullHead] = []
+    for pull in pulls:
+        head = pull.get("head") or {}
+        sha = str(head.get("sha") or "")
+        if not sha:
+            continue
+        head_repo = str((head.get("repo") or {}).get("full_name") or "")
+        heads.append(
+            PullHead(
+                number=int(pull["number"]),
+                sha=sha,
+                updated_at=pull.get("updated_at"),
+                url=str(pull.get("html_url") or ""),
+                same_repo=head_repo == repository,
+            )
+        )
+    return heads
+
+
+def select_heads(heads: Sequence[PullHead], only_pr: int) -> List[PullHead]:
+    """
+    Narrow the sweep to a single pull request when one fired the workflow.
+
+    A sweep costs roughly ``poll_attempts + 2`` API calls per head, so sweeping
+    every open PR on every pull-request event multiplies the per-event cost by
+    the size of the queue against the shared 1,000/hour ``GITHUB_TOKEN`` budget.
+    The scheduled and base-push sweeps keep covering every head; an event-driven
+    sweep only needs the head that moved.
+
+    Selecting nothing is returned as an empty list rather than silently falling
+    back to "all heads": the fallback would turn a closed or renumbered PR into
+    a full-queue sweep, which is the cost this exists to avoid.
+    """
+    if only_pr <= 0:
+        return list(heads)
+    return [head for head in heads if head.number == only_pr]
+
+
+def publish_dispatch_states(
+    api: GitHubApi,
+    heads: Sequence[PullHead],
+    config: Dict[str, Any],
+    dry_run: bool,
+    pool_serving: Optional[bool],
+    overdue: Sequence[OverdueJob] = (),
+) -> int:
+    """Write the dispatch commit status for each head. Returns the not-dispatched count."""
+    now = datetime.now(timezone.utc)
+    wedged = overdue_by_head(overdue)
+    blocked = 0
+    for head in heads:
+        try:
+            runs = api.runs_for_sha(head.sha)
+        except WatchdogApiError as exc:
+            # Never assert "CI never dispatched" on the strength of an API
+            # failure — say the state is unknown, and say why.
+            state, description = "pending", _truncate(f"dispatch state unknown (API error: {exc})")
+            runs = []
+        else:
+            state, description = classify_dispatch(
+                runs,
+                head.updated_at,
+                now,
+                config["grace_minutes"],
+                config["stall_minutes"],
+                pool_serving is not False,
+                wedged.get(head.sha, ()),
+            )
+        target = _run_url(api.repository, runs[0]) if runs else head.url
+        if dry_run:
+            print(f"  PR #{head.number}: would set {state} — {description}")
+        else:
+            code = api.set_status(head.sha, state, config["status_context"], description, target)
+            print(f"  PR #{head.number}: {state} — {description} (status API HTTP {code})")
+        if state != "success":
+            blocked += 1
+    return blocked
+
+
+def report_overdue_jobs(overdue: Sequence[OverdueJob], overdue_minutes: int) -> None:
+    """
+    Print a named annotation for every wedged self-hosted job.
+
+    Deliberately an annotation rather than an exit code in the dispatch sweep:
+    the actionable signal is the FAILING COMMIT STATUS published on the head the
+    wedged job belongs to, and failing every other PR's sweep because one PR is
+    stuck would spread a precise fault into indiscriminate noise. The starvation
+    probe, which is a dedicated repository-wide health check rather than a
+    per-PR one, does exit non-zero — see :func:`check_runner_starvation`.
+    """
+    if not overdue:
+        return
+    print(
+        f"::error::{len(overdue)} self-hosted job(s) still executing after {overdue_minutes}m. "
+        "Every job in this repository declares a shorter timeout, so these are wedged, not slow. "
+        "They hold the singleton runner and any required context they carry."
+    )
+    for entry in overdue:
+        print(f"  {entry.describe()} on {entry.head_sha[:12] or 'unknown head'} ({entry.url})")
+
+
+def check_dispatch(api: GitHubApi, config: Dict[str, Any], dry_run: bool = False) -> int:
+    """Approve what can be approved, then publish dispatch state on every open PR."""
+    if dry_run:
+        print("DRY RUN: nothing is approved, no commit status is written, and no probe is issued.")
+    pulls = api.open_pull_requests(config["base_branch"])
+    heads = collect_heads(pulls, api.repository)
+    forks = sum(1 for head in heads if not head.same_repo)
+    print(
+        f"Open PRs targeting {config['base_branch']}: {len(pulls)} ({forks} from forks, never auto-approved)"
+    )
+
+    only_pr = config.get("only_pr", 0)
+    if only_pr:
+        heads = select_heads(heads, only_pr)
+        print(f"Scoped to PR #{only_pr}: {len(heads)} head(s) selected")
+        if not heads:
+            print(
+                f"PR #{only_pr} is not an open PR targeting {config['base_branch']} — nothing to sweep."
+            )
+            return 0
+
+    permitted, explanation = probe_approval_capability(api, dry_run)
+    print(f"Approval capability probe: {explanation}")
+
+    approved, refused, raced, _touched, deferred = sweep_parked_runs(api, heads, config, dry_run)
+    pool = inspect_self_hosted_pool(api, config["max_job_lookups"], config["job_overdue_minutes"])
+    report_overdue_jobs(pool.overdue, config["job_overdue_minutes"])
+    blocked = publish_dispatch_states(api, heads, config, dry_run, pool.serving, pool.overdue)
+
+    print(
+        f"Sweep complete: {approved} approved, {raced} already released, "
+        f"{refused} refused, {blocked} PR(s) not dispatched."
+    )
+    if raced:
+        print(
+            f"{raced} run(s) had already been released by a concurrent sweep — routine, not a failure."
+        )
+
+    failed = False
+    if deferred and not dry_run:
+        # Silent deferral is the failure this tool exists to remove. Saying
+        # "next sweep" is not enough when the schedule that would provide one
+        # has never fired, so the run goes red and names what was left.
+        left = ", ".join(f"#{number}" for number in sorted(deferred))
+        print(
+            "::error::"
+            + budget_exhausted_message(deferred, config["max_approvals"]).replace("\n", "%0A")
+        )
+        print(budget_exhausted_message(deferred, config["max_approvals"]))
+        print(f"PR(s) left with parked runs: {left}")
+        failed = True
+
+    if refused or permitted is False:
+        print("::error::" + REMEDIATION.replace("\n", "%0A"))
+        print(REMEDIATION)
+        failed = True
+    if failed:
+        return 1
+    if permitted is None and not dry_run:
+        # Unresolved is not benign: the repair path is unproven until a probe
+        # returns a verdict, and saying nothing here is the exact failure mode
+        # this module was written to remove. A dry run is the one exception —
+        # it skips the probe deliberately, and `--check probe` answers the
+        # question on its own, so warning here would be noise that trains
+        # readers to ignore the warning that matters.
+        print(
+            f"::warning::Approval capability is UNRESOLVED — {explanation}. Do not treat #12823 as proven fixed."
+        )
+    return 0
+
+
+def check_probe(api: GitHubApi) -> int:
+    """
+    Print the credential verdict and nothing else.
+
+    Separate from ``dispatch`` so the question can be answered from a pull
+    request without approving anything or writing any status, and separate from
+    ``--dry-run`` because a dry run issues no approve request and therefore
+    cannot answer it.
+    """
+    permitted, explanation = probe_approval_capability(api)
+    print(f"Approval capability probe: {explanation}")
+    if permitted is False:
+        print("::error::" + REMEDIATION.replace("\n", "%0A"))
+        print(REMEDIATION)
+        return 1
+    if permitted is None:
+        print(f"::warning::Approval capability is UNRESOLVED — {explanation}")
+        return 0
+    print("This credential may approve parked runs; no owner action is required for #12823.")
+    return 0
+
+
+def check_runner_starvation(api: GitHubApi, config: Dict[str, Any]) -> int:
+    """
+    Report a self-hosted pool that is not serving the work it has been given.
+
+    Two distinct faults produce the same user-visible symptom — a required
+    context that never reaches a conclusion — and both are reported here:
+
+    * **Starvation (#13045).** Runs are created but never allocate a job because
+      no runner is serving the pool. They sit ``queued`` with ``jobs: []``.
+    * **A wedged job (#13341).** A job DID start and then stopped making
+      progress, so GitHub's runner-side ``timeout-minutes`` enforcement never
+      fires and the job holds the singleton indefinitely.
+
+    The wedged case is checked unconditionally, not only when something is
+    queued behind it. It is a fault the moment it happens — it is holding a
+    required status check — and waiting for a queue to build before saying so
+    would reproduce the three-hour silence that #13341 records.
+    """
+    now = datetime.now(timezone.utc)
+    # Filtered server-side: an unfiltered page is dominated by the hundreds of
+    # parked runs this repository carries, which can hide every queued run.
+    #
+    # KNOWN LIMIT, stated rather than papered over: this listing cannot tell the
+    # two runner pools apart. Labels live on JOBS, and a starved run has no jobs
+    # — that absence IS the condition being detected — so a run queued past the
+    # threshold cannot be attributed to the self-hosted pool from the API alone,
+    # and a GitHub-hosted capacity backlog would read the same way. The verdict
+    # below is therefore never taken from the queue on its own; it is qualified
+    # by the pool inspection, which IS label-attributed. Whether a starved queue
+    # can be attributed to a pool by any means the workflow token can read
+    # remains open.
+    queued = api.recent_runs(run_status="queued")
+    starved = starved_runs(queued, now, config["stall_minutes"])
+    pool = inspect_self_hosted_pool(
+        api, config["max_job_lookups"], config["job_overdue_minutes"], now
+    )
+    report_overdue_jobs(pool.overdue, config["job_overdue_minutes"])
+
+    if not starved:
+        if pool.overdue:
+            return 1
+        print(
+            f"No run has been queued longer than {config['stall_minutes']}m — runner pool is keeping up."
+        )
+        return 0
+
+    if pool.serving is None:
+        print(
+            f"::warning::{len(starved)} run(s) queued over {config['stall_minutes']}m; runner liveness UNKNOWN"
+        )
+        return 1 if pool.overdue else 0
+    if pool.serving:
+        # `pool.serving` excludes wedged jobs, so this really is healthy work in
+        # flight rather than the hung job that used to masquerade as liveness.
+        print(
+            f"{len(starved)} run(s) queued over {config['stall_minutes']}m, but a self-hosted job is executing — "
+            "contention, not an outage."
+        )
+        return 1 if pool.overdue else 0
+
+    reason = (
+        "while a self-hosted job is wedged"
+        if pool.overdue
+        else "while no self-hosted job is executing"
+    )
+    print(
+        f"::error::{len(starved)} workflow run(s) queued over {config['stall_minutes']}m {reason}"
+    )
+    for run in starved:
+        waited = age_minutes(run.get("created_at"), now)
+        waited_text = f"{waited:.0f}m" if waited is not None else "unknown"
+        print(
+            f"  {run.get('name')} on {run.get('head_branch')} — queued {waited_text} ({_run_url(api.repository, run)})"
+        )
+    return 1
+
+
+def load_config() -> Dict[str, Any]:
+    token = os.environ.get("GITHUB_TOKEN", "").strip()
+    repository = os.environ.get("GITHUB_REPOSITORY", "").strip()
+    if not token:
+        raise WatchdogConfigError("GITHUB_TOKEN is required")
+    if "/" not in repository:
+        raise WatchdogConfigError("GITHUB_REPOSITORY must be set to 'owner/repo'")
+    return {
+        "token": token,
+        "repository": repository,
+        "api_root": os.environ.get("GITHUB_API_URL", DEFAULT_API_ROOT),
+        "base_branch": os.environ.get("WATCHDOG_BASE_BRANCH", DEFAULT_BASE_BRANCH),
+        "grace_minutes": _env_int("WATCHDOG_GRACE_MINUTES", DEFAULT_GRACE_MINUTES),
+        "stall_minutes": _env_int("WATCHDOG_STALL_MINUTES", DEFAULT_STALL_MINUTES),
+        "max_approvals": _env_int("WATCHDOG_MAX_APPROVALS", DEFAULT_MAX_APPROVALS),
+        "poll_attempts": _env_int("WATCHDOG_POLL_ATTEMPTS", DEFAULT_POLL_ATTEMPTS),
+        "poll_interval_seconds": _env_int(
+            "WATCHDOG_POLL_INTERVAL_SECONDS", DEFAULT_POLL_INTERVAL_SECONDS
+        ),
+        "status_context": os.environ.get("WATCHDOG_STATUS_CONTEXT", DEFAULT_STATUS_CONTEXT),
+        "max_job_lookups": _env_int("WATCHDOG_MAX_JOB_LOOKUPS", DEFAULT_MAX_JOB_LOOKUPS),
+        "job_overdue_minutes": _env_int(
+            "WATCHDOG_JOB_OVERDUE_MINUTES", DEFAULT_JOB_OVERDUE_MINUTES
+        ),
+        "only_pr": _env_non_negative_int("WATCHDOG_ONLY_PR", DEFAULT_ONLY_PR),
+    }
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--check",
+        choices=("dispatch", "probe", "runner-starvation"),
+        default="dispatch",
+        help="dispatch: approve parked runs and publish PR dispatch state; "
+        "probe: print only whether this credential may approve runs; "
+        "runner-starvation: report runs queued while the self-hosted pool is idle",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="report what would be approved and which statuses would be published, changing nothing "
+        "(issues no approve request, so the capability probe is skipped)",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        config = load_config()
+    except WatchdogConfigError as exc:
+        print(f"Configuration error: {exc}", file=sys.stderr)
+        return 2
+
+    api = GitHubApi(config["token"], config["repository"], config["api_root"])
+    try:
+        if args.check == "dispatch":
+            return check_dispatch(api, config, dry_run=args.dry_run)
+        if args.check == "probe":
+            return check_probe(api)
+        return check_runner_starvation(api, config)
+    except WatchdogError as exc:
+        print(f"::error::watchdog could not complete: {exc}")
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/repo_tests/ci_dispatch_watchdog_test.py
+++ b/repo_tests/ci_dispatch_watchdog_test.py
@@ -1,0 +1,1151 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""#12823 / #13045 — the CI dispatch watchdog must never report ``success`` for a
+head commit whose CI has not demonstrably dispatched, and must never release a
+gated fork run.
+
+The production failure modes covered here:
+
+* runs created with ``conclusion=action_required`` (parked behind the fork-PR
+  approval policy after ``auto-update-pr-branches`` pushes as the bot),
+* runs created but never allocated a job while the self-hosted runner pool is
+  empty (``status=queued``, ``jobs: []``),
+* an API error being mistaken for "CI never dispatched", and
+* ``POST /actions/runs/{id}/approve`` — an approve-a-FORK-run endpoint — being
+  pointed at a fork pull request, which would execute contributor-supplied code
+  on the self-hosted runner.
+
+``interpret_probe`` is covered because it decides whether owner action is
+required, and because an earlier revision failed OPEN on every unrecognised
+response.
+"""
+
+import importlib.util
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "pipeline-scripts" / "ci_dispatch_watchdog.py"
+
+NOW = datetime(2026, 8, 2, 12, 0, 0, tzinfo=timezone.utc)
+REPO = "mrveiss/AutoBot-AI"
+FORK = "someone-else/AutoBot-AI"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("ci_dispatch_watchdog", _SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def watchdog():
+    return _load()
+
+
+def _ts(minutes_ago: float) -> str:
+    return (NOW - timedelta(minutes=minutes_ago)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _run(**overrides):
+    run = {
+        "id": 1,
+        "name": "Code Quality",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": _ts(5),
+        "head_repository": {"full_name": REPO},
+        "triggering_actor": {"login": "github-actions[bot]"},
+    }
+    run.update(overrides)
+    return run
+
+
+def _parked(**overrides):
+    return _run(status="completed", conclusion="action_required", **overrides)
+
+
+class _FakeApi:
+    """Records approve calls so a test can assert what was NOT approved."""
+
+    def __init__(self, runs_by_sha=None, repository=REPO, approve_response=(201, "")):
+        self.repository = repository
+        self._runs_by_sha = runs_by_sha or {}
+        self.approved = []
+        self.statuses = []
+        self._approve_response = approve_response
+
+    def runs_for_sha(self, sha):
+        value = self._runs_by_sha[sha]
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+    def approve_run(self, run_id):
+        self.approved.append(run_id)
+        return self._approve_response
+
+    def set_status(self, sha, state, context, description, target_url):
+        self.statuses.append((sha, state, description))
+        return 201
+
+
+# --- timestamp helpers -----------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value,expected_minutes",
+    [
+        ("2026-08-02T11:30:00Z", 30.0),
+        ("2026-08-02T11:30:00+00:00", 30.0),
+        ("2026-08-02T12:00:00Z", 0.0),
+    ],
+)
+def test_age_minutes_parses_github_timestamps(watchdog, value, expected_minutes):
+    assert watchdog.age_minutes(value, NOW) == pytest.approx(expected_minutes)
+
+
+@pytest.mark.parametrize("value", [None, "", "not-a-timestamp"])
+def test_age_minutes_returns_none_for_unusable_input(watchdog, value):
+    assert watchdog.age_minutes(value, NOW) is None
+
+
+# --- SECURITY: fork pull requests must never be auto-approved --------------
+
+
+def test_a_fork_origin_parked_run_is_never_approvable(watchdog):
+    run = _parked(head_repository={"full_name": FORK})
+    eligible, reason = watchdog.is_approvable(run, REPO)
+    assert eligible is False
+    assert FORK in reason
+
+
+def test_sweep_never_approves_a_fork_origin_parked_run(watchdog):
+    """The end-to-end guard: approve() must not be called for a fork run."""
+    api = _FakeApi()
+    outcome = watchdog._approve_head(
+        api, 42, [_parked(id=7, head_repository={"full_name": FORK})], budget=30, dry_run=False
+    )
+    assert api.approved == []
+    assert (outcome.approved, outcome.refused, outcome.raced) == (0, 0, 0)
+    assert outcome.budget == 30
+    assert outcome.exhausted is False
+
+
+def test_a_fork_head_is_flagged_by_collect_heads(watchdog):
+    heads = watchdog.collect_heads(
+        [{"number": 1, "head": {"sha": "a" * 40, "repo": {"full_name": FORK}}, "html_url": "u"}],
+        REPO,
+    )
+    assert heads[0].same_repo is False
+
+
+def test_same_repo_head_is_recognised(watchdog):
+    heads = watchdog.collect_heads(
+        [{"number": 1, "head": {"sha": "b" * 40, "repo": {"full_name": REPO}}, "html_url": "u"}],
+        REPO,
+    )
+    assert heads[0].same_repo is True
+
+
+def test_the_sweep_skips_a_fork_head_entirely(watchdog):
+    sha = "f" * 40
+    api = _FakeApi({sha: [_parked(id=99, head_repository={"full_name": FORK})]})
+    head = watchdog.PullHead(number=8, sha=sha, updated_at=_ts(5), url="u", same_repo=False)
+    outcome = watchdog._sweep_once(api, [head], budget=30, dry_run=False)
+    assert api.approved == []
+    assert (outcome.approved, outcome.refused, outcome.budget) == (0, 0, 30)
+    assert outcome.touched == set()
+    assert outcome.deferred == set()
+
+
+def test_a_run_parked_for_a_human_actor_is_not_approvable(watchdog):
+    run = _parked(triggering_actor={"login": "Some-Contributor"})
+    eligible, reason = watchdog.is_approvable(run, REPO)
+    assert eligible is False
+    assert "branch-update bot" in reason
+
+
+def test_a_same_repo_bot_parked_run_is_approvable(watchdog):
+    eligible, reason = watchdog.is_approvable(_parked(), REPO)
+    assert eligible is True
+    assert reason == ""
+
+
+def test_a_run_with_no_head_repository_is_treated_as_a_fork(watchdog):
+    """Missing provenance must fail closed, not open."""
+    run = _parked()
+    del run["head_repository"]
+    assert watchdog.is_approvable(run, REPO)[0] is False
+
+
+# --- #12823: parked runs ---------------------------------------------------
+
+
+def test_parked_run_is_reported_as_failure(watchdog):
+    runs = [_parked(name="Code Quality"), _parked(id=2, name="PR Template Check")]
+    state, description = watchdog.classify_dispatch(runs, _ts(5), NOW, 10, 30)
+    assert state == "failure"
+    assert "parked awaiting approval" in description
+    assert "Code Quality" in description
+
+
+def test_parked_run_outranks_otherwise_green_runs(watchdog):
+    """A head with 20 green runs and one parked run is still not verified."""
+    runs = [_run(id=i) for i in range(20)]
+    runs.append(_parked(id=99, name="Enforce Pre-commit Hooks"))
+    state, _ = watchdog.classify_dispatch(runs, _ts(60), NOW, 10, 30)
+    assert state == "failure"
+
+
+# --- #13045: starved runs and absent runs ----------------------------------
+
+
+def test_queued_run_past_the_stall_threshold_with_an_empty_pool_is_failure(watchdog):
+    runs = [
+        _run(status="queued", conclusion=None, created_at=_ts(45), name="Unit & Integration Tests")
+    ]
+    state, description = watchdog.classify_dispatch(runs, _ts(45), NOW, 10, 30, False)
+    assert state == "failure"
+    assert "no runner available" in description
+
+
+def test_queued_run_behind_a_busy_pool_is_pending_not_failure(watchdog):
+    """Normal contention on the singleton runner must not raise a false outage."""
+    runs = [
+        _run(status="queued", conclusion=None, created_at=_ts(45), name="Unit & Integration Tests")
+    ]
+    state, description = watchdog.classify_dispatch(runs, _ts(45), NOW, 10, 30, True)
+    assert state == "pending"
+    assert "busy runner pool" in description
+
+
+def test_a_busy_queue_is_still_never_success(watchdog):
+    runs = [_run(status="queued", conclusion=None, created_at=_ts(45))]
+    state, _ = watchdog.classify_dispatch(runs, _ts(45), NOW, 10, 30, True)
+    assert state != "success"
+
+
+def test_queued_run_inside_the_stall_threshold_is_success(watchdog):
+    runs = [_run(status="queued", conclusion=None, created_at=_ts(4))]
+    state, _ = watchdog.classify_dispatch(runs, _ts(4), NOW, 10, 30, False)
+    assert state == "success"
+
+
+def test_no_runs_past_the_grace_window_is_failure(watchdog):
+    state, description = watchdog.classify_dispatch([], _ts(30), NOW, 10, 30)
+    assert state == "failure"
+    assert "never dispatched" in description
+
+
+def test_no_runs_inside_the_grace_window_is_pending_not_success(watchdog):
+    """Absence must never read as green, even before the grace window closes."""
+    state, _ = watchdog.classify_dispatch([], _ts(2), NOW, 10, 30)
+    assert state == "pending"
+
+
+def test_unparseable_head_timestamp_with_no_runs_is_failure(watchdog):
+    state, _ = watchdog.classify_dispatch([], None, NOW, 10, 30)
+    assert state == "failure"
+
+
+def test_dispatched_runs_are_success(watchdog):
+    state, description = watchdog.classify_dispatch([_run(), _run(id=2)], _ts(5), NOW, 10, 30)
+    assert state == "success"
+    assert "2 workflow run(s) dispatched" in description
+
+
+def test_description_never_exceeds_the_github_limit(watchdog):
+    runs = [_parked(id=i, name=f"A very long workflow name number {i}" * 4) for i in range(30)]
+    _, description = watchdog.classify_dispatch(runs, _ts(5), NOW, 10, 30)
+    assert len(description) <= watchdog.MAX_STATUS_DESCRIPTION
+
+
+# --- an API error is not a diagnosis ---------------------------------------
+
+
+def test_an_api_error_publishes_unknown_not_never_dispatched(watchdog):
+    """One rate-limit window must not assert a root cause on every open PR."""
+    sha = "c" * 40
+    api = _FakeApi({sha: watchdog.WatchdogApiError("HTTP 429: rate limited")})
+    head = watchdog.PullHead(number=5, sha=sha, updated_at=_ts(60), url="u", same_repo=True)
+    config = {"grace_minutes": 10, "stall_minutes": 30, "status_context": "ctx"}
+    blocked = watchdog.publish_dispatch_states(
+        api, [head], config, dry_run=False, pool_serving=True
+    )
+    assert blocked == 1
+    _, state, description = api.statuses[0]
+    assert state == "pending"
+    assert "unknown" in description
+    assert "never dispatched" not in description
+
+
+def test_a_sweep_survives_an_api_error_on_one_head(watchdog):
+    good, bad = "d" * 40, "e" * 40
+    api = _FakeApi({good: [_parked(id=11)], bad: watchdog.WatchdogApiError("HTTP 500")})
+    heads = [
+        watchdog.PullHead(1, bad, _ts(5), "u", True),
+        watchdog.PullHead(2, good, _ts(5), "u", True),
+    ]
+    outcome = watchdog._sweep_once(api, heads, budget=30, dry_run=False)
+    assert outcome.approved == 1
+    assert outcome.refused == 0
+    assert outcome.unsettled is True
+    assert api.approved == [11]
+
+
+# --- starvation / runner liveness ------------------------------------------
+
+
+def test_starved_runs_selects_only_job_less_queued_runs(watchdog):
+    runs = [
+        _run(id=1, status="queued", conclusion=None, created_at=_ts(90)),
+        _run(id=2, status="queued", conclusion=None, created_at=_ts(5)),
+        _run(id=3, status="in_progress", conclusion=None, created_at=_ts(90)),
+        _run(id=4, status="completed", conclusion="success", created_at=_ts(90)),
+    ]
+    assert [run["id"] for run in watchdog.starved_runs(runs, NOW, 30)] == [1]
+
+
+def test_waiting_status_counts_as_unstarted(watchdog):
+    runs = [_run(id=7, status="waiting", conclusion=None, created_at=_ts(60))]
+    assert watchdog.starved_runs(runs, NOW, 30)
+
+
+def test_only_a_self_hosted_label_proves_the_singleton_is_alive(watchdog):
+    """A GitHub-hosted job executing says nothing about the self-hosted pool."""
+    assert watchdog.job_is_self_hosted({"labels": ["self-hosted", "Linux", "X64"]}) is True
+    assert watchdog.job_is_self_hosted({"labels": ["ubuntu-latest"]}) is False
+    assert watchdog.job_is_self_hosted({"labels": []}) is False
+    assert watchdog.job_is_self_hosted({}) is False
+
+
+def test_a_github_hosted_job_does_not_prove_the_pool_is_serving(watchdog):
+    """The old heuristic counted any in_progress run and was near-always true."""
+
+    class _Api:
+        repository = REPO
+
+        def recent_runs(self, per_page=100, run_status=""):
+            return [{"id": 1}]
+
+        def run_jobs(self, run_id):
+            return [{"status": "in_progress", "labels": ["ubuntu-latest"]}]
+
+    assert watchdog.self_hosted_pool_is_serving(_Api(), 10) is False
+
+
+def test_a_self_hosted_job_proves_the_pool_is_serving(watchdog):
+    class _Api:
+        repository = REPO
+
+        def recent_runs(self, per_page=100, run_status=""):
+            return [{"id": 1}]
+
+        def run_jobs(self, run_id):
+            return [{"status": "in_progress", "labels": ["self-hosted", "Linux", "X64"]}]
+
+    assert watchdog.self_hosted_pool_is_serving(_Api(), 10) is True
+
+
+def test_runner_liveness_is_none_when_it_cannot_be_established(watchdog):
+    class _Api:
+        repository = REPO
+
+        def recent_runs(self, per_page=100, run_status=""):
+            raise watchdog.WatchdogApiError("HTTP 429")
+
+    assert watchdog.self_hosted_pool_is_serving(_Api(), 10) is None
+
+
+# --- wedged self-hosted jobs (#13341) ---------------------------------------
+#
+# The required `Unit & Integration Tests` context ran for over three hours
+# against a declared `timeout-minutes: 30`. GitHub enforces that timeout from
+# the runner side, so a runner that stops making progress never receives the
+# cancellation. Two consequences these tests pin down: the job is not
+# distinguishable from a healthy one, and — worse — it made the pool read as
+# ALIVE, so the queue stacking up behind it was dismissed as contention.
+
+
+def _job(minutes_running, labels=("self-hosted", "Linux", "X64"), name="Unit & Integration Tests"):
+    return {
+        "name": name,
+        "status": "in_progress",
+        "labels": list(labels),
+        "started_at": _ts(minutes_running),
+        "html_url": "https://github.com/x/y/actions/runs/1/job/2",
+    }
+
+
+def _pool_api(jobs, run=None):
+    class _Api:
+        repository = REPO
+
+        def recent_runs(self, per_page=100, run_status=""):
+            return [run or {"id": 1, "name": "Frontend Testing Suite", "head_sha": "abc123def456"}]
+
+        def run_jobs(self, run_id):
+            return jobs
+
+    return _Api()
+
+
+def test_a_wedged_job_is_not_evidence_that_the_pool_is_healthy(watchdog):
+    """The false negative: a hung job is in_progress on a self-hosted label."""
+    state = watchdog.inspect_self_hosted_pool(_pool_api([_job(185)]), 10, 45, NOW)
+    assert state.serving is False
+    assert len(state.overdue) == 1
+
+
+def test_a_wedged_job_is_reported_with_the_head_it_is_blocking(watchdog):
+    state = watchdog.inspect_self_hosted_pool(_pool_api([_job(185)]), 10, 45, NOW)
+    entry = state.overdue[0]
+    assert entry.head_sha == "abc123def456"
+    assert entry.job == "Unit & Integration Tests"
+    assert entry.elapsed_minutes == pytest.approx(185, abs=1)
+    assert "185m" in entry.describe()
+
+
+def test_a_self_hosted_job_inside_the_ceiling_is_healthy_not_wedged(watchdog):
+    """29 minutes is inside every declared timeout in the repository."""
+    state = watchdog.inspect_self_hosted_pool(_pool_api([_job(29)]), 10, 45, NOW)
+    assert state.serving is True
+    assert state.overdue == []
+
+
+def test_a_long_running_github_hosted_job_is_not_wedged(watchdog):
+    """marker-tests declares 180m on ubuntu-latest and holds no singleton."""
+    state = watchdog.inspect_self_hosted_pool(
+        _pool_api([_job(120, labels=("ubuntu-latest",))]), 10, 45, NOW
+    )
+    assert state.overdue == []
+
+
+def test_a_job_that_has_not_started_is_never_wedged(watchdog):
+    assert (
+        watchdog.job_is_overdue({"status": "in_progress", "labels": ["self-hosted"]}, NOW, 45)
+        is False
+    )
+
+
+def test_a_completed_job_is_never_wedged(watchdog):
+    job = _job(185)
+    job["status"] = "completed"
+    assert watchdog.job_is_overdue(job, NOW, 45) is False
+
+
+def test_the_wedged_run_is_found_even_when_it_is_the_oldest_of_many(watchdog):
+    """
+    The detector's real failure mode, invisible to every other test here.
+
+    `GET /actions/runs` returns NEWEST first, and a wedged run is by definition
+    the OLDEST in-progress one. Truncating the newest N to the lookup budget
+    therefore drops exactly the run being looked for. Measured live: 12 runs in
+    progress, the wedging one the oldest of the 12, a budget of 10 — missed.
+    """
+    healthy = [
+        {"id": i, "name": "CI", "head_sha": f"sha{i}", "run_started_at": _ts(i)}
+        for i in range(1, 12)
+    ]
+    wedged = {
+        "id": 99,
+        "name": "Frontend Testing Suite",
+        "head_sha": "wedged",
+        "run_started_at": _ts(185),
+    }
+
+    class _Api:
+        repository = REPO
+
+        def recent_runs(self, per_page=100, run_status=""):
+            # Newest first, exactly as GitHub returns it.
+            return healthy + [wedged]
+
+        def run_jobs(self, run_id):
+            if run_id == 99:
+                return [_job(185)]
+            return [_job(2, name="Something Fine")]
+
+    state = watchdog.inspect_self_hosted_pool(_Api(), 10, 45, NOW)
+    assert [entry.head_sha for entry in state.overdue] == ["wedged"]
+
+
+def test_a_healthy_job_alongside_a_wedged_one_still_proves_liveness(watchdog):
+    state = watchdog.inspect_self_hosted_pool(
+        _pool_api([_job(185), _job(3, name="Build Test")]), 10, 45, NOW
+    )
+    assert state.serving is True
+    assert [entry.job for entry in state.overdue] == ["Unit & Integration Tests"]
+
+
+def test_overdue_jobs_are_grouped_by_head(watchdog):
+    a = watchdog.OverdueJob("sha-a", "wf", "job1", 90.0, "u")
+    b = watchdog.OverdueJob("sha-a", "wf", "job2", 91.0, "u")
+    c = watchdog.OverdueJob("", "wf", "job3", 92.0, "u")
+    grouped = watchdog.overdue_by_head([a, b, c])
+    assert list(grouped) == ["sha-a"]
+    assert len(grouped["sha-a"]) == 2
+
+
+def test_a_wedged_head_is_published_as_a_failure_not_a_healthy_in_progress(watchdog):
+    overdue = [
+        watchdog.OverdueJob("sha", "Frontend Testing Suite", "Unit & Integration Tests", 185.0, "u")
+    ]
+    state, description = watchdog.classify_dispatch([_run()], _ts(5), NOW, 10, 30, True, overdue)
+    assert state == "failure"
+    assert "wedged" in description
+
+
+def test_a_wedged_head_never_reads_as_success(watchdog):
+    """Otherwise-green runs must not mask a job holding a required context."""
+    overdue = [watchdog.OverdueJob("sha", "wf", "job", 200.0, "u")]
+    state, _ = watchdog.classify_dispatch([_run(), _run(id=2)], _ts(5), NOW, 10, 30, True, overdue)
+    assert state == "failure"
+
+
+def test_a_head_with_no_wedged_job_is_unaffected(watchdog):
+    state, _ = watchdog.classify_dispatch([_run()], _ts(5), NOW, 10, 30, True, [])
+    assert state == "success"
+
+
+# --- starvation probe vs. a wedged job --------------------------------------
+
+
+def _starvation_api(queued, jobs):
+    class _Api:
+        repository = REPO
+
+        def recent_runs(self, per_page=100, run_status=""):
+            if run_status == "queued":
+                return queued
+            return [{"id": 1, "name": "Frontend Testing Suite", "head_sha": "sha"}]
+
+        def run_jobs(self, run_id):
+            return jobs
+
+    return _Api()
+
+
+_STARVATION_CONFIG = {"stall_minutes": 45, "max_job_lookups": 5, "job_overdue_minutes": 45}
+
+
+def _live_ts(minutes_ago):
+    """Relative to the real clock — check_runner_starvation reads it itself."""
+    return (datetime.now(timezone.utc) - timedelta(minutes=minutes_ago)).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+
+
+def _live_job(minutes_running, name="Unit & Integration Tests"):
+    return {
+        "name": name,
+        "status": "in_progress",
+        "labels": ["self-hosted", "Linux", "X64"],
+        "started_at": _live_ts(minutes_running),
+    }
+
+
+def _live_queue():
+    return [
+        {"id": 9, "name": "CI", "status": "queued", "created_at": _live_ts(60), "head_branch": "b"}
+    ]
+
+
+def test_a_wedged_job_fails_the_probe_even_with_an_empty_queue(watchdog):
+    """It is a fault the moment it happens — it is holding a required check."""
+    api = _starvation_api([], [_live_job(185)])
+    assert watchdog.check_runner_starvation(api, _STARVATION_CONFIG) == 1
+
+
+def test_a_queue_behind_a_wedged_job_is_no_longer_dismissed_as_contention(watchdog):
+    """The regression this check existed to catch and previously reported green."""
+    api = _starvation_api(_live_queue(), [_live_job(185)])
+    assert watchdog.check_runner_starvation(api, _STARVATION_CONFIG) == 1
+
+
+def test_a_queue_behind_genuinely_busy_work_is_still_contention(watchdog):
+    api = _starvation_api(_live_queue(), [_live_job(4, name="Build Test")])
+    assert watchdog.check_runner_starvation(api, _STARVATION_CONFIG) == 0
+
+
+def test_a_quiet_healthy_pool_still_passes(watchdog):
+    assert watchdog.check_runner_starvation(_starvation_api([], []), _STARVATION_CONFIG) == 0
+
+
+def test_starvation_with_no_runner_at_all_still_fails(watchdog):
+    """#13045's original condition must keep failing."""
+    api = _starvation_api(_live_queue(), [])
+    assert watchdog.check_runner_starvation(api, _STARVATION_CONFIG) == 1
+
+
+# --- approval-capability probe ---------------------------------------------
+
+
+def test_probe_detects_a_credential_without_actions_write(watchdog):
+    permitted, explanation = watchdog.interpret_probe(403, "Resource not accessible by integration")
+    assert permitted is False
+    assert "lacks permission" in explanation
+
+
+def test_probe_detects_a_credential_with_actions_write(watchdog):
+    permitted, _ = watchdog.interpret_probe(403, "This workflow run is not waiting for approval")
+    assert permitted is True
+
+
+def test_probe_treats_an_accepted_approval_as_permitted(watchdog):
+    permitted, _ = watchdog.interpret_probe(201, "")
+    assert permitted is True
+
+
+@pytest.mark.parametrize(
+    "status,message",
+    [
+        (401, "Bad credentials"),
+        (404, "Not Found"),
+        (429, "API rate limit exceeded"),
+        (500, "Server Error"),
+        (502, "<html>bad gateway</html>"),
+        (0, "transport failure: timed out"),
+    ],
+)
+def test_probe_never_fails_open_on_an_unrecognised_response(watchdog, status, message):
+    """401/404/429/5xx/transport must be UNRESOLVED, never 'assumed permitted'."""
+    permitted, explanation = watchdog.interpret_probe(status, message)
+    assert permitted is None
+    assert "unresolved" in explanation.lower()
+
+
+def test_probe_selects_successful_runs_not_completed_ones(watchdog):
+    """Parked runs ARE status=completed, so completed candidates are all parked."""
+
+    class _Api:
+        asked_for = None
+
+        def recent_runs(self, per_page=100, run_status=""):
+            _Api.asked_for = run_status
+            return [{"id": 2, "status": "completed", "conclusion": "success"}]
+
+        def approve_run(self, run_id):
+            return 403, "This workflow run is not waiting for approval"
+
+    permitted, _ = watchdog.probe_approval_capability(_Api())
+    assert _Api.asked_for == "success"
+    assert permitted is True
+
+
+def test_probe_reports_unresolved_when_no_candidate_exists(watchdog):
+    class _Api:
+        def recent_runs(self, per_page=100, run_status=""):
+            return []
+
+    permitted, explanation = watchdog.probe_approval_capability(_Api())
+    assert permitted is None
+    assert "unresolved" in explanation
+
+
+def test_probe_is_skipped_and_unresolved_on_a_dry_run(watchdog):
+    """--dry-run must issue no approve request at all."""
+
+    class _Api:
+        def recent_runs(self, per_page=100, run_status=""):
+            raise AssertionError("a dry run must not query for probe candidates")
+
+        def approve_run(self, run_id):
+            raise AssertionError("a dry run must not POST approve")
+
+    permitted, explanation = watchdog.probe_approval_capability(_Api(), dry_run=True)
+    assert permitted is None
+    assert "dry-run" in explanation
+
+
+def test_probe_reports_unresolved_when_the_listing_fails(watchdog):
+    class _Api:
+        def recent_runs(self, per_page=100, run_status=""):
+            raise watchdog.WatchdogApiError("HTTP 429: rate limited")
+
+    permitted, explanation = watchdog.probe_approval_capability(_Api())
+    assert permitted is None
+    assert "unresolved" in explanation
+
+
+# --- dry run is side-effect free -------------------------------------------
+
+
+def test_dry_run_approves_nothing_but_still_consumes_budget(watchdog):
+    api = _FakeApi()
+    runs = [_parked(id=i) for i in range(5)]
+    outcome = watchdog._approve_head(api, 1, runs, budget=3, dry_run=True)
+    assert api.approved == []
+    assert (outcome.approved, outcome.refused) == (0, 0)
+    # Budget consumed so the preview matches the cap a real sweep would hit.
+    assert outcome.budget == 0
+    assert outcome.exhausted is True
+
+
+# --- event-scoped sweeps (#12823 pull_request trigger) ----------------------
+
+
+def test_scoping_selects_only_the_firing_pull_request(watchdog):
+    heads = [
+        watchdog.PullHead(1, "a" * 40, _ts(5), "u", True),
+        watchdog.PullHead(2, "b" * 40, _ts(5), "u", True),
+        watchdog.PullHead(3, "c" * 40, _ts(5), "u", True),
+    ]
+    assert [head.number for head in watchdog.select_heads(heads, 2)] == [2]
+
+
+def test_scoping_off_returns_every_head(watchdog):
+    heads = [
+        watchdog.PullHead(1, "a" * 40, _ts(5), "u", True),
+        watchdog.PullHead(2, "b" * 40, _ts(5), "u", True),
+    ]
+    assert watchdog.select_heads(heads, 0) == heads
+
+
+def test_an_unknown_pr_number_selects_nothing_rather_than_everything(watchdog):
+    """Falling back to 'all heads' would restore the full-queue cost this avoids."""
+    heads = [watchdog.PullHead(1, "a" * 40, _ts(5), "u", True)]
+    assert watchdog.select_heads(heads, 999) == []
+
+
+def test_scoping_to_a_fork_pr_still_never_approves_it(watchdog):
+    """SECURITY: the fork guard is independent of how the head was selected."""
+    sha = "9" * 40
+    api = _FakeApi({sha: [_parked(id=77, head_repository={"full_name": FORK})]})
+    api.open_pull_requests = lambda base: [
+        {
+            "number": 12,
+            "head": {"sha": sha, "repo": {"full_name": FORK}},
+            "html_url": "u",
+            "updated_at": _ts(5),
+        },
+        {
+            "number": 13,
+            "head": {"sha": "8" * 40, "repo": {"full_name": REPO}},
+            "html_url": "u",
+            "updated_at": _ts(5),
+        },
+    ]
+    api.recent_runs = lambda per_page=100, run_status="": []
+    api.run_jobs = lambda run_id: []
+    config = {
+        "base_branch": "Dev_new_gui",
+        "grace_minutes": 10,
+        "stall_minutes": 30,
+        "status_context": "ctx",
+        "max_approvals": 30,
+        "poll_attempts": 1,
+        "poll_interval_seconds": 1,
+        "max_job_lookups": 5,
+        "job_overdue_minutes": 45,
+        "only_pr": 12,
+    }
+    assert watchdog.check_dispatch(api, config, dry_run=False) == 0
+    assert api.approved == []
+    # The untouched same-repo PR was not swept either — scoping held.
+    assert [sha for sha, _state, _desc in api.statuses] == [sha]
+
+
+def test_scoping_to_a_same_repo_pr_still_approves_its_parked_bot_runs(watchdog):
+    sha = "7" * 40
+    api = _FakeApi({sha: [_parked(id=55)]})
+    api.open_pull_requests = lambda base: [
+        {
+            "number": 21,
+            "head": {"sha": sha, "repo": {"full_name": REPO}},
+            "html_url": "u",
+            "updated_at": _ts(5),
+        }
+    ]
+    api.recent_runs = lambda per_page=100, run_status="": []
+    api.run_jobs = lambda run_id: []
+    config = {
+        "base_branch": "Dev_new_gui",
+        "grace_minutes": 10,
+        "stall_minutes": 30,
+        "status_context": "ctx",
+        "max_approvals": 30,
+        "poll_attempts": 1,
+        "poll_interval_seconds": 1,
+        "max_job_lookups": 5,
+        "job_overdue_minutes": 45,
+        "only_pr": 21,
+    }
+    assert watchdog.check_dispatch(api, config, dry_run=False) == 0
+    assert api.approved == [55]
+
+
+def test_a_closed_or_renumbered_scope_target_sweeps_nothing(watchdog, capsys):
+    api = _FakeApi()
+    api.open_pull_requests = lambda base: [
+        {
+            "number": 1,
+            "head": {"sha": "6" * 40, "repo": {"full_name": REPO}},
+            "html_url": "u",
+            "updated_at": _ts(5),
+        }
+    ]
+    config = {"base_branch": "Dev_new_gui", "only_pr": 4242}
+    assert watchdog.check_dispatch(api, config, dry_run=False) == 0
+    assert api.approved == []
+    assert api.statuses == []
+    assert "nothing to sweep" in capsys.readouterr().out
+
+
+def test_only_pr_zero_means_every_open_pr(watchdog, monkeypatch):
+    monkeypatch.setenv("WATCHDOG_ONLY_PR", "0")
+    assert watchdog._env_non_negative_int("WATCHDOG_ONLY_PR", 0) == 0
+
+
+def test_only_pr_rejects_a_negative_number(watchdog, monkeypatch):
+    monkeypatch.setenv("WATCHDOG_ONLY_PR", "-1")
+    with pytest.raises(watchdog.WatchdogConfigError):
+        watchdog._env_non_negative_int("WATCHDOG_ONLY_PR", 0)
+
+
+# --- a concurrent sweep is not a refusal ------------------------------------
+
+RACE_403 = (403, "This workflow run is not waiting for approval")
+
+
+def test_the_race_message_is_recognised(watchdog):
+    assert watchdog.is_already_released("This workflow run is not waiting for approval") is True
+    assert watchdog.is_already_released("Resource not accessible by integration") is False
+    assert watchdog.is_already_released("") is False
+
+
+def test_the_probe_and_the_sweep_agree_about_the_same_message(watchdog):
+    """The exact string interpret_probe calls PROOF of permission.
+
+    Reading it as a refusal in one place and as proof of permission in the
+    other is what made a benign race demand a security downgrade.
+    """
+    message = "This workflow run is not waiting for approval"
+    assert watchdog.interpret_probe(403, message)[0] is True
+    assert watchdog.is_already_released(message) is True
+
+
+def test_a_run_already_released_by_a_concurrent_sweep_is_not_refused(watchdog):
+    api = _FakeApi(approve_response=RACE_403)
+    outcome = watchdog._approve_head(api, 7, [_parked(id=3)], budget=30, dry_run=False)
+    assert outcome.raced == 1
+    assert outcome.refused == 0
+    assert outcome.approved == 0
+
+
+def test_a_genuine_permission_failure_is_still_refused(watchdog):
+    api = _FakeApi(approve_response=(403, "Resource not accessible by integration"))
+    outcome = watchdog._approve_head(api, 7, [_parked(id=3)], budget=30, dry_run=False)
+    assert outcome.refused == 1
+    assert outcome.raced == 0
+
+
+def test_a_raced_sweep_exits_zero_and_never_prints_the_credential_remediation(watchdog, capsys):
+    """The whole point: a routine race must not advise relaxing repo security."""
+    sha = "a" * 40
+    api = _FakeApi({sha: [_parked(id=3)]}, approve_response=RACE_403)
+    api.open_pull_requests = lambda base: [
+        {
+            "number": 31,
+            "head": {"sha": sha, "repo": {"full_name": REPO}},
+            "html_url": "u",
+            "updated_at": _ts(5),
+        }
+    ]
+    api.recent_runs = lambda per_page=100, run_status="": [{"id": 1, "conclusion": "success"}]
+    api.run_jobs = lambda run_id: []
+    config = _sweep_config()
+    assert watchdog.check_dispatch(api, config, dry_run=False) == 0
+    out = capsys.readouterr().out
+    assert "already released" in out
+    assert "relax the repository Actions setting" not in out
+
+
+# --- budget exhaustion must be loud, not a deferral that never arrives ------
+
+
+def _sweep_config(**overrides):
+    config = {
+        "base_branch": "Dev_new_gui",
+        "grace_minutes": 10,
+        "stall_minutes": 30,
+        "status_context": "ctx",
+        "max_approvals": 30,
+        "poll_attempts": 1,
+        "poll_interval_seconds": 1,
+        "max_job_lookups": 5,
+        "job_overdue_minutes": 45,
+    }
+    config.update(overrides)
+    return config
+
+
+def test_exhausting_the_budget_marks_the_head_deferred(watchdog):
+    api = _FakeApi()
+    outcome = watchdog._approve_head(
+        api, 9, [_parked(id=i) for i in range(4)], budget=2, dry_run=False
+    )
+    assert outcome.approved == 2
+    assert outcome.exhausted is True
+
+
+def test_a_sweep_reports_which_prs_the_budget_could_not_reach(watchdog):
+    a, b = "1" * 40, "2" * 40
+    api = _FakeApi({a: [_parked(id=1), _parked(id=2)], b: [_parked(id=3), _parked(id=4)]})
+    heads = [
+        watchdog.PullHead(101, a, _ts(5), "u", True),
+        watchdog.PullHead(102, b, _ts(5), "u", True),
+    ]
+    outcome = watchdog._sweep_once(api, heads, budget=3, dry_run=False)
+    assert outcome.approved == 3
+    assert outcome.deferred == {102}
+
+
+def test_a_budget_exhausted_sweep_exits_non_zero(watchdog, capsys):
+    """Silent deferral to a sweep that never comes is the failure being removed."""
+    sha = "3" * 40
+    api = _FakeApi({sha: [_parked(id=i) for i in range(5)]})
+    api.open_pull_requests = lambda base: [
+        {
+            "number": 55,
+            "head": {"sha": sha, "repo": {"full_name": REPO}},
+            "html_url": "u",
+            "updated_at": _ts(5),
+        }
+    ]
+    api.recent_runs = lambda per_page=100, run_status="": [{"id": 1, "conclusion": "success"}]
+    api.run_jobs = lambda run_id: []
+    assert watchdog.check_dispatch(api, _sweep_config(max_approvals=2), dry_run=False) == 1
+    out = capsys.readouterr().out
+    assert "#55" in out
+    assert "not a permissions problem" in out.lower()
+
+
+def test_budget_exhaustion_does_not_blame_the_credential(watchdog):
+    message = watchdog.budget_exhausted_message({1, 2}, 30)
+    assert "not a permissions problem" in message.lower()
+    assert "30" in message
+    assert "WATCHDOG_MAX_APPROVALS" in message
+
+
+def test_a_dry_run_previews_exhaustion_without_failing(watchdog):
+    """A preview changes nothing, so it has nothing to be silent about."""
+    sha = "4" * 40
+    api = _FakeApi({sha: [_parked(id=i) for i in range(5)]})
+    api.open_pull_requests = lambda base: [
+        {
+            "number": 56,
+            "head": {"sha": sha, "repo": {"full_name": REPO}},
+            "html_url": "u",
+            "updated_at": _ts(5),
+        }
+    ]
+    api.recent_runs = lambda per_page=100, run_status="": []
+    api.run_jobs = lambda run_id: []
+    assert watchdog.check_dispatch(api, _sweep_config(max_approvals=2), dry_run=True) == 0
+
+
+def test_the_default_budget_covers_a_realistic_queue(watchdog):
+    """27 runs measured on the busiest head x 10 open PRs. Below that, sweeps
+    stop part-way and promise a next sweep the schedule cannot deliver."""
+    assert watchdog.DEFAULT_MAX_APPROVALS >= 27 * 10
+
+
+def test_a_bigger_budget_does_not_widen_what_is_approvable(watchdog):
+    """SECURITY: the cap bounds HOW MANY, never WHAT. Fork runs stay excluded."""
+    api = _FakeApi()
+    fork_runs = [_parked(id=i, head_repository={"full_name": FORK}) for i in range(50)]
+    outcome = watchdog._approve_head(
+        api, 1, fork_runs, budget=watchdog.DEFAULT_MAX_APPROVALS, dry_run=False
+    )
+    assert api.approved == []
+    assert outcome.budget == watchdog.DEFAULT_MAX_APPROVALS
+    assert outcome.exhausted is False
+
+
+# --- configuration ----------------------------------------------------------
+
+
+def test_thresholds_come_from_the_environment(watchdog, monkeypatch):
+    monkeypatch.setenv("WATCHDOG_STALL_MINUTES", "7")
+    assert watchdog._env_int("WATCHDOG_STALL_MINUTES", 30) == 7
+
+
+def test_non_positive_threshold_is_rejected(watchdog, monkeypatch):
+    monkeypatch.setenv("WATCHDOG_STALL_MINUTES", "0")
+    with pytest.raises(watchdog.WatchdogConfigError):
+        watchdog._env_int("WATCHDOG_STALL_MINUTES", 30)
+
+
+def test_missing_repository_is_rejected(watchdog, monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "not-a-repo")
+    with pytest.raises(watchdog.WatchdogConfigError):
+        watchdog.load_config()
+
+
+# --- sweep polling ----------------------------------------------------------
+
+
+def test_head_with_no_runs_yet_is_polled_again(watchdog):
+    """Right after update-branch returns, an empty result means 'too early'."""
+    assert watchdog.needs_another_look([]) is True
+
+
+def test_head_with_a_parked_run_is_polled_again(watchdog):
+    assert watchdog.needs_another_look([_run(), _parked(id=2)]) is True
+
+
+def test_head_with_dispatched_runs_is_settled(watchdog):
+    assert watchdog.needs_another_look([_run(), _run(id=2)]) is False
+
+
+def test_a_dry_run_does_not_warn_about_the_probe_it_skipped_on_purpose(watchdog, capsys):
+    """The warning must stay rare enough to be read when it means something."""
+    sha = "1" * 40
+    api = _FakeApi({sha: [_run()]})
+    api.open_pull_requests = lambda base: [
+        {
+            "number": 3,
+            "head": {"sha": sha, "repo": {"full_name": REPO}},
+            "html_url": "u",
+            "updated_at": _ts(5),
+        }
+    ]
+    api.recent_runs = lambda per_page=100, run_status="": []
+    api.run_jobs = lambda run_id: []
+    config = {
+        "base_branch": "Dev_new_gui",
+        "grace_minutes": 10,
+        "stall_minutes": 30,
+        "status_context": "ctx",
+        "max_approvals": 30,
+        "poll_attempts": 1,
+        "poll_interval_seconds": 1,
+        "max_job_lookups": 5,
+        "job_overdue_minutes": 45,
+    }
+    assert watchdog.check_dispatch(api, config, dry_run=True) == 0
+    assert "UNRESOLVED" not in capsys.readouterr().out
+
+
+def test_a_real_sweep_does_warn_when_the_probe_is_unresolved(watchdog, capsys):
+    sha = "2" * 40
+    api = _FakeApi({sha: [_run()]})
+    api.open_pull_requests = lambda base: [
+        {
+            "number": 4,
+            "head": {"sha": sha, "repo": {"full_name": REPO}},
+            "html_url": "u",
+            "updated_at": _ts(5),
+        }
+    ]
+    api.recent_runs = lambda per_page=100, run_status="": []
+    api.run_jobs = lambda run_id: []
+    config = {
+        "base_branch": "Dev_new_gui",
+        "grace_minutes": 10,
+        "stall_minutes": 30,
+        "status_context": "ctx",
+        "max_approvals": 30,
+        "poll_attempts": 1,
+        "poll_interval_seconds": 1,
+        "max_job_lookups": 5,
+        "job_overdue_minutes": 45,
+    }
+    assert watchdog.check_dispatch(api, config, dry_run=False) == 0
+    assert "UNRESOLVED" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# superseded_stuck_runs — force-cancel selection (#13439)
+# ---------------------------------------------------------------------------
+
+
+def _member(run_number: int, minutes_ago: float, **overrides):
+    """A queued run in the default concurrency group."""
+    base = {
+        "id": 1000 + run_number,
+        "run_number": run_number,
+        "workflow_id": 77,
+        "head_branch": "Dev_new_gui",
+        "event": "push",
+        "status": "queued",
+        "conclusion": None,
+        "created_at": _ts(minutes_ago),
+    }
+    base.update(overrides)
+    return _run(**base)
+
+
+def _select(watchdog, runs, grace=5, budget=10):
+    return watchdog.superseded_stuck_runs(runs, NOW, REPO, grace, budget)
+
+
+def test_the_newest_run_in_a_group_is_never_cancelled(watchdog):
+    """The newest run is what everything else is waiting for."""
+    older, newest = _member(1, 60), _member(2, 30)
+
+    picked = _select(watchdog, [older, newest])
+
+    assert [r["run_number"] for r in picked] == [1]
+
+
+def test_an_in_progress_run_is_never_cancelled(watchdog):
+    """in_progress means real work is happening — cancelling it destroys it."""
+    working, newest = _member(1, 60, status="in_progress"), _member(2, 30)
+
+    assert _select(watchdog, [working, newest]) == []
+
+
+def test_approval_gated_statuses_are_never_cancelled(watchdog):
+    """`waiting`/`requested` are approval gates, not a stuck queue."""
+    for status in ("waiting", "requested"):
+        gated, newest = _member(1, 60, status=status), _member(2, 30)
+        assert _select(watchdog, [gated, newest]) == [], status
+
+
+def test_runs_for_different_events_are_not_the_same_group(watchdog):
+    """push and pull_request produce different github.ref, so different groups.
+
+    Grouping them together would treat a PR run as superseding a push run on the
+    same branch and cancel work that is not superseded at all.
+    """
+    push_run = _member(1, 60, event="push")
+    pr_run = _member(2, 30, event="pull_request")
+
+    assert _select(watchdog, [push_run, pr_run]) == []
+
+
+def test_a_run_inside_the_grace_window_is_left_alone(watchdog):
+    """A legitimate brief queue must not be mistaken for a stuck one."""
+    recent, newest = _member(1, 2), _member(2, 1)
+
+    assert _select(watchdog, [recent, newest], grace=5) == []
+
+
+def test_selection_is_capped_by_the_budget_oldest_first(watchdog):
+    """One sweep cannot cancel the world if the grouping is ever wrong."""
+    runs = [_member(n, 100 - n) for n in range(1, 6)]  # 1 oldest ... 5 newest
+
+    picked = _select(watchdog, runs, budget=2)
+
+    assert [r["run_number"] for r in picked] == [1, 2]
+
+
+def test_fork_runs_are_never_cancelled(watchdog):
+    """Same restriction as the approval sweep, for the same reason."""
+    fork = _member(1, 60, head_repository={"full_name": "someone/fork"})
+    newest = _member(2, 30, head_repository={"full_name": "someone/fork"})
+
+    assert _select(watchdog, [fork, newest]) == []
+
+
+def test_a_lone_run_is_never_cancelled(watchdog):
+    """With nothing newer, nothing supersedes it."""
+    assert _select(watchdog, [_member(1, 60)]) == []


### PR DESCRIPTION
Part of #13791 (the safety-net half; the token-attribution half is #13792 against `Dev_new_gui`).

**This PR targets `main` deliberately** — that is the entire point of it, not an accident.

## Thinking Path

`ci-dispatch-watchdog.yml` exists to approve parked runs, and it has never done so on a schedule:

```
$ gh api .../workflows/ci-dispatch-watchdog.yml/runs --jq '[.workflow_runs[].event]|group_by(.)|map({event:.[0],n:length})'
[{"event":"pull_request","n":73},{"event":"push","n":27}]      # schedule: 0
```

GitHub dispatches `schedule` only from the **default branch**. The default branch is `main`, and the
file existed only on `Dev_new_gui`:

```
$ gh api repos/mrveiss/AutoBot-AI --jq .default_branch
main
$ gh api repos/mrveiss/AutoBot-AI/contents/.github/workflows/ci-dispatch-watchdog.yml?ref=main
404 Not Found
```

So the 15-minute sweep was dead for all 100 runs of its life. The workflow's own header predicted
exactly this ("NOT YET LIVE… the cron starts working the moment Dev_new_gui reaches main"); this PR
is that moment, without waiting for a full branch merge.

## Why this does not weaken fork safety

The sweep approves only runs whose head repository **is this repository** and whose triggering actor
is the branch-update bot. A fork pull request gets a published status and never an approval — the
`all_external_contributors` policy stays exactly as it is, which matters because `pull_request` jobs
run on the self-hosted runner and there is a live external fork PR today (#13720).

Making the cron fire changes *when* same-repo bot runs get approved, not *what* is eligible.

## What Changed

- `.github/workflows/ci-dispatch-watchdog.yml` — added to `main`, copied verbatim from
  `Dev_new_gui` apart from the header note below.
- The stale "NOT YET LIVE" comment is corrected rather than left to mislead the next reader, and now
  records the 73/27/0 event split that made the dead cron visible, plus a note to keep the two copies
  in sync.

## Verification

Self-contained — no composite actions or repo files that might not exist on `main`:

```
$ grep -n "uses: \./" .github/workflows/ci-dispatch-watchdog.yml
(no matches)
```

Parses, and its triggers and runner are intact:

```
triggers: ['schedule', 'push', 'workflow_dispatch', 'pull_request']
cron:     ['*/15 * * * *']
jobs:     ['watchdog']
runs-on:  ['ubuntu-latest']
```

`ubuntu-latest` is load-bearing and unchanged: the self-hosted runner is a singleton, so a watchdog
queued behind the outage it reports would be useless.

**The acceptance test is observational** — after merge, this workflow should show `schedule` runs,
which it never has. That is #13791's second acceptance criterion and cannot be demonstrated before
the file reaches the default branch.

## Model Used

Claude Opus 5 (1M context)
