### PR TITLE
fix(deploy): give the infrastructure stack the repo ansible config and expose the agent redeploy (#14351)

### DIFF
--- a/autobot-slm-backend/api/infrastructure.py
+++ b/autobot-slm-backend/api/infrastructure.py
@@ -209,7 +209,11 @@ AVAILABLE_PLAYBOOKS: list[PlaybookInfo] = [
         target_hosts=["slm_nodes"],
         variables={},
         estimated_duration="1-2 minutes",
-        requires_confirmation=False,
+        # Confirmation required: deploy-slm-agent.yml has `hosts: slm_nodes`
+        # and NO `serial:`, unlike update-all-nodes.yml (`serial: 3`). With
+        # limit_hosts omitted, one click restarts every agent in the fleet
+        # concurrently with no rolling or health-gated pacing (#14351 review).
+        requires_confirmation=True,
     ),
     PlaybookInfo(
         id="seed-fleet",
@@ -638,7 +642,16 @@ async def _run_playbook(
 
     try:
         # Build ansible-playbook command
-        playbook_path = os.path.join(PLAYBOOKS_DIR, playbook.playbook_file)
+        # #14351 review: this used to come from PLAYBOOKS_DIR (the DEPLOYED
+        # tree) while cwd/ANSIBLE_CONFIG/roles_path resolved against
+        # _ansible_dir() (which prefers code_source). code_source is hard-reset
+        # to origin HEAD on every canonical run, so it is routinely AHEAD of the
+        # deployed copy — meaning an OLD playbook could execute against NEW
+        # roles. That is the same class of bug this PR fixes, relocated.
+        #
+        # One tree for all four, mirroring services/playbook_executor.py's
+        # `playbook_path = self.ansible_dir / playbook_name`.
+        playbook_path = str(_ansible_dir() / playbook.playbook_file)
 
         # Check if playbook exists
         if not os.path.exists(playbook_path):

--- a/autobot-slm-backend/api/infrastructure.py
+++ b/autobot-slm-backend/api/infrastructure.py
@@ -12,10 +12,10 @@ such as database deployment, monitoring setup, and other infrastructure tasks.
 import asyncio
 import logging
 import os
-from pathlib import Path
 import uuid
 from datetime import datetime, timezone
 from enum import Enum
+from pathlib import Path
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field

--- a/autobot-slm-backend/api/infrastructure.py
+++ b/autobot-slm-backend/api/infrastructure.py
@@ -12,6 +12,7 @@ such as database deployment, monitoring setup, and other infrastructure tasks.
 import asyncio
 import logging
 import os
+from pathlib import Path
 import uuid
 from datetime import datetime, timezone
 from enum import Enum
@@ -195,6 +196,20 @@ AVAILABLE_PLAYBOOKS: list[PlaybookInfo] = [
         variables={},
         estimated_duration="20-30 minutes",
         requires_confirmation=True,
+    ),
+    PlaybookInfo(
+        id="deploy-slm-agent",
+        name="Redeploy SLM Agent",
+        description="Redeploy the SLM agent on selected nodes — code, "
+        "agent-secrets.env and a restart. This is the remedy the agent's own "
+        "401 log line names when its X-Internal-API-Key stops matching the "
+        "server's, and it was previously unreachable from the builtin (#14351).",
+        category=PlaybookCategory.NETWORKING,
+        playbook_file="playbooks/deploy-slm-agent.yml",
+        target_hosts=["slm_nodes"],
+        variables={},
+        estimated_duration="1-2 minutes",
+        requires_confirmation=False,
     ),
     PlaybookInfo(
         id="seed-fleet",
@@ -552,15 +567,41 @@ def _build_playbook_command(
     return cmd
 
 
-def _get_ansible_environment():
-    """Get environment variables for Ansible subprocess.
+def _ansible_dir() -> Path:
+    """The repo ansible directory this stack must run from (#14351).
 
-    Helper for _run_playbook (Issue #665).
+    Same directory ``services/playbook_executor.py`` uses as its cwd. Resolved
+    through the executor rather than rebuilt so the two stacks cannot drift
+    apart on where "the ansible directory" is.
+    """
+    from services.playbook_executor import get_playbook_executor
+
+    return Path(get_playbook_executor().ansible_dir)
+
+
+def _get_ansible_environment():
+    """Environment for the Ansible subprocess.
+
+    #14351: this pointed ANSIBLE_CONFIG at ``/opt/autobot/.ansible.cfg``, which
+    is **empty** on a deployed host. An empty config is not a neutral one — it
+    overrides discovery, so ansible fell back to built-in defaults and lost
+    every setting the repo's ``ansible/ansible.cfg`` provides:
+
+        roles_path       = roles      <- `import_role: slm_agent` could not resolve
+        remote_user      = autobot
+        private_key_file = /etc/autobot/ssh/autobot_key
+        timeout / forks
+
+    The symptom was ``ERROR! the role 'slm_agent' was not found``, with a search
+    path missing the one directory that contains it. The canonical executor
+    sets no ANSIBLE_CONFIG at all and lets cwd discovery find the repo file;
+    this now names it explicitly, which is the same result without depending on
+    the process's working directory being right.
     """
     env = os.environ.copy()
     env.update(
         {
-            "ANSIBLE_CONFIG": "/opt/autobot/.ansible.cfg",
+            "ANSIBLE_CONFIG": str(_ansible_dir() / "ansible.cfg"),
             "ANSIBLE_HOME": "/opt/autobot/.ansible",
             "ANSIBLE_LOCAL_TEMP": "/opt/autobot/.ansible/tmp",
         }
@@ -635,11 +676,16 @@ async def _run_playbook(
 
         execution.output.append(f"[INFO] Running: {' '.join(cmd)}")
 
+        # cwd matters even with ANSIBLE_CONFIG named explicitly: `roles_path`
+        # in that file is the RELATIVE value `roles`, so it resolves against
+        # the process working directory. The canonical executor runs from the
+        # ansible dir for exactly this reason (#14351).
         process = await asyncio.create_subprocess_exec(
             *cmd,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT,
             env=_get_ansible_environment(),
+            cwd=str(_ansible_dir()),
         )
 
         await _stream_process_output(process, execution)

--- a/autobot-slm-backend/api/infrastructure_playbook_registry_test.py
+++ b/autobot-slm-backend/api/infrastructure_playbook_registry_test.py
@@ -159,9 +159,9 @@ def test_the_subprocess_runs_from_the_ansible_directory():
     # which is the cross-tree split this PR was blocked on.
     for call in subprocess_calls:
         cwd_kw = next((kw for kw in call.keywords if kw.arg == "cwd"), None)
-        assert cwd_kw is not None, (
-            "ansible-playbook is launched without cwd, so the relative roles_path cannot resolve (#14351)"
-        )
+        assert (
+            cwd_kw is not None
+        ), "ansible-playbook is launched without cwd, so the relative roles_path cannot resolve (#14351)"
         assert any(
             isinstance(inner, ast.Call) and getattr(inner.func, "id", None) == "_ansible_dir"
             for inner in ast.walk(cwd_kw.value)

--- a/autobot-slm-backend/api/infrastructure_playbook_registry_test.py
+++ b/autobot-slm-backend/api/infrastructure_playbook_registry_test.py
@@ -1,0 +1,161 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""The builtin must be able to actually run what it advertises (#14351).
+
+Two independent failures made the agent-redeploy path unreachable at the same
+time, and neither was visible until someone needed it:
+
+1. `/infrastructure/execute` pointed `ANSIBLE_CONFIG` at
+   `/opt/autobot/.ansible.cfg`, which is **empty** on a deployed host. An empty
+   config is not a neutral one — it overrides discovery, so ansible fell back to
+   built-in defaults and lost `roles_path = roles` along with `remote_user`,
+   `private_key_file`, `timeout` and `forks`. `import_role: slm_agent` then
+   failed with "the role 'slm_agent' was not found", listing a search path that
+   omitted the only directory containing it.
+
+2. `deploy-slm-agent.yml` — the playbook the agent's own 401 message tells you
+   to run — was not in the registry at all, so the UI could not offer it.
+
+Together: an agent whose key had gone stale could not be redeployed through the
+builtin by any route, while the repo's rules forbid side-channelling ansible.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+_BACKEND_ROOT = Path(__file__).resolve().parent.parent
+_ANSIBLE_DIR = _BACKEND_ROOT / "ansible"
+_SOURCE = (_BACKEND_ROOT / "api" / "infrastructure.py").read_text(encoding="utf-8")
+
+
+def _registry_entries() -> list[tuple[str, str]]:
+    """(id, playbook_file) for every PlaybookInfo the module declares.
+
+    Parsed from source rather than imported: `api/infrastructure.py` pulls in
+    the whole backend, and this rule is about what the file declares.
+    """
+    tree = ast.parse(_SOURCE)
+    entries = []
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Call) and getattr(node.func, "id", None) == "PlaybookInfo"):
+            continue
+        fields = {kw.arg: kw.value for kw in node.keywords}
+        pid = fields.get("id")
+        pfile = fields.get("playbook_file")
+        if isinstance(pid, ast.Constant) and isinstance(pfile, ast.Constant):
+            entries.append((pid.value, pfile.value))
+    return entries
+
+
+def test_the_registry_is_not_empty():
+    """An empty parse reads exactly like a clean registry."""
+    assert _registry_entries(), "parsed no PlaybookInfo entries — the scan is broken, not the registry"
+
+
+@pytest.mark.parametrize("playbook_id,playbook_file", _registry_entries(), ids=lambda v: str(v))
+def test_every_advertised_playbook_exists(playbook_id, playbook_file):
+    """A registry entry naming a missing file offers the operator a dead button.
+
+    It fails at execution time, on a live system, at the moment someone needed
+    it — which is the worst possible time to discover a typo.
+    """
+    assert (_ANSIBLE_DIR / playbook_file).is_file(), f"{playbook_id} points at {playbook_file}, which does not exist"
+
+
+def test_the_agent_redeploy_playbook_is_reachable():
+    """The remedy the agent names must be runnable from the builtin.
+
+    `agent.py` logs "re-run deploy-slm-agent.yml to refresh agent key" on every
+    rejected heartbeat. Advice an operator cannot act on through the sanctioned
+    path is worse than no advice — it reads as a solved problem.
+    """
+    ids = {pid for pid, _ in _registry_entries()}
+
+    assert "deploy-slm-agent" in ids, (
+        "deploy-slm-agent is not exposed, so the fix the agent's own 401 message "
+        "names cannot be run through the builtin (#14351)"
+    )
+
+
+def test_the_agent_names_the_playbook_this_registry_exposes():
+    """Pin the two ends together.
+
+    If the agent's message is ever reworded to name a different playbook, this
+    fails rather than leaving the registry exposing something nobody is told to
+    run.
+    """
+    agent = (_ANSIBLE_DIR / "roles" / "slm_agent" / "files" / "slm" / "agent" / "agent.py").read_text(encoding="utf-8")
+
+    assert "deploy-slm-agent.yml" in agent, "the agent no longer names deploy-slm-agent.yml — the registry entry may be stale"
+
+
+# --------------------------------------------------------------------------
+# The execution environment must be able to resolve the roles it imports
+# --------------------------------------------------------------------------
+
+
+def test_the_ansible_config_named_is_the_repo_one():
+    """Not a path that happens to exist and happens to be empty.
+
+    The bug was `ANSIBLE_CONFIG=/opt/autobot/.ansible.cfg`, a real but empty
+    file. Because ANSIBLE_CONFIG overrides discovery, that silently disabled
+    every setting in the repo config instead of falling back to it.
+    """
+    tree = ast.parse(_SOURCE)
+    func = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "_get_ansible_environment"
+    )
+    literals = {n.value for n in ast.walk(func) if isinstance(n, ast.Constant) and isinstance(n.value, str)}
+
+    assert not any(v.endswith("/.ansible.cfg") for v in literals), (
+        "ANSIBLE_CONFIG points at a dotfile outside the repo — that file is empty on deployed "
+        "hosts and disables roles_path, remote_user and private_key_file (#14351)"
+    )
+    assert any("ansible.cfg" in v for v in literals) or "_ansible_dir" in ast.dump(func), (
+        "ANSIBLE_CONFIG is no longer derived from the repo ansible directory"
+    )
+
+
+def test_the_subprocess_runs_from_the_ansible_directory():
+    """`roles_path = roles` is relative, so cwd decides whether it resolves.
+
+    Asserted on the call rather than on a comment: without `cwd`, the relative
+    path resolves against whatever directory the API process happens to be in,
+    and `import_role` fails for a reason that names the role rather than the
+    working directory.
+    """
+    tree = ast.parse(_SOURCE)
+    subprocess_calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and getattr(node.func, "attr", None) == "create_subprocess_exec"
+    ]
+    assert subprocess_calls, "no create_subprocess_exec call found — this rule is pinned to the wrong thing"
+
+    for call in subprocess_calls:
+        assert any(kw.arg == "cwd" for kw in call.keywords), (
+            "ansible-playbook is launched without cwd, so the relative roles_path cannot resolve (#14351)"
+        )
+
+
+def test_the_repo_config_still_declares_a_relative_roles_path():
+    """The premise the cwd requirement rests on.
+
+    If `roles_path` ever becomes absolute, the cwd rule above is no longer
+    load-bearing and this test says so instead of leaving a mysterious
+    requirement in place.
+    """
+    cfg = (_ANSIBLE_DIR / "ansible.cfg").read_text(encoding="utf-8")
+    match = re.search(r"^\s*roles_path\s*=\s*(\S+)", cfg, re.M)
+
+    assert match, "ansible.cfg no longer sets roles_path — import_role resolution has changed"
+    assert not match.group(1).startswith("/"), "roles_path is absolute now; the cwd requirement can be revisited"

--- a/autobot-slm-backend/api/infrastructure_playbook_registry_test.py
+++ b/autobot-slm-backend/api/infrastructure_playbook_registry_test.py
@@ -120,9 +120,21 @@ def test_the_ansible_config_named_is_the_repo_one():
         "ANSIBLE_CONFIG points at a dotfile outside the repo — that file is empty on deployed "
         "hosts and disables roles_path, remote_user and private_key_file (#14351)"
     )
-    assert any("ansible.cfg" in v for v in literals) or "_ansible_dir" in ast.dump(
-        func
-    ), "ANSIBLE_CONFIG is no longer derived from the repo ansible directory"
+    # Review finding: the previous version of this assertion was satisfied by the
+    # function's own DOCSTRING, which mentions ansible.cfg in prose — so a
+    # regression hardcoding some other *ansible.cfg path would have passed.
+    # Assert on the assigned VALUE instead: it must be built from _ansible_dir().
+    env_value = None
+    for node in ast.walk(func):
+        if isinstance(node, ast.Dict):
+            for key, value in zip(node.keys, node.values):
+                if isinstance(key, ast.Constant) and key.value == "ANSIBLE_CONFIG":
+                    env_value = value
+    assert env_value is not None, "ANSIBLE_CONFIG is no longer set in the environment dict"
+    assert any(
+        isinstance(inner, ast.Call) and getattr(inner.func, "id", None) == "_ansible_dir"
+        for inner in ast.walk(env_value)
+    ), "ANSIBLE_CONFIG is not derived from _ansible_dir() — it may point at an unrelated tree"
 
 
 def test_the_subprocess_runs_from_the_ansible_directory():
@@ -141,10 +153,50 @@ def test_the_subprocess_runs_from_the_ansible_directory():
     ]
     assert subprocess_calls, "no create_subprocess_exec call found — this rule is pinned to the wrong thing"
 
+    # Review finding: asserting only that `cwd` is PRESENT would pass on
+    # `cwd="/tmp"`. The value has to come from the same helper the config and
+    # the playbook path use, or the three can resolve against different trees —
+    # which is the cross-tree split this PR was blocked on.
     for call in subprocess_calls:
+        cwd_kw = next((kw for kw in call.keywords if kw.arg == "cwd"), None)
+        assert cwd_kw is not None, (
+            "ansible-playbook is launched without cwd, so the relative roles_path cannot resolve (#14351)"
+        )
         assert any(
-            kw.arg == "cwd" for kw in call.keywords
-        ), "ansible-playbook is launched without cwd, so the relative roles_path cannot resolve (#14351)"
+            isinstance(inner, ast.Call) and getattr(inner.func, "id", None) == "_ansible_dir"
+            for inner in ast.walk(cwd_kw.value)
+        ), "cwd is not _ansible_dir() — config, roles and the playbook file could resolve from different trees"
+
+
+def test_the_playbook_file_comes_from_the_same_tree_as_the_config():
+    """The cross-tree split this PR was blocked on.
+
+    `PLAYBOOKS_DIR` defaults to the DEPLOYED tree; `_ansible_dir()` prefers
+    `code_source`, which is hard-reset to origin HEAD on every canonical run and
+    is therefore routinely ahead. Taking the playbook file from one and
+    roles/config from the other runs an old play against new roles — the same
+    failure this PR fixes, relocated somewhere harder to see.
+
+    `services/playbook_executor.py` derives both from one `ansible_dir`; this
+    asserts the endpoint does too.
+    """
+    tree = ast.parse(_SOURCE)
+    assignments = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Assign)
+        and any(isinstance(t, ast.Name) and t.id == "playbook_path" for t in node.targets)
+    ]
+    assert assignments, "playbook_path is no longer assigned — this rule is pinned to the wrong name"
+
+    for node in assignments:
+        names = {n.id for n in ast.walk(node.value) if isinstance(n, ast.Name)}
+        calls = {getattr(c.func, "id", None) for c in ast.walk(node.value) if isinstance(c, ast.Call)}
+        assert "PLAYBOOKS_DIR" not in names, (
+            "playbook_path is built from PLAYBOOKS_DIR while cwd/config use _ansible_dir() — "
+            "an old playbook can execute against new roles (#14351 review)"
+        )
+        assert "_ansible_dir" in calls, "playbook_path is not derived from _ansible_dir()"
 
 
 def test_the_repo_config_still_declares_a_relative_roles_path():

--- a/autobot-slm-backend/api/infrastructure_playbook_registry_test.py
+++ b/autobot-slm-backend/api/infrastructure_playbook_registry_test.py
@@ -93,7 +93,9 @@ def test_the_agent_names_the_playbook_this_registry_exposes():
     """
     agent = (_ANSIBLE_DIR / "roles" / "slm_agent" / "files" / "slm" / "agent" / "agent.py").read_text(encoding="utf-8")
 
-    assert "deploy-slm-agent.yml" in agent, "the agent no longer names deploy-slm-agent.yml — the registry entry may be stale"
+    assert (
+        "deploy-slm-agent.yml" in agent
+    ), "the agent no longer names deploy-slm-agent.yml — the registry entry may be stale"
 
 
 # --------------------------------------------------------------------------
@@ -110,9 +112,7 @@ def test_the_ansible_config_named_is_the_repo_one():
     """
     tree = ast.parse(_SOURCE)
     func = next(
-        node
-        for node in ast.walk(tree)
-        if isinstance(node, ast.FunctionDef) and node.name == "_get_ansible_environment"
+        node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == "_get_ansible_environment"
     )
     literals = {n.value for n in ast.walk(func) if isinstance(n, ast.Constant) and isinstance(n.value, str)}
 
@@ -120,9 +120,9 @@ def test_the_ansible_config_named_is_the_repo_one():
         "ANSIBLE_CONFIG points at a dotfile outside the repo — that file is empty on deployed "
         "hosts and disables roles_path, remote_user and private_key_file (#14351)"
     )
-    assert any("ansible.cfg" in v for v in literals) or "_ansible_dir" in ast.dump(func), (
-        "ANSIBLE_CONFIG is no longer derived from the repo ansible directory"
-    )
+    assert any("ansible.cfg" in v for v in literals) or "_ansible_dir" in ast.dump(
+        func
+    ), "ANSIBLE_CONFIG is no longer derived from the repo ansible directory"
 
 
 def test_the_subprocess_runs_from_the_ansible_directory():
@@ -142,9 +142,9 @@ def test_the_subprocess_runs_from_the_ansible_directory():
     assert subprocess_calls, "no create_subprocess_exec call found — this rule is pinned to the wrong thing"
 
     for call in subprocess_calls:
-        assert any(kw.arg == "cwd" for kw in call.keywords), (
-            "ansible-playbook is launched without cwd, so the relative roles_path cannot resolve (#14351)"
-        )
+        assert any(
+            kw.arg == "cwd" for kw in call.keywords
+        ), "ansible-playbook is launched without cwd, so the relative roles_path cannot resolve (#14351)"
 
 
 def test_the_repo_config_still_declares_a_relative_roles_path():


### PR DESCRIPTION
## Thinking Path

Found trying to repair a live node whose agent was 401ing. The agent's own log names the fix —
"re-run deploy-slm-agent.yml" — so I went to run it through the builtin and could not.

The first error was misleading. `POST /api/infrastructure/execute` with `provision-fleet` reported a
**syntax** error pointing at an `import_role` line, which sends you looking at YAML. The real
message was above the truncation:

```
ERROR! the role 'slm_agent' was not found in
  .../ansible/playbooks/roles : /opt/autobot/.ansible/roles :
  /usr/share/ansible/roles : /etc/ansible/roles : .../ansible/playbooks
```

A search path missing the one directory that contains it.

## Problem

Two independent failures, both invisible until someone needed this path.

**1. `ANSIBLE_CONFIG` pointed at an empty file.** `_get_ansible_environment()` set it to
`/opt/autobot/.ansible.cfg`, which exists on a deployed host and is **empty**. An empty config is
not a neutral one — naming it *overrides discovery*, so ansible fell back to built-in defaults and
lost everything the repo's `ansible/ansible.cfg` provides:

```
roles_path       = roles       <- import_role: slm_agent could not resolve
remote_user      = autobot
private_key_file = /etc/autobot/ssh/autobot_key
timeout / forks
```

The canonical executor (`services/playbook_executor.py`) sets no `ANSIBLE_CONFIG` at all and runs
with `cwd=self.ansible_dir`, so discovery finds the repo file. This is the same two-stacks divergence
as #14286 — I fixed the group_vars half there; this is the config half.

**2. `deploy-slm-agent.yml` was not in the registry.** The playbook the agent's 401 message names
was absent from `GET /api/infrastructure/playbooks`, so the UI could not offer it.

Together: no route to redeploy an agent through the builtin, while the repo's rules forbid
side-channelling ansible. That is a blocker, not an inconvenience.

## What Changed

`ANSIBLE_CONFIG` is derived from the executor's own `ansible_dir` rather than hardcoded, so the two
stacks cannot disagree about where the config lives. `cwd` is set to that directory as well —
naming the config is not sufficient on its own, because `roles_path = roles` is **relative** and
resolves against the process working directory.

`deploy-slm-agent` joins the registry (21 entries, was 20).

## Verification

CI. The rules are about the two ways this stays broken:

- `test_every_advertised_playbook_exists` — parametrised over all 21 entries. A registry naming a
  missing file offers the operator a dead button that fails on a live system at the moment they
  needed it.
- `test_the_ansible_config_named_is_the_repo_one` — fails on any `ANSIBLE_CONFIG` ending in
  `/.ansible.cfg` outside the repo. The bug was a real-but-empty file, which is exactly the case a
  "does it exist" check would have passed.
- `test_the_subprocess_runs_from_the_ansible_directory` — asserts `cwd` on the call, not in a
  comment.
- `test_the_repo_config_still_declares_a_relative_roles_path` — pins *why* cwd is load-bearing, so
  if `roles_path` ever becomes absolute the requirement is revisited rather than cargo-culted.
- `test_the_agent_names_the_playbook_this_registry_exposes` — ties the agent's log message to the
  registry entry, so rewording one without the other fails.

Checked against the tree before pushing: 21 entries, 0 missing files, no outside dotfile, cwd
present on the only subprocess call, `roles_path` relative, agent still names the playbook.

Not run locally, by instruction.

## Risks

Runs through this endpoint now get `remote_user`, `private_key_file`, `timeout` and `forks` from the
repo config where they previously got ansible defaults. That is the intent — those settings existed
and were being discarded — but it does mean this path's SSH behaviour changes to match the
canonical executor's. Anything that worked only because the wizard inventory supplied
`ansible_user`/`ansible_ssh_private_key_file` per host keeps working; those are host vars and still
win over config defaults.

## Not in scope

The stale-key precedence that sent me here (#14350) and the reconciler reporting success on a
restart that achieves nothing (#14344). This restores the *path*; those are separate.

## Model Used

Opus 5 (1M context).

Closes #14351
