### PR TITLE
fix(llc): Kanban/Sprint boards render zero cards — frontend reads a key the board API never sends (#13993)

### DIFF
--- a/autobot-backend/llc/api/boards.py
+++ b/autobot-backend/llc/api/boards.py
@@ -92,7 +92,12 @@ def _board_response(board: Any) -> Dict[str, Any]:
     }
 
 
-def _work_item_summary(item: Any) -> Dict[str, Any]:
+def _work_item_summary(item: Any, column_id: str) -> Dict[str, Any]:
+    """GH#13993: column_id and assignee_type are computed here (not stored on
+    the item) because column membership is derived from status_filter, and
+    the swimlane/column filters on the frontend (KanbanBoardView,
+    SprintBoardView) key off both fields.
+    """
     return {
         "id": str(item.id),
         "identifier": item.identifier,
@@ -103,6 +108,8 @@ def _work_item_summary(item: Any) -> Dict[str, Any]:
         "story_points": item.story_points,
         "assignee_agent_id": str(item.assignee_agent_id) if item.assignee_agent_id else None,
         "assignee_user_id": str(item.assignee_user_id) if item.assignee_user_id else None,
+        "assignee_type": item.assignee_type,
+        "column_id": column_id,
     }
 
 
@@ -237,7 +244,7 @@ async def get_board_items(
                 "position": col_data["position"],
                 "status_filter": col_data["status_filter"],
                 "wip_limit": col_data["wip_limit"],
-                "items": [_work_item_summary(i) for i in col_data["items"]],
+                "items": [_work_item_summary(i, col_data["id"]) for i in col_data["items"]],
                 "item_count": len(col_data["items"]),
             }
         )

