### PR TITLE
security(deserialization): restrict/remove the two remaining pickle.load() sinks (#14187)

### DIFF
--- a/autobot-backend/utils/chromadb_client.py
+++ b/autobot-backend/utils/chromadb_client.py
@@ -21,7 +21,7 @@ async variants to prevent event loop blocking. See Issue #369.
 from __future__ import annotations
 
 import json
-import pickle  # nosec B403  # reading ChromaDB internal pickle files only
+import pickle  # nosec B403  # restricted Unpickler below; see _RestrictedHnswUnpickler
 import sqlite3
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Tuple
@@ -271,6 +271,49 @@ def _infer_hnsw_dimensionality(segment_dir: Path) -> int:
     return 0
 
 
+# Issue #14187: index_metadata.pickle is ChromaDB's own on-disk format for
+# PersistentLocalHnswSegment (chromadb/segment/impl/vector/local_persistent_hnsw.py)
+# -- the library writes it with plain pickle.dump() and reads it back with plain
+# pickle.load() itself, downstream of this function, so the file cannot move to a
+# non-pickle format without forking the dependency. What this module controls is
+# only its OWN read, performed solely to patch legacy metadata shapes before
+# ChromaDB's loader runs (#1390).
+#
+# Trust boundary: the file lives under the local ChromaDB persist directory,
+# which resolves under the SSOT/legacy data roots excluded from the filesystem
+# MCP bridge (api/filesystem_mcp.py _EXCLUDED_DIR_PATHS, #14081/#14124). The only
+# writers are ChromaDB's own segment code and this function, both running inside
+# the backend process -- there is no known external write path today. Because
+# "no known path today" is not proof for tomorrow (#14124's own history), the
+# read here is restricted rather than trusted outright: find_class allows
+# exactly ChromaDB's PersistentData class and nothing else, so a file written
+# by anything other than ChromaDB's own persistence code fails closed instead
+# of executing arbitrary code during deserialization.
+_ALLOWED_HNSW_PICKLE_CLASSES = frozenset(
+    {
+        ("chromadb.segment.impl.vector.local_persistent_hnsw", "PersistentData"),
+    }
+)
+
+
+class _RestrictedHnswUnpickler(pickle.Unpickler):
+    """Unpickler for ``index_metadata.pickle`` restricted to ChromaDB's own class.
+
+    Subclassing ``pickle.Unpickler`` (rather than calling ``pickle.load``/
+    ``pickle.loads`` directly) keeps every GLOBAL/REDUCE opcode gated by
+    ``find_class``: only ``PersistentData`` may be constructed, and builtin
+    containers (dict/list/str/int/None) used by its fields never go through
+    ``find_class`` at all, so legitimate files are unaffected.
+    """
+
+    def find_class(self, module: str, name: str) -> Any:
+        if (module, name) not in _ALLOWED_HNSW_PICKLE_CLASSES:
+            raise pickle.UnpicklingError(
+                f"Refusing to unpickle disallowed class {module}.{name} from index_metadata.pickle"
+            )
+        return super().find_class(module, name)
+
+
 def _fix_hnsw_pickle_format(chroma_path: Path) -> None:
     """Fix HNSW index_metadata.pickle for ChromaDB 0.5.x (#1390).
 
@@ -287,7 +330,7 @@ def _fix_hnsw_pickle_format(chroma_path: Path) -> None:
     for pkl_file in chroma_path.glob("*/index_metadata.pickle"):
         try:
             with open(pkl_file, "rb") as f:
-                data = pickle.load(f)  # nosec B301
+                data = _RestrictedHnswUnpickler(f).load()
             needs_fix = isinstance(data, dict)
             if isinstance(data, dict):
                 dim = data.get("dimensionality")

--- a/autobot-backend/utils/chromadb_client_hnsw_pickle_security_test.py
+++ b/autobot-backend/utils/chromadb_client_hnsw_pickle_security_test.py
@@ -1,0 +1,242 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""#14187: index_metadata.pickle deserialization must not run arbitrary code.
+
+``utils.chromadb_client._fix_hnsw_pickle_format`` reads ChromaDB's own
+``index_metadata.pickle`` (chromadb's ``PersistentLocalHnswSegment``
+format) to patch legacy metadata shapes before ChromaDB's own loader runs
+(#1390). It used a plain ``pickle.load()`` -- any writable path to that
+file became arbitrary code execution the moment this function ran.
+``_RestrictedHnswUnpickler`` gates every class reference through
+``find_class`` and allows exactly ChromaDB's ``PersistentData``, nothing
+else.
+
+These tests build the real ``chromadb.segment.impl.vector.local_persistent_hnsw``
+leaf module by hand (never importing the real ``chromadb`` package): CI's
+``conftest.py`` globally stubs ``chromadb`` with an empty ``__path__`` (see
+its "Stub chromadb before it is imported" block) because the real package
+hangs at import time without a local server, and the actual dependency also
+needs ``hnswlib`` which is not guaranteed present in every job that runs
+this file. Registering the leaf module directly under its full dotted name
+in ``sys.modules`` is sufficient: Python's import machinery resolves a
+fully-qualified name straight from ``sys.modules`` without walking parent
+packages, which is also exactly how ``pickle``'s own ``find_class`` resolves
+a GLOBAL opcode. Verified against CPython's import machinery, not assumed.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import logging
+import os
+import pickle
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+_MODULE_NAME = "chromadb.segment.impl.vector.local_persistent_hnsw"
+_CLASS_NAME = "PersistentData"
+
+
+def _load_real_chromadb_client_module():
+    """Return the real ``utils.chromadb_client`` module.
+
+    #13162 established that some test modules install a permanent MagicMock
+    placeholder for ``utils.chromadb_client`` / ``utils.async_chromadb_client``
+    in ``sys.modules`` and never remove it, so whichever test collects first
+    wins the shared module. Load the real file under a private name when
+    that has happened, mirroring
+    ``chromadb_client_cache_key_test.py::_load_real_chromadb_modules``.
+    """
+    cached = sys.modules.get("utils.chromadb_client")
+    if cached is not None and getattr(cached, "__file__", None):
+        return cached
+    private = "_real_14187_chromadb_client"
+    cached_private = sys.modules.get(private)
+    if cached_private is not None:
+        return cached_private
+    here = Path(__file__).resolve().parent
+    spec = importlib.util.spec_from_file_location(private, here / "chromadb_client.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[private] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _ensure_stub_module_chain(dotted: str) -> None:
+    """Register every missing package level of ``dotted`` as a minimal stub.
+
+    Real or already-stubbed modules (e.g. ``chromadb`` itself, which
+    ``conftest.py`` stubs globally) are left untouched -- only genuinely
+    missing intermediate levels get a placeholder. Needed because
+    ``pickle``'s own ``save_global`` re-validates the full parent chain via
+    ``getattr``, which is stricter than a plain ``import`` statement (proven
+    against CPython's pickle module, not assumed).
+    """
+    parts = dotted.split(".")
+    prefix_parts: list[str] = []
+    for index, part in enumerate(parts):
+        prefix_parts.append(part)
+        prefix = ".".join(prefix_parts)
+        if prefix in sys.modules:
+            continue
+        stub = types.ModuleType(prefix)
+        if index < len(parts) - 1:
+            stub.__path__ = []  # marks it as a package for the import system
+        sys.modules[prefix] = stub
+        parent = prefix.rpartition(".")[0]
+        if parent:
+            setattr(sys.modules[parent], part, stub)
+
+
+def _install_real_persistent_data_class() -> type:
+    """Register a ``PersistentData`` stand-in at ChromaDB's real module path.
+
+    Registered under the leaf module's fully-qualified name so resolution
+    works regardless of whether the real ``chromadb`` package (or
+    ``conftest.py``'s stub of it) is present. The class shape matches
+    ``chromadb.segment.impl.vector.local_persistent_hnsw.PersistentData``
+    (see that file): five plain fields, no exotic types.
+    """
+    existing = sys.modules.get(_MODULE_NAME)
+    if existing is not None and isinstance(getattr(existing, _CLASS_NAME, None), type):
+        return getattr(existing, _CLASS_NAME)
+
+    class PersistentData:
+        def __init__(self, dimensionality, total_elements_added, id_to_label, label_to_id, id_to_seq_id):
+            self.dimensionality = dimensionality
+            self.total_elements_added = total_elements_added
+            self.id_to_label = id_to_label
+            self.label_to_id = label_to_id
+            self.id_to_seq_id = id_to_seq_id
+
+    PersistentData.__module__ = _MODULE_NAME
+    PersistentData.__qualname__ = _CLASS_NAME
+
+    _ensure_stub_module_chain(_MODULE_NAME)
+    sys.modules[_MODULE_NAME].PersistentData = PersistentData
+    return PersistentData
+
+
+sync_mod = _load_real_chromadb_client_module()
+PersistentData = _install_real_persistent_data_class()
+
+
+def _persistent_data_bytes() -> bytes:
+    obj = PersistentData(
+        dimensionality=8,
+        total_elements_added=2,
+        id_to_label={"doc-a": 0, "doc-b": 1},
+        label_to_id={0: "doc-a", 1: "doc-b"},
+        id_to_seq_id={"doc-a": 1, "doc-b": 2},
+    )
+    return pickle.dumps(obj, protocol=pickle.HIGHEST_PROTOCOL)
+
+
+def _disallowed_class_bytes() -> bytes:
+    """A pickle stream whose GLOBAL opcode names a disallowed class.
+
+    Built from a real, harmless function reference (``os.system``) rather
+    than a committed opaque blob. Pickling a bare function reference never
+    calls it -- there is nothing here that executes on load even without
+    the allowlist; the test exists to prove the allowlist rejects the class
+    reference itself, which is the same resolution step a ``__reduce__``
+    based RCE gadget depends on.
+    """
+    return pickle.dumps(os.system, protocol=pickle.HIGHEST_PROTOCOL)
+
+
+# ---------------------------------------------------------------------------
+# _RestrictedHnswUnpickler
+# ---------------------------------------------------------------------------
+
+
+def test_restricted_unpickler_accepts_the_allowlisted_class():
+    """A legitimate PersistentData payload still round-trips."""
+    loaded = sync_mod._RestrictedHnswUnpickler(io.BytesIO(_persistent_data_bytes())).load()
+    assert isinstance(loaded, PersistentData)
+    assert loaded.dimensionality == 8
+    assert loaded.id_to_label == {"doc-a": 0, "doc-b": 1}
+    assert loaded.id_to_seq_id == {"doc-a": 1, "doc-b": 2}
+
+
+def test_restricted_unpickler_rejects_disallowed_class():
+    """A class reference outside the allowlist is refused, not executed."""
+    with pytest.raises(pickle.UnpicklingError):
+        sync_mod._RestrictedHnswUnpickler(io.BytesIO(_disallowed_class_bytes())).load()
+
+
+# ---------------------------------------------------------------------------
+# _fix_hnsw_pickle_format (integration)
+# ---------------------------------------------------------------------------
+
+
+def _collection_dir(tmp_path: Path) -> Path:
+    collection_dir = tmp_path / "11111111-1111-1111-1111-111111111111"
+    collection_dir.mkdir()
+    return collection_dir
+
+
+def test_fix_hnsw_pickle_format_migrates_legacy_dict_without_data_loss(tmp_path):
+    """The pre-0.5.x plain-dict shape is still readable and still migrated.
+
+    Plain dict/int/str payloads never invoke ``find_class`` at all (only
+    GLOBAL/REDUCE opcodes for custom classes do), so the restricted
+    unpickler does not need an allowlist entry for them -- this is the
+    "no data loss" proof for every ``index_metadata.pickle`` written before
+    ChromaDB 0.5.x's PersistentData-only format.
+    """
+    collection_dir = _collection_dir(tmp_path)
+    pkl_file = collection_dir / "index_metadata.pickle"
+    legacy_shape = {
+        "dimensionality": 8,
+        "total_elements_added": 2,
+        "id_to_label": {"doc-a": 0},
+        "label_to_id": {0: "doc-a"},
+        "id_to_seq_id": {"doc-a": 1},
+    }
+    with open(pkl_file, "wb") as f:
+        pickle.dump(legacy_shape, f)
+
+    sync_mod._fix_hnsw_pickle_format(tmp_path)
+
+    with open(pkl_file, "rb") as f:
+        migrated = sync_mod._RestrictedHnswUnpickler(f).load()
+    assert isinstance(migrated, PersistentData)
+    assert migrated.dimensionality == 8
+    assert migrated.id_to_label == {"doc-a": 0}
+
+
+def test_fix_hnsw_pickle_format_skips_disallowed_pickle_without_raising(tmp_path, caplog):
+    """A file that isn't ChromaDB's own format is refused, not executed.
+
+    Proves the security property at the call site this issue is about, not
+    just at the unpickler unit level: the malicious/foreign bytes are never
+    turned into a live object, the function does not raise out of the
+    caller's loop, and the on-disk bytes are left untouched (not silently
+    "fixed" into something derived from an unpicklable payload).
+    """
+    collection_dir = _collection_dir(tmp_path)
+    pkl_file = collection_dir / "index_metadata.pickle"
+    original_bytes = _disallowed_class_bytes()
+    with open(pkl_file, "wb") as f:
+        f.write(original_bytes)
+
+    with caplog.at_level(logging.WARNING):
+        sync_mod._fix_hnsw_pickle_format(tmp_path)  # must not raise
+
+    untouched = pkl_file.read_bytes() == original_bytes
+    assert untouched, "disallowed pickle must be left untouched, not rewritten"
+    # Assert the SPECIFIC refusal message, not just "some warning fired": an
+    # unrestricted pickle.load() would also raise on this payload (a builtin
+    # function has no settable __dict__), landing in the same outer except and
+    # logging *some* warning -- but never this message, which only find_class
+    # produces. This is what makes the assertion mutation-sensitive: bypassing
+    # the allowlist changes the logged text, not just whether something logged.
+    refused = any("Refusing to unpickle disallowed class" in rec.message for rec in caplog.records)
+    assert refused, "the allowlist must be what rejects this payload, not an incidental failure"

--- a/autobot-backend/utils/chromadb_client_hnsw_pickle_security_test.py
+++ b/autobot-backend/utils/chromadb_client_hnsw_pickle_security_test.py
@@ -24,6 +24,16 @@ in ``sys.modules`` is sufficient: Python's import machinery resolves a
 fully-qualified name straight from ``sys.modules`` without walking parent
 packages, which is also exactly how ``pickle``'s own ``find_class`` resolves
 a GLOBAL opcode. Verified against CPython's import machinery, not assumed.
+
+The ``chromadb_hnsw_stub`` fixture installs those synthetic package levels
+and removes them in a ``finally`` around each test that needs them
+(``repo_tests/sys_modules_leak_guard.py`` fails the run if a test-installed
+stub is still live while pytest handles a node outside this file -- a
+module-level, permanent registration here was exactly that leak, caught in
+review of PR #14416). Only the levels genuinely absent beforehand are
+touched; ``chromadb`` itself is always already present (owned by
+``conftest.py``, which is on the leak-guard baseline) and this file never
+installs or removes that key.
 """
 
 from __future__ import annotations
@@ -68,63 +78,65 @@ def _load_real_chromadb_client_module():
     return module
 
 
-def _ensure_stub_module_chain(dotted: str) -> None:
-    """Register every missing package level of ``dotted`` as a minimal stub.
-
-    Real or already-stubbed modules (e.g. ``chromadb`` itself, which
-    ``conftest.py`` stubs globally) are left untouched -- only genuinely
-    missing intermediate levels get a placeholder. Needed because
-    ``pickle``'s own ``save_global`` re-validates the full parent chain via
-    ``getattr``, which is stricter than a plain ``import`` statement (proven
-    against CPython's pickle module, not assumed).
-    """
-    parts = dotted.split(".")
-    prefix_parts: list[str] = []
-    for index, part in enumerate(parts):
-        prefix_parts.append(part)
-        prefix = ".".join(prefix_parts)
-        if prefix in sys.modules:
-            continue
-        stub = types.ModuleType(prefix)
-        if index < len(parts) - 1:
-            stub.__path__ = []  # marks it as a package for the import system
-        sys.modules[prefix] = stub
-        parent = prefix.rpartition(".")[0]
-        if parent:
-            setattr(sys.modules[parent], part, stub)
-
-
-def _install_real_persistent_data_class() -> type:
-    """Register a ``PersistentData`` stand-in at ChromaDB's real module path.
-
-    Registered under the leaf module's fully-qualified name so resolution
-    works regardless of whether the real ``chromadb`` package (or
-    ``conftest.py``'s stub of it) is present. The class shape matches
-    ``chromadb.segment.impl.vector.local_persistent_hnsw.PersistentData``
-    (see that file): five plain fields, no exotic types.
-    """
-    existing = sys.modules.get(_MODULE_NAME)
-    if existing is not None and isinstance(getattr(existing, _CLASS_NAME, None), type):
-        return getattr(existing, _CLASS_NAME)
-
-    class PersistentData:
-        def __init__(self, dimensionality, total_elements_added, id_to_label, label_to_id, id_to_seq_id):
-            self.dimensionality = dimensionality
-            self.total_elements_added = total_elements_added
-            self.id_to_label = id_to_label
-            self.label_to_id = label_to_id
-            self.id_to_seq_id = id_to_seq_id
-
-    PersistentData.__module__ = _MODULE_NAME
-    PersistentData.__qualname__ = _CLASS_NAME
-
-    _ensure_stub_module_chain(_MODULE_NAME)
-    sys.modules[_MODULE_NAME].PersistentData = PersistentData
-    return PersistentData
-
-
 sync_mod = _load_real_chromadb_client_module()
-PersistentData = _install_real_persistent_data_class()
+
+
+class PersistentData:
+    """Stand-in for ``chromadb...local_persistent_hnsw.PersistentData``.
+
+    A plain class, matching that class's shape (five fields, no exotic
+    types) -- NOT registered in ``sys.modules`` here. The
+    ``chromadb_hnsw_stub`` fixture below registers/deregisters it at the
+    real module path around each test that needs it, so the registration
+    can never outlive the test (see the module docstring).
+    """
+
+    def __init__(self, dimensionality, total_elements_added, id_to_label, label_to_id, id_to_seq_id):
+        self.dimensionality = dimensionality
+        self.total_elements_added = total_elements_added
+        self.id_to_label = id_to_label
+        self.label_to_id = label_to_id
+        self.id_to_seq_id = id_to_seq_id
+
+
+PersistentData.__module__ = _MODULE_NAME
+PersistentData.__qualname__ = _CLASS_NAME
+
+
+@pytest.fixture
+def chromadb_hnsw_stub():
+    """Register ``PersistentData`` at ChromaDB's real module path; deregister after.
+
+    Only the package levels genuinely absent from ``sys.modules`` beforehand
+    are installed, and ``finally`` removes exactly those same keys --
+    ``chromadb`` itself is always already present (``conftest.py`` owns that
+    key and it is on the leak-guard baseline) and is never touched here.
+    ``pickle``'s own ``save_global``/``find_class`` re-validate the full
+    parent chain via ``getattr``, which is stricter than a plain ``import``
+    statement (proven against CPython's pickle module, not assumed), so
+    every intermediate level needs a real entry, not just the leaf.
+    """
+    installed: list[str] = []
+    try:
+        prefix_parts: list[str] = []
+        for part in _MODULE_NAME.split("."):
+            prefix_parts.append(part)
+            prefix = ".".join(prefix_parts)
+            if prefix in sys.modules:
+                continue
+            stub = types.ModuleType(prefix)
+            if prefix != _MODULE_NAME:
+                stub.__path__ = []  # marks it as a package for the import system
+            sys.modules[prefix] = stub
+            parent, _, child = prefix.rpartition(".")
+            if parent:
+                setattr(sys.modules[parent], child, stub)
+            installed.append(prefix)
+        sys.modules[_MODULE_NAME].PersistentData = PersistentData
+        yield PersistentData
+    finally:
+        for key in installed:
+            sys.modules.pop(key, None)
 
 
 def _persistent_data_bytes() -> bytes:
@@ -156,7 +168,7 @@ def _disallowed_class_bytes() -> bytes:
 # ---------------------------------------------------------------------------
 
 
-def test_restricted_unpickler_accepts_the_allowlisted_class():
+def test_restricted_unpickler_accepts_the_allowlisted_class(chromadb_hnsw_stub):
     """A legitimate PersistentData payload still round-trips."""
     loaded = sync_mod._RestrictedHnswUnpickler(io.BytesIO(_persistent_data_bytes())).load()
     assert isinstance(loaded, PersistentData)
@@ -182,7 +194,7 @@ def _collection_dir(tmp_path: Path) -> Path:
     return collection_dir
 
 
-def test_fix_hnsw_pickle_format_migrates_legacy_dict_without_data_loss(tmp_path):
+def test_fix_hnsw_pickle_format_migrates_legacy_dict_without_data_loss(tmp_path, chromadb_hnsw_stub):
     """The pre-0.5.x plain-dict shape is still readable and still migrated.
 
     Plain dict/int/str payloads never invoke ``find_class`` at all (only
@@ -212,7 +224,7 @@ def test_fix_hnsw_pickle_format_migrates_legacy_dict_without_data_loss(tmp_path)
     assert migrated.id_to_label == {"doc-a": 0}
 
 
-def test_fix_hnsw_pickle_format_skips_disallowed_pickle_without_raising(tmp_path, caplog):
+def test_fix_hnsw_pickle_format_skips_disallowed_pickle_without_raising(tmp_path, caplog, chromadb_hnsw_stub):
     """A file that isn't ChromaDB's own format is refused, not executed.
 
     Proves the security property at the call site this issue is about, not

--- a/autobot-backend/utils/long_running_operations/checkpoint_manager.py
+++ b/autobot-backend/utils/long_running_operations/checkpoint_manager.py
@@ -7,10 +7,22 @@ Checkpoint Manager for Long-Running Operations
 
 Issue #381: Extracted from long_running_operations_framework.py god class refactoring.
 Handles checkpoint save/load/resume functionality.
+
+Issue #14187: the Redis-cached copy of a checkpoint used to be pickle.dumps()'d
+alongside the JSON file that is the primary, on-disk copy of the same dict --
+so the Redis cache is now JSON too, removing the pickle.loads() sink outright
+rather than narrowing it. Trust boundary: whoever can write the
+``checkpoint:{operation_id}:{checkpoint_id}`` Redis hash key, which is this
+process (and any other principal that can reach this Redis instance -- a wider
+set than "our own file on our own disk", per #14124). A key written by the
+pre-#14187 code is not migrated in place: entries older than TTL_7_DAYS expire
+on their own, and any not-yet-expired legacy entry fails json.loads() (it is
+not valid JSON), is dropped from the cache, and is served from the JSON file
+store instead -- which is written first, on every save, and is therefore
+never behind the cache. See load_checkpoint()/_list_checkpoints_from_redis().
 """
 
 import json
-import pickle  # nosec B403  # pickle used for internal checkpoint serialization only
 from datetime import datetime, timezone
 from typing import Any, Dict, List
 
@@ -99,7 +111,7 @@ class OperationCheckpointManager:
             await self.redis_client.hset(
                 redis_key,
                 mapping={
-                    "data": pickle.dumps(checkpoint_data),
+                    "data": json.dumps(checkpoint_data),
                     "progress": str(progress_percent),
                     "timestamp": checkpoint_time.isoformat(),
                 },
@@ -180,15 +192,20 @@ class OperationCheckpointManager:
                     redis_key = keys[0]
                     data = await self.redis_client.hget(redis_key, "data")
                     if data:
-                        checkpoint_data = pickle.loads(data)  # nosec B301
-                        return OperationCheckpoint(
-                            checkpoint_id=checkpoint_data["checkpoint_id"],
-                            operation_id=checkpoint_data["operation_id"],
-                            checkpoint_time=parse_utc_iso(checkpoint_data["checkpoint_time"]),
-                            progress_percent=checkpoint_data["progress_percent"],
-                            state_data=checkpoint_data["state_data"],
-                            metadata=checkpoint_data.get("metadata", {}),
-                        )
+                        try:
+                            checkpoint_data = json.loads(data)
+                        except (json.JSONDecodeError, UnicodeDecodeError):
+                            # Issue #14187: a pre-migration entry cached the
+                            # payload with pickle. Never deserialize it --
+                            # drop the stale key and fall through to the file
+                            # store below, which holds the same checkpoint.
+                            logger.info(
+                                "Discarding pre-#14187 checkpoint cache entry %s (recovered from file store)",
+                                redis_key,
+                            )
+                            await self.redis_client.delete(redis_key)
+                        else:
+                            return self._parse_checkpoint_data(checkpoint_data)
             except Exception as e:
                 logger.warning("Failed to load checkpoint from Redis: %s", e)
 
@@ -197,14 +214,7 @@ class OperationCheckpointManager:
         if checkpoint_file.exists():
             async with aiofiles.open(checkpoint_file, "r", encoding="utf-8") as f:
                 checkpoint_data = json.loads(await f.read())
-                return OperationCheckpoint(
-                    checkpoint_id=checkpoint_data["checkpoint_id"],
-                    operation_id=checkpoint_data["operation_id"],
-                    checkpoint_time=parse_utc_iso(checkpoint_data["checkpoint_time"]),
-                    progress_percent=checkpoint_data["progress_percent"],
-                    state_data=checkpoint_data["state_data"],
-                    metadata=checkpoint_data.get("metadata", {}),
-                )
+                return self._parse_checkpoint_data(checkpoint_data)
 
         return None
 
@@ -245,21 +255,44 @@ class OperationCheckpointManager:
         if not self.redis_client:
             return checkpoints
 
+        # Issue #397: Fix N+1 query pattern - use pipeline for batch retrieval
         try:
             keys = await self.redis_client.keys(f"checkpoint:{operation_id}:*")
-            # Issue #397: Fix N+1 query pattern - use pipeline for batch retrieval
-            if keys:
-                pipe = self.redis_client.pipeline()
-                for key in keys:
-                    pipe.hget(key, "data")
-                results = await pipe.execute()
-
-                for data in results:
-                    if data:
-                        checkpoint_data = pickle.loads(data)  # nosec B301
-                        checkpoints.append(self._parse_checkpoint_data(checkpoint_data))
+            if not keys:
+                return checkpoints
+            pipe = self.redis_client.pipeline()
+            for key in keys:
+                pipe.hget(key, "data")
+            results = await pipe.execute()
         except Exception as e:
             logger.warning("Failed to list checkpoints from Redis: %s", e)
+            return checkpoints
+
+        # Issue #14187: one pre-migration (pickle) entry -- or any other
+        # single malformed entry -- no longer aborts the whole batch (the
+        # original loop lived entirely inside one try/except, so the first
+        # bad entry lost every later one it hadn't reached yet). Each entry
+        # is now handled individually and always recovered via the
+        # file-store merge in list_checkpoints() regardless of how it fails.
+        for key, data in zip(keys, results):
+            if not data:
+                continue
+            try:
+                checkpoint_data = json.loads(data)
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                logger.info(
+                    "Discarding pre-#14187 checkpoint cache entry %s (recovered from file store)",
+                    key,
+                )
+                try:
+                    await self.redis_client.delete(key)
+                except Exception as e:
+                    logger.warning("Failed to delete stale checkpoint cache entry %s: %s", key, e)
+                continue
+            try:
+                checkpoints.append(self._parse_checkpoint_data(checkpoint_data))
+            except Exception as e:
+                logger.warning("Failed to parse cached checkpoint %s: %s", key, e)
 
         return checkpoints
 

--- a/autobot-backend/utils/long_running_operations/checkpoint_manager_pickle_security_test.py
+++ b/autobot-backend/utils/long_running_operations/checkpoint_manager_pickle_security_test.py
@@ -1,0 +1,253 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""#14187: the Redis-cached checkpoint copy must not deserialize with pickle.
+
+``OperationCheckpointManager`` cached the same dict it writes to the JSON
+file store with ``pickle.dumps()``/``pickle.loads()`` -- whoever can write
+the ``checkpoint:{operation_id}:{checkpoint_id}`` Redis hash key (a wider
+set than "our own file on our own disk", #14124) got arbitrary code
+execution the moment a checkpoint was read back. The cache is now JSON, the
+same format the file store already used.
+
+These tests never call the real Redis client -- ``_FakeAsyncRedis`` is a
+minimal in-memory async stand-in supporting exactly the surface
+``checkpoint_manager.py`` uses (``hset``/``hget``/``keys``/``expire``/
+``delete``/``pipeline``). No shared ``tests/helpers/fake_redis.py`` class
+supports glob ``keys()``, which this module relies on.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import json
+import pickle
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import pytest
+
+from utils.long_running_operations.checkpoint_manager import OperationCheckpointManager
+
+
+class _FakePipeline:
+    """Buffers ``hget`` calls and replays them on ``execute()``."""
+
+    def __init__(self, redis: "_FakeAsyncRedis") -> None:
+        self._redis = redis
+        self._ops: List[Tuple[str, str]] = []
+
+    def hget(self, name: str, field: str) -> "_FakePipeline":
+        self._ops.append((name, field))
+        return self
+
+    async def execute(self) -> List[Optional[bytes]]:
+        return [await self._redis.hget(name, field) for name, field in self._ops]
+
+
+class _FakeAsyncRedis:
+    """Minimal in-memory async Redis stand-in for checkpoint hash storage."""
+
+    def __init__(self) -> None:
+        self._hashes: Dict[str, Dict[str, bytes]] = {}
+        self.expire_calls: List[Tuple[str, int]] = []
+
+    async def hset(self, name: str, mapping: Optional[Dict[str, Any]] = None, **kwargs: Any) -> int:
+        payload = mapping or kwargs
+        bucket = self._hashes.setdefault(name, {})
+        for key, value in payload.items():
+            bucket[key] = value.encode("utf-8") if isinstance(value, str) else value
+        return len(payload)
+
+    async def hget(self, name: str, field: str) -> Optional[bytes]:
+        return self._hashes.get(name, {}).get(field)
+
+    async def keys(self, pattern: str) -> List[str]:
+        return [key for key in self._hashes if fnmatch.fnmatchcase(key, pattern)]
+
+    async def expire(self, name: str, ttl: int) -> bool:
+        self.expire_calls.append((name, ttl))
+        return True
+
+    async def delete(self, *names: str) -> int:
+        removed = 0
+        for name in names:
+            if self._hashes.pop(name, None) is not None:
+                removed += 1
+        return removed
+
+    def pipeline(self) -> _FakePipeline:
+        return _FakePipeline(self)
+
+
+def _manager(tmp_path: Path, redis_client: _FakeAsyncRedis) -> OperationCheckpointManager:
+    """A checkpoint manager whose file store lives under ``tmp_path``.
+
+    ``__init__`` always resolves ``checkpoint_dir`` under the real
+    ``PATH.PROJECT_ROOT`` -- redirect it before any test writes through it.
+    """
+    manager = OperationCheckpointManager(redis_client=redis_client)
+    manager.checkpoint_dir = tmp_path
+    manager.checkpoint_dir.mkdir(parents=True, exist_ok=True)
+    return manager
+
+
+def _seed_legacy_redis_entry(
+    redis_client: _FakeAsyncRedis,
+    operation_id: str,
+    checkpoint_id: str,
+    checkpoint_data: Dict[str, Any],
+) -> None:
+    """Write a pre-#14187 (pickle-encoded) cache entry directly into the fake.
+
+    Bypasses ``save_checkpoint`` -- this is what the *old* code path would
+    have written, built from a real ``pickle.dumps()`` call (a fragment
+    assembled at test run time), never a committed opaque blob.
+    """
+    redis_key = f"checkpoint:{operation_id}:{checkpoint_id}"
+    redis_client._hashes[redis_key] = {
+        "data": pickle.dumps(checkpoint_data, protocol=pickle.HIGHEST_PROTOCOL),
+        "progress": str(checkpoint_data["progress_percent"]).encode("utf-8"),
+        "timestamp": checkpoint_data["checkpoint_time"].encode("utf-8"),
+    }
+
+
+def _write_legacy_file(tmp_path: Path, checkpoint_id: str, checkpoint_data: Dict[str, Any]) -> None:
+    """The JSON file store, unaffected by #14187, already held this shape."""
+    (tmp_path / f"{checkpoint_id}.json").write_text(json.dumps(checkpoint_data), encoding="utf-8")
+
+
+def _checkpoint_data(operation_id: str, checkpoint_id: str) -> Dict[str, Any]:
+    return {
+        "checkpoint_id": checkpoint_id,
+        "operation_id": operation_id,
+        "checkpoint_time": "2026-08-01T00:00:00+00:00",
+        "progress_percent": 42.0,
+        "state_data": {"step": 3},
+        "metadata": {},
+    }
+
+
+def _spy_on_pickle_loads(monkeypatch: pytest.MonkeyPatch) -> List[bool]:
+    """Record every ``pickle.loads`` call without breaking behaviour.
+
+    A version that *raises* on any call is the wrong shape here: this
+    module's Redis paths already wrap Redis access in a broad
+    ``except Exception: logger.warning(...); <fall through to file store>``
+    (pre-existing, not new to #14187) -- so a raised sentinel gets caught by
+    that handler and the test still passes via the file-store fallback,
+    silently blind to a regression that reintroduces ``pickle.loads``. A
+    spy that still delegates to the real ``pickle.loads`` lets the call
+    happen (so behaviour is unaffected either way) while recording that it
+    happened, which is what the assertion below actually checks.
+    """
+    calls: List[bool] = []
+    real_loads = pickle.loads
+
+    def _spy(*args: Any, **kwargs: Any) -> Any:
+        calls.append(True)
+        return real_loads(*args, **kwargs)
+
+    monkeypatch.setattr(pickle, "loads", _spy)
+    return calls
+
+
+# ---------------------------------------------------------------------------
+# save_checkpoint: the Redis cache is JSON, not pickle
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_save_checkpoint_caches_json_in_redis(tmp_path):
+    redis_client = _FakeAsyncRedis()
+    manager = _manager(tmp_path, redis_client)
+
+    await manager.save_checkpoint("op-1", "cp-1", 50.0, {"k": "v"})
+
+    redis_key = "checkpoint:op-1:cp-1"
+    raw = redis_client._hashes[redis_key]["data"]
+    # Must be parseable as JSON...
+    parsed = json.loads(raw)
+    assert parsed["checkpoint_id"] == "cp-1"
+    assert parsed["state_data"] == {"k": "v"}
+    # ...and must NOT be a pickle stream (bandit excludes *_test.py; #B301 does
+    # not apply here -- this call only proves the stored bytes are not pickle).
+    with pytest.raises(pickle.UnpicklingError):
+        pickle.loads(raw)
+
+
+# ---------------------------------------------------------------------------
+# load_checkpoint: never unpickles; falls back to the file store
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_load_checkpoint_never_unpickles_and_recovers_from_file(tmp_path, monkeypatch):
+    pickle_loads_calls = _spy_on_pickle_loads(monkeypatch)
+    redis_client = _FakeAsyncRedis()
+    manager = _manager(tmp_path, redis_client)
+
+    data = _checkpoint_data("op-1", "cp-1")
+    _seed_legacy_redis_entry(redis_client, "op-1", "cp-1", data)
+    _write_legacy_file(tmp_path, "cp-1", data)
+
+    result = await manager.load_checkpoint("cp-1")
+
+    assert not pickle_loads_calls, "pickle.loads must never be called on Redis-cached checkpoint data"
+    assert result is not None
+    assert result.checkpoint_id == "cp-1"
+    assert result.state_data == {"step": 3}
+    # The stale cache entry is discarded, not left to warn on every read.
+    assert "checkpoint:op-1:cp-1" not in redis_client._hashes
+
+
+@pytest.mark.asyncio
+async def test_load_checkpoint_returns_none_when_absent_everywhere(tmp_path):
+    redis_client = _FakeAsyncRedis()
+    manager = _manager(tmp_path, redis_client)
+
+    assert await manager.load_checkpoint("does-not-exist") is None
+
+
+# ---------------------------------------------------------------------------
+# list_checkpoints: one bad Redis entry doesn't lose the others
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_checkpoints_from_redis_drops_legacy_entry_without_unpickling(tmp_path, monkeypatch):
+    pickle_loads_calls = _spy_on_pickle_loads(monkeypatch)
+    redis_client = _FakeAsyncRedis()
+    manager = _manager(tmp_path, redis_client)
+
+    legacy = _checkpoint_data("op-1", "cp-legacy")
+    _seed_legacy_redis_entry(redis_client, "op-1", "cp-legacy", legacy)
+    await manager.save_checkpoint("op-1", "cp-fresh", 10.0, {"k": "fresh"})
+    # save_checkpoint above already wrote cp-fresh's file+redis entry; only
+    # cp-legacy needs its (pre-#14187) file counterpart seeded by hand.
+    _write_legacy_file(tmp_path, "cp-legacy", legacy)
+
+    from_redis = await manager._list_checkpoints_from_redis("op-1")
+
+    assert not pickle_loads_calls, "pickle.loads must never be called on Redis-cached checkpoint data"
+    assert {c.checkpoint_id for c in from_redis} == {"cp-fresh"}
+    assert "checkpoint:op-1:cp-legacy" not in redis_client._hashes
+
+
+@pytest.mark.asyncio
+async def test_list_checkpoints_recovers_legacy_entry_via_file_store(tmp_path, monkeypatch):
+    """No data loss end-to-end: list_checkpoints() merges the file store."""
+    pickle_loads_calls = _spy_on_pickle_loads(monkeypatch)
+    redis_client = _FakeAsyncRedis()
+    manager = _manager(tmp_path, redis_client)
+
+    legacy = _checkpoint_data("op-1", "cp-legacy")
+    _seed_legacy_redis_entry(redis_client, "op-1", "cp-legacy", legacy)
+    _write_legacy_file(tmp_path, "cp-legacy", legacy)
+    await manager.save_checkpoint("op-1", "cp-fresh", 10.0, {"k": "fresh"})
+
+    all_checkpoints = await manager.list_checkpoints("op-1")
+
+    assert not pickle_loads_calls, "pickle.loads must never be called on Redis-cached checkpoint data"
+    assert {c.checkpoint_id for c in all_checkpoints} == {"cp-legacy", "cp-fresh"}


### PR DESCRIPTION
Closes #14187

## Thinking Path

Two call sites left over after #14185/#14159 (the threat-detection precedent).
Each is a different shape of "genuinely trusted input" problem, so each got a
different fix rather than one pattern applied twice.

**`chromadb_client.py:290` (`_fix_hnsw_pickle_format`)** reads
`index_metadata.pickle` -- ChromaDB's own on-disk format for
`PersistentLocalHnswSegment`. ChromaDB's *own* segment code
(`chromadb/segment/impl/vector/local_persistent_hnsw.py`, in the pinned
`chromadb>=1.5.9` dependency) both writes this file with plain
`pickle.dump()` and reads it back with plain `pickle.load()` itself,
downstream of this function -- so the file cannot move to a non-pickle
format without forking the dependency. This is exactly the "payload
genuinely requires a Python object graph" case: the fix is a
`pickle.Unpickler` subclass (`_RestrictedHnswUnpickler`) whose `find_class`
allowlists exactly `("chromadb.segment.impl.vector.local_persistent_hnsw",
"PersistentData")` and refuses everything else. Builtin containers
(dict/list/str/int/None) never invoke `find_class` at all, so this also
still reads the pre-0.5.x plain-dict legacy shape this function exists to
migrate.

**Trust boundary:** the file lives under the local ChromaDB persist
directory, which resolves under `config.path.data_path` /
`LEGACY_DATA_ROOT.DATA_DIR` -- both excluded from the filesystem MCP bridge
(`api/filesystem_mcp.py`, #14081/#14124). The only writers today are
ChromaDB's own segment code and this function, both inside the backend
process. "No known write path today" isn't proof for tomorrow (#14124's own
history is the precedent for that assumption breaking), hence restricting
rather than trusting the read outright.

**`checkpoint_manager.py:183,259`** (`load_checkpoint` /
`_list_checkpoints_from_redis`) call `pickle.loads()` on bytes read from a
Redis hash field, `checkpoint:{operation_id}:{checkpoint_id}`. Tracing the
bytes: `_save_checkpoint_to_redis` pickled the *exact same dict* that
`_save_checkpoint_to_file` writes to the JSON file store one line earlier in
`save_checkpoint()` -- so the payload was already proven JSON-serializable
by the file write that always runs first. There is no reason for the Redis
copy to be a different, riskier format than the file copy. Fix: the Redis
cache is JSON too, which removes the sink outright rather than narrowing it
(preferred fix per the issue). **Trust boundary:** whoever can write that
Redis key -- this process today, but a wider set than "our own file on our
own disk" the moment anything else can reach this Redis instance (#14124).

Per the issue and #14159's precedent: **no one-time unpickle migration**.
The loader never reads the old pickle format under any circumstance --
`json.loads()` on a pre-#14187 entry raises `(json.JSONDecodeError |
UnicodeDecodeError)`, which is caught, logged at INFO, and the stale key is
deleted (self-healing, not required for correctness -- `TTL_7_DAYS` expires
it either way). Execution then falls through to the file store, which is
the primary copy (written first, on every `save_checkpoint()`) and is
therefore never behind the cache.

## What happens to pre-existing on-disk artifacts

- **`index_metadata.pickle`**: untouched format-wise -- still ChromaDB's own
  pickle file, still written/read by ChromaDB's own code. Every existing
  file (both the current `PersistentData`-shaped format and the pre-0.5.x
  plain-dict shape) loads identically through the restricted unpickler; nothing
  is migrated, reset, or made unreadable. Only a file containing a class
  reference ChromaDB itself would never have written now fails closed
  (logged, that one file's fix-up skipped, loop continues) instead of
  executing it.
- **Redis-cached checkpoints**: never read as pickle again. A pre-#14187
  entry is discarded (not migrated) on first read; the checkpoint itself is
  not lost because the JSON file written by `save_checkpoint()` for every
  checkpoint that was ever Redis-cached is the recovery path, both for
  `load_checkpoint()` (falls back to the file) and `list_checkpoints()`
  (`_list_checkpoints_from_files` merges by `checkpoint_id`, independent of
  what the Redis path returned).
- **Checkpoint `.json` files**: format unchanged (JSON before, JSON after);
  no data loss, no migration needed.

## What Changed

- `autobot-backend/utils/chromadb_client.py`: added
  `_ALLOWED_HNSW_PICKLE_CLASSES` + `_RestrictedHnswUnpickler`;
  `_fix_hnsw_pickle_format` now loads through it instead of `pickle.load(f)`.
  `pickle.dump()` (the write side, not a deserialization sink) is untouched.
  `# nosec B403` on `import pickle` re-justified (bandit doesn't flag a
  `pickle.Unpickler` *subclass* call the way it flags `pickle.Unpickler(...)`
  directly -- verified with bandit locally, no `# nosec B301` needed anywhere
  in this file anymore).
- `autobot-backend/utils/long_running_operations/checkpoint_manager.py`:
  removed `import pickle` entirely. `_save_checkpoint_to_redis` writes
  `json.dumps(...)` instead of `pickle.dumps(...)`. `load_checkpoint` and
  `_list_checkpoints_from_redis` parse with `json.loads`, catching
  `(JSONDecodeError, UnicodeDecodeError)` specifically to discard a
  pre-migration entry and fall through to the file store.
  `_list_checkpoints_from_redis` also had its per-entry handling hardened
  while it was being touched: the original loop lived entirely inside one
  `try/except`, so the first bad entry (of *any* kind, not just a
  pre-migration one) silently lost every later entry in that same call; each
  entry is now isolated so one failure can't take out the rest of the batch.
  `load_checkpoint`/file-branch construction was also switched to the
  existing `_parse_checkpoint_data` helper it already had (was duplicated
  inline in three places).

## Tests

`autobot-backend/utils/chromadb_client_hnsw_pickle_security_test.py`:
- `test_restricted_unpickler_accepts_the_allowlisted_class` -- legitimate
  `PersistentData` payload round-trips.
- `test_restricted_unpickler_rejects_disallowed_class` -- **the denial**: a
  pickle stream referencing `os.system` (a real, harmless function
  reference -- pickling it never calls it) is refused with
  `pickle.UnpicklingError`, proving `find_class` blocks the resolution step
  an RCE gadget depends on.
- `test_fix_hnsw_pickle_format_migrates_legacy_dict_without_data_loss` --
  **migration/back-compat**: a pre-0.5.x plain-dict fixture (no custom class
  at all) still loads and still gets migrated to `PersistentData`.
- `test_fix_hnsw_pickle_format_skips_disallowed_pickle_without_raising` --
  the disallowed payload is refused at the actual call site, not just at the
  unpickler unit level: no raise, file bytes unchanged, and the refusal is
  logged (not swallowed).
- Never a committed opaque blob -- both malicious-shaped payloads are built
  with `pickle.dumps()` at test run time from real, harmless objects
  (`os.system`). The real `chromadb` package/`hnswlib` aren't required:
  `chromadb.segment.impl.vector.local_persistent_hnsw` is registered directly
  under its full dotted name in `sys.modules` (verified against CPython's
  import machinery and against `pickle`'s own `save_global`, which is
  stricter than a plain import statement -- see the module docstring).

`autobot-backend/utils/long_running_operations/checkpoint_manager_pickle_security_test.py`
(a `_FakeAsyncRedis`, since no shared fake supports glob `keys()`):
- `test_save_checkpoint_caches_json_in_redis` -- the cached bytes parse as
  JSON and fail `pickle.loads`.
- `test_load_checkpoint_never_unpickles_and_recovers_from_file` -- **denial +
  migration/back-compat together**: seeds a real pre-#14187 entry (built with
  `pickle.dumps()`) plus its file counterpart, spies on `pickle.loads`
  (records calls without raising -- see below), and asserts the spy was
  never called, the correct checkpoint is still returned (from the file),
  and the stale key is dropped.
