### PR TITLE
ci: required checks report a verdict instead of resolving as "skipped" (#13862)

### DIFF
--- a/.github/workflows/migration-gate.yml
+++ b/.github/workflows/migration-gate.yml
@@ -49,6 +49,7 @@ jobs:
   changes:
     name: Detect changed paths
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       migrations: ${{ steps.filter.outputs.migrations }}
     steps:
@@ -152,6 +153,12 @@ jobs:
   # Fail-safe: anything other than success-or-skipped fails this gate, and a
   # failed `changes` job fails it too — otherwise a broken paths filter would
   # skip the matrix and read as "nothing to verify".
+  #
+  # `always()` rather than the repo's usual `!cancelled()` is deliberate:
+  # `!cancelled()` would SKIP this job on a cancelled run and re-publish
+  # `skipped` on the required context, which is the bug being fixed. The cost
+  # is that a cancelled run reports this check red rather than absent — the
+  # safer direction for a required gate, and self-clearing on the next run.
   migration-matrix:
     name: migration-matrix
     needs: [changes, migration-tests]

--- a/.github/workflows/migration-gate.yml
+++ b/.github/workflows/migration-gate.yml
@@ -33,7 +33,8 @@ on:
   # so its required-check context ("migration-matrix") always reports a conclusion.
   # A path-filtered required check that never triggers leaves the PR deadlocked on
   # "Expected — Waiting for status". The real matrix is gated on the `changes` job
-  # below and self-skips (reporting success) when no migration-relevant path changes.
+  # below; #13862 made the required context a separate reporting job so that
+  # "nothing to verify" is stated rather than inferred from a skip.
   pull_request:
     branches: [ main, Dev_new_gui ]
 
@@ -68,13 +69,13 @@ jobs:
               - 'autobot-slm-backend/ansible/playbooks/update-all-nodes.yml'
               - '.github/workflows/migration-gate.yml'
 
-  migration-matrix:
+  migration-tests:
     needs: changes
     # Run the full matrix whenever a migration-relevant path changed. Using
     # `!= 'false'` (rather than `== 'true'`) is fail-safe: any unexpected/empty
     # filter output still runs the gate instead of silently skipping it. On PRs
-    # that touch no migration paths the job is skipped and reports success, so the
-    # required "migration-matrix" context always resolves.
+    # that touch no migration paths this job is skipped, and the
+    # `migration-matrix` job below turns that into an explicit verdict.
     if: needs.changes.outputs.migrations != 'false'
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -131,3 +132,55 @@ jobs:
             autobot-backend/tests/migrations/test_schema_authority.py \
             autobot-backend/tests/migrations/test_ansible_migration_contract.py \
             -v --tb=short -p no:cacheprovider
+
+  # #13862: the required check reports a VERDICT, never "skipped".
+  #
+  # `migration-matrix` used to be the heavy job itself, so on a PR that touches
+  # no migration paths the required context resolved as `skipped`. Branch
+  # protection accepts that — but "skipped" cannot be read off the PR page as
+  # either "this diff has nothing to verify" or "the check never ran", and those
+  # are opposite facts. The same ambiguity is why the `pull_request` trigger
+  # above deliberately carries no paths filter (see the note there): a required
+  # context that never resolves deadlocks the PR on "Expected — Waiting for
+  # status". This finishes that job — the context now always resolves, and it
+  # always says which of the two happened.
+  #
+  # Kept separate from `migration-tests` rather than un-gating it: that job
+  # starts a postgres:16 service container, and spinning one up on every PR
+  # that changes no migration would be a real cost for a message.
+  #
+  # Fail-safe: anything other than success-or-skipped fails this gate, and a
+  # failed `changes` job fails it too — otherwise a broken paths filter would
+  # skip the matrix and read as "nothing to verify".
+  migration-matrix:
+    name: migration-matrix
+    needs: [changes, migration-tests]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Report migration gate verdict
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          TESTS_RESULT: ${{ needs.migration-tests.result }}
+        run: |
+          set -euo pipefail
+          echo "changes=$CHANGES_RESULT  migration-tests=$TESTS_RESULT"
+
+          if [ "$CHANGES_RESULT" != "success" ]; then
+            echo "::error::path detection $CHANGES_RESULT — cannot tell whether migrations changed, so this gate cannot pass"
+            exit 1
+          fi
+
+          case "$TESTS_RESULT" in
+            success)
+              echo "migration matrix passed"
+              ;;
+            skipped)
+              echo "no migration-relevant path changed in this diff — nothing to verify"
+              ;;
+            *)
+              echo "::error::migration matrix $TESTS_RESULT"
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/verify-generated-types.yml
+++ b/.github/workflows/verify-generated-types.yml
@@ -59,6 +59,7 @@ jobs:
   changes:
     name: Detect changed paths
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       types: ${{ steps.filter.outputs.types }}
       slm_types: ${{ steps.filter.outputs.slm_types }}
