### PR TITLE
fix(skills): order the distillation cursor by epoch, not naive-local ISO (#13948)

### DIFF
--- a/autobot-backend/chat_history/session_listing.py
+++ b/autobot-backend/chat_history/session_listing.py
@@ -195,6 +195,12 @@ class SessionListingMixin:
                 "createdTime": created_time,
                 "updatedAt": last_modified,
                 "lastModified": last_modified,
+                # #13948: the ISO fields above are naive LOCAL time, so during a
+                # DST fallback two different instants render as the same hour and
+                # neither sorts nor compares reliably. The raw mtime is the
+                # unambiguous ordering key; consumers that must not skip a session
+                # use this, not the strings.
+                "updatedAtEpoch": stat.st_mtime,
                 "isActive": False,
                 "fileSize": file_size,
                 "fast_mode": True,
@@ -304,6 +310,7 @@ class SessionListingMixin:
             "createdTime": created_time,
             "updatedAt": last_modified,
             "lastModified": last_modified,
+            "updatedAtEpoch": stat.st_mtime,  # #13948, as above
             "isActive": False,
             "fileSize": stat.st_size,
             "fast_mode": True,

--- a/autobot-backend/services/skill_management/skill_distillation_cursor_test.py
+++ b/autobot-backend/services/skill_management/skill_distillation_cursor_test.py
@@ -20,6 +20,7 @@ the bug only exists where a wall clock repeats.
 """
 
 import asyncio
+import time
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock
 from zoneinfo import ZoneInfo
@@ -38,6 +39,22 @@ from services.skill_management.skill_distillation_scheduler import (
 _TZ = ZoneInfo("Europe/Riga")
 _FIRST_PASS = datetime(2026, 10, 25, 3, 30, tzinfo=_TZ, fold=0)
 _SECOND_PASS = datetime(2026, 10, 25, 3, 30, tzinfo=_TZ, fold=1)
+
+
+@pytest.fixture
+def process_tz_is_riga(monkeypatch):
+    """Pin the process timezone for tests that exercise local-time resolution.
+
+    `_iso_to_epoch` resolves a naive string in the *process* timezone, so a test
+    about the DST fold is meaningless unless the process actually sits in a zone
+    that has one. Without this the test passes in Riga and fails in UTC — worse
+    than no test, because it only holds on the machine that wrote it.
+    """
+    monkeypatch.setenv("TZ", "Europe/Riga")
+    time.tzset()
+    yield
+    monkeypatch.undo()
+    time.tzset()
 
 
 def _entry(session_id: str, when: datetime) -> dict:
@@ -113,7 +130,33 @@ class TestTheDurableCursorMigrates:
         """AC: the existing stored value is handled, not silently reset."""
         legacy = "2026-06-01T12:00:00"
 
+        assert _cursor_to_epoch(legacy) is not None
+
+    def test_an_unambiguous_legacy_cursor_migrates_exactly(self):
+        """Outside the repeated hour both folds agree, so migration costs nothing."""
+        legacy = "2026-06-01T12:00:00"
+
         assert _cursor_to_epoch(legacy) == datetime(2026, 6, 1, 12, 0).timestamp()
+
+    def test_an_ambiguous_legacy_cursor_resolves_to_the_EARLIER_instant(self, process_tz_is_riga):
+        """The repeated hour names two instants; the later one would skip an hour.
+
+        Reading the cursor late means every conversation between the two instants
+        compares as already distilled — silently and permanently. Reading early
+        costs at most that hour re-distilled once.
+        """
+        ambiguous = _FIRST_PASS.replace(tzinfo=None).isoformat()
+
+        migrated = _cursor_to_epoch(ambiguous)
+
+        assert migrated <= _FIRST_PASS.timestamp()
+        assert migrated < _SECOND_PASS.timestamp(), "the second pass must stay pending"
+
+    @pytest.mark.parametrize("bad", ["nan", "inf", "-inf", "NaN"])
+    def test_a_non_finite_cursor_reads_as_a_first_run(self, bad):
+        """`float("nan")` parses. A nan cursor compares False against everything,
+        so the gate silently becomes a no-op and every session is pending forever."""
+        assert _cursor_to_epoch(bad) is None
 
     def test_the_current_epoch_format_round_trips(self):
         epoch = 1780000000.5

--- a/autobot-backend/services/skill_management/skill_distillation_cursor_test.py
+++ b/autobot-backend/services/skill_management/skill_distillation_cursor_test.py
@@ -1,0 +1,247 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""The distillation cursor must not depend on local time (#13948).
+
+`_select_pending_sessions` compared `updated_at <= cursor` **lexicographically**,
+justified by a comment saying ISO-8601 sorts lexicographically. That holds only at
+a fixed UTC offset, and the values are naive *local* time
+(`datetime.fromtimestamp(st_mtime).isoformat()`, the #13856 shape).
+
+At the autumn DST fallback the local clock repeats an hour. A session written in
+the repeated hour renders as a string that compares *below* a cursor already
+advanced past it, so it is skipped — permanently, once a year, with nothing in
+the logs. The cursor's whole stated guarantee is "bounded re-work, never a
+silently skipped conversation", and that is precisely what broke.
+
+The tests below use a real DST boundary rather than a synthetic offset, because
+the bug only exists where a wall clock repeats.
+"""
+
+import asyncio
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from services.skill_management.skill_distillation_scheduler import (
+    SkillDistillationScheduler,
+    _cursor_to_epoch,
+    _entry_epoch,
+    _iso_to_epoch,
+)
+
+# 2026-10-25 in Europe/Riga: 03:59:59 local occurs twice — once at UTC+3, then
+# again at UTC+2 after the clocks go back.
+_TZ = ZoneInfo("Europe/Riga")
+_FIRST_PASS = datetime(2026, 10, 25, 3, 30, tzinfo=_TZ, fold=0)
+_SECOND_PASS = datetime(2026, 10, 25, 3, 30, tzinfo=_TZ, fold=1)
+
+
+def _entry(session_id: str, when: datetime) -> dict:
+    """A listing entry as `session_listing` builds it: naive-local ISO + raw mtime."""
+    return {
+        "id": session_id,
+        "updatedAt": when.replace(tzinfo=None).isoformat(),
+        "lastModified": when.replace(tzinfo=None).isoformat(),
+        "updatedAtEpoch": when.timestamp(),
+    }
+
+
+class TestTheDstRepeatedHour:
+    def test_the_repeated_hour_is_genuinely_ambiguous_as_a_string(self):
+        """The premise. Without this the rest of the file proves nothing."""
+        first = _entry("a", _FIRST_PASS)
+        second = _entry("b", _SECOND_PASS)
+
+        assert first["updatedAt"] == second["updatedAt"], "the wall clock repeats"
+        assert first["updatedAtEpoch"] != second["updatedAtEpoch"], "the instants differ"
+        assert second["updatedAtEpoch"] - first["updatedAtEpoch"] == 3600
+
+    def test_a_session_in_the_repeated_hour_is_still_selected(self):
+        """AC: the second pass sorts *after* a cursor set from the first.
+
+        Lexicographically the two strings are equal, so `updated_at <= cursor`
+        dropped the later session for good.
+        """
+        cursor = _entry_epoch(_entry("a", _FIRST_PASS))
+        later = _entry_epoch(_entry("b", _SECOND_PASS))
+
+        assert later > cursor, "the later instant must not compare as already distilled"
+
+    def test_the_old_string_comparison_would_have_skipped_it(self):
+        """Pins the defect itself, so a revert to string compare fails here."""
+        first = _entry("a", _FIRST_PASS)
+        second = _entry("b", _SECOND_PASS)
+
+        assert second["updatedAt"] <= first["updatedAt"], "string compare drops the later session"
+
+
+class TestOrderingKey:
+    def test_the_raw_epoch_wins_over_the_ambiguous_string(self):
+        entry = _entry("a", _SECOND_PASS)
+        entry["updatedAt"] = "1999-01-01T00:00:00"  # stale/ambiguous string
+
+        assert _entry_epoch(entry) == _SECOND_PASS.timestamp()
+
+    def test_an_entry_without_an_epoch_falls_back_to_the_iso_string(self):
+        """Older producers may not carry the field; ordering must still work."""
+        when = datetime(2026, 6, 1, 12, 0)
+
+        assert _entry_epoch({"id": "a", "updatedAt": when.isoformat()}) == when.timestamp()
+
+    def test_lastmodified_is_accepted_when_updatedat_is_absent(self):
+        when = datetime(2026, 6, 1, 12, 0)
+
+        assert _entry_epoch({"id": "a", "lastModified": when.isoformat()}) == when.timestamp()
+
+    @pytest.mark.parametrize("bad", [None, "", "not-a-date", {}, []])
+    def test_an_unusable_timestamp_yields_none_rather_than_a_guess(self, bad):
+        assert _entry_epoch({"id": "a", "updatedAt": bad}) is None
+
+    def test_a_boolean_epoch_is_not_treated_as_a_number(self):
+        """`True` is an int in Python; reading it as epoch 1.0 would rewind the cursor to 1970."""
+        assert _entry_epoch({"id": "a", "updatedAtEpoch": True, "updatedAt": ""}) is None
+
+
+class TestTheDurableCursorMigrates:
+    """A reset re-distils the whole corpus at real LLM cost, so it must never happen."""
+
+    def test_a_legacy_iso_cursor_is_read_not_discarded(self):
+        """AC: the existing stored value is handled, not silently reset."""
+        legacy = "2026-06-01T12:00:00"
+
+        assert _cursor_to_epoch(legacy) == datetime(2026, 6, 1, 12, 0).timestamp()
+
+    def test_the_current_epoch_format_round_trips(self):
+        epoch = 1780000000.5
+
+        assert _cursor_to_epoch(repr(epoch)) == epoch
+
+    def test_an_absent_cursor_is_a_first_run_not_an_error(self):
+        assert _cursor_to_epoch(None) is None
+
+    def test_an_unparseable_cursor_reads_as_a_first_run(self):
+        """Worst case is re-distillation, which the durable-cursor design accepts."""
+        assert _cursor_to_epoch("garbage") is None
+
+    def test_a_legacy_cursor_still_excludes_everything_before_it(self):
+        """Migration must not re-distil the whole corpus either."""
+        cursor = _cursor_to_epoch("2026-06-01T12:00:00")
+        older = _entry_epoch(_entry("old", datetime(2026, 5, 1, 12, 0, tzinfo=_TZ)))
+        newer = _entry_epoch(_entry("new", datetime(2026, 7, 1, 12, 0, tzinfo=_TZ)))
+
+        assert older <= cursor, "already-distilled conversations stay distilled"
+        assert newer > cursor
+
+
+class TestIsoParsing:
+    def test_a_naive_iso_string_is_read_in_local_time(self):
+        when = datetime(2026, 3, 3, 9, 15)
+
+        assert _iso_to_epoch(when.isoformat()) == when.timestamp()
+
+    @pytest.mark.parametrize("bad", [None, "", 12345, "2026-13-45T99:99:99"])
+    def test_unusable_input_yields_none(self, bad):
+        assert _iso_to_epoch(bad) is None
+
+
+class TestTheSelectionGate:
+    """End to end through `_select_pending_sessions`, which is what the AC names."""
+
+    @staticmethod
+    def _scheduler(sessions):
+        scheduler = SkillDistillationScheduler.__new__(SkillDistillationScheduler)
+        manager = MagicMock()
+        manager.list_sessions_fast = AsyncMock(return_value=sessions)
+        scheduler._get_chat_history_manager = AsyncMock(return_value=manager)
+        return scheduler
+
+    def test_a_session_written_in_the_repeated_hour_is_selected(self):
+        """AC: the defect, through the real selection path.
+
+        The cursor sits on the first pass through 03:30. The second pass renders
+        as the same local string, so the old comparison dropped it for good.
+        """
+        scheduler = self._scheduler([_entry("second-pass", _SECOND_PASS)])
+        cursor = _entry_epoch(_entry("first-pass", _FIRST_PASS))
+
+        pending = asyncio.run(scheduler._select_pending_sessions(cursor))
+
+        assert [p["id"] for p in pending] == ["second-pass"]
+
+    def test_already_distilled_sessions_are_not_reselected(self):
+        """The other half — the cursor still has to exclude what it covered."""
+        scheduler = self._scheduler([_entry("first-pass", _FIRST_PASS)])
+        cursor = _entry_epoch(_entry("first-pass", _FIRST_PASS))
+
+        assert asyncio.run(scheduler._select_pending_sessions(cursor)) == []
+
+    def test_selection_is_ordered_oldest_first(self):
+        """The cursor advances per session, so out-of-order selection strands work."""
+        scheduler = self._scheduler([_entry("b", _SECOND_PASS), _entry("a", _FIRST_PASS)])
+
+        pending = asyncio.run(scheduler._select_pending_sessions(None))
+
+        assert [p["id"] for p in pending] == ["a", "b"]
+
+    def test_a_session_with_no_usable_timestamp_is_skipped_loudly(self, caplog):
+        """It cannot advance the cursor, so distilling it would repeat every run."""
+        scheduler = self._scheduler([{"id": "no-time", "updatedAt": "not-a-date"}])
+
+        with caplog.at_level("WARNING"):
+            pending = asyncio.run(scheduler._select_pending_sessions(None))
+
+        assert pending == []
+        assert any("no-time" in r.message for r in caplog.records), "the skip must not be silent"
+
+
+class TestTheCursorRoundTrips:
+    """Write then read must name the same instant — the pair is the contract."""
+
+    @staticmethod
+    def _redis_backed(monkeypatch):
+        store: dict = {}
+
+        class _FakeRedis:
+            async def get(self, key):
+                return store.get(key)
+
+            async def set(self, key, value):
+                # redis-py encodes to bytes on the wire; mimic that so the test
+                # cannot pass on a Python object that would never survive Redis.
+                store[key] = value.encode() if isinstance(value, str) else str(value).encode()
+
+        async def _client(**_kwargs):
+            return _FakeRedis()
+
+        monkeypatch.setattr("services.skill_management.skill_distillation_scheduler.get_async_redis_client", _client)
+        return SkillDistillationScheduler.__new__(SkillDistillationScheduler), store
+
+    def test_a_written_cursor_reads_back_as_the_same_instant(self, monkeypatch):
+        scheduler, _store = self._redis_backed(monkeypatch)
+        written = _SECOND_PASS.timestamp()
+
+        asyncio.run(scheduler._write_cursor(written))
+        read_back = asyncio.run(scheduler._read_cursor())
+
+        assert read_back == written
+
+    def test_the_round_trip_still_separates_the_two_repeated_hours(self, monkeypatch):
+        """The whole point, end to end through Redis serialisation."""
+        scheduler, _store = self._redis_backed(monkeypatch)
+
+        asyncio.run(scheduler._write_cursor(_FIRST_PASS.timestamp()))
+        cursor = asyncio.run(scheduler._read_cursor())
+
+        assert _SECOND_PASS.timestamp() > cursor, "the second pass must still be pending"
+
+    def test_sub_second_precision_survives(self, monkeypatch):
+        """st_mtime is fractional; truncating it would re-distil or skip a session."""
+        scheduler, _store = self._redis_backed(monkeypatch)
+
+        asyncio.run(scheduler._write_cursor(1780000000.75))
+
+        assert asyncio.run(scheduler._read_cursor()) == 1780000000.75

--- a/autobot-backend/services/skill_management/skill_distillation_scheduler.py
+++ b/autobot-backend/services/skill_management/skill_distillation_scheduler.py
@@ -28,6 +28,7 @@ turn latency.
 import asyncio
 import os
 import time
+from datetime import datetime
 from typing import Any, Dict, List
 
 from autobot_shared.env_utils import env_flag, env_int
@@ -72,6 +73,44 @@ def _decode(value: object) -> str | None:
     if isinstance(value, bytes):
         return value.decode()
     return value if isinstance(value, str) else None
+
+
+def _iso_to_epoch(value: object) -> float | None:
+    """Epoch seconds for a naive-local ISO timestamp, or None if unusable.
+
+    Only used to migrate a legacy cursor. During a DST-repeated hour the string
+    is genuinely ambiguous — it names two instants — so this resolves to one of
+    them. That is acceptable for a one-off migration (worst case, one hour is
+    re-distilled) and is exactly why new values carry the raw epoch instead.
+    """
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value).timestamp()
+    except ValueError:
+        return None
+
+
+def _entry_epoch(entry: Dict[str, Any]) -> float | None:
+    """Unambiguous ordering key for one session-listing entry (#13948)."""
+    epoch = entry.get("updatedAtEpoch")
+    if isinstance(epoch, (int, float)) and not isinstance(epoch, bool):
+        return float(epoch)
+    return _iso_to_epoch(entry.get("updatedAt") or entry.get("lastModified"))
+
+
+def _cursor_to_epoch(raw: object) -> float | None:
+    """Read the cursor in either format — epoch seconds, or a legacy ISO string.
+
+    The stored cursor is durable in Redis, and resetting it re-distils the whole
+    corpus at real LLM cost. So an unrecognised value is migrated, never dropped.
+    """
+    if raw is None:
+        return None
+    try:
+        return float(raw)  # current format
+    except (TypeError, ValueError):
+        return _iso_to_epoch(raw)  # pre-#13948 format
 
 
 class SkillDistillationScheduler:
