### PR TITLE
tech-debt(chat): bound the output tee and keep the host path out of model context

### DIFF
--- a/autobot-backend/services/tool_output_filter.py
+++ b/autobot-backend/services/tool_output_filter.py
@@ -19,6 +19,7 @@ import hashlib
 import json
 import os
 import re
+import time
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 
@@ -29,8 +30,18 @@ from autobot_shared.logging_manager import get_logger
 logger = get_logger(__name__)
 
 _DEFAULT_CONFIG = os.path.join(os.path.dirname(__file__), "..", "config", "tool_output_filters.yaml")
-_TEE_DIR = Path.home() / ".local" / "share" / "autobot" / "tee"
+# ``Path("")`` is ``Path(".")`` and therefore truthy, so an unset or empty
+# AUTOBOT_TEE_DIR must be tested on the string, never on the Path.
+_TEE_DIR_ENV = os.environ.get("AUTOBOT_TEE_DIR", "").strip()
+_TEE_DIR = Path(_TEE_DIR_ENV) if _TEE_DIR_ENV else Path.home() / ".local" / "share" / "autobot" / "tee"
 _MAX_UNMATCHED_OUTPUT_CHARS = int(os.environ.get("AUTOBOT_MAX_UNMATCHED_OUTPUT_CHARS", "20000"))
