### PR TITLE
fix(knowledge): stop creating ChromaDB collections on read and delete paths (#13920)

### DIFF
--- a/autobot-backend/conftest.py
+++ b/autobot-backend/conftest.py
@@ -127,9 +127,21 @@ for _chromadb_mod in [
     "chromadb.config",
     "chromadb.telemetry",
     "chromadb.telemetry.opentelemetry",
+    # #13920: production code catches chromadb.errors.NotFoundError to tell
+    # "this collection does not exist" from every other failure. Without this
+    # entry the stub has no such submodule and the import raises inside the
+    # method under test.
+    "chromadb.errors",
 ]:
     if _chromadb_mod not in sys.modules:
         sys.modules[_chromadb_mod] = _make_pkg_stub(_chromadb_mod)
+
+# The exceptions on the stub must be REAL classes: a MagicMock attribute is not
+# a valid `except` target, so a stubbed-out error type turns a handled absence
+# into a TypeError at the catch site (#13920). Named to match chromadb's own.
+if not isinstance(getattr(sys.modules["chromadb.errors"], "NotFoundError", None), type):
+    _stub_not_found = type("NotFoundError", (Exception,), {})
+    sys.modules["chromadb.errors"].NotFoundError = _stub_not_found
 
 # Stub optional heavy dependencies that may not be installed in the dev venv.
 # These are only needed at runtime on the target VM; tests use mocks.

--- a/autobot-backend/llc/api/companies.py
+++ b/autobot-backend/llc/api/companies.py
@@ -318,6 +318,12 @@ async def delete_company(
     try:
         await svc.delete(company_id)
         await svc.session.commit()
+        # #13920: drop the three collections create_company's ensure_collection
+        # loop makes (base, agents, decisions). Derived from the same constants
+        # rather than restated, so a fourth suffix cannot be created and then
+        # silently never cleaned up.
+        for suffix in (None, KbCollectionManager.AGENTS_SUFFIX, KbCollectionManager.DECISIONS_SUFFIX):
+            await _kb_manager.drop_collection(KbCollectionManager.COMPANY_PREFIX, company_id, suffix)
     except CompanyNotFoundError:
         await svc.session.rollback()
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Internal server error")

--- a/autobot-backend/llc/api/sprints.py
+++ b/autobot-backend/llc/api/sprints.py
@@ -907,6 +907,13 @@ async def delete_sprint(
         raise HTTPException(status_code=404, detail="Sprint not found")
     await session.delete(sprint)
     await session.commit()
+    # #13920: drop the KB collection with its entity (post-commit, non-fatal).
+    try:
+        from llc.kb.collections import KbCollectionManager  # noqa: PLC0415
+
+        await KbCollectionManager().drop_collection(KbCollectionManager.SPRINT_PREFIX, sprint_id)
+    except Exception:  # noqa: BLE001 - defensive; drop_collection does not raise
+        logger.warning("Could not drop KB collection for sprint %s", sprint_id, exc_info=True)
 
 
 @router.post("/sprints/{sprint_id}/close", response_model=SprintResponse)

--- a/autobot-backend/llc/api/work_items.py
+++ b/autobot-backend/llc/api/work_items.py
@@ -525,6 +525,20 @@ async def delete_work_item(
         raise HTTPException(status_code=404, detail="Work item not found")
     await session.delete(item)
     await session.commit()
+    # #13920: drop the KB collection with its entity. Post-commit and
+    # non-fatal — the row is gone either way, and a stranded collection is a
+    # tidiness problem where a failed delete would be a correctness one.
+    await _drop_kb_collection(work_item_id)
+
+
+async def _drop_kb_collection(work_item_id: str) -> None:
+    """Best-effort removal of a deleted work item's KB collection (#13920)."""
+    from llc.kb.collections import KbCollectionManager  # noqa: PLC0415
+
+    try:
+        await KbCollectionManager().drop_collection(KbCollectionManager.WORK_ITEM_PREFIX, work_item_id)
+    except Exception:  # noqa: BLE001 - defensive; drop_collection does not raise
+        logger.warning("Could not drop KB collection for work item %s", work_item_id, exc_info=True)
 
 
 @router.post("/{work_item_id}/checkout")

--- a/autobot-backend/llc/kb/collections.py
+++ b/autobot-backend/llc/kb/collections.py
@@ -182,6 +182,39 @@ class KbCollectionManager:
             )
             raise RuntimeError(f"Failed to archive KB collection {original_name}") from e
 
+    async def drop_collection(
+        self,
+        entity_type: str,
+        entity_id: uuid.UUID | str,
+        suffix: Optional[str] = None,
+    ) -> bool:
+        """Drop an entity's collection when the entity itself is deleted (#13920).
+
+        Returns True if a collection was removed, False if there was nothing to
+        remove. Never raises: deleting a work item must not fail because its KB
+        collection is already gone, or because ChromaDB is momentarily
+        unreachable. The entity is the source of truth; a stranded collection is
+        a tidiness problem, a failed delete is a correctness one.
+
+        Before this, the only ``delete_collection`` under ``llc/`` was the
+        archive/rename path, so a deleted entity left its collection behind
+        permanently.
+        """
+        collection_name = self.collection_name(entity_type, entity_id, suffix)
+
+        try:
+            kb = await _get_kb()
+            client = kb._async_chroma_client
+            if await client.get_collection_or_none(collection_name) is None:
+                return False
+            await client.delete_collection(collection_name)
+        except Exception as exc:  # noqa: BLE001 - see the docstring
+            logger.warning("Could not drop KB collection %s: %s", collection_name, exc)
+            return False
+
+        logger.info("Dropped KB collection %s with its entity", collection_name)
+        return True
+
     async def merge_collection(
         self,
         src_entity_type: str,

--- a/autobot-backend/llc/kb/rag_assembler.py
+++ b/autobot-backend/llc/kb/rag_assembler.py
@@ -200,7 +200,12 @@ class LLCRAGAssembler:
             Dict with chunks and sources from collection.
         """
         try:
-            collection = await client.get_or_create_collection(collection_name)
+            # #13920: a query must not create the collection. Merely asking an
+            # entity KB that never had anything ingested was leaving a permanent
+            # empty collection behind — 32 of 37 on one deployment.
+            collection = await client.get_collection_or_none(collection_name)
+            if collection is None:
+                return {"chunks": [], "sources": []}
             results = await collection.query(
                 query_texts=[query_text],
                 n_results=n_results,

--- a/autobot-backend/llc/services/goal.py
+++ b/autobot-backend/llc/services/goal.py
@@ -349,7 +349,12 @@ class GoalService(LLCServiceBase):
             from utils.async_chromadb_client import get_async_chromadb_client
 
             client = await get_async_chromadb_client()
-            collection = await client.get_or_create_collection(_goal_collection_name(company_id))
+            # #13920: deleting from a collection that does not exist is already
+            # a no-op — creating one so the delete has somewhere to go leaves an
+            # empty collection behind forever.
+            collection = await client.get_collection_or_none(_goal_collection_name(company_id))
+            if collection is None:
+                return
             await collection.delete(ids=ids)
         except Exception:
             logger.exception("Failed to remove goals %s from KB — non-fatal", ids)

--- a/autobot-backend/llc/services/project_disposal.py
+++ b/autobot-backend/llc/services/project_disposal.py
@@ -13,7 +13,7 @@ them at their source modules:
 
 import logging
 
-from sqlalchemy import delete
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from llc.models.sprint import LLCProject, LLCSprint
@@ -29,13 +29,46 @@ async def dispose(project: LLCProject, session: AsyncSession) -> None:
     project_id = project.id
     code_source_id = project.code_source_id
 
+    # #13920: collect the child ids BEFORE the bulk deletes — afterwards there is
+    # nothing left to derive the collection names from, and the collections would
+    # be stranded with no entity to trace them back to.
+    child_work_items = (
+        (await session.execute(select(LLCWorkItem.id).where(LLCWorkItem.project_id == project_id))).scalars().all()
+    )
+    child_sprints = (
+        (await session.execute(select(LLCSprint.id).where(LLCSprint.project_id == project_id))).scalars().all()
+    )
+
     await session.execute(delete(LLCWorkItem).where(LLCWorkItem.project_id == project_id))
     await session.execute(delete(LLCSprint).where(LLCSprint.project_id == project_id))
     await session.execute(delete(LLCProject).where(LLCProject.id == project_id))
 
+    await _drop_kb_collections(project_id, child_work_items, child_sprints)
+
     if code_source_id:
         await _dispose_source(code_source_id)
     logger.info("Disposed project %s (source=%s)", project_id, code_source_id)
+
+
+async def _drop_kb_collections(project_id, work_item_ids, sprint_ids) -> None:
+    """Drop the KB collections belonging to a disposed project and its children (#13920).
+
+    Never raises — a disposal must not fail because ChromaDB is unreachable.
+    ``drop_collection`` already swallows and logs per collection; this only
+    guards the import and the loop itself.
+    """
+    from llc.kb.collections import KbCollectionManager  # noqa: PLC0415
+
+    manager = KbCollectionManager()
+    targets = [(KbCollectionManager.PROJECT_PREFIX, project_id)]
+    targets += [(KbCollectionManager.WORK_ITEM_PREFIX, wid) for wid in work_item_ids]
+    targets += [(KbCollectionManager.SPRINT_PREFIX, sid) for sid in sprint_ids]
+
+    for entity_type, entity_id in targets:
+        try:
+            await manager.drop_collection(entity_type, entity_id)
+        except Exception:  # noqa: BLE001 - defensive; drop_collection does not raise
+            logger.warning("Could not drop KB collection for %s %s", entity_type, entity_id, exc_info=True)
 
 
 async def _dispose_source(code_source_id: str) -> None:

--- a/autobot-backend/llc/tests/test_no_empty_collections_13920.py
+++ b/autobot-backend/llc/tests/test_no_empty_collections_13920.py
@@ -1,0 +1,302 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Reading a KB does not create it, and deleting an entity drops it (#13920).
+
+The ChromaDB Explorer listed **37 collections, 32 of them empty** on one
+deployment. They were not orphans of deleted sessions: read and delete paths
+were calling ``get_or_create_collection``, so merely *querying* an entity KB
+that never had anything ingested materialised a permanent empty collection.
+
+The cost is not only the noise. An entity KB that *should* hold content and
+does not becomes indistinguishable from one that was queried once — the
+accumulation hides exactly the signal an operator would look for.
+
+Asserted against a hand-written in-memory store, not a MagicMock. The property
+under test is *what the store contains afterwards*; a MagicMock would only
+confirm which method name was called, which is a restatement of the fix.
+
+The root conftest stubs ``chromadb`` outright (it hangs at import without a
+local server), so a real ``EphemeralClient()`` here is a MagicMock whose every
+call succeeds — the first draft of this file did exactly that and was asserting
+nothing. The fake below implements the one behaviour that matters, and
+``test_real_chromadb_raises_notfounderror_for_a_missing_collection`` pins that
+behaviour against the real library whenever it is genuinely importable, so the
+fake cannot quietly drift from what it stands in for.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from utils.async_chromadb_client import AsyncChromaClient
+
+
+class _FakeChroma:
+    """The slice of chromadb's sync client these paths use.
+
+    ``get_collection`` raises ``NotFoundError`` for an absent name — that is
+    the contract ``get_collection_or_none`` is built on, and the reason a
+    ``create``-on-read was needed before.
+    """
+
+    def __init__(self):
+        self.collections: dict[str, "_FakeCollection"] = {}
+
+    def list_collections(self):
+        return [type("C", (), {"name": n})() for n in self.collections]
+
+    def get_collection(self, name, embedding_function=None):
+        from chromadb.errors import NotFoundError
+
+        if name not in self.collections:
+            raise NotFoundError(f"Collection {name} does not exist")
+        return self.collections[name]
+
+    def get_or_create_collection(self, name, metadata=None, embedding_function=None):
+        return self.collections.setdefault(name, _FakeCollection(name))
+
+    def create_collection(self, name, metadata=None, embedding_function=None):
+        self.collections[name] = _FakeCollection(name)
+        return self.collections[name]
+
+    def delete_collection(self, name):
+        self.collections.pop(name, None)
+
+
+class _FakeCollection:
+    def __init__(self, name):
+        self.name = name
+        self.deleted_ids: list = []
+
+    def delete(self, ids=None, where=None):
+        self.deleted_ids.extend(ids or [])
+
+    def query(self, **kwargs):
+        return {"documents": [[]], "metadatas": [[]], "distances": [[]]}
+
+
+@pytest.fixture
+async def client():
+    c = AsyncChromaClient.__new__(AsyncChromaClient)
+    c._client = _FakeChroma()
+    c._collection_cache = {}
+    return c
+
+
+def test_real_chromadb_raises_notfounderror_for_a_missing_collection():
+    """Pin the contract the fake encodes, against the real library.
+
+    Skipped where the root conftest's stub is in place — under the stub this
+    would assert against a MagicMock and pass regardless, which is the failure
+    mode the fake exists to avoid rather than reproduce.
+    """
+    import chromadb
+
+    # __path__, not __file__: the stub is a real ModuleType whose __getattr__
+    # hands back a MagicMock for any missing attribute, so a __file__ check
+    # returns something truthy and the skip never fires. __path__ is set
+    # explicitly on the stub (to []) and is non-empty on the real package.
+    if not list(getattr(chromadb, "__path__", []) or []):
+        pytest.skip("chromadb is stubbed by the root conftest")
+
+    from chromadb.errors import NotFoundError
+
+    real = chromadb.EphemeralClient()
+    with pytest.raises(NotFoundError):
+        real.get_collection("definitely_absent")
+
+
+# --------------------------------------------------------- the helper itself
+
+
+@pytest.mark.asyncio
+async def test_get_collection_or_none_returns_none_without_creating(client):
+    """The whole point: asking must not be the same as making."""
+    before = await client.list_collections()
+
+    result = await client.get_collection_or_none("never_ingested")
+
+    assert result is None
+    assert await client.list_collections() == before, "a lookup created the collection it was only asking about"
+
+
+@pytest.mark.asyncio
+async def test_get_collection_or_none_returns_an_existing_collection(client):
+    """It must still find what is there — a helper that always returns None
+    would pass the test above and break every read."""
+    await client.create_collection("real_one")
+
+    result = await client.get_collection_or_none("real_one")
+
+    assert result is not None
+
+
+@pytest.mark.asyncio
+async def test_a_connection_failure_is_not_reported_as_absence(client):
+    """Absence and unreachability must not collapse into the same answer.
+
+    Callers treat ``None`` as "no results". If a broken ChromaDB also returned
+    ``None``, an outage would surface as silently empty answers — the same
+    class of defect this issue is about, one layer down.
+    """
+
+    async def boom(*a, **k):
+        raise RuntimeError("chromadb unreachable")
+
+    client.get_collection = boom
+
+    with pytest.raises(RuntimeError):
+        await client.get_collection_or_none("anything")
+
+
+# ------------------------------------------------------- the calling paths
+
+
+@pytest.mark.asyncio
+async def test_querying_an_entity_kb_leaves_the_store_unchanged(client, monkeypatch):
+    """The acceptance criterion, against the real read path.
+
+    ``_query_collection`` is the function that was calling
+    ``get_or_create_collection`` before returning query results.
+    """
+    from llc.kb.rag_assembler import LLCRAGAssembler
+
+    before = await client.list_collections()
+
+    assembler = LLCRAGAssembler.__new__(LLCRAGAssembler)
+    result = await assembler._query_collection(client, "work_item:" + str(uuid.uuid4()), "anything", 5)
+
+    assert await client.list_collections() == before, "a query created the collection"
+    assert result == {"chunks": [], "sources": []}, "a missing collection must read as empty, not raise"
+
+
+@pytest.mark.asyncio
+async def test_deleting_from_a_missing_collection_does_not_create_it(client):
+    """Deleting from a collection that does not exist is already a no-op.
+
+    Creating one so the delete has somewhere to go leaves an empty collection
+    behind forever — which is how the ``company_*`` entries appeared.
+    """
+    before = await client.list_collections()
+
+    collection = await client.get_collection_or_none("company:" + str(uuid.uuid4()))
+    if collection is not None:  # pragma: no cover
+        await collection.delete(ids=["x"])
+
+    assert await client.list_collections() == before
+
+
+# ------------------------------------------------------------ dropping them
+
+
+@pytest.mark.asyncio
+async def test_drop_collection_removes_an_existing_one(client, monkeypatch):
+    from llc.kb import collections as kb_collections
+
+    await client.create_collection("work_item:abc")
+
+    class _KB:
+        _async_chroma_client = client
+
+    async def _kb():
+        return _KB()
+
+    monkeypatch.setattr(kb_collections, "_get_kb", _kb)
+
+    dropped = await kb_collections.KbCollectionManager().drop_collection("work_item", "abc")
+
+    assert dropped is True
+    assert "work_item:abc" not in await client.list_collections()
+
+
+@pytest.mark.asyncio
+async def test_drop_collection_is_a_no_op_when_absent(client, monkeypatch):
+    """Deleting an entity must not fail because its KB is already gone."""
+    from llc.kb import collections as kb_collections
+
+    class _KB:
+        _async_chroma_client = client
+
+    async def _kb():
+        return _KB()
+
+    monkeypatch.setattr(kb_collections, "_get_kb", _kb)
+
+    assert await kb_collections.KbCollectionManager().drop_collection("work_item", "gone") is False
+
+
+@pytest.mark.asyncio
+async def test_drop_collection_never_raises_when_chromadb_is_down(monkeypatch):
+    """The asymmetry that decides this design.
+
+    A stranded collection is a tidiness problem; a delete that 500s because the
+    vector store is unreachable is a correctness one. The entity is the source
+    of truth, so the drop is best-effort by design — not by oversight.
+    """
+    from llc.kb import collections as kb_collections
+
+    async def _kb():
+        raise RuntimeError("chromadb unreachable")
+
+    monkeypatch.setattr(kb_collections, "_get_kb", _kb)
+
+    assert await kb_collections.KbCollectionManager().drop_collection("work_item", "x") is False
+
+
+# ------------------------------------------------------------- wiring guards
+
+
+def test_no_read_or_delete_path_still_creates_on_access():
+    """The two sites this issue named must not regress to get_or_create.
+
+    A future edit reinstating ``get_or_create_collection`` on a read path would
+    restore the growth silently — nothing fails, collections just accumulate
+    again, which is precisely why it went unnoticed the first time.
+    """
+    import pathlib
+
+    llc = pathlib.Path(__file__).resolve().parents[1]
+
+    # Scoped to the READ/DELETE functions, not whole files. goal.py's
+    # _index_goal is a write path where get_or_create is exactly right — a
+    # file-level assertion flagged it and would have pushed the fix in the
+    # wrong direction.
+    import ast
+
+    for rel, func in (("kb/rag_assembler.py", "_query_collection"), ("services/goal.py", "_delete_from_chromadb")):
+        tree = ast.parse((llc / rel).read_text(encoding="utf-8"))
+        node = next(
+            (n for n in ast.walk(tree) if isinstance(n, ast.AsyncFunctionDef | ast.FunctionDef) and n.name == func),
+            None,
+        )
+        assert node is not None, f"{rel} no longer defines {func} — the guard would silently cover nothing"
+        called = {
+            n.func.attr for n in ast.walk(node) if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
+        }
+        assert "get_or_create_collection" not in called, (
+            f"{rel}:{func} creates a collection on a path that only reads or deletes — see #13920"
+        )
+
+
+def test_every_entity_delete_drops_its_collection():
+    """Each of the four delete paths reaches ``drop_collection``.
+
+    Named individually so a regression says *which* entity leaks, rather than
+    that "something" does.
+    """
+    import pathlib
+
+    llc = pathlib.Path(__file__).resolve().parents[1]
+
+    for rel in (
+        "api/work_items.py",
+        "api/sprints.py",
+        "api/companies.py",
+        "services/project_disposal.py",
+    ):
+        source = (llc / rel).read_text(encoding="utf-8")
+        assert "drop_collection" in source, f"{rel} deletes an entity without dropping its KB collection (#13920)"

--- a/autobot-backend/llc/tests/test_no_empty_collections_13920.py
+++ b/autobot-backend/llc/tests/test_no_empty_collections_13920.py
@@ -274,12 +274,10 @@ def test_no_read_or_delete_path_still_creates_on_access():
             None,
         )
         assert node is not None, f"{rel} no longer defines {func} — the guard would silently cover nothing"
-        called = {
-            n.func.attr for n in ast.walk(node) if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
-        }
-        assert "get_or_create_collection" not in called, (
-            f"{rel}:{func} creates a collection on a path that only reads or deletes — see #13920"
-        )
+        called = {n.func.attr for n in ast.walk(node) if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)}
+        assert (
+            "get_or_create_collection" not in called
+        ), f"{rel}:{func} creates a collection on a path that only reads or deletes — see #13920"
 
 
 def test_every_entity_delete_drops_its_collection():

--- a/autobot-backend/llc/tests/test_project_disposal_service.py
+++ b/autobot-backend/llc/tests/test_project_disposal_service.py
@@ -12,7 +12,7 @@ no module-level sys.modules surgery, so nothing leaks into sibling analytics sui
 
 import uuid
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -27,7 +27,13 @@ def _project(code_source_id=None):
 async def test_dispose_deletes_children_then_project_and_source():
     project = _project(code_source_id="src-1")
     session = AsyncMock()
-    session.execute = AsyncMock()
+    # #13920: dispose() now SELECTs the child work-item and sprint ids before
+    # deleting them, so their KB collections can be dropped. A bare AsyncMock
+    # makes result.scalars() a coroutine; shape the result so `.scalars().all()`
+    # returns a real (empty) list.
+    _result = MagicMock()
+    _result.scalars.return_value.all.return_value = []
+    session.execute = AsyncMock(return_value=_result)
     non_shared_source = SimpleNamespace(id="src-1", shared_with=[])
     with (
         patch("api.codebase_analytics.source_storage.get_source", AsyncMock(return_value=non_shared_source)),
@@ -38,14 +44,21 @@ async def test_dispose_deletes_children_then_project_and_source():
         await dispose(project, session)
     del_src.assert_awaited_once_with("src-1")
     # Exactly three bulk-delete statements: work-items, sprints, then project.
-    assert session.execute.await_count == 3
+    # 3 deletes + the 2 id SELECTs added by #13920
+    assert session.execute.await_count == 5
 
 
 @pytest.mark.asyncio
 async def test_dispose_keeps_shared_source():
     project = _project(code_source_id="src-2")
     session = AsyncMock()
-    session.execute = AsyncMock()
+    # #13920: dispose() now SELECTs the child work-item and sprint ids before
+    # deleting them, so their KB collections can be dropped. A bare AsyncMock
+    # makes result.scalars() a coroutine; shape the result so `.scalars().all()`
+    # returns a real (empty) list.
+    _result = MagicMock()
+    _result.scalars.return_value.all.return_value = []
+    session.execute = AsyncMock(return_value=_result)
     shared = SimpleNamespace(id="src-2", shared_with=["someone-else"])
     with (
         patch("api.codebase_analytics.source_storage.get_source", AsyncMock(return_value=shared)),
@@ -59,7 +72,13 @@ async def test_dispose_keeps_shared_source():
 async def test_dispose_no_source_is_noop_on_source():
     project = _project(code_source_id=None)
     session = AsyncMock()
-    session.execute = AsyncMock()
+    # #13920: dispose() now SELECTs the child work-item and sprint ids before
+    # deleting them, so their KB collections can be dropped. A bare AsyncMock
+    # makes result.scalars() a coroutine; shape the result so `.scalars().all()`
+    # returns a real (empty) list.
+    _result = MagicMock()
+    _result.scalars.return_value.all.return_value = []
+    session.execute = AsyncMock(return_value=_result)
     with patch("api.codebase_analytics.source_service.delete_source_and_cleanup", AsyncMock()) as del_src:
         await dispose(project, session)
     del_src.assert_not_awaited()

--- a/autobot-backend/utils/async_chromadb_client.py
+++ b/autobot-backend/utils/async_chromadb_client.py
@@ -370,6 +370,40 @@ class AsyncChromaClient:
         self._collection_cache[name] = async_collection
         return async_collection
 
+    async def get_collection_or_none(
+        self,
+        name: str,
+        embedding_function: Any | None = None,
+    ) -> "AsyncChromaCollection | None":
+        """Return the collection if it exists, or ``None`` — never create it (#13920).
+
+        Read and delete paths were calling ``get_or_create_collection``, so
+        merely *querying* an entity KB that never had anything ingested left a
+        permanent empty collection behind. On one deployment that was 32 of 37
+        collections, which both buries the Explorer and hides a real signal: a
+        KB that should have content and does not becomes indistinguishable from
+        one that was queried once.
+
+        Absence is reported as ``None``; every other failure still raises.
+        Collapsing a connection error into ``None`` would make an unreachable
+        ChromaDB look exactly like an empty one, and callers here treat ``None``
+        as "no results" — the outage would surface as silently empty answers.
+        """
+        # Local import: chromadb is deliberately lazy here (#3016, ~1s to import).
+        # By the time this runs the client exists, so the module is already
+        # loaded and this costs a dict lookup.
+        from chromadb.errors import NotFoundError  # noqa: PLC0415
+
+        if name in self._collection_cache:
+            return self._collection_cache[name]
+
+        try:
+            return await self.get_collection(name, embedding_function=embedding_function)
+        except NotFoundError:
+            # Raised both when the collection never existed and when it was
+            # dropped between the lookup and this call; either way it is absent.
+            return None
+
     async def get_or_create_collection(
         self,
         name: str,


### PR DESCRIPTION
Closes #13920

## Thinking Path

37 collections, 32 empty. Not orphans of deleted sessions — `get_or_create_collection` was being called from paths that never write, so **merely querying** an entity KB that never had anything ingested materialised a permanent empty collection.

The cost isn't only that 86% of the Explorer is noise. An entity KB that *should* hold content and does not becomes indistinguishable from one that was queried once — the accumulation hides exactly the signal an operator would go looking for.

## What Changed

**`get_collection_or_none()`** on the async client — the canonical get-or-none.

**Absence returns `None`; every other failure still raises.** Callers treat `None` as "no results", so if a connection error also returned `None`, an unreachable ChromaDB would surface as silently empty answers — this same defect one layer down.

| path | was | now |
|---|---|---|
| `rag_assembler._query_collection` | created, then queried | returns empty when absent |
| `goal._delete_from_chromadb` | created, then deleted from | no-op when absent |

**Entity deletes now drop the collection** — work item, sprint, company (all three suffixes, derived from the same constants `ensure_collection` uses), and project disposal, which takes its child work-items and sprints with it. Child ids are collected **before** the bulk deletes; afterwards there is nothing left to derive the names from.

Best-effort by design, not by oversight: a stranded collection is a tidiness problem, a delete that 500s because the vector store is unreachable is a correctness one.

## Verification

```
llc/tests/test_no_empty_collections_13920.py   10 passed, 1 skipped
llc/tests                                    1431 passed, 2 skipped
```

**4 mutations applied, 4 killed:** read path back to `get_or_create`; delete path back to `get_or_create`; helper swallowing every error as absence; `drop_collection` never dropping.

### Two things the first draft got wrong

Both were caught rather than shipped, and both are worth recording:

**The fixture wasn't real.** It built a `chromadb.EphemeralClient()`, but the root conftest stubs `chromadb` outright (it hangs at import without a local server) — so it was a MagicMock whose every call succeeded and the tests asserted nothing. Replaced with a hand-written in-memory fake, plus a contract test that pins `NotFoundError` against the **real** library whenever it is genuinely importable, so the fake cannot quietly drift from what it stands in for.

The stub is detected via `__path__`, not `__file__`: the stub's `__getattr__` hands back a MagicMock for *any* missing attribute, so a `__file__` check returns something truthy and the skip never fires. The test caught that too.

**The wiring guard was scoped to files, not functions.** It asserted `get_or_create_collection` was absent from whole files and flagged `goal.py`'s `_index_goal` — a **write** path where creating is exactly right. A file-level assertion would have pushed the fix in the wrong direction. Now scoped per-function via AST. (Same lesson as #13950, reached independently.)

## Incidental

- `conftest.py` gains `chromadb.errors` with a **real** `NotFoundError` class — a MagicMock attribute is not a valid `except` target, so a stubbed error type turns a handled absence into a `TypeError` at the catch site.
- `test_project_disposal_service`'s session mocks updated for the two new id SELECTs; a bare `AsyncMock` makes `result.scalars()` a coroutine.

## Not in this PR

The issue's step 3 — a one-off cleanup of the already-stranded collections — is not in the acceptance criteria and is a data operation rather than a code change. This stops the growth and removes the two causes.

## Model Used

claude-opus-5[1m]