### PR TITLE
fix(deploy): define autobot_ssh_key_path as a role default so provisioning survives a dynamic inventory

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/deploy-base.yml
+++ b/autobot-slm-backend/ansible/playbooks/deploy-base.yml
@@ -169,7 +169,7 @@
     - name: Set up authorized_keys for autobot user (if public key provided)
       authorized_key:
         user: "{{ autobot_user }}"
-        key: "{{ lookup('file', autobot_ssh_key_path ~ '.pub') }}"
+        key: "{{ lookup('file', (autobot_ssh_key_path | default('/etc/autobot/ssh/autobot_key')) ~ '.pub') }}"
         state: present
       ignore_errors: true  # In case key doesn't exist yet
 

--- a/autobot-slm-backend/ansible/playbooks/enroll-node.yml
+++ b/autobot-slm-backend/ansible/playbooks/enroll-node.yml
@@ -166,7 +166,7 @@
           authorized_key:
             user: "{{ autobot_user }}"
             state: present
-            key: "{{ lookup('file', autobot_ssh_key_path ~ '.pub') }}"
+            key: "{{ lookup('file', (autobot_ssh_key_path | default('/etc/autobot/ssh/autobot_key')) ~ '.pub') }}"
           ignore_errors: true  # Key may not exist during initial enrollment
 
         - name: "Create emergency admin user"

--- a/autobot-slm-backend/ansible/roles/common/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/common/defaults/main.yml
@@ -6,6 +6,21 @@
 # Author: mrveiss
 
 # ==========================================
+# SSH KEY PATH (#14226)
+# ==========================================
+
+# Canonical shared key path (#2828, #12429). Defined here as a ROLE DEFAULT --
+# the lowest precedence in Ansible -- so inventory/group_vars/all.yml still wins
+# wherever it is loaded, while this role stops *depending* on it being loaded.
+#
+# It previously only existed in inventory/group_vars/all.yml, so any play run
+# against an inventory without that directory (a DB-driven or dynamic one, cf.
+# #7094) aborted at "Common | Configure SSH key authentication" with
+# 'autobot_ssh_key_path' is undefined -- observed on a live /opt/autobot
+# provisioning run, failing every host in the play.
+autobot_ssh_key_path: "/etc/autobot/ssh/autobot_key"
+
+# ==========================================
 # FIREWALL PORT CONFIGURATION (#887)
 # ==========================================
 

