### PR TITLE
fix(infra): derive status-all-vms process probes from SERVICE_PORTS so both probes agree

### DIFF
--- a/autobot-infrastructure/shared/scripts/vm-management/status-all-vms.sh
+++ b/autobot-infrastructure/shared/scripts/vm-management/status-all-vms.sh
@@ -128,24 +128,26 @@ get_service_processes() {
 
     case "$vm_name" in
         "frontend")
-            # FIXED: Check for both npm dev and nginx processes
-            process_count=$(timeout 5 ssh -T -i "$SSH_KEY" -o ConnectTimeout=3 "$SSH_USER@$vm_ip" "pgrep -f 'npm.*dev\|vite.*5173' | wc -l" 2>/dev/null || echo "0")
+            # Port comes from SERVICE_PORTS, the same map the health-check URL
+            # above reads, so the two probes cannot name different ports (#14178).
+            process_count=$(timeout 5 ssh -T -i "$SSH_KEY" -o ConnectTimeout=3 "$SSH_USER@$vm_ip" "pgrep -f 'npm.*dev\|vite.*${SERVICE_PORTS[$vm_name]}' | wc -l" 2>/dev/null || echo "0")
             ;;
         "redis")
             # FIXED: Check for redis-stack-server service specifically
             process_count=$(timeout 5 ssh -T -i "$SSH_KEY" -o ConnectTimeout=3 "$SSH_USER@$vm_ip" "systemctl is-active redis-stack-server >/dev/null && echo '1' || echo '0'" 2>/dev/null || echo "0")
             ;;
         "npu-worker")
-            # FIXED: Check for NPU worker service or Python server on 8081
-            process_count=$(timeout 5 ssh -T -i "$SSH_KEY" -o ConnectTimeout=3 "$SSH_USER@$vm_ip" "systemctl is-active autobot-npu-worker >/dev/null && echo '1' || pgrep -f 'python.*8081' | wc -l" 2>/dev/null || echo "0")
+            # Service unit first, port probe as the fallback (#14178: port from SERVICE_PORTS).
+            process_count=$(timeout 5 ssh -T -i "$SSH_KEY" -o ConnectTimeout=3 "$SSH_USER@$vm_ip" "systemctl is-active autobot-npu-worker >/dev/null && echo '1' || pgrep -f 'python.*${SERVICE_PORTS[$vm_name]}' | wc -l" 2>/dev/null || echo "0")
             ;;
         "ai-stack")
-            # FIXED: Check for AI stack service on 8080 (not Ollama on 11434)
-            process_count=$(timeout 5 ssh -T -i "$SSH_KEY" -o ConnectTimeout=3 "$SSH_USER@$vm_ip" "pgrep -f 'python.*8080' | wc -l" 2>/dev/null || echo "0")
+            # AI stack, not Ollama (11434) -- port from SERVICE_PORTS (#14178).
+            process_count=$(timeout 5 ssh -T -i "$SSH_KEY" -o ConnectTimeout=3 "$SSH_USER@$vm_ip" "pgrep -f 'python.*${SERVICE_PORTS[$vm_name]}' | wc -l" 2>/dev/null || echo "0")
             ;;
         "browser")
-            # FIXED: Check for browser service on 3000
-            process_count=$(timeout 5 ssh -T -i "$SSH_KEY" -o ConnectTimeout=3 "$SSH_USER@$vm_ip" "pgrep -f 'python.*3000' | wc -l" 2>/dev/null || echo "0")
+            # 3000 was Grafana's port; the browser service is 9001 (#4052). Reading
+            # SERVICE_PORTS removes the literal that disagreed with the URL probe (#14178).
+            process_count=$(timeout 5 ssh -T -i "$SSH_KEY" -o ConnectTimeout=3 "$SSH_USER@$vm_ip" "pgrep -f 'python.*${SERVICE_PORTS[$vm_name]}' | wc -l" 2>/dev/null || echo "0")
             ;;
     esac
 

--- a/autobot-infrastructure/shared/scripts/vm-management/status-all-vms.sh
+++ b/autobot-infrastructure/shared/scripts/vm-management/status-all-vms.sh
@@ -126,11 +126,25 @@ get_service_processes() {
 
     local process_count=0
 
+    # #14178 review: `${SERVICE_PORTS[$vm_name]}` on a key that does not exist
+    # expands to the EMPTY STRING under this script's `set -e` (there is no
+    # `set -u`), turning `pgrep -f 'python.*'` into a pattern that matches every
+    # python process — the probe would report the service UP whenever any python
+    # is running. That is worse than the literal-port bug this fix removes, so a
+    # missing key reports zero processes and says why, rather than matching
+    # everything or aborting the whole status run.
+    local svc_port="${SERVICE_PORTS[$vm_name]:-}"
+    if [ -z "$svc_port" ]; then
+        echo "status-all-vms: no SERVICE_PORTS entry for '$vm_name' -- reporting 0 processes, not probing" >&2
+        echo "0"
+        return
+    fi
+
     case "$vm_name" in
         "frontend")
             # Port comes from SERVICE_PORTS, the same map the health-check URL
             # above reads, so the two probes cannot name different ports (#14178).
