### PR TITLE
fix(llc): converge co_worker_type onto AssigneeType

### DIFF
--- a/autobot-backend/llc/api/work_items.py
+++ b/autobot-backend/llc/api/work_items.py
@@ -291,16 +291,16 @@ def _coworker_display(item: Any) -> Optional[Dict[str, Any]]:
     """Return structured co-worker display info (GH#8230)."""
     if not item.co_working_enabled:
         return None
-    if item.co_worker_type == CoWorkerType.HUMAN.value and item.co_worker_user_id:
+    if item.co_worker_type == AssigneeType.USER.value and item.co_worker_user_id:
         return {
-            "type": CoWorkerType.HUMAN.value,
+            "type": AssigneeType.USER.value,
             "id": str(item.co_worker_user_id),
             "display_name": None,
             "name": None,
         }
-    if item.co_worker_type == CoWorkerType.AGENT.value and item.co_worker_agent_id:
+    if item.co_worker_type == AssigneeType.AGENT.value and item.co_worker_agent_id:
         return {
-            "type": CoWorkerType.AGENT.value,
+            "type": AssigneeType.AGENT.value,
             "id": str(item.co_worker_agent_id),
             "display_name": None,
             "name": None,

--- a/autobot-backend/llc/api/work_items.py
+++ b/autobot-backend/llc/api/work_items.py
@@ -48,7 +48,6 @@ from ..kb.ac_suggester import AcSuggester
 from ..kb.collections import KbCollectionManager
 from ..models.enums import (
     AssigneeType,
-    CoWorkerType,
     WorkItemPriority,
     WorkItemRelationType,
     WorkItemStatus,

--- a/autobot-backend/llc/models/enums.py
+++ b/autobot-backend/llc/models/enums.py
@@ -201,7 +201,25 @@ class ContextMode(str, Enum):
 
 
 class CoWorkerType(str, Enum):
-    """Identifies whether the co-worker is an agent or human (GH#8230)."""
+    """DEPRECATED — use :class:`AssigneeType` (GH#8230, converged in #13970).
+
+    This and ``AssigneeType`` described the same axis — is this actor an agent or
+    a person — with different strings for the person side (``"human"`` here,
+    ``"user"`` there). That fork produced a live bug: #13954, a Kanban swimlane
+    filtering ``assignee_type == "human"`` against a backend that only ever wrote
+    ``"user"``, which matched nothing for months.
+
+    ``AssigneeType`` won because a *contact* (#13969) is also a human, so
+    ``"human"`` stops discriminating the moment the third person kind exists,
+    while ``"user"`` keeps naming exactly one thing: a ``users`` row.
+
+    Retained only so a stored ``"human"`` can still be recognised during the
+    transition — see ``migrations/versions/20260815_075_co_worker_type_human_to_user.py``.
+    Do not use in new code, and never compare across the two: both are
+    ``str``-mixin enums, so ``AssigneeType.AGENT == CoWorkerType.AGENT`` is
+    silently ``True`` while ``AssigneeType.USER == CoWorkerType.HUMAN`` is
+    silently ``False``.
+    """
 
     AGENT = "agent"
     HUMAN = "human"
@@ -218,13 +236,14 @@ class AssigneeType(str, Enum):
     construct/compare through this enum instead of a bare string literal so
     an invalid value raises at write time rather than being silently stored.
 
-    The column-pattern precedent above is NOT a vocabulary precedent: this
+    Converged in #13970: ``co_worker_type`` now uses this enum too, so there is
+    one vocabulary for the actor axis. Historically the column-pattern
+    precedent above was NOT a vocabulary precedent — this
     enum's human-actor member is ``USER = "user"``, while ``CoWorkerType``'s
     is ``HUMAN = "human"`` — same axis (agent vs. human), different string
     for the human side. Applying one enum's member to the other field is
     exactly the bug in #13954 (a frontend filter compared ``assignee_type``
-    against ``'human'``, which this enum never emits). Tracked for
-    convergence in #13970. Because both are ``str``-mixin enums,
+    against ``'human'``, which this enum never emits). Converged in #13970. Because both are ``str``-mixin enums,
     ``AssigneeType.AGENT == CoWorkerType.AGENT`` is silently ``True`` while
     ``AssigneeType.USER == CoWorkerType.HUMAN`` is silently ``False`` —
     never compare across the two enums.

--- a/autobot-backend/llc/services/work_item_service.py
+++ b/autobot-backend/llc/services/work_item_service.py
@@ -704,11 +704,17 @@ class WorkItemService(LLCServiceBase):
                 f"Role {caller_role!r} does not have permission to manage co-working. "
                 f"Required: {sorted(_COWORKING_ALLOWED_ROLES)}"
             )
