### PR TITLE
docs(research): drop residual MailRisk references from the wave tables (#13707)

### DIFF
--- a/docs/research/email-reading-capability-audit.md
+++ b/docs/research/email-reading-capability-audit.md
@@ -427,7 +427,7 @@ mandatory regardless of autonomy mode, and per-service rather than global.
 | **2** | Mail connector under `knowledge/connectors/` (read-only, secrets via `ConnectorCredentialStore`) | Requirement 3.2 satisfied by construction |
 | **3** | `api/integration_microsoft365.py` router | 628 built lines become reachable |
 | **4** | `MailboxView.vue` — read, thread, sanitised render, compose; 11 locales | Requirement 3.3 |
-| **5** | Autonomy modes + `MailRisk` tiers wired to the Wave-1 seam | Requirement 3.1 |
+| **5** | Autonomy modes — mail actions mapped onto the existing `CommandRisk` members, no new enum (#13845) | Requirement 3.1 |
 | **6** | Inbound thread → work item; approval-by-reply gated on SPF/DKIM/DMARC | Original CEO-inbox value |
 | **7** | Agent self-signup: browser + mail + secrets + mandatory per-service approval | Requirement 3.4 — last, never full-autonomy |
 
@@ -569,7 +569,7 @@ credential back to the approval that authorised it.
 | **3** | Mail connector, read-only, secrets via `ConnectorCredentialStore` | Ingest passes through Wave 2 |
 | **4** | `api/integration_microsoft365.py` router | 628 built lines become reachable |
 | **5** | `MailboxView.vue` — read, thread, sanitised render, compose; 11 locales | |
-| **6** | Autonomy modes + `MailRisk` tiers on the Wave-1 seam | |
+| **6** | Autonomy modes — mail actions mapped onto existing `CommandRisk` members (#13845) | |
 | **7** | `store_secret_for_agent` write path + provenance fields (4.2, 4.4) | Prerequisite for signup |
 | **8** | Inbound thread → work item; approval-by-reply gated on SPF/DKIM/DMARC | |
 | **9** | Agent self-signup — browser + mail + vault deposit + per-service approval | Last; never full-autonomy |


### PR DESCRIPTION
Refs #13707

## Thinking Path

PR #13847 corrected section 3.1 to reuse `CommandRisk` instead of introducing a `MailRisk`
enum, but left two `MailRisk` references in the wave-plan tables. A partial correction is
worse than none: the wave tables are what an implementer reads to scope the work, and they
contradicted the corrected section.

## What Changed

Waves 5 and 6 now say "mail actions mapped onto the existing `CommandRisk` members, no new
enum (#13845)".

The single surviving `MailRisk` mention (line 297) is deliberate — it records that an
earlier draft proposed the enum and why that was wrong.

Docs-only. No code.

## Verification

```
$ grep -c "MailRisk" docs/research/email-reading-capability-audit.md
1     # only the explanatory mention at line 297

$ git diff --stat origin/Dev_new_gui...HEAD
 docs/research/email-reading-capability-audit.md | 4 ++--
```

## Model Used

Claude Opus 5 (1M context)
