### PR TITLE
ci(deploy): extend generated-types auto-fix to the SLM frontend (#14368)

### DIFF
--- a/.github/workflows/auto-fix-generated-types.yml
+++ b/.github/workflows/auto-fix-generated-types.yml
@@ -6,6 +6,17 @@
 # environment the gate uses and commits it back to the PR branch — self-healing
 # the recurring drift (#10817). Runs on GitHub-hosted runners so it never
 # competes with the self-hosted runner.
+#
+# #14368: autobot-slm-frontend carries the identical drift risk (verified by
+# `verify-generated-types-slm`, the SLM sibling of the required gate above)
+# but had no auto-fix, so an SLM schema change simply reddened and the author
+# had to regenerate by hand — which needs a locally-running SLM app, something
+# contributors and agents cannot do in this repo. The steps below reuse the
+# EXACT recipe `verify-generated-types-slm` runs (scripts/audit_api_wiring.py
+# --dump-slm-openapi against autobot-slm-backend/main.py's `app`), so the two
+# cannot drift apart. They stay in this one job, not a second parallel one:
+# one push, one commit, one `approve-parked-runs` follow-up, matching the
+# backend shape exactly instead of forking a second push/approve pair.
 
 name: Auto-fix Generated Types
 
@@ -16,6 +27,14 @@ on:
       - 'autobot-backend/**/*.py'
       - 'autobot_shared/**/*.py'
       - 'autobot-frontend/src/types/generated/api.ts'
+      # #14368: SLM backend changes can alter the OpenAPI schema
+      # autobot-slm-frontend's openapi.json + api.ts are generated from.
+      # openapi.json (unlike the backend's, which is an ephemeral CI temp
+      # file never committed) IS a checked-in artifact here, so it is watched
+      # too — a hand-edit or bad merge of it must also trigger the fix-back.
+      - 'autobot-slm-backend/**/*.py'
+      - 'autobot-slm-frontend/openapi.json'
+      - 'autobot-slm-frontend/src/types/generated/api.ts'
       - '.github/workflows/auto-fix-generated-types.yml'
 
 concurrency:
@@ -57,6 +76,7 @@ jobs:
           cache-dependency-path: |
             requirements*.txt
             autobot-backend/requirements*.txt
+            autobot-slm-backend/requirements.txt
 
       - name: Install backend dependencies
         run: |
@@ -81,7 +101,9 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
-          cache-dependency-path: autobot-frontend/package-lock.json
+          cache-dependency-path: |
+            autobot-frontend/package-lock.json
+            autobot-slm-frontend/package-lock.json
 
       - name: Install frontend dependencies
         working-directory: autobot-frontend
@@ -96,30 +118,89 @@ jobs:
         working-directory: autobot-frontend
         run: npx --no-install openapi-typescript ../openapi.json -o src/types/generated/api.ts --additional-properties
 
+      - name: Set up isolated venv for SLM backend dependencies
+        # #14368: autobot-slm-backend/requirements.txt pins its own
+        # fastapi/pydantic/starlette range plus packages the backend never
+        # imports (croniter, authlib, ldap3, pysaml2, pyotp, bcrypt,
+        # PyJWT[crypto], ...) — the same reason `verify-generated-types-slm`
+        # runs as a separate job from `verify-types-run` rather than sharing
+        # its environment. A venv gets the same isolation here without a
+        # second job, so this stays the one push/approve pair the backend
+        # already has.
+        run: python -m venv .venv-slm
+
+      - name: Install SLM backend dependencies
+        run: |
+          .venv-slm/bin/python -m pip install --upgrade pip setuptools wheel
+          .venv-slm/bin/python -m pip install -r autobot-slm-backend/requirements.txt --prefer-binary
+
+      - name: Dump authoritative SLM OpenAPI schema
+        run: |
+          set -o pipefail
+          mkdir -p data logs static config autobot-slm-backend/data
+          export PYTHONPATH="$PWD:$PWD/autobot-slm-backend:${PYTHONPATH:-}"
+          if ! .venv-slm/bin/python scripts/audit_api_wiring.py --dump-slm-openapi slm_openapi.raw.json; then
+            echo "::error::SLM backend app.openapi() build failed — cannot regenerate types (see startup-import-smoke)."
+            exit 1
+          fi
+          # Same recipe as verify-generated-types-slm: strip the audit-only
+          # x-websocket-paths extension and write with the exact formatting
+          # (indent=2, sort_keys, trailing newline) `npm run gen:types:openapi`
+          # produces locally, so the two can never disagree on the diff.
+          .venv-slm/bin/python -c "
+          import json
+          s = json.load(open('slm_openapi.raw.json'))
+          s.pop('x-websocket-paths', None)
+          with open('autobot-slm-frontend/openapi.json', 'w', encoding='utf-8') as f:
+              json.dump(s, f, indent=2, sort_keys=True, ensure_ascii=False)
+              f.write('\n')
+          "
+
+      - name: Install SLM frontend dependencies
+        working-directory: autobot-slm-frontend
+        run: npm ci
+
+      - name: Regenerate SLM api.ts from authoritative schema
+        working-directory: autobot-slm-frontend
+        run: npx --no-install openapi-typescript openapi.json -o src/types/generated/api.ts --additional-properties
+
       - name: Commit regenerated types if drifted
         run: |
-          rm -f openapi.raw.json openapi.json
+          rm -f openapi.raw.json openapi.json slm_openapi.raw.json
+          rm -rf .venv-slm
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add autobot-frontend/src/types/generated/api.ts
+          git add autobot-frontend/src/types/generated/api.ts \
+            autobot-slm-frontend/openapi.json \
+            autobot-slm-frontend/src/types/generated/api.ts
           if git diff --staged --quiet; then
             echo "Generated types already fresh — nothing to commit."
           else
             git commit -m "$(cat <<'EOF'
-          chore(types): regenerate api.ts from backend OpenAPI schema
+          chore(types): regenerate generated API types from OpenAPI schema(s)
 
-          Auto-regenerated (py3.14) to match the backend schema so the required
-          verify-generated-types gate passes. Triggered by auto-fix-generated-types.yml.
+          Auto-regenerated (py3.14) to match the backend and/or SLM backend
+          schema so the required verify-generated-types gate(s) pass.
+          Triggered by auto-fix-generated-types.yml.
           EOF
           )"
             git push
