### PR TITLE
fix(deploy): drop the two conflicting requirement pins that abort pip on provisioning (#14228)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -232,6 +232,20 @@ repos:
         stages: [pre-commit]
         description: "A ${AUTOBOT_*_PORT:-N} fallback that disagrees with ssot_config.py points at the wrong service whenever the shell library fails to load"
 
+      # #14228: autobot-backend/requirements.txt ends with `-r ../requirements.txt`,
+      # so pip sees both files as one set and aborts when the same distribution
+      # arrives with different specifiers. openpyxl and python-pptx did exactly
+      # that and killed a live provisioning run. pip reports only the FIRST, so a
+      # one-at-a-time fix moves the failure to the next deploy.
+      - id: requirements-no-conflicting-dupes
+        name: A requirements file and its include must not pin a package differently (#14228)
+        entry: pipeline-scripts/check_requirements_no_conflicting_dupes.py
+        language: python
+        files: requirements.*\.txt$
+        pass_filenames: false
+        stages: [pre-commit]
+        description: "pip aborts on a differing duplicate across `-r` includes; identical duplicates are tolerated and not flagged"
+
       - id: hook-exec-bits
         name: Pre-commit hook entries must be tracked executable (#14171)
         entry: pipeline-scripts/check_hook_exec_bits.py

--- a/autobot-backend/requirements.txt
+++ b/autobot-backend/requirements.txt
@@ -28,8 +28,12 @@ reportlab>=5.0.0    # PDF export for transcripts
 # PyPDF2 removed (#13893): unmaintained, and it was the PDF reader behind the
 # Drive/OneDrive connectors while the repo pinned pypdf as a security update
 # (requirements.txt:23). All PDF reading now goes through media/document/extraction.py.
-openpyxl>=3.1.0     # Excel file parsing for OneDrive connector (GH#9004)
-python-pptx>=0.6.23 # PowerPoint file parsing for OneDrive connector (GH#9004)
+# openpyxl / python-pptx: declared once, in the root requirements.txt this file
+# includes at the bottom (`-r ../requirements.txt`). Both were declared here too,
+# with LOWER floors, and pip aborts provisioning on a differing duplicate:
+#   ERROR: Double requirement given: openpyxl>=3.1.5 ... already in openpyxl>=3.1.0
+# The root file carries the stricter floor, so dropping these tightens rather than
+# loosens the constraint and the OneDrive connector's parsers still install (#14228, GH#9004).
 
 # AI/ML
 openai>=2.53.0

--- a/pipeline-scripts/check_requirements_no_conflicting_dupes.py
+++ b/pipeline-scripts/check_requirements_no_conflicting_dupes.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Fail when a requirements file and one it includes pin the same package differently (#14228).
+
+`autobot-backend/requirements.txt` ends with `-r ../requirements.txt`, so pip
+sees both files as one requirement set. When the same distribution appears in
+both with **different** specifiers, pip aborts:
+
+    ERROR: Double requirement given: openpyxl>=3.1.5
+    (from -r .../requirements.txt (line 25))
+    (already in openpyxl>=3.1.0 (from -r /tmp/requirements-filtered.txt (line 30)))
+
+That killed a live provisioning run. It had been latent for as long as the
+include existed: `build-filtered-requirements.sh` rewrites the relative `-r` to
+an absolute code_source path so it actually resolves (#11134), and only then do
+the root file's pins reach pip.
+
+**Identical duplicates are not flagged.** pip tolerates them — `aiosqlite`
+appears in both files with the same specifier, on a line *before* the openpyxl
+conflict, and did not error. They are redundant, not breaking, and failing on
+them would turn a real bug into a tidiness campaign.
+
+pip reports only the first conflict, so a one-at-a-time fix moves the failure to
+the next package on the next deploy. This reports all of them at once.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess  # nosec B404  # git plumbing, fixed argv, no shell
+import sys
+from pathlib import Path
+
+_REQ = re.compile(r"([A-Za-z0-9_.\-]+)(\[[^\]]*\])?\s*([<>=!~].*)?$")
+_INCLUDE = re.compile(r"^\s*-r\s+(\S+)")
+
+
+def _repo_root() -> Path:
+    result = subprocess.run(  # nosec B603 B607  # fixed argv, no shell
+        ["git", "rev-parse", "--show-toplevel"], capture_output=True, text=True, encoding="utf-8"
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        sys.exit(f"FATAL: cannot locate the repo root: {result.stderr.strip()}")
+    return Path(result.stdout.strip())
+
+
+def _declarations(path: Path) -> dict[str, tuple[int, str]]:
+    """First declaration of each distribution in *path*, by canonical name."""
+    found: dict[str, tuple[int, str]] = {}
+    for lineno, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        line = raw.split("#")[0].strip()
+        if not line or line.startswith("-"):
+            continue
+        match = _REQ.match(line)
+        if match:
+            found.setdefault(match.group(1).lower().replace("_", "-"), (lineno, line))
+    return found
+
+
+def _includes(path: Path) -> list[Path]:
+    out = []
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        match = _INCLUDE.match(raw.split("#")[0])
+        if match:
+            out.append((path.parent / match.group(1)).resolve())
+    return out
+
+
+def conflicts(root: Path) -> list[str]:
+    """Every package a requirements file and its include pin differently."""
+    listing = subprocess.run(  # nosec B603 B607  # fixed argv, no shell
+        ["git", "ls-files", "*requirements*.txt"], cwd=str(root), capture_output=True, text=True, encoding="utf-8"
+    )
+    if listing.returncode != 0:
+        sys.exit(f"FATAL: git ls-files failed: {listing.stderr.strip()}")
+    files = listing.stdout.split()
+    if not files:
+        sys.exit("FATAL: git ls-files listed no requirements files — refusing to report clean on an empty scope")
+
+    found: list[str] = []
+    for rel in files:
+        path = root / rel
+        own = _declarations(path)
+        for inc in _includes(path):
+            if not inc.is_file():
+                continue
+            for name, (inc_line, inc_spec) in _declarations(inc).items():
+                if name not in own:
+                    continue
+                own_line, own_spec = own[name]
+                if own_spec == inc_spec:
+                    continue  # identical: redundant, but pip accepts it
+                try:
+                    inc_rel = inc.relative_to(root).as_posix()
+                except ValueError:  # pragma: no cover - include outside the repo
+                    inc_rel = str(inc)
+                found.append(
+                    f"{rel}:{own_line}: '{own_spec}' conflicts with {inc_rel}:{inc_line}: '{inc_spec}'"
+                )
+    return found
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("filenames", nargs="*", help="ignored; every tracked requirements file is checked")
+    parser.parse_args(argv)
+
+    found = conflicts(_repo_root())
+    if not found:
+        print("check-requirements-dupes: no package is pinned differently by a file and its include")  # noqa: print
+        return 0
+
+    print(f"check-requirements-dupes: {len(found)} conflicting duplicate(s)\n")  # noqa: print
+    for item in found:
+        print(f"  FAIL  {item}")  # noqa: print
+    print(  # noqa: print
+        "\npip aborts on the FIRST of these, so fixing one at a time moves the\n"
+        "failure to the next package on the next deploy. Keep one declaration —\n"
+        "normally the stricter floor, in the file the other one includes.\n"
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pipeline-scripts/check_requirements_no_conflicting_dupes.py
+++ b/pipeline-scripts/check_requirements_no_conflicting_dupes.py
@@ -34,7 +34,9 @@ import sys
 from pathlib import Path
 
 _REQ = re.compile(r"([A-Za-z0-9_.\-]+)(\[[^\]]*\])?\s*([<>=!~].*)?$")
-_INCLUDE = re.compile(r"^\s*-r\s+(\S+)")
+# pip accepts both spellings, and a guard that silently skips one reports clean
+# on a file it never opened (#14228 review).
+_INCLUDE = re.compile(r"^\s*(?:-r|--requirement)[\s=]+(\S+)")
 
 
 def _repo_root() -> Path:
@@ -68,8 +70,28 @@ def _includes(path: Path) -> list[Path]:
     return out
 
 
+def _closure(path: Path) -> list[Path]:
+    """Every file pip would read when handed *path*, itself first.
+
+    pip resolves the whole include graph into ONE requirement set, so a conflict
+    two hops away aborts the install exactly like an adjacent one. Comparing a
+    file only against its direct includes misses that, and misses two siblings
+    of the same parent entirely -- `requirements-ci.txt` fans out to twelve
+    children that never see each other pairwise (#14228 review).
+    """
+    seen: list[Path] = []
+    queue = [path]
+    while queue:
+        current = queue.pop(0)
+        if current in seen or not current.is_file():
+            continue
+        seen.append(current)
+        queue.extend(_includes(current))
+    return seen
+
+
 def conflicts(root: Path) -> list[str]:
-    """Every package a requirements file and its include pin differently."""
+    """Every package pinned differently anywhere in one install's requirement set."""
     listing = subprocess.run(  # nosec B603 B607  # fixed argv, no shell
         ["git", "ls-files", "*requirements*.txt"], cwd=str(root), capture_output=True, text=True, encoding="utf-8"
     )
@@ -79,25 +101,37 @@ def conflicts(root: Path) -> list[str]:
     if not files:
         sys.exit("FATAL: git ls-files listed no requirements files — refusing to report clean on an empty scope")
 
+    def _label(path: Path) -> str:
+        try:
+            return path.relative_to(root).as_posix()
+        except ValueError:  # pragma: no cover - include outside the repo
+            return str(path)
+
+    # The same conflict surfaces from every root whose closure reaches it; report
+    # each distinct pair of declarations once.
+    reported: set[tuple[str, str]] = set()
     found: list[str] = []
     for rel in files:
-        path = root / rel
-        own = _declarations(path)
-        for inc in _includes(path):
-            if not inc.is_file():
-                continue
-            for name, (inc_line, inc_spec) in _declarations(inc).items():
-                if name not in own:
+        declarations: dict[str, list[tuple[str, int, str]]] = {}
+        for member in _closure(root / rel):
+            for name, (lineno, spec) in _declarations(member).items():
+                declarations.setdefault(name, []).append((_label(member), lineno, spec))
+
+        for name, sites in sorted(declarations.items()):
+            distinct = {spec for _, _, spec in sites}
+            if len(distinct) < 2:
+                continue  # absent, or declared identically: pip accepts those
+            first = sites[0]
+            for site in sites[1:]:
+                if site[2] == first[2]:
                     continue
-                own_line, own_spec = own[name]
-                if own_spec == inc_spec:
-                    continue  # identical: redundant, but pip accepts it
-                try:
-                    inc_rel = inc.relative_to(root).as_posix()
-                except ValueError:  # pragma: no cover - include outside the repo
-                    inc_rel = str(inc)
+                key = tuple(sorted((f"{first[0]}:{first[1]}", f"{site[0]}:{site[1]}")))
+                if key in reported:
+                    continue
+                reported.add(key)
                 found.append(
-                    f"{rel}:{own_line}: '{own_spec}' conflicts with {inc_rel}:{inc_line}: '{inc_spec}'"
+                    f"{name}: {first[0]}:{first[1]}: '{first[2]}' "
+                    f"conflicts with {site[0]}:{site[1]}: '{site[2]}'"
                 )
     return found
 
@@ -109,7 +143,7 @@ def main(argv: list[str] | None = None) -> int:
 
     found = conflicts(_repo_root())
     if not found:
-        print("check-requirements-dupes: no package is pinned differently by a file and its include")  # noqa: print
+        print("check-requirements-dupes: no package is pinned differently within any install's requirement set")  # noqa: print
         return 0
 
     print(f"check-requirements-dupes: {len(found)} conflicting duplicate(s)\n")  # noqa: print

--- a/pipeline-scripts/check_requirements_no_conflicting_dupes_test.py
+++ b/pipeline-scripts/check_requirements_no_conflicting_dupes_test.py
@@ -1,0 +1,94 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the conflicting-duplicate requirements guard (#14228)."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_MODULE = Path(__file__).with_name("check_requirements_no_conflicting_dupes.py")
+
+
+@pytest.fixture
+def guard():
+    spec = importlib.util.spec_from_file_location("check_requirements_dupes", _MODULE)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _tree(tmp_path: Path, child: str, parent: str) -> Path:
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "sub" / "requirements.txt").write_text(child, encoding="utf-8")
+    (tmp_path / "requirements.txt").write_text(parent, encoding="utf-8")
+    return tmp_path
+
+
+def test_a_differing_pin_across_an_include_is_reported(guard, tmp_path, monkeypatch):
+    """The live failure: pip aborts provisioning on this."""
+    _tree(tmp_path, "openpyxl>=3.1.0\n-r ../requirements.txt\n", "openpyxl>=3.1.5\n")
+    monkeypatch.setattr(guard, "_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(guard.subprocess, "run", lambda *a, **k: type(
+        "R", (), {"returncode": 0, "stdout": "sub/requirements.txt\nrequirements.txt\n", "stderr": ""})())
+
+    assert guard.main([]) == 1
+
+
+def test_an_identical_pin_is_not_reported(guard, tmp_path, monkeypatch):
+    """pip tolerates these, and failing on them would turn a real bug into a
+    tidiness campaign — `aiosqlite` sits in both real files this way, on a line
+    before the openpyxl conflict, and did not error."""
+    _tree(tmp_path, "aiosqlite>=0.22.1\n-r ../requirements.txt\n", "aiosqlite>=0.22.1\n")
+    monkeypatch.setattr(guard, "_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(guard.subprocess, "run", lambda *a, **k: type(
+        "R", (), {"returncode": 0, "stdout": "sub/requirements.txt\nrequirements.txt\n", "stderr": ""})())
+
+    assert guard.main([]) == 0
+
+
+def test_all_conflicts_are_reported_not_just_the_first(guard, tmp_path, monkeypatch):
+    """pip stops at the first, so a one-at-a-time fix fails again next deploy.
+
+    This is the property that matters: `openpyxl` and `python-pptx` both
+    conflicted, and fixing only the reported one would have moved the failure
+    rather than removed it.
+    """
+    _tree(
+        tmp_path,
+        "openpyxl>=3.1.0\npython-pptx>=0.6.23\n-r ../requirements.txt\n",
+        "openpyxl>=3.1.5\npython-pptx>=1.0.2\n",
+    )
+    monkeypatch.setattr(guard, "_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(guard.subprocess, "run", lambda *a, **k: type(
+        "R", (), {"returncode": 0, "stdout": "sub/requirements.txt\nrequirements.txt\n", "stderr": ""})())
+
+    assert len(guard.conflicts(tmp_path)) == 2
+
+
+def test_underscore_and_hyphen_are_the_same_distribution(guard, tmp_path, monkeypatch):
+    """PyPI canonicalises `_` to `-`, so pip sees these as one package."""
+    _tree(tmp_path, "python_pptx>=0.6.23\n-r ../requirements.txt\n", "python-pptx>=1.0.2\n")
+    monkeypatch.setattr(guard, "_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(guard.subprocess, "run", lambda *a, **k: type(
+        "R", (), {"returncode": 0, "stdout": "sub/requirements.txt\nrequirements.txt\n", "stderr": ""})())
+
+    assert len(guard.conflicts(tmp_path)) == 1
+
+
+def test_the_repository_currently_has_no_conflicts(guard):
+    """End-to-end against the real tree — the assertion that fails if a
+    conflicting pin is reintroduced anywhere."""
+    assert guard.main([]) == 0
+
+
+def test_an_empty_file_listing_is_fatal_not_clean(guard, monkeypatch):
+    monkeypatch.setattr(guard.subprocess, "run", lambda *a, **k: type(
+        "R", (), {"returncode": 0, "stdout": "", "stderr": ""})())
+
+    with pytest.raises(SystemExit) as excinfo:
+        guard.conflicts(Path("."))
+
+    assert "refusing to report clean" in str(excinfo.value)

--- a/pipeline-scripts/check_requirements_no_conflicting_dupes_test.py
+++ b/pipeline-scripts/check_requirements_no_conflicting_dupes_test.py
@@ -92,3 +92,92 @@ def test_an_empty_file_listing_is_fatal_not_clean(guard, monkeypatch):
         guard.conflicts(Path("."))
 
     assert "refusing to report clean" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# The pairwise blind spot (found reviewing this PR). pip resolves the whole
+# include graph into ONE requirement set, so "a file vs its direct include" is
+# the wrong unit of comparison -- it reports clean on conflicts that abort a
+# real install.
+# ---------------------------------------------------------------------------
+
+
+def _write(tmp_path, layout):
+    for relative, body in layout.items():
+        target = tmp_path / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(body, encoding="utf-8")
+
+
+def _stub_listing(guard, monkeypatch, tmp_path, relatives):
+    monkeypatch.setattr(guard, "_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(guard.subprocess, "run", lambda *a, **k: type(
+        "R", (), {"returncode": 0, "stdout": "\n".join(relatives), "stderr": ""})())
+
+
+def test_a_conflict_two_hops_away_is_reported(guard, tmp_path, monkeypatch):
+    """dev -> backend -> root, with the conflicting pins at the two ENDS.
+
+    The middle file does not mention the package at all, so no adjacent pair
+    conflicts and a pairwise check reports clean -- while pip, handed the dev
+    file, aborts. `requirements-dev.txt` already re-declares two packages this
+    exact way, so the shape is not hypothetical.
+    """
+    _write(tmp_path, {
+        "requirements-dev.txt": "-r sub/requirements.txt\nopenpyxl>=3.1.0\n",
+        "sub/requirements.txt": "-r ../requirements.txt\naiosqlite>=0.22.1\n",
+        "requirements.txt": "openpyxl>=3.1.5\n",
+    })
+    _stub_listing(guard, monkeypatch, tmp_path,
+                  ["requirements-dev.txt", "sub/requirements.txt", "requirements.txt"])
+
+    assert len(guard.conflicts(tmp_path)) == 1
+
+
+def test_two_siblings_of_one_parent_are_compared(guard, tmp_path, monkeypatch):
+    """A fan-out parent installs all its children together, so two children can
+    conflict with each other while neither conflicts with the parent."""
+    _write(tmp_path, {
+        "requirements-ci.txt": "-r ci/a.txt\n-r ci/b.txt\n",
+        "ci/a.txt": "openpyxl>=3.1.0\n",
+        "ci/b.txt": "openpyxl>=3.1.5\n",
+    })
+    _stub_listing(guard, monkeypatch, tmp_path, ["requirements-ci.txt", "ci/a.txt", "ci/b.txt"])
+
+    assert len(guard.conflicts(tmp_path)) == 1
+
+
+def test_the_long_form_include_is_followed(guard, tmp_path, monkeypatch):
+    """`--requirement` is as valid as `-r`; skipping it means reporting clean on
+    a file that was never opened."""
+    _write(tmp_path, {
+        "sub/requirements.txt": "--requirement ../requirements.txt\nopenpyxl>=3.1.0\n",
+        "requirements.txt": "openpyxl>=3.1.5\n",
+    })
+    _stub_listing(guard, monkeypatch, tmp_path, ["sub/requirements.txt", "requirements.txt"])
+
+    assert len(guard.conflicts(tmp_path)) == 1
+
+
+def test_an_include_cycle_terminates(guard, tmp_path, monkeypatch):
+    """Two files including each other must not hang the closure walk."""
+    _write(tmp_path, {
+        "a.txt": "-r b.txt\nopenpyxl>=3.1.0\n",
+        "b.txt": "-r a.txt\nopenpyxl>=3.1.5\n",
+    })
+    _stub_listing(guard, monkeypatch, tmp_path, ["a.txt", "b.txt"])
+
+    assert len(guard.conflicts(tmp_path)) == 1
+
+
+def test_one_conflict_is_reported_once_not_once_per_root(guard, tmp_path, monkeypatch):
+    """Every file whose closure reaches the pair would otherwise re-report it."""
+    _write(tmp_path, {
+        "requirements-dev.txt": "-r sub/requirements.txt\n",
+        "sub/requirements.txt": "-r ../requirements.txt\nopenpyxl>=3.1.0\n",
+        "requirements.txt": "openpyxl>=3.1.5\n",
+    })
+    _stub_listing(guard, monkeypatch, tmp_path,
+                  ["requirements-dev.txt", "sub/requirements.txt", "requirements.txt"])
+
+    assert len(guard.conflicts(tmp_path)) == 1


### PR DESCRIPTION
## Thinking Path

pip named **one** package. The question that mattered was not "which floor is right for
openpyxl" but "how many more of these are in the file" — because pip stops at the first
conflict, so a single-package fix reports success and fails the next provisioning run at
the next one. Parsing both files produced six shared packages, two conflicting. Both went
in one change; the guard exists so the count is never inferred from pip's first error again.

## Problem

A live provisioning run aborted:

```
TASK [backend : Install filtered backend requirements]
ERROR: Double requirement given: openpyxl>=3.1.5 (from -r .../requirements.txt (line 25))
       (already in openpyxl>=3.1.0 (from -r /tmp/requirements-filtered.txt (line 30)))
```

`autobot-backend/requirements.txt` ends with `-r ../requirements.txt`, so pip resolves both
files as one set. Six packages were declared in both; **two of them with different floors**:

| package | backend | root |
|---|---|---|
| openpyxl | `>=3.1.0` | `>=3.1.5` |
| python-pptx | `>=0.6.23` | `>=1.0.2` |

The other four (`aiosqlite`, `defusedxml`, `protobuf`, `python-docx`) are byte-identical and
pip accepts those silently — which is why this was latent for so long, and why `aiosqlite`
on an *earlier* line than openpyxl did not trip the same error.

Not a regression from the `-r` rewrite (#11134/#11117/#11135); that change is what finally
let the root pins reach pip and exposed a conflict that was already in the tree.

## What Changed

Both duplicate declarations removed from `autobot-backend/requirements.txt`. The root file
carries the **stricter** floor in both cases, so this tightens rather than loosens the
constraint, and the OneDrive connector's `.xlsx`/`.pptx` parsers (GH#9004) still install.

## Why a guard, and why it does not flag identical duplicates

pip reports only the **first** conflict and stops. Fixing openpyxl alone would have moved
the failure to python-pptx on the next provisioning run — the same defect, one deploy later.
`pipeline-scripts/check_requirements_no_conflicting_dupes.py` reports **all** of them at once.

It deliberately does *not* flag identical duplicates: pip tolerates those, and failing on
them would convert a real provisioning-breaking bug into a tidiness campaign across four
more packages that are not broken.

## Verification

- `check_requirements_no_conflicting_dupes.py` against the real tree: exit 0 (was 2 conflicts before the fix).
- **Mutation-verified**, not just re-run — each test fails when the behaviour it names is removed:

  | mutation | result |
  |---|---|
  | flag identical duplicates too | 2 failed |
  | report only the first conflict | 1 failed |
  | drop `_`→`-` canonicalisation | 1 failed |
  | *(restored)* | 6 passed |

- Empty file listing raises instead of reporting clean — an unreachable probe must not read
  as a clean probe.
- Hook registered in `.pre-commit-config.yaml` and committed `100755` (`check_hook_exec_bits.py` clean).

## Model Used

Opus 5 (1M context).

Closes #14228
