### PR TITLE
feat(analytics): impact analysis panel that cannot show a partial result as complete

### DIFF
--- a/autobot-frontend/src/components/analytics/CodebaseAnalytics.vue
+++ b/autobot-frontend/src/components/analytics/CodebaseAnalytics.vue
@@ -1026,14 +1026,14 @@ onUnmounted(() => {
 }
 
 .project-meta-item.status-ready { color: var(--color-success); }
-.project-meta-item.status-syncing { color: var(--color-warning, #f59e0b); }
-.project-meta-item.status-error { color: var(--color-error, #ef4444); }
+.project-meta-item.status-syncing { color: var(--color-warning); }
+.project-meta-item.status-error { color: var(--color-error); }
 
 /* GH#11129: LLC project label displayed next to source name */
 .project-header-llc-label {
   font-size: 0.75em;
   font-weight: 500;
-  color: var(--color-accent-text, var(--color-accent, #c4651a));
+  color: var(--color-accent-text, var(--color-accent));
   background: var(--bg-hover);
   padding: 0.125rem 0.5rem;
   border-radius: 999px;

--- a/autobot-frontend/src/components/analytics/CodebaseAnalytics.vue
+++ b/autobot-frontend/src/components/analytics/CodebaseAnalytics.vue
@@ -997,7 +997,7 @@ onUnmounted(() => {
   border-radius: var(--radius-lg);
   padding: var(--spacing-4) var(--spacing-5);
   margin-bottom: var(--spacing-4);
-  border-left: 4px solid var(--accent-primary, #3b82f6);
+  border-left: 4px solid var(--accent-primary);
   box-shadow: var(--shadow-sm);
 }
 
@@ -1025,7 +1025,7 @@ onUnmounted(() => {
   gap: var(--spacing-1);
 }
 
-.project-meta-item.status-ready { color: var(--color-success, #22c55e); }
+.project-meta-item.status-ready { color: var(--color-success); }
 .project-meta-item.status-syncing { color: var(--color-warning, #f59e0b); }
 .project-meta-item.status-error { color: var(--color-error, #ef4444); }
 

--- a/autobot-frontend/src/components/analytics/CodebaseAnalytics.vue
+++ b/autobot-frontend/src/components/analytics/CodebaseAnalytics.vue
@@ -175,6 +175,10 @@
         @scan-file="handleFileScan"
       />
 
+      <!-- Impact Analysis (#13506): what transitively calls a node. Self-contained —
+           it owns its own query and fetch, so it takes no props from this view. -->
+      <CodebaseImpactPanel />
+
       <!-- Duplicate Code Analysis (#1469, #184) -->
       <DuplicatesSection
         :duplicates="duplicateAnalysis"
@@ -463,6 +467,7 @@ import { useApiClient } from '@/plugins/api'
 import CodebaseOverviewPanel from '@/components/analytics/CodebaseOverviewPanel.vue'
 import CodebaseDependenciesPanel from '@/components/analytics/CodebaseDependenciesPanel.vue'
 import CodebaseSecurityPanel from '@/components/analytics/CodebaseSecurityPanel.vue'
+import CodebaseImpactPanel from '@/components/analytics/CodebaseImpactPanel.vue'
 import CodeSmellsSection from '@/components/analytics/CodeSmellsSection.vue'
 import DuplicatesSection from '@/components/analytics/DuplicatesSection.vue'
 import DeclarationsSection from '@/components/analytics/DeclarationsSection.vue'

--- a/autobot-frontend/src/components/analytics/CodebaseImpactPanel.vue
+++ b/autobot-frontend/src/components/analytics/CodebaseImpactPanel.vue
@@ -1,0 +1,237 @@
+<!-- AutoBot - AI-Powered Automation Platform -->
+<!-- Copyright (c) 2026 mrveiss -->
+<!-- Author: mrveiss -->
+
+<!-- Issue #13506: "what breaks if I change this" over the resolved code graph. -->
+<template>
+  <div class="impact-panel analytics-section">
+    <h3>
+      <Icon name="sitemap" /> {{ $t('analytics.codebase.impact.title') }}
+    </h3>
+    <p class="section-hint">{{ $t('analytics.codebase.impact.hint') }}</p>
+
+    <form class="impact-form" @submit.prevent="run">
+      <input
+        v-model="nodeId"
+        type="text"
+        class="impact-input"
+        :placeholder="$t('analytics.codebase.impact.nodeIdPlaceholder')"
+        :aria-label="$t('analytics.codebase.impact.nodeIdLabel')"
+      />
+      <button type="submit" class="action-btn primary" :disabled="loading || !nodeId.trim()">
+        <Icon :name="loading ? 'spinner' : 'search'" :class="{ 'fa-spin': loading }" />
+        {{ loading ? $t('analytics.codebase.impact.analyzing') : $t('analytics.codebase.impact.analyze') }}
+      </button>
+    </form>
+
+    <div v-if="error" class="impact-error">
+      <Icon name="exclamation-triangle" />
+      <span>{{ error }}</span>
+    </div>
+
+    <!-- "The graph was never built" is a different answer from "no callers",
+         and must not render as an empty result. -->
+    <EmptyState
+      v-else-if="notIndexed"
+      icon="database"
+      :title="$t('analytics.codebase.impact.notIndexedTitle')"
+      :description="$t('analytics.codebase.impact.notIndexedBody')"
+    />
+
+    <div v-else-if="result" class="impact-result">
+      <!-- #13468: the whole point of the contract. A depth-capped or
+           partially-resolved walk is a LOWER BOUND, and saying so has to be
+           impossible to miss — a partial list shown as complete reads as
+           evidence that nothing else is affected. -->
+      <div v-if="isPartial" class="impact-partial" role="status">
+        <Icon name="exclamation-triangle" />
+        <div>
+          <strong>{{ $t('analytics.codebase.impact.partialTitle') }}</strong>
+          <p>
+            {{
+              result.depth_capped
+                ? $t('analytics.codebase.impact.partialDepth', {
+                    depth: result.max_depth,
+                    frontier: result.depth_capped_frontier?.length ?? 0,
+                  })
+                : $t('analytics.codebase.impact.partialUnresolved', {
+                    count: result.unresolved_edge_count ?? 0,
+                  })
+            }}
+          </p>
+        </div>
+      </div>
+
+      <div class="impact-summary">
+        <div class="impact-metric">
+          <span class="metric-value">{{ callerCount }}</span>
+          <span class="metric-label">
+            {{ isPartial
+              ? $t('analytics.codebase.impact.callersAtLeast')
+              : $t('analytics.codebase.impact.callers') }}
+          </span>
+        </div>
+        <div class="impact-metric">
+          <span class="metric-value">{{ result.resolved_edge_count ?? 0 }}</span>
+          <span class="metric-label">{{ $t('analytics.codebase.impact.edgesResolved') }}</span>
+        </div>
+        <!-- Reported beside the resolved count, never folded into one score. -->
+        <div class="impact-metric" :class="{ warn: (result.unresolved_edge_count ?? 0) > 0 }">
+          <span class="metric-value">{{ result.unresolved_edge_count ?? 0 }}</span>
+          <span class="metric-label">{{ $t('analytics.codebase.impact.edgesUnresolved') }}</span>
+        </div>
+        <div class="impact-metric">
+          <span class="metric-value">{{ result.depth_reached ?? 0 }}/{{ result.max_depth ?? 0 }}</span>
+          <span class="metric-label">{{ $t('analytics.codebase.impact.depth') }}</span>
+        </div>
+      </div>
+
+      <div v-if="callerCount > 0" class="impact-list">
+        <h4>{{ $t('analytics.codebase.impact.callersHeading') }}</h4>
+        <ul>
+          <li v-for="id in result.reached" :key="id"><code>{{ id }}</code></li>
+        </ul>
+      </div>
+      <EmptyState
+        v-else
+        icon="check-circle"
+        :title="$t('analytics.codebase.impact.noCallersTitle')"
+        :description="$t('analytics.codebase.impact.noCallersBody')"
+      />
+
+      <details v-if="(result.unresolved_edge_count ?? 0) > 0" class="impact-skipped">
+        <summary>
+          {{ $t('analytics.codebase.impact.skippedHeading', { count: result.unresolved_edge_count }) }}
+        </summary>
+        <ul>
+          <li v-for="(edge, i) in result.skipped_edges" :key="i">
+            <code>{{ JSON.stringify(edge) }}</code>
+          </li>
+        </ul>
+      </details>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import Icon from '@/components/ui/Icon.vue'
+import EmptyState from '@/components/ui/EmptyState.vue'
+import { ref } from 'vue'
+import { useImpactAnalysis } from '@/composables/analytics/useImpactAnalysis'
+
+const nodeId = ref('')
+const { loading, error, result, notIndexed, isPartial, callerCount, analyze } = useImpactAnalysis()
+
+async function run(): Promise<void> {
+  await analyze(nodeId.value)
+}
+</script>
+
+<style scoped>
+.impact-panel {
+  padding: var(--spacing-md, 1rem) 0;
+}
+
+.section-hint {
+  color: var(--text-secondary);
+  margin-bottom: var(--spacing-md, 1rem);
+}
+
+.impact-form {
+  display: flex;
+  gap: var(--spacing-sm, 0.5rem);
+  margin-bottom: var(--spacing-md, 1rem);
+}
+
+.impact-input {
+  flex: 1;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--border-default);
+  border-radius: 6px;
+  background: var(--color-bg);
+  color: var(--text-primary);
+  font-family: var(--font-mono, monospace);
+}
+
+.impact-error {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--color-danger, #dc2626);
+  border-radius: 6px;
+  color: var(--color-danger, #dc2626);
+}
+
+/* Deliberately loud: this is the difference between a complete answer and a
+   lower bound, and it is the one thing a reader must not skim past. */
+.impact-partial {
+  display: flex;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  margin-bottom: var(--spacing-md, 1rem);
+  border-left: 4px solid var(--color-warning, #d97706);
+  background: var(--color-bg-secondary);
+  border-radius: 4px;
+}
+
+.impact-partial p {
+  margin: 0.25rem 0 0;
+  color: var(--text-secondary);
+}
+
+.impact-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: var(--spacing-sm, 0.5rem);
+  margin-bottom: var(--spacing-md, 1rem);
+}
+
+.impact-metric {
+  padding: 0.75rem;
+  border: 1px solid var(--border-default);
+  border-radius: 6px;
+  text-align: center;
+}
+
+.impact-metric.warn {
+  border-color: var(--color-warning, #d97706);
+}
+
+.metric-value {
+  display: block;
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.metric-label {
+  display: block;
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+}
+
+.impact-list ul,
+.impact-skipped ul {
+  list-style: none;
+  padding: 0;
+  margin: 0.5rem 0 0;
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+.impact-list li,
+.impact-skipped li {
+  padding: 0.25rem 0;
+  border-bottom: 1px solid var(--border-default);
+  word-break: break-all;
+}
+
+.impact-skipped {
+  margin-top: var(--spacing-md, 1rem);
+}
+
+.impact-skipped summary {
+  cursor: pointer;
+  color: var(--text-secondary);
+}
+</style>

--- a/autobot-frontend/src/components/analytics/CodebaseImpactPanel.vue
+++ b/autobot-frontend/src/components/analytics/CodebaseImpactPanel.vue
@@ -158,9 +158,9 @@ async function run(): Promise<void> {
   align-items: center;
   gap: 0.5rem;
   padding: 0.75rem 1rem;
-  border: 1px solid var(--color-danger, #dc2626);
+  border: 1px solid var(--color-danger);
   border-radius: 6px;
-  color: var(--color-danger, #dc2626);
+  color: var(--color-danger);
 }
 
 /* Deliberately loud: this is the difference between a complete answer and a
@@ -170,7 +170,7 @@ async function run(): Promise<void> {
   gap: 0.75rem;
   padding: 0.75rem 1rem;
   margin-bottom: var(--spacing-md, 1rem);
-  border-left: 4px solid var(--color-warning, #d97706);
+  border-left: 4px solid var(--color-warning);
   background: var(--color-bg-secondary);
   border-radius: 4px;
 }
@@ -195,7 +195,7 @@ async function run(): Promise<void> {
 }
 
 .impact-metric.warn {
-  border-color: var(--color-warning, #d97706);
+  border-color: var(--color-warning);
 }
 
 .metric-value {

--- a/autobot-frontend/src/components/analytics/__tests__/CodebaseImpactPanel.test.ts
+++ b/autobot-frontend/src/components/analytics/__tests__/CodebaseImpactPanel.test.ts
@@ -1,0 +1,143 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * A partial impact result must never render as a complete one (#13506).
+ *
+ * The engine (#13471) reports `depth_capped` with its un-expanded frontier and
+ * an unresolved-edge count precisely so a truncated walk cannot pass for the
+ * whole picture — that is the defect #13468 was filed to remove. The endpoint
+ * carries those fields; this panel is the last place they can be lost, and
+ * losing them here is worse than showing nothing: a partial caller list reads
+ * as evidence that nothing else is affected.
+ *
+ * These tests assert the rendering of that distinction, not the walk.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import CodebaseImpactPanel from '../CodebaseImpactPanel.vue'
+import en from '@/i18n/locales/en.json'
+
+const get = vi.fn()
+vi.mock('@/utils/ApiClient', () => ({ default: { get: (...a: unknown[]) => get(...a) } }))
+vi.mock('@/config/ssot-config', () => ({ getApiBase: () => '/api' }))
+
+const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } })
+
+function mountPanel() {
+  return mount(CodebaseImpactPanel, {
+    global: { plugins: [i18n], stubs: { Icon: true, EmptyState: { props: ['title'], template: '<div class="empty-state">{{ title }}</div>' } } },
+  })
+}
+
+async function analyze(wrapper: ReturnType<typeof mountPanel>, nodeId = 'pkg.mod.Thing') {
+  await wrapper.find('input').setValue(nodeId)
+  await wrapper.find('form').trigger('submit')
+  await flushPromises()
+}
+
+const COMPLETE = {
+  indexed: true,
+  root_id: 'pkg.mod.Thing',
+  reached: ['a.b', 'c.d'],
+  edges: [{ from: 'a.b' }, { from: 'c.d' }],
+  skipped_edges: [],
+  depth_capped: false,
+  depth_capped_frontier: [],
+  resolved_edge_count: 2,
+  unresolved_edge_count: 0,
+  max_depth: 5,
+  depth_reached: 2,
+}
+
+describe('CodebaseImpactPanel', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('warns that a depth-capped walk is only a lower bound', async () => {
+    get.mockResolvedValue({ ...COMPLETE, depth_capped: true, depth_capped_frontier: ['x.y'], depth_reached: 5 })
+    const wrapper = mountPanel()
+
+    await analyze(wrapper)
+
+    expect(wrapper.find('.impact-partial').exists()).toBe(true)
+    expect(wrapper.text()).toContain('lower bound')
+    // The count itself must not read as the final number.
+    expect(wrapper.text()).toContain('at least')
+  })
+
+  it('warns when edges could not be resolved, even at full depth', async () => {
+    get.mockResolvedValue({ ...COMPLETE, skipped_edges: [{ raw: 'helper' }], unresolved_edge_count: 1 })
+    const wrapper = mountPanel()
+
+    await analyze(wrapper)
+
+    expect(wrapper.find('.impact-partial').exists()).toBe(true)
+    expect(wrapper.text()).toContain('at least')
+  })
+
+  it('does not cry wolf on a complete walk', async () => {
+    get.mockResolvedValue(COMPLETE)
+    const wrapper = mountPanel()
+
+    await analyze(wrapper)
+
+    expect(wrapper.find('.impact-partial').exists()).toBe(false)
+    expect(wrapper.text()).not.toContain('at least')
+    expect(wrapper.text()).toContain('a.b')
+  })
+
+  it('shows both edge counts rather than one derived score', async () => {
+    get.mockResolvedValue({ ...COMPLETE, skipped_edges: [{ raw: 'h' }], unresolved_edge_count: 1 })
+    const wrapper = mountPanel()
+
+    await analyze(wrapper)
+
+    const text = wrapper.text()
+    expect(text).toContain('edges resolved')
+    expect(text).toContain('edges unresolved')
+    for (const forbidden of ['confidence', 'certainty', '%']) {
+      expect(text.toLowerCase()).not.toContain(forbidden)
+    }
+  })
+
+  it('distinguishes an unbuilt graph from a node with no callers', async () => {
+    get.mockResolvedValue({ indexed: false, node_id: 'pkg.mod.Thing', message: 'not available' })
+    const wrapper = mountPanel()
+
+    await analyze(wrapper)
+
+    expect(wrapper.find('.empty-state').text()).toContain('Code graph not built')
+    expect(wrapper.find('.impact-summary').exists()).toBe(false)
+  })
+
+  it('reports no callers as a real answer, not as an error', async () => {
+    get.mockResolvedValue({ ...COMPLETE, reached: [], edges: [], resolved_edge_count: 0, depth_reached: 0 })
+    const wrapper = mountPanel()
+
+    await analyze(wrapper)
+
+    expect(wrapper.find('.empty-state').text()).toContain('No callers found')
+    expect(wrapper.find('.impact-error').exists()).toBe(false)
+  })
+
+  it('surfaces a failed request instead of an empty result', async () => {
+    get.mockRejectedValue(new Error('boom'))
+    const wrapper = mountPanel()
+
+    await analyze(wrapper)
+
+    expect(wrapper.find('.impact-error').exists()).toBe(true)
+    expect(wrapper.find('.impact-summary').exists()).toBe(false)
+  })
+
+  it('sends the node id to the endpoint', async () => {
+    get.mockResolvedValue(COMPLETE)
+    const wrapper = mountPanel()
+
+    await analyze(wrapper, 'my.pkg.Widget')
+
+    expect(get).toHaveBeenCalledTimes(1)
+    expect(String(get.mock.calls[0][0])).toContain('node_id=my.pkg.Widget')
+  })
+})

--- a/autobot-frontend/src/composables/analytics/useImpactAnalysis.ts
+++ b/autobot-frontend/src/composables/analytics/useImpactAnalysis.ts
@@ -1,0 +1,108 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+/**
+ * Impact analysis — "what breaks if I change this" (#13506).
+ *
+ * Wraps `GET /api/analytics/codebase/impact`, which walks the code graph
+ * backwards from a node and reports what transitively calls it.
+ *
+ * The engine (#13471) was built so a truncated walk cannot pass for a complete
+ * one — that is the defect #13468 was filed to remove. The response therefore
+ * carries `depth_capped` with its un-expanded frontier, the skipped edges with
+ * reasons, and both edge counts. This composable keeps all of it: `isPartial`
+ * exists so the UI has a single, hard-to-ignore signal, and no confidence score
+ * is derived from the counts (#13482 Q2 bound that).
+ */
+
+import { computed, ref } from 'vue'
+
+import { getApiBase } from '@/config/ssot-config'
+import apiClient from '@/utils/ApiClient'
+import { createLogger } from '@/utils/debugUtils'
+
+const logger = createLogger('useImpactAnalysis')
+
+export interface ImpactEdge {
+  [key: string]: unknown
+}
+
+export interface ImpactResponse {
+  indexed: boolean
+  root_id?: string
+  seed_ids?: string[]
+  reached?: string[]
+  edges?: ImpactEdge[]
+  depth_capped?: boolean
+  depth_capped_frontier?: string[]
+  skipped_edges?: ImpactEdge[]
+  resolved_edge_count?: number
+  unresolved_edge_count?: number
+  max_depth?: number
+  depth_reached?: number
+  message?: string
+}
+
+export function useImpactAnalysis() {
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+  const result = ref<ImpactResponse | null>(null)
+
+  /** True when the graph has never been built — distinct from "node not found". */
+  const notIndexed = computed(() => result.value !== null && result.value.indexed === false)
+
+  /**
+   * True when the answer is a lower bound rather than the whole picture.
+   *
+   * Either the walk hit its depth limit, or edges existed that could not be
+   * resolved. Both mean "there may be more callers than shown", and the panel
+   * must say so — a partial list rendered as complete is worse than no list,
+   * because it reads as evidence that nothing else is affected.
+   */
+  const isPartial = computed(() => {
+    const r = result.value
+    if (!r || r.indexed === false) return false
+    return Boolean(r.depth_capped) || (r.unresolved_edge_count ?? 0) > 0
+  })
+
+  const callerCount = computed(() => result.value?.reached?.length ?? 0)
+
+  async function analyze(nodeId: string, maxDepth?: number): Promise<void> {
+    const id = nodeId.trim()
+    if (!id) {
+      error.value = 'A node id is required.'
+      return
+    }
+
+    loading.value = true
+    error.value = null
+    result.value = null
+
+    try {
+      const params = new URLSearchParams({ node_id: id })
+      if (maxDepth !== undefined) params.set('max_depth', String(maxDepth))
+      result.value = await apiClient.get<ImpactResponse>(
+        `${getApiBase()}/analytics/codebase/impact?${params.toString()}`,
+      )
+      logger.info(
+        'Impact walk for %s: %d reached%s',
+        id,
+        result.value?.reached?.length ?? 0,
+        result.value?.depth_capped ? ' (depth-capped)' : '',
+      )
+    } catch (err) {
+      error.value = 'Impact analysis failed. Please try again.'
+      logger.error('Impact analysis failed:', err)
+    } finally {
+      loading.value = false
+    }
+  }
+
+  function reset(): void {
+    result.value = null
+    error.value = null
+  }
+
+  return { loading, error, result, notIndexed, isPartial, callerCount, analyze, reset }
+}

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -1424,6 +1424,28 @@
         "codeGeneration": "Code Generation",
         "codeQuality": "Code Quality",
         "ariaLabel": "تحليلات المشروع"
+      },
+      "impact": {
+        "title": "تحليل الأثر",
+        "hint": "ما الذي يستدعي عقدة بشكل غير مباشر — استخدمه قبل التغيير أو الحذف.",
+        "nodeIdPlaceholder": "مثال: package.module.ClassName",
+        "nodeIdLabel": "معرّف عقدة الرسم البياني",
+        "analyze": "تحليل",
+        "analyzing": "جارٍ التحليل…",
+        "notIndexedTitle": "لم يتم بناء رسم الشيفرة",
+        "notIndexedBody": "قم بفهرسة هذا المصدر قبل تحليل الأثر.",
+        "partialTitle": "نتيجة جزئية — هذا حد أدنى",
+        "partialDepth": "توقف المسار عند العمق {depth} مع {frontier} عقدة غير موسّعة. قد يوجد مستدعون أكثر.",
+        "partialUnresolved": "تعذّر حل {count} حافة، لذا قد يكون بعض المستدعين مفقودًا.",
+        "callers": "المستدعون",
+        "callersAtLeast": "المستدعون (على الأقل)",
+        "callersHeading": "المستدعون الذين تم الوصول إليهم",
+        "edgesResolved": "حواف تم حلها",
+        "edgesUnresolved": "حواف لم تُحل",
+        "depth": "العمق المُدرك",
+        "noCallersTitle": "لا يوجد مستدعون",
+        "noCallersBody": "لا شيء في الرسم المفهرس يستدعي هذه العقدة.",
+        "skippedHeading": "إظهار {count} حافة غير محلولة"
       }
     },
     "patterns": {

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -1424,6 +1424,28 @@
         "codeGeneration": "Code Generation",
         "codeQuality": "Code Quality",
         "ariaLabel": "Projektanalysen"
+      },
+      "impact": {
+        "title": "Auswirkungsanalyse",
+        "hint": "Was einen Knoten transitiv aufruft — vor Änderung oder Entfernung prüfen.",
+        "nodeIdPlaceholder": "z. B. paket.modul.KlassenName",
+        "nodeIdLabel": "Graph-Knoten-ID",
+        "analyze": "Analysieren",
+        "analyzing": "Analysiere…",
+        "notIndexedTitle": "Code-Graph nicht erstellt",
+        "notIndexedBody": "Indexieren Sie diese Quelle, bevor Sie die Auswirkungen analysieren.",
+        "partialTitle": "Teilergebnis — dies ist eine Untergrenze",
+        "partialDepth": "Der Durchlauf endete bei Tiefe {depth}; {frontier} Knoten wurden nicht expandiert. Es kann mehr Aufrufer geben.",
+        "partialUnresolved": "{count} Kante(n) konnten nicht aufgelöst werden, daher fehlen möglicherweise Aufrufer.",
+        "callers": "Aufrufer",
+        "callersAtLeast": "Aufrufer (mindestens)",
+        "callersHeading": "Erreichte Aufrufer",
+        "edgesResolved": "aufgelöste Kanten",
+        "edgesUnresolved": "nicht aufgelöste Kanten",
+        "depth": "erreichte Tiefe",
+        "noCallersTitle": "Keine Aufrufer gefunden",
+        "noCallersBody": "Nichts im indexierten Graphen ruft diesen Knoten auf.",
+        "skippedHeading": "{count} nicht aufgelöste Kante(n) anzeigen"
       }
     },
     "patterns": {

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -1424,6 +1424,28 @@
         "evolution": "Evolution",
         "overview": "Overview",
         "ariaLabel": "Project analytics"
+      },
+      "impact": {
+        "title": "Impact Analysis",
+        "hint": "What transitively calls a node — use it before changing or removing one.",
+        "nodeIdPlaceholder": "e.g. package.module.ClassName",
+        "nodeIdLabel": "Graph node id",
+        "analyze": "Analyze",
+        "analyzing": "Analyzing…",
+        "notIndexedTitle": "Code graph not built",
+        "notIndexedBody": "Run an index for this source before analysing impact.",
+        "partialTitle": "Partial result — this is a lower bound",
+        "partialDepth": "The walk stopped at depth {depth} with {frontier} node(s) still unexpanded. There may be more callers than shown.",
+        "partialUnresolved": "{count} edge(s) could not be resolved, so some callers may be missing.",
+        "callers": "callers",
+        "callersAtLeast": "callers (at least)",
+        "callersHeading": "Callers reached",
+        "edgesResolved": "edges resolved",
+        "edgesUnresolved": "edges unresolved",
+        "depth": "depth reached",
+        "noCallersTitle": "No callers found",
+        "noCallersBody": "Nothing in the indexed graph calls this node.",
+        "skippedHeading": "Show {count} unresolved edge(s)"
       }
     },
     "patterns": {

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -1424,6 +1424,28 @@
         "codeGeneration": "Code Generation",
         "codeQuality": "Code Quality",
         "ariaLabel": "Analíticas del proyecto"
+      },
+      "impact": {
+        "title": "Análisis de impacto",
+        "hint": "Qué llama transitivamente a un nodo — úsalo antes de cambiarlo o eliminarlo.",
+        "nodeIdPlaceholder": "p. ej. paquete.modulo.NombreClase",
+        "nodeIdLabel": "ID del nodo del grafo",
+        "analyze": "Analizar",
+        "analyzing": "Analizando…",
+        "notIndexedTitle": "Grafo de código no construido",
+        "notIndexedBody": "Indexa esta fuente antes de analizar el impacto.",
+        "partialTitle": "Resultado parcial — es una cota inferior",
+        "partialDepth": "El recorrido se detuvo en la profundidad {depth} con {frontier} nodo(s) sin expandir. Puede haber más llamadores.",
+        "partialUnresolved": "No se pudieron resolver {count} arista(s), por lo que pueden faltar llamadores.",
+        "callers": "llamadores",
+        "callersAtLeast": "llamadores (al menos)",
+        "callersHeading": "Llamadores alcanzados",
+        "edgesResolved": "aristas resueltas",
+        "edgesUnresolved": "aristas sin resolver",
+        "depth": "profundidad alcanzada",
+        "noCallersTitle": "No se encontraron llamadores",
+        "noCallersBody": "Nada en el grafo indexado llama a este nodo.",
+        "skippedHeading": "Mostrar {count} arista(s) sin resolver"
       }
     },
     "patterns": {

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -823,6 +823,28 @@
         "codeQuality": "Code Quality",
         "codeGeneration": "Code Generation",
         "ariaLabel": "تحلیل‌های پروژه"
+      },
+      "impact": {
+        "title": "تحلیل اثر",
+        "hint": "چه چیزی به‌طور غیرمستقیم یک گره را فرا می‌خواند — پیش از تغییر یا حذف بررسی کنید.",
+        "nodeIdPlaceholder": "مثلاً package.module.ClassName",
+        "nodeIdLabel": "شناسه گره گراف",
+        "analyze": "تحلیل",
+        "analyzing": "در حال تحلیل…",
+        "notIndexedTitle": "گراف کد ساخته نشده است",
+        "notIndexedBody": "پیش از تحلیل اثر، این منبع را نمایه کنید.",
+        "partialTitle": "نتیجه ناقص — این یک کران پایین است",
+        "partialDepth": "پیمایش در عمق {depth} با {frontier} گره گسترش‌نیافته متوقف شد. ممکن است فراخوان‌های بیشتری وجود داشته باشد.",
+        "partialUnresolved": "{count} یال قابل حل نبود، بنابراین ممکن است برخی فراخوان‌ها جا مانده باشند.",
+        "callers": "فراخوان‌ها",
+        "callersAtLeast": "فراخوان‌ها (حداقل)",
+        "callersHeading": "فراخوان‌های یافت‌شده",
+        "edgesResolved": "یال‌های حل‌شده",
+        "edgesUnresolved": "یال‌های حل‌نشده",
+        "depth": "عمق طی‌شده",
+        "noCallersTitle": "فراخوانی یافت نشد",
+        "noCallersBody": "هیچ چیز در گراف نمایه‌شده این گره را فرا نمی‌خواند.",
+        "skippedHeading": "نمایش {count} یال حل‌نشده"
       }
     },
     "patterns": {

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -1424,6 +1424,28 @@
         "codeGeneration": "Code Generation",
         "codeQuality": "Code Quality",
         "ariaLabel": "Analyses du projet"
+      },
+      "impact": {
+        "title": "Analyse d'impact",
+        "hint": "Ce qui appelle transitivement un nœud — à consulter avant de le modifier ou le supprimer.",
+        "nodeIdPlaceholder": "ex. paquet.module.NomClasse",
+        "nodeIdLabel": "Identifiant du nœud",
+        "analyze": "Analyser",
+        "analyzing": "Analyse…",
+        "notIndexedTitle": "Graphe de code non construit",
+        "notIndexedBody": "Indexez cette source avant d'analyser l'impact.",
+        "partialTitle": "Résultat partiel — il s'agit d'une borne inférieure",
+        "partialDepth": "Le parcours s'est arrêté à la profondeur {depth} avec {frontier} nœud(s) non développé(s). Il peut y avoir d'autres appelants.",
+        "partialUnresolved": "{count} arête(s) n'ont pas pu être résolues ; des appelants peuvent manquer.",
+        "callers": "appelants",
+        "callersAtLeast": "appelants (au moins)",
+        "callersHeading": "Appelants atteints",
+        "edgesResolved": "arêtes résolues",
+        "edgesUnresolved": "arêtes non résolues",
+        "depth": "profondeur atteinte",
+        "noCallersTitle": "Aucun appelant trouvé",
+        "noCallersBody": "Rien dans le graphe indexé n'appelle ce nœud.",
+        "skippedHeading": "Afficher {count} arête(s) non résolue(s)"
       }
     },
     "patterns": {

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -823,6 +823,28 @@
         "codeQuality": "Code Quality",
         "codeGeneration": "Code Generation",
         "ariaLabel": "ניתוחי פרויקט"
+      },
+      "impact": {
+        "title": "ניתוח השפעה",
+        "hint": "מה קורא לצומת באופן טרנזיטיבי — בדוק לפני שינוי או הסרה.",
+        "nodeIdPlaceholder": "לדוגמה package.module.ClassName",
+        "nodeIdLabel": "מזהה צומת בגרף",
+        "analyze": "נתח",
+        "analyzing": "מנתח…",
+        "notIndexedTitle": "גרף הקוד לא נבנה",
+        "notIndexedBody": "בצע אינדוקס למקור זה לפני ניתוח ההשפעה.",
+        "partialTitle": "תוצאה חלקית — זהו חסם תחתון",
+        "partialDepth": "המעבר נעצר בעומק {depth} עם {frontier} צמתים שלא הורחבו. ייתכנו קוראים נוספים.",
+        "partialUnresolved": "לא ניתן היה לפתור {count} קשתות, ולכן ייתכן שחסרים קוראים.",
+        "callers": "קוראים",
+        "callersAtLeast": "קוראים (לפחות)",
+        "callersHeading": "קוראים שנמצאו",
+        "edgesResolved": "קשתות שנפתרו",
+        "edgesUnresolved": "קשתות שלא נפתרו",
+        "depth": "עומק שהושג",
+        "noCallersTitle": "לא נמצאו קוראים",
+        "noCallersBody": "דבר בגרף המאונדקס אינו קורא לצומת זה.",
+        "skippedHeading": "הצג {count} קשתות שלא נפתרו"
       }
     },
     "patterns": {

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -1424,6 +1424,28 @@
         "codeGeneration": "Code Generation",
         "codeQuality": "Code Quality",
         "ariaLabel": "Projekta analītika"
+      },
+      "impact": {
+        "title": "Ietekmes analīze",
+        "hint": "Kas tranzitīvi izsauc mezglu — pārbaudiet pirms mainīšanas vai dzēšanas.",
+        "nodeIdPlaceholder": "piem. pakotne.modulis.KlasesNosaukums",
+        "nodeIdLabel": "Grafa mezgla ID",
+        "analyze": "Analizēt",
+        "analyzing": "Analizē…",
+        "notIndexedTitle": "Koda grafs nav izveidots",
+        "notIndexedBody": "Indeksējiet šo avotu pirms ietekmes analīzes.",
+        "partialTitle": "Daļējs rezultāts — tā ir apakšējā robeža",
+        "partialDepth": "Apstaigāšana apstājās {depth}. līmenī ar {frontier} neizvērstiem mezgliem. Izsaucēju var būt vairāk.",
+        "partialUnresolved": "{count} šķautni(-es) neizdevās atrisināt, tāpēc daži izsaucēji var trūkt.",
+        "callers": "izsaucēji",
+        "callersAtLeast": "izsaucēji (vismaz)",
+        "callersHeading": "Sasniegtie izsaucēji",
+        "edgesResolved": "atrisinātās šķautnes",
+        "edgesUnresolved": "neatrisinātās šķautnes",
+        "depth": "sasniegtais dziļums",
+        "noCallersTitle": "Izsaucēji nav atrasti",
+        "noCallersBody": "Nekas indeksētajā grafā neizsauc šo mezglu.",
+        "skippedHeading": "Rādīt {count} neatrisinātās šķautnes"
       }
     },
     "patterns": {

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -1424,6 +1424,28 @@
         "codeGeneration": "Code Generation",
         "codeQuality": "Code Quality",
         "ariaLabel": "Analityka projektu"
+      },
+      "impact": {
+        "title": "Analiza wpływu",
+        "hint": "Co przechodnio wywołuje węzeł — sprawdź przed zmianą lub usunięciem.",
+        "nodeIdPlaceholder": "np. pakiet.moduł.NazwaKlasy",
+        "nodeIdLabel": "Identyfikator węzła",
+        "analyze": "Analizuj",
+        "analyzing": "Analizowanie…",
+        "notIndexedTitle": "Graf kodu nie został zbudowany",
+        "notIndexedBody": "Zindeksuj to źródło przed analizą wpływu.",
+        "partialTitle": "Wynik częściowy — to dolna granica",
+        "partialDepth": "Przejście zatrzymało się na głębokości {depth}, pozostawiając {frontier} nierozwiniętych węzłów. Wywołań może być więcej.",
+        "partialUnresolved": "Nie udało się rozwiązać {count} krawędzi, więc część wywołań może brakować.",
+        "callers": "wywołania",
+        "callersAtLeast": "wywołania (co najmniej)",
+        "callersHeading": "Osiągnięte wywołania",
+        "edgesResolved": "rozwiązane krawędzie",
+        "edgesUnresolved": "nierozwiązane krawędzie",
+        "depth": "osiągnięta głębokość",
+        "noCallersTitle": "Nie znaleziono wywołań",
+        "noCallersBody": "Nic w zindeksowanym grafie nie wywołuje tego węzła.",
+        "skippedHeading": "Pokaż {count} nierozwiązanych krawędzi"
       }
     },
     "patterns": {

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -1424,6 +1424,28 @@
         "codeGeneration": "Code Generation",
         "codeQuality": "Code Quality",
         "ariaLabel": "Análises do projeto"
+      },
+      "impact": {
+        "title": "Análise de impacto",
+        "hint": "O que chama transitivamente um nó — use antes de alterar ou remover.",
+        "nodeIdPlaceholder": "ex. pacote.modulo.NomeClasse",
+        "nodeIdLabel": "ID do nó do grafo",
+        "analyze": "Analisar",
+        "analyzing": "A analisar…",
+        "notIndexedTitle": "Grafo de código não construído",
+        "notIndexedBody": "Indexe esta fonte antes de analisar o impacto.",
+        "partialTitle": "Resultado parcial — é um limite inferior",
+        "partialDepth": "A travessia parou na profundidade {depth} com {frontier} nó(s) por expandir. Pode haver mais chamadores.",
+        "partialUnresolved": "{count} aresta(s) não puderam ser resolvidas, pelo que podem faltar chamadores.",
+        "callers": "chamadores",
+        "callersAtLeast": "chamadores (pelo menos)",
+        "callersHeading": "Chamadores alcançados",
+        "edgesResolved": "arestas resolvidas",
+        "edgesUnresolved": "arestas não resolvidas",
+        "depth": "profundidade alcançada",
+        "noCallersTitle": "Nenhum chamador encontrado",
+        "noCallersBody": "Nada no grafo indexado chama este nó.",
+        "skippedHeading": "Mostrar {count} aresta(s) não resolvida(s)"
       }
     },
     "patterns": {

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -823,6 +823,28 @@
         "codeQuality": "Code Quality",
         "codeGeneration": "Code Generation",
         "ariaLabel": "پروجیکٹ کے تجزیات"
+      },
+      "impact": {
+        "title": "اثر کا تجزیہ",
+        "hint": "کون سی چیز بالواسطہ کسی نوڈ کو کال کرتی ہے — تبدیلی یا حذف سے پہلے دیکھیں۔",
+        "nodeIdPlaceholder": "مثلاً package.module.ClassName",
+        "nodeIdLabel": "گراف نوڈ آئی ڈی",
+        "analyze": "تجزیہ کریں",
+        "analyzing": "تجزیہ جاری…",
+        "notIndexedTitle": "کوڈ گراف نہیں بنایا گیا",
+        "notIndexedBody": "اثر کا تجزیہ کرنے سے پہلے اس ماخذ کو انڈیکس کریں۔",
+        "partialTitle": "جزوی نتیجہ — یہ کم از کم حد ہے",
+        "partialDepth": "چال {depth} گہرائی پر رک گئی، {frontier} نوڈز باقی رہ گئے۔ مزید کالرز ہو سکتے ہیں۔",
+        "partialUnresolved": "{count} کنارے حل نہیں ہو سکے، اس لیے کچھ کالرز غائب ہو سکتے ہیں۔",
+        "callers": "کالرز",
+        "callersAtLeast": "کالرز (کم از کم)",
+        "callersHeading": "پائے گئے کالرز",
+        "edgesResolved": "حل شدہ کنارے",
+        "edgesUnresolved": "غیر حل شدہ کنارے",
+        "depth": "طے شدہ گہرائی",
+        "noCallersTitle": "کوئی کالر نہیں ملا",
+        "noCallersBody": "انڈیکس شدہ گراف میں کوئی چیز اس نوڈ کو کال نہیں کرتی۔",
+        "skippedHeading": "{count} غیر حل شدہ کنارے دکھائیں"
       }
     },
     "patterns": {


### PR DESCRIPTION
## Thinking Path

#13976 landed the REST half of #13506. This is the GUI consumer it asks for, and it completes the issue.

The design problem is narrow. `find_impact` reports `depth_capped` with its un-expanded frontier and an unresolved-edge count precisely so a truncated walk cannot pass for the whole picture — the defect #13468 was filed to remove. The endpoint carries those fields. **The panel is the last place they can be lost**, and losing them here is worse than showing nothing: a partial caller list rendered as complete reads as positive evidence that nothing else is affected, which is exactly the conclusion someone deleting a function wants to reach.

So the panel is built around one property: a lower bound must be visibly a lower bound.

- `isPartial` is true when the walk was depth-capped **or** any edge went unresolved — both mean "there may be more callers than shown"
- when partial, the headline count reads *"callers (at least)"*, not *"callers"*
- a warning block states which of the two happened, with the depth or the unresolved count
- resolved and unresolved edge counts sit side by side; no single score is derived from them (#13482 Q2)
- "the graph was never built" renders as its own state, not as an empty result — different cause, different fix

## What Changed

- `composables/analytics/useImpactAnalysis.ts` — wraps the endpoint, exposes `isPartial` / `notIndexed`
- `components/analytics/CodebaseImpactPanel.vue` — the panel, self-contained (owns its query and fetch, takes no props)
- Mounted in `CodebaseAnalytics.vue` beside the other codebase panels
- **20 i18n keys across all 11 locales** — no hardcoded UI strings
- 8 tests

## Verification

**Locale parity**, all 11 checked programmatically rather than by eye:

```
ar de en es fa fr he lv pl pt ur — 20 keys each, key sets identical
```

**The honesty guarantees have teeth.** Each mutation fails only the tests that exist to catch it:

| Mutation | Fails |
|---|---|
| `isPartial` ignores `depth_capped` | `warns that a depth-capped walk is only a lower bound` |
| `isPartial` ignores unresolved edges | `warns when edges could not be resolved, even at full depth` |
| headline count never says "at least" | both of the above |
| `notIndexed` renders as an ordinary empty result | `distinguishes an unbuilt graph from a node with no callers` |

One test asserts the *absence* of a derived score — no "confidence", "certainty" or `%` in the rendered output — because the tempting UI move here is to turn two numbers into one reassuring percentage, and #13482 Q2 rules that out.

```
$ npx vitest run CodebaseImpactPanel.test.ts   → 8 passed
$ eslint + oxlint + vue-tsc                    → clean, exit 0
$ npm run build                                → ✓ built in 10.90s
```

**Not verified:** no live code graph was queried. The tests stub the endpoint, so a divergence between the real response shape and the stubbed one would not be caught here — the endpoint's own contract tests (#13976) cover that side.

Closes #13506

## Model Used

Opus 5
