### PR TITLE
fix(deps): declare pytesseract so the OCR surfaces can reach tesseract (#13885)

### DIFF
--- a/autobot-backend/requirements.txt
+++ b/autobot-backend/requirements.txt
@@ -105,6 +105,12 @@ httpx>=0.28.1           # Issue #4412: hub registry fetches (async HTTP)
 pywebpush>=2.3.0        # VAPID/RFC8291 browser push delivery (GH#4459)
 beautifulsoup4>=4.15.0  # HTML parsing for link pipeline
 Pillow>=12.3.0          # Image processing - SECURITY UPDATE (OOB write fix)
+# OCR binding (#13885). MUST stay paired with the tesseract-ocr / libtesseract-dev
+# system packages installed by ansible (roles/backend/tasks/main.yml). Without this
+# line the binary ships on every host and no Python caller can reach it: /api/vision/ocr,
+# vnc_manager, gui_controller.read_text_from_region and the CAPTCHA solver all
+# guard-import it and degrade to "pytesseract not installed" with no alert.
+pytesseract>=0.3.13
 jsonschema>=4.26.0      # Issue #7405: JSON Schema validation for /knowledge/extract
 defusedxml>=0.7.1       # MVA-2039: XML parsing for WebDAV (Nextcloud connector)
 # Optional (install separately for full media support):

--- a/autobot-backend/tests/test_ocr_binding_declared_13885.py
+++ b/autobot-backend/tests/test_ocr_binding_declared_13885.py
@@ -1,0 +1,91 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+OCR dependency-pairing guard (#13885).
+
+Ansible installs the tesseract **system** packages on every backend host, but the
+Python binding that calls them lived in no requirements file. The binary shipped
+everywhere and no Python caller could reach it: ``/api/vision/ocr``, ``vnc_manager``,
+``gui_controller.read_text_from_region`` and the CAPTCHA solver each guard-import
+``pytesseract`` and degrade to a "not installed" message, so the features were
+permanently off with no crash and no alert.
+
+Half a dependency is the failure mode, so this guards the *pair* in both
+directions: the system packages without the binding is the original bug, and the
+binding without the system packages is a runtime failure at the first OCR call.
+
+Deliberately a declaration test, not an import test. The bug was a packaging gap —
+once ``pytesseract`` is declared, the resolver enforces its presence, and an import
+test would only re-assert what the installer already guarantees while failing in any
+environment that installs a subset of requirements.
+"""
+
+import pathlib
+import re
+
+import pytest
+
+_BACKEND_ROOT = pathlib.Path(__file__).resolve().parents[1]
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+_REQUIREMENTS = _BACKEND_ROOT / "requirements.txt"
+_ANSIBLE_BACKEND_TASKS = _REPO_ROOT / "autobot-slm-backend" / "ansible" / "roles" / "backend" / "tasks" / "main.yml"
+
+# System packages ansible installs for OCR, and the binding that reaches them.
+_SYSTEM_PACKAGES = ("tesseract-ocr", "libtesseract-dev")
+_BINDING = "pytesseract"
+
+
+def _declared_requirements(path: pathlib.Path) -> list[str]:
+    """Return requirement lines with comments and blanks stripped."""
+    lines = []
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if line:
+            lines.append(line)
+    return lines
+
+
+def _requirement_names(lines: list[str]) -> set[str]:
+    """Extract the distribution name from each requirement line, lowercased."""
+    names = set()
+    for line in lines:
+        match = re.match(r"^([A-Za-z0-9][A-Za-z0-9._-]*)", line)
+        if match:
+            names.add(match.group(1).lower())
+    return names
+
+
+@pytest.fixture(scope="module")
+def declared_names() -> set[str]:
+    assert _REQUIREMENTS.is_file(), f"missing requirements file: {_REQUIREMENTS}"
+    return _requirement_names(_declared_requirements(_REQUIREMENTS))
+
+
+@pytest.fixture(scope="module")
+def ansible_tasks() -> str:
+    assert _ANSIBLE_BACKEND_TASKS.is_file(), f"missing ansible tasks: {_ANSIBLE_BACKEND_TASKS}"
+    return _ANSIBLE_BACKEND_TASKS.read_text(encoding="utf-8")
+
+
+def test_binding_is_declared_in_backend_requirements(declared_names):
+    """The Python binding must be declared, or every OCR call site is dead code."""
+    assert _BINDING in declared_names, (
+        f"{_BINDING} is not declared in {_REQUIREMENTS}. Ansible installs "
+        f"{', '.join(_SYSTEM_PACKAGES)} on every host, but without this binding no "
+        "Python caller can reach tesseract and every OCR surface silently degrades "
+        "to its 'not installed' branch (#13885)."
+    )
+
+
+def test_system_packages_still_installed_by_ansible(ansible_tasks):
+    """The binding is useless without the system packages it wraps."""
+    missing = [pkg for pkg in _SYSTEM_PACKAGES if f"- {pkg}" not in ansible_tasks]
+    assert not missing, (
+        f"ansible no longer installs {missing} in {_ANSIBLE_BACKEND_TASKS}, but "
+        f"{_BINDING} is declared in backend requirements. The binding wraps the "
+        "tesseract binary — dropping the system packages makes every OCR call fail "
+        "at runtime instead of at install time (#13885)."
+    )


### PR DESCRIPTION
## Thinking Path

Found during a document-parsing capability audit (umbrella #13892). The audit was
looking for OCR in the document-ingest path and found there is none — then found
that the OCR which *does* exist, for screen and VNC capture, has never been
reachable either.

Ansible installs the tesseract **system** packages on every backend host
(`autobot-slm-backend/ansible/roles/backend/tasks/main.yml:356`, commented
"OCR / CAPTCHA solver, Issue #206"), but `pytesseract` — the Python binding that
calls them — was declared in no requirements file. Every call site guard-imports it
and degrades to a message, so there is no crash and no alert: the features are
simply permanently off. This is the `agentloop_inert_in_production` shape already
named in `llm_shared/fallback_events.py:11` — wired into one path, inert in practice.

## What Changed

- `autobot-backend/requirements.txt` — declare `pytesseract>=0.3.13`, next to
  `Pillow`, with a comment tying it to the ansible system packages so the two
  cannot drift apart again.
- `autobot-backend/tests/test_ocr_binding_declared_13885.py` — new pairing guard.

The guard checks the invariant in **both** directions, because half a dependency is
the failure mode:

- system packages without the binding → the original bug
- the binding without the system packages → a runtime failure at the first OCR call

It is deliberately a *declaration* test, not an import test. The bug was a packaging
gap; once the binding is declared the resolver enforces its presence, so an import
test would only re-assert what the installer already guarantees while failing in any
environment that installs a subset of requirements.

## Verification

Before the fix — the binary is installed, the binding is not:

```
$ grep -rn "pytesseract" --include=requirements*.txt --include=pyproject.toml .
(no matches)

$ ./venv/bin/python -c "import pytesseract"
ModuleNotFoundError: No module named 'pytesseract'
```

Tests pass:

```
$ ./venv/bin/python -m pytest autobot-backend/tests/test_ocr_binding_declared_13885.py -q
2 passed, 2 warnings in 0.52s
```

Mutation-tested rather than merely re-run — each half of the pair was broken in turn
to prove the guard can actually fail:

```
### MUTATION 1: remove the pytesseract line (reproduces the original bug)
1 failed, 1 passed
### MUTATION 2: drop the tesseract system packages from ansible
1 failed, 1 passed
### RESTORED
2 passed
```

The deploy path keeps the new line — running the same filter ansible runs
(`scripts/build-filtered-requirements.sh`, which strips only editable
`autobot-shared` entries):

```
$ bash scripts/build-filtered-requirements.sh autobot-backend/requirements.txt "$(pwd)" | grep pytesseract
112:pytesseract>=0.3.13
```

Lint clean (`flake8 --max-line-length=120`, exit 0); no `print(`.

## Remaining verification (post-merge)

The acceptance criteria on #13885 include **host** evidence — a deployed backend
returning extracted text from `POST /api/vision/ocr`. That cannot be produced from a
PR, and per the host-evidence rule the issue stays open until a code-sync lands this
and the endpoint is exercised on a host. Merging this PR does not close #13885.

## Model Used

Claude Opus 5 (1M context)

Part of #13892 — Wave 1.
