### PR TITLE
fix(packaging): register autobot_shared itself, not its submodules, in the editable install (#14035)

### DIFF
--- a/.github/workflows/startup-import-smoke.yml
+++ b/.github/workflows/startup-import-smoke.yml
@@ -98,6 +98,23 @@ jobs:
             exit 1
           }
 
+      # #14035: this is the only CI job that runs `pip install -e autobot_shared`
+      # (the sharded python-suite job relies on pytest.ini's `pythonpath =`
+      # instead), so it is the only place a broken editable-install mapping can
+      # actually be caught. The guard skips itself everywhere else.
+      - name: Run editable-install packaging guard
+        run: |
+          python -m pytest autobot_shared/editable_install_layout_test.py -v --tb=short || {
+            echo ""
+            echo "autobot_shared editable-install packaging guard FAILED (#14035)."
+            echo ""
+            echo "The editable finder is registering autobot_shared's submodules"
+            echo "as top-level names instead of (or in addition to) autobot_shared"
+            echo "itself. Check autobot_shared/pyproject.toml's"
+            echo "[tool.setuptools]/[tool.setuptools.packages.find] config."
+            exit 1
+          }
+
       # #13041: this guard has stdlib-only deps (ast/pathlib — no imports of
       # backend modules) and was never collected by any CI workflow, letting
       # the raw-ClientSession ceiling silently regress 12->13 unnoticed. This

--- a/autobot_shared/editable_install_layout_test.py
+++ b/autobot_shared/editable_install_layout_test.py
@@ -101,3 +101,28 @@ def test_submodules_not_registered_as_top_level_names(polluted_name):
         "autobot_shared's submodules as top-level package names again (#14035).\n"
         f"stdout:\n{result.stdout}"
     )
+
+
+@pytest.mark.parametrize(
+    "repo_root_sibling",
+    ["scripts", "tools", "docs", "main", "conftest", "tasks", "security", "data"],
+)
+def test_repo_root_not_leaked_onto_sys_path(repo_root_sibling):
+    """A `package-dir = {"" = ...}` root mapping is a DIFFERENT bug, not a fix.
+
+    A single ""-keyed `package-dir` entry makes setuptools' editable-install
+    `_select_strategy()` take the `_StaticPth` branch, which writes a raw
+    `.pth` line adding the ENTIRE resolved source directory to `sys.path` —
+    it never consults `include`/`exclude`. Pointed at the repo root, that
+    puts every sibling of `autobot_shared/` (`scripts/`, `tools/`,
+    `main.py`, `conftest.py`, ...) on `sys.path` as a bare top-level name —
+    the same bug class #14035 exists to close, at a far larger blast
+    radius than the original 16 submodules.
+    """
+    result = _run_in_other_cwd(f"import {repo_root_sibling}")
+    assert result.returncode != 0, (
+        f"`import {repo_root_sibling}` unexpectedly succeeded from a "
+        "non-repo-root cwd — the editable install is leaking the repo "
+        "root itself onto sys.path (#14035).\n"
+        f"stdout:\n{result.stdout}"
+    )

