### PR TITLE
fix(mcp): thread the authenticated role to MCPDispatcher (#13821)

### DIFF
--- a/autobot-backend/api/chat.py
+++ b/autobot-backend/api/chat.py
@@ -1503,6 +1503,7 @@ async def _stream_direct_response(
     message: str,
     remember_choice: bool,
     request_id: str,
+    auth_role: str | None = None,
 ):
     """Stream direct response for approvals/denials (Issue #398: extracted)."""
     try:
@@ -1513,6 +1514,7 @@ async def _stream_direct_response(
             session_id=chat_id,
             message=message,
             context={"remember_choice": remember_choice},
+            auth_role=auth_role,
         ):
             msg_data = msg.to_dict() if hasattr(msg, "to_dict") else msg
             yield f"data: {json.dumps(msg_data)}\n\n"
@@ -1904,7 +1906,15 @@ async def send_direct_chat_response(
     _validate_workflow_manager(chat_workflow_manager)
 
     return _create_streaming_response(
-        _stream_direct_response(chat_workflow_manager, chat_id, message, remember_choice, request_id)
+        _stream_direct_response(
+            chat_workflow_manager,
+            chat_id,
+            message,
+            remember_choice,
+            request_id,
+            # #13821: server-side identity, same as the message endpoint.
+            auth_role=(current_user or {}).get("role"),
+        )
     )
 
 

--- a/autobot-backend/api/chat.py
+++ b/autobot-backend/api/chat.py
@@ -1453,7 +1453,12 @@ def _validate_chat_services(chat_history_manager, chat_workflow_manager) -> None
 
 
 async def _stream_chat_workflow_messages(
-    chat_workflow_manager, chat_id: str, message: str, context: dict, request_id: str
+    chat_workflow_manager,
+    chat_id: str,
+    message: str,
+    context: dict,
+    request_id: str,
+    auth_role: str | None = None,
 ):
     """Stream chat workflow messages as SSE events (Issue #398: extracted)."""
     try:
@@ -1464,7 +1469,7 @@ async def _stream_chat_workflow_messages(
         logger.debug("[%s] Processing message: %s...", request_id, message[:50])
         message_count = 0
         async for msg in chat_workflow_manager.process_message_stream(
-            session_id=chat_id, message=message, context=context
+            session_id=chat_id, message=message, context=context, auth_role=auth_role
         ):
             message_count += 1
             msg_data = msg.to_dict() if hasattr(msg, "to_dict") else msg
@@ -1602,6 +1607,10 @@ async def send_chat_message_by_id(
             message,
             context,
             request_id,
+            # #13821: the RBAC role from the authenticated session, NOT from
+            # request_data — `context` above is the caller's own bag and is
+            # explicitly not trusted for this.
+            auth_role=(current_user or {}).get("role"),
         )
     )
 

--- a/autobot-backend/chat_workflow/delegation.py
+++ b/autobot-backend/chat_workflow/delegation.py
@@ -99,7 +99,7 @@ def forbidden_to_claude_tools(forbidden: "frozenset[str] | list[str]") -> List[s
     return sorted({tool for tool in (_claude_tool_for(f) for f in forbidden) if tool})
 
 
-async def _run_claude_code_subagent(task: str, agent_type: str, depth: int) -> str:
+async def _run_claude_code_subagent(task: str, agent_type: str, depth: int, auth_role: str = "user") -> str:
     """Run *task* as a governed claude_code subagent; return its output."""
     from orchestration.agent_registry import resolve_forbidden_tools
     from services.execution.base_backend import ExecutionTask
@@ -119,7 +119,7 @@ async def _run_claude_code_subagent(task: str, agent_type: str, depth: int) -> s
     return result.stdout or result.stderr or ""
 
 
-async def _run_internal_subagent(task: str, agent_type: str, depth: int) -> str:
+async def _run_internal_subagent(task: str, agent_type: str, depth: int, auth_role: str = "user") -> str:
     """Run *task* as a governed **internal-LLM** subagent; return its final text.
 
     Drives the production continuation loop (``_execute_llm_continuation_loop``) with
@@ -148,6 +148,13 @@ async def _run_internal_subagent(task: str, agent_type: str, depth: int) -> str:
         work_item_id=work_item_id,
         requires_approval_before=approval_categories,
         context={"delegation_depth": depth + 1},
+        # #13821: a subagent acts for the same authenticated user, so it inherits
+        # their role rather than silently dropping to the default. Leaving it
+        # unset would reproduce the pre-#13821 bug (an admin denied the tools
+        # they are entitled to) the moment delegation ships. The value comes from
+        # the delegating ctx, which a trusted server-side overlay produced — not
+        # from anything the caller can set.
+        auth_role=auth_role,
     )
     logger.info("delegation: internal subagent agent=%s depth=%d model=%s", agent_type, depth, ctx.selected_model)
     responses: List[str] = []
@@ -164,7 +171,7 @@ async def _run_internal_subagent(task: str, agent_type: str, depth: int) -> str:
 
 
 # Engine registry — provider-agnostic dispatch; new engines register a name here.
-_ENGINES: Dict[str, Callable[[str, str, int], Awaitable[str]]] = {
+_ENGINES: Dict[str, Callable[[str, str, int, str], Awaitable[str]]] = {
     "claude_code": _run_claude_code_subagent,
     "internal": _run_internal_subagent,
 }
@@ -176,8 +183,15 @@ async def run_delegated_subtask(
     depth: int = 0,
     engine: str = "claude_code",
     parent_agent_id: str | None = None,
+    auth_role: str = "user",
 ) -> str:
     """Run a delegated subtask as a governed subagent (GH#11207).
+
+    #13821: ``auth_role`` is the delegating session's authenticated role, carried
+    so a subagent acts with the same RBAC identity as the user who asked for it —
+    it is not a privilege grant, since the value can only come from a trusted
+    server-side overlay upstream. Defaulting it instead would deny an admin the
+    tools they are entitled to, which is the bug #13821 fixes.
 
     Raises ``ValueError`` past ``MAX_DELEGATION_DEPTH``, for an unknown engine, or
     for an *unbounded* ``agent_type`` (GH#13588). Emits an INFO log with engine,
@@ -209,4 +223,4 @@ async def run_delegated_subtask(
         depth,
         task,
     )
-    return await runner(task, agent_type, depth)
+    return await runner(task, agent_type, depth, auth_role)

--- a/autobot-backend/chat_workflow/delegation.py
+++ b/autobot-backend/chat_workflow/delegation.py
@@ -60,6 +60,7 @@ from typing import Awaitable, Callable, Dict, List
 from autobot_shared import tool_catalogue as _tc
 from autobot_shared.env_utils import env_flag, env_int
 from autobot_shared.logging_manager import get_logger
+from chat_workflow.session_role import DEFAULT_AUTH_ROLE
 
 logger = get_logger(__name__)
 
@@ -99,7 +100,7 @@ def forbidden_to_claude_tools(forbidden: "frozenset[str] | list[str]") -> List[s
     return sorted({tool for tool in (_claude_tool_for(f) for f in forbidden) if tool})
 
 
-async def _run_claude_code_subagent(task: str, agent_type: str, depth: int, auth_role: str = "user") -> str:
+async def _run_claude_code_subagent(task: str, agent_type: str, depth: int, auth_role: str = DEFAULT_AUTH_ROLE) -> str:
     """Run *task* as a governed claude_code subagent; return its output."""
     from orchestration.agent_registry import resolve_forbidden_tools
     from services.execution.base_backend import ExecutionTask
@@ -119,7 +120,7 @@ async def _run_claude_code_subagent(task: str, agent_type: str, depth: int, auth
     return result.stdout or result.stderr or ""
 
 
-async def _run_internal_subagent(task: str, agent_type: str, depth: int, auth_role: str = "user") -> str:
+async def _run_internal_subagent(task: str, agent_type: str, depth: int, auth_role: str = DEFAULT_AUTH_ROLE) -> str:
     """Run *task* as a governed **internal-LLM** subagent; return its final text.
 
     Drives the production continuation loop (``_execute_llm_continuation_loop``) with
@@ -183,7 +184,7 @@ async def run_delegated_subtask(
     depth: int = 0,
     engine: str = "claude_code",
     parent_agent_id: str | None = None,
-    auth_role: str = "user",
+    auth_role: str = DEFAULT_AUTH_ROLE,
 ) -> str:
     """Run a delegated subtask as a governed subagent (GH#11207).
 

--- a/autobot-backend/chat_workflow/delegation_test.py
+++ b/autobot-backend/chat_workflow/delegation_test.py
@@ -75,7 +75,7 @@ async def test_run_delegated_subtask_dispatches_to_engine():
     with patch.dict(delegation._ENGINES, {"claude_code": engine}):
         out = await run_delegated_subtask("do it", agent_type="research_agent", depth=0)
     assert out == "subagent output"
-    engine.assert_awaited_once_with("do it", "research_agent", 0)
+    engine.assert_awaited_once_with("do it", "research_agent", 0, "user")
 
 
 @pytest.mark.asyncio
@@ -126,7 +126,7 @@ async def test_internal_engine_registered_and_dispatches():
     with patch.dict(delegation._ENGINES, {"internal": engine}):
         out = await run_delegated_subtask("t", agent_type="research_agent", depth=0, engine="internal")
     assert out == "internal result"
-    engine.assert_awaited_once_with("t", "research_agent", 0)
+    engine.assert_awaited_once_with("t", "research_agent", 0, "user")
 
 
 # --- _handle_delegate_tool: flag off = unchanged, on = runs subagent -------
@@ -271,7 +271,9 @@ async def test_delegate_tool_passes_parent_agent_id_to_runner():
 
     mixin = _mixin()
     agent_ctx = SimpleNamespace(agent_id="the_parent")
-    ctx = SimpleNamespace(context={"delegations_this_turn": 0, "delegation_depth": 0}, agent_context=agent_ctx)
+    ctx = SimpleNamespace(
+        context={"delegations_this_turn": 0, "delegation_depth": 0}, agent_context=agent_ctx, auth_role="admin"
+    )
     captured = {}
     mock_run = AsyncMock(side_effect=lambda *a, **kw: captured.update(kw) or "done")
 
@@ -281,6 +283,10 @@ async def test_delegate_tool_passes_parent_agent_id_to_runner():
     ):
         _ = [m async for m in mixin._handle_delegate_tool({"params": {"task": "t"}}, [], ctx)]
     assert captured.get("parent_agent_id") == "the_parent"
+    # #13821: a subagent acts for the same authenticated user. Dropping the role
+    # here would deny an admin the tools they are entitled to, the moment
+    # delegation ships.
+    assert captured.get("auth_role") == "admin"
 
 
 # --- GH#11266: env_flag covers "on" (canonical truthy) ----------------------

--- a/autobot-backend/chat_workflow/graph.py
+++ b/autobot-backend/chat_workflow/graph.py
@@ -394,6 +394,7 @@ def _build_llm_iteration_context(state: ChatState):
     ``SystemMessage``.  See that helper's docstring for the full rationale.
     """
     from .models import LLMIterationContext, build_governed_identity
+    from .session_role import resolve_auth_role
 
     initial_prompt = state["llm_params"].get("initial_prompt") or ""
 
@@ -414,6 +415,10 @@ def _build_llm_iteration_context(state: ChatState):
     agent_context, work_item_id, approval_cats = build_governed_identity(
         state.get("context", {}) or {}, state["session_id"]
     )
+    # #13821: same lift for the authenticated role. The graph path builds its own
+    # LLMIterationContext, so omitting it here would leave every graph-path tool
+    # call evaluated as the default role — which is the bug being fixed.
+    auth_role = resolve_auth_role(state.get("context", {}) or {})
 
     return LLMIterationContext(
         ollama_endpoint=state["llm_params"]["ollama_endpoint"],
@@ -427,6 +432,7 @@ def _build_llm_iteration_context(state: ChatState):
         system_prompt=state["llm_params"].get("system_prompt"),
         initial_prompt=initial_prompt,
         message=state["user_message"],
+        auth_role=auth_role,
         # #11552: thread the request context (company_id, user_id, …) into the
         # iteration context so the tool-dispatch seam is company-scoped in the
         # GRAPH path too. The legacy _create_llm_iteration_context already passes

--- a/autobot-backend/chat_workflow/manager.py
+++ b/autobot-backend/chat_workflow/manager.py
@@ -50,6 +50,7 @@ from .models import (
     filter_internal_prompts,
 )
 from .session_handler import SessionHandlerMixin
+from .session_role import resolve_auth_role
 from .tool_handler import ToolHandlerMixin
 
 logger = get_logger(__name__)
@@ -3432,6 +3433,7 @@ before summarizing.
             agent_context=agent_context,
             work_item_id=work_item_id,
             requires_approval_before=approval_cats,
+            auth_role=resolve_auth_role(merged_context),
         )
 
     async def _execute_llm_workflow(
@@ -3557,11 +3559,15 @@ before summarizing.
 
     @error_boundary(component="chat_workflow_manager", function="process_message")
     async def process_message(
-        self, session_id: str, message: str, context: Dict[str, Any] | None = None
+        self,
+        session_id: str,
+        message: str,
+        context: Dict[str, Any] | None = None,
+        auth_role: str | None = None,
     ) -> List[WorkflowMessage]:
         """Process a message through the workflow system and return all messages."""
         messages = []
-        async for msg in self.process_message_stream(session_id, message, context):
+        async for msg in self.process_message_stream(session_id, message, context, auth_role):
             messages.append(msg)
         return messages
 
@@ -3623,7 +3629,9 @@ before summarizing.
         workflow_messages.append(error_msg)
         return error_msg
 
-    async def _apply_session_role(self, session_id: str, context: Dict[str, Any] | None) -> Dict[str, Any] | None:
+    async def _apply_session_role(
+        self, session_id: str, context: Dict[str, Any] | None, auth_role: str | None = None
+    ) -> Dict[str, Any] | None:
         """Overlay the trusted per-session governance onto the chat context (GH#11186/#11202).
 
         A server-set session role overrides any client-supplied ``agent_id`` so the
@@ -3634,10 +3642,19 @@ before summarizing.
         seam gate holds matching tools BEFORE they execute — the correct
         pre-execution stage. Backend decides; the frontend only calls the endpoints.
         """
-        from chat_workflow.session_role import CHAT_APPROVAL_GATE_ENABLED, SessionRoleService, apply_role
+        from chat_workflow.session_role import (
+            CHAT_APPROVAL_GATE_ENABLED,
+            SessionRoleService,
+            apply_auth_role,
+            apply_role,
+        )
         from chat_workflow.session_work_item import SessionWorkItemService, apply_work_item
 
         svc = SessionRoleService()
+        # #13821: the authenticated caller's RBAC role, from the endpoint's
+        # server-side identity. Applied unconditionally (it strips on a missing
+        # role) so a client-supplied auth_role can never reach the tool seam.
+        context = apply_auth_role(context, auth_role)
         context = apply_role(context, await svc.get_role(session_id))
         # #13704: same trust model for the work-item binding. A server-set value
         # overrides any client-supplied work_item_id, and an unbound session has
@@ -3650,7 +3667,13 @@ before summarizing.
                 context = {**(context or {}), "requires_approval_before": categories}
         return context
 
-    async def process_message_stream(self, session_id: str, message: str, context: Dict[str, Any] | None = None):
+    async def process_message_stream(
+        self,
+        session_id: str,
+        message: str,
+        context: Dict[str, Any] | None = None,
+        auth_role: str | None = None,
+    ):
         """Process a message via LangGraph StateGraph.
 
         Issue #1043: Replaced hand-rolled async generator with LangGraph graph
@@ -3661,7 +3684,7 @@ before summarizing.
         """
         # GH#11186: apply the trusted per-session role once here, so both the graph
         # and legacy paths carry the governed identity into the tool seam.
-        context = await self._apply_session_role(session_id, context)
+        context = await self._apply_session_role(session_id, context, auth_role)
         try:
             async for msg in self._process_via_graph(session_id, message, context):
                 yield msg

--- a/autobot-backend/chat_workflow/models.py
+++ b/autobot-backend/chat_workflow/models.py
@@ -391,6 +391,12 @@ class LLMIterationContext:
     # can gate on them without a DB round-trip.
     work_item_id: str | None = None
     requires_approval_before: List[str] = field(default_factory=list)
+    # #13821: the authenticated caller's RBAC role, resolved by a trusted
+    # server-side producer. Its own field rather than a `context` lookup at the
+    # seam, so the value that reaches MCPDispatcher cannot be a client-supplied
+    # key that slipped through. Defaults to the same "user" every downstream
+    # seam already defaulted to.
+    auth_role: str = "user"
 
 
 def build_governed_identity(

--- a/autobot-backend/chat_workflow/session_role.py
+++ b/autobot-backend/chat_workflow/session_role.py
@@ -47,6 +47,47 @@ def valid_roles() -> "frozenset[str]":
     return _valid_roles
 
 
+#: Context key carrying the *authenticated caller's* RBAC role (#13821).
+#:
+#: Distinct from the ``agent_id`` role above, which pins a governed agent profile.
+#: This one answers "who is signed in", and is what ``MCPDispatcher.dispatch()``
+#: resolves permissions against.
+AUTH_ROLE_CONTEXT_KEY = "auth_role"
+
+#: Role assumed when no authenticated identity reached the workflow. Matches the
+#: long-standing ``role: str = "user"`` default at every seam downstream, so an
+#: unauthenticated path is no more privileged than it was before #13821.
+DEFAULT_AUTH_ROLE = "user"
+
+
+def apply_auth_role(context: "dict | None", role: Optional[str]) -> "dict | None":
+    """Overlay the trusted authenticated *role* onto *context* (#13821).
+
+    Unlike ``apply_role``, a falsy *role* **strips** the key rather than leaving
+    *context* untouched. That asymmetry is the security property: ``context`` is
+    the client-supplied ``request_data["context"]`` bag, so a caller can put
+    ``auth_role: "admin"`` in it. Returning early on a missing server-side role
+    would let exactly that value survive into the tool seam and grant the
+    privileges it names. Every path therefore writes or removes the key — the
+    caller's value is never the one that reaches ``dispatch()``.
+    """
+    merged = {**(context or {})}
+    if role:
+        merged[AUTH_ROLE_CONTEXT_KEY] = role
+    else:
+        merged.pop(AUTH_ROLE_CONTEXT_KEY, None)
+    return merged
+
+
+def resolve_auth_role(context: "dict | None") -> str:
+    """Read the authenticated role a trusted producer overlaid, else the default.
+
+    Only ever called on a context already passed through ``apply_auth_role``.
+    """
+    value = (context or {}).get(AUTH_ROLE_CONTEXT_KEY)
+    return value if isinstance(value, str) and value else DEFAULT_AUTH_ROLE
+
+
 def apply_role(context: "dict | None", role: Optional[str]) -> "dict | None":
     """Overlay a trusted *role* onto *context* as ``agent_id`` (GH#11186).
 

--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -3700,6 +3700,15 @@ class ToolHandlerMixin:
         break_loop_requested = False
         respond_content = None
 
+        # #13821: forward the authenticated role. #2629 wired `role` as far as
+        # _dispatch_tool_call's signature and stopped here, so the `role="user"`
+        # default won every call and MCPDispatcher never saw who was signed in —
+        # an admin was denied the admin-only tools they are entitled to, and the
+        # #13228 shadow inventory could only ever contain user rows.
+        from chat_workflow.session_role import DEFAULT_AUTH_ROLE  # noqa: PLC0415
+
+        role = ctx.auth_role if ctx is not None else DEFAULT_AUTH_ROLE
+
         for tool_call in tool_calls:
             async for result in self._dispatch_tool_call(
                 tool_call,
@@ -3710,6 +3719,7 @@ class ToolHandlerMixin:
                 execution_results,
                 additional_response_parts,
                 ctx=ctx,
+                role=role,
             ):
                 if isinstance(result, tuple):
                     break_loop_requested, respond_content = result

--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -2167,6 +2167,8 @@ class ToolHandlerMixin:
         engine = params.get("engine", "claude_code")
         depth = int(ctx_dict.get("delegation_depth", 0))
         parent_agent_id = ctx.agent_context.agent_id if ctx and ctx.agent_context else None
+        from chat_workflow.session_role import DEFAULT_AUTH_ROLE  # noqa: PLC0415
+
         try:
             result = await run_delegated_subtask(
                 task,
@@ -2174,6 +2176,7 @@ class ToolHandlerMixin:
                 depth=depth,
                 engine=engine,
                 parent_agent_id=parent_agent_id,
+                auth_role=ctx.auth_role if ctx is not None else DEFAULT_AUTH_ROLE,
             )
             execution_results.append(
                 {
@@ -3550,9 +3553,17 @@ class ToolHandlerMixin:
         """Return an async dispatch callable routing shim calls through the seam (GH#11568)."""
 
         async def _dispatch(tool: str, params: dict) -> Any:
+            from chat_workflow.session_role import DEFAULT_AUTH_ROLE  # noqa: PLC0415
+
             sub_results: list[dict[str, Any]] = []
             sub_call = {"name": tool, "params": params}
-            async for _ in self._dispatch_tool_call(sub_call, session_id, session_id, "", "", sub_results, [], ctx=ctx):
+            # #13821: a tool called from inside a compose script is still the same
+            # authenticated caller. Omitting the role here left this one path on
+            # the "user" default — the very bug this issue fixes, unfixed.
+            role = ctx.auth_role if ctx is not None else DEFAULT_AUTH_ROLE
+            async for _ in self._dispatch_tool_call(
+                sub_call, session_id, session_id, "", "", sub_results, [], ctx=ctx, role=role
+            ):
                 pass
             last = sub_results[-1] if sub_results else {}
             if last.get("status") == "error":

--- a/autobot-backend/tests/orchestration/test_agent_registry_fail_closed.py
+++ b/autobot-backend/tests/orchestration/test_agent_registry_fail_closed.py
@@ -230,8 +230,10 @@ async def test_delegation_still_accepts_an_unregistered_agent_type(monkeypatch):
 
     seen = {}
 
-    async def _fake_engine(task, agent_type, depth):
-        seen.update(task=task, agent_type=agent_type, depth=depth)
+    async def _fake_engine(task, agent_type, depth, auth_role):
+        # #13821: engines take the delegating session's authenticated role as a
+        # 4th argument, so a subagent runs as the user who asked for it.
+        seen.update(task=task, agent_type=agent_type, depth=depth, auth_role=auth_role)
         return "ok"
 
     monkeypatch.setitem(delegation._ENGINES, "claude_code", _fake_engine)
@@ -239,3 +241,4 @@ async def test_delegation_still_accepts_an_unregistered_agent_type(monkeypatch):
     assert await delegation.run_delegated_subtask("t", agent_type="typo_agent") == "ok"
 
     assert seen["agent_type"] == "typo_agent"
+    assert seen["auth_role"] == "user"

--- a/autobot-backend/tests/unit/chat_workflow/test_auth_role_plumbing.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_auth_role_plumbing.py
@@ -127,6 +127,32 @@ class TestTheRoleReachesTheDispatchSeam:
         assert await _roles_forwarded(None) == [DEFAULT_AUTH_ROLE]
 
 
+class TestEverySeamThatReachesDispatch:
+    """Review of #13981: three more paths dropped the role and were left on the default.
+
+    Each one silently reproduced the bug this issue fixes, on its own route.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_tool_called_from_a_compose_script_carries_the_role(self):
+        """The compose shim dispatches through the same seam and must not reset it."""
+        handler = _Recorder()
+        dispatch = handler._build_compose_dispatch("sess-1", SimpleNamespace(auth_role="admin"))
+
+        await dispatch("redis_flushall", {})
+
+        assert handler.seen == ["admin"]
+
+    @pytest.mark.asyncio
+    async def test_a_compose_call_without_a_context_uses_the_default(self):
+        handler = _Recorder()
+        dispatch = handler._build_compose_dispatch("sess-1", None)
+
+        await dispatch("redis_flushall", {})
+
+        assert handler.seen == [DEFAULT_AUTH_ROLE]
+
+
 class TestTheEffectOnAdminOnlyTools:
     """AC: an admin session reaches an admin-only MCP tool; a user session does not.
 

--- a/autobot-backend/tests/unit/chat_workflow/test_auth_role_plumbing.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_auth_role_plumbing.py
@@ -1,0 +1,165 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""The authenticated role must reach MCPDispatcher.dispatch() (#13821).
+
+`dispatch()` takes ``role: str = "user"`` and, before this, nothing in production
+ever passed it. #2629 wired ``role`` as far as ``_dispatch_tool_call``'s signature
+and stopped; ``_process_tool_calls`` had no ``role`` parameter at all, so the
+default won every call.
+
+Two consequences, and the tests below pin both:
+
+- an admin was evaluated as a user and *denied* the admin-only tools they are
+  entitled to — over-restrictive, which is why nobody reported it
+- #13228's shadow inventory could only ever contain ``role="user"`` rows, so the
+  question its stage-3 flip exists to answer was unanswerable
+
+The security direction matters more than the plumbing. ``context`` is the
+caller's own ``request_data["context"]`` bag, so a client can put
+``auth_role: "admin"`` in it. The trusted overlay must therefore *always* write
+or remove that key — never leave the caller's value in place.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from chat_workflow.session_role import (
+    AUTH_ROLE_CONTEXT_KEY,
+    DEFAULT_AUTH_ROLE,
+    apply_auth_role,
+    resolve_auth_role,
+)
+from chat_workflow.tool_handler import ToolHandlerMixin
+
+
+class _Recorder(ToolHandlerMixin):
+    """Captures the role `_process_tool_calls` forwards to the dispatch seam."""
+
+    def __init__(self):
+        self.seen: list[str] = []
+
+    async def _dispatch_tool_call(
+        self,
+        tool_call,
+        session_id,
+        terminal_session_id,
+        ollama_endpoint,
+        selected_model,
+        execution_results,
+        additional_response_parts,
+        ctx=None,
+        role: str = DEFAULT_AUTH_ROLE,
+    ):
+        self.seen.append(role)
+        return
+        yield  # pragma: no cover - makes this an async generator
+
+
+async def _roles_forwarded(ctx) -> list[str]:
+    handler = _Recorder()
+    async for _ in handler._process_tool_calls(
+        [{"name": "redis_flushall", "params": {}}],
+        "sess-1",
+        "term-1",
+        "http://llm",
+        "model",
+        ctx=ctx,
+    ):
+        pass
+    return handler.seen
+
+
+class TestTheTrustedOverlay:
+    """`context` is caller-supplied, so the overlay is a security boundary."""
+
+    def test_a_server_role_overrides_a_client_supplied_one(self):
+        merged = apply_auth_role({AUTH_ROLE_CONTEXT_KEY: "admin"}, "user")
+
+        assert merged[AUTH_ROLE_CONTEXT_KEY] == "user"
+
+    def test_a_missing_server_role_strips_the_client_value(self):
+        """The whole vulnerability in one assertion.
+
+        `apply_role` returns context unchanged on a falsy role. Copying that
+        here would let a caller who writes `auth_role: "admin"` into their own
+        request body keep it — an unauthenticated path would hand the tool seam
+        the privileges the caller named for themselves.
+        """
+        merged = apply_auth_role({AUTH_ROLE_CONTEXT_KEY: "admin", "language": "en"}, None)
+
+        assert AUTH_ROLE_CONTEXT_KEY not in merged
+        assert resolve_auth_role(merged) == DEFAULT_AUTH_ROLE
+        assert merged["language"] == "en", "unrelated context keys must survive"
+
+    def test_the_caller_bag_is_not_mutated(self):
+        original = {AUTH_ROLE_CONTEXT_KEY: "admin"}
+
+        apply_auth_role(original, "user")
+
+        assert original[AUTH_ROLE_CONTEXT_KEY] == "admin", "must copy, not mutate the request bag"
+
+    @pytest.mark.parametrize("bad", [None, "", 123, {"nested": "dict"}, []])
+    def test_a_non_string_or_empty_role_resolves_to_the_default(self, bad):
+        assert resolve_auth_role({AUTH_ROLE_CONTEXT_KEY: bad}) == DEFAULT_AUTH_ROLE
+
+    def test_an_absent_context_resolves_to_the_default(self):
+        assert resolve_auth_role(None) == DEFAULT_AUTH_ROLE
+        assert resolve_auth_role({}) == DEFAULT_AUTH_ROLE
+
+
+class TestTheRoleReachesTheDispatchSeam:
+    """AC: the authenticated role reaches dispatch() from the live chat path."""
+
+    @pytest.mark.asyncio
+    async def test_the_iteration_context_role_is_forwarded(self):
+        assert await _roles_forwarded(SimpleNamespace(auth_role="admin")) == ["admin"]
+
+    @pytest.mark.asyncio
+    async def test_a_non_admin_role_is_forwarded_unchanged(self):
+        """Forwarding must carry whatever the role is, not just recognise admin."""
+        assert await _roles_forwarded(SimpleNamespace(auth_role="analyst")) == ["analyst"]
+
+    @pytest.mark.asyncio
+    async def test_no_iteration_context_falls_back_to_the_default_role(self):
+        assert await _roles_forwarded(None) == [DEFAULT_AUTH_ROLE]
+
+
+class TestTheEffectOnAdminOnlyTools:
+    """AC: an admin session reaches an admin-only MCP tool; a user session does not.
+
+    Exercised against the real `MCPDispatcher` gate rather than a stand-in, since
+    the bug was that this gate never saw a role other than "user".
+    """
+
+    @staticmethod
+    def _dispatcher():
+        from services.mcp_dispatch import MCPDispatcher
+
+        d = MCPDispatcher()
+        d._tool_cache = {"redis_flushall": {"name": "redis_flushall", "bridge": "redis", "endpoint": "/x"}}
+
+        async def _fresh():
+            return None
+
+        async def _call(tool_name, bridge, endpoint, arguments):
+            return {"success": True, "result": "ran", "bridge": bridge}
+
+        d._ensure_cache_fresh = _fresh
+        d._call_bridge = _call
+        return d
+
+    @pytest.mark.asyncio
+    async def test_an_admin_reaches_an_admin_only_tool(self):
+        result = await self._dispatcher().dispatch("redis_flushall", {}, role="admin")
+
+        assert result["success"] is True, "an admin was being denied a tool they are entitled to"
+
+    @pytest.mark.asyncio
+    async def test_a_user_is_denied_an_admin_only_tool(self):
+        result = await self._dispatcher().dispatch("redis_flushall", {}, role=DEFAULT_AUTH_ROLE)
+
+        assert result["success"] is False
+        assert "admin" in str(result["result"]).lower()


### PR DESCRIPTION
Closes #13821

## Thinking Path

`MCPDispatcher.dispatch()` takes `role: str = "user"` and, in production, nothing ever passed it. `_process_tool_calls` had no `role` parameter at all, so the default won every call. #2629 wired `role` as far as `_dispatch_tool_call`'s signature and stopped one hop short.

Two consequences:

- **Today** an admin is evaluated as a user and *denied* the admin-only redis tools they are entitled to. Over-restrictive rather than permissive, which is why nobody reported it — but it means the admin-only gate has never distinguished anybody.
- **For #13228 stage 3**, the shadow inventory the default-deny flip is meant to be planned from could only ever contain `role="user"` rows. This issue is that stage's stated blocker.

### Decision: where the role comes from

The endpoint already has a server-side `current_user`. The request also carries `request_data["context"]`, a **caller-supplied** bag that flows to the tool seam — so the one thing I could not do is read the role from it.

I reused the existing trusted-overlay pattern (`apply_role`, `apply_work_item`) rather than adding a parallel path, with one deliberate difference. `apply_role` returns the context untouched when the server value is absent. Copying that here would be the vulnerability: a caller who writes `auth_role: "admin"` into their own request body would keep it whenever no server-side role resolved. `apply_auth_role` therefore **always writes or removes** the key, so the caller's value never survives.

The role then travels as a dedicated `LLMIterationContext.auth_role` field — not a `context` lookup at the seam — so what reaches `dispatch()` cannot be a client key that slipped through.

## What Changed

- `chat_workflow/session_role.py` — `apply_auth_role` (trusted overlay, strips on absence) and `resolve_auth_role` (reads it back, defaulting to `user`).
- `chat_workflow/manager.py` — `process_message_stream`/`process_message` take `auth_role`; `_apply_session_role` overlays it; `_build_iteration_context` lifts it onto the context object.
- `chat_workflow/graph.py` — the same lift in the graph path, which builds its own `LLMIterationContext`. Omitting it there would have left every graph-path call on the default role, i.e. the bug still present on the live path.
- `chat_workflow/tool_handler.py` — `_process_tool_calls` forwards the role to `_dispatch_tool_call`. This is the hop that was missing.
- `api/chat.py` — passes `current_user["role"]`, explicitly not `request_data`.

## Verification

```
$ pytest autobot-backend/tests/unit/chat_workflow \
         autobot-backend/services/mcp_dispatch_test.py \
         autobot-backend/services/mcp_dispatch_rbac_shadow_test.py -q
362 passed
```

14 new tests. The admin/user pair runs against the real `MCPDispatcher` gate rather than a stand-in, since the bug was precisely that this gate never saw a role other than `user`.

Mutation-tested rather than merely re-run:

| mutation | result |
|---|---|
| overlay copies `apply_role`'s no-strip behaviour (the vulnerability) | KILLED (1) |
| role never forwarded (the original bug) | KILLED (2) |
| `resolve_auth_role` accepts non-strings | KILLED (2) |

Lint: black, isort, flake8 clean.

### Not covered

The fourth AC — "#13228's shadow inventory shows more than one distinct role" — is an **operational** check, not a code one. It needs this change deployed and real traffic from more than one role; the inventory is empty today because there has been no MCP traffic at all. I have not marked that box, and #13228 stage 3 should still not be planned until it has been observed on a running system.

## Model Used

Claude Opus 5