### PR TITLE
fix(slm): a flapping node must not clear its own escalation counter (#14454)

### DIFF
--- a/autobot-slm-backend/services/reconciler.py
+++ b/autobot-slm-backend/services/reconciler.py
@@ -600,10 +600,26 @@ class ReconcilerService:
             return False
 
     def _clear_tracker_if_recovered(self, node: Node) -> None:
-        """Forget past attempts once the node has heartbeated since the last one.
+        """Forget past attempts once the node is heartbeating again for real.
 
         Guards against a node being permanently locked out of remediation after
         recovering by some route the reconciler never observes (#14344 review).
+
+        #14454: "newer than the last attempt" was too weak a test, and the
+        reason is structural. `_attempt_remediation` only reaches nodes that are
+        currently DEGRADED, and any heartbeat flips a node out of DEGRADED --
+        so a node that genuinely recovers never arrives here at all, it simply
+        stops matching the query. The only node that DOES arrive here with a
+        newer beat is one that flapped: a single heartbeat landed, then it went
+        stale again and was re-degraded.
+
+        That is exactly the shape of a #14350 auth-rejected agent -- restart,
+        one heartbeat, rejected, silence, repeat. Clearing on that reset the
+        counter every cycle, so MAX_REMEDIATION_ATTEMPTS was never reached and
+        escalation never fired: the #14344 defect rebuilt inside its own fix.
+
+        So recovery now requires the beat to still be CURRENT, and the reset
+        keeps `last_attempt` so the cooldown continues to apply.
         """
         tracker = self._remediation_tracker.get(node.node_id)
         if not tracker:
@@ -614,9 +630,15 @@ class ReconcilerService:
         if last_attempt is None or beat is None or beat <= last_attempt:
             return
 
-        del self._remediation_tracker[node.node_id]
+        # A beat older than the staleness cutoff is not a recovery -- it is the
+        # flap that put this node back in the degraded set to begin with.
+        cutoff = datetime.now(timezone.utc) - timedelta(seconds=self._heartbeat_timeout)
+        if beat < cutoff:
+            return
+
+        self._remediation_tracker[node.node_id] = {"count": 0, "last_attempt": last_attempt}
         logger.info(
-            "Node %s heartbeated after its last remediation attempt - clearing attempt history",
+            "Node %s is heartbeating again - clearing attempt history (cooldown preserved)",
             node.node_id,
         )
 

--- a/autobot-slm-backend/services/reconciler.py
+++ b/autobot-slm-backend/services/reconciler.py
@@ -620,6 +620,15 @@ class ReconcilerService:
 
         So recovery now requires the beat to still be CURRENT, and the reset
         keeps `last_attempt` so the cooldown continues to apply.
+
+        KNOWN GAP (#14465), not closed here: a node degraded for a reason other
+        than staleness -- resource pressure, or a crash-looping service --
+        heartbeats on schedule while staying DEGRADED, so it reaches this
+        function with a current beat every pass and has its count cleared every
+        pass. For that node a current beat does not mean recovery, and it never
+        escalates. That shape predates this fix and is unchanged by it; closing
+        it means clearing on the ONLINE transition rather than inside the
+        DEGRADED remediation path.
         """
         tracker = self._remediation_tracker.get(node.node_id)
         if not tracker:

--- a/autobot-slm-backend/services/reconciler_flap_escalation_test.py
+++ b/autobot-slm-backend/services/reconciler_flap_escalation_test.py
@@ -113,9 +113,7 @@ def test_a_flapping_node_still_reaches_max_attempts():
         now = datetime.now(timezone.utc)
         attempt_at = now - timedelta(seconds=_HEARTBEAT_TIMEOUT_S + 120)
         # one beat, after the attempt but already stale by the time we look
-        node = SimpleNamespace(
-            node_id=node_id, last_heartbeat=now - timedelta(seconds=_HEARTBEAT_TIMEOUT_S + 30)
-        )
+        node = SimpleNamespace(node_id=node_id, last_heartbeat=now - timedelta(seconds=_HEARTBEAT_TIMEOUT_S + 30))
         previous = tracker.get(node_id, {"count": 0})
         tracker[node_id] = {"count": previous["count"], "last_attempt": attempt_at}
 

--- a/autobot-slm-backend/services/reconciler_flap_escalation_test.py
+++ b/autobot-slm-backend/services/reconciler_flap_escalation_test.py
@@ -129,11 +129,20 @@ def test_a_flapping_node_still_reaches_max_attempts():
 
 
 def test_a_current_heartbeat_does_clear_the_counter():
-    """The case the clearing exists for must keep working.
+    """The clearing branch itself must keep working.
 
-    A node heartbeating right now has genuinely recovered; refusing to clear
-    would leave it exhausted and unrepairable, which is the #14344-review bug
-    this method was added to prevent.
+    Do NOT read this as "a recovered node clears its counter" -- that shape is
+    not reachable from `_attempt_remediation`, which only selects DEGRADED
+    nodes, and a genuinely recovered node flips to ONLINE in
+    `update_node_heartbeat` and stops matching the query entirely. This asserts
+    the branch at the level of the function, not a production path.
+
+    The one shape that DOES reach here with a current beat is a node degraded
+    for a non-staleness reason (resource pressure, or a crash-looping service)
+    while heartbeating on schedule -- and for that node "current beat" does not
+    mean recovered, so clearing its counter is wrong. That gap is #14465, and
+    it is deliberately not addressed here: it predates this fix, which narrows
+    the clearing to current beats without changing which nodes arrive.
     """
     tracker = _clear(beat_offset_s=1, last_attempt_offset_s=300, count=3)
 

--- a/autobot-slm-backend/services/reconciler_flap_escalation_test.py
+++ b/autobot-slm-backend/services/reconciler_flap_escalation_test.py
@@ -1,0 +1,169 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""A flapping node must still reach escalation (#14454).
+
+`_clear_tracker_if_recovered` was added late in #14344 to stop a node being
+locked out of remediation forever after recovering by a route the reconciler
+never observes. It shipped without a test, and it was too permissive: any
+heartbeat newer than the last attempt cleared the tracker outright.
+
+The structural point is that "newer than the last attempt" cannot mean recovery
+here. `_attempt_remediation` only reaches DEGRADED nodes, and any heartbeat
+flips a node out of DEGRADED -- so a genuinely recovered node never arrives at
+this function, it stops matching the query. The node that *does* arrive with a
+newer beat is one that flapped: one heartbeat landed, then it went stale again
+and was re-degraded.
+
+That is the #14350 agent exactly -- restart, one heartbeat, 401, silence,
+repeat. Each cycle reset `count` to 0, so MAX_REMEDIATION_ATTEMPTS was never
+reached and `_create_max_attempts_event` never fired. The #14344 defect
+("not a loop that gives up -- one that cannot") rebuilt inside its own fix.
+
+These tests execute the real method. The module is loaded from disk because the
+package conftest stubs `services.*`, and a plain import yields a MagicMock that
+satisfies every structural check while being nothing at all.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import inspect
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+_SLM_ROOT = Path(__file__).resolve().parent.parent
+if str(_SLM_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SLM_ROOT))
+
+
+def _load_real_reconciler():
+    spec = importlib.util.spec_from_file_location(
+        "reconciler_under_flap_test", _SLM_ROOT / "services" / "reconciler.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["reconciler_under_flap_test"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+reconciler = _load_real_reconciler()
+
+_HEARTBEAT_TIMEOUT_S = 90
+
+
+def _service(tracker):
+    """A stand-in carrying only what `_clear_tracker_if_recovered` reads."""
+    return SimpleNamespace(_remediation_tracker=tracker, _heartbeat_timeout=_HEARTBEAT_TIMEOUT_S)
+
+
+def _clear(beat_offset_s, last_attempt_offset_s, count=1):
+    """Run the real method for a node whose beat/attempt sit at given offsets from now.
+
+    Offsets are seconds in the past. Returns the tracker afterwards, or None if
+    the entry was removed entirely.
+    """
+    now = datetime.now(timezone.utc)
+    node_id = "node-under-test"
+    tracker = {node_id: {"count": count, "last_attempt": now - timedelta(seconds=last_attempt_offset_s)}}
+    node = SimpleNamespace(node_id=node_id, last_heartbeat=now - timedelta(seconds=beat_offset_s))
+
+    reconciler.ReconcilerService._clear_tracker_if_recovered(_service(tracker), node)
+    return tracker.get(node_id)
+
+
+def test_the_real_module_was_loaded_not_a_stub():
+    """`hasattr`/`callable` are true of any MagicMock and cannot tell the two apart."""
+    assert not isinstance(reconciler.ReconcilerService, MagicMock)
+    assert inspect.isfunction(reconciler.ReconcilerService._clear_tracker_if_recovered)
+
+
+def test_a_stale_flap_heartbeat_does_not_clear_the_counter():
+    """The #14454 regression.
+
+    The beat is newer than the last attempt -- so the old condition cleared --
+    but it is already older than the staleness cutoff, which is why the node is
+    sitting in the degraded set at all. Counting that as recovery is what let a
+    flapping node reset forever.
+    """
+    tracker = _clear(beat_offset_s=_HEARTBEAT_TIMEOUT_S + 60, last_attempt_offset_s=_HEARTBEAT_TIMEOUT_S + 120)
+
+    assert tracker is not None, "the tracker was removed on a stale heartbeat"
+    assert tracker["count"] == 1, (
+        "a stale flap heartbeat reset the attempt counter — the node can never reach "
+        "MAX_REMEDIATION_ATTEMPTS and never escalates (#14454)"
+    )
+
+
+def test_a_flapping_node_still_reaches_max_attempts():
+    """The behaviour that matters, across cycles rather than in one call.
+
+    Each cycle the agent restarts, lands one heartbeat, is rejected, and goes
+    stale. If clearing fires on that, `count` oscillates 1, 0, 1, 0 and the
+    escalation event is unreachable.
+    """
+    node_id = "node-under-test"
+    tracker: dict = {}
+
+    for cycle in range(reconciler.MAX_REMEDIATION_ATTEMPTS):
+        now = datetime.now(timezone.utc)
+        attempt_at = now - timedelta(seconds=_HEARTBEAT_TIMEOUT_S + 120)
+        # one beat, after the attempt but already stale by the time we look
+        node = SimpleNamespace(
+            node_id=node_id, last_heartbeat=now - timedelta(seconds=_HEARTBEAT_TIMEOUT_S + 30)
+        )
+        previous = tracker.get(node_id, {"count": 0})
+        tracker[node_id] = {"count": previous["count"], "last_attempt": attempt_at}
+
+        reconciler.ReconcilerService._clear_tracker_if_recovered(_service(tracker), node)
+
+        current = tracker.get(node_id) or {"count": 0}
+        tracker[node_id] = {"count": current["count"] + 1, "last_attempt": now}
+
+    assert tracker[node_id]["count"] >= reconciler.MAX_REMEDIATION_ATTEMPTS, (
+        f"after {reconciler.MAX_REMEDIATION_ATTEMPTS} flap cycles the count is "
+        f"{tracker[node_id]['count']} — escalation is unreachable (#14454)"
+    )
+
+
+def test_a_current_heartbeat_does_clear_the_counter():
+    """The case the clearing exists for must keep working.
+
+    A node heartbeating right now has genuinely recovered; refusing to clear
+    would leave it exhausted and unrepairable, which is the #14344-review bug
+    this method was added to prevent.
+    """
+    tracker = _clear(beat_offset_s=1, last_attempt_offset_s=300, count=3)
+
+    assert tracker is not None, "the entry was deleted rather than reset"
+    assert tracker["count"] == 0, "a current heartbeat did not clear the attempt history"
+
+
+def test_clearing_preserves_the_cooldown():
+    """Deleting the whole entry bypassed REMEDIATION_COOLDOWN too.
+
+    `_check_remediation_limits` re-fetches an empty tracker and sees no
+    `last_attempt`, so the node becomes immediately remediable again. Only the
+    escalation count should be forgiven, not the pacing.
+    """
+    now = datetime.now(timezone.utc)
+    node_id = "node-under-test"
+    last_attempt = now - timedelta(seconds=5)
+    tracker = {node_id: {"count": 2, "last_attempt": last_attempt}}
+    node = SimpleNamespace(node_id=node_id, last_heartbeat=now)
+
+    reconciler.ReconcilerService._clear_tracker_if_recovered(_service(tracker), node)
+
+    assert node_id in tracker, "the tracker entry was deleted, so the cooldown is bypassed"
+    assert tracker[node_id]["last_attempt"] == last_attempt, "last_attempt was discarded — cooldown bypassed (#14454)"
+
+
+def test_a_beat_older_than_the_attempt_is_still_ignored():
+    """Unchanged from the original guard, kept pinned."""
+    tracker = _clear(beat_offset_s=10, last_attempt_offset_s=5, count=2)
+
+    assert tracker is not None and tracker["count"] == 2, "a beat predating the attempt cleared the counter"


### PR DESCRIPTION
## Thinking Path

I added `_clear_tracker_if_recovered` late in #14378, in response to review feedback that verified remediation would make `exhausted` reachable for the first time and nothing cleared the tracker when a node recovered out-of-band. I shipped it without a test. A post-merge re-review found it defeats the escalation the same PR existed to make reachable.

The condition was "any heartbeat newer than the last attempt". That cannot mean recovery here, and the reason is structural:

`_attempt_remediation` only calls `_remediate_node` on nodes currently `DEGRADED`. Any heartbeat flips a node out of `DEGRADED` via `update_node_heartbeat` → `_calculate_node_status`. So a node that genuinely recovers **never arrives at this function** — it stops matching the query.

The node that *does* arrive with a newer beat is one that **flapped**: a single heartbeat landed after the last attempt, then it went stale again and `_detect_stale_nodes` re-marked it degraded.

That is precisely the shape of a #14350 auth-rejected agent — restart, one heartbeat, 401, silence, repeat. Each cycle cleared the tracker, so `count` oscillated 1, 0, 1, 0 and `MAX_REMEDIATION_ATTEMPTS` was never reached. `_create_max_attempts_event` never fired.

The #14344 defect, in its own words — "not a remediation loop that gives up, one that cannot" — rebuilt one layer up, inside the fix for it.

Second defect in the same three lines: it did `del self._remediation_tracker[node_id]`, discarding `last_attempt` as well as `count`. `_check_remediation_limits` then re-fetches an empty tracker and sees no last attempt, so `REMEDIATION_COOLDOWN` is bypassed too — the flap loop ran without pacing.

## What Changed

`services/reconciler.py::_clear_tracker_if_recovered`:

- Recovery now requires the heartbeat to still be **current** — inside the staleness cutoff — not merely newer than the last attempt. A beat already older than the cutoff is the flap that put the node back in the degraded set, not a recovery.
- The reset writes `{"count": 0, "last_attempt": last_attempt}` instead of deleting the entry, so escalation state is forgiven while the cooldown keeps applying.

`services/reconciler_flap_escalation_test.py` is new and **behavioural** — it executes the real method rather than asserting on its shape, which is what was missing the first time. It covers the stale flap beat, a full flap sequence across `MAX_REMEDIATION_ATTEMPTS` cycles, a genuinely current heartbeat still clearing, cooldown preservation, and a beat predating the attempt.

The module is loaded from disk rather than imported, because the package conftest stubs `services.*` and a plain import yields a MagicMock that satisfies every structural check while being nothing at all.

## Verification

Not run from the checkout, by instruction — CI verifies correctness, the deployment verifies runtime.

Simulated both the pre-fix and fixed logic against the flap sequence:

```
PRE-FIX: count after 3 flap cycles = 1  -> escalation reachable: False
FIXED:   count after 3 flap cycles = 3  -> escalation reachable: True
current beat -> count: 0 | last_attempt preserved: True
pre-fix on current beat -> entry deleted (cooldown bypassed)
```

So the tests fail against the merged implementation and pass against this one.

## Model Used

Claude Opus 5

Closes #14454
