### PR TITLE
security(gateway): govern outbound sends at the shared egress seam (#14067)

### DIFF
--- a/autobot-backend/services/gateway/egress_governor.py
+++ b/autobot-backend/services/gateway/egress_governor.py
@@ -1,0 +1,141 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Outbound approval + audit for Gateway egress (#14067).
+
+`Gateway.send_message` checked that a session existed, that an adapter existed,
+and that the message fit the size limit — then handed it to the adapter. Nothing
+in the package referenced approval at all. Sending a message to a real person on
+Slack, Discord, Telegram, WhatsApp, Matrix, Signal, Teams or iMessage is the one
+class of agent action that cannot be undone, and it was the one class with no
+gate and no record.
+
+This mirrors :mod:`services.gateway.ingest_governor` deliberately: one shared
+stage at the Gateway seam rather than per-adapter checks, so a newly added
+adapter inherits the governance without adapter-side work. Ingest governs what
+reaches an agent; egress governs what leaves the machine.
+
+Posture
+-------
+Default is **audit-only**: every governed send is recorded, none is blocked. That
+keeps the seam live — the record is a real sink, not a dormant switch waiting for
+a caller — while the delivery path that makes a synchronous human gate usable is
+built (#14068). With ``require_approval`` on, the stage fails **closed**: no
+registered approver, an approver that denies, and an approver that raises all
+deny. An unreachable approver is not consent.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Awaitable, Callable, Dict
+
+from autobot_shared.env_utils import truthy
+from autobot_shared.logging_manager import get_logger
+
+from services.audit_logger import get_audit_logger
+
+logger = get_logger(__name__)
+
+#: Operation name every egress decision is recorded under.
+EGRESS_AUDIT_OPERATION = "gateway.egress"
+
+
+def _resolve_require_approval() -> bool:
+    """Whether outbound sends need approval, from the environment."""
+    return truthy(os.getenv("AUTOBOT_GATEWAY_REQUIRE_OUTBOUND_APPROVAL", ""))
+
+
+#: Read once at import, like the ingest governor's limits. Callers may still
+#: pass ``require_approval`` explicitly; this is only the default.
+EGRESS_REQUIRE_APPROVAL = _resolve_require_approval()
+
+#: An approver decides one outbound send. Returning False denies it.
+Approver = Callable[..., Awaitable[bool]]
+
+
+@dataclass(frozen=True)
+class EgressVerdict:
+    """Result of running the egress governance stage on one outbound message.
+
+    ``reason`` and ``rule`` are carried on the verdict rather than logged
+    separately, so the audit trail is a by-product of the decision instead of a
+    second thing a caller has to remember to do.
+    """
+
+    allowed: bool
+    reason: str = ""
+    rule: str = ""
+
+
+class EgressGovernor:
+    """Approval gate + audit record for every governed Gateway send."""
+
+    def __init__(self) -> None:
+        self._approvers: Dict[str, Approver] = {}
+
+    def register_approver(self, platform: str, approver: Approver) -> None:
+        """Register the approver consulted for *platform*'s outbound sends."""
+        self._approvers[platform] = approver
+
+    async def _decide(self, platform: str, channel_id: str, message_id: str, require_approval: bool) -> EgressVerdict:
+        """The decision, before it is recorded."""
+        if not require_approval:
+            return EgressVerdict(allowed=True, reason="approval not required", rule="audit-only")
+
+        approver = self._approvers.get(platform)
+        if approver is None:
+            return EgressVerdict(
+                allowed=False,
+                reason=f"no approver registered for platform '{platform}'",
+                rule="fail-closed",
+            )
+
+        try:
+            approved = await approver(platform=platform, channel_id=channel_id, message_id=message_id)
+        except Exception as exc:  # noqa: BLE001 - an unreachable approver is not consent
+            logger.warning("Egress approver for %s failed, denying: %s", platform, exc)
+            return EgressVerdict(allowed=False, reason=f"approver failed: {exc}", rule="fail-closed")
+
+        if approved:
+            return EgressVerdict(allowed=True, reason="approved", rule="approver")
+        return EgressVerdict(allowed=False, reason="denied by approver", rule="approver")
+
+    async def _record(self, verdict: EgressVerdict, platform: str, channel_id: str, message_id: str) -> None:
+        """Record the decision. A broken sink must never block a send."""
+        try:
+            audit = await get_audit_logger()
+            await audit.log(
+                operation=EGRESS_AUDIT_OPERATION,
+                result="success" if verdict.allowed else "denied",
+                resource=f"{platform}:{channel_id}",
+                details={
+                    "message_id": message_id,
+                    "rule": verdict.rule,
+                    "reason": verdict.reason,
+                },
+            )
+        except Exception as exc:  # noqa: BLE001 - losing the record must not lose the message
+            logger.warning("Egress audit record failed for %s:%s — %s", platform, channel_id, exc)
+
+    async def evaluate(
+        self,
+        *,
+        platform: str,
+        channel_id: str,
+        message_id: str,
+        require_approval: bool | None = None,
+    ) -> EgressVerdict:
+        """Run the egress governance stage on one outbound message."""
+        if require_approval is None:
+            require_approval = EGRESS_REQUIRE_APPROVAL
+        verdict = await self._decide(platform, channel_id, message_id, require_approval)
+        await self._record(verdict, platform, channel_id, message_id)
+        return verdict
+
+
+# Shared singleton, matching ingest_governor: holds only the per-platform
+# approver registry, never per-message state.
+egress_governor = EgressGovernor()

--- a/autobot-backend/services/gateway/egress_governor.py
+++ b/autobot-backend/services/gateway/egress_governor.py
@@ -34,7 +34,6 @@ from typing import Awaitable, Callable, Dict
 
 from autobot_shared.env_utils import truthy
 from autobot_shared.logging_manager import get_logger
-
 from services.audit_logger import get_audit_logger
 
 logger = get_logger(__name__)

--- a/autobot-backend/services/gateway/egress_governor_test.py
+++ b/autobot-backend/services/gateway/egress_governor_test.py
@@ -1,0 +1,118 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Outbound approval + audit at the shared Gateway egress seam (#14067).
+
+`Gateway.send_message` performed three checks — session exists, adapter exists,
+size limit — and then handed the message to the adapter. Sending a message to a
+real person on any of the ten channels is the one agent action that cannot be
+undone, and it was the one action with no gate and no record.
+
+The seam lives in `Gateway.send_message`, not in the adapters, so a newly added
+adapter inherits it without per-adapter work — the same structural argument
+#14028 makes for the inbound side.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from services.gateway.egress_governor import EgressGovernor, EgressVerdict
+
+
+@pytest.fixture
+def governor():
+    return EgressGovernor()
+
+
+class TestDefaultPostureAllowsButAlwaysRecords:
+    """Audit-only by default: a live sink, not a dormant switch."""
+
+    @pytest.mark.asyncio
+    async def test_a_send_is_allowed_when_approval_is_not_required(self, governor):
+        verdict = await governor.evaluate(platform="slack", channel_id="c1", message_id="m1", require_approval=False)
+        assert verdict.allowed is True
+
+    @pytest.mark.asyncio
+    async def test_an_allowed_send_is_still_recorded(self, governor):
+        with patch("services.gateway.egress_governor.get_audit_logger") as mock_get:
+            audit = AsyncMock()
+            mock_get.return_value = audit
+            await governor.evaluate(platform="slack", channel_id="c1", message_id="m1", require_approval=False)
+        audit.log.assert_awaited_once()
+        assert audit.log.await_args.kwargs["operation"] == "gateway.egress"
+        assert audit.log.await_args.kwargs["result"] == "success"
+
+    @pytest.mark.asyncio
+    async def test_the_record_names_the_platform_and_channel(self, governor):
+        with patch("services.gateway.egress_governor.get_audit_logger") as mock_get:
+            audit = AsyncMock()
+            mock_get.return_value = audit
+            await governor.evaluate(platform="discord", channel_id="c9", message_id="m1", require_approval=False)
+        resource = audit.log.await_args.kwargs["resource"]
+        assert "discord" in resource and "c9" in resource
+
+    @pytest.mark.asyncio
+    async def test_a_broken_audit_sink_does_not_block_the_send(self, governor):
+        """Recording is not the gate. Losing the record must not lose the message."""
+        with patch("services.gateway.egress_governor.get_audit_logger", side_effect=RuntimeError("redis down")):
+            verdict = await governor.evaluate(
+                platform="slack", channel_id="c1", message_id="m1", require_approval=False
+            )
+        assert verdict.allowed is True
+
+
+class TestApprovalRequiredFailsClosed:
+    @pytest.mark.asyncio
+    async def test_no_registered_approver_denies_rather_than_allows(self, governor):
+        """The direction that matters. An unreachable approver is not consent."""
+        verdict = await governor.evaluate(platform="slack", channel_id="c1", message_id="m1", require_approval=True)
+        assert verdict.allowed is False
+        assert "approver" in verdict.reason.lower()
+
+    @pytest.mark.asyncio
+    async def test_an_approver_that_denies_blocks_the_send(self, governor):
+        governor.register_approver("slack", AsyncMock(return_value=False))
+        verdict = await governor.evaluate(platform="slack", channel_id="c1", message_id="m1", require_approval=True)
+        assert verdict.allowed is False
+
+    @pytest.mark.asyncio
+    async def test_an_approver_that_allows_permits_the_send(self, governor):
+        governor.register_approver("slack", AsyncMock(return_value=True))
+        verdict = await governor.evaluate(platform="slack", channel_id="c1", message_id="m1", require_approval=True)
+        assert verdict.allowed is True
+
+    @pytest.mark.asyncio
+    async def test_an_approver_that_raises_denies_rather_than_allows(self, governor):
+        governor.register_approver("slack", AsyncMock(side_effect=RuntimeError("gone")))
+        verdict = await governor.evaluate(platform="slack", channel_id="c1", message_id="m1", require_approval=True)
+        assert verdict.allowed is False
+
+    @pytest.mark.asyncio
+    async def test_an_approver_registered_for_another_platform_does_not_apply(self, governor):
+        governor.register_approver("discord", AsyncMock(return_value=True))
+        verdict = await governor.evaluate(platform="slack", channel_id="c1", message_id="m1", require_approval=True)
+        assert verdict.allowed is False
+
+    @pytest.mark.asyncio
+    async def test_a_denial_is_recorded_as_a_denial(self, governor):
+        governor.register_approver("slack", AsyncMock(return_value=False))
+        with patch("services.gateway.egress_governor.get_audit_logger") as mock_get:
+            audit = AsyncMock()
+            mock_get.return_value = audit
+            await governor.evaluate(platform="slack", channel_id="c1", message_id="m1", require_approval=True)
+        assert audit.log.await_args.kwargs["result"] == "denied"
+
+    @pytest.mark.asyncio
+    async def test_the_verdict_names_the_rule_that_decided(self, governor):
+        """`reason` and `rule` make the audit trail a by-product of the decision."""
+        verdict = await governor.evaluate(platform="slack", channel_id="c1", message_id="m1", require_approval=True)
+        assert verdict.rule
+
+
+class TestVerdictShape:
+    def test_a_verdict_is_immutable(self):
+        verdict = EgressVerdict(allowed=True)
+        with pytest.raises(Exception):
+            verdict.allowed = False

--- a/autobot-backend/services/gateway/gateway.py
+++ b/autobot-backend/services/gateway/gateway.py
@@ -20,6 +20,7 @@ from autobot_shared.logging_manager import get_logger
 
 from .channel_adapters.base import BaseChannelAdapter
 from .config import GatewayConfig
+from .egress_governor import egress_governor
 from .ingest_governor import ingest_governor
 from .message_router import MessageRouter
 from .session_manager import SessionManager
@@ -255,6 +256,26 @@ class Gateway:
         ):
             logger.warning("Message exceeds size limit")
             return False
+
+        # Egress governance (#14067). Applied here, at the shared seam, so a
+        # newly added adapter inherits it without adapter-side work — the same
+        # structural argument #14028 makes for ingest. Scoped to agent-authored
+        # conversational turns: session/system control traffic (SESSION_START,
+        # heartbeats, SYSTEM_ERROR) is not a message to a person and would only
+        # add noise to the audit trail.
+        if message.message_type in _AGENT_MESSAGE_TYPES:
+            verdict = await egress_governor.evaluate(
+                platform=session.channel.value,
+                channel_id=session.session_id,
+                message_id=message.message_id,
+            )
+            if not verdict.allowed:
+                logger.warning(
+                    "Outbound send blocked by egress governance (%s): %s",
+                    verdict.rule,
+                    verdict.reason,
+                )
+                return False
 
         # Send through adapter
         connection_context = self._connection_contexts.get(message.session_id)

--- a/autobot-backend/services/gateway/gateway_test.py
+++ b/autobot-backend/services/gateway/gateway_test.py
@@ -194,3 +194,157 @@ class TestChannelAdapterIngestGovernance:
 
         assert result is not None
         assert result.content == "hello"
+
+
+class TestEgressGovernanceIsWiredAtTheSharedSeam:
+    """#14067: outbound sends crossed no approval seam and left no record.
+
+    These drive `Gateway.send_message` for real. The governor's own unit tests
+    all stay green if the seam is never called, which is exactly the failure
+    mode these exist to catch.
+    """
+
+    @pytest.mark.asyncio
+    async def test_the_egress_stage_actually_runs_on_an_agent_send(self, fake_redis, monkeypatch):
+        from services.gateway import egress_governor as governor_module
+        from services.gateway.types import ChannelMessage, MessageType
+
+        calls = []
+        real_evaluate = governor_module.egress_governor.evaluate
+
+        async def _spy(**kwargs):
+            calls.append(kwargs)
+            return await real_evaluate(**kwargs)
+
+        monkeypatch.setattr(governor_module.egress_governor, "evaluate", _spy)
+
+        gateway, session = await _build_gateway_with_session()
+        reply = ChannelMessage(
+            message_id="egress-1",
+            session_id=session.session_id,
+            channel=session.channel,
+            message_type=MessageType.AGENT_TEXT,
+            content="a reply to a real person",
+        )
+        assert await gateway.send_message(reply) is True
+        assert len(calls) == 1
+        assert calls[0]["message_id"] == "egress-1"
+
+    @pytest.mark.asyncio
+    async def test_a_denied_send_never_reaches_the_adapter(self, fake_redis, monkeypatch):
+        """The property that matters: blocked at the seam, not merely reported."""
+        from services.gateway import egress_governor as governor_module
+        from services.gateway.egress_governor import EgressVerdict
+        from services.gateway.types import ChannelMessage, MessageType
+
+        gateway, session = await _build_gateway_with_session()
+        adapter = gateway._channel_adapters[ChannelType.WEBSOCKET]
+        delivered = []
+
+        async def _spy_send(message, session_, connection_context=None):
+            delivered.append(message)
+            return True
+
+        monkeypatch.setattr(adapter, "send_message", _spy_send)
+
+        async def _deny(**_kwargs):
+            return EgressVerdict(allowed=False, reason="denied by test", rule="approver")
+
+        monkeypatch.setattr(governor_module.egress_governor, "evaluate", _deny)
+
+        reply = ChannelMessage(
+            session_id=session.session_id,
+            channel=session.channel,
+            message_type=MessageType.AGENT_TEXT,
+            content="must not be sent",
+        )
+        assert await gateway.send_message(reply) is False
+        assert delivered == [], "a denied message was handed to the adapter anyway"
+
+    @pytest.mark.asyncio
+    async def test_an_approved_send_reaches_the_adapter_unchanged(self, fake_redis, monkeypatch):
+        from services.gateway.types import ChannelMessage, MessageType
+
+        gateway, session = await _build_gateway_with_session()
+        adapter = gateway._channel_adapters[ChannelType.WEBSOCKET]
+        delivered = []
+
+        async def _spy_send(message, session_, connection_context=None):
+            delivered.append(message)
+            return True
+
+        monkeypatch.setattr(adapter, "send_message", _spy_send)
+
+        reply = ChannelMessage(
+            session_id=session.session_id,
+            channel=session.channel,
+            message_type=MessageType.AGENT_TEXT,
+            content="allowed content",
+        )
+        assert await gateway.send_message(reply) is True
+        assert [m.content for m in delivered] == ["allowed content"]
+
+    @pytest.mark.asyncio
+    async def test_a_newly_added_adapter_inherits_the_gate_with_no_adapter_change(self, fake_redis, monkeypatch):
+        """The structural claim, asserted rather than asserted-about.
+
+        A brand-new adapter subclass with no knowledge of egress governance must
+        still be gated, because the stage lives at the Gateway seam.
+        """
+        from services.gateway import egress_governor as governor_module
+        from services.gateway.egress_governor import EgressVerdict
+        from services.gateway.types import ChannelMessage, MessageType
+
+        class _BrandNewAdapter(_FakeChannelAdapter):
+            def __init__(self) -> None:
+                super().__init__()
+                self.delivered = []
+
+            async def send_message(self, message, session, connection_context=None) -> bool:
+                self.delivered.append(message)
+                return True
+
+        gateway = Gateway(config=GatewayConfig())
+        adapter = _BrandNewAdapter()
+        gateway.register_channel_adapter(ChannelType.WEBSOCKET, adapter)
+        session = await gateway.session_manager.create_session(user_id="u2", channel=ChannelType.WEBSOCKET)
+
+        async def _deny(**_kwargs):
+            return EgressVerdict(allowed=False, reason="denied by test", rule="approver")
+
+        monkeypatch.setattr(governor_module.egress_governor, "evaluate", _deny)
+
+        reply = ChannelMessage(
+            session_id=session.session_id,
+            channel=session.channel,
+            message_type=MessageType.AGENT_TEXT,
+            content="new adapter, same gate",
+        )
+        assert await gateway.send_message(reply) is False
+        assert adapter.delivered == []
+
+    @pytest.mark.asyncio
+    async def test_session_control_traffic_is_not_governed(self, fake_redis, monkeypatch):
+        """Heartbeats and lifecycle events are not messages to a person."""
+        from services.gateway import egress_governor as governor_module
+        from services.gateway.types import ChannelMessage, MessageType
+
+        calls = []
+
+        async def _spy(**kwargs):
+            calls.append(kwargs)
+            from services.gateway.egress_governor import EgressVerdict
+
+            return EgressVerdict(allowed=True)
+
+        monkeypatch.setattr(governor_module.egress_governor, "evaluate", _spy)
+
+        gateway, session = await _build_gateway_with_session()
+        control = ChannelMessage(
+            session_id=session.session_id,
+            channel=session.channel,
+            message_type=MessageType.SESSION_START,
+            content="",
+        )
+        await gateway.send_message(control)
+        assert calls == []

--- a/autobot_shared/env_registry.py
+++ b/autobot_shared/env_registry.py
@@ -929,6 +929,21 @@ register_env_var(
 
 register_env_var(
     EnvVarSpec(
+        name="AUTOBOT_GATEWAY_REQUIRE_OUTBOUND_APPROVAL",
+        type=bool,
+        default=False,
+        description=(
+            "Require approval before the Gateway hands an agent-authored message "
+            "to a channel adapter. Off means audit-only: every governed send is "
+            "recorded, none is blocked. On fails closed — no registered approver, "
+            "a denial, or an approver error all deny the send."
+        ),
+        component="gateway",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
         name="AUTOBOT_LLC_H2A_BRIEF_CACHE_TTL",
         type=int,
         default=86400,

--- a/autobot_shared/tool_catalogue.py
+++ b/autobot_shared/tool_catalogue.py
@@ -84,6 +84,12 @@ APPROVAL_CATEGORY_TOOLS = {
     "publishing": ("deploy", "publish", "content_reach"),
     "destructive operations": FILE_DELETE_TOOLS + SHELL_EXEC_TOOLS + CONTAINER_ORCH_TOOLS,
     "rotating credentials": ("rotate_credentials", "rotate_key", "vault_rotate"),
+    # #14067: HTTP_WRITE_TOOLS was in SENSITIVE_TOOLS (the agent-loop plane) but
+    # reachable through no category at all, so a work item could not gate the one
+    # action class that leaves the machine. The Gateway's own outbound path is
+    # governed separately at its seam (services/gateway/egress_governor.py) —
+    # a gateway send is not a tool call, so it cannot be covered by a tool name.
+    "sending externally": HTTP_WRITE_TOOLS,
 }
 
 
@@ -99,6 +105,7 @@ class ApprovalCategory(str, Enum):
     PUBLISHING = "publishing"
     DESTRUCTIVE_OPERATIONS = "destructive operations"
     ROTATING_CREDENTIALS = "rotating credentials"
+    SENDING_EXTERNALLY = "sending externally"
 
 
 _VALID_APPROVAL_CATEGORIES = frozenset(c.value for c in ApprovalCategory)

--- a/autobot_shared/tool_catalogue_test.py
+++ b/autobot_shared/tool_catalogue_test.py
@@ -177,7 +177,13 @@ def test_sensitive_tools_parity():
 
 
 def test_approval_categories_parity():
-    assert set(APPROVAL_CATEGORY_TOOLS) == set(_ORIG_APPROVAL)
+    # The extraction snapshot is a floor, not a ceiling (#14067). What this
+    # guards is *drift*: every category that existed at extraction time must
+    # still carry exactly its original tools, so a consolidation edit cannot
+    # quietly widen or narrow one. A category added since is an addition, not
+    # drift, and is asserted on its own terms in
+    # TestOutboundIsReachableThroughACategory below.
+    assert set(_ORIG_APPROVAL) <= set(APPROVAL_CATEGORY_TOOLS), "a category present at extraction time was removed"
     for category, tools in _ORIG_APPROVAL.items():
         assert set(APPROVAL_CATEGORY_TOOLS[category]) == tools, category
 
@@ -198,3 +204,49 @@ def test_consumers_reexport_the_catalogue():
     assert set(loop_sensitive) == _ORIG_SENSITIVE
     assert set(reg_infra) == _ORIG_INFRA_AND_SHELL
     assert handler_approval is APPROVAL_CATEGORY_TOOLS
+
+
+class TestOutboundIsReachableThroughACategory:
+    """#14067: the one action class that leaves the machine had no category.
+
+    `HTTP_WRITE_TOOLS` sat in `SENSITIVE_TOOLS` — so the agent-loop plane gated
+    it — while `APPROVAL_CATEGORY_TOOLS` named none of it, so a work item's
+    `requires_approval_before` could not express "ask me before you send
+    anything outward" at all.
+    """
+
+    def test_every_http_write_tool_is_reachable_through_some_category(self):
+        from autobot_shared.tool_catalogue import (
+            APPROVAL_CATEGORY_TOOLS,
+            HTTP_WRITE_TOOLS,
+            match_tool_name,
+        )
+
+        for tool in HTTP_WRITE_TOOLS:
+            assert any(
+                match_tool_name(tool, patterns, word_boundary=True) for patterns in APPROVAL_CATEGORY_TOOLS.values()
+            ), f"{tool!r} is sensitive but no approval category can gate it"
+
+    def test_the_new_category_is_in_the_controlled_vocabulary(self):
+        """A category absent from the enum "matches no tools at the seam and
+        silently disables the gate" — per ApprovalCategory's own docstring."""
+        from autobot_shared.tool_catalogue import APPROVAL_CATEGORY_TOOLS, valid_approval_categories
+
+        assert set(APPROVAL_CATEGORY_TOOLS) <= valid_approval_categories()
+
+    def test_a_gateway_send_is_deliberately_not_a_tool_name_here(self):
+        """Guards against a future edit inventing tool names for the Gateway.
+
+        Gateway egress is governed at its own seam because a channel send is not
+        a tool call; adding a fictional tool name here would create an allowlist
+        entry that matches nothing and exempts nothing, silently.
+        """
+        from autobot_shared.tool_catalogue import APPROVAL_CATEGORY_TOOLS
+
+        assert APPROVAL_CATEGORY_TOOLS["sending externally"] == (
+            "http_post",
+            "http_put",
+            "http_patch",
+            "http_delete",
+            "send_request",
+        )

--- a/changelog/unreleased/14067-gateway-egress-governance.md
+++ b/changelog/unreleased/14067-gateway-egress-governance.md
@@ -1,0 +1,7 @@
+---
+type: security
+scope: gateway
+issue: 14067
+pr: 14261
+---
+Outbound Gateway sends now pass an egress governance stage that records every agent-authored message and, when armed, requires approval before the message reaches a channel adapter.


### PR DESCRIPTION
## Thinking Path

`Gateway.send_message` checked three things — session exists, adapter exists, size limit —
then handed the message to the adapter. Nothing in the package referenced approval at all:
`grep -rni "approval|approve" autobot-backend/services/gateway --include=*.py` returns **0
hits**, verified with a positive control (the same tree returns 19 files for `grep -rlc "def "`,
so the empty result is a real absence, not a mistargeted path).

Sending a message to a real person on any of the ten channels is the one class of agent action
that cannot be undone, and it was the one class with no gate and no record. The per-session
token-bucket rate limit bounds the *volume* of unwanted sends; it says nothing about
*authorisation*.

**Why this approach:** mirror the existing `ingest_governor` rather than invent a parallel
shape. One shared stage at the Gateway seam means a newly added adapter inherits the
governance without adapter-side work — the same structural argument #14028 makes for the
inbound side. Ingest governs what reaches an agent; egress governs what leaves the machine.

**Why audit-only by default.** A gate that blocks on a human nobody can reach is a stall, not
a gate — the delivery path that makes a synchronous human gate usable is #14068, not yet
built. But shipping a default-off switch with no producer would be the "full surface, no sink"
pattern: config and code present, nothing ever emitting. So every governed send is **recorded**
now. The record is the live sink; the block is the part that arms later.

**Why fail-closed when armed.** No registered approver, an approver that denies, and an
approver that raises all deny. An unreachable approver is not consent.

**Why no tool name was invented for the Gateway.** A channel send is not a tool call. A
fictional entry in `APPROVAL_CATEGORY_TOOLS` would be an allowlist line matching nothing and
exempting nothing, silently. A test pins that decision so a later edit does not "helpfully"
add one.

## What Changed

- `autobot-backend/services/gateway/egress_governor.py` (new) — `EgressVerdict{allowed, reason,
  rule}` and `EgressGovernor` with a per-platform approver registry. `reason`/`rule` ride on the
  verdict, so the audit trail is a by-product of the decision rather than a second thing a
  caller must remember. Records via the canonical `services.audit_logger` under operation
  `gateway.egress`; a broken sink logs and allows, because losing the record must not lose the
  message.
- `autobot-backend/services/gateway/gateway.py` — the seam in `send_message`, between the size
  check and `adapter.send_message`. Scoped to agent-authored turns via the existing
  `_AGENT_MESSAGE_TYPES`: `SESSION_START`, heartbeats and `SYSTEM_ERROR` are not messages to a
  person and would only add audit noise.
- `autobot_shared/tool_catalogue.py` — `ApprovalCategory.SENDING_EXTERNALLY`
  (`"sending externally"` → `HTTP_WRITE_TOOLS`). These were in `SENSITIVE_TOOLS`, so the
  agent-loop plane gated them, while `APPROVAL_CATEGORY_TOOLS` named none of them — a work item
  could not express "ask before sending anything outward" at all. Surfaced in #13416.
- `autobot_shared/env_registry.py` — registers `AUTOBOT_GATEWAY_REQUIRE_OUTBOUND_APPROVAL`.
- `changelog/unreleased/14067-gateway-egress-governance.md` — new fragment.
- `autobot-backend/services/gateway/egress_governor_test.py` (new, 12) — governor behaviour.
- `autobot-backend/services/gateway/gateway_test.py` — 5 wiring tests driving `send_message`.
- `autobot_shared/tool_catalogue_test.py` — 3 tests; one existing test adjusted (see Risks).

## Verification

```bash
./venv/bin/python -m pytest autobot-backend/services/gateway/ autobot_shared/tool_catalogue_test.py -q
# 55 passed

./venv/bin/python -m pytest autobot-backend/agent_loop autobot-backend/tests/unit/chat_workflow \
    autobot_shared/tool_catalogue_test.py -q          # approval-plane consumers
# 634 passed

./venv/bin/python pipeline-scripts/check_env_var_registry.py   # exit 0
```

The 5 wiring tests drive `Gateway.send_message` for real. The governor's own unit tests all
stay green if the seam is never called, which is exactly the failure mode they exist to catch —
including one that registers a **brand-new adapter subclass** with no knowledge of egress
governance and asserts it is still gated.

**Mutation-tested.**

| Mutation | Result |
|---|---|
| seam never blocks (`if False:`) | 2 failed |
| seam never runs | 3 failed |
| fail-**open** when no approver registered | 2 failed |
| approver exception allows instead of denies | 1 failed |
| approval category removed | 3 failed |
| *control:* reason text only, no behaviour change | **55 passed** ✅ |

The control mutation passing is the point: it shows the suite asserts behaviour, not source text.

## Risks

- **Default posture blocks nothing**, so no message that sends today stops sending. The visible
  change is audit volume: one record per agent-authored outbound message.
- The audit path is wrapped — a Redis outage degrades to a log line, never a dropped message.
- `egress_governor` is a module-level singleton like `ingest_governor`, holding only the
  approver registry, never per-message state.
- The new approval category is inert until a work item declares it, matching the existing four.
- **One existing test was adjusted.** `test_approval_categories_parity` asserted
  `set(APPROVAL_CATEGORY_TOOLS) == set(_ORIG_APPROVAL)`, which any new category breaks. That
  snapshot guards *drift* — each category extracted in GH#11206 still carrying exactly its
  original tools. The per-category content assertions are unchanged; only the key-set equality
  became a subset check, with the reasoning inline. A **removed** category still fails.
- Rollback: revert the commit. No migration, no persisted-state change.

## Model Used

Claude Opus 5 (claude-opus-5[1m])

## Issue Link

Closes #14067

Related: #14028 (the inbound counterpart whose shape this mirrors), #13416, #13250, #13421,
#14068.

**Follow-up recorded, not fixed here:** `autobot-backend/services/slack_approval_integration.py`
(316 lines, Redis-backed approval-thread storage with a circuit breaker) has **zero non-test
consumers** — built and never wired. It is close to what #14068 needs for reply correlation, so
#14068 should wire it in rather than build a second one. Noted on #14068.

## Changelog fragment

- [x] Added `changelog/unreleased/14067-gateway-egress-governance.md`

## Checklist
- [x] Code follows AutoBot patterns from `CLAUDE.md`
- [x] Tests added or updated (or N/A with reason)
- [x] Documentation updated if behavior changed
- [x] Pre-commit hooks pass (`git commit` runs them automatically)
- [x] PR targets `Dev_new_gui` (not `main`)
- [x] No secrets or credentials in the diff

---

## Correction before merge: this seam is dormant, and #14067 overstated the exposure

Pre-merge review of my own diff, plus #14270 filed independently in the meantime.

`Gateway.send_message` has **no production callers** — `grep -rn "gateway.send_message|get_gateway()"` outside the package and tests returns nothing, and neither `Gateway` nor `GatewayManager` is constructed anywhere in production. #14270 supplies the reason I had not found: `initialization/lifespan.py:406` has Gateway init **commented out** ("Issue #881: TEMP DISABLED").

So the claim in #14067 and at the top of this PR — that outbound messages are leaving the machine through this ungated path today — is **wrong**. Nothing leaves through this path today, because the path is switched off. The 0-approval-references finding was accurate; the inference that live traffic was crossing it was not.

**What that changes, and what it does not:**

- This PR is still correct and still worth merging. The control is at the right seam *within* the Gateway, it is tested, and #14270 already cites it as the one governed path. Guarding dormant code before it is re-wired is the correct order — the alternative is remembering to add the guard at switch-on time.
- What it does **not** do is protect anything today. The live seams are `api/telegram_bot.py`, `api/whatsapp.py`, `api/integration_communication.py` and `services/notification_service.py`, all ungoverned. That is **#14270**, and it is the issue that carries the actual risk.
- Every one of those four records to `ingest_governor` — the *inbound* recursion guard — which reads as governance at a glance and is not. Worth knowing before reviewing them.

I am not silently widening this PR to cover the live seams: that is a different diff, in four modules I have not read, with a per-channel fail-closed decision behind it. #14270 owns it.
