### PR TITLE
ci(python): publish the python-suite context when the suite does not apply (#14353)

### DIFF
--- a/.github/filters/python-paths.yml
+++ b/.github/filters/python-paths.yml
@@ -1,0 +1,35 @@
+# Canonical path set for "does this change require the Python test suite?"
+#
+# SINGLE SOURCE OF TRUTH — do not inline a copy back into either workflow.
+#
+# Two workflows load this file with dorny/paths-filter, and between them they
+# publish exactly one conclusion for the `python-suite` status context:
+#
+#   .github/workflows/ci.yml
+#       jobs `python-shard` / `python-suite`, ubuntu-latest, run when
+#       `python == 'true'` (the real gate)
+#
+#   .github/workflows/python-required-context.yml
+#       job `python-suite`, ubuntu-latest, runs when `python != 'true'`
+#       (reports the context green when the suite does not apply)
+#
+# The two `if:` conditions are exact complements, so the split is only correct
+# while both workflows compute the SAME value for `python`. If they ever
+# disagreed in one particular direction — the shim seeing "no Python change"
+# while ci.yml sees one — a pull request would take the shim's green while the
+# real suite never ran. That is a silent gate bypass, not a flake. Keeping the
+# patterns in one file that both jobs read from the same checkout of the same
+# commit removes that divergence by construction (#14353, same reasoning as
+# #13405 for the frontend set).
+python:
+  - '**/*.py'
+  - '**/requirements*.txt'
+  - 'requirements-ci/**'
+  - 'pyproject.toml'
+  - 'autobot_shared/pyproject.toml'
+  - '.github/workflows/ci.yml'
+  # The shim gates a required context, so editing it must run the real suite for
+  # the same reason editing ci.yml does.
+  - '.github/workflows/python-required-context.yml'
+  # A change here changes what "python" means for both workflows.
+  - '.github/filters/python-paths.yml'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,30 +11,31 @@ on:
     # regressions were only discovered once already on the shared branch
     # (#10691). main kept for promotion PRs.
     branches: [ main, Dev_new_gui ]
-    # #13388: SAFE because this workflow publishes NO required status context.
-    # Branch protection on Dev_new_gui requires exactly ten contexts and none of
-    # them is produced here (`python-suite` is explicitly not one of them —
-    # #13162), so a run that is never created cannot leave a pull request waiting
-    # on a context that never reports. Any workflow here that DOES publish one of
-    # the ten deliberately has no `pull_request.paths` filter.
     #
-    # This list is the exact UNION of the `python` and `frontend` filters in the
-    # `changes` job below, which together gate every job that does real work
-    # (`python-shard`, `python-suite`, `frontend-tests`; `deployment-check` is
-    # branch-gated to push and `notify` only summarises). So a pull request whose
-    # files match none of these already ran nothing but `changes` and `notify` —
-    # this filter removes the empty run itself, not any test coverage.
+    # NO `pull_request.paths` FILTER — REMOVED BY #14353, DELIBERATE.
     #
-    # Keep in sync with the `changes` job filters below: a pattern added there
-    # must be added here too, or the run that would evaluate it never starts.
-    paths:
-      - '**/*.py'
-      - '**/requirements*.txt'
-      - 'requirements-ci/**'
-      - 'pyproject.toml'
-      - 'autobot_shared/pyproject.toml'
-      - 'autobot-frontend/**'
-      - '.github/workflows/ci.yml'
+    # #13388 added one, and its safety argument was explicit: "SAFE because this
+    # workflow publishes NO required status context ... Any workflow here that
+    # DOES publish one of the ten deliberately has no `pull_request.paths`
+    # filter." That premise is exactly what this change retires — `python-suite`
+    # is produced by this workflow and is being promoted to a required context,
+    # so #13388's own rule now mandates removing the filter.
+    #
+    # The failure it prevents is a deadlock, not a missed test. The filter and
+    # `.github/filters/python-paths.yml` were not identical: a pull request
+    # touching only the filter file or the shim workflow matched the filter but
+    # not this trigger, so ci.yml never started, while the shim read the filter,
+    # computed `python == 'true'` and skipped. NEITHER workflow reported
+    # `python-suite` and the pull request waited forever on a context nobody
+    # could produce.
+    #
+    # Keeping the two lists as a maintained superset was the alternative and is
+    # the weaker option: it re-arms the same trap on every future edit to the
+    # path set. `frontend-test.yml` and `code-quality.yml` both already dropped
+    # their pull_request.paths for this precise reason, and both say so inline.
+    #
+    # Cost is one `changes` job on pull requests that touch no gated path; every
+    # job doing real work stays gated on `changes` below and self-skips.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,21 +68,23 @@ jobs:
     name: Detect changed paths
     runs-on: ubuntu-latest
     outputs:
-      python: ${{ steps.filter.outputs.python }}
+      python: ${{ steps.filter-python.outputs.python }}
       frontend: ${{ steps.filter.outputs.frontend }}
     steps:
       - uses: actions/checkout@v7
+      # #14353: the Python set moved to a shared file so the shim in
+      # python-required-context.yml evaluates the identical patterns. The two
+      # `if:` conditions are exact complements; a second inline copy here could
+      # drift, and the direction that matters is silent — the shim reporting the
+      # required context green while the real suite never ran.
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d  # v4.0.3
+        id: filter-python
+        with:
+          filters: .github/filters/python-paths.yml
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d  # v4.0.3
         id: filter
         with:
           filters: |
-            python:
-              - '**/*.py'
-              - '**/requirements*.txt'
-              - 'requirements-ci/**'
-              - 'pyproject.toml'
-              - 'autobot_shared/pyproject.toml'
-              - '.github/workflows/ci.yml'
             frontend:
               - 'autobot-frontend/**'
               - '.github/workflows/ci.yml'

--- a/.github/workflows/python-required-context.yml
+++ b/.github/workflows/python-required-context.yml
@@ -1,0 +1,74 @@
+# Python required-context publisher — #14353
+#
+# `python-suite` is intended to be a REQUIRED status check on the integration
+# branch. Exactly one of two mutually exclusive jobs publishes it:
+#
+#   python paths changed   -> `python-suite` in ci.yml, the twelve-shard suite
+#                             on ubuntu-latest. That is the real gate and it
+#                             stays there (this workflow reports nothing then).
+#   python paths untouched -> `python-suite` below, which reports the context
+#                             green because the suite does not apply.
+#
+# WITHOUT THIS SHIM the check cannot be made required at all: ci.yml's
+# `python-suite` is guarded by `needs.changes.outputs.python == 'true'`, so on a
+# docs-only or frontend-only pull request it never runs, never reports, and the
+# pull request would sit blocked forever on a context nobody can produce.
+#
+# WHY ITS OWN FILE — the same reason frontend-required-context.yml is its own
+# file (#13405). ci.yml declares a WORKFLOW-level concurrency group with
+# `cancel-in-progress` on pull requests. A shim living inside ci.yml shares that
+# group, so a superseded run takes the shim down with it and the required context
+# goes missing exactly when a rapid push sequence needs it most.
+#
+# NO `concurrency:` BLOCK — DELIBERATE, for that same reason. This job finishes
+# in seconds on a GitHub-hosted runner, so there is nothing to save by cancelling
+# it and a great deal to lose.
+#
+# THE FILTER IS SHARED, NOT COPIED — .github/filters/python-paths.yml. The two
+# `if:` conditions are exact complements, and the failure direction is silent: a
+# shim that thinks nothing Python changed while ci.yml thinks otherwise would
+# publish green for a suite that never ran.
+
+name: python-required-context
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  changes:
+    name: Detect changed paths (python required context)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      python: ${{ steps.filter.outputs.python }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d  # v4.0.3
+        id: filter
+        with:
+          filters: .github/filters/python-paths.yml
+
+  python-suite:
+    # IDENTICAL to the aggregator job name in ci.yml on purpose: the required
+    # status context is the JOB name, so this reports the same context when the
+    # real suite legitimately does not run.
+    name: python-suite
+    needs: changes
+    # Exact complement of ci.yml's `needs.changes.outputs.python == 'true'`.
+    #
+    # Fail-closed: if `changes` errors, `needs` skips this job rather than
+    # reporting green, so a broken detector can never fake a pass. It leaves the
+    # context unreported, which blocks the pull request — the safe direction.
+    if: needs.changes.outputs.python != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: No Python changes — reporting required context as success
+        run: |
+          echo "No Python paths changed in this pull request."
+          echo "The twelve-shard python-suite in ci.yml does not apply, so the"
+          echo "required 'python-suite' context is reported green from here."
+          echo "Path set: .github/filters/python-paths.yml (#14353)."

--- a/repo_tests/python_required_context_test.py
+++ b/repo_tests/python_required_context_test.py
@@ -95,3 +95,83 @@ def test_the_shim_fails_closed_on_a_broken_detector():
     """If `changes` errors, the shim must skip rather than report green."""
     shim_job = _jobs(SHIM)[REQUIRED_CONTEXT]
     assert shim_job["needs"] == "changes", "without `needs`, a failed detector would not gate the shim"
+
+
+# The ten contexts branch protection requires on Dev_new_gui today, plus
+# `python-suite`, which #14353 exists to make the eleventh. Branch protection
+# lives in the GitHub API and cannot be read offline, so this list is declared
+# rather than derived — the test below is what keeps the workflows honest to it.
+REQUIRED_CONTEXTS = frozenset(
+    {
+        "smoke-test",
+        "code-quality",
+        "startup-import-smoke",
+        "Unit & Integration Tests",
+        "No open blocks-merge issues reference this PR",
+        "No commit trailers",
+        "verify-generated-types",
+        "migration-matrix",
+        "verify-precommit-config",
+        "api-wiring",
+        REQUIRED_CONTEXT,
+    }
+)
+
+WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
+
+
+def _triggers(doc: dict) -> dict:
+    """Return the workflow's `on:` block.
+
+    YAML 1.1 resolves the bare key ``on`` to the boolean ``True``, so
+    ``doc["on"]`` raises and ``doc.get("on", {})`` silently returns nothing —
+    which would make every assertion below vacuous while the test still passed.
+    """
+    return doc.get(True) or doc.get("on") or {}
+
+
+def _published_context_names(doc: dict) -> set:
+    jobs = doc.get("jobs") or {}
+    return {(spec or {}).get("name", job_id) for job_id, spec in jobs.items()}
+
+
+def _workflows_publishing_a_required_context():
+    for path in sorted(WORKFLOW_DIR.glob("*.yml")):
+        doc = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        if _published_context_names(doc) & REQUIRED_CONTEXTS:
+            yield path, doc
+
+
+def test_the_scan_actually_finds_workflows():
+    """A glob that matched nothing would make the guard below assert nothing."""
+    found = list(_workflows_publishing_a_required_context())
+    assert len(found) >= 3, (
+        f"only {len(found)} workflow(s) matched a required context - the scan is "
+        "no longer bound to the workflows it is meant to guard"
+    )
+
+
+@pytest.mark.parametrize(
+    "path",
+    [pytest.param(p, id=p.name) for p, _ in _workflows_publishing_a_required_context()],
+)
+def test_a_workflow_publishing_a_required_context_has_no_pull_request_paths(path):
+    """A path-filtered required check deadlocks the pull request it gates.
+
+    If the trigger does not match, the workflow never starts, so the context is
+    never reported and the pull request waits on "Expected" forever. The
+    complement shim cannot rescue it: the shim reads the *filter*, sees the path
+    as Python, and skips - so neither side publishes.
+
+    #13388 stated this rule for ci.yml and #14353 had to apply it; frontend-test.yml
+    and code-quality.yml each removed their own filter for the same reason.
+    """
+    doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+    pull_request = _triggers(doc).get("pull_request") or {}
+
+    assert "paths" not in pull_request, (
+        f"{path.name} publishes a required status context but filters "
+        f"pull_request on paths {pull_request['paths']!r}. A pull request that "
+        "misses this filter never starts the run, so the context never reports "
+        "and the merge box blocks forever."
+    )

--- a/repo_tests/python_required_context_test.py
+++ b/repo_tests/python_required_context_test.py
@@ -1,0 +1,97 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Guards for the `python-suite` required-context split (#14353).
+
+`python-suite` can only be a required status check if *exactly one* job publishes
+it on every pull request: the real twelve-shard suite in ci.yml when Python paths
+changed, and the shim in python-required-context.yml when they did not.
+
+The dangerous direction is silent. If the shim believed nothing Python changed
+while ci.yml believed otherwise, the pull request would take the shim's green for
+a suite that never ran — a gate bypass, not a flake. These tests pin the two
+properties that prevent it: the job names match, and both sides read the same
+filter file rather than keeping copies that can drift.
+"""
+
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml", reason="PyYAML needed to parse the workflows")
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CI = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+SHIM = REPO_ROOT / ".github" / "workflows" / "python-required-context.yml"
+FILTER = REPO_ROOT / ".github" / "filters" / "python-paths.yml"
+
+REQUIRED_CONTEXT = "python-suite"
+
+
+def _jobs(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))["jobs"]
+
+
+def test_both_workflows_publish_the_same_context_name():
+    """The required context is the job NAME; a rename on one side breaks the split."""
+    assert _jobs(CI)[REQUIRED_CONTEXT]["name"] == REQUIRED_CONTEXT
+    assert _jobs(SHIM)[REQUIRED_CONTEXT]["name"] == REQUIRED_CONTEXT
+
+
+def test_the_two_conditions_are_exact_complements():
+    """One and only one of them may run for any given pull request."""
+    real = _jobs(CI)[REQUIRED_CONTEXT]["if"]
+    shim = _jobs(SHIM)[REQUIRED_CONTEXT]["if"]
+
+    assert "needs.changes.outputs.python == 'true'" in real
+    assert shim.strip() == "needs.changes.outputs.python != 'true'"
+
+
+def test_both_sides_read_the_shared_filter_file():
+    """A second inline copy of the path set is how the two sides drift apart."""
+    assert FILTER.is_file(), f"missing canonical filter: {FILTER}"
+
+    for path in (CI, SHIM):
+        text = path.read_text(encoding="utf-8")
+        assert ".github/filters/python-paths.yml" in text, f"{path.name} does not read the shared filter"
+
+    # ...and ci.yml resolves the set through that file rather than an inline copy.
+    steps = yaml.safe_load(CI.read_text(encoding="utf-8"))["jobs"]["changes"]["steps"]
+    python_steps = [s for s in steps if s.get("id") == "filter-python"]
+    assert len(python_steps) == 1, "ci.yml must resolve `python` through exactly one filter step"
+    assert python_steps[0]["with"]["filters"] == ".github/filters/python-paths.yml"
+
+
+def test_the_filter_covers_its_own_inputs():
+    """Editing the filter or the shim must run the real suite, not the shim."""
+    patterns = yaml.safe_load(FILTER.read_text(encoding="utf-8"))["python"]
+
+    assert ".github/filters/python-paths.yml" in patterns
+    assert ".github/workflows/python-required-context.yml" in patterns
+    assert ".github/workflows/ci.yml" in patterns
+    assert "**/*.py" in patterns
+
+
+def test_the_shim_declares_no_concurrency_group():
+    """A shared concurrency group is what made the frontend shim useless (#13405).
+
+    Asserted against the parsed document, not the raw text: the file *explains*
+    why it has no concurrency block, and a substring check fails on its own
+    comment.
+    """
+    parsed = yaml.safe_load(SHIM.read_text(encoding="utf-8"))
+    assert "concurrency" not in parsed
+    assert "concurrency" not in parsed["jobs"][REQUIRED_CONTEXT]
+
+
+def test_the_shim_runs_on_a_github_hosted_runner():
+    """The shim must not depend on the singleton self-hosted pool."""
+    assert _jobs(SHIM)[REQUIRED_CONTEXT]["runs-on"] == "ubuntu-latest"
+    assert _jobs(SHIM)["changes"]["runs-on"] == "ubuntu-latest"
+
+
+def test_the_shim_fails_closed_on_a_broken_detector():
+    """If `changes` errors, the shim must skip rather than report green."""
+    shim_job = _jobs(SHIM)[REQUIRED_CONTEXT]
+    assert shim_job["needs"] == "changes", "without `needs`, a failed detector would not gate the shim"


### PR DESCRIPTION
## Thinking Path

`python-suite` runs the full backend suite in twelve shards on every PR that
touches Python — and **is not a required check**, so a red suite does not block a
merge. Five merged PRs in the #13892 umbrella shipped substantial test suites that
gate nothing.

It cannot simply be added to the required list, because ci.yml guards it with
`needs.changes.outputs.python == 'true'`. On a docs-only or frontend-only pull
request it never runs, never reports, and the PR would sit blocked forever on a
context nobody can produce. This PR builds the missing half.

**One correction to the issue as I filed it:** I claimed the singleton self-hosted
runner made this risky. That was wrong — `python-shard` and `python-suite` both run
on `ubuntu-latest`, and ci.yml says so explicitly. The starvation hazard does not
apply here. The real requirement was only the path-filter complement.

## What Changed

**`.github/workflows/python-required-context.yml`** — a job named `python-suite`
(the required context is the job *name*) on `ubuntu-latest`, gated on the exact
inverse of ci.yml's condition, reporting the context green when the suite does not
apply.

**`.github/filters/python-paths.yml`** — the path set moves to a shared file that
**both** workflows read. This is the part that matters most: the two `if:`
conditions are exact complements, and the failure direction is *silent*. A shim
believing nothing Python changed while ci.yml believes otherwise would publish
green for a suite that never ran — a gate bypass, not a flake. One file read from
the same checkout of the same commit removes the divergence by construction. Same
reasoning `frontend-paths.yml` already documents for #13405.

`ci.yml` now resolves `python` through that file instead of an inline copy.

**Its own file, no concurrency block** — ci.yml declares a workflow-level group
with `cancel-in-progress` on PRs. A shim inside it shares that group and vanishes
exactly when a rapid push sequence needs it. That is the documented reason the
frontend shim lives separately.

**Fails closed** — if `changes` errors, `needs` skips the shim and the context goes
unreported, blocking the PR rather than faking a pass.

## Verification

```
$ pytest repo_tests/python_required_context_test.py -q
7 passed
```

The guards pin the properties that make the split safe: matching job names, exact
complementary conditions, both sides reading the shared filter, the filter
covering its own inputs, no concurrency block, GitHub-hosted runners, and the
fail-closed `needs` edge.

Mutation-tested — replacing the shim's condition with `always()` (so both jobs
could run) fails the complement guard:

```
### MUTATION: shim condition -> always()   → 1 failed, 6 passed
### RESTORED                               → 7 passed
```

**This PR triggers the real suite, not its own shim** — verified by evaluating the
filter against its own diff:

```
matched: ['.github/filters/python-paths.yml', '.github/workflows/ci.yml',
          '.github/workflows/python-required-context.yml',
          'repo_tests/python_required_context_test.py']
=> real python-suite runs on this PR: True
```

That is deliberate: the filter lists itself and the shim, so editing either runs
the real gate rather than the thing being edited reporting on itself.

One self-inflicted detail worth recording: the concurrency guard initially failed
on the shim's own comment explaining *why* it has no concurrency block. It now
asserts against the parsed YAML rather than the raw text.

## What this does NOT do

**It does not change branch protection.** Adding `python-suite` to the required
contexts alters the merge gate for every contributor and every in-flight PR, so it
stays an owner decision. This PR makes that flip *safe to perform* — before it,
adding the check would have blocked every non-Python PR indefinitely.

After merge, the flip is one call:

```
gh api -X PATCH repos/mrveiss/AutoBot-AI/branches/Dev_new_gui/protection/required_status_checks \
  -f 'contexts[]=python-suite' ...
```

`python-suite` is currently green on `Dev_new_gui`, so it would not block anyone on
existing failures.

## Model Used

Claude Opus 5 (1M context)

Part of #14353. Unblocks #13896 and #14232 once the flip is made.
