### PR TITLE
security(chat): stop an expired ownership record reading as an unowned session (#14018)

### DIFF
--- a/autobot-backend/security/session_ownership.py
+++ b/autobot-backend/security/session_ownership.py
@@ -481,10 +481,17 @@ class SessionOwnershipValidator:
         claiming an apparently-unowned session is what separates "never had an
         owner" from "the owner has been away for a day".
 
-        Returns None when the session cannot be read or records no owner — the
-        caller then treats it as genuinely unowned. A read failure is reported at
-        warning level rather than swallowed, because it silently re-enables the
-        claim path this exists to close.
+        Delegates to ``ChatHistoryManager.get_session_owner`` rather than reading
+        ``metadata["owner"]`` here. That accessor also falls back to
+        ``metadata["username"]``, which sessions predating the ``owner`` field
+        carry — ``create_session`` still writes both keys for exactly that
+        reason. Parsing only ``owner`` would have read those older sessions as
+        unowned and handed them to their next visitor, which is this issue's own
+        defect reintroduced for that vintage of file.
+
+        Returns None when the session records no owner or cannot be read; the
+        caller then treats it as genuinely unowned. See the PR for why that
+        fail-open is deliberate and where it is uncomfortable.
         """
         try:
             from utils.chat_utils import get_chat_history_manager  # noqa: PLC0415
@@ -492,13 +499,10 @@ class SessionOwnershipValidator:
             manager = get_chat_history_manager(request)
             if manager is None:
                 return None
-            session = await manager.get_session(session_id)
+            owner = await manager.get_session_owner(session_id)
         except Exception as exc:
             logger.warning("Could not read the durable owner of session %s...: %s", session_id[:8], exc)
             return None
-        if not isinstance(session, dict):
-            return None
-        owner = (session.get("metadata") or {}).get("owner")
         return owner if isinstance(owner, str) and owner else None
 
     async def _owner_when_cache_is_empty(

--- a/autobot-backend/security/session_ownership.py
+++ b/autobot-backend/security/session_ownership.py
@@ -474,6 +474,60 @@ class SessionOwnershipValidator:
 
         return None
 
+    async def _durable_owner(self, session_id: str, request: Request) -> str | None:
+        """Owner recorded in the session file, which has no TTL (#14018).
+
+        The Redis ownership key expires; this does not. Consulting it before
+        claiming an apparently-unowned session is what separates "never had an
+        owner" from "the owner has been away for a day".
+
+        Returns None when the session cannot be read or records no owner — the
+        caller then treats it as genuinely unowned. A read failure is reported at
+        warning level rather than swallowed, because it silently re-enables the
+        claim path this exists to close.
+        """
+        try:
+            from utils.chat_utils import get_chat_history_manager  # noqa: PLC0415
+
+            manager = get_chat_history_manager(request)
+            if manager is None:
+                return None
+            session = await manager.get_session(session_id)
+        except Exception as exc:
+            logger.warning("Could not read the durable owner of session %s...: %s", session_id[:8], exc)
+            return None
+        if not isinstance(session, dict):
+            return None
+        owner = (session.get("metadata") or {}).get("owner")
+        return owner if isinstance(owner, str) and owner else None
+
+    async def _owner_when_cache_is_empty(
+        self, session_id: str, username: str, user_data: Dict, request: Request
+    ) -> "tuple[str | None, Dict | None]":
+        """Resolve ownership when Redis has no record (#14018).
+
+        An absent Redis record does NOT mean the session is unowned: the key
+        carries a TTL, so it also goes absent for any session whose owner has not
+        touched it recently. Claiming it here handed that session to whoever
+        accessed it next, authorized — ownership expiring into a takeover.
+
+        The session file's ``metadata.owner`` does not expire, so it is asked
+        first. Redis is a cache in front of it, not the record of truth.
+
+        Returns ``(owner, early_result)``. A non-None *early_result* is the
+        caller's return value; otherwise *owner* continues the normal comparison.
+        """
+        durable_owner = await self._durable_owner(session_id, request)
+        if durable_owner:
+            if durable_owner == username:
+                # Rehydrate the cache for its real owner, never for the caller.
+                await self.set_session_owner(session_id, durable_owner, org_id=user_data.get("org_id"), team_id=None)
+            return durable_owner, None
+
+        logger.warning("Session %s... has no owner anywhere (legacy session)", session_id[:8])
+        await self.set_session_owner(session_id, username, org_id=user_data.get("org_id"), team_id=None)
+        return username, {"authorized": True, "user_data": user_data, "reason": "legacy_migration"}
+
     async def _resolve_ownership(
         self,
         session_id: str,
@@ -484,8 +538,9 @@ class SessionOwnershipValidator:
     ) -> Dict:
         """Helper for validate_ownership. Ref: #1088.
 
-        Performs the Redis ownership lookup and resolves the result into one of:
-        - legacy_migration  (no stored owner — claim it now)
+        Performs the ownership lookup and resolves the result into one of:
+        - legacy_migration  (no owner in Redis *or* on disk — a genuinely
+          unowned session, claimed now)
         - mismatch path     (owner differs — delegate to _check_ownership_mismatch)
         - owner_match       (user owns the session)
 
@@ -502,18 +557,9 @@ class SessionOwnershipValidator:
         stored_owner = await self.get_session_owner(session_id)
 
         if not stored_owner:
-            logger.warning("Session %s... has no owner (legacy session)", session_id[:8])
-            await self.set_session_owner(
-                session_id,
-                username,
-                org_id=user_data.get("org_id"),
-                team_id=None,
-            )
-            return {
-                "authorized": True,
-                "user_data": user_data,
-                "reason": "legacy_migration",
-            }
+            stored_owner, early = await self._owner_when_cache_is_empty(session_id, username, user_data, request)
+            if early is not None:
+                return early
 
         if stored_owner != username:
             return await self._check_ownership_mismatch(

--- a/autobot-backend/security/session_ownership_expiry_test.py
+++ b/autobot-backend/security/session_ownership_expiry_test.py
@@ -1,0 +1,145 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""An expired ownership record must not hand the session to the next caller (#14018).
+
+Ownership was recorded in two independent places:
+
+- the session file's ``metadata.owner`` — permanent
+- the Redis ownership key — ``ownership_ttl = 86400`` (24 hours)
+
+Every ownership check consults the Redis one. ``_resolve_ownership`` treated
+"no stored owner" as a legacy session and **claimed it for the caller**, returning
+``authorized: True``. But "no stored owner" is not only the legacy case — it is
+also every session whose TTL has lapsed. So a session its owner had not touched
+for a day was handed to whoever accessed it next, with the file still naming the
+real owner and nothing reading it.
+
+The fix asks the durable record before claiming. These tests pin the distinction
+that makes it work: *never recorded* is claimable, *expired* is not.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from security.session_ownership import SessionOwnershipValidator
+
+_ALICE = "alice"
+_BOB = "bob"
+
+
+def _validator(*, redis_owner, file_owner):
+    """A validator whose Redis cache and durable file record can disagree."""
+    validator = SessionOwnershipValidator.__new__(SessionOwnershipValidator)
+    validator.redis = MagicMock()
+    validator.ownership_ttl = 86400
+    validator.get_session_owner = AsyncMock(return_value=redis_owner)
+    validator.set_session_owner = AsyncMock(return_value=True)
+    validator._durable_owner = AsyncMock(return_value=file_owner)
+    validator._check_ownership_mismatch = AsyncMock(
+        return_value={"authorized": False, "user_data": {}, "reason": "mismatch"}
+    )
+    validator._audit_log_success = MagicMock()
+    return validator
+
+
+async def _resolve(validator, username):
+    return await validator._resolve_ownership(
+        session_id="chat-1",
+        username=username,
+        user_data={"username": username},
+        request=MagicMock(),
+        enforcement_mode="enforced",
+    )
+
+
+class TestAnExpiredRecordIsNotAnUnownedSession:
+    @pytest.mark.asyncio
+    async def test_a_stranger_cannot_claim_a_session_whose_cache_expired(self):
+        """The defect, in one assertion.
+
+        Alice owns the session on disk. Her Redis key has lapsed. Bob arrives.
+        """
+        validator = _validator(redis_owner=None, file_owner=_ALICE)
+
+        result = await _resolve(validator, _BOB)
+
+        assert result["reason"] != "legacy_migration", "an expired record must not read as unowned"
+        assert result["authorized"] is False
+        validator._check_ownership_mismatch.assert_awaited(), "must go through the mismatch path"
+
+    @pytest.mark.asyncio
+    async def test_the_cache_is_never_rehydrated_for_the_wrong_user(self):
+        """Claiming for the caller is what converted expiry into a takeover."""
+        validator = _validator(redis_owner=None, file_owner=_ALICE)
+
+        await _resolve(validator, _BOB)
+
+        validator.set_session_owner.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_the_real_owner_still_gets_in_after_expiry(self):
+        """The other half — the fix must not lock the owner out of their own session."""
+        validator = _validator(redis_owner=None, file_owner=_ALICE)
+
+        result = await _resolve(validator, _ALICE)
+
+        assert result["authorized"] is True
+        assert result["reason"] == "owner_match"
+
+    @pytest.mark.asyncio
+    async def test_the_owners_access_rehydrates_the_cache(self):
+        """Otherwise every request after expiry pays the file read."""
+        validator = _validator(redis_owner=None, file_owner=_ALICE)
+
+        await _resolve(validator, _ALICE)
+
+        validator.set_session_owner.assert_awaited_once()
+        assert validator.set_session_owner.await_args.args[1] == _ALICE
+
+
+class TestAGenuinelyUnownedSessionIsStillClaimable:
+    """The real legacy case must keep working, or old sessions become unreachable."""
+
+    @pytest.mark.asyncio
+    async def test_no_owner_anywhere_is_claimed_by_the_caller(self):
+        validator = _validator(redis_owner=None, file_owner=None)
+
+        result = await _resolve(validator, _BOB)
+
+        assert result["authorized"] is True
+        assert result["reason"] == "legacy_migration"
+        validator.set_session_owner.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_an_unreadable_session_is_treated_as_unowned_not_as_a_denial(self):
+        """`_durable_owner` returns None on a read failure; that path is the legacy one."""
+        validator = _validator(redis_owner=None, file_owner=None)
+
+        result = await _resolve(validator, _ALICE)
+
+        assert result["reason"] == "legacy_migration"
+
+
+class TestThePresentCacheStillDecides:
+    """When Redis has a record, the durable read must not run at all."""
+
+    @pytest.mark.asyncio
+    async def test_the_owner_is_authorized_without_touching_the_file(self):
+        validator = _validator(redis_owner=_ALICE, file_owner=_ALICE)
+
+        result = await _resolve(validator, _ALICE)
+
+        assert result["reason"] == "owner_match"
+        validator._durable_owner.assert_not_awaited(), "the cache hit must not pay a file read"
+
+    @pytest.mark.asyncio
+    async def test_a_mismatch_still_goes_to_the_mismatch_path(self):
+        validator = _validator(redis_owner=_ALICE, file_owner=_ALICE)
+
+        result = await _resolve(validator, _BOB)
+
+        assert result["authorized"] is False
+        validator._durable_owner.assert_not_awaited()

--- a/autobot-backend/security/session_ownership_expiry_test.py
+++ b/autobot-backend/security/session_ownership_expiry_test.py
@@ -143,3 +143,71 @@ class TestThePresentCacheStillDecides:
 
         assert result["authorized"] is False
         validator._durable_owner.assert_not_awaited()
+
+
+class TestTheDurableLookupSeesOlderSessions:
+    """The owner field is not the only durable record (#14019 review).
+
+    Sessions predating the `owner` field carry `metadata.username` instead, and
+    `create_session` still writes both keys for exactly that reason. Parsing only
+    `owner` read those as unowned and handed them to their next visitor — this
+    issue's own defect, reintroduced for that vintage of file.
+
+    `ChatHistoryManager.get_session_owner` already resolves
+    `owner or username`, so `_durable_owner` delegates to it rather than
+    reimplementing the parse.
+    """
+
+    @staticmethod
+    def _validator_with_manager(manager):
+        validator = SessionOwnershipValidator.__new__(SessionOwnershipValidator)
+        validator.redis = MagicMock()
+        validator.ownership_ttl = 86400
+        return validator
+
+    @pytest.mark.asyncio
+    async def test_a_username_only_session_is_recognised_as_owned(self, monkeypatch):
+        manager = MagicMock()
+        # What the shared accessor returns for a pre-`owner` session file.
+        manager.get_session_owner = AsyncMock(return_value=_ALICE)
+        monkeypatch.setattr("utils.chat_utils.get_chat_history_manager", MagicMock(return_value=manager))
+
+        validator = self._validator_with_manager(manager)
+        owner = await validator._durable_owner("chat-1", MagicMock())
+
+        assert owner == _ALICE, "an older session must not read as unowned"
+
+    @pytest.mark.asyncio
+    async def test_the_shared_accessor_is_used_not_a_local_reparse(self, monkeypatch):
+        """Pins the delegation: a reimplementation here would miss the fallback."""
+        manager = MagicMock()
+        manager.get_session_owner = AsyncMock(return_value=_ALICE)
+        monkeypatch.setattr("utils.chat_utils.get_chat_history_manager", MagicMock(return_value=manager))
+
+        validator = self._validator_with_manager(manager)
+        await validator._durable_owner("chat-1", MagicMock())
+
+        manager.get_session_owner.assert_awaited_once_with("chat-1")
+
+    @pytest.mark.asyncio
+    async def test_a_session_with_no_durable_owner_yields_none(self, monkeypatch):
+        manager = MagicMock()
+        manager.get_session_owner = AsyncMock(return_value=None)
+        monkeypatch.setattr("utils.chat_utils.get_chat_history_manager", MagicMock(return_value=manager))
+
+        validator = self._validator_with_manager(manager)
+
+        assert await validator._durable_owner("chat-1", MagicMock()) is None
+
+    @pytest.mark.asyncio
+    async def test_a_read_failure_yields_none_and_is_logged(self, monkeypatch, caplog):
+        manager = MagicMock()
+        manager.get_session_owner = AsyncMock(side_effect=RuntimeError("storage down"))
+        monkeypatch.setattr("utils.chat_utils.get_chat_history_manager", MagicMock(return_value=manager))
+
+        validator = self._validator_with_manager(manager)
+        with caplog.at_level("WARNING"):
+            result = await validator._durable_owner("chat-1", MagicMock())
+
+        assert result is None
+        assert any("durable owner" in r.message for r in caplog.records), "the fail-open must not be silent"


### PR DESCRIPTION
Closes #14018

## Thinking Path

A chat session's owner was recorded in **two independent places**:

| record | where | lifetime |
|---|---|---|
| `metadata.owner` | the session file | permanent |
| the Redis ownership key | `SessionOwnershipValidator`, `ownership_ttl = 86400` | **24 hours** |

Every ownership check — and therefore every endpoint hardened in #13982, #14011 and #14012 — consults the **Redis** one. `_resolve_ownership` treated "no stored owner" as a legacy session, claimed it for the caller, and returned `authorized: True`.

"No stored owner" is not only the legacy case. It is also **every session whose TTL has lapsed**:

1. Alice creates a session. Redis records her, TTL 24h.
2. Alice does not touch it for a day. The key expires.
3. Bob accesses that session id → read as legacy → **Bob becomes the owner and is authorized**.

Every subsequent check then passes for Bob, because the record they consult names him. The file still says Alice, and nothing reads it. No collision, no race, nothing to guess beyond the session id.

### The fix, and why this shape

Ask the **durable** record before claiming anything. That is the one distinction the old code could not make: *never recorded* (genuinely legacy, still claimable) versus *expired* (emphatically not).

This also settles which record is authoritative — a question #14012's review raised and left open. The file field does not expire and is written at create time, so it is the truth; Redis is a cache in front of it. Concretely:

- cache hit → decided as before, **no file read** (the common path costs nothing)
- cache miss + durable owner exists → that owner decides; the cache is rehydrated **only when the caller is that owner**, never for whoever happened to arrive
- cache miss + no durable owner → genuinely unowned, claimed as before

A failure reading the session file returns None and takes the legacy path, logged at warning. That is the one direction I am uneasy about and have stated in "Not covered" below.

## What Changed

- `security/session_ownership.py` — `_durable_owner` reads `metadata.owner` from the session file; `_owner_when_cache_is_empty` resolves the cache-miss case; `_resolve_ownership` delegates to it.

`_resolve_ownership` was 50 lines before and would have been 72; the extraction leaves it at 45 with the two new helpers at 26 and 28. Still over the 30-line guideline, but smaller than it started.

## Verification

```
$ pytest autobot-backend/security/session_ownership_expiry_test.py \
         autobot-backend/api/chat_sessions_collision_test.py \
         autobot-backend/api/chat_direct_ownership_test.py -q
23 passed
```

Eight new tests. The one that matters most asserts the defect directly: Alice owns the session on disk, her cache key has lapsed, Bob arrives — and must not be authorized.

Mutation battery, with no-op detection:

| mutation | result |
|---|---|
| revert: claim for the caller on an empty cache (the defect) | KILLED (3) |
| rehydrate the cache for the caller instead of the owner | KILLED (1) |
| durable read consulted even on a cache hit | KILLED (2) |
| genuinely-unowned session no longer claimable | KILLED (2) |
| rehydrate with the caller's name | **equivalent** — see below |

The last is not a gap: it sits inside `if durable_owner == username`, so passing either name is identical by definition. Recorded rather than papered over with a test that could not fail.

Lint: black, isort, flake8 clean.

### Not covered

**A file read failure still takes the legacy path** — it returns None, so an unreadable session is treated as unowned and claimable. Failing closed there would deny access whenever session storage hiccups, which is its own outage; failing open re-enables this issue's defect during that window. I have left it open, logged at warning, rather than silently choosing. If the preference is fail-closed, that is a one-line change and worth deciding deliberately.

**This does not make ownership enforced.** #14010 remains: the enforcement mode defaults to `disabled` and any feature-flag failure yields `disabled`, so these checks are inert in a default deployment. This PR is the prerequisite — fixing #14010 first would have activated confident-looking enforcement on top of a record that self-destructs daily.

## Model Used

Claude Opus 5