### PR TITLE
feat(knowledge): carry page provenance as metadata, not marker text (#13894)

### DIFF
--- a/autobot-backend/api/knowledge.py
+++ b/autobot-backend/api/knowledge.py
@@ -1172,7 +1172,15 @@ def _extract_file_content(filename: str, file_content: bytes) -> "tuple[str, Ext
 
     if ext == ".pdf":
         extracted = _extract_pdf_document(filename, file_content)
-        return extracted.text, extracted
+        # #13894: store the text *without* page markers. `## Page 7` is structure,
+        # not meaning, and it competes with the document's own words for
+        # similarity once embedded. The page numbers travel as metadata instead —
+        # see _page_provenance_metadata, which derives its offsets from the same
+        # pure render of the same pages, so they always index this exact string.
+        from media.document.extraction import render_plain
+
+        plain_text, _spans = render_plain(extracted.pages)
+        return plain_text, extracted
 
     if ext == ".docx":
         extracted = _extract_docx_document(filename, file_content)
@@ -1197,6 +1205,33 @@ def _has_usable_content(content: str, extracted: "ExtractedDocument | None") -> 
     if extracted is not None:
         return extracted.has_usable_text_layer
     return bool(content.strip())
+
+
+def _page_provenance_metadata(extracted: "ExtractedDocument | None") -> dict:
+    """Page provenance for a stored fact, as metadata rather than marker text (#13894).
+
+    Offsets are derived from the same pure ``render_plain`` call over the same
+    pages that produced the stored content, so they index that exact string. A
+    retrieved span resolves to a page via ``page_for_offset`` / ``pages_for_span``
+    without the page number ever having entered the embedding.
+
+    Returns an empty dict for unpaginated formats — a DOCX has no pages, and
+    inventing ``page: 1`` would be a fabricated citation.
+    """
+    if extracted is None or not extracted.pages:
+        return {}
+
+    from media.document.extraction import render_plain
+
+    _text, spans = render_plain(extracted.pages)
+    if not spans:
+        return {}
+
+    return {
+        "page_count": extracted.page_count,
+        "page_spans": [span.as_metadata() for span in spans],
+        "pages_with_text": [span.number for span in spans],
+    }
 
 
 def _no_text_detail(extracted: "ExtractedDocument | None") -> str:
@@ -1292,18 +1327,17 @@ async def upload_file_to_knowledge(
 
     logger.info("Uploading file: filename='%s', size=%d", filename, len(file_content))
 
-    fact_id = await _store_fact_in_kb(
-        kb_to_use,
-        content,
-        {
-            "title": title,
-            "source": filename,
-            "category": category,
-            "tags": tags,
-            "type": "file",
-            "filename": filename,
-        },
-    )
+    fact_metadata = {
+        "title": title,
+        "source": filename,
+        "category": category,
+        "tags": tags,
+        "type": "file",
+        "filename": filename,
+    }
+    fact_metadata.update(_page_provenance_metadata(extracted_doc))
+
+    fact_id = await _store_fact_in_kb(kb_to_use, content, fact_metadata)
 
     _user = get_auth_middleware().get_user_from_request(req)
     audit_record(

--- a/autobot-backend/media/document/extraction.py
+++ b/autobot-backend/media/document/extraction.py
@@ -144,6 +144,24 @@ class PageText:
 
 
 @dataclass(frozen=True)
+class PageSpan:
+    """Where one page's text sits in a rendered string, as ``[start, end)``.
+
+    This is the provenance carrier: page numbers travel as offsets alongside the
+    text rather than as markers inside it, so retrieval can cite a page without
+    the citation having polluted the embedding (#13894).
+    """
+
+    number: int
+    start: int
+    end: int
+
+    def as_metadata(self) -> Dict[str, int]:
+        """Flat form for storage alongside a fact."""
+        return {"page": self.number, "start": self.start, "end": self.end}
+
+
+@dataclass(frozen=True)
 class ExtractedDocument:
     """Structured result of a document extraction."""
 
@@ -380,3 +398,83 @@ def strip_page_markers(text: str, marker: str = PAGE_MARKER_TEMPLATE) -> str:
     """
     pattern = re.escape(marker).replace(r"\{number\}", r"\d+")
     return re.sub(rf"^{pattern}\n?", "", text, flags=re.MULTILINE)
+
+
+PAGE_SEPARATOR = "\n\n"
+
+
+def render_plain(pages: Sequence[PageText], separator: str = PAGE_SEPARATOR) -> Tuple[str, Tuple[PageSpan, ...]]:
+    """Join pages with **no** markers, returning the text and where each page sits.
+
+    The marker-carrying :func:`render_pages` is the wrong input for an embedding:
+    ``## Page 7`` is structure, not meaning, and it competes with the document's
+    own words for similarity. This is the same text with the provenance moved out
+    of the string and into character spans a caller stores as metadata (#13894).
+
+    Empty pages are skipped, exactly as :func:`render_pages` skips them, so the
+    two renderings stay page-for-page comparable.
+    """
+    parts: List[str] = []
+    spans: List[PageSpan] = []
+    offset = 0
+    for page in pages:
+        if not page.text.strip():
+            continue
+        if parts:
+            offset += len(separator)
+        spans.append(PageSpan(number=page.number, start=offset, end=offset + len(page.text)))
+        parts.append(page.text)
+        offset += len(page.text)
+    return separator.join(parts), tuple(spans)
+
+
+def page_for_offset(spans: Sequence[PageSpan], offset: int) -> int | None:
+    """Return the page number containing *offset*, or ``None`` if outside them all.
+
+    An offset landing in the separator between two pages belongs to neither; the
+    caller decides what that means rather than being handed a silent guess.
+    """
+    for span in spans:
+        if span.start <= offset < span.end:
+            return span.number
+    return None
+
+
+def pages_for_span(spans: Sequence[PageSpan], start: int, end: int) -> Tuple[int, ...]:
+    """Return every page number a ``[start, end)`` range touches.
+
+    A chunk that straddles a page break genuinely comes from two pages. Reporting
+    only the first would silently mis-cite half its content, so this returns the
+    range and lets the caller record it.
+    """
+    if end <= start:
+        return ()
+    return tuple(span.number for span in spans if span.start < end and start < span.end)
+
+
+def chunk_page_map(spans: Sequence[PageSpan], chunks: Sequence[str], text: str) -> Tuple[Tuple[int, ...], ...]:
+    """Map each chunk of *text* to the page numbers it came from.
+
+    Chunkers return strings, not offsets, so the offsets are recovered by
+    scanning forward through *text*. Searching forward from the previous chunk's
+    end — rather than with :meth:`str.find` from zero — keeps repeated boilerplate
+    (headers, footers, recurring table scaffolding) from collapsing every
+    occurrence onto the first page it appeared on.
+    """
+    result: List[Tuple[int, ...]] = []
+    cursor = 0
+    for chunk in chunks:
+        if not chunk:
+            result.append(())
+            continue
+        start = text.find(chunk, cursor)
+        if start < 0:
+            # The chunker transformed the text (trimmed, normalized whitespace),
+            # so offsets cannot be recovered for this chunk. Report nothing
+            # rather than a wrong page.
+            result.append(())
+            continue
+        end = start + len(chunk)
+        result.append(pages_for_span(spans, start, end))
+        cursor = end
+    return tuple(result)

--- a/autobot-backend/tests/test_page_provenance_13894.py
+++ b/autobot-backend/tests/test_page_provenance_13894.py
@@ -1,0 +1,221 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Page-provenance guards (#13894).
+
+The KB upload path stored PDF text carrying ``## Page N`` markers, which then went
+straight into the embedding. Those markers are *structure*, not meaning: they
+compete with the document's own words for similarity, and they are a poor way to
+answer "which page did this fact come from" — recovering a page number by parsing
+markers back out of retrieved text is fragile the moment a chunker splits between
+a marker and its page.
+
+Provenance now travels as character spans in fact metadata, with the stored text
+marker-free. These tests pin the invariant that makes that safe: **the offsets
+must index the exact string that was stored.**
+"""
+
+import io
+
+import pytest
+
+from media.document.extraction import (
+    PAGE_SEPARATOR,
+    PageSpan,
+    PageText,
+    chunk_page_map,
+    extract_pdf,
+    page_for_offset,
+    pages_for_span,
+    render_pages,
+    render_plain,
+)
+
+
+def _pdf(pages: list) -> bytes:
+    pytest.importorskip("reportlab", reason="reportlab needed to synthesize PDF fixtures")
+    from reportlab.pdfgen import canvas
+
+    buffer = io.BytesIO()
+    pdf = canvas.Canvas(buffer)
+    for text in pages:
+        pdf.drawString(72, 720, text)
+        pdf.showPage()
+    pdf.save()
+    return buffer.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# The invariant everything else rests on
+# ---------------------------------------------------------------------------
+
+
+def test_spans_index_the_exact_text_that_was_rendered():
+    """If offsets and text ever disagree, every citation silently points elsewhere."""
+    pages = (PageText(1, "alpha content"), PageText(2, "beta content"), PageText(3, "gamma"))
+    text, spans = render_plain(pages)
+
+    for span, page in zip(spans, pages):
+        assert text[span.start : span.end] == page.text
+
+
+def test_spans_still_index_correctly_when_pages_are_skipped():
+    """Empty pages are dropped from the text; the surviving offsets must still land."""
+    pages = (PageText(1, "first"), PageText(2, "   "), PageText(3, "third"))
+    text, spans = render_plain(pages)
+
+    assert [span.number for span in spans] == [1, 3], "page 2 carried nothing"
+    for span in spans:
+        assert text[span.start : span.end].strip()
+    assert text[spans[1].start : spans[1].end] == "third"
+
+
+def test_rendered_text_carries_no_markers():
+    text, _spans = render_plain((PageText(1, "body"), PageText(2, "more")))
+    assert "## Page" not in text
+    # ...whereas the marker renderer still does, for callers that want it.
+    assert "## Page 1" in render_pages((PageText(1, "body"),))
+
+
+def test_plain_and_marker_renderings_cover_the_same_pages():
+    """The two renderers must not disagree about which pages exist."""
+    pages = (PageText(1, "a"), PageText(2, "  "), PageText(3, "c"))
+    _plain, spans = render_plain(pages)
+    marked = render_pages(pages)
+
+    for span in spans:
+        assert f"## Page {span.number}" in marked
+    assert "## Page 2" not in marked
+
+
+# ---------------------------------------------------------------------------
+# Offset -> page resolution
+# ---------------------------------------------------------------------------
+
+
+def test_page_for_offset_resolves_within_each_page():
+    text, spans = render_plain((PageText(1, "aaaa"), PageText(2, "bbbb")))
+
+    assert page_for_offset(spans, 0) == 1
+    assert page_for_offset(spans, 3) == 1
+    assert page_for_offset(spans, text.index("bbbb")) == 2
+
+
+def test_offset_in_the_separator_belongs_to_no_page():
+    """A guess here would fabricate a citation; None lets the caller decide."""
+    _text, spans = render_plain((PageText(1, "aa"), PageText(2, "bb")))
+    separator_offset = spans[0].end
+    assert page_for_offset(spans, separator_offset) is None
+
+
+def test_offset_past_the_end_is_not_attributed():
+    _text, spans = render_plain((PageText(1, "aa"),))
+    assert page_for_offset(spans, 999) is None
+
+
+def test_span_crossing_a_page_break_reports_both_pages():
+    """Reporting only the first would mis-cite half the chunk's content."""
+    text, spans = render_plain((PageText(1, "first"), PageText(2, "second")))
+    assert pages_for_span(spans, 0, len(text)) == (1, 2)
+
+
+def test_empty_span_reports_nothing():
+    _text, spans = render_plain((PageText(1, "x"),))
+    assert pages_for_span(spans, 3, 3) == ()
+    assert pages_for_span(spans, 5, 2) == ()
+
+
+# ---------------------------------------------------------------------------
+# Chunk mapping
+# ---------------------------------------------------------------------------
+
+
+def test_chunks_map_back_to_their_pages():
+    text, spans = render_plain((PageText(1, "alpha"), PageText(2, "beta"), PageText(3, "gamma")))
+    chunks = ["alpha", "beta", "gamma"]
+
+    assert chunk_page_map(spans, chunks, text) == ((1,), (2,), (3,))
+
+
+def test_identical_boilerplate_does_not_collapse_onto_the_first_page():
+    """A find() from zero attributes every recurring header to page 1.
+
+    The chunks here are byte-identical, which is the case that actually
+    distinguishes a forward-scanning cursor from a naive search — an earlier
+    version of this test used *similar* chunks and passed against the bug.
+    """
+    header = "CONFIDENTIAL"
+    text, spans = render_plain((PageText(1, header), PageText(2, header), PageText(3, header)))
+
+    assert chunk_page_map(spans, [header, header, header], text) == ((1,), (2,), (3,))
+
+
+def test_a_chunk_the_chunker_rewrote_reports_no_page_rather_than_a_wrong_one():
+    text, spans = render_plain((PageText(1, "original text"),))
+    assert chunk_page_map(spans, ["text the chunker invented"], text) == ((),)
+
+
+def test_chunk_spanning_a_break_reports_both_pages():
+    text, spans = render_plain((PageText(1, "aaa"), PageText(2, "bbb")))
+    whole = text  # one chunk covering everything, separator included
+    assert chunk_page_map(spans, [whole], text) == ((1, 2),)
+
+
+# ---------------------------------------------------------------------------
+# End to end, through the real extractor and the upload metadata helper
+# ---------------------------------------------------------------------------
+
+
+def test_real_pdf_offsets_resolve_to_the_right_pages():
+    extracted = extract_pdf(_pdf(["page one body", "page two body", "page three body"]))
+    text, spans = render_plain(extracted.pages)
+
+    for span in spans:
+        recovered = text[span.start : span.end]
+        assert f"page {['one', 'two', 'three'][span.number - 1]}" in recovered
+
+
+def test_upload_metadata_offsets_index_the_stored_content():
+    """The end-to-end invariant: metadata offsets must match what was stored."""
+    from api.knowledge import _extract_file_content, _page_provenance_metadata
+
+    raw = _pdf(["alpha page", "beta page"])
+    stored_content, extracted = _extract_file_content("doc.pdf", raw)
+    metadata = _page_provenance_metadata(extracted)
+
+    assert metadata["page_count"] == 2
+    assert metadata["pages_with_text"] == [1, 2]
+    for entry in metadata["page_spans"]:
+        recovered = stored_content[entry["start"] : entry["end"]]
+        assert recovered.strip(), "a stored span must resolve to real text"
+        assert "## Page" not in recovered
+
+
+def test_stored_upload_content_has_no_page_markers():
+    from api.knowledge import _extract_file_content
+
+    stored_content, _extracted = _extract_file_content("doc.pdf", _pdf(["body one", "body two"]))
+    assert "## Page" not in stored_content
+    assert "body one" in stored_content
+
+
+def test_unpaginated_formats_get_no_fabricated_page_metadata():
+    """A DOCX has no pages; `page: 1` would be an invented citation."""
+    from api.knowledge import _page_provenance_metadata
+    from media.document.extraction import ExtractedDocument
+
+    assert _page_provenance_metadata(ExtractedDocument(format="docx", text="content")) == {}
+    assert _page_provenance_metadata(None) == {}
+
+
+def test_span_metadata_round_trips():
+    span = PageSpan(number=7, start=10, end=25)
+    assert span.as_metadata() == {"page": 7, "start": 10, "end": 25}
+
+
+def test_separator_is_shared_so_offsets_are_reproducible():
+    """Offsets are stored; a renderer that changed its separator would break them."""
+    text, spans = render_plain((PageText(1, "a"), PageText(2, "b")), separator=PAGE_SEPARATOR)
+    assert text == f"a{PAGE_SEPARATOR}b"
+    assert spans[1].start == 1 + len(PAGE_SEPARATOR)


### PR DESCRIPTION
## Thinking Path

The KB upload path stored PDF text carrying `## Page N` markers — markers **I
introduced in #13893** when unifying the page-marker convention — and that text
goes straight into the embedding.

Those markers are structure, not meaning. They compete with the document's own
words for similarity, and they are a poor provenance mechanism anyway: recovering
a page number by parsing markers back out of retrieved text breaks the moment a
chunker splits between a marker and the page it labels.

## What Changed

**`render_plain(pages)`** returns the marker-free text *and* the page spans from
one pure call over the same pages. That pairing is the whole design: the offsets
always index the exact string that was stored, because both come from the same
render. Everything else rests on that invariant, so it is asserted directly rather
than assumed.

**Resolution helpers** — `page_for_offset()`, `pages_for_span()`, `chunk_page_map()`.

Three decisions worth calling out:

- **A span crossing a page break reports both pages.** A chunk that straddles a
  break genuinely comes from two pages; reporting only the first would silently
  mis-cite half its content.
- **`chunk_page_map` scans forward from the previous chunk's end.** A `find()`
  from zero attributes every recurring header, footer and table scaffold to page 1
  — precisely the content that repeats.
- **An offset in the separator between pages resolves to `None`**, and unpaginated
  formats get no page metadata at all. A DOCX has no pages, and `page: 1` would be
  a fabricated citation.

**Upload path** stores marker-free content plus `page_count`, `page_spans` and
`pages_with_text` in fact metadata.

## Verification

```
$ pytest tests/test_page_provenance_13894.py -q
19 passed

$ pytest media/document/ tests/test_page_provenance_13894.py \
         tests/test_document_extraction_canonical_13893.py \
         tests/test_no_text_layer_reporting_13884.py -q
73 passed
```

Mutation-tested:

```
### MUTATION 1: forget the separator width (off-by-N in offsets)  → 5 failed, 14 passed
### MUTATION 2: chunk mapping searches from zero                  → 1 failed, 18 passed
### MUTATION 3: upload reverts to storing marker text             → 2 failed, 17 passed
### RESTORED                                                      → 19 passed
```

**Mutation 2 initially passed, and that was a test defect, not a pass.** The
boilerplate test used *similar* chunks (`"CONFIDENTIAL one"` / `"CONFIDENTIAL two"`),
which `find()` from zero still resolves correctly. It now uses byte-identical
chunks across three pages — the only shape that actually distinguishes a forward
cursor from a naive search. Caught because the mutation was run, not because the
test looked right.

Startup imports: `352 passed`.

## A note on the wider suite

The combined `knowledge/ tests/knowledge tests/api` run is **order-unstable**, so
raw failure counts are not comparable between runs:

| | failures |
|---|---|
| base (`Dev_new_gui`) | **9** |
| this branch | **7** |

Every failure on this branch also occurs on base, and each passes in isolation
(`tests/api/test_knowledge_grounding.py` → `31 passed` alone, on both). This branch
introduces none. Filed separately as a finding — a suite that cannot distinguish a
new failure from a scheduling artefact cannot gate anything.

## Model Used

Claude Opus 5 (1M context)

Closes #13894. Part of #13892 — Wave 2.
