### PR TITLE
security(threat-detection): replace pickle profile storage with schema-validated JSON (#14159)

### DIFF
--- a/autobot-backend/api/filesystem_mcp.py
+++ b/autobot-backend/api/filesystem_mcp.py
@@ -232,10 +232,13 @@ MAX_FILE_SIZE = 10 * 1024 * 1024
 # and material that other subsystems write under the same data directory
 # without going through the secrets manager at all -- the SSO/SAML signing
 # key (security/enterprise/sso_integration.py) and, sharpest of all, a
-# *pickle* the threat-detection engine loads with pickle.load()
-# (security/enterprise/threat_detection/engine.py) -- a bridge write there is
-# arbitrary code execution, not disclosure. A filename denylist can't keep
-# up with sidecars, backups, and subsystems that don't exist yet.
+# threat-detection profile store
+# (security/enterprise/threat_detection/engine.py). That store was a pickle
+# until #14159, so a bridge write there was arbitrary code execution rather
+# than mere disclosure; it is schema-validated JSON now, and this exclusion
+# covers both it and the legacy .pkl deliberately left on disk. A filename
+# denylist can't keep up with sidecars, backups, and subsystems that don't
+# exist yet.
 #
 # No production code path needs this LLM-facing bridge to reach anything
 # under the data directory: application state goes through purpose-built

--- a/autobot-backend/security/enterprise/threat_detection/engine.py
+++ b/autobot-backend/security/enterprise/threat_detection/engine.py
@@ -12,7 +12,7 @@ Issue #378: Added threading locks for file operations to prevent race conditions
 """
 
 import asyncio
-import pickle  # nosec B403  # internal profile storage only
+import json
 import threading
 from collections import defaultdict, deque
 from datetime import timedelta
@@ -88,9 +88,16 @@ class ThreatDetectionEngine:
         self.clustering_model = DBSCAN(eps=0.5, min_samples=5)
 
     def _initialize_profile_storage(self) -> None:
-        """Initialize user profile storage paths. Issue #620."""
+        """Initialize user profile storage paths. Issue #620.
+
+        Issue #14159: storage moved from pickle to schema-validated JSON.
+        ``_legacy_profile_storage_path`` is the old ``.pkl`` location -- kept
+        only so ``_load_user_profiles`` can report it exists; it is never
+        read or deleted (no data loss on update).
+        """
         self.user_profiles: Dict[str, UserProfile] = {}
-        self.profile_storage_path = PATH.get_data_path("security", "user_profiles.pkl")
+        self.profile_storage_path = PATH.get_data_path("security", "user_profiles.json")
+        self._legacy_profile_storage_path = PATH.get_data_path("security", "user_profiles.pkl")
         self.profile_storage_path.parent.mkdir(parents=True, exist_ok=True)
 
     def _initialize_threat_patterns(self) -> None:
@@ -307,24 +314,78 @@ class ThreatDetectionEngine:
         ]
 
     def _load_user_profiles(self):
-        """Load existing user behavioral profiles"""
+        """Load existing user behavioral profiles from the JSON store.
+
+        Issue #14159: the store previously round-tripped through
+        ``pickle.load()``, an arbitrary-code-execution sink reachable by any
+        writable path to the file. The profile store is a derived,
+        rebuildable behavioral cache -- never a system of record -- so this
+        reads ONLY the new JSON path. It deliberately does NOT migrate a
+        legacy ``.pkl`` file: doing so would keep the exact ``pickle.load()``
+        call this issue removes, just on a one-time code path. A legacy
+        ``.pkl`` left on disk is reported (filename only) and otherwise
+        ignored -- it is never read or deleted (no data loss on update).
+        """
+        if self._legacy_profile_storage_path.exists():
+            logger.info(
+                "Legacy pickle profile store found (%s); ignoring it -- profiles "
+                "rebuild from the JSON store instead of being migrated (#14159)",
+                self._legacy_profile_storage_path.name,
+            )
+
+        if not self.profile_storage_path.exists():
+            logger.info("No user profile store found; profiles will rebuild from scratch")
+            self.user_profiles = {}
+            return
+
         try:
-            if self.profile_storage_path.exists():
-                with open(self.profile_storage_path, "rb") as f:
-                    self.user_profiles = pickle.load(f)  # nosec B301
-                self.stats["users_monitored"] = len(self.user_profiles)
-                logger.info("Loaded %s user profiles", len(self.user_profiles))
-        except Exception as e:
+            with self._file_lock:
+                with open(self.profile_storage_path, "r", encoding="utf-8") as f:
+                    raw = json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
             logger.error("Failed to load user profiles: %s", e)
             self.user_profiles = {}
