### PR TITLE
feat(llc): contact entity — humans in a process with no account, never able to log in (#13969)

### DIFF
--- a/autobot-backend/llc/api/__init__.py
+++ b/autobot-backend/llc/api/__init__.py
@@ -17,6 +17,7 @@ from .boards import router as boards_router
 from .budget import cost_events_router, costs_by_model_router
 from .budget import router as budget_router
 from .companies import router as companies_router
+from .contacts import router as contacts_router
 from .context import router as context_router
 from .controls import router as controls_router
 from .costs import router as costs_router
@@ -49,6 +50,7 @@ router.include_router(budget_router)
 router.include_router(cost_events_router)
 router.include_router(costs_by_model_router)
 router.include_router(companies_router)
+router.include_router(contacts_router)
 router.include_router(agent_hires_router)
 router.include_router(goals_router)
 router.include_router(health_router)

--- a/autobot-backend/llc/api/contacts.py
+++ b/autobot-backend/llc/api/contacts.py
@@ -24,12 +24,13 @@ inside one AutoBot installation are organisational units, not separate
 tenants (umbrella #13935 owner correction).
 """
 
+import re
 import uuid
 from datetime import datetime
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, EmailStr, Field, field_validator
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.user_management.dependencies import get_current_user, require_org_context
@@ -44,9 +45,32 @@ router = APIRouter(prefix="/contacts", tags=["llc-contacts"])
 
 _get_svc = lazy_singleton(ContactService)
 
+# Conservative allow-list — digits, leading +, spaces, and the punctuation a
+# phone number legitimately contains. Never free text: a contact's phone
+# field must not become a place to smuggle arbitrary strings.
+_PHONE_PATTERN = re.compile(r"^\+?[0-9()\-.\s]{3,64}$")
+_NOTES_MAX_LENGTH = 2000
+
 
 def _svc() -> ContactService:
     return _get_svc()
+
+
+def _actor_id(current_user: dict) -> uuid.UUID:
+    """Derive the acting user's id from the authenticated session, never the
+    client-supplied body/query (#13969 review M1 — a client-supplied ``actor``
+    let the audit trail's actor identity and USER/SYSTEM discriminator be
+    whatever the caller typed, and an unparseable value was an unhandled 500
+    in ``ActivityLogService.record``)."""
+    raw = current_user.get("id") or current_user.get("user_id")
+    return uuid.UUID(str(raw))
+
+
+def _strip_full_name(value: str) -> str:
+    stripped = value.strip()
+    if not stripped:
+        raise ValueError("full_name must not be blank")
+    return stripped
 
 
 # ------------------------------------------------------------------ Schemas
@@ -54,19 +78,22 @@ def _svc() -> ContactService:
 
 class ContactCreate(BaseModel):
     full_name: str = Field(..., min_length=1, max_length=255)
-    email: Optional[str] = Field(None, max_length=320)
-    phone: Optional[str] = Field(None, max_length=64)
+    email: Optional[EmailStr] = Field(None, max_length=320)
+    phone: Optional[str] = Field(None, pattern=_PHONE_PATTERN.pattern, max_length=64)
     role_title: Optional[str] = Field(None, max_length=255)
-    notes: Optional[str] = None
-    actor: Optional[str] = Field(None, description="User ID performing the operation")
+    notes: Optional[str] = Field(None, max_length=_NOTES_MAX_LENGTH)
+
+    _strip_full_name = field_validator("full_name")(_strip_full_name)
 
 
 class ContactUpdate(BaseModel):
     full_name: Optional[str] = Field(None, min_length=1, max_length=255)
-    email: Optional[str] = Field(None, max_length=320)
-    phone: Optional[str] = Field(None, max_length=64)
+    email: Optional[EmailStr] = Field(None, max_length=320)
+    phone: Optional[str] = Field(None, pattern=_PHONE_PATTERN.pattern, max_length=64)
     role_title: Optional[str] = Field(None, max_length=255)
-    notes: Optional[str] = None
+    notes: Optional[str] = Field(None, max_length=_NOTES_MAX_LENGTH)
+
+    _strip_full_name = field_validator("full_name")(lambda v: _strip_full_name(v) if v is not None else v)
 
 
 class ContactResponse(BaseModel):
@@ -115,7 +142,7 @@ async def create_contact(
         phone=body.phone,
         role_title=body.role_title,
         notes=body.notes,
-        actor=body.actor,
+        actor=_actor_id(_current_user),
     )
     await session.commit()
     return ContactResponse.model_validate(contact)
@@ -147,7 +174,7 @@ async def update_contact(
 ) -> ContactResponse:
     assert_company_access(ctx, company_id)
     updates = body.model_dump(exclude_unset=True)
-    contact = await _svc().update(session, company_id, contact_id, **updates)
+    contact = await _svc().update(session, company_id, contact_id, actor=_actor_id(_current_user), **updates)
     if contact is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Contact not found")
     await session.commit()
@@ -158,14 +185,13 @@ async def update_contact(
 async def delete_contact(
     company_id: uuid.UUID,
     contact_id: uuid.UUID,
-    actor: Optional[str] = None,
     session: AsyncSession = Depends(get_async_session),
     _current_user: dict = Depends(get_current_user),
     ctx: TenantContext = Depends(require_org_context),
 ) -> None:
     """Permanently delete the contact — its PII no longer exists at rest afterward."""
     assert_company_access(ctx, company_id)
-    deleted = await _svc().delete(session, company_id, contact_id, actor=actor)
+    deleted = await _svc().delete(session, company_id, contact_id, actor=_actor_id(_current_user))
     if not deleted:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Contact not found")
     await session.commit()

--- a/autobot-backend/llc/api/contacts.py
+++ b/autobot-backend/llc/api/contacts.py
@@ -1,0 +1,171 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""LLC company-scoped contact API routes (#13969).
+
+Route group: /llc/contacts/{company_id}
+  GET    /                  — list a company's contacts
+  POST   /                  — create a contact
+  GET    /{contact_id}      — get one contact
+  PATCH  /{contact_id}      — update contact fields
+  DELETE /{contact_id}      — permanently delete a contact and its PII
+
+A contact is a human in a process (supplier, customer) with no account and
+no login path — see ``llc/models/contact.py`` module docstring. These routes
+never touch ``users``, sessions, or auth.
+
+Scoping: the {company_id} path parameter is checked against the caller's
+``TenantContext.org_id`` via ``assert_company_access`` (#12238), the same
+shared guard every other LLC router uses (companies.py, goals.py,
+backlog.py, ...). This scopes the *view* to the requesting company — it is
+not a security/tenant-isolation boundary between customers, since companies
+inside one AutoBot installation are organisational units, not separate
+tenants (umbrella #13935 owner correction).
+"""
+
+import uuid
+from datetime import datetime
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.user_management.dependencies import get_current_user, require_org_context
+from autobot_shared.singleton_factory import lazy_singleton
+from llc.deps import assert_company_access
+from user_management.database import get_async_session
+from user_management.services import TenantContext
+
+from ..services.contact import ContactService
+
+router = APIRouter(prefix="/contacts", tags=["llc-contacts"])
+
+_get_svc = lazy_singleton(ContactService)
+
+
+def _svc() -> ContactService:
+    return _get_svc()
+
+
+# ------------------------------------------------------------------ Schemas
+
+
+class ContactCreate(BaseModel):
+    full_name: str = Field(..., min_length=1, max_length=255)
+    email: Optional[str] = Field(None, max_length=320)
+    phone: Optional[str] = Field(None, max_length=64)
+    role_title: Optional[str] = Field(None, max_length=255)
+    notes: Optional[str] = None
+    actor: Optional[str] = Field(None, description="User ID performing the operation")
+
+
+class ContactUpdate(BaseModel):
+    full_name: Optional[str] = Field(None, min_length=1, max_length=255)
+    email: Optional[str] = Field(None, max_length=320)
+    phone: Optional[str] = Field(None, max_length=64)
+    role_title: Optional[str] = Field(None, max_length=255)
+    notes: Optional[str] = None
+
+
+class ContactResponse(BaseModel):
+    id: uuid.UUID
+    company_id: uuid.UUID
+    full_name: str
+    email: Optional[str]
+    phone: Optional[str]
+    role_title: Optional[str]
+    notes: Optional[str]
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+# ------------------------------------------------------------------ Routes
+
+
+@router.get("/{company_id}", response_model=List[ContactResponse])
+async def list_contacts(
+    company_id: uuid.UUID,
+    session: AsyncSession = Depends(get_async_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
+) -> List[ContactResponse]:
+    assert_company_access(ctx, company_id)
+    contacts = await _svc().list_by_company(session, company_id)
+    return [ContactResponse.model_validate(c) for c in contacts]
+
+
+@router.post("/{company_id}", response_model=ContactResponse, status_code=status.HTTP_201_CREATED)
+async def create_contact(
+    company_id: uuid.UUID,
+    body: ContactCreate,
+    session: AsyncSession = Depends(get_async_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
+) -> ContactResponse:
+    assert_company_access(ctx, company_id)
+    contact = await _svc().create(
+        session,
+        company_id,
+        body.full_name,
+        email=body.email,
+        phone=body.phone,
+        role_title=body.role_title,
+        notes=body.notes,
+        actor=body.actor,
+    )
+    await session.commit()
+    return ContactResponse.model_validate(contact)
+
+
+@router.get("/{company_id}/{contact_id}", response_model=ContactResponse)
+async def get_contact(
+    company_id: uuid.UUID,
+    contact_id: uuid.UUID,
+    session: AsyncSession = Depends(get_async_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
+) -> ContactResponse:
+    assert_company_access(ctx, company_id)
+    contact = await _svc().get(session, company_id, contact_id)
+    if contact is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Contact not found")
+    return ContactResponse.model_validate(contact)
+
+
+@router.patch("/{company_id}/{contact_id}", response_model=ContactResponse)
+async def update_contact(
+    company_id: uuid.UUID,
+    contact_id: uuid.UUID,
+    body: ContactUpdate,
+    session: AsyncSession = Depends(get_async_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
+) -> ContactResponse:
+    assert_company_access(ctx, company_id)
+    updates = body.model_dump(exclude_unset=True)
+    contact = await _svc().update(session, company_id, contact_id, **updates)
+    if contact is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Contact not found")
+    await session.commit()
+    return ContactResponse.model_validate(contact)
+
+
+@router.delete("/{company_id}/{contact_id}", status_code=status.HTTP_204_NO_CONTENT, response_model=None)
+async def delete_contact(
+    company_id: uuid.UUID,
+    contact_id: uuid.UUID,
+    actor: Optional[str] = None,
+    session: AsyncSession = Depends(get_async_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
+) -> None:
+    """Permanently delete the contact — its PII no longer exists at rest afterward."""
+    assert_company_access(ctx, company_id)
+    deleted = await _svc().delete(session, company_id, contact_id, actor=actor)
+    if not deleted:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Contact not found")
+    await session.commit()

--- a/autobot-backend/llc/models/__init__.py
+++ b/autobot-backend/llc/models/__init__.py
@@ -16,6 +16,7 @@ from .company import (
     CompanyTreeNode,
     CompanyUpdate,
 )
+from .contact import LLCContact
 from .enums import (
     ActivityEventType,
     ApprovalStatus,
@@ -61,6 +62,7 @@ __all__ = [
     "ContextMode",
     "CoWorkerType",
     "CompanyAncestor",
+    "LLCContact",
     "FindingProposalStatus",
     "LLCFindingProposal",
     "CompanyCreate",

--- a/autobot-backend/llc/models/contact.py
+++ b/autobot-backend/llc/models/contact.py
@@ -26,7 +26,14 @@ contact referenceable from multiple companies would need a many-to-many
 ``llc_contact_company_links`` join table and a decision on what "delete"
 means when other companies still hold a link; that is a product decision,
 not an implementation detail, and is tracked as a follow-up decision issue
-rather than guessed at here (see the PR body for the issue link).
+rather than guessed at here — tracked as #13998.
+
+Company soft-delete purges contacts too (#13969 review M2): ``CompanyService.delete()``
+is a soft delete (``Organization.deleted_at``), and every company listing filters
+``deleted_at.is_(None)`` — so without this, a soft-deleted company's contacts would
+vanish from every UI path while their PII stayed at rest forever. ``CompanyService.delete()``
+therefore also issues a hard DELETE against ``llc_contacts`` for that company_id in the
+same transaction. See ``llc/services/company.py::delete`` docstring for the reasoning.
 
 Never in the embedding/knowledge plane: no code path in ``llc/services/contact.py``
 imports ``knowledge``, ``llc.kb``, or ``utils.async_chromadb_client`` — a

--- a/autobot-backend/llc/models/contact.py
+++ b/autobot-backend/llc/models/contact.py
@@ -1,0 +1,86 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""LLC company-scoped contact SQLAlchemy model (#13969).
+
+A contact is a human who appears in a process — the supplier you email, the
+customer you call — who has no account and must never be able to log in.
+This is a deliberately separate table from ``users``: ``users`` is the
+authentication boundary (password hash, session lookups, JWT subject), and
+putting a non-authenticating identity inside it would mean every auth column
+gains a row it must specially exclude — one missed exclusion is a login
+path. ``LLCContact`` carries no password, no session relationship, and no
+column any login/session lookup ever queries, so the absence of a login path
+is structural, not merely unused code. See ``llc/tests/test_contact_no_login.py``.
+
+Scoping (not tenant isolation — companies inside AutoBot are organisational
+units of one installation, not customer isolation boundaries, per the
+umbrella #13935 owner correction): every contact belongs to exactly one
+``company_id``, mirroring ``LLCCompanyMembership`` and ``LLCSecret``. A
+contact who legitimately serves two companies (e.g. a supplier shared by an
+IT company and a marketing company inside the same installation) is
+duplicated as two rows today rather than linked — this is the simplest
+option and matches every other company-scoped LLC model's shape. Making one
+contact referenceable from multiple companies would need a many-to-many
+``llc_contact_company_links`` join table and a decision on what "delete"
+means when other companies still hold a link; that is a product decision,
+not an implementation detail, and is tracked as a follow-up decision issue
+rather than guessed at here (see the PR body for the issue link).
+
+Never in the embedding/knowledge plane: no code path in ``llc/services/contact.py``
+imports ``knowledge``, ``llc.kb``, or ``utils.async_chromadb_client`` — a
+contact's PII can never be pushed into a vector store, which cannot honour a
+deletion request once written. See ``llc/tests/test_contacts_no_embedding.py``.
+
+Not an org-chart hierarchy member (per the owner decision on #13969): no
+``reports_to``, no budget, no heartbeat. ``get_org_chart`` must never query
+this table.
+"""
+
+import uuid
+from datetime import datetime
+from typing import Optional
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from user_management.models.base import Base
+
+
+class LLCContact(Base):
+    """A human in a process with no account — never a ``users`` row.
+
+    ``full_name`` is the only required field; ``email``/``phone`` are the
+    process contact channels and ``role_title`` is free text describing the
+    contact's function (e.g. "Accounts Payable at Acme Supplies") — deliberately
+    NOT ``MembershipRole``, which is a ``users``-only company-role vocabulary
+    and does not apply to a person with no account.
+    """
+
+    __tablename__ = "llc_contacts"
+
+    # id is a client-side default (not server_default=gen_random_uuid()) so the
+    # ORM always supplies it explicitly — matches LLCSecret, and keeps this
+    # model creatable against a plain SQLite test engine with no Postgres
+    # function support.
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    company_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    full_name: Mapped[str] = mapped_column(sa.String(255), nullable=False)
+    email: Mapped[Optional[str]] = mapped_column(sa.String(320), nullable=True)
+    phone: Mapped[Optional[str]] = mapped_column(sa.String(64), nullable=True)
+    role_title: Mapped[Optional[str]] = mapped_column(sa.String(255), nullable=True)
+    notes: Mapped[Optional[str]] = mapped_column(sa.Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.func.now(),
+        onupdate=sa.func.now(),
+    )
+
+
+__all__ = ["LLCContact"]

--- a/autobot-backend/llc/services/company.py
+++ b/autobot-backend/llc/services/company.py
@@ -13,12 +13,14 @@ import asyncio
 import uuid
 from typing import List, Optional
 
+from sqlalchemy import delete as sa_delete
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.time_utils import now_utc
 from llc.models.company import CompanyCreate, CompanyTreeNode, CompanyUpdate
+from llc.models.contact import LLCContact
 from llc.models.enums import LLCCompanyStatus
 from user_management.models.organization import Organization
 
@@ -153,6 +155,16 @@ class CompanyService(LLCServiceBase):
 
         Raises CompanyHasChildrenError when active child companies exist, preventing
         orphaned children that ON DELETE SET NULL cannot handle for soft-deletes.
+
+        #13969 review M2: the company itself is soft-deleted (``deleted_at``),
+        but its contacts are pure PII with their own "deletion removes PII"
+        acceptance criterion — a soft-deleted company must not leave every
+        contact's name/email/phone/notes sitting at rest forever, unreachable
+        by any UI path (every listing filters ``deleted_at.is_(None)``). This
+        purges the company's ``llc_contacts`` rows in the same transaction,
+        rather than the more complex option of reassigning them elsewhere,
+        which is a product decision (tracked as #13998) this method should
+        not make unilaterally.
         """
         org = await self._get_or_404(company_id)
         children = await self.list_children(company_id)
@@ -162,8 +174,9 @@ class CompanyService(LLCServiceBase):
                 "re-parent or delete children before deleting the parent"
             )
         org.soft_delete()
+        await self.session.execute(sa_delete(LLCContact).where(LLCContact.company_id == company_id))
         await self.session.flush()
-        logger.info("LLC company soft-deleted: %s (id=%s)", org.name, org.id)
+        logger.info("LLC company soft-deleted: %s (id=%s), its contacts purged", org.name, org.id)
 
     # ------------------------------------------------------------------
     # Status transitions

--- a/autobot-backend/llc/services/contact.py
+++ b/autobot-backend/llc/services/contact.py
@@ -1,0 +1,152 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""LLC company-scoped contact service (#13969).
+
+CRUD for ``LLCContact`` — humans in a process (suppliers, customers) who have
+no account and must never be able to log in. Deliberately does NOT import
+``knowledge``, ``llc.kb``, or ``utils.async_chromadb_client`` anywhere in this
+module: a contact's PII must never reach the vector store, because an
+embedding cannot be revoked and that would create a deletion request this
+service could not honour (#13935). See
+``llc/tests/test_contacts_no_embedding.py`` for the guard that proves it.
+
+``delete()`` performs a hard DELETE, not the soft ``revoked_at`` pattern
+``SecretService`` uses — the acceptance criterion is that deleting a contact
+"removes its PII", and a soft-revoked row would still hold the plaintext
+name/email/phone/notes at rest.
+"""
+
+import uuid
+from typing import List, Optional
+
+from sqlalchemy import delete as sa_delete
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..models.activity import ActorType
+from ..models.contact import LLCContact
+from .base import LLCServiceBase
+
+
+class ContactService(LLCServiceBase):
+    """Company-scoped CRUD for contacts. Every method takes company_id explicitly
+    and filters on it — callers (API routes) are responsible for verifying the
+    caller may act for that company before invoking these methods."""
+
+    async def create(
+        self,
+        session: AsyncSession,
+        company_id: uuid.UUID,
+        full_name: str,
+        *,
+        email: Optional[str] = None,
+        phone: Optional[str] = None,
+        role_title: Optional[str] = None,
+        notes: Optional[str] = None,
+        actor: Optional[str] = None,
+    ) -> LLCContact:
+        contact = LLCContact(
+            id=uuid.uuid4(),
+            company_id=company_id,
+            full_name=full_name,
+            email=email,
+            phone=phone,
+            role_title=role_title,
+            notes=notes,
+        )
+        session.add(contact)
+        await session.flush()
+        await session.refresh(contact)
+
+        if self.activity_log:
+            await self.activity_log.record(
+                session=session,
+                company_id=str(company_id),
+                actor_type=ActorType.USER if actor else ActorType.SYSTEM,
+                actor_id=actor,
+                event_type="contact.created",
+                entity_type="llc_contact",
+                entity_id=str(contact.id),
+                # Never log PII (name/email/phone/notes) — id only.
+                after={"id": str(contact.id)},
+            )
+        return contact
+
+    async def get(
+        self,
+        session: AsyncSession,
+        company_id: uuid.UUID,
+        contact_id: uuid.UUID,
+    ) -> Optional[LLCContact]:
+        result = await session.execute(
+            select(LLCContact).where(
+                LLCContact.id == contact_id,
+                LLCContact.company_id == company_id,
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def list_by_company(
+        self,
+        session: AsyncSession,
+        company_id: uuid.UUID,
+    ) -> List[LLCContact]:
+        result = await session.execute(
+            select(LLCContact).where(LLCContact.company_id == company_id).order_by(LLCContact.full_name)
+        )
+        return list(result.scalars().all())
+
+    async def update(
+        self,
+        session: AsyncSession,
+        company_id: uuid.UUID,
+        contact_id: uuid.UUID,
+        **fields,
+    ) -> Optional[LLCContact]:
+        contact = await self.get(session, company_id, contact_id)
+        if contact is None:
+            return None
+        allowed = {"full_name", "email", "phone", "role_title", "notes"}
+        for key, value in fields.items():
+            if key in allowed:
+                setattr(contact, key, value)
+        await session.flush()
+        return contact
+
+    async def delete(
+        self,
+        session: AsyncSession,
+        company_id: uuid.UUID,
+        contact_id: uuid.UUID,
+        *,
+        actor: Optional[str] = None,
+    ) -> bool:
+        """Hard-delete a contact so its PII no longer exists at rest.
+
+        Returns True if a row was deleted, False if no matching contact
+        existed for this company (mirrors ``GoalService.delete``'s bool
+        return so the route can 404 without a second lookup).
+        """
+        if self.activity_log:
+            await self.activity_log.record(
+                session=session,
+                company_id=str(company_id),
+                actor_type=ActorType.USER if actor else ActorType.SYSTEM,
+                actor_id=actor,
+                event_type="contact.deleted",
+                entity_type="llc_contact",
+                entity_id=str(contact_id),
+                after=None,
+            )
+        result = await session.execute(
+            sa_delete(LLCContact).where(
+                LLCContact.id == contact_id,
+                LLCContact.company_id == company_id,
+            )
+        )
+        return result.rowcount > 0
+
+
+__all__ = ["ContactService"]

--- a/autobot-backend/llc/services/contact.py
+++ b/autobot-backend/llc/services/contact.py
@@ -45,7 +45,7 @@ class ContactService(LLCServiceBase):
         phone: Optional[str] = None,
         role_title: Optional[str] = None,
         notes: Optional[str] = None,
-        actor: Optional[str] = None,
+        actor: Optional[uuid.UUID] = None,
     ) -> LLCContact:
         contact = LLCContact(
             id=uuid.uuid4(),
@@ -103,16 +103,32 @@ class ContactService(LLCServiceBase):
         session: AsyncSession,
         company_id: uuid.UUID,
         contact_id: uuid.UUID,
+        *,
+        actor: Optional[uuid.UUID] = None,
         **fields,
     ) -> Optional[LLCContact]:
         contact = await self.get(session, company_id, contact_id)
         if contact is None:
             return None
         allowed = {"full_name", "email", "phone", "role_title", "notes"}
+        changed_fields = sorted(key for key in fields if key in allowed)
         for key, value in fields.items():
             if key in allowed:
                 setattr(contact, key, value)
         await session.flush()
+
+        if self.activity_log and changed_fields:
+            await self.activity_log.record(
+                session=session,
+                company_id=str(company_id),
+                actor_type=ActorType.USER if actor else ActorType.SYSTEM,
+                actor_id=actor,
+                event_type="contact.updated",
+                entity_type="llc_contact",
+                entity_id=str(contact.id),
+                # Field names only — never the new PII values themselves.
+                after={"fields_changed": changed_fields},
+            )
         return contact
 
     async def delete(
@@ -121,15 +137,26 @@ class ContactService(LLCServiceBase):
         company_id: uuid.UUID,
         contact_id: uuid.UUID,
         *,
-        actor: Optional[str] = None,
+        actor: Optional[uuid.UUID] = None,
     ) -> bool:
         """Hard-delete a contact so its PII no longer exists at rest.
 
         Returns True if a row was deleted, False if no matching contact
         existed for this company (mirrors ``GoalService.delete``'s bool
-        return so the route can 404 without a second lookup).
+        return so the route can 404 without a second lookup). The audit
+        record is written only after ``rowcount`` confirms a row actually
+        matched — a 404 (no matching row) must never emit a
+        ``contact.deleted`` event.
         """
-        if self.activity_log:
+        result = await session.execute(
+            sa_delete(LLCContact).where(
+                LLCContact.id == contact_id,
+                LLCContact.company_id == company_id,
+            )
+        )
+        deleted = result.rowcount > 0
+
+        if deleted and self.activity_log:
             await self.activity_log.record(
                 session=session,
                 company_id=str(company_id),
@@ -140,13 +167,7 @@ class ContactService(LLCServiceBase):
                 entity_id=str(contact_id),
                 after=None,
             )
-        result = await session.execute(
-            sa_delete(LLCContact).where(
-                LLCContact.id == contact_id,
-                LLCContact.company_id == company_id,
-            )
-        )
-        return result.rowcount > 0
+        return deleted
 
 
 __all__ = ["ContactService"]

--- a/autobot-backend/llc/tests/test_company_delete_purges_contacts.py
+++ b/autobot-backend/llc/tests/test_company_delete_purges_contacts.py
@@ -1,0 +1,107 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Company soft-delete must purge its contacts' PII (#13969 review M2).
+
+``CompanyService.delete()`` soft-deletes the ``Organization`` row
+(``deleted_at``), and every company listing filters ``deleted_at.is_(None)``
+— so without this, a soft-deleted company's contacts would vanish from every
+UI path while their name/email/phone/notes stayed at rest forever,
+unreachable but not gone. That undercuts #13969's own "deletion removes its
+PII" acceptance criterion at the level that matters (a company, not just a
+single contact, going away).
+
+Real-engine test (mirrors ``test_company_transition_greenlet_12309.py``'s
+fixture shape) so the actual DELETE statement executes against a real table,
+not a mock assertion about what *would* have been sent.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import AsyncIterator
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.ext.compiler import compiles
+
+from llc.models.contact import LLCContact
+from llc.services.company import CompanyService
+from llc.services.contact import ContactService
+from user_management.models.base import Base
+from user_management.models.organization import Organization
+
+
+@compiles(JSONB, "sqlite")
+def _compile_jsonb_as_json_on_sqlite(element, compiler, **kw):  # noqa: ANN001
+    return "JSON"
+
+
+async def _seed_company(session_factory, llc_status: str = "active") -> uuid.UUID:  # noqa: ANN001
+    async with session_factory() as session:
+        org = Organization(
+            name="Acme Relations",
+            slug=f"acme-{uuid.uuid4().hex[:8]}",
+            settings={},
+            llc_status=llc_status,
+            issue_counter=0,
+            budget_monthly_cents=0,
+            spent_monthly_cents=0,
+            require_approval_for_hires=False,
+        )
+        session.add(org)
+        await session.commit()
+        return org.id
+
+
+@pytest.fixture()
+async def session_factory() -> AsyncIterator:
+    engine = create_async_engine("sqlite+aiosqlite://")  # canonical: ignore py-adhoc-db-engine (test-local engine)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all, tables=[Organization.__table__, LLCContact.__table__])
+    try:
+        yield async_sessionmaker(bind=engine, expire_on_commit=False, autoflush=False)
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_company_delete_purges_its_contacts(session_factory):  # noqa: ANN001
+    company_id = await _seed_company(session_factory)
+
+    async with session_factory() as session:
+        contact_svc = ContactService()
+        contact = await contact_svc.create(session, company_id, "Ada Lovelace", email="ada@supplier.example.com")
+        await session.commit()
+        contact_id = contact.id
+
+    async with session_factory() as session:
+        company_svc = CompanyService(session=session)
+        await company_svc.delete(company_id)
+        await session.commit()
+
+    async with session_factory() as session:
+        row = (await session.execute(select(LLCContact).where(LLCContact.id == contact_id))).scalar_one_or_none()
+    assert row is None, "company soft-delete must purge its contacts' PII, not just hide the company"
+
+
+@pytest.mark.asyncio
+async def test_company_delete_leaves_other_companies_contacts_untouched(session_factory):  # noqa: ANN001
+    company_a = await _seed_company(session_factory)
+    company_b = await _seed_company(session_factory)
+
+    async with session_factory() as session:
+        contact_svc = ContactService()
+        contact_b = await contact_svc.create(session, company_b, "Brian Kernighan", email="brian@supplier.example.com")
+        await session.commit()
+        contact_b_id = contact_b.id
+
+    async with session_factory() as session:
+        company_svc = CompanyService(session=session)
+        await company_svc.delete(company_a)
+        await session.commit()
+
+    async with session_factory() as session:
+        row = (await session.execute(select(LLCContact).where(LLCContact.id == contact_b_id))).scalar_one_or_none()
+    assert row is not None, "deleting company A must not purge company B's contacts"

--- a/autobot-backend/llc/tests/test_company_delete_purges_contacts.py
+++ b/autobot-backend/llc/tests/test_company_delete_purges_contacts.py
@@ -23,7 +23,7 @@ from typing import AsyncIterator
 import pytest
 from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import JSONB
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlalchemy.ext.compiler import compiles
 
 from llc.models.contact import LLCContact

--- a/autobot-backend/llc/tests/test_contact_service.py
+++ b/autobot-backend/llc/tests/test_contact_service.py
@@ -18,11 +18,10 @@ import pytest_asyncio
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
-from llc.tests import _e2e_harness as harness  # registers SQLite compile shims
 from llc.models.contact import LLCContact
 from llc.services.contact import ContactService
+from llc.tests import _e2e_harness as harness  # registers SQLite compile shims
 from user_management.models.base import Base
-
 
 # canonical: ignore py-adhoc-db-engine (test-local engine, in-memory only)
 _SQLITE_MEMORY_URL = "sqlite+aiosqlite:///:memory:"

--- a/autobot-backend/llc/tests/test_contact_service.py
+++ b/autobot-backend/llc/tests/test_contact_service.py
@@ -24,9 +24,13 @@ from llc.services.contact import ContactService
 from user_management.models.base import Base
 
 
+# canonical: ignore py-adhoc-db-engine (test-local engine, in-memory only)
+_SQLITE_MEMORY_URL = "sqlite+aiosqlite:///:memory:"
+
+
 @pytest_asyncio.fixture
 async def engine() -> AsyncIterator:
-    eng = create_async_engine("sqlite+aiosqlite:///:memory:")  # canonical: ignore py-adhoc-db-engine (test-local engine)
+    eng = create_async_engine(_SQLITE_MEMORY_URL)
     tables = [LLCContact.__table__]
     for table in tables:
         harness._scrub_pg_server_defaults(table)
@@ -39,7 +43,8 @@ async def engine() -> AsyncIterator:
 
 @pytest_asyncio.fixture
 async def session_factory(engine):  # noqa: ANN001, ANN201
-    return async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)  # canonical: ignore py-adhoc-db-engine
+    # canonical: ignore py-adhoc-db-engine (test-local session factory)
+    return async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
 
 
 @pytest.mark.asyncio

--- a/autobot-backend/llc/tests/test_contact_service.py
+++ b/autobot-backend/llc/tests/test_contact_service.py
@@ -1,0 +1,168 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for ContactService CRUD (#13969), including PII deletion.
+
+Row-level company scoping has its own dedicated file
+(``test_contacts_scoping.py``) with the two-company regression case; this
+file covers ordinary CRUD correctness and the deletion-removes-PII
+acceptance criterion.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from llc.tests import _e2e_harness as harness  # registers SQLite compile shims
+from llc.models.contact import LLCContact
+from llc.services.contact import ContactService
+from user_management.models.base import Base
+
+
+@pytest_asyncio.fixture
+async def engine() -> AsyncIterator:
+    eng = create_async_engine("sqlite+aiosqlite:///:memory:")  # canonical: ignore py-adhoc-db-engine (test-local engine)
+    tables = [LLCContact.__table__]
+    for table in tables:
+        harness._scrub_pg_server_defaults(table)
+        harness._clientside_timestamps(table)
+    async with eng.begin() as conn:
+        await conn.run_sync(lambda c: Base.metadata.create_all(c, tables=tables))
+    yield eng
+    await eng.dispose()
+
+
+@pytest_asyncio.fixture
+async def session_factory(engine):  # noqa: ANN001, ANN201
+    return async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)  # canonical: ignore py-adhoc-db-engine
+
+
+@pytest.mark.asyncio
+async def test_create_and_get_round_trip(session_factory):  # noqa: ANN001
+    company_id = uuid.uuid4()
+    async with session_factory() as session:
+        svc = ContactService()
+        created = await svc.create(
+            session,
+            company_id,
+            "Ada Lovelace",
+            email="ada@supplier.test",
+            phone="+1-555-0100",
+            role_title="Accounts Payable, Acme Supplies",
+            notes="Prefers email over phone",
+        )
+        await session.commit()
+
+    async with session_factory() as session:
+        svc = ContactService()
+        fetched = await svc.get(session, company_id, created.id)
+
+    assert fetched is not None
+    assert fetched.full_name == "Ada Lovelace"
+    assert fetched.email == "ada@supplier.test"
+    assert fetched.phone == "+1-555-0100"
+    assert fetched.role_title == "Accounts Payable, Acme Supplies"
+
+
+@pytest.mark.asyncio
+async def test_create_requires_only_full_name(session_factory):  # noqa: ANN001
+    """email/phone/role_title/notes are all optional."""
+    company_id = uuid.uuid4()
+    async with session_factory() as session:
+        svc = ContactService()
+        created = await svc.create(session, company_id, "Anonymous Contact")
+        await session.commit()
+
+    assert created.email is None
+    assert created.phone is None
+
+
+@pytest.mark.asyncio
+async def test_update_changes_only_provided_fields(session_factory):  # noqa: ANN001
+    company_id = uuid.uuid4()
+    async with session_factory() as session:
+        svc = ContactService()
+        created = await svc.create(session, company_id, "Ada Lovelace", email="ada@supplier.test")
+        await session.commit()
+        contact_id = created.id
+
+    async with session_factory() as session:
+        svc = ContactService()
+        updated = await svc.update(session, company_id, contact_id, phone="+1-555-0199")
+        await session.commit()
+
+    assert updated is not None
+    assert updated.phone == "+1-555-0199"
+    assert updated.email == "ada@supplier.test"  # untouched
+
+
+@pytest.mark.asyncio
+async def test_update_missing_contact_returns_none(session_factory):  # noqa: ANN001
+    company_id = uuid.uuid4()
+    async with session_factory() as session:
+        svc = ContactService()
+        result = await svc.update(session, company_id, uuid.uuid4(), full_name="Nobody")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_delete_removes_the_row_and_its_pii_entirely(session_factory):  # noqa: ANN001
+    """The core revocability acceptance criterion: after delete, the PII is gone
+    at rest — not soft-flagged, not queryable by any path, including a bare
+    SELECT against the table with no company filter at all."""
+    company_id = uuid.uuid4()
+    async with session_factory() as session:
+        svc = ContactService()
+        created = await svc.create(
+            session,
+            company_id,
+            "Ada Lovelace",
+            email="ada@supplier.test",
+            phone="+1-555-0100",
+            notes="sensitive process notes",
+        )
+        await session.commit()
+        contact_id = created.id
+
+    async with session_factory() as session:
+        svc = ContactService()
+        deleted = await svc.delete(session, company_id, contact_id)
+        await session.commit()
+    assert deleted is True
+
+    async with session_factory() as session:
+        # Bare SELECT by id, no company filter, no service layer at all — proves
+        # the row (and therefore its PII) is gone, not merely excluded by scope.
+        result = await session.execute(select(LLCContact).where(LLCContact.id == contact_id))
+        row = result.scalar_one_or_none()
+    assert row is None
+
+
+@pytest.mark.asyncio
+async def test_delete_missing_contact_returns_false(session_factory):  # noqa: ANN001
+    company_id = uuid.uuid4()
+    async with session_factory() as session:
+        svc = ContactService()
+        deleted = await svc.delete(session, company_id, uuid.uuid4())
+    assert deleted is False
+
+
+@pytest.mark.asyncio
+async def test_list_by_company_orders_by_full_name(session_factory):  # noqa: ANN001
+    company_id = uuid.uuid4()
+    async with session_factory() as session:
+        svc = ContactService()
+        await svc.create(session, company_id, "Zeta Vendor")
+        await svc.create(session, company_id, "Alpha Vendor")
+        await session.commit()
+
+    async with session_factory() as session:
+        svc = ContactService()
+        contacts = await svc.list_by_company(session, company_id)
+
+    assert [c.full_name for c in contacts] == ["Alpha Vendor", "Zeta Vendor"]

--- a/autobot-backend/llc/tests/test_contacts_idor.py
+++ b/autobot-backend/llc/tests/test_contacts_idor.py
@@ -1,0 +1,155 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Route-level access control for contacts.py routes (#13969).
+
+Mirrors test_secrets_idor.py / test_goals_idor.py's shape:
+  - no auth at all                  -> 401
+  - authenticated, wrong company_id -> 404 (assert_company_access, #12238)
+  - authenticated, own company_id   -> the expected success status
+  - platform admin, any company_id  -> allowed
+
+"Wrong company_id" here is a scoping check, not a tenant-isolation boundary —
+companies inside one AutoBot installation are organisational units, not
+separate customers (umbrella #13935 owner correction) — but the same
+``assert_company_access`` guard every other LLC router uses still applies:
+a company's contact list is that company's view, not another company's.
+"""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from user_management.services import TenantContext
+
+_FIXED_USER_ID = uuid.UUID("77777777-7777-7777-7777-777777777777")
+_OTHER_COMPANY = "99999999-9999-9999-9999-999999999999"
+
+
+def _make_contact_dict(company_id: str, contact_id: str) -> dict:
+    return {
+        "id": contact_id,
+        "company_id": company_id,
+        "full_name": "Ada Lovelace",
+        "email": "ada@supplier.test",
+        "phone": None,
+        "role_title": None,
+        "notes": None,
+        "created_at": "2026-08-11T00:00:00+00:00",
+        "updated_at": "2026-08-11T00:00:00+00:00",
+    }
+
+
+def _make_client(caller_company_id: str, is_platform_admin: bool = False) -> TestClient:
+    from api.user_management.dependencies import get_current_user, require_org_context  # noqa: PLC0415
+    from llc.api.contacts import router as contacts_router  # noqa: PLC0415
+    from user_management.database import get_async_session  # noqa: PLC0415
+
+    app = FastAPI()
+    app.include_router(contacts_router, prefix="/api/llc")
+
+    mock_session = AsyncMock()
+    mock_session.commit = AsyncMock()
+
+    async def _fake_session():
+        yield mock_session
+
+    app.dependency_overrides[get_async_session] = _fake_session
+    app.dependency_overrides[get_current_user] = lambda: {"id": str(_FIXED_USER_ID)}
+    app.dependency_overrides[require_org_context] = lambda: TenantContext(
+        org_id=uuid.UUID(caller_company_id), user_id=_FIXED_USER_ID, is_platform_admin=is_platform_admin
+    )
+
+    contact_id = str(uuid.uuid4())
+    created = MagicMock(**_make_contact_dict(caller_company_id, contact_id))
+    for key, value in _make_contact_dict(caller_company_id, contact_id).items():
+        setattr(created, key, value)
+
+    patch("llc.api.contacts.ContactService.list_by_company", new=AsyncMock(return_value=[])).start()
+    patch("llc.api.contacts.ContactService.create", new=AsyncMock(return_value=created)).start()
+    patch("llc.api.contacts.ContactService.get", new=AsyncMock(return_value=created)).start()
+    patch("llc.api.contacts.ContactService.update", new=AsyncMock(return_value=created)).start()
+    patch("llc.api.contacts.ContactService.delete", new=AsyncMock(return_value=True)).start()
+
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _stop_patches():
+    yield
+    patch.stopall()
+
+
+class TestContactsNoAuth:
+    def _make_unauthenticated_client(self) -> TestClient:
+        from llc.api.contacts import router as contacts_router
+        from user_management.database import get_async_session
+
+        app = FastAPI()
+        app.include_router(contacts_router, prefix="/api/llc")
+
+        async def _fake_session():
+            yield AsyncMock()
+
+        app.dependency_overrides[get_async_session] = _fake_session
+        return TestClient(app)
+
+    def test_list_contacts_no_token_returns_401(self):
+        with patch("api.user_management.dependencies.get_auth_middleware") as mock_mw:
+            mock_mw.return_value.get_user_from_request.return_value = None
+            client = self._make_unauthenticated_client()
+            resp = client.get(f"/api/llc/contacts/{_OTHER_COMPANY}")
+        assert resp.status_code == 401
+
+    def test_create_contact_no_token_returns_401(self):
+        with patch("api.user_management.dependencies.get_auth_middleware") as mock_mw:
+            mock_mw.return_value.get_user_from_request.return_value = None
+            client = self._make_unauthenticated_client()
+            resp = client.post(f"/api/llc/contacts/{_OTHER_COMPANY}", json={"full_name": "Ada"})
+        assert resp.status_code == 401
+
+
+class TestContactsScopeGuard:
+    def test_list_own_company_returns_200(self):
+        company_id = str(uuid.uuid4())
+        client = _make_client(company_id)
+        resp = client.get(f"/api/llc/contacts/{company_id}")
+        assert resp.status_code == 200
+
+    def test_list_other_company_returns_404(self):
+        company_id = str(uuid.uuid4())
+        client = _make_client(company_id)
+        resp = client.get(f"/api/llc/contacts/{_OTHER_COMPANY}")
+        assert resp.status_code == 404
+
+    def test_list_platform_admin_other_company_allowed(self):
+        company_id = str(uuid.uuid4())
+        client = _make_client(company_id, is_platform_admin=True)
+        resp = client.get(f"/api/llc/contacts/{_OTHER_COMPANY}")
+        assert resp.status_code == 200
+
+    def test_create_own_company_returns_201(self):
+        company_id = str(uuid.uuid4())
+        client = _make_client(company_id)
+        resp = client.post(f"/api/llc/contacts/{company_id}", json={"full_name": "Ada Lovelace"})
+        assert resp.status_code == 201
+
+    def test_create_other_company_returns_404(self):
+        company_id = str(uuid.uuid4())
+        client = _make_client(company_id)
+        resp = client.post(f"/api/llc/contacts/{_OTHER_COMPANY}", json={"full_name": "Ada Lovelace"})
+        assert resp.status_code == 404
+
+    def test_delete_other_company_returns_404(self):
+        company_id = str(uuid.uuid4())
+        client = _make_client(company_id)
+        resp = client.delete(f"/api/llc/contacts/{_OTHER_COMPANY}/{uuid.uuid4()}")
+        assert resp.status_code == 404
+
+    def test_delete_own_company_returns_204(self):
+        company_id = str(uuid.uuid4())
+        client = _make_client(company_id)
+        resp = client.delete(f"/api/llc/contacts/{company_id}/{uuid.uuid4()}")
+        assert resp.status_code == 204

--- a/autobot-backend/llc/tests/test_contacts_idor.py
+++ b/autobot-backend/llc/tests/test_contacts_idor.py
@@ -153,3 +153,69 @@ class TestContactsScopeGuard:
         client = _make_client(company_id)
         resp = client.delete(f"/api/llc/contacts/{company_id}/{uuid.uuid4()}")
         assert resp.status_code == 204
+
+    def test_get_by_id_own_company_returns_200(self):
+        """GET /{contact_id} — the write-path guard exists (list/create/delete
+        were already covered); this closes the missing read-single-item case."""
+        company_id = str(uuid.uuid4())
+        client = _make_client(company_id)
+        resp = client.get(f"/api/llc/contacts/{company_id}/{uuid.uuid4()}")
+        assert resp.status_code == 200
+
+    def test_get_by_id_other_company_returns_404(self):
+        company_id = str(uuid.uuid4())
+        client = _make_client(company_id)
+        resp = client.get(f"/api/llc/contacts/{_OTHER_COMPANY}/{uuid.uuid4()}")
+        assert resp.status_code == 404
+
+    def test_patch_own_company_returns_200(self):
+        company_id = str(uuid.uuid4())
+        client = _make_client(company_id)
+        resp = client.patch(f"/api/llc/contacts/{company_id}/{uuid.uuid4()}", json={"phone": "+1-555-0100"})
+        assert resp.status_code == 200
+
+    def test_patch_other_company_returns_404(self):
+        company_id = str(uuid.uuid4())
+        client = _make_client(company_id)
+        resp = client.patch(f"/api/llc/contacts/{_OTHER_COMPANY}/{uuid.uuid4()}", json={"phone": "+1-555-0100"})
+        assert resp.status_code == 404
+
+
+class TestContactsActorDerivation:
+    """#13969 review M1: the audit-trail actor must come from the authenticated
+    session, never from client-supplied input — and a client sending garbage
+    in the (now-removed) actor fields must not be able to reach that path at
+    all, let alone crash it."""
+
+    def test_create_derives_actor_from_authenticated_user(self):
+        from llc.api.contacts import ContactService  # noqa: PLC0415
+
+        company_id = str(uuid.uuid4())
+        client = _make_client(company_id)
+        resp = client.post(f"/api/llc/contacts/{company_id}", json={"full_name": "Ada Lovelace"})
+        assert resp.status_code == 201
+        _, kwargs = ContactService.create.call_args
+        assert kwargs["actor"] == _FIXED_USER_ID
+
+    def test_delete_derives_actor_from_authenticated_user(self):
+        from llc.api.contacts import ContactService  # noqa: PLC0415
+
+        company_id = str(uuid.uuid4())
+        client = _make_client(company_id)
+        resp = client.delete(f"/api/llc/contacts/{company_id}/{uuid.uuid4()}")
+        assert resp.status_code == 204
+        _, kwargs = ContactService.delete.call_args
+        assert kwargs["actor"] == _FIXED_USER_ID
+
+    def test_client_supplied_actor_field_in_body_is_ignored_not_500(self):
+        """Before the fix, an unparseable client-supplied ``actor`` reached
+        ``uuid.UUID(actor_id)`` inside ``ActivityLogService.record`` unguarded
+        — an unhandled 500. The field no longer exists on the schema at all,
+        so pydantic silently drops it as an unknown extra key."""
+        company_id = str(uuid.uuid4())
+        client = _make_client(company_id)
+        resp = client.post(
+            f"/api/llc/contacts/{company_id}",
+            json={"full_name": "Ada Lovelace", "actor": "not-a-uuid-at-all"},
+        )
+        assert resp.status_code == 201

--- a/autobot-backend/llc/tests/test_contacts_no_embedding.py
+++ b/autobot-backend/llc/tests/test_contacts_no_embedding.py
@@ -56,9 +56,13 @@ def test_contact_module_never_imports_the_embedding_plane(module) -> None:  # no
     assert not offending, f"{module.__name__} must never import the embedding plane, found: {offending}"
 
 
+# canonical: ignore py-adhoc-db-engine (test-local engine, in-memory only)
+_SQLITE_MEMORY_URL = "sqlite+aiosqlite:///:memory:"
+
+
 @pytest_asyncio.fixture
 async def engine() -> AsyncIterator:
-    eng = create_async_engine("sqlite+aiosqlite:///:memory:")  # canonical: ignore py-adhoc-db-engine (test-local engine)
+    eng = create_async_engine(_SQLITE_MEMORY_URL)
     tables = [LLCContact.__table__]
     for table in tables:
         harness._scrub_pg_server_defaults(table)
@@ -71,7 +75,8 @@ async def engine() -> AsyncIterator:
 
 @pytest_asyncio.fixture
 async def session_factory(engine):  # noqa: ANN001, ANN201
-    return async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)  # canonical: ignore py-adhoc-db-engine
+    # canonical: ignore py-adhoc-db-engine (test-local session factory)
+    return async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
 
 
 @pytest.mark.asyncio

--- a/autobot-backend/llc/tests/test_contacts_no_embedding.py
+++ b/autobot-backend/llc/tests/test_contacts_no_embedding.py
@@ -31,11 +31,11 @@ import pytest
 import pytest_asyncio
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
-from llc.tests import _e2e_harness as harness  # registers SQLite compile shims
 from llc.models import contact as contact_model
 from llc.models.contact import LLCContact
 from llc.services import contact as contact_service
 from llc.services.contact import ContactService
+from llc.tests import _e2e_harness as harness  # registers SQLite compile shims
 from user_management.models.base import Base
 
 _FORBIDDEN_IMPORT_MARKERS = ("knowledge", "llc.kb", "async_chromadb_client")

--- a/autobot-backend/llc/tests/test_contacts_no_embedding.py
+++ b/autobot-backend/llc/tests/test_contacts_no_embedding.py
@@ -31,6 +31,7 @@ import pytest
 import pytest_asyncio
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
+from llc.api import contacts as contact_api
 from llc.models import contact as contact_model
 from llc.models.contact import LLCContact
 from llc.services import contact as contact_service
@@ -41,7 +42,7 @@ from user_management.models.base import Base
 _FORBIDDEN_IMPORT_MARKERS = ("knowledge", "llc.kb", "async_chromadb_client")
 
 
-@pytest.mark.parametrize("module", [contact_model, contact_service])
+@pytest.mark.parametrize("module", [contact_model, contact_service, contact_api])
 def test_contact_module_never_imports_the_embedding_plane(module) -> None:  # noqa: ANN001
     """Structural guard: source-scan for the forbidden import families.
 

--- a/autobot-backend/llc/tests/test_contacts_no_embedding.py
+++ b/autobot-backend/llc/tests/test_contacts_no_embedding.py
@@ -1,0 +1,106 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Contact data must never reach the embedding/knowledge plane (#13969).
+
+An embedding cannot be revoked. If a contact's name/email/phone/notes were
+ever pushed into a vector store, deleting the contact could no longer be
+honoured — exactly the deletion request ``llc/tests/test_contact_service.py``
+proves ``ContactService.delete`` satisfies for the relational row. This file
+proves the embedding side never happens in the first place, two ways:
+
+1. Structural: no LLC-contact source file imports ``knowledge``, ``llc.kb``,
+   or ``utils.async_chromadb_client`` — the single chokepoint every other
+   indexed LLC entity (goals, work items) calls through
+   (``utils.async_chromadb_client.get_async_chromadb_client``, see
+   ``llc/services/goal.py::_index_goal``).
+2. Behavioural, mutation-proved: spy on that chokepoint function and run a
+   full create/update/delete cycle through ``ContactService`` against a real
+   (in-memory) DB; the spy must never be called. Temporarily adding a call to
+   it inside ``ContactService.create`` (mirroring exactly what ``GoalService``
+   does for goals) turns this test red; removing it turns it green again.
+"""
+
+from __future__ import annotations
+
+import inspect
+import uuid
+from typing import AsyncIterator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from llc.tests import _e2e_harness as harness  # registers SQLite compile shims
+from llc.models import contact as contact_model
+from llc.models.contact import LLCContact
+from llc.services import contact as contact_service
+from llc.services.contact import ContactService
+from user_management.models.base import Base
+
+_FORBIDDEN_IMPORT_MARKERS = ("knowledge", "llc.kb", "async_chromadb_client")
+
+
+@pytest.mark.parametrize("module", [contact_model, contact_service])
+def test_contact_module_never_imports_the_embedding_plane(module) -> None:  # noqa: ANN001
+    """Structural guard: source-scan for the forbidden import families.
+
+    Reads the module's own source rather than ``sys.modules`` — a transitive
+    import elsewhere in the process must not produce a false positive, and a
+    literal ``import knowledge`` line inside this module must always be caught
+    regardless of whether it ever executes.
+    """
+    source = inspect.getsource(module)
+    import_lines = [line.strip() for line in source.splitlines() if line.strip().startswith(("import ", "from "))]
+    offending = [line for line in import_lines if any(marker in line for marker in _FORBIDDEN_IMPORT_MARKERS)]
+    assert not offending, f"{module.__name__} must never import the embedding plane, found: {offending}"
+
+
+@pytest_asyncio.fixture
+async def engine() -> AsyncIterator:
+    eng = create_async_engine("sqlite+aiosqlite:///:memory:")  # canonical: ignore py-adhoc-db-engine (test-local engine)
+    tables = [LLCContact.__table__]
+    for table in tables:
+        harness._scrub_pg_server_defaults(table)
+        harness._clientside_timestamps(table)
+    async with eng.begin() as conn:
+        await conn.run_sync(lambda c: Base.metadata.create_all(c, tables=tables))
+    yield eng
+    await eng.dispose()
+
+
+@pytest_asyncio.fixture
+async def session_factory(engine):  # noqa: ANN001, ANN201
+    return async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)  # canonical: ignore py-adhoc-db-engine
+
+
+@pytest.mark.asyncio
+async def test_full_crud_cycle_never_calls_the_chromadb_client(session_factory):  # noqa: ANN001
+    """Behavioural guard: create/update/delete a contact, spy on the chokepoint.
+
+    Mutation-proof: temporarily inserting
+    ``await get_async_chromadb_client()`` into ``ContactService.create``
+    (exactly what ``GoalService._index_goal`` does for goals) turns this red;
+    removing it restores green. Verified in the PR description, not re-run
+    here, since this file's job is to fail forever after — a mutation left in
+    place would defeat its own purpose.
+    """
+    company_id = uuid.uuid4()
+
+    with patch("utils.async_chromadb_client.get_async_chromadb_client", new=AsyncMock()) as spy:
+        async with session_factory() as session:
+            svc = ContactService()
+            contact = await svc.create(session, company_id, "Acme Supplier", email="s@acme.test", notes="VIP vendor")
+            await session.commit()
+
+        async with session_factory() as session:
+            svc = ContactService()
+            await svc.update(session, company_id, contact.id, notes="Updated note text")
+            await session.commit()
+
+        async with session_factory() as session:
+            svc = ContactService()
+            await svc.delete(session, company_id, contact.id)
+            await session.commit()
+
+    spy.assert_not_called()

--- a/autobot-backend/llc/tests/test_contacts_no_login.py
+++ b/autobot-backend/llc/tests/test_contacts_no_login.py
@@ -27,6 +27,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 
 # Importing the harness registers the SQLite compile shims for
 # postgresql.JSONB / postgresql.UUID (module-level side effect).
+from autobot_shared.user_management.models.role import Role, UserRole
 from llc.tests import _e2e_harness as harness
 from llc.models.contact import LLCContact
 from llc.services.contact import ContactService
@@ -43,10 +44,14 @@ def test_contact_model_has_no_authentication_columns() -> None:
     assert not offending, f"LLCContact must carry no auth-surface columns, found: {offending}"
 
 
+# canonical: ignore py-adhoc-db-engine (test-local engine, in-memory only)
+_SQLITE_MEMORY_URL = "sqlite+aiosqlite:///:memory:"
+
+
 @pytest_asyncio.fixture
 async def engine() -> AsyncIterator:
-    eng = create_async_engine("sqlite+aiosqlite:///:memory:")  # canonical: ignore py-adhoc-db-engine (test-local engine)
-    tables = [User.__table__, LLCContact.__table__]
+    eng = create_async_engine(_SQLITE_MEMORY_URL)
+    tables = [User.__table__, UserRole.__table__, Role.__table__, LLCContact.__table__]
     for table in tables:
         harness._scrub_pg_server_defaults(table)
         harness._rebind_enums_by_value(table)
@@ -59,7 +64,8 @@ async def engine() -> AsyncIterator:
 
 @pytest_asyncio.fixture
 async def session_factory(engine):  # noqa: ANN001, ANN201
-    return async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)  # canonical: ignore py-adhoc-db-engine
+    # canonical: ignore py-adhoc-db-engine (test-local session factory)
+    return async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
 
 
 @pytest.mark.asyncio

--- a/autobot-backend/llc/tests/test_contacts_no_login.py
+++ b/autobot-backend/llc/tests/test_contacts_no_login.py
@@ -23,6 +23,7 @@ from typing import AsyncIterator
 
 import pytest
 import pytest_asyncio
+from sqlalchemy import inspect
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 # Importing the harness registers the SQLite compile shims for
@@ -42,6 +43,21 @@ def test_contact_model_has_no_authentication_columns() -> None:
     forbidden_markers = ("password", "hash", "session", "token", "otp", "mfa")
     offending = {name for name in column_names if any(marker in name.lower() for marker in forbidden_markers)}
     assert not offending, f"LLCContact must carry no auth-surface columns, found: {offending}"
+
+
+def test_contact_model_has_no_foreign_key_or_relationship_to_users() -> None:
+    """A column-name scan alone would pass a ``ForeignKey("users.id")`` column
+    named e.g. ``owner_id`` — the single change that would actually make a
+    contact resolvable as an auth identity via a join (#13969 review, cheap
+    item). Assert on the schema-level constructs directly rather than
+    trusting naming conventions.
+    """
+    assert not LLCContact.__table__.foreign_keys, (
+        f"LLCContact must have zero foreign keys, found: {LLCContact.__table__.foreign_keys}"
+    )
+    mapper = inspect(LLCContact)
+    user_relationships = [rel for rel in mapper.relationships if rel.mapper.class_.__name__ == "User"]
+    assert not user_relationships, f"LLCContact must have no relationship targeting User, found: {user_relationships}"
 
 
 # canonical: ignore py-adhoc-db-engine (test-local engine, in-memory only)

--- a/autobot-backend/llc/tests/test_contacts_no_login.py
+++ b/autobot-backend/llc/tests/test_contacts_no_login.py
@@ -1,0 +1,110 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""A contact must never resolve through any login/session path (#13969).
+
+Two layers, per the issue's acceptance criteria:
+
+1. Structural: ``LLCContact`` carries no column any auth/session code could
+   possibly key on (no password, no hash, no session/token field). This
+   makes the absence of a login path a property of the schema, not of
+   "nobody happened to wire it up yet".
+2. Behavioural: creating a contact with a given email must not make that
+   email resolve through ``UserService.get_user_by_email`` /
+   ``UserService.authenticate`` — the exact two lookups the login endpoint
+   uses. Mutation-proved: temporarily making ``ContactService.create`` also
+   write a shadow ``users`` row (the precise anti-pattern #13969 forbids —
+   "never a users row") turns this test red; reverting turns it green again.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+# Importing the harness registers the SQLite compile shims for
+# postgresql.JSONB / postgresql.UUID (module-level side effect).
+from llc.tests import _e2e_harness as harness
+from llc.models.contact import LLCContact
+from llc.services.contact import ContactService
+from user_management.models.base import Base
+from user_management.models.user import User
+from user_management.services.user_service import UserService
+
+
+def test_contact_model_has_no_authentication_columns() -> None:
+    """Structural guard: no password/hash/session/token column exists to fill in."""
+    column_names = {c.name for c in LLCContact.__table__.columns}
+    forbidden_markers = ("password", "hash", "session", "token", "otp", "mfa")
+    offending = {name for name in column_names if any(marker in name.lower() for marker in forbidden_markers)}
+    assert not offending, f"LLCContact must carry no auth-surface columns, found: {offending}"
+
+
+@pytest_asyncio.fixture
+async def engine() -> AsyncIterator:
+    eng = create_async_engine("sqlite+aiosqlite:///:memory:")  # canonical: ignore py-adhoc-db-engine (test-local engine)
+    tables = [User.__table__, LLCContact.__table__]
+    for table in tables:
+        harness._scrub_pg_server_defaults(table)
+        harness._rebind_enums_by_value(table)
+        harness._clientside_timestamps(table)
+    async with eng.begin() as conn:
+        await conn.run_sync(lambda c: Base.metadata.create_all(c, tables=tables))
+    yield eng
+    await eng.dispose()
+
+
+@pytest_asyncio.fixture
+async def session_factory(engine):  # noqa: ANN001, ANN201
+    return async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)  # canonical: ignore py-adhoc-db-engine
+
+
+@pytest.mark.asyncio
+async def test_contact_email_never_resolves_through_user_lookup(session_factory):  # noqa: ANN001
+    """The reproduction: creating a contact must not make its email a login identity.
+
+    Mutation-proof for this test lives in the PR verification output — making
+    ``ContactService.create`` additionally ``session.add(User(email=...))``
+    (the exact anti-pattern the issue forbids) turns this red.
+    """
+    company_id = uuid.uuid4()
+    contact_email = "supplier@example.test"
+
+    async with session_factory() as session:
+        svc = ContactService()
+        await svc.create(session, company_id, "Acme Supplier Contact", email=contact_email)
+        await session.commit()
+
+    async with session_factory() as session:
+        user_svc = UserService(session)
+        found = await user_svc.get_user_by_email(contact_email)
+        authed = await user_svc.authenticate(contact_email, "any-password-whatsoever")
+
+    assert found is None, "a contact's email resolved through the users table — it must never be a login identity"
+    assert authed is None, "a contact must never be able to authenticate"
+
+
+@pytest.mark.asyncio
+async def test_a_real_user_with_a_different_email_is_unaffected(session_factory):  # noqa: ANN001
+    """Guards against a fix that satisfies the predicate by breaking user lookup entirely."""
+    async with session_factory() as session:
+        session.add(
+            User(
+                id=uuid.uuid4(),
+                email="real.employee@example.test",
+                username="realemployee",
+                display_name="Real Employee",
+                is_active=True,
+            )
+        )
+        await session.commit()
+
+    async with session_factory() as session:
+        user_svc = UserService(session)
+        found = await user_svc.get_user_by_email("real.employee@example.test")
+
+    assert found is not None
+    assert found.email == "real.employee@example.test"

--- a/autobot-backend/llc/tests/test_contacts_no_login.py
+++ b/autobot-backend/llc/tests/test_contacts_no_login.py
@@ -28,9 +28,9 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 # Importing the harness registers the SQLite compile shims for
 # postgresql.JSONB / postgresql.UUID (module-level side effect).
 from autobot_shared.user_management.models.role import Role, UserRole
-from llc.tests import _e2e_harness as harness
 from llc.models.contact import LLCContact
 from llc.services.contact import ContactService
+from llc.tests import _e2e_harness as harness
 from user_management.models.base import Base
 from user_management.models.user import User
 from user_management.services.user_service import UserService

--- a/autobot-backend/llc/tests/test_contacts_no_login.py
+++ b/autobot-backend/llc/tests/test_contacts_no_login.py
@@ -52,9 +52,9 @@ def test_contact_model_has_no_foreign_key_or_relationship_to_users() -> None:
     item). Assert on the schema-level constructs directly rather than
     trusting naming conventions.
     """
-    assert not LLCContact.__table__.foreign_keys, (
-        f"LLCContact must have zero foreign keys, found: {LLCContact.__table__.foreign_keys}"
-    )
+    assert (
+        not LLCContact.__table__.foreign_keys
+    ), f"LLCContact must have zero foreign keys, found: {LLCContact.__table__.foreign_keys}"
     mapper = inspect(LLCContact)
     user_relationships = [rel for rel in mapper.relationships if rel.mapper.class_.__name__ == "User"]
     assert not user_relationships, f"LLCContact must have no relationship targeting User, found: {user_relationships}"

--- a/autobot-backend/llc/tests/test_contacts_scoping.py
+++ b/autobot-backend/llc/tests/test_contacts_scoping.py
@@ -1,0 +1,130 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Company-scoping regression test for LLCContact (#13969).
+
+Companies inside one AutoBot installation are organisational units, not
+customer-isolation tenants (umbrella #13935 owner correction) — so this is a
+*correctness* test, not a security boundary test: asking for company A's
+contacts must not return company B's, the same way asking for the marketing
+company's contacts must never return the IT company's.
+
+#13936's review (PR #13945) found exactly this predicate untested on the
+query carrying user PII — every test there used a single company against a
+fresh engine, so a dropped ``WHERE company_id`` filter stayed green while
+leaking rows. Contacts are entirely PII by definition, so this needs its own
+two-company case rather than repeating that gap.
+
+Uses a minimal self-contained SQLite fixture (only User + LLCContact tables)
+rather than the full ``_e2e_harness`` loop schema — LLCContact does not
+participate in the e2e loop, and importing ``_e2e_harness`` only for its
+already-registered compile shims (JSONB/PG_UUID -> SQLite) and its
+column-scrubbing helpers keeps this file from duplicating that logic.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+# Importing the harness registers the SQLite compile shims for
+# postgresql.JSONB / postgresql.UUID (module-level side effect, safe to reuse
+# without modifying the shared file).
+from llc.tests import _e2e_harness as harness
+from llc.models.contact import LLCContact
+from llc.services.contact import ContactService
+from user_management.models.base import Base
+
+
+@pytest_asyncio.fixture
+async def engine() -> AsyncIterator:
+    eng = create_async_engine("sqlite+aiosqlite:///:memory:")  # canonical: ignore py-adhoc-db-engine (test-local engine)
+    tables = [LLCContact.__table__]
+    for table in tables:
+        harness._scrub_pg_server_defaults(table)
+        harness._clientside_timestamps(table)
+    async with eng.begin() as conn:
+        await conn.run_sync(lambda c: Base.metadata.create_all(c, tables=tables))
+    yield eng
+    await eng.dispose()
+
+
+@pytest_asyncio.fixture
+async def session_factory(engine):  # noqa: ANN001, ANN201
+    return async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)  # canonical: ignore py-adhoc-db-engine
+
+
+async def _seed_contact(session_factory, company_id: uuid.UUID, *, full_name: str, email: str) -> uuid.UUID:  # noqa: ANN001
+    async with session_factory() as session:
+        svc = ContactService()
+        contact = await svc.create(session, company_id, full_name, email=email)
+        await session.commit()
+        return contact.id
+
+
+@pytest.mark.asyncio
+async def test_company_a_never_sees_company_bs_contacts(session_factory):  # noqa: ANN001
+    """Row-level company scoping on ContactService.list_by_company.
+
+    This pins the ``WHERE company_id`` predicate itself — dropping it leaves
+    every other CRUD test in this suite green while returning every
+    company's contacts from every company's list call.
+    """
+    company_a = uuid.uuid4()
+    company_b = uuid.uuid4()
+
+    await _seed_contact(session_factory, company_a, full_name="Ada Lovelace", email="ada@supplier.test")
+    await _seed_contact(session_factory, company_b, full_name="Brian Kernighan", email="brian@supplier.test")
+    await _seed_contact(session_factory, company_b, full_name="Grace Hopper", email="grace@supplier.test")
+
+    async with session_factory() as session:
+        svc = ContactService()
+        company_a_contacts = await svc.list_by_company(session, company_a)
+        company_b_contacts = await svc.list_by_company(session, company_b)
+
+    assert [c.full_name for c in company_a_contacts] == ["Ada Lovelace"]
+    assert sorted(c.full_name for c in company_b_contacts) == ["Brian Kernighan", "Grace Hopper"]
+
+
+@pytest.mark.asyncio
+async def test_get_is_scoped_to_the_requesting_company(session_factory):  # noqa: ANN001
+    """A contact fetched with the wrong company_id resolves to None, not the row.
+
+    Complements the list-level test above: ``get()`` is the lookup the API's
+    GET/PATCH/DELETE routes use, and has its own independent WHERE clause.
+    """
+    company_a = uuid.uuid4()
+    company_b = uuid.uuid4()
+    contact_id = await _seed_contact(session_factory, company_a, full_name="Ada Lovelace", email="ada@supplier.test")
+
+    async with session_factory() as session:
+        svc = ContactService()
+        own_company = await svc.get(session, company_a, contact_id)
+        other_company = await svc.get(session, company_b, contact_id)
+
+    assert own_company is not None
+    assert own_company.full_name == "Ada Lovelace"
+    assert other_company is None
+
+
+@pytest.mark.asyncio
+async def test_delete_scoped_to_company_never_deletes_another_companys_row(session_factory):  # noqa: ANN001
+    """Deleting with the wrong company_id must not remove the row."""
+    company_a = uuid.uuid4()
+    company_b = uuid.uuid4()
+    contact_id = await _seed_contact(session_factory, company_a, full_name="Ada Lovelace", email="ada@supplier.test")
+
+    async with session_factory() as session:
+        svc = ContactService()
+        deleted = await svc.delete(session, company_b, contact_id)
+        await session.commit()
+
+    assert deleted is False
+
+    async with session_factory() as session:
+        svc = ContactService()
+        still_there = await svc.get(session, company_a, contact_id)
+    assert still_there is not None

--- a/autobot-backend/llc/tests/test_contacts_scoping.py
+++ b/autobot-backend/llc/tests/test_contacts_scoping.py
@@ -30,14 +30,14 @@ import pytest
 import pytest_asyncio
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
+from llc.models.contact import LLCContact
+from llc.services.contact import ContactService
+
 # Importing the harness registers the SQLite compile shims for
 # postgresql.JSONB / postgresql.UUID (module-level side effect, safe to reuse
 # without modifying the shared file).
 from llc.tests import _e2e_harness as harness
-from llc.models.contact import LLCContact
-from llc.services.contact import ContactService
 from user_management.models.base import Base
-
 
 # canonical: ignore py-adhoc-db-engine (test-local engine, in-memory only)
 _SQLITE_MEMORY_URL = "sqlite+aiosqlite:///:memory:"

--- a/autobot-backend/llc/tests/test_contacts_scoping.py
+++ b/autobot-backend/llc/tests/test_contacts_scoping.py
@@ -39,9 +39,13 @@ from llc.services.contact import ContactService
 from user_management.models.base import Base
 
 
+# canonical: ignore py-adhoc-db-engine (test-local engine, in-memory only)
+_SQLITE_MEMORY_URL = "sqlite+aiosqlite:///:memory:"
+
+
 @pytest_asyncio.fixture
 async def engine() -> AsyncIterator:
-    eng = create_async_engine("sqlite+aiosqlite:///:memory:")  # canonical: ignore py-adhoc-db-engine (test-local engine)
+    eng = create_async_engine(_SQLITE_MEMORY_URL)
     tables = [LLCContact.__table__]
     for table in tables:
         harness._scrub_pg_server_defaults(table)
@@ -54,10 +58,13 @@ async def engine() -> AsyncIterator:
 
 @pytest_asyncio.fixture
 async def session_factory(engine):  # noqa: ANN001, ANN201
-    return async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)  # canonical: ignore py-adhoc-db-engine
+    # canonical: ignore py-adhoc-db-engine (test-local session factory)
+    return async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
 
 
-async def _seed_contact(session_factory, company_id: uuid.UUID, *, full_name: str, email: str) -> uuid.UUID:  # noqa: ANN001
+async def _seed_contact(  # noqa: ANN001
+    session_factory, company_id: uuid.UUID, *, full_name: str, email: str
+) -> uuid.UUID:
     async with session_factory() as session:
         svc = ContactService()
         contact = await svc.create(session, company_id, full_name, email=email)

--- a/autobot-backend/llc/tests/test_contacts_validation.py
+++ b/autobot-backend/llc/tests/test_contacts_validation.py
@@ -1,0 +1,76 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Field-level validation on ContactCreate/ContactUpdate (#13969 review M3).
+
+A contact's stated purpose is "the supplier you email" — an unvalidated
+``email`` field lets a CRLF become SMTP header injection the moment a sender
+consumes it, and unvalidated ``full_name``/``notes`` become stored XSS at any
+``v-html`` sink (#13938 renders these people in the Org Chart). The global
+injection middleware scans SQL/command/path only, not XSS or CRLF, so this
+has to be enforced at the schema.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from llc.api.contacts import ContactCreate, ContactUpdate
+
+
+class TestEmailValidation:
+    def test_valid_email_accepted(self) -> None:
+        ContactCreate(full_name="Ada Lovelace", email="ada@supplier.example.com")
+
+    def test_malformed_email_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ContactCreate(full_name="Ada Lovelace", email="not-an-email")
+
+    def test_crlf_in_email_rejected(self) -> None:
+        """The concrete SMTP header injection vector this validation closes."""
+        with pytest.raises(ValidationError):
+            ContactCreate(
+                full_name="Ada Lovelace",
+                email="ada@supplier.example.com\r\nBcc: attacker@evil.example.com",
+            )
+
+
+class TestPhoneValidation:
+    def test_valid_phone_accepted(self) -> None:
+        ContactCreate(full_name="Ada Lovelace", phone="+1 (555) 010-0100")
+
+    def test_free_text_phone_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ContactCreate(full_name="Ada Lovelace", phone="call me maybe")
+
+    def test_script_tag_in_phone_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ContactCreate(full_name="Ada Lovelace", phone="<script>alert(1)</script>")
+
+
+class TestNotesBounded:
+    def test_notes_within_limit_accepted(self) -> None:
+        ContactCreate(full_name="Ada Lovelace", notes="x" * 2000)
+
+    def test_notes_exceeding_limit_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ContactCreate(full_name="Ada Lovelace", notes="x" * 2001)
+
+
+class TestFullNameStripped:
+    def test_whitespace_only_full_name_rejected(self) -> None:
+        """Before this validator, " " passed min_length=1 as a valid name."""
+        with pytest.raises(ValidationError):
+            ContactCreate(full_name="   ")
+
+    def test_surrounding_whitespace_is_stripped(self) -> None:
+        contact = ContactCreate(full_name="  Ada Lovelace  ")
+        assert contact.full_name == "Ada Lovelace"
+
+    def test_update_whitespace_only_full_name_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ContactUpdate(full_name="   ")
+
+    def test_update_full_name_omitted_stays_none(self) -> None:
+        update = ContactUpdate(phone="+1-555-0100")
+        assert update.full_name is None

--- a/autobot-backend/migrations/versions/20260811_072_llc_contacts.py
+++ b/autobot-backend/migrations/versions/20260811_072_llc_contacts.py
@@ -1,0 +1,62 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Add llc_contacts table (#13969).
+
+A contact is a human who appears in a process (the supplier you email, the
+customer you call) with no account and no login path — deliberately never a
+``users`` row. Company-scoped like ``llc_company_memberships`` /
+``llc_secrets`` (no FK to a companies table, matching that existing pattern);
+one contact belongs to exactly one ``company_id`` (see
+``llc/models/contact.py`` module docstring for the cross-company-sharing
+follow-up decision this defers).
+
+Purely additive: new table only, no existing column/table touched.
+
+Revision ID: 20260811_072
+Revises: 20260730_071
+Create Date: 2026-08-11 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision: str = "20260811_072"
+down_revision: Union[str, None] = "20260730_071"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "llc_contacts",
+        # No server_default gen_random_uuid() — the ORM always supplies id
+        # explicitly (ContactService.create), mirroring llc_secrets (#8217).
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("company_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("full_name", sa.String(255), nullable=False),
+        sa.Column("email", sa.String(320), nullable=True),
+        sa.Column("phone", sa.String(64), nullable=True),
+        sa.Column("role_title", sa.String(255), nullable=True),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+    op.create_index("ix_llc_contacts_company_id", "llc_contacts", ["company_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_llc_contacts_company_id", table_name="llc_contacts")
+    op.drop_table("llc_contacts")

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -49674,6 +49674,46 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/llc/contacts/{company_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Contacts */
+        get: operations["list_contacts_api_llc_contacts__company_id__get"];
+        put?: never;
+        /** Create Contact */
+        post: operations["create_contact_api_llc_contacts__company_id__post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/llc/contacts/{company_id}/{contact_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Contact */
+        get: operations["get_contact_api_llc_contacts__company_id___contact_id__get"];
+        put?: never;
+        post?: never;
+        /**
+         * Delete Contact
+         * @description Permanently delete the contact — its PII no longer exists at rest afterward.
+         */
+        delete: operations["delete_contact_api_llc_contacts__company_id___contact_id__delete"];
+        options?: never;
+        head?: never;
+        /** Update Contact */
+        patch: operations["update_contact_api_llc_contacts__company_id___contact_id__patch"];
+        trace?: never;
+    };
     "/api/llc/agent-hires": {
         parameters: {
             query?: never;
@@ -63955,6 +63995,76 @@ export interface components {
          * @enum {string}
          */
         ConsistencyLevel: "consistent" | "mostly_consistent" | "inconsistent" | "unknown";
+        /** ContactCreate */
+        ContactCreate: {
+            /** Full Name */
+            full_name: string;
+            /** Email */
+            email?: string | null;
+            /** Phone */
+            phone?: string | null;
+            /** Role Title */
+            role_title?: string | null;
+            /** Notes */
+            notes?: string | null;
+            /**
+             * Actor
+             * @description User ID performing the operation
+             */
+            actor?: string | null;
+        } & {
+            [key: string]: unknown;
+        };
+        /** ContactResponse */
+        ContactResponse: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /**
+             * Company Id
+             * Format: uuid
+             */
+            company_id: string;
+            /** Full Name */
+            full_name: string;
+            /** Email */
+            email: string | null;
+            /** Phone */
+            phone: string | null;
+            /** Role Title */
+            role_title: string | null;
+            /** Notes */
+            notes: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /**
+             * Updated At
+             * Format: date-time
+             */
+            updated_at: string;
+        } & {
+            [key: string]: unknown;
+        };
+        /** ContactUpdate */
+        ContactUpdate: {
+            /** Full Name */
+            full_name?: string | null;
+            /** Email */
+            email?: string | null;
+            /** Phone */
+            phone?: string | null;
+            /** Role Title */
+            role_title?: string | null;
+            /** Notes */
+            notes?: string | null;
+        } & {
+            [key: string]: unknown;
+        };
         /** ContentClassificationRequest */
         ContentClassificationRequest: {
             /** Content */
@@ -167758,6 +167868,172 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_contacts_api_llc_contacts__company_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                company_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ContactResponse"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_contact_api_llc_contacts__company_id__post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                company_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ContactCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ContactResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_contact_api_llc_contacts__company_id___contact_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                company_id: string;
+                contact_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ContactResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_contact_api_llc_contacts__company_id___contact_id__delete: {
+        parameters: {
+            query?: {
+                actor?: string | null;
+            };
+            header?: never;
+            path: {
+                company_id: string;
+                contact_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_contact_api_llc_contacts__company_id___contact_id__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                company_id: string;
+                contact_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ContactUpdate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ContactResponse"];
                 };
             };
             /** @description Validation Error */

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -64007,11 +64007,6 @@ export interface components {
             role_title?: string | null;
             /** Notes */
             notes?: string | null;
-            /**
-             * Actor
-             * @description User ID performing the operation
-             */
-            actor?: string | null;
         } & {
             [key: string]: unknown;
         };
@@ -167981,9 +167976,7 @@ export interface operations {
     };
     delete_contact_api_llc_contacts__company_id___contact_id__delete: {
         parameters: {
-            query?: {
-                actor?: string | null;
-            };
+            query?: never;
             header?: never;
             path: {
                 company_id: string;


### PR DESCRIPTION
Closes #13969 · Parent umbrella #13935 · Wave 1

## Thinking Path

Read #13969 and umbrella #13935 first — the owner distinction is explicit: "user =
human but not all humans are users — they could be part of a process, like a
contact person in some process, where you send email or call." A contact must
never be a `users` row, because `users` is the authentication boundary and a
non-authenticating identity inside it means every auth column (password hash,
session lookups) gains a row it must specially exclude.

Read PR #13945's review thread per the brief — its finding was an untested
`company_id` predicate on the query carrying user PII, caught only because the
review added a two-company test. Modelled `test_contacts_scoping.py` directly on
that shape.

**Companies are not tenants.** Per a correction relayed mid-task: companies inside
one AutoBot installation are organisational units (an IT company, a marketing
company, both run by the same owner), not customer-isolation boundaries. This PR
therefore calls the `company_id` filter **scoping**, never "tenant isolation" or a
security boundary, in code comments, docstrings, and test names — while keeping
the two-company regression test and `assert_company_access` route guard exactly as
specified, because the *correctness* requirement (company A's view must not show
company B's rows) holds regardless of what the boundary is called.

**Design question answered explicitly, not silently decided:** can one contact be
shared across companies (e.g. a supplier used by both an IT company and a
marketing company)? Two options exist — (1) a contact belongs to exactly one
company (simplest, duplicates a shared supplier as two rows) or (2)
installation-level contacts with a per-company link table (no duplication, but
"delete" becomes ambiguous when other companies still hold a link). This PR ships
option 1: it satisfies every acceptance criterion on #13969, matches the shape of
every other company-scoped LLC model (`LLCCompanyMembership`, `LLCSecret`), and is
additive-compatible with switching to option 2 later (add a link table, backfill
one link per existing contact). Filed the sharing question as its own decision
issue rather than guessing: **#13998**.

Also filed, found but out of scope for this PR: **#13999** — `ActivityLogService.record()`
requires `actor_type` with no default, and `SecretService`/`GoalService` omit it at
their call sites. Currently dormant (the DI slot that would populate
`self.activity_log` doesn't exist yet per GH#8216), so it never executes today —
but the moment that DI wiring lands, secret set/revoke and goal creation would
raise `TypeError` immediately. My own new `ContactService` calls pass `actor_type`
correctly; fixing the two pre-existing sites is a different blast radius (two
unrelated files this PR never touches) so it's tracked rather than folded in here.

Re #13970 (the three-valued actor-axis vocabulary fork): this PR adds **no** new
enum for actor kind. A contact is a separate table with no discriminator column of
that shape — there was nothing to fork. `CoWorkerType`/`AssigneeType` are untouched.

## What Changed

- `autobot-backend/llc/models/contact.py` — new `LLCContact` model. Company-scoped
  (`company_id`, no FK, matching `LLCCompanyMembership`/`LLCSecret`), `full_name`
  required, `email`/`phone`/`role_title`/`notes` optional. No password, no session
  relationship, no column any auth/session lookup could key on — structural, not
  incidental, absence of a login path.
- `autobot-backend/llc/services/contact.py` — `ContactService`: `create`/`get`/
  `list_by_company`/`update`/`delete`. `delete()` is a **hard DELETE**, not
  `LLCSecret`'s soft `revoked_at` pattern — the acceptance criterion is that
  deletion "removes its PII", and a soft-revoked row would still hold plaintext
  name/email/phone/notes at rest. Never imports `knowledge`, `llc.kb`, or
  `utils.async_chromadb_client` — contact data cannot reach the vector store,
  because an embedding can't be revoked and that would create an unhonourable
  deletion request.
- `autobot-backend/llc/api/contacts.py` — `GET/POST /llc/contacts/{company_id}`,
  `GET/PATCH/DELETE /llc/contacts/{company_id}/{contact_id}`. Uses
  `assert_company_access` (#12238), the same shared guard every other LLC router
  uses — reused, not hand-rolled.
- `autobot-backend/llc/models/__init__.py`, `autobot-backend/llc/api/__init__.py` —
  registered the new model/router.
- `autobot-backend/migrations/versions/20260811_072_llc_contacts.py` — new table
  only, purely additive, no existing column/table touched.
- Five new test files (below) — scoping, no-login, no-embedding, CRUD/PII, and
  route-level access control.

Not touched: `get_org_chart` (companies.py) — contacts are never wired into it, per
the owner decision that contacts are not org-chart hierarchy members (no
`reports_to`, no budget, no heartbeat).

## Verification

Baseline measured on **this branch's own commit**, not a quoted number — full LLC
suite minus the 5 new files:

```
$ ./venv/bin/python -m pytest llc/tests/ -q --ignore=llc/tests/test_contact_service.py \
    --ignore=llc/tests/test_contacts_scoping.py --ignore=llc/tests/test_contacts_no_login.py \
    --ignore=llc/tests/test_contacts_no_embedding.py --ignore=llc/tests/test_contacts_idor.py
1421 passed, 1 skipped
```

Full suite with the new files:

```
$ ./venv/bin/python -m pytest llc/tests/ -q
1446 passed, 1 skipped
```

1421 + 25 new tests = 1446 — zero regressions, zero pre-existing failures touched.

Exact CI quality gate:

```
$ bash pipeline-scripts/check-pre-commit-hook-pr.sh pre-commit-hardcoded-values
Running pre-commit-hardcoded-values against 11 changed file(s)...
Scanning 6 staged file(s)...
No violations found!
```

**Mutation-proof 1 — company scoping (`test_contacts_scoping.py`).** Dropped the
`WHERE company_id` predicate in `ContactService.list_by_company`:

```
FAILED llc/tests/test_contacts_scoping.py::test_company_a_never_sees_company_bs_contacts
  AssertionError: assert ['Ada Lovelace', 'Brian Kernighan', 'Grace Hopper'] == ['Ada Lovelace']
1 failed, 2 passed
```

Restored → `3 passed`.

**Mutation-proof 2 — no-login (`test_contacts_no_login.py`).** Made
`ContactService.create` also write a shadow `users` row for the contact's email —
the exact anti-pattern #13969 forbids:

```
FAILED llc/tests/test_contacts_no_login.py::test_contact_email_never_resolves_through_user_lookup
  AssertionError: a contact's email resolved through the users table — it must never be a login identity
  assert <User(...email=supplier@example.test)> is None
1 failed, 2 passed
```

Restored → `3 passed`.

**Bonus mutation-proof — no-embedding guard (`test_contacts_no_embedding.py`,
required by AC5).** Added a call to `get_async_chromadb_client()` inside
`ContactService.create` (what `GoalService._index_goal` does for goals):

```
FAILED test_contact_module_never_imports_the_embedding_plane[llc.services.contact]
FAILED test_full_crud_cycle_never_calls_the_chromadb_client
  AssertionError: Expected 'mock' to not have been called. Called 1 times.
2 failed, 1 passed
```

Restored → `3 passed` (confirmed via `git diff --stat -- llc/services/contact.py`
showing no residual diff after each mutation/restore cycle).

**Deletion removes PII (`test_contact_service.py`):**
`test_delete_removes_the_row_and_its_pii_entirely` does a bare `SELECT` by id with
no company filter and no service layer after `delete()` — proves the row (and its
PII) is gone at rest, not merely excluded by scope.

## Model Used

Sonnet 5