### PR TITLE
fix(infrastructure): unbreak two operator scripts and nl_database's secrets import (#14129, #14127)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -49,8 +49,14 @@ docs
 # #14127: pytest.ini's `python_files = test_*.py *_test.py` treats BOTH naming
 # conventions as tests (colocated, #734) -- this file only excluded the suffix
 # form. 58 prefix-form files (autobot-backend/agent_loop/test_loop_repetition.py
-# and 57 others) were shipping into every Docker image nothing referenced them
-# from outside a test.
+# and 57 others) were shipping into every Docker image.
+#
+# Both rules are deliberately broad: a production module must not be named like a
+# test, so there is no allowlist here to go stale. Two modules were, and were
+# renamed rather than exempted -- code_intelligence/test_pattern_analyzer.py ->
+# testing_pattern_analyzer.py and utils/redis_immediate_test.py ->
+# redis_immediate_connection.py. `repo_tests/test_dockerignore_test_file_coverage_14127.py`
+# fails on any new one, so a rule this broad stays safe.
 **/test_*.py
 **/*.test.ts
 **/*.spec.ts

--- a/.dockerignore
+++ b/.dockerignore
@@ -46,6 +46,12 @@ docs
 # Tests
 **/tests
 **/*_test.py
+# #14127: pytest.ini's `python_files = test_*.py *_test.py` treats BOTH naming
+# conventions as tests (colocated, #734) -- this file only excluded the suffix
+# form. 58 prefix-form files (autobot-backend/agent_loop/test_loop_repetition.py
+# and 57 others) were shipping into every Docker image nothing referenced them
+# from outside a test.
+**/test_*.py
 **/*.test.ts
 **/*.spec.ts
 **/cypress

--- a/.test_durations
+++ b/.test_durations
@@ -20324,7 +20324,6 @@
     "autobot-backend/utils/redis_consolidation_test.py::TestPhase4AdvancedFeatures::test_pipeline_context_manager_exists": 0.002729925999972238,
     "autobot-backend/utils/redis_consolidation_test.py::test_documentation_completeness": 0.0032823050000274634,
     "autobot-backend/utils/redis_consolidation_test.py::test_module_imports": 0.0036010280001050887,
-    "autobot-backend/utils/redis_immediate_test.py::test_redis_connection_immediate": 0.004071015999954852,
     "autobot-backend/utils/redis_thread_safety_test.py::TestIdleCleanupThreadSafety::test_cleanup_doesnt_affect_active_connections": 0.003880088999949294,
     "autobot-backend/utils/redis_thread_safety_test.py::TestIdleCleanupThreadSafety::test_cleanup_handles_concurrent_pool_modifications": 0.004578429999924083,
     "autobot-backend/utils/redis_thread_safety_test.py::TestIdleCleanupThreadSafety::test_cleanup_idle_connections_builds_removal_list_first": 0.004098126000030788,

--- a/autobot-backend/api/nl_database.py
+++ b/autobot-backend/api/nl_database.py
@@ -15,6 +15,7 @@ Endpoints:
 - GET  /nl-database/history       - Retrieve query history
 """
 
+import asyncio
 from typing import Any, Dict, List
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
@@ -63,10 +64,14 @@ async def _resolve_db_url(db_secret_id: str | None, request: Request) -> str | N
         return None
 
     try:
-        from api.secrets import get_secrets_manager
+        from api.secrets import secrets_manager
 
-        manager = get_secrets_manager()
-        secret = await manager.get_secret(db_secret_id, user_id=None)
+        # api.secrets exposes the SecretsManager *singleton* (`secrets_manager`),
+        # not a `get_secrets_manager()` factory (#14127). `get_secret` is a
+        # blocking (file-I/O) call, so it goes through asyncio.to_thread rather
+        # than being awaited directly, matching every other call site in the
+        # backend (see api/secrets.py's own `_get_secret_dual_read`).
+        secret = await asyncio.to_thread(secrets_manager.get_secret, db_secret_id, chat_id=None)
         if secret is None:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,

--- a/autobot-backend/api/nl_database_test.py
+++ b/autobot-backend/api/nl_database_test.py
@@ -1,0 +1,120 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for api/nl_database.py's secret-resolution path (#14127).
+
+`_resolve_db_url` imported ``get_secrets_manager`` from ``api.secrets`` -- a
+name that has never existed there (``api.secrets`` exposes the
+``SecretsManager`` *singleton*, ``secrets_manager``). Every call raised
+``ImportError`` and every ImportError was caught by the function's own broad
+``except Exception`` and turned into a generic 500 -- indistinguishable from
+any other failure, and nothing noticed because this file had no test at all.
+
+These tests exercise ``_resolve_db_url`` through the real import (no
+conftest/fixture stubs ``api.secrets`` or ``get_secrets_manager`` -- see
+``test_module_imports_in_a_realistic_subprocess`` below and
+``repo_tests/test_ci_import_smoke_paths_14252.py`` for the module-path guard),
+monkeypatching only the data layer (``secrets_manager.get_secret``) so a
+reintroduced-bad-import regresses these back to a 500/ImportError instead of
+silently passing.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+
+from api.nl_database import _resolve_db_url
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_BACKEND_DIR = _REPO_ROOT / "autobot-backend"
+_FAKE_DB_URL = "postgresql://localhost/nl_database_test_db"
+
+
+def test_module_imports_in_a_realistic_subprocess():
+    """api.nl_database must import cleanly with a fresh interpreter and no
+    fixture pre-stubbing ``api.secrets`` -- the failure mode that hid #14127
+    (the broken import lived inside a function body, so even the existing
+    module-level `test_startup_imports.py::test_api_module_imports` sweep
+    never triggered it; only calling `_resolve_db_url` does).
+    """
+    # `autobot_shared.*` imports resolve off the repo ROOT (the package is
+    # `autobot_shared/__init__.py`, not a `src`-layout); `autobot-backend` is
+    # needed for the module's own first-party imports (api.*, models.*, ...).
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join([str(_BACKEND_DIR), str(_REPO_ROOT), env.get("PYTHONPATH", "")])
+
+    result = subprocess.run(
+        [sys.executable, "-c", "import api.nl_database"],
+        capture_output=True,
+        text=True,
+        cwd=str(_BACKEND_DIR),
+        env=env,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.asyncio
+async def test_resolve_db_url_returns_none_when_no_secret_id():
+    assert await _resolve_db_url(None, request=None) is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_db_url_returns_value_for_a_database_url_secret(monkeypatch):
+    def fake_get_secret(secret_id: str, chat_id: str | None = None):
+        assert secret_id == "secret-123"
+        assert chat_id is None
+        return {"type": "database_url", "value": _FAKE_DB_URL}
+
+    monkeypatch.setattr("api.secrets.secrets_manager.get_secret", fake_get_secret)
+
+    result = await _resolve_db_url("secret-123", request=None)
+
+    assert result == _FAKE_DB_URL
+
+
+@pytest.mark.asyncio
+async def test_resolve_db_url_404s_when_secret_missing(monkeypatch):
+    monkeypatch.setattr("api.secrets.secrets_manager.get_secret", lambda *a, **kw: None)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _resolve_db_url("missing-secret", request=None)
+
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_resolve_db_url_400s_for_wrong_secret_type(monkeypatch):
+    monkeypatch.setattr(
+        "api.secrets.secrets_manager.get_secret",
+        lambda *a, **kw: {"type": "api_key", "value": "not-a-db-url"},
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _resolve_db_url("wrong-type-secret", request=None)
+
+    assert exc_info.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_resolve_db_url_500s_when_the_data_layer_raises(monkeypatch):
+    """The broad `except Exception` boundary still applies to *real* data-layer
+    failures (e.g. a decrypt error) -- only the import itself was ever broken.
+    """
+
+    def boom(*_a, **_kw):
+        raise RuntimeError("decrypt failure")
+
+    monkeypatch.setattr("api.secrets.secrets_manager.get_secret", boom)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _resolve_db_url("any-secret", request=None)
+
+    assert exc_info.value.status_code == 500

--- a/autobot-backend/code_intelligence/__init__.py
+++ b/autobot-backend/code_intelligence/__init__.py
@@ -292,7 +292,7 @@ from .security import (
     get_vulnerability_types,
 )
 from .shell_analyzer import ShellAnalyzer, shell_analyzer
-from .test_pattern_analyzer import (
+from .testing_pattern_analyzer import (
     CoverageGap,
     TestAnalysisReport,
     TestAntiPatternResult,

--- a/autobot-backend/code_intelligence/testing_pattern_analyzer.py
+++ b/autobot-backend/code_intelligence/testing_pattern_analyzer.py
@@ -13,6 +13,13 @@ Analyzes test patterns to identify:
 
 Part of Issue #236 - Test-Driven Pattern Discovery
 Parent Epic: #217 - Advanced Code Intelligence
+
+Named ``test_pattern_analyzer.py`` until #14127: production code (re-exported by
+``code_intelligence/__init__.py``), but the name matched pytest's own
+`python_files = test_*.py`, so `.dockerignore` stripped it from every Docker image
+and the backend died at import with `ModuleNotFoundError`. The colocated-test
+convention in this package is the ``<module>_test.py`` suffix; this module is not a
+test. See `repo_tests/test_dockerignore_test_file_coverage_14127.py`.
 """
 
 import ast

