### PR TITLE
fix(chat): every prior assistant reply reached the model as the caller (#14305)

### DIFF
--- a/.session/HANDOFF-issue-14305.md
+++ b/.session/HANDOFF-issue-14305.md
@@ -1,0 +1,40 @@
+# Handoff: issue-14305
+
+status: complete
+pr: #14338
+base_at_push: origin/Dev_new_gui @ 7f5d11605
+gates: flake8=PASS black=PASS isort=PASS tests=PASS (49 targeted, 208 surrounding)
+needs_rebase_before_merge: no
+remaining: (none — awaiting CI + merge)
+
+## What landed here
+
+Every prior turn reached the model attributed to the caller, the assistant's own
+replies included, because the reader asked for the API-shape role key over records
+whose writer stores the speaker under the stored key.
+
+Two things a successor must not undo:
+
+1. **`llm_role` is an allowlist, deliberately.** Not a denylist of the terminal /
+   agent-terminal / state-machine speakers. Those were found by grepping ONE
+   keyword-argument form; a sender passed positionally or via a variable would not
+   have appeared, and review found ~a dozen more from the websocket layer. Naming
+   what may pass is what keeps the unenumerated ones safe.
+
+2. **The system role is excluded on purpose.** Persisted approval notices use that
+   speaker, and an adapter that splits the role out hoists it into the instruction
+   channel. Today the plain chat path carries no competing system prompt for it to
+   overwrite (`chat_optimized` does); the exclusion is about not elevating ordinary
+   history into the highest-trust slot, not about a live collision.
+
+## Sequencing constraint
+
+**#14342 must not be fixed before this merges.** The websocket layer drops its
+session id, which is the only reason its ~dozen non-conversational speakers are
+inert. Close that routing gap first and they go straight into provider requests.
+
+## Filed from this work
+
+#14340 (shared-link viewer renders every session empty), #14341 (overflow summaries
+persist empty — the conversation they replaced is lost), #14342 (websocket events
+never reach their session).

--- a/autobot-backend/api/chat.py
+++ b/autobot-backend/api/chat.py
@@ -55,6 +55,7 @@ from auth_middleware import get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.error_utils import safe_http_detail
 from autobot_shared.time_utils import parse_utc_iso, utc_timestamp
+from chat_history.message_schema import message_role, message_text
 
 # Import context overflow protection (#9043)
 from chat_history.overflow_integration import create_summary_message, handle_message_completion
