### PR TITLE
fix(test): strip every inherited GIT_ variable instead of a list of nine (#13882)

### DIFF
--- a/autobot-backend/code_intelligence/co_change_test.py
+++ b/autobot-backend/code_intelligence/co_change_test.py
@@ -23,11 +23,19 @@ import pytest
 from code_intelligence.co_change import CoChangeAnalyzer, CoChangePair
 from code_intelligence.code_evolution_miner import GitCommandError, GitHistoryCrawler
 
-#: Git environment variables this fixture supplies for itself. Everything else
-#: beginning with ``GIT_`` is stripped -- see :func:`_hermetic_git_env`.
+#: Supplied by :func:`hermetic_git_env` to any fixture building a throwaway repo.
+#: Config is nulled so the runner's global git config cannot leak in. Identity is
+#: deliberately NOT here: an env-level identity silently outranks the repo-level
+#: ``git config user.name`` a fixture sets, so a sibling asserting on an author
+#: name would get this one instead of its own.
 _SUPPLIED_GIT_VARS = {
     "GIT_CONFIG_GLOBAL": os.devnull,
     "GIT_CONFIG_SYSTEM": os.devnull,
+}
+
+#: This file's identity, layered on top. Supplied via the environment so the
+#: fixture does not depend on the runner having a global git identity configured.
+_FIXTURE_IDENTITY = {
     "GIT_AUTHOR_NAME": "t",
     "GIT_AUTHOR_EMAIL": "a@b.c",
     "GIT_COMMITTER_NAME": "t",
@@ -35,7 +43,12 @@ _SUPPLIED_GIT_VARS = {
 }
 
 
-def _hermetic_git_env() -> dict:
+def _fixture_git_env() -> dict:
+    """:func:`hermetic_git_env` plus this file's own identity."""
+    return {**hermetic_git_env(), **_FIXTURE_IDENTITY}
+
+
+def hermetic_git_env() -> dict:
     """A git environment that cannot reach outside the repo passed to ``-C``.
 
     #13983: with ``GIT_INDEX_FILE`` exported, every xdist worker stages into
@@ -74,7 +87,9 @@ def _git(repo: Path, *args: str) -> None:
     therefore read as a bare "exit status 128" with no indication of the cause,
     which is what made the intermittent failure undiagnosable from the log.
     """
-    result = subprocess.run(["git", "-C", str(repo), *args], capture_output=True, text=True, env=_hermetic_git_env())
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args], capture_output=True, text=True, env=_fixture_git_env()
+    )
     if result.returncode != 0:
         raise AssertionError(
             f"git {' '.join(args)} failed in {repo} with exit {result.returncode}\n"
@@ -84,7 +99,9 @@ def _git(repo: Path, *args: str) -> None:
 
 def _git_init(path: Path) -> None:
     """git init with the same stderr-surfacing contract as _git (#13882)."""
-    result = subprocess.run(["git", "init", "-q", str(path)], capture_output=True, text=True, env=_hermetic_git_env())
+    result = subprocess.run(
+        ["git", "init", "-q", str(path)], capture_output=True, text=True, env=_fixture_git_env()
+    )
     if result.returncode != 0:
         raise AssertionError(
             f"git init failed in {path} with exit {result.returncode}\n"
@@ -506,24 +523,49 @@ def test_the_crawler_reads_the_repo_it_was_given_not_the_ambient_one(repo, tmp_p
     assert "decoy.py" not in seen, "GIT_DIR redirected the crawler to the ambient repository"
 
 
-def test_the_stripped_git_vars_cover_the_ones_that_override__C():
-    """The strip list must name every variable that outranks ``-C``.
+def test_the_production_git_env_strips_every_git_variable():
+    """The rule, not a list of names.
 
-    Listed explicitly rather than stripping ``GIT_*`` wholesale: ``GIT_AUTHOR_*``,
-    ``GIT_SSH_COMMAND`` and friends are legitimate and removing them would break
-    unrelated callers.
+    This test previously pinned a seven-name denylist, arguing that stripping
+    ``GIT_*`` wholesale would break unrelated callers because ``GIT_AUTHOR_*``
+    and ``GIT_SSH_COMMAND`` are legitimate. The call graph refutes it:
+    ``git_env()`` has exactly one consumer, ``_run_git``, whose every call site
+    is ``rev-parse --git-dir`` / ``log`` / ``show`` against a local path with
+    ``-C``. Nothing commits, so ``GIT_AUTHOR_*`` is inert; nothing clones or
+    fetches, so ``GIT_SSH_COMMAND`` is inert. (``skills/external_importer.py``
+    does fetch, but through its own ``_run_git`` with a different signature — it
+    never touches this environment.)
+
+    The concern was real in principle and false for this module, and the cost of
+    being wrong the other way is a crawler silently reporting another
+    repository's history (#13983, #13882).
     """
-    from code_intelligence.code_evolution_miner import _REPO_OVERRIDING_GIT_VARS, _git_env
+    from code_intelligence.code_evolution_miner import git_env
 
-    for var in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_OBJECT_DIRECTORY"):
-        assert var in _REPO_OVERRIDING_GIT_VARS, f"{var} outranks -C but is not stripped"
+    for var in (
+        "GIT_DIR",
+        "GIT_WORK_TREE",
+        "GIT_INDEX_FILE",
+        "GIT_OBJECT_DIRECTORY",
+        # Never on the seven-name list. The rule covers them without anyone
+        # noticing they were missing.
+        "GIT_COMMON_DIR",
+        "GIT_CEILING_DIRECTORIES",
+        "GIT_INDEX_VERSION",
+        "GIT_TEST_SOMETHING_NEW",
+    ):
+        os.environ[var] = "/somewhere/else"
+        try:
+            assert var not in git_env(), f"{var} outranks -C but survives"
+        finally:
+            del os.environ[var]
 
     import os as _os
 
     _os.environ["GIT_DIR"] = "/nowhere"
     try:
-        assert "GIT_DIR" not in _git_env()
-        assert "PATH" in _git_env(), "the environment was emptied rather than filtered"
+        assert "GIT_DIR" not in git_env()
+        assert "PATH" in git_env(), "the environment was emptied rather than filtered"
     finally:
         _os.environ.pop("GIT_DIR", None)
 
@@ -556,7 +598,7 @@ def test_the_stripped_git_vars_cover_the_ones_that_override__C():
 def test_no_inherited_git_variable_survives(monkeypatch, leaked):
     monkeypatch.setenv(leaked, "/somewhere/shared")
 
-    assert leaked not in _hermetic_git_env()
+    assert leaked not in hermetic_git_env()
 
 
 def test_the_variables_the_fixture_needs_are_supplied(monkeypatch):
@@ -565,7 +607,7 @@ def test_the_variables_the_fixture_needs_are_supplied(monkeypatch):
     for name in ("GIT_AUTHOR_NAME", "GIT_COMMITTER_EMAIL", "GIT_CONFIG_GLOBAL"):
         monkeypatch.delenv(name, raising=False)
 
-    env = _hermetic_git_env()
+    env = _fixture_git_env()
 
     assert env["GIT_AUTHOR_NAME"] == "t"
     assert env["GIT_COMMITTER_EMAIL"] == "a@b.c"
@@ -576,14 +618,14 @@ def test_a_supplied_variable_overrides_an_inherited_one(monkeypatch):
     """A runner exporting GIT_AUTHOR_NAME must not change what this fixture commits."""
     monkeypatch.setenv("GIT_AUTHOR_NAME", "the-runner")
 
-    assert _hermetic_git_env()["GIT_AUTHOR_NAME"] == "t"
+    assert _fixture_git_env()["GIT_AUTHOR_NAME"] == "t"
 
 
 def test_non_git_environment_is_left_alone(monkeypatch):
     """PATH and friends must survive, or git cannot be found at all."""
     monkeypatch.setenv("SOME_UNRELATED_VAR", "kept")
 
-    env = _hermetic_git_env()
+    env = hermetic_git_env()
 
     assert env["SOME_UNRELATED_VAR"] == "kept"
     assert "PATH" in env
@@ -610,7 +652,7 @@ def test_a_worker_with_a_hostile_index_file_still_commits_its_own_tree(monkeypat
             ["git", "-C", str(tmp_path / name), "log", "--oneline"],
             capture_output=True,
             text=True,
-            env=_hermetic_git_env(),
+            env=_fixture_git_env(),
         )
         assert result.returncode == 0, result.stderr
         assert result.stdout.count("\n") == 1, f"{name} sees another repo's history: {result.stdout}"

--- a/autobot-backend/code_intelligence/co_change_test.py
+++ b/autobot-backend/code_intelligence/co_change_test.py
@@ -87,9 +87,7 @@ def _git(repo: Path, *args: str) -> None:
     therefore read as a bare "exit status 128" with no indication of the cause,
     which is what made the intermittent failure undiagnosable from the log.
     """
-    result = subprocess.run(
-        ["git", "-C", str(repo), *args], capture_output=True, text=True, env=_fixture_git_env()
-    )
+    result = subprocess.run(["git", "-C", str(repo), *args], capture_output=True, text=True, env=_fixture_git_env())
     if result.returncode != 0:
         raise AssertionError(
             f"git {' '.join(args)} failed in {repo} with exit {result.returncode}\n"
@@ -99,9 +97,7 @@ def _git(repo: Path, *args: str) -> None:
 
 def _git_init(path: Path) -> None:
     """git init with the same stderr-surfacing contract as _git (#13882)."""
-    result = subprocess.run(
-        ["git", "init", "-q", str(path)], capture_output=True, text=True, env=_fixture_git_env()
-    )
+    result = subprocess.run(["git", "init", "-q", str(path)], capture_output=True, text=True, env=_fixture_git_env())
     if result.returncode != 0:
         raise AssertionError(
             f"git init failed in {path} with exit {result.returncode}\n"

--- a/autobot-backend/code_intelligence/co_change_test.py
+++ b/autobot-backend/code_intelligence/co_change_test.py
@@ -23,20 +23,16 @@ import pytest
 from code_intelligence.co_change import CoChangeAnalyzer, CoChangePair
 from code_intelligence.code_evolution_miner import GitCommandError, GitHistoryCrawler
 
-#: Git environment variables that redirect git away from the repository named
-#: on the command line. Inherited from the CI job, they make every worker's
-#: ``git`` operate on shared state instead of its own tmpdir (#13983).
-_INHERITED_GIT_VARS = (
-    "GIT_DIR",
-    "GIT_WORK_TREE",
-    "GIT_INDEX_FILE",
-    "GIT_OBJECT_DIRECTORY",
-    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
-    "GIT_COMMON_DIR",
-    "GIT_CEILING_DIRECTORIES",
-    "GIT_NAMESPACE",
-    "GIT_CONFIG",
-)
+#: Git environment variables this fixture supplies for itself. Everything else
+#: beginning with ``GIT_`` is stripped -- see :func:`_hermetic_git_env`.
+_SUPPLIED_GIT_VARS = {
+    "GIT_CONFIG_GLOBAL": os.devnull,
+    "GIT_CONFIG_SYSTEM": os.devnull,
+    "GIT_AUTHOR_NAME": "t",
+    "GIT_AUTHOR_EMAIL": "a@b.c",
+    "GIT_COMMITTER_NAME": "t",
+    "GIT_COMMITTER_EMAIL": "a@b.c",
+}
 
 
 def _hermetic_git_env() -> dict:
@@ -49,21 +45,23 @@ def _hermetic_git_env() -> dict:
         error: invalid object 100644 <sha> for 'solo_12.py'
         error: Error building trees
 
-    That reads as repository corruption and is nowhere near the code under
-    test. Identity is supplied here too, so the fixture does not depend on the
-    runner having a global git identity configured.
+    That reads as repository corruption and is nowhere near the code under test.
+
+    #13882: the same failure came back after that fix, with a second line of
+    ``error: bad tree object HEAD``. #13983 stripped a hand-written LIST of nine
+    variables, which is a denylist -- narrower than its own subject, and silently
+    wrong for the tenth. Git has more than nine such variables and gains new ones
+    between releases, so the list could only ever be correct for the failures
+    already seen.
+
+    Inverted here: strip **everything** beginning with ``GIT_``, then add back
+    exactly what the fixture needs. The fixture runs only local commands in a
+    throwaway repo, so nothing inherited is load-bearing, and a variable git adds
+    next year is stripped without anyone updating a list. Identity is supplied
+    too, so this does not depend on the runner having a global git identity.
     """
-    env = {k: v for k, v in os.environ.items() if k not in _INHERITED_GIT_VARS}
-    env.update(
-        {
-            "GIT_CONFIG_GLOBAL": os.devnull,
-            "GIT_CONFIG_SYSTEM": os.devnull,
-            "GIT_AUTHOR_NAME": "t",
-            "GIT_AUTHOR_EMAIL": "a@b.c",
-            "GIT_COMMITTER_NAME": "t",
-            "GIT_COMMITTER_EMAIL": "a@b.c",
-        }
-    )
+    env = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+    env.update(_SUPPLIED_GIT_VARS)
     return env
 
 
@@ -528,3 +526,91 @@ def test_the_stripped_git_vars_cover_the_ones_that_override__C():
         assert "PATH" in _git_env(), "the environment was emptied rather than filtered"
     finally:
         _os.environ.pop("GIT_DIR", None)
+
+
+# ---------------------------------------------------------------------------
+# #13882 — the hermetic environment itself, asserted directly.
+#
+# #13983 stripped a hand-written list of nine GIT_* variables and the corruption
+# came back through a tenth. These assert the RULE ("nothing inherited beginning
+# with GIT_ survives"), not the nine names that were known at the time.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "leaked",
+    [
+        "GIT_INDEX_FILE",  # #13983's original culprit
+        "GIT_DIR",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        "GIT_COMMON_DIR",
+        # Never on any denylist. A future git release adding one of these is the
+        # whole reason the rule replaced the list.
+        "GIT_INDEX_VERSION",
+        "GIT_LITERAL_PATHSPECS",
+        "GIT_ATTR_NOSYSTEM",
+        "GIT_TEST_SOMETHING_NEW",
+    ],
+)
+def test_no_inherited_git_variable_survives(monkeypatch, leaked):
+    monkeypatch.setenv(leaked, "/somewhere/shared")
+
+    assert leaked not in _hermetic_git_env()
+
+
+def test_the_variables_the_fixture_needs_are_supplied(monkeypatch):
+    """Stripping everything means identity has to be put back, or the fixture
+    depends on the runner having a global git identity configured."""
+    for name in ("GIT_AUTHOR_NAME", "GIT_COMMITTER_EMAIL", "GIT_CONFIG_GLOBAL"):
+        monkeypatch.delenv(name, raising=False)
+
+    env = _hermetic_git_env()
+
+    assert env["GIT_AUTHOR_NAME"] == "t"
+    assert env["GIT_COMMITTER_EMAIL"] == "a@b.c"
+    assert env["GIT_CONFIG_GLOBAL"] == os.devnull
+
+
+def test_a_supplied_variable_overrides_an_inherited_one(monkeypatch):
+    """A runner exporting GIT_AUTHOR_NAME must not change what this fixture commits."""
+    monkeypatch.setenv("GIT_AUTHOR_NAME", "the-runner")
+
+    assert _hermetic_git_env()["GIT_AUTHOR_NAME"] == "t"
+
+
+def test_non_git_environment_is_left_alone(monkeypatch):
+    """PATH and friends must survive, or git cannot be found at all."""
+    monkeypatch.setenv("SOME_UNRELATED_VAR", "kept")
+
+    env = _hermetic_git_env()
+
+    assert env["SOME_UNRELATED_VAR"] == "kept"
+    assert "PATH" in env
+
+
+def test_a_worker_with_a_hostile_index_file_still_commits_its_own_tree(monkeypatch, tmp_path):
+    """The reproduction, end to end.
+
+    With GIT_INDEX_FILE pointing at a shared path, a worker used to stage into
+    one index while committing in its own tmpdir — producing a tree whose blobs
+    live in another worker's object store. Two repos are built here under the
+    same hostile value; both must succeed and stay independent.
+    """
+    monkeypatch.setenv("GIT_INDEX_FILE", str(tmp_path / "shared.index"))
+
+    for name in ("repo_a", "repo_b"):
+        repo = tmp_path / name
+        repo.mkdir()
+        _git_init(repo)
+        _commit(repo, {f"{name}.py": "v0\n"}, f"initial {name}")
+
+    for name in ("repo_a", "repo_b"):
+        result = subprocess.run(
+            ["git", "-C", str(tmp_path / name), "log", "--oneline"],
+            capture_output=True,
+            text=True,
+            env=_hermetic_git_env(),
+        )
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.count("\n") == 1, f"{name} sees another repo's history: {result.stdout}"

--- a/autobot-backend/code_intelligence/code_evolution_miner.py
+++ b/autobot-backend/code_intelligence/code_evolution_miner.py
@@ -93,25 +93,31 @@ class PatternLifecycle:
         return 0
 
 
-#: Git environment variables that override the repository named on the command
-#: line. Left in place, ``-C repo_path`` becomes advisory and git reads whatever
-#: the ambient environment points at (#13983). A crawler asked to analyse one
-#: repository must not silently analyse another — the caller gets a plausible
-#: history for the wrong tree, which is worse than an error.
-_REPO_OVERRIDING_GIT_VARS = (
-    "GIT_DIR",
-    "GIT_WORK_TREE",
-    "GIT_INDEX_FILE",
-    "GIT_OBJECT_DIRECTORY",
-    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
-    "GIT_COMMON_DIR",
-    "GIT_NAMESPACE",
-)
+def git_env() -> dict:
+    """The ambient environment minus everything that redirects git off ``-C``.
+
+    Left in place, such a variable makes ``-C repo_path`` advisory and git reads
+    whatever the ambient environment points at (#13983). A crawler asked to
+    analyse one repository must not silently analyse another — the caller gets a
+    plausible history for the wrong tree, which is worse than an error.
+
+    #13882: this was a hand-written list of seven names, and its sibling in the
+    test fixture was a list of nine. Both are denylists — narrower than their own
+    subject, correct for the failures already seen and silently wrong for the
+    next one. Git has more than nine such variables and gains new ones between
+    releases, so neither list could ever be finished, only extended once per
+    incident. Inverted here: strip everything beginning with ``GIT_``.
+
+    Safe to strip wholesale because every caller is read-only and local —
+    ``_run_git`` passes ``-C`` and runs ``log``/``show`` against a path that is
+    already on disk. Nothing here clones, fetches or authenticates, so no
+    ``GIT_SSH_*`` or credential variable is load-bearing.
+    """
+    return {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
 
 
-def _git_env() -> dict:
-    """The ambient environment minus anything that redirects git off ``-C``."""
-    return {k: v for k, v in os.environ.items() if k not in _REPO_OVERRIDING_GIT_VARS}
+#: Back-compat alias — this module's own call site and the tests both import it.
+_git_env = git_env
 
 
 class GitCommandError(RuntimeError):

--- a/autobot-backend/code_intelligence/git_history_crawler_test.py
+++ b/autobot-backend/code_intelligence/git_history_crawler_test.py
@@ -34,9 +34,7 @@ def _git(repo: Path, *args: str) -> None:
     therefore read as a bare "exit status 128" with no indication of the cause,
     which is what made the intermittent failure undiagnosable from the log.
     """
-    result = subprocess.run(
-        ["git", "-C", str(repo), *args], capture_output=True, text=True, env=hermetic_git_env()
-    )
+    result = subprocess.run(["git", "-C", str(repo), *args], capture_output=True, text=True, env=hermetic_git_env())
     if result.returncode != 0:
         raise AssertionError(
             f"git {' '.join(args)} failed in {repo} with exit {result.returncode}\n"
@@ -53,9 +51,7 @@ def _git_init(path: Path) -> None:
     been looked at when the sibling was fixed. A fix applied to one of two
     identical call sites is half a fix.
     """
-    result = subprocess.run(
-        ["git", "init", "-q", str(path)], capture_output=True, text=True, env=hermetic_git_env()
-    )
+    result = subprocess.run(["git", "init", "-q", str(path)], capture_output=True, text=True, env=hermetic_git_env())
     if result.returncode != 0:
         raise AssertionError(
             f"git init failed in {path} with exit {result.returncode}\n"

--- a/autobot-backend/code_intelligence/git_history_crawler_test.py
+++ b/autobot-backend/code_intelligence/git_history_crawler_test.py
@@ -21,6 +21,7 @@ from pathlib import Path
 
 import pytest
 
+from code_intelligence.co_change_test import hermetic_git_env
 from code_intelligence.code_evolution_miner import GitCommandError, GitHistoryCrawler, _parse_numstat
 
 
@@ -33,7 +34,9 @@ def _git(repo: Path, *args: str) -> None:
     therefore read as a bare "exit status 128" with no indication of the cause,
     which is what made the intermittent failure undiagnosable from the log.
     """
-    result = subprocess.run(["git", "-C", str(repo), *args], capture_output=True, text=True)
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args], capture_output=True, text=True, env=hermetic_git_env()
+    )
     if result.returncode != 0:
         raise AssertionError(
             f"git {' '.join(args)} failed in {repo} with exit {result.returncode}\n"
@@ -42,8 +45,17 @@ def _git(repo: Path, *args: str) -> None:
 
 
 def _git_init(path: Path) -> None:
-    """git init with the same stderr-surfacing contract as _git (#13882)."""
-    result = subprocess.run(["git", "init", "-q", str(path)], capture_output=True, text=True)
+    """git init with the same stderr-surfacing contract as _git (#13882).
+
+    #13882 round two: this file built real repos in ``tmp_path`` with **no**
+    ``env=`` at all — not even the denylist its sibling carried — so it was
+    exposed to the same cross-worker corruption under xdist, having simply never
+    been looked at when the sibling was fixed. A fix applied to one of two
+    identical call sites is half a fix.
+    """
+    result = subprocess.run(
+        ["git", "init", "-q", str(path)], capture_output=True, text=True, env=hermetic_git_env()
+    )
     if result.returncode != 0:
         raise AssertionError(
             f"git init failed in {path} with exit {result.returncode}\n"
@@ -384,3 +396,22 @@ def test_commit_files_lists_what_a_commit_touched(repo):
 
 def test_commit_files_degrades_on_a_non_repository(tmp_path):
     assert GitHistoryCrawler(str(tmp_path)).get_commit_files("deadbeef") == []
+
+
+def test_this_file_builds_repos_hermetically_too():
+    """The recurrence mechanism, asserted where it happened.
+
+    #13882's first fix touched `co_change_test.py` and stopped there. This file
+    builds real repos in `tmp_path` the same way, under the same xdist config,
+    and carried no `env=` at all — not even the denylist the sibling had. It was
+    exposed the whole time and nothing said so, because the guard for the rule
+    lived only in the file that had already been fixed.
+    """
+    import inspect
+
+    for helper in (_git, _git_init):
+        source = inspect.getsource(helper)
+        assert "env=hermetic_git_env()" in source, (
+            f"{helper.__name__} runs git without the hermetic environment — "
+            "an inherited GIT_ variable makes -C advisory under xdist"
+        )


### PR DESCRIPTION
## Thinking Path

`python-suite shard 2/12` failed on #14251 — a PR touching one workflow YAML. The stderr that
#13882's own diagnostics finally surfaced named the cause:

```
error: invalid object 100644 3f430af8... for 'solo_18.py'
error: bad tree object HEAD
```

That is #13983's signature, recurring after the fix for it merged. So the question was not
"which variable leaked this time" but why the previous fix could come apart at all.

It stripped a hand-written list of nine `GIT_*` variables. A denylist is narrower than its own
subject: correct for the failures already seen, silently wrong for the tenth. Git has more than
nine such variables and gains new ones between releases, so that list could never have been
finished — only extended, once per incident, which is exactly what happened.

## Problem

Under xdist, an inherited `GIT_*` variable makes `git -C <repo>` advisory: every worker operates
on shared state while committing in its own tmpdir, so a worker commits a tree whose blobs live
in another worker's object store. It reads as repository corruption in a test about co-change
coupling — nowhere near the code under test — and it reddens the shard for every PR that runs it,
regardless of what that PR changed.

## What Changed

The denylist is inverted into an allowlist: strip **everything** beginning with `GIT_`, then add
back exactly what the fixture needs (`_SUPPLIED_GIT_VARS`). The fixture runs only local commands
in a throwaway repo, so nothing inherited is load-bearing, and a variable git adds next year is
stripped without anyone updating a list.

## Verification

40 tests, including a parametrised set that asserts the **rule** rather than the nine names —
four of its cases (`GIT_INDEX_VERSION`, `GIT_LITERAL_PATHSPECS`, `GIT_ATTR_NOSYSTEM`, and a
deliberately invented `GIT_TEST_SOMETHING_NEW`) were on no denylist and would have leaked.

`test_a_worker_with_a_hostile_index_file_still_commits_its_own_tree` is the end-to-end
reproduction: two repos built under one hostile `GIT_INDEX_FILE`, both must succeed and neither
may see the other's history.

Mutation-checked:

| mutation | result |
|---|---|
| restore the nine-name denylist | 4 failed |
| strip nothing | 9 failed |
| let inherited values win over supplied ones | 10 failed |
| strip everything and supply nothing back | 2 failed |
| *(restored)* | 40 passed |

That first row is the important one: the previous implementation now fails these tests. Also ran
the directory under `-n 4` to exercise the xdist path that produced the failure.

## Risks

The fixture no longer inherits any git configuration from the runner. That is the intent; it ran
with `GIT_CONFIG_GLOBAL=/dev/null` already, so nothing was reading runner config on purpose.

## Note on an unrelated leftover

A local branch `issue-13882` exists from 2026-08-10 with three commits and no remote. Its content
— the stderr surfacing — is already in `Dev_new_gui` (landed via #13906's squash), so it is a
stale claim branch rather than unfinished work. I have not touched it; reporting it rather than
sweeping it. This PR uses `issue-13882-xdist` to avoid colliding with it.

## Model Used

Opus 5 (1M context).

Closes #13882
