### PR TITLE
fix(config): register the 44 helper-declared env vars and drain the baseline (#14265)

### DIFF
--- a/autobot_shared/env_registry.py
+++ b/autobot_shared/env_registry.py
@@ -1042,3 +1042,584 @@ register_env_var(
         component="backend",
     )
 )
+
+# --- backfilled from the env_utils helper form (#14265) -----------------------
+# These were read via env_int/env_flag/env_str/env_float and were therefore
+# invisible to the registry checker until it learned that form. Defaults and
+# types are taken from each call site, not guessed.
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_ALLOW_CONFIG_EDITS",
+        type=bool,
+        default=False,
+        description=(
+            "Permit writes to the repository's tracked config files. Off by default: the "
+            "codebase is the source of truth and an edit made here is invisible to "
+            "deployment (#11220)."
+        ),
+        component="system",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_APPROVAL_PENDING_SESSION_TTL_SECONDS",
+        type=int,
+        default=604800,
+        description=(
+            "Seconds a session holding a pending approval survives in Redis. Deliberately "
+            "long — what it waits for is a person, and expiring sooner discards the "
+            "approval rather than the wait (#13478)."
+        ),
+        component="execution",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_BROWSER_STATE_PROMPT_MAX_ELEMENTS",
+        type=int,
+        default=30,
+        description=(
+            "How many numbered elements the LLM-visible state block renders per browser "
+            "tool result. The browser worker caps the raw list separately; this bounds only "
+            "what reaches the prompt (#11537)."
+        ),
+        component="backend",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_CHAT_TRAJECTORY_CAPTURE_CONCURRENCY",
+        type=int,
+        default=2,
+        description=(
+            "Concurrent trajectory judge calls. Bounded so a burst of turns cannot stampede "
+            "the LLM."
+        ),
+        component="ai",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_CHAT_TRAJECTORY_CONTEXT",
+        type=bool,
+        default=True,
+        description=(
+            "Search past trajectories before answering. Defaults on because the search is "
+            "one vector query; capture is gated separately since it spends a judge call."
+        ),
+        component="ai",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_CHAT_TRAJECTORY_TIMEOUT_S",
+        type=float,
+        default=0.15,
+        description=(
+            "Seconds the pre-answer trajectory search may take. It rides the response hot "
+            "path, so a cold or slow collection must never delay first token."
+        ),
+        component="ai",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_CHAT_TRAJECTORY_TOP_K",
+        type=int,
+        default=3,
+        description=(
+            "How many past trajectories the pre-answer search retrieves."
+        ),
+        component="ai",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_COCHANGE_GIT_TIMEOUT_SECONDS",
+        type=int,
+        default=120,
+        description=(
+            "Seconds the co-change history walk may run before it is abandoned."
+        ),
+        component="backend",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_COCHANGE_MAX_FILES_PER_COMMIT",
+        type=int,
+        default=50,
+        description=(
+            "Commits touching more files than this are ignored as coupling evidence: a bulk "
+            "rename, a vendored-tree import or a reformat is not a signal (#13639)."
+        ),
+        component="backend",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_COCHANGE_MIN_CO_CHANGES",
+        type=int,
+        default=3,
+        description=(
+            "How many commits two files must share before the pair is reported at all. One "
+            "shared commit is a coincidence."
+        ),
+        component="backend",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_COCHANGE_STRENGTH_THRESHOLD",
+        type=float,
+        default=0.3,
+        description=(
+            "Minimum normalised coupling strength to report. Independent of the count "
+            "threshold: a pair can clear the count and still be weak if either file changes "
+            "constantly."
+        ),
+        component="backend",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_COCHANGE_WINDOW_DAYS",
+        type=int,
+        default=180,
+        description=(
+            "Days of history the co-change analysis considers. Coupling decays — a pair "
+            "that moved together two years ago is history, not structure."
+        ),
+        component="backend",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_CODEEXEC_APPROVAL_POLL_SECONDS",
+        type=int,
+        default=2,
+        description=(
+            "Seconds between polls while waiting for a code-execution approval decision."
+        ),
+        component="execution",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_CODEEXEC_APPROVAL_WAIT_SECONDS",
+        type=int,
+        default=1800,
+        description=(
+            "Seconds a code-execution request waits for approval before expiring. Expiry is "
+            "a decision the caller can act on, not a side effect of how long a coroutine "
+            "lives (GH#11568)."
+        ),
+        component="execution",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_CODEEXEC_AUTOAPPROVE_READONLY",
+        type=bool,
+        default=True,
+        description=(
+            "Auto-approve code-execution calls limited to the read-only tool set. The "
+            "eligible set is fixed in code, not configurable here (GH#11568, GH#11662)."
+        ),
+        component="execution",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_CODEEXEC_ENABLED",
+        type=bool,
+        default=False,
+        description=(
+            "Master switch for the compose/code-execution tool. Ships off (GH#11568)."
+        ),
+        component="execution",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_CODEEXEC_MAX_SCRIPT_RETRIES",
+        type=int,
+        default=1,
+        description=(
+            "How many times a failed generated script may be retried within one "
+            "code-execution call."
+        ),
+        component="execution",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_CODEEXEC_MAX_TOOL_CALLS",
+        type=int,
+        default=50,
+        description=(
+            "Ceiling on tool calls a single code-execution script may make, bounding a "
+            "runaway loop inside the sandbox."
+        ),
+        component="execution",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_CODEEXEC_TIMEOUT_SECONDS",
+        type=int,
+        default=120,
+        description=(
+            "Seconds a compose-tool sandbox execution may run (GH#11568)."
+        ),
+        component="execution",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_DELEGATION_ENABLED",
+        type=bool,
+        default=False,
+        description=(
+            "Master switch for the delegate tool. Off, it records the delegation request "
+            "and does not dispatch it."
+        ),
+        component="ai",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_FACT_FORCING",
+        type=bool,
+        default=False,
+        description=(
+            "Enable the fact-forcing gate, which requires an answer to cite retrieved "
+            "facts."
+        ),
+        component="ai",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_INJECTION_HARDBLOCK_ENABLED",
+        type=bool,
+        default=False,
+        description=(
+            "Hard-block prompt injection rather than only flagging it. When on and "
+            "confidence clears the threshold, the request is refused instead of annotated."
+        ),
+        component="auth",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_INJECTION_HARDBLOCK_THRESHOLD",
+        type=float,
+        default=0.75,
+        description=(
+            "Confidence in [0.0, 1.0] at or above which a detected injection is "
+            "hard-blocked. 0.75 maps to HIGH; 1.0 would block only CRITICAL."
+        ),
+        component="auth",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_LLM_TOKEN_BUDGET_PER_RUN",
+        type=int,
+        default=0,
+        description=(
+            "Cumulative token ceiling (input plus output) for one run. Zero disables the "
+            "gate, which is the shipped default (#11541)."
+        ),
+        component="ai",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_LLM_TOKEN_BUDGET_TTL_SECONDS",
+        type=int,
+        default=86400,
+        description=(
+            "Seconds a run's cumulative token counter survives in Redis, bounding memory "
+            "for abandoned sessions. Refreshed on every increment."
+        ),
+        component="ai",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_MAX_DELEGATIONS_PER_TURN",
+        type=int,
+        default=5,
+        description=(
+            "Delegate calls allowed in a single LLM turn — a fan-out bound, not a quality "
+            "setting."
+        ),
+        component="ai",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_MAX_DELEGATION_DEPTH",
+        type=int,
+        default=2,
+        description=(
+            "How deep delegation may nest before it is refused, bounding runaway recursive "
+            "delegation."
+        ),
+        component="ai",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_OWNERSHIP_BLAME_TIMEOUT_SECONDS",
+        type=float,
+        default=10.0,
+        description=(
+            "Seconds a single `git blame` may take during ownership analysis. Must stay "
+            "below the whole-analysis budget, which a previous 30s value exceeded (#13602)."
+        ),
+        component="backend",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_OWNERSHIP_BUDGET_SECONDS",
+        type=float,
+        default=20.0,
+        description=(
+            "Total seconds ownership analysis may spend blaming files before it returns "
+            "what it has (#13602)."
+        ),
+        component="backend",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_OWNERSHIP_MAX_FILES",
+        type=int,
+        default=2000,
+        description=(
+            "How many files ownership analysis will blame. Paired with the time budget "
+            "because a file count alone is the wrong bound — file size dominates blame cost "
+            "(#13602)."
+        ),
+        component="backend",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_PLAN_BEST_OF_N_COUNT",
+        type=int,
+        default=3,
+        description=(
+            "How many candidate plans best-of-N generates before selection. Clamped to a "
+            "minimum of 2, since best-of-1 is not a selection."
+        ),
+        component="ai",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_PROVIDER_DEGRADATION_TTL_SECONDS",
+        type=int,
+        default=300,
+        description=(
+            "Seconds a provider stays marked degraded after a failure before traffic is "
+            "offered to it again."
+        ),
+        component="ai",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_SKILL_DISTILLATION_ENABLED",
+        type=bool,
+        default=False,
+        description=(
+            "Master switch for skill distillation. Ships inert — enable once the LLM cost "
+            "of a recurring pass is accepted."
+        ),
+        component="backend",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_SKILL_DISTILLATION_IDLE_FLUSH_S",
+        type=int,
+        default=900,
+        description=(
+            "Seconds of corpus idleness after which a distillation pass runs early. Without "
+            "it the pass is purely clock-bound and a conversation ending at 09:00 waits for "
+            "the small hours (#13695)."
+        ),
+        component="backend",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_SKILL_DISTILLATION_INTERVAL_S",
+        type=int,
+        default=3600,
+        description=(
+            "Seconds between skill distillation passes."
+        ),
+        component="backend",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_SKILL_DISTILLATION_MAX_SESSIONS",
+        type=int,
+        default=10,
+        description=(
+            "Conversations distilled per pass. Bounds the LLM spend of any one run; the "
+            "remainder is picked up next time because the cursor only advances over what "
+            "was handled."
+        ),
+        component="backend",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_SKILL_DISTILLATION_MIN_MESSAGES",
+        type=int,
+        default=4,
+        description=(
+            "Minimum messages a conversation needs before distillation attempts it. Shorter "
+            "ones cannot contain a reusable workflow and the extractor rejects them anyway."
+        ),
+        component="backend",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_STT_PEAK_WINDOW_MS",
+        type=int,
+        default=100,
+        description=(
+            "Window in milliseconds over which speech energy is measured. Measuring across "
+            "the whole buffer averages a short reply into silence (#13104)."
+        ),
+        component="voice",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_TRAJECTORY_CONSOLIDATE_SCAN_LIMIT",
+        type=int,
+        default=50000,
+        description=(
+            "Rows a consolidation pass may scan, keeping the pass bounded on a large "
+            "trajectory store."
+        ),
+        component="ai",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_TRAJECTORY_OUTCOME_PARTIAL_MIN",
+        type=float,
+        default=0.4,
+        description=(
+            "Reward at or above which a trajectory outcome is 'partial'. Below it the "
+            "outcome is a failure (#11280)."
+        ),
+        component="ai",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_TRAJECTORY_OUTCOME_SUCCESS_MIN",
+        type=float,
+        default=0.7,
+        description=(
+            "Reward at or above which a trajectory outcome is 'success'. The canonical "
+            "threshold, so callers stop re-deriving it inline (#11280)."
+        ),
+        component="ai",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_TRAJECTORY_PRUNE_MAX_AGE_DAYS",
+        type=int,
+        default=30,
+        description=(
+            "Age in days beyond which a low-reward trajectory is eligible for pruning "
+            "(#11263)."
+        ),
+        component="ai",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_TRAJECTORY_PRUNE_REWARD_FLOOR",
+        type=float,
+        default=0.4,
+        description=(
+            "Reward below which an aged trajectory is pruned. Stale low-reward failures are "
+            "noise that costs retrieval precision (#11263)."
+        ),
+        component="ai",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_TRAJECTORY_USER_SCOPED",
+        type=bool,
+        default=True,
+        description=(
+            "Scope trajectory retrieval by user as well as tenant. tenant_id alone is "
+            "insufficient in single-company deployments where org_id is empty or identical "
+            "for everyone (#11089)."
+        ),
+        component="ai",
+    )
+)
+

