### PR TITLE
refactor(document): consolidate five forked PDF extractors onto one canonical path (#13893)

### DIFF
--- a/autobot-backend/api/knowledge.py
+++ b/autobot-backend/api/knowledge.py
@@ -61,7 +61,7 @@ from api.system_health import ComponentHealth, KnownProbes, register_health_prob
 from auth_middleware import check_admin_permission, get_auth_middleware, get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
-from constants.threshold_constants import QueryDefaults
+from constants.threshold_constants import CategoryDefaults, QueryDefaults
 from exceptions import InternalError
 from knowledge.query_sanitizer import sanitize_document as _sanitize_document
 from knowledge.schemas.documents import (
@@ -196,7 +196,7 @@ def _format_knowledge_entry(fact_id: bytes | str, fact: dict) -> dict:
         "content": fact.get("content", ""),
         "title": metadata.get("title", "Untitled"),
         "source": metadata.get("source", "unknown"),
-        "category": metadata.get("category", "general"),
+        "category": metadata.get("category", CategoryDefaults.GENERAL),
         "type": metadata.get("type", "document"),
         "created_at": metadata.get("created_at"),
         "metadata": metadata,
@@ -555,7 +555,7 @@ def _extract_add_text_fields(request: dict) -> tuple:
     text = request.get("text", "")
     title = request.get("title", "")
     source = request.get("source", "manual")
-    category = request.get("category", "general")
+    category = request.get("category", CategoryDefaults.GENERAL)
     # Issue #685: hierarchical access fields
     access_level = request.get("access_level", "user")
     visibility = request.get("visibility", "private")
@@ -980,8 +980,14 @@ async def _fetch_and_extract_url(url: str, fallback_title: str) -> "tuple[str, s
 
     from autobot_shared.security.ssrf_guard import SSRFError, fetch_safe_url
 
+    # Imported locally rather than at module scope: `config` is already a local
+    # name in add_watch_folder (a WatchFolderConfig), so a module-level import
+    # would be silently shadowed there. Kept outside the try so an ImportError
+    # surfaces as itself instead of as a fetch failure.
+    from autobot_shared.ssot_config import config
+
     try:
-        status, body_bytes, _ = await fetch_safe_url(url, timeout=30.0)
+        status, body_bytes, _ = await fetch_safe_url(url, timeout=config.timeout.default_request)
     except SSRFError:
         raise HTTPException(status_code=400, detail="Request failed")
     except aiohttp.ClientError:
@@ -1912,7 +1918,7 @@ async def search_man_pages(
     admin_check: bool = Depends(check_admin_permission),
     req: Request = None,
     query: str = None,
-    limit: int = 10,
+    limit: int = QueryDefaults.DEFAULT_SEARCH_LIMIT,
 ):
     """Search specifically for man pages in knowledge base
 
@@ -2351,7 +2357,7 @@ def _parse_fact_entry(fact_key_bytes, fact_data, get_category_for_source) -> tup
         content_raw = fact_data.get(b"content") or fact_data.get("content", b"")
         content = _decode_bytes(content_raw)
         source = metadata.get("source", "")
-        category = get_category_for_source(source).value if source else "general"
+        category = get_category_for_source(source).value if source else CategoryDefaults.GENERAL
         title = metadata.get("title", metadata.get("command", "Untitled"))
         fact_type = metadata.get("type", "unknown")
         return (fact_key, category, title, content, fact_type, metadata)
@@ -2753,9 +2759,9 @@ async def get_documentation_categories(
             try:
                 category = detect_category(Path(file_path))
             except Exception:
-                category = "general"
+                category = CategoryDefaults.GENERAL
         else:
-            category = "general"
+            category = CategoryDefaults.GENERAL
 
         category_counts[category] = category_counts.get(category, 0) + 1
 
@@ -2826,7 +2832,7 @@ async def get_documentation_stats(
             "total_indexed_entries": len(all_docs),
             "total_chunks": total_chunks,
             "latest_indexed": latest_indexed,
-            "categories_count": len(set(doc.get("category", "general") for doc in all_docs)),
+            "categories_count": len(set(doc.get("category", CategoryDefaults.GENERAL) for doc in all_docs)),
         },
     }
 

--- a/autobot-backend/api/knowledge.py
+++ b/autobot-backend/api/knowledge.py
@@ -1078,16 +1078,14 @@ def _extract_pdf_content(filename: str, file_content: bytes) -> str:
     Raises:
         HTTPException: If pypdf library is missing or parsing fails
     """
-    import io
+    from media.document.extraction import DocumentDependencyError, DocumentExtractionError, extract_pdf
 
     try:
-        import pypdf
-
-        pdf_reader = pypdf.PdfReader(io.BytesIO(file_content))
-        return "\n".join(page.extract_text() or "" for page in pdf_reader.pages)
-    except ImportError:
+        return extract_pdf(file_content).text
+    except DocumentDependencyError as e:
+        logger.error("PDF support unavailable for %s: %s", filename, e)
         raise HTTPException(status_code=400, detail="PDF support requires pypdf library")
-    except Exception as e:
+    except DocumentExtractionError as e:
         logger.error("PDF parse error for %s: %s", filename, e)
         raise HTTPException(status_code=400, detail="Failed to parse PDF file")
 
@@ -1108,16 +1106,14 @@ def _extract_docx_content(filename: str, file_content: bytes) -> str:
     Raises:
         HTTPException: If python-docx library is missing or parsing fails
     """
-    import io
+    from media.document.extraction import DocumentDependencyError, DocumentExtractionError, extract_docx
 
     try:
-        import docx
-
-        doc = docx.Document(io.BytesIO(file_content))
-        return "\n".join(para.text for para in doc.paragraphs)
-    except ImportError:
+        return extract_docx(file_content).text
+    except DocumentDependencyError as e:
+        logger.error("DOCX support unavailable for %s: %s", filename, e)
         raise HTTPException(status_code=400, detail="DOCX support requires python-docx library")
-    except Exception as e:
+    except DocumentExtractionError as e:
         logger.error("DOCX parse error for %s: %s", filename, e)
         raise HTTPException(status_code=400, detail="Failed to parse DOCX file")
 

--- a/autobot-backend/knowledge/connectors/content_extraction.py
+++ b/autobot-backend/knowledge/connectors/content_extraction.py
@@ -11,9 +11,9 @@ duplication sweep) instead of carrying its own copy.
 """
 
 import hashlib
-import io
 
 from autobot_shared.logging_manager import get_logger
+from media.document.extraction import DocumentExtractionError, extract_docx, extract_pdf
 
 logger = get_logger(__name__)
 
@@ -24,30 +24,29 @@ def content_hash(text: str) -> str:
 
 
 def extract_text_from_docx(content_bytes: bytes) -> str:
-    """Extract text from Word .docx file."""
-    try:
-        from docx import Document
+    """Extract text from Word .docx file.
 
-        doc = Document(io.BytesIO(content_bytes))
-        paragraphs = [para.text for para in doc.paragraphs if para.text.strip()]
-        return "\n\n".join(paragraphs)
-    except Exception as exc:
+    Connectors ingest in bulk, so a single unreadable file must not abort a sync:
+    failures degrade to an empty string, as they always have here.
+    """
+    try:
+        return extract_docx(content_bytes).text
+    except DocumentExtractionError as exc:
         logger.warning("Failed to extract text from DOCX: %s", exc)
         return ""
 
 
 def extract_text_from_pdf(content_bytes: bytes) -> str:
-    """Extract text from PDF file."""
-    try:
-        from PyPDF2 import PdfReader
+    """Extract text from PDF file.
 
-        pdf = PdfReader(io.BytesIO(content_bytes))
-        pages_text = []
-        for page_num, page in enumerate(pdf.pages, start=1):
-            text = page.extract_text()
-            if text.strip():
-                pages_text.append(f"## Page {page_num}\n{text}")
-        return "\n\n".join(pages_text)
-    except Exception as exc:
+    Previously ran ``PyPDF2``, which is unmaintained, while the repo pins
+    ``pypdf`` as a security update — so Drive/OneDrive ingestion used the library
+    the rest of the codebase had deliberately moved off (#13893). Now shares the
+    canonical extractor, which emits the same ``## Page N`` markers this
+    connector already used.
+    """
+    try:
+        return extract_pdf(content_bytes).text
+    except DocumentExtractionError as exc:
         logger.warning("Failed to extract text from PDF: %s", exc)
         return ""

--- a/autobot-backend/media/document/extraction.py
+++ b/autobot-backend/media/document/extraction.py
@@ -1,0 +1,244 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Canonical document text extraction (#13893).
+
+Five independent PDF extractors existed before this module: the knowledge-base
+upload endpoint, the media document pipeline, the Drive/OneDrive connectors, and
+two fully orphaned helpers. Three were live, they disagreed on page markers, and
+one still ran the unmaintained ``PyPDF2`` while the repo pins ``pypdf`` as a
+security update. Every fix to the document path had to ship five times.
+
+This module is the single implementation. Callers adapt its result to their own
+error shape — an ``HTTPException`` for the API, a ``ProcessingResult`` for the
+media pipeline, an empty string for the connectors — but nobody re-implements the
+extraction itself.
+
+Page text is kept **structured** rather than pre-joined. Callers that need a flat
+string call :func:`render_pages`; callers that need per-page provenance read
+``pages`` directly. That split is what lets page numbers reach retrieval as
+metadata instead of as marker text baked into the embedding (#13894).
+"""
+
+from __future__ import annotations
+
+import io
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Mapping, Sequence, Tuple
+
+from autobot_shared.logging_manager import get_logger
+
+logger = get_logger(__name__)
+
+# The one page-marker convention. Three different ones existed across the forks
+# (``## Page N``, ``--- Page N ---``, and none at all on the live upload path).
+PAGE_MARKER_TEMPLATE = "## Page {number}"
+
+_PDF_MAGIC = b"%PDF"
+_ZIP_MAGIC = b"PK"
+_DOCX_MARKER = b"word/"
+_DOCX_SNIFF_BYTES = 2000
+
+
+class DocumentExtractionError(Exception):
+    """Raised when a document cannot be parsed.
+
+    Callers map this to their own failure shape. It deliberately does not carry
+    an HTTP status or a pipeline result — the core has no opinion about how a
+    caller reports failure.
+    """
+
+
+class DocumentDependencyError(DocumentExtractionError):
+    """Raised when the parsing library for a format is not installed.
+
+    Kept distinct from a parse failure because the two need different responses:
+    a corrupt file is the user's problem, a missing library is ours. The media
+    pipeline reports this as ``unavailable`` rather than ``error`` so a
+    deployment gap cannot be mistaken for a bad upload.
+    """
+
+
+@dataclass(frozen=True)
+class PageText:
+    """Text recovered from a single page, 1-indexed to match human page numbers."""
+
+    number: int
+    text: str
+
+
+@dataclass(frozen=True)
+class ExtractedDocument:
+    """Structured result of a document extraction."""
+
+    format: str
+    text: str
+    pages: Tuple[PageText, ...] = ()
+    page_count: int | None = None
+    tables: Tuple[Any, ...] = ()
+    info: Mapping[str, str] = field(default_factory=dict)
+
+    @property
+    def char_count(self) -> int:
+        """Number of characters of recovered text."""
+        return len(self.text)
+
+    @property
+    def has_text(self) -> bool:
+        """Whether any non-whitespace text was recovered.
+
+        A PDF whose pages carry no text layer extracts to ``""`` rather than
+        failing, so emptiness is a normal result that callers must check — it is
+        the signal a scanned document needs OCR (#13884, #13896).
+        """
+        return bool(self.text.strip())
+
+
+def render_pages(pages: Sequence[PageText], marker: str = PAGE_MARKER_TEMPLATE) -> str:
+    """Join pages into one string, prefixing each with the canonical marker.
+
+    Pages with no recovered text are skipped so a scanned page does not emit a
+    bare marker with nothing under it.
+    """
+    parts = []
+    for page in pages:
+        if page.text.strip():
+            parts.append(f"{marker.format(number=page.number)}\n{page.text}")
+    return "\n\n".join(parts)
+
+
+def detect_format(raw: bytes, mime_type: str = "") -> str:
+    """Detect document format from magic bytes, falling back to MIME type."""
+    mime = (mime_type or "").lower()
+    if raw[:4] == _PDF_MAGIC:
+        return "pdf"
+    if raw[:2] == _ZIP_MAGIC and _DOCX_MARKER in raw[:_DOCX_SNIFF_BYTES]:
+        return "docx"
+    if "pdf" in mime:
+        return "pdf"
+    if "docx" in mime or "officedocument.wordprocessingml" in mime:
+        return "docx"
+    return "text"
+
+
+def extract_pdf(raw: bytes) -> ExtractedDocument:
+    """Extract the text layer from a PDF.
+
+    A page whose text layer is absent contributes an empty :class:`PageText`
+    rather than being dropped, so ``page_count`` stays truthful and a caller can
+    tell *which* pages were unreadable.
+    """
+    reader = _pdf_reader(raw)
+    pages = tuple(PageText(number=n, text=_pdf_page_text(page, n)) for n, page in enumerate(reader.pages, start=1))
+    info = reader.metadata or {}
+    return ExtractedDocument(
+        format="pdf",
+        text=render_pages(pages),
+        pages=pages,
+        page_count=len(pages),
+        info=_pdf_info(info),
+    )
+
+
+def _pdf_reader(raw: bytes) -> Any:
+    """Build a pypdf reader, translating library failures to our own error."""
+    try:
+        from pypdf import PdfReader
+    except ImportError as exc:  # pragma: no cover - dependency is pinned
+        raise DocumentDependencyError("PDF support requires the pypdf library") from exc
+
+    try:
+        return PdfReader(io.BytesIO(raw))
+    except Exception as exc:
+        raise DocumentExtractionError(f"Failed to parse PDF: {exc}") from exc
+
+
+def _pdf_page_text(page: Any, number: int) -> str:
+    """Extract one page, degrading to empty text rather than failing the document."""
+    try:
+        return page.extract_text() or ""
+    except Exception as exc:
+        logger.warning("Failed to extract text from PDF page %s: %s", number, exc)
+        return ""
+
+
+def _pdf_info(info: Mapping[str, Any]) -> Dict[str, str]:
+    """Normalize pypdf's slash-prefixed metadata keys."""
+    return {
+        "title": str(info.get("/Title", "") or ""),
+        "author": str(info.get("/Author", "") or ""),
+        "subject": str(info.get("/Subject", "") or ""),
+        "creator": str(info.get("/Creator", "") or ""),
+    }
+
+
+def extract_docx(raw: bytes) -> ExtractedDocument:
+    """Extract paragraphs, tables and core properties from a DOCX."""
+    try:
+        from docx import Document as DocxDocument
+    except ImportError as exc:  # pragma: no cover - dependency is pinned
+        raise DocumentDependencyError("DOCX support requires the python-docx library") from exc
+
+    try:
+        doc = DocxDocument(io.BytesIO(raw))
+        paragraphs = [p.text for p in doc.paragraphs if p.text.strip()]
+        tables = tuple(_docx_table(table) for table in doc.tables)
+    except Exception as exc:
+        raise DocumentExtractionError(f"Failed to parse DOCX: {exc}") from exc
+
+    return ExtractedDocument(
+        format="docx",
+        text="\n".join(paragraphs),
+        tables=tables,
+        info=_docx_info(doc),
+    )
+
+
+def _docx_table(table: Any) -> List[List[str]]:
+    """Render one DOCX table as rows of cell strings."""
+    return [[cell.text.strip() for cell in row.cells] for row in table.rows]
+
+
+def _docx_info(doc: Any) -> Dict[str, str]:
+    """Read DOCX core properties, tolerating documents that carry none."""
+    try:
+        props = doc.core_properties
+        return {
+            "title": props.title or "",
+            "author": props.author or "",
+            "subject": props.subject or "",
+            "keywords": props.keywords or "",
+        }
+    except Exception:
+        return {}
+
+
+def extract_plain_text(raw: bytes) -> ExtractedDocument:
+    """Decode a plain-text document as UTF-8, falling back to latin-1."""
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError:
+        text = raw.decode("latin-1", errors="replace")
+    return ExtractedDocument(format="text", text=text)
+
+
+def extract_document(raw: bytes, mime_type: str = "") -> ExtractedDocument:
+    """Detect the format and extract, dispatching to the format-specific reader."""
+    detected = detect_format(raw, mime_type)
+    if detected == "pdf":
+        return extract_pdf(raw)
+    if detected == "docx":
+        return extract_docx(raw)
+    return extract_plain_text(raw)
+
+
+def strip_page_markers(text: str, marker: str = PAGE_MARKER_TEMPLATE) -> str:
+    """Remove canonical page markers from rendered text.
+
+    Consumers that want prose without structural markers — an embedding input,
+    for instance — use this rather than re-extracting with a different renderer.
+    """
+    pattern = re.escape(marker).replace(r"\{number\}", r"\d+")
+    return re.sub(rf"^{pattern}\n?", "", text, flags=re.MULTILINE)

--- a/autobot-backend/media/document/pipeline.py
+++ b/autobot-backend/media/document/pipeline.py
@@ -10,28 +10,18 @@
 """Document processing pipeline for text documents, PDFs, DOCX, etc."""
 
 import base64
-import io
-from typing import Any, Dict, List
+from typing import Any, Dict
 
 from autobot_shared.logging_manager import get_logger
 from media.core.pipeline import BasePipeline
 from media.core.types import MediaInput, MediaType, ProcessingResult
-
-# PDF support via pypdf (required)
-try:
-    from pypdf import PdfReader
-
-    _PYPDF_AVAILABLE = True
-except ImportError:
-    _PYPDF_AVAILABLE = False
-
-# DOCX support via python-docx (required)
-try:
-    from docx import Document as DocxDocument
-
-    _DOCX_AVAILABLE = True
-except ImportError:
-    _DOCX_AVAILABLE = False
+from media.document.extraction import (
+    DocumentDependencyError,
+    DocumentExtractionError,
+    ExtractedDocument,
+    detect_format,
+    extract_document,
+)
 
 logger = get_logger(__name__)
 
@@ -59,16 +49,21 @@ class DocumentPipeline(BasePipeline):
         )
 
     async def _process_document(self, media_input: MediaInput) -> Dict[str, Any]:
-        """Dispatch to format-specific processor based on MIME type or content."""
+        """Extract via the canonical core and adapt the result to this pipeline's shape."""
         raw_bytes = self._decode_input(media_input.data)
         mime_type = (media_input.mime_type or "").lower()
-        detected = self._detect_format(raw_bytes, mime_type)
 
-        if detected == "pdf":
-            return self._extract_pdf(raw_bytes, media_input.metadata)
-        if detected == "docx":
-            return self._extract_docx(raw_bytes, media_input.metadata)
-        return self._extract_text(raw_bytes, mime_type, media_input.metadata)
+        try:
+            extracted = extract_document(raw_bytes, mime_type)
+        except DocumentDependencyError as exc:
+            # A missing library is a deployment gap, not a bad upload — keep the
+            # two distinguishable so one is never diagnosed as the other.
+            return self._unavailable_result(detect_format(raw_bytes, mime_type), str(exc), media_input.metadata)
+        except DocumentExtractionError as exc:
+            logger.warning("Document extraction failed: %s", exc)
+            return self._error_result(detect_format(raw_bytes, mime_type), str(exc), media_input.metadata)
+
+        return self._to_result(extracted, media_input.metadata)
 
     # ------------------------------------------------------------------
     # Decoding helpers
@@ -87,125 +82,47 @@ class DocumentPipeline(BasePipeline):
                     return fh.read()
         raise ValueError(f"Unsupported document data type: {type(data)}")
 
-    def _detect_format(self, raw_bytes: bytes, mime_type: str) -> str:
-        """Detect document format from magic bytes or MIME type."""
-        if raw_bytes[:4] == b"%PDF":
-            return "pdf"
-        if raw_bytes[:2] == b"PK" and b"word/" in raw_bytes[:2000]:
-            return "docx"
-        if "pdf" in mime_type:
-            return "pdf"
-        if "docx" in mime_type or "officedocument.wordprocessingml" in mime_type:
-            return "docx"
-        return "text"
-
     # ------------------------------------------------------------------
-    # Format-specific extractors
+    # Result adaptation
     # ------------------------------------------------------------------
 
-    def _extract_pdf(self, raw_bytes: bytes, metadata: Dict) -> Dict[str, Any]:
-        """Extract text and metadata from a PDF file using pypdf."""
-        if not _PYPDF_AVAILABLE:
-            return self._unavailable_result("pdf", "pypdf not installed", metadata)
-
-        try:
-            reader = PdfReader(io.BytesIO(raw_bytes))
-            pages_text = [page.extract_text() or "" for page in reader.pages]
-            full_text = "\n\n".join(pages_text)
-            info = reader.metadata or {}
-            tables = self._extract_pdf_tables(reader)
-            return {
-                "type": "document_analysis",
-                "format": "pdf",
-                "extracted_text": full_text,
-                "page_count": len(reader.pages),
-                "tables": tables,
-                "document_info": {
-                    "title": info.get("/Title", ""),
-                    "author": info.get("/Author", ""),
-                    "subject": info.get("/Subject", ""),
-                    "creator": info.get("/Creator", ""),
-                },
-                "confidence": 0.95,
-                "metadata": metadata,
-            }
-        except Exception as exc:
-            logger.warning("PDF extraction failed: %s", exc)
-            return self._error_result("pdf", str(exc), metadata)
-
-    def _extract_pdf_tables(self, reader: Any) -> List[Dict]:
-        """Best-effort table extraction from PDF annotations."""
-        # pypdf doesn't natively extract tables; return placeholder structure
-        # Full table extraction would require pdfplumber
-        return []
-
-    def _extract_docx(self, raw_bytes: bytes, metadata: Dict) -> Dict[str, Any]:
-        """Extract text and tables from a DOCX file using python-docx."""
-        if not _DOCX_AVAILABLE:
-            return self._unavailable_result("docx", "python-docx not installed", metadata)
-
-        try:
-            doc = DocxDocument(io.BytesIO(raw_bytes))
-            paragraphs = [p.text for p in doc.paragraphs if p.text.strip()]
-            full_text = "\n".join(paragraphs)
-            tables = self._extract_docx_tables(doc)
-            core_props = self._extract_docx_properties(doc)
-            return {
-                "type": "document_analysis",
-                "format": "docx",
-                "extracted_text": full_text,
-                "page_count": None,  # python-docx doesn't expose page count
-                "paragraph_count": len(paragraphs),
-                "tables": tables,
-                "document_info": core_props,
-                "confidence": 0.95,
-                "metadata": metadata,
-            }
-        except Exception as exc:
-            logger.warning("DOCX extraction failed: %s", exc)
-            return self._error_result("docx", str(exc), metadata)
-
-    def _extract_docx_tables(self, doc: Any) -> List[List[List[str]]]:
-        """Extract tables from DOCX as list-of-rows-of-cells."""
-        tables = []
-        for table in doc.tables:
-            rows = []
-            for row in table.rows:
-                rows.append([cell.text.strip() for cell in row.cells])
-            tables.append(rows)
-        return tables
-
-    def _extract_docx_properties(self, doc: Any) -> Dict[str, str]:
-        """Extract core document properties (author, title, etc.)."""
-        try:
-            props = doc.core_properties
-            return {
-                "title": props.title or "",
-                "author": props.author or "",
-                "subject": props.subject or "",
-                "keywords": props.keywords or "",
-            }
-        except Exception:
-            return {}
-
-    def _extract_text(self, raw_bytes: bytes, mime_type: str, metadata: Dict) -> Dict[str, Any]:
-        """Extract text from plain text file (UTF-8 with latin-1 fallback)."""
-        try:
-            text = raw_bytes.decode("utf-8")
-        except UnicodeDecodeError:
-            text = raw_bytes.decode("latin-1", errors="replace")
-
-        lines = text.splitlines()
-        return {
+    def _to_result(self, extracted: ExtractedDocument, metadata: Dict) -> Dict[str, Any]:
+        """Adapt a canonical ExtractedDocument to this pipeline's result dict."""
+        result: Dict[str, Any] = {
             "type": "document_analysis",
-            "format": "text",
-            "extracted_text": text,
-            "page_count": None,
-            "line_count": len(lines),
-            "char_count": len(text),
-            "confidence": 1.0,
+            "format": extracted.format,
+            "extracted_text": extracted.text,
+            "page_count": extracted.page_count,
+            "confidence": self._confidence_for(extracted),
             "metadata": metadata,
         }
+        result.update(self._format_fields(extracted))
+        return result
+
+    def _format_fields(self, extracted: ExtractedDocument) -> Dict[str, Any]:
+        """Per-format fields that are not part of the canonical result."""
+        if extracted.format == "text":
+            return {
+                "line_count": len(extracted.text.splitlines()),
+                "char_count": extracted.char_count,
+            }
+
+        fields: Dict[str, Any] = {
+            "tables": [list(table) for table in extracted.tables],
+            "document_info": dict(extracted.info),
+        }
+        if extracted.format == "docx":
+            fields["paragraph_count"] = len([line for line in extracted.text.split("\n") if line.strip()])
+        return fields
+
+    def _confidence_for(self, extracted: ExtractedDocument) -> float:
+        """Plain text decodes exactly; parsed formats keep the historical score.
+
+        PDF table extraction is still unimplemented upstream (#13895), so this
+        score continues to describe text recovery only — it is not a claim about
+        the ``tables`` field.
+        """
+        return 1.0 if extracted.format == "text" else 0.95
 
     # ------------------------------------------------------------------
     # Error/fallback helpers

--- a/autobot-backend/media/document/pipeline_test.py
+++ b/autobot-backend/media/document/pipeline_test.py
@@ -9,12 +9,33 @@
 """Unit tests for DocumentPipeline."""
 
 import base64
-from unittest.mock import MagicMock, patch
+import io
+from unittest.mock import patch
 
 import pytest
 
 from media.core.types import MediaInput, MediaType, ProcessingIntent
+from media.document.extraction import (
+    DocumentDependencyError,
+    DocumentExtractionError,
+    ExtractedDocument,
+    detect_format,
+)
 from media.document.pipeline import DocumentPipeline
+
+
+def _make_pdf(pages: list[str]) -> bytes:
+    """Build a real PDF with a text layer, so extraction is exercised end to end."""
+    reportlab = pytest.importorskip("reportlab", reason="reportlab needed to synthesize a PDF fixture")
+    from reportlab.pdfgen import canvas  # noqa: F401  (import validated by importorskip)
+
+    buffer = io.BytesIO()
+    pdf = reportlab.pdfgen.canvas.Canvas(buffer)
+    for text in pages:
+        pdf.drawString(72, 720, text)
+        pdf.showPage()
+    pdf.save()
+    return buffer.getvalue()
 
 
 def _make_input(data, mime_type="text/plain", intent=None):
@@ -49,136 +70,135 @@ class TestDocumentPipelineDecoding:
 
 
 class TestDocumentPipelineFormatDetection:
-    """Tests for _detect_format."""
+    """Format detection moved to the canonical core (#13893); assert via the pipeline result."""
 
-    def test_pdf_magic_bytes(self):
+    @pytest.mark.asyncio
+    async def test_pdf_magic_bytes_beat_a_wrong_mime_type(self):
         pipe = DocumentPipeline()
-        assert pipe._detect_format(b"%PDF-1.4 content", "") == "pdf"
+        result = await pipe._process_impl(_make_input(_make_pdf(["body"]), "text/plain"))
+        assert result.result_data["format"] == "pdf"
 
-    def test_docx_magic_bytes(self):
+    @pytest.mark.asyncio
+    async def test_text_fallback(self):
         pipe = DocumentPipeline()
-        raw = b"PK" + b"\x00" * 100 + b"word/document.xml"
-        assert pipe._detect_format(raw, "") == "docx"
+        result = await pipe._process_impl(_make_input(b"just text", "text/plain"))
+        assert result.result_data["format"] == "text"
 
-    def test_pdf_via_mime(self):
-        pipe = DocumentPipeline()
-        assert pipe._detect_format(b"plaintext", "application/pdf") == "pdf"
-
-    def test_docx_via_mime(self):
-        pipe = DocumentPipeline()
-        raw = b"not real docx bytes"
+    def test_detection_helpers_live_in_the_canonical_core(self):
+        """The pipeline must not grow its own detector back."""
+        assert detect_format(b"%PDF-1.4 content", "") == "pdf"
+        assert detect_format(b"PK" + b"\x00" * 100 + b"word/document.xml", "") == "docx"
+        assert detect_format(b"plaintext", "application/pdf") == "pdf"
         assert (
-            pipe._detect_format(
-                raw,
+            detect_format(
+                b"not real docx bytes",
                 "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
             )
             == "docx"
         )
 
-    def test_text_fallback(self):
-        pipe = DocumentPipeline()
-        assert pipe._detect_format(b"just text", "text/plain") == "text"
-
 
 class TestDocumentPipelineTextExtraction:
-    """Tests for plain text extraction."""
+    """Plain-text extraction, asserted through the public pipeline entry point."""
 
-    def test_utf8_text(self):
+    @pytest.mark.asyncio
+    async def test_utf8_text(self):
         pipe = DocumentPipeline()
-        content = b"Hello UTF-8 world"
-        result = pipe._extract_text(content, "text/plain", {})
-        assert result["format"] == "text"
-        assert result["extracted_text"] == "Hello UTF-8 world"
-        assert result["confidence"] == 1.0
+        result = await pipe._process_impl(_make_input(b"Hello UTF-8 world", "text/plain"))
+        data = result.result_data
+        assert data["format"] == "text"
+        assert data["extracted_text"] == "Hello UTF-8 world"
+        assert data["confidence"] == 1.0
 
-    def test_latin1_fallback(self):
+    @pytest.mark.asyncio
+    async def test_latin1_fallback(self):
         pipe = DocumentPipeline()
-        content = b"caf\xe9"  # café in latin-1
-        result = pipe._extract_text(content, "text/plain", {})
-        assert "caf" in result["extracted_text"]
-        assert result["confidence"] == 1.0
+        result = await pipe._process_impl(_make_input(b"caf\xe9", "text/plain"))
+        assert "caf" in result.result_data["extracted_text"]
+        assert result.result_data["confidence"] == 1.0
 
-    def test_line_and_char_count(self):
+    @pytest.mark.asyncio
+    async def test_line_and_char_count(self):
         pipe = DocumentPipeline()
         content = b"line1\nline2\nline3"
-        result = pipe._extract_text(content, "text/plain", {})
-        assert result["line_count"] == 3
-        assert result["char_count"] == len("line1\nline2\nline3")
+        result = await pipe._process_impl(_make_input(content, "text/plain"))
+        assert result.result_data["line_count"] == 3
+        assert result.result_data["char_count"] == len(content.decode())
 
 
 class TestDocumentPipelinePdf:
-    """Tests for PDF extraction."""
+    """PDF extraction against real PDFs rather than a mocked reader."""
 
-    def test_pdf_unavailable_result(self):
+    @pytest.mark.asyncio
+    async def test_pdf_extraction_success(self):
         pipe = DocumentPipeline()
-        with patch("media.document.pipeline._PYPDF_AVAILABLE", False):
-            result = pipe._extract_pdf(b"%PDF-1.4", {})
-        assert result["processing_status"] == "unavailable"
-        assert result["confidence"] == 0.0
+        result = await pipe._process_impl(_make_input(_make_pdf(["page content"]), "application/pdf"))
+        data = result.result_data
 
-    def test_pdf_extraction_success(self):
+        assert data["format"] == "pdf"
+        assert "page content" in data["extracted_text"]
+        assert data["page_count"] == 1
+        assert data["confidence"] == 0.95
+
+    @pytest.mark.asyncio
+    async def test_pdf_extraction_error_is_reported_as_error(self):
         pipe = DocumentPipeline()
-        mock_page = MagicMock()
-        mock_page.extract_text.return_value = "page content"
-        mock_reader = MagicMock()
-        mock_reader.pages = [mock_page]
-        mock_reader.metadata = {"/Title": "Test Doc", "/Author": "Author"}
-
-        with (
-            patch("media.document.pipeline._PYPDF_AVAILABLE", True),
-            patch("media.document.pipeline.PdfReader", return_value=mock_reader),
+        with patch(
+            "media.document.pipeline.extract_document",
+            side_effect=DocumentExtractionError("bad pdf"),
         ):
-            result = pipe._extract_pdf(b"%PDF-1.4", {"source": "test"})
+            result = await pipe._process_impl(_make_input(b"%PDF-1.4 garbage", "application/pdf"))
 
-        assert result["format"] == "pdf"
-        assert result["extracted_text"] == "page content"
-        assert result["page_count"] == 1
-        assert result["document_info"]["title"] == "Test Doc"
-        assert result["confidence"] == 0.95
+        assert result.result_data["processing_status"] == "error"
+        assert "bad pdf" in result.result_data["error"]
 
-    def test_pdf_extraction_error(self):
+    @pytest.mark.asyncio
+    async def test_missing_library_is_unavailable_not_error(self):
+        """A deployment gap must stay distinguishable from a corrupt upload (#13893)."""
         pipe = DocumentPipeline()
-        with (
-            patch("media.document.pipeline._PYPDF_AVAILABLE", True),
-            patch("media.document.pipeline.PdfReader", side_effect=Exception("bad pdf")),
+        with patch(
+            "media.document.pipeline.extract_document",
+            side_effect=DocumentDependencyError("PDF support requires the pypdf library"),
         ):
-            result = pipe._extract_pdf(b"garbage", {})
-        assert result["processing_status"] == "error"
-        assert "bad pdf" in result["error"]
+            result = await pipe._process_impl(_make_input(b"%PDF-1.4", "application/pdf"))
+
+        data = result.result_data
+        assert data["processing_status"] == "unavailable"
+        assert data["confidence"] == 0.0
+        assert "pypdf" in data["unavailability_reason"]
 
 
 class TestDocumentPipelineDocx:
-    """Tests for DOCX extraction."""
+    """DOCX extraction, asserted through the pipeline seam."""
 
-    def test_docx_unavailable_result(self):
+    @pytest.mark.asyncio
+    async def test_docx_unavailable_result(self):
         pipe = DocumentPipeline()
-        with patch("media.document.pipeline._DOCX_AVAILABLE", False):
-            result = pipe._extract_docx(b"PK data", {})
-        assert result["processing_status"] == "unavailable"
-
-    def test_docx_extraction_success(self):
-        pipe = DocumentPipeline()
-        mock_para = MagicMock()
-        mock_para.text = "Paragraph text"
-        mock_doc = MagicMock()
-        mock_doc.paragraphs = [mock_para]
-        mock_doc.tables = []
-        mock_doc.core_properties.title = "Doc Title"
-        mock_doc.core_properties.author = "Author"
-        mock_doc.core_properties.subject = ""
-        mock_doc.core_properties.keywords = ""
-
-        with (
-            patch("media.document.pipeline._DOCX_AVAILABLE", True),
-            patch("media.document.pipeline.DocxDocument", return_value=mock_doc),
+        with patch(
+            "media.document.pipeline.extract_document",
+            side_effect=DocumentDependencyError("DOCX support requires the python-docx library"),
         ):
-            result = pipe._extract_docx(b"PK data", {})
+            result = await pipe._process_impl(_make_input(b"PK data", "application/vnd.openxmlformats"))
+        assert result.result_data["processing_status"] == "unavailable"
 
-        assert result["format"] == "docx"
-        assert result["extracted_text"] == "Paragraph text"
-        assert result["paragraph_count"] == 1
-        assert result["document_info"]["title"] == "Doc Title"
-        assert result["confidence"] == 0.95
+    @pytest.mark.asyncio
+    async def test_docx_extraction_success(self):
+        pipe = DocumentPipeline()
+        extracted = ExtractedDocument(
+            format="docx",
+            text="Paragraph text",
+            tables=(),
+            info={"title": "Doc Title", "author": "Author", "subject": "", "keywords": ""},
+        )
+        with patch("media.document.pipeline.extract_document", return_value=extracted):
+            result = await pipe._process_impl(_make_input(b"PK data", "application/vnd.openxmlformats"))
+
+        data = result.result_data
+        assert data["format"] == "docx"
+        assert data["extracted_text"] == "Paragraph text"
+        assert data["paragraph_count"] == 1
+        assert data["document_info"]["title"] == "Doc Title"
+        assert data["confidence"] == 0.95
 
 
 class TestDocumentPipelineAsync:

--- a/autobot-backend/requirements.txt
+++ b/autobot-backend/requirements.txt
@@ -25,7 +25,9 @@ asyncpg>=0.31.0  # Async PostgreSQL driver — required for RBAC user modes (sin
 # Document Generation (MVA-2174)
 python-docx>=1.2.0  # DOCX export for transcripts
 reportlab>=5.0.0    # PDF export for transcripts
-PyPDF2>=3.0.1       # PDF testing for transcript export
+# PyPDF2 removed (#13893): unmaintained, and it was the PDF reader behind the
+# Drive/OneDrive connectors while the repo pinned pypdf as a security update
+# (requirements.txt:23). All PDF reading now goes through media/document/extraction.py.
 openpyxl>=3.1.0     # Excel file parsing for OneDrive connector (GH#9004)
 python-pptx>=0.6.23 # PowerPoint file parsing for OneDrive connector (GH#9004)
 

--- a/autobot-backend/tests/test_document_extraction_canonical_13893.py
+++ b/autobot-backend/tests/test_document_extraction_canonical_13893.py
@@ -1,0 +1,195 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Canonical document-extraction guards (#13893).
+
+Five independent PDF extractors existed before the consolidation — three live,
+two orphaned — and they disagreed on page markers. One ran the unmaintained
+``PyPDF2`` while the repo pinned ``pypdf`` as a security update, so Drive and
+OneDrive ingestion used the library everything else had deliberately moved off.
+
+These tests hold the consolidation in place. The structural guards (one reader,
+no ``PyPDF2``) are what stop the forks growing back; the behavioural ones run
+against real generated PDFs rather than mocked readers, because a mocked
+``PdfReader`` would have passed happily against all five old implementations and
+proved nothing about which one ran.
+"""
+
+import io
+import pathlib
+import re
+
+import pytest
+
+from media.document.extraction import (
+    PAGE_MARKER_TEMPLATE,
+    DocumentExtractionError,
+    ExtractedDocument,
+    PageText,
+    detect_format,
+    extract_document,
+    extract_pdf,
+    extract_plain_text,
+    render_pages,
+    strip_page_markers,
+)
+
+_BACKEND_ROOT = pathlib.Path(__file__).resolve().parents[1]
+_REQUIREMENTS = _BACKEND_ROOT / "requirements.txt"
+
+# Call sites that must not carry their own PDF reader any more.
+_CONSOLIDATED_SOURCES = (
+    "api/knowledge.py",
+    "media/document/pipeline.py",
+    "knowledge/connectors/content_extraction.py",
+    "utils/document_parser.py",
+    "utils/document_extractors.py",
+)
+
+
+def _make_pdf(pages: list[str]) -> bytes:
+    """Build a real multi-page PDF carrying a text layer."""
+    reportlab = pytest.importorskip("reportlab", reason="reportlab needed to synthesize a PDF fixture")
+    from reportlab.pdfgen import canvas  # noqa: F401  (import validated by importorskip)
+
+    buffer = io.BytesIO()
+    pdf = reportlab.pdfgen.canvas.Canvas(buffer)
+    for text in pages:
+        pdf.drawString(72, 720, text)
+        pdf.showPage()
+    pdf.save()
+    return buffer.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Structural guards — these are what stop the fork growing back
+# ---------------------------------------------------------------------------
+
+
+def test_only_the_canonical_module_constructs_a_pdf_reader():
+    """Exactly one module may own a PdfReader; five owning one was the bug."""
+    owners = []
+    for source in _CONSOLIDATED_SOURCES:
+        text = (_BACKEND_ROOT / source).read_text(encoding="utf-8")
+        if "PdfReader(" in text:
+            owners.append(source)
+    assert owners == [], (
+        f"{owners} construct their own PdfReader again. All PDF reading belongs in "
+        "media/document/extraction.py — five forked implementations is what #13893 removed."
+    )
+
+
+def test_pypdf2_is_not_imported_anywhere():
+    """The connectors ran PyPDF2 while the repo pinned pypdf as a security update."""
+    offenders = []
+    for source in _CONSOLIDATED_SOURCES:
+        for line in (_BACKEND_ROOT / source).read_text(encoding="utf-8").splitlines():
+            stripped = line.strip()
+            if stripped.startswith(("import PyPDF2", "from PyPDF2")):
+                offenders.append(source)
+    assert offenders == [], f"{offenders} import PyPDF2, which is unmaintained (#13893)"
+
+
+def test_pypdf2_is_not_declared_as_a_dependency():
+    """A removed import that stays declared invites the fork back."""
+    declared = [
+        line
+        for line in _REQUIREMENTS.read_text(encoding="utf-8").splitlines()
+        if line.strip().lower().startswith("pypdf2")
+    ]
+    assert declared == [], f"PyPDF2 is still declared in {_REQUIREMENTS}: {declared}"
+
+
+# ---------------------------------------------------------------------------
+# Behavioural guards — real PDFs, not mocked readers
+# ---------------------------------------------------------------------------
+
+
+def test_pdf_pages_are_extracted_with_the_canonical_marker():
+    raw = _make_pdf(["First page body", "Second page body"])
+    extracted = extract_pdf(raw)
+
+    assert extracted.format == "pdf"
+    assert extracted.page_count == 2
+    assert [page.number for page in extracted.pages] == [1, 2]
+    assert "First page body" in extracted.text
+    assert "Second page body" in extracted.text
+    assert PAGE_MARKER_TEMPLATE.format(number=1) in extracted.text
+    assert PAGE_MARKER_TEMPLATE.format(number=2) in extracted.text
+
+
+def test_page_numbers_are_one_indexed_to_match_human_page_numbers():
+    """Off-by-one here silently mis-cites every fact extracted from a PDF."""
+    extracted = extract_pdf(_make_pdf(["only page"]))
+    assert extracted.pages[0].number == 1
+
+
+def test_a_pdf_with_no_text_layer_extracts_empty_rather_than_raising():
+    """Scanned PDFs are the #13884/#13896 case: empty is a result, not a failure."""
+    raw = _make_pdf([" "])
+    extracted = extract_pdf(raw)
+
+    assert extracted.page_count == 1, "page count must stay truthful even with no text"
+    assert not extracted.has_text
+    assert extracted.text.strip() == ""
+
+
+def test_page_count_counts_unreadable_pages_too():
+    """Dropping empty pages would hide which pages need OCR."""
+    extracted = extract_pdf(_make_pdf(["real text", " ", "more text"]))
+    assert extracted.page_count == 3
+    assert len(extracted.pages) == 3
+
+
+def test_corrupt_pdf_raises_the_canonical_error():
+    with pytest.raises(DocumentExtractionError):
+        extract_pdf(b"%PDF-1.4 this is not actually a pdf")
+
+
+def test_detect_format_prefers_magic_bytes_over_mime_type():
+    """A mislabelled upload must be parsed by what it is, not what it claims."""
+    assert detect_format(b"%PDF-1.7 ...", "text/plain") == "pdf"
+    assert detect_format(b"plain content", "application/pdf") == "pdf"
+    assert detect_format(b"plain content", "") == "text"
+
+
+def test_plain_text_falls_back_to_latin1_on_undecodable_bytes():
+    extracted = extract_plain_text(b"caf\xe9")
+    assert extracted.format == "text"
+    assert extracted.text  # decoded rather than raised
+
+
+def test_extract_document_dispatches_on_detected_format():
+    assert extract_document(_make_pdf(["body"])).format == "pdf"
+    assert extract_document(b"just text").format == "text"
+
+
+# ---------------------------------------------------------------------------
+# Rendering / provenance split (the seam #13894 builds on)
+# ---------------------------------------------------------------------------
+
+
+def test_render_pages_skips_pages_with_no_text():
+    """A bare marker with nothing under it is noise in the embedding."""
+    rendered = render_pages([PageText(1, "kept"), PageText(2, "   "), PageText(3, "also kept")])
+    assert PAGE_MARKER_TEMPLATE.format(number=2) not in rendered
+    assert "kept" in rendered and "also kept" in rendered
+
+
+def test_structured_pages_survive_independently_of_the_rendered_text():
+    """#13894 needs per-page text that is not recoverable by parsing markers back out."""
+    extracted = extract_pdf(_make_pdf(["alpha", "beta"]))
+    assert extracted.pages[1].text.strip().startswith("beta")
+
+
+def test_strip_page_markers_removes_every_marker():
+    rendered = render_pages([PageText(1, "alpha"), PageText(2, "beta")])
+    stripped = strip_page_markers(rendered)
+    assert "alpha" in stripped and "beta" in stripped
+    assert not re.search(r"^## Page \d+$", stripped, flags=re.MULTILINE)
+
+
+def test_has_text_reports_whitespace_only_documents_as_empty():
+    assert not ExtractedDocument(format="text", text="   \n\t ").has_text
+    assert ExtractedDocument(format="text", text="content").has_text

--- a/autobot-backend/utils/document_extractors.py
+++ b/autobot-backend/utils/document_extractors.py
@@ -35,10 +35,9 @@ from typing import Dict, List
 
 import aiofiles
 import numpy as np
-from docx import Document as DocxDocument
-from pypdf import PdfReader
 
 from autobot_shared.logging_manager import get_logger
+from media.document.extraction import DocumentExtractionError, extract_docx, extract_pdf
 
 logger = get_logger(__name__)
 
@@ -121,22 +120,15 @@ class DocumentExtractor:
             raise ValueError(f"File is not a PDF: {file_path}")
 
         def extract_sync():
-            """Synchronous PDF extraction wrapped for async execution"""
+            """Synchronous PDF extraction wrapped for async execution.
+
+            Delegates to the canonical extractor (#13893) rather than carrying a
+            fourth copy of the pypdf loop; the ValueError contract is preserved
+            for existing callers.
+            """
             try:
-                reader = PdfReader(file_path)
-                pages = []
-
-                for page_num, page in enumerate(reader.pages):
-                    try:
-                        text = page.extract_text()
-                        if text and text.strip():
-                            pages.append(text)
-                    except Exception as e:
-                        logger.warning(f"Failed to extract page {page_num} from {file_path.name}: {e}")
-                        continue
-
-                return "\n\n".join(pages)
-            except Exception as e:
+                return extract_pdf(file_path.read_bytes()).text
+            except DocumentExtractionError as e:
                 logger.error("Failed to read PDF %s: %s", file_path, e)
                 raise ValueError(f"Invalid or corrupted PDF file: {file_path}") from e
 
@@ -171,18 +163,15 @@ class DocumentExtractor:
             raise ValueError(f"File is not a DOCX: {file_path}")
 
         def extract_sync():
-            """Synchronous DOCX extraction wrapped for async execution"""
+            """Synchronous DOCX extraction wrapped for async execution.
+
+            Delegates to the canonical extractor (#13893); the ValueError
+            contract is preserved for existing callers.
+            """
             try:
-                doc = DocxDocument(file_path)
-                paragraphs = []
-
-                for para in doc.paragraphs:
-                    text = para.text.strip()
-                    if text:
-                        paragraphs.append(text)
-
+                paragraphs = [line for line in extract_docx(file_path.read_bytes()).text.split("\n") if line.strip()]
                 return "\n\n".join(paragraphs)
-            except Exception as e:
+            except DocumentExtractionError as e:
                 logger.error("Failed to read DOCX %s: %s", file_path, e)
                 raise ValueError(f"Invalid or corrupted DOCX file: {file_path}") from e
 

--- a/autobot-backend/utils/document_parser.py
+++ b/autobot-backend/utils/document_parser.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Dict, Tuple
 
 from autobot_shared.logging_manager import get_logger
+from media.document.extraction import extract_docx, extract_pdf
 
 logger = get_logger(__name__)
 
@@ -122,42 +123,29 @@ class DocumentParser:
             return "", metadata
 
     def _parse_pdf(self, file_path: Path, metadata: Dict) -> str:
-        """Extract text from PDF using pypdf"""
-        from pypdf import PdfReader
+        """Extract text from PDF via the canonical extractor (#13893).
 
-        reader = PdfReader(str(file_path))
-        metadata["page_count"] = len(reader.pages)
-
-        text_parts = []
-        for page_num, page in enumerate(reader.pages, 1):
-            try:
-                text = page.extract_text()
-                if text.strip():
-                    text_parts.append(f"--- Page {page_num} ---\n{text}")
-            except Exception as e:
-                logger.warning("Failed to extract page %s: %s", page_num, e)
-
-        return "\n\n".join(text_parts)
+        Used to carry its own pypdf loop with a ``--- Page N ---`` marker; now
+        shares the one implementation and the one ``## Page N`` convention.
+        """
+        extracted = extract_pdf(file_path.read_bytes())
+        metadata["page_count"] = extracted.page_count
+        return extracted.text
 
     def _parse_docx(self, file_path: Path, metadata: Dict) -> str:
-        """Extract text from DOCX using python-docx"""
-        from docx import Document
+        """Extract text and tables from DOCX via the canonical extractor (#13893)."""
+        extracted = extract_docx(file_path.read_bytes())
 
-        doc = Document(str(file_path))
-
-        # Extract paragraphs
-        paragraphs = [para.text for para in doc.paragraphs if para.text.strip()]
-
-        # Extract text from tables
+        paragraphs = [line for line in extracted.text.split("\n") if line.strip()]
         table_text = []
-        for table in doc.tables:
-            for row in table.rows:
-                row_text = " | ".join(cell.text.strip() for cell in row.cells)
+        for table in extracted.tables:
+            for row in table:
+                row_text = " | ".join(row)
                 if row_text.strip():
                     table_text.append(row_text)
 
         metadata["paragraph_count"] = len(paragraphs)
-        metadata["table_count"] = len(doc.tables)
+        metadata["table_count"] = len(extracted.tables)
 
         all_text = paragraphs + (["--- Tables ---"] if table_text else []) + table_text
         return "\n".join(all_text)


### PR DESCRIPTION
## Thinking Path

Five independent PDF text extractors existed. Three were live, two were fully
orphaned (728 lines, zero callers, not even tests). They disagreed on page markers
— `## Page N`, `--- Page N ---`, and none at all on the live KB upload path — so
every fix to the document path had to ship five times, or ship once and be
forgotten in four places. That is precisely what blocked the rest of #13892.

One live fork ran **PyPDF2**, which is unmaintained, while `requirements.txt:23`
pins `pypdf>=6.15.0` with the comment "SECURITY UPDATE (improved permission
checks)". Google Drive and OneDrive ingestion was running on the library the rest
of the codebase had deliberately moved off.

## What Changed

**New:** `autobot-backend/media/document/extraction.py` — the single
implementation. Callers adapt its result to their own error shape (an
`HTTPException` for the API, a `ProcessingResult` for the media pipeline, an empty
string for the connectors), but nobody re-implements extraction.

All five call sites now delegate:

| Call site | Before | After |
|---|---|---|
| `api/knowledge.py:1065` | own pypdf loop | `extract_pdf(...)` |
| `media/document/pipeline.py` | own pypdf + docx loops | `extract_document(...)` |
| `knowledge/connectors/content_extraction.py` | **PyPDF2** | `extract_pdf(...)` |
| `utils/document_parser.py` | own pypdf loop | `extract_pdf(...)` |
| `utils/document_extractors.py` | own pypdf loop | `extract_pdf(...)` |

Three design decisions worth flagging:

- **Page text stays structured, not pre-joined.** `ExtractedDocument.pages` holds
  per-page text; `render_pages()` produces the flat string. That split is what lets
  #13894 carry page numbers to retrieval as *metadata* rather than as marker text
  baked into the embedding.
- **`DocumentDependencyError` split from `DocumentExtractionError`.** A missing
  library is a deployment gap; a corrupt file is the user's problem. The media
  pipeline's existing `unavailable` vs `error` distinction is preserved, so one can
  never be diagnosed as the other.
- **Empty is a result, not a failure.** A PDF with no text layer extracts to `""`
  with a truthful `page_count`, and unreadable pages are kept in `pages` rather than
  dropped — that is the signal #13884 detects and #13896 acts on.

**Removed:** the `PyPDF2` dependency. It had no remaining importers and no test
users (verified before removal).

## Verification

One reader remains, and the forks cannot grow back silently:

```
$ grep -rn "PdfReader\|import pypdf" --include=*.py autobot-backend/ | grep -v tests
autobot-backend/media/document/extraction.py:148:        from pypdf import PdfReader
autobot-backend/media/document/extraction.py:153:        return PdfReader(io.BytesIO(raw))

$ grep -rn "PyPDF2" --include=*.py autobot-backend/ | grep -v "^.*:.*#\|docstring"
(only doc-comment references explaining the removal)
```

Tests — 40 passing across the new suite and the rewritten pipeline suite:

```
$ pytest media/document/ tests/test_document_extraction_canonical_13893.py -q
30 passed
$ pytest media/document/pipeline_test.py media/pipeline_constructor_compat_test.py \
         tests/test_document_extraction_canonical_13893.py -q
40 passed
```

Mutation-tested rather than merely re-run — the anti-fork guards were each
provoked to prove they can fail:

```
### MUTATION: reintroduce a PyPDF2 fork in the connectors
1 failed, 14 passed
### MUTATION: re-declare PyPDF2 as a dependency
1 failed, 14 passed
### RESTORED
15 passed
```

No new failures anywhere. The full knowledge suite is **identical on base and on
this branch** — the 6 failures are pre-existing (4 are order-dependent and pass in
isolation, 2 are environmental):

```
base branch:  6 failed, 1349 passed, 63 skipped
this branch:  6 failed, 1349 passed, 63 skipped
```

Startup imports clean (`352 passed`); `flake8 --max-line-length=120` exit 0; no
`print(`; closure gate `check-new-module-callers.sh` exit 0.

**Test quality note:** the old pipeline tests mocked `PdfReader`. That mock would
have passed happily against all five old implementations and proved nothing about
which one actually ran — the exact blind spot that let five forks coexist. They now
generate real PDFs and assert through the public pipeline entry point.

## Known gap — not claimed as done

The issue's acceptance criterion *"every orphan is wired to a live caller"* is
**not** met by this PR. `utils/document_parser.py` and `utils/document_extractors.py`
no longer carry forked implementations — they delegate — but they still have zero
callers.

Wiring them in properly means letting the KB upload endpoint accept the formats
`DocumentParser` uniquely supports (XLSX, PPTX, ODT, ODS, ODP, ODG). It was built
for exactly that — its docstring reads "Universal Document Parser for Knowledge
Base" — but `ALLOWED_EXTENSIONS` (`api/knowledge.py:124`) has never included them.

That is a product decision with real blast radius: it puts three more parsers
(`odfpy`, `openpyxl`, `python-pptx`) on the untrusted-upload path. Per Rule 6 I am
not making that call unilaterally. Raised for a decision on #13893; this PR is
complete for the consolidation itself.

## Model Used

Claude Opus 5 (1M context)

Part of #13892 — Wave 1. Unblocks #13884, #13894, #13895, #13896, #13897.
