### PR TITLE
fix(chat): stop reporting a failed summarization as a successful compaction (#14065)

### DIFF
--- a/autobot-backend/api/chat.py
+++ b/autobot-backend/api/chat.py
@@ -821,6 +821,11 @@ async def process_chat_message(
             "fill_percentage": overflow_status.get("current_fill_percentage", 0),
             "total_tokens": overflow_status.get("total_tokens", 0),
             "context_limit": overflow_status.get("context_limit", 0),
+            # #14065: a failed compaction has to be visible to the user, not
+            # only to the log. Without this the session silently stays over
+            # threshold and the only symptom is the assistant contradicting
+            # earlier turns once history is eventually trimmed.
+            "compaction_failed": bool(overflow_status.get("summary_error")),
         }
 
     # Issue #10548: RAG grounding — query KB and attach structured citations by default.

--- a/autobot-backend/chat_history/context_overflow.py
+++ b/autobot-backend/chat_history/context_overflow.py
@@ -14,6 +14,7 @@ Provides automatic context window management:
 Builds on #8990 (token usage tracking) and #3770 (compression service).
 """
 
+import os
 from typing import Any, Dict, List, Optional
 
 from autobot_shared.logging_manager import get_logger
@@ -31,6 +32,10 @@ _SUMMARY_MARKER_KEY_PREFIX = "chat:summary_marker:"
 # Default thresholds (can be overridden)
 _DEFAULT_WARNING_THRESHOLD = 0.80  # 80%
 _DEFAULT_COMPRESS_THRESHOLD = 0.90  # 90%
+
+# How long to skip compaction after it fails, so a rate-limited provider costs
+# one attempt per window instead of one per turn (#14065 review).
+_SUMMARY_FAILURE_BACKOFF_SECONDS = int(os.getenv("AUTOBOT_SUMMARY_FAILURE_BACKOFF_SECONDS", "300"))
 
 
 class SessionTokenTracker:
@@ -160,6 +165,54 @@ class SessionTokenTracker:
         except Exception as e:
             logger.error("Failed to reset session %s: %s", session_id, e)
 
+    async def mark_summarization_failed(self, session_id: str) -> None:
+        """Back off compaction for this session after a failure (#14065 review).
+
+        Without this, a failing provider wedges the session permanently.
+        Compaction is awaited *inline* on the chat request path, under the
+        ``chat_timeout`` budget (``api/chat.py``), and the token tracker is
+        correctly left un-reset on failure — so fill never drops and every
+        subsequent turn spends the same time failing the same way, timing out a
+        turn whose answer was already generated and stored.
+
+        The marker bounds that to one attempt per backoff window. It is
+        deliberately best-effort: with Redis down the marker cannot be written,
+        and retrying every turn is the safer of the two failures.
+        """
+        redis = await self._ensure_redis()
+        if not redis:
+            return
+
+        try:
+            await redis.setex(f"{_SUMMARY_MARKER_KEY_PREFIX}{session_id}", _SUMMARY_FAILURE_BACKOFF_SECONDS, "failed")
+        except Exception as e:
+            logger.error("Failed to mark summarization failure for session %s: %s", session_id, e)
+
+    async def summarization_recently_failed(self, session_id: str) -> bool:
+        """True while the backoff window from a previous failure is still open."""
+        redis = await self._ensure_redis()
+        if not redis:
+            return False
+
+        try:
+            return bool(await redis.exists(f"{_SUMMARY_MARKER_KEY_PREFIX}{session_id}"))
+        except Exception as e:
+            logger.error("Failed to read summarization marker for session %s: %s", session_id, e)
+            return False
+
+
+def _message_text(msg: object) -> str:
+    """The text of a message, for token estimation, on any input (#14065 review).
+
+    ``estimate_fast`` needs a string. A non-dict entry or a non-string ``text``
+    (a provider emitting ``None``, an int, a content-part list) used to raise
+    here — after the token tracker had already been reset.
+    """
+    if not isinstance(msg, dict):
+        return ""
+    text = msg.get("text", "")
+    return text if isinstance(text, str) else ""
+
 
 def _sanitize_tool_messages(msgs: List[Dict]) -> List[Dict]:
     """Drop orphaned tool messages and dangling assistant tool_calls.
@@ -172,6 +225,14 @@ def _sanitize_tool_messages(msgs: List[Dict]) -> List[Dict]:
     cleaned: List[Dict] = []
     in_batch = False
     for m in msgs:
+        # #14065 review: this runs outside summarize_messages' try, so a
+        # non-dict entry here would escape as an AttributeError and 500 a turn
+        # whose answer was already generated and stored. Malformed history is
+        # data, not a programming error — skip the entry and keep compacting.
+        if not isinstance(m, dict):
+            logger.warning("Skipping non-dict message during tool sanitization: %r", type(m).__name__)
+            in_batch = False
+            continue
         role = m.get("role")
         if role == "tool":
             if in_batch:
@@ -295,7 +356,7 @@ class ConversationSummarizer:
         logger.info(
             "Generated summary for %d messages (%d → %d tokens est.)",
             len(messages),
-            sum(len(m.get("text", "")) for m in messages) // 4,
+            sum(len(_message_text(m)) for m in messages) // 4,
             len(summary) // 4,
         )
         return summary
@@ -307,11 +368,20 @@ class ConversationSummarizer:
         """
         lines = []
         for msg in messages:
+            if not isinstance(msg, dict):
+                continue
             role = msg.get("role") or msg.get("sender", "unknown")
             content = msg.get("content") or msg.get("text", "")
             if isinstance(content, list):
+                # #14065 review: a multimodal part with ``text: None`` is a shape
+                # providers genuinely emit, and ``" ".join`` raises TypeError on
+                # it. This method runs outside the try, so that escaped as a 500
+                # on the live chat path. Skip the part instead — a summary
+                # missing one empty fragment is not a failure.
                 content = " ".join(
-                    p.get("text", "") for p in content if isinstance(p, dict) and p.get("type") == "text"
+                    p["text"]
+                    for p in content
+                    if isinstance(p, dict) and p.get("type") == "text" and isinstance(p.get("text"), str)
                 )
             if role and content:
                 lines.append(f"{role}: {content}")
@@ -432,30 +502,7 @@ class ContextOverflowProtection:
         if mode == "auto" and fill_percentage >= self.compress_threshold:
             # Trigger auto-summarization
             if messages:
-                try:
-                    summary = await self._create_summary(session_id, messages, model_name)
-                except SummarizationFailed as exc:
-                    # The history is intact and the tracker was not reset, so the
-                    # session is still over threshold and the next turn retries.
-                    # Reporting this instead of swallowing it is the point: a
-                    # caller that cannot see the failure keeps talking to an
-                    # agent that has silently forgotten half the work (#14065).
-                    result["summary_error"] = str(exc)
-                    logger.error(
-                        "Auto-summarization FAILED for session %s: %s — history left intact, "
-                        "token counter not reset",
-                        session_id,
-                        exc,
-                    )
-                else:
-                    if summary:
-                        result["summary_created"] = True
-                        result["summary_text"] = summary
-                        logger.info(
-                            "Auto-summarized session %s: %d messages compressed",
-                            session_id,
-                            len(messages),
-                        )
+                await self._attempt_summary(session_id, messages, model_name, result)
             else:
                 logger.warning(
                     "Auto-summarization triggered but no messages provided for session %s",
@@ -463,6 +510,43 @@ class ContextOverflowProtection:
                 )
 
         return result
+
+    async def _attempt_summary(
+        self,
+        session_id: str,
+        messages: List[Dict[str, Any]],
+        model_name: str,
+        result: Dict[str, Any],
+    ) -> None:
+        """Run compaction once and record the outcome into *result* (#14065)."""
+        if await self.tracker.summarization_recently_failed(session_id):
+            # Compaction is awaited inline under the chat request's wall-clock
+            # budget. Retrying every turn against a provider that is already
+            # rate-limiting turns a degraded session into a dead one.
+            result["summary_error"] = "summarization recently failed; backing off"
+            logger.warning("Skipping auto-summarization for session %s: recent failure, backing off", session_id)
+            return
+
+        try:
+            summary = await self._create_summary(session_id, messages, model_name)
+        except SummarizationFailed as exc:
+            # The history is intact and the tracker was not reset, so the session
+            # is still over threshold. Reporting this instead of swallowing it is
+            # the point: a caller that cannot see the failure keeps talking to an
+            # agent that has silently forgotten half the work (#14065).
+            result["summary_error"] = str(exc)
+            await self.tracker.mark_summarization_failed(session_id)
+            logger.error(
+                "Auto-summarization FAILED for session %s: %s — history left intact, token counter not reset",
+                session_id,
+                exc,
+            )
+            return
+
+        if summary:
+            result["summary_created"] = True
+            result["summary_text"] = summary
+            logger.info("Auto-summarized session %s: %d messages compressed", session_id, len(messages))
 
     async def _get_context_limit(self, model_name: str) -> int:
         """Get context window limit for a model.
@@ -500,16 +584,22 @@ class ContextOverflowProtection:
         # what makes the next turn retry instead of proceeding on a lie.
         summary = await self.summarizer.summarize_messages(messages_to_summarize, model_name)
 
+        # Estimate BEFORE resetting. #14065 review: this loop used to run after
+        # the reset, so a malformed entry in the second half raised with the
+        # counter already cleared and the paid-for summary discarded — the same
+        # counter-reset-without-a-delivered-summary shape this method exists to
+        # prevent, one layer down and not a SummarizationFailed, so the caller's
+        # handler did not cover it.
+        #
+        # #13694: estimate_fast rather than an inline `len(text) // 4` — these
+        # are the numbers the 80/90% trigger runs on until the next provider
+        # response supplies an authoritative count, so they use the shared path.
+        retained_tokens = [estimate_fast(_message_text(msg)) for msg in messages[split_point:]]
+
         # Reset token tracker (conversation now starts from summary)
         await self.tracker.reset_session(session_id)
-
-        # Re-add tokens for remaining messages.
-        # #13694: was an inline `len(text) // 4` — a fourth estimator beside the
-        # three that already existed. These are the numbers the 80/90% trigger
-        # runs on until the next provider response supplies an authoritative
-        # count, so they use the shared fast path.
-        for msg in messages[split_point:]:
-            await self.tracker.add_message_tokens(session_id, prompt_tokens=estimate_fast(msg.get("text", "")))
+        for tokens in retained_tokens:
+            await self.tracker.add_message_tokens(session_id, prompt_tokens=tokens)
 
         return summary
 

--- a/autobot-backend/chat_history/context_overflow.py
+++ b/autobot-backend/chat_history/context_overflow.py
@@ -186,6 +186,23 @@ def _sanitize_tool_messages(msgs: List[Dict]) -> List[Dict]:
     return cleaned
 
 
+class SummarizationFailed(RuntimeError):
+    """Summarization did not produce a usable summary (#14065).
+
+    Raised instead of returning a placeholder string. The placeholder read like
+    a successful compaction — "[Summary: N earlier message(s) were summarized to
+    preserve context.]" — so the caller reset the token tracker, reported
+    ``summary_created: True`` and logged "messages compressed" while the oldest
+    half of the conversation had in fact been replaced by a sentence containing
+    none of the goals, decisions, file paths or state the summarization prompt
+    exists to preserve.
+
+    Failure has to be *shaped* differently from success, not merely logged
+    differently. A ``logger.error`` in one line and a truthy return value in the
+    next is a failure the caller cannot see.
+    """
+
+
 class ConversationSummarizer:
     """Uses LLM to create intelligent conversation summaries.
 
@@ -242,42 +259,46 @@ class ConversationSummarizer:
             model_name: LLM model to use for summarization.
 
         Returns:
-            Summary text. Returns placeholder on error.
+            Summary text.
+
+        Raises:
+            SummarizationFailed: The gateway errored, or returned nothing usable.
+                Never a placeholder — see that exception's docstring (#14065).
         """
+        # Deliberately outside the try: these are pure, local transformations of
+        # the caller's own data. A bug in _sanitize_tool_messages or
+        # _format_messages is a programming error and must surface as itself,
+        # not be relabelled "summarization failed" and retried forever (#14065).
+        safe_messages = _sanitize_tool_messages(messages)
+        conversation_text = self._format_messages(safe_messages)
+        prompt = self._SUMMARIZATION_PROMPT.replace("{{conversation}}", conversation_text).replace(
+            "{{count}}", str(len(messages))
+        )
+
         try:
             gateway = await self._get_gateway()
-
-            # Sanitize orphaned tool messages before formatting
-            safe_messages = _sanitize_tool_messages(messages)
-            conversation_text = self._format_messages(safe_messages)
-            prompt = self._SUMMARIZATION_PROMPT.replace("{{conversation}}", conversation_text).replace(
-                "{{count}}", str(len(messages))
-            )
-
-            # Generate summary via LLM
             response = await gateway.chat_completion(
                 messages=[{"role": CategoryDefaults.ROLE_USER, "content": prompt}],
                 model=model_name,
                 temperature=0.3,  # Low temp for consistent summaries
                 max_tokens=500,  # Cap summary length
             )
+            summary = (getattr(response, "content", None) or "").strip()
+        except Exception as exc:
+            logger.error("Summarization failed for %d messages: %s", len(messages), exc, exc_info=True)
+            raise SummarizationFailed(f"summarization call failed: {exc}") from exc
 
-            summary = response.content.strip()
-            if not summary:
-                raise ValueError("LLM returned empty summary")
+        if not summary:
+            logger.error("Summarization returned an empty completion for %d messages", len(messages))
+            raise SummarizationFailed("LLM returned empty summary")
 
-            logger.info(
-                "Generated summary for %d messages (%d → %d tokens est.)",
-                len(messages),
-                sum(len(m.get("text", "")) for m in messages) // 4,
-                len(summary) // 4,
-            )
-            return summary
-
-        except Exception as e:
-            logger.error("Summarization failed: %s", e, exc_info=True)
-            # Fallback: simple count-based placeholder
-            return f"[Summary: {len(messages)} earlier message(s) were summarized to preserve context.]"
+        logger.info(
+            "Generated summary for %d messages (%d → %d tokens est.)",
+            len(messages),
+            sum(len(m.get("text", "")) for m in messages) // 4,
+            len(summary) // 4,
+        )
+        return summary
 
     def _format_messages(self, messages: List[Dict[str, Any]]) -> str:
         """Format messages into readable conversation text.
@@ -385,6 +406,10 @@ class ContextOverflowProtection:
             "warning_triggered": False,
             "summary_created": False,
             "summary_text": "",
+            # Always present so a caller can branch on it without a KeyError.
+            # Empty means "no attempt failed", not "no attempt was made" —
+            # summary_created distinguishes those two (#14065).
+            "summary_error": "",
             "current_fill_percentage": fill_percentage,
             "total_tokens": total_tokens,
             "context_limit": context_limit,
@@ -407,15 +432,30 @@ class ContextOverflowProtection:
         if mode == "auto" and fill_percentage >= self.compress_threshold:
             # Trigger auto-summarization
             if messages:
-                summary = await self._create_summary(session_id, messages, model_name)
-                if summary:
-                    result["summary_created"] = True
-                    result["summary_text"] = summary
-                    logger.info(
-                        "Auto-summarized session %s: %d messages compressed",
+                try:
+                    summary = await self._create_summary(session_id, messages, model_name)
+                except SummarizationFailed as exc:
+                    # The history is intact and the tracker was not reset, so the
+                    # session is still over threshold and the next turn retries.
+                    # Reporting this instead of swallowing it is the point: a
+                    # caller that cannot see the failure keeps talking to an
+                    # agent that has silently forgotten half the work (#14065).
+                    result["summary_error"] = str(exc)
+                    logger.error(
+                        "Auto-summarization FAILED for session %s: %s — history left intact, "
+                        "token counter not reset",
                         session_id,
-                        len(messages),
+                        exc,
                     )
+                else:
+                    if summary:
+                        result["summary_created"] = True
+                        result["summary_text"] = summary
+                        logger.info(
+                            "Auto-summarized session %s: %d messages compressed",
+                            session_id,
+                            len(messages),
+                        )
             else:
                 logger.warning(
                     "Auto-summarization triggered but no messages provided for session %s",
@@ -454,7 +494,10 @@ class ContextOverflowProtection:
         if not messages_to_summarize:
             return ""
 
-        # Generate summary
+        # Generate summary. A SummarizationFailed propagates deliberately: the
+        # tracker reset below must not run when the history it claims to have
+        # compressed is still uncompressed (#14065). Leaving the counter high is
+        # what makes the next turn retry instead of proceeding on a lie.
         summary = await self.summarizer.summarize_messages(messages_to_summarize, model_name)
 
         # Reset token tracker (conversation now starts from summary)
@@ -475,4 +518,5 @@ __all__ = [
     "SessionTokenTracker",
     "ConversationSummarizer",
     "ContextOverflowProtection",
+    "SummarizationFailed",
 ]

--- a/autobot-backend/chat_history/context_overflow_test.py
+++ b/autobot-backend/chat_history/context_overflow_test.py
@@ -173,6 +173,35 @@ class TestConversationSummarizer:
                 await summarizer.summarize_messages(messages, "gpt-4")
 
     @pytest.mark.asyncio
+    async def test_malformed_history_degrades_instead_of_500ing_the_turn(self):
+        """#14065 review: these helpers run outside the try, so they must be total.
+
+        A multimodal part with ``text: None`` is a shape providers genuinely
+        emit, and a non-dict entry can reach here from trimmed history. Both
+        used to raise past ``check_and_protect``'s ``except SummarizationFailed``
+        and land on ``@with_error_handling`` as a 500 — for a turn whose answer
+        had already been generated and stored.
+        """
+        summarizer = ConversationSummarizer()
+        messages = [
+            "not a dict at all",
+            {"role": "user", "content": [{"type": "text", "text": None}]},
+            {"role": "user", "content": "a real one"},
+        ]
+
+        mock_response = MagicMock()
+        mock_response.content = "Summary."
+        mock_gateway = AsyncMock()
+        mock_gateway.chat_completion.return_value = mock_response
+
+        with patch.object(summarizer, "_get_gateway", return_value=mock_gateway):
+            summary = await summarizer.summarize_messages(messages, "gpt-4")
+
+        assert summary == "Summary."
+        prompt = mock_gateway.chat_completion.call_args.kwargs["messages"][0]["content"]
+        assert "a real one" in prompt, "the well-formed message must still reach the summarizer"
+
+    @pytest.mark.asyncio
     async def test_a_formatting_bug_is_not_relabelled_a_summarization_failure(self):
         """#14065: the ``except Exception`` used to cover the whole body.
 
@@ -241,6 +270,10 @@ class TestContextOverflowProtection:
                 "completion_tokens": 306,
                 "message_count": 12,
             }
+            # #14065 review: without this a bare AsyncMock reports "recently
+            # failed" (truthy default) and this test would silently exercise the
+            # backoff path instead of the success path it is named for.
+            mock_tracker.summarization_recently_failed.return_value = False
             protection.tracker = mock_tracker
 
             # Mock summarizer
@@ -293,6 +326,10 @@ class TestSummarizationFailureIsNotReportedAsSuccess:
             "completion_tokens": 306,
             "message_count": 12,
         }
+        # Explicit rather than left to AsyncMock's truthy default: a bare mock
+        # would report "recently failed" and every test here would silently
+        # exercise the backoff path instead of the one it names.
+        mock_tracker.summarization_recently_failed.return_value = False
         protection.tracker = mock_tracker
         return protection, mock_tracker
 
@@ -350,6 +387,43 @@ class TestSummarizationFailureIsNotReportedAsSuccess:
 
         assert status["summary_text"] == ""
         assert "were summarized to preserve context" not in status["summary_error"]
+
+    @pytest.mark.asyncio
+    async def test_a_recent_failure_backs_off_instead_of_retrying_every_turn(self):
+        """#14065 review: compaction is awaited inline under the chat timeout.
+
+        Retrying on every turn against a provider that is already rate-limiting
+        spends the whole request budget failing, times out a turn whose answer
+        was already generated and stored, and — because the tracker is correctly
+        not reset — never recovers. The backoff bounds it to one attempt per
+        window without giving up the "stay over threshold and retry later"
+        property the issue asks for.
+        """
+        protection, mock_tracker = self._protection_at_92_percent()
+        mock_tracker.summarization_recently_failed.return_value = True
+
+        mock_summarizer = AsyncMock()
+        protection.summarizer = mock_summarizer
+
+        with patch.object(protection, "_get_context_limit", return_value=1000):
+            status = await protection.check_and_protect(
+                session_id="session-1",
+                model_name="gpt-4",
+                usage={"prompt_tokens": 10, "completion_tokens": 5},
+                mode="auto",
+                messages=[{"sender": "user", "text": f"Message {i}"} for i in range(10)],
+            )
+
+        mock_summarizer.summarize_messages.assert_not_awaited()
+        assert status["summary_created"] is False
+        assert "backing off" in status["summary_error"]
+        mock_tracker.reset_session.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_failure_arms_the_backoff_marker(self):
+        _, mock_tracker = await self._run_with_failing_summarizer(SummarizationFailed("provider 429"))
+
+        mock_tracker.mark_summarization_failed.assert_awaited_once_with("session-1")
 
     @pytest.mark.asyncio
     async def test_the_failure_survives_the_integration_seam(self):
@@ -461,3 +535,38 @@ class TestSummarizationFailureIsNotReportedAsSuccess:
             prompt_tokens=100,
             completion_tokens=50,
         )
+
+
+class TestTheTrackerIsNeverResetWithoutADeliveredSummary:
+    """#14065 review finding 3 — the same defect, one layer below the fix.
+
+    ``_create_summary`` reset the tracker and *then* re-added tokens for the
+    retained half. A malformed entry in that second half raised ``AttributeError``
+    with the counter already cleared and the paid-for summary discarded — not a
+    ``SummarizationFailed``, so ``check_and_protect``'s handler did not cover it.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_malformed_retained_message_does_not_clear_the_counter(self):
+        protection = ContextOverflowProtection()
+        mock_tracker = AsyncMock()
+        protection.tracker = mock_tracker
+
+        mock_summarizer = AsyncMock()
+        mock_summarizer.summarize_messages.return_value = "Summary."
+        protection.summarizer = mock_summarizer
+
+        # The malformed entries sit in the retained (second) half only, so the
+        # summarizer's own helpers are not what raises.
+        messages = [{"sender": "user", "text": f"m{i}"} for i in range(4)] + [
+            "not a dict",
+            {"sender": "user", "text": None},
+            {"sender": "user", "text": 12345},
+            {"sender": "user", "text": "fine"},
+        ]
+
+        summary = await protection._create_summary("session-1", messages, "gpt-4")
+
+        assert summary == "Summary."
+        mock_tracker.reset_session.assert_awaited_once_with("session-1")
+        assert mock_tracker.add_message_tokens.await_count == 4

--- a/autobot-backend/chat_history/context_overflow_test.py
+++ b/autobot-backend/chat_history/context_overflow_test.py
@@ -12,6 +12,7 @@ from chat_history.context_overflow import (
     ContextOverflowProtection,
     ConversationSummarizer,
     SessionTokenTracker,
+    SummarizationFailed,
 )
 
 
@@ -139,21 +140,51 @@ class TestConversationSummarizer:
         assert "Summary" in summary
 
     @pytest.mark.asyncio
-    async def test_summarize_llm_failure_fallback(self):
-        """Verify fallback when LLM fails."""
-        summarizer = ConversationSummarizer()
+    async def test_a_gateway_failure_raises_instead_of_returning_a_placeholder(self):
+        """#14065: the old behaviour returned a success-shaped placeholder here.
 
+        This test previously asserted that placeholder ("1 earlier message"),
+        pinning the defect in place: the caller could not distinguish "history
+        was compressed" from "history was destroyed and replaced with a sentence
+        saying it existed", so it reset the token tracker and reported success.
+        """
+        summarizer = ConversationSummarizer()
         messages = [{"sender": "user", "text": "Hello"}]
 
-        mock_gateway = AsyncMock()
-        mock_gateway.chat_completion.side_effect = Exception("LLM error")
-
         with patch.object(summarizer, "_get_gateway", side_effect=Exception("LLM error")):
-            summary = await summarizer.summarize_messages(messages, "gpt-4")
+            with pytest.raises(SummarizationFailed) as excinfo:
+                await summarizer.summarize_messages(messages, "gpt-4")
 
-        # Should return fallback placeholder
-        assert "Summary" in summary
-        assert "1 earlier message" in summary
+        assert "LLM error" in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_an_empty_completion_raises_rather_than_reading_as_a_summary(self):
+        """A provider that returns nothing is a failure, not a very short summary."""
+        summarizer = ConversationSummarizer()
+        messages = [{"sender": "user", "text": "Hello"}]
+
+        mock_response = MagicMock()
+        mock_response.content = "   "
+        mock_gateway = AsyncMock()
+        mock_gateway.chat_completion.return_value = mock_response
+
+        with patch.object(summarizer, "_get_gateway", return_value=mock_gateway):
+            with pytest.raises(SummarizationFailed):
+                await summarizer.summarize_messages(messages, "gpt-4")
+
+    @pytest.mark.asyncio
+    async def test_a_formatting_bug_is_not_relabelled_a_summarization_failure(self):
+        """#14065: the ``except Exception`` used to cover the whole body.
+
+        A crash in ``_format_messages`` is a programming error. Reported as a
+        summarization failure it would be retried on every turn forever, and the
+        real traceback would be buried under a generic provider-failure message.
+        """
+        summarizer = ConversationSummarizer()
+
+        with patch.object(summarizer, "_format_messages", side_effect=TypeError("bad message shape")):
+            with pytest.raises(TypeError, match="bad message shape"):
+                await summarizer.summarize_messages([{"sender": "user", "text": "x"}], "gpt-4")
 
 
 class TestContextOverflowProtection:
@@ -231,6 +262,123 @@ class TestContextOverflowProtection:
 
         # Verify summarizer was called
         mock_summarizer.summarize_messages.assert_called_once()
+
+        # The success path must still reset the tracker — the guard added in
+        # #14065 must not break working compaction.
+        mock_tracker.reset_session.assert_awaited_once_with("session-1")
+        assert status["summary_error"] == ""
+
+
+class TestSummarizationFailureIsNotReportedAsSuccess:
+    """#14065 — what happens to the session when compaction fails.
+
+    The damage was never the failed LLM call. It was that ``reset_session`` ran
+    unconditionally afterwards: the token counter went back to a fresh baseline
+    while the conversation was still full, so nothing ever re-triggered and the
+    session continued with the agent having silently forgotten the first half of
+    the work. Every observable signal — return value, status dict, info log —
+    said compaction succeeded.
+
+    These assert the *reproduction* (a failing summarization call through the
+    real ``check_and_protect`` path), not the predicate.
+    """
+
+    @staticmethod
+    def _protection_at_92_percent():
+        protection = ContextOverflowProtection(warning_threshold=0.80, compress_threshold=0.90)
+        mock_tracker = AsyncMock()
+        mock_tracker.get_session_usage.return_value = {
+            "total_tokens": 920,
+            "prompt_tokens": 614,
+            "completion_tokens": 306,
+            "message_count": 12,
+        }
+        protection.tracker = mock_tracker
+        return protection, mock_tracker
+
+    async def _run_with_failing_summarizer(self, side_effect):
+        protection, mock_tracker = self._protection_at_92_percent()
+        messages = [{"sender": "user", "text": f"Message {i}"} for i in range(10)]
+
+        mock_summarizer = AsyncMock()
+        mock_summarizer.summarize_messages.side_effect = side_effect
+        protection.summarizer = mock_summarizer
+
+        with patch.object(protection, "_get_context_limit", return_value=1000):
+            status = await protection.check_and_protect(
+                session_id="session-1",
+                model_name="gpt-4",
+                usage={"prompt_tokens": 10, "completion_tokens": 5},
+                mode="auto",
+                messages=messages,
+            )
+        return status, mock_tracker
+
+    @pytest.mark.asyncio
+    async def test_a_gateway_error_leaves_the_token_tracker_untouched(self):
+        status, mock_tracker = await self._run_with_failing_summarizer(
+            SummarizationFailed("summarization call failed: provider 429")
+        )
+
+        assert status["summary_created"] is False
+        assert status["summary_text"] == ""
+        assert "429" in status["summary_error"]
+        # The load-bearing assertion: an un-reset counter is what makes the next
+        # turn retry instead of proceeding on a lie.
+        mock_tracker.reset_session.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_an_empty_completion_leaves_the_token_tracker_untouched(self):
+        status, mock_tracker = await self._run_with_failing_summarizer(
+            SummarizationFailed("LLM returned empty summary")
+        )
+
+        assert status["summary_created"] is False
+        assert status["summary_text"] == ""
+        assert status["summary_error"]
+        mock_tracker.reset_session.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_placeholder_text_reaches_the_outbound_view(self):
+        """The placeholder is what got injected into the conversation.
+
+        ``summary_text`` is what the caller injects as a system message
+        (``create_summary_message``). On failure it must be empty, not a
+        sentence claiming the messages were summarized.
+        """
+        status, _ = await self._run_with_failing_summarizer(SummarizationFailed("provider timeout"))
+
+        assert status["summary_text"] == ""
+        assert "were summarized to preserve context" not in status["summary_error"]
+
+    @pytest.mark.asyncio
+    async def test_the_failure_survives_the_integration_seam(self):
+        """``handle_message_completion`` is what production actually calls."""
+        from chat_history import overflow_integration
+
+        protection, mock_tracker = self._protection_at_92_percent()
+        mock_summarizer = AsyncMock()
+        mock_summarizer.summarize_messages.side_effect = SummarizationFailed("provider 503")
+        protection.summarizer = mock_summarizer
+
+        llm_response = MagicMock()
+        llm_response.usage = {"prompt_tokens": 10, "completion_tokens": 5}
+
+        with (
+            patch.object(protection, "_get_context_limit", return_value=1000),
+            patch.object(overflow_integration, "get_overflow_protection", return_value=protection),
+        ):
+            status = await overflow_integration.handle_message_completion(
+                session_id="session-1",
+                model_name="gpt-4",
+                llm_response=llm_response,
+                messages=[{"sender": "user", "text": f"Message {i}"} for i in range(10)],
+                mode="auto",
+            )
+
+        assert status["summary_created"] is False
+        assert "503" in status["summary_error"]
+        mock_tracker.reset_session.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_disabled_mode_no_action(self):

--- a/autobot-backend/chat_history/overflow_integration.py
+++ b/autobot-backend/chat_history/overflow_integration.py
@@ -64,6 +64,10 @@ async def handle_message_completion(
             - warning_triggered: bool
             - summary_created: bool
             - summary_text: str (if summary created)
+            - summary_error: str — non-empty when compaction was attempted and
+              failed. ``summary_created is False`` alone cannot distinguish
+              "not attempted" from "attempted and failed"; check this to
+              degrade visibly instead of continuing on a lie (#14065).
             - current_fill_percentage: float
             - total_tokens: int
             - context_limit: int
@@ -116,6 +120,17 @@ async def handle_message_completion(
         logger.info(
             "Context auto-compressed for session %s: summary created",
             session_id,
+        )
+    elif status.get("summary_error"):
+        # #14065: previously unreachable — a failed summarization returned a
+        # placeholder that made this branch report success. A caller reading
+        # only summary_created cannot tell "not attempted" from "attempted and
+        # destroyed the history", so the error is surfaced separately.
+        logger.error(
+            "Context auto-compression FAILED for session %s at %.1f%% fill: %s",
+            session_id,
+            status["current_fill_percentage"] * 100,
+            status["summary_error"],
         )
 
     return status


### PR DESCRIPTION
Closes #14065.

## Thinking Path

The failed LLM call was never the damage. The damage was `reset_session` running unconditionally afterwards.

`summarize_messages` swallowed every exception and returned `"[Summary: N earlier message(s) were summarized to preserve context.]"` — a string that is **truthy and success-shaped**. `_create_summary` then reset the token tracker, and `check_and_protect` saw a truthy return and set `summary_created: True` with an info log saying the messages were compressed.

So a session at 90% fill whose provider returned a 429 ended up with: the oldest half of the conversation replaced by one sentence containing none of the goals, decisions, file paths or state the summarization prompt exists to preserve; the token counter reset to a fresh baseline, so nothing ever re-triggered; and every observable signal reporting success. The only record of the truth was a `logger.error` in a different line with no correlation to the session's later confusion.

Failure has to be **shaped** differently from success, not merely logged differently. A `logger.error` on one line and a truthy return on the next is a failure the caller cannot see.

Two design choices worth naming:

**Raise rather than return a sentinel.** A sentinel is only as good as the caller's discipline in checking it, and the caller here had already demonstrated it would not check. An exception makes the unconditional `reset_session` unreachable by construction — the tracker reset is now *physically* downstream of a successful summary, not merely conditionally so.

**Narrow the `except`.** The old clause covered the whole body, including `_sanitize_tool_messages` and `_format_messages`. Those are pure local transformations of the caller's own data; a crash in them is a programming error. Reported as a summarization failure it would be retried on every turn forever, with the real traceback buried under a generic provider message. They now run outside the `try` and surface as themselves.

## What Changed

`autobot-backend/chat_history/context_overflow.py`

- New `SummarizationFailed(RuntimeError)`, exported.
- `summarize_messages` raises it on gateway failure or an empty completion; the placeholder return is gone. Message formatting moved outside the `try`.
- `_create_summary` lets it propagate, so `reset_session` cannot run on a failed compaction.
- `check_and_protect` catches it, leaves `summary_created: False` and `summary_text: ""`, and records the reason in a new **`summary_error`** key.
- `summary_error` is always present in the result dict (empty on success), so a caller can branch on it without a `KeyError`.

`autobot-backend/chat_history/overflow_integration.py`

- `handle_message_completion` logs the failure at ERROR with the fill percentage. This branch was previously unreachable.
- Return-value docstring documents `summary_error`, including why `summary_created is False` alone is not enough: it cannot distinguish "not attempted" from "attempted and failed".

`autobot-backend/chat_history/context_overflow_test.py`

- `test_summarize_llm_failure_fallback` asserted the placeholder (`"1 earlier message"`) — it pinned the defect in place. Replaced with a test that the gateway failure raises.
- New: empty completion raises; a `_format_messages` crash surfaces as `TypeError`, not as a summarization failure.
- New `TestSummarizationFailureIsNotReportedAsSuccess` covering the reproduction through the real `check_and_protect` path: tracker not reset, `summary_created` False, no placeholder text in the outbound view, and the same through `handle_message_completion` — the function production actually calls.
- The existing success-path test now also asserts `reset_session` **is** awaited and `summary_error` is empty, so the guard cannot break working compaction.

## Verification

Verified against the reproduction, not the predicate — a failing summarization call driven through the real caller chain.

```
$ pytest autobot-backend/chat_history/context_overflow_test.py -q
18 passed

$ pytest autobot-backend/chat_history/ -q
128 passed

$ pytest autobot-backend/chat_workflow/ -q
401 passed
```

Swept by the type rather than the directory: `grep -rn "summary_created\|summarize_messages\|summary_text"` across `.py`/`.ts`/`.vue` found no consumer of this status dict outside the two files changed here.

**Mutation-tested, with no-op detection.** Each mutation was confirmed to have actually changed the file (`diff` against a saved copy) before the run — a mutation that fails to apply reads as "survived".

*Mutation 1 — restore the success-shaped placeholder:*
```
M1 applied (file differs)
FAILED ...::test_a_gateway_failure_raises_instead_of_returning_a_placeholder
1 failed, 17 passed
```

*Mutation 2 — the original defect: reset the tracker regardless of outcome:*
```
M2 applied (file differs)
FAILED ...::test_a_gateway_error_leaves_the_token_tracker_untouched
FAILED ...::test_an_empty_completion_leaves_the_token_tracker_untouched
FAILED ...::test_the_failure_survives_the_integration_seam
3 failed, 15 passed
```

Restored, 18 passed.

Mutation 2 is the one that matters: it is exactly the shipped behaviour, and three independent assertions catch it.

## Behaviour change to be aware of

A session whose summarization fails now stays over threshold and retries on the next turn instead of proceeding. That is deliberate — the issue calls for it — but it means a persistently failing provider produces repeated compaction attempts rather than one silent truncation. `summary_error` is what a caller needs to decide to degrade visibly (warn the user, hard-trim, refuse the turn); no caller consumes it yet, and choosing that policy is a separate change.

Related: #13593 — compaction runs on the main model and therefore inherits its rate limits, which is the most likely route into this failure path.

## Model Used

claude-opus-5
