### PR TITLE
fix(chat-history): route session-scoped chat events and reads through the right key

### DIFF
--- a/autobot-backend/api/chat.py
+++ b/autobot-backend/api/chat.py
@@ -51,11 +51,12 @@ from api.schemas_chat import (
 )
 from api.schemas_common import DataResponse
 from api.user_management.dependencies import require_org_context
+from api.websockets import NON_CONVERSATIONAL_WEBSOCKET_MESSAGE_TYPES
 from auth_middleware import get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.error_utils import safe_http_detail
 from autobot_shared.time_utils import parse_utc_iso, utc_timestamp
-from chat_history.message_schema import llm_role, message_text
+from chat_history.message_schema import llm_role, message_text, message_type
 
 # Import context overflow protection (#9043)
 from chat_history.overflow_integration import create_summary_message, handle_message_completion
@@ -199,8 +200,7 @@ def _has_longer_streaming_response(
 
 def _is_streaming_response(msg: Dict) -> bool:
     """Check if message is a streaming LLM response (Issue #281: module-level helper)."""
-    message_type = msg.get("messageType", msg.get("type", "default"))
-    return message_type in STREAMING_MESSAGE_TYPES
+    return message_type(msg) in STREAMING_MESSAGE_TYPES
 
 
 def _get_message_signature(msg: Dict) -> tuple:
@@ -215,7 +215,7 @@ def _get_message_signature(msg: Dict) -> tuple:
     For assistant messages, use sender + content (truncated) for deduplication.
     For terminal/system messages, use ID if available, else timestamp + content prefix.
     """
-    message_type = msg.get("messageType", msg.get("type", "default"))
+    msg_type = message_type(msg)
     sender = msg.get("sender", "")
     text_content = msg.get("text", "") or msg.get("content", "")
 
@@ -229,7 +229,7 @@ def _get_message_signature(msg: Dict) -> tuple:
         # Use first 300 chars of content - enough to identify unique messages
         # while handling minor whitespace differences
         normalized_content = text_content.strip()[:300]
-        return ("assistant", message_type, normalized_content)
+        return ("assistant", msg_type, normalized_content)
 
     # For TERMINAL/SYSTEM messages: use ID if available
     msg_id = msg.get("id") or msg.get("messageId")
@@ -572,10 +572,24 @@ def _build_llm_context(
     # paid for. That is the stance `as_llm_messages` and `_sanitize_tool_messages`
     # already take. Not switched to `as_llm_messages` wholesale: that also drops
     # empty-bodied messages, which would quietly change what the model sees here.
+    #
+    # #14342 review follow-up: `messageType` in NON_CONVERSATIONAL_WEBSOCKET_
+    # MESSAGE_TYPES excludes the websocket-broadcast UI telemetry (agent
+    # steps, tool output, workflow progress/errors, thoughts) that #14342 made
+    # reachable from a session for the first time. Before that fix these
+    # records never reached any session, so this builder never saw them.
+    # Filtered *before* the `[-message_limit:]` slice, not after: filtering
+    # after would still let a busy turn's telemetry consume slots in a
+    # count-bounded window and evict real dialogue that never even reaches
+    # this list. Terminal/approval/workflow-state records that predate
+    # #14342 keep a different `messageType` and are unaffected.
+    conversational_context = [
+        msg
+        for msg in chat_context
+        if isinstance(msg, dict) and message_type(msg) not in NON_CONVERSATIONAL_WEBSOCKET_MESSAGE_TYPES
+    ]
     llm_context = [
-        {"role": llm_role(msg), "content": message_text(msg)}
-        for msg in chat_context[-message_limit:]
-        if isinstance(msg, dict)
+        {"role": llm_role(msg), "content": message_text(msg)} for msg in conversational_context[-message_limit:]
     ]
     llm_context.append({"role": message.role, "content": message.content})
 
@@ -2107,10 +2121,18 @@ async def _generate_ai_stack_chat_response(
         # path: this reads its context from the same store, in the same stored
         # shape, so the speaker was likewise never present and every turn — the
         # assistant's own replies included — arrived attributed to the caller.
+        #
+        # #14342 review follow-up: same UI-telemetry exclusion as
+        # `_build_llm_context`, and filtered before the slice for the same
+        # reason — this path reads from the same session store, so it is
+        # exposed to the same newly-reachable websocket event records.
+        conversational_context = [
+            msg
+            for msg in chat_context
+            if isinstance(msg, dict) and message_type(msg) not in NON_CONVERSATIONAL_WEBSOCKET_MESSAGE_TYPES
+        ]
         formatted_history = [
-            {"role": llm_role(msg), "content": message_text(msg)}
-            for msg in chat_context[-message_limit:]
-            if isinstance(msg, dict)
+            {"role": llm_role(msg), "content": message_text(msg)} for msg in conversational_context[-message_limit:]
         ]
 
         ai_stack_response = await ai_client.chat_message(

--- a/autobot-backend/api/chat.py
+++ b/autobot-backend/api/chat.py
@@ -405,7 +405,11 @@ def _to_persisted_message(api_data: Dict[str, Any], default_type: str) -> Dict[s
     persisted: Dict[str, Any] = {
         "id": api_data["id"],
         "sender": sender,
-        "content": api_data.get("content", ""),
+        # #14341: api_data may be API-shape ("content") or stored-shape
+        # ("text") — create_summary_message returns the latter. Resolving
+        # through message_text handles both instead of reading only "content"
+        # and silently persisting an empty summary.
+        "content": message_text(api_data),
         "timestamp": api_data.get("timestamp"),
         "type": default_type,
         "metadata": api_data.get("metadata") or {},

--- a/autobot-backend/api/chat_llm_context_test.py
+++ b/autobot-backend/api/chat_llm_context_test.py
@@ -19,11 +19,15 @@ function rather than exercise its mapping. So these tests build their records
 with the **real writer** and call the **real function**.
 """
 
+import asyncio
+from typing import Any, Dict, List
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from api.chat import _build_llm_context, _generate_ai_stack_chat_response, _to_persisted_message
+from api.websockets import NON_CONVERSATIONAL_WEBSOCKET_MESSAGE_TYPES, _create_broadcast_event_handler
+from chat_history.messages import MessagesMixin
 
 
 def _persisted(role: str, content: str) -> dict:
@@ -185,3 +189,108 @@ class TestTheIncomingTurnAndLimit:
         context = _build_llm_context(history, _incoming(), _manager(), None)
 
         assert {"role": "user", "content": "real"} in context
+
+
+class _RecordingHistory(MessagesMixin):
+    """Real add_message/get_session_messages pair over an in-memory store —
+    used here to produce a *real* #14342-routed record, not a hand-built dict
+    already shaped like the check below."""
+
+    def __init__(self) -> None:
+        self.history: List[Dict[str, Any]] = []
+        self.sessions: Dict[str, List[Dict[str, Any]]] = {}
+
+    async def load_session(self, session_id: str) -> List[Dict[str, Any]]:
+        return list(self.sessions.get(session_id, []))
+
+    async def save_session(self, session_id: str, messages: List[Dict[str, Any]], **_: Any) -> bool:
+        self.sessions[session_id] = list(messages)
+        return True
+
+
+class _FakeWebSocket:
+    async def send_json(self, data: dict) -> None:
+        pass
+
+
+class TestWebsocketTelemetryPinnedDecision:
+    """#14342 review follow-up: #14342 fixed *where* websocket-broadcast UI
+    telemetry is stored (its own session, not a bucket no reader touched).
+    That alone would have made it newly reachable from `_build_llm_context`
+    as a conversational turn. The decision, pinned here: it does not enter
+    `llm_context` — it is UI telemetry, not something the user or the
+    assistant said.
+
+    Built through the real #14342 producer (`broadcast_event`, the callback
+    `events/bus.py` invokes) into a real session store, not a hand-fed dict
+    already carrying the key the filter checks — the same trap that let
+    #14340/#14341 hide.
+    """
+
+    def test_a_real_tool_output_event_does_not_enter_llm_context(self):
+        manager = _RecordingHistory()
+
+        async def seed_and_read() -> list:
+            broadcast_event = await _create_broadcast_event_handler(_FakeWebSocket(), manager)
+            await broadcast_event(
+                {"type": "tool_output", "payload": {"output": "rm -rf leftover", "session_id": "s-1"}}
+            )
+            await manager.add_message(sender="user", text="clean up the workspace", session_id="s-1")
+            return await manager.get_session_messages("s-1", limit=500)
+
+        chat_context = asyncio.run(seed_and_read())
+        assert len(chat_context) == 2, "precondition: both records really did land in the session"
+
+        context = _build_llm_context(chat_context, _incoming("what did you just do?"), _manager(), None)
+
+        assert not any("rm -rf leftover" in m["content"] for m in context)
+        assert any(m["content"] == "clean up the workspace" for m in context)
+
+    def test_the_full_dispatch_table_is_covered_minus_the_two_real_turns(self):
+        """Precondition on the constant itself: guards against the allowlist
+        silently shrinking to nothing (or growing to swallow real turns) as
+        MESSAGE_TYPE_FORMATTERS changes."""
+        from api.websockets import MESSAGE_TYPE_FORMATTERS
+
+        assert NON_CONVERSATIONAL_WEBSOCKET_MESSAGE_TYPES == set(MESSAGE_TYPE_FORMATTERS) - {
+            "user_message",
+            "llm_response",
+        }
+        assert "tool_output" in NON_CONVERSATIONAL_WEBSOCKET_MESSAGE_TYPES
+        assert "workflow_failed" in NON_CONVERSATIONAL_WEBSOCKET_MESSAGE_TYPES
+        assert "user_message" not in NON_CONVERSATIONAL_WEBSOCKET_MESSAGE_TYPES
+
+    def test_telemetry_does_not_evict_real_dialogue_from_the_window(self):
+        """Window-displacement case: a burst of telemetry between two real
+        turns must not push the earlier real turn out of a count-bounded
+        window — filtering has to happen before the slice, not after."""
+        history = (
+            [_persisted("user", "turn 0")]
+            + [{"sender": "workflow", "text": f"step {i}", "messageType": "workflow_step_started"} for i in range(5)]
+            + [_persisted("assistant", "turn 1")]
+        )
+
+        context = _build_llm_context(history, _incoming("turn 2"), _manager(limit=2), None)
+
+        # limit=2 conversational turns from history + the incoming turn, none
+        # of them telemetry — the 5-record telemetry burst must not have
+        # consumed the 2-slot budget the slice is meant to give real turns.
+        assert [m["content"] for m in context] == ["turn 0", "turn 1", "turn 2"]
+
+    @pytest.mark.asyncio
+    async def test_a_real_tool_output_event_does_not_enter_the_ai_stack_history(self):
+        manager = _RecordingHistory()
+        broadcast_event = await _create_broadcast_event_handler(_FakeWebSocket(), manager)
+        await broadcast_event({"type": "tool_output", "payload": {"output": "secret command", "session_id": "s-2"}})
+        await manager.add_message(sender="user", text="deploy it", session_id="s-2")
+        chat_context = await manager.get_session_messages("s-2", limit=500)
+
+        client = MagicMock()
+        client.chat_message = AsyncMock(return_value={"response": "ok"})
+
+        with patch("api.chat.get_ai_stack_client", AsyncMock(return_value=client)):
+            await _generate_ai_stack_chat_response(_incoming(), chat_context, None, _manager(), None)
+
+        sent = client.chat_message.call_args.kwargs["chat_history"]
+        assert not any("secret command" in m["content"] for m in sent)
+        assert any(m["content"] == "deploy it" for m in sent)

--- a/autobot-backend/api/chat_overflow_summary_persistence_test.py
+++ b/autobot-backend/api/chat_overflow_summary_persistence_test.py
@@ -1,0 +1,82 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Regression tests for Issue #14341 — context-overflow summaries were
+
+persisted with an empty body.
+
+``chat_history/overflow_integration.py::create_summary_message`` returns the
+summary under the *stored*-shape body key (``text``); ``api/chat.py``'s
+``_to_persisted_message`` read only the *API*-shape key (``content``),
+defaulting to ``""``. The record that landed had a valid id, sender,
+timestamp and type — and no text, so the conversation the summary was meant
+to replace was gone with nothing standing in for it.
+
+These tests build the summary with the real producer
+(``create_summary_message``) and read it back with the real consumers
+(``_to_persisted_message`` and, for the end-to-end case, ``_build_llm_context``
+— the function that turns persisted history into what the model actually
+sees), rather than hand-feeding a dict already shaped like the fix's own
+check.
+"""
+
+import asyncio
+from unittest.mock import MagicMock
+
+from api.chat import _build_llm_context, _to_persisted_message
+from chat_history.message_schema import message_text
+from chat_history.overflow_integration import create_summary_message
+
+
+def _incoming(text: str = "and now?"):
+    message = MagicMock()
+    message.role = "user"
+    message.content = text
+    return message
+
+
+def _manager(limit: int = 20):
+    manager = MagicMock()
+    manager.context_manager.get_message_limit = MagicMock(return_value=limit)
+    return manager
+
+
+def test_summary_round_trips_through_persistence_with_its_text_intact() -> None:
+    """create_summary_message -> _to_persisted_message must not drop the body."""
+    summary = asyncio.run(create_summary_message("earlier: deployed the release, then rolled back"))
+
+    persisted = _to_persisted_message(summary, "context_summary")
+
+    # Read the way a consumer does (message_schema), not by inspecting the
+    # dict the writer happened to produce.
+    assert message_text(persisted) == "earlier: deployed the release, then rolled back"
+
+
+def test_summary_producer_really_does_use_the_stored_shape_key() -> None:
+    """Precondition: this cannot pass because the mismatch is already absent."""
+    summary = asyncio.run(create_summary_message("some earlier history"))
+
+    assert "content" not in summary, "producer already writes the API-shape key"
+    assert summary["text"] == "some earlier history"
+
+
+def test_a_subsequent_context_build_contains_the_summary_text() -> None:
+    """End to end: overflow triggers, summary persists, and a later context
+    build (the real _build_llm_context, not a mock) still contains it."""
+    summary = asyncio.run(create_summary_message("condensed: user asked about deploys, agent explained code-sync"))
+    persisted = _to_persisted_message(summary, "context_summary")
+
+    context = _build_llm_context([persisted], _incoming(), _manager(), None)
+
+    assert any("condensed: user asked about deploys" in m["content"] for m in context[:-1])
+
+
+def test_persisted_summary_is_not_empty() -> None:
+    """The acceptance criterion in the issue's own words: non-empty, read the
+    way a consumer reads it."""
+    summary = asyncio.run(create_summary_message("non-trivial summary body"))
+
+    persisted = _to_persisted_message(summary, "context_summary")
+
+    assert message_text(persisted) != ""

--- a/autobot-backend/api/chat_shared_links.py
+++ b/autobot-backend/api/chat_shared_links.py
@@ -46,6 +46,7 @@ from autobot_shared.logging_manager import get_logger
 from autobot_shared.proxy_utils import get_client_ip
 from autobot_shared.rate_limiter import RateLimiter
 from autobot_shared.time_utils import now_utc
+from chat_history.message_schema import message_role, message_text
 from models.chat_shared_link import ChatSharedLink
 from security.session_ownership import SessionOwnershipValidator
 from user_management.services.user_service import UserService
@@ -398,14 +399,18 @@ async def _load_session_data(link: ChatSharedLink, request: Request) -> Dict[str
 
     if chat_history_manager:
         raw = await chat_history_manager.get_session_messages(link.session_id, limit=500)
+        # #14340: get_session_messages returns the stored shape ("sender"/
+        # "text"/"timestamp"), which this filter and mapping never carried —
+        # resolve through message_schema (added for exactly this mismatch,
+        # #14259) instead of reading keys the producer never writes.
         messages = [
             SharedMessageItem(
-                role=m.get("role", "user"),
-                content=m.get("content", ""),
-                created_at=m.get("created_at"),
+                role=message_role(m, default="user"),
+                content=message_text(m),
+                created_at=m.get("created_at") or m.get("timestamp"),
             )
             for m in (raw or [])
-            if m.get("role") in {"user", "assistant"}
+            if isinstance(m, dict) and message_role(m) in {"user", "assistant"}
         ]
 
     return create_success_response(

--- a/autobot-backend/api/chat_shared_links_message_schema_test.py
+++ b/autobot-backend/api/chat_shared_links_message_schema_test.py
@@ -1,0 +1,111 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Regression tests for Issue #14340 — the shared-link viewer rendered every
+
+shared session empty.
+
+``get_session_messages`` returns records in the *stored* shape (``sender``/
+``text``), which ``_load_session_data``'s filter and mapping asked for under
+keys (``role``/``content``) the stored shape has never carried. The
+membership test was therefore ``None in {"user", "assistant"}`` for every
+record, so the comprehension always produced an empty list — a well-formed,
+empty ``200`` response indistinguishable from a session shared before
+anything was said.
+
+These tests write fixtures with the real writer (``MessagesMixin.add_message``,
+via the same in-memory harness ``chat_history/add_message_call_sites_test.py``
+uses) and call the real endpoint helper, ``_load_session_data`` — a
+hand-written record carrying ``role``/``content`` directly would pass against
+the broken code too, so it would not catch this.
+"""
+
+import asyncio
+import types
+from typing import Any, Dict, List
+
+from api.chat_shared_links import _load_session_data
+from chat_history.messages import MessagesMixin
+
+
+class _RecordingHistory(MessagesMixin):
+    """Real add_message/get_session_messages pair over an in-memory store."""
+
+    def __init__(self) -> None:
+        self.history: List[Dict[str, Any]] = []
+        self.sessions: Dict[str, List[Dict[str, Any]]] = {}
+
+    async def load_session(self, session_id: str) -> List[Dict[str, Any]]:
+        return list(self.sessions.get(session_id, []))
+
+    async def save_session(self, session_id: str, messages: List[Dict[str, Any]], **_: Any) -> bool:
+        self.sessions[session_id] = list(messages)
+        return True
+
+
+def _fake_request(manager: _RecordingHistory) -> types.SimpleNamespace:
+    """A Request stand-in exposing only what get_chat_history_manager reads."""
+    state = types.SimpleNamespace(chat_history_manager=manager)
+    app = types.SimpleNamespace(state=state)
+    return types.SimpleNamespace(app=app)
+
+
+def _link(session_id: str) -> types.SimpleNamespace:
+    return types.SimpleNamespace(session_id=session_id, has_password=False)
+
+
+def test_stored_shape_user_and_assistant_records_render_with_bodies() -> None:
+    manager = _RecordingHistory()
+
+    async def seed() -> None:
+        await manager.add_message(sender="user", text="how do I deploy?", session_id="shared-1")
+        await manager.add_message(sender="assistant", text="run code-sync", session_id="shared-1")
+
+    asyncio.run(seed())
+
+    result = asyncio.run(_load_session_data(_link("shared-1"), _fake_request(manager)))
+
+    messages = result["data"]["messages"]
+    assert len(messages) == 2
+    assert [m["role"] for m in messages] == ["user", "assistant"]
+    assert [m["content"] for m in messages] == ["how do I deploy?", "run code-sync"]
+
+
+def test_the_writer_really_does_use_the_stored_shape_keys() -> None:
+    """Precondition: cannot pass if the mismatch is already absent."""
+    manager = _RecordingHistory()
+    asyncio.run(manager.add_message(sender="user", text="hi", session_id="shared-precond"))
+
+    stored = asyncio.run(manager.get_session_messages("shared-precond", limit=500))
+
+    assert "role" not in stored[0]
+    assert "content" not in stored[0]
+    assert stored[0]["sender"] == "user"
+    assert stored[0]["text"] == "hi"
+
+
+def test_non_conversational_speakers_stay_excluded_from_the_public_view() -> None:
+    """The filter's intent — keep terminal/workflow-state records out of a
+    public share — must survive resolving the key mismatch."""
+    manager = _RecordingHistory()
+
+    async def seed() -> None:
+        await manager.add_message(sender="user", text="run ls", session_id="shared-2")
+        await manager.add_message(sender="terminal", text="$ ls -la", session_id="shared-2")
+        await manager.add_message(sender="workflow-error", text="step failed", session_id="shared-2")
+
+    asyncio.run(seed())
+
+    result = asyncio.run(_load_session_data(_link("shared-2"), _fake_request(manager)))
+
+    roles = {m["role"] for m in result["data"]["messages"]}
+    assert roles == {"user"}
+
+
+def test_a_session_with_no_messages_still_renders_empty_without_error() -> None:
+    manager = _RecordingHistory()
+
+    result = asyncio.run(_load_session_data(_link("shared-empty"), _fake_request(manager)))
+
+    assert result["data"]["messages"] == []

--- a/autobot-backend/api/websockets.py
+++ b/autobot-backend/api/websockets.py
@@ -451,12 +451,22 @@ async def _add_to_chat_history(chat_history_manager, message_type: str, raw_data
     """
     text, sender = _format_event_for_chat(message_type, raw_data)
 
+    # Issue #14342: the event payload is the only session context a broadcast
+    # event carries (the /ws connection itself is not session-scoped). Route
+    # on it when the producer set it; fall back to the default bucket
+    # otherwise, same as before, instead of always mixing every session in.
+    session_id = raw_data.get("session_id") if isinstance(raw_data, dict) else None
+
     # Add to chat history if we have meaningful text and chat_history_manager is available
     # Issue #350 Root Cause Fix: Skip message types that are explicitly persisted elsewhere
     if text and chat_history_manager and message_type not in SKIP_WEBSOCKET_PERSISTENCE_TYPES:
         try:
             await chat_history_manager.add_message(
-                sender=sender, text=text, message_type=message_type, raw_data=raw_data
+                sender=sender,
+                text=text,
+                message_type=message_type,
+                raw_data=raw_data,
+                session_id=session_id,
             )
         except Exception as e:
             logger.error("Failed to add message to chat history: %s", e)

--- a/autobot-backend/api/websockets.py
+++ b/autobot-backend/api/websockets.py
@@ -262,6 +262,21 @@ MESSAGE_TYPE_FORMATTERS: Dict[str, Callable[[dict], Tuple[str, str]]] = {
     "canvas_cell": _format_canvas_cell,
 }
 
+# Issue #14342 (review follow-up): these are UI telemetry — step/tool/workflow
+# progress the frontend renders live — not something the user or assistant
+# said. #14342 fixed *where* they are stored (their own session instead of a
+# bucket no session reader touched); before that fix an LLM context builder
+# could never see them, so nothing filtered them there. Now that they reach a
+# session, `api/chat.py`'s context builders must exclude them by this same
+# dispatch table, or the model receives them as conversation turns and they
+# evict real dialogue from a message_limit-bounded window. `user_message` and
+# `llm_response` are the two keys in this table that ARE a conversation turn
+# (the user's own text; the assistant's own reply) and stay eligible.
+NON_CONVERSATIONAL_WEBSOCKET_MESSAGE_TYPES: frozenset[str] = frozenset(MESSAGE_TYPE_FORMATTERS) - {
+    "user_message",
+    "llm_response",
+}
+
 
 def _format_event_for_chat(message_type: str, raw_data: dict) -> Tuple[str | None, str]:
     """Format event data for chat history (Issue #336 - extracted dispatch helper).

--- a/autobot-backend/api/websockets_chat_history_routing_test.py
+++ b/autobot-backend/api/websockets_chat_history_routing_test.py
@@ -1,0 +1,117 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Regression tests for Issue #14342 — websocket-formatted chat events were
+
+written to ``ChatHistoryManager``'s default (non-session) bucket because
+``_add_to_chat_history`` never forwarded ``session_id`` to ``add_message``.
+Nothing that serves a session (``get_session_messages``, ``load_session``)
+ever reads that bucket, so every agent-step, tool-output, workflow and
+thought event the websocket layer formatted was silently unreadable.
+
+These tests exercise the *real* producer path — ``broadcast_event``, the
+exact callback ``events/bus.py`` invokes for every published event — through
+to a real ``MessagesMixin``-backed session store, not a hand-fed dict shaped
+to match what the fix happens to check.
+"""
+
+import asyncio
+from typing import Any, Dict, List
+
+from api.websockets import _create_broadcast_event_handler
+from chat_history.messages import MessagesMixin
+
+
+class _RecordingHistory(MessagesMixin):
+    """Exercises the real ``add_message``/``get_session_messages`` pair
+    against an in-memory session store, mirroring
+    ``chat_history/add_message_call_sites_test.py``."""
+
+    def __init__(self) -> None:
+        self.history: List[Dict[str, Any]] = []
+        self.sessions: Dict[str, List[Dict[str, Any]]] = {}
+
+    async def load_session(self, session_id: str) -> List[Dict[str, Any]]:
+        return list(self.sessions.get(session_id, []))
+
+    async def save_session(self, session_id: str, messages: List[Dict[str, Any]], **_: Any) -> bool:
+        self.sessions[session_id] = list(messages)
+        return True
+
+
+class _FakeWebSocket:
+    """Minimal stand-in for the real FastAPI WebSocket send path."""
+
+    def __init__(self) -> None:
+        self.sent: List[dict] = []
+
+    async def send_json(self, data: dict) -> None:
+        self.sent.append(data)
+
+
+def test_tool_output_event_round_trips_through_its_own_session() -> None:
+    """A tool-output event raised on a session is readable back through
+    get_session_messages for that session — the real websocket entry point,
+    not the internal dispatch helper."""
+    manager = _RecordingHistory()
+    websocket = _FakeWebSocket()
+
+    async def run() -> None:
+        broadcast_event = await _create_broadcast_event_handler(websocket, manager)
+        await broadcast_event(
+            {
+                "type": "tool_output",
+                "payload": {"output": "command finished", "session_id": "session-a"},
+            }
+        )
+
+    asyncio.run(run())
+
+    stored = asyncio.run(manager.get_session_messages("session-a", limit=500))
+    assert len(stored) == 1
+    assert stored[0]["sender"] == "tool-output"
+    assert "command finished" in stored[0]["text"]
+    # Never written to the manager's internal default bucket.
+    assert manager.history == []
+
+
+def test_tool_output_event_not_visible_from_a_different_session() -> None:
+    """An event raised on session-a must not leak into session-b's history."""
+    manager = _RecordingHistory()
+    websocket = _FakeWebSocket()
+
+    async def run() -> None:
+        broadcast_event = await _create_broadcast_event_handler(websocket, manager)
+        await broadcast_event(
+            {
+                "type": "tool_output",
+                "payload": {"output": "secret result", "session_id": "session-a"},
+            }
+        )
+
+    asyncio.run(run())
+
+    other_session = asyncio.run(manager.get_session_messages("session-b", limit=500))
+    assert other_session == []
+
+
+def test_workflow_error_event_without_session_id_falls_back_to_default_bucket() -> None:
+    """A genuinely session-less event (no session_id in its payload) keeps its
+    prior behaviour instead of raising — the fallback the fix must preserve."""
+    manager = _RecordingHistory()
+    websocket = _FakeWebSocket()
+
+    async def run() -> None:
+        broadcast_event = await _create_broadcast_event_handler(websocket, manager)
+        await broadcast_event(
+            {
+                "type": "workflow_failed",
+                "payload": {"workflow_id": "wf-1", "error": "boom"},
+            }
+        )
+
+    asyncio.run(run())
+
+    assert len(manager.history) == 1
+    assert manager.history[0]["sender"] == "workflow-error"

--- a/autobot-backend/chat_history/message_schema.py
+++ b/autobot-backend/chat_history/message_schema.py
@@ -85,6 +85,19 @@ def message_role(message: Dict[str, Any], default: str = _UNKNOWN_ROLE) -> str:
     return str(message.get("role") or message.get("sender") or default)
 
 
+def message_type(message: Dict[str, Any], default: str = "default") -> str:
+    """The stored message-kind label, from either schema.
+
+    Stored/display records carry it under ``messageType``
+    (``MessagesMixin._build_message_dict``); ``_to_persisted_message`` in
+    ``api/chat.py`` writes it under ``type``. Both keys are read elsewhere in
+    ``api/chat.py`` by hand (``msg.get("messageType", msg.get("type", ...))``,
+    duplicated at two call sites); this is that expression promoted to the
+    shared reader so a third caller does not re-fork it.
+    """
+    return str(message.get("messageType") or message.get("type") or default)
+
+
 def message_text(message: Dict[str, Any]) -> str:
     """The body, from either schema.
 


### PR DESCRIPTION
Closes #14342, #14341, #14340

## Thinking Path

All three issues are the same defect shape — a producer and a consumer disagreeing about where a chat message lives or which key carries its body — so they were diagnosed together before any edit:

1. Read all three issues in full, then read `chat_history/message_schema.py`, which already documents #14340 and #14341 by number as known-but-unfixed readers of a single schema, and predicts that closing #14342's routing gap would let its `llm_role` clamp (from #14305, already merged) keep any newly-session-scoped websocket sender out of an illegal provider role.
2. For #14342, traced every call site of `_format_event_for_chat`/`_add_to_chat_history` (there is exactly one) and confirmed `agent.step.*`/`agent.tool.*`/`agent.llm.chunk`/`agent.plan` are already in `SKIP_WEBSOCKET_PERSISTENCE_TYPES` (added by #14305's clamp work), so the routing gap was live for the remaining formatter types: `tool_output`, `tool_code`, `thought`, `workflow_*`, `error`, `progress`, etc. The only per-event session context a broadcast event carries is its own payload — the `/ws` connection is not scoped to a session — so the fix reads `raw_data["session_id"]` (already populated by real producers such as `chat_workflow/cot_events.py`) and threads it into `add_message`.
3. For #14341, confirmed `create_summary_message` returns the stored-shape body key (`text`) while `_to_persisted_message` only read the API-shape key (`content`), exactly as filed — swapped the raw key read for `chat_history.message_schema.message_text`, which resolves both shapes and already handles every existing caller of `_to_persisted_message` (all API-shape, so unaffected).
4. For #14340, confirmed `_load_session_data` filtered/mapped on `role`/`content` against `get_session_messages`' stored-shape return (`sender`/`text`), read via `message_role`/`message_text` instead — keeping the filter's original intent (exclude non-conversational speakers from the public view) by filtering on the *resolved* role, not the raw key.
5. **Review follow-up (post-initial-push):** the reviewer flagged that `llm_role`'s clamp (#14305) guarantees a #14342-routed record reaches the provider as a *legal* role, but never guaranteed it belongs in the conversation at all — `_build_llm_context` and `_generate_ai_stack_chat_response` have no speaker/type filter, so the same records #14342 now routes into a session were about to arrive at the model as conversational turns, and — since `message_limit` is a record count — could evict real dialogue from a busy session's tail. Addressed below; see "Review follow-up" under What Changed and Verification.

## What Changed

**#14342** — `autobot-backend/api/websockets.py::_add_to_chat_history`: extracts `session_id` from the event payload and forwards it to `chat_history_manager.add_message(...)`, so it takes the session-scoped branch instead of always falling through to the default in-memory bucket. Events with no `session_id` in their payload keep the prior (default-bucket) behavior — no regression for the genuinely session-less legacy `api/agent.py` goal-execution path.

**#14341** — `autobot-backend/api/chat.py::_to_persisted_message`: resolves the persisted `content` through `chat_history.message_schema.message_text(api_data)` instead of `api_data.get("content", "")`, so a stored-shape summary (`text` key) is no longer silently coerced to an empty string. All pre-existing callers already pass API-shape dicts (`content` key), so their behavior is unchanged — `message_text` reads `content` first.

**#14340** — `autobot-backend/api/chat_shared_links.py::_load_session_data`: filters and maps through `message_role`/`message_text` instead of the raw `role`/`content` keys the stored shape has never carried. Also resolves `created_at` from `timestamp` as a fallback (the stored shape's actual key). The non-conversational-speaker filter is preserved — it now filters on the *resolved* role, so terminal/workflow-state records are still excluded from the public view.

### Producer / consumer pairs fixed

| Issue | Producer | Consumer | Shared key now used |
|---|---|---|---|
| #14342 | `broadcast_event`/`_format_event_for_chat` (event payload) | `chat_history_manager.add_message` | `raw_data["session_id"]` |
| #14341 | `chat_history/overflow_integration.py::create_summary_message` | `api/chat.py::_to_persisted_message` | `chat_history.message_schema.message_text` |
| #14340 | `chat_history/messages.py::get_session_messages` (stored shape) | `api/chat_shared_links.py::_load_session_data` | `chat_history.message_schema.message_role` / `message_text` |

### Review follow-up — the LLM context builders needed the same allowlist

`llm_role` (#14305) is an allowlist for *legality* — any non-conversational speaker collapses to the caller role rather than reaching a provider illegally. It says nothing about whether the record should be in the context at all. Once #14342 routes ~19 websocket-broadcast event variants (agent steps, tool invocations/output, plan updates, thoughts, workflow progress/errors) into a session for the first time, `_build_llm_context` and `_generate_ai_stack_chat_response` — which had no filter beyond `isinstance(msg, dict)` — would hand every one of them to the model as a user/assistant turn (content pollution), and because `message_limit` slices by record count, a busy turn's telemetry could push real dialogue out of the window entirely (window displacement).

Fix, at both call sites in `autobot-backend/api/chat.py`:

- Added `chat_history.message_schema.message_type()` — the `messageType`/`type` dual-schema read `api/chat.py` already duplicated twice inline (`_is_streaming_response`, `_get_message_signature`), promoted to the shared reader and both call sites switched to it (consolidate, don't fork a third copy).
- Added `api.websockets.NON_CONVERSATIONAL_WEBSOCKET_MESSAGE_TYPES` — derived from `MESSAGE_TYPE_FORMATTERS` itself (`frozenset(MESSAGE_TYPE_FORMATTERS) - {"user_message", "llm_response"}`), so the exclusion list can never drift from the dispatch table it excludes. `user_message`/`llm_response` are the two keys in that table that genuinely are a conversation turn.
- Both `_build_llm_context` and `_generate_ai_stack_chat_response` now build a `conversational_context` list (filtering on `message_type(msg) not in NON_CONVERSATIONAL_WEBSOCKET_MESSAGE_TYPES`) **before** applying the `[-message_limit:]` slice, not after. Filtering after the slice would still let telemetry consume slots a real turn needed — the exact window-displacement failure mode the reviewer described — so this closes both the content-pollution and the window-displacement gap, not just the first.
- Terminal integration, the agent terminal and the workflow state machine (records that predated #14342 and were already reachable) use different `messageType` values entirely and are unaffected — verified against the existing `#14305` test suite (`chat_llm_context_test.py`'s `TestSpeakersThatAreNotConversationalRoles`), which still expects their bodies to reach the model, role-clamped. This was a deliberate design choice worth restating: message *type* is the axis that separates "new #14342 telemetry" from "pre-existing intentional context," not message *sender/role* — a role-based allowlist (mirroring #14340's) would have also excluded that pre-existing terminal-output context, which is relied on by the model today.

## Verification

Static verification only — per the task instructions, application code and the test suite were **not executed**; CI runs pytest. All new tests were checked for syntax validity with `ast.parse` and traced by hand against the real production code paths (`_create_broadcast_event_handler`, `create_summary_message`, `_load_session_data`, `_build_llm_context`) — no hand-fed shapes standing in for a producer.

New/extended test files, each building fixtures with the real writer and exercising the real consumer, then reading back the way a downstream consumer does:

- `autobot-backend/api/websockets_chat_history_routing_test.py` — round-trips a `tool_output` event through the real `broadcast_event` callback (the exact function `events/bus.py` registers and invokes) into a `MessagesMixin`-backed session store, then reads it back via `get_session_messages`; asserts it is absent from a different session; asserts a payload with no `session_id` keeps the pre-existing default-bucket fallback.
- `autobot-backend/api/chat_overflow_summary_persistence_test.py` — builds a summary with the real `create_summary_message`, persists it with the real `_to_persisted_message`, and reads it back with `message_schema.message_text`; also runs the persisted record through the real `_build_llm_context` to prove the summary text survives into a subsequent context build.
- `autobot-backend/api/chat_shared_links_message_schema_test.py` — seeds a session with the real `MessagesMixin.add_message` writer (user/assistant/non-conversational speakers) and calls the real `_load_session_data` helper; asserts both conversational roles render with bodies, a non-conversational speaker stays excluded, and an empty session still renders an empty list without raising.
- `autobot-backend/api/chat_llm_context_test.py` (extended, existing #14305 file) — new `TestWebsocketTelemetryPinnedDecision` class:
  - `test_a_real_tool_output_event_does_not_enter_llm_context` — writes a `tool_output` event through the real `broadcast_event` producer plus a real user turn into the same session, reads both back via `get_session_messages`, runs the result through the real `_build_llm_context`, and asserts the telemetry body is absent while the real turn is present.
  - `test_a_real_tool_output_event_does_not_enter_the_ai_stack_history` — same shape against `_generate_ai_stack_chat_response`.
  - `test_telemetry_does_not_evict_real_dialogue_from_the_window` — the window-displacement regression case: a 5-record telemetry burst sits between two real turns in the raw history; with `message_limit=2`, asserts the earlier real turn survives. This fails under filter-after-slice (traced below) and only passes with filter-before-slice.
  - `test_the_full_dispatch_table_is_covered_minus_the_two_real_turns` — precondition pinning `NON_CONVERSATIONAL_WEBSOCKET_MESSAGE_TYPES`'s exact derivation, so it cannot silently drift as `MESSAGE_TYPE_FORMATTERS` changes.

### Test collection — confirmed, not assumed

All three new files live in `autobot-backend/api/`, inside `testpaths` (`pytest.ini`), match `python_files = test_*.py *_test.py`, and sit alongside the pre-existing `autobot-backend/api/chat_llm_context_test.py` (same directory, same `api/__init__.py` package, same collection path) that already runs in CI today — structurally identical, so nothing about their location, naming, or lack of a test class (`python_functions = test_*` collects bare module-level functions too) would cause pytest to skip them. `--asyncio-mode=auto` means the `@pytest.mark.asyncio` decorators used here (copied from this file's own pre-existing `TestTheAiStackPathCarriedTheSameDefect` class) are consistent with what's already passing in this file. No `collect_ignore`/skip hook in `conftest.py` targets this path.

### Mutation trace (statically traced, not executed — pytest was not run)

| Fix reverted | Test that goes red |
|---|---|
| #14342: drop `session_id=` from the `add_message(...)` call | `test_tool_output_event_round_trips_through_its_own_session` |
| #14341: revert `_to_persisted_message` to `api_data.get("content", "")` | `test_summary_round_trips_through_persistence_with_its_text_intact`, `test_a_subsequent_context_build_contains_the_summary_text`, `test_persisted_summary_is_not_empty` |
| #14340: revert `_load_session_data` to `m.get("role"/"content")` | `test_stored_shape_user_and_assistant_records_render_with_bodies`, `test_non_conversational_speakers_stay_excluded_from_the_public_view` |
| Review follow-up: drop the `message_type` filter from `_build_llm_context`/`_generate_ai_stack_chat_response` entirely | `test_a_real_tool_output_event_does_not_enter_llm_context`, `test_a_real_tool_output_event_does_not_enter_the_ai_stack_history` |
| Review follow-up: keep the filter but apply it *after* the `[-message_limit:]` slice (the naive fix) | `test_telemetry_does_not_evict_real_dialogue_from_the_window` — the last 2 raw records in that fixture are 1 telemetry + 1 real turn, so post-slice filtering drops the earlier real turn (`"turn 0"`) from the result entirely |

Tests that stay green under each mutation (by design, as preconditions / unrelated fallbacks / pre-existing #14305 coverage): `test_summary_producer_really_does_use_the_stored_shape_key`, `test_the_writer_really_does_use_the_stored_shape_keys`, `test_workflow_error_event_without_session_id_falls_back_to_default_bucket`, `test_a_session_with_no_messages_still_renders_empty_without_error`, `test_the_full_dispatch_table_is_covered_minus_the_two_real_turns`, and the existing `TestSpeakersThatAreNotConversationalRoles`/`TestTheApiShapeStillWorks` classes (terminal-output context is a different `messageType` and stays included).

### #14342 acceptance criteria, evidence

- Round trip through the session reader: `test_tool_output_event_round_trips_through_its_own_session`.
- Not visible from a different session: `test_tool_output_event_not_visible_from_a_different_session`.
- Verified against #14305's clamp, and against the review follow-up: `llm_role` still clamps any surviving non-conversational sender to the caller role (unchanged); `NON_CONVERSATIONAL_WEBSOCKET_MESSAGE_TYPES` now keeps the websocket-telemetry senders out of the context entirely, so the two consumers (`chat_shared_links.py`'s role allowlist and `chat.py`'s type exclusion) agree in intent — nothing #14342 makes newly reachable is treated as something the user or assistant said, in either reader.
- Privacy sweep: `self.history` (the default bucket these events used to land in) is read only by `get_all_messages()`, which has no caller anywhere in the tree outside its own definitions and test — no endpoint currently discloses one session's mixed-in events to another.

## Model Used

Claude Sonnet 5
