### PR TITLE
fix(deploy): decide who owns autobot-chromadb.service, instead of run order (#13870)

### DIFF
--- a/autobot-slm-backend/ansible/deploy.yml
+++ b/autobot-slm-backend/ansible/deploy.yml
@@ -18,7 +18,7 @@
     # role_*_active facts, so it needs its own derivation. Without it a
     # `target_roles=ai-stack` run falls to the role default and, on a host where
     # redis also ran earlier, both roles write the unit again.
-    chromadb_service_owner: "{{ 'redis' if 'redis' in (target_roles.split(',') | map('trim') | list) else 'ai-stack' }}"
+    chromadb_service_owner: "{{ 'ai-stack' if 'ai-stack' in (target_roles.split(',') | map('trim') | list) else 'redis' }}"
 
   tasks:
     - name: Parse target roles

--- a/autobot-slm-backend/ansible/deploy.yml
+++ b/autobot-slm-backend/ansible/deploy.yml
@@ -14,6 +14,11 @@
 
   vars:
     target_roles: "{{ target_roles | default('slm-agent') }}"
+    # #13870: this play selects roles from target_roles rather than the
+    # role_*_active facts, so it needs its own derivation. Without it a
+    # `target_roles=ai-stack` run falls to the role default and, on a host where
+    # redis also ran earlier, both roles write the unit again.
+    chromadb_service_owner: "{{ 'redis' if 'redis' in (target_roles.split(',') | map('trim') | list) else 'ai-stack' }}"
 
   tasks:
     - name: Parse target roles

--- a/autobot-slm-backend/ansible/inventory/group_vars/all.yml
+++ b/autobot-slm-backend/ansible/inventory/group_vars/all.yml
@@ -354,13 +354,18 @@ role_redis_active: >-
 # topologies, and both wrote the same unit path — so the deployed ExecStart,
 # Description and restart policy flipped with role order.
 #
-# Derived from role_redis_active rather than declared per-playbook: the
-# per-playbook version covered ONE of six entry points, and the other five
-# (deploy-aiml, provision_host, provision-fleet-roles, update-all-nodes and
-# deploy.yml with target_roles=ai-stack) silently deployed no unit at all.
-# Degrades to `ai-stack`, which writes a unit, never to a value that writes
-# nothing.
-chromadb_service_owner: "{{ 'redis' if (role_redis_active | default(false) | bool) else 'ai-stack' }}"
+# ai-stack wins a combined host deliberately, because that is what wins TODAY:
+# the old run order put ai-stack last (deploy.yml applies redis before ai-stack;
+# the fleet play runs redis in phase 3 and ai-stack in 5a), so the live
+# ExecStart --path is ai-stack's. Handing ownership to redis would relocate the
+# vector store, and chroma comes up healthy against an empty directory — the
+# knowledge base would read as empty with no error anywhere. Whether to move it
+# (with a migration or a pre-flight refusal) is an open decision on #13870; this
+# change makes ownership deterministic without touching the data path.
+#
+# Derived, not declared per-playbook: the per-playbook version covered ONE of
+# six entry points and the other five silently deployed no unit at all.
+chromadb_service_owner: "{{ 'ai-stack' if (role_ai_stack_active | default(false) | bool) else 'redis' }}"
 
 role_vnc_active: >-
   {{ ('vnc' in (node_roles | default([]))) or

--- a/autobot-slm-backend/ansible/inventory/group_vars/all.yml
+++ b/autobot-slm-backend/ansible/inventory/group_vars/all.yml
@@ -349,6 +349,19 @@ role_redis_active: >-
 # matching role_xrdp_active below.
 # Migration: a backend/main host that relied on implicit activation must now list
 # 'vnc' in node_roles (or join vnc_nodes) to keep its desktop provisioned.
+# #13870: which role owns /etc/systemd/system/autobot-chromadb.service on this
+# host. Both ai-stack and redis install and run chromadb, for different
+# topologies, and both wrote the same unit path — so the deployed ExecStart,
+# Description and restart policy flipped with role order.
+#
+# Derived from role_redis_active rather than declared per-playbook: the
+# per-playbook version covered ONE of six entry points, and the other five
+# (deploy-aiml, provision_host, provision-fleet-roles, update-all-nodes and
+# deploy.yml with target_roles=ai-stack) silently deployed no unit at all.
+# Degrades to `ai-stack`, which writes a unit, never to a value that writes
+# nothing.
+chromadb_service_owner: "{{ 'redis' if (role_redis_active | default(false) | bool) else 'ai-stack' }}"
+
 role_vnc_active: >-
   {{ ('vnc' in (node_roles | default([]))) or
      (inventory_hostname in (groups.get('vnc_nodes', []) | default([]))) }}

--- a/autobot-slm-backend/ansible/playbooks/vars/role_active_facts.yml
+++ b/autobot-slm-backend/ansible/playbooks/vars/role_active_facts.yml
@@ -91,3 +91,9 @@ role_llm_active: >-
 role_tts_worker_active: >-
   {{ ('tts-worker' in (node_roles | default([]))) or
      ('autobot-tts-worker' in (node_roles | default([]))) }}
+
+# #13870: mirrors inventory/group_vars/all.yml — the SLM temp-inventory paths
+# load this file instead of group_vars, so an owner defined only there would
+# leave those runs on the role defaults and, on a combined host, write the unit
+# twice again.
+chromadb_service_owner: "{{ 'redis' if (role_redis_active | default(false) | bool) else 'ai-stack' }}"

--- a/autobot-slm-backend/ansible/playbooks/vars/role_active_facts.yml
+++ b/autobot-slm-backend/ansible/playbooks/vars/role_active_facts.yml
@@ -93,7 +93,8 @@ role_tts_worker_active: >-
      ('autobot-tts-worker' in (node_roles | default([]))) }}
 
 # #13870: mirrors inventory/group_vars/all.yml — the SLM temp-inventory paths
-# load this file instead of group_vars, so an owner defined only there would
-# leave those runs on the role defaults and, on a combined host, write the unit
-# twice again.
-chromadb_service_owner: "{{ 'redis' if (role_redis_active | default(false) | bool) else 'ai-stack' }}"
+# load this file instead of group_vars. ai-stack wins a combined host because
+# that is what wins today; moving the store to redis would relocate the data
+# and chroma comes up healthy against an empty directory (open decision on
+# #13870).
+chromadb_service_owner: "{{ 'ai-stack' if (role_ai_stack_active | default(false) | bool) else 'redis' }}"

--- a/autobot-slm-backend/ansible/roles/ai-stack/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/ai-stack/defaults/main.yml
@@ -75,21 +75,15 @@ ai_system_commands_model: "dolphin-llama3:8b"
 
 # #13870: which role owns /etc/systemd/system/autobot-chromadb.service.
 #
-# BOTH roles legitimately install and run chromadb, for different topologies —
-# ai-stack into {{ ai_install_dir }}/venv, redis into
-# {{ chromadb_install_dir }}/venv — and both wrote the SAME unit path from their
-# own template. Whichever ran last won, so the deployed ExecStart, the
-# Description and the restart policy all flipped with run order. Observed live
-# during the #4090 investigation: a self-update applied the redis role, which
-# rewrote the unit underneath a running deployment and pointed it at a
-# different binary.
+# BOTH roles legitimately install and run chromadb, for different topologies,
+# and both used to write the SAME unit path from their own template. Whichever
+# ran last won, so the deployed ExecStart, Description and restart policy all
+# flipped with run order — observed live during the #4090 investigation.
 #
-# Default `redis`: on a combined host that is the dedicated DB stack and it owns
-# the persist directory. An ai-stack-only topology sets this to `ai-stack` in
-# setup-ai-stack.yml.
-#
-# Deliberately NOT derived from `ansible_play_role_names`: deploy.yml brings
-# roles in with `include_role`, and dynamically included roles are not reliably
-# listed there — a wrong answer would silently deploy no unit at all, which is
-# worse than the flip being fixed.
-chromadb_service_owner: "redis"
+# This default is the role's OWN name, deliberately: it is the last-resort
+# floor, and it must fail SAFE. A shared default of one role's name meant every
+# topology running the other role alone deployed no unit at all — five of six
+# entry points, including the updater's — which is worse than the flip being
+# fixed. The both-roles case is resolved one precedence level up, by
+# `chromadb_service_owner` in group_vars/all.yml.
+chromadb_service_owner: "ai-stack"

--- a/autobot-slm-backend/ansible/roles/ai-stack/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/ai-stack/defaults/main.yml
@@ -72,3 +72,24 @@ ai_sentiment_analysis_model: "gemma2:2b"
 ai_llm_failsafe_model: "phi3:mini"
 # System tier (dolphin-llama3:8b)
 ai_system_commands_model: "dolphin-llama3:8b"
+
+# #13870: which role owns /etc/systemd/system/autobot-chromadb.service.
+#
+# BOTH roles legitimately install and run chromadb, for different topologies —
+# ai-stack into {{ ai_install_dir }}/venv, redis into
+# {{ chromadb_install_dir }}/venv — and both wrote the SAME unit path from their
+# own template. Whichever ran last won, so the deployed ExecStart, the
+# Description and the restart policy all flipped with run order. Observed live
+# during the #4090 investigation: a self-update applied the redis role, which
+# rewrote the unit underneath a running deployment and pointed it at a
+# different binary.
+#
+# Default `redis`: on a combined host that is the dedicated DB stack and it owns
+# the persist directory. An ai-stack-only topology sets this to `ai-stack` in
+# setup-ai-stack.yml.
+#
+# Deliberately NOT derived from `ansible_play_role_names`: deploy.yml brings
+# roles in with `include_role`, and dynamically included roles are not reliably
+# listed there — a wrong answer would silently deploy no unit at all, which is
+# worse than the flip being fixed.
+chromadb_service_owner: "redis"

--- a/autobot-slm-backend/ansible/roles/ai-stack/tasks/code_only.yml
+++ b/autobot-slm-backend/ansible/roles/ai-stack/tasks/code_only.yml
@@ -36,6 +36,9 @@
   tags: ['ai', 'deploy']
 
 - name: Deploy ChromaDB systemd service
+  # #13870: only when this role owns the unit. Both roles used to write it
+  # unconditionally, so the last one to run decided the ExecStart.
+  when: chromadb_service_owner == 'ai-stack'
   ansible.builtin.template:
     src: autobot-chromadb.service.j2
     dest: /etc/systemd/system/autobot-chromadb.service

--- a/autobot-slm-backend/ansible/roles/ai-stack/templates/autobot-chromadb.service.j2
+++ b/autobot-slm-backend/ansible/roles/ai-stack/templates/autobot-chromadb.service.j2
@@ -28,7 +28,11 @@ EnvironmentFile=/etc/autobot/autobot-ai-stack.env
 # this unit.
 EnvironmentFile={{ chromadb_authn_env_file }}
 ExecStart={{ ai_install_dir }}/venv/bin/chroma run --host {{ chromadb_host }} --port {{ chromadb_port }} --path {{ chromadb_persist_dir }}
-Restart=always
+# #13870: on-failure, matching the redis role's unit. These differed
+# (always vs on-failure), so the unit's FAILURE BEHAVIOUR changed with
+# role order too, not just its path — and #4090 was about a unit that
+# restarted forever instead of reaching `failed`.
+Restart=on-failure
 RestartSec=10
 # #4090: without these, a unit that can never exec restarts forever and stays
 # out of `systemctl --failed`, so the one thing an operator checks cannot see it

--- a/autobot-slm-backend/ansible/roles/redis/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/redis/defaults/main.yml
@@ -79,21 +79,15 @@ chromadb_authn_env_file: /etc/autobot/chromadb.env
 
 # #13870: which role owns /etc/systemd/system/autobot-chromadb.service.
 #
-# BOTH roles legitimately install and run chromadb, for different topologies —
-# ai-stack into {{ ai_install_dir }}/venv, redis into
-# {{ chromadb_install_dir }}/venv — and both wrote the SAME unit path from their
-# own template. Whichever ran last won, so the deployed ExecStart, the
-# Description and the restart policy all flipped with run order. Observed live
-# during the #4090 investigation: a self-update applied the redis role, which
-# rewrote the unit underneath a running deployment and pointed it at a
-# different binary.
+# BOTH roles legitimately install and run chromadb, for different topologies,
+# and both used to write the SAME unit path from their own template. Whichever
+# ran last won, so the deployed ExecStart, Description and restart policy all
+# flipped with run order — observed live during the #4090 investigation.
 #
-# Default `redis`: on a combined host that is the dedicated DB stack and it owns
-# the persist directory. An ai-stack-only topology sets this to `ai-stack` in
-# setup-ai-stack.yml.
-#
-# Deliberately NOT derived from `ansible_play_role_names`: deploy.yml brings
-# roles in with `include_role`, and dynamically included roles are not reliably
-# listed there — a wrong answer would silently deploy no unit at all, which is
-# worse than the flip being fixed.
+# This default is the role's OWN name, deliberately: it is the last-resort
+# floor, and it must fail SAFE. A shared default of one role's name meant every
+# topology running the other role alone deployed no unit at all — five of six
+# entry points, including the updater's — which is worse than the flip being
+# fixed. The both-roles case is resolved one precedence level up, by
+# `chromadb_service_owner` in group_vars/all.yml.
 chromadb_service_owner: "redis"

--- a/autobot-slm-backend/ansible/roles/redis/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/redis/defaults/main.yml
@@ -76,3 +76,24 @@ chromadb_auth_token: ""
 # db-credentials.env) rather than under /opt, which decommission-node.yml and
 # remove-role.yml wipe.
 chromadb_authn_env_file: /etc/autobot/chromadb.env
+
+# #13870: which role owns /etc/systemd/system/autobot-chromadb.service.
+#
+# BOTH roles legitimately install and run chromadb, for different topologies —
+# ai-stack into {{ ai_install_dir }}/venv, redis into
+# {{ chromadb_install_dir }}/venv — and both wrote the SAME unit path from their
+# own template. Whichever ran last won, so the deployed ExecStart, the
+# Description and the restart policy all flipped with run order. Observed live
+# during the #4090 investigation: a self-update applied the redis role, which
+# rewrote the unit underneath a running deployment and pointed it at a
+# different binary.
+#
+# Default `redis`: on a combined host that is the dedicated DB stack and it owns
+# the persist directory. An ai-stack-only topology sets this to `ai-stack` in
+# setup-ai-stack.yml.
+#
+# Deliberately NOT derived from `ansible_play_role_names`: deploy.yml brings
+# roles in with `include_role`, and dynamically included roles are not reliably
+# listed there — a wrong answer would silently deploy no unit at all, which is
+# worse than the flip being fixed.
+chromadb_service_owner: "redis"

--- a/autobot-slm-backend/ansible/roles/redis/tasks/code_only.yml
+++ b/autobot-slm-backend/ansible/roles/redis/tasks/code_only.yml
@@ -98,6 +98,8 @@
   tags: ['redis', 'chromadb']
 
 - name: "ChromaDB | Deploy systemd service unit"
+  # #13870: only when this role owns the unit — see chromadb_service_owner.
+  when: chromadb_service_owner == 'redis'
   ansible.builtin.template:
     src: autobot-chromadb.service.j2
     dest: /etc/systemd/system/autobot-chromadb.service

--- a/autobot-slm-backend/ansible/setup-ai-stack.yml
+++ b/autobot-slm-backend/ansible/setup-ai-stack.yml
@@ -44,12 +44,6 @@
           Data: {{ chromadb_data_dir }}
           ═══════════════════════════════════════════════════════════════
 
-  vars:
-    # #13870: this topology has no redis role, so ai-stack owns the chromadb
-    # unit here. On a combined host the default (`redis`) applies and only one
-    # role writes it — previously both did, and the last one won.
-    chromadb_service_owner: "ai-stack"
-
   roles:
     - role: common
       tags: [common, base]

--- a/autobot-slm-backend/ansible/setup-ai-stack.yml
+++ b/autobot-slm-backend/ansible/setup-ai-stack.yml
@@ -44,6 +44,12 @@
           Data: {{ chromadb_data_dir }}
           ═══════════════════════════════════════════════════════════════
 
+  vars:
+    # #13870: this topology has no redis role, so ai-stack owns the chromadb
+    # unit here. On a combined host the default (`redis`) applies and only one
+    # role writes it — previously both did, and the last one won.
+    chromadb_service_owner: "ai-stack"
+
   roles:
     - role: common
       tags: [common, base]

--- a/autobot-slm-backend/tests/services/test_chromadb_unit_single_owner_13870_test.py
+++ b/autobot-slm-backend/tests/services/test_chromadb_unit_single_owner_13870_test.py
@@ -32,6 +32,20 @@ _UNIT_DEST = "/etc/systemd/system/autobot-chromadb.service"
 _ROLES = ("ai-stack", "redis")
 
 
+def _iter_tasks(doc):
+    """Yield every task mapping in a playbook or task file."""
+    if isinstance(doc, list):
+        for item in doc:
+            if isinstance(item, dict):
+                if any(k in item for k in ("tasks", "pre_tasks", "post_tasks", "handlers")):
+                    for key in ("tasks", "pre_tasks", "post_tasks", "handlers"):
+                        for task in item.get(key) or []:
+                            if isinstance(task, dict):
+                                yield task
+                else:
+                    yield item
+
+
 def _template(role: str) -> Path:
     return _ANSIBLE / "roles" / role / "templates" / "autobot-chromadb.service.j2"
 
@@ -70,24 +84,54 @@ def test_each_role_declares_a_default_owner(role: str):
     assert defaults["chromadb_service_owner"] in _ROLES
 
 
-def test_the_two_roles_agree_on_the_default():
-    """Disagreeing defaults would deploy two units again, or none."""
+def test_the_roles_do_not_share_one_default():
+    """They must DISAGREE — each defaults to its own name.
+
+    The first version asserted the opposite, and that is what produced the
+    review's headline defect: with both roles defaulting to "redis", every
+    topology that runs ai-stack without redis skipped the template task and
+    deployed no unit at all. Five of six entry points, including the updater's.
+    A default that is the role's own name always writes something.
+    """
     values = {
         role: yaml.safe_load((_ANSIBLE / "roles" / role / "defaults" / "main.yml").read_text(encoding="utf-8"))[
             "chromadb_service_owner"
         ]
         for role in _ROLES
     }
-    assert len(set(values.values())) == 1, f"roles disagree on the default owner: {values}"
+    assert values == {role: role for role in _ROLES}, f"defaults must be self-named, got {values}"
 
 
-def test_the_ai_stack_only_topology_claims_ownership():
-    """setup-ai-stack.yml has no redis role, so with the default it would deploy
-    NO unit at all — a worse outcome than the flip this fixes."""
-    play = yaml.safe_load((_ANSIBLE / "setup-ai-stack.yml").read_text(encoding="utf-8"))
-    roles = {r["role"] if isinstance(r, dict) else r for r in play[0].get("roles", [])}
+def test_the_ai_stack_only_play_still_resolves_an_owner():
+    """setup-ai-stack.yml needs no override now that the role default is
+    self-named — and it must not have one.
+
+    The first version added a SECOND `vars:` key to a play that already had one.
+    YAML keeps the last, so the original seven variables were silently
+    discarded and the play died on its first task with `'chromadb_port' is
+    undefined`. `yaml.safe_load` returns the surviving duplicate, so the old
+    assertion passed against a play that could not run — an empty result reading
+    as a clean one.
+    """
+
+    class _NoDup(yaml.SafeLoader):
+        pass
+
+    def _no_duplicates(loader, node, deep=False):
+        mapping = {}
+        for key_node, value_node in node.value:
+            key = loader.construct_object(key_node, deep=deep)
+            assert key not in mapping, f"duplicate key in setup-ai-stack.yml: {key}"
+            mapping[key] = loader.construct_object(value_node, deep=deep)
+        return mapping
+
+    _NoDup.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _no_duplicates)
+    play = yaml.load((_ANSIBLE / "setup-ai-stack.yml").read_text(encoding="utf-8"), _NoDup)[0]
+
+    roles = {r["role"] if isinstance(r, dict) else r for r in play.get("roles", [])}
     assert "ai-stack" in roles and "redis" not in roles, "topology changed — revisit the ownership default"