-            echo "✅ api.ts regenerated and pushed to the PR branch."
+            # This push only touches api.ts / openapi.json, the exact paths
+            # this workflow's own `on.pull_request.paths` filter watches, so
+            # it DOES retrigger a new run on the branch. That rerun repeats
+            # the same regeneration, finds the tree already fresh (the diff
+            # below is empty), and takes the "nothing to commit" branch above
+            # instead of pushing again — the loop terminates in two runs, the
+            # same self-limiting shape the backend-only version already had.
+            echo "✅ Generated types regenerated and pushed to the PR branch."
           fi
 
   # #14311: identical parking defect as auto-fix-formatting.yml — see the
   # comment on that workflow's `approve-parked-runs` job for the full
   # explanation. This job repairs it here too, since `autofix-types` pushes
-  # with the same bot identity and fork-safety constraints.
+  # with the same bot identity and fork-safety constraints. #14368 added
+  # SLM steps into `autofix-types` itself rather than a second job, so this
+  # approval job's `needs`/guard are unchanged — one push, one approval.
   approve-parked-runs:
     needs: autofix-types
     if: github.event.pull_request.head.repo.full_name == github.repository

--- a/repo_tests/auto_fix_generated_types_coverage_test.py
+++ b/repo_tests/auto_fix_generated_types_coverage_test.py
@@ -1,0 +1,124 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Auto-fix must cover every artifact the verify gate checks (#14368).
+
+`verify-generated-types.yml` runs TWO independent freshness checks:
+`verify-types-run` diffs the backend's `autobot-frontend/src/types/generated/api.ts`,
+and `verify-generated-types-slm` diffs the SLM backend's
+`autobot-slm-frontend/openapi.json` + `.../src/types/generated/api.ts`. Before
+#14368, `auto-fix-generated-types.yml` only regenerated and committed the
+first of those three files — an SLM schema change turned
+`verify-generated-types-slm` red with no self-heal, and the author had to
+regenerate by hand against a locally-running SLM app (something contributors
+and agents cannot do in this repo).
+
+Asserting the STRING `autobot-slm-frontend` appears somewhere in the workflow
+would pass on a comment, a trigger path with no matching commit step, or a
+commit step that stages the wrong file. This file instead derives the
+artifact set straight from the verify gate's own `git diff --exit-code`
+invocations -- the actual thing that goes red -- and asserts the auto-fix
+workflow's commit step stages every one of them, plus that the trigger paths
+can actually fire it for the SLM source tree.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+_WORKFLOWS_DIR = Path(__file__).resolve().parents[1] / ".github" / "workflows"
+_VERIFY = _WORKFLOWS_DIR / "verify-generated-types.yml"
+_AUTOFIX = _WORKFLOWS_DIR / "auto-fix-generated-types.yml"
+
+# `git diff --exit-code <path> [<path> ...]` inside a `run:` block -- the exact
+# invocation that decides whether a verify job goes red. Stops at `;`/newline
+# so the trailing `; then` from the enclosing `if ! git diff ... ; then` is not
+# swept into the path list.
+_DIFF_INVOCATION = re.compile(r"git diff --exit-code ([^\n;]+)")
+
+
+def _verify_checked_artifacts() -> set[str]:
+    """Every file path any `verify-generated-types.yml` job diffs for drift."""
+    text = _VERIFY.read_text(encoding="utf-8")
+    artifacts: set[str] = set()
+    for match in _DIFF_INVOCATION.finditer(text):
+        artifacts.update(match.group(1).split())
+    return artifacts
+
+
+def _autofix_committed_artifacts() -> set[str]:
+    """Every file path `auto-fix-generated-types.yml` stages in its commit step."""
+    document = yaml.safe_load(_AUTOFIX.read_text(encoding="utf-8"))
+    commit_step = next(
+        step
+        for step in document["jobs"]["autofix-types"]["steps"]
+        if step.get("name") == "Commit regenerated types if drifted"
+    )
+    run = commit_step["run"]
+    match = re.search(r"git add ([^\n]+(?:\n\s+[^\n]+)*)", run)
+    assert match, "commit step has no `git add` -- nothing would ever be pushed back"
+    # `git add a b \\\n  c` across a YAML block scalar -- collapse the
+    # continuation whitespace the same way the shell would.
+    return set(match.group(1).replace("\\", " ").split())
+
+
+def _autofix_trigger_paths() -> list[str]:
+    document = yaml.safe_load(_AUTOFIX.read_text(encoding="utf-8"))
+    return document[True]["pull_request"]["paths"]
+
+
+def test_the_scan_actually_found_artifacts_on_both_sides():
+    """Empty sets would make every assertion below vacuously true."""
+    assert len(_verify_checked_artifacts()) >= 3
+    assert len(_autofix_committed_artifacts()) >= 3
+
+
+def test_every_artifact_the_verify_gate_checks_is_committed_by_the_autofix():
+    """The invariant: nothing verify diffs can go stale with no self-heal path."""
+    checked = _verify_checked_artifacts()
+    committed = _autofix_committed_artifacts()
+
+    missing = checked - committed
+    assert missing == set(), (
+        f"verify-generated-types.yml diffs {missing} for freshness, but "
+        "auto-fix-generated-types.yml never stages it -- a drift there goes "
+        "red with no auto-fix, the exact #14368 gap for the SLM frontend"
+    )
+
+
+def test_the_slm_backend_source_tree_can_actually_trigger_the_autofix():
+    """A commit step that stages the right file is still dead code if nothing
+    in `on.pull_request.paths` ever fires the job for an SLM schema change."""
+    paths = _autofix_trigger_paths()
+    assert "autobot-slm-backend/**/*.py" in paths, (
+        "auto-fix-generated-types.yml's pull_request.paths does not watch "
+        "autobot-slm-backend sources -- an SLM schema change would never "
+        "trigger this workflow at all"
+    )
+
+
+def test_dropping_the_slm_commit_paths_is_caught_by_the_invariant():
+    """The mutation this file exists to catch, applied to the extracted data
+    rather than the file on disk: reproduce the pre-#14368 auto-fix (which
+    committed only the backend api.ts) and confirm the coverage assertion
+    above would have failed against it.
+
+    Statically traced, not executed as a second pytest run against a mutated
+    workflow file -- this repo's task rules forbid running the test suite
+    locally; CI is what executes this file for real.
+    """
+    checked = _verify_checked_artifacts()
+    pre_14368_committed = {"autobot-frontend/src/types/generated/api.ts"}
+
+    missing = checked - pre_14368_committed
+    assert missing == {
+        "autobot-slm-frontend/openapi.json",
+        "autobot-slm-frontend/src/types/generated/api.ts",
+    }, (
+        "the pre-#14368 auto-fix commit-step artifact set should be reported "
+        f"as missing exactly the two SLM files; got {missing}"
+    )


### PR DESCRIPTION
Closes #14368

## Thinking Path

`verify-generated-types-slm` was blocking PR #14401 with a stale `autobot-slm-frontend/openapi.json` + `api.ts` diff, and no auto-fix existed for it — `auto-fix-generated-types.yml` only regenerated the backend's `autobot-frontend/src/types/generated/api.ts`. Read `verify-generated-types.yml`'s `verify-generated-types-slm` job to get the authoritative recipe (`scripts/audit_api_wiring.py --dump-slm-openapi` against `autobot-slm-backend/main.py`'s `app`, then `openapi-typescript`), then extended `auto-fix-generated-types.yml`'s existing single `autofix-types` job with the same steps rather than forking a second workflow or a second job pair — one push, one commit, one `approve-parked-runs` follow-up, matching the backend shape exactly.

The one real design decision was dependency isolation: `autobot-slm-backend/requirements.txt` pins packages (`croniter`, `authlib`, `ldap3`, `pysaml2`, `pyotp`, `bcrypt`, `PyJWT[crypto]`, its own `fastapi`/`pydantic`/`starlette` range) that `requirements-ci.txt` (already installed earlier in the same job for the backend dump) doesn't carry, and installing both into one shared environment risks a `pip` resolver conflict that could break the *already-completed* backend step for an unrelated reason. `verify-generated-types.yml` sidesteps this by running the SLM check as a wholly separate job; a fresh `python -m venv .venv-slm` gets the same isolation here without adding a second job (and therefore without touching `approve-parked-runs`'s `needs:`/guard at all).