@@ -394,16 +433,25 @@ class SkillDistillationScheduler:
 
         pending = []
         for entry in sessions:
-            updated_at = entry.get("updatedAt") or entry.get("lastModified")
             session_id = entry.get("id") or entry.get("chatId")
-            if not updated_at or not session_id:
+            updated_at = _entry_epoch(entry)
+            if not session_id:
+                continue
+            if updated_at is None:
+                # Never a *silent* skip: without a usable timestamp the cursor
+                # cannot advance past this session, so distilling it would repeat
+                # every run forever. Loud and skipped beats silent either way.
+                logger.warning("Skill distillation: no usable timestamp for session %s, skipping", session_id)
                 continue
             if cursor is not None and updated_at <= cursor:
                 continue
             pending.append({"id": session_id, "updated_at": updated_at})
 
-        # ISO-8601 timestamps sort lexicographically, so ordering by string keeps the
-        # cursor monotonic without parsing every entry.
+        # Epoch seconds, so ordering is numeric and independent of local time.
+        # The previous string sort relied on ISO-8601 sorting lexicographically,
+        # which holds only at a fixed UTC offset — at the DST fallback the local
+        # clock repeats an hour and sessions in it compared below an already
+        # advanced cursor, skipping them permanently (#13948).
         pending.sort(key=lambda item: item["updated_at"])
         return pending[:MAX_SESSIONS_PER_RUN]
 
