### PR TITLE
fix(repo): guard against tracked symlinks and gitignore-shadowing paths (#14137)

### DIFF
--- a/.github/workflows/enforce-precommit.yml
+++ b/.github/workflows/enforce-precommit.yml
@@ -27,6 +27,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          # fetch-depth: 2 (not the actions/checkout default of 1) so the PR
+          # base commit is present. On a pull_request the checkout is the
+          # merge commit: depth 2 supplies both parents — HEAD^1 (base tip)
+          # and HEAD^2 (PR head) — which the #14137 symlink-diff step below
+          # needs. Same reasoning as code-quality.yml (#13880).
+          fetch-depth: 2
 
       - name: Check for pre-commit config
         run: |
@@ -93,6 +100,55 @@ jobs:
           # in_scope()/EXCLUDE_RE in the script skip vendored/generated/.vue/
           # workflow/infrastructure paths (same scope as the original sweep).
           git ls-files -z | xargs -0 python3 tools/lint/check_spdx_header.py
+
+      - name: Block newly tracked symlinks into or out of the working tree (#14137)
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          # BLOCKING, and diff-scoped rather than a full-tree scan: #14149
+          # found a PRE-EXISTING tracked symlink (already broken, tracked
+          # separately) that a full-tree scan would fail on every unrelated
+          # PR until it's fixed. Same changed-files scoping #13950/#14051
+          # established for the hardcoded-value and print guards — a NEWLY
+          # added or modified mode-120000 entry still fails; #14149's,
+          # untouched by a given PR, does not block that PR.
+          #
+          # Resolve through HEAD's own parents first (#13880): on a
+          # pull_request the checkout is the merge commit, so HEAD^1 is the
+          # base tip and HEAD^2 is the PR head — no event payload needed.
+          have() { git cat-file -e "${1}^{commit}" 2>/dev/null; }
+          if have 'HEAD^2' && have 'HEAD^1'; then
+            base="HEAD^1"
+          elif have "${PR_BASE_SHA:-x}"; then
+            base="$PR_BASE_SHA"
+          else
+            echo "::error::cannot resolve a base commit — refusing to report 0 changed files as clean"
+            exit 1
+          fi
+          # No extension pathspec: the destructive entries in both #14137
+          # (venv) and #14149 (all.yml) are exactly the shapes a
+          # source-extension filter would exclude — one has no extension at
+          # all, the other isn't a source file.
+          if ! raw_files=$(git diff --name-only "$base" HEAD); then
+            echo "::error::git diff failed for ${base}..HEAD — refusing to report clean."
+            exit 1
+          fi
+          if [ -z "$raw_files" ]; then
+            echo "No changed files — skipping pre-commit-no-tracked-symlink."
+            exit 0
+          fi
+          echo "$raw_files" | xargs -d '\n' bash autobot-infrastructure/shared/scripts/hooks/pre-commit-no-tracked-symlink
+
+      - name: Block tracked paths shadowing the virtualenv ignore names (#14137)
+        run: |
+          # Full-tree (git ls-files inside the hook): zero pre-existing
+          # violations as of #14137 (verified — every currently-tracked
+          # bin/lib/venv-named path is covered by a .gitignore '!' negation),
+          # so unlike the symlink guard above there is nothing pre-existing
+          # to blame an unrelated PR for.
+          bash autobot-infrastructure/shared/scripts/hooks/pre-commit-no-gitignore-shadow
 
   check-instructions:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,11 @@
 # destroying the interpreter for every tree that pulls.
 #
 # The slashless entries match a file, a directory or a symlink of that name.
+#
+# This stops a REPEAT of that instance; it does not stop a NEW tracked
+# symlink or a narrowed pattern in this section from doing the same thing
+# again. autobot-infrastructure/shared/scripts/hooks/pre-commit-no-tracked-symlink
+# and pre-commit-no-gitignore-shadow guard those cases directly (#14137).
 AutoBot/
 venv
 venv/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -459,6 +459,33 @@ repos:
         stages: [pre-commit]
         description: "Blocks commits with >50 staged file deletions (likely stash bug, not intended cleanup)"
 
+  # No tracked symlink entries — mode 120000 checks out as a plain file
+  # under this repo's core.symlinks=false, silently clobbering whatever
+  # real path was there (Issue #14137)
+  - repo: local
+    hooks:
+      - id: no-tracked-symlink
+        name: No Tracked Symlink Entries (Issue #14137)
+        entry: autobot-infrastructure/shared/scripts/hooks/pre-commit-no-tracked-symlink
+        language: script
+        pass_filenames: false
+        always_run: true
+        stages: [pre-commit]
+        description: "Blocks a NEW tracked mode-120000 entry — a symlink materialises as a plain file under core.symlinks=false, silently overwriting whatever real path was there"
+
+  # No tracked path shadows a name in .gitignore's virtualenv section
+  # (Issue #14137) — the other half of how the venv symlink got in
+  - repo: local
+    hooks:
+      - id: no-gitignore-shadow
+        name: No Tracked Path Shadows the Virtualenv Ignore Names (Issue #14137)
+        entry: autobot-infrastructure/shared/scripts/hooks/pre-commit-no-gitignore-shadow
+        language: script
+        pass_filenames: false
+        always_run: true
+        stages: [pre-commit]
+        description: "Blocks a tracked path whose name matches a .gitignore virtualenv-section entry unless explicitly negated"
+
   # Hardcoded value detection (Issue #694)
   - repo: local
     hooks:

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-gitignore-shadow
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-gitignore-shadow
@@ -34,11 +34,14 @@
 # Issue: #14137
 # Install: pre-commit install (uses .pre-commit-config.yaml)
 
-set -uo pipefail
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/_common.sh
-source "$SCRIPT_DIR/lib/_common.sh"
+source "$SCRIPT_DIR/lib/_common.sh" || {
+    echo "FATAL: cannot load lib/_common.sh — refusing to report clean" >&2
+    exit 1
+}
 
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
 if [ -z "$REPO_ROOT" ]; then

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-gitignore-shadow
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-gitignore-shadow
@@ -1,0 +1,167 @@
+#!/bin/bash
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+#
+# Pre-commit Hook: No Tracked Path Shadows the Virtualenv Ignore Names (Issue #14137)
+# ======================================================================================
+#
+# The other half of how #14137 happened: `.gitignore`'s virtualenv section
+# used to carry `venv/` with a trailing slash, which matches a DIRECTORY
+# only. A worktree that reached the shared interpreter through a `venv`
+# *symlink* was therefore never ignored, and `git add -A` swept it in.
+# #14138 made the entries slashless (`venv`, `venv/`, `venvs`, `venvs/`),
+# but nothing stopped a FUTURE edit to that section from reintroducing a
+# slash-only (or otherwise narrowed) pattern that stops covering a file or
+# symlink of the same name. This hook does not re-derive gitignore's own
+# matching semantics; it independently confirms the outcome that matters —
+# no tracked path anywhere in the repo is named after an entry in that
+# section — so a narrowed pattern is caught by what it fails to exclude,
+# not by re-implementing it.
+#
+# Scope: full-tree (`git ls-files`), not diff-scoped. Unlike
+# pre-commit-no-tracked-symlink (#14137's #14149 pre-existing instance),
+# there are zero pre-existing violations here as of #14137 — every path
+# already tracked under the section's bare names (`scripts/lib/`,
+# `autobot-infrastructure/shared/scripts/hooks/lib/`) is covered by an
+# explicit `!` negation in .gitignore, which this hook also honours.
+#
+# Matching: a bare gitignore entry with no slash matches a path SEGMENT
+# at any depth (git's own semantics), so this hook checks every path
+# component, not only the top-level or the basename.
+#
+# Issue: #14137
+# Install: pre-commit install (uses .pre-commit-config.yaml)
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/_common.sh
+source "$SCRIPT_DIR/lib/_common.sh"
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+if [ -z "$REPO_ROOT" ]; then
+    echo "FATAL: not inside a git working tree." >&2
+    exit 1
+fi
+GITIGNORE="$REPO_ROOT/.gitignore"
+
+SECTION_MARKER='# === PYTHON VIRTUAL ENVIRONMENT ==='
+
+# Extracts the virtualenv section's positive entry names (no slash, no
+# `!`) into NAMES[], and negated entries' path prefixes into
+# NEGATED_PREFIXES[]. Bails out loudly if the marker itself is gone —
+# a silently-empty guard is worse than a guard that fails closed.
+declare -a NAMES=()
+declare -a NEGATED_PREFIXES=()
+
+load_virtualenv_section() {
+    if [ ! -f "$GITIGNORE" ]; then
+        echo "FATAL: $GITIGNORE not found." >&2
+        exit 1
+    fi
+    if ! grep -qF "$SECTION_MARKER" "$GITIGNORE"; then
+        echo "FATAL: '$SECTION_MARKER' marker not found in .gitignore — this hook can no" >&2
+        echo "  longer find the virtualenv section it is meant to guard. Update" >&2
+        echo "  SECTION_MARKER in $0 to match, or restore the marker." >&2
+        exit 1
+    fi
+
+    local in_section=0 line
+    while IFS= read -r line; do
+        if [ "$line" = "$SECTION_MARKER" ]; then
+            in_section=1
+            continue
+        fi
+        if [ "$in_section" -eq 1 ]; then
+            # The section ends at the next `# ===` header (or EOF).
+            case "$line" in
+                '# ==='*)
+                    break
+                    ;;
+            esac
+            # Skip blanks and ordinary comments.
+            case "$line" in
+                ''|'#'*)
+                    continue
+                    ;;
+            esac
+            if [ "${line:0:1}" = "!" ]; then
+                local prefix="${line:1}"
+                prefix="${prefix%/}"
+                [ -n "$prefix" ] && NEGATED_PREFIXES+=("$prefix")
+            else
+                local name="${line%/}"
+                [ -n "$name" ] && NAMES+=("$name")
+            fi
+        fi
+    done < "$GITIGNORE"
+
+    if [ "${#NAMES[@]}" -eq 0 ]; then
+        echo "FATAL: virtualenv section parsed to zero names — refusing to report clean" >&2
+        echo "  on an empty guard scope. Check the section format in .gitignore." >&2
+        exit 1
+    fi
+}
+
+# True (0) if PATH is covered by a `!` negation prefix.
+is_negated() {
+    local path="$1" prefix
+    for prefix in "${NEGATED_PREFIXES[@]:-}"; do
+        [ -z "$prefix" ] && continue
+        case "$path" in
+            "$prefix"|"$prefix"/*)
+                return 0
+                ;;
+        esac
+    done
+    return 1
+}
+
+main() {
+    load_virtualenv_section
+
+    local violations=0
+    local tracked
+    tracked="$(git ls-files)"
+    [ -z "$tracked" ] && exit 0
+
+    while IFS= read -r path; do
+        [ -z "$path" ] && continue
+        is_negated "$path" && continue
+
+        local -a segs
+        IFS='/' read -ra segs <<< "$path"
+        local seg name matched=""
+        for seg in "${segs[@]}"; do
+            for name in "${NAMES[@]}"; do
+                if [ "$seg" = "$name" ]; then
+                    matched="$name"
+                    break 2
+                fi
+            done
+        done
+
+        if [ -n "$matched" ]; then
+            printf "%b✗ %s%b — shadows '%s' in .gitignore's virtualenv section\n" "$RED" "$path" "$NC" "$matched"
+            violations=$((violations + 1))
+        fi
+    done <<< "$tracked"
+
+    if [ "$violations" -gt 0 ]; then
+        printf "\n%b%bBLOCKED: %d tracked path(s) shadow a virtualenv-section ignore name%b\n\n" \
+            "$RED" "$BOLD" "$violations" "$NC"
+        printf "A path with the same name as a %s entry is either a virtualenv\n" "${NAMES[0]}"
+        printf "artifact that slipped past .gitignore (narrow it, or untrack the path), or\n"
+        printf "a legitimate path that needs a '!' negation in .gitignore next to it\n"
+        printf "(see the existing !scripts/lib/ / !autobot-infrastructure/.../lib/ entries).\n"
+        printf "Issue: #14137\n"
+        exit 1
+    fi
+
+    printf "%b%b✓ No tracked path shadows a virtualenv-section ignore name%b\n" "$GREEN" "$BOLD" "$NC"
+    exit 0
+}
+
+main "$@"

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-gitignore-shadow_test.py
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-gitignore-shadow_test.py
@@ -1,0 +1,163 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for pre-commit-no-gitignore-shadow (#14137).
+
+The other half of how the venv symlink got in: `.gitignore` carried
+`venv/` with a trailing slash (directory-only), so a `venv` *symlink* was
+never ignored and `git add -A` swept it in. This hook independently
+confirms the OUTCOME .gitignore's virtualenv section is meant to
+guarantee — no tracked path is named after one of its entries — rather
+than re-deriving gitignore's own pattern-matching rules.
+
+Every fixture writes its own throwaway `.gitignore` in a tmp_path git repo,
+so a change to the real repo's virtualenv section can't accidentally make
+these tests pass or fail for the wrong reason.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+HOOK_PATH = Path(__file__).resolve().parent / "pre-commit-no-gitignore-shadow"
+
+_SECTION = (
+    "# === PYTHON VIRTUAL ENVIRONMENT ===\n"
+    "venv\n"
+    "venv/\n"
+    "venvs\n"
+    "venvs/\n"
+    "bin/\n"
+    "lib/\n"
+    "!scripts/lib/\n"
+    "lib64/\n"
+    "include/\n"
+    "share/\n"
+    "pyvenv.cfg\n"
+    "\n"
+    "# === NODE.JS AND NPM ===\n"
+    "node_modules/\n"
+)
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(["git", *args], cwd=repo, capture_output=True, text=True, check=True)
+
+
+def _init_repo(tmp_path: Path, gitignore: str = _SECTION) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "--quiet")
+    _git(repo, "config", "user.email", "t@t")
+    _git(repo, "config", "user.name", "t")
+    (repo / ".gitignore").write_text(gitignore, encoding="utf-8")
+    return repo
+
+
+def _track(repo: Path, path: str, content: str = "x\n") -> None:
+    p = repo / path
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+    _git(repo, "add", "-f", path)
+
+
+def _run_hook(repo: Path) -> subprocess.CompletedProcess:
+    return subprocess.run([str(HOOK_PATH)], cwd=repo, capture_output=True, text=True)
+
+
+# === Ordinary tracked tree — must not be blocked ===
+
+
+def test_clean_tree_with_no_shadowing_paths_passes(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    _track(repo, "app/main.py")
+    _track(repo, ".gitignore", _SECTION)
+    result = _run_hook(repo)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+# === A tracked path shadowing a bare ignore name is rejected ===
+
+
+def test_top_level_venv_directory_is_rejected(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    _track(repo, "venv/pyvenv.cfg")
+    _track(repo, ".gitignore", _SECTION)
+    result = _run_hook(repo)
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "venv" in result.stdout
+
+
+def test_nested_directory_named_venv_is_rejected(tmp_path: Path) -> None:
+    """A bare gitignore entry (no slash) matches at any depth — this hook
+    must mirror that, not just check the top level."""
+    repo = _init_repo(tmp_path)
+    _track(repo, "some/deep/venv/site-packages/pkg/__init__.py")
+    _track(repo, ".gitignore", _SECTION)
+    result = _run_hook(repo)
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "some/deep/venv/site-packages/pkg/__init__.py" in result.stdout
+
+
+def test_bare_pyvenv_cfg_file_is_rejected(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    _track(repo, "pyvenv.cfg")
+    _track(repo, ".gitignore", _SECTION)
+    result = _run_hook(repo)
+    assert result.returncode == 1
+
+
+# === The allowlist (a `!` negation) works, and does not swallow everything ===
+
+
+def test_negated_path_is_allowed(tmp_path: Path) -> None:
+    """scripts/lib/ is explicitly negated — must not be flagged."""
+    repo = _init_repo(tmp_path)
+    _track(repo, "scripts/lib/helper.sh")
+    _track(repo, ".gitignore", _SECTION)
+    result = _run_hook(repo)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_negation_does_not_exempt_a_different_lib_path(tmp_path: Path) -> None:
+    """The allowlist must be a narrow prefix match, not a name-wide pass —
+    a `lib/` outside scripts/ is still a violation."""
+    repo = _init_repo(tmp_path)
+    _track(repo, "other/lib/helper.sh")
+    _track(repo, ".gitignore", _SECTION)
+    result = _run_hook(repo)
+    assert result.returncode == 1, "negation for scripts/lib/ leaked to an unrelated lib/ path"
+    assert "other/lib/helper.sh" in result.stdout
+
+
+def test_negation_prefix_respects_a_slash_boundary(tmp_path: Path) -> None:
+    """`scripts/lib/` is negated; `scripts/lib-extra/` is a different
+    directory that merely shares the string prefix "scripts/lib". If the
+    negation check used a bare string-prefix test instead of a '/'-bounded
+    one, this path would be wrongly exempted (exit 0) via the "lib" segment
+    the negation was never meant to cover."""
+    repo = _init_repo(tmp_path)
+    _track(repo, "scripts/lib-extra/lib/mod.py")
+    _track(repo, ".gitignore", _SECTION)
+    result = _run_hook(repo)
+    assert result.returncode == 1, "negation for scripts/lib/ leaked past its own '/' boundary"
+    assert "scripts/lib-extra/lib/mod.py" in result.stdout
+
+
+# === Fail closed if the section marker itself goes missing ===
+
+
+def test_missing_section_marker_fails_closed(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path, gitignore="node_modules/\n*.pyc\n")
+    result = _run_hook(repo)
+    assert result.returncode != 0
+    assert "marker not found" in result.stdout + result.stderr
+
+
+def test_missing_gitignore_fails_closed(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    (repo / ".gitignore").unlink()
+    result = _run_hook(repo)
+    assert result.returncode != 0

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-gitignore-shadow_test.py
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-gitignore-shadow_test.py
@@ -161,3 +161,38 @@ def test_missing_gitignore_fails_closed(tmp_path: Path) -> None:
     (repo / ".gitignore").unlink()
     result = _run_hook(repo)
     assert result.returncode != 0
+
+
+class TestTheGuardFailsClosedWhenItCannotRun:
+    """Companion to the same class in the symlink hook's tests.
+
+    This hook already failed closed for a missing marker and for a virtualenv
+    section parsing to zero names — both deliberately tested. The two paths
+    nobody tested were a missing `lib/_common.sh` and `git ls-files` erroring,
+    and those reported clean (#14150 review).
+
+    The pattern is worth naming: the failure modes that were considered were
+    handled; the ones that were not considered were not. Testing what you
+    already thought about proves the least.
+    """
+
+    def test_a_missing_common_lib_does_not_report_clean(self, tmp_path: Path) -> None:
+        repo = _init_repo(tmp_path)
+
+        isolated = tmp_path / "isolated"
+        isolated.mkdir()
+        hook_copy = isolated / HOOK_PATH.name
+        hook_copy.write_bytes(HOOK_PATH.read_bytes())
+        hook_copy.chmod(0o755)
+
+        result = subprocess.run([str(hook_copy)], cwd=repo, capture_output=True, text=True)
+
+        assert result.returncode != 0, "the hook reported clean without its dependency"
+
+    def test_a_git_failure_does_not_report_clean(self, tmp_path: Path) -> None:
+        repo = _init_repo(tmp_path)
+        (repo / ".git" / "index").write_text("garbage", encoding="utf-8")
+
+        result = _run_hook(repo)
+
+        assert result.returncode != 0, "a git failure was indistinguishable from 'no violation'"

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-tracked-symlink
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-tracked-symlink
@@ -1,0 +1,209 @@
+#!/bin/bash
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+#
+# Pre-commit Hook: No Tracked Symlink Entries (Issue #14137)
+# =============================================================
+#
+# This repo commonly runs with `core.symlinks=false` (WSL2 — see
+# docs/developer/BACKEND_DEBUGGING.md). Under that setting git cannot
+# create a real symlink on checkout: a tracked entry with mode `120000`
+# is materialised as a REGULAR FILE containing the target path as bare
+# text, silently overwriting whatever real file or directory previously
+# occupied that path. #14137 lost a `venv/` this way — a self-referential
+# absolute-path symlink replaced the interpreter with 40 bytes of text,
+# and nothing errored at checkout. #14149 found a second, already-broken
+# instance: an Ansible `group_vars/all.yml` symlink whose checkout is a
+# 37-byte path string instead of ~14 KB of real YAML.
+#
+# The defect is invisible to a content review: `git show`/`git diff` on a
+# committed symlink prints a plausible one-line path string, indistinguishable
+# from a harmless text file. Only the INDEX MODE (`git ls-files -s`) reveals
+# it, which is why this is a dedicated guard rather than a grep pattern.
+#
+# Scope: this checks CHANGED entries only (staged, for pre-commit; the PR's
+# diff, for CI), not a full-tree scan. #14149 is a pre-existing, already
+# broken symlink that this exact guard would find in a full-tree scan — but
+# blocking every future commit until #14149 is fixed would stop unrelated
+# work over a defect this guard did not introduce. Reusing lib/_common.sh's
+# get_staged_files() picks up the change-scoping already proven for
+# pre-commit-hardcoded-values / pre-commit-no-print-console (#13950,
+# #14051): a NEWLY added or modified symlink entry still fails; #14149's
+# existing one, untouched by a given commit, does not block that commit.
+#
+# Classification (inside vs outside the working tree):
+#   INSIDE  — the target, resolved relative to the symlink's own directory
+#             (or, for an absolute target, compared against this checkout's
+#             own root), lands inside the repository. BLOCKING: this is the
+#             demonstrated destructive shape — both #14137 (self-referential
+#             absolute path) and #14149 (`../../../inventory/...`) are
+#             INSIDE, and both silently clobbered or starved real content.
+#   OUTSIDE — the target escapes the repository (absolute path elsewhere,
+#             or enough `..` to climb above the root). BLOCKING too, but
+#             reported distinctly: it can't clobber a REPO-owned path this
+#             way, but under core.symlinks=false it never functions as a
+#             link on ANY clone of this repo either — it is dead weight at
+#             best, and a route for a host-specific absolute path to leak
+#             into tracked history at worst (the concern
+#             pipeline-scripts/... "Block developer absolute-path
+#             regressions" already polices for text content, which a
+#             symlink's blob is not caught by since it usually carries no
+#             file extension).
+#
+# Resolution is purely lexical (string ops on the blob content), not a
+# filesystem stat: a broken symlink — or one whose target does not exist on
+# the machine running the hook — must still classify correctly.
+#
+# Issue: #14137
+# Install: pre-commit install (uses .pre-commit-config.yaml)
+# CI: invoked with an explicit file list (see .github/workflows/enforce-precommit.yml)
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/_common.sh
+source "$SCRIPT_DIR/lib/_common.sh"
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+if [ -z "$REPO_ROOT" ]; then
+    echo "FATAL: not inside a git working tree — cannot resolve symlink targets." >&2
+    exit 1
+fi
+
+VIOLATIONS_INSIDE=0
+VIOLATIONS_OUTSIDE=0
+
+# Resolve TARGET (a symlink blob's literal content) against the directory
+# containing SYMLINK_PATH, purely lexically. Echoes INSIDE or OUTSIDE.
+classify_target() {
+    local symlink_path="$1" target="$2"
+    local base_dir
+    base_dir="$(dirname -- "$symlink_path")"
+    [ "$base_dir" = "." ] && base_dir=""
+
+    # Absolute target: only INSIDE if it sits under THIS checkout's own
+    # root on THIS machine — exactly the #14137 shape (a self-referential
+    # absolute path). Any other absolute path cannot be inside a repo it
+    # doesn't share a root with, and is reported OUTSIDE.
+    case "$target" in
+        /*)
+            case "$target" in
+                "$REPO_ROOT"|"$REPO_ROOT"/*)
+                    echo "INSIDE"
+                    ;;
+                *)
+                    echo "OUTSIDE"
+                    ;;
+            esac
+            return
+            ;;
+    esac
+
+    local -a stack=()
+    local seg escaped=0
+    if [ -n "$base_dir" ]; then
+        local -a base_segs
+        IFS='/' read -ra base_segs <<< "$base_dir"
+        for seg in "${base_segs[@]}"; do
+            [ -n "$seg" ] && stack+=("$seg")
+        done
+    fi
+
+    local -a tgt_segs
+    IFS='/' read -ra tgt_segs <<< "$target"
+    for seg in "${tgt_segs[@]}"; do
+        case "$seg" in
+            ""|".")
+                continue
+                ;;
+            "..")
+                if [ "${#stack[@]}" -eq 0 ]; then
+                    escaped=1
+                else
+                    stack=("${stack[@]:0:$((${#stack[@]}-1))}")
+                fi
+                ;;
+            *)
+                stack+=("$seg")
+                ;;
+        esac
+    done
+
+    if [ "$escaped" -eq 1 ]; then
+        echo "OUTSIDE"
+    else
+        echo "INSIDE"
+    fi
+}
+
+check_file() {
+    local file="$1"
+
+    # `git ls-files -s` reports the INDEX mode — the mode that would be
+    # committed (pre-commit: staged; CI: the merge commit's checkout) —
+    # regardless of how core.symlinks materialised it on disk. A deleted
+    # path has no index entry and is silently skipped (removing a symlink
+    # is the fix direction, never a violation).
+    local ls_line mode blob_sha
+    ls_line="$(git ls-files -s -- "$file" 2>/dev/null | head -1)"
+    [ -n "$ls_line" ] || return 0
+
+    mode="$(printf '%s' "$ls_line" | awk '{print $1}')"
+    [ "$mode" = "120000" ] || return 0
+
+    blob_sha="$(printf '%s' "$ls_line" | awk '{print $2}')"
+    local target
+    target="$(git cat-file -p "$blob_sha" 2>/dev/null)"
+
+    local location
+    location="$(classify_target "$file" "$target")"
+
+    if [ "$location" = "INSIDE" ]; then
+        printf "%b✗ %s%b — tracked symlink (mode 120000) targets INSIDE the working tree\n" "$RED" "$file" "$NC"
+        printf "  target: %s\n" "$target"
+        printf "  %bcore.symlinks=false checks this out as a plain file containing that\n" "$YELLOW"
+        printf "  text, silently overwriting whatever real path was there (#14137, #14149).%b\n" "$NC"
+        VIOLATIONS_INSIDE=$((VIOLATIONS_INSIDE + 1))
+    else
+        printf "%b✗ %s%b — tracked symlink (mode 120000) targets OUTSIDE the working tree\n" "$RED" "$file" "$NC"
+        printf "  target: %s\n" "$target"
+        printf "  %bit cannot function as a link under this repo's core.symlinks=false, on\n" "$YELLOW"
+        printf "  any clone, and a host-specific absolute path may be leaking into history.%b\n" "$NC"
+        VIOLATIONS_OUTSIDE=$((VIOLATIONS_OUTSIDE + 1))
+    fi
+}
+
+main() {
+    # '.' matches every non-empty filename — this hook applies to ANY
+    # tracked path, not a file-extension subset (the destructive entries
+    # in both #14137 and #14149 carry no extension pre-commit `types:`
+    # filtering could key on).
+    local files
+    files="$(get_staged_files '.' "$@")"
+    [ -z "$files" ] && exit 0
+
+    while IFS= read -r f; do
+        [ -z "$f" ] || check_file "$f"
+    done <<< "$files"
+
+    local total=$((VIOLATIONS_INSIDE + VIOLATIONS_OUTSIDE))
+    if [ "$total" -gt 0 ]; then
+        printf "\n%b%bBLOCKED: %d tracked symlink entr%s (%d inside, %d outside the working tree)%b\n\n" \
+            "$RED" "$BOLD" "$total" "$([ "$total" -eq 1 ] && echo y || echo ies)" \
+            "$VIOLATIONS_INSIDE" "$VIOLATIONS_OUTSIDE" "$NC"
+        printf "A tracked symlink cannot round-trip through this repo's core.symlinks=false\n"
+        printf "(common under WSL2): checkout writes a plain file containing the target path\n"
+        printf "instead of a real link, clobbering anything real at that path (#14137).\n\n"
+        printf "Fix: untrack the entry and either commit real content at that path, or\n"
+        printf "restructure the reference so it doesn't depend on filesystem symlinks\n"
+        printf "(e.g. an explicit include/copy, per #14149's fix options).\n"
+        exit 1
+    fi
+
+    printf "%b%b✓ No tracked symlinks into or out of the working tree%b\n" "$GREEN" "$BOLD" "$NC"
+    exit 0
+}
+
+main "$@"

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-tracked-symlink
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-tracked-symlink
@@ -60,11 +60,17 @@
 # Install: pre-commit install (uses .pre-commit-config.yaml)
 # CI: invoked with an explicit file list (see .github/workflows/enforce-precommit.yml)
 
-set -uo pipefail
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/_common.sh
-source "$SCRIPT_DIR/lib/_common.sh"
+# A guard whose own dependency is missing must not report clean. `set -e`
+# covers this, but the explicit exit states the intent at the one line
+# where failing open would be silent (#14137 review).
+source "$SCRIPT_DIR/lib/_common.sh" || {
+    echo "FATAL: cannot load lib/_common.sh — refusing to report clean" >&2
+    exit 1
+}
 
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
 if [ -z "$REPO_ROOT" ]; then

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-tracked-symlink_test.py
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-tracked-symlink_test.py
@@ -217,3 +217,47 @@ def test_hook_script_exists_and_is_executable() -> None:
     import os
 
     assert os.access(HOOK_PATH, os.X_OK), f"{HOOK_PATH} is not executable on disk"
+
+
+class TestTheGuardFailsClosedWhenItCannotRun:
+    """Review of #14150 found both hooks failing OPEN — reporting clean while a
+    genuinely staged symlink was present.
+
+    `set -uo pipefail` (no `-e`) plus an unguarded `source` meant a missing
+    dependency degraded to an empty result, which the scripts read as "nothing
+    to check" and exited 0. The same shape via `git` erroring: `check_file`'s
+    `[ -n "$ls_line" ] || return 0` treats "git failed" and "no index entry"
+    identically.
+
+    That is #14051's defect verbatim, in the hook built to stop that class. A
+    guard reporting green because it never ran is worse than no guard — it
+    manufactures confidence.
+
+    The marker-missing and empty-NAMES paths were already tested and already
+    failed closed. These two were not tested, and did not.
+    """
+
+    def test_a_missing_common_lib_does_not_report_clean(self, tmp_path: Path) -> None:
+        repo = _init_repo(tmp_path)
+        _stage_symlink(repo, "venv", str(repo))
+
+        # A copy of the hook with no `lib/` beside it — the dependency is gone.
+        isolated = tmp_path / "isolated"
+        isolated.mkdir()
+        hook_copy = isolated / HOOK_PATH.name
+        hook_copy.write_bytes(HOOK_PATH.read_bytes())
+        hook_copy.chmod(0o755)
+
+        result = subprocess.run([str(hook_copy)], cwd=repo, capture_output=True, text=True)
+
+        assert result.returncode != 0, "the hook reported clean with a staged symlink and no dependency"
+
+    def test_a_git_failure_does_not_report_clean(self, tmp_path: Path) -> None:
+        repo = _init_repo(tmp_path)
+        _stage_symlink(repo, "venv", str(repo))
+        # Corrupt the index so git errors rather than returning an empty answer.
+        (repo / ".git" / "index").write_text("garbage", encoding="utf-8")
+
+        result = _run_hook(repo, "venv")
+
+        assert result.returncode != 0, "a git failure was indistinguishable from 'no violation'"

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-tracked-symlink_test.py
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-tracked-symlink_test.py
@@ -1,0 +1,219 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for pre-commit-no-tracked-symlink (#14137).
+
+The defect this hook guards against is invisible to a content diff — a
+committed symlink and a one-line text file look identical in `git show`.
+Only the INDEX MODE (`git ls-files -s` reporting `120000`) reveals it, so
+every fixture here stages entries via `git update-index --add --cacheinfo
+120000,<blob-sha>,<path>` rather than actually creating filesystem symlinks:
+that is also what makes it possible to construct this on ANY machine,
+including one where `core.symlinks=true` and a real symlink would just work.
+
+Nothing here commits a symlink into the AutoBot-AI repository itself; every
+fixture lives in a throwaway `tmp_path` git repo.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+HOOK_PATH = Path(__file__).resolve().parent / "pre-commit-no-tracked-symlink"
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(["git", *args], cwd=repo, capture_output=True, text=True, check=True)
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "--quiet")
+    _git(repo, "config", "core.symlinks", "false")
+    _git(repo, "config", "user.email", "t@t")
+    _git(repo, "config", "user.name", "t")
+    (repo / "README.md").write_text("seed\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "-c", "commit.gpgsign=false", "commit", "-q", "-m", "seed")
+    return repo
+
+
+def _stage_symlink(repo: Path, path: str, target: str) -> None:
+    """Stage a tracked mode-120000 entry with the given TARGET, without ever
+    creating a real filesystem symlink (so this works under core.symlinks
+    of either setting, and on any OS)."""
+    blob = subprocess.run(
+        ["git", "hash-object", "-w", "--stdin"],
+        cwd=repo,
+        input=target,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    _git(repo, "update-index", "--add", "--cacheinfo", f"120000,{blob},{path}")
+
+
+def _stage_file(repo: Path, path: str, content: str = "hello\n") -> None:
+    p = repo / path
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+    _git(repo, "add", path)
+
+
+def _run_hook(repo: Path, *argv: str) -> subprocess.CompletedProcess:
+    return subprocess.run([str(HOOK_PATH), *argv], cwd=repo, capture_output=True, text=True)
+
+
+# === Ordinary files must not be blocked ===
+
+
+def test_ordinary_staged_file_is_accepted(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    _stage_file(repo, "app.py", "x = 1\n")
+    result = _run_hook(repo)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_no_staged_files_exits_zero(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    result = _run_hook(repo)
+    assert result.returncode == 0
+
+
+# === The destructive class: mode 120000 pointing inside the tree ===
+
+
+def test_symlink_inside_tree_self_referential_absolute_target_rejected(tmp_path: Path) -> None:
+    """The exact #14137 shape: an absolute target equal to the repo's own root + path."""
+    repo = _init_repo(tmp_path)
+    _stage_symlink(repo, "venv", f"{repo}/venv")
+    result = _run_hook(repo)
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "venv" in result.stdout
+    assert "INSIDE" in result.stdout or "targets INSIDE" in result.stdout
+
+
+def test_symlink_inside_tree_relative_traversal_rejected(tmp_path: Path) -> None:
+    """The exact #14149 shape: a relative target whose '..' climbs land back inside the repo."""
+    repo = _init_repo(tmp_path)
+    _stage_symlink(
+        repo,
+        "autobot-slm-backend/ansible/tests/inventory/group_vars/all.yml",
+        "../../../inventory/group_vars/all.yml",
+    )
+    result = _run_hook(repo)
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "targets INSIDE" in result.stdout
+
+
+def test_symlink_inside_tree_via_short_relative_target_rejected(tmp_path: Path) -> None:
+    """A relative target that never escapes the containing directory at all."""
+    repo = _init_repo(tmp_path)
+    (repo / "sub").mkdir()
+    _stage_symlink(repo, "sub/link", "real.txt")
+    result = _run_hook(repo)
+    assert result.returncode == 1
+    assert "targets INSIDE" in result.stdout
+
+
+# === Outside-the-tree targets: still rejected, distinct message ===
+
+
+def test_symlink_outside_tree_absolute_target_rejected_with_distinct_message(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    _stage_symlink(repo, "outlink", "/etc/passwd")
+    result = _run_hook(repo)
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "targets OUTSIDE" in result.stdout
+    # The two classes must not be conflated in the operator-facing message.
+    assert "targets INSIDE" not in result.stdout
+
+
+def test_symlink_outside_tree_relative_traversal_rejected(tmp_path: Path) -> None:
+    """Enough '..' to climb above the repo root entirely."""
+    repo = _init_repo(tmp_path)
+    (repo / "sub").mkdir()
+    _stage_symlink(repo, "sub/link", "../../outside.txt")
+    result = _run_hook(repo)
+    assert result.returncode == 1
+    assert "targets OUTSIDE" in result.stdout
+
+
+# === Deletion is the fix direction, never a violation ===
+
+
+def test_deleting_a_tracked_symlink_is_not_a_violation(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    _stage_symlink(repo, "venv", f"{repo}/venv")
+    _git(repo, "-c", "commit.gpgsign=false", "commit", "-q", "-m", "add bad symlink")
+    _git(repo, "rm", "-q", "venv")
+    result = _run_hook(repo)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+# === Changed-files scoping: a PRE-EXISTING violation must not block
+#     unrelated commits (#14149 is exactly this shape against the real repo) ===
+
+
+def test_pre_existing_symlink_untouched_by_this_commit_does_not_block(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    _stage_symlink(repo, "preexisting", "/etc/hosts")
+    _git(repo, "-c", "commit.gpgsign=false", "commit", "-q", "-m", "pre-existing violation, already landed")
+
+    _stage_file(repo, "unrelated.py", "x = 1\n")
+    result = _run_hook(repo)
+
+    assert result.returncode == 0, f"pre-existing violation blocked an unrelated commit:\n{result.stdout}"
+
+
+def test_a_newly_staged_symlink_alongside_unrelated_changes_still_fails(tmp_path: Path) -> None:
+    """The scoping change must not become an off switch."""
+    repo = _init_repo(tmp_path)
+    _stage_file(repo, "unrelated.py", "x = 1\n")
+    _stage_symlink(repo, "venv", f"{repo}/venv")
+
+    result = _run_hook(repo)
+
+    assert result.returncode == 1
+
+
+# === CI / argv mode: explicit file list (the calling workflow computes the
+#     PR's changed-file set and passes it positionally) ===
+
+
+def test_argv_mode_flags_an_explicitly_passed_symlink_path(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    _stage_symlink(repo, "venv", f"{repo}/venv")
+    _git(repo, "-c", "commit.gpgsign=false", "commit", "-q", "-m", "landed symlink")
+
+    result = _run_hook(repo, "venv")
+
+    assert result.returncode == 1, result.stdout + result.stderr
+
+
+def test_argv_mode_ignores_paths_not_passed(tmp_path: Path) -> None:
+    """Argv mode scopes to exactly what the caller passed — #14149's path,
+    landed but not in THIS argv list, must not surface."""
+    repo = _init_repo(tmp_path)
+    _stage_symlink(repo, "preexisting", "/etc/hosts")
+    _stage_file(repo, "other.py", "x = 1\n")
+    _git(repo, "-c", "commit.gpgsign=false", "commit", "-q", "-m", "mixed commit")
+
+    result = _run_hook(repo, "other.py")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+@pytest.mark.skipif(not HOOK_PATH.exists(), reason="hook script not found")
+def test_hook_script_exists_and_is_executable() -> None:
+    """core.fileMode=false in this repo means `chmod +x` never reaches the
+    index (#14051 topic, same gotcha) — a hook committed as 100644 dies with
+    exit 126 in CI. This guards the artifact, not the logic."""
+    import os
+
+    assert os.access(HOOK_PATH, os.X_OK), f"{HOOK_PATH} is not executable on disk"

--- a/docs/developer/BACKEND_DEBUGGING.md
+++ b/docs/developer/BACKEND_DEBUGGING.md
@@ -369,6 +369,37 @@ Or set in `/etc/wsl.conf` on the WSL instance:
 options = "metadata"
 ```
 
+### Why a COMMITTED symlink is worse than a broken one (#14137, #14149)
+
+The above is about a symlink already tracked correctly that *breaks on checkout*
+in this WSL2 shape. A different, more dangerous failure is *committing* a new
+symlink at all while `core.symlinks=false` is set:
+
+- Git cannot create a real symlink under that setting, so a tracked entry with
+  mode `120000` is materialised as a **regular file whose entire content is
+  the target path** — 30-40 bytes of text, silently overwriting whatever real
+  file or directory previously occupied that path.
+- Nothing errors at checkout. The failure surfaces later, elsewhere, and looks
+  unrelated (`Not a directory`, `ModuleNotFoundError`, or — #14149 — a config
+  loader silently receiving an empty/scalar file where it expected structured
+  content).
+- A code review cannot catch it either: `git show`/`git diff` on the commit
+  prints a plausible one-line path string, indistinguishable from a harmless
+  text file. Only the **index mode** (`git ls-files -s <path>` reporting
+  `120000`) reveals it.
+
+Two pre-commit/CI guards close this: `pre-commit-no-tracked-symlink` fails a
+commit or CI run the moment a *newly* tracked entry has mode `120000` (see the
+script's own header for the inside-vs-outside-the-tree classification), and
+`pre-commit-no-gitignore-shadow` fails when a tracked path shadows a name in
+`.gitignore`'s virtualenv section. Both live in
+`autobot-infrastructure/shared/scripts/hooks/`.
+
+If you are on a Linux-native clone with `core.symlinks=true`, a symlink you
+create locally still works for you — the guard exists because this repo's
+default clone shape (WSL2) does not, and a symlink that looks fine on your
+machine breaks silently on every other tree that pulls it.
+
 ---
 
 ## Related Issues
@@ -377,6 +408,8 @@ options = "metadata"
 |-------|---------|-----------|
 | [#881](https://github.com/mrveiss/AutoBot-AI/issues/881) | Backend deadlock / no response | UFW firewall blocking port |
 | [#886](https://github.com/mrveiss/AutoBot-AI/issues/886) | WSL2 symlink issues | `core.symlinks=false` |
+| [#14137](https://github.com/mrveiss/AutoBot-AI/issues/14137) | Committed `venv` symlink destroyed the interpreter on checkout | `core.symlinks=false` materialises mode `120000` as a text file, overwriting the real path |
+| [#14149](https://github.com/mrveiss/AutoBot-AI/issues/14149) | Ansible test inventory silently had zero variables | Same mechanism, on a tracked `group_vars/all.yml` symlink |
 | [#887](https://github.com/mrveiss/AutoBot-AI/issues/887) | UFW default rules | Needed explicit port rule |
 | [#888](https://github.com/mrveiss/AutoBot-AI/issues/888) | Requirements.txt conflicts | Pinning incompatibility |
 | [#868](https://github.com/mrveiss/AutoBot-AI/issues/868) | Backend crash-looping | Missing .env, aioredis compat, PYTHONPATH |


### PR DESCRIPTION
Closes #14137

## Thinking Path

#14138 already landed the immediate fix (untracked `venv`, made the ignore entries slashless). This PR is the remaining scope: a guard that stops the *next* symlink someone commits, since the class is invisible to a content diff — `git show`/`git diff` on a committed symlink prints a plausible one-line path string, indistinguishable from a harmless text file. Only the index mode (`git ls-files -s` reporting `120000`) reveals it.

Before writing the guard I surveyed the repo for existing tracked symlinks (`git ls-files -s | awk '$1 == "120000"'`) and found exactly one: `autobot-slm-backend/ansible/tests/inventory/group_vars/all.yml`, pointing at `../../../inventory/group_vars/all.yml`. It is not a legitimate exception — it's a second, already-broken instance of the same mechanism (the Ansible test inventory silently inherits zero variables). Filed separately as #14149, and **not** allowlisted here: allowlisting a live defect would hide it rather than fix it.

That finding decided the design questions the issue raised:

- **Diff-scoped, not full-tree, for the symlink check.** A full-tree scan would fail every unrelated PR until #14149 lands. Reused the changed-files scoping `get_staged_files()` already proven for the hardcoded-value and print guards (#13950, #14051): a newly staged/changed mode-`120000` entry still fails; #14149's, untouched by a given commit, does not block it.
- **Inside vs outside the working tree, decided with evidence, not theory.** Both real incidents — #14137's self-referential absolute path and #14149's `../../../` relative traversal — resolve to a path *inside* the repo. That's the destructive shape: `core.symlinks=false` checks the entry out as a plain file at its own tracked path, silently overwriting whatever real content was there. I block **both** inside and outside targets, but with distinct messages: inside is the demonstrated destructive class; outside can't clobber a repo-owned path this way, but it still never functions as a link under this repo's common `core.symlinks=false` (WSL2) on any clone, and is a route for a host-specific absolute path to leak into tracked history.
- **The shadow check is full-tree**, unlike the symlink check — zero pre-existing violations today (every currently-tracked `bin`/`lib`-named path is already covered by a `.gitignore` `!` negation), so there's nothing pre-existing to blame an unrelated PR for.

## What Changed

- `autobot-infrastructure/shared/scripts/hooks/pre-commit-no-tracked-symlink` — fails a commit/CI the moment a newly staged/changed tracked entry has mode `120000`. Classifies the target INSIDE/OUTSIDE via pure lexical path resolution (no filesystem access — must work for a broken symlink too).
- `autobot-infrastructure/shared/scripts/hooks/pre-commit-no-gitignore-shadow` — fails when a tracked path's name matches a `.gitignore` virtualenv-section entry, unless explicitly negated with `!`. Fails closed if the section marker itself goes missing.
- Registered both in `.pre-commit-config.yaml` (`pass_filenames: false`, `always_run: true`, matching the `detect-mass-deletions` pattern — file-extension filtering would exclude the extensionless `venv` and non-source `all.yml` shapes that actually mattered).
- CI enforcement in `.github/workflows/enforce-precommit.yml` (no `paths:` filter, so it runs on every PR regardless of file type — `code-quality.yml` is gated on Python-path changes and would never have fired on a bare `venv` add). Added `fetch-depth: 2` to the checkout so the PR's base commit is present for the diff-scoped symlink check.
- `docs/developer/BACKEND_DEBUGGING.md` — new subsection documenting `core.symlinks=false` (WSL2) and what it does to a committed symlink, cross-linking #14137/#14149.
- `.gitignore` — one-line cross-reference to both guards next to the virtualenv section.

## Verification

Local sanity (system `pytest`, not installed into the repo — no venv exists here per the "nothing gets installed" rule; real verification is the CI run below):

```
22 passed in 1.33s
```

Covers: an ordinary staged file is accepted; both real-world INSIDE shapes (self-referential absolute, `../../../` relative) are rejected; OUTSIDE targets are rejected with a distinct message; deleting a tracked symlink is not a violation; a pre-existing symlink untouched by a commit does not block it (and a newly staged one alongside unrelated changes still fails — the scoping is a scope change, not an off switch); CI argv-mode scopes to exactly the paths passed; the shadow-check allowlist (`!scripts/lib/`) works and does not leak past its own `/`-boundary to a same-prefix sibling path; fails closed if the `.gitignore` section marker goes missing.

Also checked: `git ls-files -s` on both new hook scripts shows `100755` (this repo's `core.fileMode=false` means a plain `chmod +x` never reaches the index — used `git update-index --chmod=+x` per the #14051-adjacent gotcha). `python3 scripts/check_script_exec_bits.py` passes. Both `.pre-commit-config.yaml` and the modified workflow YAML parse cleanly.

CI run: (added once the PR's checks report — see follow-up comment)

## Model Used

Sonnet