### PR TITLE
fix(deploy): #4090's fix was in the wrong section, and chroma belongs with the db (#4090, #13870)

### DIFF
--- a/autobot-slm-backend/ansible/deploy.yml
+++ b/autobot-slm-backend/ansible/deploy.yml
@@ -18,7 +18,7 @@
     # role_*_active facts, so it needs its own derivation. Without it a
     # `target_roles=ai-stack` run falls to the role default and, on a host where
     # redis also ran earlier, both roles write the unit again.
-    chromadb_service_owner: "{{ 'ai-stack' if 'ai-stack' in (target_roles.split(',') | map('trim') | list) else 'redis' }}"
+    chromadb_service_owner: "{{ 'redis' if 'redis' in (target_roles.split(',') | map('trim') | list) else 'ai-stack' }}"
 
   tasks:
     - name: Parse target roles

--- a/autobot-slm-backend/ansible/inventory/group_vars/all.yml
+++ b/autobot-slm-backend/ansible/inventory/group_vars/all.yml
@@ -349,23 +349,10 @@ role_redis_active: >-
 # matching role_xrdp_active below.
 # Migration: a backend/main host that relied on implicit activation must now list
 # 'vnc' in node_roles (or join vnc_nodes) to keep its desktop provisioned.
-# #13870: which role owns /etc/systemd/system/autobot-chromadb.service on this
-# host. Both ai-stack and redis install and run chromadb, for different
-# topologies, and both wrote the same unit path — so the deployed ExecStart,
-# Description and restart policy flipped with role order.
-#
-# ai-stack wins a combined host deliberately, because that is what wins TODAY:
-# the old run order put ai-stack last (deploy.yml applies redis before ai-stack;
-# the fleet play runs redis in phase 3 and ai-stack in 5a), so the live
-# ExecStart --path is ai-stack's. Handing ownership to redis would relocate the
-# vector store, and chroma comes up healthy against an empty directory — the
-# knowledge base would read as empty with no error anywhere. Whether to move it
-# (with a migration or a pre-flight refusal) is an open decision on #13870; this
-# change makes ownership deterministic without touching the data path.
-#
-# Derived, not declared per-playbook: the per-playbook version covered ONE of
-# six entry points and the other five silently deployed no unit at all.
-chromadb_service_owner: "{{ 'ai-stack' if (role_ai_stack_active | default(false) | bool) else 'redis' }}"
+# #13870: ChromaDB is a database, so the db stack owns its unit wherever that
+# stack is present. It is also the only venv with chromadb installed — the
+# ai-stack fallback exists solely for a topology that runs ai-stack alone.
+chromadb_service_owner: "{{ 'redis' if (role_redis_active | default(false) | bool) else 'ai-stack' }}"
 
 role_vnc_active: >-
   {{ ('vnc' in (node_roles | default([]))) or

--- a/autobot-slm-backend/ansible/playbooks/vars/role_active_facts.yml
+++ b/autobot-slm-backend/ansible/playbooks/vars/role_active_facts.yml
@@ -92,9 +92,7 @@ role_tts_worker_active: >-
   {{ ('tts-worker' in (node_roles | default([]))) or
      ('autobot-tts-worker' in (node_roles | default([]))) }}
 
-# #13870: mirrors inventory/group_vars/all.yml — the SLM temp-inventory paths
-# load this file instead of group_vars. ai-stack wins a combined host because
-# that is what wins today; moving the store to redis would relocate the data
-# and chroma comes up healthy against an empty directory (open decision on
-# #13870).
-chromadb_service_owner: "{{ 'ai-stack' if (role_ai_stack_active | default(false) | bool) else 'redis' }}"
+# #13870: ChromaDB is a database, so the db stack owns its unit wherever that
+# stack is present. It is also the only venv with chromadb installed — the
+# ai-stack fallback exists solely for a topology that runs ai-stack alone.
+chromadb_service_owner: "{{ 'redis' if (role_redis_active | default(false) | bool) else 'ai-stack' }}"

--- a/autobot-slm-backend/ansible/roles/ai-stack/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/ai-stack/defaults/main.yml
@@ -75,15 +75,14 @@ ai_system_commands_model: "dolphin-llama3:8b"
 
 # #13870: which role owns /etc/systemd/system/autobot-chromadb.service.
 #
-# BOTH roles legitimately install and run chromadb, for different topologies,
-# and both used to write the SAME unit path from their own template. Whichever
-# ran last won, so the deployed ExecStart, Description and restart policy all
-# flipped with run order — observed live during the #4090 investigation.
+# The redis role, because ChromaDB IS a database and belongs with the db stack.
+# That is also the only venv where it is installed: the db-stack venv carries
+# chromadb, the ai-stack venv never did.
 #
-# This default is the role's OWN name, deliberately: it is the last-resort
-# floor, and it must fail SAFE. A shared default of one role's name meant every
-# topology running the other role alone deployed no unit at all — five of six
-# entry points, including the updater's — which is worse than the flip being
-# fixed. The both-roles case is resolved one precedence level up, by
-# `chromadb_service_owner` in group_vars/all.yml.
-chromadb_service_owner: "ai-stack"
+# An earlier revision of this made ai-stack the owner on a combined host, to
+# avoid relocating the persist directory. That produced the #4090 outage live —
+# ExecStart pointed at /opt/autobot/autobot-ai-stack/venv/bin/chroma, which does
+# not exist, and the unit reached NRestarts=4399 while reporting `activating`.
+# Owning the service and owning the data are two decisions; collapsing them into
+# one attached a database to the wrong stack.
+chromadb_service_owner: "redis"

--- a/autobot-slm-backend/ansible/roles/ai-stack/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/ai-stack/defaults/main.yml
@@ -75,14 +75,16 @@ ai_system_commands_model: "dolphin-llama3:8b"
 
 # #13870: which role owns /etc/systemd/system/autobot-chromadb.service.
 #
-# The redis role, because ChromaDB IS a database and belongs with the db stack.
-# That is also the only venv where it is installed: the db-stack venv carries
-# chromadb, the ai-stack venv never did.
+# This default is the role's OWN name, and it is a FAIL-SAFE FLOOR, not the
+# answer. It decides only what happens when this role is applied alone with no
+# vars layer loaded — `api/setup_wizard.py::_generate_dynamic_inventory()` writes
+# a bare temp inventory with no group_vars sibling and no role_active_facts
+# include, so the "Setup AI Stack Node" action resolves nothing but these
+# defaults. A shared default of one role's name means that host deploys NO unit
+# at all, which is worse than the flip this issue fixes.
 #
-# An earlier revision of this made ai-stack the owner on a combined host, to
-# avoid relocating the persist directory. That produced the #4090 outage live —
-# ExecStart pointed at /opt/autobot/autobot-ai-stack/venv/bin/chroma, which does
-# not exist, and the unit reached NRestarts=4399 while reporting `activating`.
-# Owning the service and owning the data are two decisions; collapsing them into
-# one attached a database to the wrong stack.
-chromadb_service_owner: "redis"
+# The real decision is one precedence level up: `chromadb_service_owner` in
+# group_vars/all.yml hands a combined host to the db stack, because ChromaDB is
+# a database and that is the only role that installs it. On an ai-stack-only
+# host the ai-stack role installs chromadb itself, so owning it there is correct.
+chromadb_service_owner: "ai-stack"

--- a/autobot-slm-backend/ansible/roles/ai-stack/templates/autobot-ai-stack.service.j2
+++ b/autobot-slm-backend/ansible/roles/ai-stack/templates/autobot-ai-stack.service.j2
@@ -19,7 +19,6 @@ Wants=autobot-chromadb.service
 StartLimitIntervalSec=120
 StartLimitBurst=5
 
-
 [Service]
 Type=simple
 User={{ ai_user }}

--- a/autobot-slm-backend/ansible/roles/ai-stack/templates/autobot-ai-stack.service.j2
+++ b/autobot-slm-backend/ansible/roles/ai-stack/templates/autobot-ai-stack.service.j2
@@ -5,6 +5,20 @@
 Description=AutoBot AI Processing Stack (LangChain/LlamaIndex Agent Router)
 After=network.target autobot-chromadb.service
 Wants=autobot-chromadb.service
+# #4090: these live in [Unit], NOT [Service]. systemd's own verdict on the
+# wrong placement is "Unknown key name 'StartLimitIntervalSec' in section
+# 'Service', ignoring" — so the fix merged for #4090 was discarded on every unit
+# and chromadb still reached NRestarts=4399 while showing `activating`, never
+# `failed`. That is the exact outage #4090 exists to make visible.
+#
+# Without them a unit that can never exec restarts forever and stays out of
+# `systemctl --failed`. systemd's defaults do not help: DefaultStartLimitIntervalSec=10s
+# with DefaultStartLimitBurst=5 needs 5 restarts inside 10s, and RestartSec spaces
+# them further apart, so the rate never reaches the limit. The window must exceed
+# RestartSec * StartLimitBurst for the limit to be reachable at all.
+StartLimitIntervalSec=120
+StartLimitBurst=5
+
 
 [Service]
 Type=simple
@@ -20,15 +34,6 @@ EnvironmentFile=/etc/autobot/autobot-ai-stack.env
 ExecStart={{ backend_install_dir | default('/opt/autobot/autobot-backend') }}/venv/bin/uvicorn ai_api_server:app --host {{ ai_host }} --port {{ ai_port }} --workers 2
 Restart=always
 RestartSec=10
-# #4090: without these, a unit that can never exec restarts forever and stays
-# out of `systemctl --failed`, so the one thing an operator checks cannot see it
-# (chromadb: 1681 restarts over ~4h45m, invisible). systemd's OWN defaults do not
-# help — DefaultStartLimitIntervalSec=10s with DefaultStartLimitBurst=5 needs 5
-# restarts inside 10s, and RestartSec spaces them further apart than that, so the
-# rate never reaches the limit. The window has to be wider than
-# RestartSec * StartLimitBurst for the limit to be reachable at all.
-StartLimitIntervalSec=120
-StartLimitBurst=5
 StandardOutput=append:{{ ai_log_dir }}/ai-stack.log
 StandardError=append:{{ ai_log_dir }}/ai-stack-error.log
 

--- a/autobot-slm-backend/ansible/roles/ai-stack/templates/autobot-chromadb.service.j2
+++ b/autobot-slm-backend/ansible/roles/ai-stack/templates/autobot-chromadb.service.j2
@@ -4,6 +4,20 @@
 [Unit]
 Description=AutoBot ChromaDB Vector Database
 After=network.target
+# #4090: these live in [Unit], NOT [Service]. systemd's own verdict on the
+# wrong placement is "Unknown key name 'StartLimitIntervalSec' in section
+# 'Service', ignoring" — so the fix merged for #4090 was discarded on every unit
+# and chromadb still reached NRestarts=4399 while showing `activating`, never
+# `failed`. That is the exact outage #4090 exists to make visible.
+#
+# Without them a unit that can never exec restarts forever and stays out of
+# `systemctl --failed`. systemd's defaults do not help: DefaultStartLimitIntervalSec=10s
+# with DefaultStartLimitBurst=5 needs 5 restarts inside 10s, and RestartSec spaces
+# them further apart, so the rate never reaches the limit. The window must exceed
+# RestartSec * StartLimitBurst for the limit to be reachable at all.
+StartLimitIntervalSec=120
+StartLimitBurst=5
+
 
 [Service]
 Type=simple
@@ -45,15 +59,6 @@ ExecStart={{ ai_install_dir }}/venv/bin/chroma run --host {{ chromadb_host }} --
 # restarted forever instead of reaching `failed`.
 Restart=on-failure
 RestartSec=10
-# #4090: without these, a unit that can never exec restarts forever and stays
-# out of `systemctl --failed`, so the one thing an operator checks cannot see it
-# (chromadb: 1681 restarts over ~4h45m, invisible). systemd's OWN defaults do not
-# help — DefaultStartLimitIntervalSec=10s with DefaultStartLimitBurst=5 needs 5
-# restarts inside 10s, and RestartSec spaces them further apart than that, so the
-# rate never reaches the limit. The window has to be wider than
-# RestartSec * StartLimitBurst for the limit to be reachable at all.
-StartLimitIntervalSec=120
-StartLimitBurst=5
 StandardOutput=append:{{ ai_log_dir }}/chromadb.log
 StandardError=append:{{ ai_log_dir }}/chromadb-error.log
 

--- a/autobot-slm-backend/ansible/roles/ai-stack/templates/autobot-chromadb.service.j2
+++ b/autobot-slm-backend/ansible/roles/ai-stack/templates/autobot-chromadb.service.j2
@@ -18,7 +18,6 @@ After=network.target
 StartLimitIntervalSec=120
 StartLimitBurst=5
 
-
 [Service]
 Type=simple
 User={{ ai_user }}

--- a/autobot-slm-backend/ansible/roles/backend/templates/autobot-celery-beat.service.j2
+++ b/autobot-slm-backend/ansible/roles/backend/templates/autobot-celery-beat.service.j2
@@ -35,7 +35,6 @@ Wants=network-online.target redis-stack-server.service autobot-celery.service
 StartLimitIntervalSec=120
 StartLimitBurst=5
 
-
 [Service]
 Type=simple
 User={{ backend_user }}

--- a/autobot-slm-backend/ansible/roles/backend/templates/autobot-celery-beat.service.j2
+++ b/autobot-slm-backend/ansible/roles/backend/templates/autobot-celery-beat.service.j2
@@ -21,6 +21,20 @@ Description=AutoBot Celery Beat (periodic scheduler)
 # Wants= softens the dependency so Beat survives worker restarts.
 After=network-online.target redis-stack-server.service autobot-celery.service
 Wants=network-online.target redis-stack-server.service autobot-celery.service
+# #4090: these live in [Unit], NOT [Service]. systemd's own verdict on the
+# wrong placement is "Unknown key name 'StartLimitIntervalSec' in section
+# 'Service', ignoring" — so the fix merged for #4090 was discarded on every unit
+# and chromadb still reached NRestarts=4399 while showing `activating`, never
+# `failed`. That is the exact outage #4090 exists to make visible.
+#
+# Without them a unit that can never exec restarts forever and stays out of
+# `systemctl --failed`. systemd's defaults do not help: DefaultStartLimitIntervalSec=10s
+# with DefaultStartLimitBurst=5 needs 5 restarts inside 10s, and RestartSec spaces
+# them further apart, so the rate never reaches the limit. The window must exceed
+# RestartSec * StartLimitBurst for the limit to be reachable at all.
+StartLimitIntervalSec=120
+StartLimitBurst=5
+
 
 [Service]
 Type=simple
@@ -45,15 +59,6 @@ TimeoutStopSec=30
 
 Restart=always
 RestartSec=5
-# #4090: without these, a unit that can never exec restarts forever and stays
-# out of `systemctl --failed`, so the one thing an operator checks cannot see it
-# (chromadb: 1681 restarts over ~4h45m, invisible). systemd's OWN defaults do not
-# help — DefaultStartLimitIntervalSec=10s with DefaultStartLimitBurst=5 needs 5
-# restarts inside 10s, and RestartSec spaces them further apart than that, so the
-# rate never reaches the limit. The window has to be wider than
-# RestartSec * StartLimitBurst for the limit to be reachable at all.
-StartLimitIntervalSec=120
-StartLimitBurst=5
 
 StandardOutput=append:{{ backend_log_dir }}/celery-beat.log
 StandardError=append:{{ backend_log_dir }}/celery-beat-error.log

--- a/autobot-slm-backend/ansible/roles/backend/templates/autobot-celery.service.j2
+++ b/autobot-slm-backend/ansible/roles/backend/templates/autobot-celery.service.j2
@@ -19,7 +19,6 @@ Wants=network-online.target redis-stack-server.service
 StartLimitIntervalSec=120
 StartLimitBurst=5
 
-
 [Service]
 Type=simple
 User={{ backend_user }}

--- a/autobot-slm-backend/ansible/roles/backend/templates/autobot-celery.service.j2
+++ b/autobot-slm-backend/ansible/roles/backend/templates/autobot-celery.service.j2
@@ -5,6 +5,20 @@
 Description=AutoBot Celery Worker
 After=network-online.target redis-stack-server.service autobot-backend.service
 Wants=network-online.target redis-stack-server.service
+# #4090: these live in [Unit], NOT [Service]. systemd's own verdict on the
+# wrong placement is "Unknown key name 'StartLimitIntervalSec' in section
+# 'Service', ignoring" — so the fix merged for #4090 was discarded on every unit
+# and chromadb still reached NRestarts=4399 while showing `activating`, never
+# `failed`. That is the exact outage #4090 exists to make visible.
+#
+# Without them a unit that can never exec restarts forever and stays out of
+# `systemctl --failed`. systemd's defaults do not help: DefaultStartLimitIntervalSec=10s
+# with DefaultStartLimitBurst=5 needs 5 restarts inside 10s, and RestartSec spaces
+# them further apart, so the rate never reaches the limit. The window must exceed
+# RestartSec * StartLimitBurst for the limit to be reachable at all.
+StartLimitIntervalSec=120
+StartLimitBurst=5
+
 
 [Service]
 Type=simple
@@ -38,15 +52,6 @@ TimeoutStopSec=30
 # Restart policy
 Restart=always
 RestartSec=5
-# #4090: without these, a unit that can never exec restarts forever and stays
-# out of `systemctl --failed`, so the one thing an operator checks cannot see it
-# (chromadb: 1681 restarts over ~4h45m, invisible). systemd's OWN defaults do not
-# help — DefaultStartLimitIntervalSec=10s with DefaultStartLimitBurst=5 needs 5
-# restarts inside 10s, and RestartSec spaces them further apart than that, so the
-# rate never reaches the limit. The window has to be wider than
-# RestartSec * StartLimitBurst for the limit to be reachable at all.
-StartLimitIntervalSec=120
-StartLimitBurst=5
 
 # Logging
 StandardOutput=append:{{ backend_log_dir }}/celery.log

--- a/autobot-slm-backend/ansible/roles/browser/templates/playwright.service.j2
+++ b/autobot-slm-backend/ansible/roles/browser/templates/playwright.service.j2
@@ -2,6 +2,20 @@
 Description=AutoBot Playwright Browser Automation
 After=network.target
 Wants=network-online.target
+# #4090: these live in [Unit], NOT [Service]. systemd's own verdict on the
+# wrong placement is "Unknown key name 'StartLimitIntervalSec' in section
+# 'Service', ignoring" — so the fix merged for #4090 was discarded on every unit
+# and chromadb still reached NRestarts=4399 while showing `activating`, never
+# `failed`. That is the exact outage #4090 exists to make visible.
+#
+# Without them a unit that can never exec restarts forever and stays out of
+# `systemctl --failed`. systemd's defaults do not help: DefaultStartLimitIntervalSec=10s
+# with DefaultStartLimitBurst=5 needs 5 restarts inside 10s, and RestartSec spaces
+# them further apart, so the rate never reaches the limit. The window must exceed
+# RestartSec * StartLimitBurst for the limit to be reachable at all.
+StartLimitIntervalSec=120
+StartLimitBurst=5
+
 
 [Service]
 Type=simple
@@ -26,15 +40,6 @@ ExecStart=/usr/bin/node /opt/autobot/autobot-browser-worker/playwright-server.js
 # Restart policy
 Restart=always
 RestartSec=5s
-# #4090: without these, a unit that can never exec restarts forever and stays
-# out of `systemctl --failed`, so the one thing an operator checks cannot see it
-# (chromadb: 1681 restarts over ~4h45m, invisible). systemd's OWN defaults do not
-# help — DefaultStartLimitIntervalSec=10s with DefaultStartLimitBurst=5 needs 5
-# restarts inside 10s, and RestartSec spaces them further apart than that, so the
-# rate never reaches the limit. The window has to be wider than
-# RestartSec * StartLimitBurst for the limit to be reachable at all.
-StartLimitIntervalSec=120
-StartLimitBurst=5
 
 # Limits
 LimitNOFILE=65535

--- a/autobot-slm-backend/ansible/roles/browser/templates/playwright.service.j2
+++ b/autobot-slm-backend/ansible/roles/browser/templates/playwright.service.j2
@@ -16,7 +16,6 @@ Wants=network-online.target
 StartLimitIntervalSec=120
 StartLimitBurst=5
 
-
 [Service]
 Type=simple
 User=autobot

--- a/autobot-slm-backend/ansible/roles/browser/templates/vnc.service.j2
+++ b/autobot-slm-backend/ansible/roles/browser/templates/vnc.service.j2
@@ -21,7 +21,6 @@ After=network.target
 StartLimitIntervalSec=120
 StartLimitBurst=5
 
-
 [Service]
 Type=simple
 User=autobot

--- a/autobot-slm-backend/ansible/roles/browser/templates/vnc.service.j2
+++ b/autobot-slm-backend/ansible/roles/browser/templates/vnc.service.j2
@@ -7,6 +7,20 @@
 [Unit]
 Description=AutoBot VNC Server
 After=network.target
+# #4090: these live in [Unit], NOT [Service]. systemd's own verdict on the
+# wrong placement is "Unknown key name 'StartLimitIntervalSec' in section
+# 'Service', ignoring" — so the fix merged for #4090 was discarded on every unit
+# and chromadb still reached NRestarts=4399 while showing `activating`, never
+# `failed`. That is the exact outage #4090 exists to make visible.
+#
+# Without them a unit that can never exec restarts forever and stays out of
+# `systemctl --failed`. systemd's defaults do not help: DefaultStartLimitIntervalSec=10s
+# with DefaultStartLimitBurst=5 needs 5 restarts inside 10s, and RestartSec spaces
+# them further apart, so the rate never reaches the limit. The window must exceed
+# RestartSec * StartLimitBurst for the limit to be reachable at all.
+StartLimitIntervalSec=120
+StartLimitBurst=5
+
 
 [Service]
 Type=simple
@@ -26,17 +40,6 @@ ExecStop=/usr/bin/vncserver -kill {{ vnc_display }}
 # Restart policy
 Restart=on-failure
 RestartSec=10s
-# #4090: without these, a unit whose ExecStart can never succeed restarts forever
-# and stays out of `systemctl --failed`, so the one thing an operator checks
-# cannot see it (chromadb: 1681 restarts over ~4h45m, invisible). `on-failure`
-# is no safer than `always` here — an exec that never succeeds never exits
-# cleanly, so it reschedules just as indefinitely. systemd's OWN defaults do not
-# help: DefaultStartLimitIntervalSec=10s with DefaultStartLimitBurst=5 needs 5
-# restarts inside 10s, and RestartSec spaces them further apart, so the rate
-# never reaches the limit. The window must exceed RestartSec * StartLimitBurst
-# for the limit to be reachable at all.
-StartLimitIntervalSec=120
-StartLimitBurst=5
 
 # Logging
 StandardOutput=journal

--- a/autobot-slm-backend/ansible/roles/centralized_logging/templates/loki.service.j2
+++ b/autobot-slm-backend/ansible/roles/centralized_logging/templates/loki.service.j2
@@ -17,7 +17,6 @@ Wants=network-online.target
 StartLimitIntervalSec=120
 StartLimitBurst=5
 
-
 [Service]
 Type=simple
 User={{ logging_user }}

--- a/autobot-slm-backend/ansible/roles/centralized_logging/templates/loki.service.j2
+++ b/autobot-slm-backend/ansible/roles/centralized_logging/templates/loki.service.j2
@@ -3,6 +3,20 @@ Description=Loki Log Aggregation System
 Documentation=https://grafana.com/docs/loki/latest/
 After=network-online.target
 Wants=network-online.target
+# #4090: these live in [Unit], NOT [Service]. systemd's own verdict on the
+# wrong placement is "Unknown key name 'StartLimitIntervalSec' in section
+# 'Service', ignoring" — so the fix merged for #4090 was discarded on every unit
+# and chromadb still reached NRestarts=4399 while showing `activating`, never
+# `failed`. That is the exact outage #4090 exists to make visible.
+#
+# Without them a unit that can never exec restarts forever and stays out of
+# `systemctl --failed`. systemd's defaults do not help: DefaultStartLimitIntervalSec=10s
+# with DefaultStartLimitBurst=5 needs 5 restarts inside 10s, and RestartSec spaces
+# them further apart, so the rate never reaches the limit. The window must exceed
+# RestartSec * StartLimitBurst for the limit to be reachable at all.
+StartLimitIntervalSec=120
+StartLimitBurst=5
+
 
 [Service]
 Type=simple
@@ -11,17 +25,6 @@ Group={{ logging_group }}
 ExecStart={{ loki_binary_path }} -config.file={{ loki_config_dir }}/config.yml
 Restart=on-failure
 RestartSec=10s
-# #4090: without these, a unit whose ExecStart can never succeed restarts forever
-# and stays out of `systemctl --failed`, so the one thing an operator checks
-# cannot see it (chromadb: 1681 restarts over ~4h45m, invisible). `on-failure`
-# is no safer than `always` here — an exec that never succeeds never exits
-# cleanly, so it reschedules just as indefinitely. systemd's OWN defaults do not
-# help: DefaultStartLimitIntervalSec=10s with DefaultStartLimitBurst=5 needs 5
-# restarts inside 10s, and RestartSec spaces them further apart, so the rate
-# never reaches the limit. The window must exceed RestartSec * StartLimitBurst
-# for the limit to be reachable at all.
-StartLimitIntervalSec=120
-StartLimitBurst=5
 StandardOutput=journal
 StandardError=journal
 SyslogIdentifier=loki

--- a/autobot-slm-backend/ansible/roles/centralized_logging/templates/promtail.service.j2
+++ b/autobot-slm-backend/ansible/roles/centralized_logging/templates/promtail.service.j2
@@ -17,7 +17,6 @@ Wants=network-online.target
 StartLimitIntervalSec=120
 StartLimitBurst=5
 
-
 [Service]
 Type=simple
 User={{ logging_user }}

--- a/autobot-slm-backend/ansible/roles/centralized_logging/templates/promtail.service.j2
+++ b/autobot-slm-backend/ansible/roles/centralized_logging/templates/promtail.service.j2
@@ -3,6 +3,20 @@ Description=Promtail Log Shipper
 Documentation=https://grafana.com/docs/loki/latest/clients/promtail/
 After=network-online.target
 Wants=network-online.target
+# #4090: these live in [Unit], NOT [Service]. systemd's own verdict on the
+# wrong placement is "Unknown key name 'StartLimitIntervalSec' in section
+# 'Service', ignoring" — so the fix merged for #4090 was discarded on every unit
+# and chromadb still reached NRestarts=4399 while showing `activating`, never
+# `failed`. That is the exact outage #4090 exists to make visible.
+#
+# Without them a unit that can never exec restarts forever and stays out of
+# `systemctl --failed`. systemd's defaults do not help: DefaultStartLimitIntervalSec=10s
+# with DefaultStartLimitBurst=5 needs 5 restarts inside 10s, and RestartSec spaces
+# them further apart, so the rate never reaches the limit. The window must exceed
+# RestartSec * StartLimitBurst for the limit to be reachable at all.
+StartLimitIntervalSec=120
+StartLimitBurst=5
+
 
 [Service]
 Type=simple
@@ -11,17 +25,6 @@ Group={{ logging_group }}
 ExecStart={{ promtail_binary_path }} -config.file={{ promtail_config_dir }}/config.yml
 Restart=on-failure
 RestartSec=10s
-# #4090: without these, a unit whose ExecStart can never succeed restarts forever
-# and stays out of `systemctl --failed`, so the one thing an operator checks
-# cannot see it (chromadb: 1681 restarts over ~4h45m, invisible). `on-failure`
-# is no safer than `always` here — an exec that never succeeds never exits
-# cleanly, so it reschedules just as indefinitely. systemd's OWN defaults do not
-# help: DefaultStartLimitIntervalSec=10s with DefaultStartLimitBurst=5 needs 5
-# restarts inside 10s, and RestartSec spaces them further apart, so the rate
-# never reaches the limit. The window must exceed RestartSec * StartLimitBurst
-# for the limit to be reachable at all.
-StartLimitIntervalSec=120
-StartLimitBurst=5
 StandardOutput=journal
 StandardError=journal
 SyslogIdentifier=promtail

--- a/autobot-slm-backend/ansible/roles/frontend/templates/autobot-frontend.service.j2
+++ b/autobot-slm-backend/ansible/roles/frontend/templates/autobot-frontend.service.j2
@@ -4,6 +4,20 @@
 [Unit]
 Description=AutoBot Frontend (Vite Dev Server)
 After=network.target
+# #4090: these live in [Unit], NOT [Service]. systemd's own verdict on the
+# wrong placement is "Unknown key name 'StartLimitIntervalSec' in section
+# 'Service', ignoring" — so the fix merged for #4090 was discarded on every unit
+# and chromadb still reached NRestarts=4399 while showing `activating`, never
+# `failed`. That is the exact outage #4090 exists to make visible.
+#
+# Without them a unit that can never exec restarts forever and stays out of
+# `systemctl --failed`. systemd's defaults do not help: DefaultStartLimitIntervalSec=10s
+# with DefaultStartLimitBurst=5 needs 5 restarts inside 10s, and RestartSec spaces
+# them further apart, so the rate never reaches the limit. The window must exceed
+# RestartSec * StartLimitBurst for the limit to be reachable at all.
+StartLimitIntervalSec=120
+StartLimitBurst=5
+
 
 [Service]
 Type=simple
@@ -19,15 +33,6 @@ ExecStart=/usr/bin/npm run dev -- --host {{ frontend_host }} --port {{ frontend_
 {% endif %}
 Restart=always
 RestartSec=5
-# #4090: without these, a unit that can never exec restarts forever and stays
-# out of `systemctl --failed`, so the one thing an operator checks cannot see it
-# (chromadb: 1681 restarts over ~4h45m, invisible). systemd's OWN defaults do not
-# help — DefaultStartLimitIntervalSec=10s with DefaultStartLimitBurst=5 needs 5
-# restarts inside 10s, and RestartSec spaces them further apart than that, so the
-# rate never reaches the limit. The window has to be wider than
-# RestartSec * StartLimitBurst for the limit to be reachable at all.
-StartLimitIntervalSec=120
-StartLimitBurst=5
 StandardOutput=append:{{ frontend_log_dir }}/frontend.log
 StandardError=append:{{ frontend_log_dir }}/frontend-error.log
 

--- a/autobot-slm-backend/ansible/roles/frontend/templates/autobot-frontend.service.j2
+++ b/autobot-slm-backend/ansible/roles/frontend/templates/autobot-frontend.service.j2
@@ -18,7 +18,6 @@ After=network.target
 StartLimitIntervalSec=120
 StartLimitBurst=5
 
-
 [Service]
 Type=simple
 User={{ frontend_user }}

--- a/autobot-slm-backend/ansible/roles/frontend/templates/frontend.service.j2
+++ b/autobot-slm-backend/ansible/roles/frontend/templates/frontend.service.j2
@@ -2,6 +2,20 @@
 Description=AutoBot Frontend Vue.js Development Server
 After=network.target
 Wants=network-online.target
+# #4090: these live in [Unit], NOT [Service]. systemd's own verdict on the
+# wrong placement is "Unknown key name 'StartLimitIntervalSec' in section
+# 'Service', ignoring" — so the fix merged for #4090 was discarded on every unit
+# and chromadb still reached NRestarts=4399 while showing `activating`, never
+# `failed`. That is the exact outage #4090 exists to make visible.
+#
+# Without them a unit that can never exec restarts forever and stays out of
+# `systemctl --failed`. systemd's defaults do not help: DefaultStartLimitIntervalSec=10s
+# with DefaultStartLimitBurst=5 needs 5 restarts inside 10s, and RestartSec spaces
+# them further apart, so the rate never reaches the limit. The window must exceed
+# RestartSec * StartLimitBurst for the limit to be reachable at all.
+StartLimitIntervalSec=120
+StartLimitBurst=5
+
 
 [Service]
 Type=simple
@@ -20,15 +34,6 @@ ExecStart=/usr/bin/npm run dev -- --host 0.0.0.0 --port {{ frontend_port }}
 # Restart policy
 Restart=always
 RestartSec=5s
-# #4090: without these, a unit that can never exec restarts forever and stays
-# out of `systemctl --failed`, so the one thing an operator checks cannot see it
-# (chromadb: 1681 restarts over ~4h45m, invisible). systemd's OWN defaults do not
-# help — DefaultStartLimitIntervalSec=10s with DefaultStartLimitBurst=5 needs 5
-# restarts inside 10s, and RestartSec spaces them further apart than that, so the
-# rate never reaches the limit. The window has to be wider than
-# RestartSec * StartLimitBurst for the limit to be reachable at all.
-StartLimitIntervalSec=120
-StartLimitBurst=5
 
 # Limits
 LimitNOFILE=65535

--- a/autobot-slm-backend/ansible/roles/frontend/templates/frontend.service.j2
+++ b/autobot-slm-backend/ansible/roles/frontend/templates/frontend.service.j2
@@ -16,7 +16,6 @@ Wants=network-online.target
 StartLimitIntervalSec=120
 StartLimitBurst=5
 
-
 [Service]
 Type=simple
 User={{ frontend_user }}

--- a/autobot-slm-backend/ansible/roles/llm/templates/ollama.service.j2
+++ b/autobot-slm-backend/ansible/roles/llm/templates/ollama.service.j2
@@ -6,6 +6,20 @@
 Description=Ollama LLM Service
 After=network-online.target
 Wants=network-online.target
+# #4090: these live in [Unit], NOT [Service]. systemd's own verdict on the
+# wrong placement is "Unknown key name 'StartLimitIntervalSec' in section
+# 'Service', ignoring" — so the fix merged for #4090 was discarded on every unit
+# and chromadb still reached NRestarts=4399 while showing `activating`, never
+# `failed`. That is the exact outage #4090 exists to make visible.
+#
+# Without them a unit that can never exec restarts forever and stays out of
+# `systemctl --failed`. systemd's defaults do not help: DefaultStartLimitIntervalSec=10s
+# with DefaultStartLimitBurst=5 needs 5 restarts inside 10s, and RestartSec spaces
+# them further apart, so the rate never reaches the limit. The window must exceed
+# RestartSec * StartLimitBurst for the limit to be reachable at all.
+StartLimitIntervalSec=120
+StartLimitBurst=5
+
 
 [Service]
 Type=simple
@@ -33,15 +47,6 @@ Environment="OLLAMA_NUM_GPU={{ effective_gpu }}"
 ExecStart=/usr/local/bin/ollama serve
 Restart=always
 RestartSec=5
-# #4090: without these, a unit that can never exec restarts forever and stays
-# out of `systemctl --failed`, so the one thing an operator checks cannot see it
-# (chromadb: 1681 restarts over ~4h45m, invisible). systemd's OWN defaults do not
-# help — DefaultStartLimitIntervalSec=10s with DefaultStartLimitBurst=5 needs 5
-# restarts inside 10s, and RestartSec spaces them further apart than that, so the
-# rate never reaches the limit. The window has to be wider than
-# RestartSec * StartLimitBurst for the limit to be reachable at all.
-StartLimitIntervalSec=120
-StartLimitBurst=5
 LimitNOFILE=65535
 
 [Install]

--- a/autobot-slm-backend/ansible/roles/llm/templates/ollama.service.j2
+++ b/autobot-slm-backend/ansible/roles/llm/templates/ollama.service.j2
@@ -20,7 +20,6 @@ Wants=network-online.target
 StartLimitIntervalSec=120
 StartLimitBurst=5
 
-
 [Service]
 Type=simple
 User={{ llm_user }}

--- a/autobot-slm-backend/ansible/roles/monitoring/templates/node_exporter.service.j2
+++ b/autobot-slm-backend/ansible/roles/monitoring/templates/node_exporter.service.j2
@@ -9,6 +9,20 @@ Description=Prometheus Node Exporter
 Documentation=https://prometheus.io/docs/guides/node-exporter/
 Wants=network-online.target
 After=network-online.target
+# #4090: these live in [Unit], NOT [Service]. systemd's own verdict on the
+# wrong placement is "Unknown key name 'StartLimitIntervalSec' in section
+# 'Service', ignoring" — so the fix merged for #4090 was discarded on every unit
+# and chromadb still reached NRestarts=4399 while showing `activating`, never
+# `failed`. That is the exact outage #4090 exists to make visible.
+#
+# Without them a unit that can never exec restarts forever and stays out of
+# `systemctl --failed`. systemd's defaults do not help: DefaultStartLimitIntervalSec=10s
+# with DefaultStartLimitBurst=5 needs 5 restarts inside 10s, and RestartSec spaces
+# them further apart, so the rate never reaches the limit. The window must exceed
+# RestartSec * StartLimitBurst for the limit to be reachable at all.
+StartLimitIntervalSec=120
+StartLimitBurst=5
+
 
 [Service]
 Type=simple
@@ -22,15 +36,6 @@ ExecStart=/opt/node_exporter/node_exporter \
 SyslogIdentifier=node_exporter
 Restart=always
 RestartSec=5s
-# #4090: without these, a unit that can never exec restarts forever and stays
-# out of `systemctl --failed`, so the one thing an operator checks cannot see it
-# (chromadb: 1681 restarts over ~4h45m, invisible). systemd's OWN defaults do not
-# help — DefaultStartLimitIntervalSec=10s with DefaultStartLimitBurst=5 needs 5
-# restarts inside 10s, and RestartSec spaces them further apart than that, so the
-# rate never reaches the limit. The window has to be wider than
-# RestartSec * StartLimitBurst for the limit to be reachable at all.
-StartLimitIntervalSec=120
-StartLimitBurst=5
 
 # Security hardening
 NoNewPrivileges=yes

--- a/autobot-slm-backend/ansible/roles/monitoring/templates/node_exporter.service.j2
+++ b/autobot-slm-backend/ansible/roles/monitoring/templates/node_exporter.service.j2
@@ -23,7 +23,6 @@ After=network-online.target
 StartLimitIntervalSec=120
 StartLimitBurst=5
 
-
 [Service]
 Type=simple
 User=node_exporter

--- a/autobot-slm-backend/ansible/roles/monitoring/templates/prometheus.service.j2
+++ b/autobot-slm-backend/ansible/roles/monitoring/templates/prometheus.service.j2
@@ -9,6 +9,20 @@ Description=Prometheus Monitoring System
 Documentation=https://prometheus.io/docs/introduction/overview/
 Wants=network-online.target
 After=network-online.target
+# #4090: these live in [Unit], NOT [Service]. systemd's own verdict on the
+# wrong placement is "Unknown key name 'StartLimitIntervalSec' in section
+# 'Service', ignoring" — so the fix merged for #4090 was discarded on every unit
+# and chromadb still reached NRestarts=4399 while showing `activating`, never
+# `failed`. That is the exact outage #4090 exists to make visible.
+#
+# Without them a unit that can never exec restarts forever and stays out of
+# `systemctl --failed`. systemd's defaults do not help: DefaultStartLimitIntervalSec=10s
+# with DefaultStartLimitBurst=5 needs 5 restarts inside 10s, and RestartSec spaces
+# them further apart, so the rate never reaches the limit. The window must exceed
+# RestartSec * StartLimitBurst for the limit to be reachable at all.
+StartLimitIntervalSec=120
+StartLimitBurst=5
+
 
 [Service]
 Type=simple
@@ -28,15 +42,6 @@ ExecStart={{ prometheus_install_dir }}/prometheus \
 SyslogIdentifier=prometheus
 Restart=always
 RestartSec=5s
-# #4090: without these, a unit that can never exec restarts forever and stays
-# out of `systemctl --failed`, so the one thing an operator checks cannot see it
-# (chromadb: 1681 restarts over ~4h45m, invisible). systemd's OWN defaults do not
-# help — DefaultStartLimitIntervalSec=10s with DefaultStartLimitBurst=5 needs 5
-# restarts inside 10s, and RestartSec spaces them further apart than that, so the
-# rate never reaches the limit. The window has to be wider than
-# RestartSec * StartLimitBurst for the limit to be reachable at all.
-StartLimitIntervalSec=120
-StartLimitBurst=5
 
 # Security hardening
 NoNewPrivileges=yes

--- a/autobot-slm-backend/ansible/roles/monitoring/templates/prometheus.service.j2
+++ b/autobot-slm-backend/ansible/roles/monitoring/templates/prometheus.service.j2
@@ -23,7 +23,6 @@ After=network-online.target
 StartLimitIntervalSec=120
 StartLimitBurst=5
 
-
 [Service]
 Type=simple
 User={{ prometheus_user }}

--- a/autobot-slm-backend/ansible/roles/npu-worker/templates/autobot-npu-worker.service.j2
+++ b/autobot-slm-backend/ansible/roles/npu-worker/templates/autobot-npu-worker.service.j2
@@ -4,6 +4,20 @@
 [Unit]
 Description=AutoBot NPU Acceleration Worker
 After=network.target
+# #4090: these live in [Unit], NOT [Service]. systemd's own verdict on the
+# wrong placement is "Unknown key name 'StartLimitIntervalSec' in section
+# 'Service', ignoring" — so the fix merged for #4090 was discarded on every unit
+# and chromadb still reached NRestarts=4399 while showing `activating`, never
+# `failed`. That is the exact outage #4090 exists to make visible.
+#
+# Without them a unit that can never exec restarts forever and stays out of
+# `systemctl --failed`. systemd's defaults do not help: DefaultStartLimitIntervalSec=10s
+# with DefaultStartLimitBurst=5 needs 5 restarts inside 10s, and RestartSec spaces
+# them further apart, so the rate never reaches the limit. The window must exceed
+# RestartSec * StartLimitBurst for the limit to be reachable at all.
+StartLimitIntervalSec=120
+StartLimitBurst=5
+
 
 [Service]
 Type=simple
@@ -15,15 +29,6 @@ EnvironmentFile=/opt/autobot/autobot-npu-worker/.env
 ExecStart={{ npu_install_dir }}/venv/bin/python {{ npu_install_dir }}/npu-worker.py
 Restart=always
 RestartSec=10
-# #4090: without these, a unit that can never exec restarts forever and stays
-# out of `systemctl --failed`, so the one thing an operator checks cannot see it
-# (chromadb: 1681 restarts over ~4h45m, invisible). systemd's OWN defaults do not
-# help — DefaultStartLimitIntervalSec=10s with DefaultStartLimitBurst=5 needs 5
-# restarts inside 10s, and RestartSec spaces them further apart than that, so the
-# rate never reaches the limit. The window has to be wider than
-# RestartSec * StartLimitBurst for the limit to be reachable at all.
-StartLimitIntervalSec=120
-StartLimitBurst=5
 StandardOutput=append:{{ npu_log_dir }}/npu-worker.log
 StandardError=append:{{ npu_log_dir }}/npu-worker-error.log
 

--- a/autobot-slm-backend/ansible/roles/npu-worker/templates/autobot-npu-worker.service.j2
+++ b/autobot-slm-backend/ansible/roles/npu-worker/templates/autobot-npu-worker.service.j2
@@ -18,7 +18,6 @@ After=network.target
 StartLimitIntervalSec=120
 StartLimitBurst=5
 
-
 [Service]
 Type=simple
 User={{ npu_user }}

--- a/autobot-slm-backend/ansible/roles/redis/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/redis/defaults/main.yml
@@ -79,16 +79,18 @@ chromadb_authn_env_file: /etc/autobot/chromadb.env
 
 # #13870: which role owns /etc/systemd/system/autobot-chromadb.service.
 #
-# The redis role, because ChromaDB IS a database and belongs with the db stack.
-# That is also the only venv where it is installed: the db-stack venv carries
-# chromadb, the ai-stack venv never did.
+# This default is the role's OWN name, and it is a FAIL-SAFE FLOOR, not the
+# answer. It decides only what happens when this role is applied alone with no
+# vars layer loaded — `api/setup_wizard.py::_generate_dynamic_inventory()` writes
+# a bare temp inventory with no group_vars sibling and no role_active_facts
+# include, so the "Setup AI Stack Node" action resolves nothing but these
+# defaults. A shared default of one role's name means that host deploys NO unit
+# at all, which is worse than the flip this issue fixes.
 #
-# An earlier revision of this made ai-stack the owner on a combined host, to
-# avoid relocating the persist directory. That produced the #4090 outage live —
-# ExecStart pointed at /opt/autobot/autobot-ai-stack/venv/bin/chroma, which does
-# not exist, and the unit reached NRestarts=4399 while reporting `activating`.
-# Owning the service and owning the data are two decisions; collapsing them into
-# one attached a database to the wrong stack.
+# The real decision is one precedence level up: `chromadb_service_owner` in
+# group_vars/all.yml hands a combined host to the db stack, because ChromaDB is
+# a database and that is the only role that installs it. On an ai-stack-only
+# host the ai-stack role installs chromadb itself, so owning it there is correct.
 chromadb_service_owner: "redis"
 
 # #13870: where the persist directory lived while the ai-stack role owned the

--- a/autobot-slm-backend/ansible/roles/redis/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/redis/defaults/main.yml
@@ -79,15 +79,19 @@ chromadb_authn_env_file: /etc/autobot/chromadb.env
 
 # #13870: which role owns /etc/systemd/system/autobot-chromadb.service.
 #
-# BOTH roles legitimately install and run chromadb, for different topologies,
-# and both used to write the SAME unit path from their own template. Whichever
-# ran last won, so the deployed ExecStart, Description and restart policy all
-# flipped with run order — observed live during the #4090 investigation.
+# The redis role, because ChromaDB IS a database and belongs with the db stack.
+# That is also the only venv where it is installed: the db-stack venv carries
+# chromadb, the ai-stack venv never did.
 #
-# This default is the role's OWN name, deliberately: it is the last-resort
-# floor, and it must fail SAFE. A shared default of one role's name meant every
-# topology running the other role alone deployed no unit at all — five of six
-# entry points, including the updater's — which is worse than the flip being
-# fixed. The both-roles case is resolved one precedence level up, by
-# `chromadb_service_owner` in group_vars/all.yml.
+# An earlier revision of this made ai-stack the owner on a combined host, to
+# avoid relocating the persist directory. That produced the #4090 outage live —
+# ExecStart pointed at /opt/autobot/autobot-ai-stack/venv/bin/chroma, which does
+# not exist, and the unit reached NRestarts=4399 while reporting `activating`.
+# Owning the service and owning the data are two decisions; collapsing them into
+# one attached a database to the wrong stack.
 chromadb_service_owner: "redis"
+
+# #13870: where the persist directory lived while the ai-stack role owned the
+# unit. Kept as a variable so the migration is inspectable and overridable
+# rather than a path buried in a task.
+chromadb_legacy_data_dir: /var/lib/autobot/chromadb

--- a/autobot-slm-backend/ansible/roles/redis/tasks/chromadb_data_migration.yml
+++ b/autobot-slm-backend/ansible/roles/redis/tasks/chromadb_data_migration.yml
@@ -5,11 +5,24 @@
 # Ownership now sits with the db stack — ChromaDB is a database — so the persist
 # directory moves with it.
 #
-# The dangerous part is not the move, it is the failure mode of getting it
-# wrong: chroma starts happily against an empty directory. No error, no crash,
-# no alert — the knowledge base simply reads as empty. So this refuses to leave
-# the service pointed at an empty target while the legacy path still holds data,
-# rather than trusting the move to have worked.
+# The dangerous part is not the move, it is the failure modes around it. Chroma
+# starts happily against an empty OR partial directory: no error, no crash, no
+# alert, just a knowledge base that returns nothing. So completeness is tracked
+# explicitly with a marker written only after the copy is verified, rather than
+# inferred from "the target has some files in it" — an interrupted copy leaves
+# exactly that state, and gating on it would skip the retry forever.
+
+- name: "ChromaDB | Ensure the db-stack persist directory exists"
+  # `cp -a src/. dst/` creates only the leaf, not missing parents, and this file
+  # runs before chromadb.yml's directory task on a from-scratch host.
+  ansible.builtin.file:
+    path: "{{ chromadb_data_dir }}"
+    state: directory
+    owner: "{{ redis_owner }}"
+    group: "{{ redis_group }}"
+    mode: "0750"
+  become: true
+  tags: ['redis', 'chromadb']
 
 - name: "ChromaDB | Stat the legacy persist directory"
   ansible.builtin.stat:
@@ -17,22 +30,23 @@
   register: _chroma_legacy
   tags: ['redis', 'chromadb']
 
-- name: "ChromaDB | Stat the db-stack persist directory"
+- name: "ChromaDB | Stat the migration marker"
+  # Written only after a copy has been verified complete. Its presence is the
+  # ONLY thing that means "this store has been migrated".
   ansible.builtin.stat:
-    path: "{{ chromadb_data_dir }}"
-  register: _chroma_target
+    path: "{{ chromadb_data_dir }}/.migrated-from-legacy"
+  register: _chroma_marker
   tags: ['redis', 'chromadb']
 
-- name: "ChromaDB | Measure both persist directories"
+- name: "ChromaDB | Count files in both persist directories"
   # `find -type f` rather than a size check: a directory can be non-empty and
-  # tiny (a fresh chroma writes a small sqlite file), which is exactly the state
-  # that must NOT be mistaken for a populated store.
+  # tiny (a fresh chroma writes a small sqlite file), and that state must never
+  # be mistaken for a populated store.
   ansible.builtin.find:
     paths: "{{ item }}"
     recurse: true
     file_type: file
   register: _chroma_counts
-  when: item is defined
   loop:
     - "{{ chromadb_legacy_data_dir }}"
     - "{{ chromadb_data_dir }}"
@@ -43,38 +57,53 @@
   ansible.builtin.set_fact:
     _chroma_legacy_files: "{{ (_chroma_counts.results[0].files | default([])) | length }}"
     _chroma_target_files: "{{ (_chroma_counts.results[1].files | default([])) | length }}"
+    # Explicit boolean, set BEFORE the block. `_something is defined` is not
+    # usable here: a registered task inside a SKIPPED block still produces a
+    # result dict, so `is defined` reads True even when the block never ran.
+    _chroma_migration_ran: false
   tags: ['redis', 'chromadb']
 
 - name: "ChromaDB | Report the persist directories before any move"
   ansible.builtin.debug:
     msg: >-
       legacy={{ chromadb_legacy_data_dir }} ({{ _chroma_legacy_files }} files),
-      target={{ chromadb_data_dir }} ({{ _chroma_target_files }} files)
+      target={{ chromadb_data_dir }} ({{ _chroma_target_files }} files),
+      migrated={{ _chroma_marker.stat.exists | default(false) }}
   tags: ['redis', 'chromadb']
 
 - name: "ChromaDB | Migrate the persist directory to the db stack"
+  # Runs whenever the legacy store has data and the marker is absent — NOT when
+  # the target merely looks empty. An interrupted copy leaves files behind, and
+  # gating on emptiness would skip the retry permanently and serve the partial
+  # store forever.
   when:
     - _chroma_legacy.stat.exists | default(false)
     - _chroma_legacy_files | int > 0
-    - _chroma_target_files | int == 0
+    - not (_chroma_marker.stat.exists | default(false))
   block:
+    - name: "ChromaDB | Is the service running?"
+      ansible.builtin.service_facts:
+
     - name: "ChromaDB | Stop the service before moving its store"
-      # Moving a live store underneath a running chroma corrupts it. The unit
-      # may not exist yet on a first run, which is not an error.
+      # Moving a live store underneath a running chroma corrupts it. Scoped to
+      # the case where the unit actually exists: a blanket `failed_when: false`
+      # would also swallow a genuine refusal-to-stop and let the copy run
+      # against a live, mid-write SQLite file.
       ansible.builtin.systemd:
         name: autobot-chromadb
         state: stopped
       become: true
-      failed_when: false
+      when: "'autobot-chromadb.service' in (ansible_facts.services | default({}))"
 
     - name: "ChromaDB | Copy the store to the db-stack path"
-      # Copy, not move: a failed move loses the only copy. The legacy directory
-      # is left in place for an operator to remove once the service is verified
-      # healthy on the new path — deletion is not this play's decision.
+      # Copy, not move: a failed move loses the only copy. No `creates:` guard —
+      # a partial copy must be resumable, and cp overwrites in place. The legacy
+      # directory is left for an operator to remove once the service is verified
+      # healthy; deletion is not this play's decision.
       ansible.builtin.command:
         cmd: "cp -a {{ chromadb_legacy_data_dir }}/. {{ chromadb_data_dir }}/"
-        creates: "{{ chromadb_data_dir }}/chroma.sqlite3"
       become: true
+      changed_when: true
 
     - name: "ChromaDB | Own the migrated store"
       ansible.builtin.file:
@@ -91,29 +120,45 @@
         file_type: file
       register: _chroma_target_after
 
-    - name: "ChromaDB | The copy must have landed"
+    - name: "ChromaDB | The copy must be complete before anything trusts it"
       ansible.builtin.assert:
         that:
-          - (_chroma_target_after.files | default([])) | length >= _chroma_legacy_files | int
+          - ((_chroma_target_after.files | default([])) | length) >= (_chroma_legacy_files | int)
         fail_msg: >-
           ChromaDB migration incomplete: {{ chromadb_legacy_data_dir }} holds
           {{ _chroma_legacy_files }} files but {{ chromadb_data_dir }} holds
-          {{ (_chroma_target_after.files | default([])) | length }}. Refusing to
-          continue — starting chroma against a partial store reads as an empty
-          knowledge base with no error anywhere (#13870).
+          {{ (_chroma_target_after.files | default([])) | length }}. No marker
+          written, so a re-run will retry rather than skip. Refusing to continue —
+          serving a partial store reads as an empty knowledge base with no error
+          anywhere (#13870).
+
+    - name: "ChromaDB | Mark the store migrated (only after the count is verified)"
+      ansible.builtin.copy:
+        content: "migrated from {{ chromadb_legacy_data_dir }} ({{ _chroma_legacy_files }} files)\n"
+        dest: "{{ chromadb_data_dir }}/.migrated-from-legacy"
+        owner: "{{ redis_owner }}"
+        group: "{{ redis_group }}"
+        mode: "0640"
+      become: true
+
+    - name: "ChromaDB | Record that the migration ran"
+      ansible.builtin.set_fact:
+        _chroma_migration_ran: true
   tags: ['redis', 'chromadb']
 
-- name: "ChromaDB | Refuse to serve an empty store while the legacy one holds data"
+- name: "ChromaDB | Refuse to serve an unmigrated store"
   # The safety net for every path that did NOT migrate: a skipped block, a
-  # changed variable, a partial run. Without it the service comes up on an empty
-  # directory and the only symptom is a knowledge base that returns nothing.
+  # changed variable, a partial run, an aborted play. Without it the service
+  # comes up on an empty or partial directory and the only symptom is a
+  # knowledge base that returns nothing.
   ansible.builtin.assert:
     that:
-      - not (_chroma_legacy_files | int > 0 and _chroma_target_files | int == 0 and not _chroma_migrated | default(false))
+      - not (_chroma_legacy_files | int > 0
+             and not (_chroma_marker.stat.exists | default(false))
+             and not (_chroma_migration_ran | bool))
     fail_msg: >-
-      {{ chromadb_legacy_data_dir }} holds {{ _chroma_legacy_files }} files while
-      {{ chromadb_data_dir }} is empty, and no migration ran. Starting chroma on
-      the empty path would report a healthy service and an empty knowledge base.
-  vars:
-    _chroma_migrated: "{{ _chroma_target_after is defined }}"
+      {{ chromadb_legacy_data_dir }} holds {{ _chroma_legacy_files }} files and
+      {{ chromadb_data_dir }} carries no migration marker, but no migration ran
+      this play. Starting chroma on the target path would report a healthy
+      service and an empty or partial knowledge base.
   tags: ['redis', 'chromadb']

--- a/autobot-slm-backend/ansible/roles/redis/tasks/chromadb_data_migration.yml
+++ b/autobot-slm-backend/ansible/roles/redis/tasks/chromadb_data_migration.yml
@@ -1,0 +1,119 @@
+---
+# ChromaDB data lives with the database stack (#13870).
+#
+# The store was written to the ai-stack path while that role owned the unit.
+# Ownership now sits with the db stack — ChromaDB is a database — so the persist
+# directory moves with it.
+#
+# The dangerous part is not the move, it is the failure mode of getting it
+# wrong: chroma starts happily against an empty directory. No error, no crash,
+# no alert — the knowledge base simply reads as empty. So this refuses to leave
+# the service pointed at an empty target while the legacy path still holds data,
+# rather than trusting the move to have worked.
+
+- name: "ChromaDB | Stat the legacy persist directory"
+  ansible.builtin.stat:
+    path: "{{ chromadb_legacy_data_dir }}"
+  register: _chroma_legacy
+  tags: ['redis', 'chromadb']
+
+- name: "ChromaDB | Stat the db-stack persist directory"
+  ansible.builtin.stat:
+    path: "{{ chromadb_data_dir }}"
+  register: _chroma_target
+  tags: ['redis', 'chromadb']
+
+- name: "ChromaDB | Measure both persist directories"
+  # `find -type f` rather than a size check: a directory can be non-empty and
+  # tiny (a fresh chroma writes a small sqlite file), which is exactly the state
+  # that must NOT be mistaken for a populated store.
+  ansible.builtin.find:
+    paths: "{{ item }}"
+    recurse: true
+    file_type: file
+  register: _chroma_counts
+  when: item is defined
+  loop:
+    - "{{ chromadb_legacy_data_dir }}"
+    - "{{ chromadb_data_dir }}"
+  failed_when: false
+  tags: ['redis', 'chromadb']
+
+- name: "ChromaDB | Record what each directory holds"
+  ansible.builtin.set_fact:
+    _chroma_legacy_files: "{{ (_chroma_counts.results[0].files | default([])) | length }}"
+    _chroma_target_files: "{{ (_chroma_counts.results[1].files | default([])) | length }}"
+  tags: ['redis', 'chromadb']
+
+- name: "ChromaDB | Report the persist directories before any move"
+  ansible.builtin.debug:
+    msg: >-
+      legacy={{ chromadb_legacy_data_dir }} ({{ _chroma_legacy_files }} files),
+      target={{ chromadb_data_dir }} ({{ _chroma_target_files }} files)
+  tags: ['redis', 'chromadb']
+
+- name: "ChromaDB | Migrate the persist directory to the db stack"
+  when:
+    - _chroma_legacy.stat.exists | default(false)
+    - _chroma_legacy_files | int > 0
+    - _chroma_target_files | int == 0
+  block:
+    - name: "ChromaDB | Stop the service before moving its store"
+      # Moving a live store underneath a running chroma corrupts it. The unit
+      # may not exist yet on a first run, which is not an error.
+      ansible.builtin.systemd:
+        name: autobot-chromadb
+        state: stopped
+      become: true
+      failed_when: false
+
+    - name: "ChromaDB | Copy the store to the db-stack path"
+      # Copy, not move: a failed move loses the only copy. The legacy directory
+      # is left in place for an operator to remove once the service is verified
+      # healthy on the new path — deletion is not this play's decision.
+      ansible.builtin.command:
+        cmd: "cp -a {{ chromadb_legacy_data_dir }}/. {{ chromadb_data_dir }}/"
+        creates: "{{ chromadb_data_dir }}/chroma.sqlite3"
+      become: true
+
+    - name: "ChromaDB | Own the migrated store"
+      ansible.builtin.file:
+        path: "{{ chromadb_data_dir }}"
+        owner: "{{ redis_owner }}"
+        group: "{{ redis_group }}"
+        recurse: true
+      become: true
+
+    - name: "ChromaDB | Re-count the target after the copy"
+      ansible.builtin.find:
+        paths: "{{ chromadb_data_dir }}"
+        recurse: true
+        file_type: file
+      register: _chroma_target_after
+
+    - name: "ChromaDB | The copy must have landed"
+      ansible.builtin.assert:
+        that:
+          - (_chroma_target_after.files | default([])) | length >= _chroma_legacy_files | int
+        fail_msg: >-
+          ChromaDB migration incomplete: {{ chromadb_legacy_data_dir }} holds
+          {{ _chroma_legacy_files }} files but {{ chromadb_data_dir }} holds
+          {{ (_chroma_target_after.files | default([])) | length }}. Refusing to
+          continue — starting chroma against a partial store reads as an empty
+          knowledge base with no error anywhere (#13870).
+  tags: ['redis', 'chromadb']
+
+- name: "ChromaDB | Refuse to serve an empty store while the legacy one holds data"
+  # The safety net for every path that did NOT migrate: a skipped block, a
+  # changed variable, a partial run. Without it the service comes up on an empty
+  # directory and the only symptom is a knowledge base that returns nothing.
+  ansible.builtin.assert:
+    that:
+      - not (_chroma_legacy_files | int > 0 and _chroma_target_files | int == 0 and not _chroma_migrated | default(false))
+    fail_msg: >-
+      {{ chromadb_legacy_data_dir }} holds {{ _chroma_legacy_files }} files while
+      {{ chromadb_data_dir }} is empty, and no migration ran. Starting chroma on
+      the empty path would report a healthy service and an empty knowledge base.
+  vars:
+    _chroma_migrated: "{{ _chroma_target_after is defined }}"
+  tags: ['redis', 'chromadb']

--- a/autobot-slm-backend/ansible/roles/redis/tasks/code_only.yml
+++ b/autobot-slm-backend/ansible/roles/redis/tasks/code_only.yml
@@ -97,6 +97,11 @@
   ansible.builtin.include_tasks: ../../../_shared/tasks/write_chromadb_authn_env.yml
   tags: ['redis', 'chromadb']
 
+- name: "ChromaDB | Move the persist directory to the db stack (#13870)"
+  ansible.builtin.include_tasks: chromadb_data_migration.yml
+  when: chromadb_service_owner == 'redis'
+  tags: ['redis', 'chromadb']
+
 - name: "ChromaDB | Deploy systemd service unit"
   # #13870: only when this role owns the unit — see chromadb_service_owner.
   when: chromadb_service_owner == 'redis'

--- a/autobot-slm-backend/ansible/roles/redis/templates/autobot-chromadb.service.j2
+++ b/autobot-slm-backend/ansible/roles/redis/templates/autobot-chromadb.service.j2
@@ -5,6 +5,20 @@
 Description=AutoBot ChromaDB - Vector Database
 Documentation=https://github.com/mrveiss/AutoBot-AI
 After=network.target
+# #4090: these live in [Unit], NOT [Service]. systemd's own verdict on the
+# wrong placement is "Unknown key name 'StartLimitIntervalSec' in section
+# 'Service', ignoring" — so the fix merged for #4090 was discarded on every unit
+# and chromadb still reached NRestarts=4399 while showing `activating`, never
+# `failed`. That is the exact outage #4090 exists to make visible.
+#
+# Without them a unit that can never exec restarts forever and stays out of
+# `systemctl --failed`. systemd's defaults do not help: DefaultStartLimitIntervalSec=10s
+# with DefaultStartLimitBurst=5 needs 5 restarts inside 10s, and RestartSec spaces
+# them further apart, so the rate never reaches the limit. The window must exceed
+# RestartSec * StartLimitBurst for the limit to be reachable at all.
+StartLimitIntervalSec=120
+StartLimitBurst=5
+
 
 [Service]
 Type=simple
@@ -37,17 +51,6 @@ ExecStart={{ chromadb_install_dir }}/venv/bin/chroma run \
 
 Restart=on-failure
 RestartSec=10
-# #4090: without these, a unit whose ExecStart can never succeed restarts forever
-# and stays out of `systemctl --failed`, so the one thing an operator checks
-# cannot see it (chromadb: 1681 restarts over ~4h45m, invisible). `on-failure`
-# is no safer than `always` here — an exec that never succeeds never exits
-# cleanly, so it reschedules just as indefinitely. systemd's OWN defaults do not
-# help: DefaultStartLimitIntervalSec=10s with DefaultStartLimitBurst=5 needs 5
-# restarts inside 10s, and RestartSec spaces them further apart, so the rate
-# never reaches the limit. The window must exceed RestartSec * StartLimitBurst
-# for the limit to be reachable at all.
-StartLimitIntervalSec=120
-StartLimitBurst=5
 TimeoutStartSec=30
 TimeoutStopSec=30
 MemoryMax=4G

--- a/autobot-slm-backend/ansible/roles/redis/templates/autobot-chromadb.service.j2
+++ b/autobot-slm-backend/ansible/roles/redis/templates/autobot-chromadb.service.j2
@@ -19,7 +19,6 @@ After=network.target
 StartLimitIntervalSec=120
 StartLimitBurst=5
 
-
 [Service]
 Type=simple
 User={{ redis_owner }}

--- a/autobot-slm-backend/ansible/roles/redis/templates/redis_exporter.service.j2
+++ b/autobot-slm-backend/ansible/roles/redis/templates/redis_exporter.service.j2
@@ -22,7 +22,6 @@ Wants=network-online.target
 StartLimitIntervalSec=120
 StartLimitBurst=5
 
-
 [Service]
 Type=simple
 User=redis_exporter

--- a/autobot-slm-backend/ansible/roles/redis/templates/redis_exporter.service.j2
+++ b/autobot-slm-backend/ansible/roles/redis/templates/redis_exporter.service.j2
@@ -8,6 +8,20 @@ Description=Redis Exporter for Prometheus
 Documentation=https://github.com/oliver006/redis_exporter
 After=network-online.target redis-stack-server.service
 Wants=network-online.target
+# #4090: these live in [Unit], NOT [Service]. systemd's own verdict on the
+# wrong placement is "Unknown key name 'StartLimitIntervalSec' in section
+# 'Service', ignoring" — so the fix merged for #4090 was discarded on every unit
+# and chromadb still reached NRestarts=4399 while showing `activating`, never
+# `failed`. That is the exact outage #4090 exists to make visible.
+#
+# Without them a unit that can never exec restarts forever and stays out of
+# `systemctl --failed`. systemd's defaults do not help: DefaultStartLimitIntervalSec=10s
+# with DefaultStartLimitBurst=5 needs 5 restarts inside 10s, and RestartSec spaces
+# them further apart, so the rate never reaches the limit. The window must exceed
+# RestartSec * StartLimitBurst for the limit to be reachable at all.
+StartLimitIntervalSec=120
+StartLimitBurst=5
+
 
 [Service]
 Type=simple
@@ -22,17 +36,6 @@ Environment="REDIS_PASSWORD={{ redis_password }}"
 {% endif %}
 Restart=on-failure
 RestartSec=5s
-# #4090: without these, a unit whose ExecStart can never succeed restarts forever
-# and stays out of `systemctl --failed`, so the one thing an operator checks
-# cannot see it (chromadb: 1681 restarts over ~4h45m, invisible). `on-failure`
-# is no safer than `always` here — an exec that never succeeds never exits
-# cleanly, so it reschedules just as indefinitely. systemd's OWN defaults do not
-# help: DefaultStartLimitIntervalSec=10s with DefaultStartLimitBurst=5 needs 5
-# restarts inside 10s, and RestartSec spaces them further apart, so the rate
-# never reaches the limit. The window must exceed RestartSec * StartLimitBurst
-# for the limit to be reachable at all.
-StartLimitIntervalSec=120
-StartLimitBurst=5
 NoNewPrivileges=true
 ProtectSystem=strict
 ProtectHome=true

--- a/autobot-slm-backend/ansible/roles/slm_agent/templates/slm-agent.service.j2
+++ b/autobot-slm-backend/ansible/roles/slm_agent/templates/slm-agent.service.j2
@@ -37,7 +37,6 @@ ConditionPathExists={{ slm_agent_dir }}/slm/agent/agent.py
 StartLimitIntervalSec=120
 StartLimitBurst=5
 
-
 [Service]
 Type=simple
 User={{ slm_agent_user }}

--- a/autobot-slm-backend/ansible/roles/slm_agent/templates/slm-agent.service.j2
+++ b/autobot-slm-backend/ansible/roles/slm_agent/templates/slm-agent.service.j2
@@ -23,6 +23,20 @@ After=network-online.target
 Wants=network-online.target
 # Guard: skip start (no crash loop) if agent files not yet deployed by Ansible (#MVA-1036)
 ConditionPathExists={{ slm_agent_dir }}/slm/agent/agent.py
+# #4090: these live in [Unit], NOT [Service]. systemd's own verdict on the
+# wrong placement is "Unknown key name 'StartLimitIntervalSec' in section
+# 'Service', ignoring" — so the fix merged for #4090 was discarded on every unit
+# and chromadb still reached NRestarts=4399 while showing `activating`, never
+# `failed`. That is the exact outage #4090 exists to make visible.
+#
+# Without them a unit that can never exec restarts forever and stays out of
+# `systemctl --failed`. systemd's defaults do not help: DefaultStartLimitIntervalSec=10s
+# with DefaultStartLimitBurst=5 needs 5 restarts inside 10s, and RestartSec spaces
+# them further apart, so the rate never reaches the limit. The window must exceed
+# RestartSec * StartLimitBurst for the limit to be reachable at all.
+StartLimitIntervalSec=120
+StartLimitBurst=5
+
 
 [Service]
 Type=simple
@@ -65,15 +79,6 @@ ExecStart=/usr/bin/python3 -m slm.agent.agent \
 # Restart policy
 Restart=always
 RestartSec={{ slm_agent_restart_sec }}
-# #4090: without these, a unit that can never exec restarts forever and stays
-# out of `systemctl --failed`, so the one thing an operator checks cannot see it
-# (chromadb: 1681 restarts over ~4h45m, invisible). systemd's OWN defaults do not
-# help — DefaultStartLimitIntervalSec=10s with DefaultStartLimitBurst=5 needs 5
-# restarts inside 10s, and RestartSec spaces them further apart than that, so the
-# rate never reaches the limit. The window has to be wider than
-# RestartSec * StartLimitBurst for the limit to be reachable at all.
-StartLimitIntervalSec=120
-StartLimitBurst=5
 
 # Watchdog (systemd will restart if agent becomes unresponsive)
 WatchdogSec={{ slm_agent_watchdog_sec }}

--- a/autobot-slm-backend/ansible/roles/slm_manager/templates/autobot-slm-backend.service.j2
+++ b/autobot-slm-backend/ansible/roles/slm_manager/templates/autobot-slm-backend.service.j2
@@ -16,7 +16,6 @@ Wants=network-online.target redis-stack-server.service postgresql.service
 StartLimitIntervalSec=120
 StartLimitBurst=5
 
-
 [Service]
 Type=simple
 User={{ slm_user }}

--- a/autobot-slm-backend/ansible/roles/slm_manager/templates/autobot-slm-backend.service.j2
+++ b/autobot-slm-backend/ansible/roles/slm_manager/templates/autobot-slm-backend.service.j2
@@ -2,6 +2,20 @@
 Description=AutoBot SLM Backend Service
 After=network-online.target redis-stack-server.service postgresql.service
 Wants=network-online.target redis-stack-server.service postgresql.service
+# #4090: these live in [Unit], NOT [Service]. systemd's own verdict on the
+# wrong placement is "Unknown key name 'StartLimitIntervalSec' in section
+# 'Service', ignoring" — so the fix merged for #4090 was discarded on every unit
+# and chromadb still reached NRestarts=4399 while showing `activating`, never
+# `failed`. That is the exact outage #4090 exists to make visible.
+#
+# Without them a unit that can never exec restarts forever and stays out of
+# `systemctl --failed`. systemd's defaults do not help: DefaultStartLimitIntervalSec=10s
+# with DefaultStartLimitBurst=5 needs 5 restarts inside 10s, and RestartSec spaces
+# them further apart, so the rate never reaches the limit. The window must exceed
+# RestartSec * StartLimitBurst for the limit to be reachable at all.
+StartLimitIntervalSec=120
+StartLimitBurst=5
+
 
 [Service]
 Type=simple
@@ -23,15 +37,6 @@ ExecStart={{ slm_backend_dir }}/venv/bin/uvicorn main:app --host {{ slm_backend_
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=always
 RestartSec=5
-# #4090: without these, a unit that can never exec restarts forever and stays
-# out of `systemctl --failed`, so the one thing an operator checks cannot see it
-# (chromadb: 1681 restarts over ~4h45m, invisible). systemd's OWN defaults do not
-# help — DefaultStartLimitIntervalSec=10s with DefaultStartLimitBurst=5 needs 5
-# restarts inside 10s, and RestartSec spaces them further apart than that, so the
-# rate never reaches the limit. The window has to be wider than
-# RestartSec * StartLimitBurst for the limit to be reachable at all.
-StartLimitIntervalSec=120
-StartLimitBurst=5
 TimeoutStopSec={{ slm_backend_stop_timeout_sec | default(45) }}
 StandardOutput=append:{{ slm_log_dir }}/slm-backend.log
 StandardError=append:{{ slm_log_dir }}/slm-backend-error.log

--- a/autobot-slm-backend/ansible/roles/tts-worker/templates/autobot-tts-worker.service.j2
+++ b/autobot-slm-backend/ansible/roles/tts-worker/templates/autobot-tts-worker.service.j2
@@ -18,7 +18,6 @@ After=network.target
 StartLimitIntervalSec=120
 StartLimitBurst=5
 
-
 [Service]
 Type=simple
 User={{ tts_user }}

--- a/autobot-slm-backend/ansible/roles/tts-worker/templates/autobot-tts-worker.service.j2
+++ b/autobot-slm-backend/ansible/roles/tts-worker/templates/autobot-tts-worker.service.j2
@@ -4,6 +4,20 @@
 [Unit]
 Description=AutoBot TTS Worker (Pocket TTS)
 After=network.target
+# #4090: these live in [Unit], NOT [Service]. systemd's own verdict on the
+# wrong placement is "Unknown key name 'StartLimitIntervalSec' in section
+# 'Service', ignoring" — so the fix merged for #4090 was discarded on every unit
+# and chromadb still reached NRestarts=4399 while showing `activating`, never
+# `failed`. That is the exact outage #4090 exists to make visible.
+#
+# Without them a unit that can never exec restarts forever and stays out of
+# `systemctl --failed`. systemd's defaults do not help: DefaultStartLimitIntervalSec=10s
+# with DefaultStartLimitBurst=5 needs 5 restarts inside 10s, and RestartSec spaces
+# them further apart, so the rate never reaches the limit. The window must exceed
+# RestartSec * StartLimitBurst for the limit to be reachable at all.
+StartLimitIntervalSec=120
+StartLimitBurst=5
+
 
 [Service]
 Type=simple
@@ -15,15 +29,6 @@ EnvironmentFile={{ tts_install_dir }}/.env
 ExecStart={{ tts_install_dir }}/venv/bin/python {{ tts_install_dir }}/tts-worker.py
 Restart=always
 RestartSec=10
-# #4090: without these, a unit that can never exec restarts forever and stays
-# out of `systemctl --failed`, so the one thing an operator checks cannot see it
-# (chromadb: 1681 restarts over ~4h45m, invisible). systemd's OWN defaults do not
-# help — DefaultStartLimitIntervalSec=10s with DefaultStartLimitBurst=5 needs 5
-# restarts inside 10s, and RestartSec spaces them further apart than that, so the
-# rate never reaches the limit. The window has to be wider than
-# RestartSec * StartLimitBurst for the limit to be reachable at all.
-StartLimitIntervalSec=120
-StartLimitBurst=5
 StandardOutput=append:{{ tts_log_dir }}/tts-worker.log
 StandardError=append:{{ tts_log_dir }}/tts-worker-error.log
 

--- a/autobot-slm-backend/ansible/roles/vnc/templates/vnc-server.service.j2
+++ b/autobot-slm-backend/ansible/roles/vnc/templates/vnc-server.service.j2
@@ -21,7 +21,6 @@ After=syslog.target network.target
 StartLimitIntervalSec=120
 StartLimitBurst=5
 
-
 [Service]
 Type=simple
 User={{ vnc_user }}

--- a/autobot-slm-backend/ansible/roles/vnc/templates/vnc-server.service.j2
+++ b/autobot-slm-backend/ansible/roles/vnc/templates/vnc-server.service.j2
@@ -7,6 +7,20 @@
 [Unit]
 Description=TigerVNC Server for AutoBot
 After=syslog.target network.target
+# #4090: these live in [Unit], NOT [Service]. systemd's own verdict on the
+# wrong placement is "Unknown key name 'StartLimitIntervalSec' in section
+# 'Service', ignoring" — so the fix merged for #4090 was discarded on every unit
+# and chromadb still reached NRestarts=4399 while showing `activating`, never
+# `failed`. That is the exact outage #4090 exists to make visible.
+#
+# Without them a unit that can never exec restarts forever and stays out of
+# `systemctl --failed`. systemd's defaults do not help: DefaultStartLimitIntervalSec=10s
+# with DefaultStartLimitBurst=5 needs 5 restarts inside 10s, and RestartSec spaces
+# them further apart, so the rate never reaches the limit. The window must exceed
+# RestartSec * StartLimitBurst for the limit to be reachable at all.
+StartLimitIntervalSec=120
+StartLimitBurst=5
+
 
 [Service]
 Type=simple
@@ -25,17 +39,6 @@ ExecStop=/usr/bin/vncserver -kill :{{ vnc_display }}
 
 Restart=on-failure
 RestartSec=5
-# #4090: without these, a unit whose ExecStart can never succeed restarts forever
-# and stays out of `systemctl --failed`, so the one thing an operator checks
-# cannot see it (chromadb: 1681 restarts over ~4h45m, invisible). `on-failure`
-# is no safer than `always` here — an exec that never succeeds never exits
-# cleanly, so it reschedules just as indefinitely. systemd's OWN defaults do not
-# help: DefaultStartLimitIntervalSec=10s with DefaultStartLimitBurst=5 needs 5
-# restarts inside 10s, and RestartSec spaces them further apart, so the rate
-# never reaches the limit. The window must exceed RestartSec * StartLimitBurst
-# for the limit to be reachable at all.
-StartLimitIntervalSec=120
-StartLimitBurst=5
 
 [Install]
 WantedBy=multi-user.target

--- a/autobot-slm-backend/ansible/roles/vnc/templates/vnc-websockify.service.j2
+++ b/autobot-slm-backend/ansible/roles/vnc/templates/vnc-websockify.service.j2
@@ -8,6 +8,20 @@
 Description=Websockify for noVNC (AutoBot)
 After=network.target {{ vnc_service_name }}.service
 Requires={{ vnc_service_name }}.service
+# #4090: these live in [Unit], NOT [Service]. systemd's own verdict on the
+# wrong placement is "Unknown key name 'StartLimitIntervalSec' in section
+# 'Service', ignoring" — so the fix merged for #4090 was discarded on every unit
+# and chromadb still reached NRestarts=4399 while showing `activating`, never
+# `failed`. That is the exact outage #4090 exists to make visible.
+#
+# Without them a unit that can never exec restarts forever and stays out of
+# `systemctl --failed`. systemd's defaults do not help: DefaultStartLimitIntervalSec=10s
+# with DefaultStartLimitBurst=5 needs 5 restarts inside 10s, and RestartSec spaces
+# them further apart, so the rate never reaches the limit. The window must exceed
+# RestartSec * StartLimitBurst for the limit to be reachable at all.
+StartLimitIntervalSec=120
+StartLimitBurst=5
+
 
 [Service]
 Type=simple
@@ -26,17 +40,6 @@ ExecStart=/usr/bin/websockify --web={{ novnc_path }} \
 
 Restart=on-failure
 RestartSec=5
-# #4090: without these, a unit whose ExecStart can never succeed restarts forever
-# and stays out of `systemctl --failed`, so the one thing an operator checks
-# cannot see it (chromadb: 1681 restarts over ~4h45m, invisible). `on-failure`
-# is no safer than `always` here — an exec that never succeeds never exits
-# cleanly, so it reschedules just as indefinitely. systemd's OWN defaults do not
-# help: DefaultStartLimitIntervalSec=10s with DefaultStartLimitBurst=5 needs 5
-# restarts inside 10s, and RestartSec spaces them further apart, so the rate
-# never reaches the limit. The window must exceed RestartSec * StartLimitBurst
-# for the limit to be reachable at all.
-StartLimitIntervalSec=120
-StartLimitBurst=5
 
 [Install]
 WantedBy=multi-user.target

--- a/autobot-slm-backend/ansible/roles/vnc/templates/vnc-websockify.service.j2
+++ b/autobot-slm-backend/ansible/roles/vnc/templates/vnc-websockify.service.j2
@@ -22,7 +22,6 @@ Requires={{ vnc_service_name }}.service
 StartLimitIntervalSec=120
 StartLimitBurst=5
 
-
 [Service]
 Type=simple
 User={{ vnc_user }}

--- a/autobot-slm-backend/ansible/templates/autobot-backend-single-worker.service.j2
+++ b/autobot-slm-backend/ansible/templates/autobot-backend-single-worker.service.j2
@@ -4,6 +4,20 @@
 [Unit]
 Description=AutoBot Backend API
 After=network.target redis.service
+# #4090: these live in [Unit], NOT [Service]. systemd's own verdict on the
+# wrong placement is "Unknown key name 'StartLimitIntervalSec' in section
+# 'Service', ignoring" — so the fix merged for #4090 was discarded on every unit
+# and chromadb still reached NRestarts=4399 while showing `activating`, never
+# `failed`. That is the exact outage #4090 exists to make visible.
+#
+# Without them a unit that can never exec restarts forever and stays out of
+# `systemctl --failed`. systemd's defaults do not help: DefaultStartLimitIntervalSec=10s
+# with DefaultStartLimitBurst=5 needs 5 restarts inside 10s, and RestartSec spaces
+# them further apart, so the rate never reaches the limit. The window must exceed
+# RestartSec * StartLimitBurst for the limit to be reachable at all.
+StartLimitIntervalSec=120
+StartLimitBurst=5
+
 
 [Service]
 Type=simple
@@ -23,15 +37,6 @@ ExecStart={{ backend_venv }}/bin/uvicorn main:app --host 0.0.0.0 --port 8443 --w
 
 Restart=always
 RestartSec=5
-# #4090: without these, a unit that can never exec restarts forever and stays
-# out of `systemctl --failed`, so the one thing an operator checks cannot see it
-# (chromadb: 1681 restarts over ~4h45m, invisible). systemd's OWN defaults do not
-# help — DefaultStartLimitIntervalSec=10s with DefaultStartLimitBurst=5 needs 5
-# restarts inside 10s, and RestartSec spaces them further apart than that, so the
-# rate never reaches the limit. The window has to be wider than
-# RestartSec * StartLimitBurst for the limit to be reachable at all.
-StartLimitIntervalSec=120
-StartLimitBurst=5
 StandardOutput=append:/var/log/autobot/backend.log
 StandardError=append:/var/log/autobot/backend-error.log
 

--- a/autobot-slm-backend/ansible/templates/autobot-backend-single-worker.service.j2
+++ b/autobot-slm-backend/ansible/templates/autobot-backend-single-worker.service.j2
@@ -18,7 +18,6 @@ After=network.target redis.service
 StartLimitIntervalSec=120
 StartLimitBurst=5
 
-
 [Service]
 Type=simple
 User=autobot

--- a/autobot-slm-backend/ansible/templates/systemd/redis-stack-server.service.j2
+++ b/autobot-slm-backend/ansible/templates/systemd/redis-stack-server.service.j2
@@ -17,7 +17,6 @@ After=network-online.target
 StartLimitIntervalSec=120
 StartLimitBurst=5
 
-
 [Service]
 Type=notify
 User={{ redis_user }}

--- a/autobot-slm-backend/ansible/templates/systemd/redis-stack-server.service.j2
+++ b/autobot-slm-backend/ansible/templates/systemd/redis-stack-server.service.j2
@@ -3,6 +3,20 @@ Description=Redis Stack Server for AutoBot
 Documentation=https://redis.io/docs/latest/operate/oss_and_stack/
 Wants=network-online.target
 After=network-online.target
+# #4090: these live in [Unit], NOT [Service]. systemd's own verdict on the
+# wrong placement is "Unknown key name 'StartLimitIntervalSec' in section
+# 'Service', ignoring" — so the fix merged for #4090 was discarded on every unit
+# and chromadb still reached NRestarts=4399 while showing `activating`, never
+# `failed`. That is the exact outage #4090 exists to make visible.
+#
+# Without them a unit that can never exec restarts forever and stays out of
+# `systemctl --failed`. systemd's defaults do not help: DefaultStartLimitIntervalSec=10s
+# with DefaultStartLimitBurst=5 needs 5 restarts inside 10s, and RestartSec spaces
+# them further apart, so the rate never reaches the limit. The window must exceed
+# RestartSec * StartLimitBurst for the limit to be reachable at all.
+StartLimitIntervalSec=120
+StartLimitBurst=5
+
 
 [Service]
 Type=notify
@@ -19,15 +33,6 @@ ExecStop=/bin/kill -s TERM $MAINPID
 
 Restart=always
 RestartSec=5
-# #4090: without these, a unit that can never exec restarts forever and stays
-# out of `systemctl --failed`, so the one thing an operator checks cannot see it
-# (chromadb: 1681 restarts over ~4h45m, invisible). systemd's OWN defaults do not
-# help — DefaultStartLimitIntervalSec=10s with DefaultStartLimitBurst=5 needs 5
-# restarts inside 10s, and RestartSec spaces them further apart than that, so the
-# rate never reaches the limit. The window has to be wider than
-# RestartSec * StartLimitBurst for the limit to be reachable at all.
-StartLimitIntervalSec=120
-StartLimitBurst=5
 TimeoutStopSec=10
 
 # Resource limits

--- a/autobot-slm-backend/ansible/tests/inventory/group_vars/all.yml
+++ b/autobot-slm-backend/ansible/tests/inventory/group_vars/all.yml
@@ -98,4 +98,4 @@ role_tts_worker_active: >-
 
 # #13870: mirrors inventory/group_vars/all.yml — kept in sync by
 # tests/check_role_facts_synced.py.
-chromadb_service_owner: "{{ 'ai-stack' if (role_ai_stack_active | default(false) | bool) else 'redis' }}"
+chromadb_service_owner: "{{ 'redis' if (role_redis_active | default(false) | bool) else 'ai-stack' }}"

--- a/autobot-slm-backend/tests/services/test_chromadb_unit_single_owner_13870_test.py
+++ b/autobot-slm-backend/tests/services/test_chromadb_unit_single_owner_13870_test.py
@@ -84,24 +84,6 @@ def test_each_role_declares_a_default_owner(role: str):
     assert defaults["chromadb_service_owner"] in _ROLES
 
 
-def test_the_roles_do_not_share_one_default():
-    """They must DISAGREE — each defaults to its own name.
-
-    The first version asserted the opposite, and that is what produced the
-    review's headline defect: with both roles defaulting to "redis", every
-    topology that runs ai-stack without redis skipped the template task and
-    deployed no unit at all. Five of six entry points, including the updater's.
-    A default that is the role's own name always writes something.
-    """
-    values = {
-        role: yaml.safe_load((_ANSIBLE / "roles" / role / "defaults" / "main.yml").read_text(encoding="utf-8"))[
-            "chromadb_service_owner"
-        ]
-        for role in _ROLES
-    }
-    assert values == {role: role for role in _ROLES}, f"defaults must be self-named, got {values}"
-
-
 def test_the_ai_stack_only_play_still_resolves_an_owner():
     """setup-ai-stack.yml needs no override now that the role default is
     self-named — and it must not have one.
@@ -187,23 +169,6 @@ def test_every_unit_writer_in_the_tree_is_gated():
     assert not ungated, "tasks writing the chromadb unit without an ownership gate: " + "; ".join(ungated)
 
 
-def test_every_ai_stack_entry_point_resolves_to_a_writer():
-    """A topology that applies ai-stack without redis must still get a unit.
-
-    A shared default of one role's name meant five of six entry points —
-    including the updater's own path — silently deployed nothing, which the
-    PR's own comment had already identified as worse than the bug being fixed.
-    The floor is now each role's own name, so a single-role topology always
-    writes.
-    """
-    for role in _ROLES:
-        defaults = yaml.safe_load((_ANSIBLE / "roles" / role / "defaults" / "main.yml").read_text(encoding="utf-8"))
-        assert defaults["chromadb_service_owner"] == role, (
-            f"{role}'s default must be its own name — a shared default makes every "
-            "single-role topology deploy no unit at all"
-        )
-
-
 def test_the_combined_host_owner_is_derived_where_both_roles_can_run():
     """Both places that carry the role_*_active facts must agree, or a run that
     loads one and not the other resolves differently."""
@@ -213,40 +178,6 @@ def test_the_combined_host_owner_is_derived_where_both_roles_can_run():
         assert (
             "role_ai_stack_active" in text or "role_redis_active" in text
         ), f"{rel} does not derive the owner from a role_*_active fact"
-
-
-def test_the_combined_host_keeps_todays_data_path():
-    """ai-stack must win a combined host, because that is what wins TODAY.
-
-    The old run order put ai-stack last (deploy.yml applies redis before
-    ai-stack; the fleet play runs redis in phase 3 and ai-stack in 5a), so the
-    live ExecStart --path is ai-stack's. Handing ownership to redis relocates
-    the vector store, and chroma comes up healthy against an empty directory —
-    the knowledge base would read as empty with no error anywhere. Making
-    ownership deterministic must not smuggle in a data move.
-    """
-    for rel in ("inventory/group_vars/all.yml", "playbooks/vars/role_active_facts.yml"):
-        text = (_ANSIBLE / rel).read_text(encoding="utf-8")
-        line = next(ln for ln in text.splitlines() if ln.startswith("chromadb_service_owner:"))
-        assert "'ai-stack' if" in line, (
-            f"{rel} hands a combined host to redis — that relocates the chroma data "
-            "directory silently (#13870, open decision)"
-        )
-
-
-# ---------------------------------------------------------------------------
-# #13870 follow-up: the two units differed in more than their path, and which
-# one won was decided by role order. Whatever a host ended up with, it got an
-# arbitrary combination of these — and nothing made that visible.
-#
-# The memory watermarks that were here are gone, and the reason is worth
-# keeping: `CgroupMemoryCollector` reads its OWN host's /sys/fs/cgroup and is
-# scraped only from the backend and slm-backend processes. Chroma runs on the
-# ai/ML and database nodes, so `autobot_cgroup_memory_*` is never produced for
-# this unit on the documented multi-node topology — the alerting that would have
-# justified a watermark is structurally unable to fire for it. Adding MemoryHigh
-# there would have shipped a throttle with no observer. Tracked separately.
-# ---------------------------------------------------------------------------
 
 
 def _directive(text: str, name: str) -> str | None:
@@ -272,3 +203,46 @@ def test_the_unit_writing_to_a_file_is_unbuffered(role: str):
     if "StandardOutput=append:" not in text:
         pytest.skip(f"{role} does not append to a file")
     assert 'Environment="PYTHONUNBUFFERED=1"' in text, f"{role} buffers chroma's diagnostics into a file"
+
+
+def test_the_database_stack_owns_the_database():
+    """ChromaDB is a database, so the db stack owns its unit.
+
+    An earlier revision made ai-stack the owner on a combined host, to avoid
+    relocating the persist directory. That produced the #4090 outage live:
+    ExecStart pointed at /opt/autobot/autobot-ai-stack/venv/bin/chroma, which
+    does not exist — only the db-stack venv has chromadb installed — and the
+    unit reached NRestarts=4399 while reporting `activating`.
+
+    Owning the service and owning the data are two decisions. Collapsing them
+    into one attached a database to the wrong stack.
+    """
+    for role in _ROLES:
+        defaults = yaml.safe_load((_ANSIBLE / "roles" / role / "defaults" / "main.yml").read_text(encoding="utf-8"))
+        assert (
+            defaults["chromadb_service_owner"] == "redis"
+        ), f"{role} does not hand chroma to the db stack — the ai-stack venv has no chromadb installed"
+
+    for rel in ("inventory/group_vars/all.yml", "playbooks/vars/role_active_facts.yml"):
+        line = next(
+            ln
+            for ln in (_ANSIBLE / rel).read_text(encoding="utf-8").splitlines()
+            if ln.startswith("chromadb_service_owner:")
+        )
+        assert "'redis' if" in line, f"{rel} does not give the db stack ownership where it is present"
+
+
+def test_the_persist_directory_moves_with_the_service():
+    """The store follows the database. The migration must exist and must refuse
+    to leave the service pointed at an empty directory while the legacy path
+    holds data — chroma starts happily on an empty store and the knowledge base
+    simply reads as empty, with no error anywhere."""
+    tasks = (_ANSIBLE / "roles" / "redis" / "tasks" / "chromadb_data_migration.yml").read_text(encoding="utf-8")
+    assert "chromadb_legacy_data_dir" in tasks
+    assert "assert" in tasks, "the migration has no guard against serving an empty store"
+
+    code_only = (_ANSIBLE / "roles" / "redis" / "tasks" / "code_only.yml").read_text(encoding="utf-8")
+    assert "chromadb_data_migration.yml" in code_only, "the migration is never included"
+    assert code_only.index("chromadb_data_migration.yml") < code_only.index(
+        _UNIT_DEST
+    ), "the migration must run BEFORE the unit is deployed, or the service starts on the old path"

--- a/autobot-slm-backend/tests/services/test_chromadb_unit_single_owner_13870_test.py
+++ b/autobot-slm-backend/tests/services/test_chromadb_unit_single_owner_13870_test.py
@@ -205,31 +205,71 @@ def test_the_unit_writing_to_a_file_is_unbuffered(role: str):
     assert 'Environment="PYTHONUNBUFFERED=1"' in text, f"{role} buffers chroma's diagnostics into a file"
 
 
-def test_the_database_stack_owns_the_database():
-    """ChromaDB is a database, so the db stack owns its unit.
+def test_each_role_keeps_a_self_named_floor():
+    """The floor is what a role resolves to when applied ALONE with no vars
+    layer loaded — `setup_wizard._generate_dynamic_inventory()` writes a bare
+    temp inventory with no group_vars sibling, so the "Setup AI Stack Node"
+    action sees nothing but these defaults.
 
-    An earlier revision made ai-stack the owner on a combined host, to avoid
-    relocating the persist directory. That produced the #4090 outage live:
-    ExecStart pointed at /opt/autobot/autobot-ai-stack/venv/bin/chroma, which
-    does not exist — only the db-stack venv has chromadb installed — and the
-    unit reached NRestarts=4399 while reporting `activating`.
-
-    Owning the service and owning the data are two decisions. Collapsing them
-    into one attached a database to the wrong stack.
+    A shared default of one role's name means that host deploys NO unit at all.
+    Review caught that in #14055, and I re-created it here by moving both floors
+    to "redis" while fixing the ownership question — which is one precedence
+    level up and unaffected by the floor.
     """
     for role in _ROLES:
         defaults = yaml.safe_load((_ANSIBLE / "roles" / role / "defaults" / "main.yml").read_text(encoding="utf-8"))
-        assert (
-            defaults["chromadb_service_owner"] == "redis"
-        ), f"{role} does not hand chroma to the db stack — the ai-stack venv has no chromadb installed"
+        assert defaults["chromadb_service_owner"] == role, (
+            f"{role}'s floor must be its own name — a shared floor makes a single-role "
+            "topology with no vars layer deploy nothing"
+        )
 
+
+def test_the_migration_does_not_gate_on_an_empty_target():
+    """An interrupted copy leaves the target non-empty. Gating the retry on
+    "target is empty" would skip it forever and serve the partial store — the
+    same silent-wrong-data class the migration exists to prevent, one step
+    removed."""
+    tasks = (_ANSIBLE / "roles" / "redis" / "tasks" / "chromadb_data_migration.yml").read_text(encoding="utf-8")
+    assert ".migrated-from-legacy" in tasks, "completeness is not tracked by a marker"
+    assert "_chroma_migration_ran: false" in tasks, (
+        "the safety net must use an explicit boolean — a registered task in a SKIPPED block "
+        "still yields a result dict, so `is defined` reads True when nothing ran"
+    )
+    block_gate = tasks.index('- name: "ChromaDB | Migrate the persist directory')
+    gate_text = tasks[block_gate : block_gate + 700]
+    assert (
+        "_chroma_target_files | int == 0" not in gate_text
+    ), "the migration gates on an empty target — an interrupted copy would never be retried"
+
+
+def test_the_database_stack_owns_the_database():
+    """ChromaDB is a database, so on a host running both roles the db stack owns
+    its unit — and that is the only role that installs chromadb.
+
+    Asserted on the DERIVATION, not on the role defaults. The defaults are a
+    fail-safe floor for a role applied alone; the ownership decision is one
+    precedence level up. Conflating the two is how I broke the ai-stack-only
+    topology while fixing this.
+
+    An earlier revision made ai-stack the owner on a combined host to avoid
+    relocating the persist directory. That produced the #4090 outage live:
+    ExecStart pointed at /opt/autobot/autobot-ai-stack/venv/bin/chroma, which
+    does not exist, and the unit reached NRestarts=4399 while reporting
+    `activating`.
+    """
     for rel in ("inventory/group_vars/all.yml", "playbooks/vars/role_active_facts.yml"):
         line = next(
             ln
             for ln in (_ANSIBLE / rel).read_text(encoding="utf-8").splitlines()
             if ln.startswith("chromadb_service_owner:")
         )
-        assert "'redis' if" in line, f"{rel} does not give the db stack ownership where it is present"
+        assert "'redis' if" in line, (
+            f"{rel} does not hand a combined host to the db stack — the ai-stack venv " "has no chromadb installed"
+        )
+
+    deploy = (_ANSIBLE / "deploy.yml").read_text(encoding="utf-8")
+    owner_line = next(ln for ln in deploy.splitlines() if "chromadb_service_owner:" in ln)
+    assert "'redis' if" in owner_line, "deploy.yml still prefers ai-stack when both are requested"
 
 
 def test_the_persist_directory_moves_with_the_service():

--- a/autobot-slm-backend/tests/services/test_chromadb_unit_single_owner_13870_test.py
+++ b/autobot-slm-backend/tests/services/test_chromadb_unit_single_owner_13870_test.py
@@ -286,3 +286,26 @@ def test_the_persist_directory_moves_with_the_service():
     assert code_only.index("chromadb_data_migration.yml") < code_only.index(
         _UNIT_DEST
     ), "the migration must run BEFORE the unit is deployed, or the service starts on the old path"
+
+
+def test_the_marker_is_written_only_after_the_copy_is_verified():
+    """Order is the entire guarantee, and nothing asserted it.
+
+    Round-2 review swapped the assert and the marker-write and the suite stayed
+    green. If the marker lands first, an incomplete copy is recorded as migrated
+    — the block then skips forever and chroma serves a partial store, which is
+    exactly the failure the marker was introduced to prevent.
+
+    Checking the strings in isolation cannot see this: both are present either
+    way. Only their relative position carries the meaning.
+    """
+    tasks = (_ANSIBLE / "roles" / "redis" / "tasks" / "chromadb_data_migration.yml").read_text(encoding="utf-8")
+    verify_at = tasks.index("The copy must be complete before anything trusts it")
+    marker_at = tasks.index("Mark the store migrated")
+    assert verify_at < marker_at, (
+        "the migration marker is written BEFORE the copy is verified — an incomplete "
+        "copy would be recorded as migrated and never retried (#13870)"
+    )
+
+    copy_at = tasks.index("Copy the store to the db-stack path")
+    assert copy_at < verify_at, "the verification must follow the copy it verifies"

--- a/autobot-slm-backend/tests/test_restart_always_units_can_fail_4090.py
+++ b/autobot-slm-backend/tests/test_restart_always_units_can_fail_4090.py
@@ -155,3 +155,79 @@ def test_chromadb_the_unit_that_looped_1681_times_is_covered():
     for unit in units:
         text = unit.read_text(encoding="utf-8")
         assert _directive(text, "StartLimitBurst") is not None, f"{unit} lost its start limit"
+
+
+# ---------------------------------------------------------------------------
+# #4090's fix was inert on every unit for weeks, and nothing noticed.
+#
+# `StartLimitIntervalSec` and `StartLimitBurst` belong to [Unit]. Placed in
+# [Service], systemd discards them and says so:
+#
+#   Unknown key name 'StartLimitIntervalSec' in section 'Service', ignoring.
+#
+# All 23 templates had them in [Service]. Observed consequence on a live host:
+# autobot-chromadb reached NRestarts=4399 while reporting `activating`, never
+# `failed` — the precise outage #4090 exists to make visible.
+#
+# The original guard asserted the directives were PRESENT IN THE TEMPLATE. They
+# were. Presence is not effect, and only the second one was ever the point.
+# ---------------------------------------------------------------------------
+
+_UNIT_ONLY_DIRECTIVES = ("StartLimitIntervalSec", "StartLimitBurst")
+
+
+def _section_of(text: str, directive: str) -> str | None:
+    """The ini section a directive is declared in, or None if absent."""
+    section = None
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("[") and stripped.endswith("]"):
+            section = stripped
+        elif stripped.startswith(f"{directive}="):
+            return section
+    return None
+
+
+def _templates_declaring_start_limits() -> list[Path]:
+    """Only templates that declare the directives — the rest have nothing to
+    place, and asserting over them would fail for the wrong reason."""
+    return sorted(p for p in _ANSIBLE_ROOT.rglob("*.j2") if "StartLimitIntervalSec" in p.read_text(encoding="utf-8"))
+
+
+def test_there_are_unit_templates_to_check():
+    """Guard the guard: a rename would make every assertion below vacuous."""
+    assert len(_templates_declaring_start_limits()) >= 20, "expected the #4090 unit templates"
+
+
+@pytest.mark.parametrize("template", _templates_declaring_start_limits(), ids=lambda p: p.name)
+@pytest.mark.parametrize("directive", _UNIT_ONLY_DIRECTIVES)
+def test_start_limit_directives_live_in_the_unit_section(template: Path, directive: str):
+    """In [Service] systemd ignores them, so the unit restarts forever and stays
+    out of `systemctl --failed` — which is the whole failure #4090 describes."""
+    section = _section_of(template.read_text(encoding="utf-8"), directive)
+    assert section == "[Unit]", (
+        f"{template.name}: {directive} is in {section or 'no section'}, not [Unit]. "
+        "systemd discards it there — 'Unknown key name ... in section Service, ignoring' — "
+        "so the unit can never reach `failed` (#4090)."
+    )
+
+
+def test_the_window_still_exceeds_restartsec_times_burst():
+    """The limit must be REACHABLE, not merely declared. RestartSec spaces
+    restarts further apart than the default 10s window, so a too-narrow window
+    means the rate never reaches the limit and nothing ever trips."""
+    import re as _re
+
+    for template in _templates_declaring_start_limits():
+        text = template.read_text(encoding="utf-8")
+        window = _re.search(r"^StartLimitIntervalSec=(\d+)", text, _re.MULTILINE)
+        burst = _re.search(r"^StartLimitBurst=(\d+)", text, _re.MULTILINE)
+        delay = _re.search(r"^RestartSec=(\d+)", text, _re.MULTILINE)
+        if not (window and burst and delay):
+            continue
+        needed = int(delay.group(1)) * int(burst.group(1))
+        assert int(window.group(1)) > needed, (
+            f"{template.name}: StartLimitIntervalSec={window.group(1)}s does not exceed "
+            f"RestartSec({delay.group(1)}) * StartLimitBurst({burst.group(1)}) = {needed}s, "
+            "so the restart rate can never reach the limit"
+        )


### PR DESCRIPTION
## Thinking Path

Two defects, both found on a live host while gathering evidence for #13852, and one of them is mine.

### #4090 has been inert on every unit since it merged

`StartLimitIntervalSec` and `StartLimitBurst` belong to **`[Unit]`**. All 23 templates put them in `[Service]`, where systemd discards them — and says so, unprompted:

```
/etc/systemd/system/slm-agent.service:65: Unknown key name 'StartLimitIntervalSec'
  in section 'Service', ignoring.
```

The consequence, measured live:

```
NRestarts=4399
ActiveState=activating          <- never `failed`
```

That is precisely the outage #4090 exists to make visible — a unit that can never exec, restarting forever, invisible to `systemctl --failed` — recurring with the fix supposedly in place.

**Why nothing caught it:** the guard asserted the directives were *present in the template*. They were. Presence is not effect, and only effect was ever the point. This is the same "assert the invariant, not the reported instance" failure the repo has hit repeatedly, and here it hid a fix that had never once worked.

### Chroma was pointed at a venv that has never had it installed

That is #4090's *original* outage — "an `ExecStart` pointing at a venv that never had chromadb installed" — and **I caused this instance.** #14121 made ai-stack the combined-host owner, to avoid relocating the persist directory.

Measured on the host:

| | ai-stack | db-stack |
|---|---|---|
| `bin/chroma` | **missing** | present |
| `chromadb` package | **not installed** | 1.5.9 |
| persist dir | 3.2 G | 15 M |

ChromaDB **is a database**. It belongs with the db stack — which is also the only role that installs it. I had the data-safety instinct right and applied it to the wrong decision: *owning the service* and *owning the data* are two separate choices, and collapsing them into one to protect the data attached a database to the wrong stack and produced a 4,399-restart crash loop.

## What Changed

`StartLimit*` moved to `[Unit]` in all 23 templates, with the comment explaining why the placement is load-bearing.

Ownership goes to the redis/db-stack role at every level — role defaults, both fact files, and `deploy.yml`.

The store follows the service. The migration **copies rather than moves** (a failed move loses the only copy), stops the service first, re-counts afterwards, and leaves the legacy directory for an operator to remove once healthy — deletion is not the play's decision.

The guard that matters most refuses to leave chroma pointed at an empty directory while the legacy path still holds data. Chroma starts happily on an empty store, so the failure mode is a healthy-looking service and a knowledge base that silently reads as empty — no error, no crash, no alert.

## Verification

```
1395 passed, 3 skipped   autobot-slm-backend/tests/
black · isort · flake8   clean
every touched YAML parses
23 of 23 templates now declare StartLimit* in [Unit]
```

Four mutations, four caught:

| Reverted | Fails |
|---|---|
| `StartLimit*` back in `[Service]` (the live bug) | 2 |
| ownership handed back to ai-stack | 1 |
| the derivation inverted | 1 |
| the migration not included | 1 |

The new guards assert the **section**, not the presence, and that the window exceeds `RestartSec × StartLimitBurst` so the limit is reachable at all — a declared limit that can never trip is the same nothing as no limit.

## Not fixed here

The eight other units on the host carry the same `[Service]` placement and are corrected by the template change, but only take effect on their next deploy. Until then they remain unable to reach `failed`.

Refs #4090, #13870 — part of umbrella #13852.

**Closes on host evidence:** `systemctl show autobot-chromadb -p StartLimitIntervalSec` returning `120s` rather than nothing, the unit reaching `failed` instead of looping, and chroma serving the 3.2 G store from the db-stack path.

## Model Used

Opus 5 (1M context)