-            process_count=$(timeout 5 ssh -T -i "$SSH_KEY" -o ConnectTimeout=3 "$SSH_USER@$vm_ip" "pgrep -f 'npm.*dev\|vite.*${SERVICE_PORTS[$vm_name]}' | wc -l" 2>/dev/null || echo "0")
+            process_count=$(timeout 5 ssh -T -i "$SSH_KEY" -o ConnectTimeout=3 "$SSH_USER@$vm_ip" "pgrep -f 'npm.*dev\|vite.*${svc_port}' | wc -l" 2>/dev/null || echo "0")
             ;;
         "redis")
             # FIXED: Check for redis-stack-server service specifically
@@ -138,16 +152,16 @@ get_service_processes() {
             ;;
         "npu-worker")
             # Service unit first, port probe as the fallback (#14178: port from SERVICE_PORTS).
-            process_count=$(timeout 5 ssh -T -i "$SSH_KEY" -o ConnectTimeout=3 "$SSH_USER@$vm_ip" "systemctl is-active autobot-npu-worker >/dev/null && echo '1' || pgrep -f 'python.*${SERVICE_PORTS[$vm_name]}' | wc -l" 2>/dev/null || echo "0")
+            process_count=$(timeout 5 ssh -T -i "$SSH_KEY" -o ConnectTimeout=3 "$SSH_USER@$vm_ip" "systemctl is-active autobot-npu-worker >/dev/null && echo '1' || pgrep -f 'python.*${svc_port}' | wc -l" 2>/dev/null || echo "0")
             ;;
         "ai-stack")
             # AI stack, not Ollama (11434) -- port from SERVICE_PORTS (#14178).
-            process_count=$(timeout 5 ssh -T -i "$SSH_KEY" -o ConnectTimeout=3 "$SSH_USER@$vm_ip" "pgrep -f 'python.*${SERVICE_PORTS[$vm_name]}' | wc -l" 2>/dev/null || echo "0")
+            process_count=$(timeout 5 ssh -T -i "$SSH_KEY" -o ConnectTimeout=3 "$SSH_USER@$vm_ip" "pgrep -f 'python.*${svc_port}' | wc -l" 2>/dev/null || echo "0")
             ;;
         "browser")
             # 3000 was Grafana's port; the browser service is 9001 (#4052). Reading
             # SERVICE_PORTS removes the literal that disagreed with the URL probe (#14178).
-            process_count=$(timeout 5 ssh -T -i "$SSH_KEY" -o ConnectTimeout=3 "$SSH_USER@$vm_ip" "pgrep -f 'python.*${SERVICE_PORTS[$vm_name]}' | wc -l" 2>/dev/null || echo "0")
+            process_count=$(timeout 5 ssh -T -i "$SSH_KEY" -o ConnectTimeout=3 "$SSH_USER@$vm_ip" "pgrep -f 'python.*${svc_port}' | wc -l" 2>/dev/null || echo "0")
             ;;
     esac
 

--- a/autobot-infrastructure/shared/tests/test_ssot_config_lib.sh
+++ b/autobot-infrastructure/shared/tests/test_ssot_config_lib.sh
@@ -198,6 +198,35 @@ else
     pass=$((pass + 1))
 fi
 
+# --- #14178: the two probes in a status script must not name different ports ---
+# status-all-vms.sh checks a service two ways: an HTTP URL built from
+# SERVICE_PORTS, and a `pgrep` on the port. Those were separate literals, and
+# they disagreed the moment the SSOT library made the URL correct -- 3000 was
+# Grafana's port, the browser service is 9001 (#4052). Either probe can be
+# green while the other is red, and a process check that can never match
+# reports a running service as down.
+#
+# Asserted as a shape, not as an instance: no process probe may carry a literal
+# port at all. A specific 3000-vs-9001 assertion would pass the day someone
+# introduced the same split on a different service.
+_status_script="${REPO_ROOT}/autobot-infrastructure/shared/scripts/vm-management/status-all-vms.sh"
+if [ -f "$_status_script" ]; then
+    _literals="$(grep -cE "pgrep -f '[^']*[0-9]{4}|vite\.\*[0-9]{4}" "$_status_script" || true)"
+    check "status-all-vms.sh process probes carry no literal port" "$_literals" "0"
+
+    _derived="$(grep -c 'SERVICE_PORTS\[\$vm_name\]' "$_status_script" || true)"
+    if [ "$_derived" -ge 4 ]; then
+        echo "PASS: process probes derive their port from SERVICE_PORTS ($_derived sites)"
+        pass=$((pass + 1))
+    else
+        echo "FAIL: expected >=4 SERVICE_PORTS-derived probes, found $_derived"
+        fail=$((fail + 1))
+    fi
+else
+    echo "FAIL: status-all-vms.sh not found -- refusing to report clean on a missing target"
+    fail=$((fail + 1))
+fi
+
 echo
 echo "=== $pass passed, $fail failed ==="
 [ "$fail" -eq 0 ]

