### PR TITLE
fix(tool-sdk): autobot_shared.tool_sdk importable by its own path, without forking the registry singleton (#14373)

### DIFF
--- a/autobot-backend/api/image_generation.py
+++ b/autobot-backend/api/image_generation.py
@@ -105,7 +105,11 @@ async def generate_image(
     plugin is not loaded.
     """
     try:
-        from tool_sdk.registry import get_tool_registry
+        # Imported by the fully-qualified path (#14373): the module-level
+        # get_tool_registry() singleton must be reached through exactly one
+        # import identity, or this call would see an independently empty
+        # registry instead of the real one.
+        from autobot_shared.tool_sdk.registry import get_tool_registry  # noqa: PLC0415
 
         registry = get_tool_registry()
         input_data: Dict[str, Any] = {"prompt": request.prompt, "provider": request.provider}

--- a/autobot-backend/llc/services/role_tool.py
+++ b/autobot-backend/llc/services/role_tool.py
@@ -79,19 +79,22 @@ class RoleToolService(LLCServiceBase):
         if not cleaned:
             raise ValueError("a tool name is required")
 
-        # Imported lazily, and by the top-level ``tool_sdk`` path rather than
-        # ``autobot_shared.tool_sdk``. Both matter:
+        # Imported lazily, by the fully-qualified ``autobot_shared.tool_sdk``
+        # path (#14373). Both matter:
         #
         # * Lazily, because a module-level import runs while the feature
-        #   routers load — before ``autobot_shared/`` is on ``sys.path`` — and
-        #   an ImportError there takes the whole LLC router down, not just this
-        #   service. Every other consumer imports it the same way
-        #   (``tools/tool_registry.py``, ``api/image_generation.py``).
-        # * By the top-level path, because ``get_tool_registry()`` returns a
-        #   module-level singleton. Importing the same file under a second
-        #   module identity would yield a *second, empty* registry, so every
-        #   tool would look unregistered while the real registry was fine.
-        from tool_sdk.registry import get_tool_registry  # noqa: PLC0415
+        #   routers load, and an ImportError there takes the whole LLC router
+        #   down, not just this service. Every other consumer imports it the
+        #   same way (``tools/tool_registry.py``, ``api/image_generation.py``).
+        # * Fully-qualified, not the bare top-level ``tool_sdk`` path, because
+        #   ``get_tool_registry()`` returns a module-level singleton stored on
+        #   ``autobot_shared/tool_sdk/registry.py``. Reaching that file under a
+        #   second module identity (the bare name) would load a *second* copy
+        #   of it with its own, independently empty, registry — every tool
+        #   would look unregistered while the real registry was fine. The bare
+        #   ``tool_sdk`` path is exactly what caused the original
+        #   ``ModuleNotFoundError`` here (#14373) and is not a supported alias.
+        from autobot_shared.tool_sdk.registry import get_tool_registry  # noqa: PLC0415
 
         known = {meta.name for meta in get_tool_registry().list_tools()}
         if not known:

--- a/autobot-backend/llc/tests/test_role_tools.py
+++ b/autobot-backend/llc/tests/test_role_tools.py
@@ -24,6 +24,11 @@ import pytest_asyncio
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
+# Fully-qualified, matching RoleToolService._require_registered_tool (#14373):
+# the bare ``tool_sdk`` path would resolve to a *different* singleton object
+# than the one the service under test uses, so patching it here would be a
+# no-op against production behaviour.
+from autobot_shared.tool_sdk.registry import get_tool_registry
 from llc.models.enums import MembershipRole
 from llc.models.membership import LLCCompanyMembership
 from llc.models.role_tool import LLCRoleTool
@@ -33,12 +38,6 @@ from llc.services.role_tool import RoleToolService, ToolRegistryUnavailable
 
 # Registers the SQLite compile shims for postgresql.JSONB / postgresql.UUID.
 from llc.tests import _e2e_harness as harness
-
-# Fully-qualified, matching RoleToolService._require_registered_tool (#14373):
-# the bare ``tool_sdk`` path would resolve to a *different* singleton object
-# than the one the service under test uses, so patching it here would be a
-# no-op against production behaviour.
-from autobot_shared.tool_sdk.registry import get_tool_registry
 from user_management.models.base import Base
 from user_management.models.role import Role
 

--- a/autobot-backend/llc/tests/test_role_tools.py
+++ b/autobot-backend/llc/tests/test_role_tools.py
@@ -33,7 +33,12 @@ from llc.services.role_tool import RoleToolService, ToolRegistryUnavailable
 
 # Registers the SQLite compile shims for postgresql.JSONB / postgresql.UUID.
 from llc.tests import _e2e_harness as harness
-from tool_sdk.registry import get_tool_registry
+
+# Fully-qualified, matching RoleToolService._require_registered_tool (#14373):
+# the bare ``tool_sdk`` path would resolve to a *different* singleton object
+# than the one the service under test uses, so patching it here would be a
+# no-op against production behaviour.
+from autobot_shared.tool_sdk.registry import get_tool_registry
 from user_management.models.base import Base
 from user_management.models.role import Role
 

--- a/autobot-backend/tools/tool_registry.py
+++ b/autobot-backend/tools/tool_registry.py
@@ -781,8 +781,13 @@ class ToolRegistry:
             is not in the SDK registry.
         """
         try:
-            from tool_sdk.registry import ToolNotFoundError  # noqa: PLC0415
-            from tool_sdk.registry import get_tool_registry as _get_sdk_registry  # noqa: PLC0415
+            # Imported by the fully-qualified path (#14373), not the bare
+            # ``tool_sdk`` name: get_tool_registry() returns a module-level
+            # singleton, and reaching it through a second import identity
+            # would return an independently empty registry instead of the
+            # real one.
+            from autobot_shared.tool_sdk.registry import ToolNotFoundError  # noqa: PLC0415
+            from autobot_shared.tool_sdk.registry import get_tool_registry as _get_sdk_registry  # noqa: PLC0415
 
             registry = _get_sdk_registry()
             # Probe registry without instantiating — raises ToolNotFoundError if absent
@@ -792,7 +797,7 @@ class ToolRegistry:
                 return None
 
             # Tool is registered; execute via the registry (handles validation + timing)
-            from tool_sdk.base import ToolPermission
+            from autobot_shared.tool_sdk.base import ToolPermission  # noqa: PLC0415
 
             result = await registry.execute(
                 tool_name,

--- a/autobot_shared/tool_sdk/__init__.py
+++ b/autobot_shared/tool_sdk/__init__.py
@@ -11,8 +11,8 @@ auto-discoverable metadata.
 
 Quick start::
 
-    from tool_sdk import BaseTool, ToolMetadata, ToolPermission, ToolResult
-    from tool_sdk import ToolSDKRegistry, get_tool_registry
+    from autobot_shared.tool_sdk import BaseTool, ToolMetadata, ToolPermission, ToolResult
+    from autobot_shared.tool_sdk import ToolSDKRegistry, get_tool_registry
 
 Public API
 ----------
@@ -23,16 +23,25 @@ ToolResult       — Dataclass: success, data, error, duration_ms.
 ToolInputError   — Raised by validate_input() on bad input.
 ToolSDKRegistry  — Registry: register, get, list_tools, execute, to_openapi_spec.
 get_tool_registry — Returns the module-level singleton ToolSDKRegistry.
+
+Note (#14373): the internal imports below are relative (``from .base import``)
+rather than a bare ``from tool_sdk.base import``. ``get_tool_registry()``
+returns a module-level singleton stored on this package's ``registry``
+submodule; if that submodule were ever loaded under a second identity (e.g.
+a bare top-level ``tool_sdk.registry`` alongside this package's
+``autobot_shared.tool_sdk.registry``), it would carry its own, independently
+empty, registry instance. Only ``autobot_shared.tool_sdk`` is a supported
+import path — a bare ``tool_sdk`` alias is deliberately not provided.
 """
 
-from tool_sdk.base import (
+from .base import (
     BaseTool,
     ToolInputError,
     ToolMetadata,
     ToolPermission,
     ToolResult,
 )
-from tool_sdk.registry import (
+from .registry import (
     PermissionDeniedError,
     ToolNotFoundError,
     ToolSDKRegistry,

--- a/autobot_shared/tool_sdk/base_test.py
+++ b/autobot_shared/tool_sdk/base_test.py
@@ -10,7 +10,7 @@ using the canonical API (ToolMetadata + JSON Schema input_schema).
 
 import pytest
 
-from tool_sdk.base import BaseTool, ToolMetadata, ToolPermission, ToolResult
+from autobot_shared.tool_sdk.base import BaseTool, ToolMetadata, ToolPermission, ToolResult
 
 
 class _EchoTool(BaseTool):
@@ -78,7 +78,7 @@ class TestBaseTool:
         assert tool.input_schema["properties"]["message"]["type"] == "string"
 
     def test_input_validation_rejects_missing_field(self) -> None:
-        from tool_sdk.base import ToolInputError
+        from autobot_shared.tool_sdk.base import ToolInputError  # noqa: PLC0415
 
         tool = _EchoTool()
         with pytest.raises(ToolInputError):

--- a/autobot_shared/tool_sdk/import_identity_test.py
+++ b/autobot_shared/tool_sdk/import_identity_test.py
@@ -1,0 +1,158 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Import-identity guard for the tool SDK (#14373).
+
+``autobot_shared/tool_sdk/``'s internals used to import each other by a bare
+top-level name (``from tool_sdk.base import ...``), which raised
+``ModuleNotFoundError: No module named 'tool_sdk'`` the moment the package was
+reached through its real, importable path — ``autobot_shared.tool_sdk`` — as
+it was when an LLC service added a module-level import and took the whole
+feature router down.
+
+The bare name is also dangerous in a way an ImportError is not: reached
+through a namespace-package fallback (this suite's own ``pytest.ini`` puts
+``autobot_shared/`` itself on ``sys.path`` for unrelated legacy reasons), it
+loads the SAME files a second time under a SECOND module identity, and
+``get_tool_registry()``'s module-level singleton is per-identity. A tool
+registered through one identity is invisible through the other, and every
+lookup silently reports "unknown tool" while the real registry is healthy —
+far harder to notice than an ImportError.
+
+The fix converts every internal import to relative (``from .base import``)
+and every call site in the repository from the bare ``tool_sdk`` name to the
+fully-qualified ``autobot_shared.tool_sdk`` path. The bare name is not kept as
+a supported alias. These tests guard both halves of that: nothing may
+reintroduce the bare import (static scan), and the singleton stays reachable
+through exactly one identity even in a clean process shaped like production,
+not like this test suite (subprocess).
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, List
+
+from autobot_shared.paths import project_root
+from autobot_shared.tool_sdk import get_tool_registry as reexported_get_tool_registry
+from autobot_shared.tool_sdk.registry import get_tool_registry
+
+# Directories that never hold first-party source under review here: other
+# agents' worktrees, VCS internals, caches, and vendored/build output. Mirrors
+# pytest.ini's `norecursedirs` plus this repo's own worktree convention.
+_EXCLUDED_DIR_NAMES = {
+    ".git",
+    ".worktrees",
+    ".claude",
+    "__pycache__",
+    "node_modules",
+    ".venv",
+    "venv",
+    "dist",
+    "build",
+}
+
+
+def _iter_repo_python_files(root: Path):
+    """Yield every first-party ``.py`` file under *root*, skipping non-source dirs.
+
+    Checks exclusions against the path *relative to root*, not the absolute
+    path: this repo's whole workflow runs from `.worktrees/<name>/` checkouts,
+    so an absolute-path check would match `.worktrees` on every single file
+    here and exclude the entire tree, silently turning the scan into a no-op
+    that always reports zero offenders.
+    """
+    for path in root.rglob("*.py"):
+        if _EXCLUDED_DIR_NAMES.intersection(path.relative_to(root).parts):
+            continue
+        yield path
+
+
+def _bare_tool_sdk_imports(path: Path) -> List[str]:
+    """Return every bare ``tool_sdk`` import statement found in *path*.
+
+    Parses with ``ast`` rather than matching text, so a comment or docstring
+    mentioning ``tool_sdk`` — this package's own module docstrings do, by
+    necessity, explaining exactly why the bare form is unsupported — is never
+    mistaken for an import statement.
+    """
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except SyntaxError:
+        return []
+
+    hits: List[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "tool_sdk" or alias.name.startswith("tool_sdk."):
+                    hits.append(alias.name)
+        elif isinstance(node, ast.ImportFrom) and node.level == 0:
+            module = node.module or ""
+            if module == "tool_sdk" or module.startswith("tool_sdk."):
+                hits.append(module)
+    return hits
+
+
+class TestNoBareTopLevelImport:
+    """Regression guard: nothing in the repo may import the bare ``tool_sdk`` name."""
+
+    def test_no_bare_tool_sdk_imports_in_repo(self) -> None:
+        offenders: Dict[str, List[str]] = {}
+        for path in _iter_repo_python_files(project_root()):
+            hits = _bare_tool_sdk_imports(path)
+            if hits:
+                offenders[str(path)] = hits
+
+        assert not offenders, (
+            "Bare `tool_sdk` imports reintroduce the #14373 dual-identity "
+            f"hazard — use `autobot_shared.tool_sdk` instead: {offenders}"
+        )
+
+
+class TestSingleImportIdentity:
+    """The registry singleton is reachable through exactly one module identity."""
+
+    def test_singleton_identical_via_module_and_package_reexport(self) -> None:
+        """`autobot_shared.tool_sdk.get_tool_registry` re-exports the exact same
+        function object as `autobot_shared.tool_sdk.registry.get_tool_registry`
+        — not merely an equal one — because `__init__.py` now imports it with a
+        relative (`from .registry import ...`), which binds a second name to the
+        same module rather than loading a second copy.
+        """
+        assert reexported_get_tool_registry is get_tool_registry
+        assert reexported_get_tool_registry() is get_tool_registry()
+
+    def test_clean_process_shaped_like_production_has_no_bare_identity(self) -> None:
+        """Reproduces production's import shape: repo root on `PYTHONPATH`, NOT
+        `autobot_shared/` itself (this suite's `pytest.ini` adds the latter for
+        unrelated legacy bare-name tests — see its own comment). That gap is
+        exactly what raised `ModuleNotFoundError: No module named 'tool_sdk'`
+        for the LLC router in PR #14357 (#14373), so the regression check has to
+        run in a process that does not have pytest's convenience path.
+        """
+        root = project_root()
+        script = (
+            "import sys\n"
+            "import autobot_shared.tool_sdk.registry as m\n"
+            "import autobot_shared.tool_sdk as pkg\n"
+            "assert pkg.get_tool_registry() is m.get_tool_registry(), 'registry forked'\n"
+            "bare = [n for n in sys.modules if n == 'tool_sdk' or n.startswith('tool_sdk.')]\n"
+            "assert not bare, f'bare tool_sdk identity leaked into sys.modules: {bare}'\n"
+            "print('OK')\n"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            cwd=str(root),
+            env={**os.environ, "PYTHONPATH": str(root)},
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == "OK"

--- a/autobot_shared/tool_sdk/registry.py
+++ b/autobot_shared/tool_sdk/registry.py
@@ -12,7 +12,7 @@ OpenAPI spec generation for every BaseTool subclass registered with it.
 import logging
 from typing import Dict, List, Type
 
-from tool_sdk.base import (
+from .base import (
     BaseTool,
     ToolInputError,
     ToolMetadata,

--- a/autobot_shared/tool_sdk/registry_test.py
+++ b/autobot_shared/tool_sdk/registry_test.py
@@ -10,9 +10,9 @@ singleton behaviour, and the get_tool_sdk_registry alias.
 
 import pytest
 
-from tool_sdk import get_tool_sdk_registry
-from tool_sdk.base import BaseTool, ToolMetadata, ToolPermission, ToolResult
-from tool_sdk.registry import (
+from autobot_shared.tool_sdk import get_tool_sdk_registry
+from autobot_shared.tool_sdk.base import BaseTool, ToolMetadata, ToolPermission, ToolResult
+from autobot_shared.tool_sdk.registry import (
     PermissionDeniedError,
     ToolNotFoundError,
     ToolSDKRegistry,

--- a/autobot_shared/tool_sdk/tool_sdk_test.py
+++ b/autobot_shared/tool_sdk/tool_sdk_test.py
@@ -11,7 +11,7 @@ Run with:
 
 import pytest
 
-from tool_sdk.base import (
+from autobot_shared.tool_sdk.base import (
     BaseTool,
     ToolInputError,
     ToolMetadata,
@@ -19,7 +19,7 @@ from tool_sdk.base import (
     ToolResult,
     _validate_against_schema,
 )
-from tool_sdk.registry import (
+from autobot_shared.tool_sdk.registry import (
     PermissionDeniedError,
     ToolNotFoundError,
     ToolSDKRegistry,

--- a/plugins/core-plugins/image-generation-plugin/main.py
+++ b/plugins/core-plugins/image-generation-plugin/main.py
@@ -21,7 +21,11 @@ import os
 from typing import Optional
 
 from plugin_sdk.base import BasePlugin, PluginManifest
-from tool_sdk.registry import get_tool_registry
+
+# Fully-qualified (#14373): the bare `tool_sdk` path is not guaranteed to be
+# importable at plugin-load time and, where it is, resolves to a second
+# module identity with its own, independently empty, registry singleton.
+from autobot_shared.tool_sdk.registry import get_tool_registry
 
 from .tools import GenerateImageTool
 

--- a/plugins/core-plugins/image-generation-plugin/tools/generate_image.py
+++ b/plugins/core-plugins/image-generation-plugin/tools/generate_image.py
@@ -15,7 +15,8 @@ import logging
 import os
 from typing import Any, Dict
 
-from tool_sdk.base import BaseTool, ToolMetadata, ToolPermission, ToolResult
+# Fully-qualified (#14373) — see plugins/core-plugins/image-generation-plugin/main.py.
+from autobot_shared.tool_sdk.base import BaseTool, ToolMetadata, ToolPermission, ToolResult
 
 logger = logging.getLogger(__name__)
 

--- a/plugins/core-plugins/video-generation-plugin/main.py
+++ b/plugins/core-plugins/video-generation-plugin/main.py
@@ -21,7 +21,11 @@ import os
 from typing import Dict, Optional
 
 from plugin_sdk.base import BasePlugin, PluginManifest
-from tool_sdk.registry import get_tool_registry
+
+# Fully-qualified (#14373): the bare `tool_sdk` path is not guaranteed to be
+# importable at plugin-load time and, where it is, resolves to a second
+# module identity with its own, independently empty, registry singleton.
+from autobot_shared.tool_sdk.registry import get_tool_registry
 
 from .tools import GenerateVideoTool
 

--- a/plugins/core-plugins/video-generation-plugin/tools/generate_video.py
+++ b/plugins/core-plugins/video-generation-plugin/tools/generate_video.py
@@ -19,7 +19,8 @@ import logging
 import os
 from typing import Any, Dict
 
-from tool_sdk.base import BaseTool, ToolMetadata, ToolPermission, ToolResult
+# Fully-qualified (#14373) — see plugins/core-plugins/video-generation-plugin/main.py.
+from autobot_shared.tool_sdk.base import BaseTool, ToolMetadata, ToolPermission, ToolResult
 
 from .providers import ProviderError, get_provider
 

--- a/plugins/core-plugins/video-generation-plugin/tools/generate_video_test.py
+++ b/plugins/core-plugins/video-generation-plugin/tools/generate_video_test.py
@@ -50,8 +50,10 @@ def tool(monkeypatch):
 
     base.BaseTool = _BaseTool
 
-    monkeypatch.setitem(sys.modules, "tool_sdk", MagicMock())
-    monkeypatch.setitem(sys.modules, "tool_sdk.base", base)
+    # Fully-qualified module names (#14373) — generate_video.py imports
+    # `autobot_shared.tool_sdk.base`, not the bare `tool_sdk` path.
+    monkeypatch.setitem(sys.modules, "autobot_shared.tool_sdk", MagicMock())
+    monkeypatch.setitem(sys.modules, "autobot_shared.tool_sdk.base", base)
 
     # Build a real package module so `from .providers import ...` resolves.
     import types


### PR DESCRIPTION
Closes #14373

## Thinking Path

`autobot_shared/tool_sdk/registry.py` and `__init__.py` imported each other by a
**bare top-level name** (`from tool_sdk.base import ...`). That name only resolves
when `autobot_shared/` itself sits directly on `sys.path` — true under pytest
(`pytest.ini`'s `pythonpath = . autobot-backend autobot_shared pipeline-scripts`
puts it there for unrelated legacy reasons), false in production and false in the
`llc-contract.yml` CI job (`PYTHONPATH="$PWD:$PWD/autobot-backend"` only). So the
package could not import itself by its own real path, `autobot_shared.tool_sdk`
— any module-level `from autobot_shared.tool_sdk.registry import get_tool_registry`
anywhere in the app raised `ModuleNotFoundError: No module named 'tool_sdk'`,
which is exactly what took the LLC feature router down while #14221 step 4 was
being built (`Optional router not available: llc - No module named 'tool_sdk'`,
`Loaded 121/122 feature routers`, `dump-openapi` failing under
`AUTOBOT_FEATURE_ROUTERS_STRICT=1`).

The interim workaround landed in #14357 (`llc/services/role_tool.py`) sidesteps
this by importing the bare `tool_sdk.registry` name lazily inside a method — same
shape every other existing consumer already used. That avoids the ImportError at
router-load time, but is a workaround at the call site, not a fix of the package,
and it carries a worse hazard than the one it dodges: `get_tool_registry()` returns
a **module-level singleton**. If the package were "fixed" by making
`autobot_shared.tool_sdk` importable *without* also converting its internals off
the bare name, the same files could load under **two module identities** —
`tool_sdk.registry` and `autobot_shared.tool_sdk.registry` — each holding its own,
independently empty, `ToolSDKRegistry`. Tools registered through one identity
would be invisible through the other, and every lookup would report "unknown
tool" while the real registry was perfectly healthy — silent, and much harder to
diagnose than an ImportError.

So the fix is deliberately **not** `sys.path` manipulation and **not** a
`tool_sdk` alias/shim module (both create that second identity). It converts the
package's own internal imports to relative (`from .base import ...`), which
resolve identically regardless of the path the package is reached by, and
migrates every repo call site off the bare `tool_sdk` name onto the
fully-qualified `autobot_shared.tool_sdk` path, so nothing in the repository ever
creates the second identity in the first place. The bare name is not offered as
a supported alias.

## What Changed

**Package internals (relative imports, #14373's core fix):**
- `autobot_shared/tool_sdk/registry.py` — `from tool_sdk.base import (...)` → `from .base import (...)`
- `autobot_shared/tool_sdk/__init__.py` — same for both its `tool_sdk.base` and `tool_sdk.registry` imports; docstring's quick-start example updated to the fully-qualified form; new note explaining why the bare name is unsupported.

**Application call sites (bare → fully-qualified, all previously broken outside pytest):**
- `autobot-backend/tools/tool_registry.py` — 3 lazy imports (`ToolNotFoundError`, `get_tool_registry`, `ToolPermission`)
- `autobot-backend/api/image_generation.py` — 1 lazy import (`get_tool_registry`)
- `autobot-backend/llc/services/role_tool.py` — the #14357 interim-workaround import; kept lazy (router-resilience reasoning still holds independently of the identity fix) but switched to the fully-qualified path, with the comment rewritten to explain both reasons
- `plugins/core-plugins/image-generation-plugin/main.py` and `tools/generate_image.py` — module-level imports, previously broken whenever the plugin loaded outside pytest (repo root is on `sys.path` in production per `app_factory.py`; `autobot_shared/` itself is not)
- `plugins/core-plugins/video-generation-plugin/main.py` and `tools/generate_video.py` — same

**Tests updated to match (would otherwise patch/import a different singleton than the code under test):**
- `autobot-backend/llc/tests/test_role_tools.py` — `get_tool_registry` import switched to fully-qualified; the fixture patches the *same* singleton `RoleToolService` now reaches
- `autobot_shared/tool_sdk/{base_test,registry_test,tool_sdk_test}.py` — the package's own tests, switched to the canonical import path
- `plugins/core-plugins/video-generation-plugin/tools/generate_video_test.py` — `sys.modules` stub keys updated from `tool_sdk`/`tool_sdk.base` to `autobot_shared.tool_sdk`/`autobot_shared.tool_sdk.base` to match `generate_video.py`'s new import

**New guard test — `autobot_shared/tool_sdk/import_identity_test.py`:**
- `TestNoBareTopLevelImport` — an `ast`-based (not text-matching) static scan of every first-party `.py` file in the repo, asserting none of them import the bare `tool_sdk` name. Catches reintroduction anywhere, including inside a lazy/nested import a runtime test would never execute.
- `TestSingleImportIdentity.test_singleton_identical_via_module_and_package_reexport` — asserts `autobot_shared.tool_sdk.get_tool_registry` **is** (not just equals) `autobot_shared.tool_sdk.registry.get_tool_registry`, proving the package-level re-export and the direct module import share one function object, not two.
- `TestSingleImportIdentity.test_clean_process_shaped_like_production_has_no_bare_identity` — spawns a subprocess with `PYTHONPATH` set to the repo root only (production's shape, and `llc-contract.yml`'s — deliberately *not* this suite's `pytest.ini`-supplied `autobot_shared`-on-path convenience), imports `autobot_shared.tool_sdk.registry` and `autobot_shared.tool_sdk`, asserts the registries returned are the same object, and asserts no bare `tool_sdk*` entry leaked into `sys.modules`.

## Verification

Static only, per repo policy (no app code execution, no installs) — CI runs the tests.

- **Import-identity argument**: after this change, both `autobot_shared/tool_sdk/registry.py` and `__init__.py` import only via relative imports (`.base`, `.registry`), which resolve to the *same* module object regardless of whether the package's own `__init__.py` was reached via `autobot_shared.tool_sdk` or (hypothetically) via a bare `tool_sdk`. Because every repo call site was also migrated off the bare name (verified by an `ast` walk over every `.py` file outside `.git`/`.worktrees`/caches — zero remaining bare `from tool_sdk` / `import tool_sdk` occurrences), nothing in the codebase can trigger the second identity. `get_tool_registry()`'s module-level singleton therefore has exactly one home: `autobot_shared.tool_sdk.registry`.
- **Guard-test correctness, proved by mutation**: I round-tripped a deliberate regression — reverted `registry.py`'s `from .base import (...)` back to `from tool_sdk.base import (...)` — and re-ran the same `ast`-scan logic the new test uses against the tree; it correctly reported the offending file and import (`{'.../autobot_shared/tool_sdk/registry.py': ['tool_sdk.base']}`). My first draft of the exclusion filter checked the *absolute* path against the excluded-dir set, which always contains `.worktrees` for every file in this repo's mandatory worktree layout and silently zeroed out every result — an "empty result reads as clean" bug I caught by checking the mutated tree still reported zero offenders. Fixed by checking `path.relative_to(root).parts` instead; confirmed the mutation is caught and the clean tree is silent again after restoring.
- **`llc-wiring-audit` / #14357 failure**: that job's `PYTHONPATH` is `$PWD:$PWD/autobot-backend` only (`.github/workflows/llc-contract.yml`) — no bare `autobot_shared`-as-root entry, i.e. the exact shape that turned `Optional router not available: llc - No module named 'tool_sdk'` into a router load failure whenever anything imported `autobot_shared.tool_sdk.*` at module scope. With the internals now relative, that qualified import resolves independent of the caller's own path style, so this failure mode is structurally closed, not just avoided.
- Every touched file parses (`ast.parse`) and stays within the repo's 120-column limit (checked with `awk`).
- Confirmed by direct `grep`/`ast` sweep of the whole worktree: zero remaining `from tool_sdk` / `import tool_sdk` occurrences in source, only in comments/docstrings that document why the bare form is unsupported.

## Model Used

Claude Sonnet 5 (1M context)
