### PR TITLE
fix(plugin-sdk): one plugin's code can run under another's manifest and report healthy (#13677)

### DIFF
--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -1873,8 +1873,13 @@ async def _init_plugin_manager(app: FastAPI) -> None:
         ]
 
         plugin_manager = PluginManager(plugin_dirs)
-        await plugin_manager.startup()
+        # #13677: stored BEFORE startup. `completed=False` distinguishes exactly
+        # one thing — a crashed discovery from an empty tree — and on a crash the
+        # manager was discarded before it ever reached app.state, so the only
+        # state that key exists to report was unobservable in production. A
+        # signal nobody can read is the defect this whole issue is about.
         app.state.plugin_manager = plugin_manager
+        await plugin_manager.startup()
         # #13677: the load tally, not just per-plugin statuses. A status map
         # nobody totals is why 0-of-7 read the same as "no plugins installed".
         logger.info(
@@ -1884,6 +1889,11 @@ async def _init_plugin_manager(app: FastAPI) -> None:
         )
     except Exception as pm_err:
         logger.warning("Plugin manager startup failed (non-critical): %s", pm_err, exc_info=True)
+        # Report the tally here too: this is the crashed-discovery path, and it
+        # is the only place `completed=False` can be seen.
+        manager = getattr(app.state, "plugin_manager", None)
+        if manager is not None:
+            logger.warning("PluginManager load report after failure: %s", manager.get_load_report())
 
 
 async def _init_content_reach_registry(app: FastAPI) -> None:

