### PR TITLE
security(mcp): deny .env path components and match exclusions case-insensitively

### DIFF
--- a/autobot-backend/api/filesystem_mcp.py
+++ b/autobot-backend/api/filesystem_mcp.py
@@ -269,13 +269,14 @@ _EXCLUDED_ROOTS = [Path(os.path.realpath(str(p))) for p in _EXCLUDED_DIR_PATHS]
 # Committed, non-secret dotenv templates (review follow-up on #14081): a
 # ".env*" basename denylist alone also blocks these commonly-committed
 # examples, which is over-broad -- they carry no real credential material by
-# convention. Checked against the basename only, so a directory genuinely
-# named e.g. ".env.example" (not a file) stays denied.
+# convention. Checked against the case-folded *leaf* only, so a directory
+# genuinely named e.g. ".env.example" stays denied no matter what the file
+# inside it is called (#14125).
 _ENV_TEMPLATE_ALLOWLIST = frozenset({".env.example", ".env.sample", ".env.template"})
 
 
 def _is_excluded_path(resolved: Path) -> bool:
-    """Refuse ``.git/``, ``.env*`` and the whole data directory (#14081, #14124).
+    """Refuse ``.git/``, ``.env*`` and the data directory (#14081, #14124, #14125).
 
     Checked against the *resolved* (symlink-followed, canonicalized) path so
     a symlink or an encoded traversal that lands inside an excluded subtree
@@ -290,9 +291,26 @@ def _is_excluded_path(resolved: Path) -> bool:
     defence-in-depth against a caller who only has bridge access, not a hole
     in the boundary the bridge actually enforces.
     """
-    if ".git" in resolved.parts:
+    # Lower-cased for every comparison below (#14125). ``fnmatch`` and the
+    # ``in parts`` test are case-sensitive on POSIX, so ".GIT/config" and
+    # ".ENV" walked straight past this gate; on a case-insensitive mount
+    # (WSL DrvFs, macOS, SMB) they resolve to the *real* ``.git``/``.env``,
+    # making the exclusion bypassable by changing the case of the request.
+    # Refusing the odd-cased names on a case-sensitive filesystem too is the
+    # fail-closed direction and costs nothing real.
+    lowered = [part.lower() for part in resolved.parts]
+    if ".git" in lowered:
         return True
-    if resolved.name not in _ENV_TEMPLATE_ALLOWLIST and any(fnmatch.fnmatch(part, ".env*") for part in resolved.parts):
+    # The template allowlist applies to the *leaf only* (#14125). Applied to
+    # the whole path it short-circuited the component scan, so a directory
+    # named ".env" or ".envs" became traversable whenever the leaf happened
+    # to be named like a template (``<root>/.env/.env.example`` was allowed).
+    # A directory is never a template, so every non-leaf component is denied
+    # unconditionally.
+    if any(fnmatch.fnmatch(part, ".env*") for part in lowered[:-1]):
+        return True
+    leaf = lowered[-1] if lowered else ""
+    if leaf not in _ENV_TEMPLATE_ALLOWLIST and fnmatch.fnmatch(leaf, ".env*"):
         return True
     for excluded_root in _EXCLUDED_ROOTS:
         try:

--- a/autobot-backend/tests/api/test_filesystem_mcp_exclusions.py
+++ b/autobot-backend/tests/api/test_filesystem_mcp_exclusions.py
@@ -211,6 +211,104 @@ class TestExcludedSubtreesUnit:
         assert fs_mcp.is_path_allowed(str(seed)) is True
 
 
+class TestEnvMatchingDefects:
+    """The two ``_is_excluded_path`` matching defects from #14125.
+
+    Both are bypasses of an exclusion that #14081 already intended to
+    enforce, so every assertion here is written to fail against the
+    pre-#14125 implementation and pass after it. They are driven through the
+    real ``is_path_allowed``/``_resolve_allowed_path`` seam, never against a
+    hand-rolled restatement of the predicate.
+    """
+
+    @staticmethod
+    def _make(project: Path, relative: str) -> Path:
+        """Create ``relative`` (with parents) under *project* and return it."""
+        target = project / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("PLACEHOLDER=not-a-real-secret\n", encoding="utf-8")
+        return target
+
+    # Defect 1: the template allowlist was checked against the whole path's
+    # basename, which returned early and skipped the component scan. A
+    # directory named ".env"/".envs" was therefore traversable whenever the
+    # leaf happened to be named like a template. The last three rows already
+    # behaved correctly before the fix and are here to pin that they still do
+    # -- an over-corrected component scan that denied everything would look
+    # identical to a fix on the first two rows alone.
+    @pytest.mark.parametrize(
+        "relative",
+        [
+            "sub/.env/.env.example",
+            "sub/.envs/.env.sample",
+            "sub/.env.example.real",
+            "sub/.env.example/real.env",
+            "sub/.env.d/x.env",
+        ],
+    )
+    def test_env_component_is_denied_regardless_of_leaf_name(self, fake_project, relative):
+        """A ``.env*`` *directory* component is never excused by the leaf (#14125)."""
+        target = str(self._make(fake_project["project"], relative))
+
+        assert fs_mcp.is_path_allowed(target) is False
+        with pytest.raises(ValueError, match="excluded subtree"):
+            fs_mcp._resolve_allowed_path(target)
+
+    # Defect 2: fnmatch and the ``in parts`` test are case-sensitive on
+    # POSIX, so the exclusion was bypassable by changing the case of the
+    # request. On a case-insensitive mount these resolve to the real files.
+    @pytest.mark.parametrize(
+        "relative",
+        [
+            ".GIT/config",
+            ".Git/config",
+            "sub/.ENV",
+            "sub/.Env",
+            "sub/.ENV.local",
+            "sub/.ENV/settings.json",
+        ],
+    )
+    def test_case_variants_are_denied(self, fake_project, relative):
+        """``.GIT``/``.ENV`` and friends are refused like their lower-case forms (#14125)."""
+        target = str(self._make(fake_project["project"], relative))
+
+        assert fs_mcp.is_path_allowed(target) is False
+        with pytest.raises(ValueError, match="excluded subtree"):
+            fs_mcp._resolve_allowed_path(target)
+
+    # The allowlist must survive both fixes: denying every ".env*" leaf would
+    # pass every assertion above while silently reverting #14081's review
+    # follow-up. Case-folding the leaf extends the allowlist to odd-cased
+    # template names rather than trapping them.
+    @pytest.mark.parametrize(
+        "relative",
+        [
+            "sub/.env.example",
+            "sub/.env.sample",
+            "sub/.env.template",
+            "sub/.ENV.EXAMPLE",
+            "sub/.Env.Sample",
+        ],
+    )
+    def test_committed_templates_remain_reachable(self, fake_project, relative):
+        """Committed dotenv templates stay readable (#14081 follow-up, kept by #14125)."""
+        target = str(self._make(fake_project["project"], relative))
+
+        assert fs_mcp.is_path_allowed(target) is True
+        assert str(fs_mcp._resolve_allowed_path(target)) == str(Path(target).resolve())
+
+    def test_gitignore_and_github_are_not_swept_up_by_case_folding(self, fake_project):
+        """Case-folding must not widen ``.git`` into a prefix match (#14125).
+
+        ``.git`` is an exact component match, so ``.gitignore``, ``.GITHUB/``
+        and ``.gitattributes`` stay reachable. Without this, "fail closed"
+        would quietly become "refuse the repository's own metadata files".
+        """
+        for relative in (".gitignore", ".gitattributes", ".GITHUB/workflows/ci.yml"):
+            target = str(self._make(fake_project["project"], relative))
+            assert fs_mcp.is_path_allowed(target) is True, relative
+
+
 @pytest.fixture
 def client():
     """TestClient over a minimal app mounting the real filesystem_mcp router.


### PR DESCRIPTION
Closes #14125

## Thinking Path

Two independent matching defects in `_is_excluded_path`, both bypasses of an exclusion #14081 already intended to enforce.

**1. The template allowlist short-circuited the component scan.** The check was `resolved.name not in _ENV_TEMPLATE_ALLOWLIST and any(fnmatch(part, ".env*") for part in resolved.parts)`. When the *leaf* was a known template name the `and` short-circuited, and the component scan over the rest of the path never ran — so a directory named `.env` or `.envs` became traversable as long as the file inside it happened to be called `.env.example`. The intent (templates are safe, real env files are not) is right; it was applied to the whole path instead of to the leaf. A directory is never a template, so every non-leaf component is now denied unconditionally and the allowlist applies to `parts[-1]` only.

**2. Matching was case-sensitive.** `fnmatch` normalizes case via `os.path.normcase`, which is identity on POSIX, and `".git" in resolved.parts` is a plain string compare. `.GIT/config`, `.ENV`, `.Env` and `.Git` all walked through. On a case-insensitive mount — WSL DrvFs, macOS, an SMB share — those resolve to the **real** `.git` and `.env`, so the exclusion was bypassable by changing the case of the request. Every comparison now runs on case-folded components. Refusing the odd-cased names on a case-sensitive filesystem too is the fail-closed direction and costs nothing real.

Case-folding also extends the template allowlist to `.ENV.EXAMPLE` rather than trapping it, which keeps #14081's review follow-up intact.

## What Changed

- `autobot-backend/api/filesystem_mcp.py` — `_is_excluded_path` compares case-folded components; the `.env*` denylist runs unconditionally over `parts[:-1]`; the allowlist is consulted for the leaf only.
- `autobot-backend/tests/api/test_filesystem_mcp_exclusions.py` — new `TestEnvMatchingDefects` covering both defects plus the two ways a fix could over-correct.

`.git` remains an **exact** component match, so `.gitignore`, `.gitattributes` and `.GITHUB/` stay reachable — case-folding must not widen it into a prefix match, and that is asserted.

## Verification

Pushed as a **red baseline**: commit `de398396d` is tests-only, commit `072e8070d` is the fix. CI on the first commit shows the assertions failing against the current implementation; CI on the second shows them passing. That is the before/after, rather than a claim that the tests would have failed.

The suite deliberately pins both directions. Denying every `.env*` leaf would satisfy every bypass assertion while silently reverting #14081's allowlist, so the committed templates are asserted still reachable; an over-corrected component scan would look identical to a correct fix if only the two bypass rows were tested, so the three rows that already behaved correctly are pinned too.

All assertions run the real, unmodified `is_path_allowed` / `_resolve_allowed_path` — never a hand-rolled restatement of the predicate.

## Model Used

Opus 5