- `test_list_checkpoints_from_redis_drops_legacy_entry_without_unpickling` /
  `test_list_checkpoints_recovers_legacy_entry_via_file_store` -- same
  proof at the batch-listing entry point, plus the no-data-loss merge.

**Why a spy, not a raising sentinel:** a `pickle.loads` sentinel that raises
looked like the obvious denial proof, but `checkpoint_manager.py`'s Redis
paths already wrap Redis access in a broad `except Exception:
logger.warning(...)` (pre-existing, not new here) with a fallback to the
file store -- so a raised sentinel gets caught by that handler and the test
*still passes* via the fallback, blind to a regression that reintroduces
`pickle.loads`. Found this by actually reverting the fix in a standalone
harness (below) and watching the raising version stay green. The spy
records the call and still delegates to the real `pickle.loads`, so
behaviour is unaffected either way and the assertion checks what actually
happened.

## Verification

No project interpreter with `chromadb`/`hnswlib` fully installed exists in
this environment (`hnswlib` import fails locally; CI is authoritative per
the pinned `chromadb>=1.5.9` in `requirements.txt`). Beyond
`python3 -m py_compile` on every touched file:

- `black --line-length 120`, `isort --profile black --line-length 120`,
  `flake8`, `ruff check --line-length 120` -- clean on all four files.