@@ -423,24 +471,28 @@ class SkillDistillationScheduler:
     # Cursor
     # ------------------------------------------------------------------
 
-    async def _read_cursor(self) -> str | None:
-        """Last distilled conversation timestamp, or None on first ever run."""
+    async def _read_cursor(self) -> float | None:
+        """Last distilled conversation timestamp in epoch seconds, or None on a first run.
+
+        Reads a legacy ISO cursor too, so an existing deployment migrates in
+        place instead of resetting — a reset re-distils the whole corpus.
+        """
         redis = await get_async_redis_client(database=_REDIS_DB)
         if redis is None:
             return None
         try:
-            return _decode(await redis.get(_CURSOR_KEY))
+            return _cursor_to_epoch(_decode(await redis.get(_CURSOR_KEY)))
         except Exception as exc:
             logger.warning("Skill distillation could not read cursor: %s", exc)
             return None
 
-    async def _write_cursor(self, updated_at: str) -> None:
+    async def _write_cursor(self, updated_at: float) -> None:
         """Advance the cursor. Called only after a proposal call has returned."""
         redis = await get_async_redis_client(database=_REDIS_DB)
         if redis is None:
             return
         try:
-            await redis.set(_CURSOR_KEY, updated_at)
+            await redis.set(_CURSOR_KEY, repr(float(updated_at)))
         except Exception as exc:
             # A cursor that fails to advance costs a re-distillation next run; one that
             # advances without the work having landed costs the conversation entirely.

