### PR TITLE
security(chat): require ownership on export_session and reset_chat (#14011)

### DIFF
--- a/autobot-backend/api/chat_sessions.py
+++ b/autobot-backend/api/chat_sessions.py
@@ -1381,7 +1381,12 @@ async def delete_session(
     operation="export_session",
     error_code_prefix="CHAT_SESSIONS",
 )
-async def export_session(session_id: str, request: Request, format: str = "json"):
+async def export_session(
+    session_id: str,
+    request: Request,
+    format: str = "json",
+    ownership: Dict = Depends(validate_session_ownership),  # SECURITY: Validate ownership (#14011)
+):
     """
     Export a chat session in various formats.
 
@@ -1515,6 +1520,12 @@ async def reset_chat(request: Request, reset_request: ChatResetRequest | None = 
         logger.info("Creating new session for reset: %s", session_id)
     else:
         _validate_session_id_or_raise(session_id)
+        # #14011: session_id arrives in the request body, so the file's
+        # `Depends(validate_session_ownership)` pattern cannot be used — it
+        # resolves a path parameter. Reset clears another user's conversation,
+        # so the caller must own it. Only reachable when an id was supplied; an
+        # absent one mints a new session above, which has no owner to check.
+        await validate_session_ownership(session_id, request)  # SECURITY: caller must own the session
 
         if clear_context:
             messages_to_keep = _preserve_system_messages(chat_history_manager, session_id) if keep_system_prompt else []

--- a/autobot-backend/api/chat_sessions_ownership_test.py
+++ b/autobot-backend/api/chat_sessions_ownership_test.py
@@ -1,0 +1,124 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Session endpoints must refuse a session the caller does not own (#14011).
+
+Two gaps, both found by reading every endpoint in `api/chat_sessions.py` rather
+than grepping for the word "ownership":
+
+- ``export_session`` returned another user's **entire transcript**. It even
+  audit-logged the export, so the disclosure was recorded and not prevented.
+- ``reset_chat`` took ``session_id`` from the request body and cleared another
+  user's conversation.
+
+The tests assert behaviour. The precedent in this repo
+(`api_endpoint_migrations_test.py`) uses ``inspect.getsource`` + ``assertIn``,
+which passes on a check that is present but never reached — the failure mode
+worth guarding against when the whole defect is "the call was missing".
+"""
+
+import contextlib
+import inspect
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from api import chat_sessions
+
+
+def _forbidden(*_args, **_kwargs):
+    raise HTTPException(status_code=403, detail="not your session")
+
+
+class TestExportRequiresOwnership:
+    """A path-parameter endpoint, so it uses this file's `Depends` pattern."""
+
+    def test_the_dependency_is_declared(self):
+        """`Depends` is resolved by FastAPI, so the wiring is what there is to assert.
+
+        Calling the function directly would bypass dependency resolution
+        entirely and prove nothing — hence a signature assertion here, and a
+        behavioural one for `reset_chat` below, which calls its check inline.
+        """
+        params = inspect.signature(chat_sessions.export_session).parameters
+
+        assert "ownership" in params, "export_session must declare the ownership dependency"
+        assert params["ownership"].default is not inspect.Parameter.empty
+
+    def test_the_dependency_is_the_canonical_validator(self):
+        """A `Depends` on some other callable would look identical in the signature."""
+        dep = inspect.signature(chat_sessions.export_session).parameters["ownership"].default
+
+        assert dep.dependency is chat_sessions.validate_session_ownership
+
+
+class TestResetRequiresOwnership:
+    @pytest.mark.asyncio
+    async def test_a_non_owner_cannot_reset_someone_elses_session(self):
+        request = MagicMock()
+        reset = MagicMock(session_id="someone-elses-chat", clear_context=True, keep_system_prompt=True)
+
+        with patch.object(chat_sessions, "validate_session_ownership", side_effect=_forbidden):
+            with patch.object(chat_sessions, "get_chat_history_manager", MagicMock()):
+                with pytest.raises(HTTPException) as excinfo:
+                    await chat_sessions.reset_chat(request, reset)
+
+        assert excinfo.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_the_refusal_happens_before_the_session_is_cleared(self):
+        """A check that runs after the wipe is not a check."""
+        manager = MagicMock()
+        manager.save_session = AsyncMock()
+        manager.clear_session = AsyncMock()
+        request = MagicMock()
+        reset = MagicMock(session_id="someone-elses-chat", clear_context=True, keep_system_prompt=True)
+
+        with patch.object(chat_sessions, "validate_session_ownership", side_effect=_forbidden):
+            with patch.object(chat_sessions, "get_chat_history_manager", MagicMock(return_value=manager)):
+                with pytest.raises(HTTPException):
+                    await chat_sessions.reset_chat(request, reset)
+
+        manager.save_session.assert_not_awaited()
+        manager.clear_session.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_the_validated_session_id_is_the_one_from_the_body(self):
+        """The body-vs-path mismatch that makes `Depends` unusable here."""
+        seen = {}
+
+        async def _record(session_id, request):  # noqa: ARG001
+            seen["session_id"] = session_id
+            raise HTTPException(status_code=403, detail="stop here")
+
+        request = MagicMock()
+        reset = MagicMock(session_id="chat-from-the-body", clear_context=True, keep_system_prompt=True)
+
+        with patch.object(chat_sessions, "validate_session_ownership", _record):
+            with patch.object(chat_sessions, "get_chat_history_manager", MagicMock()):
+                with pytest.raises(HTTPException):
+                    await chat_sessions.reset_chat(request, reset)
+
+        assert seen["session_id"] == "chat-from-the-body"
+
+    @pytest.mark.asyncio
+    async def test_a_reset_with_no_session_id_is_not_gated(self):
+        """An absent id mints a new session — there is no owner to check yet.
+
+        Gating it would break starting a fresh chat, so this pins that the new
+        guard is scoped to the case that actually has an owner.
+        """
+        checked = MagicMock(side_effect=AssertionError("must not gate a session-less reset"))
+        request = MagicMock()
+        reset = MagicMock(session_id=None, clear_context=True, keep_system_prompt=True)
+
+        with patch.object(chat_sessions, "validate_session_ownership", checked):
+            with patch.object(chat_sessions, "get_chat_history_manager", MagicMock(return_value=None)):
+                # Whatever else this path does is not under test; the assertion is
+                # that the ownership guard was never consulted.
+                with contextlib.suppress(Exception):
+                    await chat_sessions.reset_chat(request, reset)
+
+        checked.assert_not_called()

--- a/autobot-backend/api/chat_sessions_ownership_test.py
+++ b/autobot-backend/api/chat_sessions_ownership_test.py
@@ -23,17 +23,71 @@ import inspect
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from fastapi import HTTPException
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.testclient import TestClient
 
 from api import chat_sessions
+from security.session_ownership import validate_session_ownership
 
 
 def _forbidden(*_args, **_kwargs):
     raise HTTPException(status_code=403, detail="not your session")
 
 
+def _client(*, owner: str, seen: list | None = None):
+    """Mount just this router, with ownership resolved for *owner* only.
+
+    A real request through FastAPI is the only way to prove the dependency binds
+    `session_id` from the **path**. Asserting on the signature cannot: a
+    dependency that resolved it as a query parameter would look identical there
+    while validating a caller-controlled value.
+    """
+    app = FastAPI()
+    app.include_router(chat_sessions.router)
+
+    async def _ownership(session_id: str, request: Request = None):  # noqa: ARG001
+        if seen is not None:
+            seen.append(session_id)
+        if session_id != owner:
+            raise HTTPException(status_code=403, detail="not your session")
+        return {"authorized": True}
+
+    app.dependency_overrides[validate_session_ownership] = _ownership
+    return TestClient(app, raise_server_exceptions=False)
+
+
+class TestExportIsRefusedForANonOwner:
+    """AC: user A cannot export user B's session; the owner still can."""
+
+    def test_a_non_owner_gets_403(self):
+        seen: list = []
+        client = _client(owner="alices-chat", seen=seen)
+
+        response = client.get("/chat/sessions/bobs-chat/export")
+
+        assert response.status_code == 403
+        assert seen == ["bobs-chat"], "the refusal must come from the validator, not a routing accident"
+
+    def test_the_owner_is_not_refused(self):
+        """The positive half — a guard that refuses everyone is not a fix.
+
+        Asserting only `!= 403` would pass on a 500, so this also pins that the
+        validator ran and saw the id from the **path**. That is the binding a
+        signature assertion cannot check: a dependency resolving `session_id` as
+        a query parameter would look identical in the signature while validating
+        a value the caller controls.
+        """
+        seen: list = []
+        client = _client(owner="alices-chat", seen=seen)
+
+        response = client.get("/chat/sessions/alices-chat/export")
+
+        assert seen == ["alices-chat"], "the validator must run on the path value"
+        assert response.status_code != 403
+
+
 class TestExportRequiresOwnership:
-    """A path-parameter endpoint, so it uses this file's `Depends` pattern."""
+    """Cheap structural guards, kept alongside the request-level tests above."""
 
     def test_the_dependency_is_declared(self):
         """`Depends` is resolved by FastAPI, so the wiring is what there is to assert.


### PR DESCRIPTION
Closes #14011

## Thinking Path

#14011 was filed for one endpoint. Auditing the file properly — reading every function body rather than grepping for "ownership" — found a second gap of the same class and a third that is worse and needed its own issue.

### The audit (AC 3)

Every endpoint in `api/chat_sessions.py` that accepts a session id:

| endpoint | verdict |
|---|---|
| `get_session_messages`, `update_session`, `delete_session` | `Depends(validate_session_ownership)` |
| `add_session_activity`, `add_session_activities_batch`, `get_session_activities` | `Depends(...)` |
| `share_session`, `get_share_preview` | `Depends(...)` |
| **`export_session`** | **no check — fixed here** |
| **`reset_chat`** | **no check — fixed here** |
| `list_sessions` | not a gap — scoped to the caller, takes no id |
| `create_session` | **separate, worse — see #14012** |
| `clear_session_checkpoints` | not a gap — admin-role gated |

### `export_session`

Returned another user's **entire transcript** to any authenticated caller who knew a session id. It already called `audit_record(...)` with `AuditAction.SESSION_EXPORT`, so the disclosure was faithfully recorded and not prevented — the audit trail would show exactly who read what, after the fact.

Fixed with this file's own `Depends(validate_session_ownership)` pattern, since the id is a path parameter.

### `reset_chat`

Took `session_id` from the request **body** with only `_validate_session_id_or_raise` (a format check), then cleared the conversation. `Depends` cannot be reused here — it resolves a path parameter, so it would validate a different value than the one acted on. The check is inline, matching the pattern used elsewhere for body-supplied ids.

It is scoped to the branch where an id was supplied. An absent id mints a new session, which has no owner yet; gating that would break starting a fresh chat, and a test pins that it stays ungated.

### Filed rather than fixed: #14012

`create_session` accepts a client-supplied id (#6746) and checks only its *format*. Neither downstream step guards a collision:

- `chat_history_manager.create_session` calls `save_session(session_id, messages=[], ...)` — **overwrites the stored session with an empty message list**
- `set_session_owner` does an unconditional `redis.set` — **no existing-owner guard**

So one request with a victim's session id both destroys their conversation and makes the attacker its registered owner, after which every other endpoint's ownership check passes for them. That is a destructive takeover, not a missing read check, and the fix interacts with the deliberate #6746 feature — so it gets its own change rather than riding along here.

## What Changed

- `api/chat_sessions.py` — `export_session` gains `ownership: Dict = Depends(validate_session_ownership)`. The id is a path parameter, so this is the same wiring the eight already-protected endpoints in this file use.
- `api/chat_sessions.py` — `reset_chat` gains an inline `await validate_session_ownership(session_id, request)`, placed immediately after the format check and before `_clear_and_restore_session`, the only destructive call. Inline rather than `Depends` because the id arrives in the request body; scoped to the branch where an id was actually supplied.
- `api/chat_sessions_ownership_test.py` (new) — eight tests covering both endpoints.

No behaviour changes for an owner; no new dependency, constant or helper — both calls reuse the canonical `security.session_ownership.validate_session_ownership`.

## Verification

```
$ pytest autobot-backend/api/chat_sessions_ownership_test.py autobot-backend/api/chat_test.py -q
8 passed
```

Eight new tests. Two drive real requests through FastAPI (`TestClient` on a bare app with the dependency overridden) and assert a non-owner gets 403 while the owner does not; four are behavioural on `reset_chat`; two are cheap structural guards on the declared dependency. The existing precedent in this repo (`api_endpoint_migrations_test.py`) uses `inspect.getsource` + `assertIn`, which passes on a check that is present but never reached — precisely the failure mode here, where the whole defect was a missing call.

For `export_session` the assertion is on the declared dependency, and deliberately so: calling the function directly would bypass FastAPI's dependency resolution entirely and prove nothing. One test asserts the dependency **is the canonical validator** — a `Depends` on any other callable would look identical in a signature check.

Mutation-tested, with no-op detection in the harness:

| mutation | result |
|---|---|
| export ownership dependency removed | KILLED (2) |
| export dependency swapped for a different callable | KILLED (1) |
| reset ownership check removed | KILLED (3) |

The harness now verifies its own edit actually changed the file before running, after a no-op silently read as "survived" on an earlier PR this session.

Lint: black, isort, flake8 clean.

### Not covered

Both new checks route through the shared validator, which currently **fails open** — see #14010. With the enforcement flag at its default, these calls are inert. They are still correct and necessary; the deployment posture is a separate change with its own rollout.

## Model Used

Claude Opus 5