+            return
+
+        if not isinstance(raw, dict):
+            logger.error(
+                "User profile store is not a JSON object (got %s); starting with an empty profile set",
+                type(raw).__name__,
+            )
+            self.user_profiles = {}
+            return
+
+        profiles: Dict[str, UserProfile] = {}
+        for key, entry in raw.items():
+            profile = UserProfile.from_dict(entry)
+            if profile is None:
+                logger.warning("Dropping invalid user profile entry for key %s", key)
+                continue
+            profiles[profile.user_id] = profile
+
+        self.user_profiles = profiles
+        self.stats["users_monitored"] = len(self.user_profiles)
+        logger.info("Loaded %s user profiles", len(self.user_profiles))
 
     def _save_user_profiles(self):
-        """Save user behavioral profiles"""
-        try:
-            with open(self.profile_storage_path, "wb") as f:
-                pickle.dump(self.user_profiles, f)
-        except Exception as e:
-            logger.error("Failed to save user profiles: %s", e)
+        """Save user behavioral profiles as schema-validated JSON (#14159).
+
+        Writes to a temp file and renames it into place so a concurrent
+        reader never observes a partially-written file (`os.replace` is
+        atomic on the same filesystem). Wrapped in ``self._file_lock`` --
+        the same lock already used for config writes (#378) -- because the
+        periodic profile-update task and any future caller could otherwise
+        interleave writes to this file from different threads.
+        """
+        with self._file_lock:
+            try:
+                payload = {user_id: profile.to_dict() for user_id, profile in self.user_profiles.items()}
+                tmp_path = self.profile_storage_path.with_suffix(".json.tmp")
+                with open(tmp_path, "w", encoding="utf-8") as f:
+                    json.dump(payload, f)
+                tmp_path.replace(self.profile_storage_path)
+            except Exception as e:
+                logger.error("Failed to save user profiles: %s", e)
 
     def _start_background_tasks(self):
         """Start background monitoring and maintenance tasks"""

