### PR TITLE
fix(agent): extract and wire the pre-action verifier at the live tool seam (#14031)

### DIFF
--- a/autobot-backend/agent_loop/pre_action_verifier.py
+++ b/autobot-backend/agent_loop/pre_action_verifier.py
@@ -5,484 +5,92 @@
 """
 Adversarial pre-action verifier (#10547).
 
-An independent, differently-prompted second model that tries to REFUTE a
-plan or claim before the agent executes a consequential action.  It integrates
-into the existing approval gate in ``agent_loop/loop.py`` — not a parallel
-path.
+The decision surface now lives in the dependency-free
+``autobot_shared.pre_action_verifier_guard`` (#14031) so the production
+tool-dispatch seam (``chat_workflow/tool_handler.py``) can call it directly,
+the same way ``agent_loop/fact_forcing.py`` re-exports
+``autobot_shared.fact_forcing_guard`` (GH#11178). This module re-exports the
+loop-facing surface so ``AgentLoop`` and its tests keep working unchanged.
 
-Design:
-- ``PreActionVerifier.verify()`` is called from ``_check_approvals`` before
-  the user approval request is emitted.
-- A distinct provider is selected from the registry (different from the actor
-  provider when multiple providers are registered).
-- Verdict + rationale are published to the event bus (VERIFIER_VERDICT) and
-  recorded in the task trajectory so the human sees them at the approval gate.
-- Thresholds are module-level constants read from env vars (never hardcoded).
-- Optional N-of-M panel for highest-stakes actions (config-gated).
-
-Action classes and their block thresholds (env-configurable):
-  VERIFIER_THRESHOLD_DEPLOY  (default 0.5)  — deploy / infra
-  VERIFIER_THRESHOLD_MUTATE  (default 0.5)  — file / git mutations
-  VERIFIER_THRESHOLD_NETWORK (default 0.6)  — external HTTP POST/PUT/DELETE
-  VERIFIER_THRESHOLD_EXEC    (default 0.5)  — bash / code execution
-  VERIFIER_THRESHOLD_DEFAULT (default 0.5)  — anything else
-
-If the LLM refutation probability >= threshold the verdict is BLOCK, which
-causes ``_check_approvals`` to either hard-block (when
-``VERIFIER_HARD_BLOCK=1``) or escalate to human approval with the rationale
-attached.
+Module-level scalar constants (``HARD_BLOCK``, the ``THRESHOLD_*`` values,
+``VERIFIER_ENABLED``, ...) are proxied through ``__getattr__`` (PEP 562)
+rather than imported statically: ``agent_loop/loop.py`` re-imports
+``HARD_BLOCK`` fresh on every call (``from agent_loop.pre_action_verifier
+import HARD_BLOCK`` inside ``_check_approvals``), and a static ``from ...
+import HARD_BLOCK`` here would freeze a copy at THIS module's first import,
+independent of the source module's value — invisible to anything that
+patches or reloads ``autobot_shared.pre_action_verifier_guard`` afterwards.
+Proxying keeps this module a true re-export rather than a stale snapshot.
 """
 
-from __future__ import annotations
-
-import os
-from dataclasses import dataclass, field
-from datetime import datetime
-from enum import Enum
-from typing import Any
-
-from autobot_shared.env_utils import env_float, env_int
-from autobot_shared.logging_manager import get_logger
-from autobot_shared.time_utils import now_utc
-
-logger = get_logger(__name__)
-
-# ---------------------------------------------------------------------------
-# Module-level threshold constants (all env-configurable, never hardcoded)
-# ---------------------------------------------------------------------------
-
-#: Minimum refutation probability to block a deploy/infra action.
-THRESHOLD_DEPLOY: float = env_float("VERIFIER_THRESHOLD_DEPLOY", 0.5)
-#: Minimum refutation probability to block a file/git mutation.
-THRESHOLD_MUTATE: float = env_float("VERIFIER_THRESHOLD_MUTATE", 0.5)
-#: Minimum refutation probability to block an external HTTP mutating call.
-THRESHOLD_NETWORK: float = env_float("VERIFIER_THRESHOLD_NETWORK", 0.6)
-#: Minimum refutation probability to block a bash/code-execution call.
-THRESHOLD_EXEC: float = env_float("VERIFIER_THRESHOLD_EXEC", 0.5)
-#: Fallback threshold for any other action class.
-THRESHOLD_DEFAULT: float = env_float("VERIFIER_THRESHOLD_DEFAULT", 0.5)
-
-#: When 1, a BLOCK verdict hard-blocks without escalating to human.
-HARD_BLOCK: bool = os.environ.get("VERIFIER_HARD_BLOCK", "0") == "1"
-
-#: Number of verifiers dispatched for N-of-M panel (highest-stakes only).
-PANEL_SIZE: int = env_int("VERIFIER_PANEL_SIZE", 1)
-
-#: Minimum verifiers that must refute to trigger a panel block.
-PANEL_QUORUM: int = env_int("VERIFIER_PANEL_QUORUM", 1)
-
-#: Whether the verifier is enabled at all.
-VERIFIER_ENABLED: bool = os.environ.get("VERIFIER_ENABLED", "1") != "0"
-
-#: Token budget for the verifier LLM call.
-VERIFIER_MAX_TOKENS: int = env_int("VERIFIER_MAX_TOKENS", 512)
-
-#: Timeout in seconds for the verifier LLM call.
-VERIFIER_TIMEOUT_S: float = env_float("VERIFIER_TIMEOUT_S", 30.0)
-
-
-# ---------------------------------------------------------------------------
-# Action class mapping (tool name → threshold)
-# ---------------------------------------------------------------------------
-
-_DEPLOY_TOOLS = frozenset({"deploy", "ansible", "docker", "kubectl", "helm", "terraform"})
-_MUTATE_TOOLS = frozenset(
-    {
-        "write_file",
-        "edit_file",
-        "delete_file",
-        "move_file",
-        "copy_file",
-        "create_directory",
-        "remove_directory",
-        "git_push",
-        "git_commit",
-        "git_merge",
-        "git_rebase",
-        "git_reset",
-        "git_force_push",
-    }
+from autobot_shared import pre_action_verifier_guard as _guard
+from autobot_shared.pre_action_verifier_guard import (
+    PreActionVerifier,
+    VerifierResult,
+    VerifierVerdict,
+    _build_verifier_prompt,
+    _call_verifier_once,
+    _parse_probability,
+    _parse_rationale,
+    _select_verifier_provider,
+    _threshold_for_tool,
+    determine_verdict,
+    hard_block_active,
+    panel_decision,
+    pre_action_verifier_enabled,
+    threshold_for_tool,
 )
-_NETWORK_TOOLS = frozenset({"http_post", "http_put", "http_patch", "http_delete", "send_request"})
-_EXEC_TOOLS = frozenset(
-    {"bash", "shell", "execute_command", "run_command", "terminal", "system_exec", "code_interpreter"}
-)
-
-
-def _threshold_for_tool(tool_name: str) -> float:
-    """Return the refutation-probability block threshold for *tool_name*."""
-    name = tool_name.lower()
-    if name in _DEPLOY_TOOLS or any(name.startswith(t) for t in _DEPLOY_TOOLS):
-        return THRESHOLD_DEPLOY
-    if name in _MUTATE_TOOLS or any(name.startswith(t) for t in _MUTATE_TOOLS):
-        return THRESHOLD_MUTATE
-    if name in _NETWORK_TOOLS or any(name.startswith(t) for t in _NETWORK_TOOLS):
-        return THRESHOLD_NETWORK
-    if name in _EXEC_TOOLS or any(name.startswith(t) for t in _EXEC_TOOLS):
-        return THRESHOLD_EXEC
-    return THRESHOLD_DEFAULT
-
-
-# ---------------------------------------------------------------------------
-# Types
-# ---------------------------------------------------------------------------
-
-
-class VerifierVerdict(str, Enum):
-    """Decision produced by the adversarial verifier."""
-
-    PASS = "PASS"  # nosec B105  # verifier verdict label, not a credential; no flaw found — allow
-    BLOCK = "BLOCK"  # Flaw found — block or escalate to human.
-    SKIP = "SKIP"  # Verifier disabled or unavailable — allow through.
-
-
-@dataclass
-class VerifierResult:
-    """Full result of one verifier pass."""
-
-    verdict: VerifierVerdict
-    refutation_probability: float  # 0.0 = no flaw; 1.0 = definitely flawed
-    rationale: str
-    tool_name: str
-    task_id: str | None = None
-    provider_used: str | None = None
-    model_used: str | None = None
-    panel_size: int = 1
-    panel_refutations: int = 0
-    timestamp: datetime = field(default_factory=now_utc)
-
-    def to_dict(self) -> dict[str, Any]:
-        return {
-            "verdict": self.verdict.value,
-            "refutation_probability": self.refutation_probability,
-            "rationale": self.rationale,
-            "tool_name": self.tool_name,
-            "task_id": self.task_id,
-            "provider_used": self.provider_used,
-            "model_used": self.model_used,
-            "panel_size": self.panel_size,
-            "panel_refutations": self.panel_refutations,
-            "timestamp": self.timestamp.isoformat(),
-        }
-
-
-# ---------------------------------------------------------------------------
-# Prompt
-# ---------------------------------------------------------------------------
-
-_VERIFIER_SYSTEM = (
-    "You are an adversarial safety reviewer. "
-    "Your ONLY job is to find flaws, risks, or incorrect assumptions in a proposed agent action. "
-    "You MUST default to flagging the action as risky when you are uncertain. "
-    "Do NOT validate or endorse the action — assume the worst and look for problems."
-)
-
-_VERIFIER_USER_TMPL = """\
-## Proposed agent action
-Tool: {tool_name}
-Arguments:
-{args_block}
-
-## Agent's stated reason for this action
-{reason}
-
-## Your task
-Find any flaw, incorrect assumption, unintended side-effect, or security risk
-in the proposed action above.  Respond with EXACTLY this format (no extra text):
-
-REFUTATION_PROBABILITY: <float 0.0-1.0>
-FLAW: <one sentence describing the primary flaw, or "None" if probability < 0.3>
-RATIONALE: <two sentences maximum explaining your assessment>
-"""
-
-
-def _build_verifier_prompt(
-    tool_name: str,
-    args: dict[str, Any],
-    reason: str,
-) -> tuple[str, str]:
-    """Return (system_prompt, user_prompt) for the verifier LLM call."""
-    args_block = "\n".join(f"  {k}: {v!r}" for k, v in args.items()) or "  (none)"
-    user = _VERIFIER_USER_TMPL.format(
-        tool_name=tool_name,
-        args_block=args_block,
-        reason=reason or "No reason provided.",
-    )
-    return _VERIFIER_SYSTEM, user
-
-
-# ---------------------------------------------------------------------------
-# Provider selection — choose a distinct provider from the actor
-# ---------------------------------------------------------------------------
-
-
-async def _select_verifier_provider(actor_provider: str | None) -> Any:
-    """Return a provider instance different from *actor_provider* when possible.
-
-    Falls back to any available provider if no distinct one exists.
-    Returns None when no provider is available.
-    """
-    from llm_shared.provider_registry import get_provider_registry
-
-    registry = get_provider_registry()
-    all_names: list[str] = [p["name"] for p in registry.list_providers()]
-
-    # Prefer a provider that differs from the actor.
-    candidates = [n for n in all_names if n != actor_provider] or all_names
-    for name in candidates:
-        provider = await registry.get_provider(name)
-        if provider is not None:
-            return provider
-    return None
-
-
-# ---------------------------------------------------------------------------
-# Core verifier call
-# ---------------------------------------------------------------------------
-
-
-async def _call_verifier_once(
-    tool_name: str,
-    args: dict[str, Any],
-    reason: str,
-    actor_provider: str | None,
-) -> tuple[float, str, str | None, str | None]:
-    """Call the verifier LLM once.
-
-    Returns (refutation_probability, rationale, provider_name, model_name).
-    On error returns (0.0, error_message, None, None) — fail-open so a broken
-    verifier does not hard-block the agent.
-    """
-    from llm_shared.models import LLMRequest
-
-    provider = await _select_verifier_provider(actor_provider)
-    if provider is None:
-        logger.warning("pre_action_verifier: no provider available — skipping")
-        return 0.0, "No verifier provider available.", None, None
-
-    system_prompt, user_prompt = _build_verifier_prompt(tool_name, args, reason)
-    request = LLMRequest(
-        messages=[
-            {"role": "system", "content": system_prompt},
-            {"role": "user", "content": user_prompt},
-        ],
-        max_tokens=VERIFIER_MAX_TOKENS,
-        temperature=0.1,  # Low temperature for adversarial consistency
-        metadata={"purpose": "pre_action_verifier", "tool": tool_name},
-    )
-    try:
-        import asyncio as _asyncio
-
-        response = await _asyncio.wait_for(
-            provider.chat_completion(request),
-            timeout=VERIFIER_TIMEOUT_S,
-        )
-    except Exception as exc:
-        logger.warning(
-            "pre_action_verifier: LLM call failed (%s: %r) — failing open",
-            type(exc).__name__,
-            exc,
-        )
-        return 0.0, f"Verifier LLM error: {exc!r}", None, None
-
-    raw = response.content or ""
-    prob = _parse_probability(raw)
-    rationale = _parse_rationale(raw)
-    return prob, rationale, provider.provider_name, getattr(response, "model", None)
-
-
-def _parse_probability(raw: str) -> float:
-    """Extract REFUTATION_PROBABILITY from the verifier response."""
-    for line in raw.splitlines():
-        stripped = line.strip()
-        if stripped.upper().startswith("REFUTATION_PROBABILITY:"):
-            value_str = stripped[len("REFUTATION_PROBABILITY:") :].strip()
-            try:
-                return max(0.0, min(1.0, float(value_str)))
-            except ValueError:
-                pass
-    return 0.5  # Conservative default when parsing fails
-
-
-def _parse_rationale(raw: str) -> str:
-    """Extract RATIONALE from the verifier response."""
-    lines = raw.splitlines()
-    collecting = False
-    parts: list[str] = []
-    for line in lines:
-        stripped = line.strip()
-        if stripped.upper().startswith("RATIONALE:"):
-            parts.append(stripped[len("RATIONALE:") :].strip())
-            collecting = True
-        elif collecting and stripped:
-            parts.append(stripped)
-    return " ".join(parts) if parts else raw[:300].strip()
-
-
-# ---------------------------------------------------------------------------
-# Public API
-# ---------------------------------------------------------------------------
-
-
-class PreActionVerifier:
-    """Adversarial pre-action verifier integrated into the approval gate.
-
-    Instantiate once per agent loop; pass *actor_provider* so the verifier
-    can select a distinct model when available.
-    """
-
-    def __init__(self, actor_provider: str | None = None) -> None:
-        self._actor_provider = actor_provider
-
-    async def verify(
-        self,
-        tool_name: str,
-        args: dict[str, Any],
-        reason: str,
-        task_id: str | None = None,
-        *,
-        panel_size: int | None = None,
-    ) -> VerifierResult:
-        """Run the adversarial verification pass for a proposed action.
-
-        Args:
-            tool_name: Name of the tool about to be executed.
-            args: Tool arguments dict.
-            reason: Reason / context the agent provided for this action.
-            task_id: Current task identifier for trajectory recording.
-            panel_size: Override the module-level PANEL_SIZE for this call.
-
-        Returns:
-            VerifierResult with verdict, rationale, and metadata.
-        """
-        if not VERIFIER_ENABLED:
-            return VerifierResult(
-                verdict=VerifierVerdict.SKIP,
-                refutation_probability=0.0,
-                rationale="Verifier disabled via VERIFIER_ENABLED=0",
-                tool_name=tool_name,
-                task_id=task_id,
-            )
-
-        n = panel_size if panel_size is not None else PANEL_SIZE
-        threshold = _threshold_for_tool(tool_name)
-
-        if n <= 1:
-            return await self._run_single(tool_name, args, reason, task_id, threshold)
-        return await self._run_panel(tool_name, args, reason, task_id, threshold, n)
-
-    async def _run_single(
-        self,
-        tool_name: str,
-        args: dict[str, Any],
-        reason: str,
-        task_id: str | None,
-        threshold: float,
-    ) -> VerifierResult:
-        """Single-verifier path (default)."""
-        prob, rationale, prov, model = await _call_verifier_once(tool_name, args, reason, self._actor_provider)
-        verdict = VerifierVerdict.BLOCK if prob >= threshold else VerifierVerdict.PASS
-        result = VerifierResult(
-            verdict=verdict,
-            refutation_probability=prob,
-            rationale=rationale,
-            tool_name=tool_name,
-            task_id=task_id,
-            provider_used=prov,
-            model_used=model,
-            panel_size=1,
-            panel_refutations=1 if verdict == VerifierVerdict.BLOCK else 0,
-        )
-        self._log_result(result, threshold)
-        return result
-
-    async def _run_panel(
-        self,
-        tool_name: str,
-        args: dict[str, Any],
-        reason: str,
-        task_id: str | None,
-        threshold: float,
-        n: int,
-    ) -> VerifierResult:
-        """N-of-M panel path for highest-stakes actions."""
-        import asyncio
-
-        tasks = [
-            asyncio.create_task(_call_verifier_once(tool_name, args, reason, self._actor_provider)) for _ in range(n)
-        ]
-        panel_results = await asyncio.gather(*tasks, return_exceptions=True)
-
-        refutations = 0
-        probs: list[float] = []
-        rationales: list[str] = []
-        prov: str | None = None
-        model: str | None = None
-
-        for r in panel_results:
-            if isinstance(r, Exception):
-                continue
-            prob, rat, p, m = r
-            probs.append(prob)
-            rationales.append(rat)
-            if p:
-                prov = p
-            if m:
-                model = m
-            if prob >= threshold:
-                refutations += 1
-
-        avg_prob = sum(probs) / len(probs) if probs else 0.0
-        verdict = VerifierVerdict.BLOCK if refutations >= PANEL_QUORUM else VerifierVerdict.PASS
-        rationale = " | ".join(r for r in rationales if r)[:600]
-        result = VerifierResult(
-            verdict=verdict,
-            refutation_probability=avg_prob,
-            rationale=rationale,
-            tool_name=tool_name,
-            task_id=task_id,
-            provider_used=prov,
-            model_used=model,
-            panel_size=n,
-            panel_refutations=refutations,
-        )
-        self._log_result(result, threshold)
-        return result
-
-    @staticmethod
-    def _log_result(result: VerifierResult, threshold: float) -> None:
-        """Log the verifier result at appropriate level."""
-        if result.verdict == VerifierVerdict.BLOCK:
-            logger.warning(
-                "pre_action_verifier: BLOCK tool=%s prob=%.2f threshold=%.2f provider=%s | %s",
-                result.tool_name,
-                result.refutation_probability,
-                threshold,
-                result.provider_used,
-                result.rationale[:120],
-            )
-        else:
-            logger.info(
-                "pre_action_verifier: %s tool=%s prob=%.2f threshold=%.2f provider=%s",
-                result.verdict.value,
-                result.tool_name,
-                result.refutation_probability,
-                threshold,
-                result.provider_used,
-            )
-
 
 __all__ = [
     "PreActionVerifier",
     "VerifierResult",
     "VerifierVerdict",
-    "THRESHOLD_DEPLOY",
-    "THRESHOLD_MUTATE",
-    "THRESHOLD_NETWORK",
-    "THRESHOLD_EXEC",
-    "THRESHOLD_DEFAULT",
-    "HARD_BLOCK",
-    "PANEL_SIZE",
-    "PANEL_QUORUM",
-    "VERIFIER_ENABLED",
+    "THRESHOLD_DEPLOY",  # noqa: F822 — resolved via module __getattr__, see below
+    "THRESHOLD_MUTATE",  # noqa: F822
+    "THRESHOLD_NETWORK",  # noqa: F822
+    "THRESHOLD_EXEC",  # noqa: F822
+    "THRESHOLD_DEFAULT",  # noqa: F822
+    "HARD_BLOCK",  # noqa: F822
+    "PANEL_SIZE",  # noqa: F822
+    "PANEL_QUORUM",  # noqa: F822
+    "VERIFIER_ENABLED",  # noqa: F822
+    "VERIFIER_MAX_TOKENS",  # noqa: F822
+    "VERIFIER_TIMEOUT_S",  # noqa: F822
+    "determine_verdict",
+    "panel_decision",
+    "threshold_for_tool",
+    "hard_block_active",
+    "pre_action_verifier_enabled",
+    # Private names kept importable for the existing test surface
+    # (agent_loop/tests/test_pre_action_verifier.py).
+    "_build_verifier_prompt",
+    "_call_verifier_once",
+    "_parse_probability",
+    "_parse_rationale",
+    "_select_verifier_provider",
+    "_threshold_for_tool",
 ]
+
+# Names proxied live from `autobot_shared.pre_action_verifier_guard` — see the
+# module docstring for why these aren't plain `from ... import NAME`.
+_PROXIED = frozenset(
+    {
+        "THRESHOLD_DEPLOY",
+        "THRESHOLD_MUTATE",
+        "THRESHOLD_NETWORK",
+        "THRESHOLD_EXEC",
+        "THRESHOLD_DEFAULT",
+        "HARD_BLOCK",
+        "PANEL_SIZE",
+        "PANEL_QUORUM",
+        "VERIFIER_ENABLED",
+        "VERIFIER_MAX_TOKENS",
+        "VERIFIER_TIMEOUT_S",
+    }
+)
+
+
+def __getattr__(name: str) -> object:
+    if name in _PROXIED:
+        return getattr(_guard, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/autobot-backend/agent_loop/pre_action_verifier.py
+++ b/autobot-backend/agent_loop/pre_action_verifier.py
@@ -41,21 +41,27 @@ from autobot_shared.pre_action_verifier_guard import (
     threshold_for_tool,
 )
 
-__all__ = [
+# flake8 reports F822 against this assignment line, not against the individual
+# entries, so a per-entry `# noqa` never applies — it has to live here. The
+# scalar names below are resolved live through the module `__getattr__` defined
+# further down rather than bound statically, because `agent_loop/loop.py`
+# re-imports `HARD_BLOCK` fresh on every call and a static copy would go stale
+# against the source module. See the module docstring.
+__all__ = [  # noqa: F822
     "PreActionVerifier",
     "VerifierResult",
     "VerifierVerdict",
-    "THRESHOLD_DEPLOY",  # noqa: F822 — resolved via module __getattr__, see below
-    "THRESHOLD_MUTATE",  # noqa: F822
-    "THRESHOLD_NETWORK",  # noqa: F822
-    "THRESHOLD_EXEC",  # noqa: F822
-    "THRESHOLD_DEFAULT",  # noqa: F822
-    "HARD_BLOCK",  # noqa: F822
-    "PANEL_SIZE",  # noqa: F822
-    "PANEL_QUORUM",  # noqa: F822
-    "VERIFIER_ENABLED",  # noqa: F822
-    "VERIFIER_MAX_TOKENS",  # noqa: F822
-    "VERIFIER_TIMEOUT_S",  # noqa: F822
+    "THRESHOLD_DEPLOY",
+    "THRESHOLD_MUTATE",
+    "THRESHOLD_NETWORK",
+    "THRESHOLD_EXEC",
+    "THRESHOLD_DEFAULT",
+    "HARD_BLOCK",
+    "PANEL_SIZE",
+    "PANEL_QUORUM",
+    "VERIFIER_ENABLED",
+    "VERIFIER_MAX_TOKENS",
+    "VERIFIER_TIMEOUT_S",
     "determine_verdict",
     "panel_decision",
     "threshold_for_tool",

--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -3173,7 +3173,10 @@ class ToolHandlerMixin:
         if not isinstance(args, dict):
             args = {"value": repr(args)}
         reason = tool_call.get("reason", "")
-        task_id = ctx.session_id if ctx is not None else None
+        # `session_id` is only used as an opaque trajectory/log identifier here —
+        # optional like `requires_approval_before` above, so a ctx double missing
+        # it (as several existing seam tests use) must not crash the guard.
+        task_id = getattr(ctx, "session_id", None) if ctx is not None else None
 
         result = await PreActionVerifier().verify(tool_name, args, reason, task_id=task_id)
         if result.verdict != VerifierVerdict.BLOCK:

--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING, Any, AsyncIterator
 from async_chat_workflow import WorkflowMessage
 from autobot_shared.env_utils import env_flag, env_int
 from autobot_shared.logging_manager import get_logger
-from autobot_shared.tool_catalogue import APPROVAL_CATEGORY_TOOLS, match_tool_name
+from autobot_shared.tool_catalogue import APPROVAL_CATEGORY_TOOLS, SENSITIVE_TOOLS, match_tool_name
 from chat_workflow.code_exec.tool_policy import CODEEXEC_READONLY_TOOLS
 from chat_workflow.tool_call_grammar import TOOL_CALL_PATTERN
 from llc.agent_tools import LLC_TOOL_NAMES, LLC_TOOL_SCHEMAS, LLCToolError, dispatch_llc_tool
@@ -3134,6 +3134,94 @@ class ToolHandlerMixin:
             metadata={"tool": name, "error": True, "fact_forcing": True},
         )
 
+    async def _enforce_pre_action_verifier(
+        self,
+        tool_call: dict[str, Any],
+        ctx: "LLMIterationContext" | None,
+        execution_results: list[dict[str, Any]],
+    ) -> WorkflowMessage | None:
+        """Run the adversarial pre-action verifier on a sensitive tool call (#14031).
+
+        ``PreActionVerifier`` (#10547) existed only inside the dormant ``AgentLoop``
+        (no production caller — #13587/#14031); this is its first production
+        caller. Scope matches the original: only tools in the canonical
+        ``SENSITIVE_TOOLS`` set are verified, the same set ``AgentLoop._sensitive_tool_name``
+        gated on. Gated on ``pre_action_verifier_enabled``, resolved through the
+        guard profile (defaults ``True`` — ``agent_loop/types.py:266``).
+
+        A BLOCK verdict with ``VERIFIER_HARD_BLOCK=1`` hard-blocks the call,
+        preserving the original semantics exactly. Without hard-block, the call
+        is held pending approval with the verifier's rationale attached — the
+        same ``pending_approval`` shape ``_enforce_work_item_approval`` already
+        uses at this seam. A broken or unavailable verifier fails open
+        (SKIP/PASS via ``PreActionVerifier.verify``) and never blocks the loop.
+        """
+        from autobot_shared.pre_action_verifier_guard import (
+            HARD_BLOCK,
+            PreActionVerifier,
+            VerifierVerdict,
+            pre_action_verifier_enabled,
+        )
+
+        tool_name = tool_call.get("name", "")
+        if match_tool_name(tool_name, SENSITIVE_TOOLS) is None:
+            return None
+        if not pre_action_verifier_enabled():
+            return None
+
+        args = tool_call.get("params") or tool_call.get("arguments") or {}
+        if not isinstance(args, dict):
+            args = {"value": repr(args)}
+        reason = tool_call.get("reason", "")
+        task_id = ctx.session_id if ctx is not None else None
+
+        result = await PreActionVerifier().verify(tool_name, args, reason, task_id=task_id)
+        if result.verdict != VerifierVerdict.BLOCK:
+            return None
+
+        if HARD_BLOCK:
+            error = (
+                f"Tool '{tool_name}' was hard-blocked by the adversarial verifier "
+                f"(prob={result.refutation_probability:.2f}): {result.rationale}"
+            )
+            logger.warning(
+                "[#14031] verifier hard-blocked tool '%s' — %s", tool_name, result.rationale[:120]
+            )
+            execution_results.append(
+                {"tool": tool_name, "status": "error", "error": error, "verifier_hard_block": True}
+            )
+            return WorkflowMessage(
+                type="error",
+                content=error,
+                metadata={"tool": tool_name, "error": True, "verifier_hard_block": True},
+            )
+
+        msg = (
+            f"Action '{tool_name}' requires approval before proceeding — the adversarial "
+            f"verifier flagged it (prob={result.refutation_probability:.2f}): {result.rationale}"
+        )
+        logger.warning(
+            "[#14031] verifier held tool '%s' pending approval — %s", tool_name, result.rationale[:120]
+        )
+        execution_results.append(
+            {
+                "tool": tool_name,
+                "status": "pending_approval",
+                "reason": msg,
+                "verifier_rationale": result.rationale,
+                "verifier_refutation_probability": result.refutation_probability,
+            }
+        )
+        return WorkflowMessage(
+            type="approval_required",
+            content=msg,
+            metadata={
+                "tool": tool_name,
+                "approval_required": True,
+                "verifier_rationale": result.rationale,
+            },
+        )
+
     def _enforce_repetition(
         self,
         tool_call: dict[str, Any],
@@ -3275,6 +3363,16 @@ class ToolHandlerMixin:
         fact_msg = self._enforce_fact_forcing(tool_call, ctx, execution_results)
         if fact_msg is not None:
             yield fact_msg
+            return
+
+        # #14031: adversarial pre-action verifier — an independent, differently
+        # prompted model tries to REFUTE a sensitive action before it executes.
+        # Runs before the approval hold below so a HARD_BLOCK verdict short-circuits
+        # without ever reaching the human approval step, matching the original
+        # AgentLoop._check_approvals ordering.
+        verifier_msg = await self._enforce_pre_action_verifier(tool_call, ctx, execution_results)
+        if verifier_msg is not None:
+            yield verifier_msg
             return
 
         # GH#11160: hold a tool the work item declared as approval-gated

--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -3184,9 +3184,7 @@ class ToolHandlerMixin:
                 f"Tool '{tool_name}' was hard-blocked by the adversarial verifier "
                 f"(prob={result.refutation_probability:.2f}): {result.rationale}"
             )
-            logger.warning(
-                "[#14031] verifier hard-blocked tool '%s' — %s", tool_name, result.rationale[:120]
-            )
+            logger.warning("[#14031] verifier hard-blocked tool '%s' — %s", tool_name, result.rationale[:120])
             execution_results.append(
                 {"tool": tool_name, "status": "error", "error": error, "verifier_hard_block": True}
             )
@@ -3200,9 +3198,7 @@ class ToolHandlerMixin:
             f"Action '{tool_name}' requires approval before proceeding — the adversarial "
             f"verifier flagged it (prob={result.refutation_probability:.2f}): {result.rationale}"
         )
-        logger.warning(
-            "[#14031] verifier held tool '%s' pending approval — %s", tool_name, result.rationale[:120]
-        )
+        logger.warning("[#14031] verifier held tool '%s' pending approval — %s", tool_name, result.rationale[:120])
         execution_results.append(
             {
                 "tool": tool_name,

--- a/autobot-backend/tests/unit/chat_workflow/test_tool_handler_pre_action_verifier.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_tool_handler_pre_action_verifier.py
@@ -32,7 +32,19 @@ def _mixin() -> ToolHandlerMixin:
 
 
 def _ctx() -> SimpleNamespace:
-    return SimpleNamespace(session_id="sess-1", context={})
+    # `agent_context`/`requires_approval_before`/`consecutive_invalid_tool_calls`
+    # are only touched by the OTHER stops on the seam (forbidden_work,
+    # work-item approval, the unknown-tool fallback) — included here so this
+    # stand-in also survives a full `_dispatch_tool_call` drive that falls
+    # through past the verifier (e.g. under the mutation test below), not just
+    # direct `_enforce_pre_action_verifier` calls.
+    return SimpleNamespace(
+        session_id="sess-1",
+        context={},
+        agent_context=None,
+        requires_approval_before=None,
+        consecutive_invalid_tool_calls=0,
+    )
 
 
 def _call(name: str = "write_file", **args) -> dict:
@@ -48,13 +60,58 @@ def _verdict(verdict: VerifierVerdict, prob: float = 0.9, rationale: str = "flaw
     )
 
 
-def test_the_guard_is_reached_from_the_dispatch_seam() -> None:
-    """`_dispatch_tool_call` must actually call it — a guard nothing invokes is #14031 all over again."""
+def test_the_call_site_still_names_the_enforcer() -> None:
+    """Rename guard, NOT a wiring guard (see `test_the_live_dispatch_seam_...` below).
+
+    A source-text substring check proves the call is *written*, not that it is
+    *reached* — it stays green if the call sits after an early `return`, behind
+    a condition that is never true, or is otherwise made dead while the text
+    stays in the file. It exists only to catch the call site being renamed or
+    deleted outright; it is deliberately NOT relied on for wiring proof.
+    """
     import inspect
 
     source = inspect.getsource(ToolHandlerMixin._dispatch_tool_call)
 
     assert "_enforce_pre_action_verifier(" in source
+
+
+@pytest.mark.asyncio
+async def test_the_live_dispatch_seam_reaches_and_awaits_the_verifier() -> None:
+    """Behavioural wiring proof: drive the REAL `_dispatch_tool_call`, not a text scan.
+
+    Patches `PreActionVerifier.verify` and asserts it was awaited with the
+    call the seam should have passed it, end to end through the actual
+    enforcer chain (forbidden_work -> config_protection -> fact_forcing ->
+    verifier -> ...). This is what catches the failure mode a source-text
+    check cannot: the call site present in the file but unreachable.
+    """
+    verify_mock = AsyncMock(return_value=_verdict(VerifierVerdict.BLOCK, prob=0.9, rationale="flawed"))
+    execution_results: list = []
+    messages = []
+
+    with patch("autobot_shared.pre_action_verifier_guard.PreActionVerifier.verify", new=verify_mock):
+        async for item in _mixin()._dispatch_tool_call(
+            _call("write_file", path="/tmp/a"),
+            "session-1",
+            "term-1",
+            "http://localhost:11434",
+            "test-model",
+            execution_results,
+            [],
+            ctx=_ctx(),
+        ):
+            messages.append(item)
+
+    verify_mock.assert_awaited_once()
+    awaited = verify_mock.await_args
+    assert awaited.args[0] == "write_file"
+    assert awaited.args[1] == {"path": "/tmp/a"}
+    assert awaited.kwargs.get("task_id") == "sess-1"
+    # The BLOCK verdict short-circuits dispatch — only the verifier's own
+    # message is yielded, proving the call was reached mid-seam, not bypassed.
+    assert len(messages) == 1
+    assert messages[0].type == "approval_required"
 
 
 @pytest.mark.asyncio

--- a/autobot-backend/tests/unit/chat_workflow/test_tool_handler_pre_action_verifier.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_tool_handler_pre_action_verifier.py
@@ -1,0 +1,153 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Dispatch-level pre-action verifier enforcement (#10547, extracted #14031).
+
+Proves the adversarial pre-action verifier — previously reachable only through
+the dormant `AgentLoop` (no production caller, #13587/#14031) — now fires on
+the real production tool-dispatch seam (`ToolHandlerMixin._dispatch_tool_call`
+via `_enforce_pre_action_verifier`). Only `SENSITIVE_TOOLS` are verified, a
+BLOCK verdict with `VERIFIER_HARD_BLOCK=1` hard-blocks, and without it the call
+is held pending approval with the verifier's rationale attached.
+
+The unit-level behaviour of the pure decision surface (threshold resolution,
+verdict determination) lives in
+`autobot_shared/pre_action_verifier_guard_test.py`. What is asserted here is
+the seam wiring.
+"""
+
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from autobot_shared.pre_action_verifier_guard import VerifierResult, VerifierVerdict
+from chat_workflow.tool_handler import ToolHandlerMixin
+
+
+def _mixin() -> ToolHandlerMixin:
+    return ToolHandlerMixin.__new__(ToolHandlerMixin)
+
+
+def _ctx() -> SimpleNamespace:
+    return SimpleNamespace(session_id="sess-1", context={})
+
+
+def _call(name: str = "write_file", **args) -> dict:
+    return {"name": name, "params": args or {"path": "/tmp/a"}}
+
+
+def _verdict(verdict: VerifierVerdict, prob: float = 0.9, rationale: str = "flawed") -> VerifierResult:
+    return VerifierResult(
+        verdict=verdict,
+        refutation_probability=prob,
+        rationale=rationale,
+        tool_name="write_file",
+    )
+
+
+def test_the_guard_is_reached_from_the_dispatch_seam() -> None:
+    """`_dispatch_tool_call` must actually call it — a guard nothing invokes is #14031 all over again."""
+    import inspect
+
+    source = inspect.getsource(ToolHandlerMixin._dispatch_tool_call)
+
+    assert "_enforce_pre_action_verifier(" in source
+
+
+@pytest.mark.asyncio
+async def test_a_non_sensitive_tool_is_never_verified() -> None:
+    """respond/delegate/read_file etc. are outside SENSITIVE_TOOLS — no LLM round trip."""
+    with patch(
+        "autobot_shared.pre_action_verifier_guard.PreActionVerifier.verify",
+        new=AsyncMock(side_effect=AssertionError("verify() must not be called for a non-sensitive tool")),
+    ):
+        result = await _mixin()._enforce_pre_action_verifier(_call("read_file"), _ctx(), [])
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_disabled_via_guard_profile_is_a_no_op() -> None:
+    with (
+        patch.dict(os.environ, {"AUTOBOT_GUARD_VERIFIER": "0"}, clear=False),
+        patch(
+            "autobot_shared.pre_action_verifier_guard.PreActionVerifier.verify",
+            new=AsyncMock(side_effect=AssertionError("verify() must not run when the guard is disabled")),
+        ),
+    ):
+        result = await _mixin()._enforce_pre_action_verifier(_call(), _ctx(), [])
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_a_pass_verdict_lets_the_call_proceed() -> None:
+    with patch(
+        "autobot_shared.pre_action_verifier_guard.PreActionVerifier.verify",
+        new=AsyncMock(return_value=_verdict(VerifierVerdict.PASS, prob=0.1)),
+    ):
+        execution_results: list = []
+        result = await _mixin()._enforce_pre_action_verifier(_call(), _ctx(), execution_results)
+
+    assert result is None
+    assert execution_results == []
+
+
+@pytest.mark.asyncio
+async def test_block_without_hard_block_holds_for_approval_with_rationale() -> None:
+    with (
+        patch.dict(os.environ, {}, clear=False),
+        patch(
+            "autobot_shared.pre_action_verifier_guard.HARD_BLOCK",
+            False,
+        ),
+        patch(
+            "autobot_shared.pre_action_verifier_guard.PreActionVerifier.verify",
+            new=AsyncMock(return_value=_verdict(VerifierVerdict.BLOCK, prob=0.92, rationale="path does not exist")),
+        ),
+    ):
+        execution_results: list = []
+        result = await _mixin()._enforce_pre_action_verifier(_call(), _ctx(), execution_results)
+
+    assert result is not None
+    assert result.type == "approval_required"
+    assert "path does not exist" in result.content
+    assert execution_results[-1]["status"] == "pending_approval"
+    assert execution_results[-1]["verifier_rationale"] == "path does not exist"
+
+
+@pytest.mark.asyncio
+async def test_block_with_hard_block_stops_the_call_outright() -> None:
+    with (
+        patch(
+            "autobot_shared.pre_action_verifier_guard.HARD_BLOCK",
+            True,
+        ),
+        patch(
+            "autobot_shared.pre_action_verifier_guard.PreActionVerifier.verify",
+            new=AsyncMock(return_value=_verdict(VerifierVerdict.BLOCK, prob=0.95, rationale="hard-blocked reason")),
+        ),
+    ):
+        execution_results: list = []
+        result = await _mixin()._enforce_pre_action_verifier(_call(), _ctx(), execution_results)
+
+    assert result is not None
+    assert result.type == "error"
+    assert result.metadata.get("verifier_hard_block") is True
+    assert execution_results[-1]["status"] == "error"
+    assert execution_results[-1]["verifier_hard_block"] is True
+
+
+@pytest.mark.asyncio
+async def test_works_without_a_context() -> None:
+    """Unlike repetition/fact-forcing the verifier carries no per-turn state — no ctx needed."""
+    with patch(
+        "autobot_shared.pre_action_verifier_guard.PreActionVerifier.verify",
+        new=AsyncMock(return_value=_verdict(VerifierVerdict.PASS, prob=0.1)),
+    ):
+        result = await _mixin()._enforce_pre_action_verifier(_call(), None, [])
+
+    assert result is None

--- a/autobot_shared/pre_action_verifier_guard.py
+++ b/autobot_shared/pre_action_verifier_guard.py
@@ -1,0 +1,553 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Adversarial pre-action verifier decision surface (#10547, extracted #14031).
+
+The verifier machinery lived in ``agent_loop/pre_action_verifier.py`` and ran
+nowhere: ``AgentLoop`` has no production caller, so ``pre_action_verifier_enabled``
+defaulting to ``True`` (``agent_loop/types.py:266``) read as an active guard while
+executing on no request (#13587, #14031). #13590 is the template this follows:
+the fact-forcing and repetition guards moved to ``autobot_shared`` and the
+production tool seam (``chat_workflow/tool_handler.py``) calls them directly.
+
+Unlike those two guards, the verifier's job is inherently an I/O call — an
+independent, differently-prompted model tries to REFUTE a proposed action
+before it executes. That call cannot be made pure. What CAN be, and is here:
+
+- Action-class threshold resolution (``threshold_for_tool``).
+- Response parsing (``parse_probability`` / ``parse_rationale``).
+- Verdict determination from a probability and threshold
+  (``determine_verdict`` / ``panel_decision``) — this is what preserves the
+  ``HARD_BLOCK`` semantics exactly, and is unit-testable with zero network I/O.
+
+``PreActionVerifier`` composes those pure functions with the LLM call. The
+live seam (``chat_workflow/tool_handler.py``) owns invoking it — the side
+effect — and only asks the pure functions to interpret the result.
+
+``agent_loop/pre_action_verifier.py`` re-exports this module's public surface
+so ``AgentLoop`` and its tests keep working unchanged (the ``fact_forcing``
+precedent).
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Any
+
+from autobot_shared.env_utils import env_float, env_int
+from autobot_shared.logging_manager import get_logger
+from autobot_shared.time_utils import now_utc
+
+logger = get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Module-level threshold constants (all env-configurable, never hardcoded)
+# ---------------------------------------------------------------------------
+
+#: Minimum refutation probability to block a deploy/infra action.
+THRESHOLD_DEPLOY: float = env_float("VERIFIER_THRESHOLD_DEPLOY", 0.5)
+#: Minimum refutation probability to block a file/git mutation.
+THRESHOLD_MUTATE: float = env_float("VERIFIER_THRESHOLD_MUTATE", 0.5)
+#: Minimum refutation probability to block an external HTTP mutating call.
+THRESHOLD_NETWORK: float = env_float("VERIFIER_THRESHOLD_NETWORK", 0.6)
+#: Minimum refutation probability to block a bash/code-execution call.
+THRESHOLD_EXEC: float = env_float("VERIFIER_THRESHOLD_EXEC", 0.5)
+#: Fallback threshold for any other action class.
+THRESHOLD_DEFAULT: float = env_float("VERIFIER_THRESHOLD_DEFAULT", 0.5)
+
+#: When 1, a BLOCK verdict hard-blocks without escalating to human.
+HARD_BLOCK: bool = os.environ.get("VERIFIER_HARD_BLOCK", "0") == "1"
+
+#: Number of verifiers dispatched for N-of-M panel (highest-stakes only).
+PANEL_SIZE: int = env_int("VERIFIER_PANEL_SIZE", 1)
+
+#: Minimum verifiers that must refute to trigger a panel block.
+PANEL_QUORUM: int = env_int("VERIFIER_PANEL_QUORUM", 1)
+
+#: Whether the verifier is enabled at all.
+VERIFIER_ENABLED: bool = os.environ.get("VERIFIER_ENABLED", "1") != "0"
+
+#: Token budget for the verifier LLM call.
+VERIFIER_MAX_TOKENS: int = env_int("VERIFIER_MAX_TOKENS", 512)
+
+#: Timeout in seconds for the verifier LLM call.
+VERIFIER_TIMEOUT_S: float = env_float("VERIFIER_TIMEOUT_S", 30.0)
+
+
+# ---------------------------------------------------------------------------
+# Action class mapping (tool name -> threshold) — pure
+# ---------------------------------------------------------------------------
+
+_DEPLOY_TOOLS = frozenset({"deploy", "ansible", "docker", "kubectl", "helm", "terraform"})
+_MUTATE_TOOLS = frozenset(
+    {
+        "write_file",
+        "edit_file",
+        "delete_file",
+        "move_file",
+        "copy_file",
+        "create_directory",
+        "remove_directory",
+        "git_push",
+        "git_commit",
+        "git_merge",
+        "git_rebase",
+        "git_reset",
+        "git_force_push",
+    }
+)
+_NETWORK_TOOLS = frozenset({"http_post", "http_put", "http_patch", "http_delete", "send_request"})
+_EXEC_TOOLS = frozenset(
+    {"bash", "shell", "execute_command", "run_command", "terminal", "system_exec", "code_interpreter"}
+)
+
+
+def _threshold_for_tool(tool_name: str) -> float:
+    """Return the refutation-probability block threshold for *tool_name*."""
+    name = tool_name.lower()
+    if name in _DEPLOY_TOOLS or any(name.startswith(t) for t in _DEPLOY_TOOLS):
+        return THRESHOLD_DEPLOY
+    if name in _MUTATE_TOOLS or any(name.startswith(t) for t in _MUTATE_TOOLS):
+        return THRESHOLD_MUTATE
+    if name in _NETWORK_TOOLS or any(name.startswith(t) for t in _NETWORK_TOOLS):
+        return THRESHOLD_NETWORK
+    if name in _EXEC_TOOLS or any(name.startswith(t) for t in _EXEC_TOOLS):
+        return THRESHOLD_EXEC
+    return THRESHOLD_DEFAULT
+
+
+# Public alias — the private name above is kept for the existing test import
+# surface (``agent_loop.tests.test_pre_action_verifier``).
+threshold_for_tool = _threshold_for_tool
+
+
+# ---------------------------------------------------------------------------
+# Types
+# ---------------------------------------------------------------------------
+
+
+class VerifierVerdict(str, Enum):
+    """Decision produced by the adversarial verifier."""
+
+    PASS = "PASS"  # nosec B105  # verifier verdict label, not a credential; no flaw found — allow
+    BLOCK = "BLOCK"  # Flaw found — block or escalate to human.
+    SKIP = "SKIP"  # Verifier disabled or unavailable — allow through.
+
+
+@dataclass
+class VerifierResult:
+    """Full result of one verifier pass."""
+
+    verdict: VerifierVerdict
+    refutation_probability: float  # 0.0 = no flaw; 1.0 = definitely flawed
+    rationale: str
+    tool_name: str
+    task_id: str | None = None
+    provider_used: str | None = None
+    model_used: str | None = None
+    panel_size: int = 1
+    panel_refutations: int = 0
+    timestamp: datetime = field(default_factory=now_utc)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "verdict": self.verdict.value,
+            "refutation_probability": self.refutation_probability,
+            "rationale": self.rationale,
+            "tool_name": self.tool_name,
+            "task_id": self.task_id,
+            "provider_used": self.provider_used,
+            "model_used": self.model_used,
+            "panel_size": self.panel_size,
+            "panel_refutations": self.panel_refutations,
+            "timestamp": self.timestamp.isoformat(),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Verdict determination — pure (this is the HARD_BLOCK-preserving surface)
+# ---------------------------------------------------------------------------
+
+
+def determine_verdict(refutation_probability: float, threshold: float) -> VerifierVerdict:
+    """Return BLOCK when *refutation_probability* meets *threshold*, else PASS.
+
+    The single-verifier decision rule, unchanged from the original module:
+    ``>=`` is a block. Pure — no I/O, no config reads.
+    """
+    return VerifierVerdict.BLOCK if refutation_probability >= threshold else VerifierVerdict.PASS
+
+
+def panel_decision(
+    probabilities: list[float],
+    threshold: float,
+    quorum: int,
+) -> tuple[VerifierVerdict, int]:
+    """Return ``(verdict, refutations)`` for an N-of-M panel. Pure.
+
+    A probability "refutes" when it meets *threshold*; the panel BLOCKs when
+    the refutation count reaches *quorum*.
+    """
+    refutations = sum(1 for p in probabilities if p >= threshold)
+    verdict = VerifierVerdict.BLOCK if refutations >= quorum else VerifierVerdict.PASS
+    return verdict, refutations
+
+
+def hard_block_active() -> bool:
+    """Return the current ``HARD_BLOCK`` posture (module constant, env-resolved at import)."""
+    return HARD_BLOCK
+
+
+def pre_action_verifier_enabled() -> bool:
+    """Resolve ``pre_action_verifier_enabled`` from the guard profile (#14031).
+
+    Mirrors ``repetition_guard.max_identical_tool_calls()``: profile + per-guard
+    env override, falling back to the ``AgentLoopConfig`` dataclass default
+    (``True``) when the active profile carries no override — ``standard``
+    deliberately carries none, so it reproduces that default.
+    """
+    from agent_loop.guard_profile import resolve_guard_config_overrides  # noqa: PLC0415
+    from agent_loop.types import AgentLoopConfig  # noqa: PLC0415
+
+    overrides = resolve_guard_config_overrides()
+    value = overrides.get("pre_action_verifier_enabled", AgentLoopConfig.pre_action_verifier_enabled)
+    return bool(value)
+
+
+# ---------------------------------------------------------------------------
+# Prompt — pure
+# ---------------------------------------------------------------------------
+
+_VERIFIER_SYSTEM = (
+    "You are an adversarial safety reviewer. "
+    "Your ONLY job is to find flaws, risks, or incorrect assumptions in a proposed agent action. "
+    "You MUST default to flagging the action as risky when you are uncertain. "
+    "Do NOT validate or endorse the action — assume the worst and look for problems."
+)
+
+_VERIFIER_USER_TMPL = """\
+## Proposed agent action
+Tool: {tool_name}
+Arguments:
+{args_block}
+
+## Agent's stated reason for this action
+{reason}
+
+## Your task
+Find any flaw, incorrect assumption, unintended side-effect, or security risk
+in the proposed action above.  Respond with EXACTLY this format (no extra text):
+
+REFUTATION_PROBABILITY: <float 0.0-1.0>
+FLAW: <one sentence describing the primary flaw, or "None" if probability < 0.3>
+RATIONALE: <two sentences maximum explaining your assessment>
+"""
+
+
+def _build_verifier_prompt(
+    tool_name: str,
+    args: dict[str, Any],
+    reason: str,
+) -> tuple[str, str]:
+    """Return (system_prompt, user_prompt) for the verifier LLM call."""
+    args_block = "\n".join(f"  {k}: {v!r}" for k, v in args.items()) or "  (none)"
+    user = _VERIFIER_USER_TMPL.format(
+        tool_name=tool_name,
+        args_block=args_block,
+        reason=reason or "No reason provided.",
+    )
+    return _VERIFIER_SYSTEM, user
+
+
+# ---------------------------------------------------------------------------
+# Provider selection — choose a distinct provider from the actor (I/O)
+# ---------------------------------------------------------------------------
+
+
+async def _select_verifier_provider(actor_provider: str | None) -> Any:
+    """Return a provider instance different from *actor_provider* when possible.
+
+    Falls back to any available provider if no distinct one exists.
+    Returns None when no provider is available.
+    """
+    from llm_shared.provider_registry import get_provider_registry
+
+    registry = get_provider_registry()
+    all_names: list[str] = [p["name"] for p in registry.list_providers()]
+
+    # Prefer a provider that differs from the actor.
+    candidates = [n for n in all_names if n != actor_provider] or all_names
+    for name in candidates:
+        provider = await registry.get_provider(name)
+        if provider is not None:
+            return provider
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Core verifier call (I/O)
+# ---------------------------------------------------------------------------
+
+
+async def _call_verifier_once(
+    tool_name: str,
+    args: dict[str, Any],
+    reason: str,
+    actor_provider: str | None,
+) -> tuple[float, str, str | None, str | None]:
+    """Call the verifier LLM once.
+
+    Returns (refutation_probability, rationale, provider_name, model_name).
+    On error returns (0.0, error_message, None, None) — fail-open so a broken
+    verifier does not hard-block the agent.
+    """
+    from llm_shared.models import LLMRequest
+
+    provider = await _select_verifier_provider(actor_provider)
+    if provider is None:
+        logger.warning("pre_action_verifier: no provider available — skipping")
+        return 0.0, "No verifier provider available.", None, None
+
+    system_prompt, user_prompt = _build_verifier_prompt(tool_name, args, reason)
+    request = LLMRequest(
+        messages=[
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt},
+        ],
+        max_tokens=VERIFIER_MAX_TOKENS,
+        temperature=0.1,  # Low temperature for adversarial consistency
+        metadata={"purpose": "pre_action_verifier", "tool": tool_name},
+    )
+    try:
+        import asyncio as _asyncio
+
+        response = await _asyncio.wait_for(
+            provider.chat_completion(request),
+            timeout=VERIFIER_TIMEOUT_S,
+        )
+    except Exception as exc:
+        logger.warning(
+            "pre_action_verifier: LLM call failed (%s: %r) — failing open",
+            type(exc).__name__,
+            exc,
+        )
+        return 0.0, f"Verifier LLM error: {exc!r}", None, None
+
+    raw = response.content or ""
+    prob = _parse_probability(raw)
+    rationale = _parse_rationale(raw)
+    return prob, rationale, provider.provider_name, getattr(response, "model", None)
+
+
+def _parse_probability(raw: str) -> float:
+    """Extract REFUTATION_PROBABILITY from the verifier response. Pure."""
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if stripped.upper().startswith("REFUTATION_PROBABILITY:"):
+            value_str = stripped[len("REFUTATION_PROBABILITY:") :].strip()
+            try:
+                return max(0.0, min(1.0, float(value_str)))
+            except ValueError:
+                pass
+    return 0.5  # Conservative default when parsing fails
+
+
+def _parse_rationale(raw: str) -> str:
+    """Extract RATIONALE from the verifier response. Pure."""
+    lines = raw.splitlines()
+    collecting = False
+    parts: list[str] = []
+    for line in lines:
+        stripped = line.strip()
+        if stripped.upper().startswith("RATIONALE:"):
+            parts.append(stripped[len("RATIONALE:") :].strip())
+            collecting = True
+        elif collecting and stripped:
+            parts.append(stripped)
+    return " ".join(parts) if parts else raw[:300].strip()
+
+
+# Public aliases — the private names above are kept for the existing test
+# import surface (``agent_loop.tests.test_pre_action_verifier``).
+parse_probability = _parse_probability
+parse_rationale = _parse_rationale
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+class PreActionVerifier:
+    """Adversarial pre-action verifier integrated into the approval gate.
+
+    Instantiate once per agent loop / dispatch; pass *actor_provider* so the
+    verifier can select a distinct model when available.
+    """
+
+    def __init__(self, actor_provider: str | None = None) -> None:
+        self._actor_provider = actor_provider
+
+    async def verify(
+        self,
+        tool_name: str,
+        args: dict[str, Any],
+        reason: str,
+        task_id: str | None = None,
+        *,
+        panel_size: int | None = None,
+    ) -> VerifierResult:
+        """Run the adversarial verification pass for a proposed action.
+
+        Args:
+            tool_name: Name of the tool about to be executed.
+            args: Tool arguments dict.
+            reason: Reason / context the agent provided for this action.
+            task_id: Current task identifier for trajectory recording.
+            panel_size: Override the module-level PANEL_SIZE for this call.
+
+        Returns:
+            VerifierResult with verdict, rationale, and metadata.
+        """
+        if not VERIFIER_ENABLED:
+            return VerifierResult(
+                verdict=VerifierVerdict.SKIP,
+                refutation_probability=0.0,
+                rationale="Verifier disabled via VERIFIER_ENABLED=0",
+                tool_name=tool_name,
+                task_id=task_id,
+            )
+
+        n = panel_size if panel_size is not None else PANEL_SIZE
+        threshold = _threshold_for_tool(tool_name)
+
+        if n <= 1:
+            return await self._run_single(tool_name, args, reason, task_id, threshold)
+        return await self._run_panel(tool_name, args, reason, task_id, threshold, n)
+
+    async def _run_single(
+        self,
+        tool_name: str,
+        args: dict[str, Any],
+        reason: str,
+        task_id: str | None,
+        threshold: float,
+    ) -> VerifierResult:
+        """Single-verifier path (default)."""
+        prob, rationale, prov, model = await _call_verifier_once(tool_name, args, reason, self._actor_provider)
+        verdict = determine_verdict(prob, threshold)
+        result = VerifierResult(
+            verdict=verdict,
+            refutation_probability=prob,
+            rationale=rationale,
+            tool_name=tool_name,
+            task_id=task_id,
+            provider_used=prov,
+            model_used=model,
+            panel_size=1,
+            panel_refutations=1 if verdict == VerifierVerdict.BLOCK else 0,
+        )
+        self._log_result(result, threshold)
+        return result
+
+    async def _run_panel(
+        self,
+        tool_name: str,
+        args: dict[str, Any],
+        reason: str,
+        task_id: str | None,
+        threshold: float,
+        n: int,
+    ) -> VerifierResult:
+        """N-of-M panel path for highest-stakes actions."""
+        import asyncio
+
+        tasks = [
+            asyncio.create_task(_call_verifier_once(tool_name, args, reason, self._actor_provider)) for _ in range(n)
+        ]
+        panel_results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        probs: list[float] = []
+        rationales: list[str] = []
+        prov: str | None = None
+        model: str | None = None
+
+        for r in panel_results:
+            if isinstance(r, Exception):
+                continue
+            prob, rat, p, m = r
+            probs.append(prob)
+            rationales.append(rat)
+            if p:
+                prov = p
+            if m:
+                model = m
+
+        verdict, refutations = panel_decision(probs, threshold, PANEL_QUORUM)
+        avg_prob = sum(probs) / len(probs) if probs else 0.0
+        rationale = " | ".join(r for r in rationales if r)[:600]
+        result = VerifierResult(
+            verdict=verdict,
+            refutation_probability=avg_prob,
+            rationale=rationale,
+            tool_name=tool_name,
+            task_id=task_id,
+            provider_used=prov,
+            model_used=model,
+            panel_size=n,
+            panel_refutations=refutations,
+        )
+        self._log_result(result, threshold)
+        return result
+
+    @staticmethod
+    def _log_result(result: VerifierResult, threshold: float) -> None:
+        """Log the verifier result at appropriate level."""
+        if result.verdict == VerifierVerdict.BLOCK:
+            logger.warning(
+                "pre_action_verifier: BLOCK tool=%s prob=%.2f threshold=%.2f provider=%s | %s",
+                result.tool_name,
+                result.refutation_probability,
+                threshold,
+                result.provider_used,
+                result.rationale[:120],
+            )
+        else:
+            logger.info(
+                "pre_action_verifier: %s tool=%s prob=%.2f threshold=%.2f provider=%s",
+                result.verdict.value,
+                result.tool_name,
+                result.refutation_probability,
+                threshold,
+                result.provider_used,
+            )
+
+
+__all__ = [
+    "PreActionVerifier",
+    "VerifierResult",
+    "VerifierVerdict",
+    "THRESHOLD_DEPLOY",
+    "THRESHOLD_MUTATE",
+    "THRESHOLD_NETWORK",
+    "THRESHOLD_EXEC",
+    "THRESHOLD_DEFAULT",
+    "HARD_BLOCK",
+    "PANEL_SIZE",
+    "PANEL_QUORUM",
+    "VERIFIER_ENABLED",
+    "VERIFIER_MAX_TOKENS",
+    "VERIFIER_TIMEOUT_S",
+    "determine_verdict",
+    "panel_decision",
+    "threshold_for_tool",
+    "hard_block_active",
+    "pre_action_verifier_enabled",
+    "parse_probability",
+    "parse_rationale",
+]

--- a/autobot_shared/pre_action_verifier_guard.py
+++ b/autobot_shared/pre_action_verifier_guard.py
@@ -41,6 +41,7 @@ from typing import Any
 
 from autobot_shared.env_utils import env_float, env_int
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.ssot_constants import CategoryDefaults
 from autobot_shared.time_utils import now_utc
 
 logger = get_logger(__name__)
@@ -316,8 +317,8 @@ async def _call_verifier_once(
     system_prompt, user_prompt = _build_verifier_prompt(tool_name, args, reason)
     request = LLMRequest(
         messages=[
-            {"role": "system", "content": system_prompt},
-            {"role": "user", "content": user_prompt},
+            {"role": CategoryDefaults.ROLE_SYSTEM, "content": system_prompt},
+            {"role": CategoryDefaults.ROLE_USER, "content": user_prompt},
         ],
         max_tokens=VERIFIER_MAX_TOKENS,
         temperature=0.1,  # Low temperature for adversarial consistency

--- a/autobot_shared/pre_action_verifier_guard.py
+++ b/autobot_shared/pre_action_verifier_guard.py
@@ -480,7 +480,17 @@ class PreActionVerifier:
 
         for r in panel_results:
             if isinstance(r, Exception):
+                # One panellist failing is a degraded panel, not a failed one —
+                # panel_decision works on however many probabilities arrived.
                 continue
+            if isinstance(r, BaseException):
+                # `return_exceptions=True` also captures BaseExceptions that are
+                # NOT Exceptions — asyncio.CancelledError above all. Swallowing
+                # a cancellation would keep this coroutine running after its
+                # caller gave up, so it propagates. This is also what mypy's
+                # "BaseException object is not iterable" was pointing at: the
+                # narrowing above left that case reaching the unpack below.
+                raise r
             prob, rat, p, m = r
             probs.append(prob)
             rationales.append(rat)

--- a/autobot_shared/pre_action_verifier_guard_test.py
+++ b/autobot_shared/pre_action_verifier_guard_test.py
@@ -1,0 +1,151 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for the pre-action verifier decision surface (#10547, extracted #14031).
+
+The verifier's LLM call cannot be made pure — this covers what CAN be: action-
+class threshold resolution, response parsing, and verdict determination
+(single-shot and panel). The ``HARD_BLOCK`` verdict semantics are the part the
+extraction must preserve exactly, so ``determine_verdict``/``panel_decision``
+get the most direct coverage.
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from autobot_shared.pre_action_verifier_guard import (
+    THRESHOLD_DEFAULT,
+    THRESHOLD_DEPLOY,
+    THRESHOLD_EXEC,
+    THRESHOLD_MUTATE,
+    THRESHOLD_NETWORK,
+    VerifierVerdict,
+    determine_verdict,
+    panel_decision,
+    parse_probability,
+    parse_rationale,
+    pre_action_verifier_enabled,
+    threshold_for_tool,
+)
+
+# --------------------------------------------------------------- thresholds
+
+
+def test_deploy_tools_map_to_the_deploy_threshold():
+    for name in ("deploy", "ansible", "kubectl", "helm", "terraform"):
+        assert threshold_for_tool(name) == THRESHOLD_DEPLOY
+
+
+def test_mutate_tools_map_to_the_mutate_threshold():
+    for name in ("write_file", "edit_file", "delete_file", "git_push", "git_commit"):
+        assert threshold_for_tool(name) == THRESHOLD_MUTATE
+
+
+def test_network_tools_map_to_the_network_threshold():
+    for name in ("http_post", "http_put", "http_patch", "http_delete", "send_request"):
+        assert threshold_for_tool(name) == THRESHOLD_NETWORK
+
+
+def test_exec_tools_map_to_the_exec_threshold():
+    for name in ("bash", "shell", "execute_command", "code_interpreter"):
+        assert threshold_for_tool(name) == THRESHOLD_EXEC
+
+
+def test_unknown_tool_falls_back_to_the_default_threshold():
+    assert threshold_for_tool("some_exotic_tool") == THRESHOLD_DEFAULT
+
+
+def test_prefix_matching_still_maps_a_deploy_variant():
+    assert threshold_for_tool("ansible_playbook") == THRESHOLD_DEPLOY
+
+
+# ------------------------------------------------------ verdict determination
+# This is the surface the HARD_BLOCK semantics depend on — it must preserve
+# the original ">=" rule exactly.
+
+
+def test_probability_at_or_above_threshold_blocks():
+    assert determine_verdict(0.5, 0.5) == VerifierVerdict.BLOCK
+    assert determine_verdict(0.9, 0.5) == VerifierVerdict.BLOCK
+
+
+def test_probability_below_threshold_passes():
+    assert determine_verdict(0.49, 0.5) == VerifierVerdict.PASS
+    assert determine_verdict(0.0, 0.5) == VerifierVerdict.PASS
+
+
+def test_panel_blocks_once_quorum_of_refutations_is_reached():
+    verdict, refutations = panel_decision([0.9, 0.9, 0.1], threshold=0.5, quorum=2)
+
+    assert verdict == VerifierVerdict.BLOCK
+    assert refutations == 2
+
+
+def test_panel_passes_below_quorum():
+    verdict, refutations = panel_decision([0.9, 0.1, 0.1], threshold=0.5, quorum=2)
+
+    assert verdict == VerifierVerdict.PASS
+    assert refutations == 1
+
+
+def test_panel_decision_on_empty_probabilities_never_blocks():
+    verdict, refutations = panel_decision([], threshold=0.5, quorum=1)
+
+    assert verdict == VerifierVerdict.PASS
+    assert refutations == 0
+
+
+# ------------------------------------------------------------------- parsing
+
+
+def test_parse_probability_reads_the_structured_line():
+    raw = "REFUTATION_PROBABILITY: 0.85\nFLAW: x\nRATIONALE: y"
+    assert parse_probability(raw) == pytest.approx(0.85)
+
+
+def test_parse_probability_clamps_to_the_unit_interval():
+    assert parse_probability("REFUTATION_PROBABILITY: 1.5") == pytest.approx(1.0)
+    assert parse_probability("REFUTATION_PROBABILITY: -0.2") == pytest.approx(0.0)
+
+
+def test_parse_probability_defaults_conservatively_on_malformed_input():
+    assert parse_probability("nothing here") == pytest.approx(0.5)
+
+
+def test_parse_rationale_extracts_the_labeled_text():
+    raw = "REFUTATION_PROBABILITY: 0.9\nFLAW: bad\nRATIONALE: the path does not exist."
+    assert "path does not exist" in parse_rationale(raw)
+
+
+def test_parse_rationale_falls_back_to_raw_text_when_unlabeled():
+    result = parse_rationale("no structured output at all")
+    assert len(result) > 0
+
+
+# ---------------------------------------------------- enable/disable config
+
+
+def test_pre_action_verifier_enabled_defaults_true():
+    """agent_loop/types.py:266 — the dataclass default the standard profile reproduces."""
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("AUTOBOT_GUARD_PROFILE", None)
+        os.environ.pop("AUTOBOT_GUARD_VERIFIER", None)
+        assert pre_action_verifier_enabled() is True
+
+
+def test_minimal_profile_disables_the_verifier():
+    with patch.dict(os.environ, {"AUTOBOT_GUARD_PROFILE": "minimal"}, clear=False):
+        os.environ.pop("AUTOBOT_GUARD_VERIFIER", None)
+        assert pre_action_verifier_enabled() is False
+
+
+def test_per_guard_env_override_wins_over_the_profile():
+    with patch.dict(
+        os.environ,
+        {"AUTOBOT_GUARD_PROFILE": "minimal", "AUTOBOT_GUARD_VERIFIER": "1"},
+        clear=False,
+    ):
+        assert pre_action_verifier_enabled() is True

--- a/venv
+++ b/venv
@@ -1,0 +1,1 @@
+/home/martins/AutoBot-Ai/AutoBot-AI/venv


### PR DESCRIPTION
Part of #14031.

## Thinking Path

#14031 lists two extractions: the pre-action verifier and belief-state
tracking. This PR does only the first — `PreActionVerifier` — because its
`pre_action_verifier_enabled` defaults to `True` (`agent_loop/types.py:266`),
so today it reads as an active guard while executing on no request (`AgentLoop`
has no production caller). Belief-state's flag defaults `False`, so it is off
*and* unreachable — a smaller, separable problem left for a follow-up.

Template: #13590 (closed). Extract the decision surface into `autobot_shared/`,
leave the original module as a re-export (the `fact_forcing` precedent), call
it from the live seam in `chat_workflow/tool_handler.py`.

Unlike `repetition_guard`/`fact_forcing_guard`, the verifier's job is an LLM
call — it cannot be made fully pure. What moved to `autobot_shared/` and IS
pure/unit-tested: action-class threshold resolution, response parsing, and
verdict determination (`determine_verdict`/`panel_decision` — the surface that
preserves the `HARD_BLOCK` semantics exactly). The LLM call orchestration
(`PreActionVerifier.verify`) moved alongside it so `agent_loop/pre_action_verifier.py`
can stay a thin re-export, same as `fact_forcing`.

## What Changed

- **New**: `autobot_shared/pre_action_verifier_guard.py` — the full decision
  surface + `PreActionVerifier` class, dependency-free of `agent_loop` (only
  lazy-imports `agent_loop.guard_profile`/`agent_loop.types` inside
  `pre_action_verifier_enabled()`, mirroring `repetition_guard.max_identical_tool_calls()`).
- **Changed**: `agent_loop/pre_action_verifier.py` is now a re-export. Scalar
  constants (`HARD_BLOCK`, `THRESHOLD_*`, ...) are proxied through module
  `__getattr__` rather than statically imported — `agent_loop/loop.py`
  re-imports `HARD_BLOCK` fresh on every call inside `_check_approvals`, and a
  static import would have frozen a stale copy, invisible to anything patching
  the source module (this broke one existing test during verification; fixed
  by proxying instead of copying).
- **Changed**: `chat_workflow/tool_handler.py` — new `_enforce_pre_action_verifier`
  enforcer, called from `_dispatch_tool_call` between fact-forcing and the
  work-item approval hold (matching where `AgentLoop._check_approvals` ran the
  verifier: before the approval step). Scoped to `autobot_shared.tool_catalogue.SENSITIVE_TOOLS`
  — the same set `AgentLoop._sensitive_tool_name` gated on — and gated on
  `pre_action_verifier_enabled()` (guard-profile resolved, defaults `True`). A
  `BLOCK` verdict with `VERIFIER_HARD_BLOCK=1` hard-blocks the call, exactly
  preserving the original semantics; without it, the call is held
  `pending_approval` with the verifier's rationale attached, reusing the shape
  `_enforce_work_item_approval` already uses at this seam. A broken/unavailable
  verifier fails open (unchanged from the original).
- **New tests**: `autobot_shared/pre_action_verifier_guard_test.py` (pure
  decision-surface unit tests) and
  `autobot-backend/tests/unit/chat_workflow/test_tool_handler_pre_action_verifier.py`
  (seam wiring, including the required wiring assertion).

### Seam insertion point

`chat_workflow/tool_handler.py::_dispatch_tool_call`, right after
`_enforce_fact_forcing` and before `_enforce_work_item_approval`. Traced the
enforcer chain end to end first: forbidden_work → config_protection →
fact_forcing → **verifier (new)** → work_item_approval → repetition, each an
early-return gate before the tool actually dispatches. This position mirrors
`AgentLoop._check_approvals`, where the verifier ran immediately before the
human-approval request — so a `HARD_BLOCK` short-circuits before any approval
plumbing, and a soft block's rationale is available to attach to the
subsequent hold.

### What the now-live guard will newly block

Nothing was gated on `PreActionVerifier` in production before this PR — the
guard executed on no request. With this PR, `pre_action_verifier_enabled`
being `True` by default means every call to a `SENSITIVE_TOOLS` tool (31 names:
`write_file`, `delete_file`, `bash`/`execute_command`/`shell`, `git_push`,
`git_force_push`, `deploy`/`kubectl`/`terraform`, `http_post`, ...) now gets an
independent adversarial LLM pass before it executes. `VERIFIER_HARD_BLOCK`
defaults to `0`, so by default a `BLOCK` verdict does **not** reject the call —
it holds it `pending_approval` with the rationale attached, which is new
behaviour for tools that previously had no approval gate at this seam at all
(e.g. `write_file`, `git_push` — only `execute_command` had its own approval
flow before).

Running the pure decision logic (`determine_verdict` + `threshold_for_tool`)
against representative refutation probabilities:

```
write_file       prob=0.10 threshold=0.50 -> PASS   (well-grounded, prior read confirmed path)
write_file       prob=0.60 threshold=0.50 -> BLOCK  (plausible but unconfirmed target)
delete_file      prob=0.70 threshold=0.50 -> BLOCK  (delete without a prior existence check)
execute_command  prob=0.20 threshold=0.50 -> PASS   (ls -la, read-only, low risk)
execute_command  prob=0.55 threshold=0.50 -> BLOCK  (rm -rf on an unconfirmed path)
git_push         prob=0.30 threshold=0.50 -> PASS   (push after tests referenced this turn)
git_force_push   prob=0.65 threshold=0.50 -> BLOCK  (force-push with no stated reason)
kubectl          prob=0.50 threshold=0.50 -> BLOCK  (kubectl apply, borderline)
http_post        prob=0.55 threshold=0.60 -> PASS   (below the 0.6 network threshold)
http_post        prob=0.65 threshold=0.60 -> BLOCK  (above the 0.6 network threshold)
```

**Finding, not just a detail**: `execute_command` is in `SENSITIVE_TOOLS` and
is almost certainly the highest-volume sensitive tool in production. It
already has its own approval flow (`_handle_pending_approval`, session-scoped
pending state). This PR adds the verifier's LLM round trip (up to
`VERIFIER_TIMEOUT_S=30s`, fails open on timeout/no-provider) in front of that
existing flow for *every* shell command, not just risky ones — matching the
original `AgentLoop` scope exactly (it verified every sensitive tool, not a
narrower "risky" subset), but that scope was never exercised before because
`AgentLoop` never ran in production. This is a real latency/cost tradeoff, not
a bug: I did not narrow the guard to work around it. If per-environment
latency turns out to be a problem, the options are (a) tune
`VERIFIER_TIMEOUT_S`/thresholds, (b) exempt read-only-flavoured `execute_command`
invocations via a cheap pre-check, or (c) accept it as the cost of the guard
finally running. That's a product call, not mine to make unilaterally, so I'm
flagging it here and on #14031 rather than quietly loosening the gate.

## Verification

```
./venv/bin/python -m pytest autobot_shared/pre_action_verifier_guard_test.py \
  autobot-backend/tests/unit/chat_workflow/test_tool_handler_pre_action_verifier.py \
  autobot-backend/agent_loop/tests/test_pre_action_verifier.py -q
# 51 passed

./venv/bin/python -m pytest autobot-backend/agent_loop/ autobot-backend/chat_workflow/ -q
# 621 passed

./venv/bin/python -m pytest autobot_shared/ -q
# 1738 passed, 3 failed — pre-existing #14035 (editable-install layout), reproduced
# identically on main tree HEAD, unrelated to this change

./venv/bin/python -m pytest autobot-backend/tests/orchestration/test_agent_registry_fail_closed.py -q
# 27 passed (the suite a prior sweep-scope mistake broke — checked per the type
# of change, not just the touched directories)
```

**Wiring-assertion mutation test**: removed the
`await self._enforce_pre_action_verifier(...)` call site from
`_dispatch_tool_call` by direct file edit (not `git stash`), confirmed via
`grep` that the call site was gone, re-ran
`test_the_guard_is_reached_from_the_dispatch_seam` — it failed
(`AssertionError: assert '_enforce_pre_action_verifier(' in '...'`). Restored
the file from the pre-mutation copy, confirmed the call site was back via
`grep`, and reran the full targeted suite green (51 passed).

`ruff check` clean on every touched/added file.

## Left for the follow-up (explicitly out of scope here)

- Extracting `BeliefState`/`BeliefStateUpdater` into `autobot_shared/` and
  wiring it into the tool seam where results are already collected.
- Deciding `belief_state_enabled`'s default deliberately once it is reachable.

Both tracked on #14031, which stays open until the belief-state slice lands.

## Model Used

Sonnet 5