### PR TITLE
fix(analytics): stop pooled analytics work when its route deadline fires

### DIFF
--- a/autobot-backend/api/codebase_analytics/api_endpoint_scanner.py
+++ b/autobot-backend/api/codebase_analytics/api_endpoint_scanner.py
@@ -11,6 +11,7 @@ frontend TypeScript/Vue files for API calls.
 
 import ast
 import re
+import threading
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, List, Set
@@ -28,6 +29,14 @@ from .models import (
 )
 
 logger = get_logger(__name__)
+
+# #14256: how often the per-file scan loops consult the cancel token, matching
+# duplicate_detector.py's CANCEL_CHECK_INTERVAL precedent. run_full_analysis()
+# used to be a single call submitted to the analytics executor with no way to
+# stop once running -- exactly the #12779 shape, just for API-endpoint
+# scanning instead of duplicate detection: a route timeout cancelled the
+# AWAIT, not the thread walking every backend/frontend file to completion.
+CANCEL_CHECK_INTERVAL = 200
 
 
 # =============================================================================
@@ -194,7 +203,11 @@ class BackendEndpointScanner:
     # Global API prefix applied to all routers in app_factory.py
     API_PREFIX = "/api"
 
-    def __init__(self, project_root: Path | None = None):
+    def __init__(
+        self,
+        project_root: Path | None = None,
+        cancel_token: threading.Event | None = None,
+    ):
         # Issue #12404: Fall back to resolve_project_root() (deployed-layout-aware,
         # #10730) rather than get_project_root() (hardcoded parents[4], which
         # resolves to /opt/autobot -- not the analyzable repo -- in the deployed
@@ -212,6 +225,14 @@ class BackendEndpointScanner:
         self._module_prefix_map: Dict[str, str] = {}
         # #12945: resolved file -> prefix for registry-mounted routers outside api/
         self._external_router_prefixes: Dict[Path, str] = {}
