### PR TITLE
feat(code-intelligence): expose impact analysis over REST

### DIFF
--- a/autobot-backend/api/codebase_analytics/endpoints/impact.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/impact.py
@@ -1,0 +1,105 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Impact analysis endpoint — "what breaks if I change this" (#13506).
+
+Exposes the reverse-BFS engine that landed with #13471 and has had no caller
+since. The engine answers the question the ``dead-code-audit``,
+``api-wiring-audit`` and ``gap-audit`` workflows currently reason about by hand.
+
+The response deliberately carries the whole coverage picture rather than a
+flattened node list: ``depth_capped`` with its un-expanded frontier, the skipped
+edges with their reasons, and the resolved/unresolved edge counts. The engine was
+built so a partial answer cannot render as a complete one (#13468), and an
+endpoint that dropped those fields would put the defect straight back.
+
+No confidence score is synthesised from the counts — #13482 Q2 bound that
+explicitly. Two numbers a caller can interpret beat one number that hides how it
+was derived.
+
+This is the REST/GUI path. #13475 covers the MCP tool surface over the same
+engine; neither substitutes for the other, and neither should reshape
+``ImpactResult`` for its own convenience.
+"""
+
+import asyncio
+
+from fastapi import APIRouter, Query
+from fastapi.responses import JSONResponse
+
+from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from autobot_shared.logging_manager import get_logger
+from services.knowledge.impact_analysis import find_impact
+
+from ..storage import get_code_collection
+
+logger = get_logger(__name__)
+
+router = APIRouter()
+
+
+@router.get("/impact")
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="analyze_impact",
+    error_code_prefix="CODEBASE_ANALYTICS",
+)
+async def analyze_impact(
+    node_id: str = Query(..., min_length=1, description="Graph node id to walk back from"),
+    max_depth: int | None = Query(
+        None,
+        ge=1,
+        le=20,
+        description="Override the configured hop limit. Omit to use impact_analysis_max_depth.",
+    ),
+):
+    """Return what transitively calls *node_id*.
+
+    A 200 with ``indexed: false`` rather than a 404 when the graph is missing:
+    "the code graph has not been built" is a different answer from "that node
+    does not exist", and collapsing them would send an operator hunting for a
+    typo in their node id.
+    """
+    collection = await asyncio.to_thread(get_code_collection)
+    if collection is None:
+        return JSONResponse(
+            status_code=200,
+            content={
+                "indexed": False,
+                "node_id": node_id,
+                "message": "The code graph collection is not available — run an index first.",
+            },
+        )
+
+    result = await find_impact(collection, node_id, max_depth=max_depth)
+
+    logger.info(
+        "Impact walk for %s: %d reached, depth %d/%d%s",
+        node_id,
+        len(result.reached),
+        result.depth_reached,
+        result.max_depth,
+        " (capped)" if result.depth_capped else "",
+    )
+
+    return JSONResponse(
+        status_code=200,
+        content={
+            "indexed": True,
+            "root_id": result.root_id,
+            "seed_ids": result.seed_ids,
+            "reached": result.reached,
+            "edges": result.edges,
+            # Coverage, in full. A caller that sees `depth_capped` knows the
+            # answer is a lower bound; `depth_capped_frontier` says where it
+            # stopped so the walk can be resumed or widened deliberately.
+            "depth_capped": result.depth_capped,
+            "depth_capped_frontier": result.depth_capped_frontier,
+            "skipped_edges": result.skipped_edges,
+            "resolved_edge_count": result.resolved_edge_count,
+            "unresolved_edge_count": result.unresolved_edge_count,
+            "max_depth": result.max_depth,
+            "depth_reached": result.depth_reached,
+        },
+    )

--- a/autobot-backend/api/codebase_analytics/endpoints/impact_endpoint_test.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/impact_endpoint_test.py
@@ -13,7 +13,6 @@ the HTTP boundary rather than asserting the walk itself (which
 import asyncio
 import json
 from dataclasses import dataclass, field
-from typing import Any
 from unittest.mock import patch
 
 import pytest

--- a/autobot-backend/api/codebase_analytics/endpoints/impact_endpoint_test.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/impact_endpoint_test.py
@@ -1,0 +1,168 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""The impact endpoint must not flatten away its own coverage (#13506).
+
+`services/knowledge/impact_analysis.py` was built so a truncated walk cannot be
+mistaken for a complete one — that is what #13468 was filed to remove and #13471
+delivered. An endpoint that returned a bare node list would put the defect back
+while looking like a feature, so these tests assert the coverage fields survive
+the HTTP boundary rather than asserting the walk itself (which
+`impact_analysis_test.py` already covers).
+"""
+
+import asyncio
+import json
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+
+def _call(node_id="pkg.mod.Thing", max_depth=None, collection=object(), result=None):
+    """Invoke the endpoint function directly, with its two dependencies stubbed."""
+    from api.codebase_analytics.endpoints import impact
+
+    async def _fake_find_impact(_collection, root_id, max_depth=None):  # noqa: ARG001
+        return result
+
+    with (
+        patch.object(impact, "get_code_collection", return_value=collection),
+        patch.object(impact, "find_impact", _fake_find_impact),
+    ):
+        response = asyncio.run(impact.analyze_impact(node_id=node_id, max_depth=max_depth))
+    return response.status_code, json.loads(response.body)
+
+
+@dataclass
+class _Result:
+    """Stands in for ImpactResult with the same field and property names."""
+
+    root_id: str = "pkg.mod.Thing"
+    seed_ids: list = field(default_factory=list)
+    reached: list = field(default_factory=list)
+    edges: list = field(default_factory=list)
+    skipped_edges: list = field(default_factory=list)
+    max_depth: int = 5
+    depth_reached: int = 0
+    depth_capped: bool = False
+    depth_capped_frontier: list = field(default_factory=list)
+
+    @property
+    def resolved_edge_count(self) -> int:
+        return len(self.edges)
+
+    @property
+    def unresolved_edge_count(self) -> int:
+        return len(self.skipped_edges)
+
+
+def test_a_capped_walk_says_so_and_names_where_it_stopped():
+    """The defect this endpoint must not reintroduce.
+
+    A depth-capped walk is a lower bound. If the response omitted
+    `depth_capped`/`depth_capped_frontier`, a caller would read a partial answer
+    as the complete set of callers — which is worse than no answer, because it
+    reads as evidence that nothing else is affected.
+    """
+    res = _Result(
+        reached=["a", "b"],
+        edges=[{"from": "a", "to": "b"}],
+        depth_capped=True,
+        depth_capped_frontier=["b"],
+        depth_reached=5,
+    )
+
+    status, body = _call(result=res)
+
+    assert status == 200
+    assert body["depth_capped"] is True
+    assert body["depth_capped_frontier"] == ["b"]
+    assert body["depth_reached"] == 5
+    assert body["max_depth"] == 5
+
+
+def test_skipped_edges_and_both_counts_survive_the_http_boundary():
+    """#13482 Q2: two interpretable numbers, not one synthesised score."""
+    res = _Result(
+        reached=["a"],
+        edges=[{"from": "a", "to": "root"}],
+        skipped_edges=[{"raw": "helper", "reason": "ambiguous"}],
+    )
+
+    status, body = _call(result=res)
+
+    assert status == 200
+    assert body["skipped_edges"] == [{"raw": "helper", "reason": "ambiguous"}]
+    assert body["resolved_edge_count"] == 1
+    assert body["unresolved_edge_count"] == 1
+
+
+def test_no_confidence_score_is_synthesised():
+    """Bound by #13482 Q2. A single number would hide how it was derived."""
+    res = _Result(reached=["a"], edges=[{"from": "a", "to": "root"}], skipped_edges=[{"raw": "x"}])
+
+    _, body = _call(result=res)
+
+    for forbidden in ("confidence", "score", "certainty", "completeness"):
+        assert not any(forbidden in key.lower() for key in body), f"{forbidden!r} leaked into the response"
+
+
+def test_a_missing_graph_is_not_a_missing_node():
+    """`indexed: false` rather than 404.
+
+    "The graph was never built" and "that node does not exist" have different
+    fixes; a 404 for the first sends the operator hunting for a typo.
+    """
+    status, body = _call(collection=None)
+
+    assert status == 200
+    assert body["indexed"] is False
+    assert body["node_id"] == "pkg.mod.Thing"
+    assert "reached" not in body
+
+
+def test_a_complete_walk_is_reported_as_complete():
+    """The guard must not mark every answer partial."""
+    res = _Result(reached=["a", "b"], edges=[{"from": "a", "to": "b"}], depth_reached=2)
+
+    _, body = _call(result=res)
+
+    assert body["indexed"] is True
+    assert body["depth_capped"] is False
+    assert body["depth_capped_frontier"] == []
+
+
+@pytest.mark.parametrize("depth", [1, 20])
+def test_max_depth_override_reaches_the_engine(depth):
+    """The knob is useless if the endpoint swallows it."""
+    from api.codebase_analytics.endpoints import impact
+
+    seen = {}
+
+    async def _capture(_collection, root_id, max_depth=None):  # noqa: ARG001
+        seen["max_depth"] = max_depth
+        return _Result()
+
+    with (
+        patch.object(impact, "get_code_collection", return_value=object()),
+        patch.object(impact, "find_impact", _capture),
+    ):
+        asyncio.run(impact.analyze_impact(node_id="x", max_depth=depth))
+
+    assert seen["max_depth"] == depth
+
+
+def test_the_endpoint_is_registered_on_the_router():
+    """#13506 is a wiring defect — an endpoint nothing includes repeats it."""
+    from api.codebase_analytics.router import router
+
+    # This app wraps includes in `_IncludedRouter`, so the mounted paths live on
+    # `.original_router.routes`, not on the top-level route objects.
+    paths = {
+        p
+        for included in router.routes
+        for sub in getattr(included, "original_router", None).routes
+        if (p := getattr(sub, "path", None))
+    }
+    assert "/impact" in paths, f"/impact not mounted; got {sorted(paths)[:8]}…"

--- a/autobot-backend/api/codebase_analytics/router.py
+++ b/autobot-backend/api/codebase_analytics/router.py
@@ -14,6 +14,7 @@ from auth_middleware import check_admin_permission
 # Issue #208: Code Pattern Detection & Optimization
 from .endpoints import api_endpoints  # Issue #527: API Endpoint Checker
 from .endpoints import environment  # Issue #538: Environment analysis
+from .endpoints import impact  # Issue #13506: impact analysis (REST/GUI path)
 from .endpoints import ownership  # Issue #248: Code Ownership and Expertise Map
 from .endpoints import (
     cache,
@@ -27,7 +28,6 @@ from .endpoints import (
     indexing,
     pattern_analysis,
 )
-from .endpoints import impact  # Issue #13506: impact analysis (REST/GUI path)
 from .endpoints import queue as queue_router
 from .endpoints import (
     report,

--- a/autobot-backend/api/codebase_analytics/router.py
+++ b/autobot-backend/api/codebase_analytics/router.py
@@ -27,6 +27,7 @@ from .endpoints import (
     indexing,
     pattern_analysis,
 )
+from .endpoints import impact  # Issue #13506: impact analysis (REST/GUI path)
 from .endpoints import queue as queue_router
 from .endpoints import (
     report,
@@ -61,3 +62,4 @@ router.include_router(pattern_analysis.router)  # Issue #208: Code Pattern Detec
 router.include_router(ownership.router)  # Issue #248: Code Ownership and Expertise Map
 router.include_router(sources.router)  # Issue #1133: Code Source Registry
 router.include_router(queue_router.router)  # Issue #1133: Index job queue
+router.include_router(impact.router)  # Issue #13506: what transitively calls a node

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -21920,6 +21920,31 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/analytics/codebase/impact": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Analyze Impact
+         * @description Return what transitively calls *node_id*.
+         *
+         *     A 200 with ``indexed: false`` rather than a 404 when the graph is missing:
+         *     "the code graph has not been built" is a different answer from "that node
+         *     does not exist", and collapsing them would send an operator hunting for a
+         *     typo in their node id.
+         */
+        get: operations["analyze_impact_api_analytics_codebase_impact_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/reporting/report": {
         parameters: {
             query?: never;
@@ -130473,6 +130498,40 @@ export interface operations {
             path: {
                 source_id: string;
             };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    analyze_impact_api_analytics_codebase_impact_get: {
+        parameters: {
+            query: {
+                /** @description Graph node id to walk back from */
+                node_id: string;
+                /** @description Override the configured hop limit. Omit to use impact_analysis_max_depth. */
+                max_depth?: number | null;
+            };
+            header?: never;
+            path?: never;
             cookie?: never;
         };
         requestBody?: never;


### PR DESCRIPTION
## Thinking Path

`services/knowledge/impact_analysis.py` landed with #13471 — reverse-BFS, cycle handling, coverage reporting, a config knob — and has had **no caller** since. Confirmed before touching anything:

```
$ grep -rn "impact_analysis\|find_impact\|analyze_impact" --include=*.py --include=*.ts --include=*.vue .
services/knowledge/impact_analysis.py:55:   raw = blank_to_none(config.misc.impact_analysis_max_depth)
services/knowledge/impact_analysis.py:173:  async def find_impact(...)
autobot_shared/ssot_config.py:1571:          impact_analysis_max_depth: str = Field(
```

The module referencing its own config field, and the field's declaration. Nothing else.

The interesting constraint is what the response must *not* do. The engine was built so a truncated walk cannot pass for a complete one — that is what #13468 was filed to remove. An endpoint returning a flat node list would put the defect straight back while looking like a feature, so the response carries the whole coverage picture: `depth_capped` with its un-expanded frontier, `skipped_edges` with reasons, and both edge counts. No confidence score is synthesised from them (#13482 Q2).

One judgement call: a missing graph returns `200 {"indexed": false}`, not `404`. "The code graph was never built" and "that node does not exist" have different fixes, and collapsing them sends an operator hunting for a typo in their node id.

## What Changed

- `api/codebase_analytics/endpoints/impact.py` — `GET /impact?node_id=…&max_depth=…`
- Registered on the package router, so it inherits the existing `check_admin_permission` + `require_source_access` gate rather than inventing its own
- `impact_endpoint_test.py` — 8 tests

No change to `ImpactResult` or the engine. #13475 (the MCP tool surface) wraps the same engine; this does not reshape it for REST's convenience.

## Verification

**Mounted for real**, not merely defined:

```
$ python -c "from api.codebase_analytics.router import router; …"
/impact mounted: True
```

**Every test earns its place** — each mutation fails only the tests that exist to catch it:

| Mutation | Fails |
|---|---|
| flatten the response, dropping the coverage fields | `test_a_capped_walk_says_so_and_names_where_it_stopped`, `test_skipped_edges_and_both_counts_survive_the_http_boundary`, `test_a_complete_walk_is_reported_as_complete` |
| `404` instead of `indexed: false` for a missing graph | `test_a_missing_graph_is_not_a_missing_node` |
| swallow the `max_depth` override | `test_max_depth_override_reaches_the_engine[1]`, `[20]` |
| remove the router include | `test_the_endpoint_is_registered_on_the_router` |

That last one matters: #13506 *is* a wiring defect, so a test that only exercised the function would repeat it.

```
$ pytest autobot-backend/api/codebase_analytics/ -q
268 passed, 7 skipped

$ black --check + flake8   → clean
```

**Not verified:** no live ChromaDB collection was queried. The engine's own walk is covered by `impact_analysis_test.py`; these tests stub `find_impact` and assert the HTTP contract, so a divergence between the real collection and the stubbed shape would not be caught here.

## Scope note — this does not close #13506

The issue asks for "an HTTP endpoint … plus its GUI consumer". The endpoint is done; **the GUI consumer is not**. Closure Gate 3 says partial delivery does not close, so the issue stays open with the remaining half stated explicitly rather than quietly dropped.

Refs #13506

## Model Used

Opus 5