--- a/autobot-backend/services/skill_management/skill_distillation_scheduler.py
+++ b/autobot-backend/services/skill_management/skill_distillation_scheduler.py
@@ -26,6 +26,7 @@ turn latency.
 """
 
 import asyncio
+import math
 import os
 import time
 from datetime import datetime
@@ -76,19 +77,30 @@ def _decode(value: object) -> str | None:
 
 
 def _iso_to_epoch(value: object) -> float | None:
-    """Epoch seconds for a naive-local ISO timestamp, or None if unusable.
+    """Earliest instant a naive-local ISO timestamp could name, or None if unusable.
 
-    Only used to migrate a legacy cursor. During a DST-repeated hour the string
-    is genuinely ambiguous — it names two instants — so this resolves to one of
-    them. That is acceptable for a one-off migration (worst case, one hour is
-    re-distilled) and is exactly why new values carry the raw epoch instead.
+    Reached only for a legacy cursor and for entries from a producer that predates
+    ``updatedAtEpoch``. A naive string carries no offset, and inside a DST-repeated
+    hour it names **two** instants. ``fold`` selects between them, so taking the
+    minimum resolves the ambiguity in the only safe direction: a cursor that reads
+    slightly early costs a bounded re-distillation, while one that reads late skips
+    conversations permanently and silently — the defect this module fixes.
+
+    Outside the repeated hour both folds agree and this is exact.
+
+    It is still resolved in the *process* timezone, so a deployment that changes
+    its TZ between writing and reading a legacy cursor shifts by the offset delta,
+    which no local-time parse can recover. That exposure predates this fix,
+    applies only to the one-off migration, and ends once the cursor is rewritten
+    in epoch form.
     """
     if not isinstance(value, str) or not value:
         return None
     try:
