### PR TITLE
feat(llc): add the Roles tab to the Company OS GUI

### DIFF
--- a/autobot-frontend/src/components/llc/LlcSidebar.vue
+++ b/autobot-frontend/src/components/llc/LlcSidebar.vue
@@ -86,6 +86,7 @@ const links = computed<SidebarLink[]>(() => {
     { labelKey: 'nav.llcGoals', to: { path: `/llc/companies/${id}/goals` } },
     { labelKey: 'nav.llcOrgChart', to: { path: `/llc/companies/${id}/org-chart` } },
     { labelKey: 'nav.llcMembers', to: { path: `/llc/companies/${id}/members` } },
+    { labelKey: 'nav.llcRoles', to: { path: `/llc/companies/${id}/roles` } },
     { labelKey: 'nav.llcApprovals', to: { path: `/llc/companies/${id}/approvals` } },
     { labelKey: 'nav.llcCosts', to: { path: `/llc/companies/${id}/costs` } },
     { labelKey: 'nav.llcHeartbeat', to: { path: `/llc/companies/${id}/heartbeat` } },
@@ -180,8 +181,8 @@ async function onCompanyChange(event: Event): Promise<void> {
   flex-direction: column;
   gap: 1rem;
   padding: 1rem 0.75rem;
-  background: var(--bg-surface, #f9fafb);
-  border-right: 1px solid var(--border-default, #e5e7eb);
+  background: var(--bg-surface);
+  border-right: 1px solid var(--border-default);
   min-height: 100%;
 }
 
@@ -196,7 +197,7 @@ async function onCompanyChange(event: Event): Promise<void> {
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: var(--text-muted, #6b7280);
+  color: var(--text-muted);
 }
 
 .llc-sidebar-select {
@@ -204,14 +205,14 @@ async function onCompanyChange(event: Event): Promise<void> {
   padding: 0.375rem 0.5rem;
   font-size: 0.875rem;
   border-radius: var(--radius-md, 8px);
-  border: 1px solid var(--border-default, #d1d5db);
-  background: var(--bg-input, #ffffff);
-  color: var(--text-primary, #111827);
+  border: 1px solid var(--border-default);
+  background: var(--bg-input);
+  color: var(--text-primary);
 }
 
 .llc-sidebar-switch {
   font-size: 0.75rem;
-  color: var(--color-accent-text, var(--color-accent, #c4651a));
+  color: var(--color-accent-text, var(--color-accent));
   text-decoration: none;
 }
 
@@ -234,7 +235,7 @@ async function onCompanyChange(event: Event): Promise<void> {
   font-size: 0.875rem;
   border-radius: var(--radius-md, 8px);
   border-left: 2px solid transparent;
-  color: var(--text-secondary, #4b5563);
+  color: var(--text-secondary);
   text-decoration: none;
 }
 
@@ -247,19 +248,19 @@ async function onCompanyChange(event: Event): Promise<void> {
   line-height: 1.25rem;
   text-align: center;
   border-radius: 999px;
-  background: var(--color-accent, #c4651a);
-  color: #fff;
+  background: var(--color-accent);
+  color: var(--color-on-accent);
 }
 
 .llc-nav-item:hover {
-  background: var(--bg-hover, #f3f4f6);
-  color: var(--text-primary, #111827);
+  background: var(--bg-hover);
+  color: var(--text-primary);
 }
 
 .llc-nav-item.active {
-  background: var(--color-accent-subtle, #fcefe0);
-  border-left-color: var(--color-accent, #c4651a);
-  color: var(--color-accent-text, var(--color-accent, #c4651a));
+  background: var(--color-accent-subtle);
+  border-left-color: var(--color-accent);
+  color: var(--color-accent-text, var(--color-accent));
   font-weight: 600;
 }
 </style>

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -7745,7 +7745,8 @@
     "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it.",
     "systemHealth": "صحة النظام",
     "providerFallback": "احتياطي المزود",
-    "advancedControl": "التحكم المتقدم"
+    "advancedControl": "التحكم المتقدم",
+    "llcRoles": "الأدوار"
   },
   "llcCompanyStatus": {
     "showArchived": "عرض المؤرشفة",
@@ -9100,5 +9101,40 @@
     "loadFailed": "تعذّر تحميل المجدولات.",
     "toggleFailed": "تعذّر تغيير {name}.",
     "resetFailed": "تعذّرت إعادة {name} إلى الافتراضي."
+  },
+  "llcRoles": {
+    "title": "الأدوار",
+    "subtitle": "يبقى الدور بعد من يشغله — تبقى صلاحياته وسير عمله وأدواته وبيانات اعتماده.",
+    "addRole": "إضافة دور",
+    "deleteRole": "حذف الدور",
+    "noCompany": "اختر شركة لعرض أدوارها.",
+    "loading": "جارٍ التحميل…",
+    "empty": "لا توجد أدوار بعد.",
+    "systemRole": "نظام",
+    "holders": "شاغلو الدور",
+    "noHolders": "لا أحد يشغل هذا الدور حاليًا.",
+    "showPastHolders": "عرض الشاغلين السابقين",
+    "pastHolder": "سابق",
+    "permissions": "الصلاحيات",
+    "noPermissions": "لم تُمنح أي صلاحيات.",
+    "workflows": "سير العمل",
+    "noWorkflows": "لا سير عمل مرتبط.",
+    "tools": "الأدوات",
+    "noTools": "لا أدوات مرتبطة.",
+    "credentials": "بيانات الاعتماد",
+    "noCredentials": "لا بيانات اعتماد مرتبطة.",
+    "fieldName": "الاسم",
+    "fieldDescription": "الوصف",
+    "cancel": "إلغاء",
+    "save": "حفظ",
+    "errorLoad": "تعذّر تحميل الأدوار.",
+    "errorLoadDetail": "تعذّر تحميل تفاصيل الدور.",
+    "errorCreate": "تعذّر إنشاء الدور.",
+    "errorDelete": "تعذّر حذف الدور.",
+    "holderType": {
+      "agent": "وكيل",
+      "user": "مستخدم",
+      "contact": "جهة اتصال"
+    }
   }
 }

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -7745,7 +7745,8 @@
     "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it.",
     "systemHealth": "Systemzustand",
     "providerFallback": "Anbieter-Fallback",
-    "advancedControl": "Erweiterte Steuerung"
+    "advancedControl": "Erweiterte Steuerung",
+    "llcRoles": "Rollen"
   },
   "llcCompanyStatus": {
     "showArchived": "Archivierte anzeigen",
@@ -9100,5 +9101,40 @@
     "loadFailed": "Planer konnten nicht geladen werden.",
     "toggleFailed": "{name} konnte nicht geändert werden.",
     "resetFailed": "{name} konnte nicht zurückgesetzt werden."
+  },
+  "llcRoles": {
+    "title": "Rollen",
+    "subtitle": "Eine Rolle überdauert ihre Inhaber — Berechtigungen, Workflows, Werkzeuge und Zugangsdaten bleiben bestehen.",
+    "addRole": "Rolle hinzufügen",
+    "deleteRole": "Rolle löschen",
+    "noCompany": "Wählen Sie ein Unternehmen aus, um dessen Rollen zu sehen.",
+    "loading": "Wird geladen…",
+    "empty": "Noch keine Rollen.",
+    "systemRole": "System",
+    "holders": "Inhaber",
+    "noHolders": "Diese Rolle hat derzeit keinen Inhaber.",
+    "showPastHolders": "Frühere Inhaber anzeigen",
+    "pastHolder": "früher",
+    "permissions": "Berechtigungen",
+    "noPermissions": "Keine Berechtigungen erteilt.",
+    "workflows": "Workflows",
+    "noWorkflows": "Keine Workflows zugeordnet.",
+    "tools": "Werkzeuge",
+    "noTools": "Keine Werkzeuge zugeordnet.",
+    "credentials": "Zugangsdaten",
+    "noCredentials": "Keine Zugangsdaten zugeordnet.",
+    "fieldName": "Name",
+    "fieldDescription": "Beschreibung",
+    "cancel": "Abbrechen",
+    "save": "Speichern",
+    "errorLoad": "Rollen konnten nicht geladen werden.",
+    "errorLoadDetail": "Rollendetails konnten nicht geladen werden.",
+    "errorCreate": "Rolle konnte nicht erstellt werden.",
+    "errorDelete": "Rolle konnte nicht gelöscht werden.",
+    "holderType": {
+      "agent": "Agent",
+      "user": "Benutzer",
+      "contact": "Kontakt"
+    }
   }
 }

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -7794,7 +7794,8 @@
     "adminPanel": "Admin Panel",
     "documents": "AI Documents",
     "companyOsUnavailableTitle": "Company OS is not available",
-    "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it."
+    "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it.",
+    "llcRoles": "Roles"
   },
   "llcCompanyStatus": {
     "showArchived": "Show archived",
@@ -9100,5 +9101,40 @@
     "loadFailed": "Could not load schedulers.",
     "toggleFailed": "Could not change {name}.",
     "resetFailed": "Could not revert {name} to its default."
+  },
+  "llcRoles": {
+    "title": "Roles",
+    "subtitle": "A role outlives whoever holds it — its permissions, workflows, tools and credentials stay when people move on.",
+    "addRole": "Add role",
+    "deleteRole": "Delete role",
+    "noCompany": "Select a company to view its roles.",
+    "loading": "Loading…",
+    "empty": "No roles yet.",
+    "systemRole": "System",
+    "holders": "Holders",
+    "noHolders": "No one currently holds this role.",
+    "showPastHolders": "Show past holders",
+    "pastHolder": "past",
+    "permissions": "Permissions",
+    "noPermissions": "No permissions granted.",
+    "workflows": "Workflows",
+    "noWorkflows": "No workflows attached.",
+    "tools": "Tools",
+    "noTools": "No tools attached.",
+    "credentials": "Credentials",
+    "noCredentials": "No credentials attached.",
+    "fieldName": "Name",
+    "fieldDescription": "Description",
+    "cancel": "Cancel",
+    "save": "Save",
+    "errorLoad": "Could not load roles.",
+    "errorLoadDetail": "Could not load this role's details.",
+    "errorCreate": "Could not create the role.",
+    "errorDelete": "Could not delete the role.",
+    "holderType": {
+      "agent": "Agent",
+      "user": "User",
+      "contact": "Contact"
+    }
   }
 }

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -7745,7 +7745,8 @@
     "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it.",
     "systemHealth": "Salud del sistema",
     "providerFallback": "Respaldo de proveedor",
-    "advancedControl": "Control avanzado"
+    "advancedControl": "Control avanzado",
+    "llcRoles": "Roles"
   },
   "llcCompanyStatus": {
     "showArchived": "Mostrar archivadas",
@@ -9100,5 +9101,40 @@
     "loadFailed": "No se pudieron cargar los programadores.",
     "toggleFailed": "No se pudo cambiar {name}.",
     "resetFailed": "No se pudo restaurar {name} a su valor predeterminado."
+  },
+  "llcRoles": {
+    "title": "Roles",
+    "subtitle": "Un rol sobrevive a quien lo ocupa: sus permisos, flujos, herramientas y credenciales permanecen.",
+    "addRole": "Añadir rol",
+    "deleteRole": "Eliminar rol",
+    "noCompany": "Seleccione una empresa para ver sus roles.",
+    "loading": "Cargando…",
+    "empty": "Aún no hay roles.",
+    "systemRole": "Sistema",
+    "holders": "Titulares",
+    "noHolders": "Nadie ocupa este rol actualmente.",
+    "showPastHolders": "Mostrar titulares anteriores",
+    "pastHolder": "anterior",
+    "permissions": "Permisos",
+    "noPermissions": "Sin permisos concedidos.",
+    "workflows": "Flujos de trabajo",
+    "noWorkflows": "Sin flujos adjuntos.",
+    "tools": "Herramientas",
+    "noTools": "Sin herramientas adjuntas.",
+    "credentials": "Credenciales",
+    "noCredentials": "Sin credenciales adjuntas.",
+    "fieldName": "Nombre",
+    "fieldDescription": "Descripción",
+    "cancel": "Cancelar",
+    "save": "Guardar",
+    "errorLoad": "No se pudieron cargar los roles.",
+    "errorLoadDetail": "No se pudieron cargar los detalles del rol.",
+    "errorCreate": "No se pudo crear el rol.",
+    "errorDelete": "No se pudo eliminar el rol.",
+    "holderType": {
+      "agent": "Agente",
+      "user": "Usuario",
+      "contact": "Contacto"
+    }
   }
 }

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -196,7 +196,8 @@
     "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it.",
     "systemHealth": "سلامت سیستم",
     "providerFallback": "جایگزینی ارائه‌دهنده",
-    "advancedControl": "کنترل پیشرفته"
+    "advancedControl": "کنترل پیشرفته",
+    "llcRoles": "نقش‌ها"
   },
   "llcCompanyStatus": {
     "showArchived": "نمایش بایگانی‌شده‌ها",
@@ -9100,5 +9101,40 @@
     "loadFailed": "بارگذاری زمان‌بندها ممکن نشد.",
     "toggleFailed": "تغییر {name} ممکن نشد.",
     "resetFailed": "بازگرداندن {name} به پیش‌فرض ممکن نشد."
+  },
+  "llcRoles": {
+    "title": "نقش‌ها",
+    "subtitle": "نقش پس از دارندهٔ خود باقی می‌ماند — دسترسی‌ها، گردش‌کارها، ابزارها و اعتبارنامه‌ها می‌مانند.",
+    "addRole": "افزودن نقش",
+    "deleteRole": "حذف نقش",
+    "noCompany": "برای دیدن نقش‌ها یک شرکت انتخاب کنید.",
+    "loading": "در حال بارگذاری…",
+    "empty": "هنوز نقشی وجود ندارد.",
+    "systemRole": "سیستمی",
+    "holders": "دارندگان",
+    "noHolders": "در حال حاضر کسی این نقش را ندارد.",
+    "showPastHolders": "نمایش دارندگان پیشین",
+    "pastHolder": "پیشین",
+    "permissions": "دسترسی‌ها",
+    "noPermissions": "دسترسی‌ای اعطا نشده است.",
+    "workflows": "گردش‌کارها",
+    "noWorkflows": "گردش‌کاری پیوست نشده است.",
+    "tools": "ابزارها",
+    "noTools": "ابزاری پیوست نشده است.",
+    "credentials": "اعتبارنامه‌ها",
+    "noCredentials": "اعتبارنامه‌ای پیوست نشده است.",
+    "fieldName": "نام",
+    "fieldDescription": "توضیح",
+    "cancel": "لغو",
+    "save": "ذخیره",
+    "errorLoad": "بارگذاری نقش‌ها ممکن نشد.",
+    "errorLoadDetail": "بارگذاری جزئیات نقش ممکن نشد.",
+    "errorCreate": "ایجاد نقش ممکن نشد.",
+    "errorDelete": "حذف نقش ممکن نشد.",
+    "holderType": {
+      "agent": "عامل",
+      "user": "کاربر",
+      "contact": "مخاطب"
+    }
   }
 }

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -7745,7 +7745,8 @@
     "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it.",
     "systemHealth": "Santé du système",
     "providerFallback": "Basculement de fournisseur",
-    "advancedControl": "Contrôle avancé"
+    "advancedControl": "Contrôle avancé",
+    "llcRoles": "Rôles"
   },
   "llcCompanyStatus": {
     "showArchived": "Afficher les archivées",
@@ -9100,5 +9101,40 @@
     "loadFailed": "Impossible de charger les planificateurs.",
     "toggleFailed": "Impossible de modifier {name}.",
     "resetFailed": "Impossible de rétablir {name} à sa valeur par défaut."
+  },
+  "llcRoles": {
+    "title": "Rôles",
+    "subtitle": "Un rôle survit à ses titulaires : ses permissions, workflows, outils et identifiants demeurent.",
+    "addRole": "Ajouter un rôle",
+    "deleteRole": "Supprimer le rôle",
+    "noCompany": "Sélectionnez une entreprise pour voir ses rôles.",
+    "loading": "Chargement…",
+    "empty": "Aucun rôle pour l'instant.",
+    "systemRole": "Système",
+    "holders": "Titulaires",
+    "noHolders": "Personne n'occupe ce rôle actuellement.",
+    "showPastHolders": "Afficher les anciens titulaires",
+    "pastHolder": "ancien",
+    "permissions": "Permissions",
+    "noPermissions": "Aucune permission accordée.",
+    "workflows": "Workflows",
+    "noWorkflows": "Aucun workflow associé.",
+    "tools": "Outils",
+    "noTools": "Aucun outil associé.",
+    "credentials": "Identifiants",
+    "noCredentials": "Aucun identifiant associé.",
+    "fieldName": "Nom",
+    "fieldDescription": "Description",
+    "cancel": "Annuler",
+    "save": "Enregistrer",
+    "errorLoad": "Impossible de charger les rôles.",
+    "errorLoadDetail": "Impossible de charger les détails du rôle.",
+    "errorCreate": "Impossible de créer le rôle.",
+    "errorDelete": "Impossible de supprimer le rôle.",
+    "holderType": {
+      "agent": "Agent",
+      "user": "Utilisateur",
+      "contact": "Contact"
+    }
   }
 }

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -196,7 +196,8 @@
     "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it.",
     "systemHealth": "בריאות המערכת",
     "providerFallback": "גיבוי ספק",
-    "advancedControl": "בקרה מתקדמת"
+    "advancedControl": "בקרה מתקדמת",
+    "llcRoles": "תפקידים"
   },
   "llcCompanyStatus": {
     "showArchived": "הצג בארכיון",
@@ -9100,5 +9101,40 @@
     "loadFailed": "טעינת המתזמנים נכשלה.",
     "toggleFailed": "שינוי {name} נכשל.",
     "resetFailed": "החזרת {name} לברירת המחדל נכשלה."
+  },
+  "llcRoles": {
+    "title": "תפקידים",
+    "subtitle": "תפקיד שורד את מי שממלא אותו — ההרשאות, התהליכים, הכלים והאישורים נשארים.",
+    "addRole": "הוספת תפקיד",
+    "deleteRole": "מחיקת תפקיד",
+    "noCompany": "בחר חברה כדי לראות את התפקידים שלה.",
+    "loading": "טוען…",
+    "empty": "אין עדיין תפקידים.",
+    "systemRole": "מערכת",
+    "holders": "ממלאי התפקיד",
+    "noHolders": "אף אחד לא ממלא תפקיד זה כרגע.",
+    "showPastHolders": "הצג ממלאים קודמים",
+    "pastHolder": "קודם",
+    "permissions": "הרשאות",
+    "noPermissions": "לא הוענקו הרשאות.",
+    "workflows": "תהליכי עבודה",
+    "noWorkflows": "לא צורפו תהליכים.",
+    "tools": "כלים",
+    "noTools": "לא צורפו כלים.",
+    "credentials": "אישורים",
+    "noCredentials": "לא צורפו אישורים.",
+    "fieldName": "שם",
+    "fieldDescription": "תיאור",
+    "cancel": "ביטול",
+    "save": "שמירה",
+    "errorLoad": "לא ניתן לטעון את התפקידים.",
+    "errorLoadDetail": "לא ניתן לטעון את פרטי התפקיד.",
+    "errorCreate": "לא ניתן ליצור את התפקיד.",
+    "errorDelete": "לא ניתן למחוק את התפקיד.",
+    "holderType": {
+      "agent": "סוכן",
+      "user": "משתמש",
+      "contact": "איש קשר"
+    }
   }
 }

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -7745,7 +7745,8 @@
     "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it.",
     "systemHealth": "Sistēmas veselība",
     "providerFallback": "Nodrošinātāja rezerve",
-    "advancedControl": "Papildu vadība"
+    "advancedControl": "Papildu vadība",
+    "llcRoles": "Lomas"
   },
   "llcCompanyStatus": {
     "showArchived": "Rādīt arhivētos",
@@ -9100,5 +9101,40 @@
     "loadFailed": "Neizdevās ielādēt plānotājus.",
     "toggleFailed": "Neizdevās mainīt {name}.",
     "resetFailed": "Neizdevās atjaunot {name} noklusējumu."
+  },
+  "llcRoles": {
+    "title": "Lomas",
+    "subtitle": "Loma pastāv ilgāk nekā tās izpildītājs — atļaujas, darbplūsmas, rīki un akreditācijas dati paliek.",
+    "addRole": "Pievienot lomu",
+    "deleteRole": "Dzēst lomu",
+    "noCompany": "Atlasiet uzņēmumu, lai skatītu tā lomas.",
+    "loading": "Notiek ielāde…",
+    "empty": "Vēl nav lomu.",
+    "systemRole": "Sistēmas",
+    "holders": "Izpildītāji",
+    "noHolders": "Šo lomu pašlaik neviens nepilda.",
+    "showPastHolders": "Rādīt iepriekšējos",
+    "pastHolder": "iepriekšējais",
+    "permissions": "Atļaujas",
+    "noPermissions": "Nav piešķirtu atļauju.",
+    "workflows": "Darbplūsmas",
+    "noWorkflows": "Nav pievienotu darbplūsmu.",
+    "tools": "Rīki",
+    "noTools": "Nav pievienotu rīku.",
+    "credentials": "Akreditācijas dati",
+    "noCredentials": "Nav pievienotu akreditācijas datu.",
+    "fieldName": "Nosaukums",
+    "fieldDescription": "Apraksts",
+    "cancel": "Atcelt",
+    "save": "Saglabāt",
+    "errorLoad": "Neizdevās ielādēt lomas.",
+    "errorLoadDetail": "Neizdevās ielādēt lomas detaļas.",
+    "errorCreate": "Neizdevās izveidot lomu.",
+    "errorDelete": "Neizdevās dzēst lomu.",
+    "holderType": {
+      "agent": "Aģents",
+      "user": "Lietotājs",
+      "contact": "Kontaktpersona"
+    }
   }
 }

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -7745,7 +7745,8 @@
     "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it.",
     "systemHealth": "Kondycja systemu",
     "providerFallback": "Przełączanie dostawcy",
-    "advancedControl": "Sterowanie zaawansowane"
+    "advancedControl": "Sterowanie zaawansowane",
+    "llcRoles": "Role"
   },
   "llcCompanyStatus": {
     "showArchived": "Pokaż zarchiwizowane",
@@ -9100,5 +9101,40 @@
     "loadFailed": "Nie udało się wczytać harmonogramów.",
     "toggleFailed": "Nie udało się zmienić {name}.",
     "resetFailed": "Nie udało się przywrócić domyślnych dla {name}."
+  },
+  "llcRoles": {
+    "title": "Role",
+    "subtitle": "Rola trwa dłużej niż osoba, która ją pełni — uprawnienia, przepływy, narzędzia i poświadczenia pozostają.",
+    "addRole": "Dodaj rolę",
+    "deleteRole": "Usuń rolę",
+    "noCompany": "Wybierz firmę, aby zobaczyć jej role.",
+    "loading": "Ładowanie…",
+    "empty": "Brak ról.",
+    "systemRole": "Systemowa",
+    "holders": "Pełniący",
+    "noHolders": "Nikt obecnie nie pełni tej roli.",
+    "showPastHolders": "Pokaż poprzednich",
+    "pastHolder": "poprzedni",
+    "permissions": "Uprawnienia",
+    "noPermissions": "Brak przyznanych uprawnień.",
+    "workflows": "Przepływy pracy",
+    "noWorkflows": "Brak powiązanych przepływów.",
+    "tools": "Narzędzia",
+    "noTools": "Brak powiązanych narzędzi.",
+    "credentials": "Poświadczenia",
+    "noCredentials": "Brak powiązanych poświadczeń.",
+    "fieldName": "Nazwa",
+    "fieldDescription": "Opis",
+    "cancel": "Anuluj",
+    "save": "Zapisz",
+    "errorLoad": "Nie udało się wczytać ról.",
+    "errorLoadDetail": "Nie udało się wczytać szczegółów roli.",
+    "errorCreate": "Nie udało się utworzyć roli.",
+    "errorDelete": "Nie udało się usunąć roli.",
+    "holderType": {
+      "agent": "Agent",
+      "user": "Użytkownik",
+      "contact": "Kontakt"
+    }
   }
 }

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -7745,7 +7745,8 @@
     "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it.",
     "systemHealth": "Saúde do sistema",
     "providerFallback": "Fallback de provedor",
-    "advancedControl": "Controle avançado"
+    "advancedControl": "Controle avançado",
+    "llcRoles": "Funções"
   },
   "llcCompanyStatus": {
     "showArchived": "Mostrar arquivadas",
@@ -9100,5 +9101,40 @@
     "loadFailed": "Não foi possível carregar os agendadores.",
     "toggleFailed": "Não foi possível alterar {name}.",
     "resetFailed": "Não foi possível voltar {name} ao padrão."
+  },
+  "llcRoles": {
+    "title": "Funções",
+    "subtitle": "Uma função sobrevive a quem a ocupa: permissões, fluxos, ferramentas e credenciais permanecem.",
+    "addRole": "Adicionar função",
+    "deleteRole": "Excluir função",
+    "noCompany": "Selecione uma empresa para ver as suas funções.",
+    "loading": "A carregar…",
+    "empty": "Ainda não há funções.",
+    "systemRole": "Sistema",
+    "holders": "Titulares",
+    "noHolders": "Ninguém ocupa esta função atualmente.",
+    "showPastHolders": "Mostrar titulares anteriores",
+    "pastHolder": "anterior",
+    "permissions": "Permissões",
+    "noPermissions": "Nenhuma permissão concedida.",
+    "workflows": "Fluxos de trabalho",
+    "noWorkflows": "Nenhum fluxo associado.",
+    "tools": "Ferramentas",
+    "noTools": "Nenhuma ferramenta associada.",
+    "credentials": "Credenciais",
+    "noCredentials": "Nenhuma credencial associada.",
+    "fieldName": "Nome",
+    "fieldDescription": "Descrição",
+    "cancel": "Cancelar",
+    "save": "Guardar",
+    "errorLoad": "Não foi possível carregar as funções.",
+    "errorLoadDetail": "Não foi possível carregar os detalhes da função.",
+    "errorCreate": "Não foi possível criar a função.",
+    "errorDelete": "Não foi possível excluir a função.",
+    "holderType": {
+      "agent": "Agente",
+      "user": "Utilizador",
+      "contact": "Contacto"
+    }
   }
 }

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -196,7 +196,8 @@
     "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it.",
     "systemHealth": "سسٹم کی صحت",
     "providerFallback": "فراہم کنندہ فال بیک",
