### PR TITLE
fix(config): register the two distillation vars added while #14265's baseline was in flight (#14265)

### DIFF
--- a/autobot_shared/env_registry.py
+++ b/autobot_shared/env_registry.py
@@ -1008,3 +1008,37 @@ register_env_var(
         component="monitoring",
     )
 )
+
+# --- skill distillation (#14255) ---------------------------------------------
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_SKILL_DISTILLATION_MAX_FAILURES",
+        type=int,
+        default=3,
+        description=(
+            "Consecutive failures on the SAME conversation before the distillation "
+            "pass stops waiting for it and moves on. Below this the pass halts and "
+            "retries next run, so a transient fault costs nothing; at it, the "
+            "conversation is quarantined with a warning and the cursor advances, so "
+            "one unreadable conversation cannot starve every newer one behind it in "
+            "an oldest-first queue (#14255). A success resets the count."
+        ),
+        component="backend",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_SKILL_DISTILLATION_FAILURE_TTL_S",
+        type=int,
+        default=86_400,
+        description=(
+            "How long a conversation's consecutive-failure count survives, in "
+            "seconds. Derived as 24 distillation intervals, so failures accumulate "
+            "across passes rather than expiring between them, while a counter for a "
+            "conversation nobody retries eventually clears instead of accumulating "
+            "forever (#14255)."
+        ),
+        component="backend",
+    )
+)

--- a/docs/developer/CLAUDE_RULES.md
+++ b/docs/developer/CLAUDE_RULES.md
@@ -500,6 +500,8 @@ To add a new variable:
 | `AUTOBOT_RETRIEVAL_REDIS_TIMEOUT` | redis | float | `1.5` | Seconds the retrieval learner waits for its Redis lock before proceeding without it. Short on purpose — retrieval must answer even when the learner cannot record what it learned. |
 | `AUTOBOT_SHOW_DEPRECATION_WARNINGS` | system | bool | false | Emit Python DeprecationWarnings for deprecated AutoBot APIs when truthy. |
 | `AUTOBOT_SIGNAL_ENABLED` | gateway | bool | false | Opt in to the Signal gateway adapter. Off by default: it needs a running signal-cli daemon and a registered number. |
+| `AUTOBOT_SKILL_DISTILLATION_FAILURE_TTL_S` | backend | int | `86400` | How long a conversation's consecutive-failure count survives, in seconds. Derived as 24 distillation intervals, so failures accumulate across passes rather than expiring between them, while a counter for a conversation nobody retries eventually clears instead of accumulating forever (#14255). |
+| `AUTOBOT_SKILL_DISTILLATION_MAX_FAILURES` | backend | int | `3` | Consecutive failures on the SAME conversation before the distillation pass stops waiting for it and moves on. Below this the pass halts and retries next run, so a transient fault costs nothing; at it, the conversation is quarantined with a warning and the cursor advances, so one unreadable conversation cannot starve every newer one behind it in an oldest-first queue (#14255). A success resets the count. |
 | `AUTOBOT_SNAPSHOT_STORAGE_PATH` | execution | str | `""` | Directory holding execution snapshots. Empty means 'derive it' — the default is `<project root>/snapshots`, so it follows the install location rather than being pinned to one path. |
 | `AUTOBOT_SNAPSHOT_TTL_DAYS` | execution | int | `7` | Age at which the cleanup task removes an execution snapshot. Snapshots are a debugging aid, so the default is deliberately short. |
 | `AUTOBOT_STT_NO_SPEECH_PROB_THRESHOLD` | voice | float | `0.8` | Decoder no-speech probability at or above which an STT transcript is discarded as a silence hallucination (#13104). Range: 0.0–1.0. |
@@ -514,5 +516,5 @@ To add a new variable:
 | `AUTOBOT_USERS_DATABASE_URL` | postgres | str | *(none)* | Full SQLAlchemy connection URL for the users database. Overrides AUTOBOT_POSTGRES_* individual vars when set. |
 | `AUTOBOT_VOICE_TOOLSETS` | voice | str | `'voice_safe'` | Comma-separated toolset bundles a voice session may call. Defaults to the restricted `voice_safe` bundle — voice input is harder to confirm than typed input, so the surface is narrowed by default. |
 
-*76 variables registered as of last generation.*
+*78 variables registered as of last generation.*
 <!-- END_AUTOGEN_ENV_DOCS -->


### PR DESCRIPTION
## Thinking Path

Two of my own PRs merged an hour apart and collided. #14264 (#14255) added two env-backed
constants. #14266 (#14265) taught the registry checker to see helper-declared variables and
shipped a completeness test asserting that registry ∪ baseline covers everything the matcher
finds — with a baseline computed **before** #14264 landed.

Neither PR was wrong on its own and both were green. The test that broke is the one doing its
job: it is the first thing in this repo that can notice an unregistered helper-declared variable,
and the first thing it noticed was mine.

## Problem

`origin/Dev_new_gui` is red on
`check_env_var_registry_helpers_test.py::test_the_repository_has_no_unbaselined_unregistered_names`:

```
neither registered nor baselined:
  ['AUTOBOT_SKILL_DISTILLATION_FAILURE_TTL_S', 'AUTOBOT_SKILL_DISTILLATION_MAX_FAILURES']
```

## What Changed

Both are registered properly rather than added to `_UNREGISTERED_BASELINE`. The baseline is for
variables whose defaults and meanings need checking against their call sites one at a time; these
two I wrote this session and can describe exactly, so putting them in a backlog list would be
padding it for no reason.

Docs regenerated from the registry: 76 → 78 variables.

## Verification

- `check_env_var_registry_helpers_test.py`: **20 passed** (was 1 failed, 19 passed at base).
- `check_env_var_registry.py` over 400 tracked Python files: exit 0.

## Risks

None to behaviour — registry entries are documentation plus the checker's source of truth.

## Note for the backfill

#14265's remaining 45 entries stay in the baseline. This is not a start on that; it is two
variables that never should have reached the baseline, caught the same day they were added by
the mechanism that PR built.

## Model Used

Opus 5 (1M context).

Refs #14265, #14255