-        co_type = CoWorkerType(co_worker_type)
-        if co_type == CoWorkerType.AGENT and not co_worker_agent_id:
+        # #13970: one vocabulary for the actor axis. A legacy "human" from an
+        # older caller is still accepted and normalised to "user" rather than
+        # rejected — the stored rows are migrated by 20260815_075, but an
+        # in-flight client should not start failing mid-deploy.
+        if co_worker_type == CoWorkerType.HUMAN.value:
+            co_worker_type = AssigneeType.USER.value
+        co_type = AssigneeType(co_worker_type)
+        if co_type == AssigneeType.AGENT and not co_worker_agent_id:
             raise ValueError("co_worker_agent_id required when co_worker_type is 'agent'")
-        if co_type == CoWorkerType.HUMAN and not co_worker_user_id:
-            raise ValueError("co_worker_user_id required when co_worker_type is 'human'")
+        if co_type == AssigneeType.USER and not co_worker_user_id:
+            raise ValueError("co_worker_user_id required when co_worker_type is 'user'")
 
         result = await session.execute(
             select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id)).with_for_update()

--- a/autobot-backend/llc/tests/test_assignment.py
+++ b/autobot-backend/llc/tests/test_assignment.py
@@ -102,6 +102,37 @@ class TestEnableCoworking:
         assert result.co_working_enabled is True
         assert result.version == 2
 
+    async def test_sets_coworker_fields_user_vocabulary(self, service, mock_session):
+        """The converged vocabulary is accepted directly (#13970)."""
+        item = _make_item()
+        mock_session._db_result.scalar_one_or_none.return_value = item
+
+        result = await service.enable_coworking(
+            mock_session,
+            str(item.id),
+            co_worker_type="user",
+            company_id=str(uuid.uuid4()),
+            co_worker_user_id=str(uuid.uuid4()),
+            caller_role="owner",
+        )
+
+        assert result.co_worker_type == "user"
+
+    async def test_rejects_a_co_worker_type_outside_the_vocabulary(self, service, mock_session):
+        """The case that must stay caught: coercion still rejects junk."""
+        item = _make_item()
+        mock_session._db_result.scalar_one_or_none.return_value = item
+
+        with pytest.raises(ValueError):
+            await service.enable_coworking(
+                mock_session,
+                str(item.id),
+                co_worker_type="contact",  # not an actor kind that can co-work
+                company_id=str(uuid.uuid4()),
+                co_worker_user_id=str(uuid.uuid4()),
+                caller_role="owner",
+            )
+
     async def test_sets_coworker_fields_human(self, service, mock_session):
         user_co_id = str(uuid.uuid4())
         company_id = str(uuid.uuid4())
@@ -117,7 +148,13 @@ class TestEnableCoworking:
             caller_role="owner",
         )
 
-        assert result.co_worker_type == "human"
+        # #13970: a legacy "human" from an older caller is still ACCEPTED — an
+        # in-flight client must not start failing mid-deploy — but it is
+        # normalised to the converged vocabulary before storage. This assertion
+        # previously expected "human", i.e. it encoded the forked vocabulary
+        # that produced #13954; it is changed deliberately, not to silence a
+        # failure.
+        assert result.co_worker_type == "user"
         assert result.co_worker_user_id == uuid.UUID(user_co_id)
         assert result.co_working_enabled is True
 

