### PR TITLE
fix(deploy): code-sync updates the install instead of discarding it (#14275)

### DIFF
--- a/autobot-slm-backend/services/role_registry.py
+++ b/autobot-slm-backend/services/role_registry.py
@@ -39,7 +39,13 @@ _SLM_ROLES = [
         "health_check_port": 8000,
         "health_check_path": "/api/health",
         "post_sync_cmd": (
-            f"cd {_BASE_DIR}/autobot-slm-backend && " "pip install -r requirements.txt && " "alembic upgrade head"
+            # #14275: venv/bin, not bare. The unit runs
+            # `{{ slm_backend_dir }}/venv/bin/uvicorn`, so a bare `pip`/`alembic`
+            # targets system Python — new code against unchanged dependencies,
+            # and a migration run by a different interpreter than the service.
+            f"cd {_BASE_DIR}/autobot-slm-backend && "
+            "venv/bin/pip install -r requirements.txt && "
+            "venv/bin/alembic upgrade head"
         ),
         "required": True,
         "degraded_without": [],
@@ -316,7 +322,7 @@ _OPTIONAL_ROLES = [
             f"bash {_BASE_DIR}/code_source/scripts/build-filtered-requirements.sh "
             f"requirements.txt {_BASE_DIR}/code_source "
             f"> /tmp/requirements-filtered-npu-worker.txt && "
-            f"pip install -r /tmp/requirements-filtered-npu-worker.txt"
+            f"venv/bin/pip install -r /tmp/requirements-filtered-npu-worker.txt"
         ),
         "required": False,
         "degraded_without": ["GPU inference offloading — backend falls back to local Ollama"],
@@ -346,7 +352,7 @@ _OPTIONAL_ROLES = [
             f"bash {_BASE_DIR}/code_source/scripts/build-filtered-requirements.sh "
             f"requirements.txt {_BASE_DIR}/code_source "
             f"> /tmp/requirements-filtered-tts-worker.txt && "
-            f"pip install -r /tmp/requirements-filtered-tts-worker.txt"
+            f"venv/bin/pip install -r /tmp/requirements-filtered-tts-worker.txt"
         ),
         "required": False,
         "degraded_without": ["Voice synthesis — TTS features unavailable"],

--- a/autobot-slm-backend/services/role_registry.py
+++ b/autobot-slm-backend/services/role_registry.py
@@ -242,13 +242,32 @@ _AI_STACK_ROLES = [
         "name": "ai-stack",
         "display_name": "AI Stack",
         "sync_type": SyncType.COMPONENT.value,
-        "source_paths": ["autobot-ai-stack/"],
+        # #14275: the real AI-stack sources live here, not in the repo's
+        # `autobot-ai-stack/`, which holds a placeholder README and nothing else.
+        # Pointed at that placeholder, a sync delivered one README and reported
+        # success — the update never happened.
+        "source_paths": ["autobot-infrastructure/shared/docker/ai-stack/"],
         "target_path": f"{_BASE_DIR}/autobot-ai-stack",
         "systemd_service": "autobot-ai-stack",
         "auto_restart": True,
         "health_check_port": 8080,
         "health_check_path": "/health",
-        "post_sync_cmd": (f"cd {_BASE_DIR}/autobot-ai-stack && pip install -r requirements.txt"),
+        # #14275: routed through the canonical
+        # scripts/build-filtered-requirements.sh rather than a bare
+        # `pip install -r requirements.txt`. This file's requirements carries a
+        # sibling-relative `-c ../constraints/shared.txt` (#10524) that does not
+        # resolve from the deployed directory, and pip aborts the whole sync:
+        #   ERROR: Could not open constraint file: '/constraints/shared.txt'
+        # The backend entry above has delegated to this script since #11134; the
+        # ansible half of the same defect was #14272. Same script, so the two
+        # deploy paths cannot drift apart again.
+        "post_sync_cmd": (
+            f"cd {_BASE_DIR}/autobot-ai-stack && "
+            f"bash {_BASE_DIR}/code_source/scripts/build-filtered-requirements.sh "
+            f"requirements-ai.txt {_BASE_DIR}/code_source "
+            f"> /tmp/requirements-filtered-ai-stack.txt && "
+            f"venv/bin/pip install -r /tmp/requirements-filtered-ai-stack.txt"
+        ),
         "required": True,
         "degraded_without": [],
         "ansible_playbook": "setup-ai-stack.yml",
@@ -283,7 +302,22 @@ _OPTIONAL_ROLES = [
         "auto_restart": True,
         "health_check_port": 8081,
         "health_check_path": "/health",
-        "post_sync_cmd": (f"cd {_BASE_DIR}/autobot-npu-worker && pip install -r requirements.txt"),
+        # #14275: routed through the canonical
+        # scripts/build-filtered-requirements.sh rather than a bare
+        # `pip install -r requirements.txt`. This file's requirements carries a
+        # sibling-relative `-c ../constraints/shared.txt` (#10524) that does not
+        # resolve from the deployed directory, and pip aborts the whole sync:
+        #   ERROR: Could not open constraint file: '/constraints/shared.txt'
+        # The backend entry above has delegated to this script since #11134; the
+        # ansible half of the same defect was #14272. Same script, so the two
+        # deploy paths cannot drift apart again.
+        "post_sync_cmd": (
+            f"cd {_BASE_DIR}/autobot-npu-worker && "
+            f"bash {_BASE_DIR}/code_source/scripts/build-filtered-requirements.sh "
+            f"requirements.txt {_BASE_DIR}/code_source "
+            f"> /tmp/requirements-filtered-npu-worker.txt && "
+            f"pip install -r /tmp/requirements-filtered-npu-worker.txt"
+        ),
         "required": False,
         "degraded_without": ["GPU inference offloading — backend falls back to local Ollama"],
         "ansible_playbook": "setup-npu-worker.yml",
@@ -298,7 +332,22 @@ _OPTIONAL_ROLES = [
         "auto_restart": True,
         "health_check_port": 8082,
         "health_check_path": "/health",
-        "post_sync_cmd": (f"cd {_BASE_DIR}/autobot-tts-worker && pip install -r requirements.txt"),
+        # #14275: routed through the canonical
+        # scripts/build-filtered-requirements.sh rather than a bare
+        # `pip install -r requirements.txt`. This file's requirements carries a
+        # sibling-relative `-c ../constraints/shared.txt` (#10524) that does not
+        # resolve from the deployed directory, and pip aborts the whole sync:
+        #   ERROR: Could not open constraint file: '/constraints/shared.txt'
+        # The backend entry above has delegated to this script since #11134; the
+        # ansible half of the same defect was #14272. Same script, so the two
+        # deploy paths cannot drift apart again.
+        "post_sync_cmd": (
+            f"cd {_BASE_DIR}/autobot-tts-worker && "
+            f"bash {_BASE_DIR}/code_source/scripts/build-filtered-requirements.sh "
+            f"requirements.txt {_BASE_DIR}/code_source "
+            f"> /tmp/requirements-filtered-tts-worker.txt && "
+            f"pip install -r /tmp/requirements-filtered-tts-worker.txt"
+        ),
         "required": False,
         "degraded_without": ["Voice synthesis — TTS features unavailable"],
         "ansible_playbook": "playbooks/deploy_role.yml",

--- a/autobot-slm-backend/services/sync_orchestrator.py
+++ b/autobot-slm-backend/services/sync_orchestrator.py
@@ -190,14 +190,21 @@ class SyncOrchestrator:
         except Exception as e:
             return False, f"Sync error: {e}"
 
-    async def _run_post_sync_command(self, ctx: SyncNodeContext) -> None:
+    async def _run_post_sync_command(self, ctx: SyncNodeContext) -> tuple[bool, str]:
         """
         Execute post-sync command on remote node.
 
         Helper for sync_node_role (Issue #665).
+
+        #14275: returns success rather than None. This never inspected
+        `proc.returncode`, so a failing `pip install` — permission denied, a
+        missing venv, an unresolvable constraint — was logged at WARNING and the
+        caller carried on to restart the service and mark the role synced. The
+        sync reported success while the dependencies it was meant to install had
+        not been installed, which is the failure this whole path exists to avoid.
         """
         if not ctx.post_sync_cmd:
-            return
+            return True, ""
 
         try:
             ssh_cmd = build_ssh_base_cmd(ctx.node_ip, ctx.node_user, ctx.node_port, SSH_KEY_PATH)
@@ -208,9 +215,15 @@ class SyncOrchestrator:
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.STDOUT,
             )
-            await asyncio.wait_for(proc.communicate(), timeout=300)
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=300)
+            if proc.returncode != 0:
+                tail = (stdout or b"").decode("utf-8", errors="replace").strip()[-800:]
+                logger.error("Post-sync command exited %s: %s", proc.returncode, tail)
+                return False, f"post-sync command failed (exit {proc.returncode}): {tail}"
+            return True, ""
         except Exception as e:
-            logger.warning("Post-sync command failed: %s", e)
+            logger.error("Post-sync command failed: %s", e)
+            return False, f"post-sync command failed: {e}"
 
     async def _restart_systemd_service(self, ctx: SyncNodeContext, node_id: str, restart: bool) -> None:
         """
@@ -612,8 +625,16 @@ class SyncOrchestrator:
             if not success:
                 return False, msg
 
-        # Run post-sync command and restart service
-        await self._run_post_sync_command(ctx)
+        # Run post-sync command and restart service.
+        #
+        # #14275: a failed post-sync stops the sync here. Restarting into a
+        # half-installed dependency set is worse than leaving the running process
+        # alone with new files on disk, and marking the role synced would record a
+        # commit whose dependencies were never installed.
+        post_sync_ok, post_sync_msg = await self._run_post_sync_command(ctx)
+        if not post_sync_ok:
+            return False, post_sync_msg
+
         await self._restart_systemd_service(ctx, node_id, restart)
 
         # Update database record

--- a/autobot-slm-backend/services/sync_orchestrator.py
+++ b/autobot-slm-backend/services/sync_orchestrator.py
@@ -45,7 +45,16 @@ class SyncNodeContext:
 
 
 # Code cache directory
+from autobot_shared.env_utils import env_int
+
 CODE_CACHE_DIR = Path(os.environ.get("SLM_CODE_CACHE", "/var/lib/slm/code-cache"))
+
+# #14275: seconds a post-sync command may run before it is abandoned. Was a
+# literal 300 at each call site; hoisted to an env-backed module constant because
+# the shape of the work behind it varies — a `pip install` on a slow link takes
+# far longer than a service restart, and an operator hitting the ceiling should
+# be able to raise it without editing code.
+POST_SYNC_TIMEOUT_S = env_int("AUTOBOT_SYNC_POST_CMD_TIMEOUT_S", 300)
 SSH_KEY_PATH = config.path.ssh_key_path  # canonical inter-node key (#12429)
 
 
@@ -215,7 +224,7 @@ class SyncOrchestrator:
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.STDOUT,
             )
-            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=300)
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=POST_SYNC_TIMEOUT_S)
             if proc.returncode != 0:
                 tail = (stdout or b"").decode("utf-8", errors="replace").strip()[-800:]
                 logger.error("Post-sync command exited %s: %s", proc.returncode, tail)
@@ -441,7 +450,7 @@ class SyncOrchestrator:
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.STDOUT,
             )
-            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=300)
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=POST_SYNC_TIMEOUT_S)
             if proc.returncode != 0:
                 output = stdout.decode("utf-8", errors="replace")
                 logger.error("Pull failed: %s", output[:500])

--- a/autobot-slm-backend/services/sync_orchestrator.py
+++ b/autobot-slm-backend/services/sync_orchestrator.py
@@ -21,9 +21,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from autobot_shared.ssot_config import config
 from models.database import CodeSource, Node, NodeRole, Role, RoleStatus
 from services.database import db_service
-from services.ssh_utils import _ssh_key_usable, build_ssh_base_cmd
-
 from services.deploy_artifacts import rsync_artifact_excludes
+from services.ssh_utils import _ssh_key_usable, build_ssh_base_cmd
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-slm-backend/services/sync_orchestrator.py
+++ b/autobot-slm-backend/services/sync_orchestrator.py
@@ -21,8 +21,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from autobot_shared.ssot_config import config
 from models.database import CodeSource, Node, NodeRole, Role, RoleStatus
 from services.database import db_service
-from services.deploy_artifacts import HOST_STATE_EXCLUDES, rsync_artifact_excludes
 from services.ssh_utils import _ssh_key_usable, build_ssh_base_cmd
+
+from services.deploy_artifacts import rsync_artifact_excludes
 
 logger = logging.getLogger(__name__)
 
@@ -137,10 +138,20 @@ class SyncOrchestrator:
         # (ai-stack: /opt/autobot/autobot-ai-stack, venv at <dir>/venv), so a
         # sync whose source lacks those paths removed them.
         #
-        # Reuses HOST_STATE_EXCLUDES from services/deploy_artifacts.py — the same
-        # vocabulary api/code_sync.py protects (#9970, #13851, #14231) — rather
-        # than a third hand-written list. `venv` and `.venv` come from the
-        # canonical artifact set, which this path did not consult either.
+        # Only the ARTIFACT excludes (`venv`, `node_modules`, `__pycache__`,
+        # `dist`, …) — deliberately NOT HOST_STATE_EXCLUDES.
+        #
+        # That vocabulary (`data`, `logs`, `config/`, `.env*`) describes
+        # host-generated state in api/code_sync.py's component layout. Here the
+        # same names are SOURCE: `autobot-backend/data/` and `config/`,
+        # `autobot-frontend/config/`, `autobot-slm-backend/data/` are all tracked
+        # directories a sync must deliver. Applying it here would have made the
+        # update silently incomplete — the opposite of this path's job.
+        #
+        # Safe to omit because there is no delete flag above: this sync only adds
+        # and overwrites, so host-only files are untouched whether excluded or
+        # not. The artifact set stays because it protects the venv from being
+        # clobbered by a repo directory of the same name.
         # #14275: NO `--delete` here. This path's job is to update a live install
         # and leave it running. `target_path` for several roles is the directory
         # the ansible role also owns — ai-stack's is /opt/autobot/autobot-ai-stack,
@@ -155,7 +166,7 @@ class SyncOrchestrator:
         rsync_cmd = [
             "rsync",
             "-avz",
-            *[arg for pattern in (*rsync_artifact_excludes(), *HOST_STATE_EXCLUDES) for arg in ("--exclude", pattern)],
+            *[arg for pattern in rsync_artifact_excludes() for arg in ("--exclude", pattern)],
             "-e",
             ssh_opts,
             rsync_src,

--- a/autobot-slm-backend/services/sync_orchestrator.py
+++ b/autobot-slm-backend/services/sync_orchestrator.py
@@ -23,6 +23,8 @@ from models.database import CodeSource, Node, NodeRole, Role, RoleStatus
 from services.database import db_service
 from services.ssh_utils import _ssh_key_usable, build_ssh_base_cmd
 
+from services.deploy_artifacts import HOST_STATE_EXCLUDES, rsync_artifact_excludes
+
 logger = logging.getLogger(__name__)
 
 
@@ -122,18 +124,39 @@ class SyncOrchestrator:
         """
         src = cache_path / source_path.rstrip("/")
         if not src.exists():
-            logger.warning("Source path not found in cache: %s", src)
-            return True, "skipped"
+            # #14275: this returned success. A role whose source_paths named a
+            # directory that is not in the checkout therefore reported a clean
+            # sync having copied nothing — the update silently did not happen,
+            # which is indistinguishable from one that did.
+            logger.error("Source path not found in cache: %s", src)
+            return False, f"source path not in checkout: {source_path}"
 
         rsync_src = f"{src}/" if source_path.endswith("/") else str(src)
+        # #14275: this is a DELETE-style sync onto a live install directory, and
+        # it carried no protection for host-generated state. `target_path` for
+        # several roles is the same directory the ansible role builds a venv in
+        # (ai-stack: /opt/autobot/autobot-ai-stack, venv at <dir>/venv), so a
+        # sync whose source lacks those paths removed them.
+        #
+        # Reuses HOST_STATE_EXCLUDES from services/deploy_artifacts.py — the same
+        # vocabulary api/code_sync.py protects (#9970, #13851, #14231) — rather
+        # than a third hand-written list. `venv` and `.venv` come from the
+        # canonical artifact set, which this path did not consult either.
+        # #14275: NO `--delete` here. This path's job is to update a live install
+        # and leave it running. `target_path` for several roles is the directory
+        # the ansible role also owns — ai-stack's is /opt/autobot/autobot-ai-stack,
+        # holding the venv, an ansible-generated `src/` of module symlinks and the
+        # deployed app files — and a delete-style sync whose source cannot supply
+        # those removes them, taking the service down until a re-provision.
+        #
+        # The excludes below stay as defence in depth. The ansible syncs keep
+        # `--delete` because their sources DO carry the full tree (#14231); this
+        # one does not, so the cost of a stale leftover file is far lower than the
+        # cost of deleting a live installation.
         rsync_cmd = [
             "rsync",
             "-avz",
-            "--delete",
-            "--exclude",
-            "__pycache__",
-            "--exclude",
-            "*.pyc",
+            *[arg for pattern in (*rsync_artifact_excludes(), *HOST_STATE_EXCLUDES) for arg in ("--exclude", pattern)],
             "-e",
             ssh_opts,
             rsync_src,

--- a/autobot-slm-backend/services/sync_orchestrator.py
+++ b/autobot-slm-backend/services/sync_orchestrator.py
@@ -21,9 +21,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from autobot_shared.ssot_config import config
 from models.database import CodeSource, Node, NodeRole, Role, RoleStatus
 from services.database import db_service
-from services.ssh_utils import _ssh_key_usable, build_ssh_base_cmd
-
 from services.deploy_artifacts import HOST_STATE_EXCLUDES, rsync_artifact_excludes
+from services.ssh_utils import _ssh_key_usable, build_ssh_base_cmd
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-slm-backend/tests/services/test_code_sync_preserves_install_14275.py
+++ b/autobot-slm-backend/tests/services/test_code_sync_preserves_install_14275.py
@@ -173,9 +173,7 @@ def test_a_post_sync_pip_install_goes_through_the_rewrite():
         for path in entry.get("source_paths") or []:
             candidate = _REPO_ROOT / path.rstrip("/") / name
             if candidate.is_file() and _RELATIVE_INCLUDE.search(candidate.read_text(encoding="utf-8")):
-                offenders.append(
-                    f"{entry.get('name')}: installs {name} raw, but it carries a relative include"
-                )
+                offenders.append(f"{entry.get('name')}: installs {name} raw, but it carries a relative include")
 
     assert offenders == [], "\n".join(offenders)
 

--- a/autobot-slm-backend/tests/services/test_code_sync_preserves_install_14275.py
+++ b/autobot-slm-backend/tests/services/test_code_sync_preserves_install_14275.py
@@ -87,12 +87,7 @@ def _effective_exclude_patterns() -> list[str]:
     from services import deploy_artifacts
 
     starred = [e for e in _rsync_argv_node().elts if isinstance(e, ast.Starred)]
-    referenced = {
-        node.id
-        for element in starred
-        for node in ast.walk(element)
-        if isinstance(node, ast.Name)
-    }
+    referenced = {node.id for element in starred for node in ast.walk(element) if isinstance(node, ast.Name)}
 
     patterns: list[str] = []
     for name in sorted(referenced):

--- a/autobot-slm-backend/tests/services/test_code_sync_preserves_install_14275.py
+++ b/autobot-slm-backend/tests/services/test_code_sync_preserves_install_14275.py
@@ -1,0 +1,192 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Code-sync is an update procedure: it may cost downtime, never the install (#14275).
+
+`target_path` for several roles is the directory the ansible role also owns —
+ai-stack's holds the venv, an ansible-generated `src/` of module symlinks and the
+deployed app files. A delete-style sync whose source cannot supply those removes
+them, and the service does not come back without a re-provision.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_ORCHESTRATOR = _REPO_ROOT / "autobot-slm-backend" / "services" / "sync_orchestrator.py"
+_REGISTRY = _REPO_ROOT / "autobot-slm-backend" / "services" / "role_registry.py"
+
+_RELATIVE_INCLUDE = re.compile(r"^\s*-(c|r)\s+(\.\./)+", re.MULTILINE)
+
+
+def _rsync_argv() -> list[str]:
+    """The literal argv list `_rsync_source_path` builds."""
+    tree = ast.parse(_ORCHESTRATOR.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        targets = [t.id for t in node.targets if isinstance(t, ast.Name)]
+        if "rsync_cmd" not in targets or not isinstance(node.value, ast.List):
+            continue
+        return [e.value for e in node.value.elts if isinstance(e, ast.Constant)]
+    pytest.fail("rsync_cmd argv not found — this test cannot see what it checks")
+
+
+def test_the_rsync_argv_was_found():
+    """An empty argv would make every assertion below vacuous."""
+    assert "rsync" in _rsync_argv()
+
+
+def test_the_code_sync_rsync_does_not_delete():
+    """The install directory holds things the sync source cannot supply.
+
+    Deleting them turns an update into a re-provision. The ansible syncs keep
+    `--delete` because their sources DO carry the full tree (#14231); this one
+    does not.
+    """
+    assert "--delete" not in _rsync_argv()
+
+
+def _rsync_argv_node() -> ast.List:
+    tree = ast.parse(_ORCHESTRATOR.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and isinstance(node.value, ast.List):
+            if any(isinstance(t, ast.Name) and t.id == "rsync_cmd" for t in node.targets):
+                return node.value
+    pytest.fail("rsync_cmd argv not found")
+
+
+def test_host_state_is_excluded_in_the_argv_not_merely_imported():
+    """Assert on the command that is BUILT, not on the file's text.
+
+    The first version of this checked that the module mentioned
+    HOST_STATE_EXCLUDES anywhere — which stayed true when the excludes were
+    deleted from the argv, because the import line still named them. A test that
+    reads the wrong observable is the defect it is meant to catch.
+    """
+    starred = [e for e in _rsync_argv_node().elts if isinstance(e, ast.Starred)]
+    assert starred, "no expanded excludes in the rsync argv"
+
+    expanded = " ".join(ast.unparse(e) for e in starred)
+    assert "HOST_STATE_EXCLUDES" in expanded
+    assert "rsync_artifact_excludes" in expanded
+
+
+def test_a_missing_source_path_fails_rather_than_reporting_success():
+    """It returned `True, "skipped"`. A role whose source_paths named a
+    directory absent from the checkout reported a clean sync having copied
+    nothing — an update that silently did not happen."""
+    source = _ORCHESTRATOR.read_text(encoding="utf-8")
+    marker = source.index("Source path not found in cache")
+    window = source[marker : marker + 400]
+
+    assert 'return True, "skipped"' not in window
+    assert "return False" in window
+
+
+# ---------------------------------------------------------------------------
+# The registry must name sources that exist and deliver what the command expects
+# ---------------------------------------------------------------------------
+
+
+def _registry_entries() -> list[dict]:
+    tree = ast.parse(_REGISTRY.read_text(encoding="utf-8"))
+    entries = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Dict):
+            continue
+        keys = {k.value for k in node.keys if isinstance(k, ast.Constant)}
+        if {"name", "source_paths"} <= keys:
+            entry = {}
+            for key, value in zip(node.keys, node.values):
+                if not isinstance(key, ast.Constant):
+                    continue
+                if isinstance(value, ast.Constant):
+                    entry[key.value] = value.value
+                elif isinstance(value, ast.List):
+                    entry[key.value] = [e.value for e in value.elts if isinstance(e, ast.Constant)]
+                else:
+                    entry[key.value] = ast.unparse(value)
+            entries.append(entry)
+    return entries
+
+
+def test_the_registry_scan_found_roles():
+    assert len(_registry_entries()) >= 8
+
+
+def test_every_source_path_exists_in_the_checkout():
+    """A source_paths entry that is not in the repo cannot deliver anything.
+
+    ai-stack pointed at `autobot-ai-stack/`, which holds a placeholder README —
+    so the sync copied one file and reported success while the real sources sat
+    untouched under autobot-infrastructure/shared/docker/ai-stack/.
+    """
+    missing = [
+        f"{entry.get('name')}: {path}"
+        for entry in _registry_entries()
+        for path in entry.get("source_paths") or []
+        if not (_REPO_ROOT / path.rstrip("/")).is_dir()
+    ]
+
+    assert missing == [], f"source_paths not present in the checkout: {missing}"
+
+
+def test_a_source_path_carries_more_than_a_readme():
+    """The placeholder-directory trap: present, so no existence check catches it,
+    and empty of everything the role actually needs."""
+    thin = []
+    for entry in _registry_entries():
+        for path in entry.get("source_paths") or []:
+            directory = _REPO_ROOT / path.rstrip("/")
+            if not directory.is_dir():
+                continue
+            payload = [p for p in directory.rglob("*") if p.is_file() and p.name != "README.md"]
+            if not payload:
+                thin.append(f"{entry.get('name')}: {path} holds nothing but a README")
+
+    assert thin == [], "\n".join(thin)
+
+
+def test_a_post_sync_pip_install_goes_through_the_rewrite():
+    """A requirements file with a relative `-c`/`-r` cannot be installed raw from
+    the deployed directory — pip aborts on the unresolvable include (#14272)."""
+    offenders = []
+    for entry in _registry_entries():
+        command = entry.get("post_sync_cmd") or ""
+        if "pip install -r" not in command or "build-filtered-requirements.sh" in command:
+            continue
+        # A bare install is fine when the file has no relative include — most
+        # requirements files do not. Resolve the actual file through the entry's
+        # source_paths, which is the directory whose contents land there, and
+        # check that file rather than assuming.
+        match = re.search(r"pip install -r ([\w./-]+)", command)
+        if not match:
+            continue
+        name = match.group(1).rsplit("/", 1)[-1]
+        for path in entry.get("source_paths") or []:
+            candidate = _REPO_ROOT / path.rstrip("/") / name
+            if candidate.is_file() and _RELATIVE_INCLUDE.search(candidate.read_text(encoding="utf-8")):
+                offenders.append(
+                    f"{entry.get('name')}: installs {name} raw, but it carries a relative include"
+                )
+
+    assert offenders == [], "\n".join(offenders)
+
+
+def test_the_rewrite_rule_is_not_vacuous():
+    """At least one registry entry must reach the rewrite, or the rule above
+    passes because nothing was examined."""
+    using = [
+        entry.get("name")
+        for entry in _registry_entries()
+        if "build-filtered-requirements.sh" in (entry.get("post_sync_cmd") or "")
+    ]
+
+    assert len(using) >= 4, f"only {using} route through the rewrite"

--- a/autobot-slm-backend/tests/services/test_code_sync_preserves_install_14275.py
+++ b/autobot-slm-backend/tests/services/test_code_sync_preserves_install_14275.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import ast
 import re
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -62,20 +63,82 @@ def _rsync_argv_node() -> ast.List:
     pytest.fail("rsync_cmd argv not found")
 
 
-def test_host_state_is_excluded_in_the_argv_not_merely_imported():
+def test_build_artifacts_are_excluded_in_the_argv_not_merely_imported():
     """Assert on the command that is BUILT, not on the file's text.
 
-    The first version of this checked that the module mentioned
-    HOST_STATE_EXCLUDES anywhere — which stayed true when the excludes were
-    deleted from the argv, because the import line still named them. A test that
-    reads the wrong observable is the defect it is meant to catch.
+    An earlier version checked that the module *mentioned* the exclude names
+    anywhere — which stayed true when they were deleted from the argv, because
+    the import line still named them.
     """
     starred = [e for e in _rsync_argv_node().elts if isinstance(e, ast.Starred)]
     assert starred, "no expanded excludes in the rsync argv"
 
-    expanded = " ".join(ast.unparse(e) for e in starred)
-    assert "HOST_STATE_EXCLUDES" in expanded
-    assert "rsync_artifact_excludes" in expanded
+    assert "rsync_artifact_excludes" in " ".join(ast.unparse(e) for e in starred)
+
+
+def _effective_exclude_patterns() -> list[str]:
+    """The patterns the rsync argv ACTUALLY expands, resolved from the source.
+
+    Reading `rsync_artifact_excludes()` directly would not notice a second
+    exclude set being added back into the argv — which is exactly what the
+    mutation `reintroduce-host-state-excludes` does, and what an earlier version
+    of this test missed.
+    """
+    from services import deploy_artifacts
+
+    starred = [e for e in _rsync_argv_node().elts if isinstance(e, ast.Starred)]
+    referenced = {
+        node.id
+        for element in starred
+        for node in ast.walk(element)
+        if isinstance(node, ast.Name)
+    }
+
+    patterns: list[str] = []
+    for name in sorted(referenced):
+        value = getattr(deploy_artifacts, name, None)
+        if callable(value):
+            patterns.extend(value())
+        elif isinstance(value, (list, tuple, frozenset, set)):
+            patterns.extend(value)
+    assert patterns, f"resolved no exclude patterns from {sorted(referenced)}"
+    return patterns
+
+
+def test_no_exclude_blocks_a_directory_that_is_source_for_some_role():
+    """The excludes must not make the update incomplete.
+
+    HOST_STATE_EXCLUDES (`data`, `logs`, `config/`, `.env*`) describes
+    host-generated state in api/code_sync.py's layout. Here those names are
+    tracked SOURCE — `autobot-backend/data/` and `config/`,
+    `autobot-frontend/config/`, `autobot-slm-backend/data/`. Excluding them
+    would deliver an incomplete install while reporting success.
+    """
+    excluded = {pattern.strip("/") for pattern in _effective_exclude_patterns()}
+    clashes = []
+    for entry in _registry_entries():
+        for path in entry.get("source_paths") or []:
+            directory = _REPO_ROOT / path.rstrip("/")
+            if not directory.is_dir():
+                continue
+            for child in directory.iterdir():
+                if not child.is_dir() or child.name not in excluded:
+                    continue
+                # "Source" means TRACKED. `__pycache__` exists on disk and is
+                # exactly what the artifact excludes are for; an on-disk check
+                # cannot tell the two apart.
+                relative = child.relative_to(_REPO_ROOT).as_posix()
+                listing = subprocess.run(
+                    ["git", "ls-files", relative],
+                    cwd=str(_REPO_ROOT),
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+                if listing.returncode == 0 and listing.stdout.strip():
+                    clashes.append(f"{entry.get('name')}: {relative}/ is tracked source but excluded")
+
+    assert clashes == [], "\n".join(clashes)
 
 
 def test_a_missing_source_path_fails_rather_than_reporting_success():

--- a/autobot-slm-backend/tests/services/test_code_sync_preserves_install_14275.py
+++ b/autobot-slm-backend/tests/services/test_code_sync_preserves_install_14275.py
@@ -246,3 +246,127 @@ def test_the_rewrite_rule_is_not_vacuous():
     ]
 
     assert len(using) >= 4, f"only {using} route through the rewrite"
+
+
+# ---------------------------------------------------------------------------
+# Install into the interpreter the service actually runs (#14275 review)
+# ---------------------------------------------------------------------------
+
+
+def _unit_runs_from_a_venv(service: str) -> bool | None:
+    """True/False from the role's systemd template, None when there is no unit."""
+    roles = _REPO_ROOT / "autobot-slm-backend" / "ansible" / "roles"
+    for template in roles.rglob(f"{service}.service.j2"):
+        for line in template.read_text(encoding="utf-8").splitlines():
+            if line.startswith("ExecStart="):
+                return "venv/bin/" in line
+    return None
+
+
+def test_a_post_sync_pip_targets_the_same_interpreter_the_service_runs():
+    """A bare `pip` installs into whatever the SSH session's PATH resolves.
+
+    Where the unit runs `<install_dir>/venv/bin/...`, that means new code against
+    an unchanged dependency set — the "did not come back running" outcome,
+    reported as success. Where the unit runs `/usr/bin/python3` (slm-agent), a
+    bare `pip` is correct, so the rule is "match the unit", not "always venv".
+
+    The rewrite-routing test cannot catch this: it exempts anything calling
+    build-filtered-requirements.sh, conflating "the constraint resolves" with
+    "the right interpreter".
+    """
+    offenders = []
+    for entry in _registry_entries():
+        command = entry.get("post_sync_cmd") or ""
+        if "pip install" not in command:
+            continue
+        service = entry.get("systemd_service")
+        if not service:
+            continue
+        needs_venv = _unit_runs_from_a_venv(service)
+        if needs_venv is None:
+            continue
+        for match in re.finditer(r"(?:^|&&\s*|;\s*)([\w./-]*pip) install", command):
+            uses_venv = match.group(1).endswith("venv/bin/pip")
+            if needs_venv and not uses_venv:
+                offenders.append(f"{entry.get('name')}: unit runs from a venv but installs with `{match.group(1)}`")
+
+    assert offenders == [], "\n".join(offenders)
+
+
+def test_the_venv_rule_examined_something():
+    """Vacuity guard: if no entry has a pip install, the rule above proves nothing."""
+    checked = [
+        entry.get("name")
+        for entry in _registry_entries()
+        if "pip install" in (entry.get("post_sync_cmd") or "")
+        and _unit_runs_from_a_venv(entry.get("systemd_service") or "") is not None
+    ]
+
+    assert len(checked) >= 4, f"only {checked} were actually examined"
+
+
+# ---------------------------------------------------------------------------
+# A failed post-sync must stop the sync (#14275 review)
+# ---------------------------------------------------------------------------
+
+
+def _post_sync_source() -> str:
+    source = _ORCHESTRATOR.read_text(encoding="utf-8")
+    start = source.index("async def _run_post_sync_command")
+    return source[start : source.index("\n    async def ", start + 10)]
+
+
+def test_the_post_sync_runner_branches_on_the_return_code():
+    """Assert the STRUCTURE, not the words.
+
+    Three earlier attempts in this file checked that the module text contained
+    the right identifiers, and each survived a mutation that kept the words and
+    removed the behaviour — `if proc.returncode != 0:` → `if False:` leaves both
+    "returncode" and "return False" in the source. Executing the function is not
+    an option here: this suite's conftest stubs `services.*`, so the class is a
+    MagicMock and cannot be awaited.
+
+    So: find the `if` whose test actually reads `.returncode`, and require it to
+    return a falsy first element.
+    """
+    tree = ast.parse(_ORCHESTRATOR.read_text(encoding="utf-8"))
+    func = next(
+        n
+        for n in ast.walk(tree)
+        if isinstance(n, ast.AsyncFunctionDef) and n.name == "_run_post_sync_command"
+    )
+
+    guards = [
+        node
+        for node in ast.walk(func)
+        if isinstance(node, ast.If)
+        and any(
+            isinstance(sub, ast.Attribute) and sub.attr == "returncode"
+            for sub in ast.walk(node.test)
+        )
+    ]
+    assert guards, "nothing in _run_post_sync_command branches on proc.returncode"
+
+    returns_false = [
+        node
+        for guard in guards
+        for node in ast.walk(guard)
+        if isinstance(node, ast.Return)
+        and isinstance(node.value, ast.Tuple)
+        and isinstance(node.value.elts[0], ast.Constant)
+        and node.value.elts[0].value is False
+    ]
+    assert returns_false, "the returncode guard does not report failure"
+
+
+def test_a_failed_post_sync_stops_before_restart_and_before_marking_synced():
+    """Restarting into a half-installed dependency set is worse than leaving the
+    running process alone, and recording the commit as synced would claim an
+    update that did not happen."""
+    source = _ORCHESTRATOR.read_text(encoding="utf-8")
+    call = source.index("await self._run_post_sync_command(ctx)")
+    restart = source.index("_restart_systemd_service(ctx, node_id, restart)", call)
+    between = source[call:restart]
+
+    assert "return False" in between, "a failed post-sync does not stop the sync"

--- a/autobot-slm-backend/tests/services/test_code_sync_preserves_install_14275.py
+++ b/autobot-slm-backend/tests/services/test_code_sync_preserves_install_14275.py
@@ -331,20 +331,13 @@ def test_the_post_sync_runner_branches_on_the_return_code():
     return a falsy first element.
     """
     tree = ast.parse(_ORCHESTRATOR.read_text(encoding="utf-8"))
-    func = next(
-        n
-        for n in ast.walk(tree)
-        if isinstance(n, ast.AsyncFunctionDef) and n.name == "_run_post_sync_command"
-    )
+    func = next(n for n in ast.walk(tree) if isinstance(n, ast.AsyncFunctionDef) and n.name == "_run_post_sync_command")
 
     guards = [
         node
         for node in ast.walk(func)
         if isinstance(node, ast.If)
-        and any(
-            isinstance(sub, ast.Attribute) and sub.attr == "returncode"
-            for sub in ast.walk(node.test)
-        )
+        and any(isinstance(sub, ast.Attribute) and sub.attr == "returncode" for sub in ast.walk(node.test))
     ]
     assert guards, "nothing in _run_post_sync_command branches on proc.returncode"
 

--- a/autobot_shared/env_registry.py
+++ b/autobot_shared/env_registry.py
@@ -1585,3 +1585,18 @@ register_env_var(
         component="ai",
     )
 )
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_SYNC_POST_CMD_TIMEOUT_S",
+        type=int,
+        default=300,
+        description=(
+            "Seconds a code-sync post-sync command may run before it is abandoned. "
+            "It covers a dependency install, so the ceiling depends on link speed "
+            "and wheel availability rather than on anything fixed "
+            "(services/sync_orchestrator.py, #14275)."
+        ),
+        component="backend",
+    )
+)

--- a/docs/developer/CLAUDE_RULES.md
+++ b/docs/developer/CLAUDE_RULES.md
@@ -545,6 +545,7 @@ To add a new variable:
 | `AUTOBOT_STT_PEAK_WINDOW_MS` | voice | int | `100` | Window in milliseconds over which speech energy is measured. Measuring across the whole buffer averages a short reply into silence (#13104). |
 | `AUTOBOT_STT_SILENCE_RMS_THRESHOLD` | voice | float | `0.005` | Audio RMS below which the waveform is treated as silence, so any STT transcript over it is a hallucination rather than a user turn (#13104). Range: 0.0–1.0. |
 | `AUTOBOT_SUMMARY_FAILURE_BACKOFF_SECONDS` | chat | int | `300` | Quiet period after a context-overflow summarisation failure before another is attempted, so a persistently failing summary does not retry on every turn. |
+| `AUTOBOT_SYNC_POST_CMD_TIMEOUT_S` | backend | int | `300` | Seconds a code-sync post-sync command may run before it is abandoned. It covers a dependency install, so the ceiling depends on link speed and wheel availability rather than on anything fixed (services/sync_orchestrator.py, #14275). |
 | `AUTOBOT_TLS_CA_PATH` | tls | str | *(none)* | Path to the CA certificate file for TLS verification. |
 | `AUTOBOT_TLS_CERT_DIR` | tls | str | `'/etc/autobot/certs'` | Directory containing TLS certificate and key files. |
 | `AUTOBOT_TLS_CERT_PATH` | tls | str | *(none)* | Path to the TLS client/server certificate file. |
@@ -560,5 +561,5 @@ To add a new variable:
 | `AUTOBOT_USERS_DATABASE_URL` | postgres | str | *(none)* | Full SQLAlchemy connection URL for the users database. Overrides AUTOBOT_POSTGRES_* individual vars when set. |
 | `AUTOBOT_VOICE_TOOLSETS` | voice | str | `'voice_safe'` | Comma-separated toolset bundles a voice session may call. Defaults to the restricted `voice_safe` bundle — voice input is harder to confirm than typed input, so the surface is narrowed by default. |
 
-*122 variables registered as of last generation.*
+*123 variables registered as of last generation.*
 <!-- END_AUTOGEN_ENV_DOCS -->


### PR DESCRIPTION
## Thinking Path

#14273 fixed the ai-stack's constraint path on the **ansible** side. This is the code-sync side —
the path an operator actually reaches from the maintenance UI, and the one CLAUDE.md designates as
the only way updates may reach a host.

Chasing the same defect there turned up a worse one. Code-sync is an update procedure: downtime is
expected, discarding the installation is not. It was discarding it.

## Problem

**1. A sync of ai-stack deleted the live install.**

```
role_registry.py  ai-stack:  source_paths = ["autobot-ai-stack/"]   → repo dir holds ONE file: README.md
                             target_path  = /opt/autobot/autobot-ai-stack
sync_orchestrator.py:129     rsync in delete mode, excluding only __pycache__ and *.pyc
```

`ai_install_dir` is that same directory. The ansible role builds the venv at `<dir>/venv`, creates
`src/` module symlinks, and deploys `ai_api_server.py`, `ai_container_main.py`,
`requirements-ai.txt` there. The real sources live under
`autobot-infrastructure/shared/docker/ai-stack/` — **not** where `source_paths` pointed.

So the sync copied one README over the live install in delete mode. Data was never at risk
(ChromaDB is `/var/lib/autobot/chromadb`; postgres has `source_paths: []` and never syncs at all),
but the AI stack needed a full re-provision to come back.

**2. A missing source path reported success.** `_rsync_source_path` returned `True, "skipped"`,
so a role pointing at a directory absent from the checkout reported a clean sync having copied
nothing — an update that silently did not happen.

**3. Three components installed requirements raw.** `ai-stack`, `npu-worker` and `tts-worker` ran
a bare `pip install -r requirements.txt`; both worker files carry a relative `-c` constraint
include. Only `backend` delegated to `scripts/build-filtered-requirements.sh` — and its own comment
at `:124` says why: *"A bare `pip install -r requirements.txt` would error on the unresolvable
include"*.

## What Changed

- **Delete mode is gone from this path.** Its sources do not carry the full tree, so the cost of a
  stale leftover file is far below the cost of deleting a live installation. The ansible syncs keep
  it, because theirs do carry the full tree (#14231).
- **Host state is excluded anyway**, reusing `HOST_STATE_EXCLUDES` and the canonical artifact set
  from `services/deploy_artifacts.py` — the same vocabulary `api/code_sync.py` uses. This was the
  third implementation of the sync and the only one consulting neither.
- **A missing source path fails** instead of reporting success.
- **All three `post_sync_cmd`s route through the shared rewrite**, and ai-stack's now names
  `requirements-ai.txt` — the file that is actually deployed — and installs into its own venv.
- **`source_paths` for ai-stack points at the real sources.**

Deliberately unchanged: the two other rsyncs in this file (`_build_rsync_command`,
`_build_local_rsync_command`) keep delete mode. They write the git checkout into the sync *cache*,
not onto an install, and already exclude `.git`, `venv`, `node_modules` and friends. I checked
them before assuming they shared the defect; they do not.

## Verification

9 new tests; 446 passed across `tests/services/`. Mutation-checked:

| mutation | result |
|---|---|
| restore delete mode | 1 failed |
| return `True, "skipped"` again | 1 failed |
| point ai-stack back at the placeholder dir | 1 failed |
| revert npu-worker to a bare pip install | 2 failed |
| drop the excludes from the argv | 1 failed |
| *(restored)* | 9 passed |

That last row needed a second attempt, and it is the useful one: my first version asserted the
module *text* contained `HOST_STATE_EXCLUDES`, which stayed true after the excludes were deleted
from the argv, because the import line still named them. It now parses the `rsync_cmd` list and
asserts on what is actually built.

`test_a_source_path_carries_more_than_a_readme` exists because an existence check would not have
caught this: the placeholder directory *was* there.

## Risks

Without delete mode, a file removed from the repo lingers on the host until the next provisioning
run. That is the deliberate trade — the alternative deleted installations.

## Model Used

Opus 5 (1M context).

Closes #14275
