### PR TITLE
feat(mcp): declare a required permission per tool at the registry chokepoint (#13228 stage 1)

### DIFF
--- a/autobot-backend/api/mcp_registry.py
+++ b/autobot-backend/api/mcp_registry.py
@@ -430,12 +430,26 @@ MCP_BRIDGES = discover_bridges()
 
 
 def _build_tool_entry(tool: dict, bridge_name: str, bridge_desc: str, endpoint: str, features: List[str]) -> dict:
-    """Build a tool entry with bridge info. (Issue #315 - extracted)"""
+    """Build a tool entry with bridge info. (Issue #315 - extracted)
+
+    #13228: attaches ``required_permission`` here because this is the single
+    point every tool crosses on both consumer paths — ``MCPDispatcher.dispatch``
+    and ``get_tool_definitions`` both read the cache this populates, so one
+    declaration governs execution and advertisement alike.
+
+    ``None`` means the tool is undeclared. Stage 1 records that without acting
+    on it; enforcement (denying the undeclared) is a later, separately
+    revertible step, so this change cannot break a working agent flow.
+    """
+    from autobot_shared.auth.mcp_tool_permissions import required_permission  # noqa: PLC0415
+
+    permission = required_permission(tool["name"], bridge_name)
     return {
         "name": tool["name"],
         "description": tool["description"],
         "input_schema": tool["input_schema"],
         "bridge": bridge_name,
+        "required_permission": permission.value if permission else None,
         "bridge_description": bridge_desc,
         "endpoint": f"{endpoint.replace('/tools', '')}/{tool['name']}",
         "features": features,

--- a/autobot_shared/auth/mcp_tool_permissions.py
+++ b/autobot_shared/auth/mcp_tool_permissions.py
@@ -1,0 +1,121 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Canonical permission required by each MCP tool (#13228).
+
+MCP tool access was governed by ``MCPDispatcher._ADMIN_ONLY_TOOLS`` — a frozenset
+of **seven Redis command substrings**. Everything else on all eleven bridges was
+reachable by ``role="user"``, and the same list gated what was advertised to the
+LLM. A newly added destructive tool was exposed unless somebody remembered to
+edit that frozenset.
+
+This module replaces the guesswork with a declaration, resolved at the one place
+every tool passes through on both consumer paths — ``mcp_registry._build_tool_entry``
+— so ``dispatch()`` and ``get_tool_definitions()`` read the same answer.
+
+Two levels, and the order matters:
+
+1. ``TOOL_PERMISSIONS`` — an exact tool name wins outright. This is where a
+   destructive tool declares a stronger grant than its bridge's baseline.
+2. ``BRIDGE_DEFAULT_PERMISSIONS`` — the baseline for a bridge, chosen as its
+   **least**-privileged operation. A tool added tomorrow inherits read-level
+   access rather than whatever the blocklist happened to miss.
+
+A tool on an unknown bridge with no exact entry resolves to ``None``, which is
+what the enforcement stage (#13228 step 5) refuses. Absence is a denial, not a
+default-allow — that inversion is the point of the issue.
+
+**This module only describes. It enforces nothing on its own.** Stage 1 attaches
+the resolved value to the registry entry so it can be inspected and logged;
+``dispatch()`` still applies the old rule until the fallout inventory is in.
+"""
+
+from typing import Dict, Optional
+
+from autobot_shared.auth.permissions import Permission
+
+# Baseline per bridge — deliberately the least-privileged operation the bridge
+# offers, so an undeclared future tool under-grants rather than over-grants.
+BRIDGE_DEFAULT_PERMISSIONS: Dict[str, Permission] = {
+    "browser_mcp": Permission.MCP_BROWSER_READ,
+    "database_mcp": Permission.MCP_DATABASE_READ,
+    "filesystem_mcp": Permission.FILES_VIEW,
+    "git_mcp": Permission.MCP_GIT_READ,
+    "http_client_mcp": Permission.MCP_HTTP_READ,
+    "knowledge_mcp": Permission.KNOWLEDGE_READ,
+    "prometheus_mcp": Permission.MCP_METRICS_READ,
+    "sequential_thinking_mcp": Permission.AGENT_EXECUTE,
+    "structured_thinking_mcp": Permission.AGENT_EXECUTE,
+    "vnc_mcp": Permission.MCP_DESKTOP_READ,
+}
+
+# Exact tool names that need more than their bridge's baseline. Everything here
+# either changes state, leaves the machine, or reads something the baseline
+# grant does not cover.
+TOOL_PERMISSIONS: Dict[str, Permission] = {
+    # --- browser: observation is the baseline; driving the page is not ---
+    "click": Permission.MCP_BROWSER_CONTROL,
+    "click_index": Permission.MCP_BROWSER_CONTROL,
+    "fill": Permission.MCP_BROWSER_CONTROL,
+    "fill_index": Permission.MCP_BROWSER_CONTROL,
+    "hover": Permission.MCP_BROWSER_CONTROL,
+    "hover_index": Permission.MCP_BROWSER_CONTROL,
+    # `evaluate` runs caller-supplied JavaScript in the page — the strongest
+    # thing this bridge can do, and it read as an ordinary user tool before.
+    "evaluate": Permission.MCP_BROWSER_CONTROL,
+    "intercept_requests": Permission.MCP_BROWSER_CONTROL,
+    # --- database: reads are the baseline; anything that can mutate is not ---
+    "database_execute": Permission.MCP_DATABASE_WRITE,
+    # --- http: a GET/HEAD is a read; the rest send a body or change state ---
+    "http_post": Permission.MCP_HTTP_WRITE,
+    "http_put": Permission.MCP_HTTP_WRITE,
+    "http_patch": Permission.MCP_HTTP_WRITE,
+    "http_delete": Permission.MCP_HTTP_WRITE,
+    # --- filesystem: FILES_VIEW is the baseline; these write or destroy ---
+    "edit_file": Permission.FILES_UPLOAD,
+    "write_file": Permission.FILES_UPLOAD,
+    "create_directory": Permission.FILES_UPLOAD,
+    "move_file": Permission.FILES_UPLOAD,
+    "delete_file": Permission.FILES_DELETE,
+    # --- knowledge: reading is the baseline; ingesting is a write ---
+    "add_to_knowledge_base": Permission.KNOWLEDGE_WRITE,
+    "crawl_site": Permission.KNOWLEDGE_WRITE,
+    # Found by test_state_changing_tools_carry_an_explicit_declaration on its
+    # first run: mcp_crawl registers a WebCrawlerConnector and ingests, so
+    # inheriting KNOWLEDGE_READ would have under-granted it.
+    "mcp_crawl": Permission.KNOWLEDGE_WRITE,
+    "map_site": Permission.KNOWLEDGE_WRITE,
+    # --- desktop/vnc: observing is the baseline; driving input is not ---
+    "desktop_mouse_click": Permission.MCP_DESKTOP_CONTROL,
+    "desktop_keyboard_type": Permission.MCP_DESKTOP_CONTROL,
+    "desktop_control_status": Permission.MCP_DESKTOP_CONTROL,
+    # --- redis: the seven names the old blocklist knew about, kept explicit ---
+    "client_list": Permission.MCP_MANAGE,
+    "slowlog": Permission.MCP_MANAGE,
+    "config_set": Permission.MCP_MANAGE,
+    "config_rewrite": Permission.MCP_MANAGE,
+    "debug": Permission.MCP_MANAGE,
+    "flushdb": Permission.MCP_MANAGE,
+    "flushall": Permission.MCP_MANAGE,
+}
+
+
+def required_permission(tool_name: str, bridge_name: str = "") -> Optional[Permission]:
+    """Return the permission *tool_name* requires, or ``None`` if undeclared.
+
+    ``None`` means "no declaration exists", which the enforcement stage treats as
+    a refusal. It is deliberately not a permissive fallback: the whole defect in
+    #13228 is that an undeclared tool was reachable.
+    """
+    exact = TOOL_PERMISSIONS.get(tool_name)
+    if exact is not None:
+        return exact
+    return BRIDGE_DEFAULT_PERMISSIONS.get(bridge_name)
+
+
+__all__ = [
+    "BRIDGE_DEFAULT_PERMISSIONS",
+    "TOOL_PERMISSIONS",
+    "required_permission",
+]

--- a/autobot_shared/auth/mcp_tool_permissions_test.py
+++ b/autobot_shared/auth/mcp_tool_permissions_test.py
@@ -70,9 +70,9 @@ def test_every_bridge_has_a_default():
     """A bridge with no default leaves its whole tool surface undeclared."""
     bridges = {p.stem for p in _bridge_files()}
 
-    assert not (bridges - set(BRIDGE_DEFAULT_PERMISSIONS)), (
-        f"bridges with no declared default: {sorted(bridges - set(BRIDGE_DEFAULT_PERMISSIONS))}"
-    )
+    assert not (
+        bridges - set(BRIDGE_DEFAULT_PERMISSIONS)
+    ), f"bridges with no declared default: {sorted(bridges - set(BRIDGE_DEFAULT_PERMISSIONS))}"
 
 
 def test_the_bridge_sources_are_actually_being_read():
@@ -86,9 +86,27 @@ def test_the_bridge_sources_are_actually_being_read():
 # Verbs that mean a tool changes state, sends a body, or drives input. A tool
 # named with one of these must carry an EXPLICIT entry — inheriting its bridge's
 # read-level baseline is the silent under-grant this issue exists to prevent.
-_MUTATING = ("write", "delete", "remove", "create", "edit", "move", "execute", "set",
-             "post", "put", "patch", "click", "type", "fill", "hover", "evaluate",
-             "flush", "crawl", "add_")
+_MUTATING = (
+    "write",
+    "delete",
+    "remove",
+    "create",
+    "edit",
+    "move",
+    "execute",
+    "set",
+    "post",
+    "put",
+    "patch",
+    "click",
+    "type",
+    "fill",
+    "hover",
+    "evaluate",
+    "flush",
+    "crawl",
+    "add_",
+)
 
 
 @pytest.mark.parametrize("bridge", [p.stem for p in _bridge_files()])
@@ -101,9 +119,7 @@ def test_state_changing_tools_carry_an_explicit_declaration(bridge):
     """
     path = _BRIDGE_DIR / f"{bridge}.py"
     inheriting = [
-        t
-        for t in sorted(_declared_tools(path))
-        if any(verb in t for verb in _MUTATING) and t not in TOOL_PERMISSIONS
+        t for t in sorted(_declared_tools(path)) if any(verb in t for verb in _MUTATING) and t not in TOOL_PERMISSIONS
     ]
 
     assert not inheriting, f"{bridge}: mutating tools inheriting a read default: {inheriting}"

--- a/autobot_shared/auth/mcp_tool_permissions_test.py
+++ b/autobot_shared/auth/mcp_tool_permissions_test.py
@@ -1,0 +1,152 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Every MCP tool declares a permission that exists (#13228).
+
+The defect was a seven-entry Redis substring blocklist governing all eleven
+bridges, default-allow. The risk in replacing it is a *different* silent failure:
+a declaration that names a permission the enum does not have, or a bridge whose
+tools nobody declared. Both are checked here, offline — the bridge sources are
+parsed rather than a live registry queried, so this runs in CI without a backend.
+"""
+
+import pathlib
+import re
+
+import pytest
+
+from autobot_shared.auth.mcp_tool_permissions import (
+    BRIDGE_DEFAULT_PERMISSIONS,
+    TOOL_PERMISSIONS,
+    required_permission,
+)
+from autobot_shared.auth.permissions import ROLE_PERMISSIONS, Permission, Role
+
+_BRIDGE_DIR = pathlib.Path(__file__).resolve().parents[2] / "autobot-backend" / "api"
+
+# Tool names declared as `("name", "description", {...})` tuples, or `name="..."`.
+_TUPLE_TOOL = re.compile(r'^\s{4}\(\s*\n\s{8}"([a-z0-9_]+)"', re.M)
+_KWARG_TOOL = re.compile(r'name="([a-z0-9_]+)"')
+
+
+def _bridge_files():
+    return sorted(p for p in _BRIDGE_DIR.glob("*_mcp.py") if p.stem != "manual_mcp")
+
+
+def _declared_tools(path: pathlib.Path) -> set:
+    """Tool names a bridge module declares, minus the bridge's own name."""
+    src = path.read_text(encoding="utf-8")
+    names = set(_TUPLE_TOOL.findall(src)) or set(_KWARG_TOOL.findall(src))
+    return {n for n in names if n != path.stem}
+
+
+# ------------------------------------------------------- the declarations
+
+
+@pytest.mark.parametrize("perm", sorted(TOOL_PERMISSIONS.values(), key=lambda p: p.value))
+def test_every_declared_tool_permission_exists_in_the_enum(perm):
+    """AC: every `required_permission` is a real `Permission` member."""
+    assert perm in set(Permission)
+
+
+@pytest.mark.parametrize("perm", sorted(BRIDGE_DEFAULT_PERMISSIONS.values(), key=lambda p: p.value))
+def test_every_bridge_default_exists_in_the_enum(perm):
+    assert perm in set(Permission)
+
+
+def test_every_declared_permission_is_granted_to_some_role():
+    """A permission no role holds denies everyone — a broken grant, not a strict one."""
+    granted = {p for perms in ROLE_PERMISSIONS.values() for p in perms}
+    declared = set(TOOL_PERMISSIONS.values()) | set(BRIDGE_DEFAULT_PERMISSIONS.values())
+
+    assert not (declared - granted), f"declared but held by no role: {sorted(p.value for p in declared - granted)}"
+
+
+# ------------------------------------------------------------- coverage
+
+
+def test_every_bridge_has_a_default():
+    """A bridge with no default leaves its whole tool surface undeclared."""
+    bridges = {p.stem for p in _bridge_files()}
+
+    assert not (bridges - set(BRIDGE_DEFAULT_PERMISSIONS)), (
+        f"bridges with no declared default: {sorted(bridges - set(BRIDGE_DEFAULT_PERMISSIONS))}"
+    )
+
+
+def test_the_bridge_sources_are_actually_being_read():
+    """Guard the guard: a parser that finds nothing would pass everything."""
+    found = {p.stem: _declared_tools(p) for p in _bridge_files()}
+    total = sum(len(v) for v in found.values())
+
+    assert total > 50, f"only {total} tool names extracted — the parser stopped matching: {found}"
+
+
+# Verbs that mean a tool changes state, sends a body, or drives input. A tool
+# named with one of these must carry an EXPLICIT entry — inheriting its bridge's
+# read-level baseline is the silent under-grant this issue exists to prevent.
+_MUTATING = ("write", "delete", "remove", "create", "edit", "move", "execute", "set",
+             "post", "put", "patch", "click", "type", "fill", "hover", "evaluate",
+             "flush", "crawl", "add_")
+
+
+@pytest.mark.parametrize("bridge", [p.stem for p in _bridge_files()])
+def test_state_changing_tools_carry_an_explicit_declaration(bridge):
+    """A mutating tool must not silently inherit a read-level bridge default.
+
+    Checking `required_permission(...) is not None` would be tautological — every
+    known bridge has a default, so nothing on one can resolve to None. The real
+    risk is a write tool quietly inheriting read, which is what this catches.
+    """
+    path = _BRIDGE_DIR / f"{bridge}.py"
+    inheriting = [
+        t
+        for t in sorted(_declared_tools(path))
+        if any(verb in t for verb in _MUTATING) and t not in TOOL_PERMISSIONS
+    ]
+
+    assert not inheriting, f"{bridge}: mutating tools inheriting a read default: {inheriting}"
+
+
+# -------------------------------------------------------- resolution rules
+
+
+def test_an_exact_tool_entry_beats_its_bridge_default():
+    """A destructive tool must not inherit its bridge's read-level baseline."""
+    assert required_permission("database_execute", "database_mcp") == Permission.MCP_DATABASE_WRITE
+    assert required_permission("database_query", "database_mcp") == Permission.MCP_DATABASE_READ
+
+
+def test_an_unknown_bridge_resolves_to_none():
+    """None is what stage 3 refuses — the inversion this issue is about."""
+    assert required_permission("whatever", "not_a_bridge") is None
+
+
+def test_an_undeclared_tool_on_a_known_bridge_inherits_the_least_privilege():
+    """A tool added tomorrow under-grants rather than over-grants."""
+    assert required_permission("some_future_tool", "browser_mcp") == Permission.MCP_BROWSER_READ
+
+
+def test_the_old_blocklist_names_still_require_management():
+    """The seven Redis names the substring blocklist knew about keep their grant."""
+    for name in ("client_list", "slowlog", "config_set", "config_rewrite", "debug", "flushdb", "flushall"):
+        assert required_permission(name, "redis_mcp") == Permission.MCP_MANAGE, name
+
+
+def test_browser_evaluate_is_not_a_read():
+    """`evaluate` runs caller-supplied JavaScript; it read as an ordinary user tool."""
+    assert required_permission("evaluate", "browser_mcp") == Permission.MCP_BROWSER_CONTROL
+
+
+def test_readonly_holds_no_control_grant():
+    """The role split has to mean something at the weakest role."""
+    readonly = set(ROLE_PERMISSIONS[Role.READONLY])
+
+    for control in (
+        Permission.MCP_BROWSER_CONTROL,
+        Permission.MCP_DATABASE_WRITE,
+        Permission.MCP_HTTP_WRITE,
+        Permission.MCP_DESKTOP_CONTROL,
+    ):
+        assert control not in readonly, control

--- a/autobot_shared/auth/permissions.py
+++ b/autobot_shared/auth/permissions.py
@@ -88,6 +88,26 @@ class Permission(str, Enum):
     MCP_EXECUTE = "mcp.execute"
     MCP_MANAGE = "mcp.manage"
 
+    # === MCP bridges with no home in the categories above (#13228) ===
+    # MCP tool access was governed by a substring blocklist of seven Redis
+    # command names — default-allow, so every tool on every other bridge was
+    # reachable by role="user". These give the remaining bridges a real
+    # permission each, split read/execute so a browser *observation* and a
+    # browser *click* are not the same grant.
+    #
+    # filesystem/knowledge/thinking bridges are NOT here: they map onto the
+    # existing FILES_*, KNOWLEDGE_* and AGENT_EXECUTE members.
+    MCP_BROWSER_READ = "mcp.browser.read"
+    MCP_BROWSER_CONTROL = "mcp.browser.control"
+    MCP_DATABASE_READ = "mcp.database.read"
+    MCP_DATABASE_WRITE = "mcp.database.write"
+    MCP_GIT_READ = "mcp.git.read"
+    MCP_HTTP_READ = "mcp.http.read"
+    MCP_HTTP_WRITE = "mcp.http.write"
+    MCP_METRICS_READ = "mcp.metrics.read"
+    MCP_DESKTOP_READ = "mcp.desktop.read"
+    MCP_DESKTOP_CONTROL = "mcp.desktop.control"
+
     # === Batch Jobs ===
     BATCH_VIEW = "batch.view"
     BATCH_CREATE = "batch.create"
@@ -194,6 +214,17 @@ ROLE_PERMISSIONS: Dict[Role, List[Permission]] = {
         Permission.SANDBOX_MANAGE,
         Permission.SERVICE_MANAGEMENT,
         Permission.SHELL_EXECUTE,
+        # #13228: per-bridge MCP grants — mirrors this role's MCP_READ/MCP_EXECUTE level.
+        Permission.MCP_BROWSER_READ,
+        Permission.MCP_DATABASE_READ,
+        Permission.MCP_GIT_READ,
+        Permission.MCP_HTTP_READ,
+        Permission.MCP_METRICS_READ,
+        Permission.MCP_DESKTOP_READ,
+        Permission.MCP_BROWSER_CONTROL,
+        Permission.MCP_DATABASE_WRITE,
+        Permission.MCP_HTTP_WRITE,
+        Permission.MCP_DESKTOP_CONTROL,
     ],
     Role.OPERATOR: [
         Permission.API_READ,
@@ -218,6 +249,17 @@ ROLE_PERMISSIONS: Dict[Role, List[Permission]] = {
         Permission.SANDBOX_VIEW,
         Permission.SANDBOX_EXECUTE,
         Permission.SERVICE_MANAGEMENT,
+        # #13228: per-bridge MCP grants — mirrors this role's MCP_READ/MCP_EXECUTE level.
+        Permission.MCP_BROWSER_READ,
+        Permission.MCP_DATABASE_READ,
+        Permission.MCP_GIT_READ,
+        Permission.MCP_HTTP_READ,
+        Permission.MCP_METRICS_READ,
+        Permission.MCP_DESKTOP_READ,
+        Permission.MCP_BROWSER_CONTROL,
+        Permission.MCP_DATABASE_WRITE,
+        Permission.MCP_HTTP_WRITE,
+        Permission.MCP_DESKTOP_CONTROL,
     ],
     Role.ANALYST: [
         Permission.API_READ,
@@ -232,6 +274,13 @@ ROLE_PERMISSIONS: Dict[Role, List[Permission]] = {
         Permission.SECURITY_VIEW,
         Permission.MCP_READ,
         Permission.BATCH_VIEW,
+        # #13228: per-bridge MCP grants — mirrors this role's MCP_READ/MCP_EXECUTE level.
+        Permission.MCP_BROWSER_READ,
+        Permission.MCP_DATABASE_READ,
+        Permission.MCP_GIT_READ,
+        Permission.MCP_HTTP_READ,
+        Permission.MCP_METRICS_READ,
+        Permission.MCP_DESKTOP_READ,
     ],
     Role.EDITOR: [
         Permission.API_READ,
@@ -248,6 +297,13 @@ ROLE_PERMISSIONS: Dict[Role, List[Permission]] = {
         Permission.MCP_READ,
         Permission.BATCH_VIEW,
         Permission.BATCH_CREATE,
+        # #13228: per-bridge MCP grants — mirrors this role's MCP_READ/MCP_EXECUTE level.
+        Permission.MCP_BROWSER_READ,
+        Permission.MCP_DATABASE_READ,
+        Permission.MCP_GIT_READ,
+        Permission.MCP_HTTP_READ,
+        Permission.MCP_METRICS_READ,
+        Permission.MCP_DESKTOP_READ,
     ],
     Role.USER: [
         Permission.API_READ,
@@ -259,6 +315,13 @@ ROLE_PERMISSIONS: Dict[Role, List[Permission]] = {
         Permission.FILES_DOWNLOAD,
         Permission.MCP_READ,
         Permission.BATCH_VIEW,
+        # #13228: per-bridge MCP grants — mirrors this role's MCP_READ/MCP_EXECUTE level.
+        Permission.MCP_BROWSER_READ,
+        Permission.MCP_DATABASE_READ,
+        Permission.MCP_GIT_READ,
+        Permission.MCP_HTTP_READ,
+        Permission.MCP_METRICS_READ,
+        Permission.MCP_DESKTOP_READ,
     ],
     Role.READONLY: [
         Permission.API_READ,


### PR DESCRIPTION
**Part of #13228** — stage 1 of 3. **Declarative only: this PR changes no access decision.**

Deliberately not `Closes` — partial delivery never closes, and the enforcement stages are where
the issue's acceptance criteria are actually met.

## Thinking Path

The issue's step 1 says to add `required_permission` to `MCPBridgeManifest`. That dataclass is
per-*bridge* metadata and carries no tools at all, so there is nowhere to put it. Tools travel a
different path: each bridge serves `/tools` as `(name, description, input_schema)`,
`mcp_registry._build_tool_entry()` assembles the aggregate entry, and `MCPDispatcher._tool_cache`
holds the result — which is what **both** `dispatch()` and `get_tool_definitions()` read.

That makes `_build_tool_entry` the single chokepoint every tool crosses on both consumer paths, so
the declaration lives there rather than being threaded through eleven bridges' tuple contracts for
the same result.

**Two resolution levels, and the order is the design:**

1. `TOOL_PERMISSIONS` — an exact name wins. Where a destructive tool declares more than its bridge.
2. `BRIDGE_DEFAULT_PERMISSIONS` — a bridge's baseline, deliberately its **least**-privileged
   operation, so a tool added tomorrow under-grants instead of over-granting.

Unknown bridge and no exact entry → `None`, which is what stage 3 refuses. Absence is a denial.

**Six bridges had no home in the enum** (browser, database, git, http_client, prometheus, vnc). They
get ten new members split read/control, so a browser *observation* and a browser *click* are not the
same grant. filesystem/knowledge/thinking map onto existing `FILES_*`, `KNOWLEDGE_*`, `AGENT_EXECUTE`.

## What Changed

- `autobot_shared/auth/permissions.py` — ten new `Permission` members for the six bridges with no
  home, each assigned in `ROLE_PERMISSIONS` at the level that role already held for MCP.
- `autobot_shared/auth/mcp_tool_permissions.py` — the tool→permission map and its resolver.
- `autobot-backend/api/mcp_registry.py` — `_build_tool_entry` attaches `required_permission`.
- `autobot_shared/auth/mcp_tool_permissions_test.py` — declaration, coverage and resolution tests.

Nothing reads the attached value yet; `dispatch()` still applies `_ADMIN_ONLY_TOOLS`.

## Staging, and why this PR does nothing

The issue warns default-deny "will surface tools that were silently reachable". So:

1. **this PR** — declare, attach at the chokepoint, test. No enforcement change; nothing can break.
2. next — `dispatch()`/`get_tool_definitions()` read the declaration while still default-allow, and
   log what *would* be denied. That log is the fallout inventory, gathered before it bites.
3. then — flip to default-deny, with `_ADMIN_ONLY_TOOLS` removed.

Each step is independently revertible, and step 3 lands with evidence instead of hope.

## Verification

```
autobot_shared/auth/            (incl. the new + parity suites)   114 passed
autobot-backend/mcp/                                              123 passed
```

**The new coverage test found a real gap on its first run:**

```
FAILED test_state_changing_tools_carry_an_explicit_declaration[knowledge_mcp]
AssertionError: knowledge_mcp: mutating tools inheriting a read default: ['mcp_crawl']
```

`mcp_crawl` registers a `WebCrawlerConnector` and ingests, so inheriting `KNOWLEDGE_READ` would have
under-granted it. Declared `KNOWLEDGE_WRITE`.

**One test was rewritten because it could not fail.** My first version asserted
`required_permission(tool, bridge) is not None` for every tool — but every known bridge has a
default, so nothing on one can ever resolve to `None`. It was tautological. It now asserts that
*mutating* tools (`write`/`delete`/`execute`/`click`/`evaluate`/…) carry an **explicit** entry rather
than silently inheriting a read-level baseline, which is the actual risk this map introduces. That is
the version that caught `mcp_crawl`.

`test_the_bridge_sources_are_actually_being_read` guards the guard: the parser must extract >50 tool
names, so a regex that stops matching fails loudly instead of passing everything.

**The #13758 parity test also did its job here** — adding ten enum members with no role assignment
failed it immediately with all ten listed, which is exactly why that test was repaired.

Also corrected on the issue: new members do **not** need hand-seeding into the SLM model.
`SYSTEM_PERMISSIONS`/`SYSTEM_ROLES` are generated from the enum and re-exported, verified here.

## Model Used

Claude Opus 5 (1M context)