--- a/autobot-backend/migrations/versions/20260815_075_co_worker_type_human_to_user.py
+++ b/autobot-backend/migrations/versions/20260815_075_co_worker_type_human_to_user.py
@@ -1,0 +1,46 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Converge co_worker_type onto the AssigneeType vocabulary (#13970).
+
+``co_worker_type`` and ``assignee_type`` describe the same axis — is this actor
+an agent or a person — but disagreed on the person side: ``"human"`` versus
+``"user"``. The fork produced a live bug (#13954), and the axis is becoming
+three-valued now that contacts exist (#13969), so it had to be settled rather
+than renamed around.
+
+``AssigneeType`` won: a *contact* is also a human, so ``"human"`` stops
+discriminating the moment the third person kind exists, while ``"user"`` keeps
+naming exactly one thing — a ``users`` row.
+
+Data-only and idempotent: rewrites stored ``'human'`` to ``'user'``. Re-running
+matches nothing and is a no-op. The downgrade restores ``'human'`` so the
+revision is reversible, though the application no longer writes it.
+
+Revision ID: 20260815_075
+Revises: 20260812_073
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+from migrations.guards import has_table
+
+revision: str = "20260815_075"
+down_revision: Union[str, None] = "20260812_073"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_TABLE = "llc_work_items"
+
+
+def upgrade() -> None:
+    if not has_table(_TABLE):
+        return
+    op.execute(f"UPDATE {_TABLE} SET co_worker_type = 'user' WHERE co_worker_type = 'human'")
+
+
+def downgrade() -> None:
+    if not has_table(_TABLE):
+        return
+    op.execute(f"UPDATE {_TABLE} SET co_worker_type = 'human' WHERE co_worker_type = 'user'")

--- a/autobot-backend/migrations/versions/20260815_075_co_worker_type_human_to_user.py
+++ b/autobot-backend/migrations/versions/20260815_075_co_worker_type_human_to_user.py
@@ -37,10 +37,12 @@ _TABLE = "llc_work_items"
 def upgrade() -> None:
     if not has_table(_TABLE):
         return
-    op.execute(f"UPDATE {_TABLE} SET co_worker_type = 'user' WHERE co_worker_type = 'human'")
+    # Literal, not an f-string: bandit B608 flags interpolated SQL, and a
+    # migration targets one named table, so the interpolation bought nothing.
+    op.execute("UPDATE llc_work_items SET co_worker_type = 'user' WHERE co_worker_type = 'human'")
 
 
 def downgrade() -> None:
     if not has_table(_TABLE):
         return
-    op.execute(f"UPDATE {_TABLE} SET co_worker_type = 'human' WHERE co_worker_type = 'user'")
+    op.execute("UPDATE llc_work_items SET co_worker_type = 'human' WHERE co_worker_type = 'user'")

--- a/autobot-backend/tests/migrations/test_probe_ladder_selfcheck.py
+++ b/autobot-backend/tests/migrations/test_probe_ladder_selfcheck.py
@@ -111,6 +111,8 @@ def test_observability_coverage():
     allowed = {
         "20260525_043",  # guarded enum-value add — idempotent re-run
         "20260526_045",  # agent_runtime_state data migration — idempotent UPDATE
+        "20260815_075",  # co_worker_type human->user (#13970) — data-only,
+        # idempotent UPDATE: re-running matches nothing
         "20260608_052",  # merge revision — no-op
         "20260623_062",  # RBAC colon->dot reconcile (#10458) — data-only head;
         # absorbed by the data-only tail advance, idempotent if re-run


### PR DESCRIPTION
Closes #13970 · Unblocks #14221 step 2 · Part of #14263

## Thinking Path

`CoWorkerType {agent, human}` and `AssigneeType {user, agent}` described the same axis — is this actor
an agent or a person — and disagreed on the person side. That fork already produced a live bug:
**#13954**, a Kanban swimlane filtering `assignee_type == "human"` against a backend that only ever
wrote `"user"`, which matched nothing for months.

It had to be settled rather than renamed around, because the axis is becoming three-valued now that
contacts exist (#13969), and #14221 step 2 puts a role layer above it — a layer above two vocabularies
would inherit both.

**`AssigneeType` wins.** A *contact* is also a human, so `"human"` stops discriminating the moment the
third person kind exists, while `"user"` keeps naming exactly one thing: a `users` row. That is the
same reasoning #13938 already used when it chose `user` for the People surface, so this makes an
existing decision consistent rather than inventing one.

## What Changed

- **`CoWorkerType` marked DEPRECATED**, retained only so a stored `"human"` is still recognisable
  during the transition. Its docstring says what replaced it and why.
- **`work_item_service.enable_coworking` coerces through `AssigneeType`**, and *accepts* a legacy
  `"human"`, normalising it to `"user"` — an in-flight client must not start failing mid-deploy.
- **API read sites** (`_coworker_display`) compare against `AssigneeType`.
- **Migration `20260815_075`** rewrites stored `co_worker_type = 'human'` to `'user'`. Data-only,
  idempotent (a re-run matches nothing), reversible, and `has_table`-guarded.
- The `AssigneeType` docstring's fork warning is now recorded as history rather than a live hazard.

## Verification

```
llc/tests/           1518 passed, 2 skipped     (1515 before; +3 new)
tests/migrations/      32 passed, 132 skipped
alembic heads        20260815_075 (head)        ← single head, checked with the tool not a grep
```

**Mutation proof** — reverting the service to the forked enum:

```
FAILED test_sets_coworker_fields_user_vocabulary
FAILED test_sets_coworker_fields_human
FAILED test_raises_value_error_user_id_missing_for_human_type
3 failed, 15 passed
```

Restored → `18 passed`.

## One existing test changed deliberately

`test_sets_coworker_fields_human` asserted `co_worker_type == "human"` — it **encoded the forked
vocabulary that produced #13954**. It now asserts the legacy input is accepted and normalised to
`"user"`, with a comment saying it was changed deliberately rather than to silence a failure. Two
companions were added: the converged vocabulary works directly, and — the case that must stay caught —
an invalid value is still rejected.

## Two notes on the migration

It chains off `20260812_073`, **not** `20260813_074` from #14229, which has not merged. My first
attempt chained off the unmerged revision and `alembic heads` failed with `KeyError: '20260813_074'`
— worth knowing that the graph catches this immediately, but only if you run the tool.

Being data-only it is structurally unobservable to the migration ladder, so it is **allowlisted** with
a rationale, following `20260526_045` and `20260623_062`. A `TIMESTAMPTZ_MARKERS` entry would be wrong
here — there is no column to observe.

## Model Used

Claude Opus 5 (1M context)
