### PR TITLE
feat(llc): attach workflows to the role, not to its holder

### DIFF
--- a/autobot-backend/llc/models/__init__.py
+++ b/autobot-backend/llc/models/__init__.py
@@ -48,6 +48,7 @@ from .membership import LLCCompanyMembership
 from .replay_log import LLCRunReplayLog
 from .review_gate import LLCReviewGatePolicy
 from .role_assignment import LLCRoleAssignment
+from .role_workflow import LLCRoleWorkflow
 from .secret import LLCSecret
 from .sprint import LLCPortfolio, LLCProgram, LLCProject, LLCSprint
 from .template import TemplateCategory
@@ -93,6 +94,7 @@ __all__ = [
     "LLCProject",
     "LLCRunStatus",
     "LLCRoleAssignment",
+    "LLCRoleWorkflow",
     "LLCSprint",
     "RoutineProduces",
     "LLCSecret",

--- a/autobot-backend/llc/models/role_workflow.py
+++ b/autobot-backend/llc/models/role_workflow.py
@@ -1,0 +1,64 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Workflows attached to a role, not to whoever currently holds it (#14221 step 5).
+
+Owner framing:
+
+    people get promoted or leave the company, but the role stays — and so do
+    the tools and workflows attached to the role
+
+That is the whole reason this table hangs off the canonical ``roles`` row and not off an
+agent, a user or an org node. When the holder changes, nothing here moves: the
+next occupant of "Head of Sales" inherits the same workflows because the
+attachment was never theirs to begin with.
+
+``workflow_id`` is ``String(255)``, matching ``Workflow.workflow_id`` — the
+workflows table is keyed by a string id, not a UUID, so this column mirrors it
+rather than converting at the boundary. (``llc_secrets`` and three other LLC
+models diverge on ``company_id`` in exactly that way, which is #14312.)
+"""
+
+import uuid
+from datetime import datetime
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from user_management.models.base import Base
+
+
+class LLCRoleWorkflow(Base):
+    """One workflow attached to one role."""
+
+    __tablename__ = "llc_role_workflows"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+
+    # Carried on the attachment itself so every query pins scope without
+    # depending on a join to llc_roles — a lost join condition cannot widen the
+    # result. Same reasoning as llc_role_assignments.
+    company_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    role_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    workflow_id: Mapped[str] = mapped_column(sa.String(255), nullable=False, index=True)
+
+    created_at: Mapped[datetime] = mapped_column(
+        sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.func.now(),
+        onupdate=sa.func.now(),
+    )
+
+    __table_args__ = (
+        # Attaching the same workflow twice is a no-op the caller should hear
+        # about, not a second row.
+        sa.UniqueConstraint("role_id", "workflow_id", name="uq_llc_role_workflows_role_workflow"),
+    )
+
+    def __repr__(self) -> str:  # pragma: no cover - debug helper
+        return f"<LLCRoleWorkflow role={self.role_id} workflow={self.workflow_id!r}>"

--- a/autobot-backend/llc/services/role_workflow.py
+++ b/autobot-backend/llc/services/role_workflow.py
@@ -1,0 +1,209 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Attach and detach workflows on a role (#14221 step 5).
+
+The attachment belongs to the role, so a change of holder moves nothing here —
+that is the point of #14221. Offboarding (step 4) therefore has nothing to
+transfer for workflows: they were never the occupant's.
+
+Two guards matter more than the CRUD:
+
+* the role must exist **in this company** (#14222's orphan-reference shape), and
+* the workflow must belong to **the same company**.
+
+The second one has a wrinkle worth stating: ``Workflow.company_id`` is
+**nullable**, because rows backfilled from Redis carry no company attribution
+(``source = legacy_redis_unattributed``). Attaching one of those to a company's
+role would give that company a workflow nobody has established it owns.
+
+The NULL case gets its own error rather than being folded into the ownership
+mismatch. To be precise about what that buys: comparing ``None != company_id``
+in Python is already ``True``, so an unattributed workflow would be refused
+either way — the branch does not close a bypass. What it closes is a
+*diagnostic* gap. Without it the caller is told the workflow "does not belong to
+company X", which reads as "it belongs to someone else" when the truth is "it
+belongs to nobody yet, and needs attributing". Those call for different fixes.
+A guard expressed as a SQL predicate instead of a Python comparison would be
+worse still, reporting the row as simply missing.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any, Dict, List, Optional
+
+from sqlalchemy import delete as sa_delete
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.workflow import Workflow
+from user_management.models.role import Role
+
+from ..models.activity import ActorType
+from ..models.role_workflow import LLCRoleWorkflow
+from .authz import require_company_admin
+from .base import LLCServiceBase
+
+
+class RoleWorkflowService(LLCServiceBase):
+    """Company-scoped attachment of workflows to roles."""
+
+    async def _record(
+        self,
+        session: AsyncSession,
+        attachment: LLCRoleWorkflow,
+        event_type: str,
+        actor: Optional[str],
+        after: Optional[Dict[str, Any]],
+    ) -> None:
+        """Emit one activity-log event, or nothing if the DI slot is unpopulated."""
+        if not self.activity_log:
+            return
+        await self.activity_log.record(
+            session=session,
+            company_id=str(attachment.company_id),
+            actor_type=ActorType.USER if actor else ActorType.SYSTEM,
+            actor_id=actor,
+            event_type=event_type,
+            entity_type="llc_role_workflow",
+            entity_id=str(attachment.id),
+            after=after,
+        )
+
+    async def _require_role(self, session: AsyncSession, company_id: uuid.UUID, role_id: uuid.UUID) -> None:
+        result = await session.execute(select(Role.id).where(Role.id == role_id, Role.org_id == company_id))
+        if result.scalar_one_or_none() is None:
+            raise ValueError(f"role {role_id} does not exist in company {company_id}")
+
+    async def _require_workflow(self, session: AsyncSession, company_id: uuid.UUID, workflow_id: str) -> None:
+        """The workflow must exist and belong to this company.
+
+        A NULL ``company_id`` is refused distinctly from a missing row: it means
+        the workflow predates company attribution, not that it is absent.
+        """
+        result = await session.execute(select(Workflow.company_id).where(Workflow.workflow_id == workflow_id))
+        row = result.first()
+        if row is None:
+            raise ValueError(f"workflow {workflow_id!r} does not exist")
+
+        owner = row[0]
+        if owner is None:
+            raise ValueError(f"workflow {workflow_id!r} has no company attribution and cannot be " "attached to a role")
+        if owner != company_id:
+            raise ValueError(f"workflow {workflow_id!r} does not belong to company {company_id}")
+
+    async def attach(
+        self,
+        session: AsyncSession,
+        *,
+        company_id: uuid.UUID,
+        role_id: uuid.UUID,
+        workflow_id: str,
+        actor_user_id: uuid.UUID,
+    ) -> LLCRoleWorkflow:
+        if company_id is None or role_id is None or not (workflow_id or "").strip():
+            raise ValueError("company_id, role_id and workflow_id are all required")
+
+        # Attaching a workflow to a role changes what every current and future
+        # holder of that role runs, so it is an admin action — same gate as
+        # occupancy and permissions.
+        await require_company_admin(session, company_id, actor_user_id)
+        await self._require_role(session, company_id, role_id)
+        await self._require_workflow(session, company_id, workflow_id)
+
+        if await self.get(session, company_id, role_id, workflow_id) is not None:
+            raise ValueError(f"workflow {workflow_id!r} is already attached to role {role_id}")
+
+        attachment = LLCRoleWorkflow(company_id=company_id, role_id=role_id, workflow_id=workflow_id)
+        session.add(attachment)
+        await session.flush()
+        await self._record(
+            session,
+            attachment,
+            "role_workflow.attached",
+            str(actor_user_id),
+            {"role_id": str(role_id), "workflow_id": workflow_id},
+        )
+        return attachment
+
+    async def get(
+        self,
+        session: AsyncSession,
+        company_id: uuid.UUID,
+        role_id: uuid.UUID,
+        workflow_id: str,
+    ) -> Optional[LLCRoleWorkflow]:
+        result = await session.execute(
+            select(LLCRoleWorkflow).where(
+                LLCRoleWorkflow.company_id == company_id,
+                LLCRoleWorkflow.role_id == role_id,
+                LLCRoleWorkflow.workflow_id == workflow_id,
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def list_for_role(
+        self, session: AsyncSession, company_id: uuid.UUID, role_id: uuid.UUID
+    ) -> List[LLCRoleWorkflow]:
+        """Workflows this role carries — independent of who currently holds it."""
+        result = await session.execute(
+            select(LLCRoleWorkflow)
+            .where(
+                LLCRoleWorkflow.company_id == company_id,
+                LLCRoleWorkflow.role_id == role_id,
+            )
+            .order_by(LLCRoleWorkflow.workflow_id)
+        )
+        return list(result.scalars().all())
+
+    async def roles_for_workflow(self, session: AsyncSession, company_id: uuid.UUID, workflow_id: str) -> List[Role]:
+        """Which roles run this workflow — the reverse lookup an audit needs."""
+        result = await session.execute(
+            select(Role)
+            .join(LLCRoleWorkflow, LLCRoleWorkflow.role_id == Role.id)
+            .where(
+                Role.org_id == company_id,
+                LLCRoleWorkflow.company_id == company_id,
+                LLCRoleWorkflow.workflow_id == workflow_id,
+            )
+            .order_by(Role.name)
+        )
+        return list(result.scalars().all())
+
+    async def detach(
+        self,
+        session: AsyncSession,
+        company_id: uuid.UUID,
+        role_id: uuid.UUID,
+        workflow_id: str,
+        *,
+        actor_user_id: uuid.UUID,
+    ) -> bool:
+        """Remove an attachment. Returns True when a row was actually removed.
+
+        Unlike ending a tenure, this deletes the row. A tenure is a fact about
+        the past that later questions depend on; an attachment is a statement
+        about the present, and the activity log carries the history of changes
+        to it.
+        """
+        await require_company_admin(session, company_id, actor_user_id)
+        attachment = await self.get(session, company_id, role_id, workflow_id) if self.activity_log else None
+        result = await session.execute(
+            sa_delete(LLCRoleWorkflow).where(
+                LLCRoleWorkflow.company_id == company_id,
+                LLCRoleWorkflow.role_id == role_id,
+                LLCRoleWorkflow.workflow_id == workflow_id,
+            )
+        )
+        detached = bool(result.rowcount)
+        if detached and attachment is not None:
+            await self._record(
+                session,
+                attachment,
+                "role_workflow.detached",
+                str(actor_user_id),
+                {"role_id": str(role_id), "workflow_id": workflow_id},
+            )
+        return detached

--- a/autobot-backend/llc/tests/test_role_workflows.py
+++ b/autobot-backend/llc/tests/test_role_workflows.py
@@ -28,12 +28,12 @@ import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from llc.models.enums import MembershipRole, RoleHolderType
-from llc.models.role_assignment import LLCRoleAssignment
 from llc.models.membership import LLCCompanyMembership
+from llc.models.role_assignment import LLCRoleAssignment
 from llc.models.role_workflow import LLCRoleWorkflow
+from llc.services.authz import NotAuthorisedError
 from llc.services.role import RoleService
 from llc.services.role_assignment import RoleAssignmentService
-from llc.services.authz import NotAuthorisedError
 from llc.services.role_workflow import RoleWorkflowService
 
 # Registers the SQLite compile shims for postgresql.JSONB / postgresql.UUID.

--- a/autobot-backend/llc/tests/test_role_workflows.py
+++ b/autobot-backend/llc/tests/test_role_workflows.py
@@ -1,0 +1,437 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Workflows attached to a role, and the guards on attaching them (#14221 step 5).
+
+The load-bearing test is ``test_workflows_survive_a_change_of_holder``: the
+whole reason a role is an object is that its workflows do not follow the person.
+
+The second one worth reading is
+``test_an_unattributed_legacy_workflow_cannot_be_attached``. ``Workflow.company_id``
+is nullable for rows backfilled from Redis. Removing the dedicated NULL branch
+reddens that test — verified by mutation — but it is worth being precise about
+why: ``None != company_id`` is already ``True``, so the workflow stays refused.
+What the branch protects is the *reason* given. Without it the caller hears
+"does not belong to company X", which reads as "it belongs to someone else"
+when in fact it belongs to nobody yet. That is a different problem with a
+different fix, and conflating the two is how unattributed legacy rows stay
+unattributed.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import AsyncIterator
+
+import pytest
+import pytest_asyncio
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from llc.models.enums import MembershipRole, RoleHolderType
+from llc.models.role_assignment import LLCRoleAssignment
+from llc.models.membership import LLCCompanyMembership
+from llc.models.role_workflow import LLCRoleWorkflow
+from llc.services.role import RoleService
+from llc.services.role_assignment import RoleAssignmentService
+from llc.services.authz import NotAuthorisedError
+from llc.services.role_workflow import RoleWorkflowService
+
+# Registers the SQLite compile shims for postgresql.JSONB / postgresql.UUID.
+from llc.tests import _e2e_harness as harness
+from models.workflow import Workflow
+from user_management.models.base import Base
+from user_management.models.role import Role
+
+
+@pytest_asyncio.fixture
+async def session_factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = create_async_engine(  # canonical: ignore py-adhoc-db-engine (test-local engine)
+        "sqlite+aiosqlite:///:memory:"
+    )
+    tables = [
+        Role.__table__,
+        LLCRoleAssignment.__table__,
+        LLCRoleWorkflow.__table__,
+        Workflow.__table__,
+        LLCCompanyMembership.__table__,
+    ]
+    for table in tables:
+        harness._scrub_pg_server_defaults(table)
+        harness._clientside_timestamps(table)
+    async with engine.begin() as conn:
+        await conn.run_sync(lambda c: Base.metadata.create_all(c, tables=tables))
+    yield async_sessionmaker(  # canonical: ignore py-adhoc-db-engine (test-local factory)
+        engine, expire_on_commit=False, class_=AsyncSession
+    )
+    await engine.dispose()
+
+
+#: Attach/detach are admin-gated; this suite acts as one admin throughout.
+_ADMIN_USER = uuid.uuid4()
+
+
+async def _grant_admin(session_factory, company_id: uuid.UUID) -> None:  # noqa: ANN001
+    async with session_factory() as session:
+        existing = await session.execute(
+            sa.select(LLCCompanyMembership.id).where(
+                LLCCompanyMembership.company_id == company_id,
+                LLCCompanyMembership.user_id == _ADMIN_USER,
+            )
+        )
+        if existing.scalar_one_or_none() is not None:
+            return
+        session.add(
+            LLCCompanyMembership(
+                id=uuid.uuid4(),
+                company_id=company_id,
+                user_id=_ADMIN_USER,
+                role=MembershipRole.ADMIN.value,
+            )
+        )
+        await session.commit()
+
+
+async def _seed_role(session_factory, company_id: uuid.UUID, name: str) -> uuid.UUID:  # noqa: ANN001
+    await _grant_admin(session_factory, company_id)
+    async with session_factory() as session:
+        role = await RoleService().create(session, company_id=company_id, name=name)
+        await session.commit()
+        return role.id
+
+
+async def _seed_workflow(session_factory, workflow_id: str, company_id: uuid.UUID | None) -> str:  # noqa: ANN001
+    async with session_factory() as session:
+        session.add(Workflow(workflow_id=workflow_id, company_id=company_id, name=workflow_id))
+        await session.commit()
+        return workflow_id
+
+
+@pytest.mark.asyncio
+async def test_workflows_survive_a_change_of_holder(session_factory):  # noqa: ANN001
+    """The point of the whole issue: the workflow belongs to the role.
+
+    Someone leaves, someone else arrives, and the role's workflows are
+    untouched throughout.
+    """
+    company = uuid.uuid4()
+    role_id = await _seed_role(session_factory, company, "Head of Sales")
+    workflow_id = await _seed_workflow(session_factory, "wf-quarterly-report", company)
+    workflows = RoleWorkflowService()
+    occupancy = RoleAssignmentService()
+    leaver, successor = uuid.uuid4(), uuid.uuid4()
+
+    async with session_factory() as session:
+        await workflows.attach(
+            session, company_id=company, role_id=role_id, workflow_id=workflow_id, actor_user_id=_ADMIN_USER
+        )
+        tenure = await occupancy.assign(
+            session,
+            actor_user_id=_ADMIN_USER,
+            company_id=company,
+            role_id=role_id,
+            holder_type=RoleHolderType.USER,
+            holder_id=leaver,
+        )
+        await session.commit()
+        tenure_id = tenure.id
+
+    async with session_factory() as session:
+        await occupancy.end_tenure(session, company, tenure_id, actor_user_id=_ADMIN_USER)
+        await occupancy.assign(
+            session,
+            actor_user_id=_ADMIN_USER,
+            company_id=company,
+            role_id=role_id,
+            holder_type=RoleHolderType.USER,
+            holder_id=successor,
+        )
+        await session.commit()
+
+    async with session_factory() as session:
+        attached = await workflows.list_for_role(session, company, role_id)
+
+    assert [a.workflow_id for a in attached] == [
+        workflow_id
+    ], "the role's workflows moved or vanished when the holder changed"
+
+
+@pytest.mark.asyncio
+async def test_an_unattributed_legacy_workflow_cannot_be_attached(session_factory):  # noqa: ANN001
+    """A NULL company_id must be refused, and refused *distinctly*.
+
+    Pins the error message, not just the refusal — see the module docstring for
+    why the distinction is the thing worth protecting here.
+    """
+    company = uuid.uuid4()
+    role_id = await _seed_role(session_factory, company, "Head of Sales")
+    workflow_id = await _seed_workflow(session_factory, "wf-legacy", None)
+    service = RoleWorkflowService()
+
+    async with session_factory() as session:
+        with pytest.raises(ValueError, match="no company attribution"):
+            await service.attach(
+                session, company_id=company, role_id=role_id, workflow_id=workflow_id, actor_user_id=_ADMIN_USER
+            )
+
+    async with session_factory() as session:
+        assert await service.list_for_role(session, company, role_id) == []
+
+
+@pytest.mark.asyncio
+async def test_another_companys_workflow_cannot_be_attached(session_factory):  # noqa: ANN001
+    company_a, company_b = uuid.uuid4(), uuid.uuid4()
+    role_a = await _seed_role(session_factory, company_a, "Head of Sales")
+    theirs = await _seed_workflow(session_factory, "wf-theirs", company_b)
+    service = RoleWorkflowService()
+
+    async with session_factory() as session:
+        with pytest.raises(ValueError, match="does not belong to company"):
+            await service.attach(
+                session, company_id=company_a, role_id=role_a, workflow_id=theirs, actor_user_id=_ADMIN_USER
+            )
+
+
+@pytest.mark.asyncio
+async def test_a_missing_workflow_is_refused_separately_from_an_unowned_one(session_factory):  # noqa: ANN001
+    """ "No such workflow" and "that workflow has no owner" are different facts."""
+    company = uuid.uuid4()
+    role_id = await _seed_role(session_factory, company, "Head of Sales")
+    service = RoleWorkflowService()
+
+    async with session_factory() as session:
+        with pytest.raises(ValueError, match="does not exist"):
+            await service.attach(
+                session, company_id=company, role_id=role_id, workflow_id="wf-nope", actor_user_id=_ADMIN_USER
+            )
+
+
+@pytest.mark.asyncio
+async def test_cannot_attach_to_another_companys_role(session_factory):  # noqa: ANN001
+    company_a, company_b = uuid.uuid4(), uuid.uuid4()
+    # Admin of company_a too, or the authorisation gate fires before the
+    # scoping check and the test stops exercising scoping.
+    await _grant_admin(session_factory, company_a)
+    role_b = await _seed_role(session_factory, company_b, "SRE")
+    workflow_a = await _seed_workflow(session_factory, "wf-a", company_a)
+    service = RoleWorkflowService()
+
+    async with session_factory() as session:
+        with pytest.raises(ValueError, match="role .* does not exist in company"):
+            await service.attach(
+                session, company_id=company_a, role_id=role_b, workflow_id=workflow_a, actor_user_id=_ADMIN_USER
+            )
+
+
+@pytest.mark.asyncio
+async def test_attaching_twice_is_refused(session_factory):  # noqa: ANN001
+    company = uuid.uuid4()
+    role_id = await _seed_role(session_factory, company, "SRE")
+    workflow_id = await _seed_workflow(session_factory, "wf-1", company)
+    service = RoleWorkflowService()
+
+    async with session_factory() as session:
+        await service.attach(
+            session, company_id=company, role_id=role_id, workflow_id=workflow_id, actor_user_id=_ADMIN_USER
+        )
+        await session.commit()
+
+    async with session_factory() as session:
+        with pytest.raises(ValueError, match="already attached"):
+            await service.attach(
+                session, company_id=company, role_id=role_id, workflow_id=workflow_id, actor_user_id=_ADMIN_USER
+            )
+
+
+@pytest.mark.asyncio
+async def test_list_and_detach_are_company_scoped(session_factory):  # noqa: ANN001
+    company_a, company_b = uuid.uuid4(), uuid.uuid4()
+    # Admin of company_a too, or the authorisation gate fires before the
+    # scoping check and the test stops exercising scoping.
+    await _grant_admin(session_factory, company_a)
+    role_b = await _seed_role(session_factory, company_b, "SRE")
+    workflow_b = await _seed_workflow(session_factory, "wf-b", company_b)
+    service = RoleWorkflowService()
+
+    async with session_factory() as session:
+        await service.attach(
+            session, company_id=company_b, role_id=role_b, workflow_id=workflow_b, actor_user_id=_ADMIN_USER
+        )
+        await session.commit()
+
+    async with session_factory() as session:
+        assert await service.list_for_role(session, company_a, role_b) == []
+        assert await service.detach(session, company_a, role_b, workflow_b, actor_user_id=_ADMIN_USER) is False
+        await session.commit()
+
+    async with session_factory() as session:
+        assert len(await service.list_for_role(session, company_b, role_b)) == 1
+
+
+@pytest.mark.asyncio
+async def test_detach_removes_the_attachment_and_reports_it(session_factory):  # noqa: ANN001
+    company = uuid.uuid4()
+    role_id = await _seed_role(session_factory, company, "SRE")
+    workflow_id = await _seed_workflow(session_factory, "wf-1", company)
+    service = RoleWorkflowService()
+
+    async with session_factory() as session:
+        await service.attach(
+            session, company_id=company, role_id=role_id, workflow_id=workflow_id, actor_user_id=_ADMIN_USER
+        )
+        await session.commit()
+
+    async with session_factory() as session:
+        assert await service.detach(session, company, role_id, workflow_id, actor_user_id=_ADMIN_USER) is True
+        assert await service.detach(session, company, role_id, workflow_id, actor_user_id=_ADMIN_USER) is False
+        await session.commit()
+
+    async with session_factory() as session:
+        assert await service.list_for_role(session, company, role_id) == []
+
+
+@pytest.mark.asyncio
+async def test_roles_for_workflow_is_the_reverse_lookup(session_factory):  # noqa: ANN001
+    """Which roles run this workflow — scoped, and sorted by role name."""
+    company_a, company_b = uuid.uuid4(), uuid.uuid4()
+    sre = await _seed_role(session_factory, company_a, "SRE")
+    lead = await _seed_role(session_factory, company_a, "Team Lead")
+    other = await _seed_role(session_factory, company_b, "SRE")
+    workflow_a = await _seed_workflow(session_factory, "wf-shared", company_a)
+    workflow_b = await _seed_workflow(session_factory, "wf-shared-b", company_b)
+    service = RoleWorkflowService()
+
+    async with session_factory() as session:
+        for role_id in (sre, lead):
+            await service.attach(
+                session, company_id=company_a, role_id=role_id, workflow_id=workflow_a, actor_user_id=_ADMIN_USER
+            )
+        await service.attach(
+            session, company_id=company_b, role_id=other, workflow_id=workflow_b, actor_user_id=_ADMIN_USER
+        )
+        await session.commit()
+
+    async with session_factory() as session:
+        found = await service.roles_for_workflow(session, company_a, workflow_a)
+
+    assert [r.name for r in found] == ["SRE", "Team Lead"]
+
+
+class _RecordingActivityLog:
+    """Captures ``record()`` calls — a stateful fake, not a MagicMock."""
+
+    def __init__(self) -> None:
+        self.events: list[dict] = []
+
+    async def record(self, **kwargs) -> None:  # noqa: ANN003
+        self.events.append(kwargs)
+
+
+@pytest.mark.asyncio
+async def test_attach_and_detach_are_audited(session_factory):  # noqa: ANN001
+    log = _RecordingActivityLog()
+    service = RoleWorkflowService(activity_log=log)
+    company = uuid.uuid4()
+    role_id = await _seed_role(session_factory, company, "SRE")
+    workflow_id = await _seed_workflow(session_factory, "wf-1", company)
+
+    async with session_factory() as session:
+        await service.attach(
+            session, company_id=company, role_id=role_id, workflow_id=workflow_id, actor_user_id=_ADMIN_USER
+        )
+        assert await service.detach(session, company, role_id, workflow_id, actor_user_id=_ADMIN_USER) is True
+        await session.commit()
+
+    assert [e["event_type"] for e in log.events] == [
+        "role_workflow.attached",
+        "role_workflow.detached",
+    ]
+    assert all(e["entity_type"] == "llc_role_workflow" for e in log.events)
+    assert all(e["company_id"] == str(company) for e in log.events)
+
+
+@pytest.mark.asyncio
+async def test_a_refused_attach_emits_nothing(session_factory):  # noqa: ANN001
+    log = _RecordingActivityLog()
+    service = RoleWorkflowService(activity_log=log)
+    company = uuid.uuid4()
+    role_id = await _seed_role(session_factory, company, "SRE")
+    workflow_id = await _seed_workflow(session_factory, "wf-legacy", None)
+
+    async with session_factory() as session:
+        with pytest.raises(ValueError):
+            await service.attach(
+                session, company_id=company, role_id=role_id, workflow_id=workflow_id, actor_user_id=_ADMIN_USER
+            )
+        await session.rollback()
+
+    assert log.events == []
+
+
+@pytest.mark.asyncio
+async def test_a_member_cannot_attach_a_workflow_to_a_role(session_factory):  # noqa: ANN001
+    """Attaching changes what every holder of that role runs — admin only.
+
+    Same shape as the occupancy escalation: a gate on one mutating path is
+    worthless while a sibling path that changes the same outcome is open.
+    """
+    service = RoleWorkflowService()
+    company = uuid.uuid4()
+    role_id = await _seed_role(session_factory, company, "SRE")
+    workflow_id = await _seed_workflow(session_factory, "wf-1", company)
+    member = uuid.uuid4()
+    async with session_factory() as session:
+        session.add(
+            LLCCompanyMembership(
+                id=uuid.uuid4(),
+                company_id=company,
+                user_id=member,
+                role=MembershipRole.MEMBER.value,
+            )
+        )
+        await session.commit()
+
+    async with session_factory() as session:
+        with pytest.raises(NotAuthorisedError, match="may not perform this change"):
+            await service.attach(
+                session,
+                company_id=company,
+                role_id=role_id,
+                workflow_id=workflow_id,
+                actor_user_id=member,
+            )
+
+    async with session_factory() as session:
+        assert await service.list_for_role(session, company, role_id) == []
+
+
+@pytest.mark.asyncio
+async def test_a_member_cannot_detach_a_workflow(session_factory):  # noqa: ANN001
+    service = RoleWorkflowService()
+    company = uuid.uuid4()
+    role_id = await _seed_role(session_factory, company, "SRE")
+    workflow_id = await _seed_workflow(session_factory, "wf-1", company)
+    member = uuid.uuid4()
+    async with session_factory() as session:
+        session.add(
+            LLCCompanyMembership(
+                id=uuid.uuid4(),
+                company_id=company,
+                user_id=member,
+                role=MembershipRole.MEMBER.value,
+            )
+        )
+        await service.attach(
+            session,
+            company_id=company,
+            role_id=role_id,
+            workflow_id=workflow_id,
+            actor_user_id=_ADMIN_USER,
+        )
+        await session.commit()
+
+    async with session_factory() as session:
+        with pytest.raises(NotAuthorisedError):
+            await service.detach(session, company, role_id, workflow_id, actor_user_id=member)
+
+    async with session_factory() as session:
+        assert len(await service.list_for_role(session, company, role_id)) == 1

--- a/autobot-backend/migrations/versions/20260819_079_llc_role_workflows.py
+++ b/autobot-backend/migrations/versions/20260819_079_llc_role_workflows.py
@@ -1,0 +1,63 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Add llc_role_workflows — workflows carried by a role (#14221 step 5).
+
+The attachment hangs off the role, so replacing the holder moves nothing: the
+next occupant of a role inherits its workflows because they were never the
+previous occupant's.
+
+``workflow_id`` is ``VARCHAR(255)`` to match ``workflows.workflow_id``, which is
+a string primary key rather than a UUID.
+
+Plain ``op.create_table`` — the tolerant ``IF NOT EXISTS`` form belongs to the
+drift reconciliations that re-add columns to tables already changed
+out-of-band, not to a table born in its own migration.
+
+Revision ID: 20260819_079
+Revises: 20260818_078
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision: str = "20260819_079"
+down_revision: Union[str, None] = "20260818_078"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_INDEXED_COLUMNS = ("company_id", "role_id", "workflow_id")
+
+
+def upgrade() -> None:
+    op.create_table(
+        "llc_role_workflows",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("company_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("role_id", UUID(as_uuid=True), nullable=False),
+        # VARCHAR, not UUID — workflows.workflow_id is a string key.
+        sa.Column("workflow_id", sa.String(255), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.UniqueConstraint("role_id", "workflow_id", name="uq_llc_role_workflows_role_workflow"),
+    )
+    for column in _INDEXED_COLUMNS:
+        op.create_index(f"ix_llc_role_workflows_{column}", "llc_role_workflows", [column])
+
+
+def downgrade() -> None:
+    for column in _INDEXED_COLUMNS:
+        op.drop_index(f"ix_llc_role_workflows_{column}", table_name="llc_role_workflows")
+    op.drop_table("llc_role_workflows")


### PR DESCRIPTION
Part of #14221 (step 5 of 6). **Stacked on #14303 → #14301 — merge those first.**

## Thinking Path

> people get promoted or leave the company, but the role stays — and so do the tools and workflows
> attached to the role

`llc_role_workflows` hangs off `llc_roles`, not off an agent, a user or an org node. That single
choice is what makes the owner's sentence true: when the holder changes, nothing here moves, and
the next occupant of "Head of Sales" inherits the same workflows because the attachment was never
the previous occupant's to begin with.

**Taken out of order deliberately.** Step 4 (tools + credential references) is blocked on #14312 —
`llc_roles.company_id` is `UUID` and `llc_secrets.company_id` is `String(255)`, so role→secret
references cross a type boundary that is already compared two different ways in live code. Workflows
do not cross it, so step 5 went first rather than adding a fifth coercion site to that problem.

## The Guard Worth Reading

`Workflow.company_id` is **nullable** — rows backfilled from Redis carry no company attribution
(`source = legacy_redis_unattributed`). Attaching one to a company's role would hand that company a
workflow nobody has established it owns, so NULL gets its own error.

**Being precise about what that branch buys**, because my first draft of this docstring overclaimed
and I caught it by mutating: `None != company_id` is already `True` in Python, so an unattributed
workflow is refused either way — **the branch does not close a bypass**. What it closes is a
diagnostic gap. Without it the caller is told the workflow "does not belong to company X", which
reads as *it belongs to someone else* when the truth is *it belongs to nobody yet and needs
attributing*. Those call for different fixes, and conflating them is how legacy rows stay
unattributed. A guard written as a SQL predicate rather than a Python comparison would be worse
still — it would report the row as simply missing.

## Design Notes

- **`detach` deletes the row**, unlike `end_tenure`, which never deletes. A tenure is a fact about
  the past that later questions depend on; an attachment is a statement about the present, and the
  activity log carries the history of changes to it.
- `workflow_id` is `VARCHAR(255)` because `workflows.workflow_id` is a string primary key, not a
  UUID. Mirrored rather than converted at the boundary.
- `company_id` is carried on the attachment so every query pins scope without depending on the join
  to `llc_roles`.

## What Changed

- New `llc_role_workflows` table + migration `20260819_079`, keyed to `roles.id`.
- `RoleWorkflowService`: attach, detach, list for role, reverse lookup by workflow.
- Guards: the role must be in this company, and the workflow must belong to it — with `NULL` company attribution refused distinctly.

## Verification

```
$ alembic heads     →  20260819_079 (head)     single head
$ pytest (3 suites) →  36 passed
$ black --check     →  clean
```

**Mutation-proved:** removing the NULL-attribution branch reddens
`test_an_unattributed_legacy_workflow_cannot_be_attached` — which is what prompted the docstring
correction above, since the test pins the *message* rather than the refusal.

`test_workflows_survive_a_change_of_holder` is a characterization test and I will not claim more for
it: it runs a full assign → end tenure → reassign cycle and asserts the workflow list is unchanged.
Nothing currently couples the two, so it does not catch a live bug — its value is that it fails
loudly if someone later makes offboarding detach workflows, which is exactly the mistake this issue
exists to prevent.

The activity-log tests use a stateful recording fake, not a MagicMock.

## Model Used

Claude Opus 5 (1M context)

