### PR TITLE
fix(deploy): report a playbook's failure instead of its banner (#14298)

### DIFF
--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -88,6 +88,7 @@ from services.git_tracker import DEFAULT_BRANCH, DEFAULT_REPO_PATH, get_git_trac
 from services.playbook_executor import get_playbook_executor
 from services.ssh_utils import _ssh_key_usable
 from services.sync_orchestrator import get_sync_orchestrator
+from services.ansible_utils import summarize_playbook_failure
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/code-sync", tags=["code-sync"])
@@ -3419,7 +3420,7 @@ async def _ansible_self_update(node_id: str) -> None:
             detach=True,
         )
         if not result["success"]:
-            logger.error("Ansible full-machine update failed for %s: %s", node_id, result["output"][:500])
+            logger.error("Ansible full-machine update failed for %s: %s", node_id, summarize_playbook_failure(result["output"]))
             # C2-a: playbook failed before restart — clear plan so it never auto-fires
             await _clear_resume_plan()
         else:
@@ -3648,12 +3649,12 @@ async def _sync_single_node(
 
         if result["success"]:
             node_state.status = "success"
-            node_state.message = result["output"][:500]
+            node_state.message = summarize_playbook_failure(result["output"])
             # Update node version in DB (#1209)
             await _update_fleet_node_version(node_state.node_id)
         else:
             node_state.status = "failed"
-            node_state.message = f"Playbook failed: {result['output'][:500]}"
+            node_state.message = f"Playbook failed: {summarize_playbook_failure(result['output'])}"
 
         node_state.completed_at = datetime.now(timezone.utc)
 

--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -65,6 +65,7 @@ from models.schemas import (
     ScheduleRunResponse,
     ScheduleUpdate,
 )
+from services.ansible_utils import summarize_playbook_failure
 from services.auth import get_current_user
 from services.code_distributor import get_code_distributor
 from services.database import get_db
@@ -88,7 +89,6 @@ from services.git_tracker import DEFAULT_BRANCH, DEFAULT_REPO_PATH, get_git_trac
 from services.playbook_executor import get_playbook_executor
 from services.ssh_utils import _ssh_key_usable
 from services.sync_orchestrator import get_sync_orchestrator
-from services.ansible_utils import summarize_playbook_failure
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/code-sync", tags=["code-sync"])
@@ -3420,7 +3420,9 @@ async def _ansible_self_update(node_id: str) -> None:
             detach=True,
         )
         if not result["success"]:
-            logger.error("Ansible full-machine update failed for %s: %s", node_id, summarize_playbook_failure(result["output"]))
+            logger.error(
+                "Ansible full-machine update failed for %s: %s", node_id, summarize_playbook_failure(result["output"])
+            )
             # C2-a: playbook failed before restart — clear plan so it never auto-fires
             await _clear_resume_plan()
         else:

--- a/autobot-slm-backend/api/nodes.py
+++ b/autobot-slm-backend/api/nodes.py
@@ -69,6 +69,7 @@ from models.schemas import (
     ServiceOrderEntry,
     UpdatePolicyResponse,
 )
+from services.ansible_utils import summarize_playbook_failure
 from services.auth import get_current_user
 from services.code_status import derive_code_status as _derive_code_status
 from services.code_status import get_latest_code_version as _get_latest_code_version
@@ -77,7 +78,6 @@ from services.database import get_db
 from services.encryption import encrypt_data
 from services.reconciler import reconciler_service
 from services.ssh_utils import build_ssh_base_cmd
-from services.ansible_utils import summarize_playbook_failure
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/nodes", tags=["nodes"])

--- a/autobot-slm-backend/api/nodes.py
+++ b/autobot-slm-backend/api/nodes.py
@@ -77,6 +77,7 @@ from services.database import get_db
 from services.encryption import encrypt_data
 from services.reconciler import reconciler_service
 from services.ssh_utils import build_ssh_base_cmd
