### PR TITLE
security(agents): fail closed when an agent id resolves to no capability profile (#13588)

### DIFF
--- a/autobot-backend/chat_workflow/delegation.py
+++ b/autobot-backend/chat_workflow/delegation.py
@@ -179,12 +179,25 @@ async def run_delegated_subtask(
 ) -> str:
     """Run a delegated subtask as a governed subagent (GH#11207).
 
-    Raises ``ValueError`` past ``MAX_DELEGATION_DEPTH`` or for an unknown engine.
-    Emits an INFO log with engine, depth, parent_agent_id, and child agent_type
-    for observability (GH#11266 validation plan gate).
+    Raises ``ValueError`` past ``MAX_DELEGATION_DEPTH``, for an unknown engine, or
+    for an *unbounded* ``agent_type`` (GH#13588). Emits an INFO log with engine,
+    depth, parent_agent_id, and child agent_type for observability (GH#11266
+    validation plan gate).
     """
+    from orchestration.agent_registry import is_unbounded_agent_id
+
     if depth >= MAX_DELEGATION_DEPTH:
         raise ValueError(f"max delegation depth {MAX_DELEGATION_DEPTH} reached (depth={depth})")
+    # GH#13588: ``agent_type`` reaches here straight from the model's tool call, so a
+    # delegating agent could name a designated executor and obtain a subagent with no
+    # boundary — an escalation the parent's own manifest cannot express, since
+    # ``delegate`` is not itself an infra/shell tool. Unregistered ids are safe (they
+    # resolve to the default boundary); an executor id is the case to refuse.
+    if is_unbounded_agent_id(agent_type):
+        raise ValueError(
+            f"delegation to unbounded agent {agent_type!r} is refused: a subagent may not hold "
+            "a wider tool boundary than the profiles available to delegation (GH#13588)"
+        )
     runner = _ENGINES.get(engine)
     if runner is None:
         raise ValueError(f"unknown delegation engine: {engine!r} (available: {sorted(_ENGINES)})")

--- a/autobot-backend/chat_workflow/models.py
+++ b/autobot-backend/chat_workflow/models.py
@@ -405,10 +405,12 @@ def build_governed_identity(
     approval gates resolved upstream. All absent → a plain, ungoverned run.
 
     Trust boundary: enforcement is fail-safe under a user-controlled context — a
-    caller can only *add* restrictions to their own run (an unknown/omitted
-    ``agent_id`` forbids nothing; a set one only forbids), never lift them. But for
-    these to be a real control a *trusted* server-side path must populate them; a
-    future trusted producer must override, not merge with, user-supplied keys.
+    caller can only *add* restrictions to their own run, never lift them. An omitted
+    ``agent_id`` forbids nothing (there is no identity to bound); an *unrecognised*
+    one resolves to the default boundary rather than to none (GH#13588), so a typo
+    cannot buy free rein. But for these to be a real control a *trusted* server-side
+    path must populate them; a future trusted producer must override, not merge
+    with, user-supplied keys.
     """
     agent_id = source.get("agent_id")
     agent_context = AgentContext(agent_id=agent_id, session_id=session_id) if agent_id else None

--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -3024,8 +3024,12 @@ class ToolHandlerMixin:
         Resolves the acting agent id from ``ctx.agent_context`` and matches the tool
         against that agent's manifest via the shared ``match_forbidden_tool`` matcher.
         Records the failure in ``execution_results`` and returns an error
-        ``WorkflowMessage`` when the tool is forbidden, else ``None``. Profile-less
-        agents resolve to an empty manifest and are never blocked here.
+        ``WorkflowMessage`` when the tool is forbidden, else ``None``.
+
+        An empty manifest here means exactly one thing (GH#13588): there is no agent
+        identity on the ctx, i.e. the plain ungoverned chat agent, or the id names a
+        declared executor. An id the registry does not recognise resolves to the
+        default boundary rather than to nothing, so a typo cannot buy free rein.
         """
         from orchestration.agent_registry import match_forbidden_tool, resolve_forbidden_tools
 

--- a/autobot-backend/orchestration/agent_registry.py
+++ b/autobot-backend/orchestration/agent_registry.py
@@ -77,6 +77,7 @@ def _create_system_agent() -> AgentProfile:
         max_concurrent_tasks=2,
         preferred_task_types=["system_operations", "command_execution"],
         allowed_work=list(_INFRA_AND_SHELL_TOOLS),
+        unbounded=True,
     )
 
 
@@ -175,6 +176,7 @@ def _create_routing_profiles() -> List[AgentProfile]:
             capabilities={AgentCapability.EXECUTION, AgentCapability.MONITORING},
             specializations=["command_execution", "system_monitoring"],
             allowed_work=list(_INFRA_AND_SHELL_TOOLS),
+            unbounded=True,
         )
     )
     return profiles
