### PR TITLE
security(mcp): exclude .git, .env* and secrets storage from the filesystem bridge

### DIFF
--- a/autobot-backend/api/filesystem_mcp.py
+++ b/autobot-backend/api/filesystem_mcp.py
@@ -237,6 +237,13 @@ _EXCLUDED_FILE_PATHS = [
 ]
 _EXCLUDED_ROOTS = [Path(os.path.realpath(str(p))) for p in _EXCLUDED_FILE_PATHS]
 
+# Committed, non-secret dotenv templates (review follow-up on #14081): a
+# ".env*" basename denylist alone also blocks these commonly-committed
+# examples, which is over-broad -- they carry no real credential material by
+# convention. Checked against the basename only, so a directory genuinely
+# named e.g. ".env.example" (not a file) stays denied.
+_ENV_TEMPLATE_ALLOWLIST = frozenset({".env.example", ".env.sample", ".env.template"})
+
 
 def _is_excluded_path(resolved: Path) -> bool:
     """Refuse ``.git/``, ``.env*`` and secrets-manager storage (#14081).
@@ -244,10 +251,19 @@ def _is_excluded_path(resolved: Path) -> bool:
     Checked against the *resolved* (symlink-followed, canonicalized) path so
     a symlink or an encoded traversal that lands inside an excluded subtree
     can't slip past a check on the raw input string.
+
+    Accepted gap: this is a path-prefix check, not an inode check, so a
+    *hardlink* to an excluded file placed at an unexcluded path would read
+    through (``os.path.realpath`` follows symlinks but not hardlinks).
+    Creating that hardlink already requires local filesystem write access to
+    the excluded file's directory -- at which point the attacker can already
+    read the excluded file directly without the bridge, so this is
+    defence-in-depth against a caller who only has bridge access, not a hole
+    in the boundary the bridge actually enforces.
     """
     if ".git" in resolved.parts:
         return True
-    if any(fnmatch.fnmatch(part, ".env*") for part in resolved.parts):
+    if resolved.name not in _ENV_TEMPLATE_ALLOWLIST and any(fnmatch.fnmatch(part, ".env*") for part in resolved.parts):
         return True
     for excluded_root in _EXCLUDED_ROOTS:
         try:

--- a/autobot-backend/api/filesystem_mcp.py
+++ b/autobot-backend/api/filesystem_mcp.py
@@ -103,10 +103,12 @@ Other MCP bridges can follow this pattern by:
 
 import asyncio
 import base64
+import fnmatch
 import mimetypes
 import os
 import shutil
 from datetime import datetime
+from pathlib import Path
 from typing import Dict, List
 
 import aiofiles
