### PR TITLE
fix(release): give the version decision an explicit range and fail loudly when it sees none (#13835)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,12 +52,42 @@ jobs:
             sudo apt-get update -qq && sudo apt-get install -y -qq jq
           fi
 
+      # #13835: compute the range explicitly instead of letting git-cliff decide
+      # what "unreleased" means. A promotion lands as a MERGE commit, and the
+      # first-parent range from the previous tag is then exactly one commit —
+      # the merge itself, which cliff.toml skips via `{ message = "^Merge " }`.
+      # git-cliff therefore found nothing to bump and returned the current
+      # version, and the run reported success having minted no release, with the
+      # 276 commits it should have covered sitting on main.
+      #
+      # Passing `<tag>..HEAD` makes the walk semantics irrelevant: cliff is told
+      # the range rather than inferring it.
+      - name: Compute the release range
+        id: range
+        run: |
+          CURRENT_TAG="$(git describe --tags --abbrev=0 --match 'v[0-9]*' 2>/dev/null || true)"
+          if [[ -n "$CURRENT_TAG" ]]; then
+            RANGE="${CURRENT_TAG}..HEAD"
+            COUNT="$(git rev-list --count "$RANGE")"
+          else
+            RANGE=""
+            COUNT="$(git rev-list --count HEAD)"
+          fi
+          # Printed so a "nothing to release" outcome can be told apart from a
+          # walk that never saw the commits — the failure this replaces.
+          echo "Release range: ${RANGE:-<all history>} (${COUNT} commits)"
+          {
+            echo "range=$RANGE"
+            echo "commit_count=$COUNT"
+            echo "current_tag=$CURRENT_TAG"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Determine next version
         id: version
         uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5  # v4
         with:
           config: cliff.toml
-          args: --bumped-version
+          args: --bumped-version ${{ steps.range.outputs.range }}
         env:
           GITHUB_REPO: ${{ github.repository }}
 
@@ -81,9 +111,18 @@ jobs:
           # from HEAD) when there is nothing to bump — that, not "a tag with
           # this name exists somewhere", is the no-release condition. A name
           # collision with a NON-ancestor tag must not skip the release (#11826).
-          CURRENT_TAG="$(git describe --tags --abbrev=0 --match 'v[0-9]*' 2>/dev/null || true)"
+          CURRENT_TAG="${{ steps.range.outputs.current_tag }}"
           if [[ "$NEXT_VERSION" == "$CURRENT_TAG" ]]; then
-            echo "Nothing to release since ${CURRENT_TAG}"
+            # #13835: a no-release outcome is legitimate only when the range is
+            # genuinely empty. Reaching here with commits in range means the
+            # version decision could not see them, and exiting 0 quietly is how
+            # that went unnoticed for a 276-commit promotion.
+            COMMIT_COUNT="${{ steps.range.outputs.commit_count }}"
+            if [[ "$COMMIT_COUNT" -gt 0 ]]; then
+              echo "::error::git-cliff found nothing to bump, but ${COMMIT_COUNT} commits are in ${CURRENT_TAG}..HEAD — the version decision is not seeing the release range (#13835)."
+              exit 1
+            fi
+            echo "::notice::Nothing to release since ${CURRENT_TAG} — the range is empty."
             echo "release_needed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/repo_tests/release_range_test.py
+++ b/repo_tests/release_range_test.py
@@ -1,0 +1,181 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""The release workflow is told its range, and says so when it sees none (#13835).
+
+A 269-commit promotion to `main` produced no release: the run reported success,
+git-cliff returned the current version, and the guard exited 0. The promotion
+lands as a merge commit, so the first-parent range from the previous tag is
+exactly one commit — the merge — which `cliff.toml` skips via
+``{ message = "^Merge ", skip = true }``.
+
+Two properties are pinned here. The range is passed explicitly, so the walk
+semantics stop mattering. And a "nothing to release" outcome with commits in
+range is an **error**, not a quiet success — that silence is why a release that
+never happened looked like one that did.
+"""
+
+import pathlib
+import subprocess
+import tempfile
+
+import pytest
+import yaml
+
+WORKFLOW = pathlib.Path(__file__).resolve().parents[1] / ".github" / "workflows" / "release.yml"
+
+# The shell body of the range step, extracted so the logic is executed rather
+# than pattern-matched. Kept in sync by test_the_extracted_logic_matches_the_workflow.
+RANGE_LOGIC = """
+CURRENT_TAG="$(git describe --tags --abbrev=0 --match 'v[0-9]*' 2>/dev/null || true)"
+if [[ -n "$CURRENT_TAG" ]]; then
+  RANGE="${CURRENT_TAG}..HEAD"
+  COUNT="$(git rev-list --count "$RANGE")"
+else
+  RANGE=""
+  COUNT="$(git rev-list --count HEAD)"
+fi
+echo "${RANGE:-<all>}|${COUNT}"
+"""
+
+
+def _steps() -> list:
+    return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))["jobs"]["release"]["steps"]
+
+
+def _step(step_id: str) -> dict:
+    return next(s for s in _steps() if s.get("id") == step_id)
+
+
+def _git(repo, *args):
+    subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True)
+
+
+def _run_range_logic(repo) -> tuple:
+    out = subprocess.run(["bash", "-c", RANGE_LOGIC], cwd=str(repo), capture_output=True, text=True, check=True)
+    rng, count = out.stdout.strip().split("|")
+    return rng, int(count)
+
+
+# ------------------------------------------------- the range is passed, not inferred
+
+
+def test_the_version_step_is_given_an_explicit_range():
+    """Without this, cliff decides what "unreleased" means and a merge hides it."""
+    args = _step("version")["with"]["args"]
+
+    assert "--bumped-version" in args
+    assert "steps.range.outputs.range" in args, "the version step still infers its own range"
+
+
+def test_the_range_step_runs_before_the_version_step():
+    ids = [s.get("id") for s in _steps()]
+
+    assert ids.index("range") < ids.index("version")
+
+
+# ------------------------------------ a no-release outcome with commits is an error
+
+
+def test_nothing_to_release_with_commits_in_range_fails_the_run():
+    """The defect was a green run that minted nothing.
+
+    A range that is genuinely empty is a legitimate no-op; a non-empty one means
+    the version decision could not see the commits, and that must not exit 0.
+    """
+    body = _step("check")["run"]
+
+    assert "commit_count" in body, "the guard does not consult the range size"
+    assert "exit 1" in body, "a version decision that misses its range still exits 0"
+    assert "::error::" in body
+
+
+def test_an_empty_range_is_still_a_clean_no_op():
+    body = _step("check")["run"]
+
+    assert "release_needed=false" in body
+    assert "::notice::" in body, "a legitimate no-op should say so rather than being silent"
+
+
+# ----------------------------------------------------- the logic itself, executed
+
+
+def test_a_tagged_repo_yields_the_range_since_its_latest_tag(tmp_path):
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    _git(tmp_path, "config", "user.email", "a@b.c")
+    _git(tmp_path, "config", "user.name", "t")
+    (tmp_path / "f.txt").write_text("1\n", encoding="utf-8")
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-qm", "feat: one")
+    _git(tmp_path, "tag", "v1.0.0")
+    (tmp_path / "f.txt").write_text("2\n", encoding="utf-8")
+    _git(tmp_path, "commit", "-qam", "feat: two")
+
+    rng, count = _run_range_logic(tmp_path)
+
+    assert rng == "v1.0.0..HEAD"
+    assert count == 1
+
+
+def test_a_merge_commit_range_reports_every_commit_not_just_the_merge(tmp_path):
+    """The exact shape that produced no release.
+
+    First-parent from the tag is one commit — the merge, which cliff skips. The
+    range must report the whole set, or the version decision has nothing to work
+    from.
+    """
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    _git(tmp_path, "config", "user.email", "a@b.c")
+    _git(tmp_path, "config", "user.name", "t")
+    (tmp_path / "f.txt").write_text("1\n", encoding="utf-8")
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-qm", "chore: base")
+    _git(tmp_path, "tag", "v1.0.0")
+    _git(tmp_path, "checkout", "-qb", "feature")
+    for i in range(3):
+        (tmp_path / f"n{i}.txt").write_text("x\n", encoding="utf-8")
+        _git(tmp_path, "add", "-A")
+        _git(tmp_path, "commit", "-qm", f"feat: change {i}")
+    _git(tmp_path, "checkout", "-q", "master") if _has_master(tmp_path) else _git(tmp_path, "checkout", "-q", "main")
+    _git(tmp_path, "merge", "--no-ff", "-q", "-m", "Merge pull request #1 from feature", "feature")
+
+    first_parent = subprocess.run(
+        ["git", "-C", str(tmp_path), "rev-list", "--count", "--first-parent", "v1.0.0..HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    rng, count = _run_range_logic(tmp_path)
+
+    assert first_parent == "1", "fixture no longer reproduces the merge shape"
+    assert count == 4, f"the range saw {count} commits, not the 3 changes plus the merge"
+
+
+def _has_master(repo) -> bool:
+    out = subprocess.run(
+        ["git", "-C", str(repo), "branch", "--list", "master"], capture_output=True, text=True, check=True
+    )
+    return bool(out.stdout.strip())
+
+
+def test_an_untagged_repo_falls_back_to_all_history(tmp_path):
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    _git(tmp_path, "config", "user.email", "a@b.c")
+    _git(tmp_path, "config", "user.name", "t")
+    (tmp_path / "f.txt").write_text("1\n", encoding="utf-8")
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-qm", "feat: only")
+
+    rng, count = _run_range_logic(tmp_path)
+
+    assert rng == "<all>"
+    assert count == 1
+
+
+def test_the_extracted_logic_matches_the_workflow():
+    """Guard the guard: the logic above is a copy, and a copy can drift."""
+    body = _step("range")["run"]
+
+    for line in ("git describe --tags --abbrev=0", "rev-list --count", 'RANGE="${CURRENT_TAG}..HEAD"'):
+        assert line in body, f"the workflow no longer contains: {line}"

--- a/repo_tests/release_range_test.py
+++ b/repo_tests/release_range_test.py
@@ -18,9 +18,7 @@ never happened looked like one that did.
 
 import pathlib
 import subprocess
-import tempfile
 
-import pytest
 import yaml
 
 WORKFLOW = pathlib.Path(__file__).resolve().parents[1] / ".github" / "workflows" / "release.yml"


### PR DESCRIPTION
**Closes #13835.**

## Thinking Path

The 269-commit promotion merged, the `Release` workflow reported **success**, and no release was
minted. `main` carries everything since `v0.6.4` and none of it is released.

### Root cause, and how far the evidence goes

The promotion lands as a **merge commit**, and `cliff.toml` has
`{ message = "^Merge ", skip = true }`. The first-parent range from the previous tag is therefore
exactly one commit, and that commit is skipped:

```
$ git log --first-parent v0.6.4..origin/main --oneline
5bae2b974 Merge pull request #13816 from mrveiss/release-sync-main      <- 1 commit

$ git rev-list --count v0.6.4..origin/main
276

$ git log v0.6.4..origin/main --format=%s | grep -cE '^(feat|fix|perf|refactor)(\(|:)'
158
```

276 commits, 158 conventional-typed with bumping types. `filter_unconventional = false` and
`filter_commits = false`, so nothing is dropped for being untyped. No tag sits inside the range —
checked every `v*` tag reachable from `main`; none is in `v0.6.4..HEAD` — so the commits are
genuinely unreleased.

**Being precise about certainty:** I could not run git-cliff locally to prove the walk semantics, so
"cliff walks first-parent" is inference from a perfect fit between the symptom and the shape, not a
demonstration. The fix is written so it does not depend on that inference being right.

### The fix does not need the root cause to be certain

Rather than adjust how git-cliff infers "unreleased", the range is now **computed and passed**:
`<latest-tag>..HEAD`. Whatever the walk would have done, cliff is told the range instead of deducing
it. If the first-parent theory is wrong, the explicit range fixes the real cause anyway.

### The second defect is the silence

A release pipeline that exits 0 having done nothing is the failure that let this pass unnoticed.
There is no red check to see. So a "nothing to release" outcome now:

- is a **hard error** when commits are in range — that combination means the version decision could
  not see them, and it is never legitimate;
- is an explicit `::notice::` when the range is genuinely empty, rather than silence.

This is the same class as the parked runs and cancelled checks hit repeatedly today: a green signal
that means *did nothing*. The difference between the two cases was invisible; now it is loud.

## What Changed

- `.github/workflows/release.yml` — a `range` step computing `<tag>..HEAD` and its commit count and
  printing both; the version step passes that range; the check step errors when a no-bump verdict
  coincides with a non-empty range. `CURRENT_TAG` is now read from the range step rather than
  recomputed, so the two cannot disagree.
- `repo_tests/release_range_test.py` — 8 tests.

## Verification

```
repo_tests/release_range_test.py    8 passed
YAML parses · flake8 · black · isort clean
```

The tests **execute** the range logic against real repositories rather than pattern-matching the
workflow. The one that matters reconstructs the exact failure shape — a tag, three typed commits on a
branch, then a merge — and asserts the difference:

```
first-parent from the tag : 1 commit   (the merge, which cliff skips)
the range this step reports: 4 commits
```

It also asserts the first-parent count is still 1, so the fixture cannot silently stop reproducing
the bug it exists for. Both branches of the tag/no-tag path are exercised, and
`test_the_extracted_logic_matches_the_workflow` guards the copied shell against drift.

## What this does not do

It does not mint the missing release. Once merged and promoted to `main`, the next release run covers
the full range. Re-tagging by hand would have produced a release today and left the defect in place
for the next promotion.

## Model Used

Claude Opus 5 (1M context)
