### PR TITLE
fix(code-intelligence): port GitHistoryCrawler to the git binary (#13832)

### DIFF
--- a/autobot-backend/code_intelligence/code_evolution_miner.py
+++ b/autobot-backend/code_intelligence/code_evolution_miner.py
@@ -124,6 +124,56 @@ def _run_git(repo_path: str, *args: str) -> str:
     return completed.stdout
 
 
+# #13832: NUL separates commits, RS separates fields. RS (0x1e) cannot appear in a
+# commit message in practice, and putting the raw body last keeps a multi-line
+# message from being mistaken for the numstat block that follows it.
+_COMMIT_FORMAT = "--pretty=format:%x00%H%x1e%at%x1e%an%x1e%B%x1e"
+
+
+def _parse_commit_block(block: str) -> "dict | None":
+    """Turn one ``git log`` block into the dict shape callers already expect.
+
+    Returns None for a block that is not a commit — notably the empty leading
+    one produced by the NUL that precedes the first record.
+    """
+    if not block.strip():
+        return None
+    parts = block.split("\x1e")
+    if len(parts) < 5:
+        return None
+    commit_hash, timestamp, author, message = parts[0], parts[1], parts[2], parts[3]
+    if not commit_hash.strip() or not timestamp.strip().isdigit():
+        return None
+    return {
+        "hash": commit_hash.strip(),
+        "message": message.strip(),
+        "author": author.strip(),
+        # #13162: tz-aware UTC. A naive datetime here crashed calculate_trend,
+        # which compares against datetime.now(tz=timezone.utc), and made month
+        # bucketing depend on the server's local timezone.
+        "timestamp": datetime.fromtimestamp(int(timestamp.strip()), tz=timezone.utc),
+        "stats": _parse_numstat(parts[4]),
+    }
+
+
+def _parse_numstat(numstat: str) -> Dict[str, int]:
+    """Totals from ``--numstat`` lines, matching GitPython's ``stats.total`` keys.
+
+    A binary file is reported by git as ``-\t-\tpath``; it counts as a changed
+    file with zero line changes rather than being dropped or crashing the parse.
+    """
+    files = insertions = deletions = 0
+    for line in numstat.splitlines():
+        columns = line.split("\t")
+        if len(columns) < 3:
+            continue
+        files += 1
+        added, removed = columns[0], columns[1]
+        insertions += int(added) if added.isdigit() else 0
+        deletions += int(removed) if removed.isdigit() else 0
+    return {"files": files, "insertions": insertions, "deletions": deletions, "lines": insertions + deletions}
+
+
 def _is_vendored_path(path: str) -> bool:
     """True for paths whose co-changes come from tooling rather than from design."""
     return any(part in _COCHANGE_SKIP_DIRS for part in PurePosixPath(path).parts)
@@ -133,54 +183,44 @@ class GitHistoryCrawler:
     """Crawls git history to extract code changes"""
 
     def __init__(self, repo_path: str):
+        """#13832: reads the git binary. GitPython was imported here and nowhere
+        else, and appeared in no requirements file, so ``self.repo`` was always
+        ``None`` and every method returned ``[]`` in every environment since this
+        class was written. The ``except ImportError`` even logged "Using fallback
+        git commands" — there were none, which is how a wholly inert subsystem
+        read as a handled degradation.
+        """
         self.repo_path = Path(repo_path)
-        try:
-            import git
-
-            self.repo = git.Repo(repo_path)
-        except ImportError:
-            logger.warning("GitPython not installed. Using fallback git commands.")
-            self.repo = None
-        except Exception as e:
-            logger.error("Failed to initialize git repository: %s", e)
-            self.repo = None
+        self.available = _run_git(str(self.repo_path), "rev-parse", "--git-dir") != ""
+        if not self.available:
+            logger.warning("GitHistoryCrawler: %s is not a git repository — history is unavailable", repo_path)
 
     def get_commits_in_range(self, start_date: datetime | None = None, end_date: datetime | None = None) -> List[Dict]:
-        """Get commits within a date range"""
-        if self.repo is None:
+        """Get commits within a date range (#13832: via the git binary)."""
+        if not self.available:
             return []
 
-        commits = []
-        try:
-            all_commits = list(self.repo.iter_commits("HEAD"))
+        args = ["log", _COMMIT_FORMAT, "--numstat"]
+        if start_date:
+            args.append(f"--since={start_date.isoformat()}")
+        if end_date:
+            args.append(f"--until={end_date.isoformat()}")
+        output = _run_git(str(self.repo_path), *args)
+        return [c for block in output.split("\x00") if (c := _parse_commit_block(block)) is not None]
 
-            for commit in all_commits:
-                # #13162: tz-aware UTC. A naive datetime here crashed
-                # calculate_trend, which compares against
-                # datetime.now(tz=timezone.utc), and made month bucketing
-                # depend on the server's local timezone.
-                commit_date = datetime.fromtimestamp(commit.committed_date, tz=timezone.utc)
+    def get_file_history(self, file_path: str) -> List[Dict]:
+        """Get commit history for a specific file (#13832: via the git binary)."""
+        if not self.available:
+            return []
 
-                # Filter by date range
-                if start_date and commit_date < start_date:
-                    continue
-                if end_date and commit_date > end_date:
-                    continue
-
-                commits.append(
-                    {
-                        "hash": commit.hexsha,
-                        "message": commit.message.strip(),
-                        "author": commit.author.name,
-                        "timestamp": commit_date,
-                        "stats": commit.stats.total,
-                    }
-                )
-
-        except Exception as e:
-            logger.error("Failed to retrieve commits: %s", e)
-
-        return commits
+        # `--` separates revisions from paths, so a path that looks like a flag
+        # or a ref cannot be reinterpreted as one.
+        output = _run_git(str(self.repo_path), "log", _COMMIT_FORMAT, "--numstat", "--", file_path)
+        return [
+            {"hash": c["hash"], "message": c["message"], "timestamp": c["timestamp"]}
+            for block in output.split("\x00")
+            if (c := _parse_commit_block(block)) is not None
+        ]
 
     def get_commit_file_sets(self, since: "datetime | None" = None) -> "list[set[str]]":
         """Return the changed-path set for **every** commit in the window (#13639).
@@ -216,26 +256,17 @@ class GitHistoryCrawler:
                 file_sets.append(paths)
         return file_sets
 
-    def get_file_history(self, file_path: str) -> List[Dict]:
-        """Get commit history for a specific file"""
-        if self.repo is None:
+    def get_commit_files(self, commit_hash: str) -> List[str]:
+        """Paths changed by one commit (#13832).
+
+        Replaces ``crawler.repo.commit(hash).stats.files`` — the GitPython call
+        that could never run.
+        """
+        if not self.available:
             return []
-
-        commits = []
-        try:
-            for commit in self.repo.iter_commits(paths=file_path):
-                commits.append(
-                    {
-                        "hash": commit.hexsha,
-                        "message": commit.message.strip(),
-                        # #13162: tz-aware UTC — see the note above.
-                        "timestamp": datetime.fromtimestamp(commit.committed_date, tz=timezone.utc),
-                    }
-                )
-        except Exception as e:
-            logger.error("Failed to get file history for %s: %s", file_path, e)
-
-        return commits
+        # `--` guards against a hash-shaped string being read as a path.
+        output = _run_git(str(self.repo_path), "show", "--pretty=format:", "--name-only", commit_hash, "--")
+        return [line for line in output.splitlines() if line.strip()]
 
     def detect_refactoring_commits(self) -> List[Dict]:
         """Detect commits that likely contain refactorings"""
@@ -448,7 +479,11 @@ class CodeEvolutionMiner:
     """Main class for code evolution mining"""
 
     def __init__(self, repo_path: str):
-        self.repo_path = repo_path
+        # #13832: was a bare str, and `self.repo_path / item` below is a Path
+        # operation. It never raised because the guard above it short-circuited
+        # on an attribute that was always None — the moment history became real,
+        # every commit failed with "unsupported operand type(s) for /".
+        self.repo_path = Path(repo_path)
         self.crawler = GitHistoryCrawler(repo_path)
         self.tracker = PatternEvolutionTracker()
         self.refactoring_detector = RefactoringDetector(self.crawler)
@@ -488,15 +523,19 @@ class CodeEvolutionMiner:
 
     def _analyze_commit_patterns(self, commit: Dict):
         """Analyze patterns in a commit"""
-        if self.repo is None or self.crawler.repo is None:
+        # #13832: was `self.repo is None or self.crawler.repo is None` — an
+        # attribute this class never had (`AttributeError` the moment the crawler
+        # returned anything) guarded by one that was always None, so the guard
+        # short-circuited before the broken half could raise. Now that history is
+        # real, both go through the crawler's own availability flag.
+        if not self.crawler.available:
             return
 
         try:
-            # Get the commit object
-            commit_obj = self.crawler.repo.commit(commit["hash"])
+            changed_files = self.crawler.get_commit_files(commit["hash"])
 
             # Analyze each changed file
-            for item in commit_obj.stats.files.keys():
+            for item in changed_files:
                 # Only analyze Python files
                 if not item.endswith(".py"):
                     continue

--- a/autobot-backend/code_intelligence/code_evolution_miner_test.py
+++ b/autobot-backend/code_intelligence/code_evolution_miner_test.py
@@ -288,7 +288,11 @@ class TestCodeEvolutionMiner:
         with tempfile.TemporaryDirectory() as tmpdir:
             miner = CodeEvolutionMiner(tmpdir)
 
-            assert miner.repo_path == tmpdir
+            # #13832: repo_path is a Path — `self.repo_path / item` is a Path
+            # operation, and holding a str made every commit fail once history
+            # became real. The sibling assertion at test_init_without_git already
+            # expected Path(tmpdir); these two disagreed.
+            assert miner.repo_path == Path(tmpdir)
             assert miner.crawler is not None
             assert miner.tracker is not None
             assert miner.refactoring_detector is not None

--- a/autobot-backend/code_intelligence/git_history_crawler_test.py
+++ b/autobot-backend/code_intelligence/git_history_crawler_test.py
@@ -1,0 +1,228 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""``GitHistoryCrawler`` returns real history (#13832).
+
+It never did. `import git` appeared here and nowhere else in the project, and
+GitPython was in no requirements file, so `self.repo` was always None and every
+method returned `[]` in every environment since the class was written. The
+`except ImportError` logged *"Using fallback git commands"* — there were none,
+which is how a wholly inert subsystem read as a handled degradation.
+
+So the load-bearing assertions here are **non-empty**. A test suite that only
+checked shapes would have passed against the inert version for years.
+"""
+
+import subprocess
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from code_intelligence.code_evolution_miner import GitHistoryCrawler, _parse_numstat
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True)
+
+
+def _commit(repo: Path, files: dict, message: str) -> None:
+    for name, content in files.items():
+        target = repo / name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if isinstance(content, bytes):
+            target.write_bytes(content)
+        else:
+            target.write_text(content, encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", message)
+
+
+@pytest.fixture
+def repo(tmp_path):
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    _git(tmp_path, "config", "user.email", "a@b.c")
+    _git(tmp_path, "config", "user.name", "Test Author")
+    _commit(tmp_path, {"a.py": "one\n"}, "feat: add a")
+    _commit(tmp_path, {"a.py": "one\ntwo\n", "b.py": "x\n"}, "refactor: extract method from a")
+    _commit(tmp_path, {"c.py": "y\n"}, "fix: unrelated\n\nWith a body line.")
+    return tmp_path
+
+
+# ------------------------------------------------------- it returns something
+
+
+def test_commits_are_returned_at_all(repo):
+    """The whole defect in one assertion: this was `[]` in every environment."""
+    commits = GitHistoryCrawler(str(repo)).get_commits_in_range()
+
+    assert len(commits) == 3
+
+
+def test_file_history_is_returned_at_all(repo):
+    history = GitHistoryCrawler(str(repo)).get_file_history("a.py")
+
+    assert len(history) == 2, "a.py was touched by two commits"
+
+
+def test_refactoring_commits_are_detected_at_all(repo):
+    found = GitHistoryCrawler(str(repo)).detect_refactoring_commits()
+
+    assert [c["refactoring_type"] for c in found] == ["extract_method"]
+
+
+def test_the_crawler_needs_no_gitpython():
+    """The dependency that was never installed is gone, not made optional."""
+    import code_intelligence.code_evolution_miner as miner
+
+    assert "import git" not in Path(miner.__file__).read_text(encoding="utf-8")
+
+
+# --------------------------------------------------------- the fields callers use
+
+
+def test_every_field_downstream_code_reads_is_populated(repo):
+    commit = GitHistoryCrawler(str(repo)).get_commits_in_range()[0]
+
+    assert len(commit["hash"]) == 40
+    assert commit["author"] == "Test Author"
+    assert commit["message"]
+    assert set(commit["stats"]) == {"files", "insertions", "deletions", "lines"}
+
+
+def test_timestamps_are_timezone_aware_utc(repo):
+    """#13162: a naive datetime here crashed `calculate_trend`, which compares
+    against `datetime.now(tz=timezone.utc)`, and made month bucketing depend on
+    the server's local timezone."""
+    commit = GitHistoryCrawler(str(repo)).get_commits_in_range()[0]
+
+    assert commit["timestamp"].tzinfo is not None
+    assert commit["timestamp"].utcoffset() == timedelta(0)
+
+
+def test_a_multi_line_message_survives_the_parse(repo):
+    """The body is last before the numstat block, so it must not swallow it."""
+    commits = GitHistoryCrawler(str(repo)).get_commits_in_range()
+    body_commit = next(c for c in commits if c["message"].startswith("fix: unrelated"))
+
+    assert "With a body line." in body_commit["message"]
+    assert body_commit["stats"]["files"] == 1, "the numstat block was consumed by the message"
+
+
+def test_stats_count_the_lines_that_changed(repo):
+    commits = GitHistoryCrawler(str(repo)).get_commits_in_range()
+    refactor = next(c for c in commits if c["message"].startswith("refactor"))
+
+    assert refactor["stats"]["files"] == 2
+    assert refactor["stats"]["insertions"] == 2
+    assert refactor["stats"]["lines"] == refactor["stats"]["insertions"] + refactor["stats"]["deletions"]
+
+
+# ------------------------------------------------------------------ filtering
+
+
+def test_the_date_range_excludes_older_commits(repo):
+    future = datetime.now(timezone.utc) + timedelta(days=1)
+
+    assert GitHistoryCrawler(str(repo)).get_commits_in_range(start_date=future) == []
+
+
+def test_an_end_date_in_the_past_excludes_everything(repo):
+    past = datetime.now(timezone.utc) - timedelta(days=3650)
+
+    assert GitHistoryCrawler(str(repo)).get_commits_in_range(end_date=past) == []
+
+
+def test_file_history_is_scoped_to_the_path(repo):
+    history = GitHistoryCrawler(str(repo)).get_file_history("c.py")
+
+    assert len(history) == 1
+    assert history[0]["message"].startswith("fix: unrelated")
+
+
+def test_a_path_that_looks_like_a_flag_is_not_read_as_one(repo):
+    """`--` separates revisions from paths, so a hostile-looking path cannot
+    become an option."""
+    assert GitHistoryCrawler(str(repo)).get_file_history("--all") == []
+
+
+# -------------------------------------------------------------- degradation
+
+
+def test_a_non_repository_degrades_rather_than_raising(tmp_path):
+    crawler = GitHistoryCrawler(str(tmp_path))
+
+    assert crawler.available is False
+    assert crawler.get_commits_in_range() == []
+    assert crawler.get_file_history("x.py") == []
+    assert crawler.detect_refactoring_commits() == []
+
+
+def test_a_real_repository_reports_itself_available(repo):
+    """The flag must distinguish the two cases, or "no history" is ambiguous again."""
+    assert GitHistoryCrawler(str(repo)).available is True
+
+
+# ---------------------------------------------------------------- numstat parsing
+
+
+def test_a_binary_file_counts_as_changed_with_no_line_changes():
+    """git reports binaries as `-\\t-\\tpath`; dropping them would undercount files."""
+    stats = _parse_numstat("-\t-\timage.png\n3\t1\tcode.py\n")
+
+    assert stats == {"files": 2, "insertions": 3, "deletions": 1, "lines": 4}
+
+
+def test_an_empty_numstat_is_zero_not_an_error():
+    assert _parse_numstat("") == {"files": 0, "insertions": 0, "deletions": 0, "lines": 0}
+
+
+def test_a_binary_only_commit_is_still_a_commit(repo):
+    _commit(repo, {"blob.bin": b"\x00\x01\x02"}, "chore: add a binary")
+
+    commits = GitHistoryCrawler(str(repo)).get_commits_in_range()
+    binary = next(c for c in commits if c["message"].startswith("chore: add a binary"))
+
+    assert binary["stats"]["files"] == 1
+    assert binary["stats"]["lines"] == 0
+
+
+# ------------------------------- the consumers, against non-empty input
+
+
+def test_analyze_evolution_actually_analyses(repo, caplog):
+    """`CodeEvolutionMiner` had never received a non-empty commit list.
+
+    Two defects surfaced the moment it did, and both were invisible before:
+    `_analyze_commit_patterns` guarded on `self.repo`, an attribute the class
+    never had, and `self.repo_path / item` was a Path operation on a `str`. The
+    first short-circuited on an always-None attribute so the second could never
+    raise — an inert subsystem hiding a broken one.
+    """
+    from code_intelligence.code_evolution_miner import CodeEvolutionMiner
+
+    with caplog.at_level("ERROR"):
+        report = CodeEvolutionMiner(str(repo)).analyze_evolution()
+
+    assert report["commits_analyzed"] == 3
+    failures = [r.getMessage() for r in caplog.records if "Failed to analyze commit" in r.getMessage()]
+    assert failures == [], f"commits failed to analyse: {failures[:2]}"
+
+
+def test_the_miner_holds_a_path_not_a_string(repo):
+    """`repo_path` is used with the `/` operator; a str made every commit fail."""
+    from code_intelligence.code_evolution_miner import CodeEvolutionMiner
+
+    assert isinstance(CodeEvolutionMiner(str(repo)).repo_path, Path)
+
+
+def test_commit_files_lists_what_a_commit_touched(repo):
+    crawler = GitHistoryCrawler(str(repo))
+    second = crawler.get_commits_in_range()[1]
+
+    assert sorted(crawler.get_commit_files(second["hash"])) == ["a.py", "b.py"]
+
+
+def test_commit_files_degrades_on_a_non_repository(tmp_path):
+    assert GitHistoryCrawler(str(tmp_path)).get_commit_files("deadbeef") == []


### PR DESCRIPTION
**Closes #13832.**

## Thinking Path

`GitHistoryCrawler.__init__` did `import git`. GitPython is in **no requirements file** and imported
nowhere else, so `self.repo` was always `None` and every method returned `[]` — in every
environment, since the class was written.

```
GitPython MISSING: No module named 'git'   ·   repo is None? True
```

The `except ImportError` logged *"Using fallback git commands"*. There were none. A message naming a
fallback that was never written is how a wholly inert subsystem read as a handled degradation for
years.

Ported to the git binary per the owner decision: no new dependency, and the binary is present
wherever the repository is.

```
after:  available=True   commits=12002   refactoring commits=4783
```

### Porting was the easy half

The decision recorded the real risk — *"four methods will start returning data to consumers that have
never seen a non-empty result"*. Exercising every entry point against real history found two defects,
and the way they interacted is the interesting part.

**1. A guard on an attribute this class never had.**

```python
if self.repo is None or self.crawler.repo is None:
```

`CodeEvolutionMiner` has no `self.repo`. That is an `AttributeError` the instant the right-hand side
matters — except the left-hand side was an attribute that was always `None`, so it short-circuited
and the broken half never evaluated. **An inert subsystem hiding a broken one.**

**2. `self.repo_path / item` on a `str`.** A Path operation on a string, unreachable behind the guard
above. The moment history became real, every commit failed with `unsupported operand type(s) for /` —
and it is swallowed into a `logger.error`, so `analyze_evolution` returned a report having analysed
nothing.

Both are now fixed and covered. Note the second defect's own test file already asserted
`crawler.repo_path == Path(tmpdir)` for the sibling class while asserting a bare `str` for this one —
the two disagreed and nothing noticed, because neither path ran.

## What Changed

- `code_evolution_miner.py` — `_run_git`-backed `get_commits_in_range`, `get_file_history`,
  `get_commit_files`; `_parse_commit_block` / `_parse_numstat`; an `available` flag replacing
  `self.repo is None`; `CodeEvolutionMiner.repo_path` is a `Path`; the `import git` block and its
  misleading message are gone.
- `git_history_crawler_test.py` — 21 tests.
- `code_evolution_miner_test.py` — one assertion aligned with its sibling.

Commit parsing uses NUL between records and RS between fields, with the raw body **last** so a
multi-line message cannot swallow the numstat block that follows it. `--` separates revisions from
paths, so a path that looks like a flag cannot become one.

## Verification

```
code_intelligence/   734 passed  ·  flake8 · black · isort · bandit clean
```

**The load-bearing assertions are the non-empty ones.** A suite that only checked shapes would have
passed against the inert version for years — which is precisely what happened. So the tests assert
`len(commits) == 3`, `refactoring_type == ["extract_method"]`, and that `analyze_evolution` logs
**zero** `Failed to analyze commit` errors.

Also covered: tz-aware UTC timestamps (#13162's crash), multi-line messages surviving the parse,
binary files counting as changed with zero line changes, date filtering, and degradation on a
non-repository.

## One consequence worth stating

`analyze_evolution` over this repository's 12,002 commits no longer returns instantly — it does real
work now. My first verification run timed out at two minutes. That is correct behaviour rather than a
regression, but any caller that assumed it was cheap was assuming it was empty. Not addressed here;
flagging it because the honest reading of "this subsystem now works" includes "and it now costs
something".

## Acceptance criteria

- [x] Returns real data with no GitPython installed
- [x] Tests asserting **non-empty** results, so the inert state cannot return
- [x] The `import git` block and its misleading message removed
- [x] Every downstream consumer re-checked against non-empty input — two defects found and fixed
- [x] Timeout-bounded, `shell=False`, argv form

## Model Used

Claude Opus 5 (1M context)