@@ -209,11 +211,55 @@ ALLOWED_DIRECTORIES = [
 # Maximum file size for read operations (10MB)
 MAX_FILE_SIZE = 10 * 1024 * 1024
 
+# Security Configuration: Excluded Subtrees (#14081)
+#
+# Since #14050, an unset AUTOBOT_BASE_DIR (every dev checkout and CI runner)
+# resolves ALLOWED_DIRECTORIES to the whole git checkout, and the only gate on
+# this bridge is admin role or the shared X-Internal-API-Key header. Without
+# an exclusion, either credential grants read *and write* access to VCS
+# history and any local secrets.
+#
+# Enforced in _resolve_allowed_path (the single seam every path goes through,
+# shared by is_path_allowed and _validated_path) rather than by curating
+# ALLOWED_DIRECTORIES, so the exclusion holds regardless of how base_dir is
+# configured -- including a deployment that legitimately points it at a
+# directory containing these.
+#
+# _EXCLUDED_FILE_PATHS are the canonical secrets-manager storage locations
+# (services/secrets_service.py, api/secrets.py, auth_middleware.py's durable
+# JWT keypair) -- all resolved from config.path.data_path so they track
+# wherever AUTOBOT_DATA_DIR actually points, not a hardcoded literal.
+_EXCLUDED_FILE_PATHS = [
+    config.path.data_path / "secrets.key",  # SecretsManager encryption key
+    config.path.data_path / "secrets.json",  # SecretsManager encrypted store
+    config.path.data_path / "secrets.db",  # SecretsService encrypted store
+    config.path.data_path / "service-keys",  # durable JWT RSA keypair (.pem)
+]
+_EXCLUDED_ROOTS = [Path(os.path.realpath(str(p))) for p in _EXCLUDED_FILE_PATHS]
+
+
+def _is_excluded_path(resolved: Path) -> bool:
+    """Refuse ``.git/``, ``.env*`` and secrets-manager storage (#14081).
+
+    Checked against the *resolved* (symlink-followed, canonicalized) path so
+    a symlink or an encoded traversal that lands inside an excluded subtree
+    can't slip past a check on the raw input string.
+    """
+    if ".git" in resolved.parts:
+        return True
+    if any(fnmatch.fnmatch(part, ".env*") for part in resolved.parts):
+        return True
+    for excluded_root in _EXCLUDED_ROOTS:
+        try:
+            resolved.relative_to(excluded_root)
+            return True
+        except ValueError:
+            continue
+    return False
+
 
 def _should_include_file(filename: str, pattern: str, exclude_patterns: list) -> bool:
     """Check if a file should be included in search results. (Issue #315 - extracted)"""
-    import fnmatch
-
     if not fnmatch.fnmatch(filename, pattern):
         return False
     return not any(fnmatch.fnmatch(filename, pat) for pat in exclude_patterns)
@@ -236,7 +282,10 @@ def _resolve_allowed_path(path: str):
     """
     if "\\" in path:
         raise ValueError("Path contains a backslash; use '/' as the separator")
-    return validate_path(path, allowed_roots=ALLOWED_DIRECTORIES)
+    resolved = validate_path(path, allowed_roots=ALLOWED_DIRECTORIES)
+    if _is_excluded_path(resolved):
+        raise ValueError("Path is within an excluded subtree (.git, .env, or secrets storage)")
+    return resolved
 
 
 def is_path_allowed(path: str) -> bool:

--- a/autobot-backend/api/secrets.py
+++ b/autobot-backend/api/secrets.py
@@ -57,6 +57,7 @@ from services.audit.audit import AuditAction, audit_record  # GH#8290 Phase 2
 from services.json_secrets_read import load_imported_json_secret
 from services.provider_key_vault import mirror_provider_key_best_effort
 from type_defs.common import Metadata
+from utils.secrets_store_migration import migrate_legacy_secrets_store
 
 logger = get_logger(__name__)
 
@@ -96,6 +97,13 @@ class SecretsManager:
         # Get paths using centralized configuration
         self.secrets_file = str(data_dir / "secrets.json")
         self.key_file = str(data_dir / "secrets.key")
+
+        # One-time migration off the legacy CWD-relative resolver (#14081
+        # review, #14113): must run before _initialize_encryption() decides
+        # whether to load an existing key or mint a fresh one, or an
+        # existing deployment's real store is silently orphaned.
+        migrate_legacy_secrets_store(data_dir, ["secrets.key", "secrets.json"], "secrets manager")
+
         self._initialize_encryption()
 
         # Cache layer to reduce file I/O (Issue #327)

--- a/autobot-backend/api/secrets.py
+++ b/autobot-backend/api/secrets.py
@@ -50,6 +50,7 @@ from autobot_memory_graph import AutoBotMemoryGraph
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.rate_limiter import RateLimiter
+from autobot_shared.ssot_config import config as ssot_config
 from autobot_shared.time_utils import parse_utc_iso
 from middleware.proxy_utils import get_client_ip
 from services.audit.audit import AuditAction, audit_record  # GH#8290 Phase 2
@@ -84,15 +85,17 @@ class SecretsManager:
 
     def __init__(self):
         """Initialize secrets manager with encryption and caching."""
-        # Use centralized path management
-        from utils.paths_manager import ensure_data_directory, get_data_path
-
-        # Ensure data directory exists
-        ensure_data_directory()
+        # Canonical data directory (#14081): resolve through ssot_config
+        # directly rather than the legacy utils.paths_manager, which reads
+        # an unset config.yaml "paths" key and silently falls back to a
+        # CWD-relative "data/" -- landing the live secrets store outside
+        # the subtree the filesystem MCP bridge excludes in production.
+        data_dir = ssot_config.path.data_path
+        data_dir.mkdir(parents=True, exist_ok=True)
 
         # Get paths using centralized configuration
-        self.secrets_file = str(get_data_path("secrets.json"))
-        self.key_file = str(get_data_path("secrets.key"))
+        self.secrets_file = str(data_dir / "secrets.json")
+        self.key_file = str(data_dir / "secrets.key")
         self._initialize_encryption()
 
         # Cache layer to reduce file I/O (Issue #327)
@@ -101,11 +104,8 @@ class SecretsManager:
         self._cache_mtime: float | None = None  # Track file modification time
 
     def _ensure_directories(self):
-        """Ensure data directory exists - now handled by centralized paths"""
-        # This method is kept for compatibility but functionality moved to centralized paths
-        from utils.paths_manager import ensure_data_directory
-
-        ensure_data_directory()
+        """Ensure the canonical data directory exists (#14081)."""
+        ssot_config.path.data_path.mkdir(parents=True, exist_ok=True)
 
     def _initialize_encryption(self):
         """Initialize or load encryption key"""

--- a/autobot-backend/api/secrets.py
+++ b/autobot-backend/api/secrets.py
@@ -85,35 +85,80 @@ class SecretsManager:
     """Manages encrypted secrets with dual scope support"""
 
     def __init__(self):
-        """Initialize secrets manager with encryption and caching."""
-        # Canonical data directory (#14081): resolve through ssot_config
-        # directly rather than the legacy utils.paths_manager, which reads
-        # an unset config.yaml "paths" key and silently falls back to a
-        # CWD-relative "data/" -- landing the live secrets store outside
-        # the subtree the filesystem MCP bridge excludes in production.
-        data_dir = ssot_config.path.data_path
-        data_dir.mkdir(parents=True, exist_ok=True)
+        """Initialize secrets manager. Never touches disk (#14081 review
+        round 4).
 
-        # Get paths using centralized configuration
-        self.secrets_file = str(data_dir / "secrets.json")
-        self.key_file = str(data_dir / "secrets.key")
+        The module-level ``secrets_manager`` singleton below runs this
+        constructor at Python import time -- unavoidable without #14116's
+        larger lazy-singleton conversion, which is out of scope here -- so
+        any disk-touching failure here (a read-only canonical data
+        directory, the legacy-store migration's own
+        ``AmbiguousSecretsStoreError``) would previously crash every
+        process that merely imported this module, before FastAPI's startup
+        ordering exists to report it or an operator can act on it. That is
+        exactly what broke ``hardened-smoke-test`` on #14110: the hardened
+        compose overlay's read-only root made the canonical data directory
+        unwritable, and ``_initialize_encryption()`` running here raised
+        ``OSError`` straight out of the import of ``api.secrets``.
 
-        # One-time migration off the legacy CWD-relative resolver (#14081
-        # review, #14113): must run before _initialize_encryption() decides
-        # whether to load an existing key or mint a fresh one, or an
-        # existing deployment's real store is silently orphaned.
-        migrate_legacy_secrets_store(data_dir, ["secrets.key", "secrets.json"], "secrets manager")
-
-        self._initialize_encryption()
+        Real initialization (data dir, one-time legacy->canonical
+        migration, encryption key) is deferred to ``ensure_initialized()``,
+        called explicitly once at FastAPI startup
+        (``initialization/lifespan.py``) and, as a fallback for callers
+        outside the app lifecycle (tests, scripts), lazily by the first
+        method that actually touches the store.
+        """
+        self._init_lock = threading.RLock()
+        self._initialized = False
+        self.secrets_file: str | None = None
+        self.key_file: str | None = None
+        self.cipher: Fernet | None = None
 
         # Cache layer to reduce file I/O (Issue #327)
         self._secrets_cache: Dict[str, Dict] | None = None
         self._cache_lock = threading.RLock()  # Thread-safe access to cache
         self._cache_mtime: float | None = None  # Track file modification time
 
-    def _ensure_directories(self):
-        """Ensure the canonical data directory exists (#14081)."""
-        ssot_config.path.data_path.mkdir(parents=True, exist_ok=True)
+    def ensure_initialized(self) -> None:
+        """Resolve the canonical data directory, migrate the legacy store,
+        and load/generate the encryption key (#14081 review round 4).
+
+        Safe to call more than once, from more than one thread -- a no-op
+        after the first successful call.
+
+        Raises:
+            AmbiguousSecretsStoreError: both the legacy and canonical
+                secrets-manager storage locations hold data; a human must
+                resolve which is authoritative (see
+                utils.secrets_store_migration).
+            OSError: the canonical data directory could not be created or
+                written to (e.g. a read-only filesystem).
+        """
+        if self._initialized:
+            return
+        with self._init_lock:
+            if self._initialized:
+                return
+            # Canonical data directory (#14081): resolve through ssot_config
+            # directly rather than the legacy utils.paths_manager, which reads
+            # an unset config.yaml "paths" key and silently falls back to a
+            # CWD-relative "data/" -- landing the live secrets store outside
+            # the subtree the filesystem MCP bridge excludes in production.
+            data_dir = ssot_config.path.data_path
+            data_dir.mkdir(parents=True, exist_ok=True)
+
+            # Get paths using centralized configuration
+            self.secrets_file = str(data_dir / "secrets.json")
+            self.key_file = str(data_dir / "secrets.key")
+
+            # One-time migration off the legacy CWD-relative resolver (#14081
+            # review, #14113): must run before _initialize_encryption() decides
+            # whether to load an existing key or mint a fresh one, or an
+            # existing deployment's real store is silently orphaned.
+            migrate_legacy_secrets_store(data_dir, ["secrets.key", "secrets.json"], "secrets manager")
+
+            self._initialize_encryption()
+            self._initialized = True
 
     def _initialize_encryption(self):
         """Initialize or load encryption key"""
@@ -148,6 +193,7 @@ class SecretsManager:
         Returns:
             Deep copy of secrets dict to prevent race conditions
         """
+        self.ensure_initialized()
         with self._cache_lock:
             # Check if file exists
             if not os.path.exists(self.secrets_file):
@@ -199,6 +245,7 @@ class SecretsManager:
                 return obj.isoformat()
             return str(obj)
 
+        self.ensure_initialized()
         with self._cache_lock:
             with open(self.secrets_file, "w", encoding="utf-8") as f:
                 # Values in `secrets` are Fernet-encrypted (stored as

--- a/autobot-backend/api/secrets.py
+++ b/autobot-backend/api/secrets.py
@@ -23,6 +23,7 @@ import threading
 import uuid
 from copy import deepcopy
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Dict, List
 
 from cryptography.fernet import Fernet
@@ -57,7 +58,11 @@ from services.audit.audit import AuditAction, audit_record  # GH#8290 Phase 2
 from services.json_secrets_read import load_imported_json_secret
 from services.provider_key_vault import mirror_provider_key_best_effort
 from type_defs.common import Metadata
-from utils.secrets_store_migration import migrate_legacy_secrets_store
+from utils.secrets_store_migration import (
+    ALL_SECRETS_STORE_FILES,
+    ensure_and_read_shared_key,
+    migrate_legacy_secrets_store,
+)
 
 logger = get_logger(__name__)
 
@@ -154,26 +159,26 @@ class SecretsManager:
             # One-time migration off the legacy CWD-relative resolver (#14081
             # review, #14113): must run before _initialize_encryption() decides
             # whether to load an existing key or mint a fresh one, or an
-            # existing deployment's real store is silently orphaned.
-            migrate_legacy_secrets_store(data_dir, ["secrets.key", "secrets.json"], "secrets manager")
+            # existing deployment's real store is silently orphaned. Migrates
+            # the FULL secrets-store file set, not just this class's own
+            # key+json (#14081 review round 5, finding 2) -- a process that
+            # only ever constructs SecretsService (a celery worker) must
+            # still get the shared key moved, or it silently mints its own.
+            migrate_legacy_secrets_store(data_dir, ALL_SECRETS_STORE_FILES, "secrets store")
 
             self._initialize_encryption()
             self._initialized = True
 
     def _initialize_encryption(self):
-        """Initialize or load encryption key"""
-        if os.path.exists(self.key_file):
-            with open(self.key_file, "rb") as f:
-                key = f.read()
-        else:
-            key = Fernet.generate_key()
-            # Fernet key must persist to decrypt secrets on next startup;
-            # secured by 0o600 file permissions.
-            with open(self.key_file, "wb") as f:
-                f.write(key)
-            os.chmod(self.key_file, 0o600)  # Restrict permissions
+        """Initialize or load encryption key.
 
-        self.cipher = Fernet(key)
+        Delegates to ``ensure_and_read_shared_key`` (#14081 review round 5)
+        rather than reading/generating ``self.key_file`` independently: it
+        is the one code path -- shared with ``SecretsService`` -- that may
+        create this file, cross-process-locked so two processes reaching a
+        genuine first boot at once cannot each mint their own key.
+        """
+        self.cipher = Fernet(ensure_and_read_shared_key(Path(self.key_file).parent))
 
     def _encrypt_value(self, value: str) -> str:
         """Encrypt a secret value"""

--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -13,6 +13,7 @@ Handles application startup and shutdown with 2-phase initialization:
 import asyncio
 import json
 import logging
+import sqlite3
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -269,6 +270,67 @@ async def _init_config(app: FastAPI) -> None:
         )
 
 
+async def _init_secrets_store(app: FastAPI) -> None:
+    """Run the one-time secrets-store legacy->canonical migration explicitly,
+    at a controlled startup point (#14081 review round 4, #14110).
+
+    Both ``SecretsManager`` (api/secrets.py) and ``SecretsService``
+    (services/secrets_service.py) resolve their storage through
+    ``ssot_config.path.data_path`` and, on an existing deployment, may need
+    to migrate real key/secret material off the legacy CWD-relative
+    location (``utils/secrets_store_migration.py``). ``SecretsManager`` in
+    particular used to do this from a module-level singleton's constructor,
+    which runs at Python import time: any failure there -- an ambiguous
+    legacy/canonical split, or (the failure that actually broke
+    ``hardened-smoke-test`` on PR #14110) a read-only canonical data
+    directory -- crashed the interpreter mid-import, before FastAPI's
+    startup ordering existed to report it. Running it here instead means a
+    failure surfaces through this phase's structured error handling and
+    ``/api/health`` reporting.
+
+    ``AmbiguousSecretsStoreError`` and filesystem/database I/O errors
+    (``OSError``, ``sqlite3.OperationalError``) are deliberately NOT fatal
+    here. Both are environment states a human must resolve -- refusing to
+    guess which store is authoritative, or refusing to write into a
+    filesystem that rejects the write, are the right calls -- but crashing
+    the container on every boot until someone edits code is not a
+    recoverable failure mode for an operator to work from. Logged at
+    CRITICAL with the underlying error and startup continues; secrets
+    operations backed by the affected store will keep failing until the
+    operator resolves the environment issue (message from the raised
+    error explains what to do). Any other exception is a genuine bug and
+    still aborts startup as before.
+    """
+    from api.secrets import secrets_manager
+    from services.secrets_service import get_secrets_service
+    from utils.secrets_store_migration import AmbiguousSecretsStoreError
+
+    logger.info("✅ [ 12%] Secrets store: running legacy-to-canonical migration check...")
+    _recoverable = (AmbiguousSecretsStoreError, OSError, sqlite3.OperationalError)
+    try:
+        await asyncio.to_thread(secrets_manager.ensure_initialized)
+    except _recoverable as store_err:
+        logger.critical(
+            "Secrets manager storage could not be initialized and was left "
+            "untouched: %s. Continuing startup; secrets-backed operations "
+            "will fail until the underlying environment issue is resolved.",
+            store_err,
+        )
+
+    # SecretsService shares the same encryption key file SecretsManager just
+    # migrated/created above -- must run after it, not in parallel.
+    try:
+        await asyncio.to_thread(get_secrets_service)
+    except _recoverable as store_err:
+        logger.critical(
+            "Secrets service storage could not be initialized and was left "
+            "untouched: %s. Continuing startup; secrets-backed operations "
+            "will fail until the underlying environment issue is resolved.",
+            store_err,
+        )
+    logger.info("✅ [ 12%] Secrets store: migration check complete")
+
+
 async def _init_security_layer(app: FastAPI) -> None:
     """Helper for initialize_critical_services. Ref: #1088."""
     logger.info("✅ [ 15%] Security: Initializing security layer...")
@@ -483,8 +545,9 @@ async def initialize_critical_services(app: FastAPI):
         # Issue #3015: Group init steps into dependency tiers and run each
         # tier concurrently with asyncio.gather() to reduce startup latency.
         #
-        # Tier 0 (sequential): env drift check + config — must complete before
-        #         anything else since all services may read global config.
+        # Tier 0 (sequential): env drift check + config + secrets-store
+        #         migration — must complete before anything else since all
+        #         services may read global config or secrets.
         # Tier 1 (parallel): security, database, telemetry — independent of
         #         each other, only need the module-level global config manager.
         # Tier 2 (parallel): chat managers — independent of each other; benefit
@@ -496,6 +559,12 @@ async def initialize_critical_services(app: FastAPI):
         # Issue #2650: check .env drift before any service initialisation
         await _check_env_drift()
         await _init_config(app)
+
+        # #14081/#14110: explicit secrets-store migration, before Tier 1's
+        # security layer (which may read secrets) and sequential so
+        # SecretsService's encryption-key fallback can rely on
+        # SecretsManager's key file already being in place.
+        await _init_secrets_store(app)
 
         # --- Tier 1: independent infrastructure (parallel) ---
         await asyncio.gather(

--- a/autobot-backend/services/secrets_service.py
+++ b/autobot-backend/services/secrets_service.py
@@ -40,11 +40,15 @@ class SecretsService:
     def __init__(self, db_path: str = None, encryption_key: str | None = None) -> None:
         """Initialize the secrets service with encryption"""
         if db_path is None:
-            # Use centralized path management for default path
-            from utils.paths_manager import ensure_data_directory, get_data_path
-
-            ensure_data_directory()
-            db_path = str(get_data_path("secrets.db"))
+            # Canonical data directory (#14081): resolve through ssot_config
+            # directly rather than the legacy utils.paths_manager, which
+            # reads an unset config.yaml "paths" key and silently falls
+            # back to a CWD-relative "data/" -- landing the live secrets DB
+            # outside the subtree the filesystem MCP bridge excludes in
+            # production.
+            data_dir = config.path.data_path
+            data_dir.mkdir(parents=True, exist_ok=True)
+            db_path = str(data_dir / "secrets.db")
 
         self.db_path = db_path
         self._ensure_db_directory()

--- a/autobot-backend/services/secrets_service.py
+++ b/autobot-backend/services/secrets_service.py
@@ -20,6 +20,7 @@ from autobot_shared.ssot_config import config
 from autobot_shared.time_utils import now_utc, parse_utc_iso
 from config.manager import get_config_manager as _get_config_manager
 from type_defs.common import Metadata
+from utils.secrets_store_migration import migrate_legacy_secrets_store
 
 logger = get_logger(__name__)
 
@@ -48,6 +49,13 @@ class SecretsService:
             # production.
             data_dir = config.path.data_path
             data_dir.mkdir(parents=True, exist_ok=True)
+
+            # One-time migration off the legacy CWD-relative resolver
+            # (#14081 review, #14113): must run before _init_database()
+            # creates a fresh, empty database, or an existing deployment's
+            # real store is silently orphaned.
+            migrate_legacy_secrets_store(data_dir, ["secrets.db"], "secrets service")
+
             db_path = str(data_dir / "secrets.db")
 
         self.db_path = db_path

--- a/autobot-backend/services/secrets_service.py
+++ b/autobot-backend/services/secrets_service.py
@@ -20,7 +20,11 @@ from autobot_shared.ssot_config import config
 from autobot_shared.time_utils import now_utc, parse_utc_iso
 from config.manager import get_config_manager as _get_config_manager
 from type_defs.common import Metadata
-from utils.secrets_store_migration import migrate_legacy_secrets_store
+from utils.secrets_store_migration import (
+    ALL_SECRETS_STORE_FILES,
+    ensure_and_read_shared_key,
+    migrate_legacy_secrets_store,
+)
 
 logger = get_logger(__name__)
 
@@ -53,8 +57,14 @@ class SecretsService:
             # One-time migration off the legacy CWD-relative resolver
             # (#14081 review, #14113): must run before _init_database()
             # creates a fresh, empty database, or an existing deployment's
-            # real store is silently orphaned.
-            migrate_legacy_secrets_store(data_dir, ["secrets.db"], "secrets service")
+            # real store is silently orphaned. Migrates the FULL
+            # secrets-store file set, not just this class's own db (#14081
+            # review round 5, finding 2): a process that constructs
+            # SecretsService alone (a celery worker, with no SecretsManager
+            # ever running) must still get the shared key moved here, or
+            # _init_encryption below finds no key file and silently mints
+            # an unpersisted one nothing else can ever decrypt.
+            migrate_legacy_secrets_store(data_dir, ALL_SECRETS_STORE_FILES, "secrets store")
 
             db_path = str(data_dir / "secrets.db")
 
@@ -80,29 +90,24 @@ class SecretsService:
             # Check multiple sources for the encryption key
             # 1. Environment variable (direct)
             # 2. Config manager (may map from env)
-            # 3. Key file in data directory
-            pass
-
+            # 3. Shared canonical key file (#14081 review round 5): minted
+            #    and persisted if it doesn't exist yet via the same helper
+            #    SecretsManager uses, cross-process-locked, so the two
+            #    classes can never disagree about the key and two processes
+            #    racing a genuine first boot can't each mint their own.
+            #    Replaces the previous fallback here, which generated a key
+            #    on a WARNING and never wrote it to disk -- indistinguishable
+            #    from first boot even with a real store present, and
+            #    undecryptable by any other process or the next restart.
             env_key = config.secrets_key
             if not env_key:
                 env_key = config_manager.get("security.secrets_key", None)
-            if not env_key:
-                # Try loading from key file
-                key_file = Path(self.db_path).parent / "secrets.key"
-                if key_file.exists():
-                    env_key = key_file.read_text().strip()
-                    logger.info("Loaded encryption key from %s", key_file)
 
             if env_key:
                 self.cipher = Fernet(env_key.encode())
                 logger.info("Secrets encryption initialized with configured key")
             else:
-                # Generate and save a new key
-                key = Fernet.generate_key()
-                self.cipher = Fernet(key)
-                logger.warning(
-                    "Generated new encryption key. Set AUTOBOT_SECRETS_KEY environment variable for persistence."
-                )
+                self.cipher = Fernet(ensure_and_read_shared_key(Path(self.db_path).parent))
 
     def _init_database(self) -> None:
         """Initialize the SQLite database with secrets table"""

--- a/autobot-backend/tests/api/test_filesystem_mcp_exclusions.py
+++ b/autobot-backend/tests/api/test_filesystem_mcp_exclusions.py
@@ -22,6 +22,8 @@ Both directions are exercised at the ``_resolve_allowed_path``/
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.testclient import TestClient
@@ -51,6 +53,14 @@ def fake_project(tmp_path, monkeypatch):
     env_file.write_text("EXAMPLE_TOKEN=not-a-real-secret\n", encoding="utf-8")
     env_local = project / ".env.local"
     env_local.write_text("EXAMPLE_TOKEN=not-a-real-secret-either\n", encoding="utf-8")
+    envrc = project / ".envrc"
+    envrc.write_text("export EXAMPLE_TOKEN=not-a-real-secret\n", encoding="utf-8")
+    env_example = project / ".env.example"
+    env_example.write_text("EXAMPLE_TOKEN=\n", encoding="utf-8")
+    env_sample = project / ".env.sample"
+    env_sample.write_text("EXAMPLE_TOKEN=\n", encoding="utf-8")
+    env_template = project / ".env.template"
+    env_template.write_text("EXAMPLE_TOKEN=\n", encoding="utf-8")
 
     data_dir = project / "data"
     data_dir.mkdir()
@@ -83,6 +93,10 @@ def fake_project(tmp_path, monkeypatch):
         "git_config": git_config,
         "env_file": env_file,
         "env_local": env_local,
+        "envrc": envrc,
+        "env_example": env_example,
+        "env_sample": env_sample,
+        "env_template": env_template,
         "secrets_key": secrets_key,
         "secrets_json": secrets_json,
         "secrets_db": secrets_db,
@@ -129,6 +143,22 @@ class TestExcludedSubtreesUnit:
         workflow.write_text("name: ci\n", encoding="utf-8")
 
         assert fs_mcp.is_path_allowed(str(workflow)) is True
+
+    @pytest.mark.parametrize("key", ["env_example", "env_sample", "env_template"])
+    def test_committed_env_templates_are_not_over_blocked(self, fake_project, key):
+        """``.env.example``/``.env.sample``/``.env.template`` are allowed (review follow-up).
+
+        These carry no real credential material by convention and are
+        commonly committed to the repo -- a bare ``.env*`` denylist also
+        catching them is an over-block, not a security requirement.
+        """
+        target = str(fake_project[key])
+
+        assert fs_mcp.is_path_allowed(target) is True
+
+    def test_envrc_still_denied(self, fake_project):
+        """``.envrc`` (direnv) commonly carries real exports -- stays denied."""
+        assert fs_mcp.is_path_allowed(str(fake_project["envrc"])) is False
 
 
 @pytest.fixture
@@ -208,3 +238,98 @@ class TestExcludedSubtreesEndpoint:
         data = response.json()
         assert data["success"] is True
         assert data["content"] == "hello world\n"
+
+
+class TestRealResolverAgreement:
+    """The real secrets-store classes must land inside the real exclusion list.
+
+    Review finding on this PR: an earlier version of the fix derived
+    ``_EXCLUDED_ROOTS`` from ``ssot_config.config.path.data_path`` while
+    ``SecretsManager``/``SecretsService`` still resolved their storage
+    through the legacy ``utils.paths_manager.get_data_path()`` -- which
+    reads an unset ``config.yaml`` "paths" key and silently falls back to a
+    CWD-relative ``"data/..."`` string. In the deployed topology (the
+    backend's systemd ``WorkingDirectory`` sits one level below
+    ``AUTOBOT_BASE_DIR``) the two resolvers disagreed, so the exclusion list
+    protected a path nothing ever wrote to and the live secrets store stayed
+    reachable through the bridge.
+
+    These tests instantiate the *real* classes -- not a monkeypatched
+    ``_EXCLUDED_ROOTS`` and not a hand-picked path -- and check the real,
+    untouched ``fs_mcp.is_path_allowed`` against whatever those classes
+    actually compute. The only stubbing is the unrelated encryption/DB I/O
+    (so the test never writes real key material into the checkout); the
+    path-resolution code under test always runs for real.
+
+    Deterministic regardless of the CWD pytest happens to be invoked from:
+    explicitly ``chdir``s into ``<base_dir>/autobot-backend`` to reproduce
+    the deployed topology rather than relying on ambient CWD, which could
+    accidentally coincide with base_dir and mask the bug.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _deployed_topology_cwd(self, monkeypatch):
+        """Match the systemd WorkingDirectory being one level below base_dir."""
+        backend_cwd = Path(fs_mcp.config.base_dir) / "autobot-backend"
+        monkeypatch.chdir(backend_cwd)
+
+    @pytest.fixture(autouse=True)
+    def _no_stray_secrets_artifacts(self):
+        """Clean up any secrets-store file this test session causes to be
+        (re-)provisioned (#14081 review).
+
+        ``api.secrets`` provisions a module-level ``SecretsManager`` singleton
+        at import time (pre-existing design, unrelated to this fix), which
+        auto-generates a real encryption key the first time the module is
+        imported and no key file exists yet. Importing it here (to reach the
+        real, unmocked path-resolution code) can be that first import in an
+        isolated test run. Removes only files that did not exist before this
+        test and were created during it -- never touches a real,
+        pre-existing store.
+        """
+        data_dir = fs_mcp.config.path.data_path
+        candidates = [data_dir / "secrets.key", data_dir / "secrets.json", data_dir / "secrets.db"]
+        pre_existing = {p for p in candidates if p.exists()}
+        yield
+        for p in candidates:
+            if p.exists() and p not in pre_existing:
+                p.unlink()
+
+    def test_secrets_manager_storage_is_excluded_by_the_real_bridge(self):
+        import api.secrets as secrets_api
+
+        # api.secrets provisions a module-level singleton (`secrets_manager`)
+        # at import time (pre-existing design, tracked separately -- see
+        # #14081 PR discussion) -- reference it directly rather than
+        # constructing a second instance, so this test adds no additional
+        # encryption-key file I/O beyond what importing the module already
+        # does elsewhere in the suite.
+        manager = secrets_api.secrets_manager
+
+        assert fs_mcp.is_path_allowed(manager.key_file) is False, (
+            f"SecretsManager's real encryption key path {manager.key_file!r} is "
+            "reachable through the filesystem MCP bridge."
+        )
+        assert fs_mcp.is_path_allowed(manager.secrets_file) is False, (
+            f"SecretsManager's real secrets store path {manager.secrets_file!r} is "
+            "reachable through the filesystem MCP bridge."
+        )
+
+    def test_secrets_service_storage_is_excluded_by_the_real_bridge(self, monkeypatch):
+        import services.secrets_service as secrets_service_module
+
+        # Stub only the encryption/DB-init I/O -- the path computation this
+        # test guards runs unmodified in the real __init__.
+        monkeypatch.setattr(
+            secrets_service_module.SecretsService,
+            "_init_encryption",
+            lambda self, encryption_key=None: None,
+        )
+        monkeypatch.setattr(secrets_service_module.SecretsService, "_init_database", lambda self: None)
+
+        service = secrets_service_module.SecretsService()
+
+        assert fs_mcp.is_path_allowed(service.db_path) is False, (
+            f"SecretsService's real database path {service.db_path!r} is "
+            "reachable through the filesystem MCP bridge."
+        )

--- a/autobot-backend/tests/api/test_filesystem_mcp_exclusions.py
+++ b/autobot-backend/tests/api/test_filesystem_mcp_exclusions.py
@@ -278,13 +278,13 @@ class TestRealResolverAgreement:
         """Clean up any secrets-store file this test session causes to be
         (re-)provisioned (#14081 review).
 
-        ``api.secrets`` provisions a module-level ``SecretsManager`` singleton
-        at import time (pre-existing design, unrelated to this fix), which
-        auto-generates a real encryption key the first time the module is
-        imported and no key file exists yet. Importing it here (to reach the
-        real, unmocked path-resolution code) can be that first import in an
-        isolated test run. Removes only files that did not exist before this
-        test and were created during it -- never touches a real,
+        ``api.secrets``'s module-level ``SecretsManager`` singleton no
+        longer touches disk at import time (#14081 review round 4, #14110)
+        -- but this class's own test still calls ``ensure_initialized()``
+        explicitly to reach the real, unmocked path-resolution code, which
+        auto-generates a real encryption key the first time it runs and no
+        key file exists yet. Removes only files that did not exist before
+        this test and were created during it -- never touches a real,
         pre-existing store.
         """
         data_dir = fs_mcp.config.path.data_path
@@ -299,12 +299,13 @@ class TestRealResolverAgreement:
         import api.secrets as secrets_api
 
         # api.secrets provisions a module-level singleton (`secrets_manager`)
-        # at import time (pre-existing design, tracked separately -- see
-        # #14081 PR discussion) -- reference it directly rather than
-        # constructing a second instance, so this test adds no additional
-        # encryption-key file I/O beyond what importing the module already
-        # does elsewhere in the suite.
+        # -- reference it directly rather than constructing a second
+        # instance. Construction no longer touches disk (#14081 review
+        # round 4, #14110): trigger the same one-time initialization the
+        # app's startup lifespan now runs explicitly, so
+        # key_file/secrets_file are populated.
         manager = secrets_api.secrets_manager
+        manager.ensure_initialized()
 
         assert fs_mcp.is_path_allowed(manager.key_file) is False, (
             f"SecretsManager's real encryption key path {manager.key_file!r} is "

--- a/autobot-backend/tests/api/test_filesystem_mcp_exclusions.py
+++ b/autobot-backend/tests/api/test_filesystem_mcp_exclusions.py
@@ -1,0 +1,210 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for the filesystem MCP bridge's excluded-subtree enforcement (#14081).
+
+Since #14050, an unset AUTOBOT_BASE_DIR resolves ALLOWED_DIRECTORIES to the
+whole git checkout, with no exclusion for ``.git/``, ``.env*`` or the
+secrets-manager storage path. These tests build a synthetic project tree so
+the assertions do not depend on the real repository's contents, then verify:
+
+1. Every excluded subtree is refused even though it sits inside the allowed
+   root (the actual vulnerability).
+2. Ordinary project files are still reachable (a bridge that refuses
+   everything is an outage, not a fix).
+
+Both directions are exercised at the ``_resolve_allowed_path``/
+``is_path_allowed`` seam (unit-level) and through the real HTTP endpoint
+(``read_text_file_mcp``), matching the established pattern in
+``test_filesystem_mcp_resources_prompts.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.testclient import TestClient
+
+import api.filesystem_mcp as fs_mcp
+
+# Header/key pair the auth gate accepts, mirroring the trusted
+# internal-service key mechanism of check_admin_permission (Issue #1145).
+_TEST_INTERNAL_KEY = "test-internal-api-key-filesystem-mcp-exclusions"
+
+
+@pytest.fixture
+def fake_project(tmp_path, monkeypatch):
+    """Build a project tree with .git/, .env*, and secrets storage.
+
+    Points the bridge's ``ALLOWED_DIRECTORIES``/``_EXCLUDED_ROOTS`` at this
+    synthetic tree (via monkeypatch, restored automatically) so the test
+    never touches the real checkout's actual VCS history or secrets.
+    """
+    project = tmp_path / "project"
+    git_dir = project / ".git"
+    git_dir.mkdir(parents=True)
+    git_config = git_dir / "config"
+    git_config.write_text("[core]\n\trepositoryformatversion = 0\n", encoding="utf-8")
+
+    env_file = project / ".env"
+    env_file.write_text("EXAMPLE_TOKEN=not-a-real-secret\n", encoding="utf-8")
+    env_local = project / ".env.local"
+    env_local.write_text("EXAMPLE_TOKEN=not-a-real-secret-either\n", encoding="utf-8")
+
+    data_dir = project / "data"
+    data_dir.mkdir()
+    secrets_key = data_dir / "secrets.key"
+    secrets_key.write_text("placeholder-key-material\n", encoding="utf-8")
+    secrets_json = data_dir / "secrets.json"
+    secrets_json.write_text("{}", encoding="utf-8")
+    secrets_db = data_dir / "secrets.db"
+    secrets_db.write_text("sqlite-stub\n", encoding="utf-8")
+
+    service_keys = data_dir / "service-keys"
+    service_keys.mkdir()
+    jwt_pem = service_keys / "jwt_rsa_private.pem"
+    jwt_pem.write_text("-----BEGIN RSA PRIVATE KEY-----\nplaceholder\n", encoding="utf-8")
+
+    ordinary_file = project / "README.md"
+    ordinary_file.write_text("hello world\n", encoding="utf-8")
+    ordinary_nested = data_dir / "scheduled_workflows.json"
+    ordinary_nested.write_text("[]", encoding="utf-8")
+
+    monkeypatch.setattr(fs_mcp, "ALLOWED_DIRECTORIES", [f"{project}/"])
+    monkeypatch.setattr(
+        fs_mcp,
+        "_EXCLUDED_ROOTS",
+        [secrets_key, secrets_json, secrets_db, service_keys],
+    )
+
+    return {
+        "project": project,
+        "git_config": git_config,
+        "env_file": env_file,
+        "env_local": env_local,
+        "secrets_key": secrets_key,
+        "secrets_json": secrets_json,
+        "secrets_db": secrets_db,
+        "jwt_pem": jwt_pem,
+        "ordinary_file": ordinary_file,
+        "ordinary_nested": ordinary_nested,
+    }
+
+
+class TestExcludedSubtreesUnit:
+    """Unit-level checks at the shared resolution seam."""
+
+    @pytest.mark.parametrize(
+        "key",
+        ["git_config", "env_file", "env_local", "secrets_key", "secrets_json", "secrets_db", "jwt_pem"],
+    )
+    def test_excluded_path_is_denied(self, fake_project, key):
+        """A path under an excluded subtree is refused (#14081 AC1/AC2)."""
+        target = str(fake_project[key])
+
+        assert fs_mcp.is_path_allowed(target) is False
+        with pytest.raises(ValueError, match="excluded subtree"):
+            fs_mcp._resolve_allowed_path(target)
+
+    @pytest.mark.parametrize("key", ["ordinary_file", "ordinary_nested", "project"])
+    def test_ordinary_path_still_allowed(self, fake_project, key):
+        """Legitimate project files remain reachable (#14081 AC5)."""
+        target = str(fake_project[key])
+
+        assert fs_mcp.is_path_allowed(target) is True
+        resolved = fs_mcp._resolve_allowed_path(target)
+        assert str(resolved) == str(fake_project[key].resolve())
+
+    def test_git_exclusion_is_not_prefix_matched(self, fake_project):
+        """A file merely *named* like ``.git`` (not the directory) is unaffected.
+
+        Guards against a naive substring check on ``.git`` that would also
+        reject a legitimately named ``.github`` directory or ``foo.git.bak``
+        file.
+        """
+        lookalike_dir = fake_project["project"] / ".github"
+        lookalike_dir.mkdir()
+        workflow = lookalike_dir / "ci.yml"
+        workflow.write_text("name: ci\n", encoding="utf-8")
+
+        assert fs_mcp.is_path_allowed(str(workflow)) is True
+
+
+@pytest.fixture
+def client():
+    """TestClient over a minimal app mounting the real filesystem_mcp router.
+
+    Mirrors the pattern in test_filesystem_mcp_resources_prompts.py: the
+    admin gate is exercised via dependency_overrides with a header-sensitive
+    stub, matching the real check_admin_permission contract (#744/#1145).
+    """
+
+    def _admin_gate(request: Request) -> bool:
+        if request.headers.get("X-Internal-API-Key") == _TEST_INTERNAL_KEY:
+            return True
+        raise HTTPException(status_code=401, detail="Authentication required")
+
+    app = FastAPI()
+    app.include_router(fs_mcp.router, prefix="/api/filesystem")
+    app.dependency_overrides[fs_mcp.check_admin_permission] = _admin_gate
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+@pytest.fixture
+def admin_headers():
+    """Headers granting admin via the trusted internal-service API key."""
+    return {"X-Internal-API-Key": _TEST_INTERNAL_KEY}
+
+
+class TestExcludedSubtreesEndpoint:
+    """End-to-end: an authenticated caller still can't reach excluded paths.
+
+    Covers the issue's exact scenario -- an admin/internal-key caller
+    attempting to read .git/config or .env through the bridge (#14081 AC4).
+    """
+
+    def test_read_git_config_denied(self, client: TestClient, admin_headers, fake_project):
+        response = client.post(
+            "/api/filesystem/mcp/read_text_file",
+            json={"path": str(fake_project["git_config"])},
+            headers=admin_headers,
+        )
+        assert response.status_code == 403
+
+    def test_read_env_denied(self, client: TestClient, admin_headers, fake_project):
+        response = client.post(
+            "/api/filesystem/mcp/read_text_file",
+            json={"path": str(fake_project["env_file"])},
+            headers=admin_headers,
+        )
+        assert response.status_code == 403
+
+    def test_read_secrets_key_denied(self, client: TestClient, admin_headers, fake_project):
+        response = client.post(
+            "/api/filesystem/mcp/read_text_file",
+            json={"path": str(fake_project["secrets_key"])},
+            headers=admin_headers,
+        )
+        assert response.status_code == 403
+
+    def test_read_jwt_key_denied(self, client: TestClient, admin_headers, fake_project):
+        response = client.post(
+            "/api/filesystem/mcp/read_text_file",
+            json={"path": str(fake_project["jwt_pem"])},
+            headers=admin_headers,
+        )
+        assert response.status_code == 403
+
+    def test_read_ordinary_file_still_works(self, client: TestClient, admin_headers, fake_project):
+        """The bridge is not a blanket outage -- ordinary files still read (#14081 AC5)."""
+        response = client.post(
+            "/api/filesystem/mcp/read_text_file",
+            json={"path": str(fake_project["ordinary_file"])},
+            headers=admin_headers,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert data["content"] == "hello world\n"

--- a/autobot-backend/tests/api/test_secrets_store_migration.py
+++ b/autobot-backend/tests/api/test_secrets_store_migration.py
@@ -1,0 +1,172 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Reproduction tests for the secrets-store migration (#14081 review).
+
+#14081's resolver fix changed *where* SecretsManager/SecretsService look for
+their storage, from a legacy CWD-relative path to the canonical
+ssot_config-derived one. On an existing deployment the real store is still
+at the legacy location -- these tests prove the migration actually
+preserves access to it, not merely that files get moved to a new path.
+
+Each test stands up a legacy store with a *known* key and a *known*
+encrypted value (never a fake "the file exists" placeholder), points the
+canonical location at an empty directory, constructs the real class, and
+asserts the original plaintext still decrypts. A test that only checked
+"the file exists at the new path" would pass even if the migrated key and
+the migrated ciphertext no longer matched -- decrypting is the only check
+that catches that.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import sqlite3
+
+import pytest
+from cryptography.fernet import Fernet
+
+from autobot_shared.ssot_config import config as _real_ssot_config
+from autobot_shared.time_utils import now_utc
+
+
+@pytest.fixture(autouse=True)
+def _no_stray_secrets_artifacts():
+    """Clean up any secrets-store file this test session causes to be
+    (re-)provisioned at the *real* canonical location (#14081 review).
+
+    ``api.secrets`` provisions a module-level ``SecretsManager`` singleton
+    at import time (pre-existing design, tracked separately as #14116),
+    which auto-generates a real encryption key the first time the module is
+    imported and no key file exists yet. Importing it here (to reach the
+    real, unmocked class) can be that first import in an isolated test run.
+    Removes only files that did not exist before this test and were created
+    during it -- never touches a real, pre-existing store.
+    """
+    data_dir = _real_ssot_config.path.data_path
+    candidates = [data_dir / "secrets.key", data_dir / "secrets.json", data_dir / "secrets.db"]
+    pre_existing = {p for p in candidates if p.exists()}
+    yield
+    for p in candidates:
+        if p.exists() and p not in pre_existing:
+            p.unlink()
+
+
+class TestSecretsManagerMigrationPreservesDecryption:
+    """SecretsManager: legacy secrets.key + secrets.json -> canonical."""
+
+    def test_legacy_secret_still_decrypts_after_migration(self, tmp_path, monkeypatch):
+        import api.secrets as secrets_api
+
+        # Legacy location: get_data_path() (unmocked, real) falls back to
+        # the CWD-relative "data/" when config.yaml has no "paths" section.
+        legacy_root = tmp_path / "legacy_cwd"
+        legacy_root.mkdir()
+        monkeypatch.chdir(legacy_root)
+        legacy_data_dir = legacy_root / "data"
+        legacy_data_dir.mkdir()
+
+        key = Fernet.generate_key()
+        cipher = Fernet(key)
+        plaintext = "sk-known-plaintext-value"  # noqa: S105 - test fixture, not a real credential
+        encrypted_value = base64.b64encode(cipher.encrypt(plaintext.encode())).decode()
+
+        (legacy_data_dir / "secrets.key").write_bytes(key)
+        (legacy_data_dir / "secrets.key").chmod(0o600)
+        (legacy_data_dir / "secrets.json").write_text(
+            json.dumps({"known-id": {"id": "known-id", "encrypted_value": encrypted_value}}),
+            encoding="utf-8",
+        )
+
+        # Canonical location: empty. Stubs api.secrets's module-level
+        # `ssot_config` reference directly rather than touching the real
+        # global singleton (which TestRealResolverAgreement already
+        # exercises for the resolver-agreement concern; this test is about
+        # the migration mechanism itself).
+        canonical_dir = tmp_path / "canonical"
+        canonical_dir.mkdir()
+
+        class _StubPathConfig:
+            data_path = canonical_dir
+
+        class _StubConfig:
+            path = _StubPathConfig()
+
+        monkeypatch.setattr(secrets_api, "ssot_config", _StubConfig())
+
+        manager = secrets_api.SecretsManager()
+
+        loaded = manager._load_secrets()
+        assert manager._decrypt_value(loaded["known-id"]["encrypted_value"]) == plaintext
+
+        # The migration must have actually moved the files, not merely made
+        # them independently reachable at both locations.
+        assert not (legacy_data_dir / "secrets.key").exists()
+        assert not (legacy_data_dir / "secrets.json").exists()
+        assert oct((canonical_dir / "secrets.key").stat().st_mode)[-3:] == "600"
+
+
+class TestSecretsServiceMigrationPreservesDecryption:
+    """SecretsService: legacy secrets.db -> canonical."""
+
+    def test_legacy_row_still_decrypts_after_migration(self, tmp_path, monkeypatch):
+        import services.secrets_service as secrets_service_module
+
+        legacy_root = tmp_path / "legacy_cwd"
+        legacy_root.mkdir()
+        monkeypatch.chdir(legacy_root)
+        legacy_data_dir = legacy_root / "data"
+        legacy_data_dir.mkdir()
+
+        key = Fernet.generate_key()
+        cipher = Fernet(key)
+        plaintext = "sk-known-plaintext-value"  # noqa: S105 - test fixture, not a real credential
+        encrypted_value = cipher.encrypt(plaintext.encode()).decode()
+
+        conn = sqlite3.connect(str(legacy_data_dir / "secrets.db"))
+        conn.execute("""
+            CREATE TABLE secrets (
+                id TEXT PRIMARY KEY, name TEXT NOT NULL, description TEXT,
+                secret_type TEXT NOT NULL, encrypted_value TEXT NOT NULL,
+                scope TEXT NOT NULL DEFAULT 'general', chat_id TEXT,
+                created_at TEXT NOT NULL, updated_at TEXT NOT NULL, expires_at TEXT,
+                created_by TEXT, metadata TEXT, access_count INTEGER DEFAULT 0,
+                last_accessed_at TEXT, is_active BOOLEAN DEFAULT 1
+            )
+            """)
+        now = now_utc().isoformat()
+        conn.execute(
+            "INSERT INTO secrets (id, name, description, secret_type, encrypted_value, "
+            "scope, chat_id, created_at, updated_at, expires_at, created_by, metadata) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            ("known-id", "test-secret", "", "api_key", encrypted_value, "general", None, now, now, None, "", "{}"),
+        )
+        conn.commit()
+        conn.close()
+
+        canonical_dir = tmp_path / "canonical"
+        canonical_dir.mkdir()
+        # Pre-place the shared key at the canonical location, as
+        # SecretsManager's own migration would already have done in a real
+        # deployment -- this test isolates SecretsService's secrets.db
+        # migration specifically.
+        (canonical_dir / "secrets.key").write_bytes(key)
+
+        class _StubPathConfig:
+            data_path = canonical_dir
+
+        class _StubConfig:
+            path = _StubPathConfig()
+            secrets_key = ""  # forces _init_encryption to fall through to the key file
+
+        monkeypatch.setattr(secrets_service_module, "config", _StubConfig())
+
+        service = secrets_service_module.SecretsService()
+
+        secret = service.get_secret(secret_id="known-id", include_value=True)
+        assert secret is not None
+        assert secret["value"] == plaintext
+
+        assert not (legacy_data_dir / "secrets.db").exists()

--- a/autobot-backend/tests/api/test_secrets_store_migration.py
+++ b/autobot-backend/tests/api/test_secrets_store_migration.py
@@ -108,6 +108,118 @@ class TestSecretsManagerMigrationPreservesDecryption:
         assert oct((canonical_dir / "secrets.key").stat().st_mode)[-3:] == "600"
 
 
+class TestMigrationRunsAtStartupNotImport:
+    """#14081 review round 4 / #14110: the migration -- and any disk I/O
+    the module-level ``SecretsManager`` singleton used to do in its
+    constructor -- must never run as a side effect of importing
+    ``api.secrets``.
+
+    That was the actual cause of the ``hardened-smoke-test`` failure on PR
+    #14110: the hardened compose overlay's read-only root made the
+    canonical data directory unwritable, and ``SecretsManager.__init__``
+    running ``_initialize_encryption()`` at import time turned that into an
+    ``OSError`` no operator could see or recover from -- it crashed the
+    interpreter before FastAPI's startup ordering existed to report it.
+    """
+
+    def test_constructing_secrets_manager_touches_no_disk(self, tmp_path, monkeypatch):
+        """Regression guard for the exact #14110 failure.
+
+        This is the reproduction that must fail against the pre-fix
+        constructor: give it a legacy store to migrate and a canonical
+        directory, then merely *construct* ``SecretsManager()`` -- exactly
+        what ``secrets_manager = SecretsManager()`` does at import time --
+        without calling any method on it. Nothing must be read, moved, or
+        written.
+        """
+        import api.secrets as secrets_api
+
+        legacy_root = tmp_path / "legacy_cwd"
+        legacy_root.mkdir()
+        monkeypatch.chdir(legacy_root)
+        legacy_data_dir = legacy_root / "data"
+        legacy_data_dir.mkdir()
+        (legacy_data_dir / "secrets.key").write_bytes(b"legacy-key-material")
+
+        canonical_dir = tmp_path / "canonical"
+        canonical_dir.mkdir()
+
+        class _StubPathConfig:
+            data_path = canonical_dir
+
+        class _StubConfig:
+            path = _StubPathConfig()
+
+        monkeypatch.setattr(secrets_api, "ssot_config", _StubConfig())
+
+        secrets_api.SecretsManager()  # must not touch disk
+
+        assert list(canonical_dir.iterdir()) == [], "construction wrote to the canonical data dir"
+        assert (legacy_data_dir / "secrets.key").exists(), "construction moved the legacy store"
+
+    def test_importing_api_secrets_module_touches_no_disk(self, tmp_path, monkeypatch):
+        """The literal regression: importing the module alone -- what
+        ``secrets_manager = SecretsManager()`` running at import time means
+        in practice -- must not migrate or generate key material.
+
+        ``reload`` re-runs every module-level statement, including
+        ``secrets_manager = SecretsManager()``, exactly reproducing what a
+        fresh process import does -- without needing to stub ``ssot_config``
+        (construction no longer reads it at all; that is the fix).
+        """
+        import importlib
+
+        import api.secrets as secrets_api
+
+        legacy_root = tmp_path / "legacy_cwd"
+        legacy_root.mkdir()
+        monkeypatch.chdir(legacy_root)
+        legacy_data_dir = legacy_root / "data"
+        legacy_data_dir.mkdir()
+        (legacy_data_dir / "secrets.key").write_bytes(b"legacy-key-material")
+
+        canonical_dir = _real_ssot_config.path.data_path
+        pre_existing_canonical = {p.name for p in canonical_dir.iterdir()} if canonical_dir.exists() else set()
+
+        importlib.reload(secrets_api)
+
+        new_canonical_files = (
+            {p.name for p in canonical_dir.iterdir()} - pre_existing_canonical if canonical_dir.exists() else set()
+        )
+        assert new_canonical_files == set(), "importing api.secrets wrote to the canonical data dir"
+        assert (legacy_data_dir / "secrets.key").exists(), "importing api.secrets moved the legacy store"
+
+    def test_ensure_initialized_is_idempotent(self, tmp_path, monkeypatch):
+        """Safe to call twice: the second call is a no-op, not a re-migration."""
+        import api.secrets as secrets_api
+
+        legacy_root = tmp_path / "legacy_cwd"
+        legacy_root.mkdir()
+        monkeypatch.chdir(legacy_root)
+        legacy_data_dir = legacy_root / "data"
+        legacy_data_dir.mkdir()
+        (legacy_data_dir / "secrets.key").write_bytes(Fernet.generate_key())
+        (legacy_data_dir / "secrets.json").write_text("{}", encoding="utf-8")
+
+        canonical_dir = tmp_path / "canonical"
+        canonical_dir.mkdir()
+
+        class _StubPathConfig:
+            data_path = canonical_dir
+
+        class _StubConfig:
+            path = _StubPathConfig()
+
+        monkeypatch.setattr(secrets_api, "ssot_config", _StubConfig())
+
+        manager = secrets_api.SecretsManager()
+        manager.ensure_initialized()
+        key_after_first_call = (canonical_dir / "secrets.key").read_bytes()
+
+        manager.ensure_initialized()  # must not raise, move, or regenerate
+        assert (canonical_dir / "secrets.key").read_bytes() == key_after_first_call
+
+
 class TestSecretsServiceMigrationPreservesDecryption:
     """SecretsService: legacy secrets.db -> canonical."""
 

--- a/autobot-backend/tests/api/test_secrets_store_migration.py
+++ b/autobot-backend/tests/api/test_secrets_store_migration.py
@@ -23,13 +23,18 @@ from __future__ import annotations
 
 import base64
 import json
+import re
 import sqlite3
+from pathlib import Path
 
 import pytest
+import yaml
 from cryptography.fernet import Fernet
 
 from autobot_shared.ssot_config import config as _real_ssot_config
 from autobot_shared.time_utils import now_utc
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
 @pytest.fixture(autouse=True)
@@ -221,7 +226,16 @@ class TestMigrationRunsAtStartupNotImport:
 
 
 class TestSecretsServiceMigrationPreservesDecryption:
-    """SecretsService: legacy secrets.db -> canonical."""
+    """SecretsService: legacy secrets.db -> canonical.
+
+    #14081 review round 5, finding 2: SecretsService now migrates the FULL
+    secrets-store file set (ALL_SECRETS_STORE_FILES), not just secrets.db,
+    so a process that constructs it standalone -- a celery worker, with no
+    SecretsManager ever running -- still gets the shared key moved. This
+    test's legacy store therefore includes a real secrets.key alongside
+    secrets.db, exactly like a real pre-#14081 deployment, rather than
+    pre-placing the key directly at canonical.
+    """
 
     def test_legacy_row_still_decrypts_after_migration(self, tmp_path, monkeypatch):
         import services.secrets_service as secrets_service_module
@@ -258,13 +272,13 @@ class TestSecretsServiceMigrationPreservesDecryption:
         conn.commit()
         conn.close()
 
+        # The shared key lives at the LEGACY location, same as secrets.db --
+        # a real pre-#14081 deployment. SecretsService alone must migrate
+        # both, not just the db it directly reads.
+        (legacy_data_dir / "secrets.key").write_bytes(key)
+
         canonical_dir = tmp_path / "canonical"
         canonical_dir.mkdir()
-        # Pre-place the shared key at the canonical location, as
-        # SecretsManager's own migration would already have done in a real
-        # deployment -- this test isolates SecretsService's secrets.db
-        # migration specifically.
-        (canonical_dir / "secrets.key").write_bytes(key)
 
         class _StubPathConfig:
             data_path = canonical_dir
@@ -282,3 +296,107 @@ class TestSecretsServiceMigrationPreservesDecryption:
         assert secret["value"] == plaintext
 
         assert not (legacy_data_dir / "secrets.db").exists()
+        assert not (legacy_data_dir / "secrets.key").exists(), "SecretsService alone must migrate the shared key too"
+        assert (canonical_dir / "secrets.key").read_bytes() == key
+
+
+class TestSecretsServiceAloneMigratesTheSharedKey:
+    """#14081 review round 5, finding 2: a process that constructs
+    SecretsService without SecretsManager (api/secrets.py) ever running --
+    a celery worker via tasks/credential_reconcile.py or
+    services/workflow_secret_service.py, neither of which runs the FastAPI
+    lifespan -- must still migrate the shared secrets.key, not just
+    secrets.db. Before the fix, SecretsService's own migration call only
+    covered ["secrets.db"]: the db moved, the key stayed at the legacy
+    location, _init_encryption found no key file there and silently minted
+    an unpersisted throwaway one -- reads raised InvalidToken, writes
+    produced rows nothing could ever decrypt.
+
+    Deliberately never imports api.secrets -- the whole point is that
+    SecretsManager plays no part in the outcome.
+    """
+
+    def test_key_is_readable_after_secrets_service_alone(self, tmp_path, monkeypatch):
+        import services.secrets_service as secrets_service_module
+
+        legacy_root = tmp_path / "legacy_cwd"
+        legacy_root.mkdir()
+        monkeypatch.chdir(legacy_root)
+        legacy_data_dir = legacy_root / "data"
+        legacy_data_dir.mkdir()
+
+        key = Fernet.generate_key()
+        (legacy_data_dir / "secrets.key").write_bytes(key)
+
+        canonical_dir = tmp_path / "canonical"
+        canonical_dir.mkdir()
+
+        class _StubPathConfig:
+            data_path = canonical_dir
+
+        class _StubConfig:
+            path = _StubPathConfig()
+            secrets_key = ""  # forces _init_encryption to fall through to the key file
+
+        monkeypatch.setattr(secrets_service_module, "config", _StubConfig())
+
+        service = secrets_service_module.SecretsService()
+
+        # Proof the service's cipher is built from the ORIGINAL migrated
+        # key, not a freshly-minted throwaway one: a Fernet token encrypted
+        # with a *different* key raises InvalidToken on decrypt, so a
+        # successful cross-decrypt is only possible if both sides agree.
+        token = service.cipher.encrypt(b"round-trip-probe")
+        assert Fernet(key).decrypt(token) == b"round-trip-probe"
+
+        assert (canonical_dir / "secrets.key").read_bytes() == key
+        assert not (legacy_data_dir / "secrets.key").exists()
+
+
+class TestComposeCanonicalDataDirIsPersistent:
+    """#14081 review round 5, finding 1: under docker-compose.yml, with no
+    AUTOBOT_DATA_DIR configured, ssot_config.path.data_path (canonical)
+    resolved to the container's ephemeral writable layer while the legacy
+    CWD-relative resolver landed on the persistent backend_data named
+    volume. The migration this PR added moved real secrets OFF durable
+    storage and deleted the source -- the next `--force-recreate` or image
+    update destroyed them.
+
+    Parses the real docker-compose.yml (never a hand-written fixture), so a
+    future edit that drops the AUTOBOT_DATA_DIR override re-triggers this
+    failure rather than silently reintroducing it.
+    """
+
+    @staticmethod
+    def _service_env(compose: dict, service_name: str) -> dict[str, str]:
+        return dict(entry.split("=", 1) for entry in compose["services"][service_name]["environment"])
+
+    @pytest.mark.parametrize("service_name", ["autobot-backend", "autobot-worker", "autobot-celery-beat"])
+    def test_canonical_data_dir_matches_the_persistent_volume_mount(self, service_name):
+        compose = yaml.safe_load((_REPO_ROOT / "docker-compose.yml").read_text(encoding="utf-8"))
+        service = compose["services"][service_name]
+
+        volume_mount = next((v for v in service["volumes"] if v.startswith("backend_data:")), None)
+        assert volume_mount is not None, f"{service_name} must mount the persistent backend_data volume"
+        persistent_mount_point = volume_mount.split(":", 1)[1]
+
+        env = self._service_env(compose, service_name)
+        data_dir_setting = env.get("AUTOBOT_DATA_DIR", "")
+        # Compose interpolation syntax `${AUTOBOT_DATA_DIR:-/app/data}` is
+        # never expanded by a plain YAML load -- extract the default, which
+        # is what applies for every operator who hasn't overridden it
+        # (including this smoke test's own environment).
+        match = re.search(r"\$\{AUTOBOT_DATA_DIR:-([^}]*)\}", data_dir_setting)
+        assert match, (
+            f"{service_name} must set AUTOBOT_DATA_DIR so ssot_config.path.data_path "
+            "resolves under the persistent backend_data volume, not the container's "
+            "ephemeral writable layer -- otherwise the legacy->canonical secrets-store "
+            "migration moves real secrets off durable storage and deletes the source."
+        )
+        default_data_dir = match.group(1)
+
+        assert default_data_dir == persistent_mount_point, (
+            f"{service_name}: AUTOBOT_DATA_DIR default ({default_data_dir!r}) does not match "
+            f"the backend_data volume's mount point ({persistent_mount_point!r}) -- the "
+            "secrets-store migration would move data off the persistent volume."
+        )

--- a/autobot-backend/utils/secrets_store_migration.py
+++ b/autobot-backend/utils/secrets_store_migration.py
@@ -1,0 +1,119 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""One-time migration for secrets-store files off the legacy CWD-relative
+resolver, onto the canonical ssot_config-derived data directory (#14081
+review, #14113).
+
+Before #14081, ``SecretsManager``/``SecretsService`` resolved their storage
+through ``utils.paths_manager.get_data_path()``, which reads an unset
+``config.yaml`` ``paths:`` key and silently falls back to a CWD-relative
+``"data/..."`` path. Pointing them at ``ssot_config.path.data_path`` instead
+fixes the divergence going forward, but on an existing deployment the real
+store already lives at the old location -- changing where the code *looks*
+without moving what is already there orphans every stored credential and
+looks exactly like a first boot (a new key gets minted, an empty store gets
+created, nothing raises).
+
+This module runs once, at the same points the old code decided "generate a
+new key vs. load the existing one", and either performs a safe move or
+refuses to guess.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+from typing import Sequence
+
+from autobot_shared.logging_manager import get_logger
+from utils.paths_manager import get_data_path
+
+logger = get_logger(__name__)
+
+
+class AmbiguousSecretsStoreError(RuntimeError):
+    """Both the legacy and canonical secrets-store locations hold data.
+
+    Raised instead of guessing which one is authoritative -- an automatic
+    choice here can silently destroy whichever store it doesn't pick.
+    """
+
+
+def _legacy_absolute_path(filename: str) -> Path:
+    """Resolve *filename* the exact way the pre-#14081 code did.
+
+    Calls the real ``get_data_path`` rather than reimplementing its
+    CWD-relative fallback, so this migration stays correct even if that
+    resolver's behavior changes later (#14113 tracks fixing it directly).
+    ``get_data_path`` can return a relative path (the bug) or, if
+    ``config.yaml`` ever gains a real ``paths:`` section, an absolute one;
+    ``os.path.abspath`` handles both.
+    """
+    return Path(os.path.abspath(str(get_data_path(filename))))
+
+
+def migrate_legacy_secrets_store(canonical_dir: Path, filenames: Sequence[str], store_role: str) -> None:
+    """Move *filenames* from the legacy data dir to *canonical_dir* if needed.
+
+    Must be called before any caller decides whether to generate a fresh
+    encryption key or treat the store as empty -- that decision is exactly
+    what silently destroys existing secrets if the legacy location still
+    holds the real store.
+
+    Args:
+        canonical_dir: the new, ssot_config-derived data directory.
+        filenames: the store's files to check/move, e.g. ``["secrets.key",
+            "secrets.json"]`` or ``["secrets.db"]``.
+        store_role: a generic, log-safe description of what this store is
+            (e.g. ``"secrets manager"``) -- never an absolute path, so log
+            lines stay safe to paste into an issue or PR.
+
+    Raises:
+        AmbiguousSecretsStoreError: both locations already hold data for
+            this store.
+    """
+    canonical_dir = Path(canonical_dir)
+    legacy_paths = {name: _legacy_absolute_path(name) for name in filenames}
+    canonical_paths = {name: canonical_dir / name for name in filenames}
+
+    # Common dev case: the legacy and canonical resolvers agree (CWD ==
+    # base_dir). Nothing to migrate, and must stay a no-op -- there is only
+    # ever one location, so "moving" it would just be a same-path shutil.move.
+    if all(legacy_paths[name] == canonical_paths[name] for name in filenames):
+        return
+
+    legacy_has_data = any(p.exists() for p in legacy_paths.values())
+    if not legacy_has_data:
+        return  # genuine first boot, or a migration that already ran
+
+    canonical_has_data = any(p.exists() for p in canonical_paths.values())
+    if canonical_has_data:
+        raise AmbiguousSecretsStoreError(
+            f"Both the legacy and canonical {store_role} storage locations contain "
+            "data (#14081/#14113 path-resolver migration). Refusing to guess which "
+            "is authoritative: a human must compare the two locations, manually "
+            "consolidate them, and remove the stale one before this service can "
+            "start."
+        )
+
+    canonical_dir.mkdir(parents=True, exist_ok=True)
+    for name in filenames:
+        legacy_path = legacy_paths[name]
+        if not legacy_path.exists():
+            continue
+        canonical_path = canonical_paths[name]
+        shutil.move(str(legacy_path), str(canonical_path))
+        # Keys stay 0o600 regardless of what mode they moved with; other
+        # store files (json/db) keep the permissions shutil.move preserved.
+        if name.endswith(".key"):
+            os.chmod(canonical_path, 0o600)
+
+    logger.warning(
+        "Migrated %s storage from its legacy location to the canonical data "
+        "directory (#14081/#14113 path-resolver fix). This is a one-time move; "
+        "no data was lost.",
+        store_role,
+    )

--- a/autobot-backend/utils/secrets_store_migration.py
+++ b/autobot-backend/utils/secrets_store_migration.py
@@ -19,19 +19,62 @@ created, nothing raises).
 This module runs once, at the same points the old code decided "generate a
 new key vs. load the existing one", and either performs a safe move or
 refuses to guess.
+
+#14081 security review round 5 (PR #14110) found three sharper problems with
+the first version of this module, all fixed here:
+
+1. ``SecretsManager`` and ``SecretsService`` each migrated only the files
+   they personally read (key+json, db respectively). A process that only
+   ever constructs one of the two -- a celery worker calling
+   ``get_secrets_service()`` without the FastAPI app's ``SecretsManager``
+   singleton ever running -- migrated the db alone, leaving the shared
+   encryption key behind at the legacy location. ``ALL_SECRETS_STORE_FILES``
+   and a single shared call site (`migrate_legacy_secrets_store` invoked
+   with that whole set, from both classes) close this: whichever class
+   constructs first migrates everything, not just its own slice.
+2. Backend and worker processes can both reach a genuine first boot at the
+   same moment on an upgrade. ``_canonical_store_lock`` serializes the
+   actual move (and, via ``ensure_and_read_shared_key``, first-time key
+   generation) across processes with an ``O_EXCL`` lockfile, so two
+   processes can never interleave writes to the same destination file.
+3. ``shutil.move`` degrades to copy2+unlink when source and destination are
+   on different filesystems -- exactly the persistent-volume-to-container-
+   layer case this migration exists for -- and that path is not atomic: an
+   interrupt mid-copy can leave a truncated file at the destination *and*
+   the intact source, which then reads as "both locations populated"
+   forever after. ``_atomic_move`` copies to a temp file in the destination
+   directory, ``fsync``s it, verifies its size against the source, and only
+   then ``os.replace``s it into place before removing the source.
 """
 
 from __future__ import annotations
 
 import os
 import shutil
+import time
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Sequence
+from typing import Iterator, Sequence
+
+from cryptography.fernet import Fernet
 
 from autobot_shared.logging_manager import get_logger
 from utils.paths_manager import get_data_path
 
 logger = get_logger(__name__)
+
+#: The complete set of files that make up the secrets store, spanning both
+#: SecretsManager (key + json) and SecretsService (db). Migrated together,
+#: as one unit, regardless of which class triggers the migration -- see
+#: finding 2 in the module docstring above.
+ALL_SECRETS_STORE_FILES: tuple[str, ...] = ("secrets.key", "secrets.json", "secrets.db")
+
+_LOCK_FILENAME = ".secrets_store_migration.lock"
+# Long enough to cover a slow cross-filesystem copy of a large secrets.db;
+# short enough that a crashed lock holder doesn't wedge every future boot.
+_LOCK_STALE_SECONDS = 120
+_LOCK_POLL_INTERVAL_SECONDS = 0.5
+_LOCK_WAIT_TIMEOUT_SECONDS = 30
 
 
 class AmbiguousSecretsStoreError(RuntimeError):
@@ -40,6 +83,10 @@ class AmbiguousSecretsStoreError(RuntimeError):
     Raised instead of guessing which one is authoritative -- an automatic
     choice here can silently destroy whichever store it doesn't pick.
     """
+
+
+class SecretsStoreLockTimeoutError(RuntimeError):
+    """Another process held the canonical secrets-store lock too long."""
 
 
 def _legacy_absolute_path(filename: str) -> Path:
@@ -55,25 +102,100 @@ def _legacy_absolute_path(filename: str) -> Path:
     return Path(os.path.abspath(str(get_data_path(filename))))
 
 
+@contextmanager
+def _canonical_store_lock(canonical_dir: Path) -> Iterator[None]:
+    """Cross-process mutual exclusion for writes to *canonical_dir* (#14081
+    review round 5, finding 3).
+
+    Backend and worker processes -- separate OS processes, so an
+    in-process ``threading.Lock`` cannot see each other -- can both reach a
+    genuine first boot at the same moment on an upgrade. ``O_CREAT |
+    O_EXCL`` makes the lockfile's creation itself atomic at the kernel
+    level: at most one caller's ``os.open`` succeeds when two race it
+    concurrently. Callers that lose the race poll until the winner releases
+    it (or a stale lock is reclaimed after a crash).
+    """
+    canonical_dir.mkdir(parents=True, exist_ok=True)
+    lock_path = canonical_dir / _LOCK_FILENAME
+    deadline = time.monotonic() + _LOCK_WAIT_TIMEOUT_SECONDS
+    fd = None
+    while fd is None:
+        try:
+            fd = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+        except FileExistsError:
+            try:
+                stale = (time.time() - lock_path.stat().st_mtime) > _LOCK_STALE_SECONDS
+            except FileNotFoundError:
+                continue  # released between our failed open() and this stat()
+            if stale:
+                # A crashed holder never reached the `finally` unlink below.
+                # Reclaiming is safe: the winner of the resulting race for
+                # the *next* O_EXCL create is the only one that proceeds.
+                lock_path.unlink(missing_ok=True)
+                continue
+            if time.monotonic() > deadline:
+                raise SecretsStoreLockTimeoutError(
+                    f"Timed out after {_LOCK_WAIT_TIMEOUT_SECONDS}s waiting for another "
+                    "process to finish initializing the secrets store (#14081/#14113)."
+                )
+            time.sleep(_LOCK_POLL_INTERVAL_SECONDS)
+    try:
+        os.write(fd, str(os.getpid()).encode("utf-8"))
+        os.close(fd)
+        yield
+    finally:
+        lock_path.unlink(missing_ok=True)
+
+
+def _atomic_move(src: Path, dst: Path) -> None:
+    """Copy *src* to *dst*, verify it, then remove *src* -- not
+    ``shutil.move`` (#14081 review round 5, finding 3).
+
+    ``shutil.move`` silently degrades to ``copy2`` + ``unlink`` when the
+    two paths are on different filesystems, which is exactly the
+    persistent-volume -> container-writable-layer move this module makes.
+    That path is not atomic: an interrupt between the copy and the unlink
+    leaves a partial file at *dst* and the untouched original at *src* --
+    both "populated", forever indistinguishable from two independent real
+    stores.
+    """
+    tmp_dst = dst.with_name(dst.name + ".tmp")
+    shutil.copy2(str(src), str(tmp_dst))
+    fd = os.open(str(tmp_dst), os.O_RDONLY)
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+    if tmp_dst.stat().st_size != src.stat().st_size:
+        tmp_dst.unlink(missing_ok=True)
+        raise OSError(f"Atomic move verification failed for {dst.name}: size mismatch after copy")
+
+    os.replace(str(tmp_dst), str(dst))
+    src.unlink()
+
+
 def migrate_legacy_secrets_store(canonical_dir: Path, filenames: Sequence[str], store_role: str) -> None:
     """Move *filenames* from the legacy data dir to *canonical_dir* if needed.
 
     Must be called before any caller decides whether to generate a fresh
     encryption key or treat the store as empty -- that decision is exactly
     what silently destroys existing secrets if the legacy location still
-    holds the real store.
+    holds the real store. Callers should pass ``ALL_SECRETS_STORE_FILES``
+    (see the module docstring, finding 2) rather than their own subset.
 
     Args:
         canonical_dir: the new, ssot_config-derived data directory.
-        filenames: the store's files to check/move, e.g. ``["secrets.key",
-            "secrets.json"]`` or ``["secrets.db"]``.
+        filenames: the store's files to check/move.
         store_role: a generic, log-safe description of what this store is
-            (e.g. ``"secrets manager"``) -- never an absolute path, so log
+            (e.g. ``"secrets store"``) -- never an absolute path, so log
             lines stay safe to paste into an issue or PR.
 
     Raises:
         AmbiguousSecretsStoreError: both locations already hold data for
             this store.
+        SecretsStoreLockTimeoutError: another process held the migration
+            lock past its timeout.
     """
     canonical_dir = Path(canonical_dir)
     legacy_paths = {name: _legacy_absolute_path(name) for name in filenames}
@@ -81,39 +203,96 @@ def migrate_legacy_secrets_store(canonical_dir: Path, filenames: Sequence[str], 
 
     # Common dev case: the legacy and canonical resolvers agree (CWD ==
     # base_dir). Nothing to migrate, and must stay a no-op -- there is only
-    # ever one location, so "moving" it would just be a same-path shutil.move.
+    # ever one location, so "moving" it would just be a same-path move.
     if all(legacy_paths[name] == canonical_paths[name] for name in filenames):
         return
 
-    legacy_has_data = any(p.exists() for p in legacy_paths.values())
-    if not legacy_has_data:
+    # Cheap, lock-free fast path (#14081 review round 5): most calls to this
+    # function happen long after the real migration completed (every
+    # SecretsService() construction, not only the first), and must not pay
+    # for a lockfile create/unlink on every one. Nothing to race over if
+    # legacy is already empty.
+    if not any(p.exists() for p in legacy_paths.values()):
         return  # genuine first boot, or a migration that already ran
 
-    canonical_has_data = any(p.exists() for p in canonical_paths.values())
-    if canonical_has_data:
-        raise AmbiguousSecretsStoreError(
-            f"Both the legacy and canonical {store_role} storage locations contain "
-            "data (#14081/#14113 path-resolver migration). Refusing to guess which "
-            "is authoritative: a human must compare the two locations, manually "
-            "consolidate them, and remove the stale one before this service can "
-            "start."
+    with _canonical_store_lock(canonical_dir):
+        # Re-check under the lock: another process may have completed the
+        # migration (or lost the ambiguous-state race) while this one
+        # waited.
+        legacy_has_data = any(p.exists() for p in legacy_paths.values())
+        if not legacy_has_data:
+            return
+
+        canonical_has_data = any(p.exists() for p in canonical_paths.values())
+        if canonical_has_data:
+            raise AmbiguousSecretsStoreError(
+                f"Both the legacy and canonical {store_role} storage locations contain "
+                "data (#14081/#14113 path-resolver migration). Refusing to guess which "
+                "is authoritative: a human must compare the two locations, manually "
+                "consolidate them, and remove the stale one before this service can "
+                "start."
+            )
+
+        canonical_dir.mkdir(parents=True, exist_ok=True)
+        for name in filenames:
+            legacy_path = legacy_paths[name]
+            if not legacy_path.exists():
+                continue
+            canonical_path = canonical_paths[name]
+            _atomic_move(legacy_path, canonical_path)
+            # Keys stay 0o600 regardless of what mode they moved with; other
+            # store files (json/db) keep the permissions copy2 preserved.
+            if name.endswith(".key"):
+                os.chmod(canonical_path, 0o600)
+
+        logger.warning(
+            "Migrated %s storage from its legacy location to the canonical data "
+            "directory (#14081/#14113 path-resolver fix). This is a one-time move; "
+            "no data was lost.",
+            store_role,
         )
 
-    canonical_dir.mkdir(parents=True, exist_ok=True)
-    for name in filenames:
-        legacy_path = legacy_paths[name]
-        if not legacy_path.exists():
-            continue
-        canonical_path = canonical_paths[name]
-        shutil.move(str(legacy_path), str(canonical_path))
-        # Keys stay 0o600 regardless of what mode they moved with; other
-        # store files (json/db) keep the permissions shutil.move preserved.
-        if name.endswith(".key"):
-            os.chmod(canonical_path, 0o600)
 
-    logger.warning(
-        "Migrated %s storage from its legacy location to the canonical data "
-        "directory (#14081/#14113 path-resolver fix). This is a one-time move; "
-        "no data was lost.",
-        store_role,
-    )
+def ensure_and_read_shared_key(canonical_dir: Path) -> bytes:
+    """Load the shared Fernet key from ``<canonical_dir>/secrets.key``,
+    minting and persisting one if it does not exist yet (#14081 review
+    round 5).
+
+    The single code path that may create this file, used by both
+    ``SecretsManager`` and ``SecretsService`` so the two classes cannot
+    disagree about the key -- and so a genuine first boot racing across two
+    processes mints exactly one real, persisted key rather than each
+    process silently keeping its own throwaway one in memory. That
+    silent-throwaway-key behavior was ``SecretsService``'s pre-#14081
+    fallback: a key generated on a WARNING and never written to disk,
+    indistinguishable from first boot even when a real store already
+    existed, and undecryptable by any other process or the next restart.
+    """
+    canonical_dir = Path(canonical_dir)
+    key_path = canonical_dir / "secrets.key"
+
+    if key_path.exists():
+        return key_path.read_bytes()
+
+    with _canonical_store_lock(canonical_dir):
+        if key_path.exists():  # minted by another process while we waited
+            return key_path.read_bytes()
+
+        canonical_dir.mkdir(parents=True, exist_ok=True)
+        key = Fernet.generate_key()
+        tmp_path = key_path.with_name(key_path.name + ".tmp")
+        tmp_path.write_bytes(key)
+        fd = os.open(str(tmp_path), os.O_RDONLY)
+        try:
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+        os.chmod(tmp_path, 0o600)
+        os.replace(str(tmp_path), str(key_path))
+
+        logger.warning(
+            "Generated and persisted a new shared secrets-store encryption key at the "
+            "canonical data directory (#14081 review round 5). Set AUTOBOT_SECRETS_KEY "
+            "for a deployment-managed key instead."
+        )
+        return key

--- a/autobot-backend/utils/secrets_store_migration_test.py
+++ b/autobot-backend/utils/secrets_store_migration_test.py
@@ -1,0 +1,125 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Unit tests for the legacy-to-canonical secrets-store migration (#14081 review).
+
+These exercise ``migrate_legacy_secrets_store`` directly, against the real
+``utils.paths_manager.get_data_path`` (never a monkeypatched stand-in for
+it, per the review requirement) with the process CWD controlled via
+``monkeypatch.chdir`` -- exactly how that resolver is CWD-sensitive in
+production.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from utils.secrets_store_migration import (
+    AmbiguousSecretsStoreError,
+    migrate_legacy_secrets_store,
+)
+
+
+class TestSameLocationIsNoOp:
+    """The common dev case: legacy and canonical resolve identically."""
+
+    def test_no_move_no_warning(self, tmp_path, monkeypatch, caplog):
+        # get_data_path("secrets.key") falls back to the literal relative
+        # Path("data") / "secrets.key", resolved against CWD -- so chdir to
+        # tmp_path and point canonical_dir at "<tmp_path>/data" to make the
+        # two resolvers agree, as they do whenever CWD == base_dir.
+        monkeypatch.chdir(tmp_path)
+        canonical_dir = tmp_path / "data"
+        canonical_dir.mkdir()
+        (canonical_dir / "secrets.key").write_bytes(b"canonical-key-material")
+
+        with caplog.at_level("WARNING"):
+            migrate_legacy_secrets_store(canonical_dir, ["secrets.key"], "test store")
+
+        assert (canonical_dir / "secrets.key").read_bytes() == b"canonical-key-material"
+        assert not any("Migrated" in r.message for r in caplog.records)
+
+
+class TestGenuineFirstBoot:
+    """Neither location has data: still a no-op, caller proceeds to provision fresh."""
+
+    def test_no_move_when_nothing_exists(self, tmp_path, monkeypatch):
+        legacy_root = tmp_path / "legacy_cwd"
+        legacy_root.mkdir()
+        monkeypatch.chdir(legacy_root)
+
+        canonical_dir = tmp_path / "canonical"
+        canonical_dir.mkdir()
+
+        migrate_legacy_secrets_store(canonical_dir, ["secrets.key", "secrets.json"], "test store")
+
+        assert list(canonical_dir.iterdir()) == []
+
+
+class TestSuccessfulMigration:
+    """Legacy has data, canonical is empty: files move, key permissions locked down."""
+
+    def test_moves_files_and_locks_down_key_permissions(self, tmp_path, monkeypatch, caplog):
+        legacy_root = tmp_path / "legacy_cwd"
+        legacy_root.mkdir()
+        monkeypatch.chdir(legacy_root)
+        legacy_data_dir = legacy_root / "data"
+        legacy_data_dir.mkdir()
+        (legacy_data_dir / "secrets.key").write_bytes(b"legacy-key-material")
+        (legacy_data_dir / "secrets.key").chmod(0o644)  # deliberately loose, to prove it gets locked down
+        (legacy_data_dir / "secrets.json").write_text('{"a": 1}', encoding="utf-8")
+
+        canonical_dir = tmp_path / "canonical"
+        canonical_dir.mkdir()
+
+        with caplog.at_level("WARNING"):
+            migrate_legacy_secrets_store(canonical_dir, ["secrets.key", "secrets.json"], "test store")
+
+        assert (canonical_dir / "secrets.key").read_bytes() == b"legacy-key-material"
+        assert (canonical_dir / "secrets.json").read_text(encoding="utf-8") == '{"a": 1}'
+        assert not (legacy_data_dir / "secrets.key").exists()
+        assert not (legacy_data_dir / "secrets.json").exists()
+        assert oct((canonical_dir / "secrets.key").stat().st_mode)[-3:] == "600"
+        assert any("Migrated" in r.message for r in caplog.records)
+
+    def test_log_line_carries_no_absolute_path(self, tmp_path, monkeypatch, caplog):
+        """Log lines must stay safe to paste into an issue or PR (#14081 review)."""
+        legacy_root = tmp_path / "legacy_cwd"
+        legacy_root.mkdir()
+        monkeypatch.chdir(legacy_root)
+        legacy_data_dir = legacy_root / "data"
+        legacy_data_dir.mkdir()
+        (legacy_data_dir / "secrets.key").write_bytes(b"legacy-key-material")
+
+        canonical_dir = tmp_path / "canonical"
+        canonical_dir.mkdir()
+
+        with caplog.at_level("WARNING"):
+            migrate_legacy_secrets_store(canonical_dir, ["secrets.key"], "test store")
+
+        for record in caplog.records:
+            assert str(tmp_path) not in record.message
+
+
+class TestBothLocationsPopulated:
+    """An ambiguous state a wrong choice would destroy: fail loudly instead."""
+
+    def test_raises_and_does_not_move_anything(self, tmp_path, monkeypatch):
+        legacy_root = tmp_path / "legacy_cwd"
+        legacy_root.mkdir()
+        monkeypatch.chdir(legacy_root)
+        legacy_data_dir = legacy_root / "data"
+        legacy_data_dir.mkdir()
+        (legacy_data_dir / "secrets.key").write_bytes(b"legacy-key-material")
+
+        canonical_dir = tmp_path / "canonical"
+        canonical_dir.mkdir()
+        (canonical_dir / "secrets.key").write_bytes(b"canonical-key-material")
+
+        with pytest.raises(AmbiguousSecretsStoreError, match="test store"):
+            migrate_legacy_secrets_store(canonical_dir, ["secrets.key"], "test store")
+
+        # Neither side was touched.
+        assert (legacy_data_dir / "secrets.key").read_bytes() == b"legacy-key-material"
+        assert (canonical_dir / "secrets.key").read_bytes() == b"canonical-key-material"

--- a/autobot-backend/utils/secrets_store_migration_test.py
+++ b/autobot-backend/utils/secrets_store_migration_test.py
@@ -13,10 +13,16 @@ production.
 
 from __future__ import annotations
 
+import os
+import shutil
+import time
+
 import pytest
 
+import utils.secrets_store_migration as migration_module
 from utils.secrets_store_migration import (
     AmbiguousSecretsStoreError,
+    SecretsStoreLockTimeoutError,
     migrate_legacy_secrets_store,
 )
 
@@ -123,3 +129,102 @@ class TestBothLocationsPopulated:
         # Neither side was touched.
         assert (legacy_data_dir / "secrets.key").read_bytes() == b"legacy-key-material"
         assert (canonical_dir / "secrets.key").read_bytes() == b"canonical-key-material"
+
+
+class TestAtomicMoveVerification:
+    """#14081 review round 5, finding 3: shutil.move is not atomic across
+    filesystems (copy2+unlink), so an interrupted copy can leave a
+    truncated file at the destination and the untouched source at the
+    legacy location -- permanently "both populated". The replacement
+    (copy-to-tmp, fsync, verify size, os.replace, then unlink source) must
+    refuse to finish and must leave the source untouched when the copy
+    comes up short.
+    """
+
+    def test_size_mismatch_aborts_and_preserves_the_source(self, tmp_path, monkeypatch):
+        legacy_root = tmp_path / "legacy_cwd"
+        legacy_root.mkdir()
+        monkeypatch.chdir(legacy_root)
+        legacy_data_dir = legacy_root / "data"
+        legacy_data_dir.mkdir()
+        (legacy_data_dir / "secrets.key").write_bytes(b"legacy-key-material-32-bytes!!!")
+
+        canonical_dir = tmp_path / "canonical"
+        canonical_dir.mkdir()
+
+        def _truncated_copy(src, dst, *a, **kw):
+            # Simulate an interrupted cross-filesystem copy: fewer bytes
+            # land at the destination than the source actually has.
+            with open(src, "rb") as f:
+                data = f.read()
+            with open(dst, "wb") as f:
+                f.write(data[:4])
+
+        monkeypatch.setattr(shutil, "copy2", _truncated_copy)
+
+        with pytest.raises(OSError, match="size mismatch"):
+            migrate_legacy_secrets_store(canonical_dir, ["secrets.key"], "test store")
+
+        # Source untouched, no truncated file left at the destination, and
+        # no stray .tmp file -- a caller retrying later sees a clean legacy
+        # location, not a poisoned canonical one.
+        assert (legacy_data_dir / "secrets.key").read_bytes() == b"legacy-key-material-32-bytes!!!"
+        assert not (canonical_dir / "secrets.key").exists()
+        assert not (canonical_dir / "secrets.key.tmp").exists()
+
+
+class TestCrossProcessLock:
+    """#14081 review round 5, finding 3: backend and worker are separate OS
+    processes and can both reach a genuine first boot at the same moment on
+    an upgrade -- an in-process lock cannot see across that boundary.
+    """
+
+    def test_a_held_lock_blocks_a_second_migration_until_timeout(self, tmp_path, monkeypatch):
+        legacy_root = tmp_path / "legacy_cwd"
+        legacy_root.mkdir()
+        monkeypatch.chdir(legacy_root)
+        legacy_data_dir = legacy_root / "data"
+        legacy_data_dir.mkdir()
+        (legacy_data_dir / "secrets.key").write_bytes(b"legacy-key-material")
+
+        canonical_dir = tmp_path / "canonical"
+        canonical_dir.mkdir()
+        # Simulate another process mid-migration: a fresh lockfile already
+        # held in the canonical directory.
+        (canonical_dir / migration_module._LOCK_FILENAME).write_text(str(9999999), encoding="utf-8")
+
+        monkeypatch.setattr(migration_module, "_LOCK_WAIT_TIMEOUT_SECONDS", 0.3)
+        monkeypatch.setattr(migration_module, "_LOCK_POLL_INTERVAL_SECONDS", 0.05)
+
+        with pytest.raises(SecretsStoreLockTimeoutError):
+            migrate_legacy_secrets_store(canonical_dir, ["secrets.key"], "test store")
+
+        # The blocked caller must not have touched anything while waiting.
+        assert (legacy_data_dir / "secrets.key").read_bytes() == b"legacy-key-material"
+        assert not (canonical_dir / "secrets.key").exists()
+
+    def test_a_stale_lock_is_reclaimed(self, tmp_path, monkeypatch):
+        legacy_root = tmp_path / "legacy_cwd"
+        legacy_root.mkdir()
+        monkeypatch.chdir(legacy_root)
+        legacy_data_dir = legacy_root / "data"
+        legacy_data_dir.mkdir()
+        (legacy_data_dir / "secrets.key").write_bytes(b"legacy-key-material")
+
+        canonical_dir = tmp_path / "canonical"
+        canonical_dir.mkdir()
+        stale_lock = canonical_dir / migration_module._LOCK_FILENAME
+        stale_lock.write_text(str(9999999), encoding="utf-8")
+        # Back-date the lockfile's mtime so it reads as abandoned by a
+        # crashed holder rather than actively held.
+        old_time = time.time() - 3600
+        os.utime(stale_lock, (old_time, old_time))
+
+        monkeypatch.setattr(migration_module, "_LOCK_STALE_SECONDS", 60)
+        monkeypatch.setattr(migration_module, "_LOCK_WAIT_TIMEOUT_SECONDS", 2)
+
+        migrate_legacy_secrets_store(canonical_dir, ["secrets.key"], "test store")
+
+        assert (canonical_dir / "secrets.key").read_bytes() == b"legacy-key-material"
+        assert not (legacy_data_dir / "secrets.key").exists()
+        assert not stale_lock.exists()

--- a/docker-compose.hardened.yml
+++ b/docker-compose.hardened.yml
@@ -98,6 +98,14 @@ services:
       - /app/autobot-backend/.cache:mode=1777
       - /app/autobot-backend/data:mode=1777  # conversation_file_manager creates data dir on init
       - /app/autobot-backend/logs:mode=1777  # logging_manager creates logs/backup dirs on init
+      # #14081/#14113: SecretsManager/SecretsService now resolve their
+      # storage through ssot_config.path.data_path, which with no
+      # AUTOBOT_BASE_DIR set (this compose topology) resolves to
+      # /opt/autobot/data -- not previously writable under read_only, so
+      # the backend crashed at import with "Read-only file system".
+      # tmpfs unblocks the smoke test but is ephemeral (secrets lost on
+      # restart) -- #14122 tracks giving this a real persistent volume.
+      - /opt/autobot/data:mode=1777
     deploy:
       resources:
         limits:
@@ -115,6 +123,9 @@ services:
       - /app/autobot-backend/.cache:mode=1777
       - /app/autobot-backend/data:mode=1777  # conversation_file_manager creates data dir on init
       - /app/autobot-backend/logs:mode=1777  # logging_manager creates logs/backup dirs on init
+      # See autobot-backend above (#14081/#14113/#14122) -- same image,
+      # same resolver, same crash if this worker imports the secrets store.
+      - /opt/autobot/data:mode=1777
     deploy:
       resources:
         limits:

--- a/docker-compose.hardened.yml
+++ b/docker-compose.hardened.yml
@@ -98,13 +98,15 @@ services:
       - /app/autobot-backend/.cache:mode=1777
       - /app/autobot-backend/data:mode=1777  # conversation_file_manager creates data dir on init
       - /app/autobot-backend/logs:mode=1777  # logging_manager creates logs/backup dirs on init
-      # #14081/#14113: SecretsManager/SecretsService now resolve their
-      # storage through ssot_config.path.data_path, which with no
-      # AUTOBOT_BASE_DIR set (this compose topology) resolves to
-      # /opt/autobot/data -- not previously writable under read_only, so
-      # the backend crashed at import with "Read-only file system".
-      # tmpfs unblocks the smoke test but is ephemeral (secrets lost on
-      # restart) -- #14122 tracks giving this a real persistent volume.
+      # #14081/#14113: SecretsManager/SecretsService resolve their storage
+      # through ssot_config.path.data_path. docker-compose.yml now pins
+      # AUTOBOT_DATA_DIR=/app/data (the persistent backend_data volume, see
+      # its comment there for the full data-loss mechanism this closes) so
+      # this path is normally never touched. Kept as a defence-in-depth
+      # fallback for an operator who overrides AUTOBOT_DATA_DIR back to an
+      # /opt/autobot-relative value: without it, read_only would turn that
+      # override into the same import-time "Read-only file system" crash
+      # this PR fixed. Still ephemeral if ever actually used -- #14122.
       - /opt/autobot/data:mode=1777
     deploy:
       resources:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -223,6 +223,16 @@ services:
     environment:
       - AUTOBOT_ENVIRONMENT=production
       - AUTOBOT_DEPLOYMENT_MODE=local
+      # #14081/#14110 security review: with no AUTOBOT_BASE_DIR set, the
+      # canonical secrets-store/JWT-key/project-state location
+      # (ssot_config.path.data_path) resolved to /opt/autobot/data — the
+      # container's ephemeral writable layer, NOT the persistent
+      # backend_data volume mounted at /app/data below. The one-time
+      # migration was moving real secrets OFF the volume and deleting the
+      # source, so the next recreate destroyed them. Pinning this to the
+      # volume's mount point makes canonical == legacy for this service, so
+      # the migration correctly no-ops instead of relocating anything.
+      - AUTOBOT_DATA_DIR=${AUTOBOT_DATA_DIR:-/app/data}
       # No AI Stack VM ships with compose — disable the poll to stop the per-boot
       # connection-error warning flood (#9782). Set to true if you run an AI Stack.
       - AUTOBOT_AI_STACK_ENABLED=${AUTOBOT_AI_STACK_ENABLED:-false}
@@ -364,6 +374,13 @@ services:
     environment:
       - AUTOBOT_ENVIRONMENT=production
       - AUTOBOT_DEPLOYMENT_MODE=local
+      # #14081/#14110 security review: this service's working_dir differs
+      # from autobot-backend's, so its own legacy CWD-relative resolver
+      # would disagree with the backend's — pinning canonical here too
+      # means both converge on the same persistent backend_data volume
+      # (see autobot-backend's AUTOBOT_DATA_DIR comment above for the full
+      # data-loss mechanism this closes).
+      - AUTOBOT_DATA_DIR=${AUTOBOT_DATA_DIR:-/app/data}
       # No AI Stack VM ships with compose — disable the poll to stop the per-boot
       # connection-error warning flood (#9782). Set to true if you run an AI Stack.
       - AUTOBOT_AI_STACK_ENABLED=${AUTOBOT_AI_STACK_ENABLED:-false}
@@ -469,6 +486,12 @@ services:
     environment:
       - AUTOBOT_ENVIRONMENT=production
       - AUTOBOT_DEPLOYMENT_MODE=local
+      # #14081/#14110 security review: kept consistent with autobot-backend
+      # and autobot-worker so any secrets-store access this process makes
+      # (task modules it loads may import services.secrets_service)
+      # resolves to the same persistent backend_data volume, not the
+      # container's ephemeral writable layer.
+      - AUTOBOT_DATA_DIR=${AUTOBOT_DATA_DIR:-/app/data}
       # No AI Stack VM ships with compose — disable the poll to stop the per-boot
       # connection-error warning flood (#9782). Set to true if you run an AI Stack.
       - AUTOBOT_AI_STACK_ENABLED=${AUTOBOT_AI_STACK_ENABLED:-false}


### PR DESCRIPTION
Closes #14081

## Thinking Path

Reproduced the exposure first: with `AUTOBOT_BASE_DIR` unset (every dev checkout and CI runner), `filesystem_mcp.ALLOWED_DIRECTORIES` resolves to the checkout root and `_resolve_allowed_path` allowed both `<checkout>/.git/config` and `<checkout>/.env`. Traced the canonical secrets-manager storage (not obvious from the issue alone): `SecretsManager` (`api/secrets.py`) writes `secrets.key`/`secrets.json`, `SecretsService` (`services/secrets_service.py`) writes `secrets.db`, and `auth_middleware.py`'s durable RS256 keypair lives at `service-keys/jwt_rsa_private.pem` — all three under `config.path.data_path`, i.e. inside the same allowed root once `base_dir` is the checkout.

The fix location follows the issue's suggestion: a single exclusion check inside `_resolve_allowed_path`, the one seam both `is_path_allowed` and `_validated_path` route through, rather than curating `ALLOWED_DIRECTORIES`. That way the exclusion holds even for a deployment that legitimately points `base_dir` somewhere containing these paths.

## What Changed

- `autobot-backend/api/filesystem_mcp.py`: added `_is_excluded_path()`, checked from `_resolve_allowed_path()` after `validate_path()` resolves the canonical path (symlinks followed, encodings decoded — so a disguised path can't land inside an excluded subtree undetected). Excludes:
  - any path with a `.git` component
  - any path with a component matching `.env*`
  - the canonical secrets-manager storage: `data/secrets.key`, `data/secrets.json`, `data/secrets.db`, `data/service-keys/` — all resolved from `config.path.data_path` so they track wherever `AUTOBOT_DATA_DIR` actually points, in dev or prod
- `autobot-backend/tests/api/test_filesystem_mcp_exclusions.py`: new test module. Unit-level checks against a synthetic project tree (isolated from the real repo — never touches this checkout's actual `.git` or secrets) plus HTTP-level checks through `read_text_file_mcp`, covering both directions: excluded paths refused (403 / `ValueError`), ordinary files still reachable (200). Also a `.github`-vs-`.git` false-positive guard.

Out of scope (per the issue, left for the owner): `venv/`/`node_modules/` were suggested as an "accidental surface" exclusion but hold no credentials, so adding them would be scope creep on a security fix — filed as a follow-up if wanted, not bundled here.

## Verification

Reproduction before the fix (`_resolve_allowed_path` allowed all three):
```
base_dir: /home/.../AutoBot-AI
ALLOWED: /home/.../AutoBot-AI/.git/config -> ...
ALLOWED: /home/.../AutoBot-AI/.env -> ...
ALLOWED: /home/.../AutoBot-AI/README.md -> ...
```

After the fix, same set plus secrets-manager storage:
```
OK: .../.git/config           expected=deny  actual=deny
OK: .../.env                  expected=deny  actual=deny
OK: .../.env.local             expected=deny  actual=deny
OK: .../data/secrets.key       expected=deny  actual=deny
OK: .../data/secrets.json      expected=deny  actual=deny
OK: .../data/secrets.db        expected=deny  actual=deny
OK: .../data/service-keys/...  expected=deny  actual=deny
OK: .../README.md              expected=allow actual=allow
OK: .../CLAUDE.md               expected=allow actual=allow
OK: .../data/scheduled_workflows.json expected=allow actual=allow
```

New test suite: `pytest tests/api/test_filesystem_mcp_exclusions.py -v` → **16 passed**.
No regression: `pytest tests/api/test_filesystem_mcp_resources_prompts.py -q` → **15 passed**.

Mutation test (no-op detection per task instructions): removed the `_is_excluded_path` call, confirmed via `diff` that the mutation actually changed the file, reran the suite → **11 of 16 tests failed** (all the exclusion tests). Reverted, reran → **16 passed** again.

Lint: `black --check`, `isort --check`, `flake8` on both changed files — clean.

**Recommendation for the owner (not changed in this PR, per the issue's own note):** this bridge currently grants read *and* write access to the whole checkout whenever `AUTOBOT_BASE_DIR` is unset — every dev machine and CI runner. Write access through an LLM-facing MCP tool is a materially larger blast radius than read (arbitrary file overwrite anywhere under the allowed root, now excluding the subtrees this PR closes off). I'd recommend making the bridge read-only by default in environments where `base_dir` falls back to the checkout (i.e., gate `write_file`/`edit_file`/`move_file`/`create_directory` behind an explicit opt-in env var), but that's a behavior change beyond this issue's scope and I left it for you to decide.

## Model Used

Sonnet

## Update (review round 2)

A reviewer found the first commit's exclusion list guarded a location the secrets store never actually writes to: `SecretsManager`/`SecretsService` resolved storage through the legacy `utils.paths_manager.get_data_path()` (an unset `config.yaml` `paths:` key, silently falling back to a CWD-relative `"data/..."` path), while the exclusion list derived from `ssot_config.path.data_path`. In the deployed topology (systemd `WorkingDirectory` one level below `AUTOBOT_BASE_DIR`) the two disagreed.

Fixed by pointing both `SecretsManager` and `SecretsService` at `ssot_config.path.data_path` directly — the same expression the exclusion list uses — so the two sides are structurally guaranteed to agree. Added `TestRealResolverAgreement`, which instantiates the real classes (no monkeypatched exclusion list) and checks the real bridge against whatever they actually compute; verified it fails against the pre-fix resolver and passes against the fix.

Also from that review round:
- `.env.example`/`.env.sample`/`.env.template` (committed, non-secret conventions) are now allowlisted ahead of the `.env*` denylist; `.envrc` stays denied.
- The hardlink gap in `_is_excluded_path` (path-prefix check, not inode-based) is documented and accepted: exploiting it already requires local write access to the excluded file's directory, at which point the bridge adds nothing an attacker didn't already have.
- Filed #14116 for a pre-existing, unrelated issue found along the way: `api/secrets.py`'s module-level `SecretsManager` singleton writes real key material at import time.

Full detail in the PR comment thread.

## Update (review round 3 — migration for existing deployments)

Blocker: the resolver-unification commit (03e91b667) moved *where* the code looks for the secrets store without moving what was already there — a silent-data-loss risk on upgrade, matching #14113's "Migration note" (its #1 named risk).

Fixed with a one-time migration (`autobot-backend/utils/secrets_store_migration.py`) run before either `SecretsManager`/`SecretsService` decides whether to generate a fresh key or treat the store as empty:
- resolves the legacy location via the real `utils.paths_manager.get_data_path()` (never a reimplementation of its CWD-relative fallback)
- same-location case (CWD == base_dir) is a no-op
- legacy has data, canonical doesn't → moves the files, locks `secrets.key` to `0o600`, logs at WARNING with no absolute paths
- both locations have data → raises `AmbiguousSecretsStoreError` rather than guessing
- neither location populated (genuine first boot) → no-op, proceeds to provision fresh, exactly as before

Related to #14113 (see cross-link below and comment there): this PR migrates the secrets store specifically. #14113 asks for more — auditing every other `get_data_path()` caller — which stays open and unclosed by this PR.