### PR TITLE
fix(deploy): route an agent-only node into infrastructure so it reaches a play (#14336)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
+++ b/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
@@ -211,6 +211,14 @@
 # =============================================================================
 # PLAY 1: Update SLM Server First
 # =============================================================================
+# #14336: `hosts: slm_server` deliberately EXCLUDES a node whose only role is
+# slm-agent (#14330 — that node has no /opt/autobot/code_source or
+# autobot-slm-backend checkout, so this play's manager-only tasks fail on it).
+# Such a node still needs its agent redeployed; `services/inventory_builder.py`
+# (`groups_for_role_tokens`, the `is_agent_only` branch) routes it into
+# `infrastructure` instead, so Play 2 below reaches it via the
+# `slm_node_id is defined` agent-redeploy task. Do not "fix" this by adding
+# agent-only nodes here — that reintroduces #14330.
 - name: "Play 1 - Update SLM Server First"
   hosts: slm_server
   gather_facts: false
@@ -518,6 +526,12 @@
 # carries app roles, so pure SLM servers still skip this play while co-located
 # backend/frontend/worker components finally receive updates. Ordering is
 # preserved: Play 1 updates the SLM components first.
+# #14336: an agent-only node (roles reduce to nothing but slm-agent — see
+# Play 1's note above) also joins `infrastructure` here, purely to reach the
+# "SLM Agent | Redeploy agent" task below (`when: slm_node_id is defined`,
+# true for every node). Every other task in this play stays gated on its own
+# `group_names` check, so an agent-only node runs that one task and nothing
+# else.
 - name: "Play 2 - Update Other Infrastructure Nodes"
   hosts: infrastructure
   gather_facts: false

--- a/autobot-slm-backend/services/inventory_builder.py
+++ b/autobot-slm-backend/services/inventory_builder.py
@@ -301,9 +301,7 @@ def groups_for_role_tokens(role_tokens: list[str]) -> set[str]:
     # allow for it — comparing against {"slm", "slm_nodes"} alone is never
     # true here and the branch silently never fires.
     is_agent_only = (
-        is_slm
-        and "slm_server" not in node_groups
-        and node_groups <= ({"slm", "slm_nodes"} | _UNIVERSAL_ALL)
+        is_slm and "slm_server" not in node_groups and node_groups <= ({"slm", "slm_nodes"} | _UNIVERSAL_ALL)
     )
     if not is_slm or has_app_roles or is_agent_only:
         node_groups |= _UNIVERSAL_NON_SLM

--- a/autobot-slm-backend/services/inventory_builder.py
+++ b/autobot-slm-backend/services/inventory_builder.py
@@ -297,7 +297,14 @@ def groups_for_role_tokens(role_tokens: list[str]) -> set[str]:
     # task (Play 2, gated on `slm_node_id is defined`, which every node
     # carries) — every other Play 2 task stays gated on its own group, so
     # this adds nothing else for a node with no other role.
-    is_agent_only = is_slm and "slm_server" not in node_groups and node_groups <= {"slm", "slm_nodes"}
+    # `_UNIVERSAL_ALL` was already merged in above, so the subset test must
+    # allow for it — comparing against {"slm", "slm_nodes"} alone is never
+    # true here and the branch silently never fires.
+    is_agent_only = (
+        is_slm
+        and "slm_server" not in node_groups
+        and node_groups <= ({"slm", "slm_nodes"} | _UNIVERSAL_ALL)
+    )
     if not is_slm or has_app_roles or is_agent_only:
         node_groups |= _UNIVERSAL_NON_SLM
 

--- a/autobot-slm-backend/services/inventory_builder.py
+++ b/autobot-slm-backend/services/inventory_builder.py
@@ -285,7 +285,20 @@ def groups_for_role_tokens(role_tokens: list[str]) -> set[str]:
     has_app_roles = any(
         (t := tok.strip().lower()) and not t.startswith("slm-") and t != "slm_agent" for tok in role_tokens
     )
-    if not is_slm or has_app_roles:
+    # #14336: every node keeps `slm-agent` forever (api/nodes.py never removes it, see
+    # "Remove roles no longer assigned"), so a node whose functional roles are all unassigned
+    # legitimately reduces to nothing but the agent. That node is neither the
+    # manager (no `slm_server`) nor carrying any component `_ROLE_TO_GROUPS`
+    # recognises, so it fell through `has_app_roles` above (deliberately
+    # false for every `slm-`-prefixed token, #11453) AND the `slm_server`
+    # gate `update-all-nodes.yml` Play 1 checks (deliberately excluded,
+    # #14330). Net effect before this fix: zero tasks from either play.
+    # `infrastructure` is the only remaining group with an agent-redeploy
+    # task (Play 2, gated on `slm_node_id is defined`, which every node
+    # carries) — every other Play 2 task stays gated on its own group, so
+    # this adds nothing else for a node with no other role.
+    is_agent_only = is_slm and "slm_server" not in node_groups and node_groups <= {"slm", "slm_nodes"}
+    if not is_slm or has_app_roles or is_agent_only:
         node_groups |= _UNIVERSAL_NON_SLM
 
     return node_groups

--- a/autobot-slm-backend/services/inventory_builder_agent_only_node_test.py
+++ b/autobot-slm-backend/services/inventory_builder_agent_only_node_test.py
@@ -1,0 +1,148 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""A node whose only role is slm-agent must still reach a play (#14336).
+
+`api/nodes.py` deliberately never removes `slm-agent` from a node's role list
+("Remove roles no longer assigned (except slm-agent — always keep)"), so a
+node whose functional roles are all unassigned legitimately ends up with
+`roles=["slm-agent"]` and nothing else.
+
+Before this fix that node received ZERO tasks from `update-all-nodes.yml`:
+
+* Play 1 (`hosts: slm_server`) skips it — correct, and #14330's fix.
+* Play 2 (`hosts: infrastructure`) also skipped it, because `has_app_roles`
+  is deliberately false for every `slm-`-prefixed token (#11453), so the node
+  never joined `infrastructure` either.
+
+`groups_for_role_tokens` now also routes a node into `infrastructure` when
+its role set carries the agent but nothing `_ROLE_TO_GROUPS` recognises as an
+app component and it is not the manager. Every other Play 2 task stays gated
+on its own group (`'backend' in group_names`, `'npu' in group_names`, ...),
+so this adds nothing beyond the agent-redeploy task, which is gated only on
+`slm_node_id is defined` — true for every node.
+
+Verification bar (per the issue): the invariant is "a node with *any* single
+role receives the tasks that role owns", not just that slm-agent specifically
+now works — a guard covering only the reported role would be narrower than
+its own subject. `test_every_single_role_reaches_a_targetable_play` checks
+that generally, parsed off the live playbook rather than a hardcoded set, so
+it also would have caught the original defect (slm-agent/slm_agent were the
+only two entries that failed it).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[1]
+_PLAYBOOK = _BACKEND_ROOT / "ansible" / "playbooks" / "update-all-nodes.yml"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("_ib_14336", _BACKEND_ROOT / "services" / "inventory_builder.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["_ib_14336"] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.modules.pop("_ib_14336", None)
+    return module
+
+
+_ib = _load()
+
+_INFRASTRUCTURE = "infrastructure"
+
+
+@pytest.mark.parametrize("roles", [["slm-agent"], ["slm_agent"], ["slm-agent", "slm_agent"]])
+def test_an_agent_only_node_reaches_play_2(roles):
+    """The reported case: an agent-only node must join `infrastructure`.
+
+    Play 1 (`slm_server`) still correctly excludes it (#14330) — this only
+    asserts the node is not orphaned from *every* play.
+    """
+    groups = _ib.groups_for_role_tokens(roles)
+
+    assert _INFRASTRUCTURE in groups, (
+        f"roles {roles} leave the node out of every group update-all-nodes.yml "
+        "targets — it receives zero tasks (#14336)"
+    )
+    assert "slm_server" not in groups, "an agent-only node must still not become the manager (#14330)"
+
+
+def test_an_agent_plus_unrecognised_role_still_reaches_play_2():
+    """An agent node also carrying a role `_ROLE_TO_GROUPS` does not recognise
+    must not be silently dropped either — the unrecognised token contributes
+    no group, so the node is agent-only in every way that matters here."""
+    groups = _ib.groups_for_role_tokens(["some-future-role-not-yet-mapped", "slm-agent"])
+
+    assert _INFRASTRUCTURE in groups
+
+
+def _play_target_groups() -> set[str]:
+    """Every group a play in update-all-nodes.yml is gated on, `localhost` excluded.
+
+    Parsed off the live playbook (not hardcoded) so a future play addition or
+    rename is picked up automatically instead of silently narrowing the check.
+    """
+    playbook = yaml.safe_load(_PLAYBOOK.read_text(encoding="utf-8"))
+    groups: set[str] = set()
+    for play in playbook:
+        host = play.get("hosts") if isinstance(play, dict) else None
+        if isinstance(host, str) and host != "localhost":
+            groups.add(host)
+    return groups
+
+
+#: One representative single-role token per `_ROLE_TO_GROUPS` entry (plus the
+#: exact-keyed `slm_agent` underscore form). Each is asserted alone — a real
+#: node carries more, but the invariant must hold for the minimal case.
+_SINGLE_ROLE_TOKENS = [
+    "slm-backend",
+    "slm-frontend",
+    "slm-agent",
+    "slm_agent",
+    "backend",
+    "celery",
+    "scheduler",
+    "autobot_shared",
+    "frontend",
+    "npu-worker",
+    "npu_worker",
+    "ai-stack",
+    "chromadb",
+    "autobot-llm-cpu",
+    "tts-worker",
+    "redis",
+    "postgres",
+    "slm-database",
+    "browser-service",
+    "monitoring",
+    "slm-monitoring",
+]
+
+
+@pytest.mark.parametrize("role", _SINGLE_ROLE_TOKENS)
+def test_every_single_role_reaches_a_targetable_play(role):
+    """Every recognised single role must land the node in a group some play
+    in update-all-nodes.yml is gated on — never in a group nothing targets.
+
+    This is the general form of the #14336 invariant: it does not special-case
+    slm-agent, so it would have failed for slm-agent/slm_agent before the fix
+    exactly as it now passes for every other recognised role.
+    """
+    groups = _ib.groups_for_role_tokens([role])
+    targetable = _play_target_groups()
+
+    assert groups & targetable, (
+        f"role {role!r} alone resolves to {sorted(groups)}, none of which "
+        f"update-all-nodes.yml targets ({sorted(targetable)}) — the node "
+        "receives zero tasks"
+    )


### PR DESCRIPTION
Closes #14336

## Thinking Path

Read `api/nodes.py:668-670` first — it deliberately never removes `slm-agent`
from a node's role list, so a node whose functional roles are all unassigned
legitimately ends up with `roles=["slm-agent"]` and nothing else. Traced what
`groups_for_role_tokens(["slm-agent"])` produces in
`services/inventory_builder.py`: `{"slm", "slm_nodes", "autobot",
"autobot_cluster"}` — no `slm_server` (correct, that's #14330's fix, confirmed
already on base) and no `infrastructure` either.

Checked both plays such a node could reach in `update-all-nodes.yml`:
- Play 1 (`hosts: slm_server`) — correctly skips it (#14330).
- Play 2 (`hosts: infrastructure`) — also skips it, because
  `groups_for_role_tokens`'s `has_app_roles` check deliberately treats every
  `slm-`-prefixed token (including `slm-agent`) as "not an app role" (#11453,
  to stop a co-located SLM manager's own internal components wrongly
  promoting it into `infrastructure`). That's correct for `slm-backend` /
  `slm-database` / `slm-monitoring`, but `slm-agent` is different — per
  #14330's own comment, it runs on **every** fleet node, not just the
  manager — and the classification treated it the same as the manager's own
  components anyway.

Net effect before this fix: an agent-only node received **zero tasks** from
either play — a green "update-all completed" run that delivered nothing to
that host, exactly the shape #13852 (silent-failure umbrella) exists to stop.

Checked whether some other path already covers it (the issue explicitly asked
this): `deploy-slm-agent.yml` targets `hosts: slm_nodes` and would reach the
node, but it is a **separate, manually-triggered** playbook
(`api/infrastructure.py`'s own registered entry), not part of the automatic
update-all-nodes.yml flow the builtin self-update / code-sync API invokes
(`api/code_sync.py`). `api/code_sync.py`'s per-node rsync path is a *local*
self-update mechanism (source → deployed dir on the SAME machine), not a
remote push — it does not reach other fleet nodes either. So no, nothing else
already covers this; the fix has to land in the group-derivation logic that
`update-all-nodes.yml` reads its `hosts:` targets from.

## What Changed

- `autobot-slm-backend/services/inventory_builder.py` —
  `groups_for_role_tokens` now also unions in `_UNIVERSAL_NON_SLM`
  (`infrastructure`, `autobot_cluster`, `production_vms`) when a node is
  SLM-classified but carries no `slm_server` membership and none of the
  groups its role tokens produced go beyond `{slm, slm_nodes}` — i.e. an
  agent-only node, or a node whose only other roles are ones
  `_ROLE_TO_GROUPS` doesn't recognise at all. This does **not** touch the
  `slm_server` exclusion #14330 already fixed — an agent-only node still
  never becomes the manager.
- `autobot-slm-backend/ansible/playbooks/update-all-nodes.yml` — added a
  comment next to each play's `hosts:` gate explaining why an agent-only node
  is excluded from Play 1 but reaches Play 2 (via the `slm_node_id is
  defined` agent-redeploy task, which every other task in that play stays
  independently gated on its own `group_names` check), so the next reader
  does not have to re-derive it.

Once in `infrastructure`, the node reaches Play 2's existing "SLM Agent |
Redeploy agent" task (`when: slm_node_id is defined`, true for every node) —
that task was already correctly written to be safe for any host; the node
just never reached the play that contains it.

## Verification

Added `autobot-slm-backend/services/inventory_builder_agent_only_node_test.py`:

- The reported case directly: `roles=["slm-agent"]` / `["slm_agent"]` /
  duplicates all now land in `infrastructure`, while `slm_server` stays
  excluded (regression guard for #14330, pinned in the same test).
- **The general invariant, not just the reported role**: parses
  `update-all-nodes.yml` for every group a play is actually gated on
  (`hosts:` targets, `localhost` excluded — derived from the live file, not
  hardcoded), then asserts that **every** recognised single role in
  `_ROLE_TO_GROUPS` (21 entries: `slm-backend`, `backend`, `npu-worker`,
  `ai-stack`, `redis`, `browser-service`, `slm-agent`, etc.) resolves to a
  group that some play targets. Before the fix, `slm-agent` and `slm_agent`
  were the only two entries that failed this check — every other role
  already reached a play via the existing `has_app_roles` → `infrastructure`
  path, which is exactly the "guard narrower than its own subject" bar the
  task asked for.

**Mutation evidence — statically traced, not executed** (per the "never run
code from the codebase" policy; CI executes the suite): reverting the new
`is_agent_only` branch back to `if not is_slm or has_app_roles:` makes
`groups_for_role_tokens(["slm-agent"])` return `{slm, slm_nodes, autobot,
autobot_cluster}` — no `infrastructure` — which fails both
`test_an_agent_only_node_reaches_play_2` and the general
`test_every_single_role_reaches_a_targetable_play[slm-agent]` /
`[slm_agent]` parametrizations (`groups & targetable` is empty). Traced by
hand through `_role_tokens_to_groups`/`groups_for_role_tokens` for all 21
roles in the general test and confirmed each already lands in `slm_server`,
`infrastructure`, or `database` — the three groups `update-all-nodes.yml`
actually targets.

## Model Used

Claude Opus 5 (1M context)
