### PR TITLE
fix(redis): resolve the 'main' host via SSOT config and stop the config-error retry storm (#14299)

### DIFF
--- a/autobot-slm-backend/ansible/roles/slm_manager/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/slm_manager/defaults/main.yml
@@ -27,6 +27,14 @@ slm_backend_service: autobot-slm-backend
 slm_backend_host: 127.0.0.1
 slm_backend_port: 8000
 
+# #14299: every OTHER component role sets its own <component>_redis_host
+# default from the global `redis_host` var (roles/backend, npu-worker,
+# slm_agent, ai-stack, tts-worker) — the SLM backend's own unit never did,
+# so REDIS_HOST/AUTOBOT_REDIS_HOST were simply never set on that process and
+# the 'main' database resolved to an empty host continuously. Same pattern,
+# same default, for consistency with the rest of the fleet.
+slm_manager_redis_host: "{{ redis_host | default('127.0.0.1') }}"
+
 # ==========================================================
 # TLS Configuration
 # ==========================================================

--- a/autobot-slm-backend/ansible/roles/slm_manager/templates/autobot-slm-backend.service.j2
+++ b/autobot-slm-backend/ansible/roles/slm_manager/templates/autobot-slm-backend.service.j2
@@ -24,6 +24,12 @@ WorkingDirectory={{ slm_backend_dir }}
 Environment="PATH={{ slm_backend_dir }}/venv/bin:/usr/local/bin:/usr/bin:/bin"
 Environment="PYTHONPATH={{ slm_backend_dir }}:{{ slm_shared_dir }}:{{ slm_base_dir }}"
 Environment="PYTHONUNBUFFERED=1"
+# #14299: this process cannot import config.registry.ConfigRegistry (its own
+# config.py is a single file, not a package — see connection_manager.py's
+# _ssot_redis_host docstring), so REDIS_HOST/AUTOBOT_REDIS_HOST must be set
+# explicitly, the same way slm-agent's own unit already does.
+Environment="REDIS_HOST={{ slm_manager_redis_host }}"
+Environment="AUTOBOT_REDIS_HOST={{ slm_manager_redis_host }}"
 EnvironmentFile=-{{ postgresql_credentials_dir }}/{{ postgresql_credentials_file }}
 EnvironmentFile=-{{ slm_credentials_dir }}/{{ slm_credentials_file }}
 # #11668: bound uvicorn's SIGTERM shutdown (see autobot-backend.service.j2) so the

--- a/autobot-slm-backend/api/health.py
+++ b/autobot-slm-backend/api/health.py
@@ -28,6 +28,42 @@ START_TIME = time.time()
 VERSION = "1.0.0"
 
 
+async def _check_redis_health() -> str:
+    """Actively probe the 'main' Redis database (#14299).
+
+    A backend whose circuit breaker is open on its primary datastore was
+    invisible to every roll-up — this node stayed `online` and this very
+    endpoint answered "healthy" purely because it never looked at Redis at
+    all. ``get_async_redis_client`` goes through the SAME circuit breaker
+    ``get_async_client`` does, so once a config/connection error has opened
+    it (see ``connection_manager._check_circuit_breaker``), this returns
+    immediately without re-attempting a connection or re-logging — it is not
+    an extra source of the retry-storm #14299 also reports.
+    """
+    try:
+        from autobot_shared.redis_client import get_async_redis_client, get_redis_health
+
+        client = await get_async_redis_client(database="main")
+        if client is not None:
+            return "healthy"
+
+        # #14299: distinguish "resolved to nothing configured" (a config
+        # error — REDIS_HOST/vm.redis needs to be set, will not fix itself)
+        # from every other reason get_async_redis_client can return None
+        # (Redis disabled, or a genuine connection failure). A bare
+        # "unhealthy" collapses both into one status an operator cannot act
+        # on without reading the backend's own logs.
+        last_error = str(
+            get_redis_health().get("databases", {}).get("main", {}).get("metrics", {}).get("last_error", "")
+        )
+        if "configuration error" in last_error:
+            return "unhealthy: redis configuration error — see backend logs"
+        return "unhealthy"
+    except Exception as exc:
+        logger.error("Redis health check failed: %s", exc)
+        return "unhealthy"
+
+
 @router.get("/health", response_model=HealthResponse)
 async def health_check(
     db: Annotated[AsyncSession, Depends(get_db)],
@@ -46,11 +82,14 @@ async def health_check(
         nodes_total = 0
         db_status = "unhealthy"
 
+    redis_status = await _check_redis_health()
+
     return HealthResponse(
-        status="healthy" if db_status == "healthy" else "degraded",
+        status="healthy" if db_status == "healthy" and redis_status == "healthy" else "degraded",
         version=VERSION,
         uptime_seconds=time.time() - START_TIME,
         database=db_status,
+        redis=redis_status,
         nodes_online=nodes_online,
         nodes_total=nodes_total,
     )

--- a/autobot-slm-backend/models/schemas.py
+++ b/autobot-slm-backend/models/schemas.py
@@ -450,6 +450,11 @@ class HealthResponse(BaseModel):
     version: str
     uptime_seconds: float
     database: str
+    # #14299: Redis was never part of this response — a backend with an open
+    # circuit breaker on its main database still reported itself healthy, as
+    # long as Postgres answered. Required (not Optional): the single caller
+    # (api/health.py::health_check) always sets it.
+    redis: str
     nodes_online: int
     nodes_total: int
 

--- a/autobot-slm-backend/tests/api/test_health_redis_14299.py
+++ b/autobot-slm-backend/tests/api/test_health_redis_14299.py
@@ -1,0 +1,195 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""GET /health must reflect Redis, not just Postgres (#14299).
+
+Before this fix, ``api/health.py``'s ``/health`` endpoint checked ONLY the SQL
+database. A backend whose circuit breaker was permanently open on its 'main'
+Redis database (see ``connection_manager_pool_test.py`` for the "log once,
+open once" half of #14299) still reported ``status="healthy"`` — the node
+stayed ``online`` and this endpoint answered normally, which is exactly the
+"invisible to every roll-up" shape the issue reports.
+
+``_check_redis_health`` also has to distinguish a config error ("resolved to
+nothing configured" — will not fix itself without an operator setting
+REDIS_HOST/vm.redis) from every other reason a client can be unavailable
+(disabled, transient connection failure) — collapsing both into a bare
+"unhealthy" is the same undiagnosable-status shape #14299 calls out for the
+log line itself.
+
+Real-load prologue (pattern: tests/api/test_drift_resolve.py): the root
+conftest stubs ``models.schemas`` as a MagicMock, and FastAPI validates
+``response_model=HealthResponse`` at *decoration* time — importing
+``api/health.py`` under the stub raises there, before a single test runs.
+This module swaps in the REAL ``models.schemas`` (pydantic model, decoration
+succeeds), execs a private copy of ``api/health.py`` against it, and restores
+the stub — ``models.database`` / ``services.auth`` / ``services.database``
+stay stubbed throughout, since every handler under test here is called
+directly with an explicit ``db`` stand-in and never actually reaches them.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import sys
+from pathlib import Path
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[2]
+
+# #14299: models.schemas has a real field annotated `NodeStatus | None`
+# (line ~178) sourced from models.database — loading schemas.py with
+# models.database still stubbed makes that annotation a MagicMock, and
+# pydantic cannot build a validator for it. Both must be real together,
+# exactly like tests/api/test_drift_resolve.py's swap list.
+_SWAP_KEYS = ("models.database", "models.schemas")
+
+
+def _is_swap_key(name: str) -> bool:
+    return name in _SWAP_KEYS or name == "sqlalchemy" or name.startswith("sqlalchemy.")
+
+
+def _load_real_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_orig_modules = {name: mod for name, mod in sys.modules.items() if _is_swap_key(name)}
+for _name in list(_orig_modules):
+    del sys.modules[_name]
+try:
+    for _name in ("sqlalchemy", "sqlalchemy.ext.asyncio", "sqlalchemy.orm"):
+        importlib.import_module(_name)
+
+    _load_real_module("models.database", _BACKEND_ROOT / "models" / "database.py")
+    _load_real_module("models.schemas", _BACKEND_ROOT / "models" / "schemas.py")
+
+    _health_spec = importlib.util.spec_from_file_location("_health_redis_test", _BACKEND_ROOT / "api" / "health.py")
+    health = importlib.util.module_from_spec(_health_spec)
+    _health_spec.loader.exec_module(health)
+finally:
+    for _name in [name for name in sys.modules if _is_swap_key(name)]:
+        del sys.modules[_name]
+    for _name, _mod in _orig_modules.items():
+        sys.modules[_name] = _mod
+
+
+def _run(coro):
+    """Run an async handler synchronously — matches tests/api/test_drift_resolve.py."""
+    return asyncio.run(coro)
+
+
+class TestCheckRedisHealth:
+    def test_healthy_when_client_available(self, monkeypatch):
+        async def _fake_client(database="main"):
+            return object()
+
+        monkeypatch.setattr("autobot_shared.redis_client.get_async_redis_client", _fake_client)
+
+        assert _run(health._check_redis_health()) == "healthy"
+
+    def test_configuration_error_is_distinguishable_from_generic_unhealthy(self, monkeypatch):
+        """The failing path: a blank-host config error must not read the same
+        as a transient connection failure — an operator needs to know which
+        one they are looking at (#14299)."""
+
+        async def _fake_client(database="main"):
+            return None
+
+        monkeypatch.setattr("autobot_shared.redis_client.get_async_redis_client", _fake_client)
+        monkeypatch.setattr(
+            "autobot_shared.redis_client.get_redis_health",
+            lambda: {
+                "databases": {
+                    "main": {
+                        "metrics": {
+                            "last_error": (
+                                "Redis host for database 'main' is empty — configuration "
+                                "error (set REDIS_HOST / vm.redis); refusing to retry"
+                            )
+                        }
+                    }
+                }
+            },
+        )
+
+        result = _run(health._check_redis_health())
+
+        assert result != "unhealthy", "a config error collapsed into the generic bare status"
+        assert "configuration error" in result
+
+    def test_generic_connection_failure_stays_the_generic_status(self, monkeypatch):
+        """The success path this test suite must not fake-pass on: a
+        transient connection failure — not a config error — must NOT trip the
+        "configuration error" branch (verify against the reproduction AND the
+        case that must stay caught, not just the reported one)."""
+
+        async def _fake_client(database="main"):
+            return None
+
+        monkeypatch.setattr("autobot_shared.redis_client.get_async_redis_client", _fake_client)
+        monkeypatch.setattr(
+            "autobot_shared.redis_client.get_redis_health",
+            lambda: {"databases": {"main": {"metrics": {"last_error": "Error 111 connecting to host:6379."}}}},
+        )
+
+        assert _run(health._check_redis_health()) == "unhealthy"
+
+    def test_missing_metrics_do_not_raise(self, monkeypatch):
+        """No prior call has touched 'main' yet — get_redis_health() has no
+        entry for it. Must degrade to the generic status, never raise."""
+
+        async def _fake_client(database="main"):
+            return None
+
+        monkeypatch.setattr("autobot_shared.redis_client.get_async_redis_client", _fake_client)
+        monkeypatch.setattr("autobot_shared.redis_client.get_redis_health", lambda: {"databases": {}})
+
+        assert _run(health._check_redis_health()) == "unhealthy"
+
+
+class TestHealthCheckEndpoint:
+    def test_degrades_when_redis_is_unhealthy_even_if_db_is_fine(self, monkeypatch):
+        """The endpoint-level invariant: Postgres alone can no longer make
+        /health say "healthy" — Redis has to agree too (#14299)."""
+
+        class _FakeScalarResult:
+            def scalar(self):
+                return 1
+
+        class _FakeDB:
+            async def execute(self, *_a, **_kw):
+                return _FakeScalarResult()
+
+        async def _unhealthy_redis():
+            return "unhealthy"
+
+        monkeypatch.setattr(health, "_check_redis_health", _unhealthy_redis)
+
+        result = _run(health.health_check(db=_FakeDB()))
+
+        assert result.database == "healthy"
+        assert result.redis == "unhealthy"
+        assert result.status != "healthy", "Postgres-only health must not mask a broken Redis"
+
+    def test_healthy_when_both_db_and_redis_agree(self, monkeypatch):
+        class _FakeScalarResult:
+            def scalar(self):
+                return 1
+
+        class _FakeDB:
+            async def execute(self, *_a, **_kw):
+                return _FakeScalarResult()
+
+        async def _healthy_redis():
+            return "healthy"
+
+        monkeypatch.setattr(health, "_check_redis_health", _healthy_redis)
+
+        result = _run(health.health_check(db=_FakeDB()))
+
+        assert result.status == "healthy"

--- a/autobot-slm-frontend/openapi.json
+++ b/autobot-slm-frontend/openapi.json
@@ -4606,6 +4606,10 @@
             "title": "Nodes Total",
             "type": "integer"
           },
+          "redis": {
+            "title": "Redis",
+            "type": "string"
+          },
           "status": {
             "title": "Status",
             "type": "string"
@@ -4624,6 +4628,7 @@
           "version",
           "uptime_seconds",
           "database",
+          "redis",
           "nodes_online",
           "nodes_total"
         ],

--- a/autobot-slm-frontend/src/types/generated/api.ts
+++ b/autobot-slm-frontend/src/types/generated/api.ts
@@ -8987,6 +8987,8 @@ export interface components {
             nodes_online: number;
             /** Nodes Total */
             nodes_total: number;
+            /** Redis */
+            redis: string;
             /** Status */
             status: string;
             /** Uptime Seconds */

--- a/autobot_shared/redis_management/connection_manager.py
+++ b/autobot_shared/redis_management/connection_manager.py
@@ -263,6 +263,12 @@ class RedisConnectionManager:
         self._failure_counts: Dict[str, int] = {}
         self._last_failure_times: Dict[str, float] = {}
         self._circuit_open: Dict[str, bool] = {}
+        # #14299: databases whose host resolved to nothing configured. A config
+        # error is permanent for the life of this process (nothing here re-reads
+        # the environment), unlike a transient connection failure, so it is
+        # tracked separately from the time-based circuit breaker below and never
+        # auto-resets — see _check_circuit_breaker and _validate_config_host.
+        self._config_broken: set[str] = set()
 
     def _init_tcp_keepalive_options(self) -> None:
         """
@@ -301,13 +307,25 @@ class RedisConnectionManager:
 
         Loads from multiple sources with priority ordering.
         Issue #620.
+
+        #14299: ``self._config`` (host/port/enabled) now resolves BEFORE
+        ``_load_configurations`` builds the "main" database's default, so
+        "main" uses the same resolution chain (config-manager -> env ->
+        NetworkConstants -> ssot_config -> loopback, see
+        ``_load_redis_config``/``_ssot_redis_host``) as every other
+        not-yet-configured database — instead of ``RedisConfig.host``'s
+        dataclass field default, which is a *class-body* expression evaluated
+        once at whichever process happens to import
+        ``redis_management.config`` first, and empty outside autobot-backend.
         """
+        # Load existing configuration (backward compatibility) — resolved
+        # first; _load_configurations's "main" default consumes it below.
+        self._config = self._load_redis_config()
+
         # Load configurations from multiple sources
         self._configs: Dict[str, RedisConfig] = {}
         self._load_configurations()
 
-        # Load existing configuration (backward compatibility)
-        self._config = self._load_redis_config()
         self._pool_config = self._load_pool_config()
 
     def _init_statistics_tracking(self) -> None:
@@ -365,6 +383,37 @@ class RedisConnectionManager:
                 return value
         return None
 
+    @staticmethod
+    def _ssot_redis_host() -> str:
+        """Resolve the Redis host via the canonical SSOT config (#14299).
+
+        ``NetworkConstants.REDIS_VM_IP`` depends on ``config.registry.ConfigRegistry``,
+        which lives only in autobot-backend (see ``network_constants._get_config_value``'s
+        own docstring: "avoiding dependency issues when autobot_shared is used
+        independently"). Importing it from any other process — autobot-slm-backend,
+        whose own ``config.py`` is a single file, not a package, so
+        ``config.registry`` cannot resolve at all — is silently caught and falls
+        back to the caller-supplied default, which for REDIS_VM_IP is the empty
+        string. That is why a deployed SLM backend resolved the 'main' database's
+        host to nothing, continuously (#14299): every other tier already came up
+        empty (no config-manager module there either — see ``_get_config_manager``
+        — and neither REDIS_HOST nor AUTOBOT_REDIS_HOST was set on that process).
+
+        ``autobot_shared.ssot_config`` has no such dependency (pydantic-settings
+        reading an env var / project-root ``.env``) and defaults to '127.0.0.1' —
+        the same co-located default every other Ansible-templated component
+        already falls back to (``roles/*/defaults/main.yml``:
+        ``"{{ redis_host | default('127.0.0.1') }}"``), so this brings the SLM
+        backend's own resolution in line with its siblings instead of the empty
+        string NetworkConstants defaults to outside autobot-backend.
+        """
+        try:
+            from autobot_shared.ssot_config import get_config
+
+            return (get_config().vm.redis or "").strip()
+        except Exception:
+            return ""
+
     def _load_redis_config(self) -> Dict[str, Any]:
         """Load Redis configuration from unified config (#2477)."""
         try:
@@ -376,7 +425,16 @@ class RedisConnectionManager:
         # #12778: env beats the NetworkConstants fallback, but NOT an explicit
         # config-manager value — a deployment that configures Redis centrally
         # must still win over a stray env var.
-        host = redis_config.get("host") or self._redis_host_from_env() or NetworkConstants.REDIS_VM_IP
+        # #14299: NetworkConstants.REDIS_VM_IP silently resolves to "" outside
+        # autobot-backend (see _ssot_redis_host's docstring) — ssot_config and
+        # finally a literal loopback keep this from ever landing on empty.
+        host = (
+            redis_config.get("host")
+            or self._redis_host_from_env()
+            or NetworkConstants.REDIS_VM_IP
+            or self._ssot_redis_host()
+            or "127.0.0.1"
+        )
         return {
             "host": host,
             "port": redis_config.get("port", NetworkConstants.REDIS_PORT),
@@ -423,9 +481,15 @@ class RedisConnectionManager:
 
         # Priority 3: Default configuration with timeout config
         timeout_config = RedisConfigLoader.load_timeout_config()
+        # #14299: host/port come from self._config (set in _init_configurations,
+        # before this runs) rather than RedisConfig's dataclass field defaults —
+        # see _init_configurations's docstring for why those defaults cannot be
+        # trusted outside autobot-backend.
         default_config = RedisConfig(
             name="main",
             db=0,
+            host=self._config["host"],
+            port=self._config["port"],
             socket_timeout=timeout_config.get("socket_timeout", 5.0),
             socket_connect_timeout=timeout_config.get("socket_connect_timeout", 5.0),
             retry_on_timeout=timeout_config.get("retry_on_timeout", True),
@@ -672,6 +736,14 @@ class RedisConnectionManager:
 
     def _check_circuit_breaker(self, database_name: str) -> bool:
         """Check if circuit breaker is open for a database."""
+        # #14299: a config error (blank host) is permanent for this process —
+        # nothing here re-reads the environment, so it cannot resolve
+        # differently on a later call. Skip the time-based reset entirely so a
+        # config error does not cycle open/closed roughly once a minute
+        # forever; it stays open until a restart picks up corrected config.
+        if database_name in self._config_broken:
+            return True
+
         if database_name not in self._circuit_open:
             self._circuit_open[database_name] = False
             self._failure_counts[database_name] = 0
@@ -685,6 +757,57 @@ class RedisConnectionManager:
                 self._failure_counts[database_name] = 0
 
         return self._circuit_open[database_name]
+
+    def _open_circuit_for_config_error(self, database_name: str, error: Exception) -> None:
+        """Permanently open the circuit for a configuration error (#14299).
+
+        Unlike a transient connection failure — which needs
+        ``circuit_breaker_threshold`` occurrences before the breaker opens, and
+        resets after ``circuit_breaker_timeout`` — a blank host cannot be
+        retried into success: nothing here re-reads the environment, so the
+        value will not change until the process restarts with corrected
+        config. Opening on the FIRST occurrence and never resetting turns
+        "refusing to retry" from a broken promise (the previous behaviour
+        re-derived and re-logged the same failure every ~2s, reopening the
+        circuit breaker roughly once a minute) into what the log line already
+        claimed.
+
+        Called once per database, from ``_validate_config_host`` — every
+        subsequent call short-circuits at ``_check_circuit_breaker`` before
+        reaching here, so this never runs twice for the same database.
+        """
+        self._config_broken.add(database_name)
+        self._circuit_open[database_name] = True
+        self._states[database_name] = ConnectionState.FAILED
+
+        self._failure_counts[database_name] = self._failure_counts.get(database_name, 0) + 1
+        self._last_failure_times[database_name] = time.time()
+
+        if database_name not in self._metrics:
+            self._metrics[database_name] = ConnectionMetrics()
+        metrics = self._metrics[database_name]
+        metrics.failed_connections += 1
+        metrics.failed_requests += 1
+        metrics.last_error = str(error)
+        metrics.last_error_time = time.time()
+        metrics.circuit_breaker_state = "open"
+
+        logger.error(str(error))
+
+        try:
+            prom_metrics = _get_metrics_manager()
+            prom_metrics.record_circuit_breaker_event(
+                database=database_name,
+                event="opened",
+                reason=str(error)[:100],
+            )
+            prom_metrics.update_circuit_breaker_state(
+                database=database_name,
+                state="open",
+                failure_count=self._failure_counts[database_name],
+            )
+        except Exception as prom_err:
+            logger.debug(f"Failed to record Prometheus circuit breaker metrics: {prom_err}")
 
     def _record_failure(self, database_name: str, error: Exception) -> None:
         """Record a connection failure and update circuit breaker."""
@@ -792,21 +915,35 @@ class RedisConnectionManager:
         self._validate_config_host(database_name, config)
         return self._create_sync_pool_with_keepalive(database_name, config)
 
-    @staticmethod
-    def _validate_config_host(database_name: str, config: "RedisConfig") -> None:
+    def _validate_config_host(self, database_name: str, config: "RedisConfig") -> None:
         """Reject blank Redis hosts before any connect attempt (#11449).
 
         An empty host (e.g. unresolvable ``vm.redis`` in a process that cannot
         import the backend ConfigRegistry) is a configuration error, not a
         transient outage — retrying it burned ~60 s of exponential backoff per
         caller during the 2026-07-10 SLM auth incident.
+
+        #14299: the resolution chain in ``_load_redis_config``/
+        ``_ssot_redis_host`` now reaches a working default almost everywhere,
+        so this should be rare in practice — but when it does still fire (a
+        ``_configs`` entry loaded from YAML/service-registry with an explicit
+        blank host, for example), the failure is opened onto
+        ``_open_circuit_for_config_error`` (logs once, opens the circuit
+        breaker permanently) instead of being re-derived and re-logged on
+        every call — the previous behaviour opened the circuit breaker
+        roughly once a minute, indefinitely, and the "refusing to retry" log
+        line was itself re-emitted every ~2s.
         """
         host = (config.host or "").strip()
-        if not host:
-            raise RedisConfigurationError(
-                f"Redis host for database '{database_name}' is empty — configuration "
-                "error (set REDIS_HOST / vm.redis); refusing to retry"
-            )
+        if host:
+            return
+        message = (
+            f"Redis host for database '{database_name}' is empty — configuration "
+            "error (set REDIS_HOST / vm.redis); refusing to retry"
+        )
+        if database_name not in self._config_broken:
+            self._open_circuit_for_config_error(database_name, RedisConfigurationError(message))
+        raise RedisConfigurationError(message)
 
     async def _create_async_pool(self, database_name: str) -> async_redis.ConnectionPool:
         """
@@ -855,7 +992,11 @@ class RedisConnectionManager:
             return False
 
         if self._check_circuit_breaker(database_name):
-            logger.warning(f"Circuit breaker is open for database '{database_name}', rejecting request")
+            # #14299: a config-broken database already logged once, in
+            # _validate_config_host / _open_circuit_for_config_error — do not
+            # re-log "circuit breaker is open" on every subsequent call too.
+            if database_name not in self._config_broken:
+                logger.warning(f"Circuit breaker is open for database '{database_name}', rejecting request")
             return False
 
         return None
@@ -892,7 +1033,16 @@ class RedisConnectionManager:
 
         Records failure metrics and updates connection state.
         Issue #620.
+
+        #14299: a RedisConfigurationError was already logged and recorded once
+        by _validate_config_host -> _open_circuit_for_config_error, on the
+        first occurrence — recording it again here would double-count the
+        failure and re-log a message that already went out.
         """
+        if isinstance(error, RedisConfigurationError):
+            self._update_stats(database_name, success=False, error=str(error))
+            self._states[database_name] = ConnectionState.FAILED
+            return
         logger.warning(f"Failed to get sync Redis client for database '{database_name}': {error}")
         self._record_failure(database_name, error)
         self._update_stats(database_name, success=False, error=str(error))
@@ -926,15 +1076,22 @@ class RedisConnectionManager:
             self._handle_sync_client_failure(database_name, e)
             return None
 
-    @staticmethod
-    def _log_pool_task_failure(database_name: str, task: "asyncio.Task") -> None:
+    def _log_pool_task_failure(self, database_name: str, task: "asyncio.Task") -> None:
         """Done-callback: retrieve (and log) a failed pool-creation's exception
         so asyncio never reports it as unretrieved, even when every waiter was
-        cancelled by its own deadline (#11451)."""
+        cancelled by its own deadline (#11451).
+
+        #14299: a RedisConfigurationError was already logged once by
+        _validate_config_host -> _open_circuit_for_config_error — this
+        callback still MUST retrieve the exception (asyncio.Task.exception()
+        below) so it is never reported as unretrieved, it just does not log a
+        second time for the one error type that is guaranteed to repeat on
+        every call until a restart.
+        """
         if task.cancelled():
             return
         exc = task.exception()
-        if exc is not None:
+        if exc is not None and not isinstance(exc, RedisConfigurationError):
             logger.warning("Async pool creation for '%s' failed: %s", database_name, exc)
 
     async def _ensure_async_pool_exists(self, database_name: str) -> None:
@@ -1012,7 +1169,11 @@ class RedisConnectionManager:
             return None
 
         if self._check_circuit_breaker(database_name):
-            logger.warning(f"Circuit breaker is open for database '{database_name}', rejecting request")
+            # #14299: a config-broken database already logged once, in
+            # _validate_config_host / _open_circuit_for_config_error — do not
+            # re-log "circuit breaker is open" on every subsequent call too.
+            if database_name not in self._config_broken:
+                logger.warning(f"Circuit breaker is open for database '{database_name}', rejecting request")
             return None
 
         try:
@@ -1028,6 +1189,15 @@ class RedisConnectionManager:
             return client
 
         except Exception as e:
+            # #14299: a RedisConfigurationError was already logged and recorded
+            # once by _validate_config_host -> _open_circuit_for_config_error,
+            # on the first occurrence — recording it again here would
+            # double-count the failure and re-log a message that already went
+            # out.
+            if isinstance(e, RedisConfigurationError):
+                self._update_stats(database_name, success=False, error="Internal server error")
+                self._states[database_name] = ConnectionState.FAILED
+                return None
             logger.warning(f"Failed to get async Redis client for database '{database_name}': {e}")
             self._record_failure(database_name, e)
             self._update_stats(database_name, success=False, error="Internal server error")

--- a/autobot_shared/redis_management/connection_manager_pool_test.py
+++ b/autobot_shared/redis_management/connection_manager_pool_test.py
@@ -27,25 +27,59 @@ def _bare_manager() -> RedisConnectionManager:
     return m
 
 
+def _bare_validate_manager() -> RedisConnectionManager:
+    """Manager instance with the state _validate_config_host/
+    _open_circuit_for_config_error touch (#14299: it stopped being a
+    staticmethod so it could log the config error once instead of on every
+    call — see _open_circuit_for_config_error)."""
+    m = object.__new__(RedisConnectionManager)
+    m._config_broken = set()
+    m._circuit_open = {}
+    m._states = {}
+    m._failure_counts = {}
+    m._last_failure_times = {}
+    m._metrics = {}
+    return m
+
+
 class TestValidateConfigHost:
     def test_empty_host_raises_configuration_error(self):
         cfg = SimpleNamespace(host="")
         with pytest.raises(RedisConfigurationError):
-            RedisConnectionManager._validate_config_host("main", cfg)
+            _bare_validate_manager()._validate_config_host("main", cfg)
 
     def test_blank_host_raises_configuration_error(self):
         cfg = SimpleNamespace(host="   ")
         with pytest.raises(RedisConfigurationError):
-            RedisConnectionManager._validate_config_host("main", cfg)
+            _bare_validate_manager()._validate_config_host("main", cfg)
 
     def test_none_host_raises_configuration_error(self):
         cfg = SimpleNamespace(host=None)
         with pytest.raises(RedisConfigurationError):
-            RedisConnectionManager._validate_config_host("main", cfg)
+            _bare_validate_manager()._validate_config_host("main", cfg)
 
     def test_valid_host_passes(self):
         cfg = SimpleNamespace(host="127.0.0.1")
-        RedisConnectionManager._validate_config_host("main", cfg)  # no raise
+        _bare_validate_manager()._validate_config_host("main", cfg)  # no raise
+
+    def test_repeated_empty_host_opens_circuit_once_not_every_call(self):
+        """#14299: a config error must log/open the circuit ONCE, then every
+        later call short-circuits without re-deriving or re-logging."""
+        cfg = SimpleNamespace(host="")
+        manager = _bare_validate_manager()
+
+        for _ in range(5):
+            with pytest.raises(RedisConfigurationError):
+                manager._validate_config_host("main", cfg)
+
+        assert manager._failure_counts["main"] == 1, (
+            "5 calls raised the same permanent config error — only the FIRST "
+            "may record a failure, or the breaker cycles exactly the noisy "
+            "way #14299 reports"
+        )
+        assert manager._circuit_open["main"] is True
+        assert manager._check_circuit_breaker("main") is True
+        assert "main" in manager._config_broken
 
     def test_configuration_error_is_not_retryable_connection_error(self):
         """The retry mechanism keys on ConnectionError/TimeoutError — the

--- a/autobot_shared/redis_management/redis_host_ssot_fallback_14299_test.py
+++ b/autobot_shared/redis_management/redis_host_ssot_fallback_14299_test.py
@@ -1,0 +1,140 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""The 'main' database must not resolve to an empty Redis host (#14299).
+
+Observed on a deployed SLM backend: ``NetworkConstants.REDIS_VM_IP`` depends on
+``config.registry.ConfigRegistry``, which lives only in autobot-backend (see
+its own docstring: "avoiding dependency issues when autobot_shared is used
+independently"). ``autobot-slm-backend/config.py`` is a single file, not a
+package, so ``config.registry`` cannot resolve there at all — every tier
+before ``autobot_shared.ssot_config`` came up empty on that process, and
+`RedisConfig.host`'s dataclass field default froze whatever NetworkConstants
+answered at whichever process imported ``redis_management.config`` first.
+
+Two things had to change together for the 'main' database specifically
+(#12778's tests already cover ``_load_redis_config``'s OTHER tiers — this
+file only adds the new one and the 'main'-specific wiring):
+
+1. ``_ssot_redis_host`` — a new fallback tier in ``_load_redis_config`` that
+   consults ``autobot_shared.ssot_config`` (no ConfigRegistry dependency,
+   works from any process) before finally defaulting to '127.0.0.1'.
+2. ``_init_configurations`` / ``_load_configurations`` — 'main' now takes its
+   host from ``self._config["host"]`` (the resolved chain above) instead of
+   ``RedisConfig.host``'s frozen class-level default, which never went
+   through that chain at all.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_SHARED_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_connection_manager():
+    """Load connection_manager.py standalone (heavy package __init__ chain)."""
+    name = "_cm_14299"
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(
+        name, _SHARED_ROOT / "autobot_shared" / "redis_management" / "connection_manager.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_cm = pytest.importorskip("redis") and _load_connection_manager()
+
+
+def _mgr():
+    return _cm.RedisConnectionManager.__new__(_cm.RedisConnectionManager)
+
+
+@pytest.fixture(autouse=True)
+def _fresh_ssot_config():
+    """``ssot_config.get_config()`` is process-wide ``@lru_cache(maxsize=1)``
+    (#14299) — any test anywhere in the session that already constructed it
+    freezes ``.vm.redis`` for the rest of the process, so an env-var change
+    here would silently do nothing. Clear before AND after so neither a
+    prior test's cache nor this one's env changes leak."""
+    import autobot_shared.ssot_config as ssot_config
+
+    ssot_config.get_config.cache_clear()
+    yield
+    ssot_config.get_config.cache_clear()
+
+
+class TestSsotRedisHostFallback:
+    def test_ssot_config_used_when_network_constants_and_env_both_empty(self, monkeypatch):
+        """The exact SLM-backend shape: config-manager unimportable, no env
+        vars set, NetworkConstants resolves to '' (ConfigRegistry
+        unavailable). ssot_config's own default ('127.0.0.1') must still
+        produce a non-empty, connectable host."""
+        monkeypatch.setattr(_cm, "_get_config_manager", lambda: None)
+        monkeypatch.setattr(_cm.NetworkConstants, "REDIS_VM_IP", "", raising=False)
+        monkeypatch.delenv("REDIS_HOST", raising=False)
+        monkeypatch.delenv("AUTOBOT_REDIS_HOST", raising=False)
+
+        host = _mgr()._load_redis_config()["host"]
+
+        assert host, "host resolved to empty even after the ssot_config fallback (#14299)"
+        assert host.strip() == host, "must already be stripped, not left to the caller"
+
+    def test_ssot_redis_host_defaults_to_loopback_with_nothing_set(self, monkeypatch):
+        """Sanity: with nothing set at all, ssot_config's own field default
+        must be the loopback — the same co-located default every other
+        Ansible-templated component already falls back to."""
+        monkeypatch.delenv("AUTOBOT_REDIS_HOST", raising=False)
+
+        assert _cm.RedisConnectionManager._ssot_redis_host() == "127.0.0.1"
+
+    def test_ssot_config_honours_an_explicit_autobot_redis_host(self, monkeypatch):
+        """ssot_config reads AUTOBOT_REDIS_HOST itself — a deployment that
+        sets it must resolve to the configured value, not the '127.0.0.1'
+        default (distinguishes "genuinely unconfigured" from "configured to
+        something else")."""
+        monkeypatch.setenv("AUTOBOT_REDIS_HOST", "10.0.0.9")
+
+        assert _cm.RedisConnectionManager._ssot_redis_host() == "10.0.0.9"
+
+    def test_ssot_redis_host_never_raises_when_ssot_config_unavailable(self, monkeypatch):
+        """A process where autobot_shared.ssot_config itself cannot import
+        (e.g. pydantic missing) must degrade to '', not propagate — the
+        caller's final `or "127.0.0.1"` is the true last resort."""
+        import builtins
+
+        real_import = builtins.__import__
+
+        def _blocked_import(name, *args, **kwargs):
+            if name == "autobot_shared.ssot_config" or name.startswith("autobot_shared.ssot_config"):
+                raise ImportError("simulated: ssot_config unavailable")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _blocked_import)
+
+        assert _cm.RedisConnectionManager._ssot_redis_host() == ""
+
+    def test_main_database_config_uses_the_resolved_host_not_the_frozen_default(self, monkeypatch):
+        """The actual reported symptom: database='main' specifically. A fresh
+        manager (full __init__) must not carry an empty host for 'main' when
+        every upstream tier is empty and only ssot_config's default answers."""
+        monkeypatch.setattr(_cm, "_get_config_manager", lambda: None)
+        monkeypatch.setattr(_cm.NetworkConstants, "REDIS_VM_IP", "", raising=False)
+        monkeypatch.delenv("REDIS_HOST", raising=False)
+        monkeypatch.delenv("AUTOBOT_REDIS_HOST", raising=False)
+
+        _cm.RedisConnectionManager.reset_instance()
+        try:
+            manager = _cm.RedisConnectionManager()
+            main_config = manager._configs["main"]
+            assert main_config.host, "'main' resolved to an empty host — the exact #14299 symptom"
+        finally:
+            _cm.RedisConnectionManager.reset_instance()


### PR DESCRIPTION
Closes #14299

## Thinking Path

The issue says the `_validate_config_host` message itself is "correct and
actionable — so the defect is not the detection," and asks for three things:
(1) establish why `REDIS_HOST`/`vm.redis` resolves empty on a deployed SLM
backend, (2) stop the "refusing to retry" path from actually retrying/
re-logging every ~2s, (3) get the condition onto a health surface.

**Root cause (1):** traced `_load_redis_config`'s fallback chain. The
`config`-manager tier (`from config import config as cm`) fails silently
under the SLM backend — `autobot-slm-backend/config.py` is a single file, not
a package, exposing `settings`, never `config`. The
`NetworkConstants.REDIS_VM_IP` tier depends on `config.registry.ConfigRegistry`,
which — per that function's own docstring — "lives only in autobot-backend,"
so it *also* silently falls back to its caller's default outside that
package, which for `REDIS_VM_IP` is `""`. Then checked the actually-exercised
path for `database='main'` specifically: `RedisConfig.host`'s dataclass field
default (`host: str = NetworkConstants.REDIS_VM_IP`) is evaluated **once**,
at class-definition/import time — `_load_configurations()` builds `"main"`'s
`default_config` without ever passing `host=`, so it always took that frozen
class-level value, never `_load_redis_config()`'s own resolution. Confirmed
the deployment side too: neither `roles/slm_manager/templates/
autobot-slm-backend.service.j2` nor `slm-secrets.env.j2` ever set
`REDIS_HOST`/`AUTOBOT_REDIS_HOST` — every *other* component role
(`backend`, `npu-worker`, `slm_agent`, `ai-stack`, `tts-worker`) sets its own
`<component>_redis_host` default and env var; `slm_manager` was the one that
never got that treatment.

**The retry storm (2):** `_ensure_async_pool_exists`/`get_async_client` retry
pool creation on every single call once the pool isn't cached, and
`_check_circuit_breaker` resets on a **time-based** timeout (default 60s) —
so a permanent config error cycled: fail every call until 5 failures open the
breaker, log "Circuit breaker opened," wait out the timeout, reset, repeat —
matching "opening the circuit breaker roughly once a minute, indefinitely."

**Health surface (3):** `autobot-slm-backend/api/health.py`'s `/health`
checked only Postgres — Redis was never consulted at all, so an open circuit
breaker on `main` was invisible to the one surface an operator/roll-up
reaches.

## What Changed

`autobot_shared/redis_management/connection_manager.py`:
- New `_ssot_redis_host()` — consults `autobot_shared.ssot_config` (no
  `config.registry` dependency, works from any process) as a fallback tier,
  before a final literal `'127.0.0.1'` loopback default — the same
  co-located default every sibling role already falls back to.
- `_init_configurations`/`_load_configurations`: `"main"`'s `RedisConfig` now
  takes `host=`/`port=` from the resolved `self._config` dict instead of the
  frozen class-level dataclass default.
- `_validate_config_host` (now an instance method — it has to be, to track
  per-database state) + new `_open_circuit_for_config_error`: a config error
  opens the circuit breaker **permanently** (no time-based reset) and logs
  **once**, not on every call. `_check_circuit_breaker`, `_log_pool_task_failure`,
  and both `get_sync_client`/`get_async_client`'s failure paths all check the
  same `_config_broken` set so a repeat never re-derives, re-logs, or
  double-counts the failure — this is what "refusing to retry" now actually
  does. A transient `ConnectionError`'s existing time-based retry/reset
  behaviour is untouched.

`autobot-slm-backend/api/health.py` + `models/schemas.py`:
- `/health` now actively probes the `'main'` Redis database via
  `get_async_redis_client` (same circuit breaker — a config-broken database
  short-circuits immediately, no extra retry source) and reports `redis` on
  `HealthResponse`. `status` degrades when Redis disagrees, even if Postgres
  is fine. On failure, `_check_redis_health` inspects the recorded
  `last_error` and returns a distinguishable
  `"unhealthy: redis configuration error — see backend logs"` instead of a
  bare `"unhealthy"` when the cause was a config error — "cannot resolve" and
  "resolved to nothing configured" no longer read the same at this surface.

`autobot-slm-backend/ansible/roles/slm_manager/`:
- `defaults/main.yml` + `templates/autobot-slm-backend.service.j2`: the SLM
  backend's own unit now sets `REDIS_HOST`/`AUTOBOT_REDIS_HOST` from
  `slm_manager_redis_host` (`redis_host | default('127.0.0.1')`), matching
  every sibling role. This closes the deployment gap directly; the code fix
  above is what makes the running process resilient even without a fresh
  unit render, since Play 1 already restarts the SLM backend on every
  self-update.

## Verification

- `autobot_shared/redis_management/redis_host_ssot_fallback_14299_test.py`
  (new): reproduces the exact reported shape — config-manager unimportable,
  `NetworkConstants.REDIS_VM_IP` empty, no env vars — and asserts the
  resolved host, and specifically `_configs["main"].host` on a fully
  constructed manager, is never empty. Also pins the ssot_config default
  (`'127.0.0.1'`), that an explicit `AUTOBOT_REDIS_HOST` is honoured, and that
  `_ssot_redis_host()` degrades to `""` (never raises) if `ssot_config`
  itself is unimportable.
- `autobot_shared/redis_management/connection_manager_pool_test.py` (updated):
  the four existing `_validate_config_host` tests updated for the new
  instance-method signature (a required, deliberate contract change — a
  staticmethod cannot track per-database "already logged" state). Added
  `test_repeated_empty_host_opens_circuit_once_not_every_call`: 5 calls with
  the same blank host must record exactly **one** failure, not five.
- `autobot-slm-backend/tests/api/test_health_redis_14299.py` (new, real-load
  prologue matching `test_drift_resolve.py`'s pattern since `models.schemas`
  is stubbed by the root conftest and FastAPI validates `response_model` at
  decoration time): distinguishable-message tests exercise **both**
  branches — a config-error `last_error` routes to the distinguishable
  string, a generic connection-failure `last_error` does **not** (verifies
  against the reproduction *and* the case that must stay caught, not just the
  failing one) — plus the endpoint-level invariant that a healthy Postgres
  can no longer mask an unhealthy Redis.

**Mutation evidence — statically traced, not executed** (per the "never run
code from the codebase" policy; CI executes the suite):
- Reverting `_load_configurations`'s `host=self._config["host"]` back to
  omitting `host=` restores the frozen `RedisConfig.host` class default —
  `test_main_database_config_uses_the_resolved_host_not_the_frozen_default`
  goes red the moment `NetworkConstants.REDIS_VM_IP` is empty (traced: the
  class-level default was captured at whatever value existed when
  `redis_management.config` was first imported in the process, independent
  of the per-test monkeypatch).
- Reverting the `if database_name not in self._config_broken:` guard in
  `_validate_config_host` (always call `_open_circuit_for_config_error`)
  makes `_failure_counts["main"]` reach 5 after 5 calls instead of 1 —
  `test_repeated_empty_host_opens_circuit_once_not_every_call` goes red.
- Reverting the `"configuration error" in last_error` branch in
  `_check_redis_health` collapses both
  `test_configuration_error_is_distinguishable_from_generic_unhealthy` and
  `test_generic_connection_failure_stays_the_generic_status` onto the same
  `"unhealthy"` string, failing the first (`!= "unhealthy"` assertion).

## Model Used

Claude Opus 5 (1M context)
