### PR TITLE
feat(llc): role access settings and effective-permission resolution

### DIFF
--- a/autobot-backend/llc/api/__init__.py
+++ b/autobot-backend/llc/api/__init__.py
@@ -30,6 +30,7 @@ from .labels import router as labels_router
 from .portability import router as portability_router
 from .replay import router as replay_router
 from .review_gate_policies import router as review_gate_router
+from .roles import router as roles_router
 from .routines import router as routines_router
 from .runs import heartbeat_runs_router
 from .runs import router as runs_router
@@ -57,6 +58,7 @@ router.include_router(goals_router)
 router.include_router(health_router)
 router.include_router(secrets_router)
 router.include_router(findings_router)
+router.include_router(roles_router)
 router.include_router(sprints_router)
 router.include_router(work_items_router)
 router.include_router(github_webhooks_router)

--- a/autobot-backend/llc/api/roles.py
+++ b/autobot-backend/llc/api/roles.py
@@ -42,9 +42,9 @@ from user_management.database import get_async_session
 from user_management.services import TenantContext
 
 from ..models.enums import RoleHolderType
+from ..services.authz import NotAuthorisedError
 from ..services.role import RoleService
 from ..services.role_assignment import RoleAssignmentService
-from ..services.authz import NotAuthorisedError
 from ..services.role_permission import RolePermissionService
 from ..services.role_workflow import RoleWorkflowService
 

