### PR TITLE
test(code-intelligence): make fixture git failures name their own cause

### DIFF
--- a/autobot-backend/code_intelligence/co_change_test.py
+++ b/autobot-backend/code_intelligence/co_change_test.py
@@ -23,7 +23,30 @@ from code_intelligence.code_evolution_miner import GitHistoryCrawler
 
 
 def _git(repo: Path, *args: str) -> None:
-    subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True)
+    """Run git, surfacing its stderr when it fails.
+
+    #13882: ``check=True`` with ``capture_output=True`` raises
+    ``CalledProcessError``, whose message carries only the exit status — the
+    captured stderr is on the exception but never printed. A CI failure here
+    therefore read as a bare "exit status 128" with no indication of the cause,
+    which is what made the intermittent failure undiagnosable from the log.
+    """
+    result = subprocess.run(["git", "-C", str(repo), *args], capture_output=True, text=True)
+    if result.returncode != 0:
+        raise AssertionError(
+            f"git {' '.join(args)} failed in {repo} with exit {result.returncode}\n"
+            f"stdout: {result.stdout.strip()}\nstderr: {result.stderr.strip()}"
+        )
+
+
+def _git_init(path: Path) -> None:
+    """git init with the same stderr-surfacing contract as _git (#13882)."""
+    result = subprocess.run(["git", "init", "-q", str(path)], capture_output=True, text=True)
+    if result.returncode != 0:
+        raise AssertionError(
+            f"git init failed in {path} with exit {result.returncode}\n"
+            f"stdout: {result.stdout.strip()}\nstderr: {result.stderr.strip()}"
+        )
 
 
 def _commit(repo: Path, files: dict, message: str) -> None:
@@ -38,7 +61,7 @@ def _commit(repo: Path, files: dict, message: str) -> None:
 @pytest.fixture
 def repo(tmp_path):
     """A repo whose history contains one genuinely coupled pair and one busy file."""
-    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    _git_init(tmp_path)
     _git(tmp_path, "config", "user.email", "a@b.c")
     _git(tmp_path, "config", "user.name", "t")
 
@@ -99,7 +122,7 @@ def test_a_file_that_usually_changes_alone_is_not_coupled(tmp_path):
     reported pairs past the threshold — the exact noise the normalised formula
     exists to reject, arriving by a different route.
     """
-    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    _git_init(tmp_path)
     _git(tmp_path, "config", "user.email", "a@b.c")
     _git(tmp_path, "config", "user.name", "t")
     for i in range(20):
@@ -114,7 +137,7 @@ def test_a_file_that_usually_changes_alone_is_not_coupled(tmp_path):
 
 def test_solo_commits_reach_the_change_counter(tmp_path):
     """Directly: the count is history, not the paired subset."""
-    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    _git_init(tmp_path)
     _git(tmp_path, "config", "user.email", "a@b.c")
     _git(tmp_path, "config", "user.name", "t")
     _commit(tmp_path, {"a.py": "1\n"}, "solo")
@@ -209,7 +232,7 @@ def test_an_over_cap_commit_is_counted_but_never_paired(tmp_path):
     Truncating to the first N would invent pairs no author ever related — worse
     than declining to pair the commit and saying so.
     """
-    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    _git_init(tmp_path)
     _git(tmp_path, "config", "user.email", "a@b.c")
     _git(tmp_path, "config", "user.name", "t")
     _commit(tmp_path, {"a.py": "1\n", "b.py": "1\n"}, "small")
@@ -224,7 +247,7 @@ def test_an_over_cap_commit_is_counted_but_never_paired(tmp_path):
 
 def test_vendored_paths_never_enter_the_analysis(tmp_path):
     """They co-change because a tool wrote them, not because they depend on each other."""
-    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    _git_init(tmp_path)
     _git(tmp_path, "config", "user.email", "a@b.c")
     _git(tmp_path, "config", "user.name", "t")
     for i in range(5):
@@ -240,7 +263,7 @@ def test_vendored_paths_never_enter_the_analysis(tmp_path):
 
 
 def test_a_single_file_commit_contributes_no_pair(tmp_path):
-    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    _git_init(tmp_path)
     _git(tmp_path, "config", "user.email", "a@b.c")
     _git(tmp_path, "config", "user.name", "t")
     _commit(tmp_path, {"only.py": "1\n"}, "solo")
