### PR TITLE
build(python): move the Linux NPU worker to 3.14 (#13747)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/configure-python-provision-permissions.yml
+++ b/autobot-slm-backend/ansible/playbooks/configure-python-provision-permissions.yml
@@ -4,7 +4,8 @@
 # Python Provision Permissions Playbook (#11343)
 # Grants the autobot service user a narrowly-scoped NOPASSWD sudoers entry so
 # the SLM code-sync update path can install the target Python interpreter
-# (python3.14 for backends, python3.11 for NPU) when it is missing, by running
+# (python3.14 fleet-wide, including the NPU worker since #13747) when it is
+# missing, by running
 # ONLY the provision-local-python.yml playbook via ansible-playbook.
 #
 # Mirrors configure-redis-service-management.yml: validated with visudo,

--- a/autobot-slm-backend/ansible/playbooks/deploy-full.yml
+++ b/autobot-slm-backend/ansible/playbooks/deploy-full.yml
@@ -70,8 +70,8 @@
 # -------------------------------------------------------------------
 # Phase 1.5: Language runtimes (#11374)
 # Install the target Python interpreter on every group whose service roles
-# build a venv, BEFORE those roles run. python3.14 for backend + AI/ML;
-# python3.11 (OpenVINO) for NPU. The python314 role is idempotent (skips when
+# build a venv, BEFORE those roles run. python3.14 fleet-wide, including the
+# NPU worker since #13747. The python314 role is idempotent (skips when
 # the interpreter is present) and fail-loud (verifies after install), so a
 # broken deadsnakes PPA fails the deploy here instead of leaving the wrong
 # interpreter for the venv step to trip over. Ordered AFTER deploy-base (needs
@@ -90,17 +90,21 @@
         python_interpreter_version: "3.14"
       tags: ['deps', 'python314', 'runtimes']
 
-- name: "Phase 1.5: Language runtimes (NPU python3.11)"
+# Kept as its own play rather than folded into the one above: `npu` is a
+# separate host group, and the backend:aiml pattern does not reach it. The
+# python314 role is idempotent, so a co-located host simply skips the second
+# install (#13747 moved this from 3.11 to 3.14).
+- name: "Phase 1.5: Language runtimes (NPU python3.14)"
   hosts: npu
   become: true
   gather_facts: true
   vars:
     deployment_phase: "language-runtimes-npu"
-    phase_description: "Install python3.11 (OpenVINO) interpreter before venv creation"
+    phase_description: "Install python3.14 interpreter before venv creation"
   roles:
     - role: python314
       vars:
-        python_interpreter_version: "3.11"
+        python_interpreter_version: "3.14"
       tags: ['deps', 'python314', 'runtimes']
 
 # Phase 2: Database Infrastructure

--- a/autobot-slm-backend/ansible/playbooks/deploy-native-services.yml
+++ b/autobot-slm-backend/ansible/playbooks/deploy-native-services.yml
@@ -323,13 +323,16 @@
     npu_venv: /opt/autobot/autobot-npu-worker/venv
 
   tasks:
-    # Python 3.11 pinned: OpenVINO/NPU runtime has no 3.14 wheels (do not bump with the rest of the fleet)
+    # #13747: was pinned to 3.11 on the premise that OpenVINO ships no 3.14
+    # wheels (#10877). Measured 2026-08-08: openvino 2026.3.0, torch 2.13.0 and
+    # numpy 2.5.1 all publish cp314, and autobot-npu-worker/requirements.txt
+    # resolves cleanly on 3.14. The NPU worker now matches the rest of the fleet.
     - name: Install Python dependencies for NPU Worker
       apt:
         name:
-          - python3.11
-          - python3.11-venv
-          - python3.11-dev
+          - python3.14
+          - python3.14-venv
+          - python3.14-dev
           - build-essential
           - pkg-config
           - libssl-dev
@@ -372,18 +375,22 @@
     # site-packages built by the other interpreter; the failure is a native
     # ImportError at worker startup, so the deploy still reports success.
     # roles/npu-worker already uses its own {{ npu_install_dir }}/venv — this
-    # matches it. The 3.11 interpreter is deliberate and out of scope here;
-    # moving the NPU worker to 3.14 is #13747.
+    # matches it.
+    #
+    # #13747: the interpreter is now 3.14, matching the rest of the fleet. This
+    # task is what makes the move safe on an already-deployed box — it detects
+    # the existing 3.11 venv as wrong-version and removes it, so 3.11-built
+    # OpenVINO binaries are never carried into a 3.14 venv.
     - name: Enforce the target interpreter on any existing NPU venv
       ansible.builtin.include_role:
         name: python314
         tasks_from: ensure_venv_version
       vars:
         venv_path: "{{ npu_venv }}"
-        venv_python: python3.11
+        venv_python: python3.14
 
     - name: Create Python virtual environment for NPU Worker
-      shell: "python3.11 -m venv {{ npu_venv }}"
+      shell: "python3.14 -m venv {{ npu_venv }}"
       args:
         creates: "{{ npu_venv }}/bin/activate"
       become_user: autobot-service
@@ -400,7 +407,7 @@
       pip:
         requirements: /opt/autobot/src/autobot-npu-worker/requirements.txt
         virtualenv: "{{ npu_venv }}"
-        virtualenv_python: python3.11
+        virtualenv_python: python3.14
       become_user: autobot-service
       environment:
         PIP_DEFAULT_TIMEOUT: "120"

--- a/autobot-slm-backend/ansible/playbooks/provision-local-python.yml
+++ b/autobot-slm-backend/ansible/playbooks/provision-local-python.yml
@@ -6,7 +6,7 @@
 # Provision the target Python interpreter on the LOCAL host (#11343).
 #
 # The SLM code-sync update path calls this when the target interpreter
-# (python3.14 for backends, python3.11 for NPU) is missing on the box it
+# (python3.14 fleet-wide, including the NPU worker since #13747) is missing on the box it
 # runs on. Applying roles/python314 to localhost installs the deadsnakes
 # interpreter so the subsequent venv recreation + pip install succeed.
 #

--- a/autobot-slm-backend/ansible/roles/npu-worker/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/npu-worker/tasks/main.yml
@@ -133,16 +133,31 @@
   when: npu_log_dir != '/var/log/autobot'
   tags: ['npu', 'dirs']
 
-# #11374: Install python3.11 (OpenVINO's supported interpreter) BEFORE any
-# venv work. `ensure_venv_version` removes a wrong-version venv and the
-# `python3.11 -m venv` step recreates it — both fail if python3.11 is absent.
-# The SAME python314 role installs it via the parametrized version var,
-# reusing the deadsnakes apt logic (no duplication). Idempotent + fail-loud.
-- name: NPU worker | Install target Python interpreter (python3.11)
+# #11374: Install the target interpreter BEFORE any venv work.
+# `ensure_venv_version` removes a wrong-version venv and the `-m venv` step
+# recreates it — both fail if the interpreter is absent. The SAME python314
+# role installs it via the parametrized version var, reusing the deadsnakes
+# apt logic (no duplication). Idempotent + fail-loud.
+#
+# #13747: was pinned to 3.11 because OpenVINO shipped no 3.14 wheels (#10877).
+# That is no longer true — openvino 2026.3.0, torch 2.13.0 and numpy 2.5.1 all
+# publish cp314, and this worker's requirements.txt resolves cleanly on 3.14.
+# The NPU worker now matches the rest of the fleet, which is what unpins black's
+# target-version (#13748) — that must land only AFTER this is deployed, or the
+# reformat writes PEP 758 syntax into shared code a still-3.11 worker imports.
+#
+# The Windows NPU worker (resources/windows-npu-worker/) stays where it is: it
+# pins onnxruntime-openvino, which has no cp314 as of 2026-08-08.
+#
+# ensure_venv_version below is what makes this safe on an already-deployed box:
+# it detects the existing 3.11 venv as wrong-version and removes it, so the
+# 3.11-built OpenVINO binaries in site-packages are never carried into a 3.14
+# venv (which would fail at import, not at deploy).
+- name: NPU worker | Install target Python interpreter (python3.14)
   ansible.builtin.include_role:
     name: python314
   vars:
-    python_interpreter_version: "3.11"
+    python_interpreter_version: "3.14"
 
 - name: NPU worker | Enforce venv target Python version (env-drift fix)
   ansible.builtin.include_role:
@@ -150,11 +165,11 @@
     tasks_from: ensure_venv_version
   vars:
     venv_path: "{{ npu_install_dir }}/venv"
-    venv_python: python3.11
+    venv_python: python3.14
 
 - name: Create Python virtual environment
   ansible.builtin.command:
-    cmd: python3.11 -m venv {{ npu_install_dir }}/venv
+    cmd: python3.14 -m venv {{ npu_install_dir }}/venv
     creates: "{{ npu_install_dir }}/venv/bin/python"
 
 - name: Fix venv ownership


### PR DESCRIPTION
## Thinking Path

#10877 pinned the NPU worker to Python 3.11 because OpenVINO shipped no 3.14 wheels. That single pin is load-bearing beyond the worker: it is also why black's `target-version` stays at `py312` (#13748), since PEP 758 `except A, B:` would be a hard `SyntaxError` on shared code the 3.11 worker imports.

I re-measured the premise rather than trusting the recorded reason. Against the PyPI JSON API on 2026-08-08:

| Package | Latest | Python tags | 3.14? |
|---|---|---|---|
| `openvino` | 2026.3.0 | cp310, cp311, cp312, cp313, **cp314** | ✅ |
| `torch` | 2.13.0 | cp310, cp311, cp312, cp313, **cp314** | ✅ |
| `numpy` | 2.5.1 | cp312, cp313, **cp314** | ✅ |
| `onnxruntime-openvino` | 1.24.1 | cp311, cp312, cp313 | ❌ **no cp314** |

"openvino has a cp314 wheel" is weaker evidence than it looks, so I resolved the worker's **actual** requirements on 3.14 — the full graph, not one package:

```
$ venv/bin/python -m pip install --dry-run --ignore-installed -r autobot-npu-worker/requirements.txt
Would install ... numpy-2.5.1 openvino-2026.3.0 openvino-telemetry-2025.2.0 ... torch-2.13.0 triton-3.7.1 ...
```

No conflicts, no fallback to an sdist. That is the whole set the worker installs.

## What Changed

Interpreter moved 3.11 → 3.14 in the two places that build the venv:

- **`roles/npu-worker/tasks/main.yml`** — the canonical path (interpreter install, `ensure_venv_version`, `-m venv`)
- **`playbooks/deploy-native-services.yml`** — the documented operator path (`apt` packages, `ensure_venv_version`, `-m venv`, `virtualenv_python`)

Plus the places that described the old split: the Phase 1.5 NPU play in `deploy-full.yml`, and the header comments in `configure-python-provision-permissions.yml` and `provision-local-python.yml`.

### The upgrade-in-place hazard, and why it is already handled

The real risk is not a fresh install — it is a box that already has a 3.11 venv. Recreating it as 3.14 over existing `site-packages` leaves 3.11-built OpenVINO native extensions in place; that fails at **import or first inference**, long after the deploy reports success.

Both paths already call `ensure_venv_version` before creating the venv, which detects a wrong-version venv and removes it. That task is what makes this change safe in place, so I documented it as load-bearing rather than leaving it looking incidental.

### Deliberately not in scope

The **Windows** NPU worker (`autobot-npu-worker/resources/windows-npu-worker/`) pins `onnxruntime-openvino`, which has no cp314. It is untouched — confirmed no Windows file appears in this diff.

I also kept the separate Phase 1.5 NPU play rather than folding it into the `backend:aiml` one. `npu` is a distinct host group that pattern does not reach, and the `python314` role is idempotent, so a co-located host just skips the second install.

## Verification

```
$ ansible-playbook --syntax-check -i inventory/hosts.yml <each changed playbook>
deploy-native-services.yml                    SYNTAX OK
deploy-full.yml                               SYNTAX OK
provision-local-python.yml                    SYNTAX OK
configure-python-provision-permissions.yml    SYNTAX OK

$ ansible-playbook --syntax-check -i inventory/hosts.yml playbooks/provision-fleet-roles.yml
SYNTAX OK          # this is the playbook that applies roles/npu-worker, so the role graph parses
```

No `python3.11` pin remains for the Linux worker anywhere in `ansible/`. The one surviving mention is a parameter example in `ensure_venv_version.yml`'s docstring, which documents the argument's form and is not a pin.

## This PR does not close #13747

Its acceptance criteria require the worker to **start and serve inference on 3.14, verified on a host** — explicitly not by a successful `pip install`. OpenVINO failures are native-extension failures that surface at import or first inference, so a green resolution proves the dependency set solves, not that the NPU runs.

I have no NPU host to verify against, so the issue stays open pending that deploy evidence. Merging this is what makes the next NPU deploy use 3.14; confirming it worked is a separate, host-side step.

**#13748 (black → py314) remains blocked** and must not be taken as unblocked by this merge. It is unblocked only once the worker is *running* 3.14 — reversing that order writes PEP 758 syntax into shared code a still-3.11 worker imports, which is a `SyntaxError` at import, in production.

## Model Used

Claude Opus 5 (1M context)

Part of #13743
