### PR TITLE
fix(code-intelligence): a failed git invocation is now distinguishable from empty history (#14114)

### DIFF
--- a/autobot-backend/code_intelligence/co_change_test.py
+++ b/autobot-backend/code_intelligence/co_change_test.py
@@ -449,16 +449,23 @@ def test_a_git_failure_on_an_available_repo_names_the_error(tmp_path):
     shutil.rmtree(tmp_path / ".git" / "objects")
     (tmp_path / ".git" / "objects").mkdir()
 
-    with pytest.raises(GitCommandError, match="git"):
+    with pytest.raises(GitCommandError, match="exited 128"):
         crawler.get_commit_file_sets()
 
 
 def test_a_genuinely_empty_window_is_not_an_error(repo):
     """A repo with real history but zero commits in range stays "no history",
-    never an error (#14114) — the distinction the fix exists to preserve."""
+    never an error (#14114) — the distinction the fix exists to preserve.
+
+    Pins ``available is True`` first — without it, a mutation that made the
+    repo read as unavailable would produce the same ``[]`` from the
+    degradation branch instead of from a successful, empty git call.
+    """
+    crawler = GitHistoryCrawler(str(repo))
+    assert crawler.available is True
     future = datetime.now(timezone.utc) + timedelta(days=1)
 
-    assert GitHistoryCrawler(str(repo)).get_commit_file_sets(since=future) == []
+    assert crawler.get_commit_file_sets(since=future) == []
 
 
 def test_the_default_window_is_actually_applied():

--- a/autobot-backend/code_intelligence/co_change_test.py
+++ b/autobot-backend/code_intelligence/co_change_test.py
@@ -13,6 +13,7 @@ and a fake would not exercise the part that costs.
 """
 
 import os
+import shutil
 import subprocess
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -20,7 +21,7 @@ from pathlib import Path
 import pytest
 
 from code_intelligence.co_change import CoChangeAnalyzer, CoChangePair
-from code_intelligence.code_evolution_miner import GitHistoryCrawler
+from code_intelligence.code_evolution_miner import GitCommandError, GitHistoryCrawler
 
 #: Git environment variables that redirect git away from the repository named
 #: on the command line. Inherited from the CI job, they make every worker's
@@ -131,6 +132,12 @@ def repo(tmp_path):
 
 
 def _pairs(repo_path: Path, **kwargs):
+    """#14114: if the git walk itself fails, this now raises ``GitCommandError``
+    with the underlying git stderr rather than returning an empty file-set list.
+    Before that fix, every test built on this helper failed (if at all) on a
+    downstream pair-count assertion that had nothing to do with the actual
+    cause — see ``test_a_git_failure_on_an_available_repo_names_the_error``.
+    """
     file_sets = GitHistoryCrawler(str(repo_path)).get_commit_file_sets()
     analyzer = CoChangeAnalyzer(**kwargs)
     return analyzer.analyze(file_sets), analyzer.commits_too_large_to_pair
@@ -399,12 +406,59 @@ def test_a_quoted_vendored_path_cannot_slip_past_the_filter(tmp_path):
 
 
 def test_a_failing_git_call_is_logged_not_swallowed(tmp_path, caplog):
-    """A timeout, a non-repo path and an empty window must not look identical."""
+    """A non-repository path degrades to an empty result, but is still logged.
+
+    This is the "not a repository" branch, distinguished from a genuine git
+    failure on an *available* repository — see
+    ``test_a_git_failure_on_an_available_repo_names_the_error`` below, which is
+    the branch that must raise rather than degrade (#14114).
+    """
     with caplog.at_level("WARNING"):
         result = GitHistoryCrawler(str(tmp_path)).get_commit_file_sets()
 
     assert result == []
     assert any("git" in r.getMessage() for r in caplog.records), "a git failure produced no log line"
+
+
+def test_a_git_failure_on_an_available_repo_names_the_error(tmp_path):
+    """A corrupted object store must not read as "no coupling found" (#14114).
+
+    This reproduces the real CI failure behind #14114: a temporary repository's
+    object store was lost mid-test, ``_run_git`` returned ``""`` on the exit-128
+    failure, ``get_commit_file_sets`` read that as "no history", and
+    ``co_change_test.py::test_the_minimum_count_is_inclusive_at_its_boundary``
+    then failed on a bogus ``assert 0 == 1`` — an assertion about pair counts
+    that had nothing to do with the actual defect.
+
+    Unlike a non-repository path, this repo passes ``rev-parse --git-dir`` at
+    construction time — ``available`` is ``True`` — and only fails later, when
+    ``git log`` cannot read its own objects. That failure must reach the
+    caller as a named git error, not disappear into an empty list.
+
+    MUST fail against the pre-#14114 code: ``_run_git`` returned ``""`` on any
+    non-zero exit and every caller treated that as an empty history.
+    """
+    _git_init(tmp_path)
+    _git(tmp_path, "config", "user.email", "a@b.c")
+    _git(tmp_path, "config", "user.name", "t")
+    _commit(tmp_path, {"a.py": "1\n"}, "solo")
+
+    crawler = GitHistoryCrawler(str(tmp_path))
+    assert crawler.available is True, "the repo is valid before its object store is corrupted"
+
+    shutil.rmtree(tmp_path / ".git" / "objects")
+    (tmp_path / ".git" / "objects").mkdir()
+
+    with pytest.raises(GitCommandError, match="git"):
+        crawler.get_commit_file_sets()
+
+
+def test_a_genuinely_empty_window_is_not_an_error(repo):
+    """A repo with real history but zero commits in range stays "no history",
+    never an error (#14114) — the distinction the fix exists to preserve."""
+    future = datetime.now(timezone.utc) + timedelta(days=1)
+
+    assert GitHistoryCrawler(str(repo)).get_commit_file_sets(since=future) == []
 
 
 def test_the_default_window_is_actually_applied():

--- a/autobot-backend/code_intelligence/code_evolution_miner.py
+++ b/autobot-backend/code_intelligence/code_evolution_miner.py
@@ -124,7 +124,22 @@ class GitCommandError(RuntimeError):
     be able to tell "there is none" from "the read failed" — the docstring on
     ``_run_git`` named this concern for over a year while still returning the
     same empty string for both.
+
+    ``returncode`` is ``None`` when the subprocess itself never completed — a
+    timeout, a missing git binary, a bad encoding argument — and an ``int``
+    when git ran and exited non-zero. Only the latter can mean "this path is
+    not a repository"; a probe that never got to run git at all is a different
+    kind of failure and must not be read as a verdict about the path. This is
+    what lets ``GitHistoryCrawler.__init__`` degrade on one and propagate the
+    other, instead of a blanket ``except GitCommandError`` there catching a
+    construction-time timeout or a missing git binary the same way it catches
+    "not a repository" — which would re-introduce this issue's defect one
+    layer up, at startup instead of at read time.
     """
+
+    def __init__(self, message: str, *, returncode: int | None = None) -> None:
+        super().__init__(message)
+        self.returncode = returncode
 
 
 def _run_git(repo_path: str, *args: str) -> str:
@@ -155,14 +170,19 @@ def _run_git(repo_path: str, *args: str) -> str:
         )
     except (OSError, subprocess.SubprocessError, ValueError) as exc:
         logger.warning("git %s failed in %s: %s", args, repo_path, exc)
-        raise GitCommandError(f"git {args} failed in {repo_path}: {exc}") from exc
+        # returncode=None: the subprocess never completed, so this cannot be a
+        # verdict about the path (see GitCommandError.returncode).
+        raise GitCommandError(f"git {args} failed in {repo_path}: {exc}", returncode=None) from exc
     if completed.returncode != 0:
         # Without this, a timeout, a non-repo path and a genuinely empty window
         # are the same empty string to the caller — the silent-computes-nothing
         # shape this method was written to get away from.
         stderr = completed.stderr.strip()
         logger.warning("git %s exited %s in %s: %s", args, completed.returncode, repo_path, stderr)
-        raise GitCommandError(f"git {args} exited {completed.returncode} in {repo_path}: {stderr}")
+        raise GitCommandError(
+            f"git {args} exited {completed.returncode} in {repo_path}: {stderr}",
+            returncode=completed.returncode,
+        )
     return completed.stdout
 
 
@@ -239,10 +259,21 @@ class GitHistoryCrawler:
         # a crash. A git failure *after* this succeeds (a corrupt object store, a
         # timeout) is a different thing and is left to raise from the method that
         # hits it — see `GitCommandError`.
+        #
+        # Only a *completed* `rev-parse` that exited non-zero (`returncode` is an
+        # int) can mean "not a repository" — `rev-parse --git-dir` never touches
+        # the object store, so that is the only way this specific probe fails
+        # short of a subprocess-level problem. A probe that never got to run git
+        # at all (a timeout, a missing git binary, a bad encoding argument —
+        # `returncode is None`) is not a verdict about the path and must
+        # propagate, or a construction-time git failure would degrade into a
+        # false "unavailable" the same way a read-time one did before #14114.
         try:
             _run_git(str(self.repo_path), "rev-parse", "--git-dir")
             self.available = True
-        except GitCommandError:
+        except GitCommandError as exc:
+            if exc.returncode is None:
+                raise
             self.available = False
             logger.warning("GitHistoryCrawler: %s is not a git repository — history is unavailable", repo_path)
 
@@ -628,6 +659,14 @@ class CodeEvolutionMiner:
                     logger.warning("Failed to analyze %s: %s", file_path, e)
                     continue
 
+        except GitCommandError:
+            # #14114: this used to fall into the broad `except Exception` below,
+            # which logged and moved on — the exact silent-degradation shape the
+            # rest of this fix removes everywhere else. A repo whose objects
+            # vanish mid-walk (a concurrent `git gc`, the tmp-retention race
+            # that motivated this issue) must not read as "no anti-patterns
+            # found"; it must fail the analysis that could not complete.
+            raise
         except Exception as e:
             logger.error("Failed to analyze commit %s: %s", commit["hash"], e)
 

--- a/autobot-backend/code_intelligence/code_evolution_miner.py
+++ b/autobot-backend/code_intelligence/code_evolution_miner.py
@@ -114,10 +114,28 @@ def _git_env() -> dict:
     return {k: v for k, v in os.environ.items() if k not in _REPO_OVERRIDING_GIT_VARS}
 
 
+class GitCommandError(RuntimeError):
+    """A git invocation failed — a corrupt object store, a timeout, a permissions
+    problem, or a path that stopped being a repository (#14114).
+
+    Deliberately distinct from an empty result: ``_run_git`` returning ``""`` on
+    both a genuinely empty window and a failed invocation is the exact defect
+    this exists to remove. A caller that asks for history and gets nothing must
+    be able to tell "there is none" from "the read failed" — the docstring on
+    ``_run_git`` named this concern for over a year while still returning the
+    same empty string for both.
+    """
+
+
 def _run_git(repo_path: str, *args: str) -> str:
-    """Run a read-only git command; empty string on any failure (#13639).
+    """Run a read-only git command; raises ``GitCommandError`` on any failure.
 
     The git binary is present wherever the repository is, which GitPython is not.
+    A non-zero exit or a subprocess-level failure (timeout, missing binary, a
+    path that is not a directory) both raise — never an empty string standing
+    in for "I could not look". Success with no matching commits still returns
+    ``""``, which is what keeps a genuinely empty window from reading as a
+    failure too.
     """
     try:
         completed = subprocess.run(  # nosec B603 B607  # fixed argv, shell=False, no user-supplied option
@@ -137,13 +155,14 @@ def _run_git(repo_path: str, *args: str) -> str:
         )
     except (OSError, subprocess.SubprocessError, ValueError) as exc:
         logger.warning("git %s failed in %s: %s", args, repo_path, exc)
-        return ""
+        raise GitCommandError(f"git {args} failed in {repo_path}: {exc}") from exc
     if completed.returncode != 0:
         # Without this, a timeout, a non-repo path and a genuinely empty window
         # are the same empty string to the caller — the silent-computes-nothing
         # shape this method was written to get away from.
-        logger.warning("git %s exited %s in %s: %s", args, completed.returncode, repo_path, completed.stderr.strip())
-        return ""
+        stderr = completed.stderr.strip()
+        logger.warning("git %s exited %s in %s: %s", args, completed.returncode, repo_path, stderr)
+        raise GitCommandError(f"git {args} exited {completed.returncode} in {repo_path}: {stderr}")
     return completed.stdout
 
 
@@ -214,8 +233,17 @@ class GitHistoryCrawler:
         read as a handled degradation.
         """
         self.repo_path = Path(repo_path)
-        self.available = _run_git(str(self.repo_path), "rev-parse", "--git-dir") != ""
-        if not self.available:
+        # "not a repository" is a legitimate, expected state at construction time
+        # (#14114) — it degrades to `available = False` rather than raising, so
+        # every caller downstream can keep treating it as "no history" instead of
+        # a crash. A git failure *after* this succeeds (a corrupt object store, a
+        # timeout) is a different thing and is left to raise from the method that
+        # hits it — see `GitCommandError`.
+        try:
+            _run_git(str(self.repo_path), "rev-parse", "--git-dir")
+            self.available = True
+        except GitCommandError:
+            self.available = False
             logger.warning("GitHistoryCrawler: %s is not a git repository — history is unavailable", repo_path)
 
     def get_commits_in_range(self, start_date: datetime | None = None, end_date: datetime | None = None) -> List[Dict]:
@@ -264,7 +292,16 @@ class GitHistoryCrawler:
         in no requirements file and is imported in exactly one place, the ``try``
         block above, so every other method here returns ``[]`` in every
         environment (#13832).
+
+        Raises ``GitCommandError`` if the repository is available but the walk
+        itself fails (#14114) — a corrupt object store, a timeout, a permissions
+        problem. A repository that is simply not a repository at all degrades to
+        ``[]`` via ``self.available``, same as every other method here; only a
+        genuinely empty window returns ``[]`` from a *successful* git call.
         """
+        if not self.available:
+            return []
+
         args = ["log", "--no-merges", "--pretty=format:%x00%H", "--name-only"]
         if since is not None:
             args.append(f"--since={since.isoformat()}")

--- a/autobot-backend/code_intelligence/git_history_crawler_test.py
+++ b/autobot-backend/code_intelligence/git_history_crawler_test.py
@@ -206,13 +206,18 @@ def _corrupt_object_store(repo: Path) -> None:
 
 def test_a_git_failure_on_an_available_repo_raises_not_degrades(repo):
     """MUST fail against the pre-#14114 code: every caller here returned ``[]``
-    on any non-zero git exit, indistinguishable from "no history"."""
+    on any non-zero git exit, indistinguishable from "no history".
+
+    Matches the exit code, not just the word "git" — every message here
+    contains "git" (the argv, the repo path), so that alone would pass even if
+    the exception carried no information about the actual failure.
+    """
     crawler = GitHistoryCrawler(str(repo))
     assert crawler.available is True
 
     _corrupt_object_store(repo)
 
-    with pytest.raises(GitCommandError, match="git"):
+    with pytest.raises(GitCommandError, match="exited 128"):
         crawler.get_commits_in_range()
 
 
@@ -221,7 +226,7 @@ def test_get_file_history_raises_on_a_git_failure_too(repo):
     crawler = GitHistoryCrawler(str(repo))
     _corrupt_object_store(repo)
 
-    with pytest.raises(GitCommandError, match="git"):
+    with pytest.raises(GitCommandError, match="exited 128"):
         crawler.get_file_history("a.py")
 
 
@@ -230,16 +235,60 @@ def test_get_commit_files_raises_on_a_git_failure_too(repo):
     commit_hash = crawler.get_commits_in_range()[0]["hash"]
     _corrupt_object_store(repo)
 
-    with pytest.raises(GitCommandError, match="git"):
+    with pytest.raises(GitCommandError, match="exited 128"):
         crawler.get_commit_files(commit_hash)
 
 
 def test_a_genuinely_empty_window_stays_no_history_not_an_error(repo):
     """The distinction the fix exists to preserve: an intact repository with no
-    commits in range is "no history", never an error (#14114)."""
+    commits in range is "no history", never an error (#14114).
+
+    Pins ``available is True`` first — without it, a mutation that made the
+    repo read as unavailable would produce the same ``[]`` from the
+    degradation branch instead of from a successful, empty git call, and this
+    test would stay green for the wrong reason.
+    """
+    crawler = GitHistoryCrawler(str(repo))
+    assert crawler.available is True
     future = datetime.now(timezone.utc) + timedelta(days=1)
 
-    assert GitHistoryCrawler(str(repo)).get_commits_in_range(start_date=future) == []
+    assert crawler.get_commits_in_range(start_date=future) == []
+
+
+# ------------------------- a construction-time failure is not "not a repo"
+
+
+def test_a_construction_time_subprocess_failure_propagates(repo, monkeypatch):
+    """A timeout or a missing git binary during the ``rev-parse`` probe must not
+    be swallowed into a false ``available = False`` (#14114 finding).
+
+    ``GitCommandError`` covers both a completed, non-zero git exit (which can
+    legitimately mean "not a repository") and a subprocess-level failure that
+    never got that far (which cannot). A blanket ``except GitCommandError`` in
+    ``__init__`` conflated the two, so a probe timeout read exactly like "not a
+    git repository" and silently degraded every subsequent call to ``[]`` —
+    reproducing this issue's core defect one call earlier, at construction.
+    """
+    import code_intelligence.code_evolution_miner as miner_module
+
+    def _timeout(*_args, **_kwargs):
+        raise subprocess.TimeoutExpired(cmd="git", timeout=1)
+
+    monkeypatch.setattr(miner_module.subprocess, "run", _timeout)
+
+    with pytest.raises(GitCommandError):
+        GitHistoryCrawler(str(repo))
+
+
+def test_a_non_repository_still_degrades_with_the_real_subprocess(tmp_path):
+    """The one case that legitimately swallows a ``GitCommandError``: a
+    completed ``rev-parse`` that exited non-zero because there is no
+    repository here at all. Runs the real subprocess, not a monkeypatch, so a
+    change to the exit-code plumbing cannot make both this and the timeout
+    test pass for the same wrong reason."""
+    crawler = GitHistoryCrawler(str(tmp_path))
+
+    assert crawler.available is False
 
 
 # ---------------------------------------------------------------- numstat parsing
@@ -286,6 +335,37 @@ def test_analyze_evolution_actually_analyses(repo, caplog):
     assert report["commits_analyzed"] == 3
     failures = [r.getMessage() for r in caplog.records if "Failed to analyze commit" in r.getMessage()]
     assert failures == [], f"commits failed to analyse: {failures[:2]}"
+
+
+def test_analyze_evolution_propagates_a_git_failure_mid_walk(repo, monkeypatch):
+    """A git failure while analysing one commit's files must reach the router,
+    not disappear into a logged warning (#14114 finding).
+
+    `_analyze_commit_patterns` wraps `crawler.get_commit_files` in its own
+    broad `except Exception`, which previously swallowed a `GitCommandError`
+    the same way it swallows a genuinely unreadable file — so
+    `analyze_evolution` returned `commits_analyzed: N, emerging_patterns: []`
+    with no indication anything had failed. Every `api/code_intelligence.py`
+    and `api/analytics_evolution.py` endpoint that calls `analyze_evolution`
+    wraps it in `except Exception`, so once this propagates out of
+    `CodeEvolutionMiner`, those endpoints turn it into a real error response
+    instead of a well-formed empty one — no router change required.
+
+    Reproduces the mid-walk failure directly (a commit whose *objects* vanish
+    after the initial `git log` already listed it — a concurrent `git gc`, or
+    the tmp-retention race that motivated #14114) rather than via git
+    corruption, so the test is deterministic and does not depend on which
+    specific commit git happens to touch first.
+    """
+    from code_intelligence.code_evolution_miner import CodeEvolutionMiner, GitCommandError
+
+    def _boom(self, commit_hash):
+        raise GitCommandError(f"git ('show', ...) exited 128 in <repo>: fatal: bad object {commit_hash}")
+
+    monkeypatch.setattr(GitHistoryCrawler, "get_commit_files", _boom)
+
+    with pytest.raises(GitCommandError, match="exited 128"):
+        CodeEvolutionMiner(str(repo)).analyze_evolution()
 
 
 def test_the_miner_holds_a_path_not_a_string(repo):

--- a/autobot-backend/code_intelligence/git_history_crawler_test.py
+++ b/autobot-backend/code_intelligence/git_history_crawler_test.py
@@ -14,13 +14,14 @@ So the load-bearing assertions here are **non-empty**. A test suite that only
 checked shapes would have passed against the inert version for years.
 """
 
+import shutil
 import subprocess
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
 
-from code_intelligence.code_evolution_miner import GitHistoryCrawler, _parse_numstat
+from code_intelligence.code_evolution_miner import GitCommandError, GitHistoryCrawler, _parse_numstat
 
 
 def _git(repo: Path, *args: str) -> None:
@@ -185,6 +186,60 @@ def test_a_non_repository_degrades_rather_than_raising(tmp_path):
 def test_a_real_repository_reports_itself_available(repo):
     """The flag must distinguish the two cases, or "no history" is ambiguous again."""
     assert GitHistoryCrawler(str(repo)).available is True
+
+
+# ------------------------- a git failure, not a missing repository (#14114)
+
+
+def _corrupt_object_store(repo: Path) -> None:
+    """Break git log on an otherwise-valid repository.
+
+    ``rev-parse --git-dir`` still succeeds afterwards — the ``.git`` directory
+    is real — so ``available`` stays ``True``. Only the history walk fails,
+    which is exactly the shape of the CI failure in #14114: the fixture's
+    temporary repository lost objects mid-test while remaining, by every
+    cheaper check, a git repository.
+    """
+    shutil.rmtree(repo / ".git" / "objects")
+    (repo / ".git" / "objects").mkdir()
+
+
+def test_a_git_failure_on_an_available_repo_raises_not_degrades(repo):
+    """MUST fail against the pre-#14114 code: every caller here returned ``[]``
+    on any non-zero git exit, indistinguishable from "no history"."""
+    crawler = GitHistoryCrawler(str(repo))
+    assert crawler.available is True
+
+    _corrupt_object_store(repo)
+
+    with pytest.raises(GitCommandError, match="git"):
+        crawler.get_commits_in_range()
+
+
+def test_get_file_history_raises_on_a_git_failure_too(repo):
+    """Every ``_run_git`` caller gets the same treatment, not just one method."""
+    crawler = GitHistoryCrawler(str(repo))
+    _corrupt_object_store(repo)
+
+    with pytest.raises(GitCommandError, match="git"):
+        crawler.get_file_history("a.py")
+
+
+def test_get_commit_files_raises_on_a_git_failure_too(repo):
+    crawler = GitHistoryCrawler(str(repo))
+    commit_hash = crawler.get_commits_in_range()[0]["hash"]
+    _corrupt_object_store(repo)
+
+    with pytest.raises(GitCommandError, match="git"):
+        crawler.get_commit_files(commit_hash)
+
+
+def test_a_genuinely_empty_window_stays_no_history_not_an_error(repo):
+    """The distinction the fix exists to preserve: an intact repository with no
+    commits in range is "no history", never an error (#14114)."""
+    future = datetime.now(timezone.utc) + timedelta(days=1)
+
+    assert GitHistoryCrawler(str(repo)).get_commits_in_range(start_date=future) == []
 
 
 # ---------------------------------------------------------------- numstat parsing


### PR DESCRIPTION
Closes #14114

## Thinking Path

`_run_git` returned `""` on any non-zero exit — the same value it returns for a genuinely empty window — and every caller (`get_commits_in_range`, `get_file_history`, `get_commit_files`, `get_commit_file_sets`) treated an empty string as "no history". A corrupt object store, a timeout, or a permissions problem therefore all read as "no coupling found" instead of an error. The CI evidence in the issue showed exactly this: a temporary repository lost its objects mid-test, `git log` exited 128, `_run_git` logged a warning and returned `""`, and a downstream test then failed on a bogus pair-count assertion that had nothing to do with the real defect.

Traced every `_run_git` caller (`grep -rn "get_commit_file_sets\|GitHistoryCrawler"`) before changing behaviour. `CoChangeAnalyzer.analyze()` (`code_intelligence/co_change.py`) is not wired into any router or service today — its only callers are its own test file — so there is no production caller currently depending on "empty list on git failure" degrading gracefully. `CodeEvolutionMiner` (which wraps `GitHistoryCrawler`) IS production-facing, through `api/code_intelligence.py` and `api/analytics_evolution.py`; every one of those endpoints already wraps its call in a broad `except Exception` that converts it into a proper error response, so letting the new exception propagate out of `analyze_evolution` turns a silently-empty report into a correctly-reported failure, with no additional changes needed at the router layer.

Picked one approach: a `GitCommandError` raised by `_run_git` on any failure — subprocess-level (timeout, OSError) or non-zero exit. `GitHistoryCrawler.__init__` is the one place that catches it, to keep "not a repository" a legitimate, non-crashing `available = False` state (unchanged public behaviour). Every other caller lets it propagate, since none of them can distinguish "the read failed" from "there is nothing" any other way.

## What Changed

- `autobot-backend/code_intelligence/code_evolution_miner.py`
  - Added `GitCommandError(RuntimeError)`.
  - `_run_git` now raises `GitCommandError` (with the git args, repo path and stderr/exception in the message) instead of returning `""` on failure. A successful call with no matching commits still returns `""` — that distinction is preserved.
  - `GitHistoryCrawler.__init__` catches `GitCommandError` from the `rev-parse --git-dir` probe and sets `available = False` — "not a repository" still degrades rather than crashing.
  - `get_commit_file_sets` gained the same `if not self.available: return []` guard the other three methods already had, so a non-repository path still degrades instead of raising through the new exception. All four `_run_git` callers now let a genuine failure on an *available* repo propagate as `GitCommandError`.
- `autobot-backend/code_intelligence/git_history_crawler_test.py`, `autobot-backend/code_intelligence/co_change_test.py`
  - New tests that corrupt an otherwise-valid repository's object store (`rev-parse --git-dir` still succeeds, `git log`/`git show` do not) and assert `GitCommandError` is raised, for `get_commits_in_range`, `get_file_history`, `get_commit_files` and `get_commit_file_sets`.
  - New tests confirming a genuinely empty window (a real repo, zero commits in range) still returns `[]` without raising.
  - Clarified the docstring on the pre-existing "not a repository" degradation test and the `_pairs()` test helper to name which branch each covers.

## Scope boundary

The issue's second defect — `/tmp/pytest-of-runner/pytest-0` being reused across concurrent jobs on the self-hosted runner, so one job's tmp retention can delete another job's live objects — is **not** fixed here. It is not a two-line `basetemp` change (it needs a per-job-unique tmp root, which touches CI job configuration, not this module), so per the issue's scope boundary it is left for a follow-up. Left a comment on #14114 noting this explicitly so it isn't lost.

## Verification

Full `code_intelligence` suite, with the fix in place:

```
$ ./venv/bin/python -m pytest code_intelligence/ -q
================= 762 passed, 63 warnings in 52.18s ==================
```

Before/after evidence for the new behaviour — reproduced the CI failure directly against the unmodified module (repo passes `rev-parse --git-dir`, i.e. `available: True`, then its object store is corrupted):

```
available: True
get_commit_file_sets result (pre-fix): []
get_commits_in_range result (pre-fix): []
```
(git itself logged `fatal: bad object HEAD`, exit 128 — silently turned into `[]` by the old code)

New tests against the unmodified module (mutation test — reverted the production fix by file content, confirmed the file actually changed, then reran):

```
ImportError: cannot import name 'GitCommandError' from 'code_intelligence.code_evolution_miner'
```
(both new test files fail to even collect, since the type they assert on doesn't exist pre-fix)

With the fix restored, the same test files:

```
$ ./venv/bin/python -m pytest code_intelligence/git_history_crawler_test.py code_intelligence/co_change_test.py code_intelligence/code_evolution_miner_test.py -v
======================= 71 passed, 2 warnings in 11.22s ========================
```

`ruff check` on all three touched files: `All checks passed!`

## Model Used

Sonnet 5