### PR TITLE
fix(ci): attribute a starved run to a runner pool before blaming that pool (#14364, #13384)

### DIFF
--- a/.github/workflows/ci-dispatch-watchdog.yml
+++ b/.github/workflows/ci-dispatch-watchdog.yml
@@ -76,7 +76,22 @@ on:
 concurrency:
   # Never cancel a sweep in flight — a half-finished sweep leaves some PRs
   # without a published status, which is the exact condition being guarded.
-  group: ci-dispatch-watchdog
+  #
+  # The group is scoped to WHAT IS BEING SWEPT, not to the workflow (#13384).
+  # A repo-global group looks like it honours `cancel-in-progress: false`, but
+  # GitHub keeps at most one in-progress AND one pending run per group: the
+  # third arrival cancels the pending one. With a `pull_request` trigger on
+  # every synchronize and a busy queue, the watchdog's own sweeps therefore
+  # cancelled each other and nothing was published. Observed 2026-08-03 (two
+  # cancelled one second apart, ~120 runs left parked for a human) and again
+  # 2026-08-16 (16 of 30 consecutive runs cancelled).
+  #
+  # A `pull_request` sweep is already narrowed to the firing PR via
+  # WATCHDOG_ONLY_PR, so per-PR groups are not merely safe — they match what
+  # the job actually does, and let twelve PR sweeps proceed in parallel.
+  # Everything else (schedule, base push, manual dispatch) shares the single
+  # `base` group, keeping the one genuinely repo-wide sweep serialised.
+  group: ci-dispatch-watchdog-${{ github.event.pull_request.number || 'base' }}
   cancel-in-progress: false
 
 permissions:

--- a/pipeline-scripts/ci_dispatch_watchdog.py
+++ b/pipeline-scripts/ci_dispatch_watchdog.py
@@ -89,6 +89,7 @@ Environment:
     WATCHDOG_BASE_BRANCH             PR base to watch (default Dev_new_gui)
     WATCHDOG_GRACE_MINUTES           age before "no runs at all" is a failure
     WATCHDOG_STALL_MINUTES           age before a job-less queued run is a failure
+    WATCHDOG_WORKFLOW_DIR            workflow definitions, for runner-pool attribution
     WATCHDOG_MAX_APPROVALS           per-sweep approval cap (blast-radius guard; exceeding it fails)
     WATCHDOG_POLL_ATTEMPTS           re-list attempts while runs appear
     WATCHDOG_POLL_INTERVAL_SECONDS   delay between those attempts
@@ -125,6 +126,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import socket
 import sys
 import time
@@ -132,6 +134,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Dict, List, NamedTuple, Optional, Sequence, Set, Tuple
 
 # GitHub returns this message when the *token* lacks `actions: write`.
@@ -146,6 +149,16 @@ UPDATE_BOT_LOGIN = "github-actions[bot]"
 
 # A job carrying this label ran on the self-hosted pool.
 SELF_HOSTED_LABEL = "self-hosted"
+
+# Where workflow definitions are read from, so a QUEUED run can be attributed to
+# a runner pool (#14364). Labels live on jobs and a starved run has none — that
+# absence is the condition being detected — but the run payload carries the
+# workflow's `path`, and `runs-on` is declared in that file. Reading it answers
+# the attribution question the job listing cannot.
+DEFAULT_WORKFLOW_DIR = ".github/workflows"
+WORKFLOW_SUFFIXES = frozenset({".yml", ".yaml"})
+RUNS_ON_RE = re.compile(r"^\s*runs-on:\s*(?P<value>.*)$")
+YAML_LIST_ITEM_RE = re.compile(r"^\s*-\s*(?P<value>.+)$")
 
 # GitHub truncates commit-status descriptions beyond this length.
 MAX_STATUS_DESCRIPTION = 140
@@ -494,6 +507,86 @@ def job_is_self_hosted(job: Dict[str, Any]) -> bool:
     return SELF_HOSTED_LABEL in labels
 
 
+def _strip_comment(value: str) -> str:
+    """A YAML scalar with any trailing `#` comment removed."""
+    return value.split("#", 1)[0].strip()
+
+
+def _block_list_items(lines: Sequence[str], start: int) -> List[str]:
+    """Items of a block-form sequence beginning at *start*."""
+    items: List[str] = []
+    for line in lines[start:]:
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        match = YAML_LIST_ITEM_RE.match(line)
+        if not match:
+            break
+        items.append(_strip_comment(match.group("value")))
+    return items
+
+
+def declares_self_hosted(text: str) -> bool:
+    """True when a workflow declares at least one job on the self-hosted pool.
+
+    Comments are stripped before matching, which is correctness rather than
+    tidiness: `code-quality.yml` carries
+
+        runs-on: ubuntu-latest  # Temporary: self-hosted runner offline
+
+    and a substring match on the raw line classifies that GitHub-hosted job as
+    self-hosted — reproducing the very misattribution this function removes.
+    `marker-tests.yml` has the same trap in a whole-line comment.
+    """
+    lines = text.splitlines()
+    for index, line in enumerate(lines):
+        match = RUNS_ON_RE.match(line)
+        if not match:
+            continue
+        inline = _strip_comment(match.group("value"))
+        values = [inline] if inline else _block_list_items(lines, index + 1)
+        if any(SELF_HOSTED_LABEL in value.lower() for value in values):
+            return True
+    return False
+
+
+def self_hosted_workflow_paths(workflow_dir: str) -> Optional[Set[str]]:
+    """Repo-relative paths of workflows declaring at least one self-hosted job.
+
+    ``None`` means the directory could not be read at all, so no run can be
+    attributed to a pool — the caller must say "unknown", never guess.
+    """
+    root = Path(workflow_dir)
+    try:
+        files = sorted(path for path in root.iterdir() if path.suffix in WORKFLOW_SUFFIXES)
+    except OSError:
+        return None
+    paths: Set[str] = set()
+    for path in files:
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            # Unreadable file: a self-hosted job cannot be ruled out, so keep it.
+            paths.add(path.as_posix())
+            continue
+        if declares_self_hosted(text):
+            paths.add(path.as_posix())
+    return paths
+
+
+def run_requires_self_hosted(run: Dict[str, Any], self_hosted_paths: Optional[Set[str]]) -> bool:
+    """True when this run's workflow declares at least one self-hosted job.
+
+    Unknown resolves to True from both directions — an unreadable workflow set,
+    or a run carrying no `path`. The verdict this gates asserts a specific
+    cause, and suppressing a real self-hosted outage is the worse error of the
+    two, so an unattributable run stays reportable.
+    """
+    if self_hosted_paths is None:
+        return True
+    path = str(run.get("path") or "")
+    return not path or path in self_hosted_paths
+
+
 def job_is_overdue(job: Dict[str, Any], now: datetime, overdue_minutes: int) -> bool:
     """
     True when a self-hosted job has been executing past the point of plausibility.
@@ -523,6 +616,7 @@ def classify_dispatch(
     stall_minutes: int,
     pool_serving: bool = True,
     overdue: Sequence[OverdueJob] = (),
+    self_hosted_paths: Optional[Set[str]] = None,
 ) -> Tuple[str, str]:
     """
     Decide the commit-status state for one PR head.
@@ -555,21 +649,28 @@ def classify_dispatch(
 
     starved = starved_runs(runs, now, stall_minutes)
     if starved:
-        names = ", ".join(sorted({str(run.get("name", "?")) for run in starved})[:3])
-        if pool_serving:
-            # Contention, not an outage — still never green, because the head is
-            # demonstrably not verified yet.
+        # Only runs that can actually reach the self-hosted pool may be cited as
+        # evidence it is starved (#14364). `pool_serving` is derived from
+        # self-hosted job labels alone, so an idle-but-healthy pool reads as not
+        # serving; without this filter a GitHub-hosted capacity backlog was
+        # published as `no runner available`, and the healthier the pool was the
+        # more reliably that happened.
+        needs_pool = [run for run in starved if run_requires_self_hosted(run, self_hosted_paths)]
+        if needs_pool and not pool_serving:
+            names = ", ".join(sorted({str(run.get("name", "?")) for run in needs_pool})[:3])
             return (
-                "pending",
+                "failure",
                 _truncate(
-                    f"{len(starved)} run(s) queued over {stall_minutes}m behind a busy runner pool: {names}"
+                    f"{len(needs_pool)} self-hosted run(s) queued over {stall_minutes}m "
+                    f"with no runner available: {names}"
                 ),
             )
+        # Contention, not an outage — still never green, because the head is
+        # demonstrably not verified yet.
+        names = ", ".join(sorted({str(run.get("name", "?")) for run in starved})[:3])
         return (
-            "failure",
-            _truncate(
-                f"{len(starved)} run(s) queued over {stall_minutes}m with no runner available: {names}"
-            ),
+            "pending",
+            _truncate(f"{len(starved)} run(s) queued over {stall_minutes}m behind a busy queue: {names}"),
         )
 
     if not runs:
@@ -1068,6 +1169,12 @@ def publish_dispatch_states(
     """Write the dispatch commit status for each head. Returns the not-dispatched count."""
     now = datetime.now(timezone.utc)
     wedged = overdue_by_head(overdue)
+    self_hosted_paths = self_hosted_workflow_paths(config["workflow_dir"])
+    if self_hosted_paths is None:
+        print(
+            f"::warning::{config['workflow_dir']} unreadable — a starved run cannot be "
+            "attributed to a runner pool, so pool verdicts fall back to unfiltered."
+        )
     blocked = 0
     for head in heads:
         try:
@@ -1086,6 +1193,7 @@ def publish_dispatch_states(
                 config["stall_minutes"],
                 pool_serving is not False,
                 wedged.get(head.sha, ()),
+                self_hosted_paths,
             )
         target = _run_url(api.repository, runs[0]) if runs else head.url
         if dry_run:
@@ -1235,17 +1343,24 @@ def check_runner_starvation(api: GitHubApi, config: Dict[str, Any]) -> int:
     # Filtered server-side: an unfiltered page is dominated by the hundreds of
     # parked runs this repository carries, which can hide every queued run.
     #
-    # KNOWN LIMIT, stated rather than papered over: this listing cannot tell the
-    # two runner pools apart. Labels live on JOBS, and a starved run has no jobs
-    # — that absence IS the condition being detected — so a run queued past the
-    # threshold cannot be attributed to the self-hosted pool from the API alone,
-    # and a GitHub-hosted capacity backlog would read the same way. The verdict
-    # below is therefore never taken from the queue on its own; it is qualified
-    # by the pool inspection, which IS label-attributed. Whether a starved queue
-    # can be attributed to a pool by any means the workflow token can read
-    # remains open.
+    # The listing cannot tell the two pools apart on its own: labels live on
+    # JOBS, and a starved run has no jobs — that absence IS the condition being
+    # detected. That limit used to be stated and left open, and qualifying the
+    # verdict with the label-attributed pool inspection was not enough: an idle
+    # pool is "not serving", so a GitHub-hosted capacity backlog read as a
+    # self-hosted outage (#14364).
+    #
+    # It is answered here without a job listing. The run payload carries the
+    # workflow's `path`, `runs-on` is declared in that file, and the file is on
+    # disk because the job checks the repository out. Attribution is therefore a
+    # local read rather than an API call, and costs no budget.
     queued = api.recent_runs(run_status="queued")
-    starved = starved_runs(queued, now, config["stall_minutes"])
+    self_hosted_paths = self_hosted_workflow_paths(config["workflow_dir"])
+    starved = [
+        run
+        for run in starved_runs(queued, now, config["stall_minutes"])
+        if run_requires_self_hosted(run, self_hosted_paths)
+    ]
     pool = inspect_self_hosted_pool(
         api, config["max_job_lookups"], config["job_overdue_minutes"], now
     )
@@ -1255,7 +1370,8 @@ def check_runner_starvation(api: GitHubApi, config: Dict[str, Any]) -> int:
         if pool.overdue:
             return 1
         print(
-            f"No run has been queued longer than {config['stall_minutes']}m — runner pool is keeping up."
+            f"No self-hosted run has been queued longer than {config['stall_minutes']}m — "
+            "runner pool is keeping up."
         )
         return 0
 
@@ -1279,7 +1395,8 @@ def check_runner_starvation(api: GitHubApi, config: Dict[str, Any]) -> int:
         else "while no self-hosted job is executing"
     )
     print(
-        f"::error::{len(starved)} workflow run(s) queued over {config['stall_minutes']}m {reason}"
+        f"::error::{len(starved)} self-hosted workflow run(s) queued over "
+        f"{config['stall_minutes']}m {reason}"
     )
     for run in starved:
         waited = age_minutes(run.get("created_at"), now)
@@ -1302,6 +1419,7 @@ def load_config() -> Dict[str, Any]:
         "repository": repository,
         "api_root": os.environ.get("GITHUB_API_URL", DEFAULT_API_ROOT),
         "base_branch": os.environ.get("WATCHDOG_BASE_BRANCH", DEFAULT_BASE_BRANCH),
+        "workflow_dir": os.environ.get("WATCHDOG_WORKFLOW_DIR", DEFAULT_WORKFLOW_DIR),
         "grace_minutes": _env_int("WATCHDOG_GRACE_MINUTES", DEFAULT_GRACE_MINUTES),
         "stall_minutes": _env_int("WATCHDOG_STALL_MINUTES", DEFAULT_STALL_MINUTES),
         "max_approvals": _env_int("WATCHDOG_MAX_APPROVALS", DEFAULT_MAX_APPROVALS),

--- a/pipeline-scripts/ci_dispatch_watchdog.py
+++ b/pipeline-scripts/ci_dispatch_watchdog.py
@@ -1169,10 +1169,17 @@ def publish_dispatch_states(
     """Write the dispatch commit status for each head. Returns the not-dispatched count."""
     now = datetime.now(timezone.utc)
     wedged = overdue_by_head(overdue)
-    self_hosted_paths = self_hosted_workflow_paths(config["workflow_dir"])
+    # `.get` with the module default, not `config["workflow_dir"]`: this is an
+    # env-var-backed knob like every other entry in `load_config`, and a caller
+    # that has not overridden it must get the real production directory rather
+    # than a KeyError. `load_config` still sets it explicitly, and
+    # `test_load_config_supplies_the_workflow_dir` pins that, so the default
+    # here is a fallback for partial configs — never the only thing wiring it.
+    workflow_dir = config.get("workflow_dir", DEFAULT_WORKFLOW_DIR)
+    self_hosted_paths = self_hosted_workflow_paths(workflow_dir)
     if self_hosted_paths is None:
         print(  # noqa: print
-            f"::warning::{config['workflow_dir']} unreadable — a starved run cannot be "
+            f"::warning::{workflow_dir} unreadable — a starved run cannot be "
             "attributed to a runner pool, so pool verdicts fall back to unfiltered."
         )
     blocked = 0
@@ -1355,7 +1362,9 @@ def check_runner_starvation(api: GitHubApi, config: Dict[str, Any]) -> int:
     # disk because the job checks the repository out. Attribution is therefore a
     # local read rather than an API call, and costs no budget.
     queued = api.recent_runs(run_status="queued")
-    self_hosted_paths = self_hosted_workflow_paths(config["workflow_dir"])
+    self_hosted_paths = self_hosted_workflow_paths(
+        config.get("workflow_dir", DEFAULT_WORKFLOW_DIR)
+    )
     starved = [
         run
         for run in starved_runs(queued, now, config["stall_minutes"])

--- a/pipeline-scripts/ci_dispatch_watchdog.py
+++ b/pipeline-scripts/ci_dispatch_watchdog.py
@@ -1171,7 +1171,7 @@ def publish_dispatch_states(
     wedged = overdue_by_head(overdue)
     self_hosted_paths = self_hosted_workflow_paths(config["workflow_dir"])
     if self_hosted_paths is None:
-        print(
+        print(  # noqa: print
             f"::warning::{config['workflow_dir']} unreadable — a starved run cannot be "
             "attributed to a runner pool, so pool verdicts fall back to unfiltered."
         )
@@ -1369,7 +1369,7 @@ def check_runner_starvation(api: GitHubApi, config: Dict[str, Any]) -> int:
     if not starved:
         if pool.overdue:
             return 1
-        print(
+        print(  # noqa: print
             f"No self-hosted run has been queued longer than {config['stall_minutes']}m — "
             "runner pool is keeping up."
         )
@@ -1394,7 +1394,7 @@ def check_runner_starvation(api: GitHubApi, config: Dict[str, Any]) -> int:
         if pool.overdue
         else "while no self-hosted job is executing"
     )
-    print(
+    print(  # noqa: print
         f"::error::{len(starved)} self-hosted workflow run(s) queued over "
         f"{config['stall_minutes']}m {reason}"
     )

--- a/repo_tests/ci_dispatch_watchdog_test.py
+++ b/repo_tests/ci_dispatch_watchdog_test.py
@@ -221,7 +221,9 @@ def test_queued_run_behind_a_busy_pool_is_pending_not_failure(watchdog):
     ]
     state, description = watchdog.classify_dispatch(runs, _ts(45), NOW, 10, 30, True)
     assert state == "pending"
-    assert "busy runner pool" in description
+    # "busy queue", not "busy runner pool" (#14364): this branch now also covers
+    # a GitHub-hosted backlog, which no runner pool is responsible for.
+    assert "busy queue" in description
 
 
 def test_a_busy_queue_is_still_never_success(watchdog):
@@ -1149,3 +1151,148 @@ def test_fork_runs_are_never_cancelled(watchdog):
 def test_a_lone_run_is_never_cancelled(watchdog):
     """With nothing newer, nothing supersedes it."""
     assert _select(watchdog, [_member(1, 60)]) == []
+
+
+# --- #14364: a starved run must be attributed to a pool before blaming it ----
+#
+# `pool_serving` is derived from self-hosted JOB LABELS, so an idle-but-healthy
+# pool reads as "not serving". Without attribution, any GitHub-hosted capacity
+# backlog past the stall threshold published `failure: no runner available` —
+# and the healthier the self-hosted pool was, the more reliably it did so.
+
+HOSTED_PATH = ".github/workflows/ci.yml"
+SELF_HOSTED_PATH = ".github/workflows/frontend-test.yml"
+WORKFLOW_DIR = Path(__file__).resolve().parents[1] / ".github" / "workflows"
+
+# Assembled from fragments so this fixture cannot be mistaken for a real
+# self-hosted declaration by a scanner reading the test file itself.
+_LABEL = "self-" + "hosted"
+
+
+def _starved_on(path, **overrides):
+    return _run(
+        status="queued",
+        conclusion=None,
+        created_at=_ts(45),
+        path=path,
+        **overrides,
+    )
+
+
+def test_a_github_hosted_backlog_is_not_reported_as_a_runner_outage(watchdog):
+    """The regression: ci.yml has no self-hosted job, so it cannot starve one."""
+    runs = [_starved_on(HOSTED_PATH, name="AutoBot CI/CD Pipeline")]
+
+    state, description = watchdog.classify_dispatch(
+        runs, _ts(45), NOW, 10, 30, False, (), {SELF_HOSTED_PATH}
+    )
+
+    assert state == "pending"
+    assert "no runner available" not in description
+
+
+def test_a_starved_self_hosted_run_still_reports_the_outage(watchdog):
+    """The case that must keep working — removing the false positive must not
+    remove the true one."""
+    runs = [_starved_on(SELF_HOSTED_PATH, name="Frontend Testing Suite")]
+
+    state, description = watchdog.classify_dispatch(
+        runs, _ts(45), NOW, 10, 30, False, (), {SELF_HOSTED_PATH}
+    )
+
+    assert state == "failure"
+    assert "no runner available" in description
+
+
+def test_only_the_self_hosted_runs_are_counted_in_the_outage(watchdog):
+    """A mixed queue names the runs that can actually reach the pool."""
+    runs = [
+        _starved_on(HOSTED_PATH, id=1, name="AutoBot CI/CD Pipeline"),
+        _starved_on(HOSTED_PATH, id=2, name="Code Quality"),
+        _starved_on(SELF_HOSTED_PATH, id=3, name="Frontend Testing Suite"),
+    ]
+
+    state, description = watchdog.classify_dispatch(
+        runs, _ts(45), NOW, 10, 30, False, (), {SELF_HOSTED_PATH}
+    )
+
+    assert state == "failure"
+    assert description.startswith("1 self-hosted run(s)")
+    assert "Frontend Testing Suite" in description
+    assert "Code Quality" not in description
+
+
+def test_a_self_hosted_run_behind_a_serving_pool_is_still_contention(watchdog):
+    runs = [_starved_on(SELF_HOSTED_PATH, name="Frontend Testing Suite")]
+
+    state, _ = watchdog.classify_dispatch(
+        runs, _ts(45), NOW, 10, 30, True, (), {SELF_HOSTED_PATH}
+    )
+
+    assert state == "pending"
+
+
+def test_an_unattributable_run_stays_reportable(watchdog):
+    """Unknown must not silence a real outage — it resolves toward reporting."""
+    no_paths_known = None
+    no_path_on_run = {_LABEL}
+
+    assert watchdog.run_requires_self_hosted(_starved_on(HOSTED_PATH), no_paths_known) is True
+    assert watchdog.run_requires_self_hosted(_run(), no_path_on_run) is True
+    assert watchdog.run_requires_self_hosted(_starved_on(""), no_path_on_run) is True
+
+
+# --- workflow parsing: the comment trap ------------------------------------
+
+
+def test_a_self_hosted_mention_in_a_comment_is_not_a_declaration(watchdog):
+    """`code-quality.yml` really does carry this line. Matching the raw text
+    classifies a GitHub-hosted job as self-hosted — the exact misattribution
+    being removed, reintroduced by the fix for it."""
+    text = f"jobs:\n  lint:\n    runs-on: ubuntu-latest  # Temporary: {_LABEL} runner offline\n"
+
+    assert watchdog.declares_self_hosted(text) is False
+
+
+def test_a_whole_line_comment_is_not_a_declaration(watchdog):
+    text = f"# runs-on: ubuntu-latest on every job. The {_LABEL} runner is a singleton\njobs: {{}}\n"
+
+    assert watchdog.declares_self_hosted(text) is False
+
+
+def test_an_inline_sequence_is_a_declaration(watchdog):
+    text = f"jobs:\n  build:\n    runs-on: [{_LABEL}, Linux, X64]\n"
+
+    assert watchdog.declares_self_hosted(text) is True
+
+
+def test_a_block_sequence_is_a_declaration(watchdog):
+    text = f"jobs:\n  build:\n    runs-on:\n      - {_LABEL}\n      - Linux\n"
+
+    assert watchdog.declares_self_hosted(text) is True
+
+
+def test_a_block_sequence_of_hosted_labels_is_not_a_declaration(watchdog):
+    text = "jobs:\n  build:\n    runs-on:\n      - ubuntu-latest\n    steps: []\n"
+
+    assert watchdog.declares_self_hosted(text) is False
+
+
+def test_an_unreadable_workflow_dir_is_unknown_not_empty(watchdog, tmp_path):
+    """None, not an empty set: an empty set would silently classify every run
+    as GitHub-hosted and suppress every real outage."""
+    assert watchdog.self_hosted_workflow_paths(str(tmp_path / "absent")) is None
+
+
+def test_the_real_workflow_tree_classifies_the_reported_workflows_correctly(watchdog):
+    """Pinned against the actual repository, which is where the trap lives."""
+    paths = watchdog.self_hosted_workflow_paths(str(WORKFLOW_DIR))
+
+    assert paths is not None
+    resolved = {Path(p).name for p in paths}
+    # Declares `runs-on: [self-hosted, Linux, X64]` on four jobs.
+    assert "frontend-test.yml" in resolved
+    # The three workflows named in the false `no runner available` status.
+    assert "ci.yml" not in resolved
+    assert "code-quality.yml" not in resolved
+    assert "frontend-required-context.yml" not in resolved

--- a/repo_tests/ci_dispatch_watchdog_test.py
+++ b/repo_tests/ci_dispatch_watchdog_test.py
@@ -991,6 +991,25 @@ def test_missing_repository_is_rejected(watchdog, monkeypatch):
         watchdog.load_config()
 
 
+def test_load_config_supplies_the_workflow_dir(watchdog, monkeypatch):
+    """The production path must WIRE the directory, not lean on the fallback.
+
+    Both starvation call sites read it with `.get(..., DEFAULT_WORKFLOW_DIR)` so
+    a partial config cannot raise KeyError. That fallback is only safe while the
+    real config genuinely sets the key — otherwise the knob would be dead and
+    `WATCHDOG_WORKFLOW_DIR` would silently do nothing. This pins the wiring.
+    """
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+    monkeypatch.delenv("WATCHDOG_WORKFLOW_DIR", raising=False)
+
+    assert watchdog.load_config()["workflow_dir"] == watchdog.DEFAULT_WORKFLOW_DIR
+
+    monkeypatch.setenv("WATCHDOG_WORKFLOW_DIR", "custom/workflows")
+
+    assert watchdog.load_config()["workflow_dir"] == "custom/workflows"
+
+
 # --- sweep polling ----------------------------------------------------------
 
 


### PR DESCRIPTION
## Thinking Path

Found by sweeping the open PR queue: all 12 open PRs read `BLOCKED`, and one carried a red `ci-dispatch-watchdog` status. The status said:

```
6 run(s) queued over 45m with no runner available:
AutoBot CI/CD Pipeline, Code Quality, Frontend Required Context
```

At the same moment both self-hosted runners were `online` and `busy=false`, and all three named workflows declare `runs-on: ubuntu-latest` on **every** job. The message named a cause that could not apply.

The mechanism is a flag answering a different question than the set it gates. `starved_runs()` returns every job-less queued run past the threshold, unfiltered by pool. The verdict then branches on `pool_serving`, which `inspect_self_hosted_pool()` derives **only** from `self-hosted`-labelled jobs that are `in_progress`. An idle-but-healthy pool has no such job, so `pool_serving` is `False` — and the failure mode inverts: **the healthier the self-hosted pool is, the more reliably a GitHub-hosted backlog is published as a runner outage.**

Half of this was already fixed. `inspect_self_hosted_pool`'s docstring records that any in-progress run used to count as liveness, and that `code-quality`, `ci.yml` and the watchdog's own cron all run GitHub-hosted, so "something is executing" says nothing about the singleton machine. The same reasoning applies to *queued* runs, and was not applied to them.

The code called that gap unfixable — "whether a starved queue can be attributed to a pool by any means the workflow token can read remains open" — because labels live on jobs and a starved run has no jobs. That is true of the *API*, not of the question: the run payload carries the workflow's `path`, `runs-on` is declared in that file, and the file is already on disk because the job runs `actions/checkout`. Attribution is a local read costing no API budget.

While in the file, #13384 is the reason the watchdog was not reporting reliably in the first place, so it is fixed here rather than left to redden a later sweep.

## What Changed

| File | Change |
|---|---|
| `pipeline-scripts/ci_dispatch_watchdog.py` | New `declares_self_hosted()` / `self_hosted_workflow_paths()` / `run_requires_self_hosted()`. `classify_dispatch()` takes `self_hosted_paths` and only cites runs that can reach the pool as evidence it is starved; everything else reports contention (`pending`). `check_runner_starvation()` filters the same way. New `WATCHDOG_WORKFLOW_DIR` (default `.github/workflows`). |
| `.github/workflows/ci-dispatch-watchdog.yml` | **#13384** — concurrency group scoped to what is swept: `ci-dispatch-watchdog-${{ github.event.pull_request.number \|\| 'base' }}`. |
| `repo_tests/ci_dispatch_watchdog_test.py` | 13 new tests; one existing assertion updated for the reworded `pending` message. |

Two details that are correctness, not polish:

**Comments are stripped before matching.** `code-quality.yml` carries `runs-on: ubuntu-latest  # Temporary: self-hosted runner offline`, and `marker-tests.yml` mentions the pool in a whole-line comment. A raw substring match classifies Code Quality — one of the three workflows in the false status — as self-hosted, reintroducing the exact bug. Both forms are pinned by tests.

**Unknown resolves toward reporting.** An unreadable workflow directory returns `None` (not an empty set, which would classify every run as GitHub-hosted and silence every real outage), and an unattributable run stays reportable. Suppressing a true outage is the worse of the two errors. The unreadable case also prints a `::warning::` rather than degrading silently.

On the concurrency group: `cancel-in-progress: false` looks like it prevents this, but GitHub keeps at most one in-progress **and one pending** run per group — the third arrival cancels the pending one. A `pull_request` sweep is already narrowed to the firing PR via `WATCHDOG_ONLY_PR`, so per-PR groups match what the job actually does. Schedule, base push and manual dispatch share the `base` group, keeping the one genuinely repo-wide sweep serialised.

## Verification

Evidence the defect is real, gathered before the change:

| Claim | Evidence |
|---|---|
| Status published `failure` naming three workflows | `ci-dispatch-watchdog` status, `created_at 2026-08-16T13:19:17Z` |
| None of the three has a self-hosted job | `ci.yml` `ubuntu-latest` x6, `code-quality.yml` x2, `frontend-required-context.yml` x2 |
| The pool was healthy at that moment | both runners `online`, `busy=false` |
| Only one workflow in the repo is genuinely self-hosted | `frontend-test.yml`, 4 jobs; 84 `ubuntu-latest` declarations vs 4 self-hosted |
| #13384 still live | 16 of 30 consecutive watchdog runs `cancelled` |

Tests added, each pinning a direction rather than the reported instance:

- a GitHub-hosted backlog with `pool_serving=False` is `pending`, never `no runner available` — **the regression**
- a starved self-hosted run with `pool_serving=False` is still `failure` — the true positive must survive
- a mixed queue counts and names only the self-hosted runs
- a self-hosted run behind a serving pool is still contention
- unknown attribution (no workflow set / no `path`) stays reportable, both directions
- the comment trap, in inline and whole-line form, is not a declaration
- inline and block sequence forms both are
- an unreadable workflow dir is `None`, not empty
- the **real** `.github/workflows` tree classifies `frontend-test.yml` in and all three falsely-named workflows out

That last test reads the actual repository rather than a fixture, so the comment trap is checked against the file that contains it. Reverting comment-stripping reddens it; dropping the filter from `classify_dispatch` reddens the regression test while leaving the true-positive test green.

Local check limited to `py_compile` on both files (exit 0) — this repository verifies correctness in CI rather than by running its own code locally.

## Model Used

Opus 5

Closes #14364, #13384