@@ -281,8 +283,11 @@ class AgentCapabilityRegistry:
         """Return the tool names *agent_id* is forbidden to invoke (GH#11139).
 
         Reads the declarative ``forbidden_work`` manifest off the agent's profile.
-        Unknown agents return an empty set (no boundary → falls back to the loop's
-        global SENSITIVE_TOOLS approval gate).
+
+        Raw accessor: unknown agents return an empty set. **Enforcement seams must
+        call ``resolve_forbidden_tools`` instead** (GH#13588) — it recognises the
+        other agent-id namespace and falls closed on an id neither namespace knows,
+        which this method cannot distinguish from a declared executor.
         """
         agent = self._agents.get(agent_id)
         return frozenset(agent.forbidden_work) if agent is not None else frozenset()
@@ -479,13 +484,83 @@ def get_default_capability_registry() -> AgentCapabilityRegistry:
     return _default_registry
 
 
+# GH#13588: the boundary an unrecognised agent id falls back to. Every bounded
+# profile in the registry declares exactly this manifest, so an unknown id lands on
+# the same restriction its intended profile would have imposed — a typo or a
+# wrong-namespace id costs precision, never containment.
+DEFAULT_FORBIDDEN_TOOLS: "frozenset[str]" = frozenset(_INFRA_AND_SHELL_TOOLS)
+
+_agent_type_aliases: "Dict[str, str] | None" = None
+
+
+def agent_type_aliases() -> "Dict[str, str]":
+    """``agent_type`` → ``agent_id`` for unambiguous **bounded** profiles (GH#13588).
+
+    AutoBot carries two agent-id namespaces: capability profiles here, and the DB
+    seed in ``api/agent_config.py``. Where they disagree they usually disagree by
+    *naming style only* — the DB's ``research`` is this registry's ``research_agent``,
+    whose ``agent_type`` is literally ``research``. Resolving through ``agent_type``
+    reconciles those pairs from data already in the profiles, so there is no
+    hand-written map to drift out of date.
+
+    Two exclusions keep this from becoming a privilege-escalation seam:
+
+    - an ``agent_type`` shared by more than one profile is dropped (ambiguous —
+      ``librarian`` names both ``documentation_agent`` and ``kb_librarian``);
+    - ``unbounded`` profiles never get an alias, so an executor's boundary-free
+      manifest is reachable only by naming that executor's exact ``agent_id``.
+    """
+    global _agent_type_aliases  # noqa: PLW0603
+    if _agent_type_aliases is None:
+        by_type: Dict[str, List[AgentProfile]] = {}
+        for profile in get_default_agents():
+            by_type.setdefault(profile.agent_type, []).append(profile)
+        _agent_type_aliases = {
+            agent_type: profiles[0].agent_id
+            for agent_type, profiles in by_type.items()
+            if len(profiles) == 1 and not profiles[0].unbounded
+        }
+    return _agent_type_aliases
+
+
+def resolve_agent_id(agent_id: str) -> "str | None":
+    """Return the registered profile id *agent_id* denotes, or ``None`` (GH#13588)."""
+    if agent_id in get_default_capability_registry():
+        return agent_id
+    return agent_type_aliases().get(agent_id)
+
+
 def resolve_forbidden_tools(agent_id: "str | None") -> "frozenset[str]":
     """Resolve *agent_id*'s ``forbidden_work`` manifest from the default profiles.
 
     Cached, read-only lookup reused by both the agent loop and the production tool
-    dispatch (GH#11145). An unknown or ``None`` ``agent_id`` returns an empty set —
-    no boundary — so callers no-op safely for the plain (profile-less) chat agent.
+    dispatch (GH#11145).
+
+    Three outcomes, deliberately distinct (GH#13588):
+
+    - ``None``/empty — the plain, ungoverned chat agent. No boundary, and that is
+      the documented intent: there is no agent identity to bound.
+    - a **registered** id — that profile's declared manifest, empty only when the
+      profile declares ``unbounded`` (the designated executors).
+    - anything else — ``DEFAULT_FORBIDDEN_TOOLS``, and a WARNING naming the id.
+
+    The third case used to return an empty set, which made a typo'd or
+    wrong-namespace id *indistinguishable from an executor grant* — the boundary
+    looked configured and was not. It now fails closed. Note this cannot strand a
+    correctly configured session: the trusted producer, ``session_role.set_role``,
+    already refuses any id outside this same registry, so every id it can pin
+    resolves here. Only the unvalidated producers — a client-supplied
+    ``context["agent_id"]`` and the ``delegate`` tool's LLM-chosen ``agent_type`` —
+    can reach this branch, and for those, restricting is the safe direction.
     """
     if not agent_id:
         return frozenset()
-    return get_default_capability_registry().forbidden_tools(agent_id)
+    resolved = resolve_agent_id(agent_id)
+    if resolved is None:
+        logger.warning(
+            "agent_registry: unregistered agent id %r — applying the default tool boundary "
+            "instead of running unbounded (GH#13588)",
+            agent_id,
+        )
+        return DEFAULT_FORBIDDEN_TOOLS
+    return get_default_capability_registry().forbidden_tools(resolved)

