### PR TITLE
fix(repo): untrack the venv symlink that destroys the interpreter on checkout (#14137)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,18 @@
 # === PYTHON VIRTUAL ENVIRONMENT ===
 # Virtual environment directories (created by setup_agent.sh)
+#
+# The entries below carry a trailing slash, which matches a DIRECTORY only. A
+# worktree that reaches the shared interpreter through a `venv` *symlink* was
+# therefore not ignored, and a `git add -A` committed it (#14133). With
+# `core.symlinks=false` — which this repo sets — checking that out replaces the
+# real venv directory with a 40-byte text file containing its own path,
+# destroying the interpreter for every tree that pulls.
+#
+# The slashless entries match a file, a directory or a symlink of that name.
 AutoBot/
+venv
 venv/
+venvs
 venvs/
 bin/
 lib/

--- a/venv
+++ b/venv
@@ -1,1 +1,0 @@
-/home/martins/AutoBot-Ai/AutoBot-AI/venv


### PR DESCRIPTION
Closes #14137.

## Thinking Path

`venv` was tracked as a symlink (mode `120000`) pointing at the repository's own venv path. This repo sets `core.symlinks=false`, so git cannot create a symlink and instead writes a **regular file containing the target path** — replacing the real `venv/` directory with 40 bytes of text.

```
$ git ls-files -s venv
120000 795760ad45c9d61c3c3899ecef5ec5cafb0baa7d 0	venv

$ file venv
venv: ASCII text, with no line terminators
```

Nothing errors at checkout. The next command needing the interpreter fails with `Not a directory`, far from the cause, and every worktree creation re-materialises it. Two worktrees on one machine were clobbered before it was spotted.

The symlink's target is its own path, so it is a self-loop — there is no `core.symlinks` setting under which this entry does anything useful.

**Root cause of the commit:** `.gitignore` carried `venv/` with a trailing slash, which matches a **directory only**. A worktree reaching the shared interpreter through a `venv` *symlink* was not ignored, and a `git add -A` swept it in. It entered the default branch through PR #14119 — mine, and recorded as such.

## What Changed

- `git rm --cached venv` — untracked, so a checkout stops overwriting the directory.
- `.gitignore` virtualenv entries are now slashless as well as slashed, so a file, directory **or symlink** of that name is covered:

```
venv
venv/
venvs
venvs/
```

- A comment above them explaining the trailing-slash semantics and the `core.symlinks=false` interaction, so the next person to tidy the ignore file does not re-narrow it.

## Verification

```
$ git ls-files -s venv
(no output — untracked)

$ git status --porcelain
 M .gitignore
D  venv
```

`git check-ignore -v venv` now matches on the slashless rule, so a symlink of that name cannot be staged again.

Nothing else is touched — no source file, no test, no workflow. Deliberately minimal: this is the smallest change that stops the interpreter being destroyed, and it should land ahead of the guard work.

## Not in this PR

The durable fix is a **guard** that fails a commit or CI when a tracked entry has mode `120000` pointing inside the working tree. This class cannot be caught by reading a diff — the diff shows a one-line text file, which looks harmless. #14137 carries that as remaining scope, along with a check that no tracked path shadows a virtualenv name in `.gitignore`.

The ignore fix stops this instance; only a mode check stops the next symlink someone commits.

## Model Used

claude-opus-5