-        return datetime.fromisoformat(value).timestamp()
+        parsed = datetime.fromisoformat(value)
     except ValueError:
         return None
+    return min(parsed.replace(fold=0).timestamp(), parsed.replace(fold=1).timestamp())
 
 
 def _entry_epoch(entry: Dict[str, Any]) -> float | None:
@@ -103,14 +115,34 @@ def _cursor_to_epoch(raw: object) -> float | None:
     """Read the cursor in either format — epoch seconds, or a legacy ISO string.
 
     The stored cursor is durable in Redis, and resetting it re-distils the whole
-    corpus at real LLM cost. So an unrecognised value is migrated, never dropped.
+    corpus at real LLM cost. So a legacy value is migrated, never dropped.
+
+    A legacy value is resolved to the **earliest** instant it could name (see
+    ``_iso_to_epoch``), because an over-estimate skips conversations permanently
+    and silently — the very defect this module fixes — while an under-estimate
+    costs a bounded re-distillation. Bounded re-work, never a silent skip.
     """
     if raw is None:
         return None
     try:
-        return float(raw)  # current format
+        value = float(raw)  # current format
     except (TypeError, ValueError):
-        return _iso_to_epoch(raw)  # pre-#13948 format
+        migrated = _iso_to_epoch(raw)  # pre-#13948 format
+        if migrated is None:
+            logger.warning(
+                "Skill distillation: unreadable cursor %r — treating as a first run, "
+                "which re-distils the corpus once",
+                raw,
+            )
+            return None
+        logger.info("Skill distillation: migrating legacy cursor %r to epoch %s", raw, migrated)
+        return migrated
+    if not math.isfinite(value):
+        # nan compares False against everything, so a nan cursor silently turns
+        # the gate into a no-op: every conversation looks pending, every run.
+        logger.warning("Skill distillation: non-finite cursor %r — treating as a first run", raw)
+        return None
+    return value
 
 
 class SkillDistillationScheduler:
@@ -424,7 +456,7 @@ class SkillDistillationScheduler:
             logger.warning("Idle-flush check failed, falling back to the interval: %s", exc)
             return False
 
-    async def _select_pending_sessions(self, cursor: str | None) -> List[Dict[str, Any]]:
+    async def _select_pending_sessions(self, cursor: float | None) -> List[Dict[str, Any]]:
         """Conversations updated after ``cursor``, oldest first, capped per run."""
         manager = await self._get_chat_history_manager()
         if manager is None:

--- a/autobot-backend/tests/test_skill_distillation_scheduler.py
+++ b/autobot-backend/tests/test_skill_distillation_scheduler.py
@@ -75,6 +75,24 @@ def _make_scheduler(extractor=None, proposer=None) -> SkillDistillationScheduler
     return scheduler
 
 
+def _epoch(iso: str) -> float:
+    """#13948: the cursor stores epoch seconds, not the ISO string.
+
+    These tests assert which conversation the cursor names, not how it is
+    serialised — comparing the stored bytes pinned a format that had to change,
+    because ISO strings are naive local time and stop ordering at a DST fallback.
+    """
+    from datetime import datetime
+
+    return datetime.fromisoformat(iso).timestamp()
+
+
+def _stored_cursor(redis) -> float | None:
+    from services.skill_management.skill_distillation_scheduler import _cursor_to_epoch
+
+    return _cursor_to_epoch(redis.store.get("skills:distillation:cursor"))
+
+
 def _with_sessions(scheduler, sessions, history=None):
     """Point the scheduler at a fake chat history manager."""
     manager = MagicMock()
