### PR TITLE
fix(chat): compact at a turn boundary, preserve user turns, and carry extracted state (#14066)

### DIFF
--- a/autobot-backend/chat_history/context_overflow.py
+++ b/autobot-backend/chat_history/context_overflow.py
@@ -14,6 +14,7 @@ Provides automatic context window management:
 Builds on #8990 (token usage tracking) and #3770 (compression service).
 """
 
+import json
 import os
 from typing import Any, Dict, List, Optional
 
@@ -22,6 +23,7 @@ from autobot_shared.redis_client import get_async_redis_client
 from autobot_shared.redis_utils import decode_redis_value
 from autobot_shared.ssot_constants import CategoryDefaults
 from autobot_shared.token_count import estimate_fast
+from autobot_shared.tool_catalogue import FILE_WRITE_TOOLS, SHELL_EXEC_TOOLS, match_tool_name
 
 logger = get_logger(__name__)
 
@@ -36,6 +38,22 @@ _DEFAULT_COMPRESS_THRESHOLD = 0.90  # 90%
 # How long to skip compaction after it fails, so a rate-limited provider costs
 # one attempt per window instead of one per turn (#14065 review).
 _SUMMARY_FAILURE_BACKOFF_SECONDS = int(os.getenv("AUTOBOT_SUMMARY_FAILURE_BACKOFF_SECONDS", "300"))
+
+# How many of the most recent user messages cross a compaction verbatim (#14066).
+# Bounded so repeated compaction cannot grow the preserved set without limit —
+# the bound is what makes preserving them unconditionally safe.
+_PRESERVED_USER_MESSAGE_CAP = int(os.getenv("AUTOBOT_COMPACTION_USER_MESSAGE_CAP", "40"))
+
+# Tool results in the summarized region are clipped to this many characters
+# before the summarizer sees them: a file read many turns ago is cheaper to
+# re-read than to carry (#14066).
+_TOOL_RESULT_CLIP_CHARS = int(os.getenv("AUTOBOT_COMPACTION_TOOL_RESULT_CLIP_CHARS", "400"))
+
+# How far back to look for a user turn before settling for any turn start.
+_BOUNDARY_SEARCH_WINDOW = int(os.getenv("AUTOBOT_COMPACTION_BOUNDARY_WINDOW", "10"))
+
+# Most recent shell commands named in the extracted state block.
+_STATE_COMMAND_CAP = int(os.getenv("AUTOBOT_COMPACTION_STATE_COMMAND_CAP", "10"))
 
 
 class SessionTokenTracker:
@@ -207,11 +225,183 @@ def _message_text(msg: object) -> str:
     ``estimate_fast`` needs a string. A non-dict entry or a non-string ``text``
     (a provider emitting ``None``, an int, a content-part list) used to raise
     here — after the token tracker had already been reset.
+
+    #14066: reads **both** schemas. This used to read only ``text``, so every
+    API-schema message (``role``/``content``) estimated as 0 tokens and the
+    post-compaction refill under-counted the retained half — which delays the
+    next compaction rather than triggering it early, so nothing surfaced it.
+    ``_format_messages`` already handled both; this did not.
     """
     if not isinstance(msg, dict):
         return ""
-    text = msg.get("text", "")
-    return text if isinstance(text, str) else ""
+    value = msg.get("content")
+    if isinstance(value, list):
+        value = " ".join(_text_parts(value))
+    if not isinstance(value, str) or not value:
+        value = msg.get("text", "")
+    return value if isinstance(value, str) else ""
+
+
+def _text_parts(parts: list) -> List[str]:
+    """The string ``text`` fields of a multimodal content list.
+
+    Non-dict entries, non-text parts, and a ``text`` that is not a string are
+    all skipped rather than joined: providers genuinely emit ``text: None``, and
+    this helper runs outside ``summarize_messages``' try, so raising here 500s a
+    turn whose answer was already generated and stored (#14065 review).
+    """
+    out: List[str] = []
+    for part in parts:
+        if not isinstance(part, dict) or part.get("type") != "text":
+            continue
+        text = part.get("text")
+        if isinstance(text, str):
+            out.append(text)
+    return out
+
+
+def _role_of(msg: object) -> str:
+    """Role across both schemas: ``role`` (API) or ``sender`` (display)."""
+    if not isinstance(msg, dict):
+        return ""
+    role = msg.get("role") or msg.get("sender") or ""
+    return role if isinstance(role, str) else ""
+
+
+def _pick_boundary(messages: List[Dict], target: int) -> int:
+    """Snap *target* back to a turn start, preferring a user turn (#14066).
+
+    ``len(messages) // 2`` is an index, not a boundary: it can land on a
+    ``role="tool"`` message whose assistant parent sits earlier, orphaning the
+    responses in the kept half. A tool message is therefore never a valid cut
+    point; anything else is, because a batch cut *before* its assistant parent
+    keeps the whole batch together.
+
+    Both searches floor at index 1, never 0. Returning 0 would summarize *no*
+    messages while the caller's early return skips the tracker reset — so the
+    session stays over threshold and re-attempts compaction every single turn.
+    A short history whose only user turn is its first message hits this
+    immediately, and it reads as "compaction is enabled" the whole time.
+    Index 0 is returned only when no valid cut point exists at all.
+    """
+    if not messages:
+        return 0
+    target = max(0, min(target, len(messages) - 1))
+    floor = max(1, target - _BOUNDARY_SEARCH_WINDOW)
+    for idx in range(target, floor - 1, -1):
+        if _role_of(messages[idx]) == CategoryDefaults.ROLE_USER:
+            return idx
+    for idx in range(target, 0, -1):
+        if _role_of(messages[idx]) != "tool":
+            return idx
+    return 0
+
+
+def _preserved_user_messages(messages: List[Dict], cap: int) -> List[str]:
+    """The most recent *cap* user messages, verbatim (#14066).
+
+    Never summarized. A long session re-summarizes the same region repeatedly
+    and each pass is another chance for the model to drop a constraint the user
+    stated once; the cap is what keeps doing this unconditionally bounded.
+    """
+    if cap <= 0:
+        return []
+    texts = [_message_text(m) for m in messages if _role_of(m) == CategoryDefaults.ROLE_USER]
+    return [t for t in texts if t][-cap:]
+
+
+def _clip_tool_results(messages: List[Dict], max_chars: int) -> List[Dict]:
+    """Clip oversized tool results before summarization (#14066).
+
+    Returns a new list; the caller's messages are never mutated — the persisted
+    transcript is untouched and only the summarizer's input is reduced.
+    """
+    clipped: List[Dict] = []
+    for msg in messages:
+        body = _message_text(msg)
+        if _role_of(msg) != "tool" or len(body) <= max_chars:
+            clipped.append(msg)
+            continue
+        copy = dict(msg)
+        copy["content" if isinstance(msg.get("content"), str) else "text"] = body[:max_chars] + "… [clipped]"
+        clipped.append(copy)
+    return clipped
+
+
+def _tool_calls_of(msg: object) -> List[Dict]:
+    """The tool calls on a message, or an empty list on any other shape."""
+    if not isinstance(msg, dict):
+        return []
+    calls = msg.get("tool_calls")
+    return [c for c in calls if isinstance(c, dict)] if isinstance(calls, list) else []
+
+
+def _call_name_and_args(call: Dict) -> "tuple[str, Dict]":
+    """``(name, arguments)`` for one tool call; ``("", {})`` on any bad shape."""
+    fn = call.get("function") if isinstance(call.get("function"), dict) else call
+    name = fn.get("name")
+    raw = fn.get("arguments", fn.get("args", {}))
+    if isinstance(raw, str):
+        try:
+            raw = json.loads(raw)
+        except (ValueError, TypeError):
+            raw = {}
+    return (name if isinstance(name, str) else ""), (raw if isinstance(raw, dict) else {})
+
+
+def _extract_state(messages: List[Dict]) -> Dict[str, List[str]]:
+    """State that crosses the boundary without a model call (#14066).
+
+    Deterministic: files written, shell commands run, tools used — read straight
+    off the tool calls. This is the part that still works when the summary is
+    bad, which is the whole reason it exists. Tool-name matching reuses the
+    canonical catalogue rather than a local literal list.
+    """
+    files: List[str] = []
+    commands: List[str] = []
+    tools: List[str] = []
+    for msg in messages:
+        for call in _tool_calls_of(msg):
+            name, args = _call_name_and_args(call)
+            if not name:
+                continue
+            if name not in tools:
+                tools.append(name)
+            if match_tool_name(name, FILE_WRITE_TOOLS):
+                path = args.get("path") or args.get("file_path")
+                if isinstance(path, str) and path and path not in files:
+                    files.append(path)
+            elif match_tool_name(name, SHELL_EXEC_TOOLS):
+                command = args.get("command")
+                if isinstance(command, str) and command:
+                    commands.append(command)
+    return {"files_written": files, "commands": commands, "tools_used": tools}
+
+
+def _render_state_block(state: Dict[str, List[str]]) -> str:
+    """Render extracted state, or "" when nothing was extracted."""
+    lines = []
+    if state["files_written"]:
+        lines.append("**Files written:** " + ", ".join(state["files_written"]))
+    if state["commands"]:
+        lines.append("**Commands run:** " + "; ".join(state["commands"][-_STATE_COMMAND_CAP:]))
+    if state["tools_used"]:
+        lines.append("**Tools used:** " + ", ".join(state["tools_used"]))
+    if not lines:
+        return ""
+    return "### Retained state (extracted, not inferred)\n" + "\n".join(lines)
+
+
+def _compose_summary(summary: str, summarized: List[Dict]) -> str:
+    """Model summary + extracted state + verbatim user turns (#14066)."""
+    parts = [summary]
+    block = _render_state_block(_extract_state(summarized))
+    if block:
+        parts.append(block)
+    preserved = _preserved_user_messages(summarized, _PRESERVED_USER_MESSAGE_CAP)
+    if preserved:
+        parts.append("### User messages (verbatim)\n" + "\n".join(f"- {t}" for t in preserved))
+    return "\n\n".join(parts)
 
 
 def _sanitize_tool_messages(msgs: List[Dict]) -> List[Dict]:
@@ -571,8 +761,11 @@ class ContextOverflowProtection:
         model_name: str,
     ) -> str:
         """Create summary and reset token counter."""
