### PR TITLE
fix(api-routing): read include_router calls with a balanced-paren scan (#14356)

### DIFF
--- a/autobot-backend/api/codebase_analytics/api_endpoint_scanner.py
+++ b/autobot-backend/api/codebase_analytics/api_endpoint_scanner.py
@@ -52,7 +52,7 @@ _ROUTER_DECORATOR_RE = re.compile(
 _include_router_prefixes = _routing.include_router_prefixes
 
 # Pattern for router prefix in APIRouter() initialization
-_APIROUTER_PREFIX_RE = _routing.APIROUTER_PREFIX_RE
+_apirouter_prefix = _routing.apirouter_prefix
 
 # Frontend patterns for API calls
 _API_CALL_PATTERNS = [
@@ -973,10 +973,7 @@ class BackendEndpointScanner:
 
     def _get_file_router_prefix(self, content: str) -> str | None:
         """Extract router prefix from file content."""
-        match = _APIROUTER_PREFIX_RE.search(content)
-        if match:
-            return match.group(1)
-        return None
+        return _apirouter_prefix(content)
 
 
 # =============================================================================

--- a/autobot-backend/api/codebase_analytics/api_endpoint_scanner.py
+++ b/autobot-backend/api/codebase_analytics/api_endpoint_scanner.py
@@ -49,7 +49,7 @@ _ROUTER_DECORATOR_RE = re.compile(
 # submodule, and nothing here was reading it. Renamed from _ROUTER_INCLUDE_RE,
 # which sat one transposition away from _INCLUDE_ROUTER_RE below and meant
 # something different.
-_INCLUDE_ROUTER_PREFIX_RE = _routing.INCLUDE_ROUTER_RE
+_include_router_prefixes = _routing.include_router_prefixes
 
 # Pattern for router prefix in APIRouter() initialization
 _APIROUTER_PREFIX_RE = _routing.APIROUTER_PREFIX_RE
@@ -785,7 +785,7 @@ class BackendEndpointScanner:
         #
         # Prefixes given at mount time apply to every route in the mounted
         # module, and are separate from the one the router declares for itself.
-        mount_prefixes = dict(_INCLUDE_ROUTER_PREFIX_RE.findall(init_content))
+        mount_prefixes = dict(_include_router_prefixes(init_content))
 
         files: Dict[Path, str] = {}
         # #12956: walk one level and recurse, rather than rglob'ing the tree.

--- a/autobot_shared/api_routing/router_prefixes.py
+++ b/autobot_shared/api_routing/router_prefixes.py
@@ -42,6 +42,7 @@ from typing import Dict, Iterable, Tuple
 
 __all__ = [
     "INCLUDE_ROUTER_NAME_RE",
+    "apirouter_prefix",
     "include_router_prefixes",
     "RELATIVE_ROUTER_IMPORT_RE",
     "ROUTER_CONFIG_ENTRY_RE",
@@ -186,8 +187,8 @@ def include_router_prefixes(text: str) -> list[Tuple[str, str]]:
 # ── Resolution ───────────────────────────────────────────────────────────────
 
 
-def file_router_prefix(source: str) -> str:
-    """The ``APIRouter(prefix=...)`` a file declares, or ``""``.
+def apirouter_prefix(source: str) -> str | None:
+    """The raw ``APIRouter(prefix=...)`` a file declares, or ``None``.
 
     Scanned the same way as ``include_router`` and for the same reason: the old
     ``APIRouter\\([^)]*?prefix=`` carried the identical defect, so a constructor
@@ -197,12 +198,22 @@ def file_router_prefix(source: str) -> str:
     The example is described rather than written out. A literal constructor call
     in this docstring is found by this module's own scanner when the file is
     read as source — the doc becoming a false positive in the tool it documents.
+
+    Returns the prefix verbatim. ``None`` and ``""`` are distinct answers here —
+    "no prefix declared" versus "a declared empty prefix" — so callers that
+    normalise choose to, rather than being unable to tell the two apart.
     """
     for call in _calls(source, "APIRouter"):
         prefix = _PREFIX_KWARG_RE.search(_own_arguments(call))
         if prefix:
-            return prefix.group(1).rstrip("/")
-    return ""
+            return prefix.group(1)
+    return None
+
+
+def file_router_prefix(source: str) -> str:
+    """The ``APIRouter(prefix=...)`` a file declares, trailing slash removed, or ``""``."""
+    prefix = apirouter_prefix(source)
+    return prefix.rstrip("/") if prefix is not None else ""
 
 
 def registry_entries(registry_dir: Path) -> list[Tuple[str, str]]:

--- a/autobot_shared/api_routing/router_prefixes.py
+++ b/autobot_shared/api_routing/router_prefixes.py
@@ -41,9 +41,8 @@ from pathlib import Path
 from typing import Dict, Iterable, Tuple
 
 __all__ = [
-    "APIROUTER_PREFIX_RE",
-    "INCLUDE_ROUTER_RE",
     "INCLUDE_ROUTER_NAME_RE",
+    "include_router_prefixes",
     "RELATIVE_ROUTER_IMPORT_RE",
     "ROUTER_CONFIG_ENTRY_RE",
     "ROUTER_IMPORT_ALIAS_RE",
@@ -55,15 +54,21 @@ __all__ = [
 
 # ── The grammar ──────────────────────────────────────────────────────────────
 
-#: ``router = APIRouter(prefix="/x")`` — a module's own prefix.
-APIROUTER_PREFIX_RE = re.compile(r"APIRouter\([^)]*?prefix\s*=\s*['\"]([^'\"]+)", re.S)
+#: The first positional argument of an ``include_router`` call — the router name.
+#:
+#: Both lookaheads are load-bearing. ``(?!\s*=)`` alone rejects a keyword-only
+#: call, but the name is greedy and backtracks: given a keyword named ``prefix``
+#: it matches ``prefi`` so the next character is ``x`` rather than ``=``, and the
+#: keyword is captured as a router under a truncated name. ``(?![\w.])`` forces
+#: the token to be maximal first, so the ``=`` test is applied to the whole name.
+_INCLUDE_ROUTER_TARGET_RE = re.compile(r"include_router\(\s*([A-Za-z_][\w.]*)(?![\w.])(?!\s*=)")
 
-#: ``app.include_router(x, prefix="/y")`` — a literal mount prefix.
-INCLUDE_ROUTER_RE = re.compile(r"include_router\(\s*([A-Za-z_][\w.]*)[^)]*?prefix\s*=\s*['\"]([^'\"]+)", re.S)
+#: ``prefix="/y"`` anywhere in a call's own argument list.
+_PREFIX_KWARG_RE = re.compile(r"prefix\s*=\s*['\"]([^'\"]+)")
 
 #: ``include_router(name)`` — which routers a package actually mounts (#12956).
-#: Distinct from INCLUDE_ROUTER_RE: here the *name* matters and the prefix may
-#: be absent, because the prefix lives on the imported router itself.
+#: Distinct from ``include_router_prefixes``: here the *name* matters and the
+#: prefix may be absent, because it lives on the imported router itself.
 INCLUDE_ROUTER_NAME_RE = re.compile(r"include_router\(\s*(\w+)")
 
 #: ``from .costs import router as costs_router`` — binds an alias to a submodule.
@@ -84,13 +89,120 @@ ROUTER_CONFIG_ENTRY_RE = re.compile(
 ROUTER_IMPORT_ALIAS_RE = re.compile(r"from\s+([\w.]+)\s+import\s+router\s+as\s+(\w+)")
 
 
+# ── Call scanning ────────────────────────────────────────────────────────────
+#
+# These calls are read with a paren-balanced scan rather than a regex (#14356).
+# The previous grammar reached its own `prefix=` through `[^)]*?`, which cannot
+# cross a `)`. So an argument containing parentheses — the common
+# `dependencies=[Depends(get_current_user)]` — hid every later keyword, and the
+# mount's prefix was dropped with NO error. A consumer defaulting to `""` then
+# reports that module's routes one segment short: an endpoint at a path nothing
+# answers on. Silent omission, never a wrong pairing, which is what made it
+# survivable for so long.
+#
+# Bounding the nesting instead (allowing one level of `(...)`) was rejected: it
+# fails identically at two levels and fails the same silent way, so it would
+# leave the defect in place at a depth nobody would think to check.
+
+
+def _call_end(text: str, open_paren: int) -> int:
+    """Index just past the ``)`` closing the call whose ``(`` is at *open_paren*.
+
+    Quoted strings are skipped. A parenthesis inside a string literal would
+    otherwise unbalance the count and reintroduce a silent miscount of exactly
+    the kind this replaces. Returns ``-1`` for an unterminated call.
+    """
+    depth = 0
+    index = open_paren
+    quote = ""
+    while index < len(text):
+        char = text[index]
+        if quote:
+            if char == "\\":
+                index += 2
+                continue
+            if char == quote:
+                quote = ""
+        elif char in "\"'":
+            quote = char
+        elif char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+            if depth == 0:
+                return index + 1
+        index += 1
+    return -1
+
+
+def _own_arguments(call: str) -> str:
+    """*call* with the contents of nested calls blanked out.
+
+    Keeps the text length stable so offsets still line up, and stops a nested
+    call's ``prefix=`` being read as this call's own.
+    """
+    chars = list(call)
+    depth = 0
+    quote = ""
+    for index, char in enumerate(chars):
+        if quote:
+            if char == quote:
+                quote = ""
+            continue
+        if char in "\"'":
+            quote = char
+        elif char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+        elif depth > 1:
+            chars[index] = " "
+    return "".join(chars)
+
+
+def _calls(text: str, function: str) -> Iterable[str]:
+    """Each complete ``function(...)`` call in *text*, parentheses balanced."""
+    for match in re.finditer(rf"\b{function}\(", text):
+        end = _call_end(text, match.end() - 1)
+        if end > 0:
+            yield text[match.start() : end]
+
+
+def include_router_prefixes(text: str) -> list[Tuple[str, str]]:
+    """``(router_name, prefix)`` for each ``include_router`` naming a literal prefix.
+
+    Replaces the former ``INCLUDE_ROUTER_RE.findall`` and returns the same shape,
+    so call sites read identically.
+    """
+    found = []
+    for call in _calls(text, "include_router"):
+        target = _INCLUDE_ROUTER_TARGET_RE.match(call)
+        prefix = _PREFIX_KWARG_RE.search(_own_arguments(call))
+        if target and prefix:
+            found.append((target.group(1), prefix.group(1)))
+    return found
+
+
 # ── Resolution ───────────────────────────────────────────────────────────────
 
 
 def file_router_prefix(source: str) -> str:
-    """The ``APIRouter(prefix=...)`` a file declares, or ``""``."""
-    match = APIROUTER_PREFIX_RE.search(source)
-    return match.group(1).rstrip("/") if match else ""
+    """The ``APIRouter(prefix=...)`` a file declares, or ``""``.
+
+    Scanned the same way as ``include_router`` and for the same reason: the old
+    ``APIRouter\\([^)]*?prefix=`` carried the identical defect, so a constructor
+    passing ``dependencies`` before ``prefix`` silently reported no prefix at
+    all (#14356).
+
+    The example is described rather than written out. A literal constructor call
+    in this docstring is found by this module's own scanner when the file is
+    read as source — the doc becoming a false positive in the tool it documents.
+    """
+    for call in _calls(source, "APIRouter"):
+        prefix = _PREFIX_KWARG_RE.search(_own_arguments(call))
+        if prefix:
+            return prefix.group(1).rstrip("/")
+    return ""
 
 
 def registry_entries(registry_dir: Path) -> list[Tuple[str, str]]:
@@ -167,7 +279,7 @@ def _package_router_files(package: Path, registry_prefix: str) -> Dict[Path, str
     # tests/api_routing/package_router_files_parity_13582_test.py enforces —
     # this one backs the blocking api-wiring gate, so a divergence means the
     # gate and the analytics report disagree about what the API serves.
-    mount_prefixes = dict(INCLUDE_ROUTER_RE.findall(init_content))
+    mount_prefixes = dict(include_router_prefixes(init_content))
 
     files: Dict[Path, str] = {}
     for module_name, alias in RELATIVE_ROUTER_IMPORT_RE.findall(init_content):

--- a/repo_tests/router_prefix_convergence_test.py
+++ b/repo_tests/router_prefix_convergence_test.py
@@ -51,8 +51,82 @@ def test_a_file_without_a_router_prefix_yields_empty():
 
 
 def test_include_router_captures_name_and_prefix():
-    found = routing.INCLUDE_ROUTER_RE.findall('app.include_router(chat_router, prefix="/chat")')
+    found = routing.include_router_prefixes('app.include_router(chat_router, prefix="/chat")')
     assert found == [("chat_router", "/chat")]
+
+
+# --- #14356: an earlier argument containing parentheses must not hide prefix ---
+#
+# The old grammar reached `prefix=` through `[^)]*?`, which cannot cross a `)`.
+# `dependencies=[Depends(...)]` therefore hid the mount's own prefix and it was
+# dropped with no error — a route reported one segment short, at a path nothing
+# answers on. Silent omission, never a wrong pairing.
+
+
+def test_a_parenthesised_earlier_argument_does_not_hide_the_prefix():
+    source = 'router.include_router(a_router, dependencies=[Depends(get_current_user)], prefix="/a")'
+
+    assert routing.include_router_prefixes(source) == [("a_router", "/a")]
+
+
+def test_two_levels_of_nesting_still_reach_the_prefix():
+    """A depth-bounded regex would pass the case above and fail this one."""
+    source = 'router.include_router(a_router, dependencies=[Depends(scoped(admin))], prefix="/a")'
+
+    assert routing.include_router_prefixes(source) == [("a_router", "/a")]
+
+
+def test_a_multiline_call_is_read_as_one_call():
+    source = (
+        "router.include_router(\n"
+        "    a_router,\n"
+        "    dependencies=[Depends(get_current_user)],\n"
+        '    prefix="/a",\n'
+        ")\n"
+        'router.include_router(b_router, prefix="/b")\n'
+    )
+
+    assert routing.include_router_prefixes(source) == [("a_router", "/a"), ("b_router", "/b")]
+
+
+def test_the_prefix_of_a_nested_call_is_not_claimed_by_the_outer_one():
+    source = 'router.include_router(build(inner, prefix="/inner"), prefix="/outer")'
+
+    assert routing.include_router_prefixes(source) == [("build", "/outer")]
+
+
+def test_a_parenthesis_inside_a_string_does_not_unbalance_the_scan():
+    source = 'router.include_router(a_router, tags=["x)y"], prefix="/a")\n'
+
+    assert routing.include_router_prefixes(source) == [("a_router", "/a")]
+
+
+def test_a_call_without_a_prefix_contributes_nothing():
+    assert routing.include_router_prefixes("app.include_router(chat_router)") == []
+
+
+def test_a_keyword_only_call_does_not_capture_the_keyword_as_the_router():
+    """Regression on the fix itself.
+
+    The router-name pattern is greedy, so a bare `(?!\\s*=)` backtracks: given a
+    keyword named `prefix` it matches `prefi` so the next character is `x` rather
+    than `=`, and the keyword is captured as a router under a truncated name.
+    A comment in `audit_api_wiring_test.py` contains exactly this shape.
+    """
+    assert routing.include_router_prefixes('include_router(prefix="/api")') == []
+
+
+def test_a_dotted_router_name_is_captured_whole():
+    source = 'app.include_router(sub.mod_router, prefix="/s")'
+
+    assert routing.include_router_prefixes(source) == [("sub.mod_router", "/s")]
+
+
+def test_apirouter_prefix_survives_a_parenthesised_earlier_argument():
+    """`file_router_prefix` carried the identical defect and is fixed with it."""
+    source = 'router = APIRouter(dependencies=[Depends(get_current_user)], prefix="/llc")'
+
+    assert routing.file_router_prefix(source) == "/llc"
 
 
 def test_a_registry_tuple_naming_a_package_is_parsed():

--- a/repo_tests/router_prefix_convergence_test.py
+++ b/repo_tests/router_prefix_convergence_test.py
@@ -275,3 +275,15 @@ def test_both_tools_use_the_shared_grammar_and_keep_no_private_copy():
         assert (
             're.compile(r"include_router' not in source and "re.compile(r'include_router" not in source
         ), f"{name} declares its own include_router regex again"
+
+
+def test_apirouter_prefix_distinguishes_absent_from_empty():
+    """`file_router_prefix` normalises; the raw form must not.
+
+    `api_endpoint_scanner._get_file_router_prefix` returns the prefix verbatim
+    and `None` when none is declared, so collapsing both onto `""` would change
+    what the scanner reports.
+    """
+    assert routing.apirouter_prefix('APIRouter(prefix="/llc/")') == "/llc/"
+    assert routing.apirouter_prefix("x = 1") is None
+    assert routing.file_router_prefix('APIRouter(prefix="/llc/")') == "/llc"

--- a/scripts/audit_api_wiring.py
+++ b/scripts/audit_api_wiring.py
@@ -95,7 +95,7 @@ ROUTE_DECORATOR_RE = re.compile(
 # autobot_shared/api_routing/router_prefixes.py. It was duplicated here and in
 # api_endpoint_scanner.py with separate regexes, and the two had diverged —
 # the scanner got package resolution (#12945/#12956), this gate did not.
-INCLUDE_ROUTER_RE = _routing.INCLUDE_ROUTER_RE
+include_router_prefixes = _routing.include_router_prefixes
 FE_API_RE = re.compile(r"[\'\"`](/api/[A-Za-z0-9_/${}():.\-]+)")
 # #12326: the dominant idiom composes the path from a helper —
 # ``apiClient.get(`${getApiBase()}/knowledge_base/health/status`)``. getApiBase()
@@ -232,7 +232,7 @@ ROUTER_PREFIX_RE = _routing.APIROUTER_PREFIX_RE
 # + a top-level ``from api.overseer_handlers import router as overseer_router``
 # in core_routers.py — never a literal ``include_router(prefix=...)`` call
 # (app_factory.py does that generically: ``prefix=f"/api{prefix}"``), so
-# INCLUDE_ROUTER_RE never sees these prefixes at all. Without resolving them,
+# include_router_prefixes never sees these prefixes at all. Without resolving them,
 # a sub-router's routes (including websocket ones) get NO prefix, not merely
 # the wrong one — e.g. advanced_control.py's ``/ws/monitoring`` never becomes
 # ``/advanced-control/ws/monitoring``.
@@ -282,7 +282,7 @@ def _scan_route_decorators(
             module_prefix[sp] = mp.group(1).rstrip("/")
         for method, path in ROUTE_DECORATOR_RE.findall(txt):
             raw[sp].append((method, path))
-        for _var, prefix in INCLUDE_ROUTER_RE.findall(txt):
+        for _var, prefix in include_router_prefixes(txt):
             prefixes.add(prefix.rstrip("/"))
     return raw, module_prefix, prefixes
 

--- a/scripts/audit_api_wiring.py
+++ b/scripts/audit_api_wiring.py
@@ -223,7 +223,7 @@ def backend_paths_from_openapi(src: str) -> set[str]:
     return paths
 
 
-ROUTER_PREFIX_RE = _routing.APIROUTER_PREFIX_RE
+apirouter_prefix = _routing.apirouter_prefix
 # #12432: feature/core routers are mounted via *data-driven config tuples* in
 # initialization/router_registry/*.py — e.g.
 #   ("api.advanced_control", "/advanced-control", ["advanced-control"], "advanced_control")
@@ -277,9 +277,9 @@ def _scan_route_decorators(
         if "__pycache__" in sp or "/tests/" in sp or sp.endswith("_test.py") or "/test_" in sp:
             continue
         txt = py.read_text(encoding="utf-8", errors="ignore")
-        mp = ROUTER_PREFIX_RE.search(txt)
-        if mp:
-            module_prefix[sp] = mp.group(1).rstrip("/")
+        mp = apirouter_prefix(txt)
+        if mp is not None:
+            module_prefix[sp] = mp.rstrip("/")
         for method, path in ROUTE_DECORATOR_RE.findall(txt):
             raw[sp].append((method, path))
         for _var, prefix in include_router_prefixes(txt):
@@ -357,8 +357,8 @@ def _module_served_by_openapi(txt: str, backend: set[str]) -> bool:
     """Authoritative suppression: a module is mounted when ALL of its declared
     routes appear in the real route table (any-route matching would let one
     coincidental suffix like /status suppress a whole unmounted module)."""
-    own = ROUTER_PREFIX_RE.search(txt)
-    prefix = own.group(1).rstrip("/") if own else ""
+    own = apirouter_prefix(txt)
+    prefix = own.rstrip("/") if own is not None else ""
     checked = 0
     for _m, route in ROUTE_DECORATOR_RE.findall(txt):
         full = norm_path(prefix + (route if route.startswith("/") or not route else "/" + route))


### PR DESCRIPTION
## Thinking Path

`INCLUDE_ROUTER_RE` reached its own `prefix=` through `[^)]*?`, which cannot cross a `)`. An earlier argument containing parentheses — the common `dependencies=[Depends(get_current_user)]` — therefore hid every later keyword, and the mount's prefix was dropped with **no error**. A consumer defaulting to `""` reports that module's routes one segment short: an endpoint at a path nothing answers on.

Two things shaped the fix.

**It is latent, not active.** I scanned all 4,886 Python files with a balanced-paren reference scanner and compared against the current regex: **zero prefixes are being dropped today**. The one apparent hit was my scanner mis-reading a keyword-only call in a comment. So nothing is currently miscounted — this is a trap waiting for the first multi-line `include_router` with a dependency, not a live miscount. The PR is worth landing because the failure is silent, not because something is broken now.

**A depth-bounded regex was rejected.** Allowing one level of nesting (`(?:[^()]|\([^()]*\))*?`) would pass `Depends(x)` and fail `Depends(scoped(admin))` — identically, and just as silently, at a depth nobody would think to check. Trading one silent omission for a rarer one is not a fix.

`APIROUTER_PREFIX_RE` carried the **identical** defect one line above (`APIRouter\([^)]*?prefix=`), so it is fixed in the same change rather than documented and left.

## What Changed

| File | Change |
|---|---|
| `autobot_shared/api_routing/router_prefixes.py` | `INCLUDE_ROUTER_RE` / `APIROUTER_PREFIX_RE` replaced by a paren-balanced scan: `_call_end`, `_own_arguments`, `_calls`, and the public `include_router_prefixes()`. `file_router_prefix()` now uses it too. |
| `scripts/audit_api_wiring.py` | consumer updated (the blocking `api-wiring` gate) |
| `autobot-backend/api/codebase_analytics/api_endpoint_scanner.py` | consumer updated |
| `repo_tests/router_prefix_convergence_test.py` | existing test updated to the new call; 9 tests added |

`include_router_prefixes()` returns the same `(name, prefix)` shape the old `.findall()` did, so call sites read identically. The old names are removed rather than kept alongside — one canonical way to parse this grammar, which is the whole point of the module (#12985).

Two subtleties the scanner handles that a regex could not:

- **Quoted strings are skipped.** A `)` inside a string literal (`tags=["x)y"]`) would otherwise unbalance the count and reintroduce a silent miscount of exactly the kind being removed.
- **Nested call contents are blanked before reading `prefix=`.** Otherwise `include_router(build(inner, prefix="/inner"), prefix="/outer")` would claim the inner prefix.

## Verification

Real-tree parity, which is the claim that matters for a parser swap:

```
scanned 4886 files
include_router diffs vs old regex: 0
APIRouter      diffs vs old regex: 0
```

Identical output everywhere on the current tree, so this cannot change any served-path calculation today — it only stops the drop that would occur once such a call is written.

**I introduced a bug in this fix and the verification caught it.** My first attempt guarded the router name with `(?!\s*=)` to reject keyword-only calls. The name pattern is greedy and backtracks, so given `include_router(prefix="/api")` it matched `prefi` — leaving `x`, not `=`, as the next character — and captured the keyword as a router under a truncated name. It showed up as a real-tree diff against a comment in `audit_api_wiring_test.py`. Fixed with `(?![\w.])` to force a maximal token before the `=` test, and pinned by `test_a_keyword_only_call_does_not_capture_the_keyword_as_the_router`.

Tests added, each asserting a direction rather than the reported instance:

- a parenthesised earlier argument does not hide the prefix — **the regression**
- two levels of nesting still reach it — the case a depth-bounded regex would fail
- a multi-line call is read as one call
- a nested call's prefix is not claimed by the outer one
- a `)` inside a string does not unbalance the scan
- a keyword-only call captures nothing (the bug above)
- a dotted router name is captured whole
- a call with no prefix contributes nothing
- `file_router_prefix` survives a parenthesised earlier argument

Also removed a literal constructor call from `file_router_prefix`'s docstring: this module's own scanner finds it when the file is read as source, making the documentation a false positive in the tool it documents.

Local verification was the scanner logic in an isolated copy plus `py_compile` on all four files; the repository verifies correctness in CI rather than by running its own code locally.

## Model Used

Opus 5

Closes #14356
