### PR TITLE
docs(git): require a worktree preflight — 3 collisions in one hour, none caught by the existing guidance (#13964)

### DIFF
--- a/docs/developer/CLAUDE_GIT.md
+++ b/docs/developer/CLAUDE_GIT.md
@@ -8,12 +8,55 @@
 - **Main session stays on `Dev_new_gui`** — never check out feature branches
 - **Why:** Switching branches in main session breaks all active worktrees that depend on that branch
 
+**Preflight — REQUIRED before creating (#13964):**
+
+`.worktrees/issue-XXXX` is derived from the issue number, so two sessions pointed
+at one issue compute the **same path**. This clone is shared, so every session's
+trees are visible — check before writing.
+
+```bash
+git worktree list                                   # every session's trees, not just yours
+git show-ref --verify --quiet refs/heads/issue-XXXX && echo "BRANCH TAKEN"
+git -C .worktrees/issue-XXXX status --short         # if it exists: any output = ACTIVE session
+git -C .worktrees/issue-XXXX log --oneline -3       # commits you did not write = not yours
+```
+
+Three rules, each from a real collision:
+
+- **Never pipe a command whose exit code gates the next step.**
+  `git worktree add ... 2>&1 | tail -1` returns *tail's* status, so `&&` proceeds
+  past `fatal: A branch named 'issue-N' already exists` — straight into another
+  session's tree. Verified: piped `0`, unpiped `255`.
+- **Uncommitted changes mean an ACTIVE session**, whatever the commit count says.
+  A clean zero-commit tree is ambiguous; a dirty one is not. One collision was a
+  tree that looked abandoned by every heuristic and held 83 uncommitted lines.
+- **A lock reason is not proof of ownership.** A lock string can match your own
+  task description because the tree *used to be* yours before another session
+  took it over. Trust `git log`, not the lock.
+
+**Backing out cleanly** if you claimed someone's tree — never `--force`:
+
+```bash
+git reset --soft HEAD~1        # drops YOUR empty claim commit, leaves their work untouched
+git worktree unlock <path>     # restore the state you found
+```
+
 **Worktree Creation:**
 ```bash
-git worktree add .worktrees/issue-XXXX -b issue-XXXX origin/Dev_new_gui
+git worktree add .worktrees/issue-XXXX -b issue-XXXX origin/Dev_new_gui   # do NOT pipe this
 cd .worktrees/issue-XXXX && git branch --unset-upstream
 # Commit and push from here. Do NOT switch branches.
 ```
+
+**Before `--force-with-lease`,** confirm the remote already contains your commit:
+
+```bash
+git merge-base --is-ancestor <your-sha> origin/issue-XXXX && echo "safe to force"
+```
+
+The `auto-update-pr-branches` workflow merges base into PR branches, so "my local
+is behind my own branch" is normal. Force-pushing over it discards the bot's
+merge.
 
 ---
 


### PR DESCRIPTION
## Thinking Path

Three worktree collisions in one hour today. The existing guidance covers `git worktree remove --force`, and **none of them involved force** — which is why it caught none of them.

The root cause is structural: `.worktrees/issue-XXXX` derives from the issue number, so two sessions pointed at one issue compute the same path. The claim protocol (`worktree lock` + empty commit) protects a tree from being *swept*; it does nothing to stop a second session *starting* there. This clone has **23 live worktrees**, so the odds are not marginal.

All three were detectable — `git worktree list` shows every session's trees. Nothing checked.

The mechanical trigger is worth stating precisely, because it is a habit rather than a slip:

```
$ git worktree add /tmp/demo -b issue-13695 origin/Dev_new_gui 2>&1 | tail -1
fatal: A branch named 'issue-13695' already exists.
exit code seen by the && chain: 0     <-- tail's

$ git worktree add /tmp/demo2 -b issue-13695 origin/Dev_new_gui >/dev/null 2>&1
exit code WITHOUT the pipe: 255       <-- git's
```

`2>&1 | tail -1` is how I keep output short. It also silently disarms `&&`, so `cd && lock && commit` marched into a live tree twice.

## What Changed

`docs/developer/CLAUDE_GIT.md` gains a required preflight before the existing creation block, plus three rules each traced to a real collision:

- **Never pipe a command whose exit code gates the next step** — with the demonstration above.
- **Uncommitted changes mean an ACTIVE session**, whatever the commit count says. `issue-13719` was unlocked with zero commits above base — "a session that just started, leave alone" by the current heuristic — and held **83 uncommitted lines** in the exact file its issue concerns.
- **A lock reason is not proof of ownership.** `issue-13694`'s lock string matched my task description verbatim, because the tree *had* been mine before another session took it over. `git log` showed foreign commits; the lock showed nothing.

Also documented: the clean backout (`git reset --soft HEAD~1` drops your empty claim without touching their working tree, then `worktree unlock`), and the push-side corollary — before `--force-with-lease`, confirm the remote contains your commit, because the `auto-update-pr-branches` bot merges base into PR branches and force-pushing discards its merge.

## Verification

The preflight was run for this very PR before creating its worktree, and the creation command was deliberately not piped:

```
=== PREFLIGHT for issue-13964 ===
1. existing worktrees:  23 trees in this clone
   no issue-13964 tree
2. branch:  branch free
3. remote branch:  remote free

worktree add exit: 0
```

Docs-only change; no code paths touched. Markdown style matches the file's existing convention (base already places fences directly after bold text) and markdownlint is not a CI check.

## Decision

Owner chose documented detection over the two structural alternatives. Both were considered and are recorded on #13964 so they are not re-proposed:

- **session-suffixed branch names** (`issue-N-<id>`) would make collisions impossible by construction, at the cost of the naming convention and multiple branches per issue;
- **GitHub issue self-assignment** is the only cross-machine signal — `issue-13719` had no remote branch at all, so nothing on GitHub could have warned me — but nothing uses assignees today.

## Model Used

Opus 5

Closes #13964
