### PR TITLE
docs(ci): sync the watchdog cron comment with main — the cron is live (#13791)

### DIFF
--- a/.github/workflows/ci-dispatch-watchdog.yml
+++ b/.github/workflows/ci-dispatch-watchdog.yml
@@ -43,12 +43,15 @@ on:
     # github-actions[bot] as a contributor, so this workflow itself is never
     # subject to the approval policy it repairs.
     #
-    # NOT YET LIVE: GitHub only dispatches `schedule` from the DEFAULT branch,
-    # which is `main`, and this file exists only on Dev_new_gui. Every run of
-    # this workflow to date came from `push` or `pull_request`; none from
-    # `schedule`. The cron starts working the moment Dev_new_gui reaches main —
-    # until then the push and pull_request hooks below are the only coverage,
-    # so neither is redundant with it.
+    # LIVE as of #13791. GitHub only dispatches `schedule` from the DEFAULT
+    # branch, so for the first 100 runs of this workflow — 73 `pull_request`,
+    # 27 `push`, zero `schedule` — the cron did nothing: the file existed only
+    # on Dev_new_gui. It is now also on `main`, which is what makes the sweep
+    # periodic rather than incidental.
+    #
+    # Keep this copy in sync with the `main` one. The push and
+    # pull_request hooks below are still not redundant: they catch a PR head
+    # parking within seconds rather than up to 15 minutes later.
     - cron: '*/15 * * * *'
   push:
     branches: [Dev_new_gui]


### PR DESCRIPTION
**Refs #13791.** Comment-only; the workflow's behaviour is unchanged.

## Thinking Path

Found while checking why the release-sync PR (#13816) had gone `CONFLICTING`. The conflict is a
single add/add on `.github/workflows/ci-dispatch-watchdog.yml`, and I caused it: #13793 put the
watchdog on `main` with a corrected comment, and left the `Dev_new_gui` copy saying the opposite.

`Dev_new_gui` currently claims:

> **NOT YET LIVE**: GitHub only dispatches `schedule` from the DEFAULT branch, which is `main`, and
> this file exists only on Dev_new_gui.

Both halves are now false — the file is on `main`, and the cron fires. A stale comment on a CI
control is worse than no comment: the next person to debug parked runs reads it and concludes the
sweep cannot be running, which is exactly backwards.

The copy I added to `main` also carries a "keep this copy in sync" instruction. Leaving the two
divergent one merge after writing that instruction is not a good look for it.

## What Changed

`Dev_new_gui`'s copy is now byte-identical to `main`'s, except the sync note points at `main` rather
than at itself.

Merging this also removes the #13816 conflict at its source, rather than resolving the same conflict
by hand every time the release branch is refreshed.

## Verification

```
$ git diff origin/main:.github/workflows/ci-dispatch-watchdog.yml \
           HEAD:.github/workflows/ci-dispatch-watchdog.yml
-    # Keep this copy in sync with the Dev_new_gui one.
+    # Keep this copy in sync with the `main` one.
```

No trigger, job, step, permission or cron expression is touched — the diff is entirely inside a
comment block above `- cron: '*/15 * * * *'`.

## Model Used

Claude Opus 5 (1M context)
