### PR TITLE
ci: make the watchdog copies byte-identical so the release sync stops conflicting (#13791)

### DIFF
--- a/.github/workflows/ci-dispatch-watchdog.yml
+++ b/.github/workflows/ci-dispatch-watchdog.yml
@@ -49,7 +49,9 @@ on:
     # on Dev_new_gui. It is now also on `main`, which is what makes the sweep
     # periodic rather than incidental.
     #
-    # Keep this copy in sync with the `main` one. The push and
+    # This file exists on both `main` and `Dev_new_gui` and the two copies must
+    # stay byte-identical — a direction-specific note here makes them permanently
+    # conflict on every release sync. The push and
     # pull_request hooks below are still not redundant: they catch a PR head
     # parking within seconds rather than up to 15 minutes later.
     - cron: '*/15 * * * *'


### PR DESCRIPTION
**Refs #13791.** Comment-only; behaviour unchanged.

## Thinking Path

I got this wrong twice, and this is the fix that actually holds.

`ci-dispatch-watchdog.yml` exists on both `main` and `Dev_new_gui`. When I put it on `main` in
#13793 I added *"Keep this copy in sync with the Dev_new_gui one"*, and when I synced `Dev_new_gui`
in #13831 I mirrored it as *"Keep this copy in sync with the `main` one"* — each pointing at the
other, which reads correctly on either branch and is **guaranteed to conflict**. Two files that must
be identical cannot each name the other.

So #13831 removed the *stale* comment but left the two copies one line apart, and the release sync
(#13816) still hit the same add/add conflict. That conflict would have recurred on every release
sync indefinitely.

Both copies now carry the same direction-neutral note, so they are byte-identical and the conflict
cannot come back.

## What Changed

`Dev_new_gui`'s copy is made byte-identical to the one now on the release branch:

```
$ git hash-object .github/workflows/ci-dispatch-watchdog.yml
$ git rev-parse origin/release-sync-main:.github/workflows/ci-dispatch-watchdog.yml
IDENTICAL
```

The note itself now says what the constraint is rather than which direction to copy — including
*why*, so the next person editing one copy sees the cost of a direction-specific edit before making
one.

## Verification

No trigger, job, step, permission or cron expression is touched. The diff is entirely inside the
comment block above `- cron: '*/15 * * * *'`.

The matching commit is already on `release-sync-main` (`e475fb0ec`); once both land the two files
are identical and #13816 merges without hand-resolution.

## Model Used

Claude Opus 5 (1M context)
