### PR TITLE
fix(plugin-sdk): all 7 core plugins failed and it looked like none were installed (#13677)

### DIFF
--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -1875,7 +1875,13 @@ async def _init_plugin_manager(app: FastAPI) -> None:
         plugin_manager = PluginManager(plugin_dirs)
         await plugin_manager.startup()
         app.state.plugin_manager = plugin_manager
-        logger.info("PluginManager started — %s", plugin_manager.get_plugin_status())
+        # #13677: the load tally, not just per-plugin statuses. A status map
+        # nobody totals is why 0-of-7 read the same as "no plugins installed".
+        logger.info(
+            "PluginManager started — %s | %s",
+            plugin_manager.get_load_report(),
+            plugin_manager.get_plugin_status(),
+        )
     except Exception as pm_err:
         logger.warning("Plugin manager startup failed (non-critical): %s", pm_err, exc_info=True)
 

--- a/autobot_shared/plugin_sdk/loader.py
+++ b/autobot_shared/plugin_sdk/loader.py
@@ -91,6 +91,58 @@ def validate_plugin_config(plugin_name: str, config: Dict[str, Any], config_sche
     _validate_config_against_schema(plugin_name, config, config_schema)
 
 
+def canonicalise_plugin_sdk() -> List[str]:
+    """Make ``plugin_sdk.*`` and ``autobot_shared.plugin_sdk.*`` the SAME modules (#13677).
+
+    `docs/developer/PLUGIN_SDK.md` tells plugin authors to write
+    ``from plugin_sdk.base import BasePlugin``, and every core plugin does. That
+    bare name resolves — autobot_shared is installed editable and exposes
+    ``plugin_sdk`` as a second top-level package over the same source — but it
+    resolves to a SECOND set of module objects, so
+    ``plugin_sdk.base.BasePlugin`` and ``autobot_shared.plugin_sdk.base.BasePlugin``
+    are different classes.
+
+    The loader checks ``issubclass(attr, BasePlugin)`` against the canonical one,
+    so a plugin subclassing the documented one fails the check and the loader
+    reports "No plugin class found in module" — for a class sitting right there
+    in the module it just imported. Six of seven core plugins failed this way,
+    and the message sends the reader hunting for the wrong thing.
+
+    Aliasing the parent alone is not enough: a later ``import plugin_sdk.base``
+    would load a fresh module object from the canonical path and reintroduce the
+    split. Every submodule is aliased too.
+
+    Returns the names bound, for logging.
+    """
+    import pkgutil
+    import sys
+
+    import autobot_shared.plugin_sdk as canonical
+
+    bound: List[str] = []
+    if sys.modules.get("plugin_sdk") is not canonical:
+        sys.modules["plugin_sdk"] = canonical
+        bound.append("plugin_sdk")
+
+    prefix = "autobot_shared.plugin_sdk."
+    for _finder, name, _ispkg in pkgutil.iter_modules(canonical.__path__):
+        alias = f"plugin_sdk.{name}"
+        full = f"{prefix}{name}"
+        existing = sys.modules.get(alias)
+        module = sys.modules.get(full)
+        if module is None:
+            try:
+                module = importlib.import_module(full)
+            except Exception as exc:  # noqa: BLE001 - a broken submodule must not stop the rest
+                logger.debug("plugin_sdk canonicalisation skipped %s: %s", full, exc)
+                continue
+        if existing is not module:
+            sys.modules[alias] = module
+            bound.append(alias)
+
+    return bound
+
+
 class PluginLoader:
     """
     Plugin discovery and loading system.
@@ -353,6 +405,13 @@ class PluginLoader:
         Returns:
             Plugin class or None on failure
         """
+        # #13677: bind the documented `plugin_sdk.*` names to the canonical
+        # modules BEFORE the plugin imports them, so the class it subclasses is
+        # the one this loader will test against.
+        bound = canonicalise_plugin_sdk()
+        if bound:
+            logger.debug("Canonicalised plugin_sdk aliases: %s", bound)
+
         module = None
 
         try:

--- a/autobot_shared/plugin_sdk/loader.py
+++ b/autobot_shared/plugin_sdk/loader.py
@@ -120,15 +120,25 @@ def canonicalise_plugin_sdk() -> List[str]:
     import autobot_shared.plugin_sdk as canonical
 
     bound: List[str] = []
-    if sys.modules.get("plugin_sdk") is not canonical:
-        sys.modules["plugin_sdk"] = canonical
-        bound.append("plugin_sdk")
-
     prefix = "autobot_shared.plugin_sdk."
+
+    # Submodules FIRST, parent last. Binding the parent first means any submodule
+    # imported during this loop that does `from plugin_sdk.X import ...` loads a
+    # fresh X from the canonical path AND sets it as an attribute on the parent —
+    # which is by then the canonical package. Repairing sys.modules afterwards
+    # does not repair that attribute, so `autobot_shared.plugin_sdk.registry`
+    # ended up holding a SECOND Registry class with its own singleton, undoing
+    # what #11636 fixed (#13677 review).
     for _finder, name, _ispkg in pkgutil.iter_modules(canonical.__path__):
+        # Never import the package's own tests: it drags pytest into the
+        # production process (~100ms), and where pytest is absent the import
+        # fails, is swallowed, and — because failed imports are not cached —
+        # retries on every plugin, every startup.
+        if name.endswith("_test") or name.startswith("test_"):
+            continue
+
         alias = f"plugin_sdk.{name}"
         full = f"{prefix}{name}"
-        existing = sys.modules.get(alias)
         module = sys.modules.get(full)
         if module is None:
             try:
@@ -136,9 +146,16 @@ def canonicalise_plugin_sdk() -> List[str]:
             except Exception as exc:  # noqa: BLE001 - a broken submodule must not stop the rest
                 logger.debug("plugin_sdk canonicalisation skipped %s: %s", full, exc)
                 continue
-        if existing is not module:
+        if sys.modules.get(alias) is not module:
             sys.modules[alias] = module
             bound.append(alias)
+        # Re-assert the parent attribute: an import during this loop may have
+        # replaced it with a duplicate module object.
+        setattr(canonical, name, module)
+
+    if sys.modules.get("plugin_sdk") is not canonical:
+        sys.modules["plugin_sdk"] = canonical
+        bound.append("plugin_sdk")
 
     return bound
 

--- a/autobot_shared/plugin_sdk/plugin_load_visibility_test.py
+++ b/autobot_shared/plugin_sdk/plugin_load_visibility_test.py
@@ -1,0 +1,243 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""All 7 core plugins failed and it looked like "no plugins installed" (#13677).
+
+Two independent defects, and the second is what made the first invisible.
+
+**The plugins could not be recognised.** `docs/developer/PLUGIN_SDK.md` tells
+authors to write ``from plugin_sdk.base import BasePlugin``, and every core
+plugin does. That name resolves — autobot_shared is installed editable and
+exposes ``plugin_sdk`` as a second top-level package over the same source — but
+to a SECOND set of module objects. So ``plugin_sdk.base.BasePlugin`` and
+``autobot_shared.plugin_sdk.base.BasePlugin`` are different classes, the loader's
+``issubclass`` check against the canonical one returns False, and it reports
+"No plugin class found in module" for a class sitting in the module it just
+imported.
+
+**Nothing totalled the result.** `startup()` logged discovery and per-plugin
+successes, and the far commoner failure — ``load_plugin`` returning None rather
+than raising — logged nothing at all at that level. A run where every plugin
+failed produced the same shape of output as a healthy one, and a host with no
+plugins produced the same shape as a host where all seven were broken.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from autobot_shared.plugin_sdk.loader import canonicalise_plugin_sdk
+from autobot_shared.plugin_sdk.plugin_manager import PluginManager
+
+_MANIFEST = """{
+  "name": "%(name)s",
+  "version": "1.0.0",
+  "display_name": "%(name)s",
+  "description": "fixture",
+  "author": "test",
+  "entry_point": "plugins.core_plugins.%(mod)s.main"
+}"""
+
+_PLUGIN_SOURCE = """
+from plugin_sdk.base import BasePlugin
+
+
+class FixturePlugin(BasePlugin):
+    async def initialize(self):
+        return None
+
+    async def shutdown(self):
+        return None
+"""
+
+
+@pytest.fixture(autouse=True)
+def _fresh_plugin_modules():
+    """Drop cached plugin modules between tests.
+
+    The loader registers each plugin under its entry-point name in sys.modules,
+    and these fixtures reuse entry points across tmp_paths — so without this a
+    later test resolves a module built from an earlier test's directory and
+    passes or fails for reasons that have nothing to do with it. Real startup
+    gets a fresh process; the tests should too.
+    """
+    before = set(sys.modules)
+    yield
+    for name in set(sys.modules) - before:
+        if name.startswith("plugins"):
+            sys.modules.pop(name, None)
+
+    # Also un-alias plugin_sdk, so the NEXT test starts from the split state a
+    # real process starts in and the loader has to canonicalise for itself.
+    # Without this the alias persisted process-wide after the first direct call
+    # to canonicalise_plugin_sdk(), and deleting the loader's call left every
+    # load test still passing — a guard that could not fail, in a file about
+    # guards that cannot fail.
+    for name in [n for n in sys.modules if n == "plugin_sdk" or n.startswith("plugin_sdk.")]:
+        sys.modules.pop(name, None)
+
+
+def _make_plugin(root: Path, name: str, source: str = _PLUGIN_SOURCE) -> None:
+    d = root / name
+    d.mkdir(parents=True)
+    (d / "plugin.json").write_text(_MANIFEST % {"name": name, "mod": name.replace("-", "_")}, encoding="utf-8")
+    (d / "main.py").write_text(source, encoding="utf-8")
+
+
+class TestTheDocumentedImportIsRecognised:
+    """The plugins were never wrong — the loader was."""
+
+    def test_the_documented_import_is_what_plugins_actually_use(self):
+        """If the SDK docs ever stop saying `from plugin_sdk...`, the
+        canonicalisation below is solving a problem nobody has."""
+        docs = Path(__file__).resolve().parents[2] / "docs" / "developer" / "PLUGIN_SDK.md"
+        if not docs.is_file():
+            pytest.skip("SDK docs not present")
+        assert "from plugin_sdk.base import BasePlugin" in docs.read_text(encoding="utf-8")
+
+    def test_canonicalise_binds_the_bare_name_to_the_same_module(self):
+        import autobot_shared.plugin_sdk as canonical
+
+        canonicalise_plugin_sdk()
+
+        assert sys.modules["plugin_sdk"] is canonical
+
+    def test_the_base_submodule_is_the_same_object_too(self):
+        """Aliasing only the parent is not enough: a later `import
+        plugin_sdk.base` would load a fresh module from the canonical path and
+        reintroduce exactly the split this closes."""
+        import autobot_shared.plugin_sdk.base as canonical_base
+
+        canonicalise_plugin_sdk()
+
+        assert sys.modules["plugin_sdk.base"] is canonical_base
+
+    def test_a_class_using_the_documented_import_passes_issubclass(self):
+        """The actual failing condition, reduced: this returned False, so the
+        loader said "No plugin class found" for a class that was right there."""
+        canonicalise_plugin_sdk()
+
+        import plugin_sdk.base as documented
+        from autobot_shared.plugin_sdk.base import BasePlugin as canonical
+
+        assert documented.BasePlugin is canonical
+
+        class Demo(documented.BasePlugin):  # type: ignore[misc, name-defined]
+            pass
+
+        assert issubclass(Demo, canonical)
+
+    def test_the_loader_canonicalises_before_importing_a_plugin(self, tmp_path):
+        """The LOADER must do this, not just the helper.
+
+        Asserted directly on sys.modules rather than inferred from a successful
+        load: whether an un-canonicalised import actually splits depends on how
+        the package happens to be installed in the running environment, so a
+        load-based assertion can pass for reasons unrelated to the fix. This
+        fails the moment the loader stops calling canonicalise_plugin_sdk().
+        """
+        import autobot_shared.plugin_sdk as canonical
+        from autobot_shared.plugin_sdk.loader import PluginLoader
+
+        for name in [n for n in list(sys.modules) if n == "plugin_sdk" or n.startswith("plugin_sdk.")]:
+            sys.modules.pop(name, None)
+        assert "plugin_sdk" not in sys.modules, "precondition: the bare name must be unbound"
+
+        # Any entry point will do — the binding happens before the import is tried.
+        PluginLoader(plugin_dirs=[tmp_path])._import_plugin_class("nonexistent.module.main", tmp_path)
+
+        assert sys.modules.get("plugin_sdk") is canonical, (
+            "the loader must bind the documented plugin_sdk name to the canonical "
+            "modules BEFORE importing a plugin, or the plugin subclasses a second "
+            "copy of BasePlugin and fails issubclass (#13677)"
+        )
+        assert sys.modules.get("plugin_sdk.base") is sys.modules["autobot_shared.plugin_sdk.base"]
+
+
+class TestLoadedNOfM:
+    """0-of-7 and "no plugins installed" must not be the same observation.
+
+    Plugin names are unique per test on purpose: `get_registry()` is a process
+    global that keeps every successfully-registered plugin, so a shared name
+    makes the second test fail with "Plugin already registered" — a failure
+    about test wiring wearing the costume of a product bug.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_total_failure_is_critical_not_a_quiet_stream(self, tmp_path, caplog):
+        _make_plugin(tmp_path, "broken-plugin", source="raise RuntimeError('boom')\n")
+
+        manager = PluginManager([tmp_path])
+        with caplog.at_level("CRITICAL", logger="autobot_shared.plugin_sdk.plugin_manager"):
+            await manager.startup()
+
+        assert "loaded 0 of 1" in caplog.text
+        assert manager.get_load_report()["loaded"] == 0
+
+    @pytest.mark.asyncio
+    async def test_a_partial_failure_warns_and_names_the_casualties(self, tmp_path, caplog):
+        _make_plugin(tmp_path, "partial-good-plugin")
+        _make_plugin(tmp_path, "partial-bad-plugin", source="raise RuntimeError('boom')\n")
+
+        manager = PluginManager([tmp_path])
+        with caplog.at_level("WARNING", logger="autobot_shared.plugin_sdk.plugin_manager"):
+            await manager.startup()
+
+        assert "loaded 1 of 2" in caplog.text
+        assert "partial-bad-plugin" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_no_plugins_is_distinguishable_from_all_plugins_broken(self, tmp_path, caplog):
+        """The headline confusion. An empty tree must NOT read as a failure, and
+        a fully-broken tree must not read as an empty one."""
+        manager = PluginManager([tmp_path])
+        with caplog.at_level("INFO", logger="autobot_shared.plugin_sdk.plugin_manager"):
+            await manager.startup()
+
+        assert "no plugins discovered" in caplog.text
+        assert "loaded 0 of" not in caplog.text
+        assert manager.get_load_report() == {
+            "discovered": 0,
+            "loaded": 0,
+            "failed": [],
+            "started": True,
+        }
+
+    @pytest.mark.asyncio
+    async def test_a_plugin_that_returns_none_is_reported(self, tmp_path, caplog):
+        """`load_plugin` returns None far more often than it raises, and that
+        branch logged nothing — the loader's own error names a module, not a
+        plugin. Six of seven core plugins failed exactly here."""
+        _make_plugin(tmp_path, "no-class-plugin", source="VALUE = 1\n")  # no BasePlugin subclass
+
+        manager = PluginManager([tmp_path])
+        with caplog.at_level("ERROR", logger="autobot_shared.plugin_sdk.plugin_manager"):
+            await manager.startup()
+
+        assert "no-class-plugin" in caplog.text
+        assert "did not load" in caplog.text
+        assert manager.get_load_report()["failed"] == ["no-class-plugin"]
+
+    @pytest.mark.asyncio
+    async def test_the_report_is_queryable_not_only_logged(self, tmp_path):
+        """#13852's acceptance: a service running but not working must be
+        distinguishable by something a check can QUERY. A log line is not that."""
+        _make_plugin(tmp_path, "queryable-good-plugin")
+
+        manager = PluginManager([tmp_path])
+        await manager.startup()
+
+        report = manager.get_load_report()
+        assert report["discovered"] == 1
+        assert report["loaded"] == 1
+        assert report["started"] is True
+
+    @pytest.mark.asyncio
+    async def test_the_report_says_started_false_before_startup(self, tmp_path):
+        """Otherwise "0 loaded" before startup is indistinguishable from
+        "0 loaded, everything failed" — the same conflation one level up."""
+        assert PluginManager([tmp_path]).get_load_report()["started"] is False

--- a/autobot_shared/plugin_sdk/plugin_load_visibility_test.py
+++ b/autobot_shared/plugin_sdk/plugin_load_visibility_test.py
@@ -241,3 +241,84 @@ class TestLoadedNOfM:
         """Otherwise "0 loaded" before startup is indistinguishable from
         "0 loaded, everything failed" — the same conflation one level up."""
         assert PluginManager([tmp_path]).get_load_report()["started"] is False
+
+
+class TestTheSignalDoesNotManufactureFailures:
+    """#13677 review: the live backend passes TWO overlapping plugin dirs.
+
+    `lifespan.py` passes the deployed root AND the dev fallback — this issue's
+    own title says "discovery runs twice". Undeduped, the second registration of
+    a HEALTHY plugin raises "Plugin already registered", is swallowed by the
+    loader, returns None, and lands in `failed`. The live config reported
+    discovered=14 with five perfectly-loaded plugins named as casualties.
+
+    A signal built to end a misdiagnosis must not manufacture one.
+    """
+
+    @pytest.mark.asyncio
+    async def test_overlapping_plugin_dirs_do_not_invent_casualties(self, tmp_path, caplog):
+        _make_plugin(tmp_path, "dedupe-good-plugin")
+
+        manager = PluginManager([tmp_path, tmp_path])  # the shape lifespan.py uses
+        with caplog.at_level("WARNING", logger="autobot_shared.plugin_sdk.plugin_manager"):
+            await manager.startup()
+
+        report = manager.get_load_report()
+        assert report["discovered"] == 1, "the same plugin found twice is one plugin"
+        assert report["loaded"] == 1
+        assert report["failed"] == [], "a healthy plugin must never be named a casualty"
+        assert "dedupe-good-plugin" not in caplog.text
+
+
+class TestCanonicalisationDoesNotSplitTheRegistry:
+    """#13677 review: binding the parent first re-created the #11636 split.
+
+    A submodule imported during the alias loop that does `from plugin_sdk.X
+    import ...` loads a fresh X from the canonical path AND sets it as an
+    attribute on the parent — which is by then the canonical package. Repairing
+    sys.modules does not repair that attribute, so
+    `autobot_shared.plugin_sdk.registry` held a SECOND Registry class with its
+    own singleton.
+    """
+
+    def test_parent_attributes_still_point_at_the_canonical_submodules(self):
+        import autobot_shared.plugin_sdk as canonical
+
+        canonicalise_plugin_sdk()
+
+        clobbered = [
+            name
+            for name in ("base", "registry", "hooks", "loader")
+            if f"autobot_shared.plugin_sdk.{name}" in sys.modules
+            and getattr(canonical, name, None) is not sys.modules[f"autobot_shared.plugin_sdk.{name}"]
+        ]
+        assert not clobbered, f"canonicalisation replaced parent attributes: {clobbered} (#11636 regression)"
+
+    def test_a_clobbered_parent_attribute_is_repaired(self):
+        """The `setattr` is belt-and-braces and needs its own trigger.
+
+        Filtering out the package's own tests removes TODAY's only clobber
+        source, so without constructing the condition this guard passes whatever
+        the loader does. Any future submodule doing `from plugin_sdk.X import
+        ...` during the alias loop reintroduces it.
+        """
+        import autobot_shared.plugin_sdk as canonical
+
+        real = sys.modules["autobot_shared.plugin_sdk.base"]
+        impostor = type(sys)("autobot_shared.plugin_sdk.base")
+        canonical.base = impostor  # what a mid-loop import does
+        try:
+            canonicalise_plugin_sdk()
+            assert canonical.base is real, (
+                "canonicalisation must re-assert the parent attribute, or "
+                "autobot_shared.plugin_sdk.base holds a duplicate module (#11636)"
+            )
+        finally:
+            canonical.base = real
+
+    def test_the_package_tests_are_not_imported_into_the_process(self):
+        """Importing them drags pytest into production (~100ms), and where
+        pytest is absent the import fails and retries on every plugin."""
+        canonicalise_plugin_sdk()
+
+        assert not [m for m in sys.modules if m.startswith("plugin_sdk.") and m.endswith("_test")]

--- a/autobot_shared/plugin_sdk/plugin_manager.py
+++ b/autobot_shared/plugin_sdk/plugin_manager.py
@@ -66,7 +66,14 @@ class PluginManager:
         self._started = True
         logger.info("PluginManager: starting plugin discovery")
 
-        manifests = self._loader.discover_plugins()
+        # Dedupe by name. lifespan.py passes BOTH the deployed plugin root and
+        # the dev fallback, which overlap — this issue's own title says
+        # "discovery runs twice". Undeduped, the second registration of a
+        # HEALTHY plugin raises "Plugin already registered", is swallowed, and
+        # lands in `failed`: the live config reported discovered=14 with five
+        # perfectly-loaded plugins named as casualties. A signal built to end a
+        # misdiagnosis must not manufacture one (#13677 review).
+        manifests = self._dedupe_manifests(self._loader.discover_plugins())
         logger.info("PluginManager: discovered %d plugin(s)", len(manifests))
 
         loaded: List[str] = []
@@ -152,6 +159,20 @@ class PluginManager:
         """Return the shared PluginRegistry."""
         return self._registry
 
+    @staticmethod
+    def _dedupe_manifests(manifests: List) -> List:
+        """First manifest wins per name, preserving discovery order."""
+        seen: Dict[str, object] = {}
+        for manifest in manifests:
+            seen.setdefault(manifest.name, manifest)
+        duplicates = len(manifests) - len(seen)
+        if duplicates:
+            logger.info(
+                "PluginManager: ignored %d duplicate manifest(s) from overlapping plugin dirs",
+                duplicates,
+            )
+        return list(seen.values())
+
     def _record_load_report(self, manifests: List, loaded: List[str], failed: List[str]) -> None:
         """Emit the `loaded N of M` summary and store it for querying (#13677).
 
@@ -198,7 +219,16 @@ class PluginManager:
         working be distinguishable by something a check can QUERY. A log line
         does not satisfy that; this does.
         """
-        return dict(self._load_report)
+        report = dict(self._load_report)
+        # Copy the list too: `dict()` is shallow, so a caller appending to
+        # report["failed"] was mutating the manager's own tally.
+        failed = self._load_report.get("failed", [])
+        report["failed"] = list(failed) if isinstance(failed, list) else []
+        # Derived, not stored: the stored flag only flips at the END of startup,
+        # so a manager mid-load — or one whose discovery raised — would have
+        # reported started=False while running.
+        report["started"] = self._started
+        return report
 
     def get_plugin_status(self) -> Dict[str, str]:
         """Return a mapping of plugin name → status string."""

--- a/autobot_shared/plugin_sdk/plugin_manager.py
+++ b/autobot_shared/plugin_sdk/plugin_manager.py
@@ -43,6 +43,10 @@ class PluginManager:
         self._registry = PluginRegistry()
         self._hook_registry = HookRegistry()
         self._started = False
+        # #13677: the load tally, so "is the plugin subsystem working?" is a
+        # QUERY and not a log-reading exercise. A stream of per-plugin lines
+        # nobody totals is why 0-of-7 and "no plugins installed" looked the same.
+        self._load_report: Dict[str, object] = {"discovered": 0, "loaded": 0, "failed": [], "started": False}
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -65,23 +69,41 @@ class PluginManager:
         manifests = self._loader.discover_plugins()
         logger.info("PluginManager: discovered %d plugin(s)", len(manifests))
 
+        loaded: List[str] = []
+        failed: List[str] = []
+
         for manifest in manifests:
             try:
                 plugin = await self._loader.load_plugin(manifest)
                 if plugin:
                     await plugin.enable()
+                    loaded.append(manifest.name)
                     logger.info(
                         "PluginManager: loaded and enabled '%s' v%s",
                         manifest.name,
                         manifest.version,
                     )
+                else:
+                    # #13677: load_plugin returns None far more often than it
+                    # raises, and this branch logged NOTHING — the loader's own
+                    # error was the only trace, and it names a module rather than
+                    # a plugin. Six of seven core plugins failed exactly here.
+                    failed.append(manifest.name)
+                    logger.error(
+                        "PluginManager: plugin '%s' did not load (entry point %s)",
+                        manifest.name,
+                        manifest.entry_point,
+                    )
             except Exception as exc:  # noqa: BLE001
+                failed.append(manifest.name)
                 logger.error(
                     "PluginManager: failed to load plugin '%s': %s",
                     manifest.name,
                     exc,
                     exc_info=True,
                 )
+
+        self._record_load_report(manifests, loaded, failed)
 
         await self._hook_registry.call_hook("on_startup")
         logger.info(
@@ -110,6 +132,10 @@ class PluginManager:
                 )
 
         self._started = False
+        # #13677: the load tally, so "is the plugin subsystem working?" is a
+        # QUERY and not a log-reading exercise. A stream of per-plugin lines
+        # nobody totals is why 0-of-7 and "no plugins installed" looked the same.
+        self._load_report: Dict[str, object] = {"discovered": 0, "loaded": 0, "failed": [], "started": False}
         logger.info("PluginManager: shutdown complete")
 
     # ------------------------------------------------------------------
@@ -125,6 +151,54 @@ class PluginManager:
     def plugin_registry(self) -> PluginRegistry:
         """Return the shared PluginRegistry."""
         return self._registry
+
+    def _record_load_report(self, manifests: List, loaded: List[str], failed: List[str]) -> None:
+        """Emit the `loaded N of M` summary and store it for querying (#13677).
+
+        The per-plugin lines above are necessary and not sufficient: nothing
+        totalled them, so a run where every plugin failed produced the same
+        shape of output as a healthy one — and a host with no plugins installed
+        produced the same shape as a host where all seven were broken.
+
+        Total failure is logged at CRITICAL rather than ERROR because it is a
+        different condition: not "a plugin is broken" but "the plugin subsystem
+        delivered nothing", which is invisible in every other signal.
+        """
+        self._load_report = {
+            "discovered": len(manifests),
+            "loaded": len(loaded),
+            "failed": sorted(failed),
+            "started": True,
+        }
+
+        if not manifests:
+            logger.info("PluginManager: no plugins discovered — nothing to load")
+            return
+
+        if not loaded:
+            logger.critical(
+                "PluginManager: loaded 0 of %d plugin(s) — the plugin subsystem is " "delivering nothing. Failed: %s",
+                len(manifests),
+                ", ".join(sorted(failed)) or "unknown",
+            )
+            return
+
+        level = logger.warning if failed else logger.info
+        level(
+            "PluginManager: loaded %d of %d plugin(s)%s",
+            len(loaded),
+            len(manifests),
+            f" — failed: {', '.join(sorted(failed))}" if failed else "",
+        )
+
+    def get_load_report(self) -> Dict[str, object]:
+        """Return the startup load tally.
+
+        The umbrella (#13852) asks that a service which is running but not
+        working be distinguishable by something a check can QUERY. A log line
+        does not satisfy that; this does.
+        """
+        return dict(self._load_report)
 
     def get_plugin_status(self) -> Dict[str, str]:
         """Return a mapping of plugin name → status string."""

--- a/autobot_shared/plugin_sdk/plugin_manager.py
+++ b/autobot_shared/plugin_sdk/plugin_manager.py
@@ -132,10 +132,10 @@ class PluginManager:
                 )
 
         self._started = False
-        # #13677: the load tally, so "is the plugin subsystem working?" is a
-        # QUERY and not a log-reading exercise. A stream of per-plugin lines
-        # nobody totals is why 0-of-7 and "no plugins installed" looked the same.
-        self._load_report: Dict[str, object] = {"discovered": 0, "loaded": 0, "failed": [], "started": False}
+        # #13677: reset the tally too — after shutdown the previous run's counts would
+        # describe a subsystem that is no longer running, and "loaded 5 of 7"
+        # from a dead manager is worse than no answer.
+        self._load_report = {"discovered": 0, "loaded": 0, "failed": [], "started": False}
         logger.info("PluginManager: shutdown complete")
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
Refs #13677 · umbrella #13852 (Wave 2, class B) · builds on #10294 (merged)

Deliberately **not** `Closes` — this takes the core plugins from **0 of 7 loaded to 5 of 7**. The last two are
real, separate defects, now visible instead of silent. See *What is left*.

## Thinking Path

Two independent defects, and the second is what made the first invisible.

**The loader could not recognise the plugins.** `docs/developer/PLUGIN_SDK.md:60` tells authors to write
`from plugin_sdk.base import BasePlugin`, and every core plugin does. That name resolves — `autobot_shared` is
installed editable and exposes `plugin_sdk` as a second top-level package over the same source — but to a
**second set of module objects**:

```
canonical: autobot_shared.plugin_sdk.base
alt      : plugin_sdk.base
SAME CLASS OBJECT: False
```

So `issubclass(HelloPlugin, BasePlugin)` is False and the loader reports **"No plugin class found in module"**
— for a class sitting in the module it has just imported, sending the reader hunting for the wrong thing. The
plugins were never wrong; the loader was.

**Nothing totalled the result.** `startup()` logged discovery and per-plugin successes, and the far commoner
failure — `load_plugin` returning `None` rather than raising — logged **nothing** at that level. A run where
every plugin failed produced the same shape of output as a healthy one, and a host with no plugins produced
the same shape as a host where all seven were broken. That is the issue's headline, exactly.

## What Changed

`canonicalise_plugin_sdk()` binds the documented names to the canonical modules before any plugin is imported.
Submodules too — aliasing only the parent lets a later `import plugin_sdk.base` load a fresh object from the
canonical path and reintroduce the split.

The startup summary:

| outcome | signal |
|---|---|
| loaded 0 of N | **CRITICAL** — "the plugin subsystem is delivering nothing" |
| loaded X of N | WARNING, naming the casualties |
| loaded N of N | INFO |
| no plugins found | INFO — explicitly **not** a failure |

and `get_load_report()` makes it a **query**, not a log-reading exercise — which is what #13852's acceptance
actually asks for ("distinguishable by something a check can query").

## Verification

On the real `plugins/core-plugins` tree, with #10294 merged into base:

```
before:  loaded=0 failed=7
after:   PluginManager: loaded 5 of 7 plugin(s) — failed: logger-plugin, telemetry-prompt-middleware
report:  {'discovered': 7, 'loaded': 5, 'failed': [...], 'started': True}
```

```
$ pytest autobot_shared/plugin_sdk/ -q
100 passed
```

## A guard of mine that could not fail

The first version of the canonicalisation test **survived deleting the loader's call** — all 92 tests stayed
green. Earlier tests in the file called the helper directly, leaving the alias bound process-wide, so every
later load test passed regardless of what the loader did.

It now asserts the loader's own effect on `sys.modules`, and an autouse fixture returns each test to the split
state a real process starts in. Mutation-verified: removing the loader's call now fails.

Plugin names are unique per test because `get_registry()` is a process global — a shared name failed the
second test with "Plugin already registered", a test-wiring failure wearing the costume of a product bug.

## What is left (why this is `Refs`)

- **logger-plugin** — `PermissionError: /tmp/plugin_events.log`. A hardcoded path with no error handling.
- **telemetry-prompt-middleware** — missing `aiohttp`, i.e. the issue's "dependency check resolves pip
  packages against the plugin registry" half.

Both were previously indistinguishable from the other five failures. They are now named in a WARNING and in
`get_load_report()["failed"]`, which is the point.

**Not verified on a host.** Closing wants a live startup showing the `loaded N of M` line and the report
served through the API.

## Model Used

Claude Opus 5 (1M context)
