### PR TITLE
ci(auto-update): serialize PR branch refresh to the head of the queue (#14022)

### DIFF
--- a/.github/workflows/auto-update-pr-branches.yml
+++ b/.github/workflows/auto-update-pr-branches.yml
@@ -233,9 +233,10 @@ jobs:
           # binary is required beyond what this file already depends on.
           check_pr_state() {
             local pr="$1"
-            # shellcheck disable=SC2016 -- `$c` below is a jq variable, not a
-            # shell one. Single quotes are required: letting the shell expand it
-            # would substitute an empty string and break the filter.
+            # `$c` below is a jq variable, not a shell one. Single quotes are
+            # required: letting the shell expand it would substitute an empty
+            # string and break the filter.
+            # shellcheck disable=SC2016
             gh pr view "$pr" --repo "$REPO" --json statusCheckRollup \
               --jq '([.statusCheckRollup[] | select((.status != null and .status != "" and .status != "COMPLETED") or (.state == "PENDING"))]) as $c | (($c | length | tostring) + "|" + (($c | map(select(.startedAt != null and .startedAt != "")) | map(.startedAt) | min) // ""))' \
               2>/dev/null || echo "0|"

--- a/.github/workflows/auto-update-pr-branches.yml
+++ b/.github/workflows/auto-update-pr-branches.yml
@@ -1,12 +1,67 @@
-# Auto-update PR branches when Dev_new_gui advances
+# Auto-update PR branches when Dev_new_gui advances — serialized (#14022)
 #
-# Whenever Dev_new_gui receives a push (merge, direct commit),
-# this workflow finds every open PR targeting Dev_new_gui that is
-# behind the base and merges the base into it automatically.
-# Eliminates the manual "Update branch" click and prevents stale
-# merge-conflict surprises at review time.
+# Whenever Dev_new_gui receives a push (merge, direct commit), this workflow
+# refreshes AT MOST ONE open PR targeting Dev_new_gui: the oldest one that is
+# behind base AND is not currently mid-run. Eliminates the manual "Update
+# branch" click and keeps the next PR to land tested against current base,
+# without resetting PRs that are still executing a check set.
 #
-# See: #9300 post-mortem — direct hotfixes on main caused drift
+# See: #9300 post-mortem — direct hotfixes on main caused drift.
+#
+# #14022: this used to refresh the single oldest-behind PR on EVERY push,
+# with no regard for whether that PR's own checks (from the last refresh)
+# had finished. On a busy day pushes arrive faster than a full check set
+# completes on the singleton self-hosted runner (~53 minutes), so the same
+# PR was repeatedly reset mid-run and never converged — measured on
+# 2026-08-11: PR #13945 was refreshed at 13:21, 13:33 and 13:43 (three
+# resets in 22 minutes), each discarding whatever of the prior run had
+# completed.
+#
+# The header used to justify this by `strict: true` — "a PR cannot merge
+# while its branch is behind, and this job is the only thing that clears
+# that". That is no longer the configuration:
+#
+#   $ gh api repos/OWNER/REPO/branches/Dev_new_gui/protection \
+#       --jq '.required_status_checks.strict'
+#   false
+#
+# `strict` was set to false as the recorded decision on #13801, so being
+# behind base no longer blocks a merge. The remaining, real reason to
+# refresh a PR is #9300 drift protection: catch a SEMANTIC conflict between
+# an already-merged PR and a still-open one before it lands, not just a
+# textual one (GitHub already computes textual mergeability on demand,
+# independent of this job). That only needs each PR tested against current
+# base once, immediately before its turn — not reset on every unrelated
+# merge while it is still running.
+#
+# WHY NOT REMOVE THE REFRESH ENTIRELY: doing so would mean a PR's CI last
+# ran against a base that has since moved, so a merge could still introduce
+# a semantic break that no check ever ran against. Base-branch push CI
+# (ci.yml on `push: [Dev_new_gui]`) partially covers this — it runs the full
+# python-suite once per merge — but ci.yml's own history shows base-push
+# runs get starved by rapid merges the same way this job's targets did (see
+# the `cancel-in-progress` comment in ci.yml, #13432: 26 of the last 39 base
+# runs were cancelled before that fix). Relying on it alone would trade one
+# unreliable safety net for another. Serializing the refresh keeps the net
+# on the PR side, where it registers as a required check.
+#
+# MERGE QUEUE WAS EVALUATED AND REJECTED FOR NOW: GitHub's native merge
+# queue is the standard solution to this exact problem (serialize, test
+# each PR against base + the queue ahead of it, merge when green) and is
+# available here (public repo, owner is a User account, Free plan). It is
+# not enabled today: `gh api repos/OWNER/REPO/rules/branches/Dev_new_gui`
+# shows only the review-count ruleset, no `merge_queue` rule. Turning it on
+# requires every workflow that publishes one of the ten required contexts
+# (smoke-test, code-quality, startup-import-smoke, "Unit & Integration
+# Tests", "No open blocks-merge issues reference this PR", "No commit
+# trailers", verify-generated-types, migration-matrix,
+# verify-precommit-config, api-wiring) to also trigger on `merge_group` —
+# `grep -rl merge_group .github/workflows/` currently returns nothing. A
+# ruleset flip without that migration deadlocks the queue: every entrant
+# waits forever for required contexts that never fire, on a repo whose
+# recovery jobs were already moved off the singleton runner once for this
+# exact class of failure (#13401). That is a multi-file, hard-to-rehearse
+# migration (issue filed: #14054) — this workflow is the safe interim fix.
 #
 # #12823: the merge commit this job creates is pushed with the default
 # GITHUB_TOKEN, so GitHub attributes it to github-actions[bot]. The repository's
@@ -15,7 +70,9 @@
 # conclusion=action_required and never starts — the refreshed PR ends up with a
 # head commit carrying ZERO executed checks, which reads as "no failures" to any
 # rollup. The `approve-refreshed-runs` job below runs immediately afterwards to
-# repair that, and publishes a visible commit status when it cannot.
+# repair that, and publishes a visible commit status when it cannot. Refreshes
+# are rarer now (once per PR turn, not once per push) but not eliminated, so
+# this job stays — retiring it would leave the next refresh's runs parked.
 
 name: Auto-update PR branches
 
@@ -26,23 +83,13 @@ on:
 
 jobs:
   auto-update:
-    # #13401: ubuntu-latest, NOT the singleton self-hosted runner.
-    #
-    # `strict: true` on Dev_new_gui means a PR cannot merge while its branch is
-    # behind, and this job is the only thing that clears "behind". Pinning it to
-    # the self-hosted runner put the recovery mechanism inside the failure domain
-    # it recovers from: when that runner went offline on 2026-08-03, every open
-    # PR fell behind, none could merge, and the sweep that would have fixed them
-    # could not start. The repository deadlocked until a human intervened.
-    #
-    # This is the same reasoning ci-dispatch-watchdog.yml already states for
-    # itself: "a watchdog that queues behind the outage it exists to report is
-    # useless." The sibling approve-refreshed-runs job below was already
-    # ubuntu-latest for exactly this reason; only this job was pinned.
+    # #13401: ubuntu-latest, NOT the singleton self-hosted runner — this job
+    # is part of what keeps PRs mergeable, so it must not queue behind the
+    # same runner outage it would need to recover from.
     #
     # Nothing here needs the self-hosted host: the steps are `gh pr list`,
-    # `gh api compare` and `gh api update-branch` — REST calls against
-    # github.com, no build, no test, no local toolchain.
+    # `gh api compare`, `gh pr view` and `gh api update-branch` — REST calls
+    # against github.com, no build, no test, no local toolchain.
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -52,29 +99,16 @@ jobs:
     steps:
       # gh is preinstalled on GitHub-hosted runners, so the self-hosted install
       # dance (apt keyring + sudo) is no longer needed (#13401).
-      - name: Update out-of-date PR branches
+      - name: Update the next due PR branch, skipping any still mid-run
         env:
           # #13791: see auto-fix-formatting.yml — a human-attributed token
           # keeps the runs this update triggers out of action_required.
           GH_TOKEN: ${{ secrets.AUTOBOT_PUSH_TOKEN || secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          # #13426: how many stale branches one sweep may refresh.
-          #
-          # Dev_new_gui has `strict: true` (require branches up to date before
-          # merging), so AT MOST ONE updated PR can merge before the next base
-          # landing makes the rest stale again. Refreshing N branches to land 1
-          # therefore costs N × ~25 runs (#13388) and discards N-1 of them —
-          # and it gets worse as the backlog grows, so the queue slows down
-          # exactly when it is busiest.
-          #
-          # It also un-approves work: the ruleset sets
-          # dismiss_stale_reviews_on_push, so every branch this sweep touches
-          # loses its approving review and has to be re-approved.
-          #
-          # 1 is the correct default under `strict: true`: refresh the next
-          # merge candidate, let it land, and let the push it produces refresh
-          # the one after. Raise this only if `strict` is relaxed, where
-          # refreshing several at once becomes useful rather than wasted.
+          # #14022: cap on how many PRs one push may refresh. Kept at 1 — a
+          # push refreshes the head of the FIFO queue and nothing else, so a
+          # PR further back never gets reset by someone else's merge. Raising
+          # this only makes sense if the singleton runner constraint is lifted.
           MAX_BRANCH_UPDATES: '1'
         run: |
           echo "Dev_new_gui was updated — checking open PRs for staleness..."
@@ -140,28 +174,50 @@ jobs:
 
           echo "PRs behind Dev_new_gui: $(echo "$OUTDATED" | tr '\n' ' ')"
 
-          # #13426: refresh at most MAX_BRANCH_UPDATES of them, oldest PR first.
-          # Under `strict: true` only one can merge per base landing, so the
-          # rest would be re-staled before they were ever mergeable. Oldest-first
-          # (lowest PR number) keeps the queue FIFO instead of starving whichever
-          # PR happens to sort last.
-          TOTAL_OUTDATED=$(echo "$OUTDATED" | tr ' ' '\n' | grep -c '[0-9]' || true)
-          OUTDATED=$(echo "$OUTDATED" | tr ' ' '\n' | grep '[0-9]' | sort -n | head -n "$MAX_BRANCH_UPDATES")
-          DEFERRED=$((TOTAL_OUTDATED - $(echo "$OUTDATED" | grep -c '[0-9]' || true)))
-          if [ "$DEFERRED" -gt 0 ]; then
-            # Say what was skipped. A cap that silently drops work reads as
-            # "everything was refreshed" when it was not.
-            echo "Refreshing $MAX_BRANCH_UPDATES of $TOTAL_OUTDATED; deferring $DEFERRED to the next base push (#13426)."
-          fi
+          # Oldest PR first (lowest number) keeps the queue FIFO instead of
+          # starving whichever PR happens to sort last.
+          OUTDATED=$(echo "$OUTDATED" | tr ' ' '\n' | grep '[0-9]' | sort -n)
+
+          # #14022: a PR is "due" for refresh only once its OWN last run has
+          # finished. Checking this is what turns "refresh every behind PR on
+          # every push" into "refresh the head of the queue once, when its
+          # turn comes" — the same PR is never reset mid-flight by an
+          # unrelated merge landing while it is still running.
+          #
+          # `statusCheckRollup` mixes two shapes: GitHub Check Runs (`status`
+          # one of QUEUED/IN_PROGRESS/COMPLETED) and legacy Status API
+          # contexts (`status` empty, verdict in `.state`, e.g. PENDING). Both
+          # are checked so a PR is never treated as idle while either kind is
+          # still running.
+          is_in_flight() {
+            local pr="$1"
+            local count
+            count=$(gh pr view "$pr" --repo "$REPO" --json statusCheckRollup \
+              --jq '[.statusCheckRollup[] | select((.status != null and .status != "" and .status != "COMPLETED") or (.state == "PENDING"))] | length' \
+              2>/dev/null || echo "")
+            [ -n "$count" ] && [ "$count" -gt 0 ]
+          }
 
           UPDATED=0
           FAILED=0
           for PR in $OUTDATED; do
+            [ "$UPDATED" -lt "$MAX_BRANCH_UPDATES" ] || break
             # Validate numeric to guard against unexpected jq output
             if ! [[ "$PR" =~ ^[0-9]+$ ]]; then
               echo "  Skipping non-numeric value: $PR"
               continue
             fi
+
+            if is_in_flight "$PR"; then
+              # This is the head of the FIFO queue and it is still running —
+              # do not skip ahead to a later PR, and do not touch it either.
+              # Skipping ahead would refresh two PRs concurrently on a
+              # singleton runner for no benefit; touching it would be exactly
+              # the reset this fix removes.
+              echo "  PR #$PR is due next but still has checks running — leaving it, and the rest of the queue, undisturbed this push."
+              break
+            fi
+
             echo "Updating PR #$PR..."
             # #12801: `gh pr update-branch` does not exist in the installed gh
             # build (same class as the missing `behindBy` field above), so this
@@ -173,7 +229,10 @@ jobs:
               echo "  ✓ PR #$PR updated"
               UPDATED=$((UPDATED + 1))
             else
-              echo "  ✗ PR #$PR failed (conflicts need manual resolution)"
+              # A real conflict — auto-merge cannot resolve it, and leaving
+              # this PR at the head of the queue would block every PR behind
+              # it from ever being tried. Move on to the next candidate.
+              echo "  ✗ PR #$PR failed (conflicts need manual resolution) — trying the next PR in the queue."
               FAILED=$((FAILED + 1))
             fi
           done
@@ -187,9 +246,9 @@ jobs:
   #
   # This job must NOT run on the self-hosted runner: it exists to unblock CI,
   # and the singleton runner is exactly the resource that is contended when
-  # several PRs are refreshed at once. `needs: auto-update` guarantees it runs
-  # after the branches were actually updated, so the parked runs already exist
-  # by the time it looks; the standalone `ci-dispatch-watchdog` schedule is the
+  # a PR is refreshed. `needs: auto-update` guarantees it runs after the
+  # branch was actually updated, so any parked run already exists by the
+  # time it looks; the standalone `ci-dispatch-watchdog` schedule is the
   # safety net for anything that appears later.
   approve-refreshed-runs:
     needs: auto-update

--- a/.github/workflows/auto-update-pr-branches.yml
+++ b/.github/workflows/auto-update-pr-branches.yml
@@ -2,37 +2,50 @@
 #
 # Whenever Dev_new_gui receives a push (merge, direct commit), this workflow
 # refreshes AT MOST ONE open PR targeting Dev_new_gui: the oldest one that is
-# behind base AND is not currently mid-run. Eliminates the manual "Update
+# both behind base AND not currently mid-run. Eliminates the manual "Update
 # branch" click and keeps the next PR to land tested against current base,
-# without resetting PRs that are still executing a check set.
+# without resetting PRs that are still executing a check set. A PR that is
+# mid-run is SKIPPED, never gated on — the workflow moves on to the next
+# behind PR in the queue rather than doing nothing (see #14022 review fix
+# below; an earlier version of this change got that wrong).
 #
 # See: #9300 post-mortem — direct hotfixes on main caused drift.
 #
 # #14022: this used to refresh the single oldest-behind PR on EVERY push,
 # with no regard for whether that PR's own checks (from the last refresh)
 # had finished. On a busy day pushes arrive faster than a full check set
-# completes on the singleton self-hosted runner (~53 minutes), so the same
-# PR was repeatedly reset mid-run and never converged — measured on
-# 2026-08-11: PR #13945 was refreshed at 13:21, 13:33 and 13:43 (three
-# resets in 22 minutes), each discarding whatever of the prior run had
-# completed.
+# completes on the singleton self-hosted runner, so the same PR was
+# repeatedly reset mid-run and never converged — measured on 2026-08-11:
+# PR #13945 was refreshed at 13:21, 13:33 and 13:43 (three resets in 22
+# minutes), each discarding whatever of the prior run had completed.
 #
-# The header used to justify this by `strict: true` — "a PR cannot merge
-# while its branch is behind, and this job is the only thing that clears
-# that". That is no longer the configuration:
+# REVIEW FIX (same PR): the first version of this serialization used
+# `break` on a busy head-of-queue PR, which abandoned every PR behind it
+# too — confirmed live: while #13945 sat busy, #13955/#13991/#14002/#14003
+# were fully idle and eligible, but `break` meant none of them were ever
+# considered. That converts "the head thrashes" into "the tail never
+# updates" — worse, because it exits 0 and looks identical to "nothing was
+# behind". Fixed to `continue`: skip a busy candidate and evaluate the next
+# one. `MAX_BRANCH_UPDATES` already caps actual refreshes at one per push,
+# so scanning past busy candidates to find a refreshable one does not
+# reintroduce the reset amplification this workflow exists to remove.
+#
+# The header used to justify refreshing by `strict: true` — "a PR cannot
+# merge while its branch is behind, and this job is the only thing that
+# clears that". That is no longer the configuration:
 #
 #   $ gh api repos/OWNER/REPO/branches/Dev_new_gui/protection \
 #       --jq '.required_status_checks.strict'
 #   false
 #
 # `strict` was set to false as the recorded decision on #13801, so being
-# behind base no longer blocks a merge. The remaining, real reason to
-# refresh a PR is #9300 drift protection: catch a SEMANTIC conflict between
-# an already-merged PR and a still-open one before it lands, not just a
-# textual one (GitHub already computes textual mergeability on demand,
-# independent of this job). That only needs each PR tested against current
-# base once, immediately before its turn — not reset on every unrelated
-# merge while it is still running.
+# behind base no longer blocks a merge. With strict=false, this workflow's
+# ENTIRE remaining purpose is the #9300 drift/semantic-conflict net: catch
+# a semantic conflict between an already-merged PR and a still-open one
+# before it lands (GitHub already computes textual mergeability on demand,
+# independent of this job). A starved tail — the bug fixed above — would
+# have meant that net went silently absent for every non-head PR exactly
+# when merge volume, and therefore semantic-conflict risk, is highest.
 #
 # WHY NOT REMOVE THE REFRESH ENTIRELY: doing so would mean a PR's CI last
 # ran against a base that has since moved, so a merge could still introduce
@@ -42,21 +55,30 @@
 # runs get starved by rapid merges the same way this job's targets did (see
 # the `cancel-in-progress` comment in ci.yml, #13432: 26 of the last 39 base
 # runs were cancelled before that fix). Relying on it alone would trade one
-# unreliable safety net for another. Serializing the refresh keeps the net
-# on the PR side, where it registers as a required check.
+# already-documented-unreliable safety net for another, and it is also
+# after-the-fact: a semantic break it catches has already landed. Serializing
+# the refresh keeps the net on the PR side, before merge, where it registers
+# as a required check.
 #
 # MERGE QUEUE WAS EVALUATED AND REJECTED FOR NOW: GitHub's native merge
 # queue is the standard solution to this exact problem (serialize, test
 # each PR against base + the queue ahead of it, merge when green) and is
 # available here (public repo, owner is a User account, Free plan). It is
-# not enabled today: `gh api repos/OWNER/REPO/rules/branches/Dev_new_gui`
-# shows only the review-count ruleset, no `merge_queue` rule. Turning it on
-# requires every workflow that publishes one of the ten required contexts
-# (smoke-test, code-quality, startup-import-smoke, "Unit & Integration
-# Tests", "No open blocks-merge issues reference this PR", "No commit
-# trailers", verify-generated-types, migration-matrix,
-# verify-precommit-config, api-wiring) to also trigger on `merge_group` —
-# `grep -rl merge_group .github/workflows/` currently returns nothing. A
+# not enabled today — checked directly:
+#
+#   $ gh api repos/OWNER/REPO/rules/branches/Dev_new_gui
+#   [only the review-count ruleset; no `merge_queue` rule]
+#
+# Turning it on requires every workflow that publishes one of the ten
+# required contexts (smoke-test, code-quality, startup-import-smoke, "Unit &
+# Integration Tests", "No open blocks-merge issues reference this PR", "No
+# commit trailers", verify-generated-types, migration-matrix,
+# verify-precommit-config, api-wiring) to also trigger on `merge_group`. As
+# of the review that produced this comment, none of those ten workflows had
+# one — check the current state yourself before relying on this, e.g.
+# `grep -L merge_group .github/workflows/{smoke-test-workflow-file}.yml`
+# (this file itself now contains the string `merge_group` in prose, so a
+# blanket `grep -rl` over the whole directory no longer proves absence). A
 # ruleset flip without that migration deadlocks the queue: every entrant
 # waits forever for required contexts that never fire, on a repo whose
 # recovery jobs were already moved off the singleton runner once for this
@@ -105,11 +127,28 @@ jobs:
           # keeps the runs this update triggers out of action_required.
           GH_TOKEN: ${{ secrets.AUTOBOT_PUSH_TOKEN || secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          # #14022: cap on how many PRs one push may refresh. Kept at 1 — a
-          # push refreshes the head of the FIFO queue and nothing else, so a
-          # PR further back never gets reset by someone else's merge. Raising
-          # this only makes sense if the singleton runner constraint is lifted.
+          # #14022: cap on how many PRs one push may ACTUALLY refresh. Kept
+          # at 1 — a push lands one refresh, at most, so a PR further back
+          # never gets reset by someone else's merge. This does NOT cap how
+          # many busy candidates may be skipped while searching for the one
+          # to refresh (see the review fix in the header): a push can pass
+          # over several in-flight PRs and still only update one.
           MAX_BRANCH_UPDATES: '1'
+          # #14022 review fix (HIGH): a check wedged in QUEUED/IN_PROGRESS
+          # forever — the #13401 singleton-runner-outage class — must not
+          # block a PR's turn indefinitely just because it looks "in
+          # flight". Bound: 90 minutes. Justification, not a round number:
+          # sampled the last 14 completed `pull_request` runs of ci.yml
+          # (the workflow carrying the heaviest required checks, including
+          # the 12-shard python-suite) on 2026-08-11 — durations ranged
+          # 14-71 minutes (median ~22, max 70m39s). 90 minutes gives ~19
+          # minutes of margin above the worst OBSERVED legitimate run,
+          # while staying far short of an outage-class wedge, which persists
+          # for hours until a human intervenes, not tens of minutes. A check
+          # non-terminal past this bound is treated as no longer eligible to
+          # block a refresh, not as failed — it is left running; only the
+          # queue-blocking effect is bypassed.
+          STALE_BOUND_SECONDS: '5400'
         run: |
           echo "Dev_new_gui was updated — checking open PRs for staleness..."
 
@@ -179,27 +218,29 @@ jobs:
           OUTDATED=$(echo "$OUTDATED" | tr ' ' '\n' | grep '[0-9]' | sort -n)
 
           # #14022: a PR is "due" for refresh only once its OWN last run has
-          # finished. Checking this is what turns "refresh every behind PR on
+          # finished (or has gone stale past STALE_BOUND_SECONDS — see env
+          # comment above). This is what turns "refresh every behind PR on
           # every push" into "refresh the head of the queue once, when its
-          # turn comes" — the same PR is never reset mid-flight by an
-          # unrelated merge landing while it is still running.
+          # turn comes" — without ALSO turning into "one busy PR blocks
+          # every PR behind it" (the review fix above).
           #
           # `statusCheckRollup` mixes two shapes: GitHub Check Runs (`status`
           # one of QUEUED/IN_PROGRESS/COMPLETED) and legacy Status API
           # contexts (`status` empty, verdict in `.state`, e.g. PENDING). Both
           # are checked so a PR is never treated as idle while either kind is
-          # still running.
-          is_in_flight() {
+          # still running. Emits one line: "<count>|<oldest non-terminal
+          # startedAt, or empty>", both computed by gh's own --jq so no extra
+          # binary is required beyond what this file already depends on.
+          check_pr_state() {
             local pr="$1"
-            local count
-            count=$(gh pr view "$pr" --repo "$REPO" --json statusCheckRollup \
-              --jq '[.statusCheckRollup[] | select((.status != null and .status != "" and .status != "COMPLETED") or (.state == "PENDING"))] | length' \
-              2>/dev/null || echo "")
-            [ -n "$count" ] && [ "$count" -gt 0 ]
+            gh pr view "$pr" --repo "$REPO" --json statusCheckRollup \
+              --jq '([.statusCheckRollup[] | select((.status != null and .status != "" and .status != "COMPLETED") or (.state == "PENDING"))]) as $c | (($c | length | tostring) + "|" + (($c | map(select(.startedAt != null and .startedAt != "")) | map(.startedAt) | min) // ""))' \
+              2>/dev/null || echo "0|"
           }
 
           UPDATED=0
           FAILED=0
+          SKIPPED_BUSY=0
           for PR in $OUTDATED; do
             [ "$UPDATED" -lt "$MAX_BRANCH_UPDATES" ] || break
             # Validate numeric to guard against unexpected jq output
@@ -208,14 +249,32 @@ jobs:
               continue
             fi
 
-            if is_in_flight "$PR"; then
-              # This is the head of the FIFO queue and it is still running —
-              # do not skip ahead to a later PR, and do not touch it either.
-              # Skipping ahead would refresh two PRs concurrently on a
-              # singleton runner for no benefit; touching it would be exactly
-              # the reset this fix removes.
-              echo "  PR #$PR is due next but still has checks running — leaving it, and the rest of the queue, undisturbed this push."
-              break
+            STATE=$(check_pr_state "$PR")
+            COUNT="${STATE%%|*}"
+            OLDEST_START="${STATE#*|}"
+            [[ "$COUNT" =~ ^[0-9]+$ ]] || COUNT=0
+
+            if [ "$COUNT" -gt 0 ]; then
+              AGE=""
+              if [ -n "$OLDEST_START" ]; then
+                NOW_EPOCH=$(date -u +%s)
+                STARTED_EPOCH=$(date -u -d "$OLDEST_START" +%s 2>/dev/null || echo "")
+                if [ -n "$STARTED_EPOCH" ]; then
+                  AGE=$((NOW_EPOCH - STARTED_EPOCH))
+                fi
+              fi
+
+              if [ -n "$AGE" ] && [ "$AGE" -gt "$STALE_BOUND_SECONDS" ]; then
+                echo "  PR #$PR has $COUNT non-terminal check(s), oldest running ${AGE}s (> ${STALE_BOUND_SECONDS}s bound) — treating as wedged (#13401 class), eligible to refresh."
+                # Falls through to the refresh below.
+              else
+                # Genuinely still running (or age unknown) — do NOT refresh
+                # it, and do NOT stop here: move on to the next PR in the
+                # queue instead of letting this one gate everyone behind it.
+                echo "  PR #$PR is due but has $COUNT check(s) still running${AGE:+ (${AGE}s so far)} — leaving it running, checking the next PR in the queue."
+                SKIPPED_BUSY=$((SKIPPED_BUSY + 1))
+                continue
+              fi
             fi
 
             echo "Updating PR #$PR..."
@@ -238,7 +297,25 @@ jobs:
           done
 
           echo ""
-          echo "Done: $UPDATED updated, $FAILED need manual attention."
+          echo "Done: $UPDATED updated, $FAILED need manual attention, $SKIPPED_BUSY skipped as still in flight."
+
+          # #14022 review fix (MEDIUM): "0 updated" is ambiguous — it means
+          # either "nothing was behind" (already reported above and exited
+          # earlier) or "everything behind was busy" (a starved queue). Make
+          # the second case visible instead of indistinguishable from a
+          # quiet, healthy run: a log-level warning annotation (surfaces in
+          # the Actions UI run list) plus a job-summary line (surfaces on the
+          # run page without opening logs).
+          if [ "$UPDATED" -eq 0 ] && [ "$SKIPPED_BUSY" -gt 0 ]; then
+            echo "::warning::auto-update-pr-branches: 0 PRs refreshed this push — all $SKIPPED_BUSY candidate(s) at the head of the queue are still mid-run. Queue is busy, not empty."
+            {
+              echo "### auto-update-pr-branches: queue busy, not empty"
+              echo ""
+              echo "$SKIPPED_BUSY PR(s) at the head of the queue were mid-run and skipped this push; 0 were refreshed."
+              echo "This means the #9300 drift-protection net did not run for any PR on this push — by design, not by failure — because every candidate is still being tested against an earlier base."
+              echo "If this repeats across many consecutive pushes, check whether the head-of-queue PR is a $STALE_BOUND_SECONDS-second-bound candidate (wedged) rather than genuinely still running."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
           # Never fail — conflicting PRs just need human resolution
           exit 0
 

--- a/.github/workflows/auto-update-pr-branches.yml
+++ b/.github/workflows/auto-update-pr-branches.yml
@@ -233,6 +233,9 @@ jobs:
           # binary is required beyond what this file already depends on.
           check_pr_state() {
             local pr="$1"
+            # shellcheck disable=SC2016 -- `$c` below is a jq variable, not a
+            # shell one. Single quotes are required: letting the shell expand it
+            # would substitute an empty string and break the filter.
             gh pr view "$pr" --repo "$REPO" --json statusCheckRollup \
               --jq '([.statusCheckRollup[] | select((.status != null and .status != "" and .status != "COMPLETED") or (.state == "PENDING"))]) as $c | (($c | length | tostring) + "|" + (($c | map(select(.startedAt != null and .startedAt != "")) | map(.startedAt) | min) // ""))' \
               2>/dev/null || echo "0|"


### PR DESCRIPTION
Closes #14022

## Thinking Path

`auto-update-pr-branches.yml` already capped refreshes at 1-per-push, oldest PR first (#13426). The remaining bug: it never checked whether that PR's *own* checks from the previous refresh had finished before merging base into it again. Verified live today (2026-08-11): PR #13945 was refreshed at 13:21, 13:33 and 13:43 — three resets in 22 minutes — and at 14:09, over 26 minutes after the last reset, it still had 22 checks in flight (`mergeStateStatus: BLOCKED`). Each push was faster than the check set it kept discarding.

**The premise in the file's own header had expired.** It said `strict: true` on `Dev_new_gui` makes this job the only thing that clears "behind" and therefore the only path to mergeability:
```
$ gh api repos/mrveiss/AutoBot-AI/branches/Dev_new_gui/protection --jq '.required_status_checks.strict'
false
```
Confirmed against both the legacy branch-protection API and the active ruleset (`Require review for external contributors`, id 17190144) — neither reimposes `strict`. `strict: false` was the recorded decision on #13801. Being behind base no longer blocks a merge, so the churn was not required for mergeability at all — it was only ever useful for the #9300 drift-protection reason (catching a *semantic* conflict between an already-merged PR and a still-open one), and that only needs each PR tested against current base once, at its turn, not reset on every unrelated merge while it's still running.

**Merging PR A does not itself invalidate PR B's checks.** B's head commit is unchanged, so its completed checks stay valid and attached to that SHA. The only reason B re-ran was that this workflow rewrote B's head by merging base into it. The reruns were manufactured by this workflow, not required by GitHub or by the merge gates.

**Options considered, and why I didn't pick "post-merge CI on base covers it":**
- Remove the refresh entirely — rejected. It would mean a PR's last CI run could predate several merges to base, so a genuine semantic break could reach `Dev_new_gui` with nothing having tested the combination.
- Rely on `ci.yml`'s `push: [Dev_new_gui]` trigger (it does run the full 12-shard python-suite post-merge, confirmed by reading the workflow) instead of refreshing PRs — rejected as the sole net. That workflow's own comment documents the identical failure mode already having happened to it: "of the last 39 completed base runs, 26 were cancelled and NONE succeeded" before a `cancel-in-progress: false` fix (#13432). Relying on it alone would trade one already-documented-unreliable safety net for another, and even now it's a once-per-merge, after-the-fact check — a break it catches has already landed on the shared branch.
- **Native GitHub merge queue** — this is structurally the right tool (serialize entrants, test each against base + queue ahead of it, merge when green) and I confirmed it's available here: the repo is public, owned by a User account, and merge queue is on GitHub Free for public repos. It is not configured (`gh api repos/mrveiss/AutoBot-AI/rules/branches/Dev_new_gui` shows only the review-count ruleset). But flipping it on is not safe as a same-PR change: as of the review that produced this PR, none of the ten required-context workflows had a `merge_group:` trigger (checked with `grep -L merge_group` against each of the ten workflow files by name, since this file's own prose now contains the string `merge_group` and would make a blanket `grep -rl` over the whole directory misleading), and a merge queue evaluates required contexts against a `merge_group` ref — a workflow that only triggers on `pull_request` never fires for it. Enabling the ruleset without first adding `merge_group:` triggers to all ten required-context workflows would deadlock the queue (every entrant waits forever for contexts that never start), on a repo whose recovery jobs were already moved off the singleton runner once for this exact class of failure (#13401). That is a real migration — filed as **#14054** with the required order (add triggers → verify each → confirm the #12823 bot-attribution job's fate → enable the rule → retire this workflow) — not something to land untested inside a fix for the churn bug.
- **Serialize the refresh in-place (chosen)** — gate the existing FIFO refresh on the target PR's own check-run state: only refresh the head-of-queue PR when it is *not* currently mid-run. This keeps the drift protection the owner wants (every PR still gets tested against current base, and now closer to its actual merge time than before) while removing the N-times-per-session reset, with a one-file, staticly-verifiable change.

## What Changed

`.github/workflows/auto-update-pr-branches.yml`:

- Added `check_pr_state()`: checks the candidate PR's `statusCheckRollup` for any Check Run not `COMPLETED` or any legacy Status API context still `PENDING` (both shapes appear in the rollup), and returns the oldest non-terminal `startedAt` alongside the count.
- The refresh loop now, per push: walk the FIFO-behind list; for each candidate, if it is mid-run and under the staleness bound, **skip it and evaluate the next candidate** (not stop — see "Review fix" below); if it is idle, or mid-run but past the staleness bound, refresh it and stop (still capped at one refresh per push via `MAX_BRANCH_UPDATES`); if `update-branch` fails on a real conflict, also move to the next candidate.
- Rewrote the file header: removed the expired `strict: true` rationale, recorded the `strict: false` verification and its source (#13801), stated the merge-queue evaluation and why it's deferred to #14054, and explained why base-push CI alone isn't a substitute.
- `approve-refreshed-runs` is **unchanged** — refreshes still happen (once per PR turn instead of once per push), so the runs they trigger can still land `action_required` under the fork-PR bot-attribution policy (#12823) and still need repair. Retiring it now would leave the next refresh's runs parked.
- `MAX_BRANCH_UPDATES` is kept at `1` with its rationale updated — it still bounds one push to one refresh; the new behaviour is *when* that refresh is allowed to happen, not how many.

Filed **#14054**: migrate to native GitHub merge queue, with the `merge_group`-trigger prerequisite spelled out so it isn't attempted as a same-day ruleset flip.

## Verification

Could not trigger a live push to `Dev_new_gui` (protected branch, per task constraints) — verified statically and against read-only live data instead:

- **YAML validity**: `venv/bin/python -c "import yaml; yaml.safe_load(open(...))"` — parses, both jobs present.
- **Bash syntax**: extracted the `run:` block and ran `bash -n` — no syntax errors. `actionlint` is not installed in this environment and installing it would be an ad-hoc install outside the sanctioned toolchain, so this is the available substitute.
- **`strict` re-verified** two ways: legacy `branches/.../protection` (`strict: false`) and the active ruleset list (`rules/branches/Dev_new_gui` — only a `pull_request` review-count rule, no `required_status_checks` rule reimposing strict).
- **Dry run of the selection logic against live, read-only data** (11 open PRs against `Dev_new_gui` at time of writing):
  - Old logic would pick PR #13955 (oldest of 9 behind PRs) and refresh it unconditionally.
  - New logic checks #13955's `statusCheckRollup` first: 0 in-flight checks → idle → same outcome, refreshed. (No PR was in-flight at the exact moment I ran the dry run, so this run doesn't exercise the skip path — see next bullet for that.)
  - Confirmed the skip path *does* fire, against real data: PR #13945 currently shows 22 non-completed checks (`is_in_flight` returns true) after being refreshed at 13:43. Under the **old** logic, a push arriving right now would reset it a 4th time. Under the **new** logic, it is correctly excluded — it isn't even in the "behind" list anymore since its own refresh already caught it up, and the in-flight check independently confirms it would be skipped if it were.
- **Before/after count, quantified from today's run history** (`gh run list --workflow auto-update-pr-branches.yml`, 31 runs today as of writing): PR #13945 was reset 3 times in 22 minutes (13:21, 13:33, 13:43) with each run confirmed via `gh run view --log` to have merged base into it while its predecessor's checks were still running (its current run, started at the 13:43 refresh, was still 22-checks-in-flight 26+ minutes later at the time of this PR). Under the new gate, only the 13:21 refresh would have proceeded — 13:33 and 13:43 would both have found it in-flight and skipped, since its run duration already exceeds the 12-minute and 22-minute gaps between those pushes. **3 resets → 1 reset** for this PR in this window; generalizing, a session with N merges against the same head-of-queue PR now costs at most 1 reset (the first) instead of up to N, because every subsequent push finds it mid-run and defers.
- Could not verify end-to-end (a real push resetting nothing while a PR's checks complete) without a live merge to `Dev_new_gui`, which I'm not permitted to trigger for this PR. Stated plainly per the task's verification constraints.

## Review fix — starved-tail blocker (2026-08-11)

Review caught a real blocker in the first version: when the head-of-queue PR was busy, the loop `break`d out entirely, so every idle PR behind it was never even evaluated. Confirmed live before fixing: with PR #13945 busy (16-26 non-terminal checks, fluctuating), PRs #13955/#13991/#14002/#14003 were fully idle but would never have been reached. That converts "the head thrashes" into "the tail never updates" — and does so silently, since the job still exits 0.

**Fix 1 — `continue` instead of `break`.** A busy candidate is now skipped, and the loop evaluates the next PR in FIFO order. `MAX_BRANCH_UPDATES=1` already bounds actual refreshes to one per push, so scanning past several busy candidates to find a refreshable one does not reintroduce the reset amplification #14022 exists to remove.

**Fix 2 — staleness bound (HIGH), so "in-flight" cannot mean "wedged forever".** `is_in_flight`-style detection with no time bound would let a check stuck in `QUEUED` (the #13401 singleton-runner-outage class) block a PR's turn indefinitely while reporting green. Added `STALE_BOUND_SECONDS=5400` (90 minutes): a candidate whose oldest non-terminal check has been running longer than that is treated as no longer eligible to block — it is left running, but its "busy" status no longer gates the queue. Justification, not a round number: sampled the last 14 completed `pull_request` runs of `ci.yml` (heaviest required-check workflow, 12-shard python-suite included) on 2026-08-11 — durations ranged 14–71 minutes, median ~22, max 70m39s. 90 minutes gives ~19 minutes of margin above the worst *observed* legitimate run, while staying far short of an outage-class wedge (hours, not tens of minutes, per the #13401 post-mortem).

**Fix 3 — starvation is now observable (MEDIUM).** A run that refreshes nothing because every behind PR was busy now emits a `::warning::` log annotation (visible in the Actions run list without opening logs) and a `$GITHUB_STEP_SUMMARY` block distinguishing "queue busy" from "nothing was behind" (which already exits earlier with its own message). I did not add cross-run escalation-after-N-consecutive-occurrences — the review flagged that as "ideally", not required, and implementing it would need persisted state across runs (a new repo-variable write, its own permission grant, and its own blast radius) that a same-PR fix for a starvation bug shouldn't introduce inline. Filed as a scoped fast-follow: #14058.

**Two things review confirmed correct and I left unchanged:** the check-state parsing (handles both `CheckRun` and legacy `StatusContext` shapes, including the `status=COMPLETED, conclusion=ACTION_REQUIRED` parked shape, without the known conclusion-filter trap), and the #13401 runner isolation (both jobs stay on `ubuntu-latest`).

### Dry run: the four previously-starved PRs are now considered

Live #13945 has since caught up (it's no longer "behind", so it dropped out of the real queue on its own) — so to reproduce the exact review scenario I forced the FIFO list back to `13945 13955 13991 14002 14003` against live check-state data:

```
Simulated behind queue (FIFO), forcing the review's exact scenario: 13945 13955 13991 14002 14003
---
  PR #13945: 26 non-terminal, age 106s -> SKIP (busy), continue to next  [OLD CODE WOULD 'break' HERE AND STOP]
  PR #13955: IDLE -> WOULD REFRESH (dry run: no API call made) [NEW CODE REACHES THIS PR]
---
NEW CODE RESULT: would-update=1 skipped-busy=1
OLD CODE (break) RESULT: would-update=0 skipped-busy=1 (never evaluated 13955/13991/14002/14003 at all)
```

Also verified the staleness-bypass path fires correctly with a shortened bound (`STALE_BOUND_SECONDS=60` for the test only): PR #13945 at 119s age is correctly reclassified `> bound -> WOULD REFRESH (stale-bypass)` instead of being skipped — confirming a wedged check does not block forever.

## Model Used

Sonnet 5