### PR TITLE
fix(llc): make workflow_id company-scoped, not a global PK (#14271)

### DIFF
--- a/autobot-backend/llc/api/workflows.py
+++ b/autobot-backend/llc/api/workflows.py
@@ -23,6 +23,13 @@ Every read/write in this router goes through the table — no Redis or
 in-memory fallback (#13916's consolidation rule: two implementations of one
 thing become one reused core; this router is the first of the two, not a
 third).
+
+#14271: ``workflow_id`` is unique per-company, not globally, so create's
+pre-check (``get()`` then ``create()``) is a UX nicety for the common case,
+not the enforcement — a concurrent same-company duplicate still reaches the
+DB's ``UNIQUE (company_id, workflow_id)`` constraint, which ``create()``
+translates into ``WorkflowConflictError`` (caught here as 409) rather than
+letting it surface as an unhandled 500.
 """
 
 import uuid
@@ -39,7 +46,7 @@ from llc.deps import assert_company_access
 from user_management.database import get_async_session
 from user_management.services import TenantContext
 
-from ..services.workflow import WorkflowService
+from ..services.workflow import WorkflowConflictError, WorkflowService
 
 router = APIRouter(prefix="/workflows", tags=["llc-workflows"])
 
@@ -112,15 +119,22 @@ async def create_workflow(
     existing = await _svc().get(session, company_id, body.workflow_id)
     if existing is not None:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Workflow already exists")
-    workflow = await _svc().create(
-        session,
-        company_id,
-        body.workflow_id,
-        name=body.name,
-        status=body.status,
-        definition=body.definition,
-        actor=_actor_id(_current_user),
-    )
+    try:
+        workflow = await _svc().create(
+            session,
+            company_id,
+            body.workflow_id,
+            name=body.name,
+            status=body.status,
+            definition=body.definition,
+            actor=_actor_id(_current_user),
+        )
+    except WorkflowConflictError:
+        # The pre-check above is TOCTOU under concurrency (#14271): a
+        # same-company duplicate that raced past it still hits the DB's
+        # UNIQUE(company_id, workflow_id) constraint, closing the race
+        # rather than merely narrowing it.
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Workflow already exists")
     await session.commit()
     return WorkflowResponse.model_validate(workflow)
 

--- a/autobot-backend/llc/services/role_workflow.py
+++ b/autobot-backend/llc/services/role_workflow.py
@@ -19,14 +19,20 @@ The second one has a wrinkle worth stating: ``Workflow.company_id`` is
 role would give that company a workflow nobody has established it owns.
 
 The NULL case gets its own error rather than being folded into the ownership
-mismatch. To be precise about what that buys: comparing ``None != company_id``
-in Python is already ``True``, so an unattributed workflow would be refused
-either way — the branch does not close a bypass. What it closes is a
-*diagnostic* gap. Without it the caller is told the workflow "does not belong to
-company X", which reads as "it belongs to someone else" when the truth is "it
-belongs to nobody yet, and needs attributing". Those call for different fixes.
-A guard expressed as a SQL predicate instead of a Python comparison would be
-worse still, reporting the row as simply missing.
+mismatch, so the caller can tell "does not exist" apart from "exists but is
+unattributed, and needs reconciling" — those call for different fixes.
+
+#14271: ``_require_workflow`` used to run one *unscoped* ``SELECT ... WHERE
+workflow_id = :workflow_id`` — sound only while ``workflow_id`` was a global
+primary key, since exactly one row could ever match. Now that
+``UNIQUE (company_id, workflow_id)`` allows the same string in more than one
+company, that query could return an arbitrary row belonging to a company the
+caller has nothing to do with, and — worse — the resulting "does not belong
+to company X" message was a cross-tenant presence oracle for a client-supplied
+id, the exact defect class #14271 exists to close. The check is now two
+queries, each scoped to a company this caller is already allowed to see
+(their own, or the unattributed-legacy set), so it never reads — and never
+reports on — another company's row.
 """
 
 from __future__ import annotations
@@ -82,17 +88,33 @@ class RoleWorkflowService(LLCServiceBase):
 
         A NULL ``company_id`` is refused distinctly from a missing row: it means
         the workflow predates company attribution, not that it is absent.
-        """
-        result = await session.execute(select(Workflow.company_id).where(Workflow.workflow_id == workflow_id))
-        row = result.first()
-        if row is None:
-            raise ValueError(f"workflow {workflow_id!r} does not exist")
 
-        owner = row[0]
-        if owner is None:
+        #14271: each query below is scoped to a company this caller is
+        entitled to see (their own, or the unattributed-legacy rows) — never
+        to ``workflow_id`` alone. A workflow that exists, but belongs to a
+        *different* company, is therefore indistinguishable from one that
+        does not exist at all: reporting the two differently would be a
+        cross-tenant presence oracle for a client-supplied id.
+        """
+        own = await session.execute(
+            select(Workflow.workflow_id).where(
+                Workflow.workflow_id == workflow_id,
+                Workflow.company_id == company_id,
+            )
+        )
+        if own.scalar_one_or_none() is not None:
+            return
+
+        unattributed = await session.execute(
+            select(Workflow.workflow_id).where(
+                Workflow.workflow_id == workflow_id,
+                Workflow.company_id.is_(None),
+            )
+        )
+        if unattributed.scalar_one_or_none() is not None:
             raise ValueError(f"workflow {workflow_id!r} has no company attribution and cannot be " "attached to a role")
-        if owner != company_id:
-            raise ValueError(f"workflow {workflow_id!r} does not belong to company {company_id}")
+
+        raise ValueError(f"workflow {workflow_id!r} does not exist")
 
     async def attach(
         self,

--- a/autobot-backend/llc/services/role_workflow.py
+++ b/autobot-backend/llc/services/role_workflow.py
@@ -95,6 +95,19 @@ class RoleWorkflowService(LLCServiceBase):
         *different* company, is therefore indistinguishable from one that
         does not exist at all: reporting the two differently would be a
         cross-tenant presence oracle for a client-supplied id.
+
+        The ``company_id == company_id`` query below may use
+        ``scalar_one_or_none()`` safely: ``UNIQUE(company_id, workflow_id)``
+        guarantees at most one row for any concrete (non-NULL) company_id.
+        The ``company_id IS NULL`` query cannot make that assumption — SQL
+        unique-constraint semantics treat every NULL as distinct from every
+        other NULL, so two legacy rows (e.g. from two backfill runs) can
+        legally share a ``workflow_id`` with ``company_id`` both NULL. This
+        branch only needs to know whether *any* such row exists — every
+        matching row produces the identical "no company attribution" refusal
+        regardless of which one is read — so ``.first()`` is the correct,
+        deliberate choice here, not merely a way to avoid
+        ``MultipleResultsFound``.
         """
         own = await session.execute(
             select(Workflow.workflow_id).where(
@@ -111,7 +124,7 @@ class RoleWorkflowService(LLCServiceBase):
                 Workflow.company_id.is_(None),
             )
         )
-        if unattributed.scalar_one_or_none() is not None:
+        if unattributed.first() is not None:
             raise ValueError(f"workflow {workflow_id!r} has no company attribution and cannot be " "attached to a role")
 
         raise ValueError(f"workflow {workflow_id!r} does not exist")

--- a/autobot-backend/llc/services/workflow.py
+++ b/autobot-backend/llc/services/workflow.py
@@ -26,6 +26,14 @@ race between two same-company requests can still reach the DB constraint;
 ``WorkflowConflictError`` so the route can translate it to a clean 409
 instead of an unhandled 500 (mirrors ``ReviewGatePolicyConflictError`` in
 ``llc/services/review_gate.py``).
+
+Review of #14443: the ``IntegrityError`` catch is narrowed to this table's
+own ``uq_workflows_company_workflow`` constraint (see
+``_is_workflow_unique_conflict``) rather than swallowing every
+``IntegrityError`` unconditionally — no other constraint on this table can
+fire today, but a broad catch would silently relabel a future FK/check
+violation as a misleading "workflow already exists" 409 instead of letting
+the real error surface.
 """
 
 import uuid
@@ -42,9 +50,32 @@ from ..models.activity import ActorType
 from ..models.enums import WorkflowStatus
 from .base import LLCServiceBase
 
+#: Name of the constraint create() is entitled to translate into a 409.
+#: Must match models/workflow.py's UniqueConstraint name exactly.
+_UNIQUE_CONSTRAINT_NAME = "uq_workflows_company_workflow"
+
 
 class WorkflowConflictError(Exception):
     """Raised when a workflow_id already exists for this company (unique-constraint race)."""
+
+
+def _is_workflow_unique_conflict(exc: IntegrityError) -> bool:
+    """True only when *exc* is this table's own UNIQUE(company_id, workflow_id).
+
+    Walks to the DBAPI exception (``exc.orig``), which carries a structured
+    ``constraint_name`` under asyncpg (the async Postgres driver this service
+    runs against — see ``user_management/database.py``'s own ``.orig`` walk
+    for the established idiom). SQLite's ``sqlite3.IntegrityError`` (used
+    under the test suite) has no such attribute; its message instead names
+    the columns, e.g. ``"UNIQUE constraint failed: workflows.company_id,
+    workflows.workflow_id"``, so that shape is matched as a fallback.
+    """
+    orig = exc.orig
+    constraint_name = getattr(orig, "constraint_name", None)
+    if constraint_name is not None:
+        return constraint_name == _UNIQUE_CONSTRAINT_NAME
+    message = str(orig)
+    return "workflows.company_id" in message and "workflows.workflow_id" in message
 
 
 class WorkflowService(LLCServiceBase):
@@ -82,6 +113,11 @@ class WorkflowService(LLCServiceBase):
             await session.flush()
         except IntegrityError as exc:
             await session.rollback()
+            if not _is_workflow_unique_conflict(exc):
+                # A different constraint fired (e.g. a future FK/check on
+                # this table) — that is a real bug, not a duplicate, and
+                # must not be relabelled as a plausible-looking 409.
+                raise
             raise WorkflowConflictError(f"workflow {workflow_id!r} already exists for company {company_id}") from exc
 
         if self.activity_log:

--- a/autobot-backend/llc/services/workflow.py
+++ b/autobot-backend/llc/services/workflow.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
-"""LLC company-scoped workflow service (#14210).
+"""LLC company-scoped workflow service (#14210, #14271).
 
 Company-scoped CRUD for ``Workflow`` (``models/workflow.py``) — the
 foundation a future process node (#13963) will reference. Every method takes
@@ -16,6 +16,16 @@ through this service are always company-attributed, even though the
 underlying table column stays nullable to hold pre-existing rows backfilled
 from Redis by ``services/workflow_redis_backfill.py`` (see
 ``models/workflow.py`` docstring).
+
+#14271: the table's uniqueness is now ``UNIQUE (company_id, workflow_id)``,
+not a global primary key on ``workflow_id`` alone — so a same-company
+duplicate is the only case that can still conflict. ``create``'s route-level
+pre-check (``get()`` then ``create()``) is TOCTOU under concurrency, so a
+race between two same-company requests can still reach the DB constraint;
+``create`` catches that ``IntegrityError`` and raises
+``WorkflowConflictError`` so the route can translate it to a clean 409
+instead of an unhandled 500 (mirrors ``ReviewGatePolicyConflictError`` in
+``llc/services/review_gate.py``).
 """
 
 import uuid
@@ -23,6 +33,7 @@ from typing import Any, Dict, List, Optional
 
 from sqlalchemy import delete as sa_delete
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.workflow import SOURCE_CREATED, Workflow
@@ -30,6 +41,10 @@ from models.workflow import SOURCE_CREATED, Workflow
 from ..models.activity import ActorType
 from ..models.enums import WorkflowStatus
 from .base import LLCServiceBase
+
+
+class WorkflowConflictError(Exception):
+    """Raised when a workflow_id already exists for this company (unique-constraint race)."""
 
 
 class WorkflowService(LLCServiceBase):
@@ -63,7 +78,13 @@ class WorkflowService(LLCServiceBase):
             created_by=actor,
         )
         session.add(workflow)
-        await session.flush()
+        try:
+            await session.flush()
+        except IntegrityError as exc:
+            await session.rollback()
+            raise WorkflowConflictError(
+                f"workflow {workflow_id!r} already exists for company {company_id}"
+            ) from exc
 
         if self.activity_log:
             await self.activity_log.record(
@@ -167,4 +188,4 @@ class WorkflowService(LLCServiceBase):
         return deleted
 
 
-__all__ = ["WorkflowService"]
+__all__ = ["WorkflowConflictError", "WorkflowService"]

--- a/autobot-backend/llc/services/workflow.py
+++ b/autobot-backend/llc/services/workflow.py
@@ -82,9 +82,7 @@ class WorkflowService(LLCServiceBase):
             await session.flush()
         except IntegrityError as exc:
             await session.rollback()
-            raise WorkflowConflictError(
-                f"workflow {workflow_id!r} already exists for company {company_id}"
-            ) from exc
+            raise WorkflowConflictError(f"workflow {workflow_id!r} already exists for company {company_id}") from exc
 
         if self.activity_log:
             await self.activity_log.record(

--- a/autobot-backend/llc/tests/test_role_workflows.py
+++ b/autobot-backend/llc/tests/test_role_workflows.py
@@ -10,11 +10,14 @@ The second one worth reading is
 is nullable for rows backfilled from Redis. Removing the dedicated NULL branch
 reddens that test — verified by mutation — but it is worth being precise about
 why: ``None != company_id`` is already ``True``, so the workflow stays refused.
-What the branch protects is the *reason* given. Without it the caller hears
-"does not belong to company X", which reads as "it belongs to someone else"
-when in fact it belongs to nobody yet. That is a different problem with a
-different fix, and conflating the two is how unattributed legacy rows stay
-unattributed.
+What the branch protects is the *reason* given: "no company attribution yet"
+versus a workflow that simply is not visible to this caller at all.
+
+``test_another_companys_workflow_cannot_be_attached`` pins the #14271 fix
+directly: attaching another company's workflow is refused with the *same*
+"does not exist" message a truly-missing workflow gets, not a distinct
+"belongs to company X" — the old distinct message was a cross-tenant
+presence oracle for a client-supplied id (#14271).
 """
 
 from __future__ import annotations
@@ -179,13 +182,20 @@ async def test_an_unattributed_legacy_workflow_cannot_be_attached(session_factor
 
 @pytest.mark.asyncio
 async def test_another_companys_workflow_cannot_be_attached(session_factory):  # noqa: ANN001
+    """#14271: refused with the *same* message a missing workflow gets.
+
+    A distinct "belongs to company X" message would tell a company-A admin
+    that a specific workflow_id exists somewhere in the installation, outside
+    their own company — a cross-tenant presence oracle for a client-supplied
+    id. The denial must be indistinguishable from "no such workflow".
+    """
     company_a, company_b = uuid.uuid4(), uuid.uuid4()
     role_a = await _seed_role(session_factory, company_a, "Head of Sales")
     theirs = await _seed_workflow(session_factory, "wf-theirs", company_b)
     service = RoleWorkflowService()
 
     async with session_factory() as session:
-        with pytest.raises(ValueError, match="does not belong to company"):
+        with pytest.raises(ValueError, match="does not exist"):
             await service.attach(
                 session, company_id=company_a, role_id=role_a, workflow_id=theirs, actor_user_id=_ADMIN_USER
             )

--- a/autobot-backend/llc/tests/test_role_workflows.py
+++ b/autobot-backend/llc/tests/test_role_workflows.py
@@ -181,6 +181,35 @@ async def test_an_unattributed_legacy_workflow_cannot_be_attached(session_factor
 
 
 @pytest.mark.asyncio
+async def test_two_ambiguous_unattributed_rows_are_refused_cleanly_not_500(session_factory):  # noqa: ANN001
+    """#14271 review: UNIQUE(company_id, workflow_id) treats every NULL as
+    distinct, so two legacy rows CAN legally share a workflow_id with
+    company_id both NULL (e.g. a race between two backfill runs). Before this
+    test, the unattributed-lookup branch used ``scalar_one_or_none()``, which
+    raises ``MultipleResultsFound`` — an unhandled 500 — the moment a second
+    such row exists. Both rows refuse identically ("no company attribution"),
+    so this must still be a clean refusal, not a crash.
+    """
+    company = uuid.uuid4()
+    role_id = await _seed_role(session_factory, company, "Head of Sales")
+    await _seed_workflow(session_factory, "wf-ambiguous", None)
+    await _seed_workflow(session_factory, "wf-ambiguous", None)  # a second NULL-company row, same workflow_id
+    service = RoleWorkflowService()
+
+    async with session_factory() as session:
+        rows = await session.execute(
+            sa.select(sa.func.count()).select_from(Workflow).where(Workflow.workflow_id == "wf-ambiguous")
+        )
+        assert rows.scalar_one() == 2, "fixture must actually create two ambiguous rows"
+
+    async with session_factory() as session:
+        with pytest.raises(ValueError, match="no company attribution"):
+            await service.attach(
+                session, company_id=company, role_id=role_id, workflow_id="wf-ambiguous", actor_user_id=_ADMIN_USER
+            )
+
+
+@pytest.mark.asyncio
 async def test_another_companys_workflow_cannot_be_attached(session_factory):  # noqa: ANN001
     """#14271: refused with the *same* message a missing workflow gets.
 

--- a/autobot-backend/llc/tests/test_role_workflows_idor.py
+++ b/autobot-backend/llc/tests/test_role_workflows_idor.py
@@ -77,9 +77,7 @@ class TestAttachWorkflowIdorIndistinguishability:
         cross_company_response = self._attach(
             company_id, "theirs", service_raises=ValueError("workflow 'theirs' does not exist")
         )
-        missing_response = self._attach(
-            company_id, "nope", service_raises=ValueError("workflow 'nope' does not exist")
-        )
+        missing_response = self._attach(company_id, "nope", service_raises=ValueError("workflow 'nope' does not exist"))
 
         assert cross_company_response.status_code == missing_response.status_code == 400
         # Body text differs only in the workflow_id it echoes back (client-

--- a/autobot-backend/llc/tests/test_role_workflows_idor.py
+++ b/autobot-backend/llc/tests/test_role_workflows_idor.py
@@ -1,0 +1,90 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""HTTP-level proof that attaching another company's workflow is indistinguishable
+from attaching a nonexistent one (#14271 review finding 3).
+
+``test_role_workflows.py`` proves the service-layer refusal
+(``RoleWorkflowService._require_workflow``) is correct — this file proves the
+*route* (``POST /llc/roles/{company_id}/{role_id}/workflows``) does not
+re-introduce a status-code or body differential on top of it. Mirrors
+``test_workflows_idor.py``'s ``_make_client`` harness for the sibling router:
+``RoleWorkflowService.attach`` is mocked to raise the exact ``ValueError``
+shape the real (fixed) service now raises for each case, and the two
+responses are asserted byte-for-byte identical.
+"""
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from user_management.services import TenantContext
+
+_FIXED_USER_ID = uuid.UUID("77777777-7777-7777-7777-777777777777")
+
+
+def _make_client(caller_company_id: str) -> TestClient:
+    from api.user_management.dependencies import get_current_user, require_org_context  # noqa: PLC0415
+    from llc.api.roles import router as roles_router  # noqa: PLC0415
+    from user_management.database import get_async_session  # noqa: PLC0415
+
+    app = FastAPI()
+    app.include_router(roles_router, prefix="/api/llc")
+
+    async def _fake_session():
+        yield AsyncMock()
+
+    app.dependency_overrides[get_async_session] = _fake_session
+    app.dependency_overrides[get_current_user] = lambda: {"id": str(_FIXED_USER_ID)}
+    app.dependency_overrides[require_org_context] = lambda: TenantContext(
+        org_id=uuid.UUID(caller_company_id), user_id=_FIXED_USER_ID, is_platform_admin=False
+    )
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _stop_patches():
+    yield
+    patch.stopall()
+
+
+class TestAttachWorkflowIdorIndistinguishability:
+    """#14271: a client must not be able to tell "belongs to another company"
+    apart from "does not exist" by posting a workflow_id and reading the
+    response — same status, same body, in both cases."""
+
+    def _attach(self, company_id: str, workflow_id: str, *, service_raises: ValueError):
+        client = _make_client(company_id)
+        with patch(
+            "llc.api.roles.RoleWorkflowService.attach",
+            new=AsyncMock(side_effect=service_raises),
+        ):
+            role_id = uuid.uuid4()
+            return client.post(
+                f"/api/llc/roles/{company_id}/{role_id}/workflows",
+                json={"workflow_id": workflow_id},
+            )
+
+    def test_another_companys_workflow_and_a_missing_one_get_identical_responses(self):
+        company_id = str(uuid.uuid4())
+
+        # This is the exact ValueError RoleWorkflowService._require_workflow
+        # now raises for BOTH "belongs to another company" and "does not
+        # exist at all" (#14271) — the route must not layer a distinction
+        # back on top of a service that deliberately collapsed one.
+        cross_company_response = self._attach(
+            company_id, "theirs", service_raises=ValueError("workflow 'theirs' does not exist")
+        )
+        missing_response = self._attach(
+            company_id, "nope", service_raises=ValueError("workflow 'nope' does not exist")
+        )
+
+        assert cross_company_response.status_code == missing_response.status_code == 400
+        # Body text differs only in the workflow_id it echoes back (client-
+        # supplied input, not tenant data) — the *shape* and every other
+        # word must be identical, which is what a presence oracle would break.
+        assert cross_company_response.json()["detail"].replace("theirs", "X") == missing_response.json()[
+            "detail"
+        ].replace("nope", "X")

--- a/autobot-backend/llc/tests/test_workflows_idor.py
+++ b/autobot-backend/llc/tests/test_workflows_idor.py
@@ -202,3 +202,30 @@ class TestWorkflowsActorDerivation:
         assert resp.status_code == 204
         _, kwargs = WorkflowService.delete.call_args
         assert kwargs["actor"] == _FIXED_USER_ID
+
+
+class TestWorkflowsConflictHandling:
+    """#14271: a same-company duplicate that races past the pre-check must
+    surface as the route's documented 409, never an unhandled 500.
+
+    ``WorkflowService.create`` is mocked here to raise ``WorkflowConflictError``
+    directly — the shape it actually raises when the DB's
+    ``UNIQUE(company_id, workflow_id)`` constraint rejects a concurrent
+    duplicate the ``get()`` pre-check already passed (see
+    ``test_workflows_scoping.py::test_same_company_duplicate_workflow_id_raises_a_clean_conflict``
+    for that translation at the service layer)."""
+
+    def test_create_race_past_the_pre_check_returns_409_not_500(self):
+        from llc.api.workflows import WorkflowConflictError  # noqa: PLC0415
+
+        company_id = str(uuid.uuid4())
+        client = _make_client(company_id)
+        with (
+            patch("llc.api.workflows.WorkflowService.get", new=AsyncMock(return_value=None)),
+            patch(
+                "llc.api.workflows.WorkflowService.create",
+                new=AsyncMock(side_effect=WorkflowConflictError("workflow 'wf-1' already exists")),
+            ),
+        ):
+            resp = client.post(f"/api/llc/workflows/{company_id}", json={"workflow_id": "wf-1"})
+        assert resp.status_code == 409

--- a/autobot-backend/llc/tests/test_workflows_scoping.py
+++ b/autobot-backend/llc/tests/test_workflows_scoping.py
@@ -16,13 +16,15 @@ from __future__ import annotations
 
 import uuid
 from typing import AsyncIterator
+from unittest.mock import patch
 
 import pytest
 import pytest_asyncio
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from llc.models.enums import WorkflowStatus
-from llc.services.workflow import WorkflowConflictError, WorkflowService
+from llc.services.workflow import WorkflowConflictError, WorkflowService, _is_workflow_unique_conflict
 
 # Importing the harness registers the SQLite compile shims for
 # postgresql.JSONB / postgresql.UUID (module-level side effect, safe to reuse
@@ -293,3 +295,47 @@ async def test_same_company_duplicate_workflow_id_raises_a_clean_conflict(sessio
     async with session_factory() as session:
         still_there = await service.get(session, company_id, "wf-dup")
     assert still_there is not None
+
+
+# #14271 review: the IntegrityError catch in create() must be narrow — only
+# this table's own UNIQUE(company_id, workflow_id) becomes WorkflowConflictError.
+# A different constraint (a future FK/check on this table) must propagate
+# unchanged, not be relabelled as a misleading "already exists".
+
+
+class _FakeAsyncpgUniqueViolation(Exception):
+    """Stands in for asyncpg's structured exception shape (has .constraint_name)."""
+
+    def __init__(self, constraint_name: str) -> None:
+        super().__init__("duplicate key value violates unique constraint")
+        self.constraint_name = constraint_name
+
+
+def test_is_workflow_unique_conflict_matches_only_its_own_constraint():
+    own = IntegrityError("INSERT", {}, _FakeAsyncpgUniqueViolation("uq_workflows_company_workflow"))
+    other = IntegrityError("INSERT", {}, _FakeAsyncpgUniqueViolation("some_other_fk_constraint"))
+    assert _is_workflow_unique_conflict(own) is True
+    assert _is_workflow_unique_conflict(other) is False
+
+
+def test_is_workflow_unique_conflict_falls_back_to_sqlite_message_shape():
+    """No structured constraint_name (sqlite, used under this test suite)."""
+    sqlite_message = "UNIQUE constraint failed: workflows.company_id, workflows.workflow_id"
+    own = IntegrityError("INSERT", {}, Exception(sqlite_message))
+    other = IntegrityError("INSERT", {}, Exception("NOT NULL constraint failed: workflows.workflow_id"))
+    assert _is_workflow_unique_conflict(own) is True
+    assert _is_workflow_unique_conflict(other) is False
+
+
+@pytest.mark.asyncio
+async def test_create_reraises_a_non_uniqueness_integrity_error(session_factory):  # noqa: ANN001
+    """A constraint violation that is NOT this table's own uq_workflows_company_workflow
+    must propagate as-is — never become a misleading WorkflowConflictError."""
+    service = WorkflowService()
+    company_id = uuid.uuid4()
+    other_constraint_error = IntegrityError("INSERT", {}, _FakeAsyncpgUniqueViolation("some_other_constraint"))
+
+    async with session_factory() as session:
+        with patch.object(session, "flush", side_effect=other_constraint_error):
+            with pytest.raises(IntegrityError):
+                await service.create(session, company_id, "wf-other-constraint")

--- a/autobot-backend/llc/tests/test_workflows_scoping.py
+++ b/autobot-backend/llc/tests/test_workflows_scoping.py
@@ -22,7 +22,7 @@ import pytest_asyncio
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from llc.models.enums import WorkflowStatus
-from llc.services.workflow import WorkflowService
+from llc.services.workflow import WorkflowConflictError, WorkflowService
 
 # Importing the harness registers the SQLite compile shims for
 # postgresql.JSONB / postgresql.UUID (module-level side effect, safe to reuse
@@ -220,3 +220,76 @@ async def test_every_defined_status_is_accepted(session_factory):  # noqa: ANN00
             )
             assert created.status == member.value
             await session.commit()
+
+
+# #14271: workflow_id was a GLOBAL primary key while every route/service above
+# it treats the identity as company-scoped. The two tests below pin the fix —
+# the collision case (two companies sharing a workflow_id, previously
+# impossible at the DB layer) and the race case (a same-company duplicate,
+# which must still conflict, but cleanly).
+
+
+@pytest.mark.asyncio
+async def test_two_companies_can_create_the_same_workflow_id(session_factory):  # noqa: ANN001
+    """The collision case: dropping this pin regresses to a global-unique PK.
+
+    Before #14271, the second create here raised an unhandled
+    ``sqlite3.IntegrityError`` / Postgres ``UNIQUE constraint failed:
+    workflows.workflow_id`` — company B could never create this id at all,
+    and the failure mode (500, not the route's documented 409) was itself a
+    cross-tenant presence oracle. Both companies must succeed independently.
+    """
+    company_a, company_b = uuid.uuid4(), uuid.uuid4()
+    service = WorkflowService()
+
+    async with session_factory() as session:
+        created_a = await service.create(session, company_a, "prod-deploy", name="A's deploy")
+        await session.commit()
+
+    async with session_factory() as session:
+        created_b = await service.create(session, company_b, "prod-deploy", name="B's deploy")
+        await session.commit()
+
+    assert created_a.workflow_id == created_b.workflow_id == "prod-deploy"
+    assert created_a.company_id == company_a
+    assert created_b.company_id == company_b
+    # Distinct rows (distinct surrogate primary keys) sharing a workflow_id —
+    # exactly what the composite UNIQUE(company_id, workflow_id) allows and a
+    # global PK on workflow_id alone forbids.
+    assert created_a.id != created_b.id
+
+    async with session_factory() as session:
+        own_a = await service.get(session, company_a, "prod-deploy")
+        own_b = await service.get(session, company_b, "prod-deploy")
+
+    assert own_a is not None and own_a.name == "A's deploy"
+    assert own_b is not None and own_b.name == "B's deploy"
+
+
+@pytest.mark.asyncio
+async def test_same_company_duplicate_workflow_id_raises_a_clean_conflict(session_factory):  # noqa: ANN001
+    """The race case: a same-company duplicate must still conflict — cleanly.
+
+    This calls ``WorkflowService.create`` directly twice (bypassing the
+    route's pre-check) so it is the DB's ``UNIQUE(company_id, workflow_id)``
+    constraint doing the rejecting, not the ``get()``-then-``create()``
+    pre-check — the TOCTOU shape a concurrent request would hit. ``create``
+    must translate that into ``WorkflowConflictError``, not let an
+    ``IntegrityError`` escape unhandled.
+    """
+    company_id = uuid.uuid4()
+    service = WorkflowService()
+
+    async with session_factory() as session:
+        await service.create(session, company_id, "wf-dup")
+        await session.commit()
+
+    async with session_factory() as session:
+        with pytest.raises(WorkflowConflictError):
+            await service.create(session, company_id, "wf-dup")
+
+    # The failed create's rollback must not have poisoned the row created
+    # before it — no data loss on the conflicting attempt.
+    async with session_factory() as session:
+        still_there = await service.get(session, company_id, "wf-dup")
+    assert still_there is not None

--- a/autobot-backend/migrations/versions/20260822_082_workflows_company_scoped_unique.py
+++ b/autobot-backend/migrations/versions/20260822_082_workflows_company_scoped_unique.py
@@ -1,0 +1,116 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Make ``workflows`` company-scoped, not globally unique, by id (#14271).
+
+20260816_076 gave ``workflows.workflow_id`` a *globally* unique primary key,
+while every route and service above it (``llc/api/workflows.py``,
+``llc/services/workflow.py``) treats the identity as company-scoped — every
+read and write filters on ``company_id`` in the query itself. The mismatch
+meant two companies could never independently pick the same human-readable
+id, a same-company duplicate raced an unhandled ``IntegrityError`` into a
+500 instead of the route's documented 409, and the 201-vs-500 split on
+create was a cross-tenant presence oracle driven by a field the caller
+controls (#14271).
+
+This migration:
+
+1. Adds a surrogate ``id`` (UUID) primary key, backfilled with
+   ``gen_random_uuid()`` for every existing row — no row is touched or
+   dropped, including the ``company_id IS NULL`` rows written by
+   ``services/workflow_redis_backfill.py`` (source =
+   ``legacy_redis_unattributed``). ``NO DATA LOSS``: this step only *adds* a
+   column and a value to it; nothing existing is altered or removed.
+2. Drops the primary key on ``workflow_id`` and makes ``id`` the primary key
+   instead. ``workflow_id`` keeps its ``NOT NULL`` (a side effect of having
+   been a PK column, which Postgres does not clear on dropping the PK
+   constraint) and gains an explicit index, since queries still filter on it.
+3. Adds ``UNIQUE (company_id, workflow_id)`` so the constraint finally
+   matches the scoping claim. Standard SQL unique-constraint semantics treat
+   NULL as distinct from every other value (including another NULL), so the
+   pre-existing ``company_id IS NULL`` legacy rows are unaffected by this
+   constraint even if two of them happened to share a ``workflow_id`` — they
+   were never distinguishable by that column anyway, and nothing about them
+   changes here.
+
+Guarded with ``has_table`` / ``has_column`` throughout (20260812_073 idiom):
+a database that already carries this shape from an out-of-band path, or one
+that skipped 076 entirely, must not hard-fail this migration.
+
+Revision ID: 20260822_082
+Revises: 20260821_081
+Create Date: 2026-08-22 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+from migrations.guards import has_column, has_table
+
+revision: str = "20260822_082"
+down_revision: Union[str, None] = "20260821_081"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_UNIQUE_NAME = "uq_workflows_company_workflow"
+_INDEX_NAME = "ix_workflows_workflow_id"
+
+
+def upgrade() -> None:
+    if not has_table("workflows"):
+        return
+
+    if not has_column("workflows", "id"):
+        # Nullable while it back-fills; every existing row (including the
+        # NULL-company legacy ones) gets a fresh value, then the column is
+        # tightened to NOT NULL. No row is dropped or altered otherwise.
+        op.add_column("workflows", sa.Column("id", UUID(as_uuid=True), nullable=True))
+        op.execute('UPDATE "workflows" SET id = gen_random_uuid() WHERE id IS NULL')
+        op.alter_column("workflows", "id", nullable=False)
+
+    inspector = sa.inspect(op.get_bind())
+    pk = inspector.get_pk_constraint("workflows")
+    if pk.get("constrained_columns") == ["workflow_id"]:
+        pk_name = pk.get("name") or "workflows_pkey"
+        op.drop_constraint(pk_name, "workflows", type_="primary")
+        op.create_primary_key("pk_workflows", "workflows", ["id"])
+
+    existing_indexes = {i["name"] for i in inspector.get_indexes("workflows")}
+    if _INDEX_NAME not in existing_indexes:
+        op.create_index(_INDEX_NAME, "workflows", ["workflow_id"])
+
+    existing_unique = {c["name"] for c in inspector.get_unique_constraints("workflows")}
+    if _UNIQUE_NAME not in existing_unique:
+        op.create_unique_constraint(_UNIQUE_NAME, "workflows", ["company_id", "workflow_id"])
+
+
+def downgrade() -> None:
+    if not has_table("workflows"):
+        return
+
+    inspector = sa.inspect(op.get_bind())
+
+    existing_unique = {c["name"] for c in inspector.get_unique_constraints("workflows")}
+    if _UNIQUE_NAME in existing_unique:
+        op.drop_constraint(_UNIQUE_NAME, "workflows", type_="unique")
+
+    existing_indexes = {i["name"] for i in inspector.get_indexes("workflows")}
+    if _INDEX_NAME in existing_indexes:
+        op.drop_index(_INDEX_NAME, table_name="workflows")
+
+    pk = inspector.get_pk_constraint("workflows")
+    if pk.get("constrained_columns") == ["id"]:
+        # This fails loudly (integrity error) if two rows now share a
+        # workflow_id across companies — that is the entire point of this
+        # migration, so a downgrade past it cannot silently succeed on data
+        # the composite constraint was created to allow.
+        pk_name = pk.get("name") or "pk_workflows"
+        op.drop_constraint(pk_name, "workflows", type_="primary")
+        op.create_primary_key("workflows_pkey", "workflows", ["workflow_id"])
+
+    if has_column("workflows", "id"):
+        op.drop_column("workflows", "id")

--- a/autobot-backend/models/workflow.py
+++ b/autobot-backend/models/workflow.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
-"""Workflow model — a durable, company-scoped identity for a workflow (#14210).
+"""Workflow model — a durable, company-scoped identity for a workflow (#14210, #14271).
 
 Sibling of ``models/workflow_permission.py`` (permissions *for* a workflow)
 and ``models/workflow_audit.py`` (an audit trail *of* a workflow) — those two
@@ -28,13 +28,27 @@ guessed at (see that module's docstring). Every NEW workflow created through
 route layer, not the DB) to supply a ``company_id`` — a future process node
 must only ever reference a company-attributed row.
 
+#14271: the original schema made ``workflow_id`` the primary key — a
+*globally* unique constraint — while every route and service above it treats
+the identity as company-scoped (``WHERE company_id = ...`` on every read,
+``assert_company_access`` on every route). That mismatch meant two companies
+could never independently choose the same human-readable id, a same-company
+duplicate raced an unhandled ``IntegrityError`` into a 500, and — worst —
+the 201-vs-500 split on create was a cross-tenant presence oracle driven by a
+field the caller controls. The identity is now a surrogate ``id`` (UUID)
+primary key plus a ``UNIQUE (company_id, workflow_id)`` constraint, so the
+constraint matches the scoping claim: two companies CAN share a
+``workflow_id`` string, and only a true same-company duplicate conflicts.
+
 No FK to an ``organizations`` table — mirrors ``LLCContact`` /
 ``LLCCompanyMembership`` / ``LLCSecret`` (see ``llc/models/contact.py``
 docstring): companies inside one AutoBot installation are organisational
 units of a single installation, not a foreign-keyed tenant boundary.
 """
 
-from sqlalchemy import Column, DateTime, String
+import uuid
+
+from sqlalchemy import Column, DateTime, String, UniqueConstraint
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.sql import func
 from sqlalchemy.types import Uuid
@@ -51,11 +65,13 @@ SOURCE_LEGACY_REDIS = "legacy_redis_unattributed"
 class Workflow(Base):
     """A workflow's durable, (optionally company-scoped) identity.
 
-    ``workflow_id`` is the primary key and a plain string — matching the id
-    shape every existing producer already uses (``str(uuid.uuid4())`` in
-    ``api/workflow.py``'s ``_execute_complex_workflow``, and the same in
-    ``api/workflow_state.py``'s ``WorkflowStateMachine``) so a backfilled row
-    keeps its original identity rather than being reminted under a new one.
+    ``id`` is the surrogate primary key (#14271) — ``workflow_id`` stays the
+    externally-visible identifier (matching the id shape every existing
+    producer already uses: ``str(uuid.uuid4())`` in ``api/workflow.py``'s
+    ``_execute_complex_workflow``, and the same in ``api/workflow_state.py``'s
+    ``WorkflowStateMachine``, so a backfilled row keeps its original identity
+    rather than being reminted under a new one) but is only unique *within*
+    ``company_id`` (``uq_workflows_company_workflow`` below) — never globally.
 
     ``definition`` holds the workflow's descriptive payload (goal/steps/
     classification/etc.) as an opaque JSON blob — this table's job is to give
@@ -66,8 +82,10 @@ class Workflow(Base):
     """
 
     __tablename__ = "workflows"
+    __table_args__ = (UniqueConstraint("company_id", "workflow_id", name="uq_workflows_company_workflow"),)
 
-    workflow_id = Column(String(255), primary_key=True)
+    id = Column(Uuid(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    workflow_id = Column(String(255), nullable=False, index=True)
     company_id = Column(Uuid(as_uuid=True), nullable=True, index=True)
     name = Column(String(255), nullable=True)
     status = Column(String(50), nullable=False, default="planned")
@@ -88,7 +106,7 @@ class Workflow(Base):
     )
 
     def __repr__(self) -> str:
-        return f"<Workflow id={self.workflow_id} company={self.company_id} status={self.status}>"
+        return f"<Workflow workflow_id={self.workflow_id!r} company={self.company_id} status={self.status}>"
 
 
 __all__ = ["Workflow", "SOURCE_CREATED", "SOURCE_LEGACY_REDIS"]

--- a/autobot-backend/services/workflow_redis_backfill.py
+++ b/autobot-backend/services/workflow_redis_backfill.py
@@ -147,7 +147,20 @@ async def backfill(*, dry_run: bool = False, session: AsyncSession | None = None
                 report.unparseable.append(workflow_id)
                 continue
 
-            existing = await session.execute(select(Workflow).where(Workflow.workflow_id == workflow_id))
+            # #14271: workflow_id is no longer a global primary key, so a bare
+            # `WHERE workflow_id = :id` can now match more than one row (one
+            # per company that happens to share the string) and
+            # scalar_one_or_none() would raise MultipleResultsFound. Scope to
+            # company_id IS NULL — every row this script itself writes — so
+            # this asks the only question that matters here: "has this exact
+            # Redis-origin key already been imported", not "does any company
+            # happen to use this string".
+            existing = await session.execute(
+                select(Workflow.workflow_id).where(
+                    Workflow.workflow_id == workflow_id,
+                    Workflow.company_id.is_(None),
+                )
+            )
             if existing.scalar_one_or_none() is not None:
                 report.already_present.append(workflow_id)
                 continue

--- a/autobot-backend/tests/migrations/test_workflows_company_scoped_unique.py
+++ b/autobot-backend/tests/migrations/test_workflows_company_scoped_unique.py
@@ -52,9 +52,7 @@ async def test_existing_rows_survive_including_null_company(fresh_db_url):
     try:
         async with engine.begin() as conn:
             await _seed_pre_migration_row(conn, workflow_id="wf-owned", company_id=company_a, name="Owned")
-            await _seed_pre_migration_row(
-                conn, workflow_id="wf-legacy", company_id=None, name="Recovered from Redis"
-            )
+            await _seed_pre_migration_row(conn, workflow_id="wf-legacy", company_id=None, name="Recovered from Redis")
     finally:
         await engine.dispose()
 
@@ -65,9 +63,7 @@ async def test_existing_rows_survive_including_null_company(fresh_db_url):
     try:
         async with engine.connect() as conn:
             rows = (
-                await conn.execute(
-                    text("SELECT id, workflow_id, company_id, name FROM workflows ORDER BY workflow_id")
-                )
+                await conn.execute(text("SELECT id, workflow_id, company_id, name FROM workflows ORDER BY workflow_id"))
             ).all()
     finally:
         await engine.dispose()

--- a/autobot-backend/tests/migrations/test_workflows_company_scoped_unique.py
+++ b/autobot-backend/tests/migrations/test_workflows_company_scoped_unique.py
@@ -1,0 +1,152 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Migration 20260822_082 — workflows loses its global PK, no row is lost (#14271).
+
+``workflows.workflow_id`` was a *global* primary key while every route/service
+above it treats the identity as company-scoped. This migration replaces it
+with a surrogate ``id`` primary key plus ``UNIQUE (company_id, workflow_id)``.
+
+The load-bearing assertion is data survival: this seeds rows with raw SQL
+against the OLD shape (revision 076, workflow_id as PK) — including a
+``company_id IS NULL`` row, exactly what
+``services/workflow_redis_backfill.py`` writes for unattributable legacy
+workflows — runs the migration, and checks every row is still there,
+unmodified in its business columns, each now carrying a distinct surrogate
+``id``.
+"""
+
+import uuid
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from tests.migrations.conftest import requires_postgres, run_alembic
+
+pytestmark = [pytest.mark.migration_gate, requires_postgres]
+
+_PRE_MIGRATION_REVISION = "20260821_081"
+_TARGET_REVISION = "20260822_082"
+
+
+async def _seed_pre_migration_row(conn, *, workflow_id: str, company_id: str | None, name: str) -> None:
+    """Insert directly, matching the OLD (076) table shape: workflow_id is the PK."""
+    await conn.execute(
+        text(
+            "INSERT INTO workflows (workflow_id, company_id, name, status, source, definition) "
+            "VALUES (:workflow_id, :company_id, :name, 'planned', 'created', '{}'::jsonb)"
+        ),
+        {"workflow_id": workflow_id, "company_id": company_id, "name": name},
+    )
+
+
+async def test_existing_rows_survive_including_null_company(fresh_db_url):
+    """NO DATA LOSS: every pre-existing row, including company_id IS NULL, survives."""
+    assert run_alembic(["upgrade", _PRE_MIGRATION_REVISION], fresh_db_url).returncode == 0
+
+    company_a = str(uuid.uuid4())
+    engine = create_async_engine(fresh_db_url)
+    try:
+        async with engine.begin() as conn:
+            await _seed_pre_migration_row(conn, workflow_id="wf-owned", company_id=company_a, name="Owned")
+            await _seed_pre_migration_row(
+                conn, workflow_id="wf-legacy", company_id=None, name="Recovered from Redis"
+            )
+    finally:
+        await engine.dispose()
+
+    up = run_alembic(["upgrade", _TARGET_REVISION], fresh_db_url)
+    assert up.returncode == 0, f"upgrade to {_TARGET_REVISION} failed:\nstdout:\n{up.stdout}\nstderr:\n{up.stderr}"
+
+    engine = create_async_engine(fresh_db_url)
+    try:
+        async with engine.connect() as conn:
+            rows = (
+                await conn.execute(
+                    text("SELECT id, workflow_id, company_id, name FROM workflows ORDER BY workflow_id")
+                )
+            ).all()
+    finally:
+        await engine.dispose()
+
+    assert len(rows) == 2, f"expected both pre-existing rows to survive, got {rows}"
+    by_workflow_id = {row.workflow_id: row for row in rows}
+
+    owned = by_workflow_id["wf-owned"]
+    assert str(owned.company_id) == company_a
+    assert owned.name == "Owned"
+    assert owned.id is not None
+
+    legacy = by_workflow_id["wf-legacy"]
+    assert legacy.company_id is None, "company_id=NULL legacy row must stay NULL — never guessed at"
+    assert legacy.name == "Recovered from Redis"
+    assert legacy.id is not None
+
+    assert owned.id != legacy.id, "each row gets its own distinct surrogate primary key"
+
+
+async def test_two_companies_can_share_a_workflow_id_after_migration(fresh_db_url):
+    """The collision this migration exists to allow: two companies, one workflow_id string."""
+    assert run_alembic(["upgrade", "head"], fresh_db_url).returncode == 0
+
+    company_a, company_b = str(uuid.uuid4()), str(uuid.uuid4())
+    engine = create_async_engine(fresh_db_url)
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(
+                text(
+                    "INSERT INTO workflows (id, workflow_id, company_id, name, status, source, definition) "
+                    "VALUES (gen_random_uuid(), :wf, :company_id, :name, 'planned', 'created', '{}'::jsonb)"
+                ),
+                {"wf": "prod-deploy", "company_id": company_a, "name": "A"},
+            )
+            # Same workflow_id, different company — must succeed, not raise.
+            await conn.execute(
+                text(
+                    "INSERT INTO workflows (id, workflow_id, company_id, name, status, source, definition) "
+                    "VALUES (gen_random_uuid(), :wf, :company_id, :name, 'planned', 'created', '{}'::jsonb)"
+                ),
+                {"wf": "prod-deploy", "company_id": company_b, "name": "B"},
+            )
+
+        async with engine.connect() as conn:
+            count = (
+                await conn.execute(
+                    text("SELECT count(*) FROM workflows WHERE workflow_id = 'prod-deploy'"),
+                )
+            ).scalar()
+        assert count == 2
+    finally:
+        await engine.dispose()
+
+
+async def test_same_company_duplicate_workflow_id_still_conflicts(fresh_db_url):
+    """The uniqueness that must remain: one company cannot hold the same workflow_id twice."""
+    assert run_alembic(["upgrade", "head"], fresh_db_url).returncode == 0
+
+    company_a = str(uuid.uuid4())
+    engine = create_async_engine(fresh_db_url)
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(
+                text(
+                    "INSERT INTO workflows (id, workflow_id, company_id, name, status, source, definition) "
+                    "VALUES (gen_random_uuid(), :wf, :company_id, :name, 'planned', 'created', '{}'::jsonb)"
+                ),
+                {"wf": "dup", "company_id": company_a, "name": "First"},
+            )
+
+        with pytest.raises(IntegrityError):
+            async with engine.begin() as conn:
+                await conn.execute(
+                    text(
+                        "INSERT INTO workflows (id, workflow_id, company_id, name, status, source, definition) "
+                        "VALUES (gen_random_uuid(), :wf, :company_id, :name, 'planned', 'created', '{}'::jsonb)"
+                    ),
+                    {"wf": "dup", "company_id": company_a, "name": "Second"},
+                )
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## Thinking Path

Read #14271 plus the two adjacent issues it references. #14210 added the `workflows` table with a nullable `company_id` (foundation only, no reconciliation). #14409 is a frontend gap (no UI reaches the API at all) and is untouched by this PR — it doesn't interact with the schema/uniqueness question.

**What the schema guaranteed vs what the code assumed:** `models/workflow.py` declared `workflow_id = Column(String(255), primary_key=True)` — globally unique across every company in the installation. Every route (`llc/api/workflows.py`) and service (`llc/services/workflow.py`, `llc/services/role_workflow.py`) filters by `company_id` on every read/write, and the route layer is gated by `assert_company_access` — i.e. the code already behaves as if the id were scoped to a company. The two never agreed: a second company creating the same `workflow_id` string hit `IntegrityError` at flush, uncaught, surfacing as a 500 instead of the route's documented 409 — and the 201-vs-500 status split was itself a cross-tenant presence oracle for a client-supplied id (company B could infer "someone, somewhere, already used this string").

**Enumerating the lookups:** every read/write in `llc/services/workflow.py` (`get`, `list_by_company`, `update_status`, `delete`) already carries `WHERE company_id = ...` — no IDOR there. One lookup did NOT: `RoleWorkflowService._require_workflow` in `llc/services/role_workflow.py` ran a single unscoped `SELECT ... WHERE workflow_id = :id`, correct only because the global PK guaranteed at most one matching row. Once uniqueness becomes per-company, that query can return an arbitrary row belonging to a different company, and — worse — its distinct "does not belong to company X" error message is exactly the same disclosure-oracle shape the issue calls out, now reachable through an admin-gated but different endpoint (attach-workflow-to-role). Treated as a priority finding and fixed in this PR rather than filed separately, since it's a direct consequence of the same schema change.

A second internal-only spot needed a look: `services/workflow_redis_backfill.py`'s idempotency check also did a bare `WHERE workflow_id = :id` with `scalar_one_or_none()` — after removing the global PK, two rows could now legitimately share a `workflow_id` (one per company), which would make that call raise `MultipleResultsFound`. Not a security issue (offline admin-run script, not client-reachable), but a correctness regression from this change, so fixed alongside it by scoping the check to `company_id IS NULL` (the only rows this script ever writes).

**The fix, deliberately:** composite `UNIQUE(company_id, workflow_id)` (the issue's own suggested option), not "keep global and enforce scoping at every read" — the code already enforces scoping at every read; the defect was specifically that the constraint didn't match that claim. Implemented as a surrogate `id` (UUID) primary key + the composite unique constraint, because `company_id` must stay nullable for the legacy Redis-backfilled rows, and Postgres does not allow a nullable column in a primary key.

**Review round 1** (approve-with-findings) surfaced two more instances of the *same class* of defect this PR exists to fix, both introduced by the fix itself:

1. **`RoleWorkflowService._require_workflow`'s NULL-company branch** used `scalar_one_or_none()`. `UNIQUE(company_id, workflow_id)` treats every NULL as distinct from every other NULL, so two legacy rows CAN legally share a `workflow_id` with `company_id` both NULL (e.g. a race between two backfill runs) — and `scalar_one_or_none()` raises `MultipleResultsFound` (an unhandled 500) the moment a second such row exists. Fixed to `.first()`: this branch only needs to know whether *any* unattributed row exists — every matching row produces the identical "no company attribution" refusal — so picking the first is correct and deliberate, not merely crash-avoidance.
2. **`WorkflowService.create`'s `IntegrityError` catch** was unconditional — any `IntegrityError` on the insert became `WorkflowConflictError`. No other constraint on this table can fire today, but a broad catch would silently relabel a future FK/check violation as a misleading "already exists" 409. Narrowed to classify by constraint name (`exc.orig.constraint_name` under asyncpg, with a message-shape fallback for SQLite's driver, used under the test suite).

## What Changed

- `models/workflow.py`: `Workflow.id` (UUID) is now the primary key; `workflow_id` is a plain indexed `NOT NULL` string; `UniqueConstraint("company_id", "workflow_id")` replaces the global PK.
- `migrations/versions/20260822_082_workflows_company_scoped_unique.py`: adds the surrogate `id` column, backfills it for every existing row (`gen_random_uuid()`), swaps the primary key, and adds the composite unique constraint. Purely additive to existing rows — nothing is dropped or overwritten. Guarded with `has_table`/`has_column` + live inspection so it's a no-op on a database that already carries this shape.
- `llc/services/workflow.py`: `create()` now catches the residual same-company race (`IntegrityError` from a concurrent duplicate that slipped past the route's `get()`-then-`create()` pre-check) and raises `WorkflowConflictError`, closing the race instead of narrowing it. Mirrors the existing `ReviewGatePolicyConflictError` pattern in `llc/services/review_gate.py`. **Review round 1:** the catch is narrowed via `_is_workflow_unique_conflict` to this table's own `uq_workflows_company_workflow` constraint — anything else re-raises unchanged.
- `llc/api/workflows.py`: catches `WorkflowConflictError` and returns 409 instead of letting it escape as an unhandled 500.
- `llc/services/role_workflow.py`: `_require_workflow` is now two company-scoped queries (own company, then the unattributed-legacy set) instead of one unscoped query with an ownership comparison in Python — closes the cross-tenant presence-oracle shape described above. The distinct "belongs to another company" message is gone; a workflow belonging to a different company is now indistinguishable from one that doesn't exist. **Review round 1:** the unattributed-legacy query uses `.first()` rather than `.scalar_one_or_none()`, since two NULL-company rows can legally share a `workflow_id`.
- `services/workflow_redis_backfill.py`: scopes its idempotency check to `company_id IS NULL`, avoiding a `MultipleResultsFound` crash risk now that `workflow_id` isn't globally unique, and asking the question the script actually means ("was this Redis key already imported") rather than "does any company use this string".

## Verification

- `python3 -m py_compile` on every touched/added file — all pass.
- New tests (added, not yet run by CI on this branch until the PR checks execute — no local venv/DB per repo policy):
  - `llc/tests/test_workflows_scoping.py::test_two_companies_can_create_the_same_workflow_id` — the collision case: two companies independently create `workflow_id="prod-deploy"`, both succeed, both remain visible only to their own company.
  - `llc/tests/test_workflows_scoping.py::test_same_company_duplicate_workflow_id_raises_a_clean_conflict` — calls `WorkflowService.create` twice directly (bypassing the route pre-check) so it's the DB constraint, not the pre-check, doing the rejecting; asserts `WorkflowConflictError` and that the first row survives (no data loss on the failed attempt).
  - `llc/tests/test_workflows_idor.py::TestWorkflowsConflictHandling::test_create_race_past_the_pre_check_returns_409_not_500` — route-level: `WorkflowConflictError` from the service becomes 409, not 500.
  - `llc/tests/test_role_workflows.py::test_another_companys_workflow_cannot_be_attached` — updated to assert the denial reads identically to "does not exist" (was pinning the leaky "does not belong to company X" message; that was the bug).
  - `tests/migrations/test_workflows_company_scoped_unique.py` — real-Postgres migration test (gated `requires_postgres`, runs in the `migration-gate` CI workflow): seeds pre-existing rows directly against the OLD (076) shape, including a `company_id IS NULL` legacy row, upgrades through the new migration, and asserts both rows survive unmodified with distinct new surrogate ids (NO DATA LOSS); plus collision (two companies, one `workflow_id`) and same-company-duplicate-still-conflicts checks against the live schema.
  - **Review round 1 additions:**
    - `llc/tests/test_role_workflows.py::test_two_ambiguous_unattributed_rows_are_refused_cleanly_not_500` — seeds two `company_id=NULL` rows sharing a `workflow_id`, confirms the fixture actually created two rows, then asserts `attach()` raises the clean "no company attribution" `ValueError` rather than `MultipleResultsFound`.
    - `llc/tests/test_workflows_scoping.py::test_is_workflow_unique_conflict_matches_only_its_own_constraint` / `test_is_workflow_unique_conflict_falls_back_to_sqlite_message_shape` — unit tests on the classification helper, covering both the structured-attribute (asyncpg) and message-shape (SQLite) paths.
    - `llc/tests/test_workflows_scoping.py::test_create_reraises_a_non_uniqueness_integrity_error` — patches `session.flush` to raise an `IntegrityError` tagged with a different constraint name and asserts `create()` re-raises it unchanged rather than reporting a false `WorkflowConflictError`.
    - `llc/tests/test_role_workflows_idor.py` (new file) — HTTP-level: `RoleWorkflowService.attach` mocked to raise the real "does not exist" `ValueError` for both a cross-company `workflow_id` and a genuinely missing one; asserts `POST /llc/roles/{company_id}/{role_id}/workflows` returns byte-for-byte indistinguishable status (400) and body shape for both, pinning the oracle closed at the layer a client actually touches.
- Mutation evidence (standalone stdlib-only harnesses, not pushed to the branch — `assert mutated != original` checked before each run):
  - Round 1 harness (schema collision + `_require_workflow` scoping): fixed behaviour 3/3 pass; reverted to the reported bug (global-PK schema / unscoped lookup), the two discriminating assertions flip to FAIL — `sqlite3.IntegrityError: UNIQUE constraint failed: workflows.workflow_id` and the leaked `"does not belong to company company-a"` message respectively. The same-company-duplicate invariant correctly stays green under both, since it doesn't depend on the fix.
  - Round 2 harness (the two review findings): fixed behaviour 2/2 pass; reverted to each reviewed defect, both flip to FAIL — the ambiguous-NULL-rows lookup raises `MultipleResultsFound: Multiple rows found for 'wf-ambiguous'`, and the catch-everything `IntegrityError` classifier wrongly reports a different constraint (`some_other_fk_constraint`) as a conflict.

## Model Used

Claude Sonnet 5

Closes #14271