### PR TITLE
fix(audit): give the worker an owned filing credential, not ambient CLI auth (#13859)

### DIFF
--- a/autobot-backend/workers/audit_filing_credential_13859_test.py
+++ b/autobot-backend/workers/audit_filing_credential_13859_test.py
@@ -37,8 +37,9 @@ class TestTheTokenReachesTheSubprocess:
         adapter sets both for the same reason."""
         monkeypatch.setattr(audit_tasks, "_resolve_filing_token", lambda: "tok-abc")
 
-        env = audit_tasks._gh_env()
+        env, from_vault = audit_tasks._gh_env()
 
+        assert from_vault is True
         assert env["GH_TOKEN"] == "tok-abc"
         assert env["GITHUB_TOKEN"] == "tok-abc"
 
@@ -48,8 +49,9 @@ class TestTheTokenReachesTheSubprocess:
         monkeypatch.setattr(audit_tasks, "_resolve_filing_token", lambda: None)
         monkeypatch.delenv("GH_TOKEN", raising=False)
 
-        env = audit_tasks._gh_env()
+        env, from_vault = audit_tasks._gh_env()
 
+        assert from_vault is False
         assert "GH_TOKEN" not in env
 
     def test_file_issue_passes_the_credential(self, monkeypatch):
@@ -91,15 +93,18 @@ class TestRevocationIsPossible:
         tokens = iter(["first", "second"])
         monkeypatch.setattr(audit_tasks, "_resolve_filing_token", lambda: next(tokens))
 
-        assert audit_tasks._gh_env()["GH_TOKEN"] == "first"
-        assert audit_tasks._gh_env()["GH_TOKEN"] == "first", "should be cached within a run"
+        assert audit_tasks._gh_env()[0]["GH_TOKEN"] == "first"
+        assert audit_tasks._gh_env()[0]["GH_TOKEN"] == "first", "should be cached within a run"
 
         audit_tasks.reset_gh_env_cache()
 
-        assert audit_tasks._gh_env()["GH_TOKEN"] == "second", "a new run must re-read the vault"
+        assert audit_tasks._gh_env()[0]["GH_TOKEN"] == "second", "a new run must re-read the vault"
 
-    def test_availability_check_resets_the_cache(self, monkeypatch):
-        """Every task calls this first, so it is where the fresh read belongs."""
+    def test_each_task_resets_before_its_first_gh_call(self, monkeypatch):
+        """The reset must precede `_list_open_issues`, not sit inside
+        `_gh_available`: every task lists issues FIRST, so the run's first gh
+        call carried the previous run's token. A revoked one there returns [],
+        which empties existing_titles and silently disables dedupe."""
         calls = {"n": 0}
 
         def _count():
@@ -109,10 +114,22 @@ class TestRevocationIsPossible:
         monkeypatch.setattr(audit_tasks, "_resolve_filing_token", _count)
         monkeypatch.setattr(audit_tasks, "_run", lambda cmd, cwd=None, env=None: (0, "", ""))
 
-        audit_tasks._gh_available()
-        audit_tasks._gh_available()
+        import ast
+        import inspect
 
-        assert calls["n"] == 2, "the availability check must re-read the vault each run"
+        source = inspect.getsource(audit_tasks)
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            if not (isinstance(node, ast.FunctionDef) and node.name.startswith("audit_")):
+                continue
+            names = [n.func.id for n in ast.walk(node) if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)]
+            assert "reset_gh_env_cache" in names, f"{node.name} never drops the cached credential"
+            first_gh = next((i for i, nm in enumerate(names) if nm in {"_list_open_issues", "_gh_available"}), None)
+            if first_gh is not None:
+                assert (
+                    names.index("reset_gh_env_cache") < first_gh
+                ), f"{node.name} resets AFTER its first gh call — that call uses the previous run's token"
+        assert calls["n"] >= 0
 
 
 class TestTheGapIsReportedEvenWhenItWorks:
@@ -122,7 +139,12 @@ class TestTheGapIsReportedEvenWhenItWorks:
         import logging
 
         monkeypatch.setattr(audit_tasks, "_resolve_filing_token", lambda: None)
-        monkeypatch.delenv("GH_TOKEN", raising=False)
+        # An AMBIENT token present, deliberately. The first version of this test
+        # deleted it, which is why it passed against a detector that answered
+        # "does this process have a GH_TOKEN anywhere?" instead of "did the vault
+        # give me one?" — docker-compose injects an empty GH_TOKEN
+        # unconditionally, and the pre-#13859 log told operators to set one.
+        monkeypatch.setenv("GH_TOKEN", "ambient-leftover")
         monkeypatch.setattr(audit_tasks, "_run", lambda cmd, cwd=None, env=None: (0, "ok", ""))
 
         with caplog.at_level(logging.WARNING):

--- a/autobot-backend/workers/audit_filing_credential_13859_test.py
+++ b/autobot-backend/workers/audit_filing_credential_13859_test.py
@@ -1,0 +1,156 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""The audit worker's filing credential must be owned, not ambient (#13859).
+
+The worker filed GitHub issues by shelling out to `gh` and relying entirely on
+whatever CLI session existed for the account Celery happened to run as. Nothing
+owned that credential, nothing rotated it, nothing audited its use, and the only
+place its absence surfaced was a log line — which is precisely how it lapsed
+unnoticed in #13570, where findings were queued for days while every clean run
+looked identical to a healthy one.
+
+CLAUDE.md requires credentials to travel via the canonical secrets manager under
+grant/audit/revocation, never as ambient state on a host.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+audit_tasks = importlib.import_module("workers.audit_tasks")
+
+
+@pytest.fixture(autouse=True)
+def _clean_cache():
+    audit_tasks.reset_gh_env_cache()
+    yield
+    audit_tasks.reset_gh_env_cache()
+
+
+class TestTheTokenReachesTheSubprocess:
+    def test_a_vault_token_is_exported_under_both_names(self, monkeypatch):
+        """Different gh subcommands read different variables — the Copilot
+        adapter sets both for the same reason."""
+        monkeypatch.setattr(audit_tasks, "_resolve_filing_token", lambda: "tok-abc")
+
+        env = audit_tasks._gh_env()
+
+        assert env["GH_TOKEN"] == "tok-abc"
+        assert env["GITHUB_TOKEN"] == "tok-abc"
+
+    def test_no_token_leaves_the_environment_untouched(self, monkeypatch):
+        """Ambient auth still works — this must not break filing on a host that
+        has not stored a token yet."""
+        monkeypatch.setattr(audit_tasks, "_resolve_filing_token", lambda: None)
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+
+        env = audit_tasks._gh_env()
+
+        assert "GH_TOKEN" not in env
+
+    def test_file_issue_passes_the_credential(self, monkeypatch):
+        """The call that actually needs it. Threading the env through
+        `_gh_available` alone would authenticate the CHECK and not the write."""
+        monkeypatch.setattr(audit_tasks, "_resolve_filing_token", lambda: "tok-file")
+        seen: dict[str, object] = {}
+
+        def _fake_run(cmd, cwd=None, env=None):
+            seen["cmd"] = cmd
+            seen["env"] = env
+            return 0, "", ""
+
+        monkeypatch.setattr(audit_tasks, "_run", _fake_run)
+
+        assert audit_tasks._file_issue("t", "b") is True
+        assert seen["cmd"][:3] == ["gh", "issue", "create"]
+        assert (seen["env"] or {}).get("GH_TOKEN") == "tok-file"
+
+    def test_listing_issues_passes_the_credential(self, monkeypatch):
+        monkeypatch.setattr(audit_tasks, "_resolve_filing_token", lambda: "tok-list")
+        seen: dict[str, object] = {}
+
+        def _fake_run(cmd, cwd=None, env=None):
+            seen["env"] = env
+            return 0, "[]", ""
+
+        monkeypatch.setattr(audit_tasks, "_run", _fake_run)
+        audit_tasks._list_open_issues()
+
+        assert (seen["env"] or {}).get("GH_TOKEN") == "tok-list"
+
+
+class TestRevocationIsPossible:
+    def test_the_cache_is_dropped_between_runs(self, monkeypatch):
+        """Celery workers are long-lived. Without a reset a revoked token keeps
+        working for the life of the process, which defeats the revocation this
+        issue exists to provide."""
+        tokens = iter(["first", "second"])
+        monkeypatch.setattr(audit_tasks, "_resolve_filing_token", lambda: next(tokens))
+
+        assert audit_tasks._gh_env()["GH_TOKEN"] == "first"
+        assert audit_tasks._gh_env()["GH_TOKEN"] == "first", "should be cached within a run"
+
+        audit_tasks.reset_gh_env_cache()
+
+        assert audit_tasks._gh_env()["GH_TOKEN"] == "second", "a new run must re-read the vault"
+
+    def test_availability_check_resets_the_cache(self, monkeypatch):
+        """Every task calls this first, so it is where the fresh read belongs."""
+        calls = {"n": 0}
+
+        def _count():
+            calls["n"] += 1
+            return "tok"
+
+        monkeypatch.setattr(audit_tasks, "_resolve_filing_token", _count)
+        monkeypatch.setattr(audit_tasks, "_run", lambda cmd, cwd=None, env=None: (0, "", ""))
+
+        audit_tasks._gh_available()
+        audit_tasks._gh_available()
+
+        assert calls["n"] == 2, "the availability check must re-read the vault each run"
+
+
+class TestTheGapIsReportedEvenWhenItWorks:
+    def test_ambient_auth_is_reported_on_every_run(self, monkeypatch, caplog):
+        """The whole failure mode was invisibility: ambient auth that happens to
+        work looks identical to an owned credential until the day it lapses."""
+        import logging
+
+        monkeypatch.setattr(audit_tasks, "_resolve_filing_token", lambda: None)
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        monkeypatch.setattr(audit_tasks, "_run", lambda cmd, cwd=None, env=None: (0, "ok", ""))
+
+        with caplog.at_level(logging.WARNING):
+            assert audit_tasks._gh_available() is True
+
+        assert any("no vault-owned filing credential" in r.message for r in caplog.records)
+
+    def test_a_vault_backed_run_is_not_warned_about(self, monkeypatch, caplog):
+        """The direction that must stay true — a warning on every run would be
+        noise nobody reads, which is how the original lapse survived."""
+        import logging
+
+        monkeypatch.setattr(audit_tasks, "_resolve_filing_token", lambda: "tok")
+        monkeypatch.setattr(audit_tasks, "_run", lambda cmd, cwd=None, env=None: (0, "ok", ""))
+
+        with caplog.at_level(logging.WARNING):
+            audit_tasks._gh_available()
+
+        assert not any("no vault-owned filing credential" in r.message for r in caplog.records)
+
+    def test_a_vault_outage_does_not_kill_the_audit_run(self, monkeypatch):
+        """Filing is best-effort; an unreachable vault must degrade to ambient
+        auth rather than take the whole audit down."""
+
+        def _boom():
+            raise RuntimeError("vault unreachable")
+
+        monkeypatch.setattr(audit_tasks, "_read_filing_token", _boom)
+        monkeypatch.setattr(audit_tasks, "run_or_schedule", lambda coro: _boom())
+
+        assert audit_tasks._resolve_filing_token() is None

--- a/autobot-backend/workers/audit_tasks.py
+++ b/autobot-backend/workers/audit_tasks.py
@@ -53,7 +53,7 @@ except ValueError:
 _GH_REPO = "mrveiss/AutoBot-AI"
 # #13859: canonical name of the issue-filing token in the SYSTEM vault. The
 # worker had no owned credential at all — see _resolve_filing_token.
-_FILING_TOKEN_SECRET = "github_issue_filing_token"
+_FILING_TOKEN_SECRET = "github_issue_filing_token"  # nosec B105  # a secret NAME, not a value
 
 # Labels applied to all discovery issues filed by this daemon
 _AUDIT_LABELS = "enhancement,observability,priority: medium"

--- a/autobot-backend/workers/audit_tasks.py
+++ b/autobot-backend/workers/audit_tasks.py
@@ -51,9 +51,17 @@ except ValueError:
 
 # GitHub repo used for filing issues
 _GH_REPO = "mrveiss/AutoBot-AI"
-# #13859: canonical name of the issue-filing token in the SYSTEM vault. The
-# worker had no owned credential at all — see _resolve_filing_token.
-_FILING_TOKEN_SECRET = "github_issue_filing_token"  # nosec B105  # a secret NAME, not a value
+# #13859: the KEY the issue-filing credential is stored under in the SYSTEM
+# vault. Not the credential — see _resolve_filing_token, which reads it.
+#
+# Named for what it is after both scanners disagreed with the old name
+# `_FILING_TOKEN_SECRET`: bandit raised B105 (hardcoded password) and CodeQL
+# raised two high-severity clear-text-logging alerts, because logging this
+# constant looked like logging a secret. They were reacting to a genuinely
+# misleading name, so the name changed rather than the warnings being
+# suppressed. A scanner-suppression comment here would have taught the next
+# reader that this file logs secrets and that we decided not to mind.
+_FILING_CREDENTIAL_VAULT_KEY = "github_issue_filing_token"
 
 # Labels applied to all discovery issues filed by this daemon
 _AUDIT_LABELS = "enhancement,observability,priority: medium"
@@ -176,7 +184,7 @@ async def _read_filing_token() -> str | None:
     owner_str = owner.to_str()
     async for session in get_async_session():
         result = await session.execute(
-            select(Secret).where(Secret.name == _FILING_TOKEN_SECRET, Secret.owner_vault == owner_str)
+            select(Secret).where(Secret.name == _FILING_CREDENTIAL_VAULT_KEY, Secret.owner_vault == owner_str)
         )
         row = result.scalar_one_or_none()
         if row is None:
@@ -294,7 +302,7 @@ def _gh_available() -> bool:
             "ambient `gh` CLI auth for whichever account this worker runs as. "
             "Store a token as '%s' in the system vault to get grant, audit and "
             "revocation. (#13859)",
-            _FILING_TOKEN_SECRET,
+            _FILING_CREDENTIAL_VAULT_KEY,
         )
     code, out, err = _run(["gh", "auth", "status"], env=env)
     if code != 0:
@@ -305,7 +313,7 @@ def _gh_available() -> bool:
             "vault, or authenticate gh for the service account. gh said: %s",
             _GH_REPO,
             "system vault" if vault_backed else "ambient CLI auth",
-            _FILING_TOKEN_SECRET,
+            _FILING_CREDENTIAL_VAULT_KEY,
             # stdout as well as stderr: gh routes this message to stderr today,
             # but a build that changed that would gut the diagnostic silently.
             ((err or "").strip() or (out or "").strip())[:_MAX_LOG_CHARS] or "no output",

--- a/autobot-backend/workers/audit_tasks.py
+++ b/autobot-backend/workers/audit_tasks.py
@@ -179,7 +179,8 @@ async def _read_filing_token() -> str | None:
         try:
             raw = await EnvelopeSecretsService().read(session, secret_id=row.id, accessible_vaults=[owner])
         except (SecretNotFoundError, SecretAccessError) as exc:
-            logger.warning("audit: filing token present but unreadable: %s", exc)
+            # Class name only — same reason as above.
+            logger.warning("audit: filing token present but unreadable (%s)", type(exc).__name__)
             return None
         return raw.decode("utf-8").strip() or None
     return None

--- a/autobot-backend/workers/audit_tasks.py
+++ b/autobot-backend/workers/audit_tasks.py
@@ -185,7 +185,9 @@ async def _read_filing_token() -> str | None:
     return None
 
 
-_gh_env_cache: dict[str, str] | None = None
+# (env, came_from_vault) — one fact, cached together. Deriving the second from
+# the first is what made the detector lie (#13859 review).
+_gh_env_cache: tuple[dict[str, str], bool] | None = None
 
 
 def reset_gh_env_cache() -> None:
@@ -199,25 +201,36 @@ def reset_gh_env_cache() -> None:
     _gh_env_cache = None
 
 
-def _gh_env() -> dict[str, str]:
-    """Subprocess environment for every `gh` call (#13859).
+def _gh_env() -> tuple[dict[str, str], bool]:
+    """Subprocess environment for every `gh` call, and whether the vault
+    supplied the token (#13859).
 
     Mirrors the LLC Copilot adapter: both GH_TOKEN and GITHUB_TOKEN, because
     different gh subcommands read different ones.
+
+    Returns the flag rather than letting callers test `"GH_TOKEN" in env`. That
+    test answers "does this process have a token anywhere?", which is a
+    different question: the env starts as a copy of os.environ, and an ambient
+    GH_TOKEN is exactly what the pre-#13859 CRITICAL log told operators to set
+    — docker-compose injects an empty one unconditionally. Deriving the flag
+    that way reported ambient state as vault-owned, suppressed the warning this
+    change exists to emit, and told the operator the credential came from the
+    vault while asking them to put one there.
 
     Cached per run: a task files one issue per finding, and a vault round-trip
     per finding would be pure waste.
     """
     global _gh_env_cache
     if _gh_env_cache is not None:
-        return dict(_gh_env_cache)
+        env, from_vault = _gh_env_cache
+        return dict(env), from_vault
     env = dict(os.environ)
     token = _resolve_filing_token()
     if token:
         env["GH_TOKEN"] = token
         env["GITHUB_TOKEN"] = token
-    _gh_env_cache = env
-    return dict(env)
+    _gh_env_cache = (env, bool(token))
+    return dict(env), bool(token)
 
 
 def _repo_root() -> Path:
@@ -242,7 +255,7 @@ def _list_open_issues(label: str | None = None) -> list[str]:
     ]
     if label:
         cmd += ["--label", label]
-    code, out, _ = _run(cmd, env=_gh_env())
+    code, out, _ = _run(cmd, env=_gh_env()[0])
     if code != 0:
         return []
     try:
@@ -263,10 +276,7 @@ def _gh_available() -> bool:
     identical to a healthy one, so there was no way to tell when filing broke or
     how much had been deferred since.
     """
-    # Fresh credential each run — see reset_gh_env_cache.
-    reset_gh_env_cache()
-    env = _gh_env()
-    vault_backed = "GH_TOKEN" in env
+    env, vault_backed = _gh_env()
     if not vault_backed:
         # #13859: ambient CLI auth is not an owned credential. Nothing rotates
         # it, nothing audits its use, and nothing can revoke it — which is how
@@ -313,7 +323,7 @@ def _file_issue(title: str, body: str, labels: str = _AUDIT_LABELS) -> bool:
             "--label",
             labels,
         ],
-        env=_gh_env(),
+        env=_gh_env()[0],
     )
     if code != 0:
         logger.error("gh issue create failed (%s): %s", title, err[:_MAX_LOG_CHARS])
@@ -588,6 +598,12 @@ def _testgap_findings(modules: list[Path], repo_root: Path) -> list[dict]:
 @celery_app.task(bind=True, name="workers.audit_testgaps")
 def audit_testgaps(self) -> dict:
     """Every-6h task: find Python modules changed since last run that lack tests."""
+    # #13859: FIRST thing in the task. reset_gh_env_cache() used to live
+    # inside _gh_available(), but every task calls _list_open_issues()
+    # before that — so the run's first gh call carried the PREVIOUS run's
+    # token. A revoked one there returns [], which empties existing_titles
+    # and silently disables dedupe, re-filing every finding.
+    reset_gh_env_cache()
     redis = _get_redis()
     last_run = _redis_get(redis, _TESTGAPS_LAST_RUN_KEY)
     run_at = utc_timestamp()
@@ -653,6 +669,12 @@ def _dead_code_fingerprint(line: str) -> str:
 @celery_app.task(bind=True, name="workers.audit_dead_code")
 def audit_dead_code(self) -> dict:
     """Daily task: run vulture, file issues only for findings new since last run."""
+    # #13859: FIRST thing in the task. reset_gh_env_cache() used to live
+    # inside _gh_available(), but every task calls _list_open_issues()
+    # before that — so the run's first gh call carried the PREVIOUS run's
+    # token. A revoked one there returns [], which empties existing_titles
+    # and silently disables dedupe, re-filing every finding.
+    reset_gh_env_cache()
     redis = _get_redis()
     last_inventory: list[str] = _redis_get(redis, _DEAD_CODE_INVENTORY_KEY) or []
     last_set = set(last_inventory)
@@ -790,6 +812,12 @@ def _write_verification_doc(repo_root: Path, verified: list, unverified: list) -
 @celery_app.task(bind=True, name="workers.audit_claims")
 def audit_claims(self) -> dict:
     """Weekly task: verify README/docs capability claims have wired implementations."""
+    # #13859: FIRST thing in the task. reset_gh_env_cache() used to live
+    # inside _gh_available(), but every task calls _list_open_issues()
+    # before that — so the run's first gh call carried the PREVIOUS run's
+    # token. A revoked one there returns [], which empties existing_titles
+    # and silently disables dedupe, re-filing every finding.
+    reset_gh_env_cache()
     redis = _get_redis()
     _redis_get(redis, _CLAIMS_LAST_RUN_KEY)
     run_at = utc_timestamp()

--- a/autobot-backend/workers/audit_tasks.py
+++ b/autobot-backend/workers/audit_tasks.py
@@ -25,6 +25,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from autobot_shared.async_compat import run_or_schedule
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.time_utils import utc_timestamp
 from celery_app import celery_app
@@ -50,6 +51,9 @@ except ValueError:
 
 # GitHub repo used for filing issues
 _GH_REPO = "mrveiss/AutoBot-AI"
+# #13859: canonical name of the issue-filing token in the SYSTEM vault. The
+# worker had no owned credential at all — see _resolve_filing_token.
+_FILING_TOKEN_SECRET = "github_issue_filing_token"
 
 # Labels applied to all discovery issues filed by this daemon
 _AUDIT_LABELS = "enhancement,observability,priority: medium"
@@ -111,7 +115,7 @@ def _redis_set(redis, key: str, value: Any, ttl: int | None = 86400 * 14) -> boo
         return False
 
 
-def _run(cmd: list[str], cwd: str | None = None) -> tuple[int, str, str]:
+def _run(cmd: list[str], cwd: str | None = None, env: dict[str, str] | None = None) -> tuple[int, str, str]:
     """Run *cmd*, return (returncode, stdout, stderr). Never raises."""
     try:
         result = subprocess.run(  # nosec B603
@@ -119,11 +123,101 @@ def _run(cmd: list[str], cwd: str | None = None) -> tuple[int, str, str]:
             capture_output=True,
             text=True,
             cwd=cwd,
+            env=env,
             timeout=60,
         )
         return result.returncode, result.stdout, result.stderr
     except Exception as exc:
         return 1, "", str(exc)
+
+
+def _resolve_filing_token() -> str | None:
+    """Read the issue-filing token from the SYSTEM vault (#13859).
+
+    The worker used to rely entirely on ambient `gh` CLI auth for whichever
+    account Celery happened to run as. Nothing owned that credential, nothing
+    rotated it, nothing audited its use, and the only place its absence showed
+    up was a log line — which is exactly how it lapsed unnoticed in #13570.
+
+    SYSTEM vault and `PrincipalKind.SERVICE`: this is a background task, not a
+    user session, so there is no user vault it could belong to and the audit
+    trail should attribute filings to the service rather than to whoever last
+    logged into the host. `VaultKind.SYSTEM` is documented as the home for
+    "admin-only system secrets (provider keys, internal tokens)".
+
+    Returns None when no token is stored — the caller decides what that means,
+    and says so loudly rather than silently continuing on ambient state.
+    """
+    try:
+        return run_or_schedule(_read_filing_token())
+    except Exception as exc:  # noqa: BLE001 — a vault outage must not kill the audit run
+        logger.warning("audit: vault lookup for the filing token failed: %s", exc)
+        return None
+
+
+async def _read_filing_token() -> str | None:
+    from sqlalchemy import select  # noqa: PLC0415
+
+    from api.user_management.dependencies import get_async_session  # noqa: PLC0415
+    from autobot_shared.secrets_vault import VaultKind, VaultRef  # noqa: PLC0415
+    from models.secret import Secret  # noqa: PLC0415
+    from services.envelope_secrets_service import (  # noqa: PLC0415
+        EnvelopeSecretsService,
+        SecretAccessError,
+        SecretNotFoundError,
+    )
+
+    owner = VaultRef(kind=VaultKind.SYSTEM)
+    owner_str = owner.to_str()
+    async for session in get_async_session():
+        result = await session.execute(
+            select(Secret).where(Secret.name == _FILING_TOKEN_SECRET, Secret.owner_vault == owner_str)
+        )
+        row = result.scalar_one_or_none()
+        if row is None:
+            return None
+        try:
+            raw = await EnvelopeSecretsService().read(session, secret_id=row.id, accessible_vaults=[owner])
+        except (SecretNotFoundError, SecretAccessError) as exc:
+            logger.warning("audit: filing token present but unreadable: %s", exc)
+            return None
+        return raw.decode("utf-8").strip() or None
+    return None
+
+
+_gh_env_cache: dict[str, str] | None = None
+
+
+def reset_gh_env_cache() -> None:
+    """Drop the cached credential so the next run re-reads the vault (#13859).
+
+    Called at the start of every audit task. Celery workers are long-lived, so
+    without this a rotated or revoked token would keep working for the life of
+    the process — which would defeat the revocation this issue is about.
+    """
+    global _gh_env_cache
+    _gh_env_cache = None
+
+
+def _gh_env() -> dict[str, str]:
+    """Subprocess environment for every `gh` call (#13859).
+
+    Mirrors the LLC Copilot adapter: both GH_TOKEN and GITHUB_TOKEN, because
+    different gh subcommands read different ones.
+
+    Cached per run: a task files one issue per finding, and a vault round-trip
+    per finding would be pure waste.
+    """
+    global _gh_env_cache
+    if _gh_env_cache is not None:
+        return dict(_gh_env_cache)
+    env = dict(os.environ)
+    token = _resolve_filing_token()
+    if token:
+        env["GH_TOKEN"] = token
+        env["GITHUB_TOKEN"] = token
+    _gh_env_cache = env
+    return dict(env)
 
 
 def _repo_root() -> Path:
@@ -148,7 +242,7 @@ def _list_open_issues(label: str | None = None) -> list[str]:
     ]
     if label:
         cmd += ["--label", label]
-    code, out, _ = _run(cmd)
+    code, out, _ = _run(cmd, env=_gh_env())
     if code != 0:
         return []
     try:
@@ -169,14 +263,33 @@ def _gh_available() -> bool:
     identical to a healthy one, so there was no way to tell when filing broke or
     how much had been deferred since.
     """
-    code, out, err = _run(["gh", "auth", "status"])
+    # Fresh credential each run — see reset_gh_env_cache.
+    reset_gh_env_cache()
+    env = _gh_env()
+    vault_backed = "GH_TOKEN" in env
+    if not vault_backed:
+        # #13859: ambient CLI auth is not an owned credential. Nothing rotates
+        # it, nothing audits its use, and nothing can revoke it — which is how
+        # it lapsed unnoticed in #13570. Say so on every run, even when the
+        # ambient session happens to work, or the gap stays invisible until the
+        # day it does not.
+        logger.warning(
+            "audit worker has no vault-owned filing credential: falling back to "
+            "ambient `gh` CLI auth for whichever account this worker runs as. "
+            "Store a token as '%s' in the system vault to get grant, audit and "
+            "revocation. (#13859)",
+            _FILING_TOKEN_SECRET,
+        )
+    code, out, err = _run(["gh", "auth", "status"], env=env)
     if code != 0:
         logger.critical(
-            "audit worker cannot file issues: `gh auth status` failed for this "
-            "service account (%s). Every finding this run produces will be queued "
-            "instead of filed. Fix: authenticate gh for the service account, or "
-            "give the worker a GH_TOKEN. gh said: %s",
+            "audit worker cannot file issues: `gh auth status` failed (%s, "
+            "credential source: %s). Every finding this run produces will be "
+            "queued instead of filed. Fix: store a token as '%s' in the system "
+            "vault, or authenticate gh for the service account. gh said: %s",
             _GH_REPO,
+            "system vault" if vault_backed else "ambient CLI auth",
+            _FILING_TOKEN_SECRET,
             # stdout as well as stderr: gh routes this message to stderr today,
             # but a build that changed that would gut the diagnostic silently.
             ((err or "").strip() or (out or "").strip())[:_MAX_LOG_CHARS] or "no output",
@@ -199,7 +312,8 @@ def _file_issue(title: str, body: str, labels: str = _AUDIT_LABELS) -> bool:
             body,
             "--label",
             labels,
-        ]
+        ],
+        env=_gh_env(),
     )
     if code != 0:
         logger.error("gh issue create failed (%s): %s", title, err[:_MAX_LOG_CHARS])

--- a/autobot-backend/workers/audit_tasks.py
+++ b/autobot-backend/workers/audit_tasks.py
@@ -151,7 +151,12 @@ def _resolve_filing_token() -> str | None:
     try:
         return run_or_schedule(_read_filing_token())
     except Exception as exc:  # noqa: BLE001 — a vault outage must not kill the audit run
-        logger.warning("audit: vault lookup for the filing token failed: %s", exc)
+        # Class name only, never the exception text. This is a secrets path, and
+        # a message that happens to interpolate a value would put it in the log.
+        # CodeQL flags it as clear-text-logging-sensitive-data and is right to:
+        # the guarantee should be structural, not a reader having audited every
+        # exception type these calls can raise.
+        logger.warning("audit: vault lookup for the filing token failed (%s)", type(exc).__name__)
         return None
 
 


### PR DESCRIPTION
## Thinking Path

The audit worker files GitHub issues by shelling out to `gh`, and its entire authentication story was:

```python
def _gh_available() -> bool:
    code, _, err = _run(["gh", "auth", "status"])
```

Ambient CLI auth for whichever account Celery happens to run as. Nothing owns that credential, nothing rotates it, nothing audits its use, nothing can revoke it, and the only place its absence surfaces is a log line.

That is not hypothetical — it is how the credential lapsed unnoticed in #13570. Findings were queued for days, and every clean run in between looked identical to a healthy one, so there was no way to tell when filing broke or how much had been deferred since.

## What Changed

The token comes from the SYSTEM vault via `EnvelopeSecretsService` and is passed as `GH_TOKEN` **and** `GITHUB_TOKEN` into the subprocess environment — both names, because different `gh` subcommands read different ones, which is why the LLC Copilot adapter sets both.

## Decision

#13859 asked which principal owns the token, since the worker is not a user session, and noted that whatever is chosen determines what the audit trail attributes the filing to. I took **SYSTEM vault, service principal** rather than parking it:

There is no user vault this could belong to — a scheduled Celery task has no user. Attributing a filing to whoever last authenticated on the host is exactly the property being removed. `VaultKind.SYSTEM` is documented as the home for *"admin-only system secrets (provider keys, internal tokens)"*, and `PrincipalKind.SERVICE` already exists for this shape.

Two details decide whether this actually delivers revocation rather than just relocating the secret:

**The env is cached per run and dropped at the start of each one.** Celery workers are long-lived, so a process-lifetime cache would keep a revoked token working until the worker restarted — which would defeat the point of moving it into the vault at all.

**Ambient fallback is preserved, but never silent.** A host that has not stored a token yet keeps filing, so this does not break anything on deploy — but every such run now says so. The failure mode being fixed is *invisibility*: ambient auth that happens to work looks identical to an owned credential right up until the day it lapses. A vault-backed run stays quiet, or the warning becomes noise nobody reads.

## Verification

```
9 passed   workers/audit_filing_credential_13859_test.py
52 passed  workers/   (full worker suite)
black · isort · flake8 · nosec-format   clean
```

Five mutations, five caught:

| Reverted | Fails |
|---|---|
| only `GH_TOKEN` exported, not `GITHUB_TOKEN` | 1 |
| `_file_issue` loses the credential | 1 |
| `_list_open_issues` loses the credential | 1 |
| per-run cache reset removed (revocation broken) | 1 |
| ambient-auth warning silenced | 1 |

The `_file_issue` mutation is the one worth naming: threading the env through `_gh_available` alone would authenticate the **check** and not the **write**, and every test that only asserted "the token is in the env" would still pass.

Both directions are covered on the warning — a vault-backed run must *not* warn, or the message becomes background noise, which is how the original lapse survived.

## Not in this PR

The secret has to be stored before it does anything. Until an operator writes `github_issue_filing_token` into the system vault, the worker uses ambient auth and says so on every run.

Refs #13859 — part of umbrella #13852.

Not `Closes`: what closes it is a run on a host showing the worker filing with the vault-owned credential, and the ambient-auth warning gone. That is host evidence, and this umbrella has been strict about not closing on merge evidence.

## Model Used

Opus 5 (1M context)