### PR TITLE
fix(ansible): stop tracking the test inventory's group_vars as a symlink (#14149)

### DIFF
--- a/.github/workflows/ansible-role-facts-test.yml
+++ b/.github/workflows/ansible-role-facts-test.yml
@@ -9,6 +9,8 @@
 #   - Forgotten group-membership check
 #   - Drift between provision-fleet-roles.yml gates and group_vars facts
 #   - Cleanup-gate regressions of the #7031 class
+#   - The test inventory's group_vars/all.yml silently resolving to nothing
+#     (#14149) — see the "Assert test inventory resolves group_vars" step
 #
 # Security note: this workflow does NOT interpolate any untrusted GitHub
 # event data (no issue titles, PR bodies, commit messages, head_ref, etc.)
@@ -73,6 +75,16 @@ jobs:
         run: |
           ansible-playbook -i tests/inventory/test_role_facts.yml tests/playbooks/test_role_active_facts.yml
 
+      # #14149: tests/inventory/group_vars/all.yml used to be a symlink to the
+      # canonical inventory/group_vars/all.yml. GitHub-hosted Linux runners keep
+      # core.symlinks=true, so the playbook run above passed here even while it
+      # silently resolved to zero variables on core.symlinks=false checkouts.
+      # This asserts the test inventory actually resolves a known group_vars key.
+      - name: "Assert test inventory resolves group_vars (#14149)"
+        working-directory: autobot-slm-backend/ansible
+        run: |
+          python3 tests/check_test_inventory_group_vars.py
+
       - name: Run role_*_active facts test (vars_files codepath, #7094)
         working-directory: autobot-slm-backend/ansible
         # #7094: tests/inventory_dynamic/ is a copy of tests/inventory/ WITHOUT
@@ -82,7 +94,7 @@ jobs:
         run: |
           ansible-playbook -i tests/inventory_dynamic/test_role_facts.yml tests/playbooks/test_role_active_facts_no_group_vars.yml
 
-      - name: "Diff guard: ensure both fact-file copies stay byte-equal (#7095)"
+      - name: "Diff guard: ensure all fact-file copies stay byte-equal (#7095, #14149)"
         working-directory: autobot-slm-backend/ansible
         run: |
           python3 tests/check_role_facts_synced.py
@@ -110,3 +122,4 @@ jobs:
           python3 -c "import yaml; yaml.safe_load(open('tests/playbooks/test_role_active_facts_no_group_vars.yml'))"
           python3 -c "import yaml; yaml.safe_load(open('tests/playbooks/test_clean_yml_loops.yml'))"
           python3 -c "import yaml; yaml.safe_load(open('tests/inventory/test_role_facts.yml'))"
+          python3 -c "import yaml; yaml.safe_load(open('tests/inventory/group_vars/all.yml'))"

--- a/autobot-slm-backend/ansible/tests/check_role_facts_synced.py
+++ b/autobot-slm-backend/ansible/tests/check_role_facts_synced.py
@@ -35,15 +35,38 @@ PLAYBOOK_VARS = REPO / "autobot-slm-backend/ansible/playbooks/vars/role_active_f
 TEST_GROUP_VARS = REPO / "autobot-slm-backend/ansible/tests/inventory/group_vars/all.yml"
 
 
+#: Keys that must stay identical across the copies but are NOT `role_*_active`
+#: folded scalars, so the pattern below cannot find them.
+#:
+#: #14152 review: the guard's own comments claimed the files were kept
+#: "byte-identical", but the regex only ever matched `role_\w+_active:` with a
+#: `>-` value. `chromadb_service_owner` is a single-line double-quoted scalar
+#: and was silently outside the comparison in all three files — so editing it
+#: canonically and forgetting the duplicates would have reported OK while the
+#: test inventory diverged. That is precisely the drift this guard exists to
+#: catch, and the overstated comment is what made the gap invisible.
+_EXTRA_SCALAR_KEYS = ("chromadb_service_owner",)
+
+
 def extract_facts(path: Path) -> dict:
-    """Extract role_X_active blocks (key + multiline `>-` value) from a file.
+    """Extract the shared facts (key + value) that must match across copies.
 
     Returns dict mapping fact name → normalized whitespace value.
     """
     text = path.read_text(encoding="utf-8")
     pattern = re.compile(r"(role_\w+_active:\s*>-(?:\n[ \t]+.*)*)")
     blocks = pattern.findall(text)
-    return {re.match(r"(role_\w+_active)", b).group(1): re.sub(r"\s+", " ", b).strip() for b in blocks}
+    facts = {re.match(r"(role_\w+_active)", b).group(1): re.sub(r"\s+", " ", b).strip() for b in blocks}
+
+    # Single-line scalars the folded-block pattern cannot see. A key that is
+    # absent from one copy and present in another must NOT compare equal, so
+    # missing keys are recorded explicitly rather than skipped — an absent key
+    # comparing clean is the same "empty reads as identical" failure.
+    for key in _EXTRA_SCALAR_KEYS:
+        match = re.search(rf"^{re.escape(key)}:.*$", text, re.MULTILINE)
+        facts[key] = re.sub(r"\s+", " ", match.group(0)).strip() if match else "<ABSENT>"
+
+    return facts
 
 
 def compare(label_a: str, a: dict, label_b: str, b: dict) -> bool:
@@ -75,7 +98,7 @@ def main() -> int:
     if diverged:
         return 1
 
-    print(f"OK — {len(canonical)} role_*_active facts identical across all three files")
+    print(f"OK — {len(canonical)} shared facts identical across all three files")
     return 0
 
 

--- a/autobot-slm-backend/ansible/tests/check_role_facts_synced.py
+++ b/autobot-slm-backend/ansible/tests/check_role_facts_synced.py
@@ -1,19 +1,28 @@
 #!/usr/bin/env python3
 # Copyright 2025-2026 mrveiss
 # SPDX-License-Identifier: Apache-2.0
-"""Diff guard: role_*_active facts must stay byte-equal across the two
-copies until #7095 (single source of truth) lands.
+"""Diff guard: role_*_active facts must stay byte-equal across all copies
+until #7095 (single source of truth) lands.
 
-Two consumers exist:
-- inventory/group_vars/all.yml   (loaded by static-inventory playbooks)
-- playbooks/vars/role_active_facts.yml  (loaded by playbooks via vars_files
-                                          when invoked with dynamic temp
-                                          inventories that lack a sibling
-                                          group_vars/, e.g. the SLM wizard)
+Three consumers exist:
+- inventory/group_vars/all.yml               canonical; loaded by static-inventory
+                                              playbooks via Ansible's own group_vars
+                                              auto-discovery
+- playbooks/vars/role_active_facts.yml       loaded by playbooks via vars_files when
+                                              invoked with dynamic temp inventories that
+                                              lack a sibling group_vars/ (e.g. the SLM
+                                              wizard, #7094)
+- tests/inventory/group_vars/all.yml         the CI regression-test inventory's copy.
+                                              Used to be a symlink to
+                                              inventory/group_vars/all.yml; this repo's
+                                              `core.symlinks=false` checkouts (WSL2)
+                                              materialize a tracked symlink as a
+                                              plain-text path string instead, so it is a
+                                              real file now (#14149)
 
-If the two files drift, behavior diverges silently. This script extracts
-the role_*_active definitions from each and compares them; exits non-zero
-on any divergence so CI fails the PR.
+If any copy drifts, behavior diverges silently. This script extracts the
+role_*_active definitions from each and compares them; exits non-zero on any
+divergence so CI fails the PR.
 """
 
 import re
@@ -23,6 +32,7 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parents[3]
 GROUP_VARS = REPO / "autobot-slm-backend/ansible/inventory/group_vars/all.yml"
 PLAYBOOK_VARS = REPO / "autobot-slm-backend/ansible/playbooks/vars/role_active_facts.yml"
+TEST_GROUP_VARS = REPO / "autobot-slm-backend/ansible/tests/inventory/group_vars/all.yml"
 
 
 def extract_facts(path: Path) -> dict:
@@ -30,27 +40,42 @@ def extract_facts(path: Path) -> dict:
 
     Returns dict mapping fact name → normalized whitespace value.
     """
-    text = path.read_text()
+    text = path.read_text(encoding="utf-8")
     pattern = re.compile(r"(role_\w+_active:\s*>-(?:\n[ \t]+.*)*)")
     blocks = pattern.findall(text)
     return {re.match(r"(role_\w+_active)", b).group(1): re.sub(r"\s+", " ", b).strip() for b in blocks}
 
 
-def main() -> int:
-    a = extract_facts(GROUP_VARS)
-    b = extract_facts(PLAYBOOK_VARS)
+def compare(label_a: str, a: dict, label_b: str, b: dict) -> bool:
+    """Print and return whether `a` and `b` diverge (True == diverged)."""
+    diverged = False
     if set(a) != set(b):
-        print(f"FACT KEYS DIVERGED:")
-        print(f"  in group_vars only:    {sorted(set(a) - set(b))}")
-        print(f"  in playbooks/vars only: {sorted(set(b) - set(a))}")
-        return 1
-    for k in sorted(a):
+        print("FACT KEYS DIVERGED:")
+        print(f"  in {label_a} only: {sorted(set(a) - set(b))}")
+        print(f"  in {label_b} only: {sorted(set(b) - set(a))}")
+        diverged = True
+    for k in sorted(set(a) & set(b)):
         if a[k] != b[k]:
             print(f"FACT {k!r} DIVERGED:")
-            print(f"  group_vars: {a[k]}")
-            print(f"  playbooks:  {b[k]}")
-            return 1
-    print(f"OK — {len(a)} role_*_active facts identical across both files")
+            print(f"  {label_a}: {a[k]}")
+            print(f"  {label_b}: {b[k]}")
+            diverged = True
+    return diverged
+
+
+def main() -> int:
+    canonical = extract_facts(GROUP_VARS)
+    playbook = extract_facts(PLAYBOOK_VARS)
+    test_inventory = extract_facts(TEST_GROUP_VARS)
+
+    diverged = False
+    diverged |= compare("inventory/group_vars", canonical, "playbooks/vars", playbook)
+    diverged |= compare("inventory/group_vars", canonical, "tests/inventory/group_vars", test_inventory)
+
+    if diverged:
+        return 1
+
+    print(f"OK — {len(canonical)} role_*_active facts identical across all three files")
     return 0
 
 

--- a/autobot-slm-backend/ansible/tests/check_test_inventory_group_vars.py
+++ b/autobot-slm-backend/ansible/tests/check_test_inventory_group_vars.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Guard: the role-facts test inventory must actually inherit group_vars (#14149).
+
+`tests/inventory/group_vars/all.yml` used to be a symlink to the canonical
+`inventory/group_vars/all.yml`. This repo runs with `core.symlinks=false` on
+some checkouts (WSL2 — see docs/developer/BACKEND_DEBUGGING.md), and git
+cannot create a real symlink there: a tracked symlink is materialized as a
+plain-text file whose entire content is the target path string. Ansible then
+loads a bare YAML scalar instead of a mapping for that group_vars file.
+
+Nothing in the existing test suite asserted the test inventory actually has
+content — `ansible-playbook -i tests/inventory/test_role_facts.yml ...`
+passed on every CI run because GitHub-hosted Linux runners keep
+`core.symlinks=true` by default, so the symlink round-trips there even
+though it silently breaks on the checkouts where it does not.
+
+This check loads the test inventory the same way `ansible-inventory --list`
+does and asserts a known key from the canonical group_vars file
+(`role_backend_active`) is present and non-empty for a synthetic host. Run
+from the ansible directory:
+
+    python3 tests/check_test_inventory_group_vars.py
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ANSIBLE_DIR = Path(__file__).resolve().parents[1]
+INVENTORY = "tests/inventory/test_role_facts.yml"
+KNOWN_HOST = "test-single-host-slm-and-backend"
+KNOWN_KEY = "role_backend_active"
+
+
+def main() -> int:
+    # log_path in ansible.cfg points at /var/log/autobot/ansible.log, which
+    # this check must never require write access to.
+    env = dict(os.environ)
+    with tempfile.TemporaryDirectory() as tmp:
+        env["ANSIBLE_LOG_PATH"] = str(Path(tmp) / "ansible.log")
+        result = subprocess.run(
+            ["ansible-inventory", "--list", "-i", INVENTORY],
+            cwd=ANSIBLE_DIR,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    if result.returncode != 0:
+        print(f"ansible-inventory --list -i {INVENTORY} exited {result.returncode}")
+        print("--- stdout ---")
+        print(result.stdout)
+        print("--- stderr ---")
+        print(result.stderr)
+        print(
+            "\nThe test inventory's group_vars/all.yml failed to load as a mapping. "
+            "If this is a symlink, core.symlinks=false checkouts materialize it as a "
+            "plain-text path string instead of YAML content (#14149)."
+        )
+        return 1
+
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        print(f"ansible-inventory --list produced non-JSON output: {exc}")
+        print(result.stdout)
+        return 1
+
+    hostvars = data.get("_meta", {}).get("hostvars", {}).get(KNOWN_HOST, {})
+    value = hostvars.get(KNOWN_KEY)
+
+    if not value:
+        print(
+            f"{KNOWN_HOST!r} is missing {KNOWN_KEY!r} (or it is empty) after loading "
+            f"{INVENTORY} — the test inventory did not inherit group_vars."
+        )
+        print(f"hostvars keys seen: {sorted(hostvars)}")
+        return 1
+
+    print(f"OK — {INVENTORY} resolves {KNOWN_KEY!r} for {KNOWN_HOST!r}: {value!r}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/autobot-slm-backend/ansible/tests/inventory/group_vars/all.yml
+++ b/autobot-slm-backend/ansible/tests/inventory/group_vars/all.yml
@@ -1,1 +1,101 @@
-../../../inventory/group_vars/all.yml
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# #7050/#7051/#7053/#14149 shared role-active facts — DUPLICATE of
+# inventory/group_vars/all.yml (and byte-identical to
+# playbooks/vars/role_active_facts.yml).
+#
+# WHY A REAL FILE, NOT A SYMLINK (#14149):
+# This used to be a symlink to ../../../inventory/group_vars/all.yml. This
+# repo runs with `core.symlinks=false` on some checkouts (typically WSL2 —
+# see docs/developer/BACKEND_DEBUGGING.md), and git cannot create a real
+# symlink there: it materializes the entry as a plain-text file whose
+# entire content is the literal target path string. Ansible then loads
+# that string as a bare YAML scalar, not a mapping, so every var this test
+# inventory is meant to inherit is silently absent (or, at load time,
+# ansible-inventory/ansible-playbook hard-errors trying to combine the
+# scalar with the existing `all` group vars — see #14149 for the captured
+# failure). Same failure mechanism that broke the tracked `venv` symlink
+# in #14137/#14138.
+#
+# Ansible's group_vars auto-loading has no cross-directory include
+# mechanism, so — following the same DRY trade-off already accepted for
+# playbooks/vars/role_active_facts.yml below — this is a THIRD real copy
+# of the role_*_active block, kept byte-identical to the other two by
+# tests/check_role_facts_synced.py (extended in #14149 to compare all
+# three files, not just two).
+#
+# CANONICAL ROLE NAMES (#7053):
+# The short-form names in the OR-chains below (e.g. 'backend', 'frontend')
+# are DEPRECATED. Canonical form is 'autobot-X' (e.g. 'autobot-backend').
+# The OR-chain is retained for backward compatibility only. See also:
+#   - inventory/group_vars/all.yml (_role_aliases dict + CANONICAL ROLE NAMES section)
+#   - tools/lint/check_canonical_role_names.py (pre-commit enforcement)
+#   - docs/developer/ANSIBLE_ROLE_NAMES.md (full reference)
+---
+role_backend_active: >-
+  {{ ('backend' in (node_roles | default([]))) or
+     ('autobot-backend' in (node_roles | default([]))) or
+     (inventory_hostname in (groups.get('main', []) | default([]))) or
+     (inventory_hostname in (groups.get('backend', []) | default([]))) }}
+
+role_frontend_active: >-
+  {{ ('frontend' in (node_roles | default([]))) or
+     ('autobot-frontend' in (node_roles | default([]))) or
+     (inventory_hostname in (groups.get('frontend', []) | default([]))) }}
+
+role_ai_stack_active: >-
+  {{ ('ai-stack' in (node_roles | default([]))) or
+     ('autobot-ai-stack' in (node_roles | default([]))) or
+     (inventory_hostname in (groups.get('ai_stack', []) | default([]))) or
+     (inventory_hostname in (groups.get('aiml', []) | default([]))) }}
+
+role_npu_worker_active: >-
+  {{ ('npu-worker' in (node_roles | default([]))) or
+     ('autobot-npu-worker' in (node_roles | default([]))) or
+     (inventory_hostname in (groups.get('npu_worker', []) | default([]))) or
+     (inventory_hostname in (groups.get('npu_workers', []) | default([]))) or
+     (inventory_hostname in (groups.get('npu', []) | default([]))) }}
+
+role_browser_active: >-
+  {{ ('browser' in (node_roles | default([]))) or
+     ('autobot-browser-worker' in (node_roles | default([]))) or
+     ('browser-service' in (node_roles | default([]))) or
+     (inventory_hostname in (groups.get('browser', []) | default([]))) or
+     (inventory_hostname in (groups.get('browser_worker', []) | default([]))) }}
+
+role_slm_active: >-
+  {{ (inventory_hostname in (groups.get('slm_server', []) | default([]))) or
+     (inventory_hostname in (groups.get('slm', []) | default([]))) }}
+
+role_redis_active: >-
+  {{ ('redis' in (node_roles | default([]))) or
+     (inventory_hostname in (groups.get('redis', []) | default([]))) or
+     (inventory_hostname in (groups.get('database', []) | default([]))) }}
+
+# #13060: NO groups['main'] / groups['backend'] fallback. Those clauses pulled the
+# full desktop stack (tigervnc, x11vnc, novnc, websockify, xfce4) onto every backend
+# and main host, including ones that never selected the role. Activation is explicit,
+# matching role_xrdp_active below.
+# Migration: a backend/main host that relied on implicit activation must now list
+# 'vnc' in node_roles (or join vnc_nodes) to keep its desktop provisioned.
+role_vnc_active: >-
+  {{ ('vnc' in (node_roles | default([]))) or
+     (inventory_hostname in (groups.get('vnc_nodes', []) | default([]))) }}
+
+role_xrdp_active: >-
+  {{ ('xrdp' in (node_roles | default([]))) or
+     ('autobot-xrdp' in (node_roles | default([]))) or
+     (inventory_hostname in (groups.get('rdp_nodes', []) | default([]))) }}
+
+role_llm_active: >-
+  {{ ('llm' in (node_roles | default([]))) or
+     (inventory_hostname in (groups.get('ai_stack', []) | default([]))) or
+     (inventory_hostname in (groups.get('llm_nodes', []) | default([]))) }}
+
+role_tts_worker_active: >-
+  {{ ('tts-worker' in (node_roles | default([]))) or
+     ('autobot-tts-worker' in (node_roles | default([]))) }}
+
+# #13870: mirrors inventory/group_vars/all.yml — kept in sync by
+# tests/check_role_facts_synced.py.
+chromadb_service_owner: "{{ 'ai-stack' if (role_ai_stack_active | default(false) | bool) else 'redis' }}"


### PR DESCRIPTION
Closes #14149

## Thinking Path

The issue offered two routes: make `core.symlinks=true` repo-wide, or stop using a symlink. Took route 2 (stop using a symlink) — it does not depend on a git setting a fresh clone may not carry, and it's the option the issue itself preferred.

Read the repo's existing convention for sharing Ansible vars across files first: `playbooks/vars/role_active_facts.yml` is already a maintained, real-file DUPLICATE of the `role_*_active` block in the canonical `inventory/group_vars/all.yml`, kept byte-identical by `tests/check_role_facts_synced.py` (a documented DRY trade-off, pending a real single-source-of-truth in #7095). That's an established pattern in this exact area of the codebase, so the fix follows it rather than inventing a third approach: `tests/inventory/group_vars/all.yml` becomes a real file containing the same `role_*_active` block (that block is self-contained — only references `node_roles`/`groups`/`inventory_hostname`, nothing else from the 14&nbsp;KB canonical file), and the sync guard now checks all three copies instead of two.

Considered pointing the test playbook at the canonical `inventory/` directory as a second `-i` source instead (Ansible would auto-merge `group_vars` from both). Rejected: it would pull every real fleet host/group into a unit-test run and make the test fragile against production inventory changes, for no benefit the duplicate+guard pattern doesn't already give more safely.

## What Changed

- `autobot-slm-backend/ansible/tests/inventory/group_vars/all.yml` — was a symlink (mode `120000`) to `../../../inventory/group_vars/all.yml`; now a real file (mode `100644`) containing a third copy of the `role_*_active` facts block.
- `autobot-slm-backend/ansible/tests/check_role_facts_synced.py` — extended from a 2-way to a 3-way byte-equality check (canonical `inventory/group_vars/all.yml`, `playbooks/vars/role_active_facts.yml`, and the test inventory's copy).
- `autobot-slm-backend/ansible/tests/check_test_inventory_group_vars.py` (new) — runs `ansible-inventory --list -i tests/inventory/test_role_facts.yml` and asserts a known canonical key (`role_backend_active`) is present and non-empty for a synthetic host. This is the check that was missing: nothing previously asserted the test inventory has content.
- `.github/workflows/ansible-role-facts-test.yml` — wires the new check in, updates comments, adds the new file to the YAML-lint step.

Ansible is already installed by this workflow (`sudo apt-get install ansible-core`), so `ansible-inventory` was the natural tool per the issue's suggestion — no new CI dependency needed.

**What the test inventory was actually missing:** with the symlink materialized as a 37-byte path string (under `core.symlinks=false`), `ansible-inventory`/`ansible-playbook` don't quietly proceed with empty vars — they hard-error trying to combine the scalar with the `all` group's vars. Either way, every `role_*_active` fact (`role_backend_active`, `role_frontend_active`, `role_slm_active`, `role_ai_stack_active`, `role_npu_worker_active`, `role_browser_active`, `role_redis_active`, `role_vnc_active`, `role_xrdp_active`, `role_llm_active`, `role_tts_worker_active`) plus `chromadb_service_owner` was unavailable to the test inventory.

## Verification

Ansible is present on this machine outside the repo (no venv, nothing installed into the checkout — the repo has no local Python interpreter and nothing is installed into it, per policy).

Before the fix (materialized symlink, simulated locally by writing the raw target-path string into the tracked file — the exact `core.symlinks=false` checkout shape):

```
$ ansible-playbook -i tests/inventory/test_role_facts.yml tests/playbooks/test_role_active_facts.yml
ERROR! failed to combine variables, expected dicts but got a 'dict' and a 'AnsibleUnicode':
{}
"../../../inventory/group_vars/all.yml"
(exit 4)

$ python3 tests/check_test_inventory_group_vars.py
ansible-inventory --list -i tests/inventory/test_role_facts.yml exited 4
...
ERROR! failed to combine variables, expected dicts but got a 'dict' and a 'AnsibleUnicode':
(exit 1)
```

After the fix:

```
$ ansible-playbook -i tests/inventory/test_role_facts.yml tests/playbooks/test_role_active_facts.yml
...
PLAY RECAP ... ok=10  changed=0  unreachable=0  failed=0 ...
(exit 0)

$ python3 tests/check_test_inventory_group_vars.py
OK — tests/inventory/test_role_facts.yml resolves 'role_backend_active' for 'test-single-host-slm-and-backend': "{{ ('backend' in (node_roles | default([]))) or ... }}"
(exit 0)

$ python3 tests/check_role_facts_synced.py
OK — 11 role_*_active facts identical across all three files
```

Also ran the full existing CI sequence locally (group_vars codepath, vars_files codepath #7094, venv-producer guard, `clean.yml` loops test, YAML lint) — all pass.

Confirmed no other tracked path in this repo has the symlink shape: `git ls-files -s | awk '$1 == "120000"'` returns nothing (repo-wide, not just the ansible tree).

CI run: this comment will be updated once the PR's checks report.

## Coordination

PR #14150 adds a guard that blocks newly *tracked* symlinks, deliberately diff-scoped so it doesn't block unrelated work while this pre-existing instance existed — and deliberately does **not** allowlist it, since that would hide a live defect instead of fixing it. Once this PR merges, that pre-existing exception is gone: the repo has zero tracked symlinks, and #14150's guard has nothing left to carve out.

## Model Used

Sonnet