### PR TITLE
fix(deploy): stop the slm-agent putting a fleet node in slm_server (#14330)

### DIFF
--- a/autobot-slm-backend/services/inventory_builder.py
+++ b/autobot-slm-backend/services/inventory_builder.py
@@ -79,9 +79,24 @@ logger = logging.getLogger(__name__)
 #   monitoring
 
 _ROLE_TO_GROUPS: dict[str, frozenset] = {
-    # SLM manager / slm-agent / any slm-* role
+    # SLM manager's own components. The "slm-" prefix catches slm-backend,
+    # slm-frontend, slm-database and slm-monitoring — all of which run only on
+    # the manager, which is what makes `slm_server` right for them.
     "slm-": frozenset({"slm", "slm_server", "slm_nodes"}),
-    "slm_agent": frozenset({"slm", "slm_server", "slm_nodes"}),
+    # slm-agent is NOT one of those: it runs on EVERY fleet node. Listed
+    # explicitly so the exact-key match above wins over the "slm-" prefix,
+    # because inheriting `slm_server` put every agent-carrying node into the
+    # group `update-all-nodes.yml`'s "Play 1 - Update SLM Server First"
+    # targets. That play does
+    #     git -C /opt/autobot/code_source rev-parse HEAD > /opt/autobot/autobot-slm-backend/.deployed_commit
+    # and neither path exists on a node that is not the manager, so it failed
+    # with a non-zero rc and halted the whole fleet stage (#14328).
+    #
+    # The manager keeps `slm_server` through its own slm-backend/-frontend/
+    # -database/-monitoring roles; only a node carrying the agent alone drops
+    # out, which is the intent.
+    "slm-agent": frozenset({"slm", "slm_nodes"}),
+    "slm_agent": frozenset({"slm", "slm_nodes"}),
     # Backend / API server
     "backend": frozenset({"backend", "main"}),
     "celery": frozenset({"backend", "main"}),

--- a/autobot-slm-backend/services/inventory_builder_agent_group_test.py
+++ b/autobot-slm-backend/services/inventory_builder_agent_group_test.py
@@ -1,0 +1,128 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""The slm-agent must not put a fleet node in slm_server (#14328).
+
+`_ROLE_TO_GROUPS` had one `"slm-"` prefix key covering the manager's own
+components — `slm-backend`, `slm-frontend`, `slm-database`, `slm-monitoring` —
+and it also caught `slm-agent`, which runs on **every** fleet node.
+
+So every agent-carrying node joined `slm_server`, and
+`update-all-nodes.yml`'s "Play 1 - Update SLM Server First" ran against it:
+
+    git -c safe.directory=/opt/autobot/code_source \\
+        -C /opt/autobot/code_source rev-parse HEAD \\
+        > /opt/autobot/autobot-slm-backend/.deployed_commit
+
+Neither path exists on a node that is not the manager, so the task failed with
+a non-zero rc and halted the entire fleet stage.
+
+Observed live on a VNC node. It was invisible until #14297 stopped skipping
+degraded nodes — #11511's skip had been hiding it, so the play never ran
+against a fleet node to fail on.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location(
+        "_ib_14328", _BACKEND_ROOT / "services" / "inventory_builder.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["_ib_14328"] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.modules.pop("_ib_14328", None)
+    return module
+
+
+_ib = _load()
+
+# Plays in update-all-nodes.yml that assume the manager's own filesystem —
+# /opt/autobot/code_source and /opt/autobot/autobot-slm-backend.
+_MANAGER_ONLY_GROUP = "slm_server"
+
+
+@pytest.mark.parametrize(
+    "roles",
+    [
+        ["slm-agent"],
+        ["slm_agent"],
+        ["vnc", "slm-agent"],
+        ["npu-worker", "slm-agent"],
+        ["browser-service", "slm-agent"],
+    ],
+)
+def test_a_node_carrying_only_the_agent_is_not_an_slm_server(roles):
+    """The agent alone must never imply the manager.
+
+    Parametrised over the role combinations a real fleet node carries, because
+    the defect was in a *prefix* match — it fires for any token starting with
+    `slm-`, so the guard has to cover the shapes that actually occur rather
+    than the one that was reported.
+    """
+    groups = _ib.groups_for_role_tokens(roles)
+
+    assert _MANAGER_ONLY_GROUP not in groups, (
+        f"roles {roles} put the node in {_MANAGER_ONLY_GROUP}, so Play 1 of "
+        "update-all-nodes.yml would run the manager's update against it (#14328)"
+    )
+
+
+@pytest.mark.parametrize(
+    "role",
+    ["slm-backend", "slm-frontend", "slm-database", "slm-monitoring"],
+)
+def test_the_managers_own_components_still_are(role):
+    """The other half, which the fix must not break.
+
+    Removing `slm_server` from the agent is only correct while the manager
+    still reaches it by its own roles. A fix that dropped everyone from
+    `slm_server` would satisfy the rule above and silently stop updating the
+    manager.
+    """
+    assert _MANAGER_ONLY_GROUP in _ib.groups_for_role_tokens([role])
+
+
+def test_the_real_manager_role_set_is_still_an_slm_server():
+    """The live manager carries all four plus the agent."""
+    manager = ["slm-backend", "slm-frontend", "slm-database", "slm-monitoring", "slm-agent"]
+
+    assert _MANAGER_ONLY_GROUP in _ib.groups_for_role_tokens(manager)
+
+
+def test_the_agent_still_joins_the_fleet_groups():
+    """It must lose `slm_server` without losing everything.
+
+    `slm_nodes` is what the agent-management plays target; dropping it would
+    trade a wrong-play bug for a never-managed one.
+    """
+    groups = _ib.groups_for_role_tokens(["vnc", "slm-agent"])
+
+    assert "slm_nodes" in groups
+    assert "slm" in groups
+
+
+def test_the_exact_key_beats_the_prefix():
+    """Why the fix works at all, pinned so a reorder cannot silently undo it.
+
+    `_role_tokens_to_groups` checks exact keys first and `continue`s, so the
+    explicit `slm-agent` entry wins over the `slm-` prefix. If that ordering
+    were ever inverted, the agent would inherit `slm_server` again and every
+    test above would fail — this one names the mechanism so the failure is
+    diagnosable rather than mysterious.
+    """
+    assert "slm-agent" in _ib._ROLE_TO_GROUPS, "the exact key is gone; the prefix would take over"
+    assert _MANAGER_ONLY_GROUP not in _ib._ROLE_TO_GROUPS["slm-agent"]
+    assert _MANAGER_ONLY_GROUP in _ib._ROLE_TO_GROUPS["slm-"]

--- a/autobot-slm-backend/services/inventory_builder_agent_group_test.py
+++ b/autobot-slm-backend/services/inventory_builder_agent_group_test.py
@@ -35,9 +35,7 @@ _BACKEND_ROOT = Path(__file__).resolve().parents[1]
 
 
 def _load():
-    spec = importlib.util.spec_from_file_location(
-        "_ib_14328", _BACKEND_ROOT / "services" / "inventory_builder.py"
-    )
+    spec = importlib.util.spec_from_file_location("_ib_14328", _BACKEND_ROOT / "services" / "inventory_builder.py")
     module = importlib.util.module_from_spec(spec)
     sys.modules["_ib_14328"] = module
     try:


### PR DESCRIPTION
## Thinking Path

Reported from a live `update-all` run. The obvious reading is "the marker task is broken" — it is
not. The task is fine; it is running on a host it was never meant to touch.

`update-all-nodes.yml`'s **"Play 1 - Update SLM Server First"** gates on `hosts: slm_server`. A VNC
fleet node matched that gate.

## Problem

`_ROLE_TO_GROUPS` carried one prefix key for two different things:

```python
"slm-": frozenset({"slm", "slm_server", "slm_nodes"}),
```

Correct for `slm-backend`, `slm-frontend`, `slm-database`, `slm-monitoring` — the manager's own
components. It also catches **`slm-agent`**, which runs on *every* fleet node.

So every agent-carrying node joined `slm_server` and got the manager's update play run against it:

```
git -c safe.directory=/opt/autobot/code_source -C /opt/autobot/code_source rev-parse HEAD
  > /opt/autobot/autobot-slm-backend/.deployed_commit
```

Neither path exists off the manager. Non-zero rc, and `_fail_fleet_stage` halts the whole stage.

Confirmed against the resolver rather than inferred:

```
node roles ['vnc', 'slm-agent'] -> ['slm', 'slm_nodes', 'slm_server']
Play 1 gate 'slm_server' matched: True
```

## Why now

It has always been wrong. #11511 skipped non-operational nodes, so Play 1 never actually ran against
a fleet node; #14297 replaced that skip with ansible's UNREACHABLE verdict, the node is reachable,
and the latent defect became a hard failure.

The #14297 mechanism behaved correctly throughout: this arrived as `FAILED`, not `UNREACHABLE`, so
it was recorded as a real failure rather than quietly counted as a skip. That distinction is the
whole point of that change, and it is what made this diagnosable instead of another silent no-op.

## What Changed

An explicit exact key. `_role_tokens_to_groups` checks exact keys **before** the prefix and
`continue`s, so it wins without touching the prefix the manager relies on:

```python
"slm-agent": frozenset({"slm", "slm_nodes"}),
"slm_agent": frozenset({"slm", "slm_nodes"}),
```

| role set | slm_server before | after |
|---|---|---|
| manager (4 components + agent) | yes | **yes** |
| vnc + slm-agent | yes | **no** |
| slm-agent alone | yes | **no** |
| slm-backend alone | yes | **yes** |

## Verification

CI. The guard is parametrised over the role combinations real fleet nodes carry — `["slm-agent"]`,
`["slm_agent"]`, `["vnc","slm-agent"]`, `["npu-worker","slm-agent"]`,
`["browser-service","slm-agent"]` — because the defect was a *prefix* match and fires for any token
starting with `slm-`. Pinning only the reported shape would leave the others unguarded.

Mutation-checked in both directions:

| mutation | result |
|---|---|
| remove the exact `slm-agent` key | node returns to `slm_server` — rule fails |
| drop `slm_server` from the `"slm-"` prefix | manager stops being an `slm_server` — second rule fails |

That second one matters: a "fix" that removed everyone from `slm_server` would satisfy the first
rule while silently ending manager updates. `test_the_managers_own_components_still_are` and
`test_the_real_manager_role_set_is_still_an_slm_server` exist for exactly that.

`test_the_agent_still_joins_the_fleet_groups` covers the other over-correction — losing
`slm_server` must not mean losing `slm_nodes`, or a wrong-play bug becomes a never-managed one.

Not run locally, by instruction.

## Risks

A node carrying **only** `slm-agent` and no other SLM component leaves `slm_server`. Any play gating
on that group stops targeting it — which is the fix, and Play 1 is the only such play in
`update-all-nodes.yml`. Plays that legitimately target every agent use `slm_nodes`, which is
unchanged.

## Model Used

Opus 5 (1M context).

Closes #14330