+from services.ansible_utils import summarize_playbook_failure
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/nodes", tags=["nodes"])
@@ -992,7 +993,7 @@ async def _execute_provision_playbook(
             "success": True,
             "message": f"Provisioned {len(target_roles)} role(s) on {node.hostname}",
             "roles": target_roles,
-            "output": result["output"][:500],
+            "output": summarize_playbook_failure(result["output"]),
         }
 
     logger.error("Failed to provision node %s: %s", node_id, result["output"])

--- a/autobot-slm-backend/api/orchestration.py
+++ b/autobot-slm-backend/api/orchestration.py
@@ -28,6 +28,7 @@ from models.schemas import ServiceActionRequest
 from services.auth import get_current_user
 from services.database import get_db
 from services.service_orchestrator import service_orchestrator
+from services.ansible_utils import summarize_playbook_failure
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/orchestration", tags=["orchestration"])
@@ -598,9 +599,9 @@ async def _run_ssh_service_action(
                 node.node_id,
                 service_name,
                 action,
-                result["output"][:200],
+                summarize_playbook_failure(result["output"]),
             )
-            return False, f"Failed: {result['output'][:200]}"
+            return False, f"Failed: {summarize_playbook_failure(result['output'])}"
 
     except Exception as e:
         logger.error(

--- a/autobot-slm-backend/api/orchestration.py
+++ b/autobot-slm-backend/api/orchestration.py
@@ -25,10 +25,10 @@ from typing_extensions import Annotated
 from api.websocket import ws_manager
 from models.database import Node, Service, ServiceStatus
 from models.schemas import ServiceActionRequest
+from services.ansible_utils import summarize_playbook_failure
 from services.auth import get_current_user
 from services.database import get_db
 from services.service_orchestrator import service_orchestrator
-from services.ansible_utils import summarize_playbook_failure
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/orchestration", tags=["orchestration"])

--- a/autobot-slm-backend/api/updates.py
+++ b/autobot-slm-backend/api/updates.py
@@ -53,6 +53,7 @@ from services.auth import get_current_user
 from services.code_status import get_latest_code_version, reported_code_status
 from services.database import get_db
 from services.playbook_executor import get_playbook_executor
+from services.ansible_utils import summarize_playbook_failure
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/updates", tags=["updates"])
@@ -211,7 +212,7 @@ async def _handle_failed_update(db: AsyncSession, job: UpdateJob, node_id: str, 
     Helper for _run_update_job (Issue #665).
     """
     job.status = UpdateJobStatus.FAILED.value
-    job.error = f"Playbook failed: {output[:500]}"
+    job.error = f"Playbook failed: {summarize_playbook_failure(output)}"
     job.output = output
 
     await db.commit()
@@ -578,7 +579,7 @@ async def _run_discover_job(
 
         if not result["success"] and not host_results:
             job["status"] = "failed"
-            job["message"] = "Playbook failed: " + result["output"][:500]
+            job["message"] = "Playbook failed: " + summarize_playbook_failure(result["output"])
             job["completed_at"] = utc_timestamp()
             logger.error("Discover job %s failed — no nodes reported results", job_id)
             return
@@ -970,7 +971,7 @@ async def _execute_upgrade_playbook(
         )
     else:
         j.status = UpdateJobStatus.FAILED.value
-        j.error = r["output"][:500]
+        j.error = summarize_playbook_failure(r["output"])
         j.output = r["output"]
     j.completed_at = datetime.now(timezone.utc)
     await sess.commit()

--- a/autobot-slm-backend/api/updates.py
+++ b/autobot-slm-backend/api/updates.py
@@ -49,11 +49,11 @@ from models.schemas import (
     UpdatePackagesResponse,
     UpdateSummaryResponse,
 )
+from services.ansible_utils import summarize_playbook_failure
 from services.auth import get_current_user
 from services.code_status import get_latest_code_version, reported_code_status
 from services.database import get_db
 from services.playbook_executor import get_playbook_executor
-from services.ansible_utils import summarize_playbook_failure
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/updates", tags=["updates"])

--- a/autobot-slm-backend/services/ansible_utils.py
+++ b/autobot-slm-backend/services/ansible_utils.py
@@ -4,6 +4,7 @@
 # Author: mrveiss
 """Ansible output parsing utilities for slm-backend endpoints."""
 
+import json
 import os
 import re
 import shutil
@@ -39,6 +40,49 @@ def _find_ansible_playbook() -> str:
     raise FileNotFoundError("ansible-playbook not found. Install Ansible: apt install ansible")
 
 
+def _msg_from_result_json(line: str) -> str:
+    """``msg`` out of the result dict on a ``fatal:`` line, parsed as JSON.
+
+    Ansible's default callback renders the whole result on one line:
+    ``fatal: [host]: FAILED! => {"changed": false, "msg": "...", "rc": 100, ...}``
+
+    Review finding on #14298: a regex ending at ``$`` cannot know where the
+    ``msg`` value stops, so whenever ``msg`` is not the last key — which is the
+    norm for ``command``/``shell``/``apt``/``pip`` tasks, since ``rc``,
+    ``stderr`` and ``stdout`` all sort after it — the captured text ran on into
+    the rest of the JSON. The first fix for that, stripping a trailing ``}``,
+    was the same mistake one size smaller: it truncated any message whose own
+    text ends in a brace.
+
+    Parsing removes both failure modes rather than trading between them.
+    """
+    start = line.find("{")
+    if start == -1:
+        return ""
+    blob = line[start:]
+    try:
+        result = json.loads(blob)
+    except (ValueError, TypeError):
+        return ""
+    if not isinstance(result, dict):
+        return ""
+    msg = result.get("msg")
+    return str(msg).strip() if msg else ""
+
+
+def _msg_from_following_lines(lines: list[str], index: int) -> str:
+    """``msg`` from the lines after a ``fatal:``, for the yaml/verbose callback.
+
+    There the dict is pretty-printed, so ``"msg": "..."`` sits alone on its own
+    line and ending the capture at ``$`` is correct.
+    """
+    for j in range(index + 1, min(index + 10, len(lines))):
+        msg_match = re.search(r'"?msg"?\s*[:=]\s*["\']?(.+?)["\',]?\s*$', lines[j].strip())
+        if msg_match:
+            return msg_match.group(1).strip().strip("'\"")
+    return ""
+
+
 def _extract_failure_summary(output: str) -> str:
     """Parse Ansible stdout and return a human-readable failure summary.
 
@@ -70,19 +114,10 @@ def _extract_failure_summary(output: str) -> str:
             host = host_match.group(1) if host_match else "unknown host"
             failure_type = "UNREACHABLE" if "UNREACHABLE" in line else "FAILED"
 
-            # #14298: start at the fatal line ITSELF, not the one after it.
-            # Ansible's default callback puts the whole result dict on the same
-            # line as `fatal: [host]: FAILED! => {...”msg”: ...}`, so scanning
-            # from i+1 found the message only in the multi-line (yaml/debug)
-            # callback form. A summary that names the task but drops the
-            # message is the half that matters least — the task is already in
-            # the play, the msg is why it stopped.
-            msg = ""
-            for j in range(i, min(i + 10, len(lines))):
-                msg_match = re.search(r'"?msg"?\s*[:=]\s*["\']?(.+?)["\']?\s*$', lines[j].strip())
-                if msg_match:
-                    msg = msg_match.group(1).strip().strip("'\"").rstrip("}").strip().strip("'\"")
-                    break
+            # #14298: the message lives on the fatal line itself under the
+            # default callback, and on its own line under the yaml/verbose one.
+            # Parse the JSON first, fall back to the line scan.
+            msg = _msg_from_result_json(line) or _msg_from_following_lines(lines, i)
 
             task_part = f' at "{current_task}"' if current_task else ""
             msg_part = f": {msg}" if msg else ""

--- a/autobot-slm-backend/services/ansible_utils.py
+++ b/autobot-slm-backend/services/ansible_utils.py
@@ -8,6 +8,8 @@ import os
 import re
 import shutil
 
+from autobot_shared.env_utils import env_int
+
 # Common install locations checked when ansible-playbook isn't on PATH
 # (Issue #12693 — shared between DeploymentService and PlaybookExecutor).
 _COMMON_ANSIBLE_PATHS = (
@@ -87,3 +89,43 @@ def _extract_failure_summary(output: str) -> str:
     count = len(failures)
     noun = "host" if count == 1 else "hosts"
     return f"{count} {noun} failed \u2014 " + "; ".join(failures)
+
+
+# How much raw output to fall back to when nothing parseable is found. From the
+# END of the run: ansible's first lines are its preamble, so a head slice
+# reliably returns deprecation warnings and nothing else (#14298).
+PLAYBOOK_FAILURE_TAIL_CHARS = env_int("AUTOBOT_PLAYBOOK_FAILURE_TAIL_CHARS", 500)
+
+
+def summarize_playbook_failure(output: str, tail_chars: int | None = None) -> str:
+    """Return the useful part of a failed playbook's output.
+
+    ``_extract_failure_summary`` first — it names the host, the task and the
+    ``msg``, which is what an operator needs. When it finds nothing parseable
+    (a run that died before any task, a non-ansible error), fall back to the
+    **tail**.
+
+    #14298: every caller previously did ``output[:500]``, which is ansible's
+    banner. A code-sync node failure reported itself as a DEFAULT_GATHER_SUBSET
+    deprecation warning while the actual cause — a pip resolution conflict —
+    sat at the end of the output, uncut. That is worse than no message: it
+    reads as a diagnosis and points somewhere unrelated.
+
+    Args:
+        output: full stdout/stderr of the playbook run.
+        tail_chars: fallback size; defaults to PLAYBOOK_FAILURE_TAIL_CHARS.
+
+    Returns:
+        A summary, or the tail of the output, or a fixed string when there is
+        no output at all.
+    """
+    summary = _extract_failure_summary(output or "")
+    if summary:
+        return summary
+    text = (output or "").strip()
+    if not text:
+        return "playbook failed with no output"
+    limit = PLAYBOOK_FAILURE_TAIL_CHARS if tail_chars is None else tail_chars
+    if len(text) <= limit:
+        return text
+    return "..." + text[-limit:]

--- a/autobot-slm-backend/services/ansible_utils.py
+++ b/autobot-slm-backend/services/ansible_utils.py
@@ -70,11 +70,18 @@ def _extract_failure_summary(output: str) -> str:
             host = host_match.group(1) if host_match else "unknown host"
             failure_type = "UNREACHABLE" if "UNREACHABLE" in line else "FAILED"
 
+            # #14298: start at the fatal line ITSELF, not the one after it.
+            # Ansible's default callback puts the whole result dict on the same
+            # line as `fatal: [host]: FAILED! => {...”msg”: ...}`, so scanning
+            # from i+1 found the message only in the multi-line (yaml/debug)
+            # callback form. A summary that names the task but drops the
+            # message is the half that matters least — the task is already in
+            # the play, the msg is why it stopped.
             msg = ""
-            for j in range(i + 1, min(i + 10, len(lines))):
+            for j in range(i, min(i + 10, len(lines))):
                 msg_match = re.search(r'"?msg"?\s*[:=]\s*["\']?(.+?)["\']?\s*$', lines[j].strip())
                 if msg_match:
-                    msg = msg_match.group(1).strip().strip("'\"")
+                    msg = msg_match.group(1).strip().strip("'\"").rstrip("}").strip().strip("'\"")
                     break
 
             task_part = f' at "{current_task}"' if current_task else ""

--- a/autobot-slm-backend/services/ansible_utils_failure_summary_test.py
+++ b/autobot-slm-backend/services/ansible_utils_failure_summary_test.py
@@ -128,3 +128,31 @@ def test_the_tail_size_is_configurable_not_hardcoded():
 
 def test_the_default_comes_from_the_environment_backed_constant():
     assert _au.PLAYBOOK_FAILURE_TAIL_CHARS == 500
+
+
+def test_the_message_is_found_on_the_fatal_line_itself():
+    """Ansible's default callback is one line; the yaml callback is many.
+
+    CI caught this: the extractor scanned from the line *after* ``fatal:``, so
+    with the default callback — which is what these runs use — it produced a
+    summary naming the task and nothing else. The task is already visible in
+    the play output; the message is the part that says why it stopped.
+    """
+    one_line = (
+        'fatal: [host]: FAILED! => {"changed": true, "cmd": "pip install", '
+        '"msg": "ERROR: Cannot install tokenizers"}'
+    )
+
+    result = _au.summarize_playbook_failure("TASK [Install] ***\n" + one_line)
+
+    assert "Cannot install tokenizers" in result
+    assert not result.rstrip().endswith("}"), "the trailing JSON brace leaked into the summary"
+
+
+def test_the_multi_line_callback_form_still_works():
+    """The form the existing suite pins — it must not regress in the fix."""
+    multi = 'TASK [Restart] ***\nfatal: [host]: FAILED! => {\n    "msg": "Service restart failed"\n}'
+
+    result = _au.summarize_playbook_failure(multi)
+
+    assert "Service restart failed" in result

--- a/autobot-slm-backend/services/ansible_utils_failure_summary_test.py
+++ b/autobot-slm-backend/services/ansible_utils_failure_summary_test.py
@@ -1,0 +1,130 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""A failed playbook must report its failure, not its banner (#14298).
+
+Every caller reporting a playbook failure did ``output[:500]``. Ansible's first
+lines are its preamble, so what reached the operator was a
+``DEFAULT_GATHER_SUBSET`` deprecation warning — while the actual cause sat at
+the end of the output, uncut.
+
+That is worse than an empty message. It reads as a diagnosis and points at
+something unrelated, so the reader goes and looks at gather_facts.
+
+The fixture below is the real output that misled a live diagnosis: a code-sync
+node failure whose cause was a pip resolution conflict.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load():
+    """Load ansible_utils standalone — the package pulls in heavy services."""
+    saved = {n: sys.modules.get(n) for n in ("services",)}
+    try:
+        if "services" not in sys.modules:
+            sys.modules["services"] = MagicMock()
+        spec = importlib.util.spec_from_file_location("_au_14298", _BACKEND_ROOT / "services" / "ansible_utils.py")
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+    finally:
+        for name, original in saved.items():
+            if original is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original
+
+
+_au = _load()
+
+# The preamble is long enough on its own to fill a 500-char head slice.
+_PREAMBLE = (
+    "[DEPRECATION WARNING]: DEFAULT_GATHER_SUBSET option, the module_defaults\n"
+    "keyword is a more generic version and can apply to all calls to the\n"
+    "M(ansible.builtin.gather_facts) or M(ansible.builtin.setup) actions, use\n"
+    "module_defaults instead. This feature will be removed from ansible-core in\n"
+    "version 2.18. Deprecation warnings can be disabled by setting\n"
+    "deprecation_warnings=False in ansible.cfg.\n"
+)
+
+_WITH_FAILED_TASK = (
+    _PREAMBLE + "\n"
+    "PLAY [Sync role] ***************************************************************\n"
+    "\n"
+    "TASK [Install AI Python packages from requirements-ai.txt] *********************\n"
+    'fatal: [ai-node]: FAILED! => {"changed": true, "cmd": "venv/bin/pip install -r requirements-ai.txt", '
+    '"msg": "ERROR: Cannot install tokenizers because these package versions have conflicting dependencies"}\n'
+    "\n"
+    "PLAY RECAP *********************************************************************\n"
+    "ai-node                    : ok=4    changed=1    unreachable=0    failed=1\n"
+)
+
+# A run that died before any task — nothing for the parser to find.
+_NO_TASK = _PREAMBLE + "\n" + "x" * 800 + "\nERROR! the playbook could not be found\n"
+
+
+def test_the_summary_names_the_task_and_the_message():
+    result = _au.summarize_playbook_failure(_WITH_FAILED_TASK)
+
+    assert "Install AI Python packages" in result
+    assert "conflicting dependencies" in result
+    assert "DEPRECATION" not in result
+
+
+def test_a_head_slice_of_the_same_output_would_have_told_you_nothing():
+    """The regression, stated as a comparison rather than as prose.
+
+    This is what every call site did. Keeping it executable means the claim in
+    the docstring above is checked rather than asserted.
+    """
+    head = _WITH_FAILED_TASK[:500]
+
+    assert "DEPRECATION WARNING" in head
+    assert "conflicting dependencies" not in head
+    assert "fatal:" not in head
+
+
+def test_unparseable_output_falls_back_to_the_tail_not_the_head():
+    result = _au.summarize_playbook_failure(_NO_TASK)
+
+    assert "the playbook could not be found" in result
+    assert "DEPRECATION WARNING" not in result
+
+
+def test_the_fallback_is_marked_as_truncated():
+    result = _au.summarize_playbook_failure(_NO_TASK)
+
+    assert result.startswith("..."), "a tail slice must not read as the whole output"
+
+
+def test_short_output_is_returned_whole():
+    result = _au.summarize_playbook_failure("ERROR! short and complete")
+
+    assert result == "ERROR! short and complete"
+    assert not result.startswith("...")
+
+
+def test_empty_output_says_so_rather_than_returning_nothing():
+    """An empty message renders as no error at all in every surface it reaches."""
+    assert _au.summarize_playbook_failure("") == "playbook failed with no output"
+    assert _au.summarize_playbook_failure(None) == "playbook failed with no output"
+
+
+def test_the_tail_size_is_configurable_not_hardcoded():
+    result = _au.summarize_playbook_failure(_NO_TASK, tail_chars=40)
+
+    assert len(result) == 43  # 40 + the "..." marker
+    assert "the playbook could not be found" in result
+
+
+def test_the_default_comes_from_the_environment_backed_constant():
+    assert _au.PLAYBOOK_FAILURE_TAIL_CHARS == 500

--- a/autobot-slm-backend/services/ansible_utils_failure_summary_test.py
+++ b/autobot-slm-backend/services/ansible_utils_failure_summary_test.py
@@ -149,6 +149,50 @@ def test_the_message_is_found_on_the_fatal_line_itself():
     assert not result.rstrip().endswith("}"), "the trailing JSON brace leaked into the summary"
 
 
+def test_the_message_stops_where_it_ends_when_msg_is_not_the_last_key():
+    """The common shape, and the one the first fix got wrong.
+
+    ``command``/``shell``/``apt``/``pip`` tasks all set ``rc``, ``stderr`` and
+    ``stdout``, which sort after ``msg`` in the result dict. A regex ending at
+    ``$`` cannot know where the value stops, so it ran the message straight on
+    into the rest of the JSON — verified in review against a real apt failure.
+    """
+    line = (
+        'fatal: [host]: FAILED! => {"changed": false, '
+        '"msg": "apt-get install failed: E: Unable to locate package", '
+        '"rc": 100, "stderr": "E: Unable to locate package", '
+        '"stderr_lines": ["E: Unable to locate package"]}'
+    )
+
+    result = _au.summarize_playbook_failure("TASK [Install] ***\n" + line)
+
+    assert "apt-get install failed: E: Unable to locate package" in result
+    for leaked in ('"rc"', '"stderr"', "stderr_lines"):
+        assert leaked not in result, f"{leaked} leaked out of the result dict into the summary"
+
+
+def test_a_message_that_itself_ends_in_braces_is_not_truncated():
+    """The first fix stripped a trailing ``}``, which ate real content.
+
+    Template and set_fact failures quote the offending structure, so a message
+    genuinely ending in ``}}`` is ordinary — and losing those two characters
+    changes what the error says.
+    """
+    line = 'fatal: [host]: FAILED! => {"msg": "Unbalanced braces: {a: 1, b: {c: 2}}"}'
+
+    result = _au.summarize_playbook_failure("TASK [Render] ***\n" + line)
+
+    assert "Unbalanced braces: {a: 1, b: {c: 2}}" in result
+
+
+def test_a_fatal_line_with_no_parseable_json_still_summarises():
+    """UNREACHABLE lines carry no dict; the host and type must still surface."""
+    result = _au.summarize_playbook_failure("TASK [Facts] ***\nfatal: [host]: UNREACHABLE!")
+
+    assert "host" in result
+    assert "unreachable" in result.lower()
+
+
 def test_the_multi_line_callback_form_still_works():
     """The form the existing suite pins — it must not regress in the fix."""
     multi = 'TASK [Restart] ***\nfatal: [host]: FAILED! => {\n    "msg": "Service restart failed"\n}'

--- a/autobot_shared/env_registry.py
+++ b/autobot_shared/env_registry.py
@@ -1588,6 +1588,21 @@ register_env_var(
 
 register_env_var(
     EnvVarSpec(
+        name="AUTOBOT_PLAYBOOK_FAILURE_TAIL_CHARS",
+        type=int,
+        default=500,
+        description=(
+            "How many characters of a failed playbook's output to fall back to when no "
+            "failed task can be parsed out of it. Taken from the END of the run: ansible "
+            "opens with its banner, so a head slice returns deprecation warnings and hides "
+            "the failure (services/ansible_utils.py, #14298)."
+        ),
+        component="backend",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
         name="AUTOBOT_SYNC_POST_CMD_TIMEOUT_S",
         type=int,
         default=300,


### PR DESCRIPTION
## Thinking Path

This one cost me the diagnosis of #14293. `POST /api/code-sync/nodes/{id}/sync` failed and told me:

```
Playbook failed: [DEPRECATION WARNING]: DEFAULT_GATHER_SUBSET option, the module_defaults
keyword is a more generic version and can apply to all calls to the
M(ansible.builtin.gather_facts) or M(ansible.builtin.setup) actions, use
module_defaults instead. ...
```

The real cause — a pip resolution conflict — was in the same output, at the end, untouched. I only
found it by going through a different endpoint that returns a structured per-node result.

## Problem

Nine call sites reported a playbook failure as `output[:500]`. Ansible opens with its banner, so a
head slice returns the preamble every time and the failing task, its `msg:` and the PLAY RECAP —
the entire useful part — are what gets cut.

An empty message would have been better. This one reads as a diagnosis and points at gather_facts.

## What Changed

`services/ansible_utils.py` gains `summarize_playbook_failure()`, which tries
`_extract_failure_summary` first — it already existed, already named the host, task and `msg`, and
was already used by `api/setup_wizard.py`, just never by any of these callers — and falls back to
the **tail** when a run died before producing a parseable task.

All nine sites now use it:

| file | sites |
|---|---|
| `api/code_sync.py` | 3 |
| `api/updates.py` | 3 |
| `api/orchestration.py` | 2 (these were `[:200]`, so worse) |
| `api/nodes.py` | 1 |

The fallback is marked with a leading `...` so a tail slice cannot be mistaken for whole output,
and empty output returns `"playbook failed with no output"` rather than an empty string, which
renders as *no error at all* in every surface it reaches.

`AUTOBOT_PLAYBOOK_FAILURE_TAIL_CHARS` is registered in `env_registry.py` rather than hardcoded.

**Deliberately unchanged:** the four remaining `output[:500]` sites in `code_sync.py` and
`sync_orchestrator.py`. Those carry rsync and git-pull output, which has no ansible banner and no
task structure — the summariser has nothing to parse there and would only add a `...`.

## Verification

CI. 8 tests, built on the actual output that misled the live diagnosis.

The one that carries the argument is
`test_a_head_slice_of_the_same_output_would_have_told_you_nothing`: it asserts that `[:500]` of the
fixture contains `DEPRECATION WARNING` and does **not** contain `conflicting dependencies` or
`fatal:`. That keeps the claim executable instead of leaving it in a docstring, and it fails if
someone later shortens the fixture to the point where the regression no longer reproduces — at
which point the other tests would be passing against a case that could not have failed.

The rest cover the fallback path specifically, because that is where a "fix" could quietly
reintroduce a head slice: unparseable output must yield the tail, be marked truncated, and short
output must come back whole rather than gaining a spurious marker.

Not run locally, by instruction.

## Risks

Messages get shorter and stop containing the raw banner. Anything scraping these strings for the
old preamble text would stop matching — nothing in the repo does; they are operator-facing fields
(`job.error`, `node_state.message`) and log lines.

## Model Used

Opus 5 (1M context).

Closes #14298
