### PR TITLE
fix(orchestration): complete the canonical service registry and guard it (#13915)

### DIFF
--- a/autobot-slm-backend/services/service_orchestrator.py
+++ b/autobot-slm-backend/services/service_orchestrator.py
@@ -41,6 +41,15 @@ class AutoBotServiceType(str, Enum):
     BROWSER = "browser"
     SLM_BACKEND = "slm-backend"
     SLM_AGENT = "slm-agent"
+    # #13915: seven running services were absent from this enum, including
+    # autobot-backend itself. Nothing failed, because the orchestration API falls
+    # back to runtime discovery — "discovered service", not "defined" — so the
+    # canonical list could be missing most of the platform without a single error.
+    CELERY = "celery"
+    CELERY_BEAT = "celery-beat"
+    CHROMADB = "chromadb"
+    TTS_WORKER = "tts-worker"
+    COORDINATOR = "coordinator"
 
 
 @dataclass
@@ -83,6 +92,7 @@ _SERVICE_DEFINITIONS = {
         stop_command="pkill -f 'python.*backend/main.py'",
         health_check_path="/api/health",
         health_check_type="https",  # Backend requires HTTPS on port 8443 (#915)
+        systemd_service="autobot-backend",  # #13915: was unnamed, so no query could find it
         requires_sudo=False,
         working_dir="/opt/autobot/autobot-backend",
         description="FastAPI backend API server",
@@ -202,6 +212,105 @@ _SERVICE_DEFINITIONS = {
         health_check_type="ssh",
         requires_sudo=True,
         description="SLM node agent for heartbeats",
+    ),
+    # #13915: the seven entries below were missing. Ports come from the ansible
+    # role defaults that render each unit, not from guesses — a registry that
+    # invents its own values is the divergence this issue is about.
+    #
+    # The backend entry above deliberately keeps its process-based start/stop
+    # commands; `systemd_service` is added so the unit is nameable, which is what
+    # a restart-set query needs (#13539).
+    "celery": ServiceDefinition(
+        name="celery",
+        service_type=AutoBotServiceType.CELERY,
+        default_host_env="",
+        default_port_env="",
+        default_host="",
+        default_port=0,  # A worker, not a listener — it has no port to probe.
+        systemd_service="autobot-celery",
+        health_check_type="systemd",
+        requires_sudo=True,
+        description="Celery worker — imports the deployed backend tree",
+        # #13539: celery served 7-day-old code across ten deploys because the
+        # updater had no authoritative "what imports the synced tree".
+        dependencies=["backend", "redis"],
+    ),
+    "celery-beat": ServiceDefinition(
+        name="celery-beat",
+        service_type=AutoBotServiceType.CELERY_BEAT,
+        default_host_env="",
+        default_port_env="",
+        default_host="",
+        default_port=0,
+        systemd_service="autobot-celery-beat",
+        health_check_type="systemd",
+        requires_sudo=True,
+        description="Celery beat scheduler — imports the deployed backend tree",
+        dependencies=["backend", "redis"],
+    ),
+    "chromadb": ServiceDefinition(
+        name="chromadb",
+        service_type=AutoBotServiceType.CHROMADB,
+        default_host_env="AUTOBOT_CHROMADB_HOST",
+        default_port_env="AUTOBOT_CHROMADB_PORT",
+        default_host=os.environ.get("AUTOBOT_CHROMADB_HOST", ""),  # noqa: ssot-fallback
+        default_port=8100,  # roles/ai-stack/defaults/main.yml: chromadb_port
+        systemd_service="autobot-chromadb",
+        health_check_type="http",
+        requires_sudo=True,
+        # #4090: crash-looped 1681 times over ~4h45m with no alert, in part
+        # because no registry-driven sweep knew it existed.
+        description="ChromaDB vector store",
+    ),
+    "tts-worker": ServiceDefinition(
+        name="tts-worker",
+        service_type=AutoBotServiceType.TTS_WORKER,
+        default_host_env="AUTOBOT_TTS_HOST",
+        default_port_env="AUTOBOT_TTS_PORT",
+        default_host=os.environ.get("AUTOBOT_TTS_HOST", ""),  # noqa: ssot-fallback
+        default_port=8083,  # roles/tts-worker/defaults/main.yml: tts_port
+        systemd_service="autobot-tts-worker",
+        health_check_type="http",
+        requires_sudo=True,
+        description="Text-to-speech worker",
+    ),
+    "ai-stack-service": ServiceDefinition(
+        name="ai-stack-service",
+        service_type=AutoBotServiceType.AI_STACK,
+        default_host_env="AUTOBOT_AI_STACK_HOST",
+        default_port_env="AUTOBOT_AI_STACK_PORT",
+        default_host=os.environ.get("AUTOBOT_AI_STACK_HOST", ""),  # noqa: ssot-fallback
+        default_port=8080,  # roles/backend/defaults/main.yml: backend_ai_stack_port
+        systemd_service="autobot-ai-stack",
+        health_check_type="http",
+        requires_sudo=True,
+        description="AI stack service (uvicorn)",
+    ),
+    "coordinator": ServiceDefinition(
+        name="coordinator",
+        service_type=AutoBotServiceType.COORDINATOR,
+        default_host_env="",
+        default_port_env="",
+        default_host="",
+        default_port=0,
+        systemd_service="autobot-coordinator",
+        health_check_type="systemd",
+        requires_sudo=True,
+        description="User-backend coordinator",
+    ),
+    "frontend-dev": ServiceDefinition(
+        name="frontend-dev",
+        service_type=AutoBotServiceType.FRONTEND,
+        default_host_env="AUTOBOT_FRONTEND_HOST",
+        default_port_env="AUTOBOT_FRONTEND_PORT",
+        default_host=os.environ.get("AUTOBOT_FRONTEND_HOST", ""),  # noqa: ssot-fallback
+        default_port=5173,
+        systemd_service="autobot-frontend",
+        health_check_type="http",
+        requires_sudo=True,
+        # Distinct from the "frontend" entry above, which is the nginx-served
+        # production surface. This is the unit the frontend role ships.
+        description="Frontend dev server unit (autobot-frontend.service)",
     ),
 }
 

--- a/autobot-slm-backend/tests/test_service_registry_covers_shipped_units_13915.py
+++ b/autobot-slm-backend/tests/test_service_registry_covers_shipped_units_13915.py
@@ -1,0 +1,173 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Every long-running AutoBot unit an ansible role ships is in the registry (#13915).
+
+`_SERVICE_DEFINITIONS` is presented as the canonical registry of orchestrable
+services and listed **2 of the 9** actually running — `autobot-backend` among the
+missing. Nothing failed, because the orchestration API falls back to runtime
+discovery; its own error message gives it away (*"node_id required for
+**discovered** service"*). A canonical source can be missing most of the platform
+and never raise.
+
+The cost was paid elsewhere: #13539 (the updater hand-wrote a restart list that
+omitted celery, which then served 7-day-old code across ten deploys) and #4090
+(chromadb crash-looped 1681 times; no registry-driven sweep knew it existed).
+
+This test is the mechanism the umbrella (#13916) asks every consolidation to ship:
+one that **fails when a new copy appears** — here, when a role starts shipping a
+service the registry does not know about.
+"""
+
+import importlib.util
+import pathlib
+import re
+
+import pytest
+
+_SLM_BACKEND = pathlib.Path(__file__).resolve().parents[1]
+_ANSIBLE = _SLM_BACKEND / "ansible"
+
+
+def _load_orchestrator():
+    """Load the module by path rather than by package name.
+
+    ``services`` exists in **both** ``autobot-backend`` and ``autobot-slm-backend``,
+    so ``from services.service_orchestrator import ...`` resolves to whichever is
+    first on the path — which under pytest is not this one. Two same-named
+    packages is its own canonical-source problem; loading by path keeps this test
+    honest about which registry it is checking.
+    """
+    path = _SLM_BACKEND / "services" / "service_orchestrator.py"
+    spec = importlib.util.spec_from_file_location("_slm_service_orchestrator_13915", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_SERVICE_DEFINITIONS = _load_orchestrator()._SERVICE_DEFINITIONS
+
+# Units that are deliberately **not** orchestrable singletons. Recorded here with
+# the reason rather than omitted, per the umbrella's second acceptance criterion —
+# an unexplained exclusion is indistinguishable from an oversight.
+_NOT_ORCHESTRABLE_SINGLETONS = {
+    # Oneshot units driven by timers, not services to start/stop/health-check.
+    "autobot-key-rotation": "oneshot, timer-driven",
+    "autobot-pg-backup": "oneshot, timer-driven",
+    # A systemd template unit: instantiated per bridge (`autobot-mcp-bridge@x`),
+    # so there is no single instance for a registry entry to describe.
+    "autobot-mcp-bridge@": "systemd template unit, instantiated per bridge",
+    # A deployment variant of autobot-backend, not a service in its own right —
+    # the two are never both running.
+    "autobot-backend-single-worker": "single-worker variant of autobot-backend",
+}
+
+
+def _service_templates() -> dict:
+    """Every ``*.service.j2`` an ansible role ships, by unit name."""
+    found = {}
+    for path in _ANSIBLE.rglob("*.service.j2"):
+        found[path.name[: -len(".service.j2")]] = path
+    return found
+
+
+def _is_long_running(path: pathlib.Path) -> bool:
+    """A unit systemd will keep alive — i.e. one worth orchestrating.
+
+    ``Restart=`` is the discriminator: oneshots do not set it. Classifying by the
+    file's own content rather than by a hand-kept list is the point, since a
+    hand-kept list is the failure mode under repair.
+    """
+    text = path.read_text(encoding="utf-8")
+    return re.search(r"^Restart=", text, re.M) is not None
+
+
+def _registry_units() -> set:
+    return {d.systemd_service for d in _SERVICE_DEFINITIONS.values() if d.systemd_service}
+
+
+# ------------------------------------------------------------- the guard
+
+
+def test_every_shipped_autobot_service_is_in_the_registry():
+    """The check that converts a silent divergence into a failing build.
+
+    Adding a role that ships ``autobot-something.service.j2`` without a registry
+    entry fails here, instead of working fine for months via discovery and then
+    surfacing as a stale worker or an unmonitored crash loop.
+    """
+    templates = _service_templates()
+    shipped = {
+        name
+        for name, path in templates.items()
+        if name.startswith("autobot-") and name not in _NOT_ORCHESTRABLE_SINGLETONS and _is_long_running(path)
+    }
+
+    missing = sorted(shipped - _registry_units())
+
+    assert missing == [], (
+        f"These units are shipped by an ansible role but absent from "
+        f"_SERVICE_DEFINITIONS: {missing}. Add a ServiceDefinition, or record the "
+        f"unit in _NOT_ORCHESTRABLE_SINGLETONS with the reason."
+    )
+
+
+def test_the_registry_names_no_unit_nobody_ships():
+    """The other direction: an entry for a unit no role ships is equally wrong.
+
+    ``autobot-agent`` was in the registry while not running on this host — the
+    same divergence pointing the other way.
+    """
+    templates = set(_service_templates())
+    # Third-party units (nginx, ollama, redis-stack-server) are managed by their
+    # own packages and ship no template here; only autobot-* units are ours.
+    ours = {u for u in _registry_units() if u.startswith("autobot-")}
+
+    unshipped = sorted(ours - templates)
+
+    assert unshipped == [], f"Registry names units no ansible role ships: {unshipped}"
+
+
+# -------------------------------------------------- the specific regressions
+
+
+@pytest.mark.parametrize(
+    "unit,issue",
+    [
+        ("autobot-backend", "the primary service, absent from the canonical registry"),
+        ("autobot-celery", "#13539: served 7-day-old code across ten deploys"),
+        ("autobot-celery-beat", "#13539: same deploy path as celery"),
+        ("autobot-chromadb", "#4090: crash-looped 1681 times unmonitored"),
+        ("autobot-tts-worker", "absent while running"),
+        ("autobot-ai-stack", "absent while running"),
+    ],
+)
+def test_the_units_this_issue_found_missing_are_present(unit, issue):
+    """Named individually so a regression says *which* service and why it mattered."""
+    assert unit in _registry_units(), f"{unit} missing from the registry — {issue}"
+
+
+def test_the_guard_would_notice_a_new_unregistered_service():
+    """Guard the guard: prove the classification actually selects units.
+
+    A `_is_long_running` that returned False for everything, or a glob that
+    matched nothing, would make the test above pass vacuously forever.
+    """
+    templates = _service_templates()
+
+    assert len(templates) > 20, f"the template glob found only {len(templates)} units"
+    assert any(_is_long_running(p) for p in templates.values())
+    assert not _is_long_running(templates["autobot-key-rotation"]), "oneshot misclassified as long-running"
+    assert _is_long_running(templates["autobot-celery"]), "a Restart= unit read as oneshot"
+
+
+def test_celery_declares_what_it_depends_on():
+    """#13539's durable fix needs edges, not just membership.
+
+    "Which services import the deployed tree and must restart after a sync?" is
+    unanswerable from a flat list, which is why the updater hand-wrote one.
+    """
+    celery = _SERVICE_DEFINITIONS["celery"]
+
+    assert "backend" in celery.dependencies


### PR DESCRIPTION
**Closes #13915.** Part of #13916.

## Thinking Path

The registry named **6 systemd units**; 14 long-running `autobot-*` units are shipped by ansible
roles, and `autobot-backend` — the primary service — was not among the 6. Nothing ever failed,
because the orchestration API falls back to runtime discovery. Its own error message is the tell:

```
POST /api/orchestration/services/autobot-celery/restart
-> 400 {"detail":"node_id required for discovered service: autobot-celery"}
```

*Discovered*, not *defined*. Discovery makes the canonical list optional at runtime, so it could be
missing most of the platform without a single error — which is why this survived long enough to cause
#13539 (the updater hand-wrote a restart list, omitted celery, and celery served 7-day-old code
across ten deploys) and to leave #4090's chromadb crash-looping 1681 times unmonitored.

### The values are derived, not invented

Every port comes from the ansible role default that renders the unit:

```
chromadb   8100   roles/ai-stack/defaults/main.yml: chromadb_port
tts-worker 8083   roles/tts-worker/defaults/main.yml: tts_port
ai-stack   8080   roles/backend/defaults/main.yml: backend_ai_stack_port
```

Celery, celery-beat and the coordinator get `default_port=0` and `health_check_type="systemd"` —
they are workers, not listeners, and giving them a probe port would be fiction. A registry that
invents its own values is the divergence this issue is about.

### The guard classifies from the files, not from a list

`Restart=` is the discriminator between a service worth orchestrating and a timer-driven oneshot.
Reading it out of each template means a new role is measured, not remembered — a hand-kept list is
exactly the failure mode under repair.

Exclusions are recorded with reasons rather than omitted, per #13916's second acceptance criterion:
two oneshots, one systemd **template** unit (`autobot-mcp-bridge@`, instantiated per bridge so there
is no single instance to describe), and `autobot-backend-single-worker` (a deployment variant, never
running alongside the real one).

The guard also checks the **other direction** — a registry entry naming a unit no role ships. That is
the same divergence pointing the other way, and it is how `autobot-agent` came to be listed while not
running.

## What Changed

- `services/service_orchestrator.py` — 5 new `AutoBotServiceType` members; 7 new `ServiceDefinition`
  entries; `systemd_service="autobot-backend"` added to the existing backend entry, which previously
  named no unit at all, so no query could find the primary service. Celery declares
  `dependencies=["backend", "redis"]` — #13539's durable fix needs edges, not just membership.
- `tests/test_service_registry_covers_shipped_units_13915.py` — 10 tests.

**Registry units: 6 → 14.**

## Verification

```
autobot-slm-backend/tests/  (service|orchestrat|registry)   574 passed, 2 skipped
flake8 · black · isort clean
```

| Mutation | Killed by |
|---|---|
| drop the celery entry (a service added without registration) | 3 tests |
| classify every unit as oneshot (a vacuous guard) | `test_the_guard_would_notice_a_new_unregistered_service` |

That second one matters: without it, a `_is_long_running` that returned `False` for everything would
make the headline assertion pass forever over an empty set.

## A second canonical-source problem found on the way

`services` is a package in **both** `autobot-backend` and `autobot-slm-backend`, so
`from services.service_orchestrator import ...` resolves to whichever is first on the path — under
pytest, not this one. The first version of this test imported an empty registry and failed for that
reason rather than a real one. It now loads the module by path, with the reason in the docstring.
Two same-named packages belongs on #13916 rather than here.

## Not done — the sequencing this issue leaves to the owner

The issue proposes four steps and states *"the measurement is the contribution and the sequencing is
an owner call"*. This delivers steps 1 and 2. Steps 3 and 4 are deliberately not attempted:

- **Discovery reconciling against the registry** rather than substituting for it — changes what an
  undeclared running service does today (silently absorbed) into a reported condition.
- **The updater deriving its restart set from the registry** — the durable form of #13539's fix, which
  currently hard-codes `autobot-celery` / `autobot-celery-beat` in the playbook because there was no
  registry to ask. Now there is.

## Model Used

Claude Opus 5 (1M context)
