### PR TITLE
security(chat): require chat ownership on /chat/direct (#13982)

### DIFF
--- a/autobot-backend/api/chat.py
+++ b/autobot-backend/api/chat.py
@@ -1898,9 +1898,21 @@ async def send_direct_chat_response(
     Send direct user response to chat (Issue #398: refactored).
 
     Issue #744: Requires authenticated user.
+    Issue #13982: and must own the chat — see the ownership check below.
     """
     request_id = generate_request_id()
     log_request_context(request, "send_direct_response", request_id)
+
+    # #13982: this endpoint carries approval and denial decisions, so without an
+    # ownership check any authenticated user could resolve another user's pending
+    # command approval — and with remember_choice, persist that decision for
+    # future turns in a chat they do not own.
+    #
+    # `Depends(validate_chat_ownership)` cannot be reused here: it resolves
+    # `chat_id` as a path parameter and this endpoint takes it from the body, so
+    # the dependency would validate a different value than the one used. The
+    # explicit call is the same pattern the session endpoints above use.
+    await validate_chat_ownership(chat_id, request)  # SECURITY: caller must own the session
 
     chat_workflow_manager = await get_chat_workflow_manager(request)
     _validate_workflow_manager(chat_workflow_manager)

--- a/autobot-backend/api/chat_direct_ownership_test.py
+++ b/autobot-backend/api/chat_direct_ownership_test.py
@@ -1,0 +1,117 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""`/chat/direct` must refuse a chat the caller does not own (#13982).
+
+The endpoint took `chat_id` from the request body and validated nothing, while
+its sibling `/chats/{chat_id}/message` declared `Depends(validate_chat_ownership)`.
+Authentication was required, so this was never anonymous — the missing boundary
+was between authenticated users.
+
+It matters more than message injection because this endpoint carries approval and
+denial decisions: resolving another user's pending command approval, and with
+`remember_choice` persisting that decision for their future turns.
+
+These tests assert **behaviour**, not that a string appears in the source. A
+source-inspection test passes on a check that is present but never reached, which
+is the failure mode worth guarding against here.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from api import chat as chat_api
+
+
+def _forbidden(*_args, **_kwargs):
+    raise HTTPException(status_code=403, detail="not your session")
+
+
+class TestOwnershipIsEnforced:
+    @pytest.mark.asyncio
+    async def test_a_non_owner_is_refused(self):
+        with patch.object(chat_api, "validate_chat_ownership", side_effect=_forbidden):
+            with pytest.raises(HTTPException) as excinfo:
+                await chat_api.send_direct_chat_response(
+                    current_user={"username": "mallory", "role": "user"},
+                    request=MagicMock(),
+                    message="approve",
+                    chat_id="someone-elses-chat",
+                    remember_choice=False,
+                )
+
+        assert excinfo.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_the_refusal_happens_before_any_workflow_work(self):
+        """A check that runs after the side effect is not a check.
+
+        `remember_choice` persists a decision, so reaching the workflow at all
+        before the boundary holds would already have done the damage.
+        """
+        manager = AsyncMock()
+        with patch.object(chat_api, "validate_chat_ownership", side_effect=_forbidden):
+            with patch.object(chat_api, "get_chat_workflow_manager", manager):
+                with pytest.raises(HTTPException):
+                    await chat_api.send_direct_chat_response(
+                        current_user={"username": "mallory", "role": "user"},
+                        request=MagicMock(),
+                        message="approve",
+                        chat_id="someone-elses-chat",
+                        remember_choice=True,
+                    )
+
+        manager.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_the_validated_chat_id_is_the_one_actually_used(self):
+        """The subtle failure: validating a different id than the request acts on.
+
+        `Depends(validate_chat_ownership)` resolves `chat_id` as a path parameter,
+        and this endpoint takes it from the body — so wiring it as a dependency
+        would have checked one value and streamed into another. This pins that
+        the body value is what gets validated.
+        """
+        seen = {}
+
+        async def _record(chat_id, request):  # noqa: ARG001
+            seen["chat_id"] = chat_id
+            return {"authorized": True}
+
+        with patch.object(chat_api, "validate_chat_ownership", _record):
+            with patch.object(chat_api, "get_chat_workflow_manager", AsyncMock(return_value=MagicMock())):
+                with patch.object(chat_api, "_validate_workflow_manager", MagicMock()):
+                    with patch.object(chat_api, "_create_streaming_response", MagicMock(return_value="streamed")):
+                        result = await chat_api.send_direct_chat_response(
+                            current_user={"username": "alice", "role": "user"},
+                            request=MagicMock(),
+                            message="approve",
+                            chat_id="alices-chat",
+                            remember_choice=False,
+                        )
+
+        assert seen["chat_id"] == "alices-chat"
+        assert result == "streamed", "the owner must still reach the stream — no regression"
+
+
+class TestTheOwnerIsUnaffected:
+    @pytest.mark.asyncio
+    async def test_the_owner_still_reaches_the_workflow(self):
+        manager = MagicMock()
+        with patch.object(chat_api, "validate_chat_ownership", AsyncMock(return_value={"authorized": True})):
+            with patch.object(chat_api, "get_chat_workflow_manager", AsyncMock(return_value=manager)) as getter:
+                with patch.object(chat_api, "_validate_workflow_manager", MagicMock()):
+                    with patch.object(chat_api, "_create_streaming_response", MagicMock(return_value="streamed")):
+                        result = await chat_api.send_direct_chat_response(
+                            current_user={"username": "alice", "role": "user"},
+                            request=MagicMock(),
+                            message="approve",
+                            chat_id="alices-chat",
+                            remember_choice=True,
+                        )
+
+        getter.assert_awaited_once()
+        assert result == "streamed"

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -1494,6 +1494,7 @@ export interface paths {
          * @description Send direct user response to chat (Issue #398: refactored).
          *
          *     Issue #744: Requires authenticated user.
+         *     Issue #13982: and must own the chat — see the ownership check below.
          */
         post: operations["send_direct_chat_response_api_chat_direct_post"];
         delete?: never;


### PR DESCRIPTION
Closes #13982

## Thinking Path

`send_direct_chat_response` took `chat_id` from the request **body** and validated nothing, while its sibling `/chats/{chat_id}/message` declares `Depends(validate_chat_ownership)`. Authentication was required, so this was never anonymous — the boundary that was missing is the one **between authenticated users**, which is exactly what `validate_chat_ownership` exists to enforce.

It matters more than message injection because this endpoint carries approval and denial decisions. Reachable consequences:

- resolving another user's pending command-approval interrupt on their behalf
- `remember_choice=True` persists that decision for their future turns
- the injected message drives the workflow, so it can trigger tool execution in a session the caller does not own

### Decision: an explicit call, not a dependency

`Depends(validate_chat_ownership)` looks like the obvious fix and is wrong here. That dependency resolves `chat_id` as a **path** parameter; this endpoint takes it from the body. FastAPI would therefore validate a *different value* than the one the request acts on — a check that passes while guarding nothing, which is worse than no check because it reads as covered.

The explicit call is the pattern the nine session endpoints above already use (`await validate_chat_ownership(session_id, request)  # SECURITY: ...`), so this adds no new mechanism and reuses the canonical validator with its feature-flag, metrics and audit integration.

## What Changed

- `api/chat.py` — `await validate_chat_ownership(chat_id, request)` in `send_direct_chat_response`, placed **before** any workflow work.

## Verification

### Audit (AC 4)

Every endpoint in `api/chat.py` that accepts a chat/session id — 14 of them. This was the only one unchecked:

```
OK  set_session_role / work_item / approval_categories (9 endpoints)
OK  send_chat_message_by_id      POST /chats/{chat_id}/message
OK  resume_chat_graph            POST /chats/{chat_id}/resume
OK  save_chat_by_id              POST /chats/{chat_id}/save
OK  delete_chat_by_id            DELETE /chats/{chat_id}
OK  send_direct_chat_response    POST /chat/direct        <- fixed here
```

Both `process_message_stream` entrypoints are now covered.

### Tests

```
$ pytest autobot-backend/api/chat_direct_ownership_test.py autobot-backend/api/chat_test.py -q
6 passed
```

Four new tests, asserting **behaviour** rather than source text. The existing precedent (`api_endpoint_migrations_test.py`) uses `inspect.getsource` + `assertIn("validate_session_ownership", ...)`, which passes on a check that is present but never reached — the exact failure mode worth guarding against here.

The tests that carry the most weight:

- **the refusal happens before any workflow work** — `remember_choice` persists a decision, so a check that runs after the side effect is not a check
- **the validated `chat_id` is the one actually used** — pins the body-vs-path mismatch described above

Mutation-tested:

| mutation | result |
|---|---|
| ownership check removed (the vulnerability) | KILLED (3) |
| check moved *after* the workflow is obtained | KILLED (1) |

A note on that second row, because my first run reported it as **SURVIVED**: my replacement anchor was missing a blank line, so the edit silently did nothing and the harness read "no test failed" as "the mutant lived". With the patch actually applied it is killed. A mutation harness that does not verify its own edit landed will report no-ops as survivors — worth knowing before adding tests to chase a phantom gap.

Lint: black, isort, flake8 clean.

### Not covered

The fix relies on `validate_chat_ownership` behaving correctly; its enforcement is feature-flagged (`SessionOwnershipValidator` degrades to permissive if the flags service is unavailable). That pre-existing behaviour is unchanged here — if the flag is off in a given deployment, this endpoint is now consistent with the other 13 rather than uniquely open, but the deployment-level posture is a separate question from this issue.

## Model Used

Claude Opus 5