## What Changed

- `.github/workflows/auto-fix-generated-types.yml`:
  - `on.pull_request.paths` now also watches `autobot-slm-backend/**/*.py`, `autobot-slm-frontend/openapi.json`, and `autobot-slm-frontend/src/types/generated/api.ts` (the SLM `openapi.json` is a committed artifact here, unlike the backend's ephemeral one, so a hand-edit of it is watched too).
  - `autofix-types` gained: `python -m venv .venv-slm` + install `autobot-slm-backend/requirements.txt` into it, dump the authoritative SLM OpenAPI schema via `scripts/audit_api_wiring.py --dump-slm-openapi` (identical strip/format recipe to `verify-generated-types-slm`, so the two cannot drift apart), `npm ci` in `autobot-slm-frontend`, and regenerate its `api.ts`.
  - The commit step now stages `autobot-slm-frontend/openapi.json` and `autobot-slm-frontend/src/types/generated/api.ts` alongside the existing `autobot-frontend/src/types/generated/api.ts`, and cleans up the venv and the SLM temp dump file.
  - `approve-parked-runs` is untouched: still `needs: autofix-types` (singular), still the exact same fork guard — no new job was added, so there was nothing to rewire.
- `repo_tests/auto_fix_generated_types_coverage_test.py` (new): guard test for the coverage invariant (see Verification).

## Verification

**Trigger and path filter that fires the SLM job:** `pull_request` on this repo (any base branch, since this workflow has no `branches:` filter), path filter `autobot-slm-backend/**/*.py` (or `autobot-slm-frontend/openapi.json`, `autobot-slm-frontend/src/types/generated/api.ts`, or the workflow file itself). Confirmed by parsing the committed YAML:
```
$ python3 -c "import yaml; d=yaml.safe_load(open('.github/workflows/auto-fix-generated-types.yml')); print(d[True]['pull_request']['paths'])"
['autobot-backend/**/*.py', 'autobot_shared/**/*.py', 'autobot-frontend/src/types/generated/api.ts',
 'autobot-slm-backend/**/*.py', 'autobot-slm-frontend/openapi.json', 'autobot-slm-frontend/src/types/generated/api.ts',
 '.github/workflows/auto-fix-generated-types.yml']
```
Once triggered, the single `autofix-types` job runs unconditionally (no per-language `changes` gate, matching the pre-existing backend-only shape) — the SLM steps just find nothing staged and skip the commit when only backend paths changed.

**Fork-safety argument:** the job carries the exact same `if: github.event.pull_request.head.repo.full_name == github.repository` guard it had before this PR — untouched, not rewritten — because the SLM steps were added to the *same* job rather than a new one. A fork PR's run therefore skips the entire job, SLM steps included, before any checkout or push happens; there is no new code path a fork PR can reach. `approve-parked-runs` is likewise untouched (`needs: autofix-types`, same guard), so its own fork-safety argument (proven by the pre-existing `repo_tests/auto_fix_bot_push_approval_test.py`) still holds without modification. No `github.event.*` text is interpolated into any `run:` step.

**SLM dependencies:** yes, needed — `autobot-slm-backend/requirements.txt` was installed into an isolated `.venv-slm` rather than reused from the backend's environment, specifically to avoid a `pip` resolver conflict with `requirements-ci.txt` (comparable to #14300 adding `bcrypt`/`PyJWT[crypto]` to the migration gate for the same reason). Confirmed `autobot-slm-backend/requirements.txt` already declares `bcrypt>=5.0.0` and `PyJWT[crypto]>=2.13.0` itself, so no extra packages beyond that file were required.

**Guard test — asserts the invariant, not the string:** `repo_tests/auto_fix_generated_types_coverage_test.py` derives the artifact set straight from `verify-generated-types.yml`'s own `git diff --exit-code <path...>` invocations (the exact thing that goes red) and asserts the auto-fix workflow's commit step stages every one of them — not merely that `autobot-slm-frontend` appears in the file. Statically traced (module loaded and its functions called directly via `importlib`, not `pytest` — this task's rules forbid running the test suite locally; CI executes it for real):
```
checked:   {'autobot-frontend/src/types/generated/api.ts', 'autobot-slm-frontend/openapi.json', 'autobot-slm-frontend/src/types/generated/api.ts'}
committed: {'autobot-frontend/src/types/generated/api.ts', 'autobot-slm-frontend/openapi.json', 'autobot-slm-frontend/src/types/generated/api.ts'}
-> all 4 test functions passed
```
**Mutation check — executed against a throwaway copy, not the tracked file:** copied the workflow to a scratch path, removed the two SLM lines from the `git add` in the copy, and re-ran the same extraction/comparison logic against it:
```
missing: {'autobot-slm-frontend/openapi.json', 'autobot-slm-frontend/src/types/generated/api.ts'}
GUARD WOULD FAIL RED — confirmed against the mutated copy
```
`test_dropping_the_slm_commit_paths_is_caught_by_the_invariant` in the same file pins this as a permanent regression check (reproduces the pre-#14368 commit-step artifact set as a literal and asserts the same two files are reported missing), so this isn't a one-off manual check.

Also confirmed the pre-existing `repo_tests/auto_fix_bot_push_approval_test.py` (the #14311 approval-job invariants) still passes unchanged, since the job id `autofix-types` and `approve-parked-runs`'s `needs`/guard were not touched.

## Model Used

Claude Sonnet 5
