### PR TITLE
fix(deploy): a single-role redeploy no longer claims chromadb ownership from target_roles (#14289)

### DIFF
--- a/autobot-slm-backend/ansible/deploy.yml
+++ b/autobot-slm-backend/ansible/deploy.yml
@@ -14,11 +14,20 @@
 
   vars:
     target_roles: "{{ target_roles | default('slm-agent') }}"
-    # #13870: this play selects roles from target_roles rather than the
-    # role_*_active facts, so it needs its own derivation. Without it a
-    # `target_roles=ai-stack` run falls to the role default and, on a host where
-    # redis also ran earlier, both roles write the unit again.
-    chromadb_service_owner: "{{ 'redis' if 'redis' in (target_roles.split(',') | map('trim') | list) else 'ai-stack' }}"
+
+  # #7050/#7051 shared role-active facts — see playbooks/vars/role_active_facts.yml
+  # for why this is needed (this play can run against a temp inventory with no
+  # sibling group_vars/, e.g. the SLM wizard path).
+  #
+  # #14289: chromadb_service_owner MUST derive from host state
+  # (role_redis_active / role_ai_stack_active), never from target_roles. A unit
+  # shared by two roles may only be claimed from facts about the host — target_roles
+  # says which roles THIS run deploys, not which roles are actually present. Deriving
+  # from target_roles meant a `target_roles=ai-stack` redeploy against an
+  # already-combined host reclaimed the unit from redis on every run, even though
+  # redis was never touched (#4090).
+  vars_files:
+    - playbooks/vars/role_active_facts.yml
 
   tasks:
     - name: Parse target roles

--- a/autobot-slm-backend/tests/services/test_chromadb_unit_single_owner_13870_test.py
+++ b/autobot-slm-backend/tests/services/test_chromadb_unit_single_owner_13870_test.py
@@ -267,9 +267,21 @@ def test_the_database_stack_owns_the_database():
             f"{rel} does not hand a combined host to the db stack — the ai-stack venv " "has no chromadb installed"
         )
 
-    deploy = (_ANSIBLE / "deploy.yml").read_text(encoding="utf-8")
-    owner_line = next(ln for ln in deploy.splitlines() if "chromadb_service_owner:" in ln)
-    assert "'redis' if" in owner_line, "deploy.yml still prefers ai-stack when both are requested"
+    # #14289: deploy.yml no longer re-derives the owner itself -- a play `vars:`
+    # override outranks the correct facts and was the bug. It must instead load
+    # the shared derivation via vars_files, which is asserted identical to the
+    # other two copies above.
+    deploy = yaml.safe_load((_ANSIBLE / "deploy.yml").read_text(encoding="utf-8"))[0]
+    assert "chromadb_service_owner" not in (deploy.get("vars") or {}), (
+        "deploy.yml re-derives chromadb_service_owner in its own vars: block again -- "
+        "that always outranks the host-derived facts loaded below (#14289)"
+    )
+    vars_files = [str(v) for v in deploy.get("vars_files") or []]
+    assert any(v.endswith("role_active_facts.yml") for v in vars_files), (
+        "deploy.yml does not load the shared role_*_active facts -- a caller with no "
+        "group_vars sibling (services/deployment.py's bare `-i host,` invocation) would "
+        "see chromadb_service_owner resolve to nothing or to the wrong value"
+    )
 
 
 def test_the_persist_directory_moves_with_the_service():

--- a/autobot-slm-backend/tests/services/test_deploy_chromadb_owner_host_derived_14289_test.py
+++ b/autobot-slm-backend/tests/services/test_deploy_chromadb_owner_host_derived_14289_test.py
@@ -116,4 +116,6 @@ def test_the_two_group_vars_copies_and_deploy_yml_agree_on_the_derivation():
     play = _deploy_play()
     vars_files = [Path(v) for v in play.get("vars_files") or []]
     resolved = {(_ANSIBLE / v).resolve() for v in vars_files}
