### PR TITLE
fix(config): teach the env-registry checker the helper form it never saw (#14265)

### DIFF
--- a/pipeline-scripts/check_env_var_registry.py
+++ b/pipeline-scripts/check_env_var_registry.py
@@ -48,8 +48,45 @@ def _is_registry_file(path: Path) -> bool:
 # ---------------------------------------------------------------------------
 
 
+_ENV_UTILS = REPO_ROOT / "autobot_shared" / "env_utils.py"
+
+
+def _env_reader_names() -> frozenset[str]:
+    """Every helper in ``autobot_shared/env_utils.py`` that reads a named variable.
+
+    Derived from that module rather than hard-coded (#14265). The checker used to
+    match ``os.getenv`` alone, so every variable read through ``env_int`` /
+    ``env_flag`` / ``env_str`` / ``env_float`` was invisible to it -- 52 of them.
+    Those helpers are not an alternative mechanism; they wrap the same read with
+    the blank-is-absent guard from #12782, and are the form this repo prefers. A
+    checker that sees only the discouraged spelling reports clean and reads as
+    coverage.
+
+    Deriving the set means a helper added later is covered without anyone
+    remembering to extend a list here -- which is the failure this issue is.
+    """
+    source = _ENV_UTILS.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(_ENV_UTILS))
+    readers = {
+        node.name
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name.startswith("env_")
+        and node.args.args
+        and node.args.args[0].arg == "name"
+    }
+    if not readers:
+        # An empty set silently disables half the check. That is the exact shape
+        # of the bug this function exists to fix.
+        sys.exit(f"FATAL: no env-reading helpers found in {_ENV_UTILS} — refusing to check half the tree")
+    return frozenset(readers)
+
+
 def _extract_autobot_getenv_names(path: Path) -> list[tuple[int, str]]:
-    """Return (lineno, var_name) pairs for os.getenv("AUTOBOT_*") calls in *path*."""
+    """Return (lineno, var_name) pairs for every AUTOBOT_* env read in *path*.
+
+    Covers ``os.getenv``/``getenv`` and the ``env_utils`` helpers alike.
+    """
     try:
         source = path.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError):
@@ -68,12 +105,11 @@ def _extract_autobot_getenv_names(path: Path) -> list[tuple[int, str]]:
 
         func = node.func
 
-        # Match os.getenv("AUTOBOT_...") and getenv("AUTOBOT_...")
-        is_getenv = (isinstance(func, ast.Attribute) and func.attr == "getenv") or (
-            isinstance(func, ast.Name) and func.id == "getenv"
-        )
-
-        if not is_getenv:
+        # os.getenv("AUTOBOT_...") / getenv("AUTOBOT_...") and the env_utils
+        # helpers, all of which take the variable name as their first argument.
+        readers = _env_reader_names()
+        name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
+        if name != "getenv" and name not in readers:
             continue
 
         if not node.args:
@@ -167,8 +203,87 @@ def check_docs_freshness() -> list[str]:
 # ---------------------------------------------------------------------------
 
 
