### PR TITLE
fix(ci): open a release PR instead of pushing to protected main

### DIFF
--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -1,8 +1,11 @@
 # Sync Dev_new_gui → main (manual release trigger only)
 #
-# Dev_new_gui is the working branch. This workflow pushes it to main
-# when explicitly triggered for a release. It never runs automatically
-# to prevent untested code from landing on main.
+# Dev_new_gui is the working branch. This workflow opens a release PR from it
+# into main when explicitly triggered. It never runs automatically, to prevent
+# untested code from landing on main.
+#
+# It opens a PR rather than pushing: main requires status checks, so a direct
+# push is declined by the protected-branch hook (GH006). Detail at the step.
 #
 # See: https://github.com/mrveiss/AutoBot-AI/issues/2445
 
@@ -23,6 +26,8 @@ concurrency:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    env:
+      SYNC_BRANCH: release-sync-main
     permissions:
       contents: write
       pull-requests: write
@@ -56,16 +61,56 @@ jobs:
           echo "behind=$BEHIND" >> "$GITHUB_OUTPUT"
           echo "Dev_new_gui is $AHEAD ahead, $BEHIND behind main"
 
-      - name: Sync main to Dev_new_gui
+      - name: Open the release sync PR
+        id: sync
         if: steps.check.outputs.ahead != '0'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AHEAD: ${{ steps.check.outputs.ahead }}
+          BEHIND: ${{ steps.check.outputs.behind }}
         run: |
-          if [ "${{ steps.check.outputs.behind }}" != "0" ]; then
-            echo "::error::main has ${{ steps.check.outputs.behind }} commit(s) not in Dev_new_gui. Resolve divergence manually first."
+          if [ "$BEHIND" != "0" ]; then
+            echo "::error::main has $BEHIND commit(s) not in Dev_new_gui. Resolve divergence manually first."
             exit 1
           fi
 
-          # Safe fast-forward push (no --force)
-          git push origin origin/Dev_new_gui:main
-          echo "main fast-forwarded to Dev_new_gui successfully."
+          # This step used to `git push origin origin/Dev_new_gui:main`, which
+          # can never succeed: `main` requires two status checks ("No open
+          # blocks-merge issues reference this PR", "No commit trailers"), and a
+          # direct push moves the branch to a commit that has neither, so the
+          # protected-branch hook declines it:
+          #
+          #   remote: error: GH006: Protected branch update failed for refs/heads/main.
+          #   ! [remote rejected] origin/Dev_new_gui -> main (protected branch hook declined)
+          #
+          # Routing through a PR lets those checks run against the release head,
+          # which is what the protection is for. Precedent: #13816 synced this
+          # way by hand.
+          git push --force origin "origin/Dev_new_gui:refs/heads/$SYNC_BRANCH"
+
+          EXISTING=$(gh pr list --base main --head "$SYNC_BRANCH" --state open --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            echo "Release sync PR already open: #$EXISTING (refreshed to the current trunk)."
+            echo "url=$(gh pr view "$EXISTING" --json url --jq .url)" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Body written to a file so it carries no leading indentation.
+          cat > /tmp/sync-pr-body.md <<EOF
+          Opened by the \`Sync Dev_new_gui → main\` workflow.
+
+          \`main\` is $AHEAD commit(s) behind \`Dev_new_gui\` and holds none the trunk lacks.
+
+          Merging this is the release. The checks \`main\` requires run against this head,
+          which a direct push could not satisfy — see the comment in
+          \`.github/workflows/sync-main-to-dev.yml\`.
+          EOF
+          sed -i 's/^          //' /tmp/sync-pr-body.md
+
+          URL=$(gh pr create \
+            --base main \
+            --head "$SYNC_BRANCH" \
+            --title "release: sync Dev_new_gui into main ($AHEAD commits)" \
+            --body-file /tmp/sync-pr-body.md)
+          echo "Opened $URL"
+          echo "url=$URL" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Thinking Path

The `Sync Dev_new_gui → main` workflow has never completed. Two independent blockers, discovered one behind the other:

**Blocked on divergence** — the 2026-08-05 run:
```
::error::main has 4 commit(s) not in Dev_new_gui. Resolve divergence manually first.
```
Fixed by #13951, which merged `main`'s history back into the trunk (zero content change).

**Then blocked on branch protection** — today's run, having passed the divergence gate:
```
remote: error: GH006: Protected branch update failed for refs/heads/main.
 ! [remote rejected] origin/Dev_new_gui -> main (protected branch hook declined)
```

`main` requires two status checks — `No open blocks-merge issues reference this PR` and `No commit trailers`. A direct push moves the branch to a commit that carries neither, so the hook declines it. That is not a misconfiguration to work around; it is the protection doing its job. **The push could never have succeeded**, which is why `main` sat 41 commits behind for days with no visible signal — a dispatch-only workflow failing silently is invisible unless someone goes looking.

So the step routes through a PR instead, which is what lets the required checks run against the release head. #13816 did exactly this by hand on 2026-08-09 — this makes the builtin do what the human already had to.

## What Changed

`.github/workflows/sync-main-to-dev.yml` only.

- The push step becomes: force-update a dedicated `release-sync-main` branch to the trunk, then open a PR into `main`
- If a sync PR is already open, refresh the branch and report it rather than creating a duplicate
- The divergence guard is unchanged, and its inline expansions moved to `env:` (it read `if [ "0" != "0" ]` in the log — correct, but interpolated rather than passed)
- The header comment no longer says the workflow pushes to `main`, and the step carries the `GH006` output so the next reader does not rediscover it

Still `workflow_dispatch`-only, still requires typing `release`. Merging the PR is the release; this only makes the PR appear.

## Verification

The `run:` block was extracted from the YAML and exercised with `git` and `gh` stubbed — a workflow edit that merely looks right is what produced the original bug.

| Case | Result |
|---|---|
| `main` diverged (BEHIND=3) | `::error::main has 3 commit(s) not in Dev_new_gui` — refuses, unchanged |
| no sync PR open | pushes `release-sync-main`, creates the PR, writes `url=` to `$GITHUB_OUTPUT` |
| sync PR already open | refreshes the branch, reports `#4242`, creates no duplicate |

The PR body is written via a file and de-indented, so the YAML block indentation does not leak into it:

```
$ grep -c "^ " /tmp/sync-pr-body.md
0
```

```
$ python -c "yaml.safe_load(open('.github/workflows/sync-main-to-dev.yml'))"
YAML valid
```

**Not verified end to end:** the workflow itself has not been re-dispatched against this change — it can only be tested by running it, and doing that from a branch would open a real release PR. Worth dispatching once this lands.

Refs #2445

## Model Used

Opus 5