--- a/autobot-infrastructure/shared/tests/test_ssot_config_lib.sh
+++ b/autobot-infrastructure/shared/tests/test_ssot_config_lib.sh
@@ -228,14 +228,55 @@ if [ -f "$_status_script" ]; then
         fail=$((fail + 1))
     fi
 
-    if grep -q 'SERVICE_PORTS\[\$vm_name\]:-' "$_status_script" && \
-       grep -q 'reporting 0 processes, not probing' "$_status_script"; then
-        echo "PASS: a missing SERVICE_PORTS key reports zero, not a wildcard match"
-        pass=$((pass + 1))
-    else
-        echo "FAIL: no empty-port defence -- an unset key would make pgrep match every python process"
-        fail=$((fail + 1))
-    fi
+    # BEHAVIOURAL, not a grep. The review defeated the previous text-presence
+    # version with `if false && [ -z "$svc_port" ]` -- dead code that keeps both
+    # substrings, so the guard passed while the wildcard vulnerability was live.
+    # A guard for a fail-closed path has to actually run the path.
+    #
+    # The function is extracted and executed with `ssh` stubbed to echo its
+    # command, so nothing reaches a network. An unknown service must produce
+    # exactly "0" and must NOT produce a pgrep pattern at all.
+    _probe_out="$(
+        {
+            sed -n '/^get_service_processes() {/,/^}/p' "$_status_script"
+            cat <<'STUB'
+# NOTE: "browser" is deliberately ABSENT while the probe is called WITH it.
+# A name that matches no `case` branch would return "0" via fall-through, so a
+# dead guard would look identical to a live one -- the review defeated the
+# previous version exactly that way.
+declare -A SERVICE_PORTS=( ["frontend"]="5173" )
+SSH_KEY="$(mktemp)"; SSH_USER=nobody
+ssh() { echo "SSH_WOULD_RUN: $*"; }
+timeout() { shift; "$@"; }
+get_service_processes 192.0.2.1 browser
+STUB
+        } | bash 2>/dev/null
+    )"
+    check "a case-matched service with no port entry reports exactly 0" "$_probe_out" "0"
+
+    _wildcard_out="$(
+        {
+            sed -n '/^get_service_processes() {/,/^}/p' "$_status_script"
+            cat <<'STUB'
+# NOTE: "browser" is deliberately ABSENT while the probe is called WITH it.
+# A name that matches no `case` branch would return "0" via fall-through, so a
+# dead guard would look identical to a live one -- the review defeated the
+# previous version exactly that way.
+declare -A SERVICE_PORTS=( ["frontend"]="5173" )
+SSH_KEY="$(mktemp)"; SSH_USER=nobody
+ssh() { echo "SSH_WOULD_RUN: $*"; }
+timeout() { shift; "$@"; }
+get_service_processes 192.0.2.1 browser
+STUB
+        } | bash 2>&1 | grep -c "pgrep -f 'python\.\*'" || true
+    )"
+    check "a missing port never builds a bare 'python.*' pattern" "$_wildcard_out" "0"
+
+    # Quote-agnostic literal check: the earlier single-quote-only regex was
+    # defeated by writing the same literal in double quotes.
+    _dq_literals="$(grep -cE "pgrep -f \"[^\"]*[0-9]{4}" "$_status_script" || true)"
+    check "no double-quoted literal port in a process probe" "$_dq_literals" "0"
+
 else
     echo "FAIL: status-all-vms.sh not found -- refusing to report clean on a missing target"
     fail=$((fail + 1))

--- a/autobot-infrastructure/shared/tests/test_ssot_config_lib.sh
+++ b/autobot-infrastructure/shared/tests/test_ssot_config_lib.sh
@@ -214,12 +214,26 @@ if [ -f "$_status_script" ]; then
     _literals="$(grep -cE "pgrep -f '[^']*[0-9]{4}|vite\.\*[0-9]{4}" "$_status_script" || true)"
     check "status-all-vms.sh process probes carry no literal port" "$_literals" "0"
 
