### PR TITLE
fix(ci): the promtool self-test asserted an environment it no longer controlled (#13927)

### DIFF
--- a/repo_tests/promtool_rules_test.py
+++ b/repo_tests/promtool_rules_test.py
@@ -229,7 +229,20 @@ class TestAMissingPromtoolIsLoudOnCI:
     """
 
     def _run_in(self, env: dict) -> subprocess.CompletedProcess:
-        merged = {**os.environ, **env, _NESTED: "1"}
+        """Child pytest with a controlled environment.
+
+        Both gate variables are stripped before `env` is applied, so a test
+        states the condition it wants rather than inheriting the parent's. The
+        first version cleared only `CI` — and when the gate moved to
+        AUTOBOT_REQUIRE_PROMTOOL, the child kept inheriting the real one from
+        the job that installs promtool, so the "developer machine" case failed
+        instead of skipping. The test asserted an environment it no longer
+        controlled.
+        """
+        merged = {**os.environ}
+        for gate in ("CI", "AUTOBOT_REQUIRE_PROMTOOL", "GITHUB_ACTIONS"):
+            merged.pop(gate, None)
+        merged.update({**env, _NESTED: "1"})
         merged.pop("PATH", None)
         merged["PATH"] = "/nonexistent-bin"
         return subprocess.run(  # nosec B603  # fixed interpreter, repo-local target
@@ -242,7 +255,7 @@ class TestAMissingPromtoolIsLoudOnCI:
         )
 
     def test_ci_without_promtool_fails_rather_than_skips(self):
-        result = self._run_in({"CI": "true", "AUTOBOT_PROMTOOL": "/nonexistent/promtool"})
+        result = self._run_in({"AUTOBOT_REQUIRE_PROMTOOL": "1", "AUTOBOT_PROMTOOL": "/nonexistent/promtool"})
 
         assert result.returncode != 0, (
             "a CI run with no promtool reported success — rule behaviour was unverified "
@@ -254,8 +267,8 @@ class TestAMissingPromtoolIsLoudOnCI:
         """The direction that must stay true. Turning every bare checkout red
         would make the failure meaningless — and a guard that only proves the
         CI case passes equally against a check that always fails."""
-        env = {"AUTOBOT_PROMTOOL": "/nonexistent/promtool"}
-        result = self._run_in({**env, "CI": ""})
+        # No AUTOBOT_REQUIRE_PROMTOOL at all — the bare-checkout condition.
+        result = self._run_in({"AUTOBOT_PROMTOOL": "/nonexistent/promtool"})
 
         assert result.returncode == 0, "a local run without promtool must skip, not fail"
         assert "skipped" in (result.stdout + result.stderr)


### PR DESCRIPTION
## Thinking Path

`test_a_developer_machine_without_promtool_still_skips` fails on CI and is currently reddening `python-suite shard 12/12` on every PR built on the current base, so this is a hotfix.

It is mine, from #14053. When I moved the require-or-skip gate off the generic `CI` var onto `AUTOBOT_REQUIRE_PROMTOOL`, I updated the production path and forgot the self-test.

`_run_in` builds the child's environment as `{**os.environ, **env}` and cleared only `CI`. So on the job that installs promtool — which exports `AUTOBOT_REQUIRE_PROMTOOL=1` precisely so a missing binary is loud — the child pytest **inherited that flag**. The "developer machine with no promtool" case therefore failed instead of skipping, which is the exact behaviour that test exists to pin.

```
E   AssertionError: a local run without promtool must skip, not fail
E   assert 1 == 0
```

The irony is the point: it is the same class as the bug it guards. A check that *reads* its environment instead of *controlling* it will eventually assert something the environment has stopped providing.

## What Changed

Both gate variables (plus `GITHUB_ACTIONS`) are stripped before the caller's `env` is applied, so each test states the condition it wants rather than inheriting whatever the parent happens to have. The two tests now name their condition explicitly — `AUTOBOT_REQUIRE_PROMTOOL: "1"` for the CI case, and its absence for the bare-checkout case — instead of toggling `CI`.

## Verification

Run under CI's actual condition, with the parent flag set:

```
AUTOBOT_REQUIRE_PROMTOOL=1  ->  10 passed, 2 xfailed
bare checkout, no flag      ->  10 passed, 2 xfailed
```

And the fix is load-bearing — reverting `_run_in` to clearing only `CI` fails under the parent flag, which is what CI hit.

Refs #13927 — part of umbrella #13852.

## Model Used

Opus 5 (1M context)