--- a/autobot_shared/plugin_sdk/loader.py
+++ b/autobot_shared/plugin_sdk/loader.py
@@ -91,6 +91,19 @@ def validate_plugin_config(plugin_name: str, config: Dict[str, Any], config_sche
     _validate_config_against_schema(plugin_name, config, config_schema)
 
 
+def is_non_production_module(name: str) -> bool:
+    """True for package modules that must never be imported at plugin-load time.
+
+    Importing the package's own tests drags pytest into the production process
+    (~100ms), and where pytest is absent the import fails, is swallowed, and —
+    because failed imports are not cached — retries for every plugin on every
+    startup. A `conftest.py` would do the same; it has no trigger in this
+    package today, which is exactly why the rule is stated here where it can be
+    tested rather than inlined where it cannot (#13677 review).
+    """
+    return name.endswith("_test") or name.startswith("test_") or name == "conftest"
+
+
 def canonicalise_plugin_sdk() -> List[str]:
     """Make ``plugin_sdk.*`` and ``autobot_shared.plugin_sdk.*`` the SAME modules (#13677).
 
@@ -130,11 +143,7 @@ def canonicalise_plugin_sdk() -> List[str]:
     # ended up holding a SECOND Registry class with its own singleton, undoing
     # what #11636 fixed (#13677 review).
     for _finder, name, _ispkg in pkgutil.iter_modules(canonical.__path__):
-        # Never import the package's own tests: it drags pytest into the
-        # production process (~100ms), and where pytest is absent the import
-        # fails, is swallowed, and — because failed imports are not cached —
-        # retries on every plugin, every startup.
-        if name.endswith("_test") or name.startswith("test_"):
+        if is_non_production_module(name):
             continue
 
         alias = f"plugin_sdk.{name}"
@@ -178,6 +187,8 @@ class PluginLoader:
         self.registry = PluginRegistry()
         # Maps plugin name -> directory containing its plugin.json (set during discover_plugins)
         self._manifest_dirs: Dict[str, Path] = {}
+        #: Plugin names claimed by more than one directory (#13677 review).
+        self.name_conflicts: List[str] = []
 
     def discover_plugins(self) -> List[PluginManifest]:
         """
@@ -187,6 +198,14 @@ class PluginLoader:
             List of plugin manifests found
         """
         manifests = []
+        # name -> resolved dir of the manifest we KEPT. Deduping here rather than
+        # in the caller is the point: `_manifest_dirs` decides which code runs and
+        # the manifest list decides what is registered, so they must agree. When
+        # they disagreed — manifest first-wins in the caller, directory last-wins
+        # here — two plugins sharing a name ran one's CODE under the other's
+        # MANIFEST, and the load report called it healthy (#13677 review).
+        self.name_conflicts = []
+        kept_dirs: Dict[str, Path] = {}
 
         for plugin_dir in self.plugin_dirs:
             if not plugin_dir.exists():
@@ -200,6 +219,34 @@ class PluginLoader:
                         data = json.load(f)
 
                     manifest = PluginManifest(**data)
+                    here = manifest_file.parent.resolve()
+                    already = kept_dirs.get(manifest.name)
+                    if already is not None:
+                        if already == here:
+                            # The same plugin reached twice through overlapping
+                            # plugin_dirs — benign, and the common case: lifespan
+                            # passes the deployed root AND the dev fallback.
+                            logger.debug(
+                                "Plugin %s already discovered at %s — ignoring duplicate path",
+                                manifest.name,
+                                here,
+                            )
+                        else:
+                            # Genuinely different plugins claiming one name. First
+                            # wins, as before; what changes is that it is no longer
+                            # silent.
+                            self.name_conflicts.append(manifest.name)
+                            logger.warning(
+                                "Plugin name conflict: %r found at BOTH %s and %s — "
+                                "keeping the first; the second is ignored entirely, "
+                                "including its code",
+                                manifest.name,
+                                already,
+                                here,
+                            )
+                        continue
+
+                    kept_dirs[manifest.name] = here
                     # Remember where on disk this plugin lives (needed for file-path fallback)
                     self._manifest_dirs[manifest.name] = manifest_file.parent
                     manifests.append(manifest)

--- a/autobot_shared/plugin_sdk/loader.py
+++ b/autobot_shared/plugin_sdk/loader.py
@@ -205,6 +205,11 @@ class PluginLoader:
         # here — two plugins sharing a name ran one's CODE under the other's
         # MANIFEST, and the load report called it healthy (#13677 review).
         self.name_conflicts = []
+        # Reset with them: never cleared, `_manifest_dirs` became a superset of
+        # the manifest list across repeated calls (the /plugins/discover admin
+        # endpoint calls this on a module-level singleton), re-establishing the
+        # very "these two must agree" invariant this method exists to enforce.
+        self._manifest_dirs = {}
         kept_dirs: Dict[str, Path] = {}
 
         for plugin_dir in self.plugin_dirs:
@@ -248,7 +253,7 @@ class PluginLoader:
 
                     kept_dirs[manifest.name] = here
                     # Remember where on disk this plugin lives (needed for file-path fallback)
-                    self._manifest_dirs[manifest.name] = manifest_file.parent
+                    self._manifest_dirs[manifest.name] = here
                     manifests.append(manifest)
                     logger.info("Discovered plugin: %s v%s", manifest.name, manifest.version)
 

--- a/autobot_shared/plugin_sdk/plugin_load_visibility_test.py
+++ b/autobot_shared/plugin_sdk/plugin_load_visibility_test.py
@@ -204,7 +204,9 @@ class TestLoadedNOfM:
             "discovered": 0,
             "loaded": 0,
             "failed": [],
+            "conflicts": [],
             "started": True,
+            "completed": True,
         }
 
     @pytest.mark.asyncio
@@ -322,3 +324,85 @@ class TestCanonicalisationDoesNotSplitTheRegistry:
         canonicalise_plugin_sdk()
 
         assert not [m for m in sys.modules if m.startswith("plugin_sdk.") and m.endswith("_test")]
+
+
+class TestTheReportCannotMisleadTheCaller:
+    """#13677 review: three properties with no test at all."""
+
+    @pytest.mark.asyncio
+    async def test_a_crashed_discovery_is_not_an_empty_tree(self, tmp_path, monkeypatch):
+        """Both report discovered=0, loaded=0. Deriving `started` from the
+        manager's own flag made them byte-identical — "the subsystem delivered
+        nothing" reading exactly like "there is nothing to deliver", which is
+        this issue's headline defect one level up."""
+        manager = PluginManager([tmp_path])
+        monkeypatch.setattr(manager._loader, "discover_plugins", lambda: (_ for _ in ()).throw(RuntimeError("boom")))
+        with pytest.raises(RuntimeError):
+            await manager.startup()
+
+        crashed = manager.get_load_report()
+
+        empty_manager = PluginManager([tmp_path])
+        await empty_manager.startup()
+        empty = empty_manager.get_load_report()
+
+        assert crashed != empty, "a crashed discovery must not look like an empty tree"
+        assert crashed["completed"] is False
+        assert empty["completed"] is True
+
+    @pytest.mark.asyncio
+    async def test_mutating_the_returned_report_cannot_corrupt_the_manager(self, tmp_path):
+        """`dict()` is shallow, so a caller appending to report["failed"] was
+        editing the manager's own tally."""
+        _make_plugin(tmp_path, "copy-guard-plugin", source="raise RuntimeError('boom')\n")
+        manager = PluginManager([tmp_path])
+        await manager.startup()
+
+        manager.get_load_report()["failed"].append("fabricated")
+
+        assert "fabricated" not in manager.get_load_report()["failed"]
+
+    @pytest.mark.asyncio
+    async def test_a_name_claimed_by_two_directories_is_reported(self, tmp_path):
+        """The blocker: manifest first-wins and directory last-wins meant one
+        plugin's CODE ran under another's MANIFEST, reported as loaded 1 of 1
+        with no failures. First still wins; it is no longer silent."""
+        core = tmp_path / "core"
+        community = tmp_path / "community"
+        _make_plugin(core, "collide-demo")
+        _make_plugin(community, "collide-demo")
+
+        manager = PluginManager([core, community])
+        await manager.startup()
+        report = manager.get_load_report()
+
+        assert report["conflicts"] == ["collide-demo"], "a shadowed plugin must be named"
+        assert (
+            manager._loader._manifest_dirs["collide-demo"].resolve() == (core / "collide-demo").resolve()
+        ), "the directory kept must be the one whose manifest was registered"
+
+
+class TestNonProductionModulesAreNeverImported:
+    """The filter's rule, asserted where it can fail.
+
+    Inlined in the alias loop it was untestable: the package has no conftest.py,
+    so the `conftest` clause had no trigger and survived deletion with the whole
+    suite green.
+    """
+
+    @pytest.mark.parametrize(
+        "name",
+        ["plugin_sdk_test", "loader_file_fallback_test", "test_something", "conftest"],
+    )
+    def test_non_production_names_are_skipped(self, name):
+        from autobot_shared.plugin_sdk.loader import is_non_production_module
+
+        assert is_non_production_module(name) is True
+
+    @pytest.mark.parametrize("name", ["base", "registry", "hooks", "loader", "manifest_contract"])
+    def test_real_submodules_are_not_skipped(self, name):
+        """Over-filtering would silently drop a submodule from canonicalisation
+        and reintroduce the split for anything importing it."""
+        from autobot_shared.plugin_sdk.loader import is_non_production_module
+
+        assert is_non_production_module(name) is False

--- a/autobot_shared/plugin_sdk/plugin_load_visibility_test.py
+++ b/autobot_shared/plugin_sdk/plugin_load_visibility_test.py
@@ -406,3 +406,73 @@ class TestNonProductionModulesAreNeverImported:
         from autobot_shared.plugin_sdk.loader import is_non_production_module
 
         assert is_non_production_module(name) is False
+
+
+class TestRepeatedDiscoveryDoesNotAccumulate:
+    """#13988 review: two new lines survived deletion with the suite green.
+
+    The `/plugins/discover` admin endpoint calls `discover_plugins()` repeatedly
+    on a module-level singleton loader, so state that is never reset grows
+    across calls — and `_manifest_dirs` growing past the manifest list
+    re-establishes exactly the "these two must agree" invariant this work exists
+    to enforce.
+    """
+
+    def test_conflicts_do_not_grow_across_calls(self, tmp_path):
+        from autobot_shared.plugin_sdk.loader import PluginLoader
+
+        core, community = tmp_path / "core", tmp_path / "community"
+        _make_plugin(core, "repeat-demo")
+        _make_plugin(community, "repeat-demo")
+        loader = PluginLoader(plugin_dirs=[core, community])
+
+        loader.discover_plugins()
+        first = list(loader.name_conflicts)
+        loader.discover_plugins()
+
+        assert loader.name_conflicts == first, "conflicts accumulated across discovery calls"
+
+    def test_manifest_dirs_never_outlives_its_manifests(self, tmp_path):
+        """A plugin deleted from disk must not leave a stale directory entry —
+        that entry is what the file-path import fallback resolves against."""
+        import shutil
+
+        from autobot_shared.plugin_sdk.loader import PluginLoader
+
+        _make_plugin(tmp_path, "ghost-plugin")
+        loader = PluginLoader(plugin_dirs=[tmp_path])
+        assert loader.discover_plugins()
+
+        shutil.rmtree(tmp_path / "ghost-plugin")
+        manifests = loader.discover_plugins()
+
+        assert manifests == []
+        assert "ghost-plugin" not in loader._manifest_dirs
+
+    @pytest.mark.asyncio
+    async def test_mutating_conflicts_cannot_corrupt_the_manager(self, tmp_path):
+        """Sibling of the `failed` copy guard — same shallow-dict hazard."""
+        core, community = tmp_path / "core", tmp_path / "community"
+        _make_plugin(core, "conflict-copy-demo")
+        _make_plugin(community, "conflict-copy-demo")
+
+        manager = PluginManager([core, community])
+        await manager.startup()
+        manager.get_load_report()["conflicts"].append("fabricated")
+
+        assert "fabricated" not in manager.get_load_report()["conflicts"]
+
+    @pytest.mark.asyncio
+    async def test_three_directories_claiming_one_name_count_once(self, tmp_path):
+        """`conflicts` names shadowed PLUGINS, not shadowed directories — a check
+        doing len() read two where there is one."""
+        dirs = []
+        for name in ("a", "b", "c"):
+            d = tmp_path / name
+            _make_plugin(d, "tri-demo")
+            dirs.append(d)
+
+        manager = PluginManager(dirs)
+        await manager.startup()
+
+        assert manager.get_load_report()["conflicts"] == ["tri-demo"]

--- a/autobot_shared/plugin_sdk/plugin_load_visibility_test.py
+++ b/autobot_shared/plugin_sdk/plugin_load_visibility_test.py
@@ -476,3 +476,20 @@ class TestRepeatedDiscoveryDoesNotAccumulate:
         await manager.startup()
 
         assert manager.get_load_report()["conflicts"] == ["tri-demo"]
+
+    def test_a_relative_plugin_dir_still_stores_an_absolute_path(self, tmp_path, monkeypatch):
+        """lifespan.py's dev fallback passes two RELATIVE plugin dirs, so an
+        unresolved parent let `_synthesise_parent_packages` walk off the top of
+        the path — yielding repeated `.` and pointing a synthesised package's
+        __path__ at the CWD. The nearest existing assertion calls .resolve() on
+        its own left-hand side, so it structurally cannot catch this."""
+        from autobot_shared.plugin_sdk.loader import PluginLoader
+
+        _make_plugin(tmp_path / "core", "rel-demo")
+        monkeypatch.chdir(tmp_path)
+        loader = PluginLoader(plugin_dirs=[Path("core")])
+
+        assert loader.discover_plugins()
+
+        stored = loader._manifest_dirs["rel-demo"]
+        assert stored.is_absolute(), f"stored plugin dir must be resolved, got {stored}"

--- a/autobot_shared/plugin_sdk/plugin_manager.py
+++ b/autobot_shared/plugin_sdk/plugin_manager.py
@@ -46,7 +46,18 @@ class PluginManager:
         # #13677: the load tally, so "is the plugin subsystem working?" is a
         # QUERY and not a log-reading exercise. A stream of per-plugin lines
         # nobody totals is why 0-of-7 and "no plugins installed" looked the same.
-        self._load_report: Dict[str, object] = {"discovered": 0, "loaded": 0, "failed": [], "started": False}
+        self._load_report: Dict[str, object] = {
+            "discovered": 0,
+            "loaded": 0,
+            "failed": [],
+            "conflicts": [],
+            "started": False,
+            # #13677 review: `started` alone made a CRASHED discovery
+            # indistinguishable from an empty tree — both reported
+            # discovered=0, loaded=0, started=True. That is this issue's own
+            # conflation one level up, so the outcome is its own key.
+            "completed": False,
+        }
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -73,7 +84,10 @@ class PluginManager:
         # lands in `failed`: the live config reported discovered=14 with five
         # perfectly-loaded plugins named as casualties. A signal built to end a
         # misdiagnosis must not manufacture one (#13677 review).
-        manifests = self._dedupe_manifests(self._loader.discover_plugins())
+        # The LOADER dedupes now, because it also owns `_manifest_dirs` — the map
+        # that decides which code runs. Deduping in two places with opposite
+        # precedence is what let one plugin's code run under another's manifest.
+        manifests = self._loader.discover_plugins()
         logger.info("PluginManager: discovered %d plugin(s)", len(manifests))
 
         loaded: List[str] = []
@@ -142,7 +156,14 @@ class PluginManager:
         # #13677: reset the tally too — after shutdown the previous run's counts would
         # describe a subsystem that is no longer running, and "loaded 5 of 7"
         # from a dead manager is worse than no answer.
-        self._load_report = {"discovered": 0, "loaded": 0, "failed": [], "started": False}
+        self._load_report = {
+            "discovered": 0,
+            "loaded": 0,
+            "failed": [],
+            "conflicts": [],
+            "started": False,
+            "completed": False,
+        }
         logger.info("PluginManager: shutdown complete")
 
     # ------------------------------------------------------------------
@@ -158,20 +179,6 @@ class PluginManager:
     def plugin_registry(self) -> PluginRegistry:
         """Return the shared PluginRegistry."""
         return self._registry
-
-    @staticmethod
-    def _dedupe_manifests(manifests: List) -> List:
-        """First manifest wins per name, preserving discovery order."""
-        seen: Dict[str, object] = {}
-        for manifest in manifests:
-            seen.setdefault(manifest.name, manifest)
-        duplicates = len(manifests) - len(seen)
-        if duplicates:
-            logger.info(
-                "PluginManager: ignored %d duplicate manifest(s) from overlapping plugin dirs",
-                duplicates,
-            )
-        return list(seen.values())
 
     def _record_load_report(self, manifests: List, loaded: List[str], failed: List[str]) -> None:
         """Emit the `loaded N of M` summary and store it for querying (#13677).
@@ -189,7 +196,9 @@ class PluginManager:
             "discovered": len(manifests),
             "loaded": len(loaded),
             "failed": sorted(failed),
+            "conflicts": sorted(getattr(self._loader, "name_conflicts", [])),
             "started": True,
+            "completed": True,
         }
 
         if not manifests:
@@ -224,10 +233,12 @@ class PluginManager:
         # report["failed"] was mutating the manager's own tally.
         failed = self._load_report.get("failed", [])
         report["failed"] = list(failed) if isinstance(failed, list) else []
-        # Derived, not stored: the stored flag only flips at the END of startup,
-        # so a manager mid-load — or one whose discovery raised — would have
-        # reported started=False while running.
+        # `started` is derived (the manager IS running); `completed` stays
+        # stored. Deriving both made a crashed discovery report exactly like an
+        # empty tree — the conflation this issue exists to remove.
         report["started"] = self._started
+        conflicts = self._load_report.get("conflicts", [])
+        report["conflicts"] = list(conflicts) if isinstance(conflicts, list) else []
         return report
 
     def get_plugin_status(self) -> Dict[str, str]:

--- a/autobot_shared/plugin_sdk/plugin_manager.py
+++ b/autobot_shared/plugin_sdk/plugin_manager.py
@@ -196,7 +196,11 @@ class PluginManager:
             "discovered": len(manifests),
             "loaded": len(loaded),
             "failed": sorted(failed),
-            "conflicts": sorted(getattr(self._loader, "name_conflicts", [])),
+            # set(): three dirs claiming one name appended twice, so a check doing
+            # len(conflicts) read two shadowed plugins where there is one.
+            # Direct attribute access, not getattr-with-default: a duck-typed
+            # loader missing it would have rendered as a clean "no conflicts".
+            "conflicts": sorted(set(self._loader.name_conflicts)),
             "started": True,
             "completed": True,
         }


### PR DESCRIPTION
Refs #13677 — fixes a blocker that **shipped** in PR #13952 (merged `e5be35d0e` at 07:10 today).

## Thinking Path

#13952 merged while its review was still in flight, so this blocker went in with it. The code in
`Dev_new_gui` right now can run one plugin under another plugin's manifest and report it as healthy.

`_dedupe_manifests` (plugin_manager) keeps the **first** manifest per name. `loader._manifest_dirs` keeps the
**last** directory per name. Opposite precedence on the same key. With two distinct plugins sharing a name:

```
INFO  PluginManager: ignored 1 duplicate manifest(s) from overlapping plugin dirs
INFO  Loaded plugin module 'plugins.core_plugins.collide_demo.main'
      from .../community/collide-demo/main.py   <- community's CODE
REPORT: {'discovered': 1, 'loaded': 1, 'failed': [], 'started': True}
```

The registered manifest is core's; the code that ran is community's. Version, entry point, config schema,
required env, capability and trust metadata all describe a different plugin than the one executing — and the
load report calls it perfectly healthy.

Before #13952 the second registration raised "Plugin already registered" and produced an ERROR naming the
plugin. That line was mislabelled (it counted healthy plugins as failures, which #13952 fixed) but it was the
**only** signal, and #13952 replaced it with an INFO line naming neither the plugin nor either path. In a
change whose stated purpose is that a broken subsystem must not look healthy.

## What Changed

Dedupe moved to where `_manifest_dirs` is written, so the manifest that gets registered and the directory
whose code runs can never disagree. The two cases are now distinct:

| case | treatment |
|---|---|
| same resolved path via overlapping `plugin_dirs` | DEBUG — benign, and the common case (`lifespan.py` passes the deployed root *and* the dev fallback) |
| same name, **different** directory | **WARNING** naming the plugin and both paths, surfaced in `get_load_report()["conflicts"]` |

First still wins, so *which* plugin loads is unchanged — it is no longer silent.

Also carried from the same review:

- **`started` was derived**, making a CRASHED discovery byte-identical to an empty tree — both
  `discovered=0, loaded=0, started=True`. That is #13677's own conflation one level up, so the outcome gets
  its own `completed` key.
- `conftest` joins the non-production skip set: a `conftest.py` in this package would drag pytest into the
  production process exactly as the `*_test` modules did. The predicate is extracted to
  `is_non_production_module()` — inlined it had no trigger and survived deletion with the suite green.

## Verification

```
$ pytest autobot_shared/plugin_sdk/ -q
116 passed
```

Every fix mutation-verified — each fails when reverted:

| mutation | result |
|---|---|
| name conflict silent again | **2 failed** |
| derive `completed` from `_started` | **1 failed** |
| shallow-copy the `failed` list | **1 failed** |
| allow `conftest` through the filter | **1 failed** |

Live two-dir shape (what `lifespan.py` passes) still correct:

```
{'discovered': 7, 'loaded': 5, 'failed': ['logger-plugin', 'telemetry-prompt-middleware'],
 'conflicts': [], 'started': True, 'completed': True}
```

Full local gate set before pushing: black, isort, flake8, mypy, and the six repo checkers. mypy caught a
redefinition and a `list(object)` overload during this work.

## Model Used

Claude Opus 5 (1M context)
