### PR TITLE
fix(backend,frontend): replace hardcoded category/mode defaults with CategoryDefaults (#14047)

### DIFF
--- a/autobot-backend/advanced_rag_optimizer.py
+++ b/autobot-backend/advanced_rag_optimizer.py
@@ -26,6 +26,7 @@ from typing import Any, Dict, List, Tuple
 
 from autobot_shared.logging_manager import get_llm_logger
 from constants.model_constants import model_config
+from constants.threshold_constants import CategoryDefaults
 from constants.ttl_constants import TTL_5_MINUTES
 from knowledge.quarantine import RESEARCH_QUARANTINE_FILTER
 from knowledge.search_components.bm25 import BM25Scorer
@@ -615,7 +616,9 @@ class AdvancedRAGOptimizer:
 
         # Compute grid keys for all results
         def _cell_key(r: SearchResult) -> tuple:
-            category = r.metadata.get("category") or r.metadata.get("chunk_category") or "unknown"
+            category = (
+                r.metadata.get("category") or r.metadata.get("chunk_category") or CategoryDefaults.UNKNOWN
+            )
             source_parts = r.source_path.replace("\\", "/").split("/")
             domain = source_parts[0] if source_parts else "unknown"
             return (str(category), str(domain))

--- a/autobot-backend/advanced_rag_optimizer.py
+++ b/autobot-backend/advanced_rag_optimizer.py
@@ -616,9 +616,7 @@ class AdvancedRAGOptimizer:
 
         # Compute grid keys for all results
         def _cell_key(r: SearchResult) -> tuple:
-            category = (
-                r.metadata.get("category") or r.metadata.get("chunk_category") or CategoryDefaults.UNKNOWN
-            )
+            category = r.metadata.get("category") or r.metadata.get("chunk_category") or CategoryDefaults.UNKNOWN
             source_parts = r.source_path.replace("\\", "/").split("/")
             domain = source_parts[0] if source_parts else "unknown"
             return (str(category), str(domain))

--- a/autobot-backend/advanced_rag_optimizer_test.py
+++ b/autobot-backend/advanced_rag_optimizer_test.py
@@ -222,3 +222,53 @@ def test_relevance_floor_keeps_exact_boundary():
     # score == min_score is inclusive (>=); guards against a future > regression
     kept = AdvancedRAGOptimizer._apply_relevance_floor([_sr(0.3)], 0.3)
     assert len(kept) == 1
+
+
+def _mapelites_sr(hybrid: float, *, category: str | None = None, source_path: str) -> SearchResult:
+    metadata = {"category": category} if category is not None else {}
+    return SearchResult(
+        content="c",
+        metadata=metadata,
+        semantic_score=0.0,
+        keyword_score=0.0,
+        hybrid_score=hybrid,
+        relevance_rank=1,
+        source_path=source_path,
+    )
+
+
+class TestMapElitesCategoryDefault:
+    """``_cell_key``'s ``category`` fallback (#14047): a result with no
+    ``category``/``chunk_category`` metadata must group into the exact same
+    MAP-Elites cell as one with an explicit ``category="unknown"`` — proving
+    the default literal is unchanged.
+    """
+
+    def test_missing_category_collides_with_explicit_unknown(self):
+        optimizer = AdvancedRAGOptimizer()
+        # Same source domain ("docs") so only `category` distinguishes the cell.
+        no_category = _mapelites_sr(0.9, source_path="docs/a.md")
+        explicit_unknown = _mapelites_sr(0.5, category="unknown", source_path="docs/b.md")
+        other = _mapelites_sr(0.1, category="other", source_path="other/c.md")
+
+        selected = optimizer._map_elites_select(
+            [no_category, explicit_unknown, other], max_results=2
+        )
+
+        # explicit_unknown collided into the same cell as no_category and lost
+        # the in-cell tie-break (lower hybrid_score) -> dropped from selection.
+        assert no_category in selected
+        assert explicit_unknown not in selected
+        assert other in selected
+
+    def test_explicit_category_avoids_collision_with_default(self):
+        optimizer = AdvancedRAGOptimizer()
+        no_category = _mapelites_sr(0.9, source_path="docs/a.md")
+        # Same source domain, but an explicit non-"unknown" category — must
+        # land in a different cell and survive alongside no_category.
+        explicit_other = _mapelites_sr(0.5, category="other", source_path="docs/b.md")
+
+        selected = optimizer._map_elites_select([no_category, explicit_other], max_results=2)
+
+        assert no_category in selected
+        assert explicit_other in selected

--- a/autobot-backend/advanced_rag_optimizer_test.py
+++ b/autobot-backend/advanced_rag_optimizer_test.py
@@ -251,9 +251,7 @@ class TestMapElitesCategoryDefault:
         explicit_unknown = _mapelites_sr(0.5, category="unknown", source_path="docs/b.md")
         other = _mapelites_sr(0.1, category="other", source_path="other/c.md")
 
-        selected = optimizer._map_elites_select(
-            [no_category, explicit_unknown, other], max_results=2
-        )
+        selected = optimizer._map_elites_select([no_category, explicit_unknown, other], max_results=2)
 
         # explicit_unknown collided into the same cell as no_category and lost
         # the in-cell tie-break (lower hybrid_score) -> dropped from selection.

--- a/autobot-backend/agents/kb_librarian/librarian.py
+++ b/autobot-backend/agents/kb_librarian/librarian.py
@@ -16,6 +16,7 @@ from typing import Any, Dict, List
 
 from agents.web_researcher import WebResearcher as WebResearchAssistant
 from autobot_shared.logging_manager import get_logger
+from constants.threshold_constants import CategoryDefaults
 from events.bus import PersistStrategy, publish_event
 from knowledge.quarantine import RESEARCH_QUARANTINE_FILTER
 from knowledge_base import KnowledgeBase
@@ -47,7 +48,7 @@ def _build_basic_info_section(tool_info: Dict[str, Any], tool_name: str) -> str:
 BASIC INFORMATION:
 - Name: {tool_name}
 - Type: {tool_info.get('type', 'command-line tool')}
-- Category: {tool_info.get('category', 'general')}
+- Category: {tool_info.get('category', CategoryDefaults.GENERAL)}
 - Platform: {tool_info.get('platform', 'linux')}
 - Purpose: {tool_info.get('purpose', 'N/A')}"""
 

--- a/autobot-backend/agents/kb_librarian/librarian_test.py
+++ b/autobot-backend/agents/kb_librarian/librarian_test.py
@@ -25,7 +25,7 @@ from unittest.mock import create_autospec
 
 import pytest
 
-from agents.kb_librarian.librarian import _build_basic_info_section, KBLibrarian
+from agents.kb_librarian.librarian import KBLibrarian, _build_basic_info_section
 from constants.threshold_constants import CategoryDefaults
 from knowledge.quarantine import RESEARCH_QUARANTINE_FILTER
 from knowledge_base import KnowledgeBase

--- a/autobot-backend/agents/kb_librarian/librarian_test.py
+++ b/autobot-backend/agents/kb_librarian/librarian_test.py
@@ -25,7 +25,8 @@ from unittest.mock import create_autospec
 
 import pytest
 
-from agents.kb_librarian.librarian import KBLibrarian
+from agents.kb_librarian.librarian import _build_basic_info_section, KBLibrarian
+from constants.threshold_constants import CategoryDefaults
 from knowledge.quarantine import RESEARCH_QUARANTINE_FILTER
 from knowledge_base import KnowledgeBase
 
@@ -65,3 +66,18 @@ async def test_get_tool_instructions_returns_real_content():
 
     assert instructions is not None
     mock_kb.search.assert_called_once_with("curl installation usage", top_k=3, filters=RESEARCH_QUARANTINE_FILTER)
+
+
+class TestBuildBasicInfoSection:
+    """Coverage for the ``category`` default in ``_build_basic_info_section`` (#14047)."""
+
+    def test_missing_category_defaults_to_general(self):
+        section = _build_basic_info_section({}, "curl")
+
+        assert f"- Category: {CategoryDefaults.GENERAL}" in section
+
+    def test_explicit_category_overrides_default(self):
+        section = _build_basic_info_section({"category": "network"}, "curl")
+
+        assert "- Category: network" in section
+        assert f"- Category: {CategoryDefaults.GENERAL}" not in section

--- a/autobot-backend/agents/kb_librarian/processors.py
+++ b/autobot-backend/agents/kb_librarian/processors.py
@@ -11,6 +11,8 @@ Extracted from enhanced_kb_librarian.py as part of Issue #381 god class refactor
 import re
 from typing import Any, Dict, List
 
+from constants.threshold_constants import CategoryDefaults
+
 from .text_extraction import TextExtractor
 from .types import (
     LIMITATION_KEYWORDS,
@@ -149,7 +151,7 @@ class ToolInfoData:
         """Initialize tool info with name, type, and default metadata fields."""
         self.name = name
         self.type = tool_type
-        self.category = "general"
+        self.category = CategoryDefaults.GENERAL
         self.platform = "linux"
         self.purpose = None
         self.installation = None

--- a/autobot-backend/agents/kb_librarian/processors_test.py
+++ b/autobot-backend/agents/kb_librarian/processors_test.py
@@ -1,0 +1,28 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Coverage for the ``category`` default on ``ToolInfoData.__init__`` (#14047).
+
+``category`` has no constructor parameter — it is always set to the default
+on construction, then optionally reassigned by callers afterward, so
+"override" here means "can still be mutated post-construction", not a
+constructor argument.
+"""
+
+from agents.kb_librarian.processors import ToolInfoData
+from constants.threshold_constants import CategoryDefaults
+
+
+def test_category_defaults_to_general_on_construction():
+    tool = ToolInfoData("curl")
+
+    assert tool.category == CategoryDefaults.GENERAL
+
+
+def test_category_can_still_be_reassigned_after_construction():
+    tool = ToolInfoData("curl")
+
+    tool.category = "network"
+
+    assert tool.category == "network"

--- a/autobot-backend/agents/system_knowledge_manager.py
+++ b/autobot-backend/agents/system_knowledge_manager.py
@@ -20,6 +20,7 @@ import yaml
 
 from agents.kb_librarian import KBLibrarian
 from autobot_shared.logging_manager import get_logger
+from constants.threshold_constants import CategoryDefaults
 from knowledge_base import KnowledgeBase
 
 logger = get_logger(__name__)
@@ -555,7 +556,7 @@ class SystemKnowledgeManager:
             "name": tool_name,
             "type": tool_data.get("type", "command-line tool"),
             "purpose": tool_data.get("purpose", ""),
-            "category": tool_data.get("type", "general"),
+            "category": tool_data.get("type", CategoryDefaults.GENERAL),
             "platform": "linux",
             "installation": self._format_installation(tool_data.get("installation", {})),
             "usage": self._format_usage(tool_data.get("usage", {})),
@@ -644,7 +645,7 @@ class SystemKnowledgeManager:
         # Convert to librarian format
         workflow_info = {
             "name": workflow_name,
-            "type": metadata.get("category", "general"),
+            "type": metadata.get("category", CategoryDefaults.GENERAL),
             "complexity": metadata.get("complexity", "medium"),
             "estimated_time": metadata.get("estimated_time", "varies"),
             "objective": workflow_data.get("objective", ""),

--- a/autobot-backend/agents/system_knowledge_manager_category_default_test.py
+++ b/autobot-backend/agents/system_knowledge_manager_category_default_test.py
@@ -1,0 +1,61 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Coverage for the ``category`` defaults in ``SystemKnowledgeManager``'s
+``_import_single_tool`` / ``_import_single_workflow`` (#14047)."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from agents.system_knowledge_manager import SystemKnowledgeManager
+from constants.threshold_constants import CategoryDefaults
+
+
+def _manager():
+    manager = SystemKnowledgeManager(MagicMock())
+    manager.librarian = MagicMock()
+    manager.librarian.store_tool_knowledge = AsyncMock()
+    manager.librarian.store_workflow_knowledge = AsyncMock()
+    return manager
+
+
+@pytest.mark.asyncio
+async def test_import_single_tool_missing_type_defaults_category_to_general():
+    manager = _manager()
+
+    await manager._import_single_tool({"name": "curl"})
+
+    tool_info = manager.librarian.store_tool_knowledge.call_args[0][0]
+    assert tool_info["category"] == CategoryDefaults.GENERAL
+
+
+@pytest.mark.asyncio
+async def test_import_single_tool_explicit_type_overrides_category_default():
+    manager = _manager()
+
+    await manager._import_single_tool({"name": "curl", "type": "network"})
+
+    tool_info = manager.librarian.store_tool_knowledge.call_args[0][0]
+    assert tool_info["category"] == "network"
+
+
+@pytest.mark.asyncio
+async def test_import_single_workflow_missing_category_defaults_to_general():
+    manager = _manager()
+
+    await manager._import_single_workflow({"metadata": {"name": "Deploy"}})
+
+    workflow_info = manager.librarian.store_workflow_knowledge.call_args[0][0]
+    assert workflow_info["type"] == CategoryDefaults.GENERAL
+
+
+@pytest.mark.asyncio
+async def test_import_single_workflow_explicit_category_overrides_default():
+    manager = _manager()
+
+    await manager._import_single_workflow({"metadata": {"name": "Deploy", "category": "ops"}})
+
+    workflow_info = manager.librarian.store_workflow_knowledge.call_args[0][0]
+    assert workflow_info["type"] == "ops"

--- a/autobot-backend/api/analytics_llm_patterns.py
+++ b/autobot-backend/api/analytics_llm_patterns.py
@@ -47,6 +47,7 @@ from api.schemas_analytics import (
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import RedisDatabase
 from autobot_shared.redis_mixin import AsyncRedisClientMixin
+from constants.threshold_constants import CategoryDefaults
 from constants.model_constants import (
     EXPENSIVE_MODEL_MARKER_GPT4,
     EXPENSIVE_MODEL_MARKER_OPUS,
@@ -807,7 +808,7 @@ class LLMPatternAnalyzer(AsyncRedisClientMixin):
             for record_str in records:
                 try:
                     record = json.loads(record_str)
-                    category = record.get("category", "unknown")
+                    category = record.get("category", CategoryDefaults.UNKNOWN)
                     categories[category]["count"] += 1
                     categories[category]["cost"] += record.get("cost", 0)
                 except json.JSONDecodeError:

--- a/autobot-backend/api/analytics_llm_patterns.py
+++ b/autobot-backend/api/analytics_llm_patterns.py
@@ -47,13 +47,13 @@ from api.schemas_analytics import (
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import RedisDatabase
 from autobot_shared.redis_mixin import AsyncRedisClientMixin
-from constants.threshold_constants import CategoryDefaults
 from constants.model_constants import (
     EXPENSIVE_MODEL_MARKER_GPT4,
     EXPENSIVE_MODEL_MARKER_OPUS,
     MODEL_COSTS_PER_1M_TOKENS,
     OPENAI_GPT4O,
 )
+from constants.threshold_constants import CategoryDefaults
 from constants.ttl_constants import TTL_30_DAYS
 
 # Prefix provided by analytics_routers.py registry (#1032)

--- a/autobot-backend/api/analytics_llm_patterns_test.py
+++ b/autobot-backend/api/analytics_llm_patterns_test.py
@@ -1,0 +1,77 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Coverage for the ``category`` default in ``get_category_distribution`` (#14047)."""
+
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+from api.analytics_llm_patterns import LLMPatternAnalyzer
+from constants.threshold_constants import CategoryDefaults
+
+
+def _todays_usage_key() -> str:
+    today = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")
+    return f"{LLMPatternAnalyzer()._usage_key}:{today}"
+
+
+class _FakePipe:
+    def __init__(self, records_by_key):
+        self._records_by_key = records_by_key
+        self._calls = []
+
+    async def lrange(self, key, start, end):
+        self._calls.append(key)
+
+    async def execute(self):
+        return [self._records_by_key.get(k, []) for k in self._calls]
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+
+class _FakeRedis:
+    def __init__(self, records_by_key):
+        self._records_by_key = records_by_key
+
+    def pipeline(self):
+        return _FakePipe(self._records_by_key)
+
+
+def _analyzer_with_records(records_by_key):
+    analyzer = LLMPatternAnalyzer()
+
+    async def _fake_get_redis():
+        return _FakeRedis(records_by_key)
+
+    analyzer._get_redis = _fake_get_redis
+    return analyzer
+
+
+@pytest.mark.asyncio
+async def test_missing_category_defaults_to_unknown():
+    record = json.dumps({"cost": 1.0})
+    analyzer = _analyzer_with_records({_todays_usage_key(): [record]})
+
+    result = await analyzer.get_category_distribution()
+
+    names = [c["category"] for c in result["categories"]]
+    assert names == [CategoryDefaults.UNKNOWN]
+
+
+@pytest.mark.asyncio
+async def test_explicit_category_overrides_default():
+    record = json.dumps({"cost": 1.0, "category": "coding"})
+    analyzer = _analyzer_with_records({_todays_usage_key(): [record]})
+
+    result = await analyzer.get_category_distribution()
+
+    names = [c["category"] for c in result["categories"]]
+    assert names == ["coding"]
+    assert CategoryDefaults.UNKNOWN not in names

--- a/autobot-backend/api/chat_knowledge.py
+++ b/autobot-backend/api/chat_knowledge.py
@@ -72,6 +72,7 @@ from autobot_shared.async_compat import run_or_schedule
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from chat_history import ChatHistoryManager
+from constants.threshold_constants import CategoryDefaults
 from knowledge.quarantine import RESEARCH_QUARANTINE_FILTER
 
 # Import existing components
@@ -852,7 +853,7 @@ async def get_session_facts(session_id: str, request: Request):
                     "id": fact.get("id"),
                     "content": fact.get("content", "")[:200] + ("..." if len(fact.get("content", "")) > 200 else ""),
                     "full_content": fact.get("content", ""),
-                    "category": fact.get("category", "general"),
+                    "category": fact.get("category", CategoryDefaults.GENERAL),
                     "tags": fact.get("tags", []),
                     "important": fact.get("important", False),
                     "preserve": fact.get("preserve", False),

--- a/autobot-backend/api/chat_knowledge_session_facts_test.py
+++ b/autobot-backend/api/chat_knowledge_session_facts_test.py
@@ -1,0 +1,36 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Coverage for the ``category`` default in ``get_session_facts`` (#14047)."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from api.chat_knowledge import get_session_facts
+from constants.threshold_constants import CategoryDefaults
+
+
+def _request_with_facts(facts):
+    kb = SimpleNamespace(get_facts_by_session=AsyncMock(return_value=facts))
+    return SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(knowledge_base=kb)))
+
+
+@pytest.mark.asyncio
+async def test_missing_category_defaults_to_general():
+    request = _request_with_facts([{"id": "f1", "content": "hi"}])
+
+    result = await get_session_facts("session-1", request)
+
+    assert result["facts"][0]["category"] == CategoryDefaults.GENERAL
+
+
+@pytest.mark.asyncio
+async def test_explicit_category_overrides_default():
+    request = _request_with_facts([{"id": "f1", "content": "hi", "category": "security"}])
+
+    result = await get_session_facts("session-1", request)
+
+    assert result["facts"][0]["category"] == "security"

--- a/autobot-backend/api/feature_flags.py
+++ b/autobot-backend/api/feature_flags.py
@@ -26,6 +26,7 @@ from auth_middleware import get_current_user
 from autobot_shared.auth.permissions import is_admin_role
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
+from constants.threshold_constants import CategoryDefaults
 from services.access_control_metrics import AccessControlMetrics, get_metrics_service
 from services.audit_logger import audit_log
 from services.feature_flags import FeatureFlags, get_feature_flags
@@ -147,7 +148,7 @@ async def update_enforcement_mode(
             user_id=admin.get("username", "admin"),
             resource="feature_flag:access_control:enforcement_mode",
             details={
-                "previous_mode": "unknown",  # Could fetch from history
+                "previous_mode": CategoryDefaults.UNKNOWN,  # Could fetch from history
                 "new_mode": update.mode.value,
                 "action": "enforcement_mode_update",
             },

--- a/autobot-backend/api/feature_flags_test.py
+++ b/autobot-backend/api/feature_flags_test.py
@@ -1,0 +1,33 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Coverage for the ``previous_mode`` audit-log default in
+``update_enforcement_mode`` (#14047).
+
+Unconditional literal (not a caller-supplied ``.get(key, default)``), so
+there is no override case — only that the fallback value is unchanged.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from api.feature_flags import update_enforcement_mode
+from api.schemas_system import EnforcementModeUpdate
+from constants.threshold_constants import CategoryDefaults
+from services.feature_flags import EnforcementMode
+
+
+@pytest.mark.asyncio
+async def test_previous_mode_defaults_to_unknown_in_audit_log():
+    mock_flags = AsyncMock()
+    mock_flags.set_enforcement_mode.return_value = True
+    update = EnforcementModeUpdate(mode=EnforcementMode.ENFORCED)
+    admin = {"username": "root"}
+
+    with patch("api.feature_flags.audit_log", new_callable=AsyncMock) as mock_audit_log:
+        await update_enforcement_mode(update, admin, mock_flags)
+
+    _, kwargs = mock_audit_log.call_args
+    assert kwargs["details"]["previous_mode"] == CategoryDefaults.UNKNOWN

--- a/autobot-backend/api/knowledge_maintenance.py
+++ b/autobot-backend/api/knowledge_maintenance.py
@@ -39,7 +39,7 @@ from api.schemas_knowledge import (
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
-from constants.threshold_constants import QueryDefaults
+from constants.threshold_constants import CategoryDefaults, QueryDefaults
 
 # Import Pydantic models from dedicated module
 from knowledge.schemas import (
@@ -103,7 +103,7 @@ def _process_fact_metadata(metadata_str, fact_key, created_at) -> dict | None:
             "fact_id": metadata.get("fact_id", fact_key.split(":")[1]),
             "fact_key": fact_key,
             "created_at": created_at or "1970-01-01T00:00:00",
-            "category": metadata.get("category", "unknown"),
+            "category": metadata.get("category", CategoryDefaults.UNKNOWN),
             "title": metadata.get("title", "unknown"),
         }
     except json.JSONDecodeError:
@@ -948,7 +948,7 @@ def _build_orphan_fact_info(key, fact_data: dict, metadata: dict, source_session
         "fact_key": fact_key,
         "session_id": source_session_id,
         "content_preview": content[:200] + ("..." if len(content) > 200 else ""),
-        "category": metadata.get("category", "unknown"),
+        "category": metadata.get("category", CategoryDefaults.UNKNOWN),
         "created_at": metadata.get("created_at"),
         "important": metadata.get("important", False),
         "preserve": metadata.get("preserve", False),

--- a/autobot-backend/api/knowledge_maintenance_category_default_test.py
+++ b/autobot-backend/api/knowledge_maintenance_category_default_test.py
@@ -34,8 +34,6 @@ class TestBuildOrphanFactInfo:
         assert info["category"] == CategoryDefaults.UNKNOWN
 
     def test_explicit_category_overrides_default(self):
-        info = _build_orphan_fact_info(
-            "fact:f1", {"content": b"hello"}, {"category": "security"}, "session-1"
-        )
+        info = _build_orphan_fact_info("fact:f1", {"content": b"hello"}, {"category": "security"}, "session-1")
 
         assert info["category"] == "security"

--- a/autobot-backend/api/knowledge_maintenance_category_default_test.py
+++ b/autobot-backend/api/knowledge_maintenance_category_default_test.py
@@ -1,0 +1,41 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Coverage for the ``category`` default in ``_process_fact_metadata`` and
+``_build_orphan_fact_info`` (#14047)."""
+
+import json
+
+from api.knowledge_maintenance import _build_orphan_fact_info, _process_fact_metadata
+from constants.threshold_constants import CategoryDefaults
+
+
+class TestProcessFactMetadata:
+    def test_missing_category_defaults_to_unknown(self):
+        metadata_str = json.dumps({"fact_id": "f1"})
+
+        info = _process_fact_metadata(metadata_str, "fact:f1", "2026-01-01T00:00:00")
+
+        assert info["category"] == CategoryDefaults.UNKNOWN
+
+    def test_explicit_category_overrides_default(self):
+        metadata_str = json.dumps({"fact_id": "f1", "category": "security"})
+
+        info = _process_fact_metadata(metadata_str, "fact:f1", "2026-01-01T00:00:00")
+
+        assert info["category"] == "security"
+
+
+class TestBuildOrphanFactInfo:
+    def test_missing_category_defaults_to_unknown(self):
+        info = _build_orphan_fact_info("fact:f1", {"content": b"hello"}, {}, "session-1")
+
+        assert info["category"] == CategoryDefaults.UNKNOWN
+
+    def test_explicit_category_overrides_default(self):
+        info = _build_orphan_fact_info(
+            "fact:f1", {"content": b"hello"}, {"category": "security"}, "session-1"
+        )
+
+        assert info["category"] == "security"

--- a/autobot-backend/api/knowledge_search.py
+++ b/autobot-backend/api/knowledge_search.py
@@ -29,6 +29,7 @@ from fastapi import APIRouter, Request
 from api.schemas_knowledge import SearchRequest
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
+from constants.threshold_constants import CategoryDefaults
 from knowledge.schemas import (
     ExpandQueryResponse,
     KnowledgeSearchResponse,
@@ -360,7 +361,7 @@ def _convert_results_to_documents(results: List[Metadata], original_query: str) 
                 "metadata": {
                     "filename": (result.get("metadata", {}).get("title", "Unknown")),
                     "source": (result.get("metadata", {}).get("source", "knowledge_base")),
-                    "category": (result.get("metadata", {}).get("category", "general")),
+                    "category": (result.get("metadata", {}).get("category", CategoryDefaults.GENERAL)),
                     "score": result.get("score", 0.0),
                     "source_query": result.get("source_query", original_query),
                 },

--- a/autobot-backend/api/knowledge_search_aggregator.py
+++ b/autobot-backend/api/knowledge_search_aggregator.py
@@ -36,6 +36,7 @@ from api.schemas_knowledge import (
 )
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
+from constants.threshold_constants import CategoryDefaults
 from knowledge.quarantine import RESEARCH_QUARANTINE_FILTER
 from knowledge_factory import get_or_create_knowledge_base
 
@@ -634,7 +635,7 @@ def _create_fact_node(fact: Dict[str, Any]) -> Dict[str, Any]:
         "type": "fact",
         "observations": [content],
         "metadata": {
-            "category": fact.get("category", "general"),
+            "category": fact.get("category", CategoryDefaults.GENERAL),
             "source": fact.get("source", "knowledge_base"),
             "confidence": fact.get("confidence", 1.0),
         },
@@ -749,7 +750,7 @@ def _create_dynamic_category_nodes(facts: List[Dict[str, Any]], nodes: List[Dict
     seen_categories: Set[str] = set()
 
     for fact in facts:
-        category = fact.get("category", "general")
+        category = fact.get("category", CategoryDefaults.GENERAL)
         if category and category not in seen_categories:
             seen_categories.add(category)
             node_id = f"cat_{category}"
@@ -837,7 +838,7 @@ def _process_facts_into_nodes(
         fact_ids.append(node["id"])
 
         # Create edge from category to fact
-        category = fact.get("category", "general")
+        category = fact.get("category", CategoryDefaults.GENERAL)
         cat_node_id = category_map.get(category)
         if cat_node_id:
             edges.append(

--- a/autobot-backend/api/knowledge_search_aggregator_category_default_test.py
+++ b/autobot-backend/api/knowledge_search_aggregator_category_default_test.py
@@ -58,9 +58,7 @@ class TestProcessFactsIntoNodes:
         edges: list = []
         category_map = {CategoryDefaults.GENERAL: "cat_general"}
 
-        fact_ids = _process_facts_into_nodes(
-            [{"content": "hello", "id": "f1"}], nodes, edges, category_map
-        )
+        fact_ids = _process_facts_into_nodes([{"content": "hello", "id": "f1"}], nodes, edges, category_map)
 
         assert fact_ids == ["f1"]
         assert edges == [{"from": "cat_general", "to": "f1", "type": "contains", "strength": 0.6}]

--- a/autobot-backend/api/knowledge_search_aggregator_category_default_test.py
+++ b/autobot-backend/api/knowledge_search_aggregator_category_default_test.py
@@ -1,0 +1,77 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Coverage for the ``category`` default across the multi-source graph-building
+helpers in ``api/knowledge_search_aggregator.py`` (#14047):
+
+- ``_create_fact_node``
+- ``_create_dynamic_category_nodes``
+- ``_process_facts_into_nodes``
+"""
+
+from __future__ import annotations
+
+from api.knowledge_search_aggregator import (
+    _create_dynamic_category_nodes,
+    _create_fact_node,
+    _process_facts_into_nodes,
+)
+from constants.threshold_constants import CategoryDefaults
+
+
+class TestCreateFactNode:
+    def test_missing_category_defaults_to_general(self):
+        node = _create_fact_node({"content": "hello", "id": "f1"})
+
+        assert node["metadata"]["category"] == CategoryDefaults.GENERAL
+
+    def test_explicit_category_overrides_default(self):
+        node = _create_fact_node({"content": "hello", "id": "f1", "category": "security"})
+
+        assert node["metadata"]["category"] == "security"
+
+
+class TestCreateDynamicCategoryNodes:
+    def test_missing_category_defaults_to_general(self):
+        nodes: list = []
+        edges: list = []
+
+        category_map = _create_dynamic_category_nodes([{"content": "hello"}], nodes, edges)
+
+        assert category_map == {CategoryDefaults.GENERAL: f"cat_{CategoryDefaults.GENERAL}"}
+        assert nodes[0]["id"] == f"cat_{CategoryDefaults.GENERAL}"
+
+    def test_explicit_category_overrides_default(self):
+        nodes: list = []
+        edges: list = []
+
+        category_map = _create_dynamic_category_nodes([{"content": "hello", "category": "security"}], nodes, edges)
+
+        assert category_map == {"security": "cat_security"}
+        assert CategoryDefaults.GENERAL not in category_map
+
+
+class TestProcessFactsIntoNodes:
+    def test_missing_category_defaults_to_general_for_edge_lookup(self):
+        nodes: list = []
+        edges: list = []
+        category_map = {CategoryDefaults.GENERAL: "cat_general"}
+
+        fact_ids = _process_facts_into_nodes(
+            [{"content": "hello", "id": "f1"}], nodes, edges, category_map
+        )
+
+        assert fact_ids == ["f1"]
+        assert edges == [{"from": "cat_general", "to": "f1", "type": "contains", "strength": 0.6}]
+
+    def test_explicit_category_overrides_default(self):
+        nodes: list = []
+        edges: list = []
+        category_map = {"security": "cat_security", CategoryDefaults.GENERAL: "cat_general"}
+
+        _process_facts_into_nodes(
+            [{"content": "hello", "id": "f1", "category": "security"}], nodes, edges, category_map
+        )
+
+        assert edges == [{"from": "cat_security", "to": "f1", "type": "contains", "strength": 0.6}]

--- a/autobot-backend/api/knowledge_search_test.py
+++ b/autobot-backend/api/knowledge_search_test.py
@@ -1,0 +1,22 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Coverage for the ``category`` default in ``_convert_results_to_documents`` (#14047)."""
+
+from api.knowledge_search import _convert_results_to_documents
+from constants.threshold_constants import CategoryDefaults
+
+
+def test_missing_category_defaults_to_general():
+    docs = _convert_results_to_documents([{"content": "hi", "metadata": {}}], "query")
+
+    assert docs[0]["metadata"]["category"] == CategoryDefaults.GENERAL
+
+
+def test_explicit_category_overrides_default():
+    docs = _convert_results_to_documents(
+        [{"content": "hi", "metadata": {"category": "security"}}], "query"
+    )
+
+    assert docs[0]["metadata"]["category"] == "security"

--- a/autobot-backend/api/knowledge_search_test.py
+++ b/autobot-backend/api/knowledge_search_test.py
@@ -15,8 +15,6 @@ def test_missing_category_defaults_to_general():
 
 
 def test_explicit_category_overrides_default():
-    docs = _convert_results_to_documents(
-        [{"content": "hi", "metadata": {"category": "security"}}], "query"
-    )
+    docs = _convert_results_to_documents([{"content": "hi", "metadata": {"category": "security"}}], "query")
 
     assert docs[0]["metadata"]["category"] == "security"

--- a/autobot-backend/command_manual_manager.py
+++ b/autobot-backend/command_manual_manager.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 from typing import Dict, List, Tuple
 
 from autobot_shared.logging_manager import get_logger
+from constants.threshold_constants import CategoryDefaults
 
 logger = get_logger(__name__)
 
@@ -515,7 +516,7 @@ class CommandManualManager:
             "development": ["development", "programming", "code", "build"],
         }
 
-        best_category = "general"
+        best_category = CategoryDefaults.GENERAL
         best_score = 0
 
         for category, keywords in category_keywords.items():

--- a/autobot-backend/command_manual_manager_category_default_test.py
+++ b/autobot-backend/command_manual_manager_category_default_test.py
@@ -1,0 +1,29 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Coverage for the ``category`` default in ``CommandManualManager._determine_category`` (#14047)."""
+
+from command_manual_manager import CommandManualManager
+from constants.threshold_constants import CategoryDefaults
+
+
+def _manager() -> CommandManualManager:
+    return CommandManualManager(db_path=":memory:")
+
+
+def test_no_keyword_match_defaults_to_general():
+    manager = _manager()
+
+    category = manager._determine_category("totallyunknowncmd", "no matching keywords here at all")
+
+    assert category == CategoryDefaults.GENERAL
+
+
+def test_explicit_pattern_match_overrides_default():
+    manager = _manager()
+    # "ls" is a known file-operation command per _load_category_patterns().
+    category = manager._determine_category("ls", "list directory contents")
+
+    assert category == "file_operations"
+    assert category != CategoryDefaults.GENERAL

--- a/autobot-backend/knowledge/bulk.py
+++ b/autobot-backend/knowledge/bulk.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any, Dict, List
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.time_utils import parse_utc_iso
+from constants.threshold_constants import CategoryDefaults
 
 if TYPE_CHECKING:
     import aioredis
@@ -889,7 +890,7 @@ class BulkOperationsMixin:
                     "fact_id": row.get("fact_id"),
                     "content": row.get("content", ""),
                     "metadata": {
-                        "category": row.get("category", "general"),
+                        "category": row.get("category", CategoryDefaults.GENERAL),
                         "tags": [t.strip() for t in row.get("tags", "").split(",") if t.strip()],
                     },
                 }

--- a/autobot-backend/knowledge/bulk_test.py
+++ b/autobot-backend/knowledge/bulk_test.py
@@ -1,0 +1,26 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Coverage for the ``category`` default in ``BulkOperationsMixin._parse_import_csv`` (#14047)."""
+
+from constants.threshold_constants import CategoryDefaults
+from knowledge.bulk import BulkOperationsMixin
+
+
+def test_missing_category_defaults_to_general():
+    mixin = BulkOperationsMixin()
+    content = "fact_id,content,tags\n1,hello,foo\n"
+
+    facts = mixin._parse_import_csv(content)
+
+    assert facts[0]["metadata"]["category"] == CategoryDefaults.GENERAL
+
+
+def test_explicit_category_overrides_default():
+    mixin = BulkOperationsMixin()
+    content = "fact_id,content,category,tags\n1,hello,security,foo\n"
+
+    facts = mixin._parse_import_csv(content)
+
+    assert facts[0]["metadata"]["category"] == "security"

--- a/autobot-backend/knowledge/search.py
+++ b/autobot-backend/knowledge/search.py
@@ -30,6 +30,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Set
 
 from autobot_shared.error_boundaries import error_boundary
 from autobot_shared.logging_manager import get_logger
+from constants.threshold_constants import CategoryDefaults
 
 # Issue #5064: prompt-injection sanitizer applied pre-embedding.
 # Issue #5064: prompt-injection sanitizer applied pre-embedding.
@@ -254,7 +255,7 @@ class SearchMixin:
 
         if advanced or enhanced:
             eff_limit = limit if limit is not None else top_k
-            eff_mode = mode if mode != "auto" else "hybrid"
+            eff_mode = mode if mode != "auto" else CategoryDefaults.SEARCH_MODE_HYBRID
             ctx = SearchContext.from_params(
                 query=query,
                 limit=eff_limit,

--- a/autobot-backend/knowledge/search_mode_default_test.py
+++ b/autobot-backend/knowledge/search_mode_default_test.py
@@ -1,0 +1,43 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Coverage for the ``mode="auto"`` -> hybrid default in ``SearchMixin.search`` (#14047).
+
+``search()`` is heavy (vector engine, reranking, ...), so the "filtered" path
+is exercised (``category`` set, no advanced params) which routes through
+``_run_search`` after building a ``SearchContext``. ``_run_search`` is
+stubbed to capture the resolved ``mode`` without doing real work.
+"""
+
+import pytest
+
+from constants.threshold_constants import CategoryDefaults
+from knowledge.search import SearchMixin
+
+
+class _CapturingSearch(SearchMixin):
+    def __init__(self):
+        self.captured_mode = None
+
+    async def _run_search(self, **kwargs):  # noqa: D401 - test stub
+        self.captured_mode = kwargs["mode"]
+        return []
+
+
+@pytest.mark.asyncio
+async def test_mode_auto_resolves_to_hybrid_default():
+    mixer = _CapturingSearch()
+
+    await mixer.search("q", category="docs", mode="auto")
+
+    assert mixer.captured_mode == CategoryDefaults.SEARCH_MODE_HYBRID
+
+
+@pytest.mark.asyncio
+async def test_explicit_mode_overrides_auto_default():
+    mixer = _CapturingSearch()
+
+    await mixer.search("q", category="docs", mode="semantic")
+
+    assert mixer.captured_mode == "semantic"

--- a/autobot-backend/memory/essential_story.py
+++ b/autobot-backend/memory/essential_story.py
@@ -21,6 +21,7 @@ import yaml
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.token_count import estimate_fast
+from constants.threshold_constants import CategoryDefaults
 
 logger = get_logger(__name__)
 
@@ -260,7 +261,7 @@ class EssentialStoryGenerator:
         lines = ["## Essential Context"]
         for fact in facts:
             meta = fact.get("metadata") or {}
-            category = meta.get("category", "general")
+            category = meta.get("category", CategoryDefaults.GENERAL)
             content = fact.get("content", "").strip()
             if content:
                 lines.append(f"[{category}] {content}")

--- a/autobot-backend/services/feature_flags.py
+++ b/autobot-backend/services/feature_flags.py
@@ -34,7 +34,7 @@ from enum import Enum
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_mixin import AsyncRedisClientMixin
-from constants.threshold_constants import StringParsingConstants
+from constants.threshold_constants import CategoryDefaults, StringParsingConstants
 from type_defs.common import Metadata
 
 logger = get_logger(__name__)
@@ -367,7 +367,7 @@ class FeatureFlags(AsyncRedisClientMixin):
             logger.error("Failed to get rollout statistics: %s", e)
             return {
                 "error": "Failed to retrieve rollout statistics",
-                "current_mode": "unknown",
+                "current_mode": CategoryDefaults.UNKNOWN,
             }
 
     async def clear_all_flags(self) -> bool:

--- a/autobot-backend/services/feature_flags_rollout_stats_test.py
+++ b/autobot-backend/services/feature_flags_rollout_stats_test.py
@@ -1,0 +1,31 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Coverage for the ``current_mode`` error-path default in
+``FeatureFlags.get_rollout_statistics`` (#14047).
+
+Unlike most sites touched in this issue, this literal is not a ``.get(key,
+default)`` call — it is the unconditional value reported when statistics
+collection raises, so there is no "explicit override" case to test; only
+that the fallback value itself is unchanged.
+"""
+
+import pytest
+
+from constants.threshold_constants import CategoryDefaults
+from services.feature_flags import FeatureFlags
+
+
+@pytest.mark.asyncio
+async def test_error_path_reports_unknown_current_mode():
+    flags = FeatureFlags()
+
+    async def _boom():
+        raise RuntimeError("redis unavailable")
+
+    flags._get_redis = _boom
+
+    result = await flags.get_rollout_statistics()
+
+    assert result["current_mode"] == CategoryDefaults.UNKNOWN

--- a/autobot-backend/services/knowledge/doc_indexer.py
+++ b/autobot-backend/services/knowledge/doc_indexer.py
@@ -35,6 +35,7 @@ if TYPE_CHECKING:
 
 from autobot_shared.ssot_config import get_ollama_url
 from constants.path_constants import PATH
+from constants.threshold_constants import CategoryDefaults
 from knowledge.query_sanitizer import sanitize_document as _sanitize_document
 from services.knowledge.synthesis_schema_loader import SynthesisSchema, load_synthesis_schema
 
@@ -732,7 +733,7 @@ class DocIndexerService:
                 categories: Dict[str, int] = {}
                 for meta in sample["metadatas"]:
                     files.add(meta.get("file_path", "unknown"))
-                    cat = meta.get("category", "unknown")
+                    cat = meta.get("category", CategoryDefaults.UNKNOWN)
                     categories[cat] = categories.get(cat, 0) + 1
                 result["files"] = len(files)
                 result["categories"] = categories

--- a/autobot-backend/services/knowledge/test_doc_indexer_get_stats_category_default.py
+++ b/autobot-backend/services/knowledge/test_doc_indexer_get_stats_category_default.py
@@ -1,0 +1,39 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Coverage for the ``category`` default in ``DocIndexerService.get_stats`` (#14047)."""
+
+from unittest.mock import patch
+
+import pytest
+
+from constants.threshold_constants import CategoryDefaults
+
+from .test_doc_indexer import _make_service
+
+
+@pytest.mark.asyncio
+async def test_missing_category_defaults_to_unknown():
+    svc = _make_service(initialized=True, collection_count=1)
+
+    with patch(
+        "utils.chromadb_client.get_all_paginated",
+        return_value={"metadatas": [{"file_path": "a.md"}]},
+    ):
+        result = await svc.get_stats()
+
+    assert result["categories"] == {CategoryDefaults.UNKNOWN: 1}
+
+
+@pytest.mark.asyncio
+async def test_explicit_category_overrides_default():
+    svc = _make_service(initialized=True, collection_count=1)
+
+    with patch(
+        "utils.chromadb_client.get_all_paginated",
+        return_value={"metadatas": [{"file_path": "a.md", "category": "security"}]},
+    ):
+        result = await svc.get_stats()
+
+    assert result["categories"] == {"security": 1}

--- a/autobot-backend/services/specialized_agent_service.py
+++ b/autobot-backend/services/specialized_agent_service.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any, Dict, List
 
 from autobot_shared.logging_manager import get_logger
+from constants.threshold_constants import CategoryDefaults
 
 logger = get_logger(__name__)
 
@@ -167,7 +168,7 @@ class SpecializedAgentService:
 
         counts: Dict[str, int] = {}
         for agent in agents:
-            cat = agent.get("category", "general")
+            cat = agent.get("category", CategoryDefaults.GENERAL)
             counts[cat] = counts.get(cat, 0) + 1
         return counts
 

--- a/autobot-backend/skills/registry.py
+++ b/autobot-backend/skills/registry.py
@@ -21,6 +21,7 @@ import yaml
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.singleton_factory import lazy_singleton
+from constants.threshold_constants import CategoryDefaults
 from prepared_facts import SkillRoutingIndex
 from skills.base_skill import BaseSkill, DeclarativeSkill, SkillHealth, SkillManifest, SkillStatus
 from skills.dependency_resolver import check_missing_dependencies, resolve_dependencies
@@ -514,7 +515,7 @@ def _parse_skill_md(skill_md_path: str) -> SkillManifest | None:
             version=str(data.get("version", "1.0.0")),
             description=str(data.get("description", "")),
             author=str(data.get("author", "mrveiss")),
-            category=str(data.get("category", "general")),
+            category=str(data.get("category", CategoryDefaults.GENERAL)),
             dependencies=[str(d) for d in (data.get("dependencies") or [])],
             tools=[str(t) for t in (data.get("tools") or [])],
             triggers=[str(tr) for tr in (data.get("triggers") or [])],

--- a/autobot-backend/utils/error_boundaries/boundary_manager.py
+++ b/autobot-backend/utils/error_boundaries/boundary_manager.py
@@ -20,7 +20,7 @@ from typing import Any, Dict, List
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.singleton_factory import lazy_singleton
-from constants.threshold_constants import RetryConfig
+from constants.threshold_constants import CategoryDefaults, RetryConfig
 from constants.ttl_constants import TTL_24_HOURS
 
 try:
@@ -363,7 +363,7 @@ class ErrorBoundaryManager:
         components = {}
 
         for error in errors:
-            category = error.get("category", "unknown")
+            category = error.get("category", CategoryDefaults.UNKNOWN)
             severity = error.get("severity", "unknown")
             component = error.get("component", "unknown")
 

--- a/autobot-backend/utils/error_boundaries/boundary_manager_category_default_test.py
+++ b/autobot-backend/utils/error_boundaries/boundary_manager_category_default_test.py
@@ -1,0 +1,30 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Coverage for the ``category`` default in
+``ErrorBoundaryManager._calculate_error_groupings`` (#14047)."""
+
+from unittest.mock import MagicMock
+
+from constants.threshold_constants import CategoryDefaults
+from utils.error_boundaries.boundary_manager import ErrorBoundaryManager
+
+
+def test_missing_category_defaults_to_unknown():
+    manager = ErrorBoundaryManager(redis_client=MagicMock())
+
+    categories, _severities, _components = manager._calculate_error_groupings([{}])
+
+    assert categories == {CategoryDefaults.UNKNOWN: 1}
+
+
+def test_explicit_category_overrides_default():
+    manager = ErrorBoundaryManager(redis_client=MagicMock())
+
+    categories, _severities, _components = manager._calculate_error_groupings(
+        [{"category": "network"}]
+    )
+
+    assert categories == {"network": 1}
+    assert CategoryDefaults.UNKNOWN not in categories

--- a/autobot-backend/utils/error_boundaries/boundary_manager_category_default_test.py
+++ b/autobot-backend/utils/error_boundaries/boundary_manager_category_default_test.py
@@ -22,9 +22,7 @@ def test_missing_category_defaults_to_unknown():
 def test_explicit_category_overrides_default():
     manager = ErrorBoundaryManager(redis_client=MagicMock())
 
-    categories, _severities, _components = manager._calculate_error_groupings(
-        [{"category": "network"}]
-    )
+    categories, _severities, _components = manager._calculate_error_groupings([{"category": "network"}])
 
     assert categories == {"network": 1}
     assert CategoryDefaults.UNKNOWN not in categories

--- a/autobot-backend/utils/performance_monitoring/monitor.py
+++ b/autobot-backend/utils/performance_monitoring/monitor.py
@@ -19,7 +19,7 @@ from dataclasses import asdict
 from typing import Any, Callable, Dict, List
 
 from autobot_shared.logging_manager import get_logger
-from autobot_shared.ssot_constants import TTL_1_HOUR
+from autobot_shared.ssot_constants import TTL_1_HOUR, CategoryDefaults
 
 # Issue #469: Import Prometheus metrics manager
 from monitoring.prometheus_metrics import get_metrics_manager
@@ -464,7 +464,7 @@ class PerformanceMonitor:
         if not alerts:
             return
         for alert in alerts:
-            category = alert.get("category", "unknown")
+            category = alert.get("category", CategoryDefaults.UNKNOWN)
             severity = alert.get("severity", "info")
             self._prometheus.record_performance_alert(category, severity)
 

--- a/autobot-backend/utils/performance_monitoring/monitor_category_default_test.py
+++ b/autobot-backend/utils/performance_monitoring/monitor_category_default_test.py
@@ -1,0 +1,36 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Coverage for the ``category`` default in
+``PerformanceMonitor._push_alerts_to_prometheus`` (#14047)."""
+
+from unittest.mock import MagicMock
+
+from constants.threshold_constants import CategoryDefaults
+from utils.performance_monitoring.monitor import PerformanceMonitor
+
+
+def _bare_monitor():
+    """A PerformanceMonitor instance without running the heavy __init__."""
+    monitor = object.__new__(PerformanceMonitor)
+    monitor._prometheus = MagicMock()
+    return monitor
+
+
+def test_missing_category_defaults_to_unknown():
+    monitor = _bare_monitor()
+
+    monitor._push_alerts_to_prometheus([{"severity": "warning"}])
+
+    monitor._prometheus.record_performance_alert.assert_called_once_with(
+        CategoryDefaults.UNKNOWN, "warning"
+    )
+
+
+def test_explicit_category_overrides_default():
+    monitor = _bare_monitor()
+
+    monitor._push_alerts_to_prometheus([{"category": "cpu", "severity": "critical"}])
+
+    monitor._prometheus.record_performance_alert.assert_called_once_with("cpu", "critical")

--- a/autobot-backend/utils/performance_monitoring/monitor_category_default_test.py
+++ b/autobot-backend/utils/performance_monitoring/monitor_category_default_test.py
@@ -23,9 +23,7 @@ def test_missing_category_defaults_to_unknown():
 
     monitor._push_alerts_to_prometheus([{"severity": "warning"}])
 
-    monitor._prometheus.record_performance_alert.assert_called_once_with(
-        CategoryDefaults.UNKNOWN, "warning"
-    )
+    monitor._prometheus.record_performance_alert.assert_called_once_with(CategoryDefaults.UNKNOWN, "warning")
 
 
 def test_explicit_category_overrides_default():

--- a/autobot-frontend/src/components/chat/DocumentationResultCard.vue
+++ b/autobot-frontend/src/components/chat/DocumentationResultCard.vue
@@ -95,6 +95,7 @@ import Icon from '@/components/ui/Icon.vue'
 import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { createLogger } from '@/utils/debugUtils'
+import { CATEGORY_DEFAULTS } from '@/config/ssot-config'
 
 const { t } = useI18n()
 
@@ -120,7 +121,7 @@ interface Emits {
 }
 
 const props = withDefaults(defineProps<Props>(), {
-  category: 'general',
+  category: CATEGORY_DEFAULTS.GENERAL,
   isHighlighted: false,
   maxContentLength: 300
 })

--- a/autobot-frontend/src/components/chat/DocumentationSuggestionChip.vue
+++ b/autobot-frontend/src/components/chat/DocumentationSuggestionChip.vue
@@ -43,6 +43,7 @@
 
 import type { IconName } from '@/components/ui/Icon.vue'
 import Icon from '@/components/ui/Icon.vue'
+import { CATEGORY_DEFAULTS } from '@/config/ssot-config'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
@@ -66,7 +67,7 @@ interface Emits {
 }
 
 const props = withDefaults(defineProps<Props>(), {
-  category: 'general',
+  category: CATEGORY_DEFAULTS.GENERAL,
   isSelected: false,
   clickable: true,
   dismissible: false,

--- a/autobot-frontend/src/components/chat/__tests__/DocumentationResultCard.categoryDefault.spec.ts
+++ b/autobot-frontend/src/components/chat/__tests__/DocumentationResultCard.categoryDefault.spec.ts
@@ -1,0 +1,43 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+//
+// Coverage for the `category` prop default in DocumentationResultCard
+// (#14047). The prop drives the rendered `category-<value>` badge class.
+
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import DocumentationResultCard from '../DocumentationResultCard.vue'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  fallbackLocale: 'en',
+  missingWarn: false,
+  fallbackWarn: false,
+  messages: { en: {} },
+})
+
+function mountCard(props: Record<string, unknown>) {
+  return mount(DocumentationResultCard, {
+    props: { title: 'Getting Started', content: 'Some content', ...props },
+    global: { plugins: [i18n] },
+  })
+}
+
+describe('DocumentationResultCard category default (#14047)', () => {
+  it('missing category prop defaults to "general"', () => {
+    const wrapper = mountCard({})
+
+    expect(wrapper.find('.category-badge').classes()).toContain('category-general')
+  })
+
+  it('explicit category prop overrides the default', () => {
+    const wrapper = mountCard({ category: 'security' })
+
+    expect(wrapper.find('.category-badge').classes()).toContain('category-security')
+    expect(wrapper.find('.category-badge').classes()).not.toContain('category-general')
+  })
+})

--- a/autobot-frontend/src/components/chat/__tests__/DocumentationSuggestionChip.categoryDefault.spec.ts
+++ b/autobot-frontend/src/components/chat/__tests__/DocumentationSuggestionChip.categoryDefault.spec.ts
@@ -1,0 +1,44 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+//
+// Coverage for the `category` prop default in DocumentationSuggestionChip
+// (#14047). The prop drives the rendered `category-<value>` icon-wrapper
+// class, so the default/override behaviour is asserted through it.
+
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import DocumentationSuggestionChip from '../DocumentationSuggestionChip.vue'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  fallbackLocale: 'en',
+  missingWarn: false,
+  fallbackWarn: false,
+  messages: { en: { chat: { docSuggestion: { dismiss: 'Dismiss' } } } },
+})
+
+function mountChip(props: Record<string, unknown>) {
+  return mount(DocumentationSuggestionChip, {
+    props: { label: 'Getting Started', ...props },
+    global: { plugins: [i18n] },
+  })
+}
+
+describe('DocumentationSuggestionChip category default (#14047)', () => {
+  it('missing category prop defaults to "general"', () => {
+    const wrapper = mountChip({})
+
+    expect(wrapper.find('.chip-icon').classes()).toContain('category-general')
+  })
+
+  it('explicit category prop overrides the default', () => {
+    const wrapper = mountChip({ category: 'security' })
+
+    expect(wrapper.find('.chip-icon').classes()).toContain('category-security')
+    expect(wrapper.find('.chip-icon').classes()).not.toContain('category-general')
+  })
+})

--- a/autobot-frontend/src/composables/__tests__/useKnowledgeCollaboration.categoryDefault.spec.ts
+++ b/autobot-frontend/src/composables/__tests__/useKnowledgeCollaboration.categoryDefault.spec.ts
@@ -1,0 +1,55 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+//
+// Coverage for the `mode` default in useKnowledgeCollaboration's
+// `scopedSearch` (#14047).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useKnowledgeCollaboration } from '../useKnowledgeCollaboration'
+import { CATEGORY_DEFAULTS } from '@/config/ssot-config'
+
+const mockPost = vi.fn()
+
+vi.mock('@/utils/ApiClient', () => ({
+  ApiClient: class {
+    post = mockPost
+    get = vi.fn()
+    put = vi.fn()
+    delete = vi.fn()
+  },
+}))
+
+vi.mock('@/config/ssot-config', () => ({
+  CATEGORY_DEFAULTS: { GENERAL: 'general', SEARCH_MODE_HYBRID: 'hybrid' },
+}))
+
+describe('useKnowledgeCollaboration.scopedSearch mode default (#14047)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockPost.mockResolvedValue({})
+  })
+
+  it('missing options.mode defaults to CATEGORY_DEFAULTS.SEARCH_MODE_HYBRID', async () => {
+    const { scopedSearch } = useKnowledgeCollaboration()
+
+    await scopedSearch('query', {})
+
+    expect(mockPost).toHaveBeenCalledWith(
+      '/api/knowledge/search/scoped',
+      expect.objectContaining({ mode: CATEGORY_DEFAULTS.SEARCH_MODE_HYBRID }),
+    )
+  })
+
+  it('explicit options.mode overrides the default', async () => {
+    const { scopedSearch } = useKnowledgeCollaboration()
+
+    await scopedSearch('query', { mode: 'semantic' })
+
+    expect(mockPost).toHaveBeenCalledWith(
+      '/api/knowledge/search/scoped',
+      expect.objectContaining({ mode: 'semantic' }),
+    )
+  })
+})

--- a/autobot-frontend/src/composables/chat/__tests__/useDocumentationSearch.categoryDefault.spec.ts
+++ b/autobot-frontend/src/composables/chat/__tests__/useDocumentationSearch.categoryDefault.spec.ts
@@ -1,0 +1,72 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+//
+// Coverage for the `category` default in useDocumentationSearch's
+// `searchDocs` / `browseMore` mappers (#14047).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useDocumentationSearch } from '../useDocumentationSearch'
+import { CATEGORY_DEFAULTS } from '@/config/ssot-config'
+
+const mockPost = vi.fn()
+
+vi.mock('@/plugins/api', () => ({
+  useApiClient: () => ({ post: mockPost, get: vi.fn(), put: vi.fn(), delete: vi.fn(), patch: vi.fn() }),
+}))
+
+vi.mock('@/config/ssot-config', () => ({
+  getApiBase: () => '/api',
+  CATEGORY_DEFAULTS: { GENERAL: 'general', SEARCH_MODE_HYBRID: 'hybrid' },
+}))
+
+vi.mock('@/composables/api/useFetchEndpoint', () => ({
+  useFetchEndpoint: () => ({ load: vi.fn(), data: { value: null }, error: { value: null } }),
+}))
+
+describe('useDocumentationSearch category default (#14047)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('searchDocs: missing metadata.category defaults to CATEGORY_DEFAULTS.GENERAL', async () => {
+    mockPost.mockResolvedValueOnce({ results: [{ content: 'hi', metadata: {} }] })
+    const { searchDocs } = useDocumentationSearch()
+
+    const results = await searchDocs('query', [])
+
+    expect(results[0].category).toBe(CATEGORY_DEFAULTS.GENERAL)
+  })
+
+  it('searchDocs: explicit metadata.category overrides the default', async () => {
+    mockPost.mockResolvedValueOnce({
+      results: [{ content: 'hi', metadata: { category: 'security' } }],
+    })
+    const { searchDocs } = useDocumentationSearch()
+
+    const results = await searchDocs('query', [])
+
+    expect(results[0].category).toBe('security')
+  })
+
+  it('browseMore: missing category defaults to CATEGORY_DEFAULTS.GENERAL', async () => {
+    mockPost.mockResolvedValueOnce({ documents: [{ content_hash: 'h1' }] })
+    const { browseMore } = useDocumentationSearch()
+
+    const results = await browseMore('query', null, 1)
+
+    expect(results[0].category).toBe(CATEGORY_DEFAULTS.GENERAL)
+  })
+
+  it('browseMore: explicit category overrides the default', async () => {
+    mockPost.mockResolvedValueOnce({
+      documents: [{ content_hash: 'h1', category: 'security' }],
+    })
+    const { browseMore } = useDocumentationSearch()
+
+    const results = await browseMore('query', null, 1)
+
+    expect(results[0].category).toBe('security')
+  })
+})

--- a/autobot-frontend/src/composables/chat/useDocumentationSearch.ts
+++ b/autobot-frontend/src/composables/chat/useDocumentationSearch.ts
@@ -15,7 +15,7 @@
 
 import { useFetchEndpoint } from '@/composables/api/useFetchEndpoint'
 import { useApiClient } from '@/plugins/api'
-import { getApiBase } from '@/config/ssot-config'
+import { getApiBase, CATEGORY_DEFAULTS } from '@/config/ssot-config'
 import { createLogger } from '@/utils/debugUtils'
 
 const logger = createLogger('useDocumentationSearch')
@@ -122,7 +122,7 @@ export function useDocumentationSearch(): UseDocumentationSearchReturn {
       contentHash: r.metadata?.content_hash,
       title: r.metadata?.title || 'Untitled',
       content: r.content || '',
-      category: r.metadata?.category || 'general',
+      category: r.metadata?.category || CATEGORY_DEFAULTS.GENERAL,
       section: r.metadata?.section,
       filePath: r.metadata?.file_path || '',
       score: r.score || r.rrf_score,
@@ -157,7 +157,7 @@ export function useDocumentationSearch(): UseDocumentationSearchReturn {
       id: d.content_hash,
       title: d.title || 'Untitled',
       content: '',
-      category: d.category || 'general',
+      category: d.category || CATEGORY_DEFAULTS.GENERAL,
       filePath: d.file_path || '',
     }))
   }

--- a/autobot-frontend/src/composables/useKnowledgeCollaboration.ts
+++ b/autobot-frontend/src/composables/useKnowledgeCollaboration.ts
@@ -10,6 +10,7 @@ import { ref, computed } from 'vue'
 import { ApiClient } from '@/utils/ApiClient'
 import { extractErrorMessage } from '@/utils/errorExtract'
 import { useLoadingState } from '@/composables/useLoadingState'
+import { CATEGORY_DEFAULTS } from '@/config/ssot-config'
 
 export interface KnowledgeScope {
   scope: string
@@ -258,7 +259,7 @@ export function useKnowledgeCollaboration() {
         const response = await apiClient.post<ScopedSearchResult>('/api/knowledge/search/scoped', {
           query,
           top_k: options.top_k || 10,
-          mode: options.mode || 'hybrid',
+          mode: options.mode || CATEGORY_DEFAULTS.SEARCH_MODE_HYBRID,
           category: options.category,
           tags: options.tags,
           min_score: options.min_score || 0.0,

--- a/autobot-frontend/src/config/__tests__/ssot-parity.spec.ts
+++ b/autobot-frontend/src/config/__tests__/ssot-parity.spec.ts
@@ -35,6 +35,7 @@ import {
   PERMISSION_MODES,
   PERMISSION_ACTIONS,
   PORT_DEFAULTS,
+  CATEGORY_DEFAULTS,
 } from '../ssot-config'
 
 const PYTHON_SSOT_RELATIVE = join('autobot_shared', 'ssot_config.py')
@@ -71,7 +72,9 @@ function readPythonSsot(): string {
 }
 
 /**
- * Return the indented body of a top-level `class <name>(...)`.
+ * Return the indented body of a top-level `class <name>(...)` or bare
+ * `class <name>:` (#14047 — `CategoryDefaults` has no base-class parens,
+ * unlike `PermissionMode(str, Enum)`).
  *
  * Throws when the class is gone — a rename must fail loudly rather than let
  * every assertion below pass vacuously against an empty extraction.
@@ -79,11 +82,11 @@ function readPythonSsot(): string {
 function pythonClassBody(source: string, className: string): string {
   const lines = source.split('\n')
   const start = lines.findIndex((line) =>
-    new RegExp(`^class ${className}\\(`).test(line),
+    new RegExp(`^class ${className}[(:]`).test(line),
   )
   if (start === -1) {
     throw new Error(
-      `class ${className} not found in ${PYTHON_SSOT_PATH} — it was renamed or removed; update this parity test alongside it.`,
+      `class ${className} not found in the given Python source — it was renamed or removed; update this parity test alongside it.`,
     )
   }
   const body: string[] = []
@@ -127,6 +130,28 @@ function pythonPortDefaults(source: string): Record<string, number> {
 }
 
 /**
+ * Extract `NAME: str = "value"` typed class-attribute defaults, in
+ * declaration order — the shape `class CategoryDefaults` uses (#14047),
+ * distinct from `pythonEnumValues`'s untyped `NAME = "value"` shape and
+ * `pythonPortDefaults`'s `name: int = Field(default=N)` shape.
+ */
+function pythonStringFieldDefaults(source: string, className: string): Record<string, string> {
+  const body = pythonClassBody(source, className)
+  const fields: Record<string, string> = {}
+  const field = /^ {4}([A-Z][A-Z0-9_]*)\s*:\s*str\s*=\s*"([^"]*)"/gm
+  let match: RegExpExecArray | null
+  while ((match = field.exec(body)) !== null) {
+    fields[match[1]] = match[2]
+  }
+  if (Object.keys(fields).length === 0) {
+    throw new Error(
+      `Parsed zero fields out of Python class ${className} — the declaration shape changed; fix this parser rather than trusting an empty comparison.`,
+    )
+  }
+  return fields
+}
+
+/**
  * Ports that legitimately exist on one side only.
  *
  * Python-only: backend-internal services the main frontend never addresses
@@ -157,6 +182,45 @@ describe('Python source parser (self-check)', () => {
     expect(pythonEnumValues(source, 'PermissionMode').length).toBeGreaterThan(0)
     expect(pythonEnumValues(source, 'PermissionAction').length).toBeGreaterThan(0)
     expect(Object.keys(pythonPortDefaults(source)).length).toBeGreaterThan(0)
+  })
+})
+
+const PYTHON_SHARED_SSOT_RELATIVE = join('autobot_shared', 'ssot_constants.py')
+
+function findPythonSharedSsotPath(): string {
+  let dir = resolve(process.cwd())
+  for (;;) {
+    const candidate = join(dir, PYTHON_SHARED_SSOT_RELATIVE)
+    if (existsSync(candidate)) return candidate
+    const parent = dirname(dir)
+    if (parent === dir) break
+    dir = parent
+  }
+  throw new Error(
+    `Could not locate ${PYTHON_SHARED_SSOT_RELATIVE} above ${process.cwd()} — this parity guard requires a full repo checkout, not a frontend-only one.`,
+  )
+}
+
+const PYTHON_SHARED_SSOT_PATH = findPythonSharedSsotPath()
+
+function readPythonSharedSsot(): string {
+  const source = readFileSync(PYTHON_SHARED_SSOT_PATH, 'utf-8')
+  if (source.length === 0) {
+    throw new Error(`Canonical Python config is empty: ${PYTHON_SHARED_SSOT_PATH}`)
+  }
+  return source
+}
+
+describe('SSOT parity: category/mode defaults (#14047)', () => {
+  it('every mirrored CATEGORY_DEFAULTS value matches the Python CategoryDefaults literal', () => {
+    const pythonFields = pythonStringFieldDefaults(readPythonSharedSsot(), 'CategoryDefaults')
+    const mirrored = Object.entries(CATEGORY_DEFAULTS)
+
+    expect(mirrored.length).toBeGreaterThan(0)
+    for (const [key, value] of mirrored) {
+      expect(pythonFields).toHaveProperty(key)
+      expect(value).toBe(pythonFields[key])
+    }
   })
 })
 

--- a/autobot-frontend/src/config/ssot-config.ts
+++ b/autobot-frontend/src/config/ssot-config.ts
@@ -194,6 +194,17 @@ export const PERMISSION_ACTIONS = ['allow', 'ask', 'deny'] as const;
 export type PermissionAction = (typeof PERMISSION_ACTIONS)[number];
 
 /**
+ * Category/mode default values matching backend `CategoryDefaults`
+ * (`autobot_shared/ssot_constants.py`). Only the values consumed on the
+ * frontend today are mirrored here — asserted value-for-value against the
+ * Python source by `src/config/__tests__/ssot-parity.spec.ts` (#14047).
+ */
+export const CATEGORY_DEFAULTS = {
+  GENERAL: 'general',
+  SEARCH_MODE_HYBRID: 'hybrid',
+} as const;
+
+/**
  * Permission rule interface.
  */
 export interface PermissionRule {

--- a/autobot-infrastructure/shared/scripts/monitoring/start_hardware_monitoring.py
+++ b/autobot-infrastructure/shared/scripts/monitoring/start_hardware_monitoring.py
@@ -16,6 +16,8 @@ import time
 from datetime import datetime
 from pathlib import Path
 
+from autobot_shared.ssot_constants import CategoryDefaults
+
 # Add project root to Python path
 project_root = Path(__file__).parent.parent.parent
 sys.path.insert(0, str(project_root))
@@ -271,7 +273,7 @@ class HardwareMonitoringManager:
             for alert in alerts:
                 self.alerts_triggered += 1
                 severity = alert.get("severity", "unknown")
-                category = alert.get("category", "unknown")
+                category = alert.get("category", CategoryDefaults.UNKNOWN)
                 message = alert.get("message", "No message")
 
                 log_level = logging.CRITICAL if severity == "critical" else logging.WARNING

--- a/autobot-infrastructure/shared/scripts/monitoring/start_monitoring.py
+++ b/autobot-infrastructure/shared/scripts/monitoring/start_monitoring.py
@@ -22,7 +22,7 @@ from pathlib import Path
 project_root = Path(__file__).parent.parent.parent
 sys.path.insert(0, str(project_root))
 
-from constants.threshold_constants import TimingConstants
+from constants.threshold_constants import CategoryDefaults, TimingConstants
 from utils.gpu_acceleration_optimizer import (
     benchmark_gpu,
     get_gpu_capabilities,
@@ -292,7 +292,7 @@ class PerformanceMonitoringManager:
             for alert in alerts:
                 self.alerts_triggered += 1
                 severity = alert.get("severity", "unknown")
-                category = alert.get("category", "unknown")
+                category = alert.get("category", CategoryDefaults.UNKNOWN)
                 message = alert.get("message", "No message")
 
                 log_level = logging.CRITICAL if severity == "critical" else logging.WARNING

--- a/autobot-infrastructure/shared/scripts/monitoring/start_monitoring_category_default_test.py
+++ b/autobot-infrastructure/shared/scripts/monitoring/start_monitoring_category_default_test.py
@@ -3,18 +3,44 @@
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
 """Coverage for the ``category`` default in
-``PerformanceMonitoringManager._handle_performance_alert`` (#14047)."""
+``PerformanceMonitoringManager._handle_performance_alert`` (#14047).
 
+Loaded by explicit path (review of #14047): ``pytest.ini`` sets
+``--import-mode=importlib``, which does NOT add a test's own directory to
+``sys.path`` (documented at pytest.ini lines 10-13 for the same trap in
+``pipeline-scripts``), so a bare ``from start_monitoring import ...`` fails
+under real pytest invocation. ``autobot-infrastructure`` is also not in
+``pytest.ini`` testpaths, so this file does not run in CI yet (tracking
+issue: wiring gap, filed alongside #14047) -- explicit-path loading makes it
+individually correct so it starts passing the moment that gap closes, with
+no further changes needed here.
+"""
+
+import importlib.util
 import logging
+from pathlib import Path
 
 import pytest
-from start_monitoring import PerformanceMonitoringManager
 
 from constants.threshold_constants import CategoryDefaults
 
+_MODULE_PATH = Path(__file__).parent / "start_monitoring.py"
+
+
+def _load_start_monitoring():
+    spec = importlib.util.spec_from_file_location("start_monitoring_under_test", _MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture()
+def PerformanceMonitoringManager():
+    return _load_start_monitoring().PerformanceMonitoringManager
+
 
 @pytest.mark.asyncio
-async def test_missing_category_defaults_to_unknown(caplog):
+async def test_missing_category_defaults_to_unknown(PerformanceMonitoringManager, caplog):
     manager = PerformanceMonitoringManager()
 
     with caplog.at_level(logging.WARNING):
@@ -24,7 +50,7 @@ async def test_missing_category_defaults_to_unknown(caplog):
 
 
 @pytest.mark.asyncio
-async def test_explicit_category_overrides_default(caplog):
+async def test_explicit_category_overrides_default(PerformanceMonitoringManager, caplog):
     manager = PerformanceMonitoringManager()
 
     with caplog.at_level(logging.WARNING):

--- a/autobot-infrastructure/shared/scripts/monitoring/start_monitoring_category_default_test.py
+++ b/autobot-infrastructure/shared/scripts/monitoring/start_monitoring_category_default_test.py
@@ -8,9 +8,9 @@
 import logging
 
 import pytest
+from start_monitoring import PerformanceMonitoringManager
 
 from constants.threshold_constants import CategoryDefaults
-from start_monitoring import PerformanceMonitoringManager
 
 
 @pytest.mark.asyncio
@@ -28,8 +28,6 @@ async def test_explicit_category_overrides_default(caplog):
     manager = PerformanceMonitoringManager()
 
     with caplog.at_level(logging.WARNING):
-        await manager._handle_performance_alert(
-            [{"severity": "warning", "category": "cpu", "message": "high load"}]
-        )
+        await manager._handle_performance_alert([{"severity": "warning", "category": "cpu", "message": "high load"}])
 
     assert "[WARNING] cpu: high load" in caplog.text

--- a/autobot-infrastructure/shared/scripts/monitoring/start_monitoring_category_default_test.py
+++ b/autobot-infrastructure/shared/scripts/monitoring/start_monitoring_category_default_test.py
@@ -1,0 +1,35 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Coverage for the ``category`` default in
+``PerformanceMonitoringManager._handle_performance_alert`` (#14047)."""
+
+import logging
+
+import pytest
+
+from constants.threshold_constants import CategoryDefaults
+from start_monitoring import PerformanceMonitoringManager
+
+
+@pytest.mark.asyncio
+async def test_missing_category_defaults_to_unknown(caplog):
+    manager = PerformanceMonitoringManager()
+
+    with caplog.at_level(logging.WARNING):
+        await manager._handle_performance_alert([{"severity": "warning", "message": "high load"}])
+
+    assert f"[WARNING] {CategoryDefaults.UNKNOWN}: high load" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_explicit_category_overrides_default(caplog):
+    manager = PerformanceMonitoringManager()
+
+    with caplog.at_level(logging.WARNING):
+        await manager._handle_performance_alert(
+            [{"severity": "warning", "category": "cpu", "message": "high load"}]
+        )
+
+    assert "[WARNING] cpu: high load" in caplog.text

--- a/autobot-infrastructure/shared/scripts/utilities/manage_system_knowledge.py
+++ b/autobot-infrastructure/shared/scripts/utilities/manage_system_knowledge.py
@@ -14,6 +14,8 @@ import logging
 import sys
 from pathlib import Path
 
+from autobot_shared.ssot_constants import CategoryDefaults
+
 logger = logging.getLogger(__name__)
 
 
@@ -260,7 +262,7 @@ def _build_workflows_template(name: str) -> dict:
     return {
         "metadata": {
             "name": f"{name} Workflow",
-            "category": "general",
+            "category": CategoryDefaults.GENERAL,
             "complexity": "medium",
             "estimated_time": "10-30 minutes",
             "version": "1.0.0",

--- a/autobot-infrastructure/shared/scripts/utilities/manage_system_knowledge_category_default_test.py
+++ b/autobot-infrastructure/shared/scripts/utilities/manage_system_knowledge_category_default_test.py
@@ -1,0 +1,18 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Coverage for the ``category`` default in ``_build_workflows_template`` (#14047).
+
+The category is an unconditional template literal (no caller-supplied
+override path) -- only the fallback value itself is asserted.
+"""
+
+from constants.threshold_constants import CategoryDefaults
+from manage_system_knowledge import _build_workflows_template
+
+
+def test_workflows_template_category_defaults_to_general():
+    template = _build_workflows_template("deploy")
+
+    assert template["metadata"]["category"] == CategoryDefaults.GENERAL

--- a/autobot-infrastructure/shared/scripts/utilities/manage_system_knowledge_category_default_test.py
+++ b/autobot-infrastructure/shared/scripts/utilities/manage_system_knowledge_category_default_test.py
@@ -8,8 +8,9 @@ The category is an unconditional template literal (no caller-supplied
 override path) -- only the fallback value itself is asserted.
 """
 
-from constants.threshold_constants import CategoryDefaults
 from manage_system_knowledge import _build_workflows_template
+
+from constants.threshold_constants import CategoryDefaults
 
 
 def test_workflows_template_category_defaults_to_general():

--- a/autobot-infrastructure/shared/scripts/utilities/manage_system_knowledge_category_default_test.py
+++ b/autobot-infrastructure/shared/scripts/utilities/manage_system_knowledge_category_default_test.py
@@ -6,14 +6,34 @@
 
 The category is an unconditional template literal (no caller-supplied
 override path) -- only the fallback value itself is asserted.
+
+Loaded by explicit path (review of #14047): ``pytest.ini`` sets
+``--import-mode=importlib``, which does NOT add a test's own directory to
+``sys.path`` (documented at pytest.ini lines 10-13 for the same trap in
+``pipeline-scripts``), so a bare ``from manage_system_knowledge import ...``
+fails under real pytest invocation. ``autobot-infrastructure`` is also not
+in ``pytest.ini`` testpaths, so this file does not run in CI yet (tracking
+issue: wiring gap, filed alongside #14047) -- explicit-path loading makes it
+individually correct so it starts passing the moment that gap closes, with
+no further changes needed here.
 """
 
-from manage_system_knowledge import _build_workflows_template
+import importlib.util
+from pathlib import Path
 
 from constants.threshold_constants import CategoryDefaults
 
+_MODULE_PATH = Path(__file__).parent / "manage_system_knowledge.py"
+
+
+def _load_manage_system_knowledge():
+    spec = importlib.util.spec_from_file_location("manage_system_knowledge_under_test", _MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
 
 def test_workflows_template_category_defaults_to_general():
-    template = _build_workflows_template("deploy")
+    template = _load_manage_system_knowledge()._build_workflows_template("deploy")
 
     assert template["metadata"]["category"] == CategoryDefaults.GENERAL

--- a/autobot-infrastructure/shared/tools/index_documentation.py
+++ b/autobot-infrastructure/shared/tools/index_documentation.py
@@ -53,6 +53,7 @@ if env_path.exists():
 from autobot_shared.doc_chunking import chunk_large_content as _chunk_large_content
 from autobot_shared.doc_chunking import estimate_tokens
 from autobot_shared.doc_chunking import process_h2_sections as _process_h2_sections
+from autobot_shared.ssot_constants import CategoryDefaults
 from utils.chromadb_client import get_chromadb_client
 
 # Hash cache file for incremental indexing (Issue #400)
@@ -799,7 +800,7 @@ def get_collection_stats() -> None:
             for meta in sample["metadatas"]:
                 file_path = meta.get("file_path", "unknown")
                 files.add(file_path)
-                cat = meta.get("category", "unknown")
+                cat = meta.get("category", CategoryDefaults.UNKNOWN)
                 categories[cat] = categories.get(cat, 0) + 1
 
             logger.info(f"Indexed files: {len(files)}")

--- a/autobot-infrastructure/shared/tools/index_documentation_category_default_test.py
+++ b/autobot-infrastructure/shared/tools/index_documentation_category_default_test.py
@@ -7,14 +7,41 @@
 ``get_collection_stats`` is a void, log-only script entry point around a real
 ``ChromaDBIndexer`` — mocked here since it has no return-value seam;
 behaviour is asserted via the logged "Chunks by category" breakdown.
+
+Loaded by explicit path (review of #14047): the repo has TWO files named
+``index_documentation.py`` (this one, and
+``shared/scripts/utilities/index_documentation.py``, which has no
+``get_collection_stats``). A bare ``from index_documentation import ...``
+resolves whichever directory happens to be first on ``sys.path``, binding to
+the wrong module depending on invocation order. Installed into
+``sys.modules`` only for the test (removed in the same fixture, matching
+``repo_tests/sys_modules_leak_guard.py``'s install/remove-in-same-scope
+convention) so ``unittest.mock.patch``'s string target still resolves.
 """
 
+import importlib.util
 import logging
+import sys
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from index_documentation import get_collection_stats
+import pytest
 
 from constants.threshold_constants import CategoryDefaults
+
+_MODULE_PATH = Path(__file__).parent / "index_documentation.py"
+
+
+@pytest.fixture()
+def index_documentation():
+    spec = importlib.util.spec_from_file_location("index_documentation", _MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["index_documentation"] = module
+    spec.loader.exec_module(module)
+    try:
+        yield module
+    finally:
+        del sys.modules["index_documentation"]
 
 
 def _mock_indexer(metadatas):
@@ -24,19 +51,19 @@ def _mock_indexer(metadatas):
     return indexer
 
 
-def test_missing_category_defaults_to_unknown(caplog):
+def test_missing_category_defaults_to_unknown(index_documentation, caplog):
     with patch("index_documentation.ChromaDBIndexer", return_value=_mock_indexer([{"file_path": "a.md"}])):
         with caplog.at_level(logging.INFO):
-            get_collection_stats()
+            index_documentation.get_collection_stats()
 
     assert f"- {CategoryDefaults.UNKNOWN}: 1 chunks" in caplog.text
 
 
-def test_explicit_category_overrides_default(caplog):
+def test_explicit_category_overrides_default(index_documentation, caplog):
     metadatas = [{"file_path": "a.md", "category": "security"}]
     with patch("index_documentation.ChromaDBIndexer", return_value=_mock_indexer(metadatas)):
         with caplog.at_level(logging.INFO):
-            get_collection_stats()
+            index_documentation.get_collection_stats()
 
     assert "- security: 1 chunks" in caplog.text
     assert CategoryDefaults.UNKNOWN not in caplog.text

--- a/autobot-infrastructure/shared/tools/index_documentation_category_default_test.py
+++ b/autobot-infrastructure/shared/tools/index_documentation_category_default_test.py
@@ -1,0 +1,41 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Coverage for the ``category`` default in ``get_collection_stats`` (#14047).
+
+``get_collection_stats`` is a void, log-only script entry point around a real
+``ChromaDBIndexer`` — mocked here since it has no return-value seam;
+behaviour is asserted via the logged "Chunks by category" breakdown.
+"""
+
+import logging
+from unittest.mock import MagicMock, patch
+
+from constants.threshold_constants import CategoryDefaults
+from index_documentation import get_collection_stats
+
+
+def _mock_indexer(metadatas):
+    indexer = MagicMock()
+    indexer.collection.count.return_value = len(metadatas)
+    indexer.collection.get.return_value = {"metadatas": metadatas}
+    return indexer
+
+
+def test_missing_category_defaults_to_unknown(caplog):
+    with patch("index_documentation.ChromaDBIndexer", return_value=_mock_indexer([{"file_path": "a.md"}])):
+        with caplog.at_level(logging.INFO):
+            get_collection_stats()
+
+    assert f"- {CategoryDefaults.UNKNOWN}: 1 chunks" in caplog.text
+
+
+def test_explicit_category_overrides_default(caplog):
+    metadatas = [{"file_path": "a.md", "category": "security"}]
+    with patch("index_documentation.ChromaDBIndexer", return_value=_mock_indexer(metadatas)):
+        with caplog.at_level(logging.INFO):
+            get_collection_stats()
+
+    assert "- security: 1 chunks" in caplog.text
+    assert CategoryDefaults.UNKNOWN not in caplog.text

--- a/autobot-infrastructure/shared/tools/index_documentation_category_default_test.py
+++ b/autobot-infrastructure/shared/tools/index_documentation_category_default_test.py
@@ -12,8 +12,9 @@ behaviour is asserted via the logged "Chunks by category" breakdown.
 import logging
 from unittest.mock import MagicMock, patch
 
-from constants.threshold_constants import CategoryDefaults
 from index_documentation import get_collection_stats
+
+from constants.threshold_constants import CategoryDefaults
 
 
 def _mock_indexer(metadatas):

--- a/autobot_shared/ssot_constants_test.py
+++ b/autobot_shared/ssot_constants_test.py
@@ -1,0 +1,30 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Value pin for ``CategoryDefaults`` (#14047 review).
+
+Every new assertion this issue's fix added elsewhere in the tree reads
+``assert x == CategoryDefaults.GENERAL`` — if someone renames the constant's
+*value* (e.g. ``GENERAL: str = "generic"``), the production call site and
+every one of those assertions move together and stay green, silently
+changing persisted KB metadata, an audit-log field, a Prometheus label, and
+a MAP-Elites grid cell key. This file pins the literal independently, the
+same role ``ssot-parity.spec.ts`` plays for the TypeScript mirror
+(``CATEGORY_DEFAULTS`` in ``src/config/ssot-config.ts``) -- both read the
+value as a hard string, not via the symbol under test.
+"""
+
+from autobot_shared.ssot_constants import CategoryDefaults
+
+
+def test_general_value_is_pinned():
+    assert CategoryDefaults.GENERAL == "general"
+
+
+def test_unknown_value_is_pinned():
+    assert CategoryDefaults.UNKNOWN == "unknown"
+
+
+def test_search_mode_hybrid_value_is_pinned():
+    assert CategoryDefaults.SEARCH_MODE_HYBRID == "hybrid"


### PR DESCRIPTION
Closes #14047

## Thinking Path

The widened `check_hardcoded_categories` guard (#14005 → #14048) flags `.get("category"/"search_mode"/"mode", "general"/"hybrid"/"unknown")`-style call-argument defaults across the whole tree. The issue as filed listed 5 sites; the task brief said the guard has since widened twice and to report the real count.

I audited the guard's own regex logic (both call-argument and keyword-style branches, matching its exact quote-class handling) against every non-test, non-generated `.py`/`.ts`/`.vue`/`.js` file, using the same allowlist the hook itself applies (`.pre-commit-config.yaml`'s `exclude: ^(.*(_generated|generated)/)` plus the hook's own test/constants exclusions). That surfaced **36 raw matches**, of which **3 are pre-existing false positives** (docstring/comment lines the guard's comment-skip doesn't catch because they aren't `#`-prefixed — `advanced_rag_optimizer.py:602`, `knowledge/__init__.py:37`, `models/task_context.py:354`). The remaining **33 are genuine sites**.

For each, I checked whether an existing SSOT constant covers it (`autobot_shared.ssot_constants.CategoryDefaults` — already used for this exact pattern in `api/knowledge.py`, #13924), whether it needed the canonical config, or was a legitimate literal-with-a-comment. Every one of the 33 turned out to be the same shape: a category/mode fallback that already has a home in `CategoryDefaults` (`GENERAL`, `UNKNOWN`, `SEARCH_MODE_HYBRID`) — no new constants class needed on the backend.

The 5 frontend sites had no TypeScript mirror of `CategoryDefaults` at all. Rather than inline literals or a second bespoke constants file, I followed the repo's existing cross-language SSOT-mirror pattern (`PERMISSION_MODES`/`PORT_DEFAULTS` in `ssot-config.ts` + `ssot-parity.spec.ts` asserting byte-for-byte parity against the Python source) and added `CATEGORY_DEFAULTS` the same way, with a new parity test.

**Review round (addressed below):** wiring `autobot-infrastructure` into `pytest.ini` testpaths turned out to have a large, pre-existing blast radius (14 collection errors + 2 fatal `sys.exit()` crashes, none related to this PR) — filed separately as #14131 rather than attempted here. Three test files that bare-imported their subject were fixed to load by explicit path instead. A value-pin test for `CategoryDefaults` was added to close the one gap a symbol-comparison test can't catch on its own.

## What Changed

**28 backend Python sites** (24 files) replaced with `CategoryDefaults.GENERAL` / `.UNKNOWN` / `.SEARCH_MODE_HYBRID` (imported from `constants.threshold_constants` inside `autobot-backend`, `autobot_shared.ssot_constants` directly inside `autobot-infrastructure/shared`):

| File | Site | Old literal | New constant |
|---|---|---|---|
| `command_manual_manager.py:519` | `_determine_category` fallback | `"general"` | `CategoryDefaults.GENERAL` |
| `advanced_rag_optimizer.py:620` | `_map_elites_select._cell_key` | `"unknown"` | `CategoryDefaults.UNKNOWN` |
| `knowledge/bulk.py:893` | `_parse_import_csv` | `"general"` | `CategoryDefaults.GENERAL` |
| `memory/essential_story.py:263` | `_format_output` | `"general"` | `CategoryDefaults.GENERAL` |
| `knowledge/search.py:258` | `search()` mode="auto" resolution | `"hybrid"` | `CategoryDefaults.SEARCH_MODE_HYBRID` |
| `api/analytics_llm_patterns.py:811` | `get_category_distribution` | `"unknown"` | `CategoryDefaults.UNKNOWN` |
| `api/knowledge_search_aggregator.py:638,753,841` | `_create_fact_node`, `_create_dynamic_category_nodes`, `_process_facts_into_nodes` (×3) | `"general"` | `CategoryDefaults.GENERAL` |
| `services/feature_flags.py:370` | `get_rollout_statistics` error path | `"unknown"` | `CategoryDefaults.UNKNOWN` |
| `agents/system_knowledge_manager.py:559,648` | `_import_single_tool`, `_import_single_workflow` (×2) | `"general"` | `CategoryDefaults.GENERAL` |
| `api/knowledge_maintenance.py:106,951` | `_process_fact_metadata`, `_build_orphan_fact_info` (×2) | `"unknown"` | `CategoryDefaults.UNKNOWN` |
| `api/chat_knowledge.py:856` | `get_session_facts` | `"general"` | `CategoryDefaults.GENERAL` |
| `api/knowledge_search.py:364` | `_convert_results_to_documents` | `"general"` | `CategoryDefaults.GENERAL` |
| `api/feature_flags.py:151` | `update_enforcement_mode` audit log | `"unknown"` | `CategoryDefaults.UNKNOWN` |
| `utils/performance_monitoring/monitor.py:467` | `_push_alerts_to_prometheus` | `"unknown"` | `CategoryDefaults.UNKNOWN` |
| `utils/error_boundaries/boundary_manager.py:366` | `_calculate_error_groupings` | `"unknown"` | `CategoryDefaults.UNKNOWN` |
| `agents/kb_librarian/librarian.py:51` | `_build_basic_info_section` (f-string) | `'general'` | `CategoryDefaults.GENERAL` |
| `services/specialized_agent_service.py:170` | `get_categories_summary` | `"general"` | `CategoryDefaults.GENERAL` |
| `autobot-infrastructure/shared/tools/index_documentation.py:802` | `get_collection_stats` | `"unknown"` | `CategoryDefaults.UNKNOWN` |
| `skills/registry.py:517` | `parse_skill_md` | `"general"` | `CategoryDefaults.GENERAL` |
| `agents/kb_librarian/processors.py:154` | `ToolInfoData.__init__` | `"general"` | `CategoryDefaults.GENERAL` |
| `services/knowledge/doc_indexer.py:736` | `get_stats` | `"unknown"` | `CategoryDefaults.UNKNOWN` |
| `autobot-infrastructure/shared/scripts/utilities/manage_system_knowledge.py:263` | `_build_workflows_template` | `"general"` | `CategoryDefaults.GENERAL` |
| `autobot-infrastructure/shared/scripts/monitoring/start_monitoring.py:295` | `_handle_performance_alert` | `"unknown"` | `CategoryDefaults.UNKNOWN` |
| `autobot-infrastructure/shared/scripts/monitoring/start_hardware_monitoring.py:274` | `_handle_performance_alert` | `"unknown"` | `CategoryDefaults.UNKNOWN` |

**5 frontend TS/Vue sites**, using a new `CATEGORY_DEFAULTS` export in `src/config/ssot-config.ts` (mirrors `CategoryDefaults.GENERAL`/`SEARCH_MODE_HYBRID`, parity-tested against the Python source):

| File | Old literal | New constant |
|---|---|---|
| `components/chat/DocumentationSuggestionChip.vue` (prop default) | `'general'` | `CATEGORY_DEFAULTS.GENERAL` |
| `components/chat/DocumentationResultCard.vue` (prop default) | `'general'` | `CATEGORY_DEFAULTS.GENERAL` |
| `composables/chat/useDocumentationSearch.ts` (×2) | `'general'` | `CATEGORY_DEFAULTS.GENERAL` |
| `composables/useKnowledgeCollaboration.ts` | `'hybrid'` | `CATEGORY_DEFAULTS.SEARCH_MODE_HYBRID` |

**Review round additions:**
- `autobot_shared/ssot_constants_test.py` — new value-pin test asserting `CategoryDefaults.GENERAL/UNKNOWN/SEARCH_MODE_HYBRID` equal their literal strings independently of the symbol, mirroring `ssot-parity.spec.ts`.
- 3 test files (`index_documentation_category_default_test.py`, `start_monitoring_category_default_test.py`, `manage_system_knowledge_category_default_test.py`) switched from a bare `from <module> import ...` to explicit-path loading via `importlib.util.spec_from_file_location`, fixing both the `--import-mode=importlib` sys.path gap and (for `index_documentation`) a same-name collision with `scripts/utilities/index_documentation.py`.

## Verification

**Constant → literal mapping (every substitution verified identical):**

| Constant | Value | Verified via |
|---|---|---|
| `CategoryDefaults.GENERAL` | `"general"` | `python -c "from autobot_shared.ssot_constants import CategoryDefaults; print(CategoryDefaults.GENERAL)"`, plus new `autobot_shared/ssot_constants_test.py` value pin |
| `CategoryDefaults.UNKNOWN` | `"unknown"` | same |
| `CategoryDefaults.SEARCH_MODE_HYBRID` | `"hybrid"` | same |
| `CATEGORY_DEFAULTS.GENERAL` (TS) | `'general'` | `ssot-parity.spec.ts` — reads and parses the actual Python source text, not a TS↔TS tautology |
| `CATEGORY_DEFAULTS.SEARCH_MODE_HYBRID` (TS) | `'hybrid'` | same |

Cross-checked every diff hunk site-by-site (`git diff` `-`/`+` pairs) — every removed literal exactly equals the constant's resolved value; no site changed behaviour. Every load-bearing site (audit-log field, Prometheus label, persisted KB metadata, MAP-Elites grid cell key, graph node id) checked individually — value-identical, no case/spelling drift anywhere.

**Tests:** 33 genuine sites, coverage breaks down as:
- **29 of 33 run and pass in CI** today (new tests + 2 pre-existing-covered sites — `specialized_agent_service.py`, `skills/registry.py` — + 1 pre-existing partial — `essential_story.py`).
- **3 of 33 have correct, passing tests that do not run in CI**, because `autobot-infrastructure` is outside `pytest.ini` testpaths (`start_monitoring.py:295`, `manage_system_knowledge.py:263`, `index_documentation.py:802`). Verified by running each with the real `pytest.ini` config and no manual `PYTHONPATH` — all 5 test cases collect and pass. Wiring the whole tree in was investigated and found to have a large pre-existing blast radius (14 collection errors, 2 fatal `sys.exit()` crashes, none related to this change) — filed as #14131 rather than attempted here.
- **1 of 33 has no automated test** (`start_hardware_monitoring.py:274`): the module is unimportable in this environment because it imports `start_phase9_monitoring` from `utils.hardware_metrics`, a function that doesn't exist in the repo's only `hardware_metrics.py`. Pre-existing, unrelated bug — filed with the other discovered bug as **#14129**.

Mutation-tested every new test, including the value pin: reverted/changed the relevant literal or constant, confirmed via file diff the mutation actually landed, ran the test and confirmed RED, then restored and confirmed GREEN. Zero survivors. The value pin specifically catches what the symbol-comparison tests can't — mutating `CategoryDefaults.GENERAL` to a bogus value reddened only the pin, while e.g. `librarian_test.py`'s `_build_basic_info_section` assertions stayed green (both sides moved together), confirming the exact gap the reviewer flagged.

**Backend test sweep** (not just touched files — `api/`, `agents/`, `services/`, `knowledge/`, `utils/`, `skills/`, plus the new/changed test files): `6278 passed, 12 failed, 20 errors` — all 32 failures/errors are pre-existing, unrelated to this change (live-Redis/live-backend/live-TTS-worker integration tests and a missing optional `playwright` dependency; none touch a file this PR modifies).

**Guard verification** (`autobot-infrastructure/shared/scripts/hooks/pre-commit-hardcoded-values`'s `check_hardcoded_categories`, which is measurably too slow to run repo-wide in one pass — same documented issue as the `.pre-commit-config.yaml` generated-file exclusion):
- Repo-wide (validated Python re-implementation of the exact guard regex, cross-checked byte-for-byte against real bash output on a sample): **before 36 raw matches (33 genuine + 3 pre-existing docstring false positives) → after 3 (only the pre-existing false positives; 0 genuine sites remain)**.
- Real bash guard on the diff's added lines only: 0 genuine violations.
- Real bash guard, full script, on `api/feature_flags.py` (mutation-test target): `No violations found!` after restore.
- Real bash guard on `advanced_rag_optimizer.py` (partial run before its own documented slowness timed it out): flags only the one known pre-existing docstring false positive at line 603 — exact match with the Python re-implementation.

**Lint:** `black`/`isort`/`flake8` clean on every changed Python file via `/home/martins/AutoBot-Ai/AutoBot-AI/venv/bin/python` (one pre-existing, unrelated `flake8` F821 finding in `manage_system_knowledge.py` — see #14129). `npm run lint` (oxlint + eslint) clean on the frontend.

## Notes for the record

- `CategoryDefaults.UNKNOWN` is used as an **enforcement-mode** sentinel at `api/feature_flags.py:151` and `services/feature_flags.py:370`, coupling an audit-log field and a public API field to a category vocabulary. Value-identical today, and `EnforcementMode` has no `UNKNOWN` member, so there's no better-fitting constant — the guard forced *a* constant onto a slightly different concept. Noted, not restructured, since restructuring `EnforcementMode` is out of scope here.
- `start_hardware_monitoring.py:19` puts its new import above the file's own `sys.path` bootstrap, while sibling `start_monitoring.py` puts it after. Two same-shaped files, two conventions — left as-is per review guidance (record, don't fix).
- Guard erosion: `check_hardcoded_categories` skips any line containing `GENERAL`/`UNKNOWN`/`SEARCH_MODE`, so all 28 edited backend lines are now permanently invisible to it going forward. Expected/intended (that's what "fixed" means to this guard), but worth knowing it can no longer re-flag a future regression on these exact lines — only the value pin added in this PR would catch that class of regression now.
- `services/knowledge/test_doc_indexer_get_stats_category_default.py` uses the `test_*` prefix, matching its own directory's convention (`test_doc_indexer.py`, `test_doc_indexer_dim_mismatch.py`), while the other 12 new backend test files use the colocated `*_test.py` suffix matching *their* directories. Correct per #734's colocated-convention rule; just visually inconsistent across this PR's own file list.

## Further bugs found (not fixed here)

Filed as **#14129**:
1. `manage_system_knowledge.py` — `KnowledgeBase`, `SystemKnowledgeManager`, `yaml` referenced but never imported (flake8 F821 ×7).
2. `start_hardware_monitoring.py` — imports `start_phase9_monitoring` (+4 siblings) from `utils.hardware_metrics`, but no such function exists anywhere in the repo.

Filed as **#14131**: `autobot-infrastructure/shared` is outside `pytest.ini` testpaths; 14 pre-existing collection errors + 2 fatal `sys.exit()` crashes found while investigating wiring it in.

## Model Used

Sonnet 5