### PR TITLE
fix(deploy): give the SLM agent its own venv so external nodes can be provisioned (#14278)

### DIFF
--- a/autobot-slm-backend/ansible/roles/slm_agent/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/slm_agent/defaults/main.yml
@@ -25,6 +25,12 @@ slm_agent_group: autobot
 
 # Installation directories (#1121/#1129: role-centric layout under /opt/autobot/)
 slm_agent_dir: /opt/autobot/autobot-slm-agent
+# #14278: the agent's dependencies live in their own venv. Installing them into
+# system Python with --break-system-packages fails on any node whose distro owns
+# a transitive dependency: pip may write to the system environment but cannot
+# uninstall what dpkg installed, so an upgrade of e.g. typing_extensions aborts
+# provisioning with "RECORD file not found. The package was installed by debian."
+slm_agent_venv: "{{ slm_agent_dir }}/venv"
 slm_agent_data_dir: /var/lib/slm-agent
 
 # Python dependencies for the agent (#11508)

--- a/autobot-slm-backend/ansible/roles/slm_agent/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/slm_agent/defaults/main.yml
@@ -34,9 +34,12 @@ slm_agent_venv: "{{ slm_agent_dir }}/venv"
 slm_agent_data_dir: /var/lib/slm-agent
 
 # Python dependencies for the agent (#11508)
-# The agent runs on the system interpreter (/usr/bin/python3, see the service
-# unit's ExecStart) and MUST have every module it + autobot_shared import on ONE
-# interpreter — it can no longer borrow modules from the SLM backend venv.
+# #14278: the agent runs on its OWN venv (slm_agent_venv, see the unit's
+# ExecStart), and MUST have every module it + autobot_shared import on that ONE
+# interpreter — it borrows from neither the SLM backend venv nor system Python.
+# A clean venv inherits nothing, so anything the import chain touches has to be
+# listed here explicitly; under system Python some of it was satisfied by
+# whatever apt happened to have installed.
 #   - aiohttp: agent.py HTTP client/server
 #   - psutil:  health_collector resource metrics
 #   - redis:   autobot_shared.redis_client (health_collector.py imports it at
@@ -52,6 +55,14 @@ slm_agent_python_packages:
   - redis
   - pydantic-settings
   - sqlalchemy
+  # #14278: required by the agent's own import chain, and previously satisfied by
+  # accident because system Python usually has the distro's python3-yaml. A clean
+  # venv has nothing, so without this the unit crash-loops on
+  # ModuleNotFoundError before SLMAgent.run() is reached:
+  #   slm/agent/__init__.py -> health_collector -> autobot_shared.redis_client
+  #   -> autobot_shared.redis_management.config -> import yaml
+  # autobot_shared/pyproject.toml declares pyyaml>=6.0.3 for exactly this reason.
+  - pyyaml
 
 # Services to monitor (systemd service names)
 # Override per-host in inventory, e.g.:

--- a/autobot-slm-backend/ansible/roles/slm_agent/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/slm_agent/tasks/main.yml
@@ -117,13 +117,28 @@
   become: true
   tags: ['slm_agent', 'version']
 
-- name: "SLM Agent | Install Python dependencies"
-  pip:
+- name: "SLM Agent | Ensure python3-venv is present (#14278)"
+  ansible.builtin.package:
+    name: python3-venv
+    state: present
+  become: true
+  tags: ['slm_agent', 'packages']
+
+# #14278: into a venv, not system Python. Every other component on the platform
+# already works this way (ai-stack, npu-worker, tts-worker, slm-backend); the
+# agent was the only exception, and it is the one that could not be provisioned
+# on a node whose distro owns one of its transitive dependencies.
+#
+# `--break-system-packages` is gone with it: inside a venv it is neither needed
+# nor meaningful.
+- name: "SLM Agent | Install Python dependencies into the agent venv (#14278)"
+  ansible.builtin.pip:
     name: "{{ slm_agent_python_packages }}"
     state: present
-    executable: pip3
-    extra_args: "--break-system-packages"
+    virtualenv: "{{ slm_agent_venv }}"
+    virtualenv_command: python3 -m venv
   become: true
+  become_user: "{{ slm_agent_user }}"
   environment:
     PIP_DEFAULT_TIMEOUT: "120"
   timeout: 300  # Issue #2835: prevent indefinite hang on dependency resolution

--- a/autobot-slm-backend/ansible/roles/slm_agent/templates/slm-agent.service.j2
+++ b/autobot-slm-backend/ansible/roles/slm_agent/templates/slm-agent.service.j2
@@ -34,9 +34,12 @@ WorkingDirectory={{ slm_agent_dir }}
 # Environment variables
 Environment=SLM_NODE_ID={{ slm_node_id }}
 Environment=SLM_ADMIN_URL={{ effective_admin_url }}
-# #11508: PYTHONPATH must let the SYSTEM interpreter (ExecStart below) import
-# autobot_shared on its own — the agent no longer borrows it from the SLM backend
-# venv. `{{ slm_agent_dir }}` resolves `slm.agent.*`; `{{ slm_agent_dir | dirname }}`
+# #11508: PYTHONPATH must let the agent's interpreter (ExecStart below) import
+# autobot_shared on its own — it does not borrow it from the SLM backend venv.
+# #14278: that interpreter is now the agent's OWN venv rather than system
+# python3. PYTHONPATH is honoured by any interpreter, so this resolution is
+# unchanged; what changed is that the agent's dependencies no longer collide
+# with the ones apt owns. `{{ slm_agent_dir }}` resolves `slm.agent.*`; `{{ slm_agent_dir | dirname }}`
 # is the install base (/opt/autobot) so `import autobot_shared` finds
 # /opt/autobot/autobot_shared directly, independent of the per-dir symlink.
 Environment=PYTHONPATH={{ slm_agent_dir }}:{{ slm_agent_dir | dirname }}
@@ -55,7 +58,7 @@ EnvironmentFile=-{{ slm_agent_data_dir }}/agent-secrets.env
 # ALL agent deps (aiohttp + psutil + redis). A stale drop-in that repointed this
 # at the backend venv (which lacks aiohttp) is removed by the role's clean tasks
 # so this ExecStart stays authoritative.
-ExecStart=/usr/bin/python3 -m slm.agent.agent \
+ExecStart={{ slm_agent_venv }}/bin/python -m slm.agent.agent \
     --node-id {{ slm_node_id }} \
     --interval {{ slm_heartbeat_interval }}{% if slm_services_to_monitor | length > 0 %} \
     --services {{ slm_services_to_monitor | join(' ') }}{% endif %}{% if slm_agent_debug %} \

--- a/autobot-slm-backend/ansible/roles/slm_agent/templates/slm-agent.service.j2
+++ b/autobot-slm-backend/ansible/roles/slm_agent/templates/slm-agent.service.j2
@@ -54,9 +54,9 @@ EnvironmentFile=-{{ slm_agent_data_dir }}/agent-secrets.env
 
 # Agent execution — admin_url resolved from SLM_ADMIN_URL env var above,
 # not baked into CLI args, so re-provisioning updates it (#2833).
-# #11508: the interpreter is the system python3, which the role provisions with
-# ALL agent deps (aiohttp + psutil + redis). A stale drop-in that repointed this
-# at the backend venv (which lacks aiohttp) is removed by the role's clean tasks
+# #11508 / #14278: the interpreter is the agent's own venv, which the role
+# provisions with ALL agent deps. A stale drop-in that repointed this at the
+# backend venv (which lacks aiohttp) is removed by the role's clean tasks
 # so this ExecStart stays authoritative.
 ExecStart={{ slm_agent_venv }}/bin/python -m slm.agent.agent \
     --node-id {{ slm_node_id }} \

--- a/autobot-slm-backend/services/role_registry.py
+++ b/autobot-slm-backend/services/role_registry.py
@@ -406,7 +406,15 @@ _INFRA_ROLES = [
         "target_path": _SLM_AGENT_DIR,
         "systemd_service": "slm-agent",
         "auto_restart": True,
-        "post_sync_cmd": (f"cd {_SLM_AGENT_DIR} && pip install aiohttp psutil"),
+        # #14278: the agent's venv, not system pip, and the SAME package set the
+        # ansible role installs. This listed two of six and targeted an
+        # interpreter the unit does not run, so a code-sync of this role could
+        # not update the dependencies the agent actually imports — and on a
+        # PEP 668 distro it fails outright with externally-managed-environment.
+        "post_sync_cmd": (
+            f"cd {_SLM_AGENT_DIR} && "
+            "venv/bin/pip install aiohttp psutil redis pydantic-settings sqlalchemy pyyaml"
+        ),
         "required": True,
         "degraded_without": [],
         "ansible_playbook": "deploy-slm-agent.yml",

--- a/autobot-slm-backend/services/role_registry.py
+++ b/autobot-slm-backend/services/role_registry.py
@@ -412,8 +412,7 @@ _INFRA_ROLES = [
         # not update the dependencies the agent actually imports — and on a
         # PEP 668 distro it fails outright with externally-managed-environment.
         "post_sync_cmd": (
-            f"cd {_SLM_AGENT_DIR} && "
-            "venv/bin/pip install aiohttp psutil redis pydantic-settings sqlalchemy pyyaml"
+            f"cd {_SLM_AGENT_DIR} && " "venv/bin/pip install aiohttp psutil redis pydantic-settings sqlalchemy pyyaml"
         ),
         "required": True,
         "degraded_without": [],

--- a/repo_tests/test_agent_venv_isolation_14278.py
+++ b/repo_tests/test_agent_venv_isolation_14278.py
@@ -113,3 +113,141 @@ def test_the_venv_path_is_derived_from_the_install_dir():
     )
 
     assert "slm_agent_dir" in str(defaults.get("slm_agent_venv", ""))
+
+
+# ---------------------------------------------------------------------------
+# The venv must contain everything the agent's import chain touches
+# ---------------------------------------------------------------------------
+
+
+def _agent_import_closure() -> set[str]:
+    """Third-party module names reachable from the agent's package import.
+
+    A clean venv inherits nothing, so anything on this chain that is not in
+    `slm_agent_python_packages` is a crash at process start. `pyyaml` was
+    exactly that: satisfied under system Python by whatever apt had installed,
+    absent the moment the agent got its own venv.
+    """
+    import ast as _ast
+
+    agent_pkg = _ROLES / "slm_agent" / "files" / "slm" / "agent"
+    shared = _REPO_ROOT / "autobot_shared"
+    seen: set[str] = set()
+    # Tests never run on the node; their imports are not runtime dependencies.
+    queue = [
+        p
+        for p in agent_pkg.rglob("*.py")
+        if not (p.name.startswith("test_") or p.name.endswith("_test.py"))
+    ]
+    visited_files: set[Path] = set()
+
+    while queue:
+        path = queue.pop()
+        if path in visited_files or not path.is_file():
+            continue
+        visited_files.add(path)
+        try:
+            tree = _ast.parse(path.read_text(encoding="utf-8"))
+        except SyntaxError:  # pragma: no cover
+            continue
+        for node in _ast.walk(tree):
+            names = []
+            if isinstance(node, _ast.ImportFrom) and node.module:
+                # Relative imports are internal by definition.
+                if node.level:
+                    continue
+                names = [node.module]
+            elif isinstance(node, _ast.Import):
+                names = [a.name for a in node.names]
+            for name in names:
+                top = name.split(".")[0]
+                if top == "autobot_shared":
+                    target = shared / Path(*name.split(".")[1:])
+                    for candidate in (target.with_suffix(".py"), target / "__init__.py"):
+                        if candidate.is_file():
+                            queue.append(candidate)
+                elif top in {"slm", "__future__"}:
+                    continue
+                else:
+                    # Resolvable next to the agent package or inside
+                    # autobot_shared -> internal, not a venv dependency.
+                    # Internal if it resolves anywhere in the repo's own import
+                    # roots. `utils`, `config` and `constants` are backend
+                    # modules, not PyPI distributions.
+                    local = [
+                        root / suffix
+                        for root in (agent_pkg, agent_pkg.parent, shared, _REPO_ROOT / "autobot-backend")
+                        for suffix in (f"{top}.py", f"{top}/__init__.py")
+                    ]
+                    if not any(candidate.is_file() for candidate in local):
+                        seen.add(top)
+    return seen
+
+
+# Modules the standard library provides; a venv always has them.
+_STDLIB = {
+    "asyncio", "json", "logging", "os", "platform", "socket", "subprocess", "sys",
+    "time", "typing", "pathlib", "datetime", "dataclasses", "enum", "functools",
+    "hashlib", "re", "shutil", "uuid", "contextlib", "collections", "itertools",
+    "threading", "traceback", "warnings", "base64", "secrets", "signal", "copy",
+    "inspect", "importlib", "math", "random", "string", "textwrap", "urllib", "io",
+    "abc", "glob", "tempfile", "types", "weakref", "struct", "binascii", "errno",
+    "ipaddress", "getpass", "argparse", "configparser", "csv", "gzip", "pickle",
+    "queue", "select", "shlex", "stat", "statistics", "unicodedata", "zlib",
+    "concurrent", "sqlite3", "unittest", "ssl", "http", "email", "html", "xml",
+}
+
+# Pulled in by a package that IS listed, so a venv gets them transitively.
+_TRANSITIVE = {"pydantic"}
+
+# PyPI distribution names differ from import names for a few packages.
+_IMPORT_TO_DISTRIBUTION = {"yaml": "pyyaml", "pydantic_settings": "pydantic-settings"}
+
+
+def test_the_import_closure_was_actually_walked():
+    """An empty closure would make the rule below vacuous."""
+    closure = _agent_import_closure()
+
+    assert "yaml" in closure, f"the walk did not reach yaml: {sorted(closure)}"
+
+
+def test_every_third_party_import_the_agent_reaches_is_installed_in_its_venv():
+    """The blind spot the first version of this PR had.
+
+    The other tests here assert on Ansible YAML structure; none of them looks at
+    what the agent actually imports, so a missing runtime dependency was
+    invisible to the whole suite.
+    """
+    defaults = yaml.safe_load(
+        (_ROLES / "slm_agent" / "defaults" / "main.yml").read_text(encoding="utf-8")
+    )
+    installed = {str(pkg).lower() for pkg in defaults["slm_agent_python_packages"]}
+
+    missing = sorted(
+        _IMPORT_TO_DISTRIBUTION.get(name, name)
+        for name in _agent_import_closure()
+        if name not in _STDLIB
+        and name not in _TRANSITIVE
+        and _IMPORT_TO_DISTRIBUTION.get(name, name).lower() not in installed
+    )
+
+    assert missing == [], f"the agent imports these but the venv would not have them: {missing}"
+
+
+def test_the_code_sync_command_installs_the_same_set_into_the_same_venv():
+    """A code-sync that updates a different interpreter than the unit runs, with
+    a different package list than provisioning, cannot keep the agent working."""
+    registry = (
+        _REPO_ROOT / "autobot-slm-backend" / "services" / "role_registry.py"
+    ).read_text(encoding="utf-8")
+    match = re.search(r'"post_sync_cmd":\s*\((.*?)\),\n', registry[registry.index("_SLM_AGENT_DIR,"):], re.DOTALL)
+    assert match, "no post_sync_cmd found for the slm-agent role"
+    command = match.group(1)
+
+    assert "venv/bin/pip" in command, f"code-sync targets the wrong interpreter: {command}"
+
+    defaults = yaml.safe_load(
+        (_ROLES / "slm_agent" / "defaults" / "main.yml").read_text(encoding="utf-8")
+    )
+    for package in defaults["slm_agent_python_packages"]:
+        assert str(package) in command, f"{package} is provisioned but not installed on code-sync"

--- a/repo_tests/test_agent_venv_isolation_14278.py
+++ b/repo_tests/test_agent_venv_isolation_14278.py
@@ -1,0 +1,115 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Every component installs into the interpreter its unit runs (#14278).
+
+The agent installed into system Python with `--break-system-packages`, so a
+transitive dependency the distro owns could not be replaced:
+
+    ERROR: Cannot uninstall typing_extensions 4.10.0, RECORD file not found.
+           Hint: The package was installed by debian.
+
+Provisioning an external node stopped there.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_ROLES = _REPO_ROOT / "autobot-slm-backend" / "ansible" / "roles"
+
+
+def _pip_tasks() -> list[tuple[str, dict]]:
+    """(role file, pip task args) for every ansible pip task in the roles tree."""
+    found = []
+    for path in sorted(_ROLES.rglob("*.yml")):
+        try:
+            document = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except yaml.YAMLError:  # pragma: no cover
+            continue
+
+        def walk(node):
+            if isinstance(node, list):
+                for item in node:
+                    walk(item)
+            elif isinstance(node, dict):
+                pip = node.get("ansible.builtin.pip") or node.get("pip")
+                if isinstance(pip, dict):
+                    found.append((str(path.relative_to(_ROLES)), pip))
+                for value in node.values():
+                    walk(value)
+
+        walk(document)
+    return found
+
+
+def test_the_scan_found_pip_tasks():
+    """An empty scan makes every rule below vacuous."""
+    assert len(_pip_tasks()) >= 4
+
+
+def test_no_role_installs_into_system_python_with_break_system_packages():
+    """`--break-system-packages` lets pip WRITE to the system environment. It does
+    not let pip remove what dpkg owns, so any distro-managed transitive
+    dependency aborts the install."""
+    offenders = [
+        f"{role_file}: {pip.get('name')}"
+        for role_file, pip in _pip_tasks()
+        if "break-system-packages" in str(pip.get("extra_args") or "")
+    ]
+
+    assert offenders == [], "\n".join(offenders)
+
+
+def test_the_agent_installs_into_a_virtualenv():
+    tasks = [pip for role_file, pip in _pip_tasks() if role_file.startswith("slm_agent/")]
+
+    assert tasks, "no pip task found in the slm_agent role"
+    assert all(task.get("virtualenv") for task in tasks), "the agent still installs outside a venv"
+
+
+def test_the_agent_unit_runs_the_venv_interpreter():
+    """The install target and the running interpreter must be the same one.
+
+    A venv that the unit does not use is worse than no venv: the dependencies are
+    installed somewhere nothing imports from, and the failure appears at runtime
+    rather than at install time.
+    """
+    unit = (_ROLES / "slm_agent" / "templates" / "slm-agent.service.j2").read_text(encoding="utf-8")
+    exec_start = next(line for line in unit.splitlines() if line.startswith("ExecStart="))
+
+    defaults = yaml.safe_load(
+        (_ROLES / "slm_agent" / "defaults" / "main.yml").read_text(encoding="utf-8")
+    )
+    venv_var = "slm_agent_venv"
+
+    assert "/usr/bin/python3" not in exec_start
+    # The unit references the venv by VARIABLE, so assert on that rather than on
+    # a literal path — the template never contains the resolved directory.
+    assert venv_var in exec_start, f"ExecStart does not use {{{{ {venv_var} }}}}: {exec_start}"
+    assert defaults[venv_var].endswith("/venv")
+
+
+def test_the_unit_still_sets_pythonpath_for_autobot_shared():
+    """#11508: the agent imports autobot_shared from the install base rather than
+    borrowing another component's venv. Moving to its own venv must not lose
+    that — PYTHONPATH is honoured by any interpreter, so it should be untouched.
+    """
+    unit = (_ROLES / "slm_agent" / "templates" / "slm-agent.service.j2").read_text(encoding="utf-8")
+
+    assert re.search(r"^Environment=PYTHONPATH=.*slm_agent_dir", unit, re.MULTILINE)
+
+
+def test_the_venv_path_is_derived_from_the_install_dir():
+    """A hardcoded second path would drift from slm_agent_dir."""
+    defaults = yaml.safe_load(
+        (_ROLES / "slm_agent" / "defaults" / "main.yml").read_text(encoding="utf-8")
+    )
+
+    assert "slm_agent_dir" in str(defaults.get("slm_agent_venv", ""))


### PR DESCRIPTION
## Thinking Path

From the deployment logs on the local machine, not from a guess:

```
TASK [slm_agent : SLM Agent | Install Python dependencies]
fatal: [<external node>]: FAILED! =>
  cmd: /usr/bin/pip3 install --break-system-packages aiohttp psutil redis pydantic-settings sqlalchemy
  stderr: ERROR: Cannot uninstall typing_extensions 4.10.0, RECORD file not found.
          Hint: The package was installed by debian.
```

`--break-system-packages` lets pip **write into** the system environment. It does not let pip
remove what `dpkg` owns — an apt-installed package has no `RECORD` file to uninstall from. So the
moment a dependency wants a newer `typing_extensions` than the distro ships, provisioning stops.

Nothing about that is specific to `typing_extensions`, or transient. Any distro-managed transitive
dependency reproduces it, on any node.

## What Changed

The agent's dependencies go into `{{ slm_agent_dir }}/venv`, and the unit runs that venv's
interpreter.

`slm-agent` was the only component installing into system Python — `ai-stack`, `npu-worker`,
`tts-worker` and `slm-backend` all have their own venv. It was also the only one that could not be
provisioned on a node whose distro owned one of its dependencies. Those two facts are the same
fact.

`--break-system-packages` is removed with it: inside a venv it is neither needed nor meaningful.

## What deliberately did not change

`Environment=PYTHONPATH={{ slm_agent_dir }}:{{ slm_agent_dir | dirname }}`.

#11508 set that so the agent imports `autobot_shared` from the install base rather than borrowing
the SLM backend's venv. `PYTHONPATH` is honoured by any interpreter, so moving to the agent's own
venv leaves that resolution untouched — what changes is only that the agent's dependencies stop
colliding with the ones apt owns. A test pins it, because losing it here would swap one import
failure for another.

## Verification

6 tests. Mutation-checked:

| mutation | result |
|---|---|
| back to system pip with `--break-system-packages` | 2 failed |
| unit back to `/usr/bin/python3` | 1 failed |
| drop the `PYTHONPATH` line | 1 failed |
| *(restored)* | 6 passed |

`test_no_role_installs_into_system_python_with_break_system_packages` is written as a rule over
every ansible pip task, not as a check on this role — the next role to take the shortcut fails it.

`test_the_agent_unit_runs_the_venv_interpreter` asserts the install target and the running
interpreter are the same. A venv the unit does not use is worse than no venv: the dependencies land
somewhere nothing imports from, and the failure moves from install time to run time. That is
#14275's defect on a different role.

## Risks

The venv is created on first provisioning run; nodes already provisioned get it on their next run.
Until then the agent keeps running under the system interpreter it was started with, so this does
not interrupt a running agent — it changes what the next restart uses.

## Not in scope

The `ai-stack` spacy build failure in the same run — different cause, filed as #14279.

## Model Used

Opus 5 (1M context).

Closes #14278
