### PR TITLE
feat(llc): rule-based node colouring and a legend on the Company OS canvas

### DIFF
--- a/autobot-frontend/src/components/workflow/WorkflowCanvas.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowCanvas.vue
@@ -23,7 +23,7 @@
         <div v-if="hasOrgNodes" class="rule-mode" role="group" :aria-label="$t('llc.canvasRules.colourBy')">
           <span class="rule-mode-label">{{ $t('llc.canvasRules.colourBy') }}</span>
           <button
-            v-for="dimension in RULE_DIMENSIONS"
+            v-for="dimension in SELECTABLE_RULE_DIMENSIONS"
             :key="dimension"
             type="button"
             class="rule-mode-btn"
@@ -257,7 +257,7 @@ import { useConfirmDialog } from '@/composables/useConfirmDialog';
 import type { WorkflowNode } from '@/composables/useWorkflowBuilder';
 import type { CanvasNode, CanvasNodeType, CanvasTab } from './canvasNode';
 import {
-  RULE_DIMENSIONS,
+  SELECTABLE_RULE_DIMENSIONS,
   activeRules,
   matchRule,
   orgNodeFacts,
@@ -682,6 +682,9 @@ function confirmSave() { emit('save-workflow', saveName.value, saveDesc.value); 
 
 /* The accent stripe. Selection still reads on the remaining three sides plus
    the focus ring, so a coloured node never hides which node is selected. */
+/* Must stay AFTER `.workflow-node.selected`: equal specificity (0,2,0), so the
+   inline-start accent wins on source order alone. Move this above it and the
+   stripe silently vanishes on the selected node. */
 .workflow-node.org-person { border-inline-start-width: 6px; border-inline-start-color: var(--rule-accent, var(--border-default)); }
 
 .rule-chip { display: inline-flex; align-items: center; gap: var(--spacing-1-5); }
@@ -701,7 +704,9 @@ function confirmSave() { emit('save-workflow', saveName.value, saveDesc.value); 
 .rule-mode-btn.active { background: var(--bg-tertiary); border-color: var(--color-primary); color: var(--text-primary); }
 .rule-mode-btn:focus-visible { outline: 2px solid var(--color-primary); outline-offset: 2px; }
 
-.canvas-legend { position: absolute; bottom: var(--spacing-3); inset-inline-start: var(--spacing-3); max-width: 240px; padding: var(--spacing-2) var(--spacing-3); background: var(--bg-secondary); border: 1px solid var(--border-default); border-radius: var(--radius-md); box-shadow: var(--shadow-sm); }
+/* max-height: one legend entry per distinct value, so a large company would
+   otherwise grow the box up over the nodes it is explaining. */
+.canvas-legend { position: absolute; bottom: var(--spacing-3); inset-inline-start: var(--spacing-3); max-width: 240px; max-height: 220px; overflow-y: auto; padding: var(--spacing-2) var(--spacing-3); background: var(--bg-secondary); border: 1px solid var(--border-default); border-radius: var(--radius-md); box-shadow: var(--shadow-sm); }
 .canvas-legend-title { display: block; font-size: var(--text-xs); font-weight: 600; color: var(--text-secondary); margin-bottom: var(--spacing-1); }
 .canvas-legend-items { list-style: none; margin: var(--spacing-0); padding: var(--spacing-0); display: flex; flex-direction: column; gap: var(--spacing-1); }
 .canvas-legend-item { display: flex; align-items: center; gap: var(--spacing-2); font-size: var(--text-xs); color: var(--text-secondary); }

--- a/autobot-frontend/src/components/workflow/WorkflowCanvas.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowCanvas.vue
@@ -17,6 +17,24 @@
             {{ tab.label }}
           </button>
         </div>
+        <!-- GH#13941: which declarative rule set colours the nodes. Offered only
+             when there are org nodes to colour, so workflow authoring is
+             untouched. -->
+        <div v-if="hasOrgNodes" class="rule-mode" role="group" :aria-label="$t('llc.canvasRules.colourBy')">
+          <span class="rule-mode-label">{{ $t('llc.canvasRules.colourBy') }}</span>
+          <button
+            v-for="dimension in RULE_DIMENSIONS"
+            :key="dimension"
+            type="button"
+            class="rule-mode-btn"
+            :class="{ active: colourMode === dimension }"
+            :aria-pressed="colourMode === dimension"
+            :data-testid="`rule-mode-${dimension}`"
+            @click="colourMode = dimension"
+          >
+            {{ dimensionLabels[dimension] }}
+          </button>
+        </div>
         <template v-if="!readonly">
         <button class="tool-btn" @click="addStepNode" :title="$t('workflow.canvas.addStep')">
           <Icon name="plus" /> {{ $t('workflow.canvas.addStep') }}
@@ -80,7 +98,9 @@
         </svg>
 
         <!-- Nodes -->
-        <div v-for="node in nodes" :key="node.id" class="workflow-node" :class="[node.type, { selected: selectedNodeId === node.id }]"
+        <div v-for="node in nodes" :key="node.id" class="workflow-node"
+             :class="[node.type, { selected: selectedNodeId === node.id }, ...ruleClasses(node)]"
+             :data-rule-id="nodeRuleId(node)"
              :style="nodeStyle(node)"
              @mousedown="onNodeMouseDown(node, $event)" @click.stop="selectNode(node.id)">
           <div class="node-header">
@@ -163,7 +183,15 @@
             <template v-else-if="node.type === 'org-person'">
               <p class="org-title">{{ nodeText(node, 'title') }}</p>
               <div class="org-meta">
-                <span class="org-status" :class="`status-${nodeText(node, 'status') || 'unknown'}`"></span>
+                <!-- GH#13941: this was a bare coloured dot — colour was the only
+                     signal it carried, and a paused agent was indistinguishable
+                     from an errored one to a reader who cannot separate the
+                     hues. The chip pairs the active rule's colour with a
+                     distinct marker shape and the rule's translated name. -->
+                <span class="rule-chip">
+                  <span class="rule-marker" aria-hidden="true"></span>
+                  <span class="rule-chip-label">{{ nodeRuleLabel(node) }}</span>
+                </span>
                 <!-- GH#13936: adapter_type is agent vocabulary. A person's node
                      already shows their role as the title, and their adapter_type
                      is the literal "human" — untranslated in all 11 locales. This
@@ -184,6 +212,25 @@
           <p>{{ $t('workflow.canvas.emptyDescription') }}</p>
           <button v-if="!readonly" class="btn-primary" @click="addStepNode"><Icon name="plus" /> {{ $t('workflow.canvas.addStep') }}</button>
         </div>
+      </div>
+
+      <!-- GH#13941: legend — derived from the same evaluation the nodes use, so
+           it lists exactly the rules that won on a node currently drawn. Sits
+           outside `.canvas-content` so panning and zooming never move it. -->
+      <div v-if="legendRules.length > 0" class="canvas-legend" data-testid="canvas-legend">
+        <span class="canvas-legend-title">{{ $t('llc.canvasRules.legendTitle') }}</span>
+        <ul class="canvas-legend-items">
+          <li
+            v-for="rule in legendRules"
+            :key="rule.id"
+            class="canvas-legend-item"
+            :class="[`rule-${rule.swatch}`, `rule-shape-${rule.shape}`]"
+            :data-rule-id="rule.id"
+          >
+            <span class="rule-marker" aria-hidden="true"></span>
+            <span>{{ ruleLabel(rule) }}</span>
+          </li>
+        </ul>
       </div>
     </div>
 
@@ -209,6 +256,16 @@ import { useI18n } from 'vue-i18n';
 import { useConfirmDialog } from '@/composables/useConfirmDialog';
 import type { WorkflowNode } from '@/composables/useWorkflowBuilder';
 import type { CanvasNode, CanvasNodeType, CanvasTab } from './canvasNode';
+import {
+  RULE_DIMENSIONS,
+  activeRules,
+  matchRule,
+  orgNodeFacts,
+  rulesForDimension,
+  type CanvasNodeFacts,
+  type CanvasNodeRule,
+  type CanvasRuleDimension,
+} from './canvasNodeRules';
 
 const { t } = useI18n();
 const { confirm } = useConfirmDialog();
@@ -314,6 +371,64 @@ function nodeStyle(node: CanvasNode): Record<string, string> {
   if (typeof data.width === 'number') style.width = `${data.width}px`;
   if (typeof data.height === 'number') style.height = `${data.height}px`;
   return style;
+}
+
+/* ------------------------------------------------------------------ *
+ * GH#13941: declarative node colouring + legend.
+ *
+ * Presentation only — the rules read facts the nodes already carry and
+ * change nothing that is fetched, authorised or persisted. The chosen
+ * dimension is component state; it is deliberately not persisted, so the
+ * canvas keeps its single source of truth in the org-chart payload.
+ * ------------------------------------------------------------------ */
+
+const colourMode = ref<CanvasRuleDimension>('status');
+
+/** Facts per node id, for the nodes the rules apply to (org people only). */
+const orgFacts = computed(() => {
+  const byId = new Map<string, CanvasNodeFacts>();
+  for (const node of props.nodes) {
+    const facts = orgNodeFacts(node);
+    if (facts) byId.set(node.id, facts);
+  }
+  return byId;
+});
+
+const hasOrgNodes = computed(() => orgFacts.value.size > 0);
+const factsOnCanvas = computed(() => [...orgFacts.value.values()]);
+const activeRuleSet = computed(() => rulesForDimension(colourMode.value, factsOnCanvas.value));
+/** Only rules that won on a node currently drawn — the legend's contents. */
+const legendRules = computed(() => activeRules(activeRuleSet.value, factsOnCanvas.value));
+
+const dimensionLabels = computed<Record<CanvasRuleDimension, string>>(() => ({
+  status: t('llc.canvasRules.dimension.status'),
+  owner: t('llc.canvasRules.dimension.owner'),
+  tool: t('llc.canvasRules.dimension.tool'),
+}));
+
+function ruleForNode(node: CanvasNode): CanvasNodeRule | null {
+  const facts = orgFacts.value.get(node.id);
+  return facts ? matchRule(activeRuleSet.value, facts) : null;
+}
+
+/** Translated rule name, or the raw data value for a data-derived rule. */
+function ruleLabel(rule: CanvasNodeRule): string {
+  return rule.labelKey ? t(rule.labelKey) : (rule.labelText ?? '');
+}
+
+function nodeRuleLabel(node: CanvasNode): string {
+  const rule = ruleForNode(node);
+  return rule ? ruleLabel(rule) : '';
+}
+
+function nodeRuleId(node: CanvasNode): string | undefined {
+  return ruleForNode(node)?.id;
+}
+
+/** Swatch (colour token) + shape classes for a node; empty for authoring nodes. */
+function ruleClasses(node: CanvasNode): string[] {
+  const rule = ruleForNode(node);
+  return rule ? [`rule-${rule.swatch}`, `rule-shape-${rule.shape}`] : [];
 }
 
 const canvasRef = ref<HTMLElement | null>(null);
@@ -542,10 +657,54 @@ function confirmSave() { emit('save-workflow', saveName.value, saveDesc.value); 
 .workflow-node.org-group .node-header { background: transparent; color: var(--text-secondary); border-bottom: 1px dashed var(--border-default); }
 .org-title { margin: var(--spacing-0); font-size: var(--text-xs); color: var(--text-secondary); }
 .org-meta { display: flex; align-items: center; gap: var(--spacing-2); font-size: var(--text-xs); color: var(--text-tertiary); }
-.org-status { width: var(--spacing-2); height: var(--spacing-2); border-radius: 50%; background: var(--text-muted); }
-.org-status.status-active, .org-status.status-working { background: var(--color-success); }
-.org-status.status-paused { background: var(--color-warning); }
-.org-status.status-terminated, .org-status.status-error { background: var(--color-error); }
+
+/* GH#13941: one swatch class per rule, each binding a single design token to
+   --rule-accent. The node accent stripe and every marker read the accent from
+   there, so a rule's colour is declared exactly once and never as a literal. */
+.rule-status-active { --rule-accent: var(--color-success); }
+.rule-status-idle { --rule-accent: var(--color-info); }
+.rule-status-paused { --rule-accent: var(--color-warning); }
+.rule-status-error { --rule-accent: var(--color-error); }
+.rule-status-terminated { --rule-accent: var(--color-secondary); }
+.rule-status-unknown { --rule-accent: var(--text-muted); }
+.rule-owner-human { --rule-accent: var(--chart-blue); }
+.rule-owner-agent { --rule-accent: var(--chart-purple); }
+.rule-owner-unassigned { --rule-accent: var(--color-warning); }
+.rule-tool-1 { --rule-accent: var(--chart-1); }
+.rule-tool-2 { --rule-accent: var(--chart-2); }
+.rule-tool-3 { --rule-accent: var(--chart-3); }
+.rule-tool-4 { --rule-accent: var(--chart-4); }
+.rule-tool-5 { --rule-accent: var(--chart-5); }
+.rule-tool-6 { --rule-accent: var(--chart-6); }
+.rule-tool-7 { --rule-accent: var(--chart-7); }
+.rule-tool-8 { --rule-accent: var(--chart-8); }
+.rule-tool-none { --rule-accent: var(--text-muted); }
+
+/* The accent stripe. Selection still reads on the remaining three sides plus
+   the focus ring, so a coloured node never hides which node is selected. */
+.workflow-node.org-person { border-inline-start-width: 6px; border-inline-start-color: var(--rule-accent, var(--border-default)); }
+
+.rule-chip { display: inline-flex; align-items: center; gap: var(--spacing-1-5); }
+.rule-chip-label { white-space: nowrap; }
+.rule-marker { flex: none; width: var(--spacing-2-5); height: var(--spacing-2-5); background: var(--rule-accent, var(--text-muted)); }
+.rule-shape-disc .rule-marker { border-radius: 50%; }
+.rule-shape-ring .rule-marker { border-radius: 50%; background: transparent; border: 2px solid var(--rule-accent, var(--text-muted)); }
+.rule-shape-square .rule-marker { border-radius: var(--radius-default); }
+.rule-shape-diamond .rule-marker { border-radius: var(--radius-default); transform: rotate(45deg); }
+.rule-shape-triangle .rule-marker { background: transparent; width: 0; height: 0; border-inline: 5px solid transparent; border-bottom: 10px solid var(--rule-accent, var(--text-muted)); }
+.rule-shape-bar .rule-marker { height: var(--spacing-1); border-radius: var(--radius-default); }
+
+.rule-mode { display: flex; align-items: center; gap: var(--spacing-1); }
+.rule-mode-label { font-size: var(--text-xs); color: var(--text-tertiary); }
+.rule-mode-btn { padding: var(--spacing-1) var(--spacing-2); background: transparent; border: 1px solid var(--border-default); border-radius: var(--radius-md); color: var(--text-secondary); font-size: var(--text-xs); cursor: pointer; }
+.rule-mode-btn:hover { background: var(--bg-hover); color: var(--text-primary); }
+.rule-mode-btn.active { background: var(--bg-tertiary); border-color: var(--color-primary); color: var(--text-primary); }
+.rule-mode-btn:focus-visible { outline: 2px solid var(--color-primary); outline-offset: 2px; }
+
+.canvas-legend { position: absolute; bottom: var(--spacing-3); inset-inline-start: var(--spacing-3); max-width: 240px; padding: var(--spacing-2) var(--spacing-3); background: var(--bg-secondary); border: 1px solid var(--border-default); border-radius: var(--radius-md); box-shadow: var(--shadow-sm); }
+.canvas-legend-title { display: block; font-size: var(--text-xs); font-weight: 600; color: var(--text-secondary); margin-bottom: var(--spacing-1); }
+.canvas-legend-items { list-style: none; margin: var(--spacing-0); padding: var(--spacing-0); display: flex; flex-direction: column; gap: var(--spacing-1); }
+.canvas-legend-item { display: flex; align-items: center; gap: var(--spacing-2); font-size: var(--text-xs); color: var(--text-secondary); }
 
 .canvas-tabs { display: flex; align-items: center; gap: var(--spacing-1); }
 .canvas-tab { padding: var(--spacing-1-5) var(--spacing-3); background: transparent; border: 1px solid transparent; border-radius: var(--radius-md); color: var(--text-secondary); font-size: var(--text-sm); cursor: pointer; }

--- a/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.orgMode.test.ts
+++ b/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.orgMode.test.ts
@@ -138,7 +138,10 @@ describe('WorkflowCanvas read-only org mode (#13939)', () => {
     expect(person.text()).toContain('Ada')
     expect(person.text()).toContain('CEO')
     expect(person.text()).toContain('claude')
-    expect(person.find('.org-status.status-paused').exists()).toBe(true)
+    // GH#13941: the bare status dot signalled by colour alone; it is now a rule
+    // chip carrying the swatch, a marker shape and the rule's translated name.
+    expect(person.attributes('data-rule-id')).toBe('status-paused')
+    expect(person.get('.rule-chip').text()).toBe(en.llc.canvasRules.status.paused)
   })
 
   it('does not print adapter vocabulary on a human node (#13936)', () => {

--- a/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.rules.test.ts
+++ b/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.rules.test.ts
@@ -1,0 +1,269 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+/**
+ * GH#13941: rule-based node colouring and the legend, asserted on rendered
+ * output.
+ *
+ * Every case below reads the DOM the user gets — the class the node actually
+ * carries, the text inside its chip, the entries the legend actually lists.
+ * Mounting the component proves nothing; five features in this umbrella shipped
+ * displaying nothing behind tests that asserted exactly that (#14062).
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import en from '@/i18n/locales/en.json'
+import ar from '@/i18n/locales/ar.json'
+
+vi.mock('@/composables/useConfirmDialog', () => ({
+  useConfirmDialog: () => ({ confirm: vi.fn().mockResolvedValue(true) }),
+}))
+
+import WorkflowCanvas from '../WorkflowCanvas.vue'
+import type { CanvasNode } from '../canvasNode'
+
+const RULES = en.llc.canvasRules
+
+/** One org-chart person as `buildOrgCanvasGraph` hands it to the canvas. */
+function person(id: string, data: Record<string, unknown>): CanvasNode {
+  return {
+    id,
+    type: 'org-person',
+    position: { x: 0, y: 0 },
+    data: { label: id, title: 'role', ...data },
+    connections: [],
+  }
+}
+
+/**
+ * Four people covering every branch the rules have: a running agent, a paused
+ * agent on a second adapter, a person, and an agent whose status is outside the
+ * display vocabulary and which carries no adapter at all.
+ */
+const ORG_NODES: CanvasNode[] = [
+  person('ada', { status: 'active', adapter_type: 'claude', is_human: false }),
+  person('bo', { status: 'paused', adapter_type: 'ollama', is_human: false }),
+  person('cy', { status: 'idle', adapter_type: 'human', is_human: true }),
+  person('dee', { status: 'on_leave', adapter_type: '', is_human: false }),
+]
+
+const WORKFLOW_NODES: CanvasNode[] = [
+  {
+    id: 'n1',
+    type: 'step',
+    position: { x: 10, y: 10 },
+    data: { command: '', description: '', risk_level: 'low', requires_confirmation: true },
+    connections: [],
+  },
+]
+
+function mountCanvas(props: Record<string, unknown>, locale: 'en' | 'ar' = 'en') {
+  return mount(WorkflowCanvas, {
+    props: { selectedNodeId: null, readonly: true, ...props },
+    global: {
+      plugins: [createI18n({ legacy: false, locale, fallbackLocale: 'en', messages: { en, ar } })],
+    },
+  })
+}
+
+/** `data-rule-id` of each drawn person node, in document order. */
+function ruleIds(wrapper: ReturnType<typeof mountCanvas>): (string | undefined)[] {
+  return wrapper
+    .findAll('.workflow-node.org-person')
+    .map((node) => node.attributes('data-rule-id'))
+}
+
+/** The text of each legend entry, in document order. */
+function legendLabels(wrapper: ReturnType<typeof mountCanvas>): string[] {
+  return wrapper.findAll('.canvas-legend-item').map((item) => item.text())
+}
+
+describe('rules colour org nodes by status (#13941)', () => {
+  it('gives every node the rule its own status selects', () => {
+    const wrapper = mountCanvas({ nodes: ORG_NODES })
+
+    expect(ruleIds(wrapper)).toEqual([
+      'status-active',
+      'status-paused',
+      'status-idle',
+      'status-unknown',
+    ])
+  })
+
+  it('binds the swatch and the shape as classes on the node', () => {
+    const wrapper = mountCanvas({ nodes: ORG_NODES })
+    const paused = wrapper.findAll('.workflow-node.org-person')[1]
+
+    expect(paused.classes()).toContain('rule-status-paused')
+    expect(paused.classes()).toContain('rule-shape-bar')
+  })
+
+  it('names the rule in text on the node — colour is never the only signal', () => {
+    const wrapper = mountCanvas({ nodes: ORG_NODES })
+    const chips = wrapper.findAll('.workflow-node.org-person .rule-chip')
+
+    expect(chips.map((chip) => chip.text())).toEqual([
+      RULES.status.active,
+      RULES.status.paused,
+      RULES.status.idle,
+      RULES.status.unknown,
+    ])
+  })
+
+  it('pairs every node with a marker shape as well as a colour', () => {
+    const wrapper = mountCanvas({ nodes: ORG_NODES })
+
+    for (const node of wrapper.findAll('.workflow-node.org-person')) {
+      expect(node.classes().some((cls) => cls.startsWith('rule-shape-'))).toBe(true)
+      expect(node.find('.rule-marker').exists()).toBe(true)
+      expect(node.find('.rule-chip-label').text()).not.toBe('')
+    }
+  })
+
+  it('re-colours in place when a status changes without a relayout', () => {
+    // #13996 merges a pause/resume into the drawn nodes rather than rebuilding
+    // the graph, so the rule must follow the mutated data.
+    const nodes = [person('ada', { status: 'active', adapter_type: 'claude', is_human: false })]
+    const wrapper = mountCanvas({ nodes })
+
+    expect(ruleIds(wrapper)).toEqual(['status-active'])
+
+    return wrapper
+      .setProps({
+        nodes: [person('ada', { status: 'paused', adapter_type: 'claude', is_human: false })],
+      })
+      .then(() => {
+        expect(ruleIds(wrapper)).toEqual(['status-paused'])
+        expect(wrapper.get('.rule-chip').text()).toBe(RULES.status.paused)
+      })
+  })
+})
+
+describe('the legend lists what is on screen (#13941)', () => {
+  it('lists exactly the rules that won on a drawn node', () => {
+    const wrapper = mountCanvas({ nodes: ORG_NODES })
+
+    expect(legendLabels(wrapper)).toEqual([
+      RULES.status.active,
+      RULES.status.idle,
+      RULES.status.paused,
+      RULES.status.unknown,
+    ])
+    // The case that must stay caught: nothing on screen is errored or
+    // terminated, so neither may appear in the legend.
+    expect(legendLabels(wrapper)).not.toContain(RULES.status.error)
+    expect(legendLabels(wrapper)).not.toContain(RULES.status.terminated)
+  })
+
+  it('shrinks when the nodes it described leave the canvas', async () => {
+    const wrapper = mountCanvas({ nodes: ORG_NODES })
+    expect(legendLabels(wrapper)).toHaveLength(4)
+
+    await wrapper.setProps({ nodes: [ORG_NODES[0]] })
+
+    expect(legendLabels(wrapper)).toEqual([RULES.status.active])
+  })
+
+  it('carries the same swatch and shape the nodes carry', () => {
+    const wrapper = mountCanvas({ nodes: ORG_NODES })
+    const entry = wrapper.get('[data-rule-id="status-paused"].canvas-legend-item')
+
+    expect(entry.classes()).toContain('rule-status-paused')
+    expect(entry.classes()).toContain('rule-shape-bar')
+    expect(entry.find('.rule-marker').exists()).toBe(true)
+  })
+
+  it('renders in the active locale, not in hard-coded English', () => {
+    const wrapper = mountCanvas({ nodes: ORG_NODES }, 'ar')
+
+    expect(wrapper.get('.canvas-legend-title').text()).toBe(ar.llc.canvasRules.legendTitle)
+    expect(legendLabels(wrapper)).toContain(ar.llc.canvasRules.status.paused)
+    expect(legendLabels(wrapper)).not.toContain(RULES.status.paused)
+  })
+})
+
+describe('the colour dimension is switchable (#13941)', () => {
+  async function switchTo(wrapper: ReturnType<typeof mountCanvas>, dimension: string) {
+    await wrapper.get(`[data-testid="rule-mode-${dimension}"]`).trigger('click')
+  }
+
+  it('offers the three dimensions, with status selected by default', () => {
+    const wrapper = mountCanvas({ nodes: ORG_NODES })
+    const buttons = wrapper.findAll('.rule-mode-btn')
+
+    expect(buttons.map((button) => button.text())).toEqual([
+      RULES.dimension.status,
+      RULES.dimension.owner,
+      RULES.dimension.tool,
+    ])
+    expect(buttons[0].attributes('aria-pressed')).toBe('true')
+  })
+
+  it('re-colours by owner kind and re-derives the legend', async () => {
+    const wrapper = mountCanvas({ nodes: ORG_NODES })
+
+    await switchTo(wrapper, 'owner')
+
+    expect(ruleIds(wrapper)).toEqual([
+      'owner-agent',
+      'owner-agent',
+      'owner-human',
+      'owner-unassigned',
+    ])
+    expect(legendLabels(wrapper)).toEqual([
+      en.llc.orgChart.human,
+      en.llc.orgChart.aiAgent,
+      RULES.owner.unassigned,
+    ])
+  })
+
+  it('re-colours by tool, labelling each bucket with the adapter itself', async () => {
+    const wrapper = mountCanvas({ nodes: ORG_NODES })
+
+    await switchTo(wrapper, 'tool')
+
+    expect(ruleIds(wrapper)).toEqual(['tool-claude', 'tool-ollama', 'tool-none', 'tool-none'])
+    expect(legendLabels(wrapper)).toEqual(['claude', 'ollama', RULES.tool.none])
+    // A person's adapter_type is the literal "human" (#13936) — it must never
+    // become a tool bucket of its own.
+    expect(legendLabels(wrapper)).not.toContain('human')
+  })
+
+  it('assigns distinct palette swatches to distinct tools', async () => {
+    const wrapper = mountCanvas({ nodes: ORG_NODES })
+
+    await switchTo(wrapper, 'tool')
+    const [ada, bo] = wrapper.findAll('.workflow-node.org-person')
+
+    expect(ada.classes()).toContain('rule-tool-1')
+    expect(bo.classes()).toContain('rule-tool-2')
+  })
+})
+
+describe('workflow authoring is untouched by the rule layer (#13941)', () => {
+  it('renders no legend and no colour-by control without org nodes', () => {
+    const wrapper = mountCanvas({ nodes: WORKFLOW_NODES, readonly: false })
+
+    expect(wrapper.find('[data-testid="canvas-legend"]').exists()).toBe(false)
+    expect(wrapper.find('.rule-mode').exists()).toBe(false)
+  })
+
+  it('leaves an authoring node without a rule class or a rule id', () => {
+    const wrapper = mountCanvas({ nodes: WORKFLOW_NODES, readonly: false })
+    const step = wrapper.get('.workflow-node.step')
+
+    expect(step.attributes('data-rule-id')).toBeUndefined()
+    expect(step.classes().some((cls) => cls.startsWith('rule-'))).toBe(false)
+  })
+
+  it('keeps the three pan/zoom buttons the org canvas relies on', () => {
+    // The colour-by control lives in the left half deliberately: #13939 pins
+    // the right half at exactly three buttons in read-only mode.
+    const wrapper = mountCanvas({ nodes: ORG_NODES })
+
+    expect(wrapper.findAll('.toolbar-right .tool-btn')).toHaveLength(3)
+  })
+})

--- a/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.rules.test.ts
+++ b/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.rules.test.ts
@@ -44,10 +44,22 @@ function person(id: string, data: Record<string, unknown>): CanvasNode {
  * display vocabulary and which carries no adapter at all.
  */
 const ORG_NODES: CanvasNode[] = [
+  // NOTE the adapter values. `'claude'` / `'ollama'` are what this field is
+  // *declared* to carry; #14109 records that the org-chart endpoint actually
+  // sends `org_role` here, so a real payload reads `worker` / `manager`. The
+  // fixture below keeps one honest value so the corpus shows today's reality
+  // rather than an aspirational shape — writing fixtures that assert a payload
+  // the backend never sends is exactly how #13993 stayed invisible for months.
   person('ada', { status: 'active', adapter_type: 'claude', is_human: false }),
   person('bo', { status: 'paused', adapter_type: 'ollama', is_human: false }),
   person('cy', { status: 'idle', adapter_type: 'human', is_human: true }),
   person('dee', { status: 'on_leave', adapter_type: '', is_human: false }),
+]
+
+/** What the API sends today (#14109): the org role, in the adapter field. */
+const ORG_NODES_TODAYS_PAYLOAD: CanvasNode[] = [
+  person('ada', { status: 'active', adapter_type: 'worker', is_human: false }),
+  person('bo', { status: 'paused', adapter_type: 'manager', is_human: false }),
 ]
 
 const WORKFLOW_NODES: CanvasNode[] = [
@@ -190,16 +202,29 @@ describe('the colour dimension is switchable (#13941)', () => {
     await wrapper.get(`[data-testid="rule-mode-${dimension}"]`).trigger('click')
   }
 
-  it('offers the three dimensions, with status selected by default', () => {
+  it('offers status and owner, with status selected by default', () => {
     const wrapper = mountCanvas({ nodes: ORG_NODES })
     const buttons = wrapper.findAll('.rule-mode-btn')
 
     expect(buttons.map((button) => button.text())).toEqual([
       RULES.dimension.status,
       RULES.dimension.owner,
-      RULES.dimension.tool,
     ])
     expect(buttons[0].attributes('aria-pressed')).toBe('true')
+  })
+
+  it('does not offer the tool dimension while the payload is dishonest (#14109)', () => {
+    // The rule layer implements `tool` correctly over the *declared* contract,
+    // but the endpoint sends `org_role` in the `adapter_type` field — so the
+    // control would title a legend of `worker` / `manager` as "Tool". Gated
+    // until #14109 lands; this test is what makes un-gating a deliberate act.
+    const wrapper = mountCanvas({ nodes: ORG_NODES_TODAYS_PAYLOAD })
+
+    expect(wrapper.find('[data-testid="rule-mode-tool"]').exists()).toBe(false)
+    expect(wrapper.text()).not.toContain(RULES.dimension.tool)
+    // …and nothing on screen presents a role as though it were a tool.
+    expect(legendLabels(wrapper)).not.toContain('worker')
+    expect(legendLabels(wrapper)).not.toContain('manager')
   })
 
   it('re-colours by owner kind and re-derives the legend', async () => {
@@ -220,27 +245,13 @@ describe('the colour dimension is switchable (#13941)', () => {
     ])
   })
 
-  it('re-colours by tool, labelling each bucket with the adapter itself', async () => {
-    const wrapper = mountCanvas({ nodes: ORG_NODES })
-
-    await switchTo(wrapper, 'tool')
-
-    expect(ruleIds(wrapper)).toEqual(['tool-claude', 'tool-ollama', 'tool-none', 'tool-none'])
-    expect(legendLabels(wrapper)).toEqual(['claude', 'ollama', RULES.tool.none])
-    // A person's adapter_type is the literal "human" (#13936) — it must never
-    // become a tool bucket of its own.
-    expect(legendLabels(wrapper)).not.toContain('human')
-  })
-
-  it('assigns distinct palette swatches to distinct tools', async () => {
-    const wrapper = mountCanvas({ nodes: ORG_NODES })
-
-    await switchTo(wrapper, 'tool')
-    const [ada, bo] = wrapper.findAll('.workflow-node.org-person')
-
-    expect(ada.classes()).toContain('rule-tool-1')
-    expect(bo.classes()).toContain('rule-tool-2')
-  })
+  // The two component tests that drove `rule-mode-tool` are gone with the
+  // control (#14109). Nothing is uncovered by that: the tool rule layer is
+  // exercised directly in `canvasNodeRules.test.ts` — one rule per distinct
+  // adapter in sorted order, raw-value labels, palette wrap, and the guard that
+  // a person's `adapter_type: 'human'` never becomes a bucket of its own. Those
+  // keep the implementation honest while it is not on screen; restore the two
+  // UI tests here when the dimension is un-gated.
 })
 
 describe('workflow authoring is untouched by the rule layer (#13941)', () => {

--- a/autobot-frontend/src/components/workflow/__tests__/canvasNodeRules.test.ts
+++ b/autobot-frontend/src/components/workflow/__tests__/canvasNodeRules.test.ts
@@ -1,0 +1,192 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+/**
+ * GH#13941: the rule layer itself — evaluation order, the derived tool rules,
+ * and the legend derivation.
+ *
+ * The legend cases are the ones that matter: a legend built from
+ * `rule.matches(facts)` rather than from the rule that actually *won* would
+ * list swatches that appear nowhere on the canvas, which is precisely the
+ * "renders something the data never says" failure this umbrella keeps hitting.
+ */
+
+import { describe, it, expect } from 'vitest'
+
+import {
+  OWNER_RULES,
+  RULE_DIMENSIONS,
+  STATUS_RULES,
+  activeRules,
+  matchRule,
+  orgNodeFacts,
+  rulesForDimension,
+  toolRules,
+  type CanvasNodeFacts,
+} from '../canvasNodeRules'
+import type { CanvasNode } from '../canvasNode'
+
+function facts(over: Partial<CanvasNodeFacts> = {}): CanvasNodeFacts {
+  return { status: 'idle', isHuman: false, adapterType: 'claude', ...over }
+}
+
+function personNode(data: Record<string, unknown>): CanvasNode {
+  return { id: 'n', type: 'org-person', position: { x: 0, y: 0 }, data, connections: [] }
+}
+
+describe('canvas node facts (#13941)', () => {
+  it('reads status, human flag and adapter off the node data bag', () => {
+    const result = orgNodeFacts(
+      personNode({ status: ' Paused ', is_human: false, adapter_type: ' claude ' }),
+    )
+
+    expect(result).toEqual({ status: 'paused', isHuman: false, adapterType: 'claude' })
+  })
+
+  it('returns null for a node the rules do not apply to', () => {
+    const step: CanvasNode = {
+      id: 's',
+      type: 'step',
+      position: { x: 0, y: 0 },
+      data: { status: 'active' },
+      connections: [],
+    }
+
+    expect(orgNodeFacts(step)).toBeNull()
+  })
+
+  it('treats a missing status and a non-boolean human flag as absent', () => {
+    const result = orgNodeFacts(personNode({ is_human: 'yes' }))
+
+    expect(result).toEqual({ status: '', isHuman: false, adapterType: '' })
+  })
+})
+
+describe('rule evaluation (#13941)', () => {
+  it('resolves each agent status to its own rule', () => {
+    for (const status of ['active', 'idle', 'paused', 'error', 'terminated']) {
+      expect(matchRule(STATUS_RULES, facts({ status })).id).toBe(`status-${status}`)
+    }
+  })
+
+  it('falls through to the unknown rule for a status outside the vocabulary', () => {
+    expect(matchRule(STATUS_RULES, facts({ status: 'in_sprint' })).id).toBe('status-unknown')
+    expect(matchRule(STATUS_RULES, facts({ status: '' })).id).toBe('status-unknown')
+  })
+
+  it('separates a person, an agent and a node with no owner information', () => {
+    expect(matchRule(OWNER_RULES, facts({ isHuman: true })).id).toBe('owner-human')
+    expect(matchRule(OWNER_RULES, facts({ isHuman: false, adapterType: 'ollama' })).id).toBe(
+      'owner-agent',
+    )
+    expect(matchRule(OWNER_RULES, facts({ isHuman: false, adapterType: '' })).id).toBe(
+      'owner-unassigned',
+    )
+  })
+
+  it('gives every rule a distinct shape within its dimension', () => {
+    // Colour is never the only signal: two rules that share a hue in a
+    // colour-blind rendering must still differ by marker shape.
+    const shapes = STATUS_RULES.map((rule) => rule.shape)
+    expect(new Set(shapes).size).toBe(STATUS_RULES.length)
+    expect(new Set(OWNER_RULES.map((rule) => rule.shape)).size).toBe(OWNER_RULES.length)
+  })
+})
+
+describe('tool rules are derived from the data (#13941)', () => {
+  const onCanvas = [
+    facts({ adapterType: 'ollama' }),
+    facts({ adapterType: 'claude' }),
+    facts({ adapterType: 'ollama' }),
+    facts({ isHuman: true, adapterType: 'human' }),
+  ]
+
+  it('emits one rule per distinct adapter, in sorted order, plus a catch-all', () => {
+    const rules = toolRules(onCanvas)
+
+    expect(rules.map((rule) => rule.id)).toEqual(['tool-claude', 'tool-ollama', 'tool-none'])
+    expect(rules.map((rule) => rule.swatch)).toEqual(['tool-1', 'tool-2', 'tool-none'])
+  })
+
+  it('labels a tool with the raw data value, never an invented UI string', () => {
+    const [claude] = toolRules(onCanvas)
+
+    expect(claude.labelKey).toBeNull()
+    expect(claude.labelText).toBe('claude')
+  })
+
+  it('never assigns a person an adapter bucket — their adapter_type is "human"', () => {
+    const rules = toolRules(onCanvas)
+
+    expect(matchRule(rules, facts({ isHuman: true, adapterType: 'human' })).id).toBe('tool-none')
+    expect(rules.some((rule) => rule.labelText === 'human')).toBe(false)
+  })
+
+  it('wraps the palette rather than running out of swatches', () => {
+    const many = Array.from({ length: 10 }, (_, i) => facts({ adapterType: `a${i}` }))
+
+    const swatches = toolRules(many).map((rule) => rule.swatch)
+    expect(swatches.slice(0, 10)).toEqual([
+      'tool-1',
+      'tool-2',
+      'tool-3',
+      'tool-4',
+      'tool-5',
+      'tool-6',
+      'tool-7',
+      'tool-8',
+      'tool-1',
+      'tool-2',
+    ])
+  })
+})
+
+describe('legend derivation (#13941)', () => {
+  it('lists only the rules that won on a node currently drawn', () => {
+    const drawn = [facts({ status: 'active' }), facts({ status: 'paused' })]
+
+    expect(activeRules(STATUS_RULES, drawn).map((rule) => rule.id)).toEqual([
+      'status-active',
+      'status-paused',
+    ])
+  })
+
+  it('never lists a catch-all that lost to an earlier rule', () => {
+    // The case that must stay caught: `status-unknown` matches everything, so a
+    // legend built from `matches()` would always show it.
+    const drawn = [facts({ status: 'active' })]
+
+    expect(activeRules(STATUS_RULES, drawn).map((rule) => rule.id)).toEqual(['status-active'])
+  })
+
+  it('lists the catch-all once a node actually falls through to it', () => {
+    const drawn = [facts({ status: 'active' }), facts({ status: 'on_leave' })]
+
+    expect(activeRules(STATUS_RULES, drawn).map((rule) => rule.id)).toEqual([
+      'status-active',
+      'status-unknown',
+    ])
+  })
+
+  it('is empty when nothing is drawn', () => {
+    expect(activeRules(STATUS_RULES, [])).toEqual([])
+  })
+})
+
+describe('dimension lookup (#13941)', () => {
+  it('offers exactly status, owner and tool', () => {
+    expect([...RULE_DIMENSIONS]).toEqual(['status', 'owner', 'tool'])
+  })
+
+  it('returns the right rule set for each dimension', () => {
+    const drawn = [facts()]
+
+    expect(rulesForDimension('status', drawn)).toBe(STATUS_RULES)
+    expect(rulesForDimension('owner', drawn)).toBe(OWNER_RULES)
+    expect(rulesForDimension('tool', drawn).map((rule) => rule.id)).toEqual([
+      'tool-claude',
+      'tool-none',
+    ])
+  })
+})

--- a/autobot-frontend/src/components/workflow/canvasNodeRules.ts
+++ b/autobot-frontend/src/components/workflow/canvasNodeRules.ts
@@ -1,0 +1,227 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+/**
+ * Declarative colour rules for Company OS canvas nodes (GH#13941).
+ *
+ * A rule is data: a predicate over the facts a node already carries, plus the
+ * presentation it selects (a token-backed swatch class, a shape, and a label).
+ * The canvas evaluates one dimension at a time — first matching rule wins, and
+ * every dimension ends in a catch-all so a node always resolves to exactly one
+ * rule. The legend is derived from the same evaluation, so it can only ever
+ * list rules that actually won on a node currently drawn.
+ *
+ * Presentation only. Nothing here fetches, authorises or persists anything.
+ *
+ * No new status vocabulary is introduced: the status dimension is generated
+ * from `AgentDisplayStatus` (`composables/llc/llcStatus.ts`, the frontend SSOT
+ * for the org-chart node status), so widening that union is a compile error
+ * here rather than a silently uncoloured node. The repo already carries nine
+ * competing status vocabularies (GH#13485); a tenth would be a defect.
+ *
+ * Lives beside `canvasNode.ts` rather than under `composables/llc/` because
+ * these are the canvas's own presentation rules — putting them in the LLC
+ * layer would make `WorkflowCanvas.vue` (a workflow component) depend on it at
+ * runtime. The only LLC import below is a *type*.
+ */
+
+import type { CanvasNode } from './canvasNode'
+import type { AgentDisplayStatus } from '@/composables/llc/llcStatus'
+
+/** The dimensions a node can be coloured by, in the order the UI offers them. */
+export const RULE_DIMENSIONS = ['status', 'owner', 'tool'] as const
+
+export type CanvasRuleDimension = (typeof RULE_DIMENSIONS)[number]
+
+/**
+ * The non-colour half of a rule's signal. Colour is never allowed to be the
+ * only differentiator, so every rule also selects a marker shape — and the
+ * label text is rendered next to it, on the node and in the legend alike.
+ */
+export type CanvasRuleShape = 'disc' | 'ring' | 'square' | 'diamond' | 'triangle' | 'bar'
+
+/** The facts a rule may look at. Read off a node's existing `data` bag. */
+export interface CanvasNodeFacts {
+  /** Org-chart node status, lower-cased. '' when the node carries none. */
+  status: string
+  /** `data.is_human` — the person/agent discriminator (GH#13936). */
+  isHuman: boolean
+  /** `data.adapter_type` — the executing tool of an agent. '' when absent. */
+  adapterType: string
+}
+
+export interface CanvasNodeRule {
+  /** Stable identity, unique within its dimension. Rendered as a data attr. */
+  id: string
+  dimension: CanvasRuleDimension
+  /** Enumerable CSS class suffix — `rule-<swatch>` binds the colour token. */
+  swatch: string
+  shape: CanvasRuleShape
+  /** i18n key for the label, or `null` when the label is a data value. */
+  labelKey: string | null
+  /** Literal label taken from the data (never a UI string), or `null`. */
+  labelText: string | null
+  matches: (facts: CanvasNodeFacts) => boolean
+}
+
+/**
+ * Shape per agent status. A `Record` over the SSOT union rather than a list, so
+ * a new member of `AgentDisplayStatus` fails type-check here instead of falling
+ * through to "unknown" on screen.
+ */
+const STATUS_SHAPES: Record<AgentDisplayStatus, CanvasRuleShape> = {
+  active: 'disc',
+  idle: 'ring',
+  paused: 'bar',
+  error: 'triangle',
+  terminated: 'square',
+}
+
+/** Catch-all appended to every dimension so a node always resolves to a rule. */
+function fallbackRule(
+  dimension: CanvasRuleDimension,
+  swatch: string,
+  shape: CanvasRuleShape,
+  labelKey: string,
+): CanvasNodeRule {
+  return {
+    id: swatch,
+    dimension,
+    swatch,
+    shape,
+    labelKey,
+    labelText: null,
+    matches: () => true,
+  }
+}
+
+/** Status rules, generated from the SSOT union, ordered as declared above. */
+export const STATUS_RULES: readonly CanvasNodeRule[] = [
+  ...(Object.keys(STATUS_SHAPES) as AgentDisplayStatus[]).map((status) => ({
+    id: `status-${status}`,
+    dimension: 'status' as const,
+    swatch: `status-${status}`,
+    shape: STATUS_SHAPES[status],
+    labelKey: `llc.canvasRules.status.${status}`,
+    labelText: null,
+    matches: (facts: CanvasNodeFacts) => facts.status === status,
+  })),
+  fallbackRule('status', 'status-unknown', 'diamond', 'llc.canvasRules.status.unknown'),
+]
+
+/**
+ * Owner-kind rules. `is_human` is the discriminator the org chart already
+ * carries; a node with neither a human flag nor an adapter has no owner
+ * information at all, which is exactly the gap the legend exists to surface.
+ */
+export const OWNER_RULES: readonly CanvasNodeRule[] = [
+  {
+    id: 'owner-human',
+    dimension: 'owner',
+    swatch: 'owner-human',
+    shape: 'disc',
+    labelKey: 'llc.orgChart.human',
+    labelText: null,
+    matches: (facts) => facts.isHuman,
+  },
+  {
+    id: 'owner-agent',
+    dimension: 'owner',
+    swatch: 'owner-agent',
+    shape: 'square',
+    labelKey: 'llc.orgChart.aiAgent',
+    labelText: null,
+    matches: (facts) => !facts.isHuman && facts.adapterType !== '',
+  },
+  fallbackRule('owner', 'owner-unassigned', 'diamond', 'llc.canvasRules.owner.unassigned'),
+]
+
+/** Palette slots available to the tool dimension (`--chart-1` … `--chart-8`). */
+const TOOL_PALETTE_SIZE = 8
+
+/** Shapes cycled alongside the palette so two tools differ by more than hue. */
+const TOOL_SHAPES: readonly CanvasRuleShape[] = [
+  'disc',
+  'square',
+  'diamond',
+  'triangle',
+  'ring',
+  'bar',
+]
+
+/**
+ * Tool rules are derived from the data, not declared: `adapter_type` is an open
+ * set (eight execution adapters today), and enumerating it here would fork a
+ * backend vocabulary into the frontend. Labels are therefore the raw data value
+ * — not a UI string — while the dimension name and the "no tool" bucket are
+ * translated.
+ *
+ * Ordering is by sorted tool name so the palette assignment is deterministic
+ * across renders and machines.
+ */
+export function toolRules(facts: readonly CanvasNodeFacts[]): CanvasNodeRule[] {
+  const tools = [
+    ...new Set(facts.filter((f) => !f.isHuman && f.adapterType !== '').map((f) => f.adapterType)),
+  ].sort()
+  const rules: CanvasNodeRule[] = tools.map((tool, index) => ({
+    id: `tool-${tool}`,
+    dimension: 'tool' as const,
+    swatch: `tool-${(index % TOOL_PALETTE_SIZE) + 1}`,
+    shape: TOOL_SHAPES[index % TOOL_SHAPES.length],
+    labelKey: null,
+    labelText: tool,
+    matches: (candidate: CanvasNodeFacts) =>
+      !candidate.isHuman && candidate.adapterType === tool,
+  }))
+  rules.push(fallbackRule('tool', 'tool-none', 'bar', 'llc.canvasRules.tool.none'))
+  return rules
+}
+
+/** The rule set for one dimension, given the nodes currently on the canvas. */
+export function rulesForDimension(
+  dimension: CanvasRuleDimension,
+  facts: readonly CanvasNodeFacts[],
+): readonly CanvasNodeRule[] {
+  if (dimension === 'status') return STATUS_RULES
+  if (dimension === 'owner') return OWNER_RULES
+  return toolRules(facts)
+}
+
+/**
+ * Facts for a node, or `null` when the node is not one the rules apply to.
+ * Only `org-person` nodes carry owner/status/tool facts; workflow authoring
+ * nodes are left exactly as they were.
+ */
+export function orgNodeFacts(node: CanvasNode): CanvasNodeFacts | null {
+  if (node.type !== 'org-person') return null
+  const data = node.data as Record<string, unknown>
+  return {
+    status: typeof data.status === 'string' ? data.status.trim().toLowerCase() : '',
+    isHuman: data.is_human === true,
+    adapterType: typeof data.adapter_type === 'string' ? data.adapter_type.trim() : '',
+  }
+}
+
+/** First matching rule. The catch-all guarantees a result. */
+export function matchRule(
+  rules: readonly CanvasNodeRule[],
+  facts: CanvasNodeFacts,
+): CanvasNodeRule {
+  return rules.find((rule) => rule.matches(facts)) ?? rules[rules.length - 1]
+}
+
+/**
+ * The rules the legend must show: those that *won* on at least one node drawn.
+ *
+ * Deliberately not `rule.matches(facts)` — a later rule can match a node that
+ * an earlier rule already claimed, and listing it would put a swatch in the
+ * legend that appears nowhere on the canvas.
+ */
+export function activeRules(
+  rules: readonly CanvasNodeRule[],
+  facts: readonly CanvasNodeFacts[],
+): CanvasNodeRule[] {
+  const won = new Set(facts.map((item) => matchRule(rules, item).id))
+  return rules.filter((rule) => won.has(rule.id))
+}

--- a/autobot-frontend/src/components/workflow/canvasNodeRules.ts
+++ b/autobot-frontend/src/components/workflow/canvasNodeRules.ts
@@ -35,6 +35,21 @@ export const RULE_DIMENSIONS = ['status', 'owner', 'tool'] as const
 export type CanvasRuleDimension = (typeof RULE_DIMENSIONS)[number]
 
 /**
+ * The dimensions actually offered in the UI.
+ *
+ * `tool` is implemented and tested but **not offered yet**: the org-chart
+ * endpoint sends `org_role` in the field named `adapter_type` (#14109), so the
+ * control would title a legend reading `worker` / `manager` / `cto` as "Tool".
+ * The rule layer is correct over the *declared* contract — when #14109 makes the
+ * payload honest, delete this list and iterate `RULE_DIMENSIONS` again. Nothing
+ * else needs to change.
+ *
+ * #13941 asked for status and owner; tool was additional scope, so gating it
+ * costs none of the issue's acceptance criteria.
+ */
+export const SELECTABLE_RULE_DIMENSIONS = ['status', 'owner'] as const satisfies readonly CanvasRuleDimension[]
+
+/**
  * The non-colour half of a rule's signal. Colour is never allowed to be the
  * only differentiator, so every rule also selects a marker shape — and the
  * label text is rendered next to it, on the node and in the legend alike.

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -8240,6 +8240,29 @@
       "canvasUnit": "وحدة {name}",
       "canvasHint": "اضغط Shift واسحب للتحريك، ومرّر للتكبير، وانقر على عقدة لعرض التفاصيل."
     },
+    "canvasRules": {
+      "legendTitle": "وسيلة الإيضاح",
+      "colourBy": "التلوين حسب",
+      "dimension": {
+        "status": "الحالة",
+        "owner": "المالك",
+        "tool": "الأداة"
+      },
+      "status": {
+        "active": "نشط",
+        "idle": "خامل",
+        "paused": "متوقف مؤقتًا",
+        "error": "خطأ",
+        "terminated": "منتهٍ",
+        "unknown": "غير معروف"
+      },
+      "owner": {
+        "unassigned": "غير مُسنَد"
+      },
+      "tool": {
+        "none": "لا توجد أداة"
+      }
+    },
     "goals": {
       "title": "Goal Tree",
       "retry": "Retry",

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -8240,6 +8240,29 @@
       "canvasUnit": "Einheit {name}",
       "canvasHint": "Umschalt+Ziehen zum Verschieben, Scrollen zum Zoomen, Knoten anklicken für Details."
     },
+    "canvasRules": {
+      "legendTitle": "Legende",
+      "colourBy": "Einfärben nach",
+      "dimension": {
+        "status": "Status",
+        "owner": "Inhaber",
+        "tool": "Werkzeug"
+      },
+      "status": {
+        "active": "Aktiv",
+        "idle": "Leerlauf",
+        "paused": "Pausiert",
+        "error": "Fehler",
+        "terminated": "Beendet",
+        "unknown": "Unbekannt"
+      },
+      "owner": {
+        "unassigned": "Nicht zugewiesen"
+      },
+      "tool": {
+        "none": "Kein Werkzeug"
+      }
+    },
     "goals": {
       "title": "Zielbaum",
       "retry": "Erneut versuchen",

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -8228,6 +8228,29 @@
       "canvasUnit": "{name} unit",
       "canvasHint": "Shift-drag to pan, scroll to zoom, click a node for details."
     },
+    "canvasRules": {
+      "legendTitle": "Legend",
+      "colourBy": "Colour by",
+      "dimension": {
+        "status": "Status",
+        "owner": "Owner",
+        "tool": "Tool"
+      },
+      "status": {
+        "active": "Active",
+        "idle": "Idle",
+        "paused": "Paused",
+        "error": "Error",
+        "terminated": "Terminated",
+        "unknown": "Unknown"
+      },
+      "owner": {
+        "unassigned": "Unassigned"
+      },
+      "tool": {
+        "none": "No tool"
+      }
+    },
     "goals": {
       "title": "Goal Tree",
       "retry": "Retry",

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -8240,6 +8240,29 @@
       "canvasUnit": "Unidad {name}",
       "canvasHint": "Mayús+arrastrar para desplazar, rueda para acercar, haz clic en un nodo para ver detalles."
     },
+    "canvasRules": {
+      "legendTitle": "Leyenda",
+      "colourBy": "Colorear por",
+      "dimension": {
+        "status": "Estado",
+        "owner": "Propietario",
+        "tool": "Herramienta"
+      },
+      "status": {
+        "active": "Activo",
+        "idle": "Inactivo",
+        "paused": "En pausa",
+        "error": "Error",
+        "terminated": "Finalizado",
+        "unknown": "Desconocido"
+      },
+      "owner": {
+        "unassigned": "Sin asignar"
+      },
+      "tool": {
+        "none": "Sin herramienta"
+      }
+    },
     "goals": {
       "title": "Árbol de objetivos",
       "retry": "Reintentar",

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -8240,6 +8240,29 @@
       "canvasUnit": "واحد {name}",
       "canvasHint": "برای جابه‌جایی Shift را نگه دارید و بکشید، برای بزرگ‌نمایی اسکرول کنید و برای جزئیات روی گره کلیک کنید."
     },
+    "canvasRules": {
+      "legendTitle": "راهنمای نمادها",
+      "colourBy": "رنگ‌آمیزی بر اساس",
+      "dimension": {
+        "status": "وضعیت",
+        "owner": "مالک",
+        "tool": "ابزار"
+      },
+      "status": {
+        "active": "فعال",
+        "idle": "بی‌کار",
+        "paused": "متوقف‌شده",
+        "error": "خطا",
+        "terminated": "خاتمه‌یافته",
+        "unknown": "نامشخص"
+      },
+      "owner": {
+        "unassigned": "تخصیص‌نیافته"
+      },
+      "tool": {
+        "none": "بدون ابزار"
+      }
+    },
     "goals": {
       "title": "Goal Tree",
       "retry": "Retry",

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -8240,6 +8240,29 @@
       "canvasUnit": "Unité {name}",
       "canvasHint": "Maj+glisser pour déplacer, molette pour zoomer, cliquez sur un nœud pour les détails."
     },
+    "canvasRules": {
+      "legendTitle": "Légende",
+      "colourBy": "Colorer par",
+      "dimension": {
+        "status": "Statut",
+        "owner": "Propriétaire",
+        "tool": "Outil"
+      },
+      "status": {
+        "active": "Actif",
+        "idle": "Inactif",
+        "paused": "En pause",
+        "error": "Erreur",
+        "terminated": "Arrêté",
+        "unknown": "Inconnu"
+      },
+      "owner": {
+        "unassigned": "Non attribué"
+      },
+      "tool": {
+        "none": "Aucun outil"
+      }
+    },
     "goals": {
       "title": "Arbre des objectifs",
       "retry": "Réessayer",

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -8240,6 +8240,29 @@
       "canvasUnit": "יחידת {name}",
       "canvasHint": "Shift+גרירה להזזה, גלילה לשינוי מרחק התצוגה, לחיצה על צומת לפרטים."
     },
+    "canvasRules": {
+      "legendTitle": "מקרא",
+      "colourBy": "צביעה לפי",
+      "dimension": {
+        "status": "סטטוס",
+        "owner": "בעלים",
+        "tool": "כלי"
+      },
+      "status": {
+        "active": "פעיל",
+        "idle": "במנוחה",
+        "paused": "מושהה",
+        "error": "שגיאה",
+        "terminated": "הופסק",
+        "unknown": "לא ידוע"
+      },
+      "owner": {
+        "unassigned": "לא הוקצה"
+      },
+      "tool": {
+        "none": "אין כלי"
+      }
+    },
     "goals": {
       "title": "Goal Tree",
       "retry": "Retry",

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -8240,6 +8240,29 @@
       "canvasUnit": "Vienība {name}",
       "canvasHint": "Shift+vilkšana pārvieto, ritināšana tuvina, uzklikšķini uz mezgla, lai redzētu detaļas."
     },
+    "canvasRules": {
+      "legendTitle": "Apzīmējumi",
+      "colourBy": "Krāsot pēc",
+      "dimension": {
+        "status": "Statuss",
+        "owner": "Īpašnieks",
+        "tool": "Rīks"
+      },
+      "status": {
+        "active": "Aktīvs",
+        "idle": "Dīkstāvē",
+        "paused": "Apturēts",
+        "error": "Kļūda",
+        "terminated": "Pārtraukts",
+        "unknown": "Nezināms"
+      },
+      "owner": {
+        "unassigned": "Nav piešķirts"
+      },
+      "tool": {
+        "none": "Nav rīka"
+      }
+    },
     "goals": {
       "title": "Goal Tree",
       "retry": "Retry",

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -8240,6 +8240,29 @@
       "canvasUnit": "Jednostka {name}",
       "canvasHint": "Shift+przeciągnięcie przesuwa, przewijanie przybliża, kliknij węzeł, aby zobaczyć szczegóły."
     },
+    "canvasRules": {
+      "legendTitle": "Legenda",
+      "colourBy": "Koloruj według",
+      "dimension": {
+        "status": "Status",
+        "owner": "Właściciel",
+        "tool": "Narzędzie"
+      },
+      "status": {
+        "active": "Aktywny",
+        "idle": "Bezczynny",
+        "paused": "Wstrzymany",
+        "error": "Błąd",
+        "terminated": "Zakończony",
+        "unknown": "Nieznany"
+      },
+      "owner": {
+        "unassigned": "Nieprzypisany"
+      },
+      "tool": {
+        "none": "Brak narzędzia"
+      }
+    },
     "goals": {
       "title": "Goal Tree",
       "retry": "Retry",

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -8240,6 +8240,29 @@
       "canvasUnit": "Unidade {name}",
       "canvasHint": "Shift+arrastar para deslocar, rolar para ampliar, clique num nó para ver detalhes."
     },
+    "canvasRules": {
+      "legendTitle": "Legenda",
+      "colourBy": "Colorir por",
+      "dimension": {
+        "status": "Estado",
+        "owner": "Proprietário",
+        "tool": "Ferramenta"
+      },
+      "status": {
+        "active": "Ativo",
+        "idle": "Inativo",
+        "paused": "Em pausa",
+        "error": "Erro",
+        "terminated": "Terminado",
+        "unknown": "Desconhecido"
+      },
+      "owner": {
+        "unassigned": "Não atribuído"
+      },
+      "tool": {
+        "none": "Sem ferramenta"
+      }
+    },
     "goals": {
       "title": "Árvore de objetivos",
       "retry": "Tentar novamente",

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -8240,6 +8240,29 @@
       "canvasUnit": "{name} یونٹ",
       "canvasHint": "پین کرنے کے لیے Shift دبا کر گھسیٹیں، زوم کے لیے اسکرول کریں، تفصیلات کے لیے نوڈ پر کلک کریں۔"
     },
+    "canvasRules": {
+      "legendTitle": "کلید",
+      "colourBy": "رنگ بندی بلحاظ",
+      "dimension": {
+        "status": "حیثیت",
+        "owner": "مالک",
+        "tool": "آلہ"
+      },
+      "status": {
+        "active": "فعال",
+        "idle": "بیکار",
+        "paused": "معطل",
+        "error": "خرابی",
+        "terminated": "ختم شدہ",
+        "unknown": "نامعلوم"
+      },
+      "owner": {
+        "unassigned": "غیر تفویض شدہ"
+      },
+      "tool": {
+        "none": "کوئی آلہ نہیں"
+      }
+    },
     "goals": {
       "title": "Goal Tree",
       "retry": "Retry",


### PR DESCRIPTION
Closes #13941 · Parent umbrella #13935 · Wave 3

## Thinking Path

The canvas already draws org people (#13939) and their nodes already carry `status`,
`is_human` and `adapter_type`. What was missing was a way to read a company at a glance:
the only visual signal a node carried was a small dot whose **colour was its entire
meaning** — a paused agent and an errored one were the same shape, the same size and the
same text.

Three decisions shaped the implementation:

1. **No new status vocabulary.** The status rules are *generated* from `AgentDisplayStatus`
   (`composables/llc/llcStatus.ts`, the frontend SSOT for an org-chart node's status) via a
   `Record` over the union, so adding a member to that union is a type error here rather
   than a node that silently falls through to "unknown". The repo already carries nine
   competing status vocabularies (#13485); a tenth would be a defect.
2. **Tool rules are derived, not declared.** `adapter_type` is an open set (eight execution
   adapters today). Enumerating it in the frontend would fork a backend vocabulary, so the
   tool dimension builds its rules from the values actually on the canvas, sorted for a
   deterministic palette assignment. A tool's label is the raw data value — not a UI string
   — while the dimension name and the "no tool" bucket are translated.
3. **The legend is derived from the same evaluation the nodes use.** It lists the rules that
   *won* on a node currently drawn, not the rules that *match* one. Built the naive way, the
   catch-all rule matches everything and would appear in the legend permanently — a swatch
   the user can never find on the canvas. That is the same class of defect as the five
   "shipped displaying nothing" features this umbrella already found (#14062), so it has its
   own test.

**Not persisted.** The selected dimension is component state and nothing is written
anywhere: presentation only, no fetch, no authorisation, no persisted state.

`views/llc/OrgChart.vue` is **untouched** — #13938 is editing it concurrently. The rule
layer needed no prop from it: the canvas enables the rules when it is actually drawing org
nodes.

## What Changed

**`autobot-frontend/src/components/workflow/canvasNodeRules.ts` (new)** — the rule layer. A
rule is data: a predicate over the facts a node already carries, plus the presentation it
selects (a token-backed swatch class, a marker shape, and a label key *or* a data value).
First match wins; every dimension ends in a catch-all, so a node always resolves to exactly
one rule. `activeRules()` derives the legend from the winners.

It sits beside `canvasNode.ts` rather than under `composables/llc/` so that
`WorkflowCanvas.vue` — a workflow component — gains no runtime dependency on the LLC layer;
the only LLC import is a *type*.

**`autobot-frontend/src/components/workflow/WorkflowCanvas.vue`**
- A "Colour by: Status · Owner · Tool" control, rendered only when org nodes are present, so
  workflow authoring is untouched.
- Each org node carries `rule-<swatch>` and `rule-shape-<shape>` classes plus a
  `data-rule-id`, and gains an accent stripe on its inline-start edge.
- The colour-only status dot became a **rule chip**: marker shape + the rule's translated
  name, so colour is never the only signal. Selection still reads on the remaining three
  borders and the focus ring.
- A legend anchored outside `.canvas-content`, so panning and zooming never move it.
- Styling: one swatch class per rule binds a **single design token** to `--rule-accent`; the
  stripe and every marker read the accent from there. Colours come from `--color-*` and
  `--chart-1…8`. **No literal hex or `rgba()` was added** — see Verification.
- RTL: `inset-inline-start` / `border-inline-start-*` throughout.

**i18n** — 13 new keys under `llc.canvasRules` in **all 11 locales**. Owner labels reuse the
existing `llc.orgChart.human` / `llc.orgChart.aiAgent` rather than duplicating them.

**Tests** — `canvasNodeRules.test.ts` (17 cases: evaluation order, derived tool rules, legend
derivation) and `WorkflowCanvas.rules.test.ts` (16 cases, all asserting **rendered output**).
One existing assertion in `WorkflowCanvas.orgMode.test.ts` moved from the removed
`.org-status` dot to the chip that replaced it.

### Explicitly not folded in

**#13961** tracks the remaining literal `rgba()` values in this file's styles
(`.dropdown-menu` box-shadow, `.delete-btn:hover`, `.dialog-overlay`). They are **left
untouched** — none of them is mine and silently absorbing them would hide that issue's scope.

## Verification

```
$ npm run lint            # oxlint -D correctness, then eslint .
> run-s lint:oxlint lint:eslint
(clean, no output)

$ npm run type-check      # vue-tsc --noEmit -p tsconfig.app.json
(clean, no output)

$ npx vitest run src/composables/llc src/views/llc src/components/workflow src/i18n
 Test Files  24 passed (24)
      Tests  254 passed (254)

$ npm run check:i18n
All translation keys found in en.json.

$ npm run check:locales
  ar.json: OK … ur.json: OK
All locale files complete.

$ bash pipeline-scripts/check-pre-commit-hook-pr.sh pre-commit-hardcoded-values
Running pre-commit-hardcoded-values against 5 changed file(s)...
1 warning(s) - commit allowed
```

(The single warning is pre-existing and unrelated: `const dragOffset = reactive({ x: 0, y: 0 })`.)

**No colour literals added** — every added line scanned for `#hex`, `rgb(a)`, `hsl(a)`:

```
$ git diff origin/Dev_new_gui...HEAD -- .../WorkflowCanvas.vue \
    | grep -E "^\+" | grep -inE "#[0-9a-f]{3,8}\b|rgba?\(|hsla?\("
2:+        <!-- GH#13941: which declarative rule set colours the nodes. …
23:+                <!-- GH#13941: this was a bare coloured dot — colour was …
33:+      <!-- GH#13941: legend — derived from the same evaluation …
62:+ * GH#13941: declarative node colouring + legend.
120:+/* GH#13941: one swatch class per rule, each binding a single design token to
```

Every hit is the literal string `GH#13941` in a comment. No declaration matched.

**No graph library:** `package.json` is not in the diff (16 files changed, all under
`src/`).

### Mutation proof

The rule application was broken on purpose — `matchRule` forced to always return the
catch-all instead of the first matching rule:

```diff
-  return rules.find((rule) => rule.matches(facts)) ?? rules[rules.length - 1]
+  return rules[rules.length - 1] // MUTATION: rule application broken on purpose
```

**RED** (17 of 53 failed, across both new suites and the DOM assertions specifically):

```
 Test Files  3 failed (3)
      Tests  17 failed | 36 passed (53)

FAIL … > gives every node the rule its own status selects
AssertionError: expected [ 'status-unknown', …(3) ] to deeply equal [ 'status-active', …(3) ]
FAIL … > binds the swatch and the shape as classes on the node
AssertionError: expected [ 'workflow-node', 'org-person', …(2) ] to include 'rule-status-paused'
FAIL … > names the rule in text on the node — colour is never the only signal
AssertionError: expected [ 'Unknown', 'Unknown', …(2) ] to deeply equal [ 'Active', 'Paused', 'Idle', …(1) ]
FAIL … > lists exactly the rules that won on a drawn node
AssertionError: expected [ 'Unknown' ] to deeply equal [ 'Active', 'Idle', 'Paused', …(1) ]
FAIL … > shrinks when the nodes it described leave the canvas
AssertionError: expected [ 'Unknown' ] to have a length of 4 but got 1
FAIL … > renders in the active locale, not in hard-coded English
AssertionError: expected [ 'غير معروف' ] to include 'متوقف مؤقتًا'
FAIL … > re-colours by owner kind and re-derives the legend
AssertionError: expected [ 'owner-unassigned', …(3) ] to deeply equal [ 'owner-agent', 'owner-agent', …(2) ]
FAIL … > re-colours by tool, labelling each bucket with the adapter itself
AssertionError: expected [ 'tool-none', 'tool-none', …(2) ] to deeply equal [ 'tool-claude', 'tool-ollama', …(2) ]
```

**GREEN** after restoring the line:

```
 ✓ src/components/workflow/__tests__/canvasNodeRules.test.ts (17 tests)
 ✓ src/components/workflow/__tests__/WorkflowCanvas.rules.test.ts (16 tests)
 ✓ src/components/workflow/__tests__/WorkflowCanvas.orgMode.test.ts (20 tests)

 Test Files  3 passed (3)
      Tests  53 passed (53)
```

### Acceptance criteria

- [x] Rules colour nodes by existing status/owner fields; no new persisted status vocabulary
      (status rules generated from the `AgentDisplayStatus` SSOT; nothing persisted at all).
- [x] A legend renders and stays in sync with the active rules (derived from the winners;
      asserted, and mutation-proved).
- [x] Colour is never the only signal — every rule pairs its colour with a distinct marker
      shape *and* a translated name rendered as text on the node and in the legend.
- [x] Tokens only, no literal colours; strings in 11 locales.

## Model Used

Claude Opus 5 (1M context)