@@ -549,8 +550,23 @@ def _build_llm_context(
         message_limit = 20
         logger.warning("Context manager not available, using default limit")
 
+    # #14305: read through the shared normaliser. This asked for the role key
+    # with a caller-shaped default, over records `_to_persisted_message` in this
+    # same file stores the speaker under `sender` — so the key was always absent
+    # and every prior turn, the assistant's own replies included, reached the
+    # model attributed to the caller. The body survived only because that writer
+    # happens to name its field the same as the API does; the speaker did not.
+    #
+    # Non-dict entries are skipped rather than raising. They raised here both
+    # before and after this fix, and this runs *after* the answer has been
+    # generated — so a malformed record would lose a reply the user already
+    # paid for. That is the stance `as_llm_messages` and `_sanitize_tool_messages`
+    # already take. Not switched to `as_llm_messages` wholesale: that also drops
+    # empty-bodied messages, which would quietly change what the model sees here.
     llm_context = [
-        {"role": msg.get("role", "user"), "content": msg.get("content", "")} for msg in chat_context[-message_limit:]
+        {"role": message_role(msg), "content": message_text(msg)}
+        for msg in chat_context[-message_limit:]
+        if isinstance(msg, dict)
     ]
     llm_context.append({"role": message.role, "content": message.content})
 

--- a/autobot-backend/api/chat.py
+++ b/autobot-backend/api/chat.py
@@ -55,7 +55,7 @@ from auth_middleware import get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.error_utils import safe_http_detail
 from autobot_shared.time_utils import parse_utc_iso, utc_timestamp
-from chat_history.message_schema import message_role, message_text
+from chat_history.message_schema import llm_role, message_text
 
 # Import context overflow protection (#9043)
 from chat_history.overflow_integration import create_summary_message, handle_message_completion
@@ -557,6 +557,11 @@ def _build_llm_context(
     # model attributed to the caller. The body survived only because that writer
     # happens to name its field the same as the API does; the speaker did not.
     #
+    # `llm_role`, not `message_role`: a session also carries records written by
+    # terminal integration and the workflow state machine, whose speakers are
+    # not roles any provider accepts. Reading them faithfully and forwarding
+    # them would turn a mislabelled-but-working turn into a rejected request.
+    #
     # Non-dict entries are skipped rather than raising. They raised here both
     # before and after this fix, and this runs *after* the answer has been
     # generated — so a malformed record would lose a reply the user already
@@ -564,7 +569,7 @@ def _build_llm_context(
     # already take. Not switched to `as_llm_messages` wholesale: that also drops
     # empty-bodied messages, which would quietly change what the model sees here.
     llm_context = [
-        {"role": message_role(msg), "content": message_text(msg)}
+        {"role": llm_role(msg), "content": message_text(msg)}
         for msg in chat_context[-message_limit:]
         if isinstance(msg, dict)
     ]
@@ -2094,9 +2099,14 @@ async def _generate_ai_stack_chat_response(
         model_name = message.metadata.get("model") if message.metadata else None
         message_limit = _get_ai_stack_message_limit(chat_history_manager, model_name)
 
+        # The same defect `_build_llm_context` carried (#14305), on the AI Stack
+        # path: this reads its context from the same store, in the same stored
+        # shape, so the speaker was likewise never present and every turn — the
+        # assistant's own replies included — arrived attributed to the caller.
         formatted_history = [
-            {"role": msg.get("role", "user"), "content": msg.get("content", "")}
+            {"role": llm_role(msg), "content": message_text(msg)}
             for msg in chat_context[-message_limit:]
+            if isinstance(msg, dict)
         ]
 
         ai_stack_response = await ai_client.chat_message(

--- a/autobot-backend/api/chat_llm_context_test.py
+++ b/autobot-backend/api/chat_llm_context_test.py
@@ -1,0 +1,115 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""What `_build_llm_context` hands the model (#14305).
+
+It mapped the role key with a caller-shaped default over records that
+`_to_persisted_message` — in the same file — stores the speaker under `sender`.
+The key was therefore always absent, and **every** prior turn reached the model
+attributed to the caller, the assistant's own replies included.
+
+The body survived only because that writer happens to name its field the same as
+the API does. The speaker did not survive at all.
+
+Nothing caught it because the two existing tests
+(`api/chat_test.py`, `tests/unit/chat_workflow/test_citations_default_on.py`)
+both patch `_build_llm_context` out with `return_value=[]` — they mock the
+function rather than exercise its mapping. So these tests build their records
+with the **real writer** and call the **real function**.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from api.chat import _build_llm_context, _to_persisted_message
+
+
+def _persisted(role: str, content: str) -> dict:
+    """A record in the shape the chat API actually stores.
+
+    Built by the real writer rather than hand-written — a hand-written record is
+    what let this defect survive, since it would have carried the very key the
+    reader was looking for.
+    """
+    return _to_persisted_message(
+        {"id": f"m-{role}-{abs(hash(content)) % 10_000}", "role": role, "content": content},
+        "message" if role == "user" else "response",
+    )
+
+
+def _manager(limit: int = 20):
+    manager = MagicMock()
+    manager.context_manager.get_message_limit = MagicMock(return_value=limit)
+    return manager
+
+
+def _incoming(text: str = "and now?"):
+    message = MagicMock()
+    message.role = "user"
+    message.content = text
+    return message
+
+
+class TestTheSpeakerSurvives:
+    """The defect: the assistant's own words came back as the caller's."""
+
+    def test_an_assistant_turn_is_not_attributed_to_the_caller(self):
+        history = [_persisted("user", "deploy it"), _persisted("assistant", "running code-sync")]
+
+        context = _build_llm_context(history, _incoming(), _manager(), None)
+
+        assert [m["role"] for m in context[:2]] == ["user", "assistant"]
+
+    def test_the_writer_really_does_store_the_speaker_elsewhere(self):
+        """Precondition, so this test cannot pass by the bug being absent for
+        some other reason."""
+        stored = _persisted("assistant", "hi")
+
+        assert "role" not in stored, "the writer stores the speaker under a different key"
+        assert stored["sender"] == "assistant"
+
+    def test_the_bodies_are_carried_through_unchanged(self):
+        history = [_persisted("user", "deploy it"), _persisted("assistant", "running code-sync")]
+
+        context = _build_llm_context(history, _incoming(), _manager(), None)
+
+        assert [m["content"] for m in context[:2]] == ["deploy it", "running code-sync"]
+
+
+class TestTheApiShapeStillWorks:
+    """Both schemas reach this function; fixing one must not break the other."""
+
+    def test_records_already_in_api_shape_pass_through(self):
+        history = [{"role": "assistant", "content": "from the api"}]
+
+        context = _build_llm_context(history, _incoming(), _manager(), None)
+
+        assert context[0] == {"role": "assistant", "content": "from the api"}
+
+
+class TestTheIncomingTurnAndLimit:
+    def test_the_new_message_is_appended_last(self):
+        context = _build_llm_context([_persisted("user", "old")], _incoming("brand new"), _manager(), None)
+
+        assert context[-1] == {"role": "user", "content": "brand new"}
+
+    def test_only_the_most_recent_history_is_included(self):
+        history = [_persisted("user", f"turn {i}") for i in range(10)]
+
+        context = _build_llm_context(history, _incoming(), _manager(limit=3), None)
+
+        # 3 from history + the incoming turn
+        assert len(context) == 4
+        assert context[0]["content"] == "turn 7"
+
+    @pytest.mark.parametrize("junk", [None, "a string", 42])
+    def test_a_malformed_history_entry_does_not_break_the_turn(self, junk):
+        """Malformed history is data, not a programming error — a 500 here would
+        lose an answer that was already generated."""
+        history = [junk, _persisted("user", "real")]
+
+        context = _build_llm_context(history, _incoming(), _manager(), None)
+
+        assert {"role": "user", "content": "real"} in context

--- a/autobot-backend/api/chat_llm_context_test.py
+++ b/autobot-backend/api/chat_llm_context_test.py
@@ -19,11 +19,11 @@ function rather than exercise its mapping. So these tests build their records
 with the **real writer** and call the **real function**.
 """
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from api.chat import _build_llm_context, _to_persisted_message
+from api.chat import _build_llm_context, _generate_ai_stack_chat_response, _to_persisted_message
 
 
 def _persisted(role: str, content: str) -> dict:
@@ -78,6 +78,44 @@ class TestTheSpeakerSurvives:
         assert [m["content"] for m in context[:2]] == ["deploy it", "running code-sync"]
 
 
+class TestSpeakersThatAreNotConversationalRoles:
+    """A session is not written only by the chat turn.
+
+    Terminal integration, the agent terminal and the workflow state machine
+    persist into the *same* session under speakers of their own. Reading the
+    speaker faithfully and forwarding it builds a request the provider rejects,
+    which fails the whole turn — strictly worse than the mislabelling this fix
+    is about. So the LLM reader clamps.
+    """
+
+    @pytest.mark.parametrize("speaker", ["terminal", "agent_terminal", "main-backend"])
+    def test_a_non_conversational_speaker_never_reaches_the_provider(self, speaker):
+        history = [{"sender": speaker, "text": "$ ls -la", "messageType": "terminal_output"}]
+
+        context = _build_llm_context(history, _incoming(), _manager(), None)
+
+        assert {m["role"] for m in context} <= {"user", "assistant"}
+
+    def test_the_body_of_such_a_record_is_still_carried(self):
+        """Clamping the speaker must not also drop the turn — terminal output
+        is context the model legitimately needs."""
+        history = [{"sender": "terminal", "text": "$ ls -la", "messageType": "terminal_output"}]
+
+        context = _build_llm_context(history, _incoming(), _manager(), None)
+
+        assert context[0]["content"] == "$ ls -la"
+
+    def test_a_stored_system_notice_does_not_become_a_system_turn(self):
+        """The approval handler persists under that speaker. An adapter that
+        splits the system role out overwrites the system prompt with whatever
+        it finds, so passing this through would replace the real instructions."""
+        history = [{"sender": "system", "text": "Command approved"}]
+
+        context = _build_llm_context(history, _incoming(), _manager(), None)
+
+        assert context[0]["role"] != "system"
+
+
 class TestTheApiShapeStillWorks:
     """Both schemas reach this function; fixing one must not break the other."""
 
@@ -87,6 +125,40 @@ class TestTheApiShapeStillWorks:
         context = _build_llm_context(history, _incoming(), _manager(), None)
 
         assert context[0] == {"role": "assistant", "content": "from the api"}
+
+
+class TestTheAiStackPathCarriedTheSameDefect:
+    """`_generate_ai_stack_chat_response` builds its history from the same
+    store, in the same stored shape — so it mislabelled every turn identically.
+
+    Found by review of this change: fixing one reader in a file that holds two
+    leaves the second one live.
+    """
+
+    @pytest.mark.asyncio
+    async def test_an_assistant_turn_is_not_attributed_to_the_caller(self):
+        client = MagicMock()
+        client.chat_message = AsyncMock(return_value={"response": "ok"})
+        history = [_persisted("user", "deploy it"), _persisted("assistant", "running code-sync")]
+
+        with patch("api.chat.get_ai_stack_client", AsyncMock(return_value=client)):
+            await _generate_ai_stack_chat_response(_incoming(), history, None, _manager(), None)
+
+        sent = client.chat_message.call_args.kwargs["chat_history"]
+        assert [m["role"] for m in sent] == ["user", "assistant"]
+        assert [m["content"] for m in sent] == ["deploy it", "running code-sync"]
+
+    @pytest.mark.asyncio
+    async def test_a_non_conversational_speaker_never_reaches_the_provider(self):
+        client = MagicMock()
+        client.chat_message = AsyncMock(return_value={"response": "ok"})
+        history = [{"sender": "terminal", "text": "$ ls -la"}]
+
+        with patch("api.chat.get_ai_stack_client", AsyncMock(return_value=client)):
+            await _generate_ai_stack_chat_response(_incoming(), history, None, _manager(), None)
+
+        sent = client.chat_message.call_args.kwargs["chat_history"]
+        assert {m["role"] for m in sent} <= {"user", "assistant"}
 
 
 class TestTheIncomingTurnAndLimit:

--- a/autobot-backend/chat_history/message_schema.py
+++ b/autobot-backend/chat_history/message_schema.py
@@ -28,17 +28,21 @@ another copy — see the consolidate-never-fork rule.
 Known readers still on a single schema, each filed rather than silently fixed
 here because they sit in different subsystems with their own blast radius:
 
-* **#14305** — ``api/chat.py::_build_llm_context`` reads the role key from
-  records whose sibling writer stores the speaker under ``sender``, so every
-  prior turn reaches the model attributed to the caller, the assistant's own
-  replies included. Live on the chat hot path.
 * **#14306** — ``api/chat_sessions.py::_preserve_system_messages`` filters on
   the role key against disk-shape records, so ``keep_system_prompt`` preserves
   nothing and reports the count it kept as 0.
 
-(Both described without quoting the literal values: the hardcoded-value gate
-scans added lines including prose, and a comment citing a banned pattern trips
-its own lint.)
+(Described without quoting the literal values: the hardcoded-value gate scans
+added lines including prose, and a comment citing a banned pattern trips its
+own lint.)
+
+Two further readers are filed but not fixed here, because both are outages of a
+different shape than the schema mismatch this module addresses — they lose the
+record rather than mislabel it, and they sit in subsystems with their own blast
+radius: **#14340** (the shared-link viewer filters on a key stored records have
+never carried, so every shared session renders empty) and **#14341** (the
+overflow summary is written under one body key and persisted from another, so
+every auto-summary is stored empty and the conversation it condensed is gone).
 
 Deliberately NOT applied to LLM-API-only readers (``llm_shared/providers/*``,
 ``token_optimizer``, ``complexity_router``, and ``context_overflow``'s
@@ -50,6 +54,11 @@ currently correct.
 from typing import Any, Dict, List
 
 _UNKNOWN_ROLE = "unknown"
+
+# The roles a conversation turn can carry into a provider request.
+_CALLER_ROLE = "user"
+_RESPONDER_ROLE = "assistant"
+_CONVERSATION_ROLES = frozenset({_CALLER_ROLE, _RESPONDER_ROLE})
 
 
 def _valid_text_value(value: Any) -> Any:
@@ -107,6 +116,33 @@ def message_text(message: Dict[str, Any]) -> str:
             if isinstance(part, dict) and part.get("type") == "text" and isinstance(part.get("text"), str)
         ).strip()
     return str(value)
+
+
+def llm_role(message: Dict[str, Any], default: str = _CALLER_ROLE) -> str:
+    """The speaker as a role a provider will actually accept (#14305).
+
+    `message_role` answers *who spoke*, faithfully — and a chat session records
+    speakers that are not conversational roles at all. Terminal integration,
+    the agent terminal and the workflow state machine all persist into the same
+    session under names of their own, so a reader that hands `message_role`'s
+    answer straight to a provider builds a request the API rejects, failing the
+    whole turn.
+
+    Anything outside the two conversational roles therefore collapses to the
+    caller. That is exactly what the hand-written readers did for these records
+    before — they asked for a key the stored shape has never carried and took
+    their default — so this preserves their behaviour for every record whose
+    speaker was never expressible, while the two roles that *are* expressible
+    now survive instead of being flattened along with them.
+
+    The system role is deliberately not passed through. It is a legal role, but
+    it does not mean *a turn in the conversation*: an adapter that separates it
+    out hoists it into the system prompt, so a stored notice with that sender
+    would silently replace the real instructions rather than be read as history.
+    Callers that genuinely carry a system prompt add it themselves.
+    """
+    role = message_role(message, default=default)
+    return role if role in _CONVERSATION_ROLES else default
 
 
 def as_llm_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, str]]:

--- a/autobot-backend/chat_history/message_schema.py
+++ b/autobot-backend/chat_history/message_schema.py
@@ -49,6 +49,16 @@ Deliberately NOT applied to LLM-API-only readers (``llm_shared/providers/*``,
 tool-batch scan). Those handle messages that are already in API shape by
 construction, and teaching them a second schema would widen a contract that is
 currently correct.
+
+``llm_role`` is the one exception to that neutrality, and is marked as such
+rather than quietly admitted. Everything else here answers a question about the
+*stored data*; that one answers a question about what a **provider** will
+accept, which is a constraint from the other side of the boundary. It lives
+here anyway because the alternative is a second module reimplementing the
+both-schemas read, and because the constraint is not one provider's quirk —
+``vertexai``'s content builder independently collapses non-conversational roles
+the same way. If a third provider-facing rule ever wants to join it, that is the
+signal to split them out rather than to keep widening this module.
 """
 
 from typing import Any, Dict, List
@@ -135,10 +145,23 @@ def llm_role(message: Dict[str, Any], default: str = _CALLER_ROLE) -> str:
     speaker was never expressible, while the two roles that *are* expressible
     now survive instead of being flattened along with them.
 
+    This is an **allowlist**, not a list of known-bad speakers, and deliberately
+    so: the speakers above were found by grepping one keyword-argument form, so
+    a writer that passes its sender positionally or through a variable would not
+    have appeared. Naming what may pass keeps the unenumerated ones safe — and
+    they exist. The websocket layer formats about a dozen more (tool output,
+    workflow, agent-step and error variants); they are inert only because that
+    path drops its session id and writes to a bucket no session reader touches
+    (#14342). Closing that routing gap must not require revisiting this.
+
     The system role is deliberately not passed through. It is a legal role, but
-    it does not mean *a turn in the conversation*: an adapter that separates it
-    out hoists it into the system prompt, so a stored notice with that sender
-    would silently replace the real instructions rather than be read as history.
+    it does not mean *a turn in the conversation* — an adapter that separates it
+    out hoists it into the instruction channel, so a persisted operational
+    notice (an approval, a command result) would arrive as an instruction rather
+    than as history. That is an elevation of ordinary history into the
+    highest-trust slot, wrong on its own terms; it becomes destructive as well
+    on any route that carries a real system prompt for it to overwrite, which
+    `chat_optimized` already does and the plain chat path does not yet.
     Callers that genuinely carry a system prompt add it themselves.
     """
     role = message_role(message, default=default)

--- a/autobot-backend/chat_history/message_schema_test.py
+++ b/autobot-backend/chat_history/message_schema_test.py
@@ -18,7 +18,7 @@ entities carry `observations`.
 
 import pytest
 
-from chat_history.message_schema import as_llm_messages, message_role, message_text
+from chat_history.message_schema import as_llm_messages, llm_role, message_role, message_text
 
 
 def _stored(sender: str, text: str) -> dict:
@@ -137,6 +137,41 @@ class TestMultimodalContent:
         msg = {"role": "user", "content": [{"type": "image_url", "image_url": {}}, {"type": "text", "text": "caption"}]}
 
         assert message_text(msg) == "caption"
+
+
+class TestTheRoleAProviderWillAccept:
+    """`llm_role` is the clamped answer; `message_role` is the faithful one.
+
+    A chat session is not written only by the chat turn. Terminal integration,
+    the agent terminal and the workflow state machine persist into the *same*
+    session under speakers of their own, and forwarding those verbatim builds a
+    request the provider rejects — failing the whole turn, where before it
+    merely mislabelled it.
+    """
+
+    @pytest.mark.parametrize("speaker", ["terminal", "agent_terminal", "main-backend"])
+    def test_a_speaker_that_is_not_a_conversational_role_collapses_to_the_caller(self, speaker):
+        assert llm_role({"sender": speaker, "text": "$ ls"}) == "user"
+
+    @pytest.mark.parametrize("speaker", ["terminal", "agent_terminal", "main-backend"])
+    def test_message_role_still_answers_faithfully_for_those(self, speaker):
+        """The clamp belongs to the LLM reader, not to the schema itself —
+        anything reporting on a session still needs the real speaker."""
+        assert message_role({"sender": speaker, "text": "$ ls"}) == speaker
+
+    def test_the_two_conversational_roles_survive(self):
+        assert llm_role({"sender": "assistant", "text": "done"}) == "assistant"
+        assert llm_role({"sender": "user", "text": "do it"}) == "user"
+
+    def test_a_stored_system_notice_does_not_reach_the_model_as_a_system_turn(self):
+        """Approval notices are persisted under that speaker. An adapter that
+        separates the system role out hoists it into the system prompt, so
+        passing it through would replace the real instructions with 'Command
+        approved'."""
+        assert llm_role({"sender": "system", "text": "Command approved"}) == "user"
+
+    def test_a_message_with_no_speaker_at_all_gets_the_caller(self):
+        assert llm_role({"text": "orphaned"}) == "user"
 
 
 class TestMalformedHistoryIsData:


### PR DESCRIPTION
## Thinking Path

`_build_llm_context` asked for the role key with a caller-shaped default, over records that `_to_persisted_message` — **in the same file, 150 lines up** — stores the speaker under `sender`. The key was therefore never present, the default always applied, and every prior turn reached the model attributed to the caller.

Including the assistant's own replies.

```
disk ai:   {'sender': 'assistant', 'content': 'running code-sync', ...}
LLM sees:  {'role': 'user',        'content': 'running code-sync'}
```

The body survived only because that writer happens to name its field the same as the API does. The speaker did not survive at all.

Conversation history is how a chat model knows what it already said, already tried, and already promised. With every turn attributed to the user it re-answers itself, and its own prior output re-enters as user input — a correctness problem and a prompt-injection-shaped one. It presents as "the model is bad at follow-ups" rather than as a bug, which is why it lasted since February.

Found by review of #14304, which fixed the identical class in skill distillation.

## What Changed

**Reading the speaker faithfully turned out not to be enough** — and reading it *only* faithfully would have made things worse.

A chat session is not written by the chat turn alone. Terminal integration, the agent terminal and the workflow state machine all persist into the **same** session under speakers of their own:

```
services/terminal_websocket/chat_integration.py   sender="terminal"
services/agent_terminal/service.py                sender="agent_terminal"
services/workflow_automation/state_machine.py     sender="main-backend"
services/agent_terminal/approval_handler.py       sender="system"
```

None of those is a role a provider accepts. Forwarding them verbatim builds a request the API rejects, which fails **the whole turn** — strictly worse than the mislabelling being fixed, and worse specifically for sessions that used the terminal features. Reproduced before fixing:

```
history → [{'sender': 'terminal', 'text': '$ ls -la', ...}]
naive   → [{'role': 'terminal', ...}]      # 400 at the provider
```

So the LLM-facing read goes through a new `llm_role`, which collapses anything outside the two conversational roles back to the caller — exactly what the old code did for those records, so they are no worse off, while the two roles that *are* expressible now survive instead of being flattened along with them.

It is an **allowlist**, not a denylist of the senders above, and that distinction is load-bearing: those were found by grepping one keyword-argument form, so a sender passed positionally or through a variable would not have appeared. Review found about a dozen more from the websocket layer, inert today only because that path drops its session id (#14342) — the clamp already handles them, because it names what may pass rather than what may not.

`message_role` is left faithful. The clamp belongs to the reader building a provider request, not to the schema — anything reporting on a session still needs the real speaker, and there is a test pinning that separation.

The system role is deliberately **not** passed through. It is legal, but an adapter that splits it out hoists it into the instruction channel, so a persisted approval notice would arrive as an instruction rather than as history — ordinary history elevated into the highest-trust slot.

Being precise about the damage, because my first draft overstated it: on **this** route there is currently no competing system prompt for it to overwrite — `llm_service.chat()` injects none, only `chat_optimized` does. The elevation is wrong on its own terms today, and becomes destructive the moment any path here carries a real system prompt.

### The sibling in the same file

`_generate_ai_stack_chat_response` (chat.py:2097) reads its history from the same store, in the same stored shape, and carried the identical defect. Fixing one reader in a file that holds two leaves the second live, so it is fixed here rather than filed.

### Non-dict entries

Now skipped rather than raising. They raised **before and after** the schema fix, and this runs *after* the answer has been generated, so a single malformed record would lose a reply the user already paid for. That matches the stance `as_llm_messages` and `_sanitize_tool_messages` already take.

Deliberately **not** switched to `as_llm_messages` wholesale: that also drops empty-bodied messages, which would quietly change what the model sees on this path.

## Verification

```
api/chat_llm_context_test.py + chat_history/message_schema_test.py   49 passed
api/chat_test.py + test_citations_default_on.py + chat_history/     208 passed
flake8 / black / isort                                              exit 0
```

Mutation-tested, three separate mutations:

| Mutation | Result |
|---|---|
| role mapping reverted to the shipped one | 1 failed |
| the clamp removed (speaker forwarded raw) | **9 failed** |
| the AI Stack mapping reverted | 1 failed |

**Why there was no test before:** the two existing ones (`api/chat_test.py`, `test_citations_default_on.py`) both patch `_build_llm_context` out with `return_value=[]` — they mock the function rather than exercise its mapping. The new tests build records with the **real writer** and call the **real function**, and one asserts the precondition explicitly:

```python
assert "role" not in stored, "the writer stores the speaker under a different key"
```

Without that, the test could pass for the wrong reason if the writer ever changed.

The hardcoded-value gate matches seven added lines, all in `_test.py` files, which it excludes at line 49 of the hook. Both non-test files are clean under its own regex.

## Filed, not fixed here

Two further readers found while tracing which record shapes reach this function. Both lose the record rather than mislabel it, and both sit in subsystems with their own blast radius:

- **#14340** — the shared-link viewer filters on a key stored records have never carried, so every shared session renders empty
- **#14341** — the overflow summary is written under one body key and persisted from another, so every auto-summary is stored empty and the conversation it condensed is gone
- **#14342** — websocket-formatted events (agent steps, tool output, workflow progress) never pass their session id, so they land in a shared bucket no session reader touches. **Sequencing matters: that fix needs this clamp already in place**, since it is the widest producer of non-conversational speakers in the codebase

## Model Used

Opus 5

Closes #14305
