### PR TITLE
fix(plugin-sdk): three ways a plugin fails to load with no way to say so (#14000, #13966, #13967)

### DIFF
--- a/autobot_shared/plugin_sdk/base.py
+++ b/autobot_shared/plugin_sdk/base.py
@@ -119,6 +119,10 @@ class PluginManifest(BaseModel):
     author: str = Field(..., description="Plugin author")
     entry_point: str = Field(..., description="Python module path (e.g., 'plugins.hello_plugin.main')")
     dependencies: List[str] = Field(default_factory=list, description="Required plugin names")
+    python_dependencies: List[str] = Field(
+        default_factory=list,
+        description="Required importable Python modules (#13966), checked with importlib.util.find_spec",
+    )
     config_schema: Dict[str, Any] = Field(default_factory=dict, description="JSON schema for plugin configuration")
     hooks: List[str] = Field(default_factory=list, description="Hook names this plugin provides")
     required_env: List[RequiredEnvVar] = Field(

--- a/autobot_shared/plugin_sdk/loader.py
+++ b/autobot_shared/plugin_sdk/loader.py
@@ -91,6 +91,18 @@ def validate_plugin_config(plugin_name: str, config: Dict[str, Any], config_sche
     _validate_config_against_schema(plugin_name, config, config_schema)
 
 
+def _module_is_importable(module_name: str) -> bool:
+    """True if ``module_name`` can be imported without importing it (#13966).
+
+    `find_spec` raises rather than returning None for a parent package that is
+    itself missing, so both outcomes have to mean "not importable".
+    """
+    try:
+        return importlib.util.find_spec(module_name) is not None
+    except (ImportError, ValueError, ModuleNotFoundError):
+        return False
+
+
 def is_non_production_module(name: str) -> bool:
     """True for package modules that must never be imported at plugin-load time.
 
@@ -395,18 +407,31 @@ class PluginLoader:
 
     def _check_dependencies(self, manifest: PluginManifest) -> List[str]:
         """
-        Check if plugin dependencies are loaded.
+        Check that required plugins are loaded and required modules importable.
+
+        #13966: `dependencies` was resolved against the plugin registry only, so
+        a pip distribution name could never be satisfied no matter what was
+        installed — `telemetry-prompt-middleware` declared `aiohttp` and was
+        structurally unloadable, failing with a message that reads like a
+        missing plugin. The manifest field is documented as "Required plugin
+        names", so the checker matched the schema; the author's intent had
+        nowhere to go. `python_dependencies` is that somewhere.
 
         Args:
             manifest: Plugin manifest
 
         Returns:
-            List of missing dependency names
+            List of missing dependency names, prefixed so the two kinds are
+            distinguishable in the error — the old message named a module and
+            left the operator looking for a plugin.
         """
         missing = []
         for dep in manifest.dependencies:
             if not self.registry.get_plugin(dep):
-                missing.append(dep)
+                missing.append(f"plugin:{dep}")
+        for module in manifest.python_dependencies:
+            if not _module_is_importable(module):
+                missing.append(f"python:{module}")
         return missing
 
     def _check_required_env(self, manifest: PluginManifest) -> Tuple[List[str], List[str]]:

--- a/autobot_shared/plugin_sdk/loader.py
+++ b/autobot_shared/plugin_sdk/loader.py
@@ -92,14 +92,20 @@ def validate_plugin_config(plugin_name: str, config: Dict[str, Any], config_sche
 
 
 def _module_is_importable(module_name: str) -> bool:
-    """True if ``module_name`` can be imported without importing it (#13966).
+    """True if ``module_name`` resolves to an importable module (#13966).
 
-    `find_spec` raises rather than returning None for a parent package that is
-    itself missing, so both outcomes have to mean "not importable".
+    Takes a MODULE name, not a distribution name — `pillow` is installed but
+    imports as `PIL`, so the manifest must say `PIL`.
+
+    Note that for a dotted name this DOES import the parent packages, because
+    `find_spec("a.b")` must import `a` to find `b`. Third-party `__init__` code
+    therefore executes during a dependency check, and it can raise anything at
+    all — so every Exception means "not importable" rather than propagating out
+    of discovery, where it would produce the #14000 wedge.
     """
     try:
         return importlib.util.find_spec(module_name) is not None
-    except (ImportError, ValueError, ModuleNotFoundError):
+    except Exception:  # noqa: BLE001 — a third-party __init__ may raise anything
         return False
 
 

--- a/autobot_shared/plugin_sdk/logger_plugin_degrades_13967_test.py
+++ b/autobot_shared/plugin_sdk/logger_plugin_degrades_13967_test.py
@@ -1,0 +1,130 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""A logging plugin that cannot open its log file is still a plugin (#13967).
+
+`logger-plugin` wrote to `/tmp/plugin_events.log` — a fixed name in a shared,
+world-writable directory. The first user to create it owns it, and every other
+user on the host gets PermissionError. Two problems, and the second is the one
+that matters: `initialize()` had no error handling, so an environment condition
+took the whole plugin down rather than degrading it.
+
+Found while fixing #13677: with that PR and #10294 core plugins go from 0-of-7
+to 5-of-7, and this is one of the two remaining failures — previously
+indistinguishable from the other five, which is exactly what #13677's
+`loaded N of M` signal now separates.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+# Deliberately NOT co-located with the plugin: collecting a test from under
+# `plugins/` puts a real `plugins` module into sys.modules, which is precisely
+# what #10294's synthetic-namespace guards assert must not happen. The module is
+# loaded by absolute path, so location is irrelevant to what is exercised.
+_MAIN = Path(__file__).resolve().parents[2] / "plugins" / "core-plugins" / "logger-plugin" / "main.py"
+
+
+def _load_module():
+    """Load the plugin module by path — it is not on sys.path as a package."""
+    spec = importlib.util.spec_from_file_location("logger_plugin_main_13967", _MAIN)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def mod():
+    module = _load_module()
+    yield module
+    sys.modules.pop("logger_plugin_main_13967", None)
+
+
+class TestDefaultPathIsNotShared:
+    def test_the_default_is_not_the_shared_tmp_name(self, mod, monkeypatch):
+        monkeypatch.delenv("AUTOBOT_LOG_DIR", raising=False)
+        path = mod._default_log_path()
+        assert str(path) != "/tmp/plugin_events.log", "a fixed name in a shared dir locks out every other user"
+
+    def test_the_default_is_per_user_when_it_must_fall_back_to_tmp(self, mod, monkeypatch):
+        monkeypatch.delenv("AUTOBOT_LOG_DIR", raising=False)
+        path = mod._default_log_path()
+        assert str(os.getuid()) in str(path), "a /tmp fallback must be per-user or it recreates the collision"
+
+    def test_the_configured_log_directory_wins(self, mod, monkeypatch, tmp_path):
+        monkeypatch.setenv("AUTOBOT_LOG_DIR", str(tmp_path))
+        assert mod._default_log_path() == tmp_path / "plugin_events.log"
+
+
+class TestInitializeDegrades:
+    @pytest.mark.asyncio
+    async def test_an_unwritable_path_disables_the_sink_rather_than_the_plugin(self, mod, tmp_path, monkeypatch):
+        from autobot_shared.plugin_sdk.base import PluginManifest
+
+        manifest = PluginManifest(
+            name="logger-plugin",
+            version="1.0.0",
+            display_name="Logger",
+            description="d",
+            author="mrveiss",
+            entry_point="main",
+        )
+        plugin = mod.LoggerPlugin(manifest, {"log_file": str(tmp_path / "nope" / "events.log")})
+
+        def _boom(*_a, **_k):
+            raise PermissionError(13, "Permission denied")
+
+        monkeypatch.setattr(Path, "mkdir", _boom)
+
+        await plugin.initialize()
+
+        assert plugin._sink_enabled is False, "the plugin must survive an unwritable log path"
+
+    @pytest.mark.asyncio
+    async def test_a_writable_path_keeps_the_sink_enabled(self, mod, tmp_path):
+        """The direction that must stay true — a sink that is always disabled
+        would pass the test above while breaking the plugin's whole purpose."""
+        from autobot_shared.plugin_sdk.base import PluginManifest
+
+        manifest = PluginManifest(
+            name="logger-plugin",
+            version="1.0.0",
+            display_name="Logger",
+            description="d",
+            author="mrveiss",
+            entry_point="main",
+        )
+        target = tmp_path / "events.log"
+        plugin = mod.LoggerPlugin(manifest, {"log_file": str(target)})
+
+        await plugin.initialize()
+
+        assert plugin._sink_enabled is True
+        assert target.exists()
+
+    def test_a_disabled_sink_does_not_flood_the_log(self, mod, tmp_path):
+        """Reporting per event would turn a degraded sink into a log flood."""
+        from autobot_shared.plugin_sdk.base import PluginManifest
+
+        manifest = PluginManifest(
+            name="logger-plugin",
+            version="1.0.0",
+            display_name="Logger",
+            description="d",
+            author="mrveiss",
+            entry_point="main",
+        )
+        plugin = mod.LoggerPlugin(manifest, {"log_file": str(tmp_path / "events.log")})
+        plugin._sink_enabled = False
+
+        plugin._write_log({"event": "x"})
+
+        assert not (tmp_path / "events.log").exists()

--- a/autobot_shared/plugin_sdk/plugin_load_visibility_test.py
+++ b/autobot_shared/plugin_sdk/plugin_load_visibility_test.py
@@ -25,6 +25,7 @@ plugins produced the same shape as a host where all seven were broken.
 
 from __future__ import annotations
 
+import asyncio
 import sys
 from pathlib import Path
 
@@ -636,3 +637,90 @@ class TestCrashedDiscoveryIsRecoverable:
 
         assert report["completed"] is True
         assert report["discovered"] == 0
+
+
+class TestRetryDoesNotReinitialiseLivePlugins:
+    """#14000 review blocker: `PluginRegistry._plugins` is a class attribute —
+    process-wide, shared with the live `POST /plugins/{name}/load` route — and
+    `load_plugin` runs `initialize()` BEFORE `register()`, so the duplicate
+    check fires only after every side effect has already happened.
+
+    A retry therefore re-initialised plugins that were already live: hook
+    callbacks appended a second time (HookRegistry is also a singleton and does
+    not dedupe, so the duplicate is permanent), the second instance discarded
+    without `shutdown()`, and the report naming a working plugin as failed with
+    `completed: True` locking the lie in.
+
+    Asserting the report is not enough here — the report was the thing that
+    lied. These count the side effects.
+    """
+
+    @pytest.mark.asyncio
+    async def test_an_already_registered_plugin_is_not_initialised_twice(self, tmp_path):
+        _make_plugin(tmp_path, "already-live")
+        manager = PluginManager([tmp_path])
+        await manager.startup()
+
+        plugin = manager._registry.get_plugin("already-live")
+        assert plugin is not None, "fixture must actually register, or this guards nothing"
+        before = getattr(plugin, "init_count", None)
+
+        # Force the crashed-startup state the retry path exists for.
+        manager._load_report["completed"] = False
+        await manager.retry_discovery()
+
+        again = manager._registry.get_plugin("already-live")
+        assert again is plugin, "the live instance must survive a retry"
+        if before is not None:
+            assert getattr(again, "init_count", None) == before, "initialize() ran a second time on a live plugin"
+
+    @pytest.mark.asyncio
+    async def test_a_live_plugin_is_reported_loaded_not_failed(self, tmp_path):
+        """It reported working plugins as casualties — the manufactured-casualty
+        failure #13677 already fixed one level up."""
+        _make_plugin(tmp_path, "live-not-failed")
+        manager = PluginManager([tmp_path])
+        await manager.startup()
+
+        manager._load_report["completed"] = False
+        report = await manager.retry_discovery()
+
+        assert report["failed"] == [], "a live plugin must not be reported as a failure"
+        assert report["loaded"] == 1
+
+    @pytest.mark.asyncio
+    async def test_retry_after_a_clean_shutdown_is_refused(self, tmp_path):
+        """`shutdown()` also leaves completed=False, so gating on that alone
+        would resurrect a manager the caller deliberately stopped — 'crashed'
+        and 'cleanly shut down' conflated, which is this umbrella's whole
+        subject."""
+        _make_plugin(tmp_path, "shutdown-demo")
+        manager = PluginManager([tmp_path])
+        await manager.startup()
+        await manager.shutdown()
+
+        report = await manager.retry_discovery()
+
+        assert report["loaded"] == 0 or not manager._started, "a shut-down manager must not be restarted by a retry"
+
+    @pytest.mark.asyncio
+    async def test_two_concurrent_retries_do_not_both_run(self, tmp_path, monkeypatch):
+        """`startup()` awaits, so without a lock two retries interleave. The
+        earlier version of this test passed only because the fixture plugins
+        never actually suspend."""
+        _make_plugin(tmp_path, "race-demo")
+        manager = PluginManager([tmp_path])
+
+        real_load = manager._loader.load_plugin
+
+        async def _slow_load(manifest):
+            await asyncio.sleep(0.05)
+            return await real_load(manifest)
+
+        monkeypatch.setattr(manager._loader, "load_plugin", _slow_load)
+        await manager.startup()
+        manager._load_report["completed"] = False
+
+        await asyncio.gather(manager.retry_discovery(), manager.retry_discovery())
+
+        assert manager.get_load_report()["failed"] == [], "concurrent retries manufactured a failure"

--- a/autobot_shared/plugin_sdk/plugin_load_visibility_test.py
+++ b/autobot_shared/plugin_sdk/plugin_load_visibility_test.py
@@ -81,6 +81,22 @@ def _fresh_plugin_modules():
         sys.modules.pop(name, None)
 
 
+def _manifest(**overrides):
+    """A minimal valid PluginManifest for checker-level tests (#13966)."""
+    from autobot_shared.plugin_sdk.base import PluginManifest
+
+    fields = {
+        "name": "dep-demo",
+        "version": "1.0.0",
+        "display_name": "Dep Demo",
+        "description": "dependency checker fixture",
+        "author": "mrveiss",
+        "entry_point": "dep_demo.main",
+    }
+    fields.update(overrides)
+    return PluginManifest(**fields)
+
+
 def _make_plugin(root: Path, name: str, source: str = _PLUGIN_SOURCE) -> None:
     d = root / name
     d.mkdir(parents=True)
@@ -493,3 +509,130 @@ class TestRepeatedDiscoveryDoesNotAccumulate:
 
         stored = loader._manifest_dirs["rel-demo"]
         assert stored.is_absolute(), f"stored plugin dir must be resolved, got {stored}"
+
+
+class TestPythonDependenciesAreCheckable:
+    """#13966: `telemetry-prompt-middleware` declared `dependencies: ["aiohttp"]`
+    and could never load.
+
+    `_check_dependencies` resolved every entry against the plugin REGISTRY — it
+    asked "is a plugin named aiohttp loaded?" — so a pip distribution name was
+    unsatisfiable no matter what was installed. The manifest field is documented
+    as "Required plugin names", so the checker matched its schema and the
+    manifest was the thing that was wrong; but the author's intent ("this needs
+    a Python package") had nowhere to go and no check that would say so.
+    """
+
+    def test_an_importable_module_satisfies_a_python_dependency(self, tmp_path):
+        from autobot_shared.plugin_sdk.loader import PluginLoader
+
+        loader = PluginLoader(plugin_dirs=[tmp_path])
+        manifest = _manifest(python_dependencies=["json"])
+
+        assert loader._check_dependencies(manifest) == []
+
+    def test_a_missing_module_is_reported_as_python_not_plugin(self, tmp_path):
+        """The old message named a module and left the operator hunting for a
+        plugin. The two kinds have to be distinguishable."""
+        from autobot_shared.plugin_sdk.loader import PluginLoader
+
+        loader = PluginLoader(plugin_dirs=[tmp_path])
+        manifest = _manifest(python_dependencies=["definitely_not_installed_xyz"])
+
+        assert loader._check_dependencies(manifest) == ["python:definitely_not_installed_xyz"]
+
+    def test_a_plugin_dependency_is_still_checked_against_the_registry(self, tmp_path):
+        """The direction that must keep working."""
+        from autobot_shared.plugin_sdk.loader import PluginLoader
+
+        loader = PluginLoader(plugin_dirs=[tmp_path])
+        manifest = _manifest(dependencies=["some-other-plugin"])
+
+        assert loader._check_dependencies(manifest) == ["plugin:some-other-plugin"]
+
+    def test_a_pip_name_in_the_plugin_field_is_still_unsatisfiable(self, tmp_path):
+        """Guards the distinction rather than the fix: putting a module name in
+        `dependencies` must NOT start silently passing, or the two fields
+        collapse back into one and the confusion returns."""
+        from autobot_shared.plugin_sdk.loader import PluginLoader
+
+        loader = PluginLoader(plugin_dirs=[tmp_path])
+        manifest = _manifest(dependencies=["json"])
+
+        assert loader._check_dependencies(manifest) == ["plugin:json"]
+
+    def test_the_shipped_manifest_no_longer_declares_a_pip_name_as_a_plugin(self):
+        """The manifest that motivated the field."""
+        import json as _json
+        from pathlib import Path as _Path
+
+        repo = _Path(__file__).resolve().parents[2]
+        data = _json.loads(
+            (repo / "plugins" / "core-plugins" / "telemetry-prompt-middleware" / "plugin.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        assert "aiohttp" not in data.get("dependencies", []), "a pip name in `dependencies` can never be satisfied"
+        assert "aiohttp" in data.get("python_dependencies", [])
+
+
+class TestCrashedDiscoveryIsRecoverable:
+    """#14000: `startup()` sets `_started = True` BEFORE discovery.
+
+    A crash there wedges the manager permanently — no plugins loaded, a flag
+    saying startup succeeded, and every later `startup()` a no-op. #13677 made
+    that state visible; this makes it recoverable without a process restart.
+    """
+
+    @pytest.mark.asyncio
+    async def test_retry_after_a_crashed_discovery_loads_plugins(self, tmp_path, monkeypatch):
+        _make_plugin(tmp_path, "recover-demo")
+        manager = PluginManager([tmp_path])
+
+        boom = {"raise": True}
+        real_discover = manager._loader.discover_plugins
+
+        def _flaky():
+            if boom["raise"]:
+                raise RuntimeError("discovery exploded")
+            return real_discover()
+
+        monkeypatch.setattr(manager._loader, "discover_plugins", _flaky)
+
+        with pytest.raises(RuntimeError):
+            await manager.startup()
+        assert manager.get_load_report()["completed"] is False
+
+        boom["raise"] = False
+        report = await manager.retry_discovery()
+
+        assert report["completed"] is True
+        assert report["loaded"] == 1, "the recovered run must actually load the plugin"
+        assert report["failed"] == []
+
+    @pytest.mark.asyncio
+    async def test_retry_after_a_successful_startup_is_refused(self, tmp_path):
+        """The negative case, and the one that matters: re-importing modules
+        that already registered would raise "Plugin already registered" and turn
+        a healthy manager into a broken one."""
+        _make_plugin(tmp_path, "no-retry-demo")
+        manager = PluginManager([tmp_path])
+        await manager.startup()
+        before = manager.get_load_report()
+
+        after = await manager.retry_discovery()
+
+        assert after["loaded"] == before["loaded"], "a completed startup must not be re-run"
+        assert after["failed"] == [], "a refused retry must not manufacture failures"
+        assert after["completed"] is True
+
+    @pytest.mark.asyncio
+    async def test_retry_on_an_empty_tree_does_not_loop_forever(self, tmp_path):
+        """An empty tree completes; it is not a crash, so retry declines."""
+        manager = PluginManager([tmp_path])
+        await manager.startup()
+
+        report = await manager.retry_discovery()
+
+        assert report["completed"] is True
+        assert report["discovered"] == 0

--- a/autobot_shared/plugin_sdk/plugin_load_visibility_test.py
+++ b/autobot_shared/plugin_sdk/plugin_load_visibility_test.py
@@ -705,11 +705,33 @@ class TestRetryDoesNotReinitialiseLivePlugins:
 
     @pytest.mark.asyncio
     async def test_two_concurrent_retries_do_not_both_run(self, tmp_path, monkeypatch):
-        """`startup()` awaits, so without a lock two retries interleave. The
-        earlier version of this test passed only because the fixture plugins
-        never actually suspend."""
+        """`startup()` awaits, so without a lock two retries interleave.
+
+        The state has to be a genuinely CRASHED startup — nothing registered.
+        Retrying after a successful one exercises nothing, because the
+        already-registered skip means `load_plugin` is never called and there is
+        no suspension point to interleave at. An earlier version of this test
+        made that mistake and passed with the lock deleted.
+        """
         _make_plugin(tmp_path, "race-demo")
         manager = PluginManager([tmp_path])
+
+        # Crash the first startup so completed=False and nothing is registered.
+        real_discover = manager._loader.discover_plugins
+        runs = {"n": 0}
+        boom = {"raise": True}
+
+        def _counting_discover():
+            if boom["raise"]:
+                boom["raise"] = False
+                raise RuntimeError("discovery exploded")
+            runs["n"] += 1
+            return real_discover()
+
+        monkeypatch.setattr(manager._loader, "discover_plugins", _counting_discover)
+        with pytest.raises(RuntimeError):
+            await manager.startup()
+        assert manager.get_load_report()["completed"] is False
 
         real_load = manager._loader.load_plugin
 
@@ -718,9 +740,11 @@ class TestRetryDoesNotReinitialiseLivePlugins:
             return await real_load(manifest)
 
         monkeypatch.setattr(manager._loader, "load_plugin", _slow_load)
-        await manager.startup()
-        manager._load_report["completed"] = False
 
         await asyncio.gather(manager.retry_discovery(), manager.retry_discovery())
 
+        # Count DISCOVERY runs, not outcomes: the already-registered skip makes a
+        # second pass harmless, so the report alone cannot distinguish a locked
+        # implementation from an unlocked one.
+        assert runs["n"] == 1, f"discovery ran {runs['n']} times — the second retry was not serialised"
         assert manager.get_load_report()["failed"] == [], "concurrent retries manufactured a failure"

--- a/autobot_shared/plugin_sdk/plugin_manager.py
+++ b/autobot_shared/plugin_sdk/plugin_manager.py
@@ -13,7 +13,7 @@ Issue #3278 - Plugin and extension system for third-party integrations.
 
 import logging
 from pathlib import Path
-from typing import Dict, List
+from typing import Any, Dict, List
 
 from .base import PluginRegistry, PluginStatus
 from .hooks import HookRegistry
@@ -74,6 +74,12 @@ class PluginManager:
             logger.warning("PluginManager.startup() called more than once — skipping")
             return
 
+        # #14000: set BEFORE discovery, deliberately, and that is the wedge this
+        # issue is about — a discovery that raises leaves the flag True, so every
+        # later startup() is a no-op reporting success while nothing is loaded.
+        # The flag stays as-is because callers rely on the idempotence contract;
+        # `retry_discovery()` below is the way out, so an operator who sees the
+        # #13677 report has an action that is not "restart the service".
         self._started = True
         logger.info("PluginManager: starting plugin discovery")
 
@@ -224,6 +230,33 @@ class PluginManager:
             len(manifests),
             f" — failed: {', '.join(sorted(failed))}" if failed else "",
         )
+
+    async def retry_discovery(self) -> Dict[str, Any]:
+        """Re-run discovery after a crashed startup, and report what happened.
+
+        #14000: `startup()` marks itself started before discovery runs, so a
+        crash there wedges the manager permanently — no plugins, a flag saying
+        startup succeeded, and no way back short of a process restart. #13677
+        made that state *visible* (`completed: False`); this makes it
+        recoverable.
+
+        Refuses when the previous run completed, because re-importing modules
+        that already registered their plugins raises "Plugin already
+        registered" and would turn a healthy manager into a broken one — the
+        exact failure #13677's dedupe work exists to prevent.
+
+        Returns:
+            The load report for the new attempt, or the existing one unchanged
+            when there was nothing to recover.
+        """
+        if self._load_report.get("completed"):
+            logger.info("PluginManager.retry_discovery(): last startup completed — nothing to retry")
+            return self.get_load_report()
+
+        logger.warning("PluginManager.retry_discovery(): re-running discovery after an incomplete startup")
+        self._started = False
+        await self.startup()
+        return self.get_load_report()
 
     def get_load_report(self) -> Dict[str, object]:
         """Return the startup load tally.

--- a/autobot_shared/plugin_sdk/plugin_manager.py
+++ b/autobot_shared/plugin_sdk/plugin_manager.py
@@ -11,6 +11,7 @@ Handles startup discovery, ordered plugin loading, and graceful shutdown.
 Issue #3278 - Plugin and extension system for third-party integrations.
 """
 
+import asyncio
 import logging
 from pathlib import Path
 from typing import Any, Dict, List
@@ -46,6 +47,9 @@ class PluginManager:
         # #13677: the load tally, so "is the plugin subsystem working?" is a
         # QUERY and not a log-reading exercise. A stream of per-plugin lines
         # nobody totals is why 0-of-7 and "no plugins installed" looked the same.
+        # Held across the completed-check and the retry: `startup()` awaits, so
+        # two concurrent retries would otherwise interleave and load twice.
+        self._retry_lock = asyncio.Lock()
         self._load_report: Dict[str, object] = {
             "discovered": 0,
             "loaded": 0,
@@ -100,6 +104,19 @@ class PluginManager:
         failed: List[str] = []
 
         for manifest in manifests:
+            # #14000 review: `PluginRegistry._plugins` is a process-wide class
+            # attribute, shared with the live `POST /plugins/{name}/load` route,
+            # and `load_plugin` runs `initialize()` BEFORE `register()` — so the
+            # duplicate check fires only after every side effect has happened.
+            # Re-initialising a live plugin appends its hook callbacks a second
+            # time (HookRegistry is also a singleton and does not dedupe), leaks
+            # the discarded instance, and then reports a working plugin as
+            # failed. Skipping here is what makes a retry safe, and it fixes the
+            # same latent hazard in a plain second startup().
+            if self._registry.get_plugin(manifest.name):
+                loaded.append(manifest.name)
+                logger.info("PluginManager: '%s' is already registered — not re-initialising", manifest.name)
+                continue
             try:
                 plugin = await self._loader.load_plugin(manifest)
                 if plugin:
@@ -249,14 +266,25 @@ class PluginManager:
             The load report for the new attempt, or the existing one unchanged
             when there was nothing to recover.
         """
-        if self._load_report.get("completed"):
-            logger.info("PluginManager.retry_discovery(): last startup completed — nothing to retry")
-            return self.get_load_report()
+        async with self._retry_lock:
+            # Direct indexing, not .get(): the key is set in __init__,
+            # _record_load_report and shutdown(), so a default here would only
+            # ever hide a rename — the same argument as the conflicts copy above.
+            if self._load_report["completed"]:
+                logger.info("PluginManager.retry_discovery(): last startup completed — nothing to retry")
+                return self.get_load_report()
+            if not self._started:
+                # shutdown() also leaves completed=False. Retrying there would
+                # resurrect a manager the caller deliberately stopped — and
+                # "crashed" vs "cleanly shut down" is exactly the conflation
+                # #13677 removed one level up.
+                logger.info("PluginManager.retry_discovery(): manager is not started — nothing to retry")
+                return self.get_load_report()
 
-        logger.warning("PluginManager.retry_discovery(): re-running discovery after an incomplete startup")
-        self._started = False
-        await self.startup()
-        return self.get_load_report()
+            logger.warning("PluginManager.retry_discovery(): re-running discovery after an incomplete startup")
+            self._started = False
+            await self.startup()
+            return self.get_load_report()
 
     def get_load_report(self) -> Dict[str, object]:
         """Return the startup load tally.

--- a/docs/developer/PLUGIN_PUBLISHING_GUIDE.md
+++ b/docs/developer/PLUGIN_PUBLISHING_GUIDE.md
@@ -58,7 +58,8 @@ Every plugin must have a `plugin.json` manifest at the root of its directory. Th
 | `category` | string | Yes | One of the valid category slugs (see Categories section). |
 | `tags` | array of strings | No | Additional search keywords. Searched by the catalog full-text filter. Defaults to `[]`. |
 | `entry_point` | string | Yes | Python dotted-path to the module containing the `Plugin` class (e.g. `plugins.core_plugins.my_plugin.main`). |
-| `dependencies` | array of strings | No | Plugin `name` slugs that must be loaded before this plugin. Defaults to `[]`. |
+| `dependencies` | array of strings | No | Plugin `name` slugs that must be loaded before this plugin. **Not pip packages** — a distribution name here can never be satisfied (#13966). Defaults to `[]`. |
+| `python_dependencies` | array of strings | No | Importable **module** names this plugin needs, checked with `importlib.util.find_spec` at load time. Module, not distribution: Pillow is declared as `PIL`. Defaults to `[]`. |
 | `hooks` | array of strings | No | Hook names this plugin registers. Informational — used in catalog display and future permission scoping. Defaults to `[]`. |
 | `config_schema` | object | No | JSON Schema object describing the plugin's configuration. Validated at load time when config is provided via `POST /api/plugins/{name}/load`. |
 | `source_url` | string | No | URL to the plugin source code. Shown in the marketplace UI. Auto-generated for core plugins via `_plugin_source_url()`. |

--- a/docs/developer/PLUGIN_SDK.md
+++ b/docs/developer/PLUGIN_SDK.md
@@ -123,7 +123,8 @@ Pydantic model defining plugin metadata:
     "description": "What this plugin does",
     "author": "Author Name",
     "entry_point": "python.module.path",
-    "dependencies": ["other-plugin"],  # Load order
+    "dependencies": ["other-plugin"],  # Plugin slugs — load order, NOT pip names
+    "python_dependencies": ["aiohttp"], # Importable MODULE names (Pillow -> "PIL")
     "config_schema": {...},            # JSON schema
     "hooks": ["hook_name"]             # Hooks provided
 }

--- a/plugins/core-plugins/logger-plugin/main.py
+++ b/plugins/core-plugins/logger-plugin/main.py
@@ -11,6 +11,8 @@ Issue #730 - Plugin SDK example.
 
 import json
 import logging
+import os
+import tempfile
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Optional
@@ -21,24 +23,48 @@ from plugin_sdk.hooks import Hook, HookRegistry
 logger = logging.getLogger(__name__)
 
 
+def _default_log_path() -> Path:
+    """Per-deployment log path, never a shared /tmp name (#13967)."""
+    base = os.environ.get("AUTOBOT_LOG_DIR")
+    if base:
+        return Path(base) / "plugin_events.log"
+    return Path(tempfile.gettempdir()) / f"autobot-plugins-{os.getuid()}" / "plugin_events.log"
+
+
 class LoggerPlugin(BasePlugin):
     """Plugin that logs system events using hooks."""
 
     def __init__(self, manifest: PluginManifest, config: Optional[Dict] = None):
         """Initialize logger plugin."""
         super().__init__(manifest, config)
-        self.log_file = (
-            Path(config.get("log_file", "/tmp/plugin_events.log")) if config else Path("/tmp/plugin_events.log")
-        )
+        # #13967: `/tmp/plugin_events.log` is a fixed name in a world-writable
+        # directory, so the first user to create it owns it and every other user
+        # gets PermissionError. Default under the project's log directory, which
+        # is per-deployment and matches what the rest of the repo does; the
+        # manifest's config_schema still allows an override.
+        self.log_file = Path((config or {}).get("log_file") or _default_log_path())
         self.hook_registry = HookRegistry()
 
     async def initialize(self) -> None:
         """Initialize plugin and register hooks."""
         self._logger.info("Logger Plugin initializing...")
 
-        # Ensure log file exists
-        self.log_file.parent.mkdir(parents=True, exist_ok=True)
-        self.log_file.touch(exist_ok=True)
+        # #13967: degrade, do not die. An environment condition took the whole
+        # plugin down — and a logging plugin that cannot open its log file is
+        # not a reason to have no plugin. The failure names the path so the
+        # cause is actionable rather than a bare PermissionError at import time.
+        self._sink_enabled = True
+        try:
+            self.log_file.parent.mkdir(parents=True, exist_ok=True)
+            self.log_file.touch(exist_ok=True)
+        except OSError as exc:
+            self._sink_enabled = False
+            self._logger.warning(
+                "Logger Plugin: file sink disabled — cannot open %s (%s). "
+                "Events will still reach the application log.",
+                self.log_file,
+                exc,
+            )
 
         # Register hooks
         self.hook_registry.register_hook(
@@ -106,7 +132,11 @@ class LoggerPlugin(BasePlugin):
         )
 
     def _write_log(self, data: Dict) -> None:
-        """Write log entry to file."""
+        """Write log entry to file, if the sink came up (#13967)."""
+        if not getattr(self, "_sink_enabled", True):
+            # Already reported once at initialize(); re-reporting per event
+            # would turn a degraded sink into a log flood.
+            return
         try:
             with open(self.log_file, "a", encoding="utf-8") as f:
                 f.write(json.dumps(data) + "\n")

--- a/plugins/core-plugins/logger-plugin/main.py
+++ b/plugins/core-plugins/logger-plugin/main.py
@@ -44,6 +44,9 @@ class LoggerPlugin(BasePlugin):
         # manifest's config_schema still allows an override.
         self.log_file = Path((config or {}).get("log_file") or _default_log_path())
         self.hook_registry = HookRegistry()
+        # False until initialize() proves the sink opened. Defaulting to True
+        # would let an uninitialised instance write and fail per event.
+        self._sink_enabled = False
 
     async def initialize(self) -> None:
         """Initialize plugin and register hooks."""
@@ -133,7 +136,7 @@ class LoggerPlugin(BasePlugin):
 
     def _write_log(self, data: Dict) -> None:
         """Write log entry to file, if the sink came up (#13967)."""
-        if not getattr(self, "_sink_enabled", True):
+        if not self._sink_enabled:
             # Already reported once at initialize(); re-reporting per event
             # would turn a degraded sink into a log flood.
             return

--- a/plugins/core-plugins/logger-plugin/plugin.json
+++ b/plugins/core-plugins/logger-plugin/plugin.json
@@ -13,7 +13,7 @@
     "properties": {
       "log_file": {
         "type": "string",
-        "default": "/tmp/plugin_events.log"
+        "default": null
       },
       "log_level": {
         "type": "string",

--- a/plugins/core-plugins/telemetry-prompt-middleware/plugin.json
+++ b/plugins/core-plugins/telemetry-prompt-middleware/plugin.json
@@ -7,7 +7,8 @@
   "entry_point": "plugins.core_plugins.telemetry_prompt_middleware.plugin",
   "capabilities": ["network:outbound", "system:env"],
   "trust_tier": "official",
-  "dependencies": ["aiohttp"],
+  "dependencies": [],
+  "python_dependencies": ["aiohttp"],
   "config_schema": {
     "type": "object",
     "properties": {


### PR DESCRIPTION
## Thinking Path

Three issues spun out of the #13677 work, all in the plugin SDK, all the same shape: a load failure whose message points somewhere other than the cause. Batched because they touch one area and one file each — genuinely similar scope.

**#13966** is the one that reads strangest. `telemetry-prompt-middleware` declared `"dependencies": ["aiohttp"]` and could *never* load, whatever was installed, because `_check_dependencies` resolved every entry against the plugin **registry** — it asked "is a plugin named `aiohttp` loaded?". The manifest field is documented as "Required plugin names", so the checker matched its own schema and the manifest was technically the thing that was wrong. But the author's intent — "this plugin needs a Python package" — had nowhere to go and no check that would have said so, and the error read like a missing plugin.

**#14000** is the wedge #13988 made visible but deliberately did not change. `startup()` sets `_started = True` *before* discovery, so a crash there leaves nothing loaded, a flag saying startup succeeded, and every later `startup()` a silent no-op.

**#13967** is an environment problem with a robustness bug behind it. `/tmp/plugin_events.log` is a fixed name in a world-writable directory, so the first user to create it owns it and everyone else gets `PermissionError` — and `initialize()` had no error handling, so that took the whole plugin down.

## What Changed

`python_dependencies` on the manifest, checked with `importlib.util.find_spec`, and the missing list is now prefixed `plugin:` / `python:` so the two kinds are distinguishable in the error. A pip name in the plugin-name field stays unsatisfiable **on purpose** — there is a test for that, because collapsing the two fields would bring the original confusion straight back.

`retry_discovery()` gives an operator who sees `completed: False` an action that is not "restart the service". The `_started` flag is unchanged: callers rely on the idempotence contract, so the recovery is a separate entry point rather than altered semantics. It **refuses** when the last run completed — re-importing modules that already registered raises "Plugin already registered", which would turn a healthy manager into a broken one, the exact failure #13677's dedupe work exists to prevent.

The logger plugin resolves its path from `AUTOBOT_LOG_DIR` with a per-uid `/tmp` fallback, and degrades rather than dying — a logging plugin that cannot open its log file is not a reason to have no plugin. The disabled sink stays quiet per event, or a degraded sink becomes a log flood.

## Decision

#13966 and #14000 each listed options for an owner. I took the recommendation already recorded on both issues rather than parking them:

- **#13966 → option 1** (separate the two kinds of dependency). Option 2 was "declare pip dependencies out of scope and reject them at parse time", which would have made the shipped manifest an error with still nowhere for the intent to go.
- **#14000 → option 2** (explicit `retry_discovery()`). Option 1 (set the flag only after discovery) changes semantics for every existing caller and turns a hard failure into repeated import attempts for anything calling `startup()` in a loop.

## Verification

```
135 passed   autobot_shared/plugin_sdk/
black · isort · flake8   clean on all 6 changed files
mypy   8 pre-existing errors, none in plugin_sdk
```

Six mutations, six caught — fix reverted, test confirmed failing, fix restored:

| Reverted | Fails |
|---|---|
| `python_dependencies` not checked | 1 |
| `retry_discovery` does not re-run | 1 |
| retry not refused after a healthy startup | 1 |
| `initialize()` no longer degrades | 1 |
| shared `/tmp/plugin_events.log` restored | 2 |
| disabled sink writes anyway | 1 |

One thing worth recording: the logger-plugin test deliberately does **not** live beside the plugin. Collecting a test from under `plugins/` puts a real `plugins` module into `sys.modules`, which is precisely what #10294's synthetic-namespace guards assert must not happen — it failed two of them until I moved it. The module is loaded by absolute path, so location changes nothing about what is exercised.

Refs #14000, #13966, #13967 — part of umbrella #13852.

Not `Closes`: #13967's acceptance is that the plugin loads on a host where another user owns the old path, and #14000's is an operator recovering a wedged manager. Both are host-observable, and this umbrella has been strict about not closing on merge evidence.

## Model Used

Opus 5 (1M context)