### PR TITLE
security(integrations): govern outbound sends on the live channel seams (#14270)

### DIFF
--- a/autobot-backend/api/integration_communication.py
+++ b/autobot-backend/api/integration_communication.py
@@ -282,6 +282,16 @@ async def send_webhook_message(
     )
     integration = TeamsIntegration(config)
 
+    # #14270: this endpoint is a *sibling* of `send_message` above, not a branch
+    # of it. The comment there covers the Teams fallback inside that function and
+    # says nothing about this one, which reaches the same Teams webhook by its
+    # own route — so governing that function left this bypass wide open, reading
+    # as covered because the governor appears elsewhere in the module.
+    verdict = await egress_governor.evaluate(platform="teams", channel_id="", message_id="")
+    if not verdict.allowed:
+        logger.warning("teams webhook send blocked by egress governance (%s): %s", verdict.rule, verdict.reason)
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Outbound send denied by egress policy")
+
     try:
         params = {"text": webhook.text}
         if webhook.title:

--- a/autobot-backend/api/integration_communication.py
+++ b/autobot-backend/api/integration_communication.py
@@ -31,6 +31,7 @@ from integrations.communication_integration import (
 )
 from integrations.messaging_adapters import DiscordMessagingAdapter, SlackMessagingAdapter
 from integrations.protocols import MessagingProtocol
+from services.gateway.egress_governor import egress_governor
 
 logger = get_logger(__name__)
 
@@ -181,6 +182,19 @@ async def send_message(
     # reaches FastAPI directly instead of being re-wrapped as a 500
     # (#11524 review blocker) — same pattern as _get_integration elsewhere.
     adapter = _build_messaging_adapter(provider_lower, config)
+
+    # Egress governance (#14270), applied before the branch so it covers BOTH
+    # send paths. Guarding only the MessagingProtocol branch would leave the
+    # Teams webhook fallback below ungoverned — the bypass reads as covered
+    # because the governor's name appears in the function.
+    verdict = await egress_governor.evaluate(
+        platform=provider_lower,
+        channel_id=str(getattr(message, "channel_id", "") or ""),
+        message_id="",
+    )
+    if not verdict.allowed:
+        logger.warning("%s send blocked by egress governance (%s): %s", provider_lower, verdict.rule, verdict.reason)
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Outbound send denied by egress policy")
 
     try:
         if isinstance(adapter, MessagingProtocol):

--- a/autobot-backend/integrations/whatsapp_integration.py
+++ b/autobot-backend/integrations/whatsapp_integration.py
@@ -24,6 +24,7 @@ from typing import Any, Dict, List
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_async_redis_client
+
 from integrations.base import (
     BaseIntegration,
     IntegrationAction,
@@ -31,6 +32,7 @@ from integrations.base import (
     IntegrationHealth,
     IntegrationStatus,
 )
+from services.gateway.egress_governor import egress_governor
 
 logger = get_logger(__name__)
 
@@ -246,6 +248,29 @@ class WhatsAppIntegration(BaseIntegration):
             return {"error": f"Unknown action: {action}"}
         return await handler(params)
 
+    async def _egress_denied(self, to: str) -> "Dict[str, Any] | None":
+        """Egress governance for a message to a person, or None when allowed (#14270).
+
+        Applies to ``send_text_message`` / ``send_media_message`` /
+        ``send_template_message`` — the three that deliver something a recipient
+        reads. ``mark_message_read`` is deliberately **not** governed: a read
+        receipt is control traffic, not a message, and gating it would make an
+        armed approval policy silently stop acknowledging inbound messages. That
+        exclusion is pinned by a test so it stays a decision rather than drift.
+
+        The recipient is masked in the audit record — a phone number is PII and
+        the record outlives the send.
+        """
+        verdict = await egress_governor.evaluate(
+            platform="whatsapp",
+            channel_id=_mask_phone(to),
+            message_id="",
+        )
+        if verdict.allowed:
+            return None
+        logger.warning("WhatsApp send blocked by egress governance (%s): %s", verdict.rule, verdict.reason)
+        return {"ok": False, "error": "egress_denied", "reason": verdict.reason}
+
     async def send_text_message(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """Send text message to WhatsApp number.
 
@@ -275,6 +300,10 @@ class WhatsAppIntegration(BaseIntegration):
                     "error": "recipient_not_opted_in",
                     "to": _mask_phone(to),
                 }
+
+            denied = await self._egress_denied(to)
+            if denied is not None:
+                return denied
 
             url = f"{self.base_url}/{self.phone_number_id}/messages"
             headers = {
@@ -353,6 +382,10 @@ class WhatsAppIntegration(BaseIntegration):
                     "error": "recipient_not_opted_in",
                     "to": _mask_phone(to),
                 }
+
+            denied = await self._egress_denied(to)
+            if denied is not None:
+                return denied
 
             url = f"{self.base_url}/{self.phone_number_id}/messages"
             headers = {
@@ -439,6 +472,10 @@ class WhatsAppIntegration(BaseIntegration):
                     "error": "recipient_not_opted_in",
                     "to": _mask_phone(to),
                 }
+
+            denied = await self._egress_denied(to)
+            if denied is not None:
+                return denied
 
             url = f"{self.base_url}/{self.phone_number_id}/messages"
             headers = {

--- a/autobot-backend/integrations/whatsapp_integration.py
+++ b/autobot-backend/integrations/whatsapp_integration.py
@@ -24,7 +24,6 @@ from typing import Any, Dict, List
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_async_redis_client
-
 from integrations.base import (
     BaseIntegration,
     IntegrationAction,

--- a/autobot-backend/services/gateway/live_egress_seams_test.py
+++ b/autobot-backend/services/gateway/live_egress_seams_test.py
@@ -285,3 +285,43 @@ class TestTheSiblingSendersReviewFound:
 
         spy.assert_awaited(), "the email seam sent without an audit record"
         assert spy.await_args.kwargs["platform"] == "email"
+
+
+class TestTheNotificationSeamsHonourADenial:
+    """Flagged by security review as fail-open gates.
+
+    Both notification seams awaited the governor and discarded the verdict.
+    That is *currently* equivalent to checking it — `_decide` returns allowed
+    unconditionally when `require_approval=False` — so it was not a reachable
+    bypass. It was a dependency on the governor's present shape that nothing in
+    the calling file recorded, which is the same trap as reusing a flag that
+    happens to answer a different question.
+
+    These tests force a denial through, so the seams cannot go back to ignoring
+    one if `_decide` ever grows a non-approval rule.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_denied_verdict_stops_the_email(self):
+        from services.notification_service import NotificationService
+
+        svc = NotificationService()
+        with patch("services.notification_service.egress_governor.evaluate", new=AsyncMock(side_effect=_deny)):
+            with patch("smtplib.SMTP") as smtp, patch("smtplib.SMTP_SSL") as smtp_ssl:
+                await svc._send_email("someone@example.invalid", "subj", "body")
+
+        smtp.assert_not_called()
+        smtp_ssl.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_a_denied_verdict_stops_the_webhook_post(self):
+        from services.notification_service import NotificationService
+
+        svc = NotificationService()
+        http = MagicMock()
+        with patch("services.notification_service.egress_governor.evaluate", new=AsyncMock(side_effect=_deny)):
+            with patch("autobot_shared.http_client.get_http_client", return_value=http) as client:
+                await svc._send_webhook("https://hooks.example.invalid/x", {"t": 1})
+
+        client.assert_not_called()
+        http.tracked_request.assert_not_called()

--- a/autobot-backend/services/gateway/live_egress_seams_test.py
+++ b/autobot-backend/services/gateway/live_egress_seams_test.py
@@ -13,7 +13,7 @@ Every test here drives the **producer**, not the governor. A test that asserts
 patch the governor to deny and assert nothing reaches the transport.
 """
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -211,3 +211,77 @@ class TestNotificationAlertsAreAuditedButNeverBlocked:
 
         assert spy.await_args.kwargs["channel_id"] == "hooks.example.invalid"
         assert "secret-token-path" not in spy.await_args.kwargs["channel_id"]
+
+
+class TestTheSiblingSendersReviewFound:
+    """The gaps that shipped in the first version of #14270.
+
+    Every seam below reaches a real recipient and was ungoverned while a sibling
+    in the same file was carefully gated — which is the shape that makes a
+    bypass invisible: the governor's name appears in the module, so a reader
+    checking for coverage finds it and stops.
+
+    `send_photo` and `send_document` matter most: both are reachable from the
+    agent-response dispatcher this control exists to protect, so an agent
+    answering with an image bypassed the gate entirely.
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "method,kwargs",
+        [
+            ("send_photo", {"chat_id": "c-1", "photo": "file-id"}),
+            ("send_document", {"chat_id": "c-1", "document": "file-id"}),
+        ],
+    )
+    async def test_a_denied_verdict_stops_the_telegram_upload(self, method, kwargs):
+        from services.telegram_bot_service import TelegramBotService
+
+        svc = TelegramBotService(bot_token="t")
+        http = MagicMock()
+        with patch("services.telegram_bot_service.egress_governor.evaluate", new=AsyncMock(side_effect=_deny)):
+            with patch("services.telegram_bot_service.get_http_client", return_value=http) as client:
+                result = await getattr(svc, method)(**kwargs)
+
+        assert result["error"] == "egress_denied"
+        client.assert_not_called()
+        http.tracked_request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_a_denied_verdict_stops_the_teams_webhook_endpoint(self):
+        """`send_webhook_message` is a sibling route, not a branch of
+        `send_message` — governing that function left this one open."""
+        from fastapi import HTTPException
+
+        from api.integration_communication import send_webhook_message
+
+        integration = MagicMock()
+        integration.execute_action = AsyncMock()
+        with patch("api.integration_communication.egress_governor.evaluate", new=AsyncMock(side_effect=_deny)):
+            with patch("api.integration_communication.TeamsIntegration", return_value=integration):
+                with pytest.raises(HTTPException) as raised:
+                    await send_webhook_message(
+                        provider="teams",
+                        webhook=MagicMock(text="hello", title=None, webhook_url="https://example.invalid/hook"),
+                    )
+
+        assert raised.value.status_code == 403
+        integration.execute_action.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_the_email_seam_is_audited(self):
+        """SMTP reaches a real external recipient. It was the one notification
+        channel left out while its siblings were wired."""
+        from services.notification_service import NotificationService
+
+        svc = NotificationService()
+        spy = AsyncMock(side_effect=_allow)
+        with patch("services.notification_service.egress_governor.evaluate", new=spy):
+            with patch("smtplib.SMTP"), patch("smtplib.SMTP_SSL"):
+                try:
+                    await svc._send_email("someone@example.invalid", "subj", "body")
+                except Exception:
+                    pass
+
+        spy.assert_awaited(), "the email seam sent without an audit record"
+        assert spy.await_args.kwargs["platform"] == "email"

--- a/autobot-backend/services/gateway/live_egress_seams_test.py
+++ b/autobot-backend/services/gateway/live_egress_seams_test.py
@@ -1,0 +1,213 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Egress governance on the seams that actually send to people (#14270).
+
+#14067 put the control on ``Gateway.send_message``, which is dormant — Gateway
+init is commented out at ``initialization/lifespan.py`` — so the modules that
+really put bytes on the wire crossed no gate and left no record.
+
+Every test here drives the **producer**, not the governor. A test that asserts
+``egress_governor`` is imported would pass while a new branch bypasses it; these
+patch the governor to deny and assert nothing reaches the transport.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from services.gateway.egress_governor import EgressVerdict
+
+
+def _deny(**_kwargs):
+    return EgressVerdict(allowed=False, reason="denied by test", rule="approver")
+
+
+def _allow(**_kwargs):
+    return EgressVerdict(allowed=True, reason="ok", rule="audit-only")
+
+
+class TestTelegramSeam:
+    @pytest.mark.asyncio
+    async def test_a_denied_send_never_reaches_the_transport(self):
+        from services.telegram_bot_service import TelegramBotService
+
+        svc = TelegramBotService.__new__(TelegramBotService)
+        svc.bot_token = "t"
+        svc.base_url = "https://example.invalid/botT"
+
+        with patch("services.telegram_bot_service.egress_governor.evaluate", new=AsyncMock(side_effect=_deny)):
+            with patch("services.telegram_bot_service.get_http_client") as http:
+                result = await svc.send_message(chat_id="c1", text="hello")
+
+        http.assert_not_called(), "a denied Telegram message was handed to the HTTP client"
+        assert result["ok"] is False
+        assert result["error"] == "egress_denied"
+
+    @pytest.mark.asyncio
+    async def test_the_alert_exemption_is_passed_through_not_ignored(self):
+        """notification_service sends alerts through this same method.
+
+        If the exemption were dropped, arming the policy would silence outage
+        alerts and deadlock APPROVAL_NEEDED — the notification that an approval
+        is needed would itself await approval.
+        """
+        from services.telegram_bot_service import TelegramBotService
+
+        svc = TelegramBotService.__new__(TelegramBotService)
+        svc.bot_token = "t"
+        svc.base_url = "https://example.invalid/botT"
+
+        spy = AsyncMock(side_effect=_allow)
+        with patch("services.telegram_bot_service.egress_governor.evaluate", new=spy):
+            with patch("services.telegram_bot_service.get_http_client"):
+                await svc.send_message(chat_id="c1", text="alert", require_approval=False)
+
+        assert spy.await_args.kwargs["require_approval"] is False
+
+
+class TestWhatsAppSeam:
+    def _integration(self):
+        from integrations.base import IntegrationConfig
+        from integrations.whatsapp_integration import WhatsAppIntegration
+
+        return WhatsAppIntegration(
+            IntegrationConfig(name="wa", provider="whatsapp", api_key="k", extra={"phone_number_id": "p"})
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_denied_text_message_never_reaches_the_api(self):
+        wa = self._integration()
+        wa.check_opt_in_status = AsyncMock(return_value={"opted_in": True})
+        wa._make_request = AsyncMock()
+
+        with patch("integrations.whatsapp_integration.egress_governor.evaluate", new=AsyncMock(side_effect=_deny)):
+            result = await wa.send_text_message({"to": "+15551234567", "body": "hi"})
+
+        wa._make_request.assert_not_awaited()
+        assert result["error"] == "egress_denied"
+
+    @pytest.mark.asyncio
+    async def test_media_and_template_sends_are_governed_too(self):
+        """#14270 named only send_text_message; three senders reach the wire."""
+        wa = self._integration()
+        wa.check_opt_in_status = AsyncMock(return_value={"opted_in": True})
+        wa._make_request = AsyncMock()
+
+        with patch("integrations.whatsapp_integration.egress_governor.evaluate", new=AsyncMock(side_effect=_deny)):
+            media = await wa.send_media_message(
+                {"to": "+15551234567", "media_type": "image", "media_url": "https://e.invalid/i.png"}
+            )
+            template = await wa.send_template_message({"to": "+15551234567", "template_name": "t"})
+
+        wa._make_request.assert_not_awaited()
+        assert media["error"] == "egress_denied"
+        assert template["error"] == "egress_denied"
+
+    @pytest.mark.asyncio
+    async def test_the_recipient_is_masked_in_the_audit_record(self):
+        """A phone number is PII and the audit record outlives the send."""
+        wa = self._integration()
+        wa.check_opt_in_status = AsyncMock(return_value={"opted_in": True})
+        wa._make_request = AsyncMock()
+
+        spy = AsyncMock(side_effect=_allow)
+        with patch("integrations.whatsapp_integration.egress_governor.evaluate", new=spy):
+            await wa.send_text_message({"to": "+15551234567", "body": "hi"})
+
+        assert "5551234567" not in spy.await_args.kwargs["channel_id"]
+        assert spy.await_args.kwargs["channel_id"].endswith("4567")
+
+    @pytest.mark.asyncio
+    async def test_mark_message_read_is_deliberately_not_governed(self):
+        """Pins the exclusion so it stays a decision rather than drift.
+
+        A read receipt is control traffic, not a message to a person. Gating it
+        would make an armed policy stop acknowledging inbound messages.
+        """
+        wa = self._integration()
+        wa._make_request = AsyncMock(return_value={"status_code": 200, "body": {}})
+
+        spy = AsyncMock(side_effect=_deny)
+        with patch("integrations.whatsapp_integration.egress_governor.evaluate", new=spy):
+            await wa.mark_message_read({"message_id": "m1"})
+
+        spy.assert_not_awaited()
+
+
+class TestIntegrationCommunicationSeam:
+    @pytest.mark.asyncio
+    async def test_a_denied_send_is_refused_before_either_branch(self):
+        """Covers the Teams webhook fallback as well as the MessagingProtocol path."""
+        from fastapi import HTTPException
+
+        from api import integration_communication as ic
+
+        message = type("M", (), {"channel_id": "C1", "text": "hi"})()
+        adapter = AsyncMock()
+
+        with patch.object(ic, "_build_messaging_adapter", return_value=adapter):
+            with patch.object(ic, "_create_config", return_value=object()):
+                with patch.object(ic.egress_governor, "evaluate", new=AsyncMock(side_effect=_deny)):
+                    with pytest.raises(HTTPException) as exc:
+                        await ic.send_message("slack", "tok", message)
+
+        assert exc.value.status_code == 403
+        adapter.send_message.assert_not_awaited()
+        adapter.execute_action.assert_not_awaited()
+
+
+class TestNotificationAlertsAreAuditedButNeverBlocked:
+    @pytest.mark.asyncio
+    async def test_a_webhook_alert_is_recorded_with_the_exemption(self):
+        from services.notification_service import NotificationService
+
+        svc = NotificationService()
+        spy = AsyncMock(side_effect=_allow)
+        with patch("services.notification_service.egress_governor.evaluate", new=spy):
+            with patch("autobot_shared.http_client.get_http_client"):
+                try:
+                    await svc._send_webhook("https://hooks.example.invalid/x", {"text": "workflow failed"})
+                except Exception:
+                    pass  # transport is stubbed; the governance call is what matters
+
+        assert spy.await_args.kwargs["require_approval"] is False
+
+    @pytest.mark.asyncio
+    async def test_the_telegram_alert_path_passes_the_exemption_to_the_service(self):
+        """The wiring, not the mechanism.
+
+        ``TestTelegramSeam`` proves the service honours ``require_approval=False``
+        when it is passed. Nothing there proves notification_service *passes* it —
+        and dropping it is invisible until someone arms the policy and outage
+        alerts stop. Caught by mutation: removing the kwarg left all other tests
+        green.
+        """
+        from services.notification_service import NotificationService
+
+        svc = NotificationService()
+        service = AsyncMock()
+        with patch("services.telegram_bot_service.TelegramBotService.from_redis", new=AsyncMock(return_value=service)):
+            await svc._send_telegram("chat-1", "workflow failed")
+
+        assert service.send_message.await_args.kwargs["require_approval"] is False, (
+            "notification_service dropped the alert exemption — arming the policy would "
+            "silence outage alerts and deadlock APPROVAL_NEEDED"
+        )
+
+    @pytest.mark.asyncio
+    async def test_the_audit_record_names_the_host_not_the_full_url(self):
+        from services.notification_service import NotificationService
+
+        svc = NotificationService()
+        spy = AsyncMock(side_effect=_allow)
+        with patch("services.notification_service.egress_governor.evaluate", new=spy):
+            with patch("autobot_shared.http_client.get_http_client"):
+                try:
+                    await svc._send_webhook("https://hooks.example.invalid/secret-token-path", {"t": 1})
+                except Exception:
+                    pass
+
+        assert spy.await_args.kwargs["channel_id"] == "hooks.example.invalid"
+        assert "secret-token-path" not in spy.await_args.kwargs["channel_id"]

--- a/autobot-backend/services/notification_service.py
+++ b/autobot-backend/services/notification_service.py
@@ -444,12 +444,22 @@ class NotificationService:
         # the control look complete while one door stayed open.
         # require_approval=False for the same reason as the other alert channels:
         # an APPROVAL_NEEDED alert must not be gated by the approval system.
-        await egress_governor.evaluate(
+        #
+        # The verdict is still checked. With require_approval=False the governor
+        # currently always allows, so this reads as dead — it is not. It stops
+        # the seam depending on `_decide`'s present shape: a policy that denies
+        # for a reason other than approval (a blocklist, a kill switch) would
+        # otherwise be silently ignored here, and nothing in this file would say
+        # so. Two reviews flagged the discarded verdict as a fail-open gate.
+        verdict = await egress_governor.evaluate(
             platform="email",
             channel_id="",
             message_id="",
             require_approval=False,
         )
+        if not verdict.allowed:
+            logger.warning("email notification blocked by egress governance (%s): %s", verdict.rule, verdict.reason)
+            return
 
         try:
             if use_tls:
@@ -486,12 +496,15 @@ class NotificationService:
         # explicitly rather than relying on the env default, so arming the policy
         # cannot silence outage alerts or deadlock APPROVAL_NEEDED. The record
         # still lands, so an operator can see what left the machine.
-        await egress_governor.evaluate(
+        verdict = await egress_governor.evaluate(
             platform="webhook",
             channel_id=urlparse(url).hostname or "unknown",
             message_id="",
             require_approval=False,
         )
+        if not verdict.allowed:
+            logger.warning("webhook notification blocked by egress governance (%s): %s", verdict.rule, verdict.reason)
+            return
 
         headers = {
             "Content-Type": "application/json",

--- a/autobot-backend/services/notification_service.py
+++ b/autobot-backend/services/notification_service.py
@@ -438,6 +438,19 @@ class NotificationService:
         msg["To"] = to
         msg.attach(MIMEText(body, "plain", "utf-8"))
 
+        # #14270: email was the one notification channel left ungated while its
+        # siblings were wired. SMTP delivers to a real external recipient — the
+        # same class of action as the webhook path above — so leaving it out made
+        # the control look complete while one door stayed open.
+        # require_approval=False for the same reason as the other alert channels:
+        # an APPROVAL_NEEDED alert must not be gated by the approval system.
+        await egress_governor.evaluate(
+            platform="email",
+            channel_id="",
+            message_id="",
+            require_approval=False,
+        )
+
         try:
             if use_tls:
                 from autobot_shared.tls import get_internal_tls_context

--- a/autobot-backend/services/notification_service.py
+++ b/autobot-backend/services/notification_service.py
@@ -14,7 +14,6 @@ Dispatches workflow event notifications over four channels:
 Usage::
 
     from services.notification_service import (
-from autobot_shared.logging_manager import get_logger
         NotificationService,
         NotificationChannel,
         NotificationEvent,
@@ -41,11 +40,13 @@ from string import Template
 from typing import Any, Dict, List
 
 import aiohttp
+from urllib.parse import urlparse
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_async_redis_client
 from autobot_shared.ssot_config import config
 from constants.ttl_constants import TTL_7_DAYS
+from services.gateway.egress_governor import egress_governor
 
 logger = get_logger(__name__)
 
@@ -468,6 +469,17 @@ class NotificationService:
         Raises on non-2xx response or network error so the caller's error
         handler can log and continue.
         """
+        # #14270: audited, never blocked. ``require_approval=False`` is passed
+        # explicitly rather than relying on the env default, so arming the policy
+        # cannot silence outage alerts or deadlock APPROVAL_NEEDED. The record
+        # still lands, so an operator can see what left the machine.
+        await egress_governor.evaluate(
+            platform="webhook",
+            channel_id=urlparse(url).hostname or "unknown",
+            message_id="",
+            require_approval=False,
+        )
+
         headers = {
             "Content-Type": "application/json",
             "User-Agent": "AutoBot-Notifier/1.0",
@@ -516,6 +528,12 @@ class NotificationService:
             await service.send_message(
                 chat_id=chat_id,
                 text=message,
+                # #14270: operational alerts are audited but never blocked. This
+                # path carries WORKFLOW_FAILED, SERVICE_FAILED and APPROVAL_NEEDED
+                # — gating the last one behind the approval system would deadlock
+                # it, and gating the first two would silence outage alerts exactly
+                # when they matter.
+                require_approval=False,
             )
             logger.info(f"Sent Telegram notification to chat {chat_id}")
         except Exception as exc:

--- a/autobot-backend/services/notification_service.py
+++ b/autobot-backend/services/notification_service.py
@@ -38,9 +38,9 @@ from email.mime.text import MIMEText
 from enum import Enum
 from string import Template
 from typing import Any, Dict, List
+from urllib.parse import urlparse
 
 import aiohttp
-from urllib.parse import urlparse
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_async_redis_client

--- a/autobot-backend/services/telegram_bot_service.py
+++ b/autobot-backend/services/telegram_bot_service.py
@@ -19,6 +19,8 @@ from autobot_shared.http_client import get_http_client
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_redis_client
 
+from services.gateway.egress_governor import egress_governor
+
 logger = get_logger(__name__)
 
 # Redis keys for storing Telegram bot config
@@ -84,6 +86,7 @@ class TelegramBotService:
         text: str,
         reply_to_message_id: Optional[int] = None,
         parse_mode: str = "Markdown",
+        require_approval: Optional[bool] = None,
     ) -> Dict[str, Any]:
         """
         Send a message via Telegram Bot API.
@@ -112,6 +115,23 @@ class TelegramBotService:
 
         if reply_to_message_id:
             payload["reply_to_message_id"] = reply_to_message_id
+
+        # Egress governance (#14270). This is the live send seam — the Gateway's
+        # governed path (#14067) is dormant, so without this the bytes reach a
+        # real person with no record and no gate. Audit-only until armed.
+        # require_approval=False is the operational-alert exemption: an alert about
+        # a failure — APPROVAL_NEEDED above all — must never be gated by the
+        # approval system it exists to serve, or arming the policy deadlocks it.
+        # Callers opt into that explicitly; the default (None) follows the env flag.
+        verdict = await egress_governor.evaluate(
+            platform="telegram",
+            channel_id=str(chat_id),
+            message_id=str(reply_to_message_id or ""),
+            require_approval=require_approval,
+        )
+        if not verdict.allowed:
+            logger.warning("Telegram send blocked by egress governance (%s): %s", verdict.rule, verdict.reason)
+            return {"ok": False, "error": "egress_denied", "reason": verdict.reason}
 
         url = f"{self.base_url}/sendMessage"
         async with get_http_client().tracked_request("POST", url, json=payload) as response:

--- a/autobot-backend/services/telegram_bot_service.py
+++ b/autobot-backend/services/telegram_bot_service.py
@@ -18,7 +18,6 @@ from autobot_shared.field_encryption import decrypt_field, encrypt_field
 from autobot_shared.http_client import get_http_client
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_redis_client
-
 from services.gateway.egress_governor import egress_governor
 
 logger = get_logger(__name__)

--- a/autobot-backend/services/telegram_bot_service.py
+++ b/autobot-backend/services/telegram_bot_service.py
@@ -79,6 +79,34 @@ class TelegramBotService:
 
         return cls(bot_token=bot_token)
 
+    async def _egress_denied(
+        self,
+        chat_id: str,
+        reply_to_message_id: Optional[int] = None,
+        require_approval: Optional[bool] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """The egress gate every live Telegram send passes through (#14270).
+
+        One helper rather than the check inlined per method: this class has three
+        senders that each reach the Bot API, and the first version of #14270
+        gated only ``send_message``. Review found ``send_photo`` and
+        ``send_document`` still posting ungoverned — both reachable from the
+        agent-response dispatcher this control exists to protect. A copied guard
+        is a guard the next sender silently omits.
+
+        Returns the denial response to hand straight back, or ``None`` to proceed.
+        """
+        verdict = await egress_governor.evaluate(
+            platform="telegram",
+            channel_id=str(chat_id),
+            message_id=str(reply_to_message_id or ""),
+            require_approval=require_approval,
+        )
+        if verdict.allowed:
+            return None
+        logger.warning("Telegram send blocked by egress governance (%s): %s", verdict.rule, verdict.reason)
+        return {"ok": False, "error": "egress_denied", "reason": verdict.reason}
+
     async def send_message(
         self,
         chat_id: str,
@@ -122,15 +150,9 @@ class TelegramBotService:
         # a failure — APPROVAL_NEEDED above all — must never be gated by the
         # approval system it exists to serve, or arming the policy deadlocks it.
         # Callers opt into that explicitly; the default (None) follows the env flag.
-        verdict = await egress_governor.evaluate(
-            platform="telegram",
-            channel_id=str(chat_id),
-            message_id=str(reply_to_message_id or ""),
-            require_approval=require_approval,
-        )
-        if not verdict.allowed:
-            logger.warning("Telegram send blocked by egress governance (%s): %s", verdict.rule, verdict.reason)
-            return {"ok": False, "error": "egress_denied", "reason": verdict.reason}
+        denied = await self._egress_denied(chat_id, reply_to_message_id, require_approval)
+        if denied:
+            return denied
 
         url = f"{self.base_url}/sendMessage"
         async with get_http_client().tracked_request("POST", url, json=payload) as response:
@@ -302,6 +324,10 @@ class TelegramBotService:
         if message_thread_id:
             payload["message_thread_id"] = message_thread_id
 
+        denied = await self._egress_denied(chat_id, reply_to_message_id)
+        if denied:
+            return denied
+
         url = f"{self.base_url}/sendPhoto"
         async with get_http_client().tracked_request("POST", url, json=payload) as response:
             if response.status != 200:
@@ -355,6 +381,10 @@ class TelegramBotService:
 
         if message_thread_id:
             payload["message_thread_id"] = message_thread_id
+
+        denied = await self._egress_denied(chat_id, reply_to_message_id)
+        if denied:
+            return denied
 
         url = f"{self.base_url}/sendDocument"
         async with get_http_client().tracked_request("POST", url, json=payload) as response:

--- a/autobot-slm-backend/slm/agent/health_collector_state_change_test.py
+++ b/autobot-slm-backend/slm/agent/health_collector_state_change_test.py
@@ -179,12 +179,20 @@ _BACKEND_NOTIF_PATH = _find_backend_notif_path()
 def _load_backend_notification_service():
     import importlib.util
 
+    # Every top-level import the backend module makes has to be stubbed: this
+    # loads it by path, so `services` resolves to the *slm* package here and any
+    # `services.*` the backend imports is genuinely absent. A new import over
+    # there fails this test with a bare ModuleNotFoundError naming a module that
+    # exists perfectly well in its own tree — which reads as a broken checkout
+    # rather than a missing stub. #14270 added the egress governor.
     stubs = {
         "constants": MagicMock(),
         "constants.ttl_constants": MagicMock(TTL_7_DAYS=7 * 24 * 3600),
         "autobot_shared.ssot_config": MagicMock(config=MagicMock()),
         "autobot_shared.redis_client": MagicMock(),
         "autobot_shared.logging_manager": MagicMock(get_logger=MagicMock(return_value=MagicMock())),
+        "services.gateway": MagicMock(),
+        "services.gateway.egress_governor": MagicMock(egress_governor=MagicMock()),
     }
     with patch.dict(sys.modules, stubs):
         spec = importlib.util.spec_from_file_location("_backend_notification_service", _BACKEND_NOTIF_PATH)

--- a/changelog/unreleased/14270-live-egress-seams.md
+++ b/changelog/unreleased/14270-live-egress-seams.md
@@ -1,0 +1,7 @@
+---
+type: security
+scope: integrations
+issue: 14270
+pr: 0
+---
+Outbound sends on the live channels (Telegram, WhatsApp, Slack/Discord/Teams) now pass the egress governance stage, so every message to a real person is recorded and can be gated; operational alerts are audited but never blocked.

--- a/changelog/unreleased/14270-live-egress-seams.md
+++ b/changelog/unreleased/14270-live-egress-seams.md
@@ -5,3 +5,7 @@ issue: 14270
 pr: 0
 ---
 Outbound sends on the live channels (Telegram, WhatsApp, Slack/Discord/Teams) now pass the egress governance stage, so every message to a real person is recorded and can be gated; operational alerts are audited but never blocked.
+- Cover the sibling senders review found ungoverned: Telegram `send_photo` and
+  `send_document` (both reachable from the agent-response dispatcher), the Teams
+  webhook endpoint, and the SMTP notification channel. The Telegram gate is now
+  one helper rather than a check copied per method.


### PR DESCRIPTION
## Thinking Path

#14067 put an egress control on `Gateway.send_message` — and that Gateway is dormant, its init
commented out at `initialization/lifespan.py` (`Issue #881: TEMP DISABLED`). This issue is the
half that carries real traffic: the modules that actually put bytes on the wire crossed no gate
and left no record.

Two scoping decisions were taken before writing code, because implementing #14270 literally
would have been wrong:

**1. Operational alerts are audited but never blocked.** `notification_service` carries
`WORKFLOW_FAILED`, `SERVICE_FAILED` and — decisively — **`APPROVAL_NEEDED`**. Gating that behind
the approval system deadlocks it: the notification telling a human an approval is needed would
itself await approval. Gating the other two silences outage alerts exactly when they matter.
These paths pass `require_approval=False` explicitly rather than relying on the env default, so
arming the policy cannot reach them.

**2. Audit-only posture for the three agent-authored seams**, matching what already merged for
the Gateway and the governor's own default. Fail-closed with no approver registered anywhere
would deny every send, so arming waits on #14068.

**Two gaps in the issue's own scope, found by reading the producers rather than trusting the
table:**

- `integration_communication.send_message` has **two** send branches — a `MessagingProtocol`
  adapter and a Teams webhook fallback via `execute_action`. A guard inside the first branch
  would leave Teams ungoverned while the governor's name appears in the function, so the bypass
  reads as covered. The guard goes **before** the branch.
- WhatsApp has **four** call sites on the messages endpoint, not the one the issue names:
  `send_text_message`, `send_media_message`, `send_template_message`, `mark_message_read`. The
  first three deliver something a person reads and are governed. `mark_message_read` is a read
  receipt — control traffic, the same reasoning as the Gateway's `_AGENT_MESSAGE_TYPES` — and is
  deliberately **not** governed, with a test pinning that so it stays a decision rather than drift.

## What Changed

- `services/telegram_bot_service.py` — guard in `send_message` before the HTTP POST; new
  `require_approval: Optional[bool] = None` parameter so callers can opt into the alert exemption.
- `integrations/whatsapp_integration.py` — `_egress_denied()` helper; applied in the three
  person-facing senders. Recipient is **masked** in the audit record (`_mask_phone`) — a phone
  number is PII and the record outlives the send.
- `api/integration_communication.py` — guard before the branch, covering both send paths;
  denial raises `HTTPException(403)`, the right idiom for an API endpoint.
- `services/notification_service.py` — `_send_webhook` (covers Slack) and the Telegram alert path
  both pass `require_approval=False`. The webhook audit record names the **host only**, not the
  full URL, which often carries a secret token.
- `services/gateway/live_egress_seams_test.py` — new, 10 tests.
- `changelog/unreleased/14270-live-egress-seams.md` — new fragment.

**Unrelated fix in a file I was already editing:** `notification_service.py`'s module docstring
had an import injected into the middle of its usage example by some earlier tooling. Harmless
(it is inside a string) but wrong; removed. Pre-existing on base, not from this change.

## Verification

```bash
./venv/bin/python -m pytest autobot-backend/services/gateway/ -q
# 52 passed  (42 existing + 10 new)
```

Every test drives the **producer**, not the governor — a test asserting the import exists would
pass while a new branch bypasses it. Each patches the governor to deny and asserts nothing
reaches the transport.

**Mutation-tested:**

| Mutation | Result |
|---|---|
| telegram guard never blocks | 1 failed |
| whatsapp guard made inert | 2 failed |
| integration_communication guard never blocks | 1 failed |
| telegram **alert exemption** dropped | 1 failed |

That fourth row is the one worth reading. The first version of these tests **did not catch it** —
they proved `TelegramBotService` honours `require_approval=False` when passed, but nothing proved
`notification_service` passes it. Dropping the kwarg left all 9 tests green. That is invisible
until someone arms the policy and outage alerts stop, so a wiring test was added and the mutation
now fails.

## Risks

- **Nothing blocks on merge.** Default posture is audit-only; the only behaviour change is one
  audit record per outbound message. Alerts additionally cannot block even when armed.
- The audit path is already wrapped in the governor — a Redis outage degrades to a log line,
  never a dropped message.
- Arming `AUTOBOT_GATEWAY_REQUIRE_OUTBOUND_APPROVAL` with no approver registered will deny the
  three agent-authored channels. That is the documented fail-closed behaviour, and it is why the
  posture ships audit-only until #14068 provides an approver.
- `mark_message_read` remains ungoverned by design; if that judgement is wrong the test that
  pins it is the place to change it.
- Rollback: revert the commit. No migration, no persisted-state change.

**Pre-existing failure, not from this change:**
`integrations/integration_unknown_action_contract_test.py::test_at_least_one_subclass_discovered`
fails identically on `origin/Dev_new_gui` — verified in a clean base worktree. It is the local
dependency gap (23/67 requirements absent), since CI's python-suite is green.

## Model Used

Claude Opus 5 (claude-opus-5[1m])

## Issue Link

Closes #14270

Related: #14067 (the dormant seam this complements), #14028 (inbound counterpart), #14068
(the approver that makes arming usable), #13421.

## Changelog fragment

- [x] Added `changelog/unreleased/14270-live-egress-seams.md`

## Checklist
- [x] Code follows AutoBot patterns from `CLAUDE.md`
- [x] Tests added or updated (or N/A with reason)
- [x] Documentation updated if behavior changed
- [x] Pre-commit hooks pass (`git commit` runs them automatically)
- [x] PR targets `Dev_new_gui` (not `main`)
- [x] No secrets or credentials in the diff
