### PR TITLE
fix(ci): make the conventions linter's bot exemption survive a rewritten name (#13921)

### DIFF
--- a/scripts/lint-conventions.sh
+++ b/scripts/lint-conventions.sh
@@ -179,7 +179,17 @@ else
   # exempted: this repo's own auto-fix workflows (generated types, formatting)
   # push commits with no issue number, and without this every PR that touches
   # an OpenAPI schema fails a required check on a commit no human wrote.
-  LOGLINES=$(git log --format='%h%x1f%s%x1f%an' "${BASE_REF}..${HEAD_REF}") \
+  # #13921: the subject goes LAST. It is the only free-text field, so with it in
+  # the middle every later field depends on it containing no separator — and when
+  # the bot exemption failed to fire in CI on a commit whose %an really was
+  # `dependabot[bot]`, a field-split fault was the only remaining explanation that
+  # fitted. Ordering the free-text field last removes the class rather than
+  # guessing which member of it occurred.
+  #
+  # %ae is carried too: a bot's *email* ends in `[bot]@users.noreply.github.com`
+  # even where its display name is rewritten (a .mailmap entry would do exactly
+  # that), so two independent signals have to fail before a bot commit is judged.
+  LOGLINES=$(git log --format='%h%x1f%an%x1f%ae%x1f%s' "${BASE_REF}..${HEAD_REF}") \
     || die "git log failed for $RANGE"
   if [ -z "$LOGLINES" ]; then
     ok "no commits in range"
