### PR TITLE
security(chat): refuse a colliding session id and a silent ownership takeover (#14012)

### DIFF
--- a/autobot-backend/api/chat_sessions.py
+++ b/autobot-backend/api/chat_sessions.py
@@ -13,7 +13,7 @@ storage to the chat_history subsystem.
 import json
 from typing import Dict, List
 
-from fastapi import APIRouter, Depends, Request, Response
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from fastapi.responses import JSONResponse
 
 from api.schemas_chat import (
@@ -734,6 +734,49 @@ async def _track_session_in_memory_graph(
         )
 
 
+async def _reject_session_id_collision(chat_history_manager, session_id: str, user_data: dict | None) -> None:
+    """Refuse to create over an existing session the caller does not own (#14012).
+
+    The caller-supplied id (#6746) is validated for shape only, so without this a
+    request naming someone else's session id would overwrite their messages and
+    reassign ownership. Re-creating one's *own* session id is left alone — that
+    is a client retry, and the #6746 round-trip depends on it.
+
+    A lookup failure refuses rather than proceeding: not being able to tell
+    whether a session exists is not a reason to overwrite it.
+    """
+    try:
+        existing = await chat_history_manager.get_session(session_id)
+    except Exception as exc:
+        logger.warning("Could not check session %s for collision, refusing create: %s", session_id, exc)
+        raise _session_id_taken_error()
+    if existing is None:
+        return
+
+    owner = ((existing.get("metadata") or {}) if isinstance(existing, dict) else {}).get("owner")
+    caller = (user_data or {}).get("username")
+    if owner and caller and owner == caller:
+        return  # the caller's own session — a retry, not a takeover
+
+    logger.warning("Refusing create over existing session %s (owner=%s, caller=%s)", session_id, owner, caller)
+    raise _session_id_taken_error()
+
+
+def _session_id_taken_error() -> HTTPException:
+    """409 for a create that collides with an existing session id (#14012).
+
+    Deliberately an ``HTTPException`` rather than the domain ``AuthorizationError``:
+    ``@with_error_handling`` re-raises ``HTTPException`` untouched but converts
+    anything else into a generic 500 ("The operation failed"), so the domain
+    exception refused the request while telling the client the server broke.
+
+    Deliberately 409 and identical for both refusal cases — a session owned by
+    someone else and one with no recorded owner. A 403 on the first would confirm
+    who does own it; the caller only needs to know the id is not theirs to take.
+    """
+    return HTTPException(status_code=409, detail="A session with this id already exists")
+
+
 @router.post("/chat/sessions", response_model=DataResponse[SessionCreateData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -754,14 +797,20 @@ async def create_session(session_data: SessionCreate, request: Request):
     # so the frontend's locally-minted UUID survives the round-trip and
     # frontend/backend stay aligned. Falls back to server-mint when absent
     # (legacy callers, CLI, tests).
+    # SECURITY: Extract authenticated user and add to metadata as owner
+    user_data = get_auth_middleware().get_user_from_request(request)
+
     if session_data.id and validate_chat_session_id(session_data.id):
         session_id = session_data.id
+        # #14012: the id above is caller-supplied and only its FORMAT was
+        # checked. Without this, creating over an existing id replaced the
+        # stored messages with [] and reassigned ownership — one request that
+        # destroyed a conversation and took the session over.
+        await _reject_session_id_collision(chat_history_manager, session_id, user_data)
     else:
         session_id = generate_chat_session_id()
     session_title = session_data.title or DEFAULT_SESSION_TITLE
 
-    # SECURITY: Extract authenticated user and add to metadata as owner
-    user_data = get_auth_middleware().get_user_from_request(request)
     metadata = session_data.metadata or {}
     if user_data and user_data.get("username"):
         metadata["owner"] = user_data["username"]

--- a/autobot-backend/api/chat_sessions_collision_test.py
+++ b/autobot-backend/api/chat_sessions_collision_test.py
@@ -1,0 +1,167 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Creating over an existing session id must not destroy or take it over (#14012).
+
+`create_session` accepts a caller-supplied id (#6746) and checked only its
+**format**. Neither downstream step guarded a collision:
+
+- `chat_history_manager.create_session` calls `save_session(..., messages=[])`,
+  replacing the stored conversation with an empty list
+- `set_session_owner` did an unconditional `redis.set`, with no existing-owner
+  guard
+
+So one request naming a victim's session id both destroyed their conversation
+and made the attacker its registered owner — after which every *other* endpoint's
+ownership check passes for them, because the record those checks consult now
+says they are the owner.
+
+Two layers are tested here, because either alone leaves the other reachable: the
+endpoint refuses the collision, and the ownership record refuses a silent
+reassignment regardless of who calls it.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from api import chat_sessions
+from api.schemas_chat import SessionCreate
+
+_ALICE = {"username": "alice", "user_id": "alice-id"}
+_MALLORY = {"username": "mallory", "user_id": "mallory-id"}
+
+
+def _manager(existing):
+    manager = MagicMock()
+    manager.get_session = AsyncMock(return_value=existing)
+    manager.create_session = AsyncMock(return_value={"session_id": "chat-1"})
+    return manager
+
+
+def _session_owned_by(owner: str) -> dict:
+    return {"session_id": "chat-1", "messages": [{"role": "user", "content": "secret"}], "metadata": {"owner": owner}}
+
+
+class TestTheEndpointRefusesACollision:
+    @pytest.mark.asyncio
+    async def test_creating_over_another_users_session_is_refused(self):
+        manager = _manager(_session_owned_by("alice"))
+
+        with pytest.raises(HTTPException):
+            await chat_sessions._reject_session_id_collision(manager, "chat-1", _MALLORY)
+
+    @pytest.mark.asyncio
+    async def test_a_free_id_is_allowed(self):
+        """The common path — #6746's client-minted id for a genuinely new session."""
+        manager = _manager(None)
+
+        await chat_sessions._reject_session_id_collision(manager, "chat-new", _ALICE)
+
+    @pytest.mark.asyncio
+    async def test_the_owner_may_recreate_their_own_id(self):
+        """A client retry, which the #6746 round-trip depends on."""
+        manager = _manager(_session_owned_by("alice"))
+
+        await chat_sessions._reject_session_id_collision(manager, "chat-1", _ALICE)
+
+    @pytest.mark.asyncio
+    async def test_an_existing_session_with_no_recorded_owner_is_refused(self):
+        """Legacy sessions have no owner metadata. Unknown is not the same as free."""
+        manager = _manager({"session_id": "chat-1", "messages": [{"role": "user", "content": "x"}], "metadata": {}})
+
+        with pytest.raises(HTTPException):
+            await chat_sessions._reject_session_id_collision(manager, "chat-1", _MALLORY)
+
+    @pytest.mark.asyncio
+    async def test_an_anonymous_caller_cannot_claim_an_owned_session(self):
+        manager = _manager(_session_owned_by("alice"))
+
+        with pytest.raises(HTTPException):
+            await chat_sessions._reject_session_id_collision(manager, "chat-1", None)
+
+    @pytest.mark.asyncio
+    async def test_a_lookup_failure_refuses_rather_than_overwrites(self):
+        """Not being able to tell whether a session exists is not a reason to overwrite it."""
+        manager = MagicMock()
+        manager.get_session = AsyncMock(side_effect=RuntimeError("storage down"))
+
+        with pytest.raises(HTTPException):
+            await chat_sessions._reject_session_id_collision(manager, "chat-1", _ALICE)
+
+
+class TestTheEndpointActuallyCallsTheGuard:
+    """The guard being correct is not the same as the endpoint using it.
+
+    Testing `_reject_session_id_collision` directly cannot see the call site —
+    deleting the call from `create_session` left every helper test green. This
+    drives the endpoint so the wiring itself is pinned.
+    """
+
+    @pytest.mark.asyncio
+    async def test_create_over_another_users_session_is_refused_end_to_end(self, monkeypatch):
+        manager = _manager(_session_owned_by("alice"))
+        middleware = MagicMock()
+        middleware.get_user_from_request.return_value = _MALLORY
+
+        monkeypatch.setattr(chat_sessions, "get_chat_history_manager", MagicMock(return_value=manager))
+        monkeypatch.setattr(chat_sessions, "get_auth_middleware", MagicMock(return_value=middleware))
+        monkeypatch.setattr(chat_sessions, "validate_chat_session_id", MagicMock(return_value=True))
+
+        with pytest.raises(HTTPException) as excinfo:
+            await chat_sessions.create_session(SessionCreate(id="chat-1", title="mine now"), MagicMock())
+
+        assert excinfo.value.status_code == 409, "must not surface as a generic 500"
+
+        manager.create_session.assert_not_called(), "nothing may be written on a refused create"
+
+
+class TestTheOwnershipRecordRefusesAReassignment:
+    """Defence in depth: a future caller that skips the endpoint check still cannot take over."""
+
+    @staticmethod
+    def _validator(existing_owner):
+        from security.session_ownership import SessionOwnershipValidator
+
+        validator = SessionOwnershipValidator.__new__(SessionOwnershipValidator)
+        validator.redis = MagicMock()
+        validator.redis.set = AsyncMock()
+        validator.redis.sadd = AsyncMock()
+        validator.redis.expire = AsyncMock()
+        validator.ownership_ttl = 3600
+        validator.get_session_owner = AsyncMock(return_value=existing_owner)
+        return validator
+
+    @pytest.mark.asyncio
+    async def test_a_different_owner_is_not_silently_overwritten(self):
+        validator = self._validator("alice")
+
+        result = await validator.set_session_owner(session_id="chat-1", username="mallory")
+
+        assert result is False
+        validator.redis.set.assert_not_awaited(), "the ownership key must not be rewritten"
+
+    @pytest.mark.asyncio
+    async def test_an_unowned_session_can_be_claimed(self):
+        """First registration — what create_session legitimately does."""
+        validator = self._validator(None)
+
+        assert await validator.set_session_owner(session_id="chat-1", username="alice") is True
+        validator.redis.set.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_the_owner_may_refresh_their_own_record(self):
+        """The TTL refresh path must keep working, or ownership expires under active use."""
+        validator = self._validator("alice")
+
+        assert await validator.set_session_owner(session_id="chat-1", username="alice") is True
+        validator.redis.set.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_deliberate_transfer_must_say_so(self):
+        validator = self._validator("alice")
+
+        assert await validator.set_session_owner(session_id="chat-1", username="bob", force=True) is True
+        validator.redis.set.assert_awaited()

--- a/autobot-backend/security/session_ownership.py
+++ b/autobot-backend/security/session_ownership.py
@@ -76,6 +76,7 @@ class SessionOwnershipValidator:
         username: str,
         org_id: str | None = None,
         team_id: str | None = None,
+        force: bool = False,
     ) -> bool:
         """
         Associate a chat session with its owner and org/team context.
@@ -85,11 +86,29 @@ class SessionOwnershipValidator:
             username: Owner username
             org_id: Organization ID (#684)
             team_id: Team ID for team-scoped sessions (#684)
+            force: Reassign an already-owned session (#14012). A deliberate
+                transfer must say so; the default refuses.
 
         Returns:
-            True if successful
+            True if successful, False if the session already has a different
+            owner and *force* was not set.
         """
         try:
+            # #14012: this used to be an unconditional set, so any writer could
+            # silently take a session over — and then pass every ownership check
+            # on it. An authorization record that any caller can overwrite is not
+            # an authorization record. Refreshing one's own ownership (the TTL
+            # refresh path) is still allowed.
+            existing = await self.get_session_owner(session_id)
+            if existing and existing != username and not force:
+                logger.warning(
+                    "Refusing to reassign session %s... from %s to %s without force",
+                    session_id[:8],
+                    existing,
+                    username,
+                )
+                return False
+
             # Store ownership mapping
             ownership_key = self._get_ownership_key(session_id)
             await self.redis.set(ownership_key, username, ex=self.ownership_ttl)


### PR DESCRIPTION
Closes #14012

## Thinking Path

`create_session` accepts a caller-supplied id (#6746, so the frontend's locally-minted UUID survives the round-trip) and checked only its **format**. Neither downstream step guarded a collision:

- `chat_history_manager.create_session` calls `save_session(session_id, messages=[], ...)` — replaces the stored conversation with an empty list
- `set_session_owner` did an unconditional `redis.set` — no existing-owner guard

So one request naming a victim's session id both **destroyed their conversation** and **made the attacker its registered owner**. The ownership half is what compounds it: after the takeover, every *other* endpoint's ownership check passes for the attacker, because the record those checks consult now names them.

### Two layers, because either alone leaves the other reachable

**1. The endpoint refuses the collision.** Re-creating one's *own* id is still allowed — that is a client retry, and #6746's round-trip depends on it. Two cases are deliberately refused rather than allowed:

- an existing session with **no recorded owner** (legacy sessions). Unknown is not the same as free.
- a **lookup failure**. Not being able to tell whether a session exists is not a reason to overwrite it.

**2. The ownership record refuses a silent reassignment.** `set_session_owner` returns False rather than rewriting an existing, different owner unless `force=True`. An authorization record that any writer can overwrite is not an authorization record. Refreshing one's *own* ownership still works, so the TTL refresh path is unaffected.

### Decision: `HTTPException(409)`, not the domain `AuthorizationError`

I wrote it with `AuthorizationError` first. The end-to-end test caught what reading would not have: `@with_error_handling` re-raises `HTTPException` untouched but converts everything else into a generic **500 — "The operation failed."** The request was correctly refused while the client was told the server had broken.

409 is also returned identically for both refusal cases, so the response does not confirm *who* owns the session — the caller only needs to know the id is not theirs to take.

## What Changed

- `api/chat_sessions.py` — `_reject_session_id_collision` called from `create_session` on the caller-supplied-id branch only; `_session_id_taken_error` returns the 409.
- `security/session_ownership.py` — `set_session_owner` gains `force: bool = False` and refuses to reassign a different existing owner without it.
- `api/chat_sessions_collision_test.py` (new) — 11 tests.

## Verification

```
$ pytest autobot-backend/api/chat_sessions_collision_test.py \
         autobot-backend/api/chat_test.py \
         autobot-backend/tests/api/test_chat_shared_links.py -q
17 passed
```

Mutation battery, with no-op detection in the harness:

| mutation | result |
|---|---|
| call site removed from `create_session` (the vulnerability) | KILLED (1) |
| 409 downgraded to the swallowed domain error | KILLED (5) |
| unknown-owner session treated as free | KILLED (1) |
| lookup failure proceeds instead of refusing | KILLED (1) |
| `set_session_owner` reassigns unconditionally | KILLED (1) |
| `force` ignored (would block a legitimate transfer) | KILLED (1) |

**The first row is why there is an endpoint-level test.** On the first run it *survived*: every test drove `_reject_session_id_collision` directly, so deleting the call from `create_session` broke nothing. Testing a guard is not testing that anything uses it — the same gap this repo has now hit twice, and the reason the harness also verifies its own edit actually landed before trusting a "survived".

Lint: black, isort, flake8 clean.

### Not covered

Layer 2 protects the ownership *record*; layer 1 protects the *conversation*. Neither addresses #14010 — the shared validator fails open, so in a default deployment the ownership checks that consult this record are inert anyway. This PR removes the takeover vector; #14010 decides whether the resulting record is enforced.

## Model Used

Claude Opus 5