--- a/autobot_shared/env_registry.py
+++ b/autobot_shared/env_registry.py
@@ -1095,10 +1095,7 @@ register_env_var(
         name="AUTOBOT_CHAT_TRAJECTORY_CAPTURE_CONCURRENCY",
         type=int,
         default=2,
-        description=(
-            "Concurrent trajectory judge calls. Bounded so a burst of turns cannot stampede "
-            "the LLM."
-        ),
+        description=("Concurrent trajectory judge calls. Bounded so a burst of turns cannot stampede " "the LLM."),
         component="ai",
     )
 )
@@ -1134,9 +1131,7 @@ register_env_var(
         name="AUTOBOT_CHAT_TRAJECTORY_TOP_K",
         type=int,
         default=3,
-        description=(
-            "How many past trajectories the pre-answer search retrieves."
-        ),
+        description=("How many past trajectories the pre-answer search retrieves."),
         component="ai",
     )
 )
@@ -1146,9 +1141,7 @@ register_env_var(
         name="AUTOBOT_COCHANGE_GIT_TIMEOUT_SECONDS",
         type=int,
         default=120,
-        description=(
-            "Seconds the co-change history walk may run before it is abandoned."
-        ),
+        description=("Seconds the co-change history walk may run before it is abandoned."),
         component="backend",
     )
 )