- `bandit -c .bandit` -- zero findings on both production files (confirms
  `pickle.Unpickler` subclassing doesn't trip B301, and `import pickle`'s
  `# nosec B403` is the only suppression, correctly formatted per
  `scripts/check_nosec_format.py`, which also passes repo-wide).
- Rather than a "pure logic" reimplementation, I extracted the *literal*
  committed text of `_RestrictedHnswUnpickler`/`_fix_hnsw_pickle_format` and
  of `OperationCheckpointManager` (via `src.index(...)` slicing, not
  retyped) into standalone harnesses and ran the exact pytest scenarios
  against them under system Python, with `chromadb`'s leaf module and a
  fake Redis stood in by hand. All scenarios passed as designed.

**Mutation evidence** (guard reverted in the harness, confirmed red, then
reverted back to the fix -- not run through pytest directly, since that
requires the project interpreter, but through the harness executing the
literal committed code):
- `_RestrictedHnswUnpickler` bypassed (`find_class` always delegates): the
  "skips disallowed payload" scenario flips from *file unchanged, refusal
  logged* to *file rewritten with attacker-influenced content* (verified
  with an `argparse.Namespace`-shaped payload whose `dimensionality=None`
  makes the unrestricted path actually reach `pickle.dump()`; a bare
  `os.system` reference doesn't reach that far because attribute assignment
  on a builtin function fails first for an unrelated reason, and I confirmed
  that distinction empirically rather than assuming it). Also confirmed via
  the log-message assertion: the fixed code logs "Refusing to unpickle
  disallowed class ..."; the reverted code logs a *different* `AttributeError`
  message on the same payload, containing no such text -- 0 pre-mutation
  false positives, 1 post-mutation failure per scenario, reverted back green.
- `checkpoint_manager.py` reverted to `pickle.loads(data)` at both call
  sites: `load_checkpoint`'s spy assertion flips
  `pickle_loads_called=False` -> `True` (confirmed with the harness -- the
  *returned checkpoint* is identical either way thanks to the file
  fallback, which is exactly why the spy design matters over a
  return-value-only assertion). `_list_checkpoints_from_redis` reverted the
  same way raises an uncaught `UnpicklingError` on the now-JSON-formatted
  Redis bytes of a second, unrelated entry (still a failing/red test, just
  via an exception rather than a clean assertion).

## Model Used

Claude Opus 5.
