### PR TITLE
fix(deploy): migrate the last deprecated ansible fact refs and widen the lint to when: clauses

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/deploy-base.yml
+++ b/autobot-slm-backend/ansible/playbooks/deploy-base.yml
@@ -250,11 +250,11 @@
     - name: Update /etc/hosts with VM information
       lineinfile:
         path: /etc/hosts
-        regexp: "^{{ hostvars[item]['ansible_default_ipv4']['address'] | default(hostvars[item]['ansible_host']) }}"
-        line: "{{ hostvars[item]['ansible_default_ipv4']['address'] | default(hostvars[item]['ansible_host']) }} {{ item }} {{ item }}.{{ network.domain }}"
+        regexp: "^{{ hostvars[item]['ansible_facts']['default_ipv4']['address'] | default(hostvars[item]['ansible_host']) }}"
+        line: "{{ hostvars[item]['ansible_facts']['default_ipv4']['address'] | default(hostvars[item]['ansible_host']) }} {{ item }} {{ item }}.{{ network.domain }}"
         state: present
       loop: "{{ groups['all'] }}"
-      when: hostvars[item]['ansible_default_ipv4']['address'] is defined
+      when: hostvars[item]['ansible_facts']['default_ipv4']['address'] is defined
 
     - name: Configure DNS servers
       lineinfile:

--- a/autobot-slm-backend/ansible/playbooks/health-check.yml
+++ b/autobot-slm-backend/ansible/playbooks/health-check.yml
@@ -84,7 +84,7 @@
     # ==========================================
 
     - name: Test internal network connectivity
-      command: ping -c 3 {{ hostvars[item]['ansible_default_ipv4']['address'] | default(hostvars[item]['ansible_host']) }}
+      command: ping -c 3 {{ hostvars[item]['ansible_facts']['default_ipv4']['address'] | default(hostvars[item]['ansible_host']) }}
       loop: "{{ groups['all'] }}"
       when: item != inventory_hostname
       register: network_tests