-    assert canonical.resolve() in resolved, "deploy.yml's vars_files does not point at the canonical role_active_facts.yml"
+    assert (
+        canonical.resolve() in resolved
+    ), "deploy.yml's vars_files does not point at the canonical role_active_facts.yml"

--- a/autobot-slm-backend/tests/services/test_deploy_chromadb_owner_host_derived_14289_test.py
+++ b/autobot-slm-backend/tests/services/test_deploy_chromadb_owner_host_derived_14289_test.py
@@ -1,0 +1,119 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""A single-role redeploy must not claim chromadb ownership from target_roles
+(#14289).
+
+Three code paths reach `ansible/deploy.yml`:
+
+- `services/playbook_executor.py::execute_playbook` -- builds a temp inventory
+  and symlinks `inventory/group_vars/` beside it, so `role_redis_active` /
+  `role_ai_stack_active` resolve from `inventory/group_vars/all.yml`.
+- `api/setup_wizard.py::_generate_dynamic_inventory` -- since #14287, also
+  links `group_vars/` the same way.
+- `services/deployment.py::_execute_ansible_playbook` -- runs
+  `ansible-playbook ... -i {host},`. That `-i` value is a bare inline host
+  string, not an inventory FILE, so Ansible's `group_vars/` auto-discovery
+  (which resolves relative to the inventory file's directory) never fires on
+  this path at all -- with or without #14287.
+
+`deploy.yml` is the one file all three converge on, so it is the only place a
+fix can be robust regardless of caller. The pre-fix bug was a play-level
+`vars:` entry that recomputed `chromadb_service_owner` from `target_roles`
+(what THIS run was asked to deploy) instead of the shared `role_redis_active`
+/ `role_ai_stack_active` facts (what is actually installed on the host) --
+Ansible play vars outrank `group_vars`, so a `target_roles=ai-stack` redeploy
+against an already-combined host reclaimed the unit from redis on every run
+(#4090's outage verbatim).
+
+The invariant these guard: `deploy.yml` resolves ownership from host state,
+and does so on its own -- no execution stack's inventory-linking behavior may
+be a precondition for the answer being correct.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+_ANSIBLE = Path(__file__).resolve().parents[2] / "ansible"
+_DEPLOY = _ANSIBLE / "deploy.yml"
+
+
+def _deploy_play() -> dict:
+    docs = yaml.safe_load(_DEPLOY.read_text(encoding="utf-8"))
+    assert isinstance(docs, list) and docs, "deploy.yml did not parse to a play list"
+    return docs[0]
+
+
+def test_deploy_yml_loads_the_shared_role_active_facts():
+    """`services/deployment.py` invokes deploy.yml with a bare `-i host,`
+    inventory string, so group_vars auto-discovery can never supply
+    role_redis_active/role_ai_stack_active on that path. Only an explicit
+    `vars_files` load makes chromadb_service_owner resolve correctly there."""
+    play = _deploy_play()
+    vars_files = [str(v) for v in play.get("vars_files") or []]
+    assert any(v.endswith("role_active_facts.yml") for v in vars_files), (
+        "deploy.yml no longer loads playbooks/vars/role_active_facts.yml -- a caller with "
+        "no group_vars sibling would see role_redis_active/role_ai_stack_active as undefined"
+    )
+
+
+def test_deploy_yml_does_not_re_derive_ownership_in_its_own_vars_block():
+    """The #14289 regression itself: a play `vars:` entry for
+    chromadb_service_owner outranks the correctly-derived facts, wherever they
+    come from (group_vars or vars_files)."""
+    play = _deploy_play()
+    play_vars = play.get("vars") or {}
+    assert "chromadb_service_owner" not in play_vars, (
+        "deploy.yml re-derives chromadb_service_owner in its own play vars: block -- "
+        "this always outranks the host-derived facts and was the #14289 bug"
+    )
+
+
+def test_no_chromadb_owner_derivation_anywhere_reads_target_roles_or_role_list():
+    """The invariant, not today's specific spelling: a unit shared by two
+    roles may only be claimed from facts ABOUT THE HOST
+    (role_redis_active / role_ai_stack_active), never from target_roles or
+    role_list -- the caller's list of roles to run THIS pass, which says
+    nothing about what is already installed on the host.
+
+    Scans every ansible YAML file rather than just deploy.yml, so a future
+    reintroduction anywhere in the tree (a new playbook, a role default, a
+    second override) is caught the same way.
+    """
+    offenders: list[str] = []
+    for path in _ANSIBLE.rglob("*.yml"):
+        for lineno, raw_line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            line = raw_line.split("#", 1)[0]
+            if "chromadb_service_owner" not in line or ":" not in line:
+                continue
+            key = line.split(":", 1)[0].strip()
+            if key != "chromadb_service_owner":
+                continue
+            if re.search(r"\btarget_roles\b|\brole_list\b", line):
+                offenders.append(f"{path.relative_to(_ANSIBLE)}:{lineno}: {line.strip()}")
+    assert not offenders, "chromadb_service_owner derived from the caller's role list, not host state: " + "; ".join(
+        offenders
+    )
+
+
+def test_the_two_group_vars_copies_and_deploy_yml_agree_on_the_derivation():
+    """Both `role_active_facts.yml` copies already derive
+    `chromadb_service_owner` from `role_redis_active` (guarded byte-for-byte
+    by `ansible/tests/check_role_facts_synced.py`). deploy.yml's `vars_files`
+    entry must point at the SAME file, or the two "stacks" resolve the same
+    variable name to two different formulas depending on which one happened
+    to link group_vars."""
+    canonical = _ANSIBLE / "playbooks" / "vars" / "role_active_facts.yml"
+    text = canonical.read_text(encoding="utf-8")
+    owner_line = next(ln for ln in text.splitlines() if ln.startswith("chromadb_service_owner:"))
+    assert "role_redis_active" in owner_line, f"{canonical} no longer derives ownership from host state"
+
+    play = _deploy_play()
+    vars_files = [Path(v) for v in play.get("vars_files") or []]
+    resolved = {(_ANSIBLE / v).resolve() for v in vars_files}
+    assert canonical.resolve() in resolved, "deploy.yml's vars_files does not point at the canonical role_active_facts.yml"


### PR DESCRIPTION
## Thinking Path

#14289 is item 3 of #14286, split out because it is not an inventory defect and PR
#14287 does not fix it. #14287 gave the two ansible execution stacks group_vars
parity (items 1+2), so `role_redis_active` / `role_ai_stack_active` now resolve
identically wherever the temp inventory is generated. This PR is the belt to that
brace: `ansible/deploy.yml` had its own play-level `vars:` entry for
`chromadb_service_owner` that recomputed the answer from `target_roles` — the
roles THIS run was asked to deploy — instead of from those facts. Play vars
outrank `group_vars`, so #14287's fix was being discarded on this specific path
regardless of how well the inventory resolved.

Read the two calling stacks named in #14286 (`playbook_executor.py`,
`setup_wizard.py`) plus a third one found while tracing every caller of
`deploy.yml`: `services/deployment.py::_execute_ansible_playbook` runs
`ansible-playbook ... -i {host},` — a bare inline host string, not an inventory
file — so `group_vars/` auto-discovery can never fire there no matter what
#14287 does. That ruled out "just rely on group_vars resolving" as the fix and
pointed at the pattern this repo already uses for exactly this situation:
`vars_files: [playbooks/vars/role_active_facts.yml]`, the same mechanism
`provision-fleet-roles.yml` and `apply-secrets.yml` use to be self-sufficient
regardless of caller.

## What Changed

- **`autobot-slm-backend/ansible/deploy.yml`** — removed the play `vars:` entry
  that derived `chromadb_service_owner` from `target_roles.split(',')`, and added
  `vars_files: [playbooks/vars/role_active_facts.yml]` so the play instead picks
  up the SAME host-derived formula (`'redis' if role_redis_active else 'ai-stack'`)
  the other two copies already use, byte-guarded identical by
  `ansible/tests/check_role_facts_synced.py`. `target_roles` still selects which
  roles this run deploys (`role_list`); it no longer decides who owns a unit it
  didn't touch.
- **`tests/services/test_chromadb_unit_single_owner_13870_test.py`** — updated
  `test_the_database_stack_owns_the_database`, which was asserting the buggy
  `target_roles`-derived line verbatim (it would have kept passing against the
  bug forever). It now asserts deploy.yml carries no `vars:` override and loads
  the canonical facts file instead.
- **`tests/services/test_deploy_chromadb_owner_host_derived_14289_test.py`**
  (new) — the guard described below.

## Verification

New guard test, 4 cases, all passing on the fix and all mutated red against the
exact pre-fix line (`chromadb_service_owner` derived from
`target_roles`/`role_list` again):

- `test_deploy_yml_loads_the_shared_role_active_facts` — `deploy.yml` must load
  `playbooks/vars/role_active_facts.yml` via `vars_files`, because the
  `services/deployment.py` calling stack never gets a group_vars sibling at all.
- `test_deploy_yml_does_not_re_derive_ownership_in_its_own_vars_block` — no play
  `vars:` key named `chromadb_service_owner` (play vars outrank everything else).
- `test_no_chromadb_owner_derivation_anywhere_reads_target_roles_or_role_list` —
  the invariant, not today's spelling: scans every `*.yml` under `ansible/` for
  any `chromadb_service_owner:` line referencing `target_roles` or `role_list`,
  anywhere in the tree, not just `deploy.yml`.
- `test_the_two_group_vars_copies_and_deploy_yml_agree_on_the_derivation` —
  `deploy.yml`'s `vars_files` entry resolves to the exact same file the
  `role_redis_active`-derived formula lives in.

Mutating `deploy.yml` back to the pre-fix play var (re-adding
`chromadb_service_owner: "{{ 'redis' if 'redis' in (target_roles.split(',') | ...) else 'ai-stack' }}"`
and dropping `vars_files`) turns all 4 new tests red, plus the pre-existing
`test_the_database_stack_owns_the_database` — 5 failures, restored to 22 passed /
1 skipped after reverting the mutation.

Ran locally (static/file-parsing only, no ansible execution):
```
tests/services/test_deploy_chromadb_owner_host_derived_14289_test.py .... [4/4]
tests/services/test_chromadb_unit_single_owner_13870_test.py ..........s..... [22 passed, 1 skipped]
tests/services/ -k "chromadb or deploy or wizard or inventory"            [56 passed, 1 skipped]
python3 ansible/tests/check_role_facts_synced.py                          OK — 12 shared facts identical
pipeline-scripts/detect-hardcoded-values.sh <changed files>                pass (0 hardcoded)
```
No ansible was run and nothing was deployed, per instruction — CI executes the
ansible-side test playbooks (`tests/playbooks/test_role_active_facts*.yml`).

### #14286 status: code delivered, host criterion outstanding

This PR completes #14286's item 3 (the third of three "what is needed" items;
1+2 already landed in #14287). But #14286's own "Verification that would close
this" section is explicitly host-observable — a live `target_roles=ai-stack`
redeploy against an already-combined host, confirming
`autobot-chromadb.service` still points at the db-stack venv and `NRestarts`
stays flat afterwards. I have no access to a live host in this session, so that
cannot be evidenced here, and per this repo's rules partial delivery does not
close an issue. This PR therefore uses `Closes #14289` (the ownership-derivation
bug itself, code-provable and guard-tested above) and `Refs #14286` (stays open
until someone with host access runs that redeploy and posts the
`systemctl show autobot-chromadb.service -p ExecStart` / `NRestarts` output).

## Model Used

Sonnet 5.

Closes #14289
Refs #14286, #4090, #13870, #13852, #11781, #14287