@@ -190,18 +200,25 @@ else
       SEEN=$((SEEN+1))
       sha=${line%%$'\x1f'*}
       rest=${line#*$'\x1f'}
-      subj=${rest%%$'\x1f'*}
-      author=${rest#*$'\x1f'}
+      author=${rest%%$'\x1f'*}
+      rest=${rest#*$'\x1f'}
+      email=${rest%%$'\x1f'*}
+      subj=${rest#*$'\x1f'}
       case "$subj" in
         "Merge "*|"Revert "*|chore:\ claim\ worktree*) continue ;;
       esac
-      case "$author" in
-        *'[bot]') continue ;;
+      # #13921: name OR email. A dependency bump has no issue by nature, and the
+      # commit is not written by a human who could add one.
+      case "$author$email" in
+        *'[bot]'*) continue ;;
       esac
       if ! printf '%s' "$subj" | grep -qE '^[a-z]+(\([a-z0-9._-]+\))?: .+'; then
-        fail "commit $sha: subject is not '<type>(scope): <description>'"; BAD=1
+        # #13921: the parsed author is echoed on failure. The previous version
+        # rejected commits without saying who it thought wrote them, so a
+        # non-firing exemption could only be diagnosed by inference.
+        fail "commit $sha (author='$author' <$email>): subject is not '<type>(scope): <description>'"; BAD=1
       elif ! printf '%s' "$subj" | grep -qE '#[0-9]{3,}'; then
-        fail "commit $sha: no issue reference"; BAD=1
+        fail "commit $sha (author='$author' <$email>): no issue reference"; BAD=1
       fi
     done <<< "$LOGLINES"
     [ "$BAD" -eq 0 ] && ok "$SEEN commit(s) conform"

--- a/scripts/lint_conventions_test.py
+++ b/scripts/lint_conventions_test.py
@@ -44,7 +44,10 @@ def run(repo: Path, *args: str, denylist: str | None = None) -> subprocess.Compl
         env["CONVENTIONS_DENYLIST"] = str(p)
     return subprocess.run(
         ["bash", "scripts/lint-conventions.sh", *args],
-        cwd=repo, capture_output=True, text=True, env=env,
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        env=env,
     )
 
 
@@ -139,3 +142,93 @@ def test_commit_msg_mode(repo: Path, subject: str, expected: int) -> None:
     msg = repo / "msg.txt"
     msg.write_text(subject + "\n", encoding="utf-8")
     assert run(repo, "--commit-msg", str(msg)).returncode == expected
+
+
+# --------------------------- bot-authored commits are exempt (#13921)
+
+
+def _bot_commit(repo: Path, subject: str, name: str, email: str) -> None:
+    """Commit as a bot identity, the way dependabot and the auto-fix workflows do."""
+    (repo / f"f{abs(hash(subject)) % 9999}.txt").write_text("x\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    subprocess.run(
+        ["git", "-C", str(repo), "commit", "-q", "-m", subject],
+        check=True,
+        capture_output=True,
+        env={
+            "PATH": "/usr/bin:/bin",
+            "HOME": str(repo),
+            "GIT_AUTHOR_NAME": name,
+            "GIT_AUTHOR_EMAIL": email,
+            "GIT_COMMITTER_NAME": name,
+            "GIT_COMMITTER_EMAIL": email,
+        },
+    )
+
+
+def test_a_dependabot_commit_without_an_issue_is_exempt(repo: Path) -> None:
+    """The regression: this failed every dependency PR (#13921).
+
+    Dependabot subjects are well-formed and carry no issue number because none
+    exists. The exemption was present and did not fire in CI; there was no test
+    covering a bot-authored commit at all, which is how that shipped.
+    """
+    _bot_commit(
+        repo,
+        "build(deps): bump the all-dependencies group",
+        "dependabot[bot]",
+        "49699333+dependabot[bot]@users.noreply.github.com",
+    )
+
+    result = run(repo, "--range", "HEAD~1..HEAD")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_a_bot_identified_only_by_email_is_exempt(repo: Path) -> None:
+    """A .mailmap rewriting the display name must not un-exempt the commit.
+
+    Matching on name alone is one signal; the email keeps the exemption working
+    when that signal is rewritten.
+    """
+    _bot_commit(repo, "build(deps): bump something", "Renamed By Mailmap", "x[bot]@users.noreply.github.com")
+
+    assert run(repo, "--range", "HEAD~1..HEAD").returncode == 0
+
+
+def test_a_human_commit_without_an_issue_still_fails(repo: Path) -> None:
+    """The exemption must not become a hole — this is the rule being enforced."""
+    (repo / "human.txt").write_text("x\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "fix(thing): no issue number here")
+
+    result = run(repo, "--range", "HEAD~1..HEAD")
+
+    assert result.returncode != 0
+    assert "no issue reference" in result.stdout
+
+
+def test_a_rejected_commit_names_the_author_it_parsed(repo: Path) -> None:
+    """So a non-firing exemption is one log line to diagnose, not an inference.
+
+    The previous version rejected commits without saying who it thought wrote
+    them, which is why #13921 took a reproduction attempt rather than a glance.
+    """
+    (repo / "human2.txt").write_text("x\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "fix(thing): still no issue")
+
+    result = run(repo, "--range", "HEAD~1..HEAD")
+
+    assert "author='t'" in result.stdout, result.stdout
+
+
+def test_a_subject_containing_the_field_separator_cannot_shift_the_parse(repo: Path) -> None:
+    """The free-text field is last, so nothing after it can be displaced.
+
+    With the subject in the middle, every later field depended on it containing
+    no separator — the fault class that best fitted #13921's CI-only failure.
+    """
+    _bot_commit(repo, "build(deps): bump a\x1fb group", "dependabot[bot]", "d[bot]@users.noreply.github.com")
+
+    assert run(repo, "--range", "HEAD~1..HEAD").returncode == 0


### PR DESCRIPTION
**Closes #13921.** Unblocks 12 dependency PRs.

## Thinking Path

The linter added in #13876 fails every dependabot PR with `no issue reference`. Their subjects are
well-formed (`build(deps): bump the all-dependencies group`) and carry no issue number because none
exists — which the script already anticipated, with the right reasoning in its own comment:

```bash
# Author is carried alongside the subject so bot-authored commits can be exempted
case "$author" in
  *'[bot]') continue ;;
esac
```

**And the exemption did not fire.**

### What I could not do: reproduce it

Stated plainly, because it shapes the fix. The exact range CI failed on passes locally:

```
CI:     conventions scope: 91ed3bc21..7642096ed (1 file(s))
        FAIL  commit 7642096ed: no issue reference
local:  ok    1 commit(s) conform
```

Ruled out, each by test rather than by reasoning:

- **Shallow clone losing the author** — reproduced CI's fetch shape (`clone --depth=1` +
  `fetch --depth=1 <sha>`); `%an` still returns `dependabot[bot]`.
- **A .mailmap rewrite** — the repo has one; it does not touch dependabot. `%an` and `%aN` agree.
- **A malformed subject** — the failure is the *second* branch (`no issue reference`), so the
  `<type>(scope):` pattern matched and only the issue check ran. The `[bot]` `continue` did not
  execute.
- **The shell field split** — exercised directly with a synthesised `\x1f`-delimited line; it parses
  correctly.

So a fix that targets one hypothesis would be a guess. This one removes the whole class instead.

## What Changed

**Two independent signals.** The exemption now matches on author name **or email**:

```bash
case "$author$email" in
  *'[bot]'*) continue ;;
esac
```

A bot's email ends in `[bot]@users.noreply.github.com` even where its display name is rewritten — a
.mailmap entry does exactly that. Two signals now have to fail before a bot commit is judged.

**The free-text field goes last.** `%h%x1f%an%x1f%ae%x1f%s`. With the subject in the middle, every
later field depended on it containing no separator. Ordering it last means no subject content can
displace the author.

**A rejected commit names the author it parsed.** The previous version rejected commits without
saying who it thought wrote them, which is why this took a reproduction attempt rather than a glance:

```
FAIL  commit abc1234 (author='t' <t@example.invalid>): no issue reference
```

## Verification

```
scripts/lint_conventions_test.py   21 passed   (was 16 — the suite had no bot-authored commit at all,
                                                which is how this shipped)
bash -n clean · flake8 · black clean
```

| Mutation | Result |
|---|---|
| drop the bot exemption | 3 tests fail |
| match on name only | 1 test fails |
| put the subject back in the middle | **all 21 pass** |

That third row is worth reading rather than hiding: reverting the field order is no longer a
regression **because the email signal survives a displaced parse**. Defence in depth doing its job —
but it means field order alone is not independently pinned, and I would rather say so than imply
three protections where there are two.

## Also worth considering, not done here

`build(deps):` arguably needs no issue **by type** rather than by author — a dependency bump has no
issue by nature, whoever pushes it. That is a policy call about the convention itself, so it belongs
on #13876 rather than inside a bug fix.

## Model Used

Claude Opus 5 (1M context)
