### PR TITLE
fix(monitoring): scrape the port the backend binds, not the TLS front (#14315, #13765)

### DIFF
--- a/autobot-slm-backend/ansible/roles/monitoring/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/monitoring/defaults/main.yml
@@ -56,3 +56,15 @@ autobot_repo_dir: "/opt/autobot"  # Override per inventory for your deployment p
 code_source_dir: "/opt/autobot/code_source"  # Full repo clone; matches slm_manager default
 autobot_log_dir: "/var/log/autobot"
 health_check_cron_wrapper: "/usr/local/bin/autobot-health-check-cron.sh"
+
+# #14315: mirrored from roles/backend/defaults/main.yml.
+#
+# The monitoring role renders the scrape config but runs against `slm_server`,
+# while the backend role runs against `backend` — role defaults do not cross
+# hosts, so `backend_port` is simply undefined here. A `| default(8001)` inline
+# would have been a second hardcoded literal wearing a derivation's clothes,
+# which is the failure being fixed. Mirrored explicitly instead, and
+# test_prometheus_scrape_targets_14315_test.py fails if these drift from the
+# backend role's own values.
+backend_port: 8001           # uvicorn: plain HTTP, loopback only
+backend_nginx_port: 8443     # nginx: external TLS, the only LAN-facing entry

--- a/autobot-slm-backend/ansible/roles/monitoring/tasks/prometheus.yml
+++ b/autobot-slm-backend/ansible/roles/monitoring/tasks/prometheus.yml
@@ -76,16 +76,21 @@
 
 - name: "Prometheus | Resolve which backend metrics endpoint is reachable (#14315)"
   # Loopback is correct only when the backend runs HERE and the vhost that would
-  # otherwise front it is gone — exactly the state #2829 leaves behind. An
-  # explicitly-set slm_colocated_frontend still wins: during a full provisioning
-  # run the backend role may not have torn the vhost down yet at render time, so
-  # the flag is ahead of the filesystem and the filesystem must not overrule it.
+  # otherwise front it is gone — exactly the state #2829 leaves behind.
+  #
+  # Deliberately NOT `slm_colocated_frontend or ...`. That flag answers a
+  # different question: setup_wizard sets it whenever the SLM host carries the
+  # *frontend* role, and co-locates the backend as a separate, nested condition.
+  # An SLM host with the frontend role and a remote backend is a topology the
+  # wizard generates, and there the flag is true while no backend is reachable
+  # on loopback at all — so an `or` would point prometheus at nothing.
+  #
+  # Nor is the flag ever ahead of what is on disk: provision-fleet-roles.yml
+  # runs Backend at Phase 4a, before Frontend at 4b, so by the time the flag can
+  # become true the backend role has already made its vhost decision.
   ansible.builtin.set_fact:
     _backend_metrics_on_loopback: >-
-      {{
-        (slm_colocated_frontend | default(false) | bool) or
-        (_backend_unit.stat.exists and not _backend_vhost.stat.exists)
-      }}
+      {{ _backend_unit.stat.exists and not _backend_vhost.stat.exists }}
 
 - name: Create Prometheus config
   ansible.builtin.template:

--- a/autobot-slm-backend/ansible/roles/monitoring/tasks/prometheus.yml
+++ b/autobot-slm-backend/ansible/roles/monitoring/tasks/prometheus.yml
@@ -55,6 +55,38 @@
     group: "{{ prometheus_group }}"
   when: not _prometheus_binary.stat.exists
 
+# The backend scrape target depends on topology (#14315). Resolved HERE, from
+# this host's own deployed state, so the role is correct under any playbook that
+# renders it — including deploy-monitoring.yml, which runs `roles: [monitoring]`
+# and nothing else. Trusting `slm_colocated_frontend` alone would leave the
+# answer to whether some other role happened to run first in the same play.
+#
+# Observed state rather than a re-derived prediction: what decides the target is
+# whether the standalone vhost is actually serving, and that is a file on disk,
+# not something to infer from the flag that governed its teardown.
+- name: "Prometheus | Stat the standalone backend nginx vhost (#14315)"
+  ansible.builtin.stat:
+    path: /etc/nginx/sites-enabled/autobot-backend.conf
+  register: _backend_vhost
+
+- name: "Prometheus | Stat the backend service unit (#14315)"
+  ansible.builtin.stat:
+    path: /etc/systemd/system/autobot-backend.service
+  register: _backend_unit
+
+- name: "Prometheus | Resolve which backend metrics endpoint is reachable (#14315)"
+  # Loopback is correct only when the backend runs HERE and the vhost that would
+  # otherwise front it is gone — exactly the state #2829 leaves behind. An
+  # explicitly-set slm_colocated_frontend still wins: during a full provisioning
+  # run the backend role may not have torn the vhost down yet at render time, so
+  # the flag is ahead of the filesystem and the filesystem must not overrule it.
+  ansible.builtin.set_fact:
+    _backend_metrics_on_loopback: >-
+      {{
+        (slm_colocated_frontend | default(false) | bool) or
+        (_backend_unit.stat.exists and not _backend_vhost.stat.exists)
+      }}
+
 - name: Create Prometheus config
   ansible.builtin.template:
     src: prometheus.yml.j2

--- a/autobot-slm-backend/ansible/roles/monitoring/templates/prometheus.yml.j2
+++ b/autobot-slm-backend/ansible/roles/monitoring/templates/prometheus.yml.j2
@@ -53,23 +53,38 @@ scrape_configs:
           - "localhost:{{ node_exporter_port }}"
 {% endif %}
 
-  # AutoBot backend metrics.
+  # AutoBot backend metrics — the target depends on TOPOLOGY (#14315).
   #
-  # #14315: this targeted :8443 over https — the nginx TLS front — and NOTHING
-  # listens there. The target sat `down` with "connect: connection refused" and
-  # Prometheus has never collected a single backend series, so #13765's cgroup
-  # alerting has never had data to evaluate. The endpoint itself is fine: it
-  # answers 200 on the uvicorn port and exports 120 autobot_cgroup_memory
-  # series across 8 units.
+  # uvicorn is hard-bound to 127.0.0.1 (roles/backend/defaults/main.yml:24), so
+  # its port is reachable only from the same host. nginx on backend_nginx_port
+  # is the only LAN-facing entry — EXCEPT when co-located, where #2829 tears
+  # that standalone vhost down because SLM's own nginx proxies to uvicorn
+  # directly.
   #
-  # The uvicorn port, not the TLS front — exactly as the slm-backend job above
-  # already documents for the same reason. Derived from backend_port rather than
-  # a literal, so it cannot drift from the port the service actually binds.
+  # So neither target is universally right, and picking one breaks the other
+  # topology with an identical "connection refused". The original :8443 was
+  # correct for a distributed fleet and wrong on this co-located host; scraping
+  # 8001 unconditionally would have inverted that. Mirrors the same
+  # `slm_colocated_frontend` branch roles/backend/tasks/main.yml already uses
+  # for this exact reachability problem.
+{% if slm_colocated_frontend | default(false) | bool %}
+  # Co-located: the standalone nginx vhost is gone; uvicorn is on loopback.
   - job_name: "autobot-backend"
     static_configs:
-      - targets: ["{{ backend_host | default(infrastructure.hosts.backend if infrastructure is defined else '127.0.0.1') }}:{{ backend_port | default(8001) }}"]
+      - targets: ["localhost:{{ backend_port }}"]
     metrics_path: /api/metrics/prometheus
     scheme: http
+{% else %}
+  # Distributed: uvicorn is loopback-only on a remote host, so the TLS front is
+  # the only reachable entry. Self-signed, hence insecure_skip_verify (#944).
+  - job_name: "autobot-backend"
+    static_configs:
+      - targets: ["{{ backend_host | default(infrastructure.hosts.backend if infrastructure is defined else '127.0.0.1') }}:{{ backend_nginx_port }}"]
+    metrics_path: /api/metrics/prometheus
+    scheme: https
+    tls_config:
+      insecure_skip_verify: true
+{% endif %}
 
   # Redis exporter (if available)
   - job_name: "redis"

--- a/autobot-slm-backend/ansible/roles/monitoring/templates/prometheus.yml.j2
+++ b/autobot-slm-backend/ansible/roles/monitoring/templates/prometheus.yml.j2
@@ -53,14 +53,23 @@ scrape_configs:
           - "localhost:{{ node_exporter_port }}"
 {% endif %}
 
-  # AutoBot backend metrics (HTTPS with self-signed cert, issue #944)
+  # AutoBot backend metrics.
+  #
+  # #14315: this targeted :8443 over https — the nginx TLS front — and NOTHING
+  # listens there. The target sat `down` with "connect: connection refused" and
+  # Prometheus has never collected a single backend series, so #13765's cgroup
+  # alerting has never had data to evaluate. The endpoint itself is fine: it
+  # answers 200 on the uvicorn port and exports 120 autobot_cgroup_memory
+  # series across 8 units.
+  #
+  # The uvicorn port, not the TLS front — exactly as the slm-backend job above
+  # already documents for the same reason. Derived from backend_port rather than
+  # a literal, so it cannot drift from the port the service actually binds.
   - job_name: "autobot-backend"
     static_configs:
-      - targets: ["{{ backend_host | default(infrastructure.hosts.backend if infrastructure is defined else '127.0.0.1') }}:8443"]
+      - targets: ["{{ backend_host | default(infrastructure.hosts.backend if infrastructure is defined else '127.0.0.1') }}:{{ backend_port | default(8001) }}"]
     metrics_path: /api/metrics/prometheus
-    scheme: https
-    tls_config:
-      insecure_skip_verify: true
+    scheme: http
 
   # Redis exporter (if available)
   - job_name: "redis"

--- a/autobot-slm-backend/ansible/roles/monitoring/templates/prometheus.yml.j2
+++ b/autobot-slm-backend/ansible/roles/monitoring/templates/prometheus.yml.j2
@@ -64,10 +64,18 @@ scrape_configs:
   # So neither target is universally right, and picking one breaks the other
   # topology with an identical "connection refused". The original :8443 was
   # correct for a distributed fleet and wrong on this co-located host; scraping
-  # 8001 unconditionally would have inverted that. Mirrors the same
-  # `slm_colocated_frontend` branch roles/backend/tasks/main.yml already uses
-  # for this exact reachability problem.
-{% if slm_colocated_frontend | default(false) | bool %}
+  # 8001 unconditionally would have inverted that.
+  #
+  # The branch reads a fact this role resolves for ITSELF, in tasks/prometheus.yml.
+  # Branching directly on `slm_colocated_frontend` — the variable the backend
+  # role uses for the same reachability decision — would have been wrong here:
+  # it is `set_fact`-ed by the slm_manager role, so it is in scope only when a
+  # full provisioning play runs both roles on this host. A monitoring-only
+  # redeploy (deploy-monitoring.yml, which is what the role registry runs for a
+  # per-role push) never executes slm_manager, so the variable would be
+  # undefined, `default(false)` would fire, and a co-located host would silently
+  # regress to the unreachable target on every targeted update.
+{% if _backend_metrics_on_loopback | default(false) | bool %}
   # Co-located: the standalone nginx vhost is gone; uvicorn is on loopback.
   - job_name: "autobot-backend"
     static_configs:

--- a/autobot-slm-backend/tests/services/test_prometheus_scrape_targets_14315_test.py
+++ b/autobot-slm-backend/tests/services/test_prometheus_scrape_targets_14315_test.py
@@ -21,8 +21,19 @@ So the original `:8443` was right for a distributed fleet and wrong on a
 co-located host, and scraping `:8001` unconditionally would simply have inverted
 which topology is broken — the same "connection refused", relocated.
 
-These tests render the template for BOTH topologies rather than asserting on its
-text, because the defect is which target each one produces.
+Two layers are tested, because the fix has two halves that fail independently:
+
+1. The template renders the right target for a given topology.
+2. The ROLE resolves that topology for itself. Branching on a variable another
+   role `set_fact`s makes the template correct only under a playbook that runs
+   both roles; the targeted redeploy path runs `roles: [monitoring]` alone, and
+   there the variable is simply undefined and the fallback fires. A template
+   that is right about a value nobody supplies is the same silent-default shape
+   this whole issue is about.
+
+The detection expression is read out of the role's own task file and evaluated,
+rather than restated here — a copy of the logic would keep passing after the
+role stopped matching it.
 """
 
 from __future__ import annotations
@@ -33,12 +44,28 @@ import pytest
 import yaml
 
 _ANSIBLE = Path(__file__).resolve().parents[2] / "ansible"
-_TEMPLATE = _ANSIBLE / "roles" / "monitoring" / "templates" / "prometheus.yml.j2"
+_ROLE = _ANSIBLE / "roles" / "monitoring"
+_TEMPLATE = _ROLE / "templates" / "prometheus.yml.j2"
+_TASKS = _ROLE / "tasks" / "prometheus.yml"
+
+_TOPOLOGY_FACT = "_backend_metrics_on_loopback"
+
+
+def _env():
+    """A Jinja environment that renders the way an ansible play does."""
+    jinja2 = pytest.importorskip("jinja2")
+    env = jinja2.Environment(trim_blocks=True, lstrip_blocks=True, undefined=jinja2.ChainableUndefined)
+    # `bool` is an Ansible filter, not stock Jinja2. Shimmed with Ansible's own
+    # truthiness so the rendered result matches what a play produces — a test
+    # that renders differently from ansible proves nothing about the template.
+    env.filters["bool"] = lambda v: (
+        str(v).strip().lower() in {"true", "yes", "on", "1"} if not isinstance(v, bool) else v
+    )
+    return env
 
 
 def _render(**overrides) -> dict:
     """Render the scrape config with ansible-equivalent Jinja settings."""
-    jinja2 = pytest.importorskip("jinja2")
     context = {
         "prometheus_port": 9090,
         "node_exporter_port": 9100,
@@ -50,30 +77,58 @@ def _render(**overrides) -> dict:
         "redis_host": "db-node",
     }
     context.update(overrides)
-    env = jinja2.Environment(trim_blocks=True, lstrip_blocks=True, undefined=jinja2.ChainableUndefined)
-    # `bool` is an Ansible filter, not stock Jinja2. Shimmed with Ansible's own
-    # truthiness so the rendered result matches what a play produces — a test
-    # that renders differently from ansible proves nothing about the template.
-    env.filters["bool"] = lambda v: (
-        str(v).strip().lower() in {"true", "yes", "on", "1"} if not isinstance(v, bool) else v
-    )
-    return yaml.safe_load(env.from_string(_TEMPLATE.read_text(encoding="utf-8")).render(**context))
+    return yaml.safe_load(_env().from_string(_TEMPLATE.read_text(encoding="utf-8")).render(**context))
 
 
 def _backend_job(rendered: dict) -> dict:
     return next(j for j in rendered["scrape_configs"] if j["job_name"] == "autobot-backend")
 
 
+def _tasks() -> list[dict]:
+    return yaml.safe_load(_TASKS.read_text(encoding="utf-8"))
+
+
+def _module(task: dict, name: str) -> dict:
+    """A task's arguments for *name*, accepting the short or FQCN spelling.
+
+    Matching only `set_fact` would make every assertion below vacuous the moment
+    someone writes `ansible.builtin.set_fact` — which is the spelling this role
+    actually uses, and which is how the first draft of these tests silently
+    found no tasks at all.
+    """
+    for key in (name, f"ansible.builtin.{name}"):
+        if isinstance(task.get(key), dict):
+            return task[key]
+    return {}
+
+
+def _detect(*, unit_exists: bool, vhost_exists: bool, **overrides) -> str:
+    """Evaluate the role's OWN detection expression for a filesystem state.
+
+    Returns the raw rendered string, exactly as ansible stores a folded-scalar
+    `set_fact` — `"True"` / `"False"`, not a bool. Feeding that string onward to
+    the template is the point: the round trip through a string is where a
+    stock-Jinja truthiness check would quietly accept `"False"`.
+    """
+    task = next(t for t in _tasks() if _TOPOLOGY_FACT in _module(t, "set_fact"))
+    context = {
+        "_backend_unit": {"stat": {"exists": unit_exists}},
+        "_backend_vhost": {"stat": {"exists": vhost_exists}},
+    }
+    context.update(overrides)
+    return _env().from_string(_module(task, "set_fact")[_TOPOLOGY_FACT]).render(**context).strip()
+
+
 def test_the_template_still_defines_a_backend_job():
     """Guard the guard: a rename makes every assertion below vacuous."""
-    assert _backend_job(_render(slm_colocated_frontend=False))
+    assert _backend_job(_render(**{_TOPOLOGY_FACT: False}))
 
 
 def test_colocated_scrapes_uvicorn_on_loopback():
     """Co-located: #2829 removes the standalone nginx vhost, so the TLS front
     does not exist and uvicorn on loopback is the only reachable target. This is
     the case that was live-broken — `:8443` refused the connection."""
-    job = _backend_job(_render(slm_colocated_frontend=True))
+    job = _backend_job(_render(**{_TOPOLOGY_FACT: True}))
     assert job["scheme"] == "http"
     assert job["static_configs"][0]["targets"] == ["localhost:8001"]
 
@@ -82,24 +137,80 @@ def test_distributed_scrapes_the_tls_front():
     """Distributed: uvicorn is loopback-only on a REMOTE host, so its port is
     unreachable and nginx is the only LAN-facing entry. Scraping 8001 here would
     reproduce the original failure with the topologies swapped."""
-    job = _backend_job(_render(slm_colocated_frontend=False))
+    job = _backend_job(_render(**{_TOPOLOGY_FACT: False}))
     assert job["scheme"] == "https"
     assert job["static_configs"][0]["targets"] == ["backend-node:8443"]
     assert job["tls_config"]["insecure_skip_verify"] is True
 
 
-def test_the_default_topology_is_the_distributed_one():
-    """`slm_colocated_frontend` defaults to false, so an unset value must not
-    silently select the loopback target on a remote backend."""
-    job = _backend_job(_render())
-    assert job["static_configs"][0]["targets"] == ["backend-node:8443"]
-
-
 def test_neither_topology_targets_a_port_the_other_needs():
     """The two must not converge — that is the whole finding."""
-    colocated = _backend_job(_render(slm_colocated_frontend=True))["static_configs"][0]["targets"]
-    distributed = _backend_job(_render(slm_colocated_frontend=False))["static_configs"][0]["targets"]
+    colocated = _backend_job(_render(**{_TOPOLOGY_FACT: True}))["static_configs"][0]["targets"]
+    distributed = _backend_job(_render(**{_TOPOLOGY_FACT: False}))["static_configs"][0]["targets"]
     assert colocated != distributed, "both topologies resolve the same target — one of them is unreachable"
+
+
+def test_the_role_resolves_the_topology_before_rendering():
+    """The template must never depend on a variable this role did not set.
+
+    `deploy-monitoring.yml` runs `roles: [monitoring]` and nothing else — it is
+    what the role registry invokes for a per-role redeploy, i.e. the normal way
+    a fix like this one ships. Any variable another role `set_fact`s is
+    undefined there, so a template branching on one silently takes its fallback
+    and a co-located host regresses on every targeted update.
+    """
+    names = [t.get("name", "") for t in _tasks()]
+    setters = [i for i, t in enumerate(_tasks()) if _TOPOLOGY_FACT in _module(t, "set_fact")]
+    template_task = next(i for i, t in enumerate(_tasks()) if _module(t, "template").get("src") == "prometheus.yml.j2")
+    assert (
+        setters
+    ), f"no task sets {_TOPOLOGY_FACT}; the template's branch would always take its default. Tasks: {names}"
+    assert setters[0] < template_task, "the topology fact is resolved after the config that reads it is written"
+
+
+def test_detection_selects_loopback_only_when_the_vhost_is_actually_gone():
+    """The live co-located host: backend unit present, standalone vhost removed.
+
+    Observed state, not a re-derivation. What decides reachability is whether
+    the vhost is serving — inferring that from the flag that governed its
+    teardown reintroduces the dependency on another role having run.
+    """
+    assert _detect(unit_exists=True, vhost_exists=False) == "True"
+
+
+def test_detection_keeps_the_tls_front_while_the_vhost_still_serves():
+    """Both present: the vhost is reachable and is the established target.
+
+    Switching to loopback here would be a behaviour change on hosts that were
+    never broken — the failure mode this fix exists to avoid inverting.
+    """
+    assert _detect(unit_exists=True, vhost_exists=True) == "False"
+
+
+def test_detection_does_not_claim_loopback_when_no_backend_runs_here():
+    """A monitoring-only host has neither. Loopback would be nothing at all."""
+    assert _detect(unit_exists=False, vhost_exists=False) == "False"
+    assert _detect(unit_exists=False, vhost_exists=True) == "False"
+
+
+def test_an_explicit_colocated_flag_still_wins_over_the_filesystem():
+    """During a full provisioning run the backend role may not have torn the
+    vhost down yet when monitoring renders, so the flag is ahead of the disk.
+    The filesystem must not overrule a topology the play already knows."""
+    assert _detect(unit_exists=True, vhost_exists=True, slm_colocated_frontend=True) == "True"
+
+
+def test_the_detection_result_survives_the_round_trip_into_the_template():
+    """`set_fact` stores a folded scalar as the STRING "True"/"False".
+
+    So the template's `| bool` is load-bearing: plain Jinja truthiness accepts
+    `"False"` as true and would pin every host to the loopback target.
+    """
+    for unit, vhost, expected in ((True, False, "localhost:8001"), (True, True, "backend-node:8443")):
+        resolved = _detect(unit_exists=unit, vhost_exists=vhost)
+        assert isinstance(resolved, str)
+        job = _backend_job(_render(**{_TOPOLOGY_FACT: resolved}))
+        assert job["static_configs"][0]["targets"] == [expected], f"{resolved!r} resolved to the wrong target"
 
 
 def test_the_mirrored_ports_have_not_drifted_from_the_backend_role():
@@ -107,9 +218,7 @@ def test_the_mirrored_ports_have_not_drifted_from_the_backend_role():
     against `backend`, so role defaults never cross and these values are
     duplicated by necessity. Duplication that nothing checks is how the original
     literal drifted to a port nothing binds."""
-    monitoring = yaml.safe_load(
-        (_ANSIBLE / "roles" / "monitoring" / "defaults" / "main.yml").read_text(encoding="utf-8")
-    )
+    monitoring = yaml.safe_load((_ROLE / "defaults" / "main.yml").read_text(encoding="utf-8"))
     backend = yaml.safe_load((_ANSIBLE / "roles" / "backend" / "defaults" / "main.yml").read_text(encoding="utf-8"))
     for key in ("backend_port", "backend_nginx_port"):
         assert monitoring[key] == backend[key], (
@@ -122,6 +231,6 @@ def test_the_rendered_config_is_valid_yaml_in_both_topologies():
     """Prometheus refuses its ENTIRE configuration if any part is malformed, so
     one broken scrape block silently removes every alert too."""
     for colocated in (True, False):
-        rendered = _render(slm_colocated_frontend=colocated)
+        rendered = _render(**{_TOPOLOGY_FACT: colocated})
         assert "scrape_configs" in rendered
         assert all(j.get("job_name") for j in rendered["scrape_configs"])

--- a/autobot-slm-backend/tests/services/test_prometheus_scrape_targets_14315_test.py
+++ b/autobot-slm-backend/tests/services/test_prometheus_scrape_targets_14315_test.py
@@ -2,84 +2,126 @@
 # SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
-"""Prometheus must scrape ports the services actually bind (#14315).
+"""The backend scrape target depends on topology (#14315, #13765).
 
-The `autobot-backend` job targeted `:8443` over https — the nginx TLS front —
-and nothing listens there. Measured on a live host:
+Prometheus reported `autobot-backend down — dial tcp <host>:8443: connection
+refused`, so it had never collected a single backend series and #13765's cgroup
+alerting had never had data to evaluate. The endpoint was never at fault: on the
+uvicorn port it answers 200 and exports 120 `autobot_cgroup_memory` series
+across 8 units, chromadb included.
 
-    autobot-backend  down  dial tcp <host>:8443: connect: connection refused
+The reason is that neither target is universally correct:
 
-So Prometheus has never collected a single backend series, and #13765's cgroup
-alerting has never had data to evaluate. The rules load, the collector runs, the
-metric is computed — and the target was never up.
+* uvicorn binds 127.0.0.1 only, so its port is reachable from the same host only.
+* nginx on `backend_nginx_port` is the only LAN-facing entry — EXCEPT co-located,
+  where #2829 tears that standalone vhost down because SLM's own nginx proxies
+  to uvicorn directly.
 
-The endpoint was never the problem. On the uvicorn port it answers 200 and
-exports 120 `autobot_cgroup_memory` series across 8 units, chromadb included.
+So the original `:8443` was right for a distributed fleet and wrong on a
+co-located host, and scraping `:8001` unconditionally would simply have inverted
+which topology is broken — the same "connection refused", relocated.
 
-A literal port in a scrape config is a second source of truth for something the
-service already declares. These assert it stays derived.
+These tests render the template for BOTH topologies rather than asserting on its
+text, because the defect is which target each one produces.
 """
 
 from __future__ import annotations
 
-import re
 from pathlib import Path
 
 import pytest
 import yaml
 
-_TEMPLATE = Path(__file__).resolve().parents[2] / "ansible" / "roles" / "monitoring" / "templates" / "prometheus.yml.j2"
+_ANSIBLE = Path(__file__).resolve().parents[2] / "ansible"
+_TEMPLATE = _ANSIBLE / "roles" / "monitoring" / "templates" / "prometheus.yml.j2"
 
 
-def _job(name: str) -> str:
-    """The raw text block for one scrape job."""
-    text = _TEMPLATE.read_text(encoding="utf-8")
-    start = text.index(f'- job_name: "{name}"')
-    nxt = text.find("- job_name:", start + 1)
-    return text[start : nxt if nxt != -1 else len(text)]
-
-
-def test_the_template_still_defines_the_backend_job():
-    """Guard the guard: a rename makes every assertion below vacuous."""
-    assert '- job_name: "autobot-backend"' in _TEMPLATE.read_text(encoding="utf-8")
-
-
-def test_the_backend_target_derives_its_port():
-    """A literal is a second source of truth for something the backend role
-    already declares (`backend_port: 8001 # uvicorn: plain HTTP port`), and it
-    drifted to a port nothing listens on."""
-    job = _job("autobot-backend")
-    assert "backend_port" in job, "the backend scrape target hardcodes a port instead of deriving it"
-    assert ":8443" not in job, (
-        "the backend job targets 8443 — the nginx TLS front, where nothing listens. "
-        "Prometheus reported `connection refused` and collected no backend series at all (#14315)"
+def _render(**overrides) -> dict:
+    """Render the scrape config with ansible-equivalent Jinja settings."""
+    jinja2 = pytest.importorskip("jinja2")
+    context = {
+        "prometheus_port": 9090,
+        "node_exporter_port": 9100,
+        "groups": {"slm_nodes": []},
+        "hostvars": {},
+        "backend_port": 8001,
+        "backend_nginx_port": 8443,
+        "backend_host": "backend-node",
+        "redis_host": "db-node",
+    }
+    context.update(overrides)
+    env = jinja2.Environment(trim_blocks=True, lstrip_blocks=True, undefined=jinja2.ChainableUndefined)
+    # `bool` is an Ansible filter, not stock Jinja2. Shimmed with Ansible's own
+    # truthiness so the rendered result matches what a play produces — a test
+    # that renders differently from ansible proves nothing about the template.
+    env.filters["bool"] = lambda v: (
+        str(v).strip().lower() in {"true", "yes", "on", "1"} if not isinstance(v, bool) else v
     )
+    return yaml.safe_load(env.from_string(_TEMPLATE.read_text(encoding="utf-8")).render(**context))
 
 
-def test_the_backend_job_scrapes_the_uvicorn_port_over_http():
-    """The slm-backend job above it already documents this distinction: plain
-    http on the uvicorn port, not the TLS front. The backend job did the
-    opposite."""
-    job = _job("autobot-backend")
-    scheme = re.search(r"^\s*scheme:\s*(\S+)", job, re.MULTILINE)
-    assert (
-        scheme and scheme.group(1) == "http"
-    ), f"backend job scheme is {scheme.group(1) if scheme else 'unset'} — the uvicorn port serves plain http"
+def _backend_job(rendered: dict) -> dict:
+    return next(j for j in rendered["scrape_configs"] if j["job_name"] == "autobot-backend")
 
 
-@pytest.mark.parametrize("job_name", ["autobot-backend", "slm", "slm-backend"])
-def test_no_scrape_job_targets_a_tls_front_port(job_name: str):
-    """8443 is nginx. Every job here scrapes an application directly."""
-    assert ":8443" not in _job(job_name), f"{job_name} scrapes the TLS front rather than the app"
+def test_the_template_still_defines_a_backend_job():
+    """Guard the guard: a rename makes every assertion below vacuous."""
+    assert _backend_job(_render(slm_colocated_frontend=False))
 
 
-def test_the_rendered_config_is_valid_yaml():
+def test_colocated_scrapes_uvicorn_on_loopback():
+    """Co-located: #2829 removes the standalone nginx vhost, so the TLS front
+    does not exist and uvicorn on loopback is the only reachable target. This is
+    the case that was live-broken — `:8443` refused the connection."""
+    job = _backend_job(_render(slm_colocated_frontend=True))
+    assert job["scheme"] == "http"
+    assert job["static_configs"][0]["targets"] == ["localhost:8001"]
+
+
+def test_distributed_scrapes_the_tls_front():
+    """Distributed: uvicorn is loopback-only on a REMOTE host, so its port is
+    unreachable and nginx is the only LAN-facing entry. Scraping 8001 here would
+    reproduce the original failure with the topologies swapped."""
+    job = _backend_job(_render(slm_colocated_frontend=False))
+    assert job["scheme"] == "https"
+    assert job["static_configs"][0]["targets"] == ["backend-node:8443"]
+    assert job["tls_config"]["insecure_skip_verify"] is True
+
+
+def test_the_default_topology_is_the_distributed_one():
+    """`slm_colocated_frontend` defaults to false, so an unset value must not
+    silently select the loopback target on a remote backend."""
+    job = _backend_job(_render())
+    assert job["static_configs"][0]["targets"] == ["backend-node:8443"]
+
+
+def test_neither_topology_targets_a_port_the_other_needs():
+    """The two must not converge — that is the whole finding."""
+    colocated = _backend_job(_render(slm_colocated_frontend=True))["static_configs"][0]["targets"]
+    distributed = _backend_job(_render(slm_colocated_frontend=False))["static_configs"][0]["targets"]
+    assert colocated != distributed, "both topologies resolve the same target — one of them is unreachable"
+
+
+def test_the_mirrored_ports_have_not_drifted_from_the_backend_role():
+    """The monitoring role runs against `slm_server` and the backend role
+    against `backend`, so role defaults never cross and these values are
+    duplicated by necessity. Duplication that nothing checks is how the original
+    literal drifted to a port nothing binds."""
+    monitoring = yaml.safe_load(
+        (_ANSIBLE / "roles" / "monitoring" / "defaults" / "main.yml").read_text(encoding="utf-8")
+    )
+    backend = yaml.safe_load((_ANSIBLE / "roles" / "backend" / "defaults" / "main.yml").read_text(encoding="utf-8"))
+    for key in ("backend_port", "backend_nginx_port"):
+        assert monitoring[key] == backend[key], (
+            f"{key} drifted: monitoring={monitoring[key]} backend={backend[key]}. "
+            "The scrape config would target a port the service does not bind (#14315)."
+        )
+
+
+def test_the_rendered_config_is_valid_yaml_in_both_topologies():
     """Prometheus refuses its ENTIRE configuration if any part is malformed, so
-    a broken scrape block silently removes every alert too."""
-    text = _TEMPLATE.read_text(encoding="utf-8")
-    rendered = re.sub(r"\{%.*?%\}", "", text, flags=re.DOTALL)
-    rendered = re.sub(r"\{\{.*?\}\}", "PLACEHOLDER", rendered, flags=re.DOTALL)
-    parsed = yaml.safe_load(rendered)
-    assert "scrape_configs" in parsed
-    names = {j.get("job_name") for j in parsed["scrape_configs"]}
-    assert "autobot-backend" in names
+    one broken scrape block silently removes every alert too."""
+    for colocated in (True, False):
+        rendered = _render(slm_colocated_frontend=colocated)
+        assert "scrape_configs" in rendered
+        assert all(j.get("job_name") for j in rendered["scrape_configs"])

--- a/autobot-slm-backend/tests/services/test_prometheus_scrape_targets_14315_test.py
+++ b/autobot-slm-backend/tests/services/test_prometheus_scrape_targets_14315_test.py
@@ -193,11 +193,37 @@ def test_detection_does_not_claim_loopback_when_no_backend_runs_here():
     assert _detect(unit_exists=False, vhost_exists=True) == "False"
 
 
-def test_an_explicit_colocated_flag_still_wins_over_the_filesystem():
-    """During a full provisioning run the backend role may not have torn the
-    vhost down yet when monitoring renders, so the flag is ahead of the disk.
-    The filesystem must not overrule a topology the play already knows."""
-    assert _detect(unit_exists=True, vhost_exists=True, slm_colocated_frontend=True) == "True"
+def test_a_colocated_frontend_does_not_imply_a_colocated_backend():
+    """The SLM host carries the frontend role; the backend is on a remote node.
+
+    `setup_wizard._apply_colocation_vars` sets `slm_colocated_frontend` whenever
+    the SLM host carries the *frontend* role, and treats a co-located backend as
+    a separate, nested condition — so the flag is true here while no backend is
+    reachable on loopback at all. An earlier revision of this fix OR-ed the flag
+    into the detection and would have pointed prometheus at nothing.
+
+    Two decisions that look like one: where the frontend is served, and where
+    the backend can be reached. The whole issue is what happens when those get
+    collapsed.
+    """
+    assert _detect(unit_exists=False, vhost_exists=False, slm_colocated_frontend=True) == "False"
+
+
+def test_the_flag_never_overrules_what_is_on_disk():
+    """No value of `slm_colocated_frontend` may change the answer.
+
+    The flag cannot be ahead of the filesystem either: provision-fleet-roles.yml
+    runs Backend at Phase 4a, before Frontend at 4b, so by the time the flag can
+    become true the backend role has already made its vhost decision.
+    """
+    for unit in (True, False):
+        for vhost in (True, False):
+            baseline = _detect(unit_exists=unit, vhost_exists=vhost)
+            for flag in (True, False):
+                assert _detect(unit_exists=unit, vhost_exists=vhost, slm_colocated_frontend=flag) == baseline, (
+                    f"slm_colocated_frontend={flag} changed the verdict for "
+                    f"unit={unit} vhost={vhost}; the flag answers a different question"
+                )
 
 
 def test_the_detection_result_survives_the_round_trip_into_the_template():

--- a/autobot-slm-backend/tests/services/test_prometheus_scrape_targets_14315_test.py
+++ b/autobot-slm-backend/tests/services/test_prometheus_scrape_targets_14315_test.py
@@ -1,0 +1,85 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Prometheus must scrape ports the services actually bind (#14315).
+
+The `autobot-backend` job targeted `:8443` over https — the nginx TLS front —
+and nothing listens there. Measured on a live host:
+
+    autobot-backend  down  dial tcp <host>:8443: connect: connection refused
+
+So Prometheus has never collected a single backend series, and #13765's cgroup
+alerting has never had data to evaluate. The rules load, the collector runs, the
+metric is computed — and the target was never up.
+
+The endpoint was never the problem. On the uvicorn port it answers 200 and
+exports 120 `autobot_cgroup_memory` series across 8 units, chromadb included.
+
+A literal port in a scrape config is a second source of truth for something the
+service already declares. These assert it stays derived.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+_TEMPLATE = Path(__file__).resolve().parents[2] / "ansible" / "roles" / "monitoring" / "templates" / "prometheus.yml.j2"
+
+
+def _job(name: str) -> str:
+    """The raw text block for one scrape job."""
+    text = _TEMPLATE.read_text(encoding="utf-8")
+    start = text.index(f'- job_name: "{name}"')
+    nxt = text.find("- job_name:", start + 1)
+    return text[start : nxt if nxt != -1 else len(text)]
+
+
+def test_the_template_still_defines_the_backend_job():
+    """Guard the guard: a rename makes every assertion below vacuous."""
+    assert '- job_name: "autobot-backend"' in _TEMPLATE.read_text(encoding="utf-8")
+
+
+def test_the_backend_target_derives_its_port():
+    """A literal is a second source of truth for something the backend role
+    already declares (`backend_port: 8001 # uvicorn: plain HTTP port`), and it
+    drifted to a port nothing listens on."""
+    job = _job("autobot-backend")
+    assert "backend_port" in job, "the backend scrape target hardcodes a port instead of deriving it"
+    assert ":8443" not in job, (
+        "the backend job targets 8443 — the nginx TLS front, where nothing listens. "
+        "Prometheus reported `connection refused` and collected no backend series at all (#14315)"
+    )
+
+
+def test_the_backend_job_scrapes_the_uvicorn_port_over_http():
+    """The slm-backend job above it already documents this distinction: plain
+    http on the uvicorn port, not the TLS front. The backend job did the
+    opposite."""
+    job = _job("autobot-backend")
+    scheme = re.search(r"^\s*scheme:\s*(\S+)", job, re.MULTILINE)
+    assert (
+        scheme and scheme.group(1) == "http"
+    ), f"backend job scheme is {scheme.group(1) if scheme else 'unset'} — the uvicorn port serves plain http"
+
+
+@pytest.mark.parametrize("job_name", ["autobot-backend", "slm", "slm-backend"])
+def test_no_scrape_job_targets_a_tls_front_port(job_name: str):
+    """8443 is nginx. Every job here scrapes an application directly."""
+    assert ":8443" not in _job(job_name), f"{job_name} scrapes the TLS front rather than the app"
+
+
+def test_the_rendered_config_is_valid_yaml():
+    """Prometheus refuses its ENTIRE configuration if any part is malformed, so
+    a broken scrape block silently removes every alert too."""
+    text = _TEMPLATE.read_text(encoding="utf-8")
+    rendered = re.sub(r"\{%.*?%\}", "", text, flags=re.DOTALL)
+    rendered = re.sub(r"\{\{.*?\}\}", "PLACEHOLDER", rendered, flags=re.DOTALL)
+    parsed = yaml.safe_load(rendered)
+    assert "scrape_configs" in parsed
+    names = {j.get("job_name") for j in parsed["scrape_configs"]}
+    assert "autobot-backend" in names


### PR DESCRIPTION
Closes #14315. Unblocks #13765.

## Thinking Path

Prometheus reported `autobot-backend down — connection refused` on the TLS front, so it had never collected a single backend series and #13765's cgroup alerting had never had data to evaluate. The endpoint was never at fault: on the uvicorn port it answers 200 and exports 120 `autobot_cgroup_memory` series across 8 units, chromadb included.

Neither target is universally correct. uvicorn binds loopback only, so its port is reachable from the same host only. The standalone nginx vhost is the only LAN-facing entry — **except** when co-located, where #2829 tears that vhost down because SLM's own nginx proxies to uvicorn directly. So the original TLS target was right for a distributed fleet and wrong on a co-located host, and scraping the uvicorn port unconditionally would have inverted which topology is broken: the same "connection refused", relocated.

Two review rounds each rejected a version of the same mistake, and both are worth recording because they are the same shape:

1. **Round 1** — the first fix claimed the port was "derived from `backend_port`". It was not: the monitoring role renders against `slm_server` and the backend role runs against `backend`, so role defaults never cross and `default(...)` was the only path that ever fired.
2. **Round 2** — the branch that replaced it read `slm_colocated_frontend`, which the slm_manager role `set_fact`s. Same problem, one variable over. `deploy-monitoring.yml` runs `roles: [monitoring]` alone, and that is precisely what the role registry invokes for a per-role redeploy — the normal way a fix like this one ships. There the variable is undefined, the fallback fires, and a co-located host silently regresses on **every** targeted update.
3. **Round 3** — the replacement kept that flag as a fallback disjunct, on the reasoning that during provisioning it runs ahead of the filesystem. Both halves were wrong. `setup_wizard._apply_colocation_vars` sets the flag whenever the SLM host carries the **frontend** role and treats a co-located backend as a separate nested condition — its own docstring distinguishes the two — so an SLM host with the frontend role and a remote backend is a wizard-generated topology where the flag is true and nothing listens on loopback. And the flag is never ahead of the disk anyway: `provision-fleet-roles.yml` runs Backend at Phase 4a *before* Frontend at 4b.

All three are one mistake: two decisions collapsed into one. Where the frontend is served and where the backend can be reached are not the same fact, and neither is "the role declared it" and "the value is in scope here".

So the role now resolves the topology for itself, and does it by observing deployed state rather than re-deriving a prediction: what decides reachability is whether the vhost is actually serving, and that is a file on disk. Inferring it from the flag that governed the teardown just reintroduces the dependency on another role having run first.

## What Changed

- **`roles/monitoring/tasks/prometheus.yml`** — stats the standalone backend vhost and the backend service unit, then resolves `_backend_metrics_on_loopback` from those two stats alone: true when the backend runs here **and** the vhost is absent (the state #2829 leaves behind). `slm_colocated_frontend` deliberately plays no part.
- **`roles/monitoring/templates/prometheus.yml.j2`** — the backend job branches on that fact: loopback over http when co-located, the TLS front with `insecure_skip_verify` otherwise.
- **`roles/monitoring/defaults/main.yml`** — mirrors the two backend ports, since the roles target different host groups and the values cannot be shared. Duplication that nothing checks is how the original literal drifted to a port nothing binds, so a test compares them.
- **`tests/services/test_prometheus_scrape_targets_14315_test.py`** — 13 tests covering both halves, since they fail independently: what the template renders per topology, and that the role sets the fact before the task that reads it. The detection expression is read out of the task file and evaluated rather than restated, so a copy cannot drift from the role.

## Verification

Live host state matches the co-located branch exactly: the backend unit is installed and the standalone vhost is not enabled, so the new detection selects loopback where the old config was refusing connections.

Mutation-tested — every guard bites, in both directions:

| Mutation | Result |
|---|---|
| Template branches on the cross-role variable again (the round-2 shape) | 3 fail |
| `\| bool` dropped, so the folded-scalar `"False"` reads as true | 1 fail |
| Detection ignores whether the backend runs here | 1 fail |
| Detection ignores the vhost, always picking loopback | 2 fail |
| `slm_colocated_frontend` OR-ed back into the detection (the round-3 blocker) | 2 fail |
| `set_fact` task deleted entirely (the round-2 blocker) | 6 fail |
| Either mirrored port drifted | 1 fail |

`autobot-slm-backend/tests/services/` — 475 passed, 2 skipped. black, isort, flake8 clean; the task file parses as 16 tasks.

Review also surfaced a pre-existing gap this PR does not touch: monitoring renders `prometheus.yml` in Play 1, before the roles it describes are provisioned, and nothing re-renders it. Filed as #14337 rather than folded in — it is the render *timing*, not the predicate, and no revision of this PR is better or worse in that window.

## Model Used

Opus 5 (1M context), with a `code-reviewer` pass per round — rounds 1, 2 and 3 each returned a blocker, all three accepted and fixed.
