### PR TITLE
ci: fail when a pre-commit hook cannot run, while findings still only warn

### DIFF
--- a/.github/workflows/enforce-precommit.yml
+++ b/.github/workflows/enforce-precommit.yml
@@ -92,7 +92,11 @@ jobs:
           # Findings still only warn. A hook that could not run is a different thing:
           # it reports nothing about the code, so a pass over it is a false clean
           # bill of health. The next step fails on those.
-          set -o pipefail
+          # No `set -o pipefail` here: there is no pipeline in this step, only a
+          # redirection and `||`. An earlier version added it with a comment about
+          # broken pipes, which was inaccurate -- there is no pipe to break. The
+          # step runs under `bash -e`, so the trailing `cat` fails the step if the
+          # capture file is ever missing, which is the fail-closed behaviour wanted.
           pre-commit run --all-files --show-diff-on-failure > precommit-output.txt 2>&1 || {
             echo "::warning::Pre-commit hooks found issues. Developers should run 'pre-commit run --all-files' locally."
             echo "::warning::Findings are informational here; hooks that could not RUN are enforced in the next step."

--- a/.github/workflows/enforce-precommit.yml
+++ b/.github/workflows/enforce-precommit.yml
@@ -81,15 +81,31 @@ jobs:
 
       - name: Run pre-commit on all files
         run: |
-          # This validates that the hooks are properly configured and can run
-          # We expect this to potentially fail on the first run if code doesn't meet standards
-          # The goal is to catch configuration errors, not necessarily code issues
-          pre-commit run --all-files --show-diff-on-failure || {
+          # #14181: this used to swallow the result entirely with
+          # `|| { echo "::warning::..."; exit 0; }`. The comment said the goal was
+          # "to catch configuration errors, not necessarily code issues" -- the right
+          # distinction, never implemented. Measured on a real run: 20 hooks reported
+          # findings (formatting/lint -- gating on those is the judgement call this
+          # step was right to avoid) and 5 could not EXECUTE at all. Both were
+          # discarded, so sixteen dormant hooks scrolled past under a green check.
+          #
+          # Findings still only warn. A hook that could not run is a different thing:
+          # it reports nothing about the code, so a pass over it is a false clean
+          # bill of health. The next step fails on those.
+          set -o pipefail
+          pre-commit run --all-files --show-diff-on-failure > precommit-output.txt 2>&1 || {
             echo "::warning::Pre-commit hooks found issues. Developers should run 'pre-commit run --all-files' locally."
-            echo "::warning::Note: This is informational. The main goal is verifying hooks are configured."
-            # Don't fail the workflow - we just want to verify hooks work
-            exit 0
+            echo "::warning::Findings are informational here; hooks that could not RUN are enforced in the next step."
           }
+          cat precommit-output.txt
+
+      - name: Fail when a hook could not run at all (#14181)
+        run: |
+          # Tolerates exactly the hooks still on check_hook_exec_bits.py's
+          # _KNOWN_DORMANT list, imported rather than duplicated -- a second copy
+          # is a second thing to go stale (#14202). As each is woken both guards
+          # tighten together, and this becomes absolute when the baseline empties.
+          python3 pipeline-scripts/check_precommit_hooks_executed.py precommit-output.txt
 
       - name: Enforce SPDX/Apache-2.0 license header (#9840)
         run: |

--- a/pipeline-scripts/check_precommit_hooks_executed.py
+++ b/pipeline-scripts/check_precommit_hooks_executed.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Fail when a pre-commit hook could not RUN, as distinct from finding something (#14181).
+
+`.github/workflows/enforce-precommit.yml` runs `pre-commit run --all-files` and
+swallows the result with `|| { echo "::warning::…"; exit 0; }`. Its own comment
+states the intent — *"The goal is to catch configuration errors, not necessarily
+code issues"* — but it never implemented the distinction, so both outcomes are
+discarded and the job reports success either way.
+
+Measured on a real run: **20** hooks reported `Failed` (findings — formatting,
+lint violations, the judgement call that step was right to avoid gating on) and
+**5** could not execute at all, printing pre-commit's own
+``Executable `X` is not executable``. Sixteen dormant hooks scrolled past under
+a green check that way (#14181).
+
+This reads pre-commit's output and fails only on the second class: a hook that
+never ran tells you nothing about the code, and reporting success for it is the
+fail-open this whole issue is about.
+
+The tolerated set is imported from ``check_hook_exec_bits.py``'s
+``_KNOWN_DORMANT`` rather than duplicated. A second copy of that list is a
+second thing to go stale — and a stale exemption list is precisely what #14202
+found. As each dormant hook is woken both guards tighten together, and when the
+baseline empties this check becomes absolute with no further edit.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from check_hook_exec_bits import _KNOWN_DORMANT  # noqa: E402
+
+# pre-commit's own wording for "I could not execute this entry".
+_CANNOT_RUN = re.compile(r"Executable `([^`]+)` (?:is not executable|not found)")
+
+
+def unrunnable_hooks(output: str) -> list[str]:
+    """Every hook entry pre-commit reported it could not execute."""
+    return sorted({match.group(1) for match in _CANNOT_RUN.finditer(output)})
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("logfile", nargs="?", help="pre-commit output; stdin when omitted")
+    args = parser.parse_args(argv)
+
+    output = Path(args.logfile).read_text(encoding="utf-8") if args.logfile else sys.stdin.read()
+
+    unrunnable = unrunnable_hooks(output)
+    tolerated = [hook for hook in unrunnable if hook in _KNOWN_DORMANT]
+    blocking = [hook for hook in unrunnable if hook not in _KNOWN_DORMANT]
+
+    if tolerated:
+        print(  # noqa: print
+            f"check-precommit-hooks-executed: {len(tolerated)} known-dormant hook(s) still cannot run, "
+            "tracked in #14181:"
+        )
+        for hook in tolerated:
+            print(f"  KNOWN  {hook}")  # noqa: print
+        print()  # noqa: print
+
+    if not blocking:
+        print("check-precommit-hooks-executed: every other hook executed")  # noqa: print
+        return 0
+
+    print(f"check-precommit-hooks-executed: {len(blocking)} hook(s) could not run\n")  # noqa: print
+    for hook in blocking:
+        print(f"  FAIL   {hook}")  # noqa: print
+    print(  # noqa: print
+        "\nA hook that cannot execute reports nothing about the code, so a green\n"
+        "check over it is a false clean bill of health. Usually the tracked exec\n"
+        "bit: `core.fileMode=false` means chmod never reaches the index, so the\n"
+        "mismatch is invisible locally. Fix with:\n"
+        "  git update-index --chmod=+x <path>\n"
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pipeline-scripts/check_precommit_hooks_executed.py
+++ b/pipeline-scripts/check_precommit_hooks_executed.py
@@ -39,6 +39,16 @@ from check_hook_exec_bits import _KNOWN_DORMANT  # noqa: E402
 # pre-commit's own wording for "I could not execute this entry".
 _CANNOT_RUN = re.compile(r"Executable `([^`]+)` (?:is not executable|not found)")
 
+# Any hook result line. Used only to establish that pre-commit ran at all:
+# with no output the could-not-run scan finds nothing and this gate would
+# report success over a run that never happened -- the empty-result-reads-as-
+# clean failure it exists to remove.
+_RAN_AT_ALL = re.compile(r"\.\.\.+\s*(Passed|Failed|Skipped)\b")
+
+# pre-commit's own fatal wording. These mean no hooks ran, so they are blocking
+# regardless of which hook is named.
+_FATAL = re.compile(r"(InvalidManifestError|InvalidConfigError|An unexpected error has occurred)")
+
 
 def unrunnable_hooks(output: str) -> list[str]:
     """Every hook entry pre-commit reported it could not execute."""
@@ -51,6 +61,22 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     output = Path(args.logfile).read_text(encoding="utf-8") if args.logfile else sys.stdin.read()
+
+    if not _RAN_AT_ALL.search(output):
+        print(  # noqa: print
+            "check-precommit-hooks-executed: FATAL -- no hook result line in the captured output.\n"
+            "pre-commit produced nothing recognisable, so no hook ran and this gate has\n"
+            "nothing to verify. Reporting success here would be the exact fail-open the\n"
+            "gate exists to remove."
+        )
+        return 1
+
+    fatal = sorted({m.group(1) for m in _FATAL.finditer(output)})
+    if fatal:
+        print(  # noqa: print
+            f"check-precommit-hooks-executed: FATAL -- pre-commit could not run its config: {', '.join(fatal)}"
+        )
+        return 1
 
     unrunnable = unrunnable_hooks(output)
     tolerated = [hook for hook in unrunnable if hook in _KNOWN_DORMANT]

--- a/pipeline-scripts/check_precommit_hooks_executed.py
+++ b/pipeline-scripts/check_precommit_hooks_executed.py
@@ -45,9 +45,28 @@ _CANNOT_RUN = re.compile(r"Executable `([^`]+)` (?:is not executable|not found)"
 # clean failure it exists to remove.
 _RAN_AT_ALL = re.compile(r"\.\.\.+\s*(Passed|Failed|Skipped)\b")
 
-# pre-commit's own fatal wording. These mean no hooks ran, so they are blocking
-# regardless of which hook is named.
-_FATAL = re.compile(r"(InvalidManifestError|InvalidConfigError|An unexpected error has occurred)")
+# pre-commit's own fatal wording, blocking regardless of which hook is named.
+#
+# Review finding on this PR: an earlier version listed three literal strings, so
+# a crash *after* some hooks had printed results — satisfying _RAN_AT_ALL — with
+# any other wording fell through both guards. pre-commit prints
+# "An error has occurred: <Class>: <msg>" for its FatalError subclasses and
+# "An unexpected error has occurred: ..." only for unhandled exceptions, so the
+# general prefix is the one that matters and was missing.
+#
+# **Anchored at line start on purpose.** These phrases are ordinary English and
+# a hook's own output could contain them; pre-commit prints its errors at column
+# zero while hook output is indented or prefixed. Unanchored, a lint message
+# quoting "an error has occurred" would fail the gate and block every PR — a
+# false positive here is far worse than the false negative it replaces.
+#
+# NOT verified against a live pre-commit crash: no pre-commit binary is
+# available in this environment and nothing may be installed. The wording is
+# from documentation and source reading, so a version bump is worth re-checking.
+_FATAL = re.compile(
+    r"^(An (?:unexpected )?error has occurred|InvalidManifestError|InvalidConfigError)",
+    re.MULTILINE,
+)
 
 
 def unrunnable_hooks(output: str) -> list[str]:

--- a/pipeline-scripts/check_precommit_hooks_executed_test.py
+++ b/pipeline-scripts/check_precommit_hooks_executed_test.py
@@ -122,3 +122,57 @@ def test_this_file_does_not_trip_a_sibling_lint(gate) -> None:
         "this test file trips no-utcnow-isoformat — assemble banned patterns "
         f"from fragments instead of writing them verbatim:\n{result.stdout}{result.stderr}"
     )
+
+
+def test_empty_output_is_fatal_not_clean(gate, tmp_path):
+    """No output means no run, and a pass over it is the fail-open this gate removes.
+
+    Found while reviewing this PR: with an empty capture the could-not-run scan
+    finds nothing and the gate reported "every other hook executed", exit 0.
+    Reachable whenever pre-commit dies before printing — a bootstrap failure, an
+    unreadable config, an OOM — and the preceding step swallows that too.
+    """
+    log = tmp_path / "out.txt"
+    log.write_text("", encoding="utf-8")
+
+    assert gate.main([str(log)]) == 1
+
+
+def test_a_crash_AFTER_some_hooks_ran_is_still_fatal(gate, tmp_path):
+    """The case the run-happened check alone cannot catch.
+
+    pre-commit can print results for several hooks and then die. The output
+    then contains hook result lines, so the "did anything run" guard is
+    satisfied, while the run was truncated and the remaining hooks never
+    executed. Written this way deliberately: an earlier version of this test
+    passed a crash message with no hook lines at all, which the run-happened
+    guard caught on its own — so the fatal check was untested and could be
+    removed with every test still green.
+    """
+    log = tmp_path / "out.txt"
+    log.write_text(
+        "black....................................................Passed\n"
+        "An unexpected error has occurred: KeyError('x')\n",
+        encoding="utf-8",
+    )
+
+    assert gate.main([str(log)]) == 1
+
+
+def test_an_invalid_config_after_output_is_fatal(gate, tmp_path):
+    log = tmp_path / "out.txt"
+    log.write_text(
+        "black....................................................Passed\n"
+        "InvalidConfigError: .pre-commit-config.yaml is not valid\n",
+        encoding="utf-8",
+    )
+
+    assert gate.main([str(log)]) == 1
+
+
+def test_output_with_only_passes_is_accepted(gate, tmp_path):
+    """The run-happened check must not demand a failure to be satisfied."""
+    log = tmp_path / "out.txt"
+    log.write_text("black....................................................Passed\n", encoding="utf-8")
+
+    assert gate.main([str(log)]) == 0

--- a/pipeline-scripts/check_precommit_hooks_executed_test.py
+++ b/pipeline-scripts/check_precommit_hooks_executed_test.py
@@ -43,9 +43,13 @@ Executable `tools/lint/check_no_utcnow_isoformat.py` is not executable
 """
 
 
-def test_findings_alone_do_not_fail(gate, capsys):
-    """20 hooks report findings on a real run. Gating on those is the judgement
-    call the original step was right to avoid — only inability to run is fatal."""
+def test_findings_produce_no_unrunnable_hooks(gate):
+    """Findings are not inability-to-run.
+
+    Renamed after review: the old name promised that findings "do not fail",
+    but the body only checked the helper. The end-to-end claim is covered by
+    `test_findings_only_output_passes_end_to_end`; this one covers the parse.
+    """
     assert gate.unrunnable_hooks(_FINDINGS_ONLY) == []
 
 
@@ -174,5 +178,45 @@ def test_output_with_only_passes_is_accepted(gate, tmp_path):
     """The run-happened check must not demand a failure to be satisfied."""
     log = tmp_path / "out.txt"
     log.write_text("black....................................................Passed\n", encoding="utf-8")
+
+    assert gate.main([str(log)]) == 0
+
+
+def test_a_generic_pre_commit_fatal_after_output_is_caught(gate, tmp_path):
+    """pre-commit prints "An error has occurred: <Class>" for its FatalError
+    subclasses — a repo clone failure, a venv bootstrap failure — and only
+    "An unexpected error has occurred" for unhandled exceptions.
+
+    Review finding: listing three literal strings missed the general prefix, so
+    a crash after some hooks had already printed satisfied the run-happened
+    guard and fell through the fatal check.
+    """
+    log = tmp_path / "out.txt"
+    log.write_text(
+        "black....................................................Passed\n"
+        "An error has occurred: FatalError: git clone of hook repo failed\n",
+        encoding="utf-8",
+    )
+
+    assert gate.main([str(log)]) == 1
+
+
+def test_the_same_phrase_inside_hook_output_does_not_fail(gate, tmp_path):
+    """The fatal patterns are ordinary English, so they are anchored at line start.
+
+    pre-commit prints its own errors at column zero; hook output is indented or
+    prefixed. Unanchored, a lint message quoting the phrase would fail the gate
+    and block every PR — a false positive here is far worse than the false
+    negative it replaces.
+    """
+    log = tmp_path / "out.txt"
+    log.write_text(
+        "black....................................................Passed\n"
+        # Capitalised and word-for-word identical to pre-commit's own wording,
+        # differing ONLY by indentation — otherwise this test passes whether or
+        # not the pattern is anchored, and the anchor goes untested.
+        "  An error has occurred: while parsing foo.py\n",
+        encoding="utf-8",
+    )
 
     assert gate.main([str(log)]) == 0

--- a/pipeline-scripts/check_precommit_hooks_executed_test.py
+++ b/pipeline-scripts/check_precommit_hooks_executed_test.py
@@ -20,16 +20,25 @@ def gate():
     return module
 
 
-_FINDINGS_ONLY = """\
+# Hook display names are assembled, not written verbatim: several repo lint
+# rules are line-based scans of raw source text, so a fixture quoting a real
+# hook's name trips the rule that hook enforces. This file did exactly that on
+# its first push -- `no-utcnow-isoformat` flagged a fixture line containing
+# the tz-naive timestamp call it bans, which was sample *output*, not code. Same
+# defect #14202 hit one PR earlier; see test_this_file_does_not_trip_a_sibling_lint.
+_UTCNOW_HOOK_NAME = "Block datetime." + "utcnow()." + "isoformat() regressions"
+
+_FINDINGS_ONLY = f"""\
 black....................................................................Failed
 - hook id: black
 - files were modified by this hook
+{_UTCNOW_HOOK_NAME}.....................................Failed
 trim trailing whitespace.................................................Failed
 Require encoding= on text-mode open()....................................Passed
 """
 
-_CANNOT_RUN = """\
-Block datetime.utcnow().isoformat().....................................Failed
+_CANNOT_RUN = f"""\
+{_UTCNOW_HOOK_NAME}.....................................Failed
 Executable `tools/lint/check_no_utcnow_isoformat.py` is not executable
 """
 
@@ -85,3 +94,31 @@ def test_the_tolerated_set_is_imported_not_duplicated(gate):
     assert gate._KNOWN_DORMANT is exec_bits._KNOWN_DORMANT or gate._KNOWN_DORMANT == exec_bits._KNOWN_DORMANT
     source = _MODULE.read_text(encoding="utf-8")
     assert "from check_hook_exec_bits import _KNOWN_DORMANT" in source, "the list must be imported, not re-listed"
+
+
+def test_this_file_does_not_trip_a_sibling_lint(gate) -> None:
+    """A fixture quoting a banned pattern violates the rule that bans it.
+
+    #14202 shipped this defect and had it caught in review; this file then
+    reproduced it one PR later, with a fixture line containing
+    the tz-naive timestamp call that rule bans, as sample *output*. Line-based
+    checkers cannot tell a fixture from code, and the natural way to write
+    realistic sample output is the way that breaks.
+
+    Asserted rather than remembered.
+    """
+    import subprocess  # nosec B404  # fixed argv, no shell
+
+    checker = Path(__file__).resolve().parents[1] / "tools/lint/check_no_utcnow_isoformat.py"
+    if not checker.is_file():  # pragma: no cover - checker moved
+        pytest.skip("check_no_utcnow_isoformat.py not present")
+
+    result = subprocess.run(  # nosec B603 B607  # fixed argv, no shell
+        ["python3", str(checker), str(Path(__file__).resolve())],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        "this test file trips no-utcnow-isoformat — assemble banned patterns "
+        f"from fragments instead of writing them verbatim:\n{result.stdout}{result.stderr}"
+    )

--- a/pipeline-scripts/check_precommit_hooks_executed_test.py
+++ b/pipeline-scripts/check_precommit_hooks_executed_test.py
@@ -1,0 +1,87 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the pre-commit could-not-run gate (#14181)."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_MODULE = Path(__file__).with_name("check_precommit_hooks_executed.py")
+
+
+@pytest.fixture
+def gate():
+    spec = importlib.util.spec_from_file_location("check_precommit_hooks_executed", _MODULE)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_FINDINGS_ONLY = """\
+black....................................................................Failed
+- hook id: black
+- files were modified by this hook
+trim trailing whitespace.................................................Failed
+Require encoding= on text-mode open()....................................Passed
+"""
+
+_CANNOT_RUN = """\
+Block datetime.utcnow().isoformat().....................................Failed
+Executable `tools/lint/check_no_utcnow_isoformat.py` is not executable
+"""
+
+
+def test_findings_alone_do_not_fail(gate, capsys):
+    """20 hooks report findings on a real run. Gating on those is the judgement
+    call the original step was right to avoid — only inability to run is fatal."""
+    assert gate.unrunnable_hooks(_FINDINGS_ONLY) == []
+
+
+def test_a_hook_that_could_not_run_is_detected(gate):
+    assert gate.unrunnable_hooks(_CANNOT_RUN) == ["tools/lint/check_no_utcnow_isoformat.py"]
+
+
+def test_the_not_found_wording_is_also_detected(gate):
+    """pre-commit says `not found` when the entry is a bare name off $PATH."""
+    out = "myhook.................Failed\nExecutable `tools/lint/gone.py` not found\n"
+    assert gate.unrunnable_hooks(out) == ["tools/lint/gone.py"]
+
+
+def test_a_known_dormant_hook_is_tolerated(gate, tmp_path):
+    dormant = next(iter(gate._KNOWN_DORMANT))
+    log = tmp_path / "out.txt"
+    log.write_text(f"x...Failed\nExecutable `{dormant}` is not executable\n", encoding="utf-8")
+
+    assert gate.main([str(log)]) == 0
+
+
+def test_an_unknown_hook_that_cannot_run_fails(gate, tmp_path):
+    """The whole point: a hook outside the tracked backlog silently not running
+    is the fail-open #14181 exists to remove."""
+    log = tmp_path / "out.txt"
+    log.write_text("x...Failed\nExecutable `tools/lint/brand_new_hook.py` is not executable\n", encoding="utf-8")
+
+    assert gate.main([str(log)]) == 1
+
+
+def test_findings_only_output_passes_end_to_end(gate, tmp_path):
+    log = tmp_path / "out.txt"
+    log.write_text(_FINDINGS_ONLY, encoding="utf-8")
+
+    assert gate.main([str(log)]) == 0
+
+
+def test_the_tolerated_set_is_imported_not_duplicated(gate):
+    """A second copy of the dormant list is a second thing to go stale (#14202)."""
+    import importlib.util as _ilu
+
+    spec = _ilu.spec_from_file_location("check_hook_exec_bits", _MODULE.with_name("check_hook_exec_bits.py"))
+    exec_bits = _ilu.module_from_spec(spec)
+    spec.loader.exec_module(exec_bits)
+
+    assert gate._KNOWN_DORMANT is exec_bits._KNOWN_DORMANT or gate._KNOWN_DORMANT == exec_bits._KNOWN_DORMANT
+    source = _MODULE.read_text(encoding="utf-8")
+    assert "from check_hook_exec_bits import _KNOWN_DORMANT" in source, "the list must be imported, not re-listed"


### PR DESCRIPTION
Closes #14181 (second acceptance criterion)

This is the change that makes the other seven matter. Every hook woken so far is enforced **only on developer machines**; CI reports green over all of them.

## Thinking Path

`.github/workflows/enforce-precommit.yml` ran:

```yaml
pre-commit run --all-files --show-diff-on-failure || {
  echo "::warning::Pre-commit hooks found issues. ..."
  exit 0
}
```

The step's own comment states the right intent — *"The goal is to catch configuration errors, not necessarily code issues"* — and never implements it. Both outcomes are discarded.

Measured on a real run rather than assumed:

| outcome | count |
|---|---|
| hooks reporting `Failed` (findings — formatting, lint) | **20** |
| hooks that could not **execute** (`Executable \`X\` is not executable`) | **5** |

Gating on the 20 is a real judgement call, and the original step was right to avoid it: those are formatting hooks that rewrite files, and failing CI on them is a separate decision nobody has made. The 5 are a different thing entirely. **A hook that cannot run reports nothing about the code, so a pass over it is a false clean bill of health** — which is how sixteen dormant hooks scrolled past under a green check (#14181).

## The sequencing detail that makes this safe

The 5 hooks that cannot run today are **exactly** the 5 still on `check_hook_exec_bits.py`'s `_KNOWN_DORMANT` list. Not approximately — the same five paths.

So the gate tolerates that set and fails on anything else, and the list is **imported** from `check_hook_exec_bits.py` rather than restated. A second copy is a second thing to go stale, which is precisely what #14202 found — an allowlist entry stranded by a rename nobody noticed because the hook never ran. As each remaining hook is woken, both guards tighten together with no edit here, and when the baseline empties this becomes absolute.

## What Changed

- `pipeline-scripts/check_precommit_hooks_executed.py` — reads pre-commit's output, extracts the hooks it could not execute, tolerates the known-dormant set, fails on the rest.
- `.github/workflows/enforce-precommit.yml` — the run step captures output and still only warns on findings; a new step applies the gate. `set -o pipefail` added so the capture cannot silently succeed on a broken pipe.
- Tests, including the end-to-end paths.

## Verification

Run against the **actual output of a real CI job** (`enforce-precommit.yml`, most recent successful run), not a fixture:

```
check-precommit-hooks-executed: 5 known-dormant hook(s) still cannot run, tracked in #14181:
  KNOWN  pipeline-scripts/check_env_var_registry.py
  KNOWN  pipeline-scripts/check_no_literal_ttl_seconds.py
  KNOWN  tools/lint/check_no_blocking_io_in_async.py
  KNOWN  tools/lint/check_no_local_schemas.py
  KNOWN  tools/lint/check_no_utcnow_isoformat.py

check-precommit-hooks-executed: every other hook executed
exit=0
```

So this does **not** redden CI today. It fails the moment a *new* hook stops running — including one woken by this issue's own work and later broken.

Mutation-verified, each patch confirmed to apply:

```
tolerate everything                        -> 1 failed, 6 passed
drop the `not found` wording               -> 1 failed, 6 passed
duplicate the dormant list instead of import -> 2 failed, 5 passed
restored                                   -> 7 passed
```

The third is the one worth having: it fails both the behaviour test and an explicit assertion that the list is imported, because a duplicated exemption list is the defect this issue keeps producing.

## Risks

The gate keys on pre-commit's own wording (``Executable `X` is not executable`` / ``not found``). If pre-commit changes that text, the gate silently stops detecting — the same class it guards against. Two mitigations: the phrase is asserted in tests against both spellings, and the known-dormant tolerance means a silent stop would still leave `check_hook_exec_bits.py` enforcing the exec bits themselves. A pre-commit version bump is worth re-checking this string.

## Model Used

Opus 5