-        # Determine how many messages to summarize (oldest half)
-        split_point = len(messages) // 2
+        # #14066: snap the midpoint back to a turn start. The raw index could
+        # fall between an assistant's tool_calls and its tool responses, leaving
+        # orphans in the *kept* half — _sanitize_tool_messages repairs only the
+        # summarizer's input, never the half that continues to the provider.
+        split_point = _pick_boundary(messages, len(messages) // 2)
         messages_to_summarize = messages[:split_point]
 
         if not messages_to_summarize:
@@ -582,7 +775,9 @@ class ContextOverflowProtection:
         # tracker reset below must not run when the history it claims to have
         # compressed is still uncompressed (#14065). Leaving the counter high is
         # what makes the next turn retry instead of proceeding on a lie.
-        summary = await self.summarizer.summarize_messages(messages_to_summarize, model_name)
+        summary = await self.summarizer.summarize_messages(
+            _clip_tool_results(messages_to_summarize, _TOOL_RESULT_CLIP_CHARS), model_name
+        )
 
         # Estimate BEFORE resetting. #14065 review: this loop used to run after
         # the reset, so a malformed entry in the second half raised with the
@@ -601,7 +796,10 @@ class ContextOverflowProtection:
         for tokens in retained_tokens:
             await self.tracker.add_message_tokens(session_id, prompt_tokens=tokens)
 
-        return summary
+        # #14066: the model's summary is only one of three things that cross the
+        # boundary. The extracted state and the verbatim user turns are the two
+        # that survive a bad summarization turn.
+        return _compose_summary(summary, messages_to_summarize)
 
 
 __all__ = [

--- a/autobot-backend/chat_history/context_overflow.py
+++ b/autobot-backend/chat_history/context_overflow.py
@@ -323,9 +323,26 @@ def _clip_tool_results(messages: List[Dict], max_chars: int) -> List[Dict]:
             clipped.append(msg)
             continue
         copy = dict(msg)
-        copy["content" if isinstance(msg.get("content"), str) else "text"] = body[:max_chars] + "… [clipped]"
+        copy[_body_key(msg)] = body[:max_chars] + "… [clipped]"
         clipped.append(copy)
     return clipped
+
+
+def _body_key(msg: Dict) -> str:
+    """The key whose value ``_message_text`` read, so a rewrite lands where it is read.
+
+    Keying on ``isinstance(content, str)`` alone was wrong twice: a tool result
+    whose ``content`` is a multimodal *list* would have its clipped body written
+    to ``text`` while ``_format_messages`` still read the untouched list, and an
+    empty-string ``content`` beside a populated ``text`` would have the clip
+    written to ``content`` where the ``content or text`` fallback skips it. Both
+    leave the full body reaching the summarizer while the clip looks applied —
+    an empty result reading as a clean one.
+    """
+    content = msg.get("content")
+    if isinstance(content, list):
+        return "content" if _text_parts(content) else "text"
+    return "content" if isinstance(content, str) and content else "text"
 
 
 def _tool_calls_of(msg: object) -> List[Dict]:

--- a/autobot-backend/chat_history/context_overflow_boundary_test.py
+++ b/autobot-backend/chat_history/context_overflow_boundary_test.py
@@ -1,0 +1,415 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Compaction boundary, user-message preservation and extracted state (#14066).
+
+Three properties, each of which used to be absent:
+
+1. The cut lands on a turn boundary. ``len(messages) // 2`` is a raw index and
+   can fall between an assistant message carrying ``tool_calls`` and its
+   ``role="tool"`` responses, orphaning them in the kept half.
+2. User messages cross the boundary **verbatim**. They used to survive only if
+   the summarizing model chose to include them, and a long session re-summarizes
+   the same content repeatedly — each pass another chance to drop it.
+3. A deterministic state block crosses alongside the model's summary, so a bad
+   summarization turn cannot take the file paths and exit statuses with it.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from chat_history.context_overflow import (
+    _TOOL_RESULT_CLIP_CHARS,
+    ContextOverflowProtection,
+    _clip_tool_results,
+    _extract_state,
+    _pick_boundary,
+    _preserved_user_messages,
+)
+
+
+def _tool_batch_history():
+    """History whose raw midpoint falls inside a tool batch.
+
+    10 messages; ``len // 2`` is 5, which is a ``role="tool"`` response whose
+    assistant parent sits at index 4.
+    """
+    return [
+        {"role": "user", "content": "first ask"},
+        {"role": "assistant", "content": "sure"},
+        {"role": "user", "content": "second ask"},
+        {"role": "assistant", "content": "working"},
+        {"role": "assistant", "content": "", "tool_calls": [{"function": {"name": "read_file"}}]},
+        {"role": "tool", "content": "file body"},
+        {"role": "tool", "content": "second file body"},
+        {"role": "assistant", "content": "done"},
+        {"role": "user", "content": "third ask"},
+        {"role": "assistant", "content": "ok"},
+    ]
+
+
+class TestBoundaryLandsOnATurnStart:
+    """`len(messages) // 2` is an index, not a boundary."""
+
+    def test_the_raw_midpoint_of_the_fixture_really_is_a_tool_message(self):
+        # Guards the fixture itself: if this stops being true the tests below
+        # would pass while asserting nothing.
+        history = _tool_batch_history()
+        assert history[len(history) // 2]["role"] == "tool"
+
+    def test_the_chosen_boundary_is_never_inside_a_tool_batch(self):
+        history = _tool_batch_history()
+        boundary = _pick_boundary(history, len(history) // 2)
+        assert history[boundary]["role"] != "tool"
+
+    def test_the_kept_half_carries_no_orphaned_tool_message(self):
+        history = _tool_batch_history()
+        boundary = _pick_boundary(history, len(history) // 2)
+        kept = history[boundary:]
+        # A tool message is an orphan unless an assistant with tool_calls
+        # precedes it within the kept half.
+        in_batch = False
+        for msg in kept:
+            if msg["role"] == "tool":
+                assert in_batch, "kept half starts with, or contains, an orphaned tool message"
+                continue
+            in_batch = msg["role"] == "assistant" and bool(msg.get("tool_calls"))
+
+    def test_a_user_turn_is_preferred_when_one_is_in_reach(self):
+        history = _tool_batch_history()
+        boundary = _pick_boundary(history, len(history) // 2)
+        assert history[boundary]["role"] == "user"
+
+    def test_a_history_of_only_tool_messages_falls_back_to_zero(self):
+        # Degenerate input must not raise and must not pick a tool index.
+        history = [{"role": "tool", "content": "x"} for _ in range(4)]
+        assert _pick_boundary(history, 2) == 0
+
+    def test_an_empty_history_is_boundary_zero(self):
+        assert _pick_boundary([], 0) == 0
+
+    def test_a_leading_user_turn_does_not_drag_the_boundary_to_zero(self):
+        """Boundary 0 summarizes nothing — and the caller then skips the reset.
+
+        Found by the clipping wiring test: with the only user turn at index 0,
+        the user-turn preference chose 0, so compaction summarized no messages,
+        never reset the tracker, and the session re-attempted it every turn while
+        reporting that compaction was enabled. Silent, and permanent.
+        """
+        history = [
+            {"role": "user", "content": "go"},
+            {"role": "assistant", "content": "", "tool_calls": [{"function": {"name": "read_file"}}]},
+            {"role": "tool", "content": "body"},
+            {"role": "assistant", "content": "ok"},
+        ]
+        boundary = _pick_boundary(history, len(history) // 2)
+        assert boundary > 0, "compaction would summarize nothing and never reset the tracker"
+        assert history[boundary]["role"] != "tool"
+
+
+class TestUserMessagesSurviveVerbatim:
+    def test_user_text_is_returned_unchanged(self):
+        history = [
+            {"role": "user", "content": "deploy only to staging, never prod"},
+            {"role": "assistant", "content": "understood"},
+        ]
+        assert _preserved_user_messages(history, cap=40) == ["deploy only to staging, never prod"]
+
+    def test_both_message_schemas_are_read(self):
+        # API schema (role/content) and display schema (sender/text) both occur;
+        # reading only one silently preserves nothing for the other.
+        history = [
+            {"role": "user", "content": "api schema"},
+            {"sender": "user", "text": "display schema"},
+        ]
+        assert _preserved_user_messages(history, cap=40) == ["api schema", "display schema"]
+
+    def test_the_cap_keeps_the_most_recent_not_the_oldest(self):
+        history = [{"role": "user", "content": f"ask {i}"} for i in range(10)]
+        assert _preserved_user_messages(history, cap=3) == ["ask 7", "ask 8", "ask 9"]
+
+    def test_non_user_messages_are_not_preserved_here(self):
+        history = [
+            {"role": "assistant", "content": "assistant prose"},
+            {"role": "tool", "content": "tool output"},
+        ]
+        assert _preserved_user_messages(history, cap=40) == []
+
+
+class TestExtractedStateIsDeterministic:
+    def _history_with_work(self):
+        return [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {"function": {"name": "write_file", "arguments": '{"path": "src/app.py"}'}},
+                ],
+            },
+            {"role": "tool", "content": "ok"},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {"function": {"name": "execute_command", "arguments": '{"command": "pytest -q"}'}},
+                ],
+            },
+            {"role": "tool", "content": "2 failed, 5 passed\nexit status 1"},
+        ]
+
+    def test_a_written_file_is_reported(self):
+        state = _extract_state(self._history_with_work())
+        assert "src/app.py" in state["files_written"]
+
+    def test_a_shell_command_is_reported(self):
+        state = _extract_state(self._history_with_work())
+        assert any("pytest -q" in c for c in state["commands"])
+
+    def test_tools_used_are_reported(self):
+        state = _extract_state(self._history_with_work())
+        assert set(state["tools_used"]) == {"write_file", "execute_command"}
+
+    def test_extraction_needs_no_model_call(self):
+        # No gateway is patched here at all. If extraction ever reached for one
+        # this test would error rather than fail, which is the point.
+        assert _extract_state(self._history_with_work())["files_written"]
+
+    def test_malformed_tool_calls_do_not_raise(self):
+        history = [
+            {"role": "assistant", "tool_calls": "not-a-list"},
+            {"role": "assistant", "tool_calls": [{"function": {"name": "write_file", "arguments": "{bad json"}}]},
+            "not-a-dict",
+        ]
+        state = _extract_state(history)
+        assert state["files_written"] == []
+
+
+class TestToolResultsAreClipped:
+    def test_a_long_tool_result_is_clipped(self):
+        history = [{"role": "tool", "content": "x" * (_TOOL_RESULT_CLIP_CHARS + 500)}]
+        clipped = _clip_tool_results(history, _TOOL_RESULT_CLIP_CHARS)
+        assert len(clipped[0]["content"]) <= _TOOL_RESULT_CLIP_CHARS + 32  # + truncation marker
+
+    def test_a_short_tool_result_is_untouched(self):
+        history = [{"role": "tool", "content": "short"}]
+        assert _clip_tool_results(history, _TOOL_RESULT_CLIP_CHARS)[0]["content"] == "short"
+
+    def test_user_and_assistant_text_is_never_clipped(self):
+        long_text = "y" * (_TOOL_RESULT_CLIP_CHARS + 500)
+        history = [{"role": "user", "content": long_text}]
+        assert _clip_tool_results(history, _TOOL_RESULT_CLIP_CHARS)[0]["content"] == long_text
+
+    @pytest.mark.asyncio
+    async def test_create_summary_actually_clips_before_calling_the_summarizer(self):
+        """The wiring, not the helper — see the boundary equivalent above.
+
+        The three tests above all pass if ``_create_summary`` stops calling
+        ``_clip_tool_results``. This one does not.
+        """
+        long_body = "x" * (_TOOL_RESULT_CLIP_CHARS + 500)
+        history = [
+            {"role": "user", "content": "go"},
+            {"role": "assistant", "content": "", "tool_calls": [{"function": {"name": "read_file"}}]},
+            {"role": "tool", "content": long_body},
+            {"role": "assistant", "content": "ok"},
+            {"role": "user", "content": "more"},
+            {"role": "assistant", "content": "sure"},
+            {"role": "user", "content": "next"},
+            {"role": "assistant", "content": "done"},
+            {"role": "user", "content": "and again"},
+            {"role": "assistant", "content": "yes"},
+        ]
+        protection = ContextOverflowProtection()
+        protection.summarizer.summarize_messages = AsyncMock(return_value="S")
+        protection.tracker.reset_session = AsyncMock()
+        protection.tracker.add_message_tokens = AsyncMock()
+
+        await protection._create_summary("session-1", history, "gpt-4")
+
+        sent = protection.summarizer.summarize_messages.await_args.args[0]
+        tool_bodies = [m["content"] for m in sent if m.get("role") == "tool"]
+        assert tool_bodies, "fixture must put a tool result in the summarized region"
+        assert all(len(b) < len(long_body) for b in tool_bodies), "tool result reached the summarizer unclipped"
+        # And the caller's own history is untouched.
+        assert history[2]["content"] == long_body
+
+    def test_the_input_list_is_not_mutated(self):
+        history = [{"role": "tool", "content": "z" * (_TOOL_RESULT_CLIP_CHARS + 500)}]
+        original = history[0]["content"]
+        _clip_tool_results(history, _TOOL_RESULT_CLIP_CHARS)
+        assert history[0]["content"] == original
+
+
+class TestTheComposedSummaryCarriesAllThree:
+    """End-to-end through `_create_summary`, with the model stubbed."""
+
+    async def _compact(self, history, summary_text="MODEL SUMMARY"):
+        protection = ContextOverflowProtection()
+        protection.summarizer.summarize_messages = AsyncMock(return_value=summary_text)
+        protection.tracker.reset_session = AsyncMock()
+        protection.tracker.add_message_tokens = AsyncMock()
+        return await protection._create_summary("session-1", history, "gpt-4")
+
+    @pytest.mark.asyncio
+    async def test_state_survives_a_summary_that_mentions_none_of_it(self):
+        history = [
+            {"role": "user", "content": "ship it"},
+            {
+                "role": "assistant",
+                "tool_calls": [{"function": {"name": "write_file", "arguments": '{"path": "src/app.py"}'}}],
+            },
+            {"role": "tool", "content": "ok"},
+            {"role": "user", "content": "and run the tests"},
+            {"role": "assistant", "content": "done"},
+            {"role": "user", "content": "thanks"},
+        ]
+        composed = await self._compact(history, summary_text="The user asked for some changes.")
+        # The stub summary names no file. The path must still cross the boundary.
+        assert "src/app.py" in composed
+        assert "src/app.py" not in "The user asked for some changes."
+
+    @pytest.mark.asyncio
+    async def test_user_instructions_cross_verbatim(self):
+        history = [
+            {"role": "user", "content": "never touch the prod database"},
+            {"role": "assistant", "content": "understood"},
+            {"role": "user", "content": "now add the endpoint"},
+            {"role": "assistant", "content": "added"},
+        ]
+        composed = await self._compact(history)
+        assert "never touch the prod database" in composed
+
+    @pytest.mark.asyncio
+    async def test_two_successive_compactions_do_not_erode_the_instruction(self):
+        history = [
+            {"role": "user", "content": "never touch the prod database"},
+            {"role": "assistant", "content": "understood"},
+            {"role": "user", "content": "add the endpoint"},
+            {"role": "assistant", "content": "added"},
+        ]
+        first = await self._compact(history)
+        # The composed summary becomes a message in the next round's history.
+        second_round = [{"role": "user", "content": first}] + history
+        second = await self._compact(second_round)
+        assert "never touch the prod database" in second
+
+    @pytest.mark.asyncio
+    async def test_an_empty_history_still_returns_empty(self):
+        assert await self._compact([]) == ""
+
+    @pytest.mark.asyncio
+    async def test_create_summary_cuts_at_the_snapped_boundary_not_the_raw_index(self):
+        """The wiring, not the helper.
+
+        Every other boundary test calls ``_pick_boundary`` directly, so all of
+        them stay green if ``_create_summary`` goes back to ``len // 2``. This
+        one fails in that case, which is the only reason it exists.
+        """
+        history = _tool_batch_history()
+        protection = ContextOverflowProtection()
+        protection.summarizer.summarize_messages = AsyncMock(return_value="S")
+        protection.tracker.reset_session = AsyncMock()
+        protection.tracker.add_message_tokens = AsyncMock()
+
+        await protection._create_summary("session-1", history, "gpt-4")
+
+        expected = _pick_boundary(history, len(history) // 2)
+        assert expected != len(history) // 2, "fixture no longer distinguishes snapped from raw"
+
+        sent = protection.summarizer.summarize_messages.await_args.args[0]
+        assert len(sent) == expected, "summarizer was given the raw-index region, not the snapped one"
+        # One refill per retained message: the kept half is everything after the
+        # boundary the production path actually used.
+        assert protection.tracker.add_message_tokens.await_count == len(history) - expected
+
+    @pytest.mark.asyncio
+    async def test_the_kept_half_of_a_real_compaction_has_no_orphaned_tool_message(self):
+        """The invariant the boundary exists to protect, through the real path."""
+        history = _tool_batch_history()
+        protection = ContextOverflowProtection()
+        protection.summarizer.summarize_messages = AsyncMock(return_value="S")
+        protection.tracker.reset_session = AsyncMock()
+        protection.tracker.add_message_tokens = AsyncMock()
+
+        await protection._create_summary("session-1", history, "gpt-4")
+
+        retained = protection.tracker.add_message_tokens.await_count
+        kept = history[len(history) - retained :]
+        in_batch = False
+        for msg in kept:
+            if msg["role"] == "tool":
+                assert in_batch, f"compaction left an orphaned tool message in the kept half: {kept!r}"
+                continue
+            in_batch = msg["role"] == "assistant" and bool(msg.get("tool_calls"))
+
+
+class TestCompactedViewIsSmallerThanWhatItReplaced:
+    @pytest.mark.asyncio
+    async def test_compaction_measurably_reduces_the_summarized_region(self):
+        """The invariant, asserted — not a number quoted in a PR body.
+
+        The whole point of compaction is that the composed replacement is
+        smaller than the region it replaces. A change that grows the state block
+        or the preserved-user set without bound breaks this and nothing else
+        would notice.
+        """
+        from autobot_shared.token_count import estimate_fast
+
+        history = []
+        for i in range(40):
+            history.append({"role": "user", "content": f"instruction {i} " + ("detail " * 40)})
+            history.append({"role": "assistant", "content": "acknowledged " * 60})
+
+        protection = ContextOverflowProtection()
+        protection.summarizer.summarize_messages = AsyncMock(return_value="A short summary.")
+        protection.tracker.reset_session = AsyncMock()
+        protection.tracker.add_message_tokens = AsyncMock()
+
+        boundary = _pick_boundary(history, len(history) // 2)
+        replaced_tokens = sum(estimate_fast(str(m.get("content", ""))) for m in history[:boundary])
+
+        composed = await protection._create_summary("session-1", history, "gpt-4")
+        composed_tokens = estimate_fast(composed)
+
+        assert replaced_tokens > 0
+        assert (
+            composed_tokens < replaced_tokens
+        ), f"compaction grew the region it replaced: {replaced_tokens} → {composed_tokens}"
+
+
+class TestExistingBehaviourIsPreserved:
+    @pytest.mark.asyncio
+    async def test_a_summarization_failure_still_propagates(self):
+        """#14065's guarantee must not regress under #14066's changes."""
+        from chat_history.context_overflow import SummarizationFailed
+
+        protection = ContextOverflowProtection()
+        protection.summarizer.summarize_messages = AsyncMock(side_effect=SummarizationFailed("boom"))
+        protection.tracker.reset_session = AsyncMock()
+
+        history = [
+            {"role": "user", "content": "a"},
+            {"role": "assistant", "content": "b"},
+            {"role": "user", "content": "c"},
+            {"role": "assistant", "content": "d"},
+        ]
+        with pytest.raises(SummarizationFailed):
+            await protection._create_summary("session-1", history, "gpt-4")
+        protection.tracker.reset_session.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_the_tracker_is_still_reset_and_refilled_on_success(self):
+        protection = ContextOverflowProtection()
+        protection.summarizer.summarize_messages = AsyncMock(return_value="summary")
+        protection.tracker.reset_session = AsyncMock()
+        protection.tracker.add_message_tokens = AsyncMock()
+
+        history = [
+            {"role": "user", "content": "a"},
+            {"role": "assistant", "content": "b"},
+            {"role": "user", "content": "c"},
+            {"role": "assistant", "content": "d"},
+        ]
+        await protection._create_summary("session-1", history, "gpt-4")
+        protection.tracker.reset_session.assert_awaited_once_with("session-1")
+        assert protection.tracker.add_message_tokens.await_count > 0

--- a/autobot-backend/chat_history/context_overflow_boundary_test.py
+++ b/autobot-backend/chat_history/context_overflow_boundary_test.py
@@ -413,3 +413,43 @@ class TestExistingBehaviourIsPreserved:
         await protection._create_summary("session-1", history, "gpt-4")
         protection.tracker.reset_session.assert_awaited_once_with("session-1")
         assert protection.tracker.add_message_tokens.await_count > 0
+
+
+class TestClippingLandsWhereTheSummarizerReads:
+    """Review finding on this PR: the clip must land in the key that is *read*.
+
+    `_format_messages` reads `msg.get("content") or msg.get("text", "")`. Writing
+    the clipped body to `text` while a truthy `content` survives means the full
+    body still reaches the summarizer — with every clipping test still green,
+    because they all used string content.
+    """
+
+    def _summarizer_view(self, msg):
+        """What ConversationSummarizer._format_messages would actually read."""
+        from chat_history.context_overflow import ConversationSummarizer
+
+        return ConversationSummarizer()._format_messages([msg])
+
+    def test_a_list_content_tool_result_is_actually_clipped(self):
+        long_text = "x" * (_TOOL_RESULT_CLIP_CHARS + 500)
+        msg = {"role": "tool", "content": [{"type": "text", "text": long_text}]}
+        clipped = _clip_tool_results([msg], _TOOL_RESULT_CLIP_CHARS)[0]
+        assert len(self._summarizer_view(clipped)) < len(long_text)
+
+    def test_an_empty_content_beside_a_populated_text_is_actually_clipped(self):
+        long_text = "y" * (_TOOL_RESULT_CLIP_CHARS + 500)
+        msg = {"role": "tool", "content": "", "text": long_text}
+        clipped = _clip_tool_results([msg], _TOOL_RESULT_CLIP_CHARS)[0]
+        assert len(self._summarizer_view(clipped)) < len(long_text)
+
+    def test_a_string_content_tool_result_is_still_clipped(self):
+        long_text = "z" * (_TOOL_RESULT_CLIP_CHARS + 500)
+        msg = {"role": "tool", "content": long_text}
+        clipped = _clip_tool_results([msg], _TOOL_RESULT_CLIP_CHARS)[0]
+        assert len(self._summarizer_view(clipped)) < len(long_text)
+
+    def test_a_list_content_with_no_text_parts_falls_back_to_text(self):
+        long_text = "w" * (_TOOL_RESULT_CLIP_CHARS + 500)
+        msg = {"role": "tool", "content": [{"type": "image", "url": "u"}], "text": long_text}
+        clipped = _clip_tool_results([msg], _TOOL_RESULT_CLIP_CHARS)[0]
+        assert len(clipped["text"]) < len(long_text)

--- a/autobot-backend/chat_history/context_overflow_test.py
+++ b/autobot-backend/chat_history/context_overflow_test.py
@@ -567,6 +567,18 @@ class TestTheTrackerIsNeverResetWithoutADeliveredSummary:
 
         summary = await protection._create_summary("session-1", messages, "gpt-4")
 
-        assert summary == "Summary."
+        # #14066 changed two things this test had pinned, both deliberately:
+        #
+        # 1. The return value is now the model summary *plus* extracted state and
+        #    verbatim user turns, so it is no longer equal to the stub. The
+        #    property that matters — the paid-for summary is delivered, not
+        #    discarded — is asserted on containment instead.
+        # 2. The boundary snaps back from the raw midpoint (index 4, which is the
+        #    ``"not a dict"`` entry) to the nearest user turn at index 3, so five
+        #    messages are retained rather than four.
+        #
+        # The original intent is unchanged and still asserted: exactly one reset,
+        # and every retained message re-counted despite three malformed entries.
+        assert "Summary." in summary
         mock_tracker.reset_session.assert_awaited_once_with("session-1")
-        assert mock_tracker.add_message_tokens.await_count == 4
+        assert mock_tracker.add_message_tokens.await_count == 5

--- a/autobot_shared/env_registry.py
+++ b/autobot_shared/env_registry.py
@@ -929,6 +929,58 @@ register_env_var(
 
 register_env_var(
     EnvVarSpec(
+        name="AUTOBOT_COMPACTION_USER_MESSAGE_CAP",
+        type=int,
+        default=40,
+        description=(
+            "How many of the most recent user messages cross a context compaction "
+            "verbatim instead of being summarised. Bounded so repeated compaction "
+            "cannot grow the preserved set without limit."
+        ),
+        component="chat",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_COMPACTION_TOOL_RESULT_CLIP_CHARS",
+        type=int,
+        default=400,
+        description=(
+            "Maximum characters of a tool result in the summarised region before "
+            "it is clipped for the summariser; a file read many turns ago is "
+            "cheaper to re-read than to carry."
+        ),
+        component="chat",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_COMPACTION_BOUNDARY_WINDOW",
+        type=int,
+        default=10,
+        description=(
+            "How far back the compaction boundary looks for a user turn before "
+            "settling for any turn start, so the cut cannot be dragged far from "
+            "the midpoint."
+        ),
+        component="chat",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_COMPACTION_STATE_COMMAND_CAP",
+        type=int,
+        default=10,
+        description="Most recent shell commands named in a compaction's extracted state block.",
+        component="chat",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
         name="AUTOBOT_LLC_H2A_BRIEF_CACHE_TTL",
         type=int,
         default=86400,

--- a/changelog/unreleased/14066-compaction-boundary.md
+++ b/changelog/unreleased/14066-compaction-boundary.md
@@ -1,0 +1,7 @@
+---
+type: fix
+scope: chat
+issue: 14066
+pr: 14249
+---
+Context compaction now cuts at a turn boundary, carries recent user messages across verbatim, and emits a deterministic state block (files written, commands run, tools used) alongside the model's summary, so a bad summarisation turn no longer takes the session's state with it.


### PR DESCRIPTION
## Thinking Path

Compaction replaced the oldest half of a conversation and depended entirely on one LLM call
to carry it forward. Three things followed from `split_point = len(messages) // 2`:

1. **The cut was an index, not a boundary.** It could land between an assistant message
   carrying `tool_calls` and its `role="tool"` responses. `_sanitize_tool_messages` exists and
   repairs exactly this — but it was applied only to the *summariser's input*, never to the
   half that continues on to the provider.
2. **Every user message in the older half became prose.** The summarisation prompt asks for
   constraints under "Key Context", which is a request, not a guarantee — and a long session
   re-summarises the same region repeatedly, each pass another chance to drop the thing the
   user said once.
3. **Nothing deterministic crossed.** Facts that are exact and free to compute — files
   written, commands run with exit status — were re-derived by a model from prose, or lost.

**Why this approach:** keep the LLM summary and add a deterministic layer beside it, rather
than replacing summarisation. The state block's value is precisely that it still works when
the summary is bad; that is a design property, not an optimisation. Preserving user turns is
made safe by bounding the set, not by choosing which ones matter.

**Alternative rejected:** repairing the kept half with `_sanitize_tool_messages` instead of
moving the boundary. That drops the orphaned tool responses — losing real content — where
snapping the cut keeps the whole batch together on one side.

## What Changed

- `autobot-backend/chat_history/context_overflow.py`
  - `_pick_boundary` — snaps `len(messages) // 2` back to a turn start, preferring a user turn
    within a bounded window. A `role="tool"` message is never a valid cut point.
  - `_preserved_user_messages` — the most recent N user messages, verbatim, never summarised.
  - `_extract_state` / `_render_state_block` — files written, shell commands, tools used, read
    off the tool calls. Tool-name matching reuses `autobot_shared.tool_catalogue`
    (`FILE_WRITE_TOOLS`, `SHELL_EXEC_TOOLS`, `match_tool_name`), not a local literal list.
  - `_clip_tool_results` — clips oversized tool results in the summarised region. Returns a
    new list; the caller's history and the persisted transcript are untouched.
  - `_compose_summary` — joins the three.
  - `_message_text` + new `_text_parts` — **defect fixed**: it read only `msg["text"]`, so every
    API-schema message (`role`/`content`) estimated as **0 tokens** and the post-compaction
    refill under-counted the retained half. That delays the next compaction rather than
    triggering one early, so it produced no error and no alert.
- `autobot_shared/env_registry.py` — registers the four new `AUTOBOT_COMPACTION_*` vars.
- `changelog/unreleased/14066-compaction-boundary.md` — new fragment.
- `autobot-backend/chat_history/context_overflow_boundary_test.py` — new, 30 tests.
- `autobot-backend/chat_history/context_overflow_test.py` — one assertion pair updated (see Risks).

**Second defect fixed, found by a test failing at baseline:** the user-turn preference could
drag the boundary to index 0. `_create_summary` then summarised *no* messages and returned
early — **before** the tracker reset — so the session stayed over threshold and re-attempted
compaction every turn while reporting compaction as enabled. Both searches now floor at index 1.

## Verification

```bash
./venv/bin/python -m pytest autobot-backend/chat_history/ -q
# 162 passed in 14.11s

./venv/bin/python pipeline-scripts/check_env_var_registry.py   # exit 0
```

**Mutation-tested — every guard was verified to fail when the line it guards is reverted.**
This mattered: the first version of these tests called `_pick_boundary` directly, and **all 26
passed with `_create_summary` reverted to `len(messages) // 2`**. Three wiring tests were added
to close that.

| Mutation | Result |
|---|---|
| boundary snap → raw `len // 2` | 3 failed |
| composition → bare `return summary` | 3 failed |
| tool-result clipping removed | 1 failed |
| user-message preservation → `[]` | 2 failed |
| state block → `""` | 1 failed |
| boundary floor `max(1, …)` → `max(0, …)` | 1 failed |

Baseline restored and re-verified green after each.

The token-accounting acceptance criterion is asserted as an **invariant** — the composed
replacement is smaller than the region it replaces — rather than quoted as a number here.

## Risks

- **The compacted view is larger than before**, carrying state and user turns alongside the
  summary. Bounded by `AUTOBOT_COMPACTION_USER_MESSAGE_CAP` (40) and
  `AUTOBOT_COMPACTION_STATE_COMMAND_CAP` (10); the size invariant is asserted in a test.
- **Token estimates for API-schema sessions change from 0 to correct**, so compaction triggers
  *earlier* for those sessions than it has been. This is the fix, not a regression, but it is
  the change most likely to be visible in production.
- **One existing test was modified.** `test_a_malformed_retained_message_does_not_clear_the_counter`
  pinned `summary == "Summary."` and `await_count == 4`; the return value is now composed and
  the boundary snaps from index 4 to 3. Its intent — exactly one reset, every retained message
  re-counted despite malformed entries — is unchanged and still asserted.
- `summary_text` remains a single string injected as a system message; no consumer contract
  changed (`chat_history/overflow_integration.py`).
- Rollback: revert the commit. No migration, no persisted-format change — the stored transcript
  was never touched.

## Model Used

Claude Opus 5 (claude-opus-5[1m])

## Issue Link

Closes #14066

Related: #14065 (the failure-path fix this builds on — its guarantee is re-asserted here so it
cannot regress), #14029 (context sizing), #13685 (tiered context stack), #13593.

## Changelog fragment

- [x] Added `changelog/unreleased/14066-compaction-boundary.md`

## Checklist
- [x] Code follows AutoBot patterns from `CLAUDE.md`
- [x] Tests added or updated (or N/A with reason)
- [x] Documentation updated if behavior changed
- [x] Pre-commit hooks pass (`git commit` runs them automatically)
- [x] PR targets `Dev_new_gui` (not `main`)
- [x] No secrets or credentials in the diff

---

## Review finding fixed after CI first went green (`747e9c730`)

Self-review before merge caught a real bug in this PR. `_clip_tool_results` chose its write
key with `isinstance(msg.get("content"), str)`, but `_format_messages` reads
`msg.get("content") or msg.get("text", "")`. For a tool result whose `content` is a
**multimodal list**, the clipped body was written to `text` while the untouched list stayed in
`content` — so the full body still reached the summarizer while the clip looked applied.

Every clipping test passed, because they all used string content. That is the
empty-result-reads-as-clean shape this PR is otherwise about.

Fixed by `_body_key`, which mirrors `_message_text`'s own precedence so a rewrite lands in
the key that is actually read. Four regression tests added, asserting through
`_format_messages` (what the summarizer sees) rather than through the returned dict.
Mutation-verified: reverting to the old key selection fails
`test_a_list_content_tool_result_is_actually_clipped`.

```
186 passed    # chat_history/ + check_env_var_registry_helpers_test.py, after merging base
```