--- a/autobot-backend/conftest.py
+++ b/autobot-backend/conftest.py
@@ -1074,17 +1074,17 @@ _real_load_and_bind(
 # new colocated test file is added for a stubbed submodule — otherwise that test
 # silently asserts against MagicMock attributes instead of real behaviour.
 #
-# NOTE: "code_intelligence.test_pattern_analyzer" is intentionally NOT in this
-# list (#12437). Stubbing it here would poison sys.modules before pytest ever
-# collects code_intelligence/test_pattern_analyzer.py itself: with
-# --import-mode=importlib, pytest's import_path() returns whatever is already
-# in sys.modules[module_name] rather than re-importing, so the real test file
-# would never execute — pytest would instead try to treat the MagicMock-backed
-# stub module as the test module, and accessing its (mocked) `pytestmark`
-# attribute raises TypeError during collection. Nothing else in the codebase
-# imports this submodule (code_intelligence/__init__.py does, but that package
-# is itself fully stubbed above and never executes its real __init__), so
-# leaving it unstubbed is safe.
+# NOTE: "code_intelligence.testing_pattern_analyzer" is intentionally NOT in this
+# list (#12437, #14127). It was named test_pattern_analyzer.py until #14127, which
+# made pytest collect the production module itself; stubbing it here would then
+# poison sys.modules before that collection (with --import-mode=importlib,
+# pytest's import_path() returns whatever is already in sys.modules[module_name]
+# rather than re-importing, and accessing the MagicMock stub's `pytestmark`
+# raises TypeError during collection). The rename ends the collection, but the
+# entry still does not belong here: nothing else in the codebase imports this
+# submodule (code_intelligence/__init__.py does, but that package is itself fully
+# stubbed above and never executes its real __init__), so leaving it unstubbed
+# keeps the stub list to modules that actually need one.
 for _ci_sub in [
     "code_intelligence.performance_analyzer",
     "code_intelligence.redis_optimizer",

--- a/autobot-backend/utils/async_cancellation.py
+++ b/autobot-backend/utils/async_cancellation.py
@@ -113,7 +113,7 @@ class ResourceMonitor:
 
         # Quick Redis check
         try:
-            from utils.redis_immediate_test import redis_circuit_breaker
+            from utils.redis_immediate_connection import redis_circuit_breaker
 
             self.redis_available = not redis_circuit_breaker.is_circuit_open
         except Exception:

--- a/autobot-backend/utils/redis_immediate_connection.py
+++ b/autobot-backend/utils/redis_immediate_connection.py
@@ -3,8 +3,14 @@
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
 """
-Redis Immediate Connection Test - No Timeouts
-Replaces timeout-based Redis connection with immediate success/failure patterns
+Redis Immediate Connection Checks - No Timeouts
+Replaces timeout-based Redis connection with immediate success/failure patterns.
+
+Named ``redis_immediate_test.py`` until #14127: production code, but the name
+matched `.dockerignore`'s `**/*_test.py`, so it was stripped from every Docker
+image while `utils/async_cancellation.py` still imported `redis_circuit_breaker`
+from it inside a bare `except Exception` -- leaving `redis_available` silently
+pinned to False in every container. See `repo_tests/test_dockerignore_test_file_coverage_14127.py`.
 """
 
 import asyncio
@@ -272,12 +278,15 @@ async def get_redis_with_immediate_test(
     return await create_redis_with_fallback(config, fallback_configs)
 
 
-async def test_redis_connection_immediate(
+async def check_redis_connection_immediate(
     database: str = "main",
 ) -> redis.Redis | None:
     """
     Test Redis connection immediately and return canonical client if successful.
-    Used by backend startup to quickly test Redis availability.
+
+    Named ``test_redis_connection_immediate`` until #14127, which made pytest
+    collect it from the then `*_test.py`-named module as a test that could only
+    ever pass (no assertions, and `get_redis_client()` returns None in CI).
 
     USES CANONICAL get_redis_client() PATTERN:
     - Circuit breaker protection

--- a/autobot-infrastructure/shared/scripts/monitoring/start_hardware_monitoring.py
+++ b/autobot-infrastructure/shared/scripts/monitoring/start_hardware_monitoring.py
@@ -18,8 +18,12 @@ from pathlib import Path
 
 from autobot_shared.ssot_constants import CategoryDefaults
 
-# Add project root to Python path
-project_root = Path(__file__).parent.parent.parent
+# Add autobot-backend to Python path so the `utils.*` imports below resolve
+# regardless of the caller's working directory. The previous
+# `Path(__file__).parent.parent.parent` landed on
+# autobot-infrastructure/shared/, which has no `utils` package — this lands
+# on autobot-backend/, which does (#14129).
+project_root = Path(__file__).resolve().parents[4] / "autobot-backend"
 sys.path.insert(0, str(project_root))
 
 from utils.gpu_acceleration_optimizer import (
@@ -30,14 +34,17 @@ from utils.gpu_acceleration_optimizer import (
     optimize_gpu_for_multimodal,
 )
 
-# Import Phase 9 monitoring components
+# Import hardware monitoring components. `start_phase9_monitoring` /
+# `stop_phase9_monitoring` were renamed to `start_hardware_monitoring` /
+# `stop_hardware_monitoring` in #10666/#10733 (B6 phase-era-prefix cleanup);
+# this script was never updated to follow (#14129).
 from utils.hardware_metrics import (
     add_phase9_alert_callback,
     collect_phase9_metrics,
     get_phase9_performance_dashboard,
     hardware_monitor,
-    start_phase9_monitoring,
-    stop_phase9_monitoring,
+    start_hardware_monitoring as start_phase9_monitoring,
+    stop_hardware_monitoring as stop_phase9_monitoring,
 )
 
 # Configure logging

--- a/autobot-infrastructure/shared/scripts/utilities/manage_system_knowledge.py
+++ b/autobot-infrastructure/shared/scripts/utilities/manage_system_knowledge.py
@@ -14,7 +14,20 @@ import logging
 import sys
 from pathlib import Path
 
-from autobot_shared.ssot_constants import CategoryDefaults
+# Add autobot-backend to sys.path so the first-party `knowledge`/`agents`
+# imports below resolve regardless of the caller's working directory (#14129).
+# This script is a standalone operator entry point, not part of an installed
+# package, so it needs the same explicit path setup other scripts under
+# autobot-infrastructure/shared/scripts/ use.
+_BACKEND_DIR = Path(__file__).resolve().parents[4] / "autobot-backend"
+if str(_BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_DIR))
+
+import yaml  # noqa: E402 - must follow the sys.path setup above
+
+from agents.system_knowledge_manager import SystemKnowledgeManager  # noqa: E402
+from autobot_shared.ssot_constants import CategoryDefaults  # noqa: E402
+from knowledge import KnowledgeBase  # noqa: E402
 
 logger = logging.getLogger(__name__)
 

--- a/repo_tests/test_dockerignore_test_file_coverage_14127.py
+++ b/repo_tests/test_dockerignore_test_file_coverage_14127.py
@@ -22,12 +22,23 @@ Docker-syntax-compatible glob matcher, not a full spec implementation --
 sufficient for the finite pattern set actually in this file), not a Docker
 build -- so a new test file in either naming convention that predates its
 own `.dockerignore` coverage fails here instead of shipping in an image.
+
+The second half guards the other direction (#14413): a rule broad enough to
+catch every test file also catches any *production* module named like one, and
+excluding a module something imports at runtime is an ImportError in the image.
+`**/test_*.py` did exactly that to `code_intelligence/test_pattern_analyzer.py`,
+killing every backend container at startup; `**/*_test.py` had already done the
+silent version to `utils/redis_immediate_test.py`. Both were renamed, not
+allowlisted, and `test_no_shipped_module_imports_a_dockerignored_file` is what
+keeps a rule this broad safe.
 """
 
 from __future__ import annotations
 
 import fnmatch
+import re
 import subprocess
+from functools import lru_cache
 from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -44,16 +55,33 @@ def _dockerignore_patterns() -> list[str]:
 
 
 def _matches_pattern(relative_posix: str, pattern: str) -> bool:
-    """Docker-ignore-style match: a leading '**/' matches any depth, including zero."""
+    """Docker-ignore-style match: a leading '**/' matches any depth, including zero;
+    a plain pattern also excludes everything *under* a directory it names (`docs`
+    excludes `docs/guides/x.py`), which is how Docker reads it.
+    """
+    parts = relative_posix.split("/")
     if pattern.startswith("**/"):
         tail = pattern[3:]
-        parts = relative_posix.split("/")
         return any(fnmatch.fnmatch("/".join(parts[i:]), tail) for i in range(len(parts)))
-    return fnmatch.fnmatch(relative_posix, pattern) or fnmatch.fnmatch(Path(relative_posix).name, pattern)
+    if any(fnmatch.fnmatch("/".join(parts[:i]), pattern) for i in range(1, len(parts) + 1)):
+        return True
+    return fnmatch.fnmatch(parts[-1], pattern)
 
 
-def _is_dockerignored(relative_posix: str, patterns: list[str]) -> bool:
+@lru_cache(maxsize=None)
+def _is_dockerignored_cached(relative_posix: str, patterns: tuple[str, ...]) -> bool:
     return any(_matches_pattern(relative_posix, pattern) for pattern in patterns)
+
+
+def _is_dockerignored(relative_posix: str, patterns) -> bool:
+    """Memoised -- the import guard below asks about every tracked file once per
+    sys.path root, which is tens of thousands of repeated questions."""
+    return _is_dockerignored_cached(relative_posix, tuple(patterns))
+
+
+@lru_cache(maxsize=None)
+def _dockerignored_patterns_cached() -> tuple[str, ...]:
+    return tuple(_dockerignore_patterns())
 
 
 def _tracked_test_files() -> list[str]:
@@ -105,6 +133,177 @@ def test_the_gap_that_was_missed_would_now_be_caught():
 
 
 def test_the_corrected_pattern_covers_the_prefix_convention():
-    patterns = _dockerignore_patterns()
+    patterns = _dockerignored_patterns_cached()
 
     assert _is_dockerignored("autobot-backend/orchestration/test_causal_executor.py", patterns)
+
+
+# ---------------------------------------------------------------------------
+# The other half of the invariant (#14127): a rule broad enough to exclude every
+# test file is only safe while no *shipped* module imports something it excludes.
+# `**/test_*.py` was broad enough and did exactly that -- code_intelligence/
+# __init__.py imported .test_pattern_analyzer (production code, prefix-named), so
+# every backend container died at import with ModuleNotFoundError. The pre-existing
+# `**/*_test.py` rule had already done the quieter version of the same thing:
+# utils/async_cancellation.py imported utils.redis_immediate_test inside a bare
+# `except Exception`, pinning `redis_available` to False in every image.
+#
+# The fix is a rename in both cases, not an allowlist -- an allowlist entry naming
+# a moved file exempts nothing, silently. This check is what makes that safe.
+# ---------------------------------------------------------------------------
+
+_IMPORT_HEAD = re.compile(
+    r"^[ \t]*(?:from[ \t]+(?P<dots>\.*)(?P<from_mod>[A-Za-z0-9_.]*)[ \t]+import\b"
+    r"|import[ \t]+(?P<import_mods>[A-Za-z0-9_.]+(?:[ \t]*,[ \t]*[A-Za-z0-9_.]+)*))",
+    re.MULTILINE,
+)
+
+
+def _import_heads(text: str) -> list[tuple[int, str, int]]:
+    """(line, module, relative-level) for every import statement head.
+
+    Only the head matters: a module name always sits on the statement's first
+    line, even when the imported names are wrapped across several.
+    """
+    heads: list[tuple[int, str, int]] = []
+    for match in _IMPORT_HEAD.finditer(text):
+        line = text.count("\n", 0, match.start()) + 1
+        if match.group("import_mods"):
+            heads.extend((line, name.strip(), 0) for name in match.group("import_mods").split(","))
+        else:
+            heads.append((line, match.group("from_mod"), len(match.group("dots"))))
+    return heads
+
+
+def _module_index(files: list[str], patterns: list[str]) -> tuple[dict[str, str], set[str]]:
+    """Map absolute dotted module name -> excluded file, plus the names that ship.
+
+    Every top-level directory acts as a sys.path root (that is how the images run
+    the backends), so one file yields a dotted name per root that contains it.
+    """
+    patterns = tuple(patterns)
+    roots = sorted({f.split("/")[0] for f in files if "/" in f} | {""})
+    excluded: dict[str, str] = {}
+    shipped: set[str] = set()
+    for relative in files:
+        stem = relative[: -len(".py")].removesuffix("/__init__")
+        for root in roots:
+            prefix = f"{root}/" if root else ""
+            if not stem.startswith(prefix):
+                continue
+            dotted = stem[len(prefix) :].replace("/", ".")
+            if not dotted:
+                continue
+            if _is_dockerignored(relative, patterns):
+                excluded.setdefault(dotted, relative)
+            else:
+                shipped.add(dotted)
+    return excluded, shipped
+
+
+def _imports_of_excluded_files(files, patterns, read_text) -> list[tuple[str, int, str]]:
+    """Every (importer, line, excluded target) where a shipped file imports a file
+    `.dockerignore` strips from the build context -- i.e. an ImportError waiting
+    in the image. A name that *also* resolves to a shipped module is not a finding.
+    """
+    patterns = tuple(patterns)
+    excluded, shipped = _module_index(files, patterns)
+    tracked = set(files)
+    findings: list[tuple[str, int, str]] = []
+    for relative in files:
+        if _is_dockerignored(relative, patterns):
+            continue
+        for line, module, level in _import_heads(read_text(relative)):
+            if level:
+                base = Path(relative).parent
+                for _ in range(level - 1):
+                    base = base.parent
+                target = base.joinpath(*module.split(".")) if module else base
+                candidates = [f"{target}.py", f"{target}/__init__.py"]
+                findings.extend(
+                    (relative, line, c) for c in candidates if c in tracked and _is_dockerignored(c, patterns)
+                )
+            elif module in excluded and module not in shipped:
+                findings.append((relative, line, excluded[module]))
+    return sorted(set(findings))
+
+
+@lru_cache(maxsize=None)
+def _tracked_python_files() -> tuple[str, ...]:
+    result = subprocess.run(
+        ["git", "-C", str(_REPO_ROOT), "ls-files", "*.py"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return tuple(line for line in result.stdout.splitlines() if line.strip())
+
+
+def _read_tracked(relative: str) -> str:
+    return (_REPO_ROOT / relative).read_text(encoding="utf-8", errors="replace")
+
+
+def test_no_shipped_module_imports_a_dockerignored_file():
+    """The invariant, on the real tree: nothing that reaches an image imports
+    something `.dockerignore` keeps out of it."""
+    findings = _imports_of_excluded_files(_tracked_python_files(), _dockerignored_patterns_cached(), _read_tracked)
+
+    assert findings == [], "shipped module(s) import a file .dockerignore strips from the build context: " + "; ".join(
+        f"{importer}:{line} -> {target}" for importer, line, target in findings[:10]
+    )
+
+
+def test_the_import_scan_reaches_the_backend_trees():
+    """An empty or backend-less scan would make the assertion above vacuous."""
+    patterns = _dockerignored_patterns_cached()
+    shipped = [f for f in _tracked_python_files() if not _is_dockerignored(f, patterns)]
+
+    assert len(shipped) > 1000
+    assert sum(1 for f in shipped if f.startswith("autobot-backend/")) > 100
+
+
+def test_the_detector_catches_the_regression_it_was_written_for():
+    """The reproduction, as a direct assertion on the detector (#14127).
+
+    Both shapes that actually broke: a relative import of a prefix-named sibling
+    (the ModuleNotFoundError that killed every backend container) and an absolute
+    import of a suffix-named module (the silent one).
+    """
+    rules = ["**/test_*.py", "**/*_test.py"]
+    sources = {
+        "backend/pkg/__init__.py": "from .test_analyzer import Analyzer\n",
+        "backend/pkg/test_analyzer.py": "",
+        "backend/utils/caller.py": "def check():\n    from utils.circuit_test import breaker\n",
+        "backend/utils/circuit_test.py": "",
+    }
+
+    findings = _imports_of_excluded_files(list(sources), rules, sources.__getitem__)
+
+    assert findings == [
+        ("backend/pkg/__init__.py", 1, "backend/pkg/test_analyzer.py"),
+        ("backend/utils/caller.py", 2, "backend/utils/circuit_test.py"),
+    ]
+
+    # ... and stays quiet once the modules are renamed out of the test conventions,
+    # which is the fix that was applied rather than an allowlist entry.
+    renamed = {
+        "backend/pkg/__init__.py": "from .testing_analyzer import Analyzer\n",
+        "backend/pkg/testing_analyzer.py": "",
+        "backend/utils/caller.py": "def check():\n    from utils.circuit_connection import breaker\n",
+        "backend/utils/circuit_connection.py": "",
+    }
+
+    assert _imports_of_excluded_files(list(renamed), rules, renamed.__getitem__) == []
+
+
+def test_no_negation_line_re_includes_a_python_file():
+    """`_dockerignore_patterns()` drops `!` lines, so a Python re-include would make
+    every check above read a file as excluded when Docker ships it. Keep the fix a
+    rename, not an exemption."""
+    negations = [
+        line.strip()[1:]
+        for line in _DOCKERIGNORE.read_text(encoding="utf-8").splitlines()
+        if line.strip().startswith("!")
+    ]
+
+    assert [n for n in negations if n.endswith(".py") or n.endswith("*")] == []

--- a/repo_tests/test_dockerignore_test_file_coverage_14127.py
+++ b/repo_tests/test_dockerignore_test_file_coverage_14127.py
@@ -262,6 +262,29 @@ def test_the_import_scan_reaches_the_backend_trees():
     assert sum(1 for f in shipped if f.startswith("autobot-backend/")) > 100
 
 
+_TEST_FILE_RULES = ["**/test_*.py", "**/*_test.py"]
+
+# A miniature tree carrying both shapes that actually broke: `pkg/__init__.py`
+# relative-importing a prefix-named sibling (the ModuleNotFoundError that killed
+# every backend container) and `utils/caller.py` absolute-importing a suffix-named
+# module from inside a function (the silent one).
+_BROKEN_TREE = {
+    "backend/pkg/__init__.py": "from .test_analyzer import Analyzer\n",
+    "backend/pkg/test_analyzer.py": "",
+    "backend/utils/caller.py": "def check():\n    from utils.circuit_test import breaker\n",
+    "backend/utils/circuit_test.py": "",
+}
+
+# The same tree with the fix that was applied: both modules renamed out of the
+# test conventions, no `.dockerignore` exemption anywhere.
+_FIXED_TREE = {
+    "backend/pkg/__init__.py": "from .testing_analyzer import Analyzer\n",
+    "backend/pkg/testing_analyzer.py": "",
+    "backend/utils/caller.py": "def check():\n    from utils.circuit_connection import breaker\n",
+    "backend/utils/circuit_connection.py": "",
+}
+
+
 def test_the_detector_catches_the_regression_it_was_written_for():
     """The reproduction, as a direct assertion on the detector (#14127).
 
@@ -269,31 +292,19 @@ def test_the_detector_catches_the_regression_it_was_written_for():
     (the ModuleNotFoundError that killed every backend container) and an absolute
     import of a suffix-named module (the silent one).
     """
-    rules = ["**/test_*.py", "**/*_test.py"]
-    sources = {
-        "backend/pkg/__init__.py": "from .test_analyzer import Analyzer\n",
-        "backend/pkg/test_analyzer.py": "",
-        "backend/utils/caller.py": "def check():\n    from utils.circuit_test import breaker\n",
-        "backend/utils/circuit_test.py": "",
-    }
-
-    findings = _imports_of_excluded_files(list(sources), rules, sources.__getitem__)
+    findings = _imports_of_excluded_files(list(_BROKEN_TREE), _TEST_FILE_RULES, _BROKEN_TREE.__getitem__)
 
     assert findings == [
         ("backend/pkg/__init__.py", 1, "backend/pkg/test_analyzer.py"),
         ("backend/utils/caller.py", 2, "backend/utils/circuit_test.py"),
     ]
 
-    # ... and stays quiet once the modules are renamed out of the test conventions,
-    # which is the fix that was applied rather than an allowlist entry.
-    renamed = {
-        "backend/pkg/__init__.py": "from .testing_analyzer import Analyzer\n",
-        "backend/pkg/testing_analyzer.py": "",
-        "backend/utils/caller.py": "def check():\n    from utils.circuit_connection import breaker\n",
-        "backend/utils/circuit_connection.py": "",
-    }
 
-    assert _imports_of_excluded_files(list(renamed), rules, renamed.__getitem__) == []
+def test_the_detector_goes_quiet_once_the_modules_are_renamed():
+    """The other half of the mutation: the fix that was applied (a rename out of
+    both test conventions) clears the finding, so the assertion above is pinned to
+    the defect and not to the detector simply reporting everything."""
+    assert _imports_of_excluded_files(list(_FIXED_TREE), _TEST_FILE_RULES, _FIXED_TREE.__getitem__) == []
 
 
 def test_no_negation_line_re_includes_a_python_file():

--- a/repo_tests/test_dockerignore_test_file_coverage_14127.py
+++ b/repo_tests/test_dockerignore_test_file_coverage_14127.py
@@ -1,0 +1,110 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Every tracked test file must be excluded from Docker build contexts (#14127).
+
+`.dockerignore` excluded `**/*_test.py` (the suffix convention) but not
+`**/test_*.py` (the prefix convention) -- both are test files by this repo's
+own definition (`pytest.ini`'s `python_files = test_*.py *_test.py`, colocated
+per #734), so the prefix form shipped into every Docker image built from
+`docker/backend/Dockerfile`'s `COPY autobot-backend/ /app/autobot-backend/`
+(and the sibling backends' equivalents). 58 files did, none referenced by
+anything outside a test.
+
+`autobot-backend/utils/secrets_store_migration_test.py` -- the file #14127
+named specifically -- turned out to already be covered by the pre-existing
+`**/*_test.py` rule; the real gap was the other naming convention, on files
+that rule never looked at.
+
+This is a static check against `.dockerignore`'s own patterns (a small,
+Docker-syntax-compatible glob matcher, not a full spec implementation --
+sufficient for the finite pattern set actually in this file), not a Docker
+build -- so a new test file in either naming convention that predates its
+own `.dockerignore` coverage fails here instead of shipping in an image.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import subprocess
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_DOCKERIGNORE = _REPO_ROOT / ".dockerignore"
+
+# Directories with their own dependency/packaging story (frontend bundlers,
+# vendored trees) -- not backend Docker images, so not in scope for this check.
+_EXCLUDED_ROOTS = ("autobot-frontend/", "autobot-slm-frontend/", "node_modules/")
+
+
+def _dockerignore_patterns() -> list[str]:
+    lines = _DOCKERIGNORE.read_text(encoding="utf-8").splitlines()
+    return [line.strip() for line in lines if line.strip() and not line.strip().startswith(("#", "!"))]
+
+
+def _matches_pattern(relative_posix: str, pattern: str) -> bool:
+    """Docker-ignore-style match: a leading '**/' matches any depth, including zero."""
+    if pattern.startswith("**/"):
+        tail = pattern[3:]
+        parts = relative_posix.split("/")
+        return any(fnmatch.fnmatch("/".join(parts[i:]), tail) for i in range(len(parts)))
+    return fnmatch.fnmatch(relative_posix, pattern) or fnmatch.fnmatch(Path(relative_posix).name, pattern)
+
+
+def _is_dockerignored(relative_posix: str, patterns: list[str]) -> bool:
+    return any(_matches_pattern(relative_posix, pattern) for pattern in patterns)
+
+
+def _tracked_test_files() -> list[str]:
+    """Every git-tracked file matching pytest's own test-file conventions
+    (`python_files = test_*.py *_test.py` in pytest.ini), outside the frontend
+    trees this check does not cover.
+    """
+    result = subprocess.run(
+        ["git", "-C", str(_REPO_ROOT), "ls-files", "*test_*.py"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    files = [line for line in result.stdout.splitlines() if line.strip()]
+    return [
+        f
+        for f in files
+        if not f.startswith(_EXCLUDED_ROOTS) and (Path(f).name.startswith("test_") or Path(f).name.endswith("_test.py"))
+    ]
+
+
+def test_the_scan_actually_found_test_files():
+    """An empty scan would make the assertion below vacuous."""
+    assert len(_tracked_test_files()) > 100
+
+
+def test_every_tracked_test_file_is_dockerignored():
+    patterns = _dockerignore_patterns()
+    missing = [f for f in _tracked_test_files() if not _is_dockerignored(f, patterns)]
+
+    assert missing == [], (
+        f"{len(missing)} tracked test file(s) are not excluded by .dockerignore and "
+        f"will ship into a Docker image built from the repo root: {missing[:10]}"
+        + (" ..." if len(missing) > 10 else "")
+    )
+
+
+def test_the_gap_that_was_missed_would_now_be_caught():
+    """The reproduction, as a direct assertion on the matcher (#14127).
+
+    `secrets_store_migration_test.py` (suffix convention) was already covered;
+    `test_causal_executor.py` (prefix convention) was not, before `**/test_*.py`
+    was added to `.dockerignore`.
+    """
+    patterns_before = [p for p in _dockerignore_patterns() if p != "**/test_*.py"]
+
+    assert _is_dockerignored("autobot-backend/utils/secrets_store_migration_test.py", patterns_before)
+    assert not _is_dockerignored("autobot-backend/orchestration/test_causal_executor.py", patterns_before)
+
+
+def test_the_corrected_pattern_covers_the_prefix_convention():
+    patterns = _dockerignore_patterns()
+
+    assert _is_dockerignored("autobot-backend/orchestration/test_causal_executor.py", patterns)

--- a/repo_tests/test_infra_scripts_import_14129.py
+++ b/repo_tests/test_infra_scripts_import_14129.py
@@ -1,0 +1,174 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Import-integrity guard for autobot-infrastructure/shared/scripts/ (#14129).
+
+`manage_system_knowledge.py` referenced `KnowledgeBase`, `SystemKnowledgeManager`
+and `yaml` without importing any of them (flake8 F821 x7); `start_hardware_monitoring.py`
+imported `start_phase9_monitoring`/`stop_phase9_monitoring`, renamed to
+`start_hardware_monitoring`/`stop_hardware_monitoring` in #10666/#10733, and computed
+its `sys.path` insertion two directories short of `autobot-backend/` (landing on
+`autobot-infrastructure/shared/`, which has no `utils` package). Both operator entry
+points were unimportable.
+
+Nothing caught either: `.pre-commit-config.yaml`'s flake8 hook excludes
+`autobot-infrastructure/` entirely, so F821 never gated a commit here, and neither
+script is imported by anything under test. "An import smoke test... would have caught
+both on the commit that broke them" (#14129) — this is that smoke test, generalised to
+the whole directory so the next regression is caught too, not just these two.
+
+Two checks:
+
+1. `test_script_has_no_undefined_names` — a static, per-file `flake8 --select=F821`
+   sweep of every script in the tree. Cheap, catches names referenced but never
+   imported/defined (the `manage_system_knowledge.py` class of bug). Pre-existing
+   offenders beyond the two fixed here are tracked in `KNOWN_BROKEN_AT_GUARD_INTRODUCTION`
+   with a reference to #14405 — fixing #14129 is not the same PR as fixing all of them.
+2. `test_operator_script_imports_in_a_realistic_subprocess` — a genuine dynamic import,
+   in a fresh subprocess with `autobot-backend` and the repo root (for `autobot_shared`)
+   on PYTHONPATH (the convention every other script under this tree assumes; see
+   `autobot-infrastructure/shared/scripts/restore_kb_backup.sh`), for the two scripts
+   #14129 fixed. Catches a name that IS imported but does not exist in the target module
+   (the `start_hardware_monitoring.py` class of bug) — undetectable by static analysis
+   alone, since pyflakes never loads the module a `from X import Y` names.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPTS_DIR = _REPO_ROOT / "autobot-infrastructure" / "shared" / "scripts"
+_BACKEND_DIR = _REPO_ROOT / "autobot-backend"
+
+# Pre-existing undefined-name breakage found while introducing this guard, not fixed
+# here (#14129 scoped its fix to the two scripts below). Remove an entry when its file
+# is fixed and #14405 can drop the corresponding acceptance criterion.
+KNOWN_BROKEN_AT_GUARD_INTRODUCTION: dict[str, str] = {
+    "populate_knowledge_base.py": "#14405",
+    "comprehensive_log_aggregator.py": "#14405",
+    "seq_log_forwarder.py": "#14405",
+    "profile_api_endpoints.py": "#14405",
+    "diagnose_backend.py": "#14405",
+    "analysis/test_gui_chat_visual.py": "#14405",
+    "analysis/check_backend_status.py": "#14405",
+    "analysis/test_llm_interface_direct.py": "#14405",
+    "analysis/npu_performance_measurement.py": "#14405",
+    "analysis/test_frontend_errors.py": "#14405",
+    "utilities/report_processing_system.py": "#14405",
+    "utilities/system_monitor.py": "#14405",
+}
+
+# The two scripts #14129 made importable. Exercised with a real subprocess import
+# (Verification bar: "in a subprocess with a realistic path, not via a fixture that
+# pre-stubs the missing name") rather than in-process importlib, which would let an
+# already-imported `utils`/`knowledge`/`agents` module in the pytest session's own
+# sys.modules mask a sys.path regression these scripts are prone to (#14129).
+_OPERATOR_ENTRYPOINTS = (
+    "utilities/manage_system_knowledge.py",
+    "monitoring/start_hardware_monitoring.py",
+)
+
+
+def _discover_scripts() -> list[Path]:
+    return sorted(p for p in _SCRIPTS_DIR.rglob("*.py") if "__pycache__" not in p.parts)
+
+
+def _relative_key(path: Path) -> str:
+    return str(path.relative_to(_SCRIPTS_DIR))
+
+
+def _undefined_name_lines(path: Path) -> list[str]:
+    """Every `flake8 --select=F821` finding for *path*, one per line.
+
+    `--isolated`: the repo's own `.flake8` sets `count = True` / `statistics = True`
+    for the pre-commit hook's human-readable output, which appends a bare count line
+    (and, with findings, a summary line) after the real violations. Reading `.flake8`
+    here would count every clean file as "broken" (its trailing ``0``).
+    """
+    result = subprocess.run(
+        [sys.executable, "-m", "flake8", "--isolated", "--select=F821", str(path)],
+        capture_output=True,
+        text=True,
+        cwd=_REPO_ROOT,
+        check=False,
+    )
+    return [line for line in result.stdout.splitlines() if line.strip()]
+
+
+def _script_params() -> list:
+    params = []
+    for path in _discover_scripts():
+        key = _relative_key(path)
+        marks = []
+        if key in KNOWN_BROKEN_AT_GUARD_INTRODUCTION:
+            marks.append(
+                pytest.mark.xfail(
+                    reason=f"tracked in {KNOWN_BROKEN_AT_GUARD_INTRODUCTION[key]}",
+                    strict=True,
+                )
+            )
+        params.append(pytest.param(path, id=key, marks=marks))
+    return params
+
+
+def test_the_guard_actually_found_scripts():
+    """An empty discovery would make every parametrised check below vacuous."""
+    assert len(_discover_scripts()) > 100
+
+
+@pytest.mark.parametrize("path", _script_params())
+def test_script_has_no_undefined_names(path: Path):
+    """Every name a script references must be imported or defined somewhere in it.
+
+    This is what `manage_system_knowledge.py` failed before #14129: `KnowledgeBase`,
+    `SystemKnowledgeManager` and `yaml` were referenced inside function bodies with no
+    corresponding import anywhere in the file.
+    """
+    undefined = _undefined_name_lines(path)
+    assert undefined == [], "\n".join(undefined)
+
+
+@pytest.mark.parametrize("relative_path", _OPERATOR_ENTRYPOINTS)
+def test_operator_script_imports_in_a_realistic_subprocess(relative_path: str):
+    """The script must actually import, with PYTHONPATH set the way every other
+    script under this tree expects it (`autobot-backend` + the repo root, for
+    `autobot_shared` — see restore_kb_backup.sh) — not via a fixture that stubs
+    the name out.
+
+    This is what `start_hardware_monitoring.py` failed before #14129:
+    `from utils.hardware_metrics import start_phase9_monitoring` named a function
+    that had been renamed to `start_hardware_monitoring` in #10666/#10733, and the
+    script's own `sys.path` calculation landed two directories short of
+    `autobot-backend/` regardless. Neither is visible to a static per-file check.
+    """
+    script = _SCRIPTS_DIR / relative_path
+    assert script.is_file(), f"entrypoint moved or renamed: {script}"
+
+    code = (
+        "import importlib.util\n"
+        f"spec = importlib.util.spec_from_file_location('operator_entrypoint', {str(script)!r})\n"
+        "module = importlib.util.module_from_spec(spec)\n"
+        "spec.loader.exec_module(module)\n"
+    )
+    # `autobot_shared.*` imports resolve off the repo ROOT (the package is
+    # `autobot_shared/__init__.py`, not a `src`-layout); `autobot-backend` is
+    # needed for `utils`/`knowledge`/`agents` (#14129).
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join([str(_BACKEND_DIR), str(_REPO_ROOT), env.get("PYTHONPATH", "")])
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        cwd=_REPO_ROOT,
+        env=env,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
Closes #14129, Closes #14127

## Thinking Path

Both issues are the same shape: a module that cannot import, invisible because
nothing exercises the specific line that breaks.

- **#14129** names two scripts. `manage_system_knowledge.py` referenced
  `KnowledgeBase`, `SystemKnowledgeManager` and `yaml` inside function bodies with
  no corresponding import anywhere in the file (flake8 F821 x7) — invisible
  because `.pre-commit-config.yaml`'s flake8 hook excludes
  `autobot-infrastructure/` entirely. `start_hardware_monitoring.py` had two
  independent breaks: it imported `start_phase9_monitoring`/`stop_phase9_monitoring`,
  renamed to `start_hardware_monitoring`/`stop_hardware_monitoring` in #10666/#10733
  (confirmed via `git log -S`), and its own `sys.path` calculation
  (`Path(__file__).parent.parent.parent`) landed on
  `autobot-infrastructure/shared/`, two directories short of `autobot-backend/` —
  which has no `utils` package, so the import would still fail even with the
  right name. I verified both independently: reverting either fix in isolation
  reproduces the original failure (see Verification).
- **#14127**: `api/nl_database.py` imported `get_secrets_manager` from
  `api.secrets` — a name that has never existed there. `api/secrets.py` exposes
  the `SecretsManager` **singleton** (`secrets_manager`), the same object four
  other call sites already import directly (`slash_command_handler.py`,
  `api/infrastructure.py`, `api/codebase_analytics/endpoints/sources.py`,
  `initialization/lifespan.py`). The call site also had two more bugs riding
  along: `await`ing a synchronous method, and a `user_id=` keyword the method
  doesn't accept (it's `chat_id=`) — both would have surfaced as a *different*
  masked 500 the moment the import was fixed in isolation, so I fixed the whole
  call, not just the import line.

  **What was masking it**: nothing mocks `get_secrets_manager` anywhere in the
  repo — I grepped for it. The real masking is the combination of (a) zero test
  coverage for `_resolve_db_url`/`nl_database.py` (no test file existed at all)
  and (b) the function's own broad `except Exception` boundary, which turns
  *any* failure, including an `ImportError` that fires on every single call,
  into an indistinguishable generic 500. `#14127`'s own text points at a second
  file, `utils/secrets_store_migration_test.py`, as "a test module [that] ships
  inside the production package" and asks to move it. I checked: it's already
  covered by `.dockerignore`'s existing `**/*_test.py` rule, and the repo's
  documented, established convention (`pytest.ini`: "colocated tests live next
  to source files (#734)") already puts dozens of other `*_test.py` files in
  the same position under `utils/` — moving this one file alone would be
  arbitrary and fix nothing. Checking further (the issue explicitly asks for
  "a quick check for others in the same position") found the *real* gap:
  `.dockerignore` only excluded the `*_test.py` **suffix** convention, not the
  equally-valid `test_*.py` **prefix** convention pytest.ini itself declares
  (`python_files = test_*.py *_test.py`) — 58 files across the backend, none
  referenced from outside a test, were shipping into every Docker image built
  from `docker/backend/Dockerfile`'s `COPY autobot-backend/ /app/autobot-backend/`.
  That's the actual, previously-invisible "test module in the production
  package" problem, and it's fixed here.

**Follow-up (smoke tests went red on the first push).** `smoke-test` and
`hardened-smoke-test` both failed: `dependency failed to start: container
autobot-backend is unhealthy`, and the backend container log gives the reason —

```
File "/app/autobot-backend/code_intelligence/__init__.py", line 295, in <module>
    from .test_pattern_analyzer import (
ModuleNotFoundError: No module named 'code_intelligence.test_pattern_analyzer'
```

`code_intelligence/test_pattern_analyzer.py` is not a test. It is 1155 lines of
production code (`TestPatternAnalyzer`, `analyze_tests`, ... — an analyzer *of*
test patterns, from #236), re-exported by the package `__init__`, with zero
`def test_` in it. It matched the new prefix rule by name only, so the image no
longer contained it and every backend container died at import.

Auditing the whole invariant rather than just the crash found a second instance,
pre-existing and quieter, from the *old* `**/*_test.py` rule:
`utils/redis_immediate_test.py` is the Redis circuit breaker, and
`utils/async_cancellation.py:116` imports `redis_circuit_breaker` from it inside a
bare `except Exception` — so in every image ever built, `check_resources()` has
been reporting `redis_available=False` unconditionally. Same defect, one silent
and one loud.

Reverting the `.dockerignore` change was not the fix: shipping 58 test files into
every production image is a real finding worth keeping fixed. Nor was an
allowlist — a `!`-exemption naming a moved file exempts nothing, silently. The
fix is that a production module must not be named like a test, so both were
renamed and both broad rules stay.

## What Changed

**#14129**
- `autobot-infrastructure/shared/scripts/utilities/manage_system_knowledge.py`:
  added the sys.path setup this standalone script needs (points at
  `autobot-backend/`, not the previously-absent implicit path) plus the three
  missing imports (`yaml`, `agents.system_knowledge_manager.SystemKnowledgeManager`,
  `knowledge.KnowledgeBase`).
- `autobot-infrastructure/shared/scripts/monitoring/start_hardware_monitoring.py`:
  fixed the `sys.path` calculation (`parents[4] / "autobot-backend"`, matching
  the repo root correctly) and imported the renamed functions under their old
  local names (`start_hardware_monitoring as start_phase9_monitoring`, etc.) so
  the rest of the file — which still legitimately uses `phase9` in several
  *other*, un-renamed symbol names from `hardware_metrics.py` — needed no
  further changes.
- `repo_tests/test_infra_scripts_import_14129.py` (new): a static
  `flake8 --isolated --select=F821` sweep over all 222 scripts under
  `autobot-infrastructure/shared/scripts/` (catches the "referenced but never
  imported" class of bug), plus a real subprocess import of the two fixed
  scripts with a realistic `PYTHONPATH` (catches "imported a name that doesn't
  exist in the target module" — invisible to static analysis, since pyflakes
  never loads the module a `from X import Y` names). 12 pre-existing,
  unrelated F821 offenders discovered while building this guard are `xfail`-marked
  against a new tracking issue (#14405) rather than fixed here or silently
  ignored by the guard.

**#14127**
- `autobot-backend/api/nl_database.py`: `from api.secrets import secrets_manager`
  (the real singleton) instead of the nonexistent `get_secrets_manager()`
  factory; `secret = await asyncio.to_thread(secrets_manager.get_secret, db_secret_id, chat_id=None)`
  instead of a bare `await` on a synchronous call with a `user_id=` kwarg that
  doesn't exist.
- `autobot-backend/api/nl_database_test.py` (new): a real subprocess import of
  `api.nl_database` (no fixture stubs `api.secrets`), plus tests for
  `_resolve_db_url`'s four outcomes (no secret ID, success, 404, wrong type,
  underlying-failure 500), monkeypatching only `secrets_manager.get_secret` —
  never the import — so a reintroduced bad import fails these tests with a
  real `ImportError`/500 instead of passing silently.
- `.dockerignore`: added `**/test_*.py` alongside the existing `**/*_test.py`,
  closing the real packaging gap (58 files).
- `repo_tests/test_dockerignore_test_file_coverage_14127.py` (new): asserts
  every git-tracked file matching pytest's own two test-file conventions is
  excluded by some `.dockerignore` pattern, with a direct reproduction test
  pinning that `secrets_store_migration_test.py` was already covered and
  `test_causal_executor.py` was not, before the fix.
- **Not changed**: `utils/secrets_store_migration_test.py`'s location (see
  Thinking Path — moving it fixes nothing given the convention and the
  `.dockerignore` state) and the `mode=1777` secrets-directory permissions
  (#14127's own text defers that to #14122, which is still open — out of
  scope here by the parent issue's own design).

**#14413 (the red smoke tests)**
- `autobot-backend/code_intelligence/test_pattern_analyzer.py` ->
  `testing_pattern_analyzer.py`; the one importer
  (`code_intelligence/__init__.py:295`) updated. The colocated-test convention in
  that package is the `<module>_test.py` suffix, which this module never was.
- `autobot-backend/utils/redis_immediate_test.py` ->
  `redis_immediate_connection.py`; the one importer
  (`utils/async_cancellation.py:116`) updated. Its
  `test_redis_connection_immediate` is also renamed to
  `check_redis_connection_immediate` — pytest had been collecting that production
  helper as a test that could only ever pass (no assertions, and the canonical
  client is None in CI); `.test_durations` still carried its node id, which is
  dropped.
- `autobot-backend/conftest.py`: the #12437 note explaining why the analyzer is
  deliberately not stubbed rested on pytest collecting the production module; the
  rename ends that, and the note now says why the entry still does not belong.
- `.dockerignore`: both rules unchanged and still broad; the comment records why
  there is no allowlist.
- `repo_tests/test_dockerignore_test_file_coverage_14127.py`: new guard,
  `test_no_shipped_module_imports_a_dockerignored_file` — parses the import head of
  every git-tracked Python file that is *not* dockerignored, resolves each
  relative and absolute import against the tracked tree (each top-level directory
  acting as a sys.path root, as the images run them), and fails on any that lands
  on a file `.dockerignore` strips from the build context. Also
  `test_no_negation_line_re_includes_a_python_file`, so the "rename, don't
  exempt" rule cannot be quietly reversed later, and the matcher now applies
  directory-prefix semantics (`docs` excludes `docs/guides/x.py`) the way Docker
  reads it.

## Verification

All mutations below were **executed** (a temporary copy of the file with the
fix reverted, re-run against the real check), not statically traced.

- `manage_system_knowledge.py`: `flake8 --isolated --select=F821` is clean
  after the fix (0 findings); reverting the three added imports on a scratch
  copy reproduces the original 7 F821 findings exactly.
- `start_hardware_monitoring.py`: a real subprocess import (via
  `importlib.util.spec_from_file_location` + `exec_module`, with `autobot-backend`
  + repo root on `PYTHONPATH`) succeeds after the fix. Reverting *only* the
  function-name aliasing on a scratch copy reproduces
  `ImportError: cannot import name 'start_phase9_monitoring'`; reverting *only*
  the `sys.path` calculation reproduces `ModuleNotFoundError: No module named 'utils'`
  — both fixes are independently load-bearing.
- `nl_database.py`: ran the fixed `_resolve_db_url` end-to-end (the same
  assertions as `nl_database_test.py`) against a real `import api.nl_database`
  in this environment — none-secret-id, success, 404, 400, and 500-on-data-layer-failure
  all behave as asserted. Reverting the import back to `get_secrets_manager`
  and re-running the success-path assertion reproduces
  `ImportError: cannot import name 'get_secrets_manager' from 'api.secrets'`,
  caught by the function's own broad `except Exception` and surfaced as
  `HTTPException(500)` — exactly the failure the success test asserts against
  and would catch.
- `.dockerignore`: ran the new guard's matcher directly (not via `pytest`, per
  the "don't run the test suite" instruction) — 832 tracked test files, 0
  unmatched, after the fix. Removing `**/test_*.py` from the pattern set and
  re-running reproduces `test_causal_executor.py` as unmatched while
  `secrets_store_migration_test.py` stays matched (proving the original issue's
  named file was never actually the gap).
- `test_infra_scripts_import_14129.py`'s own `KNOWN_BROKEN_AT_GUARD_INTRODUCTION`
  list was cross-checked against a live run of the F821 sweep over all 222
  scripts: zero mismatches in either direction.

`pytest` itself was not invoked (per instruction — do not run the test suite);
all of the above ran the underlying checks (flake8, subprocess imports, the
guard modules' own functions) directly.

**#14413**
- The failure text is quoted verbatim in Thinking Path, taken from the
  `smoke-test` job log (`actions/jobs/<id>/logs`), not inferred. The
  `hardened-smoke-test` job failed at the same step with the same
  `container autobot-backend is unhealthy` and never printed the backend log at
  all — its post-mortem step inspects `autobot-slm` only, so the failing container
  names nothing. Filed as #14417.
- Ran the new guard's functions directly (stdlib only, no `pytest`, no Docker
  build): 8/8 pass on this branch, `test_no_shipped_module_imports_a_dockerignored_file`
  in ~2s over 3064 shipped Python files.
- **Mutation, not just a green run.** Pointed the same detector at the base
  branch's tree (pre-rename, and without `**/test_*.py`) and it reports exactly
  one finding —
  `autobot-backend/utils/async_cancellation.py:116 -> autobot-backend/utils/redis_immediate_test.py`
  — proving it fires on real data. Run against this PR's previous commit's rules
  it reported both. `test_the_detector_catches_the_regression_it_was_written_for`
  pins both shapes (relative import of a prefix-named sibling; absolute import of
  a suffix-named module) as direct assertions on the detector, and asserts it goes
  quiet once the modules are renamed — so it cannot pass vacuously.
- `test_the_import_scan_reaches_the_backend_trees` asserts the scan is
  non-empty and actually reaches `autobot-backend/`, so an empty result cannot
  read as a clean result.
- Every reference to both old module names across the tree is either updated or a
  deliberate historical note (verified by grep); `.test_durations` re-parses as
  valid JSON with 22087 entries.

## Model Used

Claude Sonnet 5 (original fixes); Claude Opus 5 (the #14413 smoke-test root cause and the import guard)

