### PR TITLE
fix(ci): call-argument shape + roles quote-class bug in hardcoded-values guard (#14048)

### DIFF
--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-hardcoded-values
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-hardcoded-values
@@ -41,6 +41,41 @@ get_files_to_scan() {
         grep -v -E '(constants/|config\.py$|\.env)' || true
 }
 
+# Shared call-argument matcher (#14005 -> #14048).
+#
+# Every "keyword-style" regex in this file (identifier bound to a literal with
+# `=`/`:` — assignment, dict value, function default) is blind to the
+# "call-argument" shape: `obj.get("field", value)`. There the field name is a
+# STRING-LITERAL positional argument, not an identifier bound with `=`/`:`, so
+# there is no operator between the field name and the default value for the
+# keyword-style regex to anchor on. #14005 hit this first for
+# check_hardcoded_categories (`doc.get("category", "general")`); the same gap
+# was audited and confirmed in check_hardcoded_roles, check_hardcoded_timeouts
+# and check_magic_numbers (#14048) — every one of them reuses this identical
+# keyword-style shape and is blind to the identical call-argument shape.
+#
+# Anchored to `.get(` so it only matches an actual dict-style lookup, not any
+# comma-joined pair of matching literals elsewhere (a tuple, an assertion).
+#
+# Args:
+#   $1  line to test
+#   $2  field-name alternation, e.g. 'role' or 'timeout|timeout_seconds'
+#   $3  value regex, ALREADY shaped by the caller (quoted for string values —
+#       e.g. `["'](user|assistant|system)["']` — or bare for numeric ones —
+#       e.g. `\b(30|60)\b` — since some checkers key off a quoted string
+#       default and others off a bare numeric one)
+#   $4  optional: pass "i" for a case-insensitive match, matching
+#       check_magic_numbers' existing `grep -qiE` keyword-style patterns
+_matches_get_call_argument() {
+    local line="$1" fields="$2" value_regex="$3" flags="${4:-}"
+    local pattern="\\.get\\([[:space:]]*[\"'](${fields})[\"'][[:space:]]*,[[:space:]]*${value_regex}"
+    if [ "$flags" = "i" ]; then
+        echo "$line" | grep -qiE "$pattern"
+    else
+        echo "$line" | grep -qE "$pattern"
+    fi
+}
+
 # Check for hardcoded VM IPs
 check_hardcoded_ips() {
     local file="$1"
@@ -137,8 +172,11 @@ check_magic_numbers() {
             continue
         fi
 
-        # Pattern 1: limit=10, limit: int = 10, default=10, Field(default=10) for limit/search context
-        if echo "$line" | grep -qiE '(limit|top_k|max_results|page_size)[^a-z_].*=\s*10\b'; then
+        # Pattern 1: limit=10, limit: int = 10, default=10, Field(default=10) for
+        # limit/search context (keyword-style) AND the call-argument shape
+        # `d.get("limit", 10)` — see _matches_get_call_argument (#14005 -> #14048).
+        if echo "$line" | grep -qiE '(limit|top_k|max_results|page_size)[^a-z_].*=\s*10\b' || \
+           _matches_get_call_argument "$line" 'limit|top_k|max_results|page_size' '10\b' i; then
             echo -e "${RED}VIOLATION${NC} $file:$line_num"
             echo "  Magic number 10 in limit/search context"
             echo -e "  ${CYAN}Fix: Use QueryDefaults.DEFAULT_SEARCH_LIMIT${NC}"
@@ -148,8 +186,10 @@ check_magic_numbers() {
             continue
         fi
 
-        # Pattern 2: limit=50, page_size=50, Field(default=50)
-        if echo "$line" | grep -qiE '(limit|page_size)[^a-z_].*=\s*50\b'; then
+        # Pattern 2: limit=50, page_size=50, Field(default=50) (keyword-style) AND
+        # the call-argument shape `d.get("page_size", 50)` (#14005 -> #14048).
+        if echo "$line" | grep -qiE '(limit|page_size)[^a-z_].*=\s*50\b' || \
+           _matches_get_call_argument "$line" 'limit|page_size' '50\b' i; then
             echo -e "${RED}VIOLATION${NC} $file:$line_num"
             echo "  Magic number 50 in pagination context"
             echo -e "  ${CYAN}Fix: Use QueryDefaults.DEFAULT_PAGE_SIZE${NC}"
@@ -159,8 +199,10 @@ check_magic_numbers() {
             continue
         fi
 
-        # Pattern 3: limit=100 for knowledge/batch context
-        if echo "$line" | grep -qiE '(limit|batch)[^a-z_].*=\s*100\b'; then
+        # Pattern 3: limit=100 for knowledge/batch context (keyword-style) AND the
+        # call-argument shape `d.get("limit", 100)` (#14005 -> #14048).
+        if echo "$line" | grep -qiE '(limit|batch)[^a-z_].*=\s*100\b' || \
+           _matches_get_call_argument "$line" 'limit|batch' '100\b' i; then
             echo -e "${RED}VIOLATION${NC} $file:$line_num"
             echo "  Magic number 100 in limit/batch context"
             echo -e "  ${CYAN}Fix: Use QueryDefaults.KNOWLEDGE_DEFAULT_LIMIT or BatchConfig.LARGE_BATCH${NC}"
@@ -171,7 +213,10 @@ check_magic_numbers() {
         fi
 
         # Pattern 4: offset=0 (only if explicitly set, not just = 0 anywhere)
-        if echo "$line" | grep -qiE 'offset[^a-z_]*[=:][^=]*\b0\b'; then
+        # (keyword-style) AND the call-argument shape `d.get("offset", 0)`
+        # (#14005 -> #14048).
+        if echo "$line" | grep -qiE 'offset[^a-z_]*[=:][^=]*\b0\b' || \
+           _matches_get_call_argument "$line" 'offset' '0\b' i; then
             # This is a warning, not a violation - offset=0 is common
             echo -e "${YELLOW}WARNING${NC} $file:$line_num"
             echo "  Consider using QueryDefaults.DEFAULT_OFFSET for consistency"
@@ -181,8 +226,10 @@ check_magic_numbers() {
             continue
         fi
 
-        # Pattern 5: max_results=5 for RAG context
-        if echo "$line" | grep -qiE '(max_results|rag)[^a-z_]*[=:][^=]*\b5\b'; then
+        # Pattern 5: max_results=5 for RAG context (keyword-style) AND the
+        # call-argument shape `d.get("max_results", 5)` (#14005 -> #14048).
+        if echo "$line" | grep -qiE '(max_results|rag)[^a-z_]*[=:][^=]*\b5\b' || \
+           _matches_get_call_argument "$line" 'max_results|rag' '5\b' i; then
             echo -e "${RED}VIOLATION${NC} $file:$line_num"
             echo "  Magic number 5 in RAG/results context"
             echo -e "  ${CYAN}Fix: Use QueryDefaults.RAG_DEFAULT_RESULTS${NC}"
@@ -202,8 +249,13 @@ check_hardcoded_roles() {
     while IFS= read -r line; do
         ((line_num++))
 
-        # Skip comments
-        if [[ "$line" =~ ^[[:space:]]*# ]] || [[ "$line" =~ ^[[:space:]]*// ]]; then
+        # Skip comments. Includes JSDoc/block-comment continuation lines
+        # (`* ...`) — same false-positive class caught for
+        # check_hardcoded_categories in review of #14005: the quote-class fix
+        # below makes single-quoted literals visible for the first time,
+        # which surfaces `* - role: 'user'`-style doc comments in .ts files
+        # (#14048).
+        if [[ "$line" =~ ^[[:space:]]*# ]] || [[ "$line" =~ ^[[:space:]]*// ]] || [[ "$line" =~ ^[[:space:]]*\* ]]; then
             continue
         fi
 
@@ -217,10 +269,30 @@ check_hardcoded_roles() {
             continue
         fi
 
-        # Check for role="user" or role: "user" patterns (with quotes)
-        if echo "$line" | grep -qE 'role[^a-z_]*[=:][^=]*["\x27](user|assistant|system)["\x27]'; then
+        # Skip TypeScript/Flow string-literal union types, e.g.
+        # `role?: 'user' | 'assistant' | 'system'` — a type annotation
+        # enumerating accepted values, not a hardcoded default. Same
+        # surfacing as the comment case above (#14048, mirroring #14005).
+        if echo "$line" | grep -qE '["'"'"'][[:space:]]*\|[[:space:]]*["'"'"']'; then
+            continue
+        fi
+
+        # Check for role="user" or role: "user" patterns (keyword-style:
+        # assignment, dict literal value, function default) AND the
+        # call-argument shape `d.get("role", "user")` — see
+        # _matches_get_call_argument (#14005 -> #14048).
+        #
+        # Quote class is a LITERAL apostrophe inside the bracket expression
+        # (["'](...)["']), not `["\x27]`. Backslash has no special meaning
+        # inside a POSIX bracket expression under GNU grep, so `["\x27]`
+        # matched one of the five literal characters ", \, x, 2, 7 — never
+        # an apostrophe — and every single-quoted literal (`'user'`) silently
+        # passed. Same bug as #14005's categories fix, audited and confirmed
+        # here in #14048.
+        if echo "$line" | grep -qE 'role[^a-z_]*[=:][^=]*["'"'"'](user|assistant|system)["'"'"']' || \
+           _matches_get_call_argument "$line" 'role' '["'"'"'](user|assistant|system)["'"'"']'; then
             local role
-            role=$(echo "$line" | grep -oE '["\x27](user|assistant|system)["\x27]' | head -1)
+            role=$(echo "$line" | grep -oE '["'"'"'](user|assistant|system)["'"'"']' | head -1)
             echo -e "${RED}VIOLATION${NC} $file:$line_num"
             echo "  Hardcoded role string: $role"
             echo -e "  ${CYAN}Fix: Use CategoryDefaults.ROLE_USER/ROLE_ASSISTANT/ROLE_SYSTEM${NC}"
@@ -363,11 +435,12 @@ check_hardcoded_categories() {
         # apostrophe — and every single-quoted literal (`'general'`) silently
         # passed both alternatives. Caught in review of #14005.
         #
-        # The call-argument alternative is anchored to `.get(` so it only
-        # matches an actual dict-style lookup, not any comma-joined pair of
-        # matching string literals (e.g. a tuple literal or an assertion).
+        # The call-argument alternative is the shared _matches_get_call_argument
+        # helper (#14048) — anchored to `.get(` so it only matches an actual
+        # dict-style lookup, not any comma-joined pair of matching string
+        # literals (e.g. a tuple literal or an assertion).
         if echo "$line" | grep -qE '(category|search_mode|mode)[^a-z_]*[=:][^=]*["'"'"'](general|hybrid|unknown)["'"'"']' || \
-           echo "$line" | grep -qE '\.get\([[:space:]]*["'"'"'](category|search_mode|mode)["'"'"'][[:space:]]*,[[:space:]]*["'"'"'](general|hybrid|unknown)["'"'"']'; then
+           _matches_get_call_argument "$line" 'category|search_mode|mode' '["'"'"'](general|hybrid|unknown)["'"'"']'; then
             local value
             value=$(echo "$line" | grep -oE '["'"'"'](general|hybrid|unknown)["'"'"']' | head -1)
             echo -e "${RED}VIOLATION${NC} $file:$line_num"
@@ -445,8 +518,14 @@ check_hardcoded_timeouts() {
             continue
         fi
 
-        # Detect timeout=N or timeout_seconds=N patterns
-        if echo "$line" | grep -qE "(timeout|timeout_seconds|connect_timeout|read_timeout)[^a-z_]*[=:][^=]*\b(${timeout_values})\b"; then
+        # Detect timeout=N or timeout_seconds=N patterns (keyword-style) AND
+        # the call-argument shape `d.get("timeout", 30)` — see
+        # _matches_get_call_argument (#14005 -> #14048). Unlike
+        # categories/roles the default here is a bare numeric literal, not a
+        # quoted string, so no quote-class bug applies — only the missing
+        # keyword-style operator did.
+        if echo "$line" | grep -qE "(timeout|timeout_seconds|connect_timeout|read_timeout)[^a-z_]*[=:][^=]*\b(${timeout_values})\b" || \
+           _matches_get_call_argument "$line" 'timeout|timeout_seconds|connect_timeout|read_timeout' "\\b(${timeout_values})\\b"; then
             local val
             val=$(echo "$line" | grep -oE "\b(${timeout_values})\b" | head -1)
             echo -e "${RED}VIOLATION${NC} $file:$line_num"

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-hardcoded-values_test.py
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-hardcoded-values_test.py
@@ -288,10 +288,78 @@ class TestMagicNumbers:
         )
         assert result.returncode == 0
 
+    # Issue #14048: same call-argument blind spot fixed for
+    # check_hardcoded_categories in #14005 — `d.get("limit", 10)` has no
+    # `=`/`:` between the field name and the default, so the keyword-style
+    # regex alone never matches. One test per magic-number pattern the
+    # call-argument alternative was added to.
+
+    def test_blocks_call_argument_limit_10(self, tmp_path: Path) -> None:
+        result = _run_hook_with_staged(
+            tmp_path,
+            {"src/q.py": 'def c(d):\n    return d.get("limit", 10)\n'},
+        )
+        assert result.returncode != 0
+        assert "10" in result.stdout
+
+    def test_blocks_call_argument_page_size_50(self, tmp_path: Path) -> None:
+        result = _run_hook_with_staged(
+            tmp_path,
+            {"src/q.py": 'def e(d):\n    return d.get("page_size", 50)\n'},
+        )
+        assert result.returncode != 0
+        assert "50" in result.stdout
+
+    def test_blocks_call_argument_limit_100(self, tmp_path: Path) -> None:
+        result = _run_hook_with_staged(
+            tmp_path,
+            {"src/q.py": 'def f(d):\n    return d.get("limit", 100)\n'},
+        )
+        assert result.returncode != 0
+        assert "100" in result.stdout
+
+    def test_blocks_call_argument_max_results_5(self, tmp_path: Path) -> None:
+        result = _run_hook_with_staged(
+            tmp_path,
+            {"src/q.py": 'def g(d):\n    return d.get("max_results", 5)\n'},
+        )
+        assert result.returncode != 0
+        assert "5" in result.stdout
+
+    def test_allows_call_argument_unrelated_key(self, tmp_path: Path) -> None:
+        # Ordinary code: neither the key nor the default is one of the
+        # limit/page_size/max_results/batch literals the rule targets.
+        result = _run_hook_with_staged(
+            tmp_path,
+            {"src/q.py": 'def h(d):\n    return d.get("count", 10)\n'},
+        )
+        assert result.returncode == 0
+
+    def test_allows_call_argument_using_query_defaults(self, tmp_path: Path) -> None:
+        result = _run_hook_with_staged(
+            tmp_path,
+            {
+                "src/q.py": (
+                    "from constants import QueryDefaults\n"
+                    'def i(d):\n    return d.get("limit", QueryDefaults.DEFAULT_SEARCH_LIMIT)\n'
+                ),
+            },
+        )
+        assert result.returncode == 0
+
 
 @pytest.mark.skipif(not HOOK_PATH.exists(), reason="hook script missing at expected path")
 class TestHardcodedRoles:
-    """check_hardcoded_roles: blocks `role="user"` literals."""
+    """check_hardcoded_roles: blocks `role="user"` literals.
+
+    Issue #14048: shares the same two bugs #14005 fixed for
+    check_hardcoded_categories — the keyword-style regex is blind to the
+    call-argument shape (`d.get("role", "user")`, no `=`/`:` between key and
+    default), and the quote class `["\\x27]` is not "double or single quote"
+    inside a POSIX bracket expression (backslash has no special meaning
+    there), so it never matched an apostrophe and every single-quoted role
+    literal silently passed.
+    """
 
     def test_blocks_hardcoded_role_string(self, tmp_path: Path) -> None:
         result = _run_hook_with_staged(
@@ -307,6 +375,62 @@ class TestHardcodedRoles:
             {
                 "src/chat.py": (
                     "from constants import CategoryDefaults\n" 'msg = {"role": CategoryDefaults.ROLE_USER}\n'
+                ),
+            },
+        )
+        assert result.returncode == 0
+
+    def test_blocks_call_argument(self, tmp_path: Path) -> None:
+        result = _run_hook_with_staged(
+            tmp_path,
+            {"src/chat.py": 'def a(msg):\n    return msg.get("role", "user")\n'},
+        )
+        assert result.returncode != 0
+        assert "user" in result.stdout
+
+    def test_blocks_single_quoted_keyword_style(self, tmp_path: Path) -> None:
+        # Regression for the quote-class bug: `["\x27]` matched one of the
+        # five literal characters ", \, x, 2, 7 — never an apostrophe.
+        result = _run_hook_with_staged(
+            tmp_path,
+            {"src/chat.py": "msg = {'role': 'user', 'content': 'hi'}\n"},
+        )
+        assert result.returncode != 0
+        assert "user" in result.stdout
+
+    def test_blocks_single_quoted_call_argument(self, tmp_path: Path) -> None:
+        result = _run_hook_with_staged(
+            tmp_path,
+            {"src/chat.py": "def a(msg):\n    return msg.get('role', 'user')\n"},
+        )
+        assert result.returncode != 0
+        assert "user" in result.stdout
+
+    def test_allows_unrelated_key_in_call_argument(self, tmp_path: Path) -> None:
+        result = _run_hook_with_staged(
+            tmp_path,
+            {"src/chat.py": 'ids = [doc.get("id", "unknown_id") for doc in docs]\n'},
+        )
+        assert result.returncode == 0
+
+    def test_allows_jsdoc_block_comment_continuation(self, tmp_path: Path) -> None:
+        # Same false-positive class caught for categories in review of
+        # #14005: fixing the quote class surfaces `*`-prefixed JSDoc
+        # continuation lines unless the comment skip also covers them.
+        result = _run_hook_with_staged(
+            tmp_path,
+            {
+                "src/q.ts": ("/**\n" " * role: 'user'\n" " */\n" "export const x = 1\n"),
+            },
+        )
+        assert result.returncode == 0
+
+    def test_allows_typescript_string_literal_union_type(self, tmp_path: Path) -> None:
+        result = _run_hook_with_staged(
+            tmp_path,
+            {
+                "src/types.ts": (
+                    "export interface Options {\n" "  role?: 'user' | 'assistant' | 'system'\n" "}\n"
                 ),
             },
         )
@@ -568,6 +692,24 @@ class TestHardcodedTimeouts:
         # a hook tightening, the new behavior should be reflected here
         # rather than the test being deleted.
         assert result.returncode in (0, 1), "Hook should produce either pass or violation, not error"
+
+    def test_blocks_call_argument(self, tmp_path: Path) -> None:
+        # Issue #14048: same call-argument blind spot fixed for
+        # check_hardcoded_categories in #14005 — `d.get("timeout", 30)` has
+        # no `=`/`:` between the field name and the default.
+        result = _run_hook_with_staged(
+            tmp_path,
+            {"src/api.py": 'def b(d):\n    return d.get("timeout", 30)\n'},
+        )
+        assert result.returncode != 0
+        assert "30" in result.stdout
+
+    def test_allows_call_argument_unrelated_key(self, tmp_path: Path) -> None:
+        result = _run_hook_with_staged(
+            tmp_path,
+            {"src/api.py": 'def c(d):\n    return d.get("retry_count", 30)\n'},
+        )
+        assert result.returncode == 0
 
     def test_allows_timeout_via_config(self, tmp_path: Path) -> None:
         result = _run_hook_with_staged(

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-hardcoded-values_test.py
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-hardcoded-values_test.py
@@ -429,9 +429,7 @@ class TestHardcodedRoles:
         result = _run_hook_with_staged(
             tmp_path,
             {
-                "src/types.ts": (
-                    "export interface Options {\n" "  role?: 'user' | 'assistant' | 'system'\n" "}\n"
-                ),
+                "src/types.ts": ("export interface Options {\n" "  role?: 'user' | 'assistant' | 'system'\n" "}\n"),
             },
         )
         assert result.returncode == 0


### PR DESCRIPTION
Closes #14048

## Thinking Path

#14005 fixed `check_hardcoded_categories` for two bugs: (1) the keyword-style
regex is blind to the call-argument shape (`d.get("category", "general")` has
no `=`/`:` between the field name and the default), and (2) `["\x27]` is not
"double or single quote" inside a POSIX bracket expression — backslash has no
special meaning there, so it matches one of the five literal characters `"`,
`\`, `x`, `2`, `7`, never an apostrophe. #14048 audited the three other
checkers that share the identical keyword-style regex shape and confirmed all
three share bug (1); `check_hardcoded_roles` additionally shares bug (2)
because its default values are quoted strings, same as categories.
`check_hardcoded_timeouts` and `check_magic_numbers` key off bare numeric
defaults, so bug (2) does not apply to them.

Rather than pasting the same two-grep OR into three more checkers (flagged in
review of #14005), the call-argument alternative is factored into one shared
`_matches_get_call_argument` helper that `check_hardcoded_categories` now also
calls, so there is exactly one place that shape is matched.

## What Changed

`autobot-infrastructure/shared/scripts/hooks/pre-commit-hardcoded-values`:

- New `_matches_get_call_argument(line, fields, value_regex, [flags])` helper —
  matches `obj.get("field", value)`, anchored to `.get(` so it doesn't false-
  positive on a comma-joined pair of literals elsewhere (a tuple, an
  assertion). Callers pass the value pattern already quoted (string defaults)
  or bare (numeric defaults), and an optional `i` flag for
  `check_magic_numbers`' existing case-insensitive matching.
- `check_hardcoded_categories` now calls the shared helper instead of its own
  inline second grep (behavior unchanged, still covered by the existing
  #14005 test class).
- `check_hardcoded_roles`: fixed the quote class (mirrors #14005's fix),
  added the call-argument alternative, and added the matching JSDoc/block-
  comment (`* ...`) and TypeScript union-type (`'a' | 'b'`) skips #14005
  needed once single-quoted literals became visible.
- `check_hardcoded_timeouts`: added the call-argument alternative (numeric
  default, no quote-class bug to fix).
- `check_magic_numbers`: added the call-argument alternative to all five
  patterns (limit=10, limit/page_size=50, limit/batch=100, offset=0 warning,
  max_results/rag=5).

`pre-commit-hardcoded-values_test.py`: 14 new tests — one per newly-caught
shape (call-argument for roles/timeouts/magic_numbers, single-quoted keyword-
style and call-argument for roles) plus the allow-side guards (JSDoc
continuation, TS union type, unrelated `.get()` keys, SSOT-constant defaults).
45 -> 59 tests, all passing.

## Verification

**Reproduction, before the fix (all 4 silently passed):**
```
$ bash pre-commit-hardcoded-values role_call_arg.py    # msg.get("role", "user")
No violations found!
$ bash pre-commit-hardcoded-values role_single_quote.py  # msg.get('role', 'user')
No violations found!
$ bash pre-commit-hardcoded-values timeout_call_arg.py  # d.get("timeout", 30)
No violations found!
$ bash pre-commit-hardcoded-values limit_call_arg.py    # d.get("limit", 10)
No violations found!
```
After the fix, all four are caught (exit 1, correct violation message).

**Full test suite:** `venv/bin/python -m pytest .../pre-commit-hardcoded-values_test.py -q`
→ 59 passed (was 45; +14 new).

**Repo-wide false-positive audit** (whole repo, `get_files_to_scan`
allowlist, generated/ trees excluded — same exclusion the CI wrapper already
applies for the 240s+ generated-file performance cliff):

| Checker | Before | After | New matches (delta) | Hand-classified |
|---|---|---|---|---|
| `check_hardcoded_roles` | 264 | 287 | 23 | **23/23 genuine** — single-quoted `role: 'user'/'assistant'/'system'` literals in `.vue`/`.ts` files, invisible under the old quote-class bug |
| `check_hardcoded_timeouts` | 187 | 191 | 4 | **4/4 genuine** — `cfg.get("timeout_seconds", 3600)` / `d.get("timeout", 300)` call-argument shapes |
| `check_magic_numbers` | 251 | 268 | 17 | **17/17 genuine** (16 violations + 1 pre-existing-pattern warning) — `.get("top_k"/"limit"/"page_size"/"max_results"/"offset", N)` call-argument shapes |

**False-positive rate: 0/44 across all three checkers.** Every new delta line
was independently re-verified against the real bash checker (not just the
Python model used to compute the repo-wide counts) by running
`check_hardcoded_roles`/`check_hardcoded_timeouts` directly against the
flagged files, and `check_magic_numbers` against single-line snippets
extracted at the flagged line numbers — all matched exactly. `magic_numbers`
was the one flagged as highest-risk for noise (numeric literals are far more
common in call arguments than category strings); it came back clean, so
nothing was left out.

**`--changed-lines-only` mode**, verified end-to-end via
`pipeline-scripts/check-pre-commit-hook-pr.sh --changed-lines-only
pre-commit-hardcoded-values` against a synthetic base/head pair: a
pre-existing role call-argument violation on an untouched line is reported
but does not fail the build; a newly-added timeout call-argument violation on
the same file does fail the build (exit 1). Matches #13950's documented
behavior.

**Mutation testing** (with no-op detection — every mutation's diff against
the pre-mutation file was confirmed non-empty before trusting a result):
- Disabling the roles call-argument alternative → kills exactly the 2
  call-argument tests.
- Reverting the roles quote-class fix → kills exactly the single-quoted
  keyword-style test.
- Gutting the shared `_matches_get_call_argument` helper → kills all 10
  call-argument tests across roles/timeouts/magic_numbers/categories,
  confirming the shared factoring is load-bearing for all four checkers, not
  just the one it was written for.
- Disabling the timeouts call-argument alternative → kills exactly its test.
- Disabling one magic_numbers pattern's call-argument alternative → kills
  exactly its test.

All mutants restored from backup after verification; final `git status` /
`git diff` against the last commit is clean.

**Lint:** `venv/bin/python -m black --check` and `-m pyflakes` clean;
`bash -n` syntax check clean.

## Model Used

Sonnet
