### PR TITLE
fix(chat): close two tool-output-offload coverage holes — LLC dict payload and approval-gate resume (#14284, #14242)

### DIFF
--- a/autobot-backend/chat_workflow/graph.py
+++ b/autobot-backend/chat_workflow/graph.py
@@ -1074,6 +1074,13 @@ async def execute_tools(state: ChatState, config: RunnableConfig) -> dict:
     exec_history = list(state.get("execution_history", []))
     break_loop = False
 
+    # #14242: bind the spill run on THIS path too. `_run_continuation_loop_
+    # iteration` binds it for the non-gated path (#13997), but that method is
+    # never called here — GH#11202's whole point is that this node dispatches
+    # instead of it — so a run reaching this seam was never bound and the
+    # offload below would decline to write (no run to re-read it under).
+    manager._bind_spill_run(session_id)
+
     # GH#11202: thread the governed-identity context so the same production
     # seam gates (forbidden_work #11145, config-protection #11177,
     # fact-forcing #11178) apply here exactly as they do on the inline
@@ -1118,9 +1125,20 @@ async def execute_tools(state: ChatState, config: RunnableConfig) -> dict:
             is_streaming = msg_dict.get("metadata", {}).get("streaming", False)
             if not is_streaming:
                 messages.append(msg_dict)
-            # Track execution results
-            if isinstance(item, dict) and item.get("type") == "execution_summary":
-                exec_history.append(item)
+            # Track execution results (#14242). `item` is the yielded
+            # WorkflowMessage — never a dict — so `isinstance(item, dict)` here
+            # never matched and `exec_history` silently stayed whatever
+            # `state["execution_history"]` already held: new tool results never
+            # reached it, and neither did the offload this seam now applies.
+            # `msg_dict["metadata"]["execution_results"]` is the flat per-tool
+            # list `_build_execution_summary` produces — the same shape
+            # `_handle_execution_summary` extends `execution_history` with on
+            # the non-gated path — offloaded through the same #13997 seam so
+            # oversized output does not reach the model on a resume either.
+            if msg_dict.get("type") == "execution_summary":
+                new_results = msg_dict.get("metadata", {}).get("execution_results", [])
+                new_results = await manager._offload_oversized_output(new_results)
+                exec_history.extend(new_results)
 
     # Issue #3254: Emit a user-visible message when the loop abort threshold is
     # reached so the user understands why the assistant stopped making progress.

--- a/autobot-backend/chat_workflow/graph_execute_tools_offload_test.py
+++ b/autobot-backend/chat_workflow/graph_execute_tools_offload_test.py
@@ -1,0 +1,166 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tool-output offload on the approval-gate resume path (#14242).
+
+With ``AUTOBOT_CHAT_APPROVAL_GATE`` on (GH#11202), ``generate_response`` plans
+tool calls without dispatching them and defers dispatch to the graph's
+``execute_tools`` node. That node calls ``manager._process_tool_calls``
+directly and builds its own ``exec_history`` — bypassing
+``_process_tool_results``/``_handle_execution_summary``, which is where #13997
+hooks the #13692 spill. So the offload never ran on a resume, whatever
+``AUTOBOT_TOOL_OUTPUT_SPILL`` was set to.
+
+Fixing that exposed a second bug in the same lines: the "track execution
+results" check read ``isinstance(item, dict)`` on the yielded
+``WorkflowMessage`` itself, which is never a dict (only its ``.to_dict()``
+form, already computed into ``msg_dict``, is) — so it never matched, and
+``exec_history`` silently stayed whatever ``state["execution_history"]``
+already held. New tool results never reached it at all, offloaded or not.
+Both are fixed together because the second bug is what made the first one
+untestable: there was nothing to offload.
+
+``chat_workflow.graph`` is imported inside each test (not at module scope),
+matching ``streamed_reply_persistence_test.py`` — it pulls in
+``langgraph``/``langchain_core``, present in CI but not guaranteed in every
+dev shell.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import pytest
+
+from agent_loop import tool_output_spill as spill
+from chat_workflow.manager import ChatWorkflowManager
+from chat_workflow.tool_handler import ToolHandlerMixin
+
+pytestmark = pytest.mark.asyncio
+
+SESSION_ID = "sess-14242"
+_BIG = "K" * 40_000
+
+
+@pytest.fixture(autouse=True)
+def _spill_on(tmp_path, monkeypatch):
+    monkeypatch.setattr(spill, "SPILL_ENABLED", True)
+    monkeypatch.setenv("AUTOBOT_TOOL_OUTPUT_SPILL_ROOT", str(tmp_path))
+    spill.bind_task(None)
+    yield
+    spill.bind_task(None)
+
+
+def _manager() -> ChatWorkflowManager:
+    return ChatWorkflowManager.__new__(ChatWorkflowManager)
+
+
+def _state(**overrides: Any) -> Dict[str, Any]:
+    base: Dict[str, Any] = {
+        "session_id": SESSION_ID,
+        "terminal_session_id": "term-1",
+        "user_message": "do the thing",
+        "context": {},
+        "llm_params": {"ollama_endpoint": "http://127.0.0.1:11434", "selected_model": "test-model"},
+        "tool_calls": [{"name": "bash", "params": {"command": "ls"}}],
+        "execution_history": [],
+        "iteration_count": 1,
+        "workflow_messages": [],
+    }
+    base.update(overrides)
+    return base
+
+
+def _config(manager: ChatWorkflowManager) -> Dict[str, Any]:
+    return {"configurable": {"manager": manager, "stream_callback": None}}
+
+
+def _fake_dispatch(results: List[Dict[str, Any]]):
+    """Shaped exactly like ``manager._process_tool_calls``.
+
+    Built through the REAL ``ToolHandlerMixin._build_execution_summary``, not a
+    hand-written ``WorkflowMessage`` — the fixture is the same wrapping-event
+    shape production actually yields (``metadata.execution_results`` holding
+    the flat per-tool list).
+    """
+
+    async def _gen(*_args: Any, **_kwargs: Any):
+        handler = ToolHandlerMixin()
+        yield handler._build_execution_summary(results)
+        yield (False, None)
+
+    return _gen
+
+
+class TestExecutionHistoryActuallyAccumulates:
+    """The bug under the bug: without this, nothing reaches the offload."""
+
+    async def test_a_dispatched_result_reaches_execution_history(self, monkeypatch):
+        from chat_workflow import graph as graph_mod
+
+        mgr = _manager()
+        original = [{"tool": "bash", "status": "success", "output": "ok"}]
+        monkeypatch.setattr(mgr, "_process_tool_calls", _fake_dispatch(original))
+
+        out = await graph_mod.execute_tools(_state(), _config(mgr))
+
+        assert out["execution_history"] == original
+
+
+class TestTheApprovalGateResumeOffloads:
+    async def test_oversized_output_is_offloaded_with_excerpt_and_anchor(self, monkeypatch):
+        from chat_workflow import graph as graph_mod
+
+        mgr = _manager()
+        monkeypatch.setattr(
+            mgr,
+            "_process_tool_calls",
+            _fake_dispatch([{"tool": "bash", "status": "success", "output": _BIG}]),
+        )
+
+        out = await graph_mod.execute_tools(_state(), _config(mgr))
+
+        entry = out["execution_history"][0]
+        assert len(entry["output"]) < len(_BIG)
+        assert entry["anchors"][0].startswith(f"autobot:spill:{SESSION_ID}:")
+        assert "read_spilled_output" in entry["output"]
+
+    async def test_the_full_output_is_retrievable_through_the_anchor(self, monkeypatch):
+        from chat_workflow import graph as graph_mod
+
+        mgr = _manager()
+        monkeypatch.setattr(
+            mgr,
+            "_process_tool_calls",
+            _fake_dispatch([{"tool": "bash", "status": "success", "output": _BIG}]),
+        )
+
+        out = await graph_mod.execute_tools(_state(), _config(mgr))
+        window = spill.read_spilled_window(out["execution_history"][0]["anchors"][0])
+
+        assert window["found"] is True
+        assert window["total_chars"] == len(_BIG)
+
+    async def test_small_results_pass_through_untouched(self, monkeypatch):
+        from chat_workflow import graph as graph_mod
+
+        mgr = _manager()
+        original = [{"tool": "bash", "status": "success", "output": "short"}]
+        monkeypatch.setattr(mgr, "_process_tool_calls", _fake_dispatch(original))
+
+        out = await graph_mod.execute_tools(_state(), _config(mgr))
+
+        assert out["execution_history"] == original
+
+    async def test_the_flag_off_leaves_the_turn_untouched(self, monkeypatch):
+        from chat_workflow import graph as graph_mod
+
+        monkeypatch.setattr(spill, "SPILL_ENABLED", False)
+        mgr = _manager()
+        original = [{"tool": "bash", "status": "success", "output": _BIG}]
+        monkeypatch.setattr(mgr, "_process_tool_calls", _fake_dispatch(original))
+
+        out = await graph_mod.execute_tools(_state(), _config(mgr))
+
+        assert out["execution_history"] == original

--- a/autobot-backend/chat_workflow/llc_tool_output_offload_test.py
+++ b/autobot-backend/chat_workflow/llc_tool_output_offload_test.py
@@ -1,0 +1,158 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""An LLC tool result is a dict, and the offload only understands strings (#14284).
+
+``_handle_llc_tool`` (``chat_workflow/tool_handler.py``) used to store the raw
+dict ``dispatch_llc_tool`` returns under ``output``. ``spill_execution_results``
+(``agent_loop/tool_output_spill.py``) type-guards on ``str`` before it will even
+look at a key:
+
+    keys = [k for k in _EXECUTION_RESULT_TEXT_KEYS if isinstance(entry.get(k), str) and entry[k]]
+
+so a dict payload was skipped silently no matter what the adapter's key list
+contained, and an oversized LLC entity dump reached the model whole.
+
+The fixture is built by driving the real ``dispatch_llc_tool``/``_handle_llc_tool``
+path — mocking only the DB session and service layer, the same pattern as
+``llc/tests/test_agent_tools.py`` — not a hand-written ``{"output": {...}}``
+dict. A hand-written fixture is exactly the shape that let this hole survive
+two prior key-list fixes: it proves the adapter forwards what it is given,
+which was never the question.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agent_loop import tool_output_spill as spill
+from chat_workflow.manager import ChatWorkflowManager
+from chat_workflow.tool_handler import ToolHandlerMixin
+from llc import agent_tools
+
+pytestmark = pytest.mark.asyncio
+
+_COMPANY = str(uuid.uuid4())
+_USER = str(uuid.uuid4())
+_BIG_TITLE = "T" * 40_000
+_TASK_ID = "run-14284"
+
+
+def _patch_session():
+    """Same pattern as ``llc/tests/test_agent_tools.py::_patch_session``."""
+    session = MagicMock()
+
+    @asynccontextmanager
+    async def _begin():
+        yield
+
+    session.begin = _begin
+
+    @asynccontextmanager
+    async def _sess_cm():
+        yield session
+
+    factory = MagicMock(return_value=_sess_cm())
+    return patch.object(agent_tools, "_session_factory", return_value=factory)
+
+
+async def _dispatch_create_task(title: str):
+    """Drive ``_handle_llc_tool`` through the real LLC dispatch path.
+
+    Only ``WorkItemService`` (the DB-facing collaborator) is mocked, exactly as
+    ``test_agent_tools.py`` does — ``dispatch_llc_tool``, ``_create_task`` and
+    ``_handle_llc_tool`` all run for real, so the resulting envelope is the one
+    production actually builds.
+    """
+    handler = ToolHandlerMixin()
+    execution_results: list = []
+    item = MagicMock(id=uuid.uuid4())
+    svc = MagicMock()
+    svc.create = AsyncMock(return_value=item)
+    ctx = SimpleNamespace(context={"company_id": _COMPANY, "user_id": _USER})
+    tool_call = {"name": "create_task", "params": {"title": title, "priority": "high"}}
+
+    with _patch_session(), patch("llc.services.work_item_service.WorkItemService", return_value=svc):
+        messages = [m async for m in handler._handle_llc_tool("create_task", tool_call, execution_results, ctx)]
+
+    return execution_results, messages
+
+
+@pytest.fixture(autouse=True)
+def _spill_on(tmp_path, monkeypatch):
+    monkeypatch.setattr(spill, "SPILL_ENABLED", True)
+    monkeypatch.setattr(spill, "SPILL_THRESHOLD_CHARS", 500)
+    monkeypatch.setattr(spill, "SPILL_EXCERPT_CHARS", 100)
+    monkeypatch.setenv("AUTOBOT_TOOL_OUTPUT_SPILL_ROOT", str(tmp_path))
+    spill.bind_task(_TASK_ID)
+    yield
+    spill.bind_task(None)
+
+
+class TestTheEnvelopeStaysAString:
+    async def test_a_successful_llc_result_stores_a_str_not_a_dict(self):
+        execution_results, _ = await _dispatch_create_task("Write Q3 report")
+
+        assert execution_results[0]["status"] == "success"
+        assert isinstance(execution_results[0]["output"], str)
+
+    async def test_the_serialised_output_round_trips_the_real_result(self):
+        """Nothing the caller reads (entity_type/entity_id) is lost by serialising."""
+        execution_results, _ = await _dispatch_create_task("Write Q3 report")
+
+        parsed = json.loads(execution_results[0]["output"])
+        assert parsed["entity_type"] == "work_item"
+        assert parsed["title"] == "Write Q3 report"
+        assert "entity_id" in parsed
+
+    async def test_as_output_text_still_renders_it(self):
+        """AC: ``_as_output_text``/``_format_execution_step`` still work."""
+        execution_results, _ = await _dispatch_create_task("Write Q3 report")
+        mgr = ChatWorkflowManager.__new__(ChatWorkflowManager)
+
+        rendered = mgr._format_execution_step(1, execution_results[0])
+
+        assert "work_item" in rendered
+        assert "Write Q3 report" in rendered
+        assert "(no output)" not in rendered
+
+
+class TestAnOversizedLLCResultOffloads:
+    async def test_the_dict_payload_is_offloaded_with_excerpt_and_anchor(self):
+        """AC: an oversized LLC tool result is offloaded, excerpt+anchor reach the model."""
+        execution_results, _ = await _dispatch_create_task(_BIG_TITLE)
+        original_output = execution_results[0]["output"]
+        assert isinstance(original_output, str), "precondition: the producer serialises (#14284)"
+
+        rewritten, count = spill.spill_execution_results(_TASK_ID, execution_results)
+
+        assert count == 1
+        assert len(rewritten[0]["output"]) < len(original_output)
+        assert rewritten[0]["anchors"][0].startswith(f"autobot:spill:{_TASK_ID}:")
+        assert "read_spilled_output" in rewritten[0]["output"]
+
+    async def test_the_full_output_is_retrievable_through_the_anchor(self):
+        execution_results, _ = await _dispatch_create_task(_BIG_TITLE)
+        original_output = execution_results[0]["output"]
+
+        rewritten, _ = spill.spill_execution_results(_TASK_ID, execution_results)
+        window = spill.read_spilled_window(rewritten[0]["anchors"][0])
+
+        assert window["found"] is True
+        assert window["total_chars"] == len(original_output)
+
+    async def test_the_envelope_survives(self):
+        """``status``/``tool`` decide error handling downstream — must not be dropped."""
+        execution_results, _ = await _dispatch_create_task(_BIG_TITLE)
+
+        rewritten, _ = spill.spill_execution_results(_TASK_ID, execution_results)
+
+        assert rewritten[0]["status"] == "success"
+        assert rewritten[0]["tool"] == "create_task"

--- a/autobot-backend/chat_workflow/manager.py
+++ b/autobot-backend/chat_workflow/manager.py
@@ -198,11 +198,13 @@ def _filter_step_output(cmd: str, output_text: str, *, is_shell: bool) -> str:
 def _as_output_text(value: Any) -> str:
     """Render an execution-result field as prompt text (#14120).
 
-    ``stdout``/``stderr`` are strings, but the tool vocabularies are not. The
-    shape that actually occurs is a **dict** — ``_handle_llc_tool`` records one
-    (its caller immediately reads ``result.get("entity_type")``), and the MCP
-    bridge records one under ``result``. Web search records a ``str``; a list is
-    reachable only if an ``AFTER_TOOL_EXECUTE`` hook returns one. A bare
+    ``stdout``/``stderr`` are strings, but the tool vocabularies are not. A
+    **dict** is reachable — the MCP bridge records one under ``result`` — and a
+    list is reachable only if an ``AFTER_TOOL_EXECUTE`` hook returns one. (
+    ``_handle_llc_tool`` used to store a dict under ``output`` too; #14284
+    serialises it at the producer instead, so the envelope's payload fields stay
+    a uniform str — this dict branch now exists for the MCP bridge and any
+    future producer, not for that one.) Web search records a ``str``. A bare
     ``.strip()`` raised on every non-string case.
 
     Dicts go through ``json.dumps`` rather than ``str()``, matching the

--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -2747,7 +2747,12 @@ class ToolHandlerMixin:
         user_id = _cctx.get("user_id")
         try:
             result = await dispatch_llc_tool(tool_name, params, company_id, user_id)
-            execution_results.append({"tool": tool_name, "status": "success", "output": result})
+            # #14284: `output` must stay a str — the offload adapter
+            # (spill_execution_results) type-guards on str before it looks at a
+            # key, so a raw dict here silently defeated it. Serialise at the
+            # producer, matching every other handler's envelope.
+            output_text = json.dumps(result, default=str, ensure_ascii=False)
+            execution_results.append({"tool": tool_name, "status": "success", "output": output_text})
             entity = result.get("entity_type", "item")
             entity_id = result.get("entity_id")
             summary = f"Done ({entity})" + (f" [{entity_id}]" if entity_id else "")


### PR DESCRIPTION
Closes #14284, #14242

## Thinking Path

Both issues are holes in the #13997 tool-output offload's coverage, found in
review of PR #14237. I read `agent_loop/tool_output_spill.py` (the adapter)
and `chat_workflow/tool_handler.py`/`manager.py`/`graph.py` (the two producer
seams) before touching anything, to find the actual root cause rather than
patching the reported symptom.

**#14284.** `spill_execution_results` only offloads an envelope field when
`isinstance(entry.get(k), str)` — a type guard, not a name guard. `_handle_llc_tool`
stored the raw dict `dispatch_llc_tool` returns under `output`, so no amount of
growing the key list could ever reach it. Per the issue's preferred fix shape
(option 1), I serialise at the producer instead of teaching the adapter a
second, dict-shaped contract — every other tool handler already writes a str
there.

**#14242.** Tracing `graph.py::execute_tools` (the approval-gate resume node)
to see how the offload could be wired in, I found it calls
`manager._process_tool_calls` directly and builds its own `exec_history`,
never routing through `_process_tool_results`/`_handle_execution_summary`
(where #13997 hooks the spill) — matching the issue exactly. Wiring the
offload call in exposed two more problems in the same lines, both necessary
for the wiring to do anything at all:

1. the spill run was never bound on this path. `_bind_spill_run` runs inside
   `_run_continuation_loop_iteration`, and this node never calls that method
   (that's the whole point of GH#11202's plan-only split) — so `_spill_run_id()`
   would read `None` and the offload declines to write ("an artifact that
   could never be re-read is pure cost").
2. the "track execution results" check read `isinstance(item, dict)` on the
   yielded `WorkflowMessage` itself, which is a dataclass and is **never** a
   dict — only its already-computed `.to_dict()` form (`msg_dict`) is. So the
   check never matched, and `exec_history` silently stayed whatever
   `state["execution_history"]` already held on entry. New tool results never
   reached it, offloaded or not — on the approval-gate path, tool output never
   reached the model's next continuation prompt at all, a strictly worse bug
   than "the offload doesn't fire on it."

All three had to be fixed together: (1)+(2) are what make the offload call
meaningful, and nothing here had a test, which is exactly how a dead
`isinstance` check and an unbound ContextVar both survived.

## What Changed

- `autobot-backend/chat_workflow/tool_handler.py` — `_handle_llc_tool` now
  JSON-serialises the LLC dispatch result before storing it under `output`,
  instead of storing the raw dict. (#14284)
- `autobot-backend/chat_workflow/manager.py` — updated `_as_output_text`'s
  docstring, which specifically named `_handle_llc_tool` as the dict-shape
  example this change removes; left the dict-handling branch itself alone
  (still needed for the MCP bridge's `result` field). (#14284, doc accuracy)
- `autobot-backend/chat_workflow/graph.py` — `execute_tools`:
  - binds the spill run (`manager._bind_spill_run(session_id)`) before
    dispatch, since this path never calls the method that does it elsewhere;
  - fixed the dead `isinstance(item, dict)` check so newly dispatched results
    actually reach `exec_history` (reading the flat `execution_results` list
    out of the summary event's `metadata`, the same shape the non-gated path
    reads);
  - routes those results through `manager._offload_oversized_output` before
    extending `exec_history`, so oversized output is offloaded on a resume
    exactly as it already is on the non-gated path. (#14242)
- Two new test files (`chat_workflow/llc_tool_output_offload_test.py`,
  `chat_workflow/graph_execute_tools_offload_test.py`) — see Verification.

No other producer was switched to a dict payload, and the MCP bridge's dict
under `result` is untouched, so the adapter's existing dict-handling paths
(`_as_output_text`) still have a live caller.

## Verification

Both test files build their fixtures from the real path the issues name,
not a hand-written dict/exec_history:

- `llc_tool_output_offload_test.py` drives `dispatch_llc_tool` →
  `_handle_llc_tool` for real (only the DB session + `WorkItemService` are
  mocked, the same pattern as `llc/tests/test_agent_tools.py`), then runs the
  resulting envelope through the real `spill_execution_results`.
- `graph_execute_tools_offload_test.py` calls `chat_workflow.graph.execute_tools`
  directly with a realistic `ChatState`, faking only `manager._process_tool_calls`
  — and that fake yields a summary built by the real
  `ToolHandlerMixin._build_execution_summary`, not a hand-written
  `WorkflowMessage`.

Static verification only in this environment per project policy (no local
test execution) — CI runs both files. I hand-traced each assertion against
the code paths above rather than executing them; the mutation table below is
therefore a **static trace** of what each assertion depends on, not an
executed run.

| # | Mutation (fix reverted) | Test expected to fail | Why |
|---|---|---|---|
| 1 | `tool_handler.py`: store `result` (dict) instead of `json.dumps(result)` under `output` | `llc_tool_output_offload_test.py::TestTheEnvelopeStaysAString::test_a_successful_llc_result_stores_a_str_not_a_dict` | asserts `isinstance(..., str)` directly on the reverted dict |
| 2 | same mutation | `TestAnOversizedLLCResultOffloads::test_the_dict_payload_is_offloaded_with_excerpt_and_anchor` | precondition `isinstance(original_output, str)` fails immediately; even if bypassed, `spill_execution_results` would skip the dict key and `count == 1` would fail |
| 3 | `graph.py`: remove `manager._bind_spill_run(session_id)` | `graph_execute_tools_offload_test.py::TestTheApprovalGateResumeOffloads::test_oversized_output_is_offloaded_with_excerpt_and_anchor` | `_spill_run_id()` reads `None`, `_offload_oversized_output` returns results untouched — `len(entry["output"]) < len(_BIG)` fails |
| 4 | `graph.py`: revert the `isinstance(item, dict)` check (drop the `msg_dict.get("type")` fix) | `graph_execute_tools_offload_test.py::TestExecutionHistoryActuallyAccumulates::test_a_dispatched_result_reaches_execution_history` | `out["execution_history"]` stays `[]` (from `state`), never equals `original` |
| 5 | same mutation | `TestTheApprovalGateResumeOffloads::test_oversized_output_is_offloaded_with_excerpt_and_anchor` | `out["execution_history"]` is empty — `IndexError` on `[0]` |
| 6 | `graph.py`: drop the `await manager._offload_oversized_output(new_results)` call (keep the `isinstance`/bind fixes) | `test_oversized_output_is_offloaded_with_excerpt_and_anchor` | `entry["output"]` is the full `_BIG` string, `len(entry["output"]) < len(_BIG)` fails, no `anchors` key |

Also covered: `_as_output_text`/`_format_execution_step` still render the
(now-string) LLC output correctly; small/under-threshold results pass through
byte-identical on both paths; the flag-off case leaves the approval-gate turn
untouched; the full spilled output is retrievable through its anchor on both
paths.

## Model Used

Claude Opus 5 (1M context)
