### PR TITLE
feat(agent-loop): lower max_identical_tool_calls default 3 -> 2 (#13764)

### DIFF
--- a/autobot-backend/agent_loop/guard_profile.py
+++ b/autobot-backend/agent_loop/guard_profile.py
@@ -17,7 +17,7 @@ Guard matrix (fields are ``AgentLoopConfig`` guard booleans / limits):
     pre_action_verifier_enabled      False       True      True
     halt_on_stagnation               False       True      True
     abstain_on_low_confidence        False       True      True
-    max_identical_tool_calls           5           3        2
+    max_identical_tool_calls           5           2        2
 
 (*) ``standard`` is the default and reproduces today's ``AgentLoopConfig``
 defaults exactly.

--- a/autobot-backend/agent_loop/types.py
+++ b/autobot-backend/agent_loop/types.py
@@ -216,7 +216,15 @@ class AgentLoopConfig:
     max_retries_low: int = 5  # LOW/RETRY-class: 5 retries (transient errors)
 
     # Repetitive tool-call detection (#3255)
-    max_identical_tool_calls: int = 3  # Halt when same tool+args seen N times
+    # #13764: 2, not 3. The production seam counts on (call fingerprint,
+    # result hash) since #13590, so a repeat only counts when the result is
+    # unchanged too — a polling loop resets and is never affected by this
+    # number. What remains is an agent reproducing a result it already has,
+    # where each further call is worth nothing and the asymmetry is stark:
+    # halting one call early costs almost nothing, one call late costs the
+    # rest of the iteration budget. AUTOBOT_GUARD_MAX_IDENTICAL raises it
+    # per deployment without a code change.
+    max_identical_tool_calls: int = 2
 
     # Semantic stagnation detection (#6627)
     stagnation_window: int = 5  # Rolling window of observations to evaluate

--- a/autobot-backend/tests/agent_loop/test_guard_profile.py
+++ b/autobot-backend/tests/agent_loop/test_guard_profile.py
@@ -18,6 +18,7 @@ import pytest
 
 from agent_loop.guard_profile import (
     DEFAULT_PROFILE,
+    GUARD_PROFILES,
     resolve_guard_config_overrides,
     resolve_profile_name,
 )
@@ -135,3 +136,49 @@ class TestLoopWiring:
         default = AgentLoopConfig()
         for field_name in _GUARD_FIELDS:
             assert getattr(loop.config, field_name) == getattr(default, field_name)
+
+
+class TestIdenticalCallDefault:
+    """The dataclass default is 2 (#13764), and `standard` must not shadow it."""
+
+    def test_the_default_is_two(self) -> None:
+        """Pinned so a silent revert to 3 fails here rather than in production.
+
+        Safe at 2 only because #13590 made the production counter key on
+        (call fingerprint, result hash): a repeat counts only when the result is
+        unchanged, so polling resets and is unaffected by this number.
+        """
+        assert AgentLoopConfig().max_identical_tool_calls == 2
+
+    def test_standard_carries_no_overrides_at_all(self) -> None:
+        """The invariant from #13590: `standard` reproduces the dataclass exactly.
+
+        An override here — even one spelling the same value — would mean the
+        dataclass default silently stops governing the default profile.
+        """
+        assert GUARD_PROFILES["standard"] == {}
+
+    def test_standard_mirrors_every_dataclass_default(self) -> None:
+        """AC: `standard` still mirrors the dataclass, field for field."""
+        profiled = AgentLoopConfig.with_guard_profile()
+        default = AgentLoopConfig()
+
+        for field_name in _GUARD_FIELDS:
+            assert getattr(profiled, field_name) == getattr(default, field_name), field_name
+
+    def test_strict_is_no_longer_stricter_on_this_field(self) -> None:
+        """`strict` keeps its explicit 2 for readability; it is now redundant.
+
+        Recorded rather than removed — if the dataclass default moves again,
+        this is where the redundancy stops being true.
+        """
+        assert GUARD_PROFILES["strict"]["max_identical_tool_calls"] == AgentLoopConfig().max_identical_tool_calls
+
+    def test_minimal_still_relaxes_it(self) -> None:
+        assert GUARD_PROFILES["minimal"]["max_identical_tool_calls"] > AgentLoopConfig().max_identical_tool_calls
+
+    def test_the_env_escape_hatch_restores_the_old_value(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Deployments wanting 3 back need no code change (#13764's blast radius)."""
+        monkeypatch.setenv("AUTOBOT_GUARD_MAX_IDENTICAL", "3")
+
+        assert AgentLoopConfig.with_guard_profile().max_identical_tool_calls == 3


### PR DESCRIPTION
Closes #13764

## Thinking Path

This issue carried a sequencing constraint — **land #13590's pair-key first, then lower the default**
— and I verified it rather than assuming it, both before starting and after the blocker merged:

```
$ git show origin/Dev_new_gui:autobot_shared/repetition_guard.py | grep -n "result_hash != previous_hash"
110:    if result_hash is not None and result_hash != previous_hash:
```

The pair key is in the base. That is what makes 2 safe rather than aggressive: a repeat now counts
only when the **result** is unchanged too, so a polling loop resets its own counter and is unaffected
by this number regardless of what it is set to. What is left at the threshold is an agent reproducing
a result it already has — where each further call is worth nothing, and the asymmetry the issue
describes holds: halting one call early costs almost nothing, one call late costs the remaining
iteration budget.

## What Changed

- `agent_loop/types.py` — the dataclass default, `3` → `2`, with the reasoning at the field.
- `agent_loop/guard_profile.py` — **only the docstring table** (`5 3 2` → `5 2 2`), which had become
  wrong the moment the default moved. `GUARD_PROFILES` itself is untouched; the diff is one line and
  it is a comment.

`standard` stays `{}` — the invariant #13590 recorded. `minimal` keeps 5. `strict` keeps its explicit
2, now redundant, kept for profile readability as the issue asks.

## Verification

```
tests/agent_loop/ + agent_loop/ + autobot_shared/repetition_guard_test.py     433 passed
tests/unit/chat_workflow/ (seam) + chat_workflow/                             411 passed
```

**No existing test needed changing.** `test_standard_equals_default_config` compares profiled against
default dynamically rather than hardcoding 3, and `test_loop_repetition.py` passes explicit values —
so nothing was pinned to the old number. That is also why the change could have slipped by silently,
which is what the new tests fix.

**Mutation check** — reverting the default to 3:

```
FAILED TestIdenticalCallDefault::test_the_default_is_two
FAILED TestIdenticalCallDefault::test_strict_is_no_longer_stricter_on_this_field
2 failed, 18 passed
```

Per acceptance criterion:

| AC | Evidence |
|---|---|
| 1 — dataclass default 3 → 2, comment references this issue | `agent_loop/types.py` |
| 2 — `guard_profile.py` untouched, `standard` stays `{}` | `test_standard_carries_no_overrides_at_all` asserts the dict is literally empty — an override spelling the same value would still mean the dataclass stopped governing the default profile |
| 3 — test asserting `standard` mirrors dataclass defaults | `test_standard_mirrors_every_dataclass_default`, field for field |
| 4 — blocked on the pair-key | landed in #13590 / PR #13789; verified in the base above |

`test_the_env_escape_hatch_restores_the_old_value` covers the blast radius the issue names: a
deployment wanting 3 back sets `AUTOBOT_GUARD_MAX_IDENTICAL=3` and needs no code change. The polling
case needs no escape hatch at all — the pair key already handles it.

## Model Used

Claude Opus 5 (1M context)
