### PR TITLE
fix(slm): give the migration runner a way to reach a second database (#14300)

### DIFF
--- a/.github/workflows/slm-migration-gate.yml
+++ b/.github/workflows/slm-migration-gate.yml
@@ -86,6 +86,16 @@ jobs:
         # longer load-bearing — kept because inventory_builder is the one
         # listed module a migration test could plausibly want real, and one
         # line is cheaper than discovering it is absent.
+        # bcrypt / PyJWT[crypto]: NOT a migration dependency either, but the
+        # user_management schema-bootstrap step (#14300) imports
+        # user_management.models to register every table on Base.metadata,
+        # and one of those (role.py) imports
+        # autobot_shared.user_management.models.role ->
+        # autobot_shared.auth.permissions. Importing any submodule of
+        # autobot_shared.auth runs autobot_shared/auth/__init__.py, which
+        # eagerly imports jwt_core (bcrypt + PyJWT) regardless of which
+        # submodule was actually requested. Same versions as
+        # autobot-slm-backend/requirements.txt.
         run: |
           python -m pip install --upgrade pip
           python -m pip install \
@@ -93,6 +103,7 @@ jobs:
             "sqlalchemy>=2.0.51" \
             pydantic pydantic-settings \
             pyyaml \
+            "bcrypt>=5.0.0" "PyJWT[crypto]>=2.13.0" \
             pytest "pytest-asyncio>=0.24"
 
       - name: Create slm and slm_users databases

--- a/.github/workflows/slm-migration-gate.yml
+++ b/.github/workflows/slm-migration-gate.yml
@@ -145,9 +145,73 @@ jobs:
           print(f"Created {len(slm_models_database.Base.metadata.tables)} SLM table(s) (matches production create_all)")
           PY
 
+      # SLM_POSTGRES_* below are the discrete-component fallback
+      # user_management/config.py::get_slm_db_config() already reads when
+      # SLM_USERS_DATABASE_URL itself isn't set -- same mechanism, so this
+      # step exercises exactly the code path production falls back to,
+      # rather than a connection-string literal invented for the gate.
+      - name: Create user_management schema in slm_users (matches production's create_all)
+        # #14300: main.py's lifespan calls _init_user_management_tables()
+        # BEFORE _run_migrations() — user_management's Base.metadata
+        # (role_permissions, audit_logs, users, ...) already exists in the
+        # SEPARATE slm_users database by the time the real runner starts.
+        # This step replicates that with the same model layer production
+        # uses (user_management/models) and the same config source
+        # (user_management.config.get_slm_db_config) that
+        # migrations.runner.get_user_management_db_url() now resolves
+        # TARGET_DB_USER_MANAGEMENT migrations against
+        # (add_role_permission_audit_log_timestamps is the first).
+        #
+        # Imported by package name, not by file path: unlike `models` and
+        # `migrations`, `user_management` resolving under `autobot-backend/`
+        # too does not create an ambiguity the static import-smoke guard
+        # (repo_tests/test_ci_import_smoke_paths_14252.py) can be fooled by
+        # — that guard only checks a dotted path exists *somewhere* under
+        # its fixed root list, which `autobot-backend/user_management/`
+        # already satisfies, while the interpreter here (working-directory:
+        # autobot-slm-backend) resolves the real, intended package from its
+        # own cwd on sys.path regardless.
+        env:
+          SLM_POSTGRES_HOST: 127.0.0.1
+          SLM_POSTGRES_PORT: "5432"
+          SLM_POSTGRES_DB: slm_users
+          SLM_POSTGRES_USER: slmtest
+          SLM_POSTGRES_PASSWORD: slmtest
+          PYTHONPATH: ${{ github.workspace }}
+        working-directory: autobot-slm-backend
+        run: |
+          python3 - <<'PY'
+          from sqlalchemy import create_engine
+
+          import user_management.models as um_models
+          from user_management.config import get_slm_db_config
+
+          engine = create_engine(get_slm_db_config().sync_url)
+          try:
+              um_models.Base.metadata.create_all(engine)
+          finally:
+              engine.dispose()
+
+          print(
+              f"Created {len(um_models.Base.metadata.tables)} user_management "
+              "table(s) in slm_users (matches production create_all)"
+          )
+          PY
+
       - name: (a) Apply all migrations on a fresh DB
         env:
           DATABASE_URL: postgresql://slmtest:slmtest@127.0.0.1:5432/slm
+          # #14300: role_permissions/audit_logs live in the separate
+          # slm_users database. migrations.runner.get_user_management_db_url()
+          # resolves it via user_management.config.get_slm_db_config(), which
+          # reads SLM_USERS_DATABASE_URL or -- as configured here -- these
+          # discrete SLM_POSTGRES_* components (its documented fallback,
+          # same mechanism the schema-bootstrap step above uses).
+          SLM_POSTGRES_HOST: 127.0.0.1
+          SLM_POSTGRES_PORT: "5432"
+          SLM_POSTGRES_DB: slm_users
+          SLM_POSTGRES_USER: slmtest
+          SLM_POSTGRES_PASSWORD: slmtest
           # #14326: migrations.seed_agents imports autobot_shared.ssot_config
           # at module level. autobot_shared lives at the repo root, one level
           # above working-directory below, so it is invisible to the
@@ -169,6 +233,11 @@ jobs:
         # A second run must succeed with 'No migrations to run' (no failures).
         env:
           DATABASE_URL: postgresql://slmtest:slmtest@127.0.0.1:5432/slm
+          SLM_POSTGRES_HOST: 127.0.0.1
+          SLM_POSTGRES_PORT: "5432"
+          SLM_POSTGRES_DB: slm_users
+          SLM_POSTGRES_USER: slmtest
+          SLM_POSTGRES_PASSWORD: slmtest
           PYTHONPATH: ${{ github.workspace }}
         working-directory: autobot-slm-backend
         run: |
@@ -181,7 +250,9 @@ jobs:
         # #14326: this used to be two psql SELECTs that printed rows and
         # compared nothing, so the step was green regardless of what the
         # table held. It now asserts every entry in migrations.runner.MIGRATIONS
-        # was recorded, with one documented permanent exception.
+        # was recorded. #14300 closed out the one migration that used to be a
+        # documented permanent exception (ALLOWED_DEFERRED is empty below) --
+        # every entry is now required.
         #
         # MIGRATIONS is loaded from runner.py by file path, not
         # `from migrations.runner import MIGRATIONS`: `migrations` is also a
@@ -210,24 +281,18 @@ jobs:
           spec.loader.exec_module(slm_runner)
           MIGRATIONS = slm_runner.MIGRATIONS
 
-          # add_role_permission_audit_log_timestamps targets role_permissions
-          # and audit_logs — user_management tables that live in the SEPARATE
-          # slm_users database (user_management/config.py:get_slm_db_config).
-          # The runner connects only to DATABASE_URL (the slm database, per
-          # runner.get_db_url()), so it can never reach those tables through
-          # this connection. That is true in production exactly as it is
-          # here — not a harness artifact, and not fixable by create_all()
-          # of any Base, since create_all only creates tables in the
-          # database its own engine is bound to. #14300's deferral mechanism
-          # is what keeps this migration retried rather than falsely marked
-          # applied; it is expected to stay pending indefinitely until the
-          # runner gains a second connection for user_management tables
-          # (tracked separately from #14326 as #14300, which reports the
-          # user-visible symptom: audit_logs.updated_at missing on the live DB.
-          # Remove this entry when #14300 lands — `stale_allowlist` above fails
-          # the gate the moment the migration starts applying, so this cannot
-          # rot into a permanent exemption).
-          ALLOWED_DEFERRED = {"add_role_permission_audit_log_timestamps"}
+          # #14300 CLOSED: add_role_permission_audit_log_timestamps used to be
+          # allow-listed here because it alters role_permissions/audit_logs —
+          # user_management tables in the SEPARATE slm_users database — while
+          # the runner connected only to DATABASE_URL and had no way to reach
+          # them. migrations.runner now resolves a migration's db_url from a
+          # module-level TARGET_DB constant (see runner.get_user_management_db_url
+          # and this migration's own TARGET_DB = TARGET_DB_USER_MANAGEMENT),
+          # so it applies cleanly like every other migration. `stale_allowlist`
+          # below would have failed the gate the moment that became true, so
+          # the entry is removed here rather than left to rot into a permanent
+          # exemption nobody re-checks.
+          ALLOWED_DEFERRED = set()
 
           conn = psycopg2.connect(os.environ["DATABASE_URL"])
           try:

--- a/.github/workflows/slm-migration-gate.yml
+++ b/.github/workflows/slm-migration-gate.yml
@@ -257,6 +257,60 @@ jobs:
             exit 1
           fi
 
+      - name: Verify audit_logs.updated_at and role_permissions timestamps actually exist (#14300)
+        # #14321's lesson: a migration recorded as applied while doing
+        # nothing is the exact defect class this repo keeps hitting.
+        # "Applied migration: add_role_permission_audit_log_timestamps" in
+        # the runner's own log, and its row in migrations_applied, are both
+        # the runner's self-report -- neither queries the database it
+        # claims to have changed. This step does, independently, against
+        # slm_users (not slm): the same real Postgres 16 instance, a fresh
+        # cursor, and a live information_schema.columns query -- proof the
+        # columns exist, not merely that migrate() returned without
+        # raising.
+        env:
+          PGHOST: 127.0.0.1
+          PGPORT: "5432"
+          PGDATABASE: slm_users
+          PGUSER: slmtest
+          PGPASSWORD: slmtest
+        working-directory: autobot-slm-backend
+        run: |
+          python3 - <<'PY'
+          import sys
+
+          import psycopg2
+
+          expected = {
+              ("role_permissions", "created_at"),
+              ("role_permissions", "updated_at"),
+              ("audit_logs", "updated_at"),
+          }
+
+          conn = psycopg2.connect()
+          try:
+              with conn.cursor() as cur:
+                  cur.execute(
+                      """
+                      SELECT table_name, column_name
+                      FROM information_schema.columns
+                      WHERE table_schema = 'public'
+                        AND table_name IN ('role_permissions', 'audit_logs')
+                      """
+                  )
+                  present = {(row[0], row[1]) for row in cur.fetchall()}
+          finally:
+              conn.close()
+
+          missing = expected - present
+          print(f"Expected columns: {sorted(expected)}")
+          print(f"Present in slm_users: {sorted(present)}")
+
+          if missing:
+              print(f"::error::columns missing from slm_users despite the migration reporting applied: {sorted(missing)}")
+              sys.exit(1)
+          PY
+
       - name: Verify migrations_applied matches the full migration list
         # #14326: this used to be two psql SELECTs that printed rows and
         # compared nothing, so the step was green regardless of what the

--- a/autobot-slm-backend/migrations/add_role_permission_audit_log_timestamps.py
+++ b/autobot-slm-backend/migrations/add_role_permission_audit_log_timestamps.py
@@ -19,16 +19,30 @@ tables [were] created without updated_at") — same idempotent,
 guard-checked, forward-only, no-data-loss pattern, applied here because SLM
 has its own separate database and never received that migration.
 
+#14300: role_permissions and audit_logs are user_management tables, which
+live in a *different* database than the rest of SLM's schema (the primary
+SLM database the runner otherwise connects to via DATABASE_URL cannot see
+them, by construction). TARGET_DB below tells the runner to resolve this
+migration's db_url against the user_management database instead, via
+``migrations.runner.get_user_management_db_url`` — the same config source
+(``user_management.config.get_slm_db_config``) the SLM backend itself uses
+to open that database at startup.
+
 Run: python3 -m migrations.add_role_permission_audit_log_timestamps
 """
 
 import logging
 import sys
 
+from migrations.runner import TARGET_DB_USER_MANAGEMENT
 from migrations.utils import add_column_if_not_exists, get_connection
 
 logging.basicConfig(level=logging.INFO, format="%(message)s")
 logger = logging.getLogger(__name__)
+
+# Read by migrations.runner.run_migration to pick this migration's db_url
+# (#14300) -- see the module docstring above.
+TARGET_DB = TARGET_DB_USER_MANAGEMENT
 
 _TIMESTAMP_COLUMN = "TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()"
 
@@ -51,7 +65,11 @@ def migrate(db_url: str) -> None:
 
 
 if __name__ == "__main__":
-    from migrations.runner import get_db_url
+    from migrations.runner import get_user_management_db_url
 
-    db_url = sys.argv[1] if len(sys.argv) > 1 else get_db_url()
+    # Standalone invocation bypasses migrations.runner.run_migration's
+    # TARGET_DB resolution, so default to the same user_management database
+    # that resolution would have picked (#14300) rather than DATABASE_URL,
+    # which cannot reach role_permissions/audit_logs.
+    db_url = sys.argv[1] if len(sys.argv) > 1 else get_user_management_db_url()
     migrate(db_url)

--- a/autobot-slm-backend/migrations/runner.py
+++ b/autobot-slm-backend/migrations/runner.py
@@ -106,6 +106,62 @@ def get_db_url() -> str:
     return url.replace("postgresql+asyncpg://", "postgresql://")
 
 
+def get_user_management_db_url() -> str:
+    """URL for the separate user_management database (#14300).
+
+    ``role_permissions`` and ``audit_logs`` are user_management tables,
+    which live in a database of their own — distinct from the primary SLM
+    database ``get_db_url()`` returns for ``DATABASE_URL``. Production opens
+    that second database the same way the SLM backend itself already does
+    at startup (``main.py``'s ``_init_user_management_tables`` via
+    ``user_management.database.get_slm_engine``): through
+    ``user_management.config.get_slm_db_config``, which reads
+    ``SLM_USERS_DATABASE_URL`` (falling back to discrete
+    ``SLM_POSTGRES_*`` env vars). No connection string is hardcoded here —
+    this function is a thin sync-URL adapter over that existing config
+    source, not a second source of truth for it.
+    """
+    from user_management.config import get_slm_db_config
+
+    return get_slm_db_config().sync_url
+
+
+# A migration module may declare which database it targets by setting a
+# module-level ``TARGET_DB`` constant to one of these. Migrations that don't
+# declare one default to TARGET_DB_SLM (DATABASE_URL) -- every migration
+# written before #14300 is unaffected.
+TARGET_DB_SLM = "slm"
+TARGET_DB_USER_MANAGEMENT = "user_management"
+
+
+def _resolve_migration_db_url(module, default_db_url: str) -> str:
+    """Pick the connection URL a migration module should run against (#14300).
+
+    Reading ``TARGET_DB`` off the module, rather than always handing every
+    migration ``DATABASE_URL``, is what makes a cross-database migration
+    like ``add_role_permission_audit_log_timestamps`` reachable at all: it
+    alters ``role_permissions``/``audit_logs``, which live in the
+    user_management database, never in ``DATABASE_URL``'s database — no
+    connection to the latter can ever see those tables, by construction.
+
+    An unrecognized ``TARGET_DB`` value is a configuration mistake in the
+    migration itself, not something to quietly defer around: it raises here,
+    at the moment the migration is loaded, so the mismatch is a loud,
+    diagnosable failure instead of a deferral that looks identical to the
+    ordinary "table not created yet" case and retries forever without
+    anyone noticing the target database was wrong in the first place.
+    """
+    target = getattr(module, "TARGET_DB", TARGET_DB_SLM)
+    if target == TARGET_DB_SLM:
+        return default_db_url
+    if target == TARGET_DB_USER_MANAGEMENT:
+        return get_user_management_db_url()
+    raise ValueError(
+        f"{module.__name__} declares unknown TARGET_DB={target!r}; "
+        f"expected {TARGET_DB_SLM!r} or {TARGET_DB_USER_MANAGEMENT!r}"
+    )
+
+
 def _parse_db_url(url: str) -> dict:
     """Parse PostgreSQL URL into connection parameters (#786)."""
     # postgresql://user:pass@host:port/database
@@ -226,12 +282,17 @@ def run_migration(db_url: str, name: str) -> Tuple[bool, str]:
         # Import the migration module
         module = importlib.import_module(f"migrations.{name}")
 
+        # Resolve which database this migration actually targets (#14300) --
+        # defaults to db_url (DATABASE_URL) unchanged for every migration
+        # that doesn't declare TARGET_DB.
+        target_db_url = _resolve_migration_db_url(module, db_url)
+
         # Check if it has a migrate() function (passes db_url)
         if hasattr(module, "migrate"):
-            module.migrate(db_url)
+            module.migrate(target_db_url)
             return True, f"Applied migration: {name}"
         elif hasattr(module, "run"):
-            module.run(db_url)
+            module.run(target_db_url)
             return True, f"Applied migration: {name}"
         else:
             # A module with no entry point did NOT run, so it must not report

--- a/autobot-slm-backend/migrations/runner_target_db_test.py
+++ b/autobot-slm-backend/migrations/runner_target_db_test.py
@@ -1,0 +1,183 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""A migration can declare a database other than DATABASE_URL (#14300).
+
+``add_role_permission_audit_log_timestamps`` alters ``role_permissions`` and
+``audit_logs`` — user_management tables that live in a database separate
+from the one ``migrations.runner`` connects to for everything else
+(``DATABASE_URL``). Before this change the runner had no way to express
+that, so the migration's own ``table_exists`` checks always failed and it
+deferred forever without ever reaching its tables (#14300's root cause,
+isolated by #14370's real-Postgres gate).
+
+Two things this file exists to prove:
+
+1. A migration that declares no ``TARGET_DB`` keeps using ``DATABASE_URL``
+   unchanged -- every migration written before #14300 is unaffected.
+2. A migration that declares ``TARGET_DB_USER_MANAGEMENT`` gets the
+   user_management database's URL instead, sourced from the same config
+   module (``user_management.config.get_slm_db_config``) the SLM backend
+   itself already uses to open that database at startup -- not a second,
+   hardcoded connection string.
+3. An unrecognized ``TARGET_DB`` value raises immediately rather than
+   silently falling back to a database that cannot see the migration's own
+   tables -- the exact failure mode (a wrong target that looks like an
+   ordinary deferral) this change exists to make loud.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[1]
+_MIGRATION_PATH = _BACKEND_ROOT / "migrations" / "add_role_permission_audit_log_timestamps.py"
+
+
+def _migration_source() -> str:
+    return _MIGRATION_PATH.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Structural -- no import, so these run regardless of whether psycopg2 is
+# installed in this environment.
+# ---------------------------------------------------------------------------
+
+
+def test_the_migration_declares_a_target_db():
+    """The migration must opt into the user_management database explicitly --
+    a silent default would put it right back on DATABASE_URL (#14300)."""
+    tree = ast.parse(_migration_source())
+    module_level_names = {
+        target.id
+        for node in tree.body
+        if isinstance(node, ast.Assign)
+        for target in node.targets
+        if isinstance(target, ast.Name)
+    }
+    assert "TARGET_DB" in module_level_names, (
+        "add_role_permission_audit_log_timestamps.py must set a module-level "
+        "TARGET_DB, or migrations.runner falls back to DATABASE_URL and the "
+        "migration can never reach role_permissions/audit_logs again"
+    )
+
+
+def test_the_migration_imports_the_user_management_target_constant():
+    """Guards against the value drifting to a literal that no longer matches
+    ``migrations.runner.TARGET_DB_USER_MANAGEMENT`` (#14300)."""
+    tree = ast.parse(_migration_source())
+    imported = {
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module == "migrations.runner"
+        for alias in node.names
+    }
+    assert "TARGET_DB_USER_MANAGEMENT" in imported
+
+
+# ---------------------------------------------------------------------------
+# Behavioural -- require importing the real modules (psycopg2).
+# ---------------------------------------------------------------------------
+
+psycopg2 = pytest.importorskip("psycopg2")
+
+
+def _load(name: str, relative: str):
+    spec = importlib.util.spec_from_file_location(name, _BACKEND_ROOT / relative)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.modules.pop(name, None)
+    return module
+
+
+@pytest.fixture
+def runner():
+    return _load("_runner_14300", "migrations/runner.py")
+
+
+class _Module:
+    """A bare object standing in for an imported migration module."""
+
+
+def test_a_module_with_no_target_db_uses_the_default_url(runner):
+    module = _Module()
+
+    resolved = runner._resolve_migration_db_url(module, "postgresql://default-db/slm")
+
+    assert resolved == "postgresql://default-db/slm"
+
+
+def test_a_module_targeting_user_management_gets_that_databases_url(runner, monkeypatch):
+    module = _Module()
+    module.TARGET_DB = runner.TARGET_DB_USER_MANAGEMENT
+
+    monkeypatch.setattr(runner, "get_user_management_db_url", lambda: "postgresql://um-db/slm_users")
+
+    resolved = runner._resolve_migration_db_url(module, "postgresql://default-db/slm")
+
+    assert resolved == "postgresql://um-db/slm_users"
+
+
+def test_an_unrecognized_target_db_raises_instead_of_deferring(runner):
+    module = _Module()
+    module.TARGET_DB = "some_other_database_nobody_wired_up"
+    module.__name__ = "pretend_migration"
+
+    with pytest.raises(ValueError, match="unknown TARGET_DB"):
+        runner._resolve_migration_db_url(module, "postgresql://default-db/slm")
+
+
+def test_run_migration_passes_the_resolved_url_to_migrate(runner, monkeypatch):
+    """The resolution must actually reach the migration's entry point, not
+    just exist as a helper nothing calls (#14300)."""
+    captured = {}
+
+    class _TargetedMigration:
+        TARGET_DB = runner.TARGET_DB_USER_MANAGEMENT
+
+        @staticmethod
+        def migrate(db_url):
+            captured["db_url"] = db_url
+
+    monkeypatch.setattr(runner.importlib, "import_module", lambda _name: _TargetedMigration(), raising=False)
+    monkeypatch.setattr(runner, "get_user_management_db_url", lambda: "postgresql://um-db/slm_users")
+
+    success, message = runner.run_migration("postgresql://default-db/slm", "pretend_migration")
+
+    assert success is True
+    assert captured["db_url"] == "postgresql://um-db/slm_users"
+
+
+def test_run_migration_defaults_untargeted_migrations_to_database_url(runner, monkeypatch):
+    """A migration that declares no TARGET_DB must keep behaving exactly as
+    it did before #14300 -- no regression for the other 26 migrations."""
+    captured = {}
+
+    class _UntargetedMigration:
+        @staticmethod
+        def migrate(db_url):
+            captured["db_url"] = db_url
+
+    monkeypatch.setattr(runner.importlib, "import_module", lambda _name: _UntargetedMigration(), raising=False)
+
+    success, message = runner.run_migration("postgresql://default-db/slm", "pretend_migration")
+
+    assert success is True
+    assert captured["db_url"] == "postgresql://default-db/slm"
+
+
+def test_the_real_migration_module_targets_user_management(runner):
+    """Connects the structural assertions above to the runner's own constant
+    -- both must agree, not merely each compile independently."""
+    migration = _load("_mig_14300_target", "migrations/add_role_permission_audit_log_timestamps.py")
+
+    assert migration.TARGET_DB == runner.TARGET_DB_USER_MANAGEMENT


### PR DESCRIPTION
Closes #14300

## Thinking Path

The issue's own investigation (see the comment thread) already isolated the
root cause before this PR started: `add_role_permission_audit_log_timestamps`
alters `role_permissions` and `audit_logs`, which are **user_management**
tables living in the separate `slm_users` database
(`user_management/config.py::get_slm_db_config`). `migrations/runner.py`
connects only to `DATABASE_URL` (the `slm` database). A connection to `slm`
cannot see tables in `slm_users` — the migration was unreachable **by
construction**, not by ordering or registration. PR #14370's real-Postgres
gate proved this by replicating production's `create_all()` for the primary
database: every other migration then applied cleanly, and this one alone
kept deferring.

That left one open design question: how should the runner reach a second
database without hardcoding a connection string or weakening the
already-merged deferral/failure guarantees from #14320/#14321? The chosen
shape — a migration declares `TARGET_DB` and the runner resolves the actual
`db_url` per-migration — was picked over alternatives considered and
rejected:

- **Give the runner a hardcoded second `DATABASE_URL`-like env var it always
  connects to in parallel.** Rejected: every migration would need a second
  connection whether it uses it or not, and nothing would stop a *future*
  single-database migration from accidentally running against the wrong one.
- **Make the migration module open its own connection internally,
  independent of the runner.** Rejected: the runner's bookkeeping
  (`migrations_applied`, deferral tracking) is what makes #14320's fix work;
  bypassing it for one migration reintroduces the exact "looks applied but
  did nothing" failure mode #14300 exists to close.
- **Module declares `TARGET_DB`, runner resolves the URL.** Chosen: every
  existing migration is unaffected (default target = `DATABASE_URL`,
  unchanged), the new migration opts in explicitly and visibly, and an
  unrecognized target is a loud `ValueError` at resolution time rather than
  a deferral that looks identical to the ordinary "table not created yet"
  case.

## What Changed

**`autobot-slm-backend/migrations/runner.py`**
- Added `get_user_management_db_url()` — a thin adapter over the *existing*
  `user_management.config.get_slm_db_config()` (the same config source the
  SLM backend itself already uses to open `slm_users` at startup). No
  connection string is hardcoded; it reads `SLM_USERS_DATABASE_URL` or the
  documented `SLM_POSTGRES_*` component fallback.
- Added `TARGET_DB_SLM` / `TARGET_DB_USER_MANAGEMENT` constants and
  `_resolve_migration_db_url(module, default_db_url)`: reads an optional
  module-level `TARGET_DB` off the imported migration, defaults to
  `DATABASE_URL` when absent, and **raises `ValueError`** for any other
  value instead of silently deferring.
- `run_migration()` now resolves the target URL before calling
  `migrate()`/`run()`, so the migration's DDL runs against the right
  database while `migrations_applied` bookkeeping stays in `slm` as before.

**`autobot-slm-backend/migrations/add_role_permission_audit_log_timestamps.py`**
- Declares `TARGET_DB = TARGET_DB_USER_MANAGEMENT`.
- Standalone (`python3 -m migrations.add_role_permission_audit_log_timestamps`)
  invocation now defaults to `get_user_management_db_url()` instead of
  `get_db_url()`, so running the file directly doesn't silently target the
  wrong database either.

**`.github/workflows/slm-migration-gate.yml`**
- New step "Create user_management schema in slm_users" runs
  `user_management.models.Base.metadata.create_all()` against `slm_users`,
  mirroring production's `main.py::_init_user_management_tables()` (which
  runs before migrations at real startup) — the same gap the gate already
  fixed for the primary `slm` schema in #14370.
- `(a)`/`(b)` runner steps now also set the `SLM_POSTGRES_*` discrete env
  vars so `get_user_management_db_url()` resolves during the gate.
- **`ALLOWED_DEFERRED` is now `set()`** — `add_role_permission_audit_log_timestamps`
  is removed from the allow-list. The gate's own `stale_allowlist` check
  would fail the moment this migration started applying cleanly; this PR is
  what makes that true, so the entry comes out rather than rotting into a
  permanent exemption.

**`autobot-slm-backend/migrations/runner_target_db_test.py`** (new)
- Structural: the migration declares `TARGET_DB` and imports the constant
  from `migrations.runner` (not a re-typed literal).
- Behavioural (psycopg2-gated, matching the existing `runner_*_test.py`
  style): a module without `TARGET_DB` keeps `DATABASE_URL`; a module
  targeting user_management gets `get_user_management_db_url()`'s value; an
  unrecognized target raises `ValueError`; `run_migration()` actually
  threads the resolved URL into `migrate()` for both the targeted and
  untargeted cases; the real migration file's `TARGET_DB` matches the
  runner's own constant (guards the two from drifting apart).

## Verification

**CI is the real evidence** — this environment does not run application
code or install dependencies (repo policy); the SLM Migration Gate workflow
(real Postgres 16, real runner invocation) is what actually exercises this.
On this PR it should show:
- The new "Create user_management schema in slm_users" step creating the
  user_management tables in `slm_users`.
- "(a) Apply all migrations on a fresh DB" and "(b) Idempotency" both
  green, with `add_role_permission_audit_log_timestamps` no longer logging
  a deferral.
- "Verify migrations_applied matches the full migration list" printing
  `Applied in migrations_applied: 27` (all 27, not 26) and
  `Allow-listed permanent deferral: []`.

That satisfies the bar this repo keeps failing on: a migration recorded as
applied while doing nothing. The gate's assertion is on the bookkeeping
table *and* (via the schema-bootstrap steps mirroring production) the
migration's own `add_column_if_not_exists` runs against a database where
`role_permissions`/`audit_logs` genuinely exist, so "applied" here means the
columns were actually added, not merely that the runner didn't raise.

**Local static verification performed** (no code executed, per repo
policy):
- `ast.parse()` on every changed `.py` file and every heredoc Python block
  extracted from the workflow YAML.
- `yaml.safe_load()` on the full workflow file.
- Manually re-ran `repo_tests/test_ci_import_smoke_paths_14252.py`'s own
  extraction/resolution logic (`_inline_programs`, `_imported_names`,
  `_is_first_party`, `_resolves_in_tree`) against the new workflow content
  — zero missing first-party imports for the new/changed steps.

**Mutation evidence — statically traced, not executed** (this environment
does not run the test suite; CI does):
- Deleting the `TARGET_DB` resolution call in `run_migration()` (reverting
  to the old `module.migrate(db_url)`) makes
  `test_run_migration_passes_the_resolved_url_to_migrate` fail: `captured["db_url"]`
  would equal the default URL instead of the monkeypatched
  user_management URL.
- Changing `_resolve_migration_db_url` to swallow the unknown-target case
  (returning `default_db_url` instead of raising) makes
  `test_an_unrecognized_target_db_raises_instead_of_deferring` fail: no
  `ValueError` is raised.
- Removing `TARGET_DB = TARGET_DB_USER_MANAGEMENT` from the migration file
  makes both `test_the_migration_declares_a_target_db` (structural) and
  `test_the_real_migration_module_targets_user_management` (behavioural)
  fail, and — the real regression this PR fixes — the migration goes back
  to deferring forever against `DATABASE_URL` in the live gate.
- Setting `ALLOWED_DEFERRED` back to `{"add_role_permission_audit_log_timestamps"}`
  in the workflow would make the gate's own `stale_allowlist` check fail
  red the moment the migration applies cleanly — verified by inspection of
  that check's logic (`ALLOWED_DEFERRED - (set(MIGRATIONS) - applied)`),
  which is exactly why the entry is removed in this PR rather than restored.

## Model Used

Claude Opus 5 (1M context)
