### PR TITLE
fix(infra): stop 12 pre-commit hooks reporting clean when their own dependency fails (#14151)

### DIFF
--- a/autobot-infrastructure/shared/scripts/hooks/lib/_common.sh
+++ b/autobot-infrastructure/shared/scripts/hooks/lib/_common.sh
@@ -46,6 +46,15 @@ NC='\033[0m'
 # tokenizer, and the resulting IndentationError was reported to the user as
 # "1 direct Redis connection(s) found" in a file containing no Redis at all.
 # The pattern now applies to both branches, so the two invocation paths agree.
+# GH#14151: the no-argv branch used to pipe `git diff --cached` straight into
+# `grep ... || true` — the trailing `|| true` swallowed BOTH "grep matched
+# nothing" (normal) AND "git diff itself failed" (e.g. a corrupted index)
+# identically, returning empty output either way. Every caller's own
+# `[ -z "$files" ] && exit 0` then read a broken git as "nothing staged" and
+# reported clean. `git diff`'s own exit status is now captured separately so
+# a real git failure propagates as get_staged_files' own non-zero return
+# (which `set -e` in every caller turns into a hard stop), while an empty-but
+# -successful diff still yields empty output via the same `|| true` as before.
 get_staged_files() {
     local pattern="$1"
     shift
@@ -53,7 +62,10 @@ get_staged_files() {
         printf '%s\n' "$@" | grep -E "$pattern" || true
         return
     fi
-    git diff --cached --name-only --diff-filter=ACMRT \
-        | grep -E "$pattern" \
-        || true
+    local diff_output
+    diff_output="$(git diff --cached --name-only --diff-filter=ACMRT)" || {
+        echo "FATAL: git diff --cached failed — cannot determine staged files, refusing to report clean" >&2
+        return 1
+    }
+    printf '%s\n' "$diff_output" | grep -E "$pattern" || true
 }

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-branch-guard
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-branch-guard
@@ -23,11 +23,14 @@
 #
 # Install: pre-commit install --hook-type prepare-commit-msg
 
-set -uo pipefail
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/_common.sh
-source "$SCRIPT_DIR/lib/_common.sh"
+source "$SCRIPT_DIR/lib/_common.sh" || {
+    echo "FATAL: cannot load lib/_common.sh — refusing to report clean" >&2
+    exit 1
+}
 
 GIT_DIR_PATH=$(git rev-parse --git-dir 2>/dev/null)
 if [ -z "$GIT_DIR_PATH" ]; then

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-detect-mass-deletions
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-detect-mass-deletions
@@ -20,11 +20,14 @@
 #   2. Unstage the files with `git reset`
 #   3. Investigate the root cause
 
-set -uo pipefail
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/_common.sh
-source "$SCRIPT_DIR/lib/_common.sh"
+source "$SCRIPT_DIR/lib/_common.sh" || {
+    echo "FATAL: cannot load lib/_common.sh — refusing to report clean" >&2
+    exit 1
+}
 
 # Threshold: alert if >50 files are staged for deletion
 # (anything >50 is almost certainly a stash bug, not intended cleanup)

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-detect-mass-deletions_test.py
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-detect-mass-deletions_test.py
@@ -1,0 +1,76 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for pre-commit-detect-mass-deletions (#4111, GH#14151 fail-closed
+guard).
+
+Issue #14151: see pre-commit-no-direct-redis_test.py's module docstring for
+the shared background. This hook doesn't use get_staged_files() at all — it
+calls `git diff --cached --diff-filter=D` directly into a bare top-level
+assignment, so `set -e` alone (no lib/_common.sh change needed) is enough to
+make a git failure abort instead of silently reading as "0 deletions,
+allow". Its opening also references an unbound color variable only inside
+the >50 violation branch, under `set -u`, which independently closed the
+"missing lib/_common.sh" case pre-fix — only the git-failure path is the
+genuine, newly-fixed defect here.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+HOOK_PATH = Path(__file__).resolve().parent / "pre-commit-detect-mass-deletions"
+
+DELETION_THRESHOLD = 50
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(["git", *args], cwd=repo, capture_output=True, text=True, check=True)
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    _git(tmp_path, "init", "--quiet")
+    _git(tmp_path, "config", "user.email", "t@t")
+    _git(tmp_path, "config", "user.name", "t")
+    return tmp_path
+
+
+def _commit_and_stage_deletion_of(repo: Path, count: int) -> None:
+    for i in range(count):
+        (repo / f"f{i}.txt").write_text("x\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "-c", "commit.gpgsign=false", "commit", "-q", "-m", "seed many files")
+    for i in range(count):
+        (repo / f"f{i}.txt").unlink()
+    _git(repo, "add", "-A")
+
+
+def test_allows_deletions_at_or_below_threshold(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    _commit_and_stage_deletion_of(repo, DELETION_THRESHOLD)
+    result = subprocess.run(["bash", str(HOOK_PATH)], cwd=repo, capture_output=True, text=True)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_blocks_mass_deletion_above_threshold(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    _commit_and_stage_deletion_of(repo, DELETION_THRESHOLD + 10)
+    result = subprocess.run(["bash", str(HOOK_PATH)], cwd=repo, capture_output=True, text=True)
+    assert result.returncode != 0, result.stdout + result.stderr
+
+
+class TestFailsClosedOnGitFailure:
+    """GH#14151: a corrupted `.git/index` used to be indistinguishable from
+    "0 files deleted" — reproduced with a genuine mass-deletion staged.
+    """
+
+    def test_a_git_failure_does_not_report_clean(self, tmp_path: Path) -> None:
+        repo = _init_repo(tmp_path)
+        _commit_and_stage_deletion_of(repo, DELETION_THRESHOLD + 10)
+        # Corrupt the index so git errors rather than returning an empty answer.
+        (repo / ".git" / "index").write_text("garbage", encoding="utf-8")
+
+        result = subprocess.run(["bash", str(HOOK_PATH)], cwd=repo, capture_output=True, text=True)
+        assert result.returncode != 0, "a git failure was indistinguishable from '0 deletions'"

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-function-length
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-function-length
@@ -16,12 +16,15 @@
 #
 # Install: pre-commit install (uses .pre-commit-config.yaml)
 
-set -uo pipefail
+set -euo pipefail
 
 # Get script directory for Python script location (also used by lib/_common.sh source)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/_common.sh
-source "$SCRIPT_DIR/lib/_common.sh"
+source "$SCRIPT_DIR/lib/_common.sh" || {
+    echo "FATAL: cannot load lib/_common.sh — refusing to report clean" >&2
+    exit 1
+}
 
 PYTHON_SCRIPT="${SCRIPT_DIR}/function_length_checker.py"
 
@@ -43,8 +46,16 @@ find_python() {
 
 # Get staged Python files (excluding tests, __init__, temp directories, migrations).
 # Named get_staged_python_files to avoid shadowing _common.sh's get_staged_files.
+# GH#14151: get_staged_files' own git-diff failure (e.g. a corrupted index)
+# used to be masked by the trailing `|| true` below, which existed only to
+# tolerate "the filters matched nothing" — a real git failure looked
+# identical. Captured separately so get_staged_files' non-zero return
+# propagates (set -e turns that into a hard stop); the later filter chain's
+# `|| true` still only ever tolerates an empty *result*, not a git error.
 get_staged_python_files() {
-    get_staged_files '\.py$' | \
+    local staged
+    staged="$(get_staged_files '\.py$')" || return 1
+    printf '%s\n' "$staged" | \
         grep -v -E '(__pycache__|node_modules|\.venv|venv|archive|temp)' | \
         grep -v -E '(test_|_test\.py|tests/)' | \
         grep -v -E '__init__\.py$' | \
@@ -84,11 +95,15 @@ main() {
     echo -e "Checking ${BOLD}${file_count}${NC} staged Python file(s)..."
     echo ""
 
-    # Run Python analyzer and capture exit code
-    echo "$files" | "$python_cmd" "$PYTHON_SCRIPT"
-    exit_code=$?
+    # Run Python analyzer and capture exit code. GH#14151: a bare pipeline
+    # statement's own non-zero status (the analyzer reporting violations,
+    # not an error) would trip `set -e` right here, before `exit_code=$?`
+    # on the next line ever ran. `|| exit_code=$?` captures the real code
+    # without tripping -e, since the assignment is the last command run.
+    local exit_code=0
+    echo "$files" | "$python_cmd" "$PYTHON_SCRIPT" || exit_code=$?
 
-    exit $exit_code
+    exit "$exit_code"
 }
 
 main "$@"

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-function-length_test.py
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-function-length_test.py
@@ -1,0 +1,67 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for pre-commit-function-length (#620, GH#14151 fail-closed guard).
+
+Issue #14151: see pre-commit-no-direct-redis_test.py's module docstring for
+the shared background. This hook's opening banner already references an
+unbound color variable under `set -u` (independently closing the
+"missing lib/_common.sh" case pre-fix), so only the git-failure path is the
+genuine, newly-fixed defect here.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+HOOK_PATH = Path(__file__).resolve().parent / "pre-commit-function-length"
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(["git", *args], cwd=repo, capture_output=True, text=True, check=True)
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    _git(tmp_path, "init", "--quiet")
+    _git(tmp_path, "config", "user.email", "t@t")
+    _git(tmp_path, "config", "user.name", "t")
+    return tmp_path
+
+
+def _long_function_source(lines: int = 80) -> str:
+    body = "\n".join(f"    x{i} = {i}" for i in range(lines))
+    return f"def big():\n{body}\n"
+
+
+def test_blocks_overlong_function(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    (repo / "bad.py").write_text(_long_function_source(), encoding="utf-8")
+    _git(repo, "add", "bad.py")
+    result = subprocess.run(["bash", str(HOOK_PATH)], cwd=repo, capture_output=True, text=True)
+    assert result.returncode != 0, result.stdout + result.stderr
+
+
+def test_allows_short_function(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    (repo / "ok.py").write_text("def small():\n    return 1\n", encoding="utf-8")
+    _git(repo, "add", "ok.py")
+    result = subprocess.run(["bash", str(HOOK_PATH)], cwd=repo, capture_output=True, text=True)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+class TestFailsClosedOnGitFailure:
+    """GH#14151: a corrupted `.git/index` used to be indistinguishable from
+    "nothing staged" — reproduced with a genuinely staged violation.
+    """
+
+    def test_a_git_failure_does_not_report_clean(self, tmp_path: Path) -> None:
+        repo = _init_repo(tmp_path)
+        (repo / "bad.py").write_text(_long_function_source(), encoding="utf-8")
+        _git(repo, "add", "bad.py")
+        # Corrupt the index so git errors rather than returning an empty answer.
+        (repo / ".git" / "index").write_text("garbage", encoding="utf-8")
+
+        result = subprocess.run(["bash", str(HOOK_PATH)], cwd=repo, capture_output=True, text=True)
+        assert result.returncode != 0, "a git failure was indistinguishable from 'no violation'"

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-hardcoded-values
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-hardcoded-values
@@ -17,12 +17,15 @@
 # Install: ln -sf ../../scripts/hooks/pre-commit-hardcoded-values .git/hooks/pre-commit
 # Or add to .pre-commit-config.yaml as local hook
 
-set -uo pipefail
+set -euo pipefail
 
 # Source shared library (#7185 — colors + get_staged_files)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/_common.sh
-source "$SCRIPT_DIR/lib/_common.sh"
+source "$SCRIPT_DIR/lib/_common.sh" || {
+    echo "FATAL: cannot load lib/_common.sh — refusing to report clean" >&2
+    exit 1
+}
 
 VIOLATIONS=0
 WARNINGS=0
@@ -32,8 +35,16 @@ WARNINGS=0
 # lookup with positional-args override (#6725: same hook runs as local
 # pre-commit AND CI gate). The multi-stage allowlist below is hook-specific
 # and must remain.
+# GH#14151: get_staged_files' own git-diff failure (e.g. a corrupted index)
+# used to be masked by the trailing `|| true` below, which existed only to
+# tolerate "the filters matched nothing" — a real git failure looked
+# identical. Captured separately so get_staged_files' non-zero return
+# propagates (set -e turns that into a hard stop); the later filter chain's
+# `|| true` still only ever tolerates an empty *result*, not a git error.
 get_files_to_scan() {
-    get_staged_files '\.(py|ts|vue|js)$' "$@" | \
+    local staged
+    staged="$(get_staged_files '\.(py|ts|vue|js)$' "$@")" || return 1
+    printf '%s\n' "$staged" | \
         grep -v -E '(/__pycache__/|/node_modules/|/\.venv/|/venv/|/archive/|/tmp/|/\.tmp/|^tmp/|^archive/)' | \
         grep -v -E '(test_|_test\.py|\.test\.ts|\.test\.js|\.spec\.ts|\.spec\.js)' | \
         grep -v -E '(ssot_config\.py|ssot-config\.ts|threshold_constants\.py)' | \
@@ -82,7 +93,7 @@ check_hardcoded_ips() {
     local line_num=0
 
     while IFS= read -r line; do
-        ((line_num++))
+        line_num=$((line_num + 1))
 
         # Skip comments
         if [[ "$line" =~ ^[[:space:]]*# ]] || [[ "$line" =~ ^[[:space:]]*// ]] || [[ "$line" =~ ^[[:space:]]*\* ]]; then
@@ -103,7 +114,7 @@ check_hardcoded_ips() {
             echo -e "  ${CYAN}Fix: Use config.vm.* from ssot_config${NC}"
             echo "  Line: ${line:0:80}"
             echo ""
-            ((VIOLATIONS++))
+            VIOLATIONS=$((VIOLATIONS + 1))
         fi
     done < "$file"
 }
@@ -117,7 +128,7 @@ check_hardcoded_ports() {
     local ports="8001|5173|6379|11434|6080|8080|8081|8082|3000"
 
     while IFS= read -r line; do
-        ((line_num++))
+        line_num=$((line_num + 1))
 
         # Skip comments
         if [[ "$line" =~ ^[[:space:]]*# ]] || [[ "$line" =~ ^[[:space:]]*// ]]; then
@@ -143,7 +154,7 @@ check_hardcoded_ports() {
             echo -e "  ${CYAN}Fix: Use config.port.* from ssot_config${NC}"
             echo "  Line: ${line:0:80}"
             echo ""
-            ((VIOLATIONS++))
+            VIOLATIONS=$((VIOLATIONS + 1))
         fi
     done < "$file"
 }
@@ -154,7 +165,7 @@ check_magic_numbers() {
     local line_num=0
 
     while IFS= read -r line; do
-        ((line_num++))
+        line_num=$((line_num + 1))
 
         # Skip comments
         if [[ "$line" =~ ^[[:space:]]*# ]] || [[ "$line" =~ ^[[:space:]]*// ]]; then
@@ -182,7 +193,7 @@ check_magic_numbers() {
             echo -e "  ${CYAN}Fix: Use QueryDefaults.DEFAULT_SEARCH_LIMIT${NC}"
             echo "  Line: ${line:0:80}"
             echo ""
-            ((VIOLATIONS++))
+            VIOLATIONS=$((VIOLATIONS + 1))
             continue
         fi
 
@@ -195,7 +206,7 @@ check_magic_numbers() {
             echo -e "  ${CYAN}Fix: Use QueryDefaults.DEFAULT_PAGE_SIZE${NC}"
             echo "  Line: ${line:0:80}"
             echo ""
-            ((VIOLATIONS++))
+            VIOLATIONS=$((VIOLATIONS + 1))
             continue
         fi
 
@@ -208,7 +219,7 @@ check_magic_numbers() {
             echo -e "  ${CYAN}Fix: Use QueryDefaults.KNOWLEDGE_DEFAULT_LIMIT or BatchConfig.LARGE_BATCH${NC}"
             echo "  Line: ${line:0:80}"
             echo ""
-            ((VIOLATIONS++))
+            VIOLATIONS=$((VIOLATIONS + 1))
             continue
         fi
 
@@ -222,7 +233,7 @@ check_magic_numbers() {
             echo "  Consider using QueryDefaults.DEFAULT_OFFSET for consistency"
             echo "  Line: ${line:0:80}"
             echo ""
-            ((WARNINGS++))
+            WARNINGS=$((WARNINGS + 1))
             continue
         fi
 
@@ -235,7 +246,7 @@ check_magic_numbers() {
             echo -e "  ${CYAN}Fix: Use QueryDefaults.RAG_DEFAULT_RESULTS${NC}"
             echo "  Line: ${line:0:80}"
             echo ""
-            ((VIOLATIONS++))
+            VIOLATIONS=$((VIOLATIONS + 1))
             continue
         fi
     done < "$file"
@@ -247,7 +258,7 @@ check_hardcoded_roles() {
     local line_num=0
 
     while IFS= read -r line; do
-        ((line_num++))
+        line_num=$((line_num + 1))
 
         # Skip comments. Includes JSDoc/block-comment continuation lines
         # (`* ...`) — same false-positive class caught for
@@ -298,7 +309,7 @@ check_hardcoded_roles() {
             echo -e "  ${CYAN}Fix: Use CategoryDefaults.ROLE_USER/ROLE_ASSISTANT/ROLE_SYSTEM${NC}"
             echo "  Line: ${line:0:80}"
             echo ""
-            ((VIOLATIONS++))
+            VIOLATIONS=$((VIOLATIONS + 1))
         fi
     done < "$file"
 }
@@ -311,7 +322,7 @@ check_hardcoded_paths() {
     local line_num=0
 
     while IFS= read -r line; do
-        ((line_num++))
+        line_num=$((line_num + 1))
 
         # Skip comments
         if [[ "$line" =~ ^[[:space:]]*# ]] || [[ "$line" =~ ^[[:space:]]*// ]] || [[ "$line" =~ ^[[:space:]]*\* ]]; then
@@ -342,7 +353,7 @@ check_hardcoded_paths() {
             echo -e "  ${CYAN}Fix: Use config.path.base_dir from ssot_config or os.environ.get('AUTOBOT_BASE_DIR', '/opt/autobot')${NC}"
             echo "  Line: ${line:0:80}"
             echo ""
-            ((VIOLATIONS++))
+            VIOLATIONS=$((VIOLATIONS + 1))
         fi
     done < "$file"
 }
@@ -357,7 +368,7 @@ check_hardcoded_model_names() {
     local model_pattern="llama3\.2:latest|llama3\.2:1b|qwen3\.5:9b|nomic-embed-text:latest|gemma2:2b|phi3:mini|mistral:7b-instruct|dolphin-llama3:8b"
 
     while IFS= read -r line; do
-        ((line_num++))
+        line_num=$((line_num + 1))
 
         # Skip comments
         if [[ "$line" =~ ^[[:space:]]*# ]] || [[ "$line" =~ ^[[:space:]]*// ]]; then
@@ -383,7 +394,7 @@ check_hardcoded_model_names() {
             echo -e "  ${CYAN}Fix: Import ROUTING_MODEL/DEFAULT_LLM_MODEL/etc from autobot_shared.ssot_config${NC}"
             echo "  Line: ${line:0:80}"
             echo ""
-            ((VIOLATIONS++))
+            VIOLATIONS=$((VIOLATIONS + 1))
         fi
     done < "$file"
 }
@@ -394,7 +405,7 @@ check_hardcoded_categories() {
     local line_num=0
 
     while IFS= read -r line; do
-        ((line_num++))
+        line_num=$((line_num + 1))
 
         # Skip comments. Includes JSDoc/block-comment continuation lines
         # (`* ...`) — the fixed quote class below now also matches
@@ -448,7 +459,7 @@ check_hardcoded_categories() {
             echo -e "  ${CYAN}Fix: Use CategoryDefaults.GENERAL/SEARCH_MODE_HYBRID/UNKNOWN${NC}"
             echo "  Line: ${line:0:80}"
             echo ""
-            ((VIOLATIONS++))
+            VIOLATIONS=$((VIOLATIONS + 1))
         fi
     done < "$file"
 }
@@ -460,7 +471,7 @@ check_hardcoded_db_dsns() {
     local line_num=0
 
     while IFS= read -r line; do
-        ((line_num++))
+        line_num=$((line_num + 1))
 
         # Skip comments
         if [[ "$line" =~ ^[[:space:]]*# ]] || [[ "$line" =~ ^[[:space:]]*// ]] || [[ "$line" =~ ^[[:space:]]*\* ]]; then
@@ -486,7 +497,7 @@ check_hardcoded_db_dsns() {
             echo -e "  ${CYAN}Fix: Use config.database.* from ssot_config or AUTOBOT_DB_URL env var${NC}"
             echo "  Line: ${line:0:80}"
             echo ""
-            ((VIOLATIONS++))
+            VIOLATIONS=$((VIOLATIONS + 1))
         fi
     done < "$file"
 }
@@ -501,7 +512,7 @@ check_hardcoded_timeouts() {
     local timeout_values="30|60|120|300|3600"
 
     while IFS= read -r line; do
-        ((line_num++))
+        line_num=$((line_num + 1))
 
         # Skip comments
         if [[ "$line" =~ ^[[:space:]]*# ]] || [[ "$line" =~ ^[[:space:]]*// ]]; then
@@ -533,7 +544,7 @@ check_hardcoded_timeouts() {
             echo -e "  ${CYAN}Fix: Use config.timeout.* from ssot_config (TimeoutConfig)${NC}"
             echo "  Line: ${line:0:80}"
             echo ""
-            ((VIOLATIONS++))
+            VIOLATIONS=$((VIOLATIONS + 1))
         fi
     done < "$file"
 }

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-hardcoded-values_test.py
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-hardcoded-values_test.py
@@ -721,3 +721,37 @@ class TestHardcodedTimeouts:
             },
         )
         assert result.returncode == 0
+
+
+# === GH#14151: fails closed when git itself cannot answer ===
+
+
+def _git(repo, *args):
+    return subprocess.run(["git", *args], cwd=repo, capture_output=True, text=True, check=True)
+
+
+@pytest.mark.skipif(not HOOK_PATH.exists(), reason="hook script missing at expected path")
+class TestFailsClosedOnGitFailure:
+    """GH#14151: get_staged_files()'s former blanket `|| true` masked BOTH
+    "the filters matched nothing" (normal) and "git diff --cached itself
+    failed" (e.g. a corrupted index) identically — this hook's own opening
+    banner already referenced an unbound color variable under `set -u`
+    (independently closing the missing-lib case pre-fix), but a git
+    failure produced no such reference and reported clean with a
+    genuinely staged violation present. Reproduced with a corrupted
+    .git/index, mirroring #14150's fixed hooks.
+    """
+
+    def test_a_git_failure_does_not_report_clean(self, tmp_path: Path) -> None:
+        _git(tmp_path, "init", "--quiet")
+        _git(tmp_path, "config", "user.email", "test@test")
+        _git(tmp_path, "config", "user.name", "test")
+        bad = tmp_path / "src" / "bad.py"
+        bad.parent.mkdir(parents=True, exist_ok=True)
+        bad.write_text('IP = "172.16.168.21"\n', encoding="utf-8")
+        _git(tmp_path, "add", "src/bad.py")
+        # Corrupt the index so git errors rather than returning an empty answer.
+        (tmp_path / ".git" / "index").write_text("garbage", encoding="utf-8")
+
+        result = subprocess.run(["bash", str(HOOK_PATH)], cwd=tmp_path, capture_output=True, text=True)
+        assert result.returncode != 0, "a git failure was indistinguishable from 'no violation'"

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-direct-redis
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-direct-redis
@@ -20,12 +20,15 @@
 #
 # Install: pre-commit install (uses .pre-commit-config.yaml)
 
-set -uo pipefail
+set -euo pipefail
 
 # Source shared library (#7185 — colors + get_staged_files)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/_common.sh
-source "$SCRIPT_DIR/lib/_common.sh"
+source "$SCRIPT_DIR/lib/_common.sh" || {
+    echo "FATAL: cannot load lib/_common.sh — refusing to report clean" >&2
+    exit 1
+}
 
 VIOLATIONS=0
 
@@ -33,8 +36,16 @@ VIOLATIONS=0
 # Uses get_staged_files (#7185) for the staged-files lookup with positional-args
 # override (#6785: same hook runs as local pre-commit AND CI gate). The
 # multi-stage allowlist below is hook-specific and must remain.
+# GH#14151: get_staged_files' own git-diff failure (e.g. a corrupted index)
+# used to be masked by the trailing `|| true` below, which existed only to
+# tolerate "the filters matched nothing" — a real git failure looked
+# identical. Captured separately so get_staged_files' non-zero return
+# propagates (set -e turns that into a hard stop); the later filter chain's
+# `|| true` still only ever tolerates an empty *result*, not a git error.
 get_staged_python_files() {
-    get_staged_files '\.py$' "$@" | \
+    local staged
+    staged="$(get_staged_files '\.py$' "$@")" || return 1
+    printf '%s\n' "$staged" | \
         grep -v -E '(__pycache__|node_modules|\.venv|venv|archive|temp)' | \
         grep -v -E '(_test\.py$|\.e2e_test\.py$|\.integration_test\.py$|\.performance_test\.py$)' | \
         grep -v -E '(conftest\.py$|test_.*\.py$)' | \
@@ -54,7 +65,7 @@ get_staged_python_files() {
 # Issue #1829 — false positives on comments/docstrings
 check_direct_redis() {
     local file="$1"
-    local violations
+    local violations py_exit=0
     violations=$(python3 - "$file" <<'PYEOF'
 import sys
 import re
@@ -136,15 +147,14 @@ for lno in sorted(code_lines):
 
 sys.exit(1 if found else 0)
 PYEOF
-)
-    local py_exit=$?
+) || py_exit=$?
     if [[ $py_exit -ne 0 ]]; then
         while IFS= read -r entry; do
             local lno="${entry%%:*}"
             local text="${entry#*:}"
             echo -e "  ${RED}VIOLATION${NC} ${file}:${lno}"
             echo "    ${text}"
-            ((VIOLATIONS++))
+            VIOLATIONS=$((VIOLATIONS + 1))
         done <<< "$violations"
     fi
 }

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-direct-redis_test.py
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-direct-redis_test.py
@@ -1,0 +1,73 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for pre-commit-no-direct-redis (#1086, GH#14151 fail-closed guard).
+
+Issue #14151: 13 of the 14 hooks in this directory shared the
+`set -uo pipefail` (no `-e`) + unguarded `source lib/_common.sh` shape
+found and fixed in #14150 for two other hooks — a broken dependency or a
+`git diff --cached` failure degraded to "nothing staged" and the hook
+reported clean. This hook's own get_staged_files()-based file discovery had
+no other git touchpoint, so a git failure there was invisible to `set -e`
+alone: get_staged_files()'s own former `|| true` masked it before the
+caller ever saw a non-zero status. Fixed in lib/_common.sh directly.
+
+This hook's opening banner already references an unbound color variable
+under `set -u`, which independently closed the "missing lib/_common.sh"
+case even before this fix — only the git-failure path is a genuine,
+newly-fixed defect here, so that is the only reproduction below (see
+pre-commit-no-tag-pinned-action_test.py for a hook where BOTH reproduce,
+since it has no such banner).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+HOOK_PATH = Path(__file__).resolve().parent / "pre-commit-no-direct-redis"
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(["git", *args], cwd=repo, capture_output=True, text=True, check=True)
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    _git(tmp_path, "init", "--quiet")
+    _git(tmp_path, "config", "user.email", "t@t")
+    _git(tmp_path, "config", "user.name", "t")
+    return tmp_path
+
+
+def test_blocks_direct_redis_instantiation(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    (repo / "bad.py").write_text("r = redis.Redis()\n", encoding="utf-8")
+    _git(repo, "add", "bad.py")
+    result = subprocess.run(["bash", str(HOOK_PATH)], cwd=repo, capture_output=True, text=True)
+    assert result.returncode != 0, result.stdout + result.stderr
+    assert "redis.Redis()" in result.stdout
+
+
+def test_allows_clean_file(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    (repo / "ok.py").write_text("x = 1\n", encoding="utf-8")
+    _git(repo, "add", "ok.py")
+    result = subprocess.run(["bash", str(HOOK_PATH)], cwd=repo, capture_output=True, text=True)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+class TestFailsClosedOnGitFailure:
+    """GH#14151: a corrupted `.git/index` used to be indistinguishable from
+    "nothing staged" — reproduced with a genuinely staged violation.
+    """
+
+    def test_a_git_failure_does_not_report_clean(self, tmp_path: Path) -> None:
+        repo = _init_repo(tmp_path)
+        (repo / "bad.py").write_text("r = redis.Redis()\n", encoding="utf-8")
+        _git(repo, "add", "bad.py")
+        # Corrupt the index so git errors rather than returning an empty answer.
+        (repo / ".git" / "index").write_text("garbage", encoding="utf-8")
+
+        result = subprocess.run(["bash", str(HOOK_PATH)], cwd=repo, capture_output=True, text=True)
+        assert result.returncode != 0, "a git failure was indistinguishable from 'no violation'"

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-new-health-route
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-new-health-route
@@ -24,14 +24,17 @@
 #
 # Install: pre-commit install (uses .pre-commit-config.yaml)
 
-set -uo pipefail
+set -euo pipefail
 
 # Source shared library (#7185 — colors + get_staged_files).
 # This hook reads `git diff --cached -U0` (line-level diff) rather than a file
 # list, so get_staged_files isn't applicable; only colors are reused.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/_common.sh
-source "$SCRIPT_DIR/lib/_common.sh"
+source "$SCRIPT_DIR/lib/_common.sh" || {
+    echo "FATAL: cannot load lib/_common.sh — refusing to report clean" >&2
+    exit 1
+}
 
 # Files exempt from the rule.
 EXEMPT_PATHS=(
@@ -105,7 +108,12 @@ main() {
         fi
         echo -e "  ${RED}VIOLATION${NC} ${path}:${lineno}"
         echo "    ${text}"
-        ((count++))
+        # GH#14151: `((count++))` evaluates to the PRE-increment value —
+        # 0 on the very first violation — and a bare `((expr))` compound
+        # command that evaluates to 0 returns exit status 1. Under
+        # `set -e` that aborted the script on the FIRST violation found,
+        # before the "COMMIT BLOCKED" summary ever printed.
+        count=$((count + 1))
     done <<< "$violations"
 
     echo ""

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-new-health-route_test.py
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-new-health-route_test.py
@@ -1,0 +1,74 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for pre-commit-no-new-health-route (#3333, GH#14151 fail-closed
+guard).
+
+Issue #14151: see pre-commit-no-direct-redis_test.py's module docstring for
+the shared background. This hook doesn't use get_staged_files() — it pipes
+`git diff --cached -U0` straight into an awk collector, and the result is
+captured with a bare top-level `violations=$(collect_violations)`, so
+`set -e` alone (no lib/_common.sh change needed) is enough to make a git
+failure abort. Its opening banner already references an unbound color
+variable under `set -u`, which independently closed the "missing
+lib/_common.sh" case pre-fix — only the git-failure path is the genuine,
+newly-fixed defect here.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+HOOK_PATH = Path(__file__).resolve().parent / "pre-commit-no-new-health-route"
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(["git", *args], cwd=repo, capture_output=True, text=True, check=True)
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    _git(tmp_path, "init", "--quiet")
+    _git(tmp_path, "config", "user.email", "t@t")
+    _git(tmp_path, "config", "user.name", "t")
+    return tmp_path
+
+
+def _stage_health_route(repo: Path) -> None:
+    f = repo / "autobot-backend" / "api" / "foo.py"
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_text('@router.get("/health")\nasync def h():\n    return {}\n', encoding="utf-8")
+    _git(repo, "add", "autobot-backend/api/foo.py")
+
+
+def test_blocks_new_health_route(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    _stage_health_route(repo)
+    result = subprocess.run(["bash", str(HOOK_PATH)], cwd=repo, capture_output=True, text=True)
+    assert result.returncode != 0, result.stdout + result.stderr
+
+
+def test_allows_ordinary_route(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    f = repo / "autobot-backend" / "api" / "foo.py"
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_text("def h():\n    return {}\n", encoding="utf-8")
+    _git(repo, "add", "autobot-backend/api/foo.py")
+    result = subprocess.run(["bash", str(HOOK_PATH)], cwd=repo, capture_output=True, text=True)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+class TestFailsClosedOnGitFailure:
+    """GH#14151: a corrupted `.git/index` used to be indistinguishable from
+    "no new /health routes" — reproduced with a genuinely staged violation.
+    """
+
+    def test_a_git_failure_does_not_report_clean(self, tmp_path: Path) -> None:
+        repo = _init_repo(tmp_path)
+        _stage_health_route(repo)
+        # Corrupt the index so git errors rather than returning an empty answer.
+        (repo / ".git" / "index").write_text("garbage", encoding="utf-8")
+
+        result = subprocess.run(["bash", str(HOOK_PATH)], cwd=repo, capture_output=True, text=True)
+        assert result.returncode != 0, "a git failure was indistinguishable from 'no violation'"

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-new-status-enum
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-new-status-enum
@@ -36,11 +36,14 @@
 #
 # Suppression: append `# noqa: status-shape` to the offending line (last resort).
 
-set -uo pipefail
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/_common.sh
-source "$SCRIPT_DIR/lib/_common.sh"
+source "$SCRIPT_DIR/lib/_common.sh" || {
+    echo "FATAL: cannot load lib/_common.sh — refusing to report clean" >&2
+    exit 1
+}
 
 EXEMPT_PATHS=(
     "autobot_shared/status_enums.py"
@@ -146,7 +149,12 @@ main() {
         fi
         echo -e "  ${RED}VIOLATION${NC} ${path}:${lineno}"
         echo "    ${text}"
-        ((count++))
+        # GH#14151: `((count++))` evaluates to the PRE-increment value —
+        # 0 on the very first violation — and a bare `((expr))` compound
+        # command that evaluates to 0 returns exit status 1. Under
+        # `set -e` that aborted the script on the FIRST violation found,
+        # before the "COMMIT BLOCKED" summary ever printed.
+        count=$((count + 1))
     done <<< "$violations"
 
     echo ""

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-new-status-enum_test.py
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-new-status-enum_test.py
@@ -1,0 +1,68 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for pre-commit-no-new-status-enum (#6973, GH#14151 fail-closed
+guard).
+
+Issue #14151: see pre-commit-no-new-health-route_test.py's module docstring
+for the shared background — same diff-direct shape, same `set -e`-only fix,
+same pre-existing `set -u` protection for the missing-lib case, so only the
+git-failure path is the genuine, newly-fixed defect here.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+HOOK_PATH = Path(__file__).resolve().parent / "pre-commit-no-new-status-enum"
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(["git", *args], cwd=repo, capture_output=True, text=True, check=True)
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    _git(tmp_path, "init", "--quiet")
+    _git(tmp_path, "config", "user.email", "t@t")
+    _git(tmp_path, "config", "user.name", "t")
+    return tmp_path
+
+
+def _stage_status_enum(repo: Path) -> None:
+    (repo / "mod.py").write_text("class FooStatus(Enum):\n    A = 1\n", encoding="utf-8")
+    _git(repo, "add", "mod.py")
+
+
+def test_blocks_new_status_enum(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    _stage_status_enum(repo)
+    result = subprocess.run(["bash", str(HOOK_PATH)], cwd=repo, capture_output=True, text=True)
+    assert result.returncode != 0, result.stdout + result.stderr
+
+
+def test_allows_exempt_path(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    f = repo / "autobot_shared" / "status_enums.py"
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_text("class FooStatus(Enum):\n    A = 1\n", encoding="utf-8")
+    _git(repo, "add", "autobot_shared/status_enums.py")
+    result = subprocess.run(["bash", str(HOOK_PATH)], cwd=repo, capture_output=True, text=True)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+class TestFailsClosedOnGitFailure:
+    """GH#14151: a corrupted `.git/index` used to be indistinguishable from
+    "no new status-enum declarations" — reproduced with a genuinely staged
+    violation.
+    """
+
+    def test_a_git_failure_does_not_report_clean(self, tmp_path: Path) -> None:
+        repo = _init_repo(tmp_path)
+        _stage_status_enum(repo)
+        # Corrupt the index so git errors rather than returning an empty answer.
+        (repo / ".git" / "index").write_text("garbage", encoding="utf-8")
+
+        result = subprocess.run(["bash", str(HOOK_PATH)], cwd=repo, capture_output=True, text=True)
+        assert result.returncode != 0, "a git failure was indistinguishable from 'no violation'"

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-new-workflow-step
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-new-workflow-step
@@ -35,14 +35,17 @@
 #
 # Install: pre-commit install (uses .pre-commit-config.yaml)
 
-set -uo pipefail
+set -euo pipefail
 
 # Source shared library (#7185 — colors + get_staged_files).
 # This hook reads `git diff --cached -U0` (line-level diff) rather than a file
 # list, so get_staged_files isn't applicable; only colors are reused.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/_common.sh
-source "$SCRIPT_DIR/lib/_common.sh"
+source "$SCRIPT_DIR/lib/_common.sh" || {
+    echo "FATAL: cannot load lib/_common.sh — refusing to report clean" >&2
+    exit 1
+}
 
 EXEMPT_PATHS=(
     "autobot_shared/workflow/types.py"
@@ -115,7 +118,12 @@ main() {
         fi
         echo -e "  ${RED}VIOLATION${NC} ${path}:${lineno}"
         echo "    ${text}"
-        ((count++))
+        # GH#14151: `((count++))` evaluates to the PRE-increment value —
+        # 0 on the very first violation — and a bare `((expr))` compound
+        # command that evaluates to 0 returns exit status 1. Under
+        # `set -e` that aborted the script on the FIRST violation found,
+        # before the "COMMIT BLOCKED" summary ever printed.
+        count=$((count + 1))
     done <<< "$violations"
 
     echo ""

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-new-workflow-step_test.py
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-new-workflow-step_test.py
@@ -1,0 +1,66 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for pre-commit-no-new-workflow-step (#6951, GH#14151 fail-closed
+guard).
+
+Issue #14151: see pre-commit-no-new-health-route_test.py's module docstring
+for the shared background — same diff-direct shape, same `set -e`-only fix,
+same pre-existing `set -u` protection for the missing-lib case, so only the
+git-failure path is the genuine, newly-fixed defect here.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+HOOK_PATH = Path(__file__).resolve().parent / "pre-commit-no-new-workflow-step"
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(["git", *args], cwd=repo, capture_output=True, text=True, check=True)
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    _git(tmp_path, "init", "--quiet")
+    _git(tmp_path, "config", "user.email", "t@t")
+    _git(tmp_path, "config", "user.name", "t")
+    return tmp_path
+
+
+def _stage_workflow_step(repo: Path) -> None:
+    (repo / "mod.py").write_text("class WorkflowStep:\n    pass\n", encoding="utf-8")
+    _git(repo, "add", "mod.py")
+
+
+def test_blocks_new_workflow_step(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    _stage_workflow_step(repo)
+    result = subprocess.run(["bash", str(HOOK_PATH)], cwd=repo, capture_output=True, text=True)
+    assert result.returncode != 0, result.stdout + result.stderr
+
+
+def test_allows_subclass(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    (repo / "mod.py").write_text("class WorkflowStep(WorkflowTask):\n    pass\n", encoding="utf-8")
+    _git(repo, "add", "mod.py")
+    result = subprocess.run(["bash", str(HOOK_PATH)], cwd=repo, capture_output=True, text=True)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+class TestFailsClosedOnGitFailure:
+    """GH#14151: a corrupted `.git/index` used to be indistinguishable from
+    "no new workflow-shape declarations" — reproduced with a genuinely
+    staged violation.
+    """
+
+    def test_a_git_failure_does_not_report_clean(self, tmp_path: Path) -> None:
+        repo = _init_repo(tmp_path)
+        _stage_workflow_step(repo)
+        # Corrupt the index so git errors rather than returning an empty answer.
+        (repo / ".git" / "index").write_text("garbage", encoding="utf-8")
+
+        result = subprocess.run(["bash", str(HOOK_PATH)], cwd=repo, capture_output=True, text=True)
+        assert result.returncode != 0, "a git failure was indistinguishable from 'no violation'"

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-print-console
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-print-console
@@ -43,12 +43,15 @@
 #
 # Install: pre-commit install (uses .pre-commit-config.yaml)
 
-set -uo pipefail
+set -euo pipefail
 
 # Source shared library (#7185 — colors + get_staged_files)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/_common.sh
-source "$SCRIPT_DIR/lib/_common.sh"
+source "$SCRIPT_DIR/lib/_common.sh" || {
+    echo "FATAL: cannot load lib/_common.sh — refusing to report clean" >&2
+    exit 1
+}
 
 VIOLATIONS=0
 
@@ -162,15 +165,23 @@ report_violation() {
         echo -e "  ${RED}VIOLATION${NC} ${file}:${line_num}"
     fi
     echo "    ${code:0:100}"
-    ((VIOLATIONS++))
+    VIOLATIONS=$((VIOLATIONS + 1))
 }
 
 # Get Python files to scan (production code only).
 # Uses get_staged_files (#7185) for the staged-files lookup with positional-args
 # override (#6785: same hook runs as local pre-commit AND CI gate). The
 # multi-stage allowlist below is hook-specific and must remain.
+# GH#14151: get_staged_files' own git-diff failure (e.g. a corrupted index)
+# used to be masked by the trailing `|| true` below, which existed only to
+# tolerate "the filters matched nothing" — a real git failure looked
+# identical. Captured separately so get_staged_files' non-zero return
+# propagates (set -e turns that into a hard stop); the later filter chain's
+# `|| true` still only ever tolerates an empty *result*, not a git error.
 get_staged_python_files() {
-    get_staged_files '\.py$' "$@" | \
+    local staged
+    staged="$(get_staged_files '\.py$' "$@")" || return 1
+    printf '%s\n' "$staged" | \
         grep -v -E '(__pycache__|node_modules|\.venv|venv|archive|temp)' | \
         grep -v -E '(_test\.py$|\.e2e_test\.py$|\.integration_test\.py$|\.performance_test\.py$)' | \
         grep -v -E '(conftest\.py$|test_.*\.py$)' | \
@@ -181,8 +192,11 @@ get_staged_python_files() {
 
 # Get TypeScript/Vue files to scan (production code only).
 # Same #7185 + #6785 pattern as get_staged_python_files.
+# GH#14151: same masking fix as get_staged_python_files above.
 get_staged_ts_files() {
-    get_staged_files '\.(ts|vue|js)$' "$@" | \
+    local staged
+    staged="$(get_staged_files '\.(ts|vue|js)$' "$@")" || return 1
+    printf '%s\n' "$staged" | \
         grep -v -E '(node_modules|\.venv|venv|archive|temp|dist)' | \
         grep -v -E '(\.spec\.(ts|js)$|\.test\.(ts|js)$|\.e2e\.(ts|js)$|-test\.(ts|js)$)' | \
         grep -v -E '(debugUtils\.ts$|RumConsoleHelper\.ts$)' | \

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-print-console_test.py
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-print-console_test.py
@@ -1,0 +1,66 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for pre-commit-no-print-console (#1082, GH#14151 fail-closed guard).
+
+Issue #14151: see pre-commit-no-direct-redis_test.py's module docstring for
+the shared background. This hook's opening banner already references an
+unbound color variable under `set -u` (independently closing the
+"missing lib/_common.sh" case pre-fix), AND main() calls
+`_self_test_strip_significant` before that banner, which already fails
+closed if `lib/strip-significant.awk` (a second, sibling dependency) goes
+missing — so, like no-direct-redis, only the git-failure path is the
+genuine, newly-fixed defect here.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+HOOK_PATH = Path(__file__).resolve().parent / "pre-commit-no-print-console"
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(["git", *args], cwd=repo, capture_output=True, text=True, check=True)
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    _git(tmp_path, "init", "--quiet")
+    _git(tmp_path, "config", "user.email", "t@t")
+    _git(tmp_path, "config", "user.name", "t")
+    return tmp_path
+
+
+def test_blocks_print_call(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    (repo / "bad.py").write_text('print("hi")\n', encoding="utf-8")
+    _git(repo, "add", "bad.py")
+    result = subprocess.run(["bash", str(HOOK_PATH)], cwd=repo, capture_output=True, text=True)
+    assert result.returncode != 0, result.stdout + result.stderr
+    assert "print(" in result.stdout
+
+
+def test_allows_clean_file(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    (repo / "ok.py").write_text("x = 1\n", encoding="utf-8")
+    _git(repo, "add", "ok.py")
+    result = subprocess.run(["bash", str(HOOK_PATH)], cwd=repo, capture_output=True, text=True)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+class TestFailsClosedOnGitFailure:
+    """GH#14151: a corrupted `.git/index` used to be indistinguishable from
+    "nothing staged" — reproduced with a genuinely staged violation.
+    """
+
+    def test_a_git_failure_does_not_report_clean(self, tmp_path: Path) -> None:
+        repo = _init_repo(tmp_path)
+        (repo / "bad.py").write_text('print("hi")\n', encoding="utf-8")
+        _git(repo, "add", "bad.py")
+        # Corrupt the index so git errors rather than returning an empty answer.
+        (repo / ".git" / "index").write_text("garbage", encoding="utf-8")
+
+        result = subprocess.run(["bash", str(HOOK_PATH)], cwd=repo, capture_output=True, text=True)
+        assert result.returncode != 0, "a git failure was indistinguishable from 'no violation'"

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-tag-pinned-action
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-tag-pinned-action
@@ -26,12 +26,15 @@
 #
 # Install: pre-commit install (uses .pre-commit-config.yaml)
 
-set -uo pipefail
+set -euo pipefail
 
 # Source shared library (#7185 — colors + get_staged_files)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/_common.sh
-source "$SCRIPT_DIR/lib/_common.sh"
+source "$SCRIPT_DIR/lib/_common.sh" || {
+    echo "FATAL: cannot load lib/_common.sh — refusing to report clean" >&2
+    exit 1
+}
 
 VIOLATIONS=0
 

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-tag-pinned-action_test.py
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-tag-pinned-action_test.py
@@ -132,10 +132,16 @@ def test_comment_lines_ignored(tmp_path):
     assert result.returncode == 0
 
 
-def test_empty_file(tmp_path):
-    """No staged workflow files — hook exits cleanly."""
-    result = subprocess.run([str(HOOK_PATH)], capture_output=True, text=True)
-    assert result.returncode == 0
+def test_no_staged_files_in_a_real_repo_exits_cleanly(tmp_path):
+    """Nothing staged, inside an actual git repo — the real 'nothing to
+    check' case a git hook invocation always runs in. Replaces the old
+    test_empty_file, which ran the hook OUTSIDE any git repository at all;
+    that is not "no files staged", it is git itself failing to answer the
+    question — now covered by TestFailsClosedWhenGitCannotAnswer below
+    (GH#14151)."""
+    subprocess.run(["git", "init", "--quiet"], cwd=tmp_path, check=True)
+    result = subprocess.run([str(HOOK_PATH)], cwd=tmp_path, capture_output=True, text=True)
+    assert result.returncode == 0, result.stdout + result.stderr
 
 
 def test_actions_path_allowed(tmp_path):
@@ -157,3 +163,60 @@ def test_actions_path_rejects_third_party_tag(tmp_path):
         rel=".github/actions/setup/action.yml",
     )
     assert result.returncode == 1
+
+
+# === GH#14151: fails closed when git itself cannot answer ===
+
+
+def _git(repo, *args):
+    return subprocess.run(["git", *args], cwd=repo, capture_output=True, text=True, check=True)
+
+
+def _init_repo(tmp_path):
+    _git(tmp_path, "init", "--quiet")
+    _git(tmp_path, "config", "user.email", "t@t")
+    _git(tmp_path, "config", "user.name", "t")
+    return tmp_path
+
+
+def _stage_tag_pinned_workflow(repo):
+    wf = repo / ".github" / "workflows" / "ci.yml"
+    wf.parent.mkdir(parents=True, exist_ok=True)
+    wf.write_text("jobs:\n  build:\n    steps:\n      - uses: dorny/paths-filter@v3\n", encoding="utf-8")
+    _git(repo, "add", ".github/workflows/ci.yml")
+
+
+class TestFailsClosedWhenGitCannotAnswer:
+    """GH#14151: `set -uo pipefail` (no `-e`) plus an unguarded `source
+    lib/_common.sh`, combined with get_staged_files()'s former blanket
+    `|| true`, meant a broken dependency OR a `git diff --cached` failure
+    degraded to an empty file list — read as "nothing to check" and exited
+    0 even with a genuinely staged tag-pinned action present. Unlike the
+    other hooks in this family, THIS one has no banner echo referencing a
+    color variable at the top of main(), so `set -u` alone never caught the
+    missing-lib case either — both reproductions below are genuine fail-open
+    bugs in the pre-fix script, not merely defense-in-depth.
+    """
+
+    def test_a_missing_common_lib_does_not_report_clean(self, tmp_path):
+        repo = _init_repo(tmp_path)
+        _stage_tag_pinned_workflow(repo)
+
+        # A copy of the hook with no `lib/` beside it — the dependency is gone.
+        isolated = tmp_path.parent / "isolated-no-tag-pinned-action"
+        isolated.mkdir()
+        hook_copy = isolated / HOOK_PATH.name
+        hook_copy.write_bytes(HOOK_PATH.read_bytes())
+        hook_copy.chmod(0o755)
+
+        result = subprocess.run([str(hook_copy)], cwd=repo, capture_output=True, text=True)
+        assert result.returncode != 0, "the hook reported clean with a staged violation and no dependency"
+
+    def test_a_git_failure_does_not_report_clean(self, tmp_path):
+        repo = _init_repo(tmp_path)
+        _stage_tag_pinned_workflow(repo)
+        # Corrupt the index so git errors rather than returning an empty answer.
+        (repo / ".git" / "index").write_text("garbage", encoding="utf-8")
+
+        result = subprocess.run([str(HOOK_PATH)], cwd=repo, capture_output=True, text=True)
+        assert result.returncode != 0, "a git failure was indistinguishable from 'no violation'"

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-tracked-symlink_test.py
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-tracked-symlink_test.py
@@ -235,6 +235,20 @@ class TestTheGuardFailsClosedWhenItCannotRun:
 
     The marker-missing and empty-NAMES paths were already tested and already
     failed closed. These two were not tested, and did not.
+
+    GH#14151 review (round 2): the ARGV-mode git-failure test below was
+    approved as covering "a git failure" in general, but `.pre-commit-
+    config.yaml` sets `pass_filenames: false` for this hook — the REAL,
+    every-day local invocation is always NO-ARGV, which takes
+    get_staged_files()'s `git diff --cached` branch instead of the argv
+    branch this test exercises. That branch had its own, separate `|| true`
+    inside lib/_common.sh itself, independent of anything in THIS hook, and
+    it was still masking a git failure identically to "nothing staged"
+    after #14150 landed — proven by running the no-argv case against
+    Dev_new_gui HEAD (post-#14150, pre-#14151) below: RC=0, reports clean,
+    the symlink still ships. Fixed by #14151's lib/_common.sh change, not
+    by anything in this file — the test below exists so that fix can never
+    silently regress unnoticed.
     """
 
     def test_a_missing_common_lib_does_not_report_clean(self, tmp_path: Path) -> None:
@@ -252,12 +266,32 @@ class TestTheGuardFailsClosedWhenItCannotRun:
 
         assert result.returncode != 0, "the hook reported clean with a staged symlink and no dependency"
 
-    def test_a_git_failure_does_not_report_clean(self, tmp_path: Path) -> None:
+    def test_a_git_failure_does_not_report_clean_argv_mode(self, tmp_path: Path) -> None:
+        """CI invocation: an explicit file list, bypassing get_staged_files()'s
+        own git-diff branch entirely — the failure this test catches lives in
+        check_file()'s own `git ls-files -s` call, not in lib/_common.sh."""
         repo = _init_repo(tmp_path)
         _stage_symlink(repo, "venv", str(repo))
         # Corrupt the index so git errors rather than returning an empty answer.
         (repo / ".git" / "index").write_text("garbage", encoding="utf-8")
 
         result = _run_hook(repo, "venv")
+
+        assert result.returncode != 0, "a git failure was indistinguishable from 'no violation'"
+
+    def test_a_git_failure_does_not_report_clean_no_argv_mode(self, tmp_path: Path) -> None:
+        """Local pre-commit invocation: `.pre-commit-config.yaml` sets
+        `pass_filenames: false` for this hook, so no-argv is the path a real
+        commit always takes. This exercises get_staged_files()'s own
+        `git diff --cached` branch in lib/_common.sh — a DIFFERENT git call
+        than the argv-mode test above, and the one #14151 review found still
+        masked after #14150 (lib/_common.sh's own trailing `|| true` swallowed
+        the failure before this hook's `set -e` could ever see it)."""
+        repo = _init_repo(tmp_path)
+        _stage_symlink(repo, "venv", str(repo))
+        # Corrupt the index so git errors rather than returning an empty answer.
+        (repo / ".git" / "index").write_text("garbage", encoding="utf-8")
+
+        result = _run_hook(repo)
 
         assert result.returncode != 0, "a git failure was indistinguishable from 'no violation'"

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-record-branch
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-record-branch
@@ -17,7 +17,7 @@
 #
 # Install: pre-commit install (uses .pre-commit-config.yaml)
 
-set -uo pipefail
+set -euo pipefail
 
 GIT_DIR_PATH=$(git rev-parse --git-dir 2>/dev/null)
 if [ -z "$GIT_DIR_PATH" ]; then

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-target-branch-guard
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-target-branch-guard
@@ -28,11 +28,14 @@
 #
 # Related issues: #4113 (branch discipline), #1689 (branch safety)
 
-set -uo pipefail
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/_common.sh
-source "$SCRIPT_DIR/lib/_common.sh"
+source "$SCRIPT_DIR/lib/_common.sh" || {
+    echo "FATAL: cannot load lib/_common.sh — refusing to report clean" >&2
+    exit 1
+}
 
 CURRENT_BRANCH=$(git branch --show-current 2>/dev/null)
 

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-worktree-branch-guard
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-worktree-branch-guard
@@ -40,7 +40,20 @@ main() {
         exit 0
     fi
 
-    # Check if any other worktree has this branch checked out
+    # Check if any other worktree has this branch checked out.
+    # GH#14151 review: `done < <(git worktree list --porcelain)` is PROCESS
+    # substitution — its exit status never reaches this shell, so neither
+    # `set -e` nor `set -u` can see it fail. A corrupted `.git/worktrees`
+    # tree or disk pressure would make `git worktree list` fail silently,
+    # the while loop would just see zero lines of input, and this hook
+    # would report "no conflict" with a genuine one present. Captured via
+    # command substitution first so the failure is an ordinary non-zero
+    # return that `set -e` DOES observe.
+    wt_output="$(git worktree list --porcelain)" || {
+        echo "FATAL: git worktree list failed — refusing to report clean" >&2
+        exit 1
+    }
+
     conflict=""
     while IFS= read -r line; do
         # git worktree list --porcelain outputs:
@@ -60,7 +73,7 @@ main() {
                 break
             fi
         fi
-    done < <(git worktree list --porcelain 2>/dev/null)
+    done <<< "$wt_output"
 
     if [[ -z "$conflict" ]]; then
         exit 0

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-worktree-branch-guard
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-worktree-branch-guard
@@ -23,11 +23,14 @@
 # Issue: #1654 - pre-commit stash pop can switch active branch
 # Related: #1503 - pre-commit stash/restore stages untracked files
 
-set -uo pipefail
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/_common.sh
-source "$SCRIPT_DIR/lib/_common.sh"
+source "$SCRIPT_DIR/lib/_common.sh" || {
+    echo "FATAL: cannot load lib/_common.sh — refusing to report clean" >&2
+    exit 1
+}
 
 main() {
     current_branch=$(git branch --show-current 2>/dev/null)

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-worktree-branch-guard_test.py
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-worktree-branch-guard_test.py
@@ -1,0 +1,117 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for pre-commit-worktree-branch-guard (#1654, GH#14151 fail-closed
+guard).
+
+Issue #14151 review (round 2): this hook's `git worktree list --porcelain`
+call was fed into the loop through PROCESS substitution —
+`done < <(git worktree list --porcelain)` — whose exit status never reaches
+the calling shell. Neither `set -e` nor `set -u` can observe a process
+substitution's failure, so corrupting `.git/index` (the probe used for
+every other hook in this campaign) cannot reach this code path at all:
+`git worktree list` doesn't read the index. The genuine reproduction needs
+a `git` that fails specifically on `worktree list` while every other git
+call still succeeds normally — a fake `git` shim on PATH, not a corrupted
+repository.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+HOOK_PATH = Path(__file__).resolve().parent / "pre-commit-worktree-branch-guard"
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(["git", *args], cwd=repo, capture_output=True, text=True, check=True)
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    _git(tmp_path, "init", "--quiet")
+    _git(tmp_path, "config", "user.email", "t@t")
+    _git(tmp_path, "config", "user.name", "t")
+    (tmp_path / "README.md").write_text("seed\n", encoding="utf-8")
+    _git(tmp_path, "add", "README.md")
+    _git(tmp_path, "-c", "commit.gpgsign=false", "commit", "-q", "-m", "seed")
+    return tmp_path
+
+
+def _stage_worktree_conflict(repo: Path, linked_wt: Path) -> None:
+    """Make `repo` (the main working tree) and a linked worktree both
+    resolve to the same branch — the real shape this hook guards against.
+    `git worktree add -b` refuses to double-check-out a branch, so the
+    conflict is engineered by adding the linked worktree for a NEW branch
+    first, then pointing the main tree's HEAD at that same branch directly
+    (a plain file write, not `git checkout` — this simulates the race the
+    hook exists to catch, not a state a normal `git checkout` could reach
+    in one step)."""
+    _git(repo, "worktree", "add", "-q", "-b", "shared-branch", str(linked_wt))
+    (repo / ".git" / "HEAD").write_text("ref: refs/heads/shared-branch\n", encoding="utf-8")
+
+
+def test_no_conflict_is_allowed(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    result = subprocess.run(["bash", str(HOOK_PATH)], cwd=repo, capture_output=True, text=True)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_real_conflict_is_blocked(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    linked_wt = tmp_path.parent / "linked-wt"
+    _stage_worktree_conflict(repo, linked_wt)
+    result = subprocess.run(["bash", str(HOOK_PATH)], cwd=repo, capture_output=True, text=True)
+    assert result.returncode != 0, result.stdout + result.stderr
+    assert "shared-branch" in result.stdout
+
+
+class TestFailsClosedWhenGitWorktreeListFails:
+    """GH#14151 review: a corrupted `.git/worktrees` tree or disk pressure
+    makes `git worktree list` itself fail — reproduced with a fake `git` on
+    PATH that fails ONLY `worktree list` and delegates everything else to
+    the real binary, since a corrupted `.git/index` cannot reach this path
+    (`git worktree list` never reads the index).
+    """
+
+    def _make_fake_git(self, tmp_path: Path) -> Path:
+        real_git = subprocess.run(["command", "-v", "git"], shell=False, capture_output=True, text=True)
+        # Resolve the real git path without relying on a shell builtin.
+        real_git_path = None
+        for candidate in ("/usr/bin/git", "/bin/git", "/usr/local/bin/git"):
+            if Path(candidate).exists():
+                real_git_path = candidate
+                break
+        assert real_git_path, "could not locate a real git binary to delegate to"
+
+        fake_bin = tmp_path.parent / "fake-bin"
+        fake_bin.mkdir(exist_ok=True)
+        fake_git = fake_bin / "git"
+        fake_git.write_text(
+            "#!/bin/bash\n"
+            f'REAL_GIT="{real_git_path}"\n'
+            'if [ "$1" = "worktree" ] && [ "$2" = "list" ]; then\n'
+            '    echo "fatal: simulated worktree list failure" >&2\n'
+            "    exit 128\n"
+            "fi\n"
+            'exec "$REAL_GIT" "$@"\n',
+            encoding="utf-8",
+        )
+        fake_git.chmod(fake_git.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+        return fake_bin
+
+    def test_a_git_worktree_list_failure_does_not_report_clean(self, tmp_path: Path) -> None:
+        repo = _init_repo(tmp_path)
+        linked_wt = tmp_path.parent / "linked-wt-2"
+        _stage_worktree_conflict(repo, linked_wt)
+
+        fake_bin = self._make_fake_git(tmp_path)
+        env = dict(os.environ)
+        env["PATH"] = f"{fake_bin}:{env.get('PATH', '')}"
+
+        result = subprocess.run(["bash", str(HOOK_PATH)], cwd=repo, capture_output=True, text=True, env=env)
+
+        assert result.returncode != 0, "a `git worktree list` failure was indistinguishable from 'no conflict'"


### PR DESCRIPTION
Refs #14151

## Thinking Path

#14150 fixed two hooks with this shape: `set -uo pipefail` (no `-e`) plus an unguarded `source lib/_common.sh`, where a broken dependency or a `git` failure degraded to an empty result the hook read as "nothing to check" and exited 0. #14151 asked whether the same shape reproduces across the other 13 hooks in the directory, not just assumed it does.

I checked each hook's own control flow before touching it (per the issue's explicit instruction not to mass-`sed` this). That surfaced three distinct findings, not one:

1. **The root cause is partly in the shared library, not each hook.** `get_staged_files()` in `lib/_common.sh` wraps its own `git diff --cached` call in `|| true`, which swallows "git failed" identically to "grep matched nothing" — so `set -e` alone in a calling hook is NOT enough when that hook's only git touchpoint is `get_staged_files()`. Fixed once in the library (capture the diff separately, propagate a real failure as a non-zero return), then decomposed each affected hook's own `get_*_files()` wrapper so it no longer re-masks that return with its own trailing `|| true`.
2. **`-e` has its own landmine in this family: `((VAR++))`.** A bare `((expr))` compound command that evaluates to `0` returns exit status `1` — `((VIOLATIONS++))` on the *first* violation (when `VIOLATIONS` is still `0`) does exactly that. Under `-e` this aborted `pre-commit-hardcoded-values` (9 separate counters), `pre-commit-no-direct-redis`, `pre-commit-no-print-console`, and the three diff-direct hooks on the very first violation found — before it was ever reported. Fixed by switching to `VAR=$((VAR + 1))`, which is already the house style used elsewhere in this same file (`pre-commit-no-tag-pinned-action`).
3. **Some hooks were already fail-closed for the missing-lib case, for an unrelated reason.** Several hooks print a banner referencing a color variable (`${BOLD}`, etc.) as the very first line of `main()` — under the pre-existing `set -u`, a missing `lib/_common.sh` already killed the script there with "unbound variable" before it could reach any check. That's not intentional hardening, but it does mean the "missing lib" reproduction from #14150's template does **not** demonstrate a new defect for those specific hooks — only "corrupted git index" does. I only added a test where I could show it failing against the pre-fix script; a test that can't fail against the original proves nothing (explicit ask in #14151).

Also found while touching these exact files: 10 of the 13 were tracked at git mode `100644` despite `.pre-commit-config.yaml`'s `language: script` requiring the executable bit (`core.fileMode=false` locally hides this — the same gotcha #14150 flagged). Fixed via `git update-index --chmod=+x` since I was already opening every one of these files for the fail-open fix.

## What Changed

**`autobot-infrastructure/shared/scripts/hooks/lib/_common.sh`** — `get_staged_files()`'s no-argv branch now captures `git diff --cached`'s own exit status instead of masking it inside the same `|| true` used to tolerate "the pattern matched nothing".

**12 of the 13 hooks get `set -uo pipefail` → `set -euo pipefail`, plus (where they source it) an explicit `source lib/_common.sh || { echo FATAL...; exit 1; }` guard:**
- `pre-commit-branch-guard`, `pre-commit-detect-mass-deletions`, `pre-commit-function-length`, `pre-commit-hardcoded-values`, `pre-commit-no-direct-redis`, `pre-commit-no-new-health-route`, `pre-commit-no-new-status-enum`, `pre-commit-no-new-workflow-step`, `pre-commit-no-print-console`, `pre-commit-no-tag-pinned-action`, `pre-commit-record-branch` (no lib dependency — `-e` only), `pre-commit-target-branch-guard`, `pre-commit-worktree-branch-guard`.

**Additional per-hook fixes required to make `-e` safe, found by reading control flow (not applied blindly):**
- `pre-commit-hardcoded-values`: 22 occurrences of `((VAR++))` (`line_num`, `VIOLATIONS`, `WARNINGS` across all 9 checker functions) → `VAR=$((VAR + 1))`; `get_files_to_scan()` decomposed to propagate `get_staged_files()` failures.
- `pre-commit-no-direct-redis`: 1 `((VIOLATIONS++))` fixed; `get_staged_python_files()` decomposed; `violations=$(python3 ... heredoc)` — the heredoc intentionally `sys.exit(1)`s when it *finds* a violation (a signal, not an error) — rewritten to `... || py_exit=$?` so `-e` doesn't treat "violation found" as a script crash.
- `pre-commit-no-print-console`: 1 `((VIOLATIONS++))` fixed; both `get_staged_python_files()` and `get_staged_ts_files()` decomposed.
- `pre-commit-function-length`: `get_staged_python_files()` decomposed; `echo "$files" | "$python_cmd" ...; exit_code=$?` rewritten to `... || exit_code=$?` for the same "expected non-zero is a signal" reason as no-direct-redis.
- `pre-commit-no-new-health-route`, `pre-commit-no-new-status-enum`, `pre-commit-no-new-workflow-step`: 1 `((count++))` each fixed.
- `pre-commit-no-tag-pinned-action`: calls `get_staged_files` directly (no wrapper) — needed no additional fix beyond the library change.
- `pre-commit-detect-mass-deletions`: calls `git diff --cached` directly (not via `get_staged_files`) — `-e` alone closes it.

**Deliberately NOT touched:** `pre-commit-warn-untracked`. It is warn-only by explicit design ("This is a WARNING only (exit 0) — it never blocks a commit"). A dependency failure there degrading to "no warning shown" is consistent with, not contrary to, its own documented contract — the "manufactures false confidence" framing in #14151 applies to hooks whose job is to *block* on a verdict, not to this one. It also already has an unrelated, opposite-direction latent bug (missing lib currently makes it accidentally abort a commit it promises never to block) that is out of scope here and would need different handling — filed separately.

**Test files** — `_test.py` count going in: 2 of 13 existed (`pre-commit-hardcoded-values_test.py`, `pre-commit-no-tag-pinned-action_test.py`). Appended to those 2; created 7 new ones (`pre-commit-no-direct-redis_test.py`, `pre-commit-no-print-console_test.py`, `pre-commit-function-length_test.py`, `pre-commit-detect-mass-deletions_test.py`, `pre-commit-no-new-health-route_test.py`, `pre-commit-no-new-status-enum_test.py`, `pre-commit-no-new-workflow-step_test.py`) — 4 hooks (`branch-guard`, `record-branch`, `target-branch-guard`, `worktree-branch-guard`) get the code fix only, no test, because I could not construct a reproduction that fails against the pre-fix script for either scenario (see finding 3 above and Verification below).

`pre-commit-no-tag-pinned-action_test.py`'s pre-existing `test_empty_file` ran the hook completely outside a git repository and asserted `returncode == 0` — that was locking down the exact defect this PR fixes (a git failure reading as "nothing staged"), not real "no files" behavior. Replaced with `test_no_staged_files_in_a_real_repo_exits_cleanly` (a real, empty git repo — genuinely nothing staged, still `== 0`) plus a new `TestFailsClosedWhenGitCannotAnswer` class covering the actual defect.

**Mode fix (git-tracked, not content):** `git update-index --chmod=+x` on the 10 of these 13 hooks that were tracked as `100644` despite `language: script` requiring executability.

## Verification

Everything below was run against real scratch git repos under `/tmp` (bash + git only — no local Python interpreter, no venv, no pytest per repo policy).

**Pre-fix vs. post-fix, side by side, with a genuinely staged violation in every case** (bug reproduced pre-fix = `RC=0`/clean; fixed post-fix = non-zero):

| Hook | Missing-lib pre-fix | Missing-lib post-fix | Corrupted-index pre-fix | Corrupted-index post-fix |
|---|---|---|---|---|
| `no-tag-pinned-action` | RC=0 (bug) | RC=1 | RC=0 (bug) | RC=1 |
| `hardcoded-values` | RC=1 (already safe, `-u` catches banner) | RC=1 | RC=0 (bug) | RC=1 |
| `no-direct-redis` | RC=1 (already safe) | RC=1 | RC=0 (bug) | RC=1 |
| `no-print-console` | RC=2 (already safe, own self-test) | RC=1 | RC=0 (bug) | RC=1 |
| `function-length` | RC=1 (already safe) | RC=1 | RC=0 (bug) | RC=1 |
| `detect-mass-deletions` | RC=1 (already safe) | RC=1 | RC=0 (bug) | RC=128 |
| `no-new-health-route` | RC=1 (already safe) | RC=1 | RC=0 (bug) | RC=128 |
| `no-new-status-enum` | RC=1 (already safe) | RC=1 | RC=0 (bug) | RC=128 |
| `no-new-workflow-step` | RC=1 (already safe) | RC=1 | RC=0 (bug) | RC=128 |
| `branch-guard` | RC=1 (already safe) | RC=1 | n/a (index untouched) | n/a |
| `record-branch` | n/a (no lib dep) | n/a | n/a (index untouched) | n/a |
| `target-branch-guard` | RC=1 (already safe) | RC=1 | n/a (index untouched) | n/a |
| `worktree-branch-guard` | RC=1 (already safe) | RC=1 | n/a (index untouched; see Review round 2 below — a different git call fails open here) | fixed (see Review round 2) |

**No functional regression** — re-ran every hook against a healthy repo with both a genuine violation (all 9 `hardcoded-values` checkers individually, direct-redis, print/console incl. multi-line-with-noqa paths, tag-pinning, overlong function, mass deletion, new health-route/status-enum/workflow-step, mismatched-branch, protected-branch, worktree-conflict) and a clean file, in both no-argv (pre-commit) and argv (CI) invocation modes — all match pre-existing expected behavior/messages exactly.

`bash -n` clean on all 13 edited scripts + `lib/_common.sh`. `python3 -m py_compile` clean on all 9 touched/new `_test.py` files (syntax only — CI runs the actual suite).

CI run: pushed, awaiting checks.

## Review round 2 (two gaps found, both closed)

**1. `pre-commit-worktree-branch-guard` was still fail-open — through a mechanism `set -e` cannot see.** `done < <(git worktree list --porcelain)` is PROCESS substitution, not command substitution — its exit status never reaches the calling shell, so neither `set -e` nor `set -u` observes it fail. A corrupted `.git/index` (the probe used for every other hook in this PR) can't reach this path at all: `git worktree list` never reads the index. Reproduced instead with a fake `git` on `PATH` that fails only `worktree list` and delegates everything else to the real binary, with a genuine worktree conflict staged:

```
PATH="fake-bin:$PATH" bash pre-commit-worktree-branch-guard
RC=0   # pre-fix: reports clean, real conflict present
```

Fixed by capturing `git worktree list --porcelain` via command substitution first (`wt_output="$(...)" || { FATAL; exit 1; }`), then iterating over the captured string with a here-string instead of process substitution — an ordinary non-zero return `set -e` does observe. Post-fix, same fake-`git` repro: `RC=1`. New test file `pre-commit-worktree-branch-guard_test.py` (previously had none) uses the same fake-`git`-on-`PATH` technique, plus basic no-conflict/real-conflict sanity tests.

Swept the rest of this hook family (all 13 touched here + the 2 hooks #14150 already fixed) for the same class — process substitution, backgrounding, `xargs`, or any other construct that hides a git call's exit status from the shell. This was the only instance (`grep -n '< <(' pre-commit-* lib/_common.sh` — one hit, now fixed and commented against regressing).

**2. `pre-commit-no-tracked-symlink`'s no-argv path was still fail-open after #14150.** `.pre-commit-config.yaml` sets `pass_filenames: false` for this hook, so the real, every-day local invocation is *always* no-argv — which takes `get_staged_files()`'s `git diff --cached` branch. That branch's failure lived inside `lib/_common.sh` itself (the same `|| true` masking documented in this PR's "Thinking Path" #1), not in anything #14150's own diff touched, so it stayed broken:

```
# origin/Dev_new_gui HEAD (post-#14150, pre-this-PR), no argv, corrupted index, genuine symlink staged
bash pre-commit-no-tracked-symlink
RC=0   # reports clean, symlink ships
```

This PR's `lib/_common.sh` fix (finding #1 in "Thinking Path" above) already closes this as a side effect — confirmed with the post-fix library alongside the *unmodified* hook script: `RC=1`, `FATAL: git diff --cached failed`. Added the missing no-argv regression test to `pre-commit-no-tracked-symlink_test.py` (`test_a_git_failure_does_not_report_clean_no_argv_mode`, alongside the pre-existing argv-mode one, now renamed `..._argv_mode` for clarity) so this fix is locked in rather than an invisible side effect nobody knows to preserve.

## Model Used

Sonnet