### PR TITLE
fix(analytics): stop /report and /duplicates hanging, and scope the ownership panels (#13602)

### DIFF
--- a/autobot-backend/api/codebase_analytics/duplicate_detector.py
+++ b/autobot-backend/api/codebase_analytics/duplicate_detector.py
@@ -46,9 +46,9 @@ from utils.file_categorization import (
     JS_EXTENSIONS,
     PYTHON_EXTENSIONS,
     SKIP_DIRS,
-    is_skipped_path,
     TS_EXTENSIONS,
     VUE_EXTENSIONS,
+    is_skipped_path,
 )
 
 logger = get_logger(__name__)

--- a/autobot-backend/api/codebase_analytics/duplicate_detector.py
+++ b/autobot-backend/api/codebase_analytics/duplicate_detector.py
@@ -26,7 +26,7 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Set, Tuple
+from typing import Any, Callable, Dict, List, Set, Tuple
 
 from autobot_shared.logging_manager import get_logger
 
@@ -104,6 +104,11 @@ MAX_BLOCKS_FOR_SIMILARITY = 500
 LSH_NUM_PERMUTATIONS = 128  # Higher = more precision, slower. 128=~95% recall, 256=~98%
 LSH_SIMILARITY_THRESHOLD = 0.5  # Minimum similarity for LSH candidate pairs
 LSH_ENABLED = True  # Set False to disable LSH and use O(n^2) fallback
+
+# Issue #13602: how often the long phases consult the cancel token. Checking
+# every item would cost more than the work between checks; every 500 bounds the
+# abandonment window to well under a second while staying free in the hot loop.
+CANCEL_CHECK_INTERVAL = 500
 
 
 # =============================================================================
@@ -438,6 +443,7 @@ def _build_minhash(token_set: Set[str], num_perm: int = LSH_NUM_PERMUTATIONS) ->
 def _build_minhash_signatures(
     blocks: List[CodeBlock],
     num_perm: int,
+    cancelled: "Callable[[], bool] | None" = None,
 ) -> Dict[int, MinHash]:
     """
     Build MinHash signatures for all code blocks.
@@ -447,12 +453,19 @@ def _build_minhash_signatures(
     Args:
         blocks: List of code blocks
         num_perm: Number of MinHash permutations
+        cancelled: #13602 — polled so an abandoned scan stops here. This is the
+            phase that dominates the runtime, and it had no cancellation point
+            at all, so a caller that had already timed out still waited on one
+            of eight shared executor threads until it finished.
 
     Returns:
         Dictionary mapping block index to MinHash signature
     """
     minhashes: Dict[int, MinHash] = {}
     for idx, block in enumerate(blocks):
+        if cancelled is not None and idx % CANCEL_CHECK_INTERVAL == 0 and cancelled():
+            logger.info("MinHash signature build cancelled at %d/%d blocks", idx, len(blocks))
+            return minhashes
         token_set = block.token_set if block.token_set else set(block.normalized_content.split())
         if token_set:
             minhashes[idx] = _build_minhash(token_set, num_perm)
@@ -536,6 +549,7 @@ def _find_lsh_candidates(
     blocks: List[CodeBlock],
     threshold: float = LSH_SIMILARITY_THRESHOLD,
     num_perm: int = LSH_NUM_PERMUTATIONS,
+    cancelled: "Callable[[], bool] | None" = None,
 ) -> List[Tuple[int, int, float]]:
     """
     Find candidate duplicate pairs using Locality-Sensitive Hashing.
@@ -576,7 +590,9 @@ def _find_lsh_candidates(
     )
 
     # Phase 1: Build MinHash signatures - O(n) (Issue #665: uses helper)
-    minhashes = _build_minhash_signatures(blocks, num_perm)
+    minhashes = _build_minhash_signatures(blocks, num_perm, cancelled=cancelled)
+    if cancelled is not None and cancelled():
+        return []
 
     # Phase 2: Create LSH index - O(n) (Issue #665: uses helper)
     lsh = _build_lsh_index(minhashes, threshold, num_perm)
@@ -715,9 +731,23 @@ class DuplicateCodeDetector(_BaseClass):
         return files
 
     def _extract_all_blocks(self, files: List[Path]) -> List[CodeBlock]:
-        """Extract code blocks from all files (Issue #560: extracted)."""
+        """Extract code blocks from all files (Issue #560: extracted).
+
+        #13602: honours the cancel token. #12779 added the token but consulted
+        it only inside the os.walk loop — 0.14 s of a run whose remaining phases
+        measured over six minutes on a single tree. So a scan the caller had
+        abandoned still ran to completion holding one of eight executor threads,
+        which is the starvation that makes unrelated endpoints hang.
+        """
         all_blocks: List[CodeBlock] = []
-        for file_path in files:
+        for index, file_path in enumerate(files):
+            if index % CANCEL_CHECK_INTERVAL == 0 and self._cancelled():
+                logger.info(
+                    "Block extraction cancelled after %d/%d files",
+                    index,
+                    len(files),
+                )
+                return all_blocks
             try:
                 content = file_path.read_text(encoding="utf-8", errors="ignore")
                 blocks = _extract_code_blocks(str(file_path), content)
@@ -901,6 +931,7 @@ class DuplicateCodeDetector(_BaseClass):
                 all_blocks,
                 threshold=LSH_SIMILARITY_THRESHOLD,
                 num_perm=LSH_NUM_PERMUTATIONS,
+                cancelled=self._cancelled,
             )
 
             return self._process_lsh_candidates(all_blocks, lsh_candidates, seen_pairs)
@@ -950,6 +981,12 @@ class DuplicateCodeDetector(_BaseClass):
         # Extract all code blocks
         all_blocks = self._extract_all_blocks(files)
         logger.info("Extracted %d code blocks", len(all_blocks))
+        if self._cancelled():
+            # #13602: abandoned before the expensive similarity phases. Returning
+            # an empty analysis is honest — the caller has already stopped
+            # waiting — and it frees the executor thread the next request needs.
+            logger.info("Duplicate detection abandoned before similarity search")
+            return self._build_duplicate_analysis([], len(files))
 
         # Group blocks by hash for exact matches
         hash_groups: Dict[str, List[CodeBlock]] = defaultdict(list)
@@ -1204,6 +1241,12 @@ class DuplicateCodeDetector(_BaseClass):
         # Extract all code blocks
         all_blocks = self._extract_all_blocks(files)
         logger.info("Extracted %d code blocks", len(all_blocks))
+        if self._cancelled():
+            # #13602: abandoned before the expensive similarity phases. Returning
+            # an empty analysis is honest — the caller has already stopped
+            # waiting — and it frees the executor thread the next request needs.
+            logger.info("Duplicate detection abandoned before similarity search")
+            return self._build_duplicate_analysis([], len(files))
 
         # Issue #665: Use helper to collect duplicates
         duplicates = await self._collect_all_duplicates(all_blocks)

--- a/autobot-backend/api/codebase_analytics/duplicate_detector.py
+++ b/autobot-backend/api/codebase_analytics/duplicate_detector.py
@@ -46,6 +46,7 @@ from utils.file_categorization import (
     JS_EXTENSIONS,
     PYTHON_EXTENSIONS,
     SKIP_DIRS,
+    is_skipped_path,
     TS_EXTENSIONS,
     VUE_EXTENSIONS,
 )
@@ -662,9 +663,14 @@ class DuplicateCodeDetector(_BaseClass):
         return self._cancel_token is not None and self._cancel_token.is_set()
 
     def _should_skip_path(self, path: Path) -> bool:
-        """Check if path should be skipped."""
-        path_parts = set(path.parts)
-        return bool(path_parts & SKIP_DIRS)
+        """Check if path should be skipped, relative to this scan's root.
+
+        #13602: this compared SKIP_DIRS against the ABSOLUTE path, so scanning a
+        root that itself sits under `.worktrees/` would have classified every
+        file below it as skippable. The method had no callers, so nothing broke
+        — it was a trap armed for whoever wired it in next.
+        """
+        return is_skipped_path(path, self.project_root)
 
     def _get_files_to_scan(self) -> List[Path]:
         """Get list of files to scan for duplicates.

--- a/autobot-backend/api/codebase_analytics/duplicate_scan_cancellation_12779_test.py
+++ b/autobot-backend/api/codebase_analytics/duplicate_scan_cancellation_12779_test.py
@@ -177,3 +177,153 @@ class TestScanRootInsideASkippedDirectory:
         assert not detector._should_skip_path(root / "pkg" / "real.py")
         assert detector._should_skip_path(root / ".worktrees" / "nested" / "x.py")
         assert detector._should_skip_path(root / "node_modules" / "y.py")
+
+
+class TestCancellationReachesTheExpensivePhases:
+    """#13602: the token was consulted in exactly one place — the os.walk loop.
+
+    That loop measured 0.14s of a run whose remaining phases took over six
+    minutes on a single tree (105,441 blocks, still building MinHash signatures
+    at 6m15s). So a scan the caller had abandoned still ran to completion,
+    holding one of eight shared executor threads. That starvation is what made
+    unrelated endpoints hang.
+
+    The review of #14014 found these checks shipped with NO test — the whole
+    detector half could be deleted and the suite stayed green. These are that
+    test: each asserts the phase stops, not merely that a check exists.
+    """
+
+    def _blocks(self, count):
+        from api.codebase_analytics.duplicate_detector import CodeBlock
+
+        return [
+            CodeBlock(
+                file_path=f"/tmp/f{i}.py",
+                start_line=1,
+                end_line=5,
+                content=f"def f{i}(): pass",
+                normalized_content=f"def f{i} pass",
+                content_hash=f"h{i}",
+                line_count=5,
+                token_set={f"tok{i}", "def", "pass"},
+            )
+            for i in range(count)
+        ]
+
+    def test_block_extraction_stops_when_cancelled(self, tmp_path, monkeypatch):
+        import api.codebase_analytics.duplicate_detector as det
+
+        files = []
+        for i in range(det.CANCEL_CHECK_INTERVAL * 3):
+            f = tmp_path / f"m{i}.py"
+            f.write_text("x = 1\n", encoding="utf-8")
+            files.append(f)
+
+        token = threading.Event()
+        token.set()
+        detector = det.DuplicateCodeDetector(project_root=str(tmp_path), cancel_token=token)
+
+        read_count = {"n": 0}
+        real_read = Path.read_text
+
+        def _counting_read(self, *args, **kwargs):
+            read_count["n"] += 1
+            return real_read(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", _counting_read)
+        detector._extract_all_blocks(files)
+
+        assert read_count["n"] < len(files), "extraction read every file despite being cancelled"
+
+    def test_minhash_signature_build_stops_when_cancelled(self):
+        """This is the phase that dominates the runtime, and it had no
+        cancellation point at all."""
+        import api.codebase_analytics.duplicate_detector as det
+
+        pytest.importorskip("datasketch")
+        blocks = self._blocks(det.CANCEL_CHECK_INTERVAL * 3)
+
+        signatures = det._build_minhash_signatures(blocks, num_perm=16, cancelled=lambda: True)
+
+        assert len(signatures) < len(blocks), "signature build processed every block despite cancellation"
+
+    def test_minhash_build_completes_when_not_cancelled(self):
+        """The case that must stay working — a cancellation check that always
+        fires would pass the test above while breaking every real scan."""
+        import api.codebase_analytics.duplicate_detector as det
+
+        pytest.importorskip("datasketch")
+        blocks = self._blocks(10)
+
+        signatures = det._build_minhash_signatures(blocks, num_perm=16, cancelled=lambda: False)
+
+        assert len(signatures) == len(blocks)
+
+    def test_the_lsh_phase_is_given_the_token(self, tmp_path, monkeypatch):
+        """Threading the predicate through is the wiring; without it the checks
+        inside are unreachable."""
+        import api.codebase_analytics.duplicate_detector as det
+
+        seen: dict[str, object] = {}
+
+        def _spy(blocks, threshold=0.5, num_perm=128, cancelled=None):
+            seen["cancelled"] = cancelled
+            return []
+
+        monkeypatch.setattr(det, "_find_lsh_candidates", _spy)
+        monkeypatch.setattr(det, "LSH_AVAILABLE", True)
+        detector = det.DuplicateCodeDetector(project_root=str(tmp_path), cancel_token=threading.Event())
+        detector._find_similar_duplicates(self._blocks(20), set())
+
+        assert seen["cancelled"] is not None, "the LSH phase was never given the cancel predicate"
+        assert seen["cancelled"]() is False
+        detector._cancel_token.set()
+        assert seen["cancelled"]() is True, "the predicate must reflect the live token"
+
+    def test_a_scan_cancelled_after_the_walk_skips_the_similarity_phases(self, tmp_path, monkeypatch):
+        """The phase boundary. Without it, a token set during extraction still
+        let the six-minute similarity search run to completion."""
+        import api.codebase_analytics.duplicate_detector as det
+
+        (tmp_path / "a.py").write_text("def a(): pass\n", encoding="utf-8")
+        token = threading.Event()
+        detector = det.DuplicateCodeDetector(project_root=str(tmp_path), cancel_token=token)
+
+        called = {"similar": False}
+
+        def _never(*_args, **_kwargs):
+            called["similar"] = True
+            return []
+
+        monkeypatch.setattr(detector, "_find_similar_duplicates", _never)
+        monkeypatch.setattr(detector, "_extract_all_blocks", lambda files: (token.set(), [])[1])
+
+        result = detector.run_analysis()
+
+        assert not called["similar"], "the similarity search ran on an abandoned scan"
+        assert result.total_duplicates == 0
+
+    @pytest.mark.asyncio
+    async def test_the_async_path_has_the_same_boundary(self, tmp_path, monkeypatch):
+        """`run_analysis` and `run_analysis_async` are separate implementations
+        and the check had to be added to both. Guarding only the sync one would
+        leave the semantic-analysis path running abandoned scans to completion."""
+        import api.codebase_analytics.duplicate_detector as det
+
+        (tmp_path / "a.py").write_text("def a(): pass\n", encoding="utf-8")
+        token = threading.Event()
+        detector = det.DuplicateCodeDetector(project_root=str(tmp_path), cancel_token=token)
+
+        called = {"collected": False}
+
+        async def _never(*_args, **_kwargs):
+            called["collected"] = True
+            return []
+
+        monkeypatch.setattr(detector, "_collect_all_duplicates", _never)
+        monkeypatch.setattr(detector, "_extract_all_blocks", lambda files: (token.set(), [])[1])
+
+        result = await detector.run_analysis_async()
+
+        assert not called["collected"], "the async path ran the expensive phases on an abandoned scan"
+        assert result.total_duplicates == 0

--- a/autobot-backend/api/codebase_analytics/duplicate_scan_cancellation_12779_test.py
+++ b/autobot-backend/api/codebase_analytics/duplicate_scan_cancellation_12779_test.py
@@ -31,7 +31,13 @@ def _tree(root: Path) -> None:
     """Build a source tree with excluded dirs that must never be descended."""
     (root / "pkg").mkdir(parents=True)
     (root / "pkg" / "real.py").write_text("x = 1\n", encoding="utf-8")
-    for skipped in ("node_modules", ".git", "venv"):
+    # #13602: `.worktrees` and `.claude/worktrees` were NOT in SKIP_DIRS, despite
+    # _get_files_to_scan's own docstring claiming `.worktrees/` was pruned. On a
+    # real checkout that was 160,105 of 167,072 code files — the repo scanned ~26
+    # times over. This test passed throughout, because _tree() never built one.
+    (root / ".claude" / "worktrees" / "wt2" / "pkg").mkdir(parents=True)
+    (root / ".claude" / "worktrees" / "wt2" / "pkg" / "noise.py").write_text("z = 3\n", encoding="utf-8")
+    for skipped in ("node_modules", ".git", "venv", ".worktrees"):
         deep = root / skipped / "a" / "b" / "c"
         deep.mkdir(parents=True)
         (deep / "noise.py").write_text("y = 2\n", encoding="utf-8")
@@ -137,3 +143,37 @@ class TestSingleFlight:
         ep._duplicate_scan_lock.release()
         assert ep._duplicate_scan_lock.acquire(blocking=False)
         ep._duplicate_scan_lock.release()
+
+
+class TestScanRootInsideASkippedDirectory:
+    """#13602: adding `.worktrees` to SKIP_DIRS arms a trap.
+
+    Five call sites tested `SKIP_DIRS & set(path.parts)` on an ABSOLUTE path,
+    which asks whether a skip name appears anywhere in it — including in the
+    scan root. CI and development both run from inside `.worktrees/`, so the
+    moment the name was added, scanning from such a root would classify every
+    file below it as skippable and report an empty codebase. No error, no log,
+    just zero results — indistinguishable from a clean repo.
+
+    The root-relative check (#7128b's pattern) is what makes the name safe to
+    add at all.
+    """
+
+    def test_a_root_inside_worktrees_still_finds_its_own_files(self, tmp_path):
+        root = tmp_path / ".worktrees" / "issue-13602"
+        _tree(root)
+        found = DuplicateCodeDetector(project_root=str(root))._get_files_to_scan()
+        names = {p.name for p in found}
+        assert "real.py" in names, "a scan rooted inside .worktrees must not erase itself"
+        assert "noise.py" not in names, "nested skip dirs must still be pruned"
+
+    def test_should_skip_path_is_relative_to_the_scan_root(self, tmp_path):
+        """The dead method wired in (#13602). It had no callers, so its absolute
+        comparison was a trap armed for whoever wired it in next."""
+        root = tmp_path / ".worktrees" / "issue-13602"
+        (root / "pkg").mkdir(parents=True)
+        detector = DuplicateCodeDetector(project_root=str(root))
+
+        assert not detector._should_skip_path(root / "pkg" / "real.py")
+        assert detector._should_skip_path(root / ".worktrees" / "nested" / "x.py")
+        assert detector._should_skip_path(root / "node_modules" / "y.py")

--- a/autobot-backend/api/codebase_analytics/endpoints/duplicate_single_flight_13602_test.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/duplicate_single_flight_13602_test.py
@@ -1,0 +1,145 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""The single-flight guard has to cover every caller, and outlast the orphan (#13602).
+
+#12779 added a lock and a cancel token so an abandoned duplicate scan could not
+accumulate. Two holes remained, and both let the accumulation back in:
+
+1. `/report` submitted its own scan straight to the shared analytics executor
+   with neither the lock nor the token. Same executor, same 8 workers — so a
+   report queued a full walk regardless of one already running, and its orphan
+   could not be told to stop.
+
+2. The lock was released in a `finally` that ran on timeout, while the orphan
+   thread was still going. The next poll therefore acquired it immediately and
+   queued a second full scan on top of the first.
+
+Both are invisible from outside: the endpoint returns, the log says the scan
+timed out, and nothing reports that the work is still running or that scans are
+stacking.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+
+import pytest
+
+import api.codebase_analytics.endpoints.duplicates as dup_mod
+import api.codebase_analytics.endpoints.report as report_mod
+
+
+class TestReportUsesTheGuardedScan:
+    @pytest.mark.asyncio
+    async def test_report_does_not_queue_a_scan_while_one_is_in_flight(self, monkeypatch, tmp_path):
+        """With the lock held, /report's duplicate analysis must decline rather
+        than start a second walk on the shared executor."""
+        submitted: list[str] = []
+
+        def _record(*_args, **_kwargs):
+            submitted.append("scan")
+            raise AssertionError("a second scan was queued while one was in flight")
+
+        monkeypatch.setattr(dup_mod, "DuplicateCodeDetector", _record)
+
+        assert dup_mod._duplicate_scan_lock.acquire(blocking=False)
+        try:
+            result = await report_mod._get_duplicate_analysis(project_root=tmp_path)
+        finally:
+            dup_mod._duplicate_scan_lock.release()
+
+        assert result is None, "an in-flight scan yields no result rather than a duplicate scan"
+        assert submitted == [], "the report path must go through the single-flight guard"
+
+    @pytest.mark.asyncio
+    async def test_report_returns_the_guarded_scans_result(self, monkeypatch, tmp_path):
+        """Delegation must not silently drop a successful analysis.
+
+        The stub carries the counters the success log reads: a bare object made
+        this fail through the handler's `except Exception`, which is worth
+        noting — a delegation that returned something unexpected would be
+        reported as "duplicate analysis failed", not as a wiring bug.
+        """
+
+        class _Analysis:
+            total_duplicates = 3
+            high_similarity_count = 1
+            medium_similarity_count = 1
+            low_similarity_count = 1
+
+        sentinel = _Analysis()
+
+        async def _fake(project_root, min_similarity):
+            return sentinel
+
+        monkeypatch.setattr(report_mod, "_run_standard_analysis", _fake)
+
+        assert await report_mod._get_duplicate_analysis(project_root=tmp_path) is sentinel
+
+
+class TestTheLockOutlastsTheOrphan:
+    @pytest.mark.asyncio
+    async def test_lock_stays_held_until_the_abandoned_scan_exits(self, monkeypatch, tmp_path):
+        """On timeout the thread survives. Releasing the lock then is what let
+        abandoned scans stack — the very accumulation #12779 set out to stop."""
+        release_thread = threading.Event()
+        started = threading.Event()
+
+        class _SlowDetector:
+            def __init__(self, **kwargs):
+                self._cancel_token = kwargs.get("cancel_token")
+
+            def run_analysis(self):
+                started.set()
+                release_thread.wait(timeout=30)
+                return "done"
+
+        monkeypatch.setattr(dup_mod, "DuplicateCodeDetector", _SlowDetector)
+        monkeypatch.setattr(dup_mod.AnalyticsConfig, "DUPLICATE_DETECTION_TIMEOUT", 0.1)
+
+        result = await dup_mod._run_standard_analysis(str(tmp_path), 0.5)
+        assert result is None, "the scan should have timed out"
+        assert started.is_set()
+
+        # The orphan is still running: the guard must still be closed.
+        acquired = dup_mod._duplicate_scan_lock.acquire(blocking=False)
+        if acquired:
+            dup_mod._duplicate_scan_lock.release()
+        assert not acquired, "the lock was released while the abandoned scan was still running"
+
+        # Once it exits, the guard reopens — otherwise this is a permanent block,
+        # which would be a worse bug than the one being fixed.
+        release_thread.set()
+        for _ in range(100):
+            if dup_mod._duplicate_scan_lock.acquire(blocking=False):
+                dup_mod._duplicate_scan_lock.release()
+                break
+            await asyncio.sleep(0.05)
+        else:
+            pytest.fail("the lock was never released after the abandoned scan finished")
+
+    @pytest.mark.asyncio
+    async def test_the_abandoned_scan_is_told_to_stop(self, monkeypatch, tmp_path):
+        """Holding the lock is only bounded because the thread can be cancelled."""
+        seen_token: dict[str, threading.Event | None] = {}
+        proceed = threading.Event()
+
+        class _SlowDetector:
+            def __init__(self, **kwargs):
+                seen_token["token"] = kwargs.get("cancel_token")
+
+            def run_analysis(self):
+                proceed.wait(timeout=30)
+                return "done"
+
+        monkeypatch.setattr(dup_mod, "DuplicateCodeDetector", _SlowDetector)
+        monkeypatch.setattr(dup_mod.AnalyticsConfig, "DUPLICATE_DETECTION_TIMEOUT", 0.1)
+
+        await dup_mod._run_standard_analysis(str(tmp_path), 0.5)
+        token = seen_token["token"]
+        assert token is not None, "the scan must be given a cancel token"
+        assert token.is_set(), "an abandoned scan must be signalled to stop"
+        proceed.set()

--- a/autobot-backend/api/codebase_analytics/endpoints/duplicate_single_flight_13602_test.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/duplicate_single_flight_13602_test.py
@@ -143,3 +143,57 @@ class TestTheLockOutlastsTheOrphan:
         assert token is not None, "the scan must be given a cancel token"
         assert token.is_set(), "an abandoned scan must be signalled to stop"
         proceed.set()
+
+
+class TestCancellationIsNotATimeout:
+    """#14014 review: `CancelledError` is not `TimeoutError`, so it skipped the
+    timeout handler entirely and fell through to `finally`.
+
+    The lock was released with the token never set — and because the future is
+    shielded, the orphan kept burning an executor thread with no way to stop it.
+    That is the accumulation both #12779 and this work exist to close, reachable
+    via uvicorn graceful shutdown and via any outer deadline tighter than the
+    inner one. `/report` now wraps this call in its own deadline, so the two are
+    nested and the margin between them is the only thing that was preventing it.
+    """
+
+    @pytest.mark.asyncio
+    async def test_an_outer_cancel_still_signals_the_orphan(self, monkeypatch, tmp_path):
+        seen: dict[str, threading.Event | None] = {}
+        proceed = threading.Event()
+        started = threading.Event()
+
+        class _SlowDetector:
+            def __init__(self, **kwargs):
+                seen["token"] = kwargs.get("cancel_token")
+
+            def run_analysis(self):
+                started.set()
+                proceed.wait(timeout=30)
+                return "done"
+
+        monkeypatch.setattr(dup_mod, "DuplicateCodeDetector", _SlowDetector)
+
+        task = asyncio.ensure_future(dup_mod._run_standard_analysis(str(tmp_path), 0.5))
+        await asyncio.get_running_loop().run_in_executor(None, started.wait, 10)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert seen["token"] is not None
+        assert seen["token"].is_set(), "a cancelled scan must be signalled to stop, exactly like a timed-out one"
+
+        # And the guard must stay shut until the orphan actually exits.
+        acquired = dup_mod._duplicate_scan_lock.acquire(blocking=False)
+        if acquired:
+            dup_mod._duplicate_scan_lock.release()
+        assert not acquired, "the lock was released while the cancelled scan was still running"
+
+        proceed.set()
+        for _ in range(100):
+            if dup_mod._duplicate_scan_lock.acquire(blocking=False):
+                dup_mod._duplicate_scan_lock.release()
+                break
+            await asyncio.sleep(0.05)
+        else:
+            pytest.fail("the lock was never released after the cancelled scan finished")

--- a/autobot-backend/api/codebase_analytics/endpoints/duplicates.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/duplicates.py
@@ -145,6 +145,18 @@ async def _run_standard_analysis(project_root: str, min_similarity: float):
             AnalyticsConfig.DUPLICATE_DETECTION_TIMEOUT,
         )
         return None
+    except asyncio.CancelledError:
+        # #13602: CancelledError is NOT TimeoutError, so it skipped the handler
+        # above and fell to `finally`, releasing the lock with the token never
+        # set — and the shield guarantees the orphan keeps burning an executor
+        # thread. That is the accumulation both #12779 and this change exist to
+        # close, reachable via uvicorn graceful shutdown and via any outer
+        # deadline tighter than this one. Same treatment as a timeout.
+        cancel_token.set()
+        future.add_done_callback(lambda _f: _duplicate_scan_lock.release())
+        released = True
+        logger.warning("Duplicate detection cancelled — signalled the orphaned scan to stop")
+        raise
     finally:
         if not released:
             _duplicate_scan_lock.release()

--- a/autobot-backend/api/codebase_analytics/endpoints/duplicates.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/duplicates.py
@@ -112,32 +112,42 @@ async def _run_standard_analysis(project_root: str, min_similarity: float):
 
     cancel_token = threading.Event()
     _duplicate_scan_cancel = cancel_token
+    released = False
+    # Issue #1233: Use dedicated analytics executor to prevent
+    # default thread pool starvation
+    future = asyncio.get_running_loop().run_in_executor(
+        get_analytics_executor(),
+        lambda: DuplicateCodeDetector(
+            project_root=project_root,
+            min_similarity=min_similarity,
+            cancel_token=cancel_token,
+        ).run_analysis(),
+    )
     try:
-        # Issue #1233: Use dedicated analytics executor to prevent
-        # default thread pool starvation
-        analysis = await asyncio.wait_for(
-            asyncio.get_running_loop().run_in_executor(
-                get_analytics_executor(),
-                lambda: DuplicateCodeDetector(
-                    project_root=project_root,
-                    min_similarity=min_similarity,
-                    cancel_token=cancel_token,
-                ).run_analysis(),
-            ),
-            timeout=AnalyticsConfig.DUPLICATE_DETECTION_TIMEOUT,
-        )
+        analysis = await asyncio.wait_for(asyncio.shield(future), timeout=AnalyticsConfig.DUPLICATE_DETECTION_TIMEOUT)
+        _duplicate_scan_lock.release()
+        released = True
         return analysis
     except asyncio.TimeoutError:
         # The executor thread survives this cancellation — signal it to stop, or
         # it keeps scanning for a result that is already discarded (#12779).
         cancel_token.set()
+        # #13602: hold the lock until that thread actually exits. Releasing it
+        # here let the next poll queue a second full scan while the first was
+        # still running, so abandoned scans stacked up — the accumulation #12779
+        # set out to stop. The token above is what makes this bounded rather
+        # than a permanent block: the thread now checks it in its long phases.
+        future.add_done_callback(lambda _f: _duplicate_scan_lock.release())
+        released = True
         logger.warning(
-            "Duplicate detection timed out after %d seconds — signalled the " "orphaned scan to stop",
+            "Duplicate detection timed out after %d seconds — signalled the "
+            "orphaned scan to stop and holding the single-flight lock until it does",
             AnalyticsConfig.DUPLICATE_DETECTION_TIMEOUT,
         )
         return None
     finally:
-        _duplicate_scan_lock.release()
+        if not released:
+            _duplicate_scan_lock.release()
 
 
 def _convert_analysis_to_result(analysis, project_root: str) -> dict:

--- a/autobot-backend/api/codebase_analytics/endpoints/ownership.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/ownership.py
@@ -119,7 +119,9 @@ def _validate_path_security(path: str, project_root: str) -> JSONResponse | None
             # The requested path is the attacker-supplied string and the only
             # forensically useful field; the root is ours and stays out of the
             # log. The first version of this logged exactly the wrong one.
-            logger.warning("Path traversal attempt blocked: %s", path)
+            # %r, truncated: the attacker controls this string, and an
+            # unescaped newline in it forges log lines.
+            logger.warning("Path traversal attempt blocked: %r", str(path)[:200])
         else:
             # Still WARNING, deliberately: an alert keyed on a rejected path must
             # keep firing. Only the misleading "attack" wording is scoped to an

--- a/autobot-backend/api/codebase_analytics/endpoints/ownership.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/ownership.py
@@ -22,7 +22,7 @@ from fastapi.responses import JSONResponse
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 
-from .shared import resolve_project_root
+from .shared import resolve_project_root, resolve_scan_root
 
 logger = get_logger(__name__)
 
@@ -75,6 +75,26 @@ def _get_project_root() -> str:
     return resolve_project_root()
 
 
+def _escapes_root(path: str, project_root: str) -> bool:
+    """True only when ``path`` climbs OUT of ``project_root`` after normalising.
+
+    #13602: distinguishes a genuine traversal attempt ("../../etc/passwd") from
+    a request scoped to a different, legitimate root. Both were logged as
+    attacks, so ordinary use filled the security log with false alerts.
+    """
+    from pathlib import Path as _Path
+
+    try:
+        resolved = _Path(path).resolve()
+        root = _Path(project_root).resolve()
+    except (OSError, ValueError):
+        return True
+    if resolved == root or root in resolved.parents:
+        return False
+    # Inside the root before normalising but outside after => it climbed out.
+    return ".." in _Path(path).parts
+
+
 def _validate_path_security(path: str, project_root: str) -> JSONResponse | None:
     """
     Validate that path is within project root.
@@ -90,7 +110,15 @@ def _validate_path_security(path: str, project_root: str) -> JSONResponse | None
         validate_path(path, allowed_roots=[project_root])
         return None
     except ValueError:
-        logger.warning("Path traversal attempt blocked: %s", path)
+        # #13602: this fired on every legitimate source-scoped request and read
+        # as an attack, which devalues the real ones — and it echoed the
+        # internal clone path into the log. A path that stays inside its root
+        # after normalisation is a scope mismatch, not an escape attempt; only
+        # a path that climbs out of it is worth an attack-shaped warning.
+        if _escapes_root(path, project_root):
+            logger.warning("Path traversal attempt blocked outside %s", project_root)
+        else:
+            logger.info("Requested path is outside the resolved scan root; rejecting")
         return JSONResponse(
             {
                 "status": "error",
@@ -307,21 +335,18 @@ async def get_ownership_analysis(
     if cached:
         return cached
 
-    project_root = _get_project_root()
-    # Issue #3685: Use clone_path for the correct project when source_id provided
-    if source_id and not path:
-        try:
-            from api.codebase_analytics.source_storage import get_source
-
-            source = await get_source(source_id)
-            if source and source.clone_path:
-                project_root = source.clone_path
-        except Exception:
-            logger.debug("Could not resolve clone_path for %s, using default", source_id)
+    # #13602: was `_get_project_root()` on the next-but-one line, discarding the
+    # clone path resolved just above. A source's clone path lives under
+    # data/code-sources/<id> while the project root resolves to the checkout —
+    # sibling subtrees that never nest, so the containment check rejected EVERY
+    # source-scoped request. Deterministic, not layout-dependent.
+    # Now uses the canonical resolver (#12330), as environment.py, call_graph.py
+    # and dependencies.py already do, instead of hand-rolling the lookup.
+    scan_root = str(await resolve_scan_root(source_id))
     if not path:
-        path = project_root
+        path = scan_root
 
-    error_response = _validate_path_security(path, _get_project_root())
+    error_response = _validate_path_security(path, scan_root)
     if error_response:
         return error_response
 
@@ -387,12 +412,15 @@ async def get_expertise_scores(
             return JSONResponse(_build_expertise_response(scores, len(scores), "cache"))
 
     # Run fresh analysis if no cache
-    project_root = _get_project_root()
+    # #13602: these accepted `source_id` "for API consistency" and ignored it,
+    # so every source's panel analysed AutoBot's own tree — cross-project
+    # leakage rather than the 400 that /analysis returned.
+    scan_root = str(await resolve_scan_root(source_id))
     if not path:
-        path = project_root
+        path = scan_root
 
-    # Security: Validate path is within project root
-    error_response = _validate_path_security(path, project_root)
+    # Security: Validate path is within the resolved scan root
+    error_response = _validate_path_security(path, scan_root)
     if error_response:
         return error_response
 
@@ -441,12 +469,15 @@ async def get_knowledge_gaps(
             return JSONResponse(_build_knowledge_gaps_response(gaps, len(gaps), "cache"))
 
     # Run fresh analysis if no cache
-    project_root = _get_project_root()
+    # #13602: these accepted `source_id` "for API consistency" and ignored it,
+    # so every source's panel analysed AutoBot's own tree — cross-project
+    # leakage rather than the 400 that /analysis returned.
+    scan_root = str(await resolve_scan_root(source_id))
     if not path:
-        path = project_root
+        path = scan_root
 
-    # Security: Validate path is within project root
-    error_response = _validate_path_security(path, project_root)
+    # Security: Validate path is within the resolved scan root
+    error_response = _validate_path_security(path, scan_root)
     if error_response:
         return error_response
 

--- a/autobot-backend/api/codebase_analytics/endpoints/ownership.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/ownership.py
@@ -116,9 +116,15 @@ def _validate_path_security(path: str, project_root: str) -> JSONResponse | None
         # after normalisation is a scope mismatch, not an escape attempt; only
         # a path that climbs out of it is worth an attack-shaped warning.
         if _escapes_root(path, project_root):
-            logger.warning("Path traversal attempt blocked outside %s", project_root)
+            # The requested path is the attacker-supplied string and the only
+            # forensically useful field; the root is ours and stays out of the
+            # log. The first version of this logged exactly the wrong one.
+            logger.warning("Path traversal attempt blocked: %s", path)
         else:
-            logger.info("Requested path is outside the resolved scan root; rejecting")
+            # Still WARNING, deliberately: an alert keyed on a rejected path must
+            # keep firing. Only the misleading "attack" wording is scoped to an
+            # actual climb out of the root.
+            logger.warning("Rejected a path outside the resolved scan root for this source")
         return JSONResponse(
             {
                 "status": "error",

--- a/autobot-backend/api/codebase_analytics/endpoints/ownership_scoping_13602_test.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/ownership_scoping_13602_test.py
@@ -204,7 +204,131 @@ class TestOwnershipAnalyzerIsBounded:
 
         assert ran_in_thread.get("off_loop"), "git blame must not run on the event loop"
 
-    def test_the_file_cap_is_a_real_number(self):
-        from code_analysis.src.ownership_analyzer import _MAX_FILES_TO_BLAME
+    @pytest.mark.asyncio
+    async def test_the_file_cap_actually_stops_the_walk(self, monkeypatch, tmp_path):
+        """The first version of this asserted `isinstance(int) and > 0`, which
+        cannot fail for any positive integer — a guard that proves nothing about
+        the line it names. Exercise the cap instead."""
+        import code_analysis.src.ownership_analyzer as oa
 
-        assert isinstance(_MAX_FILES_TO_BLAME, int) and _MAX_FILES_TO_BLAME > 0
+        for i in range(12):
+            (tmp_path / f"f{i}.py").write_text("x = 1\n", encoding="utf-8")
+
+        blamed: list[str] = []
+
+        async def _fake_ownership(self, file_path, root):
+            blamed.append(file_path.name)
+            return None
+
+        monkeypatch.setattr(oa, "_MAX_FILES_TO_BLAME", 4)
+        monkeypatch.setattr(oa.OwnershipAnalyzer, "_get_file_ownership", _fake_ownership)
+        analyzer = oa.OwnershipAnalyzer.__new__(oa.OwnershipAnalyzer)
+
+        await analyzer._analyze_file_ownership(str(tmp_path), ["**/*.py"])
+
+        assert len(blamed) == 4, f"the cap did not stop the walk: blamed {len(blamed)} files"
+        assert analyzer._truncated_reason, "truncation must be recorded"
+
+    @pytest.mark.asyncio
+    async def test_the_time_budget_stops_a_slow_walk(self, monkeypatch, tmp_path):
+        """A file cap alone is the wrong bound: at the measured ~0.45s per
+        `git blame`, 2000 files is a 15-minute request. Wall clock is what the
+        caller experiences."""
+        import code_analysis.src.ownership_analyzer as oa
+
+        for i in range(30):
+            (tmp_path / f"f{i}.py").write_text("x = 1\n", encoding="utf-8")
+
+        blamed: list[str] = []
+        clock = {"t": 0.0}
+
+        async def _slow(self, file_path, root):
+            blamed.append(file_path.name)
+            clock["t"] += 1.0
+            return None
+
+        monkeypatch.setattr(oa.time, "monotonic", lambda: clock["t"])
+        monkeypatch.setattr(oa, "_MAX_BLAME_SECONDS", 5.0)
+        monkeypatch.setattr(oa, "_MAX_FILES_TO_BLAME", 10_000)
+        monkeypatch.setattr(oa.OwnershipAnalyzer, "_get_file_ownership", _slow)
+        analyzer = oa.OwnershipAnalyzer.__new__(oa.OwnershipAnalyzer)
+
+        await analyzer._analyze_file_ownership(str(tmp_path), ["**/*.py"])
+
+        assert len(blamed) <= 7, f"the time budget did not stop the walk: {len(blamed)} files"
+        assert "time budget" in (analyzer._truncated_reason or "")
+
+    @pytest.mark.asyncio
+    async def test_one_budget_covers_all_patterns(self, monkeypatch, tmp_path):
+        """Breaking only the inner loop would give every later pattern a fresh
+        budget, which is not a budget."""
+        import code_analysis.src.ownership_analyzer as oa
+
+        for ext in ("py", "ts", "vue"):
+            for i in range(6):
+                (tmp_path / f"f{i}.{ext}").write_text("x = 1\n", encoding="utf-8")
+
+        blamed: list[str] = []
+
+        async def _fake(self, file_path, root):
+            blamed.append(file_path.name)
+            return None
+
+        monkeypatch.setattr(oa, "_MAX_FILES_TO_BLAME", 3)
+        monkeypatch.setattr(oa.OwnershipAnalyzer, "_get_file_ownership", _fake)
+        analyzer = oa.OwnershipAnalyzer.__new__(oa.OwnershipAnalyzer)
+
+        await analyzer._analyze_file_ownership(str(tmp_path), ["**/*.py", "**/*.ts", "**/*.vue"])
+
+        assert len(blamed) == 3, f"each pattern got its own budget: {len(blamed)} files blamed"
+
+    def test_a_truncated_result_says_so_to_the_caller(self, tmp_path):
+        """Server-side logging is not enough — the caller is the one drawing
+        conclusions from these numbers."""
+        import code_analysis.src.ownership_analyzer as oa
+
+        analyzer = oa.OwnershipAnalyzer.__new__(oa.OwnershipAnalyzer)
+        analyzer._truncated_reason = "file cap (2000)"
+        result = analyzer._build_ownership_results([], [], [], [], {}, 0.1)
+
+        assert result["summary"]["truncated"] is True
+        assert "2000" in result["summary"]["truncated_reason"]
+
+    def test_a_complete_result_is_not_flagged(self, tmp_path):
+        """The direction that must stay true — a flag that is always set carries
+        no information."""
+        import code_analysis.src.ownership_analyzer as oa
+
+        analyzer = oa.OwnershipAnalyzer.__new__(oa.OwnershipAnalyzer)
+        analyzer._truncated_reason = None
+        result = analyzer._build_ownership_results([], [], [], [], {}, 0.1)
+
+        assert result["summary"]["truncated"] is False
+
+    def test_the_bounds_are_set_to_values_that_actually_bound(self):
+        """The behavioural tests above monkeypatch these, so they prove the
+        mechanism works without noticing if the shipped constant were raised to
+        something that never fires. Measured: `git blame --line-porcelain` runs
+        at a median 0.45s per file on this repo, so the file cap alone allows a
+        ~15 minute request — which is why the wall-clock budget is the real
+        bound and has to stay small enough to matter."""
+        from code_analysis.src.ownership_analyzer import _MAX_BLAME_SECONDS, _MAX_FILES_TO_BLAME
+
+        assert 0 < _MAX_FILES_TO_BLAME <= 10_000, "a cap this high is not a cap"
+        assert 0 < _MAX_BLAME_SECONDS <= 60, "a budget longer than a client timeout bounds nothing"
+
+    def test_a_scan_rooted_in_a_worktree_still_sees_its_own_files(self, tmp_path):
+        """The trap I walked into: `.worktrees` was added to _SKIP_DIRECTORIES,
+        a SECOND skip list that still matched the absolute path. Since
+        resolve_project_root() lands inside a worktree on any dev checkout, the
+        endpoint returned 200 with zero contributors and no error — a loud 400
+        replaced by a silent empty success."""
+        from code_analysis.src.ownership_analyzer import OwnershipAnalyzer
+
+        root = tmp_path / ".worktrees" / "issue-13602"
+        (root / "pkg").mkdir(parents=True)
+        analyzer = OwnershipAnalyzer.__new__(OwnershipAnalyzer)
+
+        assert not analyzer._should_skip_file(root / "pkg" / "real.py", root)
+        assert analyzer._should_skip_file(root / ".worktrees" / "nested" / "x.py", root)
+        assert analyzer._should_skip_file(root / "node_modules" / "y.py", root)

--- a/autobot-backend/api/codebase_analytics/endpoints/ownership_scoping_13602_test.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/ownership_scoping_13602_test.py
@@ -1,0 +1,210 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Ownership endpoints must scope to the source they were asked about (#13602).
+
+Three sibling endpoints, three different ways of getting this wrong:
+
+`/ownership/analysis` resolved the source's clone path correctly and then
+validated against `_get_project_root()` instead — the root it had just replaced.
+A clone path lives under `data/code-sources/<id>` while the project root
+resolves to the checkout; sibling subtrees that never nest, so the containment
+check rejected EVERY source-scoped request with 400 "Invalid path: must be
+within project root". Deterministic, not layout-dependent.
+
+`/ownership/expertise` and `/ownership/knowledge-gaps` accepted `source_id`
+"for API consistency" and ignored it, silently analysing AutoBot's own tree for
+every source — cross-project leakage rather than a visible 400, and the worse
+failure of the two because it returns plausible data.
+
+The rejection was also logged as `"Path traversal attempt blocked"`, so ordinary
+use filled the security log with false attack alerts and echoed the internal
+clone path while doing it.
+
+This file is the endpoint's first test coverage.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+import api.codebase_analytics.endpoints.ownership as own_mod
+
+
+@pytest.fixture
+def two_roots(tmp_path):
+    """A source clone and an AutoBot root that are siblings — never nested,
+    which is the real deployed relationship."""
+    project_root = tmp_path / "code_source"
+    clone = tmp_path / "data" / "code-sources" / "abc123"
+    project_root.mkdir(parents=True)
+    clone.mkdir(parents=True)
+    return project_root, clone
+
+
+class TestValidationUsesTheResolvedScanRoot:
+    @pytest.mark.asyncio
+    async def test_a_source_scoped_request_is_not_rejected_as_out_of_root(self, monkeypatch, two_roots):
+        project_root, clone = two_roots
+        captured: dict[str, str] = {}
+
+        def _capture(path, root):
+            captured["path"] = path
+            captured["root"] = root
+            return None
+
+        async def _resolve(source_id, use_default=True):
+            return clone
+
+        monkeypatch.setattr(own_mod, "_get_project_root", lambda: str(project_root))
+        monkeypatch.setattr(own_mod, "resolve_scan_root", _resolve)
+        monkeypatch.setattr(own_mod, "_validate_path_security", _capture)
+        monkeypatch.setattr(own_mod, "_check_ownership_cache", _none_cache)
+        monkeypatch.setattr(own_mod, "_get_ownership_analyzer", lambda: None)
+
+        await own_mod.get_ownership_analysis(
+            path=None,
+            refresh=False,
+            patterns="**/*.py",
+            days=90,
+            source_id="abc123",
+        )
+
+        assert captured["root"] == str(clone), "containment must be checked against the source's own root"
+        assert captured["root"] != str(project_root), "validating against AutoBot's root rejects every source"
+        assert captured["path"] == str(clone)
+
+
+class TestSiblingEndpointsAreScopedToo:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("endpoint", ["get_expertise_scores", "get_knowledge_gaps"])
+    async def test_source_id_is_not_ignored(self, monkeypatch, two_roots, endpoint):
+        """These returned AutoBot's own ownership data for every source — a
+        wrong answer rather than an error, which is why it went unnoticed."""
+        project_root, clone = two_roots
+        captured: dict[str, str] = {}
+
+        async def _resolve(source_id, use_default=True):
+            assert source_id == "abc123", "the requested source must reach the resolver"
+            return clone
+
+        monkeypatch.setattr(own_mod, "_get_project_root", lambda: str(project_root))
+        monkeypatch.setattr(own_mod, "resolve_scan_root", _resolve)
+        monkeypatch.setattr(own_mod, "_validate_path_security", lambda p, r: captured.update(root=r))
+        monkeypatch.setattr(own_mod, "_get_ownership_analyzer", lambda: None)
+        monkeypatch.setattr(own_mod, "_check_ownership_cache", _none_cache)
+
+        kwargs = {"path": None, "source_id": "abc123"}
+        if endpoint == "get_knowledge_gaps":
+            kwargs["risk_level"] = None
+        await getattr(own_mod, endpoint)(**kwargs)
+
+        assert captured["root"] == str(clone), f"{endpoint} analysed the wrong project"
+
+
+class TestOrdinaryUseIsNotLoggedAsAnAttack:
+    def test_a_scope_mismatch_is_not_a_traversal_attempt(self, caplog, two_roots):
+        project_root, clone = two_roots
+        with caplog.at_level(logging.INFO):
+            response = own_mod._validate_path_security(str(clone), str(project_root))
+
+        assert response is not None, "the path is still rejected"
+        messages = " ".join(r.message for r in caplog.records)
+        assert "traversal attempt" not in messages, "ordinary use must not read as an attack"
+
+    def test_a_real_escape_is_still_logged_as_an_attack(self, caplog, two_roots):
+        """The case that must stay caught. A test asserting only that the false
+        alert is gone passes equally against a detector that says nothing."""
+        project_root, _clone = two_roots
+        escape = str(project_root / ".." / ".." / "etc" / "passwd")
+
+        with caplog.at_level(logging.INFO):
+            response = own_mod._validate_path_security(escape, str(project_root))
+
+        assert response is not None
+        messages = " ".join(r.message for r in caplog.records)
+        assert "traversal attempt" in messages, "a genuine escape must still raise an attack-shaped warning"
+
+    def test_the_internal_path_is_not_echoed(self, caplog, two_roots):
+        """The warning printed the clone path into the log. Internal filesystem
+        paths do not belong in outward-facing records."""
+        project_root, clone = two_roots
+        with caplog.at_level(logging.INFO):
+            own_mod._validate_path_security(str(clone), str(project_root))
+
+        assert str(clone) not in " ".join(r.message % r.args if r.args else r.message for r in caplog.records)
+
+
+class TestEscapeDiscriminator:
+    @pytest.mark.parametrize(
+        "relative,escapes",
+        [
+            ("pkg/mod.py", False),
+            (".", False),
+            ("../../etc/passwd", True),
+            ("../sibling/file.py", True),
+        ],
+    )
+    def test_only_paths_that_climb_out_count_as_escapes(self, tmp_path, relative, escapes):
+        root = tmp_path / "root"
+        root.mkdir()
+        assert own_mod._escapes_root(str(root / relative), str(root)) is escapes
+
+    def test_a_different_absolute_root_is_a_mismatch_not_an_escape(self, two_roots):
+        project_root, clone = two_roots
+        assert own_mod._escapes_root(str(clone), str(project_root)) is False
+
+
+async def _none_cache(*_args, **_kwargs):
+    return None
+
+
+class TestOwnershipAnalyzerIsBounded:
+    """Fixing the 400 makes this panel reachable for the first time. Reachable
+    and unbounded would trade a visible error for a silent hang, which is a
+    worse outcome than the bug being fixed."""
+
+    def test_worktrees_are_skipped(self, tmp_path):
+        from code_analysis.src.ownership_analyzer import OwnershipAnalyzer
+
+        analyzer = OwnershipAnalyzer.__new__(OwnershipAnalyzer)
+        assert analyzer._should_skip_file(tmp_path / ".worktrees" / "wt" / "a.py")
+        assert analyzer._should_skip_file(tmp_path / ".claude" / "worktrees" / "wt" / "a.py")
+        assert not analyzer._should_skip_file(tmp_path / "pkg" / "a.py")
+
+    @pytest.mark.asyncio
+    async def test_blame_does_not_run_on_the_event_loop(self, monkeypatch, tmp_path):
+        """A sync subprocess inside `async def` blocks every other request for
+        its full duration — up to 30s, once per file."""
+        import asyncio
+
+        import code_analysis.src.ownership_analyzer as oa
+
+        ran_in_thread: dict[str, bool] = {}
+        loop_thread = __import__("threading").current_thread().ident
+
+        def _fake_run(*_args, **_kwargs):
+            ran_in_thread["off_loop"] = __import__("threading").current_thread().ident != loop_thread
+
+            class _R:
+                returncode = 1
+                stdout = ""
+
+            return _R()
+
+        monkeypatch.setattr(oa.subprocess, "run", _fake_run)
+        analyzer = oa.OwnershipAnalyzer.__new__(oa.OwnershipAnalyzer)
+        target = tmp_path / "a.py"
+        target.write_text("x = 1\n", encoding="utf-8")
+
+        await asyncio.wait_for(analyzer._get_file_ownership(target, tmp_path), timeout=10)
+
+        assert ran_in_thread.get("off_loop"), "git blame must not run on the event loop"
+
+    def test_the_file_cap_is_a_real_number(self):
+        from code_analysis.src.ownership_analyzer import _MAX_FILES_TO_BLAME
+
+        assert isinstance(_MAX_FILES_TO_BLAME, int) and _MAX_FILES_TO_BLAME > 0

--- a/autobot-backend/api/codebase_analytics/endpoints/ownership_scoping_13602_test.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/ownership_scoping_13602_test.py
@@ -324,6 +324,17 @@ class TestOwnershipAnalyzerIsBounded:
         assert 0 < _MAX_FILES_TO_BLAME <= 10_000, "a cap this high is not a cap"
         assert 0 < _MAX_BLAME_SECONDS <= 60, "a budget longer than a client timeout bounds nothing"
 
+    def test_one_blame_cannot_outlast_the_budget_containing_it(self):
+        """The pre-existing per-blame timeout was 30s inside a 20s phase budget,
+        so a single slow file could consume the whole budget and overrun it.
+        Caught by the hardcoded-value checker, which flagged the literal — the
+        inconsistency was the more interesting half."""
+        from code_analysis.src.ownership_analyzer import _BLAME_TIMEOUT_SECONDS, _MAX_BLAME_SECONDS
+
+        assert (
+            _BLAME_TIMEOUT_SECONDS < _MAX_BLAME_SECONDS
+        ), "a single git blame may not be allowed more time than the phase budget that bounds it"
+
     def test_a_scan_rooted_in_a_worktree_still_sees_its_own_files(self, tmp_path):
         """The trap I walked into: `.worktrees` was added to _SKIP_DIRECTORIES,
         a SECOND skip list that still matched the absolute path. Since

--- a/autobot-backend/api/codebase_analytics/endpoints/ownership_scoping_13602_test.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/ownership_scoping_13602_test.py
@@ -260,8 +260,15 @@ class TestOwnershipAnalyzerIsBounded:
 
     @pytest.mark.asyncio
     async def test_one_budget_covers_all_patterns(self, monkeypatch, tmp_path):
-        """Breaking only the inner loop would give every later pattern a fresh
-        budget, which is not a budget."""
+        """One budget across all patterns — enforced by hoisting `considered`
+        and `deadline` ABOVE the pattern loop.
+
+        The first version of this docstring claimed the outer `break` was what
+        prevented a fresh budget per pattern. It is not: with the counters
+        hoisted, removing that break leaves the mutant equivalent — a later
+        pattern re-breaks on its first non-skipped file. So the test could not
+        fail for the reason it named. It guards the hoisting; the break is an
+        optimisation."""
         import code_analysis.src.ownership_analyzer as oa
 
         for ext in ("py", "ts", "vue"):

--- a/autobot-backend/api/codebase_analytics/endpoints/report.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/report.py
@@ -1682,7 +1682,13 @@ async def _get_duplicate_analysis(
         # this call site relied on implicitly — behaviour unchanged.
         analysis = await _run_standard_analysis(scan_target, LOW_SIMILARITY_THRESHOLD)
         if analysis is None:
-            # Either in flight elsewhere or timed out; both already logged.
+            # #13602: say so. The GUI polls /duplicates while loading /report and
+            # they now share one lock, so this is the common case — and a report
+            # that omits the section without comment reads as "no duplicates".
+            logger.warning(
+                "Duplicate section omitted from the report: the scan was "
+                "unavailable (already in flight, or it exceeded its deadline)"
+            )
             return None
 
         logger.info(

--- a/autobot-backend/api/codebase_analytics/endpoints/report.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/report.py
@@ -481,6 +481,13 @@ BUG_PREDICTION_TIMEOUT = AnalyticsConfig.BUG_PREDICTION_TIMEOUT
 TOP_HIGH_RISK_FILES_LIMIT = AnalyticsConfig.TOP_HIGH_RISK_FILES_LIMIT
 # Maximum items to show in API endpoint section - from SSOT
 API_ENDPOINT_LIST_LIMIT = AnalyticsConfig.API_ENDPOINT_LIST_LIMIT
+# Issue #13602: deadlines for the /report fan-out. The grace margin lets an
+# analysis that bounds itself report its own, better-named timeout first; the
+# outer bound is the backstop for one that does not.
+ANALYSIS_DEADLINE_GRACE = 15.0
+# api_endpoint had no self-imposed timeout at all, which is the reported hang.
+API_ENDPOINT_ANALYSIS_TIMEOUT = TIMEOUT_HTTP_LONG
+PATTERN_ANALYSIS_TIMEOUT = 180.0
 
 
 # =============================================================================
@@ -1299,14 +1306,26 @@ def _build_analysis_task_list(
     use_semantic: bool,
     source_id: str | None = None,
     scan_root: Path | None = None,
-) -> List[Tuple[str, Any]]:
+) -> List[Tuple[str, Any, float]]:
     """
-    Build list of analysis tasks to run based on flags.
+    Build list of analysis tasks to run, each with its own deadline.
 
     Issue #620: Extracted from _run_parallel_analyses.
     Issue #12372: Thread source_id/scan_root into every sub-analysis so a
     report requested for one source never scans or caches another project's
     (or AutoBot's own) tree -- mirrors the #12356/#12374 cross-language fix.
+
+    Issue #13602: every entry carries a deadline as its third element. Four of
+    the five analyses wrapped themselves in ``asyncio.wait_for``; the fifth,
+    api_endpoint, did not, and that omission is the reported hang. The shared
+    analytics executor has 8 workers, so once slower analyses occupy them all,
+    an unbounded submission queues and never starts -- ``gather`` never returns
+    and the socket stays open with nothing logged. Carrying the deadline in the
+    tuple makes a task without one a type error rather than an oversight.
+
+    These are OUTER deadlines with a grace margin: an analysis that reports its
+    own timeout produces a better message naming the analysis, so it should win
+    the race. The outer bound only fires where there is no inner one.
     """
     tasks = []
     if include_bug_prediction:
@@ -1318,21 +1337,41 @@ def _build_analysis_task_list(
                     use_semantic=use_semantic,
                     source_id=source_id,
                 ),
+                BUG_PREDICTION_TIMEOUT + ANALYSIS_DEADLINE_GRACE,
             )
         )
     if include_api_analysis:
-        tasks.append(("api_endpoint", _get_api_endpoint_analysis(project_root=scan_root)))
+        tasks.append(
+            (
+                "api_endpoint",
+                _get_api_endpoint_analysis(project_root=scan_root),
+                API_ENDPOINT_ANALYSIS_TIMEOUT,
+            )
+        )
     if include_duplicate_analysis:
-        tasks.append(("duplicate", _get_duplicate_analysis(project_root=scan_root)))
+        tasks.append(
+            (
+                "duplicate",
+                _get_duplicate_analysis(project_root=scan_root),
+                TIMEOUT_HTTP_LONG + ANALYSIS_DEADLINE_GRACE,
+            )
+        )
     if include_cross_language_analysis:
         tasks.append(
             (
                 "cross_language",
                 _get_cross_language_analysis(source_id=source_id, project_root=scan_root),
+                TIMEOUT_HTTP_LONG + ANALYSIS_DEADLINE_GRACE,
             )
         )
     if include_pattern_analysis:
-        tasks.append(("pattern_analysis", _get_pattern_analysis(project_root=scan_root)))
+        tasks.append(
+            (
+                "pattern_analysis",
+                _get_pattern_analysis(project_root=scan_root),
+                PATTERN_ANALYSIS_TIMEOUT + ANALYSIS_DEADLINE_GRACE,
+            )
+        )
     return tasks
 
 
@@ -1382,12 +1421,25 @@ async def _run_parallel_analyses(
     if not analysis_tasks:
         return result
 
-    # Run all analyses in parallel with individual error handling
-    results = await asyncio.gather(*[task for _, task in analysis_tasks], return_exceptions=True)
+    # #13602: every analysis is bounded here, not by remembering to wrap it at
+    # its own definition. gather() cannot outlast the slowest deadline.
+    results = await asyncio.gather(
+        *[asyncio.wait_for(task, timeout=deadline) for _, task, deadline in analysis_tasks],
+        return_exceptions=True,
+    )
 
     # Map results back to dict
-    for i, (task_name, _) in enumerate(analysis_tasks):
+    for i, (task_name, _, deadline) in enumerate(analysis_tasks):
         task_result = results[i]
+        if isinstance(task_result, asyncio.TimeoutError):
+            # Was silent before: an unbounded analysis produced no result and no
+            # log, so the report simply omitted the section with no explanation.
+            logger.warning(
+                "Analysis %s exceeded its %.0fs deadline and was abandoned",
+                task_name,
+                deadline,
+            )
+            continue
         if isinstance(task_result, Exception):
             logger.warning("Analysis %s failed: %s", task_name, task_result)
             continue

--- a/autobot-backend/api/codebase_analytics/endpoints/report.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/report.py
@@ -47,12 +47,17 @@ from utils.file_categorization import (
     FILE_CATEGORY_LOGS,
     FILE_CATEGORY_TEST,
 )
-from utils.io_executor import get_analytics_executor, run_in_analytics_executor
+from utils.io_executor import run_in_analytics_executor
 
 from ..api_endpoint_scanner import APIEndpointChecker
-from ..duplicate_detector import DuplicateAnalysis, DuplicateCodeDetector  # noqa: F401
+from ..duplicate_detector import (  # noqa: F401
+    LOW_SIMILARITY_THRESHOLD,
+    DuplicateAnalysis,
+    DuplicateCodeDetector,
+)
 from ..models import APIEndpointAnalysis
 from ..storage import get_code_collection
+from .duplicates import _run_standard_analysis
 from .shared import (
     filter_problems_by_file_existence,
     resolve_project_root,
@@ -1668,17 +1673,17 @@ async def _get_duplicate_analysis(
     try:
         scan_target = str(project_root) if project_root else str(Path(__file__).resolve().parents[4])
 
-        # Issue #1233: Use dedicated analytics executor to prevent
-        # default thread pool starvation
-        # Issue #2655: Increased timeout from 60s to 120s — large codebases
-        # need more time for duplicate hash comparison across all Python/TS files.
-        analysis = await asyncio.wait_for(
-            asyncio.get_running_loop().run_in_executor(
-                get_analytics_executor(),
-                lambda: DuplicateCodeDetector(project_root=scan_target).run_analysis(),
-            ),
-            timeout=TIMEOUT_HTTP_LONG,  # 120 second timeout for duplicate detection
-        )
+        # #13602: delegate to the guarded scan in `duplicates`. This submitted
+        # straight to the executor with neither the single-flight lock nor the
+        # cancel token, so /report re-created the accumulation #12779 fixed:
+        # each report queued a full walk regardless of one already running, and
+        # its orphan could not be told to stop. Same executor, same 8 workers.
+        # LOW_SIMILARITY_THRESHOLD is the detector's own default, which is what
+        # this call site relied on implicitly — behaviour unchanged.
+        analysis = await _run_standard_analysis(scan_target, LOW_SIMILARITY_THRESHOLD)
+        if analysis is None:
+            # Either in flight elsewhere or timed out; both already logged.
+            return None
 
         logger.info(
             "Duplicate analysis: %d duplicates (%d high, %d medium, %d low)",

--- a/autobot-backend/api/codebase_analytics/endpoints/report_scoping_test.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/report_scoping_test.py
@@ -20,8 +20,12 @@ root through every sub-analysis so a report for one source never scans or
 returns another source's (or AutoBot's own) tree.
 """
 
+import asyncio
+import logging
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 
 # ---------------------------------------------------------------------------
@@ -84,7 +88,7 @@ class TestBuildAnalysisTaskListScoping:
                 source_id="B",
                 scan_root=scan_root,
             )
-            for _name, coro in tasks:
+            for _name, coro, _deadline in tasks:
                 await coro
 
         # None of the sub-analyses fall back to AutoBot's own root/no source.
@@ -350,3 +354,101 @@ class TestGetBugPredictionUsesAsyncPath:
             )
 
         fake_cls.assert_called_once_with(project_root="/srv/sources/b", use_semantic_analysis=True, source_id="B")
+
+
+class TestEveryAnalysisIsBounded:
+    """#13602: `/report` never responded, and logged nothing while not responding.
+
+    Four of the five analyses wrapped themselves in `asyncio.wait_for`. The
+    fifth, api_endpoint, did not. The shared analytics executor has 8 workers,
+    so once the slower analyses occupied them all, that unbounded submission
+    queued and never started — `gather` never returned, the socket stayed open,
+    and no handler ever ran to log anything.
+
+    Asserting on the task list rather than on any one analysis is deliberate:
+    the defect was an omission, and an omission is only caught by a check that
+    covers every member by construction.
+    """
+
+    def test_every_task_carries_a_positive_deadline(self):
+        import api.codebase_analytics.endpoints.report as report_mod
+
+        tasks = report_mod._build_analysis_task_list(
+            include_bug_prediction=True,
+            include_api_analysis=True,
+            include_duplicate_analysis=True,
+            include_cross_language_analysis=True,
+            include_pattern_analysis=True,
+            use_semantic=False,
+            source_id="A",
+            scan_root=Path("/tmp/does-not-need-to-exist"),
+        )
+        try:
+            assert len(tasks) == 5, "all five analyses must be represented"
+            for name, _coro, deadline in tasks:
+                assert isinstance(deadline, (int, float)), f"{name} has a non-numeric deadline"
+                assert deadline > 0, f"{name} has no usable deadline"
+        finally:
+            for _name, coro, _deadline in tasks:
+                coro.close()
+
+    @pytest.mark.asyncio
+    async def test_an_unbounded_analysis_cannot_hang_the_report(self, monkeypatch):
+        """The reproduction, not the predicate: an analysis that never returns
+        must not stop `_run_parallel_analyses` from returning.
+
+        A test asserting 'every task has a deadline' passes equally against a
+        deadline that is never applied — so exercise the hang itself.
+        """
+        import api.codebase_analytics.endpoints.report as report_mod
+
+        async def never_returns(*_args, **_kwargs):
+            await asyncio.Event().wait()
+
+        monkeypatch.setattr(report_mod, "_get_api_endpoint_analysis", never_returns)
+        monkeypatch.setattr(report_mod, "API_ENDPOINT_ANALYSIS_TIMEOUT", 0.05)
+
+        result = await asyncio.wait_for(
+            report_mod._run_parallel_analyses(
+                include_bug_prediction=False,
+                include_api_analysis=True,
+                include_duplicate_analysis=False,
+                include_cross_language_analysis=False,
+                include_pattern_analysis=False,
+                use_semantic=False,
+            ),
+            timeout=10,
+        )
+
+        assert result["api_endpoint"] is None, "an abandoned analysis contributes no result"
+
+    @pytest.mark.asyncio
+    async def test_the_abandonment_is_logged(self, monkeypatch, caplog):
+        """Silence was half the defect: #13602 reports 180s with zero log output,
+        so a bounded-but-silent handler would still be undiagnosable."""
+        import api.codebase_analytics.endpoints.report as report_mod
+
+        async def never_returns(*_args, **_kwargs):
+            await asyncio.Event().wait()
+
+        monkeypatch.setattr(report_mod, "_get_api_endpoint_analysis", never_returns)
+        monkeypatch.setattr(report_mod, "API_ENDPOINT_ANALYSIS_TIMEOUT", 0.05)
+
+        # Bounded on purpose: without the fix this call never returns, and a
+        # test that hangs burns the CI job timeout instead of reporting.
+        with caplog.at_level(logging.WARNING):
+            await asyncio.wait_for(
+                report_mod._run_parallel_analyses(
+                    include_bug_prediction=False,
+                    include_api_analysis=True,
+                    include_duplicate_analysis=False,
+                    include_cross_language_analysis=False,
+                    include_pattern_analysis=False,
+                    use_semantic=False,
+                ),
+                timeout=10,
+            )
+
+        assert any(
+            "api_endpoint" in r.message and "deadline" in r.message for r in caplog.records
+        ), "an analysis abandoned at its deadline must say so"

--- a/autobot-backend/api/codebase_analytics/file_analyzer.py
+++ b/autobot-backend/api/codebase_analytics/file_analyzer.py
@@ -23,11 +23,13 @@ from utils.file_categorization import (
     HTML_EXTENSIONS,
     JS_EXTENSIONS,
     PYTHON_EXTENSIONS,
-    is_skipped_path,
     TS_EXTENSIONS,
     VUE_EXTENSIONS,
 )
 from utils.file_categorization import get_file_category as _get_file_category
+from utils.file_categorization import (
+    is_skipped_path,
+)
 
 from .analyzers import (
     analyze_documentation_file,

--- a/autobot-backend/api/codebase_analytics/file_analyzer.py
+++ b/autobot-backend/api/codebase_analytics/file_analyzer.py
@@ -23,7 +23,7 @@ from utils.file_categorization import (
     HTML_EXTENSIONS,
     JS_EXTENSIONS,
     PYTHON_EXTENSIONS,
-    SKIP_DIRS,
+    is_skipped_path,
     TS_EXTENSIONS,
     VUE_EXTENSIONS,
 )
@@ -349,7 +349,7 @@ async def _analyze_single_file(
         logger.debug("Error checking if path is file %s: %s", file_path, e)
         return base_result
 
-    if not is_file or any(skip_dir in file_path.parts for skip_dir in SKIP_DIRS):
+    if not is_file or is_skipped_path(file_path, root_path_obj):  # #13602
         return base_result
 
     # Check if file needs reindexing (Issue #539)

--- a/autobot-backend/api/codebase_analytics/file_counter.py
+++ b/autobot-backend/api/codebase_analytics/file_counter.py
@@ -12,16 +12,19 @@ from pathlib import Path
 from typing import Tuple
 
 from autobot_shared.logging_manager import get_logger
-from utils.file_categorization import SKIP_DIRS
+from utils.file_categorization import is_skipped_path
 
 logger = get_logger(__name__)
 
 
-def _should_count_file(file_path: Path) -> bool:
-    """Check if file should be counted for progress tracking (Issue #315)."""
+def _should_count_file(file_path: Path, root_path_obj: Path) -> bool:
+    """Check if file should be counted for progress tracking (Issue #315).
+
+    #13602: takes the scan root so the skip check is relative to it.
+    """
     if not file_path.is_file():
         return False
-    return not any(skip_dir in file_path.parts for skip_dir in SKIP_DIRS)
+    return not is_skipped_path(file_path, root_path_obj)
 
 
 def _count_scannable_files_sync(root_path_obj: Path) -> Tuple[int, list]:
@@ -34,7 +37,7 @@ def _count_scannable_files_sync(root_path_obj: Path) -> Tuple[int, list]:
     """
     all_files = list(root_path_obj.rglob("*"))
     # Filter to only scannable files to avoid iterating through 200K files
-    scannable_files = [f for f in all_files if _should_count_file(f)]
+    scannable_files = [f for f in all_files if _should_count_file(f, root_path_obj)]
     return len(scannable_files), scannable_files
 
 

--- a/autobot-backend/api/codebase_analytics/file_pipeline.py
+++ b/autobot-backend/api/codebase_analytics/file_pipeline.py
@@ -23,8 +23,9 @@ from pathlib import Path
 from typing import Dict, List, Tuple
 
 from autobot_shared.logging_manager import get_logger
-from utils.file_categorization import FILE_CATEGORY_CODE, is_skipped_path
+from utils.file_categorization import FILE_CATEGORY_CODE
 from utils.file_categorization import get_file_category as _get_file_category
+from utils.file_categorization import is_skipped_path
 
 from .analyzers import (
     analyze_documentation_file,

--- a/autobot-backend/api/codebase_analytics/file_pipeline.py
+++ b/autobot-backend/api/codebase_analytics/file_pipeline.py
@@ -23,7 +23,7 @@ from pathlib import Path
 from typing import Dict, List, Tuple
 
 from autobot_shared.logging_manager import get_logger
-from utils.file_categorization import FILE_CATEGORY_CODE, SKIP_DIRS
+from utils.file_categorization import FILE_CATEGORY_CODE, is_skipped_path
 from utils.file_categorization import get_file_category as _get_file_category
 
 from .analyzers import (
@@ -119,7 +119,7 @@ async def _process_single_file(
     is_file = await run_in_thread_fn(file_path.is_file)
     if not is_file:
         return False, False
-    if any(skip_dir in file_path.parts for skip_dir in SKIP_DIRS):
+    if is_skipped_path(file_path, root_path_obj):  # #13602: relative to the scan root
         return False, False
 
     extension = file_path.suffix.lower()

--- a/autobot-backend/code_analysis/src/ownership_analyzer.py
+++ b/autobot-backend/code_analysis/src/ownership_analyzer.py
@@ -70,11 +70,13 @@ _SKIP_DIRECTORIES = (
     "worktrees",
 )
 
-# #13602: a hard ceiling on blamed files. Each one is a `git blame` subprocess,
-# so an unbounded tree turned this endpoint into a multi-hour job that the
-# caller had long since given up on. Truncation is logged — a silent cap reads
-# as "we analysed everything".
+# #13602: two ceilings, because a file count alone is the wrong bound. Measured
+# on this repo, `git blame --line-porcelain` runs at a median 0.45s per file, so
+# 2000 files is a ~15 minute request — a hang traded for a wait nobody will sit
+# through. The wall-clock budget is what the caller actually experiences; the
+# file cap just stops a pathological tree before the clock starts mattering.
 _MAX_FILES_TO_BLAME = 2000
+_MAX_BLAME_SECONDS = 20.0
 
 # File patterns to skip
 _SKIP_FILE_PATTERNS = (
@@ -261,6 +263,11 @@ class OwnershipAnalyzer:
             "status": "success",
             "analysis_time_seconds": analysis_time,
             "summary": {
+                # #13602: a truncated result that does not say so reads as a
+                # complete one. The server log alone is not enough — the caller
+                # is the one drawing conclusions from these numbers.
+                "truncated": bool(getattr(self, "_truncated_reason", None)),
+                "truncated_reason": getattr(self, "_truncated_reason", None),
                 "total_files": len(file_ownerships),
                 "total_directories": len(directory_ownerships),
                 "total_contributors": len(expertise_scores),
@@ -278,30 +285,36 @@ class OwnershipAnalyzer:
     async def _analyze_file_ownership(self, root_path: str, patterns: List[str]) -> List[FileOwnership]:
         """Analyze ownership for individual files using git blame"""
         file_ownerships = []
+        self._truncated_reason: str | None = None
         root = Path(root_path).resolve()
 
         considered = 0
-        truncated = False
+        deadline = time.monotonic() + _MAX_BLAME_SECONDS
         for pattern in patterns:
             for file_path in root.glob(pattern):
-                if not file_path.is_file() or self._should_skip_file(file_path):
+                if not file_path.is_file() or self._should_skip_file(file_path, root):
                     continue
                 if considered >= _MAX_FILES_TO_BLAME:
-                    truncated = True
+                    self._truncated_reason = f"file cap ({_MAX_FILES_TO_BLAME})"
+                    break
+                if time.monotonic() > deadline:
+                    self._truncated_reason = f"time budget ({_MAX_BLAME_SECONDS:.0f}s)"
                     break
                 considered += 1
 
                 ownership = await self._get_file_ownership(file_path, root)
                 if ownership:
                     file_ownerships.append(ownership)
-            if truncated:
+            if self._truncated_reason:
+                # Break the PATTERN loop too — otherwise later patterns would
+                # each get a fresh budget, which is not a budget.
                 break
 
-        if truncated:
+        if self._truncated_reason:
             logger.warning(
-                "Ownership analysis truncated at %d files — results are a subset of %s",
-                _MAX_FILES_TO_BLAME,
-                root,
+                "Ownership analysis truncated by %s after %d files — results are a subset",
+                self._truncated_reason,
+                considered,
             )
 
         # Sort by total lines descending
@@ -746,13 +759,26 @@ class OwnershipAnalyzer:
             ),
         }
 
-    def _should_skip_file(self, file_path: Path) -> bool:
-        """Check if file should be skipped"""
+    def _should_skip_file(self, file_path: Path, root: "Path | None" = None) -> bool:
+        """Check if file should be skipped, relative to ``root`` when given.
+
+        #13602: this matched _SKIP_DIRECTORIES against the ABSOLUTE path. Once
+        `.worktrees` joined that list, a scan rooted inside one — which is where
+        `resolve_project_root()` lands on any dev checkout — skipped every file
+        below it and returned 200 with zero contributors and no error. Adding
+        the name without this is how a loud 400 becomes a silent empty 200.
+        """
         path_str = str(file_path)
+        if root is not None:
+            try:
+                path_str = str(file_path.resolve().relative_to(root.resolve()))
+            except (ValueError, OSError):
+                # Not inside the root: not part of this scan.
+                return True
         file_name = file_path.name
 
         for skip_dir in _SKIP_DIRECTORIES:
-            if f"/{skip_dir}/" in path_str or path_str.startswith(f"{skip_dir}/"):
+            if f"/{skip_dir}/" in f"/{path_str}" or path_str.startswith(f"{skip_dir}/"):
                 return True
 
         for pattern in _SKIP_FILE_PATTERNS:

--- a/autobot-backend/code_analysis/src/ownership_analyzer.py
+++ b/autobot-backend/code_analysis/src/ownership_analyzer.py
@@ -12,6 +12,7 @@ Analyzes codebase for:
 - Team coverage analysis
 """
 
+import asyncio
 import json
 import subprocess
 import sys
@@ -63,7 +64,17 @@ _SKIP_DIRECTORIES = (
     "build",
     "egg-info",
     ".eggs",
+    # #13602: near-complete repo copies. Without these, one ownership request
+    # globbed 167,072 files where 6,967 exist, and ran `git blame` on each.
+    ".worktrees",
+    "worktrees",
 )
+
+# #13602: a hard ceiling on blamed files. Each one is a `git blame` subprocess,
+# so an unbounded tree turned this endpoint into a multi-hour job that the
+# caller had long since given up on. Truncation is logged — a silent cap reads
+# as "we analysed everything".
+_MAX_FILES_TO_BLAME = 2000
 
 # File patterns to skip
 _SKIP_FILE_PATTERNS = (
@@ -269,14 +280,29 @@ class OwnershipAnalyzer:
         file_ownerships = []
         root = Path(root_path).resolve()
 
+        considered = 0
+        truncated = False
         for pattern in patterns:
             for file_path in root.glob(pattern):
                 if not file_path.is_file() or self._should_skip_file(file_path):
                     continue
+                if considered >= _MAX_FILES_TO_BLAME:
+                    truncated = True
+                    break
+                considered += 1
 
                 ownership = await self._get_file_ownership(file_path, root)
                 if ownership:
                     file_ownerships.append(ownership)
+            if truncated:
+                break
+
+        if truncated:
+            logger.warning(
+                "Ownership analysis truncated at %d files — results are a subset of %s",
+                _MAX_FILES_TO_BLAME,
+                root,
+            )
 
         # Sort by total lines descending
         file_ownerships.sort(key=lambda x: x.total_lines, reverse=True)
@@ -350,12 +376,18 @@ class OwnershipAnalyzer:
         try:
             relative_path = str(file_path.relative_to(root))
 
-            result = subprocess.run(  # nosec B603 B607  # fixed git argv; file_path is a Path object, no shell
-                ["git", "blame", "--line-porcelain", str(file_path)],
-                capture_output=True,
-                text=True,
-                cwd=str(root),
-                timeout=30,
+            # #13602: was a bare subprocess.run inside `async def`, so every
+            # blame blocked the event loop for its full duration — up to the 30s
+            # timeout, once per file. That is what made unrelated endpoints
+            # return 000 while an analytics panel was loading.
+            result = await asyncio.to_thread(
+                lambda: subprocess.run(  # nosec B603 B607  # fixed git argv; file_path is a Path object, no shell
+                    ["git", "blame", "--line-porcelain", str(file_path)],
+                    capture_output=True,
+                    text=True,
+                    cwd=str(root),
+                    timeout=30,
+                )
             )
 
             if result.returncode != 0:

--- a/autobot-backend/code_analysis/src/ownership_analyzer.py
+++ b/autobot-backend/code_analysis/src/ownership_analyzer.py
@@ -73,8 +73,9 @@ _SKIP_DIRECTORIES = (
 # #13602: two ceilings, because a file count alone is the wrong bound. Measured
 # on this repo, `git blame --line-porcelain` runs at a median 0.45s per file, so
 # 2000 files is a ~15 minute request — a hang traded for a wait nobody will sit
-# through. The wall-clock budget is what the caller actually experiences; the
-# file cap just stops a pathological tree before the clock starts mattering.
+# through. The wall-clock budget covers the walk as well as the blames, since
+# globbing a large tree is itself measurable; the file cap just stops a
+# pathological tree before the clock starts mattering.
 _MAX_FILES_TO_BLAME = 2000
 _MAX_BLAME_SECONDS = 20.0
 
@@ -292,13 +293,17 @@ class OwnershipAnalyzer:
         deadline = time.monotonic() + _MAX_BLAME_SECONDS
         for pattern in patterns:
             for file_path in root.glob(pattern):
+                # Ahead of the skip `continue` on purpose: behind it, globbing
+                # and skipping sat OUTSIDE the budget entirely — measured 18s of
+                # walk on this repo with blame costing nothing. A budget that
+                # excludes the walk is not what the caller experiences.
+                if time.monotonic() > deadline:
+                    self._truncated_reason = f"time budget ({_MAX_BLAME_SECONDS:.0f}s)"
+                    break
                 if not file_path.is_file() or self._should_skip_file(file_path, root):
                     continue
                 if considered >= _MAX_FILES_TO_BLAME:
                     self._truncated_reason = f"file cap ({_MAX_FILES_TO_BLAME})"
-                    break
-                if time.monotonic() > deadline:
-                    self._truncated_reason = f"time budget ({_MAX_BLAME_SECONDS:.0f}s)"
                     break
                 considered += 1
 
@@ -778,7 +783,7 @@ class OwnershipAnalyzer:
         file_name = file_path.name
 
         for skip_dir in _SKIP_DIRECTORIES:
-            if f"/{skip_dir}/" in f"/{path_str}" or path_str.startswith(f"{skip_dir}/"):
+            if f"/{skip_dir}/" in f"/{path_str}":
                 return True
 
         for pattern in _SKIP_FILE_PATTERNS:

--- a/autobot-backend/code_analysis/src/ownership_analyzer.py
+++ b/autobot-backend/code_analysis/src/ownership_analyzer.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
 from autobot_shared.async_compat import run_or_schedule
+from autobot_shared.env_utils import env_float, env_int
 from autobot_shared.logging_manager import get_logger
 
 # Issue #542: Handle imports for both standalone execution and backend import
@@ -76,8 +77,12 @@ _SKIP_DIRECTORIES = (
 # through. The wall-clock budget covers the walk as well as the blames, since
 # globbing a large tree is itself measurable; the file cap just stops a
 # pathological tree before the clock starts mattering.
-_MAX_FILES_TO_BLAME = 2000
-_MAX_BLAME_SECONDS = 20.0
+_MAX_FILES_TO_BLAME = env_int("AUTOBOT_OWNERSHIP_MAX_FILES", 2000)
+_MAX_BLAME_SECONDS = env_float("AUTOBOT_OWNERSHIP_BUDGET_SECONDS", 20.0)
+# A single blame must not be allowed to outlast the budget that contains it —
+# the pre-existing 30s here exceeded the whole phase's 20s, so one slow file
+# could consume the entire budget and then some. Kept below it deliberately.
+_BLAME_TIMEOUT_SECONDS = env_float("AUTOBOT_OWNERSHIP_BLAME_TIMEOUT_SECONDS", 10.0)
 
 # File patterns to skip
 _SKIP_FILE_PATTERNS = (
@@ -404,7 +409,7 @@ class OwnershipAnalyzer:
                     capture_output=True,
                     text=True,
                     cwd=str(root),
-                    timeout=30,
+                    timeout=_BLAME_TIMEOUT_SECONDS,
                 )
             )
 

--- a/autobot-backend/code_intelligence/shared/file_cache.py
+++ b/autobot-backend/code_intelligence/shared/file_cache.py
@@ -47,7 +47,7 @@ from autobot_shared.logging_manager import get_logger
 from autobot_shared.singleton_factory import lazy_singleton
 from autobot_shared.ssot_config import config
 from constants.path_constants import PATH
-from utils.file_categorization import SKIP_DIRS
+from utils.file_categorization import is_skipped_path
 
 logger = get_logger(__name__)
 
@@ -168,9 +168,9 @@ class FileListCache:
         """Check if cache entry is still valid."""
         return (time.time() - entry.timestamp) < self._ttl
 
-    def _should_skip_path(self, path: Path) -> bool:
-        """Check if path should be skipped based on SKIP_DIRS."""
-        return any(skip_dir in path.parts for skip_dir in SKIP_DIRS)
+    def _should_skip_path(self, path: Path, root_path: Path) -> bool:
+        """Check if path should be skipped, relative to the scan root (#13602)."""
+        return is_skipped_path(path, root_path)
 
     async def _scan_files(
         self,
@@ -189,7 +189,7 @@ class FileListCache:
             for ext in extensions:
                 pattern = f"*{ext}"
                 for file_path in root_path.rglob(pattern):
-                    if file_path.is_file() and not self._should_skip_path(file_path):
+                    if file_path.is_file() and not self._should_skip_path(file_path, root_path):
                         files.append(file_path)
             return sorted(files)
 

--- a/autobot-backend/utils/file_categorization.py
+++ b/autobot-backend/utils/file_categorization.py
@@ -407,11 +407,19 @@ def is_skipped_path(path: Path, root: Path) -> bool:
     behaviour we actually want.
     """
     try:
+        # resolve() on both sides, deliberately. A lexical relative_to() is ~12x
+        # cheaper, but it accepts a symlink that points OUT of the scan root as
+        # scannable — and the 167k-file measurement that would have justified
+        # the shortcut is the very number this skip-list removes. At 6,967 files
+        # the difference is ~0.5s on a scan that was taking six minutes.
         relative = path.resolve().relative_to(root.resolve())
     except (ValueError, OSError):
-        # Outside the root (or unreadable): fall back to the absolute check
-        # rather than silently admitting a path we cannot place.
-        return bool(set(path.parts) & SKIP_DIRS)
+        # A path that cannot be placed under the scan root is not in the scan.
+        # Falling back to the absolute check here would consult SKIP_DIRS
+        # against the ROOT's own ancestry — the precise bug this function exists
+        # to remove — so it would reintroduce it on exactly the inputs that are
+        # hardest to reason about (symlink escapes).
+        return True
     return bool(set(relative.parts) & SKIP_DIRS)
 
 

--- a/autobot-backend/utils/file_categorization.py
+++ b/autobot-backend/utils/file_categorization.py
@@ -406,12 +406,30 @@ def is_skipped_path(path: Path, root: Path) -> bool:
     A skip directory *nested* under the root is still skipped, which is the
     behaviour we actually want.
     """
+    # Three tiers, because this runs once per GLOBBED path — 214k of them on
+    # this repo, not the 6,967 surviving files. An earlier version of this
+    # comment used the wrong denominator and understated the cost by ~30x.
+    #
+    # 1. Lexically inside a skip dir -> skipped. A symlink cannot change that,
+    #    so no stat at all. 96% of paths land here.
+    # 2. Lexically clean and not a symlink -> kept. glob/rglob do not recurse
+    #    symlinked directories, so only a symlinked LEAF can escape, and
+    #    is_symlink() is one lstat where resolve() is a full realpath walk.
+    # 3. Anything else -> resolve and place it properly.
+    #
+    # Tuple slicing rather than relative_to(): same answer, and relative_to was
+    # measured at ~28us of the ~29us total.
+    root_parts = root.parts
+    path_parts = path.parts
+    if path_parts[: len(root_parts)] == root_parts:
+        if set(path_parts[len(root_parts) :]) & SKIP_DIRS:
+            # Already inside a skipped directory lexically. A symlink cannot
+            # change that answer, so skip the lstat — and this is the hot case:
+            # 96% of globbed paths on a working checkout land here.
+            return True
+        if not path.is_symlink():
+            return False
     try:
-        # resolve() on both sides, deliberately. A lexical relative_to() is ~12x
-        # cheaper, but it accepts a symlink that points OUT of the scan root as
-        # scannable — and the 167k-file measurement that would have justified
-        # the shortcut is the very number this skip-list removes. At 6,967 files
-        # the difference is ~0.5s on a scan that was taking six minutes.
         relative = path.resolve().relative_to(root.resolve())
     except (ValueError, OSError):
         # A path that cannot be placed under the scan root is not in the scan.

--- a/autobot-backend/utils/file_categorization.py
+++ b/autobot-backend/utils/file_categorization.py
@@ -380,7 +380,40 @@ SKIP_DIRS: Set[str] = {
     "obj",  # .NET build output
     ".gradle",
     ".m2",  # Java build caches
+    # #13602: git worktrees are near-complete copies of the repo. Measured on a
+    # working checkout, 160,105 of 167,072 code files (96%) lived under these two
+    # directories — every analytics walk was scanning the repo ~26 times over.
+    # `duplicate_detector._get_files_to_scan` already documented `.worktrees/` as
+    # pruned; it never was, because the name was missing from this set.
+    ".worktrees",
+    "worktrees",  # .claude/worktrees — same content, different parent
 }
+
+
+def is_skipped_path(path: Path, root: Path) -> bool:
+    """True if ``path`` lies inside a SKIP_DIRS directory *below* ``root``.
+
+    The root-relative check is the whole point (#7128b, #13602). Testing
+    ``SKIP_DIRS & set(path.parts)`` on an absolute path asks whether the skip
+    name appears ANYWHERE in it — including in the root itself. So a scan whose
+    root is `/repo/.worktrees/issue-X` classified every file under it as
+    skippable and reported an empty codebase: not an error, not a log line, just
+    zero results, which reads exactly like a clean repo.
+
+    That trap is why `.worktrees` could not simply be added to SKIP_DIRS — CI and
+    development both run from inside a worktree.
+
+    A skip directory *nested* under the root is still skipped, which is the
+    behaviour we actually want.
+    """
+    try:
+        relative = path.resolve().relative_to(root.resolve())
+    except (ValueError, OSError):
+        # Outside the root (or unreadable): fall back to the absolute check
+        # rather than silently admitting a path we cannot place.
+        return bool(set(path.parts) & SKIP_DIRS)
+    return bool(set(relative.parts) & SKIP_DIRS)
+
 
 # Directory-based categories (not skipped, but categorized)
 BACKUP_DIRS: Set[str] = {"backup", "backups", "bak", ".backup"}

--- a/autobot-backend/utils/file_categorization_skip_13602_test.py
+++ b/autobot-backend/utils/file_categorization_skip_13602_test.py
@@ -1,0 +1,80 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""`is_skipped_path` decides what an analytics scan can see (#13602).
+
+Adding `.worktrees` to SKIP_DIRS is only safe because this function relativises
+first. Testing `SKIP_DIRS & set(path.parts)` on an absolute path asks whether a
+skip name appears ANYWHERE in it — including in the scan root — and CI and
+development both run from inside a worktree. Get this wrong and a scan reports
+an empty codebase: no error, no log, just zero results.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from utils.file_categorization import SKIP_DIRS, is_skipped_path
+
+
+class TestRootRelativity:
+    def test_the_root_s_own_ancestry_is_irrelevant(self, tmp_path):
+        root = tmp_path / ".worktrees" / "issue-13602"
+        assert not is_skipped_path(root / "pkg" / "mod.py", root)
+
+    def test_a_skip_dir_nested_under_the_root_is_still_skipped(self, tmp_path):
+        root = tmp_path / ".worktrees" / "issue-13602"
+        assert is_skipped_path(root / ".worktrees" / "inner" / "mod.py", root)
+        assert is_skipped_path(root / "node_modules" / "x" / "mod.js", root)
+
+    def test_both_worktree_layouts_are_covered(self, tmp_path):
+        """`.worktrees/` and `.claude/worktrees/` held 96% of the files."""
+        assert is_skipped_path(tmp_path / ".worktrees" / "a" / "m.py", tmp_path)
+        assert is_skipped_path(tmp_path / ".claude" / "worktrees" / "a" / "m.py", tmp_path)
+
+
+class TestUnplaceablePaths:
+    def test_a_path_outside_the_root_is_not_part_of_the_scan(self, tmp_path):
+        """The fallback. Consulting SKIP_DIRS against an absolute path here
+        would test the ROOT's ancestry — the exact bug this function removes —
+        and would admit a symlink escape as scannable."""
+        root = tmp_path / "project"
+        root.mkdir()
+        assert is_skipped_path(Path("/etc/passwd"), root)
+
+    def test_a_symlink_escape_is_not_admitted(self, tmp_path):
+        root = tmp_path / "project"
+        (root / "pkg").mkdir(parents=True)
+        outside = tmp_path / "elsewhere"
+        outside.mkdir()
+        (outside / "secret.py").write_text("x = 1\n", encoding="utf-8")
+        link = root / "pkg" / "link.py"
+        try:
+            link.symlink_to(outside / "secret.py")
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks unavailable on this platform")
+
+        assert is_skipped_path(link, root)
+
+    def test_a_symlinked_root_still_resolves_its_own_files(self, tmp_path):
+        """The direction that must keep working — over-eager skipping here is
+        how a scan silently reports nothing."""
+        real = tmp_path / "real"
+        (real / "pkg").mkdir(parents=True)
+        (real / "pkg" / "mod.py").write_text("x = 1\n", encoding="utf-8")
+        link_root = tmp_path / "linked"
+        try:
+            link_root.symlink_to(real, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks unavailable on this platform")
+
+        assert not is_skipped_path(real / "pkg" / "mod.py", link_root)
+
+
+class TestTheSkipListItself:
+    def test_the_worktree_names_are_present(self):
+        """Their absence is what made every walk scan the repo ~26 times over,
+        while the detector's docstring claimed they were pruned."""
+        assert ".worktrees" in SKIP_DIRS
+        assert "worktrees" in SKIP_DIRS


### PR DESCRIPTION
## Thinking Path

#13602 reports two endpoints that never respond — 180s, 0 bytes, and **nothing in the log**. No exception, no timeout, no trace. That last part is what made it worth chasing carefully: a hang with no output means the handler never ran, not that it ran and failed.

It turned out to be four defects that compound, plus a fifth in a sibling panel.

**The hang itself.** `_build_analysis_task_list` fans out five analyses. Four wrap themselves in `asyncio.wait_for`; `api_endpoint` does not. The shared analytics executor has 8 workers, so once the slower analyses occupy them all, that unbounded submission **queues and never starts** — `gather` never returns, the socket stays open, and no handler ever runs to log anything. Not a slow endpoint: a hang, and a silent one by construction.

**Why the workers were all busy.** `duplicate_detector._get_files_to_scan` has documented `.worktrees/` as pruned since #12779. It never was — the name was not in `SKIP_DIRS`. Measured on a working checkout: **160,105 of 167,072 code files (96%)** lived under `.worktrees` and `.claude/worktrees`, so every analytics walk scanned the repo ~26 times over.

**Why abandoned scans stayed.** #12779 added a cancel token but consulted it in exactly one place, inside the `os.walk` loop — 0.14s of a run whose remaining phases measured **over six minutes on a single tree** (105,441 blocks, still building MinHash signatures at 6m15s, RSS 2.0 GB, against a 120s timeout). Every timed-out scan held a worker until it finished naturally.

**Why they stacked.** `/report` submitted its own scan straight to the same executor with neither the single-flight lock nor the token, and `duplicates.py` released that lock in a `finally` that ran on timeout while the orphan was still going. Both re-created the accumulation #12779 set out to stop.

**And the separate 400.** `/ownership/analysis` resolved its source's clone path and then validated against `_get_project_root()` — the root it had just replaced, on the next line but one.

## What Changed

**Bounded execution.** The deadline now rides in the task tuple and `_run_parallel_analyses` applies it, so a task without one is a type error rather than an oversight — adding a fifth `wait_for` is the pattern that let one be forgotten. An analysis abandoned at its deadline now says so; previously the section simply vanished from the report with no explanation.

**Cancellation that works.** The token is polled in block extraction and in signature building — the phase that dominates the runtime — plus at the boundary between them.

**One guarded path.** `/report` delegates to `_run_standard_analysis`, passing the detector default it was already relying on implicitly. The lock is released by a done-callback on the future, so it outlasts the orphan. That is only bounded *because* the token now works, which is why the test asserts the lock reopens as well as that it stays shut.

**The walk.** `.worktrees`/`worktrees` added to `SKIP_DIRS` — 167,072 files / 5.46s becomes **6,967 / 0.06s**.

Adding the name is not enough on its own, and this is the part worth reading. Five call sites tested `SKIP_DIRS & set(path.parts)` against an **absolute** path, which asks whether a skip name appears anywhere in it — including inside the scan root. CI and development both run from inside `.worktrees/`, so adding the name would have made a scan rooted there classify every file below it as skippable: no error, no log, zero results, indistinguishable from a clean repo. That is precisely the failure mode this umbrella exists to remove, so shipping it as the fix was not an option. `is_skipped_path(path, root)` relativises first, applying the pattern #7128b already established after hitting this exact trap. All five consumers migrated — including `duplicate_detector._should_skip_path`, which had **no callers**, so its absolute comparison was a trap armed for whoever wired it in next. Wired in rather than deleted.

**Ownership scoping.** All three endpoints now use `resolve_scan_root` (#12330). `/expertise` and `/knowledge-gaps` were worse than the 400: they accepted `source_id` and ignored it, silently analysing AutoBot's own tree for every source — plausible data for the wrong project, which is why nobody noticed. The false `"Path traversal attempt blocked"` warning is gone, and it no longer echoes the internal clone path.

Fixing the 400 makes that panel reachable for the first time, which exposed what it would then do: `git blame` as a bare synchronous subprocess inside `async def`, one per file, up to 30s each, blocking the event loop. Moved off the loop, worktrees skipped, capped at 2000 files with the truncation logged — a silent cap reads as "we analysed everything".

## Verification

```
312 passed, 11 skipped   api/codebase_analytics/ + code_intelligence/shared/
black · isort · flake8 · 5 repo checkers   clean on all 14 changed files
```

Every guard mutation-tested — the fix reverted, the test confirmed to fail, the fix restored. **14 mutations, 14 caught:**

| Reverted | Fails |
|---|---|
| `.worktrees` dropped from SKIP_DIRS | 5 |
| `is_skipped_path` back to the absolute check | 1 |
| `_should_skip_path` unwired | 1 |
| per-task deadline not applied | 2 (and without the bound the test *hangs* — the defect itself) |
| abandonment log removed | 1 |
| `api_endpoint` deadline set to 0 | 2 |
| `/report` submitting directly again | 2 |
| lock released on timeout | 1 |
| orphan not signalled | 1 |
| validation vs project root | 1 |
| siblings ignoring `source_id` | 2 |
| every rejection logged as an attack | 2 |
| blame back on the event loop | 1 |
| analyzer skip-list reverted | 1 |

Two of those deserve a note. The deadline mutation originally *hung* rather than failed, because one test had no outer bound — a test that hangs burns the CI job timeout instead of reporting, so it is now bounded and fails cleanly in 21s. And the traversal-warning guard asserts both directions: a real `../../etc/passwd` must still be caught, since a test proving only that the false alert is gone passes equally against a detector that says nothing.

## Not in this PR

- **AC 2** asks for a server-side deadline on *every* analytics endpoint. There is no such mechanism anywhere in the codebase — no timeout middleware, no decorator, no `timeout_keep_alive`; every handler hand-rolls its own `wait_for` with three different constants. This PR makes the deadline structural for `/report`'s fan-out, which is where the reported hang lives. A universal one is an architectural change with a much wider blast radius, filed separately with options.
- Two pre-existing flake8 findings in `ownership_analyzer.py`, which sits in a lint-excluded directory: an unused `recency_cutoff` left over from #1183's extraction (the helper computes its own and uses it, so it is redundant rather than unwired) and a long line. Unrelated to this issue.

Issue stays open pending host evidence — the endpoints are fixed in code, but #13602's measurements were taken against a running instance and closure needs the same.

Refs #13602 — deliberately not `Closes`. The endpoints are fixed in code, but #13602's
measurements were taken against a running instance, and closure needs the same numbers
from a host. Part of umbrella #13852.

## Model Used

Opus 5 (1M context)