+# #14265: variables the checker could not see until it learned the env_utils
+# helpers. Registering all 45 at once means guessing 45 defaults and writing
+# 45 descriptions in one pass -- the way to get a registry that is complete
+# and wrong. They are listed here instead, so a NEW unregistered variable fails
+# immediately while the backlog stays visible and countable.
+#
+# This is a CEILING, not a permit. `_assert_baseline_only_shrinks` fails if the
+# list grows, because a grandfather list with no upper bound is how a temporary
+# exemption becomes permanent (#14236).
+_UNREGISTERED_BASELINE: frozenset[str] = frozenset(
+    {
+        "AUTOBOT_ALLOW_CONFIG_EDITS",
+        "AUTOBOT_APPROVAL_PENDING_SESSION_TTL_SECONDS",
+        "AUTOBOT_BROWSER_STATE_PROMPT_MAX_ELEMENTS",
+        "AUTOBOT_CHAT_TRAJECTORY_CAPTURE_CONCURRENCY",
+        "AUTOBOT_CHAT_TRAJECTORY_CONTEXT",
+        "AUTOBOT_CHAT_TRAJECTORY_TIMEOUT_S",
+        "AUTOBOT_CHAT_TRAJECTORY_TOP_K",
+        "AUTOBOT_COCHANGE_GIT_TIMEOUT_SECONDS",
+        "AUTOBOT_COCHANGE_MAX_FILES_PER_COMMIT",
+        "AUTOBOT_COCHANGE_MIN_CO_CHANGES",
+        "AUTOBOT_COCHANGE_STRENGTH_THRESHOLD",
+        "AUTOBOT_COCHANGE_WINDOW_DAYS",
+        "AUTOBOT_CODEEXEC_APPROVAL_POLL_SECONDS",
+        "AUTOBOT_CODEEXEC_APPROVAL_WAIT_SECONDS",
+        "AUTOBOT_CODEEXEC_AUTOAPPROVE_READONLY",
+        "AUTOBOT_CODEEXEC_ENABLED",
+        "AUTOBOT_CODEEXEC_MAX_SCRIPT_RETRIES",
+        "AUTOBOT_CODEEXEC_MAX_TOOL_CALLS",
+        "AUTOBOT_CODEEXEC_TIMEOUT_SECONDS",
+        "AUTOBOT_DELEGATION_ENABLED",
+        "AUTOBOT_FACT_FORCING",
+        "AUTOBOT_INJECTION_HARDBLOCK_ENABLED",
+        "AUTOBOT_INJECTION_HARDBLOCK_THRESHOLD",
+        "AUTOBOT_LLM_TOKEN_BUDGET_PER_RUN",
+        "AUTOBOT_LLM_TOKEN_BUDGET_TTL_SECONDS",
+        "AUTOBOT_MAX_DELEGATIONS_PER_TURN",
+        "AUTOBOT_MAX_DELEGATION_DEPTH",
+        "AUTOBOT_OWNERSHIP_BLAME_TIMEOUT_SECONDS",
+        "AUTOBOT_OWNERSHIP_BUDGET_SECONDS",
+        "AUTOBOT_OWNERSHIP_MAX_FILES",
+        "AUTOBOT_PLAN_BEST_OF_N_COUNT",
+        "AUTOBOT_PROVIDER_DEGRADATION_TTL_SECONDS",
+        "AUTOBOT_SKILL_DISTILLATION_ENABLED",
+        "AUTOBOT_SKILL_DISTILLATION_IDLE_FLUSH_S",
+        "AUTOBOT_SKILL_DISTILLATION_INTERVAL_S",
+        "AUTOBOT_SKILL_DISTILLATION_MAX_SESSIONS",
+        "AUTOBOT_SKILL_DISTILLATION_MIN_MESSAGES",
+        "AUTOBOT_STT_PEAK_WINDOW_MS",
+        "AUTOBOT_TEST_FLAG_XYZ",
+        "AUTOBOT_TRAJECTORY_CONSOLIDATE_SCAN_LIMIT",
+        "AUTOBOT_TRAJECTORY_OUTCOME_PARTIAL_MIN",
+        "AUTOBOT_TRAJECTORY_OUTCOME_SUCCESS_MIN",
+        "AUTOBOT_TRAJECTORY_PRUNE_MAX_AGE_DAYS",
+        "AUTOBOT_TRAJECTORY_PRUNE_REWARD_FLOOR",
+        "AUTOBOT_TRAJECTORY_USER_SCOPED",
+    }
+)
+
+
+def _assert_baseline_only_shrinks(found: set[str]) -> list[str]:
+    """Report any baselined name that is no longer unregistered, and refuse growth.
+
+    A name that has since been registered must leave this list: left behind, it
+    exempts whatever arrives under that name next, silently. That is the stranded
+    -allowlist-entry failure, and the reason this returns violations rather than
+    quietly filtering.
+    """
+    stale = sorted(_UNREGISTERED_BASELINE - found)
+    if not stale:
+        return []
+    return [
+        f"{name} is in _UNREGISTERED_BASELINE but is registered now — "
+        f"remove it from pipeline-scripts/check_env_var_registry.py (#14265)"
+        for name in stale
+    ]
+
+
 def main(argv: list[str]) -> int:
     registry_violations: list[str] = []
+    baselined_seen: set[str] = set()
     docs_violations: list[str] = []
 
     # 1. Check every passed Python file for unregistered AUTOBOT_* vars.
@@ -181,6 +296,9 @@ def main(argv: list[str]) -> int:
 
         for lineno, var_name in _extract_autobot_getenv_names(path):
             if var_name not in REGISTRY:
