### PR TITLE
fix(ci): make the release divergence guard content-aware

### DIFF
--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -57,9 +57,29 @@ jobs:
           git fetch origin main
           AHEAD=$(git rev-list --count origin/main..origin/Dev_new_gui)
           BEHIND=$(git rev-list --count origin/Dev_new_gui..origin/main)
+
+          # #13974: BEHIND counts the merge commit this very workflow's release PR
+          # creates on main, so a successful promotion armed the guard against the
+          # next one. That is why main sat 41 commits behind for five days: the
+          # error blamed "divergence" for a commit the release process itself made.
+          #
+          # DIVERGENT counts only NON-merge commits on main that the trunk lacks —
+          # actual work committed to main directly, which is what the guard exists
+          # to protect. A merge commit carries no content of its own, so it is not
+          # divergence in any sense that matters to a fast-forward.
+          #
+          # Limitation, stated rather than hidden: an "evil merge" (a merge commit
+          # edited to carry content from neither parent) would not be counted. That
+          # cannot arise from the PR-merge path this workflow uses, and catching it
+          # needs `git merge-tree --write-tree` (git >= 2.38) comparing the merge
+          # result against the trunk tree — worth doing if direct pushes to main are
+          # ever allowed.
+          DIVERGENT=$(git rev-list --count --no-merges origin/Dev_new_gui..origin/main)
+
           echo "ahead=$AHEAD" >> "$GITHUB_OUTPUT"
           echo "behind=$BEHIND" >> "$GITHUB_OUTPUT"
-          echo "Dev_new_gui is $AHEAD ahead, $BEHIND behind main"
+          echo "divergent=$DIVERGENT" >> "$GITHUB_OUTPUT"
+          echo "Dev_new_gui is $AHEAD ahead, $BEHIND behind main ($DIVERGENT non-merge commit(s) only on main)"
 
       - name: Open the release sync PR
         id: sync
@@ -68,10 +88,14 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AHEAD: ${{ steps.check.outputs.ahead }}
           BEHIND: ${{ steps.check.outputs.behind }}
+          DIVERGENT: ${{ steps.check.outputs.divergent }}
         run: |
-          if [ "$BEHIND" != "0" ]; then
-            echo "::error::main has $BEHIND commit(s) not in Dev_new_gui. Resolve divergence manually first."
+          if [ "$DIVERGENT" != "0" ]; then
+            echo "::error::main has $DIVERGENT non-merge commit(s) not in Dev_new_gui — work committed straight to main. Resolve manually first."
             exit 1
+          fi
+          if [ "$BEHIND" != "0" ]; then
+            echo "::notice::main carries $BEHIND merge commit(s) the trunk lacks (from previous promotions). No content of their own, so not a blocker — see #13974."
           fi
 
           # This step used to `git push origin origin/Dev_new_gui:main`, which

--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -76,9 +76,11 @@ jobs:
           # ever allowed.
           DIVERGENT=$(git rev-list --count --no-merges origin/Dev_new_gui..origin/main)
 
-          echo "ahead=$AHEAD" >> "$GITHUB_OUTPUT"
-          echo "behind=$BEHIND" >> "$GITHUB_OUTPUT"
-          echo "divergent=$DIVERGENT" >> "$GITHUB_OUTPUT"
+          {
+            echo "ahead=$AHEAD"
+            echo "behind=$BEHIND"
+            echo "divergent=$DIVERGENT"
+          } >> "$GITHUB_OUTPUT"
           echo "Dev_new_gui is $AHEAD ahead, $BEHIND behind main ($DIVERGENT non-merge commit(s) only on main)"
 
       - name: Open the release sync PR


### PR DESCRIPTION
## Thinking Path

Promoting `Dev_new_gui` to `main` leaves a merge commit on `main` that the trunk does not have. The workflow's guard counts *any* such commit as divergence and refuses:

```
::error::main has 1 commit(s) not in Dev_new_gui. Resolve divergence manually first.
```

So a successful release arms the guard against the next one. That is not hypothetical — it is why `main` sat 41 commits behind for five days, and the same commit shape (`b56497fa9`) is what #13389 was originally filed about, produced by the promotion before that. Three cycles, each needing a manual back-merge, and each time the error blames "divergence" for a commit the release process itself created.

The guard is worth keeping. What it exists to catch is *work committed straight to `main`* that a fast-forward would silently discard. A merge commit carries no content of its own, so it is not that.

## What Changed

`.github/workflows/sync-main-to-dev.yml` only.

- New `DIVERGENT` count: `git rev-list --count --no-merges origin/Dev_new_gui..origin/main` — non-merge commits on `main` the trunk lacks
- The refusal now keys on `DIVERGENT`, not `BEHIND`
- `BEHIND > 0` with `DIVERGENT == 0` emits a `::notice::` explaining it came from a previous promotion, rather than failing
- The error message says *what* the divergence is ("work committed straight to main"), so the reader knows what to look for

`--no-merges` rather than `git merge-tree --write-tree`: the latter is the airtight test but needs git ≥ 2.38, and I could not verify it here (local git is 2.34.1, where `--write-tree` silently returns nothing — which would have read as "no difference" and passed for the wrong reason). The limitation is written into the workflow rather than left implicit.

## Verification

**The detection, against real refs:**

| State | `BEHIND` | `DIVERGENT` |
|---|---|---|
| today — one merge commit from #13972 | 1 | **0** |
| simulated commit made directly on `main` | 2 | **1** |

The second was produced by actually committing to a throwaway branch off `main`, not by reasoning about it.

**The guard, with the run block extracted and `git`/`gh` stubbed:**

| Case | Result |
|---|---|
| `BEHIND=1 DIVERGENT=0` (post-release) | `::notice::` about previous promotions, then opens the PR |
| `BEHIND=2 DIVERGENT=1` (work on main) | `::error::…non-merge commit(s)…` and exits 1 |
| `BEHIND=0 DIVERGENT=0` (clean) | opens the PR, no notice |

```
$ python -c "yaml.safe_load(open('.github/workflows/sync-main-to-dev.yml'))"
YAML valid
```

**Not verified end to end:** proving it takes running a real promotion, and the next one is not due. The acceptance criterion "two consecutive promotions succeed with no manual resolution" can only be closed by the next release.

Closes #13974

## Model Used

Opus 5
