### PR TITLE
fix(deploy): spacy is an optional backend extra, not an AI-stack dependency (#14279)

### DIFF
--- a/autobot-infrastructure/shared/docker/ai-stack/requirements-ai.txt
+++ b/autobot-infrastructure/shared/docker/ai-stack/requirements-ai.txt
@@ -30,7 +30,18 @@ torchaudio>=2.11.0
 
 # Text Processing
 nltk>=3.10.2
-spacy>=3.8.14
+# spacy: NOT a dependency of the AI stack (#14279). Nothing under
+# autobot-infrastructure/shared/docker/ai-stack/ imports it — the only importer
+# in the repo is autobot-backend/knowledge/pipeline/cognifiers/entity_extractor.py,
+# where it is an OPTIONAL extra behind `_spacy_available()` and declared in
+# autobot-backend/requirements-nlp.txt.
+#
+# That guard's own docstring says why: "spaCy is not in the default image (its
+# build deps lack py3.14 wheels, #9825); when absent, entity extraction falls
+# back to the LLM path automatically." Listing it here as a HARD dependency made
+# provisioning fail on exactly the incompatibility the backend designed around —
+# no stable spacy declares support for 3.14, so pip fell through to the
+# 4.0.0.dev3 sdist and tried to build it on the node.
 
 # HTTP and API
 fastapi>=0.141.1

--- a/repo_tests/test_optional_extras_are_not_hard_deps_14279.py
+++ b/repo_tests/test_optional_extras_are_not_hard_deps_14279.py
@@ -1,0 +1,109 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""An optional extra must not be a hard dependency of another component (#14279).
+
+`spacy` is opt-in for the backend, behind `_spacy_available()`, and declared in
+`autobot-backend/requirements-nlp.txt`. Its guard's docstring says why: spaCy's
+build deps lack py3.14 wheels (#9825), so entity extraction falls back to the LLM
+path when it is absent.
+
+It was also listed as a hard requirement of the AI stack, which nothing there
+imports — so provisioning failed on exactly the incompatibility the backend had
+designed around: no stable spacy supports 3.14, pip fell through to a
+`4.0.0.dev3` sdist, and the build died on the node.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_NLP_EXTRA = _REPO_ROOT / "autobot-backend" / "requirements-nlp.txt"
+_AI_STACK = (
+    _REPO_ROOT / "autobot-infrastructure" / "shared" / "docker" / "ai-stack" / "requirements-ai.txt"
+)
+_AI_STACK_SRC = _AI_STACK.parent
+
+_REQ = re.compile(r"^\s*([A-Za-z0-9_.\-]+)\s*(?:[<>=!~\[].*)?$")
+
+
+def _declared(path: Path) -> set[str]:
+    found = set()
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.split("#")[0].strip()
+        if not line or line.startswith("-"):
+            continue
+        match = _REQ.match(line)
+        if match:
+            found.add(match.group(1).lower().replace("_", "-"))
+    return found
+
+
+def test_both_requirement_files_were_read():
+    """Empty sets would make the rule below vacuously true."""
+    assert len(_declared(_AI_STACK)) >= 10
+    assert len(_declared(_NLP_EXTRA)) >= 1
+
+
+def test_no_optional_nlp_extra_is_a_hard_ai_stack_dependency():
+    """The rule, not just the one package.
+
+    `requirements-nlp.txt` exists so spaCy and friends are installed
+    deliberately. Anything in it that also appears as a hard requirement
+    elsewhere defeats that — the opt-in becomes mandatory, and its
+    platform constraints become everyone's.
+    """
+    overlap = sorted(_declared(_NLP_EXTRA) & _declared(_AI_STACK))
+
+    assert overlap == [], (
+        f"optional NLP extras declared as hard AI-stack deps: {overlap}. "
+        "They are opt-in for a reason — see _spacy_available() and #9825."
+    )
+
+
+def test_the_ai_stack_does_not_import_what_it_no_longer_declares():
+    """If something under the AI stack actually imported spacy, removing the
+    requirement would be wrong — so this pins the premise rather than assuming
+    it stays true."""
+    sources = "\n".join(
+        path.read_text(encoding="utf-8") for path in _AI_STACK_SRC.glob("*.py")
+    )
+
+    assert "import spacy" not in sources
+    assert "from spacy" not in sources
+
+
+def test_the_backend_still_owns_the_capability():
+    """Removing the mis-declaration must not remove the feature."""
+    assert "spacy" in _declared(_NLP_EXTRA)
+
+    extractor = (
+        _REPO_ROOT
+        / "autobot-backend"
+        / "knowledge"
+        / "pipeline"
+        / "cognifiers"
+        / "entity_extractor.py"
+    ).read_text(encoding="utf-8")
+
+    assert "_spacy_available" in extractor
+    assert "import spacy" in extractor
+
+
+@pytest.mark.parametrize("path", [_AI_STACK, _NLP_EXTRA])
+def test_no_requirement_file_pins_a_pre_release(path):
+    """A `.devN` / `aN` / `bN` / `rcN` pin would put a pre-release into a
+    production install deliberately. pip reached one here by fallback; nothing
+    should reach one on purpose."""
+    offenders = [
+        line.strip()
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if re.search(r"==\s*[0-9][^\s#]*(dev|a|b|rc)[0-9]", line.split("#")[0])
+    ]
+
+    assert offenders == [], offenders


### PR DESCRIPTION
## Thinking Path

The obvious reading of the failure is "pin spacy to a version that builds". I went looking for
*why* pip chose a pre-release first, and the answer changed the fix.

`spacy>=3.8.14` is satisfied by stable 3.8.x, so pip should never consider a pre-release. It does
consider them when **no stable candidate is installable** — and no stable spacy declares support
for Python 3.14, which is what the AI-stack venv runs. So pip fell through to
`spacy-4.0.0.dev3.tar.gz`, the only release whose metadata admits 3.14, and tried to build it on
the node.

Then the more useful question: what in the AI stack needs spacy? Nothing does.

The repo already knew all of this. `entity_extractor.py:34`:

> `_spacy_available()` — "spaCy is not in the default image (its build deps lack py3.14 wheels,
> **#9825**); when absent, entity extraction falls back to the LLM path automatically."

## Problem

`autobot-infrastructure/shared/docker/ai-stack/requirements-ai.txt:33` declared `spacy>=3.8.14` as
a **hard** dependency of the AI stack.

- Nothing under `autobot-infrastructure/shared/docker/ai-stack/` imports it — both source files
  checked.
- The only importer in the repo is
  `autobot-backend/knowledge/pipeline/cognifiers/entity_extractor.py:124`, where it is an
  **optional** extra behind `_spacy_available()`, declared in
  `autobot-backend/requirements-nlp.txt` so it is installed deliberately.

So an opt-in extra, deliberately kept out of the default install because of a known py3.14
incompatibility, was a mandatory dependency of a different component — and provisioning failed on
exactly the incompatibility the backend had designed around.

## What Changed

The declaration is removed from `requirements-ai.txt`, with the reasoning recorded in place.

Nothing is lost: the capability stays in the backend, behind its guard, in its own opt-in
requirements file. This removes a mis-declaration, not a feature.

## Verification

6 tests. Mutation-checked:

| mutation | result |
|---|---|
| reintroduce `spacy` in the AI-stack requirements | 1 failed |
| pin any package to a `.devN` pre-release | 1 failed |
| *(restored)* | 6 passed |

The rule is written as "nothing in `requirements-nlp.txt` may be a hard AI-stack dependency",
not as "spacy must be absent" — the opt-in file exists precisely so its contents are installed on
purpose, and any of them becoming mandatory elsewhere defeats that.

Two premises are pinned rather than assumed, because the fix is only correct while they hold:
`test_the_ai_stack_does_not_import_what_it_no_longer_declares` fails if AI-stack code ever starts
importing spacy, and `test_the_backend_still_owns_the_capability` fails if the backend's guard or
its `requirements-nlp.txt` entry disappears.

`check_requirements_no_conflicting_dupes.py`: exit 0.

## Risks

None to the backend's NLP path — it is unchanged and still opt-in. If someone later wants spaCy
*in* the AI stack, they will need it to support the interpreter that stack runs, which is the
underlying constraint #9825 already tracks.

## Not verified here

Host evidence. The AI-stack install step should now complete, but that needs a provisioning run —
#14279 stays open until it has one.

## Model Used

Opus 5 (1M context).

Closes #14279
