### PR TITLE
fix(chat): stat-failure listing goes silent, and compaction summary composes after the reset (#14248, #14322)

### DIFF
--- a/autobot-backend/chat_history/context_overflow.py
+++ b/autobot-backend/chat_history/context_overflow.py
@@ -304,7 +304,8 @@ def _preserved_user_messages(messages: List[Dict], cap: int) -> List[str]:
     user stated once cannot be dropped by that pass; the cap is what keeps this
     unconditionally bounded.
 
-    Scoped to raw ``role == "user"`` turns, not to a *prior* compaction's own
+    Scoped to raw user-role turns (``CategoryDefaults.ROLE_USER``), not to a
+    *prior* compaction's own
     composed summary (#14322). That artifact is injected with ``sender ==
     "system"`` (``overflow_integration.create_summary_message``), so it is
     never picked up here — and it should not be: its "### User messages

--- a/autobot-backend/chat_history/context_overflow.py
+++ b/autobot-backend/chat_history/context_overflow.py
@@ -300,9 +300,20 @@ def _pick_boundary(messages: List[Dict], target: int) -> int:
 def _preserved_user_messages(messages: List[Dict], cap: int) -> List[str]:
     """The most recent *cap* user messages, verbatim (#14066).
 
-    Never summarized. A long session re-summarizes the same region repeatedly
-    and each pass is another chance for the model to drop a constraint the user
-    stated once; the cap is what keeps doing this unconditionally bounded.
+    Never summarized within the round that summarizes them, so a constraint the
+    user stated once cannot be dropped by that pass; the cap is what keeps this
+    unconditionally bounded.
+
+    Scoped to raw ``role == "user"`` turns, not to a *prior* compaction's own
+    composed summary (#14322). That artifact is injected with ``sender ==
+    "system"`` (``overflow_integration.create_summary_message``), so it is
+    never picked up here — and it should not be: its "### User messages
+    (verbatim)" block is prose to a later summarization call, not a
+    deterministic structure this function can re-extract without re-parsing
+    the model's own markdown, which is the "prose, not guarantee" failure mode
+    #14066 introduced this deterministic path to avoid. A user turn already
+    protected once and later swept — inside its parent summary — into a
+    further compaction window is not re-protected by a second pass.
     """
     if cap <= 0:
         return []
@@ -808,15 +819,23 @@ class ContextOverflowProtection:
         # response supplies an authoritative count, so they use the shared path.
         retained_tokens = [estimate_fast(_message_text(msg)) for msg in messages[split_point:]]
 
+        # #14322: composed BEFORE the reset below, same reason as
+        # retained_tokens above — every helper behind _compose_summary reads
+        # `messages_to_summarize`, the pre-reset history, so it belongs on the
+        # same side of the #14065 invariant. Composing after the reset does not
+        # raise today (each helper is isinstance-guarded and falls back on an
+        # unexpected shape), but it silently violates that invariant one call
+        # deeper: a future edit to _extract_state, _render_state_block or
+        # _preserved_user_messages that starts reading tracker-derived state
+        # would reintroduce #14065 past the caller's `except SummarizationFailed`.
+        summary_text = _compose_summary(summary, messages_to_summarize)
+
         # Reset token tracker (conversation now starts from summary)
         await self.tracker.reset_session(session_id)
         for tokens in retained_tokens:
             await self.tracker.add_message_tokens(session_id, prompt_tokens=tokens)
 
-        # #14066: the model's summary is only one of three things that cross the
-        # boundary. The extracted state and the verbatim user turns are the two
-        # that survive a bad summarization turn.
-        return _compose_summary(summary, messages_to_summarize)
+        return summary_text
 
 
 __all__ = [

--- a/autobot-backend/chat_history/context_overflow_boundary_test.py
+++ b/autobot-backend/chat_history/context_overflow_boundary_test.py
@@ -9,9 +9,14 @@ Three properties, each of which used to be absent:
 1. The cut lands on a turn boundary. ``len(messages) // 2`` is a raw index and
    can fall between an assistant message carrying ``tool_calls`` and its
    ``role="tool"`` responses, orphaning them in the kept half.
-2. User messages cross the boundary **verbatim**. They used to survive only if
-   the summarizing model chose to include them, and a long session re-summarizes
-   the same content repeatedly — each pass another chance to drop it.
+2. User messages cross the boundary **verbatim**, within the round that
+   summarizes them. They used to survive only if the summarizing model chose to
+   include them. Scope, corrected by #14322: this does NOT compound across
+   repeated compactions — once an earlier round's own composed summary is
+   itself swept into a *later* summarization window, its embedded verbatim
+   block is prose to that call, not a re-protected structure. Re-parsing a
+   prior summary's markdown to recover it would reintroduce the exact
+   "prose, not guarantee" failure this deterministic path exists to avoid.
 3. A deterministic state block crosses alongside the model's summary, so a bad
    summarization turn cannot take the file paths and exit statuses with it.
 """
@@ -20,6 +25,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+import chat_history.context_overflow as context_overflow_module
 from chat_history.context_overflow import (
     _TOOL_RESULT_CLIP_CHARS,
     ContextOverflowProtection,
@@ -280,7 +286,26 @@ class TestTheComposedSummaryCarriesAllThree:
         assert "never touch the prod database" in composed
 
     @pytest.mark.asyncio
-    async def test_two_successive_compactions_do_not_erode_the_instruction(self):
+    async def test_a_prior_rounds_summary_is_not_silently_re_protected_as_a_user_turn(self):
+        """#14322: the multi-round guarantee is scoped to raw user turns, not to
+        a previously-injected summary artifact re-entering a later window.
+
+        The original version of this test fed round 1's composed summary back
+        as ``{"role": "user", "content": first}`` — a shape production never
+        writes. Under that fake role, ``_preserved_user_messages`` mistook the
+        entire round-1 summary blob for a user instruction and re-protected it
+        wholesale, passing for the wrong reason.
+
+        Production injects a round's summary via
+        ``overflow_integration.create_summary_message``, as ``{"sender":
+        "system", "messageType": "context_summary", "text": ...}``. ``_role_of``
+        reads ``role or sender``, so that artifact's role is ``"system"`` —
+        excluded from ``_preserved_user_messages``, which rescues only
+        ``role == "user"``. This test drives the real shape and pins the
+        CURRENT, documented scope: verbatim protection holds for the round that
+        summarizes a user turn directly; it does not compound when that turn is
+        only reachable through an earlier round's own summary.
+        """
         history = [
             {"role": "user", "content": "never touch the prod database"},
             {"role": "assistant", "content": "understood"},
@@ -288,10 +313,23 @@ class TestTheComposedSummaryCarriesAllThree:
             {"role": "assistant", "content": "added"},
         ]
         first = await self._compact(history)
-        # The composed summary becomes a message in the next round's history.
-        second_round = [{"role": "user", "content": first}] + history
+        assert "never touch the prod database" in first, "single-round guarantee must still hold"
+
+        # The shape overflow_integration.create_summary_message actually
+        # writes — not a bare chat turn.
+        injected_summary = {
+            "sender": "system",
+            "text": first,
+            "messageType": "context_summary",
+        }
+        second_round = [injected_summary] + history
         second = await self._compact(second_round)
-        assert "never touch the prod database" in second
+
+        assert "never touch the prod database" not in second, (
+            "a prior summary's verbatim block was re-protected without a real "
+            "cross-round mechanism — update this test if #14322's follow-up "
+            "adds one, don't just relax the assertion"
+        )
 
     @pytest.mark.asyncio
     async def test_an_empty_history_still_returns_empty(self):
@@ -341,6 +379,57 @@ class TestTheComposedSummaryCarriesAllThree:
                 assert in_batch, f"compaction left an orphaned tool message in the kept half: {kept!r}"
                 continue
             in_batch = msg["role"] == "assistant" and bool(msg.get("tool_calls"))
+
+
+class TestCompositionRunsBeforeTheReset:
+    """#14322: the composed summary must be built from the pre-reset state.
+
+    ``_create_summary`` computes ``retained_tokens`` before ``reset_session``
+    with a comment citing #14065: the tracker must not reset while the history
+    it claims to have compressed is still uncompressed. ``_compose_summary``
+    reads that same pre-reset ``messages_to_summarize`` list, so it belongs on
+    the same side of the reset — the fix moves it there.
+
+    ``_compose_summary`` cannot raise today: every helper behind it
+    (``_extract_state``, ``_render_state_block``, ``_preserved_user_messages``)
+    is isinstance-guarded and falls back on an unexpected shape. So an ordering
+    regression would NOT show up as a different composed string under the
+    mocked summarizer used elsewhere in this file — it has to be caught by
+    observing the actual call order through the real ``_create_summary`` path,
+    which is what this test does. It does not call ``_compose_summary``
+    directly with an invented shape.
+    """
+
+    @pytest.mark.asyncio
+    async def test_compose_summary_is_called_before_reset_session(self, monkeypatch):
+        call_order: list = []
+
+        protection = ContextOverflowProtection()
+        protection.summarizer.summarize_messages = AsyncMock(return_value="S")
+        protection.tracker.reset_session = AsyncMock(side_effect=lambda session_id: call_order.append("reset"))
+        protection.tracker.add_message_tokens = AsyncMock()
+
+        real_compose_summary = context_overflow_module._compose_summary
+
+        def recording_compose_summary(summary, summarized):
+            call_order.append("compose")
+            return real_compose_summary(summary, summarized)
+
+        monkeypatch.setattr(context_overflow_module, "_compose_summary", recording_compose_summary)
+
+        history = [
+            {"role": "user", "content": "never touch the prod database"},
+            {"role": "assistant", "content": "understood"},
+            {"role": "user", "content": "add the endpoint"},
+            {"role": "assistant", "content": "added"},
+        ]
+        summary_text = await protection._create_summary("session-1", history, "gpt-4")
+
+        assert call_order == ["compose", "reset"], f"expected compose before reset, got {call_order}"
+        # The returned summary must be the one composed pre-reset, not a stale
+        # or empty value picked up after — this is the observable outcome an
+        # operator actually sees.
+        assert "never touch the prod database" in summary_text
 
 
 class TestCompactedViewIsSmallerThanWhatItReplaced:

--- a/autobot-backend/chat_history/session_listing.py
+++ b/autobot-backend/chat_history/session_listing.py
@@ -206,7 +206,19 @@ class SessionListingMixin:
                 "fast_mode": True,
             }
         except Exception as e:
-            logger.error("Error reading file stats for %s: %s", filename, str(e))
+            # #14248: loud and excluded, matching the malformed-timestamp precedent
+            # in skill_distillation_scheduler.py — the session id is named
+            # explicitly (not just the filename) so this is grep-able, and the
+            # wording deliberately differs from "Chat session %s not found" (used
+            # when no file exists at all) so an operator can tell "unreadable"
+            # from "never existed" at a glance.
+            logger.error(
+                "Chat session %s exists (%s) but its file stats could not be read — "
+                "excluded from this listing pass: %s",
+                chat_id,
+                filename,
+                e,
+            )
             return None
 
     async def list_sessions_fast(self) -> List[Dict[str, Any]]:

--- a/autobot-backend/chat_history/session_listing_stat_failure_test.py
+++ b/autobot-backend/chat_history/session_listing_stat_failure_test.py
@@ -86,9 +86,9 @@ class TestStatFailureIsVisible:
         # fixed affix), so a looser "id in message" check would still pass
         # against the pre-fix message ("Error reading file stats for
         # <filename>: ...") and catch nothing.
-        assert any(f"session {bad_id} " in r.getMessage() for r in error_records), (
-            "log record does not name the failing session id in a 'session <id>' position"
-        )
+        assert any(
+            f"session {bad_id} " in r.getMessage() for r in error_records
+        ), "log record does not name the failing session id in a 'session <id>' position"
 
     @pytest.mark.asyncio
     async def test_unreadable_session_wording_differs_from_not_found(self, manager, tmp_path, monkeypatch, caplog):

--- a/autobot-backend/chat_history/session_listing_stat_failure_test.py
+++ b/autobot-backend/chat_history/session_listing_stat_failure_test.py
@@ -1,0 +1,136 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Unit tests for #14248 — a session whose ``os.stat`` fails must not vanish from
+``list_sessions_fast`` without a trace.
+
+Before the fix, ``_build_session_entry`` caught the stat failure, logged a
+generic ``"Error reading file stats for %s: %s"`` keyed on the *filename*, and
+returned ``None`` — which the caller silently dropped from the sessions list.
+An operator reading the log could not tell "this conversation is unreadable"
+from "no such conversation ever existed", and skill distillation (which reads
+``list_sessions_fast`` for its pending set) never saw the session at all, so it
+was never reported as skipped.
+
+These tests drive the real listing path (a real ``SessionListingMixin`` over
+real files on disk, with ``os.stat`` failing for exactly one of them) rather
+than stubbing ``_build_session_entry`` or the lister — the defect was in the
+composition of the real path, and a stubbed lister would hide it.
+"""
+
+import json
+import logging
+import os
+
+import pytest
+
+from chat_history.session_listing import SessionListingMixin
+
+
+class _StubManager(SessionListingMixin):
+    """Minimal manager exercising the real listing path on real disk."""
+
+    def __init__(self, chats_directory: str):
+        self._chats_directory = chats_directory
+
+    def _get_chats_directory(self) -> str:
+        return self._chats_directory
+
+
+def _write_chat_file(tmp_path, chat_id: str) -> str:
+    chat_path = tmp_path / f"{chat_id}_chat.json"
+    chat_path.write_text(
+        json.dumps({"name": f"Chat {chat_id}", "messages": []}),
+        encoding="utf-8",
+    )
+    return str(chat_path)
+
+
+@pytest.fixture()
+def manager(tmp_path):
+    return _StubManager(str(tmp_path))
+
+
+class TestStatFailureIsVisible:
+    """A stat failure must be logged and distinguishable from "does not exist" (#14248)."""
+
+    @pytest.mark.asyncio
+    async def test_unreadable_session_is_logged_with_its_id(self, manager, tmp_path, monkeypatch, caplog):
+        good_id = "sess-good"
+        bad_id = "sess-bad-stat"
+        _write_chat_file(tmp_path, good_id)
+        bad_path = _write_chat_file(tmp_path, bad_id)
+
+        real_stat = os.stat
+
+        def flaky_stat(path, *args, **kwargs):
+            if os.fspath(path) == bad_path:
+                raise PermissionError(f"simulated stat failure for {path}")
+            return real_stat(path, *args, **kwargs)
+
+        monkeypatch.setattr(os, "stat", flaky_stat)
+
+        with caplog.at_level(logging.ERROR, logger="chat_history.session_listing"):
+            sessions = await manager.list_sessions_fast()
+
+        session_ids = {s["id"] for s in sessions}
+        assert good_id in session_ids
+
+        error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert error_records, "stat failure produced no log record — silent drop reproduced"
+        # Requires the session id in a "session <id>" position, not merely as a
+        # filename substring — chat_id is always a substring of its own
+        # filename by construction (_extract_chat_id_from_filename strips a
+        # fixed affix), so a looser "id in message" check would still pass
+        # against the pre-fix message ("Error reading file stats for
+        # <filename>: ...") and catch nothing.
+        assert any(f"session {bad_id} " in r.getMessage() for r in error_records), (
+            "log record does not name the failing session id in a 'session <id>' position"
+        )
+
+    @pytest.mark.asyncio
+    async def test_unreadable_session_wording_differs_from_not_found(self, manager, tmp_path, monkeypatch, caplog):
+        bad_id = "sess-bad-stat-2"
+        bad_path = _write_chat_file(tmp_path, bad_id)
+
+        real_stat = os.stat
+
+        def flaky_stat(path, *args, **kwargs):
+            if os.fspath(path) == bad_path:
+                raise OSError(f"simulated stat failure for {path}")
+            return real_stat(path, *args, **kwargs)
+
+        monkeypatch.setattr(os, "stat", flaky_stat)
+
+        with caplog.at_level(logging.ERROR, logger="chat_history.session_listing"):
+            await manager.list_sessions_fast()
+
+        [record] = [r for r in caplog.records if bad_id in r.getMessage()]
+        message = record.getMessage()
+        # "not found" is the phrasing used elsewhere in chat_history for a
+        # session that never existed (see session.py). A stat failure on a
+        # file that IS present must not read the same way.
+        assert "not found" not in message.lower()
+        assert "exists" in message.lower()
+
+    @pytest.mark.asyncio
+    async def test_stat_failure_still_excludes_from_this_pass(self, manager, tmp_path, monkeypatch):
+        """Matches the malformed-timestamp precedent: loud, then excluded — not
+        silently kept with garbage data, and not silently dropped."""
+        bad_id = "sess-bad-stat-3"
+        bad_path = _write_chat_file(tmp_path, bad_id)
+
+        real_stat = os.stat
+
+        def flaky_stat(path, *args, **kwargs):
+            if os.fspath(path) == bad_path:
+                raise OSError("simulated stat failure")
+            return real_stat(path, *args, **kwargs)
+
+        monkeypatch.setattr(os, "stat", flaky_stat)
+
+        sessions = await manager.list_sessions_fast()
+
+        assert bad_id not in {s["id"] for s in sessions}


### PR DESCRIPTION
Closes #14248, #14322

## Thinking Path

Both issues are the same failure mode on the chat session path: an ordering or
error-handling defect where nothing raises and nothing logs, so a caller sees
wrong or missing data instead of a visible failure.

**#14248** — `SessionListingMixin._build_session_entry` (`chat_history/session_listing.py`)
already caught an `os.stat` failure and logged it, but the message was keyed on
the *filename* ("Error reading file stats for %s: %s") and read no differently
from any other I/O error. It did not name the session id in a way an operator
(or a log-scraping alert) could grep for, and it did not distinguish "this
conversation exists but is unreadable" from "Chat session %s not found" — the
wording used elsewhere in `chat_history` for a session that never existed.
Because the entry is dropped either way, distillation's `_select_pending_sessions`
never even sees a `session_id` for it, so it can't emit its own "no usable
timestamp" style warning (`skill_distillation_scheduler.py:578-583`) — the
listing layer is the only place this failure is observable at all, and it read
the same as routine noise.

**#14322** — `ContextOverflowProtection._create_summary` computed `retained_tokens`
*before* `reset_session`, with a comment citing #14065 that the tracker must not
reset while the history it claims to have compressed is still uncompressed —
but `_compose_summary` (and through it `_extract_state`, `_render_state_block`,
`_preserved_user_messages`) ran *after* that reset, on the wrong side of the
invariant the comment states one statement above it. It doesn't raise today
because every helper is `isinstance`-guarded and falls back on an unexpected
shape, which is exactly why it needed an issue instead of a runtime crash: the
next edit to any of those three helpers that starts reading tracker state would
reintroduce #14065 one call deeper, past the caller's `except SummarizationFailed`.

The issue also flagged that PR #14249's multi-round idempotency test fed round
1's composed summary back into round 2 as `{"role": "user", "content": first}` —
a shape production never writes. `overflow_integration.create_summary_message`
actually injects `{"sender": "system", "messageType": "context_summary", ...}`,
and `_role_of` reads `role or sender`, so the real artifact's role is `"system"`.
Under the fake `"user"` role, `_preserved_user_messages` mistook the *entire*
round-1 summary blob for a user instruction and re-protected it wholesale — the
test passed for the wrong reason. Traced through the real shape: the guarantee
does not survive round 2. The issue offered two ways out — teach extraction to
recognise a prior summary's verbatim block, or scope the docstring claim to a
single round. Recognising a prior summary's rendered markdown block would mean
parsing prose back into structured data, which is precisely the "prose, not
guarantee" failure mode #14066 built the deterministic extraction path to
avoid, one layer removed. I scoped the claim instead, and turned the test into
a guard that pins the corrected scope so it can't quietly regress back to
"believed to work across every round."

## What Changed

`autobot-backend/chat_history/session_listing.py`
- `_build_session_entry`'s stat-failure log now names the session id explicitly
  and reads "Chat session %s exists (%s) but its file stats could not be read
  — excluded from this listing pass: %s" — grep-able by id, and worded so it
  cannot be confused with "not found".

`autobot-backend/chat_history/session_listing_stat_failure_test.py` (new)
- Drives the real `list_sessions_fast()` path over real files on disk, with
  `os.stat` monkeypatched to fail for exactly one of them (not a stubbed
  lister). Asserts: the healthy session still lists; the failure produces a
  logged error naming the session id in a `"session <id> "` position (not
  merely as an incidental filename substring); the wording differs from "not
  found"; the failing session is still excluded from that pass (matching the
  malformed-timestamp precedent — loud, then excluded, never silent).

`autobot-backend/chat_history/context_overflow.py`
- `_create_summary`: `_compose_summary(...)` now runs before
  `self.tracker.reset_session(...)`, on the same side of the #14065 invariant
  as `retained_tokens`.
- `_preserved_user_messages` docstring corrected: the verbatim guarantee is
  scoped to raw `role == "user"` turns within the round that summarizes them,
  not to a prior round's own composed summary swept into a later window.

`autobot-backend/chat_history/context_overflow_boundary_test.py`
- New `TestCompositionRunsBeforeTheReset`: patches the module-level
  `_compose_summary` to record call order against a `reset_session` `AsyncMock`,
  drives the real `_create_summary` path, and asserts `compose` precedes
  `reset`. `_compose_summary` can't raise today, so an ordering regression
  would not show up as a different composed string under this suite's mocked
  summarizer — only the call order proves it.
- `test_two_successive_compactions_do_not_erode_the_instruction` replaced with
  `test_a_prior_rounds_summary_is_not_silently_re_protected_as_a_user_turn`,
  which feeds round 2 the real `{"sender": "system", "messageType":
  "context_summary", ...}` shape and asserts the single-round guarantee holds
  while the cross-round one explicitly does not, with a comment steering a
  future author toward a real fix rather than relaxing the assertion.
- Module docstring's item 2 corrected to state the scope explicitly.

## Verification

Static only — per instructions, application code and the test suite were not
executed; CI runs pytest. Verified by:
- `python3 -m py_compile` on all four touched files — clean.
- Manual line-by-line trace of `_pick_boundary`, `_role_of`,
  `_preserved_user_messages` and `_compose_summary` against each new test's
  fixture to confirm the asserted outcome (documented inline in the tests
  themselves).
- No lines over the project's 120-char limit; import ordering follows the
  `profile = "black"` / straight-imports-before-from-imports convention already
  used in this file.

**Mutations — statically traced, not executed** (no test run per instructions):
- #14248: reverting the log message to
  `"Error reading file stats for %s: %s", filename, str(e)` removes the
  `"session <id> "` phrase and the word "exists" — both
  `test_unreadable_session_is_logged_with_its_id` and
  `test_unreadable_session_wording_differs_from_not_found` go red. (A looser
  "id is a substring of the message" check would NOT catch this — `chat_id` is
  always a substring of its own filename by construction — which is why the
  first test asserts the id in a `"session <id> "` position instead.)
- #14322 ordering: swapping `summary_text = _compose_summary(...)` back to
  below `await self.tracker.reset_session(...)` flips
  `TestCompositionRunsBeforeTheReset`'s recorded `call_order` to
  `["reset", "compose"]`, red against the asserted `["compose", "reset"]`.
- #14322 test-shape: reverting
  `test_a_prior_rounds_summary_is_not_silently_re_protected_as_a_user_turn`'s
  `injected_summary` back to `{"role": "user", "content": first}` makes
  `_role_of` return `"user"`, so `_preserved_user_messages` re-protects the
  entire round-1 blob (which contains "never touch the prod database" as
  quoted text) and the `assert ... not in second` goes red — reproducing the
  original mis-passing test.

## Model Used

Claude Sonnet 5
