### PR TITLE
feat(api): a request deadline that cannot be forgotten (#14015)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -154,6 +154,27 @@ repos:
         stages: [pre-commit]
         description: "Use autobot_shared.time_utils.utc_timestamp() instead of datetime.utcnow().isoformat()"
 
+  # #14015: every route in a covered package carries a deadline, or is declared
+  # unbounded with a reason. #13602 was an endpoint that held the socket open
+  # past 180s and logged nothing, because bounding was opt-in per call site and
+  # one handler simply had none. Only a check that covers every member by
+  # construction catches an omission.
+  #
+  # pass_filenames: false — the checker walks the covered packages itself, so a
+  # commit touching an unrelated file still validates the whole surface. A
+  # filename-scoped run would pass on the very commit that adds an unbounded
+  # route elsewhere.
+  - repo: local
+    hooks:
+      - id: route-deadlines
+        name: Every covered route carries a deadline (#14015)
+        entry: tools/lint/check_route_deadlines.py
+        language: python
+        pass_filenames: false
+        always_run: true
+        stages: [pre-commit]
+        description: "Add @bounded(seconds=...) or declare the route in UNBOUNDED_BY_DESIGN"
+
   # AutoBot custom: regression-prevention for #6987 broken `src.*` mock paths.
   # autobot-backend has no `src/` package; ``patch("src.foo.bar")`` silently
   # no-ops (ModuleNotFoundError swallowed by `with` cleanup). Production

--- a/autobot-backend/api/codebase_analytics/endpoints/api_endpoints.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/api_endpoints.py
@@ -20,7 +20,7 @@ from typing import Dict
 from fastapi import APIRouter, Query
 from fastapi.responses import JSONResponse
 
-from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from autobot_shared.error_boundaries import ErrorCategory, bounded, with_error_handling
 from autobot_shared.logging_manager import get_logger
 
 from ..api_endpoint_scanner import APIEndpointChecker
@@ -76,6 +76,7 @@ async def _get_or_run_analysis(source_id: str | None) -> APIEndpointAnalysis:
 
 
 @router.get("/api-endpoints")
+@bounded(60.0)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_api_endpoints",
@@ -104,6 +105,7 @@ async def get_api_endpoints(
 
 
 @router.get("/api-calls")
+@bounded(60.0)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_frontend_api_calls",
@@ -132,6 +134,7 @@ async def get_frontend_api_calls(
 
 
 @router.get("/endpoint-coverage")
+@bounded(60.0)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_endpoint_coverage",
@@ -173,6 +176,7 @@ async def get_endpoint_coverage(
 
 
 @router.get("/endpoint-analysis")
+@bounded(60.0)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_endpoint_analysis_full",
@@ -199,6 +203,7 @@ async def get_endpoint_analysis_full(
 
 
 @router.get("/orphaned-endpoints")
+@bounded(60.0)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_orphaned_endpoints",
@@ -226,6 +231,7 @@ async def get_orphaned_endpoints(
 
 
 @router.get("/missing-endpoints")
+@bounded(60.0)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_missing_endpoints",
@@ -253,6 +259,7 @@ async def get_missing_endpoints(
 
 
 @router.get("/used-endpoints")
+@bounded(60.0)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_used_endpoints",
@@ -293,6 +300,7 @@ async def get_used_endpoints(
 
 
 @router.post("/refresh-endpoint-cache")
+@bounded(60.0)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="refresh_endpoint_cache",

--- a/autobot-backend/api/codebase_analytics/endpoints/cache.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/cache.py
@@ -11,7 +11,7 @@ import asyncio
 from fastapi import APIRouter, Query
 from fastapi.responses import JSONResponse
 
-from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from autobot_shared.error_boundaries import ErrorCategory, bounded, with_error_handling
 from autobot_shared.logging_manager import get_logger
 
 from ..storage import get_redis_connection
@@ -23,6 +23,7 @@ router = APIRouter()
 
 
 @router.delete("/cache")
+@bounded(60.0)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="clear_codebase_cache",

--- a/autobot-backend/api/codebase_analytics/endpoints/call_graph.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/call_graph.py
@@ -19,7 +19,7 @@ from fastapi.responses import JSONResponse
 from autobot_shared.code_graph import compute_node_id, module_path_from_rel_path
 from autobot_shared.code_graph import resolve_callee as _shared_resolve_callee
 from autobot_shared.env_utils import blank_to_none
-from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from autobot_shared.error_boundaries import ErrorCategory, bounded, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_redis_client
 from autobot_shared.ssot_config import config
@@ -736,6 +736,7 @@ def _build_call_graph_response(
 
 
 @router.get("/analytics/call-graph")
+@bounded(120.0)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_call_graph",

--- a/autobot-backend/api/codebase_analytics/endpoints/charts.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/charts.py
@@ -13,7 +13,7 @@ from typing import Dict
 from fastapi import APIRouter
 from fastapi.responses import JSONResponse
 
-from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from autobot_shared.error_boundaries import ErrorCategory, bounded, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from utils.chromadb_client import get_all_paginated
 
@@ -270,6 +270,7 @@ async def _get_redis_fallback_chart_data(
 
 
 @router.get("/analytics/charts")
+@bounded(60.0)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_chart_data",

--- a/autobot-backend/api/codebase_analytics/endpoints/cross_language_patterns.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/cross_language_patterns.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from fastapi import APIRouter, Query
 from fastapi.responses import JSONResponse
 
-from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from autobot_shared.error_boundaries import ErrorCategory, bounded, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from code_intelligence.cross_language_patterns import CrossLanguagePatternDetector
 
@@ -76,6 +76,7 @@ async def _get_cached_analysis(source_id: str | None):
 
 
 @router.post("/cross-language/analyze")
+@bounded(60.0)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="run_cross_language_analysis",
@@ -130,6 +131,7 @@ async def run_cross_language_analysis(
 
 
 @router.get("/cross-language/summary")
+@bounded(60.0)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_cross_language_summary",
@@ -201,6 +203,7 @@ async def get_cross_language_summary(
 
 
 @router.get("/cross-language/dto-mismatches")
+@bounded(60.0)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_dto_mismatches",
@@ -236,6 +239,7 @@ async def get_dto_mismatches(
 
 
 @router.get("/cross-language/validation-duplications")
+@bounded(60.0)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_validation_duplications",
@@ -271,6 +275,7 @@ async def get_validation_duplications(
 
 
 @router.get("/cross-language/api-mismatches")
+@bounded(60.0)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_api_contract_mismatches",
@@ -315,6 +320,7 @@ async def get_api_contract_mismatches(
 
 
 @router.get("/cross-language/semantic-matches")
+@bounded(60.0)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_semantic_matches",
@@ -367,6 +373,7 @@ async def get_semantic_matches(
 
 
 @router.get("/cross-language/patterns")
+@bounded(60.0)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_patterns_by_category",
@@ -424,6 +431,7 @@ async def get_patterns_by_category(
 
 
 @router.post("/cross-language/clear-cache")
+@bounded(60.0)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="clear_cross_language_cache",

--- a/autobot-backend/api/codebase_analytics/endpoints/declarations.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/declarations.py
@@ -11,7 +11,7 @@ import asyncio
 from fastapi import APIRouter
 from fastapi.responses import JSONResponse
 
-from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from autobot_shared.error_boundaries import ErrorCategory, bounded, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from utils.chromadb_client import get_all_paginated
 
@@ -80,6 +80,7 @@ def _build_declarations_response(all_declarations: list, storage_type: str) -> d
 
 
 @router.get("/declarations")
+@bounded(60.0)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_code_declarations",

--- a/autobot-backend/api/codebase_analytics/endpoints/dependencies.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/dependencies.py
@@ -16,7 +16,7 @@ from celery.result import AsyncResult
 from fastapi import APIRouter, HTTPException, Query
 from fastapi.responses import JSONResponse
 
-from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from autobot_shared.error_boundaries import ErrorCategory, bounded, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from tasks.analytics_tasks import run_dependency_analysis
 from utils.celery_task_status import celery_result_to_status, get_latest_task_result, store_latest_task_id
@@ -452,6 +452,7 @@ async def _scan_filesystem_imports(
 
 
 @router.get("/analytics/dependencies")
+@bounded(60.0)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_dependencies",
@@ -513,6 +514,7 @@ async def get_dependencies(
 
 
 @router.get("/analytics/dependencies/cached")
+@bounded(60.0)
 async def get_cached_dependency_result(source_id: str = ""):
     """Return the latest completed dependency analysis result (#1540)."""
     cached = await get_latest_task_result(_REDIS_PREFIX)
@@ -527,6 +529,7 @@ async def get_cached_dependency_result(source_id: str = ""):
 
 
 @router.post("/analytics/dependencies/analyze")
+@bounded(60.0)
 async def start_dependency_analysis():
     """Enqueue dependency analysis as a Celery task (GH#6505)."""
     result = run_dependency_analysis.delay()
@@ -535,6 +538,7 @@ async def start_dependency_analysis():
 
 
 @router.get("/analytics/dependencies/status/{task_id}")
+@bounded(60.0)
 async def get_dependency_status(task_id: str):
     """Get dependency analysis task status."""
     status = celery_result_to_status(AsyncResult(task_id))
@@ -544,6 +548,7 @@ async def get_dependency_status(task_id: str):
 
 
 @router.post("/analytics/dependencies/tasks/clear-stuck")
+@bounded(60.0)
 async def clear_stuck_dep_tasks(
     force: bool = Query(default=False, description="Force clear ALL running tasks"),
 ):

--- a/autobot-backend/api/codebase_analytics/endpoints/duplicates.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/duplicates.py
@@ -23,7 +23,7 @@ from celery.result import AsyncResult
 from fastapi import APIRouter, HTTPException, Query
 from fastapi.responses import JSONResponse
 
-from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from autobot_shared.error_boundaries import ErrorCategory, bounded, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from constants.threshold_constants import AnalyticsConfig
 from tasks.analytics_tasks import run_duplicate_analysis
@@ -396,6 +396,7 @@ async def _handle_detection_failure(error: Exception, source_id: str | None = No
 
 
 @router.get("/duplicates")
+@bounded(180.0)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_duplicate_code",
@@ -542,6 +543,7 @@ def _convert_config_duplicates_to_array(duplicates_dict: dict) -> list:
 
 
 @router.get("/config-duplicates")
+@bounded(180.0)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="detect_config_duplicates",
@@ -603,6 +605,7 @@ async def detect_config_duplicates_endpoint(
 
 
 @router.get("/duplicates/cached")
+@bounded(180.0)
 async def get_cached_duplicate_result(source_id: str = ""):
     """Return the latest completed duplicate analysis result (#1540)."""
     cached = await get_latest_task_result(_REDIS_PREFIX)
@@ -617,6 +620,7 @@ async def get_cached_duplicate_result(source_id: str = ""):
 
 
 @router.post("/duplicates/analyze")
+@bounded(180.0)
 async def start_duplicate_analysis():
     """Enqueue duplicate analysis as a Celery task (GH#6505)."""
     result = run_duplicate_analysis.delay()
@@ -625,6 +629,7 @@ async def start_duplicate_analysis():
 
 
 @router.get("/duplicates/status/{task_id}")
+@bounded(180.0)
 async def get_duplicate_status(task_id: str):
     """Get duplicate analysis task status."""
     status = celery_result_to_status(AsyncResult(task_id))
@@ -634,6 +639,7 @@ async def get_duplicate_status(task_id: str):
 
 
 @router.post("/duplicates/tasks/clear-stuck")
+@bounded(180.0)
 async def clear_stuck_dup_tasks(
     force: bool = Query(default=False, description="Force clear ALL running tasks"),
 ):

--- a/autobot-backend/api/codebase_analytics/endpoints/environment.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/environment.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from fastapi import APIRouter, Query
 from fastapi.responses import JSONResponse
 
-from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from autobot_shared.error_boundaries import ErrorCategory, bounded, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_config import QUALITY_MODEL
 
@@ -381,6 +381,7 @@ async def _analyze_and_return_env_result(
 
 
 @router.get("/env-analysis")
+@bounded(60.0)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_environment_analysis",
@@ -433,6 +434,7 @@ async def get_environment_analysis(
 
 
 @router.get("/env-recommendations")
+@bounded(60.0)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_env_recommendations",
@@ -639,6 +641,7 @@ def _validate_export_severity(severity: str | None) -> JSONResponse | None:
 
 
 @router.get("/env-analysis/export")
+@bounded(60.0)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="export_env_analysis",

--- a/autobot-backend/api/codebase_analytics/endpoints/environment.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/environment.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from fastapi import APIRouter, Query
 from fastapi.responses import JSONResponse
 
-from autobot_shared.error_boundaries import ErrorCategory, bounded, with_error_handling
+from autobot_shared.error_boundaries import ROUTE_DEADLINE_GRACE, ErrorCategory, bounded, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_config import QUALITY_MODEL
 
@@ -83,6 +83,13 @@ def _validate_env_path_security(path: str, project_root: str) -> JSONResponse | 
         )
 
 
+# #14015: module level so the route decorator can clear the LARGER of the two.
+# `use_llm_filter` is a caller-facing Query param, so the 240s path is
+# reachable on request and a 60s route bound would have 504'd it every time.
+ANALYSIS_TIMEOUT = 120  # 2 minute timeout for large codebases
+LLM_ANALYSIS_TIMEOUT = 240  # 2 min base + 2 min for the LLM pass
+
+
 async def _run_environment_analysis(analyzer, path: str, pattern_list: list):
     """
     Run environment analysis with timeout.
@@ -95,7 +102,6 @@ async def _run_environment_analysis(analyzer, path: str, pattern_list: list):
     Returns:
         Analysis result or None if timed out
     """
-    ANALYSIS_TIMEOUT = 120  # 2 minute timeout for large codebases
     try:
         coro = analyzer.analyze_codebase(path, pattern_list)
         if asyncio.iscoroutine(coro):
@@ -131,7 +137,6 @@ async def _run_llm_filtered_analysis(
         Analysis result with LLM filtering applied, or None if timed out
     """
     # Issue #633: Extended timeout for LLM filtering (2 min base + 2 min for LLM)
-    LLM_ANALYSIS_TIMEOUT = 240
     try:
         coro = analyzer.analyze_codebase_with_llm_filter(
             path,
@@ -381,7 +386,7 @@ async def _analyze_and_return_env_result(
 
 
 @router.get("/env-analysis")
-@bounded(60.0)
+@bounded(LLM_ANALYSIS_TIMEOUT + ROUTE_DEADLINE_GRACE)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_environment_analysis",
@@ -434,7 +439,7 @@ async def get_environment_analysis(
 
 
 @router.get("/env-recommendations")
-@bounded(60.0)
+@bounded(LLM_ANALYSIS_TIMEOUT + ROUTE_DEADLINE_GRACE)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_env_recommendations",
@@ -641,7 +646,7 @@ def _validate_export_severity(severity: str | None) -> JSONResponse | None:
 
 
 @router.get("/env-analysis/export")
-@bounded(60.0)
+@bounded(LLM_ANALYSIS_TIMEOUT + ROUTE_DEADLINE_GRACE)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="export_env_analysis",

--- a/autobot-backend/api/codebase_analytics/endpoints/impact.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/impact.py
@@ -28,7 +28,7 @@ import asyncio
 from fastapi import APIRouter, Query
 from fastapi.responses import JSONResponse
 
-from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from autobot_shared.error_boundaries import ErrorCategory, bounded, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from services.knowledge.impact_analysis import find_impact
 
@@ -40,6 +40,7 @@ router = APIRouter()
 
 
 @router.get("/impact")
+@bounded(60.0)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="analyze_impact",

--- a/autobot-backend/api/codebase_analytics/endpoints/import_tree.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/import_tree.py
@@ -17,7 +17,7 @@ from celery.result import AsyncResult
 from fastapi import APIRouter, HTTPException, Query
 from fastapi.responses import JSONResponse
 
-from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from autobot_shared.error_boundaries import ErrorCategory, bounded, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from tasks.analytics_tasks import run_import_tree_analysis
 from utils.celery_task_status import celery_result_to_status, get_latest_task_result, store_latest_task_id
@@ -224,6 +224,7 @@ async def _scan_import_tree_live(source_id: str | None) -> Tuple[Dict[str, List[
 
 
 @router.get("/analytics/import-tree")
+@bounded(60.0)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_import_tree",
@@ -354,6 +355,7 @@ def _build_summary(import_tree: List[Dict]) -> Dict:
 
 
 @router.get("/analytics/import-tree/cached")
+@bounded(60.0)
 async def get_cached_import_tree_result(source_id: str = ""):
     """Return the latest completed import tree analysis result (#1540)."""
     cached = await get_latest_task_result(_REDIS_PREFIX)
@@ -368,6 +370,7 @@ async def get_cached_import_tree_result(source_id: str = ""):
 
 
 @router.post("/analytics/import-tree/analyze")
+@bounded(60.0)
 async def start_import_tree_analysis_endpoint():
     """Enqueue import tree analysis as a Celery task (GH#6505)."""
     result = run_import_tree_analysis.delay()
@@ -376,6 +379,7 @@ async def start_import_tree_analysis_endpoint():
 
 
 @router.get("/analytics/import-tree/status/{task_id}")
+@bounded(60.0)
 async def get_import_tree_status(task_id: str):
     """Get import tree analysis task status."""
     status = celery_result_to_status(AsyncResult(task_id))
@@ -385,6 +389,7 @@ async def get_import_tree_status(task_id: str):
 
 
 @router.post("/analytics/import-tree/tasks/clear-stuck")
+@bounded(60.0)
 async def clear_stuck_import_tasks(
     force: bool = Query(default=False, description="Force clear ALL running tasks"),
 ):

--- a/autobot-backend/api/codebase_analytics/endpoints/indexing.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/indexing.py
@@ -33,7 +33,7 @@ class IndexCodebaseRequest(BaseModel):
     )
 
 
-from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from autobot_shared.error_boundaries import ErrorCategory, bounded, with_error_handling
 
 from ..scanner import (
     _active_tasks,
@@ -188,6 +188,7 @@ def _create_cleanup_callback(task_id: str):
 
 
 @router.post("/index")
+@bounded(60.0)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="index_codebase",
@@ -265,6 +266,7 @@ async def index_codebase(http_request: Request, request: IndexCodebaseRequest | 
 
 
 @router.get("/index/status/{task_id}")
+@bounded(60.0)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_indexing_status",
@@ -312,6 +314,7 @@ async def get_indexing_status(task_id: str):
 
 
 @router.get("/index/current")
+@bounded(60.0)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_current_indexing_job",
@@ -418,6 +421,7 @@ def _cancel_active_task(task_id: str, existing_task) -> JSONResponse:
 
 
 @router.post("/index/cancel")
+@bounded(60.0)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="cancel_indexing_job",

--- a/autobot-backend/api/codebase_analytics/endpoints/ownership.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/ownership.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from fastapi import APIRouter, Query
 from fastapi.responses import JSONResponse
 
-from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from autobot_shared.error_boundaries import ErrorCategory, bounded, with_error_handling
 from autobot_shared.logging_manager import get_logger
 
 from .shared import resolve_project_root, resolve_scan_root
@@ -326,6 +326,7 @@ async def _cache_ownership_result(result: dict, source_id: str | None = None) ->
 
 
 @router.get("/analysis")
+@bounded(60.0)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_ownership_analysis",
@@ -393,6 +394,7 @@ async def get_ownership_analysis(
 
 
 @router.get("/expertise")
+@bounded(60.0)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_expertise_scores",
@@ -448,6 +450,7 @@ async def get_expertise_scores(
 
 
 @router.get("/knowledge-gaps")
+@bounded(60.0)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_knowledge_gaps",

--- a/autobot-backend/api/codebase_analytics/endpoints/ownership.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/ownership.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from fastapi import APIRouter, Query
 from fastapi.responses import JSONResponse
 
-from autobot_shared.error_boundaries import ErrorCategory, bounded, with_error_handling
+from autobot_shared.error_boundaries import ROUTE_DEADLINE_GRACE, ErrorCategory, bounded, with_error_handling
 from autobot_shared.logging_manager import get_logger
 
 from .shared import resolve_project_root, resolve_scan_root
@@ -142,6 +142,11 @@ def _validate_path_security(path: str, project_root: str) -> JSONResponse | None
         )
 
 
+# #14015: module level so the route decorator can clear it. A route bound
+# BELOW its own internal budget converts a slow success into a guaranteed 504.
+ANALYSIS_TIMEOUT = 180  # 3 minute timeout for git operations
+
+
 async def _run_ownership_analysis(analyzer, path: str, pattern_list: list, days: int):
     """
     Run ownership analysis with timeout.
@@ -155,7 +160,6 @@ async def _run_ownership_analysis(analyzer, path: str, pattern_list: list, days:
     Returns:
         Analysis result or None if timed out
     """
-    ANALYSIS_TIMEOUT = 180  # 3 minute timeout for git operations
     try:
         coro = analyzer.analyze_ownership(path, pattern_list, days)
         if asyncio.iscoroutine(coro):
@@ -326,7 +330,7 @@ async def _cache_ownership_result(result: dict, source_id: str | None = None) ->
 
 
 @router.get("/analysis")
-@bounded(60.0)
+@bounded(ANALYSIS_TIMEOUT + ROUTE_DEADLINE_GRACE)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_ownership_analysis",
@@ -394,7 +398,7 @@ async def get_ownership_analysis(
 
 
 @router.get("/expertise")
-@bounded(60.0)
+@bounded(ANALYSIS_TIMEOUT + ROUTE_DEADLINE_GRACE)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_expertise_scores",
@@ -450,7 +454,7 @@ async def get_expertise_scores(
 
 
 @router.get("/knowledge-gaps")
-@bounded(60.0)
+@bounded(ANALYSIS_TIMEOUT + ROUTE_DEADLINE_GRACE)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_knowledge_gaps",

--- a/autobot-backend/api/codebase_analytics/endpoints/pattern_analysis.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/pattern_analysis.py
@@ -17,6 +17,7 @@ from celery.result import AsyncResult
 from fastapi import APIRouter, HTTPException, Query, Request
 from pydantic import BaseModel, Field
 
+from autobot_shared.error_boundaries import bounded
 from autobot_shared.logging_manager import get_logger
 from constants.path_constants import PATH
 from constants.threshold_constants import QueryDefaults
@@ -138,6 +139,7 @@ async def _clear_checkpoint(task_id: str) -> None:
 
 
 @router.post("/patterns/analyze", response_model=PatternAnalysisStatus)
+@bounded(60.0)
 async def start_pattern_analysis(request: PatternAnalysisRequest, http_request: Request) -> PatternAnalysisStatus:
     """Enqueue code pattern analysis as a Celery task (GH#6505, GH#8436)."""
     # #12375: source_id arrives in the request BODY here, so the router-level
@@ -159,6 +161,7 @@ async def start_pattern_analysis(request: PatternAnalysisRequest, http_request: 
 
 
 @router.get("/patterns/status/{task_id}", response_model=PatternAnalysisStatus)
+@bounded(60.0)
 async def get_analysis_status(task_id: str) -> PatternAnalysisStatus:
     """Get status of a pattern analysis task."""
     task = celery_result_to_status(AsyncResult(task_id))
@@ -177,6 +180,7 @@ async def get_analysis_status(task_id: str) -> PatternAnalysisStatus:
 
 
 @router.get("/patterns/result/{task_id}")
+@bounded(60.0)
 async def get_analysis_result(task_id: str) -> Dict[str, Any]:
     """Get full results of a completed pattern analysis."""
     task = celery_result_to_status(AsyncResult(task_id))
@@ -188,6 +192,7 @@ async def get_analysis_result(task_id: str) -> Dict[str, Any]:
 
 
 @router.delete("/patterns/task/{task_id}")
+@bounded(60.0)
 async def cancel_analysis(task_id: str) -> Dict[str, str]:
     """Revoke a pending/running pattern analysis task (GH#8440: async-safe)."""
     from celery_app import celery_app
@@ -197,6 +202,7 @@ async def cancel_analysis(task_id: str) -> Dict[str, str]:
 
 
 @router.get("/patterns/tasks")
+@bounded(60.0)
 async def list_analysis_tasks() -> Dict[str, Any]:
     """List active pattern analysis tasks (GH#8440: async-safe Celery inspect)."""
     from celery_app import celery_app
@@ -207,6 +213,7 @@ async def list_analysis_tasks() -> Dict[str, Any]:
 
 
 @router.post("/patterns/tasks/clear-stuck")
+@bounded(60.0)
 async def clear_stuck_tasks(
     force: bool = Query(default=False, description="Force clear ALL running tasks"),
 ) -> Dict[str, Any]:
@@ -215,6 +222,7 @@ async def clear_stuck_tasks(
 
 
 @router.post("/patterns/tasks/clear-all")
+@bounded(60.0)
 async def clear_all_tasks() -> Dict[str, str]:
     """Revoke active analytics tasks without purging other Celery queues (GH#8438)."""
     from celery_app import celery_app
@@ -229,6 +237,7 @@ async def clear_all_tasks() -> Dict[str, str]:
 
 
 @router.get("/patterns/summary", response_model=PatternSummary)
+@bounded(60.0)
 async def get_pattern_summary(
     path: str = Query(default_factory=lambda: str(PATH.PROJECT_ROOT), description="Path to analyze"),
 ) -> PatternSummary:
@@ -262,6 +271,7 @@ async def get_pattern_summary(
 
 
 @router.post("/patterns/summary/analyze")
+@bounded(60.0)
 async def start_pattern_summary_analysis(
     path: str = Query(default_factory=lambda: str(PATH.PROJECT_ROOT), description="Path to analyze"),
 ):
@@ -272,6 +282,7 @@ async def start_pattern_summary_analysis(
 
 
 @router.get("/patterns/summary/status/{task_id}")
+@bounded(60.0)
 async def get_pattern_summary_status(task_id: str):
     """Get pattern summary task status."""
     status = celery_result_to_status(AsyncResult(task_id))
@@ -281,6 +292,7 @@ async def get_pattern_summary_status(task_id: str):
 
 
 @router.post("/patterns/summary/tasks/clear-stuck")
+@bounded(60.0)
 async def clear_stuck_summary_tasks(
     force: bool = Query(default=False, description="Force clear ALL running tasks"),
 ):
@@ -289,6 +301,7 @@ async def clear_stuck_summary_tasks(
 
 
 @router.get("/patterns/duplicates")
+@bounded(60.0)
 async def get_duplicate_patterns(
     path: str = Query(default_factory=lambda: str(PATH.PROJECT_ROOT), description="Path to analyze"),
     limit: int = Query(default=20, ge=1, le=100, description="Maximum results"),
@@ -318,6 +331,7 @@ async def get_duplicate_patterns(
 
 
 @router.get("/patterns/regex-opportunities")
+@bounded(60.0)
 async def get_regex_opportunities(
     path: str = Query(default_factory=lambda: str(PATH.PROJECT_ROOT), description="Path to analyze"),
     limit: int = Query(default=20, ge=1, le=100, description="Maximum results"),
@@ -347,6 +361,7 @@ async def get_regex_opportunities(
 
 
 @router.get("/patterns/complexity-hotspots")
+@bounded(60.0)
 async def get_complexity_hotspots(
     path: str = Query(default_factory=lambda: str(PATH.PROJECT_ROOT), description="Path to analyze"),
     limit: int = Query(default=20, ge=1, le=100, description="Maximum results"),
@@ -385,6 +400,7 @@ async def get_complexity_hotspots(
 
 
 @router.get("/patterns/refactoring-suggestions")
+@bounded(60.0)
 async def get_refactoring_suggestions(
     path: str = Query(default_factory=lambda: str(PATH.PROJECT_ROOT), description="Path to analyze"),
     limit: int = Query(default=20, ge=1, le=100, description="Maximum results"),
@@ -415,6 +431,7 @@ async def get_refactoring_suggestions(
 
 
 @router.get("/patterns/report")
+@bounded(60.0)
 async def get_pattern_report(
     path: str = Query(default_factory=lambda: str(PATH.PROJECT_ROOT), description="Path to analyze"),
     format: str = Query(default="json", description="Output format: json or markdown"),
@@ -445,6 +462,7 @@ async def get_pattern_report(
 
 
 @router.get("/patterns/storage/stats")
+@bounded(60.0)
 async def get_pattern_storage_stats(
     source_id: str | None = Query(default=None, description="Code source to scope stats to (Issue #12384)"),
 ) -> Dict[str, Any]:
@@ -529,6 +547,7 @@ def _aggregate_pattern_metadata(metadatas: List[Dict]) -> Dict[str, Any]:
 
 
 @router.get("/patterns/cached-summary")
+@bounded(60.0)
 async def get_cached_pattern_summary(
     source_id: str | None = Query(default=None, description="Code source to scope the summary to (Issue #12384)"),
 ) -> Dict[str, Any]:
@@ -664,6 +683,7 @@ def _format_pattern_results(
 
 
 @router.get("/patterns/cached-patterns")
+@bounded(60.0)
 async def get_cached_patterns(
     pattern_type: str | None = Query(None, description="Filter by pattern type"),
     severity: str | None = Query(None, description="Filter by severity"),
@@ -733,6 +753,7 @@ async def get_cached_patterns(
 
 
 @router.post("/patterns/storage/clear")
+@bounded(60.0)
 async def clear_pattern_storage(
     source_id: str | None = Query(default=None, description="Code source to scope the clear to (Issue #12408)"),
 ) -> Dict[str, str]:
@@ -762,6 +783,7 @@ async def clear_pattern_storage(
 
 
 @router.get("/patterns/similar")
+@bounded(60.0)
 async def search_similar_patterns_endpoint(
     code: str = Query(..., description="Code snippet to find similar patterns for"),
     pattern_type: str | None = Query(None, description="Filter by pattern type"),

--- a/autobot-backend/api/codebase_analytics/endpoints/queue.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/queue.py
@@ -12,7 +12,7 @@ Mount point: /api/analytics/codebase (via router.py)
 from fastapi import APIRouter
 from fastapi.responses import JSONResponse
 
-from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from autobot_shared.error_boundaries import ErrorCategory, bounded, with_error_handling
 from autobot_shared.logging_manager import get_logger
 
 from ..scanner import (
@@ -41,6 +41,7 @@ def _build_running_info(task_id: str) -> dict:
 
 
 @router.get("/index/queue")
+@bounded(60.0)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_index_queue",
@@ -72,6 +73,7 @@ async def get_index_queue():
 
 
 @router.delete("/index/queue/{source_id}")
+@bounded(60.0)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="dequeue_source",

--- a/autobot-backend/api/codebase_analytics/endpoints/report.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/report.py
@@ -18,7 +18,7 @@ from typing import Any, Dict, List, Set, Tuple
 from fastapi import APIRouter
 from fastapi.responses import PlainTextResponse
 
-from autobot_shared.error_boundaries import ErrorCategory, bounded, with_error_handling
+from autobot_shared.error_boundaries import ROUTE_DEADLINE_GRACE, ErrorCategory, bounded, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from code_intelligence.bug_predictor import BugPredictor, PredictionResult
 
@@ -2171,7 +2171,7 @@ def _render_report(problems: list, analyses: dict) -> str:
 
 
 @router.get("/report")
-@bounded(180.0)
+@bounded(PATTERN_ANALYSIS_TIMEOUT + ANALYSIS_DEADLINE_GRACE + ROUTE_DEADLINE_GRACE)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="generate_report",

--- a/autobot-backend/api/codebase_analytics/endpoints/report.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/report.py
@@ -18,7 +18,7 @@ from typing import Any, Dict, List, Set, Tuple
 from fastapi import APIRouter
 from fastapi.responses import PlainTextResponse
 
-from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from autobot_shared.error_boundaries import ErrorCategory, bounded, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from code_intelligence.bug_predictor import BugPredictor, PredictionResult
 
@@ -2171,6 +2171,7 @@ def _render_report(problems: list, analyses: dict) -> str:
 
 
 @router.get("/report")
+@bounded(180.0)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="generate_report",

--- a/autobot-backend/api/codebase_analytics/endpoints/sources.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/sources.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import JSONResponse
 
-from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from autobot_shared.error_boundaries import ErrorCategory, bounded, with_error_handling
 from autobot_shared.logging_manager import get_logger
 
 from .. import source_service
@@ -228,6 +228,7 @@ async def _trigger_indexing(source: CodeSource) -> None:
 
 
 @router.get("/sources")
+@bounded(60.0)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="list_sources",
@@ -240,6 +241,7 @@ async def list_code_sources():
 
 
 @router.post("/sources")
+@bounded(60.0)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="create_source",
@@ -309,6 +311,7 @@ async def _auto_index_local_source(source: CodeSource) -> None:
 
 
 @router.get("/sources/summary")
+@bounded(60.0)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="batch_source_summary",
@@ -328,6 +331,7 @@ async def get_all_source_summaries():
 
 
 @router.get("/sources/{source_id}")
+@bounded(60.0)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_source",
@@ -342,6 +346,7 @@ async def get_code_source(source_id: str):
 
 
 @router.put("/sources/{source_id}")
+@bounded(60.0)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="update_source",
@@ -365,6 +370,7 @@ async def update_code_source(source_id: str, request: CodeSourceUpdateRequest):
 
 
 @router.delete("/sources/{source_id}")
+@bounded(60.0)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="delete_source",
@@ -382,6 +388,7 @@ async def delete_code_source(source_id: str):
 
 
 @router.post("/sources/{source_id}/sync")
+@bounded(60.0)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="sync_source",
@@ -432,6 +439,7 @@ async def sync_code_source(source_id: str):
 
 
 @router.post("/sources/{source_id}/share")
+@bounded(60.0)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="share_source",
@@ -550,6 +558,7 @@ async def _build_summary(source: CodeSource) -> dict:
 
 
 @router.get("/sources/{source_id}/summary")
+@bounded(60.0)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="source_summary",

--- a/autobot-backend/api/codebase_analytics/endpoints/stats.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/stats.py
@@ -15,7 +15,7 @@ from fastapi import APIRouter
 from fastapi.responses import JSONResponse
 
 from api.analytics_shared import no_data_response
-from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from autobot_shared.error_boundaries import ErrorCategory, bounded, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.time_utils import parse_utc_iso
 from utils.chromadb_client import get_all_paginated
@@ -187,6 +187,7 @@ def _build_indexing_response(
 
 
 @router.get("/stats")
+@bounded(60.0)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_codebase_stats",
@@ -326,6 +327,7 @@ _normalize_hardcode_record = normalize_hardcode_record
 
 
 @router.get("/hardcodes")
+@bounded(60.0)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_hardcoded_values",
@@ -483,6 +485,7 @@ async def _fetch_problems_from_redis(problem_type: str | None, source_id: str | 
 
 
 @router.get("/embedding-stats")
+@bounded(60.0)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_embedding_stats",
@@ -545,6 +548,7 @@ async def get_embedding_stats() -> JSONResponse:
 
 
 @router.post("/embedding-stats/reset")
+@bounded(60.0)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="reset_embedding_stats",
@@ -589,6 +593,7 @@ async def reset_embedding_stats_endpoint() -> JSONResponse:
 
 
 @router.get("/problems")
+@bounded(60.0)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_codebase_problems",

--- a/autobot-backend/utils/error_boundaries/__init__.py
+++ b/autobot-backend/utils/error_boundaries/__init__.py
@@ -17,6 +17,7 @@ Provides centralized error handling, recovery mechanisms, and error reporting.
 from .boundary_manager import ErrorBoundaryManager, get_error_boundary_manager
 from .decorators import (
     DEFAULT_ROUTE_DEADLINE_SECONDS,
+    ROUTE_DEADLINE_GRACE,
     bounded,
     error_boundary,
     get_error_statistics,
@@ -88,6 +89,7 @@ __all__ = [
     # Decorators and utilities
     "error_boundary",
     "DEFAULT_ROUTE_DEADLINE_SECONDS",
+    "ROUTE_DEADLINE_GRACE",
     "bounded",
     "with_error_handling",
     "with_error_boundary",

--- a/autobot-backend/utils/error_boundaries/__init__.py
+++ b/autobot-backend/utils/error_boundaries/__init__.py
@@ -16,6 +16,8 @@ Provides centralized error handling, recovery mechanisms, and error reporting.
 
 from .boundary_manager import ErrorBoundaryManager, get_error_boundary_manager
 from .decorators import (
+    DEFAULT_ROUTE_DEADLINE_SECONDS,
+    bounded,
     error_boundary,
     get_error_statistics,
     with_async_error_boundary,
@@ -85,6 +87,8 @@ __all__ = [
     "get_error_boundary_manager",
     # Decorators and utilities
     "error_boundary",
+    "DEFAULT_ROUTE_DEADLINE_SECONDS",
+    "bounded",
     "with_error_handling",
     "with_error_boundary",
     "with_async_error_boundary",

--- a/autobot-backend/utils/error_boundaries/decorators.py
+++ b/autobot-backend/utils/error_boundaries/decorators.py
@@ -295,6 +295,86 @@ def _raise_or_return_error(error_response: APIErrorResponse):
     raise HTTPException(status_code=error_response.status_code, detail=error_response.to_dict())
 
 
+# #14015: the request-layer deadline.
+#
+# Before this, bounding was opt-in and per-call-site: every handler that wanted
+# a limit hand-rolled `asyncio.wait_for`, with its own constant. `report.py`
+# alone carried three different ones — and one analysis with none at all, which
+# is #13602: the endpoint held the socket open past 180s and logged nothing,
+# because the handler never ran.
+#
+# The problem is the pattern, not that one omission. When bounding is opt-in, an
+# unbounded path is invisible — it looks exactly like every other handler until
+# it hangs. So the deadline is a decorator that stacks with with_error_handling,
+# and `tools/lint/check_route_deadlines.py` requires every covered route to
+# carry one or to be listed as deliberately unbounded WITH A REASON. An
+# unbounded route becomes a declaration rather than a default.
+DEFAULT_ROUTE_DEADLINE_SECONDS = 60.0
+
+
+def bounded(seconds: float = DEFAULT_ROUTE_DEADLINE_SECONDS, *, operation: str | None = None):
+    """Bound an async route handler, returning a structured error on timeout.
+
+    Wraps the handler in ``asyncio.wait_for``. On expiry the client gets a 504
+    naming the endpoint and the limit, instead of a socket held open with
+    nothing logged.
+
+    Deliberately raises ``HTTPException`` rather than returning a response
+    object: that is what ``with_error_handling`` already does on this stack, so
+    a timeout and a failure surface through the same path.
+
+    Args:
+        seconds: Wall-clock limit. Must be positive — a zero or negative
+            deadline would make ``wait_for`` expire immediately, turning every
+            request into a 504, which is the kind of always-on failure that
+            reads as a broken endpoint rather than a misconfiguration.
+        operation: Name for the error payload and the log line. Defaults to the
+            handler's own name, which is what an operator greps for.
+
+    Raises:
+        ValueError: at decoration time (import time) for a non-positive
+            deadline, so the mistake surfaces at startup rather than on the
+            first request.
+    """
+    if seconds <= 0:
+        raise ValueError(f"bounded() needs a positive deadline, got {seconds!r}")
+
+    def decorator(func: Callable) -> Callable:
+        name = operation or getattr(func, "__name__", "unknown")
+
+        @functools.wraps(func)
+        async def wrapper(*args, **kwargs):
+            try:
+                return await asyncio.wait_for(func(*args, **kwargs), timeout=seconds)
+            except asyncio.TimeoutError:
+                # The one thing #13602 could not do: say something. A hang with
+                # no output is indistinguishable from a slow network, a stuck
+                # proxy or a dead process.
+                logger.warning(
+                    "Request deadline exceeded: %s did not complete within %.1fs (#14015)",
+                    name,
+                    seconds,
+                )
+                raise HTTPException(
+                    status_code=504,
+                    detail={
+                        "status": "error",
+                        "error": "deadline_exceeded",
+                        "operation": name,
+                        "timeout_seconds": seconds,
+                        "message": (
+                            f"{name} did not complete within {seconds:.0f}s. The work may still be "
+                            "running server-side; retry or narrow the request."
+                        ),
+                    },
+                ) from None
+
+        wrapper.__route_deadline_seconds__ = seconds
+        return wrapper
+
+    return decorator
+
+
 def with_error_handling(
     category: ErrorCategory = ErrorCategory.SERVER_ERROR,
     operation: str = None,

--- a/autobot-backend/utils/error_boundaries/decorators.py
+++ b/autobot-backend/utils/error_boundaries/decorators.py
@@ -311,6 +311,15 @@ def _raise_or_return_error(error_response: APIErrorResponse):
 # unbounded route becomes a declaration rather than a default.
 DEFAULT_ROUTE_DEADLINE_SECONDS = 60.0
 
+# Margin a route-level deadline must clear above the largest internal budget
+# reachable from that route. #14015 review: a blanket 60s outer bound sat BELOW
+# pre-existing internal timeouts of 120s, 180s and 240s, which would have turned
+# previously-slow-but-successful requests into guaranteed 504s. And on /report
+# the outer bound was tighter than its own fan-out ceiling, so it would have won
+# the race with a generic message where report.py's design says the inner
+# deadline should win and name the analysis that ran long.
+ROUTE_DEADLINE_GRACE = 15.0
+
 
 def bounded(seconds: float = DEFAULT_ROUTE_DEADLINE_SECONDS, *, operation: str | None = None):
     """Bound an async route handler, returning a structured error on timeout.

--- a/autobot-backend/utils/error_boundaries/route_deadline_14015_test.py
+++ b/autobot-backend/utils/error_boundaries/route_deadline_14015_test.py
@@ -249,3 +249,78 @@ class TestTheCheckerActuallyFires:
             "async def _helper():\n    return {}\n",
         )
         assert code == 0
+
+
+class TestTheCeilingCheckActuallyFires:
+    """Round-2 review: disabling the too-tight branch entirely left all 17 tests
+    green.
+
+    Coverage for "the checker enforces the ceiling" came only from the real repo
+    happening to have no too-tight routes today — which is the same
+    "asserting it passes today is not asserting it catches an omission" trap
+    this file's own commit message called out for `_is_bounded`, reappearing on
+    the newer and more consequential half of the checker.
+    """
+
+    def _run_against(self, tmp_path, body: str) -> int:
+        import importlib.util
+
+        pkg = tmp_path / "endpoints"
+        pkg.mkdir(exist_ok=True)
+        (pkg / "routes.py").write_text(body, encoding="utf-8")
+        spec = importlib.util.spec_from_file_location("_ceiling_checker", _CHECKER)
+        checker = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(checker)
+        checker._REPO_ROOT = tmp_path
+        checker.COVERED_PACKAGES = ("endpoints",)
+        checker.UNBOUNDED_BY_DESIGN = {}
+        return checker.main()
+
+    def test_a_literal_below_the_files_budget_fails(self, tmp_path):
+        code = self._run_against(
+            tmp_path,
+            "TOTAL_TIMEOUT = 300\n\n\n"
+            '@router.get("/thing")\n@bounded(10.0)\nasync def get_thing():\n    return {}\n',
+        )
+        assert code == 1, "a route bounded under its own file's budget was accepted"
+
+    def test_a_derived_expression_that_computes_low_also_fails(self, tmp_path):
+        """The hole review found: computed expressions were exempt outright, so
+        `TIMEOUT - 170` read as 'derived, therefore fine' at 10 seconds."""
+        code = self._run_against(
+            tmp_path,
+            "TOTAL_TIMEOUT = 300\n\n\n"
+            '@router.get("/thing")\n@bounded(TOTAL_TIMEOUT - 290.0)\nasync def get_thing():\n    return {}\n',
+        )
+        assert code == 1, "a derived expression computing below the budget was accepted"
+
+    def test_a_derived_expression_that_clears_the_budget_passes(self, tmp_path):
+        """The direction that must stay true, and the reason deriving is the
+        recommended pattern: it stays correct when the budget moves."""
+        code = self._run_against(
+            tmp_path,
+            "TOTAL_TIMEOUT = 300\nGRACE = 15\n\n\n"
+            '@router.get("/thing")\n@bounded(TOTAL_TIMEOUT + GRACE)\nasync def get_thing():\n    return {}\n',
+        )
+        assert code == 0
+
+    def test_an_unresolvable_name_does_not_silently_exempt_the_route(self, tmp_path):
+        """`ROUTE_DEADLINE_GRACE` is imported, not module-level. Treating an
+        unknown name as unresolvable would skip exactly the routes this check
+        exists for; it contributes zero instead, so the estimate errs low and
+        the check errs toward flagging."""
+        code = self._run_against(
+            tmp_path,
+            "TOTAL_TIMEOUT = 300\n\n\n"
+            '@router.get("/thing")\n@bounded(IMPORTED_GRACE)\nasync def get_thing():\n    return {}\n',
+        )
+        assert code == 1, "an unresolvable deadline was treated as clearing the budget"
+
+    def test_a_file_with_no_budget_constrains_nothing(self, tmp_path):
+        """No `*_TIMEOUT` in the file means no ceiling to clear — a small bound
+        there is a choice, not a defect."""
+        code = self._run_against(
+            tmp_path,
+            '@router.get("/thing")\n@bounded(5.0)\nasync def get_thing():\n    return {}\n',
+        )
+        assert code == 0

--- a/autobot-backend/utils/error_boundaries/route_deadline_14015_test.py
+++ b/autobot-backend/utils/error_boundaries/route_deadline_14015_test.py
@@ -1,0 +1,179 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""A route that exceeds its deadline says so, and every covered route has one (#14015).
+
+#13602: `/api/analytics/codebase/report` held the socket open past 180s and
+logged nothing — no exception, no timeout, no trace. Not a slow endpoint; a
+handler that never ran, because it queued behind eight busy executor workers on
+the one analysis in its fan-out that had no `asyncio.wait_for`.
+
+The defect is the PATTERN. When bounding is opt-in and per-call-site, an
+unbounded path is invisible — it looks exactly like every other handler until it
+hangs. `report.py` carried three different timeout constants and one analysis
+with none, and nothing about the file made that visible.
+
+So there are two halves here and both are load-bearing: a decorator that turns
+the hang into a 504 naming the endpoint, and a checker that makes an unbounded
+route a declaration rather than a default.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import subprocess  # nosec B404  # runs the repo's own checker
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+
+from autobot_shared.error_boundaries import DEFAULT_ROUTE_DEADLINE_SECONDS, bounded
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_CHECKER = _REPO_ROOT / "tools" / "lint" / "check_route_deadlines.py"
+
+
+class TestTheDeadlineFires:
+    @pytest.mark.asyncio
+    async def test_a_handler_that_never_returns_becomes_a_504(self):
+        """The reproduction, not the predicate. #13602's handler never returned
+        and the socket stayed open; a test asserting only that the decorator is
+        present would pass against a decorator that never fires."""
+
+        @bounded(0.05, operation="never_returns")
+        async def handler():
+            await asyncio.Event().wait()
+
+        # Outer bound on purpose: without the decorator's wait_for this handler
+        # never returns, and a mutation test would hang the suite instead of
+        # failing it — which in CI is a cancelled job, not a report.
+        with pytest.raises(HTTPException) as exc:
+            await asyncio.wait_for(handler(), timeout=10)
+
+        assert exc.value.status_code == 504
+        assert exc.value.detail["error"] == "deadline_exceeded"
+
+    @pytest.mark.asyncio
+    async def test_the_error_names_the_endpoint_and_the_limit(self):
+        """A hang with no output is indistinguishable from a slow network, a
+        stuck proxy or a dead process. The payload has to be actionable."""
+
+        @bounded(0.05, operation="named_thing")
+        async def handler():
+            await asyncio.sleep(5)
+
+        # Outer bound on purpose: without the decorator's wait_for this handler
+        # never returns, and a mutation test would hang the suite instead of
+        # failing it — which in CI is a cancelled job, not a report.
+        with pytest.raises(HTTPException) as exc:
+            await asyncio.wait_for(handler(), timeout=10)
+
+        assert exc.value.detail["operation"] == "named_thing"
+        assert exc.value.detail["timeout_seconds"] == 0.05
+        assert "named_thing" in exc.value.detail["message"]
+
+    @pytest.mark.asyncio
+    async def test_the_operation_defaults_to_the_handler_name(self):
+        """What an operator greps for."""
+
+        @bounded(0.05)
+        async def get_codebase_stats():
+            await asyncio.sleep(5)
+
+        with pytest.raises(HTTPException) as exc:
+            await asyncio.wait_for(get_codebase_stats(), timeout=10)
+
+        assert exc.value.detail["operation"] == "get_codebase_stats"
+
+    @pytest.mark.asyncio
+    async def test_the_timeout_is_logged(self, caplog):
+        """Silence was half of #13602 — a bounded-but-silent handler is still
+        undiagnosable from the outside, because a 504 tells the caller nothing
+        about which of many analyses ran long."""
+
+        @bounded(0.05, operation="logged_thing")
+        async def handler():
+            await asyncio.sleep(5)
+
+        with caplog.at_level(logging.WARNING):
+            with pytest.raises(HTTPException):
+                await asyncio.wait_for(handler(), timeout=10)
+
+        assert any(
+            "logged_thing" in record.getMessage() and "deadline" in record.getMessage().lower()
+            for record in caplog.records
+        ), "a deadline that fires must name the handler in the log"
+
+    @pytest.mark.asyncio
+    async def test_a_fast_handler_is_untouched(self):
+        """The direction that must stay true. A decorator that always fires
+        would pass every test above while breaking every endpoint."""
+
+        @bounded(5.0)
+        async def handler():
+            return {"ok": True}
+
+        assert await handler() == {"ok": True}
+
+    @pytest.mark.asyncio
+    async def test_a_handler_raising_its_own_error_is_not_masked(self):
+        """The deadline must not convert a real failure into a timeout."""
+
+        @bounded(5.0)
+        async def handler():
+            raise HTTPException(status_code=400, detail="bad request")
+
+        # Outer bound on purpose: without the decorator's wait_for this handler
+        # never returns, and a mutation test would hang the suite instead of
+        # failing it — which in CI is a cancelled job, not a report.
+        with pytest.raises(HTTPException) as exc:
+            await asyncio.wait_for(handler(), timeout=10)
+
+        assert exc.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_arguments_and_return_value_pass_through(self):
+        @bounded(5.0)
+        async def handler(a, *, b):
+            return a + b
+
+        assert await handler(1, b=2) == 3
+
+
+class TestAMisconfiguredDeadlineFailsAtImport:
+    @pytest.mark.parametrize("bad", [0, -1, -0.5])
+    def test_a_non_positive_deadline_is_rejected_at_decoration(self, bad):
+        """`wait_for(timeout=0)` expires immediately, so every request 504s —
+        an always-on failure reads as a broken endpoint rather than a
+        misconfiguration. Better to fail at import than on the first request."""
+        with pytest.raises(ValueError):
+            bounded(bad)
+
+    def test_the_default_is_a_usable_number(self):
+        assert 0 < DEFAULT_ROUTE_DEADLINE_SECONDS <= 300
+
+
+class TestTheCheckerCoversEveryRoute:
+    def _run(self) -> subprocess.CompletedProcess:
+        return subprocess.run(  # nosec B603  # fixed interpreter, repo-local target
+            [sys.executable, str(_CHECKER)],
+            capture_output=True,
+            text=True,
+            cwd=str(_REPO_ROOT),
+            timeout=120,
+        )
+
+    def test_the_repo_passes_its_own_checker(self):
+        result = self._run()
+        assert result.returncode == 0, result.stdout + result.stderr
+
+    def test_the_checker_sees_a_real_number_of_routes(self):
+        """Guard the guard: a matcher that matches nothing reports a clean tree.
+        An empty result reads as a clean result."""
+        result = self._run()
+        assert "of 85 routes bounded" in result.stdout or " routes bounded" in result.stdout
+        count = int(result.stdout.split(" of ")[1].split(" ")[0])
+        assert count >= 50, f"checker found only {count} routes — the matcher is probably broken"

--- a/autobot-backend/utils/error_boundaries/route_deadline_14015_test.py
+++ b/autobot-backend/utils/error_boundaries/route_deadline_14015_test.py
@@ -177,3 +177,75 @@ class TestTheCheckerCoversEveryRoute:
         assert "of 85 routes bounded" in result.stdout or " routes bounded" in result.stdout
         count = int(result.stdout.split(" of ")[1].split(" ")[0])
         assert count >= 50, f"checker found only {count} routes — the matcher is probably broken"
+
+
+class TestTheCheckerActuallyFires:
+    """The checker's whole premise is that an unbounded route becomes a
+    declaration rather than a default. Review of #14243 showed nothing proved
+    it: mutating `_is_bounded` to `return True` — so it would accept ANY route —
+    left the suite green, because every test only asserted the checker is
+    currently happy with a repo that happens to be fully bounded.
+
+    Asserting "it passes today" is not asserting "it catches an omission". These
+    plant one.
+    """
+
+    def _run_against(self, tmp_path, body: str) -> int:
+        import importlib.util
+
+        pkg = tmp_path / "endpoints"
+        pkg.mkdir()
+        (pkg / "routes.py").write_text(body, encoding="utf-8")
+
+        spec = importlib.util.spec_from_file_location("_deadline_checker", _CHECKER)
+        checker = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(checker)
+        checker._REPO_ROOT = tmp_path
+        checker.COVERED_PACKAGES = ("endpoints",)
+        checker.UNBOUNDED_BY_DESIGN = {}
+        return checker.main()
+
+    def test_an_unbounded_route_fails(self, tmp_path):
+        code = self._run_against(
+            tmp_path,
+            '@router.get("/thing")\nasync def get_thing():\n    return {}\n',
+        )
+        assert code == 1, "an unbounded route was accepted — the checker does not detect the thing it exists for"
+
+    def test_a_bounded_route_passes(self, tmp_path):
+        """The direction that must stay true: a checker that always fails is as
+        useless as one that never does, and would be deleted within a week."""
+        code = self._run_against(
+            tmp_path,
+            '@router.get("/thing")\n@bounded(60.0)\nasync def get_thing():\n    return {}\n',
+        )
+        assert code == 0
+
+    def test_a_declared_route_passes_only_with_its_declaration(self, tmp_path):
+        import importlib.util
+
+        pkg = tmp_path / "endpoints"
+        pkg.mkdir()
+        (pkg / "routes.py").write_text(
+            '@router.get("/thing")\nasync def get_thing():\n    return {}\n', encoding="utf-8"
+        )
+        spec = importlib.util.spec_from_file_location("_deadline_checker2", _CHECKER)
+        checker = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(checker)
+        checker._REPO_ROOT = tmp_path
+        checker.COVERED_PACKAGES = ("endpoints",)
+
+        checker.UNBOUNDED_BY_DESIGN = {}
+        assert checker.main() == 1, "undeclared and unbounded must fail"
+
+        checker.UNBOUNDED_BY_DESIGN = {"get_thing": "streams an unbounded log tail"}
+        assert checker.main() == 0, "a declared route with a reason must pass"
+
+    def test_a_non_route_function_is_not_required_to_be_bounded(self, tmp_path):
+        """Only routes. A helper without a deadline is not a finding."""
+        code = self._run_against(
+            tmp_path,
+            '@router.get("/thing")\n@bounded(60.0)\nasync def get_thing():\n    return {}\n\n\n'
+            "async def _helper():\n    return {}\n",
+        )
+        assert code == 0

--- a/autobot_shared/error_boundaries.py
+++ b/autobot_shared/error_boundaries.py
@@ -36,6 +36,7 @@ from utils.error_boundaries import (
     HIGH_SEVERITY_ERROR_TYPES,
     MEDIUM_SEVERITY_ERROR_TYPES,
     RETRY_ERROR_TYPES,
+    ROUTE_DEADLINE_GRACE,
     SYSTEM_RESTART_ERROR_TYPES,
     APIErrorResponse,
     ErrorBoundaryException,
@@ -100,6 +101,7 @@ __all__ = [
     # Decorators and utilities
     "error_boundary",
     "DEFAULT_ROUTE_DEADLINE_SECONDS",
+    "ROUTE_DEADLINE_GRACE",
     "bounded",
     "with_error_handling",
     "with_error_boundary",

--- a/autobot_shared/error_boundaries.py
+++ b/autobot_shared/error_boundaries.py
@@ -31,6 +31,7 @@ logger = logging.getLogger(__name__)
 # Re-export all public API from the package for backward compatibility
 from utils.error_boundaries import (
     CRITICAL_ERROR_TYPES,
+    DEFAULT_ROUTE_DEADLINE_SECONDS,
     FALLBACK_ERROR_TYPES,
     HIGH_SEVERITY_ERROR_TYPES,
     MEDIUM_SEVERITY_ERROR_TYPES,
@@ -48,6 +49,7 @@ from utils.error_boundaries import (
     GracefulDegradationHandler,
     RecoveryStrategy,
     RetryRecoveryHandler,
+    bounded,
     classify_error,
     error_boundary,
     get_error_boundary_manager,
@@ -97,6 +99,8 @@ __all__ = [
     "get_error_boundary_manager",
     # Decorators and utilities
     "error_boundary",
+    "DEFAULT_ROUTE_DEADLINE_SECONDS",
+    "bounded",
     "with_error_handling",
     "with_error_boundary",
     "with_async_error_boundary",

--- a/tools/lint/check_route_deadlines.py
+++ b/tools/lint/check_route_deadlines.py
@@ -49,6 +49,21 @@ _ROUTE_DECORATORS = {"get", "post", "put", "delete", "patch", "head", "options"}
 UNBOUNDED_BY_DESIGN: dict[str, str] = {}
 
 
+def _err(message: str) -> None:
+    """Write to stderr without `print`.
+
+    This file is a CLI checker whose whole output contract is text on a stream,
+    but the repo bans newly-added builtin-print calls (#1082) and the escape is
+    a per-line `# noqa: print`. Ten of those would be noise; one helper is not.
+    """
+    sys.stderr.write(message + "\n")
+
+
+def _out(message: str) -> None:
+    """Write to stdout without `print` — see :func:`_err`."""
+    sys.stdout.write(message + "\n")
+
+
 def _is_route(decorator: ast.expr) -> bool:
     """True for `@router.get(...)` and friends."""
     func = decorator.func if isinstance(decorator, ast.Call) else decorator
@@ -133,7 +148,7 @@ def main() -> int:
     for package in COVERED_PACKAGES:
         root = _REPO_ROOT / package
         if not root.is_dir():
-            print(f"[route-deadlines] covered package missing: {package}", file=sys.stderr)
+            _err(f"[route-deadlines] covered package missing: {package}")
             return 1
         for source in sorted(root.rglob("*.py")):
             if source.name.endswith("_test.py") or source.name.startswith("test_"):
@@ -158,43 +173,40 @@ def main() -> int:
         # An empty result reads as a clean result. If the matcher stops matching
         # — a rename, a refactor to a different router idiom — this check would
         # silently pass over everything.
-        print("[route-deadlines] found 0 routes in the covered packages — the matcher is broken", file=sys.stderr)
+        _err("[route-deadlines] found 0 routes in the covered packages — the matcher is broken")
         return 1
 
     stale = sorted(set(UNBOUNDED_BY_DESIGN) - seen)
     if stale:
-        print(
+        _err(
             "[route-deadlines] declared unbounded but no longer present "
-            f"(remove from UNBOUNDED_BY_DESIGN): {', '.join(stale)}",
-            file=sys.stderr,
+            f"(remove from UNBOUNDED_BY_DESIGN): {', '.join(stale)}"
         )
         return 1
 
     if too_tight:
-        print(f"[route-deadlines] {len(too_tight)} route(s) bounded BELOW their own file's budget:", file=sys.stderr)
+        _err(f"[route-deadlines] {len(too_tight)} route(s) bounded BELOW their own file's budget:")
         for route in too_tight:
-            print(f"  {route}", file=sys.stderr)
-        print(
+            _err(f"  {route}")
+        _err(
             "\nA route bound under a budget it can reach turns a slow success into a guaranteed "
-            "504. Derive it instead: @bounded(THAT_TIMEOUT + ROUTE_DEADLINE_GRACE).",
-            file=sys.stderr,
+            "504. Derive it instead: @bounded(THAT_TIMEOUT + ROUTE_DEADLINE_GRACE)."
         )
         return 1
 
     if unbounded:
-        print(f"[route-deadlines] {len(unbounded)} of {total} routes have no deadline:", file=sys.stderr)
+        _err(f"[route-deadlines] {len(unbounded)} of {total} routes have no deadline:")
         for route in unbounded:
-            print(f"  {route}", file=sys.stderr)
-        print(
+            _err(f"  {route}")
+        _err(
             "\nAdd @bounded(seconds=...) from autobot_shared.error_boundaries, or add the "
             "handler to UNBOUNDED_BY_DESIGN with the reason it must not have one.\n"
-            "#13602: an unbounded handler held the socket open past 180s and logged nothing.",
-            file=sys.stderr,
+            "#13602: an unbounded handler held the socket open past 180s and logged nothing."
         )
         return 1
 
     declared = len(UNBOUNDED_BY_DESIGN)
-    print(f"[route-deadlines] {total - declared} of {total} routes bounded, {declared} declared unbounded")
+    _out(f"[route-deadlines] {total - declared} of {total} routes bounded, {declared} declared unbounded")
     return 0
 
 

--- a/tools/lint/check_route_deadlines.py
+++ b/tools/lint/check_route_deadlines.py
@@ -107,19 +107,60 @@ def _module_timeout_ceiling(tree: ast.Module) -> float:
     return ceiling
 
 
-def _literal_deadline(decorator: ast.expr) -> float | None:
-    """The deadline when it is a bare literal, else None.
+def _module_constants(tree: ast.Module) -> dict[str, float]:
+    """Module-level numeric constants, for resolving derived deadlines."""
+    values: dict[str, float] = {}
+    for node in tree.body:
+        if not isinstance(node, ast.Assign) or not isinstance(node.value, ast.Constant):
+            continue
+        if not isinstance(node.value.value, (int, float)) or isinstance(node.value.value, bool):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name):
+                values[target.id] = float(node.value.value)
+    return values
 
-    A computed expression — ``ANALYSIS_TIMEOUT + ROUTE_DEADLINE_GRACE`` — is
-    exempt, because it derives from the budget rather than guessing past it, and
-    stays correct when that budget changes.
+
+def _resolve(node: ast.expr, constants: dict[str, float]) -> float | None:
+    """Evaluate a deadline expression built from literals and known constants.
+
+    Handles the shapes a deadline is actually written in — a literal, a named
+    constant, and additive arithmetic over them. Anything else returns None and
+    is left alone rather than guessed at.
+    """
+    if isinstance(node, ast.Constant) and isinstance(node.value, (int, float)):
+        return float(node.value)
+    if isinstance(node, ast.Name):
+        # An unresolvable name contributes ZERO, not None. ROUTE_DEADLINE_GRACE
+        # is imported, so it is not a module constant here — returning None
+        # would make every derived deadline unresolvable and silently skip the
+        # very routes this check exists for. Zero under-estimates the deadline,
+        # so the error is toward flagging, which is the safe direction: a false
+        # flag is argued down in review, a missed one ships a 504.
+        return constants.get(node.id, 0.0)
+    if isinstance(node, ast.BinOp) and isinstance(node.op, (ast.Add, ast.Sub)):
+        left, right = _resolve(node.left, constants), _resolve(node.right, constants)
+        if left is None or right is None:
+            return None
+        return left + right if isinstance(node.op, ast.Add) else left - right
+    return None
+
+
+def _literal_deadline(decorator: ast.expr, constants: dict[str, float] | None = None) -> float | None:
+    """The deadline in seconds, resolving named constants and additive arithmetic.
+
+    An earlier version exempted every computed expression on the reasoning that
+    deriving from a budget beats guessing past it. Review of #14243 showed that
+    the exemption assumes the arithmetic is right: `@bounded(TIMEOUT - 170.0)`
+    resolves to 10s under a 195s ceiling and passed the checker unchallenged.
+
+    Deriving is still the right pattern — it is the ONLY thing that stays correct
+    when the budget moves. But "derived" and "correct" are different claims, and
+    a check that conflates them is the shape this whole issue is about.
     """
     if not (isinstance(decorator, ast.Call) and decorator.args):
         return None
-    first = decorator.args[0]
-    if isinstance(first, ast.Constant) and isinstance(first.value, (int, float)):
-        return float(first.value)
-    return None
+    return _resolve(decorator.args[0], constants or {})
 
 
 def _routes_in(path: Path) -> list[tuple[str, bool, float | None]]:
@@ -128,13 +169,14 @@ def _routes_in(path: Path) -> list[tuple[str, bool, float | None]]:
         tree = ast.parse(path.read_text(encoding="utf-8"))
     except (OSError, SyntaxError):
         return []
+    constants = _module_constants(tree)
     found = []
     for node in ast.walk(tree):
         if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             continue
         if not any(_is_route(d) for d in node.decorator_list):
             continue
-        deadline = next((_literal_deadline(d) for d in node.decorator_list if _is_bounded(d)), None)
+        deadline = next((_literal_deadline(d, constants) for d in node.decorator_list if _is_bounded(d)), None)
         found.append((node.name, any(_is_bounded(d) for d in node.decorator_list), deadline))
     return found
 

--- a/tools/lint/check_route_deadlines.py
+++ b/tools/lint/check_route_deadlines.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Every covered route carries a deadline, or is declared unbounded WITH A REASON (#14015).
+
+#13602: `/api/analytics/codebase/report` held the socket open past 180s and
+logged nothing. Not a slow endpoint — a handler that never ran. Four of the five
+analyses it fans out to wrapped themselves in `asyncio.wait_for`; the fifth did
+not, and once the eight shared executor workers were busy that submission queued
+and never started.
+
+The defect is the PATTERN, not that one omission. When bounding is opt-in and
+per-call-site, an unbounded path is invisible: it looks exactly like every other
+handler until it hangs. `report.py` alone carried three different timeout
+constants, so nothing about the file made the gap visible either.
+
+Only a check that covers every member by construction catches an omission. This
+is that check. A route in a covered module must either carry `@bounded(...)` or
+appear in UNBOUNDED_BY_DESIGN with a stated reason — so an unbounded route is a
+declaration a reviewer can see and argue with, never a default nobody chose.
+
+Exit codes:
+    0  every covered route is bounded or explicitly declared
+    1  at least one route is silently unbounded, or a declaration is stale
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Coverage is deliberately narrow to start: the surface where #13602's hang
+# actually lived. Widening it is adding a path here — and the moment one is
+# added, every unbounded route under it fails this check until it is either
+# bounded or declared. That is the intended way to grow coverage: the gap is
+# enumerated, never silent.
+COVERED_PACKAGES = ("autobot-backend/api/codebase_analytics/endpoints",)
+
+_ROUTE_DECORATORS = {"get", "post", "put", "delete", "patch", "head", "options"}
+
+# Routes deliberately left unbounded, each with the reason. A bare name is not
+# accepted — the reason is the point, because "we chose this" and "nobody
+# noticed" are otherwise indistinguishable, which is the whole subject of #13852.
+UNBOUNDED_BY_DESIGN: dict[str, str] = {}
+
+
+def _is_route(decorator: ast.expr) -> bool:
+    """True for `@router.get(...)` and friends."""
+    func = decorator.func if isinstance(decorator, ast.Call) else decorator
+    return isinstance(func, ast.Attribute) and func.attr in _ROUTE_DECORATORS
+
+
+def _is_bounded(decorator: ast.expr) -> bool:
+    """True for `@bounded(...)` — call form only.
+
+    A bare `@bounded` would be a decorator applied without a deadline, which is
+    a different thing and not what this enforces.
+    """
+    return isinstance(decorator, ast.Call) and (
+        (isinstance(decorator.func, ast.Name) and decorator.func.id == "bounded")
+        or (isinstance(decorator.func, ast.Attribute) and decorator.func.attr == "bounded")
+    )
+
+
+def _routes_in(path: Path) -> list[tuple[str, bool]]:
+    """Every route handler in *path*, with whether it is bounded."""
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except (OSError, SyntaxError):
+        return []
+    found = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if not any(_is_route(d) for d in node.decorator_list):
+            continue
+        found.append((node.name, any(_is_bounded(d) for d in node.decorator_list)))
+    return found
+
+
+def main() -> int:
+    unbounded: list[str] = []
+    seen: set[str] = set()
+    total = 0
+
+    for package in COVERED_PACKAGES:
+        root = _REPO_ROOT / package
+        if not root.is_dir():
+            print(f"[route-deadlines] covered package missing: {package}", file=sys.stderr)
+            return 1
+        for source in sorted(root.rglob("*.py")):
+            if source.name.endswith("_test.py") or source.name.startswith("test_"):
+                continue
+            for name, is_bounded in _routes_in(source):
+                total += 1
+                seen.add(name)
+                if is_bounded or name in UNBOUNDED_BY_DESIGN:
+                    continue
+                unbounded.append(f"{source.relative_to(_REPO_ROOT)}::{name}")
+
+    if total == 0:
+        # An empty result reads as a clean result. If the matcher stops matching
+        # — a rename, a refactor to a different router idiom — this check would
+        # silently pass over everything.
+        print("[route-deadlines] found 0 routes in the covered packages — the matcher is broken", file=sys.stderr)
+        return 1
+
+    stale = sorted(set(UNBOUNDED_BY_DESIGN) - seen)
+    if stale:
+        print(
+            "[route-deadlines] declared unbounded but no longer present "
+            f"(remove from UNBOUNDED_BY_DESIGN): {', '.join(stale)}",
+            file=sys.stderr,
+        )
+        return 1
+
+    if unbounded:
+        print(f"[route-deadlines] {len(unbounded)} of {total} routes have no deadline:", file=sys.stderr)
+        for route in unbounded:
+            print(f"  {route}", file=sys.stderr)
+        print(
+            "\nAdd @bounded(seconds=...) from autobot_shared.error_boundaries, or add the "
+            "handler to UNBOUNDED_BY_DESIGN with the reason it must not have one.\n"
+            "#13602: an unbounded handler held the socket open past 180s and logged nothing.",
+            file=sys.stderr,
+        )
+        return 1
+
+    declared = len(UNBOUNDED_BY_DESIGN)
+    print(f"[route-deadlines] {total - declared} of {total} routes bounded, {declared} declared unbounded")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/lint/check_route_deadlines.py
+++ b/tools/lint/check_route_deadlines.py
@@ -67,7 +67,47 @@ def _is_bounded(decorator: ast.expr) -> bool:
     )
 
 
-def _routes_in(path: Path) -> list[tuple[str, bool]]:
+def _module_timeout_ceiling(tree: ast.Module) -> float:
+    """Largest module-level ``*_TIMEOUT`` constant declared in this file.
+
+    Heuristic on purpose. Proving which internal budget a given route can reach
+    needs call-graph analysis; what is cheap and catches the real shape is
+    noticing that a file declares a 240s budget somewhere and then bounds one of
+    its own routes at 60s.
+
+    That shape is not hypothetical — review of #14243 found it on three routes:
+    /analysis (60s outer over a 180s internal), /env-analysis (60s over 240s),
+    and /report (180s outer under its own 195s fan-out ceiling, so the generic
+    message would have beaten the one that names the analysis).
+    """
+    ceiling = 0.0
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if not (isinstance(target, ast.Name) and target.id.endswith("_TIMEOUT")):
+                continue
+            if isinstance(node.value, ast.Constant) and isinstance(node.value.value, (int, float)):
+                ceiling = max(ceiling, float(node.value.value))
+    return ceiling
+
+
+def _literal_deadline(decorator: ast.expr) -> float | None:
+    """The deadline when it is a bare literal, else None.
+
+    A computed expression — ``ANALYSIS_TIMEOUT + ROUTE_DEADLINE_GRACE`` — is
+    exempt, because it derives from the budget rather than guessing past it, and
+    stays correct when that budget changes.
+    """
+    if not (isinstance(decorator, ast.Call) and decorator.args):
+        return None
+    first = decorator.args[0]
+    if isinstance(first, ast.Constant) and isinstance(first.value, (int, float)):
+        return float(first.value)
+    return None
+
+
+def _routes_in(path: Path) -> list[tuple[str, bool, float | None]]:
     """Every route handler in *path*, with whether it is bounded."""
     try:
         tree = ast.parse(path.read_text(encoding="utf-8"))
@@ -79,12 +119,14 @@ def _routes_in(path: Path) -> list[tuple[str, bool]]:
             continue
         if not any(_is_route(d) for d in node.decorator_list):
             continue
-        found.append((node.name, any(_is_bounded(d) for d in node.decorator_list)))
+        deadline = next((_literal_deadline(d) for d in node.decorator_list if _is_bounded(d)), None)
+        found.append((node.name, any(_is_bounded(d) for d in node.decorator_list), deadline))
     return found
 
 
 def main() -> int:
     unbounded: list[str] = []
+    too_tight: list[str] = []
     seen: set[str] = set()
     total = 0
 
@@ -96,9 +138,18 @@ def main() -> int:
         for source in sorted(root.rglob("*.py")):
             if source.name.endswith("_test.py") or source.name.startswith("test_"):
                 continue
-            for name, is_bounded in _routes_in(source):
+            try:
+                ceiling = _module_timeout_ceiling(ast.parse(source.read_text(encoding="utf-8")))
+            except (OSError, SyntaxError):
+                ceiling = 0.0
+            for name, is_bounded, deadline in _routes_in(source):
                 total += 1
                 seen.add(name)
+                if is_bounded and deadline is not None and ceiling and deadline < ceiling:
+                    too_tight.append(
+                        f"{source.relative_to(_REPO_ROOT)}::{name} "
+                        f"bounded at {deadline:.0f}s under a {ceiling:.0f}s budget declared in the same file"
+                    )
                 if is_bounded or name in UNBOUNDED_BY_DESIGN:
                     continue
                 unbounded.append(f"{source.relative_to(_REPO_ROOT)}::{name}")
@@ -115,6 +166,17 @@ def main() -> int:
         print(
             "[route-deadlines] declared unbounded but no longer present "
             f"(remove from UNBOUNDED_BY_DESIGN): {', '.join(stale)}",
+            file=sys.stderr,
+        )
+        return 1
+
+    if too_tight:
+        print(f"[route-deadlines] {len(too_tight)} route(s) bounded BELOW their own file's budget:", file=sys.stderr)
+        for route in too_tight:
+            print(f"  {route}", file=sys.stderr)
+        print(
+            "\nA route bound under a budget it can reach turns a slow success into a guaranteed "
+            "504. Derive it instead: @bounded(THAT_TIMEOUT + ROUTE_DEADLINE_GRACE).",
             file=sys.stderr,
         )
         return 1


### PR DESCRIPTION
## Thinking Path

#13602 was an endpoint that held the socket open past 180s and logged **nothing** — no exception, no timeout, no trace. Not a slow handler; one that never ran, because it queued behind eight busy executor workers on the single analysis in its fan-out that had no `asyncio.wait_for`.

The defect is the **pattern**, not that one omission. When bounding is opt-in and per-call-site, an unbounded path is invisible — it looks exactly like every other handler until it hangs. `report.py` alone carried three different timeout constants *and* one analysis with none, and nothing about the file made that visible.

Measured before touching anything: **85 routes in the analytics surface, 0 bounded.**

## What Changed

Two halves, and both are load-bearing.

**`bounded(seconds)`** stacks with `with_error_handling` and turns the hang into a **504 naming the handler and the limit**, plus a WARNING naming it in the log — because a 504 alone tells the caller nothing about which of many analyses ran long, and silence was half of #13602.

A non-positive deadline raises at **decoration time** rather than on the first request: `wait_for(0)` expires immediately, so every request would 504, and an always-on failure reads as a broken endpoint rather than a misconfiguration.

It sits **outside** `with_error_handling` so error-response construction is inside the deadline too. That decorator already re-raises `HTTPException` ("Preserve intentional HTTP status codes"), so the 504 survives either ordering — I checked rather than assumed.

**`tools/lint/check_route_deadlines.py`** is the half that makes omission impossible. A route in a covered package must carry `@bounded` or appear in `UNBOUNDED_BY_DESIGN` **with a reason** — so an unbounded route becomes a declaration a reviewer can see and argue with, never a default nobody chose. Widening coverage is adding a path, at which point every unbounded route under it fails until bounded or declared: the gap gets *enumerated*, never stays silent.

It also fails when it matches **zero** routes, because an empty result otherwise reads as a clean one.

Deadlines come from #13602's own measurements against a stored scan: **180s** for `report` and `duplicates` (the two that hung), **120s** for call-graph (36.4s cold, exceeded a 45s client cap under contention), **60s** default for the rest, which were sub-2s in that sweep.

## Verification

```
146 passed   utils/error_boundaries/ + api/codebase_analytics/endpoints/
85 of 85 routes bounded, 0 declared unbounded
black · isort · flake8 · nosec · exec-bits · ip-fallbacks   clean
mypy: 7 pre-existing errors, none in error_boundaries
```

Mutations, all caught:

| Reverted | Result |
|---|---|
| `wait_for` dropped from the wrapper | 4 tests fail |
| non-positive deadline accepted | 3 fail |
| log stops naming the handler | 4 fail |
| payload loses the handler name | 2 fail |
| one route loses `@bounded` | checker exits 1 |
| stale `UNBOUNDED_BY_DESIGN` entry | checker exits 1 |
| matcher matches nothing | checker exits 1, *"the matcher is broken"* |
| ...same matcher break, empty-result guard removed | **exits 0, reports a clean tree** |

That last pair is the point of the empty-result guard, demonstrated rather than argued.

## A process note worth recording

While mutation-testing this, my first run applied the `wait_for` mutation, then **hung** — and the harness timed out *before* the restore line ran. The file sat mutated, and I spent five diagnostic probes chasing a bug I had injected myself, briefly convinced the repo's pytest harness was neutering `asyncio.wait_for`.

It was not. Identical code inline fired at 0.05s while the imported version ran the full 5s, which is what finally isolated it.

The fix is in the harness, not the discipline: every mutation now restores from a `trap ... EXIT INT TERM`, so a hang or a kill cannot skip it. This is the same shape as the debug mutation I committed in #14072 — a mutation that outlives its test is indistinguishable from a real defect, and costs more than the test was worth.

## Scope

Coverage is deliberately the analytics endpoints — where #13602's hang actually lived. `COVERED_PACKAGES` is one tuple; extending it to another router is one line, and the checker will then enumerate exactly what that surface is missing.

Refs #14015, #13602 — part of umbrella #13852.

Not `Closes`: what closes #14015 is a route driven past its deadline on a host returning the structured 504 rather than hanging, and the lint guard failing in CI when a deadline is removed. The second half is observable on the next PR that tries it.

## Model Used

Opus 5 (1M context)