### PR TITLE
fix(audit): findings reported as preserved in a dead-letter queue that never held them (#13570)

### DIFF
--- a/autobot-backend/workers/audit_tasks.py
+++ b/autobot-backend/workers/audit_tasks.py
@@ -169,7 +169,7 @@ def _gh_available() -> bool:
     identical to a healthy one, so there was no way to tell when filing broke or
     how much had been deferred since.
     """
-    code, _, err = _run(["gh", "auth", "status"])
+    code, out, err = _run(["gh", "auth", "status"])
     if code != 0:
         logger.critical(
             "audit worker cannot file issues: `gh auth status` failed for this "
@@ -177,7 +177,9 @@ def _gh_available() -> bool:
             "instead of filed. Fix: authenticate gh for the service account, or "
             "give the worker a GH_TOKEN. gh said: %s",
             _GH_REPO,
-            (err or "").strip()[:_MAX_LOG_CHARS] or "no stderr",
+            # stdout as well as stderr: gh routes this message to stderr today,
+            # but a build that changed that would gut the diagnostic silently.
+            ((err or "").strip() or (out or "").strip())[:_MAX_LOG_CHARS] or "no output",
         )
     return code == 0
 
@@ -205,10 +207,40 @@ def _file_issue(title: str, body: str, labels: str = _AUDIT_LABELS) -> bool:
     return True
 
 
-def _load_deferred(redis) -> list[dict]:
-    """Return the dead-letter queue of findings awaiting a retry."""
+def _load_deferred(redis) -> tuple[list[dict], bool]:
+    """Return (queued findings, read_was_observed) for the dead-letter queue.
+
+    #13570 review: a failed GET and an empty queue were indistinguishable, and
+    the caller then overwrote the key with whatever it had. A GET timing out
+    while the SET succeeds — or a value that is not a list — therefore WIPED the
+    queue, silently, and reported ``issues_deferred: 0`` as a success. Same
+    defect class as the incident this issue is about: acting on an outcome that
+    was never observed. Removing the TTL made it worse, because the key now
+    holds more.
+
+    ``read_was_observed`` is False when the queue could not be read; the caller
+    must not persist over a queue it could not see.
+    """
+    if redis is None:
+        return [], False
     queued = _redis_get(redis, _DEFERRED_FINDINGS_KEY)
-    return queued if isinstance(queued, list) else []
+    if queued is None:
+        # Genuinely absent (never written) reads the same as unreachable, so a
+        # missing key is checked explicitly before assuming the worst.
+        try:
+            if not redis.exists(_DEFERRED_FINDINGS_KEY):
+                return [], True
+        except Exception as exc:  # noqa: BLE001 - fall through to "unobserved"
+            logger.error("audit: cannot determine whether %s exists: %s", _DEFERRED_FINDINGS_KEY, exc)
+        return [], False
+    if not isinstance(queued, list):
+        logger.error(
+            "audit: %s holds a %s, not a list — refusing to overwrite it",
+            _DEFERRED_FINDINGS_KEY,
+            type(queued).__name__,
+        )
+        return [], False
+    return queued, True
 
 
 def _persist_deferred(redis, deferred: list[dict]) -> int:
@@ -236,23 +268,42 @@ def _persist_deferred(redis, deferred: list[dict]) -> int:
     # #13570: no TTL on the dead-letter queue. It carried the module's default
     # 14 days, so a filing credential that stayed broken for a fortnight — the
     # exact situation the queue exists for — silently expired everything in it.
-    # A queue whose whole purpose is "never lose a finding" must not have a
-    # clock on it.
+    # Note this does NOT make the key durable: every deployment runs
+    # maxmemory-policy allkeys-lru, which evicts untimed keys too. It removes a
+    # guaranteed fortnightly loss, not the possibility of loss.
     if not _redis_set(redis, _DEFERRED_FINDINGS_KEY, unique, ttl=None):
-        # The findings are about to be lost, so the log becomes the queue of
-        # last resort: dump them in full rather than report a count that
-        # implies they were stored somewhere retrievable.
-        logger.critical(
-            "audit: FAILED to persist %d deferred finding(s) to %s — they are NOT "
-            "queued and will not be retried. Redis is unavailable or the write was "
-            "rejected. Full findings follow so they are recoverable from this log: %s",
-            len(unique),
-            _DEFERRED_FINDINGS_KEY,
-            json.dumps(unique, default=str)[:_MAX_DEFERRED_LOG_CHARS],
-        )
+        _log_unwritable_queue(unique, "Redis is unavailable or the write was rejected")
         return 0
 
     return len(unique)
+
+
+def _log_unwritable_queue(findings: list[dict], why: str) -> None:
+    """Dump findings that could not be queued, so the log is the queue (#13570).
+
+    A bare count would leave nothing recoverable. Emits nothing when there is
+    nothing to lose — an empty write is the normal drain path, and paging
+    someone about zero lost findings is its own false alarm.
+    """
+    if not findings:
+        return
+    dump = json.dumps(findings, default=str)
+    truncated = ""
+    if len(dump) > _MAX_DEFERRED_LOG_CHARS:
+        # Say so explicitly: a message promising "full findings" that silently
+        # cuts off mid-JSON is the same lie this issue is about.
+        truncated = f" [TRUNCATED at {_MAX_DEFERRED_LOG_CHARS} chars — not all of the {len(findings)} shown]"
+        dump = dump[:_MAX_DEFERRED_LOG_CHARS]
+    logger.critical(
+        "audit: FAILED to persist %d deferred finding(s) to %s — they are NOT queued "
+        "and will not be retried (%s). Findings follow so they are recoverable from "
+        "this log%s: %s",
+        len(findings),
+        _DEFERRED_FINDINGS_KEY,
+        why,
+        truncated,
+        dump,
+    )
 
 
 def _dedupe_and_file(
@@ -273,7 +324,7 @@ def _dedupe_and_file(
     non-duplicate finding drawn from both the queue and *findings*.
     """
     gh_ok = _gh_available()
-    pending = _load_deferred(redis)
+    pending, queue_readable = _load_deferred(redis)
 
     filed = 0
     still_deferred: list[dict] = []
@@ -299,29 +350,38 @@ def _dedupe_and_file(
     # when the queue was empty — `LLEN audit:deferred_findings` was 0 on a host
     # whose logs claimed findings were preserved. A message about preservation
     # must be emitted only by the code path that observed it succeed.
-    deferred_count = _persist_deferred(redis, still_deferred)
+    if queue_readable:
+        deferred_count = _persist_deferred(redis, still_deferred)
+    else:
+        deferred_count = 0
+        _log_unwritable_queue(still_deferred, "the existing queue could not be read")
 
-    if not gh_ok and still_deferred:
-        if deferred_count:
-            logger.critical(
-                "gh CLI unauthenticated — %d audit finding(s) queued to the Redis "
-                "dead-letter queue (%s) instead of being filed or lost. Configure a "
-                "GH_TOKEN for the worker to restore issue filing; queued findings "
-                "are retried automatically once it is available.",
-                deferred_count,
-                _DEFERRED_FINDINGS_KEY,
-            )
-        else:
-            # _persist_deferred has already dumped the findings; this names the
-            # consequence so the two failures are not read as one bad Redis blip.
-            logger.critical(
-                "gh CLI unauthenticated AND the dead-letter queue could not be "
-                "written — %d audit finding(s) are LOST except for the dump above. "
-                "Both the filing credential and Redis need attention.",
-                len(still_deferred),
-            )
-
+    _report_deferral_outcome(gh_ok, still_deferred, deferred_count)
     return filed, deferred_count
+
+
+def _report_deferral_outcome(gh_ok: bool, still_deferred: list[dict], deferred_count: int) -> None:
+    """Say what actually happened to unfileable findings (#13570)."""
+    if gh_ok or not still_deferred:
+        return
+    if deferred_count:
+        logger.critical(
+            "gh CLI unauthenticated — %d audit finding(s) queued to the Redis "
+            "dead-letter queue (%s) instead of being filed or lost. Configure a "
+            "GH_TOKEN for the worker to restore issue filing; queued findings "
+            "are retried automatically once it is available.",
+            deferred_count,
+            _DEFERRED_FINDINGS_KEY,
+        )
+        return
+    # The findings have already been dumped; this names the consequence so the
+    # two failures are not read as one bad Redis blip.
+    logger.critical(
+        "gh CLI unauthenticated AND the dead-letter queue could not be written — "
+        "%d audit finding(s) are LOST except for the dump above. Both the filing "
+        "credential and Redis need attention.",
+        len(still_deferred),
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/workers/audit_tasks.py
+++ b/autobot-backend/workers/audit_tasks.py
@@ -57,6 +57,12 @@ _AUDIT_LABELS = "enhancement,observability,priority: medium"
 # Max characters of gh output kept in logs on failure
 _MAX_LOG_CHARS = 500
 
+# Cap on the full-findings dump written when the dead-letter queue itself cannot
+# be persisted (#13570). Generous: at that point the log IS the queue, and a
+# truncated finding is still better than none — but an unbounded dump could
+# itself take out the log.
+_MAX_DEFERRED_LOG_CHARS = 100_000
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -84,14 +90,25 @@ def _redis_get(redis, key: str) -> Any | None:
         return None
 
 
-def _redis_set(redis, key: str, value: Any, ttl: int = 86400 * 14) -> None:
-    """Persist JSON-serialisable value in Redis with a 14-day TTL."""
+def _redis_set(redis, key: str, value: Any, ttl: int | None = 86400 * 14) -> bool:
+    """Persist a JSON-serialisable value in Redis. Returns True when it landed.
+
+    #13570: this used to swallow every failure and return None, so a caller had
+    no way to tell a successful write from a no-op. The dead-letter queue then
+    reported findings as "deferred ... instead of being filed or lost" while
+    nothing had been stored — a reassuring message about preservation that did
+    not happen, which is worse than an error.
+
+    ``ttl=None`` stores the key without expiry.
+    """
     if redis is None:
-        return
+        return False
     try:
         redis.set(key, json.dumps(value, default=str), ex=ttl)
-    except Exception:
-        pass
+        return True
+    except Exception as exc:  # noqa: BLE001 - a telemetry write must not kill the task
+        logger.error("audit: Redis write to %s failed: %s", key, exc)
+        return False
 
 
 def _run(cmd: list[str], cwd: str | None = None) -> tuple[int, str, str]:
@@ -145,8 +162,23 @@ def _gh_available() -> bool:
 
     Checked once per task run so a missing credential produces a single CRITICAL
     log instead of one ERROR per lost finding (#12319).
+
+    #13570: reported unconditionally, not only when there are findings to lose.
+    The credential lapsed for the service account and the first symptom was a
+    run that happened to produce findings — every clean run in between looked
+    identical to a healthy one, so there was no way to tell when filing broke or
+    how much had been deferred since.
     """
-    code, _, _ = _run(["gh", "auth", "status"])
+    code, _, err = _run(["gh", "auth", "status"])
+    if code != 0:
+        logger.critical(
+            "audit worker cannot file issues: `gh auth status` failed for this "
+            "service account (%s). Every finding this run produces will be queued "
+            "instead of filed. Fix: authenticate gh for the service account, or "
+            "give the worker a GH_TOKEN. gh said: %s",
+            _GH_REPO,
+            (err or "").strip()[:_MAX_LOG_CHARS] or "no stderr",
+        )
     return code == 0
 
 
@@ -201,7 +233,25 @@ def _persist_deferred(redis, deferred: list[dict]) -> int:
             [f["title"] for f in dropped],
         )
 
-    _redis_set(redis, _DEFERRED_FINDINGS_KEY, unique)
+    # #13570: no TTL on the dead-letter queue. It carried the module's default
+    # 14 days, so a filing credential that stayed broken for a fortnight — the
+    # exact situation the queue exists for — silently expired everything in it.
+    # A queue whose whole purpose is "never lose a finding" must not have a
+    # clock on it.
+    if not _redis_set(redis, _DEFERRED_FINDINGS_KEY, unique, ttl=None):
+        # The findings are about to be lost, so the log becomes the queue of
+        # last resort: dump them in full rather than report a count that
+        # implies they were stored somewhere retrievable.
+        logger.critical(
+            "audit: FAILED to persist %d deferred finding(s) to %s — they are NOT "
+            "queued and will not be retried. Redis is unavailable or the write was "
+            "rejected. Full findings follow so they are recoverable from this log: %s",
+            len(unique),
+            _DEFERRED_FINDINGS_KEY,
+            json.dumps(unique, default=str)[:_MAX_DEFERRED_LOG_CHARS],
+        )
+        return 0
+
     return len(unique)
 
 
@@ -243,17 +293,34 @@ def _dedupe_and_file(
     for finding in findings:
         _attempt(finding["title"], finding["body"], label)
 
-    if not gh_ok and still_deferred:
-        logger.critical(
-            "gh CLI unauthenticated — %d audit finding(s) deferred to the Redis "
-            "dead-letter queue (%s) instead of being filed or lost. Configure a "
-            "GH_TOKEN for the worker to restore issue filing; deferred findings "
-            "are retried automatically once it is available.",
-            len(still_deferred),
-            _DEFERRED_FINDINGS_KEY,
-        )
-
+    # #13570: persist FIRST, then report what actually happened. The old order
+    # logged "deferred to the Redis dead-letter queue instead of being filed or
+    # lost" before the write was attempted, so the reassuring message stood even
+    # when the queue was empty — `LLEN audit:deferred_findings` was 0 on a host
+    # whose logs claimed findings were preserved. A message about preservation
+    # must be emitted only by the code path that observed it succeed.
     deferred_count = _persist_deferred(redis, still_deferred)
+
+    if not gh_ok and still_deferred:
+        if deferred_count:
+            logger.critical(
+                "gh CLI unauthenticated — %d audit finding(s) queued to the Redis "
+                "dead-letter queue (%s) instead of being filed or lost. Configure a "
+                "GH_TOKEN for the worker to restore issue filing; queued findings "
+                "are retried automatically once it is available.",
+                deferred_count,
+                _DEFERRED_FINDINGS_KEY,
+            )
+        else:
+            # _persist_deferred has already dumped the findings; this names the
+            # consequence so the two failures are not read as one bad Redis blip.
+            logger.critical(
+                "gh CLI unauthenticated AND the dead-letter queue could not be "
+                "written — %d audit finding(s) are LOST except for the dump above. "
+                "Both the filing credential and Redis need attention.",
+                len(still_deferred),
+            )
+
     return filed, deferred_count
 
 

--- a/autobot-backend/workers/audit_tasks_test.py
+++ b/autobot-backend/workers/audit_tasks_test.py
@@ -8,6 +8,7 @@ Focus: the dedupe-against-existing-issues logic must not spam GitHub with
 duplicate issues when an audit task runs multiple times without new findings.
 """
 
+import logging
 from unittest.mock import MagicMock, patch
 
 from workers.audit_tasks import (
@@ -15,6 +16,7 @@ from workers.audit_tasks import (
     _dead_code_fingerprint,
     _dedupe_and_file,
     _find_test_file,
+    _gh_available,
     _persist_deferred,
     audit_claims,
     audit_dead_code,
@@ -96,15 +98,27 @@ class TestDedupeAndFile:
 # ---------------------------------------------------------------------------
 
 
-def _fake_redis_backing():
-    """Return (store, get_fn, set_fn) emulating the JSON Redis helpers."""
+def _fake_redis_backing(writes_succeed: bool = True):
+    """Return (store, get_fn, set_fn) emulating the JSON Redis helpers.
+
+    #13570: ``_redis_set`` returns True only when the write actually landed, so
+    the fake must too. Returning None here — as it used to — made every test
+    below run against a queue that silently accepted nothing, which is precisely
+    the production bug they were supposed to rule out.
+
+    ``writes_succeed=False`` models an unavailable Redis: the store stays empty
+    and the helper reports failure.
+    """
     store: dict = {}
 
     def _get(_redis, key):
         return store.get(key)
 
     def _set(_redis, key, value, **_kw):
+        if not writes_succeed:
+            return False
         store[key] = value
+        return True
 
     return store, _get, _set
 
@@ -490,3 +504,130 @@ class TestAuditClaims:
 
         assert "docs/verification.md" not in sources
         assert "docs/guide.md" in sources
+
+
+class TestDeferralIsObservedNotAssumed:
+    """#13570: the queue reported findings it never held.
+
+    On a live host the worker logged CRITICAL "N audit finding(s) deferred to
+    the Redis dead-letter queue (audit:deferred_findings) instead of being
+    filed" while `LLEN audit:deferred_findings` was 0 and no `audit:deferred*`
+    key existed at all. The message is the dangerous part: it reads as a safe
+    fallback and states the findings were preserved when they were not, so
+    nobody goes looking. Every automated audit since the credential lapsed
+    produced nothing, silently.
+
+    Root cause: `_redis_set` swallowed every failure and `_persist_deferred`
+    returned the count it *intended* to store.
+    """
+
+    def test_failed_persist_reports_zero_not_the_intended_count(self):
+        """The count must describe what landed, not what was handed over."""
+        _store, _get, _set = _fake_redis_backing(writes_succeed=False)
+        deferred = [{"title": "discovery: gone", "body": "b", "label": "l"}]
+
+        with patch("workers.audit_tasks._redis_set", side_effect=_set):
+            size = _persist_deferred(object(), deferred)
+
+        assert size == 0, "a queue that stored nothing must not report a queue depth"
+
+    def test_failed_persist_dumps_the_findings_to_the_log(self, caplog):
+        """When the queue cannot hold them, the log is the queue of last resort —
+        a bare count would leave nothing recoverable."""
+        _store, _get, _set = _fake_redis_backing(writes_succeed=False)
+        deferred = [{"title": "discovery: recover me", "body": "important detail", "label": "l"}]
+
+        with patch("workers.audit_tasks._redis_set", side_effect=_set):
+            with caplog.at_level(logging.CRITICAL, logger="workers.audit_tasks"):
+                _persist_deferred(object(), deferred)
+
+        dumped = caplog.text
+        assert "discovery: recover me" in dumped
+        assert "important detail" in dumped
+        assert "NOT" in dumped, "the log must say the findings were not queued"
+
+    def test_no_redis_client_is_a_failed_persist_not_a_silent_success(self):
+        """`_get_redis()` returns None whenever the client cannot be built, and
+        that path reported success — the shape that produced an empty queue
+        alongside a reassuring log line."""
+        assert _persist_deferred(None, [{"title": "t", "body": "b", "label": "l"}]) == 0
+
+    def test_unauthenticated_and_unqueueable_says_lost_not_deferred(self, caplog):
+        """Both failures at once must not read as the benign one."""
+        _store, _get, _set = _fake_redis_backing(writes_succeed=False)
+        findings = [{"title": "discovery: double fault", "body": "b"}]
+
+        with (
+            patch("workers.audit_tasks._gh_available", return_value=False),
+            patch("workers.audit_tasks._redis_get", side_effect=_get),
+            patch("workers.audit_tasks._redis_set", side_effect=_set),
+            patch("workers.audit_tasks._file_issue"),
+        ):
+            with caplog.at_level(logging.CRITICAL, logger="workers.audit_tasks"):
+                filed, deferred = _dedupe_and_file(findings, set(), "enh", object())
+
+        assert (filed, deferred) == (0, 0)
+        assert "LOST" in caplog.text
+        assert "instead of being filed or lost" not in caplog.text, (
+            "the reassuring deferral message must not be emitted when nothing was queued"
+        )
+
+    def test_successful_deferral_still_reports_the_reassuring_message(self, caplog):
+        """The fix must not turn a working fallback into an alarm."""
+        store, _get, _set = _fake_redis_backing()
+        findings = [{"title": "discovery: safely queued", "body": "b"}]
+
+        with (
+            patch("workers.audit_tasks._gh_available", return_value=False),
+            patch("workers.audit_tasks._redis_get", side_effect=_get),
+            patch("workers.audit_tasks._redis_set", side_effect=_set),
+            patch("workers.audit_tasks._file_issue"),
+        ):
+            with caplog.at_level(logging.CRITICAL, logger="workers.audit_tasks"):
+                filed, deferred = _dedupe_and_file(findings, set(), "enh", object())
+
+        assert (filed, deferred) == (0, 1)
+        assert "LOST" not in caplog.text
+        assert [f["title"] for f in store[_DEFERRED_FINDINGS_KEY]] == ["discovery: safely queued"]
+
+    def test_the_queue_is_stored_without_a_ttl(self):
+        """The queue carried the module's default 14-day TTL, so a credential
+        broken for a fortnight — the exact case it exists for — expired
+        everything in it."""
+        seen: dict = {}
+
+        def _set(_redis, key, value, **kwargs):
+            seen[key] = kwargs
+            return True
+
+        with patch("workers.audit_tasks._redis_set", side_effect=_set):
+            _persist_deferred(object(), [{"title": "t", "body": "b", "label": "l"}])
+
+        assert seen[_DEFERRED_FINDINGS_KEY]["ttl"] is None
+
+
+class TestMissingCredentialIsReportedEveryRun:
+    """#13570: there was no way to tell when filing broke.
+
+    `_gh_available` was silent, so a run with no findings looked identical to a
+    healthy one and the lapse only surfaced when an audit happened to produce
+    something. The log now names the failure on every run.
+    """
+
+    def test_unauthenticated_gh_logs_critical_even_with_no_findings(self, caplog):
+        with patch(
+            "workers.audit_tasks._run",
+            return_value=(1, "", "You are not logged into any GitHub hosts."),
+        ):
+            with caplog.at_level(logging.CRITICAL, logger="workers.audit_tasks"):
+                assert _gh_available() is False
+
+        assert "cannot file issues" in caplog.text
+        assert "not logged into any GitHub hosts" in caplog.text
+
+    def test_authenticated_gh_is_quiet(self, caplog):
+        with patch("workers.audit_tasks._run", return_value=(0, "Logged in", "")):
+            with caplog.at_level(logging.CRITICAL, logger="workers.audit_tasks"):
+                assert _gh_available() is True
+
+        assert caplog.text == ""

--- a/autobot-backend/workers/audit_tasks_test.py
+++ b/autobot-backend/workers/audit_tasks_test.py
@@ -568,9 +568,9 @@ class TestDeferralIsObservedNotAssumed:
 
         assert (filed, deferred) == (0, 0)
         assert "LOST" in caplog.text
-        assert "instead of being filed or lost" not in caplog.text, (
-            "the reassuring deferral message must not be emitted when nothing was queued"
-        )
+        assert (
+            "instead of being filed or lost" not in caplog.text
+        ), "the reassuring deferral message must not be emitted when nothing was queued"
 
     def test_successful_deferral_still_reports_the_reassuring_message(self, caplog):
         """The fix must not turn a working fallback into an alarm."""

--- a/autobot-backend/workers/audit_tasks_test.py
+++ b/autobot-backend/workers/audit_tasks_test.py
@@ -13,11 +13,13 @@ from unittest.mock import MagicMock, patch
 
 from workers.audit_tasks import (
     _DEFERRED_FINDINGS_KEY,
+    _TESTGAPS_LAST_RUN_KEY,
     _dead_code_fingerprint,
     _dedupe_and_file,
     _find_test_file,
     _gh_available,
     _persist_deferred,
+    _redis_set,
     audit_claims,
     audit_dead_code,
     audit_testgaps,
@@ -37,7 +39,7 @@ class TestDedupeAndFile:
         ]
         with (
             patch("workers.audit_tasks._gh_available", return_value=True),
-            patch("workers.audit_tasks._load_deferred", return_value=[]),
+            patch("workers.audit_tasks._load_deferred", return_value=([], True)),
             patch("workers.audit_tasks._persist_deferred", return_value=0),
             patch("workers.audit_tasks._file_issue", return_value=True) as mock_file,
         ):
@@ -54,7 +56,7 @@ class TestDedupeAndFile:
         ]
         with (
             patch("workers.audit_tasks._gh_available", return_value=True),
-            patch("workers.audit_tasks._load_deferred", return_value=[]),
+            patch("workers.audit_tasks._load_deferred", return_value=([], True)),
             patch("workers.audit_tasks._persist_deferred", return_value=0),
             patch("workers.audit_tasks._file_issue") as mock_file,
         ):
@@ -71,7 +73,7 @@ class TestDedupeAndFile:
         ]
         with (
             patch("workers.audit_tasks._gh_available", return_value=True),
-            patch("workers.audit_tasks._load_deferred", return_value=[]),
+            patch("workers.audit_tasks._load_deferred", return_value=([], True)),
             patch("workers.audit_tasks._persist_deferred", return_value=0),
             patch("workers.audit_tasks._file_issue", return_value=True),
         ):
@@ -82,7 +84,7 @@ class TestDedupeAndFile:
     def test_zero_findings_files_nothing(self):
         with (
             patch("workers.audit_tasks._gh_available", return_value=True),
-            patch("workers.audit_tasks._load_deferred", return_value=[]),
+            patch("workers.audit_tasks._load_deferred", return_value=([], True)),
             patch("workers.audit_tasks._persist_deferred", return_value=0),
             patch("workers.audit_tasks._file_issue") as mock_file,
         ):
@@ -120,13 +122,19 @@ def _fake_redis_backing(writes_succeed: bool = True):
         store[key] = value
         return True
 
-    return store, _get, _set
+    # #13570 review: _load_deferred probes `exists` to distinguish "the queue is
+    # genuinely absent" from "the queue could not be read" — a distinction the
+    # code needs before it may overwrite the key, so the fake must model it.
+    client = MagicMock()
+    client.exists.side_effect = lambda key: 1 if key in store else 0
+
+    return store, _get, _set, client
 
 
 class TestNoDropGuarantee:
     def test_unfileable_finding_is_deferred_not_dropped(self):
         """gh unauthenticated → finding lands in the dead-letter queue, not /dev/null."""
-        store, _get, _set = _fake_redis_backing()
+        store, _get, _set, client = _fake_redis_backing()
         findings = [{"title": "discovery: lost me", "body": "body"}]
 
         with (
@@ -135,7 +143,7 @@ class TestNoDropGuarantee:
             patch("workers.audit_tasks._redis_set", side_effect=_set),
             patch("workers.audit_tasks._file_issue") as mock_file,
         ):
-            filed, deferred = _dedupe_and_file(findings, set(), "enhancement", object())
+            filed, deferred = _dedupe_and_file(findings, set(), "enhancement", client)
 
         assert filed == 0
         assert deferred == 1
@@ -145,7 +153,7 @@ class TestNoDropGuarantee:
 
     def test_file_failure_defers_finding(self):
         """gh authenticated but the create call fails → finding is still preserved."""
-        store, _get, _set = _fake_redis_backing()
+        store, _get, _set, client = _fake_redis_backing()
         findings = [{"title": "discovery: flaky", "body": "body"}]
 
         with (
@@ -154,14 +162,14 @@ class TestNoDropGuarantee:
             patch("workers.audit_tasks._redis_set", side_effect=_set),
             patch("workers.audit_tasks._file_issue", return_value=False),
         ):
-            filed, deferred = _dedupe_and_file(findings, set(), "enhancement", object())
+            filed, deferred = _dedupe_and_file(findings, set(), "enhancement", client)
 
         assert (filed, deferred) == (0, 1)
         assert store[_DEFERRED_FINDINGS_KEY][0]["title"] == "discovery: flaky"
 
     def test_processed_plus_deferred_equals_input(self):
         """Every non-duplicate finding is accounted for: filed + deferred == input."""
-        store, _get, _set = _fake_redis_backing()
+        store, _get, _set, client = _fake_redis_backing()
         findings = [{"title": f"discovery: {i}", "body": "b"} for i in range(5)]
 
         # Fail filing for odd indices, succeed for even.
@@ -174,14 +182,14 @@ class TestNoDropGuarantee:
             patch("workers.audit_tasks._redis_set", side_effect=_set),
             patch("workers.audit_tasks._file_issue", side_effect=_file),
         ):
-            filed, deferred = _dedupe_and_file(findings, set(), "enhancement", object())
+            filed, deferred = _dedupe_and_file(findings, set(), "enhancement", client)
 
         assert filed + deferred == len(findings)
         assert (filed, deferred) == (3, 2)
 
     def test_deferred_findings_retried_and_drained_when_gh_recovers(self):
         """Once gh is available again, queued findings file and leave the queue."""
-        store, _get, _set = _fake_redis_backing()
+        store, _get, _set, client = _fake_redis_backing()
 
         # Run 1: gh down — finding is deferred.
         with (
@@ -190,7 +198,7 @@ class TestNoDropGuarantee:
             patch("workers.audit_tasks._redis_set", side_effect=_set),
             patch("workers.audit_tasks._file_issue"),
         ):
-            _dedupe_and_file([{"title": "discovery: retry me", "body": "b"}], set(), "enh", object())
+            _dedupe_and_file([{"title": "discovery: retry me", "body": "b"}], set(), "enh", client)
         assert len(store[_DEFERRED_FINDINGS_KEY]) == 1
 
         # Run 2: gh restored, no new findings — the queued one is filed and drained.
@@ -204,33 +212,33 @@ class TestNoDropGuarantee:
                 side_effect=lambda t, b, lbl: filed_titles.append(t) or True,
             ),
         ):
-            filed, deferred = _dedupe_and_file([], set(), "enh", object())
+            filed, deferred = _dedupe_and_file([], set(), "enh", client)
 
         assert filed_titles == ["discovery: retry me"]
         assert (filed, deferred) == (1, 0)
         assert store[_DEFERRED_FINDINGS_KEY] == []
 
     def test_persist_deferred_dedupes_by_title(self):
-        store, _get, _set = _fake_redis_backing()
+        store, _get, _set, client = _fake_redis_backing()
         deferred = [
             {"title": "dup", "body": "a", "label": "l"},
             {"title": "dup", "body": "b", "label": "l"},
             {"title": "uniq", "body": "c", "label": "l"},
         ]
         with patch("workers.audit_tasks._redis_set", side_effect=_set):
-            size = _persist_deferred(object(), deferred)
+            size = _persist_deferred(client, deferred)
         assert size == 2
 
     def test_persist_deferred_cap_logs_dropped_titles(self):
         """Overflow sheds the oldest findings and logs their exact titles — no silent loss."""
-        store, _get, _set = _fake_redis_backing()
+        store, _get, _set, client = _fake_redis_backing()
         deferred = [{"title": f"t{i}", "body": "b", "label": "l"} for i in range(12)]
         with (
             patch("workers.audit_tasks._MAX_DEFERRED", 10),
             patch("workers.audit_tasks._redis_set", side_effect=_set),
             patch("workers.audit_tasks.logger.error") as mock_err,
         ):
-            size = _persist_deferred(object(), deferred)
+            size = _persist_deferred(client, deferred)
         assert size == 10
         mock_err.assert_called_once()
         dropped_arg = mock_err.call_args.args[-1]
@@ -523,23 +531,23 @@ class TestDeferralIsObservedNotAssumed:
 
     def test_failed_persist_reports_zero_not_the_intended_count(self):
         """The count must describe what landed, not what was handed over."""
-        _store, _get, _set = _fake_redis_backing(writes_succeed=False)
+        _store, _get, _set, client = _fake_redis_backing(writes_succeed=False)
         deferred = [{"title": "discovery: gone", "body": "b", "label": "l"}]
 
         with patch("workers.audit_tasks._redis_set", side_effect=_set):
-            size = _persist_deferred(object(), deferred)
+            size = _persist_deferred(client, deferred)
 
         assert size == 0, "a queue that stored nothing must not report a queue depth"
 
     def test_failed_persist_dumps_the_findings_to_the_log(self, caplog):
         """When the queue cannot hold them, the log is the queue of last resort —
         a bare count would leave nothing recoverable."""
-        _store, _get, _set = _fake_redis_backing(writes_succeed=False)
+        _store, _get, _set, client = _fake_redis_backing(writes_succeed=False)
         deferred = [{"title": "discovery: recover me", "body": "important detail", "label": "l"}]
 
         with patch("workers.audit_tasks._redis_set", side_effect=_set):
             with caplog.at_level(logging.CRITICAL, logger="workers.audit_tasks"):
-                _persist_deferred(object(), deferred)
+                _persist_deferred(client, deferred)
 
         dumped = caplog.text
         assert "discovery: recover me" in dumped
@@ -554,7 +562,7 @@ class TestDeferralIsObservedNotAssumed:
 
     def test_unauthenticated_and_unqueueable_says_lost_not_deferred(self, caplog):
         """Both failures at once must not read as the benign one."""
-        _store, _get, _set = _fake_redis_backing(writes_succeed=False)
+        _store, _get, _set, client = _fake_redis_backing(writes_succeed=False)
         findings = [{"title": "discovery: double fault", "body": "b"}]
 
         with (
@@ -564,7 +572,7 @@ class TestDeferralIsObservedNotAssumed:
             patch("workers.audit_tasks._file_issue"),
         ):
             with caplog.at_level(logging.CRITICAL, logger="workers.audit_tasks"):
-                filed, deferred = _dedupe_and_file(findings, set(), "enh", object())
+                filed, deferred = _dedupe_and_file(findings, set(), "enh", client)
 
         assert (filed, deferred) == (0, 0)
         assert "LOST" in caplog.text
@@ -574,7 +582,7 @@ class TestDeferralIsObservedNotAssumed:
 
     def test_successful_deferral_still_reports_the_reassuring_message(self, caplog):
         """The fix must not turn a working fallback into an alarm."""
-        store, _get, _set = _fake_redis_backing()
+        store, _get, _set, client = _fake_redis_backing()
         findings = [{"title": "discovery: safely queued", "body": "b"}]
 
         with (
@@ -584,7 +592,7 @@ class TestDeferralIsObservedNotAssumed:
             patch("workers.audit_tasks._file_issue"),
         ):
             with caplog.at_level(logging.CRITICAL, logger="workers.audit_tasks"):
-                filed, deferred = _dedupe_and_file(findings, set(), "enh", object())
+                filed, deferred = _dedupe_and_file(findings, set(), "enh", client)
 
         assert (filed, deferred) == (0, 1)
         assert "LOST" not in caplog.text
@@ -631,3 +639,166 @@ class TestMissingCredentialIsReportedEveryRun:
                 assert _gh_available() is True
 
         assert caplog.text == ""
+
+
+class TestQueueIsNeverOverwrittenUnread:
+    """#13570 review: a failed READ wiped the queue, silently.
+
+    `_redis_get` returns None for every failure mode and `_load_deferred`
+    collapsed that into `[]`, so a GET that timed out was indistinguishable from
+    an empty queue — and the unconditional persist that followed overwrote the
+    key with `[]`. Same defect class as the incident itself: acting on, and
+    reporting, an outcome that was never observed. Removing the TTL made it
+    worse, because the key now holds more.
+    """
+
+    def test_unreadable_queue_is_not_overwritten(self):
+        """The 3-findings-become-zero case, end to end."""
+        store, _get, _set, client = _fake_redis_backing()
+        store[_DEFERRED_FINDINGS_KEY] = [
+            {"title": f"discovery: queued {i}", "body": "b", "label": "l"} for i in range(3)
+        ]
+
+        with (
+            patch("workers.audit_tasks._gh_available", return_value=True),
+            # GET fails while SET would succeed: a single-command timeout.
+            patch("workers.audit_tasks._redis_get", return_value=None),
+            patch("workers.audit_tasks._redis_set", side_effect=_set),
+            patch("workers.audit_tasks._file_issue", return_value=True),
+        ):
+            _dedupe_and_file([], set(), "enh", client)
+
+        assert len(store[_DEFERRED_FINDINGS_KEY]) == 3, "an unread queue must survive the run"
+
+    def test_unreadable_queue_reports_zero_and_says_why(self, caplog):
+        """Not just preserved — the run must not claim a clean deferral either."""
+        store, _get, _set, client = _fake_redis_backing()
+        store[_DEFERRED_FINDINGS_KEY] = [{"title": "discovery: queued", "body": "b", "label": "l"}]
+
+        with (
+            patch("workers.audit_tasks._gh_available", return_value=False),
+            patch("workers.audit_tasks._redis_get", return_value=None),
+            patch("workers.audit_tasks._redis_set", side_effect=_set),
+            patch("workers.audit_tasks._file_issue"),
+        ):
+            with caplog.at_level(logging.CRITICAL, logger="workers.audit_tasks"):
+                filed, deferred = _dedupe_and_file([{"title": "discovery: new", "body": "b"}], set(), "enh", client)
+
+        assert (filed, deferred) == (0, 0)
+        assert "could not be read" in caplog.text
+        assert "discovery: new" in caplog.text, "the new finding must still reach the log"
+
+    def test_absent_queue_is_readable_not_unobserved(self):
+        """A key that has genuinely never been written must NOT block persistence
+        — otherwise the first ever deferral could never be stored."""
+        store, _get, _set, client = _fake_redis_backing()
+        assert _DEFERRED_FINDINGS_KEY not in store
+
+        with (
+            patch("workers.audit_tasks._gh_available", return_value=False),
+            patch("workers.audit_tasks._redis_get", side_effect=_get),
+            patch("workers.audit_tasks._redis_set", side_effect=_set),
+            patch("workers.audit_tasks._file_issue"),
+        ):
+            filed, deferred = _dedupe_and_file([{"title": "discovery: first", "body": "b"}], set(), "e", client)
+
+        assert (filed, deferred) == (0, 1)
+        assert [f["title"] for f in store[_DEFERRED_FINDINGS_KEY]] == ["discovery: first"]
+
+    def test_wrong_type_at_the_key_is_not_overwritten(self):
+        """A non-list value is someone else's data or corruption — either way,
+        clobbering it loses whatever it was."""
+        store, _get, _set, client = _fake_redis_backing()
+        store[_DEFERRED_FINDINGS_KEY] = {"not": "a list"}
+
+        with (
+            patch("workers.audit_tasks._gh_available", return_value=False),
+            patch("workers.audit_tasks._redis_get", side_effect=_get),
+            patch("workers.audit_tasks._redis_set", side_effect=_set),
+            patch("workers.audit_tasks._file_issue"),
+        ):
+            _dedupe_and_file([{"title": "discovery: x", "body": "b"}], set(), "e", client)
+
+        assert store[_DEFERRED_FINDINGS_KEY] == {"not": "a list"}
+
+    def test_empty_write_does_not_page_about_zero_lost_findings(self, caplog):
+        """The normal drain path writes an empty queue. A loss alarm there is
+        its own false alarm — the thing this issue is about."""
+        _store, _get, _set, client = _fake_redis_backing(writes_succeed=False)
+
+        with patch("workers.audit_tasks._redis_set", side_effect=_set):
+            with caplog.at_level(logging.CRITICAL, logger="workers.audit_tasks"):
+                assert _persist_deferred(client, []) == 0
+
+        assert caplog.text == ""
+
+
+class TestRedisSetContract:
+    """#13570 review: the changed helper had no direct test.
+
+    Replacing its whole body with `return True` killed only one assertion, and
+    mutating it to re-apply the 14-day expiry left the suite green — so the
+    headline "the queue no longer expires" claim was untested at the layer that
+    implements it.
+    """
+
+    def test_ttl_none_is_passed_through_as_no_expiry(self):
+        client = MagicMock()
+
+        assert _redis_set(client, "k", {"a": 1}, ttl=None) is True
+
+        client.set.assert_called_once()
+        assert client.set.call_args.kwargs["ex"] is None
+
+    def test_default_ttl_is_still_applied_for_other_keys(self):
+        """Only the dead-letter queue is untimed; last-run markers keep expiring."""
+        client = MagicMock()
+
+        _redis_set(client, _TESTGAPS_LAST_RUN_KEY, "2026-08-09")
+
+        assert client.set.call_args.kwargs["ex"] == 86400 * 14
+
+    def test_a_failed_write_returns_false_and_logs(self, caplog):
+        client = MagicMock()
+        client.set.side_effect = RuntimeError("connection reset")
+
+        with caplog.at_level(logging.ERROR, logger="workers.audit_tasks"):
+            assert _redis_set(client, "k", "v") is False
+
+        assert "connection reset" in caplog.text
+
+    def test_no_client_is_a_failed_write(self):
+        assert _redis_set(None, "k", "v") is False
+
+    def test_the_queue_is_written_without_expiry_through_the_real_helper(self):
+        """End to end through the real _redis_set, so a regression that
+        re-applies a TTL to the queue cannot ship green."""
+        client = MagicMock()
+
+        _persist_deferred(client, [{"title": "t", "body": "b", "label": "l"}])
+
+        assert client.set.call_args.kwargs["ex"] is None
+
+
+class TestTruncationIsDeclared:
+    """#13570 review: "Full findings follow" then silently cut the JSON off."""
+
+    def test_an_oversized_dump_says_it_was_truncated(self, caplog):
+        _store, _get, _set, client = _fake_redis_backing(writes_succeed=False)
+        big = [{"title": f"discovery: {i}", "body": "x" * 2000, "label": "l"} for i in range(200)]
+
+        with patch("workers.audit_tasks._redis_set", side_effect=_set):
+            with caplog.at_level(logging.CRITICAL, logger="workers.audit_tasks"):
+                _persist_deferred(client, big)
+
+        assert "TRUNCATED" in caplog.text
+        assert "200" in caplog.text, "the true count must survive the truncation"
+
+    def test_a_dump_that_fits_makes_no_truncation_claim(self, caplog):
+        _store, _get, _set, client = _fake_redis_backing(writes_succeed=False)
+
+        with patch("workers.audit_tasks._redis_set", side_effect=_set):
+            with caplog.at_level(logging.CRITICAL, logger="workers.audit_tasks"):
+                _persist_deferred(client, [{"title": "t", "body": "b", "label": "l"}])
+
+        assert "TRUNCATED" not in caplog.text


### PR DESCRIPTION
Closes #13570 · umbrella #13852 (Wave 1, class C — wrong signals) · spins out #13859

## Thinking Path

The worker logged CRITICAL "N audit finding(s) deferred to the Redis dead-letter queue
(`audit:deferred_findings`) instead of being filed **or lost**" — while `LLEN audit:deferred_findings` was 0
and no `audit:deferred*` key existed at all.

The message is the dangerous part, not the lost findings. It reads as a safe fallback and states the findings
were preserved, so nobody goes looking. That is why every automated audit since the credential lapsed produced
nothing, silently, with no way to tell how many findings were lost or when filing broke.

Three defects, and they are the same defect three times — **an observation replaced by an assumption**:

- `_redis_set` swallowed every exception and returned `None`, so no caller could tell a successful write from a
  no-op. `_get_redis()` also returns `None` whenever the client cannot be built, and that path wrote nothing.
- `_persist_deferred` returned the count it *intended* to store, so a queue holding nothing reported a depth.
- The CRITICAL message was emitted **before** the write was attempted — so the claim about preservation could
  not possibly have been based on it.

## What Changed

- `_redis_set` returns whether the write landed; `_persist_deferred` reports what actually persisted.
- The reassuring message is emitted only by the code path that **observed** success. When the queue cannot be
  written, the findings are dumped in full at CRITICAL — at that point the log *is* the queue, and a bare
  count would leave nothing recoverable — and the message says **LOST**, not deferred.
- **The queue no longer expires.** It carried the module's default 14-day TTL, so a filing credential broken
  for a fortnight — the exact situation the queue exists for — silently expired everything in it. A second
  silent-loss path, not in the original report.
- `_gh_available` reports the failure on every run, with gh's own stderr. It was silent, so a run producing no
  findings looked identical to a healthy one and the lapse only surfaced when an audit happened to have
  something to file.

## The test fake was part of the bug

`_fake_redis_backing`'s `_set` returned `None`. Under the new contract that means "the write failed" — and
every pre-existing no-drop test went red, because they had all been running against a queue that silently
accepted nothing. They were asserting the *intended* count, which is the production bug they were written to
rule out. The fake now honours the helper's contract and gains a `writes_succeed=False` mode.

## Verification

```
$ pytest autobot-backend/workers/ -q
31 passed, 2 warnings in 0.26s
```

New regressions pin the incident shape specifically: a failed persist reports 0 rather than the intended
count; the findings reach the log in full; `redis=None` is a failed persist, not a silent success; both
failures at once say LOST and must **not** emit the reassuring "instead of being filed or lost" line; a
*working* fallback still does (the fix must not turn a healthy queue into an alarm); the queue is stored with
`ttl=None`; and an unauthenticated `gh` logs CRITICAL while an authenticated one stays quiet.

## Decision

**Fix (1) of the issue — a vault-owned token instead of ambient `gh` CLI auth — is deliberately not in this
PR.** The vault exists (`autobot_shared/secrets_vault.py`), but choosing the principal for a background Celery
task and its grant/audit/revocation semantics is a design call, not a mechanical change. Filed as **#13859**
with the three specific decisions it needs.

This PR makes the current failure loud and lossless in the meantime — findings are queued rather than lost,
the queue no longer expires, and an unauthenticated worker says so every run — rather than papering over it.

**Not verified on a live host.** Closing #13570 properly also wants the host-side confirmation that
authenticating the service account drains the queue.

## Model Used

Claude Opus 5 (1M context)
