### PR TITLE
docs(research): link the email audit to its umbrella and child issues (#13707)

### DIFF
--- a/docs/research/email-reading-capability-audit.md
+++ b/docs/research/email-reading-capability-audit.md
@@ -6,6 +6,39 @@ module benefit from the CEO agent having an email address?
 **Method:** audit-first — grep + read the actual modules, verify wiring before claiming
 a gap. Every claim below cites a path.
 
+**Tracking umbrella:** [#13707](https://github.com/mrveiss/AutoBot-AI/issues/13707) —
+company mailbox for Company OS: inbound email, autonomy-gated, vault-backed.
+
+---
+
+## Tracking issues
+
+Every gap identified below is filed. This table is the map from a finding to the issue that
+owns it — and back: each issue cites the section here that produced it.
+
+| Wave | Issue | Gap | Section |
+| --- | --- | --- | --- |
+| — | [#13707](https://github.com/mrveiss/AutoBot-AI/issues/13707) | **Umbrella** — company mailbox for Company OS | all |
+| 0 | [#13588](https://github.com/mrveiss/AutoBot-AI/issues/13588) | Agent seam authorises by tool name, fails open on unknown agent id | 2.2 |
+| 0 | [#13250](https://github.com/mrveiss/AutoBot-AI/issues/13250) | Tool approval gated twice by different mechanisms (backend) | 3.1 |
+| 0 | [#13421](https://github.com/mrveiss/AutoBot-AI/issues/13421) | Five approval surfaces, three `risk_level` definitions (frontend) | 3.1, 3.3 |
+| 1 | [#13708](https://github.com/mrveiss/AutoBot-AI/issues/13708) | Credential redaction is name-keyed, blind to free text | 4.3 |
+| 1 | [#13709](https://github.com/mrveiss/AutoBot-AI/issues/13709) | Approval memory scoped per project path | 3.1 |
+| 1 | [#13710](https://github.com/mrveiss/AutoBot-AI/issues/13710) | Outlook integration has no API router; duplicate `__all__` entry | 1.3 |
+| 2 | [#13712](https://github.com/mrveiss/AutoBot-AI/issues/13712) | No mail connector — email never reaches the knowledge base | 1.5, 3.2 |
+| 2 | [#13713](https://github.com/mrveiss/AutoBot-AI/issues/13713) | Orphaned Gmail service cannot run | 1.2, 2.5 |
+| 3 | [#13714](https://github.com/mrveiss/AutoBot-AI/issues/13714) | No mailbox GUI | 3.3 |
+| 3 | [#13715](https://github.com/mrveiss/AutoBot-AI/issues/13715) | Mail has no autonomy/sign-off model | 3.1 |
+| 3 | [#13711](https://github.com/mrveiss/AutoBot-AI/issues/13711) | Agents have no write path to the vault; no provenance | 4.2, 4.4 |
+| 4 | [#13716](https://github.com/mrveiss/AutoBot-AI/issues/13716) | Company OS has zero email | 1.6, 2.1 |
+| 5 | [#13718](https://github.com/mrveiss/AutoBot-AI/issues/13718) | Agent cannot sign up for services | 3.4, 4.5 |
+
+**Critical path:** #13708 → #13712 → #13715 → #13716 → #13718.
+#13710 and #13711 have no blockers inside the umbrella and may start at any time.
+
+**Ordering constraint that drives the waves:** a credential copied into the vector store
+cannot be revoked, so #13708 ships *before* #13712 — see section 4.3.
+
 ---
 
 ## Answer in one line


### PR DESCRIPTION
Refs #13707

## Thinking Path

Design/research docs must be linked to the issues they produced — umbrella and children,
both directions. The audit doc landed in PR #13724 naming no issues at all, and the eleven
issues cited it only as a bare path.

This commit adds the doc-to-issue direction. The issue-to-doc direction is a permalink
added to each of the eleven issue bodies (no code change).

## What Changed

Adds a **Tracking issues** section to `docs/research/email-reading-capability-audit.md`:

- Umbrella #13707 named in the header.
- A wave/issue/gap/section table mapping all 14 tracked issues (3 external Wave-0
  prerequisites + umbrella + 10 children) to the audit section that produced each.
- The critical path and the ordering constraint that drives it.

Docs-only. No code.

## Verification

```
$ git diff --stat origin/Dev_new_gui...HEAD
 docs/research/email-reading-capability-audit.md | 33 +++++++++++++++++++++++++
 1 file changed, 33 insertions(+)
```

Every issue number in the table was verified to exist and be OPEN before linking:

```
$ for n in 13707 13708 13709 13710 13711 13712 13713 13714 13715 13716 13718 \
           13588 13250 13421; do gh issue view $n --json number,state; done
all 14 -> OPEN
```

Section references (1.2, 1.3, 1.5, 1.6, 2.1, 2.2, 2.5, 3.1-3.4, 4.2-4.5) all resolve to
headings that exist in the doc.

## Model Used

Claude Opus 5 (1M context)
