### PR TITLE
feat(llc): attach tools and credential references to the role

### DIFF
--- a/autobot-backend/llc/api/roles.py
+++ b/autobot-backend/llc/api/roles.py
@@ -45,7 +45,9 @@ from ..models.enums import RoleHolderType
 from ..services.authz import NotAuthorisedError
 from ..services.role import RoleService
 from ..services.role_assignment import RoleAssignmentService
+from ..services.role_credential import RoleCredentialService
 from ..services.role_permission import RolePermissionService
+from ..services.role_tool import RoleToolService, ToolRegistryUnavailable
 from ..services.role_workflow import RoleWorkflowService
 
 router = APIRouter(prefix="/roles", tags=["llc-roles"])
@@ -54,6 +56,8 @@ _get_roles = lazy_singleton(RoleService)
 _get_holders = lazy_singleton(RoleAssignmentService)
 _get_permissions = lazy_singleton(RolePermissionService)
 _get_workflows = lazy_singleton(RoleWorkflowService)
+_get_tools = lazy_singleton(RoleToolService)
+_get_credentials = lazy_singleton(RoleCredentialService)
 
 _NAME_MAX = 100  # matches Role.name = String(100)
 _DESCRIPTION_MAX = 2000
@@ -404,6 +408,146 @@ async def detach_workflow(
     try:
         detached = await _get_workflows().detach(
             session, company_id, role_id, workflow_id, actor_user_id=_actor_id(current_user)
+        )
+    except NotAuthorisedError as exc:
+        raise _forbidden(exc) from exc
+    if not detached:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Attachment not found")
+    await session.commit()
+
+
+class ToolAttach(BaseModel):
+    tool_name: str = Field(..., min_length=1, max_length=255)
+
+
+class CredentialAttach(BaseModel):
+    secret_id: uuid.UUID
+
+
+def _unavailable(exc: ToolRegistryUnavailable) -> HTTPException:
+    """503, not 400.
+
+    An unpopulated tool registry is an environment problem; reporting it as a
+    bad request would send the caller looking for a typo in their own payload.
+    """
+    return HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc))
+
+
+@router.get("/{company_id}/{role_id}/tools", response_model=List[str])
+async def list_role_tools(
+    company_id: uuid.UUID,
+    role_id: uuid.UUID,
+    session: AsyncSession = Depends(get_async_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
+) -> List[str]:
+    assert_company_access(ctx, company_id)
+    return await _get_tools().list_for_role(session, company_id, role_id)
+
+
+@router.post("/{company_id}/{role_id}/tools", status_code=status.HTTP_204_NO_CONTENT)
+async def attach_tool(
+    company_id: uuid.UUID,
+    role_id: uuid.UUID,
+    payload: ToolAttach,
+    session: AsyncSession = Depends(get_async_session),
+    current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
+) -> None:
+    assert_company_access(ctx, company_id)
+    try:
+        await _get_tools().attach(
+            session,
+            company_id=company_id,
+            role_id=role_id,
+            tool_name=payload.tool_name,
+            actor_user_id=_actor_id(current_user),
+        )
+    except ToolRegistryUnavailable as exc:
+        raise _unavailable(exc) from exc
+    except NotAuthorisedError as exc:
+        raise _forbidden(exc) from exc
+    except ValueError as exc:
+        raise _bad_request(exc) from exc
+    await session.commit()
+
+
+@router.delete("/{company_id}/{role_id}/tools/{tool_name}", status_code=status.HTTP_204_NO_CONTENT)
+async def detach_tool(
+    company_id: uuid.UUID,
+    role_id: uuid.UUID,
+    tool_name: str,
+    session: AsyncSession = Depends(get_async_session),
+    current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
+) -> None:
+    assert_company_access(ctx, company_id)
+    try:
+        detached = await _get_tools().detach(
+            session, company_id, role_id, tool_name, actor_user_id=_actor_id(current_user)
+        )
+    except NotAuthorisedError as exc:
+        raise _forbidden(exc) from exc
+    if not detached:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Attachment not found")
+    await session.commit()
+
+
+@router.get("/{company_id}/{role_id}/credentials", response_model=List[uuid.UUID])
+async def list_role_credentials(
+    company_id: uuid.UUID,
+    role_id: uuid.UUID,
+    include_revoked: bool = False,
+    session: AsyncSession = Depends(get_async_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
+) -> List[uuid.UUID]:
+    """Secret ids only — never values. Revoked ones are excluded by default."""
+    assert_company_access(ctx, company_id)
+    service = _get_credentials()
+    if include_revoked:
+        return [a.secret_id for a in await service.list_for_role(session, company_id, role_id)]
+    return await service.list_active_for_role(session, company_id, role_id)
+
+
+@router.post("/{company_id}/{role_id}/credentials", status_code=status.HTTP_204_NO_CONTENT)
+async def attach_credential(
+    company_id: uuid.UUID,
+    role_id: uuid.UUID,
+    payload: CredentialAttach,
+    session: AsyncSession = Depends(get_async_session),
+    current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
+) -> None:
+    assert_company_access(ctx, company_id)
+    try:
+        await _get_credentials().attach(
+            session,
+            company_id=company_id,
+            role_id=role_id,
+            secret_id=payload.secret_id,
+            actor_user_id=_actor_id(current_user),
+        )
+    except NotAuthorisedError as exc:
+        raise _forbidden(exc) from exc
+    except ValueError as exc:
+        raise _bad_request(exc) from exc
+    await session.commit()
+
+
+@router.delete("/{company_id}/{role_id}/credentials/{secret_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def detach_credential(
+    company_id: uuid.UUID,
+    role_id: uuid.UUID,
+    secret_id: uuid.UUID,
+    session: AsyncSession = Depends(get_async_session),
+    current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
+) -> None:
+    assert_company_access(ctx, company_id)
+    try:
+        detached = await _get_credentials().detach(
+            session, company_id, role_id, secret_id, actor_user_id=_actor_id(current_user)
         )
     except NotAuthorisedError as exc:
         raise _forbidden(exc) from exc

--- a/autobot-backend/llc/models/__init__.py
+++ b/autobot-backend/llc/models/__init__.py
@@ -48,6 +48,8 @@ from .membership import LLCCompanyMembership
 from .replay_log import LLCRunReplayLog
 from .review_gate import LLCReviewGatePolicy
 from .role_assignment import LLCRoleAssignment
+from .role_credential import LLCRoleCredential
+from .role_tool import LLCRoleTool
 from .role_workflow import LLCRoleWorkflow
 from .secret import LLCSecret
 from .sprint import LLCPortfolio, LLCProgram, LLCProject, LLCSprint
@@ -94,6 +96,8 @@ __all__ = [
     "LLCProject",
     "LLCRunStatus",
     "LLCRoleAssignment",
+    "LLCRoleCredential",
+    "LLCRoleTool",
     "LLCRoleWorkflow",
     "LLCSprint",
     "RoutineProduces",

--- a/autobot-backend/llc/models/role_credential.py
+++ b/autobot-backend/llc/models/role_credential.py
@@ -1,0 +1,68 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Credential *references* carried by a role (#14221 step 4).
+
+Owner framing:
+
+    people get promoted or leave the company, but the role stays — and so do
+    the tools and workflows attached to the role
+
+Before this, a secret was keyed to the agent that created it
+(``LLCSecret.created_by_agent_id``), so terminating that agent left the secret
+referencing nobody active and the next holder of the same role starting from
+nothing. The reference belongs to the **role**, which outlives its occupants.
+
+**A reference, never a value.** This table stores ``secret_id`` only. The
+plaintext stays behind ``SecretService``, which owns decryption, revocation and
+the audit trail. Copying a secret's value into a second table would create a
+parallel credential path with no revocation story — the defect shape recorded in
+#10088 and #13643.
+
+Revocation is honoured at **read** time, not just at attach time. A secret
+revoked after being attached must stop resolving through the role immediately;
+see ``RoleCredentialService.list_active_for_role``. Filtering only at attach
+would let a revoked credential stay reachable for as long as the row survived,
+which is precisely what revocation is supposed to prevent.
+"""
+
+import uuid
+from datetime import datetime
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from user_management.models.base import Base
+
+
+class LLCRoleCredential(Base):
+    """One secret made available to the holders of one role."""
+
+    __tablename__ = "llc_role_credentials"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+
+    # Carried on the attachment so every query pins scope without depending on
+    # a join — a lost join condition cannot widen the result. UUID here, matching
+    # llc_roles/organizations; llc_secrets.company_id is String(255) and the one
+    # coercion that bridges them is confined to the service (#14312).
+    company_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    role_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    secret_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+
+    created_at: Mapped[datetime] = mapped_column(
+        sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.func.now(),
+        onupdate=sa.func.now(),
+    )
+
+    __table_args__ = (sa.UniqueConstraint("role_id", "secret_id", name="uq_llc_role_credentials_role_secret"),)
+
+    def __repr__(self) -> str:  # pragma: no cover - debug helper
+        return f"<LLCRoleCredential role={self.role_id} secret={self.secret_id}>"

--- a/autobot-backend/llc/models/role_tool.py
+++ b/autobot-backend/llc/models/role_tool.py
@@ -1,0 +1,51 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tools carried by a role (#14221 step 4).
+
+The other half of "tools and workflows attached to the role". A change of holder
+moves nothing here: the next occupant of a role reaches the same tools because
+the attachment was never the previous occupant's.
+
+``tool_name`` is a plain string because tools have **no database table** — they
+register in-process by name via ``autobot_shared.tool_sdk.registry``. That
+asymmetry with permissions (which resolve against the ``permissions`` table) is
+deliberate and is why validation lives in the service rather than in a foreign
+key: the authority for "is this a real tool" is the registry, not the schema.
+"""
+
+import uuid
+from datetime import datetime
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from user_management.models.base import Base
+
+
+class LLCRoleTool(Base):
+    """One tool made available to the holders of one role."""
+
+    __tablename__ = "llc_role_tools"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    company_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    role_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    tool_name: Mapped[str] = mapped_column(sa.String(255), nullable=False, index=True)
+
+    created_at: Mapped[datetime] = mapped_column(
+        sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.func.now(),
+        onupdate=sa.func.now(),
+    )
+
+    __table_args__ = (sa.UniqueConstraint("role_id", "tool_name", name="uq_llc_role_tools_role_tool"),)
+
+    def __repr__(self) -> str:  # pragma: no cover - debug helper
+        return f"<LLCRoleTool role={self.role_id} tool={self.tool_name!r}>"

--- a/autobot-backend/llc/services/role_credential.py
+++ b/autobot-backend/llc/services/role_credential.py
@@ -28,6 +28,7 @@ from typing import Any, Dict, List, Optional
 from sqlalchemy import delete as sa_delete
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+
 from user_management.models.role import Role
 
 from ..models.activity import ActorType

--- a/autobot-backend/llc/services/role_credential.py
+++ b/autobot-backend/llc/services/role_credential.py
@@ -1,0 +1,217 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Attach and resolve credential references on a role (#14221 step 4).
+
+Stores ``secret_id`` only — never a value. Plaintext stays behind
+``SecretService``, which owns decryption, revocation and the audit trail.
+
+Two properties carry the design:
+
+* **Revocation is honoured at read time.** ``list_active_for_role`` joins
+  ``llc_secrets`` and excludes ``revoked_at IS NOT NULL``. Filtering only when
+  attaching would leave a revoked credential reachable through the role for as
+  long as the attachment row survived, which is exactly what revocation exists
+  to prevent.
+* **The company boundary is crossed in one place, explicitly.**
+  ``llc_roles``/``organizations`` key companies as ``UUID``; ``llc_secrets``
+  keys them as ``String(255)`` (#14312). Rather than scatter coercions, this
+  module converts once in :func:`_secret_company_key` and says why.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any, Dict, List, Optional
+
+from sqlalchemy import delete as sa_delete
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from user_management.models.role import Role
+
+from ..models.activity import ActorType
+from ..models.role_credential import LLCRoleCredential
+from ..models.secret import LLCSecret
+from .authz import require_company_admin
+from .base import LLCServiceBase
+
+
+def _secret_company_key(company_id: uuid.UUID) -> str:
+    """Render a company id the way ``llc_secrets`` stores it.
+
+    ``LLCSecret.company_id`` is ``String(255)`` while every table in this step
+    uses ``UUID`` — the split tracked in #14312. Comparing a ``uuid.UUID``
+    against the string column would not match, and a scoping predicate that
+    matches nothing is indistinguishable from one that works. The conversion is
+    therefore explicit, named, and confined to this one function so the
+    eventual type migration has a single site to delete.
+    """
+    return str(company_id)
+
+
+class RoleCredentialService(LLCServiceBase):
+    """Company-scoped attachment of secret references to roles."""
+
+    async def _record(
+        self,
+        session: AsyncSession,
+        attachment: LLCRoleCredential,
+        event_type: str,
+        actor: Optional[uuid.UUID],
+        after: Optional[Dict[str, Any]],
+    ) -> None:
+        if not self.activity_log:
+            return
+        await self.activity_log.record(
+            session=session,
+            company_id=str(attachment.company_id),
+            actor_type=ActorType.USER if actor else ActorType.SYSTEM,
+            actor_id=str(actor) if actor else None,
+            event_type=event_type,
+            entity_type="llc_role_credential",
+            entity_id=str(attachment.id),
+            # Never the secret's value or name — the id is the reference.
+            after=after,
+        )
+
+    async def _require_role(self, session: AsyncSession, company_id: uuid.UUID, role_id: uuid.UUID) -> None:
+        result = await session.execute(select(Role.id).where(Role.id == role_id, Role.org_id == company_id))
+        if result.scalar_one_or_none() is None:
+            raise ValueError(f"role {role_id} does not exist in company {company_id}")
+
+    async def _require_secret(self, session: AsyncSession, company_id: uuid.UUID, secret_id: uuid.UUID) -> None:
+        """The secret must exist in this company and not be revoked.
+
+        A revoked secret is refused with its own message rather than folded into
+        "not found": the caller needs to distinguish "no such credential" from
+        "that credential was withdrawn", because only the second is a signal
+        that something upstream changed.
+        """
+        result = await session.execute(
+            select(LLCSecret.revoked_at).where(
+                LLCSecret.id == secret_id,
+                LLCSecret.company_id == _secret_company_key(company_id),
+            )
+        )
+        row = result.first()
+        if row is None:
+            raise ValueError(f"secret {secret_id} does not exist in company {company_id}")
+        if row[0] is not None:
+            raise ValueError(f"secret {secret_id} is revoked and cannot be attached to a role")
+
+    async def attach(
+        self,
+        session: AsyncSession,
+        *,
+        company_id: uuid.UUID,
+        role_id: uuid.UUID,
+        secret_id: uuid.UUID,
+        actor_user_id: uuid.UUID,
+    ) -> LLCRoleCredential:
+        if company_id is None or role_id is None or secret_id is None:
+            raise ValueError("company_id, role_id and secret_id are all required")
+
+        await require_company_admin(session, company_id, actor_user_id)
+        await self._require_role(session, company_id, role_id)
+        await self._require_secret(session, company_id, secret_id)
+
+        if await self.get(session, company_id, role_id, secret_id) is not None:
+            raise ValueError(f"secret {secret_id} is already attached to role {role_id}")
+
+        attachment = LLCRoleCredential(company_id=company_id, role_id=role_id, secret_id=secret_id)
+        session.add(attachment)
+        await session.flush()
+        await self._record(
+            session,
+            attachment,
+            "role_credential.attached",
+            actor_user_id,
+            {"role_id": str(role_id), "secret_id": str(secret_id)},
+        )
+        return attachment
+
+    async def get(
+        self,
+        session: AsyncSession,
+        company_id: uuid.UUID,
+        role_id: uuid.UUID,
+        secret_id: uuid.UUID,
+    ) -> Optional[LLCRoleCredential]:
+        result = await session.execute(
+            select(LLCRoleCredential).where(
+                LLCRoleCredential.company_id == company_id,
+                LLCRoleCredential.role_id == role_id,
+                LLCRoleCredential.secret_id == secret_id,
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def list_for_role(
+        self, session: AsyncSession, company_id: uuid.UUID, role_id: uuid.UUID
+    ) -> List[LLCRoleCredential]:
+        """Every attachment, including ones whose secret was later revoked.
+
+        The administrative view — use :meth:`list_active_for_role` to decide
+        what a holder may actually reach.
+        """
+        result = await session.execute(
+            select(LLCRoleCredential)
+            .where(
+                LLCRoleCredential.company_id == company_id,
+                LLCRoleCredential.role_id == role_id,
+            )
+            .order_by(LLCRoleCredential.created_at)
+        )
+        return list(result.scalars().all())
+
+    async def list_active_for_role(
+        self, session: AsyncSession, company_id: uuid.UUID, role_id: uuid.UUID
+    ) -> List[uuid.UUID]:
+        """Secret ids a holder of this role may actually reach, right now.
+
+        Revocation is applied here rather than at attach time, so revoking a
+        secret withdraws it from every role immediately with no sweep.
+        """
+        result = await session.execute(
+            select(LLCRoleCredential.secret_id)
+            .join(LLCSecret, LLCSecret.id == LLCRoleCredential.secret_id)
+            .where(
+                LLCRoleCredential.company_id == company_id,
+                LLCRoleCredential.role_id == role_id,
+                LLCSecret.company_id == _secret_company_key(company_id),
+                LLCSecret.revoked_at.is_(None),
+            )
+            .order_by(LLCRoleCredential.secret_id)
+        )
+        return list(result.scalars().all())
+
+    async def detach(
+        self,
+        session: AsyncSession,
+        company_id: uuid.UUID,
+        role_id: uuid.UUID,
+        secret_id: uuid.UUID,
+        *,
+        actor_user_id: uuid.UUID,
+    ) -> bool:
+        """Remove a reference. Returns True when a row was actually removed."""
+        await require_company_admin(session, company_id, actor_user_id)
+        attachment = await self.get(session, company_id, role_id, secret_id)
+        result = await session.execute(
+            sa_delete(LLCRoleCredential).where(
+                LLCRoleCredential.company_id == company_id,
+                LLCRoleCredential.role_id == role_id,
+                LLCRoleCredential.secret_id == secret_id,
+            )
+        )
+        detached = bool(result.rowcount)
+        if detached and attachment is not None:
+            await self._record(
+                session,
+                attachment,
+                "role_credential.detached",
+                actor_user_id,
+                {"role_id": str(role_id), "secret_id": str(secret_id)},
+            )
+        return detached

--- a/autobot-backend/llc/services/role_tool.py
+++ b/autobot-backend/llc/services/role_tool.py
@@ -1,0 +1,185 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Attach and detach tools on a role (#14221 step 4).
+
+Tools have no database table — they register in-process by name via
+``autobot_shared.tool_sdk.registry``. So the authority for "is this a real tool"
+is the registry, not a foreign key, and validation lives here.
+
+That raises a failure mode worth naming. If the registry has not been populated
+(import ordering, a stripped-down process), every name looks unknown. Reporting
+that as "unknown tool" would send someone hunting for a typo when the real cause
+is that nothing has registered yet. So the two cases are separated: an empty
+registry raises :class:`ToolRegistryUnavailable`, an absent name raises
+``ValueError``. Same reasoning as the unattributed-workflow branch in step 5 —
+"it isn't there" and "I can't tell" are different answers.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any, Dict, List, Optional
+
+from sqlalchemy import delete as sa_delete
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from user_management.models.role import Role
+
+from autobot_shared.tool_sdk.registry import get_tool_registry
+
+from ..models.activity import ActorType
+from ..models.role_tool import LLCRoleTool
+from .authz import require_company_admin
+from .base import LLCServiceBase
+
+
+class ToolRegistryUnavailable(RuntimeError):
+    """The tool registry holds no tools, so no name can be validated.
+
+    Distinct from "unknown tool" on purpose: this is an environment problem,
+    not a caller mistake, and conflating them turns a startup-ordering bug into
+    a wild goose chase for a misspelling.
+    """
+
+
+class RoleToolService(LLCServiceBase):
+    """Company-scoped attachment of tools to roles."""
+
+    async def _record(
+        self,
+        session: AsyncSession,
+        attachment: LLCRoleTool,
+        event_type: str,
+        actor: Optional[uuid.UUID],
+        after: Optional[Dict[str, Any]],
+    ) -> None:
+        if not self.activity_log:
+            return
+        await self.activity_log.record(
+            session=session,
+            company_id=str(attachment.company_id),
+            actor_type=ActorType.USER if actor else ActorType.SYSTEM,
+            actor_id=str(actor) if actor else None,
+            event_type=event_type,
+            entity_type="llc_role_tool",
+            entity_id=str(attachment.id),
+            after=after,
+        )
+
+    async def _require_role(self, session: AsyncSession, company_id: uuid.UUID, role_id: uuid.UUID) -> None:
+        result = await session.execute(select(Role.id).where(Role.id == role_id, Role.org_id == company_id))
+        if result.scalar_one_or_none() is None:
+            raise ValueError(f"role {role_id} does not exist in company {company_id}")
+
+    @staticmethod
+    def _require_registered_tool(tool_name: str) -> str:
+        """The tool must be registered. Returns the cleaned name."""
+        cleaned = (tool_name or "").strip()
+        if not cleaned:
+            raise ValueError("a tool name is required")
+
+        known = {meta.name for meta in get_tool_registry().list_tools()}
+        if not known:
+            raise ToolRegistryUnavailable(
+                "the tool registry is empty, so no tool name can be validated; "
+                "this is an environment problem, not an unknown tool"
+            )
+        if cleaned not in known:
+            raise ValueError(f"unknown tool {cleaned!r}")
+        return cleaned
+
+    async def attach(
+        self,
+        session: AsyncSession,
+        *,
+        company_id: uuid.UUID,
+        role_id: uuid.UUID,
+        tool_name: str,
+        actor_user_id: uuid.UUID,
+    ) -> LLCRoleTool:
+        if company_id is None or role_id is None:
+            raise ValueError("company_id and role_id are both required")
+
+        await require_company_admin(session, company_id, actor_user_id)
+        await self._require_role(session, company_id, role_id)
+        cleaned = self._require_registered_tool(tool_name)
+
+        if await self.get(session, company_id, role_id, cleaned) is not None:
+            raise ValueError(f"tool {cleaned!r} is already attached to role {role_id}")
+
+        attachment = LLCRoleTool(company_id=company_id, role_id=role_id, tool_name=cleaned)
+        session.add(attachment)
+        await session.flush()
+        await self._record(
+            session,
+            attachment,
+            "role_tool.attached",
+            actor_user_id,
+            {"role_id": str(role_id), "tool_name": cleaned},
+        )
+        return attachment
+
+    async def get(
+        self,
+        session: AsyncSession,
+        company_id: uuid.UUID,
+        role_id: uuid.UUID,
+        tool_name: str,
+    ) -> Optional[LLCRoleTool]:
+        result = await session.execute(
+            select(LLCRoleTool).where(
+                LLCRoleTool.company_id == company_id,
+                LLCRoleTool.role_id == role_id,
+                LLCRoleTool.tool_name == tool_name,
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def list_for_role(self, session: AsyncSession, company_id: uuid.UUID, role_id: uuid.UUID) -> List[str]:
+        """Tool names this role carries — independent of who currently holds it."""
+        result = await session.execute(
+            select(LLCRoleTool.tool_name)
+            .where(
+                LLCRoleTool.company_id == company_id,
+                LLCRoleTool.role_id == role_id,
+            )
+            .order_by(LLCRoleTool.tool_name)
+        )
+        return list(result.scalars().all())
+
+    async def detach(
+        self,
+        session: AsyncSession,
+        company_id: uuid.UUID,
+        role_id: uuid.UUID,
+        tool_name: str,
+        *,
+        actor_user_id: uuid.UUID,
+    ) -> bool:
+        """Remove an attachment. Returns True when a row was actually removed.
+
+        Does **not** re-validate the tool against the registry: a tool that has
+        since been unregistered must still be detachable, or a removed tool
+        would be permanently stuck on every role that carried it.
+        """
+        await require_company_admin(session, company_id, actor_user_id)
+        attachment = await self.get(session, company_id, role_id, tool_name)
+        result = await session.execute(
+            sa_delete(LLCRoleTool).where(
+                LLCRoleTool.company_id == company_id,
+                LLCRoleTool.role_id == role_id,
+                LLCRoleTool.tool_name == tool_name,
+            )
+        )
+        detached = bool(result.rowcount)
+        if detached and attachment is not None:
+            await self._record(
+                session,
+                attachment,
+                "role_tool.detached",
+                actor_user_id,
+                {"role_id": str(role_id), "tool_name": tool_name},
+            )
+        return detached

--- a/autobot-backend/llc/services/role_tool.py
+++ b/autobot-backend/llc/services/role_tool.py
@@ -25,9 +25,9 @@ from typing import Any, Dict, List, Optional
 from sqlalchemy import delete as sa_delete
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
-from user_management.models.role import Role
 
 from autobot_shared.tool_sdk.registry import get_tool_registry
+from user_management.models.role import Role
 
 from ..models.activity import ActorType
 from ..models.role_tool import LLCRoleTool

--- a/autobot-backend/llc/services/role_tool.py
+++ b/autobot-backend/llc/services/role_tool.py
@@ -25,6 +25,7 @@ from typing import Any, Dict, List, Optional
 from sqlalchemy import delete as sa_delete
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+
 from user_management.models.role import Role
 
 from ..models.activity import ActorType

--- a/autobot-backend/llc/services/role_tool.py
+++ b/autobot-backend/llc/services/role_tool.py
@@ -25,8 +25,6 @@ from typing import Any, Dict, List, Optional
 from sqlalchemy import delete as sa_delete
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
-
-from autobot_shared.tool_sdk.registry import get_tool_registry
 from user_management.models.role import Role
 
 from ..models.activity import ActorType
@@ -79,6 +77,20 @@ class RoleToolService(LLCServiceBase):
         cleaned = (tool_name or "").strip()
         if not cleaned:
             raise ValueError("a tool name is required")
+
+        # Imported lazily, and by the top-level ``tool_sdk`` path rather than
+        # ``autobot_shared.tool_sdk``. Both matter:
+        #
+        # * Lazily, because a module-level import runs while the feature
+        #   routers load — before ``autobot_shared/`` is on ``sys.path`` — and
+        #   an ImportError there takes the whole LLC router down, not just this
+        #   service. Every other consumer imports it the same way
+        #   (``tools/tool_registry.py``, ``api/image_generation.py``).
+        # * By the top-level path, because ``get_tool_registry()`` returns a
+        #   module-level singleton. Importing the same file under a second
+        #   module identity would yield a *second, empty* registry, so every
+        #   tool would look unregistered while the real registry was fine.
+        from tool_sdk.registry import get_tool_registry  # noqa: PLC0415
 
         known = {meta.name for meta in get_tool_registry().list_tools()}
         if not known:

--- a/autobot-backend/llc/tests/test_role_credentials.py
+++ b/autobot-backend/llc/tests/test_role_credentials.py
@@ -1,0 +1,331 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Credential references on a role, and revocation (#14221 step 4).
+
+The load-bearing test is ``test_revoking_a_secret_withdraws_it_from_the_role``.
+Revocation is applied when *reading*, not only when attaching — so revoking a
+secret removes it from every role immediately, with no sweep. An implementation
+that filtered only at attach time passes every "can I attach a revoked secret?"
+assertion while leaving already-attached revoked credentials reachable, which is
+the one thing revocation exists to prevent.
+
+``test_a_secret_from_another_company_cannot_be_attached`` is the second: it
+exercises the single UUID/String coercion that bridges ``llc_roles`` and
+``llc_secrets`` (#14312). If that conversion were wrong the predicate would
+match nothing and the guard would look like it worked.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import AsyncIterator
+
+import pytest
+import pytest_asyncio
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from user_management.models.role import Role
+
+from llc.models.enums import MembershipRole
+from llc.models.membership import LLCCompanyMembership
+from llc.models.role_credential import LLCRoleCredential
+from llc.models.secret import LLCSecret
+from llc.services.authz import NotAuthorisedError
+from llc.services.role import RoleService
+from llc.services.role_credential import RoleCredentialService
+
+# Registers the SQLite compile shims for postgresql.JSONB / postgresql.UUID.
+from llc.tests import _e2e_harness as harness
+from user_management.models.base import Base
+
+_ADMIN_USER = uuid.uuid4()
+
+
+@pytest_asyncio.fixture
+async def session_factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = create_async_engine(  # canonical: ignore py-adhoc-db-engine (test-local engine)
+        "sqlite+aiosqlite:///:memory:"
+    )
+    tables = [
+        Role.__table__,
+        LLCCompanyMembership.__table__,
+        LLCRoleCredential.__table__,
+        LLCSecret.__table__,
+    ]
+    for table in tables:
+        harness._scrub_pg_server_defaults(table)
+        harness._clientside_timestamps(table)
+    async with engine.begin() as conn:
+        await conn.run_sync(lambda c: Base.metadata.create_all(c, tables=tables))
+    yield async_sessionmaker(  # canonical: ignore py-adhoc-db-engine (test-local factory)
+        engine, expire_on_commit=False, class_=AsyncSession
+    )
+    await engine.dispose()
+
+
+async def _grant_admin(session_factory, company_id: uuid.UUID) -> None:  # noqa: ANN001
+    async with session_factory() as session:
+        existing = await session.execute(
+            sa.select(LLCCompanyMembership.id).where(
+                LLCCompanyMembership.company_id == company_id,
+                LLCCompanyMembership.user_id == _ADMIN_USER,
+            )
+        )
+        if existing.scalar_one_or_none() is not None:
+            return
+        session.add(
+            LLCCompanyMembership(
+                id=uuid.uuid4(),
+                company_id=company_id,
+                user_id=_ADMIN_USER,
+                role=MembershipRole.ADMIN.value,
+            )
+        )
+        await session.commit()
+
+
+async def _seed_role(session_factory, company_id: uuid.UUID, name: str) -> uuid.UUID:  # noqa: ANN001
+    await _grant_admin(session_factory, company_id)
+    async with session_factory() as session:
+        role = await RoleService().create(session, company_id=company_id, name=name, actor_user_id=_ADMIN_USER)
+        await session.commit()
+        return role.id
+
+
+async def _seed_secret(  # noqa: ANN001
+    session_factory, company_id: uuid.UUID, name: str, *, revoked: bool = False
+) -> uuid.UUID:
+    """A secret row. company_id is stored as a STRING here — that is the #14312 split."""
+    secret_id = uuid.uuid4()
+    async with session_factory() as session:
+        session.add(
+            LLCSecret(
+                id=secret_id,
+                company_id=str(company_id),
+                name=name,
+                value=b"encrypted-bytes",
+                created_by_agent_id="agent-1",
+                revoked_at=datetime(2026, 1, 1, tzinfo=timezone.utc) if revoked else None,
+            )
+        )
+        await session.commit()
+    return secret_id
+
+
+@pytest.mark.asyncio
+async def test_revoking_a_secret_withdraws_it_from_the_role(session_factory):  # noqa: ANN001
+    """Revocation is honoured at read time, so it needs no sweep."""
+    service = RoleCredentialService()
+    company = uuid.uuid4()
+    role_id = await _seed_role(session_factory, company, "Head of Sales")
+    secret_id = await _seed_secret(session_factory, company, "stripe-key")
+
+    async with session_factory() as session:
+        await service.attach(
+            session,
+            company_id=company,
+            role_id=role_id,
+            secret_id=secret_id,
+            actor_user_id=_ADMIN_USER,
+        )
+        await session.commit()
+
+    async with session_factory() as session:
+        assert await service.list_active_for_role(session, company, role_id) == [secret_id]
+
+    async with session_factory() as session:
+        await session.execute(
+            sa.update(LLCSecret)
+            .where(LLCSecret.id == secret_id)
+            .values(revoked_at=datetime(2026, 6, 1, tzinfo=timezone.utc))
+        )
+        await session.commit()
+
+    async with session_factory() as session:
+        assert (
+            await service.list_active_for_role(session, company, role_id) == []
+        ), "a revoked secret was still reachable through the role"
+        # The attachment row survives — the administrative view still shows it,
+        # so an admin can see what was withdrawn rather than it vanishing.
+        assert len(await service.list_for_role(session, company, role_id)) == 1
+
+
+@pytest.mark.asyncio
+async def test_a_revoked_secret_cannot_be_attached(session_factory):  # noqa: ANN001
+    """Refused distinctly from 'not found' — only one means something changed."""
+    service = RoleCredentialService()
+    company = uuid.uuid4()
+    role_id = await _seed_role(session_factory, company, "SRE")
+    secret_id = await _seed_secret(session_factory, company, "old-key", revoked=True)
+
+    async with session_factory() as session:
+        with pytest.raises(ValueError, match="is revoked"):
+            await service.attach(
+                session,
+                company_id=company,
+                role_id=role_id,
+                secret_id=secret_id,
+                actor_user_id=_ADMIN_USER,
+            )
+
+
+@pytest.mark.asyncio
+async def test_a_secret_from_another_company_cannot_be_attached(session_factory):  # noqa: ANN001
+    """Exercises the one UUID/String coercion bridging roles and secrets (#14312)."""
+    service = RoleCredentialService()
+    company_a, company_b = uuid.uuid4(), uuid.uuid4()
+    role_a = await _seed_role(session_factory, company_a, "SRE")
+    theirs = await _seed_secret(session_factory, company_b, "their-key")
+
+    async with session_factory() as session:
+        with pytest.raises(ValueError, match="does not exist in company"):
+            await service.attach(
+                session,
+                company_id=company_a,
+                role_id=role_a,
+                secret_id=theirs,
+                actor_user_id=_ADMIN_USER,
+            )
+
+
+@pytest.mark.asyncio
+async def test_the_company_coercion_actually_matches(session_factory):  # noqa: ANN001
+    """The positive half of the coercion.
+
+    Asserting only that another company's secret is refused would also pass if
+    the predicate matched *nothing* — the empty-result-reads-as-clean trap. This
+    proves the same code path accepts the right secret.
+    """
+    service = RoleCredentialService()
+    company = uuid.uuid4()
+    role_id = await _seed_role(session_factory, company, "SRE")
+    secret_id = await _seed_secret(session_factory, company, "ours")
+
+    async with session_factory() as session:
+        attachment = await service.attach(
+            session,
+            company_id=company,
+            role_id=role_id,
+            secret_id=secret_id,
+            actor_user_id=_ADMIN_USER,
+        )
+        await session.commit()
+
+    assert attachment.secret_id == secret_id
+
+
+@pytest.mark.asyncio
+async def test_a_member_cannot_attach_a_credential(session_factory):  # noqa: ANN001
+    """Credential access is an admin decision."""
+    service = RoleCredentialService()
+    company = uuid.uuid4()
+    role_id = await _seed_role(session_factory, company, "SRE")
+    secret_id = await _seed_secret(session_factory, company, "k")
+    member = uuid.uuid4()
+    async with session_factory() as session:
+        session.add(
+            LLCCompanyMembership(
+                id=uuid.uuid4(),
+                company_id=company,
+                user_id=member,
+                role=MembershipRole.MEMBER.value,
+            )
+        )
+        await session.commit()
+
+    async with session_factory() as session:
+        with pytest.raises(NotAuthorisedError, match="may not perform this change"):
+            await service.attach(
+                session,
+                company_id=company,
+                role_id=role_id,
+                secret_id=secret_id,
+                actor_user_id=member,
+            )
+
+    async with session_factory() as session:
+        assert await service.list_for_role(session, company, role_id) == []
+
+
+@pytest.mark.asyncio
+async def test_attaching_twice_is_refused(session_factory):  # noqa: ANN001
+    service = RoleCredentialService()
+    company = uuid.uuid4()
+    role_id = await _seed_role(session_factory, company, "SRE")
+    secret_id = await _seed_secret(session_factory, company, "k")
+
+    async with session_factory() as session:
+        await service.attach(
+            session,
+            company_id=company,
+            role_id=role_id,
+            secret_id=secret_id,
+            actor_user_id=_ADMIN_USER,
+        )
+        await session.commit()
+
+    async with session_factory() as session:
+        with pytest.raises(ValueError, match="already attached"):
+            await service.attach(
+                session,
+                company_id=company,
+                role_id=role_id,
+                secret_id=secret_id,
+                actor_user_id=_ADMIN_USER,
+            )
+
+
+@pytest.mark.asyncio
+async def test_list_and_detach_are_company_scoped(session_factory):  # noqa: ANN001
+    service = RoleCredentialService()
+    company_a, company_b = uuid.uuid4(), uuid.uuid4()
+    await _grant_admin(session_factory, company_a)
+    role_b = await _seed_role(session_factory, company_b, "SRE")
+    secret_b = await _seed_secret(session_factory, company_b, "k")
+
+    async with session_factory() as session:
+        await service.attach(
+            session,
+            company_id=company_b,
+            role_id=role_b,
+            secret_id=secret_b,
+            actor_user_id=_ADMIN_USER,
+        )
+        await session.commit()
+
+    async with session_factory() as session:
+        assert await service.list_for_role(session, company_a, role_b) == []
+        assert await service.detach(session, company_a, role_b, secret_b, actor_user_id=_ADMIN_USER) is False
+        await session.commit()
+
+    async with session_factory() as session:
+        assert len(await service.list_for_role(session, company_b, role_b)) == 1
+
+
+@pytest.mark.asyncio
+async def test_detach_removes_the_reference(session_factory):  # noqa: ANN001
+    service = RoleCredentialService()
+    company = uuid.uuid4()
+    role_id = await _seed_role(session_factory, company, "SRE")
+    secret_id = await _seed_secret(session_factory, company, "k")
+
+    async with session_factory() as session:
+        await service.attach(
+            session,
+            company_id=company,
+            role_id=role_id,
+            secret_id=secret_id,
+            actor_user_id=_ADMIN_USER,
+        )
+        await session.commit()
+
+    async with session_factory() as session:
+        assert await service.detach(session, company, role_id, secret_id, actor_user_id=_ADMIN_USER) is True
+        await session.commit()
+
+    async with session_factory() as session:
+        assert await service.list_for_role(session, company, role_id) == []
+        # The secret itself is untouched — detaching a reference is not a delete.
+        remaining = await session.execute(sa.select(LLCSecret.id).where(LLCSecret.id == secret_id))
+        assert remaining.scalar_one_or_none() == secret_id

--- a/autobot-backend/llc/tests/test_role_credentials.py
+++ b/autobot-backend/llc/tests/test_role_credentials.py
@@ -25,7 +25,6 @@ import pytest
 import pytest_asyncio
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
-from user_management.models.role import Role
 
 from llc.models.enums import MembershipRole
 from llc.models.membership import LLCCompanyMembership
@@ -38,6 +37,7 @@ from llc.services.role_credential import RoleCredentialService
 # Registers the SQLite compile shims for postgresql.JSONB / postgresql.UUID.
 from llc.tests import _e2e_harness as harness
 from user_management.models.base import Base
+from user_management.models.role import Role
 
 _ADMIN_USER = uuid.uuid4()
 

--- a/autobot-backend/llc/tests/test_role_tools.py
+++ b/autobot-backend/llc/tests/test_role_tools.py
@@ -23,8 +23,10 @@ import pytest
 import pytest_asyncio
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from user_management.models.role import Role
 
-from autobot_shared.tool_sdk.registry import get_tool_registry
+from tool_sdk.registry import get_tool_registry
+
 from llc.models.enums import MembershipRole
 from llc.models.membership import LLCCompanyMembership
 from llc.models.role_tool import LLCRoleTool
@@ -35,7 +37,6 @@ from llc.services.role_tool import RoleToolService, ToolRegistryUnavailable
 # Registers the SQLite compile shims for postgresql.JSONB / postgresql.UUID.
 from llc.tests import _e2e_harness as harness
 from user_management.models.base import Base
-from user_management.models.role import Role
 
 _ADMIN_USER = uuid.uuid4()
 _TOOL = "llc.role_tool_fixture"

--- a/autobot-backend/llc/tests/test_role_tools.py
+++ b/autobot-backend/llc/tests/test_role_tools.py
@@ -1,0 +1,291 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Tools attached to a role (#14221 step 4).
+
+Two tests carry the weight:
+
+``test_an_empty_registry_is_reported_as_such`` — tools have no table, so the
+registry is the authority for "is this a real tool". If it is unpopulated, every
+name looks unknown, and reporting that as "unknown tool" sends someone hunting
+for a typo when the cause is startup ordering. The two cases must stay distinct.
+
+``test_a_detached_tool_survives_being_unregistered`` — detaching deliberately
+skips registry validation. Otherwise removing a tool from the registry would
+strand it on every role that carried it, permanently.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import AsyncIterator
+
+import pytest
+import pytest_asyncio
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from user_management.models.role import Role
+
+from autobot_shared.tool_sdk.registry import get_tool_registry
+
+from llc.models.enums import MembershipRole
+from llc.models.membership import LLCCompanyMembership
+from llc.models.role_tool import LLCRoleTool
+from llc.services.authz import NotAuthorisedError
+from llc.services.role import RoleService
+from llc.services.role_tool import RoleToolService, ToolRegistryUnavailable
+
+# Registers the SQLite compile shims for postgresql.JSONB / postgresql.UUID.
+from llc.tests import _e2e_harness as harness
+from user_management.models.base import Base
+
+_ADMIN_USER = uuid.uuid4()
+_TOOL = "llc.role_tool_fixture"
+
+
+class _FakeMeta:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+@pytest.fixture
+def registry(monkeypatch):  # noqa: ANN001, ANN201
+    """Control what the registry reports, without registering real tools.
+
+    Patches ``list_tools`` on the live singleton rather than swapping the
+    accessor, so the service exercises the same object it uses in production.
+    """
+    live = get_tool_registry()
+    names: list[str] = [_TOOL]
+    monkeypatch.setattr(live, "list_tools", lambda **_: [_FakeMeta(n) for n in names])
+    return names
+
+
+@pytest_asyncio.fixture
+async def session_factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = create_async_engine(  # canonical: ignore py-adhoc-db-engine (test-local engine)
+        "sqlite+aiosqlite:///:memory:"
+    )
+    tables = [Role.__table__, LLCCompanyMembership.__table__, LLCRoleTool.__table__]
+    for table in tables:
+        harness._scrub_pg_server_defaults(table)
+        harness._clientside_timestamps(table)
+    async with engine.begin() as conn:
+        await conn.run_sync(lambda c: Base.metadata.create_all(c, tables=tables))
+    yield async_sessionmaker(  # canonical: ignore py-adhoc-db-engine (test-local factory)
+        engine, expire_on_commit=False, class_=AsyncSession
+    )
+    await engine.dispose()
+
+
+async def _grant_admin(session_factory, company_id: uuid.UUID) -> None:  # noqa: ANN001
+    async with session_factory() as session:
+        existing = await session.execute(
+            sa.select(LLCCompanyMembership.id).where(
+                LLCCompanyMembership.company_id == company_id,
+                LLCCompanyMembership.user_id == _ADMIN_USER,
+            )
+        )
+        if existing.scalar_one_or_none() is not None:
+            return
+        session.add(
+            LLCCompanyMembership(
+                id=uuid.uuid4(),
+                company_id=company_id,
+                user_id=_ADMIN_USER,
+                role=MembershipRole.ADMIN.value,
+            )
+        )
+        await session.commit()
+
+
+async def _seed_role(session_factory, company_id: uuid.UUID, name: str) -> uuid.UUID:  # noqa: ANN001
+    await _grant_admin(session_factory, company_id)
+    async with session_factory() as session:
+        role = await RoleService().create(session, company_id=company_id, name=name, actor_user_id=_ADMIN_USER)
+        await session.commit()
+        return role.id
+
+
+@pytest.mark.asyncio
+async def test_a_registered_tool_attaches(session_factory, registry):  # noqa: ANN001
+    service = RoleToolService()
+    company = uuid.uuid4()
+    role_id = await _seed_role(session_factory, company, "SRE")
+
+    async with session_factory() as session:
+        await service.attach(
+            session,
+            company_id=company,
+            role_id=role_id,
+            tool_name=f"  {_TOOL}  ",
+            actor_user_id=_ADMIN_USER,
+        )
+        await session.commit()
+
+    async with session_factory() as session:
+        assert await service.list_for_role(session, company, role_id) == [_TOOL]
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_tool_is_refused(session_factory, registry):  # noqa: ANN001
+    service = RoleToolService()
+    company = uuid.uuid4()
+    role_id = await _seed_role(session_factory, company, "SRE")
+
+    async with session_factory() as session:
+        with pytest.raises(ValueError, match="unknown tool"):
+            await service.attach(
+                session,
+                company_id=company,
+                role_id=role_id,
+                tool_name="llc.nope",
+                actor_user_id=_ADMIN_USER,
+            )
+
+
+@pytest.mark.asyncio
+async def test_an_empty_registry_is_reported_as_such(session_factory, registry):  # noqa: ANN001
+    """ "Nothing is registered" must not masquerade as "your tool is misspelt"."""
+    service = RoleToolService()
+    company = uuid.uuid4()
+    role_id = await _seed_role(session_factory, company, "SRE")
+    registry.clear()
+
+    async with session_factory() as session:
+        with pytest.raises(ToolRegistryUnavailable, match="registry is empty"):
+            await service.attach(
+                session,
+                company_id=company,
+                role_id=role_id,
+                tool_name=_TOOL,
+                actor_user_id=_ADMIN_USER,
+            )
+
+
+@pytest.mark.asyncio
+async def test_a_detached_tool_survives_being_unregistered(session_factory, registry):  # noqa: ANN001
+    """Removing a tool from the registry must not strand it on every role."""
+    service = RoleToolService()
+    company = uuid.uuid4()
+    role_id = await _seed_role(session_factory, company, "SRE")
+
+    async with session_factory() as session:
+        await service.attach(
+            session,
+            company_id=company,
+            role_id=role_id,
+            tool_name=_TOOL,
+            actor_user_id=_ADMIN_USER,
+        )
+        await session.commit()
+
+    registry.clear()  # the tool is withdrawn from the process
+
+    async with session_factory() as session:
+        assert await service.detach(session, company, role_id, _TOOL, actor_user_id=_ADMIN_USER) is True
+        await session.commit()
+
+    async with session_factory() as session:
+        assert await service.list_for_role(session, company, role_id) == []
+
+
+@pytest.mark.asyncio
+async def test_a_member_cannot_attach_a_tool(session_factory, registry):  # noqa: ANN001
+    service = RoleToolService()
+    company = uuid.uuid4()
+    role_id = await _seed_role(session_factory, company, "SRE")
+    member = uuid.uuid4()
+    async with session_factory() as session:
+        session.add(
+            LLCCompanyMembership(
+                id=uuid.uuid4(),
+                company_id=company,
+                user_id=member,
+                role=MembershipRole.MEMBER.value,
+            )
+        )
+        await session.commit()
+
+    async with session_factory() as session:
+        with pytest.raises(NotAuthorisedError, match="may not perform this change"):
+            await service.attach(
+                session,
+                company_id=company,
+                role_id=role_id,
+                tool_name=_TOOL,
+                actor_user_id=member,
+            )
+
+    async with session_factory() as session:
+        assert await service.list_for_role(session, company, role_id) == []
+
+
+@pytest.mark.asyncio
+async def test_attaching_twice_is_refused(session_factory, registry):  # noqa: ANN001
+    service = RoleToolService()
+    company = uuid.uuid4()
+    role_id = await _seed_role(session_factory, company, "SRE")
+
+    async with session_factory() as session:
+        await service.attach(
+            session,
+            company_id=company,
+            role_id=role_id,
+            tool_name=_TOOL,
+            actor_user_id=_ADMIN_USER,
+        )
+        await session.commit()
+
+    async with session_factory() as session:
+        with pytest.raises(ValueError, match="already attached"):
+            await service.attach(
+                session,
+                company_id=company,
+                role_id=role_id,
+                tool_name=_TOOL,
+                actor_user_id=_ADMIN_USER,
+            )
+
+
+@pytest.mark.asyncio
+async def test_cannot_attach_to_another_companys_role(session_factory, registry):  # noqa: ANN001
+    service = RoleToolService()
+    company_a, company_b = uuid.uuid4(), uuid.uuid4()
+    await _grant_admin(session_factory, company_a)
+    role_b = await _seed_role(session_factory, company_b, "SRE")
+
+    async with session_factory() as session:
+        with pytest.raises(ValueError, match="does not exist in company"):
+            await service.attach(
+                session,
+                company_id=company_a,
+                role_id=role_b,
+                tool_name=_TOOL,
+                actor_user_id=_ADMIN_USER,
+            )
+
+
+@pytest.mark.asyncio
+async def test_list_and_detach_are_company_scoped(session_factory, registry):  # noqa: ANN001
+    service = RoleToolService()
+    company_a, company_b = uuid.uuid4(), uuid.uuid4()
+    await _grant_admin(session_factory, company_a)
+    role_b = await _seed_role(session_factory, company_b, "SRE")
+
+    async with session_factory() as session:
+        await service.attach(
+            session,
+            company_id=company_b,
+            role_id=role_b,
+            tool_name=_TOOL,
+            actor_user_id=_ADMIN_USER,
+        )
+        await session.commit()
+
+    async with session_factory() as session:
+        assert await service.list_for_role(session, company_a, role_b) == []
+        assert await service.detach(session, company_a, role_b, _TOOL, actor_user_id=_ADMIN_USER) is False
+        await session.commit()
+
+    async with session_factory() as session:
+        assert await service.list_for_role(session, company_b, role_b) == [_TOOL]

--- a/autobot-backend/llc/tests/test_role_tools.py
+++ b/autobot-backend/llc/tests/test_role_tools.py
@@ -23,9 +23,6 @@ import pytest
 import pytest_asyncio
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
-from user_management.models.role import Role
-
-from tool_sdk.registry import get_tool_registry
 
 from llc.models.enums import MembershipRole
 from llc.models.membership import LLCCompanyMembership
@@ -36,7 +33,9 @@ from llc.services.role_tool import RoleToolService, ToolRegistryUnavailable
 
 # Registers the SQLite compile shims for postgresql.JSONB / postgresql.UUID.
 from llc.tests import _e2e_harness as harness
+from tool_sdk.registry import get_tool_registry
 from user_management.models.base import Base
+from user_management.models.role import Role
 
 _ADMIN_USER = uuid.uuid4()
 _TOOL = "llc.role_tool_fixture"

--- a/autobot-backend/llc/tests/test_role_tools.py
+++ b/autobot-backend/llc/tests/test_role_tools.py
@@ -23,10 +23,8 @@ import pytest
 import pytest_asyncio
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
-from user_management.models.role import Role
 
 from autobot_shared.tool_sdk.registry import get_tool_registry
-
 from llc.models.enums import MembershipRole
 from llc.models.membership import LLCCompanyMembership
 from llc.models.role_tool import LLCRoleTool
@@ -37,6 +35,7 @@ from llc.services.role_tool import RoleToolService, ToolRegistryUnavailable
 # Registers the SQLite compile shims for postgresql.JSONB / postgresql.UUID.
 from llc.tests import _e2e_harness as harness
 from user_management.models.base import Base
+from user_management.models.role import Role
 
 _ADMIN_USER = uuid.uuid4()
 _TOOL = "llc.role_tool_fixture"

--- a/autobot-backend/llc/tests/test_roles_routes_registered.py
+++ b/autobot-backend/llc/tests/test_roles_routes_registered.py
@@ -32,6 +32,12 @@ _EXPECTED = {
     ("GET", f"{_PREFIX}/{{company_id}}/{{role_id}}/workflows"),
     ("POST", f"{_PREFIX}/{{company_id}}/{{role_id}}/workflows"),
     ("DELETE", f"{_PREFIX}/{{company_id}}/{{role_id}}/workflows/{{workflow_id}}"),
+    ("GET", f"{_PREFIX}/{{company_id}}/{{role_id}}/tools"),
+    ("POST", f"{_PREFIX}/{{company_id}}/{{role_id}}/tools"),
+    ("DELETE", f"{_PREFIX}/{{company_id}}/{{role_id}}/tools/{{tool_name}}"),
+    ("GET", f"{_PREFIX}/{{company_id}}/{{role_id}}/credentials"),
+    ("POST", f"{_PREFIX}/{{company_id}}/{{role_id}}/credentials"),
+    ("DELETE", f"{_PREFIX}/{{company_id}}/{{role_id}}/credentials/{{secret_id}}"),
 }
 
 

--- a/autobot-backend/migrations/versions/20260820_080_llc_role_tools_and_credentials.py
+++ b/autobot-backend/migrations/versions/20260820_080_llc_role_tools_and_credentials.py
@@ -1,0 +1,92 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Add llc_role_tools and llc_role_credentials (#14221 step 4).
+
+Tools and credential *references* hang off the role, so a change of holder moves
+nothing: the next occupant reaches the same tools and secrets because the
+attachments were never the previous occupant's.
+
+``llc_role_credentials`` stores ``secret_id`` only — never a value. The
+plaintext stays behind ``SecretService``, which owns decryption, revocation and
+the audit trail.
+
+Note the deliberate type asymmetry: ``company_id`` here is ``UUID`` (matching
+``roles.org_id`` / ``organizations.id``), while ``llc_secrets.company_id`` is
+``VARCHAR(255)`` — the split tracked in #14312. No foreign key to ``llc_secrets``
+for that reason; the reference is validated in the service, where the one
+conversion lives and is named.
+
+Plain ``op.create_table`` — the tolerant ``IF NOT EXISTS`` form belongs to drift
+reconciliations for tables already changed out-of-band, not to tables born here.
+
+Revision ID: 20260820_080
+Revises: 20260819_079
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision: str = "20260820_080"
+down_revision: Union[str, None] = "20260819_079"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_TOOL_INDEXES = ("company_id", "role_id", "tool_name")
+_CREDENTIAL_INDEXES = ("company_id", "role_id", "secret_id")
+
+
+def _timestamps() -> list:
+    return [
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    ]
+
+
+def upgrade() -> None:
+    op.create_table(
+        "llc_role_tools",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("company_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("role_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("tool_name", sa.String(255), nullable=False),
+        *_timestamps(),
+        sa.UniqueConstraint("role_id", "tool_name", name="uq_llc_role_tools_role_tool"),
+    )
+    for column in _TOOL_INDEXES:
+        op.create_index(f"ix_llc_role_tools_{column}", "llc_role_tools", [column])
+
+    op.create_table(
+        "llc_role_credentials",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("company_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("role_id", UUID(as_uuid=True), nullable=False),
+        # No FK to llc_secrets: its company_id is VARCHAR while this is UUID
+        # (#14312). Validated in RoleCredentialService instead.
+        sa.Column("secret_id", UUID(as_uuid=True), nullable=False),
+        *_timestamps(),
+        sa.UniqueConstraint("role_id", "secret_id", name="uq_llc_role_credentials_role_secret"),
+    )
+    for column in _CREDENTIAL_INDEXES:
+        op.create_index(f"ix_llc_role_credentials_{column}", "llc_role_credentials", [column])
+
+
+def downgrade() -> None:
+    for column in _CREDENTIAL_INDEXES:
+        op.drop_index(f"ix_llc_role_credentials_{column}", table_name="llc_role_credentials")
+    op.drop_table("llc_role_credentials")
+    for column in _TOOL_INDEXES:
+        op.drop_index(f"ix_llc_role_tools_{column}", table_name="llc_role_tools")
+    op.drop_table("llc_role_tools")

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -50268,6 +50268,79 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/llc/roles/{company_id}/{role_id}/tools": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Role Tools */
+        get: operations["list_role_tools_api_llc_roles__company_id___role_id__tools_get"];
+        put?: never;
+        /** Attach Tool */
+        post: operations["attach_tool_api_llc_roles__company_id___role_id__tools_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/llc/roles/{company_id}/{role_id}/tools/{tool_name}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Detach Tool */
+        delete: operations["detach_tool_api_llc_roles__company_id___role_id__tools__tool_name__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/llc/roles/{company_id}/{role_id}/credentials": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Role Credentials
+         * @description Secret ids only — never values. Revoked ones are excluded by default.
+         */
+        get: operations["list_role_credentials_api_llc_roles__company_id___role_id__credentials_get"];
+        put?: never;
+        /** Attach Credential */
+        post: operations["attach_credential_api_llc_roles__company_id___role_id__credentials_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/llc/roles/{company_id}/{role_id}/credentials/{secret_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Detach Credential */
+        delete: operations["detach_credential_api_llc_roles__company_id___role_id__credentials__secret_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/llc/companies/{company_id}/portfolios": {
         parameters: {
             query?: never;
@@ -65664,6 +65737,16 @@ export interface components {
             scopes: string[];
             /** Label */
             label: string;
+        } & {
+            [key: string]: unknown;
+        };
+        /** CredentialAttach */
+        CredentialAttach: {
+            /**
+             * Secret Id
+             * Format: uuid
+             */
+            secret_id: string;
         } & {
             [key: string]: unknown;
         };
@@ -97411,6 +97494,13 @@ export interface components {
             last_used: number | null;
             /** Masked Secret */
             masked_secret: string;
+        } & {
+            [key: string]: unknown;
+        };
+        /** ToolAttach */
+        ToolAttach: {
+            /** Tool Name */
+            tool_name: string;
         } & {
             [key: string]: unknown;
         };
@@ -169677,6 +169767,202 @@ export interface operations {
                 company_id: string;
                 role_id: string;
                 workflow_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_role_tools_api_llc_roles__company_id___role_id__tools_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                company_id: string;
+                role_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": string[];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    attach_tool_api_llc_roles__company_id___role_id__tools_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                company_id: string;
+                role_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ToolAttach"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    detach_tool_api_llc_roles__company_id___role_id__tools__tool_name__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                company_id: string;
+                role_id: string;
+                tool_name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_role_credentials_api_llc_roles__company_id___role_id__credentials_get: {
+        parameters: {
+            query?: {
+                include_revoked?: boolean;
+            };
+            header?: never;
+            path: {
+                company_id: string;
+                role_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": string[];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    attach_credential_api_llc_roles__company_id___role_id__credentials_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                company_id: string;
+                role_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CredentialAttach"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    detach_credential_api_llc_roles__company_id___role_id__credentials__secret_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                company_id: string;
+                role_id: string;
+                secret_id: string;
             };
             cookie?: never;
         };


### PR DESCRIPTION
Part of #14221 (step 4 of 6).

## Thinking Path

> people get promoted or leave the company, but the role stays — and so do the tools and workflows
> attached to the role

Before this, a secret was keyed to the agent that created it (`LLCSecret.created_by_agent_id`), so
terminating that agent left the secret referencing nobody active and the next holder of the same
role starting from nothing. Both attachments now hang off the **role**, which outlives its occupants.

**References, never values.** `llc_role_credentials` stores `secret_id` only. Plaintext stays behind
`SecretService`, which owns decryption, revocation and the audit trail. Copying a value into a second
table would create a parallel credential path with no revocation story — the shape recorded in
#10088 / #13643.

## What Changed

- `llc_role_tools` + `llc_role_credentials`, migration `20260820_080`, both models registered in
  `llc/models/__init__.py`.
- `RoleToolService` / `RoleCredentialService` — attach, detach, list; admin-gated through the shared
  `require_company_admin`, audited, company-scoped.
- **6 new routes** on `llc/api/roles.py` (19 total), all mounted and auth-guarded.

## The Property This Turns On

**Revocation is honoured at read time, not attach time.** `list_active_for_role` joins `llc_secrets`
and excludes `revoked_at IS NOT NULL`, so revoking a secret withdraws it from every role
immediately, with no sweep. Filtering only at attach would pass every "can I attach a revoked
secret?" test while leaving already-attached revoked credentials reachable — the one thing
revocation exists to prevent.

The attachment row survives revocation on purpose: the administrative view still shows what was
withdrawn rather than it silently vanishing.

## Two Asymmetries, Deliberate

**Tools have no table.** They register in-process by name, so the registry is the authority, not a
foreign key. That creates a failure mode worth separating: an unpopulated registry makes *every*
name look unknown. Reporting that as "unknown tool" sends someone hunting for a typo when the cause
is startup ordering — so an empty registry raises `ToolRegistryUnavailable` (**503**), an absent name
raises `ValueError` (**400**). `detach` deliberately skips registry validation, or unregistering a
tool would strand it on every role that carried it, permanently.

**The company-id boundary is crossed once, explicitly.** `llc_roles`/`organizations` key companies
as `UUID`; `llc_secrets` keys them as `String(255)` (#14312). Rather than scatter coercions, the
conversion lives in one named function, `_secret_company_key`, so the eventual type migration has a
single site to delete. No FK to `llc_secrets` for the same reason.

## Verification

**86 role tests pass** (16 new). Mutation-proved:

| Mutation | Reddens |
|---|---|
| drop `revoked_at IS NULL` from the resolver | `test_revoking_a_secret_withdraws_it_from_the_role` |

`test_the_company_coercion_actually_matches` is the positive half of the scoping check — asserting
only that another company's secret is refused would also pass if the predicate matched *nothing*,
the empty-result-reads-as-clean trap this module keeps hitting.

`alembic heads` → `20260820_080`, single head. flake8 clean on all seven touched files — added after
a re-export stripped by autofix broke CI on #14324 while local tests passed.

## Model Used

Claude Opus 5 (1M context)
