### PR TITLE
test(chat): assert the exit-code invariant at its producer, not at a restated fixture

### DIFF
--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -920,6 +920,17 @@ def _create_execution_result(command: str, host: str, result: dict[str, Any], ap
     # the model as having succeeded, with stderr as the only hint — and a test
     # runner writes its failure report to *stdout*, so the model saw a
     # full-looking report under "success" and no signal that the suite failed.
+    #
+    # Reachability, so nobody mistakes this for the protection: both call sites
+    # are gated on ``status == "success"`` upstream (`_handle_approved_command`
+    # at the approval branch, `_handle_successful_command` in
+    # `_dispatch_command_by_status`), so this mapping cannot currently observe a
+    # non-zero code. It is kept as a correct restatement of the invariant for
+    # the day a caller stops gating -- not deleted, because a dict feeding the
+    # model's prompt with a hardcoded "success" is exactly the defect that got
+    # filed. The single *reachable* decision is
+    # `command_executor._build_pty_result`, which every layer here propagates
+    # rather than re-derives; that is where the invariant is asserted.
     return_code = result.get("return_code", 0)
     return {
         "command": command,

--- a/autobot-backend/tests/unit/chat_workflow/test_failing_command_does_not_crash_the_turn.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_failing_command_does_not_crash_the_turn.py
@@ -130,9 +130,7 @@ class TestTheRealBoundaryFromPtyResultToPrompt:
         Those two facts are why the old fallback chain always degraded to its
         literal, and why a hand-built dict with an `error` key hid the bug.
         """
-        return CommandExecutor._build_pty_result(
-            CommandExecutor.__new__(CommandExecutor), stdout, return_code
-        )
+        return CommandExecutor._build_pty_result(CommandExecutor.__new__(CommandExecutor), stdout, return_code)
 
     def test_the_producer_still_derives_status_from_the_exit_code(self):
         """The invariant #14141 is really about, asserted at its origin.

--- a/autobot-backend/tests/unit/chat_workflow/test_failing_command_does_not_crash_the_turn.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_failing_command_does_not_crash_the_turn.py
@@ -30,6 +30,7 @@ would leave the others a refactor away from reintroducing it.
 import pytest
 
 from chat_workflow.tool_handler import ToolHandlerMixin
+from services.agent_terminal.command_executor import CommandExecutor
 from tools.terminal_tool import TerminalTool
 
 
@@ -115,18 +116,41 @@ class TestTheRealBoundaryFromPtyResultToPrompt:
 
     @staticmethod
     def _pty_result(return_code: int, stdout: str) -> dict:
-        """Exactly what `command_executor._build_pty_result` emits.
+        """Whatever `command_executor._build_pty_result` emits -- by calling it.
 
-        Note `stderr: ""` and no `error` key — the PTY combines the streams.
+        #14141 round 4: this used to be a hand-written restatement whose
+        docstring claimed it was "exactly what `_build_pty_result` emits". A
+        restatement is only true on the day it is written; the producer can
+        rename a key, stop setting one, or start setting `error`, and every
+        assertion downstream keeps passing against a shape nothing produces.
+        That is the same defect rounds 1 and 2 failed on, one layer further
+        out -- so the producer is called instead of described.
+
+        Note `stderr: ""` and no `error` key -- the PTY combines the streams.
         Those two facts are why the old fallback chain always degraded to its
         literal, and why a hand-built dict with an `error` key hid the bug.
         """
-        return {
-            "status": "success" if return_code == 0 else "error",
-            "stdout": stdout,
-            "stderr": "",
-            "return_code": return_code,
-        }
+        return CommandExecutor._build_pty_result(
+            CommandExecutor.__new__(CommandExecutor), stdout, return_code
+        )
+
+    def test_the_producer_still_derives_status_from_the_exit_code(self):
+        """The invariant #14141 is really about, asserted at its origin.
+
+        `_create_execution_result` also maps an exit code to a status, but both
+        of its call sites are gated on ``status == "success"`` upstream, so that
+        mapping is unreachable and cannot be what protects this. The single
+        reachable decision is here, in the producer: everything downstream --
+        `_format_execution_result`'s branch, `_dispatch_command_by_status`'s
+        routing, and the ``Status:`` line the model reads -- propagates it
+        rather than re-deriving it. If this line ever reports success for a
+        non-zero exit, every one of those layers reports success too.
+        """
+        assert self._pty_result(0, "ok")["status"] == "success"
+        for code in (1, 2, 127, 139, 255):
+            result = self._pty_result(code, "output")
+            assert result["status"] == "error", f"exit {code} was reported to the model as success"
+            assert result["return_code"] == code
 
     @pytest.mark.asyncio
     async def test_a_failing_runners_report_survives_the_whole_chain(self):


### PR DESCRIPTION
Closes #14141

## Thinking Path

#14141 reported that `_create_execution_result` hardcoded `"status": "success"` regardless of `return_code`, so a failing command reached the model's continuation prompt as `Status: success`. PR #14147 replaced the literal with `_status_for_return_code(...)` — and then found, during review, that both call sites are gated on `status == "success"` upstream, so the mapping it had just fixed could never observe a non-zero code. The fix was correct and unreachable. It shipped as `Refs #14141`, not `Closes`, which is why this issue is still open.

So the question this PR had to answer first was not "is the literal gone" but **"is there any reachable path that reports a non-zero exit as success"**. Tracing it end to end:

| layer | what it does with status |
|---|---|
| `command_executor._build_pty_result:516` | **derives** it: `"success" if return_code == 0 else "error"` |
| `terminal_tool._format_execution_result:181` | branches on the status it was given; propagates |
| `tool_handler._dispatch_command_by_status:2015` | routes `success` → `_handle_successful_command`, `error` → `_handle_command_error` |
| `manager._format_execution_step:1925` | prints `- Status: {status}` |
| `tool_handler._create_execution_result:930` | derives it again — but only ever runs on the `success` branch |

Exactly one layer decides; the rest carry. The reported defect does not exist on any reachable path, and #14148's work made the failure branch carry its outcome fields so the report itself arrives too.

## What Changed

Two things, both about making that conclusion checkable rather than argued.

**The chain test's fixture now calls the producer instead of describing it.** `_pty_result` was a hand-written dict whose docstring claimed it was "exactly what `_build_pty_result` emits". A restatement is only true on the day it is written — the producer can rename a key, stop setting one, or start setting `error`, and every assertion downstream keeps passing against a shape nothing produces. That is precisely how rounds 1 and 2 of this issue went wrong, one layer further out. It now calls `CommandExecutor._build_pty_result` directly.

**A test asserts the invariant at the single reachable decision.** `test_the_producer_still_derives_status_from_the_exit_code` pins exit 0 → `success` and 1/2/127/139/255 → `error` with the code preserved. If that line ever reports success for a non-zero exit, every layer downstream reports success too — which is the failure mode the issue describes, stated once at its origin instead of re-tested at each layer.

**`_create_execution_result` keeps its derivation**, now with its reachability written down so nobody mistakes it for the protection. It is a correct restatement of the invariant for the day a caller stops gating, and it is not deleted: a dict feeding the model's prompt with a hardcoded `"success"` is exactly what got filed in the first place.

## Verification

The invariant test fails if `_build_pty_result:516` is mutated to return a constant `"success"` — that is the mutation the whole issue is about, and no test caught it before, because the previous coverage asserted the *rendered instance* (`"Status: error" in rendered`) against a fixture that had already hardcoded the answer.

Note for reviewers: the check named **Unit & Integration Tests** is a frontend required-context stub and reports success without running any Python. The real verdict is the twelve `python-suite` shards under `AutoBot CI/CD Pipeline`, which is not a required context.

## Model Used

Opus 5