### PR TITLE
fix(analytics): apply mount-time router prefixes and drop a guard that hid them (#13582)

### DIFF
--- a/autobot-backend/api/codebase_analytics/api_endpoint_scanner.py
+++ b/autobot-backend/api/codebase_analytics/api_endpoint_scanner.py
@@ -40,11 +40,16 @@ _ROUTER_DECORATOR_RE = re.compile(
     re.IGNORECASE,
 )
 
-# Pattern for router variable names to detect prefix
-# NOTE (#12985): currently unreferenced — it was already dead before this
-# convergence, so it is left in place rather than removed as a drive-by.
-# Kept pointing at the shared grammar so it cannot drift while unused.
-_ROUTER_INCLUDE_RE = _routing.INCLUDE_ROUTER_RE
+# ``include_router(name, ..., prefix="/x")`` — the prefix given at MOUNT time,
+# as opposed to the one declared on the router itself by ``APIRouter(prefix=)``.
+#
+# #13582: this was dead for so long that the question became whether to delete
+# it. It turned out to be missing wiring rather than surplus: a package that
+# mounts a submodule with a prefix has that prefix applied to every route in the
+# submodule, and nothing here was reading it. Renamed from _ROUTER_INCLUDE_RE,
+# which sat one transposition away from _INCLUDE_ROUTER_RE below and meant
+# something different.
+_INCLUDE_ROUTER_PREFIX_RE = _routing.INCLUDE_ROUTER_RE
 
 # Pattern for router prefix in APIRouter() initialization
 _APIROUTER_PREFIX_RE = _routing.APIROUTER_PREFIX_RE
@@ -764,13 +769,23 @@ class BackendEndpointScanner:
         init_file = package / "__init__.py"
         init_content = init_file.read_text(encoding="utf-8", errors="ignore")
         package_prefix = self._get_file_router_prefix(init_content) or ""
-        if not _INCLUDE_ROUTER_RE.search(init_content):
-            return {}
 
         served_prefix = f"{registry_prefix}{package_prefix}"
         mounted = set(_INCLUDE_ROUTER_NAME_RE.findall(init_content))
         if not mounted:
             return {}
+
+        # #13582: a narrower `_INCLUDE_ROUTER_RE.search()` guard used to stand
+        # ahead of this check. It matched only `router.include_router(name)`
+        # with the call closing immediately after the name, so a package
+        # mounting with `prefix=`, `tags=`, or through `app.` failed it and
+        # returned {} — dropping every route in that package, silently. The
+        # `mounted` check below is the same question asked at the right width,
+        # and it was already here; the guard only ever subtracted from it.
+        #
+        # Prefixes given at mount time apply to every route in the mounted
+        # module, and are separate from the one the router declares for itself.
+        mount_prefixes = dict(_INCLUDE_ROUTER_PREFIX_RE.findall(init_content))
 
         files: Dict[Path, str] = {}
         # #12956: walk one level and recurse, rather than rglob'ing the tree.
@@ -782,13 +797,14 @@ class BackendEndpointScanner:
             if alias not in mounted:
                 # Declared but never mounted: it serves nothing.
                 continue
+            mounted_prefix = f"{served_prefix}{mount_prefixes.get(alias, '')}"
             module_file = (package / module_name).with_suffix(".py")
             if module_file.is_file():
-                files[module_file] = served_prefix
+                files[module_file] = mounted_prefix
                 continue
             subpackage = package / module_name
             if (subpackage / "__init__.py").is_file():
-                files.update(self._package_router_files(subpackage, served_prefix))
+                files.update(self._package_router_files(subpackage, mounted_prefix))
         return files
 
     def _get_module_prefix(self, file_path: Path) -> str:

--- a/autobot-backend/api/codebase_analytics/package_router_files_parity_13582_test.py
+++ b/autobot-backend/api/codebase_analytics/package_router_files_parity_13582_test.py
@@ -1,0 +1,152 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""The two `_package_router_files` implementations must agree (#13582).
+
+The same algorithm — which submodules a registry-mounted package serves, and
+under which prefix — exists twice:
+
+* `autobot_shared.api_routing.router_prefixes._package_router_files`, reached by
+  `scripts/audit_api_wiring.py`, which backs the **blocking** api-wiring gate.
+* `BackendEndpointScanner._package_router_files`, which produces the codebase
+  analytics endpoint inventory.
+
+A fork here is not a tidiness problem. The gate decides whether a PR may merge
+and the report tells a human what the API serves; when they disagree, one of
+them is wrong about the shape of the API and nothing says which. #13582 fixed a
+missing mount-prefix path in the analytics copy, which would have widened an
+existing divergence had the shared copy not been fixed with it.
+
+So the guard is equality between them, not a restatement of either one's
+expected output. Asserting each separately is what allowed them to drift in the
+first place: both had tests, and both passed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from api.codebase_analytics.api_endpoint_scanner import (  # noqa: E402
+    BackendEndpointScanner,
+)
+from autobot_shared.api_routing.router_prefixes import (  # noqa: E402
+    _package_router_files as shared_package_router_files,
+)
+
+_ROUTER_MODULE = "router = APIRouter()\n\n\n@router.get('/items')\nasync def items():\n    return []\n"
+
+
+def _write(root: Path, name: str, init_body: str, modules: dict[str, str] | None = None) -> Path:
+    pkg = root / name
+    pkg.mkdir(parents=True, exist_ok=True)
+    (pkg / "__init__.py").write_text(init_body, encoding="utf-8")
+    for module, body in (modules or {}).items():
+        (pkg / f"{module}.py").write_text(body, encoding="utf-8")
+    return pkg
+
+
+def _both(tmp_path: Path, pkg: Path, registry_prefix: str) -> tuple[dict, dict]:
+    (tmp_path / "api").mkdir(parents=True, exist_ok=True)
+    scanner = BackendEndpointScanner(project_root=tmp_path)
+    return (
+        scanner._package_router_files(pkg, registry_prefix),
+        shared_package_router_files(pkg, registry_prefix),
+    )
+
+
+_CASES = {
+    "plain mount": (
+        "from fastapi import APIRouter\n"
+        "from .costs import router as costs_router\n"
+        "router = APIRouter()\n"
+        "router.include_router(costs_router)\n",
+        {"costs": _ROUTER_MODULE},
+    ),
+    "mount with a prefix": (
+        "from fastapi import APIRouter\n"
+        "from .costs import router as costs_router\n"
+        "router = APIRouter()\n"
+        "router.include_router(costs_router, prefix='/costs')\n",
+        {"costs": _ROUTER_MODULE},
+    ),
+    "mount with tags only": (
+        "from fastapi import APIRouter\n"
+        "from .tts import router as tts_router\n"
+        "router = APIRouter()\n"
+        "router.include_router(tts_router, tags=['voice'])\n",
+        {"tts": _ROUTER_MODULE},
+    ),
+    "two mounts, two prefixes": (
+        "from fastapi import APIRouter\n"
+        "from .users import router as users_router\n"
+        "from .audit import router as audit_router\n"
+        "router = APIRouter()\n"
+        "router.include_router(users_router, prefix='/users')\n"
+        "router.include_router(audit_router, prefix='/audit')\n",
+        {"users": _ROUTER_MODULE, "audit": _ROUTER_MODULE},
+    ),
+    "declared but not mounted": (
+        "from fastapi import APIRouter\n"
+        "from .draft import router as draft_router\n"
+        "from .live import router as live_router\n"
+        "router = APIRouter()\n"
+        "router.include_router(live_router, prefix='/live')\n",
+        {"draft": _ROUTER_MODULE, "live": _ROUTER_MODULE},
+    ),
+    "mounts nothing": ("from fastapi import APIRouter\n\nrouter = APIRouter()\n", {}),
+}
+
+
+@pytest.mark.parametrize("case", sorted(_CASES))
+def test_both_implementations_return_the_same_mapping(tmp_path, case):
+    """Equality, not a restatement — the point is that they cannot drift apart."""
+    init_body, modules = _CASES[case]
+    pkg = _write(tmp_path, "billing", init_body, modules)
+    analytics, shared = _both(tmp_path, pkg, "/api/billing")
+    assert analytics == shared, (
+        f"the analytics scanner and the api-wiring gate disagree on {case!r}: "
+        f"{analytics} vs {shared}. One of them is wrong about what the API serves (#13582)."
+    )
+
+
+def test_the_agreed_mapping_is_not_trivially_empty(tmp_path):
+    """Two implementations that both return nothing agree perfectly.
+
+    Without this, every assertion above would keep passing if either function
+    started returning `{}` for everything — the failure mode where an empty
+    result reads as a clean result.
+    """
+    init_body, modules = _CASES["mount with a prefix"]
+    pkg = _write(tmp_path, "billing", init_body, modules)
+    analytics, shared = _both(tmp_path, pkg, "/api/billing")
+    assert analytics == {pkg / "costs.py": "/api/billing/costs"}
+    assert shared == analytics
+
+
+def test_nested_subpackages_agree(tmp_path):
+    """The recursion is where a prefix error compounds rather than cancels."""
+    parent = _write(
+        tmp_path,
+        "platform",
+        "from fastapi import APIRouter\n"
+        "from .metrics import router as metrics_router\n"
+        "router = APIRouter()\n"
+        "router.include_router(metrics_router, prefix='/metrics')\n",
+    )
+    _write(
+        parent,
+        "metrics",
+        "from fastapi import APIRouter\n"
+        "from .cpu import router as cpu_router\n"
+        "router = APIRouter()\n"
+        "router.include_router(cpu_router, prefix='/cpu')\n",
+        {"cpu": _ROUTER_MODULE},
+    )
+    analytics, shared = _both(tmp_path, parent, "/api/platform")
+    assert analytics == shared
+    assert analytics[parent / "metrics" / "cpu.py"] == "/api/platform/metrics/cpu"

--- a/autobot-backend/api/codebase_analytics/router_mount_prefixes_13582_test.py
+++ b/autobot-backend/api/codebase_analytics/router_mount_prefixes_13582_test.py
@@ -1,0 +1,216 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""A package's mount-time prefix reaches the routes it mounts (#13582).
+
+#13582 was filed as dead-constant cleanup: `_ROUTER_INCLUDE_RE` had exactly one
+reference, its own definition, and the question was whether to use it or remove
+it. It was missing wiring, not surplus — and finding that out turned up a second
+defect standing in front of it.
+
+`_package_router_files` guarded itself with a regex matching only
+`router.include_router(name)` with the call closing immediately after the name.
+Any package mounting with `prefix=`, `tags=`, or through `app.` failed that
+guard and returned `{}` — every route in the package dropped, with no error.
+The guard sat directly ahead of a `mounted` check asking the same question at
+the correct width, so it could only ever subtract.
+
+With the guard gone those packages are found, which then exposes what the dead
+constant was for: a prefix given at mount time applies to every route in the
+mounted module, and nothing was reading it. Reporting those routes without it
+would invent endpoints that do not exist — the failure the surrounding code
+says in its own comments that it exists to prevent.
+
+These tests build real package trees on disk and assert on the paths the scanner
+returns, because both defects are about which prefix a file is served under —
+something no assertion on source text can see.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from api.codebase_analytics.api_endpoint_scanner import (  # noqa: E402
+    BackendEndpointScanner,
+)
+
+
+def _package(root: Path, name: str, init_body: str, modules: dict[str, str] | None = None) -> Path:
+    """Write a router package whose __init__ mounts its submodules."""
+    pkg = root / name
+    pkg.mkdir(parents=True, exist_ok=True)
+    (pkg / "__init__.py").write_text(init_body, encoding="utf-8")
+    for module, body in (modules or {}).items():
+        (pkg / f"{module}.py").write_text(body, encoding="utf-8")
+    return pkg
+
+
+def _scanner(tmp_path: Path) -> BackendEndpointScanner:
+    """A scanner rooted at a throwaway tree.
+
+    `_package_router_files` reads only the tree it is handed, so the constructor's
+    project-root discovery is irrelevant to what is under test here.
+    """
+    (tmp_path / "api").mkdir(parents=True, exist_ok=True)
+    return BackendEndpointScanner(project_root=tmp_path)
+
+
+_ROUTER_MODULE = "router = APIRouter()\n\n\n@router.get('/items')\nasync def items():\n    return []\n"
+
+
+def test_a_package_mounting_with_a_prefix_is_not_dropped(tmp_path):
+    """The regression. `prefix=` in the mount call used to fail the guard.
+
+    Before the fix this returned `{}` and every route in the package vanished
+    from the scan — no error, no warning, just an endpoint inventory quietly
+    missing a subtree.
+    """
+    pkg = _package(
+        tmp_path,
+        "billing",
+        "from fastapi import APIRouter\n"
+        "from .costs import router as costs_router\n"
+        "router = APIRouter()\n"
+        "router.include_router(costs_router, prefix='/costs')\n",
+        {"costs": _ROUTER_MODULE},
+    )
+    files = _scanner(tmp_path)._package_router_files(pkg, "/api/billing")
+    assert pkg / "costs.py" in files, "a package mounting with a prefix was dropped entirely"
+
+
+def test_the_mount_prefix_reaches_the_module_it_mounts(tmp_path):
+    """What the dead constant was for.
+
+    The prefix lives on the mount call, not on the mounted router, so it is
+    invisible to `APIRouter(prefix=)` parsing. Serving these routes without it
+    reports endpoints at paths nothing answers on.
+    """
+    pkg = _package(
+        tmp_path,
+        "billing",
+        "from fastapi import APIRouter\n"
+        "from .costs import router as costs_router\n"
+        "router = APIRouter()\n"
+        "router.include_router(costs_router, prefix='/costs')\n",
+        {"costs": _ROUTER_MODULE},
+    )
+    files = _scanner(tmp_path)._package_router_files(pkg, "/api/billing")
+    assert files[pkg / "costs.py"] == "/api/billing/costs"
+
+
+def test_a_mount_without_a_prefix_is_unchanged(tmp_path):
+    """The common case must not acquire a prefix from nowhere."""
+    pkg = _package(
+        tmp_path,
+        "chat",
+        "from fastapi import APIRouter\n"
+        "from .history import router as history_router\n"
+        "router = APIRouter()\n"
+        "router.include_router(history_router)\n",
+        {"history": _ROUTER_MODULE},
+    )
+    files = _scanner(tmp_path)._package_router_files(pkg, "/api/chat")
+    assert files[pkg / "history.py"] == "/api/chat"
+
+
+def test_each_mount_gets_its_own_prefix(tmp_path):
+    """Two submodules, two different mount prefixes.
+
+    A single package-wide prefix would give both the same answer, so this is
+    what separates 'reads the mount call' from 'reads something adjacent'.
+    """
+    pkg = _package(
+        tmp_path,
+        "admin",
+        "from fastapi import APIRouter\n"
+        "from .users import router as users_router\n"
+        "from .audit import router as audit_router\n"
+        "router = APIRouter()\n"
+        "router.include_router(users_router, prefix='/users')\n"
+        "router.include_router(audit_router, prefix='/audit')\n",
+        {"users": _ROUTER_MODULE, "audit": _ROUTER_MODULE},
+    )
+    files = _scanner(tmp_path)._package_router_files(pkg, "/api/admin")
+    assert files[pkg / "users.py"] == "/api/admin/users"
+    assert files[pkg / "audit.py"] == "/api/admin/audit"
+
+
+def test_a_mount_with_tags_but_no_prefix_is_not_dropped(tmp_path):
+    """`tags=` also failed the old guard, for the same reason `prefix=` did:
+    the pattern required the call to close right after the router name."""
+    pkg = _package(
+        tmp_path,
+        "voice",
+        "from fastapi import APIRouter\n"
+        "from .tts import router as tts_router\n"
+        "router = APIRouter()\n"
+        "router.include_router(tts_router, tags=['voice'])\n",
+        {"tts": _ROUTER_MODULE},
+    )
+    files = _scanner(tmp_path)._package_router_files(pkg, "/api/voice")
+    assert files[pkg / "tts.py"] == "/api/voice"
+
+
+def test_a_declared_but_unmounted_module_still_serves_nothing(tmp_path):
+    """Widening the guard must not widen what counts as mounted.
+
+    An import binds a name; only `include_router` serves it. This is the
+    behaviour the removed guard was nominally protecting, and it is enforced by
+    the `mounted` check that was always the real gate.
+    """
+    pkg = _package(
+        tmp_path,
+        "reports",
+        "from fastapi import APIRouter\n"
+        "from .draft import router as draft_router\n"
+        "from .live import router as live_router\n"
+        "router = APIRouter()\n"
+        "router.include_router(live_router, prefix='/live')\n",
+        {"draft": _ROUTER_MODULE, "live": _ROUTER_MODULE},
+    )
+    files = _scanner(tmp_path)._package_router_files(pkg, "/api/reports")
+    assert pkg / "live.py" in files
+    assert pkg / "draft.py" not in files, "an imported-but-never-mounted module serves no routes"
+
+
+def test_a_package_mounting_nothing_still_returns_nothing(tmp_path):
+    """The empty case the removed guard shared with the `mounted` check."""
+    pkg = _package(
+        tmp_path,
+        "empty",
+        "from fastapi import APIRouter\n\nrouter = APIRouter()\n",
+    )
+    assert _scanner(tmp_path)._package_router_files(pkg, "/api/empty") == {}
+
+
+def test_nested_subpackages_inherit_the_mount_prefix(tmp_path):
+    """The recursion carries the mount prefix down.
+
+    `_package_router_files` recurses for subpackages, so a mount prefix applied
+    at the wrong level compounds — the nested module lands under a path with a
+    missing or duplicated segment.
+    """
+    parent = _package(
+        tmp_path,
+        "platform",
+        "from fastapi import APIRouter\n"
+        "from .metrics import router as metrics_router\n"
+        "router = APIRouter()\n"
+        "router.include_router(metrics_router, prefix='/metrics')\n",
+    )
+    _package(
+        parent,
+        "metrics",
+        "from fastapi import APIRouter\n"
+        "from .cpu import router as cpu_router\n"
+        "router = APIRouter()\n"
+        "router.include_router(cpu_router, prefix='/cpu')\n",
+        {"cpu": _ROUTER_MODULE},
+    )
+    files = _scanner(tmp_path)._package_router_files(parent, "/api/platform")
+    assert files[parent / "metrics" / "cpu.py"] == "/api/platform/metrics/cpu"

--- a/autobot_shared/api_routing/router_prefixes.py
+++ b/autobot_shared/api_routing/router_prefixes.py
@@ -155,24 +155,30 @@ def _package_router_files(package: Path, registry_prefix: str) -> Dict[Path, str
     """
     init_file = package / "__init__.py"
     init_content = init_file.read_text(encoding="utf-8", errors="ignore")
-    if not INCLUDE_ROUTER_NAME_RE.search(init_content):
-        return {}
-
     mounted = set(INCLUDE_ROUTER_NAME_RE.findall(init_content))
     if not mounted:
         return {}
 
     served_prefix = f"{registry_prefix}{file_router_prefix(init_content)}"
+    # #13582: a prefix given on the mount call applies to every route in the
+    # mounted module and is invisible to APIRouter(prefix=) parsing. The
+    # analytics scanner grew this at the same time; the two implementations of
+    # this function must stay in step, which
+    # tests/api_routing/package_router_files_parity_13582_test.py enforces —
+    # this one backs the blocking api-wiring gate, so a divergence means the
+    # gate and the analytics report disagree about what the API serves.
+    mount_prefixes = dict(INCLUDE_ROUTER_RE.findall(init_content))
 
     files: Dict[Path, str] = {}
     for module_name, alias in RELATIVE_ROUTER_IMPORT_RE.findall(init_content):
         if alias not in mounted:
             continue  # declared but never mounted: it serves nothing
+        mounted_prefix = f"{served_prefix}{mount_prefixes.get(alias, '')}"
         module_file = (package / module_name).with_suffix(".py")
         if module_file.is_file():
-            files[module_file] = served_prefix
+            files[module_file] = mounted_prefix
             continue
         subpackage = package / module_name
         if (subpackage / "__init__.py").is_file():
-            files.update(_package_router_files(subpackage, served_prefix))
+            files.update(_package_router_files(subpackage, mounted_prefix))
     return files


### PR DESCRIPTION
Closes #13582.

## Thinking Path

Filed as dead-constant cleanup: `_ROUTER_INCLUDE_RE` had exactly one reference — its own definition — and #12985 had deliberately left it in place rather than removing it as a drive-by. The issue asks to either use it or remove it with the reason recorded.

It turned out to be missing wiring, and looking for the wiring found a defect sitting in front of it.

`_package_router_files` opened with `if not _INCLUDE_ROUTER_RE.search(init_content): return {}`. That pattern matches only `router.include_router(name)` with the call closing immediately after the name. Measured against the shapes that actually occur:

| Mount shape | Old guard | The `mounted` check below it |
|---|---|---|
| `router.include_router(x)` | matches | matches |
| `router.include_router(x, prefix='/y')` | **rejects** | matches |
| `router.include_router(x, tags=[...])` | **rejects** | matches |
| `app.include_router(x)` | **rejects** | matches |

So a package mounting in any of those three shapes returned `{}` and every route in it disappeared from the scan — no error, no warning. The guard stood directly ahead of a `mounted` check asking the same question at the correct width, so it could only ever subtract. It is removed rather than widened, because the right check was already there.

Removing it alone would have made things worse. Once those packages are discovered, their mount-time prefix has to be applied or their routes are reported at paths nothing serves — inventing endpoints, which the surrounding code states in its own comments is the failure the area exists to prevent. That is exactly what the dead constant captures: a prefix on the mount call, invisible to `APIRouter(prefix=)` parsing.

So the answer to the issue's question is "use it", and the two halves are one change: the guard hid the case the constant existed to handle.

## What Changed

- **`api_endpoint_scanner.py`** — removed the narrow guard; read mount-time prefixes with the (renamed) `_INCLUDE_ROUTER_PREFIX_RE` and apply them per mount and through the subpackage recursion. Renamed from `_ROUTER_INCLUDE_RE`, which sat one transposition away from `_INCLUDE_ROUTER_RE` and meant something different.
- **`router_mount_prefixes_13582_test.py`** — 8 tests that build real package trees on disk and assert on the prefixes the scanner returns. Both defects are about which prefix a file is served under, which no assertion on source text can see.

## Verification

Mutation-tested — each half of the fix is independently guarded:

| Mutation | Result |
|---|---|
| Restore the narrow guard | 6 fail |
| Stop applying the mount prefix | 3 fail |
| Recurse with the package prefix instead of the mount prefix | 1 fail |

`api/codebase_analytics/` — 311 passed, 13 skipped. black, isort, flake8 clean.

**Scope note:** no package in the backend currently mounts with extra arguments — measured, 0 of the `__init__.py` files — so this changes nothing about today's scan output. It is a latent fix: one ordinary `prefix=` away from silently dropping a subtree.

## Model Used

Opus 5 (1M context).

---

## Round 2 — the fix was half a fix

Review found the same algorithm implemented twice. `autobot_shared/api_routing/router_prefixes.py::_package_router_files` backs the **blocking** api-wiring gate through `scripts/audit_api_wiring.py`, and it has the correct guard but the identical missing mount-prefix wiring.

Fixing only the analytics copy would have widened the divergence rather than closing it: the gate that decides whether a PR may merge and the report describing the API would disagree, with nothing to say which was right. So the shared copy is fixed in the same scope — the defect is identical and the two are one decision.

The durable half is `package_router_files_parity_13582_test.py`, which asserts the two implementations return the **same mapping** for each mount shape rather than restating either one's expected output. Both copies already had tests, and both passed while diverging — which is exactly what asserting them separately buys. It also pins the agreed result to a non-empty value, because two functions that both return `{}` agree perfectly.

Mutations against the shared copy: dropping its mount-prefix application fails 5, recursing with the wrong prefix fails 1.

`api/codebase_analytics/` — 319 passed, 13 skipped.

**Correction to an earlier claim in this PR.** I wrote that the api-wiring gate's output is unchanged. That is overstated, and the precise version matters. Everything the gate *decides on* is identical before and after — unwired-call count (69), unmounted-router count (1), exit code (0), verified against the merge base. The raw STATIC-mode text is not byte-identical: the candidate backend-path count rises from 25,308 to 28,930, and one non-gating suggestion line changes. That rise is the fix working — more submodule prefixes now resolve correctly — not a regression. The mode CI normally uses is the authoritative OpenAPI dump, which does not reach this function at all.

Two things found and deliberately **not** folded in, because neither is a regression here and both change behaviour beyond this fix's claim:

- **#14355** — collapse the two implementations into one. Blocked on a decision: they normalise prefixes differently (`file_router_prefix` rstrips a trailing slash, the scanner's equivalent does not), so merging them changes output for any prefix carrying one. The parity test holds the line until then.
- **#14356** — `INCLUDE_ROUTER_RE`'s `[^)]*?` cannot cross a `)`, so a mount with `dependencies=[Depends(x)]` before `prefix=` silently loses its prefix. Verified it does *not* mispair across calls. Dormant today — no call site has that shape — but this PR is what makes the constant load-bearing for prefix computation.