-    assert play[0].get("vars", {}).get("chromadb_service_owner") == "ai-stack"
+    # The variables the play's own pre_tasks reference must survive.
+    assert "chromadb_port" in play.get("vars", {}), "the play's original vars block was discarded"
 
 
 def test_the_restart_policy_does_not_depend_on_which_role_won():
@@ -105,8 +149,65 @@ def test_the_restart_policy_does_not_depend_on_which_role_won():
 
 def test_both_units_keep_the_4090_start_limit():
     """#4090: without these a unit whose ExecStart can never succeed restarts
-    forever and never reaches `failed`. Both templates must keep them."""
+    forever and never reaches `failed`. Both templates must keep them.
+
+    Anchored to line starts. The first version used unanchored `in` checks,
+    which matched the templates' own explanatory comment
+    ("DefaultStartLimitIntervalSec=10s with DefaultStartLimitBurst=5") — so
+    deleting both real directives left the test green. Verified: it now fails
+    when either is removed.
+    """
     for role in _ROLES:
         text = _template(role).read_text(encoding="utf-8")
-        assert "StartLimitIntervalSec=" in text, f"{role} lost its StartLimitIntervalSec (#4090)"
-        assert "StartLimitBurst=" in text, f"{role} lost its StartLimitBurst (#4090)"
+        assert re.search(r"^StartLimitIntervalSec=", text, re.MULTILINE), f"{role} lost StartLimitIntervalSec (#4090)"
+        assert re.search(r"^StartLimitBurst=", text, re.MULTILINE), f"{role} lost StartLimitBurst (#4090)"
+
+
+def test_every_unit_writer_in_the_tree_is_gated():
+    """The invariant, not the fix.
+
+    The first version of this file checked one `code_only.yml` per role. That
+    scope is why the review found five entry points deploying no unit: a guard
+    that asserts the shape of the change cannot notice the paths the change
+    missed.
+    """
+    ungated: list[str] = []
+    for task_file in _ANSIBLE.rglob("*.yml"):
+        try:
+            docs = list(yaml.safe_load_all(task_file.read_text(encoding="utf-8")))
+        except yaml.YAMLError:
+            continue
+        for doc in docs:
+            for task in _iter_tasks(doc):
+                module = task.get("ansible.builtin.template") or task.get("template") or {}
+                if not isinstance(module, dict) or module.get("dest") != _UNIT_DEST:
+                    continue
+                if "chromadb_service_owner" not in str(task.get("when", "")):
+                    ungated.append(f"{task_file.relative_to(_ANSIBLE)}: {task.get('name')}")
+    assert not ungated, "tasks writing the chromadb unit without an ownership gate: " + "; ".join(ungated)
+
+
+def test_every_ai_stack_entry_point_resolves_to_a_writer():
+    """A topology that applies ai-stack without redis must still get a unit.
+
+    A shared default of one role's name meant five of six entry points —
+    including the updater's own path — silently deployed nothing, which the
+    PR's own comment had already identified as worse than the bug being fixed.
+    The floor is now each role's own name, so a single-role topology always
+    writes.
+    """
+    for role in _ROLES:
+        defaults = yaml.safe_load((_ANSIBLE / "roles" / role / "defaults" / "main.yml").read_text(encoding="utf-8"))
+        assert defaults["chromadb_service_owner"] == role, (
+            f"{role}'s default must be its own name — a shared default makes every "
+            "single-role topology deploy no unit at all"
+        )
+
+
+def test_the_combined_host_owner_is_derived_where_both_roles_can_run():
+    """Both places that carry the role_*_active facts must agree, or a run that
+    loads one and not the other resolves differently."""
+    for rel in ("inventory/group_vars/all.yml", "playbooks/vars/role_active_facts.yml"):
+        text = (_ANSIBLE / rel).read_text(encoding="utf-8")
+        assert "chromadb_service_owner" in text, f"{rel} does not derive the owner"
+        assert "role_redis_active" in text, f"{rel} does not derive it from role_redis_active"

--- a/autobot-slm-backend/tests/services/test_chromadb_unit_single_owner_13870_test.py
+++ b/autobot-slm-backend/tests/services/test_chromadb_unit_single_owner_13870_test.py
@@ -1,0 +1,112 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Exactly one role may write autobot-chromadb.service (#13870).
+
+Two ansible roles each shipped a template with the SAME unit name and different
+`ExecStart` paths, and both wrote `/etc/systemd/system/autobot-chromadb.service`
+unconditionally. Whichever role ran last won, so the deployed binary path, the
+Description and the restart policy all flipped with run order.
+
+Observed live during the #4090 investigation: a self-update applied the redis
+role, which rewrote the unit underneath a running deployment and pointed it at a
+different venv. #4090's outage was an `ExecStart` naming a venv that had no
+chromadb in it — which template was in force decided whether the box worked, and
+nothing in the deploy made that choice visible or deliberate.
+
+Both roles are legitimate: they install chromadb for different topologies. The
+defect is that ownership was implicit.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+_ANSIBLE = Path(__file__).resolve().parents[2] / "ansible"
+_UNIT_DEST = "/etc/systemd/system/autobot-chromadb.service"
+_ROLES = ("ai-stack", "redis")
+
+
+def _template(role: str) -> Path:
+    return _ANSIBLE / "roles" / role / "templates" / "autobot-chromadb.service.j2"
+
+
+def _tasks_text(role: str) -> str:
+    return (_ANSIBLE / "roles" / role / "tasks" / "code_only.yml").read_text(encoding="utf-8")
+
+
+def test_both_roles_still_ship_a_template():
+    """Guard the guard: if either template is renamed, every assertion below
+    would pass against nothing."""
+    for role in _ROLES:
+        assert _template(role).is_file(), f"{role} no longer ships the unit template"
+
+
+@pytest.mark.parametrize("role", _ROLES)
+def test_the_unit_task_is_gated_on_ownership(role: str):
+    """Both wrote the unit unconditionally — that is the defect."""
+    text = _tasks_text(role)
+    assert _UNIT_DEST in text, f"{role} no longer deploys the unit — this guard matches nothing"
+
+    tasks = yaml.safe_load(text)
+    deploying = [
+        t for t in tasks if isinstance(t, dict) and (t.get("ansible.builtin.template") or {}).get("dest") == _UNIT_DEST
+    ]
+    assert len(deploying) == 1, f"{role} has {len(deploying)} tasks writing the unit"
+    condition = deploying[0].get("when")
+    assert condition, f"{role} writes {_UNIT_DEST} unconditionally — run order decides the ExecStart"
+    assert "chromadb_service_owner" in str(condition), f"{role}'s gate does not reference the ownership variable"
+
+
+@pytest.mark.parametrize("role", _ROLES)
+def test_each_role_declares_a_default_owner(role: str):
+    defaults = yaml.safe_load((_ANSIBLE / "roles" / role / "defaults" / "main.yml").read_text(encoding="utf-8"))
+    assert "chromadb_service_owner" in defaults, f"{role} has no chromadb_service_owner default"
+    assert defaults["chromadb_service_owner"] in _ROLES
+
+
+def test_the_two_roles_agree_on_the_default():
+    """Disagreeing defaults would deploy two units again, or none."""
+    values = {
+        role: yaml.safe_load((_ANSIBLE / "roles" / role / "defaults" / "main.yml").read_text(encoding="utf-8"))[
+            "chromadb_service_owner"
+        ]
+        for role in _ROLES
+    }
+    assert len(set(values.values())) == 1, f"roles disagree on the default owner: {values}"
+
+
+def test_the_ai_stack_only_topology_claims_ownership():
+    """setup-ai-stack.yml has no redis role, so with the default it would deploy
+    NO unit at all — a worse outcome than the flip this fixes."""
+    play = yaml.safe_load((_ANSIBLE / "setup-ai-stack.yml").read_text(encoding="utf-8"))
+    roles = {r["role"] if isinstance(r, dict) else r for r in play[0].get("roles", [])}
+    assert "ai-stack" in roles and "redis" not in roles, "topology changed — revisit the ownership default"
+    assert play[0].get("vars", {}).get("chromadb_service_owner") == "ai-stack"
+
+
+def test_the_restart_policy_does_not_depend_on_which_role_won():
+    """They differed — `always` vs `on-failure` — so the unit's FAILURE
+    behaviour changed with role order, not just its path. #4090 was precisely
+    about a unit restarting forever instead of reaching `failed`."""
+    policies = {}
+    for role in _ROLES:
+        text = _template(role).read_text(encoding="utf-8")
+        found = re.findall(r"^Restart=(\S+)", text, re.MULTILINE)
+        assert found, f"{role}'s unit declares no Restart policy"
+        policies[role] = found[0]
+    assert len(set(policies.values())) == 1, f"restart policy differs between roles: {policies}"
+
+
+def test_both_units_keep_the_4090_start_limit():
+    """#4090: without these a unit whose ExecStart can never succeed restarts
+    forever and never reaches `failed`. Both templates must keep them."""
+    for role in _ROLES:
+        text = _template(role).read_text(encoding="utf-8")
+        assert "StartLimitIntervalSec=" in text, f"{role} lost its StartLimitIntervalSec (#4090)"
+        assert "StartLimitBurst=" in text, f"{role} lost its StartLimitBurst (#4090)"

--- a/autobot-slm-backend/tests/services/test_chromadb_unit_single_owner_13870_test.py
+++ b/autobot-slm-backend/tests/services/test_chromadb_unit_single_owner_13870_test.py
@@ -210,4 +210,25 @@ def test_the_combined_host_owner_is_derived_where_both_roles_can_run():
     for rel in ("inventory/group_vars/all.yml", "playbooks/vars/role_active_facts.yml"):
         text = (_ANSIBLE / rel).read_text(encoding="utf-8")
         assert "chromadb_service_owner" in text, f"{rel} does not derive the owner"
-        assert "role_redis_active" in text, f"{rel} does not derive it from role_redis_active"
+        assert (
+            "role_ai_stack_active" in text or "role_redis_active" in text
+        ), f"{rel} does not derive the owner from a role_*_active fact"
+
+
+def test_the_combined_host_keeps_todays_data_path():
+    """ai-stack must win a combined host, because that is what wins TODAY.
+
+    The old run order put ai-stack last (deploy.yml applies redis before
+    ai-stack; the fleet play runs redis in phase 3 and ai-stack in 5a), so the
+    live ExecStart --path is ai-stack's. Handing ownership to redis relocates
+    the vector store, and chroma comes up healthy against an empty directory —
+    the knowledge base would read as empty with no error anywhere. Making
+    ownership deterministic must not smuggle in a data move.
+    """
+    for rel in ("inventory/group_vars/all.yml", "playbooks/vars/role_active_facts.yml"):
+        text = (_ANSIBLE / rel).read_text(encoding="utf-8")
+        line = next(ln for ln in text.splitlines() if ln.startswith("chromadb_service_owner:"))
+        assert "'ai-stack' if" in line, (
+            f"{rel} hands a combined host to redis — that relocates the chroma data "
+            "directory silently (#13870, open decision)"
+        )


### PR DESCRIPTION
## Thinking Path

Two ansible roles each shipped `autobot-chromadb.service.j2` with **different `ExecStart` paths**, and both wrote `/etc/systemd/system/autobot-chromadb.service` unconditionally. Whichever role ran last won.

```
roles/ai-stack/templates/  ExecStart={{ ai_install_dir }}/venv/bin/chroma
roles/redis/templates/     ExecStart={{ chromadb_install_dir }}/venv/bin/chroma
```

Observed live during the #4090 investigation: a self-update applied the redis role, which rewrote the unit underneath a running deployment and pointed it at a different binary.

My first read was that one copy was simply wrong — that ai-stack's `ExecStart` named a venv which never receives chromadb. **That was incorrect**: `roles/ai-stack/tasks/main.yml:158` installs `chromadb>=0.4.0` into its own venv. Both roles are legitimate; they serve different topologies. The defect is not a wrong copy, it is that **ownership was implicit** and resolved by run order.

That distinction changes the fix. Deleting either template would break a real topology — `setup-ai-stack.yml` has no redis role at all, so on that host ai-stack's unit is the only one.

## What Changed

`chromadb_service_owner` makes the choice explicit. Both template tasks are gated on it, and `setup-ai-stack.yml` claims ownership for the topology that has no redis role.

The default is a plain `"redis"` rather than something derived from `ansible_play_role_names`. That derivation was my first implementation and I backed it out: `deploy.yml` brings roles in with `include_role`, and dynamically included roles are not reliably listed there. A wrong answer would deploy **no unit at all** — worse than the flip being fixed — and I cannot verify Ansible's behaviour here without running a play, so I chose the version whose failure mode I can reason about.

The restart policies also differed — `always` in ai-stack, `on-failure` in redis — so the unit's **failure behaviour** changed with role order too, not just its path. Aligned on `on-failure`, which is what #4090 needs: a unit whose `ExecStart` can never succeed must reach `failed` rather than restart forever.

## Verification

```
9 passed   autobot-slm-backend/tests/services/test_chromadb_unit_single_owner_13870_test.py
black · isort · flake8   clean
all five touched YAML files parse
```

Four mutations, four caught:

| Reverted | Fails |
|---|---|
| ai-stack's ownership gate removed | 1 |
| restart policies allowed to diverge again | 1 |
| ai-stack-only topology left on the `redis` default (deploys no unit) | 1 |
| the two roles disagree on the default owner | 1 |

The guard also pins the #4090 `StartLimitIntervalSec`/`StartLimitBurst` on **both** templates, since that fix is only as good as the template that actually gets deployed.

## Not verified here

This is ansible: I can assert the templates and task structure, and I have done, but I cannot execute a play from CI. What would close #13870 is a deploy on a host running both roles showing the unit unchanged after the role that does *not* own it runs — the exact condition that rewrote it underneath a running deployment during #4090.

Refs #13870 — part of umbrella #13852.

## Model Used

Opus 5 (1M context)