-    "advancedControl": "ایڈوانسڈ کنٹرول"
+    "advancedControl": "ایڈوانسڈ کنٹرول",
+    "llcRoles": "کردار"
   },
   "llcCompanyStatus": {
     "showArchived": "محفوظ شدہ دکھائیں",
@@ -9100,5 +9101,40 @@
     "loadFailed": "شیڈولر لوڈ نہیں ہو سکے۔",
     "toggleFailed": "{name} تبدیل نہیں ہو سکا۔",
     "resetFailed": "{name} کو ڈیفالٹ پر واپس نہیں کیا جا سکا۔"
+  },
+  "llcRoles": {
+    "title": "کردار",
+    "subtitle": "کردار اپنے حامل سے زیادہ دیر قائم رہتا ہے — اس کی اجازتیں، ورک فلو، اوزار اور اسناد باقی رہتی ہیں۔",
+    "addRole": "کردار شامل کریں",
+    "deleteRole": "کردار حذف کریں",
+    "noCompany": "کردار دیکھنے کے لیے کمپنی منتخب کریں۔",
+    "loading": "لوڈ ہو رہا ہے…",
+    "empty": "ابھی کوئی کردار نہیں۔",
+    "systemRole": "سسٹم",
+    "holders": "حاملین",
+    "noHolders": "فی الحال کوئی یہ کردار نہیں رکھتا۔",
+    "showPastHolders": "سابقہ حاملین دکھائیں",
+    "pastHolder": "سابقہ",
+    "permissions": "اجازتیں",
+    "noPermissions": "کوئی اجازت نہیں دی گئی۔",
+    "workflows": "ورک فلو",
+    "noWorkflows": "کوئی ورک فلو منسلک نہیں۔",
+    "tools": "اوزار",
+    "noTools": "کوئی اوزار منسلک نہیں۔",
+    "credentials": "اسناد",
+    "noCredentials": "کوئی اسناد منسلک نہیں۔",
+    "fieldName": "نام",
+    "fieldDescription": "تفصیل",
+    "cancel": "منسوخ",
+    "save": "محفوظ کریں",
+    "errorLoad": "کردار لوڈ نہیں ہو سکے۔",
+    "errorLoadDetail": "کردار کی تفصیلات لوڈ نہیں ہو سکیں۔",
+    "errorCreate": "کردار نہیں بن سکا۔",
+    "errorDelete": "کردار حذف نہیں ہو سکا۔",
+    "holderType": {
+      "agent": "ایجنٹ",
+      "user": "صارف",
+      "contact": "رابطہ"
+    }
   }
 }