+# #14142: nothing pruned this directory. Every oversized output accumulated
+# indefinitely, keyed by content hash. Until #14120 only shell stdout reached
+# it; that change carries web-tool content down the same path, and a crawl or
+# scrape result routinely exceeds the cap -- so third-party page content was
+# being persisted without bound and without expiry.
+_TEE_RETENTION_HOURS = int(os.environ.get("AUTOBOT_TEE_RETENTION_HOURS", "168"))
+_TEE_MAX_TOTAL_BYTES = int(os.environ.get("AUTOBOT_TEE_MAX_TOTAL_MB", "256")) * 1024 * 1024
 _NO_OP_PATTERNS = re.compile(
     r"(Everything up-to-date|nothing to commit|Already up to date|" r"no changes added|working tree clean)",
     re.IGNORECASE,
@@ -252,6 +263,69 @@ def filter_by_blocks(output: str, handler: BlockHandler, exit_code: int = 0) -> 
     return "\n".join(result)
 
 
+def _tee_entries() -> list[tuple[float, int, Path]]:
+    """Return ``(mtime, size, path)`` for every tee file, oldest first."""
+    entries: list[tuple[float, int, Path]] = []
+    for path in _TEE_DIR.glob("*.txt"):
+        try:
+            stat = path.stat()
+        except OSError:
+            continue  # vanished between glob and stat -- another prune, or a cleanup
+        entries.append((stat.st_mtime, stat.st_size, path))
+    entries.sort()
+    return entries
+
+
+def _prune_tee_dir(keep: Path | None = None) -> None:
+    """Enforce the retention window and the total-size ceiling (#14142).
+
+    Age first, then size, because an age sweep is what keeps the common case
+    bounded; the size ceiling is the backstop for a burst that outruns it.
+    Both knobs come from module-level constants sourced from env vars, and a
+    non-positive value disables that half deliberately.
+
+    *keep* is never deleted. The caller has just written it and returned a
+    hint pointing at it, so a sweep that removed it would hand the model a
+    pointer to a file that no longer exists -- and a single output larger
+    than the whole ceiling would do exactly that, since the sweep runs
+    oldest-first and the new file is last.
+    """
+    entries = [entry for entry in _tee_entries() if keep is None or entry[2] != keep]
+    if _TEE_RETENTION_HOURS > 0:
+        cutoff = time.time() - _TEE_RETENTION_HOURS * 3600
+        survivors = []
+        for mtime, size, path in entries:
+            if mtime < cutoff:
+                path.unlink(missing_ok=True)
+            else:
+                survivors.append((mtime, size, path))
+        entries = survivors
+    if _TEE_MAX_TOTAL_BYTES <= 0:
+        return
+    total = sum(size for _, size, _ in entries)
+    for _, size, path in entries:  # oldest first
+        if total <= _TEE_MAX_TOTAL_BYTES:
+            return
+        path.unlink(missing_ok=True)
+        total -= size
+
+
+def _tee_hint_path(tee_path: Path) -> str:
+    """Render *tee_path* for the model's prompt without an absolute host path.
+
+    #14142: the hint used to carry the real filesystem path straight into
+    model context, where it can be echoed into a reply, a log or an artifact.
+    Under the operator's home directory it becomes a ``~``-relative path --
+    still shell-expandable, so the pointer stays usable, but carrying no
+    account name and no host layout. Anywhere else only the basename is
+    disclosed.
+    """
+    try:
+        return f"~/{tee_path.relative_to(Path.home())}"
+    except ValueError:
+        return tee_path.name
+
+
 def tee_and_hint(raw: str, slug: str, exit_code: int, mode: str = "failures") -> str | None:
     """
     Save *raw* output to a tee file; return a read-path hint or None on error.
@@ -267,9 +341,16 @@ def tee_and_hint(raw: str, slug: str, exit_code: int, mode: str = "failures") ->
         _TEE_DIR.mkdir(parents=True, exist_ok=True)
         tee_path = _TEE_DIR / filename
         tee_path.write_text(raw, encoding="utf-8")
-        return f"[full output saved: {tee_path}]"
     except Exception:
         return None
+    # Pruning runs after the write, never before: a prune failure must not cost
+    # the caller the tee file it just asked for, and the new file is the one
+    # entry that must survive its own sweep.
+    try:
+        _prune_tee_dir(keep=tee_path)
+    except Exception:
+        logger.warning("tee retention sweep failed; the tee directory may be over its ceiling", exc_info=True)
+    return f"[full output saved: {_tee_hint_path(tee_path)}]"
 
 
 def _hard_cap(command: str, text: str, raw: str, exit_code: int) -> str:

--- a/autobot-backend/tests/services/test_tool_output_filter.py
+++ b/autobot-backend/tests/services/test_tool_output_filter.py
@@ -6,6 +6,8 @@
 
 import os
 import tempfile
+import time
+from pathlib import Path
 
 import yaml
 
@@ -890,3 +892,163 @@ def test_matched_rule_path_bypasses_the_cap(tmp_path, monkeypatch):
     result = filt.filter("run", "\n".join(str(n) for n in range(6)))
     assert "4\n5" in result
     assert "lines omitted" in result
+
+
+# ---------------------------------------------------------------------------
+# #14142 -- tee retention and the host path in the prompt hint
+# ---------------------------------------------------------------------------
+
+
+def _tee(mod, raw: str, slug: str = "cmd") -> str | None:
+    """Call the real ``tee_and_hint`` (never a restatement of its logic)."""
+    return mod.tee_and_hint(raw, slug, 0)
+
+
+def test_tee_hint_carries_no_absolute_host_path(tmp_path, monkeypatch):
+    """The prompt hint must not put the real filesystem path into model context.
+
+    An absolute path in the hint crosses into the model's context, where it
+    can be echoed into a reply, a log or an artifact. Under the operator's
+    home directory the pointer stays usable as a ``~``-relative path while
+    disclosing neither the account name nor the host layout.
+    """
+    import services.tool_output_filter as mod
+
+    home = tmp_path / "home"
+    tee_dir = home / ".local" / "share" / "autobot" / "tee"
+    monkeypatch.setattr(mod.Path, "home", staticmethod(lambda: home))
+    monkeypatch.setattr(mod, "_TEE_DIR", tee_dir)
+
+    hint = _tee(mod, "x" * 900)
+
+    assert hint is not None
+    assert str(home) not in hint, f"absolute host path leaked into the prompt: {hint}"
+    assert hint.startswith("[full output saved: ~/"), hint
+    # Still a real, resolvable pointer -- a hint nobody can follow is not a fix.
+    written = tee_dir / hint.split("~/")[1].rstrip("]").split("/")[-1]
+    assert written.exists()
+
+
+def test_tee_hint_outside_home_discloses_only_the_basename(tmp_path, monkeypatch):
+    """A tee dir outside the home directory cannot be made ``~``-relative."""
+    import services.tool_output_filter as mod
+
+    monkeypatch.setattr(mod.Path, "home", staticmethod(lambda: tmp_path / "elsewhere"))
+    monkeypatch.setattr(mod, "_TEE_DIR", tmp_path / "spool")
+
+    hint = _tee(mod, "y" * 900)
+
+    assert hint is not None
+    assert str(tmp_path) not in hint, hint
+    assert hint.endswith(".txt]"), hint
+
+
+def test_tee_dir_is_pruned_past_the_retention_window(tmp_path, monkeypatch):
+    """Files older than the retention window are removed on the next write."""
+    import os
+
+    import services.tool_output_filter as mod
+
+    monkeypatch.setattr(mod, "_TEE_DIR", tmp_path)
+    monkeypatch.setattr(mod, "_TEE_RETENTION_HOURS", 1)
+    monkeypatch.setattr(mod, "_TEE_MAX_TOTAL_BYTES", 0)  # size half off: age only
+
+    stale = tmp_path / "stale.deadbeef.txt"
+    stale.write_text("old", encoding="utf-8")
+    old = time.time() - 2 * 3600
+    os.utime(stale, (old, old))
+    fresh = tmp_path / "fresh.cafebabe.txt"
+    fresh.write_text("new", encoding="utf-8")
+
+    _tee(mod, "z" * 900)
+
+    assert not stale.exists(), "a file past the retention window survived the sweep"
+    assert fresh.exists(), "a file inside the retention window was swept"
+
+
+def test_tee_dir_is_pruned_oldest_first_past_the_size_ceiling(tmp_path, monkeypatch):
+    """The total-size ceiling evicts oldest-first once the window alone is not enough."""
+    import os
+
+    import services.tool_output_filter as mod
+
+    monkeypatch.setattr(mod, "_TEE_DIR", tmp_path)
+    monkeypatch.setattr(mod, "_TEE_RETENTION_HOURS", 0)  # age half off: size only
+    monkeypatch.setattr(mod, "_TEE_MAX_TOTAL_BYTES", 2000)
+
+    for index, name in enumerate(("oldest", "middle", "newest")):
+        path = tmp_path / f"{name}.0000000{index}.txt"
+        path.write_text("q" * 900, encoding="utf-8")
+        stamp = time.time() - (10 - index) * 60
+        os.utime(path, (stamp, stamp))
+
+    _tee(mod, "w" * 900)
+
+    assert not (tmp_path / "oldest.00000000.txt").exists(), "the ceiling did not evict"
+    assert (tmp_path / "newest.00000002.txt").exists(), "eviction was not oldest-first"
+
+
+def test_the_file_just_written_survives_its_own_sweep(tmp_path, monkeypatch):
+    """A single output larger than the whole ceiling must not delete itself.
+
+    The sweep runs oldest-first and the new file is last, so without an
+    explicit exemption the hint would point at a file the same call had
+    already removed -- a pointer to nothing, which reads exactly like a
+    working hint until someone follows it.
+    """
+    import services.tool_output_filter as mod
+
+    monkeypatch.setattr(mod, "_TEE_DIR", tmp_path)
+    monkeypatch.setattr(mod, "_TEE_RETENTION_HOURS", 0)
+    monkeypatch.setattr(mod, "_TEE_MAX_TOTAL_BYTES", 100)  # smaller than the payload
+
+    hint = _tee(mod, "b" * 5000)
+
+    assert hint is not None
+    survivors = list(tmp_path.glob("*.txt"))
+    assert len(survivors) == 1, f"expected the new file to survive, found {survivors}"
+    assert survivors[0].read_text(encoding="utf-8") == "b" * 5000
+
+
+def test_retention_knobs_come_from_env_vars(monkeypatch):
+    """Both bounds are configurable without a code change (repo convention)."""
+    import importlib
+
+    monkeypatch.setenv("AUTOBOT_TEE_RETENTION_HOURS", "3")
+    monkeypatch.setenv("AUTOBOT_TEE_MAX_TOTAL_MB", "7")
+    monkeypatch.setenv("AUTOBOT_TEE_DIR", "/tmp/autobot-tee-envtest")
+
+    import services.tool_output_filter as mod
+
+    reloaded = importlib.reload(mod)
+    try:
+        assert reloaded._TEE_RETENTION_HOURS == 3
+        assert reloaded._TEE_MAX_TOTAL_BYTES == 7 * 1024 * 1024
+        assert str(reloaded._TEE_DIR) == "/tmp/autobot-tee-envtest"
+    finally:
+        monkeypatch.delenv("AUTOBOT_TEE_RETENTION_HOURS")
+        monkeypatch.delenv("AUTOBOT_TEE_MAX_TOTAL_MB")
+        monkeypatch.delenv("AUTOBOT_TEE_DIR")
+        importlib.reload(mod)
+
+
+def test_empty_tee_dir_env_var_falls_back_to_the_default(monkeypatch):
+    """``Path("")`` is ``Path(".")`` and truthy -- an empty value must not win.
+
+    Tested because the obvious ``Path(os.environ.get(...)) or <default>``
+    spelling silently redirects every tee file into the process's working
+    directory instead of falling back.
+    """
+    import importlib
+
+    monkeypatch.setenv("AUTOBOT_TEE_DIR", "   ")
+
+    import services.tool_output_filter as mod
+
+    reloaded = importlib.reload(mod)
+    try:
+        assert reloaded._TEE_DIR != Path("."), "an empty env var redirected the tee dir to CWD"
+        assert reloaded._TEE_DIR.name == "tee"
+    finally:
+        monkeypatch.delenv("AUTOBOT_TEE_DIR")
+        importlib.reload(mod)

--- a/autobot-backend/tests/services/test_tool_output_filter.py
+++ b/autobot-backend/tests/services/test_tool_output_filter.py
@@ -866,7 +866,13 @@ def test_cap_tees_full_copy_and_links_it(tmp_path, monkeypatch):
     teed = list(tmp_path.glob("*.txt"))
     assert len(teed) == 1
     assert teed[0].read_text(encoding="utf-8") == oversized
-    assert str(teed[0]) in result
+    # #14142: the hint links the tee'd file by name, not by absolute path. The
+    # assertion here used to be `str(teed[0]) in result`, which passed only
+    # because the absolute host path was being written into model context --
+    # the defect. What this test is really for is that the cap tees a full copy
+    # and points at it, and that is what is asserted now.
+    assert teed[0].name in result
+    assert str(tmp_path) not in result, "the absolute host path is back in the prompt"
 
 
 def test_filter_applies_cap_when_no_rule_matches(tmp_path, monkeypatch):


### PR DESCRIPTION
Closes #14142

## Thinking Path

`tee_and_hint` did two things that were reasonable while only shell stdout reached it, and stopped being reasonable once #14120 widened the input.

**Unbounded growth.** Nothing pruned the tee directory. Every oversized output accumulated there indefinitely, keyed by content hash — so content-hash keying deduplicates repeats but does nothing about volume. Since #14120, web-tool content travels the same path and a crawl or scrape result routinely exceeds the cap, which means third-party page content was being persisted to disk with no bound and no expiry.

**An absolute host path in the prompt.** The hint embedded the real filesystem path in the text handed to the model, where it can be echoed into a reply, a log, or an artifact.

## What Changed

`autobot-backend/services/tool_output_filter.py`:

- Three env-var-backed module constants, per the repo's TTL convention: `AUTOBOT_TEE_DIR`, `AUTOBOT_TEE_RETENTION_HOURS` (default 168 — seven days), `AUTOBOT_TEE_MAX_TOTAL_MB` (default 256).
- `_prune_tee_dir()` sweeps age first, then total size oldest-first. A non-positive value disables that half deliberately, so either bound can be turned off without turning off the other.
- `_tee_hint_path()` renders the pointer as `~/…` when the tee directory sits under the operator's home, and as a bare basename otherwise. Still shell-expandable, so the pointer remains usable; it just carries no account name and no host layout.

Two ordering details that are load-bearing rather than incidental:

- The sweep runs **after** the write, so a prune failure never costs the caller the file it just asked for. A failed sweep logs a warning instead of propagating — the tee is a convenience, not the result.
- The just-written file is **exempt** from the sweep. Without that, an output larger than the whole ceiling would be deleted by its own call (the sweep is oldest-first and the new file is last), and the hint would point at a file that no longer exists — which reads exactly like a working hint until someone follows it.

## Decision

#14142's third acceptance criterion asks for a recorded decision on whether non-shell tool output should be tee'd at all, or whether the existing spill anchors (#13692, #13919) cover it.

**Decision: keep teeing non-shell output, now that it is bounded.** The spill anchors solve a different problem — they keep large content out of the prompt while leaving it retrievable through the anchor mechanism. The tee is the terminal guard at `_hard_cap`, and it fires on the path where output has *already* bypassed every earlier reduction. Removing it there would mean the truncated middle of an oversized result is simply gone. The objection in the issue was the absence of a bound, not the teeing itself, and that is what this PR fixes. Reversible in either direction: `AUTOBOT_TEE_MAX_TOTAL_MB=0` with a short retention window effectively disables it without a code change.

Existing shell behaviour is unchanged apart from the hint's rendering.

## Verification

Seven tests added to `autobot-backend/tests/services/test_tool_output_filter.py`, all driving the real `tee_and_hint` rather than a restatement of its logic:

- the hint contains no absolute host path, and the file it names actually exists (a hint nobody can follow is not a fix)
- a tee directory outside the home directory falls back to the basename
- age sweep with the size ceiling disabled: stale removed, fresh kept
- size ceiling with the age sweep disabled: eviction happens and is oldest-first
- an output larger than the entire ceiling survives its own sweep
- all three knobs read from env vars
- an **empty** `AUTOBOT_TEE_DIR` falls back to the default — `Path("")` is `Path(".")` and therefore truthy, so the obvious `Path(os.environ.get(...)) or <default>` spelling silently redirects every tee file into the process's working directory instead of falling back. That spelling was written and caught here, which is why it has a test.

Note for reviewers: the check named **Unit & Integration Tests** is a frontend required-context stub and reports success without running any Python. The real verdict is the twelve `python-suite` shards under `AutoBot CI/CD Pipeline`, which is not a required context.

## Model Used

Opus 5