### PR TITLE
docs(research): agent-harness guard, context-sizing and ingest-governance audit (#14027)

### DIFF
--- a/.session/HANDOFF-issue-14027.md
+++ b/.session/HANDOFF-issue-14027.md
@@ -1,6 +1,7 @@
 # Handoff: issue-14027
 
 status: complete
+reviewed: code-reviewer pass ISSUES FOUND -> all corrections applied in `aff59c6da`
 pr: #14032
 base_at_push: d018373e11862d5503cffaed9e8cbf307fda7010
 gates: wiring=N/A duplication=N/A tests=N/A (documentation-only change, no code paths touched)
@@ -11,15 +12,15 @@ worktree: .worktrees/issue-14027  (locked; safe to remove after #14032 merges)
 ## What this branch is
 
 Documentation only: `docs/research/agent-harness-guard-and-context-audit.md`
-plus its `_index.md` row. It is the research artifact behind issues
-#14027-#14031, moved out of scratch per the "filing an umbrella or design doc is
+plus its `_index.md` row. It is the research artifact behind issues #14027
+through #14031, moved out of scratch per the "filing an umbrella or design doc is
 the trigger" rule.
 
 **The branch name is misleading — this branch does NOT implement #14027.** It is
 named `issue-14027` after the first issue the audit produced. The actual code
 fix for #14027 is a different session's work; see below.
 
-## Do not duplicate — #14027 is already being implemented elsewhere
+## Do not duplicate — the code fix for #14027 landed elsewhere
 
 A concurrent session owns the code fix:
 
@@ -28,7 +29,8 @@ A concurrent session owns the code fix:
 - branch `issue-14027-fix`, commits `76e9be082` (normalize input before
   dangerous-pattern matching) and `5afdb3d1b` (require the OSC terminator so it
   cannot swallow the command)
-- **PR #14038**, open
+- **PR #14038 — MERGED** into `Dev_new_gui` as `5d20497c0`, and auto-merged into this branch
+  (`e1fd57865`). #14027's code fix has landed; only the docs remain here.
 
 That second commit is worth reading before touching this area: an OSC-strip
 without a required terminator will consume the rest of the command, which turns
@@ -40,12 +42,12 @@ execute.
 ## Issues filed from this audit
 
 | Issue | Gap | Wave | State |
-|---|---|---|---|
-| #14027 | `security/command_patterns.py` matches un-normalized input | 1 | in progress (PR #14038, other session) |
-| #14028 | Gateway ingest has no bot-self filter, dedup, or recursion guard | 1 | open, unstarted |
-| #14029 | Context windows static with a 4096 fallback; no probe, no learn-from-rejection | 1 | open, unstarted |
+| --- | --- | --- | --- |
+| #14027 | `security/command_patterns.py` matches un-normalized input | 1 | **DONE** — PR #14038 merged as `5d20497c0` (other session) |
+| #14028 | Gateway ingest has no bot-self filter, dedup, or recursion guard — **two** disjoint adapter stacks, both ungoverned | 1 | open, unstarted — **fix location corrected**, see issue comment |
+| #14029 | No learned context-window tier, and **four** static sources can disagree (incl. the `num_ctx` actually sent) | 1 | open, unstarted — **scope enlarged**, see issue comment |
 | #14030 | Distillation is per-conversation; recurrence invisible | 2 | open, **gated** on `AUTOBOT_SKILL_DISTILLATION_ENABLED` being true and producing accepted proposals |
-| #14031 | Pre-action verifier + belief state run nowhere | Wave B of #13587 | open, unstarted |
+| #14031 | Verifier enabled-by-default inside the dormant loop; #13587 miscounted it. Dormancy itself already known via **#11221 (CLOSED)** | Wave B of #13587 | open, unstarted — **scope narrowed**, see issue comment |
 
 Cross-cutting notes posted, not filed as issues:
 

--- a/.session/HANDOFF-issue-14027.md
+++ b/.session/HANDOFF-issue-14027.md
@@ -1,0 +1,75 @@
+# Handoff: issue-14027
+
+status: complete
+pr: #14032
+base_at_push: d018373e11862d5503cffaed9e8cbf307fda7010
+gates: wiring=N/A duplication=N/A tests=N/A (documentation-only change, no code paths touched)
+needs_rebase_before_merge: no
+remaining:
+worktree: .worktrees/issue-14027  (locked; safe to remove after #14032 merges)
+
+## What this branch is
+
+Documentation only: `docs/research/agent-harness-guard-and-context-audit.md`
+plus its `_index.md` row. It is the research artifact behind issues
+#14027-#14031, moved out of scratch per the "filing an umbrella or design doc is
+the trigger" rule.
+
+**The branch name is misleading — this branch does NOT implement #14027.** It is
+named `issue-14027` after the first issue the audit produced. The actual code
+fix for #14027 is a different session's work; see below.
+
+## Do not duplicate — #14027 is already being implemented elsewhere
+
+A concurrent session owns the code fix:
+
+- worktree `.worktrees/issue-14027-fix` (locked, reason "in use: #14027") — **not
+  mine, not swept, left untouched**
+- branch `issue-14027-fix`, commits `76e9be082` (normalize input before
+  dangerous-pattern matching) and `5afdb3d1b` (require the OSC terminator so it
+  cannot swallow the command)
+- **PR #14038**, open
+
+That second commit is worth reading before touching this area: an OSC-strip
+without a required terminator will consume the rest of the command, which turns
+a hardening fix into a bypass. Whoever reviews #14038 should verify the
+both-directions assertion demanded by #14027's acceptance criteria — the bypass
+case must now fail **and** a legitimate fullwidth-character filename must still
+execute.
+
+## Issues filed from this audit
+
+| Issue | Gap | Wave | State |
+|---|---|---|---|
+| #14027 | `security/command_patterns.py` matches un-normalized input | 1 | in progress (PR #14038, other session) |
+| #14028 | Gateway ingest has no bot-self filter, dedup, or recursion guard | 1 | open, unstarted |
+| #14029 | Context windows static with a 4096 fallback; no probe, no learn-from-rejection | 1 | open, unstarted |
+| #14030 | Distillation is per-conversation; recurrence invisible | 2 | open, **gated** on `AUTOBOT_SKILL_DISTILLATION_ENABLED` being true and producing accepted proposals |
+| #14031 | Pre-action verifier + belief state run nowhere | Wave B of #13587 | open, unstarted |
+
+Cross-cutting notes posted, not filed as issues:
+
+- **#13587** — premise correction: its "Already covered" list cites
+  `agent_loop/loop.py` for the pre-action verifier and durable checkpointing, but
+  `AgentLoop` has no production caller.
+- **#13250** — two-tier safety floor design input, deliberately a comment so it
+  does not become a fifth approval mechanism. #14027 is its prerequisite.
+- **#13919 / #13997** — cross-linked; same root cause as #14031. One extraction
+  pass over `agent_loop/` beats three separate wirings.
+
+## Next session — suggested order
+
+1. Review and land **PR #14038** (#14027), applying the both-directions check above.
+2. **#14031** together with #13919 and #13997 — one extraction pass over
+   `agent_loop/`, following the #13590 pattern: pure decision function in
+   `autobot_shared/`, called from the live seam, plus a wiring assertion.
+3. **#14028**, then **#14029** — both wave 1, independent of each other.
+4. Leave **#14030** parked until its gate opens.
+
+## Pre-existing condition, not introduced here
+
+`grep -rn "^<<<<<<< "` across the tree hits
+`docs/external_apps/system-prompts-and-models-of-ai-tools-main/.../Cline/Prompt.txt`.
+Those are example diff markers inside vendored prompt text, committed in #645 —
+not conflict residue, and not in this branch's diff (`git diff origin/Dev_new_gui
+--name-only` returns exactly the two docs files).

--- a/docs/research/_index.md
+++ b/docs/research/_index.md
@@ -21,6 +21,7 @@ Research reports covering hardware integration, system conflicts, and technology
 | [[connector-credential-egress-audit]] | Connector, credential and egress layer audit — 2 live OAuth bugs, 2 fail-open guards, secrets-manager bypass (#13623, #13643) |
 | [[tiered-context-ab-13689]] | Tiered L0–L4 context stack — #5066 A/B result, **corrected**: measured against test doubles, 3 of 5 layers cannot render, flag reverted to off (#13689, #13742, #13866) |
 | [[layered-agent-memory-and-context-offload]] | Layered agent memory + symbolic context offload — tiered L0–L4 stack built but never ran, 2 of 5 layers structurally disconnected, memory plane untenanted (#13685) |
+| [[agent-harness-guard-and-context-audit]] | Agent harness comparison — our loop guards are stronger, but guard input is un-normalized, context windows are a static 4096 fallback, ingest has no bot-self filter, and `AgentLoop` has no production caller (#14027–#14031) |
 
 ## Related Sections
 

--- a/docs/research/agent-harness-guard-and-context-audit.md
+++ b/docs/research/agent-harness-guard-and-context-audit.md
@@ -1,0 +1,195 @@
+---
+tags:
+  - research
+  - agents
+  - security
+aliases:
+  - Agent Harness Guard and Context Audit
+---
+
+# Agent harness comparison — guards, context sizing, and ingest governance
+
+Comparative audit of AutoBot's agent execution seam against an external
+self-hosted multi-agent harness (JVM stack, single-deployment, multi-channel).
+The source is not adoptable as code — wrong language, wrong framework, and a
+release cadence still stabilising its streaming path — so only *designs* were
+considered. Every item below was checked against AutoBot's own code before being
+filed; capabilities AutoBot already has are recorded in "Already covered" and were
+deliberately **not** filed.
+
+**The through-line:** AutoBot's loop-guard machinery is, where it runs, better
+than the source's. The gaps are at the edges the loop does not own — the
+*normalization* of what a guard matches on, the *sizing* of the context window,
+the *ingest* seam ahead of the router, and the fact that a whole package of built
+guards has no production caller.
+
+Filed: #14027, #14028, #14029, #14030, #14031. Premise correction on #13587,
+design input on #13250.
+
+---
+
+## Already covered — audited, confirmed present, NOT filed
+
+Each verified against the code on `Dev_new_gui`, 2026-08-11.
+
+| Capability | Where it lives | Note |
+|---|---|---|
+| Identical-call loop detection | `chat_workflow/graph.py:169` `_detect_tool_call_loop`; warn via `_inject_mid_conversation_warning` (`:348`), abort at `_LOOP_ABORT_THRESHOLD` (`:56`, `:1121`) | warn-then-halt already graduated |
+| Repetition guard | `autobot_shared/repetition_guard.py`, wired at `chat_workflow/tool_handler.py:3163` | **stronger than the source** — see below |
+| Stagnation / novelty guard | `stagnation_halt_reason`, same seam | **no counterpart in the source** |
+| Orphaned tool-pair sanitizing | `chat_history/context_overflow.py:163`, applied `:248` | drops orphaned tool messages and dangling `tool_calls` |
+| Fact forcing | `chat_workflow/tool_handler.py:3096` | blocks the first edit to an uninvestigated file |
+| Config protection | `chat_workflow/tool_handler.py:3061` | blocks writes weakening linter/formatter gates |
+| Provider failover | `circuit_breaker.py`, `llm_shared/model_fallback_coordinator`, `provider_registry.health_check_all` | |
+| Execution leases | `autobot_shared/leader_lease.py` (Redis SETNX + TTL) | used by the distillation and connector schedulers |
+| Lifecycle hook bus | `middleware/hooks.py` — 25 hook points, all with live call sites in `chat_workflow/llm_handler.py` and `session_handler.py` | **more than the source's 7 event types** |
+| Multi-section context allocation | `context_window_manager.py` `allocate_sections` (#13640) | **no counterpart in the source** |
+| Feature flags | `api/feature_flags.py` | |
+
+### Where our design is better, and why
+
+**Repetition keyed on `(call fingerprint, result hash)`.** The source keys on
+`toolName + sha256(args)` alone, and therefore needs a hard-coded read-only tool
+allowlist (`read_file`, `web_search`, …) to avoid halting legitimate repeated
+calls. Our pair key makes that exemption *structural*: the count resets the moment
+the result moves, so a polling loop survives any threshold with no allowlist to
+maintain. Their list will drift as tools are added; ours cannot.
+
+**The stagnation guard has no counterpart at all.** The source catches one call
+re-issued. It has nothing for a run of *different* calls whose results carry no
+new information — a distinct failure mode that `stagnation_halt_reason` scores by
+novel-token ratio over a window with an accumulating vocabulary.
+
+**One tunable posture.** `AUTOBOT_GUARD_PROFILE` resolves every guard's thresholds
+from a single profile. The source hard-codes `WARN_AFTER`/`HALT_AFTER` constants
+per detector.
+
+**Architecture-family-aware compression bypass** (#7351) — non-transformer
+families (SSM, linear-attention, hybrid) skip the 4K/8K trigger. No equivalent.
+
+---
+
+## Filed gaps
+
+### #14027 — guard patterns match un-normalized input *(security, wave 1)*
+
+`security/command_patterns.py` is the single source of truth for dangerous-command
+detection, and it matches raw text: `is_dangerous_substring` (`:394`) only
+lowercases; `check_dangerous_patterns` (`:411`) searches the unmodified string. A
+homoglyph (fullwidth `m`), an ANSI-wrapped command, or an embedded NUL bypasses
+every pattern.
+
+`strip_ansi_codes` exists (`utils/command_utils.py:38`) but is applied to command
+**output**, never to the command **before** matching. Grep for
+`NFKC|unicodedata.normalize` finds nothing on this path.
+
+Reachable via three live paths that carry attacker-influenced text into a loop
+with shell tools: the KB web crawler, document ingest, and the browser agent.
+
+Fix: normalize (ANSI strip → C0 strip → NFKC → whitespace collapse) **for matching
+only**, never mutating the executed string.
+
+### #14028 — inbound ingest has no bot-self filter, dedup, or recursion guard *(wave 1)*
+
+`services/gateway/` normalizes inbound payloads from 10 platform adapters
+(`gateway.py:263` `receive_message`, `adapters/base_adapter.py:23`) and routes them
+to agents via `message_router.py`. Grep across the whole package for
+`bot_id|is_bot|self_.*message|dedup|seen_.*id|recursion` returns **only rate-limit
+hits**.
+
+Rate limiting bounds the *volume* of a feedback loop; it does not prevent one and
+does not deduplicate a redelivered message. Open failure modes: self-reply loops
+(the platform echoes our own post back as a user turn), duplicate delivery on
+webhook retry producing two agent turns and double tool side effects, and
+unbounded agent-to-agent recursion. Nothing errors and nothing alerts — the loop
+quietly bills tokens.
+
+### #14029 — context windows are a static catalog with a 4096 fallback *(wave 1)*
+
+`context_window_manager.py` resolves from `config/context_windows.yaml` (`:117`)
+with hard-coded fallbacks of `4096` (`:169`, `:178`, `:577`, `:584`) and `8192`
+(`:519`). No probe, no parser: grep for
+`max_model_len|maximum context length|num_ctx|context_length_exceeded` returns
+nothing; the only Ollama call is a liveness check (`startup_validator.py:311`).
+
+Both directions fail silently — a 32k model catalogued as 4k is compressed for no
+reason (quality loss, never an error), and one catalogued too high returns a 400
+every turn until the YAML is hand-edited. This hits every local and self-hosted
+model, which is the deployment shape we ship.
+
+The transferable trick: **the serving stack states its own limit in the text it
+rejects with**. Parse it once and every later turn is correct. Two details make
+the parser correct rather than merely present — anchor each pattern on the *limit
+keyword* so `"requested 50000 … maximum … 32768"` yields 32768 and not 50000, and
+band the result (~512 … ~10M) so an implausible parse falls through instead of
+raising the assumed window into a hard failure.
+
+### #14030 — skill distillation cannot see recurrence *(wave 2, gated)*
+
+`services/skill_management/skill_extractor.py:86` takes a single conversation;
+the scheduler feeds them one at a time. Within one window, a habitual request and
+a one-off task are indistinguishable, and the reviewer is *right* to decline
+writing a skill for a one-off — so "I ask this every week" can never reach it. No
+prompt change recovers the signal; it needs a cross-session pass keyed on distinct
+conversations **and distinct days**.
+
+The transferable discipline is the second half: **recompute each sweep from
+scratch over the lookback window instead of incrementing counters.** Re-runs
+become idempotent and an abandoned routine decays out on its own, with no expiry
+job.
+
+**Gated, deliberately.** `AUTOBOT_SKILL_DISTILLATION_ENABLED` defaults to `False`
+(`skill_distillation_scheduler.py:44`). Building a recurrence miner for a pipeline
+nobody has turned on adds maintained-but-dormant surface — the #13685 shape.
+
+### #14031 — pre-action verifier and belief state run nowhere *(child of #13587)*
+
+`grep -rn "from agent_loop.loop import\|AgentLoop("` returns **only test files**.
+`AgentLoop` has no production caller; the live path is `chat_workflow/graph.py` +
+`chat_workflow/tool_handler.py`. So `PreActionVerifier` (sole caller
+`agent_loop/loop.py:191-192,1668`, `pre_action_verifier_enabled` defaulting to
+**True**) and `BeliefState` (sole caller `agent_loop/loop.py:28,186,…`,
+`belief_state_enabled` defaulting to **False**) execute on no request.
+
+This corrects #13587's own "Already covered" list, which cited
+`agent_loop/loop.py` for both the pre-action verifier and durable run
+checkpointing. The capabilities are real and well built; they are not *covered*,
+because they never run. A guard whose enable flag defaults to `True` inside a dead
+module is exactly how this survives an audit.
+
+#13590 (CLOSED) is the template for the fix, and it is worth stating as a rule:
+**do not wire the dead entry point in — extract the decision logic into
+`autobot_shared/` as a dependency-free pure function, call it from the live seam,
+and add a wiring assertion so the next refactor cannot silently un-wire it.**
+`repetition_guard` and `fact_forcing` both took that route. #13919 and #13997 are
+the same extraction over the rest of the package; one pass beats three.
+
+---
+
+## Design input, not filed as an issue
+
+**Two-tier safety floor** → posted on #13250. A frozen, startup-built pattern floor
+returning `PASS` / `FORCE_HUMAN` / `HARD_BLOCK`, evaluated *before* any grant
+lookup. Today `is_dangerous_command` computes severity but uses it only to pick
+the message wording — there is no tier meaning "no approval path may execute
+this". Filed as a comment rather than an issue **on purpose**: as a standalone
+addition it becomes a fifth approval mechanism, which is the problem #13250
+exists to remove. #14027 is a practical prerequisite — a floor matching
+un-normalized input inherits the same bypass.
+
+## Deliberately NOT proposed — do not re-file
+
+- **Progressive tool disclosure** — already evaluated and rejected at our scale.
+- **The source's contradiction detector** — string-overlap only, self-labelled
+  EXPERIMENTAL and shipped default-off. Our `ContradictionRecord` in
+  `agent_loop/belief_state.py` is a better starting point.
+- **Its IM-channel set and publishing pipeline** — market-shaped, no fit.
+- **Anything requiring its JVM framework stack.**
+
+## Method note
+
+Greps excluded `.worktrees/`, `.claude/`, `venv/`, `node_modules/`. Two items
+listed as unverified in the working draft were closed out before filing: the hook
+bus was confirmed fully invoked (25 declared, all with live call sites — so no gap
+exists there), and the inbound trigger path was confirmed to exist, which is what
+turned #14028 from a question into a finding.

--- a/docs/research/agent-harness-guard-and-context-audit.md
+++ b/docs/research/agent-harness-guard-and-context-audit.md
@@ -1,195 +1,267 @@
----
-tags:
-  - research
-  - agents
-  - security
-aliases:
-  - Agent Harness Guard and Context Audit
----
-
 # Agent harness comparison — guards, context sizing, and ingest governance
 
-Comparative audit of AutoBot's agent execution seam against an external
-self-hosted multi-agent harness (JVM stack, single-deployment, multi-channel).
-The source is not adoptable as code — wrong language, wrong framework, and a
-release cadence still stabilising its streaming path — so only *designs* were
-considered. Every item below was checked against AutoBot's own code before being
-filed; capabilities AutoBot already has are recorded in "Already covered" and were
-deliberately **not** filed.
-
-**The through-line:** AutoBot's loop-guard machinery is, where it runs, better
-than the source's. The gaps are at the edges the loop does not own — the
-*normalization* of what a guard matches on, the *sizing* of the context window,
-the *ingest* seam ahead of the router, and the fact that a whole package of built
-guards has no production caller.
-
-Filed: #14027, #14028, #14029, #14030, #14031. Premise correction on #13587,
+**Date:** 2026-08-11
+**Source:** an external self-hosted multi-agent harness (JVM stack, single-deployment,
+multi-channel, permissive licence, a few months old and still stabilising its streaming
+path). Repo name, vendor and locating metadata are withheld per the no-external-names rule
+for committed docs; the URL was supplied in-session. Star counts and creation dates are
+omitted deliberately — together they identify the repository as surely as its name does.
+**Scope:** `chat_workflow/`, `agent_loop/`, `autobot_shared/repetition_guard.py`,
+`security/command_patterns.py`, `context_window_manager.py`, `services/gateway/`,
+`services/skill_management/`, `middleware/hooks.py`.
+**Method:** the source is not adoptable as code — wrong language, wrong framework, wrong
+stability profile — so only *designs* were considered. Every candidate was checked against
+our own code before being filed; capabilities we already have are recorded in
+"Already covered" and were deliberately **not** filed. All paths below are repo-relative
+from the root, and all line numbers are against `Dev_new_gui` at `d018373e1`.
+**Filed as:** #14027, #14028, #14029, #14030, #14031. Premise correction on #13587,
 design input on #13250.
+
+> **Corrected 2026-08-11 after review.** The first version of this doc carried seven
+> off-by-a-few line citations and three grep claims that did not return what they said they
+> returned — including one that asserted an *empty* result never obtained. All five findings
+> survived correction, and two of them (#14028, #14029) got **stronger** once the evidence
+> was stated accurately. The corrections are kept inline rather than rewritten away, because
+> a doc that will be cited as evidence of what was audited has to show where its evidence
+> was wrong. See "Corrections" at the end.
+
+**The through-line:** AutoBot's loop-guard machinery is, where it runs, better than the
+source's. The gaps are at the edges the loop does not own — the *normalization* of what a
+guard matches on, the *sizing* of the context window, the *ingest* seam ahead of the router,
+and a package of built guards with no production caller.
 
 ---
 
 ## Already covered — audited, confirmed present, NOT filed
 
-Each verified against the code on `Dev_new_gui`, 2026-08-11.
-
 | Capability | Where it lives | Note |
-|---|---|---|
-| Identical-call loop detection | `chat_workflow/graph.py:169` `_detect_tool_call_loop`; warn via `_inject_mid_conversation_warning` (`:348`), abort at `_LOOP_ABORT_THRESHOLD` (`:56`, `:1121`) | warn-then-halt already graduated |
-| Repetition guard | `autobot_shared/repetition_guard.py`, wired at `chat_workflow/tool_handler.py:3163` | **stronger than the source** — see below |
+| --- | --- | --- |
+| Identical-call loop detection | `autobot-backend/chat_workflow/graph.py:169` `_detect_tool_call_loop`; warn via `_inject_mid_conversation_warning` (`:348`); abort at `_LOOP_ABORT_THRESHOLD` (`:56`, checked `:1127`, also `:1157`, `:1504`) | warn-then-halt already graduated |
+| Repetition guard | `autobot_shared/repetition_guard.py`, wired at `autobot-backend/chat_workflow/tool_handler.py:3137` `_enforce_repetition` (import `:3155`, call `:3166`) | **stronger than the source** — see below |
 | Stagnation / novelty guard | `stagnation_halt_reason`, same seam | **no counterpart in the source** |
-| Orphaned tool-pair sanitizing | `chat_history/context_overflow.py:163`, applied `:248` | drops orphaned tool messages and dangling `tool_calls` |
-| Fact forcing | `chat_workflow/tool_handler.py:3096` | blocks the first edit to an uninvestigated file |
-| Config protection | `chat_workflow/tool_handler.py:3061` | blocks writes weakening linter/formatter gates |
-| Provider failover | `circuit_breaker.py`, `llm_shared/model_fallback_coordinator`, `provider_registry.health_check_all` | |
+| Orphaned tool-pair sanitizing | `autobot-backend/chat_history/context_overflow.py:164`, applied `:251` | drops orphaned tool messages and dangling `tool_calls` |
+| Fact forcing | `autobot-backend/chat_workflow/tool_handler.py:3096` | blocks the first edit to an uninvestigated file |
+| Config protection | `autobot-backend/chat_workflow/tool_handler.py:3061` | blocks writes weakening linter/formatter gates |
+| Provider failover | `autobot-backend/circuit_breaker.py`, `llm_shared/model_fallback_coordinator.py`, `llm_shared/provider_registry.py:204` `health_check_all` | |
 | Execution leases | `autobot_shared/leader_lease.py` (Redis SETNX + TTL) | used by the distillation and connector schedulers |
-| Lifecycle hook bus | `middleware/hooks.py` — 25 hook points, all with live call sites in `chat_workflow/llm_handler.py` and `session_handler.py` | **more than the source's 7 event types** |
-| Multi-section context allocation | `context_window_manager.py` `allocate_sections` (#13640) | **no counterpart in the source** |
-| Feature flags | `api/feature_flags.py` | |
+| Lifecycle hook bus | `autobot-backend/middleware/hooks.py:15` — 25 hook points, **all 25** with live call sites (21 in `chat_workflow/llm_handler.py`, the rest in `chat_workflow/session_handler.py`) | **more than the source's 7 event types** |
+| Multi-section context allocation | `autobot-backend/context_window_manager.py:279` `allocate_sections` (#13640) | **no counterpart in the source** |
+| Feature flags | `autobot-backend/api/feature_flags.py` | |
 
 ### Where our design is better, and why
 
 **Repetition keyed on `(call fingerprint, result hash)`.** The source keys on
-`toolName + sha256(args)` alone, and therefore needs a hard-coded read-only tool
-allowlist (`read_file`, `web_search`, …) to avoid halting legitimate repeated
-calls. Our pair key makes that exemption *structural*: the count resets the moment
-the result moves, so a polling loop survives any threshold with no allowlist to
-maintain. Their list will drift as tools are added; ours cannot.
+`toolName + sha256(args)` alone, and therefore needs a hard-coded read-only tool allowlist
+(`read_file`, `web_search`, …) to avoid halting legitimate repeated calls. Our pair key makes
+that exemption *structural*: the count resets the moment the result moves, so a polling loop
+survives any threshold with no allowlist to maintain. Their list will drift as tools are
+added; ours cannot.
 
-**The stagnation guard has no counterpart at all.** The source catches one call
-re-issued. It has nothing for a run of *different* calls whose results carry no
-new information — a distinct failure mode that `stagnation_halt_reason` scores by
-novel-token ratio over a window with an accumulating vocabulary.
+**The stagnation guard has no counterpart at all.** The source catches one call re-issued. It
+has nothing for a run of *different* calls whose results carry no new information — a distinct
+failure mode that `stagnation_halt_reason` scores by novel-token ratio over a window with an
+accumulating vocabulary.
 
-**One tunable posture.** `AUTOBOT_GUARD_PROFILE` resolves every guard's thresholds
-from a single profile. The source hard-codes `WARN_AFTER`/`HALT_AFTER` constants
-per detector.
+**One tunable posture.** `AUTOBOT_GUARD_PROFILE` resolves every guard's thresholds from a
+single profile. The source hard-codes `WARN_AFTER`/`HALT_AFTER` constants per detector.
 
-**Architecture-family-aware compression bypass** (#7351) — non-transformer
-families (SSM, linear-attention, hybrid) skip the 4K/8K trigger. No equivalent.
+**Architecture-family-aware compression bypass** (#7351) — non-transformer families (SSM,
+linear-attention, hybrid) skip the 4K/8K trigger. No equivalent.
 
 ---
 
 ## Filed gaps
 
-### #14027 — guard patterns match un-normalized input *(security, wave 1)*
+### Gap 1 · #14027 — guard patterns match un-normalized input *(security, wave 1)*
 
-`security/command_patterns.py` is the single source of truth for dangerous-command
-detection, and it matches raw text: `is_dangerous_substring` (`:394`) only
-lowercases; `check_dangerous_patterns` (`:411`) searches the unmodified string. A
-homoglyph (fullwidth `m`), an ANSI-wrapped command, or an embedded NUL bypasses
-every pattern.
+`autobot-backend/security/command_patterns.py` is the single source of truth for
+dangerous-command detection, and it matches raw text: `is_dangerous_substring` (`:394`) only
+lowercases; `check_dangerous_patterns` (`:411`) searches the unmodified string;
+`is_dangerous_command` (`:430`) composes the two. A homoglyph (fullwidth `m`), an
+ANSI-wrapped command, or an embedded NUL bypasses every pattern.
 
-`strip_ansi_codes` exists (`utils/command_utils.py:38`) but is applied to command
-**output**, never to the command **before** matching. Grep for
-`NFKC|unicodedata.normalize` finds nothing on this path.
+`strip_ansi_codes` exists (defined `autobot-backend/utils/encoding_utils.py:199`, re-exported
+`utils/command_utils.py:38`) but is applied to command **output**, never to the command
+**before** matching. Grep for `NFKC|unicodedata.normalize` returns two repo-wide hits, neither
+on this path (`auth_rbac_admin_guard_test.py:109`; `knowledge/adapters/okf_adapter.py:148`,
+which is NFKD).
 
-Reachable via three live paths that carry attacker-influenced text into a loop
-with shell tools: the KB web crawler, document ingest, and the browser agent.
+Reachable via three live paths that carry attacker-influenced text into a loop with shell
+tools: the KB web crawler, document ingest, and the browser agent.
 
-Fix: normalize (ANSI strip → C0 strip → NFKC → whitespace collapse) **for matching
-only**, never mutating the executed string.
+Fix: normalize (ANSI strip → C0 strip → NFKC → whitespace collapse) **for matching only**,
+never mutating the executed string.
 
-### #14028 — inbound ingest has no bot-self filter, dedup, or recursion guard *(wave 1)*
+### Gap 2 · #14028 — inbound ingest has no bot-self filter, dedup, or recursion guard *(wave 1)*
 
-`services/gateway/` normalizes inbound payloads from 10 platform adapters
-(`gateway.py:263` `receive_message`, `adapters/base_adapter.py:23`) and routes them
-to agents via `message_router.py`. Grep across the whole package for
-`bot_id|is_bot|self_.*message|dedup|seen_.*id|recursion` returns **only rate-limit
-hits**.
+**`services/gateway/` contains two disjoint adapter stacks**, and the finding applies to both:
 
-Rate limiting bounds the *volume* of a feedback loop; it does not prevent one and
-does not deduplicate a redelivered message. Open failure modes: self-reply loops
-(the platform echoes our own post back as a user turn), duplicate delivery on
-webhook retry producing two agent turns and double tool side effects, and
-unbounded agent-to-agent recursion. Nothing errors and nothing alerts — the loop
-quietly bills tokens.
+| Stack | Entry point | Routes via |
+| --- | --- | --- |
+| `channel_adapters/` (`base.py`, `websocket_adapter.py`) | `Gateway.receive_message` (`gateway.py:263`), reading `self._channel_adapters` (`:73`) | `message_router.py` (`gateway.py:326`) — the only path that reaches it |
+| `adapters/` — **9** platform adapters (web, slack, discord, whatsapp, teams, telegram, signal, matrix, imessage; `gateway_manager.py:67-75`) | `GatewayManager.normalize_message` (`:99`) | its **own** `route_message` (`:163`), which never touches `message_router.py`. Live callers: `api/telegram_bot.py:41`, `api/whatsapp.py:51` |
 
-### #14029 — context windows are a static catalog with a 4096 fallback *(wave 1)*
+`grep -rnE "bot_id|is_bot|self_.*message|dedup|seen_.*id|recursion" autobot-backend/services/gateway/`
+returns **zero hits**. Rate limiting is real but surfaces under different names
+(`gateway.py:285`, `session_manager.py:194`, `config.py:33-34`) — and rate limiting bounds the
+*volume* of a feedback loop without preventing one, and does not deduplicate a redelivered
+message.
 
-`context_window_manager.py` resolves from `config/context_windows.yaml` (`:117`)
-with hard-coded fallbacks of `4096` (`:169`, `:178`, `:577`, `:584`) and `8192`
-(`:519`). No probe, no parser: grep for
-`max_model_len|maximum context length|num_ctx|context_length_exceeded` returns
-nothing; the only Ollama call is a liveness check (`startup_validator.py:311`).
+Open failure modes: self-reply loops (the platform echoes our own post back as a user turn),
+duplicate delivery on webhook retry producing two agent turns and double tool side effects,
+and unbounded agent-to-agent recursion. Nothing errors and nothing alerts — the loop quietly
+bills tokens.
 
-Both directions fail silently — a 32k model catalogued as 4k is compressed for no
-reason (quality loss, never an error), and one catalogued too high returns a 400
-every turn until the YAML is hand-edited. This hits every local and self-hosted
-model, which is the deployment shape we ship.
+**The governance stage belongs on the platform seam** (`gateway_manager.py:99`/`:163`), not on
+`message_router.py` — the 9 platform adapters never reach the latter. Applying it in one place
+per stack is the only way a newly added adapter inherits it.
 
-The transferable trick: **the serving stack states its own limit in the text it
-rejects with**. Parse it once and every later turn is correct. Two details make
-the parser correct rather than merely present — anchor each pattern on the *limit
-keyword* so `"requested 50000 … maximum … 32768"` yields 32768 and not 50000, and
-band the result (~512 … ~10M) so an implausible parse falls through instead of
-raising the assumed window into a hard failure.
+**Spun out of this:** two adapter stacks under one gateway, with two independent routing paths,
+is itself a consolidate-never-fork finding. Recorded here; not separately filed.
 
-### #14030 — skill distillation cannot see recurrence *(wave 2, gated)*
+### Gap 3 · #14029 — context-window sizing has no learned tier, and four static sources can disagree *(wave 1)*
 
-`services/skill_management/skill_extractor.py:86` takes a single conversation;
-the scheduler feeds them one at a time. Within one window, a habitual request and
-a one-off task are indistinguishable, and the reviewer is *right* to decline
-writing a skill for a one-off — so "I ask this every week" can never reach it. No
-prompt change recovers the signal; it needs a cross-session pass keyed on distinct
-conversations **and distinct days**.
+The resolution chain in `autobot-backend/context_window_manager.py:575-584` is
+**YAML → registry → YAML default**, not "YAML → 4096" as first written:
 
-The transferable discipline is the second half: **recompute each sweep from
-scratch over the lookback window instead of incrementing counters.** Re-runs
-become idempotent and an abandoned routine decays out on its own, with no expiry
-job.
+1. `config/context_windows.yaml` (`:117`), returning `context_window_tokens` (`:577`);
+2. `_query_known_context_length` → `llm_shared.model_param_registry` (`:579`), scaled by
+   `_CONTEXT_HEADROOM = 0.85` and capped at `_CONTEXT_HARD_MAX = 200_000` (`:26-27`);
+3. otherwise the YAML `default` model's value, falling back to `4096` (`:584`; also `:169`,
+   `:178`). Separately, `get_compression_threshold` falls back to `8192` (`:545`, `:554`).
+
+**What is genuinely missing is the *learned* tier**, and the real finding is larger than a
+single fallback: **four static sources can each state a context size, and nothing reconciles
+them.** Besides the YAML and the registry —
+
+- a per-model `max_model_len` table in `llm_shared/providers/vllm.py:246-270` (4096/8192
+  literals), plus `self.max_model_len` from config (`:49`, used `:77`, `:157`);
+- the `num_ctx` actually sent per request — `llm_shared/providers/ollama.py:120` from
+  `ModelConfig.DEFAULT_NUM_CTX` (`chat_workflow/llm_handler.py:1008`,
+  `chat_workflow/manager.py:2019`), and a hard-coded `num_ctx: 2048` in
+  `knowledge/base.py:255`;
+- `llm_shared/models.py:67` declaring the `num_ctx` field default.
+
+Grep confirms the *parser* half is absent: `maximum context length|context_length_exceeded`
+returns nothing on this path, and there is no `/api/show` call anywhere — the only Ollama
+metadata call is a liveness check (`startup_validator.py:311`). `llm_shared/providers/ollama.py`
+is otherwise a full provider (`chat_completion:489`, `stream_response:386`), so the accurate
+claim is **no capability/metadata probe**, not "no Ollama calls".
+
+Both directions fail silently — a 32k model sized as 4k is compressed for no reason (quality
+loss, never an error), and one sized too high returns a 400 every turn until a human edits
+YAML. This hits every local and self-hosted model, which is the deployment shape we ship.
+
+The transferable trick: **the serving stack states its own limit in the text it rejects with.**
+Parse it once and every later turn is correct. Two details make the parser correct rather than
+merely present — anchor each pattern on the *limit keyword* so
+`"requested 50000 … maximum … 32768"` yields 32768 and not 50000, and band the result so an
+implausible parse falls through instead of raising the assumed window into a hard failure.
+`_CONTEXT_HARD_MAX` already supplies the upper half of that band.
+
+### Gap 4 · #14030 — skill distillation cannot see recurrence *(wave 2, gated)*
+
+`autobot-backend/services/skill_management/skill_extractor.py:86` takes a single conversation;
+the scheduler feeds them one at a time. Within one window, a habitual request and a one-off
+task are indistinguishable, and the reviewer is *right* to decline writing a skill for a
+one-off — so "I ask this every week" can never reach it. No prompt change recovers the signal;
+it needs a cross-session pass keyed on distinct conversations **and distinct days**.
+
+The transferable discipline is the second half: **recompute each sweep from scratch over the
+lookback window instead of incrementing counters.** Re-runs become idempotent and an abandoned
+routine decays out on its own, with no expiry job.
 
 **Gated, deliberately.** `AUTOBOT_SKILL_DISTILLATION_ENABLED` defaults to `False`
-(`skill_distillation_scheduler.py:44`). Building a recurrence miner for a pipeline
-nobody has turned on adds maintained-but-dormant surface — the #13685 shape.
+(`skill_distillation_scheduler.py:46`). Building a recurrence miner for a pipeline nobody has
+turned on adds maintained-but-dormant surface — the #13685 shape.
 
-### #14031 — pre-action verifier and belief state run nowhere *(child of #13587)*
+### Gap 5 · #14031 — the dormant-loop problem is known (#11221); what is new is narrower *(child of #13587)*
 
-`grep -rn "from agent_loop.loop import\|AgentLoop("` returns **only test files**.
-`AgentLoop` has no production caller; the live path is `chat_workflow/graph.py` +
-`chat_workflow/tool_handler.py`. So `PreActionVerifier` (sole caller
-`agent_loop/loop.py:191-192,1668`, `pre_action_verifier_enabled` defaulting to
-**True**) and `BeliefState` (sole caller `agent_loop/loop.py:28,186,…`,
-`belief_state_enabled` defaulting to **False**) execute on no request.
+`AgentLoop` has no production instantiation. **This is already documented in-code and under a
+closed issue** — `autobot-backend/agent_loop/__init__.py:11-15`:
 
-This corrects #13587's own "Already covered" list, which cited
-`agent_loop/loop.py` for both the pre-action verifier and durable run
-checkpointing. The capabilities are real and well built; they are not *covered*,
-because they never run. A guard whose enable flag defaults to `True` inside a dead
-module is exactly how this survives an audit.
+> NOT WIRED IN PRODUCTION (#11221): ``AgentLoop`` is never instantiated by any production
+> caller — the live tool seam is ``chat_workflow._dispatch_tool_call``.
 
-#13590 (CLOSED) is the template for the fix, and it is worth stating as a rule:
-**do not wire the dead entry point in — extract the decision logic into
-`autobot_shared/` as a dependency-free pure function, call it from the live seam,
-and add a wiring assertion so the next refactor cannot silently un-wire it.**
-`repetition_guard` and `fact_forcing` both took that route. #13919 and #13997 are
-the same extraction over the rest of the package; one pass beats three.
+**#11221 is CLOSED** ("decide wire vs port vs document"), resolved as *document*. So the
+existence of the dormant loop is not a discovery, and this doc does not claim it as one.
+
+What is new is narrower, and is what #14031 is actually for:
+
+- `PreActionVerifier` is reachable only from that dormant loop
+  (`agent_loop/loop.py:191-192`, `:1668`), and `pre_action_verifier_enabled` defaults to
+  **`True`** (`agent_loop/types.py:266`) — so it reads as an *active* guard while executing on
+  no request. A disabled-by-default dormant component is honest; an enabled-by-default one
+  invites exactly the miscount below.
+- `BeliefState` / `BeliefStateUpdater` likewise (`agent_loop/loop.py:28`, `:186`, `:644`,
+  `:699`, `:1350`, `:1385`), with `belief_state_enabled` defaulting to `False`
+  (`agent_loop/types.py:258`) — off *and* unreachable.
+- **#13587's "Already covered — NOT filed" list miscounts both**, citing `agent_loop/loop.py`
+  for the pre-action verifier and for durable run checkpointing. Documenting a dormant module
+  (#11221) did not stop a later audit from reading it as live coverage.
+
+For accuracy: `grep -rn "from agent_loop.loop import\|AgentLoop("` returns two non-test hits
+besides the tests — `agent_loop/__init__.py:38` (package re-export) and `:28` (docstring
+example). Neither is an instantiation, so the conclusion holds; the earlier "only test files"
+wording did not.
+
+#13590 (CLOSED) is the template for the fix, and it is worth stating as a rule: **do not wire
+the dead entry point in — extract the decision logic into `autobot_shared/` as a
+dependency-free pure function, call it from the live seam, and add a wiring assertion so the
+next refactor cannot silently un-wire it.** `repetition_guard` and `fact_forcing` both took
+that route. #13919 and #13997 are the same extraction over the rest of the package; one pass
+beats three.
 
 ---
 
 ## Design input, not filed as an issue
 
-**Two-tier safety floor** → posted on #13250. A frozen, startup-built pattern floor
-returning `PASS` / `FORCE_HUMAN` / `HARD_BLOCK`, evaluated *before* any grant
-lookup. Today `is_dangerous_command` computes severity but uses it only to pick
-the message wording — there is no tier meaning "no approval path may execute
-this". Filed as a comment rather than an issue **on purpose**: as a standalone
-addition it becomes a fifth approval mechanism, which is the problem #13250
-exists to remove. #14027 is a practical prerequisite — a floor matching
-un-normalized input inherits the same bypass.
+**Two-tier safety floor** → posted on #13250. A frozen, startup-built pattern floor returning
+`PASS` / `FORCE_HUMAN` / `HARD_BLOCK`, evaluated *before* any grant lookup. Today
+`is_dangerous_command` (`security/command_patterns.py:430`) computes severity but uses it only
+to pick the message wording — there is no tier meaning "no approval path may execute this".
+Filed as a comment rather than an issue **on purpose**: as a standalone addition it becomes a
+fifth approval mechanism, which is the problem #13250 exists to remove. #14027 is a practical
+prerequisite — a floor matching un-normalized input inherits the same bypass.
 
 ## Deliberately NOT proposed — do not re-file
 
 - **Progressive tool disclosure** — already evaluated and rejected at our scale.
-- **The source's contradiction detector** — string-overlap only, self-labelled
-  EXPERIMENTAL and shipped default-off. Our `ContradictionRecord` in
-  `agent_loop/belief_state.py` is a better starting point.
+- **The source's contradiction detector** — string-overlap only, self-labelled EXPERIMENTAL
+  and shipped default-off. Our `ContradictionRecord` (defined `agent_loop/types.py:482`, used
+  via `agent_loop/belief_state.py:22`) is a better starting point.
 - **Its IM-channel set and publishing pipeline** — market-shaped, no fit.
 - **Anything requiring its JVM framework stack.**
 
-## Method note
+## Corrections
 
-Greps excluded `.worktrees/`, `.claude/`, `venv/`, `node_modules/`. Two items
-listed as unverified in the working draft were closed out before filing: the hook
-bus was confirmed fully invoked (25 declared, all with live call sites — so no gap
-exists there), and the inbound trigger path was confirmed to exist, which is what
-turned #14028 from a question into a finding.
+Applied 2026-08-11 after a `code-reviewer` pass that re-ran every citation. Recorded because
+the failure mode is instructive, not just to log the churn.
+
+| # | Was | Is |
+| --- | --- | --- |
+| 1 | `graph.py:1121` abort check | `:1127` (`:1121` is a comment) |
+| 2 | repetition guard wired at `tool_handler.py:3163` | `_enforce_repetition` at `:3137`, call at `:3166` (`:3163` is the `ctx is None` no-op) |
+| 3 | `context_overflow.py:163` / `:248` | `:164` / `:251` |
+| 4 | `8192` fallback at `context_window_manager.py:519` | `:545` and `:554` (`:519` is a docstring) |
+| 5 | `strip_ansi_codes` "exists at `command_utils.py:38`" | defined `utils/encoding_utils.py:199`; `:38` is a re-export |
+| 6 | `skill_distillation_scheduler.py:44` | `:46` |
+| 7 | `ContradictionRecord` in `belief_state.py` | defined `agent_loop/types.py:482` |
+| 8 | "grep for `max_model_len\|num_ctx` returns nothing" | **false** — 12+ non-test hits. Only the error-message parser is absent. Correcting this *enlarged* #14029 from one bad fallback to four unreconciled sources |
+| 9 | "the only Ollama call is a liveness check" | false — full provider; the true claim is no capability/metadata probe |
+| 10 | #14029 chain "YAML → 4096" | YAML → registry → default, with `_CONTEXT_HEADROOM`/`_CONTEXT_HARD_MAX` |
+| 11 | #14028 "10 platform adapters … route via `message_router.py`" | 9 adapters, on a **separate** stack that never reaches `message_router.py` |
+| 12 | #14028 grep "returns only rate-limit hits" | returns **zero** hits; rate limiting surfaces under other names |
+| 13 | #14031 "grep returns only test files" | two non-test hits (re-export, docstring); no instantiation |
+| 14 | #14031 presented as a fresh discovery | already documented in-code under **#11221 (CLOSED)**; the new part is the enabled-by-default verifier and #13587's miscount |
+
+Two lessons worth carrying, both instances of patterns already in our own guidance:
+
+- **An empty result reads as a clean result — including one you never actually obtained.**
+  Claim 8 asserted an empty grep. The original command had been truncated by `head`, so the
+  absence was an artifact of the pipeline, not of the codebase. Paste the command *and* its
+  real output, or do not claim the absence.
+- **A citation is evidence only if it resolves.** Seven line numbers drifted by 1–26 lines
+  because they were taken from a grep index rather than re-read at write time. For a doc meant
+  to stop the next audit re-deriving this, an off-by-six citation is worse than no citation —
+  it looks checkable and is not.


### PR DESCRIPTION
Refs #14027, #14028, #14029, #14030, #14031.

`Refs`, not `Closes`, deliberately: this PR is the research artifact behind those
five issues and delivers none of them. The code fix for #14027 landed separately in
PR #14038 (`5d20497c0`); #14028-#14031 remain open and unstarted.

---

## Thinking Path

A comparative audit of AutoBot's agent execution seam against an external
self-hosted multi-agent harness. The source is not adoptable as code (JVM stack,
release cadence still stabilising its streaming path), so only designs were
considered, and every candidate was checked against our own code before being
filed.

The result inverted the expected shape. Our loop guards are, where they run,
**better** than the source's — the repetition guard keyed on
`(call fingerprint, result hash)` makes the polling exemption structural where the
source needs a hard-coded read-only tool allowlist, and our stagnation/novelty
guard has no counterpart there at all. The gaps sit at the edges the loop does not
own: what a guard *matches on*, how the context window is *sized*, the *ingest*
seam ahead of the router, and a package of built guards with no production caller.

Filing this doc is the trigger to move the analysis out of scratch and into
`docs/research/`, cross-linked with the issues both ways.

## What Changed

Documentation only — no code.

- `docs/research/agent-harness-guard-and-context-audit.md` (new) — the audit:
  what we already cover (with file:line evidence), where our design is stronger
  and why, the five filed gaps, one design input filed as a comment rather than an
  issue, and a do-not-re-file list.
- `docs/research/_index.md` — index row.

## Issues filed from this audit

| Issue | Gap | Wave |
|---|---|---|
| #14027 | `security/command_patterns.py` matches un-normalized input — homoglyph / ANSI-wrapped commands bypass the gate | 1 |
| #14028 | `services/gateway/` ingest has no bot-self filter, dedup, or recursion guard | 1 |
| #14029 | Context windows are a static catalog with a 4096 fallback — no probe, no learning from the provider's rejection | 1 |
| #14030 | Skill distillation is per-conversation, so recurrence is structurally invisible | 2 (gated on distillation being enabled) |
| #14031 | Pre-action verifier + belief state run nowhere — `AgentLoop` has no production caller | Wave B of #13587 |

Also posted: a **premise correction** on umbrella #13587 (its "Already covered"
list cited `agent_loop/loop.py` for the pre-action verifier and durable
checkpointing — a module with no production caller), design input on #13250 (a
two-tier safety floor, deliberately *not* filed as an issue so it does not become
a fifth approval mechanism), and cross-links on #13919 / #13997, which share
#14031's root cause.

## Verification

Source-name anonymization (repo rule — no third-party project/product/company
names in committed artifacts):

```
$ grep -rniE "mateclaw|mateaix|spring ai alibaba|dashscope|xiaohongshu|feishu|dingtalk|wecom" \
    docs/research/agent-harness-guard-and-context-audit.md
clean: no source/vendor names
```

Commit contents:

```
$ git diff --stat HEAD~1
 docs/research/_index.md                            |   1 +
 .../agent-harness-guard-and-context-audit.md       | 195 +++++++++++++++++++++
 2 files changed, 196 insertions(+)
```

Every claim in the doc carries a `file:line` citation and was read, not inferred
from filenames. Two items left unverified in the working draft were closed out
before filing rather than shipped as open questions:

- the lifecycle hook bus was confirmed **fully invoked** (25 hook points declared,
  all with live call sites in `chat_workflow/llm_handler.py` and
  `session_handler.py`) — so no gap exists there and none was filed;
- the inbound trigger path was confirmed to **exist** (`gateway.py:263`
  `receive_message`, 10 adapters, `message_router.py`), which is what turned
  #14028 from an open question into a finding.

No code paths touched, so no test run applies.

## Model Used

Claude Opus 5 (1M context)