@@ -87,9 +88,16 @@ jobs:
 
   verify-types-run:
     needs: changes
-    if: needs.changes.outputs.types == 'true'
+    # `!= 'false'` rather than `== 'true'`, matching migration-gate.yml: an
+    # unexpected or empty filter output then still RUNS the check instead of
+    # silently skipping it. With `== 'true'`, a paths-filter that succeeded but
+    # emitted nothing would skip this job and the verdict below would report a
+    # green "nothing to verify" — the fail-safe only bites when `changes` fails
+    # outright (#13862 review).
+    if: needs.changes.outputs.types != 'false'
     name: verify-types-run
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v7
@@ -242,14 +250,22 @@ jobs:
   # #13862: the required check reports a VERDICT, never "skipped".
   #
   # `verify-generated-types` used to be the working job itself, so a PR touching
-  # only autobot-slm-backend (where the SLM sibling below does the real work)
+  # only autobot-slm-backend (where the SLM sibling above does the real work)
   # resolved the required context as `skipped`. Branch protection accepts that,
   # but "skipped" reads identically to "never ran" on the PR page, and those are
   # opposite facts — the distinction this workflow's own header calls out for the
   # deadlock case. The context now always resolves and always says which it was.
   #
+  # `verify-generated-types-slm` is deliberately NOT in this verdict: it is not a
+  # required context, and folding it in would silently widen what the required
+  # gate covers. It reports for itself, exactly as before.
+  #
   # Fail-safe: only success-or-skipped passes, and a failed `changes` job fails
-  # this gate too — a broken paths filter must not read as "nothing to verify".
+  # this gate too. `always()` (not the repo's usual `!cancelled()`) is
+  # deliberate: `!cancelled()` would SKIP this job on a cancelled run and
+  # re-publish `skipped` on the required context — the exact bug being fixed.
+  # The cost is that a cancelled run reports this check red rather than absent,
+  # which is the safer direction for a required gate.
   verify-generated-types:
     name: verify-generated-types
     needs: [changes, verify-types-run]

--- a/.github/workflows/verify-generated-types.yml
+++ b/.github/workflows/verify-generated-types.yml
@@ -43,7 +43,8 @@ on:
   # required-check context ("verify-generated-types") always reports a conclusion.
   # A path-filtered required check that never triggers leaves the PR deadlocked
   # on "Expected — Waiting for status". The real work is gated on the `changes`
-  # job below and self-skips (reporting success) when no relevant paths change.
+  # job below; #13862 made the required context a separate reporting job so that
+  # "nothing to verify" is stated rather than inferred from a skip.
   pull_request:
     branches: [ main, Dev_new_gui ]
 
@@ -84,10 +85,10 @@ jobs:
               - '**/requirements*.txt'
               - '.github/workflows/verify-generated-types.yml'
 
-  verify-generated-types:
+  verify-types-run:
     needs: changes
     if: needs.changes.outputs.types == 'true'
-    name: verify-generated-types
+    name: verify-types-run
     runs-on: ubuntu-latest
 
     steps:
@@ -237,3 +238,47 @@ jobs:
             exit 1
           fi
           echo "SLM generated types are fresh."
