### PR TITLE
fix(deps): bump nanoid to 3.3.18 to clear the advisory blocking Security Scan

### DIFF
--- a/autobot-frontend/package-lock.json
+++ b/autobot-frontend/package-lock.json
@@ -10848,9 +10848,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Closes #14245

## Thinking Path

`Security Scan` was failing on **every** PR, including backend-only ones. It failed on #14229, which
touches nine Python files plus one generated types file and no npm surface at all — which is what
made it obvious the advisory was on the base branch rather than in the change.

```
nanoid  <3.3.18   Severity: high
nanoid: custom generators can loop indefinitely when size is zero
  https://github.com/advisories/GHSA-2v37-7h3g-55p8
```

The gate itself is behaving correctly — #13400 made high/critical advisories fail the job. The issue
is purely that the base was carrying the advisory.

## What Changed

One dependency, lockfile only.

```
$ git diff --stat autobot-frontend/package-lock.json
 autobot-frontend/package-lock.json | 6 +++---

-      "version": "3.3.17",
+      "version": "3.3.18",
```

`package.json` is **untouched** — `git diff --stat autobot-frontend/package.json` is empty. `nanoid`
is not a direct dependency; it arrives transitively through `postcss`, which declares `^3.3.17`, and
`3.3.18` satisfies that range.

Worth recording how this was done, because the obvious command is wrong: `npm install nanoid@^3.3.18
--package-lock-only` **adds `nanoid` to `package.json` as a direct dependency**, which would have
quietly promoted a transitive build-time package into our declared surface. I reverted that and used
`npm update nanoid --package-lock-only`, which bumps within the existing range and leaves
`package.json` alone. A broad `npm audit fix` was also avoided — it rewrites unrelated lockfile
entries and would have made the diff unreviewable.

## Verification

```
$ npm audit --audit-level=high
found 0 vulnerabilities

npm run lint (oxlint + eslint)   clean
npm run type-check (vue-tsc)     clean
vitest src/components/workflow src/composables/llc   12 files / 168 tests passed
```

## Model Used

Claude Opus 5 (1M context)
