### PR TITLE
security(slm): close decorator and app-alias bypasses of the public-router registry (#14363, #14366)

### DIFF
--- a/autobot-slm-backend/main.py
+++ b/autobot-slm-backend/main.py
@@ -621,11 +621,23 @@ app.add_middleware(ApiRequestCounterMiddleware)
 #   performance_metrics_router — prometheus scrape surface; a scraper cannot
 #       authenticate, so the gate returned 401 on every scrape (#14339)
 #
+# Two routes below are declared here rather than moved into a router, because
+# the idiom itself — not the auth outcome — is what has to be visible:
+#   root (@app.get("/")) — service banner; no credentials exist yet to check,
+#       and it discloses only a static name/version string
+#   prometheus_registry_metrics (@app.get("/metrics")) — top-level prometheus
+#       scrape target (#10851); a scraper cannot authenticate, same reasoning
+#       as performance_metrics_router above
+#
 # This list is enforced, not decorative: tests/api/
 # test_prometheus_scrape_is_unauthenticated_14339.py fails if any router is
 # mounted without the gate and is not named here. It had already gone stale
 # once, which is how a public surface stops being visible in the one place the
-# file keeps that inventory.
+# file keeps that inventory. The same check now also covers routes added
+# directly with `@app.<verb>(...)` or `app.add_api_route(...)` instead of a
+# router (#14363), and resolves a simple module-level alias of `app` before
+# deciding what a mount's receiver is (#14366) — both used to slip past
+# entirely because the check only ever looked for `app.include_router(...)`.
 
 # Service-management gate (#10198, epic #10193): all other routers require
 # Permission.SERVICE_MANAGEMENT.  Ordinary users (role=user/readonly/analyst/editor)

--- a/autobot-slm-backend/tests/api/test_prometheus_scrape_is_unauthenticated_14339.py
+++ b/autobot-slm-backend/tests/api/test_prometheus_scrape_is_unauthenticated_14339.py
@@ -558,9 +558,7 @@ def test_a_bare_app_get_route_is_caught_as_an_ungated_bypass():
     through, and land in the ungated set because it carries no `dependencies`.
     """
     tree = ast.parse(
-        "@app.get('/api/services/sneaky-list')\n"
-        "async def sneaky_list():\n"
-        "    return {'leaked': 'everything'}\n"
+        "@app.get('/api/services/sneaky-list')\n" "async def sneaky_list():\n" "    return {'leaked': 'everything'}\n"
     )
     calls, unparseable = _decorator_calls(tree, frozenset())
     assert not unparseable
@@ -572,11 +570,7 @@ def test_a_gated_app_get_route_is_still_found_but_not_flagged_ungated():
     """A route added this way with an explicit `dependencies=` is a legitimate
     use of the idiom and must not be forced into the registry text — only the
     ungated case should demand a declaration."""
-    tree = ast.parse(
-        "@app.get('/api/services/reports', dependencies=_SM)\n"
-        "async def reports():\n"
-        "    return {}\n"
-    )
+    tree = ast.parse("@app.get('/api/services/reports', dependencies=_SM)\n" "async def reports():\n" "    return {}\n")
     calls, unparseable = _decorator_calls(tree, frozenset())
     assert not unparseable
     assert "reports" in calls
@@ -586,12 +580,7 @@ def test_a_gated_app_get_route_is_still_found_but_not_flagged_ungated():
 def test_an_add_api_route_call_is_caught_as_an_ungated_bypass():
     """`app.add_api_route(...)` is the third idiom named in #14363 — a call
     rather than a decorator, but reaching the app exactly as directly."""
-    tree = ast.parse(
-        "def sneaky():\n"
-        "    return {}\n"
-        "\n"
-        "app.add_api_route('/api/services/sneaky2', sneaky)\n"
-    )
+    tree = ast.parse("def sneaky():\n" "    return {}\n" "\n" "app.add_api_route('/api/services/sneaky2', sneaky)\n")
     calls, unparseable = _add_api_route_calls(tree, frozenset())
     assert not unparseable
     assert "sneaky" in calls, "app.add_api_route(...) was not caught"

--- a/autobot-slm-backend/tests/api/test_prometheus_scrape_is_unauthenticated_14339.py
+++ b/autobot-slm-backend/tests/api/test_prometheus_scrape_is_unauthenticated_14339.py
@@ -448,6 +448,22 @@ def test_every_ungated_router_is_named_in_the_registry():
     )
 
 
+def _code_lines(block: str) -> str:
+    """*block* with comment-only lines removed, leaving only executable code.
+
+    A comment line is allowed to *name* `include_router` in prose — the
+    explanatory text in this very block does exactly that, describing what
+    the check used to miss — without tripping the "has this block swallowed
+    real code" guard below. Only a line that is not a comment can contain an
+    actual mount call, so stripping comments first measures code, not prose.
+    The registry block is legitimately all comments, so on the real file this
+    reduces to the empty string; an over-run block would still carry real
+    `app.include_router(...)` statements, which are not comment lines and
+    survive the strip.
+    """
+    return "\n".join(line for line in block.splitlines() if not line.strip().startswith("#"))
+
+
 def test_the_registry_block_is_bounded_at_both_ends():
     """The block must not run past its closing marker.
 
@@ -455,6 +471,12 @@ def test_the_registry_block_is_bounded_at_both_ends():
     block became the rest of the file, every router matched its own mount line,
     and an undeclared ungated router passed unnoticed. Sized rather than merely
     non-empty, because "the rest of the file" is also non-empty.
+
+    The substring check below is deliberately run against comment-stripped
+    text, not the raw block. A prior version matched the raw block, which
+    means an explanatory comment that *names* `include_router` while
+    describing what it guards against would trip the guard it is standing
+    next to — reworded here after review demonstrated exactly that (#14363).
     """
     block = _registry_block()
     source = _main_source()
@@ -463,7 +485,7 @@ def test_the_registry_block_is_bounded_at_both_ends():
         f"the registry block is {len(block)} chars of a {len(source)}-char file — "
         "it has run past its closing marker and would declare everything (#14339)"
     )
-    assert "include_router" not in block, (
+    assert "include_router" not in _code_lines(block), (
         "the registry block contains mount calls, so it has swallowed code rather "
         "than stopping at the comment that ends it"
     )

--- a/autobot-slm-backend/tests/api/test_prometheus_scrape_is_unauthenticated_14339.py
+++ b/autobot-slm-backend/tests/api/test_prometheus_scrape_is_unauthenticated_14339.py
@@ -18,6 +18,20 @@ unchanged, so a deployed scrape config needs no rewrite.
 Both directions are asserted. Checking only that the metrics route is reachable
 would stay green if someone dropped the dependency from the whole performance
 router, which would expose every service-management endpoint on this service.
+
+Two further bypasses of the registry this file enforces were found after the
+above shipped, and are closed here rather than in a second, parallel check:
+
+* A route added with `@app.get(...)`, `@app.post(...)`, or
+  `app.add_api_route(...)` never passed through the `include_router` matcher,
+  so it was neither gated nor declared — reachable and invisible at once
+  (#14363). `_decorator_calls` and `_add_api_route_calls` extend the same
+  matcher to these idioms.
+* Binding another name to the app object before mounting through it —
+  `application = app; application.include_router(...)` — read as a receiver
+  that is not literally named `app` and was skipped as if it were an
+  unrelated object (#14366). `_app_aliases` resolves simple, module-level
+  aliases before any receiver is classified, for all three idioms.
 """
 
 from __future__ import annotations
@@ -34,6 +48,18 @@ from api import performance  # noqa: E402
 
 _SCRAPE_PATH = "/performance/metrics/prometheus"
 _MOUNTED_AT = "/api/performance/metrics/prometheus"
+
+_HTTP_VERB_DECORATORS = {
+    "get",
+    "post",
+    "put",
+    "delete",
+    "patch",
+    "options",
+    "head",
+    "trace",
+    "websocket",
+}
 
 
 def _paths(router) -> set[str]:
@@ -68,8 +94,75 @@ def test_the_two_routers_share_a_prefix_so_the_path_is_unchanged():
     assert performance.metrics_router.prefix == performance.router.prefix
 
 
-def _mount_calls() -> dict[str, ast.Call]:
-    """Every `app.include_router(<name>, ...)` in main.py, keyed by router name.
+def _main_source() -> str:
+    return (Path(__file__).resolve().parents[2] / "main.py").read_text(encoding="utf-8")
+
+
+def _main_tree() -> ast.Module:
+    return ast.parse(_main_source())
+
+
+def _app_aliases(tree: ast.Module) -> frozenset[str]:
+    """Module-level names bound directly (transitively) to `app` (#14366).
+
+    One pass over `tree.body` in source order: `x = app` followed later by
+    `y = x` extends the known set, because `known` already contains `x` by
+    the time the second assignment is read. Deliberately scoped to the
+    module's *top-level* statements — an alias introduced inside a function
+    body (a helper that takes the app as a parameter, a closure) is a
+    different, open-ended problem that #14366 records as future work rather
+    than one this pass closes.
+    """
+    known = {"app"}
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not (isinstance(node.value, ast.Name) and node.value.id in known):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name):
+                known.add(target.id)
+    known.discard("app")
+    return frozenset(known)
+
+
+def _is_app_receiver(receiver: ast.expr, aliases: frozenset[str] = frozenset()) -> bool:
+    """Whether a call's receiver is the application object itself, or a known
+    module-level alias of it (#14366).
+
+    A named helper, not an inline condition, so the tests below can pin the
+    decision rather than restate it. Restating it is how two tests here came
+    to pass while the production branch they claimed to guard was deleted.
+    """
+    return isinstance(receiver, ast.Name) and (receiver.id == "app" or receiver.id in aliases)
+
+
+def _receiver_kind(receiver: ast.expr, aliases: frozenset[str]) -> str:
+    """Classify a call's receiver as `"app"`, `"skip"`, or `"unparseable"`.
+
+    Shared by every matcher below so the fail-closed rule is defined once:
+    `app` or a known alias resolves; a *different* bare name is a legitimately
+    different object — a router mounting its own sub-router, a route
+    decorator on some other router entirely — and is skipped; anything else
+    (an attribute chain like `app.router`, a call result, a subscript) cannot
+    be proven to miss the app, so it is reported rather than silently
+    skipped. `app.router.include_router(...)` proved that an attribute chain
+    can reach the app just as directly as a bare name.
+    """
+    if _is_app_receiver(receiver, aliases):
+        return "app"
+    if isinstance(receiver, ast.Name):
+        return "skip"
+    return "unparseable"
+
+
+def _is_plain_name_arg(call: ast.Call) -> bool:
+    """Whether the first argument is a bare router name this parser can read."""
+    return bool(call.args) and isinstance(call.args[0], ast.Name)
+
+
+def _app_mounts(tree: ast.Module | None = None) -> tuple[dict[str, ast.Call], list[str]]:
+    """`app.include_router(...)` calls, split into readable and unreadable.
 
     Read structurally rather than executed: importing `main` works from a shell
     but not under pytest, where `api` resolves as a different namespace package
@@ -87,40 +180,15 @@ def _mount_calls() -> dict[str, ast.Call]:
     leak. Closing it means making `main` importable under pytest, which is a
     separate problem from this one.
 
-    A second limit, and this one points the other way: only `include_router`
-    calls are scanned. A route added with `@app.get(...)` or
-    `app.add_api_route(...)` never passes through here, so it is neither checked
-    nor declared. `main.py` already carries two legitimate instances of that
-    idiom, each justified inline. Catching them needs a different matcher rather
-    than a patch to this one — filed as #14363. Unlike the branch-wrap limit
-    above, this gap can hide an exposure, so it is worth closing.
+    Two further gaps recorded here previously are now closed rather than
+    open: a route added with `@app.get(...)` or `app.add_api_route(...)`
+    instead of `include_router` is now caught by `_decorator_calls` and
+    `_add_api_route_calls` (#14363), and a receiver reached through a
+    module-level alias of `app` is now resolved by `_app_aliases` before
+    `_receiver_kind` classifies it (#14366).
     """
-    calls, unparseable = _app_mounts()
-    assert not unparseable, (
-        f"mount calls this check cannot read: {unparseable}. A shape it does not "
-        "recognise used to be skipped in silence, which let an ungated router be "
-        "invisible rather than flagged. Mount with a plain router name, or teach "
-        "this parser the new shape (#14339)."
-    )
-    return calls
-
-
-def _app_mounts() -> tuple[dict[str, ast.Call], list[str]]:
-    """`app.include_router(...)` calls, split into readable and unreadable.
-
-    Two things this deliberately does NOT do, both fail-open holes review
-    demonstrated with working exploits:
-
-    * It no longer matches any receiver. Only `app` mounts decide what is
-      reachable from outside; a router-on-router include is a different question.
-    * It no longer skips a call whose first argument is not a plain name.
-      `app.include_router(*routers)` and `app.include_router(module.router)` are
-      ordinary FastAPI idioms, and each left a genuinely ungated, undeclared
-      router reachable while every test here stayed green. An unreadable mount is
-      now returned for the caller to fail on, because "I could not parse this"
-      and "there is nothing here" must not look the same.
-    """
-    tree = ast.parse((Path(__file__).resolve().parents[2] / "main.py").read_text(encoding="utf-8"))
+    tree = tree if tree is not None else _main_tree()
+    aliases = _app_aliases(tree)
     calls: dict[str, ast.Call] = {}
     unparseable: list[str] = []
     for node in ast.walk(tree):
@@ -129,14 +197,14 @@ def _app_mounts() -> tuple[dict[str, ast.Call], list[str]]:
         if node.func.attr != "include_router":
             continue
         receiver = node.func.value
-        if not _is_app_receiver(receiver):
-            # Not `app.include_router(...)`. A plain name that is not `app` is a
-            # router-on-router include — a different question, correctly skipped.
-            # Anything else is a receiver this parser cannot resolve, and
-            # `app.router.include_router(...)` proved that reaches the app just
-            # as directly, so it is reported rather than skipped.
-            if not isinstance(receiver, ast.Name):
-                unparseable.append(f"line {node.lineno}: receiver {ast.dump(receiver)[:70]}")
+        kind = _receiver_kind(receiver, aliases)
+        if kind == "skip":
+            # Not `app` (or an alias of it). A plain name that resolves to
+            # something else is a router-on-router include — a different
+            # question, correctly skipped.
+            continue
+        if kind == "unparseable":
+            unparseable.append(f"line {node.lineno}: receiver {ast.dump(receiver)[:70]}")
             continue
         if _is_plain_name_arg(node):
             calls[node.args[0].id] = node
@@ -146,19 +214,132 @@ def _app_mounts() -> tuple[dict[str, ast.Call], list[str]]:
     return calls, unparseable
 
 
-def _is_app_receiver(receiver: ast.expr) -> bool:
-    """Whether a call's receiver is the application object itself.
+def _decorator_calls(tree: ast.Module, aliases: frozenset[str]) -> tuple[dict[str, ast.Call], list[str]]:
+    """Every `@app.<verb>(...)` route decorator in `main.py` (#14363).
 
-    A named helper, not an inline condition, so the tests below can pin the
-    decision rather than restate it. Restating it is how two tests here came to
-    pass while the production branch they claimed to guard was deleted.
+    Keyed by the decorated function's name — the identifier the registry
+    block can name, the same way it names a router variable. Only recognised
+    HTTP-verb attributes (`get`, `post`, ... `websocket`) are treated as
+    route registration; other decorators on `app` (`exception_handler`,
+    `on_event`, ...) are not routes and are correctly ignored. Among the
+    recognised verbs, a receiver this parser cannot resolve to either `app`
+    or a clearly different object is reported rather than skipped, matching
+    `_app_mounts`'s fail-closed rule.
     """
-    return isinstance(receiver, ast.Name) and receiver.id == "app"
+    calls: dict[str, ast.Call] = {}
+    unparseable: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for deco in node.decorator_list:
+            if not (isinstance(deco, ast.Call) and isinstance(deco.func, ast.Attribute)):
+                continue
+            if deco.func.attr not in _HTTP_VERB_DECORATORS:
+                continue
+            receiver = deco.func.value
+            kind = _receiver_kind(receiver, aliases)
+            if kind == "skip":
+                continue
+            if kind == "unparseable":
+                unparseable.append(f"line {deco.lineno}: receiver {ast.dump(receiver)[:70]}")
+                continue
+            calls[node.name] = deco
+    return calls, unparseable
 
 
-def _is_plain_name_arg(call: ast.Call) -> bool:
-    """Whether the first argument is a bare router name this parser can read."""
-    return bool(call.args) and isinstance(call.args[0], ast.Name)
+def _endpoint_arg(call: ast.Call) -> ast.expr | None:
+    """The `endpoint` argument of an `add_api_route(...)` call, positional or keyword."""
+    if len(call.args) >= 2:
+        return call.args[1]
+    for kw in call.keywords:
+        if kw.arg == "endpoint":
+            return kw.value
+    return None
+
+
+def _add_api_route_calls(tree: ast.Module, aliases: frozenset[str]) -> tuple[dict[str, ast.Call], list[str]]:
+    """Every `app.add_api_route(...)` call in `main.py` (#14363).
+
+    Keyed by the endpoint callable's name when it is a bare function name;
+    anything else — a lambda, an attribute, a call result — is unparseable
+    rather than silently skipped, the same "cannot read this must not look
+    like nothing here" rule `_app_mounts` already applies to router mounts.
+    """
+    calls: dict[str, ast.Call] = {}
+    unparseable: list[str] = []
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)):
+            continue
+        if node.func.attr != "add_api_route":
+            continue
+        receiver = node.func.value
+        kind = _receiver_kind(receiver, aliases)
+        if kind == "skip":
+            continue
+        if kind == "unparseable":
+            unparseable.append(f"line {node.lineno}: receiver {ast.dump(receiver)[:70]}")
+            continue
+        endpoint = _endpoint_arg(node)
+        if isinstance(endpoint, ast.Name):
+            calls[endpoint.id] = node
+        else:
+            shape = ast.dump(endpoint)[:80] if endpoint is not None else "no endpoint argument"
+            unparseable.append(f"line {node.lineno}: endpoint {shape}")
+    return calls, unparseable
+
+
+def _all_bypass_calls(tree: ast.Module | None = None) -> tuple[dict[str, ast.AST], list[str]]:
+    """Every route-adding call in `main.py` that can make a route reachable
+    from outside, across all three idioms the registry must see (#14363,
+    #14366): `app.include_router(...)`, `@app.<verb>(...)`, and
+    `app.add_api_route(...)`, each resolved through any module-level alias of
+    `app`.
+
+    Merged into one map rather than checked with three separate registry
+    tests, because the registry answers a single question per name — is this
+    declared? — regardless of which idiom put the name there. Extending the
+    one gate, not adding a second one beside it.
+    """
+    tree = tree if tree is not None else _main_tree()
+    aliases = _app_aliases(tree)
+    router_calls, unparseable = _app_mounts(tree)
+    decorator_calls, decorator_unparseable = _decorator_calls(tree, aliases)
+    api_route_calls, api_route_unparseable = _add_api_route_calls(tree, aliases)
+
+    calls: dict[str, ast.AST] = dict(router_calls)
+    calls.update(decorator_calls)
+    calls.update(api_route_calls)
+    return calls, [*unparseable, *decorator_unparseable, *api_route_unparseable]
+
+
+def _bypass_calls() -> dict[str, ast.AST]:
+    """`_all_bypass_calls()` against the real `main.py`, asserting every call
+    was readable.
+
+    Mirrors `_mount_calls`'s contract for the merged surface: an unreadable
+    call must fail the suite, not be silently dropped from what the registry
+    checks.
+    """
+    calls, unparseable = _all_bypass_calls()
+    assert not unparseable, (
+        f"bypass-surface calls this check cannot read: {unparseable}. A shape it "
+        "does not recognise used to be skipped in silence, which let an ungated "
+        "route be invisible rather than flagged. Use a plain `app`/alias receiver "
+        "and a bare endpoint name, or teach this parser the new shape (#14363, #14366)."
+    )
+    return calls
+
+
+def _mount_calls() -> dict[str, ast.Call]:
+    """`app.include_router(...)` calls, asserting every one was readable."""
+    calls, unparseable = _app_mounts()
+    assert not unparseable, (
+        f"mount calls this check cannot read: {unparseable}. A shape it does not "
+        "recognise used to be skipped in silence, which let an ungated router be "
+        "invisible rather than flagged. Mount with a plain router name, or teach "
+        "this parser the new shape (#14339)."
+    )
+    return calls
 
 
 def _keywords(call: ast.Call) -> set[str]:
@@ -194,7 +375,7 @@ def _registry_block() -> str:
     and the result is indistinguishable from having nothing to report. So a
     missing marker is an error here, never an empty block.
     """
-    source = (Path(__file__).resolve().parents[2] / "main.py").read_text(encoding="utf-8")
+    source = _main_source()
     assert source.count(_REGISTRY_OPENS) == 1, f"expected exactly one {_REGISTRY_OPENS!r} marker in main.py"
     assert source.count(_REGISTRY_CLOSES) == 1, (
         f"the registry's closing marker {_REGISTRY_CLOSES!r} is missing from main.py. "
@@ -241,26 +422,29 @@ def test_the_mounted_path_is_the_one_prometheus_scrapes():
 
 
 def test_every_ungated_router_is_named_in_the_registry():
-    """`main.py` keeps a list of routers deliberately mounted without the gate.
+    """`main.py` keeps a list of surfaces deliberately mounted without the gate.
 
     Nothing enforced it, and it had already gone stale before this change — a
     public surface that is not in the one inventory the file maintains is a
     public surface nobody reviewing auth will see. So the list is checked here
-    rather than trusted: mount a router without `dependencies` and this fails
-    until it is declared, which makes adding public surface a visible act.
+    rather than trusted: mount a router without `dependencies`, or add a route
+    with `@app.get(...)`/`app.add_api_route(...)` (directly or through an
+    alias of `app`) without `dependencies`, and this fails until it is
+    declared, which makes adding public surface a visible act regardless of
+    which of the three idioms did it (#14363, #14366).
 
-    Deliberately keyed on the mount, not on the comment. A name can be removed
-    from the list and the test still fails, because the mount is what decides
-    who can reach the route.
+    Deliberately keyed on the mount/route, not on the comment. A name can be
+    removed from the list and the test still fails, because the call is what
+    decides who can reach the route.
     """
     declared = _registry_block()
 
-    ungated = {name for name, call in _mount_calls().items() if "dependencies" not in _keywords(call)}
+    ungated = {name for name, call in _bypass_calls().items() if "dependencies" not in _keywords(call)}
     undeclared = sorted(name for name in ungated if not _is_declared(name, declared))
     assert not undeclared, (
-        f"mounted without the service-management gate but not declared in the registry: "
+        f"reachable without the service-management gate but not declared in the registry: "
         f"{undeclared}. Add each with the reason it must be reachable unauthenticated, "
-        f"or mount it with `dependencies=_SM` (#14339)."
+        f"or mount/decorate it with `dependencies=_SM` (#14339, #14363, #14366)."
     )
 
 
@@ -273,7 +457,7 @@ def test_the_registry_block_is_bounded_at_both_ends():
     non-empty, because "the rest of the file" is also non-empty.
     """
     block = _registry_block()
-    source = (Path(__file__).resolve().parents[2] / "main.py").read_text(encoding="utf-8")
+    source = _main_source()
     assert block.strip(), "the registry block is empty"
     assert len(block) < len(source) / 4, (
         f"the registry block is {len(block)} chars of a {len(source)}-char file — "
@@ -336,11 +520,15 @@ def test_only_app_level_mounts_are_checked():
     decided by the `app` mounts. Matching every receiver made an inner include
     look ungated even when the outer app mount gated it.
     """
-    assert not _is_app_receiver(ast.parse("sub_router.include_router(x)").body[0].value.func.value)
-    assert _is_app_receiver(ast.parse("app.include_router(x)").body[0].value.func.value)
+    empty_aliases: frozenset[str] = frozenset()
+    assert _receiver_kind(ast.parse("sub_router.include_router(x)").body[0].value.func.value, empty_aliases) == "skip"
+    assert _receiver_kind(ast.parse("app.include_router(x)").body[0].value.func.value, empty_aliases) == "app"
     # `app.router.include_router(...)` reaches the app just as directly, and is
     # NOT a plain `app` receiver — so it must be reported, never skipped.
-    assert not _is_app_receiver(ast.parse("app.router.include_router(x)").body[0].value.func.value)
+    assert (
+        _receiver_kind(ast.parse("app.router.include_router(x)").body[0].value.func.value, empty_aliases)
+        == "unparseable"
+    )
 
 
 def test_the_registry_check_actually_sees_the_ungated_mounts():
@@ -349,6 +537,144 @@ def test_the_registry_check_actually_sees_the_ungated_mounts():
     If the mount matcher stopped matching — a rename, a different idiom — every
     router would look gated and the registry check would pass over all of them.
     """
-    ungated = {name for name, call in _mount_calls().items() if "dependencies" not in _keywords(call)}
+    ungated = {name for name, call in _bypass_calls().items() if "dependencies" not in _keywords(call)}
     assert "performance_metrics_router" in ungated
-    assert len(ungated) >= 3, f"only {len(ungated)} ungated mounts found — the matcher is broken"
+    assert "root" in ungated, "the @app.get('/') banner route is not seen as an ungated bypass"
+    assert "prometheus_registry_metrics" in ungated, "the @app.get('/metrics') route is not seen as an ungated bypass"
+    assert len(ungated) >= 5, f"only {len(ungated)} ungated mounts found — the matcher is broken"
+
+
+def test_a_bare_app_get_route_is_caught_as_an_ungated_bypass():
+    """The concrete exploit demonstrated in #14363.
+
+    Inserting this into `main.py` used to leave all 13 registry tests green
+    while the route was reachable with no authentication::
+
+        @app.get("/api/services/sneaky-list")
+        async def sneaky_list():
+            return {"leaked": "everything"}
+
+    It must now be found by the same matcher an `include_router` mount goes
+    through, and land in the ungated set because it carries no `dependencies`.
+    """
+    tree = ast.parse(
+        "@app.get('/api/services/sneaky-list')\n"
+        "async def sneaky_list():\n"
+        "    return {'leaked': 'everything'}\n"
+    )
+    calls, unparseable = _decorator_calls(tree, frozenset())
+    assert not unparseable
+    assert "sneaky_list" in calls, "a bare @app.get(...) route was not caught by the decorator matcher"
+    assert "dependencies" not in _keywords(calls["sneaky_list"])
+
+
+def test_a_gated_app_get_route_is_still_found_but_not_flagged_ungated():
+    """A route added this way with an explicit `dependencies=` is a legitimate
+    use of the idiom and must not be forced into the registry text — only the
+    ungated case should demand a declaration."""
+    tree = ast.parse(
+        "@app.get('/api/services/reports', dependencies=_SM)\n"
+        "async def reports():\n"
+        "    return {}\n"
+    )
+    calls, unparseable = _decorator_calls(tree, frozenset())
+    assert not unparseable
+    assert "reports" in calls
+    assert "dependencies" in _keywords(calls["reports"])
+
+
+def test_an_add_api_route_call_is_caught_as_an_ungated_bypass():
+    """`app.add_api_route(...)` is the third idiom named in #14363 — a call
+    rather than a decorator, but reaching the app exactly as directly."""
+    tree = ast.parse(
+        "def sneaky():\n"
+        "    return {}\n"
+        "\n"
+        "app.add_api_route('/api/services/sneaky2', sneaky)\n"
+    )
+    calls, unparseable = _add_api_route_calls(tree, frozenset())
+    assert not unparseable
+    assert "sneaky" in calls, "app.add_api_route(...) was not caught"
+    assert "dependencies" not in _keywords(calls["sneaky"])
+
+
+def test_an_alias_of_app_is_resolved_before_receiver_matching():
+    """The concrete exploit demonstrated in #14366.
+
+    ``application = app`` followed by ``application.include_router(...)``
+    used to read as a receiver that is not literally named ``app`` and was
+    skipped exactly like a genuinely different router object — leaving a
+    mounted, ungated, undeclared router unreachable by this check.
+    """
+    tree = ast.parse("application = app\napplication.include_router(some_router, prefix='/x')\n")
+    aliases = _app_aliases(tree)
+    assert "application" in aliases, "a direct alias of app was not resolved"
+
+    calls, unparseable = _app_mounts(tree)
+    assert not unparseable
+    assert "some_router" in calls, "a router mounted through an alias of app was not caught"
+
+
+def test_an_alias_extends_transitively_within_the_module():
+    """`y = x` after `x = app` is still a module-level alias of `app`.
+
+    Bounded to a single forward pass over `tree.body`, matching what
+    `_app_aliases` documents: only names that resolve back to `app` through
+    other module-level assignments are treated as aliases.
+    """
+    tree = ast.parse("x = app\ny = x\ny.include_router(some_router)\n")
+    aliases = _app_aliases(tree)
+    assert {"x", "y"} <= aliases
+
+    calls, unparseable = _app_mounts(tree)
+    assert not unparseable
+    assert "some_router" in calls
+
+
+def test_a_name_that_is_never_assigned_from_app_is_not_treated_as_an_alias():
+    """The alias resolution must not swallow ordinary router-on-router includes.
+
+    `sub_router` is never assigned from `app` anywhere in this snippet, so it
+    must still read as a legitimately different object, not a bypass.
+    """
+    tree = ast.parse("sub_router.include_router(x)\n")
+    aliases = _app_aliases(tree)
+    assert "sub_router" not in aliases
+
+    calls, unparseable = _app_mounts(tree)
+    assert not calls
+    assert not unparseable
+
+
+def test_a_decorator_reached_through_an_ambiguous_receiver_fails_closed():
+    """`@app.router.get(...)` reaches the app just as directly as
+    `app.router.include_router(...)` already does. It must be reported as
+    unreadable, never silently skipped as "some other object's decorator".
+    """
+    tree = ast.parse("@app.router.get('/api/sneaky3')\nasync def sneaky3():\n    return {}\n")
+    calls, unparseable = _decorator_calls(tree, frozenset())
+    assert not calls, "an ambiguous receiver must not be classified as a clean mount"
+    assert unparseable, "an ambiguous receiver was silently skipped instead of failing closed"
+
+
+def test_the_two_declared_app_get_routes_in_main_are_found_by_the_combined_matcher():
+    """Guard the guard: `main.py` really does carry `root` and
+    `prometheus_registry_metrics` as `@app.get(...)` routes, so the registry
+    test above is exercising the real file, not a matcher that has stopped
+    matching anything.
+    """
+    calls = _bypass_calls()
+    assert "root" in calls
+    assert "prometheus_registry_metrics" in calls
+
+
+def test_the_registry_check_sees_the_root_and_metrics_routes_as_app_get_calls():
+    """Pin the shape: both are decorator-based, not `add_api_route` or
+    `include_router` — if the idiom in `main.py` ever changes, this documents
+    what changed."""
+    tree = _main_tree()
+    aliases = _app_aliases(tree)
+    decorator_calls, unparseable = _decorator_calls(tree, aliases)
+    assert not unparseable
+    assert "root" in decorator_calls
+    assert "prometheus_registry_metrics" in decorator_calls


### PR DESCRIPTION
## Thinking Path

The registry that decides which SLM routes may be public was only ever looking at
one of the several ways a route can reach the app. It scanned `app.include_router(...)`
with a literal `app` receiver, so anything registered another way was neither gated
nor declared — it simply was not seen.

Two such ways existed. A route added with `@app.<verb>(...)` or `app.add_api_route(...)`
never passes through `include_router` at all. And binding a second name to the app
object first made the receiver read as "some other object", which the matcher skipped
using the same rule that legitimately skips a router-included-into-a-router.

The fix extends the one canonical checker rather than adding a second gate beside it.
A parallel gate would be the more likely thing to drift, and a bypass that only one of
two gates knows about is the same defect one layer up.

The classifier is deliberately three-valued rather than boolean. "Is this receiver the
app?" has a third answer — cannot tell — and collapsing that into "no" is exactly how
the alias bypass survived. Unprovable receivers are treated as in scope, so the guard
rejects what it cannot prove safe.

## What Changed

Both issues are the same defect class: the "Routers intentionally left open" registry in `autobot-slm-backend/main.py` — enforced by `tests/api/test_prometheus_scrape_is_unauthenticated_14339.py` — only ever scanned `app.include_router(...)` calls with a literal `app` receiver. Two other ways to add a reachable route slipped past it entirely:

- **#14363** — a route added with `@app.<verb>(...)` (e.g. `@app.get(...)`) or `app.add_api_route(...)` never passed through the matcher, so it was neither gated nor declared.
- **#14366** — binding another name to the app object first (`application = app; application.include_router(...)`) made the receiver read as "some other object" and was skipped, the same way a legitimate router-on-router include is skipped.

Both are closed by extending the **same** canonical check (no second, parallel gate):

- `_app_aliases()` resolves simple, module-level aliases of `app` (`x = app`, and transitively `y = x`) before any receiver is classified.
- `_receiver_kind()` is now the one place that decides whether a receiver is `app`/an alias (`"app"`), a genuinely different object (`"skip"`), or too ambiguous to prove either way (`"unparseable"` — fails closed). It replaces the inline logic previously duplicated only inside the `include_router` matcher.
- `_decorator_calls()` and `_add_api_route_calls()` apply the same classification to `@app.<verb>(...)` decorators and `app.add_api_route(...)` calls, keyed by the endpoint function's name (the same way a router mount is keyed by its variable name).
- `_all_bypass_calls()` merges all three idioms into one map, and the existing `test_every_ungated_router_is_named_in_the_registry` / `test_the_registry_check_actually_sees_the_ungated_mounts` tests now check the merged surface instead of `include_router` alone.

No new production code — the registry mechanism is a static test-time check, so this is the enforcement point.

## Scope boundary respected

`#14361`/`#14362` are concurrently touching the *body* of the Prometheus metrics handling in `autobot-slm-backend/api/performance.py` (`_generate_prometheus_metrics` / `get_prometheus_metrics`). This PR does not touch that file at all.

`main.py`'s own top-level `/metrics` route (`prometheus_registry_metrics`, calling `monitoring.prometheus_metrics.get_metrics_manager()`) **is** in scope because it's registered via `@app.get(...)` — a bypassing decorator. Only its *registration* is addressed: it is declared in the registry comment block alongside `root`. The `@app.get("/metrics", ...)` line and the handler body are byte-for-byte unchanged.

## Every currently-bypassing route, enumerated

| Name | Idiom | Verdict |
|---|---|---|
| `root` (`@app.get("/")`) | decorator | **Genuinely public** — service banner, no credentials exist before login, discloses only a static name/version string. Declared in the registry. |
| `prometheus_registry_metrics` (`@app.get("/metrics")`) | decorator | **Genuinely public** — the top-level Prometheus scrape target (#10851); a scraper cannot authenticate, same reasoning as `performance_metrics_router`. Declared in the registry. Registration-only change, per the scope boundary above. |

No `app.add_api_route(...)` calls exist in `main.py` today, and no other `@app.<verb>` decorators exist beyond the two above — confirmed by grep and by the new matcher itself finding exactly these two names. Nothing was found to be **accidentally** exposed; the two existing decorator routes were already intentional, just undeclared and previously invisible to the check.

## Guard fails closed

`_receiver_kind()` treats any receiver it cannot positively resolve to `app`/a known alias, and cannot positively resolve to an unrelated bare name either (e.g. `app.router.get(...)`, a call result, a subscript), as `"unparseable"` — which fails the suite rather than being silently skipped. This rule is now shared by all three matchers (`include_router`, decorator, `add_api_route`), not restated per-idiom.

## Verification

Verified with a standalone script (no codebase imports — pure `ast`/`re` re-implementation of the exact logic now in the test file, diffed AST-structurally against the committed functions to confirm faithful transcription) against the real `main.py`:

**Before the fix** (old matcher: `include_router` only, no alias resolution):
- `@app.get(...)` bypass route injected → registry check stays **green** (undeclared=[], the route is invisible to the old matcher).
- `browser_router` re-mounted through `application = app; application.include_router(browser_router, ...)`, dropping `dependencies=_SM` → registry check stays **green** (the alias reads as an unrelated object).

**After the fix:**
- Baseline (unmodified, fixed `main.py`): registry check **passes** — 13 pre-existing assertions + 9 new ones, all green.
- `@app.get(...)` bypass injected → **fails**: `undeclared=['sneaky_list']`.
- Alias bypass (`application = app`) injected → **fails**: `undeclared=['browser_router']`.
- `app.add_api_route(...)` bypass injected → **fails**: `undeclared=['sneaky2']`.
- Revert (remove all three mutations) → **passes** again.

Test count: 13 → 22 (9 new tests), including a dedicated test per mutation shape (`test_a_bare_app_get_route_is_caught_as_an_ungated_bypass`, `test_an_alias_of_app_is_resolved_before_receiver_matching`, `test_an_add_api_route_call_is_caught_as_an_ungated_bypass`) plus a fail-closed test for an ambiguous receiver (`test_a_decorator_reached_through_an_ambiguous_receiver_fails_closed`) and negative controls confirming legitimate router-on-router includes and gated `@app.get(...)` routes are still correctly *not* flagged.

## Checklist

- [x] Scan `@app.<verb>` decorators and `app.add_api_route` calls alongside `include_router` (#14363)
- [x] Require each to be declared with a reason, the same way routers are (#14363)
- [x] Declare the two existing legitimate instances (`root`, `prometheus_registry_metrics`) rather than exempting the pattern (#14363)
- [x] Guard it: a synthetic unauthenticated `@app.get` must fail the check (#14363)
- [x] Resolve simple module-level aliases of `app` (#14366)
- [x] Guard it: mounting an ungated, undeclared router through an alias of `app` fails the check (#14366)
- [x] Single canonical gate extended, not a second parallel one
- [x] Fail closed on a receiver shape the matcher cannot positively classify

Closes #14363, #14366

## Model Used

Claude Opus 5.
