### PR TITLE
test(workflow-automation): pin that chat plans are fixed echoes and must not be

### DIFF
--- a/autobot-backend/tests/services/test_chat_workflow_is_request_shaped.py
+++ b/autobot-backend/tests/services/test_chat_workflow_is_request_shaped.py
@@ -1,0 +1,105 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Chat-driven workflow plans must reflect the request (#13809).
+
+#13730 unblocked `create_workflow_from_chat_request`, which had returned `None`
+— and therefore HTTP 500 — for every request. The path is live again, but what
+it produces is the same three placeholder steps whatever was asked. A silent
+no-op is harder to notice than a 500, so the fix traded a visible failure for an
+invisible one.
+
+Two independent reasons the request never reaches the command:
+
+1. `orchestrator.plan_workflow_steps` returns a fixed skeleton with the actions
+   `analyze_request` / `execute_plan` / `synthesize_results`. It puts the request
+   in `inputs["query"]` and never derives an action from it. This is *not* the
+   LLM planner — `orchestrator.create_workflow_plan` does real planning, and this
+   path does not call it.
+2. `_extract_command_from_step` looks for `inputs["command"]`, which this plan
+   never sets, then keyword-matches the *action* — but the three fixed actions
+   match none of its branches, so every step falls through to `echo 'Executing:
+   {action}'`.
+
+The two tests below are marked `xfail(strict=True)` deliberately. They describe
+the behaviour the endpoint is supposed to have, so when #13809 is fixed they
+XPASS — which *fails* — and whoever fixes it must remove the markers. A plain
+assertion of today's broken behaviour would instead have to be rewritten, and a
+non-strict xfail would go quietly green and re-arm, hiding any later regression.
+That is the property #13866 established and #13686 proved out.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from autobot_types import TaskComplexity
+
+
+def _plan(request: str):
+    """The step skeleton this endpoint actually builds for *request*."""
+    from orchestrator import Orchestrator
+
+    planner = Orchestrator.plan_workflow_steps.__get__(SimpleNamespace())
+    return asyncio.run(planner(request, TaskComplexity.COMPLEX))
+
+
+def _commands(request: str):
+    """The commands the chat path would execute for *request*."""
+    from services.workflow_automation.manager import WorkflowAutomationManager
+
+    extract = WorkflowAutomationManager._extract_command_from_step.__get__(SimpleNamespace())
+    return [extract(step) for step in _plan(request)]
+
+
+def test_the_plan_is_a_fixed_skeleton_today():
+    """Characterises the defect so the claim is checked, not asserted in prose.
+
+    This one is NOT xfail: it is the evidence that the two below describe a real
+    gap rather than an imagined one. It fails when the skeleton stops being fixed,
+    at which point it should be deleted along with the markers.
+    """
+    actions = [s.action for s in _plan("install docker and wipe logs")]
+
+    assert actions == ["analyze_request", "execute_plan", "synthesize_results"]
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="#13809: plan_workflow_steps returns a fixed skeleton; the request only "
+    "reaches inputs['query'] and never shapes an action",
+)
+def test_two_different_requests_produce_different_plans():
+    """AC #13809: a chat request must produce steps that reflect the request."""
+    install = [s.action for s in _plan("install docker")]
+    report = [s.action for s in _plan("summarise last week's deploy failures")]
+
+    assert install != report
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="#13809: every step falls through to echo — the fixed actions match no "
+    "branch of _extract_command_from_step and inputs['command'] is never set",
+)
+def test_commands_are_not_all_echoes():
+    """A workflow that only echoes its own step names does no work."""
+    commands = _commands("install docker and wipe logs")
+
+    assert not all(c.startswith("echo 'Executing:") for c in commands)
+
+
+def test_the_user_request_never_reaches_a_command():
+    """Security property worth pinning while the path is live (#13809).
+
+    The endpoint generates shell commands and `auto_start` defaults to True, so
+    it matters that hostile text cannot reach one. It cannot: the extractor only
+    ever emits a literal echo of a fixed action name, or one of two hardcoded
+    strings on keyword match. This test stays after #13809 is fixed — whatever
+    planner the endpoint moves to must keep this true.
+    """
+    hostile = "install docker; rm -rf / #"
+
+    for command in _commands(hostile):
+        assert "rm -rf" not in command
+        assert hostile not in command


### PR DESCRIPTION
## Thinking Path

I did not fix this, deliberately, and the reason is the interesting part.

The issue recommends routing the endpoint at `orchestrator.create_workflow_plan` — the real LLM planner. Reading the route first changed my mind about whether that is safe to do unilaterally:

```python
auto_start = request.get("auto_start", True)        # default: start immediately
require_approval = request.get("require_approval", False)  # default: no approval
```

Today the endpoint builds three `echo` steps and starts them — useless, but harmless. Wiring a real planner behind those defaults turns it into a route that **generates shell commands from user text and executes them without approval**. That is not a refactor; it is a change in what the system is permitted to do on its own. Making it while the safety posture is still `auto_start=True, require_approval=False` would be the risky half of the fix shipped without the decision that governs it.

So this PR delivers the acceptance criterion I *can* deliver honestly — the machine-checked proof that the plans are fixed — and leaves the routing decision on the issue.

## What Changed

Tests only. No production code, no behaviour change.

Four tests, in two deliberate groups.

**Two `xfail(strict=True)`** describing the behaviour the endpoint is supposed to have:
- `test_two_different_requests_produce_different_plans`
- `test_commands_are_not_all_echoes`

They fail today. When #13809 is fixed they XPASS — which *fails* — forcing whoever fixes it to remove the markers. A plain assertion of today's broken behaviour would have to be rewritten instead, and a non-strict xfail would go quietly green and re-arm. That property is not theoretical: a strict marker of exactly this shape caught an incomplete fix of mine on #13686 three hours ago, in a file I had not opened.

**Two ordinary passing tests:**
- `test_the_plan_is_a_fixed_skeleton_today` — evidence the two above describe a real gap rather than an imagined one. It fails when the skeleton stops being fixed, and should be deleted along with the markers.
- `test_the_user_request_never_reaches_a_command` — the security property, pinned while the route is live. This one **stays** after #13809 is fixed: whatever planner the endpoint moves to must keep hostile text out of the generated command.

## Verification

Ran, then simulated the fix to prove the markers flip rather than failing for some unrelated reason:

```
$ pytest test_chat_workflow_is_request_shaped.py -q
2 passed, 2 xfailed

$ # made the skeleton request-shaped in orchestrator.py, then re-ran:
[XPASS(strict)] #13809: plan_workflow_steps returns a fixed skeleton …
[XPASS(strict)] #13809: every step falls through to echo …
FAILED test_the_plan_is_a_fixed_skeleton_today
3 failed, 1 passed
```

Both markers XPASS and the characterisation test correctly goes red, while the security test still passes. Reverted; final state `2 passed, 2 xfailed`.

Worth noting my first attempt at that simulation silently did nothing — I patched the wrong indentation and the run came back unchanged, which looked like a pass. The characterisation test failing is what exposed it. A mutation that does not apply is indistinguishable from a test that cannot fail unless something independent tells you the edit landed.

## Decision left on the issue

Two acceptance criteria are decisions, not code, and both are recorded on #13809 rather than assumed here:

- **which planner** this endpoint should use — `create_workflow_plan` converges on the canonical path per the #13751 supersession record, and is my recommendation
- **whether `auto_start=True` stays** for a route that will execute generated commands — my recommendation is no, and that it should flip before the planner is wired, not after

Refs #13809 — does not close it.

## Model Used

Opus 5
