### PR TITLE
fix(skills): quarantine a conversation that keeps failing so the queue drains (#14255)

### DIFF
--- a/autobot-backend/services/skill_management/skill_distillation_scheduler.py
+++ b/autobot-backend/services/skill_management/skill_distillation_scheduler.py
@@ -64,9 +64,27 @@ MIN_MESSAGES_TO_DISTILL = env_int("AUTOBOT_SKILL_DISTILLATION_MIN_MESSAGES", 4)
 # whether its memory layer helped.
 IDLE_FLUSH_S = env_int("AUTOBOT_SKILL_DISTILLATION_IDLE_FLUSH_S", 900)
 
+# #14255: how many consecutive failures on the SAME conversation before the pass
+# stops waiting for it and moves on. Stopping is right for a transient fault --
+# an extractor timeout, a proposer blip -- where the next run succeeds and
+# nothing is lost. It is wrong for one that cannot heal: a corrupted history file
+# or a rotated decryption key re-sorts to the front of an oldest-first queue
+# every run, so the cursor never advances and every newer conversation starves
+# behind it, with silence as the only symptom.
+#
+# The distinction is repetition, not error type. An exception class cannot tell
+# you whether the next attempt will work; N attempts can.
+MAX_CONSECUTIVE_FAILURES = env_int("AUTOBOT_SKILL_DISTILLATION_MAX_FAILURES", 3)
+
+# Long enough that a session failing once a pass keeps its count across the gap
+# between runs, short enough that a counter for a session nobody retries expires
+# instead of accumulating forever.
+_FAILURE_TTL_S = env_int("AUTOBOT_SKILL_DISTILLATION_FAILURE_TTL_S", DISTILLATION_INTERVAL_S * 24)
+
 _REDIS_DB = "knowledge"
 _LEADER_KEY = "skills:distillation:leader"
 _CURSOR_KEY = "skills:distillation:cursor"
+_FAILURE_KEY_PREFIX = "skills:distillation:failures:"
 
 
 def _decode(value: object) -> str | None:
@@ -261,32 +279,107 @@ class SkillDistillationScheduler:
             logger.debug("Skill distillation: no conversations since cursor %s", cursor or "(start)")
             return {"sessions_seen": 0, "sessions_distilled": 0, "proposed": []}
 
-        distilled, proposed = await self._distil_pending(pending)
+        distilled, proposed, quarantined = await self._distil_pending(pending)
 
         logger.info(
-            "Skill distillation pass: %d/%d conversations distilled, %d skills proposed",
+            "Skill distillation pass: %d/%d conversations distilled, %d skills proposed, %d quarantined",
             distilled,
             len(pending),
             len(proposed),
+            quarantined,
         )
-        return {"sessions_seen": len(pending), "sessions_distilled": distilled, "proposed": proposed}
+        # `quarantined` is in the summary, not only the log: a caller counting
+        # pass outcomes must be able to see that conversations were skipped
+        # rather than infer it from an unchanged `sessions_distilled` (#14255).
+        return {
+            "sessions_seen": len(pending),
+            "sessions_distilled": distilled,
+            "proposed": proposed,
+            "quarantined": quarantined,
+        }
 
-    async def _distil_pending(self, pending: List[Dict[str, Any]]) -> tuple[int, List[str]]:
+    async def _distil_pending(self, pending: List[Dict[str, Any]]) -> tuple[int, List[str], int]:
         """Distil each pending conversation in order, advancing the cursor as it goes.
 
         Stops at the first conversation whose proposal did not land rather than
         skipping it — advancing past a failed session would drop it permanently.
+
+        #14255: unless it has now failed ``MAX_CONSECUTIVE_FAILURES`` times, in
+        which case it is quarantined and the pass moves on. Waiting forever for a
+        conversation that cannot be read is not patience, it is a queue that
+        never drains.
         """
         proposed: List[str] = []
         distilled = 0
+        quarantined = 0
         for session in pending:
             names = await self._distil_session(session)
             if names is None:
-                break
+                if not await self._should_quarantine(session["id"]):
+                    break
+                quarantined += 1
+                await self._write_cursor(session["updated_at"])
+                continue
+            await self._clear_failures(session["id"])
             proposed.extend(names)
             distilled += 1
             await self._write_cursor(session["updated_at"])
-        return distilled, proposed
+        return distilled, proposed, quarantined
+
+    async def _should_quarantine(self, session_id: str) -> bool:
+        """Record a failure for *session_id* and report whether to move past it.
+
+        Returns False on a Redis failure: without a durable count there is no
+        evidence the conversation is unrecoverable, and skipping one that is
+        merely unlucky drops it permanently. The pass stops, which is the
+        pre-#14255 behaviour and the safe direction.
+        """
+        redis = await get_async_redis_client(database=_REDIS_DB)
+        if redis is None:
+            return False
+        key = f"{_FAILURE_KEY_PREFIX}{session_id}"
+        try:
+            failures = int(await redis.incr(key))
+            await redis.expire(key, _FAILURE_TTL_S)
+        except Exception as exc:
+            logger.warning("Skill distillation could not record a failure for %s: %s", session_id, exc)
+            return False
+
+        if failures < MAX_CONSECUTIVE_FAILURES:
+            logger.info(
+                "Skill distillation: conversation %s failed (%d/%d) — pass stops, will retry",
+                session_id,
+                failures,
+                MAX_CONSECUTIVE_FAILURES,
+            )
+            return False
+
+        # Loud on purpose. A silent skip would reinstate the defect #14247
+        # removed -- a conversation reported as handled when it was not -- one
+        # level up, at the scheduler instead of the loader.
+        logger.warning(
+            "Skill distillation: quarantining conversation %s after %d consecutive failures. "
+            "It will not be distilled and the pass will continue past it. "
+            "Investigate the conversation itself — this is not a transient fault (#14255).",
+            session_id,
+            failures,
+        )
+        return True
+
+    async def _clear_failures(self, session_id: str) -> None:
+        """Forget a session's failures once it succeeds.
+
+        Without this the counter is cumulative rather than consecutive, and a
+        conversation that fails intermittently over months eventually crosses the
+        threshold despite always recovering.
+        """
+        redis = await get_async_redis_client(database=_REDIS_DB)
+        if redis is None:
+            return
+        try:
+            await redis.delete(f"{_FAILURE_KEY_PREFIX}{session_id}")
+        except Exception as exc:
+            logger.debug("Skill distillation could not clear failures for %s: %s", session_id, exc)
 
     async def _distil_session(self, session: Dict[str, Any]) -> List[str] | None:
         """Extract and propose for one conversation. ``None`` means the pass must stop."""

--- a/autobot-backend/services/skill_management/skill_distillation_scheduler.py
+++ b/autobot-backend/services/skill_management/skill_distillation_scheduler.py
@@ -277,7 +277,10 @@ class SkillDistillationScheduler:
         pending = await self._select_pending_sessions(cursor)
         if not pending:
             logger.debug("Skill distillation: no conversations since cursor %s", cursor or "(start)")
-            return {"sessions_seen": 0, "sessions_distilled": 0, "proposed": []}
+            # `quarantined` is present on BOTH paths: a caller reading
+            # result["quarantined"] must not KeyError on the empty pass, which is
+            # the common case.
+            return {"sessions_seen": 0, "sessions_distilled": 0, "proposed": [], "quarantined": 0}
 
         distilled, proposed, quarantined = await self._distil_pending(pending)
 
@@ -318,6 +321,11 @@ class SkillDistillationScheduler:
                 if not await self._should_quarantine(session["id"]):
                     break
                 quarantined += 1
+                # Clear the count as well. Left at the threshold, a conversation
+                # that resurfaces later — the queue is keyed on updated_at, so an
+                # edited one does — would re-quarantine on its FIRST new failure,
+                # which is the opposite of "N failures is evidence, one is not".
+                await self._clear_failures(session["id"])
                 await self._write_cursor(session["updated_at"])
                 continue
             await self._clear_failures(session["id"])

--- a/autobot-backend/tests/test_skill_distillation_scheduler.py
+++ b/autobot-backend/tests/test_skill_distillation_scheduler.py
@@ -587,6 +587,6 @@ class TestQuarantineAfterRepeatedFailures:
         result = await scheduler.run_once()
 
         assert result["quarantined"] == 1
-        assert "skills:distillation:failures:chat-a" not in redis.store, (
-            "the count survived the quarantine, so one more failure would re-quarantine immediately"
-        )
+        assert (
+            "skills:distillation:failures:chat-a" not in redis.store
+        ), "the count survived the quarantine, so one more failure would re-quarantine immediately"

--- a/autobot-backend/tests/test_skill_distillation_scheduler.py
+++ b/autobot-backend/tests/test_skill_distillation_scheduler.py
@@ -58,6 +58,19 @@ class _FakeRedis:
         # builtin eval. Nothing here executes caller-supplied code.
         return 1
 
+    # #14255: the failure counter. Stateful rather than a MagicMock, because
+    # "counted" and "never written" are indistinguishable to a mock, and the
+    # whole mechanism is a count crossing a threshold.
+    async def incr(self, key):
+        self.store[key] = int(self.store.get(key, 0)) + 1
+        return self.store[key]
+
+    async def expire(self, key, _ttl):
+        return key in self.store
+
+    async def delete(self, key):
+        return 1 if self.store.pop(key, None) is not None else 0
+
 
 @pytest.fixture
 def redis():
@@ -393,3 +406,146 @@ class TestSchedulerRegistry:
         source = lifespan.read_text(encoding="utf-8")
         assert "_init_skill_distillation_scheduler" in source
         assert "await _init_skill_distillation_scheduler(app)" in source
+
+
+class TestQuarantineAfterRepeatedFailures:
+    """#14255: a conversation that cannot be read must not starve the queue.
+
+    The pass stops on a failure so a transient fault costs nothing — that is
+    right, and `test_failure_stops_the_pass_instead_of_skipping_ahead` pins it.
+    But an oldest-first queue plus a cursor that never advances means a
+    permanently unreadable conversation re-sorts to the front every run and
+    blocks every newer one, with silence as the only symptom.
+
+    Both directions are asserted here on purpose. A fix that only proves
+    "eventually skips" turns the scheduler into "skip everything that errors",
+    which is the defect #14247 removed.
+    """
+
+    async def test_a_transient_failure_still_stops_the_pass(self, redis):
+        """One failure is not evidence of anything. The cursor must hold."""
+        extractor = MagicMock()
+        extractor.extract_skills = AsyncMock(return_value=[_skill()])
+        proposer = MagicMock()
+        proposer.propose_skills = AsyncMock(side_effect=RuntimeError("SLM unreachable"))
+        scheduler = _make_scheduler(extractor, proposer)
+        _with_sessions(scheduler, [{"id": "chat-a", "updatedAt": "2026-07-27T10:00:00"}])
+
+        result = await scheduler.run_once()
+
+        assert result["sessions_distilled"] == 0
+        assert result["quarantined"] == 0
+        assert _stored_cursor(redis) is None
+
+    async def test_the_same_conversation_is_quarantined_once_it_keeps_failing(self, redis):
+        """After MAX_CONSECUTIVE_FAILURES passes, the queue moves on."""
+        from services.skill_management.skill_distillation_scheduler import MAX_CONSECUTIVE_FAILURES
+
+        for _ in range(MAX_CONSECUTIVE_FAILURES):
+            extractor = MagicMock()
+            extractor.extract_skills = AsyncMock(return_value=[_skill()])
+            proposer = MagicMock()
+            proposer.propose_skills = AsyncMock(side_effect=RuntimeError("corrupt history"))
+            scheduler = _make_scheduler(extractor, proposer)
+            _with_sessions(scheduler, [{"id": "chat-a", "updatedAt": "2026-07-27T10:00:00"}])
+            result = await scheduler.run_once()
+
+        assert result["quarantined"] == 1
+        assert _stored_cursor(redis) is not None, "the cursor must advance past a quarantined session"
+
+    async def test_a_newer_conversation_is_reached_after_a_quarantine(self, redis):
+        """The point of the escape hatch: healthy work behind the blockage runs."""
+        from services.skill_management.skill_distillation_scheduler import MAX_CONSECUTIVE_FAILURES
+
+        redis.store[f"skills:distillation:failures:chat-a"] = MAX_CONSECUTIVE_FAILURES - 1
+        extractor = MagicMock()
+        extractor.extract_skills = AsyncMock(return_value=[_skill()])
+        proposer = MagicMock()
+        proposer.propose_skills = AsyncMock(
+            side_effect=[RuntimeError("corrupt history"), {"proposed": ["later_skill"]}]
+        )
+        scheduler = _make_scheduler(extractor, proposer)
+        _with_sessions(
+            scheduler,
+            [
+                {"id": "chat-a", "updatedAt": "2026-07-27T10:00:00"},
+                {"id": "chat-b", "updatedAt": "2026-07-27T11:00:00"},
+            ],
+        )
+
+        result = await scheduler.run_once()
+
+        assert result["quarantined"] == 1
+        assert result["sessions_distilled"] == 1
+        assert "later_skill" in result["proposed"]
+
+    async def test_a_success_forgets_earlier_failures(self, redis):
+        """Otherwise the count is cumulative, and a conversation that fails
+        intermittently over months is eventually quarantined despite always
+        recovering."""
+        from services.skill_management.skill_distillation_scheduler import MAX_CONSECUTIVE_FAILURES
+
+        redis.store["skills:distillation:failures:chat-a"] = MAX_CONSECUTIVE_FAILURES - 1
+        extractor = MagicMock()
+        extractor.extract_skills = AsyncMock(return_value=[_skill()])
+        proposer = MagicMock()
+        proposer.propose_skills = AsyncMock(return_value={"proposed": ["a_skill"]})
+        scheduler = _make_scheduler(extractor, proposer)
+        _with_sessions(scheduler, [{"id": "chat-a", "updatedAt": "2026-07-27T10:00:00"}])
+
+        await scheduler.run_once()
+
+        assert "skills:distillation:failures:chat-a" not in redis.store
+
+    async def test_quarantining_is_announced_not_silent(self, redis, caplog):
+        """A silent skip would reinstate the defect #14247 removed — a
+        conversation reported as handled when it was not — one level up."""
+        from services.skill_management.skill_distillation_scheduler import MAX_CONSECUTIVE_FAILURES
+
+        redis.store["skills:distillation:failures:chat-a"] = MAX_CONSECUTIVE_FAILURES - 1
+        extractor = MagicMock()
+        extractor.extract_skills = AsyncMock(return_value=[_skill()])
+        proposer = MagicMock()
+        proposer.propose_skills = AsyncMock(side_effect=RuntimeError("corrupt history"))
+        scheduler = _make_scheduler(extractor, proposer)
+        _with_sessions(scheduler, [{"id": "chat-a", "updatedAt": "2026-07-27T10:00:00"}])
+
+        with caplog.at_level("WARNING"):
+            await scheduler.run_once()
+
+        assert any("quarantin" in record.message.lower() for record in caplog.records)
+        assert any("chat-a" in str(record.args) for record in caplog.records)
+
+    async def test_an_unavailable_redis_stops_the_pass_rather_than_quarantining(self, monkeypatch):
+        """Without a durable count there is no evidence anything is unrecoverable.
+
+        A Redis outage would otherwise quarantine every failing conversation at
+        once — turning an infrastructure blip into permanent data loss, which is
+        far worse than the head-of-line block this mechanism exists to prevent.
+        Fail closed: the pass stops, which is the pre-#14255 behaviour.
+
+        This is the direction a mutation caught: returning True on `redis is
+        None` left all 22 other tests green, because every one of them has a
+        working fake.
+        """
+        import services.skill_management.skill_distillation_scheduler as mod
+
+        extractor = MagicMock()
+        extractor.extract_skills = AsyncMock(return_value=[_skill()])
+        proposer = MagicMock()
+        proposer.propose_skills = AsyncMock(side_effect=RuntimeError("corrupt history"))
+        scheduler = _make_scheduler(extractor, proposer)
+        _with_sessions(
+            scheduler,
+            [
+                {"id": "chat-a", "updatedAt": "2026-07-27T10:00:00"},
+                {"id": "chat-b", "updatedAt": "2026-07-27T11:00:00"},
+            ],
+        )
+        monkeypatch.setattr(mod, "get_async_redis_client", AsyncMock(return_value=None))
+
+        result = await scheduler.run_once()
+
+        assert result["quarantined"] == 0
+        assert result["sessions_distilled"] == 0
+        assert proposer.propose_skills.await_count == 1, "the pass continued past the failure"

--- a/autobot-backend/tests/test_skill_distillation_scheduler.py
+++ b/autobot-backend/tests/test_skill_distillation_scheduler.py
@@ -355,7 +355,7 @@ class TestDurableCursor:
 
         result = await scheduler.run_once()
 
-        assert result == {"sessions_seen": 0, "sessions_distilled": 0, "proposed": []}
+        assert result == {"sessions_seen": 0, "sessions_distilled": 0, "proposed": [], "quarantined": 0}
         assert _stored_cursor(redis) is None
 
 
@@ -549,3 +549,44 @@ class TestQuarantineAfterRepeatedFailures:
         assert result["quarantined"] == 0
         assert result["sessions_distilled"] == 0
         assert proposer.propose_skills.await_count == 1, "the pass continued past the failure"
+
+    async def test_the_summary_shape_is_the_same_on_both_paths(self, redis):
+        """An empty pass is the common case. A caller reading
+        result["quarantined"] must not KeyError on it — and an equality
+        assertion on the busy path alone would never notice."""
+        extractor = MagicMock()
+        extractor.extract_skills = AsyncMock(return_value=[_skill()])
+        proposer = MagicMock()
+        proposer.propose_skills = AsyncMock(return_value={"proposed": ["a_skill"]})
+
+        empty = _make_scheduler(extractor, proposer)
+        _with_sessions(empty, [])
+        busy = _make_scheduler(extractor, proposer)
+        _with_sessions(busy, [{"id": "chat-a", "updatedAt": "2026-07-27T10:00:00"}])
+
+        assert set((await empty.run_once())) == set((await busy.run_once()))
+
+    async def test_a_quarantined_conversation_gets_a_fresh_budget_if_it_returns(self, redis):
+        """The counter must not survive the quarantine that consumed it.
+
+        The queue is keyed on updated_at, so an edited conversation re-enters it.
+        Left at the threshold, its FIRST new failure would quarantine it again —
+        the opposite of "N failures is evidence, one is not", and unfair to
+        exactly the conversation someone just repaired.
+        """
+        from services.skill_management.skill_distillation_scheduler import MAX_CONSECUTIVE_FAILURES
+
+        redis.store["skills:distillation:failures:chat-a"] = MAX_CONSECUTIVE_FAILURES - 1
+        extractor = MagicMock()
+        extractor.extract_skills = AsyncMock(return_value=[_skill()])
+        proposer = MagicMock()
+        proposer.propose_skills = AsyncMock(side_effect=RuntimeError("corrupt history"))
+        scheduler = _make_scheduler(extractor, proposer)
+        _with_sessions(scheduler, [{"id": "chat-a", "updatedAt": "2026-07-27T10:00:00"}])
+
+        result = await scheduler.run_once()
+
+        assert result["quarantined"] == 1
+        assert "skills:distillation:failures:chat-a" not in redis.store, (
+            "the count survived the quarantine, so one more failure would re-quarantine immediately"
+        )


### PR DESCRIPTION
## Thinking Path

The pass stops on the first failure and holds the cursor. That is correct for a transient fault
and the existing test pins it — skipping ahead would drop a conversation permanently.

It is wrong for a fault that cannot heal. The queue is oldest-first, so a corrupted history file
or a rotated decryption key re-sorts to the front every run, fails again, and the cursor never
advances. Every newer conversation starves behind it and the only symptom is that distillation
quietly stops producing anything.

The tempting discriminator is the exception type — treat `PermissionError` as permanent, a
timeout as transient. That is guesswork: an exception class cannot tell you whether the next
attempt will work. **Repetition can.** N consecutive failures on the same conversation is
evidence; one failure is not.

## What Changed

`_should_quarantine` counts consecutive failures per session in Redis. Below
`MAX_CONSECUTIVE_FAILURES` the pass stops exactly as before. At the threshold the conversation is
quarantined: a warning names it, the cursor advances past it, and the queue drains.

Three deliberate details:

- **A success clears the counter.** Otherwise it is cumulative rather than consecutive, and a
  conversation that fails intermittently over months is eventually quarantined despite always
  recovering.
- **Redis unavailable → do not quarantine.** Without a durable count there is no evidence
  anything is unrecoverable, and an outage would otherwise quarantine every failing conversation
  at once — turning an infrastructure blip into permanent data loss, which is worse than the
  block this fixes. Fail closed to the pre-#14255 behaviour.
- **`quarantined` is in the returned summary, not only the log.** A caller counting pass outcomes
  must be able to see conversations were skipped rather than infer it from an unchanged
  `sessions_distilled`.

Both new knobs are env-backed module constants (`AUTOBOT_SKILL_DISTILLATION_MAX_FAILURES`,
`AUTOBOT_SKILL_DISTILLATION_FAILURE_TTL_S`), matching the existing constants in this module.

## Verification

23 tests. Mutation-checked:

| mutation | result |
|---|---|
| never quarantine (pre-#14255 behaviour) | 3 failed |
| quarantine on the first failure | 5 failed |
| never clear the counter on success | 1 failed |
| quarantine silently, no warning | 1 failed |
| quarantine but do not advance the cursor | 1 failed |
| quarantine when Redis is unavailable | 1 failed |

That last row escaped the first time. All 22 tests then passed, because every one of them has a
working fake Redis — the fail-open direction was documented in the docstring and asserted
nowhere. `test_an_unavailable_redis_stops_the_pass_rather_than_quarantining` closes it; the same
mutation now fails.

The fake Redis gained real `incr`/`expire`/`delete` rather than mock stubs, because "counted" and
"never written" are indistinguishable to a MagicMock and the whole mechanism is a count crossing
a threshold.

Both directions are pinned on purpose: `test_a_transient_failure_still_stops_the_pass` guards
against this becoming "skip everything that errors", which is the defect #14247 removed.

## Risks

A conversation that is genuinely unreadable is now never distilled. That is the intended trade —
it was never being distilled anyway, it was just taking the rest of the queue down with it. The
warning names it so the cause can be investigated.

## Model Used

Opus 5 (1M context).

Closes #14255
