### PR TITLE
fix(plugin-sdk): file-path fallback located the plugin file and could not execute it (#10294)

### DIFF
--- a/autobot_shared/plugin_sdk/loader.py
+++ b/autobot_shared/plugin_sdk/loader.py
@@ -395,9 +395,15 @@ class PluginLoader:
         # Candidate file paths, most-canonical first.
         candidates: List[Path] = []
 
+        # The module filename is the entry point's LAST segment, not always
+        # "main". telemetry-prompt-middleware declares
+        # `...telemetry_prompt_middleware.plugin` and ships plugin.py, so a
+        # hardcoded main.py could never find it (#10294).
+        module_filename = f"{entry_point.rsplit('.', 1)[-1]}.py"
+
         # 1. Use the stored manifest directory directly (most reliable).
         if plugin_dir is not None:
-            candidates.append(plugin_dir / "main.py")
+            candidates.append(plugin_dir / module_filename)
 
         # 2. Derive the path from the entry_point by mapping underscores -> hyphens
         #    for each segment, then looking inside every configured plugin_dir.
@@ -408,7 +414,7 @@ class PluginLoader:
         # Drop the leading "plugins" segment and the trailing "main" module name.
         inner_parts = parts[1:-1] if len(parts) >= 3 else parts[:-1]
         hyphenated_parts = [p.replace("_", "-") for p in inner_parts]
-        rel_path = Path(*hyphenated_parts) / "main.py" if hyphenated_parts else None
+        rel_path = Path(*hyphenated_parts) / module_filename if hyphenated_parts else None
 
         for base_dir in self.plugin_dirs:
             if rel_path is not None:
@@ -417,11 +423,18 @@ class PluginLoader:
         for path in candidates:
             if not path.exists():
                 continue
+            synthesised: List[str] = []
             try:
                 spec = importlib.util.spec_from_file_location(entry_point, path)
                 if spec is None or spec.loader is None:
                     continue
                 module = importlib.util.module_from_spec(spec)
+                # #10294: locating the file was never the whole problem. The
+                # module's OWN imports reference `plugins.core_plugins.*`, and
+                # those parent packages exist in no sys.modules, so exec_module
+                # raised ModuleNotFoundError even though the right file had been
+                # found — which read as "the fallback failed to load the file".
+                synthesised = self._synthesise_parent_packages(entry_point, path)
                 # Register before exec so intra-plugin dataclasses/relative refs resolve.
                 sys.modules[entry_point] = module
                 spec.loader.exec_module(module)  # type: ignore[union-attr]
@@ -430,9 +443,57 @@ class PluginLoader:
             except Exception as exc:
                 logger.warning("File-path fallback failed for %r at %s: %s", entry_point, path, exc)
                 sys.modules.pop(entry_point, None)
+                for name in synthesised:
+                    sys.modules.pop(name, None)
                 continue
 
         return None
+
+    def _synthesise_parent_packages(self, entry_point: str, module_path: Path) -> List[str]:
+        """Make `plugins.core_plugins.<name>` importable for the plugin's own imports.
+
+        The entry point is a dotted path whose packages do not exist on disk
+        under those names — `core_plugins` is the directory `core-plugins`, and
+        neither carries an ``__init__.py``. A plugin that imports its own
+        siblings by absolute path therefore fails at ``exec_module`` even when
+        the loader has located exactly the right file (#10294).
+
+        Each parent gets a namespace module whose ``__path__`` points at the
+        matching real directory, walked up from the module file so the hyphen /
+        underscore mapping never has to be guessed.
+
+        Returns the names created, so a failed exec can withdraw them rather
+        than leave half a package tree behind for the next import to trip on.
+        """
+        import sys
+
+        parents = entry_point.split(".")[:-1]
+        if not parents:
+            return []
+
+        # Walk up from the module's own directory: the innermost package is the
+        # plugin dir, its parent is core-plugins, and so on.
+        directories: List[Path] = []
+        current = module_path.parent
+        for _ in parents:
+            directories.append(current)
+            current = current.parent
+        directories.reverse()
+
+        created: List[str] = []
+        for depth, _part in enumerate(parents):
+            name = ".".join(parents[: depth + 1])
+            if name in sys.modules:
+                continue
+            package = ModuleType(name)
+            package.__path__ = [str(directories[depth])]  # type: ignore[attr-defined]
+            package.__package__ = name
+            sys.modules[name] = package
+            created.append(name)
+
+        if created:
+            logger.debug("Synthesised namespace packages for %s: %s", entry_point, created)
+        return created
 
     def get_loaded_plugins(self) -> Dict[str, BasePlugin]:
         """Get all loaded plugins."""

--- a/autobot_shared/plugin_sdk/loader_file_fallback_test.py
+++ b/autobot_shared/plugin_sdk/loader_file_fallback_test.py
@@ -1,0 +1,176 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""File-path fallback for core plugins whose package path is not importable (#10294).
+
+Core plugins live in hyphenated directories (`plugins/core-plugins/image-generation-plugin/`)
+but declare underscored entry points (`plugins.core_plugins.image_generation_plugin.main`).
+Nothing maps one to the other — no `__init__.py`, no namespace package, no path hook — so
+`importlib.import_module(entry_point)` raises `ModuleNotFoundError`.
+
+A `spec_from_file_location` fallback was added for this and did not work, which is easy to
+misread. It located the right file. What failed was `exec_module`, because the plugin's OWN
+imports also reference `plugins.core_plugins.*` — and those parent packages exist in no
+`sys.modules`. The observable symptom was:
+
+    File-path fallback failed for 'plugins.core_plugins.image_generation_plugin.main'
+      at plugins/core-plugins/image-generation-plugin/main.py: No module named 'plugins.core_plugins'
+
+i.e. the loader reporting that it could not load a file it had already found. So the fix is
+not "load from the located file" (already done) but "make the dotted path resolvable for the
+module's own imports".
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from autobot_shared.plugin_sdk.loader import PluginLoader
+
+_ENTRY = "plugins.core_plugins.demo_plugin.main"
+_PARENTS = ("plugins", "plugins.core_plugins", "plugins.core_plugins.demo_plugin")
+
+
+@pytest.fixture(autouse=True)
+def _clean_sys_modules():
+    """Leave sys.modules exactly as found — these tests install packages into it."""
+    touched = (_ENTRY, "plugins.core_plugins.demo_plugin.helper", *_PARENTS)
+    saved = {k: sys.modules.get(k) for k in touched}
+    yield
+    for key, value in saved.items():
+        if value is None:
+            sys.modules.pop(key, None)
+        else:
+            sys.modules[key] = value
+
+
+def _make_plugin(root: Path, *, module_name: str = "main", with_sibling_import: bool = False) -> Path:
+    """Build a core-plugin tree: hyphenated dirs, no __init__.py anywhere."""
+    plugin_dir = root / "core-plugins" / "demo-plugin"
+    plugin_dir.mkdir(parents=True)
+
+    (plugin_dir / "helper.py").write_text("ANSWER = 42\n", encoding="utf-8")
+
+    body = "VALUE = 'loaded'\n"
+    if with_sibling_import:
+        # The import that broke exec_module: absolute, via the dotted path that
+        # does not exist on disk under that name.
+        body = "from plugins.core_plugins.demo_plugin.helper import ANSWER\n\nVALUE = ANSWER\n"
+    (plugin_dir / f"{module_name}.py").write_text(body, encoding="utf-8")
+    return plugin_dir
+
+
+def test_the_dotted_entry_point_is_genuinely_unimportable(tmp_path):
+    """Pins the premise. If this ever starts working the fallback is dead code."""
+    _make_plugin(tmp_path)
+    with pytest.raises(ModuleNotFoundError):
+        __import__(_ENTRY)
+
+
+def test_a_plugin_with_no_internal_imports_loads(tmp_path):
+    """The case the original fallback already handled."""
+    plugin_dir = _make_plugin(tmp_path)
+    loader = PluginLoader(plugin_dirs=[tmp_path])
+
+    module = loader._import_from_file(_ENTRY, plugin_dir)
+
+    assert module is not None
+    assert module.VALUE == "loaded"
+
+
+def test_a_plugin_that_imports_its_own_sibling_loads(tmp_path):
+    """#10294's actual bug: the file was found, exec_module then failed.
+
+    This is what image-generation-plugin and video-generation-plugin hit — the
+    loader logged "File-path fallback failed" for a file it had located.
+    """
+    plugin_dir = _make_plugin(tmp_path, with_sibling_import=True)
+    loader = PluginLoader(plugin_dirs=[tmp_path])
+
+    module = loader._import_from_file(_ENTRY, plugin_dir)
+
+    assert module is not None, "the module's own absolute import must resolve"
+    assert module.VALUE == 42
+
+
+def test_the_parent_packages_point_at_the_real_hyphenated_directories(tmp_path):
+    """The mapping is derived by walking up from the module file, never guessed —
+    so a plugin dir that is not simply `name.replace('_','-')` still works."""
+    plugin_dir = _make_plugin(tmp_path, with_sibling_import=True)
+    loader = PluginLoader(plugin_dirs=[tmp_path])
+
+    loader._import_from_file(_ENTRY, plugin_dir)
+
+    assert sys.modules["plugins.core_plugins.demo_plugin"].__path__ == [str(plugin_dir)]
+    assert sys.modules["plugins.core_plugins"].__path__ == [str(tmp_path / "core-plugins")]
+    assert sys.modules["plugins"].__path__ == [str(tmp_path)]
+
+
+def test_the_module_filename_comes_from_the_entry_point(tmp_path):
+    """telemetry-prompt-middleware declares `...telemetry_prompt_middleware.plugin`
+    and ships plugin.py, so a hardcoded main.py could never find it."""
+    plugin_dir = _make_plugin(tmp_path, module_name="plugin")
+    loader = PluginLoader(plugin_dirs=[tmp_path])
+
+    module = loader._import_from_file("plugins.core_plugins.demo_plugin.plugin", plugin_dir)
+
+    assert module is not None
+    assert module.VALUE == "loaded"
+
+
+def test_a_failed_exec_withdraws_the_synthetic_packages(tmp_path):
+    """Half a package tree left behind would make the NEXT plugin's import
+    resolve against a directory nobody chose."""
+    plugin_dir = _make_plugin(tmp_path)
+    (plugin_dir / "main.py").write_text("raise RuntimeError('boom')\n", encoding="utf-8")
+    loader = PluginLoader(plugin_dirs=[tmp_path])
+
+    assert loader._import_from_file(_ENTRY, plugin_dir) is None
+    for name in _PARENTS:
+        assert name not in sys.modules, f"{name} survived a failed load"
+    assert _ENTRY not in sys.modules
+
+
+def test_an_existing_real_package_is_not_replaced(tmp_path):
+    """`plugins` may already be a genuine package. Overwriting it would redirect
+    every later import in the process to the plugin tree."""
+    plugin_dir = _make_plugin(tmp_path, with_sibling_import=True)
+    sentinel = sys.modules["plugins"] = type(sys)("plugins")
+    sentinel.__path__ = ["/somewhere/real"]
+
+    PluginLoader(plugin_dirs=[tmp_path])._import_from_file(_ENTRY, plugin_dir)
+
+    assert sys.modules["plugins"] is sentinel
+    assert sys.modules["plugins"].__path__ == ["/somewhere/real"]
+
+
+def test_the_real_core_plugins_import_through_the_fallback():
+    """End-to-end against the shipped tree, not a fixture.
+
+    Both plugins named in #10294 logged "File-path fallback failed" before this.
+    They import here — recognising the CLASS afterwards is a separate defect
+    (the plugins subclass a second copy of BasePlugin), tracked in #13677.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    plugins_root = repo_root / "plugins"
+    if not (plugins_root / "core-plugins").is_dir():
+        pytest.skip("core-plugins tree not present")
+
+    loader = PluginLoader(plugin_dirs=[plugins_root])
+    for name in ("image-generation-plugin", "video-generation-plugin"):
+        entry = f"plugins.core_plugins.{name.replace('-', '_')}.main"
+        plugin_dir = plugins_root / "core-plugins" / name
+        saved = {k: sys.modules.get(k) for k in (entry, *_PARENTS[:2])}
+        try:
+            module = loader._import_from_file(entry, plugin_dir)
+            assert module is not None, f"{name} still fails the file-path fallback"
+        finally:
+            for key, value in saved.items():
+                if value is None:
+                    sys.modules.pop(key, None)
+                else:
+                    sys.modules[key] = value


### PR DESCRIPTION
Closes #10294 · umbrella #13852 (Wave 2) · unblocks #13677

## Thinking Path

The dotted entry point fails exactly as the issue reports. What the issue could not know is that **the
suggested fix was already implemented** — `_import_from_file` uses `spec_from_file_location` and locates the
correct file. What fails is `exec_module`:

```
File-path fallback failed for 'plugins.core_plugins.image_generation_plugin.main'
  at plugins/core-plugins/image-generation-plugin/main.py: No module named 'plugins.core_plugins'
```

The loader reporting it could not load a file it had already found. The plugin's **own** imports also
reference `plugins.core_plugins.*`, and those parent packages exist in no `sys.modules`. So the fix is not
"load from the located file" — it is "make the dotted path resolvable for the module's own imports".

## What Changed

Each parent gets a namespace module whose `__path__` points at the matching real directory, walked **up from
the module file** so the hyphen/underscore mapping is derived rather than guessed — a plugin dir that is not
simply `name.replace('_','-')` needs no special case. An existing real `plugins` package is never replaced,
and a failed exec withdraws what it created rather than leaving half a tree for the next import to resolve
against.

The fallback also hardcoded `main.py`, so `telemetry-prompt-middleware` — which declares
`...telemetry_prompt_middleware.plugin` and ships `plugin.py` — could never have been found by it. The
filename now comes from the entry point's last segment.

## Verification

```
$ pytest autobot_shared/plugin_sdk/ -q
89 passed
```

Mutation-tested; each part of the fix is guarded:

| mutation | result |
|---|---|
| don't synthesise parent packages | **3 failed** |
| hardcode `main.py` again | **1 failed** |
| don't withdraw packages after a failed exec | **1 failed** |
| restored | 8 passed |

One test runs against the **shipped tree**, not fixtures: both plugins named in the issue now import through
the fallback.

## Honest scope — this does not make any plugin load yet

Driving the real loader over the real `plugins/` tree still gives **0 of 7 loaded**. There are three distinct
causes and this fixes one:

| route | cause | plugins |
|---|---|---|
| 2 (this PR) | fallback could not exec what it found | 2 |
| **1** | plugins subclass a **second copy** of `BasePlugin` | 6 |
| 3 | missing optional dependency (`aiohttp`) | 1 |

Route 1 is the gate:

```
ImageGenerationPlugin mro: ['plugin_sdk.base.BasePlugin', ...]   issubclass(canonical)=False
```

The plugins import `from plugin_sdk.base import BasePlugin`; the loader tests against
`autobot_shared.plugin_sdk.base.BasePlugin`. Different class objects, so `issubclass` is False and the loader
reports **"No plugin class found in module"** for a class sitting right there — an error that sends the reader
hunting for the wrong thing.

**The two plugins fixed here moved from route 2's error to route 1's**, which is the observable proof this
change works. Routes 1 and 3, plus the missing `loaded N of M` signal that makes any of this visible at all,
are #13677 — next.

## Model Used

Claude Opus 5 (1M context)
