### PR TITLE
security(chat): write the durable owner when the save path creates a session (#14020)

### DIFF
--- a/autobot-backend/api/chat.py
+++ b/autobot-backend/api/chat.py
@@ -69,7 +69,7 @@ from exceptions import get_exceptions_lazy
 from knowledge.quarantine import RESEARCH_QUARANTINE_FILTER
 
 # CRITICAL SECURITY FIX: Import session ownership validation
-from security.session_ownership import validate_session_ownership
+from security.session_ownership import build_owner_metadata, validate_session_ownership
 from services.ai_stack_client import AIStackError, get_ai_stack_client
 from type_defs.common import STREAMING_MESSAGE_TYPES, Metadata
 
@@ -1784,32 +1784,28 @@ async def _merge_chat_messages(
         return new_messages
 
 
-async def _durable_owner_metadata(chat_history_manager, session_id: str, current_user: dict | None) -> dict | None:
-    """Owner metadata to write when a session has no durable owner yet (#14020).
+async def _durable_owner_metadata(chat_history_manager, session_id: str, ownership: "dict | None") -> dict | None:
+    """Owner metadata to write when the save path creates a session (#14020).
 
     `save_session` writes a `metadata` key only when one is passed, so saving to a
     session id with no existing file produced a session with **no durable owner**.
     Since #14018 made the file record authoritative, such a session reads as
-    genuinely unowned every time its Redis key lapses — reclaimable by whoever
-    visits next, once per TTL window.
+    unowned every time its Redis key lapses and is claimed by whoever visits next.
 
-    Returns None when a durable owner already exists, so an existing session's
-    recorded owner is never overwritten by whoever happens to be saving. The
-    caller has already passed `validate_chat_ownership` by this point, so when
-    there is no durable owner they are the recognised owner and the record is
-    simply catching up with that.
+    The write **mirrors the validator's own decision** rather than making an
+    independent one. `validate_chat_ownership` returns ``legacy_migration`` exactly
+    when it found no owner and granted the caller ownership — that is the only case
+    where stamping the file is recording what already happened.
+
+    It deliberately does NOT write on ``enforcement_disabled`` or ``auth_disabled``:
+    those fast paths authorise **without checking any owner at all** (and disabled
+    is the default today, #14010), so claiming there would let any authenticated
+    caller permanently stamp themselves onto an ownerless session — a claim that
+    would outlive the switch to enforced.
     """
-    username = (current_user or {}).get("username")
-    if not username:
+    if not isinstance(ownership, dict) or ownership.get("reason") != "legacy_migration":
         return None
-    try:
-        if await chat_history_manager.get_session_owner(session_id):
-            return None
-    except Exception as exc:
-        logger.warning("Could not check the durable owner of %s, not writing one: %s", session_id, exc)
-        return None
-    # Both keys, matching create_session — older readers look at `username`.
-    return {"owner": username, "username": username}
+    return build_owner_metadata(ownership.get("user_data")) or None
 
 
 @router.post("/chats/{chat_id}/save", response_model=DataResponse[ChatSaveData])
@@ -1851,7 +1847,7 @@ async def save_chat_by_id(
         session_id=chat_id,
         messages=merged_messages,
         name=save_data.get("name", ""),
-        metadata=await _durable_owner_metadata(chat_history_manager, chat_id, current_user),
+        metadata=await _durable_owner_metadata(chat_history_manager, chat_id, ownership),
     )
 
     return JSONResponse(

--- a/autobot-backend/api/chat.py
+++ b/autobot-backend/api/chat.py
@@ -1784,6 +1784,34 @@ async def _merge_chat_messages(
         return new_messages
 
 
+async def _durable_owner_metadata(chat_history_manager, session_id: str, current_user: dict | None) -> dict | None:
+    """Owner metadata to write when a session has no durable owner yet (#14020).
+
+    `save_session` writes a `metadata` key only when one is passed, so saving to a
+    session id with no existing file produced a session with **no durable owner**.
+    Since #14018 made the file record authoritative, such a session reads as
+    genuinely unowned every time its Redis key lapses — reclaimable by whoever
+    visits next, once per TTL window.
+
+    Returns None when a durable owner already exists, so an existing session's
+    recorded owner is never overwritten by whoever happens to be saving. The
+    caller has already passed `validate_chat_ownership` by this point, so when
+    there is no durable owner they are the recognised owner and the record is
+    simply catching up with that.
+    """
+    username = (current_user or {}).get("username")
+    if not username:
+        return None
+    try:
+        if await chat_history_manager.get_session_owner(session_id):
+            return None
+    except Exception as exc:
+        logger.warning("Could not check the durable owner of %s, not writing one: %s", session_id, exc)
+        return None
+    # Both keys, matching create_session — older readers look at `username`.
+    return {"owner": username, "username": username}
+
+
 @router.post("/chats/{chat_id}/save", response_model=DataResponse[ChatSaveData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1820,7 +1848,10 @@ async def save_chat_by_id(
     )
 
     result = await chat_history_manager.save_session(
-        session_id=chat_id, messages=merged_messages, name=save_data.get("name", "")
+        session_id=chat_id,
+        messages=merged_messages,
+        name=save_data.get("name", ""),
+        metadata=await _durable_owner_metadata(chat_history_manager, chat_id, current_user),
     )
 
     return JSONResponse(

--- a/autobot-backend/api/chat_save_owner_test.py
+++ b/autobot-backend/api/chat_save_owner_test.py
@@ -1,0 +1,71 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Every path that creates a session file must write the durable owner (#14020).
+
+`save_chat_by_id` called `save_session` with no `metadata`, and
+`_build_session_chat_data` writes the key only `if metadata:`. So a session
+created through the save endpoint — rather than `POST /chat/sessions` — had no
+`metadata.owner`.
+
+Since #14018 made the file record authoritative, that is not cosmetic: such a
+session reads as *genuinely unowned* every time its 24-hour Redis key lapses, and
+is claimed by whoever visits next. Permanently reclaimable, once per TTL window.
+
+The invariant these tests pin: a session with no durable owner gets one; a
+session that already has one never has it overwritten by whoever is saving.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from api import chat as chat_api
+
+_ALICE = {"username": "alice", "user_id": "alice-id"}
+
+
+def _manager(existing_owner):
+    manager = MagicMock()
+    manager.get_session_owner = AsyncMock(return_value=existing_owner)
+    return manager
+
+
+class TestANewSessionGetsADurableOwner:
+    @pytest.mark.asyncio
+    async def test_an_unowned_session_is_given_the_savers_owner_metadata(self):
+        metadata = await chat_api._durable_owner_metadata(_manager(None), "chat-new", _ALICE)
+
+        assert metadata == {"owner": "alice", "username": "alice"}
+
+    @pytest.mark.asyncio
+    async def test_both_keys_are_written(self):
+        """`create_session` writes both, and the shared owner lookup falls back to
+        `username` for sessions predating the `owner` field. Writing only one
+        would make this path's sessions look different from every other."""
+        metadata = await chat_api._durable_owner_metadata(_manager(None), "chat-new", _ALICE)
+
+        assert set(metadata) == {"owner", "username"}
+
+
+class TestAnExistingOwnerIsNeverOverwritten:
+    @pytest.mark.asyncio
+    async def test_a_session_that_already_has_an_owner_is_left_alone(self):
+        """Returning metadata here would let any saver rewrite the durable record."""
+        metadata = await chat_api._durable_owner_metadata(_manager("alice"), "chat-1", {"username": "bob"})
+
+        assert metadata is None
+
+    @pytest.mark.asyncio
+    async def test_an_owner_lookup_failure_writes_nothing(self):
+        """Not being able to tell whether an owner exists is not a licence to claim."""
+        manager = MagicMock()
+        manager.get_session_owner = AsyncMock(side_effect=RuntimeError("storage down"))
+
+        assert await chat_api._durable_owner_metadata(manager, "chat-1", _ALICE) is None
+
+    @pytest.mark.asyncio
+    async def test_an_anonymous_saver_writes_nothing(self):
+        assert await chat_api._durable_owner_metadata(_manager(None), "chat-1", None) is None
+        assert await chat_api._durable_owner_metadata(_manager(None), "chat-1", {}) is None

--- a/autobot-backend/api/chat_save_owner_test.py
+++ b/autobot-backend/api/chat_save_owner_test.py
@@ -9,63 +9,122 @@
 created through the save endpoint — rather than `POST /chat/sessions` — had no
 `metadata.owner`.
 
-Since #14018 made the file record authoritative, that is not cosmetic: such a
+Since #14018 made the file record authoritative that is not cosmetic: such a
 session reads as *genuinely unowned* every time its 24-hour Redis key lapses, and
-is claimed by whoever visits next. Permanently reclaimable, once per TTL window.
+is claimed by whoever visits next.
 
-The invariant these tests pin: a session with no durable owner gets one; a
-session that already has one never has it overwritten by whoever is saving.
+The write **mirrors the validator's decision** instead of making its own. That
+distinction is the whole safety argument, and the tests that matter most are the
+ones pinning when it must NOT write: the `enforcement_disabled` and
+`auth_disabled` fast paths authorise without checking any owner, so claiming
+there would let any authenticated caller stamp themselves onto an ownerless
+session — permanently, outliving the eventual switch to enforced.
 """
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from api import chat as chat_api
 
-_ALICE = {"username": "alice", "user_id": "alice-id"}
+_ALICE = {"username": "alice", "user_id": "alice-id", "org_id": "org-1"}
 
 
-def _manager(existing_owner):
-    manager = MagicMock()
-    manager.get_session_owner = AsyncMock(return_value=existing_owner)
-    return manager
+def _ownership(reason, user_data=None):
+    return {"authorized": True, "user_data": user_data if user_data is not None else _ALICE, "reason": reason}
 
 
-class TestANewSessionGetsADurableOwner:
+class TestItWritesOnlyWhenTheValidatorJustClaimed:
     @pytest.mark.asyncio
-    async def test_an_unowned_session_is_given_the_savers_owner_metadata(self):
-        metadata = await chat_api._durable_owner_metadata(_manager(None), "chat-new", _ALICE)
+    async def test_a_legacy_migration_stamps_the_owner(self):
+        """The validator found no owner and granted it — record what happened."""
+        metadata = await chat_api._durable_owner_metadata(MagicMock(), "chat-new", _ownership("legacy_migration"))
 
-        assert metadata == {"owner": "alice", "username": "alice"}
-
-    @pytest.mark.asyncio
-    async def test_both_keys_are_written(self):
-        """`create_session` writes both, and the shared owner lookup falls back to
-        `username` for sessions predating the `owner` field. Writing only one
-        would make this path's sessions look different from every other."""
-        metadata = await chat_api._durable_owner_metadata(_manager(None), "chat-new", _ALICE)
-
-        assert set(metadata) == {"owner", "username"}
-
-
-class TestAnExistingOwnerIsNeverOverwritten:
-    @pytest.mark.asyncio
-    async def test_a_session_that_already_has_an_owner_is_left_alone(self):
-        """Returning metadata here would let any saver rewrite the durable record."""
-        metadata = await chat_api._durable_owner_metadata(_manager("alice"), "chat-1", {"username": "bob"})
-
-        assert metadata is None
+        assert metadata["owner"] == "alice"
+        assert metadata["username"] == "alice"
 
     @pytest.mark.asyncio
-    async def test_an_owner_lookup_failure_writes_nothing(self):
-        """Not being able to tell whether an owner exists is not a licence to claim."""
+    async def test_the_org_hierarchy_is_carried_too(self):
+        """Shared with create_session, so the two paths cannot drift (#684)."""
+        metadata = await chat_api._durable_owner_metadata(MagicMock(), "chat-new", _ownership("legacy_migration"))
+
+        assert metadata["user_id"] == "alice-id"
+        assert metadata["org_id"] == "org-1"
+
+    @pytest.mark.asyncio
+    async def test_an_owner_match_writes_nothing(self):
+        """The session already has an owner; nothing to record."""
+        assert await chat_api._durable_owner_metadata(MagicMock(), "chat-1", _ownership("owner_match")) is None
+
+
+class TestItNeverClaimsOnAnUncheckedFastPath:
+    """The finding that made the first version of this fix harmful.
+
+    `enforcement_disabled` is the DEFAULT today (#14010): `_resolve_fast_paths`
+    returns authorized without consulting any owner. Writing an owner there is a
+    land grab, not a record.
+    """
+
+    @pytest.mark.asyncio
+    async def test_enforcement_disabled_writes_nothing(self):
+        assert await chat_api._durable_owner_metadata(MagicMock(), "chat-1", _ownership("enforcement_disabled")) is None
+
+    @pytest.mark.asyncio
+    async def test_auth_disabled_writes_nothing(self):
+        assert await chat_api._durable_owner_metadata(MagicMock(), "chat-1", _ownership("auth_disabled")) is None
+
+    @pytest.mark.asyncio
+    async def test_log_only_mode_writes_nothing(self):
+        """log_only reports what enforcement *would* do; it decides nothing."""
+        assert await chat_api._durable_owner_metadata(MagicMock(), "chat-1", _ownership("log_only_mode")) is None
+
+    @pytest.mark.asyncio
+    async def test_org_admin_and_shared_access_write_nothing(self):
+        """Both authorise someone who is explicitly NOT the owner."""
+        assert await chat_api._durable_owner_metadata(MagicMock(), "chat-1", _ownership("org_admin")) is None
+        assert await chat_api._durable_owner_metadata(MagicMock(), "chat-1", _ownership("shared_access")) is None
+
+    @pytest.mark.asyncio
+    async def test_a_missing_or_malformed_ownership_result_writes_nothing(self):
+        assert await chat_api._durable_owner_metadata(MagicMock(), "chat-1", None) is None
+        assert await chat_api._durable_owner_metadata(MagicMock(), "chat-1", {}) is None
+        assert await chat_api._durable_owner_metadata(MagicMock(), "chat-1", "not-a-dict") is None
+
+    @pytest.mark.asyncio
+    async def test_a_claim_with_no_username_writes_nothing(self):
+        assert await chat_api._durable_owner_metadata(MagicMock(), "chat-1", _ownership("legacy_migration", {})) is None
+
+
+class TestTheEndpointActuallyPassesIt:
+    """Testing the helper is not testing that anything uses it.
+
+    A previous PR in this series had exactly this mutant survive, and the
+    existing endpoint test only asserts `save_session.called`, never its kwargs.
+    """
+
+    @staticmethod
+    async def _save(ownership):
         manager = MagicMock()
-        manager.get_session_owner = AsyncMock(side_effect=RuntimeError("storage down"))
-
-        assert await chat_api._durable_owner_metadata(manager, "chat-1", _ALICE) is None
+        manager.save_session = AsyncMock(return_value={"session_id": "chat-1"})
+        with patch.object(chat_api, "get_chat_history_manager", MagicMock(return_value=manager)):
+            with patch.object(chat_api, "_merge_chat_messages", AsyncMock(return_value=[])):
+                await chat_api.save_chat_by_id(
+                    chat_id="chat-1",
+                    current_user=_ALICE,
+                    request_data={"data": {"messages": [], "name": "n"}},
+                    request=MagicMock(),
+                    ownership=ownership,
+                )
+        return manager.save_session.call_args.kwargs
 
     @pytest.mark.asyncio
-    async def test_an_anonymous_saver_writes_nothing(self):
-        assert await chat_api._durable_owner_metadata(_manager(None), "chat-1", None) is None
-        assert await chat_api._durable_owner_metadata(_manager(None), "chat-1", {}) is None
+    async def test_the_owner_metadata_reaches_save_session(self):
+        kwargs = await self._save(_ownership("legacy_migration"))
+
+        assert kwargs["metadata"]["owner"] == "alice"
+
+    @pytest.mark.asyncio
+    async def test_nothing_is_written_on_an_unchecked_fast_path(self):
+        kwargs = await self._save(_ownership("enforcement_disabled"))
+
+        assert kwargs["metadata"] is None, "must not stamp an owner the validator never verified"

--- a/autobot-backend/api/chat_sessions.py
+++ b/autobot-backend/api/chat_sessions.py
@@ -49,7 +49,7 @@ from chat_workflow.session_handler import _emit_session_create, _emit_session_de
 from exceptions import get_exceptions_lazy
 
 # CRITICAL SECURITY FIX: Import session ownership validation
-from security.session_ownership import validate_session_ownership
+from security.session_ownership import build_owner_metadata, validate_session_ownership
 
 # Issue #6559: Wire audit_record into session create/delete/export endpoints
 from services.audit.audit import AuditAction, audit_record  # GH#8290 Phase 2
@@ -812,16 +812,10 @@ async def create_session(session_data: SessionCreate, request: Request):
     session_title = session_data.title or DEFAULT_SESSION_TITLE
 
     metadata = session_data.metadata or {}
+    # #14020: one builder for every path that stamps ownership (#684 org/team
+    # hierarchy included), so create and backfill cannot drift apart.
+    metadata.update(build_owner_metadata(user_data, session_data.team_id))
     if user_data and user_data.get("username"):
-        metadata["owner"] = user_data["username"]
-        metadata["username"] = user_data["username"]  # For backward compatibility
-        # Issue #684: Capture org/team hierarchy in session metadata
-        if user_data.get("user_id"):
-            metadata["user_id"] = user_data["user_id"]
-        if user_data.get("org_id"):
-            metadata["org_id"] = user_data["org_id"]
-        if session_data.team_id:
-            metadata["team_id"] = session_data.team_id
         logger.info(
             "Session %s created with owner: %s (org: %s)",
             session_id,

--- a/autobot-backend/security/session_ownership.py
+++ b/autobot-backend/security/session_ownership.py
@@ -26,6 +26,34 @@ from autobot_shared.ssot_constants import TTL_30_DAYS
 logger = get_logger(__name__)
 
 
+def build_owner_metadata(user_data: "dict | None", team_id: str | None = None) -> dict:
+    """The durable owner record written into a session file (#14020).
+
+    One builder for every path that stamps ownership, so a session created by
+    ``POST /chat/sessions`` and one backfilled by the save endpoint carry the same
+    fields. They previously drifted: the save path wrote only ``owner``/``username``
+    and dropped the org/team hierarchy #684 records.
+
+    ``username`` is written alongside ``owner`` because ``get_session_owner``
+    resolves ``owner or username`` — sessions predating the ``owner`` field carry
+    only the latter, and dropping it would make older readers blind to new writes.
+
+    Returns {} when there is no authenticated username, so callers can pass the
+    result straight through without a truthiness dance.
+    """
+    username = (user_data or {}).get("username")
+    if not username:
+        return {}
+    metadata = {"owner": username, "username": username}
+    if user_data.get("user_id"):
+        metadata["user_id"] = user_data["user_id"]
+    if user_data.get("org_id"):
+        metadata["org_id"] = user_data["org_id"]
+    if team_id:
+        metadata["team_id"] = team_id
+    return metadata
+
+
 class SessionOwnershipValidator:
     """
     Validates and enforces session ownership for conversation access control.


### PR DESCRIPTION
Closes #14020

## Thinking Path

`save_chat_by_id` called `save_session` with no `metadata`, and `_build_session_chat_data` writes the key only `if metadata:`. So a session created through the save endpoint — rather than `POST /chat/sessions` — had no `metadata.owner`.

Before #14018 that was cosmetic. Now the file record is **authoritative**, so such a session reads as *genuinely unowned* every time its 24-hour Redis key lapses, and is claimed by whoever visits next. Reclaimable once per TTL window, indefinitely.

### Decision: backfill, not reject

The issue offered two shapes — refuse a save for an unknown session id (creation goes only through the canonical endpoint), or write the owner when the file is new.

I chose the second. Rejecting removes an undocumented creation path and is the smaller long-term surface, but it is a behaviour change with unknown blast radius — CLI callers, integrations and tests may rely on save-creates. Writing the owner restores the invariant without removing anything, and the caller has already passed `Depends(validate_chat_ownership)` by that point, so when there is no durable owner they are already the recognised owner and the record is simply catching up.

Two guards make that safe rather than presumptuous:

- an **existing** durable owner is never overwritten by whoever happens to be saving
- a **lookup failure** writes nothing — not being able to tell whether an owner exists is not a licence to claim one

Both `owner` and `username` are written, matching `create_session`, so the shared owner lookup's `owner or username` fallback keeps working for this path's sessions too.

## What Changed

- `api/chat.py` — `_durable_owner_metadata` helper; `save_chat_by_id` passes its result as `save_session(..., metadata=...)`.

## Verification

```
$ pytest api/chat_save_owner_test.py api/chat_direct_ownership_test.py api/chat_test.py -q
11 passed
```

Mutation battery, with no-op detection:

| mutation | result |
|---|---|
| metadata never written (the defect) | KILLED (2) |
| existing owner overwritten by the saver | KILLED (2) |
| lookup failure claims anyway | KILLED (1) |
| only the `owner` key written (loses the `username` fallback) | KILLED (2) |

Lint: black, isort, flake8 clean.

## Audit of the other session-creation paths (AC 3)

Swept every non-test caller of `ChatHistoryManager.save_session`:

| caller | verdict |
|---|---|
| `chat_history/session.py` `create_session` | passes owner metadata — the canonical path |
| `chat_history/session.py` `_process_loaded_messages` | operates on an already-loaded session |
| `chat_history/messages.py` (4 call sites) | load-then-save on existing sessions |
| `chat_history/session_reply_backfill.py` | repairs an existing session |
| `api/chat.py` `save_chat_by_id` | **the gap — fixed here** |
| `services/conversation_export.py` `import_conversation` | **a second gap — filed, see below** |

(The `autoresearch` `save_session` hits are a different method on a different object.)

### Filed, not fixed here: #14022

`import_conversation` creates a session from a user-supplied export document and calls `save_session` with no metadata, so imported sessions have no durable owner — the same defect on a different path. It also takes **no user identity at all** (`chat_history_manager, document, on_conflict`), so fixing it means threading the importing user through, not adding a line.

While reading it I also found `on_conflict="replace"` **overwrites an existing session** with no ownership check — the same shape as #14012's create collision, on the import path. That is an authorization question rather than a missing-metadata one, and it is in that issue too.

## Model Used

Claude Opus 5