-    _derived="$(grep -c 'SERVICE_PORTS\[\$vm_name\]' "$_status_script" || true)"
+    # The four probes read one resolved local, `$svc_port`, rather than the array
+    # directly -- the review found that an unset key expands to EMPTY under this
+    # script's `set -e` (no `set -u`), which would make `pgrep -f 'python.*'`
+    # match every python process and report the service UP. So the guard checks
+    # both that the probes are derived AND that the empty-key path is defended.
+    _derived="$(grep -cE "pgrep -f '[^']*\\\$\\{svc_port\\}" "$_status_script" || true)"
     if [ "$_derived" -ge 4 ]; then
-        echo "PASS: process probes derive their port from SERVICE_PORTS ($_derived sites)"
+        echo "PASS: process probes derive their port from the resolved svc_port ($_derived sites)"
         pass=$((pass + 1))
     else
-        echo "FAIL: expected >=4 SERVICE_PORTS-derived probes, found $_derived"
+        echo "FAIL: expected >=4 svc_port-derived probes, found $_derived"
+        fail=$((fail + 1))
+    fi
+
+    if grep -q 'SERVICE_PORTS\[\$vm_name\]:-' "$_status_script" && \
+       grep -q 'reporting 0 processes, not probing' "$_status_script"; then
+        echo "PASS: a missing SERVICE_PORTS key reports zero, not a wildcard match"
+        pass=$((pass + 1))
+    else
+        echo "FAIL: no empty-port defence -- an unset key would make pgrep match every python process"
         fail=$((fail + 1))
     fi
 else


### PR DESCRIPTION
Closes #14178

## Thinking Path

`status-all-vms.sh` checks each service two ways, and the two halves disagreed.

The health-check URLs (lines 39-42) already read the library variables: `http://${VMS["browser"]}:$AUTOBOT_BROWSER_SERVICE_PORT/health`. The process probes in the `case` block did not — they carried literal ports:

```bash
"browser")     pgrep -f 'python.*3000'    # Grafana's port; the browser service is 9001 (#4052)
"ai-stack")    pgrep -f 'python.*8080'
"npu-worker")  pgrep -f 'python.*8081'
"frontend")    pgrep -f 'npm.*dev\|vite.*5173'
```

Neither half worked before #14174 — the library the script sources never existed, so the URL probe fell back to `${VAR:-3000}` and agreed with the `pgrep` by accident. Landing the library corrected one half and exposed the other. Either probe can now be green while the other is red, and a process check that can never match reports a running service as **down**.

**The issue names the browser port; there were four literals, not one.** `frontend` is the same defect with `5173` inside a `vite.*` alternation, and `ai-stack`/`npu-worker` happen to agree with the SSOT today — which is exactly the state the browser probe was in before someone changed a port. Fixing only the one that currently disagrees would leave three sites one config change away from the same bug.

## What Changed

All four probes read `${SERVICE_PORTS[$vm_name]}` — the same associative array the health-check URLs are built from, keyed by the case label. That is not "both literals updated to the same value"; it removes the second source entirely, so the two probes are structurally incapable of naming different ports.

The `SERVICE_PORTS` keys already match the `case` labels exactly (`frontend`, `npu-worker`, `ai-stack`, `browser`), so no mapping layer was needed. Variables expand before the SSH command string is built, so the value is resolved locally and sent as a literal to the remote host — unchanged from how the URL probe already behaves.

Comments updated: the `# FIXED: Check for browser service on 3000` line said the wrong thing and would have kept saying it.

## Verification

A guard in `test_ssot_config_lib.sh`, asserted as a **shape rather than an instance**: no process probe may carry a literal four-digit port at all, and at least four must derive from `SERVICE_PORTS`. A 3000-vs-9001 assertion would pass the day someone reintroduced the same split on a different service.

Mutation-verified rather than re-run green — reinstating just the `3000` literal:

```
FAIL: status-all-vms.sh process probes carry no literal port -- expected [0], got [1]
PASS: process probes derive their port from SERVICE_PORTS (4 sites)
=== 16 passed, 1 failed ===

restored: 17 passed, 0 failed
```

`bash -n` clean. **Sibling sweep, as the issue asks:** `git grep -nE "pgrep -f '[^']*[0-9]{4}|lsof -i :[0-9]{4}|netstat.*:[0-9]{4}"` across `vm-management/` and `distributed/` returns **nothing else** — reporting that explicitly because "no other offenders" and "my search was wrong" look identical otherwise.

## Risks

Behavioural verification needs a real fleet: these probes run over SSH against live VMs, so what is verified here is that the port now comes from one resolved source and that the script parses. Whether a given service is actually listening on its SSOT port is a host-evidence question this cannot answer.

## Model Used

Opus 5