### PR TITLE
fix(agents): sync AGENT_TIER_MAP with both agent rosters and add a drift guard (#14194)

### DIFF
--- a/autobot-backend/agent_tier_classifier.py
+++ b/autobot-backend/agent_tier_classifier.py
@@ -32,22 +32,45 @@ class AgentTier(Enum):
     TIER_4_ORCHESTRATOR = "tier4_orchestrator"  # 50-70% cache hit
 
 
-# Agent type to tier mapping
+# Agent type to tier mapping (#14194)
+#
+# Two independent rosters feed this map, and neither can see the other:
+#
+#   1. Claude Code dev subagents -- one name per .claude/agents/*.md file
+#      (frontend-engineer, senior-backend-engineer, code-reviewer, ...).
+#   2. AutoBot's own internal task-agent taxonomy -- AgentType in
+#      agents/agent_orchestration/types.py, dispatched at runtime by
+#      BaseModalityAgent subclasses (agents/*_agent.py) and the
+#      orchestrator/workflow templates via
+#      LLMService.chat_optimized(agent_type=...). AgentType values use
+#      underscores ("audio_processing"); get_agent_tier() normalizes '_' to
+#      '-' before lookup, so they are stored here in dash form.
+#
+# agent_tier_classifier_test.py asserts every member of BOTH rosters has an
+# entry here (in both directions) so a name can no longer drift silently --
+# see that file's module docstring for why it reads each roster without
+# importing agent_tier_classifier or the agents package.
 AGENT_TIER_MAP: Dict[str, AgentTier] = {
     # Tier 1: Default Implementation Agents (Highest Cache Hit Rate)
     "frontend-engineer": AgentTier.TIER_1_DEFAULT,
-    "backend-engineer": AgentTier.TIER_1_DEFAULT,
     "senior-backend-engineer": AgentTier.TIER_1_DEFAULT,
     "database-engineer": AgentTier.TIER_1_DEFAULT,
     "documentation-engineer": AgentTier.TIER_1_DEFAULT,
     "testing-engineer": AgentTier.TIER_1_DEFAULT,
     "devops-engineer": AgentTier.TIER_1_DEFAULT,
     "project-manager": AgentTier.TIER_1_DEFAULT,
+    # AgentType.CHAT (#14194): the default conversational flow, shares the
+    # most prefix of any task agent.
+    "chat": AgentTier.TIER_1_DEFAULT,
     # Tier 2: Analysis Agents (High Cache Hit Rate)
     "code-reviewer": AgentTier.TIER_2_ANALYSIS,
     "performance-engineer": AgentTier.TIER_2_ANALYSIS,
     "security-auditor": AgentTier.TIER_2_ANALYSIS,
     "code-refactorer": AgentTier.TIER_2_ANALYSIS,
+    # AgentType.RAG / AgentType.KNOWLEDGE_RETRIEVAL (#14194): retrieval +
+    # synthesis, same cache profile as the other analysis agents.
+    "rag": AgentTier.TIER_2_ANALYSIS,
+    "knowledge-retrieval": AgentTier.TIER_2_ANALYSIS,
     # Tier 3: Specialized Agents (Moderate Cache Hit Rate)
     "code-skeptic": AgentTier.TIER_3_SPECIALIZED,
     "systems-architect": AgentTier.TIER_3_SPECIALIZED,
@@ -58,6 +81,12 @@ AGENT_TIER_MAP: Dict[str, AgentTier] = {
     "content-writer": AgentTier.TIER_3_SPECIALIZED,
     "memory-monitor": AgentTier.TIER_3_SPECIALIZED,
     "project-task-planner": AgentTier.TIER_3_SPECIALIZED,
+    # #14194: added when .claude/agents/*.md gained these three definitions
+    # (#14135, #14139) without a matching entry here. Narrow, non-default
+    # tasks like the existing specialized agents above.
+    "conversation-compacter": AgentTier.TIER_3_SPECIALIZED,
+    "memory-curator": AgentTier.TIER_3_SPECIALIZED,
+    "repo-sweeper": AgentTier.TIER_3_SPECIALIZED,
     # Issue #3389: task agents that call chat_completion_optimized
     "summarization": AgentTier.TIER_3_SPECIALIZED,
     "translation": AgentTier.TIER_3_SPECIALIZED,
@@ -66,6 +95,10 @@ AGENT_TIER_MAP: Dict[str, AgentTier] = {
     "audio-processing": AgentTier.TIER_3_SPECIALIZED,
     "image-analysis": AgentTier.TIER_3_SPECIALIZED,
     "data-analysis": AgentTier.TIER_3_SPECIALIZED,
+    # AgentType.SYSTEM_COMMANDS / AgentType.RESEARCH (#14194): per-task tool
+    # context (shell state, search results) keeps their shared prefix low.
+    "system-commands": AgentTier.TIER_3_SPECIALIZED,
+    "research": AgentTier.TIER_3_SPECIALIZED,
     # Tier 4: Orchestrator (Session-Specific)
     "orchestrator": AgentTier.TIER_4_ORCHESTRATOR,
 }

--- a/autobot-backend/agent_tier_classifier_test.py
+++ b/autobot-backend/agent_tier_classifier_test.py
@@ -80,13 +80,20 @@ def _agent_orchestration_type_values() -> set[str]:
         raise ImportError(f"Could not load {_AGENT_TYPES_FILE}")
     module = importlib.util.module_from_spec(spec)
 
-    # Registered in sys.modules BEFORE exec_module, then removed. `enum`
-    # resolves a member's defining module through `sys.modules[cls.__module__]`
-    # while building the class; with the module absent that lookup returns None
-    # and class creation dies on `'NoneType' object has no attribute '__dict__'`.
-    # Executing a module out-of-band is only safe for modules that define no
-    # enums -- `types.py` defines several. Same register-then-pop shape as
-    # `migrations/runner_deferral_test.py` and `migrations/seed_agents_test.py`.
+    # Registered in sys.modules BEFORE exec_module, then removed.
+    #
+    # `types.py:169` declares a `@dataclass`, and `dataclasses._is_type` does
+    # `sys.modules.get(cls.__module__).__dict__` (CPython 3.14
+    # dataclasses.py:814) while scanning for a `KW_ONLY` sentinel. A module
+    # executed out-of-band is not in `sys.modules`, so that `.get()` returns
+    # None and class creation dies on
+    # `'NoneType' object has no attribute '__dict__'`.
+    #
+    # So `spec_from_file_location` + `exec_module` alone is only safe for a
+    # module that declares no dataclass. Same register-then-pop shape as
+    # `migrations/runner_deferral_test.py` and `migrations/seed_agents_test.py`,
+    # and the `finally` matters: leaving the name behind would shadow a real
+    # import for the rest of the session.
     sys.modules[name] = module
     try:
         spec.loader.exec_module(module)

--- a/autobot-backend/agent_tier_classifier_test.py
+++ b/autobot-backend/agent_tier_classifier_test.py
@@ -44,6 +44,7 @@ compared here in dash form to match AGENT_TIER_MAP's own key convention.
 
 import importlib.util
 import re
+import sys
 from pathlib import Path
 
 from agent_tier_classifier import AGENT_TIER_MAP
@@ -73,12 +74,25 @@ def _claude_subagent_names() -> set[str]:
 
 def _agent_orchestration_type_values() -> set[str]:
     """AgentType's string values, loaded without importing the ``agents`` package."""
-    spec = importlib.util.spec_from_file_location("_agent_orchestration_types_isolated", _AGENT_TYPES_FILE)
+    name = "_agent_orchestration_types_isolated"
+    spec = importlib.util.spec_from_file_location(name, _AGENT_TYPES_FILE)
     if spec is None or spec.loader is None:
         raise ImportError(f"Could not load {_AGENT_TYPES_FILE}")
     module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return {member.value.replace("_", "-") for member in module.AgentType}
+
+    # Registered in sys.modules BEFORE exec_module, then removed. `enum`
+    # resolves a member's defining module through `sys.modules[cls.__module__]`
+    # while building the class; with the module absent that lookup returns None
+    # and class creation dies on `'NoneType' object has no attribute '__dict__'`.
+    # Executing a module out-of-band is only safe for modules that define no
+    # enums -- `types.py` defines several. Same register-then-pop shape as
+    # `migrations/runner_deferral_test.py` and `migrations/seed_agents_test.py`.
+    sys.modules[name] = module
+    try:
+        spec.loader.exec_module(module)
+        return {member.value.replace("_", "-") for member in module.AgentType}
+    finally:
+        sys.modules.pop(name, None)
 
 
 def test_claude_subagent_roster_is_non_empty():

--- a/autobot-backend/agent_tier_classifier_test.py
+++ b/autobot-backend/agent_tier_classifier_test.py
@@ -1,0 +1,135 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Guard test for AGENT_TIER_MAP roster drift (#14194).
+
+AGENT_TIER_MAP (agent_tier_classifier.py) classifies TWO independent agent
+rosters for vLLM prefix-cache tiering, and neither roster can see the other:
+
+  1. Claude Code dev subagents -- one ``.claude/agents/*.md`` file per agent,
+     each carrying the agent's ``name:`` frontmatter field.
+  2. AutoBot's own internal task-agent taxonomy -- ``AgentType`` in
+     ``agents/agent_orchestration/types.py``, dispatched at runtime by
+     ``BaseModalityAgent`` subclasses (``agents/*_agent.py``) and the
+     orchestrator/workflow templates via
+     ``LLMService.chat_optimized(agent_type=...)``.
+
+An agent_type absent from AGENT_TIER_MAP does not error -- get_agent_tier()
+silently defaults it to TIER_1_DEFAULT (see agent_tier_classifier.py). This
+test makes that silent default loud in both directions: a roster member with
+no AGENT_TIER_MAP entry, and an AGENT_TIER_MAP entry with no roster member
+(a dead/orphan entry).
+
+Both rosters are read here WITHOUT going through agent_tier_classifier or the
+``agents`` package:
+
+- ``.claude/agents/*.md`` via a regex frontmatter scan -- the same technique
+  ``services/specialized_agent_service.py`` already uses in production.
+- ``AgentType`` via ``importlib.util.spec_from_file_location``, loading
+  ``types.py`` in isolation. ``agents/__init__.py`` eagerly imports
+  ``kb_librarian_agent`` (which imports ``services.llm_service``), and
+  ``agents/agent_orchestration/__init__.py`` eagerly imports the distributed
+  orchestration stack -- the same eager-`__init__` defect class as #12830 and
+  #12814. ``types.py`` has no runtime dependency on either package (its one
+  package-relative import, ``agents.base_agent``, is TYPE_CHECKING-only), so
+  loading the file directly is safe and avoids the cycle entirely
+  (``agent_tier_classifier`` is imported from inside
+  ``services/llm_service.py``).
+
+get_agent_tier() normalizes '_' -> '-' before lookup, so both rosters are
+compared here in dash form to match AGENT_TIER_MAP's own key convention.
+"""
+
+import importlib.util
+import re
+from pathlib import Path
+
+from agent_tier_classifier import AGENT_TIER_MAP
+
+_BACKEND_ROOT = Path(__file__).resolve().parent
+_REPO_ROOT = _BACKEND_ROOT.parent
+_CLAUDE_AGENTS_DIR = _REPO_ROOT / ".claude" / "agents"
+_AGENT_TYPES_FILE = _BACKEND_ROOT / "agents" / "agent_orchestration" / "types.py"
+
+_FRONTMATTER_BLOCK_RE = re.compile(r"^---\s*\n(.*?)\n---", re.DOTALL)
+_FRONTMATTER_NAME_RE = re.compile(r"^name:\s*(\S+)\s*$", re.MULTILINE)
+
+
+def _claude_subagent_names() -> set[str]:
+    """Every ``name:`` frontmatter value across ``.claude/agents/*.md``."""
+    names: set[str] = set()
+    for md_file in sorted(_CLAUDE_AGENTS_DIR.glob("*.md")):
+        content = md_file.read_text(encoding="utf-8")
+        block = _FRONTMATTER_BLOCK_RE.match(content)
+        if not block:
+            continue
+        name_match = _FRONTMATTER_NAME_RE.search(block.group(1))
+        if name_match:
+            names.add(name_match.group(1))
+    return names
+
+
+def _agent_orchestration_type_values() -> set[str]:
+    """AgentType's string values, loaded without importing the ``agents`` package."""
+    spec = importlib.util.spec_from_file_location("_agent_orchestration_types_isolated", _AGENT_TYPES_FILE)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Could not load {_AGENT_TYPES_FILE}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return {member.value.replace("_", "-") for member in module.AgentType}
+
+
+def test_claude_subagent_roster_is_non_empty():
+    """Sanity check: the .claude/agents scan must find real agents (#14194).
+
+    Guards against a silently-empty roster making the drift tests vacuously
+    pass -- e.g. a wrong path or a frontmatter format change.
+    """
+    assert len(_claude_subagent_names()) >= 10
+
+
+def test_agent_orchestration_roster_is_non_empty():
+    """Sanity check: the AgentType scan must find real members (#14194)."""
+    assert len(_agent_orchestration_type_values()) >= 5
+
+
+def test_every_claude_subagent_definition_is_mapped():
+    """Every .claude/agents/*.md name has an AGENT_TIER_MAP entry (#14194).
+
+    Direction 1 (on disk, unmapped): the agent silently defaults to
+    TIER_1_DEFAULT instead of getting a deliberate classification.
+    """
+    unmapped = _claude_subagent_names() - set(AGENT_TIER_MAP)
+    assert not unmapped, (
+        f"Agent definition(s) on disk with no AGENT_TIER_MAP entry: {sorted(unmapped)}. "
+        "Add a deliberate AgentTier to AGENT_TIER_MAP in agent_tier_classifier.py."
+    )
+
+
+def test_every_agent_orchestration_type_is_mapped():
+    """Every AgentType member has an AGENT_TIER_MAP entry (#14194).
+
+    Same failure mode as above, for AutoBot's internal task-agent roster.
+    """
+    unmapped = _agent_orchestration_type_values() - set(AGENT_TIER_MAP)
+    assert not unmapped, (
+        f"AgentType member(s) with no AGENT_TIER_MAP entry: {sorted(unmapped)}. "
+        "Add a deliberate AgentTier to AGENT_TIER_MAP in agent_tier_classifier.py."
+    )
+
+
+def test_agent_tier_map_has_no_orphan_entries():
+    """Every AGENT_TIER_MAP key traces to one of the two known rosters (#14194).
+
+    Direction 2 (mapped, no definition anywhere): a dead entry -- the agent
+    was renamed or removed and AGENT_TIER_MAP was never updated.
+    """
+    known_roster = _claude_subagent_names() | _agent_orchestration_type_values()
+    orphans = set(AGENT_TIER_MAP) - known_roster
+    assert not orphans, (
+        f"AGENT_TIER_MAP entries with no matching .claude/agents definition or "
+        f"AgentType member: {sorted(orphans)}. Remove the dead entry, or restore the "
+        "missing agent definition / AgentType member if it still exists elsewhere."
+    )


### PR DESCRIPTION
Closes #14194

## Thinking Path

#14194 names two hardcoded places: `.claude/agents/*.md` (23 Claude Code dev-subagent
definitions) vs. `autobot-backend/agent_tier_classifier.py`'s `AGENT_TIER_MAP` (29 entries),
claiming 3 on-disk-but-unmapped and 9 mapped-but-dead. Before changing anything I checked which
pair this actually is per the task brief's option (c): a different pair than the
`agent_seed_roster.py` SLM extraction from #14386/#14321 — that PR is unrelated to this issue,
which never touches `autobot-slm-backend`. Confirmed with `gh api repos/mrveiss/AutoBot-AI/issues/14194`.

Re-measuring the drift turned up a fact the issue didn't have: `AGENT_TIER_MAP` isn't only fed
by `.claude/agents/*.md`. `services/llm_service.py::chat_optimized` calls
`get_base_prompt_for_agent(agent_type)`, and `agent_type` is populated at 90 live call sites
across `orchestration/`, `workflow_templates/`, and `agents/*_agent.py` with values from
`agents/agent_orchestration/types.py::AgentType` — AutoBot's own internal task-agent taxonomy
(`chat`, `system_commands`, `rag`, `knowledge_retrieval`, `research`, `orchestrator`,
`data_analysis`, `code_generation`, `translation`, `summarization`, `sentiment_analysis`,
`image_analysis`, `audio_processing`). Every `BaseModalityAgent` subclass
(`agents/audio_processing_agent.py`, `code_generation_agent.py`, etc.) sets `AGENT_ID` to one of
these and calls `chat_optimized(agent_type=self.AGENT_ID, ...)`.

So of the issue's "9 dead entries", 8 are alive — they're `AgentType` members, not
`.claude/agents` names, and the issue's disk-only scan couldn't see them. `orchestrator` is
functionally significant beyond caching: `TIER_PROMPT_MAP[TIER_4_ORCHESTRATOR]` selects a
different base prompt (`orchestrator.system_prompt`) than every other tier. Removing it, as the
issue's naive reading of "dead" would suggest, would have silently swapped the orchestrator's
system prompt. Only `backend-engineer` (distinct from the real `senior-backend-engineer`) has
zero consumers in either roster — genuinely dead.

Given `AGENT_TIER_MAP` legitimately serves two different rosters that can't be merged into one
without breaking the tier-4 orchestrator prompt selection, I kept it as one map fed by two
sources and added a guard test that reads both rosters independently and asserts drift in all
four directions (each roster vs. the map, both ways), rather than force a single-source
derivation that would silently misclassify AutoBot's own task agents.

## What Changed

- `autobot-backend/agent_tier_classifier.py`:
  - Removed `backend-engineer` (dead — no `.claude/agents` definition, no `AgentType` member,
    no other consumer anywhere in the codebase).
  - Added deliberate tiers for the 3 `.claude/agents` definitions #14194 named
    (`conversation-compacter`, `memory-curator`, `repo-sweeper` → `TIER_3_SPECIALIZED`, matching
    the existing narrow/specialized agents already in that tier, e.g. `memory-monitor`,
    `project-task-planner`).
  - Added deliberate tiers for the 5 `AgentType` members that were also silently defaulting
    (`chat` → `TIER_1_DEFAULT`, `rag`/`knowledge_retrieval` → `TIER_2_ANALYSIS`,
    `system_commands`/`research` → `TIER_3_SPECIALIZED`), discovered while building the
    guard test — same defect, same file, same silent-default failure mode as the issue's own
    3, so fixed in scope rather than filed separately. The tiers line up with
    `DEFAULT_AGENT_CAPABILITIES` in `agents/agent_orchestration/types.py` (e.g. `chat` is
    "1B / Low resource", `rag`/`knowledge_retrieval` are synthesis/retrieval, matching the
    existing `TIER_2_ANALYSIS` cohort).
  - Documented the two-roster split with a comment block above `AGENT_TIER_MAP` so the next
    person adding an agent knows both places to check.
- `autobot-backend/agent_tier_classifier_test.py` (new): guard test, mandatory per the issue
  regardless of which fix direction was chosen. Reads both rosters independently of
  `agent_tier_classifier` and of the `agents` package:
  - `.claude/agents/*.md` via a regex frontmatter scan (the same technique already shipped in
    `services/specialized_agent_service.py`).
  - `AgentType` via `importlib.util.spec_from_file_location`, loading
    `agents/agent_orchestration/types.py` in isolation rather than importing it normally —
    `agents/__init__.py` eagerly imports `kb_librarian_agent` (which imports
    `services.llm_service`, the module that imports `agent_tier_classifier`), and
    `agents/agent_orchestration/__init__.py` eagerly imports the distributed-orchestration
    stack. Both are the same eager-`__init__` defect class as #12830/#12814, and importing
    either normally from a leaf utility module (or its test) would either create a cycle or
    drag the whole agents/LLM/orchestration stack into a tier-lookup test. `types.py` has no
    runtime dependency on either package (its one package-relative import is
    `TYPE_CHECKING`-only), so loading the file directly is safe.
  - Three tests assert the invariant, not today's contents: every `.claude/agents` name is
    mapped, every `AgentType` member is mapped, and every `AGENT_TIER_MAP` key traces to one
    of the two rosters (no orphans). Two sanity tests guard against an empty-roster read
    making the drift tests vacuously pass.

## Verification

Static only, per instructions (no test suite run, no installs):

- `python3 -m py_compile` on both changed files — syntax OK (does not execute anything).
- Recomputed the roster/map diff by hand with `grep`/`comm` before and after the edit:
  - **Before:** `AGENT_TIER_MAP` had 29 keys. Known-roster union (23 `.claude/agents` names +
    13 `AgentType` values) = 36. Orphans (in map, not in either roster): `backend-engineer`.
    Unmapped (in a roster, not in map): `chat`, `conversation-compacter`, `knowledge-retrieval`,
    `memory-curator`, `rag`, `repo-sweeper`, `research`, `system-commands` (8, not the issue's
    3 — the extra 5 are the `AgentType` members it couldn't see).
  - **After:** `AGENT_TIER_MAP` has 36 keys = the full known-roster union, 0 orphans, 0 unmapped
    — verified again with `grep -oP` + `comm` after the edit.
- Mutation reasoning (guard-test evidence, since I can't execute pytest here): removing any of
  the 8 newly-added keys makes `_claude_subagent_names() - set(AGENT_TIER_MAP)` or
  `_agent_orchestration_type_values() - set(AGENT_TIER_MAP)` non-empty →
  `test_every_claude_subagent_definition_is_mapped` / `test_every_agent_orchestration_type_is_mapped`
  goes red. Adding back `backend-engineer` (or any other stray key) makes
  `set(AGENT_TIER_MAP) - known_roster` non-empty → `test_agent_tier_map_has_no_orphan_entries`
  goes red. Deleting a `.claude/agents/*.md` file while leaving its `AGENT_TIER_MAP` entry in
  place is also caught by the orphan test (direction 2 covers removed definitions, not just
  renames).
- Confirmed no other test hardcodes `AGENT_TIER_MAP` contents or a specific tier count for any
  of the touched names (`grep -rln get_agent_tier\|get_base_prompt_for_agent\|AGENT_TIER_MAP`
  across the repo → only `agent_tier_classifier.py` itself, `services/llm_service.py`, the new
  test, and two non-test `docs/examples/*.py` scripts that aren't in `pytest.ini`'s `testpaths`).
- The `docstring` example in `get_tier_statistics()` (`TIER_1_DEFAULT count == 8`) stays
  accurate: removing `backend-engineer` and adding `chat` keeps Tier 1 at 8.

### Consumer counts

| Roster | Definitions | Live consumers (non-test) |
|---|---|---|
| `.claude/agents/*.md` | 23 | `services/specialized_agent_service.py::SpecializedAgentService`, called from 3 sites in `api/agent_config.py` (plus a pre-existing `services/claude_agent_service.py` compat re-export) |
| `agents/agent_orchestration/types.py::AgentType` | 13 | 90 `agent_type="..."` call sites across `orchestration/`, `workflow_templates/`, and `agents/*_agent.py` |
| `AGENT_TIER_MAP` (`agent_tier_classifier.py`) | 1 canonical module (never forked) | `services/llm_service.py::chat_optimized` (1 call site) |

## Model Used

Claude Sonnet 5 (senior-backend-engineer)
