### PR TITLE
fix(deploy): self-update verdict calls a healthy run "cut short" every day after logrotate (#13125)

### DIFF
--- a/autobot-slm-backend/services/playbook_executor.py
+++ b/autobot-slm-backend/services/playbook_executor.py
@@ -16,6 +16,7 @@ import re
 import shlex
 import shutil
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Callable, Dict, List
 
@@ -115,6 +116,13 @@ ANSIBLE_ENV_ALLOWLIST_EXACT = (
 # still alive. Mirrors the existing /var/log/autobot/provision-wizard.log
 # precedent (api/setup_wizard.py).
 SELF_UPDATE_LOG_PATH = Path(os.getenv("SLM_SELF_UPDATE_LOG_PATH", "/var/log/autobot/self-update-ansible.log"))
+
+# #13125: first line of every fresh self-update log. Two different things empty
+# this file — the per-run truncation in _write_fresh_log_file and logrotate's
+# nightly `copytruncate` — and the completion verdict has to tell them apart, so
+# a started run stamps itself. Read by services/self_update_log_reader.py; keep
+# the two in step (a shared constant rather than a literal on each side).
+SELF_UPDATE_RUN_HEADER: str = "SELF-UPDATE RUN STARTED"
 
 # #12425: /var/log/autobot is a shared dir that any autobot-* service user
 # may have created/re-created first (observed owned by the TTS worker,
@@ -590,12 +598,25 @@ class PlaybookExecutor:
         Ansible output can contain sensitive paths/values — 0600, not the
         world-readable default umask.
 
+        #13125: the file is stamped with a run-start header rather than left at
+        zero bytes. Two different things empty this file — this truncation, and
+        logrotate's ``copytruncate`` — and the completion verdict has to tell
+        them apart. Without the header, "empty" is ambiguous: a run that started
+        and produced nothing (systemd-run failed to exec, or output went to the
+        #12425 fallback path) is indistinguishable from "no run since the
+        nightly rotation", so the verdict must either cry wolf on the second or
+        stay silent about the first. The header makes it decidable, and the
+        timestamp gives the verdict something honest to say about staleness.
+
         Returns None on any OSError; the caller decides whether to fall back
         to another path or give up.
         """
         try:
             path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_text("", encoding="utf-8")
+            path.write_text(
+                f"{SELF_UPDATE_RUN_HEADER} {datetime.now(timezone.utc).isoformat()}\n",
+                encoding="utf-8",
+            )
             os.chmod(path, 0o600)
             return path
         except OSError:

--- a/autobot-slm-backend/services/self_update_log_reader.py
+++ b/autobot-slm-backend/services/self_update_log_reader.py
@@ -37,6 +37,30 @@ _RECAP_COUNTS = re.compile(r"\b(?P<key>failed|unreachable)=(?P<count>\d+)")
 # (play headers and the recap) is cheap to find without holding the whole file.
 MAX_LOG_BYTES = 512 * 1024
 
+# #13125: logrotate rotates /var/log/autobot/*.log daily with ``copytruncate``
+# (roles/common/templates/autobot-logrotate.j2) — mandatory for the append: units
+# that hold their fd open. It copies the file aside and truncates the original to
+# zero bytes, so from the 01:00 rotation until the next self-update runs, the
+# live log EXISTS and is EMPTY.
+#
+# The reader distinguished missing from present but not present-but-empty, so an
+# empty log reached the parse path, found zero play headers, and produced "the
+# run was cut short; later plays did not execute" — on a deployment whose last
+# self-update finished normally. For most of every day, on every node. It was
+# discounted as noise once before the cause was found, which is the real damage:
+# a detector that cries wolf daily teaches everyone to ignore that whole class of
+# alert.
+#
+# Suppressing to "nothing to say" would fix the false positive and lose a true
+# one — the last run's actual verdict is sitting in the rotation, and going
+# silent all day is its own gap. So the rotation is read instead.
+#
+# ``.1`` only: the stanza sets ``delaycompress``, so the most recent rotation is
+# always the uncompressed ``.1``. Older ones are ``.2.gz`` and up, and a verdict
+# from two rotations back describes a run at least two days old — staleness the
+# freshness marker below could not honestly paper over.
+_ROTATED_SUFFIX = ".1"
+
 
 @dataclass
 class SelfUpdateVerdict:
@@ -52,6 +76,10 @@ class SelfUpdateVerdict:
     #: Independent of the log — a run can reach its recap cleanly and still
     #: deliver nothing, because the updater applies almost none of the roles.
     role_delivery_incomplete: bool = False
+    #: #13125: the verdict was parsed from the rotated log because the live one
+    #: had been truncated to zero bytes by logrotate. The verdict is real but
+    #: describes a run from before the last rotation, so the reason says so.
+    from_rotated_log: bool = False
 
     @property
     def degraded(self) -> bool:
@@ -83,19 +111,54 @@ def _read_tail(path: Path, max_bytes: int = MAX_LOG_BYTES) -> str | None:
         return None
 
 
+def _read_log_text(log_path: Path) -> tuple[str | None, bool]:
+    """Return (text, from_rotated) for the newest log that actually has content.
+
+    Prefers the live log. When logrotate's ``copytruncate`` has emptied it
+    (#13125) the most recent rotation is read instead, so the verdict keeps
+    describing the last real run rather than going blank until the next one.
+
+    Returns ``(None, False)`` when neither has content — the genuine "nothing to
+    say" case, which is NOT a failure (see :attr:`SelfUpdateVerdict.degraded`).
+    """
+    if log_path.exists():
+        text = _read_tail(log_path)
+        if text is None:
+            return None, False
+        if text.strip():
+            return text, False
+
+    rotated = log_path.with_name(log_path.name + _ROTATED_SUFFIX)
+    if rotated.exists():
+        rotated_text = _read_tail(rotated)
+        if rotated_text and rotated_text.strip():
+            logger.info(
+                "self-update log %s is empty (logrotate copytruncate) — reading %s instead (#13125)",
+                log_path,
+                rotated,
+            )
+            return rotated_text, True
+
+    return None, False
+
+
 def read_self_update_verdict(log_path: Path) -> SelfUpdateVerdict:
     """Parse *log_path* and report whether the last self-update run completed.
 
     Never raises: a status endpoint must not fail because a log is missing or
-    malformed. An unreadable log yields ``log_present=False``, which is treated
-    as "nothing to say" rather than as a failure.
+    malformed. A log that is missing, unreadable, or empty on both the live and
+    rotated paths yields ``log_present=False``, which is treated as "nothing to
+    say" rather than as a failure.
     """
-    if not log_path.exists():
+    if not log_path.exists() and not log_path.with_name(log_path.name + _ROTATED_SUFFIX).exists():
         return SelfUpdateVerdict(reason="no self-update log yet")
 
-    text = _read_tail(log_path)
+    text, from_rotated = _read_log_text(log_path)
     if text is None:
-        return SelfUpdateVerdict(reason=f"self-update log unreadable: {log_path}")
+        # #13125: an empty live log with no usable rotation is the same
+        # situation as no log at all — a box that has nothing to report. It was
+        # previously parsed as zero plays and reported as a run cut short.
+        return SelfUpdateVerdict(reason="no self-update log yet")
 
     plays = _PLAY_HEADER.findall(text)
     has_recap = bool(_PLAY_RECAP.search(text))
@@ -115,6 +178,7 @@ def read_self_update_verdict(log_path: Path) -> SelfUpdateVerdict:
         plays_seen=plays,
         failed_hosts=failed,
         unreachable_hosts=unreachable,
+        from_rotated_log=from_rotated,
     )
     verdict.reason = _describe(verdict)
     if verdict.degraded:
@@ -123,18 +187,24 @@ def read_self_update_verdict(log_path: Path) -> SelfUpdateVerdict:
 
 
 def _describe(v: SelfUpdateVerdict) -> str:
-    """Human-readable reason, naming what is missing rather than just 'failed'."""
+    """Human-readable reason, naming what is missing rather than just 'failed'.
+
+    #13125: when the verdict came from the rotated log it is qualified as such.
+    An operator reading "completed, no failures" needs to know it describes the
+    run before the last rotation, not one since.
+    """
+    suffix = " (from the rotated log — the live log was rotated away)" if v.from_rotated_log else ""
     if not v.complete:
         seen = ", ".join(v.plays_seen) if v.plays_seen else "none"
         return (
             f"self-update run did not finish — no PLAY RECAP in the log "
-            f"(plays started: {seen}). The run was cut short; later plays did not execute."
+            f"(plays started: {seen}). The run was cut short; later plays did not execute.{suffix}"
         )
     if v.unreachable_hosts:
-        return f"self-update finished with {v.unreachable_hosts} unreachable host(s)"
+        return f"self-update finished with {v.unreachable_hosts} unreachable host(s){suffix}"
     if v.failed_hosts:
-        return f"self-update finished with {v.failed_hosts} failed task(s)"
-    return f"self-update completed ({len(v.plays_seen)} plays, no failures)"
+        return f"self-update finished with {v.failed_hosts} failed task(s){suffix}"
+    return f"self-update completed ({len(v.plays_seen)} plays, no failures){suffix}"
 
 
 __all__ = ["SelfUpdateVerdict", "read_self_update_verdict", "MAX_LOG_BYTES"]

--- a/autobot-slm-backend/services/self_update_log_reader.py
+++ b/autobot-slm-backend/services/self_update_log_reader.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
 
 from autobot_shared.logging_manager import get_logger
@@ -55,11 +56,30 @@ MAX_LOG_BYTES = 512 * 1024
 # one — the last run's actual verdict is sitting in the rotation, and going
 # silent all day is its own gap. So the rotation is read instead.
 #
+# That fallback is only SAFE because a started run stamps the log with
+# ``SELF_UPDATE_RUN_HEADER`` (playbook_executor._write_fresh_log_file). The
+# executor also truncates this file per run, so without the stamp "empty" would
+# have two causes — rotation, and a run that started and emitted nothing (a
+# systemd-run exec failure, or output diverted to the #12425 fallback path) —
+# and reading the rotation would report the PREVIOUS run's clean verdict over a
+# live failure. With the stamp, an empty live log means only "no run since the
+# rotation", and a header-only log is a started run with no plays: degraded, as
+# it should be.
+#
 # ``.1`` only: the stanza sets ``delaycompress``, so the most recent rotation is
-# always the uncompressed ``.1``. Older ones are ``.2.gz`` and up, and a verdict
-# from two rotations back describes a run at least two days old — staleness the
-# freshness marker below could not honestly paper over.
+# always the uncompressed ``.1`` (each cycle compresses the previous ``.1`` to
+# ``.2.gz``). ``notifempty`` is load-bearing here too — it stops logrotate
+# rotating an already-empty live log, so ``.1`` keeps holding the last real run
+# instead of ageing into ``.2.gz`` on an idle node. That also means ``.1`` can be
+# far older than a day, which is why the reason carries its mtime rather than
+# implying "yesterday".
 _ROTATED_SUFFIX = ".1"
+
+# Kept in step with services.playbook_executor.SELF_UPDATE_RUN_HEADER. Not
+# imported from it: that module pulls in ansible/inventory machinery this reader
+# has no business loading on the status path, and the value is a log format both
+# sides agree on. The pairing is pinned by a test.
+_RUN_HEADER = "SELF-UPDATE RUN STARTED"
 
 
 @dataclass
@@ -80,6 +100,10 @@ class SelfUpdateVerdict:
     #: had been truncated to zero bytes by logrotate. The verdict is real but
     #: describes a run from before the last rotation, so the reason says so.
     from_rotated_log: bool = False
+    #: When that rotation was last written (ISO-8601 UTC). ``notifempty`` means
+    #: an idle node's rotation is never superseded, so it can be far older than
+    #: a day — the reason states the date instead of implying "yesterday".
+    rotated_log_mtime: str | None = None
 
     @property
     def degraded(self) -> bool:
@@ -111,55 +135,87 @@ def _read_tail(path: Path, max_bytes: int = MAX_LOG_BYTES) -> str | None:
         return None
 
 
-def _read_log_text(log_path: Path) -> tuple[str | None, bool]:
-    """Return (text, from_rotated) for the newest log that actually has content.
+@dataclass
+class _LogSource:
+    """Which log the verdict came from, and whether it could be read at all."""
+
+    text: str | None = None
+    from_rotated: bool = False
+    rotated_age: str | None = None
+    unreadable: bool = False
+
+
+def _rotated_path(log_path: Path) -> Path:
+    return log_path.with_name(log_path.name + _ROTATED_SUFFIX)
+
+
+def _read_log_text(log_path: Path) -> _LogSource:
+    """Return the newest log that actually describes a run.
 
     Prefers the live log. When logrotate's ``copytruncate`` has emptied it
     (#13125) the most recent rotation is read instead, so the verdict keeps
     describing the last real run rather than going blank until the next one.
 
-    Returns ``(None, False)`` when neither has content — the genuine "nothing to
-    say" case, which is NOT a failure (see :attr:`SelfUpdateVerdict.degraded`).
+    ``text=None`` with ``unreadable=False`` is the genuine "nothing to say" case,
+    which is NOT a failure (see :attr:`SelfUpdateVerdict.degraded`).
     """
     if log_path.exists():
         text = _read_tail(log_path)
         if text is None:
-            return None, False
+            # A log that is a directory, or one this process cannot read, is a
+            # broken deployment — reported as its own thing rather than folded
+            # into "no log yet", which would look like a fresh box.
+            return _LogSource(unreadable=True)
         if text.strip():
-            return text, False
+            return _LogSource(text=text)
 
-    rotated = log_path.with_name(log_path.name + _ROTATED_SUFFIX)
-    if rotated.exists():
-        rotated_text = _read_tail(rotated)
-        if rotated_text and rotated_text.strip():
-            logger.info(
-                "self-update log %s is empty (logrotate copytruncate) — reading %s instead (#13125)",
-                log_path,
-                rotated,
-            )
-            return rotated_text, True
+    rotated = _rotated_path(log_path)
+    rotated_text = _read_tail(rotated) if rotated.exists() else None
+    if rotated_text and rotated_text.strip():
+        logger.info(
+            "self-update log %s is empty (logrotate copytruncate) — reading %s instead (#13125)",
+            log_path,
+            rotated,
+        )
+        return _LogSource(text=rotated_text, from_rotated=True, rotated_age=_mtime_iso(rotated))
 
-    return None, False
+    return _LogSource()
+
+
+def _mtime_iso(path: Path) -> str | None:
+    """UTC mtime of *path* as an ISO-8601 string, or None if unavailable.
+
+    The rotation can be far older than a day (``notifempty`` skips an idle
+    node's empty log), so the verdict states when it is from rather than letting
+    "rotated away" imply yesterday.
+    """
+    try:
+        return datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc).isoformat(timespec="seconds")
+    except OSError:
+        return None
 
 
 def read_self_update_verdict(log_path: Path) -> SelfUpdateVerdict:
     """Parse *log_path* and report whether the last self-update run completed.
 
     Never raises: a status endpoint must not fail because a log is missing or
-    malformed. A log that is missing, unreadable, or empty on both the live and
-    rotated paths yields ``log_present=False``, which is treated as "nothing to
-    say" rather than as a failure.
+    malformed. A log that is missing, or empty on both the live and rotated
+    paths, yields ``log_present=False``, which is treated as "nothing to say"
+    rather than as a failure.
     """
-    if not log_path.exists() and not log_path.with_name(log_path.name + _ROTATED_SUFFIX).exists():
-        return SelfUpdateVerdict(reason="no self-update log yet")
-
-    text, from_rotated = _read_log_text(log_path)
-    if text is None:
+    source = _read_log_text(log_path)
+    if source.unreadable:
+        # Path-free on purpose: this string reaches an API response, and an
+        # internal filesystem path does not belong in one.
+        return SelfUpdateVerdict(reason="self-update log unreadable")
+    if source.text is None:
         # #13125: an empty live log with no usable rotation is the same
         # situation as no log at all — a box that has nothing to report. It was
         # previously parsed as zero plays and reported as a run cut short.
         return SelfUpdateVerdict(reason="no self-update log yet")
 
+    text = source.text
+    from_rotated = source.from_rotated
     plays = _PLAY_HEADER.findall(text)
     has_recap = bool(_PLAY_RECAP.search(text))
 
@@ -179,6 +235,7 @@ def read_self_update_verdict(log_path: Path) -> SelfUpdateVerdict:
         failed_hosts=failed,
         unreachable_hosts=unreachable,
         from_rotated_log=from_rotated,
+        rotated_log_mtime=source.rotated_age,
     )
     verdict.reason = _describe(verdict)
     if verdict.degraded:
@@ -193,7 +250,12 @@ def _describe(v: SelfUpdateVerdict) -> str:
     An operator reading "completed, no failures" needs to know it describes the
     run before the last rotation, not one since.
     """
-    suffix = " (from the rotated log — the live log was rotated away)" if v.from_rotated_log else ""
+    if not v.from_rotated_log:
+        suffix = ""
+    elif v.rotated_log_mtime:
+        suffix = f" (from the log rotated at {v.rotated_log_mtime}; no self-update has run since)"
+    else:
+        suffix = " (from the rotated log; no self-update has run since)"
     if not v.complete:
         seen = ", ".join(v.plays_seen) if v.plays_seen else "none"
         return (

--- a/autobot-slm-backend/tests/services/test_self_update_log_reader.py
+++ b/autobot-slm-backend/tests/services/test_self_update_log_reader.py
@@ -145,6 +145,10 @@ def test_unreadable_log_does_not_raise(tmp_path):
 
     assert v.degraded is False
     assert v.log_present is False
+    # #13125: a broken log must not read as a fresh box that has never updated.
+    assert v.reason == "self-update log unreadable"
+    # …and must not leak an internal filesystem path into an API response.
+    assert str(d) not in v.reason
 
 
 def test_only_the_last_recap_is_counted(tmp_path):
@@ -206,7 +210,8 @@ def test_empty_log_falls_back_to_the_rotation(tmp_path):
     assert v.complete is True
     assert v.degraded is False
     assert v.from_rotated_log is True
-    assert "rotated log" in (v.reason or "")
+    assert "rotated at" in (v.reason or "")
+    assert v.rotated_log_mtime is not None
 
 
 def test_rotation_is_only_consulted_when_the_live_log_is_empty(tmp_path):
@@ -218,7 +223,7 @@ def test_rotation_is_only_consulted_when_the_live_log_is_empty(tmp_path):
 
     assert v.complete is True
     assert v.from_rotated_log is False
-    assert "rotated log" not in (v.reason or "")
+    assert "rotated at" not in (v.reason or "")
 
 
 def test_a_genuinely_incomplete_rotation_is_still_degraded(tmp_path):
@@ -255,3 +260,68 @@ def test_empty_rotation_is_not_used(tmp_path):
 
     assert v.log_present is False
     assert v.degraded is False
+
+
+# ---------------------------------------------------------------------------
+# #13125 review: the rotation fallback must not launder a NEWER failure.
+#
+# playbook_executor._write_fresh_log_file truncates this log at the start of
+# every run, so "empty" had two causes: the nightly rotation, and a run that
+# started and emitted nothing (systemd-run failing to exec, or output diverted
+# to the #12425 fallback path). Reading the rotation in the second case reports
+# the PREVIOUS run's clean verdict over a live failure — trading a daily false
+# alarm for a false negative on the very failure #12776 exists to catch.
+#
+# The run-start header removes the ambiguity: a started run always leaves a
+# line, so an empty live log means only "no run since the rotation".
+# ---------------------------------------------------------------------------
+
+_RUN_HEADER = "SELF-UPDATE RUN STARTED 2026-08-09T09:00:00+00:00\n"
+
+
+def test_a_started_run_that_emitted_nothing_is_degraded_not_laundered(tmp_path):
+    """The masking sequence, end to end: clean rotation, newer run that died
+    before any play. The verdict must describe the LIVE run, not the rotation."""
+    live = _write(tmp_path, _RUN_HEADER)
+    live.with_name(live.name + ".1").write_text(_COMPLETE, encoding="utf-8")
+
+    v = read_self_update_verdict(live)
+
+    assert v.from_rotated_log is False, "a started run must never fall back to the rotation"
+    assert v.log_present is True
+    assert v.complete is False
+    assert v.degraded is True
+    assert v.plays_seen == []
+
+
+def test_a_started_run_that_emitted_nothing_is_degraded_without_a_rotation(tmp_path):
+    """Same on a fresh node, where notifempty means no rotation exists yet —
+    the case that previously downgraded to "no self-update log yet"."""
+    v = read_self_update_verdict(_write(tmp_path, _RUN_HEADER))
+
+    assert v.log_present is True
+    assert v.degraded is True
+
+
+def test_the_header_does_not_disturb_a_normal_verdict(tmp_path):
+    """Real logs carry the header AND the run output."""
+    v = read_self_update_verdict(_write(tmp_path, _RUN_HEADER + _COMPLETE))
+
+    assert v.complete is True
+    assert v.degraded is False
+    assert v.plays_seen == ["Play 1 - Prepare", "Play 2 - Deploy app tier"]
+
+
+def test_the_executor_writes_the_header_the_reader_expects():
+    """Cross-module contract. Nothing else fails if these drift apart — the
+    reader would just treat every started run as an empty log again, silently
+    restoring the laundering this closes."""
+    reader_header = _load_reader()._RUN_HEADER
+
+    # Asserted on the source rather than by import: playbook_executor pulls in
+    # the ansible/inventory stack, which is exactly why the reader keeps its own
+    # copy of the string instead of importing it.
+    executor_src = (_BACKEND_ROOT / "services" / "playbook_executor.py").read_text(encoding="utf-8")
+    assert f'SELF_UPDATE_RUN_HEADER: str = "{reader_header}"' in executor_src
+    # …and that the constant is what actually gets written, not a stale literal.
+    assert "f\"{SELF_UPDATE_RUN_HEADER} {datetime.now(timezone.utc).isoformat()}" in executor_src

--- a/autobot-slm-backend/tests/services/test_self_update_log_reader.py
+++ b/autobot-slm-backend/tests/services/test_self_update_log_reader.py
@@ -324,4 +324,4 @@ def test_the_executor_writes_the_header_the_reader_expects():
     executor_src = (_BACKEND_ROOT / "services" / "playbook_executor.py").read_text(encoding="utf-8")
     assert f'SELF_UPDATE_RUN_HEADER: str = "{reader_header}"' in executor_src
     # …and that the constant is what actually gets written, not a stale literal.
-    assert "f\"{SELF_UPDATE_RUN_HEADER} {datetime.now(timezone.utc).isoformat()}" in executor_src
+    assert 'f"{SELF_UPDATE_RUN_HEADER} {datetime.now(timezone.utc).isoformat()}' in executor_src

--- a/autobot-slm-backend/tests/services/test_self_update_log_reader.py
+++ b/autobot-slm-backend/tests/services/test_self_update_log_reader.py
@@ -171,9 +171,87 @@ def test_large_log_is_read_from_the_tail(tmp_path):
 
 
 @pytest.mark.parametrize("empty", ["", "\n\n"])
-def test_empty_log_is_degraded(tmp_path, empty):
-    """An empty log means a run started and produced nothing — not a success."""
+def test_empty_log_with_no_rotation_is_not_degraded(tmp_path, empty):
+    """#13125: an empty log does NOT mean a run started and produced nothing.
+
+    logrotate truncates the live log to zero bytes daily (``copytruncate``, which
+    the append: units require), so from 01:00 until the next self-update the file
+    exists and is empty on every node. Read as "a run was cut short", that fired
+    daily on healthy deployments and was discounted as noise before the cause was
+    found — the expensive failure, because it trains operators to ignore the
+    whole class of alert.
+
+    With nothing in the rotation either, this is the same situation as no log at
+    all: nothing to say, which is explicitly not a failure.
+    """
     v = read_self_update_verdict(_write(tmp_path, empty))
 
+    assert v.log_present is False
+    assert v.degraded is False
+    assert v.reason == "no self-update log yet"
+
+
+def test_empty_log_falls_back_to_the_rotation(tmp_path):
+    """The last run's real verdict is sitting in the rotated file — read it.
+
+    Going silent for the rest of the day would trade a false alarm for a blind
+    spot; the point of the verdict is to be able to answer at any hour.
+    """
+    live = _write(tmp_path, "")
+    live.with_name(live.name + ".1").write_text(_COMPLETE, encoding="utf-8")
+
+    v = read_self_update_verdict(live)
+
     assert v.log_present is True
+    assert v.complete is True
+    assert v.degraded is False
+    assert v.from_rotated_log is True
+    assert "rotated log" in (v.reason or "")
+
+
+def test_rotation_is_only_consulted_when_the_live_log_is_empty(tmp_path):
+    """A live log with content wins — the rotation is older by definition."""
+    live = _write(tmp_path, _COMPLETE)
+    live.with_name(live.name + ".1").write_text(_TRUNCATED, encoding="utf-8")
+
+    v = read_self_update_verdict(live)
+
+    assert v.complete is True
+    assert v.from_rotated_log is False
+    assert "rotated log" not in (v.reason or "")
+
+
+def test_a_genuinely_incomplete_rotation_is_still_degraded(tmp_path):
+    """The fallback must not launder a failure into silence: if the last real
+    run died mid-play, that verdict survives the rotation."""
+    live = _write(tmp_path, "")
+    live.with_name(live.name + ".1").write_text(_TRUNCATED, encoding="utf-8")
+
+    v = read_self_update_verdict(live)
+
     assert v.degraded is True
+    assert v.from_rotated_log is True
+
+
+def test_missing_live_log_still_reads_a_rotation(tmp_path):
+    """copytruncate preserves the live file, but a hand-cleaned /var/log or a
+    different rotation mode can leave only the rotated copy."""
+    live = tmp_path / "self-update-ansible.log"
+    live.with_name(live.name + ".1").write_text(_COMPLETE, encoding="utf-8")
+
+    v = read_self_update_verdict(live)
+
+    assert v.log_present is True
+    assert v.complete is True
+    assert v.from_rotated_log is True
+
+
+def test_empty_rotation_is_not_used(tmp_path):
+    """An empty rotation is no more informative than an empty live log."""
+    live = _write(tmp_path, "")
+    live.with_name(live.name + ".1").write_text("\n\n", encoding="utf-8")
+
+    v = read_self_update_verdict(live)
+
+    assert v.log_present is False
+    assert v.degraded is False

--- a/autobot-slm-backend/tests/services/test_self_update_systemd_detach_11492.py
+++ b/autobot-slm-backend/tests/services/test_self_update_systemd_detach_11492.py
@@ -138,7 +138,12 @@ def test_prepare_self_update_log_file_creates_and_truncates(tmp_path):
         result = _pe.PlaybookExecutor._prepare_self_update_log_file()
 
     assert result == log_path
-    assert log_path.read_text(encoding="utf-8") == ""
+    # #13125: truncation means "the prior run's content is gone", not "byte
+    # empty" — the file now carries a run-start stamp so the completion verdict
+    # can tell a started run from a log logrotate emptied overnight.
+    written = log_path.read_text(encoding="utf-8")
+    assert "stale prior run content" not in written
+    assert written.startswith(_pe.SELF_UPDATE_RUN_HEADER)
     # Ansible output can contain sensitive paths/values — 0600, not the
     # world-readable default umask (#11492 hardening).
     assert oct(log_path.stat().st_mode & 0o777) == "0o600"
@@ -270,7 +275,8 @@ async def test_run_subprocess_wraps_file_backed_when_systemd_available(tmp_path)
     assert captured["kwargs"]["stdout"] == asyncio.subprocess.DEVNULL
     assert captured["kwargs"]["stderr"] == asyncio.subprocess.DEVNULL
     # The log file was truncated fresh for this run and locked to 0600.
-    assert log_path.read_text(encoding="utf-8") == ""
+    # #13125: "fresh" is the run-start stamp alone, not zero bytes.
+    assert log_path.read_text(encoding="utf-8").startswith(_pe.SELF_UPDATE_RUN_HEADER)
     assert oct(log_path.stat().st_mode & 0o777) == "0o600"
 
 
@@ -365,7 +371,7 @@ async def test_run_subprocess_still_detaches_via_fallback_log_path(tmp_path):
     assert captured["kwargs"]["stdout"] == asyncio.subprocess.DEVNULL
     assert captured["kwargs"]["stderr"] == asyncio.subprocess.DEVNULL
     # The fallback log file was actually created, truncated, and locked down.
-    assert fallback_log_path.read_text(encoding="utf-8") == ""
+    assert fallback_log_path.read_text(encoding="utf-8").startswith(_pe.SELF_UPDATE_RUN_HEADER)
     assert oct(fallback_log_path.stat().st_mode & 0o777) == "0o600"
 
 
@@ -377,7 +383,12 @@ def test_write_fresh_log_file_creates_truncates_and_chmods(tmp_path):
     result = _pe.PlaybookExecutor._write_fresh_log_file(log_path)
 
     assert result == log_path
-    assert log_path.read_text(encoding="utf-8") == ""
+    written = log_path.read_text(encoding="utf-8")
+    assert "stale prior run content" not in written, "a prior run must not replay as this one"
+    # #13125: truncation means "the prior run's content is gone", not "byte
+    # empty" — the file now carries a run-start stamp so the completion verdict
+    # can tell a started run from a log logrotate emptied overnight.
+    assert written.startswith(_pe.SELF_UPDATE_RUN_HEADER)
     assert oct(log_path.stat().st_mode & 0o777) == "0o600"
 
 


### PR DESCRIPTION
Refs #13125 · umbrella #13852 (Wave 1, class C — wrong signals)

Deliberately **not** `Closes` — this fixes the `copytruncate` finding in the issue's comments, while the
issue *body* covers the role-delivery detection half of #12959 and is untouched here. Closing on merge
would lose that half.

## Thinking Path

`GET /api/code-sync/status` reported `self_update_incomplete: true` — "the run was cut short; later plays did
not execute" — on a deployment whose last self-update finished normally. Running a fresh self-update
immediately afterwards returned `false`, with nothing changed except that a run had happened.

logrotate rotates `/var/log/autobot/*.log` daily with `copytruncate`, which the `append:` units require: it
copies the file aside and truncates the original to zero bytes. `read_self_update_verdict` distinguished
*missing* from *present* but not *present-but-empty*, so an empty file reached the parse path, found zero play
headers, and produced the failure verdict — daily, on every node, from 01:00 until the next run.

The damage is not the false alarm. It was **discounted as noise once before the cause was found**, which is
how a detector that cries wolf daily teaches everyone to ignore that entire class of alert.

Suppressing the empty case to "nothing to say" would fix the false positive and create a true negative: the
last run's real verdict is sitting in the rotation, and going blind until the next run is its own gap. So the
rotation is read instead.

**That fallback is only safe once "empty" means one thing.** The first attempt at this was wrong, and review
caught it: `_write_fresh_log_file` also truncates the log at the *start* of every run, so "empty" also covers
a run that started and emitted nothing — systemd-run failing to exec the transient unit, or output diverted to
the #12425 fallback path the verdict never reads. Reading the rotation there reports the previous run's clean
verdict over a live failure. The #12425 variant is the sharpest: the executor already logs "UPDATE-ALL
DEGRADED … silently leaving the co-located app tier stale" for exactly the state the endpoint would have
called complete.

So a started run now stamps itself.

## What Changed

- **`playbook_executor`** — a fresh self-update log is written with `SELF-UPDATE RUN STARTED <iso>` instead of
  zero bytes. "Empty" is now decidable: it can only mean "no run since the rotation".
- **`self_update_log_reader`** — an empty live log reads the most recent rotation (`.1`) rather than parsing as
  a cut-short run. A header-only log is a started run with no plays: degraded, which is correct — and is what
  the old `test_empty_log_is_degraded` was really protecting on a fresh node, where `notifempty` means no
  rotation exists to fall back to.
- **Freshness is stated, not implied.** `notifempty` stops logrotate rotating an already-empty log, so `.1`
  never ages into `.2.gz` on an idle node and can be weeks old. The reason names its mtime instead of letting
  "rotated away" imply yesterday.
- **`.1` only** — `delaycompress` makes the most recent rotation always uncompressed; anything older describes
  a run at least two rotations back.
- An **unreadable** log (a directory, EACCES) reported as "no self-update log yet", making a broken deployment
  look like a box that had never updated. It has its own reason again — path-free, since that string reaches
  an API response.

No schema change: `from_rotated_log` folds into the existing `self_update_detail`, so the API contract and
generated types are untouched, as #13125 requires.

## Verification

```
$ pytest tests/ -q            # autobot-slm-backend
1157 passed, 1 skipped, 16 warnings in 51.01s

$ pytest tests/services/test_self_update_log_reader.py -q
19 passed
```

New coverage for the masking sequence the review identified — clean rotation, newer run that died before any
play — asserting the verdict describes the **live** run and never falls back. Plus: the fallback and its
precedence, a genuinely incomplete rotation staying degraded, an empty rotation not being used, and the
cross-module header contract (nothing else fails if the two constants drift apart — the reader would silently
treat every started run as an empty log again).

Four `#11492` tests asserted the fresh log was byte-empty. Their intent is "the prior run's content cannot
replay as this one", so they now assert that directly plus the stamp, rather than being relaxed to fit.

Reviewed by `code-reviewer`, which found the laundering bug above; fixed in the second commit with the test
that was missing.

**Not verified on a live host.** The reasoning is from the logrotate stanza in this repo and the observed
symptom on #13125. A host check that `self_update_incomplete` is false after 01:00 with no run since would
close it properly.

## Model Used

Claude Opus 5 (1M context)
