### PR TITLE
test(infra): pin fail-closed coverage for the last 3 #14151 hooks; #14181 status update

### DIFF
--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-branch-guard_test.py
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-branch-guard_test.py
@@ -1,0 +1,130 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for pre-commit-branch-guard (#1670, GH#14151 fail-closed guard).
+
+Issue #14151: unlike most hooks in this campaign, this one never calls
+get_staged_files() or touches `git diff --cached` at all — it only calls
+`git rev-parse --git-dir` and `git branch --show-current`, neither of which
+reads `.git/index`. The corrupted-index probe every other hook in this
+family uses cannot reach either call, so the genuine reproduction is a fake
+`git` on PATH that fails only `branch --show-current`, the same technique
+pre-commit-worktree-branch-guard_test.py uses for `worktree list`.
+
+This hook does `source lib/_common.sh` unconditionally and now aborts with
+a FATAL message on failure (GH#14151's fix), so a missing-dependency
+reproduction is included alongside the git-failure one.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+HOOK_PATH = Path(__file__).resolve().parent / "pre-commit-branch-guard"
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(["git", *args], cwd=repo, capture_output=True, text=True, check=True)
+
+
+def _init_repo(tmp_path: Path, branch: str = "feature") -> Path:
+    _git(tmp_path, "init", "--quiet", "-b", branch)
+    _git(tmp_path, "config", "user.email", "t@t")
+    _git(tmp_path, "config", "user.name", "t")
+    (tmp_path / "README.md").write_text("seed\n", encoding="utf-8")
+    _git(tmp_path, "add", "README.md")
+    _git(tmp_path, "-c", "commit.gpgsign=false", "commit", "-q", "-m", "seed")
+    return tmp_path
+
+
+def _write_record(repo: Path, branch: str) -> None:
+    (repo / ".git" / ".autobot-pre-commit-branch").write_text(branch, encoding="utf-8")
+
+
+def test_matching_branch_allows_commit(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path, branch="feature")
+    _write_record(repo, "feature")
+    result = subprocess.run(["bash", str(HOOK_PATH)], cwd=repo, capture_output=True, text=True)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_mismatched_branch_blocks_commit(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path, branch="feature")
+    _write_record(repo, "main")
+    result = subprocess.run(["bash", str(HOOK_PATH)], cwd=repo, capture_output=True, text=True)
+    assert result.returncode != 0, result.stdout + result.stderr
+    assert "COMMIT ABORTED" in result.stdout
+
+
+def test_missing_record_file_allows_commit(tmp_path: Path) -> None:
+    """No record file means pre-commit-record-branch didn't run — skip
+    silently rather than block (e.g. first install)."""
+    repo = _init_repo(tmp_path, branch="feature")
+    result = subprocess.run(["bash", str(HOOK_PATH)], cwd=repo, capture_output=True, text=True)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+class TestFailsClosedWhenDependencyMissing:
+    """GH#14151: `source lib/_common.sh` now aborts with a FATAL message
+    instead of the pre-fix `set -uo pipefail` running past a source failure
+    into whatever came next."""
+
+    def test_a_missing_common_lib_does_not_report_clean(self, tmp_path: Path) -> None:
+        repo = _init_repo(tmp_path, branch="feature")
+        _write_record(repo, "main")  # a genuine mismatch present
+
+        isolated = tmp_path.parent / "isolated-branch-guard"
+        isolated.mkdir()
+        hook_copy = isolated / HOOK_PATH.name
+        hook_copy.write_bytes(HOOK_PATH.read_bytes())
+        hook_copy.chmod(0o755)
+
+        result = subprocess.run([str(hook_copy)], cwd=repo, capture_output=True, text=True)
+        assert result.returncode != 0, "the hook reported clean with no dependency and a real mismatch present"
+
+
+class TestFailsClosedWhenGitCannotAnswer:
+    """GH#14151: a `git branch --show-current` failure must not be
+    indistinguishable from "no mismatch" — reproduced with a fake `git` on
+    PATH that fails ONLY `branch --show-current` and delegates everything
+    else to the real binary, since a corrupted `.git/index` never reaches
+    either git call this hook makes."""
+
+    def _make_fake_git(self, tmp_path: Path) -> Path:
+        real_git_path = None
+        for candidate in ("/usr/bin/git", "/bin/git", "/usr/local/bin/git"):
+            if Path(candidate).exists():
+                real_git_path = candidate
+                break
+        assert real_git_path, "could not locate a real git binary to delegate to"
+
+        fake_bin = tmp_path.parent / "fake-bin"
+        fake_bin.mkdir(exist_ok=True)
+        fake_git = fake_bin / "git"
+        fake_git.write_text(
+            "#!/bin/bash\n"
+            f'REAL_GIT="{real_git_path}"\n'
+            'if [ "$1" = "branch" ] && [ "$2" = "--show-current" ]; then\n'
+            '    echo "fatal: simulated branch failure" >&2\n'
+            "    exit 128\n"
+            "fi\n"
+            'exec "$REAL_GIT" "$@"\n',
+            encoding="utf-8",
+        )
+        fake_git.chmod(fake_git.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+        return fake_bin
+
+    def test_a_git_branch_failure_does_not_report_clean(self, tmp_path: Path) -> None:
+        repo = _init_repo(tmp_path, branch="feature")
+        _write_record(repo, "main")  # a genuine mismatch present
+
+        fake_bin = self._make_fake_git(tmp_path)
+        env = dict(os.environ)
+        env["PATH"] = f"{fake_bin}:{env.get('PATH', '')}"
+
+        result = subprocess.run(["bash", str(HOOK_PATH)], cwd=repo, capture_output=True, text=True, env=env)
+        assert result.returncode != 0, "a `git branch --show-current` failure was indistinguishable from 'no mismatch'"

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-record-branch_test.py
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-record-branch_test.py
@@ -1,0 +1,97 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for pre-commit-record-branch (#1670, GH#14151 fail-closed guard).
+
+Issue #14151: this hook has no lib/_common.sh dependency at all — it only
+calls `git rev-parse --git-dir` and `git branch --show-current` directly,
+so `set -uo pipefail` -> `set -euo pipefail` alone is the fix (no guarded
+source needed, matching PR #14160's own table: "record-branch (no lib
+dependency — -e only)"). Neither call reads `.git/index`, so the
+corrupted-index probe every other hook in this family uses cannot reach
+either — reproduced instead with a fake `git` on PATH that fails one call
+at a time, the same technique pre-commit-worktree-branch-guard_test.py uses
+for `worktree list`.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+HOOK_PATH = Path(__file__).resolve().parent / "pre-commit-record-branch"
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(["git", *args], cwd=repo, capture_output=True, text=True, check=True)
+
+
+def _init_repo(tmp_path: Path, branch: str = "feature") -> Path:
+    _git(tmp_path, "init", "--quiet", "-b", branch)
+    _git(tmp_path, "config", "user.email", "t@t")
+    _git(tmp_path, "config", "user.name", "t")
+    (tmp_path / "README.md").write_text("seed\n", encoding="utf-8")
+    _git(tmp_path, "add", "README.md")
+    _git(tmp_path, "-c", "commit.gpgsign=false", "commit", "-q", "-m", "seed")
+    return tmp_path
+
+
+def test_records_current_branch(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path, branch="feature")
+    result = subprocess.run(["bash", str(HOOK_PATH)], cwd=repo, capture_output=True, text=True)
+    assert result.returncode == 0, result.stdout + result.stderr
+    record = repo / ".git" / ".autobot-pre-commit-branch"
+    assert record.read_text(encoding="utf-8").strip() == "feature"
+
+
+class TestFailsClosedWhenGitCannotAnswer:
+    """GH#14151: neither `git rev-parse --git-dir` nor `git branch
+    --show-current` failing may be indistinguishable from "recorded (or
+    intentionally skipped) cleanly" — each is reproduced with a fake `git`
+    on PATH that fails ONLY that one subcommand and delegates the rest to
+    the real binary."""
+
+    def _make_fake_git(self, tmp_path: Path, name: str, fail_args: tuple[str, ...]) -> Path:
+        real_git_path = None
+        for candidate in ("/usr/bin/git", "/bin/git", "/usr/local/bin/git"):
+            if Path(candidate).exists():
+                real_git_path = candidate
+                break
+        assert real_git_path, "could not locate a real git binary to delegate to"
+
+        condition = " && ".join(f'[ "${i + 1}" = "{arg}" ]' for i, arg in enumerate(fail_args))
+        fake_bin = tmp_path.parent / f"fake-bin-{name}"
+        fake_bin.mkdir(exist_ok=True)
+        fake_git = fake_bin / "git"
+        fake_git.write_text(
+            "#!/bin/bash\n"
+            f'REAL_GIT="{real_git_path}"\n'
+            f"if {condition}; then\n"
+            '    echo "fatal: simulated failure" >&2\n'
+            "    exit 128\n"
+            "fi\n"
+            'exec "$REAL_GIT" "$@"\n',
+            encoding="utf-8",
+        )
+        fake_git.chmod(fake_git.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+        return fake_bin
+
+    def _run_with_fake_git(self, repo: Path, fake_bin: Path) -> subprocess.CompletedProcess:
+        env = dict(os.environ)
+        env["PATH"] = f"{fake_bin}:{env.get('PATH', '')}"
+        return subprocess.run(["bash", str(HOOK_PATH)], cwd=repo, capture_output=True, text=True, env=env)
+
+    def test_a_git_dir_lookup_failure_does_not_report_clean(self, tmp_path: Path) -> None:
+        repo = _init_repo(tmp_path, branch="feature")
+        fake_bin = self._make_fake_git(tmp_path, "gitdir", ("rev-parse", "--git-dir"))
+        result = self._run_with_fake_git(repo, fake_bin)
+        assert result.returncode != 0, "a `git rev-parse --git-dir` failure was silently swallowed"
+
+    def test_a_git_branch_lookup_failure_does_not_report_clean(self, tmp_path: Path) -> None:
+        repo = _init_repo(tmp_path, branch="feature")
+        fake_bin = self._make_fake_git(tmp_path, "branch", ("branch", "--show-current"))
+        result = self._run_with_fake_git(repo, fake_bin)
+        assert result.returncode != 0, "a `git branch --show-current` failure was silently swallowed"

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-target-branch-guard_test.py
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-target-branch-guard_test.py
@@ -1,0 +1,110 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for pre-commit-target-branch-guard (#4113, GH#14151 fail-closed
+guard).
+
+Issue #14151: like pre-commit-branch-guard, this hook never calls
+get_staged_files() or `git diff --cached` — it only calls `git branch
+--show-current`, which does not read `.git/index`. The corrupted-index
+probe every other hook in this family uses cannot reach it, so the genuine
+reproduction is a fake `git` on PATH that fails only `branch --show-current`,
+the same technique pre-commit-worktree-branch-guard_test.py uses for
+`worktree list`.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+HOOK_PATH = Path(__file__).resolve().parent / "pre-commit-target-branch-guard"
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(["git", *args], cwd=repo, capture_output=True, text=True, check=True)
+
+
+def _init_repo(tmp_path: Path, branch: str) -> Path:
+    _git(tmp_path, "init", "--quiet", "-b", branch)
+    _git(tmp_path, "config", "user.email", "t@t")
+    _git(tmp_path, "config", "user.name", "t")
+    (tmp_path / "README.md").write_text("seed\n", encoding="utf-8")
+    _git(tmp_path, "add", "README.md")
+    _git(tmp_path, "-c", "commit.gpgsign=false", "commit", "-q", "-m", "seed")
+    return tmp_path
+
+
+def test_allowed_branch_permits_commit(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path, branch="issue-9999")
+    result = subprocess.run(["bash", str(HOOK_PATH)], cwd=repo, capture_output=True, text=True)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_main_branch_blocks_commit(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path, branch="main")
+    result = subprocess.run(["bash", str(HOOK_PATH)], cwd=repo, capture_output=True, text=True)
+    assert result.returncode != 0, result.stdout + result.stderr
+    assert "COMMIT BLOCKED" in result.stdout
+
+
+class TestFailsClosedWhenDependencyMissing:
+    """GH#14151: `source lib/_common.sh` now aborts with a FATAL message
+    instead of running past a source failure with `${BOLD}`/`${RED}`/etc.
+    unset."""
+
+    def test_a_missing_common_lib_does_not_report_clean(self, tmp_path: Path) -> None:
+        repo = _init_repo(tmp_path, branch="main")  # a genuine violation present
+
+        isolated = tmp_path.parent / "isolated-target-branch-guard"
+        isolated.mkdir()
+        hook_copy = isolated / HOOK_PATH.name
+        hook_copy.write_bytes(HOOK_PATH.read_bytes())
+        hook_copy.chmod(0o755)
+
+        result = subprocess.run([str(hook_copy)], cwd=repo, capture_output=True, text=True)
+        assert result.returncode != 0, "the hook reported clean with no dependency while on a protected branch"
+
+
+class TestFailsClosedWhenGitCannotAnswer:
+    """GH#14151: a `git branch --show-current` failure must not be
+    indistinguishable from "not on a protected branch"."""
+
+    def _make_fake_git(self, tmp_path: Path) -> Path:
+        real_git_path = None
+        for candidate in ("/usr/bin/git", "/bin/git", "/usr/local/bin/git"):
+            if Path(candidate).exists():
+                real_git_path = candidate
+                break
+        assert real_git_path, "could not locate a real git binary to delegate to"
+
+        fake_bin = tmp_path.parent / "fake-bin"
+        fake_bin.mkdir(exist_ok=True)
+        fake_git = fake_bin / "git"
+        fake_git.write_text(
+            "#!/bin/bash\n"
+            f'REAL_GIT="{real_git_path}"\n'
+            'if [ "$1" = "branch" ] && [ "$2" = "--show-current" ]; then\n'
+            '    echo "fatal: simulated branch failure" >&2\n'
+            "    exit 128\n"
+            "fi\n"
+            'exec "$REAL_GIT" "$@"\n',
+            encoding="utf-8",
+        )
+        fake_git.chmod(fake_git.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+        return fake_bin
+
+    def test_a_git_branch_failure_does_not_report_clean(self, tmp_path: Path) -> None:
+        repo = _init_repo(tmp_path, branch="main")  # a genuine violation present
+
+        fake_bin = self._make_fake_git(tmp_path)
+        env = dict(os.environ)
+        env["PATH"] = f"{fake_bin}:{env.get('PATH', '')}"
+
+        result = subprocess.run(["bash", str(HOOK_PATH)], cwd=repo, capture_output=True, text=True, env=env)
+        assert (
+            result.returncode != 0
+        ), "a `git branch --show-current` failure was indistinguishable from 'not protected'"

--- a/pipeline-scripts/check_hook_exec_bits.py
+++ b/pipeline-scripts/check_hook_exec_bits.py
@@ -55,11 +55,17 @@ _CONFIG_PATHS = (
 _REQUIRED_MODE = "100755"
 
 # Hooks that are dormant today and cannot be woken by flipping a mode bit alone,
-# because each has real violations behind it (#14181 measures them: 201
-# blocking-I/O calls, ~1370 local schemas, 71 unregistered env vars, and so on).
-# Turning them on together would block every local commit, so they are recorded
-# here instead of silently passing: every run prints them as KNOWN, with the
-# issue that owns the backlog.
+# because each has real violations behind it. #14181 tracks the backlog; as of
+# this change the two remaining are 201 blocking-I/O calls (tools/lint/
+# check_no_blocking_io_in_async.py, epic #7442) and ~1370 local Pydantic
+# schemas (tools/lint/check_no_local_schemas.py) -- eight other hooks that
+# started on this list (decorator-order, git-safe-directory-required,
+# no-deprecated-ansible-facts, canonical-role-names, no-kb-aioredis-access,
+# no-literal-ttl-seconds, no-utcnow-isoformat, env-vars-documented) have
+# already had their backlogs triaged and come off it. Turning the remaining
+# two on before their backlogs are fixed would block every local commit, so
+# they stay recorded here instead of silently passing: every run prints them
+# as KNOWN, with the issue that owns the backlog.
 #
 # This list only ever shrinks. A hook comes off it in the same change that fixes
 # its violations and flips its exec bit. Adding a new entry is not a way to make


### PR DESCRIPTION
## Thinking Path

Both issues share one theme — a guard that reports clean without checking — and both had substantial prior work landed before this session:

- **#14151** (13 of 14 local hooks share the fail-open `set -uo pipefail` shape): PR #14160 already flipped 12 hooks to `set -euo pipefail` (+ a guarded `source lib/_common.sh` where applicable, + the `((VAR++))`/process-substitution/`|| true`-in-library landmines it found along the way), PR #14170 closed the sibling issues it spawned (#14161/#14162/#14163/#14167). I re-verified against `origin/Dev_new_gui`: **all 13 in-scope hooks are `set -euo pipefail`**, and the 10 that source `lib/_common.sh` all guard it with a `FATAL ... || exit 1`. `pre-commit-warn-untracked` is deliberately excluded (warn-only by documented contract, its own opposite-direction bug is #14161 — closed). The one gap: PR #14160 could not construct a pre-fix-failing reproduction for `pre-commit-branch-guard`, `pre-commit-record-branch` and `pre-commit-target-branch-guard` (none of their git calls read `.git/index`, so the corrupted-index probe every sibling test uses can't reach them), so those three shipped **without** the regression tests AC3 asks for. This PR closes that gap.
- **#14181** (16 hooks tracked non-executable, CI swallowed it): PR #14204 already removed the CI-side `|| exit 0` (criterion 2 — done, verified live in that PR's own CI run). Eight of the original ten backlogged hooks (`decorator-order`, `git-safe-directory-required`, `no-deprecated-ansible-facts`, `canonical-role-names`, `no-kb-aioredis-access`, `no-literal-ttl-seconds`, `no-utcnow-isoformat`, `env-vars-documented`) were triaged and taken off `_KNOWN_DORMANT` by PRs #14186/#14188/#14195/#14200/#14202/#14205/#14213/#14225 before this session started.

Read the full comment history on both issues (`gh issue view 14181/14151 --json comments`) before touching anything, per this repo's own lesson-8 finding on #14181 ("the reported count is a floor, and fixing findings can itself introduce the same defect") — I did not want to re-break something already fixed.

## What Changed

**#14151 — closed the remaining gap (3 hooks, tests only; the `set -euo pipefail` fix itself already landed in #14160):**

- `autobot-infrastructure/shared/scripts/hooks/pre-commit-branch-guard_test.py` (new) — `TestFailsClosedWhenDependencyMissing` (isolated copy with no `lib/` beside it) and `TestFailsClosedWhenGitCannotAnswer` (fake `git` on `PATH` that fails only `branch --show-current`, delegating everything else to the real binary — same technique `pre-commit-worktree-branch-guard_test.py` already uses for `worktree list`), plus 3 ordinary-path tests.
- `autobot-infrastructure/shared/scripts/hooks/pre-commit-record-branch_test.py` (new) — this hook has no `lib/_common.sh` dependency (per #14160's own table: "-e only"), so two `TestFailsClosedWhenGitCannotAnswer` cases cover its two git call sites (`rev-parse --git-dir`, `branch --show-current`) individually with the same fake-git technique.
- `autobot-infrastructure/shared/scripts/hooks/pre-commit-target-branch-guard_test.py` (new) — same two classes as `branch-guard`.
- `pipeline-scripts/check_hook_exec_bits.py` — refreshed a stale comment that still enumerated the original 10-hook #14181 backlog (including 3 hooks fixed by earlier PRs) as if it were current; now names the 2 that remain and the 8 already triaged off the list. Comment-only, no behavior change.

**#14181 — NOT closed. Documented here rather than claimed.** The two remaining `_KNOWN_DORMANT` entries are backlog-campaign scale, not the single-file fixes the prior eight were:

| hook | findings (last measured, #14181 comment thread) | why it's out of scope for this PR |
|---|---|---|
| `tools/lint/check_no_blocking_io_in_async.py` | 201 blocking-I/O calls inside `async def` | tracked as its own epic, **#7442** |
| `tools/lint/check_no_local_schemas.py` | ~1370 local `BaseModel` subclasses under `api/` | a multi-hundred-file migration |

Flipping either hook's exec bit before fixing its backlog would block every future commit touching those files — the same "temp fix that manufactures false confidence" shape these two issues exist to close. Fixing either backlog for real needs the checker and the full test suite run repeatedly to confirm ~200-1370 individual sites don't regress behavior, which is outside this session's static-verification-only constraint (`Do NOT run application code or the test suite`). The issue's own owner called these two "a different scale... worth planning rather than picking up in a loop tick" — I agree with that assessment rather than rushing a shallow pass across 1,370 Pydantic models. Left `_KNOWN_DORMANT` and `enforce-precommit.yml` untouched beyond the comment refresh; no regression.

## Verification

**`git ls-files -s` evidence (mode, not `ls -l`) for the 3 new test files and the touched baseline file:**

```
100644 e2f1341d36cdbb0eb4a2b5231921f809cb28162f 0  autobot-infrastructure/shared/scripts/hooks/pre-commit-branch-guard_test.py
100644 487e729afaac341bbb4f245ece21fecd41cecbbd 0  autobot-infrastructure/shared/scripts/hooks/pre-commit-record-branch_test.py
100644 acb59954f71623a6a060bcad1bdc3e8a8b31fd56 0  autobot-infrastructure/shared/scripts/hooks/pre-commit-target-branch-guard_test.py
```
(`100644` is correct here — these are pytest-collected `_test.py` files, not `entry:`-invoked hook scripts; every sibling `_test.py` in the directory is tracked the same way, confirmed against `pre-commit-worktree-branch-guard_test.py` and `pre-commit-no-tag-pinned-action_test.py`.)

**Per-hook fail-open analysis, re-verified against `origin/Dev_new_gui` (not assumed from the issue thread):**

```
$ grep -n "^set -" autobot-infrastructure/shared/scripts/hooks/pre-commit-*
... all 16 hook scripts: set -euo pipefail, EXCEPT pre-commit-warn-untracked: set -uo pipefail (deliberate, warn-only, #14161 closed)
```

All 13 of #14151's in-scope hooks are `set -euo pipefail`; the 10 that source `lib/_common.sh` all have `source ... || { echo FATAL...; exit 1; }`. For the 3 this PR adds tests for:

- `pre-commit-branch-guard` / `pre-commit-target-branch-guard`: neither calls `get_staged_files()` or `git diff --cached` — only `git rev-parse --git-dir` / `git branch --show-current`, neither of which reads `.git/index`. Verified generically (scratch, non-repo script) that bash's `set -e` DOES abort on a failing command substitution inside a plain assignment (`x=$(false)` under `set -e` never reaches the next line) — so a `git branch --show-current` failure aborts the hook via `-e` alone, before its own `[ -z ... ]` skip-check is ever reached. Regression pinned with a fake `git` on `PATH` that fails only that one subcommand.
- `pre-commit-record-branch`: no `lib/_common.sh` dependency; same `-e`-on-command-substitution mechanism covers both of its git calls. Two tests, one per call site.
- Missing-lib case: both `branch-guard` and `target-branch-guard` source `lib/_common.sh` unconditionally; an isolated copy of the hook with no `lib/` directory beside it reproduces `source: No such file or directory` → the `||` guard's `FATAL` + `exit 1`, non-zero as required.

I did not execute any of these tests or hook scripts myself (static verification only, per this task's constraint) — CI runs the actual suite. The technique (fake `git` on `PATH`, isolated hook copy with no sibling `lib/`) is copied verbatim from `pre-commit-worktree-branch-guard_test.py` and `pre-commit-no-tag-pinned-action_test.py`, both already merged and passing in CI.

**#14181 exec-bit baseline: NOT empty.** Current state, read from the file added by this PR's own diff:

```
_KNOWN_DORMANT = frozenset(
    {
        "tools/lint/check_no_blocking_io_in_async.py",
        "tools/lint/check_no_local_schemas.py",
    }
)
```

Two entries remain — down from the original ten, but not zero. See "What Changed" above for why these two are out of scope here.

## Model Used

Sonnet 5

Closes #14151
Refs #14181