--- a/autobot-backend/llc/tests/test_board_items_shape_13993.py
+++ b/autobot-backend/llc/tests/test_board_items_shape_13993.py
@@ -1,0 +1,178 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""GH#13993: GET /api/llc/boards/{id}/items response shape.
+
+Regression coverage for three stacked defects:
+
+1. The response nests items inside each column (`columns[].items`) — there
+   is no top-level `items` key. The frontend previously read
+   `itemsData.items`, which is always undefined, so every board rendered
+   zero cards regardless of backend data.
+2. `_work_item_summary()` omitted `assignee_type` and `column_id`, the two
+   fields the frontend's column/swimlane filters key off.
+3. The backend only ever writes `assignee_type` as "user" or "agent" —
+   never "human" — so a frontend filter comparing against "human" silently
+   drops every human-assigned item even once (1) and (2) are fixed.
+
+This test locks in the actual response shape so a regression to any of the
+three is caught here, not downstream in the UI.
+"""
+
+import uuid
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from user_management.services import TenantContext
+
+_FIXED_USER_ID = uuid.UUID("55555555-5555-5555-5555-555555555555")
+_ORG_ID = str(uuid.uuid4())
+
+
+def _make_board(company_id: str) -> MagicMock:
+    board = MagicMock()
+    board.id = uuid.uuid4()
+    board.company_id = uuid.UUID(company_id)
+    board.project_id = None
+    board.sprint_id = None
+    board.type = "kanban"
+    board.name = "Board"
+    board.created_at = None
+    board.updated_at = None
+    board.columns = []
+    return board
+
+
+def _make_work_item(assignee_type, assignee_user_id=None, assignee_agent_id=None) -> MagicMock:
+    item = MagicMock()
+    item.id = uuid.uuid4()
+    item.identifier = "WI-001"
+    item.title = "Test task"
+    item.type = "task"
+    item.status = "ready"
+    item.priority = "medium"
+    item.story_points = None
+    item.assignee_agent_id = assignee_agent_id
+    item.assignee_user_id = assignee_user_id
+    item.assignee_type = assignee_type
+    return item
+
+
+@contextmanager
+def _make_client(board: MagicMock, columns_with_items: list):
+    """Yield a TestClient with BoardService stubbed for the duration of the block.
+
+    Scoped with ``monkeypatch``-style context management rather than
+    ``patch(...).start()`` + ``patch.stopall()``: ``stopall`` tears down *every*
+    started patch in the process, including ones owned by other modules, so a
+    module-local cleanup would reach outside this file.
+    """
+    from api.user_management.dependencies import get_current_user, require_org_context  # noqa: PLC0415
+    from llc.api.boards import router as boards_router  # noqa: PLC0415
+    from llc.deps import get_session  # noqa: PLC0415
+
+    app = FastAPI()
+    app.include_router(boards_router, prefix="/api/llc")
+
+    mock_session = AsyncMock()
+
+    async def _fake_session():
+        yield mock_session
+
+    app.dependency_overrides[get_session] = _fake_session
+    app.dependency_overrides[get_current_user] = lambda: {"id": str(_FIXED_USER_ID)}
+    app.dependency_overrides[require_org_context] = lambda: TenantContext(
+        org_id=uuid.UUID(_ORG_ID), user_id=_FIXED_USER_ID, is_platform_admin=False
+    )
+
+    with (
+        patch("llc.services.board.BoardService.get_board", new=AsyncMock(return_value=board)),
+        patch(
+            "llc.services.board.BoardService.get_board_items",
+            new=AsyncMock(return_value={"board": board, "columns": columns_with_items}),
+        ),
+    ):
+        yield TestClient(app)
+
+
+class TestBoardItemsShape:
+    def test_items_are_nested_under_columns_not_top_level(self):
+        """The response never carries a top-level `items` key (GH#13993 defect 1)."""
+        board = _make_board(_ORG_ID)
+        col_id = str(uuid.uuid4())
+        item = _make_work_item(assignee_type="user", assignee_user_id=uuid.uuid4())
+        columns_with_items = [
+            {
+                "id": col_id,
+                "name": "Ready",
+                "position": 0,
+                "status_filter": ["ready"],
+                "wip_limit": None,
+                "items": [item],
+            }
+        ]
+
+        with _make_client(board, columns_with_items) as client:
+            resp = client.get(f"/api/llc/boards/{board.id}/items")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "items" not in body
+        assert len(body["columns"]) == 1
+        assert len(body["columns"][0]["items"]) == 1
+
+    def test_each_item_carries_assignee_type_and_column_id(self):
+        """GH#13993 defect 2: the swimlane/column filters need both fields."""
+        board = _make_board(_ORG_ID)
+        col_id = str(uuid.uuid4())
+        user_item = _make_work_item(assignee_type="user", assignee_user_id=uuid.uuid4())
+        agent_item = _make_work_item(assignee_type="agent", assignee_agent_id=uuid.uuid4())
+        columns_with_items = [
+            {
+                "id": col_id,
+                "name": "Ready",
+                "position": 0,
+                "status_filter": ["ready"],
+                "wip_limit": None,
+                "items": [user_item, agent_item],
+            }
+        ]
+
+        with _make_client(board, columns_with_items) as client:
+            resp = client.get(f"/api/llc/boards/{board.id}/items")
+
+        assert resp.status_code == 200
+        items = resp.json()["columns"][0]["items"]
+        assert {i["id"] for i in items} == {str(user_item.id), str(agent_item.id)}
+        for returned in items:
+            assert returned["column_id"] == col_id
+        by_id = {i["id"]: i for i in items}
+        assert by_id[str(user_item.id)]["assignee_type"] == "user"
+        assert by_id[str(agent_item.id)]["assignee_type"] == "agent"
+
+    def test_assignee_type_vocabulary_is_user_not_human(self):
+        """GH#13993 defect 3: the backend never writes "human" — only "user"."""
+        board = _make_board(_ORG_ID)
+        col_id = str(uuid.uuid4())
+        item = _make_work_item(assignee_type="user", assignee_user_id=uuid.uuid4())
+        columns_with_items = [
+            {
+                "id": col_id,
+                "name": "Ready",
+                "position": 0,
+                "status_filter": ["ready"],
+                "wip_limit": None,
+                "items": [item],
+            }
+        ]
+
+        with _make_client(board, columns_with_items) as client:
+            resp = client.get(f"/api/llc/boards/{board.id}/items")
+
+        returned = resp.json()["columns"][0]["items"][0]
+        assert returned["assignee_type"] == "user"
+        assert returned["assignee_type"] != "human"

--- a/autobot-frontend/src/composables/llc/useKanbanBoardsApi.ts
+++ b/autobot-frontend/src/composables/llc/useKanbanBoardsApi.ts
@@ -5,9 +5,13 @@
 // per-board and move endpoints were already consumed inline by BoardsView /
 // KanbanBoardView / SprintBoardView, but the *create* endpoints
 // (POST /kanban, POST /sprint) had no frontend caller, so a fresh company's
-// empty board list was a dead end. This composable centralises all five calls
-// (list / create-kanban / create-sprint / items / move) so the create path is
+// empty board list was a dead end. This composable centralises four calls
+// (list / create-kanban / create-sprint / move) so the create path is
 // reachable and unit-testable.
+//
+// GH#13993: this comment previously advertised five calls including `items`,
+// which was never implemented here — the board views call that endpoint
+// directly. Corrected rather than left claiming a function that does not exist.
 import { ref } from 'vue'
 import { useApiClient } from '@/plugins/api'
 import { createLogger } from '@/utils/debugUtils'

--- a/autobot-frontend/src/views/llc/GanttTimelineView.vue
+++ b/autobot-frontend/src/views/llc/GanttTimelineView.vue
@@ -417,9 +417,13 @@ async function loadBoardScope() {
   try {
     const [board, boardItems] = await Promise.all([
       api.get<{ project_id: string | null; name: string }>(`/api/llc/boards/${scopeBoardId.value}`),
-      api.get<{ items: { id: string }[] }>(`/api/llc/boards/${scopeBoardId.value}/items`),
+      // GH#13993: the board-items endpoint nests items inside each column —
+      // there is no top-level `items` key. Flatten before collecting the ids.
+      api.get<{ columns: Array<{ items: { id: string }[] }> }>(`/api/llc/boards/${scopeBoardId.value}/items`),
     ])
-    scopedItemIds.value = new Set((boardItems.items ?? []).map((i) => i.id))
+    scopedItemIds.value = new Set(
+      (boardItems.columns ?? []).flatMap((col) => col.items ?? []).map((i) => i.id),
+    )
     scopeLabel.value = board.name
     if (board.project_id) selectedProjectId.value = board.project_id
   } catch (err) {

--- a/autobot-frontend/src/views/llc/KanbanBoardView.vue
+++ b/autobot-frontend/src/views/llc/KanbanBoardView.vue
@@ -28,7 +28,7 @@
             'wip-exceeded': isWipExceeded(col),
           }"
         >
-          <span class="column-title">{{ col.title }}</span>
+          <span class="column-title">{{ col.name }}</span>
           <div class="column-meta">
             <span class="column-count">{{ itemsByColumn(col.id).length }}</span>
             <span v-if="col.wip_limit" class="wip-limit" :title="$t('llc.kanban.wipLimit', { limit: col.wip_limit })">
@@ -140,7 +140,10 @@ import type { WorkItem } from './workItemTypes'
 
 interface BoardColumn {
   id: string
-  title: string
+  // GH#13993: the board endpoint (`_board_response` in llc/api/boards.py) emits
+  // `name`, never `title`. The old `title` field rendered a blank header on
+  // every column.
+  name: string
   wip_limit: number | null
 }
 
@@ -156,7 +159,7 @@ function itemsByColumn(colId: string) {
 }
 
 function humanItems(colId: string) {
-  return items.value.filter(i => i.column_id === colId && i.assignee_type === 'human')
+  return items.value.filter(i => i.column_id === colId && i.assignee_type === 'user')
 }
 
 function agentItems(colId: string) {
@@ -220,10 +223,12 @@ async function fetchBoard() {
   try {
     const [boardData, itemsData] = await Promise.all([
       api.get<{ columns: BoardColumn[] }>(`/api/llc/boards/${boardId.value}`),
-      api.get<{ items: WorkItem[] }>(`/api/llc/boards/${boardId.value}/items`),
+      // GH#13993: the board-items endpoint nests items inside each column —
+      // there is no top-level `items` key. Flatten before storing.
+      api.get<{ columns: Array<{ id: string; items: WorkItem[] }> }>(`/api/llc/boards/${boardId.value}/items`),
     ])
     columns.value = boardData.columns ?? []
-    items.value = itemsData.items ?? []
+    items.value = (itemsData.columns ?? []).flatMap(col => col.items ?? [])
   } catch (err) {
     logger.error('Failed to load board', err)
   } finally {

--- a/autobot-frontend/src/views/llc/SprintBoardView.vue
+++ b/autobot-frontend/src/views/llc/SprintBoardView.vue
@@ -50,7 +50,7 @@
           @drop="onDrop(col.id)"
         >
           <div class="column-header">
-            <span class="column-title">{{ col.title }}</span>
+            <span class="column-title">{{ col.name }}</span>
             <span class="column-count">{{ itemsByColumn(col.id).length }}</span>
           </div>
           <div class="column-cards">
@@ -150,8 +150,11 @@ import type { WorkItem } from './workItemTypes'
 
 interface BoardColumn {
   id: string
-  title: string
-  status_mapping: string[]
+  // GH#13993: the board endpoint (`_board_response` in llc/api/boards.py) emits
+  // `name`/`status_filter`, never `title`/`status_mapping`. The old names
+  // rendered a blank header on every column.
+  name: string
+  status_filter: string[]
 }
 
 interface Sprint {
@@ -256,12 +259,14 @@ async function fetchBoard() {
   try {
     const [boardData, sprintData] = await Promise.all([
       api.get<{ columns: BoardColumn[]; sprint: Sprint; burndown: BurndownPoint[] }>(`/api/llc/boards/${boardId.value}`),
-      api.get<{ items: WorkItem[] }>(`/api/llc/boards/${boardId.value}/items`),
+      // GH#13993: the board-items endpoint nests items inside each column —
+      // there is no top-level `items` key. Flatten before storing.
+      api.get<{ columns: Array<{ id: string; items: WorkItem[] }> }>(`/api/llc/boards/${boardId.value}/items`),
     ])
     columns.value = boardData.columns ?? []
     sprint.value = boardData.sprint ?? null
     burndown.value = boardData.burndown ?? []
-    items.value = sprintData.items ?? []
+    items.value = (sprintData.columns ?? []).flatMap(col => col.items ?? [])
   } catch (err) {
     logger.error('Failed to load board', err)
   } finally {

--- a/autobot-frontend/src/views/llc/__tests__/GanttTimelineView.spec.ts
+++ b/autobot-frontend/src/views/llc/__tests__/GanttTimelineView.spec.ts
@@ -59,7 +59,18 @@ const PROJECT_TIMELINE = {
 function wireApi() {
   h.api.get.mockImplementation((url: string) => {
     if (url === '/api/llc/boards/b1') return Promise.resolve({ project_id: 'p1', name: 'Sprint 3 Board' })
-    if (url === '/api/llc/boards/b1/items') return Promise.resolve({ items: [{ id: 'w1' }, { id: 'w2' }] })
+    // GH#13993: the real board-items response nests items inside each column —
+    // there is no top-level `items` key. This fixture previously used the
+    // top-level shape, so these tests passed while the view read a key the API
+    // never sends and every board-scoped timeline silently filtered to empty.
+    if (url === '/api/llc/boards/b1/items')
+      return Promise.resolve({
+        board: { id: 'b1', name: 'Sprint 3 Board' },
+        columns: [
+          { id: 'col-ready', name: 'Ready', position: 0, status_filter: ['ready'], wip_limit: null, items: [{ id: 'w1' }], item_count: 1 },
+          { id: 'col-doing', name: 'Doing', position: 1, status_filter: ['in_progress'], wip_limit: null, items: [{ id: 'w2' }], item_count: 1 },
+        ],
+      })
     if (url === '/api/llc/companies/c1/projects')
       return Promise.resolve([{ id: 'p1', name: 'Proj 1' }, { id: 'p2', name: 'Proj 2' }])
     if (url === '/api/llc/projects/p1/timeline') return Promise.resolve(PROJECT_TIMELINE)

--- a/autobot-frontend/src/views/llc/__tests__/KanbanBoardView.items.test.ts
+++ b/autobot-frontend/src/views/llc/__tests__/KanbanBoardView.items.test.ts
@@ -1,0 +1,187 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// GH#13993: the board-items endpoint (GET /api/llc/boards/{id}/items) nests
+// work items inside each column — there is no top-level `items` key. The
+// view previously read `itemsData.items`, which is always undefined, so the
+// board rendered zero cards in every column regardless of backend data.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import en from '@/i18n/locales/en.json'
+
+const get = vi.fn()
+const post = vi.fn()
+
+vi.mock('@/plugins/api', () => ({
+  useApiClient: () => ({ get, post }),
+}))
+
+vi.mock('@/utils/debugUtils', () => ({
+  createLogger: () => ({ warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() }),
+}))
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ params: { companyId: 'c1', boardId: 'b1' } }),
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+vi.mock('@/composables/useLiveEvents', () => ({
+  useLiveEvents: () => ({ subscribe: vi.fn(() => vi.fn()) }),
+}))
+
+import KanbanBoardView from '../KanbanBoardView.vue'
+
+interface WorkItemLike {
+  id: string
+  column_id?: string
+  assignee_type?: string | null
+}
+
+interface KanbanVm {
+  columns: { id: string; title: string; wip_limit: number | null }[]
+  items: WorkItemLike[]
+}
+
+// Shape actually returned by GET /api/llc/boards/{id}/items — items nested
+// per-column, each carrying `column_id` + `assignee_type` (backend/llc/api/boards.py).
+const BOARD_ITEMS_RESPONSE = {
+  board: { id: 'b1', name: 'Board' },
+  columns: [
+    {
+      id: 'col-ready',
+      name: 'Ready',
+      position: 0,
+      status_filter: ['ready'],
+      wip_limit: null,
+      items: [
+        {
+          id: 'wi-1',
+          identifier: 'WI-1',
+          title: 'First',
+          type: 'task',
+          status: 'ready',
+          priority: 'medium',
+          story_points: null,
+          assignee_agent_id: null,
+          assignee_user_id: 'u1',
+          assignee_type: 'user',
+          column_id: 'col-ready',
+        },
+      ],
+      item_count: 1,
+    },
+    {
+      id: 'col-progress',
+      name: 'In Progress',
+      position: 1,
+      status_filter: ['in_progress'],
+      wip_limit: null,
+      items: [
+        {
+          id: 'wi-2',
+          identifier: 'WI-2',
+          title: 'Second',
+          type: 'task',
+          status: 'in_progress',
+          priority: 'high',
+          story_points: 3,
+          assignee_agent_id: 'a1',
+          assignee_user_id: null,
+          assignee_type: 'agent',
+          column_id: 'col-progress',
+        },
+      ],
+      item_count: 1,
+    },
+  ],
+}
+
+// Shape actually returned by GET /api/llc/boards/{id} — see `_board_response`
+// in autobot-backend/llc/api/boards.py. Columns carry `name` and
+// `status_filter`; there is no `title` key. An earlier revision of this fixture
+// claimed `title`, which is exactly the defect this file exists to catch.
+const BOARD_RESPONSE = {
+  id: 'b1',
+  company_id: 'c1',
+  project_id: null,
+  sprint_id: null,
+  type: 'kanban',
+  name: 'Board',
+  created_at: null,
+  updated_at: null,
+  columns: [
+    { id: 'col-ready', name: 'Ready', position: 0, status_filter: ['ready'], wip_limit: null },
+    { id: 'col-progress', name: 'In Progress', position: 1, status_filter: ['in_progress'], wip_limit: null },
+  ],
+}
+
+const i18n = createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en } })
+
+async function mountView() {
+  get.mockImplementation((url: string) => {
+    if (url.endsWith('/items')) return Promise.resolve(BOARD_ITEMS_RESPONSE)
+    return Promise.resolve(BOARD_RESPONSE)
+  })
+  const wrapper = mount(KanbanBoardView, {
+    global: { plugins: [i18n], stubs: { WorkItemDetail: true } },
+  })
+  await flushPromises()
+  return wrapper
+}
+
+describe('KanbanBoardView items wiring (GH#13993)', () => {
+  beforeEach(() => {
+    get.mockReset()
+    post.mockReset()
+  })
+
+  it('flattens columns[].items from the board-items response into items', async () => {
+    const wrapper = await mountView()
+    const vm = wrapper.vm as unknown as KanbanVm
+
+    expect(vm.items.map(i => i.id).sort()).toEqual(['wi-1', 'wi-2'])
+  })
+
+  it('renders a card per item — the board is not empty when the backend has items', async () => {
+    const wrapper = await mountView()
+
+    expect(wrapper.findAll('.work-card')).toHaveLength(2)
+    expect(wrapper.text()).toContain('First')
+    expect(wrapper.text()).toContain('Second')
+  })
+
+  it('renders each column header from the `name` the board API actually sends', async () => {
+    const wrapper = await mountView()
+
+    // GH#13993: the view previously read `col.title`, a key `_board_response`
+    // never emits, so every column header rendered blank.
+    const headers = wrapper.findAll('.column-title').map(n => n.text())
+    expect(headers).toEqual(['Ready', 'In Progress'])
+  })
+
+  it('assigns each item to its column via column_id from the response', async () => {
+    const wrapper = await mountView()
+    const vm = wrapper.vm as unknown as KanbanVm
+
+    const wi1 = vm.items.find(i => i.id === 'wi-1')
+    const wi2 = vm.items.find(i => i.id === 'wi-2')
+    expect(wi1?.column_id).toBe('col-ready')
+    expect(wi2?.column_id).toBe('col-progress')
+  })
+
+  it('swimlane split uses the backend vocabulary ("user"), not "human"', async () => {
+    const wrapper = await mountView()
+    // Enable swimlane grouping.
+    await wrapper.find('.swimlane-toggle input').setValue(true)
+    await flushPromises()
+
+    // wi-1 (assignee_type "user") must land in the human swimlane and
+    // wi-2 (assignee_type "agent") in the agent swimlane. Each column has
+    // exactly one of the two types, so each column shows exactly one
+    // populated lane and one empty lane — never both empty, which is what
+    // happened while the filter compared against the literal "human".
+    expect(wrapper.findAll('.work-card')).toHaveLength(2)
+    expect(wrapper.findAll('.lane-empty')).toHaveLength(2)
+  })
+})

--- a/autobot-frontend/src/views/llc/__tests__/SprintBoardView.items.test.ts
+++ b/autobot-frontend/src/views/llc/__tests__/SprintBoardView.items.test.ts
@@ -1,0 +1,149 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// GH#13993: the board-items endpoint (GET /api/llc/boards/{id}/items) nests
+// work items inside each column — there is no top-level `items` key.
+// SprintBoardView shares the same bug as KanbanBoardView: it read
+// `sprintData.items`, which is always undefined, so the sprint board
+// rendered zero cards regardless of backend data.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import en from '@/i18n/locales/en.json'
+
+const get = vi.fn()
+const post = vi.fn()
+
+vi.mock('@/plugins/api', () => ({
+  useApiClient: () => ({ get, post }),
+}))
+
+vi.mock('@/utils/debugUtils', () => ({
+  createLogger: () => ({ warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() }),
+}))
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ params: { companyId: 'c1', boardId: 'b1' } }),
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+vi.mock('@/composables/useLiveEvents', () => ({
+  useLiveEvents: () => ({ subscribe: vi.fn(() => vi.fn()) }),
+}))
+
+import SprintBoardView from '../SprintBoardView.vue'
+
+interface WorkItemLike {
+  id: string
+  column_id?: string
+}
+
+interface SprintVm {
+  items: WorkItemLike[]
+}
+
+const BOARD_ITEMS_RESPONSE = {
+  board: { id: 'b1', name: 'Board' },
+  columns: [
+    {
+      id: 'col-ready',
+      name: 'Ready',
+      position: 0,
+      status_filter: ['ready'],
+      wip_limit: null,
+      items: [
+        {
+          id: 'wi-1',
+          identifier: 'WI-1',
+          title: 'First',
+          type: 'task',
+          status: 'ready',
+          priority: 'medium',
+          story_points: null,
+          assignee_agent_id: null,
+          assignee_user_id: 'u1',
+          assignee_type: 'user',
+          column_id: 'col-ready',
+        },
+      ],
+      item_count: 1,
+    },
+  ],
+}
+
+// Shape actually returned by GET /api/llc/boards/{id} — see `_board_response`
+// in autobot-backend/llc/api/boards.py. Columns carry `name`/`status_filter`,
+// and the response has NO `sprint` and NO `burndown` key.
+//
+// An earlier revision of this fixture invented all three. That fiction hid two
+// live defects, now filed as GH#14074: SprintBoardView reads `boardData.sprint`
+// and `boardData.burndown`, so the sprint header never renders and the burndown
+// is permanently the empty state. The assertions below pin that real behaviour
+// rather than a shape the API does not send; they flip when GH#14074 is fixed.
+const BOARD_RESPONSE = {
+  id: 'b1',
+  company_id: 'c1',
+  project_id: null,
+  sprint_id: 's1',
+  type: 'sprint',
+  name: 'Board',
+  created_at: null,
+  updated_at: null,
+  columns: [{ id: 'col-ready', name: 'Ready', position: 0, status_filter: ['ready'], wip_limit: null }],
+}
+
+const i18n = createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en } })
+
+async function mountView() {
+  get.mockImplementation((url: string) => {
+    if (url.endsWith('/items')) return Promise.resolve(BOARD_ITEMS_RESPONSE)
+    return Promise.resolve(BOARD_RESPONSE)
+  })
+  const wrapper = mount(SprintBoardView, {
+    global: { plugins: [i18n], stubs: { WorkItemDetail: true } },
+  })
+  await flushPromises()
+  return wrapper
+}
+
+describe('SprintBoardView items wiring (GH#13993)', () => {
+  beforeEach(() => {
+    get.mockReset()
+    post.mockReset()
+  })
+
+  it('flattens columns[].items from the board-items response into items', async () => {
+    const wrapper = await mountView()
+    const vm = wrapper.vm as unknown as SprintVm
+
+    expect(vm.items.map(i => i.id)).toEqual(['wi-1'])
+  })
+
+  it('renders a card — the sprint board is not empty when the backend has items', async () => {
+    const wrapper = await mountView()
+
+    expect(wrapper.findAll('.work-card')).toHaveLength(1)
+    expect(wrapper.text()).toContain('First')
+  })
+
+  it('renders the column header from the `name` the board API actually sends', async () => {
+    const wrapper = await mountView()
+
+    // GH#13993: the view previously read `col.title`, a key `_board_response`
+    // never emits, so every column header rendered blank.
+    expect(wrapper.findAll('.column-title').map(n => n.text())).toEqual(['Ready'])
+  })
+
+  it('GH#14074 (known defect): the sprint header and burndown never render', async () => {
+    const wrapper = await mountView()
+
+    // Documented failing behaviour, not an endorsement. The board endpoint
+    // sends neither `sprint` nor `burndown`, and the view reads both from it,
+    // so `sprint` stays null and `burndown` stays []. The sprint data IS
+    // available — GET /api/llc/sprints/{id} and .../burndown both exist — the
+    // view simply never asks for it. Flip these assertions when GH#14074 lands.
+    expect(wrapper.find('.sprint-title').exists()).toBe(false)
+    expect(wrapper.find('.burndown-chart').exists()).toBe(false)
+    expect(wrapper.find('.chart-empty').exists()).toBe(true)
+  })
+})

--- a/autobot-frontend/src/views/llc/workItemTypes.ts
+++ b/autobot-frontend/src/views/llc/workItemTypes.ts
@@ -8,8 +8,13 @@
  * column_id), which made the views' WorkItem incompatible with
  * WorkItemDetail's `@updated` payload.
  *
- * `column_id` and `assignee_type` are only present on board API responses,
- * hence optional here.
+ * Both `column_id` and `assignee_type` are optional because neither is on
+ * every response (GH#13993):
+ * - `assignee_type` is emitted by the work-items response (`api/work_items.py`)
+ *   and, since GH#13993, by the board-items response as well.
+ * - `column_id` is derived from a board's column `status_filter` rather than
+ *   stored on the item, so ONLY the board-items response
+ *   (`GET /api/llc/boards/{id}/items`) carries it.
  */
 
 /**
@@ -37,7 +42,8 @@ export interface WorkItem {
   priority: WorkItemPriority
   story_points: number | null
   assignee_name: string | null
-  assignee_type?: 'human' | 'agent' | null
+  // GH#13993: backend only ever writes 'user' | 'agent' (never 'human').
+  assignee_type?: 'user' | 'agent' | null
   // Assignment keyspace (#10032): agent = AgentOrgNode UUID PK, user = user UUID.
   assignee_agent_id?: string | null
   assignee_user_id?: string | null


### PR DESCRIPTION
Closes #13993, #13954

## Thinking Path

**Canonical shape decision: the backend is right, the frontend read was the bug.**

`GET /api/llc/boards/{id}/items` returns `{"board": ..., "columns": [...]}` with each column carrying its own `items` array. That nesting is the correct shape — column membership is *derived* from each column's `status_filter`, not stored on the work item, so the grouping only exists in the context of a board. Flattening to a top-level `items` array would throw away the very relationship the endpoint exists to compute, and would force every caller to re-derive it. Three of the four callers also want the per-column grouping anyway. So: **keep the nested response, fix the readers.**

Verified each of the issue's three claims against the code rather than trusting the text — all three were correct:

1. **Response shape.** `boards.py` `get_board_items()` has no top-level `items` key. `KanbanBoardView.vue` read `itemsData.items`, which is `undefined` on that shape, so `items.value` was unconditionally `[]`.
2. **Missing fields.** `grep -n "assignee_type" autobot-backend/llc/api/boards.py` returned nothing — `_work_item_summary()` emitted neither `assignee_type` nor `column_id`, so even a correctly-flattened array would fail every column and swimlane filter.
3. **Vocabulary (#13954).** The backend only ever writes `"user"` / `"agent"`, never `"human"` (`services/handoff.py`, `services/work_item_service.py`, `api/work_items.py:263`). `KanbanBoardView.vue:159` compared against `'human'`, and `workItemTypes.ts` typed the field `'human' | 'agent' | null` — a union that does not even contain the value the backend sends, so this needed a type change, not just a comparison change.

**Two things the issue did not list, found by grepping every caller of the endpoint rather than only the two files named:**

- **`GanttTimelineView.vue:420` has the same bug.** It read `boardItems.items ?? []` into `scopedItemIds`, so any board-scoped timeline (`?board=`, #11701) resolved to an empty id set and filtered the entire roadmap down to zero rows. Same root cause, same endpoint, same one-line fix — fixed here rather than filed separately.
- **`GanttTimelineView.spec.ts:62` is why nothing caught this.** Its fixture mocked `{ items: [...] }` — a shape the API never returns. The test asserted the *broken* contract, so it stayed green while the feature was dead. Corrected the fixture to the real nested shape; that alone turns the suite red until the view is fixed. This is the concrete mechanism behind the "shipped with tests and displayed nothing" question in the issue: the tests encoded the bug.

**Enum SSOT:** PR #13955 (which adds `AssigneeType`) has **not** merged, so `AssigneeType` does not exist in `llc/models/enums.py` on this base. The backend change avoids the question entirely by passing `item.assignee_type` straight through — no literal is written backend-side. The `'user' | 'agent'` union in `workItemTypes.ts` is frontend-side and mirrors what the API sends. The `CoWorkerType {agent,human}` vs assignee `{user,agent}` vocabulary fork is **#13970** and is deliberately not touched here.

## What Changed

- **`autobot-backend/llc/api/boards.py`** — `_work_item_summary()` now takes `column_id` and emits it plus `assignee_type`. `column_id` is passed in by the caller because it is derived from the column's `status_filter`, not stored on the item. The endpoint declares no `response_model`, so the added keys reach the client unfiltered (verified).
- **`autobot-frontend/src/views/llc/KanbanBoardView.vue`** — `fetchBoard()` flattens `columns[].items` instead of reading the nonexistent top-level `items`; `humanItems()` filters on `'user'`.
- **`autobot-frontend/src/views/llc/SprintBoardView.vue`** — same flattening fix, identical bug against the same endpoint.
- **`autobot-frontend/src/views/llc/GanttTimelineView.vue`** — same flattening fix in `loadBoardScope()`; board-scoped timelines no longer collapse to zero rows.
- **`autobot-frontend/src/views/llc/workItemTypes.ts`** — `assignee_type` retyped `'user' | 'agent' | null`. Rewrote the provenance comment, which was inverted in the original *and* still inaccurate in my first pass: `assignee_type` is emitted by **both** the work-items response (`work_items.py:381`) and (now) the board-items response; only `column_id` is board-items-only.
- **`autobot-frontend/src/composables/llc/useKanbanBoardsApi.ts`** — header comment advertised five calls including `items`, which was never implemented there. Corrected to the four that exist.
- **Tests** — new `test_board_items_shape_13993.py` (3), `KanbanBoardView.items.test.ts` (5), `SprintBoardView.items.test.ts` (4); corrected the `GanttTimelineView.spec.ts` fixture.

### Review round 2 — my own fixtures repeated the defect

Review found that two of my new fixtures lied about `GET /api/llc/boards/{id}` in exactly the way this PR exists to fix. That was correct and is now fixed. `_board_response` (`boards.py:72-91`) emits columns as `{id, name, position, status_filter, wip_limit}` and has no `sprint` / `burndown` key at all.

| Fixture claimed | API sends | Consequence | Outcome |
|---|---|---|---|
| `columns[].title` | `columns[].name` | every column header renders blank | **fixed in this PR** (both views) |
| `status_mapping` | `status_filter` | unused type, wrong either way | **fixed in this PR** |
| top-level `sprint` + `burndown` | neither exists | sprint header never renders, burndown always empty | **filed as #14074**, fixture corrected, assertions pin today's real behaviour |

All three fixtures now mirror `_board_response` field-for-field. The `title`→`name` correction turned the suites red exactly as predicted, which is what made the blank-header defect visible; it is fixed here because it is a one-word change in the same two views. The sprint/burndown defect needs a call on whether the board endpoint stays a pure board projection, so it is filed rather than guessed at — the fixture is honest and the new test documents the broken behaviour so it fails loudly when #14074 lands.

Also switched `test_board_items_shape_13993.py` off `patch.stopall()` (which tears down every started patch in the process, not just this module's) to scoped `with patch(...)` context management.

## Verification

Baselines measured on this branch, not quoted.

**Backend** — `venv/bin/python -m pytest llc/tests/ -q`:
```
1482 passed, 2 skipped, 29 warnings in 151.25s (0:02:31)
```

**Frontend** — `npx vitest run src/views/llc/__tests__/`:
```
Test Files  11 passed (11)
     Tests  66 passed (66)
```

**Commit subjects** — `code-quality` was red because `scripts/lint-conventions.sh:215` allows `[a-z0-9._-]` in a scope, with no `/`, so `fix(llc/frontend):` was rejected. History rebuilt linearly on current `Dev_new_gui` as three commits, all scoped `(llc)`, each verified against that exact regex:
```
PASS: fix(llc): read board items from the nested column shape the API sends (#13993)
PASS: fix(llc): flatten nested board items in the Gantt board scope (#13993)
PASS: docs(llc): correct the boards composable call list (#13993)
```
The rebuilt tree is byte-identical to the reviewed one (`git diff --stat <old> HEAD` empty).

**Lint** — `npm run lint` (oxlint **and** eslint): exit 0.
**Type-check** — `npm run type-check` (`vue-tsc --noEmit`): exit 0.
**Hardcoded values** — `bash pipeline-scripts/check-pre-commit-hook-pr.sh pre-commit-hardcoded-values`: `No violations found!`

### Mutation proof

Each fix was reverted, the suite re-run to confirm it goes **red**, then restored to confirm **green**. A test that only asserts a component mounted would survive all four; these do not.

**A — revert the flatten in Kanban + Sprint** → 6/6 red, including the "board renders no cards" assertion:
```
× flattens columns[].items from the board-items response into items
× renders a card per item — the board is not empty when the backend has items
× assigns each item to its column via column_id from the response
× swimlane split uses the backend vocabulary ("user"), not "human"
× flattens columns[].items from the board-items response into items      (Sprint)
× renders a card — the sprint board is not empty when the backend has items
AssertionError: expected [] to deeply equal [ 'wi-1', 'wi-2' ]
AssertionError: expected [] to have a length of 2 but got +0
AssertionError: expected undefined to be 'col-ready'
Test Files  2 failed (2)
     Tests  6 failed (6)
```

**B — revert only the vocabulary fix (`'user'` → `'human'`)** → the swimlane test isolates it; the other three still pass, so the assertion is specific rather than incidental:
```
✓ flattens columns[].items from the board-items response into items
✓ renders a card per item — the board is not empty when the backend has items
✓ assigns each item to its column via column_id from the response
× swimlane split uses the backend vocabulary ("user"), not "human"
AssertionError: expected [ DOMWrapper{ …(3) } ] to have a length of 2 but got 1
Tests  1 failed | 3 passed (4)
```

**C — drop `assignee_type` + `column_id` from `_work_item_summary()`** → 2/3 red (the third only asserts nesting, which defect 2 does not affect, so it correctly survives):
```
FAILED llc/tests/test_board_items_shape_13993.py::TestBoardItemsShape::test_each_item_carries_assignee_type_and_column_id
FAILED llc/tests/test_board_items_shape_13993.py::TestBoardItemsShape::test_assignee_type_vocabulary_is_user_not_human
2 failed, 1 passed, 5 warnings in 3.31s
```

**D — revert the Gantt flatten, against the corrected fixture** → 2/3 red with zero rows; the no-scope test correctly survives because it never fetches board items:
```
× scopes the timeline to the sprint board when opened with a board query
✓ renders the whole company timeline (no scope) when no board query is present
× clears the scope and returns to the company-wide roadmap
AssertionError: expected [] to have a length of 2 but got +0
Tests  2 failed | 1 passed (3)
```

**E — revert the column-header fix (`col.name` → `col.title`)**, against the corrected fixtures → 2 red, and the failure is literally the blank header:
```
× renders each column header from the `name` the board API actually sends   (Kanban)
× renders the column header from the `name` the board API actually sends    (Sprint)
AssertionError: expected [ '', '' ] to deeply equal [ 'Ready', 'In Progress' ]
AssertionError: expected [ '' ] to deeply equal [ 'Ready' ]
Tests  2 failed | 7 passed (9)
```

**Restored → green**, full suite: `Test Files 11 passed (11) / Tests 66 passed (66)`.

No UI strings were added or changed — the fix is data plumbing only — so no i18n changes were required across the 11 locales.

**#13954 delivery check:** its stated fix (option 1, frontend type + comparison to the backend vocabulary) is fully delivered — `workItemTypes.ts:46` is `'user' | 'agent' | null` and `KanbanBoardView.vue:159` compares `=== 'user'`. `grep -rn "assignee_type" autobot-frontend/src` confirms no `'human'` literal remains anywhere in the frontend. Closing it here.

### Filed, not fixed here

- **#14074** — `SprintBoardView` reads `sprint` and `burndown` from the board endpoint, which sends neither: the sprint header never renders and the burndown is permanently the empty state. The data exists (`GET /api/llc/sprints/{id}/burndown`, `sprints.py:1082`); the view never asks for it. Reproduction attached; the new test pins the broken behaviour.
- **#14075** — board cards are an 11-field summary typed as a full `WorkItem`. `openDetail()` passes `props.item` straight to `WorkItemDetail` without refetching, so the drawer opens with a blank description and empty acceptance criteria. Latent before this PR (nothing was clickable when the board rendered zero cards) and reachable now — it is a pre-existing defect this fix exposes, not one it introduces.
- **#14062** — hand-written fixtures assert API shapes the backend never returns; **#14064** — load failures render as a legitimately empty board.

**AC not met:** none. All four items in the issue's "Ask" are addressed.

## Model Used

Opus 5 (1M context)
