### PR TITLE
fix(vnc): expand the VNC user before writing the systemd units (#14036)

### DIFF
--- a/autobot-infrastructure/shared/scripts/utilities/fix-vnc-desktop.sh
+++ b/autobot-infrastructure/shared/scripts/utilities/fix-vnc-desktop.sh
@@ -15,7 +15,7 @@ set -e
 #
 # $USER is not usable here either: this script is run with sudo, so $USER is
 # root and the paths resolved to /home/root.
-VNC_USER="${VNC_USER}"
+VNC_USER="${AUTOBOT_VNC_USER:-autobot}"
 VNC_HOME="/home/${VNC_USER}"
 
 echo "Setting up VNC with XFCE desktop..."

--- a/autobot-infrastructure/shared/scripts/utilities/fix-vnc-desktop.sh
+++ b/autobot-infrastructure/shared/scripts/utilities/fix-vnc-desktop.sh
@@ -6,6 +6,18 @@
 
 set -e
 
+# #14036: resolve the VNC user ONCE, here, in the shell.
+#
+# The unit heredocs below are quoted (<< 'EOF'), which disables parameter
+# expansion, so a ${...} written inside one lands in the unit file verbatim.
+# systemd has no bash-style :- default syntax, so `User=${VNC_USER}`
+# is not a valid directive value and the unit is broken on every run.
+#
+# $USER is not usable here either: this script is run with sudo, so $USER is
+# root and the paths resolved to /home/root.
+VNC_USER="${VNC_USER}"
+VNC_HOME="/home/${VNC_USER}"
+
 echo "Setting up VNC with XFCE desktop..."
 
 # Stop existing services
@@ -17,8 +29,8 @@ pkill -9 x11vnc 2>/dev/null || true
 pkill -9 Xtigervnc 2>/dev/null || true
 
 # Create proper xstartup for XFCE
-mkdir -p /home/${USER:-autobot}/.vnc
-cat > /home/${USER:-autobot}/.vnc/xstartup << 'EOF'
+mkdir -p ${VNC_HOME}/.vnc
+cat > ${VNC_HOME}/.vnc/xstartup << 'EOF'
 #!/bin/bash
 unset SESSION_MANAGER
 unset DBUS_SESSION_BUS_ADDRESS
@@ -33,29 +45,29 @@ xsetroot -solid "#2E3440" &
 # Start XFCE desktop
 exec startxfce4
 EOF
-chmod +x /home/${USER:-autobot}/.vnc/xstartup
-chown kali:kali /home/${USER:-autobot}/.vnc/xstartup
+chmod +x ${VNC_HOME}/.vnc/xstartup
+chown "${VNC_USER}:${VNC_USER}" ${VNC_HOME}/.vnc/xstartup
 
 # Create VNC password (random, displayed once)
 VNC_PASS=$(openssl rand -base64 12 | tr -dc 'a-zA-Z0-9' | head -c 16)
-echo "$VNC_PASS" | vncpasswd -f > /home/${USER:-autobot}/.vnc/passwd
+echo "$VNC_PASS" | vncpasswd -f > ${VNC_HOME}/.vnc/passwd
 echo "Generated VNC password: $VNC_PASS"
-chmod 600 /home/${USER:-autobot}/.vnc/passwd
-chown kali:kali /home/${USER:-autobot}/.vnc/passwd
+chmod 600 ${VNC_HOME}/.vnc/passwd
+chown "${VNC_USER}:${VNC_USER}" ${VNC_HOME}/.vnc/passwd
 
 # Create TigerVNC service (runs its own X server with desktop)
-cat > /etc/systemd/system/tigervnc.service << 'EOF'
+cat > /etc/systemd/system/tigervnc.service << EOF
 [Unit]
 Description=TigerVNC Server with XFCE Desktop
 After=network.target
 
 [Service]
 Type=simple
-User=${AUTOBOT_VNC_USER:-autobot}
-Group=${AUTOBOT_VNC_USER:-autobot}
-Environment=HOME=/home/${AUTOBOT_VNC_USER:-autobot}
-WorkingDirectory=/home/${AUTOBOT_VNC_USER:-autobot}
-ExecStart=/usr/bin/tigervncserver -fg -geometry 1920x1080 -depth 24 -SecurityTypes VncAuth -passwd /home/${USER:-autobot}/.vnc/passwd -xstartup /home/${USER:-autobot}/.vnc/xstartup :1
+User=${VNC_USER}
+Group=${VNC_USER}
+Environment=HOME=/home/${VNC_USER}
+WorkingDirectory=/home/${VNC_USER}
+ExecStart=/usr/bin/tigervncserver -fg -geometry 1920x1080 -depth 24 -SecurityTypes VncAuth -passwd ${VNC_HOME}/.vnc/passwd -xstartup ${VNC_HOME}/.vnc/xstartup :1
 ExecStop=/usr/bin/tigervncserver -kill :1
 Restart=on-failure
 RestartSec=5
@@ -70,7 +82,7 @@ EOF
 # removes (#13069) and which otherwise serves a stale pre-VeNCrypt client
 # (#13060). This script does not install noVNC itself; run the vnc role (or
 # an equivalent pinned install) first so /opt/novnc exists.
-cat > /etc/systemd/system/novnc.service << 'EOF'
+cat > /etc/systemd/system/novnc.service << EOF
 [Unit]
 Description=noVNC Web Interface
 After=tigervnc.service
@@ -78,13 +90,13 @@ Requires=tigervnc.service
 
 [Service]
 Type=simple
-User=kali
-Group=kali
+User=${VNC_USER}
+Group=${VNC_USER}
 WorkingDirectory=/opt/novnc
-ExecStart=/usr/bin/websockify --web /opt/novnc \
-    --cert=/etc/autobot/certs/server-cert.pem \
-    --key=/etc/autobot/certs/server-key.pem \
-    --ssl-only \
+ExecStart=/usr/bin/websockify --web /opt/novnc \\
+    --cert=/etc/autobot/certs/server-cert.pem \\
+    --key=/etc/autobot/certs/server-key.pem \\
+    --ssl-only \\
     localhost:6080 localhost:5901
 Restart=always
 RestartSec=5

--- a/autobot-infrastructure/shared/scripts/utilities/fix-vnc-wsl.sh
+++ b/autobot-infrastructure/shared/scripts/utilities/fix-vnc-wsl.sh
@@ -6,21 +6,33 @@
 
 set -e
 
+# #14036: resolve the VNC user ONCE, here, in the shell.
+#
+# The unit heredocs below are quoted (<< 'EOF'), which disables parameter
+# expansion, so a ${...} written inside one lands in the unit file verbatim.
+# systemd has no bash-style :- default syntax, so `User=${VNC_USER}`
+# is not a valid directive value and the unit is broken on every run.
+#
+# $USER is not usable here either: this script is run with sudo, so $USER is
+# root and the paths resolved to /home/root.
+VNC_USER="${VNC_USER}"
+VNC_HOME="/home/${VNC_USER}"
+
 echo "Setting up VNC for WSL environment..."
 
 # Stop existing services
 systemctl stop x11vnc.service novnc.service 2>/dev/null || true
 
 # Create Xvfb service (virtual framebuffer)
-cat > /etc/systemd/system/xvfb.service << 'EOF'
+cat > /etc/systemd/system/xvfb.service << EOF
 [Unit]
 Description=X Virtual Framebuffer
 After=network.target
 
 [Service]
 Type=simple
-User=kali
-Group=kali
+User=${VNC_USER}
+Group=${VNC_USER}
 ExecStart=/usr/bin/Xvfb :1 -screen 0 1920x1080x24
 Restart=always
 RestartSec=5
@@ -30,7 +42,7 @@ WantedBy=multi-user.target
 EOF
 
 # Create x11vnc service that connects to Xvfb
-cat > /etc/systemd/system/x11vnc.service << 'EOF'
+cat > /etc/systemd/system/x11vnc.service << EOF
 [Unit]
 Description=x11vnc VNC Server for Xvfb
 After=xvfb.service
@@ -38,10 +50,10 @@ Requires=xvfb.service
 
 [Service]
 Type=simple
-User=kali
-Group=kali
+User=${VNC_USER}
+Group=${VNC_USER}
 Environment=DISPLAY=:1
-ExecStart=/usr/bin/x11vnc -display :1 -forever -shared -rfbauth /home/${USER:-autobot}/.vnc/passwd -rfbport 5900 -noxdamage -noxfixes
+ExecStart=/usr/bin/x11vnc -display :1 -forever -shared -rfbauth ${VNC_HOME}/.vnc/passwd -rfbport 5900 -noxdamage -noxfixes
 Restart=always
 RestartSec=5
 
@@ -55,7 +67,7 @@ EOF
 # removes (#13069) and which otherwise serves a stale pre-VeNCrypt client
 # (#13060). This script does not install noVNC itself; run the vnc role (or
 # an equivalent pinned install) first so /opt/novnc exists.
-cat > /etc/systemd/system/novnc.service << 'EOF'
+cat > /etc/systemd/system/novnc.service << EOF
 [Unit]
 Description=noVNC Web Interface
 After=x11vnc.service
@@ -63,13 +75,13 @@ Requires=x11vnc.service
 
 [Service]
 Type=simple
-User=kali
-Group=kali
+User=${VNC_USER}
+Group=${VNC_USER}
 WorkingDirectory=/opt/novnc
-ExecStart=/usr/bin/websockify --web /opt/novnc \
-    --cert=/etc/autobot/certs/server-cert.pem \
-    --key=/etc/autobot/certs/server-key.pem \
-    --ssl-only \
+ExecStart=/usr/bin/websockify --web /opt/novnc \\
+    --cert=/etc/autobot/certs/server-cert.pem \\
+    --key=/etc/autobot/certs/server-key.pem \\
+    --ssl-only \\
     localhost:6080 localhost:5900
 Restart=always
 RestartSec=5
@@ -79,13 +91,13 @@ WantedBy=multi-user.target
 EOF
 
 # Ensure password file exists
-mkdir -p /home/${USER:-autobot}/.vnc
-if [ ! -f /home/${USER:-autobot}/.vnc/passwd ]; then
+mkdir -p ${VNC_HOME}/.vnc
+if [ ! -f ${VNC_HOME}/.vnc/passwd ]; then
     VNC_PASS=$(openssl rand -base64 12 | tr -dc 'a-zA-Z0-9' | head -c 16)
-    x11vnc -storepasswd "$VNC_PASS" /home/${USER:-autobot}/.vnc/passwd
+    x11vnc -storepasswd "$VNC_PASS" ${VNC_HOME}/.vnc/passwd
     echo "Generated VNC password: $VNC_PASS"
 fi
-chown -R kali:kali /home/${USER:-autobot}/.vnc
+chown -R kali:kali ${VNC_HOME}/.vnc
 
 echo "Reloading systemd..."
 systemctl daemon-reload

--- a/autobot-infrastructure/shared/scripts/utilities/fix-vnc-wsl.sh
+++ b/autobot-infrastructure/shared/scripts/utilities/fix-vnc-wsl.sh
@@ -15,7 +15,7 @@ set -e
 #
 # $USER is not usable here either: this script is run with sudo, so $USER is
 # root and the paths resolved to /home/root.
-VNC_USER="${VNC_USER}"
+VNC_USER="${AUTOBOT_VNC_USER:-autobot}"
 VNC_HOME="/home/${VNC_USER}"
 
 echo "Setting up VNC for WSL environment..."

--- a/autobot-infrastructure/shared/scripts/utilities/fix-vnc-wsl.sh
+++ b/autobot-infrastructure/shared/scripts/utilities/fix-vnc-wsl.sh
@@ -97,7 +97,7 @@ if [ ! -f ${VNC_HOME}/.vnc/passwd ]; then
     x11vnc -storepasswd "$VNC_PASS" ${VNC_HOME}/.vnc/passwd
     echo "Generated VNC password: $VNC_PASS"
 fi
-chown -R kali:kali ${VNC_HOME}/.vnc
+chown -R "${VNC_USER}:${VNC_USER}" "${VNC_HOME}/.vnc"
 
 echo "Reloading systemd..."
 systemctl daemon-reload

--- a/scripts/systemd_heredoc_expansion_test.py
+++ b/scripts/systemd_heredoc_expansion_test.py
@@ -42,7 +42,13 @@ _HEREDOC = re.compile(r"""cat\s*>>?\s*(?P<target>\S+)\s*<<-?\s*(?P<q>['"]?)(?P<d
 # ${NAME}, ${NAME:-default}, $NAME
 _VAR_REF = re.compile(r"\$\{(?P<braced>[A-Za-z_][A-Za-z0-9_]*)[^}]*\}|\$(?P<bare>[A-Za-z_][A-Za-z0-9_]*)")
 
-_ASSIGNMENT = re.compile(r"^\s*(?:export\s+)?(?P<name>[A-Za-z_][A-Za-z0-9_]*)=")
+# `local`/`declare`/`readonly`/`typeset` bind a name just as plainly as a bare
+# assignment does. Reading only the bare form reported 10 false positives in
+# install-bare-metal.sh, where every unit variable is a function `local`.
+_ASSIGNMENT = re.compile(
+    r"^\s*(?:export\s+|local\s+|declare\s+(?:-\w+\s+)?|readonly\s+|typeset\s+)?"
+    r"(?P<name>[A-Za-z_][A-Za-z0-9_]*)="
+)
 
 # Names systemd itself resolves at runtime, which must reach the unit file
 # unexpanded. A script wanting one writes it escaped; this list keeps the rule
@@ -164,14 +170,23 @@ def test_the_vnc_units_resolve_to_a_real_user():
         text = script.read_text(encoding="utf-8")
         values = dict(re.findall(r'^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)="?([^"\n]*)"?', text, re.M))
 
+        def substitute(match: re.Match) -> str:
+            """``${NAME}`` from the script, else ``${NAME:-default}``'s default.
+
+            The default branch matters: the resolved value is *built* from one
+            (``VNC_USER="${AUTOBOT_VNC_USER:-autobot}"``), so ignoring it leaves
+            the expansion stuck one level short and the assertion below reports
+            an unresolved token that resolves fine at runtime.
+            """
+            name, default = match.group(1), match.group(2)
+            if name in values:
+                return values[name]
+            return default if default is not None else match.group(0)
+
         def expand(raw: str) -> str:
             out = raw
-            for _ in range(5):  # VNC_HOME references VNC_USER
-                new = re.sub(
-                    r"\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-[^}]*)?\}",
-                    lambda m: values.get(m.group(1), m.group(0)),
-                    out,
-                )
+            for _ in range(5):  # VNC_HOME references VNC_USER references the default
+                new = re.sub(r"\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-([^}]*))?\}", substitute, out)
                 if new == out:
                     break
                 out = new

--- a/scripts/systemd_heredoc_expansion_test.py
+++ b/scripts/systemd_heredoc_expansion_test.py
@@ -1,0 +1,187 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""A generated systemd unit may not contain an unexpanded ``${...}`` (#14036).
+
+``cat > x.service << 'EOF'`` — quoted delimiter — disables shell parameter
+expansion for the whole block. A ``${AUTOBOT_VNC_USER:-autobot}`` written
+inside one lands in the unit file verbatim, and systemd has no bash-style
+``:-`` default syntax, so ``User=${AUTOBOT_VNC_USER:-autobot}`` is not a valid
+directive value. Every run of the script produced a broken unit.
+
+The failure is quiet in the worst way: the script exits 0 having written a file
+that looks plausible, and the breakage only appears when someone starts the
+unit.
+
+Two rules, because fixing this has two ways to go wrong:
+
+1. A quoted unit heredoc must contain no ``${...}`` at all.
+2. An *unquoted* one — the fix — may only reference variables the script has
+   already assigned. Unquoting is what makes expansion work, and it also
+   exposes every other token in the block: ``${USER}`` expands to ``root``
+   under ``sudo``, which is how these scripts came to reference ``/home/root``.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+_SKIP_DIRS = ("venv/", "node_modules/", ".git/", ".worktrees/")
+
+# A heredoc whose target is a unit file, or anywhere under a systemd directory.
+_UNIT_SUFFIXES = (".service", ".timer", ".socket", ".mount", ".path")
+
+_HEREDOC = re.compile(r"""cat\s*>>?\s*(?P<target>\S+)\s*<<-?\s*(?P<q>['"]?)(?P<delim>\w+)(?P=q)\s*$""")
+
+# ${NAME}, ${NAME:-default}, $NAME
+_VAR_REF = re.compile(r"\$\{(?P<braced>[A-Za-z_][A-Za-z0-9_]*)[^}]*\}|\$(?P<bare>[A-Za-z_][A-Za-z0-9_]*)")
+
+_ASSIGNMENT = re.compile(r"^\s*(?:export\s+)?(?P<name>[A-Za-z_][A-Za-z0-9_]*)=")
+
+# Names systemd itself resolves at runtime, which must reach the unit file
+# unexpanded. A script wanting one writes it escaped; this list keeps the rule
+# from demanding a shell assignment for something the shell must not touch.
+_SYSTEMD_RUNTIME_VARS = frozenset({"MAINPID", "TERM", "PATH", "HOME", "USER", "LOGNAME", "SHELL"})
+
+
+def _shell_scripts() -> list[Path]:
+    return sorted(
+        p
+        for p in _REPO_ROOT.rglob("*.sh")
+        if not any(skip in str(p.relative_to(_REPO_ROOT)) for skip in _SKIP_DIRS)
+    )
+
+
+def _unit_heredocs(path: Path):
+    """Yield (target, quoted, start_line, body_lines, assigned_before)."""
+    text = path.read_text(encoding="utf-8", errors="replace")
+    lines = text.splitlines()
+    assigned: set[str] = set()
+    i = 0
+    while i < len(lines):
+        assignment = _ASSIGNMENT.match(lines[i])
+        if assignment:
+            assigned.add(assignment.group("name"))
+        match = _HEREDOC.search(lines[i])
+        if match:
+            target, delim = match.group("target"), match.group("delim")
+            body, j = [], i + 1
+            while j < len(lines) and lines[j].strip() != delim:
+                body.append((j + 1, lines[j]))
+                j += 1
+            is_unit = target.endswith(_UNIT_SUFFIXES) or "/systemd/" in target
+            if is_unit:
+                yield target, bool(match.group("q")), i + 1, body, set(assigned)
+            i = j
+        i += 1
+
+
+def _scripts_writing_units() -> list[Path]:
+    return [p for p in _shell_scripts() if any(_unit_heredocs(p))]
+
+
+def test_the_scan_finds_the_scripts_it_is_meant_to_guard():
+    """An empty scan reads exactly like a clean one.
+
+    If the heredoc pattern ever stops matching — a reformat, a different
+    redirect form — every rule below passes over zero blocks and reports
+    success.
+    """
+    found = _scripts_writing_units()
+    assert found, "no script writing a systemd unit was found — the scan is broken, not the repo"
+
+
+@pytest.mark.parametrize("script", _scripts_writing_units(), ids=lambda p: p.name)
+def test_a_quoted_unit_heredoc_contains_no_variable_reference(script):
+    offenders = [
+        f"{script.relative_to(_REPO_ROOT)}:{ln}  {text.strip()}"
+        for _target, quoted, _start, body, _assigned in _unit_heredocs(script)
+        if quoted
+        for ln, text in body
+        if "${" in text
+    ]
+    assert not offenders, "a quoted heredoc does not expand — these land in the unit verbatim:\n" + "\n".join(offenders)
+
+
+@pytest.mark.parametrize("script", _scripts_writing_units(), ids=lambda p: p.name)
+def test_an_unquoted_unit_heredoc_only_uses_variables_the_script_defines(script):
+    """Unquoting is the fix; it is also what makes ``$USER`` a live hazard.
+
+    These scripts run under ``sudo``, where ``$USER`` is ``root`` — which is
+    how a path meant for the VNC user resolved to ``/home/root``.
+    """
+    offenders = []
+    for _target, quoted, _start, body, assigned in _unit_heredocs(script):
+        if quoted:
+            continue
+        for ln, text in body:
+            # an escaped \$ is deliberate and reaches the unit as-is
+            for match in _VAR_REF.finditer(re.sub(r"\\\$", "", text)):
+                name = match.group("braced") or match.group("bare")
+                if name not in assigned and name not in _SYSTEMD_RUNTIME_VARS:
+                    offenders.append(f"{script.relative_to(_REPO_ROOT)}:{ln}  ${name} is never assigned in this script")
+    assert not offenders, "\n".join(offenders)
+
+
+@pytest.mark.parametrize("script", _scripts_writing_units(), ids=lambda p: p.name)
+def test_a_line_continuation_survives_into_the_unit(script):
+    """An unquoted heredoc eats a trailing backslash as a continuation.
+
+    The joined line is still valid to systemd, so nothing breaks loudly — but
+    the written file stops matching the script that wrote it, and the next
+    person diffing them finds a discrepancy with no cause. It must be ``\\\\``.
+    """
+    offenders = [
+        f"{script.relative_to(_REPO_ROOT)}:{ln}"
+        for _target, quoted, _start, body, _assigned in _unit_heredocs(script)
+        if not quoted
+        for ln, text in body
+        if re.search(r"(?<!\\)\\$", text)
+    ]
+    assert not offenders, "unescaped line continuation inside an unquoted heredoc:\n" + "\n".join(offenders)
+
+
+def test_the_vnc_units_resolve_to_a_real_user():
+    """The reported case, checked by expanding the script the way bash would.
+
+    Static substitution rather than execution: the assignments are read out of
+    the script and applied to the heredoc body, so this says what the file
+    would contain without running anything from the checkout.
+    """
+    scripts = [
+        _REPO_ROOT / "autobot-infrastructure/shared/scripts/utilities/fix-vnc-desktop.sh",
+        _REPO_ROOT / "autobot-infrastructure/shared/scripts/utilities/fix-vnc-wsl.sh",
+    ]
+    checked = 0
+    for script in scripts:
+        assert script.is_file(), f"{script} is gone — this test names a file that no longer exists"
+        text = script.read_text(encoding="utf-8")
+        values = dict(re.findall(r'^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)="?([^"\n]*)"?', text, re.M))
+
+        def expand(raw: str) -> str:
+            out = raw
+            for _ in range(5):  # VNC_HOME references VNC_USER
+                new = re.sub(
+                    r"\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-[^}]*)?\}",
+                    lambda m: values.get(m.group(1), m.group(0)),
+                    out,
+                )
+                if new == out:
+                    break
+                out = new
+            return out
+
+        for _target, _quoted, _start, body, _assigned in _unit_heredocs(script):
+            for _ln, line in body:
+                if line.startswith(("User=", "Group=", "WorkingDirectory=", "Environment=HOME=")):
+                    resolved = expand(line)
+                    assert "${" not in resolved and "$" not in resolved, f"{script.name}: {line} -> {resolved}"
+                    assert resolved.split("=", 1)[1].strip(), f"{script.name}: {line} resolved to an empty value"
+                    checked += 1
+    assert checked >= 8, f"expected the four directives across both scripts' units, checked {checked}"

--- a/scripts/systemd_heredoc_expansion_test.py
+++ b/scripts/systemd_heredoc_expansion_test.py
@@ -50,10 +50,21 @@ _ASSIGNMENT = re.compile(
     r"(?P<name>[A-Za-z_][A-Za-z0-9_]*)="
 )
 
-# Names systemd itself resolves at runtime, which must reach the unit file
-# unexpanded. A script wanting one writes it escaped; this list keeps the rule
-# from demanding a shell assignment for something the shell must not touch.
-_SYSTEMD_RUNTIME_VARS = frozenset({"MAINPID", "TERM", "PATH", "HOME", "USER", "LOGNAME", "SHELL"})
+# No allowlist. Review finding on this PR: the previous one exempted USER and
+# HOME — the two names #14036 was actually about — from the rule below.
+#
+# The reasoning it carried ("systemd resolves these at runtime") is backwards
+# for the case the rule governs. systemd's specifiers are `%u` and `%h`; it does
+# not resolve `$USER` or `$HOME` in a unit file at all. Inside an *unquoted*
+# heredoc those are live bash expansions at the moment the file is written —
+# under `sudo bash` that is root, which is exactly how `/home/root` got into
+# these units.
+#
+# A token that genuinely must reach the unit unexpanded — `$MAINPID` is the
+# real example — is written escaped as `\$MAINPID`, and escaped forms are
+# stripped before this rule runs. So requiring an assignment for every
+# unescaped reference costs nothing and closes the hole.
+_SYSTEMD_RUNTIME_VARS: frozenset = frozenset()
 
 
 def _shell_scripts() -> list[Path]:
@@ -200,3 +211,29 @@ def test_the_vnc_units_resolve_to_a_real_user():
                     assert resolved.split("=", 1)[1].strip(), f"{script.name}: {line} resolved to an empty value"
                     checked += 1
     assert checked >= 8, f"expected the four directives across both scripts' units, checked {checked}"
+
+
+_LITERAL_USER_CHOWN = re.compile(r"^\s*chown\s+(?:-\w+\s+)*(?P<owner>[A-Za-z_][A-Za-z0-9_-]*):")
+
+
+@pytest.mark.parametrize("script", _scripts_writing_units(), ids=lambda p: p.name)
+def test_no_chown_names_a_literal_user_in_a_script_that_writes_units(script):
+    """Ownership must follow the unit's ``User=``, not a hardcoded name.
+
+    Found by review, and invisible to every other rule here by design: the
+    heredoc scanner only reads inside heredoc bodies, and this is a plain shell
+    command outside one.
+
+    `fix-vnc-wsl.sh` kept `chown -R kali:kali` on the shared `.vnc` directory
+    while its units were rewritten to run as `${VNC_USER}` (default `autobot`).
+    On a host with no `kali` account the chown fails, and `set -e` aborts the
+    script before `daemon-reload` — so the units are written and never started.
+    On a host that has one, the password file ends up owned by `kali` while the
+    service runs as `autobot` and cannot read its own `rfbauth` file (mode 600).
+    """
+    offenders = []
+    for number, line in enumerate(script.read_text(encoding="utf-8", errors="replace").splitlines(), 1):
+        match = _LITERAL_USER_CHOWN.match(line)
+        if match and "$" not in match.group("owner"):
+            offenders.append(f"{script.relative_to(_REPO_ROOT)}:{number}  {line.strip()}")
+    assert not offenders, "chown must use the same variable the unit's User= does:\n" + "\n".join(offenders)


### PR DESCRIPTION
## Thinking Path

The reported line is one of six. I swept the repo for the shape before fixing, because a
one-file fix to a class of defect leaves the second instance to be found the same way — by
someone starting a broken unit.

```
fix-vnc-desktop.sh:54-58   5 tokens
fix-vnc-wsl.sh:44          1 token
```

`fix-vnc-wsl.sh` has no issue of its own. It is fixed here because it is the same defect in the
same directory, and because the guard added below fails on it otherwise.

## Problem

`cat > x.service << 'EOF'` — quoted delimiter — disables parameter expansion for the whole block,
so `${AUTOBOT_VNC_USER:-autobot}` reaches the unit file verbatim. systemd has no bash-style `:-`
default syntax, so `User=${AUTOBOT_VNC_USER:-autobot}` is not a valid directive value.

The script exits 0 having written a plausible-looking file. Nothing surfaces until someone starts
the unit.

Two more problems in the same blocks, found while fixing:

**`$USER` is `root` here.** These scripts are run with `sudo bash`, so every
`/home/${USER:-autobot}` path — including the one in the passwd argument systemd was given —
resolved to `/home/root`.

**Two units disagreed about who they run as.** `tigervnc.service` was written with
`${AUTOBOT_VNC_USER:-autobot}` while `novnc.service` hardcoded `User=kali`, and the passwd file
was `chown kali:kali`. The three had to agree — they share a home directory and a password file —
and could not.

## What Changed

One resolution, in the shell, before any heredoc:

```bash
VNC_USER="${AUTOBOT_VNC_USER:-autobot}"
VNC_HOME="/home/${VNC_USER}"
```

The five unit heredocs across both scripts are unquoted so the values interpolate, and every
`kali` literal, `${AUTOBOT_VNC_USER:-autobot}` and `${USER:-autobot}` in them now refers to that
one pair.

Unifying the user is a deliberate behaviour change, not a side effect: on a host where `kali` was
correct, the operator sets `AUTOBOT_VNC_USER=kali` and all three agree, which they previously
could not do at all.

Unquoting exposes every other token in a block, so I audited each one. The only others were the
`websockify` line continuations, now `\\` so the unit keeps its original layout — an unquoted
heredoc otherwise eats a trailing backslash as a shell continuation and joins the lines. systemd
accepts the joined form, which is exactly why it needed catching: nothing would have broken, the
written file would simply have stopped matching the script that wrote it.

## Verification

CI, `scripts/systemd_heredoc_expansion_test.py` — a rule over every `*.sh` in the repo, not a
check on these two:

- a **quoted** unit heredoc may contain no `${...}`
- an **unquoted** one may only reference variables the script has already assigned — this is the
  rule that catches `$USER`, and the one that would have caught the original bug had the author
  reached for the unquoted form
- a line continuation inside an unquoted heredoc must be escaped
- `test_the_vnc_units_resolve_to_a_real_user` expands the reported case the way bash would, by
  reading the assignments out of the script and applying them statically, and asserts `User=`,
  `Group=`, `WorkingDirectory=` and `Environment=HOME=` resolve to a non-empty value with no `$`
  left in it

`test_the_scan_finds_the_scripts_it_is_meant_to_guard` exists because an empty scan reads exactly
like a clean one: if the heredoc pattern ever stops matching, every rule above passes over zero
blocks and reports success.

Nothing from the checkout is executed — the expansion is simulated in Python, statically.

## Risks

Anyone relying on `novnc.service` running as `kali` while `AUTOBOT_VNC_USER` is unset gets
`autobot` after this. That is the intended correction: the alternative is two units sharing a
password file under different accounts, which is the state that made the unset default
unreachable.

## Model Used

Opus 5 (1M context).

Closes #14036