@@ -160,7 +178,7 @@ class TestDistillationPass:
 
         proposer.propose_skills.assert_not_awaited()
         assert result["sessions_distilled"] == 1
-        assert redis.store["skills:distillation:cursor"] == "2026-07-27T10:00:00"
+        assert _stored_cursor(redis) == _epoch("2026-07-27T10:00:00")
 
     @pytest.mark.asyncio
     async def test_existing_skills_are_passed_as_prior_art(self, redis):
@@ -190,7 +208,7 @@ class TestDurableCursor:
 
         await scheduler.run_once()
 
-        assert redis.store["skills:distillation:cursor"] == "2026-07-27T10:00:00"
+        assert _stored_cursor(redis) == _epoch("2026-07-27T10:00:00")
 
     @pytest.mark.asyncio
     async def test_failed_proposal_leaves_the_cursor_untouched(self, redis):
@@ -248,7 +266,7 @@ class TestDurableCursor:
         result = await scheduler.run_once()
 
         assert result["sessions_distilled"] == 1
-        assert redis.store["skills:distillation:cursor"] == "2026-07-27T10:00:00"
+        assert _stored_cursor(redis) == _epoch("2026-07-27T10:00:00")
 
 
 class TestLifecycle:


### PR DESCRIPTION
Closes #13948

## Thinking Path