--- a/pipeline-scripts/check_hook_exec_bits.py
+++ b/pipeline-scripts/check_hook_exec_bits.py
@@ -72,7 +72,6 @@ _KNOWN_DORMANT = frozenset(
         "tools/lint/check_canonical_role_names.py",
         "tools/lint/check_git_safe_directory.py",
         "tools/lint/check_no_blocking_io_in_async.py",
-        "tools/lint/check_no_deprecated_ansible_facts.py",
         "tools/lint/check_no_kb_aioredis_access.py",
         "tools/lint/check_no_local_schemas.py",
         "tools/lint/check_no_utcnow_isoformat.py",

--- a/tools/lint/check_no_deprecated_ansible_facts.py
+++ b/tools/lint/check_no_deprecated_ansible_facts.py
@@ -110,6 +110,19 @@ FACT_ATTRS = frozenset(
 # positives on inventory vars (host, user, become_*, etc.).
 PATTERN = re.compile(r"\{\{[^}]*?\bansible_([a-z][a-z0-9_]*)\b")
 
+# #14181: Ansible evaluates `when:` and friends as Jinja **without** `{{ }}`, so
+# the pattern above cannot see them. That is not academic -- `deploy-base.yml`
+# carried the same fact on the same task in all three forms, two inside `{{ }}`
+# and one in a `when:`. Fixing only the reported two would have moved the
+# ansible-core 2.24 breakage from the template to the conditional while the
+# hook reported the file clean. Both patterns filter through FACT_ATTRS, so
+# inventory/connection vars (ansible_host, ansible_user, ansible_become_*, ...)
+# stay valid in either form.
+_BARE_EXPR_KEYS = ("when", "failed_when", "changed_when", "until", "that")
+BARE_EXPR_PATTERN = re.compile(
+    r"^\s*-?\s*(?:" + "|".join(_BARE_EXPR_KEYS) + r")\s*:.*?\bansible_([a-z][a-z0-9_]*)\b"
+)
+
 # Files allowed to contain the banned patterns (the hook itself + tests).
 ALLOWLIST = frozenset(
     {
@@ -147,10 +160,13 @@ def find_violations(path: Path) -> List[Tuple[int, str, str]]:
         return []
     violations: List[Tuple[int, str, str]] = []
     for lineno, line in enumerate(text.splitlines(), start=1):
-        for match in PATTERN.finditer(line):
-            attr = match.group(1)
-            if attr in FACT_ATTRS:
-                violations.append((lineno, attr, line.strip()[:120]))
+        seen_on_line = set()
+        for pattern in (PATTERN, BARE_EXPR_PATTERN):
+            for match in pattern.finditer(line):
+                attr = match.group(1)
+                if attr in FACT_ATTRS and attr not in seen_on_line:
+                    seen_on_line.add(attr)
+                    violations.append((lineno, attr, line.strip()[:120]))
     return violations
 
 

--- a/tools/lint/check_no_deprecated_ansible_facts_test.py
+++ b/tools/lint/check_no_deprecated_ansible_facts_test.py
@@ -104,3 +104,57 @@ if __name__ == "__main__":
     test_multiple_violations_in_one_file()
     test_jinja_template_file()
     print("All tests passed.")
+
+
+# --- #14181: `when:` and friends are Jinja without `{{ }}` --------------------
+
+
+def test_a_deprecated_fact_in_a_when_clause_is_blocked() -> None:
+    """Ansible evaluates `when:` as Jinja with no braces, so the `{{ }}`-anchored
+    pattern could not see it.
+
+    `deploy-base.yml` carried the same fact on the same task in all three forms
+    — two inside `{{ }}` and one in a `when:`. Fixing only the reported two
+    would have moved the ansible-core 2.24 breakage from the template to the
+    conditional while the hook reported the file clean.
+    """
+    body = "      when: hostvars[item]['ansible_default_ipv4']['address'] is defined\n"
+    with tempfile.TemporaryDirectory() as d:
+        f = _write(Path(d), "when.yml", body)
+        assert len(find_violations(f)) == 1
+
+
+def test_other_bare_expression_keys_are_covered() -> None:
+    body = (
+        "      failed_when: ansible_distribution == 'Ubuntu'\n"
+        "      changed_when: ansible_os_family != 'Debian'\n"
+        "      until: ansible_hostname is defined\n"
+    )
+    with tempfile.TemporaryDirectory() as d:
+        f = _write(Path(d), "bare.yml", body)
+        assert len(find_violations(f)) == 3
+
+
+def test_inventory_vars_stay_valid_in_a_when_clause() -> None:
+    """`ansible_host`/`ansible_user` are connection vars, not facts.
+
+    Widening the match without keeping the FACT_ATTRS filter would block the
+    inventory vars the migration deliberately left alone — worse than the
+    blind spot it closes.
+    """
+    body = (
+        "      when: hostvars[item]['ansible_host'] is defined\n"
+        "      failed_when: ansible_user != 'root'\n"
+        "      changed_when: ansible_python_interpreter is defined\n"
+    )
+    with tempfile.TemporaryDirectory() as d:
+        f = _write(Path(d), "inventory.yml", body)
+        assert find_violations(f) == []
+
+
+def test_a_line_is_not_double_counted_across_both_patterns() -> None:
+    """A `when:` that also contains `{{ }}` must report once, not twice."""
+    body = "      when: \"{{ ansible_distribution }}\" == 'Ubuntu'\n"
+    with tempfile.TemporaryDirectory() as d:
+        f = _write(Path(d), "both.yml", body)
+        assert len(find_violations(f)) == 1


### PR DESCRIPTION
Refs #14181, #7180

Third hook off #14181's dormant baseline, and the third whose rule turned out narrower than its subject.

## Thinking Path

`no-deprecated-ansible-facts` guards against ansible-core 2.24 removing `INJECT_FACTS_AS_VARS`, which breaks every bare `{{ ansible_X }}` fact reference. #7180 migrated 84 files; the hook exists to stop regrowth, and it has been dormant since.

It reported three sites. Fixing them turned up a fourth the hook could not see.

`deploy-base.yml` carries the **same fact on the same task** three times:

```yaml
regexp: "^{{ hostvars[item]['ansible_default_ipv4']['address'] | ... }}"   # line 253, reported
line:   "{{ hostvars[item]['ansible_default_ipv4']['address'] | ... }} ..." # line 254, reported
when:   hostvars[item]['ansible_default_ipv4']['address'] is defined        # line 257, NOT reported
```

The pattern is `\{\{[^}]*?\bansible_([a-z][a-z0-9_]*)\b` — anchored on `{{`. But Ansible evaluates `when:`, `failed_when:`, `changed_when:`, `until:` and `that:` as Jinja **without** braces. So line 257 breaks under 2.24 exactly like the two above it, and the hook was blind to it.

Fixing only the reported lines would have moved the breakage from the template to the conditional while the checker reported the file clean.

## What Changed

**A second pattern for bare-expression keys**, filtered through the same `FACT_ATTRS` set. That filter is what keeps the widening safe: `ansible_host`, `ansible_user`, `ansible_become_*`, `ansible_python_interpreter` are connection/inventory vars, not facts, and #7180 deliberately left them alone. Widening the match without keeping the filter would block them — worse than the blind spot it closes, and asserted against.

Measured repo-wide before touching anything: the widened checker finds **4** sites against the old pattern's 3, and the one extra is `deploy-base.yml:257`. So the blind spot is narrow — but it sat on the same task as two reported ones, which is the worst place for it.

**All four sites migrated** to `hostvars[item]['ansible_facts']['default_ipv4']['address']`, matching the established form. Both files still parse as YAML.

**The hook is woken** (tracked `100755`) and comes off `_KNOWN_DORMANT`. Baseline nine → eight.

## Verification

Four tests added; the widening is mutation-verified rather than re-run green:

```
drop BARE_EXPR_PATTERN from the scan:
  FAILED test_a_deprecated_fact_in_a_when_clause_is_blocked
  FAILED test_other_bare_expression_keys_are_covered
  2 failed, 11 passed

restored: 13 passed
```

Two of the four guard the opposite direction. `test_inventory_vars_stay_valid_in_a_when_clause` pins that `ansible_host` / `ansible_user` / `ansible_python_interpreter` remain legal in a `when:`, and `test_a_line_is_not_double_counted_across_both_patterns` pins that a `when:` which *also* contains `{{ }}` reports once rather than twice — the naive two-pattern loop double-counts.

The checker exits 0 across all tracked YAML/J2, against 4 violations before. `check_hook_exec_bits.py` passes with an eight-entry baseline; its own suite is `14 passed`.

## Risks

The behavioural claim — that these references keep resolving under ansible-core 2.24 — cannot be verified here; it needs a real run against that version. What is verified is that the new form matches the one #7180's 84-file migration already established, and that YAML parsing is unaffected.

## Model Used

Opus 5