### PR TITLE
fix(ci): approve the auto-fix bot's own parked runs immediately (#14311)

### DIFF
--- a/.github/workflows/auto-fix-formatting.yml
+++ b/.github/workflows/auto-fix-formatting.yml
@@ -40,7 +40,9 @@ jobs:
           # treats that bot as external — so every run the push triggers is
           # created with conclusion=action_required and never starts. Falls back
           # to GITHUB_TOKEN so this workflow keeps working before the secret is
-          # configured; the runs simply park as they do today.
+          # configured; the runs simply park as they do today. #14311's
+          # `approve-parked-runs` job below repairs that fallback case
+          # immediately instead of leaving it parked.
           token: ${{ secrets.AUTOBOT_PUSH_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Set up Python 3.12
@@ -88,3 +90,52 @@ jobs:
             git push
             echo "✅ Formatting fixes committed and pushed"
           fi
+
+  # #14311: when the token above falls back to the default GITHUB_TOKEN (or
+  # even with AUTOBOT_PUSH_TOKEN configured but still resolving to a
+  # bot/app identity the fork-PR approval policy does not recognise as a
+  # human), the push in `autofix` is authored by github-actions[bot]. This
+  # repository's fork-PR approval policy (all_external_contributors) treats
+  # that bot as an external contributor, so the `pull_request` run the push
+  # triggers is created with conclusion=action_required and never starts —
+  # the same defect as #12823, guarded in general by ci-dispatch-watchdog.yml.
+  #
+  # That watchdog's own `pull_request` trigger cannot self-repair THIS case:
+  # the `synchronize` event the push raises is itself attributed to
+  # github-actions[bot], so a watchdog run it triggers would park too,
+  # awaiting the very approval it exists to grant (see the header comment in
+  # ci-dispatch-watchdog.yml). Its `schedule` cron still catches this within
+  # 15 minutes, but leaves the PR parked with zero visible failing checks
+  # until then. This job repairs it immediately — in the SAME workflow run
+  # that did the push, which was triggered by whatever human action opened
+  # or updated the PR and is therefore not itself parked — using the
+  # identical script the watchdog runs (`ci_dispatch_watchdog.py --check
+  # dispatch`), not a reimplementation of it.
+  approve-parked-runs:
+    needs: autofix
+    # Mirrors the `autofix` job's own fork guard above: a fork PR never
+    # reaches the push (autofix is skipped for it), and this job must never
+    # widen approval to a fork-origin run regardless. The watchdog script
+    # also enforces this internally — it only approves runs whose head
+    # repository is this repository AND whose triggering actor is
+    # github-actions[bot] — but gating here means a fork PR run never even
+    # attempts the call with its read-only token.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      actions: write
+      statuses: write
+      pull-requests: read
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Approve the run this push just parked
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          WATCHDOG_BASE_BRANCH: Dev_new_gui
+          WATCHDOG_ONLY_PR: ${{ github.event.pull_request.number }}
+        run: python3 pipeline-scripts/ci_dispatch_watchdog.py --check dispatch

--- a/.github/workflows/auto-fix-generated-types.yml
+++ b/.github/workflows/auto-fix-generated-types.yml
@@ -44,7 +44,9 @@ jobs:
           # treats that bot as external — so every run the push triggers is
           # created with conclusion=action_required and never starts. Falls back
           # to GITHUB_TOKEN so this workflow keeps working before the secret is
-          # configured; the runs simply park as they do today.
+          # configured; the runs simply park as they do today. #14311's
+          # `approve-parked-runs` job below repairs that fallback case
+          # immediately instead of leaving it parked.
           token: ${{ secrets.AUTOBOT_PUSH_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Set up Python 3.14
@@ -113,3 +115,29 @@ jobs:
             git push
             echo "✅ api.ts regenerated and pushed to the PR branch."
           fi
+
+  # #14311: identical parking defect as auto-fix-formatting.yml — see the
+  # comment on that workflow's `approve-parked-runs` job for the full
+  # explanation. This job repairs it here too, since `autofix-types` pushes
+  # with the same bot identity and fork-safety constraints.
+  approve-parked-runs:
+    needs: autofix-types
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      actions: write
+      statuses: write
+      pull-requests: read
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Approve the run this push just parked
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          WATCHDOG_BASE_BRANCH: Dev_new_gui
+          WATCHDOG_ONLY_PR: ${{ github.event.pull_request.number }}
+        run: python3 pipeline-scripts/ci_dispatch_watchdog.py --check dispatch

--- a/repo_tests/auto_fix_bot_push_approval_test.py
+++ b/repo_tests/auto_fix_bot_push_approval_test.py
@@ -1,0 +1,106 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""The auto-fix bot's own push must not leave its PR parked (#14311).
+
+``auto-fix-formatting.yml`` and ``auto-fix-generated-types.yml`` both push a
+commit back to the PR branch as ``github-actions[bot]``. This repository's
+fork-PR approval policy (``all_external_contributors``) treats that bot as an
+external contributor, so every ``pull_request`` run the push triggers is
+created with ``conclusion=action_required`` and never starts (#12823's shape,
+reported against these two workflows specifically in #14311). The PR then
+shows zero failing checks and simply stops moving.
+
+Each workflow now carries an ``approve-parked-runs`` job that repairs this
+immediately, in the SAME run that did the push (which was triggered by a
+human action and so is not itself parked), by invoking the SAME script
+``ci-dispatch-watchdog.yml`` already relies on
+(``pipeline-scripts/ci_dispatch_watchdog.py --check dispatch``) rather than
+reimplementing its approval logic. That script owns the actual behaviour and
+its own tests (``repo_tests/ci_dispatch_watchdog_test.py``); what is pinned
+here is the WIRING invariant a review can't eyeball reliably from two
+similar-looking YAML files: the approval job exists, runs right after the
+push job, is scoped to this PR only, and carries the identical same-repo
+fork guard as the push job it follows -- so it can never be the path a fork
+PR's run gets approved through.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import yaml
+
+_WORKFLOWS_DIR = pathlib.Path(__file__).resolve().parents[1] / ".github" / "workflows"
+
+# (workflow filename, id of the job that pushes as github-actions[bot])
+_PUSH_WORKFLOWS = [
+    ("auto-fix-formatting.yml", "autofix"),
+    ("auto-fix-generated-types.yml", "autofix-types"),
+]
+
+_APPROVAL_JOB_ID = "approve-parked-runs"
+_SAME_REPO_GUARD = "github.event.pull_request.head.repo.full_name == github.repository"
+
+
+def _jobs(filename: str) -> dict:
+    document = yaml.safe_load((_WORKFLOWS_DIR / filename).read_text(encoding="utf-8"))
+    return document["jobs"]
+
+
+def test_every_bot_push_job_has_a_same_repo_fork_guard():
+    """Precondition for the rest of this file: if the push job itself were
+    unguarded, scoping only the approval job would still leave a fork path."""
+    for filename, push_job_id in _PUSH_WORKFLOWS:
+        jobs = _jobs(filename)
+        assert jobs[push_job_id]["if"].strip() == _SAME_REPO_GUARD, filename
+
+
+def test_an_approval_job_exists_and_runs_right_after_the_push():
+    for filename, push_job_id in _PUSH_WORKFLOWS:
+        jobs = _jobs(filename)
+        assert _APPROVAL_JOB_ID in jobs, f"{filename} has no {_APPROVAL_JOB_ID} job"
+        approval_job = jobs[_APPROVAL_JOB_ID]
+        assert approval_job["needs"] == push_job_id, filename
+
+
+def test_the_approval_job_never_widens_scope_to_fork_prs():
+    """Same exact guard as the push job -- not `always()`, which would run the
+    approval job even when the push job was skipped for a fork PR."""
+    for filename, _ in _PUSH_WORKFLOWS:
+        jobs = _jobs(filename)
+        approval_if = jobs[_APPROVAL_JOB_ID]["if"].strip()
+        assert approval_if == _SAME_REPO_GUARD, filename
+        assert "always()" not in approval_if, filename
+
+
+def test_the_approval_job_scopes_to_only_this_pr():
+    """WATCHDOG_ONLY_PR must be set -- an unscoped sweep would still repair
+    the parking eventually, but only this PR's run needs releasing right now,
+    and a full sweep from every push-triggered run multiplies API cost."""
+    for filename, _ in _PUSH_WORKFLOWS:
+        jobs = _jobs(filename)
+        step = jobs[_APPROVAL_JOB_ID]["steps"][-1]
+        env = step.get("env", {})
+        assert env.get("WATCHDOG_ONLY_PR") == "${{ github.event.pull_request.number }}", filename
+
+
+def test_the_approval_job_reuses_the_watchdog_script_rather_than_reimplementing_it():
+    for filename, _ in _PUSH_WORKFLOWS:
+        jobs = _jobs(filename)
+        step = jobs[_APPROVAL_JOB_ID]["steps"][-1]
+        run = step["run"]
+        assert "pipeline-scripts/ci_dispatch_watchdog.py" in run, filename
+        assert "--check dispatch" in run, filename
+
+
+def test_the_approval_job_holds_only_the_permissions_it_needs():
+    """actions:write is what lets it call POST .../runs/{id}/approve; nothing
+    here needs contents:write, even though the workflow-level default (used
+    by the push job) grants it."""
+    for filename, _ in _PUSH_WORKFLOWS:
+        jobs = _jobs(filename)
+        permissions = jobs[_APPROVAL_JOB_ID]["permissions"]
+        assert permissions.get("actions") == "write", filename
+        assert permissions.get("contents") == "read", filename


### PR DESCRIPTION
Closes #14311

## Thinking Path

`auto-fix-formatting.yml` pushes a formatting commit back to the PR branch
attributed to `github-actions[bot]` whenever `AUTOBOT_PUSH_TOKEN` is unset
(the fallback documented in the workflow itself, #13791). Every
`pull_request` run that push triggers is then created with
`conclusion=action_required` under this repository's `all_external_contributors`
approval policy — the exact shape of #12823 — so ~23 of 24 runs park and the
PR shows zero failing checks while not moving. `auto-fix-generated-types.yml`
pushes with the identical fallback token and the identical bot identity, so it
has the same defect even though the issue only measured the formatter.

The general-purpose repair for this class already exists:
`ci-dispatch-watchdog.yml` calls `pipeline-scripts/ci_dispatch_watchdog.py
--check dispatch` on a schedule (every 15 minutes) and on pushes to
`Dev_new_gui`, approving exactly the runs whose head repository is this
repository and whose triggering actor is `github-actions[bot]`. It cannot
self-repair THIS case immediately, though: the `synchronize` event a bot push
raises is itself attributed to the bot, so a watchdog run triggered by that
event would park too, waiting on the very approval it exists to grant (see the
header comment in `ci-dispatch-watchdog.yml`). That leaves the PR parked for
up to 15 minutes after every auto-fix push — better than #14311's "stuck for
three review cycles", but still parked with zero visible failures in the
interim, and the PR author has no reason to think anything is happening.

`auto-update-pr-branches.yml` already solved this exact problem for its own
bot push: its `approve-refreshed-runs` job runs `needs: auto-update` in the
SAME workflow run that did the push (which was triggered by a human pushing
to `Dev_new_gui`, so it is not itself parked) and calls the watchdog script
scoped to repair what the push above it just parked. This PR applies that
same, already-reviewed pattern to the two auto-fix workflows, closing the gap
at its source instead of only shortening the watchdog's worst-case delay.

## What Changed

- `.github/workflows/auto-fix-formatting.yml`: added an `approve-parked-runs`
  job (`needs: autofix`) that calls
  `pipeline-scripts/ci_dispatch_watchdog.py --check dispatch`, scoped to the
  firing PR via `WATCHDOG_ONLY_PR`, immediately after the formatter's push.
- `.github/workflows/auto-fix-generated-types.yml`: the identical
  `approve-parked-runs` job (`needs: autofix-types`), since this workflow
  pushes with the same bot identity and has the same defect — found while
  fixing the reported one, fixed rather than left for a follow-up (found
  problems get fixed in scope, not filed separately when the fix is this
  small and this local).
- `repo_tests/auto_fix_bot_push_approval_test.py`: pins the wiring invariant
  structurally (parses both workflow YAML files) — the approval job exists,
  runs right after the push job, carries the exact same fork guard as the
  push job (never `always()`, never widened), is scoped to only the firing
  PR, reuses the watchdog script rather than reimplementing its logic, and
  holds only the permissions it needs (`actions: write`, not
  `contents: write`).

Neither `ci-dispatch-watchdog.yml`, `pipeline-scripts/ci_dispatch_watchdog.py`
nor `repo_tests/ci_dispatch_watchdog_test.py` were touched — this PR calls
that already-reviewed, already-tested script, matching the exact invocation
pattern `auto-update-pr-branches.yml` already uses, rather than duplicating
any of its logic.

## Verification

- Both edited workflow files parse as valid YAML
  (`python3 -c "import yaml; yaml.safe_load(open(...))"`, both clean).
- Structural diff confirms only the two workflow files and the new test file
  changed — none of the files owned by the concurrent #14367 PR
  (`ci-dispatch-watchdog.yml`, `pipeline-scripts/ci_dispatch_watchdog.py`,
  `repo_tests/ci_dispatch_watchdog_test.py`) were read-modified or included.
- Manually traced the new test's assertions against the actual parsed YAML
  for both workflows (`needs`, `if`, `permissions`, `env`, `run`) — every
  value the test checks matches what the workflow files actually contain,
  confirming the test is not vacuous before CI executes it.
- `actionlint.yml` (this repo's required workflow-syntax gate) will run
  against both files on this PR and is the authoritative structural check on
  GitHub Actions syntax that this environment cannot fully replicate locally
  without installing tooling into the repo (disallowed).
- This cannot be proven end-to-end without a real bot push happening on
  GitHub's infrastructure (the parking only exists once a real run is created
  and gated), which this environment cannot trigger. What is proven here is
  that the wiring exactly matches the already-live, already-relied-upon
  pattern in `auto-update-pr-branches.yml`'s `approve-refreshed-runs` job —
  same script, same scoping approach, same fork guard shape — which is the
  precedent this repository already trusts for the identical class of bug.

## Fork Safety

`POST /actions/runs/{id}/approve` is GitHub's approve-a-fork-run endpoint, and
this repository runs `pull_request` jobs on a self-hosted runner, so an
auto-approval path that ever reached a fork-origin run would execute
contributor-controlled code on the owner's machine. The new
`approve-parked-runs` job cannot become that path, on two independent layers:

1. **Workflow-level gate.** The job's `if:` is byte-identical to the push
   job's own fork guard
   (`github.event.pull_request.head.repo.full_name == github.repository`) —
   not `if: always()`. A fork PR never even reaches this job: its push job
   (`autofix` / `autofix-types`) is already skipped for forks (#14153), and
   because this job's `needs:` targets that skipped job with no `always()`
   override, GitHub Actions skips it too. A fork-origin `pull_request` event
   also only ever grants a read-only `GITHUB_TOKEN`, so even a hypothetical
   bypass of the `if:` would fail the `actions: write` call rather than
   succeed.
2. **Script-level gate (pre-existing, unmodified).** The invoked script,
   `ci_dispatch_watchdog.py`, only ever approves a run whose head repository
   is this repository AND whose triggering actor is `github-actions[bot]`
   (`UPDATE_BOT_LOGIN`) — every other parked run, including any fork-origin
   run, is reported, never approved. This PR does not touch that logic; it
   only invokes it, the same way `auto-update-pr-branches.yml` already does.

No workflow `permissions:` were widened beyond what approving a run requires
(`actions: write`, `statuses: write`, `pull-requests: read`, `contents: read`)
— no `contents: write` on the new job, and no `github.event.*` text is
interpolated into any `run:` step (the two new steps take no PR-controlled
input at all; the only inputs are the internal `github.repository` and
`github.event.pull_request.number`, both action-provided and non-attacker-
controlled).

## Model Used

Claude Sonnet 5
