### PR TITLE
security(llc): require auth and tenant scoping on POST/GET /api/llc/work-items (#14168)

### DIFF
--- a/autobot-backend/llc/api/work_items.py
+++ b/autobot-backend/llc/api/work_items.py
@@ -39,7 +39,7 @@ from api.user_management.dependencies import get_current_user, require_org_conte
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_async_redis_client
 from autobot_shared.singleton_factory import lazy_singleton
-from llc.deps import get_session, service_dep
+from llc.deps import assert_company_access, get_session, service_dep
 from models.agent_org import AgentOrgNode
 from user_management.models.user import User
 from user_management.services import TenantContext
@@ -92,18 +92,23 @@ class HumanUnclaimRequest(BaseModel):
 
 
 class CoworkerRequest(BaseModel):
-    """Set or clear a co-worker on a work item (GH#8230).
-    To clear the co-worker, omit co_worker_type (or send null).
-    The caller's role is resolved server-side from the auth context — not supplied
-    by the client (GH#8516: removed client-supplied caller_role to prevent privilege escalation).
+    """Set or clear a co-worker on a work item (GH#8230, GH#8516, GH#8583, #14168).
+
+    To clear the co-worker, omit co_worker_type (or send null). Both the
+    caller's role and the company scope are resolved server-side from the
+    authenticated org context — never supplied by the client. GH#8516/
+    GH#8583 removed client-supplied ``caller_role`` to prevent privilege
+    escalation; #14168 removed client-supplied ``company_id`` for the same
+    reason — it was used unvalidated to resolve the caller's role, letting a
+    caller impersonate a role held in a company other than the one owning
+    the work item. ``actor_agent_id``/``actor_user_id`` were likewise
+    removed — the acting identity comes from the authenticated session, not
+    the request body, so the audit trail cannot be spoofed.
     """
 
-    company_id: str
     co_worker_type: Optional[str] = None
     co_worker_agent_id: Optional[str] = None
     co_worker_user_id: Optional[str] = None
-    actor_agent_id: Optional[str] = None
-    actor_user_id: Optional[str] = None
 
 
 logger = get_logger(__name__)
@@ -411,7 +416,12 @@ async def _item_to_dict(item: Any, session: AsyncSession) -> Dict[str, Any]:
 async def create_work_item(
     body: WorkItemCreate,
     session: AsyncSession = Depends(get_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> Dict[str, Any]:
+    # Tenant guard (#14168): reject cross-tenant creation before touching the DB —
+    # body.company_id is client-controlled and must match the caller's authenticated org.
+    assert_company_access(ctx, body.company_id)
     try:
         item = await _service().create(
             session,
@@ -457,7 +467,16 @@ async def list_work_items(
     limit: int = Query(100, ge=1, le=500),
     offset: int = Query(0, ge=0),
     session: AsyncSession = Depends(get_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> List[Dict[str, Any]]:
+    # Tenant guard (#14168): the ``company_id`` query param is client-controlled;
+    # require_org_context already membership-checks it when it is the sole org
+    # source, but a caller can still supply a different, still-valid
+    # ``X-Organization-Id`` header alongside a foreign ``company_id`` query
+    # value (header wins in get_tenant_context's precedence). Reject any
+    # mismatch explicitly rather than relying on precedence order.
+    assert_company_access(ctx, company_id)
     items = await _service().list_by_project(
         session,
         company_id=company_id,
@@ -728,52 +747,63 @@ async def unclaim_work_item(
         raise HTTPException(status_code=400, detail="Internal server error")
 
 
-class CoWorkerSetRequest(BaseModel):
-    """Set co-worker on a work item (GH#8230).
-
-    caller_role is resolved server-side from auth context — not supplied
-    by the client (GH#8583: removed client-supplied caller_role to prevent privilege escalation).
-    """
-
-    co_worker_type: str
-    company_id: str
-    co_worker_agent_id: Optional[str] = None
-    co_worker_user_id: Optional[str] = None
-    actor_id: Optional[str] = None
-
-
-class CoWorkerClearRequest(BaseModel):
-    company_id: str
-    actor_id: Optional[str] = None
-
-
 @router.post("/{work_item_id}/coworker", status_code=200)
 async def set_coworker(
     work_item_id: str,
-    body: CoWorkerSetRequest,
+    body: CoworkerRequest,
     session: AsyncSession = Depends(get_session),
     current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> Dict[str, Any]:
-    """Set co-worker fields for a work item (GH#8230, GH#8517, GH#8583).
+    """Set or clear co-worker fields for a work item (GH#8230, GH#8517, GH#8583, #14168).
 
-    Returns 404 when the work item is not found, 403 when the caller lacks
-    permission, and 422 for invalid co-worker identity values.
+    Omit ``co_worker_type`` (or send null) to clear the co-worker.
+
+    Returns 404 when the work item is not found or belongs to a different
+    org (#14168 IDOR guard — checked against the caller's authenticated org,
+    never client input), 403 when the caller lacks permission, and 422 for
+    invalid co-worker identity values.
+
+    This used to be two separate routes registered on the same path/method
+    (the second, unauthenticated one — ``set_or_clear_coworker`` — was
+    unreachable dead code shadowed by this one, but a live landmine: it
+    hard-coded ``caller_role="owner"`` and trusted a client-supplied
+    ``company_id`` with zero tenant check). Consolidated into one canonical,
+    authenticated, tenant-scoped handler (#14168).
     """
     actor_id = current_user.get("user_id") or current_user.get("agent_id") or current_user.get("id")
     if not actor_id:
         raise HTTPException(status_code=401, detail="Not authenticated")
+    # IDOR guard (#14168): verify the item belongs to the caller's org before
+    # mutating or resolving a role for it.
+    existing = await _service().get(session, work_item_id)
+    if existing is None or str(existing.company_id) != str(ctx.org_id):
+        raise HTTPException(status_code=404, detail="Work item not found")
+    company_id = str(ctx.org_id)
+    actor_type = "user" if current_user.get("user_id") else "agent"
     try:
-        caller_role = await resolve_actor_role(session, actor_id, body.company_id)
-        item = await _service().enable_coworking(
-            session,
-            work_item_id=work_item_id,
-            co_worker_type=body.co_worker_type,
-            company_id=body.company_id,
-            co_worker_agent_id=body.co_worker_agent_id,
-            co_worker_user_id=body.co_worker_user_id,
-            actor_id=actor_id,
-            caller_role=caller_role,
-        )
+        caller_role = await resolve_actor_role(session, actor_id, company_id)
+        if body.co_worker_type:
+            item = await _service().enable_coworking(
+                session,
+                work_item_id=work_item_id,
+                co_worker_type=body.co_worker_type,
+                company_id=company_id,
+                co_worker_agent_id=body.co_worker_agent_id,
+                co_worker_user_id=body.co_worker_user_id,
+                actor_id=actor_id,
+                actor_type=actor_type,
+                caller_role=caller_role,
+            )
+        else:
+            item = await _service().disable_coworking(
+                session,
+                work_item_id=work_item_id,
+                company_id=company_id,
+                actor_id=actor_id,
+                actor_type=actor_type,
+                caller_role=caller_role,
+            )
         await session.commit()
         return await _item_to_dict(item, session)
     except CoWorkingPermissionError as exc:
@@ -994,58 +1024,6 @@ async def get_handoff_brief(
     except ValueError as exc:
         logger.error("Exception in API handler: %s", exc, exc_info=True)
         raise HTTPException(status_code=404, detail="Internal server error")
-
-
-@router.post("/{work_item_id}/coworker", status_code=200)
-async def set_or_clear_coworker(
-    work_item_id: str,
-    body: CoworkerRequest,
-    session: AsyncSession = Depends(get_session),
-) -> Dict[str, Any]:
-    """Set or clear co-worker on a work item (GH#8230, GH#8516).
-
-    Omit or null co_worker_type to clear the co-worker.
-    caller_role is resolved server-side; it is no longer accepted from the
-    client (GH#8516: removed to prevent privilege escalation).
-    """
-    actor_id = body.actor_agent_id or body.actor_user_id
-    actor_type = "agent" if body.actor_agent_id else "user"
-    try:
-        if body.co_worker_type:
-            item = await _service().enable_coworking(
-                session,
-                work_item_id=work_item_id,
-                co_worker_type=body.co_worker_type,
-                company_id=body.company_id,
-                co_worker_agent_id=body.co_worker_agent_id,
-                co_worker_user_id=body.co_worker_user_id,
-                actor_id=actor_id,
-                actor_type=actor_type,
-                caller_role="owner",
-            )
-        else:
-            item = await _service().disable_coworking(
-                session,
-                work_item_id=work_item_id,
-                company_id=body.company_id,
-                actor_id=actor_id,
-                actor_type=actor_type,
-                caller_role="owner",
-            )
-        await session.commit()
-        # #11684: was `return _item_to_dict(item)` — unawaited and missing the
-        # session arg (latent since _item_to_dict became an async 2-arg fn); the
-        # awaitable_attrs relation load makes it a guaranteed crash. Match every
-        # other caller.
-        return await _item_to_dict(item, session)
-    except CoWorkingPermissionError as exc:
-        logger.error("Exception in API handler: %s", exc, exc_info=True)
-        raise HTTPException(status_code=403, detail="Internal server error")
-    except ValueError as exc:
-        msg = str(exc)
-        if "not found" in msg.lower():
-            raise HTTPException(status_code=404, detail=msg)
-        raise HTTPException(status_code=422, detail=msg)
 
 
 @router.get("/{work_item_id}/products")

--- a/autobot-backend/llc/tests/test_coworker_privilege_fix.py
+++ b/autobot-backend/llc/tests/test_coworker_privilege_fix.py
@@ -2,13 +2,21 @@
 # SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
-"""Tests for GH#8583 — CoWorkerSetRequest.caller_role privilege escalation fix.
+"""Tests for GH#8583/#14168 — CoworkerRequest privilege-escalation fixes.
+
+GH#8583's ``CoWorkerSetRequest`` and the duplicate, unauthenticated
+``set_or_clear_coworker`` route's ``CoworkerRequest`` were consolidated into
+one canonical, tenant-scoped ``CoworkerRequest`` model + ``set_coworker``
+handler (#14168) — see llc/api/work_items.py.
 
 Verifies:
-1. CoWorkerSetRequest no longer accepts caller_role (schema-level guard).
-2. resolve_actor_role looks up human membership and returns the correct role.
-3. resolve_actor_role falls back to AgentOrgNode org_role for agent actors.
-4. resolve_actor_role defaults to "member" when the actor is unknown.
+1. CoworkerRequest no longer accepts caller_role (schema-level guard, GH#8583).
+2. CoworkerRequest no longer accepts company_id (schema-level guard, #14168 —
+   it was used unvalidated to resolve the caller's role in an
+   attacker-chosen company rather than the work item's actual company).
+3. resolve_actor_role looks up human membership and returns the correct role.
+4. resolve_actor_role falls back to AgentOrgNode org_role for agent actors.
+5. resolve_actor_role defaults to "member" when the actor is unknown.
 """
 
 import uuid
@@ -65,8 +73,8 @@ def _make_session(*results):
 # ---------------------------------------------------------------------------
 
 
-def test_coworker_set_request_has_no_caller_role_field():
-    """GH#8583: caller_role must not appear in the CoWorkerSetRequest class definition."""
+def test_coworker_request_has_no_caller_role_field():
+    """GH#8583: caller_role must not appear in the CoworkerRequest class definition."""
     import ast
     import pathlib
 
@@ -74,16 +82,44 @@ def test_coworker_set_request_has_no_caller_role_field():
     tree = ast.parse(src)
 
     for node in ast.walk(tree):
-        if isinstance(node, ast.ClassDef) and node.name == "CoWorkerSetRequest":
+        if isinstance(node, ast.ClassDef) and node.name == "CoworkerRequest":
             field_names = [
                 t.target.id for t in node.body if isinstance(t, ast.AnnAssign) and isinstance(t.target, ast.Name)
             ]
             assert (
                 "caller_role" not in field_names
-            ), "CoWorkerSetRequest still defines caller_role — GH#8583 fix not applied"
+            ), "CoworkerRequest still defines caller_role — GH#8583 fix not applied"
             return  # class found and checked
 
-    raise AssertionError("CoWorkerSetRequest class not found in work_items.py")
+    raise AssertionError("CoworkerRequest class not found in work_items.py")
+
+
+def test_coworker_request_has_no_company_id_field():
+    """#14168: company_id must not appear in the CoworkerRequest class definition.
+
+    A client-supplied company_id was used unvalidated to resolve the
+    caller's role (resolve_actor_role) and to load/mutate the work item's
+    co-worker fields, independent of which company actually owns the item —
+    a cross-tenant write. The company scope must come from the authenticated
+    TenantContext (ctx.org_id) instead.
+    """
+    import ast
+    import pathlib
+
+    src = (pathlib.Path(__file__).parent.parent / "api" / "work_items.py").read_text(encoding="utf-8")
+    tree = ast.parse(src)
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == "CoworkerRequest":
+            field_names = [
+                t.target.id for t in node.body if isinstance(t, ast.AnnAssign) and isinstance(t.target, ast.Name)
+            ]
+            assert (
+                "company_id" not in field_names
+            ), "CoworkerRequest still defines company_id — #14168 fix not applied"
+            return  # class found and checked
+
+    raise AssertionError("CoworkerRequest class not found in work_items.py")
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/llc/tests/test_coworker_privilege_fix.py
+++ b/autobot-backend/llc/tests/test_coworker_privilege_fix.py
@@ -114,9 +114,7 @@ def test_coworker_request_has_no_company_id_field():
             field_names = [
                 t.target.id for t in node.body if isinstance(t, ast.AnnAssign) and isinstance(t.target, ast.Name)
             ]
-            assert (
-                "company_id" not in field_names
-            ), "CoworkerRequest still defines company_id — #14168 fix not applied"
+            assert "company_id" not in field_names, "CoworkerRequest still defines company_id — #14168 fix not applied"
             return  # class found and checked
 
     raise AssertionError("CoworkerRequest class not found in work_items.py")

--- a/autobot-backend/llc/tests/test_work_items_collection_authz.py
+++ b/autobot-backend/llc/tests/test_work_items_collection_authz.py
@@ -1,0 +1,319 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Authn/tenant-authz tests for the work-items collection routes (#14168).
+
+``POST /work-items`` and ``GET /work-items`` previously carried only
+``Depends(get_session)`` — no ``get_current_user``, no ``require_org_context``
+— letting an unauthenticated caller enumerate or create work items in any
+company by supplying its ``company_id``. This mirrors the pattern established
+in ``test_company_crud_authz_12233.py`` (GH#12233, the earlier recurrence of
+this same defect class): override ``get_current_user``/``require_org_context``
+to simulate unauthenticated/cross-tenant callers, and assert both the HTTP
+response *and* that the service layer was never invoked (no row crossed the
+tenant boundary).
+
+Also covers ``POST /work-items/{id}/coworker`` (#14168): previously reachable
+with no ``require_org_context``/IDOR guard, and shadowed by a second,
+fully-unauthenticated duplicate route hard-coding ``caller_role="owner"``.
+Both gaps are closed by consolidating into one tenant-scoped handler.
+"""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from api.user_management.dependencies import get_current_user, require_org_context
+from user_management.services import TenantContext
+
+_USER_ID = uuid.uuid4()
+
+
+def _mock_item(company_id: str) -> MagicMock:
+    item = MagicMock()
+    item.id = uuid.uuid4()
+    item.company_id = company_id
+    item.identifier = "WI-001"
+    item.type = "task"
+    item.title = "Mock item"
+    item.description = None
+    item.acceptance_criteria = []
+    item.acceptance_criteria_done = []
+    item.status = "backlog"
+    item.priority = "medium"
+    item.story_points = None
+    item.labels = []
+    item.linked_pr_urls = []
+    item.requires_approval_before = []
+    item.parent_id = None
+    item.project_id = None
+    item.sprint_id = None
+    item.goal_id = None
+    item.assignee_agent_id = None
+    item.assignee_user_id = None
+    item.assignee_type = None
+    item.checkout_run_id = None
+    item.checkout_locked_at = None
+    item.checkout_intent = None
+    item.version = 1
+    item.created_by_agent_id = None
+    item.created_by_user_id = None
+    item.reviewer_user_id = None
+    item.reviewer_agent_id = None
+    item.scheduled_start = None
+    item.scheduled_end = None
+    item.started_at = None
+    item.completed_at = None
+    item.cancelled_at = None
+    item.review_brief = None
+    item.created_at = None
+    item.updated_at = None
+    item.co_working_enabled = False
+    item.co_worker_type = None
+    item.co_worker_agent_id = None
+    item.co_worker_user_id = None
+    item.outgoing_relations = []
+    item.incoming_relations = []
+    return item
+
+
+def _make_app(*, org_id: str, unauth: bool = False) -> FastAPI:
+    from llc.api.work_items import router as wi_router  # noqa: PLC0415
+    from llc.deps import get_session  # noqa: PLC0415
+
+    app = FastAPI()
+    app.include_router(wi_router)
+
+    mock_session = AsyncMock()
+    mock_session.commit = AsyncMock()
+
+    async def _fake_session():
+        yield mock_session
+
+    app.dependency_overrides[get_session] = _fake_session
+
+    def _cur() -> dict:
+        if unauth:
+            raise HTTPException(status_code=401, detail="Authentication required")
+        return {"id": str(_USER_ID), "user_id": str(_USER_ID)}
+
+    def _ctx() -> TenantContext:
+        return TenantContext(org_id=uuid.UUID(org_id), user_id=_USER_ID, is_platform_admin=False)
+
+    app.dependency_overrides[get_current_user] = _cur
+    app.dependency_overrides[require_org_context] = _ctx
+
+    return app
+
+
+@pytest.fixture(autouse=True)
+def _stop_patches():
+    yield
+    patch.stopall()
+
+
+# ---------------------------------------------------------------------------
+# POST /work-items — create_work_item
+# ---------------------------------------------------------------------------
+
+
+class TestCreateWorkItemAuthz:
+    def test_unauthenticated_is_rejected(self):
+        create_mock = patch(
+            "llc.services.work_item_service.WorkItemService.create",
+            new=AsyncMock(),
+        ).start()
+        app = _make_app(org_id=str(uuid.uuid4()), unauth=True)
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.post(
+            "/work-items",
+            json={"company_id": str(uuid.uuid4()), "type": "task", "title": "Hijack"},
+        )
+        assert resp.status_code == 401
+        create_mock.assert_not_called()
+
+    def test_cross_tenant_company_id_is_rejected(self):
+        """An authenticated caller in org A cannot create a work item under org B."""
+        create_mock = patch(
+            "llc.services.work_item_service.WorkItemService.create",
+            new=AsyncMock(),
+        ).start()
+        caller_org = str(uuid.uuid4())
+        other_org = str(uuid.uuid4())
+        app = _make_app(org_id=caller_org)
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.post(
+            "/work-items",
+            json={"company_id": other_org, "type": "task", "title": "Hijack"},
+        )
+        assert resp.status_code == 404
+        create_mock.assert_not_called()
+
+    def test_own_company_succeeds(self):
+        org = str(uuid.uuid4())
+        item = _mock_item(org)
+        create_mock = patch(
+            "llc.services.work_item_service.WorkItemService.create",
+            new=AsyncMock(return_value=item),
+        ).start()
+        patch("llc.api.work_items._relations_to_list", new=AsyncMock(return_value=[])).start()
+        patch("llc.kb.collections.KbCollectionManager.ensure_collection", new=AsyncMock()).start()
+        app = _make_app(org_id=org)
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.post(
+            "/work-items",
+            json={"company_id": org, "type": "task", "title": "Legit item"},
+        )
+        assert resp.status_code == 201, resp.text
+        create_mock.assert_awaited_once()
+        assert create_mock.await_args.kwargs["company_id"] == org
+
+
+# ---------------------------------------------------------------------------
+# GET /work-items — list_work_items
+# ---------------------------------------------------------------------------
+
+
+class TestListWorkItemsAuthz:
+    def test_unauthenticated_is_rejected(self):
+        list_mock = patch(
+            "llc.services.work_item_service.WorkItemService.list_by_project",
+            new=AsyncMock(return_value=[]),
+        ).start()
+        app = _make_app(org_id=str(uuid.uuid4()), unauth=True)
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/work-items", params={"company_id": str(uuid.uuid4())})
+        assert resp.status_code == 401
+        list_mock.assert_not_called()
+
+    def test_cross_tenant_enumeration_is_rejected(self):
+        """Company A caller cannot list company B's work items by supplying its id."""
+        list_mock = patch(
+            "llc.services.work_item_service.WorkItemService.list_by_project",
+            new=AsyncMock(return_value=[_mock_item("should-not-be-returned")]),
+        ).start()
+        caller_org = str(uuid.uuid4())
+        other_org = str(uuid.uuid4())
+        app = _make_app(org_id=caller_org)
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/work-items", params={"company_id": other_org})
+        assert resp.status_code == 404
+        list_mock.assert_not_called()
+        # No cross-tenant row is ever serialized into the response body.
+        assert "should-not-be-returned" not in resp.text
+
+    def test_own_company_succeeds(self):
+        org = str(uuid.uuid4())
+        item = _mock_item(org)
+        list_mock = patch(
+            "llc.services.work_item_service.WorkItemService.list_by_project",
+            new=AsyncMock(return_value=[item]),
+        ).start()
+        patch("llc.api.work_items._relations_to_list", new=AsyncMock(return_value=[])).start()
+        app = _make_app(org_id=org)
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/work-items", params={"company_id": org})
+        assert resp.status_code == 200
+        list_mock.assert_awaited_once()
+        assert list_mock.await_args.kwargs["company_id"] == org
+        assert len(resp.json()) == 1
+
+
+# ---------------------------------------------------------------------------
+# POST /work-items/{id}/coworker — set_coworker (consolidated, #14168)
+# ---------------------------------------------------------------------------
+
+
+class TestCoworkerAuthz:
+    def test_unauthenticated_is_rejected(self):
+        enable_mock = patch(
+            "llc.services.work_item_service.WorkItemService.enable_coworking",
+            new=AsyncMock(),
+        ).start()
+        app = _make_app(org_id=str(uuid.uuid4()), unauth=True)
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.post(
+            f"/work-items/{uuid.uuid4()}/coworker",
+            json={"co_worker_type": "agent", "co_worker_agent_id": str(uuid.uuid4())},
+        )
+        assert resp.status_code == 401
+        enable_mock.assert_not_called()
+
+    def test_cross_tenant_work_item_is_rejected(self):
+        """Caller authenticated into org A cannot set a co-worker on org B's item."""
+        caller_org = str(uuid.uuid4())
+        other_org = str(uuid.uuid4())
+        enable_mock = patch(
+            "llc.services.work_item_service.WorkItemService.enable_coworking",
+            new=AsyncMock(),
+        ).start()
+        patch(
+            "llc.services.work_item_service.WorkItemService.get",
+            new=AsyncMock(return_value=_mock_item(other_org)),
+        ).start()
+        app = _make_app(org_id=caller_org)
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.post(
+            f"/work-items/{uuid.uuid4()}/coworker",
+            json={"co_worker_type": "agent", "co_worker_agent_id": str(uuid.uuid4())},
+        )
+        assert resp.status_code == 404
+        enable_mock.assert_not_called()
+
+    def test_own_company_set_resolves_role_from_ctx_org_not_body(self):
+        """company_id used for role resolution must be ctx.org_id, never client input."""
+        org = str(uuid.uuid4())
+        item = _mock_item(org)
+        patch(
+            "llc.services.work_item_service.WorkItemService.get",
+            new=AsyncMock(return_value=item),
+        ).start()
+        enable_mock = patch(
+            "llc.services.work_item_service.WorkItemService.enable_coworking",
+            new=AsyncMock(return_value=item),
+        ).start()
+        resolve_mock = patch(
+            "llc.api.work_items.resolve_actor_role",
+            new=AsyncMock(return_value="owner"),
+        ).start()
+        patch("llc.api.work_items._relations_to_list", new=AsyncMock(return_value=[])).start()
+        app = _make_app(org_id=org)
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.post(
+            f"/work-items/{uuid.uuid4()}/coworker",
+            json={"co_worker_type": "agent", "co_worker_agent_id": str(uuid.uuid4())},
+        )
+        assert resp.status_code == 200, resp.text
+        resolve_mock.assert_awaited_once()
+        assert resolve_mock.await_args.args[-1] == org
+        enable_mock.assert_awaited_once()
+        assert enable_mock.await_args.kwargs["company_id"] == org
+
+    def test_omitting_co_worker_type_clears_via_disable_coworking(self):
+        """The consolidated route preserves the "clear" behaviour of the old
+        duplicate (now-removed) set_or_clear_coworker route."""
+        org = str(uuid.uuid4())
+        item = _mock_item(org)
+        patch(
+            "llc.services.work_item_service.WorkItemService.get",
+            new=AsyncMock(return_value=item),
+        ).start()
+        disable_mock = patch(
+            "llc.services.work_item_service.WorkItemService.disable_coworking",
+            new=AsyncMock(return_value=item),
+        ).start()
+        patch(
+            "llc.api.work_items.resolve_actor_role",
+            new=AsyncMock(return_value="owner"),
+        ).start()
+        patch("llc.api.work_items._relations_to_list", new=AsyncMock(return_value=[])).start()
+        app = _make_app(org_id=org)
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.post(f"/work-items/{uuid.uuid4()}/coworker", json={})
+        assert resp.status_code == 200, resp.text
+        disable_mock.assert_awaited_once()
+        assert disable_mock.await_args.kwargs["company_id"] == org

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -50948,14 +50948,24 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Set Or Clear Coworker
-         * @description Set or clear co-worker on a work item (GH#8230, GH#8516).
+         * Set Coworker
+         * @description Set or clear co-worker fields for a work item (GH#8230, GH#8517, GH#8583, #14168).
          *
-         *     Omit or null co_worker_type to clear the co-worker.
-         *     caller_role is resolved server-side; it is no longer accepted from the
-         *     client (GH#8516: removed to prevent privilege escalation).
+         *     Omit ``co_worker_type`` (or send null) to clear the co-worker.
+         *
+         *     Returns 404 when the work item is not found or belongs to a different
+         *     org (#14168 IDOR guard — checked against the caller's authenticated org,
+         *     never client input), 403 when the caller lacks permission, and 422 for
+         *     invalid co-worker identity values.
+         *
+         *     This used to be two separate routes registered on the same path/method
+         *     (the second, unauthenticated one — ``set_or_clear_coworker`` — was
+         *     unreachable dead code shadowed by this one, but a live landmine: it
+         *     hard-coded ``caller_role="owner"`` and trusted a client-supplied
+         *     ``company_id`` with zero tenant check). Consolidated into one canonical,
+         *     authenticated, tenant-scoped handler (#14168).
          */
-        post: operations["set_or_clear_coworker_api_llc_work_items__work_item_id__coworker_post"];
+        post: operations["set_coworker_api_llc_work_items__work_item_id__coworker_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -62209,27 +62219,6 @@ export interface components {
             [key: string]: unknown;
         };
         /**
-         * CoWorkerSetRequest
-         * @description Set co-worker on a work item (GH#8230).
-         *
-         *     caller_role is resolved server-side from auth context — not supplied
-         *     by the client (GH#8583: removed client-supplied caller_role to prevent privilege escalation).
-         */
-        CoWorkerSetRequest: {
-            /** Co Worker Type */
-            co_worker_type: string;
-            /** Company Id */
-            company_id: string;
-            /** Co Worker Agent Id */
-            co_worker_agent_id?: string | null;
-            /** Co Worker User Id */
-            co_worker_user_id?: string | null;
-            /** Actor Id */
-            actor_id?: string | null;
-        } & {
-            [key: string]: unknown;
-        };
-        /**
          * CodeAction
          * @description LSP-compatible code action.
          */
@@ -65188,24 +65177,26 @@ export interface components {
         };
         /**
          * CoworkerRequest
-         * @description Set or clear a co-worker on a work item (GH#8230).
-         *     To clear the co-worker, omit co_worker_type (or send null).
-         *     The caller's role is resolved server-side from the auth context — not supplied
-         *     by the client (GH#8516: removed client-supplied caller_role to prevent privilege escalation).
+         * @description Set or clear a co-worker on a work item (GH#8230, GH#8516, GH#8583, #14168).
+         *
+         *     To clear the co-worker, omit co_worker_type (or send null). Both the
+         *     caller's role and the company scope are resolved server-side from the
+         *     authenticated org context — never supplied by the client. GH#8516/
+         *     GH#8583 removed client-supplied ``caller_role`` to prevent privilege
+         *     escalation; #14168 removed client-supplied ``company_id`` for the same
+         *     reason — it was used unvalidated to resolve the caller's role, letting a
+         *     caller impersonate a role held in a company other than the one owning
+         *     the work item. ``actor_agent_id``/``actor_user_id`` were likewise
+         *     removed — the acting identity comes from the authenticated session, not
+         *     the request body, so the audit trail cannot be spoofed.
          */
         CoworkerRequest: {
-            /** Company Id */
-            company_id: string;
             /** Co Worker Type */
             co_worker_type?: string | null;
             /** Co Worker Agent Id */
             co_worker_agent_id?: string | null;
             /** Co Worker User Id */
             co_worker_user_id?: string | null;
-            /** Actor Agent Id */
-            actor_agent_id?: string | null;
-            /** Actor User Id */
-            actor_user_id?: string | null;
         } & {
             [key: string]: unknown;
         };
@@ -171512,7 +171503,7 @@ export interface operations {
             };
         };
     };
-    set_or_clear_coworker_api_llc_work_items__work_item_id__coworker_post: {
+    set_coworker_api_llc_work_items__work_item_id__coworker_post: {
         parameters: {
             query?: never;
             header?: never;


### PR DESCRIPTION
Closes #14168

## Thinking Path

Read the issue and the owner's follow-up comment: `POST`/`GET /api/llc/work-items`
carried only `Depends(get_session)` — no `get_current_user`, no
`require_org_context` — while every other route in the same file has both,
plus an IDOR guard comparing the item's `company_id` to `ctx.org_id`. The
threat model is unauthenticated + cross-tenant access, not a missing
decorator, so the fix has to authenticate the caller *and* prove the query/
write is scoped to their own org, not just that they're logged in.

Grepped every route in `work_items.py` (29 total, not just the two named in
the issue) against the file's own established idiom
(`get_current_user` + `require_org_context` + an org-id comparison, or
`assert_company_access` from `llc/deps.py`). That surfaced two more
unguarded doors beyond the two the issue names:

- `set_coworker` (`POST /{id}/coworker`) had `get_current_user` but no
  `require_org_context`/IDOR guard, and resolved the caller's role
  (`resolve_actor_role`) from a **client-supplied** `company_id` — so an
  authenticated user with `owner` membership in their own company could set/
  clear the co-worker on a work item belonging to a *different* company,
  because the role check and the item-ownership check never used the same
  company id.
- A second, fully-unauthenticated route (`set_or_clear_coworker`) was
  registered on the exact same path/method (`POST /{id}/coworker`),
  hard-coding `caller_role="owner"`. Route-registration order makes it
  unreachable today (`set_coworker` wins), but it's a landmine: any future
  reorder of the two functions makes it live, and it trusts a client
  `company_id` outright. It duplicated (rather than extended) `set_coworker`
  — the only functional difference was co-worker *clearing*, which
  `set_coworker` didn't support.

Verified `get_tenant_context`'s org-id resolution precedence (header → path
`company_id` → query `company_id` → JWT claim) explicitly, since it's
membership-checked for header/path/query sources — that's why
`require_org_context` alone already closes most of the cross-tenant gap for
`GET`, but a caller can still pair a valid `X-Organization-Id` header for
their *own* org with a foreign `company_id` **query** value (header wins),
so the explicit `assert_company_access` check is not redundant.

## What Changed

- `autobot-backend/llc/api/work_items.py`
  - `POST /work-items` (`create_work_item`) and `GET /work-items`
    (`list_work_items`): added `_current_user: dict = Depends(get_current_user)`
    and `ctx: TenantContext = Depends(require_org_context)`, then
    `assert_company_access(ctx, company_id)` (the canonical idiom from
    `llc/deps.py`, already used across `companies.py`) before touching the
    service layer, rejecting any client-supplied `company_id`/body that
    doesn't match the caller's authenticated org.
  - Consolidated the two `POST /{work_item_id}/coworker` routes into one:
    `set_coworker` now takes `ctx: TenantContext = Depends(require_org_context)`,
    adds the same IDOR guard as every sibling route (`existing.company_id ==
    ctx.org_id`), derives `company_id` for role resolution and for the
    service call from `ctx.org_id` (never the request body), and supports
    both set *and* clear (folding in the removed duplicate's clear branch).
    The unauthenticated, `caller_role="owner"`-hardcoded duplicate route
    (`set_or_clear_coworker`) is removed.
  - `CoworkerRequest` no longer accepts `company_id` or `actor_agent_id`/
    `actor_user_id` — company scope comes from `ctx.org_id`, actor identity
    from the authenticated session, matching the pattern already established
    for `SuggestAcRequest` (H2 fix) elsewhere in this file.
- `autobot-backend/llc/tests/test_coworker_privilege_fix.py`: updated the
  GH#8583 schema test for the renamed/consolidated `CoworkerRequest` class,
  and added a companion test asserting `company_id` is also absent from it.
- `autobot-backend/llc/tests/test_work_items_collection_authz.py` (new):
  authn/tenant-authz tests for `POST`/`GET /work-items` and the consolidated
  coworker route, following the established pattern in
  `test_company_crud_authz_12233.py` (GH#12233, the prior recurrence of this
  same defect class).

Every other route in the router already carried `get_current_user` +
`require_org_context` + an IDOR guard and was left unchanged.

## Verification

Static verification only — per instructions, application code and the test
suite were not run locally; CI executes them.

- `python3 -m py_compile` / `ast.parse` on all three touched files: clean.
- No remaining references to the removed `CoWorkerSetRequest`,
  `CoWorkerClearRequest`, or `set_or_clear_coworker` anywhere in the
  Python or frontend source (grepped repo-wide; only the generated
  `api.ts` OpenAPI client and this PR's own docstrings mention the old
  name, both expected).
- Grepped every `@router.*` decorator in `work_items.py` post-change (29
  routes, one path each — the former path collision on
  `POST /{work_item_id}/coworker` is gone): all 29 now carry
  `get_current_user` + `require_org_context` (or, for `POST`/`GET`
  `/work-items`, the new `assert_company_access` guard).
- Traced `get_tenant_context`'s org-id precedence and `_check_org_membership`
  to confirm `ctx.org_id` is always membership-verified before this PR's
  `assert_company_access` calls run, and that a header/query mismatch is
  the specific gap the explicit check (rather than relying on
  `require_org_context` alone) closes for `GET /work-items`.
- Traced `WorkItemService.list_by_project` to confirm the DB query itself
  filters on `LLCWorkItem.company_id == company_id` — scoping is enforced
  at the query level, not just at the auth boundary.
- Traced `WorkItemService.enable_coworking`/`disable_coworking` to confirm
  neither checks the loaded item's `company_id` against the caller — the
  router-level IDOR guard (matching every sibling route's pattern in this
  file) is the only enforcement point, so it had to be added there.

New/updated tests, added in `test_work_items_collection_authz.py` and
`test_coworker_privilege_fix.py`:
- `POST`/`GET /work-items` and `POST /{id}/coworker`: unauthenticated caller
  → 401, service method never called.
- `POST`/`GET /work-items` and `POST /{id}/coworker`: authenticated caller
  from company A, target/body company B → 404, service method never called
  (asserted via `assert_not_called()` — no row crosses the tenant
  boundary, not just an HTTP status check).
- Same-tenant success paths for all three, asserting the service is called
  with the caller's own org id specifically (not an echo of client input).
- `test_own_company_set_resolves_role_from_ctx_org_not_body`: asserts
  `resolve_actor_role` is invoked with `ctx.org_id`, closing the
  role-resolution-company-spoofing vector described above.
- `test_omitting_co_worker_type_clears_via_disable_coworking`: asserts the
  consolidated route still exercises the "clear" behaviour the removed
  duplicate route provided.
- Schema tests: `CoworkerRequest` has neither `caller_role` nor
  `company_id` fields.

**Mutations were statically traced, not executed** (no test suite run,
per instructions):
- Removing the `assert_company_access(ctx, body.company_id)` /
  `assert_company_access(ctx, company_id)` calls: the corresponding
  cross-tenant test's `..._mock.assert_not_called()` would fail, since the
  service method would then be reached and called — traced through the
  route bodies line by line to confirm no other guard intervenes.
- Removing the `_current_user`/`ctx` dependency parameters entirely
  (reverting to the original vulnerable signatures): the unauthenticated
  test's forced-401 override on `get_current_user` would no longer be wired
  into the route's dependency graph, so the request would reach the service
  and return 201/200 instead of 401 — traced against the exact original
  (pre-fix) signatures recorded in the diff.
- Removing the coworker route's IDOR guard block: `enable_coworking` would
  be reached directly with the cross-tenant item, and the mock would be
  called — confirmed by tracing that `resolve_actor_role`/`enable_coworking`
  are the very next statements once the guard is gone.

## Model Used

Claude Opus 5 (1M context)
