### PR TITLE
fix(context): revert tiered_context_enabled to off — the A/B it was flipped on measured mocks (#13866)

### DIFF
--- a/autobot-backend/chat_history/layers_test.py
+++ b/autobot-backend/chat_history/layers_test.py
@@ -165,14 +165,28 @@ class TestLayer2OnDemand:
         result = await layer.render({"user_message": "Tell me about AutoBot", "memory_graph": None})
         assert result == ""
 
+    @pytest.mark.xfail(
+        strict=True,
+        reason="#13686: L2 reads description/content; entity documents carry observations (#13866)",
+    )
     @pytest.mark.asyncio
     async def test_render_with_memory_graph_returns_context(self):
+        from autobot_memory_graph.entities import EntityOperationsMixin
         from chat_history.layers import Layer2OnDemand
 
+        # Built by the function that defines the schema, not hand-written: the
+        # hand-written fixture agreed with the layer's own wrong assumption.
         fake_graph = MagicMock()
         fake_graph.search_entities = AsyncMock(
             return_value=[
-                {"name": "AutoBot", "description": "An AI automation platform"},
+                EntityOperationsMixin._build_entity_document(
+                    None,
+                    entity_id="ent-autobot",
+                    entity_type="platform",
+                    name="AutoBot",
+                    observations=["An AI automation platform"],
+                    entity_metadata={},
+                ),
             ]
         )
         layer = Layer2OnDemand()
@@ -315,6 +329,10 @@ class TestTieredContextBuilderFeatureFlag:
         finally:
             layers_mod.TIERED_CONTEXT_ENABLED = original
 
+    @pytest.mark.xfail(
+        strict=True,
+        reason="#13686: L2 reads description/content; entity documents carry observations (#13866)",
+    )
     @pytest.mark.asyncio
     async def test_l2_fires_when_entity_in_message_and_flag_on(self):
         """L2 fires when entity detected and flag is on."""
@@ -324,11 +342,22 @@ class TestTieredContextBuilderFeatureFlag:
         try:
             layers_mod.TIERED_CONTEXT_ENABLED = True
 
+            from autobot_memory_graph.entities import EntityOperationsMixin
+
             mock_gen = MagicMock()
             mock_gen.generate = AsyncMock(return_value="")
             fake_graph = MagicMock()
             fake_graph.search_entities = AsyncMock(
-                return_value=[{"name": "Redis", "description": "In-memory data store"}]
+                return_value=[
+                    EntityOperationsMixin._build_entity_document(
+                        None,
+                        entity_id="ent-redis",
+                        entity_type="service",
+                        name="Redis",
+                        observations=["In-memory data store"],
+                        entity_metadata={},
+                    )
+                ]
             )
 
             with patch("memory.essential_story.EssentialStoryGenerator", return_value=mock_gen):

--- a/autobot-backend/chat_workflow/llm_handler.py
+++ b/autobot-backend/chat_workflow/llm_handler.py
@@ -866,11 +866,14 @@ NEVER teach commands - ALWAYS execute them.""" + lang_instruction
             company_id=(session.metadata.get("company_id") if session and session.metadata else None),
         )
         # Issue #5066: Tiered L0-L4 context wake-up.
-        # #13689: the A/B RAN (2026-08-08) — it is no longer an open intention.
-        # All five layers render; costs are +14..45 tokens and +6..8ms assembly.
-        # Result: ON. It stayed off until #13742 fixed L3 duplicating the
-        # retrieval performed below, which is why L3 is no longer handed a
-        # knowledge_service. Full record: docs/research/tiered-context-ab-13689.md
+        # #13689 turned this ON on 2026-08-08; #13866 reverted it to OFF on
+        # 2026-08-10. The A/B's "all five layers render" was measured against
+        # test doubles: at this call site L2 cannot render (it reads
+        # description/content; entity documents carry observations — #13686),
+        # L3 cannot render (knowledge_service=None since #13742, below), and L0
+        # renders a compile-time constant carrying a hardcoded owner (#13867).
+        # Re-enabling is gated on #13686 + #13867 and an A/B re-run against a
+        # live backend. Full record: docs/research/tiered-context-ab-13689.md
         # When TIERED_CONTEXT_ENABLED=true the TieredContextBuilder owns all
         # context prepending (L0 identity + L1 essential story + L2/L3 on-demand).
         # When false the pre-existing unconditional EssentialStory path is used.

--- a/autobot-backend/chat_workflow/tiered_context_prompt_test.py
+++ b/autobot-backend/chat_workflow/tiered_context_prompt_test.py
@@ -82,13 +82,33 @@ def _session():
 
 
 class TestL2RendersInPrompt:
+    @pytest.mark.xfail(
+        strict=True,
+        reason="#13686: L2 reads description/content; entity documents carry observations. "
+        "This AC was green against an invented fixture shape (#13866).",
+    )
     @pytest.mark.asyncio
     async def test_known_entity_renders_related_context_block(self):
-        """AC #13686: flag on + a known entity -> '## Related Context' in the prompt."""
-        graph = MagicMock()
-        graph.search_entities = AsyncMock(
-            return_value=[{"name": "Redis", "description": "in-memory store used for sessions"}]
+        """AC #13686: flag on + a known entity -> '## Related Context' in the prompt.
+
+        The fixture is built by ``_build_entity_document`` — the function that
+        defines what an entity document is — rather than hand-written. The
+        hand-written version of this test passed while L2 rendered "" on every
+        real turn, because the fixture and the layer shared the same wrong
+        assumption about the schema.
+        """
+        from autobot_memory_graph.entities import EntityOperationsMixin
+
+        doc = EntityOperationsMixin._build_entity_document(
+            None,
+            entity_id="ent-redis",
+            entity_type="service",
+            name="Redis",
+            observations=["in-memory store used for sessions"],
+            entity_metadata={},
         )
+        graph = MagicMock()
+        graph.search_entities = AsyncMock(return_value=[doc])
         chm = MagicMock()
         chm.memory_graph = graph
 

--- a/autobot-backend/scripts/tiered_context_ab.py
+++ b/autobot-backend/scripts/tiered_context_ab.py
@@ -138,7 +138,11 @@ async def _build_tiered(case: Dict[str, Any]) -> str:
                 model_name="default",
                 session_id="ab-session",
                 memory_graph=_memory_graph(),
-                knowledge_service=_knowledge_service(),
+                # #13866: None, mirroring the production call site
+                # (llm_handler.py) since #13742. Passing a mock here reported L3
+                # as rendering while production could not render it at all —
+                # the same divergence that made the ENTITY_FACTS result false.
+                knowledge_service=None,
                 goal_ancestry=case.get("goal_ancestry"),
             )
 

--- a/autobot-backend/scripts/tiered_context_ab.py
+++ b/autobot-backend/scripts/tiered_context_ab.py
@@ -72,7 +72,22 @@ CASES = [
 ]
 
 ESSENTIAL_STORY = "## Essential Story\n- the deploy ran at 09:00\n- the owner is mrveiss"
-ENTITY_FACTS = [{"name": "Redis", "description": "in-memory store backing session state"}]
+# #13866: this was `{"name": ..., "description": ...}` — a shape no production
+# write path produces. The double agreed with the layer's own wrong assumption,
+# so the A/B reported L2 rendering when it cannot. The fixture now matches what
+# `_build_entity_document` actually stores; L2 will render nothing here until
+# #13686 teaches it to read `observations`, and that is the honest result.
+ENTITY_FACTS = [
+    {
+        "id": "ent-redis",
+        "type": "service",
+        "name": "Redis",
+        "created_at": 0,
+        "updated_at": 0,
+        "observations": ["in-memory store backing session state"],
+        "metadata": {},
+    }
+]
 # L3 returns whatever the knowledge service hands back — it adds no heading of
 # its own — so the double emits a recognisable grounded-context block.
 KB_CONTEXT = "## Knowledge Base\nDeploy runbook: run code-sync from the maintenance page."

--- a/autobot-backend/tests/test_entity_fixture_shape.py
+++ b/autobot-backend/tests/test_entity_fixture_shape.py
@@ -1,0 +1,111 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Entity fixtures must match the document the graph actually stores (#13866).
+
+The tiered-context A/B concluded "all five layers render" and that conclusion
+changed a production default. It was wrong about L2, and the reason it was wrong
+is the failure mode these tests exist to prevent:
+
+    the fixture and the layer shared the same false assumption, so they agreed.
+
+`Layer2OnDemand` read ``description``/``content``. The A/B harness and the layer's
+own unit test both supplied ``{"name": ..., "description": ...}``. Every test
+passed. No production write path has ever produced a ``description`` key, so the
+layer returned "" on every real turn — the exact symptom #13686 was filed for and
+believed fixed.
+
+A fixture invented alongside the code it verifies certifies nothing. These tests
+pin fixtures against `_build_entity_document`, the single function that defines
+what an entity document is, so the next divergence fails here instead of in
+production.
+"""
+
+from typing import Any, Dict, Set
+
+import pytest
+
+
+def _real_entity_keys() -> Set[str]:
+    """The keys an entity document actually carries, from the builder itself.
+
+    Derived, never hardcoded: a hardcoded copy would drift the same way the
+    fixtures did.
+    """
+    from autobot_memory_graph.entities import EntityOperationsMixin
+
+    doc: Dict[str, Any] = EntityOperationsMixin._build_entity_document(
+        None,  # unbound: the builder is pure and does not touch self
+        entity_id="e1",
+        entity_type="service",
+        name="Redis",
+        observations=["an observation"],
+        entity_metadata={},
+    )
+    return set(doc.keys())
+
+
+class TestTheBuilderDefinesTheShape:
+    def test_the_document_has_observations_and_no_description(self):
+        """The precondition the A/B got wrong.
+
+        If this ever fails, an entity really did gain a ``description`` field and
+        the rest of this file should be revisited rather than deleted.
+        """
+        keys = _real_entity_keys()
+
+        assert "observations" in keys, "entity text lives in observations"
+        assert "description" not in keys, "no write path produces a description"
+        assert "content" not in keys, "no write path produces a content key"
+
+
+class TestFixturesMatchProduction:
+    """Any dict claiming to be an entity document must be shaped like one."""
+
+    def test_the_ab_harness_entity_fixture_is_a_real_document(self):
+        """`scripts/tiered_context_ab.py` fed L2 an invented shape, which is how
+        a layer that cannot render was measured as rendering."""
+        from scripts.tiered_context_ab import ENTITY_FACTS
+
+        real = _real_entity_keys()
+
+        assert ENTITY_FACTS, "the harness needs at least one entity to exercise L2"
+        for fact in ENTITY_FACTS:
+            unknown = set(fact) - real
+            assert not unknown, f"fixture invents keys production never writes: {sorted(unknown)}"
+            assert "observations" in fact, "a real entity carries its text in observations"
+
+
+class TestTheLayerReadsAFieldThatExists:
+    """Guards the fix itself, not just the fixtures.
+
+    #13686 is what teaches L2 to read ``observations``. Until it lands this test
+    records the defect rather than asserting it away — a passing test here must
+    mean the layer works, never merely that it was called.
+    """
+
+    @pytest.mark.asyncio
+    async def test_l2_renders_from_a_document_the_graph_would_store(self):
+        from unittest.mock import AsyncMock
+
+        from autobot_memory_graph.entities import EntityOperationsMixin
+        from chat_history.layers import Layer2OnDemand
+
+        doc = EntityOperationsMixin._build_entity_document(
+            None,
+            entity_id="e1",
+            entity_type="service",
+            name="Redis",
+            observations=["in-memory store backing session state"],
+            entity_metadata={},
+        )
+        graph = AsyncMock()
+        graph.search_entities = AsyncMock(return_value=[doc])
+
+        rendered = await Layer2OnDemand().render({"user_message": "How is Redis configured?", "memory_graph": graph})
+
+        if not rendered:
+            pytest.xfail("#13686: L2 reads description/content, which entity documents do not carry")
+        assert "Redis" in rendered
+        assert "in-memory store" in rendered

--- a/autobot-backend/tests/test_entity_fixture_shape.py
+++ b/autobot-backend/tests/test_entity_fixture_shape.py
@@ -72,7 +72,8 @@ def _assert_is_entity_document(fixture: Dict[str, Any]) -> None:
         f"invented {sorted(set(fixture) - set(real))}"
     )
     for key, value in fixture.items():
-        assert isinstance(value, type(real[key])), f"{key}: expected {type(real[key]).__name__}, got {type(value).__name__}"
+        expected = type(real[key])
+        assert isinstance(value, expected), f"{key}: expected {expected.__name__}, got {type(value).__name__}"
     assert fixture["observations"], "an entity with no observations renders nothing"
     assert fixture["name"], "L2 requires a name to render a line"
 

--- a/autobot-backend/tests/test_entity_fixture_shape.py
+++ b/autobot-backend/tests/test_entity_fixture_shape.py
@@ -27,23 +27,54 @@ from typing import Any, Dict, Set
 import pytest
 
 
-def _real_entity_keys() -> Set[str]:
-    """The keys an entity document actually carries, from the builder itself.
+def _real_entity_doc() -> Dict[str, Any]:
+    """A genuine entity document, from the builder itself.
 
     Derived, never hardcoded: a hardcoded copy would drift the same way the
     fixtures did.
+
+    ``self`` is None deliberately. ``_build_entity_document``
+    (``autobot_memory_graph/entities.py:68``) is annotated as a method but
+    touches no attribute. If someone adds one, this raises ``AttributeError:
+    'NoneType'`` naming the exact access — loud, and at the right line. A
+    ``MagicMock()`` would instead succeed silently and bake a mock into a field
+    value, which is the same class of lie these tests exist to catch.
     """
     from autobot_memory_graph.entities import EntityOperationsMixin
 
-    doc: Dict[str, Any] = EntityOperationsMixin._build_entity_document(
-        None,  # unbound: the builder is pure and does not touch self
+    return EntityOperationsMixin._build_entity_document(
+        None,
         entity_id="e1",
         entity_type="service",
         name="Redis",
         observations=["an observation"],
         entity_metadata={},
     )
-    return set(doc.keys())
+
+
+def _real_entity_keys() -> Set[str]:
+    return set(_real_entity_doc().keys())
+
+
+def _assert_is_entity_document(fixture: Dict[str, Any]) -> None:
+    """Fail unless *fixture* is shaped like something the graph would store.
+
+    Whole-document equality, not a subset: a partial fixture passes a subset
+    check and still renders nothing, which reads as a layer bug rather than a
+    fixture bug. Types are compared field-by-field against the real document
+    because ``observations`` being a str instead of a list is silent — a later
+    ``join`` over it yields characters.
+    """
+    real = _real_entity_doc()
+
+    assert set(fixture) == set(real), (
+        f"not an entity document — missing {sorted(set(real) - set(fixture))}, "
+        f"invented {sorted(set(fixture) - set(real))}"
+    )
+    for key, value in fixture.items():
+        assert isinstance(value, type(real[key])), f"{key}: expected {type(real[key]).__name__}, got {type(value).__name__}"
+    assert fixture["observations"], "an entity with no observations renders nothing"
+    assert fixture["name"], "L2 requires a name to render a line"
 
 
 class TestTheBuilderDefinesTheShape:
@@ -68,44 +99,53 @@ class TestFixturesMatchProduction:
         a layer that cannot render was measured as rendering."""
         from scripts.tiered_context_ab import ENTITY_FACTS
 
-        real = _real_entity_keys()
-
         assert ENTITY_FACTS, "the harness needs at least one entity to exercise L2"
         for fact in ENTITY_FACTS:
-            unknown = set(fact) - real
-            assert not unknown, f"fixture invents keys production never writes: {sorted(unknown)}"
-            assert "observations" in fact, "a real entity carries its text in observations"
+            _assert_is_entity_document(fact)
+
+    def test_a_subset_of_the_right_keys_is_not_enough(self):
+        """Guards the guard.
+
+        A key-subset check passes for `{"observations": "a string"}` and for
+        `{"observations": []}` — both of which render nothing, and the second of
+        which would send someone chasing a phantom L2 bug. Whole-document
+        equality plus per-field types is what actually constrains a fixture.
+        """
+        real = _real_entity_doc()
+
+        with pytest.raises(AssertionError):
+            _assert_is_entity_document({"observations": ["x"]})  # incomplete
+        with pytest.raises(AssertionError):
+            _assert_is_entity_document({**real, "observations": "not a list"})  # wrong type
 
 
 class TestTheLayerReadsAFieldThatExists:
     """Guards the fix itself, not just the fixtures.
 
-    #13686 is what teaches L2 to read ``observations``. Until it lands this test
-    records the defect rather than asserting it away — a passing test here must
-    mean the layer works, never merely that it was called.
+    ``strict=True`` is the point. A conditional ``pytest.xfail()`` would go
+    quietly green when #13686 lands and then silently re-arm — any later
+    regression that empties L2 would read as an expected failure, which is the
+    "green tick means nothing" property this whole change exists to remove.
+    Strict makes the fix XPASS, which *fails*, forcing the marker's removal in
+    the PR that does the fixing.
     """
 
+    @pytest.mark.xfail(
+        strict=True,
+        reason="#13686: L2 reads description/content; entity documents carry observations",
+    )
     @pytest.mark.asyncio
     async def test_l2_renders_from_a_document_the_graph_would_store(self):
         from unittest.mock import AsyncMock
 
-        from autobot_memory_graph.entities import EntityOperationsMixin
         from chat_history.layers import Layer2OnDemand
 
-        doc = EntityOperationsMixin._build_entity_document(
-            None,
-            entity_id="e1",
-            entity_type="service",
-            name="Redis",
-            observations=["in-memory store backing session state"],
-            entity_metadata={},
-        )
+        doc = _real_entity_doc()
+        doc["observations"] = ["in-memory store backing session state"]
         graph = AsyncMock()
         graph.search_entities = AsyncMock(return_value=[doc])
 
         rendered = await Layer2OnDemand().render({"user_message": "How is Redis configured?", "memory_graph": graph})
 
-        if not rendered:
-            pytest.xfail("#13686: L2 reads description/content, which entity documents do not carry")
         assert "Redis" in rendered
         assert "in-memory store" in rendered

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -1982,18 +1982,28 @@ class MiscConfig(RedactedSettings):
     skill_hub_url: str = Field(default="", alias="AUTOBOT_SKILL_HUB_URL")
     testing: str = Field(default="", alias="TESTING")
     tf_use_legacy_keras: str = Field(default="", alias="TF_USE_LEGACY_KERAS")
-    # #13689: ON is a recorded decision, not a drift. The #5066 A/B ran on
-    # 2026-08-08 with all five layers live for the first time — L2 and L4 could
-    # not render at all until #13686/#13687. All five render; the cost is
-    # +14..45 tokens and +6..8 ms of assembly per turn.
-    # It stayed off until #13742 landed, because L3 duplicated the KB retrieval
-    # the chat path already performs — two vector searches and the same chunks
-    # twice in the prompt. That is fixed; there is now one retrieval per turn.
-    # NOT measured, and no claim is implied: answer quality. Recall quality is
-    # unmeasurable until #13251/#13243, so this decision rests on what the stack
-    # demonstrably puts in the prompt, its token cost, and its latency.
-    # Evidence: docs/research/tiered-context-ab-13689.md
-    tiered_context_enabled: bool = Field(default=True, alias="TIERED_CONTEXT_ENABLED")
+    # #13866: OFF. This was flipped ON by #13689 and is reverted here, because
+    # the evidence it rested on was measured entirely against test doubles.
+    # The #5066 A/B concluded "all five layers render". Against production code
+    # that is false, and the two layers whose fixtures diverged most from
+    # production are exactly the two that do not work:
+    #   L0  renders a compile-time constant. AutoBotConfig has no `owner` and no
+    #       `agent` attribute, so both getattr chains fall through to literals —
+    #       every tenant's prompt gets the same hardcoded owner name (#13867).
+    #   L1  already rendered before the flip, via the legacy path. Zero delta.
+    #   L2  cannot render. Entity documents carry `observations`; the layer
+    #       reads `description`/`content`, which no write path produces. It
+    #       returns "" on every turn after up to 20 Redis round-trips (#13686,
+    #       reopened — the wiring was fixed, the schema mismatch was not).
+    #   L3  cannot render: knowledge_service is None since #13742.
+    #   L4  renders, for sessions with a work-item binding only.
+    # So the measured +14..45 tokens described mocks, not a deployment. The
+    # latency figure is also stale: #13729 added a Redis GET and two DB sessions
+    # to this path after the measurement was taken.
+    # Re-enabling needs #13686 and #13867 fixed and the A/B re-run against a
+    # live backend — not another mock-based pass.
+    # Evidence: docs/research/tiered-context-ab-13689.md (corrected in #13866)
+    tiered_context_enabled: bool = Field(default=False, alias="TIERED_CONTEXT_ENABLED")
     tokenizers_parallelism: str = Field(default="", alias="TOKENIZERS_PARALLELISM")
     transformers_offline: bool = Field(default=False, alias="TRANSFORMERS_OFFLINE")
     travis: str = Field(default="", alias="TRAVIS")

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -1990,7 +1990,9 @@ class MiscConfig(RedactedSettings):
     #   L0  renders a compile-time constant. AutoBotConfig has no `owner` and no
     #       `agent` attribute, so both getattr chains fall through to literals —
     #       every tenant's prompt gets the same hardcoded owner name (#13867).
-    #   L1  already rendered before the flip, via the legacy path. Zero delta.
+    #   L1  already rendered before the flip, via the legacy path — no new
+    #       content, and a small net cost (it now also routes through
+    #       _fit_l0_l1, which can only shrink it).
     #   L2  cannot render. Entity documents carry `observations`; the layer
     #       reads `description`/`content`, which no write path produces. It
     #       returns "" on every turn after up to 20 Redis round-trips (#13686,
@@ -1998,8 +2000,9 @@ class MiscConfig(RedactedSettings):
     #   L3  cannot render: knowledge_service is None since #13742.
     #   L4  renders, for sessions with a work-item binding only.
     # So the measured +14..45 tokens described mocks, not a deployment. The
-    # latency figure is also stale: #13729 added a Redis GET and two DB sessions
-    # to this path after the measurement was taken.
+    # latency figure is also stale: #13729 added two indexed DB queries on bound
+    # sessions after the measurement was taken. (The per-turn Redis GET for the
+    # binding is not new — it predates #13729, from #13704.)
     # Re-enabling needs #13686 and #13867 fixed and the A/B re-run against a
     # live backend — not another mock-based pass.
     # Evidence: docs/research/tiered-context-ab-13689.md (corrected in #13866)

--- a/docs/research/_index.md
+++ b/docs/research/_index.md
@@ -18,7 +18,7 @@ Research reports covering hardware integration, system conflicts, and technology
 | [[lean-hardware-model-loading]] | Large-model inference on lean hardware — target architecture and capability audit of `llm_shared/optimization/` (#13030) |
 | [[REDIS_OWNERSHIP_CONFLICT_RESEARCH_REPORT]] | Redis ownership conflict investigation and resolution research |
 | [[connector-credential-egress-audit]] | Connector, credential and egress layer audit — 2 live OAuth bugs, 2 fail-open guards, secrets-manager bypass (#13623, #13643) |
-| [[tiered-context-ab-13689]] | Tiered L0–L4 context stack — #5066 A/B result with all five layers live, and the recorded reason the flag stays off (#13689, #13742) |
+| [[tiered-context-ab-13689]] | Tiered L0–L4 context stack — #5066 A/B result, **corrected**: measured against test doubles, 3 of 5 layers cannot render, flag reverted to off (#13689, #13742, #13866) |
 | [[layered-agent-memory-and-context-offload]] | Layered agent memory + symbolic context offload — tiered L0–L4 stack built but never ran, 2 of 5 layers structurally disconnected, memory plane untenanted (#13685) |
 
 ## Related Sections

--- a/docs/research/tiered-context-ab-13689.md
+++ b/docs/research/tiered-context-ab-13689.md
@@ -23,20 +23,24 @@ that do not work:
 | Layer | Result below | Against production code |
 |---|---|---|
 | L0 | renders | renders a **compile-time constant** — `AutoBotConfig` has no `owner`/`agent` attribute, so both getattr chains always fall through to literals (#13867) |
-| L1 | renders | already rendered before the flip, via the legacy path — **zero delta** |
+| L1 | renders | already rendered before the flip, via the legacy path — **no new content**, and a small net cost: the tiered path additionally routes it through `_fit_l0_l1`, which can only shrink it |
 | L2 | renders | **cannot render** — entities carry `observations`; the layer reads `description`/`content`, which no write path produces (#13686, reopened) |
-| L3 | renders | **cannot render** — `knowledge_service=None` since #13742, which landed in the same PR as this measurement |
-| L4 | renders | renders, for work-item-bound sessions only |
+| L3 | renders | **cannot render** — `knowledge_service=None` since #13742 (`29eeb904b`), merged in a *sibling* PR earlier the same day, **before** this measurement ran |
+| L4 | renders | renders for work-item-bound sessions, and since #13729 only when the binding also passes a membership re-check — narrower still |
 
-Specifically, `scripts/tiered_context_ab.py:75` supplies `ENTITY_FACTS = [{"name": "Redis",
+Specifically, before this correction the harness supplied `ENTITY_FACTS = [{"name": "Redis",
 "description": "..."}]`. No production code produces an entity document with a `description` key.
-Line 96 mocks the knowledge service that the sibling commit in the *same PR* then removed.
+The harness also mocked the knowledge service — while `29eeb904b`, already merged on this branch,
+had removed it from the production call site. The mock contradicted merged code at the moment the
+A/B ran.
 
-So "+14 to +45 tokens" describes the mocks. One of five layers contributes anything new in a real
-deployment, and L2 pays up to 20 Redis round-trips per turn to return an empty string.
+So "+14 to +45 tokens" describes the mocks. Only **L4** contributes anything that varies with the
+turn; L0 adds a fixed block, L1 was already there, and L2 pays up to 20 Redis round-trips per turn
+to return an empty string.
 
-The latency figure is stale for a second reason: #13729 added a Redis GET and two DB sessions to
-this path *after* this measurement was taken, and the number here was never revised.
+The latency figure is stale for a second reason: #13729 added two indexed DB queries on *bound*
+sessions after this measurement was taken, and the number here was never revised. (The per-turn
+Redis GET for the binding is **not** new — it predates #13729, from #13704.)
 
 **What this record got wrong methodologically:** it correctly noted "real retrieval latency is not
 measured here" as an open caveat, then drew a default-changing conclusion as if the caveat were
@@ -55,10 +59,13 @@ entity documents built by `_build_entity_document`. Not another mock-based pass.
 the five layers were structurally unable to render (#13686, #13687), so the flag compared the
 legacy path against the legacy path plus a static identity block.
 
-Both are now fixed and merged. This is the first run where all five layers can render, and this
+Both are now fixed and merged. ~~This is the first run where all five layers can render~~ (**false — three of five cannot; #13866**), and this
 file exists so the next person does not have to re-derive the outcome from an unexplained default.
 
-## Result — all five layers render
+## Result — all five layers render (SUPERSEDED)
+
+> **SUPERSEDED (2026-08-10, #13866)** — see the correction at the top of this file.
+
 
 | Case | Path | Tokens | ms | Layers rendered |
 |---|---|---|---|---|
@@ -72,9 +79,9 @@ file exists so the next person does not have to re-derive the outcome from an un
 | | legacy | 16 | 1.1 | essential_story |
 
 L0 and L1 always; L2 on an entity mention; L3 on a retrieval keyword; L4 on a bound session.
-**AC 1 satisfied** — the first time it could be.
+~~**AC 1 satisfied** — the first time it could be.~~ **Not satisfied: L2 and L3 cannot render (#13866).**
 
-Cost: **+14 to +45 tokens** and **+6 to +8 ms** of assembly per turn.
+~~Cost: **+14 to +45 tokens** and **+6 to +8 ms** of assembly per turn.~~ **Retracted — measured against mocks (#13866).**
 
 ## The blocker that held it off — now fixed (#13742, merged `29eeb904b`)
 
@@ -98,7 +105,7 @@ is the first run where L3 could fire at all.
 through `budget_grounded_context` for trimming and citation rebinding — and the tiered builder is
 no longer handed a `knowledge_service`. Verified by call count: one retrieval per turn.
 
-With that resolved, every criterion this issue set is met, and the flag is on.
+~~With that resolved, every criterion this issue set is met, and the flag is on.~~ **False — see the correction (#13866).**
 
 ## What was NOT measured, stated plainly
 
@@ -133,19 +140,21 @@ cache, so there is now one parser of that file. Tracked as **#13741**.
 The table above is measured **after** that fix. Reporting the pre-fix numbers as the tiered
 path's cost would have made the flag look far worse than it is.
 
-## Decision
+## Decision (SUPERSEDED)
 
-**On.**
+> **SUPERSEDED (2026-08-10, #13866)** — see the correction at the top of this file.
+
+
+~~**On.**~~ **Reverted to OFF on 2026-08-10 (#13866).**
 
 - All five layers work; the stack does what #5066 intended.
 - Token and latency costs are modest and acceptable: +14–45 tokens, +6–8 ms assembly.
 - The single blocker — L3's duplicate retrieval — is fixed (#13742), so enabling no longer
   doubles retrieval cost.
 
-**What would reverse this:** evidence that the added context hurts answer quality. None exists in
-either direction, because quality is unmeasurable until #13251/#13243. If that measurement later
-shows the tiered path is worse, this decision should be revisited on that evidence — the flag is
-one line and this file is the record of why it moved.
+~~**What would reverse this:** evidence that the added context hurts answer quality.~~
+**This got it wrong.** The decision was reversed on entirely different grounds: the layers it
+credited were never rendering, so there was no added context to evaluate (#13866).
 
 `autobot_shared/ssot_config.py` links this file from the `tiered_context_enabled` field so the
 default is explained where it is defined, not only here.

--- a/docs/research/tiered-context-ab-13689.md
+++ b/docs/research/tiered-context-ab-13689.md
@@ -3,11 +3,48 @@
 **Date:** 2026-08-08
 **Issue:** #13689 · umbrella #13685 · original experiment #5066
 **Harness:** `autobot-backend/scripts/tiered_context_ab.py` (committed; re-run to reproduce)
-**Decision:** **`tiered_context_enabled` is now ON.**
+**Decision:** ~~**`tiered_context_enabled` is now ON.**~~ **CORRECTED 2026-08-10 — reverted to OFF (#13866).**
 
 It was measured OFF and stayed off until the one blocker below was fixed. That sequence is kept
 rather than rewritten — a decision record that only shows its final state teaches nothing about
-how it was reached.
+how it was reached. The correction below is appended for the same reason.
+
+---
+
+## CORRECTION (2026-08-10, #13866) — this result was measured against test doubles
+
+**The headline below ("all five layers render") is false against production code.** The flag has
+been reverted to OFF. Read the correction before the result.
+
+The harness mocks the memory graph and the knowledge service. Both mocks diverge from production
+in exactly the way that hides a defect, and the two layers whose fixtures diverge most are the two
+that do not work:
+
+| Layer | Result below | Against production code |
+|---|---|---|
+| L0 | renders | renders a **compile-time constant** — `AutoBotConfig` has no `owner`/`agent` attribute, so both getattr chains always fall through to literals (#13867) |
+| L1 | renders | already rendered before the flip, via the legacy path — **zero delta** |
+| L2 | renders | **cannot render** — entities carry `observations`; the layer reads `description`/`content`, which no write path produces (#13686, reopened) |
+| L3 | renders | **cannot render** — `knowledge_service=None` since #13742, which landed in the same PR as this measurement |
+| L4 | renders | renders, for work-item-bound sessions only |
+
+Specifically, `scripts/tiered_context_ab.py:75` supplies `ENTITY_FACTS = [{"name": "Redis",
+"description": "..."}]`. No production code produces an entity document with a `description` key.
+Line 96 mocks the knowledge service that the sibling commit in the *same PR* then removed.
+
+So "+14 to +45 tokens" describes the mocks. One of five layers contributes anything new in a real
+deployment, and L2 pays up to 20 Redis round-trips per turn to return an empty string.
+
+The latency figure is stale for a second reason: #13729 added a Redis GET and two DB sessions to
+this path *after* this measurement was taken, and the number here was never revised.
+
+**What this record got wrong methodologically:** it correctly noted "real retrieval latency is not
+measured here" as an open caveat, then drew a default-changing conclusion as if the caveat were
+closed. A layer that has never rendered in production cannot be certified by a fixture written
+alongside it — the fixture and the layer share the same wrong assumption, so they agree.
+
+**Re-enabling requires:** #13686 and #13867 fixed, and this A/B re-run against a live backend with
+entity documents built by `_build_entity_document`. Not another mock-based pass.
 
 ---
 


### PR DESCRIPTION
## Thinking Path

I flipped `tiered_context_enabled` to `True` in #13749 earlier in this session and merged it on green CI without a review pass. A retrospective review of that merge found the decision rested on evidence measured entirely against test doubles.

The failure mode is worth naming, because it is not "the test was weak" — it is that **the fixture and the layer shared the same false assumption, so they agreed.** `Layer2OnDemand` reads `description`/`content`. The A/B harness and the layer's unit test both supplied `{"name": ..., "description": ...}`. Everything passed. No production write path has ever produced a `description` key.

That means the A/B's headline — "all five layers render" — is false, and it was the stated basis for changing a production default.

Against production code:

| Layer | A/B claimed | Actual |
|---|---|---|
| L0 | renders | renders a compile-time constant; `AutoBotConfig` has no `owner`/`agent` attribute, so both getattr chains always fall through to literals (#13867) |
| L1 | renders | already rendered before the flip via the legacy path — **zero delta** |
| L2 | renders | **cannot render** — schema mismatch (#13686, reopened) |
| L3 | renders | **cannot render** — `knowledge_service=None` since #13742 (`29eeb904b`), merged in a *sibling* PR earlier the same day, **before** the measurement ran |
| L4 | renders | renders, for work-item-bound sessions only |

One of five layers contributes anything new. Meanwhile L2's `should_load` fires on any capitalised token — including a sentence-initial one, so `"Hello there"` triggers it — and each trigger runs up to 5 `search_entities`, each 1 `FT.SEARCH` plus up to 3 sequential un-pipelined `JSON.GET`. Up to **20 Redis round-trips per turn to produce an empty string**, on a client with a 5s socket timeout and a `scan_iter` fallback.

Reverting the default is the smallest change that neutralises the owner leak, the Redis cost, and the unbudgeted prompt block at once. It also restores the module's own stated precedent — a context mechanism ships flag-off until a benchmark shows the win — which the flip violated.

## What Changed

- `ssot_config.py` — `tiered_context_enabled` back to `default=False`; the inline justification replaced with what is actually true per layer, with issue links. The old comment asserted a measured result that does not hold.
- `docs/research/tiered-context-ab-13689.md` — a correction block **prepended, not a rewrite**. The original result stays visible; the correction explains what the mocks hid and why the methodology failed. The doc's own convention is to keep the sequence rather than show only the final state.
- `scripts/tiered_context_ab.py` — `ENTITY_FACTS` now uses the shape `_build_entity_document` actually stores. L2 will render nothing in the harness until #13686 lands, and that is the honest result.
- `tests/test_entity_fixture_shape.py` — new. Pins fixtures against the builder itself rather than a hardcoded key list, since a hardcoded copy would drift the same way.

## Verification

New tests, and the affected suites:

```
tests/test_entity_fixture_shape.py ..x                          [100%]
2 passed, 1 xfailed in 0.82s
```

The `xfail` is deliberate and load-bearing: it renders L2 from a document built by `_build_entity_document` and records that the layer cannot read it. It flips to a real pass when #13686 lands — a passing test there must mean the layer works, never merely that it was called.

Mutation test — the guard has teeth. Restoring the original fixture:

```
E   AssertionError: fixture invents keys production never writes: ['description']
FAILED tests/test_entity_fixture_shape.py::TestFixturesMatchProduction::test_the_ab_harness_entity_fixture_is_a_real_document
```

Full affected set:

```
chat_history/layers_test.py .......................             [ 56%]
tests/test_goal_ancestry_layer.py ...........                   [ 82%]
chat_workflow/l3_no_duplicate_retrieval_test.py ....            [ 92%]
tests/test_entity_fixture_shape.py ..x                          [100%]
40 passed, 1 xfailed in 2.12s
```

No test depended on the default: every one sets `TIERED_CONTEXT_ENABLED` explicitly.

## Decision

Reverting rather than fixing forward. Fixing L2's schema (#13686) and L0's owner (#13867) is more work than a revert, and until both land the flag is costing Redis round-trips and leaking a hardcoded owner name into every tenant's prompt for no benefit. Re-enabling is gated on those two plus an A/B re-run against a live backend — not another mock-based pass.

## Model Used

Opus 5

Closes #13866



---

## Correction (post-review)

Review found three unverified assertions in a correction whose thesis is that unverified assertions changed a default. All three are fixed in `5fe531e6a`:

- **"landed in the same PR"** — false. `git merge-base --is-ancestor 29eeb904b 247e16919` confirms #13742 merged *earlier*, in #13759, not #13749. The true statement is stronger: the harness's L3 mock contradicted already-merged code on the same branch when the A/B ran.
- **"#13729 added a Redis GET and two DB sessions"** — false on both counts. `git show 026a21025` shows `get_binding` was already called before that commit; #13729 added two indexed DB queries, on bound sessions only. The Redis GET dates from #13704.
- **"L1 zero delta"** — overstated. No new *content*, but the tiered path adds `_fit_l0_l1` on top, so it is a small net cost.

Review also found the blocker that mattered most: **#13686's acceptance test was still green on this branch**, asserting `"## Related Context"` from the invented fixture, while this PR documented L2 as unable to render. That and two sibling fixtures in `layers_test.py` are now built by `_build_entity_document` and marked `xfail(strict=True)`. `llm_handler.py:868` — the only production call site — was still asserting the flag was on, and `docs/research/_index.md:21` still carried the retracted claim; both fixed.
