### PR TITLE
fix(config): route 6 highest-risk /opt/autobot runtime defaults through project_root() (#13149)

### DIFF
--- a/autobot-backend/api/codebase_analytics/source_paths.py
+++ b/autobot-backend/api/codebase_analytics/source_paths.py
@@ -4,7 +4,12 @@
 
 from pathlib import Path
 
-CODE_SOURCES_BASE: Path = Path("/opt/autobot/data/code-sources")
+from autobot_shared.paths import project_root
+
+# #13149: derived from the canonical project root instead of a hardcoded
+# `/opt/autobot` literal, so a dev checkout clones sources under the checkout
+# rather than reading/writing the live install's clone directory.
+CODE_SOURCES_BASE: Path = project_root() / "data" / "code-sources"
 
 
 def make_clone_path(source_id: str) -> str:

--- a/autobot-backend/api/codebase_analytics/source_paths_test.py
+++ b/autobot-backend/api/codebase_analytics/source_paths_test.py
@@ -1,0 +1,69 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for CODE_SOURCES_BASE's canonical project-root default (#13149).
+
+Before this fix ``CODE_SOURCES_BASE`` was a module-level literal hardcoding
+``/opt/autobot/data/code-sources`` — every dev checkout cloned code sources
+into (or read them from) the live install's directory. It now derives from
+``autobot_shared.paths.project_root()``.
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import api.codebase_analytics.source_paths as source_paths
+from autobot_shared.paths import project_root
+
+
+def test_code_sources_base_is_not_the_live_install():
+    """The property that matters: a dev run must not resolve under /opt/autobot."""
+    assert not str(source_paths.CODE_SOURCES_BASE).startswith("/opt/autobot")
+
+
+def test_code_sources_base_is_wired_to_the_canonical_resolver():
+    """Not just 'some path comes back' — it must be *this checkout's* root."""
+    assert source_paths.CODE_SOURCES_BASE == project_root() / "data" / "code-sources"
+
+
+def test_code_sources_base_tracks_project_root_env_override(monkeypatch, tmp_path):
+    """Changing AUTOBOT_PROJECT_ROOT changes the derived default, proving the
+    site is actually wired through project_root() rather than re-hardcoded
+    under a different name."""
+    fake_root = tmp_path / "fake-checkout"
+    fake_root.mkdir()
+    monkeypatch.setenv("AUTOBOT_PROJECT_ROOT", str(fake_root))
+
+    reloaded = importlib.reload(source_paths)
+    try:
+        assert reloaded.CODE_SOURCES_BASE == fake_root / "data" / "code-sources"
+    finally:
+        monkeypatch.delenv("AUTOBOT_PROJECT_ROOT", raising=False)
+        importlib.reload(source_paths)
+
+
+def test_deployed_install_still_resolves_to_the_original_default(monkeypatch):
+    """Compositional check for the deployed case.
+
+    A real host resolves ``project_root()`` to ``/opt/autobot`` via the
+    ``.env``-walk (verified separately in ``autobot_shared/paths_test.py``'s
+    ``TestDeployedInstall`` and confirmed on a live host per #13149's comment
+    thread). ``AUTOBOT_PROJECT_ROOT`` is the resolver's first-priority branch
+    and reaches the same value without requiring a real ``/opt/autobot`` tree
+    on this machine, so it is used here to prove *composition* — that when
+    project_root() is ``/opt/autobot``, this call site reproduces the exact
+    previous literal, byte for byte, and does not additionally break the
+    deployed case with an extra path segment or a different join order.
+    Confirming the resolver's own branch selection on a real deployed host is
+    out of scope for a hermetic test — no host was available to verify this
+    beyond that compositional guarantee.
+    """
+    monkeypatch.setenv("AUTOBOT_PROJECT_ROOT", "/opt/autobot")
+
+    reloaded = importlib.reload(source_paths)
+    try:
+        assert reloaded.CODE_SOURCES_BASE == Path("/opt/autobot/data/code-sources")
+    finally:
+        monkeypatch.delenv("AUTOBOT_PROJECT_ROOT", raising=False)
+        importlib.reload(source_paths)

--- a/autobot-backend/cli/doctor.py
+++ b/autobot-backend/cli/doctor.py
@@ -110,9 +110,22 @@ def _bootstrap_chromadb_collections(missing: set[str]) -> None:
         client.get_or_create_collection(name)
 
 
-def check_env_file(env_path: str = "/opt/autobot/autobot-backend/.env") -> CheckResult:
-    """Validate required environment variables are present."""
+def check_env_file(env_path: str | None = None) -> CheckResult:
+    """Validate required environment variables are present.
+
+    #13149: the default used to be a hardcoded `/opt/autobot` literal, so the
+    diagnostic always read the *live install's* `.env` regardless of which
+    checkout invoked it. It now resolves through the canonical project root,
+    computed lazily (not as a mutable-default-style module-import-time
+    literal) so tests can still override it and the resolver is only invoked
+    on the code path that needs it.
+    """
     import os
+
+    from autobot_shared.paths import project_root
+
+    if env_path is None:
+        env_path = str(project_root() / "autobot-backend" / ".env")
 
     required_vars = [
         "OLLAMA_HOST",

--- a/autobot-backend/cli/doctor.py
+++ b/autobot-backend/cli/doctor.py
@@ -224,9 +224,9 @@ def run_doctor(fix: bool = False) -> int:
 
     if fix:
         if fixable:
-            print(
+            print(  # noqa: print  # canonical: ignore py-print-smoke
                 f"Auto-repairing {len(fixable)} fixable issue(s)..."
-            )  # noqa: print  # canonical: ignore py-print-smoke
+            )
             for r in fixable:
                 try:
                     r.fix()
@@ -235,17 +235,17 @@ def run_doctor(fix: bool = False) -> int:
                     print(f"  Failed to fix {r.name}: {exc}")  # noqa: print  # canonical: ignore py-print-smoke
         manual = [r for r in failures if not r.fixable]
         if manual:
-            print(
+            print(  # noqa: print  # canonical: ignore py-print-smoke
                 f"{len(manual)} issue(s) require manual intervention."
-            )  # noqa: print  # canonical: ignore py-print-smoke
+            )
             return 1
         return 0
     else:
         auto_fixable = len(fixable)
         manual = len(failures) - auto_fixable
-        print(
+        print(  # noqa: print  # canonical: ignore py-print-smoke
             f"Run `autobot doctor --fix` to auto-repair ({auto_fixable} fixable, {manual} manual)."
-        )  # noqa: print  # canonical: ignore py-print-smoke
+        )
         return 1
 
 

--- a/autobot-backend/security_layer.py
+++ b/autobot-backend/security_layer.py
@@ -23,6 +23,7 @@ from typing import Any, Dict, List
 from autobot_shared.async_compat import run_or_schedule
 from autobot_shared.auth.permissions import ROLE_PERMISSIONS, Permission, Role
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.paths import project_root
 from autobot_shared.ssot_config import config
 from config import get_config_manager
 from secure_command_executor import CommandRisk, SecureCommandExecutor, SecurityPolicy
@@ -31,7 +32,10 @@ logger = get_logger(__name__)
 
 # Audit log file path resolved from AUTOBOT_AUDIT_LOG_FILE env var at import time.
 # Set AUTOBOT_AUDIT_LOG_FILE to override the default path.
-_AUDIT_LOG_FILE_DEFAULT = "/opt/autobot/logs/audit.log"
+# #13149: derived from the canonical project root rather than a hardcoded
+# `/opt/autobot` literal, so a dev checkout writes its audit log under the
+# checkout instead of (attempting to write into) the live install.
+_AUDIT_LOG_FILE_DEFAULT = str(project_root() / "logs" / "audit.log")
 
 
 def _resolve_audit_log_file() -> str:

--- a/autobot-backend/security_layer_test.py
+++ b/autobot-backend/security_layer_test.py
@@ -6,16 +6,19 @@ Tests integrated security features including role-based access and command execu
 """
 
 import asyncio
+import importlib
 import json
 import os
 import tempfile
+from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from secure_command_executor import CommandRisk
-
 # Import the modules to test
+import security_layer
+from autobot_shared.paths import project_root
+from secure_command_executor import CommandRisk
 from security_layer import SecurityLayer
 
 
@@ -505,6 +508,50 @@ class TestSecurityLayerIntegration:
         assert "Command forbidden" in result["stderr"]
         assert result["security"]["risk"] == "forbidden"
         assert result["security"]["blocked"] is True
+
+
+class TestAuditLogFileDefault:
+    """_AUDIT_LOG_FILE_DEFAULT's canonical project-root fallback (#13149).
+
+    Before this fix it was a module-level literal hardcoding
+    ``/opt/autobot/logs/audit.log`` — reached whenever
+    ``AUTOBOT_AUDIT_LOG_FILE``/``config.audit_log_file`` was empty. It now
+    derives from ``autobot_shared.paths.project_root()``.
+    """
+
+    def test_default_is_not_the_live_install(self):
+        """The property that matters: a dev run must not resolve under /opt/autobot."""
+        assert not security_layer._AUDIT_LOG_FILE_DEFAULT.startswith("/opt/autobot")
+
+    def test_default_is_wired_to_the_canonical_resolver(self):
+        assert security_layer._AUDIT_LOG_FILE_DEFAULT == str(project_root() / "logs" / "audit.log")
+
+    def test_default_tracks_project_root_env_override(self, monkeypatch, tmp_path):
+        fake_root = tmp_path / "fake-checkout"
+        fake_root.mkdir()
+        monkeypatch.setenv("AUTOBOT_PROJECT_ROOT", str(fake_root))
+
+        reloaded = importlib.reload(security_layer)
+        try:
+            assert reloaded._AUDIT_LOG_FILE_DEFAULT == str(fake_root / "logs" / "audit.log")
+        finally:
+            monkeypatch.delenv("AUTOBOT_PROJECT_ROOT", raising=False)
+            importlib.reload(security_layer)
+
+    def test_deployed_install_still_resolves_to_the_original_default(self, monkeypatch):
+        """Compositional check for the deployed case — see the equivalent test
+        in ``source_paths_test.py`` for why AUTOBOT_PROJECT_ROOT stands in for
+        the real ``.env``-walk here, and why full host verification is out of
+        scope for a hermetic test.
+        """
+        monkeypatch.setenv("AUTOBOT_PROJECT_ROOT", "/opt/autobot")
+
+        reloaded = importlib.reload(security_layer)
+        try:
+            assert reloaded._AUDIT_LOG_FILE_DEFAULT == str(Path("/opt/autobot/logs/audit.log"))
+        finally:
+            monkeypatch.delenv("AUTOBOT_PROJECT_ROOT", raising=False)
+            importlib.reload(security_layer)
 
 
 # Run tests

--- a/autobot-backend/services/autoresearch/config.py
+++ b/autobot-backend/services/autoresearch/config.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from autobot_shared.paths import project_root
 from autobot_shared.ssot_config import config
 from constants.model_constants import ANTHROPIC_CLAUDE_SONNET4_6
 
@@ -21,9 +22,12 @@ from constants.model_constants import ANTHROPIC_CLAUDE_SONNET4_6
 class AutoResearchConfig:
     """Configuration for the autoresearch experiment runner."""
 
-    # Path to the cloned autoresearch repo on the GPU node
+    # Path to the cloned autoresearch repo on the GPU node.
+    # #13149: falls back to the canonical project root instead of a hardcoded
+    # `/opt/autobot` literal, so a dev checkout resolves under the checkout
+    # rather than the live install when AUTOBOT_AUTORESEARCH_DIR is unset.
     autoresearch_dir: Path = field(
-        default_factory=lambda: Path(config.misc.autoresearch_dir or "/opt/autobot/autoresearch")
+        default_factory=lambda: Path(config.misc.autoresearch_dir or str(project_root() / "autoresearch"))
     )
 
     # Training defaults
@@ -72,9 +76,10 @@ class AutoResearchConfig:
     meta_agent_test_timeout: int = field(default_factory=lambda: int(config.meta_agent_test_timeout))
     meta_agent_approval_threshold: float = field(default_factory=lambda: float(config.meta_agent_approval_threshold))
 
-    # Data directory for experiment outputs
+    # Data directory for experiment outputs.
+    # #13149: same checkout-relative fallback as autoresearch_dir above.
     data_dir: Path = field(
-        default_factory=lambda: Path(config.misc.autoresearch_data_dir or "/opt/autobot/autoresearch/data")
+        default_factory=lambda: Path(config.misc.autoresearch_data_dir or str(project_root() / "autoresearch" / "data"))
     )
 
     # Human-in-the-loop research checkpoints (issue #3291)

--- a/autobot-backend/services/autoresearch/config_test.py
+++ b/autobot-backend/services/autoresearch/config_test.py
@@ -1,0 +1,90 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for AutoResearchConfig's canonical project-root fallbacks (#13149).
+
+``autoresearch_dir`` and ``data_dir`` used to fall back to hardcoded
+``/opt/autobot/autoresearch[...]`` literals whenever the corresponding SSOT
+config value was unset or blank. A dev checkout with no
+``AUTOBOT_AUTORESEARCH_DIR``/``AUTOBOT_AUTORESEARCH_DATA_DIR`` set therefore
+pointed the autoresearch runner at the live install. Both now fall back to
+``autobot_shared.paths.project_root()``.
+
+Both fields are ``default_factory`` lambdas evaluated lazily at instance
+construction (not at module import), so these tests build a fresh
+``AutoResearchConfig()`` per case rather than reloading the module.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from autobot_shared.paths import project_root
+from autobot_shared.ssot_config import config
+from services.autoresearch.config import AutoResearchConfig
+
+
+def _clear_ssot_overrides(monkeypatch) -> None:
+    """Force both SSOT fields blank, exercising the ``or <fallback>`` branch
+    regardless of what the host running the test has configured."""
+    monkeypatch.setattr(config.misc, "autoresearch_dir", "")
+    monkeypatch.setattr(config.misc, "autoresearch_data_dir", "")
+
+
+def test_autoresearch_dir_is_not_the_live_install(monkeypatch):
+    """The property that matters: a dev run must not resolve under /opt/autobot."""
+    _clear_ssot_overrides(monkeypatch)
+
+    cfg = AutoResearchConfig()
+
+    assert not str(cfg.autoresearch_dir).startswith("/opt/autobot")
+
+
+def test_data_dir_is_not_the_live_install(monkeypatch):
+    _clear_ssot_overrides(monkeypatch)
+
+    cfg = AutoResearchConfig()
+
+    assert not str(cfg.data_dir).startswith("/opt/autobot")
+
+
+def test_autoresearch_dir_is_wired_to_the_canonical_resolver(monkeypatch):
+    _clear_ssot_overrides(monkeypatch)
+
+    cfg = AutoResearchConfig()
+
+    assert cfg.autoresearch_dir == project_root() / "autoresearch"
+
+
+def test_data_dir_is_wired_to_the_canonical_resolver(monkeypatch):
+    _clear_ssot_overrides(monkeypatch)
+
+    cfg = AutoResearchConfig()
+
+    assert cfg.data_dir == project_root() / "autoresearch" / "data"
+
+
+def test_ssot_override_still_wins_over_the_fallback(monkeypatch, tmp_path):
+    """The fallback only fires when the SSOT value is blank — an explicit
+    operator setting must still take priority, exactly as before."""
+    explicit = tmp_path / "explicit-autoresearch"
+    monkeypatch.setattr(config.misc, "autoresearch_dir", str(explicit))
+    monkeypatch.setattr(config.misc, "autoresearch_data_dir", "")
+
+    cfg = AutoResearchConfig()
+
+    assert cfg.autoresearch_dir == Path(str(explicit))
+
+
+def test_deployed_install_still_resolves_to_the_original_default(monkeypatch):
+    """Compositional check for the deployed case — see the equivalent test in
+    ``source_paths_test.py`` for why AUTOBOT_PROJECT_ROOT stands in for the
+    real ``.env``-walk here, and why full host verification is out of scope
+    for a hermetic test.
+    """
+    _clear_ssot_overrides(monkeypatch)
+    monkeypatch.setenv("AUTOBOT_PROJECT_ROOT", "/opt/autobot")
+
+    cfg = AutoResearchConfig()
+
+    assert cfg.autoresearch_dir == Path("/opt/autobot/autoresearch")
+    assert cfg.data_dir == Path("/opt/autobot/autoresearch/data")

--- a/autobot-backend/services/execution/snapshot_index.py
+++ b/autobot-backend/services/execution/snapshot_index.py
@@ -19,10 +19,14 @@ from pathlib import Path
 from typing import Dict, List, Optional
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.paths import project_root
 
 logger = get_logger(__name__)
 
-_DEFAULT_SNAPSHOT_PATH = "/opt/autobot/snapshots"
+# #13149: derived from the canonical project root instead of a hardcoded
+# `/opt/autobot` literal, so a dev checkout stores its snapshot index under
+# the checkout rather than the live install's snapshot directory.
+_DEFAULT_SNAPSHOT_PATH = str(project_root() / "snapshots")
 _INDEX_FILENAME = "snapshot_index.json"
 
 _SNAPSHOT_STORAGE_PATH: str = os.getenv("AUTOBOT_SNAPSHOT_STORAGE_PATH", _DEFAULT_SNAPSHOT_PATH)

--- a/autobot-backend/services/execution/snapshot_index_test.py
+++ b/autobot-backend/services/execution/snapshot_index_test.py
@@ -1,0 +1,55 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for _DEFAULT_SNAPSHOT_PATH's canonical project-root default (#13149).
+
+Before this fix ``_DEFAULT_SNAPSHOT_PATH`` was a module-level literal
+hardcoding ``/opt/autobot/snapshots`` — a dev run with
+``AUTOBOT_SNAPSHOT_STORAGE_PATH`` unset would index (and attempt to write)
+container snapshots under the live install. It now derives from
+``autobot_shared.paths.project_root()``.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import services.execution.snapshot_index as snapshot_index
+from autobot_shared.paths import project_root
+
+
+def test_default_snapshot_path_is_not_the_live_install():
+    """The property that matters: a dev run must not resolve under /opt/autobot."""
+    assert not snapshot_index._DEFAULT_SNAPSHOT_PATH.startswith("/opt/autobot")
+
+
+def test_default_snapshot_path_is_wired_to_the_canonical_resolver():
+    assert snapshot_index._DEFAULT_SNAPSHOT_PATH == str(project_root() / "snapshots")
+
+
+def test_default_snapshot_path_tracks_project_root_env_override(monkeypatch, tmp_path):
+    fake_root = tmp_path / "fake-checkout"
+    fake_root.mkdir()
+    monkeypatch.setenv("AUTOBOT_PROJECT_ROOT", str(fake_root))
+
+    reloaded = importlib.reload(snapshot_index)
+    try:
+        assert reloaded._DEFAULT_SNAPSHOT_PATH == str(fake_root / "snapshots")
+    finally:
+        monkeypatch.delenv("AUTOBOT_PROJECT_ROOT", raising=False)
+        importlib.reload(snapshot_index)
+
+
+def test_deployed_install_still_resolves_to_the_original_default(monkeypatch):
+    """Compositional check for the deployed case — see the equivalent test in
+    ``source_paths_test.py`` for why AUTOBOT_PROJECT_ROOT stands in for the
+    real ``.env``-walk here, and why full host verification is out of scope
+    for a hermetic test.
+    """
+    monkeypatch.setenv("AUTOBOT_PROJECT_ROOT", "/opt/autobot")
+
+    reloaded = importlib.reload(snapshot_index)
+    try:
+        assert reloaded._DEFAULT_SNAPSHOT_PATH == "/opt/autobot/snapshots"
+    finally:
+        monkeypatch.delenv("AUTOBOT_PROJECT_ROOT", raising=False)
+        importlib.reload(snapshot_index)

--- a/autobot-backend/tests/cli/test_doctor.py
+++ b/autobot-backend/tests/cli/test_doctor.py
@@ -7,6 +7,7 @@
 Issue #7371: each repair is a discrete idempotent function with a unit test.
 """
 
+from autobot_shared.paths import project_root
 from cli.doctor import (
     CheckResult,
     check_env_file,
@@ -33,6 +34,53 @@ def test_check_env_file_missing(tmp_path):
     result = check_env_file(str(tmp_path / "nonexistent.env"))
     assert not result.ok
     assert "not found" in result.message
+
+
+def test_check_env_file_default_is_not_the_live_install():
+    """#13149: the default used to be a hardcoded `/opt/autobot` literal, so
+    the diagnostic always read the live install's `.env` regardless of which
+    checkout invoked it. Calling with no arg (as ALL_CHECKS does) must not
+    resolve under /opt/autobot."""
+    result = check_env_file()
+
+    assert "/opt/autobot" not in result.message
+
+
+def test_check_env_file_default_is_wired_to_the_canonical_resolver():
+    result = check_env_file()
+
+    expected = str(project_root() / "autobot-backend" / ".env")
+    assert expected in result.message
+
+
+def test_check_env_file_default_tracks_project_root_env_override(monkeypatch, tmp_path):
+    fake_root = tmp_path / "fake-checkout"
+    (fake_root / "autobot-backend").mkdir(parents=True)
+    monkeypatch.setenv("AUTOBOT_PROJECT_ROOT", str(fake_root))
+
+    result = check_env_file()
+
+    assert str(fake_root / "autobot-backend" / ".env") in result.message
+
+
+def test_check_env_file_default_matches_original_literal_when_deployed(monkeypatch):
+    """Compositional check for the deployed case — see the equivalent test in
+    ``source_paths_test.py`` for why AUTOBOT_PROJECT_ROOT stands in for the
+    real ``.env``-walk here, and why full host verification is out of scope
+    for a hermetic test.
+
+    Whether this dev machine can even stat ``/opt/autobot`` varies (it may
+    not exist, or exist with restricted permissions owned by the deployed
+    service account) — either way the diagnostic must fail closed and name
+    the exact path the original hardcoded literal pointed at, proving the
+    composed default is unchanged for a real deployment.
+    """
+    monkeypatch.setenv("AUTOBOT_PROJECT_ROOT", "/opt/autobot")
+
+    result = check_env_file()
+
+    assert result.ok is False
+    assert "/opt/autobot/autobot-backend/.env" in result.message
 
 
 def test_check_env_file_ok(tmp_path):
@@ -87,6 +135,7 @@ def test_run_doctor_fix_fixable(capsys, monkeypatch):
     monkeypatch.setattr("cli.doctor.ALL_CHECKS", [fake_check])
     rc = run_doctor(fix=True)
     assert fixed == [1]
+    assert rc == 0
 
 
 def test_run_doctor_fix_manual_items_return_1(capsys, monkeypatch):


### PR DESCRIPTION
Refs #13149

This is **Slice A** of #13149 (per the [2026-08-11 slice-decomposition comment](https://github.com/mrveiss/AutoBot-AI/issues/13149#issuecomment-latest)). It does **not** close #13149 — Slices B (Ansible), C1/C2 (infra scripts) and D (frontend literals) are still open, tracked separately.

## Thinking Path

#13149's stale headline numbers (60 literals / 34 shell scripts) mostly already shipped via #13652/#13646/#13659. The owner's latest audit found the remainder is split into risk tiers: 28 `autobot-infrastructure/` scripts are untidy-but-harmless (they create local junk paths), while **6 files / 7 sites** are genuinely dangerous — they default to `/opt/autobot`, so a dev run with no explicit override can read or write the *live install's* state (audit log, code-source clones, snapshot index, autoresearch dirs, `.env`).

I confirmed each of the 6 named sites still carried the literal on the current `Dev_new_gui` tip before changing anything, and found no additional dangerous sites in those same files beyond the 7 already identified.

**One thing worth flagging that I did *not* fix, because it's outside this slice's named files:** `autobot_shared/ssot_config.py:1424` has `audit_log_file: str = Field(default="/opt/autobot/logs/audit.log", ...)`. Because that field's default is always truthy, `security_layer.py`'s own fallback (`_AUDIT_LOG_FILE_DEFAULT`, fixed here) is only reached when `AUTOBOT_AUDIT_LOG_FILE` is explicitly set to an empty string — the *actual* controlling default for a normal dev run is the `ssot_config.py` one, which this PR does not touch since it's a different file than the 6 named in Slice A. Flagging for a follow-up rather than expanding scope unilaterally.

## What Changed

All six sites now derive from the existing, stdlib-only `autobot_shared/paths.py::project_root()` resolver instead of a hardcoded `/opt/autobot` literal — no new constant, env var, or resolver was added, per the task constraint:

- `autobot-backend/security_layer.py` — `_AUDIT_LOG_FILE_DEFAULT`
- `autobot-backend/api/codebase_analytics/source_paths.py` — `CODE_SOURCES_BASE`
- `autobot-backend/services/execution/snapshot_index.py` — `_DEFAULT_SNAPSHOT_PATH`
- `autobot-backend/services/autoresearch/config.py` — `autoresearch_dir`, `data_dir` (2 sites)
- `autobot-backend/cli/doctor.py` — `check_env_file`'s default `env_path` (changed from a module-import-time literal default to a lazily-computed `None` sentinel, since the diagnostic must resolve the *current* checkout, not whatever was true at import time)

## Verification

**Tests added** (68 collected, all pass), one file per module plus additions to the two files that already had test coverage:

```
autobot-backend/api/codebase_analytics/source_paths_test.py   (new)
autobot-backend/services/execution/snapshot_index_test.py     (new)
autobot-backend/services/autoresearch/config_test.py          (new)
autobot-backend/security_layer_test.py                        (+TestAuditLogFileDefault)
autobot-backend/tests/cli/test_doctor.py                      (+4 cases)
```

Each site has 3-4 tests asserting the actual property that matters — *not* "some path comes back":

1. **the resolved default does not start with `/opt/autobot`** (the regression this PR fixes)
2. **the resolved default equals `project_root() / <suffix>`** exactly (wired to the resolver, not re-hardcoded under a new name)
3. **changing `AUTOBOT_PROJECT_ROOT` changes the derived value** (proves live wiring, not a coincidental match)
4. **a compositional check for the deployed case** — forcing `project_root()` to resolve to `/opt/autobot` (via `AUTOBOT_PROJECT_ROOT`, the resolver's own first-priority branch) reproduces the *exact original literal*, proving these call sites don't additionally break a real deployment by changing the join order or adding a segment

```
$ ./venv/bin/python -m pytest -q \
    autobot-backend/api/codebase_analytics/source_paths_test.py \
    autobot-backend/services/execution/snapshot_index_test.py \
    autobot-backend/services/autoresearch/config_test.py \
    autobot-backend/security_layer_test.py \
    autobot-backend/tests/cli/test_doctor.py \
    autobot_shared/paths_test.py
68 passed
```

Also ran the existing suites for every caller of these modules to confirm no regressions:

```
$ ./venv/bin/python -m pytest -q autobot-backend/tests/test_autoresearch.py \
    autobot-backend/tests/test_execution_backends.py \
    autobot-backend/api/codebase_analytics/source_service_test.py \
    autobot-backend/api/codebase_analytics/source_delete_service_test.py
101 passed, 2 skipped
```

**Mutation testing**: reverted each of the 5 changed source files one at a time (via `git stash push -- <file>`), confirmed via `git diff` that the revert actually changed the file (not a no-op), reran that file's new tests, confirmed 3-4 of them fail as expected (the "deployed case" compositional test correctly still passes, since it asserts equality with the *original* literal), then restored the fix and confirmed `git status` was clean again. All 5 mutations were killed.

**Deployed-case verification — could not be done against a real host.** I don't have access to the production `/opt/autobot` install, so the "deployed case" tests above simulate it by forcing `project_root()` to resolve to `/opt/autobot` via `AUTOBOT_PROJECT_ROOT` (the resolver's env-var branch) rather than the real `.env`-walk branch a live host actually takes. That proves each call site *composes* the value correctly once `project_root()` returns `/opt/autobot` — it does not re-verify that `project_root()` itself takes that branch on a real host (that's already covered by `autobot_shared/paths_test.py::TestDeployedInstall`, and was separately confirmed on a live host per #13149's comment thread for the resolver itself, not for these specific call sites). Saying this explicitly rather than assuming it's covered.

Lint clean: `black`, `isort`, `flake8` (via `venv/bin/python`) on all 10 touched files.

## Model Used

Sonnet 5
