### PR TITLE
fix(knowledge): JSON-encode structured sequences instead of flattening them (#14257)

### DIFF
--- a/autobot-backend/knowledge/utils.py
+++ b/autobot-backend/knowledge/utils.py
@@ -11,9 +11,48 @@ Shared helper functions for knowledge base operations.
 import json
 from typing import Any, Dict
 
+from autobot_shared.logging_manager import get_logger
+
+logger = get_logger(__name__)
+
 # Issue #380: Module-level tuples for type checking
 _SEQUENCE_TYPES = (list, tuple)
 _CHROMADB_ALLOWED_TYPES = (str, int, float, type(None))
+
+
+def _encode_sequence(key: str, value: Any) -> str:
+    """Encode a list/tuple for ChromaDB without losing structure (#14257).
+
+    A list of scalars keeps the historical comma-joined form: that is what every
+    caller before #13894 passed, it is what is already stored, and changing it
+    would make existing metadata unreadable.
+
+    A list containing anything structured is JSON-encoded instead — the same
+    treatment a bare ``dict`` has always had. Joining those with ``str()``
+    produced a Python repr that ``json.loads`` rejects and no split can undo,
+    because the commas *inside* each element are indistinguishable from the
+    commas *between* them:
+
+        [{"page": 1, "start": 0}]  ->  "{'page': 1, 'start': 0}"
+
+    The write succeeded and the read returned a string, so nothing failed; the
+    structure was simply gone. An encoder that accepts input it cannot represent
+    and reports success is the same shape as a guard that reports clean on input
+    it could not read.
+    """
+    if all(isinstance(item, _CHROMADB_ALLOWED_TYPES) for item in value):
+        return ", ".join(str(item) for item in value)
+    try:
+        return json.dumps(value)
+    except (TypeError, ValueError):
+        # Not JSON-serialisable either. `str()` is the only remaining option, so
+        # say so rather than letting the caller believe the value round-trips.
+        logger.warning(
+            "Metadata %r holds a sequence that is neither scalar nor JSON-serialisable; "
+            "storing its repr, which cannot be parsed back.",
+            key,
+        )
+        return str(value)
 
 
 def sanitize_metadata_for_chromadb(metadata: Dict[str, Any]) -> Dict[str, Any]:
@@ -21,7 +60,8 @@ def sanitize_metadata_for_chromadb(metadata: Dict[str, Any]) -> Dict[str, Any]:
     Sanitize metadata for ChromaDB compatibility.
 
     ChromaDB only allows metadata values of type: str, int, float, None.
-    This function converts lists/arrays to comma-separated strings.
+    Lists of scalars become comma-separated strings; anything structured is
+    JSON-encoded so it survives the round trip (#14257).
 
     Args:
         metadata: Original metadata dict that may contain arrays
@@ -35,8 +75,7 @@ def sanitize_metadata_for_chromadb(metadata: Dict[str, Any]) -> Dict[str, Any]:
     sanitized = {}
     for key, value in metadata.items():
         if isinstance(value, _SEQUENCE_TYPES):  # Issue #380
-            # Convert arrays to comma-separated strings
-            sanitized[key] = ", ".join(str(v) for v in value)
+            sanitized[key] = _encode_sequence(key, value)
         elif isinstance(value, dict):
             # Convert dicts to JSON strings
             sanitized[key] = json.dumps(value)

--- a/autobot-backend/knowledge/utils_test.py
+++ b/autobot-backend/knowledge/utils_test.py
@@ -1,0 +1,100 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""ChromaDB metadata sanitisation must not lose structure it accepts (#14257)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from knowledge.utils import sanitize_metadata_for_chromadb
+
+# The shape that exposed this: page provenance from a PDF upload (#13894/#14239).
+_PAGE_SPANS = [
+    {"page": 1, "start": 0, "end": 13},
+    {"page": 2, "start": 15, "end": 27},
+    {"page": 3, "start": 29, "end": 34},
+]
+
+
+def test_a_list_of_dicts_round_trips():
+    """The reproduction. Before this fix the value came back as a Python repr
+    joined with ', ' — which json.loads rejects, and which no split can undo
+    because the commas inside each element are indistinguishable from the
+    commas between them."""
+    sanitized = sanitize_metadata_for_chromadb({"page_spans": _PAGE_SPANS})
+
+    assert json.loads(sanitized["page_spans"]) == _PAGE_SPANS
+
+
+def test_the_offsets_survive_individually():
+    """Asserting the whole list is equal would still pass if every span were
+    reordered or merged; this pins the field a consumer actually indexes with."""
+    sanitized = sanitize_metadata_for_chromadb({"page_spans": _PAGE_SPANS})
+    decoded = json.loads(sanitized["page_spans"])
+
+    assert [span["start"] for span in decoded] == [0, 15, 29]
+    assert decoded[1]["page"] == 2
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ([1, 2, 3], "1, 2, 3"),
+        (["a", "b"], "a, b"),
+        ((1.5, 2.5), "1.5, 2.5"),
+        ([], ""),
+        ([None], "None"),
+    ],
+)
+def test_a_list_of_scalars_keeps_its_historical_form(value, expected):
+    """Metadata already stored uses the comma-joined form. Switching every
+    sequence to JSON would round-trip beautifully and make every existing
+    document unreadable."""
+    assert sanitize_metadata_for_chromadb({"k": value})["k"] == expected
+
+
+def test_one_structured_element_is_enough_to_switch_encoding():
+    """A list that is mostly scalars is still unrecoverable if any element is
+    structured, so the decision is per-list, not per-element."""
+    sanitized = sanitize_metadata_for_chromadb({"k": [1, {"a": 2}, 3]})
+
+    assert json.loads(sanitized["k"]) == [1, {"a": 2}, 3]
+
+
+def test_a_nested_list_is_structured_too():
+    assert json.loads(sanitize_metadata_for_chromadb({"k": [[1, 2], [3]]})["k"]) == [[1, 2], [3]]
+
+
+def test_a_bare_dict_is_unchanged():
+    """This branch was already correct — the bug was that a list OF dicts did
+    not reach it."""
+    assert json.loads(sanitize_metadata_for_chromadb({"k": {"a": 1}})["k"]) == {"a": 1}
+
+
+@pytest.mark.parametrize("value", ["text", 7, 1.5, None])
+def test_scalars_pass_through_untouched(value):
+    assert sanitize_metadata_for_chromadb({"k": value})["k"] == value
+
+
+def test_an_unserialisable_sequence_says_so_instead_of_pretending(caplog):
+    """`str()` is the only option left for a value JSON cannot take. Falling
+    back silently is the defect this issue is about, one case further along."""
+
+    class NotSerialisable:
+        def __repr__(self) -> str:
+            return "<opaque>"
+
+    with caplog.at_level("WARNING"):
+        sanitized = sanitize_metadata_for_chromadb({"k": [NotSerialisable()]})
+
+    assert sanitized["k"] == "[<opaque>]"
+    assert any("k" in record.message or "k" in str(record.args) for record in caplog.records)
+
+
+def test_empty_metadata_is_still_empty():
+    assert sanitize_metadata_for_chromadb({}) == {}
+    assert sanitize_metadata_for_chromadb(None) == {}


### PR DESCRIPTION
## Thinking Path

Found reviewing PR #14239, whose `page_spans` is the first structured value to reach this
encoder. The tempting fix was in that PR — JSON-encode at the producer and move on. That would
have worked and left the next caller to rediscover the same thing.

The defect is not that one value was shaped wrong. It is that `sanitize_metadata_for_chromadb`
accepts a shape it cannot represent, transforms it destructively, and reports success. Its
docstring says it "converts lists/arrays to comma-separated strings" — accurate, and exactly the
problem: lossless for a list of scalars, lossy for a list of anything else, with no signal at the
boundary.

## Problem

```python
if isinstance(value, _SEQUENCE_TYPES):
    sanitized[key] = ", ".join(str(v) for v in value)   # list of dicts lands here
elif isinstance(value, dict):
    sanitized[key] = json.dumps(value)                  # a bare dict is handled correctly
```

A `dict` is JSON-encoded; a list *of* dicts is not:

```
[{"page": 1, "start": 0, "end": 13}, {"page": 2, "start": 15, "end": 27}]
->  "{'page': 1, 'start': 0, 'end': 13}, {'page': 2, 'start': 15, 'end': 27}"
```

`json.loads` rejects that, and no split recovers it — the commas inside each element are
indistinguishable from the commas between them. The write succeeded, the read returned a string,
nothing failed. It stayed dormant because every earlier caller passed scalars or lists of strings.

It matters because `knowledge/search.py:420` reads metadata straight off the Chroma query result;
nothing re-hydrates the correctly JSON-encoded Redis copy at `knowledge/facts.py:646`.

## What Changed

`_encode_sequence` decides per list:

- **every element scalar** → the historical comma-joined form, unchanged. Metadata already stored
  uses it, and switching every sequence to JSON would round-trip beautifully while making every
  existing document unreadable.
- **anything structured** → `json.dumps`, the same treatment a bare `dict` has always had.
- **not JSON-serialisable either** → `str()`, with a warning naming the key. `str()` is the only
  option left; doing it silently is the same defect one case further along.

No decoder is added. Nothing in the tree currently decodes this metadata, and an unused decoder
is a surface with no sink. The consumer that needs one can `json.loads` at the point of use.

## Verification

16 tests. Mutation-checked:

| mutation | result |
|---|---|
| restore the old unconditional join | 5 failed |
| JSON-encode every sequence, including scalar lists | 5 failed |
| `any(...)` instead of `all(...)` for the scalar check | 2 failed |
| drop the warning, fall back silently | 1 failed |
| *(restored)* | 16 passed |

The second row is the one that keeps this safe to deploy: it proves the scalar-list form is
pinned, so existing stored metadata stays readable.

`autobot-backend/knowledge/`: **1157 passed**, and the 6 failures are byte-identical to base —
I ran the same suite on a detached worktree at `origin/Dev_new_gui` and got the same 6 with 1141
passing. They are the `code_semantic_search_test` / `gpu_kb_integration_test` /
`kb_optimization_test` singletons tracked in #13551, untouched by this change.

## Risks

A caller that was reading the flattened string and parsing it by hand would break. Grep finds
none — `sanitize_metadata_for_chromadb` has exactly one production caller
(`knowledge/facts.py:763`), and no consumer parses its output.

## Model Used

Opus 5 (1M context).

Closes #14257