--- a/autobot_shared/editable_install_layout_test.py
+++ b/autobot_shared/editable_install_layout_test.py
@@ -1,0 +1,103 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Editable-install packaging guard (#14035).
+
+`autobot_shared/pyproject.toml` lives INSIDE the package directory it
+describes (`autobot_shared/pyproject.toml`, not `<repo>/pyproject.toml`).
+A naive `[tool.setuptools.packages.find]` with `where = ["."]` treats the
+*contents* of `autobot_shared/` (`auth/`, `browser/`, `components/`, ...)
+as top-level installable packages, and never registers `autobot_shared`
+itself. `pip show autobot_shared` still reports the package installed —
+only the editable finder's mapping is wrong.
+
+Running pytest from the repo root cannot catch this: the repo root sits
+on `sys.path[0]`, so `import autobot_shared` "works" via a plain
+filesystem lookup regardless of what the editable install actually
+registered. These tests spawn a subprocess from a cwd that is NOT the
+repo root, using the *installed* interpreter (`sys.executable`), so only
+the real package-discovery mapping is exercised — cwd cannot mask a
+regression here.
+
+The main sharded `python-suite` CI job (ci.yml) never runs `pip install
+-e ./autobot_shared` — it relies entirely on `pytest.ini`'s `pythonpath =
+. autobot-backend autobot_shared ...` to make imports resolve, the same
+cwd-adjacent mechanism this bug hides behind. This module is collected
+by that job too (it globs the whole `autobot_shared/` tree), so these
+tests skip themselves there rather than failing on an environment that
+never claims to have installed the package. `startup-import-smoke.yml`
+DOES run `pip install -e autobot_shared` and is where this guard is
+meant to bite.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import shutil
+import subprocess
+import sys
+import tempfile
+
+import pytest
+
+
+def _autobot_shared_is_pip_installed() -> bool:
+    """True only where this interpreter has real distribution metadata.
+
+    A bare checkout on `pythonpath`/`PYTHONPATH` has no dist-info at all —
+    `import autobot_shared` can still "work" there via cwd, which is
+    exactly the masking this guard exists to bypass.
+    """
+    try:
+        importlib.metadata.distribution("autobot_shared")
+        return True
+    except importlib.metadata.PackageNotFoundError:
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _autobot_shared_is_pip_installed(),
+    reason=(
+        "autobot_shared has no pip distribution metadata in this interpreter "
+        "(a bare checkout on pythonpath/PYTHONPATH, not a real `pip install "
+        "-e`) — the editable-install mapping this guard checks does not apply."
+    ),
+)
+
+
+def _run_in_other_cwd(code: str) -> subprocess.CompletedProcess[str]:
+    """Run `code` with `sys.executable` from a cwd that is not the repo root."""
+    tmp_dir = tempfile.mkdtemp(prefix="autobot_shared_editable_guard_")
+    try:
+        return subprocess.run(
+            [sys.executable, "-c", code],
+            cwd=tmp_dir,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+
+
+def test_autobot_shared_importable_outside_repo_root():
+    """The editable install must register `autobot_shared`, not rely on cwd."""
+    result = _run_in_other_cwd("import autobot_shared")
+    assert result.returncode == 0, (
+        "`import autobot_shared` failed from a non-repo-root cwd — the "
+        "editable install does not register the top-level package (#14035).\n"
+        f"stderr:\n{result.stderr}"
+    )
+
+
+@pytest.mark.parametrize("polluted_name", ["auth", "browser", "components", "code_graph"])
+def test_submodules_not_registered_as_top_level_names(polluted_name):
+    """Submodules of autobot_shared must not shadow generic top-level names."""
+    result = _run_in_other_cwd(f"import {polluted_name}")
+    assert result.returncode != 0, (
+        f"`import {polluted_name}` unexpectedly succeeded from a "
+        "non-repo-root cwd — the editable install is registering "
+        "autobot_shared's submodules as top-level package names again (#14035).\n"
+        f"stdout:\n{result.stdout}"
+    )

--- a/autobot_shared/pyproject.toml
+++ b/autobot_shared/pyproject.toml
@@ -44,6 +44,16 @@ test = [
     "pytest-asyncio>=0.24",
 ]
 
+[tool.setuptools]
+# pyproject.toml lives INSIDE the package directory it describes
+# (autobot_shared/pyproject.toml, not <repo>/pyproject.toml), so the
+# package source root is one level up from this file.
+package-dir = { "" = ".." }
+
 [tool.setuptools.packages.find]
-where = ["."]
-exclude = ["tests*", "*_test*"]
+# Rooted one level up so setuptools registers the "autobot_shared"
+# directory itself as the top-level package, instead of treating its
+# contents (auth/, browser/, components/, ...) as top-level packages.
+where = [".."]
+include = ["autobot_shared", "autobot_shared.*"]
+exclude = ["autobot_shared.tests*", "autobot_shared.*_test*"]

--- a/autobot_shared/pyproject.toml
+++ b/autobot_shared/pyproject.toml
@@ -46,9 +46,21 @@ test = [
 
 [tool.setuptools]
 # pyproject.toml lives INSIDE the package directory it describes
-# (autobot_shared/pyproject.toml, not <repo>/pyproject.toml), so the
-# package source root is one level up from this file.
-package-dir = { "" = ".." }
+# (autobot_shared/pyproject.toml, not <repo>/pyproject.toml). Mapping the
+# "autobot_shared" package name (NOT the "" root key) to "." tells
+# setuptools that THIS directory IS the autobot_shared package's source.
+#
+# A `{"" = ".."}` root mapping looks equivalent but is not: with a single
+# ""-keyed entry setuptools' editable-install `_select_strategy()` takes
+# the `_StaticPth` branch, which writes a raw .pth line adding the ENTIRE
+# resolved ".." directory (the repo root) to sys.path — it never consults
+# include/exclude. That put every repo-root sibling (scripts/, tools/,
+# main.py, conftest.py, ...) on sys.path as bare top-level names, which is
+# the same bug class #14035 exists to close, at a larger blast radius.
+# Keying on the real package name instead makes setuptools use
+# `_TopLevelFinder`, a meta-path finder scoped to exactly the packages
+# `packages.find` discovered below.
+package-dir = { "autobot_shared" = "." }
 
 [tool.setuptools.packages.find]
 # Rooted one level up so setuptools registers the "autobot_shared"


### PR DESCRIPTION
Closes #14035

## Thinking Path

`autobot_shared/pyproject.toml` lives *inside* the package directory it describes (`autobot_shared/pyproject.toml`, not `<repo>/pyproject.toml`). Its `[tool.setuptools.packages.find]` had `where = ["."]`, which is relative to the pyproject.toml's own directory — so setuptools discovered the *contents* of `autobot_shared/` (`auth/`, `browser/`, `components/`, `code_graph/`, ...) as 16 top-level installable packages, and never discovered a package named `autobot_shared` at all. `pip show autobot_shared` still reports the distribution installed (dist-info is fine); only the editable finder's `MAPPING` is wrong.

Two consequences, both reproduced directly:
1. `import autobot_shared` fails from any cwd that isn't the repo root (a systemd `WorkingDirectory`, a script invoked by absolute path, anything not run from repo root).
2. Inside the venv, `import auth` / `import components` / `import browser` resolve into `autobot_shared`'s submodules — a namespace collision hazard.

It survives because almost everything in this repo runs `python -m pytest ...` (or similar) from the repo root, where the repo root itself lands on `sys.path[0]` and masks the broken install — `import autobot_shared` "works" via a plain filesystem lookup, not because of what pip actually registered.

**Revision (post-review):** the first version of this fix used `package-dir = {"" = ".."}`. That looks like the standard "root discovery one level up" idiom, but with a single `""`-keyed entry, setuptools' editable-install `_select_strategy()` takes the `_StaticPth` branch, which writes a raw `.pth` line adding the *entire* resolved `".."` directory (the repo root) to `sys.path` — it never consults `include`/`exclude`. Verified in a throwaway venv: `scripts`, `tools`, `docs`, `main`, `conftest`, `security`, `tasks`, `data` all became importable as bare top-level names from `/tmp`. That reproduces the exact bug class #14035 exists to close, at a much larger blast radius than the original 16 submodules. Corrected to `package-dir = {"autobot_shared" = "."}` — keying on the real package name (not the root key) makes setuptools use `_TopLevelFinder`, a meta-path finder scoped to exactly the packages `packages.find` discovers.

## What Changed

- `autobot_shared/pyproject.toml`: `[tool.setuptools] package-dir = {"autobot_shared" = "."}` (declares "this directory IS the autobot_shared package's source") plus `[tool.setuptools.packages.find]` with `where = [".."]` and `include = ["autobot_shared", "autobot_shared.*"]` (excluding `autobot_shared.tests*` / `autobot_shared.*_test*` as before, now dotted).
- `autobot_shared/editable_install_layout_test.py` (new): regression guard. Spawns a subprocess with `sys.executable` from a cwd that is **not** the repo root (a fresh tempdir), so cwd-on-`sys.path` cannot mask a regression. Asserts:
  - `import autobot_shared` succeeds outside the repo root.
  - `auth` / `browser` / `components` / `code_graph` (autobot_shared's own submodules) do NOT resolve as bare top-level names.
  - `scripts` / `tools` / `docs` / `main` / `conftest` / `tasks` / `security` / `data` (repo-root siblings) do NOT resolve as bare top-level names either — this is the case that caught the `{"" = ".."}` regression; the original guard only checked autobot_shared's own submodules and stayed green through that bug.

  Skips itself (via `importlib.metadata.distribution("autobot_shared")` presence) in the main sharded `python-suite` CI job, which never runs `pip install -e ./autobot_shared` at all (it relies on `pytest.ini`'s `pythonpath =` instead) — that job would otherwise always fail this test regardless of the fix, since no real editable install exists there.
- `.github/workflows/startup-import-smoke.yml`: added a step that runs the guard right after this workflow's existing `pip install -e autobot_shared` — the only CI job that performs a real editable install of `autobot_shared`, so the only place this class of regression can be caught.

## Verification

All validated in throwaway venvs under the worktree/scratchpad — **the shared repo venv (`venv/`) was never reinstalled into**, per the task constraint.

**Reproduction of the original bug (before either fix, real `pip install -e ./autobot_shared`):**
```
$ cd /tmp && python -c "import autobot_shared"
ModuleNotFoundError: No module named 'autobot_shared'

$ python -c "import auth; print(auth.__file__)"   # from /tmp
<repo>/autobot_shared/auth/__init__.py             # pollution — succeeds when it shouldn't

$ grep -o "^MAPPING.*" .../__editable___autobot_shared_1_0_0_finder.py
MAPPING: dict[str, str] = {'api_routing': ..., 'auth': ..., 'browser': ..., ... 16 entries, no 'autobot_shared'}
```

**Reproduction of the review-caught regression (`{"" = ".."}` variant, real `pip install -e ./autobot_shared`):**
```
$ cd /tmp && python -c "
import importlib.util
for name in ['tools', 'main', 'conftest']:
    spec = importlib.util.find_spec(name)
    print(name, '->', spec.origin if spec else None)
"
tools    -> <repo>/tools/__init__.py
main     -> <repo>/main.py
conftest -> <repo>/conftest.py

$ cat .../__editable__.autobot_shared-1.0.0.pth
<repo>          # the raw StaticPth line — entire repo root on sys.path
```

**After the corrected fix (`{"autobot_shared" = "."}`, fresh `pip install -e ./autobot_shared`):**
```
$ grep -o "^MAPPING.*" .../__editable___autobot_shared_1_0_0_finder.py
MAPPING: dict[str, str] = {'autobot_shared': '<repo>/autobot_shared'}   # exactly one entry

$ cd /tmp && python -c "import autobot_shared; print(autobot_shared.__file__)"
<repo>/autobot_shared/__init__.py                  # succeeds, from outside the repo root

$ python -c "import auth"      # from /tmp -> ModuleNotFoundError
$ python -c "import tools"     # from /tmp -> ModuleNotFoundError
$ python -c "import main"      # from /tmp -> ModuleNotFoundError
$ python -c "import conftest"  # from /tmp -> ModuleNotFoundError

$ cat .../autobot_shared-1.0.0.dist-info/top_level.txt
autobot_shared

$ python -m build --wheel --no-isolation   # from autobot_shared/
Successfully built autobot_shared-1.0.0-py3-none-any.whl   # 490 files, zero repo-root siblings in the RECORD
```

**Widened regression guard, before/after (identical committed test file, three throwaway venvs):**
- `{"" = ".."}` regression config: `8 failed, 5 passed` — the 8 new `test_repo_root_not_leaked_onto_sys_path` cases (`scripts`/`tools`/`docs`/`main`/`conftest`/`tasks`/`security`/`data`) all fail, exactly the case the original guard missed.
- Corrected `{"autobot_shared" = "."}` config: `13 passed`.
- No `pip install -e` at all (bare checkout, `pythonpath`-only — the shape of the main CI shard): `13 skipped` — the guard correctly declines to judge an environment that never claims to have installed the package.

## Pre-existing issues noted, not fixed here (reviewer-confirmed, out of scope for this PR)

- `exclude` in `packages.find` matches *package* names only (directories with `__init__.py`), not module files — 158 `*_test.py` files still ship inside the built wheel. Pre-existing behavior of the original `exclude = ["tests*", "*_test*"]` too; unchanged by this PR either way.
- `.github/workflows/phase_validation.yml` also runs `pip install -e ./autobot_shared` but does not run this guard. `startup-import-smoke.yml` is the one wired up in this PR since it's the workflow with the tightest scope match (backend-import smoke testing).

## Reinstall required

This is a packaging-metadata fix only. **Landing this code does not, by itself, fix anyone's existing checkout.** Anyone who already ran `pip install -e ./autobot_shared` against the old (or the reverted `{"" = ".."}`) config still has the broken mapping in their venv's `__editable__.autobot_shared-1.0.0.pth`/finder until they reinstall. To pick up the fix:
```
pip uninstall -y autobot_shared
pip install -e ./autobot_shared
```
(or equivalent for whichever venv/environment is affected). CI is unaffected going forward since `startup-import-smoke.yml` always does a fresh `pip install -e autobot_shared` per run; the main sharded `python-suite` job doesn't install it at all and is unaffected either way.

## Model Used

Sonnet 5