@@ -1211,9 +1204,7 @@ register_env_var(
         name="AUTOBOT_CODEEXEC_APPROVAL_POLL_SECONDS",
         type=int,
         default=2,
-        description=(
-            "Seconds between polls while waiting for a code-execution approval decision."
-        ),
+        description=("Seconds between polls while waiting for a code-execution approval decision."),
         component="execution",
     )
 )
@@ -1250,9 +1241,7 @@ register_env_var(
         name="AUTOBOT_CODEEXEC_ENABLED",
         type=bool,
         default=False,
-        description=(
-            "Master switch for the compose/code-execution tool. Ships off (GH#11568)."
-        ),
+        description=("Master switch for the compose/code-execution tool. Ships off (GH#11568)."),
         component="execution",
     )
 )
@@ -1262,10 +1251,7 @@ register_env_var(
         name="AUTOBOT_CODEEXEC_MAX_SCRIPT_RETRIES",
         type=int,
         default=1,
-        description=(
-            "How many times a failed generated script may be retried within one "
-            "code-execution call."
-        ),
+        description=("How many times a failed generated script may be retried within one " "code-execution call."),
         component="execution",
     )
 )
@@ -1288,9 +1274,7 @@ register_env_var(
         name="AUTOBOT_CODEEXEC_TIMEOUT_SECONDS",
         type=int,
         default=120,
-        description=(
-            "Seconds a compose-tool sandbox execution may run (GH#11568)."
-        ),
+        description=("Seconds a compose-tool sandbox execution may run (GH#11568)."),
         component="execution",
     )
 )
@@ -1301,8 +1285,7 @@ register_env_var(
         type=bool,
         default=False,
         description=(
-            "Master switch for the delegate tool. Off, it records the delegation request "
-            "and does not dispatch it."
+            "Master switch for the delegate tool. Off, it records the delegation request " "and does not dispatch it."
         ),
         component="ai",
     )
@@ -1313,10 +1296,7 @@ register_env_var(
         name="AUTOBOT_FACT_FORCING",
         type=bool,
         default=False,
-        description=(
-            "Enable the fact-forcing gate, which requires an answer to cite retrieved "
-            "facts."
-        ),
+        description=("Enable the fact-forcing gate, which requires an answer to cite retrieved " "facts."),
         component="ai",
     )
 )
@@ -1378,10 +1358,7 @@ register_env_var(
         name="AUTOBOT_MAX_DELEGATIONS_PER_TURN",
         type=int,
         default=5,
-        description=(
-            "Delegate calls allowed in a single LLM turn — a fan-out bound, not a quality "
-            "setting."
-        ),
+        description=("Delegate calls allowed in a single LLM turn — a fan-out bound, not a quality " "setting."),
         component="ai",
     )
 )
@@ -1391,10 +1368,7 @@ register_env_var(
         name="AUTOBOT_MAX_DELEGATION_DEPTH",
         type=int,
         default=2,
-        description=(
-            "How deep delegation may nest before it is refused, bounding runaway recursive "
-            "delegation."
-        ),
+        description=("How deep delegation may nest before it is refused, bounding runaway recursive " "delegation."),
         component="ai",
     )
 )
@@ -1418,8 +1392,7 @@ register_env_var(
         type=float,
         default=20.0,
         description=(
-            "Total seconds ownership analysis may spend blaming files before it returns "
-            "what it has (#13602)."
+            "Total seconds ownership analysis may spend blaming files before it returns " "what it has (#13602)."
         ),
         component="backend",
     )
@@ -1458,8 +1431,7 @@ register_env_var(
         type=int,
         default=300,
         description=(
-            "Seconds a provider stays marked degraded after a failure before traffic is "
-            "offered to it again."
+            "Seconds a provider stays marked degraded after a failure before traffic is " "offered to it again."
         ),
         component="ai",
     )
@@ -1497,9 +1469,7 @@ register_env_var(
         name="AUTOBOT_SKILL_DISTILLATION_INTERVAL_S",
         type=int,
         default=3600,
-        description=(
-            "Seconds between skill distillation passes."
-        ),
+        description=("Seconds between skill distillation passes."),
         component="backend",
     )
 )
@@ -1549,10 +1519,7 @@ register_env_var(
         name="AUTOBOT_TRAJECTORY_CONSOLIDATE_SCAN_LIMIT",
         type=int,
         default=50000,
-        description=(
-            "Rows a consolidation pass may scan, keeping the pass bounded on a large "
-            "trajectory store."
-        ),
+        description=("Rows a consolidation pass may scan, keeping the pass bounded on a large " "trajectory store."),
         component="ai",
     )
 )
@@ -1563,8 +1530,7 @@ register_env_var(
         type=float,
         default=0.4,
         description=(
-            "Reward at or above which a trajectory outcome is 'partial'. Below it the "
-            "outcome is a failure (#11280)."
+            "Reward at or above which a trajectory outcome is 'partial'. Below it the " "outcome is a failure (#11280)."
         ),
         component="ai",
     )
@@ -1588,10 +1554,7 @@ register_env_var(
         name="AUTOBOT_TRAJECTORY_PRUNE_MAX_AGE_DAYS",
         type=int,
         default=30,
-        description=(
-            "Age in days beyond which a low-reward trajectory is eligible for pruning "
-            "(#11263)."
-        ),
+        description=("Age in days beyond which a low-reward trajectory is eligible for pruning " "(#11263)."),
         component="ai",
     )
 )
@@ -1622,4 +1585,3 @@ register_env_var(
         component="ai",
     )
 )
-

--- a/docs/developer/CLAUDE_RULES.md
+++ b/docs/developer/CLAUDE_RULES.md
@@ -437,15 +437,35 @@ To add a new variable:
 <!-- BEGIN_AUTOGEN_ENV_DOCS -->
 | Name | Component | Type | Default | Description |
 |---|---|---|---|---|
