### PR TITLE
fix(analytics): kill the git blame child when the ownership request is cancelled (#14390)

### DIFF
--- a/autobot-backend/api/codebase_analytics/endpoints/ownership_scoping_13602_test.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/ownership_scoping_13602_test.py
@@ -178,31 +178,63 @@ class TestOwnershipAnalyzerIsBounded:
     @pytest.mark.asyncio
     async def test_blame_does_not_run_on_the_event_loop(self, monkeypatch, tmp_path):
         """A sync subprocess inside `async def` blocks every other request for
-        its full duration — up to 30s, once per file."""
+        its full duration — up to 30s, once per file.
+
+        Asserted on **loop responsiveness**, not on a thread hop (#14390).
+
+        The original version patched `subprocess.run` and checked it executed on
+        a non-loop thread. That proved `asyncio.to_thread` was in use, which was
+        the #13602 fix — but it pinned the *mechanism*, so replacing that
+        mechanism broke the test even though the guarantee got stronger.
+        `asyncio.create_subprocess_exec` cannot block the loop by construction.
+
+        This version asserts the property itself: while a blame is in flight,
+        other coroutines still get scheduled. That holds for a thread hop, for a
+        native asyncio subprocess, and for whatever replaces them next.
+        """
         import asyncio
 
         import code_analysis.src.ownership_analyzer as oa
 
-        ran_in_thread: dict[str, bool] = {}
-        loop_thread = __import__("threading").current_thread().ident
+        blame_started = asyncio.Event()
+        release_blame = asyncio.Event()
 
-        def _fake_run(*_args, **_kwargs):
-            ran_in_thread["off_loop"] = __import__("threading").current_thread().ident != loop_thread
+        class _StalledProc:
+            returncode = 1
 
-            class _R:
-                returncode = 1
-                stdout = ""
+            async def communicate(self):
+                blame_started.set()
+                await release_blame.wait()
+                return (b"", b"")
 
-            return _R()
+            def kill(self):  # pragma: no cover - not reached in this test
+                self.returncode = -9
 
-        monkeypatch.setattr(oa.subprocess, "run", _fake_run)
+            async def wait(self):  # pragma: no cover - not reached in this test
+                return self.returncode
+
+        async def _fake_exec(*_args, **_kwargs):
+            return _StalledProc()
+
+        monkeypatch.setattr(oa.asyncio, "create_subprocess_exec", _fake_exec)
         analyzer = oa.OwnershipAnalyzer.__new__(oa.OwnershipAnalyzer)
         target = tmp_path / "a.py"
         target.write_text("x = 1\n", encoding="utf-8")
 
-        await asyncio.wait_for(analyzer._get_file_ownership(target, tmp_path), timeout=10)
+        blame = asyncio.ensure_future(analyzer._get_file_ownership(target, tmp_path))
+        await asyncio.wait_for(blame_started.wait(), timeout=5)
 
-        assert ran_in_thread.get("off_loop"), "git blame must not run on the event loop"
+        # The loop must still be servicing other work while the blame is open.
+        ticks = 0
+        for _ in range(5):
+            await asyncio.sleep(0)
+            ticks += 1
+
+        assert ticks == 5, "the event loop stopped scheduling while a blame was in flight"
+        assert not blame.done(), "the blame should still be open — otherwise this proves nothing"
+
+        release_blame.set()
+        await asyncio.wait_for(blame, timeout=10)
 
     @pytest.mark.asyncio
     async def test_the_file_cap_actually_stops_the_walk(self, monkeypatch, tmp_path):

--- a/autobot-backend/code_analysis/src/ownership_analyzer.py
+++ b/autobot-backend/code_analysis/src/ownership_analyzer.py
@@ -14,7 +14,6 @@ Analyzes codebase for:
 
 import asyncio
 import json
-import subprocess
 import sys
 import time
 from collections import defaultdict
@@ -394,6 +393,60 @@ class OwnershipAnalyzer:
         contributors.sort(key=lambda x: x.lines_count, reverse=True)
         return contributors
 
+    @staticmethod
+    async def _run_blame(file_path: Path, root: Path) -> str | None:
+        """``git blame`` for one file, killed if this coroutine is cancelled (#14390).
+
+        Returns the porcelain stdout, or ``None`` when the blame failed or timed
+        out — the two outcomes the caller already treats as "no ownership data".
+
+        Both non-normal exits terminate the child explicitly:
+
+        * **timeout** — the per-file ceiling that keeps one slow file from eating
+          the whole phase budget (``_MAX_BLAME_SECONDS``);
+        * **cancellation** — the route deadline firing, or an outer
+          ``task.cancel()``. ``CancelledError`` is re-raised after the kill:
+          swallowing it would report the request as completed while the work was
+          abandoned, and every caller above would lose the signal.
+
+        ``proc.wait()`` after ``kill()`` is not optional — it reaps the child.
+        Without it the process becomes a zombie held by this event loop, which
+        is the leak in a slower disguise.
+        """
+        proc = await asyncio.create_subprocess_exec(  # nosec B603 B607  # fixed git argv, no shell
+            "git",
+            "blame",
+            "--line-porcelain",
+            str(file_path),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+            cwd=str(root),
+        )
+        try:
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=_BLAME_TIMEOUT_SECONDS)
+        except asyncio.TimeoutError:
+            await OwnershipAnalyzer._terminate(proc)
+            logger.warning("Git blame timed out for %s", file_path)
+            return None
+        except asyncio.CancelledError:
+            await OwnershipAnalyzer._terminate(proc)
+            raise
+
+        if proc.returncode != 0:
+            return None
+        return stdout.decode("utf-8", errors="replace")
+
+    @staticmethod
+    async def _terminate(proc: "asyncio.subprocess.Process") -> None:
+        """Kill a blame child and reap it, tolerating one that already exited."""
+        if proc.returncode is not None:
+            return
+        try:
+            proc.kill()
+        except ProcessLookupError:
+            return
+        await proc.wait()
+
     async def _get_file_ownership(self, file_path: Path, root: Path) -> FileOwnership | None:
         """Get ownership data for a single file using git blame"""
         try:
@@ -403,21 +456,24 @@ class OwnershipAnalyzer:
             # blame blocked the event loop for its full duration — up to the 30s
             # timeout, once per file. That is what made unrelated endpoints
             # return 000 while an analytics panel was loading.
-            result = await asyncio.to_thread(
-                lambda: subprocess.run(  # nosec B603 B607  # fixed git argv; file_path is a Path object, no shell
-                    ["git", "blame", "--line-porcelain", str(file_path)],
-                    capture_output=True,
-                    text=True,
-                    cwd=str(root),
-                    timeout=_BLAME_TIMEOUT_SECONDS,
-                )
-            )
-
-            if result.returncode != 0:
+            #
+            # #14390: and then it was `asyncio.to_thread(subprocess.run(...))`,
+            # which unblocks the loop but is still not cancellable. Cancelling
+            # that await abandons the worker thread; the `git blame` child keeps
+            # running until it exits on its own, because nothing holds a handle
+            # to signal. #14256's cooperative token cannot help — it polls a
+            # Python loop, and there is no loop here, only a blocked syscall.
+            #
+            # A native asyncio subprocess is the mechanism that fits: it gives
+            # up the thread hop AND a real handle to kill. See the two
+            # terminating handlers below — without them the child outlives the
+            # request either way.
+            stdout_text = await self._run_blame(file_path, root)
+            if stdout_text is None:
                 return None
 
             # Issue #1183: Delegate parsing and contributor building to helpers
-            total_lines, author_lines = self._parse_blame_output(result.stdout)
+            total_lines, author_lines = self._parse_blame_output(stdout_text)
 
             if total_lines == 0:
                 return None
@@ -449,9 +505,15 @@ class OwnershipAnalyzer:
                 last_modified=last_modified,
             )
 
-        except subprocess.TimeoutExpired:
-            logger.warning(f"Git blame timed out for {file_path}")
-            return None
+        # #14390: the `subprocess.TimeoutExpired` handler that sat here is gone
+        # with the blocking call that raised it — `_run_blame` owns the timeout
+        # now and logs the same message before returning None. A handler for an
+        # exception the body can no longer raise reads as live coverage.
+        #
+        # `CancelledError` is deliberately NOT caught here: it derives from
+        # BaseException, so `except Exception` never saw it, and `_run_blame`
+        # re-raises it after killing the child. Catching it would turn an
+        # abandoned request into a silently empty result.
         except Exception as e:
             logger.warning(f"Failed to analyze {file_path}: {e}")
             return None

--- a/autobot-backend/code_analysis/src/ownership_blame_cancellation_test.py
+++ b/autobot-backend/code_analysis/src/ownership_blame_cancellation_test.py
@@ -1,0 +1,167 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""A cancelled ownership request must not leave `git blame` running (#14390).
+
+The failure this pins is invisible from the caller's side. `asyncio.to_thread`
+around a blocking `subprocess.run` unblocks the event loop, so the symptom
+#13602 fixed stays fixed — but cancelling that await abandons the worker thread
+while the child process keeps running. Nothing errors. The request returns. The
+process is simply still there, holding a `git blame` on a large file until it
+finishes on its own.
+
+So these tests assert on **the child**, not on the coroutine:
+
+* the process object reaches a terminated state after cancellation;
+* `CancelledError` still propagates (swallowing it would report an abandoned
+  request as a completed one);
+* the child is reaped, not left as a zombie.
+
+`_run_blame` is driven directly rather than through `_analyze_file_ownership`,
+because the per-file loop would need a real repository and hundreds of blames to
+reach the same seam — and the seam is what is under test.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_MODULE_PATH = Path(__file__).with_name("ownership_analyzer.py")
+
+
+def _load_analyzer():
+    """Load the analyzer without importing the `code_analysis` package.
+
+    Registered in sys.modules before exec_module and popped after: the module
+    declares dataclasses, and `dataclasses._is_type` resolves names through
+    `sys.modules[cls.__module__]` when annotations are strings. A module
+    executed out-of-band is absent from that table, and class creation dies on
+    `'NoneType' object has no attribute '__dict__'` (#14194 hit exactly this).
+    """
+    name = "_ownership_analyzer_isolated_14390"
+    spec = importlib.util.spec_from_file_location(name, _MODULE_PATH)
+    if spec is None or spec.loader is None:  # pragma: no cover - path is fixed
+        raise ImportError(f"could not load {_MODULE_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.modules.pop(name, None)
+    return module
+
+
+@pytest.fixture(scope="module")
+def analyzer_module():
+    return _load_analyzer()
+
+
+class _FakeProc:
+    """An asyncio subprocess that never finishes until it is killed."""
+
+    def __init__(self) -> None:
+        self.returncode: int | None = None
+        self.kill_calls = 0
+        self.wait_calls = 0
+
+    async def communicate(self):
+        await asyncio.Event().wait()  # never completes on its own
+        raise AssertionError("unreachable")
+
+    def kill(self) -> None:
+        self.kill_calls += 1
+        self.returncode = -9
+
+    async def wait(self) -> int:
+        self.wait_calls += 1
+        return self.returncode if self.returncode is not None else 0
+
+
+async def _drive_until_started(module, proc, monkeypatch):
+    """Start `_run_blame` against *proc* and yield once it is awaiting output."""
+
+    async def _fake_exec(*_args, **_kwargs):
+        return proc
+
+    monkeypatch.setattr(module.asyncio, "create_subprocess_exec", _fake_exec)
+    task = asyncio.ensure_future(module.OwnershipAnalyzer._run_blame(Path("f.py"), Path(".")))
+    await asyncio.sleep(0)  # let the coroutine reach `communicate()`
+    await asyncio.sleep(0)
+    return task
+
+
+@pytest.mark.asyncio
+async def test_cancelling_the_blame_kills_the_child(analyzer_module, monkeypatch):
+    """The regression: the caller's cancellation must reach the process."""
+    proc = _FakeProc()
+    task = await _drive_until_started(analyzer_module, proc, monkeypatch)
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert proc.kill_calls == 1, "the git blame child was never killed — it outlives the request"
+
+
+@pytest.mark.asyncio
+async def test_the_killed_child_is_reaped(analyzer_module, monkeypatch):
+    """kill() alone leaves a zombie held by this event loop."""
+    proc = _FakeProc()
+    task = await _drive_until_started(analyzer_module, proc, monkeypatch)
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert proc.wait_calls == 1, "kill() without wait() leaks a zombie"
+
+
+@pytest.mark.asyncio
+async def test_cancellation_still_propagates(analyzer_module, monkeypatch):
+    """Killing the child must not swallow the signal.
+
+    If `CancelledError` were absorbed, an abandoned request would be reported
+    to every caller above as a completed one with no ownership data.
+    """
+    proc = _FakeProc()
+    task = await _drive_until_started(analyzer_module, proc, monkeypatch)
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+@pytest.mark.asyncio
+async def test_a_timeout_also_kills_the_child(analyzer_module, monkeypatch):
+    """The per-file ceiling terminates too, and returns the no-data sentinel."""
+    proc = _FakeProc()
+
+    async def _fake_exec(*_args, **_kwargs):
+        return proc
+
+    monkeypatch.setattr(analyzer_module.asyncio, "create_subprocess_exec", _fake_exec)
+    monkeypatch.setattr(analyzer_module, "_BLAME_TIMEOUT_SECONDS", 0.01)
+
+    result = await analyzer_module.OwnershipAnalyzer._run_blame(Path("f.py"), Path("."))
+
+    assert result is None
+    assert proc.kill_calls == 1, "a timed-out blame must be killed, not abandoned"
+    assert proc.wait_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_an_already_exited_child_is_not_killed_twice(analyzer_module):
+    """`_terminate` must tolerate a process that finished on its own."""
+    proc = _FakeProc()
+    proc.returncode = 0
+
+    await analyzer_module.OwnershipAnalyzer._terminate(proc)
+
+    assert proc.kill_calls == 0
+    assert proc.wait_calls == 0


### PR DESCRIPTION
## Thinking Path

#14390 was carved out of #14256/#14244 during that PR's own review, deliberately rather than forced in — and the reason it was carved out is the reason it needs a different fix.

#14256 hoisted the `threading.Event` cooperative-cancellation shape into `utils.cancel_tokens`. That mechanism is **a poll inside a Python loop**. It has nothing to attach to here: `git blame` is a subprocess, and the thing that blocks is a syscall, not a loop. There is no boundary at which to check a token.

The previous state was already one fix deep. #13602 replaced a bare `subprocess.run` inside `async def` — which blocked the event loop for the full per-file timeout — with `asyncio.to_thread(subprocess.run(...))`. That fixed the symptom it targeted: unrelated endpoints stopped returning `000` while an analytics panel loaded.

But `to_thread` unblocks the loop **without** making the work cancellable. Cancelling that await abandons the worker thread; the `git blame` child keeps running until it exits on its own, because nothing holds a handle to signal it. Nothing errors. The request returns. The process is simply still there.

A native asyncio subprocess is the mechanism that actually fits: it gives up the thread hop *and* yields a real handle to kill.

## What Changed

| File | Change |
|---|---|
| `code_analysis/src/ownership_analyzer.py` | `_run_blame()` — `asyncio.create_subprocess_exec` + `wait_for`, terminating the child on **both** timeout and cancellation. `_terminate()` — kill and reap, tolerating a child that already exited. Dead `except subprocess.TimeoutExpired` and the now-unused `import subprocess` removed. |
| `code_analysis/src/ownership_blame_cancellation_test.py` | New — 5 tests asserting on the child process, not the coroutine. |

Three details that are correctness rather than style:

**`CancelledError` is re-raised after the kill, never swallowed.** It derives from `BaseException`, so the pre-existing `except Exception` never caught it — but without an explicit handler the child would be orphaned on the way out. Absorbing it would report an abandoned request to every caller above as a completed one with no ownership data.

**`proc.wait()` after `kill()` is not optional.** It reaps the child. Without it the process becomes a zombie held by this event loop — the same leak in a slower disguise.

**The dead handler was removed, not left.** `subprocess.TimeoutExpired` can no longer be raised in that body; `_run_blame` owns the timeout and logs the same message. A handler for an impossible exception reads as live coverage of a path nothing exercises.

## Verification

The failure mode is invisible from the caller's side — the request returns, nothing errors, the process is just still running. So every test asserts on **the child**:

| Test | Asserts |
|---|---|
| `test_cancelling_the_blame_kills_the_child` | `kill_calls == 1` — the regression |
| `test_the_killed_child_is_reaped` | `wait_calls == 1` — no zombie |
| `test_cancellation_still_propagates` | `CancelledError` reaches the caller |
| `test_a_timeout_also_kills_the_child` | timeout terminates too, returns the no-data sentinel |
| `test_an_already_exited_child_is_not_killed_twice` | `_terminate` tolerates a finished child |

Mechanism replayed standalone (scratch script, not repo code) — cancel → `kill=1 wait=1 propagated=True`; timeout → `result=None kill=1 wait=1`; already-exited → `kill=0 wait=0`.

**Mutation, traced against a standalone replica:** dropping the `CancelledError` handler gives `kill_calls=0`, so `test_cancelling_the_blame_kills_the_child` goes red. Stated precisely: the mutation was executed against a faithful standalone replica of the control flow, not against the repo module — this repository verifies its own code in CI rather than by running it locally.

The test loader registers the module in `sys.modules` before `exec_module` and pops it after. That is load-bearing: the module declares dataclasses, and `dataclasses._is_type` resolves names through `sys.modules[cls.__module__]` when annotations are strings, so an out-of-band module dies on `'NoneType' object has no attribute '__dict__'`. #14194 hit exactly this a few hours ago.

## Model Used

Opus 5

Closes #14390