--- a/autobot-frontend/src/router/index.ts
+++ b/autobot-frontend/src/router/index.ts
@@ -1146,6 +1146,7 @@ export const routes: RouteRecordRaw[] = [
       { path: 'routines', name: 'llc-routines', component: () => import('@/views/llc/RoutinesView.vue'), props: true, meta: { title: 'Routines', requiresAuth: true } },
       { path: 'ceo-chat', name: 'llc-ceo-chat', component: () => import('@/views/llc/CeoChatView.vue'), props: true, meta: { title: 'CEO Chat', requiresAuth: true } },
       { path: 'activity', name: 'llc-activity', component: () => import('@/views/llc/ActivityFeedView.vue'), props: true, meta: { title: 'Activity', requiresAuth: true } },
+      { path: 'roles', name: 'llc-roles', component: () => import('@/views/llc/RolesView.vue'), props: true, meta: { title: 'Roles', requiresAuth: true } },
       { path: 'members', name: 'llc-members', component: () => import('@/views/llc/MembersView.vue'), props: true, meta: { title: 'Members', requiresAuth: true } },
       { path: 'portability', name: 'llc-company-portability', component: () => import('@/views/llc/CompanyPortabilityView.vue'), props: true, meta: { title: 'Portability', requiresAuth: true } },
       { path: 'secrets', name: 'llc-company-secrets', component: () => import('@/views/llc/SecretsView.vue'), props: true, meta: { title: 'Secrets', requiresAuth: true } },

--- a/autobot-frontend/src/views/llc/RolesView.vue
+++ b/autobot-frontend/src/views/llc/RolesView.vue
@@ -1,0 +1,498 @@
+<!-- Copyright 2025-2026 mrveiss -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- AutoBot - AI-Powered Automation Platform -->
+<!-- Author: mrveiss -->
+<!--
+  #14221 step 6: Company OS "Roles" tab.
+
+  Company-scoped child of LlcCompanyLayout (/llc/companies/:companyId/roles).
+
+  The layout follows the idea the whole issue is built on: a role is the durable
+  thing, and holders come and go. So the left column lists roles, and the right
+  column shows what a role *carries* — holders, permissions, workflows, tools
+  and credentials — with the holder panel showing past tenures as well as
+  current ones, because that history is what survives a departure.
+
+  Credentials are shown as ids only. The backend never returns a secret's value
+  or name through this surface, and this view must not invent a place to put
+  one.
+
+  Every mutation here is admin-only server-side (llc/services/authz.py). The UI
+  does not hide the controls based on a locally-guessed role: a client-side
+  guess that disagrees with the server produces a worse experience than a clear
+  403, and duplicating the rule invites the two copies to drift.
+-->
+<template>
+  <div class="roles-view">
+    <header class="roles-header">
+      <div>
+        <h2 class="roles-title">{{ t('llcRoles.title') }}</h2>
+        <p class="roles-subtitle">{{ t('llcRoles.subtitle') }}</p>
+      </div>
+      <BaseButton variant="primary" :disabled="!companyId" @click="openCreateModal">
+        {{ t('llcRoles.addRole') }}
+      </BaseButton>
+    </header>
+
+    <p v-if="!companyId" class="roles-state">{{ t('llcRoles.noCompany') }}</p>
+
+    <template v-else>
+      <ErrorBanner v-if="errorMessage" :message="errorMessage" class="roles-error" />
+
+      <p v-if="isLoading" class="roles-state">{{ t('llcRoles.loading') }}</p>
+
+      <BaseCard v-else-if="roles.length === 0" class="roles-empty">
+        {{ t('llcRoles.empty') }}
+      </BaseCard>
+
+      <div v-else class="roles-layout">
+        <BaseCard class="roles-list-card">
+          <ul class="roles-list">
+            <li v-for="role in roles" :key="role.id">
+              <button
+                type="button"
+                class="roles-list-item"
+                :class="{ 'is-active': role.id === selectedRoleId }"
+                @click="selectRole(role.id)"
+              >
+                <span class="roles-list-name">{{ role.name }}</span>
+                <BaseBadge v-if="role.is_system" variant="neutral">
+                  {{ t('llcRoles.systemRole') }}
+                </BaseBadge>
+              </button>
+            </li>
+          </ul>
+        </BaseCard>
+
+        <BaseCard v-if="selectedRole" class="roles-detail-card">
+          <header class="roles-detail-header">
+            <div>
+              <h3 class="roles-detail-name">{{ selectedRole.name }}</h3>
+              <p v-if="selectedRole.description" class="roles-detail-description">
+                {{ selectedRole.description }}
+              </p>
+            </div>
+            <BaseButton
+              variant="error"
+              :disabled="selectedRole.is_system"
+              @click="removeRole(selectedRole.id)"
+            >
+              {{ t('llcRoles.deleteRole') }}
+            </BaseButton>
+          </header>
+
+          <p v-if="isDetailLoading" class="roles-state">{{ t('llcRoles.loading') }}</p>
+
+          <template v-else>
+            <section class="roles-section">
+              <h4 class="roles-section-title">{{ t('llcRoles.holders') }}</h4>
+              <p v-if="holders.length === 0" class="roles-section-empty">
+                {{ t('llcRoles.noHolders') }}
+              </p>
+              <ul v-else class="roles-chip-list">
+                <li v-for="holder in holders" :key="holder.id" class="roles-chip">
+                  <BaseBadge :variant="holder.ended_at ? 'neutral' : 'success'">
+                    {{ t(`llcRoles.holderType.${holder.holder_type}`) }}
+                  </BaseBadge>
+                  <span class="roles-chip-id">{{ holder.holder_id }}</span>
+                  <span v-if="holder.ended_at" class="roles-chip-note">
+                    {{ t('llcRoles.pastHolder') }}
+                  </span>
+                </li>
+              </ul>
+              <label class="roles-toggle">
+                <input v-model="includePastHolders" type="checkbox" @change="loadDetail" />
+                {{ t('llcRoles.showPastHolders') }}
+              </label>
+            </section>
+
+            <section class="roles-section">
+              <h4 class="roles-section-title">{{ t('llcRoles.permissions') }}</h4>
+              <p v-if="permissions.length === 0" class="roles-section-empty">
+                {{ t('llcRoles.noPermissions') }}
+              </p>
+              <ul v-else class="roles-chip-list">
+                <li v-for="permission in permissions" :key="permission" class="roles-chip">
+                  {{ permission }}
+                </li>
+              </ul>
+            </section>
+
+            <section class="roles-section">
+              <h4 class="roles-section-title">{{ t('llcRoles.workflows') }}</h4>
+              <p v-if="workflows.length === 0" class="roles-section-empty">
+                {{ t('llcRoles.noWorkflows') }}
+              </p>
+              <ul v-else class="roles-chip-list">
+                <li v-for="workflow in workflows" :key="workflow" class="roles-chip">
+                  {{ workflow }}
+                </li>
+              </ul>
+            </section>
+
+            <section class="roles-section">
+              <h4 class="roles-section-title">{{ t('llcRoles.tools') }}</h4>
+              <p v-if="tools.length === 0" class="roles-section-empty">
+                {{ t('llcRoles.noTools') }}
+              </p>
+              <ul v-else class="roles-chip-list">
+                <li v-for="tool in tools" :key="tool" class="roles-chip">{{ tool }}</li>
+              </ul>
+            </section>
+
+            <section class="roles-section">
+              <h4 class="roles-section-title">{{ t('llcRoles.credentials') }}</h4>
+              <!-- Ids only. The backend never exposes a secret's value or name
+                   through this surface. -->
+              <p v-if="credentials.length === 0" class="roles-section-empty">
+                {{ t('llcRoles.noCredentials') }}
+              </p>
+              <ul v-else class="roles-chip-list">
+                <li v-for="secretId in credentials" :key="secretId" class="roles-chip">
+                  {{ secretId }}
+                </li>
+              </ul>
+            </section>
+          </template>
+        </BaseCard>
+      </div>
+    </template>
+
+    <BaseModal
+      v-model="isCreateModalOpen"
+      :title="t('llcRoles.addRole')"
+      :close-label="t('ui.modal.closeDialog')"
+      size="md"
+    >
+      <template #default>
+        <label class="roles-field">
+          <span>{{ t('llcRoles.fieldName') }}</span>
+          <input v-model="newRoleName" type="text" maxlength="100" />
+        </label>
+        <label class="roles-field">
+          <span>{{ t('llcRoles.fieldDescription') }}</span>
+          <textarea v-model="newRoleDescription" rows="3" maxlength="2000"></textarea>
+        </label>
+      </template>
+      <template #footer>
+        <BaseButton variant="secondary" @click="closeCreateModal">
+          {{ t('llcRoles.cancel') }}
+        </BaseButton>
+        <BaseButton variant="primary" :disabled="!newRoleName.trim()" @click="createRole">
+          {{ t('llcRoles.save') }}
+        </BaseButton>
+      </template>
+    </BaseModal>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch, onMounted } from 'vue'
+import { useRoute } from 'vue-router'
+import { useI18n } from 'vue-i18n'
+import { useApiClient } from '@/plugins/api'
+import { createLogger } from '@/utils/debugUtils'
+import BaseButton from '@/components/base/BaseButton.vue'
+import BaseCard from '@/components/base/BaseCard.vue'
+import BaseBadge from '@/components/base/BaseBadge.vue'
+import { BaseModal } from '@autobot/ui'
+import ErrorBanner from '@/components/base/ErrorBanner.vue'
+
+interface RoleRow {
+  id: string
+  company_id: string
+  name: string
+  description?: string | null
+  is_system: boolean
+}
+
+interface HolderRow {
+  id: string
+  role_id: string
+  holder_type: string
+  holder_id?: string | null
+  started_at?: string | null
+  ended_at?: string | null
+}
+
+const logger = createLogger('LlcRolesView')
+const { t } = useI18n()
+const route = useRoute()
+const api = useApiClient()
+
+const roles = ref<RoleRow[]>([])
+const holders = ref<HolderRow[]>([])
+const permissions = ref<string[]>([])
+const workflows = ref<string[]>([])
+const tools = ref<string[]>([])
+const credentials = ref<string[]>([])
+
+const selectedRoleId = ref<string | null>(null)
+const includePastHolders = ref(false)
+const isLoading = ref(false)
+const isDetailLoading = ref(false)
+const errorMessage = ref('')
+
+const isCreateModalOpen = ref(false)
+const newRoleName = ref('')
+const newRoleDescription = ref('')
+
+const companyId = computed(() => (route.params.companyId as string) || '')
+const selectedRole = computed(
+  () => roles.value.find((role) => role.id === selectedRoleId.value) ?? null,
+)
+
+function describeError(error: unknown, fallbackKey: string): string {
+  // Surface the server's reason rather than a generic message: a 403 from the
+  // admin gate and a 400 from validation need different actions from the user,
+  // and collapsing them into "something went wrong" hides which one happened.
+  //
+  // ApiClient throws a plain Error whose message is already `HTTP <status>:
+  // <detail>` — it extracts `detail` itself (utils/ApiClient.ts
+  // _extractErrorInfo). It is NOT axios-shaped, so reading
+  // `error.response.data.detail` would silently always miss and this function
+  // would return the generic fallback every time while looking like it worked.
+  const message = error instanceof Error ? error.message : ''
+  return message.length > 0 ? message : t(fallbackKey)
+}
+
+async function loadRoles(): Promise<void> {
+  if (!companyId.value) return
+  isLoading.value = true
+  errorMessage.value = ''
+  try {
+    const loaded = await api.get<RoleRow[]>(`/api/llc/roles/${companyId.value}`)
+    roles.value = Array.isArray(loaded) ? loaded : []
+    if (roles.value.length > 0 && !selectedRoleId.value) {
+      await selectRole(roles.value[0].id)
+    }
+  } catch (error) {
+    logger.error('Failed to load roles', error)
+    errorMessage.value = describeError(error, 'llcRoles.errorLoad')
+  } finally {
+    isLoading.value = false
+  }
+}
+
+async function loadDetail(): Promise<void> {
+  const roleId = selectedRoleId.value
+  if (!companyId.value || !roleId) return
+  isDetailLoading.value = true
+  errorMessage.value = ''
+  const base = `/api/llc/roles/${companyId.value}/${roleId}`
+  try {
+    // Fetched together so a slow panel cannot leave the others showing a
+    // previous role's data — a partially-updated detail pane reads as fact.
+    const [loadedHolders, loadedPermissions, loadedWorkflows, loadedTools, loadedCredentials] =
+      await Promise.all([
+        api.get<HolderRow[]>(`${base}/holders?include_past=${includePastHolders.value}`),
+        api.get<string[]>(`${base}/permissions`),
+        api.get<string[]>(`${base}/workflows`),
+        api.get<string[]>(`${base}/tools`),
+        api.get<string[]>(`${base}/credentials`),
+      ])
+    holders.value = Array.isArray(loadedHolders) ? loadedHolders : []
+    permissions.value = Array.isArray(loadedPermissions) ? loadedPermissions : []
+    workflows.value = Array.isArray(loadedWorkflows) ? loadedWorkflows : []
+    tools.value = Array.isArray(loadedTools) ? loadedTools : []
+    credentials.value = Array.isArray(loadedCredentials) ? loadedCredentials : []
+  } catch (error) {
+    logger.error('Failed to load role detail', error)
+    errorMessage.value = describeError(error, 'llcRoles.errorLoadDetail')
+  } finally {
+    isDetailLoading.value = false
+  }
+}
+
+async function selectRole(roleId: string): Promise<void> {
+  selectedRoleId.value = roleId
+  await loadDetail()
+}
+
+function openCreateModal(): void {
+  newRoleName.value = ''
+  newRoleDescription.value = ''
+  isCreateModalOpen.value = true
+}
+
+function closeCreateModal(): void {
+  isCreateModalOpen.value = false
+}
+
+async function createRole(): Promise<void> {
+  if (!companyId.value || !newRoleName.value.trim()) return
+  try {
+    await api.post(`/api/llc/roles/${companyId.value}`, {
+      name: newRoleName.value.trim(),
+      description: newRoleDescription.value.trim() || null,
+    })
+    closeCreateModal()
+    await loadRoles()
+  } catch (error) {
+    logger.error('Failed to create role', error)
+    errorMessage.value = describeError(error, 'llcRoles.errorCreate')
+  }
+}
+
+async function removeRole(roleId: string): Promise<void> {
+  if (!companyId.value) return
+  try {
+    await api.delete(`/api/llc/roles/${companyId.value}/${roleId}`)
+    if (selectedRoleId.value === roleId) selectedRoleId.value = null
+    await loadRoles()
+  } catch (error) {
+    logger.error('Failed to delete role', error)
+    errorMessage.value = describeError(error, 'llcRoles.errorDelete')
+  }
+}
+
+watch(companyId, async () => {
+  selectedRoleId.value = null
+  await loadRoles()
+})
+
+onMounted(loadRoles)
+</script>
+
+<style scoped>
+.roles-view {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-lg);
+}
+
+.roles-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--spacing-md);
+}
+
+.roles-title {
+  margin: 0;
+  font-size: var(--font-size-xl);
+  color: var(--color-text-primary);
+}
+
+.roles-subtitle {
+  margin: var(--spacing-xs) 0 0;
+  color: var(--color-text-secondary);
+}
+
+.roles-state,
+.roles-section-empty {
+  color: var(--color-text-secondary);
+}
+
+.roles-layout {
+  display: grid;
+  grid-template-columns: minmax(12rem, 18rem) 1fr;
+  gap: var(--spacing-lg);
+  align-items: start;
+}
+
+.roles-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.roles-list-item {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-sm);
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--color-text-primary);
+  cursor: pointer;
+  text-align: start;
+}
+
+.roles-list-item:hover,
+.roles-list-item.is-active {
+  background: var(--color-surface-hover);
+}
+
+.roles-detail-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--spacing-md);
+  margin-bottom: var(--spacing-md);
+}
+
+.roles-detail-name {
+  margin: 0;
+  font-size: var(--font-size-lg);
+  color: var(--color-text-primary);
+}
+
+.roles-detail-description {
+  margin: var(--spacing-xs) 0 0;
+  color: var(--color-text-secondary);
+}
+
+.roles-section {
+  margin-top: var(--spacing-md);
+}
+
+.roles-section-title {
+  margin: 0 0 var(--spacing-xs);
+  font-size: var(--font-size-md);
+  color: var(--color-text-primary);
+}
+
+.roles-chip-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-xs);
+}
+
+.roles-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  padding: var(--spacing-xs) var(--spacing-sm);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface-hover);
+  color: var(--color-text-primary);
+  font-family: var(--font-family-mono, monospace);
+  font-size: var(--font-size-sm);
+}
+
+.roles-chip-note {
+  color: var(--color-text-secondary);
+  font-family: var(--font-family-base, inherit);
+}
+
+.roles-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  margin-top: var(--spacing-sm);
+  color: var(--color-text-secondary);
+}
+
+.roles-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+  margin-bottom: var(--spacing-md);
+}
+
+@media (max-width: 48rem) {
+  .roles-layout {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/autobot-frontend/src/views/llc/__tests__/RolesView.test.ts
+++ b/autobot-frontend/src/views/llc/__tests__/RolesView.test.ts
@@ -1,0 +1,188 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// #14221 step 6: the Company OS Roles tab.
+//
+// These tests assert *rendered content*, not that the component mounted. A
+// mount-only test passes while the view renders an empty shell, which is how a
+// data-wiring bug survives a green suite.
+//
+// Two of them exist because I made the mistakes they guard:
+//
+//  * `api.get<T>()` returns T directly — there is no axios-style `.data`
+//    wrapper. My first draft read `response.data`, which is `undefined` for
+//    every call (the #14062 / #13993 defect shape: reading a key the client
+//    never returns). `renders role names from the API response` fails against
+//    that draft.
+//  * ApiClient throws a plain Error whose message already carries the server's
+//    detail. My first draft read `error.response.data.detail`, so every failure
+//    silently showed the generic fallback while looking correct.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import en from '@/i18n/locales/en.json'
+
+const get = vi.fn()
+const post = vi.fn()
+const del = vi.fn()
+
+vi.mock('@/plugins/api', () => ({
+  useApiClient: () => ({ get, post, delete: del }),
+}))
+
+vi.mock('@/utils/debugUtils', () => ({
+  createLogger: () => ({ warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() }),
+}))
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ params: { companyId: 'c1' } }),
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+import RolesView from '../RolesView.vue'
+
+const ROLE = {
+  id: 'r1',
+  company_id: 'c1',
+  name: 'Head of Sales',
+  description: 'Owns the pipeline',
+  is_system: false,
+}
+
+const SYSTEM_ROLE = { id: 'r2', company_id: 'c1', name: 'platform-admin', is_system: true }
+
+function respond(overrides: Record<string, unknown> = {}): void {
+  get.mockImplementation((url: string) => {
+    if (url.includes('/holders')) return Promise.resolve(overrides.holders ?? [])
+    if (url.includes('/permissions')) return Promise.resolve(overrides.permissions ?? [])
+    if (url.includes('/workflows')) return Promise.resolve(overrides.workflows ?? [])
+    if (url.includes('/tools')) return Promise.resolve(overrides.tools ?? [])
+    if (url.includes('/credentials')) return Promise.resolve(overrides.credentials ?? [])
+    return Promise.resolve(overrides.roles ?? [ROLE])
+  })
+}
+
+async function mountView() {
+  const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } })
+  const wrapper = mount(RolesView, {
+    global: { plugins: [i18n], stubs: { BaseModal: true } },
+  })
+  await flushPromises()
+  return wrapper
+}
+
+describe('RolesView (#14221 step 6)', () => {
+  beforeEach(() => {
+    get.mockReset()
+    post.mockReset()
+    del.mockReset()
+  })
+
+  it('renders role names from the API response', async () => {
+    // Guards the `.data` mistake: with `response.data` this renders nothing.
+    respond({ roles: [ROLE, SYSTEM_ROLE] })
+    const wrapper = await mountView()
+
+    expect(wrapper.text()).toContain('Head of Sales')
+    expect(wrapper.text()).toContain('platform-admin')
+  })
+
+  it('renders what the selected role carries, not just that it loaded', async () => {
+    respond({
+      permissions: ['knowledge.read'],
+      workflows: ['wf-quarterly'],
+      tools: ['llc.create_work_item'],
+    })
+    const wrapper = await mountView()
+
+    const text = wrapper.text()
+    expect(text).toContain('knowledge.read')
+    expect(text).toContain('wf-quarterly')
+    expect(text).toContain('llc.create_work_item')
+  })
+
+  it('shows a past holder as past, so departure history stays visible', async () => {
+    // The whole point of the issue: a tenure that ended is still a fact.
+    respond({
+      holders: [
+        {
+          id: 'a1',
+          role_id: 'r1',
+          holder_type: 'user',
+          holder_id: 'u-9',
+          ended_at: '2026-01-01T00:00:00Z',
+        },
+      ],
+    })
+    const wrapper = await mountView()
+
+    expect(wrapper.text()).toContain('u-9')
+    expect(wrapper.text()).toContain(en.llcRoles.pastHolder)
+  })
+
+  it('requests only current holders unless past ones are asked for', async () => {
+    respond()
+    await mountView()
+
+    const holderCalls = get.mock.calls.map((c) => String(c[0])).filter((u) => u.includes('/holders'))
+    expect(holderCalls).toHaveLength(1)
+    expect(holderCalls[0]).toContain('include_past=false')
+  })
+
+  it('renders credentials as ids only', async () => {
+    // The backend never exposes a secret's value or name through this surface;
+    // this asserts the view does not invent a place to put one.
+    respond({ credentials: ['11111111-2222-3333-4444-555555555555'] })
+    const wrapper = await mountView()
+
+    expect(wrapper.text()).toContain('11111111-2222-3333-4444-555555555555')
+  })
+
+  it("surfaces the server's reason for a refusal, not a generic message", async () => {
+    // ApiClient throws `Error('HTTP 403: <detail>')`. Reading an axios-shaped
+    // `error.response.data.detail` would show the generic fallback instead —
+    // hiding whether the user was refused or sent something invalid.
+    get.mockRejectedValue(
+      new Error("HTTP 403: membership role 'member' may not perform this change"),
+    )
+    const wrapper = await mountView()
+
+    expect(wrapper.text()).toContain('may not perform this change')
+    expect(wrapper.text()).not.toContain(en.llcRoles.errorLoad)
+  })
+
+  it('falls back to a translated message when the error carries no detail', async () => {
+    get.mockRejectedValue({})
+    const wrapper = await mountView()
+
+    expect(wrapper.text()).toContain(en.llcRoles.errorLoad)
+  })
+
+  it('reloads the list after creating a role', async () => {
+    respond()
+    post.mockResolvedValue(undefined)
+    const wrapper = await mountView()
+    const vm = wrapper.vm as unknown as {
+      newRoleName: string
+      createRole: () => Promise<void>
+    }
+
+    const before = get.mock.calls.length
+    vm.newRoleName = 'SRE'
+    await vm.createRole()
+    await flushPromises()
+
+    expect(post).toHaveBeenCalledWith('/api/llc/roles/c1', {
+      name: 'SRE',
+      description: null,
+    })
+    expect(get.mock.calls.length).toBeGreaterThan(before)
+  })
+
+  it('shows the empty state rather than a blank panel when there are no roles', async () => {
+    respond({ roles: [] })
+    const wrapper = await mountView()
+
+    expect(wrapper.text()).toContain(en.llcRoles.empty)
+  })
+})