+| `AUTOBOT_ALLOW_CONFIG_EDITS` | system | bool | false | Permit writes to the repository's tracked config files. Off by default: the codebase is the source of truth and an edit made here is invisible to deployment (#11220). |
+| `AUTOBOT_APPROVAL_PENDING_SESSION_TTL_SECONDS` | execution | int | `604800` | Seconds a session holding a pending approval survives in Redis. Deliberately long — what it waits for is a person, and expiring sooner discards the approval rather than the wait (#13478). |
 | `AUTOBOT_AUDIT_MAX_DEFERRED` | backend | int | `10000` | Ceiling on audit records held in the deferred queue when the sink is unavailable. Beyond it the oldest are dropped, bounding memory rather than letting an outage grow it without limit. |
 | `AUTOBOT_BACKEND_HOST` | backend | str | `'10.0.0.1'` | Hostname or IP address of the AutoBot backend service. |
 | `AUTOBOT_BACKEND_PORT` | backend | str | `'8001'` | TCP port of the AutoBot backend service. |
 | `AUTOBOT_BACKEND_URL` | backend | str | `'http://10.255.255.254:8001'` | Full base URL of the AutoBot backend service (overrides HOST+PORT). |
+| `AUTOBOT_BROWSER_STATE_PROMPT_MAX_ELEMENTS` | backend | int | `30` | How many numbered elements the LLM-visible state block renders per browser tool result. The browser worker caps the raw list separately; this bounds only what reaches the prompt (#11537). |
 | `AUTOBOT_CHATS_DIRECTORY` | chat | str | `'data/chats'` | Filesystem path where chat session files are stored. |
+| `AUTOBOT_CHAT_TRAJECTORY_CAPTURE_CONCURRENCY` | ai | int | `2` | Concurrent trajectory judge calls. Bounded so a burst of turns cannot stampede the LLM. |
+| `AUTOBOT_CHAT_TRAJECTORY_CONTEXT` | ai | bool | true | Search past trajectories before answering. Defaults on because the search is one vector query; capture is gated separately since it spends a judge call. |
+| `AUTOBOT_CHAT_TRAJECTORY_TIMEOUT_S` | ai | float | `0.15` | Seconds the pre-answer trajectory search may take. It rides the response hot path, so a cold or slow collection must never delay first token. |
+| `AUTOBOT_CHAT_TRAJECTORY_TOP_K` | ai | int | `3` | How many past trajectories the pre-answer search retrieves. |
 | `AUTOBOT_CLASSIFICATION_MODEL` | ai | str | `'gemma2:2b'` | Ollama model name used for intent classification. |
+| `AUTOBOT_COCHANGE_GIT_TIMEOUT_SECONDS` | backend | int | `120` | Seconds the co-change history walk may run before it is abandoned. |
+| `AUTOBOT_COCHANGE_MAX_FILES_PER_COMMIT` | backend | int | `50` | Commits touching more files than this are ignored as coupling evidence: a bulk rename, a vendored-tree import or a reformat is not a signal (#13639). |
+| `AUTOBOT_COCHANGE_MIN_CO_CHANGES` | backend | int | `3` | How many commits two files must share before the pair is reported at all. One shared commit is a coincidence. |
+| `AUTOBOT_COCHANGE_STRENGTH_THRESHOLD` | backend | float | `0.3` | Minimum normalised coupling strength to report. Independent of the count threshold: a pair can clear the count and still be weak if either file changes constantly. |
+| `AUTOBOT_COCHANGE_WINDOW_DAYS` | backend | int | `180` | Days of history the co-change analysis considers. Coupling decays — a pair that moved together two years ago is history, not structure. |
+| `AUTOBOT_CODEEXEC_APPROVAL_POLL_SECONDS` | execution | int | `2` | Seconds between polls while waiting for a code-execution approval decision. |
+| `AUTOBOT_CODEEXEC_APPROVAL_WAIT_SECONDS` | execution | int | `1800` | Seconds a code-execution request waits for approval before expiring. Expiry is a decision the caller can act on, not a side effect of how long a coroutine lives (GH#11568). |
+| `AUTOBOT_CODEEXEC_AUTOAPPROVE_READONLY` | execution | bool | true | Auto-approve code-execution calls limited to the read-only tool set. The eligible set is fixed in code, not configurable here (GH#11568, GH#11662). |
+| `AUTOBOT_CODEEXEC_ENABLED` | execution | bool | false | Master switch for the compose/code-execution tool. Ships off (GH#11568). |
+| `AUTOBOT_CODEEXEC_MAX_SCRIPT_RETRIES` | execution | int | `1` | How many times a failed generated script may be retried within one code-execution call. |
+| `AUTOBOT_CODEEXEC_MAX_TOOL_CALLS` | execution | int | `50` | Ceiling on tool calls a single code-execution script may make, bounding a runaway loop inside the sandbox. |
+| `AUTOBOT_CODEEXEC_TIMEOUT_SECONDS` | execution | int | `120` | Seconds a compose-tool sandbox execution may run (GH#11568). |
 | `AUTOBOT_CODE_ANALYSIS_POOL_MAX_TASKS` | backend | int | `8` | Tasks a code-analysis child handles before it is recycled. Recycling bounds memory growth in long-lived children. |
 | `AUTOBOT_CODE_ANALYSIS_POOL_WORKERS` | backend | int | `2` | Child processes used to offload code analysis. Deliberately small: each carries a full interpreter, and analysis is bursty rather than sustained. |
 | `AUTOBOT_CONFIG_REGISTRY_REDIS_RETRY_SECONDS` | redis | float | `30.0` | Interval between config-registry attempts to reconnect to Redis after a failure, so a Redis outage does not become a reconnect storm. |
+| `AUTOBOT_DELEGATION_ENABLED` | ai | bool | false | Master switch for the delegate tool. Off, it records the delegation request and does not dispatch it. |
 | `AUTOBOT_DEPLOYMENT_MODE` | system | str | `'distributed'` | Deployment topology: 'distributed' or 'standalone'. |
 | `AUTOBOT_DEVICE_POLL_BACKOFF_SECONDS` | auth | int | `5` | Extra delay added to the device-code poll interval after the provider answers `slow_down`. |
 | `AUTOBOT_DEVICE_POLL_MAX_ATTEMPTS` | auth | int | `360` | Maximum device-code poll attempts before the flow is abandoned. Bounds the poll loop independently of the time window below. |
@@ -455,18 +475,25 @@ To add a new variable:
 | `AUTOBOT_DOCKER_USE_POOL` | execution | bool | false | Reuse a pool of warm containers for tool execution instead of starting one per call. Off by default — the pool trades isolation between calls for start-up latency. |
 | `AUTOBOT_ENV` | system | str | `'production'` | Short environment label used in logs and traces (e.g. 'development', 'production'). |
 | `AUTOBOT_ENVIRONMENT` | system | str | `'development'` | Full environment name for OTel deployment.environment attribute. Prefer AUTOBOT_ENV for new code. |
+| `AUTOBOT_FACT_FORCING` | ai | bool | false | Enable the fact-forcing gate, which requires an answer to cite retrieved facts. |
 | `AUTOBOT_GIT_BRANCH` | system | str | `'Dev_new_gui'` | Git branch that the running instance was built from. |
 | `AUTOBOT_GRAFANA_PORT` | monitoring | str | `'3000'` | TCP port of the Grafana instance. Also declared in ssot_config.py; 3000 is Grafana's own default and is NOT the browser service, which is 9001 (#4052, #14198). |
 | `AUTOBOT_GRAPH_PATH_TIMEOUT_SECONDS` | kb | float | `10.0` | Ceiling on a knowledge-graph path search. Path queries are unbounded in the worst case, so this is what stops one request occupying a worker indefinitely. |
 | `AUTOBOT_IMESSAGE_ENABLED` | gateway | bool | false | Opt in to the iMessage gateway adapter. Off by default: it is macOS-only and needs Full Disk Access to the Messages database. |
+| `AUTOBOT_INJECTION_HARDBLOCK_ENABLED` | auth | bool | false | Hard-block prompt injection rather than only flagging it. When on and confidence clears the threshold, the request is refused instead of annotated. |
+| `AUTOBOT_INJECTION_HARDBLOCK_THRESHOLD` | auth | float | `0.75` | Confidence in [0.0, 1.0] at or above which a detected injection is hard-blocked. 0.75 maps to HIGH; 1.0 would block only CRITICAL. |
 | `AUTOBOT_INTERNAL_API_KEY` | auth | str | `""` | Shared secret used to authenticate internal service-to-service calls. |
 | `AUTOBOT_KB_TIMEOUT` | kb | int | `30` | Timeout in seconds for knowledge-base HTTP requests. Range: 1–300. |
 | `AUTOBOT_LLC_H2A_BRIEF_CACHE_TTL` | orchestrator | int | `86400` | Cache lifetime in seconds for a human-to-agent handoff brief (llc/services/handoff.py). One day. |
 | `AUTOBOT_LLM_MAX_RETRY_AFTER_SECONDS` | ai | float | `30.0` | Cap applied to a provider's `Retry-After`. Without it a provider advertising a long back-off would stall a request for that whole period (services/llm_service.py). |
+| `AUTOBOT_LLM_TOKEN_BUDGET_PER_RUN` | ai | int | `0` | Cumulative token ceiling (input plus output) for one run. Zero disables the gate, which is the shipped default (#11541). |
+| `AUTOBOT_LLM_TOKEN_BUDGET_TTL_SECONDS` | ai | int | `86400` | Seconds a run's cumulative token counter survives in Redis, bounding memory for abandoned sessions. Refreshed on every increment. |
 | `AUTOBOT_LOGS_BACKUP_DIR` | logging | str | `'backup'` | Directory where rotated log archives are written. |
 | `AUTOBOT_LOGS_DIR` | logging | str | `'logs'` | Primary directory for application log files. |
 | `AUTOBOT_LOG_VIEWER_URL` | logging | str | `'http://localhost:5341'` | Base URL of the Seq (or compatible) structured-log viewer. |
 | `AUTOBOT_MATRIX_E2EE` | gateway | bool | false | Opt in to end-to-end encryption for the Matrix adapter. Off by default because E2EE needs the optional olm dependency and a persisted device store. |
+| `AUTOBOT_MAX_DELEGATIONS_PER_TURN` | ai | int | `5` | Delegate calls allowed in a single LLM turn — a fan-out bound, not a quality setting. |
+| `AUTOBOT_MAX_DELEGATION_DEPTH` | ai | int | `2` | How deep delegation may nest before it is refused, bounding runaway recursive delegation. |
 | `AUTOBOT_MULTIMODAL_VOICE_CONFIDENCE_THRESHOLD` | voice | float | `0.7` | Fallback confidence threshold for VoiceProcessor when the multimodal.voice config section omits it (#13207). Range: 0.0–1.0. |
 | `AUTOBOT_MULTIMODAL_VOICE_PROCESSING_TIMEOUT` | voice | int | `30` | Fallback processing timeout in seconds for VoiceProcessor when the multimodal.voice config section omits it (#13207). |
 | `AUTOBOT_OAUTH_REFRESH_LOCK_TTL_MS` | auth | int | `90000` | Milliseconds a connector holds the single-flight lock while refreshing an OAuth token. Derived as three times the token request timeout — 90000 with the default 30s timeout — so it tracks that timeout instead of drifting from it (knowledge/connectors/credential_store.py). This variable can only RAISE it: a smaller value is floored back to the derived TTL and a warning is logged, because the lease is held across the store write as well as the HTTP call, and one that expires mid-refresh lets two workers rotate the same token (#14238). |
@@ -480,6 +507,10 @@ To add a new variable:
 | `AUTOBOT_OTEL_PROTOCOL` | otel | str | `'grpc'` | OTLP export protocol: 'grpc' or 'http/protobuf'. |
 | `AUTOBOT_OTEL_SAMPLE_RATE` | otel | float | `0.1` | Fraction of traces to sample (0.0–1.0). Range: 0.0–1.0. |
 | `AUTOBOT_OTEL_SERVICE_VERSION` | otel | str | `'1.5.0'` | Service version tag attached to all OTel spans. |
+| `AUTOBOT_OWNERSHIP_BLAME_TIMEOUT_SECONDS` | backend | float | `10.0` | Seconds a single `git blame` may take during ownership analysis. Must stay below the whole-analysis budget, which a previous 30s value exceeded (#13602). |
+| `AUTOBOT_OWNERSHIP_BUDGET_SECONDS` | backend | float | `20.0` | Total seconds ownership analysis may spend blaming files before it returns what it has (#13602). |
+| `AUTOBOT_OWNERSHIP_MAX_FILES` | backend | int | `2000` | How many files ownership analysis will blame. Paired with the time budget because a file count alone is the wrong bound — file size dominates blame cost (#13602). |
+| `AUTOBOT_PLAN_BEST_OF_N_COUNT` | ai | int | `3` | How many candidate plans best-of-N generates before selection. Clamped to a minimum of 2, since best-of-1 is not a selection. |
 | `AUTOBOT_POSTGRES_DB` | postgres | str | `'autobot_users'` | PostgreSQL database name. |
 | `AUTOBOT_POSTGRES_HOST` | postgres | str | `'127.0.0.1'` | PostgreSQL server hostname or IP. |
 | `AUTOBOT_POSTGRES_PASSWORD` | postgres | str | `""` | PostgreSQL user password. |
@@ -487,6 +518,7 @@ To add a new variable:
 | `AUTOBOT_POSTGRES_USER` | postgres | str | `'slm_app'` | PostgreSQL login role. |
 | `AUTOBOT_PROMETHEUS_PORT` | monitoring | str | `'9090'` | TCP port of the Prometheus instance. Also declared in ssot_config.py. |
 | `AUTOBOT_PROMETHEUS_URL` | monitoring | str | `'http://10.0.0.4:9090'` | Base URL of the Prometheus metrics server. |
+| `AUTOBOT_PROVIDER_DEGRADATION_TTL_SECONDS` | ai | int | `300` | Seconds a provider stays marked degraded after a failure before traffic is offered to it again. |
 | `AUTOBOT_PROVIDER_OAUTH_STATE_TTL_SECONDS` | auth | int | `600` | Lifetime of a pending OAuth `state` value. A provider authorisation that is not completed within this window is rejected as expired (api/provider_auth.py). |
 | `AUTOBOT_REDIS_DB_ANALYTICS` | redis | int | `11` | Redis logical database number for analytics data. Range: 0–15. |
 | `AUTOBOT_REDIS_DB_KNOWLEDGE` | redis | int | `1` | Redis logical database number for knowledge-base vectors. Range: 0–15. |
@@ -500,21 +532,33 @@ To add a new variable:
 | `AUTOBOT_RETRIEVAL_REDIS_TIMEOUT` | redis | float | `1.5` | Seconds the retrieval learner waits for its Redis lock before proceeding without it. Short on purpose — retrieval must answer even when the learner cannot record what it learned. |
 | `AUTOBOT_SHOW_DEPRECATION_WARNINGS` | system | bool | false | Emit Python DeprecationWarnings for deprecated AutoBot APIs when truthy. |
 | `AUTOBOT_SIGNAL_ENABLED` | gateway | bool | false | Opt in to the Signal gateway adapter. Off by default: it needs a running signal-cli daemon and a registered number. |
+| `AUTOBOT_SKILL_DISTILLATION_ENABLED` | backend | bool | false | Master switch for skill distillation. Ships inert — enable once the LLM cost of a recurring pass is accepted. |
 | `AUTOBOT_SKILL_DISTILLATION_FAILURE_TTL_S` | backend | int | `86400` | How long a conversation's consecutive-failure count survives, in seconds. Derived as 24 distillation intervals, so failures accumulate across passes rather than expiring between them, while a counter for a conversation nobody retries eventually clears instead of accumulating forever (#14255). |
+| `AUTOBOT_SKILL_DISTILLATION_IDLE_FLUSH_S` | backend | int | `900` | Seconds of corpus idleness after which a distillation pass runs early. Without it the pass is purely clock-bound and a conversation ending at 09:00 waits for the small hours (#13695). |
+| `AUTOBOT_SKILL_DISTILLATION_INTERVAL_S` | backend | int | `3600` | Seconds between skill distillation passes. |
 | `AUTOBOT_SKILL_DISTILLATION_MAX_FAILURES` | backend | int | `3` | Consecutive failures on the SAME conversation before the distillation pass stops waiting for it and moves on. Below this the pass halts and retries next run, so a transient fault costs nothing; at it, the conversation is quarantined with a warning and the cursor advances, so one unreadable conversation cannot starve every newer one behind it in an oldest-first queue (#14255). A success resets the count. |
+| `AUTOBOT_SKILL_DISTILLATION_MAX_SESSIONS` | backend | int | `10` | Conversations distilled per pass. Bounds the LLM spend of any one run; the remainder is picked up next time because the cursor only advances over what was handled. |
+| `AUTOBOT_SKILL_DISTILLATION_MIN_MESSAGES` | backend | int | `4` | Minimum messages a conversation needs before distillation attempts it. Shorter ones cannot contain a reusable workflow and the extractor rejects them anyway. |
 | `AUTOBOT_SNAPSHOT_STORAGE_PATH` | execution | str | `""` | Directory holding execution snapshots. Empty means 'derive it' — the default is `<project root>/snapshots`, so it follows the install location rather than being pinned to one path. |
 | `AUTOBOT_SNAPSHOT_TTL_DAYS` | execution | int | `7` | Age at which the cleanup task removes an execution snapshot. Snapshots are a debugging aid, so the default is deliberately short. |
 | `AUTOBOT_STT_NO_SPEECH_PROB_THRESHOLD` | voice | float | `0.8` | Decoder no-speech probability at or above which an STT transcript is discarded as a silence hallucination (#13104). Range: 0.0–1.0. |
+| `AUTOBOT_STT_PEAK_WINDOW_MS` | voice | int | `100` | Window in milliseconds over which speech energy is measured. Measuring across the whole buffer averages a short reply into silence (#13104). |
 | `AUTOBOT_STT_SILENCE_RMS_THRESHOLD` | voice | float | `0.005` | Audio RMS below which the waveform is treated as silence, so any STT transcript over it is a hallucination rather than a user turn (#13104). Range: 0.0–1.0. |
 | `AUTOBOT_SUMMARY_FAILURE_BACKOFF_SECONDS` | chat | int | `300` | Quiet period after a context-overflow summarisation failure before another is attempted, so a persistently failing summary does not retry on every turn. |
 | `AUTOBOT_TLS_CA_PATH` | tls | str | *(none)* | Path to the CA certificate file for TLS verification. |
 | `AUTOBOT_TLS_CERT_DIR` | tls | str | `'/etc/autobot/certs'` | Directory containing TLS certificate and key files. |
 | `AUTOBOT_TLS_CERT_PATH` | tls | str | *(none)* | Path to the TLS client/server certificate file. |
 | `AUTOBOT_TLS_KEY_PATH` | tls | str | *(none)* | Path to the TLS private key file. |
+| `AUTOBOT_TRAJECTORY_CONSOLIDATE_SCAN_LIMIT` | ai | int | `50000` | Rows a consolidation pass may scan, keeping the pass bounded on a large trajectory store. |
+| `AUTOBOT_TRAJECTORY_OUTCOME_PARTIAL_MIN` | ai | float | `0.4` | Reward at or above which a trajectory outcome is 'partial'. Below it the outcome is a failure (#11280). |
+| `AUTOBOT_TRAJECTORY_OUTCOME_SUCCESS_MIN` | ai | float | `0.7` | Reward at or above which a trajectory outcome is 'success'. The canonical threshold, so callers stop re-deriving it inline (#11280). |
+| `AUTOBOT_TRAJECTORY_PRUNE_MAX_AGE_DAYS` | ai | int | `30` | Age in days beyond which a low-reward trajectory is eligible for pruning (#11263). |
+| `AUTOBOT_TRAJECTORY_PRUNE_REWARD_FLOOR` | ai | float | `0.4` | Reward below which an aged trajectory is pruned. Stale low-reward failures are noise that costs retrieval precision (#11263). |
+| `AUTOBOT_TRAJECTORY_USER_SCOPED` | ai | bool | true | Scope trajectory retrieval by user as well as tenant. tenant_id alone is insufficient in single-company deployments where org_id is empty or identical for everyone (#11089). |
 | `AUTOBOT_TRANSCRIBER_DB_PATH` | voice | str | `'data/transcriber.db'` | SQLite database backing the transcriber. Relative to the working directory unless given as an absolute path. |
 | `AUTOBOT_TRUSTED_PROXIES` | network | str | `""` | Comma-separated list of trusted reverse-proxy IP addresses or CIDR ranges for X-Forwarded-For header trust. |
 | `AUTOBOT_USERS_DATABASE_URL` | postgres | str | *(none)* | Full SQLAlchemy connection URL for the users database. Overrides AUTOBOT_POSTGRES_* individual vars when set. |
 | `AUTOBOT_VOICE_TOOLSETS` | voice | str | `'voice_safe'` | Comma-separated toolset bundles a voice session may call. Defaults to the restricted `voice_safe` bundle — voice input is harder to confirm than typed input, so the surface is narrowed by default. |
 
-*78 variables registered as of last generation.*
+*122 variables registered as of last generation.*
 <!-- END_AUTOGEN_ENV_DOCS -->

--- a/pipeline-scripts/check_env_var_registry.py
+++ b/pipeline-scripts/check_env_var_registry.py
@@ -238,64 +238,15 @@ def check_docs_freshness() -> list[str]:
 # ---------------------------------------------------------------------------
 
 
-# #14265: variables the checker could not see until it learned the env_utils
-# helpers. Registering all 45 at once means guessing 45 defaults and writing
-# 45 descriptions in one pass -- the way to get a registry that is complete
-# and wrong. They are listed here instead, so a NEW unregistered variable fails
-# immediately while the backlog stays visible and countable.
+# #14265: this held the 45 variables the checker could not see until it learned
+# the env_utils helper form. All of them are now registered, and the two that
+# were test fixtures are exempt by rule rather than by listing, so the set is
+# EMPTY — which is the state it was always meant to reach.
 #
-# This is a CEILING, not a permit. `_assert_baseline_only_shrinks` fails if the
-# list grows, because a grandfather list with no upper bound is how a temporary
-# exemption becomes permanent (#14236).
-_UNREGISTERED_BASELINE: frozenset[str] = frozenset(
-    {
-        "AUTOBOT_ALLOW_CONFIG_EDITS",
-        "AUTOBOT_APPROVAL_PENDING_SESSION_TTL_SECONDS",
-        "AUTOBOT_BROWSER_STATE_PROMPT_MAX_ELEMENTS",
-        "AUTOBOT_CHAT_TRAJECTORY_CAPTURE_CONCURRENCY",
-        "AUTOBOT_CHAT_TRAJECTORY_CONTEXT",
-        "AUTOBOT_CHAT_TRAJECTORY_TIMEOUT_S",
-        "AUTOBOT_CHAT_TRAJECTORY_TOP_K",
-        "AUTOBOT_COCHANGE_GIT_TIMEOUT_SECONDS",
-        "AUTOBOT_COCHANGE_MAX_FILES_PER_COMMIT",
-        "AUTOBOT_COCHANGE_MIN_CO_CHANGES",
-        "AUTOBOT_COCHANGE_STRENGTH_THRESHOLD",
-        "AUTOBOT_COCHANGE_WINDOW_DAYS",
-        "AUTOBOT_CODEEXEC_APPROVAL_POLL_SECONDS",
-        "AUTOBOT_CODEEXEC_APPROVAL_WAIT_SECONDS",
-        "AUTOBOT_CODEEXEC_AUTOAPPROVE_READONLY",
-        "AUTOBOT_CODEEXEC_ENABLED",
-        "AUTOBOT_CODEEXEC_MAX_SCRIPT_RETRIES",
-        "AUTOBOT_CODEEXEC_MAX_TOOL_CALLS",
-        "AUTOBOT_CODEEXEC_TIMEOUT_SECONDS",
-        "AUTOBOT_DELEGATION_ENABLED",
-        "AUTOBOT_FACT_FORCING",
-        "AUTOBOT_INJECTION_HARDBLOCK_ENABLED",
-        "AUTOBOT_INJECTION_HARDBLOCK_THRESHOLD",
-        "AUTOBOT_LLM_TOKEN_BUDGET_PER_RUN",
-        "AUTOBOT_LLM_TOKEN_BUDGET_TTL_SECONDS",
-        "AUTOBOT_MAX_DELEGATIONS_PER_TURN",
-        "AUTOBOT_MAX_DELEGATION_DEPTH",
-        "AUTOBOT_OWNERSHIP_BLAME_TIMEOUT_SECONDS",
-        "AUTOBOT_OWNERSHIP_BUDGET_SECONDS",
-        "AUTOBOT_OWNERSHIP_MAX_FILES",
-        "AUTOBOT_PLAN_BEST_OF_N_COUNT",
-        "AUTOBOT_PROVIDER_DEGRADATION_TTL_SECONDS",
-        "AUTOBOT_SKILL_DISTILLATION_ENABLED",
-        "AUTOBOT_SKILL_DISTILLATION_IDLE_FLUSH_S",
-        "AUTOBOT_SKILL_DISTILLATION_INTERVAL_S",
-        "AUTOBOT_SKILL_DISTILLATION_MAX_SESSIONS",
-        "AUTOBOT_SKILL_DISTILLATION_MIN_MESSAGES",
-        "AUTOBOT_STT_PEAK_WINDOW_MS",
-        "AUTOBOT_TEST_FLAG_XYZ",
-        "AUTOBOT_TRAJECTORY_CONSOLIDATE_SCAN_LIMIT",
-        "AUTOBOT_TRAJECTORY_OUTCOME_PARTIAL_MIN",
-        "AUTOBOT_TRAJECTORY_OUTCOME_SUCCESS_MIN",
-        "AUTOBOT_TRAJECTORY_PRUNE_MAX_AGE_DAYS",
-        "AUTOBOT_TRAJECTORY_PRUNE_REWARD_FLOOR",
-        "AUTOBOT_TRAJECTORY_USER_SCOPED",
-    }
-)
+# Kept rather than deleted: `_stale_baseline_entries` still runs against it, so
+# the next time someone needs a temporary exemption there is a ceiling with a
+# shrink check already attached, instead of a fresh list with neither.
+_UNREGISTERED_BASELINE: frozenset[str] = frozenset()
 
 
 def _stale_baseline_entries() -> list[str]:

--- a/pipeline-scripts/check_env_var_registry_helpers_test.py
+++ b/pipeline-scripts/check_env_var_registry_helpers_test.py
@@ -71,13 +71,24 @@ def test_a_non_autobot_name_is_not_matched(checker, tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_the_baseline_is_not_empty(checker):
-    """An empty baseline would make the shrink assertion vacuous."""
-    assert len(checker._UNREGISTERED_BASELINE) >= 40
+def test_the_baseline_is_empty_now_that_the_backlog_is_drained(checker):
+    """This asserted `>= 40` when the baseline held the backlog, to stop an empty
+    set making the shrink check vacuous. The backlog is drained, so that
+    assertion now encodes "the debt must stay large" — the opposite of the point.
+
+    The vacuity it guarded against is covered better by
+    `test_the_repository_has_no_unbaselined_unregistered_names`, which fails if
+    anything is unregistered whether or not the baseline is empty.
+    """
+    assert checker._UNREGISTERED_BASELINE == frozenset()
 
 
 def test_no_baselined_name_is_already_registered(checker):
-    """A stranded entry exempts whatever arrives under that name next, silently."""
+    """A stranded entry exempts whatever arrives under that name next, silently.
+
+    Vacuously true while the baseline is empty, and deliberately kept: it is the
+    assertion that matters the moment anyone adds an entry back.
+    """
     already = sorted(checker._UNREGISTERED_BASELINE & set(checker.REGISTRY))
 
     assert already == [], f"remove these from _UNREGISTERED_BASELINE — they are registered: {already}"
@@ -85,7 +96,8 @@ def test_no_baselined_name_is_already_registered(checker):
 
 def test_a_registered_baseline_entry_is_reported(checker):
     """The mechanism that keeps the list shrinking rather than rotting."""
-    name = sorted(checker._UNREGISTERED_BASELINE)[0]
+    name = "AUTOBOT_SYNTHETIC_BASELINE_ENTRY"
+    checker._UNREGISTERED_BASELINE = frozenset({name})
     checker.REGISTRY[name] = next(iter(checker.REGISTRY.values()))
     try:
         violations = checker._stale_baseline_entries()
@@ -110,7 +122,8 @@ def test_the_ceiling_is_reached_from_main_not_only_by_calling_it(checker, tmp_pa
     import io
     import sys as _sys
 
-    name = sorted(checker._UNREGISTERED_BASELINE)[0]
+    name = "AUTOBOT_SYNTHETIC_BASELINE_ENTRY"
+    checker._UNREGISTERED_BASELINE = frozenset({name})
     sample = tmp_path / "empty.py"
     sample.write_text("x = 1\n", encoding="utf-8")
     checker.REGISTRY[name] = next(iter(checker.REGISTRY.values()))


### PR DESCRIPTION
## Thinking Path

#14266 taught the registry checker to see the `env_utils` helper form and parked the 44 existing
gaps in `_UNREGISTERED_BASELINE`, deliberately, so the mechanism could land without 44 guessed
descriptions riding along. This is that backfill.

The defaults are read from each call site, not inferred. That mattered: three are not literals —
`AUTOBOT_APPROVAL_PENDING_SESSION_TTL_SECONDS` is `7 * 24 * 60 * 60`,
`AUTOBOT_TRAJECTORY_OUTCOME_SUCCESS_MIN` is `_MIN_REWARD_DEFAULT` (0.7), and two flags are
`env_flag(name)` with no second argument (False). A bulk extraction reads those as `None` and
would have documented three variables wrongly.

## What Changed

44 entries registered, with descriptions written from each call site's own comments and
surrounding code rather than restated from the variable name. Registry: 78 → 122. Docs
regenerated.

`_UNREGISTERED_BASELINE` is now **empty**. The two remaining names in it were test fixtures —
`AUTOBOT_TEST_BLANK` and `AUTOBOT_TEST_FLAG_XYZ`, both set by their own test via
`monkeypatch.setenv` and read straight back — and the self-provided rule already exempts them by
rule rather than by listing.

The constant is kept rather than deleted: `_stale_baseline_entries` still runs against it, so the
next person who needs a temporary exemption finds a ceiling with a shrink check attached instead
of starting a fresh list with neither.

## Two tests corrected, and why

`test_the_baseline_is_not_empty` asserted `>= 40`. It was written to stop an empty baseline making
the shrink check vacuous — but with the backlog drained it now encodes *"the debt must stay
large"*, the opposite of the point. Inverted to assert the baseline **is** empty. The vacuity it
guarded is covered better by `test_the_repository_has_no_unbaselined_unregistered_names`, which
fails whether or not the baseline is empty.

Two others indexed `sorted(_UNREGISTERED_BASELINE)[0]` and broke on the empty set. They now inject
a synthetic entry, so they test the mechanism rather than depending on the backlog's contents —
which is what they should have done from the start.

## Verification

- `check_env_var_registry_helpers_test.py`: **20 passed**.
- `check_env_var_registry.py` over 600 tracked Python files: exit 0.
- Spot-checked five entries' defaults against their call sites, including the two non-literal ones.

## Risks

Registry entries are documentation plus the checker's source of truth; no runtime behaviour
changes. The risk is a wrong description, which is why the defaults were read rather than derived
and why the awkward three are called out above.

## Model Used

Opus 5 (1M context).

Closes #14265
