### PR TITLE
fix(slm): record a deferral when an index is skipped for a missing table (#14327)

### DIFF
--- a/autobot-slm-backend/migrations/utils.py
+++ b/autobot-slm-backend/migrations/utils.py
@@ -158,8 +158,19 @@ def create_index_if_not_exists(
     later create-all converges the schema without a Postgres ERROR (#9785).
     """
     if not table_exists(cursor, table_name):
-        logger.debug(
-            "Skipping index %s: table %s does not exist yet",
+        # #14327: the same shape #14300 fixed for columns. The #9785 skip is
+        # right, but on its own the runner then marks the migration applied,
+        # permanently — so the index is never created once the table appears,
+        # or when the table lives in a different database than the one the
+        # runner connects to. Recording the deferral lets the runner decline to
+        # mark it applied, so it is retried on the next boot.
+        #
+        # WARNING rather than DEBUG for the same reason as the column helper: a
+        # skipped schema change that looks like a completed one is exactly the
+        # thing nobody goes looking for, and DEBUG is not on in production.
+        _DEFERRED.append(f"{table_name}.{index_name}")
+        logger.warning(
+            "Deferring index %s on %s: table does not exist in this database yet (#14327)",
             index_name,
             table_name,
         )

--- a/autobot-slm-backend/migrations/utils_test.py
+++ b/autobot-slm-backend/migrations/utils_test.py
@@ -9,7 +9,18 @@ On a fresh DB the target table may not exist when add_column/create_index run
 ALTER/CREATE that errors with 'relation "<t>" does not exist'.
 """
 
+import pytest
+
 from migrations import utils
+
+
+@pytest.fixture(autouse=True)
+def _clear_deferrals():
+    """``_DEFERRED`` is module state, so without this the column tests above
+    leak entries into the index assertions below and vice versa."""
+    utils.reset_deferrals()
+    yield
+    utils.reset_deferrals()
 
 
 class _FakeCursor:
@@ -74,3 +85,58 @@ def test_create_index_creates_when_table_present_and_index_missing():
     cur = _FakeCursor(table_present=True, index_present=False)
     assert utils.create_index_if_not_exists(cur, "ix_nodes_name", "nodes", "name") is True
     assert cur.ran("CREATE INDEX ix_nodes_name")
+
+
+def test_create_index_records_a_deferral_when_the_table_is_absent():
+    """The fix for #14327.
+
+    Skipping is right (#9785) — an index on a missing table is a Postgres
+    ERROR. Skipping *silently* is what made it permanent: the runner marks the
+    migration applied, so the index is never created once the table appears, or
+    when the table lives in a different database than the one the runner
+    connects to. That is #14300's audit_logs scenario, for indexes.
+    """
+    cur = _FakeCursor(table_present=False)
+
+    assert utils.create_index_if_not_exists(cur, "ix_nodes_name", "nodes", "name") is False
+    assert not cur.ran("CREATE INDEX")
+    assert utils.deferrals() == ["nodes.ix_nodes_name"]
+
+
+def test_create_index_records_nothing_when_it_creates_the_index():
+    """A deferral recorded on the success path would make every re-run refuse to
+    mark the migration applied, forever — the mirror-image failure."""
+    cur = _FakeCursor(table_present=True, index_present=False)
+
+    assert utils.create_index_if_not_exists(cur, "ix_nodes_name", "nodes", "name") is True
+    assert utils.deferrals() == []
+
+
+def test_create_index_records_nothing_when_the_index_already_exists():
+    cur = _FakeCursor(table_present=True, index_present=True)
+
+    assert utils.create_index_if_not_exists(cur, "ix_nodes_name", "nodes", "name") is False
+    assert not cur.ran("CREATE INDEX")
+    assert utils.deferrals() == []
+
+
+def test_both_helpers_feed_the_one_record_the_runner_reads():
+    """The invariant, rather than either helper in isolation.
+
+    ``run_all_migrations`` consults ``deferrals()`` and declines to mark a
+    migration applied when it is non-empty. That gate is generic — it never
+    asks which helper deferred. So the property that matters is that both
+    helpers write to the same record; a helper that skips without recording is
+    invisible to the gate no matter how correct the gate is.
+
+    #14327 existed because only the column helper did.
+    """
+    cur = _FakeCursor(table_present=False)
+
+    utils.add_column_if_not_exists(cur, "audit_logs", "updated_at", "TIMESTAMP")
+    utils.create_index_if_not_exists(cur, "ix_audit_logs_updated_at", "audit_logs", "updated_at")
+
+    assert utils.deferrals() == [
+        "audit_logs.updated_at",
+        "audit_logs.ix_audit_logs_updated_at",
+    ]


### PR DESCRIPTION
## Thinking Path

`#14300` fixed a live incident: `column audit_logs.updated_at does not exist` raised on an HTTP request while the migration written for exactly that column sat marked applied. The cause was an absence read as a success — `add_column_if_not_exists` skipped a missing table (correct per #9785; the alternative is an ALTER that errors), the runner then marked the migration applied, and the skip became permanent. `audit_logs` lives in the user-management database, so the table was *never* going to be there.

`create_index_if_not_exists` carries the identical skip with the identical rationale, and #14300's deferral tracking was added only to the column helper. The index helper logged at DEBUG and returned `False` with no `_DEFERRED` entry.

What makes this worth fixing while it is still dead: `run_all_migrations` consults `deferrals()` and declines to mark a migration applied when it is non-empty. **That gate is generic — it never asks which helper deferred.** So a helper that skips without recording is invisible to it no matter how correct the gate is. The gate looks like it protects both helpers; it only protects the one that reports.

`defer()`'s own docstring already claimed both helpers "already record their own deferrals internally". That was true of one of them.

## What Changed

**`autobot-slm-backend/migrations/utils.py`** — `create_index_if_not_exists` appends `f"{table_name}.{index_name}"` to `_DEFERRED` and logs at WARNING rather than DEBUG when the target table is absent, matching `add_column_if_not_exists` exactly. DEBUG is not enabled in production, and a skipped schema change that looks like a completed one is precisely what nobody goes looking for.

**`autobot-slm-backend/migrations/utils_test.py`** — four new tests, plus the `reset_deferrals` autouse fixture the file lacked. `_DEFERRED` is module state, so without it the existing column assertions leaked entries into the index ones.

The runner needed no change: its deferral branch is already asserted structurally (AST-walked, requiring the `continue` to live inside the branch that tests `deferred`), and it keys on the record, not the helper.

## Verification

**Dead today, deliberately.** Every current call site — `add_replications_table.py`, `add_service_discovery.py`, and the rest — creates its target table unconditionally in the same migration immediately before calling this, so `table_exists` is always true by then. This is fixed so the next author does not have to know which of the two helpers remembers. It matters the moment someone indexes a table in a different database, which is #14300's scenario for indexes.

**Mutation evidence.** The committed helpers were extracted into a standalone module and exercised directly; the mutation removes only the `_DEFERRED.append(...)` line, leaving the WARNING in place:

```
utils_fixed    3/3 pass   index_deferral_recorded=OK    no_deferral_on_create=OK  both_helpers_feed_one_record=OK
utils_mutated  1/3 pass   index_deferral_recorded=FAIL  no_deferral_on_create=OK  both_helpers_feed_one_record=FAIL
```

The mutation-was-not-a-no-op assertion is in the harness, so a mutation that failed to apply cannot be reported as green.

Worth noting what that mutation proves: the mutated build **still emits the WARNING**. A test asserting on the log line would have passed it. The append is the signal the runner reads, and that is what these tests pin.

`test_both_helpers_feed_the_one_record_the_runner_reads` asserts the invariant rather than either helper alone — both write to the single record the gate consults, in order — because that is the property the runner's correctness actually rests on.

`python3 -m py_compile` clean on both files. CI is the authority on the suite.

## Model Used

Claude Opus 5.

Closes #14327