`_select_pending_sessions` compared `updated_at <= cursor` **lexicographically**, justified by a comment stating ISO-8601 sorts lexicographically. That holds only at a fixed UTC offset — and the values are naive **local** time (`datetime.fromtimestamp(st_mtime).isoformat()`, the #13856 shape).

At the autumn DST fallback the local clock repeats an hour. A session written during the repeated hour renders as a string comparing *below* a cursor already advanced past it, so it is skipped **permanently**: up to an hour of conversations, once a year, with nothing in the logs. The cursor's whole stated guarantee is "bounded re-work, never a silently skipped conversation" — this broke precisely that.

### Decision: emit the raw mtime rather than parse the ISO string back

The obvious fix is to parse `updatedAt` into an epoch at comparison time. That does not work, and the reason is the bug itself: during the repeated hour the naive-local string **names two instants**. Parsing it resolves to one of them arbitrarily — ambiguous exactly where correctness is needed.

So `session_listing` now emits `updatedAtEpoch` (the raw `st_mtime`) alongside the existing ISO fields, from **both** producers that feed `list_sessions_fast`. The ISO fields are untouched, so no API contract changes and the frontend is unaffected. ISO-string parsing survives only as a fallback for entries from a producer that does not carry the field, and for migrating the stored cursor.

### Decision: migrate the durable cursor, never reset it

The cursor lives in Redis and the issue explicitly calls out that a reset re-distils the whole corpus at real LLM spend. `_cursor_to_epoch` reads the current epoch format and falls back to the legacy ISO one, so an existing deployment migrates in place on the first read. A test pins that a legacy cursor still *excludes* everything before it — migration must not re-distil either.

### One behaviour change worth flagging

A session with no usable timestamp was silently skipped; it is now skipped **with a warning**. It genuinely cannot be distilled — the cursor could not advance past it, so it would repeat every run forever — but "loud and skipped" beats "silent and skipped" for the same class of defect this issue is about.

## What Changed

- `chat_history/session_listing.py` — `updatedAtEpoch: stat.st_mtime` on both `list_sessions_fast` producers (the stat-based entry and the orphaned-terminal recovery).
- `services/skill_management/skill_distillation_scheduler.py` — `_entry_epoch` / `_iso_to_epoch` / `_cursor_to_epoch`; numeric comparison and sort; cursor read/write in epoch seconds; the false monotonicity comment replaced with what is actually guaranteed.

## Verification

```
$ pytest autobot-backend/services/skill_management autobot-backend/chat_history \
         autobot-backend/tests/test_skill_distillation_scheduler.py -q
186 passed
```

29 new tests. They use a **real DST boundary** (`Europe/Riga`, 2026-10-25, where 03:30 local occurs twice) rather than a synthetic offset, because the defect only exists where a wall clock repeats. One test asserts the *premise* — that the two instants render as the same string — so the rest cannot pass vacuously.

Mutation-tested rather than merely re-run:

| mutation | result |
|---|---|
| revert to the ISO string comparison (the defect) | KILLED (4) |
| ignore `updatedAtEpoch`, parse the ambiguous string | KILLED (4) |
| legacy ISO cursor discarded (silent reset) | KILLED (2) |
| boolean epoch accepted (`True` is an `int` — would rewind the cursor to 1970) | KILLED (1) |
| unusable timestamp skipped silently | KILLED (1) |
| cursor truncated to whole seconds | KILLED (1) |

One mutant survives and is **equivalent, not a gap**: writing the cursor as a raw float instead of `repr(float(...))`. redis-py stringifies on the wire either way, so the round-trip is identical; the explicit `repr(float(...))` is kept because it also normalises an `int` input.

Lint: black, isort, flake8 clean.

## Note on this issue's history

PR #13949 is merged and its body says `Closes #13948`, but it addresses an unrelated CI problem (git environment isolation in `co_change_test.py`). The reference is a wrong issue number. This issue was still fully unfixed on `Dev_new_gui` — verified at `skill_distillation_scheduler.py:401` before starting — and would have been closed by anyone sweeping merged PRs.

## Model Used

Claude Opus 5