### PR TITLE
fix(context): stop asserting a hardcoded owner in the L0 identity block

### DIFF
--- a/autobot-backend/chat_history/layers.py
+++ b/autobot-backend/chat_history/layers.py
@@ -7,7 +7,7 @@
 Replaces unconditional prompt injection (#4811) with a 5-tier context
 pipeline that is budget-aware and selectively loaded:
 
-  L0 Identity     (~100 tok, always) — agent role + owner
+  L0 Identity     (~100 tok, always) — agent role
   L1 EssentialStory (~500-800 tok, always) — compact memory summary
   L2 OnDemand     (~200-500 tok, conditional) — entity/topic lookup
   L3 DeepSearch   (unlimited, conditional) — hybrid KB search + rerank
@@ -76,19 +76,29 @@ _UPPER_TOKEN_RE = re.compile(r"\b[A-Z][a-zA-Z]{1,}\b")
 
 
 class Layer0Identity:
-    """Agent role + owner block. Always loaded. Estimated ~100 tokens."""
+    """Agent role block. Always loaded. Estimated ~100 tokens.
+
+    #13867: this used to assert an owner as well —
+    ``getattr(getattr(_cfg, "owner", None), "name", None) or "mrveiss"``. Neither
+    ``owner`` nor ``agent`` is an attribute of ``AutoBotConfig``; its
+    ``__getattr__`` walks the sub-configs and raises, so both lookups always fell
+    through and the block was a compile-time constant naming one individual. On a
+    platform whose standing rule is full multi-tenant management, that put a
+    specific person's name into every tenant's system prompt.
+
+    The owner line is gone rather than made configurable: a role is defensible
+    context for the model, an owner is an assertion about who the deployment
+    belongs to, and nothing consumes it. Resolving identity per tenant is a
+    product decision, recorded on #13867 rather than assumed here.
+    """
+
+    #: Kept as a module-level constant so the test that guards against a
+    #: personal name reappearing has something stable to assert against.
+    DEFAULT_ROLE = "AutoBot AI assistant"
 
     async def render(self, context: dict) -> str:  # noqa: ARG002
-        """Return a short identity block from config or safe defaults."""
-        try:
-            from autobot_shared.ssot_config import config as _cfg
-
-            owner = getattr(getattr(_cfg, "owner", None), "name", None) or "mrveiss"
-            role = getattr(getattr(_cfg, "agent", None), "role", None) or "AutoBot AI assistant"
-        except Exception:
-            owner = "mrveiss"
-            role = "AutoBot AI assistant"
-        return f"## Identity\nRole: {role}\nOwner: {owner}"
+        """Return a short identity block."""
+        return f"## Identity\nRole: {self.DEFAULT_ROLE}"
 
     async def token_estimate(self, context: dict) -> int:  # noqa: ARG002
         return 100

--- a/autobot-backend/chat_history/layers_test.py
+++ b/autobot-backend/chat_history/layers_test.py
@@ -40,7 +40,9 @@ class TestLayer0Identity:
         result = await layer.render({})
         assert "## Identity" in result
         assert "Role" in result
-        assert "Owner" in result
+        # #13867: the owner line is gone deliberately. This assertion used to
+        # require it, which made the defect look like the specification.
+        assert "Owner" not in result
 
     @pytest.mark.asyncio
     async def test_token_estimate_is_100(self):
@@ -513,3 +515,55 @@ class TestEntityFacts:
         from chat_history.layers import Layer2OnDemand
 
         assert await Layer2OnDemand().render({"user_message": "Redis?", "memory_graph": None}) == ""
+
+
+# ---------------------------------------------------------------------------
+# L0 identity must not name a person (#13867)
+#
+# The block used to end with `Owner: mrveiss`. Neither `owner` nor `agent` is an
+# attribute of AutoBotConfig, so the getattr chain guarding it always fell
+# through and the literal shipped on every deployment — into every tenant's
+# system prompt, on a platform whose standing rule is full multi-tenancy.
+# ---------------------------------------------------------------------------
+
+
+class TestLayer0CarriesNoPersonalName:
+    @pytest.mark.asyncio
+    async def test_render_names_no_individual(self):
+        from chat_history.layers import Layer0Identity
+
+        out = await Layer0Identity().render({})
+
+        assert "mrveiss" not in out
+        assert "Owner:" not in out
+        assert out == "## Identity\nRole: AutoBot AI assistant"
+
+    @pytest.mark.asyncio
+    async def test_render_is_independent_of_config(self):
+        """No config lookup means no chain that can silently fall through.
+
+        The previous implementation *looked* configurable. Rendering identically
+        with the config module unavailable is what proves it is not pretending.
+        """
+        import sys
+        from unittest.mock import patch
+
+        from chat_history.layers import Layer0Identity
+
+        with patch.dict(sys.modules, {"autobot_shared.ssot_config": None}):
+            out = await Layer0Identity().render({})
+
+        assert out == "## Identity\nRole: AutoBot AI assistant"
+
+    def test_the_config_attributes_it_used_to_read_do_not_exist(self):
+        """Pins why the old chain could never resolve, so the fix is not undone.
+
+        If AutoBotConfig ever grows a real `owner`, this fails and whoever adds
+        it has to decide deliberately whether identity should assert one — per
+        tenant — rather than reintroducing a global literal.
+        """
+        from autobot_shared.ssot_config import config as cfg
+
+        for attr in ("owner", "agent"):
+            with pytest.raises(AttributeError):
+                getattr(cfg, attr)


### PR DESCRIPTION
## Thinking Path

Verified the premise before changing anything — neither attribute the guard reads exists:

```
owner: AttributeError -> falls through to the literal
agent: AttributeError -> falls through to the literal
```

`AutoBotConfig.__getattr__` walks its sub-configs and raises when none matches, so both lookups always fell through and the block was a compile-time constant:

```
## Identity
Role: AutoBot AI assistant
Owner: mrveiss
```

The `try`/`getattr` chain made it *look* configurable, which is why it survived. On a platform whose standing rule is full multi-tenant management, that put one individual's name into every tenant's system prompt.

I took the option the issue recommends — drop the owner claim rather than invent per-tenant identity. A role is defensible context for the model; an owner is an assertion about who the deployment belongs to, nothing consumes it, and resolving it per tenant is a product decision rather than something to assume mid-fix.

## What Changed

- `Layer0Identity.render` returns `## Identity\nRole: AutoBot AI assistant` — no config lookup, so there is no chain left that can silently fall through
- `DEFAULT_ROLE` promoted to a class constant so the guard test has something stable to assert against
- The module docstring's layer table no longer says "agent role + owner"
- An existing test asserted `"Owner" in result` — it encoded the defect as the specification, and now asserts the opposite

## The trim change I made and then reverted

The issue's "Related" note asks to resolve `ContextSection.trim` in the same change: it defaults to a head-trim, which drops the tail, and `Owner:` was the last line.

I added an `all_or_nothing_trim` and pointed identity at it, reasoning that a truncated `Role: AutoBot AI` reads as fact. An existing test then failed:

```
test_the_story_absorbs_the_overflow_not_identity
  assert cwm.estimate_tokens(l0) == identity_cap, "identity keeps its whole share"
  E  assert 0 == 55
```

That test is right and I was wrong. Identity carries priority 90 precisely because *"a turn can lose recalled facts and still behave; losing who it is cannot be recovered from"*. All-or-nothing **drops** identity under contention where head-trim keeps as much as fits — I had inverted the protection the priority exists to provide.

Reverted both the strategy and its tests; `context_window_manager.py` is untouched in the final diff. With the owner line gone the original concern is moot anyway — the tail that got dropped no longer exists, and the remaining block is ~10 tokens against a ~55-token cap, so the trim never fires in practice.

## Verification

**The rendered block, against this branch's checkout** (I initially measured against the main tree by mistake and got the old string — the path is stated because "I ran it" is exactly the claim a stale checkout hides):

```
module: .worktrees/issue-13867/autobot-backend/chat_history/layers.py
render: '## Identity\nRole: AutoBot AI assistant'
no personal name: True
```

**The guard has teeth** — both ways of regressing it fail:

| Mutation | Fails |
|---|---|
| reintroduce the hardcoded owner line | `test_render_returns_identity_block`, `test_render_names_no_individual`, `test_render_is_independent_of_config` |
| reintroduce the dead `getattr` chain | the three above plus `test_render_never_raises_on_missing_config` |

One test pins *why* the old chain could never resolve: `test_the_config_attributes_it_used_to_read_do_not_exist` asserts `getattr(cfg, "owner")` raises. If config ever grows a real `owner`, it fails and forces a deliberate decision about per-tenant identity rather than a quiet literal.

```
$ pytest autobot-backend/chat_history/ autobot-backend/chat_workflow/ -q
523 passed

$ black --check + flake8   → clean
```

## Acceptance criteria

- [x] no hardcoded personal name reaches any prompt
- [x] the identity block does not claim an owner
- [x] no dead `getattr` chain left implying configurability that does not exist
- [x] a test fails if a literal owner name reappears

**Not verified:** the flag is off, so this block does not reach a live prompt today. The render is asserted directly rather than observed in a served conversation.

Closes #13867

## Model Used

Opus 5