--- a/autobot-frontend/src/views/llc/__tests__/RolesView.test.ts
+++ b/autobot-frontend/src/views/llc/__tests__/RolesView.test.ts
@@ -185,4 +185,108 @@ describe('RolesView (#14221 step 6)', () => {
 
     expect(wrapper.text()).toContain(en.llcRoles.empty)
   })
+
+  it('requests past holders when the toggle is on', async () => {
+    respond()
+    const wrapper = await mountView()
+    const vm = wrapper.vm as unknown as {
+      includePastHolders: boolean
+      loadDetail: () => Promise<void>
+    }
+
+    vm.includePastHolders = true
+    await vm.loadDetail()
+    await flushPromises()
+
+    const holderCalls = get.mock.calls.map((c) => String(c[0])).filter((u) => u.includes('/holders'))
+    expect(holderCalls.at(-1)).toContain('include_past=true')
+  })
+
+  it('opens and closes the create modal', async () => {
+    respond()
+    const wrapper = await mountView()
+    const vm = wrapper.vm as unknown as {
+      isCreateModalOpen: boolean
+      newRoleName: string
+      openCreateModal: () => void
+      closeCreateModal: () => void
+    }
+
+    vm.newRoleName = 'left over from last time'
+    vm.openCreateModal()
+    expect(vm.isCreateModalOpen).toBe(true)
+    // Reopening must not present the previous attempt's text as a new draft.
+    expect(vm.newRoleName).toBe('')
+
+    vm.closeCreateModal()
+    expect(vm.isCreateModalOpen).toBe(false)
+  })
+
+  it('surfaces the refusal when creating a role is not permitted', async () => {
+    respond()
+    post.mockRejectedValue(new Error("HTTP 403: membership role 'member' may not perform this change"))
+    const wrapper = await mountView()
+    const vm = wrapper.vm as unknown as {
+      newRoleName: string
+      createRole: () => Promise<void>
+    }
+
+    vm.newRoleName = 'SRE'
+    await vm.createRole()
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('may not perform this change')
+  })
+
+  it('deletes a role and reloads the list', async () => {
+    respond()
+    del.mockResolvedValue(undefined)
+    const wrapper = await mountView()
+    const vm = wrapper.vm as unknown as {
+      selectedRoleId: string | null
+      removeRole: (id: string) => Promise<void>
+    }
+
+    // The reload must see the role gone. Leaving it in the mock response would
+    // model an impossible state, and the view would legitimately re-select it.
+    respond({ roles: [] })
+    const before = get.mock.calls.length
+    await vm.removeRole('r1')
+    await flushPromises()
+
+    expect(del).toHaveBeenCalledWith('/api/llc/roles/c1/r1')
+    expect(get.mock.calls.length).toBeGreaterThan(before)
+    // Selection must not survive the row it pointed at, or the detail pane
+    // renders a role that no longer exists.
+    expect(vm.selectedRoleId).toBeNull()
+    expect(wrapper.text()).toContain(en.llcRoles.empty)
+  })
+
+  it('re-selects a remaining role after a delete', async () => {
+    respond()
+    del.mockResolvedValue(undefined)
+    const wrapper = await mountView()
+    const vm = wrapper.vm as unknown as {
+      selectedRoleId: string | null
+      removeRole: (id: string) => Promise<void>
+    }
+
+    respond({ roles: [SYSTEM_ROLE] })
+    await vm.removeRole('r1')
+    await flushPromises()
+
+    expect(vm.selectedRoleId).toBe('r2')
+  })
+
+  it('surfaces the reason a delete was refused', async () => {
+    respond()
+    del.mockRejectedValue(new Error('HTTP 400: a system role cannot be deleted'))
+    const wrapper = await mountView()
+    const vm = wrapper.vm as unknown as { removeRole: (id: string) => Promise<void> }
+
+    await vm.removeRole('r1')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('system role cannot be deleted')
+  })
 })


