### PR TITLE
fix(ci): cancel superseded pull-request runs in 12 workflows (#14434)

### DIFF
--- a/.github/workflows/ansible-file-references.yml
+++ b/.github/workflows/ansible-file-references.yml
@@ -30,6 +30,21 @@ on:
       - '**/ansible/**/*.yaml'
       - 'scripts/check_ansible_file_references.py'
 
+# #14434: without this, every push left its predecessors queued. 42 of a 271-run
+# sample were for commits no longer at their branch tip - work nothing would ever
+# read, each still fetching its actions. During GitHub's 2026-08-17 archive-download
+# degradation that wasted load became failures on unrelated pull requests (#14444).
+#
+# cancel-in-progress is guarded on the event rather than set to a bare `true`:
+# #13432 found that cancelling base-branch runs meant each merge cancelled the
+# previous merge's verification, and merges arrive faster than a suite completes -
+# of 39 completed base runs, 26 were cancelled and NONE succeeded. Six of the
+# workflows this was applied to also trigger on push to Dev_new_gui, so the guard
+# is load-bearing there and harmless where it is not.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/ansible-role-facts-test.yml
+++ b/.github/workflows/ansible-role-facts-test.yml
@@ -58,6 +58,21 @@ on:
       - 'autobot-slm-backend/ansible/tests/**'
       - 'autobot-slm-backend/ansible/tests/**'
 
+# #14434: without this, every push left its predecessors queued. 42 of a 271-run
+# sample were for commits no longer at their branch tip - work nothing would ever
+# read, each still fetching its actions. During GitHub's 2026-08-17 archive-download
+# degradation that wasted load became failures on unrelated pull requests (#14444).
+#
+# cancel-in-progress is guarded on the event rather than set to a bare `true`:
+# #13432 found that cancelling base-branch runs meant each merge cancelled the
+# previous merge's verification, and merges arrive faster than a suite completes -
+# of 39 completed base runs, 26 were cancelled and NONE succeeded. Six of the
+# workflows this was applied to also trigger on push to Dev_new_gui, so the guard
+# is load-bearing there and harmless where it is not.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/constraint-drift.yml
+++ b/.github/workflows/constraint-drift.yml
@@ -30,6 +30,21 @@ on:
       - 'scripts/check_constraint_drift.py'
       - 'scripts/check_websockets_cap.py'
 
+# #14434: without this, every push left its predecessors queued. 42 of a 271-run
+# sample were for commits no longer at their branch tip - work nothing would ever
+# read, each still fetching its actions. During GitHub's 2026-08-17 archive-download
+# degradation that wasted load became failures on unrelated pull requests (#14444).
+#
+# cancel-in-progress is guarded on the event rather than set to a bare `true`:
+# #13432 found that cancelling base-branch runs meant each merge cancelled the
+# previous merge's verification, and merges arrive faster than a suite completes -
+# of 39 completed base runs, 26 were cancelled and NONE succeeded. Six of the
+# workflows this was applied to also trigger on push to Dev_new_gui, so the guard
+# is load-bearing there and harmless where it is not.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/duplication-guard.yml
+++ b/.github/workflows/duplication-guard.yml
@@ -42,6 +42,21 @@ on:
       - 'autobot-frontend/src/**/*.js'
       - 'autobot-frontend/src/**/*.vue'
 
+# #14434: without this, every push left its predecessors queued. 42 of a 271-run
+# sample were for commits no longer at their branch tip - work nothing would ever
+# read, each still fetching its actions. During GitHub's 2026-08-17 archive-download
+# degradation that wasted load became failures on unrelated pull requests (#14444).
+#
+# cancel-in-progress is guarded on the event rather than set to a bare `true`:
+# #13432 found that cancelling base-branch runs meant each merge cancelled the
+# previous merge's verification, and merges arrive faster than a suite completes -
+# of 39 completed base runs, 26 were cancelled and NONE succeeded. Six of the
+# workflows this was applied to also trigger on push to Dev_new_gui, so the guard
+# is load-bearing there and harmless where it is not.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/frontend-codegen-drift.yml
+++ b/.github/workflows/frontend-codegen-drift.yml
@@ -45,6 +45,21 @@ on:
       - 'autobot-frontend/src/types/_generated/**'
       - 'autobot-infrastructure/shared/scripts/gen_frontend_types.py'
 
+# #14434: without this, every push left its predecessors queued. 42 of a 271-run
+# sample were for commits no longer at their branch tip - work nothing would ever
+# read, each still fetching its actions. During GitHub's 2026-08-17 archive-download
+# degradation that wasted load became failures on unrelated pull requests (#14444).
+#
+# cancel-in-progress is guarded on the event rather than set to a bare `true`:
+# #13432 found that cancelling base-branch runs meant each merge cancelled the
+# previous merge's verification, and merges arrive faster than a suite completes -
+# of 39 completed base runs, 26 were cancelled and NONE succeeded. Six of the
+# workflows this was applied to also trigger on push to Dev_new_gui, so the guard
+# is load-bearing there and harmless where it is not.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/frontend-typecheck-regression.yml
+++ b/.github/workflows/frontend-typecheck-regression.yml
@@ -31,6 +31,21 @@ on:
       - 'autobot-frontend/src/**/*.ts'
       - 'autobot-frontend/src/**/*.vue'
 
+# #14434: without this, every push left its predecessors queued. 42 of a 271-run
+# sample were for commits no longer at their branch tip - work nothing would ever
+# read, each still fetching its actions. During GitHub's 2026-08-17 archive-download
+# degradation that wasted load became failures on unrelated pull requests (#14444).
+#
+# cancel-in-progress is guarded on the event rather than set to a bare `true`:
+# #13432 found that cancelling base-branch runs meant each merge cancelled the
+# previous merge's verification, and merges arrive faster than a suite completes -
+# of 39 completed base runs, 26 were cancelled and NONE succeeded. Six of the
+# workflows this was applied to also trigger on push to Dev_new_gui, so the guard
+# is load-bearing there and harmless where it is not.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/no-commit-trailers.yml
+++ b/.github/workflows/no-commit-trailers.yml
@@ -10,6 +10,21 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+# #14434: without this, every push left its predecessors queued. 42 of a 271-run
+# sample were for commits no longer at their branch tip - work nothing would ever
+# read, each still fetching its actions. During GitHub's 2026-08-17 archive-download
+# degradation that wasted load became failures on unrelated pull requests (#14444).
+#
+# cancel-in-progress is guarded on the event rather than set to a bare `true`:
+# #13432 found that cancelling base-branch runs meant each merge cancelled the
+# previous merge's verification, and merges arrive faster than a suite completes -
+# of 39 completed base runs, 26 were cancelled and NONE succeeded. Six of the
+# workflows this was applied to also trigger on push to Dev_new_gui, so the guard
+# is load-bearing there and harmless where it is not.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/pr-blocking-findings.yml
+++ b/.github/workflows/pr-blocking-findings.yml
@@ -17,6 +17,21 @@ on:
     types: [opened, edited, synchronize, reopened]
     branches: [Dev_new_gui, main]
 
+# #14434: without this, every push left its predecessors queued. 42 of a 271-run
+# sample were for commits no longer at their branch tip - work nothing would ever
+# read, each still fetching its actions. During GitHub's 2026-08-17 archive-download
+# degradation that wasted load became failures on unrelated pull requests (#14444).
+#
+# cancel-in-progress is guarded on the event rather than set to a bare `true`:
+# #13432 found that cancelling base-branch runs meant each merge cancelled the
+# previous merge's verification, and merges arrive faster than a suite completes -
+# of 39 completed base runs, 26 were cancelled and NONE succeeded. Six of the
+# workflows this was applied to also trigger on push to Dev_new_gui, so the guard
+# is load-bearing there and harmless where it is not.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   issues: read
   pull-requests: read

--- a/.github/workflows/pr-issue-validation.yml
+++ b/.github/workflows/pr-issue-validation.yml
@@ -14,6 +14,21 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
+# #14434: without this, every push left its predecessors queued. 42 of a 271-run
+# sample were for commits no longer at their branch tip - work nothing would ever
+# read, each still fetching its actions. During GitHub's 2026-08-17 archive-download
+# degradation that wasted load became failures on unrelated pull requests (#14444).
+#
+# cancel-in-progress is guarded on the event rather than set to a bare `true`:
+# #13432 found that cancelling base-branch runs meant each merge cancelled the
+# previous merge's verification, and merges arrive faster than a suite completes -
+# of 39 completed base runs, 26 were cancelled and NONE succeeded. Six of the
+# workflows this was applied to also trigger on push to Dev_new_gui, so the guard
+# is load-bearing there and harmless where it is not.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   pull-requests: read
 

--- a/.github/workflows/pr-queue-gate.yml
+++ b/.github/workflows/pr-queue-gate.yml
@@ -4,6 +4,21 @@ on:
   pull_request:
     types: [opened, reopened]
 
+# #14434: without this, every push left its predecessors queued. 42 of a 271-run
+# sample were for commits no longer at their branch tip - work nothing would ever
+# read, each still fetching its actions. During GitHub's 2026-08-17 archive-download
+# degradation that wasted load became failures on unrelated pull requests (#14444).
+#
+# cancel-in-progress is guarded on the event rather than set to a bare `true`:
+# #13432 found that cancelling base-branch runs meant each merge cancelled the
+# previous merge's verification, and merges arrive faster than a suite completes -
+# of 39 completed base runs, 26 were cancelled and NONE succeeded. Six of the
+# workflows this was applied to also trigger on push to Dev_new_gui, so the guard
+# is load-bearing there and harmless where it is not.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   check-pr-limit:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -11,6 +11,21 @@ on:
     types: [opened, edited, synchronize, reopened]
     branches: [Dev_new_gui, main]
 
+# #14434: without this, every push left its predecessors queued. 42 of a 271-run
+# sample were for commits no longer at their branch tip - work nothing would ever
+# read, each still fetching its actions. During GitHub's 2026-08-17 archive-download
+# degradation that wasted load became failures on unrelated pull requests (#14444).
+#
+# cancel-in-progress is guarded on the event rather than set to a bare `true`:
+# #13432 found that cancelling base-branch runs meant each merge cancelled the
+# previous merge's verification, and merges arrive faster than a suite completes -
+# of 39 completed base runs, 26 were cancelled and NONE succeeded. Six of the
+# workflows this was applied to also trigger on push to Dev_new_gui, so the guard
+# is load-bearing there and harmless where it is not.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   check-template:
     name: Validate PR template sections

--- a/.github/workflows/stylelint-tokens.yml
+++ b/.github/workflows/stylelint-tokens.yml
@@ -24,6 +24,21 @@ on:
       - "autobot-slm-frontend/.stylelintrc.json"
       - ".github/workflows/stylelint-tokens.yml"
 
+# #14434: without this, every push left its predecessors queued. 42 of a 271-run
+# sample were for commits no longer at their branch tip - work nothing would ever
+# read, each still fetching its actions. During GitHub's 2026-08-17 archive-download
+# degradation that wasted load became failures on unrelated pull requests (#14444).
+#
+# cancel-in-progress is guarded on the event rather than set to a bare `true`:
+# #13432 found that cancelling base-branch runs meant each merge cancelled the
+# previous merge's verification, and merges arrive faster than a suite completes -
+# of 39 completed base runs, 26 were cancelled and NONE succeeded. Six of the
+# workflows this was applied to also trigger on push to Dev_new_gui, so the guard
+# is load-bearing there and harmless where it is not.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/repo_tests/workflow_concurrency_guard_test.py
+++ b/repo_tests/workflow_concurrency_guard_test.py
@@ -1,0 +1,175 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Every pull-request-triggered workflow must cancel its superseded runs (#14434).
+
+Without a ``concurrency`` group, a push leaves its predecessors queued. They can
+never affect anything - nothing reads the result of a run for a commit that is no
+longer the branch tip - but each one still checks out and fetches its actions.
+
+Measured before the fix: 260 queued runs, of which 42 of a 271-run sample were for
+superseded commits. During GitHub's 2026-08-17 archive-download degradation that
+wasted load stopped being merely slow and became *failures* on unrelated pull
+requests (#14444), because each redundant job made its own attempt against an
+endpoint returning errors.
+
+Two workflows are deliberately exempt, and the exemption is by name with its reason
+attached rather than a silent allowlist - a bare list of filenames is how an
+exemption outlives the thing that justified it.
+"""
+
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml", reason="PyYAML needed to parse the workflows")
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
+
+# The required-context shims publish a context branch protection demands, from a
+# job that is SKIPPED by its own `if:` whenever the real suite runs instead. Put
+# them in a concurrency group and a superseded run takes the shim down with it -
+# the context is then never reported at all, and the pull request blocks forever
+# on "Expected - Waiting for status". Both files say so inline (#13405, #14353).
+DELIBERATELY_EXEMPT = {
+    "frontend-required-context.yml": (
+        "publishes the required 'Unit & Integration Tests' context; cancelling a "
+        "superseded run would leave it unreported and deadlock the pull request"
+    ),
+    "python-required-context.yml": (
+        "publishes the required 'python-suite' context; same deadlock (#14353)"
+    ),
+}
+
+
+def _triggers(doc: dict) -> dict:
+    """Return the workflow's ``on:`` block.
+
+    YAML 1.1 resolves the bare key ``on`` to the boolean ``True``, so ``doc["on"]``
+    raises and ``doc.get("on", {})`` silently returns nothing - which would make
+    every assertion below vacuous while the test still passed.
+    """
+    return doc.get(True) or doc.get("on") or {}
+
+
+def _pull_request_workflows():
+    for path in sorted(WORKFLOW_DIR.glob("*.yml")):
+        try:
+            doc = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        except yaml.YAMLError:  # a malformed workflow is a different test's problem
+            continue
+        if "pull_request" in _triggers(doc):
+            yield path, doc
+
+
+def test_the_scan_actually_finds_workflows():
+    """A glob that matched nothing would make the guard below assert nothing."""
+    found = list(_pull_request_workflows())
+
+    assert len(found) >= 20, (
+        f"only {len(found)} pull_request-triggered workflow(s) matched - the scan is "
+        "no longer bound to the workflows it is meant to guard"
+    )
+
+
+def test_every_exemption_still_names_a_real_workflow():
+    """An allowlist entry naming a moved or renamed file exempts nothing, silently."""
+    for name in DELIBERATELY_EXEMPT:
+        assert (WORKFLOW_DIR / name).is_file(), (
+            f"{name} is exempt from the concurrency requirement but no longer exists. "
+            "A stale exemption is invisible: it stops applying without failing."
+        )
+
+
+@pytest.mark.parametrize(
+    "path",
+    [pytest.param(p, id=p.name) for p, _ in _pull_request_workflows()],
+)
+def test_a_pull_request_workflow_cancels_superseded_runs(path):
+    doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+    concurrency = doc.get("concurrency")
+
+    if path.name in DELIBERATELY_EXEMPT:
+        assert concurrency is None, (
+            f"{path.name} is exempt because it {DELIBERATELY_EXEMPT[path.name]}. "
+            "It now declares a concurrency group, which reintroduces that deadlock."
+        )
+        return
+
+    assert concurrency, (
+        f"{path.name} triggers on pull_request with no `concurrency:` group, so every "
+        "push leaves its predecessors queued. Each redundant run still fetches its "
+        "actions (#14434, #14444)."
+    )
+    assert concurrency.get("group"), f"{path.name}: concurrency group is empty"
+
+
+# Workflows that also run on push and cancel unconditionally, so a merge to the
+# base branch cancels the previous merge's verification (#13432). Measured on
+# Dev_new_gui at d68c09c88 while fixing #14434. This is a RATCHET: the number may
+# only ever go DOWN. Fixing one means deleting its line.
+#
+# It is not a style nit. Seven of the ten required contexts are produced by
+# workflows on this list - api-wiring, code-quality, smoke-test (docker-smoke-test),
+# migration-gate, startup-import-smoke, verify-generated-types, and
+# "Unit & Integration Tests" (frontend-test) - so on a busy day the base branch is
+# verified by whichever merge happens not to be superseded. #13432 measured exactly
+# that for ci.yml: of 39 completed base runs, 26 were cancelled and NONE succeeded.
+# ci.yml was fixed; these were not. Tracked separately - see the issue referenced
+# from #14434.
+UNGUARDED_BASE_BRANCH_CANCEL = frozenset(
+    {
+        "actionlint.yml",
+        "api-wiring.yml",
+        "code-quality.yml",
+        "docker-smoke-test.yml",
+        "frontend-test.yml",
+        "hardened-smoke-test.yml",
+        "llc-contract.yml",
+        "migration-gate.yml",
+        "phase_validation.yml",
+        "security.yml",
+        "slm-frontend-check.yml",
+        "slm-migration-gate.yml",
+        "ssot-coverage.yml",
+        "startup-import-smoke.yml",
+        "trajectory-eval.yml",
+        "verify-generated-types.yml",
+    }
+)
+
+
+def _cancels_base_branch_runs_unguarded(path: Path, doc: dict) -> bool:
+    if "push" not in _triggers(doc):
+        return False
+    return (doc.get("concurrency") or {}).get("cancel-in-progress") is True
+
+
+def test_base_branch_cancellation_does_not_spread():
+    """A ratchet, because the existing offenders cannot all be fixed in one change.
+
+    Each entry cancels base-branch verification. The set may shrink, never grow -
+    a new workflow copying the `cancel-in-progress: true` idiom from a neighbour is
+    exactly how this reached sixteen.
+    """
+    offenders = {
+        path.name
+        for path, doc in _pull_request_workflows()
+        if _cancels_base_branch_runs_unguarded(path, doc)
+    }
+
+    new = offenders - UNGUARDED_BASE_BRANCH_CANCEL
+    assert not new, (
+        f"{sorted(new)} also trigger on push and cancel unconditionally, so a merge "
+        "cancels the previous merge's verification (#13432). Guard cancel-in-progress "
+        "on github.event_name == 'pull_request'."
+    )
+
+    fixed = UNGUARDED_BASE_BRANCH_CANCEL - offenders
+    assert not fixed, (
+        f"{sorted(fixed)} no longer cancel base-branch runs - delete them from "
+        "UNGUARDED_BASE_BRANCH_CANCEL so the ratchet keeps its grip. A list that "
+        "still names a fixed file exempts nothing while looking like it does."
+    )

--- a/repo_tests/workflow_concurrency_guard_test.py
+++ b/repo_tests/workflow_concurrency_guard_test.py
@@ -106,10 +106,19 @@ def test_a_pull_request_workflow_cancels_superseded_runs(path):
     assert concurrency.get("group"), f"{path.name}: concurrency group is empty"
 
 
-# Workflows that also run on push and cancel unconditionally, so a merge to the
-# base branch cancels the previous merge's verification (#13432). Measured on
-# Dev_new_gui at d68c09c88 while fixing #14434. This is a RATCHET: the number may
-# only ever go DOWN. Fixing one means deleting its line.
+# Workflows that trigger on pull_request AND push, and cancel unconditionally, so
+# a merge to the base branch cancels the previous merge's verification (#13432).
+# Measured on Dev_new_gui at d68c09c88 while fixing #14434. This is a RATCHET: the
+# number may only ever go DOWN. Fixing one means deleting its line.
+#
+# SCOPED BY DESIGN, and the scope is narrower than the defect. Everything here
+# filters through `_pull_request_workflows()` first, so a workflow with the same
+# collision shape but NO pull_request trigger is structurally invisible to this
+# ratchet - `coverage.yml` (push + schedule) is exactly that, and its own comment
+# claims the figure "tracks what actually landed" while two merges inside its ~35
+# minute window cancel each other. Stating the scope because a guard narrower than
+# its subject otherwise reads as coverage of the whole subject. Those cases are
+# recorded on #14450 rather than silently absent.
 #
 # It is not a style nit. Seven of the ten required contexts are produced by
 # workflows on this list - api-wiring, code-quality, smoke-test (docker-smoke-test),


### PR DESCRIPTION
## Thinking Path

Twelve pull-request-triggered workflows had no `concurrency` group, so every push left its predecessors queued. Nothing ever reads the result of a run for a commit that is no longer the branch tip — but each one still checks out and fetches its actions. Of a 271-run sample taken while the queue sat at 260, **42 were for superseded commits**.

That was a throughput problem until 2026-08-17, when GitHub's archive-download degradation (~50% error rate, #14444) turned every redundant action fetch into an independent chance to fail. Wasted load stopped being merely slow and started reddening *unrelated* pull requests, with a signature — several checks failing together, no test output — that reads exactly like a real breakage.

Two decisions worth stating rather than leaving implicit:

**`cancel-in-progress` is guarded on the event, not set to a bare `true`.** Six of the twelve also trigger on push to `Dev_new_gui`, and #13432 measured what an unguarded cancel does there: each merge cancels the previous merge's verification, and of 39 completed base runs, 26 were cancelled and none succeeded. The guard is load-bearing for those six and harmless for the other six — one idiom, and it cannot become wrong if someone later adds a push trigger.

**The two required-context shims are left without a group, deliberately.** Their job is *skipped* by its own `if:` whenever the real suite runs; put them in a concurrency group and a superseded run takes the shim down with it, so the required context never reports and the pull request deadlocks on "Expected — Waiting for status". Both files already say so inline (#13405, #14353).

## What Changed

`concurrency` added to the twelve, each with the comment explaining why the guard is conditional:

```
ansible-file-references  ansible-role-facts-test  constraint-drift  duplication-guard
frontend-codegen-drift   frontend-typecheck-regression              no-commit-trailers
pr-blocking-findings     pr-issue-validation      pr-queue-gate     pr-template-check
stylelint-tokens
```

`repo_tests/workflow_concurrency_guard_test.py` enforces it going forward, so the rule is checked rather than restated in a comment.

The exemptions are recorded **by name with the reason attached**, and a test asserts each still names a real file — an allowlist entry pointing at a moved file exempts nothing while looking like it does.

## Verification

Mutation evidence, from a standalone harness over the workflow files as data:

```
BASELINE (fixed)                                     PASS
MUT A: drop concurrency from no-commit-trailers      FAIL  missing=1
MUT B: give the python shim a concurrency group      FAIL  shim=1
MUT C: bare `true` on a push-triggered fixed one     FAIL  new_offenders=['constraint-drift.yml']
MUT D: 'fix' code-quality without updating ratchet   FAIL  stale_ratchet=['code-quality.yml']
```

Mutation D is the one worth noting: it proves the ratchet below cannot go stale silently. Fixing a workflow without removing it from the list fails, so the list cannot keep naming files it no longer describes.

The scan is self-checking — `test_the_scan_actually_finds_workflows` requires ≥20 matches, so a glob that stops matching cannot pass having asserted nothing. It currently sees 41.

The YAML 1.1 trap is handled explicitly: the bare key `on` resolves to the boolean `True`, so `doc["on"]` raises and `doc.get("on", {})` silently returns nothing — a guard written the obvious way would pass while asserting nothing at all.

## A larger problem this surfaced — filed, not silently fixed

Writing the guard flagged **16 other workflows** that trigger on push *and* cancel unconditionally, including **seven of the ten required contexts** (`api-wiring`, `code-quality`, `smoke-test`, `migration-gate`, `startup-import-smoke`, `verify-generated-types`, `Unit & Integration Tests`).

That is #13432's defect still live almost everywhere it matters — `ci.yml` was fixed, these were not. On a busy day the base branch is verified by whichever merge happened not to be superseded, with no signal separating "the base is green" from "its verification was cancelled".

Filed as **#14450** rather than widening this change. Recorded here as `UNGUARDED_BASE_BRANCH_CANCEL`, a ratchet that may only shrink, so a new workflow cannot copy the idiom from a neighbour in the meantime.

## Model Used

Claude Opus 5.

Closes #14434