@@ -308,7 +331,7 @@ def test_non_ascii_paths_are_not_c_quoted(tmp_path):
     ``core.quotepath`` setting, so the same repository yields different identities
     for different people.
     """
-    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    _git_init(tmp_path)
     _git(tmp_path, "config", "user.email", "a@b.c")
     _git(tmp_path, "config", "user.name", "t")
     _commit(tmp_path, {"lätïn.py": "1\n", "plain.py": "1\n"}, "unicode")
@@ -321,7 +344,7 @@ def test_non_ascii_paths_are_not_c_quoted(tmp_path):
 
 def test_a_quoted_vendored_path_cannot_slip_past_the_filter(tmp_path):
     """The filter splits on path segments, so a leading quote would defeat it."""
-    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    _git_init(tmp_path)
     _git(tmp_path, "config", "user.email", "a@b.c")
     _git(tmp_path, "config", "user.name", "t")
     _commit(tmp_path, {"node_modules/pkg/ä.js": "1\n", "app.py": "1\n"}, "vendored unicode")

--- a/autobot-backend/code_intelligence/git_history_crawler_test.py
+++ b/autobot-backend/code_intelligence/git_history_crawler_test.py
@@ -24,7 +24,30 @@ from code_intelligence.code_evolution_miner import GitHistoryCrawler, _parse_num
 
 
 def _git(repo: Path, *args: str) -> None:
-    subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True)
+    """Run git, surfacing its stderr when it fails.
+
+    #13882: ``check=True`` with ``capture_output=True`` raises
+    ``CalledProcessError``, whose message carries only the exit status — the
+    captured stderr is on the exception but never printed. A CI failure here
+    therefore read as a bare "exit status 128" with no indication of the cause,
+    which is what made the intermittent failure undiagnosable from the log.
+    """
+    result = subprocess.run(["git", "-C", str(repo), *args], capture_output=True, text=True)
+    if result.returncode != 0:
+        raise AssertionError(
+            f"git {' '.join(args)} failed in {repo} with exit {result.returncode}\n"
+            f"stdout: {result.stdout.strip()}\nstderr: {result.stderr.strip()}"
+        )
+
+
+def _git_init(path: Path) -> None:
+    """git init with the same stderr-surfacing contract as _git (#13882)."""
+    result = subprocess.run(["git", "init", "-q", str(path)], capture_output=True, text=True)
+    if result.returncode != 0:
+        raise AssertionError(
+            f"git init failed in {path} with exit {result.returncode}\n"
+            f"stdout: {result.stdout.strip()}\nstderr: {result.stderr.strip()}"
+        )
 
 
 def _commit(repo: Path, files: dict, message: str) -> None:
@@ -41,7 +64,7 @@ def _commit(repo: Path, files: dict, message: str) -> None:
 
 @pytest.fixture
 def repo(tmp_path):
-    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    _git_init(tmp_path)
     _git(tmp_path, "config", "user.email", "a@b.c")
     _git(tmp_path, "config", "user.name", "Test Author")
     _commit(tmp_path, {"a.py": "one\n"}, "feat: add a")


### PR DESCRIPTION
## Thinking Path

The flake itself is not diagnosable yet, and this PR does not pretend to fix it. It fixes the reason it *cannot* be diagnosed.

The fixture helper already captured git's output:

```python
subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True)
```

`check=True` raises `CalledProcessError`, whose message carries only the exit status. The captured streams live on the exception and are never printed. So a CI failure reads as:

```
E   subprocess.CalledProcessError: Command '[...'commit', '-qm', 'unrelated 18']'
    returned non-zero exit status 128.
```

Exit 128 with no message. Everything after that is inference — I could rule out missing author identity (the fixture configures it) and "nothing to commit" (that exits 1, not 128), but not name the actual cause.

One thing the investigation changed my mind about: git does not reliably use stderr. Reproducing a failure locally, the explanation came back on **stdout**:

```
stdout: On branch master
        nothing to commit (create/copy files and use "git add" to track)
stderr:
```

So capturing stderr alone — the obvious fix — would still have produced a silent failure for a whole class of git errors. Both streams are reported.

## What Changed

Test fixtures only. No production code, no behaviour change.

- `_git` in `co_change_test.py` and `git_history_crawler_test.py` now raises an `AssertionError` carrying the command, the repo, the exit code, **and both streams**
- The nine bare `git init … check=True` calls across both files go through a `_git_init` helper with the same contract — they had the identical blind spot

## Verification

The failure now names its own cause, which is the entire point:

```
$ # forced a genuine git failure through the edited helper
CAUGHT:
    git commit -qm nothing staged failed in /tmp/tmpht7aoyyx with exit 1
    stdout: On branch master

    Initial commit

    nothing to commit (create/copy files and use "git add" to track)
    stderr:
```

Previously that was `CalledProcessError … exit status 1` and nothing else.

Suites unaffected:

```
$ pytest co_change_test.py git_history_crawler_test.py -q
44 passed in 8.57s

$ black --check + flake8   → clean
```

**Explicitly not done:** the flake is not fixed, and no retry wrapper was added. #13882 asks for the root cause to be identified *from a captured message rather than inferred*, and that message does not exist until this lands and the flake recurs. Adding a retry now would hide it permanently.

## Known duplication, deliberately not consolidated here

`_git` is defined identically in both test files — a fork. I did not merge them into one helper: the natural home would be `code_intelligence/conftest.py`, which is dedicated to `sys.modules` stub repair and would be a poor fit, and the alternative is inventing a new shared test-support module. That placement is worth deciding rather than assuming, so it is recorded on #13882 instead of guessed at here.

Refs #13882 — does not close it; the root cause is still unknown by design.

## Model Used

Opus 5
