### PR TITLE
fix(ci): exclude generated clients from the pre-commit guards

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -467,6 +467,19 @@ repos:
         entry: autobot-infrastructure/shared/scripts/hooks/pre-commit-hardcoded-values
         language: script
         types: [python, ts, vue]
+        # Generated clients are machine-produced from the OpenAPI schema; a
+        # "hardcoded value" in one is a symptom of the schema, not of code
+        # anyone wrote, so scanning them finds nothing actionable.
+        #
+        # It is also ruinously slow. Measured 2026-08-11 on this hook:
+        #   3 changed .py files ........  3.7s
+        #   generated/api.ts alone .....  >240s (173,665 lines, timed out)
+        # Every PR that touches an API response model regenerates that file,
+        # which drags it into the changed set and turns `code-quality` — a
+        # REQUIRED check — into a 40-70 minute job. Observed on #13976.
+        #
+        # Same pattern the line-length hook above already uses.
+        exclude: ^(.*(_generated|generated)/)
         pass_filenames: false
         stages: [pre-commit]
         description: "Blocks commits with hardcoded IPs, ports, magic numbers, role strings, AutoBot file paths, and model name literals (#3397)"

--- a/pipeline-scripts/check-pre-commit-hook-pr.sh
+++ b/pipeline-scripts/check-pre-commit-hook-pr.sh
@@ -165,7 +165,25 @@ fi
 # The trailing `|| true` normalises the while-loop's EOF exit status (1) under
 # `set -e`. It is scoped to the FILTER only — git's exit status is checked
 # above, so this no longer hides a failed diff the way the original did.
+# Generated clients are excluded from every guard this wrapper runs. They are
+# machine-produced from the OpenAPI schema, so a "hardcoded value", a stray
+# console call or a direct redis reference in one is a property of the
+# generator, not of anything a human wrote — nothing here is actionable.
+#
+# It is also a hard performance cliff. Measured 2026-08-11 against
+# pre-commit-hardcoded-values:
+#     3 changed .py files ......  3.7s
+#     generated/api.ts alone ...  >240s (173,665 lines, timed out)
+# Every PR that touches an API response model regenerates that file, which puts
+# it in this diff and turns `code-quality` — a REQUIRED check — into a 40-70
+# minute job. Observed on #13976, where it ran 73 minutes without finishing.
+#
+# NOTE: the `exclude:` key in .pre-commit-config.yaml does NOT cover this path —
+# the invocation below runs the hook script directly rather than through
+# pre-commit, so the filter has to live here. Both are set, for CI and for the
+# local `pre-commit run` respectively.
 files=$(printf '%s\n' "$raw_files" \
+    | grep -Ev '(^|/)(_generated|generated)/' \
     | while read -r f; do [ -n "$f" ] && [ -f "$f" ] && printf '%s\n' "$f"; done \
     || true)
 


### PR DESCRIPTION
## Thinking Path

`code-quality` — a **required** check — ran 73 minutes on #13976 without finishing, stuck on "Block hardcoded value regressions". It normally takes 0.2 minutes.

I got this wrong twice before getting it right, and both mistakes are the same shape.

**First**, I formed the right hypothesis (the bot regenerates a 173,665-line `api.ts` on any schema change, and the hook declares `types: [python, ts, vue]` with no generated-file exclusion) and then "disproved" it:

```
$ time bash pipeline-scripts/check-pre-commit-hook-pr.sh pre-commit-hardcoded-values
real 0m0.019s
```

That run was meaningless. Without `BASE_SHA`/`HEAD_SHA` the wrapper falls back to `HEAD^`, so it diffed one commit rather than the PR. I had measured the wrong thing and concluded the hypothesis was dead. With the real range it reproduced immediately — past 600 seconds.

Isolated:

| Scope | Time |
|---|---|
| the 3 changed `.py` files | **3.7s** |
| `generated/api.ts` alone | **>240s** (timed out) |

**Second**, my first fix was a no-op that looked correct. I added `exclude:` to the hook in `.pre-commit-config.yaml` — and the CI path never reads it. The wrapper ends in `bash "$HOOK_PATH" $files`, invoking the script directly rather than through pre-commit. Caught it by reading the invocation before trusting the fix.

## What Changed

Two places, because there are two invocation paths:

- **`pipeline-scripts/check-pre-commit-hook-pr.sh`** — filters `(^|/)(_generated|generated)/` out of the changed-file list. This is the one that fixes CI, and it covers every guard the wrapper runs, not just this hook: a stray console call or redis reference in a generated client is equally unactionable.
- **`.pre-commit-config.yaml`** — the same exclusion on the hook, for local `pre-commit run`. Same pattern the line-length hook already uses.

The comment in the wrapper states explicitly that the YAML key does not cover the CI path, so the next reader does not "consolidate" them and silently restore the problem.

## Verification

**The reproduction, before and after**, same range, same machine:

```
before: >600s (timed out)
after :  10.5s
```

**Coverage is not reduced** — 3 of the 4 changed files still reach the hook, only the generated one is dropped:

```
Running pre-commit-hardcoded-values against 3 changed file(s)...
No violations found!
```

**The filter is narrow.** It matches a `generated/` or `_generated/` path segment, not the substring:

```
kept: a/b/c.py
kept: src/regenerated_notes.py      ← not dropped
kept: lib/generator/tool.py         ← not dropped
```

```
$ bash -n pipeline-scripts/check-pre-commit-hook-pr.sh   → syntax OK
$ python -c "yaml.safe_load(open('.pre-commit-config.yaml'))" → valid
```

**Not verified:** I could not demonstrate the hook still *detects* a violation. Staging a file containing a `172.16.168.x` literal produced `No violations found!`, so that pattern is evidently not one it flags, and I did not go hunting for one it does. What is verified is the file *list*: non-generated files still reach the hook unchanged, and the change touches nothing else. Detection behaviour is untouched by construction, not by test.

Unblocks #13976.

## Model Used

Opus 5
