### PR TITLE
fix(ci): recognize multi-line noqa and scope print/console guard to changed lines (#14051)

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -205,7 +205,13 @@ jobs:
       run: bash pipeline-scripts/check-pre-commit-hook-pr.sh pre-commit-no-direct-redis
 
     - name: Block print/console regressions (#1082, #6785)
-      run: bash pipeline-scripts/check-pre-commit-hook-pr.sh pre-commit-no-print-console
+      # --changed-lines-only (#14051, same treatment #13950 gave the
+      # hardcoded-value guard): without it, a PR that edits one line of a
+      # legacy file is blamed for that file's entire print()/console.*
+      # backlog. Combined with the hook's own multi-line-noqa fix (#14051),
+      # this closes the class rather than one shape of it — the pre-commit
+      # stage and a direct run of the hook still scan whole files.
+      run: bash pipeline-scripts/check-pre-commit-hook-pr.sh --changed-lines-only pre-commit-no-print-console
 
     - name: Check repo conventions — third-party names, doc cross-links (#13876)
       env:

--- a/autobot-infrastructure/shared/scripts/hooks/lib/strip-significant.awk
+++ b/autobot-infrastructure/shared/scripts/hooks/lib/strip-significant.awk
@@ -1,0 +1,77 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+#
+# Character-by-character line normalizer for the no-print-console guard
+# (#14051 review round 2). Strips string/template/regex-literal BODIES
+# (their punctuation must not count as call structure) and, depending on
+# keep_comment, the trailing comment too:
+#   keep_comment=0 — used for paren-BALANCE tracking: comment removed, since
+#     a comment's stray '(' must not hold a call's "still open" window open.
+#   keep_comment=1 — used for MATCHING the call and searching for a noqa:
+#     comment kept (that is where a real suppression lives); a noqa written
+#     inside a STRING ARGUMENT is still removed with the string, so it can't
+#     be mistaken for a real suppression.
+#
+# Inputs (via -v): lang ("py" or "ts"), keep_comment ("0" or "1"), sq (a
+# literal single-quote character, passed in rather than embedded so the
+# calling shell never has to quote one inside this program's invocation).
+#
+# lang="py": '/" strings (backslash-escaped), '#' starts the comment.
+# lang="ts": '/"/`" strings including template literals, plus a best-effort
+#   `/regex/` literal detector — a '/' preceded by start-of-line or one of
+#   ([{,;:=&|!?+-*%^~<> opens a regex literal; anything else (an identifier,
+#   ')', ']') is read as division and left alone. Nested ${} inside a
+#   template literal is stripped along with the rest of the template body —
+#   this only protects OUR call's balance; a real call embedded in an
+#   interpolation is simply not analyzed by this pass. '//' starts the
+#   comment. Known limitation, like Python's triple-quoted strings: this is
+#   a heuristic, not a full lexer (e.g. a '/' inside a regex character class
+#   is not modeled) — add an explicit noqa if a line is still misread.
+
+BEGIN {
+    punct = "([{,;:=&|!?+-*%^~<>"
+}
+{
+    n = length($0)
+    out = ""
+    in_str = 0; str_ch = ""
+    in_tmpl = 0; in_regex = 0
+    prev_sig = ""
+    for (i = 1; i <= n; i++) {
+        c = substr($0, i, 1)
+        if (in_str) {
+            if (c == "\\") { i++; continue }
+            if (c == str_ch) in_str = 0
+            continue
+        }
+        if (in_tmpl) {
+            if (c == "\\") { i++; continue }
+            if (c == "`") in_tmpl = 0
+            continue
+        }
+        if (in_regex) {
+            if (c == "\\") { i++; continue }
+            if (c == "/") { in_regex = 0; prev_sig = "/" }
+            continue
+        }
+        if (c == "\"" || c == sq) { in_str = 1; str_ch = c; continue }
+        if (lang == "ts" && c == "`") { in_tmpl = 1; continue }
+        if (lang == "py" && c == "#") {
+            if (keep_comment == "1") out = out substr($0, i)
+            break
+        }
+        if (lang == "ts" && c == "/") {
+            nc = substr($0, i + 1, 1)
+            if (nc == "/") {
+                if (keep_comment == "1") out = out substr($0, i)
+                break
+            }
+            if (prev_sig == "" || index(punct, prev_sig) > 0) { in_regex = 1; continue }
+        }
+        out = out c
+        if (c !~ /[ \t]/) prev_sig = c
+    }
+    print out
+}

--- a/autobot-infrastructure/shared/scripts/hooks/lib/strip-significant.awk
+++ b/autobot-infrastructure/shared/scripts/hooks/lib/strip-significant.awk
@@ -27,8 +27,20 @@
 #   this only protects OUR call's balance; a real call embedded in an
 #   interpolation is simply not analyzed by this pass. '//' starts the
 #   comment. Known limitation, like Python's triple-quoted strings: this is
-#   a heuristic, not a full lexer (e.g. a '/' inside a regex character class
-#   is not modeled) — add an explicit noqa if a line is still misread.
+#   a heuristic, not a full lexer (e.g. a '/' inside a regex character class,
+#   or a '!'/'++'/'--' immediately before a real division, is not modeled) —
+#   add an explicit noqa if a line is still misread.
+#
+# ts ATTRIBUTE quotes (#14051 review round 3, finding 1): a '"' immediately
+# preceded by '=' with NO space (`@click="console.log(x)"`) is Vue/HTML
+# attribute-value syntax, not a JS string — a .vue <template> region, or a
+# Vue template embedded as a backtick string in a .stories.ts render(), both
+# hit this. Content is emitted VERBATIM (not stripped) up to the matching
+# quote, so the call inside stays visible. A JS assignment with normal
+# spacing (`x = "text"`, this codebase's Prettier convention) has a SPACE
+# before the quote and is unaffected; a compact `x="text"` with no space
+# would be misread as an attribute — same class of tradeoff as the
+# regex-vs-division heuristic above.
 
 BEGIN {
     punct = "([{,;:=&|!?+-*%^~<>"
@@ -37,10 +49,15 @@ BEGIN {
     n = length($0)
     out = ""
     in_str = 0; str_ch = ""
-    in_tmpl = 0; in_regex = 0
+    in_tmpl = 0; in_regex = 0; in_attr = 0; attr_ch = ""
     prev_sig = ""
     for (i = 1; i <= n; i++) {
         c = substr($0, i, 1)
+        if (in_attr) {
+            out = out c
+            if (c == attr_ch) in_attr = 0
+            continue
+        }
         if (in_str) {
             if (c == "\\") { i++; continue }
             if (c == str_ch) in_str = 0
@@ -55,6 +72,9 @@ BEGIN {
             if (c == "\\") { i++; continue }
             if (c == "/") { in_regex = 0; prev_sig = "/" }
             continue
+        }
+        if (lang == "ts" && (c == "\"" || c == sq) && i > 1 && substr($0, i - 1, 1) == "=") {
+            in_attr = 1; attr_ch = c; out = out c; continue
         }
         if (c == "\"" || c == sq) { in_str = 1; str_ch = c; continue }
         if (lang == "ts" && c == "`") { in_tmpl = 1; continue }

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-print-console
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-print-console
@@ -13,10 +13,20 @@
 # Intentional exceptions:
 # - Test files (*_test.py, *.spec.ts, *.e2e_test.*, *-test.js)
 # - debugUtils.ts, RumConsoleHelper.ts (logging infrastructure)
-# - Lines with "# noqa: print" or "// noqa: console" comments
+# - Lines with "# noqa: print" or "// noqa: console" comments — for a
+#   multi-line call this is recognised on the OPENING line ("print(") as well
+#   as any line up to the closing paren (#14051). Both placements are
+#   black-stable IF the call is written multi-line to begin with (the
+#   collapsed single-line form would exceed the 120-char limit, so black has
+#   no reason to touch it). What is NOT stable: manually collapsing a wrapped
+#   call onto one line just to attach the comment. If that collapsed line is
+#   still over 120 chars, `black` re-splits it right back — moving the
+#   suppression onto the new closing-paren line regardless of where you
+#   wrote it. Verified against the real doctor.py multi-line calls (#14051).
 # - ansible/ (deployed copies with doctest examples)
 #
 # Issue: #1082 - Pre-commit hooks not blocking print/console violations
+# Issue: #14051 - multi-line noqa recognition + changed-lines scoping (CI wrapper)
 #
 # Install: pre-commit install (uses .pre-commit-config.yaml)
 
@@ -28,6 +38,59 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/lib/_common.sh"
 
 VIOLATIONS=0
+
+# #14051: a multi-line call's `# noqa`/`// noqa` often sits on the
+# closing-paren line, not the line the call opened on — the line-by-line scan
+# below never looks past the line it matched on, so that suppression was
+# invisible and the file became uneditable by anyone who merely touched it.
+#
+# Net unmatched '(' on a single line: opens minus closes. Used to detect a
+# call left open at end-of-line and to track when it closes again.
+_paren_balance() {
+    local s="$1"
+    local opens closes
+    opens=$(printf '%s' "$s" | tr -cd '(' | wc -c)
+    closes=$(printf '%s' "$s" | tr -cd ')' | wc -c)
+    echo $((opens - closes))
+}
+
+# Bounded forward scan: a print(/console.*( call that reads as still-open at
+# the end of the matched line may close (and carry its noqa) several lines
+# later. Minimal by design, per the issue: track paren balance line by line
+# until it returns to zero, and accept a noqa found on ANY line in between —
+# not a full parser, just enough for the one shape (#14051) reports. Capped so
+# a genuinely unbalanced file (mismatched quotes defeating the strip, etc.)
+# fails closed instead of scanning to EOF.
+MULTILINE_NOQA_SCAN_LIMIT=20
+
+# Args: <array-name> <next-line-index> <first-line-text> <noqa-regex>
+# array-name holds the whole file, 0-indexed; next-line-index is where to
+# resume scanning (the line after the one that matched).
+suppressed_in_multiline_call() {
+    local -n _lines_ref="$1"
+    local next_idx="$2"
+    local first_line="$3"
+    local noqa_regex="$4"
+
+    local balance
+    balance=$(_paren_balance "$first_line")
+    [ "$balance" -le 0 ] && return 1  # closes on the same line — not multi-line
+
+    local scanned=0 j="$next_idx"
+    local total="${#_lines_ref[@]}"
+
+    while [ "$balance" -gt 0 ] && [ "$j" -lt "$total" ] && [ "$scanned" -lt "$MULTILINE_NOQA_SCAN_LIMIT" ]; do
+        local candidate="${_lines_ref[$j]}"
+        if printf '%s' "$candidate" | grep -qE "$noqa_regex"; then
+            return 0
+        fi
+        balance=$((balance + $(_paren_balance "$candidate")))
+        j=$((j + 1))
+        scanned=$((scanned + 1))
+    done
+
+    return 1
+}
 
 # Get Python files to scan (production code only).
 # Uses get_staged_files (#7185) for the staged-files lookup with positional-args
@@ -58,10 +121,15 @@ get_staged_ts_files() {
 # Check a Python file for print() calls
 check_python_print() {
     local file="$1"
-    local line_num=0
+    local -a lines
+    mapfile -t lines < "$file"
+    local total="${#lines[@]}"
+    local idx=0
 
-    while IFS= read -r line; do
-        ((line_num++))
+    while [ "$idx" -lt "$total" ]; do
+        local line="${lines[$idx]}"
+        local line_num=$((idx + 1))
+        idx=$((idx + 1))
 
         # Skip empty lines
         [[ -z "$line" ]] && continue
@@ -85,20 +153,31 @@ check_python_print() {
 
         # Match actual print( calls — word boundary before print
         if printf '%s' "$stripped" | grep -qE '(^|[^a-zA-Z0-9_.])print\s*\('; then
+            # #14051: the call may still be open at end-of-line (multi-line
+            # args) — check forward lines up to the closing paren for a noqa
+            # before reporting.
+            if suppressed_in_multiline_call lines "$idx" "$stripped" '# noqa(: print)?($| )'; then
+                continue
+            fi
             echo -e "  ${RED}VIOLATION${NC} ${file}:${line_num}"
             echo "    ${line:0:100}"
             ((VIOLATIONS++))
         fi
-    done < "$file"
+    done
 }
 
 # Check a TypeScript/Vue file for console.* calls
 check_ts_console() {
     local file="$1"
-    local line_num=0
+    local -a lines
+    mapfile -t lines < "$file"
+    local total="${#lines[@]}"
+    local idx=0
 
-    while IFS= read -r line; do
-        ((line_num++))
+    while [ "$idx" -lt "$total" ]; do
+        local line="${lines[$idx]}"
+        local line_num=$((idx + 1))
+        idx=$((idx + 1))
 
         # Skip empty lines
         [[ -z "$line" ]] && continue
@@ -114,11 +193,15 @@ check_ts_console() {
 
         # Match console.log/warn/error/debug/info calls
         if echo "$line" | grep -qE 'console\.(log|warn|error|debug|info)\s*\('; then
+            # #14051: same multi-line-suppression gap as Python print().
+            if suppressed_in_multiline_call lines "$idx" "$line" 'noqa: console'; then
+                continue
+            fi
             echo -e "  ${RED}VIOLATION${NC} ${file}:${line_num}"
             echo "    ${line:0:100}"
             ((VIOLATIONS++))
         fi
-    done < "$file"
+    done
 }
 
 main() {

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-print-console
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-print-console
@@ -14,15 +14,28 @@
 # - Test files (*_test.py, *.spec.ts, *.e2e_test.*, *-test.js)
 # - debugUtils.ts, RumConsoleHelper.ts (logging infrastructure)
 # - Lines with "# noqa: print" or "// noqa: console" comments — for a
-#   multi-line call this is recognised on the OPENING line ("print(") as well
-#   as any line up to the closing paren (#14051). Both placements are
-#   black-stable IF the call is written multi-line to begin with (the
-#   collapsed single-line form would exceed the 120-char limit, so black has
-#   no reason to touch it). What is NOT stable: manually collapsing a wrapped
-#   call onto one line just to attach the comment. If that collapsed line is
-#   still over 120 chars, `black` re-splits it right back — moving the
-#   suppression onto the new closing-paren line regardless of where you
-#   wrote it. Verified against the real doctor.py multi-line calls (#14051).
+#   multi-line call this is recognised on any line from the opening
+#   "print("/"console.*(" through its closing paren (#14051). Every
+#   candidate line is normalized first via lib/strip-significant.awk —
+#   string/template/regex-literal BODIES and (for balance tracking) the
+#   trailing comment are stripped, so punctuation living inside a string
+#   argument or a comment cannot masquerade as call structure or as a
+#   suppression (#14051 review round 2: the original scan compared a
+#   stripped opening line against RAW candidate lines, which a comment's or
+#   a regex literal's stray '(' — or a noqa-shaped string of characters
+#   inside a string argument — could fool).
+#   Both opening- and closing-line placement are black-stable for a call
+#   that is genuinely multi-line (its collapsed single-line form would
+#   exceed the 120-char limit, so black has no reason to touch it). What is
+#   NOT stable: manually collapsing a wrapped call onto one line just to
+#   attach the comment — if that collapsed line is still over 120 chars,
+#   `black` re-splits it right back onto the closing-paren line regardless
+#   of where the comment started.
+#   Note: the doctor.py calls that motivated #14051 all carry their noqa on
+#   the OPENING line, which the pre-#14051 hook already honoured — the CI
+#   failure there was the *unscoped* wrapper blaming a PR for pre-existing
+#   violations elsewhere in the file, fixed by --changed-lines-only, not by
+#   this recognition change.
 # - ansible/ (deployed copies with doctest examples)
 #
 # Issue: #1082 - Pre-commit hooks not blocking print/console violations
@@ -39,13 +52,22 @@ source "$SCRIPT_DIR/lib/_common.sh"
 
 VIOLATIONS=0
 
-# #14051: a multi-line call's `# noqa`/`// noqa` often sits on the
-# closing-paren line, not the line the call opened on — the line-by-line scan
-# below never looks past the line it matched on, so that suppression was
-# invisible and the file became uneditable by anyone who merely touched it.
-#
-# Net unmatched '(' on a single line: opens minus closes. Used to detect a
-# call left open at end-of-line and to track when it closes again.
+# Normalize a line via lib/strip-significant.awk — see that file for the
+# per-language rules and the keep_comment contract. `sq` is passed in rather
+# than embedded so this invocation never has to quote a literal single quote.
+_strip_significant() {
+    local lang="$1" keep_comment="$2" line="$3"
+    awk -v lang="$lang" -v keep_comment="$keep_comment" -v sq="'" \
+        -f "$SCRIPT_DIR/lib/strip-significant.awk" <<< "$line"
+}
+
+_strip_py_for_balance() { _strip_significant py 0 "$1"; }
+_strip_py_for_noqa()    { _strip_significant py 1 "$1"; }
+_strip_ts_for_balance() { _strip_significant ts 0 "$1"; }
+_strip_ts_for_noqa()    { _strip_significant ts 1 "$1"; }
+
+# Net unmatched '(' on an already-normalized line: opens minus closes. Used to
+# detect a call left open at end-of-line and to track when it closes again.
 _paren_balance() {
     local s="$1"
     local opens closes
@@ -56,40 +78,62 @@ _paren_balance() {
 
 # Bounded forward scan: a print(/console.*( call that reads as still-open at
 # the end of the matched line may close (and carry its noqa) several lines
-# later. Minimal by design, per the issue: track paren balance line by line
-# until it returns to zero, and accept a noqa found on ANY line in between —
-# not a full parser, just enough for the one shape (#14051) reports. Capped so
-# a genuinely unbalanced file (mismatched quotes defeating the strip, etc.)
-# fails closed instead of scanning to EOF.
+# later. Balance is tracked on NORMALIZED text so a comment's or a regex
+# literal's stray '(' cannot hold the window open past the real closing
+# paren (#14051 review round 2). Stops at the first line where balance
+# returns to zero — never accepts a suppression past where the call actually
+# closes — and is capped so a line the strip still can't balance (should not
+# happen post-fix, kept as a fail-closed backstop) doesn't scan to EOF.
+#
+# Populates LAST_CALL_CLOSE_LINE (1-based, out-parameter): the line the
+# suppression was found on, the line the call's parens actually balanced on,
+# or the matched line itself if neither happened — used by the caller to
+# report a line RANGE for multi-line violations. Without the range, deleting
+# a closing-line noqa left the CI wrapper's added-line scoping blind to it,
+# since the reported (opening) line never changed (#14051 review finding 4).
 MULTILINE_NOQA_SCAN_LIMIT=20
+LAST_CALL_CLOSE_LINE=0
 
-# Args: <array-name> <next-line-index> <first-line-text> <noqa-regex>
-# array-name holds the whole file, 0-indexed; next-line-index is where to
-# resume scanning (the line after the one that matched).
+# Args: <array-name> <next-idx> <first-line-raw> <noqa-regex> <match-line-num>
+#       <balance-strip-fn> <noqa-strip-fn>
 suppressed_in_multiline_call() {
     local -n _lines_ref="$1"
-    local next_idx="$2"
-    local first_line="$3"
-    local noqa_regex="$4"
+    local next_idx="$2" first_line="$3" noqa_regex="$4" match_line_num="$5"
+    local balance_fn="$6" noqa_fn="$7"
 
+    LAST_CALL_CLOSE_LINE="$match_line_num"
     local balance
-    balance=$(_paren_balance "$first_line")
+    balance=$(_paren_balance "$("$balance_fn" "$first_line")")
     [ "$balance" -le 0 ] && return 1  # closes on the same line — not multi-line
 
-    local scanned=0 j="$next_idx"
-    local total="${#_lines_ref[@]}"
-
+    local scanned=0 j="$next_idx" total="${#_lines_ref[@]}"
     while [ "$balance" -gt 0 ] && [ "$j" -lt "$total" ] && [ "$scanned" -lt "$MULTILINE_NOQA_SCAN_LIMIT" ]; do
-        local candidate="${_lines_ref[$j]}"
-        if printf '%s' "$candidate" | grep -qE "$noqa_regex"; then
+        local candidate="${_lines_ref[$j]}" candidate_line=$((j + 1))
+        if "$noqa_fn" "$candidate" | grep -qE "$noqa_regex"; then
+            LAST_CALL_CLOSE_LINE="$candidate_line"
             return 0
         fi
-        balance=$((balance + $(_paren_balance "$candidate")))
+        balance=$((balance + $(_paren_balance "$("$balance_fn" "$candidate")")))
+        [ "$balance" -le 0 ] && LAST_CALL_CLOSE_LINE="$candidate_line"
         j=$((j + 1))
         scanned=$((scanned + 1))
     done
 
     return 1
+}
+
+# Report a VIOLATION, as a line RANGE when the call spans more than one line
+# (#14051 review finding 4) so the CI wrapper's --changed-lines-only key
+# comparison covers every line the suppression could live on.
+report_violation() {
+    local file="$1" line_num="$2" close_line="$3" code="$4"
+    if [ "$close_line" -gt "$line_num" ]; then
+        echo -e "  ${RED}VIOLATION${NC} ${file}:${line_num}-${close_line}"
+    else
+        echo -e "  ${RED}VIOLATION${NC} ${file}:${line_num}"
+    fi
+    echo "    ${code:0:100}"
+    ((VIOLATIONS++))
 }
 
 # Get Python files to scan (production code only).
@@ -118,90 +162,55 @@ get_staged_ts_files() {
         grep -v -E '(autobot-browser-worker/)' || true  # Node.js server: console.* is appropriate
 }
 
-# Check a Python file for print() calls
-check_python_print() {
-    local file="$1"
+# Shared driver: both languages are "read file, walk lines, skip the
+# language's own comment/doc-comment lines, match the call on a normalized
+# line, resolve any multi-line suppression, report" — only the regexes and
+# strip functions differ (#14051 review finding 6: check_python_print and
+# check_ts_console had grown past the ≤30-line convention by duplicating
+# this exact shape).
+# Args: <file> <skip-regex> <match-regex> <noqa-regex> <balance-fn> <noqa-fn>
+_scan_file_for_calls() {
+    local file="$1" skip_regex="$2" match_regex="$3" noqa_regex="$4"
+    local balance_fn="$5" noqa_fn="$6"
     local -a lines
     mapfile -t lines < "$file"
-    local total="${#lines[@]}"
-    local idx=0
+    local total="${#lines[@]}" idx=0
 
     while [ "$idx" -lt "$total" ]; do
-        local line="${lines[$idx]}"
-        local line_num=$((idx + 1))
+        local line="${lines[$idx]}" line_num=$((idx + 1))
         idx=$((idx + 1))
-
-        # Skip empty lines
         [[ -z "$line" ]] && continue
+        [[ "$line" =~ $skip_regex ]] && continue
 
-        # Skip comments
-        [[ "$line" =~ ^[[:space:]]*# ]] && continue
+        # Strings (TS also: templates/regex bodies) stripped — a noqa or a
+        # call MENTIONED inside one must not count (#14051 findings 1/2) —
+        # comment kept; also what the call match below runs against.
+        local sig
+        sig=$("$noqa_fn" "$line")
+        printf '%s' "$sig" | grep -qE "$noqa_regex" && continue
 
-        # Skip noqa exemption (specific "noqa: print" or bare "noqa" suppressing all rules)
-        echo "$line" | grep -qE '# noqa(: print)?($| )' && continue
-
-        # Strip quoted spans BEFORE matching (#13880). The comment below used to
-        # claim string definitions were skipped, but a word boundary alone does
-        # not do that: `"... e.g. \`print(json.dumps(x))\` ..."` inside a prompt
-        # or docstring was reported as a logging violation. Removing "..." and
-        # '...' spans first keeps real calls (`print("hi")` -> `print()`, still
-        # matched) while dropping mentions (`log.info("use print(x)")` ->
-        # `log.info()`, no longer matched).
-        # Known limitation: line-based, so a print( inside a TRIPLE-quoted block
-        # spanning lines is still reported. Add `# noqa: print` there.
-        stripped=$(printf '%s' "$line" | sed 's/"[^"]*"//g; s/'"'"'[^'"'"']*'"'"'//g')
-
-        # Match actual print( calls — word boundary before print
-        if printf '%s' "$stripped" | grep -qE '(^|[^a-zA-Z0-9_.])print\s*\('; then
-            # #14051: the call may still be open at end-of-line (multi-line
-            # args) — check forward lines up to the closing paren for a noqa
-            # before reporting.
-            if suppressed_in_multiline_call lines "$idx" "$stripped" '# noqa(: print)?($| )'; then
+        if printf '%s' "$sig" | grep -qE "$match_regex"; then
+            if suppressed_in_multiline_call lines "$idx" "$line" "$noqa_regex" \
+                "$line_num" "$balance_fn" "$noqa_fn"; then
                 continue
             fi
-            echo -e "  ${RED}VIOLATION${NC} ${file}:${line_num}"
-            echo "    ${line:0:100}"
-            ((VIOLATIONS++))
+            report_violation "$file" "$line_num" "$LAST_CALL_CLOSE_LINE" "$line"
         fi
     done
 }
 
+# Check a Python file for print() calls
+check_python_print() {
+    _scan_file_for_calls "$1" '^[[:space:]]*#' \
+        '(^|[^a-zA-Z0-9_.])print\s*\(' '# noqa(: print)?($| )' \
+        _strip_py_for_balance _strip_py_for_noqa
+}
+
 # Check a TypeScript/Vue file for console.* calls
 check_ts_console() {
-    local file="$1"
-    local -a lines
-    mapfile -t lines < "$file"
-    local total="${#lines[@]}"
-    local idx=0
-
-    while [ "$idx" -lt "$total" ]; do
-        local line="${lines[$idx]}"
-        local line_num=$((idx + 1))
-        idx=$((idx + 1))
-
-        # Skip empty lines
-        [[ -z "$line" ]] && continue
-
-        # Skip comments (single-line)
-        [[ "$line" =~ ^[[:space:]]*//.* ]] && continue
-
-        # Skip noqa exemption
-        echo "$line" | grep -q 'noqa: console' && continue
-
-        # Skip lines inside JSDoc/multiline comments (starts with *)
-        [[ "$line" =~ ^[[:space:]]*\* ]] && continue
-
-        # Match console.log/warn/error/debug/info calls
-        if echo "$line" | grep -qE 'console\.(log|warn|error|debug|info)\s*\('; then
-            # #14051: same multi-line-suppression gap as Python print().
-            if suppressed_in_multiline_call lines "$idx" "$line" 'noqa: console'; then
-                continue
-            fi
-            echo -e "  ${RED}VIOLATION${NC} ${file}:${line_num}"
-            echo "    ${line:0:100}"
-            ((VIOLATIONS++))
-        fi
-    done
+    _scan_file_for_calls "$1" '^[[:space:]]*(//.*|\*)' \
+        'console\.(log|warn|error|debug|info)\s*\(' 'noqa: console' \
+        _strip_ts_for_balance _strip_ts_for_noqa
 }
 
 main() {

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-print-console
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-print-console
@@ -55,10 +55,32 @@ VIOLATIONS=0
 # Normalize a line via lib/strip-significant.awk — see that file for the
 # per-language rules and the keep_comment contract. `sq` is passed in rather
 # than embedded so this invocation never has to quote a literal single quote.
+# Deliberately does NOT try to `exit` here on awk failure: every call site
+# captures this function's output via command substitution, which runs it in
+# a SUBSHELL — an exit inside would only end that subshell, silently
+# returning empty output to the caller instead of the intended hard stop.
+# The actual enforcement is _self_test_strip_significant below.
 _strip_significant() {
     local lang="$1" keep_comment="$2" line="$3"
     awk -v lang="$lang" -v keep_comment="$keep_comment" -v sq="'" \
         -f "$SCRIPT_DIR/lib/strip-significant.awk" <<< "$line"
+}
+
+# One-shot startup check (#14051 review round 3, finding 4): a missing or
+# unparseable strip-significant.awk must not read as "line is empty, nothing
+# matches" — a silent fail-OPEN that would make every check pass. Runs
+# directly from main() (not subshelled), so its own `exit 2` on failure
+# actually terminates the script — unlike a failure inside _strip_significant
+# itself, see above. Covers the case reproduced in review: the lib file
+# missing or containing invalid awk, both persistent for the whole run.
+_self_test_strip_significant() {
+    local result
+    result=$(_strip_significant py 1 'print("x")')
+    if [ "$result" != 'print()' ]; then
+        echo "FATAL: strip-significant.awk self-test failed (got: '${result}')." >&2
+        echo "  Check that lib/strip-significant.awk exists and is parseable by awk." >&2
+        exit 2
+    fi
 }
 
 _strip_py_for_balance() { _strip_significant py 0 "$1"; }
@@ -78,19 +100,26 @@ _paren_balance() {
 
 # Bounded forward scan: a print(/console.*( call that reads as still-open at
 # the end of the matched line may close (and carry its noqa) several lines
-# later. Balance is tracked on NORMALIZED text so a comment's or a regex
-# literal's stray '(' cannot hold the window open past the real closing
-# paren (#14051 review round 2). Stops at the first line where balance
-# returns to zero — never accepts a suppression past where the call actually
-# closes — and is capped so a line the strip still can't balance (should not
-# happen post-fix, kept as a fail-closed backstop) doesn't scan to EOF.
+# later. A suppression is accepted ONLY on a line where the running balance
+# actually reaches zero on THAT line — i.e. only the call's true closing
+# line, matching the "opening line or closing-paren line" contract in this
+# file's header comment (#14051 review round 3, finding 3: a noqa found on
+# an INTERMEDIATE line — one the call is still open past, even if a
+# tokenizer gap misjudged that — must never suppress; this is a second,
+# independent layer under the normalization fix, not a replacement for it —
+# a Python triple-quoted argument or a TS '!'/'++'/'--' before a division
+# can still fool the balance count, but can no longer reach an unrelated
+# noqa several lines down, because no line's noqa is even inspected until
+# the call is confirmed closed).
 #
-# Populates LAST_CALL_CLOSE_LINE (1-based, out-parameter): the line the
-# suppression was found on, the line the call's parens actually balanced on,
-# or the matched line itself if neither happened — used by the caller to
-# report a line RANGE for multi-line violations. Without the range, deleting
-# a closing-line noqa left the CI wrapper's added-line scoping blind to it,
-# since the reported (opening) line never changed (#14051 review finding 4).
+# Populates LAST_CALL_CLOSE_LINE (1-based, out-parameter): the line the call
+# closed and was found suppressed on. If the scan exits WITHOUT the balance
+# ever reaching zero (bound hit, or EOF), it is set to the LAST line
+# actually scanned — not left at the opening line — so the caller reports a
+# too-WIDE range rather than a too-NARROW one. A single-line (opening-line)
+# key there was invisible to the CI wrapper's added-line scoping when only
+# the true closing line was edited (#14051 review finding 4 — round 1's
+# fix for this collapsed back to a single line exactly on this path).
 MULTILINE_NOQA_SCAN_LIMIT=20
 LAST_CALL_CLOSE_LINE=0
 
@@ -109,16 +138,16 @@ suppressed_in_multiline_call() {
     local scanned=0 j="$next_idx" total="${#_lines_ref[@]}"
     while [ "$balance" -gt 0 ] && [ "$j" -lt "$total" ] && [ "$scanned" -lt "$MULTILINE_NOQA_SCAN_LIMIT" ]; do
         local candidate="${_lines_ref[$j]}" candidate_line=$((j + 1))
-        if "$noqa_fn" "$candidate" | grep -qE "$noqa_regex"; then
-            LAST_CALL_CLOSE_LINE="$candidate_line"
-            return 0
-        fi
         balance=$((balance + $(_paren_balance "$("$balance_fn" "$candidate")")))
-        [ "$balance" -le 0 ] && LAST_CALL_CLOSE_LINE="$candidate_line"
+        if [ "$balance" -le 0 ]; then
+            LAST_CALL_CLOSE_LINE="$candidate_line"
+            "$noqa_fn" "$candidate" | grep -qE "$noqa_regex" && return 0
+        fi
         j=$((j + 1))
         scanned=$((scanned + 1))
     done
 
+    [ "$balance" -gt 0 ] && LAST_CALL_CLOSE_LINE="$j"
     return 1
 }
 
@@ -214,6 +243,8 @@ check_ts_console() {
 }
 
 main() {
+    _self_test_strip_significant
+
     echo -e "${BOLD}${CYAN}Pre-commit: No print()/console.* in Production Code${NC}"
     echo "Issue #1082 - Logging Standard Enforcement"
     echo "================================================"

--- a/pipeline-scripts/check-pre-commit-hook-pr.sh
+++ b/pipeline-scripts/check-pre-commit-hook-pr.sh
@@ -277,6 +277,23 @@ else
             else               { supp_text = supp_text block; suppressed++ }
             block = ""; keep = 1; is_violation = 0
         }
+        # A key is "path:N" or "path:N-M" (#14051): a hook may report a
+        # multi-line construct as the range it spans, since the ONE line it
+        # picks to report on can go untouched while a line elsewhere in
+        # the range changes — e.g. deleting a closing-paren noqa touches
+        # only that line, not the opening line the print/console guard
+        # reports at. A single reported line would make that edit invisible
+        # to this scope check. For a range, kept if ANY line in it was added.
+        function key_is_added(key,    spec, path, rng, s, e, i) {
+            match(key, /:[0-9]+(-[0-9]+)?$/)
+            spec = substr(key, RSTART + 1, RLENGTH - 1)
+            path = substr(key, 1, RSTART - 1)
+            if (spec !~ /-/) return (path ":" spec) in added
+            split(spec, rng, "-")
+            s = rng[1] + 0; e = rng[2] + 0
+            for (i = s; i <= e; i++) if ((path ":" i) in added) return 1
+            return 0
+        }
         BEGIN {
             split(ENVIRON["ADDED"], a, "\n")
             for (i in a) if (a[i] != "") added[a[i]] = 1
@@ -293,9 +310,9 @@ else
                 flush_block()
                 seen_header++
                 is_violation = 1
-                match(plain, /[^[:space:]]+:[0-9]+/)
+                match(plain, /[^[:space:]]+:[0-9]+(-[0-9]+)?/)
                 key = substr(plain, RSTART, RLENGTH)
-                keep = (key in added) ? 1 : 0
+                keep = key_is_added(key) ? 1 : 0
             }
             block = block $0 "\n"
             if (plain ~ /^[[:space:]]*$/) flush_block()

--- a/pipeline-scripts/check-pre-commit-hook-pr_test.py
+++ b/pipeline-scripts/check-pre-commit-hook-pr_test.py
@@ -25,6 +25,9 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 WRAPPER = REPO_ROOT / "pipeline-scripts" / "check-pre-commit-hook-pr.sh"
+NO_PRINT_CONSOLE_HOOK = (
+    REPO_ROOT / "autobot-infrastructure" / "shared" / "scripts" / "hooks" / "pre-commit-no-print-console"
+)
 
 
 def _make_pr(tmp_path: Path, files: dict[str, str]) -> tuple[str, str]:
@@ -361,5 +364,165 @@ class TestChangedLinesOnly:
         head = _commit_pr(tmp_path)
 
         result = _run_wrapper(tmp_path, "pre-commit-hardcoded-values", base, head)
+
+        assert result.returncode == 1
+
+
+# #14051: a multi-line print()/console.*() call's suppression comment can sit
+# on the closing-paren line, several lines below where the guard matches.
+_MULTILINE_NOQA_OPEN = (
+    "def f():\n"
+    "    print(  # noqa: print\n"
+    '        "a long message that lives on its own line inside the call"\n'
+    "    )\n"
+)
+_MULTILINE_NOQA_CLOSE = (
+    "def f():\n"
+    "    print(\n"
+    '        "a long message that lives on its own line inside the call"\n'
+    "    )  # noqa: print\n"
+)
+_MULTILINE_NO_NOQA = (
+    "def f():\n" "    print(\n" '        "a long message that lives on its own line inside the call"\n' "    )\n"
+)
+_SINGLELINE_NO_NOQA = 'print("still a violation")\n'
+
+
+@pytest.mark.skipif(not NO_PRINT_CONSOLE_HOOK.exists(), reason="hook script not found")
+class TestMultilineNoqaRecognition:
+    """The hook's own multi-line scan (#14051), invoked directly (argv mode).
+
+    Independent of --changed-lines-only: this is about the hook understanding
+    a suppression that isn't on the line it matched on, whole-file or scoped.
+    """
+
+    # Filenames passed as RELATIVE paths, cwd=tmp_path: the hook's own
+    # `test_.*\.py$` exclusion matches anywhere in the string it is given, and
+    # pytest's own tmp_path is named e.g. "test_noqa_on_opening_line0" — an
+    # absolute path would silently fall into that exclusion and report exit 0
+    # for "filtered out as a test file", indistinguishable from "recognised".
+    # Caught by the mutation check (#14051 workflow step 7): two tests here
+    # first passed with the fix REMOVED, because they were filtered, not
+    # exercised.
+
+    def test_noqa_on_opening_line_is_recognised(self, tmp_path: Path) -> None:
+        (tmp_path / "m.py").write_text(_MULTILINE_NOQA_OPEN, encoding="utf-8")
+        result = subprocess.run(
+            ["bash", str(NO_PRINT_CONSOLE_HOOK), "m.py"], cwd=tmp_path, capture_output=True, text=True
+        )
+        assert result.returncode == 0, result.stdout
+        assert "No production files staged" not in result.stdout, "file was filtered, not scanned"
+
+    def test_noqa_on_closing_paren_line_is_recognised(self, tmp_path: Path) -> None:
+        """The exact shape from PR #14046: the comment sat on the `)` line."""
+        (tmp_path / "m.py").write_text(_MULTILINE_NOQA_CLOSE, encoding="utf-8")
+        result = subprocess.run(
+            ["bash", str(NO_PRINT_CONSOLE_HOOK), "m.py"], cwd=tmp_path, capture_output=True, text=True
+        )
+        assert result.returncode == 0, result.stdout
+        assert "No production files staged" not in result.stdout, "file was filtered, not scanned"
+
+    def test_multiline_call_with_no_noqa_anywhere_still_fails(self, tmp_path: Path) -> None:
+        """The scan must not become so permissive it stops catching real calls."""
+        (tmp_path / "m.py").write_text(_MULTILINE_NO_NOQA, encoding="utf-8")
+        result = subprocess.run(
+            ["bash", str(NO_PRINT_CONSOLE_HOOK), "m.py"], cwd=tmp_path, capture_output=True, text=True
+        )
+        assert result.returncode == 1, result.stdout
+
+    def test_singleline_call_with_no_noqa_still_fails(self, tmp_path: Path) -> None:
+        """Regression guard: the single-line path must be untouched by the scan."""
+        (tmp_path / "m.py").write_text(_SINGLELINE_NO_NOQA, encoding="utf-8")
+        result = subprocess.run(
+            ["bash", str(NO_PRINT_CONSOLE_HOOK), "m.py"], cwd=tmp_path, capture_output=True, text=True
+        )
+        assert result.returncode == 1, result.stdout
+
+    def test_multiline_console_noqa_on_closing_line_is_recognised(self, tmp_path: Path) -> None:
+        """Same gap, TypeScript side: `console.*(` can wrap across lines too."""
+        (tmp_path / "m.ts").write_text(
+            "function f() {\n"
+            "  console.log(\n"
+            '    "a long message that lives on its own line inside the call"\n'
+            "  );  // noqa: console\n"
+            "}\n",
+            encoding="utf-8",
+        )
+        result = subprocess.run(
+            ["bash", str(NO_PRINT_CONSOLE_HOOK), "m.ts"], cwd=tmp_path, capture_output=True, text=True
+        )
+        assert result.returncode == 0, result.stdout
+        assert "No production files staged" not in result.stdout, "file was filtered, not scanned"
+
+
+@pytest.mark.skipif(not WRAPPER.exists(), reason="wrapper script not found")
+class TestChangedLinesOnlyPrintConsole:
+    """#14051 fix (2): the same --changed-lines-only scoping #13950 gave the
+    hardcoded-values guard, applied to pre-commit-no-print-console.
+
+    This is what actually made autobot-backend/cli/doctor.py editable again:
+    PR #14046 changed a function signature, added zero prints, and still hit
+    three violations because the file had pre-existing (suppressed, but
+    invisible to the unscoped guard) print() calls elsewhere in it.
+    """
+
+    def test_a_pre_existing_violation_in_a_touched_file_does_not_fail(self, tmp_path: Path) -> None:
+        base, _ = _amend_pr(tmp_path, {"m.py": _SINGLELINE_NO_NOQA})
+        (tmp_path / "m.py").write_text(_SINGLELINE_NO_NOQA + "x = 1\n", encoding="utf-8")
+        head = _commit_pr(tmp_path)
+
+        result = _run_scoped(tmp_path, "pre-commit-no-print-console", base, head)
+
+        assert result.returncode == 0, f"pre-existing violation failed the build:\n{result.stdout}"
+        assert "did not touch" in result.stdout
+
+    def test_a_violation_the_pr_adds_still_fails(self, tmp_path: Path) -> None:
+        """The property that must survive: this is a scope change, not an off switch."""
+        base, _ = _amend_pr(tmp_path, {"m.py": "x = 1\n"})
+        (tmp_path / "m.py").write_text("x = 1\n" + _SINGLELINE_NO_NOQA, encoding="utf-8")
+        head = _commit_pr(tmp_path)
+
+        result = _run_scoped(tmp_path, "pre-commit-no-print-console", base, head)
+
+        assert result.returncode == 1, f"a newly added violation passed:\n{result.stdout}"
+        assert "lines this PR added" in result.stdout
+
+    def test_a_newly_added_multiline_violation_still_fails(self, tmp_path: Path) -> None:
+        """Combines both #14051 fixes: scoping must not let a NEW multi-line,
+        unsuppressed call slip through just because it spans several lines."""
+        base, _ = _amend_pr(tmp_path, {"m.py": "x = 1\n"})
+        (tmp_path / "m.py").write_text("x = 1\n" + _MULTILINE_NO_NOQA, encoding="utf-8")
+        head = _commit_pr(tmp_path)
+
+        result = _run_scoped(tmp_path, "pre-commit-no-print-console", base, head)
+
+        assert result.returncode == 1, f"a newly added multi-line violation passed:\n{result.stdout}"
+
+    def test_a_newly_added_multiline_call_with_noqa_on_closing_line_passes(self, tmp_path: Path) -> None:
+        """The PR #14046 shape, reproduced end-to-end through the CI wrapper."""
+        base, _ = _amend_pr(tmp_path, {"m.py": "x = 1\n"})
+        (tmp_path / "m.py").write_text("x = 1\n" + _MULTILINE_NOQA_CLOSE, encoding="utf-8")
+        head = _commit_pr(tmp_path)
+
+        result = _run_scoped(tmp_path, "pre-commit-no-print-console", base, head)
+
+        assert result.returncode == 0, result.stdout
+
+    def test_a_clean_pr_stays_clean(self, tmp_path: Path) -> None:
+        base, _ = _amend_pr(tmp_path, {"m.py": "x = 1\n"})
+        (tmp_path / "m.py").write_text("x = 1\ny = 2\n", encoding="utf-8")
+        head = _commit_pr(tmp_path)
+
+        result = _run_scoped(tmp_path, "pre-commit-no-print-console", base, head)
+
+        assert result.returncode == 0
+
+    def test_the_default_mode_is_unchanged(self, tmp_path: Path) -> None:
+        """Without the flag, a pre-existing violation still fails whole-file."""
+        base, _ = _amend_pr(tmp_path, {"m.py": _SINGLELINE_NO_NOQA})
+        (tmp_path / "m.py").write_text(_SINGLELINE_NO_NOQA + "x = 1\n", encoding="utf-8")
+        head = _commit_pr(tmp_path)
+
+        result = _run_wrapper(tmp_path, "pre-commit-no-print-console", base, head)
 
         assert result.returncode == 1

--- a/pipeline-scripts/check-pre-commit-hook-pr_test.py
+++ b/pipeline-scripts/check-pre-commit-hook-pr_test.py
@@ -171,9 +171,7 @@ class TestPathspecIsNotShellExpanded:
         assert result.returncode != 0, "nested violation must still be caught"
 
     @pytest.mark.parametrize("bad_ext", [".py", " py", "py!", "p y"])
-    def test_malformed_ext_exits_2_rather_than_matching_nothing(
-        self, tmp_path: Path, bad_ext: str
-    ) -> None:
+    def test_malformed_ext_exits_2_rather_than_matching_nothing(self, tmp_path: Path, bad_ext: str) -> None:
         """A pathspec like `*..py` matches nothing and would read as 'clean'."""
         validator = tmp_path / "check_always_fail.py"
         validator.write_text("import sys; sys.exit(1)\n", encoding="utf-8")
@@ -279,9 +277,7 @@ def _amend_pr(tmp_path: Path, files: dict[str, str]) -> tuple[str, str]:
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(content, encoding="utf-8")
         subprocess.run(["git", "add", rel], cwd=tmp_path, check=True)
-    subprocess.run(
-        ["git", "-c", "commit.gpgsign=false", "commit", "-q", "-m", "base"], cwd=tmp_path, check=True
-    )
+    subprocess.run(["git", "-c", "commit.gpgsign=false", "commit", "-q", "-m", "base"], cwd=tmp_path, check=True)
     base = subprocess.run(
         ["git", "rev-parse", "HEAD"], cwd=tmp_path, capture_output=True, text=True, check=True
     ).stdout.strip()
@@ -290,9 +286,7 @@ def _amend_pr(tmp_path: Path, files: dict[str, str]) -> tuple[str, str]:
 
 def _commit_pr(tmp_path: Path) -> str:
     subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
-    subprocess.run(
-        ["git", "-c", "commit.gpgsign=false", "commit", "-q", "-m", "pr"], cwd=tmp_path, check=True
-    )
+    subprocess.run(["git", "-c", "commit.gpgsign=false", "commit", "-q", "-m", "pr"], cwd=tmp_path, check=True)
     return subprocess.run(
         ["git", "rev-parse", "HEAD"], cwd=tmp_path, capture_output=True, text=True, check=True
     ).stdout.strip()
@@ -388,6 +382,11 @@ _MULTILINE_NO_NOQA = (
 _SINGLELINE_NO_NOQA = 'print("still a violation")\n'
 
 
+def _run_hook(tmp_path: Path, filename: str) -> subprocess.CompletedProcess:
+    """Invoke the hook directly (argv mode) with a RELATIVE filename, cwd=tmp_path."""
+    return subprocess.run(["bash", str(NO_PRINT_CONSOLE_HOOK), filename], cwd=tmp_path, capture_output=True, text=True)
+
+
 @pytest.mark.skipif(not NO_PRINT_CONSOLE_HOOK.exists(), reason="hook script not found")
 class TestMultilineNoqaRecognition:
     """The hook's own multi-line scan (#14051), invoked directly (argv mode).
@@ -406,36 +405,35 @@ class TestMultilineNoqaRecognition:
     # exercised.
 
     def test_noqa_on_opening_line_is_recognised(self, tmp_path: Path) -> None:
+        """A REGRESSION guard, not forward-scan coverage: this shape is caught
+        by the pre-existing same-line check, and passes even with the
+        forward scan disabled entirely. See
+        test_noqa_on_closing_paren_line_is_recognised for a case that
+        actually exercises the scan."""
         (tmp_path / "m.py").write_text(_MULTILINE_NOQA_OPEN, encoding="utf-8")
-        result = subprocess.run(
-            ["bash", str(NO_PRINT_CONSOLE_HOOK), "m.py"], cwd=tmp_path, capture_output=True, text=True
-        )
+        result = _run_hook(tmp_path, "m.py")
         assert result.returncode == 0, result.stdout
         assert "No production files staged" not in result.stdout, "file was filtered, not scanned"
 
     def test_noqa_on_closing_paren_line_is_recognised(self, tmp_path: Path) -> None:
-        """The exact shape from PR #14046: the comment sat on the `)` line."""
+        """The exact shape from PR #14046: the comment sat on the `)` line.
+        Genuinely exercises the forward scan — the opening line carries no
+        noqa at all."""
         (tmp_path / "m.py").write_text(_MULTILINE_NOQA_CLOSE, encoding="utf-8")
-        result = subprocess.run(
-            ["bash", str(NO_PRINT_CONSOLE_HOOK), "m.py"], cwd=tmp_path, capture_output=True, text=True
-        )
+        result = _run_hook(tmp_path, "m.py")
         assert result.returncode == 0, result.stdout
         assert "No production files staged" not in result.stdout, "file was filtered, not scanned"
 
     def test_multiline_call_with_no_noqa_anywhere_still_fails(self, tmp_path: Path) -> None:
         """The scan must not become so permissive it stops catching real calls."""
         (tmp_path / "m.py").write_text(_MULTILINE_NO_NOQA, encoding="utf-8")
-        result = subprocess.run(
-            ["bash", str(NO_PRINT_CONSOLE_HOOK), "m.py"], cwd=tmp_path, capture_output=True, text=True
-        )
+        result = _run_hook(tmp_path, "m.py")
         assert result.returncode == 1, result.stdout
 
     def test_singleline_call_with_no_noqa_still_fails(self, tmp_path: Path) -> None:
         """Regression guard: the single-line path must be untouched by the scan."""
         (tmp_path / "m.py").write_text(_SINGLELINE_NO_NOQA, encoding="utf-8")
-        result = subprocess.run(
-            ["bash", str(NO_PRINT_CONSOLE_HOOK), "m.py"], cwd=tmp_path, capture_output=True, text=True
-        )
+        result = _run_hook(tmp_path, "m.py")
         assert result.returncode == 1, result.stdout
 
     def test_multiline_console_noqa_on_closing_line_is_recognised(self, tmp_path: Path) -> None:
@@ -448,11 +446,80 @@ class TestMultilineNoqaRecognition:
             "}\n",
             encoding="utf-8",
         )
-        result = subprocess.run(
-            ["bash", str(NO_PRINT_CONSOLE_HOOK), "m.ts"], cwd=tmp_path, capture_output=True, text=True
-        )
+        result = _run_hook(tmp_path, "m.ts")
         assert result.returncode == 0, result.stdout
         assert "No production files staged" not in result.stdout, "file was filtered, not scanned"
+
+
+@pytest.mark.skipif(not NO_PRINT_CONSOLE_HOOK.exists(), reason="hook script not found")
+class TestMultilineScanDoesNotOverreach:
+    """#14051 code review round 2 (PR #14112): the forward scan seeded its
+    paren balance from a STRIPPED first line but then read RAW candidate
+    lines. Wherever raw parens diverged from real syntax — a trailing
+    comment's stray '(', a regex literal, a noqa-shaped string of characters
+    inside a string ARGUMENT — the window stayed open past the real closing
+    paren and could accept an unrelated noqa or hide a live violation. Every
+    case here failed (exit 0 — wrongly suppressed) against the hook at
+    63e957e2d and must fail (exit 1) here.
+    """
+
+    def test_unrelated_noqa_below_does_not_suppress_backtick_call(self, tmp_path: Path) -> None:
+        """A template literal's stray '(' held the scan window open long
+        enough to reach an unrelated noqa 19 lines down."""
+        lines = ["console.log(`fetching (${url}`);"] + [f"const a{i} = {i};" for i in range(18)]
+        lines.append('console.warn("x");  // noqa: console')
+        (tmp_path / "m.ts").write_text("\n".join(lines) + "\n", encoding="utf-8")
+        result = _run_hook(tmp_path, "m.ts")
+        assert result.returncode == 1, result.stdout
+
+    def test_unrelated_noqa_below_does_not_suppress_regex_literal_call(self, tmp_path: Path) -> None:
+        """A regex literal's parenthesis character is not call structure."""
+        (tmp_path / "m.ts").write_text(
+            'console.log(str.replace(/\\(/g, ""));\nconst a = 1;\nconsole.warn("x");  // noqa: console\n',
+            encoding="utf-8",
+        )
+        result = _run_hook(tmp_path, "m.ts")
+        assert result.returncode == 1, result.stdout
+
+    def test_noqa_substring_inside_ts_string_does_not_suppress(self, tmp_path: Path) -> None:
+        """A noqa MENTIONED in a string argument, on a line the forward scan
+        visits WHILE the call is still open, must not suppress it. A fake
+        noqa on a line that never enters the scan window (e.g. because the
+        call already closed, or a standalone line elsewhere) proves nothing
+        about this bug — it has to be a live forward-scan candidate."""
+        (tmp_path / "m.ts").write_text(
+            'console.log(\n  "a message",\n  "write // noqa: console to skip"\n);\n',
+            encoding="utf-8",
+        )
+        result = _run_hook(tmp_path, "m.ts")
+        assert result.returncode == 1, result.stdout
+
+    def test_noqa_inside_python_string_argument_does_not_suppress(self, tmp_path: Path) -> None:
+        """The exact shape the hook's own quick-fix message prints:
+        'add # noqa to suppress this rule' — as a STRING, not a comment."""
+        (tmp_path / "m.py").write_text('print(\n    "add # noqa to suppress this rule",\n)\n', encoding="utf-8")
+        result = _run_hook(tmp_path, "m.py")
+        assert result.returncode == 1, result.stdout
+
+    def test_trailing_comment_paren_does_not_open_scan_window(self, tmp_path: Path) -> None:
+        """A single-line call's own trailing comment must not be misread as
+        leaving the call open, reaching a `# noqa` on the next line down."""
+        (tmp_path / "m.py").write_text("print(x)  # emit the value (verbose mode\ny = g()  # noqa\n", encoding="utf-8")
+        result = _run_hook(tmp_path, "m.py")
+        assert result.returncode == 1, result.stdout
+
+    def test_escaped_quote_does_not_defeat_the_strip(self, tmp_path: Path) -> None:
+        (tmp_path / "m.py").write_text('print("say \\" ( hi")\ny = g()  # noqa\n', encoding="utf-8")
+        result = _run_hook(tmp_path, "m.py")
+        assert result.returncode == 1, result.stdout
+
+    def test_scan_bound_fails_closed(self, tmp_path: Path) -> None:
+        """A call that never resolves within the bound must still fail, not
+        read as suppressed just because the window ran out."""
+        lines = ["print("] + [f"    arg{i}," for i in range(25)] + [")  # noqa: print"]
+        (tmp_path / "m.py").write_text("\n".join(lines) + "\n", encoding="utf-8")
+        result = _run_hook(tmp_path, "m.py")
+        assert result.returncode == 1, result.stdout
 
 
 @pytest.mark.skipif(not WRAPPER.exists(), reason="wrapper script not found")
@@ -526,3 +593,28 @@ class TestChangedLinesOnlyPrintConsole:
         result = _run_wrapper(tmp_path, "pre-commit-no-print-console", base, head)
 
         assert result.returncode == 1
+
+    def test_deleting_a_closing_line_noqa_is_still_caught(self, tmp_path: Path) -> None:
+        """#14051 review round 2, finding 4: fix (1) lets a suppression live
+        on the CLOSING line; fix (2) scopes CI by the REPORTED line, which
+        the guard always put on the OPENING line. Combined, deleting a
+        closing-line noqa touched only that line — the diff hunk never
+        touches the opening line the guard reports at — so the scoped
+        wrapper read it as untouched and passed. The hook now reports a line
+        RANGE for multi-line violations so this diff hunk falls inside it."""
+        base, _ = _amend_pr(tmp_path, {"m.py": _MULTILINE_NOQA_CLOSE})
+        (tmp_path / "m.py").write_text(_MULTILINE_NO_NOQA, encoding="utf-8")
+        head = _commit_pr(tmp_path)
+
+        # Confirm the diff really is closing-line-only, or this test proves nothing.
+        diff = subprocess.run(
+            ["git", "diff", base, head, "--", "m.py"], cwd=tmp_path, capture_output=True, text=True, check=True
+        ).stdout
+        removed = [ln for ln in diff.splitlines() if ln.startswith("-") and not ln.startswith("---")]
+        added = [ln for ln in diff.splitlines() if ln.startswith("+") and not ln.startswith("+++")]
+        assert removed == ["-    )  # noqa: print"], f"expected exactly one removed (noqa) line:\n{diff}"
+        assert added == ["+    )"], f"expected exactly one added line:\n{diff}"
+
+        result = _run_scoped(tmp_path, "pre-commit-no-print-console", base, head)
+
+        assert result.returncode == 1, f"deleting a closing-line noqa was not caught:\n{result.stdout}"

--- a/pipeline-scripts/check-pre-commit-hook-pr_test.py
+++ b/pipeline-scripts/check-pre-commit-hook-pr_test.py
@@ -18,6 +18,7 @@ the wrapper with BASE_SHA/HEAD_SHA pointing at it.
 
 from __future__ import annotations
 
+import re
 import subprocess
 from pathlib import Path
 
@@ -458,9 +459,12 @@ class TestMultilineScanDoesNotOverreach:
     lines. Wherever raw parens diverged from real syntax — a trailing
     comment's stray '(', a regex literal, a noqa-shaped string of characters
     inside a string ARGUMENT — the window stayed open past the real closing
-    paren and could accept an unrelated noqa or hide a live violation. Every
-    case here failed (exit 0 — wrongly suppressed) against the hook at
-    63e957e2d and must fail (exit 1) here.
+    paren and could accept an unrelated noqa or hide a live violation. Most
+    cases here failed (exit 0 — wrongly suppressed) against the hook at
+    63e957e2d and must fail (exit 1) here. Exception:
+    test_scan_bound_fails_closed guards MULTILINE_NOQA_SCAN_LIMIT itself
+    (already correct in round 1, not a round-2 regression) — see its own
+    docstring.
     """
 
     def test_unrelated_noqa_below_does_not_suppress_backtick_call(self, tmp_path: Path) -> None:
@@ -515,10 +519,137 @@ class TestMultilineScanDoesNotOverreach:
 
     def test_scan_bound_fails_closed(self, tmp_path: Path) -> None:
         """A call that never resolves within the bound must still fail, not
-        read as suppressed just because the window ran out."""
+        read as suppressed just because the window ran out.
+
+        NOT a round-2 regression case, unlike its siblings in this class:
+        MULTILINE_NOQA_SCAN_LIMIT existed since round 1, and this property
+        already held against the hook at 63e957e2d. This test guards the
+        bound itself — it goes red if MULTILINE_NOQA_SCAN_LIMIT is raised
+        past 25 (verified by hand: raising it to 1000 flips this to a
+        false-suppressed exit 0), not against round 2's fixes."""
         lines = ["print("] + [f"    arg{i}," for i in range(25)] + [")  # noqa: print"]
         (tmp_path / "m.py").write_text("\n".join(lines) + "\n", encoding="utf-8")
         result = _run_hook(tmp_path, "m.py")
+        assert result.returncode == 1, result.stdout
+
+
+@pytest.mark.skipif(not NO_PRINT_CONSOLE_HOOK.exists(), reason="hook script not found")
+class TestVueAttributeQuotesAreNotStrings:
+    """#14051 code review round 3, finding 1: `"` inside a .vue <template> or
+    a Vue template embedded as a backtick string (a .stories.ts render())
+    delimits an HTML ATTRIBUTE, not a JS string. The generic tokenizer built
+    for TS/JS syntax was eating the whole attribute body, hiding a live
+    console.* call inside it — a regression against BASE (unscoped, no
+    stripping at all), which caught these. There was no .vue-shaped case in
+    the suite at all before this.
+    """
+
+    def test_inline_click_handler_in_vue_template(self, tmp_path: Path) -> None:
+        (tmp_path / "m.vue").write_text(
+            '<template>\n  <button @click="console.log(x)">Go</button>\n</template>\n', encoding="utf-8"
+        )
+        result = _run_hook(tmp_path, "m.vue")
+        assert result.returncode == 1, result.stdout
+
+    def test_inline_arrow_handler_in_vue_template(self, tmp_path: Path) -> None:
+        (tmp_path / "m.vue").write_text(
+            '<template>\n  <button :on="() => console.warn(1)">Go</button>\n</template>\n', encoding="utf-8"
+        )
+        result = _run_hook(tmp_path, "m.vue")
+        assert result.returncode == 1, result.stdout
+
+    def test_vue_template_embedded_as_backtick_string_in_stories_ts(self, tmp_path: Path) -> None:
+        """The exact real-code shape: autobot-frontend .../NpuWorkerPairConfirmDialog.stories.ts
+        carries this inside a `template: \\`...\\`` render() property."""
+        (tmp_path / "m.ts").write_text(
+            "const story = {\n"
+            "  render: () => ({\n"
+            "    template: `\n"
+            "      <Dialog @confirm=\"(p) => console.log('confirmed', p)\" />\n"
+            "    `,\n"
+            "  }),\n"
+            "};\n",
+            encoding="utf-8",
+        )
+        result = _run_hook(tmp_path, "m.ts")
+        assert result.returncode == 1, result.stdout
+
+    def test_normal_spaced_assignment_is_still_a_string_not_an_attribute(self, tmp_path: Path) -> None:
+        """Regression guard for the fix itself: `x = "text"` (this codebase's
+        Prettier convention — spaces around `=`) must NOT be misread as an
+        attribute, or finding 1/2's round-2 fixes (noqa hidden inside a
+        string) would be undone by the attribute heuristic."""
+        (tmp_path / "m.ts").write_text(
+            'const msg = "write // noqa: console to skip";\nconsole.log("live violation");\n',
+            encoding="utf-8",
+        )
+        result = _run_hook(tmp_path, "m.ts")
+        assert result.returncode == 1, result.stdout
+
+
+@pytest.mark.skipif(not NO_PRINT_CONSOLE_HOOK.exists(), reason="hook script not found")
+class TestUnresolvedBalanceReportsAWideRange:
+    """#14051 code review round 3, finding 2: when the forward scan exits
+    WITHOUT the balance ever reaching zero (bound hit, or a tokenizer gap —
+    e.g. Python's triple-quoted strings have no dedicated state, so a third
+    `"` re-opens a single-quoted span that runs to EOL), LAST_CALL_CLOSE_LINE
+    must widen to the last line actually scanned, not collapse back to the
+    opening line. A single-line key there reproduced round 1's finding 4
+    bypass through a different, narrower trigger.
+    """
+
+    def test_unresolved_triple_quote_reports_a_range_not_a_single_line(self, tmp_path: Path) -> None:
+        (tmp_path / "m.py").write_text('print("""\n    line 0\n    line 1\n""")\n', encoding="utf-8")
+        result = _run_hook(tmp_path, "m.py")
+        assert result.returncode == 1
+        assert re.search(r"m\.py:\d+-\d+", result.stdout), f"expected a RANGE key:\n{result.stdout}"
+
+    def test_deleting_a_noqa_past_an_unresolved_triple_quote_is_still_caught(self, tmp_path: Path) -> None:
+        """End-to-end through the scoped wrapper: the finding-4 shape,
+        reached via the triple-quote gap instead of a stray comment paren.
+        density like autobot-backend/cli/service_registry_cli.py (near-every
+        print line carries a noqa) makes an unrelated noqa within 20 lines
+        the norm, not the exception, once balance stops resolving."""
+        base_lines = ['print("""', "    line 0", "    line 1", '""")', "other_call()  # noqa"]
+        base, _ = _amend_pr(tmp_path, {"m.py": "\n".join(base_lines) + "\n"})
+        pr_lines = ['print("""', "    line 0", "    line 1", '""")', "other_call2()  # noqa"]
+        (tmp_path / "m.py").write_text("\n".join(pr_lines) + "\n", encoding="utf-8")
+        head = _commit_pr(tmp_path)
+
+        result = _run_scoped(tmp_path, "pre-commit-no-print-console", base, head)
+
+        assert result.returncode == 1, f"unrelated edit near an unresolved call was not caught:\n{result.stdout}"
+
+
+@pytest.mark.skipif(not NO_PRINT_CONSOLE_HOOK.exists(), reason="hook script not found")
+class TestSuppressionOnlyOnTheTrueClosingLine:
+    """#14051 code review round 3, finding 3: a noqa is accepted only on a
+    line where the running balance genuinely reaches zero — not on any line
+    a tokenizer gap left inside an apparently-still-open window. This is a
+    SECOND, independent layer under the round-2 normalization fix: even a
+    line the tokenizer still misjudges (a triple-quoted argument, `!`/`++`/
+    `--` before a real division) can no longer reach an unrelated noqa,
+    because no candidate line's noqa is inspected until the call is
+    confirmed closed on that exact line.
+    """
+
+    def test_triple_quoted_argument_does_not_let_an_unrelated_noqa_through(self, tmp_path: Path) -> None:
+        (tmp_path / "m.py").write_text(
+            'print("""\n    has an unbalanced "quote below\n""")\nother = 1  # noqa\n', encoding="utf-8"
+        )
+        result = _run_hook(tmp_path, "m.py")
+        assert result.returncode == 1, result.stdout
+
+    def test_non_null_assertion_before_division_does_not_let_an_unrelated_noqa_through(self, tmp_path: Path) -> None:
+        """`val!` then ` / ` is TS non-null assertion + division, not a
+        regex literal — `!` sits in the tokenizer's regex-open punct set. The
+        false regex-open swallows the REST OF THE LINE, including the call's
+        own real closing paren, so the call misreads as still-open even
+        though it's a complete, single-line, unsuppressed call — exactly the
+        shape that reached an unrelated noqa on the next line under round 2
+        alone (confirmed: exit 0 against bc2f1babd, exit 1 here)."""
+        (tmp_path / "m.ts").write_text("console.log(val! / 2);\nconst other = 1;  // noqa: console\n", encoding="utf-8")
+        result = _run_hook(tmp_path, "m.ts")
         assert result.returncode == 1, result.stdout
 
 


### PR DESCRIPTION
Closes #14051

## Thinking Path

The print()/console.* guard read each changed file whole and matched
violations line-by-line. A suppression comment on the closing-paren line of a
multi-line call was invisible to it, and the CI wrapper blamed a PR for
pre-existing violations in any file it merely touched.

**Correction (round 1 → round 2):** the motivating
`autobot-backend/cli/doctor.py` calls (lines 227, 238, 246) all carry their
noqa on the *opening* line, which the pre-#14051 hook already honoured — the
#14046 CI failure was entirely the *unscoped* wrapper blaming that PR for
pre-existing violations elsewhere in the file. `--changed-lines-only` is what
actually explains #14046; multi-line recognition is real and worth having,
but is not what #14046 hit.

Two fixes, hardened across two further review rounds after the scan itself
turned out to be exploitable:

1. **Understand multi-line suppressions.** When a matched call is still open
   at end-of-line, scan forward — bounded, tracking paren balance — for a
   noqa on any line up to where the call closes.
2. **Scope the CI wrapper to changed lines.** `check-pre-commit-hook-pr.sh
   --changed-lines-only pre-commit-no-print-console` reuses #13950's exact
   mechanism — no second implementation.

**Round 2 findings (raw-vs-stripped line divergence) — fixed:** the forward
scan compared a *stripped* opening line against *raw* candidate lines, so a
trailing comment's `(`, a regex literal's `(`, or a noqa mentioned inside a
string argument could hold the "still open" window open or fool the noqa
search. Replaced with `lib/strip-significant.awk`, a small character-by-
character tokenizer applied consistently to every candidate line.

**Round 3 findings — fixed:**

- **HIGH:** a `"` inside a `.vue` `<template>` — or a Vue template embedded
  as a backtick string in a `.stories.ts` `render()` — delimits an HTML
  *attribute*, not a JS string. The tokenizer (built for TS/JS syntax) was
  eating the whole attribute body, hiding a live `console.*` call inside it —
  a regression against base's raw-line matching, and the frontend's primary
  file type. Fixed with one targeted heuristic: a `"` immediately preceded by
  `=` with no space is emitted verbatim rather than treated as a string
  delimiter. Covers both the `.vue` and the `.stories.ts` shapes, since
  neither is tied to file extension.
- **HIGH:** when the forward scan exited without the balance ever reaching
  zero (bound hit, or a tokenizer gap), the reported line never advanced past
  the opening line — collapsing back to round 1's finding-4 bypass (deleting
  a closing-line noqa goes unnoticed by the scoped wrapper) through the
  Python triple-quoted-string gap instead of a stray comment paren. Fixed:
  when the scan exits with the balance still open, the reported range widens
  to the last line actually scanned — fails closed (too wide) instead of
  collapsing narrow.
- **MEDIUM:** tightened `suppressed_in_multiline_call` to accept a noqa only
  on the line where the balance *actually* reaches zero, not any line in the
  scan window. This is a second, independent layer under the tokenizer fix —
  even a line the tokenizer still misjudges (a triple-quoted argument,
  `!`/`++`/`--` before a division) can no longer reach an unrelated noqa,
  because no candidate's noqa is inspected until the call is confirmed
  closed on that exact line.
- **MEDIUM:** a missing or unparseable `strip-significant.awk` previously
  read as "line is empty, nothing matches" — silent fail-open. Added a
  one-shot startup self-test (`_self_test_strip_significant`) that exits 2 if
  a known input doesn't normalize to the expected result.
- **Docstring overclaim corrected:** `test_scan_bound_fails_closed` guards
  `MULTILINE_NOQA_SCAN_LIMIT` itself (already correct in round 1), not a
  round-2/3 finding — the class docstring's blanket "every case here failed
  against 63e957e2d" was inaccurate for that one test.

## What Changed

- `autobot-infrastructure/shared/scripts/hooks/lib/strip-significant.awk`
  (new): character-by-character line normalizer shared by both languages —
  strips string/template/regex-literal bodies and (for balance tracking) the
  comment; keeps the comment when searching for a noqa. Includes the
  attribute-quote heuristic from round 3.
- `autobot-infrastructure/shared/scripts/hooks/pre-commit-no-print-console`:
  balance/noqa detection normalizes every candidate line; a noqa is accepted
  only on the line balance reaches zero on; violations report a line RANGE
  for multi-line calls, widened to the last-scanned line when balance never
  resolves; a startup self-test on the normalizer; the two per-language
  checkers are 5-line wrappers around a shared `_scan_file_for_calls` driver
  (≤30 lines).
- `.github/workflows/code-quality.yml`: the "Block print/console
  regressions" step runs with `--changed-lines-only`.
- `pipeline-scripts/check-pre-commit-hook-pr.sh`: the violation-key parser
  accepts a `path:N-M` range, kept if any line in `[N,M]` was added —
  additive; single-line `path:N` keys (every other hook this wrapper serves)
  are unaffected.
- `pipeline-scripts/check-pre-commit-hook-pr_test.py`: 49 tests total —
  multi-line recognition (round 1), raw-vs-stripped negatives (round 2),
  Vue attribute quotes / unresolved-balance range / suppression-tightening
  (round 3), plus the scoped-wrapper end-to-end cases including the
  finding-4 bypass regression test.

## Verification

**Every reproduction from all three review rounds flips exit 0 → exit 1**
against the final hook, including: TS backtick/regex-literal calls with an
unrelated noqa below, a noqa inside a Python string argument, a trailing
comment's stray `(`, an escaped quote defeating the old strip, deleting a
closing-line noqa through the scoped wrapper, a Vue `<template>` inline
handler, the real `NpuWorkerPairConfirmDialog.stories.ts` lines (58, 59, 76,
77, 94, 95 — all now flagged, matching base), an unresolved Python
triple-quote reaching an unrelated noqa through the scoped wrapper, and a TS
non-null-assertion-before-division swallowing a real closing paren on the
same line. Positive cases re-verified unaffected: opening-line noqa,
closing-line noqa, the real `doctor.py` (still exit 0, still black-stable),
the 20-line bound still fails closed.

**Repo-wide base-vs-head comparison** (the whole-repo *scan itself* is
#14115's territory; this run was scoped to the ~475 tracked files that can
possibly contain a `print(`/`console.*(` call — files without either
substring cannot produce a violation from any version of this hook, so this
is an exact, not approximate, reduction):
- **Miss set (base flags, head does not): 24** — exactly the legitimate
  closing-line-noqa sites (`agent_wiki.py`, `service_registry_cli.py`,
  `benchmark_belief_state.py`, `examples_counterfactual.py`), down from 30
  before round 3 (the 6 Vue false negatives are gone).
- **New false positives (head flags, base does not): 1**, and it is not a
  regression — `data/file_manager_root/test.js` has no trailing newline;
  `mapfile -t` (already reviewed and approved in round 1) catches the final
  line the old `read`-loop-based base hook silently skipped.

```
$ venv/bin/python -m pytest pipeline-scripts/check-pre-commit-hook-pr_test.py -q
49 passed

$ venv/bin/python -m black --check pipeline-scripts/check-pre-commit-hook-pr_test.py   # clean
$ venv/bin/python -m isort --check pipeline-scripts/check-pre-commit-hook-pr_test.py   # clean
$ venv/bin/python -m flake8 pipeline-scripts/check-pre-commit-hook-pr_test.py          # clean
$ bash -n autobot-infrastructure/shared/scripts/hooks/pre-commit-no-print-console      # OK
$ bash -n pipeline-scripts/check-pre-commit-hook-pr.sh                                 # OK
$ gawk --lint -f autobot-infrastructure/shared/scripts/hooks/lib/strip-significant.awk # no warnings
```

**Mutation-tested with no-op detection, all three rounds:** reverted hook +
lib + wrapper to the prior round's committed SHA via `git show <sha>:<path>`
(never `git stash` — shared stash stack), confirmed via `diff` the working
files actually changed before AND after re-applying. Round 3: 7 of 49 tests
failed against the round-2 code — exactly the ones depending on round-3
fixes; the other 42 were unaffected. One test initially needed a rewrite
after this check (`test_non_null_assertion_before_division...` first didn't
reproduce the exact shape the finding described — a false regex-open
swallowing the call's OWN closing paren on the same line, not a separate
line — rewrote the fixture, reconfirmed the flip).

**Function length:** all functions ≤30 lines
(`_scan_file_for_calls` is 29, the shared driver both per-language checkers
wrap).

## Deliberate behavior change (flagging explicitly, not fixing)

Editing any line **inside** a pre-existing, unsuppressed multi-line call now
fails the build — the hook now reports that call as a line RANGE, and the
wrapper's widened key-matching (needed to close the finding-4 bypass) treats
touching *any* line in that range as taking responsibility for the whole
call, not just the line edited. This is defensible (the PR did touch the
call) but stricter than #13950's original "answer for the lines you added"
framing for a single-line violation. Example: a base file has a 4-line
`print(...)` with no noqa at all; a PR that only edits line 4 (still inside
the call, still no noqa) sees `VIOLATION m.py:2-5` and fails, even though
line 2 (the `print(` itself) was untouched.

## Not fixed here (explicitly out of scope, tracked separately)

- Whole-repo scan performance (#14115) — this PR's own verification uses a
  substring-prefiltered subset for exactly this reason.

## Model Used

Sonnet 5