### PR TITLE
docs(code-intelligence): correct stale issue references to #13983 (#13983)

### DIFF
--- a/autobot-backend/code_intelligence/co_change_test.py
+++ b/autobot-backend/code_intelligence/co_change_test.py
@@ -24,7 +24,7 @@ from code_intelligence.code_evolution_miner import GitHistoryCrawler
 
 #: Git environment variables that redirect git away from the repository named
 #: on the command line. Inherited from the CI job, they make every worker's
-#: ``git`` operate on shared state instead of its own tmpdir (#13948).
+#: ``git`` operate on shared state instead of its own tmpdir (#13983).
 _INHERITED_GIT_VARS = (
     "GIT_DIR",
     "GIT_WORK_TREE",
@@ -41,7 +41,7 @@ _INHERITED_GIT_VARS = (
 def _hermetic_git_env() -> dict:
     """A git environment that cannot reach outside the repo passed to ``-C``.
 
-    #13948: with ``GIT_INDEX_FILE`` exported, every xdist worker stages into
+    #13983: with ``GIT_INDEX_FILE`` exported, every xdist worker stages into
     **one** index while committing in its **own** tmpdir repo, so a worker
     commits a tree whose blobs live in another worker's object store:
 
@@ -416,7 +416,7 @@ def test_the_default_window_is_actually_applied():
     assert abs(delta.days - COCHANGE_WINDOW_DAYS) <= 1
 
 
-# ------------------------------------------- the repo named is the repo read (#13948)
+# ------------------------------------------- the repo named is the repo read (#13983)
 
 
 def test_the_crawler_reads_the_repo_it_was_given_not_the_ambient_one(repo, tmp_path, monkeypatch):
@@ -431,7 +431,7 @@ def test_the_crawler_reads_the_repo_it_was_given_not_the_ambient_one(repo, tmp_p
     file is built, ``GIT_DIR`` is pointed at it, and the crawler must still
     report the fixture's files.
     """
-    other = tmp_path.parent / "other_repo_13948"
+    other = tmp_path.parent / "other_repo_13983"
     other.mkdir()
     _git_init(other)
     _git(other, "config", "user.email", "a@b.c")

--- a/autobot-backend/code_intelligence/code_evolution_miner.py
+++ b/autobot-backend/code_intelligence/code_evolution_miner.py
@@ -95,7 +95,7 @@ class PatternLifecycle:
 
 #: Git environment variables that override the repository named on the command
 #: line. Left in place, ``-C repo_path`` becomes advisory and git reads whatever
-#: the ambient environment points at (#13948). A crawler asked to analyse one
+#: the ambient environment points at (#13983). A crawler asked to analyse one
 #: repository must not silently analyse another — the caller gets a plausible
 #: history for the wrong tree, which is worse than an error.
 _REPO_OVERRIDING_GIT_VARS = (


### PR DESCRIPTION
Refs #13983

## Thinking Path

#13949 was written against issue number **#13948**, which belongs to an unrelated open issue (a distillation-cursor DST bug). The number was wrong from the start.

Cause: I filed the issue with

```
gh issue create ... --json number --jq .number || gh issue list --state open --limit 1 --json number --jq '.[0].number'
```

`gh issue create` has no `--json` flag, so it **errored before creating anything** and the `||` fallback returned the newest *existing* issue number. I then used that number without checking it against the title I had just written.

The wrong number reached the PR body, five source comments, and a test fixture directory name — and I compounded it by *closing* #13948 with an evidence comment about `GIT_INDEX_FILE`. It has been reopened with an explanation, and is untouched.

## What Changed

Comments and one identifier. No behaviour change.

| file | refs |
|---|---|
| `code_intelligence/co_change_test.py` | 4 (incl. `other_repo_13948` → `other_repo_13983`) |
| `code_intelligence/code_evolution_miner.py` | 1 |

## Verification

```
autobot-backend/code_intelligence/co_change_test.py .... 25 passed
$ grep -rn 13948 autobot-backend/code_intelligence/
(no matches)
```

## Model Used

claude-opus-5[1m]