+
+  # #13862: the required check reports a VERDICT, never "skipped".
+  #
+  # `verify-generated-types` used to be the working job itself, so a PR touching
+  # only autobot-slm-backend (where the SLM sibling below does the real work)
+  # resolved the required context as `skipped`. Branch protection accepts that,
+  # but "skipped" reads identically to "never ran" on the PR page, and those are
+  # opposite facts — the distinction this workflow's own header calls out for the
+  # deadlock case. The context now always resolves and always says which it was.
+  #
+  # Fail-safe: only success-or-skipped passes, and a failed `changes` job fails
+  # this gate too — a broken paths filter must not read as "nothing to verify".
+  verify-generated-types:
+    name: verify-generated-types
+    needs: [changes, verify-types-run]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Report generated-types verdict
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          RUN_RESULT: ${{ needs.verify-types-run.result }}
+        run: |
+          set -euo pipefail
+          echo "changes=$CHANGES_RESULT  verify-types-run=$RUN_RESULT"
+
+          if [ "$CHANGES_RESULT" != "success" ]; then
+            echo "::error::path detection $CHANGES_RESULT — cannot tell whether generated types need checking"
+            exit 1
+          fi
+
+          case "$RUN_RESULT" in
+            success)
+              echo "autobot-frontend generated types are fresh"
+              ;;
+            skipped)
+              echo "no autobot-backend schema or autobot-frontend type path changed in this diff — nothing to verify"
+              ;;
+            *)
+              echo "::error::generated-types verification $RUN_RESULT"
+              exit 1
+              ;;
+          esac


### PR DESCRIPTION
Closes #13862 · related #13852, #13861

## Thinking Path

Asked why the Wave 1 PRs showed `8/10 SUCCESS` rather than `10/10`, the honest answer was: the two
non-successes are **skips**, skips satisfy branch protection, and forcing them to SUCCESS would mean adding an
Alembic migration and unrelated `autobot-backend` edits to PRs that need neither — inventing changes to colour
a badge, on deploy tooling where a stray edit is how you get a bad deploy.

But "don't damage the PRs" and "get to 10/10" are only in tension if the PRs are the thing you change. They
aren't. **The checks are.**

`skipped` does not say which of two opposite things happened — "this diff touches nothing I guard" or "I never
ran". Both workflows already carry a comment about the second one:

> A path-filtered required check that never triggers leaves the PR deadlocked on "Expected — Waiting for
> status".

So they always run and self-skip the real job. That fixed the deadlock and left the ambiguity: the context
resolves, but to a non-answer. This finishes the job.

## What Changed

The working job keeps its gate and is renamed — `migration-matrix` → `migration-tests`,
`verify-generated-types` → `verify-types-run`. The required context becomes a separate always-running job that
states the outcome:

| gated job | verdict |
|---|---|
| success | pass — "verified" |
| skipped | pass — "no relevant path changed in this diff — nothing to verify" |
| failure / cancelled | **fail** |
| path detection itself failed | **fail** |

That last row is the part that is not cosmetic. Previously, a broken paths filter reporting "no relevant
changes" for a diff that *has* them would skip the gated job and resolve the context as `skipped` — visually
identical to a healthy PR. A filter failure now fails the gate instead of reading as "nothing to verify".

**Required context names are unchanged.** `name:` is pinned on both reporting jobs, so branch protection needs
no edit and no PR can deadlock on a context that stopped existing — the exact failure #11346 fixed.

Heavy jobs stay gated rather than un-gated to report for themselves: `migration-tests` starts a `postgres:16`
service container, and starting one on every PR that changes no migration is a real cost for a message.

## Verification

Job graph and context names validated locally:

```
migration-gate.yml:            contexts=['Detect changed paths', 'migration-tests', 'migration-matrix']
verify-generated-types.yml:    contexts=['Detect changed paths', 'verify-types-run',
                                         'verify-generated-types-slm', 'verify-generated-types']
```

Both required contexts (`migration-matrix`, `verify-generated-types`) survive; every `needs:` target resolves.

Checked that nothing else depends on the old job ids — every other mention across `.github/`, `docs/` and
`scripts/` is to the *workflow file* or the *check context*, and `slm-migration-gate.yml` has its own separate
`slm-migration-matrix` job.

**This PR is its own evidence.** It edits both workflow files, which are in both paths filters, so both gated
jobs run for real here — the success branch. The skip branch is what every other PR in the queue will
exercise; the three Wave 1 PRs (#13857, #13858, #13860) are the immediate readout once this lands and they are
updated.

No expression interpolates untrusted event data: the only `${{ }}` values are `needs.*.result`, and they are
passed via `env:` rather than inlined into the shell.

## Risk

This touches required checks for every PR in the repo, so a mistake blocks everything until reverted. The two
mitigations are that the context names are unchanged (no branch-protection edit, nothing to desynchronise) and
that the verdict logic fails closed on every state except an explicit success or skip.

## Model Used

Claude Opus 5 (1M context)
