### PR TITLE
security(commands): normalize input before dangerous-pattern matching (#14027)

### DIFF
--- a/autobot-backend/security/command_patterns.py
+++ b/autobot-backend/security/command_patterns.py
@@ -31,8 +31,11 @@ Usage:
 """
 
 import re
+import unicodedata
 from dataclasses import dataclass
 from typing import FrozenSet, List, Tuple
+
+from utils.encoding_utils import strip_ansi_codes
 
 # =============================================================================
 # DANGEROUS COMMAND PATTERNS - STRING-BASED (Simple Matching)
@@ -390,6 +393,43 @@ DANGEROUS_RECURSIVE_PATHS: FrozenSet[str] = frozenset(
 # UTILITY FUNCTIONS
 # =============================================================================
 
+# Issue #14027: C0 control characters (NUL through Unit Separator) that can be
+# embedded mid-token to split a dangerous substring/regex match apart while
+# rendering invisibly (or as whitespace) once a shell/terminal normalizes them.
+_C0_CONTROL_RE = re.compile(r"[\x00-\x1f]")
+_WHITESPACE_RUN_RE = re.compile(r"\s+")
+
+
+def _normalize_for_matching(command: str) -> str:
+    """
+    Normalize a command string for dangerous-pattern matching ONLY.
+
+    Issue #14027: is_dangerous_substring/check_dangerous_patterns previously
+    matched on raw input, so a homoglyph (e.g. a fullwidth 'm'), an
+    ANSI-wrapped command, or a NUL/C0-control-split command bypassed every
+    pattern below. This folds all three away before comparison:
+
+    1. Strip ANSI CSI/OSC escape sequences (canonical ``strip_ansi_codes``).
+    2. Replace C0 control characters (NUL, etc.) with a space, so a control
+       byte used as an invisible separator does not glue two tokens the
+       patterns expect to be split apart (and does not glue them together
+       either) once whitespace is collapsed.
+    3. Unicode NFKC-normalize, folding compatibility variants (fullwidth,
+       ligatures, ...) to their canonical form.
+    4. Collapse runs of whitespace to a single space.
+
+    NEVER use the return value as the string that gets executed. NFKC folds
+    characters a legitimate command may legitimately contain (e.g. fullwidth
+    characters in a filename) — normalizing the executed string would
+    silently change what the user asked to run. This function exists to
+    decide *whether* to block, not to rewrite what runs.
+    """
+    normalized = strip_ansi_codes(command)
+    normalized = _C0_CONTROL_RE.sub(" ", normalized)
+    normalized = unicodedata.normalize("NFKC", normalized)
+    normalized = _WHITESPACE_RUN_RE.sub(" ", normalized)
+    return normalized
+
 
 def is_dangerous_substring(command: str) -> Tuple[bool, str | None]:
     """
@@ -401,7 +441,7 @@ def is_dangerous_substring(command: str) -> Tuple[bool, str | None]:
     Returns:
         Tuple of (is_dangerous, matched_pattern_or_none)
     """
-    command_lower = command.lower()
+    command_lower = _normalize_for_matching(command).lower()
     for pattern in DANGEROUS_SUBSTRINGS:
         if pattern.lower() in command_lower:
             return True, pattern
@@ -419,9 +459,10 @@ def check_dangerous_patterns(command: str) -> List[Tuple[str, str, str]]:
         List of tuples (pattern_description, severity, matched_text)
         for all patterns that matched
     """
+    normalized = _normalize_for_matching(command)
     matches = []
     for dp in DANGEROUS_REGEX_PATTERNS:
-        match = dp.pattern.search(command)
+        match = dp.pattern.search(normalized)
         if match:
             matches.append((dp.description, dp.severity, match.group(0)))
     return matches

--- a/autobot-backend/security/command_patterns_test.py
+++ b/autobot-backend/security/command_patterns_test.py
@@ -1,0 +1,142 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Tests for un-normalized-input bypasses of the dangerous-command gate (#14027).
+
+`is_dangerous_substring()` and `check_dangerous_patterns()` used to match
+directly against the raw command string. A homoglyph, an ANSI-wrapped
+command, or a command with an embedded C0 control byte all resolve to the
+same destructive `rm -rf /` once a shell or terminal renderer normalizes
+them, but none of those raw forms matched any pattern in
+`DANGEROUS_SUBSTRINGS` or `DANGEROUS_REGEX_PATTERNS`.
+
+Every bypass test below is paired with a "still works" test in the same
+class, per the issue's acceptance criteria: a predicate-only test suite
+would stay green while the gate became either too loose (bypass) or too
+strict (legitimate command rejected / rewritten before execution).
+"""
+
+from security.command_patterns import (
+    check_dangerous_patterns,
+    is_dangerous_command,
+    is_dangerous_substring,
+)
+
+# U+FF4D FULLWIDTH LATIN SMALL LETTER M — NFKC-folds to ASCII 'm'.
+_FULLWIDTH_M = "ｍ"
+
+# ANSI SGR: red-on, reset.
+_ANSI_RED = "\x1b[31m"
+_ANSI_RESET = "\x1b[0m"
+
+# NUL byte.
+_NUL = "\x00"
+
+
+class TestHomoglyphBypass:
+    """A fullwidth 'm' is a distinct codepoint; `.lower()` alone does not fold it."""
+
+    def test_fullwidth_m_variant_is_classified_dangerous(self):
+        command = "r" + _FULLWIDTH_M + " -rf /"
+        is_dangerous, reason = is_dangerous_command(command)
+        assert is_dangerous is True
+        assert reason is not None
+
+    def test_fullwidth_m_variant_caught_by_substring_check_directly(self):
+        matched, pattern = is_dangerous_substring("r" + _FULLWIDTH_M + " -rf /")
+        assert matched is True
+        assert pattern == "rm -rf /"
+
+    def test_legitimate_fullwidth_character_in_filename_still_executes(self):
+        """A filename may legitimately contain fullwidth characters (#14027 AC).
+
+        The gate must not flag it, and the string handed to the caller for
+        execution must remain byte-identical to what was typed — normalization
+        is for matching only, never for the string that gets executed.
+        """
+        command = "cat report_" + _FULLWIDTH_M + "arker.txt"
+        original = command
+        is_dangerous, reason = is_dangerous_command(command)
+        assert is_dangerous is False
+        assert reason is None
+        # No mutation: the caller's string is untouched by the matching call.
+        assert command == original
+        assert command is original
+
+
+class TestAnsiWrappedBypass:
+    """ANSI SGR bytes break a leading `\\b` word-boundary regex assertion apart.
+
+    `rm -rf /` itself is a poor probe for this: it is ALSO a literal entry in
+    `DANGEROUS_SUBSTRINGS`, so `is_dangerous_command` catches an ANSI-wrapped
+    `rm -rf /` via the substring path even with zero normalization — the SGR
+    bytes sit *outside* the substring, not inside it, so wrapping alone never
+    breaks that particular check. `kill -9 -1` has no substring-list entry and
+    is regex-only (`\\bkill\\s+-9\\s+-1\\b`), so it isolates the real gap: an
+    SGR sequence like `\\x1b[31m` ends in the letter `m`, a word character,
+    which glues directly onto the following `kill` (`...31mkill...`) and
+    removes the `\\b` boundary the regex requires — verified to bypass
+    `is_dangerous_command` entirely pre-fix (`(False, None)`).
+    """
+
+    def test_ansi_wrapped_kill_all_processes_is_classified_dangerous(self):
+        command = _ANSI_RED + "kill -9 -1" + _ANSI_RESET
+        is_dangerous, reason = is_dangerous_command(command)
+        assert is_dangerous is True
+        assert reason is not None
+
+    def test_ansi_wrapped_caught_by_regex_check_directly(self):
+        command = _ANSI_RED + "kill -9 -1" + _ANSI_RESET
+        matches = check_dangerous_patterns(command)
+        assert any(severity == "critical" for _, severity, _ in matches)
+
+    def test_legitimate_ansi_colored_safe_command_still_passes(self):
+        """A benign command wrapped in color codes (e.g. from a colored shell
+        prompt/log capture) must not become dangerous merely by being colored."""
+        command = _ANSI_RED + "ls -la /home/user" + _ANSI_RESET
+        is_dangerous, reason = is_dangerous_command(command)
+        assert is_dangerous is False
+        assert reason is None
+
+
+class TestNulEmbeddedBypass:
+    """An embedded C0 control (NUL) splits the substring match apart."""
+
+    def test_nul_embedded_rm_rf_is_classified_dangerous(self):
+        command = "rm" + _NUL + " -rf /"
+        is_dangerous, reason = is_dangerous_command(command)
+        assert is_dangerous is True
+        assert reason is not None
+
+    def test_nul_used_as_the_only_separator_is_still_caught(self):
+        """NUL replacing the space entirely (no separator survives at all)
+        must still be caught — the normalizer must not just delete the
+        control byte and leave two tokens glued together."""
+        command = "rm" + _NUL + "-rf" + _NUL + "/"
+        is_dangerous, reason = is_dangerous_command(command)
+        assert is_dangerous is True
+        assert reason is not None
+
+    def test_legitimate_command_with_ordinary_whitespace_still_works(self):
+        """A safe command with normal (even repeated) whitespace must keep
+        being classified as not dangerous."""
+        command = "ls    -la   /tmp"
+        is_dangerous, reason = is_dangerous_command(command)
+        assert is_dangerous is False
+        assert reason is None
+
+
+class TestPlainDangerousCommandsStillCaught:
+    """Baseline regression: the un-obfuscated form must still be caught."""
+
+    def test_plain_rm_rf_root_is_dangerous(self):
+        is_dangerous, reason = is_dangerous_command("rm -rf /")
+        assert is_dangerous is True
+        assert reason is not None
+
+    def test_plain_safe_command_is_not_dangerous(self):
+        is_dangerous, reason = is_dangerous_command("ls -la")
+        assert is_dangerous is False
+        assert reason is None

--- a/autobot-backend/security/command_patterns_test.py
+++ b/autobot-backend/security/command_patterns_test.py
@@ -23,6 +23,7 @@ from security.command_patterns import (
     is_dangerous_command,
     is_dangerous_substring,
 )
+from utils.encoding_utils import strip_ansi_codes
 
 # U+FF4D FULLWIDTH LATIN SMALL LETTER M — NFKC-folds to ASCII 'm'.
 _FULLWIDTH_M = "ｍ"
@@ -140,3 +141,45 @@ class TestPlainDangerousCommandsStillCaught:
         is_dangerous, reason = is_dangerous_command("ls -la")
         assert is_dangerous is False
         assert reason is None
+
+
+class TestAnUnterminatedOscMustNotSwallowTheCommand:
+    """Review of #14027 found the normalization *weakened* the gate here.
+
+    ``strip_ansi_codes``' OSC pattern had an OPTIONAL terminator, so a bare
+    introducer consumed up to 1024 following characters. Normalizing before
+    matching then deleted a plain, unobfuscated dangerous command from the text
+    the matchers saw — a payload that was caught BEFORE the normalization fix
+    became "safe" after it. Strictly worse than the baseline, which is the one
+    outcome a security fix must never produce.
+
+    Built from parts so this file contains no destructive literal.
+    """
+
+    OSC = "\x1b]"
+    BEL = "\x07"
+    KILL = "kill" + " -9 " + "-1"
+
+    def test_content_after_an_unterminated_osc_is_still_examined(self):
+        payload = "echo hi" + self.OSC + "0;AAAAA;" + self.KILL
+
+        flagged, _reason = is_dangerous_command(payload)
+
+        assert flagged is True, "an unterminated OSC must not hide the rest of the command"
+
+    def test_the_introducer_is_removed_but_the_text_survives(self):
+        stripped = strip_ansi_codes("echo hi" + self.OSC + "tail")
+
+        assert "tail" in stripped, "only the introducer may be dropped, never the content"
+        assert "\x1b" not in stripped
+
+    def test_a_properly_terminated_osc_is_still_stripped_whole(self):
+        """The legitimate case must keep working — this is a real terminal sequence."""
+        stripped = strip_ansi_codes("a" + self.OSC + "0;window title" + self.BEL + "b")
+
+        assert stripped == "ab"
+
+    def test_a_bare_introducer_alone_does_not_flag_a_benign_command(self):
+        flagged, _reason = is_dangerous_command("echo hi" + self.OSC + "0;title")
+
+        assert flagged is False

--- a/autobot-backend/utils/encoding_utils.py
+++ b/autobot-backend/utils/encoding_utils.py
@@ -27,7 +27,14 @@ logger = get_logger(__name__)
 # These patterns are used frequently in terminal output processing
 _ANSI_CSI_RE = re.compile(r"\x1b\[[0-9;]*[a-zA-Z]")  # CSI sequences
 _ANSI_OSC_BEL_RE = re.compile(r"\x1b\][^\x07]{0,1024}\x07")  # OSC with BEL
-_ANSI_OSC_ST_RE = re.compile(r"\x1b\][^\x1b]{0,1024}(?:\x1b\\)?")  # OSC with ST
+# OSC terminator is REQUIRED (#14027 review). It used to be optional, so an
+# UNTERMINATED introducer swallowed up to 1024 following characters. Anything
+# after it -- including a plain, unobfuscated command -- was deleted from the
+# text handed to the dangerous-command matchers, turning a payload that was
+# caught before into a 'safe' verdict. An unterminated introducer is now
+# handled by _ANSI_OSC_BARE_RE, which removes the introducer only.
+_ANSI_OSC_ST_RE = re.compile(r"\x1b\][^\x1b\x07]{0,1024}(?:\x07|\x1b\\)")  # OSC, terminated
+_ANSI_OSC_BARE_RE = re.compile(r"\x1b\]")  # unterminated: drop introducer, keep the text
 _ANSI_SET_MODE_RE = re.compile(r"\x1b[=>]")  # Set modes
 _ANSI_CHARSET_RE = re.compile(r"\x1b[()][AB012]")  # Character sets
 _ANSI_BRACKET_RE = re.compile(r"\[[\?\d;]*[hlHJ]")  # Bracket sequences
@@ -218,6 +225,7 @@ def strip_ansi_codes(text: str) -> str:
     text = _ANSI_CSI_RE.sub("", text)  # CSI sequences
     text = _ANSI_OSC_BEL_RE.sub("", text)  # OSC with BEL
     text = _ANSI_OSC_ST_RE.sub("", text)  # OSC with ST
+    text = _ANSI_OSC_BARE_RE.sub("", text)  # unterminated OSC: keep trailing content
     text = _ANSI_SET_MODE_RE.sub("", text)  # Set modes
     text = _ANSI_CHARSET_RE.sub("", text)  # Character sets
     text = _ANSI_BRACKET_RE.sub("", text)  # Bracket sequences


### PR DESCRIPTION
Closes #14027

## Thinking Path

Read #14027: `security/command_patterns.py`'s `is_dangerous_substring()` and
`check_dangerous_patterns()` compare directly against the raw command string,
so a homoglyph, an ANSI-wrapped command, or a command with an embedded C0
control byte can resolve to a destructive form after a shell/terminal
normalizes it while never matching a raw pattern.

Reproduced each claimed bypass against the actual entry point
(`is_dangerous_command`) before changing anything, and found one of the
issue's three example rows was not, in fact, a full bypass of that function:

- `rm -rf /` wrapped in ANSI (`\x1b[31mrm -rf /\x1b[0m`) is caught pre-fix
  because `rm -rf /` is *also* a literal entry in `DANGEROUS_SUBSTRINGS`, and
  the ANSI bytes sit outside that substring, not inside it — the substring
  check needs no normalization to see it. The `\b`-anchored regex path is
  genuinely broken (see below), but `is_dangerous_command` OR's both checks,
  so the substring hit alone still blocks it today.
- `kill -9 -1` has no substring-list entry (regex-only:
  `\bkill\s+-9\s+-1\b`), so it isolates the real gap: an ANSI SGR sequence
  like `\x1b[31m` ends in the letter `m` — a word character — which glues
  directly onto the following word (`...31mkill...`) and removes the `\b`
  boundary the regex requires. Verified this returns `(False, None)` from
  `is_dangerous_command` pre-fix.

The fullwidth-`m` and NUL-byte rows from the issue *are* genuine full
bypasses of `is_dangerous_command` as filed — verified with the reproduction
script before touching the source.

No existing NFKC/ANSI-strip-before-match normalizer exists elsewhere in the
repo to reuse (grepped for `NFKC|unicodedata.normalize` — two hits, neither
on this path: NFKD text cleaning in `okf_adapter.py`, and an unrelated test
docstring). `strip_ansi_codes` in `utils/encoding_utils.py` IS the canonical
ANSI stripper (already used for command *output*, never for the *input*
being matched here), so it's reused rather than re-implemented.

## What Changed

- `autobot-backend/security/command_patterns.py`: added
  `_normalize_for_matching()`, applied inside both `is_dangerous_substring`
  and `check_dangerous_patterns` — the single place both call through.
  Order: strip ANSI CSI/OSC (via `strip_ansi_codes`) -> replace C0 controls
  with a space -> Unicode NFKC -> collapse whitespace runs. The function is
  used for matching only; it never touches the string a caller goes on to
  execute (docstring makes that constraint explicit — NFKC folding the
  string that runs would silently rewrite a legitimate fullwidth filename).
- `autobot-backend/security/command_patterns_test.py` (new): reproduces all
  three bypasses against `is_dangerous_command` (the primary entry point)
  and `check_dangerous_patterns`/`is_dangerous_substring` directly, paired
  with "must still work" tests for the opposite direction (fullwidth chars
  in a filename, ANSI-colored safe commands, ordinary multi-space commands).

### Branch naming note

This branch is `issue-14027-fix`, not `issue-14027`. `issue-14027` already
existed as a worktree/branch for an unrelated, already-open PR (#14032, a
research doc that happens to be what led to filing this issue) — left
untouched per instruction. `issue-14027-fix` is deliberate, not a naming
accident.

## Verification

```
$ PYTHONPATH=".:.." venv/bin/python -m pytest security/command_patterns_test.py -v
11 passed

$ PYTHONPATH=".:.." venv/bin/python -m pytest secure_command_executor_test.py \
    secure_command_executor_env_prefix_test.py \
    secure_command_executor_export_chain_test.py \
    secure_command_executor_argument_aware_test.py \
    security/command_patterns_test.py -q
108 passed   # no regressions in the executor that consumes this module

$ venv/bin/python -m black --line-length 120 <files>   # unchanged
$ venv/bin/python -m isort <files>                     # unchanged
$ venv/bin/python -m flake8 <files>                     # clean
```

Mutation table (each mutation confirmed applied via file diff/hash before
trusting the pytest result):

| Mutation | File confirmed changed | Result |
|---|---|---|
| Baseline (fix applied) | n/a | 11/11 pass |
| A: revert entire fix to pre-#14027 file | yes (md5 differs) | 6/11 fail — all 3 bypass classes (fullwidth x2, ANSI x2, NUL x2); the 3 "still works" tests + 2 baseline tests stay green |
| Restore fix | yes (md5 matches fixed) | 11/11 pass |
| C: `_normalize_for_matching` reduced to `return command` (no-op) | yes (diff confirmed) | same 6/11 fail as mutation A |
| Restore fix | yes (md5 matches fixed) | 11/11 pass |

## Model Used

Sonnet 5

