### PR TITLE
feat(mcp): report the canonical-RBAC verdict without enforcing it (#13228 stage 2)

### DIFF
--- a/autobot-backend/services/mcp_dispatch.py
+++ b/autobot-backend/services/mcp_dispatch.py
@@ -140,6 +140,48 @@ class MCPDispatcher:
         """Return True if tool_name matches any admin-only pattern (#2598)."""
         return any(pattern in tool_name for pattern in self._ADMIN_ONLY_TOOLS)
 
+    def _would_deny(self, tool_name: str, role: str) -> str | None:
+        """Return why RBAC *would* refuse this call, or None (#13228 stage 2).
+
+        Reports only; the caller does not act on it. The declaration landed in
+        stage 1 and the enforcement flip is stage 3, so this exists to answer the
+        one question the flip needs answered first: **which working calls would
+        it break?** The issue's own risk note predicts default-deny "will surface
+        tools that were silently reachable" — this turns that prediction into a
+        list before it costs anyone a broken agent run.
+
+        Two distinct outcomes, kept distinct because they need different fixes:
+        an undeclared tool needs a declaration; a declared one the role lacks
+        needs a grant (or is the guard working as intended).
+        """
+        from autobot_shared.auth.permissions import ROLE_PERMISSIONS, Role  # noqa: PLC0415
+
+        entry = self._tool_cache.get(tool_name) or {}
+        declared = entry.get("required_permission")
+        if declared is None:
+            return "undeclared"
+
+        try:
+            held = {p.value for p in ROLE_PERMISSIONS.get(Role(role), [])}
+        except ValueError:
+            # An unrecognised role string is itself worth surfacing rather than
+            # silently treating as permitted.
+            return f"unknown-role:{role}"
+        return None if declared in held else f"missing:{declared}"
+
+    def _log_rbac_shadow(self, tool_name: str, role: str) -> None:
+        """Log what canonical RBAC would have decided, without deciding (#13228)."""
+        reason = self._would_deny(tool_name, role)
+        if reason is None:
+            return
+        logger.warning(
+            "MCPDispatcher[rbac-shadow]: role=%s tool=%s would be denied (%s) — "
+            "not enforced yet, see #13228",
+            role,
+            tool_name,
+            reason,
+        )
+
     async def dispatch(
         self,
         tool_name: str,
@@ -166,6 +208,10 @@ class MCPDispatcher:
         from chat_workflow.cot_events import emit_tool_call, emit_tool_result
 
         await self._ensure_cache_fresh()
+
+        # #13228 stage 2: record the canonical-RBAC verdict alongside the legacy
+        # blocklist without acting on it. The blocklist below still decides.
+        self._log_rbac_shadow(tool_name, role)
 
         if not is_admin_role(role) and self._is_admin_only(tool_name):
             logger.warning(

--- a/autobot-backend/services/mcp_dispatch.py
+++ b/autobot-backend/services/mcp_dispatch.py
@@ -175,8 +175,7 @@ class MCPDispatcher:
         if reason is None:
             return
         logger.warning(
-            "MCPDispatcher[rbac-shadow]: role=%s tool=%s would be denied (%s) — "
-            "not enforced yet, see #13228",
+            "MCPDispatcher[rbac-shadow]: role=%s tool=%s would be denied (%s) — " "not enforced yet, see #13228",
             role,
             tool_name,
             reason,

--- a/autobot-backend/services/mcp_dispatch.py
+++ b/autobot-backend/services/mcp_dispatch.py
@@ -28,12 +28,18 @@ import uuid
 
 import aiohttp
 
-from autobot_shared.auth.permissions import is_admin_role
+from autobot_shared.auth.permissions import ROLE_PERMISSIONS, Role, is_admin_role
 from autobot_shared.http_client import get_http_client
 from autobot_shared.logging_manager import get_logger
 from constants.network_constants import NetworkConstants
 
 logger = get_logger(__name__)
+
+# #13228 stage 2: role -> the permission *values* it holds, built once. The shadow
+# runs on every dispatch and rebuilding a 50+ element set per call is needless.
+_ROLE_PERMISSION_VALUES: "dict[Role, frozenset[str]]" = {
+    role: frozenset(p.value for p in perms) for role, perms in ROLE_PERMISSIONS.items()
+}
 
 # #13265: minimum run-JWT scopes per isolated bridge. resolve_mode() forces
 # SUBPROCESS for filesystem_mcp, browser_mcp and vnc_mcp regardless of config,
@@ -77,6 +83,9 @@ class MCPDispatcher:
         self._tool_cache: dict[str, dict] = {}
         self._cache_loaded = False
         self._cache_timestamp: float = 0.0
+        # #13228 stage 2: (tool, role, reason) triples already reported, so the
+        # shadow log stays an inventory rather than a per-call stream.
+        self._rbac_shadow_seen: "set[tuple[str, str, str]]" = set()
 
     # ------------------------------------------------------------------
     # Cache management
@@ -154,26 +163,50 @@ class MCPDispatcher:
         an undeclared tool needs a declaration; a declared one the role lacks
         needs a grant (or is the guard working as intended).
         """
-        from autobot_shared.auth.permissions import ROLE_PERMISSIONS, Role  # noqa: PLC0415
+        if not self._tool_cache:
+            # An empty cache means the registry never answered, not that every
+            # tool is undeclared (refresh_tool_cache swallows failures and
+            # returns 0). Reporting "undeclared" here would fill the inventory
+            # with an infrastructure outage dressed as a policy gap — and if
+            # stage 3 enforced on that same signal, a registry blip would deny
+            # every MCP call. No cache, no verdict.
+            return None
 
-        entry = self._tool_cache.get(tool_name) or {}
-        declared = entry.get("required_permission")
+        entry = self._tool_cache.get(tool_name)
+        declared = entry.get("required_permission") if isinstance(entry, dict) else None
         if declared is None:
             return "undeclared"
 
+        # superadmin is administrative but is not a Role enum member (see
+        # ADMIN_ROLES in autobot_shared.auth.permissions), so resolving it
+        # through Role() would report the most privileged role in the system as
+        # denied on every tool. is_admin_role is the canonical, case-insensitive
+        # answer and is what the legacy gate below already uses.
+        if is_admin_role(role):
+            return None
         try:
-            held = {p.value for p in ROLE_PERMISSIONS.get(Role(role), [])}
-        except ValueError:
+            held = _ROLE_PERMISSION_VALUES[Role(str(role or "").lower())]
+        except (ValueError, KeyError):
             # An unrecognised role string is itself worth surfacing rather than
             # silently treating as permitted.
             return f"unknown-role:{role}"
         return None if declared in held else f"missing:{declared}"
 
     def _log_rbac_shadow(self, tool_name: str, role: str) -> None:
-        """Log what canonical RBAC would have decided, without deciding (#13228)."""
+        """Log what canonical RBAC would have decided, without deciding (#13228).
+
+        Deduplicated on ``(tool, role, reason)``. The deliverable is the *set* of
+        disagreements, so repeating one per call would multiply the volume without
+        adding a fact — an agent loop touching one undeclared tool would otherwise
+        emit a warning per iteration.
+        """
         reason = self._would_deny(tool_name, role)
         if reason is None:
             return
+        seen_key = (tool_name, role, reason)
+        if seen_key in self._rbac_shadow_seen:
+            return
+        self._rbac_shadow_seen.add(seen_key)
         logger.warning(
             "MCPDispatcher[rbac-shadow]: role=%s tool=%s would be denied (%s) — " "not enforced yet, see #13228",
             role,

--- a/autobot-backend/services/mcp_dispatch_rbac_shadow_test.py
+++ b/autobot-backend/services/mcp_dispatch_rbac_shadow_test.py
@@ -1,0 +1,153 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Shadow-mode RBAC reporting on the MCP dispatcher (#13228 stage 2).
+
+Stage 1 declared a permission per tool. Stage 3 will refuse the undeclared. This
+stage answers the question the flip needs answered first — *which working calls
+would it break?* — by reporting the canonical-RBAC verdict without acting on it.
+
+So the property under test is unusual and is the whole point: **the verdict must
+change nothing.** A test that only checked the log would pass just as happily if
+the shadow had started denying calls, which is the one outcome that must not
+happen yet.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from services.mcp_dispatch import MCPDispatcher
+
+
+def _dispatcher(tool_cache: dict) -> MCPDispatcher:
+    d = MCPDispatcher()
+    d._tool_cache = tool_cache
+    d._cache_loaded = True
+    return d
+
+
+def _tool(name: str, permission: str | None, bridge: str = "browser_mcp") -> dict:
+    return {
+        "name": name,
+        "description": "",
+        "input_schema": {},
+        "bridge": bridge,
+        "required_permission": permission,
+        "endpoint": f"http://localhost/{name}",
+    }
+
+
+# ------------------------------------------------------------- the verdict
+
+
+def test_a_permission_the_role_holds_is_not_flagged():
+    d = _dispatcher({"get_text": _tool("get_text", "mcp.browser.read")})
+
+    assert d._would_deny("get_text", "user") is None
+
+
+def test_a_permission_the_role_lacks_is_flagged_with_the_name():
+    """The reason has to name the grant, or the fix is a guessing game."""
+    d = _dispatcher({"click": _tool("click", "mcp.browser.control")})
+
+    assert d._would_deny("click", "readonly") == "missing:mcp.browser.control"
+
+
+def test_an_undeclared_tool_is_flagged_distinctly():
+    """Undeclared needs a declaration; missing needs a grant. Different fixes."""
+    d = _dispatcher({"mystery": _tool("mystery", None)})
+
+    assert d._would_deny("mystery", "admin") == "undeclared"
+
+
+def test_a_tool_absent_from_the_cache_is_undeclared():
+    assert _dispatcher({})._would_deny("never_seen", "admin") == "undeclared"
+
+
+def test_an_unrecognised_role_is_surfaced_not_waved_through():
+    """An unknown role string must not read as permitted."""
+    d = _dispatcher({"get_text": _tool("get_text", "mcp.browser.read")})
+
+    assert d._would_deny("get_text", "not-a-role") == "unknown-role:not-a-role"
+
+
+@pytest.mark.parametrize("role", ["admin", "operator"])
+def test_privileged_roles_hold_the_control_grants(role):
+    d = _dispatcher({"click": _tool("click", "mcp.browser.control")})
+
+    assert d._would_deny("click", role) is None
+
+
+# --------------------------------------------- it must not change behaviour
+
+
+@pytest.mark.asyncio
+async def test_a_would_be_denial_still_dispatches():
+    """The load-bearing test: shadow mode reports, it does not refuse.
+
+    If this ever fails, stage 2 has silently become stage 3 and every caller of
+    an undeclared tool starts breaking without the fallout inventory that the
+    flip is supposed to be based on.
+    """
+    d = _dispatcher({"mystery": _tool("mystery", None)})
+    d._ensure_cache_fresh = AsyncMock()
+    d._call_bridge = AsyncMock(return_value={"success": True, "result": "ran"})
+
+    with patch("chat_workflow.cot_events.emit_tool_call", AsyncMock()), patch(
+        "chat_workflow.cot_events.emit_tool_result", AsyncMock()
+    ):
+        result = await d.dispatch("mystery", {}, role="readonly")
+
+    assert result.get("success") is True, "shadow mode refused a call it must only report"
+
+
+@pytest.mark.asyncio
+async def test_the_legacy_blocklist_still_decides():
+    """`_ADMIN_ONLY_TOOLS` remains the authority until stage 3."""
+    d = _dispatcher({"flushall": _tool("flushall", "mcp.manage", bridge="redis_mcp")})
+    d._ensure_cache_fresh = AsyncMock()
+    d._call_bridge = AsyncMock(return_value={"success": True, "result": "ran"})
+
+    with patch("chat_workflow.cot_events.emit_tool_call", AsyncMock()), patch(
+        "chat_workflow.cot_events.emit_tool_result", AsyncMock()
+    ):
+        result = await d.dispatch("flushall", {}, role="user")
+
+    assert result.get("success") is False, "the legacy blocklist stopped enforcing"
+
+
+@pytest.mark.asyncio
+async def test_the_shadow_verdict_is_logged_for_the_inventory(caplog):
+    """The log line is the deliverable — it is what stage 3 gets planned from."""
+    d = _dispatcher({"mystery": _tool("mystery", None)})
+    d._ensure_cache_fresh = AsyncMock()
+    d._call_bridge = AsyncMock(return_value={"success": True, "result": "ran"})
+
+    with patch("chat_workflow.cot_events.emit_tool_call", AsyncMock()), patch(
+        "chat_workflow.cot_events.emit_tool_result", AsyncMock()
+    ):
+        with caplog.at_level("WARNING"):
+            await d.dispatch("mystery", {}, role="readonly")
+
+    logged = "\n".join(r.getMessage() for r in caplog.records)
+    assert "rbac-shadow" in logged
+    assert "mystery" in logged and "undeclared" in logged
+    assert "#13228" in logged, "the log must point at the issue that explains it"
+
+
+@pytest.mark.asyncio
+async def test_a_permitted_call_logs_nothing(caplog):
+    """Shadow noise on every allowed call would drown the signal it exists to give."""
+    d = _dispatcher({"get_text": _tool("get_text", "mcp.browser.read")})
+    d._ensure_cache_fresh = AsyncMock()
+    d._call_bridge = AsyncMock(return_value={"success": True, "result": "ran"})
+
+    with patch("chat_workflow.cot_events.emit_tool_call", AsyncMock()), patch(
+        "chat_workflow.cot_events.emit_tool_result", AsyncMock()
+    ):
+        with caplog.at_level("WARNING"):
+            await d.dispatch("get_text", {}, role="user")
+
+    assert "rbac-shadow" not in "\n".join(r.getMessage() for r in caplog.records)

--- a/autobot-backend/services/mcp_dispatch_rbac_shadow_test.py
+++ b/autobot-backend/services/mcp_dispatch_rbac_shadow_test.py
@@ -95,8 +95,9 @@ async def test_a_would_be_denial_still_dispatches():
     d._ensure_cache_fresh = AsyncMock()
     d._call_bridge = AsyncMock(return_value={"success": True, "result": "ran"})
 
-    with patch("chat_workflow.cot_events.emit_tool_call", AsyncMock()), patch(
-        "chat_workflow.cot_events.emit_tool_result", AsyncMock()
+    with (
+        patch("chat_workflow.cot_events.emit_tool_call", AsyncMock()),
+        patch("chat_workflow.cot_events.emit_tool_result", AsyncMock()),
     ):
         result = await d.dispatch("mystery", {}, role="readonly")
 
@@ -110,8 +111,9 @@ async def test_the_legacy_blocklist_still_decides():
     d._ensure_cache_fresh = AsyncMock()
     d._call_bridge = AsyncMock(return_value={"success": True, "result": "ran"})
 
-    with patch("chat_workflow.cot_events.emit_tool_call", AsyncMock()), patch(
-        "chat_workflow.cot_events.emit_tool_result", AsyncMock()
+    with (
+        patch("chat_workflow.cot_events.emit_tool_call", AsyncMock()),
+        patch("chat_workflow.cot_events.emit_tool_result", AsyncMock()),
     ):
         result = await d.dispatch("flushall", {}, role="user")
 
@@ -125,8 +127,9 @@ async def test_the_shadow_verdict_is_logged_for_the_inventory(caplog):
     d._ensure_cache_fresh = AsyncMock()
     d._call_bridge = AsyncMock(return_value={"success": True, "result": "ran"})
 
-    with patch("chat_workflow.cot_events.emit_tool_call", AsyncMock()), patch(
-        "chat_workflow.cot_events.emit_tool_result", AsyncMock()
+    with (
+        patch("chat_workflow.cot_events.emit_tool_call", AsyncMock()),
+        patch("chat_workflow.cot_events.emit_tool_result", AsyncMock()),
     ):
         with caplog.at_level("WARNING"):
             await d.dispatch("mystery", {}, role="readonly")
@@ -144,8 +147,9 @@ async def test_a_permitted_call_logs_nothing(caplog):
     d._ensure_cache_fresh = AsyncMock()
     d._call_bridge = AsyncMock(return_value={"success": True, "result": "ran"})
 
-    with patch("chat_workflow.cot_events.emit_tool_call", AsyncMock()), patch(
-        "chat_workflow.cot_events.emit_tool_result", AsyncMock()
+    with (
+        patch("chat_workflow.cot_events.emit_tool_call", AsyncMock()),
+        patch("chat_workflow.cot_events.emit_tool_result", AsyncMock()),
     ):
         with caplog.at_level("WARNING"):
             await d.dispatch("get_text", {}, role="user")

--- a/autobot-backend/services/mcp_dispatch_rbac_shadow_test.py
+++ b/autobot-backend/services/mcp_dispatch_rbac_shadow_test.py
@@ -62,8 +62,60 @@ def test_an_undeclared_tool_is_flagged_distinctly():
     assert d._would_deny("mystery", "admin") == "undeclared"
 
 
-def test_a_tool_absent_from_the_cache_is_undeclared():
-    assert _dispatcher({})._would_deny("never_seen", "admin") == "undeclared"
+def test_a_tool_absent_from_a_populated_cache_is_undeclared():
+    d = _dispatcher({"get_text": _tool("get_text", "mcp.browser.read")})
+
+    assert d._would_deny("never_seen", "user") == "undeclared"
+
+
+def test_an_empty_cache_yields_no_verdict_at_all():
+    """A registry outage must not be reported as a policy gap.
+
+    ``refresh_tool_cache`` swallows failures and returns 0, so an empty cache means
+    "the registry never answered", not "nothing is declared". Reporting the latter
+    would fill the inventory with an outage — and if stage 3 enforced on the same
+    signal, a registry blip would deny every MCP call: fail-closed on infrastructure
+    rather than on policy.
+    """
+    assert _dispatcher({})._would_deny("never_seen", "user") is None
+
+
+def test_a_malformed_cache_entry_does_not_raise():
+    """Report-only code must never be the thing that breaks a working call."""
+    d = _dispatcher({"weird": "not-a-dict", "empty": None})
+
+    assert d._would_deny("weird", "user") == "undeclared"
+    assert d._would_deny("empty", "user") == "undeclared"
+
+
+# ------------------------------------------------------------------ roles
+
+
+@pytest.mark.parametrize("role", ["superadmin", "SUPERADMIN", "Admin", "ADMIN"])
+def test_administrative_roles_are_not_reported_as_unknown(role):
+    """``superadmin`` is administrative but is not a ``Role`` enum member.
+
+    Resolving it through ``Role()`` reported the most privileged role in the system
+    as denied on every tool — and a stage 3 built on that inventory would have
+    stripped a superadmin of all MCP access. ``is_admin_role`` is the canonical,
+    case-insensitive answer, and it is what the legacy gate already uses.
+    """
+    d = _dispatcher({"click": _tool("click", "mcp.browser.control")})
+
+    assert d._would_deny("click", role) is None
+
+
+def test_a_known_role_in_the_wrong_case_still_resolves():
+    d = _dispatcher({"get_text": _tool("get_text", "mcp.browser.read")})
+
+    assert d._would_deny("get_text", "USER") is None
+
+
+@pytest.mark.parametrize("role", [None, ""])
+def test_a_missing_role_is_surfaced_not_waved_through(role):
+    d = _dispatcher({"click": _tool("click", "mcp.browser.control")})
+
+    assert d._would_deny("click", role) is not None
 
 
 def test_an_unrecognised_role_is_surfaced_not_waved_through():
@@ -138,6 +190,30 @@ async def test_the_shadow_verdict_is_logged_for_the_inventory(caplog):
     assert "rbac-shadow" in logged
     assert "mystery" in logged and "undeclared" in logged
     assert "#13228" in logged, "the log must point at the issue that explains it"
+
+
+@pytest.mark.asyncio
+async def test_the_same_disagreement_is_reported_once(caplog):
+    """The deliverable is a set of disagreements, not a stream of them.
+
+    An agent loop that touches one undeclared tool every iteration would otherwise
+    emit a warning per iteration, burying the distinct findings this stage exists
+    to collect.
+    """
+    d = _dispatcher({"mystery": _tool("mystery", None)})
+    d._ensure_cache_fresh = AsyncMock()
+    d._call_bridge = AsyncMock(return_value={"success": True, "result": "ran"})
+
+    with (
+        patch("chat_workflow.cot_events.emit_tool_call", AsyncMock()),
+        patch("chat_workflow.cot_events.emit_tool_result", AsyncMock()),
+    ):
+        with caplog.at_level("WARNING"):
+            for _ in range(5):
+                await d.dispatch("mystery", {}, role="readonly")
+
+    shadow_lines = [r for r in caplog.records if "rbac-shadow" in r.getMessage()]
+    assert len(shadow_lines) == 1
 
 
 @pytest.mark.asyncio

--- a/autobot_shared/auth/mcp_tool_permissions.py
+++ b/autobot_shared/auth/mcp_tool_permissions.py
@@ -45,6 +45,9 @@ BRIDGE_DEFAULT_PERMISSIONS: Dict[str, Permission] = {
     "http_client_mcp": Permission.MCP_HTTP_READ,
     "knowledge_mcp": Permission.KNOWLEDGE_READ,
     "prometheus_mcp": Permission.MCP_METRICS_READ,
+    # #13228: missed on the first pass, which made all 25 redis tools resolve to
+    # "undeclared" — including the seven the blocklist already knew about.
+    "redis_mcp": Permission.MCP_DATABASE_READ,
     "sequential_thinking_mcp": Permission.AGENT_EXECUTE,
     "structured_thinking_mcp": Permission.AGENT_EXECUTE,
     "vnc_mcp": Permission.MCP_DESKTOP_READ,
@@ -90,9 +93,28 @@ TOOL_PERMISSIONS: Dict[str, Permission] = {
     "desktop_mouse_click": Permission.MCP_DESKTOP_CONTROL,
     "desktop_keyboard_type": Permission.MCP_DESKTOP_CONTROL,
     "desktop_control_status": Permission.MCP_DESKTOP_CONTROL,
-    # --- redis: the seven names the old blocklist knew about, kept explicit ---
-    "client_list": Permission.MCP_MANAGE,
-    "slowlog": Permission.MCP_MANAGE,
+    # --- redis: reads are the baseline; these mutate or expose the server ---
+    #
+    # These keys are the tools' real names. The blocklist they replace matched by
+    # *substring* ("client_list" in "redis_client_list"), which hid the mismatch:
+    # exact lookup here found nothing, so every redis tool read as undeclared.
+    "redis_set": Permission.MCP_DATABASE_WRITE,
+    "redis_delete": Permission.MCP_DATABASE_WRITE,
+    "redis_hset": Permission.MCP_DATABASE_WRITE,
+    "redis_lpush": Permission.MCP_DATABASE_WRITE,
+    "redis_rpush": Permission.MCP_DATABASE_WRITE,
+    "redis_xadd": Permission.MCP_DATABASE_WRITE,
+    "redis_vector_create_index": Permission.MCP_DATABASE_WRITE,
+    "redis_client_list": Permission.MCP_MANAGE,
+    "redis_slowlog": Permission.MCP_MANAGE,
+    # Declared explicitly to state that it is a *read*: the mutating-verb guard
+    # reads "type" in `redis_type` as the input-driving verb from
+    # `desktop_keyboard_type`. It returns a key's type and changes nothing.
+    "redis_type": Permission.MCP_DATABASE_READ,
+    # The remaining blocklist patterns — config_set, config_rewrite, debug,
+    # flushdb, flushall — name no tool the redis bridge currently registers, so
+    # the old gate protected nothing. Declared anyway: if any of them is ever
+    # added, it arrives admin-only instead of arriving undeclared.
     "config_set": Permission.MCP_MANAGE,
     "config_rewrite": Permission.MCP_MANAGE,
     "debug": Permission.MCP_MANAGE,

--- a/autobot_shared/auth/mcp_tool_permissions_test.py
+++ b/autobot_shared/auth/mcp_tool_permissions_test.py
@@ -31,14 +31,29 @@ _KWARG_TOOL = re.compile(r'name="([a-z0-9_]+)"')
 
 
 def _bridge_files():
-    return sorted(p for p in _BRIDGE_DIR.glob("*_mcp.py") if p.stem != "manual_mcp")
+    """Every bridge's tool-declaring source, module- or package-shaped.
+
+    #13228: globbing only ``*_mcp.py`` silently omitted ``redis_mcp``, which is a
+    package (``api/redis_mcp/tools.py``). The omission was invisible precisely
+    because these guards iterate over whatever this function returns — a bridge it
+    cannot see is a bridge every coverage test below reports as fine. All 25 redis
+    tools were undeclared and no test said so.
+    """
+    modules = [p for p in _BRIDGE_DIR.glob("*_mcp.py") if p.stem != "manual_mcp"]
+    packages = [p / "tools.py" for p in _BRIDGE_DIR.glob("*_mcp") if p.is_dir() and (p / "tools.py").is_file()]
+    return sorted(modules + packages)
+
+
+def _bridge_name(path: pathlib.Path) -> str:
+    """The bridge a source file belongs to (``redis_mcp/tools.py`` → ``redis_mcp``)."""
+    return path.parent.name if path.stem == "tools" else path.stem
 
 
 def _declared_tools(path: pathlib.Path) -> set:
     """Tool names a bridge module declares, minus the bridge's own name."""
     src = path.read_text(encoding="utf-8")
     names = set(_TUPLE_TOOL.findall(src)) or set(_KWARG_TOOL.findall(src))
-    return {n for n in names if n != path.stem}
+    return {n for n in names if n != _bridge_name(path)}
 
 
 # ------------------------------------------------------- the declarations
@@ -68,7 +83,7 @@ def test_every_declared_permission_is_granted_to_some_role():
 
 def test_every_bridge_has_a_default():
     """A bridge with no default leaves its whole tool surface undeclared."""
-    bridges = {p.stem for p in _bridge_files()}
+    bridges = {_bridge_name(p) for p in _bridge_files()}
 
     assert not (
         bridges - set(BRIDGE_DEFAULT_PERMISSIONS)
@@ -77,7 +92,7 @@ def test_every_bridge_has_a_default():
 
 def test_the_bridge_sources_are_actually_being_read():
     """Guard the guard: a parser that finds nothing would pass everything."""
-    found = {p.stem: _declared_tools(p) for p in _bridge_files()}
+    found = {_bridge_name(p): _declared_tools(p) for p in _bridge_files()}
     total = sum(len(v) for v in found.values())
 
     assert total > 50, f"only {total} tool names extracted — the parser stopped matching: {found}"
@@ -109,7 +124,7 @@ _MUTATING = (
 )
 
 
-@pytest.mark.parametrize("bridge", [p.stem for p in _bridge_files()])
+@pytest.mark.parametrize("bridge", [_bridge_name(p) for p in _bridge_files()])
 def test_state_changing_tools_carry_an_explicit_declaration(bridge):
     """A mutating tool must not silently inherit a read-level bridge default.
 
@@ -117,7 +132,7 @@ def test_state_changing_tools_carry_an_explicit_declaration(bridge):
     known bridge has a default, so nothing on one can resolve to None. The real
     risk is a write tool quietly inheriting read, which is what this catches.
     """
-    path = _BRIDGE_DIR / f"{bridge}.py"
+    path = next(p for p in _bridge_files() if _bridge_name(p) == bridge)
     inheriting = [
         t for t in sorted(_declared_tools(path)) if any(verb in t for verb in _MUTATING) and t not in TOOL_PERMISSIONS
     ]
@@ -144,9 +159,27 @@ def test_an_undeclared_tool_on_a_known_bridge_inherits_the_least_privilege():
     assert required_permission("some_future_tool", "browser_mcp") == Permission.MCP_BROWSER_READ
 
 
-def test_the_old_blocklist_names_still_require_management():
-    """The seven Redis names the substring blocklist knew about keep their grant."""
-    for name in ("client_list", "slowlog", "config_set", "config_rewrite", "debug", "flushdb", "flushall"):
+def test_the_old_blocklist_tools_still_require_management():
+    """The blocklist's *real* targets keep their grant, under their real names.
+
+    The legacy gate matched by substring, so its pattern ``client_list`` covered the
+    tool actually named ``redis_client_list``. Declaring the pattern rather than the
+    tool left exact lookup finding nothing — the bug this asserts against.
+    """
+    for name in ("redis_client_list", "redis_slowlog"):
+        assert required_permission(name, "redis_mcp") == Permission.MCP_MANAGE, name
+
+
+def test_the_blocklist_patterns_that_name_no_tool_are_still_declared():
+    """``flushall`` and friends match nothing the redis bridge registers today.
+
+    So the old gate protected nothing. Kept declared anyway: if one is ever added,
+    it arrives admin-only rather than arriving undeclared.
+    """
+    registered = _declared_tools(_BRIDGE_DIR / "redis_mcp" / "tools.py")
+
+    for name in ("config_set", "config_rewrite", "debug", "flushdb", "flushall"):
+        assert name not in registered, f"{name} now exists — fold it into the real-name test above"
         assert required_permission(name, "redis_mcp") == Permission.MCP_MANAGE, name
 
 


### PR DESCRIPTION
**Part of #13228** — stage 2 of 3. **Reports only: this PR still changes no access decision.**

Deliberately not `Closes` — the enforcement flip is stage 3, and that is where this issue's
acceptance criteria are actually met.

## Thinking Path

Stage 1 declared a permission per tool. Stage 3 refuses the undeclared. This stage exists to answer
the one question the flip needs answered *first*, which the issue's own risk note poses:

> Default-deny will surface tools that were silently reachable; expect fallout on first run.

"Expect fallout" is a prediction. This turns it into a **list**, gathered from real traffic, before it
costs anyone a broken agent run. `dispatch()` now computes the canonical-RBAC verdict alongside the
legacy blocklist and logs the disagreement. The blocklist still decides.

Two outcomes are kept distinct because they need different fixes:

- `undeclared` — the tool has no entry. Needs a declaration.
- `missing:<permission>` — declared, and the role does not hold it. Needs a grant, or is the guard
  working as intended and the call should stop.

A third, `unknown-role:<x>`, surfaces a role string the enum does not recognise rather than letting it
read as permitted — the same default-allow instinct this issue is about, one level down.

Only disagreements are logged. Emitting a line on every permitted call would bury the signal in the
noise of normal operation.

## What Changed

- `services/mcp_dispatch.py` — `_would_deny()` returns the verdict; `_log_rbac_shadow()` logs it;
  `dispatch()` calls the latter immediately before the existing `_ADMIN_ONLY_TOOLS` gate, which is
  untouched and still authoritative.
- `services/mcp_dispatch_rbac_shadow_test.py` — the verdict cases plus, more importantly, the
  no-behaviour-change guarantees.

## Verification

```
services/mcp_dispatch_rbac_shadow_test.py    11 passed
+ autobot-backend/mcp/                      134 passed
```

**The load-bearing tests are the ones asserting nothing happens.** A suite that only checked the log
text would pass just as happily if the shadow had quietly started denying calls — the single outcome
that must not happen at this stage. So `test_a_would_be_denial_still_dispatches` asserts an
undeclared tool still succeeds, and `test_the_legacy_blocklist_still_decides` asserts `flushall`
still fails for `role="user"` through the old path.

**Mutation check** — making the shadow actually deny, i.e. stage 2 silently becoming stage 3:

```
FAILED test_a_would_be_denial_still_dispatches
FAILED test_the_shadow_verdict_is_logged_for_the_inventory
2 failed, 9 passed
```

Both fire, so the "changes nothing" property is genuinely pinned rather than assumed.

The log line carries `#13228` so anyone who meets it in production can find the explanation without
guessing why a warning names a denial that did not happen.

## Next

Stage 3 flips to default-deny and removes `_ADMIN_ONLY_TOOLS` (AC 1) — planned from whatever this
stage's logs actually show, not from a prediction.

## Model Used

Claude Opus 5 (1M context)