--- a/autobot-slm-backend/ansible/tests/check_ssh_key_path_defined.py
+++ b/autobot-slm-backend/ansible/tests/check_ssh_key_path_defined.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Fail when `autobot_ssh_key_path` can be undefined at run time (#14226).
+
+The variable lived only in `inventory/group_vars/all.yml`. `group_vars` is
+loaded from the inventory in use, so any play run against an inventory without
+that directory — a DB-driven or otherwise dynamic one, cf. #7094 — left it
+undefined and aborted `roles/common`:
+
+    fatal: [node_00_SLM_Manager]: 'autobot_ssh_key_path' is undefined
+    ... roles/common/tasks/main.yml': line 102
+
+Observed on a live /opt/autobot provisioning run, failing every host in the
+play. Four other sites already guarded the same value with
+`| default('/etc/autobot/ssh/autobot_key')`, including one labelled canonical
+(#12429) — so the value had two spellings and the unguarded one is what runs
+under a dynamic inventory.
+
+Two rules, because roles and plays resolve variables differently:
+
+* A **role** may use the variable bare **iff** its own `defaults/main.yml`
+  defines it. Role defaults are the lowest precedence, so `group_vars` still
+  wins wherever it is loaded; the role simply stops depending on that.
+* A **playbook** has no role defaults to fall back on, so every use must carry
+  an explicit `| default(...)`.
+
+Files under `inventory/` are exempt: `group_vars/all.yml` is loaded alongside
+them by definition.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess  # nosec B404  # git plumbing, fixed argv, no shell
+import sys
+from pathlib import Path
+
+VAR = "autobot_ssh_key_path"
+_GUARDED = re.compile(rf"{VAR}\s*\|\s*default\(")
+
+
+def _repo_root() -> Path:
+    result = subprocess.run(  # nosec B603 B607  # fixed argv, no shell
+        ["git", "rev-parse", "--show-toplevel"], capture_output=True, text=True, encoding="utf-8"
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        sys.exit(f"FATAL: cannot locate the repo root: {result.stderr.strip()}")
+    return Path(result.stdout.strip())
+
+
+def _tracked_yaml(root: Path) -> list[str]:
+    result = subprocess.run(  # nosec B603 B607  # fixed argv, no shell
+        ["git", "ls-files", "autobot-slm-backend/ansible/*.yml", "autobot-slm-backend/ansible/*.yaml"],
+        cwd=str(root),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    if result.returncode != 0:
+        sys.exit(f"FATAL: git ls-files failed: {result.stderr.strip()}")
+    files = result.stdout.split()
+    if not files:
+        sys.exit("FATAL: git ls-files listed no ansible YAML — refusing to report clean on an empty scope")
+    return files
+
+
+def _role_of(rel: str) -> str | None:
+    parts = rel.split("/")
+    if "roles" in parts:
+        i = parts.index("roles")
+        if i + 1 < len(parts):
+            return "/".join(parts[: i + 2])
+    return None
+
+
+def violations(root: Path) -> list[str]:
+    """Every bare use that has no default available to it."""
+    roles_with_default: set[str] = set()
+    files = _tracked_yaml(root)
+
+    for rel in files:
+        if not rel.endswith("defaults/main.yml"):
+            continue
+        text = (root / rel).read_text(encoding="utf-8")
+        if re.search(rf"^{VAR}\s*:", text, re.M):
+            role = _role_of(rel)
+            if role:
+                roles_with_default.add(role)
+
+    found: list[str] = []
+    for rel in files:
+        if "/inventory/" in rel or rel.endswith("defaults/main.yml"):
+            continue
+        for lineno, line in enumerate((root / rel).read_text(encoding="utf-8").splitlines(), 1):
+            if VAR not in line or _GUARDED.search(line):
+                continue
+            role = _role_of(rel)
+            if role and role in roles_with_default:
+                continue  # the role supplies its own default
+            where = "playbook" if role is None else f"role {role} (no defaults entry)"
+            found.append(f"{rel}:{lineno}: bare `{VAR}` in a {where}")
+    return found
+
+
+def main() -> int:
+    root = _repo_root()
+    found = violations(root)
+    if not found:
+        print(f"check-ssh-key-path: every `{VAR}` use has a default available")  # noqa: print
+        return 0
+    print(f"check-ssh-key-path: {len(found)} unguarded use(s)\n")  # noqa: print
+    for item in found:
+        print(f"  FAIL  {item}")  # noqa: print
+    print(  # noqa: print
+        "\nA play run against an inventory without group_vars/ aborts on these.\n"
+        "Either add the variable to the role's defaults/main.yml, or use\n"
+        f"`{VAR} | default('/etc/autobot/ssh/autobot_key')` in a playbook.\n"
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #14226
Refs #12429, #7094, #2828

Live provisioning failure on `/opt/autobot`. Both hosts in the play aborted at the same task.

## Thinking Path

```
TASK [common : Common | Configure SSH key authentication] ***
fatal: [node_00_SLM_Manager]: 'autobot_ssh_key_path' is undefined
    ... roles/common/tasks/main.yml': line 102

b9a29e04             : ok=8   failed=1
node_00_SLM_Manager  : ok=31  failed=1
```

`autobot_ssh_key_path` existed in exactly one place: `inventory/group_vars/all.yml:15`. `group_vars` is loaded **from the inventory in use**, so a play run against an inventory without that directory leaves it undefined and `roles/common` aborts — taking everything after it in the play with it. #7094 documents this shape already: `tests/inventory_dynamic/` is a copy of the test inventory *without* `group_vars`, precisely because that codepath exists.

**The value already had two spellings, one guarded and one not.** Four sites supply the canonical fallback, including one that labels itself canonical:

```
roles/distributed_setup/defaults/main.yml:32  ... | default('/etc/autobot/ssh/autobot_key')  # canonical (#12429)
playbooks/bootstrap-node.yml:50               ... | default('/etc/autobot/ssh/autobot_key')
playbooks/rotate-ssh-keys.yml:217,249         ... | default('/etc/autobot/ssh/autobot_key')
```

Four others used it bare — and those are the ones that abort. Same shape as #14198's port fallbacks: the guarded and unguarded spellings agree until something changes, and then only the unguarded one is running.

## What Changed

**`roles/common/defaults/main.yml` now defines it.** Role defaults are the **lowest** precedence in Ansible, so `inventory/group_vars/all.yml` still wins wherever it is loaded — the role simply stops *depending* on it being loaded. `roles/distributed_setup` already worked this way. Both files carry the identical value, verified rather than assumed.

**`deploy-base.yml:172` and `enroll-node.yml:169` gained the explicit `| default(...)`.** They are plays, not roles, so a role default does not reach them.

The two bare uses that remain in `roles/common/tasks/main.yml` are now correct: a role's own tasks always see its `defaults/main.yml`.

## Verification

A guard, `ansible/tests/check_ssh_key_path_defined.py`, encoding both rules — because roles and plays resolve variables differently:

- a **role** may use it bare **iff** its own `defaults/main.yml` defines it;
- a **playbook** must carry an explicit `| default(...)`;
- `inventory/` is exempt, since `group_vars/all.yml` is loaded alongside it by definition.

Mutation-verified, each patch confirmed to apply:

```
remove the role default        -> exit 1, 2 findings  (the two bare uses in roles/common)
unguard the deploy-base play   -> exit 1, 1 finding
restored                       -> exit 0
```

The first mutation is the reported failure itself, reproduced.

## Risks

**This is a static fix for a host-behaviour bug, and the acceptance criterion on #14226 asks for a provisioning run as evidence.** What is verified here is that the variable now resolves under an inventory with no `group_vars`, that the two values agree, and that no unguarded use remains. Whether provisioning completes on `node_00_SLM_Manager` and `b9a29e04` needs a re-run against those hosts — the retry file is already written:

```
ansible-playbook ... --limit @/home/autobot/.ansible/retry/provision-fleet-roles.retry
```

That must go through the builtin code-sync/self-update path so `/opt/autobot/code_source` picks the change up; I have not run it and have not touched `/opt/autobot`.

## Model Used

Opus 5