--- a/autobot-backend/security/enterprise/threat_detection/models.py
+++ b/autobot-backend/security/enterprise/threat_detection/models.py
@@ -10,6 +10,7 @@ Dataclasses for security events, threats, and user profiles.
 Part of Issue #381 - God Class Refactoring
 """
 
+import math
 import time
 from collections import deque
 from dataclasses import dataclass, field
@@ -258,6 +259,24 @@ class ThreatEvent:
     mitigation_actions: List[str]
 
 
+
+def _is_finite_number(value: object) -> bool:
+    """True for a real, finite int/float -- rejecting bool, NaN and Infinity.
+
+    Two traps in one predicate (#14159 review):
+
+    * ``isinstance(True, int)`` is ``True``, so a bare int check accepts
+      booleans and a profile can arrive with ``risk_score=True``.
+    * Python's ``json.load`` accepts the **non-standard** ``NaN`` /
+      ``Infinity`` / ``-Infinity`` tokens by default, and ``isinstance`` is
+      perfectly happy with the resulting floats. A ``NaN`` risk score makes
+      ``is_high_risk()`` (``risk_score > 0.7``) silently evaluate ``False``
+      forever -- a threat profile that can never be flagged -- and re-saving
+      re-emits the non-standard token, so the store stops being parseable by
+      a strict JSON reader.
+    """
+    return isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(value)
+
 @dataclass
 class UserProfile:
     """User behavioral profile for anomaly detection"""
@@ -331,13 +350,15 @@ class UserProfile:
             return None
 
         user_id = data.get("user_id")
-        if not isinstance(user_id, str) or not user_id:
+        # `.strip()` because a whitespace-only id is truthy and would key a
+        # profile nobody can look up (#14159 review).
+        if not isinstance(user_id, str) or not user_id.strip():
             logger.warning("Skipping user profile entry: missing or invalid user_id")
             return None
 
         baseline_actions = data.get("baseline_actions", {})
         if not isinstance(baseline_actions, dict) or not all(
-            isinstance(k, str) and isinstance(v, (int, float)) and not isinstance(v, bool)
+            isinstance(k, str) and _is_finite_number(v)
             for k, v in baseline_actions.items()
         ):
             logger.warning("Skipping user profile %s: invalid baseline_actions", user_id)
@@ -370,14 +391,14 @@ class UserProfile:
 
         api_usage_patterns = data.get("api_usage_patterns", {})
         if not isinstance(api_usage_patterns, dict) or not all(
-            isinstance(k, str) and isinstance(v, (int, float)) and not isinstance(v, bool)
+            isinstance(k, str) and _is_finite_number(v)
             for k, v in api_usage_patterns.items()
         ):
             logger.warning("Skipping user profile %s: invalid api_usage_patterns", user_id)
             return None
 
         risk_score = data.get("risk_score", 0.5)
-        if not isinstance(risk_score, (int, float)) or isinstance(risk_score, bool):
+        if not _is_finite_number(risk_score):
             logger.warning("Skipping user profile %s: invalid risk_score", user_id)
             return None
 

--- a/autobot-backend/security/enterprise/threat_detection/models.py
+++ b/autobot-backend/security/enterprise/threat_detection/models.py
@@ -16,9 +16,12 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from typing import Dict, List
 
+from autobot_shared.logging_manager import get_logger
 from autobot_shared.time_utils import now_utc, parse_utc_iso, utc_timestamp
 
 from .types import FILE_OPERATION_ACTIONS, ThreatCategory, ThreatLevel
+
+logger = get_logger(__name__)
 
 
 @dataclass
@@ -289,6 +292,113 @@ class UserProfile:
     def is_high_risk(self) -> bool:
         """Check if user is considered high risk"""
         return self.risk_score > 0.7
+
+    # === Issue #14159: JSON (de)serialization, replacing pickle ===
+
+    def to_dict(self) -> Dict:
+        """Serialize to a JSON-safe dict.
+
+        ``typical_ips`` is a ``set`` (JSON has no set type) so it is
+        serialized as a sorted list; ``from_dict`` restores it to a set.
+        ``last_updated`` is serialized as an ISO-8601 string.
+        """
+        return {
+            "user_id": self.user_id,
+            "baseline_actions": dict(self.baseline_actions),
+            "typical_hours": list(self.typical_hours),
+            "typical_ips": sorted(self.typical_ips),
+            "command_patterns": list(self.command_patterns),
+            "file_access_patterns": dict(self.file_access_patterns),
+            "api_usage_patterns": dict(self.api_usage_patterns),
+            "risk_score": self.risk_score,
+            "last_updated": self.last_updated.isoformat(),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict) -> "UserProfile | None":
+        """Build a ``UserProfile`` from a parsed-JSON dict, validating every field.
+
+        Returns ``None`` (and logs a warning) instead of raising when the
+        entry does not validate, so one corrupt or hand-edited profile
+        degrades to "that profile is dropped" -- never to "the process
+        dies" and never to "unvalidated data is trusted" (#14159).
+        """
+        if not isinstance(data, dict):
+            logger.warning(
+                "Skipping user profile entry: expected a JSON object, got %s",
+                type(data).__name__,
+            )
+            return None
+
+        user_id = data.get("user_id")
+        if not isinstance(user_id, str) or not user_id:
+            logger.warning("Skipping user profile entry: missing or invalid user_id")
+            return None
+
+        baseline_actions = data.get("baseline_actions", {})
+        if not isinstance(baseline_actions, dict) or not all(
+            isinstance(k, str) and isinstance(v, (int, float)) and not isinstance(v, bool)
+            for k, v in baseline_actions.items()
+        ):
+            logger.warning("Skipping user profile %s: invalid baseline_actions", user_id)
+            return None
+
+        typical_hours = data.get("typical_hours", [])
+        if not isinstance(typical_hours, list) or not all(
+            isinstance(h, int) and not isinstance(h, bool) for h in typical_hours
+        ):
+            logger.warning("Skipping user profile %s: invalid typical_hours", user_id)
+            return None
+
+        typical_ips = data.get("typical_ips", [])
+        if not isinstance(typical_ips, list) or not all(isinstance(ip, str) for ip in typical_ips):
+            logger.warning("Skipping user profile %s: invalid typical_ips", user_id)
+            return None
+
+        command_patterns = data.get("command_patterns", [])
+        if not isinstance(command_patterns, list) or not all(isinstance(c, str) for c in command_patterns):
+            logger.warning("Skipping user profile %s: invalid command_patterns", user_id)
+            return None
+
+        file_access_patterns = data.get("file_access_patterns", {})
+        if not isinstance(file_access_patterns, dict) or not all(
+            isinstance(k, str) and isinstance(v, int) and not isinstance(v, bool)
+            for k, v in file_access_patterns.items()
+        ):
+            logger.warning("Skipping user profile %s: invalid file_access_patterns", user_id)
+            return None
+
+        api_usage_patterns = data.get("api_usage_patterns", {})
+        if not isinstance(api_usage_patterns, dict) or not all(
+            isinstance(k, str) and isinstance(v, (int, float)) and not isinstance(v, bool)
+            for k, v in api_usage_patterns.items()
+        ):
+            logger.warning("Skipping user profile %s: invalid api_usage_patterns", user_id)
+            return None
+
+        risk_score = data.get("risk_score", 0.5)
+        if not isinstance(risk_score, (int, float)) or isinstance(risk_score, bool):
+            logger.warning("Skipping user profile %s: invalid risk_score", user_id)
+            return None
+
+        last_updated_raw = data.get("last_updated")
+        try:
+            last_updated = parse_utc_iso(last_updated_raw) if last_updated_raw is not None else now_utc()
+        except (TypeError, ValueError) as exc:
+            logger.warning("Skipping user profile %s: invalid last_updated (%s)", user_id, exc)
+            return None
+
+        return cls(
+            user_id=user_id,
+            baseline_actions=dict(baseline_actions),
+            typical_hours=list(typical_hours),
+            typical_ips=set(typical_ips),
+            command_patterns=list(command_patterns),
+            file_access_patterns=dict(file_access_patterns),
+            api_usage_patterns=dict(api_usage_patterns),
+            risk_score=float(risk_score),
+            last_updated=last_updated,
+        )
 
     # === Issue #372: Feature Envy Reduction Methods ===
 

--- a/autobot-backend/security/enterprise/threat_detection/models.py
+++ b/autobot-backend/security/enterprise/threat_detection/models.py
@@ -259,7 +259,6 @@ class ThreatEvent:
     mitigation_actions: List[str]
 
 
-
 def _is_finite_number(value: object) -> bool:
     """True for a real, finite int/float -- rejecting bool, NaN and Infinity.
 
@@ -276,6 +275,7 @@ def _is_finite_number(value: object) -> bool:
       a strict JSON reader.
     """
     return isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(value)
+
 
 @dataclass
 class UserProfile:
@@ -358,8 +358,7 @@ class UserProfile:
 
         baseline_actions = data.get("baseline_actions", {})
         if not isinstance(baseline_actions, dict) or not all(
-            isinstance(k, str) and _is_finite_number(v)
-            for k, v in baseline_actions.items()
+            isinstance(k, str) and _is_finite_number(v) for k, v in baseline_actions.items()
         ):
             logger.warning("Skipping user profile %s: invalid baseline_actions", user_id)
             return None
@@ -391,8 +390,7 @@ class UserProfile:
 
         api_usage_patterns = data.get("api_usage_patterns", {})
         if not isinstance(api_usage_patterns, dict) or not all(
-            isinstance(k, str) and _is_finite_number(v)
-            for k, v in api_usage_patterns.items()
+            isinstance(k, str) and _is_finite_number(v) for k, v in api_usage_patterns.items()
         ):
             logger.warning("Skipping user profile %s: invalid api_usage_patterns", user_id)
             return None

--- a/autobot-backend/security/threat_detection_refactor_test.py
+++ b/autobot-backend/security/threat_detection_refactor_test.py
@@ -819,3 +819,62 @@ class TestThreatDetectionEngineProfileStorageJson:
         restored = engine.user_profiles["erin"]
         assert restored.typical_ips == {"192.168.0.1"}
         assert restored.risk_score == pytest.approx(0.9)
+
+
+# --- #14159 review follow-ups -------------------------------------------------
+
+
+def _profile_payload(**overrides):
+    """A minimal valid to_dict() payload, with fields overridden per test."""
+    from security.enterprise.threat_detection.models import UserProfile
+
+    payload = UserProfile(user_id="u1").to_dict()
+    payload.update(overrides)
+    return payload
+
+
+@pytest.mark.parametrize("token", ["NaN", "Infinity", "-Infinity"])
+def test_a_non_finite_risk_score_is_rejected(token):
+    """`json.load` accepts NaN/Infinity by default; the validator must not.
+
+    A NaN risk score makes `is_high_risk()` (`risk_score > 0.7`) evaluate
+    False forever -- a profile that can never be flagged -- and re-saving
+    re-emits the non-standard token, so the store stops being readable by a
+    strict JSON parser. `isinstance(x, float)` is True for NaN, so the type
+    check alone does not catch it.
+    """
+    import json
+
+    from security.enterprise.threat_detection.models import UserProfile
+
+    raw = json.loads('{"user_id": "u1", "risk_score": %s}' % token)
+    assert isinstance(raw["risk_score"], float), "precondition: json parsed it as a float"
+
+    assert UserProfile.from_dict(_profile_payload(risk_score=raw["risk_score"])) is None
+
+
+@pytest.mark.parametrize("field_name", ["baseline_actions", "api_usage_patterns"])
+def test_a_non_finite_metric_value_is_rejected(field_name):
+    """Same trap, in the two float-valued mappings."""
+    import json
+
+    from security.enterprise.threat_detection.models import UserProfile
+
+    nan = json.loads("NaN")
+    assert UserProfile.from_dict(_profile_payload(**{field_name: {"a": nan}})) is None
+
+
+def test_a_whitespace_only_user_id_is_rejected():
+    """A non-empty string is truthy, so `not user_id` lets `"   "` through."""
+    from security.enterprise.threat_detection.models import UserProfile
+
+    assert UserProfile.from_dict(_profile_payload(user_id="   ")) is None
+
+
+def test_a_finite_risk_score_still_loads():
+    """The rejections above must not take ordinary values with them."""
+    from security.enterprise.threat_detection.models import UserProfile
+
+    profile = UserProfile.from_dict(_profile_payload(risk_score=0.9))
+    assert profile is not None and profile.risk_score == 0.9
+    assert profile.is_high_risk()

--- a/autobot-backend/security/threat_detection_refactor_test.py
+++ b/autobot-backend/security/threat_detection_refactor_test.py
@@ -7,6 +7,7 @@ Test suite for threat_detection.py refactoring
 Verifies backward compatibility and Feature Envy fixes
 """
 
+import json
 import tempfile
 from collections import deque
 from datetime import datetime, timedelta
@@ -19,6 +20,7 @@ import pytest
 pytest.importorskip("sklearn", reason="scikit-learn not installed — optional ML dep")
 
 from autobot_shared.time_utils import now_utc, utc_timestamp  # noqa: E402
+from constants.path_constants import PathConstants  # noqa: E402
 from security.enterprise.threat_detection import (  # noqa: E402
     AnalysisContext,
     EventHistory,
@@ -669,3 +671,151 @@ class TestAnalyzerPositiveDetection:
         context = self._context(file_signatures=[{"extension": [".exe"]}])
 
         assert await MaliciousFileAnalyzer().analyze(event, context) is None
+
+
+# ---------------------------------------------------------------------------
+# #14159: UserProfile storage moved from pickle.load()/dump() to a
+# schema-validated JSON format. Pickle on a bridge-writable file is arbitrary
+# code execution; these tests pin the JSON round trip, the validate-or-skip
+# behavior, and the security property that the legacy .pkl is never read.
+# ---------------------------------------------------------------------------
+
+
+class TestUserProfileJsonSerialization:
+    """UserProfile.to_dict()/from_dict() replace pickle for this dataclass."""
+
+    def test_round_trip_preserves_set_and_datetime_types(self):
+        """A ``set`` stays a ``set`` and a ``datetime`` stays a ``datetime``.
+
+        JSON has no set type -- a naive ``json.dumps``/``json.loads`` round
+        trip would silently turn ``typical_ips`` into a list. That silent
+        type change is exactly the defect ``from_dict`` exists to prevent.
+        """
+        original = UserProfile(
+            user_id="alice",
+            typical_ips={"10.0.0.1", "10.0.0.2", "10.0.0.3"},
+            last_updated=now_utc().replace(microsecond=0),
+        )
+
+        # Simulate an actual save->load through the JSON store.
+        payload = json.loads(json.dumps(original.to_dict()))
+        restored = UserProfile.from_dict(payload)
+
+        assert restored is not None
+        assert isinstance(restored.typical_ips, set)
+        assert restored.typical_ips == original.typical_ips
+        assert isinstance(restored.last_updated, datetime)
+        assert restored.last_updated == original.last_updated
+        assert restored.user_id == original.user_id
+
+    def test_from_dict_skips_malformed_entries_without_raising(self):
+        """A hand-edited/corrupt entry degrades to ``None``, never an exception."""
+        assert UserProfile.from_dict({"user_id": "bob", "typical_ips": "not-a-list"}) is None
+        assert UserProfile.from_dict({"user_id": ""}) is None
+        assert UserProfile.from_dict({}) is None
+        assert UserProfile.from_dict("not-a-dict") is None
+        assert UserProfile.from_dict(["also", "not", "a", "dict"]) is None
+        assert UserProfile.from_dict({"user_id": "carol", "last_updated": "not-a-timestamp"}) is None
+
+    def test_from_dict_accepts_a_minimal_valid_entry(self):
+        """Only ``user_id`` is required; the rest fall back to field defaults."""
+        profile = UserProfile.from_dict({"user_id": "dave"})
+
+        assert profile is not None
+        assert profile.user_id == "dave"
+        assert profile.typical_ips == set()
+        assert isinstance(profile.last_updated, datetime)
+
+
+class TestEngineModuleDoesNotImportPickle:
+    """#14159 AC: the ``# nosec B301`` suppression is gone with pickle.load()."""
+
+    def test_pickle_is_not_imported_by_the_engine_module(self):
+        from security.enterprise.threat_detection import engine as engine_module
+
+        assert not hasattr(engine_module, "pickle")
+
+
+class TestThreatDetectionEngineProfileStorageJson:
+    """#14159: the engine's profile load/save path is JSON-only."""
+
+    @pytest.fixture
+    def engine_with_isolated_storage(self, tmp_path, monkeypatch):
+        """A ThreatDetectionEngine with profile storage under ``tmp_path``.
+
+        ``PathConstants.DATA_DIR`` is a class attribute that
+        ``_initialize_profile_storage`` resolves through
+        ``PATH.get_data_path(...)`` -- patching it here (restored
+        automatically by ``monkeypatch``) isolates the engine's profile
+        store from the real repo data directory for the duration of the
+        test.
+        """
+        monkeypatch.setattr(PathConstants, "DATA_DIR", tmp_path)
+        config_path = str(tmp_path / "threat_detection.yaml")
+        return ThreatDetectionEngine(config_path=config_path)
+
+    def test_profile_storage_path_is_json_not_pickle(self, engine_with_isolated_storage):
+        engine = engine_with_isolated_storage
+
+        assert engine.profile_storage_path.suffix == ".json"
+        assert engine.profile_storage_path.name == "user_profiles.json"
+
+    def test_loader_does_not_read_a_pkl_file_even_when_present_next_to_the_json(self, engine_with_isolated_storage):
+        """The security property under test: no pickle deserialization, ever.
+
+        Writes bytes to the legacy ``.pkl`` path that are not a valid pickle
+        stream. If the loader still called ``pickle.load()`` on that path,
+        this would raise ``pickle.UnpicklingError`` (or similar). It must
+        not, because the loader reads the JSON path exclusively and never
+        opens the ``.pkl`` at all.
+        """
+        engine = engine_with_isolated_storage
+        engine._legacy_profile_storage_path.write_bytes(b"not-a-valid-pickle-stream-at-all")
+
+        valid_profile = UserProfile(user_id="carol", typical_ips={"10.0.0.5"})
+        engine.profile_storage_path.write_text(json.dumps({"carol": valid_profile.to_dict()}), encoding="utf-8")
+
+        engine._load_user_profiles()  # must not raise
+
+        assert set(engine.user_profiles) == {"carol"}
+        assert engine.user_profiles["carol"].typical_ips == {"10.0.0.5"}
+        # Never deleted -- no data loss on update.
+        assert engine._legacy_profile_storage_path.exists()
+        assert engine._legacy_profile_storage_path.read_bytes() == b"not-a-valid-pickle-stream-at-all"
+
+    def test_loader_skips_a_malformed_entry_and_loads_the_rest(self, engine_with_isolated_storage):
+        engine = engine_with_isolated_storage
+        valid_profile = UserProfile(user_id="dave", typical_ips={"10.0.0.9"})
+        store = {
+            "dave": valid_profile.to_dict(),
+            "corrupt": {"user_id": "corrupt", "typical_ips": "not-a-list"},
+        }
+        engine.profile_storage_path.write_text(json.dumps(store), encoding="utf-8")
+
+        engine._load_user_profiles()  # must not raise
+
+        assert set(engine.user_profiles) == {"dave"}
+
+    def test_loader_starts_empty_when_no_store_exists(self, engine_with_isolated_storage):
+        engine = engine_with_isolated_storage
+
+        assert not engine.profile_storage_path.exists()
+        assert engine.user_profiles == {}
+
+    def test_save_then_load_round_trips_through_the_real_engine_methods(self, engine_with_isolated_storage):
+        """End-to-end through ``_save_user_profiles``/``_load_user_profiles``."""
+        engine = engine_with_isolated_storage
+        engine.user_profiles = {
+            "erin": UserProfile(user_id="erin", typical_ips={"192.168.0.1"}, risk_score=0.9),
+        }
+
+        engine._save_user_profiles()
+        assert engine.profile_storage_path.exists()
+
+        engine.user_profiles = {}
+        engine._load_user_profiles()
+
+        assert set(engine.user_profiles) == {"erin"}
+        restored = engine.user_profiles["erin"]
+        assert restored.typical_ips == {"192.168.0.1"}
+        assert restored.risk_score == pytest.approx(0.9)

--- a/autobot-backend/tests/api/test_filesystem_mcp_exclusions.py
+++ b/autobot-backend/tests/api/test_filesystem_mcp_exclusions.py
@@ -15,9 +15,13 @@ filename denylist missed:
   backup (``secrets.json.bak``) -- same plaintext-equivalent rows, different
   names
 - the SSO/SAML signing key (``security/sso_keys/private_key.pem``)
-- the threat-detection engine's pickle (``security/user_profiles.pkl``) --
-  the sharp one: ``pickle.load()`` on a bridge-writable file is arbitrary
-  code execution, not disclosure
+- the threat-detection engine's profile store (``security/user_profiles.pkl``)
+  -- the sharp one at the time: ``pickle.load()`` on a bridge-writable file
+  is arbitrary code execution, not disclosure. #14159 later replaced the
+  pickle format with schema-validated JSON (``user_profiles.json``); the
+  exclusion here is by *subtree*, not filename, so it still covers both the
+  current JSON store and any legacy ``.pkl`` left on disk (no data loss on
+  update -- the old file is never deleted)
 
 These tests build a synthetic project tree so the assertions do not depend
 on the real repository's contents, then verify:
@@ -109,10 +113,11 @@ def fake_project(tmp_path, monkeypatch):
     sso_private_key = sso_keys_dir / "private_key.pem"
     sso_private_key.write_text("placeholder-sso-signing-key-material\n", encoding="utf-8")
 
+    # Legacy filename (#14159 replaced pickle with JSON and never deletes an
+    # existing .pkl -- no data loss on update). Real content is irrelevant --
+    # the point under test is that the bridge never reads or writes this path
+    # at all, regardless of what pickle.load() would do with it.
     user_profiles_pkl = security_dir / "user_profiles.pkl"
-    # Real content is irrelevant -- the point under test is that the bridge
-    # never reads or writes this path at all, regardless of what pickle.load()
-    # would do with it.
     user_profiles_pkl.write_bytes(b"placeholder-pickle-stub-bytes")
 
     ordinary_file = project / "README.md"
@@ -457,9 +462,17 @@ class TestRealResolverAgreement:
         assert fs_mcp.is_path_allowed(str(sso_keys_dir / "private_key.pem")) is False
 
     def test_threat_detection_profile_storage_location_is_excluded(self):
-        """The exact path threat_detection/engine.py resolves for its pickle."""
-        profile_storage_path = fs_mcp.LEGACY_DATA_ROOT.get_data_path("security", "user_profiles.pkl")
+        """The exact path threat_detection/engine.py resolves for its JSON
+        profile store (#14159 replaced the pickle format with JSON)."""
+        profile_storage_path = fs_mcp.LEGACY_DATA_ROOT.get_data_path("security", "user_profiles.json")
         assert fs_mcp.is_path_allowed(str(profile_storage_path)) is False
+
+    def test_threat_detection_legacy_pickle_location_is_still_excluded(self):
+        """#14159 stopped reading this path but never deletes it (no data loss
+        on update) -- the subtree exclusion must still cover it even though
+        the engine itself no longer opens it."""
+        legacy_path = fs_mcp.LEGACY_DATA_ROOT.get_data_path("security", "user_profiles.pkl")
+        assert fs_mcp.is_path_allowed(str(legacy_path)) is False
 
     def test_secrets_manager_storage_is_excluded_by_the_real_bridge(self):
         import api.secrets as secrets_api


### PR DESCRIPTION
Closes #14159

## Thinking Path

`_load_user_profiles()` deserialized `user_profiles.pkl` with `pickle.load()`
(`# nosec B301`) -- any writable path to that file, present or future, is
arbitrary code execution the moment the engine loads. `UserProfile` is a
plain bounded dataclass (counters, timestamps, a score), so it does not need
arbitrary-object serialization; JSON with explicit per-field validation is
sufficient and removes the sink outright, rather than narrowing it.

The two non-JSON-native fields needed explicit handling: `typical_ips` is a
`set` (serialized as a sorted list, restored with `set(...)`), and
`last_updated` is a `datetime` (serialized with `.isoformat()`, restored with
the shared `parse_utc_iso`).

Migration: the issue explicitly allows treating the store as a rebuildable
behavioral cache. A one-time "read the old .pkl to migrate it" path was
considered and rejected -- it would keep the exact `pickle.load()` call this
issue exists to remove, just gated to run once instead of on every load. So
the loader reads only the new JSON path; if absent, it starts empty and logs
at INFO. The legacy `.pkl` is left on disk untouched (no data loss on
update) and is never opened -- its presence is only checked with
`Path.exists()` to log an informational, filename-only note.

## What Changed

- `autobot-backend/security/enterprise/threat_detection/models.py`: added
  `UserProfile.to_dict()`/`UserProfile.from_dict()`. `from_dict` validates
  every field's type explicitly (never `UserProfile(**data)`) and returns
  `None` with a `logger.warning` on any mismatch, so one corrupt/hand-edited
  entry degrades to "that profile is dropped," never to a raised exception
  or to unvalidated data flowing into the dataclass.
- `autobot-backend/security/enterprise/threat_detection/engine.py`:
  - Removed `import pickle` and both `# nosec` suppressions.
  - `profile_storage_path` now resolves to `user_profiles.json`;
    `_legacy_profile_storage_path` (`user_profiles.pkl`) is kept only so the
    loader can detect and report it, never to read it.
  - `_load_user_profiles()` reads the JSON store, validates each entry via
    `UserProfile.from_dict`, and drops invalid entries individually. No JSON
    store present -> starts empty, logs at INFO. Legacy `.pkl` present ->
    logs once at INFO, filename only (no absolute path -- logs are an
    outward artifact here), and is otherwise ignored.
  - `_save_user_profiles()` writes to a `.json.tmp` file and renames it into
    place (`Path.replace`, atomic on the same filesystem), so a reader never
    observes a partial write.
  - Both load and save now take `self._file_lock` (the same lock #378 added
    for config writes). Decision: yes, take it. Save is called from
    `_update_user_profiles()`, an async periodic task, and could in
    principle race a future second writer touching the same path; the lock
    is cheap and keeps the file-write pattern consistent with the existing
    config-save precedent rather than leaving this one write path
    unguarded.
- `autobot-backend/security/threat_detection_refactor_test.py`: new tests
  (below).
- `autobot-backend/tests/api/test_filesystem_mcp_exclusions.py`: the
  filesystem-MCP exclusion is by *subtree* (`security/`), not filename, so
  it already covered both `.pkl` and `.json` -- no exclusion logic changed.
  Updated wording/an exact-path assertion that had gone stale: the module
  docstring described `user_profiles.pkl` as "the threat-detection engine's
  pickle" in the present tense, and
  `test_threat_detection_profile_storage_location_is_excluded` asserted
  against the exact path `engine.py` resolves, which is now
  `user_profiles.json`. Added a companion test
  (`test_threat_detection_legacy_pickle_location_is_still_excluded`) so the
  legacy `.pkl` path stays covered by an explicit assertion, not just by
  implication.

## Verification

CI is the authority here -- no local interpreter with the project's
dependencies exists in this environment (`sklearn`, `numpy`, etc. are not
installed, per policy). I did NOT run pytest locally. What I did verify
locally:
- `python3 -c "import ast; ast.parse(...)"` on every touched file --
  confirms syntax only.
- `black --line-length 120 --target-version py312` and
  `isort --profile black --line-length 120` on all four touched files --
  clean/reformatted, matches `pyproject.toml`.
- `ruff check --line-length 120` on all four touched files -- no findings.
- A standalone scratch reimplementation of `to_dict`/`from_dict`'s pure
  logic (dataclass + json + validation, no project imports), run under
  system `python3`, confirming: the set/datetime round trip preserves
  types, a malformed entry returns `None`, a non-dict input returns `None`,
  and a missing `user_id` returns `None`. This validates the *logic*, not
  the actual project code path -- the real assertions live in the tests
  below and must pass in CI.
- `grep -rn "pickle"` over the two production files -- zero remaining
  `import pickle` or `pickle.*` calls; only comments/docstrings mention the
  word.

New tests added (all in
`autobot-backend/security/threat_detection_refactor_test.py` unless noted):

- `TestUserProfileJsonSerialization::test_round_trip_preserves_set_and_datetime_types`
  -- the round trip the issue calls out: `typical_ips` stays a `set` and
  `last_updated` stays a `datetime` after a `to_dict`/JSON/`from_dict`
  cycle. **Fails today** because `UserProfile.to_dict`/`from_dict` do not
  exist.
- `TestUserProfileJsonSerialization::test_from_dict_skips_malformed_entries_without_raising`
  -- six malformed shapes (bad `typical_ips` type, empty `user_id`, empty
  dict, non-dict, list, bad `last_updated`) all return `None`, never raise.
- `TestUserProfileJsonSerialization::test_from_dict_accepts_a_minimal_valid_entry`
  -- only `user_id` is required.
- `TestEngineModuleDoesNotImportPickle::test_pickle_is_not_imported_by_the_engine_module`
  -- asserts `engine` module has no `pickle` attribute. **Fails today**
  (pickle is imported).
- `TestThreatDetectionEngineProfileStorageJson` (isolates
  `PathConstants.DATA_DIR` under `tmp_path` via `monkeypatch` before
  constructing the engine):
  - `test_profile_storage_path_is_json_not_pickle` -- **fails today**
    (resolves to `.pkl`).
  - `test_loader_does_not_read_a_pkl_file_even_when_present_next_to_the_json`
    -- writes garbage bytes to the legacy `.pkl` path (not a valid pickle
    stream) alongside a valid JSON store, calls `_load_user_profiles()`, and
    asserts it does not raise and loads only the JSON entry. This is the
    security property from the issue, asserted directly: if the loader
    still called `pickle.load()` on that path, `pickle.UnpicklingError`
    would propagate. **Fails today** (raises `UnpicklingError`).
  - `test_loader_skips_a_malformed_entry_and_loads_the_rest` -- a JSON store
    with one valid and one malformed entry loads the valid one and drops
    the other without raising. **Fails today** (loader has no per-entry
    validation).
  - `test_loader_starts_empty_when_no_store_exists` -- no file at all ->
    empty profile dict, no exception.
  - `test_save_then_load_round_trips_through_the_real_engine_methods` --
    end-to-end through the real `_save_user_profiles`/`_load_user_profiles`.
- `test_filesystem_mcp_exclusions.py::TestThreatDetectionEngineProfileStorageIsExcludedFromTheRealBridge::test_threat_detection_legacy_pickle_location_is_still_excluded`
  (new) -- the legacy `.pkl` path stays excluded even though the engine no
  longer resolves or reads it.

For each production change, the assertion that fails if reverted:
- Reverting `models.py`'s `to_dict`/`from_dict` fails
  `test_round_trip_preserves_set_and_datetime_types`,
  `test_from_dict_skips_malformed_entries_without_raising`, and every
  engine-level test that calls them (they don't exist -> `AttributeError`).
- Reverting the `pickle` import removal in `engine.py` fails
  `test_pickle_is_not_imported_by_the_engine_module`.
- Reverting `profile_storage_path` back to `.pkl` fails
  `test_profile_storage_path_is_json_not_pickle` and
  `test_threat_detection_profile_storage_location_is_excluded` (now checking
  the `.json` path).
- Reverting `_load_user_profiles`'s JSON-only read (i.e. restoring
  `pickle.load()` on the legacy path) fails
  `test_loader_does_not_read_a_pkl_file_even_when_present_next_to_the_json`
  by raising instead of returning cleanly.
- Reverting the per-entry validation (back to trusting the whole file) fails
  `test_loader_skips_a_malformed_entry_and_loads_the_rest`.

## Model Used

Claude Opus 5