--- a/autobot-backend/llc/api/roles.py
+++ b/autobot-backend/llc/api/roles.py
@@ -1,0 +1,412 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Company role routes — the reachable surface for #14221.
+
+Route group: ``/llc/roles/{company_id}``
+
+Steps 1-3 and 5 built services with no routes, which made every one of them
+unreachable. This is that surface, so the Roles tab has something to call and
+the services are wired rather than dormant.
+
+Scoping is applied **twice on purpose**, and the redundancy is the point:
+
+* :func:`assert_company_access` rejects a caller reaching outside their own
+  company (404, so "not mine" is indistinguishable from "doesn't exist"), and
+* every service query carries its own ``WHERE org_id`` / ``WHERE company_id``.
+
+A route guard and a row filter fail in different ways, and a test exercising
+only one cannot see the other — the gap this module has closed five separate
+times (#13936, #13969, #13942, #14222, #14210).
+
+``actor`` always comes from the authenticated session, never from the request
+body. A client-supplied actor let the audit trail's identity be whatever the
+caller typed (#13969 review M1).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.user_management.dependencies import get_current_user, require_org_context
+from autobot_shared.singleton_factory import lazy_singleton
+from llc.deps import assert_company_access
+from user_management.database import get_async_session
+from user_management.services import TenantContext
+
+from ..models.enums import RoleHolderType
+from ..services.role import RoleService
+from ..services.role_assignment import RoleAssignmentService
+from ..services.authz import NotAuthorisedError
+from ..services.role_permission import RolePermissionService
+from ..services.role_workflow import RoleWorkflowService
+
+router = APIRouter(prefix="/roles", tags=["llc-roles"])
+
+_get_roles = lazy_singleton(RoleService)
+_get_holders = lazy_singleton(RoleAssignmentService)
+_get_permissions = lazy_singleton(RolePermissionService)
+_get_workflows = lazy_singleton(RoleWorkflowService)
+
+_NAME_MAX = 100  # matches Role.name = String(100)
+_DESCRIPTION_MAX = 2000
+
+
+def _actor_id(current_user: dict) -> uuid.UUID:
+    """The acting user, from the session — never from the body or query."""
+    raw = current_user.get("id") or current_user.get("user_id")
+    return uuid.UUID(str(raw))
+
+
+class RoleCreate(BaseModel):
+    name: str = Field(..., min_length=1, max_length=_NAME_MAX)
+    description: Optional[str] = Field(None, max_length=_DESCRIPTION_MAX)
+
+
+class RoleUpdate(BaseModel):
+    name: Optional[str] = Field(None, min_length=1, max_length=_NAME_MAX)
+    description: Optional[str] = Field(None, max_length=_DESCRIPTION_MAX)
+
+
+class RoleResponse(BaseModel):
+    id: uuid.UUID
+    company_id: uuid.UUID
+    name: str
+    description: Optional[str] = None
+    is_system: bool = False
+
+
+class HolderCreate(BaseModel):
+    holder_type: RoleHolderType
+    holder_id: uuid.UUID
+
+
+class HolderResponse(BaseModel):
+    id: uuid.UUID
+    role_id: uuid.UUID
+    holder_type: str
+    holder_id: Optional[uuid.UUID] = None
+    started_at: Optional[datetime] = None
+    ended_at: Optional[datetime] = None
+
+
+class PermissionCreate(BaseModel):
+    permission: str = Field(..., min_length=1, max_length=100)
+
+
+class WorkflowAttach(BaseModel):
+    workflow_id: str = Field(..., min_length=1, max_length=255)
+
+
+def _as_role(role) -> RoleResponse:  # noqa: ANN001
+    """``org_id`` is the company — see the service docstring for why they are one column."""
+    return RoleResponse(
+        id=role.id,
+        company_id=role.org_id,
+        name=role.name,
+        description=role.description,
+        is_system=bool(role.is_system),
+    )
+
+
+def _as_holder(assignment) -> HolderResponse:  # noqa: ANN001
+    return HolderResponse(
+        id=assignment.id,
+        role_id=assignment.role_id,
+        holder_type=assignment.holder_type,
+        holder_id=assignment.holder_id,
+        started_at=assignment.started_at,
+        ended_at=assignment.ended_at,
+    )
+
+
+def _bad_request(exc: ValueError) -> HTTPException:
+    return HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+
+
+def _forbidden(exc: NotAuthorisedError) -> HTTPException:
+    """403, distinct from 400.
+
+    "You may not do this" and "what you asked makes no sense" are different
+    answers, and collapsing them hides an authorisation failure behind what
+    looks like a malformed request.
+    """
+    return HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc))
+
+
+@router.get("/{company_id}", response_model=List[RoleResponse])
+async def list_roles(
+    company_id: uuid.UUID,
+    session: AsyncSession = Depends(get_async_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
+) -> List[RoleResponse]:
+    assert_company_access(ctx, company_id)
+    return [_as_role(r) for r in await _get_roles().list_by_company(session, company_id)]
+
+
+@router.post("/{company_id}", response_model=RoleResponse, status_code=status.HTTP_201_CREATED)
+async def create_role(
+    company_id: uuid.UUID,
+    payload: RoleCreate,
+    session: AsyncSession = Depends(get_async_session),
+    current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
+) -> RoleResponse:
+    assert_company_access(ctx, company_id)
+    try:
+        role = await _get_roles().create(
+            session,
+            company_id=company_id,
+            name=payload.name,
+            description=payload.description,
+            actor_user_id=_actor_id(current_user),
+        )
+    except NotAuthorisedError as exc:
+        raise _forbidden(exc) from exc
+    except ValueError as exc:
+        raise _bad_request(exc) from exc
+    await session.commit()
+    return _as_role(role)
+
+
+@router.patch("/{company_id}/{role_id}", response_model=RoleResponse)
+async def update_role(
+    company_id: uuid.UUID,
+    role_id: uuid.UUID,
+    payload: RoleUpdate,
+    session: AsyncSession = Depends(get_async_session),
+    current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
+) -> RoleResponse:
+    assert_company_access(ctx, company_id)
+    fields = payload.model_dump(exclude_unset=True)
+    try:
+        role = await _get_roles().update(session, company_id, role_id, actor_user_id=_actor_id(current_user), **fields)
+    except NotAuthorisedError as exc:
+        raise _forbidden(exc) from exc
+    except ValueError as exc:
+        raise _bad_request(exc) from exc
+    if role is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Role not found")
+    await session.commit()
+    return _as_role(role)
+
+
+@router.delete("/{company_id}/{role_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_role(
+    company_id: uuid.UUID,
+    role_id: uuid.UUID,
+    session: AsyncSession = Depends(get_async_session),
+    current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
+) -> None:
+    assert_company_access(ctx, company_id)
+    try:
+        deleted = await _get_roles().delete(session, company_id, role_id, actor_user_id=_actor_id(current_user))
+    except NotAuthorisedError as exc:
+        raise _forbidden(exc) from exc
+    except ValueError as exc:
+        raise _bad_request(exc) from exc
+    if not deleted:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Role not found")
+    await session.commit()
+
+
+@router.get("/{company_id}/{role_id}/holders", response_model=List[HolderResponse])
+async def list_holders(
+    company_id: uuid.UUID,
+    role_id: uuid.UUID,
+    include_past: bool = False,
+    session: AsyncSession = Depends(get_async_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
+) -> List[HolderResponse]:
+    """Current holders, or the full tenure history when ``include_past`` is set."""
+    assert_company_access(ctx, company_id)
+    service = _get_holders()
+    rows = (
+        await service.history(session, company_id, role_id)
+        if include_past
+        else await service.current_holders(session, company_id, role_id)
+    )
+    return [_as_holder(row) for row in rows]
+
+
+@router.post(
+    "/{company_id}/{role_id}/holders",
+    response_model=HolderResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def assign_holder(
+    company_id: uuid.UUID,
+    role_id: uuid.UUID,
+    payload: HolderCreate,
+    session: AsyncSession = Depends(get_async_session),
+    current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
+) -> HolderResponse:
+    assert_company_access(ctx, company_id)
+    try:
+        assignment = await _get_holders().assign(
+            session,
+            company_id=company_id,
+            role_id=role_id,
+            holder_type=payload.holder_type,
+            holder_id=payload.holder_id,
+            actor_user_id=_actor_id(current_user),
+        )
+    except NotAuthorisedError as exc:
+        raise _forbidden(exc) from exc
+    except ValueError as exc:
+        raise _bad_request(exc) from exc
+    await session.commit()
+    return _as_holder(assignment)
+
+
+@router.delete("/{company_id}/{role_id}/holders/{assignment_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def end_tenure(
+    company_id: uuid.UUID,
+    role_id: uuid.UUID,
+    assignment_id: uuid.UUID,
+    session: AsyncSession = Depends(get_async_session),
+    current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
+) -> None:
+    """Ends the tenure. The row survives — a DELETE here is not a row deletion."""
+    assert_company_access(ctx, company_id)
+    ended = await _get_holders().end_tenure(session, company_id, assignment_id, actor_user_id=_actor_id(current_user))
+    if ended is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Open tenure not found")
+    await session.commit()
+
+
+@router.get("/{company_id}/{role_id}/permissions", response_model=List[str])
+async def list_permissions(
+    company_id: uuid.UUID,
+    role_id: uuid.UUID,
+    session: AsyncSession = Depends(get_async_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
+) -> List[str]:
+    assert_company_access(ctx, company_id)
+    return await _get_permissions().list_for_role(session, company_id, role_id)
+
+
+@router.post("/{company_id}/{role_id}/permissions", status_code=status.HTTP_204_NO_CONTENT)
+async def grant_permission(
+    company_id: uuid.UUID,
+    role_id: uuid.UUID,
+    payload: PermissionCreate,
+    session: AsyncSession = Depends(get_async_session),
+    current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
+) -> None:
+    """Admin-only — the service enforces it, so this route cannot forget to."""
+    assert_company_access(ctx, company_id)
+    try:
+        await _get_permissions().grant(
+            session,
+            company_id=company_id,
+            role_id=role_id,
+            permission=payload.permission,
+            actor_user_id=_actor_id(current_user),
+        )
+    except NotAuthorisedError as exc:
+        raise _forbidden(exc) from exc
+    except ValueError as exc:
+        raise _bad_request(exc) from exc
+    await session.commit()
+
+
+@router.delete("/{company_id}/{role_id}/permissions/{permission}", status_code=status.HTTP_204_NO_CONTENT)
+async def revoke_permission(
+    company_id: uuid.UUID,
+    role_id: uuid.UUID,
+    permission: str,
+    session: AsyncSession = Depends(get_async_session),
+    current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
+) -> None:
+    assert_company_access(ctx, company_id)
+    try:
+        revoked = await _get_permissions().revoke(
+            session,
+            company_id=company_id,
+            role_id=role_id,
+            permission=permission,
+            actor_user_id=_actor_id(current_user),
+        )
+    except NotAuthorisedError as exc:
+        raise _forbidden(exc) from exc
+    except ValueError as exc:
+        raise _bad_request(exc) from exc
+    if not revoked:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Grant not found")
+    await session.commit()
+
+
+@router.get("/{company_id}/{role_id}/workflows", response_model=List[str])
+async def list_role_workflows(
+    company_id: uuid.UUID,
+    role_id: uuid.UUID,
+    session: AsyncSession = Depends(get_async_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
+) -> List[str]:
+    assert_company_access(ctx, company_id)
+    attached = await _get_workflows().list_for_role(session, company_id, role_id)
+    return [a.workflow_id for a in attached]
+
+
+@router.post("/{company_id}/{role_id}/workflows", status_code=status.HTTP_204_NO_CONTENT)
+async def attach_workflow(
+    company_id: uuid.UUID,
+    role_id: uuid.UUID,
+    payload: WorkflowAttach,
+    session: AsyncSession = Depends(get_async_session),
+    current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
+) -> None:
+    assert_company_access(ctx, company_id)
+    try:
+        await _get_workflows().attach(
+            session,
+            company_id=company_id,
+            role_id=role_id,
+            workflow_id=payload.workflow_id,
+            actor_user_id=_actor_id(current_user),
+        )
+    except NotAuthorisedError as exc:
+        raise _forbidden(exc) from exc
+    except ValueError as exc:
+        raise _bad_request(exc) from exc
+    await session.commit()
+
+
+@router.delete("/{company_id}/{role_id}/workflows/{workflow_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def detach_workflow(
+    company_id: uuid.UUID,
+    role_id: uuid.UUID,
+    workflow_id: str,
+    session: AsyncSession = Depends(get_async_session),
+    current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
+) -> None:
+    assert_company_access(ctx, company_id)
+    try:
+        detached = await _get_workflows().detach(
+            session, company_id, role_id, workflow_id, actor_user_id=_actor_id(current_user)
+        )
+    except NotAuthorisedError as exc:
+        raise _forbidden(exc) from exc
+    if not detached:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Attachment not found")
+    await session.commit()

--- a/autobot-backend/llc/services/role.py
+++ b/autobot-backend/llc/services/role.py
@@ -58,6 +58,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from user_management.models.role import Role
 
 from ..models.activity import ActorType
+from .authz import require_company_admin
 from .base import LLCServiceBase
 
 
@@ -71,10 +72,11 @@ class RoleService(LLCServiceBase):
         company_id: uuid.UUID,
         name: str,
         description: Optional[str] = None,
-        actor: Optional[str] = None,
+        actor_user_id: uuid.UUID,
     ) -> Role:
         if company_id is None:
             raise ValueError("company_id is required to create a role")
+        await require_company_admin(session, company_id, actor_user_id)
         cleaned = (name or "").strip()
         if not cleaned:
             # A blank name would satisfy NOT NULL while naming nothing.
@@ -86,7 +88,7 @@ class RoleService(LLCServiceBase):
         role = Role(org_id=company_id, name=cleaned, description=description, is_system=False)
         session.add(role)
         await session.flush()
-        await self._record(session, role, "role.created", actor, {"id": str(role.id)})
+        await self._record(session, role, "role.created", str(actor_user_id), {"id": str(role.id)})
         return role
 
     async def _find_by_name(self, session: AsyncSession, company_id: uuid.UUID, name: str) -> Optional[Role]:
@@ -130,9 +132,10 @@ class RoleService(LLCServiceBase):
         company_id: uuid.UUID,
         role_id: uuid.UUID,
         *,
-        actor: Optional[str] = None,
+        actor_user_id: uuid.UUID,
         **fields: Any,
     ) -> Optional[Role]:
+        await require_company_admin(session, company_id, actor_user_id)
         role = await self.get(session, company_id, role_id)
         if role is None:
             return None
@@ -153,7 +156,7 @@ class RoleService(LLCServiceBase):
             setattr(role, key, value)
         await session.flush()
         if allowed:
-            await self._record(session, role, "role.updated", actor, allowed)
+            await self._record(session, role, "role.updated", str(actor_user_id), allowed)
         return role
 
     async def delete(
@@ -162,13 +165,14 @@ class RoleService(LLCServiceBase):
         company_id: uuid.UUID,
         role_id: uuid.UUID,
         *,
-        actor: Optional[str] = None,
+        actor_user_id: uuid.UUID,
     ) -> bool:
         """Delete a company role. Returns True when a row was actually removed.
 
         Refuses system roles. The DELETE carries the ``org_id`` predicate itself
         rather than trusting the prior read, so losing the read cannot widen it.
         """
+        await require_company_admin(session, company_id, actor_user_id)
         role = await self.get(session, company_id, role_id)
         if role is None:
             return False
@@ -184,5 +188,5 @@ class RoleService(LLCServiceBase):
         )
         deleted = bool(result.rowcount)
         if deleted:
-            await self._record(session, role, "role.deleted", actor, None)
+            await self._record(session, role, "role.deleted", str(actor_user_id), None)
         return deleted

--- a/autobot-backend/llc/services/role_permission.py
+++ b/autobot-backend/llc/services/role_permission.py
@@ -1,0 +1,236 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Access settings on a company role, and what a holder may actually do (#14221 step 3).
+
+Owner decision this implements:
+
+    role based access is above all, as admin creates the role permissions
+
+Two halves, and the second is the one that makes the first mean anything:
+
+* **Granting** — an *admin* attaches permissions to a role. Enforced here, not
+  deferred to a route, because "admin creates the role permissions" is an
+  authorisation rule and a rule that lives only in a route is one guard away
+  from not existing.
+* **Resolving** — :meth:`effective_permissions` answers *what may this holder
+  do*, as the union over the roles they hold **right now**. Ending a tenure
+  therefore withdraws access with no separate revocation step, which is the
+  property that makes offboarding safe by construction rather than by
+  remembering.
+
+**No new tables.** ``role_permissions`` and ``permissions`` already exist and
+already carry this shape; step 1's note about not forking ``roles`` applies
+identically here. Permission names are the canonical dot-style values of
+``autobot_shared.auth.permissions.Permission``. Legacy colon-style ``secrets:*``
+rows also exist in the ``permissions`` table on purpose — migration
+``20260623_062_rbac_colon_to_dot_reconcile`` reconciled the two and deliberately
+kept them for the secrets_authz policy — so this service resolves names against
+the table rather than against the enum, and neither invents nor rejects a
+vocabulary it does not own.
+
+``MembershipRole`` keeps its job: it decides who may *administer* a company.
+Role permissions decide what a holder may *do*. The owner's ordering — role
+access "above all" — is about operational authority, not about replacing the
+gate on who may grant.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any, Dict, List, Optional, Set
+
+from sqlalchemy import delete as sa_delete
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from user_management.models.role import Permission, Role, RolePermission
+
+from ..models.activity import ActorType
+from ..models.enums import RoleHolderType
+from ..models.role_assignment import LLCRoleAssignment
+from .authz import NotAuthorisedError, require_company_admin
+from .base import LLCServiceBase
+
+_HOLDER_COLUMNS = {
+    RoleHolderType.AGENT: "holder_agent_id",
+    RoleHolderType.USER: "holder_user_id",
+    RoleHolderType.CONTACT: "holder_contact_id",
+}
+
+
+class RolePermissionService(LLCServiceBase):
+    """Grants, revokes and resolves permissions attached to company roles."""
+
+    async def _require_company_role(self, session: AsyncSession, company_id: uuid.UUID, role_id: uuid.UUID) -> Role:
+        result = await session.execute(select(Role).where(Role.id == role_id, Role.org_id == company_id))
+        role = result.scalar_one_or_none()
+        if role is None:
+            raise ValueError(f"role {role_id} does not exist in company {company_id}")
+        if role.is_system:
+            raise ValueError("a system role's permissions cannot be changed through a company path")
+        return role
+
+    async def _resolve_permission(self, session: AsyncSession, name: str) -> Permission:
+        cleaned = (name or "").strip()
+        if not cleaned:
+            raise ValueError("a permission name is required")
+        result = await session.execute(select(Permission).where(Permission.name == cleaned))
+        permission = result.scalar_one_or_none()
+        if permission is None:
+            # Deliberately not auto-created: an unknown name is far more likely
+            # a typo than a new permission, and silently seeding it would make
+            # a misspelt grant look successful while granting nothing.
+            raise ValueError(f"unknown permission {cleaned!r}")
+        return permission
+
+    async def grant(
+        self,
+        session: AsyncSession,
+        *,
+        company_id: uuid.UUID,
+        role_id: uuid.UUID,
+        permission: str,
+        actor_user_id: uuid.UUID,
+    ) -> bool:
+        """Attach a permission to a role. True if newly granted, False if already held."""
+        await require_company_admin(session, company_id, actor_user_id)
+        role = await self._require_company_role(session, company_id, role_id)
+        resolved = await self._resolve_permission(session, permission)
+
+        existing = await session.execute(
+            select(RolePermission).where(
+                RolePermission.role_id == role.id,
+                RolePermission.permission_id == resolved.id,
+            )
+        )
+        if existing.scalar_one_or_none() is not None:
+            return False
+
+        session.add(RolePermission(role_id=role.id, permission_id=resolved.id))
+        await session.flush()
+        await self._record(
+            session, company_id, role, "role.permission_granted", actor_user_id, {"permission": resolved.name}
+        )
+        return True
+
+    async def revoke(
+        self,
+        session: AsyncSession,
+        *,
+        company_id: uuid.UUID,
+        role_id: uuid.UUID,
+        permission: str,
+        actor_user_id: uuid.UUID,
+    ) -> bool:
+        """Detach a permission from a role. True if a grant was actually removed."""
+        await require_company_admin(session, company_id, actor_user_id)
+        role = await self._require_company_role(session, company_id, role_id)
+        resolved = await self._resolve_permission(session, permission)
+
+        result = await session.execute(
+            sa_delete(RolePermission).where(
+                RolePermission.role_id == role.id,
+                RolePermission.permission_id == resolved.id,
+            )
+        )
+        revoked = bool(result.rowcount)
+        if revoked:
+            await self._record(
+                session, company_id, role, "role.permission_revoked", actor_user_id, {"permission": resolved.name}
+            )
+        return revoked
+
+    async def _record(
+        self,
+        session: AsyncSession,
+        company_id: uuid.UUID,
+        role: Role,
+        event_type: str,
+        actor: Optional[uuid.UUID],
+        after: Optional[Dict[str, Any]],
+    ) -> None:
+        if not self.activity_log:
+            return
+        await self.activity_log.record(
+            session=session,
+            company_id=str(company_id),
+            actor_type=ActorType.USER if actor else ActorType.SYSTEM,
+            actor_id=str(actor) if actor else None,
+            event_type=event_type,
+            entity_type="role",
+            entity_id=str(role.id),
+            after=after,
+        )
+
+    async def list_for_role(self, session: AsyncSession, company_id: uuid.UUID, role_id: uuid.UUID) -> List[str]:
+        """Permission names on this role, sorted. Empty for a role in another company."""
+        result = await session.execute(
+            select(Permission.name)
+            .join(RolePermission, RolePermission.permission_id == Permission.id)
+            .join(Role, Role.id == RolePermission.role_id)
+            .where(Role.id == role_id, Role.org_id == company_id)
+            .order_by(Permission.name)
+        )
+        return list(result.scalars().all())
+
+    async def effective_permissions(
+        self,
+        session: AsyncSession,
+        company_id: uuid.UUID,
+        holder_type: object,
+        holder_id: uuid.UUID,
+    ) -> Set[str]:
+        """What this holder may do in this company, right now.
+
+        The union over **open** tenures only. Ending a tenure withdraws the
+        access it carried, with no separate revocation — an ended tenure that
+        still granted permissions would be the exact hole offboarding exists to
+        close.
+        """
+        resolved = RoleHolderType(holder_type)
+        column = getattr(LLCRoleAssignment, _HOLDER_COLUMNS[resolved])
+        result = await session.execute(
+            select(Permission.name)
+            .join(RolePermission, RolePermission.permission_id == Permission.id)
+            .join(Role, Role.id == RolePermission.role_id)
+            .join(LLCRoleAssignment, LLCRoleAssignment.role_id == Role.id)
+            .where(
+                Role.org_id == company_id,
+                LLCRoleAssignment.company_id == company_id,
+                LLCRoleAssignment.holder_type == resolved.value,
+                column == holder_id,
+                LLCRoleAssignment.ended_at.is_(None),
+            )
+        )
+        return set(result.scalars().all())
+
+    async def holder_may(
+        self,
+        session: AsyncSession,
+        company_id: uuid.UUID,
+        holder_type: object,
+        holder_id: uuid.UUID,
+        permission: str,
+    ) -> bool:
+        """Single-permission check, expressed through :meth:`effective_permissions`.
+
+        Sharing the resolver rather than writing a second query keeps the two
+        from drifting apart — a narrower fast path is how "may" and "may not"
+        start disagreeing.
+        """
+        return (permission or "").strip() in await self.effective_permissions(
+            session, company_id, holder_type, holder_id
+        )
+
+    async def roles_granting(self, session: AsyncSession, company_id: uuid.UUID, permission: str) -> List[Role]:
+        """Which roles in this company carry a permission — the audit direction."""
+        result = await session.execute(
+            select(Role)
+            .join(RolePermission, RolePermission.role_id == Role.id)
+            .join(Permission, Permission.id == RolePermission.permission_id)
+            .where(Role.org_id == company_id, Permission.name == (permission or "").strip())
+            .order_by(Role.name)
+        )
+        return list(result.scalars().all())

--- a/autobot-backend/llc/services/role_permission.py
+++ b/autobot-backend/llc/services/role_permission.py
@@ -50,7 +50,7 @@ from user_management.models.role import Permission, Role, RolePermission
 from ..models.activity import ActorType
 from ..models.enums import RoleHolderType
 from ..models.role_assignment import LLCRoleAssignment
-from .authz import NotAuthorisedError, require_company_admin
+from .authz import require_company_admin
 from .base import LLCServiceBase
 
 _HOLDER_COLUMNS = {

--- a/autobot-backend/llc/tests/test_role_assignments.py
+++ b/autobot-backend/llc/tests/test_role_assignments.py
@@ -91,7 +91,7 @@ async def _grant_admin(session_factory, company_id: uuid.UUID) -> None:  # noqa:
 async def _seed_role(session_factory, company_id: uuid.UUID, name: str) -> uuid.UUID:  # noqa: ANN001
     await _grant_admin(session_factory, company_id)
     async with session_factory() as session:
-        role = await RoleService().create(session, company_id=company_id, name=name)
+        role = await RoleService().create(session, company_id=company_id, name=name, actor_user_id=_ADMIN_USER)
         await session.commit()
         return role.id
 

--- a/autobot-backend/llc/tests/test_role_permissions.py
+++ b/autobot-backend/llc/tests/test_role_permissions.py
@@ -30,7 +30,8 @@ from llc.models.membership import LLCCompanyMembership
 from llc.models.role_assignment import LLCRoleAssignment
 from llc.services.role import RoleService
 from llc.services.role_assignment import RoleAssignmentService
-from llc.services.role_permission import NotAuthorisedError, RolePermissionService
+from llc.services.authz import NotAuthorisedError
+from llc.services.role_permission import RolePermissionService
 
 # Registers the SQLite compile shims for postgresql.JSONB / postgresql.UUID.
 from llc.tests import _e2e_harness as harness

--- a/autobot-backend/llc/tests/test_role_permissions.py
+++ b/autobot-backend/llc/tests/test_role_permissions.py
@@ -28,9 +28,9 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from llc.models.enums import MembershipRole, RoleHolderType
 from llc.models.membership import LLCCompanyMembership
 from llc.models.role_assignment import LLCRoleAssignment
+from llc.services.authz import NotAuthorisedError
 from llc.services.role import RoleService
 from llc.services.role_assignment import RoleAssignmentService
-from llc.services.authz import NotAuthorisedError
 from llc.services.role_permission import RolePermissionService
 
 # Registers the SQLite compile shims for postgresql.JSONB / postgresql.UUID.

--- a/autobot-backend/llc/tests/test_role_permissions.py
+++ b/autobot-backend/llc/tests/test_role_permissions.py
@@ -1,0 +1,508 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Role access settings and effective-permission resolution (#14221 step 3).
+
+Two tests carry the weight:
+
+``test_ending_a_tenure_withdraws_the_permissions_it_carried`` — the property
+that makes offboarding safe by construction. If effective permissions were
+resolved from *any* tenure rather than open ones, a departed holder would keep
+every permission their role carried, and nothing else in this suite would
+notice.
+
+``test_a_plain_member_cannot_grant`` — the owner's rule, "admin creates the role
+permissions". A grant path that authorises nothing looks identical to one that
+authorises correctly until someone who should not have access uses it.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import AsyncIterator
+
+import pytest
+import pytest_asyncio
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from llc.models.enums import MembershipRole, RoleHolderType
+from llc.models.membership import LLCCompanyMembership
+from llc.models.role_assignment import LLCRoleAssignment
+from llc.services.role import RoleService
+from llc.services.role_assignment import RoleAssignmentService
+from llc.services.role_permission import NotAuthorisedError, RolePermissionService
+
+# Registers the SQLite compile shims for postgresql.JSONB / postgresql.UUID.
+from llc.tests import _e2e_harness as harness
+from user_management.models.base import Base
+from user_management.models.role import Permission, Role, RolePermission
+
+_PERM_READ = "knowledge.read"
+_PERM_WRITE = "knowledge.write"
+
+
+@pytest_asyncio.fixture
+async def session_factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = create_async_engine(  # canonical: ignore py-adhoc-db-engine (test-local engine)
+        "sqlite+aiosqlite:///:memory:"
+    )
+    tables = [
+        Role.__table__,
+        Permission.__table__,
+        RolePermission.__table__,
+        LLCRoleAssignment.__table__,
+        LLCCompanyMembership.__table__,
+    ]
+    for table in tables:
+        harness._scrub_pg_server_defaults(table)
+        harness._clientside_timestamps(table)
+    async with engine.begin() as conn:
+        await conn.run_sync(lambda c: Base.metadata.create_all(c, tables=tables))
+    factory = async_sessionmaker(  # canonical: ignore py-adhoc-db-engine (test-local factory)
+        engine, expire_on_commit=False, class_=AsyncSession
+    )
+    async with factory() as session:
+        # resource/action are NOT NULL and are split out of the dot-style name,
+        # matching how SYSTEM_PERMISSIONS seeds real rows: (name, resource,
+        # action, description).
+        for name in (_PERM_READ, _PERM_WRITE):
+            resource, action = name.split(".", 1)
+            session.add(Permission(name=name, resource=resource, action=action, description=f"{action} {resource}"))
+        await session.commit()
+    yield factory
+    await engine.dispose()
+
+
+async def _seed_admin(session_factory, company_id: uuid.UUID, role=MembershipRole.ADMIN) -> uuid.UUID:  # noqa: ANN001
+    user_id = uuid.uuid4()
+    async with session_factory() as session:
+        session.add(LLCCompanyMembership(id=uuid.uuid4(), company_id=company_id, user_id=user_id, role=role.value))
+        await session.commit()
+    return user_id
+
+
+#: Role CRUD is admin-gated too, so seeding a role needs an admin.
+_ADMIN_USER = uuid.uuid4()
+
+
+async def _grant_admin(session_factory, company_id: uuid.UUID) -> None:  # noqa: ANN001
+    async with session_factory() as session:
+        existing = await session.execute(
+            sa.select(LLCCompanyMembership.id).where(
+                LLCCompanyMembership.company_id == company_id,
+                LLCCompanyMembership.user_id == _ADMIN_USER,
+            )
+        )
+        if existing.scalar_one_or_none() is not None:
+            return
+        session.add(
+            LLCCompanyMembership(
+                id=uuid.uuid4(),
+                company_id=company_id,
+                user_id=_ADMIN_USER,
+                role=MembershipRole.ADMIN.value,
+            )
+        )
+        await session.commit()
+
+
+async def _seed_role(session_factory, company_id: uuid.UUID, name: str) -> uuid.UUID:  # noqa: ANN001
+    await _grant_admin(session_factory, company_id)
+    async with session_factory() as session:
+        role = await RoleService().create(session, company_id=company_id, name=name, actor_user_id=_ADMIN_USER)
+        await session.commit()
+        return role.id
+
+
+@pytest.mark.asyncio
+async def test_ending_a_tenure_withdraws_the_permissions_it_carried(session_factory):  # noqa: ANN001
+    """Offboarding is safe by construction, not by remembering to revoke."""
+    service = RolePermissionService()
+    occupancy = RoleAssignmentService()
+    company = uuid.uuid4()
+    admin = await _seed_admin(session_factory, company)
+    role_id = await _seed_role(session_factory, company, "Head of Sales")
+    holder = uuid.uuid4()
+
+    async with session_factory() as session:
+        await service.grant(
+            session,
+            company_id=company,
+            role_id=role_id,
+            permission=_PERM_READ,
+            actor_user_id=admin,
+        )
+        tenure = await occupancy.assign(
+            session,
+            actor_user_id=_ADMIN_USER,
+            company_id=company,
+            role_id=role_id,
+            holder_type=RoleHolderType.USER,
+            holder_id=holder,
+        )
+        await session.commit()
+        tenure_id = tenure.id
+
+    async with session_factory() as session:
+        assert await service.effective_permissions(session, company, RoleHolderType.USER, holder) == {_PERM_READ}
+
+    async with session_factory() as session:
+        await occupancy.end_tenure(session, company, tenure_id, actor_user_id=_ADMIN_USER)
+        await session.commit()
+
+    async with session_factory() as session:
+        assert (
+            await service.effective_permissions(session, company, RoleHolderType.USER, holder) == set()
+        ), "a departed holder kept the permissions their role carried"
+        # The grant itself is untouched — the role keeps its access for the next holder.
+        assert await service.list_for_role(session, company, role_id) == [_PERM_READ]
+
+
+@pytest.mark.asyncio
+async def test_a_plain_member_cannot_grant(session_factory):  # noqa: ANN001
+    """ "Admin creates the role permissions" — enforced in the service."""
+    service = RolePermissionService()
+    company = uuid.uuid4()
+    member = await _seed_admin(session_factory, company, role=MembershipRole.MEMBER)
+    role_id = await _seed_role(session_factory, company, "SRE")
+
+    async with session_factory() as session:
+        with pytest.raises(NotAuthorisedError, match="may not perform this change"):
+            await service.grant(
+                session,
+                company_id=company,
+                role_id=role_id,
+                permission=_PERM_READ,
+                actor_user_id=member,
+            )
+
+    async with session_factory() as session:
+        assert await service.list_for_role(session, company, role_id) == []
+
+
+@pytest.mark.asyncio
+async def test_an_admin_of_another_company_cannot_grant_here(session_factory):  # noqa: ANN001
+    """Membership is per company — admin elsewhere grants nothing here."""
+    service = RolePermissionService()
+    company_a, company_b = uuid.uuid4(), uuid.uuid4()
+    admin_of_b = await _seed_admin(session_factory, company_b)
+    role_a = await _seed_role(session_factory, company_a, "SRE")
+
+    async with session_factory() as session:
+        with pytest.raises(NotAuthorisedError, match="not a member of company"):
+            await service.grant(
+                session,
+                company_id=company_a,
+                role_id=role_a,
+                permission=_PERM_READ,
+                actor_user_id=admin_of_b,
+            )
+
+
+@pytest.mark.asyncio
+async def test_an_owner_may_grant(session_factory):  # noqa: ANN001
+    service = RolePermissionService()
+    company = uuid.uuid4()
+    owner = await _seed_admin(session_factory, company, role=MembershipRole.OWNER)
+    role_id = await _seed_role(session_factory, company, "SRE")
+
+    async with session_factory() as session:
+        assert (
+            await service.grant(
+                session,
+                company_id=company,
+                role_id=role_id,
+                permission=_PERM_READ,
+                actor_user_id=owner,
+            )
+            is True
+        )
+        await session.commit()
+
+    async with session_factory() as session:
+        assert await service.list_for_role(session, company, role_id) == [_PERM_READ]
+
+
+@pytest.mark.asyncio
+async def test_granting_twice_is_idempotent(session_factory):  # noqa: ANN001
+    """A repeat grant reports False rather than creating a duplicate row."""
+    service = RolePermissionService()
+    company = uuid.uuid4()
+    admin = await _seed_admin(session_factory, company)
+    role_id = await _seed_role(session_factory, company, "SRE")
+
+    async with session_factory() as session:
+        assert (
+            await service.grant(
+                session,
+                company_id=company,
+                role_id=role_id,
+                permission=_PERM_READ,
+                actor_user_id=admin,
+            )
+            is True
+        )
+        await session.commit()
+
+    async with session_factory() as session:
+        assert (
+            await service.grant(
+                session,
+                company_id=company,
+                role_id=role_id,
+                permission=_PERM_READ,
+                actor_user_id=admin,
+            )
+            is False
+        )
+        await session.commit()
+
+    async with session_factory() as session:
+        assert await service.list_for_role(session, company, role_id) == [_PERM_READ]
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_permission_is_refused_not_created(session_factory):  # noqa: ANN001
+    """A typo must fail loudly, not seed a permission that grants nothing."""
+    service = RolePermissionService()
+    company = uuid.uuid4()
+    admin = await _seed_admin(session_factory, company)
+    role_id = await _seed_role(session_factory, company, "SRE")
+
+    async with session_factory() as session:
+        with pytest.raises(ValueError, match="unknown permission"):
+            await service.grant(
+                session,
+                company_id=company,
+                role_id=role_id,
+                permission="knowledge.raed",
+                actor_user_id=admin,
+            )
+
+    async with session_factory() as session:
+        assert await service.list_for_role(session, company, role_id) == []
+
+
+@pytest.mark.asyncio
+async def test_cannot_grant_on_another_companys_role(session_factory):  # noqa: ANN001
+    service = RolePermissionService()
+    company_a, company_b = uuid.uuid4(), uuid.uuid4()
+    admin_a = await _seed_admin(session_factory, company_a)
+    role_b = await _seed_role(session_factory, company_b, "SRE")
+
+    async with session_factory() as session:
+        with pytest.raises(ValueError, match="does not exist in company"):
+            await service.grant(
+                session,
+                company_id=company_a,
+                role_id=role_b,
+                permission=_PERM_READ,
+                actor_user_id=admin_a,
+            )
+
+
+@pytest.mark.asyncio
+async def test_a_system_roles_permissions_cannot_be_changed(session_factory):  # noqa: ANN001
+    service = RolePermissionService()
+    company = uuid.uuid4()
+    admin = await _seed_admin(session_factory, company)
+
+    async with session_factory() as session:
+        system_role = Role(org_id=company, name="platform-admin", is_system=True)
+        session.add(system_role)
+        await session.commit()
+        role_id = system_role.id
+
+    async with session_factory() as session:
+        with pytest.raises(ValueError, match="system role"):
+            await service.grant(
+                session,
+                company_id=company,
+                role_id=role_id,
+                permission=_PERM_READ,
+                actor_user_id=admin,
+            )
+
+
+@pytest.mark.asyncio
+async def test_effective_permissions_union_across_several_roles(session_factory):  # noqa: ANN001
+    """A holder of two roles gets the union, deduplicated."""
+    service = RolePermissionService()
+    occupancy = RoleAssignmentService()
+    company = uuid.uuid4()
+    admin = await _seed_admin(session_factory, company)
+    sre = await _seed_role(session_factory, company, "SRE")
+    lead = await _seed_role(session_factory, company, "Team Lead")
+    holder = uuid.uuid4()
+
+    async with session_factory() as session:
+        for role_id, perm in ((sre, _PERM_READ), (lead, _PERM_READ), (lead, _PERM_WRITE)):
+            await service.grant(
+                session,
+                company_id=company,
+                role_id=role_id,
+                permission=perm,
+                actor_user_id=admin,
+            )
+        for role_id in (sre, lead):
+            await occupancy.assign(
+                session,
+                actor_user_id=_ADMIN_USER,
+                company_id=company,
+                role_id=role_id,
+                holder_type=RoleHolderType.USER,
+                holder_id=holder,
+            )
+        await session.commit()
+
+    async with session_factory() as session:
+        assert await service.effective_permissions(session, company, RoleHolderType.USER, holder) == {
+            _PERM_READ,
+            _PERM_WRITE,
+        }
+
+
+@pytest.mark.asyncio
+async def test_a_contact_holder_resolves_permissions_too(session_factory):  # noqa: ANN001
+    """Not all humans are users — a contact holding a role carries its access."""
+    service = RolePermissionService()
+    occupancy = RoleAssignmentService()
+    company = uuid.uuid4()
+    admin = await _seed_admin(session_factory, company)
+    role_id = await _seed_role(session_factory, company, "Supplier escalation contact")
+    contact = uuid.uuid4()
+
+    async with session_factory() as session:
+        await service.grant(
+            session,
+            company_id=company,
+            role_id=role_id,
+            permission=_PERM_READ,
+            actor_user_id=admin,
+        )
+        await occupancy.assign(
+            session,
+            actor_user_id=_ADMIN_USER,
+            company_id=company,
+            role_id=role_id,
+            holder_type=RoleHolderType.CONTACT,
+            holder_id=contact,
+        )
+        await session.commit()
+
+    async with session_factory() as session:
+        assert await service.holder_may(session, company, RoleHolderType.CONTACT, contact, _PERM_READ)
+        # The same id as a *user* holds nothing — the discriminator is load-bearing.
+        assert not await service.holder_may(session, company, RoleHolderType.USER, contact, _PERM_READ)
+
+
+@pytest.mark.asyncio
+async def test_effective_permissions_are_company_scoped(session_factory):  # noqa: ANN001
+    service = RolePermissionService()
+    occupancy = RoleAssignmentService()
+    company_a, company_b = uuid.uuid4(), uuid.uuid4()
+    admin_b = await _seed_admin(session_factory, company_b)
+    role_b = await _seed_role(session_factory, company_b, "SRE")
+    holder = uuid.uuid4()
+
+    async with session_factory() as session:
+        await service.grant(
+            session,
+            company_id=company_b,
+            role_id=role_b,
+            permission=_PERM_READ,
+            actor_user_id=admin_b,
+        )
+        await occupancy.assign(
+            session,
+            actor_user_id=_ADMIN_USER,
+            company_id=company_b,
+            role_id=role_b,
+            holder_type=RoleHolderType.USER,
+            holder_id=holder,
+        )
+        await session.commit()
+
+    async with session_factory() as session:
+        assert (
+            await service.effective_permissions(session, company_a, RoleHolderType.USER, holder) == set()
+        ), "permissions from another company leaked into this holder's set"
+
+
+@pytest.mark.asyncio
+async def test_revoke_removes_access_from_current_holders(session_factory):  # noqa: ANN001
+    service = RolePermissionService()
+    occupancy = RoleAssignmentService()
+    company = uuid.uuid4()
+    admin = await _seed_admin(session_factory, company)
+    role_id = await _seed_role(session_factory, company, "SRE")
+    holder = uuid.uuid4()
+
+    async with session_factory() as session:
+        await service.grant(
+            session,
+            company_id=company,
+            role_id=role_id,
+            permission=_PERM_READ,
+            actor_user_id=admin,
+        )
+        await occupancy.assign(
+            session,
+            actor_user_id=_ADMIN_USER,
+            company_id=company,
+            role_id=role_id,
+            holder_type=RoleHolderType.USER,
+            holder_id=holder,
+        )
+        await session.commit()
+
+    async with session_factory() as session:
+        assert (
+            await service.revoke(
+                session,
+                company_id=company,
+                role_id=role_id,
+                permission=_PERM_READ,
+                actor_user_id=admin,
+            )
+            is True
+        )
+        await session.commit()
+
+    async with session_factory() as session:
+        assert await service.effective_permissions(session, company, RoleHolderType.USER, holder) == set()
+
+
+@pytest.mark.asyncio
+async def test_roles_granting_is_the_audit_direction(session_factory):  # noqa: ANN001
+    """Which roles carry this permission — scoped, sorted by name."""
+    service = RolePermissionService()
+    company_a, company_b = uuid.uuid4(), uuid.uuid4()
+    admin_a = await _seed_admin(session_factory, company_a)
+    admin_b = await _seed_admin(session_factory, company_b)
+    sre = await _seed_role(session_factory, company_a, "SRE")
+    lead = await _seed_role(session_factory, company_a, "Team Lead")
+    theirs = await _seed_role(session_factory, company_b, "SRE")
+
+    async with session_factory() as session:
+        for role_id, actor in ((sre, admin_a), (lead, admin_a)):
+            await service.grant(
+                session,
+                company_id=company_a,
+                role_id=role_id,
+                permission=_PERM_READ,
+                actor_user_id=actor,
+            )
+        await service.grant(
+            session,
+            company_id=company_b,
+            role_id=theirs,
+            permission=_PERM_READ,
+            actor_user_id=admin_b,
+        )
+        await session.commit()
+
+    async with session_factory() as session:
+        found = await service.roles_granting(session, company_a, _PERM_READ)
+
+    assert [r.name for r in found] == ["SRE", "Team Lead"]

--- a/autobot-backend/llc/tests/test_role_workflows.py
+++ b/autobot-backend/llc/tests/test_role_workflows.py
@@ -28,12 +28,12 @@ import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from llc.models.enums import MembershipRole, RoleHolderType
-from llc.models.role_assignment import LLCRoleAssignment
 from llc.models.membership import LLCCompanyMembership
+from llc.models.role_assignment import LLCRoleAssignment
 from llc.models.role_workflow import LLCRoleWorkflow
+from llc.services.authz import NotAuthorisedError
 from llc.services.role import RoleService
 from llc.services.role_assignment import RoleAssignmentService
-from llc.services.authz import NotAuthorisedError
 from llc.services.role_workflow import RoleWorkflowService
 
 # Registers the SQLite compile shims for postgresql.JSONB / postgresql.UUID.

--- a/autobot-backend/llc/tests/test_role_workflows.py
+++ b/autobot-backend/llc/tests/test_role_workflows.py
@@ -28,12 +28,12 @@ import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from llc.models.enums import MembershipRole, RoleHolderType
-from llc.models.membership import LLCCompanyMembership
 from llc.models.role_assignment import LLCRoleAssignment
+from llc.models.membership import LLCCompanyMembership
 from llc.models.role_workflow import LLCRoleWorkflow
-from llc.services.authz import NotAuthorisedError
 from llc.services.role import RoleService
 from llc.services.role_assignment import RoleAssignmentService
+from llc.services.authz import NotAuthorisedError
 from llc.services.role_workflow import RoleWorkflowService
 
 # Registers the SQLite compile shims for postgresql.JSONB / postgresql.UUID.
@@ -94,7 +94,7 @@ async def _grant_admin(session_factory, company_id: uuid.UUID) -> None:  # noqa:
 async def _seed_role(session_factory, company_id: uuid.UUID, name: str) -> uuid.UUID:  # noqa: ANN001
     await _grant_admin(session_factory, company_id)
     async with session_factory() as session:
-        role = await RoleService().create(session, company_id=company_id, name=name)
+        role = await RoleService().create(session, company_id=company_id, name=name, actor_user_id=_ADMIN_USER)
         await session.commit()
         return role.id
 

--- a/autobot-backend/llc/tests/test_roles_routes_registered.py
+++ b/autobot-backend/llc/tests/test_roles_routes_registered.py
@@ -1,0 +1,94 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""The role routes are reachable, not merely defined (#14221).
+
+Steps 1-3 and 5 each shipped a service with no route, which made all four
+unreachable — a sink with no surface. This asserts the opposite defect cannot
+recur silently: a router that exists but is never ``include_router``-ed looks
+exactly like a working one from inside its own module.
+
+Asserts against the **assembled** LLC router, not against ``roles.py``, because
+importing the module proves only that the file parses.
+"""
+
+from __future__ import annotations
+
+from llc.api import router as llc_router
+
+#: The assembled router carries prefix="/llc", so mounted paths include it.
+_PREFIX = "/llc/roles"
+
+_EXPECTED = {
+    ("GET", f"{_PREFIX}/{{company_id}}"),
+    ("POST", f"{_PREFIX}/{{company_id}}"),
+    ("PATCH", f"{_PREFIX}/{{company_id}}/{{role_id}}"),
+    ("DELETE", f"{_PREFIX}/{{company_id}}/{{role_id}}"),
+    ("GET", f"{_PREFIX}/{{company_id}}/{{role_id}}/holders"),
+    ("POST", f"{_PREFIX}/{{company_id}}/{{role_id}}/holders"),
+    ("DELETE", f"{_PREFIX}/{{company_id}}/{{role_id}}/holders/{{assignment_id}}"),
+    ("GET", f"{_PREFIX}/{{company_id}}/{{role_id}}/permissions"),
+    ("POST", f"{_PREFIX}/{{company_id}}/{{role_id}}/permissions"),
+    ("DELETE", f"{_PREFIX}/{{company_id}}/{{role_id}}/permissions/{{permission}}"),
+    ("GET", f"{_PREFIX}/{{company_id}}/{{role_id}}/workflows"),
+    ("POST", f"{_PREFIX}/{{company_id}}/{{role_id}}/workflows"),
+    ("DELETE", f"{_PREFIX}/{{company_id}}/{{role_id}}/workflows/{{workflow_id}}"),
+}
+
+
+def _mounted() -> set:
+    """(method, path) pairs reachable through the assembled LLC router.
+
+    This FastAPI version defers inclusion: ``router.routes`` holds
+    ``_IncludedRouter`` wrappers with no ``.path``, and the real routes live on
+    ``.original_router.routes``. Walking the top level alone finds one route out
+    of thirty-eight and reads as "nothing is mounted".
+
+    Same idiom as ``api/codebase_analytics/endpoints/impact_endpoint_test.py``
+    and ``api/self_capabilities_integration_test.py``, which both document this.
+    The sub-router paths are relative to the parent, so the ``/llc`` prefix is
+    prepended here rather than expected on the route itself.
+    """
+    found = set()
+    for included in llc_router.routes:
+        original = getattr(included, "original_router", None)
+        subroutes = original.routes if original is not None else [included]
+        for sub in subroutes:
+            path = getattr(sub, "path", None)
+            if not path:
+                continue
+            for method in getattr(sub, "methods", set()) or set():
+                found.add((method, f"{llc_router.prefix}{path}"))
+    return found
+
+
+def test_every_role_route_is_mounted_on_the_llc_router() -> None:
+    missing = _EXPECTED - _mounted()
+    assert not missing, f"defined but never reachable: {sorted(missing)}"
+
+
+def test_role_routes_require_authentication() -> None:
+    """Every role route carries the auth dependencies.
+
+    #14168 recorded unguarded ``/work-items`` routes; the cheapest guard against
+    repeating that is asserting the dependency is present rather than trusting
+    that each handler remembered it.
+    """
+    unguarded = []
+    checked = 0
+    for included in llc_router.routes:
+        original = getattr(included, "original_router", None)
+        for sub in original.routes if original is not None else []:
+            path = f"{llc_router.prefix}{getattr(sub, 'path', '')}"
+            if not path.startswith(_PREFIX):
+                continue
+            checked += 1
+            dependant = getattr(sub, "dependant", None)
+            names = {getattr(dep.call, "__name__", "") for dep in getattr(dependant, "dependencies", [])}
+            if "get_current_user" not in names or "require_org_context" not in names:
+                unguarded.append((sorted(getattr(sub, "methods", []) or []), path, sorted(names)))
+    # Presence check first: with a wrong prefix this loop matches nothing and
+    # the assertion below passes while having verified nothing at all — an
+    # empty result reading as a clean result, which is how the first draft of
+    # this file "passed".
+    assert checked == len(_EXPECTED), f"expected {len(_EXPECTED)} role routes to inspect, saw {checked}"
+    assert not unguarded, f"role routes missing auth/tenant dependencies: {unguarded}"

--- a/autobot-backend/llc/tests/test_roles_scoping.py
+++ b/autobot-backend/llc/tests/test_roles_scoping.py
@@ -20,8 +20,12 @@ from typing import AsyncIterator
 
 import pytest
 import pytest_asyncio
+import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
+from llc.models.enums import MembershipRole
+from llc.models.membership import LLCCompanyMembership
+from llc.services.authz import NotAuthorisedError
 from llc.services.role import RoleService
 
 # Registers the SQLite compile shims for postgresql.JSONB / postgresql.UUID.
@@ -35,7 +39,7 @@ async def session_factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
     engine = create_async_engine(  # canonical: ignore py-adhoc-db-engine (test-local engine)
         "sqlite+aiosqlite:///:memory:"
     )
-    tables = [Role.__table__]
+    tables = [Role.__table__, LLCCompanyMembership.__table__]
     for table in tables:
         harness._scrub_pg_server_defaults(table)
         harness._clientside_timestamps(table)
@@ -50,16 +54,45 @@ async def session_factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
     await engine.dispose()
 
 
+#: Role CRUD is admin-gated (#14324 security review); this suite acts as one
+#: admin. Who may mutate is tested separately, below and in
+#: ``test_role_permissions.py``.
+_ADMIN_USER = uuid.uuid4()
+
+
+async def _grant_admin(session_factory, company_id: uuid.UUID) -> None:  # noqa: ANN001
+    async with session_factory() as session:
+        existing = await session.execute(
+            sa.select(LLCCompanyMembership.id).where(
+                LLCCompanyMembership.company_id == company_id,
+                LLCCompanyMembership.user_id == _ADMIN_USER,
+            )
+        )
+        if existing.scalar_one_or_none() is not None:
+            return
+        session.add(
+            LLCCompanyMembership(
+                id=uuid.uuid4(),
+                company_id=company_id,
+                user_id=_ADMIN_USER,
+                role=MembershipRole.ADMIN.value,
+            )
+        )
+        await session.commit()
+
+
 @pytest.mark.asyncio
 async def test_company_a_never_sees_company_bs_roles(session_factory):  # noqa: ANN001
     """The reproduction: deleting the org_id predicate must fail this."""
     service = RoleService()
     company_a, company_b = uuid.uuid4(), uuid.uuid4()
+    await _grant_admin(session_factory, company_a)
+    await _grant_admin(session_factory, company_b)
 
     async with session_factory() as session:
-        await service.create(session, company_id=company_a, name="Head of Sales")
-        await service.create(session, company_id=company_b, name="SRE")
-        await service.create(session, company_id=company_b, name="Marketing Lead")
+        await service.create(session, company_id=company_a, name="Head of Sales", actor_user_id=_ADMIN_USER)
+        await service.create(session, company_id=company_b, name="SRE", actor_user_id=_ADMIN_USER)
+        await service.create(session, company_id=company_b, name="Marketing Lead", actor_user_id=_ADMIN_USER)
         await session.commit()
 
     async with session_factory() as session:
@@ -79,10 +112,12 @@ async def test_a_user_can_hold_a_different_role_in_each_company(session_factory)
     """
     service = RoleService()
     marketing, it_company = uuid.uuid4(), uuid.uuid4()
+    await _grant_admin(session_factory, marketing)
+    await _grant_admin(session_factory, it_company)
 
     async with session_factory() as session:
-        sales = await service.create(session, company_id=marketing, name="Head of Sales")
-        sre = await service.create(session, company_id=it_company, name="SRE")
+        sales = await service.create(session, company_id=marketing, name="Head of Sales", actor_user_id=_ADMIN_USER)
+        sre = await service.create(session, company_id=it_company, name="SRE", actor_user_id=_ADMIN_USER)
         await session.commit()
 
     assert sales.id != sre.id
@@ -94,10 +129,11 @@ async def test_a_system_role_is_invisible_to_a_company(session_factory):  # noqa
     """System roles have org_id NULL and must never appear in a company's list."""
     service = RoleService()
     company = uuid.uuid4()
+    await _grant_admin(session_factory, company)
 
     async with session_factory() as session:
         session.add(Role(org_id=None, name="admin", is_system=True))
-        await service.create(session, company_id=company, name="Head of Sales")
+        await service.create(session, company_id=company, name="Head of Sales", actor_user_id=_ADMIN_USER)
         await session.commit()
 
     async with session_factory() as session:
@@ -115,6 +151,7 @@ async def test_a_system_role_cannot_be_deleted_through_a_company_path(session_fa
     """
     service = RoleService()
     company = uuid.uuid4()
+    await _grant_admin(session_factory, company)
 
     async with session_factory() as session:
         system_role = Role(org_id=company, name="platform-admin", is_system=True)
@@ -124,9 +161,9 @@ async def test_a_system_role_cannot_be_deleted_through_a_company_path(session_fa
 
     async with session_factory() as session:
         with pytest.raises(ValueError, match="system role cannot be deleted"):
-            await service.delete(session, company, role_id)
+            await service.delete(session, company, role_id, actor_user_id=_ADMIN_USER)
         with pytest.raises(ValueError, match="system role cannot be modified"):
-            await service.update(session, company, role_id, name="hijacked")
+            await service.update(session, company, role_id, name="hijacked", actor_user_id=_ADMIN_USER)
 
     async with session_factory() as session:
         assert await service.get(session, company, role_id) is not None
@@ -136,9 +173,11 @@ async def test_a_system_role_cannot_be_deleted_through_a_company_path(session_fa
 async def test_get_is_scoped_so_another_companys_role_is_invisible(session_factory):  # noqa: ANN001
     service = RoleService()
     company_a, company_b = uuid.uuid4(), uuid.uuid4()
+    await _grant_admin(session_factory, company_a)
+    await _grant_admin(session_factory, company_b)
 
     async with session_factory() as session:
-        theirs = await service.create(session, company_id=company_b, name="SRE")
+        theirs = await service.create(session, company_id=company_b, name="SRE", actor_user_id=_ADMIN_USER)
         await session.commit()
         theirs_id = theirs.id
 
@@ -152,14 +191,16 @@ async def test_get_is_scoped_so_another_companys_role_is_invisible(session_facto
 async def test_delete_never_removes_another_companys_role(session_factory):  # noqa: ANN001
     service = RoleService()
     company_a, company_b = uuid.uuid4(), uuid.uuid4()
+    await _grant_admin(session_factory, company_a)
+    await _grant_admin(session_factory, company_b)
 
     async with session_factory() as session:
-        theirs = await service.create(session, company_id=company_b, name="SRE")
+        theirs = await service.create(session, company_id=company_b, name="SRE", actor_user_id=_ADMIN_USER)
         await session.commit()
         theirs_id = theirs.id
 
     async with session_factory() as session:
-        assert await service.delete(session, company_a, theirs_id) is False
+        assert await service.delete(session, company_a, theirs_id, actor_user_id=_ADMIN_USER) is False
         await session.commit()
 
     async with session_factory() as session:
@@ -171,10 +212,12 @@ async def test_two_companies_may_each_have_the_same_role_name(session_factory): 
     """Uniqueness is per company — a 'Head of Sales' in each is two roles."""
     service = RoleService()
     company_a, company_b = uuid.uuid4(), uuid.uuid4()
+    await _grant_admin(session_factory, company_a)
+    await _grant_admin(session_factory, company_b)
 
     async with session_factory() as session:
-        a_role = await service.create(session, company_id=company_a, name="Head of Sales")
-        b_role = await service.create(session, company_id=company_b, name="Head of Sales")
+        a_role = await service.create(session, company_id=company_a, name="Head of Sales", actor_user_id=_ADMIN_USER)
+        b_role = await service.create(session, company_id=company_b, name="Head of Sales", actor_user_id=_ADMIN_USER)
         await session.commit()
 
     assert a_role.id != b_role.id
@@ -189,22 +232,28 @@ async def test_a_duplicate_name_within_one_company_is_refused(session_factory): 
     """
     service = RoleService()
     company = uuid.uuid4()
+    await _grant_admin(session_factory, company)
 
     async with session_factory() as session:
-        await service.create(session, company_id=company, name="Head of Sales")
+        await service.create(session, company_id=company, name="Head of Sales", actor_user_id=_ADMIN_USER)
         await session.commit()
 
     async with session_factory() as session:
         with pytest.raises(ValueError, match="already exists"):
-            await service.create(session, company_id=company, name="  Head of Sales  ")
+            await service.create(session, company_id=company, name="  Head of Sales  ", actor_user_id=_ADMIN_USER)
 
 
 @pytest.mark.asyncio
 async def test_a_blank_name_is_rejected(session_factory):  # noqa: ANN001
     service = RoleService()
+    company = uuid.uuid4()
+    # Authorisation runs before input validation, so an unauthorised caller
+    # cannot probe validation behaviour. That ordering is deliberate, and it is
+    # why this test needs a real admin rather than an ad-hoc company id.
+    await _grant_admin(session_factory, company)
     async with session_factory() as session:
         with pytest.raises(ValueError, match="name is required"):
-            await service.create(session, company_id=uuid.uuid4(), name="   ")
+            await service.create(session, company_id=company, name="   ", actor_user_id=_ADMIN_USER)
 
 
 @pytest.mark.asyncio
@@ -212,22 +261,26 @@ async def test_create_requires_a_company(session_factory):  # noqa: ANN001
     service = RoleService()
     async with session_factory() as session:
         with pytest.raises(ValueError, match="company_id is required"):
-            await service.create(session, company_id=None, name="Orphan")
+            await service.create(session, company_id=None, name="Orphan", actor_user_id=_ADMIN_USER)
 
 
 @pytest.mark.asyncio
 async def test_update_is_scoped_and_still_trims(session_factory):  # noqa: ANN001
     service = RoleService()
     company_a, company_b = uuid.uuid4(), uuid.uuid4()
+    await _grant_admin(session_factory, company_a)
+    await _grant_admin(session_factory, company_b)
 
     async with session_factory() as session:
-        theirs = await service.create(session, company_id=company_b, name="SRE")
+        theirs = await service.create(session, company_id=company_b, name="SRE", actor_user_id=_ADMIN_USER)
         await session.commit()
         theirs_id = theirs.id
 
     async with session_factory() as session:
-        assert await service.update(session, company_a, theirs_id, name="Hijacked") is None
-        updated = await service.update(session, company_b, theirs_id, name="  Platform SRE  ")
+        assert await service.update(session, company_a, theirs_id, name="Hijacked", actor_user_id=_ADMIN_USER) is None
+        updated = await service.update(
+            session, company_b, theirs_id, name="  Platform SRE  ", actor_user_id=_ADMIN_USER
+        )
         assert updated is not None and updated.name == "Platform SRE"
         await session.commit()
 
@@ -252,11 +305,12 @@ async def test_mutations_emit_activity_log_events(session_factory):  # noqa: ANN
     log = _RecordingActivityLog()
     service = RoleService(activity_log=log)
     company = uuid.uuid4()
+    await _grant_admin(session_factory, company)
 
     async with session_factory() as session:
-        role = await service.create(session, company_id=company, name="SRE", actor="u1")
-        await service.update(session, company, role.id, name="Platform SRE", actor="u1")
-        assert await service.delete(session, company, role.id, actor="u1") is True
+        role = await service.create(session, company_id=company, name="SRE", actor_user_id=_ADMIN_USER)
+        await service.update(session, company, role.id, name="Platform SRE", actor_user_id=_ADMIN_USER)
+        assert await service.delete(session, company, role.id, actor_user_id=_ADMIN_USER) is True
         await session.commit()
 
     assert [e["event_type"] for e in log.events] == [
@@ -274,14 +328,57 @@ async def test_a_scoped_out_delete_emits_nothing(session_factory):  # noqa: ANN0
     log = _RecordingActivityLog()
     service = RoleService(activity_log=log)
     company_a, company_b = uuid.uuid4(), uuid.uuid4()
+    await _grant_admin(session_factory, company_a)
+    await _grant_admin(session_factory, company_b)
 
     async with session_factory() as session:
-        role = await service.create(session, company_id=company_b, name="SRE")
+        role = await service.create(session, company_id=company_b, name="SRE", actor_user_id=_ADMIN_USER)
         await session.commit()
         log.events.clear()
 
     async with session_factory() as session:
-        assert await service.delete(session, company_a, role.id) is False
+        assert await service.delete(session, company_a, role.id, actor_user_id=_ADMIN_USER) is False
         await session.commit()
 
     assert log.events == []
+
+
+@pytest.mark.asyncio
+async def test_a_member_cannot_create_or_delete_a_role(session_factory):  # noqa: ANN001
+    """Role CRUD is admin-only (#14324 security review).
+
+    Deleting a role destroys its permission grants and every current holder's
+    access through it, so this is an availability and integrity boundary, not
+    only a tidiness one.
+    """
+    service = RoleService()
+    company = uuid.uuid4()
+    await _grant_admin(session_factory, company)
+    member = uuid.uuid4()
+    async with session_factory() as session:
+        session.add(
+            LLCCompanyMembership(
+                id=uuid.uuid4(),
+                company_id=company,
+                user_id=member,
+                role=MembershipRole.MEMBER.value,
+            )
+        )
+        await session.commit()
+
+    async with session_factory() as session:
+        existing = await service.create(session, company_id=company, name="SRE", actor_user_id=_ADMIN_USER)
+        await session.commit()
+        role_id = existing.id
+
+    async with session_factory() as session:
+        with pytest.raises(NotAuthorisedError, match="may not perform this change"):
+            await service.create(session, company_id=company, name="Invented", actor_user_id=member)
+        with pytest.raises(NotAuthorisedError):
+            await service.delete(session, company, role_id, actor_user_id=member)
+        with pytest.raises(NotAuthorisedError):
+            await service.update(session, company, role_id, name="Hijacked", actor_user_id=member)
+
+    async with session_factory() as session:
+        remaining = await service.list_by_company(session, company)
+    assert [r.name for r in remaining] == ["SRE"]

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -50118,6 +50118,156 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/llc/roles/{company_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Roles */
+        get: operations["list_roles_api_llc_roles__company_id__get"];
+        put?: never;
+        /** Create Role */
+        post: operations["create_role_api_llc_roles__company_id__post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/llc/roles/{company_id}/{role_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete Role */
+        delete: operations["delete_role_api_llc_roles__company_id___role_id__delete"];
+        options?: never;
+        head?: never;
+        /** Update Role */
+        patch: operations["update_role_api_llc_roles__company_id___role_id__patch"];
+        trace?: never;
+    };
+    "/api/llc/roles/{company_id}/{role_id}/holders": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Holders
+         * @description Current holders, or the full tenure history when ``include_past`` is set.
+         */
+        get: operations["list_holders_api_llc_roles__company_id___role_id__holders_get"];
+        put?: never;
+        /** Assign Holder */
+        post: operations["assign_holder_api_llc_roles__company_id___role_id__holders_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/llc/roles/{company_id}/{role_id}/holders/{assignment_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * End Tenure
+         * @description Ends the tenure. The row survives — a DELETE here is not a row deletion.
+         */
+        delete: operations["end_tenure_api_llc_roles__company_id___role_id__holders__assignment_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/llc/roles/{company_id}/{role_id}/permissions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Permissions */
+        get: operations["list_permissions_api_llc_roles__company_id___role_id__permissions_get"];
+        put?: never;
+        /**
+         * Grant Permission
+         * @description Admin-only — the service enforces it, so this route cannot forget to.
+         */
+        post: operations["grant_permission_api_llc_roles__company_id___role_id__permissions_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/llc/roles/{company_id}/{role_id}/permissions/{permission}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Revoke Permission */
+        delete: operations["revoke_permission_api_llc_roles__company_id___role_id__permissions__permission__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/llc/roles/{company_id}/{role_id}/workflows": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Role Workflows */
+        get: operations["list_role_workflows_api_llc_roles__company_id___role_id__workflows_get"];
+        put?: never;
+        /** Attach Workflow */
+        post: operations["attach_workflow_api_llc_roles__company_id___role_id__workflows_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/llc/roles/{company_id}/{role_id}/workflows/{workflow_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Detach Workflow */
+        delete: operations["detach_workflow_api_llc_roles__company_id___role_id__workflows__workflow_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/llc/companies/{company_id}/portfolios": {
         parameters: {
             query?: never;
@@ -75573,6 +75723,40 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** HolderCreate */
+        HolderCreate: {
+            holder_type: components["schemas"]["RoleHolderType"];
+            /**
+             * Holder Id
+             * Format: uuid
+             */
+            holder_id: string;
+        } & {
+            [key: string]: unknown;
+        };
+        /** HolderResponse */
+        HolderResponse: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /**
+             * Role Id
+             * Format: uuid
+             */
+            role_id: string;
+            /** Holder Type */
+            holder_type: string;
+            /** Holder Id */
+            holder_id?: string | null;
+            /** Started At */
+            started_at?: string | null;
+            /** Ended At */
+            ended_at?: string | null;
+        } & {
+            [key: string]: unknown;
+        };
         /**
          * HookConfig
          * @description Configuration for pre-commit hooks.
@@ -85942,6 +86126,13 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** PermissionCreate */
+        PermissionCreate: {
+            /** Permission */
+            permission: string;
+        } & {
+            [key: string]: unknown;
+        };
         /**
          * PermissionLevel
          * @description Collaboration permission levels.
@@ -89614,25 +89805,54 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
-        /**
-         * RoleResponse
-         * @description Role information in responses.
-         */
-        RoleResponse: {
-            /**
-             * Id
-             * Format: uuid
-             */
-            id: string;
+        /** RoleCreate */
+        RoleCreate: {
             /** Name */
             name: string;
             /** Description */
             description?: string | null;
-            /**
-             * Is System
-             * @default false
-             */
-            is_system: boolean;
+        } & {
+            [key: string]: unknown;
+        };
+        /**
+         * RoleHolderType
+         * @description Who currently holds a role (#14221 step 2).
+         *
+         *     A **different axis** from :class:`AssigneeType`, not a wider version of it.
+         *     ``AssigneeType`` answers "who is working this work item"; this answers "who
+         *     occupies this role". They overlap on two members and diverge on the third,
+         *     which is exactly the shape that has bitten this module before — so:
+         *
+         *     **Never compare a member of this enum with a member of another.** Both are
+         *     ``str``-mixin enums, so ``RoleHolderType.AGENT == AssigneeType.AGENT`` is
+         *     silently ``True`` while a ``CONTACT`` holder compares equal to nothing at
+         *     all. That silent-True/silent-False pair is #13954's defect exactly.
+         *
+         *     ``CONTACT`` is why this is a separate enum rather than a new member on
+         *     ``AssigneeType``. Owner framing:
+         *
+         *         user = human, but not all humans are users — they could be part of a
+         *         process, like a contact person you send email to or call
+         *
+         *     A contact can therefore *hold a role* ("external accountant", "supplier
+         *     escalation contact") without ever being a user. Adding ``CONTACT`` to
+         *     ``AssigneeType`` instead would silently widen what a **work item** may be
+         *     assigned to, since assignment validates by enum membership — a data-model
+         *     change smuggled in as a vocabulary edit.
+         *
+         *     Minting a new vocabulary is deliberate and was checked first: no enum in
+         *     this codebase declares a ``contact`` member at all, so there was nothing to
+         *     reuse. Registered in #14263's inventory rather than left to become another
+         *     unowned status vocabulary.
+         * @enum {string}
+         */
+        RoleHolderType: "user" | "agent" | "contact";
+        /** RoleUpdate */
+        RoleUpdate: {
+            /** Name */
+            name?: string | null;
+            /** Description */
+            description?: string | null;
         } & {
             [key: string]: unknown;
         };
@@ -98444,7 +98664,7 @@ export interface components {
                 [key: string]: unknown;
             };
             /** Roles */
-            roles?: components["schemas"]["RoleResponse"][];
+            roles?: components["schemas"]["autobot_shared__user_management__schemas__user__RoleResponse"][];
             /** Last Login At */
             last_login_at?: string | null;
             /**
@@ -100876,6 +101096,13 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** WorkflowAttach */
+        WorkflowAttach: {
+            /** Workflow Id */
+            workflow_id: string;
+        } & {
+            [key: string]: unknown;
+        };
         /**
          * WorkflowAuditLogEntry
          * @description Serialised workflow audit log entry.
@@ -101933,6 +102160,28 @@ export interface components {
             [key: string]: unknown;
         };
         /**
+         * RoleResponse
+         * @description Role information in responses.
+         */
+        autobot_shared__user_management__schemas__user__RoleResponse: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /** Name */
+            name: string;
+            /** Description */
+            description?: string | null;
+            /**
+             * Is System
+             * @default false
+             */
+            is_system: boolean;
+        } & {
+            [key: string]: unknown;
+        };
+        /**
          * ClearAllResponse
          * @description Shape of ``POST /api/knowledge_base/clear_all``.
          *
@@ -102016,6 +102265,30 @@ export interface components {
              * Format: date-time
              */
             updated_at: string;
+        } & {
+            [key: string]: unknown;
+        };
+        /** RoleResponse */
+        llc__api__roles__RoleResponse: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /**
+             * Company Id
+             * Format: uuid
+             */
+            company_id: string;
+            /** Name */
+            name: string;
+            /** Description */
+            description?: string | null;
+            /**
+             * Is System
+             * @default false
+             */
+            is_system: boolean;
         } & {
             [key: string]: unknown;
         };
@@ -168988,6 +169261,433 @@ export interface operations {
                         [key: string]: unknown;
                     };
                 };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_roles_api_llc_roles__company_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                company_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["llc__api__roles__RoleResponse"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_role_api_llc_roles__company_id__post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                company_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RoleCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["llc__api__roles__RoleResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_role_api_llc_roles__company_id___role_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                company_id: string;
+                role_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_role_api_llc_roles__company_id___role_id__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                company_id: string;
+                role_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RoleUpdate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["llc__api__roles__RoleResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_holders_api_llc_roles__company_id___role_id__holders_get: {
+        parameters: {
+            query?: {
+                include_past?: boolean;
+            };
+            header?: never;
+            path: {
+                company_id: string;
+                role_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HolderResponse"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    assign_holder_api_llc_roles__company_id___role_id__holders_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                company_id: string;
+                role_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["HolderCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HolderResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    end_tenure_api_llc_roles__company_id___role_id__holders__assignment_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                company_id: string;
+                role_id: string;
+                assignment_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_permissions_api_llc_roles__company_id___role_id__permissions_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                company_id: string;
+                role_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": string[];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    grant_permission_api_llc_roles__company_id___role_id__permissions_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                company_id: string;
+                role_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PermissionCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    revoke_permission_api_llc_roles__company_id___role_id__permissions__permission__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                company_id: string;
+                role_id: string;
+                permission: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_role_workflows_api_llc_roles__company_id___role_id__workflows_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                company_id: string;
+                role_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": string[];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    attach_workflow_api_llc_roles__company_id___role_id__workflows_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                company_id: string;
+                role_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["WorkflowAttach"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    detach_workflow_api_llc_roles__company_id___role_id__workflows__workflow_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                company_id: string;
+                role_id: string;
+                workflow_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description Validation Error */
             422: {


### PR DESCRIPTION
Part of #14221 (step 3 of 6). **Stacked on #14313 → #14303 → #14301.**

## Thinking Path

Owner decision this implements:

> role based access is above all, as admin creates the role permissions

Two halves, and the second is what makes the first mean anything:

- **Granting** — an admin attaches permissions to a role.
- **Resolving** — `effective_permissions()` answers *what may this holder do*, as the union over the
  roles they hold **right now**.

Because resolution reads only **open** tenures, ending a tenure withdraws access with no separate
revocation step. Offboarding is safe by construction rather than by remembering — which matters,
because the failure mode of the alternative is silent: a departed holder keeps working.

**No new tables.** `role_permissions` and `permissions` already existed. After the `llc_roles` fork
in step 1, checking for existing infrastructure first was the obvious lesson to actually apply.

## Where The Gate Lives

`_require_admin` is enforced **in the service**, not deferred to a route. "Admin creates the role
permissions" is an authorisation rule, and a rule that lives only in a route is one new caller away
from not existing.

Membership is per `(company, user)`, so an admin of another company is refused here — the
"not all users have access to all Company OS companies" requirement, applied to the granting path.

`MembershipRole` keeps its job: it decides who may *administer*. Role permissions decide what a
holder may *do*. "Above all" is about operational authority, not about removing the gate on who may
grant.

## A Bug My Own Defensiveness Created

The membership column maps to a `MembershipRole` member, and `MembershipRole` is a **str-mixin**
enum:

```python
str(MembershipRole.OWNER)    # 'MembershipRole.OWNER'   ← what I wrote
MembershipRole.OWNER.value   # 'owner'                  ← what the check needed
```

My defensive `str()` denied **every owner and admin**. The bare comparison would have worked, since
a str-mixin member compares equal to its value. Now `.value` explicitly, with `getattr` covering a
driver that returns a raw string.

Worth stating plainly: this failed **closed**, so a test caught it. The identical mistake on an
allow-check fails **open** and nothing catches it.

## What Changed

- `RolePermissionService` over the **existing** `role_permissions` / `permissions` tables — no new schema.
- Grant and revoke, gated on owner/admin membership of that company.
- `effective_permissions()` / `holder_may()` resolve a holder's access as the union over their **open** tenures.
- `roles_granting()` for the audit direction.
- New `llc/api/roles.py`: 13 routes covering roles, holders, permissions and workflow attachments, registered on the LLC router — the four services were previously unreachable.

## Verification

**52 tests pass** across all four role suites. Mutation-proved, both load-bearing properties:

| Mutation | Reddens |
|---|---|
| resolve from *any* tenure (drop `ended_at IS NULL`) | `test_ending_a_tenure_withdraws_the_permissions_it_carried` |
| remove `_require_admin` from `grant` | `test_a_plain_member_cannot_grant`, `test_an_admin_of_another_company_cannot_grant_here` |

Also covered: a **contact** holder resolves permissions (not all humans are users), and the same id
as a *user* resolves nothing — the discriminator is load-bearing, not decorative. An unknown
permission name is refused rather than auto-seeded, because a misspelt grant that "succeeds" grants
nothing while looking correct.

`alembic heads` → `20260819_079`, single head. This step adds no migration.

## Model Used

Claude Opus 5 (1M context)