### PR DESCRIPTION
Part of #14221 (step 6 of 6). **Stacked on #14357** — it calls the tools/credentials routes that PR adds.

## Thinking Path

The layout follows the idea the whole issue rests on: **a role is the durable thing, and holders
come and go.** So the left column lists roles; the right shows what a role *carries* — holders,
permissions, workflows, tools, credentials. The holder panel can show **past tenures** as well as
current, because that history is exactly what survives a departure and is the reason occupancy got
its own table rather than a column.

**Extension, not replacement.** All 17 existing sidebar entries stay; Roles is the 18th, placed next
to Members and Org Chart where people and structure already live.

## What Changed

- `RolesView.vue` — role list + detail panels for all five attachment kinds.
- Route `llc-roles` at `/llc/companies/:companyId/roles`, sidebar entry, and `llcRoles` +
  `nav.llcRoles` in **all 11 locales** (29 keys each, including the 4 RTL locales).

## Deliberate Choices

**Credentials render as ids only.** The backend never exposes a secret's value or name through this
surface, and the view must not invent a place to put one.

**Mutation controls are not hidden by a client-side role guess.** Every mutation is admin-gated
server-side. A local guess that disagrees with the server gives a worse experience than a clear 403,
and duplicating the rule invites the two copies to drift apart.

**Server error detail is surfaced, not swallowed.** A 403 from the admin gate and a 400 from
validation need different actions from the user; collapsing both into "something went wrong" hides
which one happened.

**The five detail calls are issued together.** Loading them independently would let a slow panel
keep showing the previous role's data next to the new role's — a partially-updated pane reads as
fact.

## Verification, and its limits

- **Locale key parity checked programmatically**: all 11 locales carry the same 29 keys, the same
  `holderType` members, and `nav.llcRoles`. Parity is asserted rather than eyeballed because a
  missing key renders as a raw key string in production.
- **oxlint clean** on the new view and the sidebar.
- Every path the view calls exists in the generated OpenAPI schema — verified against the
  `app.openapi()` dump (12 `/api/llc/roles` paths, tools and credentials included).

**What I could not verify locally, stated plainly:** eslint and `vue-tsc` cannot run from a git
worktree here — `node_modules` lives in the main tree, so eslint fails to resolve its config and
vue-tsc cannot read `@vue/tsconfig/tsconfig.dom.json`, producing cascading false errors in unrelated
files. I did not install anything to work around it. **CI is the authority for both**, and I will
treat a failure there as real rather than environmental.

## Model Used

Claude Opus 5 (1M context)
