### PR TITLE
fix(deploy): let ansible decide reachability instead of skipping every degraded node (#14297)

### DIFF
--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -5189,6 +5189,49 @@ def _extract_ansible_fatal(output: str) -> str:
     return output.strip()[-300:] if output.strip() else "playbook failed (no output)"
 
 
+async def _record_fleet_node_outcome(
+    node: Node,
+    node_id: str,
+    job: UpdateAllJob,
+    stage,
+    unhealthy: bool,
+    playbook_result: dict,
+) -> bool:
+    """Count one node's run and say whether the stage continues.
+
+    Split out of ``_sync_fleet_node`` (#14297) to keep it under the length
+    rule. Three outcomes, and the middle one is the whole point of #14297:
+
+    * success -> completed, noted as a recovery when the node was unhealthy
+    * unhealthy AND ansible said UNREACHABLE -> skipped, #11511's outcome
+    * anything else -> failed, which halts the stage
+
+    The third branch is deliberately not narrowed to healthy nodes: a broken
+    deploy against an unhealthy node must stay a failure, or the job goes green
+    while the node stays stale — the defect this change exists to end, wearing
+    a skip's costume.
+    """
+    if playbook_result["success"]:
+        await _update_fleet_node_version(node_id)
+        job.completed_fleet_nodes += 1
+        _stage_log(
+            stage,
+            f"Node {node_id} updated successfully" + (" (recovered while not operational)" if unhealthy else ""),
+        )
+        return True
+
+    if unhealthy and _node_was_unreachable(node, playbook_result):
+        _stage_log(stage, f"Node {node_id} ({node.hostname}) skipped — unreachable")
+        job.skipped_fleet_nodes += 1
+        return True
+
+    error_msg = _extract_ansible_fatal(playbook_result["output"])
+    job.failed_fleet_nodes += 1
+    _stage_log(stage, f"Node {node_id} FAILED: {error_msg}")
+    _fail_fleet_stage(job, stage, f"Fleet node {node_id} playbook failed: {error_msg}")
+    return False
+
+
 async def _sync_fleet_node(
     executor,
     node_id: str,
@@ -5248,26 +5291,7 @@ async def _sync_fleet_node(
         playbook_name="update-all-nodes.yml",
         limit=["localhost", node_id],
     )
-    if playbook_result["success"]:
-        await _update_fleet_node_version(node_id)
-        job.completed_fleet_nodes += 1
-        _stage_log(
-            stage,
-            f"Node {node_id} updated successfully" + (" (recovered while not operational)" if unhealthy else ""),
-        )
-        return True
-
-    output = playbook_result["output"]
-    if unhealthy and _node_was_unreachable(node, playbook_result):
-        _stage_log(stage, f"Node {node_id} ({node.hostname}) skipped — unreachable")
-        job.skipped_fleet_nodes += 1
-        return True
-
-    error_msg = _extract_ansible_fatal(output)
-    job.failed_fleet_nodes += 1
-    _stage_log(stage, f"Node {node_id} FAILED: {error_msg}")
-    _fail_fleet_stage(job, stage, f"Fleet node {node_id} playbook failed: {error_msg}")
-    return False
+    return await _record_fleet_node_outcome(node, node_id, job, stage, unhealthy, playbook_result)
 
 
 async def _run_fleet_stage(job: UpdateAllJob, node_ids: List[str]) -> None:
@@ -5306,7 +5330,9 @@ async def _run_fleet_stage(job: UpdateAllJob, node_ids: List[str]) -> None:
     skipped = job.skipped_fleet_nodes
     summary = f"Updated {job.completed_fleet_nodes}/{job.total_fleet_nodes} nodes"
     if skipped:
-        summary += f" ({skipped} skipped — not operational)"
+        # A skip now means unhealthy AND unreachable, not unhealthy alone
+        # (#14297) — an unhealthy node that answers gets deployed to.
+        summary += f" ({skipped} skipped — unreachable)"
 
     stage.status = _StageStatus.SUCCESS
     stage.message = summary

--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -88,6 +88,7 @@ from services.git_tracker import DEFAULT_BRANCH, DEFAULT_REPO_PATH, get_git_trac
 from services.playbook_executor import get_playbook_executor
 from services.ssh_utils import _ssh_key_usable
 from services.sync_orchestrator import get_sync_orchestrator
+from services.ansible_utils import parse_unreachable_hosts
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/code-sync", tags=["code-sync"])
@@ -5150,6 +5151,25 @@ def _is_node_operational(node: Node) -> bool:
     return node.status not in _NON_OPERATIONAL_STATUSES
 
 
+def _node_was_unreachable(node: Node, playbook_result: dict) -> bool:
+    """Did ansible report *this* node as UNREACHABLE?
+
+    Matched on node_id, hostname or ip_address, because the inventory name a
+    play reports is not always the one the DB stores — ``ansible_hostname`` is
+    the OS hostname while ``nodes.hostname`` is a display name (#1789 hit the
+    same mismatch and fell back to IP).
+
+    A run that failed for some other reason is NOT unreachable, and must stay a
+    failure: treating every failure as "node was down" is how a broken deploy
+    would come to report itself as a skip.
+    """
+    unreachable = parse_unreachable_hosts(playbook_result.get("output") or "")
+    if not unreachable:
+        return False
+    identities = {node.node_id, node.hostname, node.ip_address} - {None, ""}
+    return bool(identities & set(unreachable))
+
+
 def _extract_ansible_fatal(output: str) -> str:
     """Return the first meaningful ansible error line from playbook output (#11511).
 
@@ -5200,14 +5220,29 @@ async def _sync_fleet_node(
         job.completed_fleet_nodes += 1
         return True
 
-    # Skip non-operational nodes rather than attempting a deploy that will fail (#11511).
-    if not _is_node_operational(node):
+    # #11511 skipped non-operational nodes outright, on the reasoning that a
+    # deploy against them "will always fail". That holds for a node that is
+    # down; it does not hold for one that is merely unhealthy — and #14297 is
+    # the case where the two diverge. A node whose agent is too old to
+    # heartbeat is marked degraded, so it is skipped, so it never receives the
+    # update that would replace the agent. The health signal gates the only
+    # thing that could repair it.
+    #
+    # Health is not transport. The attempt goes ahead, and ansible's own
+    # UNREACHABLE verdict — which it reports distinctly from a failure — is
+    # what decides whether the node was actually contactable. Unreachable on
+    # this path is counted as skipped exactly as before, so a genuinely down
+    # node still does not fail the job.
+    unhealthy = not _is_node_operational(node)
+    if unhealthy:
         reason = (
             f"status={node.status}, last_heartbeat={'none' if node.last_heartbeat is None else node.last_heartbeat}"
         )
-        _stage_log(stage, f"Node {node_id} ({node.hostname}) skipped — not operational ({reason})")
-        job.skipped_fleet_nodes += 1
-        return True
+        _stage_log(
+            stage,
+            f"Node {node_id} ({node.hostname}) is not operational ({reason}) — "
+            f"attempting anyway; ansible decides whether it is reachable (#14297)",
+        )
 
     playbook_result = await executor.execute_playbook(
         playbook_name="update-all-nodes.yml",
@@ -5216,10 +5251,20 @@ async def _sync_fleet_node(
     if playbook_result["success"]:
         await _update_fleet_node_version(node_id)
         job.completed_fleet_nodes += 1
-        _stage_log(stage, f"Node {node_id} updated successfully")
+        _stage_log(
+            stage,
+            f"Node {node_id} updated successfully"
+            + (" (recovered while not operational)" if unhealthy else ""),
+        )
         return True
 
-    error_msg = _extract_ansible_fatal(playbook_result["output"])
+    output = playbook_result["output"]
+    if unhealthy and _node_was_unreachable(node, playbook_result):
+        _stage_log(stage, f"Node {node_id} ({node.hostname}) skipped — unreachable")
+        job.skipped_fleet_nodes += 1
+        return True
+
+    error_msg = _extract_ansible_fatal(output)
     job.failed_fleet_nodes += 1
     _stage_log(stage, f"Node {node_id} FAILED: {error_msg}")
     _fail_fleet_stage(job, stage, f"Fleet node {node_id} playbook failed: {error_msg}")

--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -65,11 +65,7 @@ from models.schemas import (
     ScheduleRunResponse,
     ScheduleUpdate,
 )
-<<<<<<< HEAD
-from services.ansible_utils import parse_unreachable_hosts
-=======
-from services.ansible_utils import summarize_playbook_failure
->>>>>>> origin/Dev_new_gui
+from services.ansible_utils import parse_unreachable_hosts, summarize_playbook_failure
 from services.auth import get_current_user
 from services.code_distributor import get_code_distributor
 from services.database import get_db

--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -65,6 +65,7 @@ from models.schemas import (
     ScheduleRunResponse,
     ScheduleUpdate,
 )
+from services.ansible_utils import parse_unreachable_hosts
 from services.auth import get_current_user
 from services.code_distributor import get_code_distributor
 from services.database import get_db
@@ -88,7 +89,6 @@ from services.git_tracker import DEFAULT_BRANCH, DEFAULT_REPO_PATH, get_git_trac
 from services.playbook_executor import get_playbook_executor
 from services.ssh_utils import _ssh_key_usable
 from services.sync_orchestrator import get_sync_orchestrator
-from services.ansible_utils import parse_unreachable_hosts
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/code-sync", tags=["code-sync"])
@@ -5253,8 +5253,7 @@ async def _sync_fleet_node(
         job.completed_fleet_nodes += 1
         _stage_log(
             stage,
-            f"Node {node_id} updated successfully"
-            + (" (recovered while not operational)" if unhealthy else ""),
+            f"Node {node_id} updated successfully" + (" (recovered while not operational)" if unhealthy else ""),
         )
         return True
 

--- a/autobot-slm-backend/api/updates.py
+++ b/autobot-slm-backend/api/updates.py
@@ -53,6 +53,7 @@ from services.auth import get_current_user
 from services.code_status import get_latest_code_version, reported_code_status
 from services.database import get_db
 from services.playbook_executor import get_playbook_executor
+from services.ansible_utils import parse_unreachable_hosts
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/updates", tags=["updates"])
@@ -329,17 +330,12 @@ def _parse_discover_output(output: str) -> List[dict]:
 
 
 def _parse_unreachable_hosts(output: str) -> List[str]:
-    """Extract hostnames of unreachable nodes from Ansible output.
+    """Hostnames ansible reported UNREACHABLE (#1816).
 
-    Ansible emits lines like:
-        fatal: [hostname]: UNREACHABLE! => {...}
-    This function collects all such hostnames so callers can report
-    partial success with a descriptive warning (Issue #1816).
+    Delegates to :func:`services.ansible_utils.parse_unreachable_hosts`, where
+    the implementation now lives so ``api/code_sync.py`` can share it (#14297).
     """
-    import re
-
-    pattern = re.compile(r"^fatal:\s+\[([^\]]+)\]:\s+UNREACHABLE!", re.MULTILINE)
-    return list(dict.fromkeys(m.group(1) for m in pattern.finditer(output)))
+    return parse_unreachable_hosts(output)
 
 
 async def _resolve_host_to_node(

--- a/autobot-slm-backend/api/updates.py
+++ b/autobot-slm-backend/api/updates.py
@@ -49,11 +49,7 @@ from models.schemas import (
     UpdatePackagesResponse,
     UpdateSummaryResponse,
 )
-<<<<<<< HEAD
-from services.ansible_utils import parse_unreachable_hosts
-=======
-from services.ansible_utils import summarize_playbook_failure
->>>>>>> origin/Dev_new_gui
+from services.ansible_utils import parse_unreachable_hosts, summarize_playbook_failure
 from services.auth import get_current_user
 from services.code_status import get_latest_code_version, reported_code_status
 from services.database import get_db

--- a/autobot-slm-backend/api/updates.py
+++ b/autobot-slm-backend/api/updates.py
@@ -49,11 +49,11 @@ from models.schemas import (
     UpdatePackagesResponse,
     UpdateSummaryResponse,
 )
+from services.ansible_utils import parse_unreachable_hosts
 from services.auth import get_current_user
 from services.code_status import get_latest_code_version, reported_code_status
 from services.database import get_db
 from services.playbook_executor import get_playbook_executor
-from services.ansible_utils import parse_unreachable_hosts
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/updates", tags=["updates"])

--- a/autobot-slm-backend/conftest.py
+++ b/autobot-slm-backend/conftest.py
@@ -247,6 +247,27 @@ sys.modules["services.deploy_artifacts"] = _artifacts_mod
 _artifacts_spec.loader.exec_module(_artifacts_mod)
 setattr(sys.modules["services"], "deploy_artifacts", _artifacts_mod)
 
+# ── services.ansible_utils — REAL module, not a stub (#14297) ─────────────────
+# Third instance of the ssh_utils/deploy_artifacts pattern, and self-inflicted:
+# _CODE_SYNC_SERVICE_MODULES above is derived by AST from code_sync.py's
+# `services.*` imports, so adding `from services.ansible_utils import
+# parse_unreachable_hosts` to that module automatically enrolled it for
+# stubbing.
+#
+# The consequence is the deploy_artifacts failure mode verbatim: the stub's
+# parse_unreachable_hosts returns a MagicMock, `set(MagicMock)` is EMPTY, so
+# _node_was_unreachable finds no match, an unreachable node is recorded as a
+# hard failure instead of a skip, and the fleet stage halts. The module is
+# dependency-light (re/os/shutil + env_utils), so real-load it.
+_ansible_utils_spec = _importlib_util.spec_from_file_location(
+    "services.ansible_utils",
+    Path(__file__).parent / "services" / "ansible_utils.py",
+)
+_ansible_utils_mod = _importlib_util.module_from_spec(_ansible_utils_spec)
+sys.modules["services.ansible_utils"] = _ansible_utils_mod
+_ansible_utils_spec.loader.exec_module(_ansible_utils_mod)
+setattr(sys.modules["services"], "ansible_utils", _ansible_utils_mod)
+
 # ── python-multipart ─────────────────────────────────────────────────────────
 # FastAPI's ensure_multipart_is_installed() is called when any route uses
 # UploadFile or Form parameters.  It checks for python_multipart.__version__

--- a/autobot-slm-backend/services/ansible_utils.py
+++ b/autobot-slm-backend/services/ansible_utils.py
@@ -146,6 +146,8 @@ def parse_unreachable_hosts(output: str) -> list[str]:
     """
     pattern = re.compile(r"^fatal:\s+\[([^\]]+)\]:\s+UNREACHABLE!", re.MULTILINE)
     return list(dict.fromkeys(m.group(1) for m in pattern.finditer(output or "")))
+
+
 # How much raw output to fall back to when nothing parseable is found. From the
 # END of the run: ansible's first lines are its preamble, so a head slice
 # reliably returns deprecation warnings and nothing else (#14298).

--- a/autobot-slm-backend/services/ansible_utils.py
+++ b/autobot-slm-backend/services/ansible_utils.py
@@ -87,3 +87,18 @@ def _extract_failure_summary(output: str) -> str:
     count = len(failures)
     noun = "host" if count == 1 else "hosts"
     return f"{count} {noun} failed \u2014 " + "; ".join(failures)
+
+
+def parse_unreachable_hosts(output: str) -> list[str]:
+    """Hostnames ansible reported as UNREACHABLE, in order of appearance.
+
+    Ansible distinguishes *unreachable* from *failed*, and the difference is
+    the whole answer to "is this node down, or is the deploy broken?" — #14297
+    needs it to tell a node that cannot be contacted from one that is merely
+    unhealthy.
+
+    Moved here from ``api/updates.py`` (#1816) so ``api/code_sync.py`` can use
+    it without importing another api module.
+    """
+    pattern = re.compile(r"^fatal:\s+\[([^\]]+)\]:\s+UNREACHABLE!", re.MULTILINE)
+    return list(dict.fromkeys(m.group(1) for m in pattern.finditer(output or "")))

--- a/autobot-slm-backend/tests/api/test_fleet_degraded_but_reachable_14297.py
+++ b/autobot-slm-backend/tests/api/test_fleet_degraded_but_reachable_14297.py
@@ -39,9 +39,7 @@ _BACKEND_ROOT = Path(__file__).resolve().parents[2]
 
 def _load_ansible_utils():
     """The shared parser, loaded standalone — it imports only stdlib + env_utils."""
-    spec = importlib.util.spec_from_file_location(
-        "_au_14297", _BACKEND_ROOT / "services" / "ansible_utils.py"
-    )
+    spec = importlib.util.spec_from_file_location("_au_14297", _BACKEND_ROOT / "services" / "ansible_utils.py")
     module = importlib.util.module_from_spec(spec)
     sys.modules["_au_14297"] = module
     try:

--- a/autobot-slm-backend/tests/api/test_fleet_degraded_but_reachable_14297.py
+++ b/autobot-slm-backend/tests/api/test_fleet_degraded_but_reachable_14297.py
@@ -1,0 +1,218 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""A node too stale to heartbeat must still be updatable (#14297).
+
+#11511 skipped non-operational nodes outright, reasoning that a deploy against
+them "will always fail". That is true of a node that is down. It is not true of
+a node that is merely unhealthy — and the case where the two diverge is a
+deadlock:
+
+    the agent is too old to heartbeat
+      -> the node is marked degraded
+        -> update-all skips degraded nodes
+          -> the node never receives the update that would replace the agent
+
+Observed live: a fleet node 1140 commits behind, SSH-reachable, remediation
+looping three attempts at a time for hours and never succeeding, skipped on
+every update-all.
+
+The fix does not add a reachability probe. Ansible already reports UNREACHABLE
+distinctly from a failure, so the attempt goes ahead and that verdict decides.
+The tests below are about the two ways this could go wrong: a genuinely down
+node must still not fail the job, and a broken deploy must NOT be able to
+report itself as "node was down".
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_ansible_utils():
+    """The shared parser, loaded standalone — it imports only stdlib + env_utils."""
+    spec = importlib.util.spec_from_file_location(
+        "_au_14297", _BACKEND_ROOT / "services" / "ansible_utils.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["_au_14297"] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.modules.pop("_au_14297", None)
+    return module
+
+
+_au = _load_ansible_utils()
+
+_UNREACHABLE_OUTPUT = """
+PLAY [Update fleet node] *******************************************************
+
+TASK [Gathering Facts] *********************************************************
+fatal: [vnc-node]: UNREACHABLE! => {"changed": false, "msg": "Failed to connect to the host via ssh", "unreachable": true}
+
+PLAY RECAP *********************************************************************
+vnc-node                   : ok=0    changed=0    unreachable=1    failed=0
+"""
+
+_FAILED_OUTPUT = """
+PLAY [Update fleet node] *******************************************************
+
+TASK [Install packages] ********************************************************
+fatal: [vnc-node]: FAILED! => {"changed": true, "msg": "ERROR: Cannot install tokenizers"}
+
+PLAY RECAP *********************************************************************
+vnc-node                   : ok=3    changed=1    unreachable=0    failed=1
+"""
+
+
+def _node(node_id="b9a29e04", hostname="vnc-node", ip="10.0.0.9"):
+    return SimpleNamespace(node_id=node_id, hostname=hostname, ip_address=ip)
+
+
+# --------------------------------------------------------------------------
+# The parser the decision rests on
+# --------------------------------------------------------------------------
+
+
+def test_an_unreachable_host_is_extracted():
+    assert _au.parse_unreachable_hosts(_UNREACHABLE_OUTPUT) == ["vnc-node"]
+
+
+def test_a_failed_host_is_not_reported_as_unreachable():
+    """The distinction the whole fix rests on.
+
+    If a plain failure parsed as unreachable, every broken deploy against a
+    degraded node would be recorded as a skip — the job would go green and the
+    node would stay stale, which is the bug this is meant to end.
+    """
+    assert _au.parse_unreachable_hosts(_FAILED_OUTPUT) == []
+
+
+def test_empty_and_missing_output_are_handled():
+    assert _au.parse_unreachable_hosts("") == []
+    assert _au.parse_unreachable_hosts(None) == []
+
+
+def test_each_host_is_reported_once_in_order():
+    doubled = _UNREACHABLE_OUTPUT + _UNREACHABLE_OUTPUT.replace("vnc-node", "other-node") + _UNREACHABLE_OUTPUT
+    assert _au.parse_unreachable_hosts(doubled) == ["vnc-node", "other-node"]
+
+
+# --------------------------------------------------------------------------
+# Matching the verdict back to the node
+# --------------------------------------------------------------------------
+
+
+def _was_unreachable(node, output: str) -> bool:
+    """Mirror of ``code_sync._node_was_unreachable`` over the shared parser.
+
+    Reimplemented rather than imported because ``api/code_sync.py`` pulls in
+    the whole backend; the identity-matching rule is what is under test and it
+    is three lines. ``test_the_production_helper_matches_this_rule`` below pins
+    the two together so this cannot drift into testing itself.
+    """
+    unreachable = _au.parse_unreachable_hosts(output or "")
+    if not unreachable:
+        return False
+    identities = {node.node_id, node.hostname, node.ip_address} - {None, ""}
+    return bool(identities & set(unreachable))
+
+
+@pytest.mark.parametrize("attr", ["node_id", "hostname", "ip_address"])
+def test_the_node_is_matched_on_any_of_its_identities(attr):
+    """Ansible's inventory name is not reliably the DB's hostname.
+
+    ``ansible_hostname`` is the OS hostname while ``nodes.hostname`` is a
+    display name — #1789 hit exactly this and fell back to IP.
+    """
+    node = _node()
+    output = _UNREACHABLE_OUTPUT.replace("vnc-node", getattr(node, attr))
+
+    assert _was_unreachable(node, output)
+
+
+def test_another_nodes_unreachability_is_not_this_nodes():
+    """A multi-host run must not let one down host excuse a different one."""
+    node = _node()
+    output = _UNREACHABLE_OUTPUT.replace("vnc-node", "some-other-node")
+
+    assert not _was_unreachable(node, output)
+
+
+def test_a_failure_is_not_treated_as_unreachable():
+    assert not _was_unreachable(_node(), _FAILED_OUTPUT)
+
+
+def test_the_production_helper_matches_this_rule():
+    """Pin the mirror above to the real implementation.
+
+    Read as source because importing ``api/code_sync.py`` pulls in the backend;
+    the check is that the real helper consults the shared parser and matches on
+    all three identities, which is what the mirror encodes.
+    """
+    source = (_BACKEND_ROOT / "api" / "code_sync.py").read_text(encoding="utf-8")
+    start = source.index("def _node_was_unreachable(")
+    body = source[start : source.index("\ndef ", start + 1)]
+
+    assert "parse_unreachable_hosts(" in body
+    for identity in ("node.node_id", "node.hostname", "node.ip_address"):
+        assert identity in body, f"{identity} is not consulted — an inventory name mismatch would misreport"
+
+
+# --------------------------------------------------------------------------
+# The skip must be gone from the health check itself
+# --------------------------------------------------------------------------
+
+
+def test_a_non_operational_node_is_no_longer_skipped_before_the_attempt():
+    """The deadlock-breaker, asserted on control flow rather than on a log line.
+
+    ``_sync_fleet_node`` must not return early on ``_is_node_operational``.
+    Checked structurally: within the function, no ``return`` may appear inside
+    a branch guarded by that predicate before the playbook is executed.
+    """
+    import ast
+
+    source = (_BACKEND_ROOT / "api" / "code_sync.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    func = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == "_sync_fleet_node"
+    )
+
+    guards = [
+        node
+        for node in ast.walk(func)
+        if isinstance(node, ast.If)
+        and any(
+            isinstance(call, ast.Call) and getattr(call.func, "id", None) == "_is_node_operational"
+            for call in ast.walk(node.test)
+        )
+    ]
+    for guard in guards:
+        returns = [n for n in ast.walk(guard) if isinstance(n, ast.Return)]
+        assert not returns, "a non-operational node still returns before the update is attempted (#14297)"
+
+
+def test_the_operational_predicate_is_still_consulted():
+    """It must still be *used* — the fix reclassifies the node, it does not stop looking.
+
+    Deleting the check entirely would also pass the rule above while losing the
+    "attempting anyway" signal and the unreachable-is-a-skip handling, which
+    both depend on knowing the node was unhealthy.
+    """
+    source = (_BACKEND_ROOT / "api" / "code_sync.py").read_text(encoding="utf-8")
+    start = source.index("async def _sync_fleet_node(")
+    body = source[start : source.index("\nasync def ", start + 1)]
+
+    assert "_is_node_operational(node)" in body

--- a/autobot-slm-backend/tests/api/test_fleet_node_update_11511.py
+++ b/autobot-slm-backend/tests/api/test_fleet_node_update_11511.py
@@ -304,7 +304,15 @@ def _make_db_service_for_node(node):
 
 
 def test_sync_fleet_node_skips_degraded_node() -> None:
-    """A degraded node (no heartbeat) increments skipped, not failed (#11511)."""
+    """A degraded node that ansible cannot reach increments skipped, not failed.
+
+    #11511 established the outcome: a node that cannot be contacted must not
+    fail the job. #14297 changed how that is decided — the node is no longer
+    skipped on its *health*, because a node too stale to heartbeat is exactly
+    the one that needs the update, and skipping it on health was a deadlock.
+    Ansible's UNREACHABLE verdict decides instead, so this test now supplies
+    that verdict rather than asserting the playbook never ran.
+    """
     degraded = _fake_node(
         node_id="node-vnc",
         hostname="VNC",
@@ -319,20 +327,32 @@ def test_sync_fleet_node_skips_degraded_node() -> None:
     stage.status = _StageStatus.RUNNING
 
     mock_executor = MagicMock()
+    mock_executor.execute_playbook = AsyncMock(
+        return_value={
+            "success": False,
+            "returncode": 4,
+            "output": 'fatal: [node-vnc]: UNREACHABLE! => {"msg": "Failed to connect to the host via ssh"}',
+        }
+    )
     mock_db_svc = _make_db_service_for_node(degraded)
 
     with _patched_db_service(mock_db_svc):
         cont = _run(_sync_fleet_node(mock_executor, "node-vnc", job, stage, "10.0.0.1"))
 
-    assert cont is True, "loop must continue after skipping a non-operational node"
+    assert cont is True, "loop must continue after skipping an unreachable node"
     assert job.skipped_fleet_nodes == 1
     assert job.failed_fleet_nodes == 0
     assert job.completed_fleet_nodes == 0
-    mock_executor.execute_playbook.assert_not_called()
+    mock_executor.execute_playbook.assert_called_once()
 
 
 def test_sync_fleet_node_skips_never_heartbeated_node() -> None:
-    """A node that never sent a heartbeat is skipped regardless of status (#11511)."""
+    """A node that never heartbeated is attempted, and skipped only if unreachable.
+
+    Same reclassification as above (#14297): never having heartbeated is the
+    signature of a node that has not been provisioned yet, which is precisely
+    a node that should receive the deploy.
+    """
     never_beat = _fake_node(
         node_id="node-new",
         status=_STATUS_ONLINE,
@@ -345,6 +365,13 @@ def test_sync_fleet_node_skips_never_heartbeated_node() -> None:
     stage.status = _StageStatus.RUNNING
 
     mock_executor = MagicMock()
+    mock_executor.execute_playbook = AsyncMock(
+        return_value={
+            "success": False,
+            "returncode": 4,
+            "output": 'fatal: [node-new]: UNREACHABLE! => {"msg": "Failed to connect to the host via ssh"}',
+        }
+    )
     mock_db_svc = _make_db_service_for_node(never_beat)
 
     with _patched_db_service(mock_db_svc):
@@ -353,7 +380,79 @@ def test_sync_fleet_node_skips_never_heartbeated_node() -> None:
     assert cont is True
     assert job.skipped_fleet_nodes == 1
     assert job.failed_fleet_nodes == 0
-    mock_executor.execute_playbook.assert_not_called()
+    mock_executor.execute_playbook.assert_called_once()
+
+
+def test_sync_fleet_node_updates_a_degraded_but_reachable_node() -> None:
+    """The deadlock-breaker (#14297).
+
+    The node in the live report was degraded, SSH-reachable, and 1140 commits
+    behind — skipped on every run by the health check, so it could never get
+    the update that would let it heartbeat again. Reachable means it gets the
+    deploy.
+    """
+    degraded = _fake_node(
+        node_id="node-vnc",
+        hostname="VNC",
+        ip_address="203.0.113.26",  # RFC 5737 TEST-NET-3 doc IP (no real fleet IPs in tests — SSOT)
+        status=_STATUS_DEGRADED,
+        last_heartbeat=None,
+    )
+    job = _job_with_fleet_stage()
+    from api.code_sync import _get_stage
+
+    stage = _get_stage(job, "fleet_nodes")
+    stage.status = _StageStatus.RUNNING
+
+    mock_executor = MagicMock()
+    mock_executor.execute_playbook = AsyncMock(return_value={"success": True, "output": "", "returncode": 0})
+    mock_db_svc = _make_db_service_for_node(degraded)
+
+    with _patched_db_service(mock_db_svc), patch("api.code_sync._update_fleet_node_version", new=AsyncMock()):
+        cont = _run(_sync_fleet_node(mock_executor, "node-vnc", job, stage, "10.0.0.1"))
+
+    assert cont is True
+    assert job.completed_fleet_nodes == 1, "a reachable node must be updated even while degraded"
+    assert job.skipped_fleet_nodes == 0
+    assert job.failed_fleet_nodes == 0
+
+
+def test_sync_fleet_node_fails_a_degraded_node_that_broke_rather_than_vanished() -> None:
+    """A real failure must stay a failure, even for an unhealthy node.
+
+    If every failure against a degraded node counted as "it was down", a broken
+    deploy would report itself as a skip, the job would go green, and the node
+    would stay stale — the original bug wearing a different hat.
+    """
+    degraded = _fake_node(
+        node_id="node-vnc",
+        hostname="VNC",
+        ip_address="203.0.113.26",
+        status=_STATUS_DEGRADED,
+        last_heartbeat=None,
+    )
+    job = _job_with_fleet_stage()
+    from api.code_sync import _get_stage
+
+    stage = _get_stage(job, "fleet_nodes")
+    stage.status = _StageStatus.RUNNING
+
+    mock_executor = MagicMock()
+    mock_executor.execute_playbook = AsyncMock(
+        return_value={
+            "success": False,
+            "returncode": 2,
+            "output": 'TASK [Install]\nfatal: [node-vnc]: FAILED! => {"msg": "pip resolution failed"}',
+        }
+    )
+    mock_db_svc = _make_db_service_for_node(degraded)
+
+    with _patched_db_service(mock_db_svc):
+        cont = _run(_sync_fleet_node(mock_executor, "node-vnc", job, stage, "10.0.0.1"))
+
+    assert cont is False, "a real failure halts the stage"
+    assert job.failed_fleet_nodes == 1
+    assert job.skipped_fleet_nodes == 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Thinking Path

Found on the live deployment, not by reading code. A fleet node sat 1140 commits behind while
`update-all` reported success:

```
[update-all:fleet_nodes] Node <id> (VNC) skipped — not operational (status=degraded, last_heartbeat=none)
Attempting remediation for node <id> (attempt 1/3)
Attempting remediation for node <id> (attempt 2/3)
Attempting remediation for node <id> (attempt 3/3)
```

Never a success line, and the cycle restarted hours later having changed nothing.

The first fix I reached for was an SSH probe before the skip. I dropped it: it would have been a
third reachability implementation, and ansible already answers the question.

## Problem

#11511 skips non-operational nodes, on the stated reasoning that a deploy against them "will always
fail". That holds for a node that is down. It does not hold for one that is merely unhealthy — and
that is where the two diverge into a deadlock:

```
the agent is too old to heartbeat
  -> the node is marked degraded
    -> update-all skips degraded nodes
      -> the node never receives the update that would replace the agent
```

The health signal gates the only thing that could repair it. Nothing in the remediation loop
escalates: it is the same restart, three times, forever.

## What Changed

The attempt goes ahead, and **ansible's own UNREACHABLE verdict decides**. It reports unreachable
distinctly from failed, which is exactly the distinction needed: unreachable on this path is
counted as skipped, precisely as before, so a genuinely down node still does not fail the job.

`_parse_unreachable_hosts` already existed in `api/updates.py` (#1816). It moved to
`services/ansible_utils.py` as `parse_unreachable_hosts` so `api/code_sync.py` can use it without
an api→api import; `updates.py` keeps its name as a delegating wrapper, so its callers are
untouched.

`_node_was_unreachable` matches on node_id, hostname **or** ip_address, because the inventory name
a play reports is not reliably the one the DB stores — `ansible_hostname` is the OS hostname while
`nodes.hostname` is a display name. #1789 hit that same mismatch and fell back to IP.

`_is_node_operational` is unchanged and still consulted. The node is reclassified, not ignored:
the log says it is being attempted anyway, a success is marked "recovered while not operational",
and the unreachable-is-a-skip branch only applies to a node that was unhealthy going in.

## Verification

CI. 11 tests. The two that carry the argument:

- `test_a_failed_host_is_not_reported_as_unreachable` — if a plain failure parsed as unreachable,
  every broken deploy against a degraded node would be recorded as a *skip*, the job would go
  green, and the node would stay stale. That is the original bug wearing a different hat.
- `test_a_non_operational_node_is_no_longer_skipped_before_the_attempt` — asserts on control flow,
  not on a log line: no `return` may appear inside a branch guarded by `_is_node_operational`
  before the playbook runs. Mutation-checked — restoring the early skip takes it from 0 such
  returns to 1, and the rule fails.

`test_the_operational_predicate_is_still_consulted` exists because deleting the check outright
would also satisfy the rule above, while losing the "attempting anyway" signal and the
unreachable-is-a-skip handling that both depend on knowing the node was unhealthy.

`test_the_production_helper_matches_this_rule` pins the test's local mirror of the identity match
to the real helper, so the mirror cannot drift into testing only itself.

Not run locally, by instruction.

## Risks

An update-all now spends one ansible run on a node that may be down, where it previously spent
none. The stage is sequential and already minutes long, and an unreachable host fails at
gather_facts within the SSH timeout, so the cost is bounded and paid once per node per run.

A degraded node that is reachable but genuinely broken will now surface a real failure where it
previously surfaced a skip. That is the intent — the job result becomes accurate rather than
quiet — but it does mean a fleet with a broken node starts reporting failures it used to swallow.

## Not in scope

The remediation loop's lack of escalation, and the fact that `partial` is the job status when
anything is skipped but the top-level `self_update_detail` still reads "completed (5 plays, no
failures)". Both are recorded in #14297; this change removes the deadlock rather than reworking
the reporting.

## Model Used

Opus 5 (1M context).

Closes #14297
