### PR TITLE
fix(ci): do not fail the release sync when Actions may not open PRs

### DIFF
--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -107,10 +107,30 @@ jobs:
           EOF
           sed -i 's/^          //' /tmp/sync-pr-body.md
 
-          URL=$(gh pr create \
+          # Creating the PR can be refused by a repository setting:
+          #   GraphQL: GitHub Actions is not permitted to create or approve pull requests
+          # ("Allow GitHub Actions to create and approve pull requests", Settings →
+          # Actions → General). The branch push above is the part that matters and
+          # has already succeeded, so a refusal here must not read as "the sync
+          # failed" — it means one click is left. Observed 2026-08-10.
+          if URL=$(gh pr create \
             --base main \
             --head "$SYNC_BRANCH" \
             --title "release: sync Dev_new_gui into main ($AHEAD commits)" \
-            --body-file /tmp/sync-pr-body.md)
-          echo "Opened $URL"
-          echo "url=$URL" >> "$GITHUB_OUTPUT"
+            --body-file /tmp/sync-pr-body.md 2>/tmp/pr-create.err); then
+            echo "Opened $URL"
+            echo "url=$URL" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          cat /tmp/pr-create.err
+          if grep -q "not permitted to create or approve pull requests" /tmp/pr-create.err; then
+            COMPARE="https://github.com/$GITHUB_REPOSITORY/compare/main...$SYNC_BRANCH?expand=1"
+            echo "::warning::Actions may not open PRs in this repository, so the release PR was not created."
+            echo "::warning::The branch is pushed and ready — open it here: $COMPARE"
+            echo "url=$COMPARE" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "::error::Failed to open the release PR for a reason other than the Actions PR restriction."
+          exit 1


### PR DESCRIPTION
## Thinking Path

#13968 routed the release sync through a PR to get past the protected-branch rejection. Dispatching it surfaced the next layer:

```
pull request create failed: GraphQL: GitHub Actions is not permitted to
create or approve pull requests (createPullRequest)
```

A repository setting (*Settings → Actions → General → Allow GitHub Actions to create and approve pull requests*) forbids it. That is a policy choice, not a bug, and not mine to flip.

What is wrong is the *reporting*. The branch push — the part that actually does the work — had already succeeded. The job then died on the `gh pr create` exit code, so the run read as **failure** when the sync was one click from done. That is the same silent-CI shape that let `main` drift 47 commits behind: a run whose outcome does not describe what happened.

Note the error was also buried under ~30 lines of git credential cleanup in the log, well past the point most readers stop.

## What Changed

`.github/workflows/sync-main-to-dev.yml` only — the failure handling around `gh pr create`.

- PR created → report the URL, succeed (unchanged)
- Refused **specifically** by the Actions PR restriction → emit `::warning::` with a ready-made compare link and succeed, because the branch is pushed and the remaining step is human
- Any other failure → still `::error::` and exit 1

The restriction is matched on its message rather than on a bare non-zero exit, so a real breakage cannot be swallowed as "probably the permission thing".

## Verification

The `run:` block was extracted and exercised with `gh` stubbed for each outcome:

| `gh pr create` behaviour | Result |
|---|---|
| succeeds | `Opened https://…/pull/1`, `url=` written, exit 0 |
| fails with *"not permitted to create or approve pull requests"* | two `::warning::` lines including `…/compare/main...release-sync-main?expand=1`, exit 0 |
| fails with anything else | `::error::Failed to open the release PR for a reason other than the Actions PR restriction`, exit 1 |

```
$ python -c "yaml.safe_load(open('.github/workflows/sync-main-to-dev.yml'))"
YAML valid
```

**Not verified end to end:** re-dispatching to prove it would open another real release PR, and one is already open (#13972). The stubbed run covers the branching; the live path is unchanged from #13968 apart from how failure is reported.

## Alternative not taken

Enabling the repository setting would let the workflow open the PR itself and make this unnecessary. That is a permissions decision for the owner — Actions gaining PR-creation rights is a real expansion of what automation may do — so the workflow degrades honestly instead of asking for more privilege.

Refs #2445

## Model Used

Opus 5
