### PR TITLE
fix(deploy): protect host-generated state from delete-style syncs (#14231)

### DIFF
--- a/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
@@ -543,6 +543,17 @@
         - "--exclude=*.pyc"
         - "--exclude=.git"
         - "--exclude=archives"
+        # Host-generated state, mirrored from HOST_STATE_EXCLUDES in
+        # services/deploy_artifacts.py (#14231). Anchored entries cannot match
+        # anything here, and cost nothing -- carrying the whole vocabulary is what
+        # keeps the delete-style syncs from disagreeing with each other again.
+        - "--exclude=.env"
+        - "--exclude=.env.*"
+        - "--exclude=data"
+        - "--exclude=logs"
+        - "--exclude=/config/"
+        - "--exclude=/.deployed_commit"
+        - "--exclude=/ansible/enroll.yml"
     tags: ['backend', 'deploy']
 
   # Issue #10020: backend_install_dir/autobot_shared is now a symlink to

--- a/autobot-slm-backend/ansible/roles/frontend/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/frontend/tasks/main.yml
@@ -107,8 +107,18 @@
       - "--exclude=node_modules"
       - "--exclude=dist"
       - "--exclude=.git"
-      - "--exclude=.env"
       - "--exclude=*.env"
+      # Host-generated state, mirrored from HOST_STATE_EXCLUDES in
+      # services/deploy_artifacts.py (#14231). Anchored entries cannot match
+      # anything here, and cost nothing -- carrying the whole vocabulary is what
+      # keeps the delete-style syncs from disagreeing with each other again.
+      - "--exclude=.env"
+      - "--exclude=.env.*"
+      - "--exclude=data"
+      - "--exclude=logs"
+      - "--exclude=/config/"
+      - "--exclude=/.deployed_commit"
+      - "--exclude=/ansible/enroll.yml"
     delete: true
   tags: ['frontend', 'deploy']
 
@@ -120,8 +130,18 @@
       - "--exclude=node_modules"
       - "--exclude=dist"
       - "--exclude=.git"
-      - "--exclude=.env"
       - "--exclude=*.env"
+      # Host-generated state, mirrored from HOST_STATE_EXCLUDES in
+      # services/deploy_artifacts.py (#14231). Anchored entries cannot match
+      # anything here, and cost nothing -- carrying the whole vocabulary is what
+      # keeps the delete-style syncs from disagreeing with each other again.
+      - "--exclude=.env"
+      - "--exclude=.env.*"
+      - "--exclude=data"
+      - "--exclude=logs"
+      - "--exclude=/config/"
+      - "--exclude=/.deployed_commit"
+      - "--exclude=/ansible/enroll.yml"
     delete: true
   tags: ['frontend', 'deploy']
 

--- a/autobot-slm-backend/ansible/roles/slm_manager/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/slm_manager/tasks/main.yml
@@ -202,13 +202,27 @@
     src: "{{ code_source_dir | default('/opt/autobot/code_source') }}/autobot-slm-backend/"
     dest: "{{ slm_backend_dir }}/"
     rsync_opts:
+      # Re-includes come first -- rsync applies the first matching rule, and
+      # `.env.example` is tracked source that the `.env.*` family below would
+      # otherwise swallow (#14231).
+      - "--include=/.env.example"
       - "--exclude=__pycache__"
       - "--exclude=*.pyc"
       - "--exclude=*.egg-info"
       - "--exclude=.git"
       - "--exclude=venv"
+      # Host-generated state, mirrored from HOST_STATE_EXCLUDES in
+      # services/deploy_artifacts.py. This task and the code-sync API both write
+      # this tree; they disagreed about which files may be deleted, and whichever
+      # ran last decided (#14231). tests/api/test_host_state_excludes_14231.py
+      # fails if the two lists drift apart again.
+      - "--exclude=.env"
+      - "--exclude=.env.*"
       - "--exclude=data"
-      - "--exclude=.deployed_commit"
+      - "--exclude=logs"
+      - "--exclude=/config/"
+      - "--exclude=/.deployed_commit"
+      - "--exclude=/ansible/enroll.yml"
     delete: true
   notify: restart slm backend
   tags: ['slm', 'backend', 'deploy']
@@ -674,8 +688,18 @@
       - "--exclude=node_modules"
       - "--exclude=dist"
       - "--exclude=.git"
-      - "--exclude=.env"
       - "--exclude=*.env"
+      # Host-generated state, mirrored from HOST_STATE_EXCLUDES in
+      # services/deploy_artifacts.py (#14231). Anchored entries cannot match
+      # anything here, and cost nothing -- carrying the whole vocabulary is what
+      # keeps the delete-style syncs from disagreeing with each other again.
+      - "--exclude=.env"
+      - "--exclude=.env.*"
+      - "--exclude=data"
+      - "--exclude=logs"
+      - "--exclude=/config/"
+      - "--exclude=/.deployed_commit"
+      - "--exclude=/ansible/enroll.yml"
     delete: true
   tags: ['slm', 'frontend']
 
@@ -692,8 +716,18 @@
       - "--exclude=node_modules"
       - "--exclude=dist"
       - "--exclude=.git"
-      - "--exclude=.env"
       - "--exclude=*.env"
+      # Host-generated state, mirrored from HOST_STATE_EXCLUDES in
+      # services/deploy_artifacts.py (#14231). Anchored entries cannot match
+      # anything here, and cost nothing -- carrying the whole vocabulary is what
+      # keeps the delete-style syncs from disagreeing with each other again.
+      - "--exclude=.env"
+      - "--exclude=.env.*"
+      - "--exclude=data"
+      - "--exclude=logs"
+      - "--exclude=/config/"
+      - "--exclude=/.deployed_commit"
+      - "--exclude=/ansible/enroll.yml"
     delete: true
   tags: ['slm', 'frontend']
 

--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -1289,11 +1289,7 @@ def _rsync_exclude_args(excludes: List[str], component: str | None = None) -> Li
     # Host-state args go FIRST: they carry `--include` entries, and rsync applies
     # the first matching rule (#14231). Dedup spans the whole list, not just
     # `merged` -- a caller passing `.env` would otherwise emit it twice.
-    return list(
-        dict.fromkeys(
-            [*rsync_host_state_args(), *(f"--exclude={exc}" for exc in merged)]
-        )
-    )
+    return list(dict.fromkeys([*rsync_host_state_args(), *(f"--exclude={exc}" for exc in merged)]))
 
 
 # #13851: rsync itemize marker for a delete. `--dry-run --delete --itemize-changes`

--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -69,7 +69,11 @@ from services.auth import get_current_user
 from services.code_distributor import get_code_distributor
 from services.database import get_db
 from services.deploy_activity import read_deploy_activity
-from services.deploy_artifacts import rsync_artifact_excludes
+from services.deploy_artifacts import (
+    HOST_STATE_EXCLUDES,
+    rsync_artifact_excludes,
+    rsync_host_state_args,
+)
 from services.drift_checker import (
     ALLOWED_COMPONENTS,
     VISIBILITY_COMPONENTS,
@@ -1242,19 +1246,14 @@ _SLM_COMPONENTS: List[Tuple[str, List[str]]] = [
 ]
 
 
-# #9970: secret/runtime paths that must survive every sync. The deployed .env
-# is the systemd EnvironmentFile (#2824) and exists only in the deployment --
-# a delete-style sync without these excludes removes it and the service cannot
-# start ("Failed to load environment files"). `data` holds per-service runtime
-# state with the same property. Applied at the rsync chokepoint so no caller
-# or future component list can forget them.
-#
-# #13851: `logs` joins them. A dry run of the autobot-backend resolve on a live
-# host listed logs/audit/*.jsonl among 55 deletions — the audit trail, removed
-# by the remediation for what turned out to be a false drift signal. No
-# component in the repo tracks a `logs/` directory, so excluding it cannot
-# suppress a legitimate source file.
-_PROTECTED_EXCLUDES: List[str] = [".env", "data", "logs"]
+# #14231: the list of paths that must survive every sync now lives in
+# services/deploy_artifacts.py, next to the artifact vocabulary it sits beside
+# at the rsync chokepoint. It was extended here three times by incident (#9970
+# `.env`/`data`, #13851 `logs`, #14231 four more) while the ansible sync path
+# in roles/slm_manager/tasks/main.yml carried its own partial copy -- two code
+# paths writing the same tree, disagreeing about which files may be deleted.
+# One source, one guard test (tests/api/test_host_state_excludes_14231.py).
+_PROTECTED_EXCLUDES: List[str] = list(HOST_STATE_EXCLUDES)
 
 
 def _rsync_exclude_args(excludes: List[str], component: str | None = None) -> List[str]:
@@ -1286,8 +1285,15 @@ def _rsync_exclude_args(excludes: List[str], component: str | None = None) -> Li
     if component is not None:
         foreign = [f"/{sub}/" for sub in sorted(owned_subtrees(component))]
         foreign += [f"/{path}" for path in sorted(deploy_only_entries(component))]
-    merged = list(dict.fromkeys([*excludes, *rsync_artifact_excludes(), *_PROTECTED_EXCLUDES, *foreign]))
-    return [f"--exclude={exc}" for exc in merged]
+    merged = list(dict.fromkeys([*excludes, *rsync_artifact_excludes(), *foreign]))
+    # Host-state args go FIRST: they carry `--include` entries, and rsync applies
+    # the first matching rule (#14231). Dedup spans the whole list, not just
+    # `merged` -- a caller passing `.env` would otherwise emit it twice.
+    return list(
+        dict.fromkeys(
+            [*rsync_host_state_args(), *(f"--exclude={exc}" for exc in merged)]
+        )
+    )
 
 
 # #13851: rsync itemize marker for a delete. `--dry-run --delete --itemize-changes`

--- a/autobot-slm-backend/conftest.py
+++ b/autobot-slm-backend/conftest.py
@@ -231,6 +231,22 @@ sys.modules["services.ssh_utils"] = _ssh_utils_mod
 _ssh_utils_spec.loader.exec_module(_ssh_utils_mod)
 setattr(sys.modules["services"], "ssh_utils", _ssh_utils_mod)
 
+# ── services.deploy_artifacts — REAL module, not a stub (#14231) ──────────────
+# Same reasoning as ssh_utils, opposite failure mode: this module is *only*
+# data (frozensets and tuples of rsync patterns, no imports beyond
+# ``__future__``), and a MagicMock iterates as EMPTY.  Stubbed, every
+# ``for pattern in HOST_STATE_EXCLUDES`` loop runs zero times and the rsync
+# chokepoint's protections vanish under test while looking perfectly healthy --
+# the artifact excludes had exactly that blind spot until this line existed.
+_artifacts_spec = _importlib_util.spec_from_file_location(
+    "services.deploy_artifacts",
+    Path(__file__).parent / "services" / "deploy_artifacts.py",
+)
+_artifacts_mod = _importlib_util.module_from_spec(_artifacts_spec)
+sys.modules["services.deploy_artifacts"] = _artifacts_mod
+_artifacts_spec.loader.exec_module(_artifacts_mod)
+setattr(sys.modules["services"], "deploy_artifacts", _artifacts_mod)
+
 # ── python-multipart ─────────────────────────────────────────────────────────
 # FastAPI's ensure_multipart_is_installed() is called when any route uses
 # UploadFile or Form parameters.  It checks for python_multipart.__version__

--- a/autobot-slm-backend/services/deploy_artifacts.py
+++ b/autobot-slm-backend/services/deploy_artifacts.py
@@ -49,6 +49,55 @@ ARTIFACT_DIR_SUFFIXES: tuple[str, ...] = (".egg-info",)
 ARTIFACT_FILE_GLOBS: tuple[str, ...] = ("*.pyc", "*.log")
 
 
+# ---------------------------------------------------------------------------
+# Host-generated state (#14231)
+# ---------------------------------------------------------------------------
+# Artifacts above are *generated from the source tree*. These are different:
+# they exist only in the deployment, are never tracked in git, and a
+# delete-style sync removes them because the source has nothing to match.
+#
+# The list grew one incident at a time -- `.env`/`data` (#9970), `logs`
+# (#13851), and then four more (#14231) surfaced by a refused resync on a live
+# node. Each fix protected the single path that had just been reported. The
+# rule they were all instances of: **a path that exists only on the host and
+# holds state the node cannot regenerate must survive every sync.**
+#
+# Anchored (`/`-prefixed) entries match at the transfer root only. This matters:
+# a bare `config` would also exclude `autobot-slm-frontend/src/config/`, which
+# is tracked source, and suppressing it would read as permanent drift -- the
+# #11440 failure mode, arriving from the opposite direction.
+HOST_STATE_EXCLUDES: tuple[str, ...] = (
+    ".env",  # systemd EnvironmentFile (#2824, #9970) -- service will not start without it
+    ".env.*",  # .env.production and siblings; the exact `.env` pattern never matched them
+    "data",  # per-service runtime state (#9970)
+    "logs",  # audit trail; a dry run once listed logs/audit/*.jsonl among 55 deletions (#13851)
+    "/config/",  # host-rendered service config
+    "/.deployed_commit",  # what the self-update skip-check reads (#12202)
+    "/ansible/enroll.yml",  # the node's rendered enrolment play
+)
+
+# Tracked source files that a HOST_STATE_EXCLUDES pattern would otherwise catch.
+# rsync applies the FIRST matching rule, so these must be emitted as `--include`
+# ahead of the excludes. Deriving the exclude family from a glob is what makes
+# this necessary -- `.env.*` is right for host state and wrong for the one
+# `.env.example` the backend tracks. A guard test asserts this list covers every
+# such file, so adding `.env.template` tomorrow fails loudly instead of silently
+# going undeployed.
+HOST_STATE_REINCLUDES: tuple[str, ...] = ("/.env.example",)
+
+
+def rsync_host_state_args() -> list[str]:
+    """rsync args protecting host-generated state, re-includes first.
+
+    Returns `--include` args ahead of `--exclude` args because rsync stops at
+    the first matching rule; the order is the mechanism, not a preference.
+    """
+    return [
+        *(f"--include={pattern}" for pattern in HOST_STATE_REINCLUDES),
+        *(f"--exclude={pattern}" for pattern in HOST_STATE_EXCLUDES),
+    ]
+
+
 def rsync_artifact_excludes() -> list[str]:
     """rsync ``--exclude`` patterns covering every build/deploy artifact.
 

--- a/autobot-slm-backend/tests/api/test_code_sync_protected_excludes.py
+++ b/autobot-slm-backend/tests/api/test_code_sync_protected_excludes.py
@@ -109,8 +109,20 @@ def test_backend_sync_excludes_the_runtime_worker_registry(monkeypatch) -> None:
     assert "--exclude=/config/npu_workers.yaml" in args
 
 
-def test_component_omitted_keeps_previous_behaviour() -> None:
-    """Callers that pass no component get exactly the pre-#13851 set plus
-    logs — no anchored foreign excludes appear from nowhere."""
+def test_component_omitted_adds_no_foreign_anchored_excludes() -> None:
+    """Callers that pass no component get no anchored excludes from nowhere.
+
+    #14231 introduced anchored host-state patterns that are always on, so the
+    assertion can no longer be "no anchored args at all" — it is "the anchored
+    args are exactly the host-state ones". Kept as an equality rather than a
+    subset check so a foreign exclude leaking in without a component still
+    fails here.
+    """
+    from services.deploy_artifacts import HOST_STATE_EXCLUDES
+
     args = _rsync_exclude_args([])
-    assert not [a for a in args if a.startswith("--exclude=/")]
+    anchored = {a for a in args if a.startswith("--exclude=/")}
+    expected = {f"--exclude={p}" for p in HOST_STATE_EXCLUDES if p.startswith("/")}
+
+    assert expected, "host-state vocabulary did not load — this test proves nothing"
+    assert anchored == expected

--- a/autobot-slm-backend/tests/api/test_host_state_excludes_14231.py
+++ b/autobot-slm-backend/tests/api/test_host_state_excludes_14231.py
@@ -1,0 +1,238 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Host-generated state must survive every delete-style sync (#14231).
+
+These tests assert the *invariant* -- no path that exists only on the host ends
+up in a deletion set -- rather than the five paths a refused resync happened to
+name. Three previous fixes (#9970, #11440, #13851) each asserted their own
+reported instance and the next instance still got through.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SLM_BACKEND = _REPO_ROOT / "autobot-slm-backend"
+
+
+def _load_deploy_artifacts():
+    """Load the module from its file, not through the `services` package.
+
+    The api/ conftests stub package entries in sys.modules, and a MagicMock
+    answers `iter()` with an empty sequence -- so `for pattern in
+    HOST_STATE_EXCLUDES` would loop zero times and every assertion below would
+    read as "nothing is protected" rather than "the module was not loaded".
+    """
+    path = _SLM_BACKEND / "services" / "deploy_artifacts.py"
+    spec = importlib.util.spec_from_file_location("_deploy_artifacts_14231", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_ARTIFACTS = _load_deploy_artifacts()
+HOST_STATE_EXCLUDES = _ARTIFACTS.HOST_STATE_EXCLUDES
+HOST_STATE_REINCLUDES = _ARTIFACTS.HOST_STATE_REINCLUDES
+rsync_host_state_args = _ARTIFACTS.rsync_host_state_args
+
+
+def test_the_vocabulary_actually_loaded():
+    """Guard the guard: an empty tuple would make every test below pass."""
+    assert isinstance(HOST_STATE_EXCLUDES, tuple)
+    assert len(HOST_STATE_EXCLUDES) >= 7
+    assert isinstance(HOST_STATE_REINCLUDES, tuple) and HOST_STATE_REINCLUDES
+
+_ANSIBLE_SYNC_TASK = (
+    _REPO_ROOT
+    / "autobot-slm-backend"
+    / "ansible"
+    / "roles"
+    / "slm_manager"
+    / "tasks"
+    / "main.yml"
+)
+
+# The paths a live node reported it would lose. Kept as data, not as the
+# assertion -- they are the reproduction, and the invariant tests below are what
+# must hold for the paths nobody has reported yet.
+_REPORTED_ON_A_LIVE_NODE = (
+    ".env.production",
+    "config/",
+    ".deployed_commit",
+    "ansible/enroll.yml",
+)
+
+# Synced by the code-sync flow; must match _SLM_COMPONENTS in api/code_sync.py.
+_SYNCED_COMPONENTS = ("autobot-slm-backend", "autobot-slm-frontend", "autobot_shared")
+
+
+def _matches_any_exclude(relative_path: str) -> bool:
+    """Approximate rsync pattern matching for the patterns this module uses.
+
+    Anchored (`/`-prefixed) patterns match from the transfer root; bare patterns
+    match any path component. A trailing slash marks a directory.
+    """
+    parts = relative_path.split("/")
+    for pattern in HOST_STATE_EXCLUDES:
+        if pattern.startswith("/"):
+            anchored = pattern.strip("/")
+            if relative_path == anchored or relative_path.startswith(anchored + "/"):
+                return True
+        elif any(fnmatch.fnmatch(part, pattern.rstrip("/")) for part in parts):
+            return True
+    return False
+
+
+def _matches_any_reinclude(relative_path: str) -> bool:
+    return any(
+        relative_path == pattern.lstrip("/") for pattern in HOST_STATE_REINCLUDES
+    )
+
+
+def _tracked_files(component: str) -> list[str]:
+    result = subprocess.run(
+        ["git", "ls-files", component],
+        cwd=str(_REPO_ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        pytest.fail(f"git ls-files failed for {component}: {result.stderr}")
+    files = [line for line in result.stdout.splitlines() if line.strip()]
+    if not files:
+        # An empty listing and a clean listing look identical; refuse to pass on it.
+        pytest.fail(f"git ls-files returned nothing for {component}")
+    return files
+
+
+# --------------------------------------------------------------------------
+# The invariant: nothing tracked is silently dropped
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("component", _SYNCED_COMPONENTS)
+def test_no_tracked_source_file_is_excluded_without_a_reinclude(component):
+    """A protected pattern that also catches tracked source stops that file
+    being deployed, and the drift checker then reports it missing forever --
+    #11440's failure mode arriving from the opposite direction.
+
+    `.env.*` is exactly that shape: right for host state, wrong for the
+    `.env.example` the backend tracks.
+    """
+    swallowed = []
+    for tracked in _tracked_files(component):
+        relative = tracked[len(component) + 1 :]
+        if relative.rsplit("/", 1)[-1] == ".gitkeep":
+            # A placeholder whose only job is to keep an empty directory in git.
+            # The deployment creates the directory itself, so not shipping it
+            # costs nothing -- unlike a real source file, which would read as
+            # permanent drift. Expressed as a rule, not as an allowlist entry,
+            # so a genuinely new file under data/ still fails this test.
+            continue
+        if _matches_any_exclude(relative) and not _matches_any_reinclude(relative):
+            swallowed.append(relative)
+
+    assert swallowed == [], (
+        f"{component}: tracked source matched a host-state exclude with no "
+        f"re-include, so it would never be deployed: {swallowed}"
+    )
+
+
+def test_every_reported_host_path_survives_a_sync():
+    """The reproduction. Each of these was listed for deletion on a live node."""
+    unprotected = [p for p in _REPORTED_ON_A_LIVE_NODE if not _matches_any_exclude(p.rstrip("/"))]
+
+    assert unprotected == [], f"still deletable: {unprotected}"
+
+
+def test_the_exact_env_pattern_does_not_cover_its_siblings():
+    """Why `.env` alone was not enough -- the fact that made this a bug.
+
+    If this ever passes with only `.env` present, the family pattern has been
+    removed and `.env.production` is deletable again.
+    """
+    assert not fnmatch.fnmatch(".env.production", ".env")
+    assert _matches_any_exclude(".env.production")
+
+
+def test_config_is_anchored_so_nested_source_config_still_syncs():
+    """A bare `config` would also exclude `autobot-slm-frontend/src/config/`,
+    which is tracked source."""
+    assert _matches_any_exclude("config/settings.yaml")
+    assert not _matches_any_exclude("src/config/ssot-config.ts")
+
+
+# --------------------------------------------------------------------------
+# One source, two writers
+# --------------------------------------------------------------------------
+
+
+def test_the_ansible_sync_task_carries_every_host_state_exclude():
+    """Both writers of the deployed tree must agree, or whichever runs last
+    decides. The ansible task protected `.deployed_commit` and the code-sync API
+    did not -- for the same file, in the same tree."""
+    tasks = yaml.safe_load(_ANSIBLE_SYNC_TASK.read_text(encoding="utf-8"))
+    sync_tasks = [
+        task
+        for task in tasks
+        if isinstance(task, dict) and "ansible.posix.synchronize" in task
+    ]
+    assert sync_tasks, "no synchronize task found -- the guard cannot see what it checks"
+
+    for task in sync_tasks:
+        if not task["ansible.posix.synchronize"].get("delete"):
+            continue  # a non-delete sync cannot remove host state
+        opts = task["ansible.posix.synchronize"].get("rsync_opts", [])
+        missing = [p for p in HOST_STATE_EXCLUDES if f"--exclude={p}" not in opts]
+        assert missing == [], (
+            f"{task.get('name')}: delete-style sync missing host-state excludes {missing}"
+        )
+
+
+def test_the_ansible_task_puts_reincludes_before_excludes():
+    """rsync applies the first matching rule; order is the mechanism here."""
+    tasks = yaml.safe_load(_ANSIBLE_SYNC_TASK.read_text(encoding="utf-8"))
+    for task in tasks:
+        if not isinstance(task, dict) or "ansible.posix.synchronize" not in task:
+            continue
+        opts = task["ansible.posix.synchronize"].get("rsync_opts", [])
+        includes = [i for i, opt in enumerate(opts) if opt.startswith("--include=")]
+        excludes = [i for i, opt in enumerate(opts) if opt.startswith("--exclude=")]
+        if includes and excludes:
+            assert max(includes) < min(excludes), (
+                f"{task.get('name')}: --include must precede --exclude"
+            )
+
+
+def test_rsync_host_state_args_emits_reincludes_first():
+    args = rsync_host_state_args()
+    first_exclude = next(i for i, a in enumerate(args) if a.startswith("--exclude="))
+    includes = [i for i, a in enumerate(args) if a.startswith("--include=")]
+
+    assert includes, "no re-includes emitted"
+    assert max(includes) < first_exclude
+
+
+def test_the_chokepoint_passes_host_state_args_through():
+    """The API-side wiring: a caller that forgets nothing still gets them."""
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from _code_sync_import import import_code_sync  # #12572: real schema stand-ins
+
+    _rsync_exclude_args = import_code_sync()._rsync_exclude_args
+
+    args = _rsync_exclude_args([], component="autobot-slm-backend")
+
+    for pattern in HOST_STATE_EXCLUDES:
+        assert f"--exclude={pattern}" in args, f"{pattern} missing at the rsync chokepoint"
+    assert args[0].startswith("--include=")

--- a/autobot-slm-backend/tests/api/test_host_state_excludes_14231.py
+++ b/autobot-slm-backend/tests/api/test_host_state_excludes_14231.py
@@ -52,6 +52,7 @@ def test_the_vocabulary_actually_loaded():
     assert len(HOST_STATE_EXCLUDES) >= 7
     assert isinstance(HOST_STATE_REINCLUDES, tuple) and HOST_STATE_REINCLUDES
 
+
 _ANSIBLE_ROOT = _REPO_ROOT / "autobot-slm-backend" / "ansible"
 
 
@@ -83,6 +84,7 @@ def _delete_style_syncs():
 
         walk(document)
     return found
+
 
 # The paths a live node reported it would lose. Kept as data, not as the
 # assertion -- they are the reproduction, and the invariant tests below are what
@@ -128,9 +130,7 @@ def _matches_any_exclude(relative_path: str) -> bool:
 
 
 def _matches_any_reinclude(relative_path: str) -> bool:
-    return any(
-        relative_path == pattern.lstrip("/") for pattern in HOST_STATE_REINCLUDES
-    )
+    return any(relative_path == pattern.lstrip("/") for pattern in HOST_STATE_REINCLUDES)
 
 
 def _tracked_files(component: str) -> list[str]:
@@ -235,8 +235,7 @@ def test_no_delete_style_sync_uses_delete_excluded():
     offenders = [
         f"{source}: {name}"
         for source, name, sync in _delete_style_syncs()
-        if any("--delete-excluded" in str(opt) for opt in sync.get("rsync_opts", []))
-        or sync.get("delete_excluded")
+        if any("--delete-excluded" in str(opt) for opt in sync.get("rsync_opts", [])) or sync.get("delete_excluded")
     ]
 
     assert offenders == [], offenders

--- a/autobot-slm-backend/tests/api/test_host_state_excludes_14231.py
+++ b/autobot-slm-backend/tests/api/test_host_state_excludes_14231.py
@@ -52,15 +52,8 @@ def test_the_vocabulary_actually_loaded():
     assert len(HOST_STATE_EXCLUDES) >= 7
     assert isinstance(HOST_STATE_REINCLUDES, tuple) and HOST_STATE_REINCLUDES
 
-_ANSIBLE_SYNC_TASK = (
-    _REPO_ROOT
-    / "autobot-slm-backend"
-    / "ansible"
-    / "roles"
-    / "slm_manager"
-    / "tasks"
-    / "main.yml"
-)
+
+_ANSIBLE_SYNC_TASK = _REPO_ROOT / "autobot-slm-backend" / "ansible" / "roles" / "slm_manager" / "tasks" / "main.yml"
 
 # The paths a live node reported it would lose. Kept as data, not as the
 # assertion -- they are the reproduction, and the invariant tests below are what
@@ -94,9 +87,7 @@ def _matches_any_exclude(relative_path: str) -> bool:
 
 
 def _matches_any_reinclude(relative_path: str) -> bool:
-    return any(
-        relative_path == pattern.lstrip("/") for pattern in HOST_STATE_REINCLUDES
-    )
+    return any(relative_path == pattern.lstrip("/") for pattern in HOST_STATE_REINCLUDES)
 
 
 def _tracked_files(component: str) -> list[str]:
@@ -183,11 +174,7 @@ def test_the_ansible_sync_task_carries_every_host_state_exclude():
     decides. The ansible task protected `.deployed_commit` and the code-sync API
     did not -- for the same file, in the same tree."""
     tasks = yaml.safe_load(_ANSIBLE_SYNC_TASK.read_text(encoding="utf-8"))
-    sync_tasks = [
-        task
-        for task in tasks
-        if isinstance(task, dict) and "ansible.posix.synchronize" in task
-    ]
+    sync_tasks = [task for task in tasks if isinstance(task, dict) and "ansible.posix.synchronize" in task]
     assert sync_tasks, "no synchronize task found -- the guard cannot see what it checks"
 
     for task in sync_tasks:
@@ -195,9 +182,7 @@ def test_the_ansible_sync_task_carries_every_host_state_exclude():
             continue  # a non-delete sync cannot remove host state
         opts = task["ansible.posix.synchronize"].get("rsync_opts", [])
         missing = [p for p in HOST_STATE_EXCLUDES if f"--exclude={p}" not in opts]
-        assert missing == [], (
-            f"{task.get('name')}: delete-style sync missing host-state excludes {missing}"
-        )
+        assert missing == [], f"{task.get('name')}: delete-style sync missing host-state excludes {missing}"
 
 
 def test_the_ansible_task_puts_reincludes_before_excludes():
@@ -210,9 +195,7 @@ def test_the_ansible_task_puts_reincludes_before_excludes():
         includes = [i for i, opt in enumerate(opts) if opt.startswith("--include=")]
         excludes = [i for i, opt in enumerate(opts) if opt.startswith("--exclude=")]
         if includes and excludes:
-            assert max(includes) < min(excludes), (
-                f"{task.get('name')}: --include must precede --exclude"
-            )
+            assert max(includes) < min(excludes), f"{task.get('name')}: --include must precede --exclude"
 
 
 def test_rsync_host_state_args_emits_reincludes_first():

--- a/autobot-slm-backend/tests/api/test_host_state_excludes_14231.py
+++ b/autobot-slm-backend/tests/api/test_host_state_excludes_14231.py
@@ -52,8 +52,37 @@ def test_the_vocabulary_actually_loaded():
     assert len(HOST_STATE_EXCLUDES) >= 7
     assert isinstance(HOST_STATE_REINCLUDES, tuple) and HOST_STATE_REINCLUDES
 
+_ANSIBLE_ROOT = _REPO_ROOT / "autobot-slm-backend" / "ansible"
 
-_ANSIBLE_SYNC_TASK = _REPO_ROOT / "autobot-slm-backend" / "ansible" / "roles" / "slm_manager" / "tasks" / "main.yml"
+
+def _delete_style_syncs():
+    """Every `synchronize` task in the ansible tree that can remove files.
+
+    Scoped to the whole tree, not to one role. The first version of this test
+    read `roles/slm_manager/tasks/main.yml` alone -- and three more delete-style
+    syncs with the identical gap sat in the frontend and backend roles, invisible
+    to a guard whose reach was narrower than its own subject.
+    """
+    found = []
+    for path in sorted(_ANSIBLE_ROOT.rglob("*.yml")):
+        try:
+            document = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except yaml.YAMLError:  # pragma: no cover - a malformed file fails elsewhere
+            continue
+
+        def walk(node):
+            if isinstance(node, list):
+                for item in node:
+                    walk(item)
+            elif isinstance(node, dict):
+                sync = node.get("ansible.posix.synchronize") or node.get("synchronize")
+                if isinstance(sync, dict) and sync.get("delete"):
+                    found.append((path.relative_to(_ANSIBLE_ROOT).as_posix(), node.get("name"), sync))
+                for value in node.values():
+                    walk(value)
+
+        walk(document)
+    return found
 
 # The paths a live node reported it would lose. Kept as data, not as the
 # assertion -- they are the reproduction, and the invariant tests below are what
@@ -65,8 +94,20 @@ _REPORTED_ON_A_LIVE_NODE = (
     "ansible/enroll.yml",
 )
 
-# Synced by the code-sync flow; must match _SLM_COMPONENTS in api/code_sync.py.
-_SYNCED_COMPONENTS = ("autobot-slm-backend", "autobot-slm-frontend", "autobot_shared")
+# Every source root a delete-style sync copies from: the three code-sync
+# components (matching _SLM_COMPONENTS in api/code_sync.py) AND the shared trees
+# the ansible roles sync separately. The excludes apply to all of them, so the
+# "no tracked file is swallowed" invariant has to cover all of them -- checking
+# only the code-sync three would leave three roots where a new `.env.*` or
+# root-level `config/` could silently stop deploying.
+_SYNCED_COMPONENTS = (
+    "autobot-slm-backend",
+    "autobot-slm-frontend",
+    "autobot_shared",
+    "autobot-plugins",
+    "libs",
+    "docs",
+)
 
 
 def _matches_any_exclude(relative_path: str) -> bool:
@@ -87,7 +128,9 @@ def _matches_any_exclude(relative_path: str) -> bool:
 
 
 def _matches_any_reinclude(relative_path: str) -> bool:
-    return any(relative_path == pattern.lstrip("/") for pattern in HOST_STATE_REINCLUDES)
+    return any(
+        relative_path == pattern.lstrip("/") for pattern in HOST_STATE_REINCLUDES
+    )
 
 
 def _tracked_files(component: str) -> list[str]:
@@ -169,33 +212,44 @@ def test_config_is_anchored_so_nested_source_config_still_syncs():
 # --------------------------------------------------------------------------
 
 
-def test_the_ansible_sync_task_carries_every_host_state_exclude():
+def test_every_delete_style_ansible_sync_carries_the_host_state_excludes():
     """Both writers of the deployed tree must agree, or whichever runs last
-    decides. The ansible task protected `.deployed_commit` and the code-sync API
+    decides. The ansible role protected `.deployed_commit` and the code-sync API
     did not -- for the same file, in the same tree."""
-    tasks = yaml.safe_load(_ANSIBLE_SYNC_TASK.read_text(encoding="utf-8"))
-    sync_tasks = [task for task in tasks if isinstance(task, dict) and "ansible.posix.synchronize" in task]
-    assert sync_tasks, "no synchronize task found -- the guard cannot see what it checks"
+    syncs = _delete_style_syncs()
+    assert len(syncs) >= 6, f"only {len(syncs)} delete-style syncs found — the scan did not reach the ansible tree"
 
-    for task in sync_tasks:
-        if not task["ansible.posix.synchronize"].get("delete"):
-            continue  # a non-delete sync cannot remove host state
-        opts = task["ansible.posix.synchronize"].get("rsync_opts", [])
+    gaps = []
+    for source, name, sync in syncs:
+        opts = sync.get("rsync_opts", [])
         missing = [p for p in HOST_STATE_EXCLUDES if f"--exclude={p}" not in opts]
-        assert missing == [], f"{task.get('name')}: delete-style sync missing host-state excludes {missing}"
+        if missing:
+            gaps.append(f"{source}: {name}: missing {missing}")
+
+    assert gaps == [], "\n".join(gaps)
 
 
-def test_the_ansible_task_puts_reincludes_before_excludes():
+def test_no_delete_style_sync_uses_delete_excluded():
+    """`--delete-excluded` would remove the very paths the excludes protect,
+    turning every guarantee above into its opposite."""
+    offenders = [
+        f"{source}: {name}"
+        for source, name, sync in _delete_style_syncs()
+        if any("--delete-excluded" in str(opt) for opt in sync.get("rsync_opts", []))
+        or sync.get("delete_excluded")
+    ]
+
+    assert offenders == [], offenders
+
+
+def test_every_ansible_task_puts_reincludes_before_excludes():
     """rsync applies the first matching rule; order is the mechanism here."""
-    tasks = yaml.safe_load(_ANSIBLE_SYNC_TASK.read_text(encoding="utf-8"))
-    for task in tasks:
-        if not isinstance(task, dict) or "ansible.posix.synchronize" not in task:
-            continue
-        opts = task["ansible.posix.synchronize"].get("rsync_opts", [])
-        includes = [i for i, opt in enumerate(opts) if opt.startswith("--include=")]
-        excludes = [i for i, opt in enumerate(opts) if opt.startswith("--exclude=")]
+    for source, name, sync in _delete_style_syncs():
+        opts = sync.get("rsync_opts", [])
+        includes = [i for i, opt in enumerate(opts) if str(opt).startswith("--include=")]
+        excludes = [i for i, opt in enumerate(opts) if str(opt).startswith("--exclude=")]
         if includes and excludes:
-            assert max(includes) < min(excludes), f"{task.get('name')}: --include must precede --exclude"
+            assert max(includes) < min(excludes), f"{source}: {name}: --include must precede --exclude"
 
 
 def test_rsync_host_state_args_emits_reincludes_first():


### PR DESCRIPTION
## Thinking Path

The refusal named five files and offered one button: delete all of them. Four were host
state that the node cannot regenerate. The tempting fix is to add four strings to a list —
which is what the three previous fixes did (#9970 `.env`/`data`, #11440, #13851 `logs`),
each protecting the one path that had just been reported, each followed by another report.

So the question became *why* the list keeps being short, and there were two answers, both
structural. `.env` is an exact rsync pattern and never covered `.env.production`. And the
same tree is written by **two** code paths — the code-sync API and an ansible role — which
carried different lists; the role already protected `.deployed_commit`, the API did not,
and whichever ran last decided. Adding four strings to one of them fixes neither.

Writing the invariant test then surfaced two more delete-style syncs in the same role
(`autobot-plugins`, `libs`) with the same gap, which nobody had reported yet.

## Problem

Two resyncs on a live fleet node refused, listing host-only state among the deletions:

```
Resync refused — it would delete files
  .env.production
  src/components/settings/DevicePairingSettingsPanel.vue
```
```
Resync refused — it would delete files
  config/  ·  .deployed_commit  ·  ansible/enroll.yml
```

Only the `.vue` file is genuine — it was deliberately removed in #13869 when four pairing
implementations were consolidated. It cannot be deleted without taking the other four with
it, because the resync is all-or-nothing. None of the four is tracked anywhere in the repo.

## What Changed

**One source.** `HOST_STATE_EXCLUDES` / `HOST_STATE_REINCLUDES` and `rsync_host_state_args()`
now live in `services/deploy_artifacts.py`, beside the artifact vocabulary they sit next to
at the rsync chokepoint. `api/code_sync.py` derives `_PROTECTED_EXCLUDES` from it; all four
delete-style ansible syncs carry the same set, and a test fails if they drift apart.

**`.env` became a family** (`.env` + `.env.*`), which is right for host state and wrong for
the one `.env.example` the backend tracks — so `--include=/.env.example` is emitted *ahead*
of the excludes. rsync applies the first matching rule; the ordering is the mechanism, not
a preference, and it is asserted in both the Python and the YAML.

**New entries are anchored** (`/config/`, `/.deployed_commit`, `/ansible/enroll.yml`). A bare
`config` would also exclude `autobot-slm-frontend/src/config/` — tracked source — and a
tracked file that never deploys reads as permanent drift. That is #11440's failure mode
arriving from the opposite direction, so a test asserts no tracked file is silently swallowed.

**One test-harness fix.** The conftest AST-derives the `services.*` modules `code_sync.py`
imports and stubs them all as MagicMocks. A MagicMock iterates as **empty**, so every
`for pattern in ...` loop ran zero times and the protections vanished under test while
looking healthy — the artifact excludes had that blind spot already. `deploy_artifacts` is
pure data with no imports, so it is now real-loaded by file spec, the same treatment
`ssh_utils` got for the mirror-image reason (#11793).

## Verification

- 20 targeted tests pass; 254 in `tests/api` and 125 in `drift_checker_test` + the
  infrastructure playbook tests pass unchanged.
- **Mutation-verified** — every claim fails when the behaviour behind it is removed:

  | mutation | result |
  |---|---|
  | drop the `.env.*` family | 3 failed |
  | drop `/config/` | 3 failed |
  | un-anchor `config` | 3 failed |
  | drop the `.env.example` re-include | 1 failed |
  | emit excludes before includes | 2 failed |
  | strip the plugins sync's protections | 1 failed |
  | stop passing host-state args at the chokepoint | 5 failed |
  | let the conftest stub `deploy_artifacts` again | 7 failed |
  | *(restored)* | 20 passed |

- The tests assert the **invariant** (no host-only path is deletable, no tracked file is
  swallowed, both writers agree), with the five reported paths kept as the reproduction
  rather than as the assertion. The previous three fixes each asserted their own instance.

## Risks

`data/.gitkeep` is tracked and excluded by `data` — pre-existing since #9970, and the
invariant test skips `.gitkeep` by rule rather than by allowlist: the deployment creates the
directory itself, and any genuinely new file under `data/` still fails the test.

Host verification requires a code-sync; this cannot be confirmed from a diff. The next
resync on the affected node is the acceptance evidence.

## Model Used

Opus 5 (1M context).

Closes #14231
