### PR TITLE
fix(ci): hardcoded-value guard misses category/mode literals inside comprehensions (#14005)

### DIFF
--- a/autobot-backend/api/knowledge_search.py
+++ b/autobot-backend/api/knowledge_search.py
@@ -531,7 +531,7 @@ async def search(request: SearchRequest, req: Request):
     - **query** (required): Search query string
     - **limit** / **top_k**: Maximum results (default: 10, max: 100)
     - **category**: Filter by category
-    - **mode**: Search mode — 'semantic', 'keyword', 'hybrid' (default), 'auto'
+    - **mode**: Search mode — `semantic`, `keyword`, `hybrid` (default), `auto`
     - **enable_rag**: Enable RAG enhancement for synthesized responses
     - **enable_reranking**: Enable cross-encoder reranking
     - **reformulate_query**: Expand query for better coverage

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-hardcoded-values
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-hardcoded-values
@@ -324,13 +324,26 @@ check_hardcoded_categories() {
     while IFS= read -r line; do
         ((line_num++))
 
-        # Skip comments
-        if [[ "$line" =~ ^[[:space:]]*# ]] || [[ "$line" =~ ^[[:space:]]*// ]]; then
+        # Skip comments. Includes JSDoc/block-comment continuation lines
+        # (`* ...`) — the fixed quote class below now also matches
+        # single-quoted literals, which surfaced `* - mode: 'a' | 'b'`-style
+        # doc comments in .ts files as false positives (review of #14005).
+        if [[ "$line" =~ ^[[:space:]]*# ]] || [[ "$line" =~ ^[[:space:]]*// ]] || [[ "$line" =~ ^[[:space:]]*\* ]]; then
             continue
         fi
 
         # Skip if using CategoryDefaults
         if echo "$line" | grep -qE '(CategoryDefaults\.|GENERAL|UNKNOWN|SEARCH_MODE)'; then
+            continue
+        fi
+
+        # Skip TypeScript/Flow string-literal union types, e.g.
+        # `mode?: 'semantic' | 'keyword' | 'hybrid' | 'auto'` — a type
+        # annotation enumerating the accepted values, not a hardcoded
+        # default. Same surfacing as the comment case above: the fixed
+        # quote class now matches these once single-quoted values are
+        # visible at all.
+        if echo "$line" | grep -qE '["'"'"'][[:space:]]*\|[[:space:]]*["'"'"']'; then
             continue
         fi
 
@@ -342,10 +355,21 @@ check_hardcoded_categories() {
         # through the keyword-style pattern whether or not it sits inside a
         # comprehension (#14005) — the comprehension itself isn't the cause, the
         # missing operator is.
-        if echo "$line" | grep -qE '(category|search_mode|mode)[^a-z_]*[=:][^=]*["\x27](general|hybrid|unknown)["\x27]' || \
-           echo "$line" | grep -qE '["\x27](category|search_mode|mode)["\x27][[:space:]]*,[[:space:]]*["\x27](general|hybrid|unknown)["\x27]'; then
+        #
+        # Quote class is a LITERAL apostrophe inside the bracket expression
+        # (["'](...)["']), not `["\x27]`. Backslash has no special meaning
+        # inside a POSIX bracket expression under GNU grep, so `["\x27]`
+        # matches one of the five literal characters ", \, x, 2, 7 — never an
+        # apostrophe — and every single-quoted literal (`'general'`) silently
+        # passed both alternatives. Caught in review of #14005.
+        #
+        # The call-argument alternative is anchored to `.get(` so it only
+        # matches an actual dict-style lookup, not any comma-joined pair of
+        # matching string literals (e.g. a tuple literal or an assertion).
+        if echo "$line" | grep -qE '(category|search_mode|mode)[^a-z_]*[=:][^=]*["'"'"'](general|hybrid|unknown)["'"'"']' || \
+           echo "$line" | grep -qE '\.get\([[:space:]]*["'"'"'](category|search_mode|mode)["'"'"'][[:space:]]*,[[:space:]]*["'"'"'](general|hybrid|unknown)["'"'"']'; then
             local value
-            value=$(echo "$line" | grep -oE '["\x27](general|hybrid|unknown)["\x27]' | head -1)
+            value=$(echo "$line" | grep -oE '["'"'"'](general|hybrid|unknown)["'"'"']' | head -1)
             echo -e "${RED}VIOLATION${NC} $file:$line_num"
             echo "  Hardcoded category/mode string: $value"
             echo -e "  ${CYAN}Fix: Use CategoryDefaults.GENERAL/SEARCH_MODE_HYBRID/UNKNOWN${NC}"

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-hardcoded-values
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-hardcoded-values
@@ -334,8 +334,16 @@ check_hardcoded_categories() {
             continue
         fi
 
-        # Check for category="general" or mode="hybrid" patterns
-        if echo "$line" | grep -qE '(category|search_mode|mode)[^a-z_]*[=:][^=]*["\x27](general|hybrid|unknown)["\x27]'; then
+        # Check for category="general" or mode="hybrid" patterns (keyword-style:
+        # assignment, dict literal value, function default) AND the call-argument
+        # shape `d.get("category", "general")` — the key is a STRING LITERAL
+        # positional argument, not an identifier bound with `=`/`:`, so it has no
+        # operator between the field name and the default value. That shape falls
+        # through the keyword-style pattern whether or not it sits inside a
+        # comprehension (#14005) — the comprehension itself isn't the cause, the
+        # missing operator is.
+        if echo "$line" | grep -qE '(category|search_mode|mode)[^a-z_]*[=:][^=]*["\x27](general|hybrid|unknown)["\x27]' || \
+           echo "$line" | grep -qE '["\x27](category|search_mode|mode)["\x27][[:space:]]*,[[:space:]]*["\x27](general|hybrid|unknown)["\x27]'; then
             local value
             value=$(echo "$line" | grep -oE '["\x27](general|hybrid|unknown)["\x27]' | head -1)
             echo -e "${RED}VIOLATION${NC} $file:$line_num"

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-hardcoded-values_test.py
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-hardcoded-values_test.py
@@ -375,6 +375,21 @@ class TestHardcodedCategories:
         assert result.returncode != 0
         assert "general" in result.stdout
 
+    def test_blocks_single_quoted_call_argument(self, tmp_path: Path) -> None:
+        # Regression for review of #14005: `["\x27]` in a POSIX bracket
+        # expression is NOT "double or single quote" — backslash has no
+        # special meaning inside `[...]` under GNU grep, so that class only
+        # ever matched one of the five literal characters ", \, x, 2, 7 and
+        # never an apostrophe. Every single-quoted literal silently passed
+        # both alternatives. Shape taken verbatim from the real miss found by
+        # the repo-wide audit: autobot-backend/agents/kb_librarian/librarian.py:50.
+        result = _run_hook_with_staged(
+            tmp_path,
+            {"src/q.py": "def c(tool_info):\n    return f\"- Category: {tool_info.get('category', 'general')}\"\n"},
+        )
+        assert result.returncode != 0
+        assert "general" in result.stdout
+
     def test_allows_category_via_constants(self, tmp_path: Path) -> None:
         result = _run_hook_with_staged(
             tmp_path,
@@ -392,6 +407,48 @@ class TestHardcodedCategories:
         result = _run_hook_with_staged(
             tmp_path,
             {"src/q.py": 'ids = [doc.get("id", "unknown_id") for doc in docs]\n'},
+        )
+        assert result.returncode == 0
+
+    def test_allows_matching_pair_outside_a_get_call(self, tmp_path: Path) -> None:
+        # The call-argument alternative is anchored to `.get(` so a
+        # comma-joined pair of matching string literals elsewhere — a tuple
+        # literal, an assertion — doesn't false-positive just because the
+        # vocabulary happens to line up.
+        result = _run_hook_with_staged(
+            tmp_path,
+            {"src/q.py": 'CATEGORIES = ("category", "general")\n'},
+        )
+        assert result.returncode == 0
+
+    def test_allows_jsdoc_block_comment_continuation(self, tmp_path: Path) -> None:
+        # Regression from the repo-wide audit (review of #14005): fixing the
+        # quote class to actually match single-quoted literals surfaced
+        # `*`-prefixed JSDoc continuation lines — the hook's comment skip
+        # only recognized `#`/`//` prefixes, not `*` block-comment
+        # continuations. Deliberately a SINGLE quoted value (no ` | `) so
+        # this test exercises the comment skip alone, not the union-type
+        # skip below — a mutation dropping the `\*` comment skip must fail
+        # THIS test independent of the union-type one.
+        result = _run_hook_with_staged(
+            tmp_path,
+            {
+                "src/q.ts": ("/**\n" " * mode: 'general'\n" " */\n" "export const x = 1\n"),
+            },
+        )
+        assert result.returncode == 0
+
+    def test_allows_typescript_string_literal_union_type(self, tmp_path: Path) -> None:
+        # Same audit finding: `mode?: 'semantic' | 'keyword' | 'hybrid' |
+        # 'auto'` is a TS union-type annotation enumerating accepted values,
+        # not a hardcoded default assignment — must stay unflagged.
+        result = _run_hook_with_staged(
+            tmp_path,
+            {
+                "src/types.ts": (
+                    "export interface Options {\n" "  mode?: 'semantic' | 'keyword' | 'hybrid' | 'auto'\n" "}\n"
+                ),
+            },
         )
         assert result.returncode == 0
 

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-hardcoded-values_test.py
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-hardcoded-values_test.py
@@ -17,7 +17,6 @@ on exit code + output.
 from __future__ import annotations
 
 import os
-import shutil
 import subprocess
 from pathlib import Path
 
@@ -316,12 +315,62 @@ class TestHardcodedRoles:
 
 @pytest.mark.skipif(not HOOK_PATH.exists(), reason="hook script missing at expected path")
 class TestHardcodedCategories:
-    """check_hardcoded_categories: blocks `category="general"` literals."""
+    """check_hardcoded_categories: blocks `category="general"` literals.
 
-    def test_blocks_hardcoded_category_string(self, tmp_path: Path) -> None:
+    Issue #14005: the rule catches "keyword-style" shapes (an identifier bound
+    to the literal with `=`/`:`) but was blind to the "call-argument" shape —
+    a STRING-LITERAL key followed by a positional default, e.g.
+    ``doc.get("category", "general")`` — because there is no `=`/`:` between
+    the field name and the value in that shape. It doesn't matter whether that
+    call sits inside a comprehension or not; the missing operator is the gap,
+    not the comprehension. One test per shape the rule intends to catch.
+    """
+
+    def test_blocks_plain_assignment(self, tmp_path: Path) -> None:
+        result = _run_hook_with_staged(
+            tmp_path,
+            {"src/q.py": 'category = "general"\n'},
+        )
+        assert result.returncode != 0
+        assert "general" in result.stdout
+
+    def test_blocks_dict_literal_value(self, tmp_path: Path) -> None:
         result = _run_hook_with_staged(
             tmp_path,
             {"src/q.py": 'q = {"category": "general"}\n'},
+        )
+        assert result.returncode != 0
+        assert "general" in result.stdout
+
+    def test_blocks_function_default(self, tmp_path: Path) -> None:
+        result = _run_hook_with_staged(
+            tmp_path,
+            {"src/q.py": 'def search(category="general"):\n    pass\n'},
+        )
+        assert result.returncode != 0
+        assert "general" in result.stdout
+
+    def test_blocks_call_argument(self, tmp_path: Path) -> None:
+        # #14005 reproduction, line 4 of the issue — already caught before the
+        # fix because of the surrounding `category = ` assignment. Kept as a
+        # standalone call-argument case with no assignment wrapper at all.
+        result = _run_hook_with_staged(
+            tmp_path,
+            {"src/q.py": 'def b(req):\n    return req.get("category", "general")\n'},
+        )
+        assert result.returncode != 0
+        assert "general" in result.stdout
+
+    def test_blocks_literal_inside_comprehension(self, tmp_path: Path) -> None:
+        # #14005 reproduction, line 2 of the issue — the exact case that was
+        # missed: same literal, same meaning, invisible only because it sits
+        # inside a `set(... for ...)` comprehension rather than a plain
+        # assignment.
+        result = _run_hook_with_staged(
+            tmp_path,
+            {
+                "src/q.py": ("def a(docs):\n" '    return len(set(doc.get("category", "general") for doc in docs))\n'),
+            },
         )
         assert result.returncode != 0
         assert "general" in result.stdout
@@ -331,6 +380,31 @@ class TestHardcodedCategories:
             tmp_path,
             {
                 "src/q.py": ("from constants import CategoryDefaults\n" 'q = {"category": CategoryDefaults.GENERAL}\n'),
+            },
+        )
+        assert result.returncode == 0
+
+    def test_allows_unrelated_key_in_comprehension(self, tmp_path: Path) -> None:
+        # Ordinary code: neither the key nor the default is one of the
+        # category/mode literals the rule targets — must stay unflagged so
+        # the widened call-argument pattern doesn't turn into a blanket
+        # "any .get() with two string args" false positive.
+        result = _run_hook_with_staged(
+            tmp_path,
+            {"src/q.py": 'ids = [doc.get("id", "unknown_id") for doc in docs]\n'},
+        )
+        assert result.returncode == 0
+
+    def test_allows_comprehension_using_category_defaults(self, tmp_path: Path) -> None:
+        # Same call-argument shape as the reproduction, but the default is
+        # already the SSOT constant — must stay unflagged.
+        result = _run_hook_with_staged(
+            tmp_path,
+            {
+                "src/q.py": (
+                    "from constants import CategoryDefaults\n"
+                    'cats = [doc.get("category", CategoryDefaults.GENERAL) for doc in docs]\n'
+                ),
             },
         )
         assert result.returncode == 0


### PR DESCRIPTION
Closes #14005

## Thinking Path

`check_hardcoded_categories` in `autobot-infrastructure/shared/scripts/hooks/pre-commit-hardcoded-values` used a single "keyword-style" regex — `identifier[^a-z_]*[=:][^=]*"value"` — that requires an `=`/`:` operator directly between the field name and the literal. That covers plain assignment, dict-literal values, and function defaults, but not the **call-argument shape**: `d.get("category", "general")`, where the field name is itself a string-literal positional argument and there is no operator between it and the default. Whether that call sits inside a comprehension is incidental — the missing operator is the actual gap, confirmed by reproducing the exact two-line fixture from the issue and showing only the assignment-style line was reported.

Fix: add a second alternative pattern that matches the quoted-key-comma-quoted-value shape directly (`"category", "general"`), anchored to `.get(` so it only fires on an actual dict-style lookup, combined with the existing pattern in a single `if` so a line matching both never double-reports.

**Review caught a second, independent bug in both alternatives**: `["\x27]` inside a POSIX bracket expression is NOT "double or single quote" — backslash has no special meaning inside `[...]` under GNU grep, so that class matches one of the five literal characters `"`, `\`, `x`, `2`, `7`, never an apostrophe. Every single-quoted literal (`'general'`) silently passed both alternatives, before and after my first pass at this fix. Corrected both alternatives to use a literal apostrophe inside the bracket expression (`["'](...)["']`).

Fixing the quote class to actually match single-quoted literals surfaced two new false-positive shapes in the repo-wide re-scan (see Verification): JSDoc/block-comment continuation lines (`* - mode: 'a' | 'b'`, not covered by the existing `#`/`//`-only comment skip) and TypeScript string-literal union types (`mode?: 'semantic' | 'keyword' | 'hybrid' | 'auto'`, a type annotation, not a hardcoded default). Both are now skipped explicitly. A third false positive — a Python docstring enumerating accepted values with straight quotes — was fixed at the source by rewording the one affected docstring line in `autobot-backend/api/knowledge_search.py` to use markdown code-spans instead of straight quotes (a documentation-only change, zero behavior change).

Audited the sibling checks in the same file for the same class of gap (issue asked to widen category/mode and audit port/timeout/limit):
- `check_hardcoded_ports` — value-based match (`:8001`), unaffected — still fires inside a comprehension or call argument.
- `check_hardcoded_roles`, `check_hardcoded_timeouts`, `check_magic_numbers` — share the exact same keyword-style regex shape and the same call-argument gap. `check_hardcoded_roles` additionally carries the identical `["\x27]` quote-class bug found here. Scoped OUT of this PR per the issue's acceptance criteria (category/mode only); filed as #14048, updated to include the quote-class bug alongside the call-argument gap.

The repo-wide re-scan under the final pattern surfaced 10 pre-existing real violations invisible to the old pattern. Fixing those touches business-logic files unrelated to the CI script itself, so they're filed as #14047 (fast-follow) rather than folded into this detector PR.

## What Changed

- `autobot-infrastructure/shared/scripts/hooks/pre-commit-hardcoded-values`: `check_hardcoded_categories` now also matches the call-argument shape (`"category", "general"` / `"mode", "hybrid"` / `"search_mode", "unknown"` etc. inside a `.get(...)` call, anchored to `.get(`), independent of whether it appears inside a comprehension, and matches that shape (and the pre-existing keyword-style shape) for **both** single- and double-quoted literals. Added two false-positive guards: skip `*`-prefixed block-comment continuation lines, and skip TypeScript/Flow string-literal union types (`'a' | 'b'`).
- `autobot-backend/api/knowledge_search.py`: reworded one API docstring line to use markdown code-spans instead of straight quotes, removing the one false positive that couldn't be closed with a general-purpose guard (a comma-separated value enumeration inside a Python docstring).
- `autobot-infrastructure/shared/scripts/hooks/pre-commit-hardcoded-values_test.py`: one test per shape the rule intends to catch — plain assignment, dict literal value, function default, call argument, comprehension (the issue's exact reproduction), and a single-quoted call argument (the exact shape review found still slipping through after the first pass) — plus false-positive guards for: unrelated key/value pair in a comprehension, comprehension using the SSOT `CategoryDefaults` constant, a matching pair outside a `.get()` call, a JSDoc block-comment continuation line, and a TypeScript union type. Also dropped an unused `import shutil` in the same test file (pre-existing flake8 F401, unrelated to the fix but trivial and in the file already being touched).

## Verification

Reproduction (before any fix) — only the assignment line was reported:
```
$ bash autobot-infrastructure/shared/scripts/hooks/pre-commit-hardcoded-values debug/probe_14005.py
VIOLATION debug/probe_14005.py:4
  Line:     category = req.get("category", "general")
COMMIT BLOCKED: 1 violation(s) found
```

After the final fix — all three shapes reported, including the single-quoted call argument:
```
VIOLATION debug/probe_14005.py:2
  Line:     return len(set(doc.get("category", "general") for doc in docs))
VIOLATION debug/probe_14005.py:4
  Line:     category = req.get("category", "general")
VIOLATION debug/probe_14005.py:6
  Line:     return f"- Category: {tool_info.get('category', 'general')}"
COMMIT BLOCKED: 3 violation(s) found
```

`--changed-lines-only` mode (#13950) verified end-to-end with the final pattern: a base commit with an assignment-style violation, a follow-up commit adding a single-quoted call-argument violation. `check-pre-commit-hook-pr.sh --changed-lines-only pre-commit-hardcoded-values` correctly fails on the newly-added line and reports the base-commit violation as suppressed/non-failing.

Mutation testing (each mutation confirmed applied via `md5sum`/`diff` before trusting a "survived" result):
- Reverted the call-argument alternative entirely → exactly `test_blocks_call_argument` and `test_blocks_literal_inside_comprehension` went red, 39/41 others stayed green.
- Reverted the quote class back to `["\x27]` → exactly `test_blocks_single_quoted_call_argument` went red, 9/10 `TestHardcodedCategories` others stayed green.
- Removed the `.get(` anchor → exactly `test_allows_matching_pair_outside_a_get_call` went red.
- Removed the `*`-comment skip → exactly `test_allows_jsdoc_block_comment_continuation` went red (rewritten to use a single quoted value with no ` | `, so it doesn't overlap with the union-type guard below).
- Neutered the union-type skip → exactly `test_allows_typescript_string_literal_union_type` went red.

**Repo-wide false-positive audit, final pattern, real GNU grep** (the local interactive shell's `grep` is a `ugrep`-backed shell function that is NOT exported to child `bash` processes — confirmed every invocation below actually exercises `/usr/bin/grep` (GNU grep 3.7), matching what CI runs):
- Scanned all 4,439 non-test/non-generated/non-constants `.py/.ts/.vue/.js` files under the hook's own allowlist.
- **Before (`origin/Dev_new_gui`, buggy quote class, no call-argument alternative): 26 matches.**
- **After (this PR, final): 36 matches. +10, zero false positives.**
- All 10 new matches hand-verified by reading each in context: `kb_librarian/librarian.py:50`, `system_knowledge_manager.py:647`, `doc_indexer.py:735`, `specialized_agent_service.py:170`, `DocumentationResultCard.vue:123`, `DocumentationSuggestionChip.vue:69`, `useDocumentationSearch.ts:125`, `useDocumentationSearch.ts:160`, `useKnowledgeCollaboration.ts:261`, `index_documentation.py:802` — every one is a genuine hardcoded `category`/`mode` default. Filed as #14047.
- An earlier pass (before the quote-class bug was caught) reported 34→39 with the call-argument shape unanchored and using the still-broken `["\x27]` class — that number does not reflect what was actually shipped and is superseded by the 26→36 figures above. Anchoring to `.get(` and fixing the quote class changed which specific lines are caught (adds single-quoted literals across the whole keyword-style pattern too, not just the call-argument one) but the net false-positive count is the same: zero, after the two guard additions.

```
$ ./venv/bin/python -m pytest autobot-infrastructure/shared/scripts/hooks/pre-commit-hardcoded-values_test.py -q
45 passed in 8.07s

$ ./venv/bin/python -m black --check ... && ./venv/bin/python -m isort --check-only ... && ./venv/bin/python -m flake8 ...
All done! (black) / 0 (isort) / 0 (flake8)
```

## Model Used

Claude Sonnet 5