+        # #14256: set by the caller when it stops waiting -- the run_full_analysis()
+        # call this scan is part of used to run to completion in its executor
+        # thread regardless, matching #12779's original duplicate-scan shape.
+        self._cancel_token = cancel_token
+
+    def _cancelled(self) -> bool:
+        """True once the caller has stopped waiting for this scan (#14256)."""
+        return self._cancel_token is not None and self._cancel_token.is_set()
 
     def scan_all_endpoints(self) -> List[APIEndpointItem]:
         """
@@ -235,7 +256,17 @@ class BackendEndpointScanner:
 
         # Second pass: scan all Python files
         scan_targets = list(self.backend_path.rglob("*.py")) + list(self._external_router_prefixes)
-        for py_file in scan_targets:
+        for index, py_file in enumerate(scan_targets):
+            # #14256: checked every CANCEL_CHECK_INTERVAL files, not every file --
+            # matches duplicate_detector.py's own cadence: cheap enough that the
+            # check itself never dominates, while bounding the abandonment window.
+            if index % CANCEL_CHECK_INTERVAL == 0 and self._cancelled():
+                logger.info(
+                    "Backend endpoint scan cancelled after %d/%d files",
+                    index,
+                    len(scan_targets),
+                )
+                break
             if py_file.name.startswith("__"):
                 continue
             if "archive" in str(py_file).lower():
@@ -984,13 +1015,23 @@ class BackendEndpointScanner:
 class FrontendAPICallScanner:
     """Scans frontend TypeScript/Vue files for API calls."""
 
-    def __init__(self, project_root: Path | None = None):
+    def __init__(
+        self,
+        project_root: Path | None = None,
+        cancel_token: threading.Event | None = None,
+    ):
         # Issue #12404: Fall back to resolve_project_root() (deployed-layout-aware,
         # #10730) rather than get_project_root() (hardcoded parents[4], which
         # resolves to /opt/autobot -- not the analyzable repo -- in the deployed
         # standalone rsync layout).
         self.project_root = project_root or Path(resolve_project_root())
         self.frontend_path = self.project_root / "autobot-frontend" / "src"
+        # #14256: see BackendEndpointScanner._cancel_token.
+        self._cancel_token = cancel_token
+
+    def _cancelled(self) -> bool:
+        """True once the caller has stopped waiting for this scan (#14256)."""
+        return self._cancel_token is not None and self._cancel_token.is_set()
 
     def scan_all_calls(self) -> List[FrontendAPICallItem]:
         """
@@ -1006,8 +1047,17 @@ class FrontendAPICallScanner:
             return calls
 
         # Scan TypeScript and Vue files
+        index = 0
         for pattern in ("*.ts", "*.vue", "*.tsx", "*.js"):
             for file in self.frontend_path.rglob(pattern):
+                # #14256: same cadence as BackendEndpointScanner -- a route
+                # timeout used to cancel only the AWAIT, leaving this loop
+                # running to completion in its executor thread.
+                if index % CANCEL_CHECK_INTERVAL == 0 and self._cancelled():
+                    logger.info("Frontend API call scan cancelled after %d calls found", len(calls))
+                    return calls
+                index += 1
+
                 if "node_modules" in str(file):
                     continue
                 if file.name.endswith(".d.ts"):
@@ -1399,14 +1449,22 @@ class APIEndpointChecker:
         analysis = checker.run_full_analysis()
     """
 
-    def __init__(self, project_root: Path | None = None):
+    def __init__(
+        self,
+        project_root: Path | None = None,
+        cancel_token: threading.Event | None = None,
+    ):
         # Issue #12404: Fall back to resolve_project_root() (deployed-layout-aware,
         # #10730) rather than get_project_root() (hardcoded parents[4], which
         # resolves to /opt/autobot -- not the analyzable repo -- in the deployed
         # standalone rsync layout).
         self.project_root = project_root or Path(resolve_project_root())
-        self.backend_scanner = BackendEndpointScanner(self.project_root)
-        self.frontend_scanner = FrontendAPICallScanner(self.project_root)
+        # #14256: run_full_analysis() dispatches straight to the analytics
+        # executor with nothing checking whether the caller is still waiting --
+        # the exact #12779 shape. Threaded into both scanners so cancellation
+        # reaches whichever one is running when the deadline fires.
+        self.backend_scanner = BackendEndpointScanner(self.project_root, cancel_token=cancel_token)
+        self.frontend_scanner = FrontendAPICallScanner(self.project_root, cancel_token=cancel_token)
 
     def run_full_analysis(self) -> APIEndpointAnalysis:
         """

--- a/autobot-backend/api/codebase_analytics/api_endpoint_scanner_cancellation_14256_test.py
+++ b/autobot-backend/api/codebase_analytics/api_endpoint_scanner_cancellation_14256_test.py
@@ -1,0 +1,168 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Cooperative cancellation for API-endpoint scanning (#14256, #14244).
+
+``APIEndpointChecker.run_full_analysis()`` was one synchronous call submitted
+to the analytics executor (``report.py``) or the default executor
+(``api_endpoints.py``) that walked the ENTIRE backend and frontend tree with
+nothing checking whether the caller was still waiting -- the same shape
+#12779 found and fixed for duplicate detection, just for endpoint scanning:
+`asyncio.wait_for` cancels the AWAIT, not the thread already walking the
+tree.
+
+These tests assert the scan loops actually stop, not merely that a check was
+added somewhere.
+"""
+
+from __future__ import annotations
+
+import threading
+
+from api.codebase_analytics import api_endpoint_scanner as scanner_mod
+
+
+def _make_backend_files(tmp_path, count: int) -> None:
+    api_dir = tmp_path / "api"
+    api_dir.mkdir(parents=True, exist_ok=True)
+    for i in range(count):
+        (api_dir / f"m{i}.py").write_text(
+            f'@router.get("/x{i}")\nasync def h{i}():\n    return {{}}\n',
+            encoding="utf-8",
+        )
+
+
+def _make_frontend_files(tmp_path, count: int) -> None:
+    src_dir = tmp_path / "autobot-frontend" / "src"
+    src_dir.mkdir(parents=True, exist_ok=True)
+    for i in range(count):
+        (src_dir / f"c{i}.ts").write_text(f'api.get("/x{i}");\n', encoding="utf-8")
+
+
+class TestBackendScannerCooperativeCancellation:
+    def test_pre_set_token_stops_the_scan_before_any_file(self, tmp_path):
+        """A timed-out scan must stop, not run to completion for a discarded
+        result -- the #12779 shape, applied here."""
+        _make_backend_files(tmp_path, 5)
+        token = threading.Event()
+        token.set()
+        scanner = scanner_mod.BackendEndpointScanner(project_root=tmp_path, cancel_token=token)
+
+        assert scanner.scan_all_endpoints() == []
+
+    def test_scan_completes_normally_without_a_token(self, tmp_path):
+        """Cancellation must be opt-in -- the default path is unchanged."""
+        _make_backend_files(tmp_path, 3)
+        scanner = scanner_mod.BackendEndpointScanner(project_root=tmp_path)
+
+        assert scanner._cancel_token is None
+        assert scanner._cancelled() is False
+        endpoints = scanner.scan_all_endpoints()
+        assert len(endpoints) == 3
+
+    def test_the_check_is_periodic_not_only_at_the_top(self, tmp_path, monkeypatch):
+        """#14256: 'checked at loop boundaries... not only at the top'.
+
+        With more files than CANCEL_CHECK_INTERVAL, setting the token after a
+        few files must stop the scan well before the last file -- proving the
+        loop re-checks periodically, not once at entry.
+        """
+        total = scanner_mod.CANCEL_CHECK_INTERVAL * 3
+        _make_backend_files(tmp_path, total)
+        token = threading.Event()
+        scanner = scanner_mod.BackendEndpointScanner(project_root=tmp_path, cancel_token=token)
+
+        call_count = {"n": 0}
+        real_scan_file = scanner._scan_file
+
+        def _counting_scan_file(py_file):
+            call_count["n"] += 1
+            if call_count["n"] == 5:
+                token.set()
+            return real_scan_file(py_file)
+
+        monkeypatch.setattr(scanner, "_scan_file", _counting_scan_file)
+        scanner.scan_all_endpoints()
+
+        assert 5 <= call_count["n"] < total, (
+            f"expected the scan to stop well short of all {total} files after being "
+            f"cancelled at file 5, but it processed {call_count['n']}"
+        )
+
+    def test_unset_token_does_not_cancel(self, tmp_path):
+        _make_backend_files(tmp_path, 2)
+        scanner = scanner_mod.BackendEndpointScanner(project_root=tmp_path, cancel_token=threading.Event())
+
+        assert scanner._cancelled() is False
+        assert len(scanner.scan_all_endpoints()) == 2
+
+
+class TestFrontendScannerCooperativeCancellation:
+    def test_pre_set_token_stops_the_scan_before_any_file(self, tmp_path):
+        _make_frontend_files(tmp_path, 5)
+        token = threading.Event()
+        token.set()
+        scanner = scanner_mod.FrontendAPICallScanner(project_root=tmp_path, cancel_token=token)
+
+        assert scanner.scan_all_calls() == []
+
+    def test_scan_completes_normally_without_a_token(self, tmp_path):
+        _make_frontend_files(tmp_path, 3)
+        scanner = scanner_mod.FrontendAPICallScanner(project_root=tmp_path)
+
+        assert scanner._cancelled() is False
+        assert len(scanner.scan_all_calls()) == 3
+
+    def test_the_check_is_periodic_not_only_at_the_top(self, tmp_path, monkeypatch):
+        total = scanner_mod.CANCEL_CHECK_INTERVAL * 3
+        _make_frontend_files(tmp_path, total)
+        token = threading.Event()
+        scanner = scanner_mod.FrontendAPICallScanner(project_root=tmp_path, cancel_token=token)
+
+        call_count = {"n": 0}
+        real_scan_file = scanner._scan_file
+
+        def _counting_scan_file(file_path):
+            call_count["n"] += 1
+            if call_count["n"] == 5:
+                token.set()
+            return real_scan_file(file_path)
+
+        monkeypatch.setattr(scanner, "_scan_file", _counting_scan_file)
+        scanner.scan_all_calls()
+
+        assert 5 <= call_count["n"] < total, (
+            f"expected the scan to stop well short of all {total} files after being "
+            f"cancelled at file 5, but it processed {call_count['n']}"
+        )
+
+
+class TestAPIEndpointCheckerThreadsTheTokenThrough:
+    """run_full_analysis() dispatches both scanners as ONE call submitted to
+    a pool (report.py/api_endpoints.py) -- the token has to reach whichever
+    of the two scanners is running when the deadline fires."""
+
+    def test_the_same_token_reaches_both_scanners(self, tmp_path):
+        _make_backend_files(tmp_path, 1)
+        _make_frontend_files(tmp_path, 1)
+        token = threading.Event()
+
+        checker = scanner_mod.APIEndpointChecker(project_root=tmp_path, cancel_token=token)
+
+        assert checker.backend_scanner._cancel_token is token
+        assert checker.frontend_scanner._cancel_token is token
+
+    def test_a_pre_set_token_makes_run_full_analysis_return_an_empty_analysis(self, tmp_path):
+        """Abandoned before it starts: an honest, immediate result rather than
+        the full backend+frontend walk running anyway."""
+        _make_backend_files(tmp_path, 5)
+        _make_frontend_files(tmp_path, 5)
+        token = threading.Event()
+        token.set()
+
+        checker = scanner_mod.APIEndpointChecker(project_root=tmp_path, cancel_token=token)
+        analysis = checker.run_full_analysis()
+
+        assert analysis.backend_endpoints == 0
+        assert analysis.frontend_calls == 0

--- a/autobot-backend/api/codebase_analytics/endpoints/api_endpoints.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/api_endpoints.py
@@ -14,6 +14,7 @@ Provides endpoints to:
 """
 
 import asyncio
+import threading
 from pathlib import Path
 from typing import Dict
 
@@ -22,6 +23,7 @@ from fastapi.responses import JSONResponse
 
 from autobot_shared.error_boundaries import ErrorCategory, bounded, with_error_handling
 from autobot_shared.logging_manager import get_logger
+from utils.cancel_tokens import new_cancel_token, run_cancellable
 
 from ..api_endpoint_scanner import APIEndpointChecker
 from ..models import APIEndpointAnalysis
@@ -45,13 +47,20 @@ def _cache_key(source_id: str | None) -> str:
     return source_id or "default"
 
 
-def _get_checker(project_root: Path | None = None) -> APIEndpointChecker:
+def _get_checker(
+    project_root: Path | None = None,
+    cancel_token: threading.Event | None = None,
+) -> APIEndpointChecker:
     """Get or create the API endpoint checker instance.
 
     Issue #12330: Bind the checker to the requested source's root so it scans
     the selected project rather than AutoBot's own root.
+    Issue #14256: cancel_token is threaded through so a route deadline stops
+    the scan, not only the wait -- these routes dispatch via
+    ``asyncio.to_thread`` (the default executor), the same unmitigated shape
+    as ``report.py``'s ``_get_api_endpoint_analysis`` before that fix.
     """
-    return APIEndpointChecker(project_root=project_root)
+    return APIEndpointChecker(project_root=project_root, cancel_token=cancel_token)
 
 
 async def _get_or_run_analysis(source_id: str | None) -> APIEndpointAnalysis:
@@ -67,8 +76,16 @@ async def _get_or_run_analysis(source_id: str | None) -> APIEndpointAnalysis:
         return cached
 
     root = await resolve_scan_root(source_id)
-    checker = _get_checker(root)
-    analysis = await asyncio.to_thread(checker.run_full_analysis)
+    cancel_token = new_cancel_token()
+    checker = _get_checker(root, cancel_token=cancel_token)
+    # Issue #14256: default executor (``None``), cancellably -- was a bare
+    # ``asyncio.to_thread`` with nothing to stop the scan once running.
+    analysis = await run_cancellable(
+        None,
+        checker.run_full_analysis,
+        operation="api_endpoint_analysis",
+        cancel_token=cancel_token,
+    )
 
     async with _analysis_cache_lock:
         _analysis_cache[key] = analysis
@@ -92,8 +109,14 @@ async def get_api_endpoints(
     Issue #12330: Scoped to the selected source's clone path.
     """
     root = await resolve_scan_root(source_id)
-    checker = _get_checker(root)
-    endpoints = await asyncio.to_thread(checker.get_backend_endpoints)
+    cancel_token = new_cancel_token()
+    checker = _get_checker(root, cancel_token=cancel_token)
+    endpoints = await run_cancellable(
+        None,
+        checker.get_backend_endpoints,
+        operation="get_backend_endpoints",
+        cancel_token=cancel_token,
+    )
 
     return JSONResponse(
         {
@@ -121,8 +144,14 @@ async def get_frontend_api_calls(
     Issue #12330: Scoped to the selected source's clone path.
     """
     root = await resolve_scan_root(source_id)
-    checker = _get_checker(root)
-    calls = await asyncio.to_thread(checker.get_frontend_calls)
+    cancel_token = new_cancel_token()
+    checker = _get_checker(root, cancel_token=cancel_token)
+    calls = await run_cancellable(
+        None,
+        checker.get_frontend_calls,
+        operation="get_frontend_calls",
+        cancel_token=cancel_token,
+    )
 
     return JSONResponse(
         {
@@ -318,8 +347,14 @@ async def refresh_endpoint_cache(
     another project's cached analysis.
     """
     root = await resolve_scan_root(source_id)
-    checker = _get_checker(root)
-    analysis = await asyncio.to_thread(checker.run_full_analysis)
+    cancel_token = new_cancel_token()
+    checker = _get_checker(root, cancel_token=cancel_token)
+    analysis = await run_cancellable(
+        None,
+        checker.run_full_analysis,
+        operation="refresh_endpoint_cache",
+        cancel_token=cancel_token,
+    )
 
     # Update cache (thread-safe, Issue #559)
     async with _analysis_cache_lock:

--- a/autobot-backend/api/codebase_analytics/endpoints/cross_project_scoping_test.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/cross_project_scoping_test.py
@@ -171,7 +171,7 @@ class TestEndpointCoverageCacheScoping:
         analysis_a = MagicMock(name="analysis_A")
         analysis_b = MagicMock(name="analysis_B")
 
-        def fake_checker(project_root=None):
+        def fake_checker(project_root=None, cancel_token=None):
             checker = MagicMock()
             checker.run_full_analysis = MagicMock(return_value=analysis_a if project_root == root_a else analysis_b)
             return checker

--- a/autobot-backend/api/codebase_analytics/endpoints/duplicates.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/duplicates.py
@@ -27,6 +27,7 @@ from autobot_shared.error_boundaries import ErrorCategory, bounded, with_error_h
 from autobot_shared.logging_manager import get_logger
 from constants.threshold_constants import AnalyticsConfig
 from tasks.analytics_tasks import run_duplicate_analysis
+from utils.cancel_tokens import new_cancel_token, signal_cancel_token, submit_cancellable
 from utils.celery_task_status import celery_result_to_status, get_latest_task_result, store_latest_task_id
 from utils.chromadb_client import get_all_paginated
 from utils.io_executor import get_analytics_executor
@@ -102,6 +103,15 @@ async def _run_standard_analysis(project_root: str, min_similarity: float):
 
     Returns:
         Analysis result or None if timed out
+
+    Issue #14256: the submit-and-register step now goes through
+    ``utils.cancel_tokens.submit_cancellable`` -- the same shape this function
+    hand-rolled for #12779/#13602, hoisted so ``bounded()`` can also signal
+    this token (e.g. if the route's own deadline is tighter than
+    ``DUPLICATE_DETECTION_TIMEOUT``), not only this function's own timeout
+    handler. The single-flight lock stays call-site-specific: releasing it
+    only once the orphaned thread actually exits is this endpoint's own
+    bookkeeping, not part of the general cancellation mechanism.
     """
     global _duplicate_scan_cancel
 
@@ -110,19 +120,26 @@ async def _run_standard_analysis(project_root: str, min_similarity: float):
         logger.info("Duplicate detection already in flight — not queuing another scan")
         return None
 
-    cancel_token = threading.Event()
-    _duplicate_scan_cancel = cancel_token
     released = False
+    cancel_token = new_cancel_token()
     # Issue #1233: Use dedicated analytics executor to prevent
     # default thread pool starvation
-    future = asyncio.get_running_loop().run_in_executor(
+    #
+    # submit_cancellable() registers `cancel_token` in bounded()'s active scope
+    # and hands back the SAME token object (since one is passed in here) --
+    # the lambda below closes over it directly, so signalling either the
+    # returned token or this one stops the same detector.
+    future, _ = submit_cancellable(
         get_analytics_executor(),
         lambda: DuplicateCodeDetector(
             project_root=project_root,
             min_similarity=min_similarity,
             cancel_token=cancel_token,
         ).run_analysis(),
+        operation="duplicate_detection",
+        cancel_token=cancel_token,
     )
+    _duplicate_scan_cancel = cancel_token
     try:
         analysis = await asyncio.wait_for(asyncio.shield(future), timeout=AnalyticsConfig.DUPLICATE_DETECTION_TIMEOUT)
         _duplicate_scan_lock.release()
@@ -131,7 +148,11 @@ async def _run_standard_analysis(project_root: str, min_similarity: float):
     except asyncio.TimeoutError:
         # The executor thread survives this cancellation — signal it to stop, or
         # it keeps scanning for a result that is already discarded (#12779).
-        cancel_token.set()
+        signal_cancel_token(
+            "duplicate_detection",
+            cancel_token,
+            f"exceeded its {AnalyticsConfig.DUPLICATE_DETECTION_TIMEOUT}s deadline",
+        )
         # #13602: hold the lock until that thread actually exits. Releasing it
         # here let the next poll queue a second full scan while the first was
         # still running, so abandoned scans stacked up — the accumulation #12779
@@ -152,7 +173,7 @@ async def _run_standard_analysis(project_root: str, min_similarity: float):
         # thread. That is the accumulation both #12779 and this change exist to
         # close, reachable via uvicorn graceful shutdown and via any outer
         # deadline tighter than this one. Same treatment as a timeout.
-        cancel_token.set()
+        signal_cancel_token("duplicate_detection", cancel_token, "cancelled before its own deadline")
         future.add_done_callback(lambda _f: _duplicate_scan_lock.release())
         released = True
         logger.warning("Duplicate detection cancelled — signalled the orphaned scan to stop")

--- a/autobot-backend/api/codebase_analytics/endpoints/report.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/report.py
@@ -35,6 +35,7 @@ from code_intelligence.pattern_analysis import (
 )
 from constants.path_constants import PATH
 from constants.ttl_constants import TIMEOUT_HTTP_LONG
+from utils.cancel_tokens import new_cancel_token, run_cancellable
 from utils.chromadb_client import get_all_paginated
 from utils.file_categorization import (
     FILE_CATEGORY_ARCHIVE,
@@ -47,7 +48,7 @@ from utils.file_categorization import (
     FILE_CATEGORY_LOGS,
     FILE_CATEGORY_TEST,
 )
-from utils.io_executor import run_in_analytics_executor
+from utils.io_executor import get_analytics_executor
 
 from ..api_endpoint_scanner import APIEndpointChecker
 from ..duplicate_detector import (  # noqa: F401
@@ -1725,11 +1726,26 @@ async def _get_api_endpoint_analysis(
 
     Returns:
         APIEndpointAnalysis or None if analysis fails
+
+    Issue #14256/#14244: run_full_analysis() used to be submitted to the
+    analytics executor with nothing to stop it -- the reported hang, and the
+    one call in this fan-out with no cancellation of any kind. A cancel token
+    is now created here and registered in bounded()'s active scope (via
+    run_cancellable), so a route deadline -- this call's own outer
+    ``asyncio.wait_for`` in ``_run_parallel_analyses``, or ``/report``'s
+    ``bounded()`` itself if that fires first -- stops the scan instead of
+    just the wait.
     """
+    cancel_token = new_cancel_token()
     try:
-        checker = APIEndpointChecker(project_root=project_root)
+        checker = APIEndpointChecker(project_root=project_root, cancel_token=cancel_token)
         # Issue #1233: Use dedicated analytics executor
-        analysis = await run_in_analytics_executor(checker.run_full_analysis)
+        analysis = await run_cancellable(
+            get_analytics_executor(),
+            checker.run_full_analysis,
+            operation="api_endpoint_analysis",
+            cancel_token=cancel_token,
+        )
         logger.info(
             "API endpoint analysis: %d endpoints, %d calls, %.1f%% coverage",
             analysis.backend_endpoints,
@@ -1737,6 +1753,8 @@ async def _get_api_endpoint_analysis(
             analysis.coverage_percentage,
         )
         return analysis
+    except asyncio.CancelledError:
+        raise
     except Exception as e:
         logger.error("API endpoint analysis failed: %s", e, exc_info=True)
         return None

--- a/autobot-backend/utils/cancel_tokens.py
+++ b/autobot-backend/utils/cancel_tokens.py
@@ -1,0 +1,225 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Cooperative cancellation for pooled analytics work (#14256, #14244).
+
+``asyncio.wait_for`` and ``task.cancel()`` stop an AWAIT. They cannot stop work
+already running in a ``ThreadPoolExecutor`` -- a Python thread cannot be
+pre-empted from the outside. #12779 (``duplicates.py``) proved the fix once:
+hand the worker a ``threading.Event``, poll it at loop boundaries, and set it
+from the asyncio side when the caller stops waiting. #13602 then found that
+check wired to exactly one phase of one endpoint.
+
+This module hoists that shape so every analytics route can reuse it instead of
+re-deriving it, per #14256's fix checklist:
+
+- A cancellation handle passed into pooled work, checked at loop boundaries --
+  ``new_cancel_token()`` / ``register_cancel_token()`` below, the same
+  ``threading.Event`` #12779 already used.
+- ``bounded()`` (``utils/error_boundaries/decorators.py``) signals every token
+  registered during its own call on expiry, via ``begin_cancel_scope()`` /
+  ``signal_cancel_scope()`` -- the deadline and the cancellation are the same
+  event, not two facts that can drift.
+- ``submit_cancellable()`` is the "cancellable executor submission helper"
+  from #14244: it submits a zero-argument callable to a pool and registers
+  its token in the active scope, so ``bounded()`` can reach it without either
+  side importing the other.
+- ``signal_cancel_token()`` records the "cancelled but still running" gap as a
+  log line and a Prometheus counter (#14244 item 3), so the gap between "the
+  client got a response" and "the work actually stopped" is measured instead
+  of inferred.
+
+Deliberately kept a raw ``threading.Event`` rather than a new wrapper class:
+``DuplicateCodeDetector`` (#12779/#13602) already takes and tests
+``cancel_token: threading.Event | None`` on its public constructor, and that
+contract stays unchanged here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextvars
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from typing import Callable, TypeVar
+
+from autobot_shared.logging_manager import get_logger
+
+logger = get_logger(__name__)
+
+T = TypeVar("T")
+
+# #14256: bounded() wraps arbitrary route handlers and has no idea what, if
+# anything, they submit to a pool. This contextvar is the only thing the two
+# sides share: submit_cancellable() (or a call site handling its own timeout)
+# registers a token here if a scope is open; bounded() signals every token
+# registered during its own call when its deadline expires. Neither imports
+# the other.
+_active_tokens: contextvars.ContextVar[list[tuple[str, threading.Event]] | None] = contextvars.ContextVar(
+    "_autobot_active_cancel_tokens", default=None
+)
+
+
+def new_cancel_token() -> threading.Event:
+    """Create a cancel token -- the #12779/#13602 shape, hoisted.
+
+    A plain ``threading.Event`` so it can be handed straight into a
+    ``ThreadPoolExecutor`` callable exactly like ``DuplicateCodeDetector``
+    already expects, with no adapter needed.
+    """
+    return threading.Event()
+
+
+def begin_cancel_scope() -> contextvars.Token:
+    """Open a collection point for tokens created during this call.
+
+    Called by ``bounded()`` before invoking the wrapped handler. Returns the
+    reset token for ``end_cancel_scope()``.
+    """
+    return _active_tokens.set([])
+
+
+def end_cancel_scope(reset_token: contextvars.Token) -> None:
+    """Close the collection point opened by ``begin_cancel_scope()``."""
+    _active_tokens.reset(reset_token)
+
+
+def register_cancel_token(operation: str, token: threading.Event) -> None:
+    """Register a token in the currently-open cancel scope, if any.
+
+    A no-op outside a ``bounded()`` call (no scope open) -- pooled work
+    remains cancellable via its own timeout even when nothing is listening
+    for an outer deadline.
+    """
+    scope = _active_tokens.get()
+    if scope is not None:
+        scope.append((operation, token))
+
+
+def signal_cancel_token(operation: str, token: threading.Event, reason: str) -> None:
+    """Set a cancel token and record the "cancelled but still running" gap.
+
+    #14244 item 3: logged and counted here, not just set, because a token
+    that is merely set is invisible from outside -- the whole point is that
+    this state used to only be inferred from a hang.
+    """
+    if token.is_set():
+        return
+    token.set()
+    logger.warning(
+        "Signalled cancel token for %s (%s) -- pooled work may still be "
+        "running until it next checks the token (#14244)",
+        operation,
+        reason,
+    )
+    try:
+        from monitoring.prometheus_metrics import get_metrics_manager
+
+        get_metrics_manager().record_executor_cancel_signalled(operation)
+    except Exception:  # pragma: no cover - metrics must never break cancellation
+        logger.debug("Could not record executor-cancel metric for %s", operation, exc_info=True)
+
+
+def signal_cancel_scope(reason: str) -> None:
+    """Signal every token registered in the currently-open cancel scope.
+
+    #14256: called by ``bounded()`` on timeout (and on outer cancellation) so
+    the route deadline and the cancellation of the work it dispatched are the
+    same event.
+    """
+    scope = _active_tokens.get()
+    if not scope:
+        return
+    for operation, token in scope:
+        signal_cancel_token(operation, token, reason)
+
+
+def submit_cancellable(
+    executor: ThreadPoolExecutor | None,
+    func: Callable[[], T],
+    *,
+    operation: str,
+    cancel_token: threading.Event | None = None,
+) -> tuple["asyncio.Future[T]", threading.Event]:
+    """Submit a zero-argument callable to ``executor``, cancellably (#14244).
+
+    The "cancellable executor submission helper": creates a token if the
+    caller has none, hands it nowhere itself (the caller already bound it
+    into ``func``, e.g. via a constructor kwarg or ``functools.partial`` --
+    mirrors ``DuplicateCodeDetector(cancel_token=...)``), and registers it in
+    the active cancel scope so ``bounded()`` can signal it on expiry even if
+    this call never sets its own timeout.
+
+    Returns the raw ``asyncio.Future`` (not awaited) plus the token, so the
+    caller can apply its own deadline / ``asyncio.shield`` / done-callback
+    behaviour -- resource cleanup on abandonment (e.g. duplicates.py's
+    single-flight lock) is call-site-specific and does not belong here.
+
+    Deliberately synchronous (not a coroutine): submitting to the executor and
+    registering the token must happen atomically with the call, with no
+    ``await`` point between them where ``task.cancel()`` could land outside a
+    caller's own ``try``/``except`` and leave the token unregistered and the
+    thread unaccounted for.
+    """
+    token = cancel_token if cancel_token is not None else new_cancel_token()
+    register_cancel_token(operation, token)
+    loop = asyncio.get_running_loop()
+    future = loop.run_in_executor(executor, func)
+    return future, token
+
+
+async def run_cancellable(
+    executor: ThreadPoolExecutor | None,
+    func: Callable[[], T],
+    *,
+    operation: str,
+    cancel_token: threading.Event | None = None,
+    timeout: float | None = None,
+) -> T:
+    """Await ``func()`` in ``executor``, signalling its token on abandonment.
+
+    The simple case built on ``submit_cancellable()``: no caller-specific
+    cleanup needed, just "run this, and if the caller stops waiting for it
+    (its own ``timeout``, or an outer ``bounded()``/``task.cancel()``),
+    signal the token before propagating." Used where a route dispatches a
+    single pooled call with no other bookkeeping (e.g.
+    ``APIEndpointChecker.run_full_analysis``).
+
+    Raises:
+        asyncio.TimeoutError: on expiry, after signalling ``cancel_token``.
+        asyncio.CancelledError: if the awaiting task itself is cancelled
+            (outer deadline, shutdown), after signalling and re-raising --
+            never swallowed.
+    """
+    future, token = submit_cancellable(executor, func, operation=operation, cancel_token=cancel_token)
+    try:
+        if timeout is not None:
+            return await asyncio.wait_for(asyncio.shield(future), timeout=timeout)
+        return await future
+    except asyncio.TimeoutError:
+        signal_cancel_token(operation, token, f"{operation} exceeded its {timeout}s deadline")
+        raise
+    except asyncio.CancelledError:
+        signal_cancel_token(operation, token, f"{operation} was cancelled")
+        raise
+
+
+def cancel_scope_depth() -> int:
+    """Number of tokens registered in the current scope (test/debug helper)."""
+    scope = _active_tokens.get()
+    return len(scope) if scope else 0
+
+
+__all__ = [
+    "new_cancel_token",
+    "begin_cancel_scope",
+    "end_cancel_scope",
+    "register_cancel_token",
+    "signal_cancel_token",
+    "signal_cancel_scope",
+    "submit_cancellable",
+    "run_cancellable",
+    "cancel_scope_depth",
+]

--- a/autobot-backend/utils/cancel_tokens_test.py
+++ b/autobot-backend/utils/cancel_tokens_test.py
@@ -199,10 +199,21 @@ class TestRunCancellable:
         active = {"n": 0}
         lock = threading.Lock()
 
+        entered = threading.Event()
+        may_observe = threading.Event()
+
         def _work(token: threading.Event):
             with lock:
                 active["n"] += 1
             try:
+                # Park before the first token check so the "still occupied"
+                # assertion below is deterministic rather than a race. The
+                # worker polls every 10ms against a 50ms timeout, so without
+                # this gate it can notice the token and exit before the test
+                # gets to look -- the assertion would then fail precisely
+                # BECAUSE cancellation worked, which is the wrong signal.
+                entered.set()
+                may_observe.wait(timeout=5.0)
                 for _ in range(400):  # bounded: ~4s worst case, checked every 10ms
                     if token.is_set():
                         return "cancelled"
@@ -229,16 +240,19 @@ class TestRunCancellable:
 
             token = asyncio.run(_drive())
 
-            # Immediately after the asyncio-level timeout, the OS thread is
-            # still running -- this is the bug #14256/#14244 describe: the
-            # caller already has its error, the pool slot is not yet free.
+            # The worker is parked at `may_observe`, so this is a fact about
+            # the pool, not a race: the caller already has its TimeoutError
+            # while the OS thread still holds the only slot. That is exactly
+            # the bug #14256/#14244 describe.
+            assert entered.is_set(), "the work never started -- the test proves nothing"
             with lock:
                 assert active["n"] == 1, "the worker must still be occupied right after the caller's timeout"
             assert token.is_set()
 
-            # Once the thread next checks the (now-signalled) token it must
-            # exit -- prove the slot returns to baseline, not just that the
-            # token was set.
+            # Release the worker; once it checks the (now-signalled) token it
+            # must exit -- prove the slot returns to baseline, not merely that
+            # the token was set.
+            may_observe.set()
             deadline = time.monotonic() + 3.0
             while time.monotonic() < deadline:
                 with lock:

--- a/autobot-backend/utils/cancel_tokens_test.py
+++ b/autobot-backend/utils/cancel_tokens_test.py
@@ -1,0 +1,236 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Cooperative cancellation for pooled work (#14256, #14244).
+
+``asyncio.wait_for``/``task.cancel()`` stop an AWAIT, not work already running
+in a ``ThreadPoolExecutor`` -- a thread cannot be pre-empted from outside.
+These tests assert the mechanism actually stops the work and frees the
+executor slot, not merely that the caller's await raised.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+
+import pytest
+
+from utils import cancel_tokens as ct
+
+
+class TestCancelScope:
+    def test_register_outside_a_scope_is_a_no_op(self):
+        """No bounded() call open -- pooled work stays cancellable via its
+        own timeout even when nothing is listening for an outer deadline."""
+        token = ct.new_cancel_token()
+        ct.register_cancel_token("op", token)  # must not raise
+        assert ct.cancel_scope_depth() == 0
+
+    def test_register_inside_a_scope_is_collected(self):
+        token = ct.new_cancel_token()
+        scope = ct.begin_cancel_scope()
+        try:
+            ct.register_cancel_token("op", token)
+            assert ct.cancel_scope_depth() == 1
+        finally:
+            ct.end_cancel_scope(scope)
+        assert ct.cancel_scope_depth() == 0
+
+    def test_signal_scope_sets_every_registered_token_exactly_once(self):
+        token_a = ct.new_cancel_token()
+        token_b = ct.new_cancel_token()
+        scope = ct.begin_cancel_scope()
+        try:
+            ct.register_cancel_token("a", token_a)
+            ct.register_cancel_token("b", token_b)
+            ct.signal_cancel_scope("deadline exceeded")
+            assert token_a.is_set()
+            assert token_b.is_set()
+        finally:
+            ct.end_cancel_scope(scope)
+
+    def test_signal_scope_with_nothing_registered_does_not_raise(self):
+        scope = ct.begin_cancel_scope()
+        try:
+            ct.signal_cancel_scope("deadline exceeded")  # no tokens: no-op
+        finally:
+            ct.end_cancel_scope(scope)
+
+    def test_nested_scopes_do_not_leak_into_each_other(self):
+        """A scope closed by end_cancel_scope must not see a sibling's tokens."""
+        outer_token = ct.new_cancel_token()
+        outer = ct.begin_cancel_scope()
+        ct.register_cancel_token("outer", outer_token)
+
+        inner_token = ct.new_cancel_token()
+        inner = ct.begin_cancel_scope()
+        try:
+            ct.register_cancel_token("inner", inner_token)
+            assert ct.cancel_scope_depth() == 1
+            ct.signal_cancel_scope("inner deadline")
+            assert inner_token.is_set()
+            assert not outer_token.is_set(), "signalling the inner scope must not reach the outer one"
+        finally:
+            ct.end_cancel_scope(inner)
+
+        assert ct.cancel_scope_depth() == 1, "closing the inner scope must restore the outer one"
+        ct.end_cancel_scope(outer)
+
+
+class TestSignalCancelToken:
+    def test_sets_the_token(self):
+        token = ct.new_cancel_token()
+        ct.signal_cancel_token("op", token, "timed out")
+        assert token.is_set()
+
+    def test_is_idempotent(self, monkeypatch):
+        """Signalling an already-signalled token must not log/record twice --
+        a route can be cancelled and then time out on the same call."""
+        token = ct.new_cancel_token()
+        token.set()
+        calls = []
+        monkeypatch.setattr(ct.logger, "warning", lambda *a, **k: calls.append(a))
+        ct.signal_cancel_token("op", token, "second signal")
+        assert calls == [], "an already-signalled token must not be logged again"
+
+
+class TestSubmitCancellable:
+    @pytest.mark.asyncio
+    async def test_creates_a_token_when_none_given(self):
+        future, token = ct.submit_cancellable(None, lambda: 1, operation="op")
+        assert isinstance(token, threading.Event)
+        assert await future == 1
+
+    @pytest.mark.asyncio
+    async def test_uses_the_given_token(self):
+        given = ct.new_cancel_token()
+        future, token = ct.submit_cancellable(None, lambda: 1, operation="op", cancel_token=given)
+        assert token is given
+        await future
+
+    @pytest.mark.asyncio
+    async def test_registers_in_the_active_scope(self):
+        scope = ct.begin_cancel_scope()
+        try:
+            future, token = ct.submit_cancellable(None, lambda: 1, operation="op")
+            assert ct.cancel_scope_depth() == 1
+            await future
+        finally:
+            ct.end_cancel_scope(scope)
+
+
+class TestRunCancellable:
+    """The verification bar: assert the WORK stopped, not that the caller's
+    await raised. Every blocking function below is a REAL callable submitted
+    to a REAL ThreadPoolExecutor -- these are executed, not simulated."""
+
+    @pytest.mark.asyncio
+    async def test_normal_completion_does_not_signal_the_token(self):
+        """Negative case (#14244's verification bar): a request that completes
+        normally must not have its work flagged as cancelled."""
+        result = await ct.run_cancellable(None, lambda: 42, operation="op")
+        assert result == 42
+
+    @pytest.mark.asyncio
+    async def test_timeout_signals_the_token_and_raises_timeout_error(self):
+        token = ct.new_cancel_token()
+
+        def _slow():
+            token.wait(timeout=5)
+            return "done"
+
+        with pytest.raises(asyncio.TimeoutError):
+            await ct.run_cancellable(None, _slow, operation="op", cancel_token=token, timeout=0.05)
+
+        assert token.is_set(), "the token must be signalled so the thread can stop itself"
+
+    @pytest.mark.asyncio
+    async def test_outer_cancellation_signals_the_token_and_reraises(self):
+        """CancelledError must never be swallowed -- it propagates after the
+        token is signalled (#14256: 'never swallow CancelledError')."""
+        token = ct.new_cancel_token()
+        started = threading.Event()
+        release = threading.Event()
+
+        def _slow():
+            started.set()
+            release.wait(timeout=5)
+            return "done"
+
+        task = asyncio.ensure_future(ct.run_cancellable(None, _slow, operation="op", cancel_token=token))
+        await asyncio.get_running_loop().run_in_executor(None, started.wait, 5)
+        task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert token.is_set(), "an outer cancellation must signal the token exactly like a timeout"
+        release.set()
+
+    def test_the_executor_slot_is_actually_freed(self):
+        """Executor saturation under repeated timeouts (#14256 AC): the
+        assertion is on worker occupancy, not on the response.
+
+        A single-worker pool proves the point sharply: submit cancellable work
+        that honours its token, let run_cancellable's timeout fire, then prove
+        the pool's one worker slot returns to idle once the thread notices the
+        signal -- not merely that the caller's await raised TimeoutError.
+        """
+        from concurrent.futures import ThreadPoolExecutor
+
+        active = {"n": 0}
+        lock = threading.Lock()
+
+        def _work(token: threading.Event):
+            with lock:
+                active["n"] += 1
+            try:
+                for _ in range(400):  # bounded: ~4s worst case, checked every 10ms
+                    if token.is_set():
+                        return "cancelled"
+                    time.sleep(0.01)
+                return "ran_to_completion_without_noticing_cancellation"
+            finally:
+                with lock:
+                    active["n"] -= 1
+
+        executor = ThreadPoolExecutor(max_workers=1)
+        try:
+
+            async def _drive():
+                token = ct.new_cancel_token()
+                with pytest.raises(asyncio.TimeoutError):
+                    await ct.run_cancellable(
+                        executor,
+                        lambda: _work(token),
+                        operation="occupancy_test",
+                        cancel_token=token,
+                        timeout=0.05,
+                    )
+                return token
+
+            token = asyncio.run(_drive())
+
+            # Immediately after the asyncio-level timeout, the OS thread is
+            # still running -- this is the bug #14256/#14244 describe: the
+            # caller already has its error, the pool slot is not yet free.
+            with lock:
+                assert active["n"] == 1, "the worker must still be occupied right after the caller's timeout"
+            assert token.is_set()
+
+            # Once the thread next checks the (now-signalled) token it must
+            # exit -- prove the slot returns to baseline, not just that the
+            # token was set.
+            deadline = time.monotonic() + 3.0
+            while time.monotonic() < deadline:
+                with lock:
+                    if active["n"] == 0:
+                        break
+                time.sleep(0.02)
+            with lock:
+                assert active["n"] == 0, "the executor slot was never freed -- the work kept the thread"
+        finally:
+            executor.shutdown(wait=True)

--- a/autobot-backend/utils/cancel_tokens_test.py
+++ b/autobot-backend/utils/cancel_tokens_test.py
@@ -96,6 +96,21 @@ class TestSignalCancelToken:
         ct.signal_cancel_token("op", token, "second signal")
         assert calls == [], "an already-signalled token must not be logged again"
 
+    def test_records_the_prometheus_metric(self):
+        """#14244 item 3: a metric, not only a log line, so the gap between
+        'the client got a response' and 'the work actually stopped' shows up
+        on a dashboard instead of only in logs someone has to go looking for.
+        """
+        from monitoring.prometheus_metrics import get_metrics_manager
+
+        manager = get_metrics_manager()
+        before = manager.executor_cancel_signalled_total.labels(operation="metric_test")._value.get()
+
+        ct.signal_cancel_token("metric_test", ct.new_cancel_token(), "timed out")
+
+        after = manager.executor_cancel_signalled_total.labels(operation="metric_test")._value.get()
+        assert after == before + 1
+
 
 class TestSubmitCancellable:
     @pytest.mark.asyncio

--- a/autobot-backend/utils/error_boundaries/bounded_cancel_scope_14256_test.py
+++ b/autobot-backend/utils/error_boundaries/bounded_cancel_scope_14256_test.py
@@ -1,0 +1,182 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""``bounded()`` signals the pooled work it dispatched, not just the wait (#14256, #14244).
+
+#14015/PR #14243 shipped the route deadline: a hung handler now returns a 504
+naming itself instead of holding the socket open forever. That turns the
+AWAIT into a 504, but ``asyncio.wait_for`` cannot stop work already running in
+a ``ThreadPoolExecutor`` -- the thread keeps walking whatever it was walking,
+holding a worker slot the next request needs (#12779, #13602).
+
+These tests assert the other half: a cancel token any pooled work registers
+via ``utils.cancel_tokens`` gets signalled by ``bounded()`` on expiry (and on
+an outer cancellation reaching the route before its own deadline does) --
+without ``bounded()`` importing anything about what the handler dispatched.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+
+import pytest
+from fastapi import HTTPException
+
+from autobot_shared.error_boundaries import bounded
+from utils import cancel_tokens as ct
+
+
+class TestBoundedSignalsOnTimeout:
+    @pytest.mark.asyncio
+    async def test_a_token_registered_by_the_handler_is_signalled_on_expiry(self):
+        """The reproduction: a handler that dispatches pooled work and then
+        hangs must leave that work signalled, not merely return a 504."""
+        token = ct.new_cancel_token()
+
+        @bounded(0.05, operation="dispatches_pooled_work")
+        async def handler():
+            ct.register_cancel_token("pooled_work", token)
+            await asyncio.Event().wait()  # never returns on its own
+
+        with pytest.raises(HTTPException) as exc:
+            await asyncio.wait_for(handler(), timeout=10)
+
+        assert exc.value.status_code == 504
+        assert token.is_set(), "bounded() must signal every token the handler registered"
+
+    @pytest.mark.asyncio
+    async def test_run_cancellable_registered_work_is_reachable_from_bounded(self):
+        """End-to-end: a handler using run_cancellable (the #14244 helper) with
+        NO timeout of its own is still stopped by bounded()'s deadline alone."""
+        release = threading.Event()
+
+        def _blocks_until_released():
+            release.wait(timeout=5)
+            return "should never be observed"
+
+        @bounded(0.05, operation="uses_run_cancellable")
+        async def handler():
+            return await ct.run_cancellable(None, _blocks_until_released, operation="pooled_work")
+
+        with pytest.raises(HTTPException) as exc:
+            await asyncio.wait_for(handler(), timeout=10)
+
+        assert exc.value.status_code == 504
+        release.set()
+
+    @pytest.mark.asyncio
+    async def test_a_call_site_with_no_cancelled_error_handling_of_its_own_is_still_reached(self):
+        """The ambient scope's actual value: a call site that does NOT itself
+        catch CancelledError (bare submit_cancellable(), unlike
+        run_cancellable()) still gets its token signalled -- bounded() reaches
+        in via the scope rather than relying on every call site's own
+        diligence to propagate the signal. This is what makes the mechanism
+        safe by default for a call site added later without that diligence.
+        """
+        release = threading.Event()
+        holder: dict[str, threading.Event] = {}
+
+        def _blocks_until_released():
+            release.wait(timeout=5)
+            return "should never be observed"
+
+        @bounded(0.05, operation="bare_submit_cancellable")
+        async def handler():
+            future, token = ct.submit_cancellable(None, _blocks_until_released, operation="pooled_work")
+            holder["token"] = token
+            return await future  # deliberately no try/except around this
+
+        with pytest.raises(HTTPException) as exc:
+            await asyncio.wait_for(handler(), timeout=10)
+
+        assert exc.value.status_code == 504
+        assert holder["token"].is_set(), "bounded() must reach a token registered via bare submit_cancellable"
+        release.set()
+
+
+class TestBoundedSignalsOnOuterCancellation:
+    @pytest.mark.asyncio
+    async def test_a_cancellation_reaching_bounded_before_its_own_deadline_still_signals(self):
+        """Reachable via graceful shutdown or a tighter outer deadline (#14256:
+        same treatment as a timeout). CancelledError is not TimeoutError and
+        must not fall through unsignalled."""
+        token = ct.new_cancel_token()
+        started = asyncio.Event()
+
+        @bounded(30.0, operation="outlives_the_test")
+        async def handler():
+            ct.register_cancel_token("pooled_work", token)
+            started.set()
+            await asyncio.Event().wait()
+
+        task = asyncio.ensure_future(handler())
+        await asyncio.wait_for(started.wait(), timeout=5)
+        task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert token.is_set(), "an outer cancellation must signal registered tokens exactly like a timeout"
+
+
+class TestBoundedDoesNotSignalOnSuccess:
+    @pytest.mark.asyncio
+    async def test_a_request_that_completes_normally_is_not_flagged_cancelled(self):
+        """Negative case (#14244's verification bar): success must not be
+        reported as an abandoned/cancelled scan."""
+        token = ct.new_cancel_token()
+
+        @bounded(5.0, operation="completes_normally")
+        async def handler():
+            ct.register_cancel_token("pooled_work", token)
+            return "ok"
+
+        result = await handler()
+
+        assert result == "ok"
+        assert not token.is_set(), "a token from a successful call must never be signalled"
+
+
+class TestBoundedScopeIsolation:
+    @pytest.mark.asyncio
+    async def test_a_token_registered_outside_any_bounded_call_is_not_touched(self):
+        """register_cancel_token() is a no-op with no scope open -- a token
+        created before any bounded() call must be unaffected by one expiring."""
+        stray_token = ct.new_cancel_token()  # never registered anywhere
+
+        @bounded(0.05, operation="unrelated")
+        async def handler():
+            await asyncio.Event().wait()
+
+        with pytest.raises(HTTPException):
+            await asyncio.wait_for(handler(), timeout=10)
+
+        assert not stray_token.is_set()
+
+    @pytest.mark.asyncio
+    async def test_two_concurrent_bounded_calls_do_not_cross_signal(self):
+        """Each bounded() call opens its own scope -- one route's expiry must
+        never signal a concurrently-running, unrelated route's pooled work."""
+        token_slow = ct.new_cancel_token()
+        token_fast = ct.new_cancel_token()
+
+        @bounded(0.05, operation="slow_route")
+        async def slow_handler():
+            ct.register_cancel_token("slow", token_slow)
+            await asyncio.Event().wait()
+
+        @bounded(5.0, operation="fast_route")
+        async def fast_handler():
+            ct.register_cancel_token("fast", token_fast)
+            return "ok"
+
+        with pytest.raises(HTTPException):
+            await asyncio.wait_for(
+                asyncio.gather(slow_handler(), fast_handler()),
+                timeout=10,
+            )
+
+        assert token_slow.is_set(), "the route that actually timed out must be signalled"
+        assert not token_fast.is_set(), "an unrelated concurrent route must not be cross-signalled"

--- a/autobot-backend/utils/error_boundaries/decorators.py
+++ b/autobot-backend/utils/error_boundaries/decorators.py
@@ -19,6 +19,7 @@ from fastapi import HTTPException
 from autobot_shared.async_compat import run_or_schedule
 from autobot_shared.logging_manager import get_logger
 from constants.threshold_constants import RetryConfig, exponential_backoff_delay
+from utils.cancel_tokens import begin_cancel_scope, end_cancel_scope, signal_cancel_scope
 
 from .boundary_manager import get_error_boundary_manager
 from .types import APIErrorResponse, ErrorCategory, ErrorContext, RecoveryStrategy
@@ -344,6 +345,15 @@ def bounded(seconds: float = DEFAULT_ROUTE_DEADLINE_SECONDS, *, operation: str |
         ValueError: at decoration time (import time) for a non-positive
             deadline, so the mistake surfaces at startup rather than on the
             first request.
+
+    Issue #14256: opens a cancel scope for the duration of the call. Any
+    pooled work the handler dispatches via
+    ``utils.cancel_tokens.submit_cancellable``/``run_cancellable`` registers
+    its cancel token here; on expiry (or on this call being cancelled from
+    outside, e.g. graceful shutdown) every registered token is signalled
+    before the 504/CancelledError propagates. The route deadline and the
+    cancellation of the work it dispatched are therefore the same event
+    rather than two facts that can drift (#14244).
     """
     if seconds <= 0:
         raise ValueError(f"bounded() needs a positive deadline, got {seconds!r}")
@@ -353,6 +363,7 @@ def bounded(seconds: float = DEFAULT_ROUTE_DEADLINE_SECONDS, *, operation: str |
 
         @functools.wraps(func)
         async def wrapper(*args, **kwargs):
+            scope = begin_cancel_scope()
             try:
                 return await asyncio.wait_for(func(*args, **kwargs), timeout=seconds)
             except asyncio.TimeoutError:
@@ -364,6 +375,11 @@ def bounded(seconds: float = DEFAULT_ROUTE_DEADLINE_SECONDS, *, operation: str |
                     name,
                     seconds,
                 )
+                # #14256: the deadline stopping the CALLER is only half the fix --
+                # signal every cancel token this call dispatched so pooled work
+                # stops cooperatively instead of running to completion for a
+                # result nobody reads (#14244).
+                signal_cancel_scope(f"route deadline for {name} exceeded {seconds:.1f}s")
                 raise HTTPException(
                     status_code=504,
                     detail={
@@ -377,6 +393,14 @@ def bounded(seconds: float = DEFAULT_ROUTE_DEADLINE_SECONDS, *, operation: str |
                         ),
                     },
                 ) from None
+            except asyncio.CancelledError:
+                # Reachable via graceful shutdown or an outer deadline tighter
+                # than this one -- same treatment as a timeout (#14256): signal,
+                # then re-raise. Never swallowed.
+                signal_cancel_scope(f"{name} was cancelled before its {seconds:.1f}s deadline")
+                raise
+            finally:
+                end_cancel_scope(scope)
 
         wrapper.__route_deadline_seconds__ = seconds
         return wrapper

--- a/autobot_shared/monitoring/prometheus_metrics.py
+++ b/autobot_shared/monitoring/prometheus_metrics.py
@@ -105,6 +105,8 @@ class PrometheusMetricsManager:
         self._init_circuit_breaker_metrics()
         self._init_request_metrics()
         self._init_error_metrics()
+        # Issue #14244: pooled-work cancellation visibility
+        self._init_executor_cancel_metrics()
 
         # Issue #394: Initialize domain-specific recorders
         self._workflow = WorkflowMetricsRecorder(self.registry)
@@ -250,9 +252,30 @@ class PrometheusMetricsManager:
             registry=self.registry,
         )
 
+    def _init_executor_cancel_metrics(self) -> None:
+        """Initialize pooled-work cancellation metrics (#14244).
+
+        ``asyncio.wait_for`` cancels the AWAIT, not work already running in a
+        ``ThreadPoolExecutor`` -- so a timed-out request can leave a thread
+        running with nothing externally visible; the client already has its
+        504. This counts every time a cancel token is signalled so the gap
+        between "the client got a response" and "the work actually stopped"
+        is measured instead of inferred from a hang.
+        """
+        self.executor_cancel_signalled_total = Counter(
+            "autobot_executor_cancel_signalled_total",
+            "Cancel tokens signalled for pooled analytics work that outlived its deadline",
+            ["operation"],
+            registry=self.registry,
+        )
+
     # =========================================================================
     # Core Infrastructure Metric Recording Methods
     # =========================================================================
+
+    def record_executor_cancel_signalled(self, operation: str) -> None:
+        """Record that pooled work was signalled to stop cooperatively (#14244)."""
+        self.executor_cancel_signalled_total.labels(operation=operation).inc()
 
     def record_timeout(self, operation_type: str, database: str, timed_out: bool) -> None:
         """Record a timeout event."""


### PR DESCRIPTION
Closes #14256, Closes #14244

## Thinking Path

Both issues are one root cause: `asyncio.wait_for`/`task.cancel()` stop the AWAIT, not work
already running in a `ThreadPoolExecutor` — a Python thread can't be pre-empted from outside.
#12779/#13602 already proved the fix once, for duplicate detection alone: a `threading.Event`
cancel token, created per scan, polled at loop boundaries inside the worker thread, set by
whichever side (timeout or outer cancellation) stops waiting first.

I read both issues in full, then read the code they point at rather than trusting the issue
bodies' file list at face value:

- `utils/error_boundaries/decorators.py` — confirmed `bounded()` (#14015) already exists on
  `Dev_new_gui` and does exactly what the issues describe: `asyncio.wait_for` around the handler,
  504 on expiry, nothing that touches work the handler dispatched to a pool.
- `duplicate_detector.py` / `endpoints/duplicates.py` — confirmed the existing, tested
  `threading.Event` cancel-token shape (#12779/#13602), including its `_run_standard_analysis`
  single-flight-lock-plus-cancel-token dance.
- `api_endpoint_scanner.py` — `APIEndpointChecker.run_full_analysis()` is **one synchronous call**
  (`scan_all_endpoints()` then `scan_all_calls()`) submitted whole to a pool
  (`report.py` via the analytics executor, `api_endpoints.py` via the default one), with **zero**
  cancellation of any kind. This is the exact #12779 shape, unfixed, and directly named in both
  issue bodies.
- `report.py`'s `_get_pattern_analysis` / `_get_cross_language_analysis`, and
  `cross_language_patterns/detector.py`'s `_extract_language_patterns`, dispatch **one
  `asyncio.to_thread`/`run_in_executor` call per file**, awaited individually inside a loop that
  already yields to asyncio between files. Cancelling the outer coroutine there stops the *next*
  file's submission natively — asyncio's own `run_in_executor` future, when not-yet-started,
  cancels cleanly. The leak these already have is bounded to at most one in-flight file, not a
  whole-tree walk. I judged wiring a `cancel_token` through these lower-value than the report
  claims and left them alone, documented below.
- `call_graph.py`'s `_analyze_python_files` — reads files via `aiofiles` and calls `ast.parse` in
  the event loop itself, not in any executor at all. No thread to abandon.
- `environment.py`'s `EnvironmentAnalyzer.analyze_codebase` — plain `async def`, no executor or
  subprocess hop anywhere in it. Native `asyncio` cancellation already covers it.
- `ownership.py`'s `OwnershipAnalyzer._get_file_ownership` — `await asyncio.to_thread(lambda:
  subprocess.run(["git", "blame", ...]))` per file. This **is** a real, distinct gap, but the
  primitive needed is `Popen.terminate()`, not a `threading.Event` check inside a Python loop —
  there's no code running that could poll a token. Filed as **#14390** rather than shoe-horned in
  here.

So the fix is: hoist the #12779 `threading.Event` shape into a small shared module
(`utils/cancel_tokens.py`), wire `bounded()` to signal every token registered during its own call
on expiry (making the deadline and the cancellation the same event per #14256's checklist), fold
`duplicates.py`'s hand-rolled version into it, and apply the mechanism to the one clean,
fully-unmitigated, "walks the whole tree in one thread" case that both issues actually name:
`APIEndpointChecker`.

## What Changed

**New: `autobot-backend/utils/cancel_tokens.py`** — the general mechanism, hoisting the
`threading.Event` shape #12779 proved:
- `new_cancel_token()` — a plain `threading.Event`, handed straight into pooled work exactly like
  `DuplicateCodeDetector` already expects (deliberately **not** a new wrapper class —
  `DuplicateCodeDetector.__init__`'s tested `cancel_token: threading.Event | None` contract stays
  unchanged).
- `begin_cancel_scope()` / `end_cancel_scope()` / `register_cancel_token()` — a `contextvars`-based
  collection point. `bounded()` opens a scope before calling the handler; any pooled call the
  handler dispatches registers its token there, with no import in either direction.
- `signal_cancel_token()` — idempotently sets a token, logs "signalled but still running", and
  records a Prometheus counter (`autobot_executor_cancel_signalled_total{operation}`) — the
  #14244 item 3 metric for "cancelled but still running".
- `signal_cancel_scope()` — signals every token in the active scope; called by `bounded()`.
- `submit_cancellable()` — the #14244 "cancellable executor submission helper": submits a
  zero-arg callable to a pool and registers its token, synchronously (no `await` between submit
  and registration, so `task.cancel()` can't land in the gap and leave a thread unaccounted for).
- `run_cancellable()` — the simple case built on `submit_cancellable()`: await the result, and on
  `TimeoutError`/`CancelledError` (never swallowed — always re-raised after signalling) set the
  token.

**`utils/error_boundaries/decorators.py` (`bounded()`)** — opens a cancel scope for the call; on
timeout or on being cancelled from outside (graceful shutdown, an outer deadline tighter than its
own), signals every token registered in that scope before the 504/`CancelledError` propagates.

**`autobot_shared/monitoring/prometheus_metrics.py`** — new
`autobot_executor_cancel_signalled_total{operation}` counter and
`record_executor_cancel_signalled()`.

**`api/codebase_analytics/endpoints/duplicates.py`** — `_run_standard_analysis`'s hand-rolled
`threading.Event()` + `run_in_executor` + timeout/cancel signalling now goes through
`submit_cancellable()`/`signal_cancel_token()`. Behaviour is unchanged (verified against the
existing `duplicate_single_flight_13602_test.py` suite, all of which passes an explicit
`threading.Event` and reads `.is_set()` — untouched contract); the token is now also registered in
`bounded()`'s scope, so an outer route deadline tighter than `DUPLICATE_DETECTION_TIMEOUT` reaches
it via the shared mechanism too, not only this function's own `except` blocks. This closes
#14256's "the single existing cancel-token path is folded into the general mechanism" AC.

**`api/codebase_analytics/api_endpoint_scanner.py`** — `BackendEndpointScanner`,
`FrontendAPICallScanner` and `APIEndpointChecker` all take an optional `cancel_token`. Both
scanners' per-file loops check it every `CANCEL_CHECK_INTERVAL` (200) files — same cadence
convention as `duplicate_detector.CANCEL_CHECK_INTERVAL`.

**`api/codebase_analytics/endpoints/report.py`** (`_get_api_endpoint_analysis`) and
**`api/codebase_analytics/endpoints/api_endpoints.py`** (`_get_or_run_analysis`,
`get_api_endpoints`, `get_frontend_api_calls`, `refresh_endpoint_cache`) — all six call sites that
dispatch `APIEndpointChecker` now create a token and submit via `run_cancellable()` instead of a
bare `run_in_analytics_executor`/`asyncio.to_thread`.

**Filed, not fixed here:** **#14390** — `ownership.py`'s per-file `git blame` subprocess needs
`Popen.terminate()` signalled the same way, not a loop-check; different primitive, separate PR.

**Explicitly left alone, with evidence:** `report.py`'s pattern/cross-language analyses,
`call_graph.py`, `environment.py` — none of them match the "one un-yielding call walking a whole
tree in a thread" shape; see Thinking Path above for the read on each.

## Verification

Static only — I did not run the suite (project policy: CI executes, I verify statically). Every
test below is a real callable/thread/executor exercised through the actual code path; none mock
out the mechanism under test.

New test files:
- `autobot-backend/utils/cancel_tokens_test.py` — scope isolation/nesting, idempotent signalling,
  the Prometheus counter, and `TestRunCancellable::test_the_executor_slot_is_actually_freed`: a
  **real** `ThreadPoolExecutor(max_workers=1)` proves the worker is still occupied immediately
  after the caller's `asyncio.TimeoutError`, then polls until occupancy returns to baseline once
  the thread notices the (now-signalled) token — the AC's "asserted, not assumed" / "assertion on
  worker occupancy, not on response codes".
- `autobot-backend/utils/error_boundaries/bounded_cancel_scope_14256_test.py` — `bounded()`
  signals on timeout and on outer cancellation, does **not** signal on success (negative case),
  isolates concurrent unrelated routes from cross-signalling each other, and reaches a token
  registered via bare `submit_cancellable()` with no `except CancelledError` of its own — the
  defense-in-depth case that's the actual reason the ambient scope exists rather than relying on
  every call site's own diligence.
- `autobot-backend/api/codebase_analytics/api_endpoint_scanner_cancellation_14256_test.py` — a
  pre-set token stops both scanners before any file is read; a token set mid-scan (after file 5 of
  `CANCEL_CHECK_INTERVAL * 3`) stops the loop at the *next* checkpoint, not at the end — proving
  the check is periodic, not only-at-the-top; `APIEndpointChecker` threads one token into both
  scanners; a pre-set token makes `run_full_analysis()` return an honest empty result instead of
  scanning anyway.

### Mutation table (statically traced, not executed)

| Mutation | Test(s) that go red |
|---|---|
| `bounded()`: drop `signal_cancel_scope(...)` in the `except TimeoutError` branch | `bounded_cancel_scope_14256_test.py::TestBoundedSignalsOnTimeout::test_a_token_registered_by_the_handler_is_signalled_on_expiry`, `::test_run_cancellable_registered_work_is_reachable_from_bounded`, `::test_a_call_site_with_no_cancelled_error_handling_of_its_own_is_still_reached` |
| `bounded()`: drop the `except asyncio.CancelledError` branch entirely | `TestBoundedSignalsOnOuterCancellation::test_a_cancellation_reaching_bounded_before_its_own_deadline_still_signals` |
| `register_cancel_token()`: made a permanent no-op | `cancel_tokens_test.py::TestCancelScope::test_register_inside_a_scope_is_collected`; transitively every `TestBoundedSignals*` test |
| `signal_cancel_token()`: drop the `if token.is_set(): return` idempotency guard | `cancel_tokens_test.py::TestSignalCancelToken::test_is_idempotent` |
| `record_executor_cancel_signalled()`: made a no-op | `cancel_tokens_test.py::TestSignalCancelToken::test_records_the_prometheus_metric` |
| `run_cancellable()`: drop the `except asyncio.TimeoutError` signalling | `cancel_tokens_test.py::TestRunCancellable::test_timeout_signals_the_token_and_raises_timeout_error`, `::test_the_executor_slot_is_actually_freed` (worker occupancy never returns to baseline within the 3s poll budget) |
| `run_cancellable()`: drop the `except asyncio.CancelledError` signalling | `cancel_tokens_test.py::TestRunCancellable::test_outer_cancellation_signals_the_token_and_reraises` |
| `BackendEndpointScanner.scan_all_endpoints`: drop the periodic cancel check | `api_endpoint_scanner_cancellation_14256_test.py::TestBackendScannerCooperativeCancellation::test_pre_set_token_stops_the_scan_before_any_file`, `::test_the_check_is_periodic_not_only_at_the_top` |
| `FrontendAPICallScanner.scan_all_calls`: drop the periodic cancel check | `TestFrontendScannerCooperativeCancellation::test_pre_set_token_stops_the_scan_before_any_file`, `::test_the_check_is_periodic_not_only_at_the_top` |
| `APIEndpointChecker.__init__`: stop threading `cancel_token` into the two scanners | `TestAPIEndpointCheckerThreadsTheTokenThrough::test_the_same_token_reaches_both_scanners`, `::test_a_pre_set_token_makes_run_full_analysis_return_an_empty_analysis` |
| `duplicates.py._run_standard_analysis`: revert the `CancelledError` branch to bare `cancel_token.set()` with no scope registration | Existing `duplicate_single_flight_13602_test.py::TestCancellationIsNotATimeout::test_an_outer_cancel_still_signals_the_orphan` still passes (behaviour preserved) — the *new* coverage for the scope registration itself is `bounded_cancel_scope_14256_test.py`, since duplicates.py's own `except` blocks already handled its two cases pre-fix |

### Negative case (verification bar)

`cancel_tokens_test.py::TestRunCancellable::test_normal_completion_does_not_signal_the_token` and
`bounded_cancel_scope_14256_test.py::TestBoundedDoesNotSignalOnSuccess` assert a request that
completes normally is never flagged as cancelled.

### Route-deadline lint

`tools/lint/check_route_deadlines.py` still reports `85 of 85 routes bounded, 0 declared
unbounded` after this change — no route lost its `@bounded` decorator.

## Model Used

Claude Opus 5 (1M context)
