### PR TITLE
fix(code-intelligence): give clone fingerprints the canonical node identity (#13470)

### DIFF
--- a/autobot-backend/code_intelligence/fingerprinting/detector.py
+++ b/autobot-backend/code_intelligence/fingerprinting/detector.py
@@ -252,7 +252,7 @@ class CloneDetector:
         return sorted(python_files)
 
     def _create_fragment_from_node(
-        self, node: ast.AST, file_path: str, lines: List[str], fragment_type: str
+        self, node: ast.AST, file_path: str, lines: List[str], fragment_type: str, parent_class: str | None = None
     ) -> CodeFragment | None:
         """
         Create a CodeFragment from an AST node.
@@ -282,6 +282,7 @@ class CloneDetector:
             ast_node=node,
             fragment_type=fragment_type,
             entity_name=node.name,
+            parent_class=parent_class,
         )
 
     def _extract_fragments(self, file_path: str) -> List[CodeFragment]:
@@ -328,13 +329,36 @@ class CloneDetector:
             tree = ast.parse(source, filename=file_path)
 
         fragments: List[CodeFragment] = []
-        for node in ast.walk(tree):
-            fragment = self._maybe_create_fragment(node, file_path, lines)
-            if fragment:
-                fragments.append(fragment)
+        self._walk_definitions(tree, file_path, lines, fragments, parent_class=None)
         return fragments
 
-    def _maybe_create_fragment(self, node: ast.AST, file_path: str, lines: List[str]) -> CodeFragment | None:
+    def _walk_definitions(
+        self,
+        node: ast.AST,
+        file_path: str,
+        lines: List[str],
+        fragments: List[CodeFragment],
+        parent_class: str | None,
+    ) -> None:
+        """Walk *node*, recording fragments and the class each one sits in (#13470).
+
+        Replaces a flat ``ast.walk``. That walk yielded every definition with no
+        record of its enclosing class, so a method's ``entity_name`` was a bare
+        name — indistinguishable from a module-level function of the same name,
+        and unable to produce the canonical node id, which is class-qualified.
+        Without the class the fingerprinter's findings cannot be joined to the
+        code graph's, which is the whole point of a shared identity.
+        """
+        for child in ast.iter_child_nodes(node):
+            fragment = self._maybe_create_fragment(child, file_path, lines, parent_class)
+            if fragment:
+                fragments.append(fragment)
+            inner_class = child.name if isinstance(child, ast.ClassDef) else parent_class
+            self._walk_definitions(child, file_path, lines, fragments, inner_class)
+
+    def _maybe_create_fragment(
+        self, node: ast.AST, file_path: str, lines: List[str], parent_class: str | None = None
+    ) -> CodeFragment | None:
         """
         Create a fragment from node if it's a function or class.
 
@@ -347,7 +371,7 @@ class CloneDetector:
             CodeFragment if node is function/class and meets threshold, None otherwise
         """
         if isinstance(node, _FUNCTION_DEF_TYPES):  # Issue #380
-            return self._create_fragment_from_node(node, file_path, lines, "function")
+            return self._create_fragment_from_node(node, file_path, lines, "function", parent_class)
         if isinstance(node, ast.ClassDef):
             return self._create_fragment_from_node(node, file_path, lines, "class")
         return None

--- a/autobot-backend/code_intelligence/fingerprinting/detector.py
+++ b/autobot-backend/code_intelligence/fingerprinting/detector.py
@@ -334,13 +334,13 @@ class CloneDetector:
 
     def _walk_definitions(
         self,
-        node: ast.AST,
+        root: ast.AST,
         file_path: str,
         lines: List[str],
         fragments: List[CodeFragment],
         parent_class: str | None,
     ) -> None:
-        """Walk *node*, recording fragments and the class each one sits in (#13470).
+        """Walk *root*, recording fragments and the class each one sits in (#13470).
 
         Replaces a flat ``ast.walk``. That walk yielded every definition with no
         record of its enclosing class, so a method's ``entity_name`` was a bare
@@ -348,13 +348,21 @@ class CloneDetector:
         and unable to produce the canonical node id, which is class-qualified.
         Without the class the fingerprinter's findings cannot be joined to the
         code graph's, which is the whole point of a shared identity.
+
+        Iterative rather than recursive on purpose: ``ast.walk`` never recursed,
+        so recursing here would newly turn a deeply nested expression into a
+        ``RecursionError`` — which ``_extract_fragments`` catches, silently
+        reporting the file as having no fragments at all.
         """
-        for child in ast.iter_child_nodes(node):
-            fragment = self._maybe_create_fragment(child, file_path, lines, parent_class)
-            if fragment:
-                fragments.append(fragment)
-            inner_class = child.name if isinstance(child, ast.ClassDef) else parent_class
-            self._walk_definitions(child, file_path, lines, fragments, inner_class)
+        stack: list[tuple[ast.AST, str | None]] = [(root, parent_class)]
+        while stack:
+            node, enclosing = stack.pop()
+            for child in ast.iter_child_nodes(node):
+                fragment = self._maybe_create_fragment(child, file_path, lines, enclosing)
+                if fragment:
+                    fragments.append(fragment)
+                inner = child.name if isinstance(child, ast.ClassDef) else enclosing
+                stack.append((child, inner))
 
     def _maybe_create_fragment(
         self, node: ast.AST, file_path: str, lines: List[str], parent_class: str | None = None
@@ -373,7 +381,7 @@ class CloneDetector:
         if isinstance(node, _FUNCTION_DEF_TYPES):  # Issue #380
             return self._create_fragment_from_node(node, file_path, lines, "function", parent_class)
         if isinstance(node, ast.ClassDef):
-            return self._create_fragment_from_node(node, file_path, lines, "class")
+            return self._create_fragment_from_node(node, file_path, lines, "class", parent_class)
         return None
 
     def _generate_fingerprints(self, fragment: CodeFragment) -> None:

--- a/autobot-backend/code_intelligence/fingerprinting/shared_identity_test.py
+++ b/autobot-backend/code_intelligence/fingerprinting/shared_identity_test.py
@@ -22,9 +22,8 @@ import ast
 import pytest
 
 from autobot_shared.code_graph import compute_node_id, module_path_from_rel_path
-from code_intelligence.fingerprinting.detector import CloneDetector
 from autobot_shared.code_graph.identity import _PROJECT_ROOT as PROJECT_ROOT
-from code_intelligence.fingerprinting.detector import CloneDetector as _CD  # noqa: F401
+from code_intelligence.fingerprinting.detector import CloneDetector  # noqa: F401
 from code_intelligence.fingerprinting.types import CodeFragment
 
 SOURCE = """

--- a/autobot-backend/code_intelligence/fingerprinting/shared_identity_test.py
+++ b/autobot-backend/code_intelligence/fingerprinting/shared_identity_test.py
@@ -1,0 +1,160 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""One node identity across every subsystem that parses source (#13470).
+
+The issue's verification criterion is a *join*: an id produced by one extractor
+has to equal the id another produces for the same function, or no finding from
+either can be related to the other. Four subsystems parse the same files;
+`code_indexer` and `call_graph` were converged onto `autobot_shared.code_graph`
+already, and the clone fingerprinter was not.
+
+The blocker was not the id function — it was that the fingerprinter discarded
+class scope. Its extraction used a flat ``ast.walk``, so a method arrived with a
+bare ``entity_name``, indistinguishable from a module-level function of the same
+name and unable to produce the class-qualified canonical id. An id computed from
+that is not merely different from the graph's; it is *wrong*, and quietly so.
+"""
+
+import ast
+
+import pytest
+
+from autobot_shared.code_graph import compute_node_id, module_path_from_rel_path
+from code_intelligence.fingerprinting.detector import CloneDetector
+from code_intelligence.fingerprinting.types import CodeFragment
+
+SOURCE = """
+def module_level(a):
+    return a + 1
+
+
+class Service:
+    def handle(self, request):
+        return module_level(request)
+
+    class Inner:
+        def nested(self):
+            return 1
+"""
+
+REL_PATH = "services/example/service.py"
+
+
+def _fragments(tmp_path, source: str = SOURCE, rel_path: str = REL_PATH):
+    """Extract fragments the way the detector does, keyed by ``(parent_class, name)``.
+
+    Keyed on the pair deliberately: keying on the bare name loses exactly the case
+    under test, since a method and a module-level function can share one.
+    """
+    path = tmp_path / "service.py"
+    path.write_text(source, encoding="utf-8")
+    detector = CloneDetector(min_fragment_lines=1)
+    found = detector._extract_fragments_from_file(str(path))
+    # The detector records whatever path it was handed; the id namespace is
+    # project-relative, so re-point the fragments at the repo-relative path.
+    for fragment in found:
+        fragment.file_path = rel_path
+    return {(f.parent_class, f.entity_name): f for f in found}
+
+
+# ------------------------------------------------------------- the join itself
+
+
+def test_a_method_id_matches_what_the_code_graph_computes(tmp_path):
+    """The verification criterion of #13470, on the case that used to break.
+
+    ``code_indexer`` builds a method's id from (name, module path, parent class).
+    If the fingerprinter cannot supply the parent class, its id silently belongs
+    to a different function.
+    """
+    handle = _fragments(tmp_path)[("Service", "handle")]
+    graph_id = compute_node_id("handle", module_path_from_rel_path(REL_PATH), "Service")
+
+    assert handle.node_id == graph_id
+
+
+def test_a_module_level_function_id_matches_too(tmp_path):
+    fragment = _fragments(tmp_path)[(None, "module_level")]
+    graph_id = compute_node_id("module_level", module_path_from_rel_path(REL_PATH), None)
+
+    assert fragment.node_id == graph_id
+
+
+def test_a_method_and_a_same_named_function_do_not_collide(tmp_path):
+    """The ambiguity a bare name creates, stated as a property.
+
+    Without the class, ``Service.handle`` and a module-level ``handle`` produce
+    the same id — so a clone reported against one would be joined to the other.
+    """
+    source = SOURCE + "\n\ndef handle(request):\n    return request\n"
+    fragments = _fragments(tmp_path, source=source)
+
+    method = fragments[("Service", "handle")]
+    free_function = fragments[(None, "handle")]
+
+    assert method.node_id != free_function.node_id
+    assert method.node_id.endswith(".Service.handle")
+
+
+# ------------------------------------------------------ class scope is recorded
+
+
+def test_the_enclosing_class_is_recorded(tmp_path):
+    fragments = _fragments(tmp_path)
+
+    assert fragments[("Service", "handle")].parent_class == "Service"
+    assert fragments[(None, "module_level")].parent_class is None
+
+
+def test_a_nested_class_binds_its_own_methods(tmp_path):
+    """Scope is tracked through nesting, not just one level deep."""
+    fragments = _fragments(tmp_path)
+
+    assert fragments[("Inner", "nested")].parent_class == "Inner"
+
+
+def test_every_definition_is_still_found(tmp_path):
+    """The scope-aware walk must not lose fragments the flat walk found.
+
+    ``ast.walk`` visited every node; recursing over children has to reach the
+    same set, or this becomes a coverage regression dressed as a fix.
+    """
+    flat = {
+        node.name
+        for node in ast.walk(ast.parse(SOURCE))
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef))
+    }
+
+    assert {name for _, name in _fragments(tmp_path)} == flat
+
+
+# ---------------------------------------------------------- edges of identity
+
+
+def test_a_fragment_with_no_entity_name_has_no_id():
+    """A fragment that names nothing cannot be identified, and does not pretend to."""
+    anonymous = CodeFragment(file_path=REL_PATH, start_line=1, end_line=2, source_code="x = 1")
+
+    assert anonymous.node_id == ""
+
+
+def test_the_id_reaches_the_serialised_finding(tmp_path):
+    """A finding nobody can join is the state this issue exists to end."""
+    from code_intelligence.fingerprinting.types import Fingerprint, FingerprintType
+
+    fragment = _fragments(tmp_path)[("Service", "handle")]
+    payload = Fingerprint(
+        hash_value="abc", fingerprint_type=FingerprintType.AST_STRUCTURAL, fragment=fragment
+    ).to_dict()
+
+    assert payload["node_id"] == fragment.node_id
+    assert payload["node_id"], "the serialised finding carries no id at all"
+
+
+@pytest.mark.parametrize("rel_path", ["services/a/b.py", "autobot-backend/api/x.py"])
+def test_the_id_namespace_follows_the_project_relative_path(tmp_path, rel_path):
+    fragment = _fragments(tmp_path, rel_path=rel_path)[(None, "module_level")]
+
+    assert fragment.node_id == compute_node_id("module_level", module_path_from_rel_path(rel_path), None)

--- a/autobot-backend/code_intelligence/fingerprinting/shared_identity_test.py
+++ b/autobot-backend/code_intelligence/fingerprinting/shared_identity_test.py
@@ -23,15 +23,47 @@ import pytest
 
 from autobot_shared.code_graph import compute_node_id, module_path_from_rel_path
 from code_intelligence.fingerprinting.detector import CloneDetector
+from autobot_shared.code_graph.identity import _PROJECT_ROOT as PROJECT_ROOT
+from code_intelligence.fingerprinting.detector import CloneDetector as _CD  # noqa: F401
 from code_intelligence.fingerprinting.types import CodeFragment
 
 SOURCE = """
 def module_level(a):
-    return a + 1
+    def helper(b):
+        return b
+    if a:
+        def conditional(c):
+            return c
+    try:
+        def guarded(d):
+            return d
+    except ValueError:
+        def recovered(e):
+            return e
+    for _ in range(1):
+        def looped(f):
+            return f
+    with open("x") as fh:
+        def managed(g):
+            return g
+    return helper
+
+
+async def module_level_async(a):
+    async def inner_async(b):
+        return b
+    return inner_async
 
 
 class Service:
     def handle(self, request):
+        def local_helper(x):
+            return x
+
+        class LocalClass:
+            def local_method(self):
+                return 1
+
         return module_level(request)
 
     class Inner:
@@ -52,10 +84,25 @@ def _fragments(tmp_path, source: str = SOURCE, rel_path: str = REL_PATH):
     path.write_text(source, encoding="utf-8")
     detector = CloneDetector(min_fragment_lines=1)
     found = detector._extract_fragments_from_file(str(path))
-    # The detector records whatever path it was handed; the id namespace is
-    # project-relative, so re-point the fragments at the repo-relative path.
     for fragment in found:
         fragment.file_path = rel_path
+    return {(f.parent_class, f.entity_name): f for f in found}
+
+
+def _fragments_from_repo_file(source: str):
+    """Extract from a file inside the project root, path untouched.
+
+    The point is that nothing rewrites ``file_path`` afterwards. The previous
+    version of this helper did exactly that, which is how it hid the fact that
+    production ids carried the deploy root as a prefix and joined with nothing.
+    """
+    target = PROJECT_ROOT / "autobot-backend" / "code_intelligence" / "_identity_probe_13470.py"
+    target.write_text(source, encoding="utf-8")
+    try:
+        detector = CloneDetector(min_fragment_lines=1)
+        found = detector._extract_fragments_from_file(str(target))
+    finally:
+        target.unlink(missing_ok=True)
     return {(f.parent_class, f.entity_name): f for f in found}
 
 
@@ -158,3 +205,117 @@ def test_the_id_namespace_follows_the_project_relative_path(tmp_path, rel_path):
     fragment = _fragments(tmp_path, rel_path=rel_path)[(None, "module_level")]
 
     assert fragment.node_id == compute_node_id("module_level", module_path_from_rel_path(rel_path), None)
+
+
+# ------------------------------ the join, against the other extractor's output
+
+
+JOIN_SOURCE = """
+def module_level(a):
+    return a + 1
+
+
+class Service:
+    def handle(self, request):
+        return module_level(request)
+
+    class Inner:
+        def nested(self):
+            return 1
+"""
+
+
+def _graph_ids(source: str, rel_path: str) -> set:
+    """Node ids ``code_indexer`` produces for *source* — the other side of the join."""
+    from services.knowledge.code_indexer import extract_python
+
+    extracted = extract_python(rel_path, source.encode("utf-8"))
+    return {node["id"] for node in extracted["nodes"]}
+
+
+@pytest.mark.skipif(
+    __import__("importlib").util.find_spec("tree_sitter_python") is None,
+    reason="tree-sitter-python not installed",
+)
+def test_the_two_extractors_agree_on_every_id(tmp_path):
+    """The issue's actual verification criterion, asserted against real output.
+
+    The earlier version of this file compared the fingerprinter's id to a second
+    application of the same formula — which cannot disagree, and which is why a
+    nested *class* silently produced an id the graph did not have. Intersecting
+    two real id sets found it immediately.
+    """
+    rel_path = "services/example/service.py"
+    fingerprint_ids = {f.node_id for f in _fragments(tmp_path, source=JOIN_SOURCE, rel_path=rel_path).values()}
+    graph_ids = _graph_ids(JOIN_SOURCE, rel_path)
+
+    assert fingerprint_ids, "the fingerprinter produced no ids at all"
+    assert graph_ids, "the graph extractor produced no ids at all"
+    assert fingerprint_ids == graph_ids, (
+        f"only in fingerprinter: {sorted(fingerprint_ids - graph_ids)}\n"
+        f"only in graph:         {sorted(graph_ids - fingerprint_ids)}"
+    )
+
+
+def test_a_nested_class_is_qualified_by_its_enclosing_class(tmp_path):
+    """The class branch dropped ``parent_class`` while the function branch kept it.
+
+    So ``Service.Inner`` was recorded as ``Inner`` — the exact defect this issue
+    describes, on the class kind rather than the function kind.
+    """
+    fragment = _fragments(tmp_path, source=JOIN_SOURCE)[("Service", "Inner")]
+
+    assert fragment.node_id.endswith(".Service.Inner")
+
+
+# ------------------------- production paths are absolute, and must still join
+
+
+def test_an_absolute_path_from_the_project_root_produces_a_joinable_id():
+    """The blocker: production hands the detector absolute paths.
+
+    ``rglob`` from ``PATH.PROJECT_ROOT`` yields absolute paths, so every id this
+    module shipped was prefixed with the deploy root
+    (``.opt.autobot.autobot-backend…``) while the graph relativises first. They
+    never joined, and nothing reported it.
+    """
+    fragments = _fragments_from_repo_file(JOIN_SOURCE)
+    handle = fragments[("Service", "handle")]
+
+    assert not handle.node_id.startswith("."), f"id carries an absolute prefix: {handle.node_id}"
+    assert handle.node_id.startswith("autobot-backend.code_intelligence.")
+
+
+def test_a_path_outside_the_project_is_left_alone_rather_than_guessed_at():
+    """Declining to give an identity beats inventing one."""
+    outside = CodeFragment(file_path="/etc/somewhere/mod.py", start_line=1, end_line=2, source_code="", entity_name="f")
+
+    assert outside.node_id == ".etc.somewhere.mod.f", "a path outside the project must be left as it was"
+
+
+# ------------------ the walk must not lose definitions, on shapes that have them
+
+
+def test_definitions_nested_inside_functions_are_still_found(tmp_path):
+    """The guard that used to be vacuous.
+
+    Its predecessor asserted the scope-aware walk found everything ``ast.walk``
+    found — using a fixture with no definition inside a function body, no
+    ``if``/``try``/``for``/``with``, and nothing ``async``. It stayed green when
+    the walk stopped descending into function bodies entirely.
+    """
+    names = {name for _, name in _fragments(tmp_path)}
+
+    for nested in ("helper", "conditional", "guarded", "recovered", "looped", "managed", "inner_async"):
+        assert nested in names, f"{nested} was lost by the walk"
+
+
+def test_a_deeply_chained_expression_does_not_lose_the_whole_file(tmp_path):
+    """``ast.walk`` never recursed, so the replacement must not either.
+
+    A ``RecursionError`` here is caught by ``_extract_fragments`` and degrades to
+    "this file has no fragments" — a silent, total coverage loss for that file.
+    """
+    chained = "def f():\n    return " + " + ".join(["1"] * 1500) + "\n"
+
+    assert "f" in {name for _, name in _fragments(tmp_path, source=chained)}

--- a/autobot-backend/code_intelligence/fingerprinting/shared_identity_test.py
+++ b/autobot-backend/code_intelligence/fingerprinting/shared_identity_test.py
@@ -18,13 +18,18 @@ that is not merely different from the graph's; it is *wrong*, and quietly so.
 """
 
 import ast
+from pathlib import Path
 
 import pytest
 
 from autobot_shared.code_graph import compute_node_id, module_path_from_rel_path
-from autobot_shared.code_graph.identity import _PROJECT_ROOT as PROJECT_ROOT
-from code_intelligence.fingerprinting.detector import CloneDetector  # noqa: F401
+from code_intelligence.fingerprinting.detector import CloneDetector
 from code_intelligence.fingerprinting.types import CodeFragment
+
+# This file is <root>/autobot-backend/code_intelligence/fingerprinting/, so the
+# project root is three levels up. Derived here rather than imported from the
+# module under test, so the test does not inherit the value it is checking.
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
 
 SOURCE = """
 def module_level(a):

--- a/autobot-backend/code_intelligence/fingerprinting/types.py
+++ b/autobot-backend/code_intelligence/fingerprinting/types.py
@@ -14,6 +14,8 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Dict, List, Tuple
 
+from autobot_shared.code_graph import compute_node_id, module_path_from_rel_path
+
 # =============================================================================
 # Enums and Constants
 # =============================================================================
@@ -63,6 +65,10 @@ class CodeFragment:
     ast_node: ast.AST | None = None
     fragment_type: str = "unknown"  # function, class, block, etc.
     entity_name: str = ""
+    # #13470: the class this fragment sits in, or None at module level. Recorded
+    # so ``node_id`` can be class-qualified — a bare method name is ambiguous and
+    # cannot be joined to anything.
+    parent_class: str | None = None
 
     def __hash__(self) -> int:
         """
@@ -96,6 +102,27 @@ class CodeFragment:
         """Get the number of lines in this fragment."""
         return self.end_line - self.start_line + 1
 
+    @property
+    def node_id(self) -> str:
+        """Canonical code-graph id for this fragment (#13470).
+
+        The same function computes the same id here, in ``code_indexer`` and in
+        ``call_graph``, so a clone finding can be joined to the node the graph
+        holds for it. Empty when this fragment has no entity name — a fragment
+        that names nothing cannot be identified.
+
+        ``file_path`` must be project-relative for the id to match the graph's;
+        an absolute path yields an id in a different namespace, which is a
+        mismatch that would otherwise be silent.
+        """
+        if not self.entity_name:
+            return ""
+        return compute_node_id(
+            self.entity_name,
+            module_path_from_rel_path(self.file_path),
+            self.parent_class,
+        )
+
 
 @dataclass
 class Fingerprint:
@@ -116,6 +143,9 @@ class Fingerprint:
             "start_line": self.fragment.start_line,
             "end_line": self.fragment.end_line,
             "entity_name": self.fragment.entity_name,
+            # #13470: canonical code-graph id, so a finding can be joined to the
+            # node the graph holds for the same function.
+            "node_id": self.fragment.node_id,
             "line_count": self.fragment.line_count,
             "structural_features": self.structural_features,
         }
@@ -136,6 +166,9 @@ class CloneInstance:
             "start_line": self.fragment.start_line,
             "end_line": self.fragment.end_line,
             "entity_name": self.fragment.entity_name,
+            # #13470: canonical code-graph id, so a finding can be joined to the
+            # node the graph holds for the same function.
+            "node_id": self.fragment.node_id,
             "line_count": self.fragment.line_count,
             "similarity_score": self.similarity_score,
             "source_preview": self._get_source_preview(),

--- a/autobot-backend/code_intelligence/fingerprinting/types.py
+++ b/autobot-backend/code_intelligence/fingerprinting/types.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Dict, List, Tuple
 
-from autobot_shared.code_graph import compute_node_id, module_path_from_rel_path
+from autobot_shared.code_graph import compute_node_id, module_path_from_rel_path, project_relative_path
 
 # =============================================================================
 # Enums and Constants
@@ -111,15 +111,19 @@ class CodeFragment:
         holds for it. Empty when this fragment has no entity name — a fragment
         that names nothing cannot be identified.
 
-        ``file_path`` must be project-relative for the id to match the graph's;
-        an absolute path yields an id in a different namespace, which is a
-        mismatch that would otherwise be silent.
+        The path is made project-relative first. The detector walks with
+        ``rglob`` from whatever root it was given, which in production is
+        ``PATH.PROJECT_ROOT`` — an absolute path. Feeding that to the identity
+        scheme produced ids prefixed with the deploy root
+        (``.opt.autobot.autobot-backend.services…``) while the graph, which
+        relativises before extracting, produced ``autobot-backend.services…``.
+        The two never joined, and nothing said so.
         """
         if not self.entity_name:
             return ""
         return compute_node_id(
             self.entity_name,
-            module_path_from_rel_path(self.file_path),
+            module_path_from_rel_path(project_relative_path(self.file_path)),
             self.parent_class,
         )
 

--- a/autobot_shared/code_graph/__init__.py
+++ b/autobot_shared/code_graph/__init__.py
@@ -9,7 +9,11 @@ Single-sourced so ``services/knowledge/code_indexer.py`` (#13469) and
 name nodes the same way instead of maintaining incompatible schemes.
 """
 
-from autobot_shared.code_graph.identity import compute_node_id, module_path_from_rel_path
+from autobot_shared.code_graph.identity import (
+    compute_node_id,
+    module_path_from_rel_path,
+    project_relative_path,
+)
 from autobot_shared.code_graph.resolver import (
     COMMON_THIRD_PARTY,
     INTERNAL_MODULE_PREFIXES,
@@ -25,6 +29,7 @@ from autobot_shared.code_graph.resolver import (
 __all__ = [
     "compute_node_id",
     "module_path_from_rel_path",
+    "project_relative_path",
     "COMMON_THIRD_PARTY",
     "INTERNAL_MODULE_PREFIXES",
     "STDLIB_MODULES",

--- a/autobot_shared/code_graph/identity.py
+++ b/autobot_shared/code_graph/identity.py
@@ -19,7 +19,7 @@ computed dotted module path) should go through :func:`module_path_from_rel_path`
 first.
 """
 
-from pathlib import PurePosixPath
+from pathlib import Path, PurePosixPath
 
 
 def module_path_from_rel_path(rel_path: str) -> str:
@@ -33,6 +33,10 @@ def module_path_from_rel_path(rel_path: str) -> str:
     """
     posix_path = PurePosixPath(rel_path.replace("\\", "/"))
     return posix_path.with_suffix("").as_posix().replace("/", ".")
+
+
+# Repo root: this file is autobot_shared/code_graph/identity.py.
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
 
 def compute_node_id(name: str, module_path: str, parent_class: str | None = None) -> str:
@@ -50,3 +54,25 @@ def compute_node_id(name: str, module_path: str, parent_class: str | None = None
     if parent_class:
         return f"{module_path}.{parent_class}.{name}"
     return f"{module_path}.{name}"
+
+
+def project_relative_path(path: str) -> str:
+    """Return *path* relative to the project root, for node-identity purposes (#13470).
+
+    Node ids are computed from a module path, and a module path is only stable if
+    every producer agrees where the tree starts. ``code_indexer`` relativises
+    against the root it was handed before extracting; the clone fingerprinter
+    walks absolute paths from ``rglob``. Same function, two namespaces, joining
+    with nothing — so the normalisation belongs here, beside the identity
+    scheme it exists to serve, rather than in one caller.
+
+    A path already relative, or outside the project root, is returned unchanged:
+    guessing at a root would invent an identity rather than decline to give one.
+    """
+    candidate = Path(path)
+    if not candidate.is_absolute():
+        return path
+    try:
+        return str(candidate.resolve().relative_to(_PROJECT_ROOT))
+    except ValueError:
+        return path


### PR DESCRIPTION
**Part of #13470** — the last extractor that could not be joined. Not `Closes`: see below.

## Thinking Path

The issue's four-extractor table is now two-thirds resolved without anyone recording it.
`code_indexer` and `call_graph` both import `autobot_shared.code_graph` today, so the two schemes
the issue names as incompatible (`<stem>::<safe_name>` vs `<module_path>.<Class>.<name>`) are already
one. What remained is item 4 of the proposed fix — *"have them consume the shared identity so their
findings can be joined"* — for the clone fingerprinter.

**The blocker was not the id function.** `CodeFragment` already carried `file_path`, `entity_name`
and `fragment_type`, so it looked like a two-line change. It wasn't, because fragment extraction used
a flat `ast.walk`:

```python
for node in ast.walk(tree):
    fragment = self._maybe_create_fragment(node, file_path, lines)
```

`ast.walk` yields every definition with no record of what encloses it, so a method arrived with a
bare `entity_name`. Computing an id from that does not produce an id that merely *differs* from the
graph's — it produces the id of a **different function**: the module-level one of the same name.
Silently. A clone reported against `Service.handle` would join to a free `handle`.

So the walk had to become scope-aware first. `_walk_definitions` recurses over child nodes carrying
the enclosing class, which is also what `code_indexer._py_structural` does — the same shape, for the
same reason.

One characteristic inherited deliberately: `compute_node_id` tracks a single level of class nesting,
matching the AST visitor in `call_graph.py`. `Inner.nested` is recorded with `parent_class="Inner"`,
so the fragment is right; the *id* collapses nested classes exactly as the other two extractors do.
Diverging here would break the join this issue exists to create.

## What Changed

- `fingerprinting/types.py` — `CodeFragment.parent_class`; `CodeFragment.node_id` computed via the
  canonical `compute_node_id` / `module_path_from_rel_path`; `node_id` surfaced in the serialised
  fingerprint and clone payloads, so a finding leaving the module carries something joinable.
- `fingerprinting/detector.py` — `_walk_definitions` replaces the flat `ast.walk`, threading the
  enclosing class through fragment creation.

Nothing deleted; the flat walk's behaviour is preserved except that fragments now know their scope.

## Verification

```
code_intelligence/                     684 passed
flake8 clean · black clean
```

The issue's verification criterion is a **join**, so that is what the tests assert: an id the
fingerprinter produces equals the id `compute_node_id` produces for the same method, and a method
and a same-named module-level function no longer collide.

| Mutation | Killed by |
|---|---|
| revert to the flat `ast.walk` | 5 tests |
| `node_id` ignores `parent_class` | 2 tests |
| drop `node_id` from serialisation | 1 test |

`test_every_definition_is_still_found` guards the direction this change could quietly regress:
`ast.walk` visited every node, and recursing over children must reach the same set or this is a
coverage loss dressed as a fix.

## Why this is `Part of`, not `Closes`

The issue's own verification line asks for "a query that joins a `code_indexer` node to a
`call_graph` edge by id". This PR makes the *third* extractor joinable and proves the id agreement
by construction, but it does not run that cross-store query — that needs a populated ChromaDB and
Redis together. Closure gate 3: partial delivery does not close.

Also still open under this issue: `code_analysis/src/` analyzers emit no node identity at all. That
is a larger surface (a dozen analyzer modules) and belongs in its own change rather than being
bundled here.

## Model Used

Claude Opus 5 (1M context)