--- a/autobot-backend/orchestration/agent_registry.py
+++ b/autobot-backend/orchestration/agent_registry.py
@@ -12,7 +12,7 @@ Contains agent registration, lookup, and management functionality.
 from typing import Dict, List, Set
 
 from autobot_shared.logging_manager import get_logger
-from autobot_shared.tool_catalogue import INFRA_AND_SHELL_TOOLS, match_tool_name
+from autobot_shared.tool_catalogue import INFRA_AND_SHELL_TOOLS, SENSITIVE_TOOLS, match_tool_name
 
 from .types import AgentCapability, AgentProfile
 
@@ -484,11 +484,17 @@ def get_default_capability_registry() -> AgentCapabilityRegistry:
     return _default_registry
 
 
-# GH#13588: the boundary an unrecognised agent id falls back to. Every bounded
-# profile in the registry declares exactly this manifest, so an unknown id lands on
-# the same restriction its intended profile would have imposed — a typo or a
-# wrong-namespace id costs precision, never containment.
-DEFAULT_FORBIDDEN_TOOLS: "frozenset[str]" = frozenset(_INFRA_AND_SHELL_TOOLS)
+# GH#13588: the boundary an unrecognised agent id falls back to.
+#
+# Deliberately the *approval* catalogue and not ``INFRA_AND_SHELL_TOOLS`` — which is
+# what every bounded profile declares. A profile's manifest is a considered
+# least-privilege decision for a known role; this is the opposite situation, an id
+# nobody has decided anything about. Falling back to the profile default would still
+# leave ``terminal``, ``write_file``, ``delete_file``, ``git_force_push``,
+# ``http_delete`` and ``code_interpreter`` reachable, which is not "closed" in any
+# sense worth the name. A misidentified agent is therefore *more* restricted than
+# any real one, which is the correct direction for a case that should not happen.
+DEFAULT_FORBIDDEN_TOOLS: "frozenset[str]" = frozenset(SENSITIVE_TOOLS)
 
 _agent_type_aliases: "Dict[str, str] | None" = None
 
@@ -528,6 +534,22 @@ def resolve_agent_id(agent_id: str) -> "str | None":
     if agent_id in get_default_capability_registry():
         return agent_id
     return agent_type_aliases().get(agent_id)
+
+
+def is_unbounded_agent_id(agent_id: "str | None") -> bool:
+    """True when *agent_id* names a profile that declares itself unbounded (GH#13588).
+
+    For callers that must *refuse* an executor rather than merely resolve one — a
+    manifest of ``frozenset()`` alone cannot tell "designated executor" apart from
+    "no agent identity", and those two want opposite handling.
+    """
+    if not agent_id:
+        return False
+    resolved = resolve_agent_id(agent_id)
+    if resolved is None:
+        return False
+    profile = get_default_capability_registry().get(resolved)
+    return bool(profile is not None and profile.unbounded)
 
 
 def resolve_forbidden_tools(agent_id: "str | None") -> "frozenset[str]":

--- a/autobot-backend/orchestration/types.py
+++ b/autobot-backend/orchestration/types.py
@@ -131,6 +131,10 @@ class AgentProfile:
     # not invoke. ``forbidden_work`` is hard-blocked before approval in the loop.
     allowed_work: List[str] = field(default_factory=list)
     forbidden_work: List[str] = field(default_factory=list)
+    # GH#13588: "this agent is deliberately unbounded" stated as a property, so it
+    # is distinguishable from a profile that merely forgot its ``forbidden_work``.
+    # Only designated executors set this; everything else inherits a boundary.
+    unbounded: bool = False
 
 
 @dataclass

--- a/autobot-backend/tests/agent_loop/test_forbidden_tools_wiring.py
+++ b/autobot-backend/tests/agent_loop/test_forbidden_tools_wiring.py
@@ -13,7 +13,7 @@ forbidden tools through a real dispatch path.
 Acceptance criteria:
   - ``agent_id`` populates ``config.forbidden_tools`` from the agent's profile.
   - The designated executor (``system_agent``, no ``forbidden_work``) stays unbounded.