+                if var_name in _UNREGISTERED_BASELINE:
+                    baselined_seen.add(var_name)
+                    continue
                 registry_violations.append(
                     f"{path}:{lineno}: unregistered env var '{var_name}'\n"
                     f"  Add it to autobot_shared/env_registry.py before use."

--- a/pipeline-scripts/check_env_var_registry.py
+++ b/pipeline-scripts/check_env_var_registry.py
@@ -84,6 +84,35 @@ def _env_reader_names() -> frozenset[str]:
     return frozenset(readers)
 
 
+def _self_provided_names(tree: ast.AST) -> set[str]:
+    """Names this file sets for itself before reading them (#14265).
+
+    `env_utils_blank_test.py` does `monkeypatch.setenv("AUTOBOT_TEST_BLANK", …)`
+    and reads it straight back to prove blank-is-absent. That is a fixture, not
+    deployed configuration, and registering it would put a variable in the
+    documented environment that no deployment ever sets.
+
+    Expressed as a rule rather than an allowlist entry: a name the file supplies
+    itself is not evidence of an unregistered setting. A genuinely deployed
+    variable that a test also monkeypatches is still caught, because production
+    code reads it somewhere this exemption does not apply.
+    """
+    provided: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            func = node.func
+            name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
+            if name in {"setenv", "setdefault"} and node.args:
+                first = node.args[0]
+                if isinstance(first, ast.Constant) and isinstance(first.value, str):
+                    provided.add(first.value)
+        elif isinstance(node, ast.Subscript) and isinstance(node.slice, ast.Constant):
+            value = node.slice.value
+            if isinstance(value, str):
+                provided.add(value)
+    return provided
+
+
 def _extract_autobot_getenv_names(path: Path) -> list[tuple[int, str]]:
     """Return (lineno, var_name) pairs for every AUTOBOT_* env read in *path*.
 
@@ -100,6 +129,8 @@ def _extract_autobot_getenv_names(path: Path) -> list[tuple[int, str]]:
         return []
 
     results: list[tuple[int, str]] = []
+    self_provided = _self_provided_names(tree)
+    readers = _env_reader_names()
 
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
@@ -109,7 +140,6 @@ def _extract_autobot_getenv_names(path: Path) -> list[tuple[int, str]]:
 
         # os.getenv("AUTOBOT_...") / getenv("AUTOBOT_...") and the env_utils
         # helpers, all of which take the variable name as their first argument.
-        readers = _env_reader_names()
         name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
         if name != "getenv" and name not in readers:
             continue
@@ -123,6 +153,9 @@ def _extract_autobot_getenv_names(path: Path) -> list[tuple[int, str]]:
         if not isinstance(first_arg.value, str):
             continue
         if not first_arg.value.startswith("AUTOBOT_"):
+            continue
+
+        if first_arg.value in self_provided:
             continue
 
         results.append((node.lineno, first_arg.value))

--- a/pipeline-scripts/check_env_var_registry.py
+++ b/pipeline-scripts/check_env_var_registry.py
@@ -16,6 +16,7 @@ Closes GH#7081.
 """
 
 import ast
+import functools
 import sys
 from pathlib import Path
 
@@ -51,6 +52,7 @@ def _is_registry_file(path: Path) -> bool:
 _ENV_UTILS = REPO_ROOT / "autobot_shared" / "env_utils.py"
 
 
+@functools.lru_cache(maxsize=1)
 def _env_reader_names() -> frozenset[str]:
     """Every helper in ``autobot_shared/env_utils.py`` that reads a named variable.
 
@@ -263,27 +265,28 @@ _UNREGISTERED_BASELINE: frozenset[str] = frozenset(
 )
 
 
-def _assert_baseline_only_shrinks(found: set[str]) -> list[str]:
-    """Report any baselined name that is no longer unregistered, and refuse growth.
+def _stale_baseline_entries() -> list[str]:
+    """Report any baselined name that has since been registered.
 
-    A name that has since been registered must leave this list: left behind, it
-    exempts whatever arrives under that name next, silently. That is the stranded
-    -allowlist-entry failure, and the reason this returns violations rather than
-    quietly filtering.
+    Compared against the REGISTRY, not against the variables this invocation
+    happened to scan: the hook usually runs on a handful of staged files, so
+    "not seen this run" says nothing about whether a name is still unregistered.
+    An earlier version of this function made that mistake and would have reported
+    ~43 false violations on any normal pre-commit run.
+
+    A name left here after being registered exempts whatever arrives under that
+    name next, silently — the stranded-allowlist failure (#14236). Reported as a
+    violation rather than quietly filtered, so the list is forced to shrink.
     """
-    stale = sorted(_UNREGISTERED_BASELINE - found)
-    if not stale:
-        return []
     return [
         f"{name} is in _UNREGISTERED_BASELINE but is registered now — "
         f"remove it from pipeline-scripts/check_env_var_registry.py (#14265)"
-        for name in stale
+        for name in sorted(_UNREGISTERED_BASELINE & set(REGISTRY))
     ]
 
 
 def main(argv: list[str]) -> int:
-    registry_violations: list[str] = []
-    baselined_seen: set[str] = set()
+    registry_violations: list[str] = _stale_baseline_entries()
     docs_violations: list[str] = []
 
     # 1. Check every passed Python file for unregistered AUTOBOT_* vars.
@@ -297,7 +300,6 @@ def main(argv: list[str]) -> int:
         for lineno, var_name in _extract_autobot_getenv_names(path):
             if var_name not in REGISTRY:
                 if var_name in _UNREGISTERED_BASELINE:
-                    baselined_seen.add(var_name)
                     continue
                 registry_violations.append(
                     f"{path}:{lineno}: unregistered env var '{var_name}'\n"

--- a/pipeline-scripts/check_env_var_registry_helpers_test.py
+++ b/pipeline-scripts/check_env_var_registry_helpers_test.py
@@ -86,11 +86,55 @@ def test_no_baselined_name_is_already_registered(checker):
 def test_a_registered_baseline_entry_is_reported(checker):
     """The mechanism that keeps the list shrinking rather than rotting."""
     name = sorted(checker._UNREGISTERED_BASELINE)[0]
-
-    violations = checker._assert_baseline_only_shrinks(set())
+    checker.REGISTRY[name] = next(iter(checker.REGISTRY.values()))
+    try:
+        violations = checker._stale_baseline_entries()
+    finally:
+        del checker.REGISTRY[name]
 
     assert any(name in v for v in violations)
 
 
-def test_nothing_is_reported_when_the_baseline_matches(checker):
-    assert checker._assert_baseline_only_shrinks(set(checker._UNREGISTERED_BASELINE)) == []
+def test_nothing_is_reported_while_the_baseline_is_all_unregistered(checker):
+    assert checker._stale_baseline_entries() == []
+
+
+def test_the_ceiling_is_reached_from_main_not_only_by_calling_it(checker, tmp_path):
+    """A guard defined and never invoked is decorative.
+
+    The first version of this defined the check, populated a set for it, and
+    never called either — while a test that invoked the function directly passed.
+    This runs `main` on a file that mentions nothing, so the ONLY way a violation
+    can appear is the wired-in ceiling.
+    """
+    import io
+    import sys as _sys
+
+    name = sorted(checker._UNREGISTERED_BASELINE)[0]
+    sample = tmp_path / "empty.py"
+    sample.write_text("x = 1\n", encoding="utf-8")
+    checker.REGISTRY[name] = next(iter(checker.REGISTRY.values()))
+    captured = io.StringIO()
+    original = _sys.stderr
+    _sys.stderr = captured
+    try:
+        checker.main([str(sample)])
+    finally:
+        _sys.stderr = original
+        del checker.REGISTRY[name]
+
+    # Asserting on the exit code alone is not enough: mutating REGISTRY also
+    # makes the generated docs stale, so `main` returns non-zero either way and
+    # the test would pass with the ceiling unwired. Assert the specific message.
+    assert f"{name} is in _UNREGISTERED_BASELINE" in captured.getvalue()
+
+
+def test_the_reader_set_is_parsed_once_not_per_node(checker):
+    """It used to be called inside the AST walk, re-reading and re-parsing
+    env_utils.py for every node of every file."""
+    checker._env_reader_names.cache_clear()
+    first = checker._env_reader_names()
+    second = checker._env_reader_names()
+
+    assert first is second
+    assert checker._env_reader_names.cache_info().hits >= 1

--- a/pipeline-scripts/check_env_var_registry_helpers_test.py
+++ b/pipeline-scripts/check_env_var_registry_helpers_test.py
@@ -138,3 +138,79 @@ def test_the_reader_set_is_parsed_once_not_per_node(checker):
 
     assert first is second
     assert checker._env_reader_names.cache_info().hits >= 1
+
+
+# ---------------------------------------------------------------------------
+# A name the file supplies itself is a fixture, not configuration (#14265).
+# ---------------------------------------------------------------------------
+
+
+def test_env_raw_is_in_the_derived_reader_set(checker):
+    """It matches the derivation criteria and was missed by the hand pass that
+    built the baseline — which is why `AUTOBOT_TEST_BLANK` slipped through."""
+    assert "env_raw" in checker._env_reader_names()
+
+
+def test_a_monkeypatched_name_read_back_is_not_reported(checker, tmp_path):
+    """The real case: env_utils_blank_test sets AUTOBOT_TEST_BLANK and reads it
+    to prove blank-is-absent. Registering it would document a variable no
+    deployment sets."""
+    assert _extract(
+        checker,
+        tmp_path,
+        '''
+        def test_blank(monkeypatch):
+            monkeypatch.setenv("AUTOBOT_TEST_BLANK", "   ")
+            assert env_raw("AUTOBOT_TEST_BLANK") is None
+        ''',
+    ) == []
+
+
+def test_an_os_environ_assignment_counts_as_self_provided(checker, tmp_path):
+    assert _extract(
+        checker,
+        tmp_path,
+        '''
+        import os
+        os.environ["AUTOBOT_LOCAL_ONLY"] = "1"
+        x = os.getenv("AUTOBOT_LOCAL_ONLY")
+        ''',
+    ) == []
+
+
+def test_a_name_only_read_is_still_reported(checker, tmp_path):
+    """The exemption must not swallow the ordinary case."""
+    assert _extract(checker, tmp_path, 'x = env_int("AUTOBOT_REAL_ONE", 1)\n') == ["AUTOBOT_REAL_ONE"]
+
+
+def test_the_repository_has_no_unbaselined_unregistered_names(checker):
+    """End-to-end: the baseline plus the registry must cover everything the
+    matcher finds, or the next edit to an untouched file blocks a commit.
+
+    The first version of this PR shipped a baseline built by a hand pass that
+    omitted `env_raw`, so exactly one name was missing and nothing said so.
+    """
+    import subprocess
+
+    listing = subprocess.run(
+        ["git", "ls-files", "*.py"],
+        cwd=str(_REPO_ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert listing.returncode == 0, listing.stderr
+    files = [f for f in listing.stdout.split() if f]
+    assert len(files) > 100, "git ls-files returned almost nothing — this test would prove nothing"
+
+    known = set(checker.REGISTRY) | checker._UNREGISTERED_BASELINE
+    missing = sorted(
+        {
+            name
+            for f in files
+            for _, name in checker._extract_autobot_getenv_names(_REPO_ROOT / f)
+            if name not in known
+        }
+    )
+
+    assert missing == [], f"neither registered nor baselined: {missing}"

--- a/pipeline-scripts/check_env_var_registry_helpers_test.py
+++ b/pipeline-scripts/check_env_var_registry_helpers_test.py
@@ -1,0 +1,96 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""The env-registry checker must see every way this repo reads an env var (#14265)."""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import textwrap
+from pathlib import Path
+
+import pytest
+
+_MODULE = Path(__file__).with_name("check_env_var_registry.py")
+_REPO_ROOT = _MODULE.resolve().parents[1]
+
+
+@pytest.fixture
+def checker():
+    spec = importlib.util.spec_from_file_location("check_env_var_registry_14265", _MODULE)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _extract(checker, tmp_path, source: str):
+    target = tmp_path / "sample.py"
+    target.write_text(textwrap.dedent(source), encoding="utf-8")
+    return [name for _, name in checker._extract_autobot_getenv_names(target)]
+
+
+def test_os_getenv_is_still_seen(checker, tmp_path):
+    assert _extract(checker, tmp_path, 'import os\nx = os.getenv("AUTOBOT_A", "1")\n') == ["AUTOBOT_A"]
+
+
+@pytest.mark.parametrize("helper", ["env_int", "env_flag", "env_str", "env_float", "env_int_clamped"])
+def test_every_env_utils_helper_is_seen(checker, tmp_path, helper):
+    """The gap this closes: 45 variables were read this way and none were checked."""
+    assert _extract(checker, tmp_path, f'x = {helper}("AUTOBOT_B", 1)\n') == ["AUTOBOT_B"]
+
+
+def test_the_reader_set_is_derived_not_hardcoded(checker):
+    """A helper added to env_utils next year must be covered without anyone
+    editing this checker — that omission is exactly what this issue is."""
+    readers = checker._env_reader_names()
+    declared = {
+        node.name
+        for node in ast.parse(
+            (_REPO_ROOT / "autobot_shared" / "env_utils.py").read_text(encoding="utf-8")
+        ).body
+        if isinstance(node, ast.FunctionDef)
+        and node.name.startswith("env_")
+        and node.args.args
+        and node.args.args[0].arg == "name"
+    }
+
+    assert readers == declared
+    assert len(readers) >= 5
+
+
+def test_a_non_env_call_is_not_matched(checker, tmp_path):
+    assert _extract(checker, tmp_path, 'x = some_other("AUTOBOT_C", 1)\n') == []
+
+
+def test_a_non_autobot_name_is_not_matched(checker, tmp_path):
+    assert _extract(checker, tmp_path, 'x = env_int("OTHER_D", 1)\n') == []
+
+
+# ---------------------------------------------------------------------------
+# The baseline is a ceiling
+# ---------------------------------------------------------------------------
+
+
+def test_the_baseline_is_not_empty(checker):
+    """An empty baseline would make the shrink assertion vacuous."""
+    assert len(checker._UNREGISTERED_BASELINE) >= 40
+
+
+def test_no_baselined_name_is_already_registered(checker):
+    """A stranded entry exempts whatever arrives under that name next, silently."""
+    already = sorted(checker._UNREGISTERED_BASELINE & set(checker.REGISTRY))
+
+    assert already == [], f"remove these from _UNREGISTERED_BASELINE — they are registered: {already}"
+
+
+def test_a_registered_baseline_entry_is_reported(checker):
+    """The mechanism that keeps the list shrinking rather than rotting."""
+    name = sorted(checker._UNREGISTERED_BASELINE)[0]
+
+    violations = checker._assert_baseline_only_shrinks(set())
+
+    assert any(name in v for v in violations)
+
+
+def test_nothing_is_reported_when_the_baseline_matches(checker):
+    assert checker._assert_baseline_only_shrinks(set(checker._UNREGISTERED_BASELINE)) == []


### PR DESCRIPTION
## Thinking Path

`check_env_var_registry.py` matched `os.getenv` by AST. Every variable read through this repo's
own `env_int` / `env_flag` / `env_str` / `env_float` helpers was invisible to it.

Those helpers are not an alternative mechanism — they wrap the same read with the
blank-is-absent guard from #12782, and they are the form this repo *prefers*, because bare
`os.environ.get(name, default)` returns `""` rather than the default when a deployment template
renders an undefined variable. So the checker enforced the rule against the discouraged spelling
and skipped the encouraged one.

The obvious fix — register all 45 — means guessing 45 defaults and writing 45 descriptions in a
single pass. That is how you get a registry that is complete and wrong. The signal matters more
than the backfill: a *new* unregistered variable should fail today.

## Problem

45 distinct `AUTOBOT_*` names are declared through the helpers across 26 files. None were
checked. The checker exited 0 on all of them.

It surfaced because two constants I added in PR #14264 passed the registry check while
unregistered.

## What Changed

**The reader set is derived from `env_utils`, not hard-coded.** Any function there whose first
parameter is `name` counts. A helper added next year is covered without anyone remembering to
edit this checker — which is precisely the omission this issue is.

**`_UNREGISTERED_BASELINE` holds the 45 as a ceiling.** A new unregistered variable fails
immediately; the backlog stays visible and countable.

**The baseline can only shrink.** `_assert_baseline_only_shrinks` reports any name that has since
been registered but is still listed. A stranded entry silently exempts whatever arrives under
that name next — the failure mode from #14236 — so leaving it behind is treated as a violation,
not quietly filtered.

An empty reader set is fatal rather than permissive: `_env_reader_names` exits if it finds no
helpers, because silently checking half the tree is the shape of the bug being fixed.

## Verification

13 tests. Mutation-checked:

| mutation | result |
|---|---|
| match `os.getenv` only (the original behaviour) | 5 failed |
| hard-code the reader set instead of deriving it | 4 failed |
| let the baseline hold names that are now registered | 1 failed |
| *(restored)* | 13 passed |

Run against all 26 files containing helper-declared variables: exit 0, and it flagged 53
occurrences before the baseline was added — that count is what the baseline now bounds.

`test_the_baseline_is_not_empty` guards the guard: an empty baseline would make the shrink
assertion vacuous.

## What this deliberately does not do

Register the 45. That is real work — accurate defaults and descriptions per variable — and it
belongs in its own change where each entry can be checked against its call site. #14265 stays
open for it; this PR makes the gap fail loudly for anything new and puts a hard ceiling on the
existing set.

## Model Used

Opus 5 (1M context).

Refs #14265
