### PR TITLE
chore(vnc): converge 12 hardcoded /usr/share/novnc references on canonical /opt/novnc (#13076)

### DIFF
--- a/autobot-backend/api/vnc_manager.py
+++ b/autobot-backend/api/vnc_manager.py
@@ -64,6 +64,7 @@ from api.vnc_humanization import (
 from auth_middleware import check_admin_permission, get_current_user
 from autobot_shared.error_boundaries import with_error_handling
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.ssot_config import config
 from autobot_shared.temp_files import temporary_file_path
 from constants.network_constants import NetworkConstants
 from constants.threshold_constants import TimingConstants
@@ -94,14 +95,19 @@ def is_vnc_running() -> bool:
 
 
 def _launch_websockify() -> None:
-    """Start websockify daemon for noVNC access (TLS-only, proxied by nginx). Ref: #2735."""
+    """Start websockify daemon for noVNC access (TLS-only, proxied by nginx). Ref: #2735.
+
+    #13076: web root is config.path.novnc_path (default /opt/novnc), not the
+    distro /usr/share/novnc — roles/vnc removes that package (#13069) and it
+    otherwise serves a stale pre-VeNCrypt client (#13060).
+    """
     websockify_bind = f"{NetworkConstants.LOCALHOST_NAME}:{NetworkConstants.VNC_PORT}"
     vnc_target = f"{NetworkConstants.LOCALHOST_NAME}:5901"
     subprocess.Popen(  # nosec B603 B607  # fixed argv, no user input
         [
             "/usr/bin/websockify",
             "--web",
-            "/usr/share/novnc",
+            config.path.novnc_path,
             "--cert=/etc/autobot/certs/server-cert.pem",
             "--key=/etc/autobot/certs/server-key.pem",
             "--ssl-only",

--- a/autobot-backend/desktop_streaming_manager.py
+++ b/autobot-backend/desktop_streaming_manager.py
@@ -254,8 +254,11 @@ class VNCServerManager:
         Returns:
             True if NoVNC is found, False otherwise.
         """
-        # Common NoVNC installation paths
-        novnc_paths = ["/usr/share/novnc", "/opt/novnc", "~/novnc", "./novnc"]
+        # Common NoVNC installation paths. #13076: /usr/share/novnc dropped —
+        # roles/vnc removes that distro package (#13069), and where it survives
+        # it serves a stale pre-VeNCrypt 1.0.0 client (#13060). config.path.novnc_path
+        # is the canonical install location (default /opt/novnc).
+        novnc_paths = [config.path.novnc_path, "~/novnc", "./novnc"]
 
         for path in novnc_paths:
             if Path(path).expanduser().exists():
@@ -444,7 +447,7 @@ class VNCServerManager:
             novnc_command = [
                 websockify_cmd,
                 "--web",
-                "/usr/share/novnc",
+                config.path.novnc_path,
                 "--cert=/etc/autobot/certs/server-cert.pem",
                 "--key=/etc/autobot/certs/server-key.pem",
                 "--ssl-only",

--- a/autobot-infrastructure/shared/scripts/infrastructure/browser-vnc-websockify.service
+++ b/autobot-infrastructure/shared/scripts/infrastructure/browser-vnc-websockify.service
@@ -6,7 +6,12 @@ After=network.target
 Type=simple
 User=autobot
 WorkingDirectory=/home/autobot
-ExecStart=/usr/bin/websockify --web /usr/share/novnc 0.0.0.0:6080 localhost:5901
+# #13076: /opt/novnc, matching autobot-slm-backend/ansible/roles/vnc/defaults/
+# main.yml novnc_path. The distro /usr/share/novnc package is removed by
+# roles/vnc (#13069) and, where it survives, serves a stale pre-VeNCrypt
+# client (#13060). This unit does not install noVNC; run the vnc role (or an
+# equivalent pinned install) first so /opt/novnc exists.
+ExecStart=/usr/bin/websockify --web /opt/novnc 0.0.0.0:6080 localhost:5901
 Restart=always
 RestartSec=10
 StandardOutput=journal

--- a/autobot-infrastructure/shared/scripts/setup_browser_vnc.sh
+++ b/autobot-infrastructure/shared/scripts/setup_browser_vnc.sh
@@ -61,9 +61,14 @@ run_on_browser_vm "/usr/bin/vncserver :1 \
 echo "  VNC server started on :1 (port 5901, password-protected)"
 
 # Step 5: Start websockify for noVNC access
+# #13076: web root is /opt/novnc, matching autobot-slm-backend/ansible/roles/
+# vnc/defaults/main.yml novnc_path — NOT the distro /usr/share/novnc, which
+# roles/vnc removes (#13069) and which otherwise serves a stale pre-VeNCrypt
+# client (#13060). This script does not install noVNC itself; run the vnc role
+# (or an equivalent pinned install) first so /opt/novnc exists.
 echo "[5/7] Starting websockify for noVNC..."
 run_on_browser_vm "nohup /usr/bin/websockify \
-    --web /usr/share/novnc \
+    --web ${AUTOBOT_NOVNC_PATH:-/opt/novnc} \
     --cert=/etc/autobot/certs/server-cert.pem \
     --key=/etc/autobot/certs/server-key.pem \
     --ssl-only \

--- a/autobot-infrastructure/shared/scripts/utilities/fix-vnc-desktop.sh
+++ b/autobot-infrastructure/shared/scripts/utilities/fix-vnc-desktop.sh
@@ -65,6 +65,11 @@ WantedBy=multi-user.target
 EOF
 
 # Update noVNC to connect to TigerVNC (port 5901 for display :1)
+# #13076: /opt/novnc, matching autobot-slm-backend/ansible/roles/vnc/defaults/
+# main.yml novnc_path — NOT the distro /usr/share/novnc, which roles/vnc
+# removes (#13069) and which otherwise serves a stale pre-VeNCrypt client
+# (#13060). This script does not install noVNC itself; run the vnc role (or
+# an equivalent pinned install) first so /opt/novnc exists.
 cat > /etc/systemd/system/novnc.service << 'EOF'
 [Unit]
 Description=noVNC Web Interface
@@ -75,8 +80,8 @@ Requires=tigervnc.service
 Type=simple
 User=kali
 Group=kali
-WorkingDirectory=/usr/share/novnc
-ExecStart=/usr/bin/websockify --web /usr/share/novnc \
+WorkingDirectory=/opt/novnc
+ExecStart=/usr/bin/websockify --web /opt/novnc \
     --cert=/etc/autobot/certs/server-cert.pem \
     --key=/etc/autobot/certs/server-key.pem \
     --ssl-only \

--- a/autobot-infrastructure/shared/scripts/utilities/fix-vnc-wsl.sh
+++ b/autobot-infrastructure/shared/scripts/utilities/fix-vnc-wsl.sh
@@ -50,6 +50,11 @@ WantedBy=multi-user.target
 EOF
 
 # Update noVNC service
+# #13076: /opt/novnc, matching autobot-slm-backend/ansible/roles/vnc/defaults/
+# main.yml novnc_path — NOT the distro /usr/share/novnc, which roles/vnc
+# removes (#13069) and which otherwise serves a stale pre-VeNCrypt client
+# (#13060). This script does not install noVNC itself; run the vnc role (or
+# an equivalent pinned install) first so /opt/novnc exists.
 cat > /etc/systemd/system/novnc.service << 'EOF'
 [Unit]
 Description=noVNC Web Interface
@@ -60,8 +65,8 @@ Requires=x11vnc.service
 Type=simple
 User=kali
 Group=kali
-WorkingDirectory=/usr/share/novnc
-ExecStart=/usr/bin/websockify --web /usr/share/novnc \
+WorkingDirectory=/opt/novnc
+ExecStart=/usr/bin/websockify --web /opt/novnc \
     --cert=/etc/autobot/certs/server-cert.pem \
     --key=/etc/autobot/certs/server-key.pem \
     --ssl-only \

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -1322,6 +1322,17 @@ class PathConfig(RedactedSettings):
     # Override via AUTOBOT_VNC_PASSWD_FILE env var.
     vnc_passwd_file: str = Field(default="/home/autobot/.vnc/x11vnc.passwd", alias="AUTOBOT_VNC_PASSWD_FILE")
 
+    # noVNC web root — absolute path, not relative to base_dir.
+    #
+    # #13069: pinned to /opt/novnc, NOT the distro /usr/share/novnc package.
+    # roles/vnc removes that package (state: absent) and installs a checksummed
+    # upstream release at this path instead, because the distro build
+    # (novnc 1:1.0.0-5 on Ubuntu 22.04) predates VeNCrypt support and was the
+    # cause of the handshake failure in #13060. Keep in sync with
+    # autobot-slm-backend/ansible/roles/vnc/defaults/main.yml novnc_path.
+    # Override via AUTOBOT_NOVNC_PATH env var.
+    novnc_path: str = Field(default="/opt/novnc", alias="AUTOBOT_NOVNC_PATH")
+
     # Canonical inter-node SSH private key (#12429). SINGLE source of truth for
     # every consumer that SSHes to fleet nodes (SLM -> fleet, deploy, code-sync,
     # service orchestration). Absolute path — never relative to base_dir. Legacy

--- a/docs/features/PHASE_8_ENHANCED_INTERFACE.md
+++ b/docs/features/PHASE_8_ENHANCED_INTERFACE.md
@@ -561,7 +561,7 @@ which websockify
 pip list | grep websockify
 
 # Test websockify manually
-websockify --web /usr/share/novnc 6080 localhost:5900
+websockify --web /opt/novnc 6080 localhost:5900
 ```
 
 **Takeover Session Failures**:

--- a/docs/guides/vision-vnc-ui-testing.md
+++ b/docs/guides/vision-vnc-ui-testing.md
@@ -2317,7 +2317,7 @@ vncserver :1 -localhost no -SecurityTypes VncAuth,TLSVnc -rfbport 5901 \
     -geometry 1920x1080 -depth 24
 
 # Start websockify
-websockify --web /usr/share/novnc 0.0.0.0:6080 localhost:5901
+websockify --web /opt/novnc 0.0.0.0:6080 localhost:5901
 ```
 
 **Problem: VNC accessible locally but not remotely**

--- a/docs/infrastructure/BROWSER_VNC_SETUP.md
+++ b/docs/infrastructure/BROWSER_VNC_SETUP.md
@@ -138,7 +138,7 @@ Environment="DISPLAY=:1"
 ### noVNC Settings
 
 - **Port**: 6080
-- **Web Root**: /usr/share/novnc
+- **Web Root**: /opt/novnc (#13069; distro /usr/share/novnc is removed by roles/vnc and stale where it survives)
 - **Proxy Target**: localhost:5901
 
 ## Frontend Integration


### PR DESCRIPTION
Closes #13076

## Thinking Path

The issue named 4 files with hardcoded `/usr/share/novnc`. A repo-wide `grep -rn "/usr/share/novnc"` (ansible, scripts, docs, systemd units, Python) found **12 active occurrences across 9 files** — the 4 named plus 3 more in `docs/`, 2 in `autobot-backend/desktop_streaming_manager.py`, and 1 in `autobot-backend/api/vnc_manager.py`. A 13th hit in `autobot-slm-backend/ansible/roles/vnc/defaults/main.yml` is an explanatory comment that correctly documents *why not* to use that path — left untouched.

Canonical source search: `autobot-slm-backend/ansible/roles/vnc/defaults/main.yml` already defines `novnc_path: /opt/novnc` (set by #13069) as the value the Ansible `vnc` role templates into `vnc-websockify.service.j2`. That's the existing single source of truth for infrastructure provisioning. For Python code, the repo's `autobot_shared.ssot_config.PathConfig` class is the established SSOT pattern (`vnc_passwd_file`, `ssh_key_path`, etc. all live there, each with an `AUTOBOT_*` env alias and a `ConfigRegistry`-independent direct-import usage pattern already exercised by `desktop_streaming_manager.py:544` for `config.path.vnc_passwd_path`). No canonical Python-side value existed for the noVNC path yet, so this PR adds one — `PathConfig.novnc_path`, default `/opt/novnc`, alias `AUTOBOT_NOVNC_PATH` — rather than inventing a second mechanism or duplicating the Ansible default as a bare literal in each call site.

The 4 named legacy scripts are manual/standalone VNC setup paths (SSH-driven or systemd-unit generators), separate from the Ansible role per #13076's own description. Per the issue's own options, Option 2 ("converge them on `/opt/novnc`") was chosen over retiring them, since liveness of these manual paths can't be confirmed without a host, and the never-delete-code rule blocks removal without that confirmation. They now point at the same `/opt/novnc` path the role installs to, with a comment noting they do not perform the pinned install themselves (pre-existing limitation, unchanged by this PR — installing/version-pinning noVNC is the Ansible role's job).

## What Changed

- `autobot_shared/ssot_config.py` — new `PathConfig.novnc_path` field (default `/opt/novnc`, env override `AUTOBOT_NOVNC_PATH`), documented against `roles/vnc/defaults/main.yml` as the value to keep in sync with.
- `autobot-backend/api/vnc_manager.py`, `autobot-backend/desktop_streaming_manager.py` — websockify `--web` arguments and the noVNC-availability probe now read `config.path.novnc_path` instead of the literal `/usr/share/novnc`. The stale-package fallback probe path was also removed from `desktop_streaming_manager.py`'s `_check_novnc_availability()` — reporting noVNC "available" just because the pre-#13069 distro path still exists on some host would mask exactly the stale-client issue #13060 was about.
- `autobot-infrastructure/shared/scripts/setup_browser_vnc.sh`, `.../infrastructure/browser-vnc-websockify.service`, `.../utilities/fix-vnc-desktop.sh`, `.../utilities/fix-vnc-wsl.sh` — the 4 files named in #13076, converged on `/opt/novnc`. `setup_browser_vnc.sh` uses `${AUTOBOT_NOVNC_PATH:-/opt/novnc}` (it already sources an SSOT-config helper and expands locally before sending the command over SSH); the systemd unit files use the literal `/opt/novnc`, since ExecStart= there has no bash-style `${VAR:-default}` expansion available without an `EnvironmentFile=` directive I'm not introducing unverified.
- `docs/features/PHASE_8_ENHANCED_INTERFACE.md`, `docs/guides/vision-vnc-ui-testing.md`, `docs/infrastructure/BROWSER_VNC_SETUP.md` — example commands and reference text updated to `/opt/novnc`.

No `ansible.builtin.shell` tasks were touched, so the dash/`pipefail` gotcha does not apply here — nothing in this PR runs through Ansible's shell module.

## Verification

Before (fresh worktree off `origin/Dev_new_gui`):
```
$ grep -rn "/usr/share/novnc" . --include="*" -I
<12 hits across 9 files, plus 1 explanatory-comment hit in roles/vnc/defaults/main.yml>
```

After:
```
$ grep -rn "/usr/share/novnc" . --include="*" -I
docs/infrastructure/BROWSER_VNC_SETUP.md:141:   (comment, explains the old path is gone)
autobot-backend/desktop_streaming_manager.py:257: (comment)
autobot-backend/api/vnc_manager.py:101:           (comment)
autobot_shared/ssot_config.py:1327:               (comment)
autobot-infrastructure/.../setup_browser_vnc.sh:65:            (comment)
autobot-infrastructure/.../browser-vnc-websockify.service:10:  (comment)
autobot-infrastructure/.../fix-vnc-desktop.sh:69:               (comment)
autobot-infrastructure/.../fix-vnc-wsl.sh:54:                   (comment)
autobot-slm-backend/ansible/roles/vnc/defaults/main.yml:33:     (pre-existing, correct-as-is comment)
```
Zero active (non-comment) references remain — confirmed with `grep -rn "^\s*[^#].*\/usr\/share\/novnc"` returning nothing but comment lines.

- `bash -n` on all 3 touched shell scripts — pass.
- `venv/bin/python -m py_compile` on `ssot_config.py`, `desktop_streaming_manager.py`, `api/vnc_manager.py` — pass.
- `systemd-analyze verify` on `browser-vnc-websockify.service` — no error attributable to this file (output only shows pre-existing warnings from unrelated live-host units).
- `PathConfig()` instantiation confirmed at the Python REPL: default resolves to `/opt/novnc`; setting `AUTOBOT_NOVNC_PATH=/custom/novnc` in the environment correctly overrides it.
- `pytest autobot-backend/api/vnc_manager_control_lock_test.py` — 17 passed (confirms the new `ssot_config` import doesn't break module load).
- `pytest autobot_shared/ssot_config_test.py` — 41 passed (confirms the new `PathConfig` field doesn't break existing config tests).

**Not verifiable without a live host:** whether the modified shell scripts and systemd units, when actually executed against a browser VM that has `/opt/novnc` populated by the Ansible role, produce a working noVNC session end-to-end. Static syntax/parse checks pass; runtime behavior on the target VMs is unverified.

## Discovered but not fixed here

While reading `fix-vnc-desktop.sh`, found that its `tigervnc.service` heredoc uses a *quoted* delimiter (`<< 'EOF'`), which disables shell expansion — so `User=${AUTOBOT_VNC_USER:-autobot}` is written **literally** into the generated systemd unit instead of being resolved, which is not valid systemd syntax. This is unrelated to the noVNC path and predates this PR; filed as #14036 rather than fixed here to keep this PR scoped to #13076.

#13148 (the related "3 hand-synchronised duplications" issue, including converging VNC *launch parameters* like `SecurityTypes` across these same sites) is explicitly out of scope for this PR per the task — only the noVNC web-root path is addressed here.

## Model Used

Sonnet 5
