### PR TITLE
fix(llc/frontend): a unit is a root with reports, not any root (#13994)

### DIFF
--- a/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.orgMode.test.ts
+++ b/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.orgMode.test.ts
@@ -18,6 +18,8 @@ vi.mock('@/composables/useConfirmDialog', () => ({
 
 import WorkflowCanvas from '../WorkflowCanvas.vue'
 import type { CanvasNode } from '../canvasNode'
+import { buildOrgCanvasGraph } from '@/composables/llc/orgCanvasGraph'
+import type { OrgNode } from '@/views/llc/OrgTreeNode.vue'
 
 const ORG_NODES: CanvasNode[] = [
   {
@@ -146,6 +148,64 @@ describe('WorkflowCanvas read-only org mode (#13939)', () => {
     expect(tabs[0].classes()).toContain('active')
     await tabs[1].trigger('click')
     expect(wrapper.emitted('tab-selected')).toEqual([['ceo']])
+  })
+})
+
+/** A company member as the org-chart endpoint returns one: a root, no reports. */
+function member(index: number): OrgNode {
+  return {
+    id: `user:${index}`,
+    name: `Person ${index}`,
+    title: 'member',
+    status: 'idle',
+    adapter_type: 'human',
+    is_human: true,
+    last_heartbeat: null,
+    budget_spent: 0,
+    budget_total: 0,
+    assigned_item_count: 0,
+    parent_id: null,
+    children: [],
+  }
+}
+
+// GH#13994: every fixture above is agent-shaped, so the canvas suite never saw
+// what a company of people renders as. It rendered one "unit" box and one tab
+// per person. These cases mount the graph the Org Chart actually hands over and
+// assert the DOM, not that the component mounted.
+describe('WorkflowCanvas draws a company of people (#13994)', () => {
+  const unitLabel = (name: string) => `${name} unit`
+  const people = Array.from({ length: 12 }, (_, i) => member(i))
+
+  it('renders twelve person cards and not one unit box', () => {
+    const nodes = buildOrgCanvasGraph(people, unitLabel)
+    const wrapper = mountCanvas({ nodes, readonly: true })
+
+    expect(wrapper.findAll('.workflow-node.org-person')).toHaveLength(12)
+    expect(wrapper.findAll('.workflow-node.org-group')).toHaveLength(0)
+    expect(wrapper.text()).not.toContain('unit')
+  })
+
+  it('still boxes the one root that has reports, and only that one', () => {
+    const boss: OrgNode = { ...member(99), name: 'Ada', children: [member(0)] }
+    const nodes = buildOrgCanvasGraph([boss, member(1), member(2)], unitLabel)
+    const wrapper = mountCanvas({ nodes, readonly: true })
+
+    const groups = wrapper.findAll('.workflow-node.org-group')
+    expect(groups).toHaveLength(1)
+    expect(groups[0].text()).toContain('Ada unit')
+    expect(wrapper.findAll('.workflow-node.org-person')).toHaveLength(4)
+  })
+
+  it('keeps a bare person clickable — no container, same selection', async () => {
+    const nodes = buildOrgCanvasGraph(people, unitLabel)
+    const wrapper = mountCanvas({ nodes, readonly: true })
+    const cards = wrapper.findAll('.workflow-node.org-person')
+
+    expect(cards[3].text()).toContain('Person 3')
+    await cards[3].trigger('click')
+
+    expect(wrapper.emitted('node-selected')).toEqual([['user:3']])
   })
 })
 

--- a/autobot-frontend/src/composables/llc/__tests__/orgCanvasGraph.test.ts
+++ b/autobot-frontend/src/composables/llc/__tests__/orgCanvasGraph.test.ts
@@ -7,7 +7,13 @@
 // parent→child link survives as a canvas connection.
 
 import { describe, it, expect } from 'vitest'
-import { buildOrgCanvasGraph, flattenOrgNodes, ORG_GROUP_PREFIX } from '../orgCanvasGraph'
+import {
+  buildOrgCanvasGraph,
+  flattenOrgNodes,
+  isOrgUnit,
+  orgUnitRoots,
+  ORG_GROUP_PREFIX,
+} from '../orgCanvasGraph'
 import type { OrgNode } from '@/views/llc/OrgTreeNode.vue'
 
 function node(id: string, children: OrgNode[] = []): OrgNode {
@@ -32,15 +38,29 @@ const FOREST: OrgNode[] = [
   node('advisor'),
 ]
 
+/** Two real hierarchies — the case where two containers must stack. */
+const TWO_UNIT_FOREST: OrgNode[] = [FOREST[0], node('ops', [node('sre')])]
+
+/** A person: a root with no reports, exactly what a membership produces. */
+function person(id: string, name: string): OrgNode {
+  return { ...node(id), name, title: 'member', is_human: true, budget_total: 0 }
+}
+
+/** Twelve people and nothing else — the company shape from GH#13994. */
+const PEOPLE_ONLY: OrgNode[] = Array.from({ length: 12 }, (_, i) =>
+  person(`user:${i}`, `Person ${i}`),
+)
+
 const unitLabel = (name: string) => `${name} unit`
 
 describe('buildOrgCanvasGraph (#13939)', () => {
-  it('emits one container per root plus one node per person', () => {
+  it('emits one container per unit plus one node per person', () => {
     const graph = buildOrgCanvasGraph(FOREST, unitLabel)
     const groups = graph.filter((n) => n.type === 'org-group')
     const people = graph.filter((n) => n.type === 'org-person')
 
-    expect(groups.map((g) => g.id)).toEqual([`${ORG_GROUP_PREFIX}ceo`, `${ORG_GROUP_PREFIX}advisor`])
+    // #13994: `advisor` is a root with no reports — a person, not a unit.
+    expect(groups.map((g) => g.id)).toEqual([`${ORG_GROUP_PREFIX}ceo`])
     expect(people.map((p) => p.id).sort()).toEqual(['advisor', 'ceo', 'cfo', 'cto', 'dev1', 'dev2'])
   })
 
@@ -96,10 +116,10 @@ describe('buildOrgCanvasGraph (#13939)', () => {
     }
   })
 
-  it('stacks root containers without overlapping', () => {
-    const graph = buildOrgCanvasGraph(FOREST, unitLabel)
+  it('stacks unit containers without overlapping', () => {
+    const graph = buildOrgCanvasGraph(TWO_UNIT_FOREST, unitLabel)
     const first = graph.find((n) => n.id === `${ORG_GROUP_PREFIX}ceo`)!
-    const second = graph.find((n) => n.id === `${ORG_GROUP_PREFIX}advisor`)!
+    const second = graph.find((n) => n.id === `${ORG_GROUP_PREFIX}ops`)!
 
     expect(second.position.y).toBeGreaterThanOrEqual(
       first.position.y + (first.data.height as number),
@@ -136,5 +156,63 @@ describe('buildOrgCanvasGraph (#13939)', () => {
 
     expect([...byId.keys()].sort()).toEqual(['advisor', 'ceo', 'cfo', 'cto', 'dev1', 'dev2'])
     expect(byId.get('dev2')!.name).toBe('Agent dev2')
+  })
+})
+
+// GH#13994: the backend returns every person of the company as a root, because a
+// membership carries no `reports_to` edge. Wrapping every root made each of them
+// a single-person "unit". These cases are people-shaped on purpose — the older
+// fixtures are all agent hierarchies, which is why the explosion was invisible.
+describe('grouping is by descendants, not root-ness (#13994)', () => {
+  it('draws no container at all for a company that is only people', () => {
+    const graph = buildOrgCanvasGraph(PEOPLE_ONLY, unitLabel)
+
+    expect(graph.filter((n) => n.type === 'org-group')).toEqual([])
+    expect(graph.filter((n) => n.type === 'org-person')).toHaveLength(12)
+    expect(graph.map((n) => n.data.label)).not.toContain(unitLabel('Person 0'))
+  })
+
+  it('keeps every bare person a first-class, selectable node', () => {
+    const graph = buildOrgCanvasGraph(PEOPLE_ONLY, unitLabel)
+    const first = graph[0]
+
+    expect(first.id).toBe('user:0')
+    expect(first.data).toMatchObject({ label: 'Person 0', title: 'member', is_human: true })
+    expect(first.connections).toEqual([])
+  })
+
+  it('packs bare people across before stacking them down', () => {
+    const graph = buildOrgCanvasGraph(PEOPLE_ONLY, unitLabel)
+    const positions = graph.map((n) => n.position)
+
+    // Row 1 walks right; the fifth wraps back to the first column, one row down.
+    expect(positions[1].x).toBeGreaterThan(positions[0].x)
+    expect(positions[1].y).toBe(positions[0].y)
+    expect(positions[4].x).toBe(positions[0].x)
+    expect(positions[4].y).toBeGreaterThan(positions[0].y)
+    expect(new Set(positions.map((p) => `${p.x}:${p.y}`)).size).toBe(12)
+  })
+
+  it('mixes units and people: containers wrap only the hierarchies', () => {
+    const graph = buildOrgCanvasGraph([...FOREST, ...PEOPLE_ONLY.slice(0, 3)], unitLabel)
+    const groups = graph.filter((n) => n.type === 'org-group')
+    const container = groups[0]
+
+    expect(groups.map((g) => g.id)).toEqual([`${ORG_GROUP_PREFIX}ceo`])
+    // The people sit below the last container, not inside it.
+    for (const id of ['advisor', 'user:0', 'user:1', 'user:2']) {
+      const bare = graph.find((n) => n.id === id)!
+      expect(bare.position.y).toBeGreaterThanOrEqual(
+        container.position.y + (container.data.height as number),
+      )
+    }
+  })
+
+  it('names a unit as a root with reports — the predicate the tab strip shares', () => {
+    expect(isOrgUnit(FOREST[0])).toBe(true)
+    expect(isOrgUnit(FOREST[1])).toBe(false)
+    expect(isOrgUnit({ ...FOREST[1], children: undefined as unknown as OrgNode[] })).toBe(false)
+    expect(orgUnitRoots([...FOREST, ...PEOPLE_ONLY]).map((r) => r.id)).toEqual(['ceo'])
+    expect(orgUnitRoots(PEOPLE_ONLY)).toEqual([])
   })
 })

--- a/autobot-frontend/src/composables/llc/orgCanvasGraph.ts
+++ b/autobot-frontend/src/composables/llc/orgCanvasGraph.ts
@@ -11,10 +11,16 @@
  * canvas implementation.
  *
  * Layout is left-to-right hierarchical (depth → column, leaves → rows) because
- * that is the direction the canvas draws its ports and bezier edges in. Each
- * root subtree also gets an `org-group` container node — the section/grouping
- * container — sized to its subtree bounding box and emitted first so it paints
- * behind the people.
+ * that is the direction the canvas draws its ports and bezier edges in. A root
+ * subtree that actually *is* a hierarchy also gets an `org-group` container
+ * node — the section/grouping container — sized to its subtree bounding box and
+ * emitted first so it paints behind the people.
+ *
+ * GH#13994: "root" is not a synonym for "unit". People join the forest as roots
+ * because a membership carries no `reports_to` edge, so wrapping every root
+ * turned a company of twelve people into twelve single-person "units". A unit
+ * is a root that has someone under it; everyone else is drawn bare, in a grid
+ * below the units.
  */
 
 import type { CanvasNode } from '@/components/workflow/canvasNode'
@@ -31,6 +37,13 @@ const GROUP_PADDING = 24
 const GROUP_HEADER = 44
 /** Vertical distance between two grouping containers. */
 const GROUP_GAP = 60
+/**
+ * Columns in the grid of ungrouped individuals (GH#13994). They have no
+ * hierarchy to lay out, so they pack across before they stack down — a company
+ * of twelve people is three rows of a readable grid, not a twelve-row column
+ * the reader has to pan through.
+ */
+const UNGROUPED_COLUMNS = 4
 /** Id prefix that keeps container ids from colliding with agent ids. */
 export const ORG_GROUP_PREFIX = 'org-group:'
 
@@ -65,13 +78,13 @@ function placeSubtree(
   return y
 }
 
-/** One person node, offset into its grouping container. */
-function toPersonNode(placed: PlacedNode, topOffset: number): CanvasNode {
+/** One person node, offset by the origin of whatever region holds it. */
+function toPersonNode(placed: PlacedNode, leftOffset: number, topOffset: number): CanvasNode {
   const { node } = placed
   return {
     id: node.id,
     type: 'org-person',
-    position: { x: GROUP_PADDING + placed.x, y: topOffset + placed.y },
+    position: { x: leftOffset + placed.x, y: topOffset + placed.y },
     data: {
       label: node.name,
       title: node.title,
@@ -106,6 +119,68 @@ function toGroupNode(
 }
 
 /**
+ * Is this root an org *unit* — something a container and a tab can stand for?
+ *
+ * Only a root with someone under it. Root-ness alone is not a unit: the
+ * org-chart endpoint returns every person of the company as a root because a
+ * membership carries no `reports_to` edge, and treating that as a unit drew one
+ * container and one tab per person (GH#13994).
+ *
+ * This is the single definition of "unit" — `buildOrgCanvasGraph` draws the
+ * containers from it and `OrgChart.vue` builds the tab strip from it, so the
+ * strip and the canvas cannot disagree about what a unit is. It stays a
+ * structural proxy only until real team grouping lands (GH#13938).
+ */
+export function isOrgUnit(root: OrgNode): boolean {
+  return (root.children ?? []).length > 0
+}
+
+/** The roots that are units, in tree order. */
+export function orgUnitRoots(roots: OrgNode[]): OrgNode[] {
+  return roots.filter(isOrgUnit)
+}
+
+/**
+ * Lay out one unit — its container plus the subtree inside it.
+ *
+ * @returns the next free top offset
+ */
+function layoutUnit(
+  root: OrgNode,
+  topOffset: number,
+  groups: CanvasNode[],
+  people: CanvasNode[],
+  unitLabel: (name: string) => string,
+): number {
+  const placed: PlacedNode[] = []
+  const cursor = { row: 0 }
+  placeSubtree(root, 0, cursor, placed)
+  const contentTop = topOffset + GROUP_HEADER + GROUP_PADDING
+  for (const item of placed) people.push(toPersonNode(item, GROUP_PADDING, contentTop))
+  groups.push(toGroupNode(root, placed, topOffset, cursor.row, unitLabel))
+  return topOffset + GROUP_HEADER + 2 * GROUP_PADDING + cursor.row * ROW_HEIGHT + GROUP_GAP
+}
+
+/**
+ * Lay out the individuals who are not a unit: a bare grid, no container.
+ *
+ * They are still first-class canvas nodes — same id, same payload, same click
+ * target — they simply are not wrapped in a box that claims they are an
+ * organisational unit of one (GH#13994).
+ */
+function layoutUngrouped(roots: OrgNode[], topOffset: number, people: CanvasNode[]): void {
+  roots.forEach((root, index) => {
+    const placed: PlacedNode = {
+      node: root,
+      depth: 0,
+      x: (index % UNGROUPED_COLUMNS) * (CANVAS_NODE_WIDTH + COLUMN_GAP),
+      y: Math.floor(index / UNGROUPED_COLUMNS) * ROW_HEIGHT,
+    }
+    people.push(toPersonNode(placed, 0, topOffset))
+  })
+}
+
+/**
  * Build the canvas graph for an org-chart forest.
  *
  * @param roots      root org nodes as returned by the org-chart endpoint
@@ -118,15 +193,14 @@ export function buildOrgCanvasGraph(
   const groups: CanvasNode[] = []
   const people: CanvasNode[] = []
   let topOffset = 0
-  for (const root of roots) {
-    const placed: PlacedNode[] = []
-    const cursor = { row: 0 }
-    placeSubtree(root, 0, cursor, placed)
-    const contentTop = topOffset + GROUP_HEADER + GROUP_PADDING
-    for (const item of placed) people.push(toPersonNode(item, contentTop))
-    groups.push(toGroupNode(root, placed, topOffset, cursor.row, unitLabel))
-    topOffset += GROUP_HEADER + 2 * GROUP_PADDING + cursor.row * ROW_HEIGHT + GROUP_GAP
+  for (const root of orgUnitRoots(roots)) {
+    topOffset = layoutUnit(root, topOffset, groups, people, unitLabel)
   }
+  layoutUngrouped(
+    roots.filter((root) => !isOrgUnit(root)),
+    topOffset,
+    people,
+  )
   // Containers first so the people paint on top of them.
   return [...groups, ...people]
 }

--- a/autobot-frontend/src/views/llc/OrgChart.vue
+++ b/autobot-frontend/src/views/llc/OrgChart.vue
@@ -13,7 +13,12 @@ import type { OrgNode } from './OrgTreeNode.vue'
 import HireAgentModal from '@/components/llc/HireAgentModal.vue'
 import WorkflowCanvas from '@/components/workflow/WorkflowCanvas.vue'
 import type { CanvasNode, CanvasTab } from '@/components/workflow/canvasNode'
-import { buildOrgCanvasGraph, flattenOrgNodes, ORG_GROUP_PREFIX } from '@/composables/llc/orgCanvasGraph'
+import {
+  buildOrgCanvasGraph,
+  flattenOrgNodes,
+  orgUnitRoots,
+  ORG_GROUP_PREFIX,
+} from '@/composables/llc/orgCanvasGraph'
 
 const logger = createLogger('OrgChart')
 const api = useApiClient()
@@ -34,18 +39,34 @@ type OrgViewMode = 'tree' | 'canvas'
 const viewMode = ref<OrgViewMode>('tree')
 const activeTabId = ref<string>(ALL_UNITS_TAB)
 
-/** Roots the canvas draws: every unit, or the one the active tab selects. */
-const visibleRoots = computed<OrgNode[]>(() =>
-  activeTabId.value === ALL_UNITS_TAB
-    ? tree.value
-    : tree.value.filter((node) => node.id === activeTabId.value),
+/**
+ * One tab per unit, plus an "all units" tab — and no strip at all when nothing
+ * is grouped. GH#13994: this used to be one tab per *root*, which gave a
+ * company of twelve people twelve person-named tabs. `orgUnitRoots` is the same
+ * predicate the canvas draws its containers from, so the strip and the canvas
+ * can never disagree about what a unit is.
+ */
+const canvasTabs = computed<CanvasTab[]>(() => {
+  const units = orgUnitRoots(tree.value)
+  if (units.length === 0) return []
+  return [
+    { id: ALL_UNITS_TAB, label: t('llc.orgChart.canvasTabAll') },
+    ...units.map((node) => ({ id: node.id, label: node.name })),
+  ]
+})
+
+// A selected unit can stop being one between reloads (its last report leaves).
+// Falling back to "all units" keeps the canvas populated instead of blank.
+const effectiveTabId = computed<string>(() =>
+  canvasTabs.value.some((tab) => tab.id === activeTabId.value) ? activeTabId.value : ALL_UNITS_TAB,
 )
 
-/** One tab per top-level unit, plus an "all units" tab. */
-const canvasTabs = computed<CanvasTab[]>(() => [
-  { id: ALL_UNITS_TAB, label: t('llc.orgChart.canvasTabAll') },
-  ...tree.value.map((node) => ({ id: node.id, label: node.name })),
-])
+/** Roots the canvas draws: the whole forest, or the one unit the tab selects. */
+const visibleRoots = computed<OrgNode[]>(() =>
+  effectiveTabId.value === ALL_UNITS_TAB
+    ? tree.value
+    : tree.value.filter((node) => node.id === effectiveTabId.value),
+)
 
 // A ref (not a computed) so node drags stay put: the canvas mutates
 // `node.position` in place and that must survive until the tree reloads.
@@ -217,7 +238,7 @@ onMounted(fetchTree)
         :nodes="canvasNodes"
         :selected-node-id="selectedNode?.id ?? null"
         :tabs="canvasTabs"
-        :active-tab-id="activeTabId"
+        :active-tab-id="effectiveTabId"
         @node-selected="onCanvasNodeSelected"
         @node-moved="onCanvasNodeMoved"
         @tab-selected="activeTabId = $event"

--- a/autobot-frontend/src/views/llc/__tests__/OrgChart.viewMode.test.ts
+++ b/autobot-frontend/src/views/llc/__tests__/OrgChart.viewMode.test.ts
@@ -135,10 +135,11 @@ describe('OrgChart view-mode toggle (#13939)', () => {
     await wrapper.get('[data-testid="org-view-canvas"]').trigger('click')
 
     const canvas = wrapper.findComponent(WorkflowCanvas)
+    // #13994: `advisor` is a root with no reports — a person, not a unit, so it
+    // gets no tab of its own.
     expect(canvas.props('tabs')).toEqual([
       { id: 'all', label: en.llc.orgChart.canvasTabAll },
       { id: 'ceo', label: 'Ada' },
-      { id: 'advisor', label: 'Alan' },
     ])
     expect(canvas.props('activeTabId')).toBe('all')
   })
@@ -148,11 +149,11 @@ describe('OrgChart view-mode toggle (#13939)', () => {
     await wrapper.get('[data-testid="org-view-canvas"]').trigger('click')
     const canvas = wrapper.findComponent(WorkflowCanvas)
 
-    canvas.vm.$emit('tab-selected', 'advisor')
+    canvas.vm.$emit('tab-selected', 'ceo')
     await flushPromises()
 
     const ids = wrapper.findComponent(WorkflowCanvas).props('nodes').map((node) => node.id)
-    expect(ids).toEqual([`${ORG_GROUP_PREFIX}advisor`, 'advisor'])
+    expect(ids).toEqual([`${ORG_GROUP_PREFIX}ceo`, 'dev', 'ceo'])
   })
 
   it('a canvas node selection opens the same detail drawer the tree opens', async () => {
@@ -273,5 +274,57 @@ describe('OrgChart nested-tree mode is unregressed (#13939)', () => {
 
     expect(wrapper.findComponent(OrgTreeNode).exists()).toBe(true)
     expect(wrapper.findComponent(WorkflowCanvas).exists()).toBe(false)
+  })
+})
+
+// GH#13994: people arrive from the org-chart endpoint as roots (a membership
+// carries no `reports_to` edge). The tab strip used to be built from root-ness,
+// so a company of twelve people got twelve person-named tabs beside twelve
+// single-person boxes. The strip and the canvas now share one definition of a
+// unit, so they cannot disagree.
+describe('OrgChart canvas tabs follow the container rule (#13994)', () => {
+  const MEMBERS = Array.from({ length: 12 }, (_, i) => ({
+    ...structuredClone(NODES)[1],
+    id: `user:${i}`,
+    name: `Person ${i}`,
+    title: 'member',
+  }))
+
+  async function mountWith(nodes: unknown[]) {
+    get.mockResolvedValue({ nodes })
+    const wrapper = await mountChart()
+    await wrapper.get('[data-testid="org-view-canvas"]').trigger('click')
+    return wrapper
+  }
+
+  it('shows no tab strip for a company that is only people', async () => {
+    const canvas = (await mountWith(MEMBERS)).findComponent(WorkflowCanvas)
+
+    expect(canvas.props('tabs')).toEqual([])
+    const nodes = canvas.props('nodes')
+    expect(nodes.filter((node) => node.type === 'org-group')).toEqual([])
+    expect(nodes.filter((node) => node.type === 'org-person')).toHaveLength(12)
+  })
+
+  it('draws all twelve people on the canvas — none of them hidden behind a tab', async () => {
+    const wrapper = await mountWith(MEMBERS)
+    const canvas = wrapper.findComponent(WorkflowCanvas)
+
+    expect(canvas.props('nodes').map((node) => node.id)).toEqual(
+      MEMBERS.map((member) => member.id),
+    )
+    expect(wrapper.findAll('.workflow-node.org-person')).toHaveLength(12)
+    expect(wrapper.find('.canvas-tabs').exists()).toBe(false)
+  })
+
+  it('falls back to all units when the selected tab is no longer a unit', async () => {
+    const wrapper = await mountWith(MEMBERS)
+
+    wrapper.findComponent(WorkflowCanvas).vm.$emit('tab-selected', 'user:3')
+    await flushPromises()
+
+    const canvas = wrapper.findComponent(WorkflowCanvas)
+    expect(canvas.props('activeTabId')).toBe('all')
+    expect(canvas.props('nodes')).toHaveLength(12)
   })
 })


### PR DESCRIPTION
Closes #13994 · Parent umbrella #13935

## Thinking Path

The org-chart endpoint returns every member of a company as a **root**, because a membership
carries no `reports_to` edge — that is correct and stays. The canvas mapper then treated
"root" as a synonym for "unit": it wrapped every root in an `org-group` container labelled
`"<name> unit"`, and the view built one tab per root. A company of twelve people therefore
rendered twelve single-person boxes and twelve person-named tabs.

Of the three options in the issue I took **option 1 — only wrap roots that actually have
descendants** — because it fixes the whole class, not just the human case:

- Option 2 (a single "People" container) fixes people but leaves the same explosion for
  *agents*: an agent whose `reports_to` is unset is also a childless root, so a flat roster of
  hired agents still produces one box per agent. It also needs a new i18n string in 11 locales
  and invents a container for something the backend has no grouping for.
- Option 3 (real team grouping) is the right end state and is explicitly deferred to #13938 —
  `isOrgUnit` carries that note in its docstring, and when teams land the predicate is the one
  place to change. This PR is the interim.
- Option 1 needs **no new string and no new concept**: it just stops asserting a hierarchy that
  is not in the data. A box that contains exactly one person communicates nothing; twelve of
  them communicate noise.

`isOrgUnit` / `orgUnitRoots` are exported from `orgCanvasGraph.ts` and used by **both** the
container layout and `canvasTabs`, so the tab strip and the canvas share one definition of a
unit and cannot drift apart — which was the second half of the ask.

Two consequences worth naming:
- With no units, `canvasTabs` is `[]` and `WorkflowCanvas` renders no strip at all (it already
  hides an empty strip) rather than a lone "All units" tab that filters nothing.
- A selected unit can stop being one between reloads (its last report leaves). `effectiveTabId`
  falls back to "all units" in that case, so the canvas cannot end up blank with a highlighted
  tab that no longer exists.

## What Changed

- `composables/llc/orgCanvasGraph.ts` — `isOrgUnit()` / `orgUnitRoots()` (the single definition
  of a unit); `buildOrgCanvasGraph` lays units out as before and draws the remaining
  individuals bare, packed `UNGROUPED_COLUMNS` wide so twelve people are a readable grid rather
  than a twelve-row column. `toPersonNode` takes the left offset of its region instead of
  assuming container padding. Bare people keep their id, payload, and click target — only the
  box is gone.
- `views/llc/OrgChart.vue` — `canvasTabs` is built from `orgUnitRoots`, is empty when nothing is
  grouped, and `effectiveTabId` guards a vanished selection.
- Tests — the canvas suite's fixtures were all agent hierarchies, which is exactly why the
  explosion was invisible; added a twelve-member people-shaped company and assert the **rendered
  DOM** (`.workflow-node.org-person` × 12, `.org-group` × 0, a bare card still emits
  `node-selected`). Existing expectations that encoded one-container/one-tab-per-root were
  updated to the new rule.

No dependency added (`package.json` untouched), no new i18n key, no new CSS, no `console.*`.

### Coordination

- **PR #14003** (`issue-13996`) adds `orgLayoutKey()` to the same module and swaps `watchEffect`
  for `watch` in `OrgChart.vue`. No conflict of intent: `orgLayoutKey` hashes the forest's
  structure (including children), so a root gaining or losing its last report changes the key
  and triggers exactly the relayout this grouping rule needs. `isOrgUnit` was placed *before*
  `buildOrgCanvasGraph` and `orgLayoutKey` is appended *after* it, so the textual overlap is
  minimal; whichever lands second may need a trivial rebase around `canvasTabs`.
- **PR #13945** (`issue-13936`) is the backend that appends people as roots plus drawer changes.
  Its `OrgChart.vue` edits are all in the drawer template, disjoint from the script block
  touched here, and it does not change `orgCanvasGraph.ts`. Its `WorkflowCanvas.vue` /
  `WorkflowCanvas.orgMode.test.ts` edits are untouched by this PR — the new tests were inserted
  mid-file, away from both PRs' hunks. No conflict of intent: this PR is precisely the frontend
  half that makes #13945's people render sanely.

## Verification

Frontend, from `autobot-frontend/`:

```
$ npm run lint          # oxlint -D correctness, then eslint .
> autobot-vue@0.0.1 lint:oxlint
> autobot-vue@0.0.1 lint:eslint
(clean, no findings)

$ npm run type-check
> vue-tsc --noEmit -p tsconfig.app.json
(clean)

$ npx vitest run src/composables/llc/__tests__/orgCanvasGraph.test.ts \
                 src/views/llc/__tests__/OrgChart.viewMode.test.ts \
                 src/components/workflow/__tests__/WorkflowCanvas.orgMode.test.ts
 ✓ src/composables/llc/__tests__/orgCanvasGraph.test.ts (16 tests)
 ✓ src/components/workflow/__tests__/WorkflowCanvas.orgMode.test.ts (13 tests)
 ✓ src/views/llc/__tests__/OrgChart.viewMode.test.ts (18 tests)
 Test Files  3 passed (3)
      Tests  47 passed (47)
```

**Mutation-proved** — a passing test proves nothing until the code it guards is broken.

Mutant 1, `isOrgUnit` returns true for every root (the exact pre-fix behaviour):

```
 × emits one container per unit plus one node per person
 × draws no container at all for a company that is only people
 × keeps every bare person a first-class, selectable node
 × packs bare people across before stacking them down
 × mixes units and people: containers wrap only the hierarchies
 × names a unit as a root with reports — the predicate the tab strip shares
 × renders twelve person cards and not one unit box
 × still boxes the one root that has reports, and only that one
 × offers one canvas tab per unit plus "all units"
 × shows no tab strip for a company that is only people
 × draws all twelve people on the canvas — none of them hidden behind a tab
 × falls back to all units when the selected tab is no longer a unit
 Test Files  3 failed (3)
      Tests  12 failed | 35 passed (47)
```

Mutant 2, only the tab strip regressed to root-ness (`canvasTabs` from `tree` instead of
`orgUnitRoots`) — proving the strip is pinned independently of the containers:

```
 × offers one canvas tab per unit plus "all units"
 × shows no tab strip for a company that is only people
 × draws all twelve people on the canvas — none of them hidden behind a tab
 × falls back to all units when the selected tab is no longer a unit
 Test Files  1 failed (1)
      Tests  4 failed | 14 passed (18)
```

Both mutants reverted; suites green again (47/47 above).

## Model Used

Opus 5 (1M context)
