### PR TITLE
fix(monitoring): re-render prometheus.yml after the fleet roles exist (#14337)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/deploy-slm-manager.yml
+++ b/autobot-slm-backend/ansible/playbooks/deploy-slm-manager.yml
@@ -79,3 +79,25 @@
 - name: Provision Fleet Roles
   import_playbook: provision-fleet-roles.yml
   tags: ['provision']
+
+# The monitoring role rendered prometheus.yml back in Play 1, before the backend
+# and frontend roles above had run. Its scrape targets depend on which of them
+# landed on this host, so on a first-ever provisioning run that render decided
+# the topology against a host where neither existed yet — and nothing re-read it
+# afterwards, leaving the config wrong until an operator redeployed monitoring
+# by hand (#14337).
+#
+# Scoped to the config tasks rather than re-running the whole role: prometheus
+# is already installed and running by this point, and reinstalling it would
+# restart the service for no reason. The handler still fires if the rendered
+# file actually changed.
+- name: Re-render monitoring config now the fleet roles exist
+  hosts: slm_server
+  become: true
+  gather_facts: false
+  tags: ['provision', 'monitoring']
+  tasks:
+    - name: "Monitoring | Resolve the scrape topology against the provisioned host (#14337)"
+      ansible.builtin.include_role:
+        name: monitoring
+        tasks_from: prometheus_config.yml

--- a/autobot-slm-backend/ansible/roles/monitoring/tasks/prometheus.yml
+++ b/autobot-slm-backend/ansible/roles/monitoring/tasks/prometheus.yml
@@ -55,51 +55,12 @@
     group: "{{ prometheus_group }}"
   when: not _prometheus_binary.stat.exists
 
-# The backend scrape target depends on topology (#14315). Resolved HERE, from
-# this host's own deployed state, so the role is correct under any playbook that
-# renders it — including deploy-monitoring.yml, which runs `roles: [monitoring]`
-# and nothing else. Trusting `slm_colocated_frontend` alone would leave the
-# answer to whether some other role happened to run first in the same play.
-#
-# Observed state rather than a re-derived prediction: what decides the target is
-# whether the standalone vhost is actually serving, and that is a file on disk,
-# not something to infer from the flag that governed its teardown.
-- name: "Prometheus | Stat the standalone backend nginx vhost (#14315)"
-  ansible.builtin.stat:
-    path: /etc/nginx/sites-enabled/autobot-backend.conf
-  register: _backend_vhost
-
-- name: "Prometheus | Stat the backend service unit (#14315)"
-  ansible.builtin.stat:
-    path: /etc/systemd/system/autobot-backend.service
-  register: _backend_unit
-
-- name: "Prometheus | Resolve which backend metrics endpoint is reachable (#14315)"
-  # Loopback is correct only when the backend runs HERE and the vhost that would
-  # otherwise front it is gone — exactly the state #2829 leaves behind.
-  #
-  # Deliberately NOT `slm_colocated_frontend or ...`. That flag answers a
-  # different question: setup_wizard sets it whenever the SLM host carries the
-  # *frontend* role, and co-locates the backend as a separate, nested condition.
-  # An SLM host with the frontend role and a remote backend is a topology the
-  # wizard generates, and there the flag is true while no backend is reachable
-  # on loopback at all — so an `or` would point prometheus at nothing.
-  #
-  # Nor is the flag ever ahead of what is on disk: provision-fleet-roles.yml
-  # runs Backend at Phase 4a, before Frontend at 4b, so by the time the flag can
-  # become true the backend role has already made its vhost decision.
-  ansible.builtin.set_fact:
-    _backend_metrics_on_loopback: >-
-      {{ _backend_unit.stat.exists and not _backend_vhost.stat.exists }}
-
-- name: Create Prometheus config
-  ansible.builtin.template:
-    src: prometheus.yml.j2
-    dest: "{{ prometheus_config_dir }}/prometheus.yml"
-    owner: "{{ prometheus_user }}"
-    group: "{{ prometheus_group }}"
-    mode: "0644"
-  notify: Restart prometheus
+# Topology detection and the config render live in their own file so the same
+# tasks can run again after the fleet roles exist (#14337). In this play they
+# run before the backend role has been provisioned at all, so on a first-ever
+# run the decision they make is based on a host that has no backend on it yet.
+- name: "Prometheus | Resolve the scrape topology and write the config"
+  ansible.builtin.include_tasks: prometheus_config.yml
 
 # #12460: the alert rules live in the repo under autobot-monitoring/ and were
 # never installed, so `rule_files` had nothing to point at on a fleet host.

--- a/autobot-slm-backend/ansible/roles/monitoring/tasks/prometheus_config.yml
+++ b/autobot-slm-backend/ansible/roles/monitoring/tasks/prometheus_config.yml
@@ -1,0 +1,55 @@
+---
+# Resolving the scrape topology and writing prometheus.yml, in one file so it can
+# be run again on its own (#14337).
+#
+# The monitoring role renders this in Play 1 of deploy-slm-manager.yml, before
+# provision-fleet-roles.yml has run the backend (Phase 4a) or frontend (4b)
+# roles. On a first-ever provisioning run there is therefore no backend unit and
+# no nginx vhost to observe when the decision below is made, so every host looks
+# like a remote-backend topology and prometheus is left scraping an address that
+# answers nothing. Nothing re-rendered the file afterwards, so it stayed wrong
+# until an operator redeployed monitoring by hand — which is how the deployed
+# config came to carry a target the backend never bound (#14315) and one job
+# fewer than the template defines.
+#
+# So the same tasks run once more at the end of the playbook, when the roles
+# they describe actually exist. Both entry points include this file rather than
+# duplicating it: a second copy of a topology decision is how the two ended up
+# disagreeing in the first place.
+
+- name: "Prometheus | Stat the standalone backend nginx vhost (#14315)"
+  ansible.builtin.stat:
+    path: /etc/nginx/sites-enabled/autobot-backend.conf
+  register: _backend_vhost
+
+- name: "Prometheus | Stat the backend service unit (#14315)"
+  ansible.builtin.stat:
+    path: /etc/systemd/system/autobot-backend.service
+  register: _backend_unit
+
+- name: "Prometheus | Resolve which backend metrics endpoint is reachable (#14315)"
+  # Loopback is correct only when the backend runs HERE and the vhost that would
+  # otherwise front it is gone — exactly the state #2829 leaves behind.
+  #
+  # Deliberately NOT `slm_colocated_frontend or ...`. That flag answers a
+  # different question: setup_wizard sets it whenever the SLM host carries the
+  # *frontend* role, and co-locates the backend as a separate, nested condition.
+  # An SLM host with the frontend role and a remote backend is a topology the
+  # wizard generates, and there the flag is true while no backend is reachable
+  # on loopback at all — so an `or` would point prometheus at nothing.
+  #
+  # Nor is the flag ever ahead of what is on disk: provision-fleet-roles.yml
+  # runs Backend at Phase 4a, before Frontend at 4b, so by the time the flag can
+  # become true the backend role has already made its vhost decision.
+  ansible.builtin.set_fact:
+    _backend_metrics_on_loopback: >-
+      {{ _backend_unit.stat.exists and not _backend_vhost.stat.exists }}
+
+- name: Create Prometheus config
+  ansible.builtin.template:
+    src: prometheus.yml.j2
+    dest: "{{ prometheus_config_dir }}/prometheus.yml"
+    owner: "{{ prometheus_user }}"
+    group: "{{ prometheus_group }}"
+    mode: "0644"
+  notify: Restart prometheus

--- a/autobot-slm-backend/tests/services/test_prometheus_rendered_after_roles_14337_test.py
+++ b/autobot-slm-backend/tests/services/test_prometheus_rendered_after_roles_14337_test.py
@@ -1,0 +1,133 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""prometheus.yml is rendered after the roles it describes exist (#14337).
+
+The monitoring role runs in Play 1 of `deploy-slm-manager.yml`, while the
+backend (Phase 4a) and frontend (4b) roles run inside `provision-fleet-roles.yml`,
+imported afterwards. The scrape targets depend on which of those landed on this
+host — #14315 resolves the backend target by observing whether the unit is
+installed and whether the standalone nginx vhost is gone — so on a first-ever
+provisioning run that decision is made against a host where neither exists yet.
+
+Nothing re-read it afterwards. The monitoring role appears in exactly one play,
+with no handler or later task that renders the config again, so a first run left
+prometheus scraping an address nothing answers and it stayed that way until an
+operator redeployed monitoring by hand. That is how the deployed config came to
+carry a target the backend never bound, and one job fewer than the template
+defines.
+
+These tests assert the ordering rather than the text: which play renders the
+config, and whether it comes after the roles that decide what the config should
+say.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+_ANSIBLE = Path(__file__).resolve().parents[2] / "ansible"
+_PLAYBOOK = _ANSIBLE / "playbooks" / "deploy-slm-manager.yml"
+_ROLE_TASKS = _ANSIBLE / "roles" / "monitoring" / "tasks"
+_CONFIG_TASKS = _ROLE_TASKS / "prometheus_config.yml"
+
+_TEMPLATE = "prometheus.yml.j2"
+
+
+def _plays() -> list[dict]:
+    return yaml.safe_load(_PLAYBOOK.read_text(encoding="utf-8"))
+
+
+def _index_of_fleet_provisioning() -> int:
+    for i, play in enumerate(_plays()):
+        if str(play.get("import_playbook", "")).endswith("provision-fleet-roles.yml"):
+            return i
+    raise AssertionError("provision-fleet-roles.yml is no longer imported by deploy-slm-manager.yml")
+
+
+def _renders_config(play: dict) -> bool:
+    """Whether this play runs the monitoring config tasks, by role or by include."""
+    for entry in play.get("roles", []) or []:
+        name = entry.get("role") if isinstance(entry, dict) else entry
+        if name == "monitoring":
+            return True
+    for task in play.get("tasks", []) or []:
+        include = task.get("ansible.builtin.include_role") or task.get("include_role") or {}
+        if include.get("name") == "monitoring" and include.get("tasks_from") == _CONFIG_TASKS.name:
+            return True
+    return False
+
+
+def test_the_config_is_rendered_again_after_fleet_roles_are_provisioned():
+    """The regression. Before this, the only render happened in Play 1."""
+    fleet = _index_of_fleet_provisioning()
+    later = [i for i, play in enumerate(_plays()) if _renders_config(play) and i > fleet]
+    assert later, (
+        "no play renders the prometheus config after provision-fleet-roles.yml. "
+        "The first render decides the scrape topology against a host where the "
+        "backend and frontend roles have not run yet (#14337)."
+    )
+
+
+def test_the_early_render_is_still_there():
+    """The late pass is an addition, not a replacement.
+
+    Prometheus must be installed and configured before fleet provisioning too —
+    dropping the early render would leave the service without a config for the
+    whole of that phase.
+    """
+    fleet = _index_of_fleet_provisioning()
+    early = [i for i, play in enumerate(_plays()) if _renders_config(play) and i < fleet]
+    assert early, "the monitoring role no longer runs before fleet provisioning"
+
+
+def test_the_render_tasks_exist_in_one_place_only():
+    """Both entry points include the same file rather than copying it.
+
+    A second copy of a topology decision is exactly how the analytics scanner
+    and the api-wiring gate came to disagree about the same question (#13582).
+    """
+    assert _CONFIG_TASKS.is_file(), f"{_CONFIG_TASKS.name} is missing"
+
+    templating = []
+    for task_file in sorted(_ROLE_TASKS.glob("*.yml")):
+        tasks = yaml.safe_load(task_file.read_text(encoding="utf-8")) or []
+        for task in tasks:
+            spec = task.get("ansible.builtin.template") or task.get("template") or {}
+            if spec.get("src") == _TEMPLATE:
+                templating.append(task_file.name)
+    assert templating == [_CONFIG_TASKS.name], f"{_TEMPLATE} is rendered from {templating}, expected one file"
+
+
+def test_the_config_file_actually_resolves_the_topology():
+    """Rendering without the detection would emit the template's own fallback.
+
+    The template branches on `_backend_metrics_on_loopback`; a render pass that
+    does not set it takes `default(false)` and produces the distributed target
+    regardless of the host — the exact bug #14315 fixed, reintroduced by a
+    second entry point that renders without deciding.
+    """
+    tasks = yaml.safe_load(_CONFIG_TASKS.read_text(encoding="utf-8"))
+    sets_fact = [t for t in tasks if "_backend_metrics_on_loopback" in (t.get("ansible.builtin.set_fact") or {})]
+    renders = [i for i, t in enumerate(tasks) if (t.get("ansible.builtin.template") or {}).get("src") == _TEMPLATE]
+    assert sets_fact, "the config tasks do not resolve _backend_metrics_on_loopback"
+    assert renders, "the config tasks do not render the template"
+    assert tasks.index(sets_fact[0]) < renders[0], "the topology is resolved after the config that reads it"
+
+
+def test_the_late_pass_does_not_reinstall_prometheus():
+    """Scoped to the config tasks, not the whole role.
+
+    Re-running the role would reinstall the binary and restart a service that is
+    already up, for a config change the handler already covers.
+    """
+    fleet = _index_of_fleet_provisioning()
+    for play in _plays()[fleet + 1 :]:
+        if not _renders_config(play):
+            continue
+        assert not play.get("roles"), (
+            f"play {play.get('name')!r} re-runs whole roles after fleet provisioning; " "include only the config tasks"
+        )

--- a/autobot-slm-backend/tests/services/test_prometheus_scrape_targets_14315_test.py
+++ b/autobot-slm-backend/tests/services/test_prometheus_scrape_targets_14315_test.py
@@ -46,7 +46,7 @@ import yaml
 _ANSIBLE = Path(__file__).resolve().parents[2] / "ansible"
 _ROLE = _ANSIBLE / "roles" / "monitoring"
 _TEMPLATE = _ROLE / "templates" / "prometheus.yml.j2"
-_TASKS = _ROLE / "tasks" / "prometheus.yml"
+_TASK_DIR = _ROLE / "tasks"
 
 _TOPOLOGY_FACT = "_backend_metrics_on_loopback"
 
@@ -84,8 +84,25 @@ def _backend_job(rendered: dict) -> dict:
     return next(j for j in rendered["scrape_configs"] if j["job_name"] == "autobot-backend")
 
 
+def _config_task_file() -> Path:
+    """The role task file that renders the scrape config, wherever it now lives.
+
+    Located by what it does rather than by name. #14337 moved these tasks into
+    their own file so a second render pass could run them after the fleet roles
+    exist, and a hard-coded filename here turned every assertion below red for a
+    move that changed no behaviour.
+    """
+    for candidate in sorted(_TASK_DIR.glob("*.yml")):
+        tasks = yaml.safe_load(candidate.read_text(encoding="utf-8")) or []
+        for task in tasks:
+            spec = task.get("ansible.builtin.template") or task.get("template") or {}
+            if spec.get("src") == "prometheus.yml.j2":
+                return candidate
+    raise AssertionError(f"no task file under {_TASK_DIR} renders prometheus.yml.j2")
+
+
 def _tasks() -> list[dict]:
-    return yaml.safe_load(_TASKS.read_text(encoding="utf-8"))
+    return yaml.safe_load(_config_task_file().read_text(encoding="utf-8"))
 
 
 def _module(task: dict, name: str) -> dict:


### PR DESCRIPTION
Closes #14337.

## Thinking Path

The monitoring role renders `prometheus.yml` in Play 1 of `deploy-slm-manager.yml`. The backend (Phase 4a) and frontend (4b) roles run inside `provision-fleet-roles.yml`, imported afterwards.

The scrape targets depend on which of those landed on this host — #14315 resolves the backend target by observing whether the service unit is installed and whether the standalone nginx vhost is gone. On a first-ever provisioning run that decision is therefore made against a host where neither exists yet, so every host reads as a remote-backend topology.

Nothing re-read it. The role appears in exactly one play, with no handler or later task that renders the config again, so the file stayed wrong until an operator redeployed monitoring by hand.

That is not hypothetical — it is why the deployed config on the live host carries **5 scrape jobs against the template's 6**, missing the `slm-backend` job added by #10851/#10858, which is what the BI dashboard's real-source queries read. Written once, never re-rendered.

## What Changed

- **`roles/monitoring/tasks/prometheus_config.yml`** (new) — the topology detection and the config render, extracted so the same tasks can run twice.
- **`roles/monitoring/tasks/prometheus.yml`** — includes it where those tasks used to be.
- **`playbooks/deploy-slm-manager.yml`** — a final play re-runs just those tasks once provisioning has finished.

Both entry points include the one file rather than copying it. A second copy of a topology decision is exactly how the analytics scanner and the api-wiring gate came to disagree about the same question (#13582), fixed earlier today.

Scoped to the config tasks rather than re-running the whole role: prometheus is installed and running by that point, and reinstalling it would restart the service for a config change the existing handler already covers.

## Verification

Mutation-tested — each guard bites:

| Mutation | Result |
|---|---|
| Remove the late render pass (the regression) | 1 fail |
| Late pass re-runs the whole role instead of the config tasks | 1 fail |
| Duplicate the template task back into the role | 1 fail |
| Config file renders without resolving the topology | 1 fail |
| Detection hard-coded to loopback (#14315's own guard, relocated) | 4 fail |

`autobot-slm-backend/tests/services/` — 480 passed, 2 skipped. black, isort, flake8 clean.

**One thing worth calling out.** The extraction turned all 7 of #14315's detection tests red, because that guard read the tasks out of a hard-coded `roles/monitoring/tasks/prometheus.yml` — a move that changed no behaviour broke every assertion about it. It now locates whichever role task file renders `prometheus.yml.j2`, so the assertions follow the tasks rather than their address. Verified the relocated guard still fails under the detection mutation it was written for.

## Model Used

Opus 5 (1M context).

---

## Review note: one suggestion deliberately not taken

Review found that `--tags provision` alone, skipping the `monitoring` tag, on a never-before-provisioned host would reach the new final play without Play 1 having created the prometheus user or config directory — and the render would fail. It offered a defensive `when:` guard and judged the scenario unrealistic (the documented use of `--tags provision` on its own is adding fleet nodes to an SLM server that already exists).

Not adding the guard, on purpose. A `when:` there would skip the render silently whenever the condition read false — including for reasons that are not "prometheus was never installed". This PR exists because a config was written once and never re-read, and the whole point of the second pass is that it runs. Trading a loud failure in an implausible tag combination for a silent no-op in unknown ones is the wrong direction, and it is the exact fail-open shape that took five review rounds to clear on #14360 earlier today.

If that tag combination ever becomes a real workflow, the fix is for it to install prometheus, not for the render to quietly opt out.

Also noted, not changed: `_config_task_file()` globs `tasks/*.yml` non-recursively. If the render ever moved into a `block:` or a subdirectory it would find zero matches and raise — a loud failure, not a silent pass — so the fragility is acceptable as it stands.
