### PR TITLE
fix(memory): make the entity-type schema derive from the graph vocabulary (#13795)

### DIFF
--- a/autobot-backend/api/memory.py
+++ b/autobot-backend/api/memory.py
@@ -397,10 +397,19 @@ async def create_entity(
         )
 
     except ValueError as e:
+        # #13795: this used to answer "Internal server error" with a 400 — a
+        # client-error code carrying a server-error message, and the one string
+        # that says what was actually wrong was thrown away. It made a total
+        # outage of this endpoint undiagnosable from the outside. ValueError here
+        # is raised only by create_entity's own input validation (unknown
+        # entity_type, blank name), so its message is caller-facing by
+        # construction and safe to return.
         logger.warning("[%s] Validation error creating entity: %s", request_id, e)
-        raise HTTPException(status_code=400, detail="Internal server error")
+        raise HTTPException(status_code=400, detail=f"Invalid entity: {e}")
     except Exception as e:
-        logger.error("[%s] Error creating entity: %s", request_id, e)
+        # Generic to the caller, full traceback to the log — the reverse of the
+        # above, because an unexpected failure may carry internals (#13740).
+        logger.error("[%s] Error creating entity: %s", request_id, e, exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to create entity")
 
 

--- a/autobot-backend/api/memory_entity_vocabulary_test.py
+++ b/autobot-backend/api/memory_entity_vocabulary_test.py
@@ -34,8 +34,8 @@ import pytest
 
 pytest.importorskip("pydantic")
 
+from api.schemas_knowledge import _VALID_ENTITY_TYPES, EntityCreateRequest  # noqa: E402
 from autobot_memory_graph.core import ENTITY_TYPES  # noqa: E402
-from api.schemas_knowledge import EntityCreateRequest, _VALID_ENTITY_TYPES  # noqa: E402
 
 
 def _req(entity_type: str) -> EntityCreateRequest:

--- a/autobot-backend/api/memory_entity_vocabulary_test.py
+++ b/autobot-backend/api/memory_entity_vocabulary_test.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Entity-type vocabulary contract — Issue #13795.
+
+`EntityCreateRequest` is the body of POST /api/memory/entities, which calls
+`AutoBotMemoryGraph.create_entity`. The schema used to carry its own literal
+copy of the *knowledge base's* lower-case vocabulary ("decision", "bug_fix", …)
+while `create_entity` validates against the memory graph's `ENTITY_TYPES`
+("DECISION", "BUG", …). The two sets were **disjoint**, so every value the
+schema admitted then raised ValueError one layer down:
+
+    $ for t in research context feature conversation implementation \
+               user_preference learning bug_fix decision task; do POST …; done
+    research         -> 400 {"detail":"Internal server error"}
+    ...              (all ten)
+    task             -> 400 {"detail":"Internal server error"}
+
+Entity creation was impossible through the API for any input at all, and the
+memory graph could not be populated — which silently disabled every
+graph-dependent feature (graph-RAG expansion, the #13474 connection path, the
+memory.* MCP tools, the Entity Graph GUI).
+
+This is the same defect #13452 fixed for relation types, one field over. These
+tests pin the two vocabularies together so a literal copy cannot come back.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pydantic")
+
+from autobot_memory_graph.core import ENTITY_TYPES  # noqa: E402
+from api.schemas_knowledge import EntityCreateRequest, _VALID_ENTITY_TYPES  # noqa: E402
+
+
+def _req(entity_type: str) -> EntityCreateRequest:
+    return EntityCreateRequest(entity_type=entity_type, name="X", observations=["o"])
+
+
+def test_schema_vocabulary_is_the_graph_vocabulary():
+    """The regression itself: a literal copy is free to drift, a derivation is not."""
+    assert _VALID_ENTITY_TYPES == frozenset(ENTITY_TYPES)
+
+
+@pytest.mark.parametrize("entity_type", sorted(ENTITY_TYPES))
+def test_every_accepted_type_is_one_create_entity_accepts(entity_type: str):
+    """Whatever the schema admits must survive create_entity's own validation.
+
+    Previously this was false for all ten admitted values.
+    """
+    assert _req(entity_type).entity_type in ENTITY_TYPES
+
+
+@pytest.mark.parametrize("entity_type", sorted(ENTITY_TYPES))
+def test_lowercase_is_normalised_not_rejected(entity_type: str):
+    """Callers written against the old lower-case schema keep working, and the
+    value handed to create_entity is the canonical casing it requires."""
+    assert _req(entity_type.lower()).entity_type == entity_type
+
+
+def test_mixed_case_is_normalised():
+    assert _req("DeCiSiOn").entity_type == "DECISION"
+
+
+def test_unknown_type_is_rejected():
+    with pytest.raises(ValueError):
+        _req("definitely_not_a_type")
+
+
+def test_rejection_message_names_the_allowed_values():
+    """The old message was thrown away by the router; a caller must be able to
+    see what is allowed without reading the source."""
+    with pytest.raises(ValueError) as exc_info:
+        _req("nope")
+    message = str(exc_info.value)
+    assert "DECISION" in message
+
+
+def test_knowledge_base_vocabulary_is_gone():
+    """The literal copy admitted these and create_entity rejected all of them."""
+    for stale in ("bug_fix", "user_preference", "context", "learning", "implementation"):
+        with pytest.raises(ValueError):
+            _req(stale)

--- a/autobot-backend/api/schemas_knowledge.py
+++ b/autobot-backend/api/schemas_knowledge.py
@@ -15,6 +15,7 @@ from typing import Any, Dict, List, Literal
 from pydantic import AliasChoices, BaseModel, Field, field_validator
 
 from autobot_memory_graph.core import (
+    ENTITY_TYPES,
     RELATION_TYPE_ALIASES,
     RELATION_TYPES,
     canonical_relation_type,
@@ -3800,20 +3801,16 @@ class MCPToolCallRequest(BaseModel):
 
 # memory.py schemas (#6042)
 
-_VALID_ENTITY_TYPES = frozenset(
-    {
-        "conversation",
-        "bug_fix",
-        "feature",
-        "decision",
-        "task",
-        "user_preference",
-        "context",
-        "learning",
-        "research",
-        "implementation",
-    }
-)
+# Issue #13795: the same defect #13452 fixed for relations, one field over.
+# EntityCreateRequest is the body of POST /api/memory/entities, which calls
+# AutoBotMemoryGraph.create_entity — so it must validate against the memory
+# graph's vocabulary, not the knowledge base's. The literal copy here was the
+# knowledge-base list ("decision", "bug_fix", …) while create_entity validates
+# against ENTITY_TYPES ("DECISION", "BUG", …). The two sets are **disjoint**, so
+# every value this schema accepted then raised ValueError inside create_entity —
+# entity creation was impossible through the API for any input at all. Derived
+# now, so it cannot drift again.
+_VALID_ENTITY_TYPES = frozenset(ENTITY_TYPES)
 # Issue #13452: RelationCreateRequest is the body of POST /api/memory/relations,
 # which calls AutoBotMemoryGraph.create_relation — so it must validate against
 # the memory graph's vocabulary, not the knowledge base's. The previous literal
@@ -3833,9 +3830,17 @@ class EntityCreateRequest(BaseModel):
     @field_validator("entity_type")
     @classmethod
     def validate_entity_type(cls, v):
-        if v not in _VALID_ENTITY_TYPES:
-            raise ValueError(f"entity_type must be one of: {_VALID_ENTITY_TYPES}")
-        return v
+        """Validate against the memory graph's vocabulary, case-insensitively.
+
+        #13795: ENTITY_TYPES is upper-case; every caller written against the old
+        lower-case schema sent "decision". Normalising rather than rejecting
+        keeps those callers working, and returning the canonical casing means
+        create_entity receives a value it accepts.
+        """
+        canonical = v.upper() if isinstance(v, str) else v
+        if canonical not in _VALID_ENTITY_TYPES:
+            raise ValueError(f"entity_type must be one of: {sorted(_VALID_ENTITY_TYPES)}")
+        return canonical
 
 
 class ObservationAddRequest(BaseModel):


### PR DESCRIPTION
Closes #13795.

## Thinking Path

`POST /api/memory/entities` returned **400 for every possible input**. Not a subset — every one:

```
research/context/feature/conversation/implementation/
user_preference/learning/bug_fix/decision/task   ->  400 {"detail":"Internal server error"}
```

`EntityCreateRequest` carried a literal copy of the *knowledge base's* lower-case vocabulary, while `create_entity` validates against the memory graph's `ENTITY_TYPES` (upper-case). The two sets are **disjoint**, so everything the schema admitted raised `ValueError` one layer down. Anything the schema rejected never got that far. There was no value that worked.

Consequence: the memory graph could not be populated through the API at all, which silently disabled every graph-dependent feature — graph-RAG expansion, the #13474 connection path, the `memory.*` MCP tools, the Entity Graph GUI. `/api/graph-rag/health` reported `memory_graph: healthy` throughout, because readiness is measured by `initialized`, not by whether writes succeed.

This is **the same defect #13452 fixed for relation types, one field over**. That fix's own comment sits ten lines above the broken copy: *"The previous literal copy was the knowledge-base list… Derived now, so it cannot drift again."* Relations were fixed; entities were missed.

The second defect is why it survived: the `ValueError` branch returned `400 "Internal server error"` — a client-error code carrying a server-error message — and threw away the one string that said what was wrong. From outside, a total outage of the endpoint was indistinguishable from a generic server fault, with no traceback logged either.

## What Changed

| File | Change |
|---|---|
| `api/schemas_knowledge.py` | `_VALID_ENTITY_TYPES` now **derives** from `ENTITY_TYPES`; validator normalises case and returns the canonical form |
| `api/memory.py` | `ValueError` → returns the validation message; unexpected errors log a traceback and stay generic to the client (#13740) |
| `api/memory_entity_vocabulary_test.py` | **new** — pins the two vocabularies together |

Case-insensitive on purpose: every caller written against the old lower-case schema keeps working, and `create_entity` receives the upper-case value it requires.

## Verification

Reproduced against the **live** install at `/opt/autobot` before fixing — all ten schema-accepted values returned `400`. Root cause confirmed by reading both vocabularies.

```
$ python3 -m pytest api/memory_entity_vocabulary_test.py -q
29 passed

$ python3 -m pytest api/memory_privacy_forget_everywhere_test.py tests/memory_graph/ tests/memory/ -q
175 passed

$ python3 -m flake8 api/schemas_knowledge.py api/memory.py api/memory_entity_vocabulary_test.py
(clean)
```

The new tests assert the derivation itself (`_VALID_ENTITY_TYPES == frozenset(ENTITY_TYPES)`), that every admitted value survives `create_entity`'s own validation, that lower- and mixed-case normalise, and that the stale knowledge-base values are gone. A literal copy cannot come back without failing them.

## Deliberately NOT in this PR

An audit of `entity_type=` literals reaching `create_entity` found **17 call sites passing values the graph rejects**, and only some are case mismatches:

| literal | sites | problem |
|---|---|---|
| `system` | 7 | absent from the vocabulary |
| `agent` | 3 | absent from the vocabulary |
| `context` | 2 | absent from the vocabulary |
| `conversation` | 2 | case only |
| `bug_fix` / `task` / `CONCEPT` | 1 each | rename / case / absent |

Whether to widen `ENTITY_TYPES` or rewrite those call sites is a product decision about the entity vocabulary, with a blast radius well beyond this endpoint. Filed separately rather than decided here — this PR fixes the API surface that was provably, totally broken.

## Model Used

Claude Opus 5 (1M context)
