### PR TITLE
fix(infra): parse YAML structurally in ansible lints; correct byte-identity claim (#14196, #14201)

### DIFF
--- a/.github/workflows/ansible-role-facts-test.yml
+++ b/.github/workflows/ansible-role-facts-test.yml
@@ -94,7 +94,7 @@ jobs:
         run: |
           ansible-playbook -i tests/inventory_dynamic/test_role_facts.yml tests/playbooks/test_role_active_facts_no_group_vars.yml
 
-      - name: "Diff guard: ensure all fact-file copies stay byte-equal (#7095, #14149)"
+      - name: "Diff guard: role_*_active facts stay in sync across all three copies (#7095, #14149, #14201)"
         working-directory: autobot-slm-backend/ansible
         run: |
           python3 tests/check_role_facts_synced.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -333,6 +333,8 @@ repos:
         name: Block unguarded `git -C {{ git_repo_root }}` (#7150 #7219)
         entry: tools/lint/check_git_safe_directory.py
         language: python
+        # #14196: parses the YAML instead of scanning lines, so it needs PyYAML.
+        additional_dependencies: [pyyaml]
         files: \.(yml|yaml)$
         stages: [pre-commit]
         description: "Pass -c safe.directory={{ git_repo_root }} to every git -C invocation against code_source"
@@ -351,6 +353,9 @@ repos:
         name: Block deprecated `{{ ansible_X }}` fact refs (#7180 #7221)
         entry: tools/lint/check_no_deprecated_ansible_facts.py
         language: python
+        # #14196: .yml/.yaml are parsed with PyYAML instead of scanned line by
+        # line; .j2 templates (not YAML) still use the line-based path.
+        additional_dependencies: [pyyaml]
         files: \.(yml|yaml|j2)$
         stages: [pre-commit]
         description: "Use ansible_facts['X'] instead of the deprecated ansible_X top-level fact"

--- a/autobot-slm-backend/ansible/playbooks/sync-code-source.yml
+++ b/autobot-slm-backend/ansible/playbooks/sync-code-source.yml
@@ -69,7 +69,10 @@
 
     - name: "code_source sync | Show pushed commit"
       ansible.builtin.command:
-        cmd: "git -c safe.directory={{ _code_source_dest }} -C {{ _code_source_dest }} log -1 --format='%h %s'"
+        cmd: >-
+          git -c safe.directory={{ _code_source_dest }}
+          -C {{ _code_source_dest }}
+          log -1 --format='%h %s'
       register: _pushed_commit
       changed_when: false
       when: controller_repo_root is defined

--- a/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
+++ b/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
@@ -279,7 +279,9 @@
     - name: "[PLAY 1] SLM | Record deployed commit marker (#12223, #12202)"
       ansible.builtin.shell:
         cmd: >-
-          git -c safe.directory={{ code_source_dir | default('/opt/autobot/code_source') }} -C {{ code_source_dir | default('/opt/autobot/code_source') }} rev-parse HEAD
+          git -c safe.directory={{ code_source_dir | default('/opt/autobot/code_source') }}
+          -C {{ code_source_dir | default('/opt/autobot/code_source') }}
+          rev-parse HEAD
           > /opt/autobot/autobot-slm-backend/.deployed_commit
       changed_when: false
       become: true

--- a/autobot-slm-backend/ansible/roles/slm_manager/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/slm_manager/tasks/main.yml
@@ -234,7 +234,9 @@
 - name: "SLM | Record deployed commit marker (#12202)"
   ansible.builtin.shell:
     cmd: >-
-      git -c safe.directory={{ code_source_dir | default('/opt/autobot/code_source') }} -C {{ code_source_dir | default('/opt/autobot/code_source') }} rev-parse HEAD
+      git -c safe.directory={{ code_source_dir | default('/opt/autobot/code_source') }}
+      -C {{ code_source_dir | default('/opt/autobot/code_source') }}
+      rev-parse HEAD
       > {{ slm_backend_dir }}/.deployed_commit
   changed_when: false
   tags: ['slm', 'backend', 'deploy']

--- a/autobot-slm-backend/ansible/tests/check_role_facts_synced.py
+++ b/autobot-slm-backend/ansible/tests/check_role_facts_synced.py
@@ -121,6 +121,11 @@ def _leading_comment_block(path: Path) -> str:
 def check_no_false_byte_identity_claims() -> bool:
     """Return True (and print) if a header claims whole-file byte-identity
     the actual file contents do not back.
+
+    Scoped to exactly the three files in `_ROLE_FACTS_FILES` -- a
+    regression guard for this specific, known trio (#14201), not a
+    general repo-wide scanner for the phrase. A different pair of files
+    making the same mistake elsewhere would not be caught here.
     """
     contents = {label: path.read_bytes() for label, path in _ROLE_FACTS_FILES.items()}
     found_false_claim = False

--- a/autobot-slm-backend/ansible/tests/check_role_facts_synced.py
+++ b/autobot-slm-backend/ansible/tests/check_role_facts_synced.py
@@ -86,6 +86,61 @@ def compare(label_a: str, a: dict, label_b: str, b: dict) -> bool:
     return diverged
 
 
+#: #14201: `tests/inventory/group_vars/all.yml`'s header once said it was kept
+#: "byte-identical" to a sibling copy. It never was — three different files,
+#: three different hashes — and the only thing this script actually enforces
+#: is the role_*_active fragment (+ chromadb_service_owner) compared above. A
+#: header claim with no check behind it is exactly how that happened, so any
+#: of these three files' headers claiming whole-file byte-identity again is
+#: itself a failure here, independent of whether the fragments still match.
+#: Deliberately whole-file (not per-fragment): a fragment-level claim like
+#: "these definitions are kept identical" is accurate and must NOT trip this.
+_BYTE_IDENTITY_CLAIM = re.compile(r"byte[- ]identical", re.IGNORECASE)
+
+_ROLE_FACTS_FILES = {
+    "inventory/group_vars/all.yml": GROUP_VARS,
+    "playbooks/vars/role_active_facts.yml": PLAYBOOK_VARS,
+    "tests/inventory/group_vars/all.yml": TEST_GROUP_VARS,
+}
+
+
+def _leading_comment_block(path: Path) -> str:
+    """Return the leading `#`/blank-line header of a YAML file, stopping at
+    the first substantive line (the `---` document marker or real content).
+    """
+    lines = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped == "" or stripped.startswith("#"):
+            lines.append(line)
+            continue
+        break
+    return "\n".join(lines)
+
+
+def check_no_false_byte_identity_claims() -> bool:
+    """Return True (and print) if a header claims whole-file byte-identity
+    the actual file contents do not back.
+    """
+    contents = {label: path.read_bytes() for label, path in _ROLE_FACTS_FILES.items()}
+    found_false_claim = False
+    for label, path in _ROLE_FACTS_FILES.items():
+        header = _leading_comment_block(path)
+        if not _BYTE_IDENTITY_CLAIM.search(header):
+            continue
+        matches_a_sibling = any(contents[label] == contents[other] for other in _ROLE_FACTS_FILES if other != label)
+        if not matches_a_sibling:
+            print(
+                f"HEADER CLAIM ERROR: {label}'s header claims byte-identity to a sibling, "
+                "but no two of the three role-facts files are a whole-file byte match. "
+                "Only the role_*_active fragment (+ chromadb_service_owner) is kept in "
+                "sync, by this script — correct the header instead of restoring the "
+                "claim (#14201)."
+            )
+            found_false_claim = True
+    return found_false_claim
+
+
 def main() -> int:
     canonical = extract_facts(GROUP_VARS)
     playbook = extract_facts(PLAYBOOK_VARS)
@@ -94,6 +149,7 @@ def main() -> int:
     diverged = False
     diverged |= compare("inventory/group_vars", canonical, "playbooks/vars", playbook)
     diverged |= compare("inventory/group_vars", canonical, "tests/inventory/group_vars", test_inventory)
+    diverged |= check_no_false_byte_identity_claims()
 
     if diverged:
         return 1

--- a/autobot-slm-backend/ansible/tests/inventory/group_vars/all.yml
+++ b/autobot-slm-backend/ansible/tests/inventory/group_vars/all.yml
@@ -1,8 +1,18 @@
 # Copyright 2025-2026 mrveiss
 # SPDX-License-Identifier: Apache-2.0
-# #7050/#7051/#7053/#14149 shared role-active facts — DUPLICATE of
-# inventory/group_vars/all.yml (and byte-identical to
-# playbooks/vars/role_active_facts.yml).
+# #7050/#7051/#7053/#14149 shared role-active facts — a THIRD copy of the
+# role_*_active OR-chains (plus chromadb_service_owner) that also live in
+# inventory/group_vars/all.yml and playbooks/vars/role_active_facts.yml.
+#
+# #14201: this file's full content is NOT a match for either sibling — it
+# additionally carries the CANONICAL ROLE NAMES header comment and the
+# #14149 explanation below, so the three files differ well beyond the parts
+# that matter. What IS kept in sync is narrower and enforced: tests/check_role_facts_synced.py
+# extracts the role_*_active fragments (+ chromadb_service_owner) from all
+# three files and fails CI on drift (#14149 extended it to all three).
+# tests/check_test_inventory_group_vars.py is a separate, weaker check — it
+# only asserts the test inventory resolves ONE key via `ansible-inventory
+# --list`; it does not compare file contents.
 #
 # WHY A REAL FILE, NOT A SYMLINK (#14149):
 # This used to be a symlink to ../../../inventory/group_vars/all.yml. This
@@ -16,13 +26,6 @@
 # scalar with the existing `all` group vars — see #14149 for the captured
 # failure). Same failure mechanism that broke the tracked `venv` symlink
 # in #14137/#14138.
-#
-# Ansible's group_vars auto-loading has no cross-directory include
-# mechanism, so — following the same DRY trade-off already accepted for
-# playbooks/vars/role_active_facts.yml below — this is a THIRD real copy
-# of the role_*_active block, kept byte-identical to the other two by
-# tests/check_role_facts_synced.py (extended in #14149 to compare all
-# three files, not just two).
 #
 # CANONICAL ROLE NAMES (#7053):
 # The short-form names in the OR-chains below (e.g. 'backend', 'frontend')

--- a/tools/lint/check_canonical_role_names.py
+++ b/tools/lint/check_canonical_role_names.py
@@ -60,11 +60,16 @@ ALLOWLIST: frozenset[str] = frozenset(
         # files and compares them. "Fixing" the OR-chains here would break that
         # check against the two files already allowlisted above.
         #
-        # NOT byte-identical, despite what this file's own header claims: the
-        # three are 411 / 101 / 100 lines with different hashes. Only the
-        # extracted fact fragment is compared. It is a real file rather than a
-        # symlink because `core.symlinks=false` materializes symlinks as plain
-        # text (#14149) -- that part of the header is correct.
+        # #14201: this file's own header used to claim it was kept
+        # byte-identical to a sibling copy -- it never was (three different
+        # files with different line counts and hashes; only the extracted
+        # fact fragment above is compared, by
+        # tests/check_role_facts_synced.py, which now also fails CI if any
+        # of the three headers makes that claim again). The header has
+        # since been corrected to describe what is actually kept in sync.
+        # It is a real file rather than a symlink because
+        # `core.symlinks=false` materializes symlinks as plain text
+        # (#14149) -- that part of the header is correct.
         #
         # `tests/check_test_inventory_group_vars.py` is NOT the enforcer: it only
         # runs `ansible-inventory --list` and asserts one key resolves. Naming it

--- a/tools/lint/check_canonical_role_names_test.py
+++ b/tools/lint/check_canonical_role_names_test.py
@@ -108,10 +108,11 @@ def test_a_negated_membership_check_is_also_blocked() -> None:
 def test_the_test_inventory_is_allowlisted() -> None:
     """The test inventory carries the same OR-chains on purpose (#14149).
 
-    Not byte-identical to either sibling — the three files are 411 / 101 / 100
-    lines. What `check_role_facts_synced.py` compares is the extracted
-    `role_*_active:` fragment, and editing it here would break that comparison
-    against the two files already allowlisted.
+    Not a whole-file match for either sibling (#14201) — the three files
+    differ in length and hash. What `check_role_facts_synced.py` compares is
+    the extracted `role_*_active:` fragment (+ chromadb_service_owner), and
+    editing it here would break that comparison against the two files
+    already allowlisted.
     """
     assert "autobot-slm-backend/ansible/tests/inventory/group_vars/all.yml" in ALLOWLIST
     assert "autobot-slm-backend/ansible/inventory/group_vars/all.yml" in ALLOWLIST

--- a/tools/lint/check_git_safe_directory.py
+++ b/tools/lint/check_git_safe_directory.py
@@ -36,6 +36,8 @@ import sys
 from pathlib import Path
 from typing import Iterable, List, Tuple
 
+import yaml
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 # `git -C <repo>` where <repo> is git_repo_root or /opt/autobot/code_source.
@@ -52,6 +54,14 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 # tracked tree: 22 matches, 19 of them already carrying `-c safe.directory`
 # (the sites #7150's migration fixed), which is what says the widening targets
 # the right shape rather than merely matching more.
+#
+# #14196: this used to run per physical line, which is blind to a command
+# folded across a YAML `>-`/`|` block scalar — a real (fixed) instance dropped
+# a guarded `git ... -C ...` invocation out of the checker's view entirely
+# when it wrapped to a second line. `.yml`/`.yaml` are now parsed with PyYAML
+# and every scalar's resolved *value* is matched instead of raw text, so a
+# folded/literal command reads exactly as Ansible will evaluate it: one
+# string, regardless of how many physical lines it was written across.
 PATTERN = re.compile(
     r"\bgit\s+(?P<flags>[^\n]*?)-C\s+"
     r"(?:\{\{\s*[\w]*(?:code_source|git_repo_root)[\w]*\s*(?:\|[^}]*)?\}\}"
@@ -84,6 +94,48 @@ def iter_ansible_files(root: Path) -> Iterable[Path]:
         yield path
 
 
+def _iter_scalar_nodes(node: "yaml.Node") -> Iterable["yaml.ScalarNode"]:
+    """Walk a composed YAML node tree, yielding every scalar node.
+
+    Unlike the ansible-facts checker, no key context is needed here: a
+    `git -C ...` invocation can live under `cmd:`, `command:`, a raw
+    `- git ...` shell line, etc. — it is the string *content* that matters,
+    not which key holds it.
+    """
+    if isinstance(node, yaml.ScalarNode):
+        yield node
+    elif isinstance(node, yaml.SequenceNode):
+        for item in node.value:
+            yield from _iter_scalar_nodes(item)
+    elif isinstance(node, yaml.MappingNode):
+        for _key_node, value_node in node.value:
+            yield from _iter_scalar_nodes(value_node)
+    # AliasNode (YAML anchors/aliases): nothing new to walk, skip silently.
+
+
+def _yaml_violations(text: str) -> List[Tuple[int, str]]:
+    try:
+        documents = list(yaml.compose_all(text, Loader=yaml.SafeLoader))
+    except yaml.YAMLError:
+        # Malformed YAML is another hook's job (check-yaml); do not crash
+        # pre-commit over a file this hook cannot parse.
+        return []
+
+    lines = text.splitlines()
+    violations: List[Tuple[int, str]] = []
+    for doc in documents:
+        if doc is None:
+            continue
+        for node in _iter_scalar_nodes(doc):
+            value = node.value
+            match = PATTERN.search(value)
+            if match and not SAFE_FLAG.search(match.group("flags")):
+                lineno0 = node.start_mark.line
+                snippet = lines[lineno0].strip()[:140] if 0 <= lineno0 < len(lines) else value.strip()[:140]
+                violations.append((lineno0 + 1, snippet))
+    return violations
+
+
 def find_violations(path: Path) -> List[Tuple[int, str]]:
     try:
         rel = path.resolve().relative_to(REPO_ROOT).as_posix()
@@ -95,12 +147,7 @@ def find_violations(path: Path) -> List[Tuple[int, str]]:
         text = path.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError):
         return []
-    violations: List[Tuple[int, str]] = []
-    for lineno, line in enumerate(text.splitlines(), start=1):
-        match = PATTERN.search(line)
-        if match and not SAFE_FLAG.search(match.group("flags")):
-            violations.append((lineno, line.strip()[:140]))
-    return violations
+    return _yaml_violations(text)
 
 
 def main(paths: List[str]) -> int:

--- a/tools/lint/check_git_safe_directory.py
+++ b/tools/lint/check_git_safe_directory.py
@@ -101,6 +101,18 @@ def _iter_scalar_nodes(node: "yaml.Node") -> Iterable["yaml.ScalarNode"]:
     `git -C ...` invocation can live under `cmd:`, `command:`, a raw
     `- git ...` shell line, etc. — it is the string *content* that matters,
     not which key holds it.
+
+    Mapping KEYS are scalars too and are yielded here alongside values --
+    a walk that only descended into `value_node` would silently drop a
+    dynamically-named key, the same coverage the line-based scanner had.
+
+    PyYAML's `Composer` has no separate node type for an alias (`*anchor`):
+    resolving one returns the *same* node object as its anchor definition
+    (`yaml.AliasNode` does not exist), so a node reachable through more than
+    one anchor/alias/merge-key site is revisited once per reachable path.
+    That is a duplicate report for one physical scalar, not a missed one --
+    harmless here, and there are currently zero YAML anchors in the tracked
+    ansible tree.
     """
     if isinstance(node, yaml.ScalarNode):
         yield node
@@ -108,9 +120,10 @@ def _iter_scalar_nodes(node: "yaml.Node") -> Iterable["yaml.ScalarNode"]:
         for item in node.value:
             yield from _iter_scalar_nodes(item)
     elif isinstance(node, yaml.MappingNode):
-        for _key_node, value_node in node.value:
+        for key_node, value_node in node.value:
+            if isinstance(key_node, yaml.ScalarNode):
+                yield key_node
             yield from _iter_scalar_nodes(value_node)
-    # AliasNode (YAML anchors/aliases): nothing new to walk, skip silently.
 
 
 def _yaml_violations(text: str) -> List[Tuple[int, str]]:

--- a/tools/lint/check_git_safe_directory_test.py
+++ b/tools/lint/check_git_safe_directory_test.py
@@ -179,6 +179,20 @@ def test_literal_block_scalar_command_is_caught() -> None:
         assert len(find_violations(f)) == 1
 
 
+def test_an_unguarded_command_used_as_a_mapping_key_is_caught() -> None:
+    """A dynamically-keyed mapping is a contrived shape, but it proves the
+    same coverage as the ansible-facts checker's mapping-key fixture: the
+    node-walk must yield mapping KEYS as well as values. A walk that only
+    descended into `value_node` would silently drop this, even though the
+    pre-#14196 line-based scanner (which matched anywhere in a line) caught
+    it.
+    """
+    body = "- name: t\n  vars:\n    \"git -C {{ git_repo_root }} log -1\": marker\n"
+    with tempfile.TemporaryDirectory() as d:
+        f = _write(Path(d), "key_git.yml", body)
+        assert len(find_violations(f)) == 1
+
+
 def test_malformed_yaml_does_not_crash_the_hook() -> None:
     """Broken YAML syntax is another hook's job (check-yaml)."""
     with tempfile.TemporaryDirectory() as d:
@@ -348,6 +362,12 @@ def test_the_node_walk_reaches_the_same_matches_as_an_independent_count() -> Non
     safe_load-dict-recursion) of the same tracked tree must agree on how
     many `git -C <code_source>` sites exist. If the node-walk regressed to
     matching nothing (or matching only some), this would diverge.
+
+    Scope: this proves TRAVERSAL completeness, not CLASSIFICATION
+    correctness. Both counters import the same `PATTERN` to decide what
+    counts as a match — narrow or widen `PATTERN` and both counters move
+    together and stay equal, because they agree on what to look for, not on
+    whether the walk actually visits everything reachable.
     """
     walked = _node_walk_pattern_match_count()
     independent = _independent_pattern_match_count()

--- a/tools/lint/check_git_safe_directory_test.py
+++ b/tools/lint/check_git_safe_directory_test.py
@@ -11,8 +11,16 @@ import sys
 import tempfile
 from pathlib import Path
 
+import yaml
+
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from check_git_safe_directory import find_violations  # noqa: E402
+from check_git_safe_directory import (  # noqa: E402
+    PATTERN,
+    REPO_ROOT,
+    SAFE_FLAG,
+    _iter_scalar_nodes,
+    find_violations,
+)
 
 
 def _write(tmp: Path, name: str, body: str) -> Path:
@@ -22,7 +30,7 @@ def _write(tmp: Path, name: str, body: str) -> Path:
 
 
 def test_unguarded_blocked() -> None:
-    body = "      command: git -C {{ git_repo_root }} log -1 --format='%h %s'\n"
+    body = "- name: t\n  command: git -C {{ git_repo_root }} log -1 --format='%h %s'\n"
     with tempfile.TemporaryDirectory() as d:
         f = _write(Path(d), "bad.yml", body)
         violations = find_violations(f)
@@ -30,14 +38,14 @@ def test_unguarded_blocked() -> None:
 
 
 def test_guarded_passes() -> None:
-    body = "      command: git -c safe.directory={{ git_repo_root }} -C {{ git_repo_root }} log -1\n"
+    body = "- name: t\n  command: git -c safe.directory={{ git_repo_root }} -C {{ git_repo_root }} log -1\n"
     with tempfile.TemporaryDirectory() as d:
         f = _write(Path(d), "ok.yml", body)
         assert find_violations(f) == []
 
 
 def test_unguarded_literal_path_blocked() -> None:
-    body = "      cmd: git -C /opt/autobot/code_source status --porcelain\n"
+    body = "- name: t\n  cmd: git -C /opt/autobot/code_source status --porcelain\n"
     with tempfile.TemporaryDirectory() as d:
         f = _write(Path(d), "bad.yml", body)
         violations = find_violations(f)
@@ -45,7 +53,7 @@ def test_unguarded_literal_path_blocked() -> None:
 
 
 def test_guarded_literal_path_passes() -> None:
-    body = "      cmd: git -c safe.directory=/opt/autobot/code_source -C /opt/autobot/code_source status\n"
+    body = "- name: t\n  cmd: git -c safe.directory=/opt/autobot/code_source -C /opt/autobot/code_source status\n"
     with tempfile.TemporaryDirectory() as d:
         f = _write(Path(d), "ok.yml", body)
         assert find_violations(f) == []
@@ -53,7 +61,7 @@ def test_guarded_literal_path_passes() -> None:
 
 def test_git_other_dir_unaffected() -> None:
     """git -C of an UNrelated dir doesn't trigger the check."""
-    body = "      cmd: git -C /tmp/some_repo log\n"
+    body = "- name: t\n  cmd: git -C /tmp/some_repo log\n"
     with tempfile.TemporaryDirectory() as d:
         f = _write(Path(d), "ok.yml", body)
         assert find_violations(f) == []
@@ -61,15 +69,13 @@ def test_git_other_dir_unaffected() -> None:
 
 def test_multiline_play_with_guard_passes() -> None:
     body = (
-        "      cmd: >-\n"
-        "        git -c safe.directory={{ git_repo_root }} -C {{ git_repo_root }}\n"
-        "        log -1 --format='%h %s'\n"
+        "- name: t\n"
+        "  cmd: >-\n"
+        "    git -c safe.directory={{ git_repo_root }} -C {{ git_repo_root }}\n"
+        "    log -1 --format='%h %s'\n"
     )
     with tempfile.TemporaryDirectory() as d:
         f = _write(Path(d), "ok.yml", body)
-        # Single-line-only check; multi-line >- folded form should be on one line by the time YAML parses it.
-        # Per-line check: the line containing `git -C` must have `-c safe.directory` on the SAME line.
-        # In the above sample, both are on the same line — should pass.
         assert find_violations(f) == []
 
 
@@ -94,7 +100,7 @@ def test_an_alternately_named_code_source_var_is_blocked() -> None:
     path passed the rule — which is precisely where a `dubious ownership`
     rc=128 aborts a deploy (#7150).
     """
-    body = "        cmd: \"git -C {{ _code_source_dest }} log -1 --format='%h %s'\"\n"
+    body = "- name: t\n  cmd: \"git -C {{ _code_source_dest }} log -1 --format='%h %s'\"\n"
     with tempfile.TemporaryDirectory() as d:
         f = _write(Path(d), "alt.yml", body)
         assert len(find_violations(f)) == 1
@@ -102,7 +108,7 @@ def test_an_alternately_named_code_source_var_is_blocked() -> None:
 
 def test_a_filtered_code_source_var_is_blocked() -> None:
     """A Jinja filter expression must not hide the target either."""
-    body = "          git -C {{ code_source_dir | default('/opt/autobot/code_source') }} rev-parse HEAD\n"
+    body = "- name: t\n  cmd: git -C {{ code_source_dir | default('/opt/autobot/code_source') }} rev-parse HEAD\n"
     with tempfile.TemporaryDirectory() as d:
         f = _write(Path(d), "filtered.yml", body)
         assert len(find_violations(f)) == 1
@@ -115,9 +121,11 @@ def test_the_same_alternately_named_vars_pass_once_guarded() -> None:
     the blind one — it would block every site #7150 already fixed.
     """
     bodies = [
-        "        cmd: \"git -c safe.directory={{ _code_source_dest }} -C {{ _code_source_dest }} log -1\"\n",
-        "          git -c safe.directory={{ code_source_dir | default('/opt/autobot/code_source') }}\n"
-        "          -C {{ code_source_dir | default('/opt/autobot/code_source') }} rev-parse HEAD\n",
+        "- name: t\n  cmd: \"git -c safe.directory={{ _code_source_dest }} -C {{ _code_source_dest }} log -1\"\n",
+        "- name: t\n"
+        "  cmd: >-\n"
+        "    git -c safe.directory={{ code_source_dir | default('/opt/autobot/code_source') }}\n"
+        "    -C {{ code_source_dir | default('/opt/autobot/code_source') }} rev-parse HEAD\n",
     ]
     with tempfile.TemporaryDirectory() as d:
         for index, body in enumerate(bodies):
@@ -127,49 +135,72 @@ def test_the_same_alternately_named_vars_pass_once_guarded() -> None:
 
 def test_an_unrelated_git_c_is_still_ignored() -> None:
     """The widening keys on the *name*, not on `-C` alone."""
-    body = "      command: git -C {{ some_other_dir }} status\n"
+    body = "- name: t\n  command: git -C {{ some_other_dir }} status\n"
     with tempfile.TemporaryDirectory() as d:
         f = _write(Path(d), "unrelated.yml", body)
         assert find_violations(f) == []
 
 
-def test_a_command_split_across_lines_is_not_silently_invisible() -> None:
-    """A guard the checker cannot see is not a guard.
+# --- #14196: structural parsing sees the value, not the physical line ---------
 
-    Found on this PR: guarding two sites pushed `git ... -C ...` onto two
-    physical lines of a `>-` folded scalar. The command was correct, but both
-    patterns are line-based — `git` was on one line and `-C` on the next — so
-    the checker stopped matching them entirely. They read as fixed while being
-    unwatched, and a later edit removing `safe.directory` would not be caught.
 
-    This pins the shape rather than the instance: a `git` line with no `-C`
-    must not be treated as a passing guarded site, because it is not a site at
-    all. The real protection is that the fixed files keep their commands on one
-    line, which `test_the_repository_guarded_sites_stay_visible` asserts.
+def test_an_unguarded_command_split_across_lines_is_now_caught() -> None:
+    """The line-based version's actual, historical blind spot.
+
+    #14188 guarded two sites and the guarded command no longer fit on one
+    physical line of a `>-` folded scalar; `git` landed on one line and `-C`
+    on the next, so both patterns being line-based meant the checker stopped
+    matching them entirely — a regression removing `safe.directory` later
+    would not have been caught. Parsing the YAML and matching the *resolved*
+    scalar value (which PyYAML folds into one string regardless of how many
+    physical lines it spans) closes this: an UNGUARDED version of the same
+    split must now be blocked.
     """
-    body = (
-        "        cmd: >-\n"
-        "          git -c safe.directory={{ git_repo_root }}\n"
-        "          -C {{ git_repo_root }} rev-parse HEAD\n"
-    )
+    body = "- name: t\n  cmd: >-\n    git\n    -C {{ git_repo_root }} rev-parse HEAD\n"
     with tempfile.TemporaryDirectory() as d:
-        f = _write(Path(d), "split.yml", body)
-        # Neither line matches: no violation is reported, and that is precisely
-        # the blind spot — asserted so the behaviour is documented, not assumed.
+        f = _write(Path(d), "split_unguarded.yml", body)
+        assert len(find_violations(f)) == 1
+
+
+def test_a_guarded_command_split_across_lines_still_passes() -> None:
+    """The same split, but guarded — proves the fix isn't a blanket reject of
+    multi-line commands, only of the unguarded ones.
+    """
+    body = "- name: t\n  cmd: >-\n    git -c safe.directory={{ git_repo_root }}\n    -C {{ git_repo_root }} rev-parse HEAD\n"
+    with tempfile.TemporaryDirectory() as d:
+        f = _write(Path(d), "split_guarded.yml", body)
+        assert find_violations(f) == []
+
+
+def test_literal_block_scalar_command_is_caught() -> None:
+    body = "- name: t\n  shell: |\n    git -C /opt/autobot/code_source status\n"
+    with tempfile.TemporaryDirectory() as d:
+        f = _write(Path(d), "literal.yml", body)
+        assert len(find_violations(f)) == 1
+
+
+def test_malformed_yaml_does_not_crash_the_hook() -> None:
+    """Broken YAML syntax is another hook's job (check-yaml)."""
+    with tempfile.TemporaryDirectory() as d:
+        f = _write(Path(d), "broken.yml", "cmd: [unclosed\n")
         assert find_violations(f) == []
 
 
 def test_the_repository_guarded_sites_stay_visible() -> None:
-    """Every real `git -C <code_source>` in the tree is on one line and guarded.
+    """Every real `git -C <code_source>` in the tree is visible and guarded.
 
-    This is the assertion that would have caught the split introduced on this
-    PR. It runs against the actual repository rather than a fixture, so it
-    fails if any future edit folds a guarded command across lines and quietly
-    removes it from the checker's view.
+    This runs against the actual repository rather than a fixture, so it
+    fails if a future edit removes `safe.directory` from a real site, or if
+    the structural walk itself regresses and stops reaching a site.
+
+    Unlike the line-based era, the guarded commands are no longer required
+    to stay on one physical line (#14196 relaxes that constraint from
+    #14188) — `sync-code-source.yml`, `update-all-nodes.yml` and
+    `slm_manager/tasks/main.yml` now wrap their `git -c safe.directory=...
+    -C ...` invocation across several lines of a folded `>-` block, and the
+    structural walk still sees it.
     """
     import subprocess  # nosec B404  # git plumbing, fixed argv, no shell
-
-    from check_git_safe_directory import PATTERN, REPO_ROOT, SAFE_FLAG
 
     listing = subprocess.run(  # nosec B603 B607  # fixed argv, no shell
         ["git", "ls-files", "*.yml", "*.yaml"],
@@ -188,26 +219,29 @@ def test_the_repository_guarded_sites_stay_visible() -> None:
             text = path.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError):
             continue
-        for line in text.splitlines():
-            if PATTERN.search(line):
+        try:
+            documents = list(yaml.compose_all(text, Loader=yaml.SafeLoader))
+        except yaml.YAMLError:
+            continue
+        for doc in documents:
+            if doc is None:
+                continue
+            for node in _iter_scalar_nodes(doc):
+                match = PATTERN.search(node.value)
+                if match is None:
+                    continue
                 visible += 1
-                assert SAFE_FLAG.search(line) or name.endswith(".pre-commit-config.yaml"), (
-                    f"{name}: an unguarded `git -C <code_source>` is visible to the checker:\n  {line.strip()[:120]}"
+                guarded = SAFE_FLAG.search(match.group("flags"))
+                assert guarded or name.endswith(".pre-commit-config.yaml"), (
+                    f"{name}: an unguarded `git -C <code_source>` is visible to the checker:\n"
+                    f"  {node.value.strip()[:160]}"
                 )
 
-    # Two weaker forms were tried and both let the mutation through, so they
-    # are recorded rather than repeated: a `visible >= 20` floor still passed
-    # when re-splitting one site dropped the count to 20, and "each file has at
-    # least one visible site" still passed because update-all-nodes.yml has ten
-    # other guarded sites. The assertion has to name the *specific* command
-    # each fix guards.
+    # Marker must be UNIQUE to the guarded site, and matched against the
+    # resolved scalar *value* (so it still matches after the command wraps
+    # across several physical lines, unlike a per-line marker search).
     must_be_visible = {
         "autobot-slm-backend/ansible/playbooks/sync-code-source.yml": "_code_source_dest",
-        # Marker must be UNIQUE to the guarded site. "rev-parse HEAD" is not:
-        # update-all-nodes.yml:150 contains "rev-parse HEAD~", which matches as a
-        # substring, so re-splitting line 274 still found a "matching" line and the
-        # mutation passed. "code_source_dir" appears only on the sites this fix
-        # guards; the other ten use git_repo_root.
         "autobot-slm-backend/ansible/playbooks/update-all-nodes.yml": "code_source_dir",
         "autobot-slm-backend/ansible/roles/slm_manager/tasks/main.yml": "code_source_dir",
     }
@@ -215,13 +249,111 @@ def test_the_repository_guarded_sites_stay_visible() -> None:
         path = REPO_ROOT / name
         if not path.is_file():  # pragma: no cover - file moved
             continue
-        hits = [line for line in path.read_text(encoding="utf-8").splitlines() if PATTERN.search(line)]
-        matching = [line for line in hits if marker in line]
+        text = path.read_text(encoding="utf-8")
+        docs = list(yaml.compose_all(text, Loader=yaml.SafeLoader))
+        matching = []
+        for doc in docs:
+            if doc is None:
+                continue
+            for node in _iter_scalar_nodes(doc):
+                if PATTERN.search(node.value) and marker in node.value:
+                    matching.append(node.value)
         assert matching, (
-            f"{name}: the `{marker}` command is no longer visible to the checker. "
-            "A guarded command folded across physical lines drops out of view entirely — "
-            "the command stays correct while the guard stops watching it."
+            f"{name}: the `{marker}` command is no longer visible to the checker — "
+            "a guarded command folded across physical lines dropping out of view "
+            "entirely is exactly what #14196 fixed."
         )
-        assert all(SAFE_FLAG.search(line) for line in matching), f"{name}: `{marker}` lost its safe.directory guard"
+        for value in matching:
+            match = PATTERN.search(value)
+            assert match and SAFE_FLAG.search(match.group("flags")), f"{name}: `{marker}` lost its safe.directory guard"
 
     assert visible >= len(must_be_visible), f"expected at least {len(must_be_visible)} visible sites, found {visible}"
+
+
+# --- reach self-check: prove the walk actually descends into the tree ---------
+
+
+def _tracked_yaml_files() -> list:
+    import subprocess  # nosec B404
+
+    listing = subprocess.run(  # nosec B603 B607
+        ["git", "ls-files", "*.yml", "*.yaml"],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+    )
+    return listing.stdout.split()
+
+
+def _independent_pattern_match_count() -> int:
+    """Count `PATTERN` matches by walking `yaml.safe_load`'s plain dict/list
+    output — deliberately NOT the checker's `yaml.compose` node-walk — so a
+    regression in that walk cannot also hide from this count.
+    """
+
+    def strings(obj):
+        if isinstance(obj, str):
+            yield obj
+        elif isinstance(obj, dict):
+            for value in obj.values():
+                yield from strings(value)
+        elif isinstance(obj, list):
+            for item in obj:
+                yield from strings(item)
+
+    total = 0
+    for name in _tracked_yaml_files():
+        path = REPO_ROOT / name
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        try:
+            docs = list(yaml.safe_load_all(text))
+        except yaml.YAMLError:
+            continue
+        for doc in docs:
+            if doc is None:
+                continue
+            for value in strings(doc):
+                if PATTERN.search(value):
+                    total += 1
+    return total
+
+
+def _node_walk_pattern_match_count() -> int:
+    total = 0
+    for name in _tracked_yaml_files():
+        path = REPO_ROOT / name
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        try:
+            docs = list(yaml.compose_all(text, Loader=yaml.SafeLoader))
+        except yaml.YAMLError:
+            continue
+        for doc in docs:
+            if doc is None:
+                continue
+            for node in _iter_scalar_nodes(doc):
+                if PATTERN.search(node.value):
+                    total += 1
+    return total
+
+
+def test_the_node_walk_reaches_the_same_matches_as_an_independent_count() -> None:
+    """Same principle as the ansible-facts checker's reach test: two
+    independently-written traversals (compose-node-walk vs.
+    safe_load-dict-recursion) of the same tracked tree must agree on how
+    many `git -C <code_source>` sites exist. If the node-walk regressed to
+    matching nothing (or matching only some), this would diverge.
+    """
+    walked = _node_walk_pattern_match_count()
+    independent = _independent_pattern_match_count()
+    assert walked > 0, "the node-walk found zero matches — it never reached the tree"
+    assert independent > 0, "the independent count found zero — the ground truth itself is broken"
+    assert walked == independent, (
+        f"node-walk saw {walked} matches, the independently-counted dict/list "
+        f"recursion found {independent} — the two traversals disagree"
+    )

--- a/tools/lint/check_no_deprecated_ansible_facts.py
+++ b/tools/lint/check_no_deprecated_ansible_facts.py
@@ -173,6 +173,27 @@ def _iter_scalar_nodes(
     propagated through sequences (a list-style `when:` condition list is
     still "under" `when`) but reset to the new key on every nested mapping —
     a task nested inside a `block:` gets its own `when:`/`vars:`/etc.
+
+    Mapping KEYS are scalars too (`{{ ansible_hostname }}_status: ok` is a
+    dynamically-named var) and are yielded here as well -- a walk that only
+    descended into `value_node` would silently drop them, which is exactly
+    the coverage the line-based scanner had and this rewrite must not lose.
+    A key is never itself a bare-expr value (Ansible templates a mapping key
+    the same `{{ }}`-wrapped way as any other string, never bare), so it is
+    always yielded with `key_context=None`, regardless of what key the
+    enclosing mapping is nested under.
+
+    PyYAML's `Composer` has no separate node type for an alias (`*anchor`):
+    resolving one returns the *same* node object as its anchor definition
+    (`yaml.AliasNode` does not exist), so a node reachable through more than
+    one anchor/alias/merge-key site is revisited once per reachable path and
+    yielded once per visit. That is a duplicate report for one physical
+    scalar, not a missed one -- harmless for `.pre-commit` output, and there
+    are currently zero YAML anchors in the tracked ansible tree. Not
+    de-duplicated on purpose: a shared node can sit under different keys at
+    different reachable paths (e.g. one alias site under `when:`, another
+    not), and de-duplicating on node identity would silently drop whichever
+    context-dependent check ran second.
     """
     if isinstance(node, yaml.ScalarNode):
         yield key_context, node
@@ -181,9 +202,10 @@ def _iter_scalar_nodes(
             yield from _iter_scalar_nodes(item, key_context)
     elif isinstance(node, yaml.MappingNode):
         for key_node, value_node in node.value:
+            if isinstance(key_node, yaml.ScalarNode):
+                yield None, key_node
             new_key = key_node.value if isinstance(key_node, yaml.ScalarNode) else None
             yield from _iter_scalar_nodes(value_node, new_key)
-    # AliasNode (YAML anchors/aliases): nothing new to walk, skip silently.
 
 
 def _snippet(lines: List[str], node: "yaml.ScalarNode") -> str:

--- a/tools/lint/check_no_deprecated_ansible_facts.py
+++ b/tools/lint/check_no_deprecated_ansible_facts.py
@@ -30,7 +30,9 @@ from __future__ import annotations
 import re
 import sys
 from pathlib import Path
-from typing import Iterable, List, Tuple
+from typing import Iterable, List, Optional, Tuple
+
+import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -107,20 +109,37 @@ FACT_ATTRS = frozenset(
 
 # `{{ ansible_X.Y }}`, `{{ ansible_X[0] }}`, `{{ ansible_X|filter }}`, `{{ ansible_X }}`
 # Captures the attribute name; we filter against FACT_ATTRS to avoid false
-# positives on inventory vars (host, user, become_*, etc.).
+# positives on inventory vars (host, user, become_*, etc.). Used for scalar
+# values that only run through Jinja *inside* `{{ }}` (the common case, and
+# the only case for `.j2` templates, which are not YAML).
 PATTERN = re.compile(r"\{\{[^}]*?\bansible_([a-z][a-z0-9_]*)\b")
 
+# Bare `ansible_X` with no requirement for surrounding `{{ }}`. Ansible
+# evaluates `when:`/`failed_when:`/etc. as Jinja without braces, so a plain
+# `ansible_hostname` inside one of those keys is a live reference even
+# though it never matches PATTERN.
+ATTR_PATTERN = re.compile(r"\bansible_([a-z][a-z0-9_]*)\b")
+
 # #14181: Ansible evaluates `when:` and friends as Jinja **without** `{{ }}`, so
-# the pattern above cannot see them. That is not academic -- `deploy-base.yml`
-# carried the same fact on the same task in all three forms, two inside `{{ }}`
-# and one in a `when:`. Fixing only the reported two would have moved the
-# ansible-core 2.24 breakage from the template to the conditional while the
-# hook reported the file clean. Both patterns filter through FACT_ATTRS, so
-# inventory/connection vars (ansible_host, ansible_user, ansible_become_*, ...)
-# stay valid in either form.
-_BARE_EXPR_KEYS = ("when", "failed_when", "changed_when", "until", "that")
+# a pattern anchored on `{{ }}` cannot see them. That is not academic --
+# `deploy-base.yml` carried the same fact on the same task in all three forms,
+# two inside `{{ }}` and one in a `when:`. Fixing only the reported two would
+# have moved the ansible-core 2.24 breakage from the template to the
+# conditional while the hook reported the file clean.
+#
+# #14196: line-based scanning of `when:` (and friends) is itself blind to two
+# common shapes: a folded/literal block scalar (`when: >-`, `until: |`) whose
+# value spans several physical lines, and the list-style condition form
+# (`when:` on its own line followed by `- cond_a` / `- cond_b`, all ANDed).
+# Both shapes are invisible to a per-line regex but are ordinary YAML, so
+# `.yml`/`.yaml` files are now parsed with PyYAML and walked structurally
+# instead (see `_iter_scalar_nodes`/`_yaml_violations` below). `.j2` templates
+# are not YAML at all and keep the line-based path.
+_BARE_EXPR_KEYS = frozenset({"when", "failed_when", "changed_when", "until", "that"})
+
+# Retained for the .j2 (line-based) path only.
 BARE_EXPR_PATTERN = re.compile(
-    r"^\s*-?\s*(?:" + "|".join(_BARE_EXPR_KEYS) + r")\s*:.*?\bansible_([a-z][a-z0-9_]*)\b"
+    r"^\s*-?\s*(?:" + "|".join(sorted(_BARE_EXPR_KEYS)) + r")\s*:.*?\bansible_([a-z][a-z0-9_]*)\b"
 )
 
 # Files allowed to contain the banned patterns (the hook itself + tests).
@@ -145,6 +164,79 @@ def iter_ansible_files(root: Path) -> Iterable[Path]:
         yield path
 
 
+def _iter_scalar_nodes(
+    node: "yaml.Node", key_context: Optional[str]
+) -> Iterable[Tuple[Optional[str], "yaml.ScalarNode"]]:
+    """Walk a composed YAML node tree, yielding (key_context, scalar_node).
+
+    `key_context` is the name of the mapping key whose value this scalar is,
+    propagated through sequences (a list-style `when:` condition list is
+    still "under" `when`) but reset to the new key on every nested mapping —
+    a task nested inside a `block:` gets its own `when:`/`vars:`/etc.
+    """
+    if isinstance(node, yaml.ScalarNode):
+        yield key_context, node
+    elif isinstance(node, yaml.SequenceNode):
+        for item in node.value:
+            yield from _iter_scalar_nodes(item, key_context)
+    elif isinstance(node, yaml.MappingNode):
+        for key_node, value_node in node.value:
+            new_key = key_node.value if isinstance(key_node, yaml.ScalarNode) else None
+            yield from _iter_scalar_nodes(value_node, new_key)
+    # AliasNode (YAML anchors/aliases): nothing new to walk, skip silently.
+
+
+def _snippet(lines: List[str], node: "yaml.ScalarNode") -> str:
+    lineno0 = node.start_mark.line
+    if 0 <= lineno0 < len(lines):
+        return lines[lineno0].strip()[:120]
+    return node.value.strip()[:120]
+
+
+def _yaml_violations(text: str) -> List[Tuple[int, str, str]]:
+    """Structural scan for `.yml`/`.yaml`: parses the document(s) and
+    evaluates each scalar's *value*, so folded/literal blocks and
+    list-style `when:` conditions are visible regardless of how they are
+    laid out across physical lines.
+    """
+    try:
+        documents = list(yaml.compose_all(text, Loader=yaml.SafeLoader))
+    except yaml.YAMLError:
+        # Malformed YAML is another hook's job (check-yaml); do not crash
+        # pre-commit over a file this hook cannot parse.
+        return []
+
+    lines = text.splitlines()
+    violations: List[Tuple[int, str, str]] = []
+    for doc in documents:
+        if doc is None:
+            continue
+        for key_context, node in _iter_scalar_nodes(doc, None):
+            value = node.value
+            pattern = ATTR_PATTERN if key_context in _BARE_EXPR_KEYS else PATTERN
+            seen: set = set()
+            for match in pattern.finditer(value):
+                attr = match.group(1)
+                if attr in FACT_ATTRS and attr not in seen:
+                    seen.add(attr)
+                    violations.append((node.start_mark.line + 1, attr, _snippet(lines, node)))
+    return violations
+
+
+def _line_based_violations(text: str) -> List[Tuple[int, str, str]]:
+    """Line-by-line scan, used only for `.j2` templates (not valid YAML)."""
+    violations: List[Tuple[int, str, str]] = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        seen_on_line: set = set()
+        for pattern in (PATTERN, BARE_EXPR_PATTERN):
+            for match in pattern.finditer(line):
+                attr = match.group(1)
+                if attr in FACT_ATTRS and attr not in seen_on_line:
+                    seen_on_line.add(attr)
+                    violations.append((lineno, attr, line.strip()[:120]))
+    return violations
+
+
 def find_violations(path: Path) -> List[Tuple[int, str, str]]:
     """Return (line_number, attribute, snippet) tuples for each violation."""
     try:
@@ -158,16 +250,9 @@ def find_violations(path: Path) -> List[Tuple[int, str, str]]:
         text = path.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError):
         return []
-    violations: List[Tuple[int, str, str]] = []
-    for lineno, line in enumerate(text.splitlines(), start=1):
-        seen_on_line = set()
-        for pattern in (PATTERN, BARE_EXPR_PATTERN):
-            for match in pattern.finditer(line):
-                attr = match.group(1)
-                if attr in FACT_ATTRS and attr not in seen_on_line:
-                    seen_on_line.add(attr)
-                    violations.append((lineno, attr, line.strip()[:120]))
-    return violations
+    if path.suffix == ".j2":
+        return _line_based_violations(text)
+    return _yaml_violations(text)
 
 
 def main(paths: List[str]) -> int:

--- a/tools/lint/check_no_deprecated_ansible_facts_test.py
+++ b/tools/lint/check_no_deprecated_ansible_facts_test.py
@@ -298,6 +298,25 @@ def test_nested_block_resets_key_context_per_task() -> None:
         assert violations[0][1] == "hostname"
 
 
+def test_a_deprecated_fact_used_as_a_mapping_key_is_caught() -> None:
+    """A dynamically-named var: `'{{ ansible_hostname }}_status': ok`.
+
+    `_iter_scalar_nodes` walks each mapping pair's `value_node` but, in an
+    earlier version of this rewrite, never yielded the `key_node` itself --
+    so a deprecated fact used as a YAML *key* (as opposed to a value) was
+    silently invisible, even though the pre-#14196 line-based scanner (which
+    matched anywhere in a line) caught it. That is a coverage regression a
+    structural rewrite must not introduce while fixing five other blind
+    spots; this fixture pins the key position as covered.
+    """
+    body = "- name: t\n  vars:\n    '{{ ansible_hostname }}_status': ok\n"
+    with tempfile.TemporaryDirectory() as d:
+        f = _write(Path(d), "key_fact.yml", body)
+        violations = find_violations(f)
+        assert len(violations) == 1
+        assert violations[0][1] == "hostname"
+
+
 def test_malformed_yaml_does_not_crash_the_hook() -> None:
     """Broken YAML syntax is another hook's job (check-yaml); this hook must
     not raise and block the whole pre-commit run over it.
@@ -381,6 +400,14 @@ def test_the_node_walk_reaches_every_bare_expr_key_scalar_in_the_tree() -> None:
     that exact gap was found in another lint this week. Counting reach a
     second, independent way closes it: if the node-walk's count diverges
     from the plain-dict-recursion count, the walk regressed.
+
+    Scope: this proves TRAVERSAL completeness, not CLASSIFICATION
+    correctness. Both counters import the same `_BARE_EXPR_KEYS` constant to
+    decide what counts as "reachable" — narrow that set (e.g. drop `"until"`)
+    and both counters shrink together and stay equal, because they agree on
+    what to look for, not on whether the walk actually visits everything.
+    This test cannot catch a classification gap; only that the walk reaches
+    everything the shared definition currently designates.
     """
     ansible_root = REPO_ROOT / "autobot-slm-backend" / "ansible"
     walked = _node_walk_bare_key_scalar_count(ansible_root)

--- a/tools/lint/check_no_deprecated_ansible_facts_test.py
+++ b/tools/lint/check_no_deprecated_ansible_facts_test.py
@@ -11,8 +11,15 @@ import sys
 import tempfile
 from pathlib import Path
 
+import yaml
+
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from check_no_deprecated_ansible_facts import find_violations  # noqa: E402
+from check_no_deprecated_ansible_facts import (  # noqa: E402
+    REPO_ROOT,
+    _BARE_EXPR_KEYS,
+    _iter_scalar_nodes,
+    find_violations,
+)
 
 
 def _write(tmp: Path, name: str, body: str) -> Path:
@@ -85,6 +92,7 @@ def test_multiple_violations_in_one_file() -> None:
 
 
 def test_jinja_template_file() -> None:
+    """`.j2` templates are not YAML and stay on the line-based path."""
     with tempfile.TemporaryDirectory() as d:
         f = _write(Path(d), "service.j2", "Environment=HOST={{ ansible_fqdn }}\n")
         violations = find_violations(f)
@@ -152,9 +160,234 @@ def test_inventory_vars_stay_valid_in_a_when_clause() -> None:
         assert find_violations(f) == []
 
 
-def test_a_line_is_not_double_counted_across_both_patterns() -> None:
-    """A `when:` that also contains `{{ }}` must report once, not twice."""
-    body = "      when: \"{{ ansible_distribution }}\" == 'Ubuntu'\n"
+def test_a_mixed_when_is_not_double_counted() -> None:
+    """A `when:` string that also contains `{{ }}` must report once, not twice.
+
+    Written as a single quoted scalar (the only valid-YAML way to mix a
+    `{{ }}` template with trailing bare Jinja on one `when:` line) — the
+    line-based era's fixture here quoted only the `{{ }}` half, which is not
+    valid YAML and would never appear in a real playbook.
+    """
+    body = "      when: \"{{ ansible_distribution }} == 'Ubuntu'\"\n"
     with tempfile.TemporaryDirectory() as d:
         f = _write(Path(d), "both.yml", body)
         assert len(find_violations(f)) == 1
+
+
+# --- #14196: line-based scanning is blind to folded/literal/list shapes -------
+
+
+def test_list_style_when_is_no_longer_invisible() -> None:
+    """`when:` on its own line followed by a `- cond` list (all ANDed).
+
+    A line-based scan sees `- ansible_hostname is defined` with no `when:`
+    prefix on the same line and never matches it. This shape has 22
+    occurrences in the tracked tree today, none of them currently violating
+    — but the checker was blind to the shape itself, not just to a specific
+    violation.
+    """
+    body = (
+        "- name: t\n"
+        "  debug:\n"
+        "    msg: x\n"
+        "  when:\n"
+        "    - ansible_hostname is defined\n"
+        "    - inventory_hostname is defined\n"
+    )
+    with tempfile.TemporaryDirectory() as d:
+        f = _write(Path(d), "list_when.yml", body)
+        violations = find_violations(f)
+        assert len(violations) == 1
+        assert violations[0][1] == "hostname"
+
+
+def test_folded_when_block_is_no_longer_invisible() -> None:
+    """`when: >-` folds the condition onto a physical line the checker never
+    scanned before, because the deprecated fact and the `when:` key are no
+    longer on the same line.
+    """
+    body = "- name: t\n  debug:\n    msg: x\n  when: >-\n    ansible_distribution_release in ['focal']\n    and inventory_hostname is defined\n"
+    with tempfile.TemporaryDirectory() as d:
+        f = _write(Path(d), "folded_when.yml", body)
+        violations = find_violations(f)
+        assert len(violations) == 1
+        assert violations[0][1] == "distribution_release"
+
+
+def test_literal_until_block_is_no_longer_invisible() -> None:
+    body = "- name: t\n  command: echo hi\n  until: |\n    ansible_hostname is defined\n  retries: 3\n"
+    with tempfile.TemporaryDirectory() as d:
+        f = _write(Path(d), "literal_until.yml", body)
+        violations = find_violations(f)
+        assert len(violations) == 1
+        assert violations[0][1] == "hostname"
+
+
+def test_a_brace_split_across_a_folded_line_is_no_longer_invisible() -> None:
+    """A multi-line `cmd: >-` template reference (not a bare-expr key), where
+    the `{{ }}` pair itself straddles the fold.
+
+    A per-line scan of `cmd: >-`/`{{ ansible_X }}` folded onto ONE physical
+    line was already visible to the old checker (the whole `{{ }}` sat on
+    one line, same as any other match) — that shape is a parity case, not a
+    fix, and is covered by `test_a_folded_non_bare_key_value_stays_visible`
+    below. The genuine blind spot is narrower: PyYAML's folding rule joins
+    `echo {{\n      ansible_hostname }}` into `echo {{ ansible_hostname }}`
+    (one space where the newline was), so the reference only exists once the
+    fold has been resolved. A per-line scan never sees it, because neither
+    physical line contains a matched `{{ ... ansible_X ... }}` on its own.
+    """
+    body = "- name: t\n  ansible.builtin.command:\n    cmd: >-\n      echo {{\n      ansible_hostname }}\n"
+    with tempfile.TemporaryDirectory() as d:
+        f = _write(Path(d), "folded_cmd_split.yml", body)
+        violations = find_violations(f)
+        assert len(violations) == 1
+        assert violations[0][1] == "hostname"
+
+
+def test_a_folded_non_bare_key_value_stays_visible() -> None:
+    """Parity check: a `cmd: >-` value whose whole `{{ ansible_X }}` fits on
+    one physical continuation line was already visible to the line-based
+    scanner (PATTERN doesn't care which key it's under). The structural
+    walker must not regress this — it's not a fix, it's a floor.
+    """
+    body = "- name: t\n  ansible.builtin.command:\n    cmd: >-\n      echo {{ ansible_hostname }}\n      more args\n"
+    with tempfile.TemporaryDirectory() as d:
+        f = _write(Path(d), "folded_cmd.yml", body)
+        violations = find_violations(f)
+        assert len(violations) == 1
+        assert violations[0][1] == "hostname"
+
+
+def test_connection_vars_in_a_folded_when_stay_clean() -> None:
+    """The real `seed-fleet-nodes.yml`/`setup-internal-ca.yml` shape: a folded
+    `when: >-` carrying `ansible_host`/`ansible_run_tags` on a continuation
+    line. Neither is a FACT_ATTRS member, so widening the scan to see folded
+    blocks must not start flagging them.
+    """
+    body = (
+        "- name: t\n"
+        "  debug:\n"
+        "    msg: x\n"
+        "  when: >-\n"
+        "    item in groups['slm_nodes']\n"
+        "    or (hostvars[item].ansible_host != slm_manager_ip\n"
+        "        and 'force' not in ansible_run_tags)\n"
+    )
+    with tempfile.TemporaryDirectory() as d:
+        f = _write(Path(d), "connvars.yml", body)
+        assert find_violations(f) == []
+
+
+def test_nested_block_resets_key_context_per_task() -> None:
+    """A `block:` nests task mappings; each nested task has its own keys, so
+    the outer `when:` context must not leak into the inner task's `msg:`.
+    """
+    body = (
+        "- name: outer\n"
+        "  block:\n"
+        "    - name: inner\n"
+        "      debug:\n"
+        "        msg: '{{ ansible_hostname }}'\n"
+        "  when: inventory_hostname is defined\n"
+    )
+    with tempfile.TemporaryDirectory() as d:
+        f = _write(Path(d), "block.yml", body)
+        violations = find_violations(f)
+        assert len(violations) == 1
+        assert violations[0][1] == "hostname"
+
+
+def test_malformed_yaml_does_not_crash_the_hook() -> None:
+    """Broken YAML syntax is another hook's job (check-yaml); this hook must
+    not raise and block the whole pre-commit run over it.
+    """
+    with tempfile.TemporaryDirectory() as d:
+        f = _write(Path(d), "broken.yml", "when: [unclosed\n")
+        assert find_violations(f) == []
+
+
+# --- reach self-check: prove the walk actually descends into the tree ---------
+
+
+def _tracked_yaml_files(root: Path) -> list:
+    skip_dirs = {".git", "__pycache__", "node_modules", ".worktrees", "venv", ".venv"}
+    out = []
+    for path in root.rglob("*.yml"):
+        rel_parts = path.relative_to(root).parts
+        if any(part in skip_dirs for part in rel_parts):
+            continue
+        out.append(path)
+    for path in root.rglob("*.yaml"):
+        rel_parts = path.relative_to(root).parts
+        if any(part in skip_dirs for part in rel_parts):
+            continue
+        out.append(path)
+    return out
+
+
+def _independent_bare_key_scalar_count(root: Path) -> int:
+    """Count bare-expr-key scalars via plain `yaml.safe_load` + dict/list
+    recursion — deliberately NOT the checker's own `yaml.compose` node-walk,
+    so a regression in that walk (e.g. silently reverting to line-based, or
+    stopping descent into sequences) cannot also hide from this count. Two
+    independently-written traversals of the same tree must agree.
+    """
+
+    def count(obj) -> int:
+        total = 0
+        if isinstance(obj, dict):
+            for key, value in obj.items():
+                if key in _BARE_EXPR_KEYS:
+                    total += len(value) if isinstance(value, list) else 1
+                total += count(value)
+        elif isinstance(obj, list):
+            for item in obj:
+                total += count(item)
+        return total
+
+    total = 0
+    for path in _tracked_yaml_files(root):
+        try:
+            docs = list(yaml.safe_load_all(path.read_text(encoding="utf-8")))
+        except yaml.YAMLError:
+            continue
+        for doc in docs:
+            if doc is not None:
+                total += count(doc)
+    return total
+
+
+def _node_walk_bare_key_scalar_count(root: Path) -> int:
+    """The same count, produced by the checker's own `_iter_scalar_nodes`."""
+    total = 0
+    for path in _tracked_yaml_files(root):
+        try:
+            docs = list(yaml.compose_all(path.read_text(encoding="utf-8"), Loader=yaml.SafeLoader))
+        except yaml.YAMLError:
+            continue
+        for doc in docs:
+            if doc is None:
+                continue
+            for key_context, _node in _iter_scalar_nodes(doc, None):
+                if key_context in _BARE_EXPR_KEYS:
+                    total += 1
+    return total
+
+
+def test_the_node_walk_reaches_every_bare_expr_key_scalar_in_the_tree() -> None:
+    """A scan that silently stopped descending (e.g. only visiting top-level
+    keys, or reverting to line-based matching) would still report "clean" —
+    that exact gap was found in another lint this week. Counting reach a
+    second, independent way closes it: if the node-walk's count diverges
+    from the plain-dict-recursion count, the walk regressed.
+    """
+    ansible_root = REPO_ROOT / "autobot-slm-backend" / "ansible"
+    walked = _node_walk_bare_key_scalar_count(ansible_root)
+    independent = _independent_bare_key_scalar_count(ansible_root)
+    assert walked > 0, "the node-walk found zero bare-expr-key scalars — it never reached the tree"
+    assert independent > 0, "the independent count found zero — the ground truth itself is broken"
+    assert walked == independent, (
+        f"node-walk saw {walked} bare-expr-key scalars, the independently-counted "
+        f"dict/list recursion found {independent} — the two traversals disagree"
+    )


### PR DESCRIPTION
## Thinking Path

Both issues are the same shape: a guard or a doc comment claims more than the
code structurally backs. Read both issues in full (`gh issue view 14196
14201`), then read the two checkers and their tests, and the three
role-facts files plus the two check scripts that reference them.

For #14196: a line-based regex can't see a construct split across physical
lines, reordered onto a list, or re-indented — probed this by running
`yaml.compose_all` against every tracked `.yml`/`.yaml` in the repo (509
files, 0 parse failures with multi-document support) to confirm a structural
rewrite was safe, then designed a single node-walk (`_iter_scalar_nodes`)
that both checkers share the shape of: walk the composed YAML tree, and for
the ansible-facts checker, propagate the enclosing mapping key down through
sequences (so a list-style `when:` condition is still "under" `when`) but
reset it on every nested mapping (so a `block:`'s inner tasks get their own
keys). `.j2` templates are not YAML and the facts checker keeps its original
line-based path for them; `check_git_safe_directory.py` never processed
`.j2` in either version (its `files:` filter has always been `.yml`/`.yaml`
only).
Verified the two traps named in the task up front: bare-expr keys
(`when`/`failed_when`/`changed_when`/`until`/`that`) are evaluated by
Ansible without `{{ }}`, so they're matched on the raw scalar value, not
through a `{{ }}`-anchored pattern; the `ansible.builtin.shell`/dash
`pipefail` trap doesn't apply here (neither checker touches `set -o
pipefail` or `failed_when: false`).

For #14201: read `check_role_facts_synced.py` (what it actually compares —
an extracted `role_*_active` + `chromadb_service_owner` fragment, not whole
files) and `check_test_inventory_group_vars.py` (a resolution check, not a
sync guard) before touching the header, to avoid repeating the exact
mistake the issue describes (PR #14200 quoting the wrong claim into a lint
comment). Measured the real file lengths/hashes to confirm the claim was
false, then corrected the header to describe what's actually enforced and
added a guard so it can't drift back silently.

## What Changed

**#14196** — `tools/lint/check_no_deprecated_ansible_facts.py` and
`tools/lint/check_git_safe_directory.py` now parse `.yml`/`.yaml` with
PyYAML (`yaml.compose_all`, multi-document aware) and match against each
scalar's *resolved* value instead of scanning physical lines:
- The ansible-facts checker walks the composed tree via `_iter_scalar_nodes`,
  tracking which mapping key each scalar sits under. Bare-expr keys
  (`when`/`failed_when`/`changed_when`/`until`/`that`) are matched with a
  brace-free pattern (Ansible evaluates them without `{{ }}`); every other
  key still requires `{{ ansible_X }}`.
- The git-safe-directory checker walks the same way but needs no key
  context — it matches `git ... -C <code_source>` against the joined scalar
  value, so a command PyYAML folds across several physical lines (a `>-` or
  `|` block) is evaluated exactly as Ansible will see it.
- `.j2` templates aren't YAML: the facts checker keeps its original per-line
  scan for them; the git-safe checker was never registered against `.j2` in
  either version, so there's no line-based path for it to fall back to.
- Malformed YAML no longer crashes the hook — it's caught and skipped
  (`check-yaml` is the syntax guard; this one isn't).
- Relaxed #14188's "keep the git command on one physical line" constraint:
  reformatted the three `code_source_dir`/`_code_source_dest` guarded
  commands (`sync-code-source.yml`, `update-all-nodes.yml`,
  `slm_manager/tasks/main.yml`) across multiple lines of a `>-` fold. The
  old line-based checker goes blind on all three after this reformat (22 → 19
  matches); the new one still sees all 22.
- `.pre-commit-config.yaml`: both hooks now declare
  `additional_dependencies: [pyyaml]` (they didn't need it before).
- Both `*_test.py` files gained fixtures for each shape the old scanner
  missed (list-style `when:`, folded `when: >-`, literal `until: |`, a
  `{{ }}` pair split across a fold, a multi-line unguarded git command), a
  parity fixture proving a shape that was *already* visible stays visible,
  and a reach self-check per checker: an independently-written
  `yaml.safe_load` + dict/list recursion count that must exactly match the
  checker's own `yaml.compose` node-walk count, so a regression that stops
  the walk short can't also fool its own reach counter.

**#14201** — `autobot-slm-backend/ansible/tests/inventory/group_vars/all.yml`'s
header no longer claims it is "DUPLICATE of inventory/group_vars/all.yml
(and byte-identical to playbooks/vars/role_active_facts.yml)". It now
states: it carries the same `role_*_active` OR-chains (+
`chromadb_service_owner`) as the other two copies; `check_role_facts_synced.py`
is the real sync guard and compares that fragment only; `check_test_inventory_group_vars.py`
is a separate, weaker resolution check; and keeps the `core.symlinks=false`
explanation (#14149) verbatim, since that part was already correct. The two
sibling files (`inventory/group_vars/all.yml`, `playbooks/vars/role_active_facts.yml`)
were checked for the same claim — neither makes it (the latter says "kept
identical to ... *definitions*", correctly scoped to the fragment, not the
whole file).

`check_role_facts_synced.py` gained `check_no_false_byte_identity_claims()`,
wired into `main()` (already invoked every CI run by
`.github/workflows/ansible-role-facts-test.yml`): it reads each of the three
files' leading comment header, flags a `byte[- ]identical` claim, and fails
unless the two whole files it's made about really are a byte-for-byte match
— so the exact defect this issue reports can't silently reappear.

Also corrected the same now-stale claim's echo in
`tools/lint/check_canonical_role_names.py`'s allowlist comment (previously:
*"NOT byte-identical, despite what this file's own header claims"* — now
stale since the header no longer claims it) and its test's docstring
(pinned line counts that go stale on every edit — replaced with a
length/hash description instead of numbers), and the CI step name in
`ansible-role-facts-test.yml` ("... stay byte-equal" → "... stay in sync
across all three copies").

## Verification

**#14196 — mutation test** (standalone harness, no mutation commit pushed):
ran each new fixture against the OLD (pre-fix, line-based) checker loaded
from `origin/Dev_new_gui`, and the NEW checker in this branch.

| fixture | OLD | NEW |
|---|---|---|
| facts: list-style `when:` | missed | **caught** |
| facts: folded `when: >-` | missed | **caught** |
| facts: literal `until: \|` | missed | **caught** |
| facts: `{{ }}` split across a fold | missed | **caught** |
| facts: folded `cmd:`, whole `{{ }}` on one line (parity, not a fix) | caught | caught |
| git-safe: `git`/`-C` split across a `>-` fold, unguarded | missed | **caught** |

**#14196 — real-tree parity**: both checkers scanned against
`autobot-slm-backend/ansible` (423 files for facts, 320 for git-safe) return
**0 violations before and after** — the widening doesn't start flagging
anything that wasn't already a violation. The five real sites named in the
issue (`roles/common/tasks/main.yml`, `roles/postgresql/tasks/install.yml`,
`roles/backend/tasks/main.yml` for facts; the seed-fleet-nodes.yml /
setup-internal-ca.yml folded `when:` carrying `ansible_host`/
`ansible_run_tags`, neither a `FACT_ATTRS` member) all stay clean.

**#14196 — reach self-check**: two independently-written traversals of the
tracked tree agree exactly — 1856 bare-expr-key scalars (facts checker) and
22 `git -C <code_source>` matches (git-safe checker), `yaml.compose`
node-walk vs. `yaml.safe_load` dict/list recursion.

**#14196 — all 38 test functions** (both `*_test.py` files, run directly —
not copied — so `REPO_ROOT` resolves against the real tree): 38/38 pass,
including the real-tree "guarded sites stay visible" test and both reach
self-checks.

**#14201 — mutation test**: on a throwaway filesystem copy (never written
back to the worktree), reintroduced `# byte-identical to the other two
copies` into the test-inventory header. `check_no_false_byte_identity_claims()`
returns `True` and `main()` returns `1` on the mutated copy; both are clean
(`False`/`0`) on the real, fixed tree.

`python3 -m py_compile` on every touched `.py` file, `yaml.safe_load_all` on
every touched `.yml`/`.yaml` (including the reformatted multi-line
playbooks and the corrected header) — all parse. No code was executed from
the codebase beyond importing these two small lint modules and one ansible
test-support script for verification, per the task's standalone-harness
allowance; no ansible play or inventory script was run.

## Review Round 2 — REQUEST CHANGES addressed

- **HIGH (regression)**: `_iter_scalar_nodes` in both checkers only
  descended into each mapping pair's `value_node`, so a deprecated fact or
  an unguarded git command used as a mapping **key** (e.g. a
  dynamically-named var, `'{{ ansible_hostname }}_status': ok`) was
  invisible — even though the pre-#14196 line-based scanner caught it
  anywhere on a line. Fixed in **both** walkers: they now also yield the
  key node when it's a `ScalarNode`, always checked with the braced
  `PATTERN` (a key is templated `{{ }}`-wrapped, never bare). Added a
  mapping-key fixture to both `*_test.py` files. Standalone-harness
  mutation proof (not pushed): loaded the pre-fix code from this branch's
  own prior commit and the fixed code side by side —
  `find_violations()` on `'{{ ansible_hostname }}_status': ok` returns `[]`
  pre-fix, `[(3, 'hostname', ...)]` post-fix, matching the original
  line-based checker's `[(3, 'hostname', ...)]`; same shape confirmed for
  the git-safe checker with a `"git -C {{ git_repo_root }} log -1": marker`
  key.
- **MEDIUM**: added a "scope" paragraph to both reach self-check
  docstrings — they prove *traversal* completeness against the checker's
  own classification constant (`_BARE_EXPR_KEYS` / `PATTERN`), not that the
  constant itself is complete; narrowing it moves both counters together.
- **LOW**: the "`AliasNode`: skip silently" comment was wrong —
  `yaml.AliasNode` doesn't exist in PyYAML; resolving an alias returns the
  *same* node object as its anchor. Corrected in both files: a shared node
  is revisited once per reachable path (a duplicate report, not a missed
  one; zero anchors exist in the tracked ansible tree today). Deliberately
  not de-duplicated by `id(node)` — a shared node can sit under different
  keys at different reachable paths, and de-duplicating could silently drop
  whichever context-dependent check ran second.
- **Also noted**: `.j2` scoping corrected above (git-safe checker never
  processed `.j2`, in this PR or before it); `check_no_false_byte_identity_claims()`
  docstring now states it's scoped to its three known files, not a
  general scanner.

New commit: `9370e1bc3` (`fix(infra): yield mapping keys too in the
ansible-lint node walks (#14196)`) plus a small docs-only follow-up,
`9c3d74c09`, scoping the byte-identity guard's docstring per the "also
worth a line" note. 40/40 test functions pass (was 38/38 — two new
mapping-key fixtures). Reach self-check counts are unchanged (1856 / 22 —
no mapping keys in the real ansible tree happen to be deprecated facts or
unguarded git commands today), and real-tree parity stays 0 violations
before/after.

## Model Used

Claude Opus 5 (1M context)

Closes #14196, #14201