-  - No / unknown ``agent_id`` is a no-op (backward compatible).
+  - No ``agent_id`` is a no-op; an *unknown* one falls closed (GH#13588).
   - An explicit ``config.forbidden_tools`` is never overwritten by the manifest.
   - A forbidden tool is blocked in ``_execute_tools`` before the approval gate.
 """
@@ -24,6 +24,7 @@ import pytest
 
 from agent_loop.loop import AgentLoop
 from agent_loop.types import AgentLoopConfig
+from orchestration.agent_registry import DEFAULT_FORBIDDEN_TOOLS
 
 
 def _make_loop(agent_id: str | None = None, config: AgentLoopConfig | None = None) -> AgentLoop:
@@ -54,9 +55,17 @@ class TestManifestWiring:
         loop = _make_loop(agent_id=None)
         assert loop.config.forbidden_tools == frozenset()
 
-    def test_unknown_agent_is_unbounded(self) -> None:
+    def test_unknown_agent_is_bounded_by_the_default(self) -> None:
+        """GH#13588: was ``test_unknown_agent_is_unbounded``, asserting the defect.
+
+        An id nothing recognises used to reach the loop with no boundary at all —
+        indistinguishable from ``system_agent`` above, which earns that by
+        declaration. The loop now inherits the fail-closed default instead.
+        """
         loop = _make_loop(agent_id="does_not_exist")
-        assert loop.config.forbidden_tools == frozenset()
+
+        assert loop.config.forbidden_tools == DEFAULT_FORBIDDEN_TOOLS
+        assert loop.config.forbidden_tools != frozenset()
 
     def test_explicit_config_forbidden_tools_not_overwritten(self) -> None:
         cfg = AgentLoopConfig(

--- a/autobot-backend/tests/orchestration/test_agent_capability_manifest.py
+++ b/autobot-backend/tests/orchestration/test_agent_capability_manifest.py
@@ -66,6 +66,12 @@ class TestAgentRegistryAccessors:
         assert "docker" in forbidden
 
     def test_unknown_agent_degrades_to_empty(self) -> None:
+        """The raw accessor reports "no profile" as an empty manifest.
+
+        Not a security property, and not what any enforcement seam sees: those go
+        through ``resolve_forbidden_tools``, which turns this same miss into the
+        default boundary plus a warning (GH#13588, ``test_agent_registry_fail_closed``).
+        """
         reg = AgentCapabilityRegistry(initialize_defaults=True)
         assert reg.forbidden_tools("does-not-exist") == frozenset()
         assert reg.work_boundary("does-not-exist") == ([], [])

--- a/autobot-backend/tests/orchestration/test_agent_registry_fail_closed.py
+++ b/autobot-backend/tests/orchestration/test_agent_registry_fail_closed.py
@@ -101,6 +101,7 @@ def test_a_resolved_id_logs_nothing(caplog):
         resolve_forbidden_tools("research_agent")
 
     assert not [r for r in caplog.records if "research_agent" in r.getMessage()]
+    assert "GH#13588" not in "\n".join(r.getMessage() for r in caplog.records)
 
 
 # ------------------------------------------------- "unbounded" is declared, not inferred
@@ -219,7 +220,7 @@ async def test_delegation_refuses_an_executor_agent_type():
 
 
 @pytest.mark.asyncio
-async def test_delegation_still_accepts_an_unregistered_agent_type():
+async def test_delegation_still_accepts_an_unregistered_agent_type(monkeypatch):
     """Unknown ids are already safe — they resolve to the default boundary.
 
     Refusing them too would turn a typo into a hard failure for no security gain, so
@@ -233,12 +234,8 @@ async def test_delegation_still_accepts_an_unregistered_agent_type():
         seen.update(task=task, agent_type=agent_type, depth=depth)
         return "ok"
 
-    original = delegation._ENGINES.get("claude_code")
-    delegation._ENGINES["claude_code"] = _fake_engine
-    try:
-        assert await delegation.run_delegated_subtask("t", agent_type="typo_agent") == "ok"
-    finally:
-        if original is not None:
-            delegation._ENGINES["claude_code"] = original
+    monkeypatch.setitem(delegation._ENGINES, "claude_code", _fake_engine)
+
+    assert await delegation.run_delegated_subtask("t", agent_type="typo_agent") == "ok"
 
     assert seen["agent_type"] == "typo_agent"

--- a/autobot-backend/tests/orchestration/test_agent_registry_fail_closed.py
+++ b/autobot-backend/tests/orchestration/test_agent_registry_fail_closed.py
@@ -23,6 +23,7 @@ from orchestration.agent_registry import (
     DEFAULT_FORBIDDEN_TOOLS,
     agent_type_aliases,
     get_default_agents,
+    is_unbounded_agent_id,
     resolve_agent_id,
     resolve_forbidden_tools,
 )
@@ -39,9 +40,26 @@ def test_an_unknown_agent_id_is_bounded_not_unleashed():
     assert forbidden == DEFAULT_FORBIDDEN_TOOLS
 
 
-def test_the_default_boundary_covers_the_tools_the_boundary_exists_for():
-    """Falling closed is only meaningful if it lands on the infra/shell set."""
-    assert set(INFRA_AND_SHELL_TOOLS) <= DEFAULT_FORBIDDEN_TOOLS
+def test_the_default_is_stricter_than_any_profile_not_merely_equal_to_them():
+    """The property that makes falling closed worth the name.
+
+    A misidentified agent must not land on the *typical* profile boundary: that set
+    is only infra/shell, so it would still leave ``terminal``, ``write_file``,
+    ``delete_file``, ``git_force_push`` and ``code_interpreter`` reachable. The
+    default has to dominate every real profile's manifest, strictly.
+    """
+    profile_manifests = [frozenset(p.forbidden_work) for p in get_default_agents() if p.forbidden_work]
+
+    assert profile_manifests, "no bounded profiles — this test would pass vacuously"
+    for manifest in profile_manifests:
+        assert manifest < DEFAULT_FORBIDDEN_TOOLS, "the default is no stricter than a profile"
+
+
+@pytest.mark.parametrize("tool", ["terminal", "write_file", "delete_file", "git_force_push", "code_interpreter"])
+def test_the_default_covers_what_the_profile_default_leaves_open(tool):
+    """Named explicitly: these are the tools an unknown id reached under INFRA_AND_SHELL."""
+    assert tool not in set(INFRA_AND_SHELL_TOOLS)
+    assert tool in DEFAULT_FORBIDDEN_TOOLS
 
 
 def test_no_agent_id_stays_unbounded():
@@ -51,7 +69,16 @@ def test_no_agent_id_stays_unbounded():
 
 
 def test_a_registered_bounded_agent_keeps_its_declared_manifest():
-    assert resolve_forbidden_tools("research_agent") == frozenset(INFRA_AND_SHELL_TOOLS)
+    """Reads the profile — it does not just hand back the fallback.
+
+    Only discriminating because the default is now strictly wider than any profile
+    manifest: delete the profile lookup and this fails, where against an equal
+    default it would have passed either way.
+    """
+    resolved = resolve_forbidden_tools("research_agent")
+
+    assert resolved == frozenset(INFRA_AND_SHELL_TOOLS)
+    assert resolved != DEFAULT_FORBIDDEN_TOOLS
 
 
 @pytest.mark.parametrize("executor", ["system_agent", "system_commands"])
@@ -74,7 +101,7 @@ def test_a_resolved_id_logs_nothing(caplog):
     with caplog.at_level("WARNING"):
         resolve_forbidden_tools("research_agent")
 
-    assert "GH#13588" not in "\n".join(r.getMessage() for r in caplog.records)
+    assert not [r for r in caplog.records if "research_agent" in r.getMessage()]
 
 
 # ------------------------------------------------- "unbounded" is declared, not inferred
@@ -129,14 +156,90 @@ def test_every_db_namespace_agent_id_is_bounded():
 
     ``api/agent_config.py`` seeds 29 agent ids; only a handful share a name with a
     capability profile. Before this fix the other ~22 resolved to no boundary at all.
+
+    Asserted per-id against the *expected source* of the manifest, not merely
+    "non-empty": an id with a profile must get that profile's manifest, and one
+    without must get the fallback. A blanket truthiness check would pass even if the
+    profile lookup were deleted, since both answers are non-empty.
     """
     from api.agent_config import DEFAULT_AGENT_CONFIGS
 
-    unbounded_ids = sorted(p.agent_id for p in get_default_agents() if p.unbounded)
-    unexpected = sorted(
-        agent_id
-        for agent_id in DEFAULT_AGENT_CONFIGS
-        if agent_id not in unbounded_ids and not resolve_forbidden_tools(agent_id)
-    )
+    mismatched = {}
+    for agent_id in DEFAULT_AGENT_CONFIGS:
+        resolved = resolve_agent_id(agent_id)
+        if resolved is not None and is_unbounded_agent_id(agent_id):
+            expected = frozenset()
+        elif resolved is not None:
+            expected = frozenset(next(p for p in get_default_agents() if p.agent_id == resolved).forbidden_work)
+        else:
+            expected = DEFAULT_FORBIDDEN_TOOLS
+        actual = resolve_forbidden_tools(agent_id)
+        if actual != expected:
+            mismatched[agent_id] = (sorted(expected), sorted(actual))
 
-    assert unexpected == [], f"DB-namespace agent ids with no tool boundary: {unexpected}"
+    assert mismatched == {}, f"DB-namespace ids resolving to the wrong manifest: {mismatched}"
+
+
+def test_the_db_namespace_check_is_not_vacuous():
+    """Both branches of the test above must actually occur, or it proves little."""
+    from api.agent_config import DEFAULT_AGENT_CONFIGS
+
+    with_profile = [a for a in DEFAULT_AGENT_CONFIGS if resolve_agent_id(a) is not None]
+    without_profile = [a for a in DEFAULT_AGENT_CONFIGS if resolve_agent_id(a) is None]
+
+    assert with_profile, "no DB id resolved to a profile"
+    assert without_profile, "every DB id resolved — the fallback branch is never exercised"
+
+
+# ------------------------------------------------- executors are not delegable
+
+
+def test_an_executor_is_recognised_as_unbounded():
+    assert is_unbounded_agent_id("system_agent") is True
+    assert is_unbounded_agent_id("system_commands") is True
+
+
+@pytest.mark.parametrize("agent_id", ["research_agent", "no_such_agent", None, ""])
+def test_everything_else_is_not_unbounded(agent_id):
+    """An id nobody recognises is bounded, not an executor — the two must not merge."""
+    assert is_unbounded_agent_id(agent_id) is False
+
+
+@pytest.mark.asyncio
+async def test_delegation_refuses_an_executor_agent_type():
+    """A bounded agent must not obtain an unbounded subagent by naming one.
+
+    ``agent_type`` arrives straight from the model's tool call and ``delegate`` is not
+    itself an infra/shell tool, so a parent with a manifest can still call it. Without
+    this refusal the subagent's boundary is whatever the parent asked for.
+    """
+    from chat_workflow.delegation import run_delegated_subtask
+
+    with pytest.raises(ValueError, match="unbounded"):
+        await run_delegated_subtask("do a thing", agent_type="system_agent")
+
+
+@pytest.mark.asyncio
+async def test_delegation_still_accepts_an_unregistered_agent_type():
+    """Unknown ids are already safe — they resolve to the default boundary.
+
+    Refusing them too would turn a typo into a hard failure for no security gain, so
+    the check is narrowly about executors.
+    """
+    from chat_workflow import delegation
+
+    seen = {}
+
+    async def _fake_engine(task, agent_type, depth):
+        seen.update(task=task, agent_type=agent_type, depth=depth)
+        return "ok"
+
+    original = delegation._ENGINES.get("claude_code")
+    delegation._ENGINES["claude_code"] = _fake_engine
+    try:
+        assert await delegation.run_delegated_subtask("t", agent_type="typo_agent") == "ok"
+    finally:
+        if original is not None:
+            delegation._ENGINES["claude_code"] = original
+
+    assert seen["agent_type"] == "typo_agent"

--- a/autobot-backend/tests/orchestration/test_agent_registry_fail_closed.py
+++ b/autobot-backend/tests/orchestration/test_agent_registry_fail_closed.py
@@ -1,0 +1,142 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""``resolve_forbidden_tools`` fails closed on an unrecognised agent id (GH#13588).
+
+The defect: an id the registry did not recognise resolved to an *empty* manifest,
+which the enforcement seams read as "nothing is forbidden". A typo, or an id from
+AutoBot's other agent-id namespace, therefore produced a silently unbounded agent —
+identical in effect to naming the designated executor.
+
+What makes it reachable is that the two producers of an agent id disagree about
+validation: ``session_role.set_role`` (server-side, trusted) *rejects* an id outside
+this registry, while a client-supplied ``context["agent_id"]`` and the ``delegate``
+tool's LLM-chosen ``agent_type`` are passed through unchecked. The validated path
+refused exactly the strings the unvalidated ones rewarded with no boundary.
+"""
+
+import pytest
+
+from autobot_shared.tool_catalogue import INFRA_AND_SHELL_TOOLS
+from orchestration.agent_registry import (
+    DEFAULT_FORBIDDEN_TOOLS,
+    agent_type_aliases,
+    get_default_agents,
+    resolve_agent_id,
+    resolve_forbidden_tools,
+)
+
+
+# ------------------------------------------------------------ the fail-open fix
+
+
+def test_an_unknown_agent_id_is_bounded_not_unleashed():
+    """The defect, directly: an unrecognised id must not mean "nothing forbidden"."""
+    forbidden = resolve_forbidden_tools("no_such_agent")
+
+    assert forbidden, "an unknown agent id resolved to no boundary at all"
+    assert forbidden == DEFAULT_FORBIDDEN_TOOLS
+
+
+def test_the_default_boundary_covers_the_tools_the_boundary_exists_for():
+    """Falling closed is only meaningful if it lands on the infra/shell set."""
+    assert set(INFRA_AND_SHELL_TOOLS) <= DEFAULT_FORBIDDEN_TOOLS
+
+
+def test_no_agent_id_stays_unbounded():
+    """The plain chat agent has no identity to bound — the documented exception."""
+    assert resolve_forbidden_tools(None) == frozenset()
+    assert resolve_forbidden_tools("") == frozenset()
+
+
+def test_a_registered_bounded_agent_keeps_its_declared_manifest():
+    assert resolve_forbidden_tools("research_agent") == frozenset(INFRA_AND_SHELL_TOOLS)
+
+
+@pytest.mark.parametrize("executor", ["system_agent", "system_commands"])
+def test_a_declared_executor_is_still_unbounded(executor):
+    """Failing closed must not bound the agents whose job is infra/shell."""
+    assert resolve_forbidden_tools(executor) == frozenset()
+
+
+def test_the_warning_names_the_id_that_missed(caplog):
+    """An unresolved id has to be observable, or the miss is only found in an audit."""
+    with caplog.at_level("WARNING"):
+        resolve_forbidden_tools("typo_agent")
+
+    logged = "\n".join(r.getMessage() for r in caplog.records)
+    assert "typo_agent" in logged
+    assert "GH#13588" in logged
+
+
+def test_a_resolved_id_logs_nothing(caplog):
+    with caplog.at_level("WARNING"):
+        resolve_forbidden_tools("research_agent")
+
+    assert "GH#13588" not in "\n".join(r.getMessage() for r in caplog.records)
+
+
+# ------------------------------------------------- "unbounded" is declared, not inferred
+
+
+def test_every_profile_is_bounded_or_says_it_is_not():
+    """A forgotten ``forbidden_work`` must not read as a deliberate executor grant.
+
+    This is the property that keeps the fix from decaying: add a profile, forget its
+    manifest, and this fails rather than shipping another silently unbounded agent.
+    """
+    undeclared = [p.agent_id for p in get_default_agents() if not p.forbidden_work and not p.unbounded]
+
+    assert undeclared == [], f"profiles with no boundary and no `unbounded=True`: {undeclared}"
+
+
+def test_only_the_designated_executors_declare_themselves_unbounded():
+    unbounded = sorted(p.agent_id for p in get_default_agents() if p.unbounded)
+
+    assert unbounded == ["system_agent", "system_commands"]
+
+
+# ------------------------------------------------------------ namespace reconciliation
+
+
+def test_agent_type_reconciles_the_two_naming_styles():
+    """The DB namespace's ``research`` is this registry's ``research_agent``."""
+    assert resolve_agent_id("research") == "research_agent"
+    assert resolve_agent_id("orchestrator") == "coordination_agent"
+
+
+def test_an_ambiguous_agent_type_resolves_to_nothing():
+    """``librarian`` names two profiles; guessing one of them would be a coin flip."""
+    assert "librarian" not in agent_type_aliases()
+    assert resolve_agent_id("librarian") is None
+
+
+def test_an_executor_is_not_reachable_through_its_agent_type():
+    """Aliasing must never hand out a boundary-free manifest.
+
+    ``system_agent``'s ``agent_type`` is ``system_commands`` and ``system_commands``'
+    is ``executor``. If aliases included unbounded profiles, the string ``executor`` —
+    which names no agent anyone configured — would resolve to a full infra/shell
+    grant, re-creating this issue's escalation with an extra step.
+    """
+    assert "executor" not in agent_type_aliases()
+    assert resolve_forbidden_tools("executor") == DEFAULT_FORBIDDEN_TOOLS
+
+
+def test_every_db_namespace_agent_id_is_bounded():
+    """AC: an id from the DB seed is bounded exactly as its profile counterpart is.
+
+    ``api/agent_config.py`` seeds 29 agent ids; only a handful share a name with a
+    capability profile. Before this fix the other ~22 resolved to no boundary at all.
+    """
+    from api.agent_config import DEFAULT_AGENT_CONFIGS
+
+    unbounded_ids = sorted(p.agent_id for p in get_default_agents() if p.unbounded)
+    unexpected = sorted(
+        agent_id
+        for agent_id in DEFAULT_AGENT_CONFIGS
+        if agent_id not in unbounded_ids and not resolve_forbidden_tools(agent_id)
+    )
+
+    assert unexpected == [], f"DB-namespace agent ids with no tool boundary: {unexpected}"

--- a/autobot-backend/tests/orchestration/test_agent_registry_fail_closed.py
+++ b/autobot-backend/tests/orchestration/test_agent_registry_fail_closed.py
@@ -28,7 +28,6 @@ from orchestration.agent_registry import (
     resolve_forbidden_tools,
 )
 
-
 # ------------------------------------------------------------ the fail-open fix
 
 

--- a/autobot-backend/tests/unit/chat_workflow/test_tool_handler_forbidden_work.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_tool_handler_forbidden_work.py
@@ -73,12 +73,28 @@ def test_enforce_noop_for_executor_agent() -> None:
 
 
 def test_enforce_noop_for_profileless_chat_agent() -> None:
-    """No agent_context (plain chat) → empty manifest → never blocked."""
+    """No agent_context (plain chat) → no identity to bound → never blocked."""
     mixin = _mixin()
     results: list[dict] = []
     assert mixin._enforce_forbidden_work({"name": "bash"}, None, results) is None
-    assert mixin._enforce_forbidden_work({"name": "bash"}, _ctx("unknown_agent"), results) is None
     assert results == []
+
+
+def test_enforce_blocks_an_unregistered_agent_id() -> None:
+    """GH#13588: an unknown id is bounded, not waved through.
+
+    This used to sit in the profile-less test above, asserting that ``unknown_agent``
+    reached ``bash`` — the two cases look alike (both resolved to an empty manifest)
+    but mean opposite things. "No agent identity" is the documented ungoverned path;
+    "an agent identity nothing recognises" is a typo or a wrong-namespace id, and
+    letting it run unbounded is the defect that issue reports.
+    """
+    mixin = _mixin()
+    results: list[dict] = []
+    msg = mixin._enforce_forbidden_work({"name": "bash"}, _ctx("unknown_agent"), results)
+
+    assert msg is not None
+    assert results, "the block was not recorded in the execution results"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**Closes #13588.**

## Thinking Path

`resolve_forbidden_tools()` returned an empty set for an id it did not recognise, and both
enforcement seams read an empty manifest as *nothing is forbidden*. So a typo, or an id from
AutoBot's other agent-id namespace, produced an agent with no boundary — identical in effect to
naming the designated executor, with no error and no log line.

What makes it reachable is an asymmetry the issue did not name. There are three producers of an
agent id, and only one validates:

| Producer | Validates? |
|---|---|
| `session_role.set_role` — server-side, trusted | **yes** — raises `ValueError` outside this registry |
| client-supplied `context["agent_id"]` → `build_governed_identity` | no |
| the `delegate` tool's `agent_type` (LLM-chosen) | no |

**The validated path refuses exactly the strings the unvalidated ones rewarded with free rein.**
That asymmetry is also why this lands in one PR rather than the warn-then-flip staging the issue
proposed: failing closed cannot strand a correctly configured session, because every id
`set_role` can pin is by construction an id this registry resolves. Only the unvalidated producers
reach the new branch, and there restricting is the safe direction — `forbidden_work` is deny-only,
so it can never lift a restriction, only add one.

Worth flagging on the `delegate` path: `agent_type` is read at `tool_handler.py:2166` but is **not
in the tool's documented parameter list** (`task`, `reason`, `wait_for_result`). It is an
undocumented, unvalidated parameter whose value is whatever the model emits — and the DB-namespace
ids it might plausibly emit are surfaced through the agents API. Delegation is off by default
(`AUTOBOT_DELEGATION_ENABLED`), which is the main reason this was latent rather than live.

### Reconciling the namespaces without a map to maintain

The obvious fix is a hand-written alias table, but every entry is a security binding, and a wrong
guess is a wrong boundary. The profiles already carry the answer: the DB's `research` is this
registry's `research_agent`, whose `agent_type` is literally `research`; `orchestrator` is
`coordination_agent`'s `agent_type`. So resolution falls back to `agent_type`, derived from the
profiles — nothing to drift.

Two exclusions stop that from becoming an escalation seam of its own:

- an `agent_type` naming more than one profile is dropped (`librarian` is both
  `documentation_agent` and `kb_librarian` — guessing would be a coin flip);
- **`unbounded` profiles never get an alias.** Otherwise the string `executor`, which names no agent
  anyone configured, would resolve to `system_commands` and hand out a full infra/shell grant —
  re-creating this very issue with one extra step. An executor is reachable only by its exact id.

### A correction to the issue

It states only `system_commands` appears in both namespaces. That was true when written; #11251 gave
the routing ids first-class profiles, so **seven** now overlap. The remaining ~22 DB ids had no
profile, and it is those that were running unbounded.

## What Changed

- `orchestration/types.py` — `AgentProfile.unbounded: bool`. "Deliberately unbounded" is now a
  stated property, so it is distinguishable from a profile that simply forgot its manifest.
- `orchestration/agent_registry.py` — `system_agent` / `system_commands` declare `unbounded=True`;
  `DEFAULT_FORBIDDEN_TOOLS`; `agent_type_aliases()`; `resolve_agent_id()`; `resolve_forbidden_tools()`
  falls closed on an unresolved id and WARNs naming it.
- `chat_workflow/tool_handler.py` — docstring corrected: an empty manifest now means *no agent
  identity* or *a declared executor*, never *an id nobody recognises*.

Both enforcement seams (`tool_handler._enforce_forbidden_work`, `agent_loop/loop.py`) already route
through `resolve_forbidden_tools`, so they inherit the fix with no edit.

## Verification

```
tests/orchestration/test_agent_registry_fail_closed.py           14 passed
+ tests/orchestration/ tests/unit/chat_workflow/ agent_loop/    755 passed
```

**Mutation-tested — each mutation is a way this could quietly stop working:**

| Mutation | Killed by |
|---|---|
| unknown id → empty manifest again (the original bug) | 4 tests, incl. the tool-seam one |
| let `unbounded` profiles into the alias map | `test_an_executor_is_not_reachable_through_its_agent_type` |
| drop `unbounded=True` from `system_agent` | `test_every_profile_is_bounded_or_says_it_is_not` |

That third one is the anti-decay guard: add a profile, forget its `forbidden_work`, and the suite
fails rather than shipping another silently unbounded agent.

### One existing test asserted the defect

`test_enforce_noop_for_profileless_chat_agent` asserted that `_ctx("unknown_agent")` reached `bash`,
bundled with the genuine profile-less case. The two look alike — both resolved to an empty manifest —
but mean opposite things. Split into two tests, and the unknown-id half now asserts the block.

## Acceptance criteria

- [x] Unknown id produces a denial, never an empty manifest
- [x] "Deliberately unbounded" is a declared property, not a lookup miss
- [x] Every unresolved id emits a WARNING naming it
- [x] Namespaces reconciled — via `agent_type`, derived from the profiles, with a test asserting
      every DB-seed id is bounded. Implemented as the safety property rather than the bidirectional
      name equality the AC's wording suggests: the registry holds ids the DB has no row for
      (`documentation_agent`), and forcing symmetry would mean inventing rows to satisfy a test.
- [x] A DB-namespace id is bounded exactly as its profile counterpart is — every bounded profile
      declares the same `INFRA_AND_SHELL_TOOLS` manifest, which is what the fallback lands on

## Model Used

Claude Opus 5 (1M context)
