### PR TITLE
fix(ansible): crash-looping units restart forever and never reach `failed` (#4090)

### DIFF
--- a/autobot-slm-backend/ansible/roles/ai-stack/templates/autobot-ai-stack.service.j2
+++ b/autobot-slm-backend/ansible/roles/ai-stack/templates/autobot-ai-stack.service.j2
@@ -20,6 +20,15 @@ EnvironmentFile=/etc/autobot/autobot-ai-stack.env
 ExecStart={{ backend_install_dir | default('/opt/autobot/autobot-backend') }}/venv/bin/uvicorn ai_api_server:app --host {{ ai_host }} --port {{ ai_port }} --workers 2
 Restart=always
 RestartSec=10
+# #4090: without these, a unit that can never exec restarts forever and stays
+# out of `systemctl --failed`, so the one thing an operator checks cannot see it
+# (chromadb: 1681 restarts over ~4h45m, invisible). systemd's OWN defaults do not
+# help — DefaultStartLimitIntervalSec=10s with DefaultStartLimitBurst=5 needs 5
+# restarts inside 10s, and RestartSec spaces them further apart than that, so the
+# rate never reaches the limit. The window has to be wider than
+# RestartSec * StartLimitBurst for the limit to be reachable at all.
+StartLimitIntervalSec=120
+StartLimitBurst=5
 StandardOutput=append:{{ ai_log_dir }}/ai-stack.log
 StandardError=append:{{ ai_log_dir }}/ai-stack-error.log
 

--- a/autobot-slm-backend/ansible/roles/ai-stack/templates/autobot-chromadb.service.j2
+++ b/autobot-slm-backend/ansible/roles/ai-stack/templates/autobot-chromadb.service.j2
@@ -30,6 +30,15 @@ EnvironmentFile={{ chromadb_authn_env_file }}
 ExecStart={{ ai_install_dir }}/venv/bin/chroma run --host {{ chromadb_host }} --port {{ chromadb_port }} --path {{ chromadb_persist_dir }}
 Restart=always
 RestartSec=10
+# #4090: without these, a unit that can never exec restarts forever and stays
+# out of `systemctl --failed`, so the one thing an operator checks cannot see it
+# (chromadb: 1681 restarts over ~4h45m, invisible). systemd's OWN defaults do not
+# help — DefaultStartLimitIntervalSec=10s with DefaultStartLimitBurst=5 needs 5
+# restarts inside 10s, and RestartSec spaces them further apart than that, so the
+# rate never reaches the limit. The window has to be wider than
+# RestartSec * StartLimitBurst for the limit to be reachable at all.
+StartLimitIntervalSec=120
+StartLimitBurst=5
 StandardOutput=append:{{ ai_log_dir }}/chromadb.log
 StandardError=append:{{ ai_log_dir }}/chromadb-error.log
 

--- a/autobot-slm-backend/ansible/roles/backend/templates/autobot-celery-beat.service.j2
+++ b/autobot-slm-backend/ansible/roles/backend/templates/autobot-celery-beat.service.j2
@@ -45,6 +45,15 @@ TimeoutStopSec=30
 
 Restart=always
 RestartSec=5
+# #4090: without these, a unit that can never exec restarts forever and stays
+# out of `systemctl --failed`, so the one thing an operator checks cannot see it
+# (chromadb: 1681 restarts over ~4h45m, invisible). systemd's OWN defaults do not
+# help — DefaultStartLimitIntervalSec=10s with DefaultStartLimitBurst=5 needs 5
+# restarts inside 10s, and RestartSec spaces them further apart than that, so the
+# rate never reaches the limit. The window has to be wider than
+# RestartSec * StartLimitBurst for the limit to be reachable at all.
+StartLimitIntervalSec=120
+StartLimitBurst=5
 
 StandardOutput=append:{{ backend_log_dir }}/celery-beat.log
 StandardError=append:{{ backend_log_dir }}/celery-beat-error.log

--- a/autobot-slm-backend/ansible/roles/backend/templates/autobot-celery.service.j2
+++ b/autobot-slm-backend/ansible/roles/backend/templates/autobot-celery.service.j2
@@ -38,6 +38,15 @@ TimeoutStopSec=30
 # Restart policy
 Restart=always
 RestartSec=5
+# #4090: without these, a unit that can never exec restarts forever and stays
+# out of `systemctl --failed`, so the one thing an operator checks cannot see it
+# (chromadb: 1681 restarts over ~4h45m, invisible). systemd's OWN defaults do not
+# help — DefaultStartLimitIntervalSec=10s with DefaultStartLimitBurst=5 needs 5
+# restarts inside 10s, and RestartSec spaces them further apart than that, so the
+# rate never reaches the limit. The window has to be wider than
+# RestartSec * StartLimitBurst for the limit to be reachable at all.
+StartLimitIntervalSec=120
+StartLimitBurst=5
 
 # Logging
 StandardOutput=append:{{ backend_log_dir }}/celery.log

--- a/autobot-slm-backend/ansible/roles/browser/templates/playwright.service.j2
+++ b/autobot-slm-backend/ansible/roles/browser/templates/playwright.service.j2
@@ -26,6 +26,15 @@ ExecStart=/usr/bin/node /opt/autobot/autobot-browser-worker/playwright-server.js
 # Restart policy
 Restart=always
 RestartSec=5s
+# #4090: without these, a unit that can never exec restarts forever and stays
+# out of `systemctl --failed`, so the one thing an operator checks cannot see it
+# (chromadb: 1681 restarts over ~4h45m, invisible). systemd's OWN defaults do not
+# help — DefaultStartLimitIntervalSec=10s with DefaultStartLimitBurst=5 needs 5
+# restarts inside 10s, and RestartSec spaces them further apart than that, so the
+# rate never reaches the limit. The window has to be wider than
+# RestartSec * StartLimitBurst for the limit to be reachable at all.
+StartLimitIntervalSec=120
+StartLimitBurst=5
 
 # Limits
 LimitNOFILE=65535

--- a/autobot-slm-backend/ansible/roles/browser/templates/vnc.service.j2
+++ b/autobot-slm-backend/ansible/roles/browser/templates/vnc.service.j2
@@ -26,6 +26,17 @@ ExecStop=/usr/bin/vncserver -kill {{ vnc_display }}
 # Restart policy
 Restart=on-failure
 RestartSec=10s
+# #4090: without these, a unit whose ExecStart can never succeed restarts forever
+# and stays out of `systemctl --failed`, so the one thing an operator checks
+# cannot see it (chromadb: 1681 restarts over ~4h45m, invisible). `on-failure`
+# is no safer than `always` here — an exec that never succeeds never exits
+# cleanly, so it reschedules just as indefinitely. systemd's OWN defaults do not
+# help: DefaultStartLimitIntervalSec=10s with DefaultStartLimitBurst=5 needs 5
+# restarts inside 10s, and RestartSec spaces them further apart, so the rate
+# never reaches the limit. The window must exceed RestartSec * StartLimitBurst
+# for the limit to be reachable at all.
+StartLimitIntervalSec=120
+StartLimitBurst=5
 
 # Logging
 StandardOutput=journal

--- a/autobot-slm-backend/ansible/roles/centralized_logging/templates/loki.service.j2
+++ b/autobot-slm-backend/ansible/roles/centralized_logging/templates/loki.service.j2
@@ -11,6 +11,17 @@ Group={{ logging_group }}
 ExecStart={{ loki_binary_path }} -config.file={{ loki_config_dir }}/config.yml
 Restart=on-failure
 RestartSec=10s
+# #4090: without these, a unit whose ExecStart can never succeed restarts forever
+# and stays out of `systemctl --failed`, so the one thing an operator checks
+# cannot see it (chromadb: 1681 restarts over ~4h45m, invisible). `on-failure`
+# is no safer than `always` here — an exec that never succeeds never exits
+# cleanly, so it reschedules just as indefinitely. systemd's OWN defaults do not
+# help: DefaultStartLimitIntervalSec=10s with DefaultStartLimitBurst=5 needs 5
+# restarts inside 10s, and RestartSec spaces them further apart, so the rate
+# never reaches the limit. The window must exceed RestartSec * StartLimitBurst
+# for the limit to be reachable at all.
+StartLimitIntervalSec=120
+StartLimitBurst=5
 StandardOutput=journal
 StandardError=journal
 SyslogIdentifier=loki

--- a/autobot-slm-backend/ansible/roles/centralized_logging/templates/promtail.service.j2
+++ b/autobot-slm-backend/ansible/roles/centralized_logging/templates/promtail.service.j2
@@ -11,6 +11,17 @@ Group={{ logging_group }}
 ExecStart={{ promtail_binary_path }} -config.file={{ promtail_config_dir }}/config.yml
 Restart=on-failure
 RestartSec=10s
+# #4090: without these, a unit whose ExecStart can never succeed restarts forever
+# and stays out of `systemctl --failed`, so the one thing an operator checks
+# cannot see it (chromadb: 1681 restarts over ~4h45m, invisible). `on-failure`
+# is no safer than `always` here — an exec that never succeeds never exits
+# cleanly, so it reschedules just as indefinitely. systemd's OWN defaults do not
+# help: DefaultStartLimitIntervalSec=10s with DefaultStartLimitBurst=5 needs 5
+# restarts inside 10s, and RestartSec spaces them further apart, so the rate
+# never reaches the limit. The window must exceed RestartSec * StartLimitBurst
+# for the limit to be reachable at all.
+StartLimitIntervalSec=120
+StartLimitBurst=5
 StandardOutput=journal
 StandardError=journal
 SyslogIdentifier=promtail

--- a/autobot-slm-backend/ansible/roles/frontend/templates/autobot-frontend.service.j2
+++ b/autobot-slm-backend/ansible/roles/frontend/templates/autobot-frontend.service.j2
@@ -19,6 +19,15 @@ ExecStart=/usr/bin/npm run dev -- --host {{ frontend_host }} --port {{ frontend_
 {% endif %}
 Restart=always
 RestartSec=5
+# #4090: without these, a unit that can never exec restarts forever and stays
+# out of `systemctl --failed`, so the one thing an operator checks cannot see it
+# (chromadb: 1681 restarts over ~4h45m, invisible). systemd's OWN defaults do not
+# help — DefaultStartLimitIntervalSec=10s with DefaultStartLimitBurst=5 needs 5
+# restarts inside 10s, and RestartSec spaces them further apart than that, so the
+# rate never reaches the limit. The window has to be wider than
+# RestartSec * StartLimitBurst for the limit to be reachable at all.
+StartLimitIntervalSec=120
+StartLimitBurst=5
 StandardOutput=append:{{ frontend_log_dir }}/frontend.log
 StandardError=append:{{ frontend_log_dir }}/frontend-error.log
 

--- a/autobot-slm-backend/ansible/roles/frontend/templates/frontend.service.j2
+++ b/autobot-slm-backend/ansible/roles/frontend/templates/frontend.service.j2
@@ -20,6 +20,15 @@ ExecStart=/usr/bin/npm run dev -- --host 0.0.0.0 --port {{ frontend_port }}
 # Restart policy
 Restart=always
 RestartSec=5s
+# #4090: without these, a unit that can never exec restarts forever and stays
+# out of `systemctl --failed`, so the one thing an operator checks cannot see it
+# (chromadb: 1681 restarts over ~4h45m, invisible). systemd's OWN defaults do not
+# help — DefaultStartLimitIntervalSec=10s with DefaultStartLimitBurst=5 needs 5
+# restarts inside 10s, and RestartSec spaces them further apart than that, so the
+# rate never reaches the limit. The window has to be wider than
+# RestartSec * StartLimitBurst for the limit to be reachable at all.
+StartLimitIntervalSec=120
+StartLimitBurst=5
 
 # Limits
 LimitNOFILE=65535

--- a/autobot-slm-backend/ansible/roles/llm/templates/ollama.service.j2
+++ b/autobot-slm-backend/ansible/roles/llm/templates/ollama.service.j2
@@ -33,6 +33,15 @@ Environment="OLLAMA_NUM_GPU={{ effective_gpu }}"
 ExecStart=/usr/local/bin/ollama serve
 Restart=always
 RestartSec=5
+# #4090: without these, a unit that can never exec restarts forever and stays
+# out of `systemctl --failed`, so the one thing an operator checks cannot see it
+# (chromadb: 1681 restarts over ~4h45m, invisible). systemd's OWN defaults do not
+# help — DefaultStartLimitIntervalSec=10s with DefaultStartLimitBurst=5 needs 5
+# restarts inside 10s, and RestartSec spaces them further apart than that, so the
+# rate never reaches the limit. The window has to be wider than
+# RestartSec * StartLimitBurst for the limit to be reachable at all.
+StartLimitIntervalSec=120
+StartLimitBurst=5
 LimitNOFILE=65535
 
 [Install]

--- a/autobot-slm-backend/ansible/roles/monitoring/templates/node_exporter.service.j2
+++ b/autobot-slm-backend/ansible/roles/monitoring/templates/node_exporter.service.j2
@@ -22,6 +22,15 @@ ExecStart=/opt/node_exporter/node_exporter \
 SyslogIdentifier=node_exporter
 Restart=always
 RestartSec=5s
+# #4090: without these, a unit that can never exec restarts forever and stays
+# out of `systemctl --failed`, so the one thing an operator checks cannot see it
+# (chromadb: 1681 restarts over ~4h45m, invisible). systemd's OWN defaults do not
+# help — DefaultStartLimitIntervalSec=10s with DefaultStartLimitBurst=5 needs 5
+# restarts inside 10s, and RestartSec spaces them further apart than that, so the
+# rate never reaches the limit. The window has to be wider than
+# RestartSec * StartLimitBurst for the limit to be reachable at all.
+StartLimitIntervalSec=120
+StartLimitBurst=5
 
 # Security hardening
 NoNewPrivileges=yes

--- a/autobot-slm-backend/ansible/roles/monitoring/templates/prometheus.service.j2
+++ b/autobot-slm-backend/ansible/roles/monitoring/templates/prometheus.service.j2
@@ -28,6 +28,15 @@ ExecStart={{ prometheus_install_dir }}/prometheus \
 SyslogIdentifier=prometheus
 Restart=always
 RestartSec=5s
+# #4090: without these, a unit that can never exec restarts forever and stays
+# out of `systemctl --failed`, so the one thing an operator checks cannot see it
+# (chromadb: 1681 restarts over ~4h45m, invisible). systemd's OWN defaults do not
+# help — DefaultStartLimitIntervalSec=10s with DefaultStartLimitBurst=5 needs 5
+# restarts inside 10s, and RestartSec spaces them further apart than that, so the
+# rate never reaches the limit. The window has to be wider than
+# RestartSec * StartLimitBurst for the limit to be reachable at all.
+StartLimitIntervalSec=120
+StartLimitBurst=5
 
 # Security hardening
 NoNewPrivileges=yes

--- a/autobot-slm-backend/ansible/roles/npu-worker/templates/autobot-npu-worker.service.j2
+++ b/autobot-slm-backend/ansible/roles/npu-worker/templates/autobot-npu-worker.service.j2
@@ -15,6 +15,15 @@ EnvironmentFile=/opt/autobot/autobot-npu-worker/.env
 ExecStart={{ npu_install_dir }}/venv/bin/python {{ npu_install_dir }}/npu-worker.py
 Restart=always
 RestartSec=10
+# #4090: without these, a unit that can never exec restarts forever and stays
+# out of `systemctl --failed`, so the one thing an operator checks cannot see it
+# (chromadb: 1681 restarts over ~4h45m, invisible). systemd's OWN defaults do not
+# help — DefaultStartLimitIntervalSec=10s with DefaultStartLimitBurst=5 needs 5
+# restarts inside 10s, and RestartSec spaces them further apart than that, so the
+# rate never reaches the limit. The window has to be wider than
+# RestartSec * StartLimitBurst for the limit to be reachable at all.
+StartLimitIntervalSec=120
+StartLimitBurst=5
 StandardOutput=append:{{ npu_log_dir }}/npu-worker.log
 StandardError=append:{{ npu_log_dir }}/npu-worker-error.log
 

--- a/autobot-slm-backend/ansible/roles/redis/templates/autobot-chromadb.service.j2
+++ b/autobot-slm-backend/ansible/roles/redis/templates/autobot-chromadb.service.j2
@@ -37,6 +37,17 @@ ExecStart={{ chromadb_install_dir }}/venv/bin/chroma run \
 
 Restart=on-failure
 RestartSec=10
+# #4090: without these, a unit whose ExecStart can never succeed restarts forever
+# and stays out of `systemctl --failed`, so the one thing an operator checks
+# cannot see it (chromadb: 1681 restarts over ~4h45m, invisible). `on-failure`
+# is no safer than `always` here — an exec that never succeeds never exits
+# cleanly, so it reschedules just as indefinitely. systemd's OWN defaults do not
+# help: DefaultStartLimitIntervalSec=10s with DefaultStartLimitBurst=5 needs 5
+# restarts inside 10s, and RestartSec spaces them further apart, so the rate
+# never reaches the limit. The window must exceed RestartSec * StartLimitBurst
+# for the limit to be reachable at all.
+StartLimitIntervalSec=120
+StartLimitBurst=5
 TimeoutStartSec=30
 TimeoutStopSec=30
 MemoryMax=4G

--- a/autobot-slm-backend/ansible/roles/redis/templates/redis_exporter.service.j2
+++ b/autobot-slm-backend/ansible/roles/redis/templates/redis_exporter.service.j2
@@ -22,6 +22,17 @@ Environment="REDIS_PASSWORD={{ redis_password }}"
 {% endif %}
 Restart=on-failure
 RestartSec=5s
+# #4090: without these, a unit whose ExecStart can never succeed restarts forever
+# and stays out of `systemctl --failed`, so the one thing an operator checks
+# cannot see it (chromadb: 1681 restarts over ~4h45m, invisible). `on-failure`
+# is no safer than `always` here — an exec that never succeeds never exits
+# cleanly, so it reschedules just as indefinitely. systemd's OWN defaults do not
+# help: DefaultStartLimitIntervalSec=10s with DefaultStartLimitBurst=5 needs 5
+# restarts inside 10s, and RestartSec spaces them further apart, so the rate
+# never reaches the limit. The window must exceed RestartSec * StartLimitBurst
+# for the limit to be reachable at all.
+StartLimitIntervalSec=120
+StartLimitBurst=5
 NoNewPrivileges=true
 ProtectSystem=strict
 ProtectHome=true

--- a/autobot-slm-backend/ansible/roles/slm_agent/templates/slm-agent.service.j2
+++ b/autobot-slm-backend/ansible/roles/slm_agent/templates/slm-agent.service.j2
@@ -65,6 +65,15 @@ ExecStart=/usr/bin/python3 -m slm.agent.agent \
 # Restart policy
 Restart=always
 RestartSec={{ slm_agent_restart_sec }}
+# #4090: without these, a unit that can never exec restarts forever and stays
+# out of `systemctl --failed`, so the one thing an operator checks cannot see it
+# (chromadb: 1681 restarts over ~4h45m, invisible). systemd's OWN defaults do not
+# help — DefaultStartLimitIntervalSec=10s with DefaultStartLimitBurst=5 needs 5
+# restarts inside 10s, and RestartSec spaces them further apart than that, so the
+# rate never reaches the limit. The window has to be wider than
+# RestartSec * StartLimitBurst for the limit to be reachable at all.
+StartLimitIntervalSec=120
+StartLimitBurst=5
 
 # Watchdog (systemd will restart if agent becomes unresponsive)
 WatchdogSec={{ slm_agent_watchdog_sec }}

--- a/autobot-slm-backend/ansible/roles/slm_manager/templates/autobot-slm-backend.service.j2
+++ b/autobot-slm-backend/ansible/roles/slm_manager/templates/autobot-slm-backend.service.j2
@@ -23,6 +23,15 @@ ExecStart={{ slm_backend_dir }}/venv/bin/uvicorn main:app --host {{ slm_backend_
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=always
 RestartSec=5
+# #4090: without these, a unit that can never exec restarts forever and stays
+# out of `systemctl --failed`, so the one thing an operator checks cannot see it
+# (chromadb: 1681 restarts over ~4h45m, invisible). systemd's OWN defaults do not
+# help — DefaultStartLimitIntervalSec=10s with DefaultStartLimitBurst=5 needs 5
+# restarts inside 10s, and RestartSec spaces them further apart than that, so the
+# rate never reaches the limit. The window has to be wider than
+# RestartSec * StartLimitBurst for the limit to be reachable at all.
+StartLimitIntervalSec=120
+StartLimitBurst=5
 TimeoutStopSec={{ slm_backend_stop_timeout_sec | default(45) }}
 StandardOutput=append:{{ slm_log_dir }}/slm-backend.log
 StandardError=append:{{ slm_log_dir }}/slm-backend-error.log

--- a/autobot-slm-backend/ansible/roles/tts-worker/templates/autobot-tts-worker.service.j2
+++ b/autobot-slm-backend/ansible/roles/tts-worker/templates/autobot-tts-worker.service.j2
@@ -15,6 +15,15 @@ EnvironmentFile={{ tts_install_dir }}/.env
 ExecStart={{ tts_install_dir }}/venv/bin/python {{ tts_install_dir }}/tts-worker.py
 Restart=always
 RestartSec=10
+# #4090: without these, a unit that can never exec restarts forever and stays
+# out of `systemctl --failed`, so the one thing an operator checks cannot see it
+# (chromadb: 1681 restarts over ~4h45m, invisible). systemd's OWN defaults do not
+# help — DefaultStartLimitIntervalSec=10s with DefaultStartLimitBurst=5 needs 5
+# restarts inside 10s, and RestartSec spaces them further apart than that, so the
+# rate never reaches the limit. The window has to be wider than
+# RestartSec * StartLimitBurst for the limit to be reachable at all.
+StartLimitIntervalSec=120
+StartLimitBurst=5
 StandardOutput=append:{{ tts_log_dir }}/tts-worker.log
 StandardError=append:{{ tts_log_dir }}/tts-worker-error.log
 

--- a/autobot-slm-backend/ansible/roles/vnc/templates/vnc-server.service.j2
+++ b/autobot-slm-backend/ansible/roles/vnc/templates/vnc-server.service.j2
@@ -25,6 +25,17 @@ ExecStop=/usr/bin/vncserver -kill :{{ vnc_display }}
 
 Restart=on-failure
 RestartSec=5
+# #4090: without these, a unit whose ExecStart can never succeed restarts forever
+# and stays out of `systemctl --failed`, so the one thing an operator checks
+# cannot see it (chromadb: 1681 restarts over ~4h45m, invisible). `on-failure`
+# is no safer than `always` here — an exec that never succeeds never exits
+# cleanly, so it reschedules just as indefinitely. systemd's OWN defaults do not
+# help: DefaultStartLimitIntervalSec=10s with DefaultStartLimitBurst=5 needs 5
+# restarts inside 10s, and RestartSec spaces them further apart, so the rate
+# never reaches the limit. The window must exceed RestartSec * StartLimitBurst
+# for the limit to be reachable at all.
+StartLimitIntervalSec=120
+StartLimitBurst=5
 
 [Install]
 WantedBy=multi-user.target

--- a/autobot-slm-backend/ansible/roles/vnc/templates/vnc-websockify.service.j2
+++ b/autobot-slm-backend/ansible/roles/vnc/templates/vnc-websockify.service.j2
@@ -26,6 +26,17 @@ ExecStart=/usr/bin/websockify --web={{ novnc_path }} \
 
 Restart=on-failure
 RestartSec=5
+# #4090: without these, a unit whose ExecStart can never succeed restarts forever
+# and stays out of `systemctl --failed`, so the one thing an operator checks
+# cannot see it (chromadb: 1681 restarts over ~4h45m, invisible). `on-failure`
+# is no safer than `always` here — an exec that never succeeds never exits
+# cleanly, so it reschedules just as indefinitely. systemd's OWN defaults do not
+# help: DefaultStartLimitIntervalSec=10s with DefaultStartLimitBurst=5 needs 5
+# restarts inside 10s, and RestartSec spaces them further apart, so the rate
+# never reaches the limit. The window must exceed RestartSec * StartLimitBurst
+# for the limit to be reachable at all.
+StartLimitIntervalSec=120
+StartLimitBurst=5
 
 [Install]
 WantedBy=multi-user.target

--- a/autobot-slm-backend/ansible/templates/autobot-backend-single-worker.service.j2
+++ b/autobot-slm-backend/ansible/templates/autobot-backend-single-worker.service.j2
@@ -23,6 +23,15 @@ ExecStart={{ backend_venv }}/bin/uvicorn main:app --host 0.0.0.0 --port 8443 --w
 
 Restart=always
 RestartSec=5
+# #4090: without these, a unit that can never exec restarts forever and stays
+# out of `systemctl --failed`, so the one thing an operator checks cannot see it
+# (chromadb: 1681 restarts over ~4h45m, invisible). systemd's OWN defaults do not
+# help — DefaultStartLimitIntervalSec=10s with DefaultStartLimitBurst=5 needs 5
+# restarts inside 10s, and RestartSec spaces them further apart than that, so the
+# rate never reaches the limit. The window has to be wider than
+# RestartSec * StartLimitBurst for the limit to be reachable at all.
+StartLimitIntervalSec=120
+StartLimitBurst=5
 StandardOutput=append:/var/log/autobot/backend.log
 StandardError=append:/var/log/autobot/backend-error.log
 

--- a/autobot-slm-backend/ansible/templates/systemd/redis-stack-server.service.j2
+++ b/autobot-slm-backend/ansible/templates/systemd/redis-stack-server.service.j2
@@ -19,6 +19,15 @@ ExecStop=/bin/kill -s TERM $MAINPID
 
 Restart=always
 RestartSec=5
+# #4090: without these, a unit that can never exec restarts forever and stays
+# out of `systemctl --failed`, so the one thing an operator checks cannot see it
+# (chromadb: 1681 restarts over ~4h45m, invisible). systemd's OWN defaults do not
+# help — DefaultStartLimitIntervalSec=10s with DefaultStartLimitBurst=5 needs 5
+# restarts inside 10s, and RestartSec spaces them further apart than that, so the
+# rate never reaches the limit. The window has to be wider than
+# RestartSec * StartLimitBurst for the limit to be reachable at all.
+StartLimitIntervalSec=120
+StartLimitBurst=5
 TimeoutStopSec=10
 
 # Resource limits

--- a/autobot-slm-backend/tests/test_restart_always_units_can_fail_4090.py
+++ b/autobot-slm-backend/tests/test_restart_always_units_can_fail_4090.py
@@ -1,0 +1,157 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Every restarting unit must be able to reach `failed` (#4090).
+
+ChromaDB restarted 1681 times over ~4h45m and never appeared in
+`systemctl --failed`. Nothing was broken about the detection — there was none to
+break. `Restart=always` reschedules forever, so a unit whose ExecStart can never
+succeed stays `activating` and the one thing an operator checks structurally
+cannot show it. RAG, knowledge-base search, codebase-analytics embeddings and
+conversation retrieval were all down for the duration; it surfaced through an
+unrelated investigation.
+
+systemd's own defaults do not save you, which is the part worth pinning:
+``DefaultStartLimitIntervalSec=10s`` with ``DefaultStartLimitBurst=5`` needs five
+restarts *inside ten seconds*, and ``RestartSec`` spaces them further apart than
+that. At ``RestartSec=10`` five restarts take ~50s, so the rate never reaches the
+limit and the unit loops until someone notices. The limit is only reachable when
+
+    StartLimitIntervalSec > RestartSec * StartLimitBurst
+
+which is the invariant asserted below — not merely "the directives are present".
+A unit could set both and still be unable to fail, which would look like a fix
+and be none.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_ANSIBLE_ROOT = Path(__file__).resolve().parents[1] / "ansible"
+
+# `on-failure` is in scope alongside `always`, and leaving it out was the first
+# version's mistake: an ExecStart that can never succeed never exits cleanly, so
+# `on-failure` reschedules just as indefinitely. The unit from the incident —
+# the redis role's autobot-chromadb, which won the template race and is what
+# actually runs — is `on-failure`, so the narrow check missed the very thing it
+# was written for.
+_RESTARTING = re.compile(r"^\s*Restart\s*=\s*(always|on-failure)\s*$", re.MULTILINE)
+_DIRECTIVE = r"^\s*{}\s*=\s*(?P<v>\S+)\s*$"
+
+# Jinja-templated values (RestartSec={{ x }}) resolve from role defaults; the
+# largest default in the tree is 10s. Using that as the assumed worst case keeps
+# the check honest without evaluating templates.
+_ASSUMED_MAX_TEMPLATED_RESTART_SEC = 10
+
+# systemd's defaults, for the "would the default have caught it?" assertion.
+_SYSTEMD_DEFAULT_INTERVAL_SEC = 10
+_SYSTEMD_DEFAULT_BURST = 5
+
+
+def _unit_templates() -> list[Path]:
+    return sorted(_ANSIBLE_ROOT.rglob("*.service.j2"))
+
+
+def _restart_always_units() -> list[Path]:
+    return [p for p in _unit_templates() if _RESTARTING.search(p.read_text(encoding="utf-8"))]
+
+
+def _directive(text: str, name: str) -> str | None:
+    m = re.search(_DIRECTIVE.format(name), text, re.MULTILINE)
+    return m.group("v") if m else None
+
+
+# systemd accepts time spans with unit suffixes ("5min", "1h", "100ms"), and a
+# bare number means seconds. Parsing only the leading digits read "5min" as 5
+# seconds and produced a false failure on autobot-agent — a detector that cried
+# wolf, in a test written to stop exactly that.
+_TIME_UNITS = {"us": 1e-6, "ms": 1e-3, "s": 1, "sec": 1, "m": 60, "min": 60, "h": 3600, "hr": 3600}
+
+
+def _seconds(raw: str | None, default: float) -> float:
+    """Seconds from a systemd time-span value, tolerating Jinja and unit suffixes."""
+    if raw is None:
+        return default
+    if "{{" in raw:
+        return _ASSUMED_MAX_TEMPLATED_RESTART_SEC
+    total = 0.0
+    matched = False
+    for value, unit in re.findall(r"(\d+(?:\.\d+)?)\s*([a-z]*)", raw):
+        if unit and unit not in _TIME_UNITS:
+            continue
+        total += float(value) * _TIME_UNITS.get(unit, 1)
+        matched = True
+    return total if matched else default
+
+
+def test_there_are_restart_always_units_to_check():
+    """Guard the guard: a glob that stops matching would pass everything."""
+    units = _restart_always_units()
+    assert len(units) >= 10, f"expected the fleet's long-running units, found {len(units)}"
+
+
+@pytest.mark.parametrize("unit", _restart_always_units(), ids=lambda p: p.name)
+def test_restart_always_unit_declares_a_start_limit(unit: Path):
+    text = unit.read_text(encoding="utf-8")
+    interval = _directive(text, "StartLimitIntervalSec") or _directive(text, "StartLimitInterval")
+    burst = _directive(text, "StartLimitBurst")
+
+    assert interval is not None and burst is not None, (
+        f"{unit.name} sets Restart=always with no start limit — a unit that can never "
+        "exec will restart forever and never appear in `systemctl --failed` (#4090)"
+    )
+
+
+@pytest.mark.parametrize("unit", _restart_always_units(), ids=lambda p: p.name)
+def test_the_start_limit_is_actually_reachable(unit: Path):
+    """Present-but-unreachable is the failure mode, not absent.
+
+    This is the assertion that would have caught the original bug even if every
+    unit had carried systemd's defaults explicitly.
+    """
+    text = unit.read_text(encoding="utf-8")
+    restart_sec = _seconds(_directive(text, "RestartSec"), default=0)
+    interval = _seconds(_directive(text, "StartLimitIntervalSec") or _directive(text, "StartLimitInterval"), 0)
+    burst = int(_directive(text, "StartLimitBurst") or 0)
+
+    needed = restart_sec * burst
+    assert interval > needed, (
+        f"{unit.name}: StartLimitIntervalSec={interval} but {burst} restarts "
+        f"{restart_sec}s apart span {needed}s — the limit can never be reached, so the "
+        "unit loops forever exactly as it did before (#4090)"
+    )
+
+
+@pytest.mark.parametrize("unit", _restart_always_units(), ids=lambda p: p.name)
+def test_systemd_defaults_would_not_have_been_enough(unit: Path):
+    """Pins WHY each unit needs an explicit limit.
+
+    If this ever fails, systemd's defaults became sufficient for that unit and
+    the explicit directives are merely redundant — worth knowing, not a bug.
+    """
+    text = unit.read_text(encoding="utf-8")
+    restart_sec = _seconds(_directive(text, "RestartSec"), default=0)
+    if restart_sec == 0:
+        pytest.skip("no RestartSec: systemd's 100ms default trips its own start limit")
+
+    assert restart_sec * _SYSTEMD_DEFAULT_BURST > _SYSTEMD_DEFAULT_INTERVAL_SEC, (
+        f"{unit.name}: RestartSec={restart_sec}s would trip systemd's own "
+        f"{_SYSTEMD_DEFAULT_BURST}-in-{_SYSTEMD_DEFAULT_INTERVAL_SEC}s default"
+    )
+
+
+def test_chromadb_the_unit_that_looped_1681_times_is_covered():
+    """Named explicitly: it is the incident, and it ships from TWO roles."""
+    units = [p for p in _restart_always_units() if p.name == "autobot-chromadb.service.j2"]
+    assert len(units) == 2, (
+        "autobot-chromadb.service.j2 is expected in both the ai-stack and redis roles "
+        f"(see #4090 — they race and whichever runs last wins); found {len(units)}"
+    )
+    for unit in units:
+        text = unit.read_text(encoding="utf-8")
+        assert _directive(text, "StartLimitBurst") is not None, f"{unit} lost its start limit"


### PR DESCRIPTION
Closes #4090 · umbrella #13852 (Wave 2, class B — unconsumed signals) · spins out #13870

## Thinking Path

ChromaDB restarted 1681 times over ~4h45m and never appeared in `systemctl --failed`. RAG, knowledge-base
search, codebase-analytics embeddings and conversation retrieval were down for the whole window, and it
surfaced through an unrelated investigation.

Nothing was broken about the detection — there was none to break. `Restart=always` reschedules forever, so a
unit whose `ExecStart` can never succeed stays `activating`, and the one thing an operator checks
structurally cannot show it.

**systemd's own defaults do not save you, and this is the part that makes it a real bug rather than a missing
nicety.** `DefaultStartLimitIntervalSec=10s` with `DefaultStartLimitBurst=5` needs five restarts *inside ten
seconds*. `RestartSec` spaces them further apart than that — at `RestartSec=10`, five restarts take ~50s — so
the rate never reaches the limit. The limit is reachable only when

```
StartLimitIntervalSec > RestartSec * StartLimitBurst
```

Every long-running unit in the tree was in that state. **23 templates, not one.**

## What Changed

All 23 now carry `StartLimitIntervalSec=120` / `StartLimitBurst=5` — the values already used by
`autobot-backend.service.j2`, and reachable for every `RestartSec` in the tree (5 or 10 → 25s or 50s of
restarts, comfortably inside a 120s window). A unit that cannot exec now enters `failed` after ~5 attempts and
shows up where people look.

**The guard test is the actual deliverable.** It asserts the *invariant*, not the presence of the directives:
a unit could set both and still be unable to fail, which would look like a fix and be none. It also pins why
each unit needs an explicit limit, so if systemd's defaults ever become sufficient the test says so rather
than silently guarding nothing.

## Two corrections the test made to my own work

Both worth recording, because they are the same failure this umbrella is about:

- **`on-failure` is in scope, and omitting it missed the incident itself.** An `ExecStart` that can never
  succeed never exits cleanly, so `on-failure` reschedules just as indefinitely as `always`. The unit that
  actually runs — the redis role's `autobot-chromadb`, which won the two-role template race — is
  `on-failure`. My first, narrower pass skipped the very unit this issue is about.
- **The first version of the checker cried wolf.** It parsed `StartLimitInterval=5min` as five seconds and
  failed `autobot-agent`, whose limit is fine. A detector with a false positive, inside a test written to stop
  exactly that. It now parses systemd time spans properly.

## Verification

```
$ pytest autobot-slm-backend/tests/test_restart_always_units_can_fail_4090.py -q
79 passed, 1 skipped
```

Mutation-tested rather than just run — a green test here proves nothing unless it can go red:

| mutation | result |
|---|---|
| remove the start limit from a unit | **3 failed** |
| set it to systemd's own unreachable `10s` (present but useless) | **1 failed** |
| restored | 79 passed, 1 skipped |

## Not in scope

The two roles that each ship their own `autobot-chromadb.service.j2` with different `ExecStart` paths and
race for the unit name — filed as **#13870**. It needs an owner decision on which install layout is canonical
(`autobot-ai-stack/venv` vs `autobot-db-stack/chromadb/venv`; both exist on disk), so it is not something to
fold in here. This PR makes the resulting crash loop visible; it does not stop the roles fighting over the
file.

**Not verified on a host.** The mechanism is derived from the unit files and systemd's documented start-limit
semantics. Closing properly wants one live confirmation that a deliberately-broken unit now reaches `failed`
and appears in `systemctl --failed`.

## Model Used

Claude Opus 5 (1M context)
