### PR TITLE
fix(infra): wire the four AUTOBOT_ shell var families with no SSOT source (#14173)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,6 +80,28 @@ AUTOBOT_OLLAMA_HOST=127.0.0.1
 
 
 # =============================================================================
+# SSH / FLEET IDENTITY (#14173)
+# =============================================================================
+# Two distinct SSH keys, deliberately not the same value:
+#   - AUTOBOT_SSH_KEY is the operator's own key, generated under $HOME the
+#     first time a human runs autobot-infrastructure/shared/scripts/utilities/
+#     setup-ssh-keys.sh from their own workstation.
+#   - AUTOBOT_SSH_KEY_PATH (alias SLM_SSH_KEY, #12429) is the service
+#     account's key, deployed by Ansible to /etc/autobot/ssh for automated
+#     fleet orchestration (SLM backend, code-sync agents).
+# AUTOBOT_SSH_KEY=YOUR_HOME/.ssh/autobot_key
+# AUTOBOT_SSH_KEY_PATH=/etc/autobot/ssh/autobot_key
+
+# SSH user for connections to fleet VMs (matches the ansible.cfg remote_user
+# and inventory ansible_user "autobot" operational account).
+AUTOBOT_SSH_USER=autobot
+
+# SLM manager's DB node_id. Deployments may rename the node -- override to
+# match the inventory's slm_server host slm_node_id if it differs.
+AUTOBOT_SLM_NODE_ID=00-SLM-Manager
+
+
+# =============================================================================
 # SERVICE PORTS
 # =============================================================================
 # Standard ports for all AutoBot services.
@@ -105,8 +127,13 @@ AUTOBOT_NPU_WORKER_PORT=8081
 # Browser automation service port
 AUTOBOT_BROWSER_SERVICE_PORT=9001
 
-# VNC desktop port
+# VNC desktop port (noVNC web interface / websockify)
 AUTOBOT_VNC_PORT=6080
+
+# Raw VNC protocol port (x11vnc via vncserver), NOT the noVNC web port above
+# (#14173). 5900 + vnc_display; vnc_display defaults to 1 in
+# autobot-slm-backend/ansible/roles/vnc/defaults/main.yml.
+AUTOBOT_VNC_SERVER_PORT=5901
 
 # Prometheus monitoring port
 AUTOBOT_PROMETHEUS_PORT=9090

--- a/autobot-frontend/src/config/__tests__/ssot-parity.spec.ts
+++ b/autobot-frontend/src/config/__tests__/ssot-parity.spec.ts
@@ -158,8 +158,19 @@ function pythonStringFieldDefaults(source: string, className: string): Record<st
  * directly. TS-only: a frontend-to-frontend link with no Python analog.
  * Anything appearing on one side that is *not* listed here is unmirrored
  * drift and fails below.
+ *
+ * Each entry carries its reason inline (#14173 review) — a bare list rots:
+ * an entry naming a field that was later removed from PortConfig exempts
+ * nothing while still looking authoritative, because the "still genuinely
+ * one-sided" check below only proves the Python side still HAS the field,
+ * never why keeping it one-sided is still correct.
  */
-const PYTHON_ONLY_PORTS = ['chromadb', 'tts', 'chrome_cdp'] as const
+const PYTHON_ONLY_PORTS = [
+  'chromadb', // ChromaDB vector store — the backend talks to it directly; the frontend only ever goes through backend API routes (#3094)
+  'tts', // TTS worker — backend-to-worker only, no frontend consumer (#928)
+  'chrome_cdp', // Chrome DevTools Protocol — backend browser-automation only (#3829)
+  'vnc_server', // raw VNC protocol port (x11vnc), consumed by the node's own systemd service + the Ansible vnc role. The frontend's desktop viewer only ever talks to the noVNC WEB port ('vnc' above, already mirrored) — verified no frontend file reads AUTOBOT_VNC_SERVER_PORT or hardcodes 5901; the 5901 literals in *.test.ts are unrelated per-session `vnc_port` API-response mocks (AdvancedControlApiClient), a dynamic runtime value with no static SSOT default on either side (#14173)
+] as const
 const TS_ONLY_PORTS = ['slmAdmin'] as const
 
 describe('Python source parser (self-check)', () => {

--- a/autobot-frontend/src/config/__tests__/ssot-parity.spec.ts
+++ b/autobot-frontend/src/config/__tests__/ssot-parity.spec.ts
@@ -166,10 +166,25 @@ function pythonStringFieldDefaults(source: string, className: string): Record<st
  * never why keeping it one-sided is still correct.
  */
 const PYTHON_ONLY_PORTS = [
-  'chromadb', // ChromaDB vector store — the backend talks to it directly; the frontend only ever goes through backend API routes (#3094)
-  'tts', // TTS worker — backend-to-worker only, no frontend consumer (#928)
-  'chrome_cdp', // Chrome DevTools Protocol — backend browser-automation only (#3829)
-  'vnc_server', // raw VNC protocol port (x11vnc), consumed by the node's own systemd service + the Ansible vnc role. The frontend's desktop viewer only ever talks to the noVNC WEB port ('vnc' above, already mirrored) — verified no frontend file reads AUTOBOT_VNC_SERVER_PORT or hardcodes 5901; the 5901 literals in *.test.ts are unrelated per-session `vnc_port` API-response mocks (AdvancedControlApiClient), a dynamic runtime value with no static SSOT default on either side (#14173)
+  // #3094/#3829/#928 (originally cited here) are the ssot_config.py field
+  // comments' OWN issue refs for why that port NUMBER was chosen — not for
+  // the frontend/backend boundary claim below. Wrong-but-plausible citations
+  // are worse than none (#14173 review), so the architectural reason is
+  // stated plainly instead of re-attaching an unrelated issue number.
+  'chromadb', // ChromaDB vector store — the backend talks to it directly; the frontend only ever goes through backend API routes
+  'tts', // TTS worker — backend-to-worker only, no frontend consumer
+  'chrome_cdp', // Chrome DevTools Protocol — backend browser-automation only
+  // raw VNC protocol port (x11vnc), consumed by the node's own systemd
+  // service + the Ansible vnc role. The frontend's desktop viewer only ever
+  // talks to the noVNC WEB port ('vnc' above, already mirrored) — no
+  // frontend file reads AUTOBOT_VNC_SERVER_PORT. One hardcoded `5901`
+  // exists (SecretsManager.vue's `placeholder="5901"` on a per-host VNC
+  // port form field), but it is a UI example on user-entered data for an
+  // arbitrary external host, not a functional default sourced from any
+  // SSOT; the `5901` literals in *.test.ts are a separate, unrelated
+  // per-session `vnc_port` API-response mock (AdvancedControlApiClient), a
+  // dynamic runtime value with no static SSOT default on either side (#14173)
+  'vnc_server',
 ] as const
 const TS_ONLY_PORTS = ['slmAdmin'] as const
 

--- a/autobot-infrastructure/shared/scripts/lib/ssot-config.sh
+++ b/autobot-infrastructure/shared/scripts/lib/ssot-config.sh
@@ -19,12 +19,12 @@
 #
 # Scope note (#14041 enumeration, docs/audit/ssot_config_shell_library_14041.md):
 # this file exports exactly the variables the 56 scripts were proven to consume.
-# It deliberately does NOT export AUTOBOT_SSH_KEY, AUTOBOT_SSH_USER,
-# AUTOBOT_SLM_NODE_ID, or the four AUTOBOT_VNC_* names some scripts also read --
-# none of those has a canonical value anywhere (not autobot_shared/ssot_config.py,
-# not .env.example, not the Ansible group_vars). Inventing a default for them here
-# would be a second source of truth, which is exactly the failure mode this file
-# exists to end. Those scripts keep their own literal fallback unchanged.
+#
+# #14173 follow-up: AUTOBOT_SSH_KEY, AUTOBOT_SSH_USER, AUTOBOT_SLM_NODE_ID and
+# the four AUTOBOT_VNC_* names below were left out of the original #14041 pass
+# because none of them had a canonical value anywhere at the time. They now do
+# (autobot_shared/ssot_config.py PathConfig.management_ssh_key_path/ssh_user,
+# MiscConfig.slm_node_id, PortConfig.vnc_server) -- see section 3b below.
 #
 # Source this file -- do not execute it.
 
@@ -129,6 +129,40 @@ fi
 : "${AUTOBOT_NOVNC_PATH:=/opt/novnc}"
 : "${NETWORK_SUBNET:=}"
 
+# ---------------------------------------------------------------------------
+# 3b. #14173 -- the four var families #14041 deliberately left unexported
+#     because nothing defined them anywhere. Each now has a real SSOT field
+#     in autobot_shared/ssot_config.py; values below mirror those defaults.
+# ---------------------------------------------------------------------------
+
+# PathConfig.management_ssh_key_path (alias AUTOBOT_SSH_KEY) -- distinct from
+# PathConfig.ssh_key_path (AUTOBOT_SSH_KEY_PATH/SLM_SSH_KEY, #12429). This is
+# the operator's own key, generated under $HOME by
+# utilities/setup-ssh-keys.sh; ssh_key_path is the service account's key
+# under /etc/autobot, deployed by Ansible. Deliberately NOT the same default
+# -- see the field comment in ssot_config.py for the evidence.
+: "${AUTOBOT_SSH_KEY:=${HOME}/.ssh/autobot_key}"
+
+# PathConfig.ssh_user
+: "${AUTOBOT_SSH_USER:=autobot}"
+
+# MiscConfig.slm_node_id
+: "${AUTOBOT_SLM_NODE_ID:=00-SLM-Manager}"
+
+# VNC: network/network-config.sh is the only script that reads all four
+# AUTOBOT_VNC_* names below. WEB is the noVNC/websockify HTTP port and runs
+# on the same machine as the backend (Main/WSL) -- it now consolidates onto
+# the two names that were already canonical (AUTOBOT_BACKEND_HOST,
+# AUTOBOT_VNC_PORT) instead of carrying its own separate, coincidentally-equal
+# literal. SERVER is the raw VNC protocol port (x11vnc), a genuinely separate
+# concept with no prior SSOT source -- PortConfig.vnc_server's field comment
+# has the derivation (5900 + vnc_display, corrected from the script's stale
+# 5902 literal to 5901).
+: "${AUTOBOT_VNC_WEB_HOST:=${AUTOBOT_BACKEND_HOST}}"
+: "${AUTOBOT_VNC_WEB_PORT:=${AUTOBOT_VNC_PORT}}"
+: "${AUTOBOT_VNC_SERVER_HOST:=${AUTOBOT_BACKEND_HOST}}"
+: "${AUTOBOT_VNC_SERVER_PORT:=5901}"
+
 export AUTOBOT_BACKEND_HOST AUTOBOT_FRONTEND_HOST AUTOBOT_NPU_WORKER_HOST \
     AUTOBOT_REDIS_HOST AUTOBOT_AI_STACK_HOST AUTOBOT_BROWSER_SERVICE_HOST \
     AUTOBOT_SLM_HOST AUTOBOT_OLLAMA_HOST \
@@ -136,7 +170,9 @@ export AUTOBOT_BACKEND_HOST AUTOBOT_FRONTEND_HOST AUTOBOT_NPU_WORKER_HOST \
     AUTOBOT_REDIS_PORT AUTOBOT_AI_STACK_PORT AUTOBOT_BROWSER_SERVICE_PORT \
     AUTOBOT_OLLAMA_PORT AUTOBOT_VNC_PORT \
     AUTOBOT_REDIS_PASSWORD AUTOBOT_REDIS_DB_CELERY_BROKER AUTOBOT_REDIS_DB_CELERY_RESULTS \
-    AUTOBOT_NOVNC_PATH NETWORK_SUBNET
+    AUTOBOT_NOVNC_PATH NETWORK_SUBNET \
+    AUTOBOT_SSH_KEY AUTOBOT_SSH_USER AUTOBOT_SLM_NODE_ID \
+    AUTOBOT_VNC_WEB_HOST AUTOBOT_VNC_WEB_PORT AUTOBOT_VNC_SERVER_HOST AUTOBOT_VNC_SERVER_PORT
 
 # ---------------------------------------------------------------------------
 # 4. VMS associative array -- vm-management/status-all-vms.sh is the one script

--- a/autobot-infrastructure/shared/scripts/network/network-config.sh
+++ b/autobot-infrastructure/shared/scripts/network/network-config.sh
@@ -43,8 +43,10 @@ export VNC_WEB_HOST="${AUTOBOT_VNC_WEB_HOST:-localhost}"
 export VNC_WEB_PORT="${AUTOBOT_VNC_WEB_PORT:-6080}"
 export VNC_WEB_URL="http://${VNC_WEB_HOST}:${VNC_WEB_PORT}"
 
+# 5901, not 5902 (#14173 review) -- matches ssot-config.sh/ssot_config.py's
+# PortConfig.vnc_server: 5900 + vnc_display, vnc_display default 1.
 export VNC_SERVER_HOST="${AUTOBOT_VNC_SERVER_HOST:-localhost}"
-export VNC_SERVER_PORT="${AUTOBOT_VNC_SERVER_PORT:-5902}"
+export VNC_SERVER_PORT="${AUTOBOT_VNC_SERVER_PORT:-5901}"
 
 # Log configuration loaded
 echo "✅ Network configuration loaded:"

--- a/autobot-infrastructure/shared/scripts/network/network-health-monitor.sh
+++ b/autobot-infrastructure/shared/scripts/network/network-health-monitor.sh
@@ -124,11 +124,15 @@ echo "🛡️ Security Status:"
 echo "-------------------"
 
 # VNC Security Check
+# Port from network-config.sh's VNC_SERVER_PORT (#14173 review) -- was a
+# hardcoded :5902 literal with no variable, so the port-fallback guard
+# (tools/lint/check_port_fallbacks_match_ssot.py) could never see it; the
+# real raw-VNC listener has always been 5901 (ssot_config.py PortConfig.vnc_server).
 echo -n "🔒 VNC Server Binding: "
-if netstat -tuln | grep ":5902" | grep -q "127.0.0.1\|::1"; then
+if netstat -tuln | grep ":${VNC_SERVER_PORT}" | grep -q "127.0.0.1\|::1"; then
     echo "✅ SECURE (localhost only)"
 else
-    if netstat -tuln | grep -q ":5902"; then
+    if netstat -tuln | grep -q ":${VNC_SERVER_PORT}"; then
         echo "⚠️  EXPOSED (not localhost-bound)"
     else
         echo "❌ NOT RUNNING"

--- a/autobot-infrastructure/shared/tests/test_ssot_config_lib.sh
+++ b/autobot-infrastructure/shared/tests/test_ssot_config_lib.sh
@@ -282,6 +282,131 @@ else
     fail=$((fail + 1))
 fi
 
+# --- #14173: the four var families #14041 deliberately left unexported now
+#     have real SSOT fields (autobot_shared/ssot_config.py) and the library
+#     exports them. ------------------------------------------------------
+
+out=$(bash -c "
+export HOME='/nonexistent-home-for-ssot-test'
+unset AUTOBOT_SSH_KEY AUTOBOT_SSH_USER AUTOBOT_SLM_NODE_ID AUTOBOT_VNC_WEB_PORT AUTOBOT_VNC_SERVER_PORT
+source '$LIB'
+echo \"\$AUTOBOT_SSH_KEY|\$AUTOBOT_SSH_USER|\$AUTOBOT_SLM_NODE_ID|\$AUTOBOT_VNC_WEB_PORT|\$AUTOBOT_VNC_SERVER_PORT\"
+")
+check "14173: SSH/SLM/VNC families get SSOT defaults" "$out" \
+    "/nonexistent-home-for-ssot-test/.ssh/autobot_key|autobot|00-SLM-Manager|6080|5901"
+
+# --- VNC WEB/SERVER host derive from AUTOBOT_BACKEND_HOST, not a separate
+#     hardcoded literal -- proves the four-name fork actually consolidated
+#     onto an existing canonical field instead of gaining its own literal. --
+out=$(bash -c "
+export AUTOBOT_BACKEND_HOST='10.9.8.7'
+unset AUTOBOT_VNC_WEB_HOST AUTOBOT_VNC_SERVER_HOST
+source '$LIB'
+echo \"\$AUTOBOT_VNC_WEB_HOST|\$AUTOBOT_VNC_SERVER_HOST\"
+")
+check "14173: VNC_WEB_HOST/VNC_SERVER_HOST derive from AUTOBOT_BACKEND_HOST" "$out" "10.9.8.7|10.9.8.7"
+
+# --- .env override still wins for the four new families too ---------------
+tmp_root3="$(mktemp -d)"
+cat > "$tmp_root3/.env" <<'ENVEOF'
+AUTOBOT_SSH_USER=custom-user
+AUTOBOT_SLM_NODE_ID=99-Custom-Manager
+ENVEOF
+out=$(bash -c "
+export PROJECT_ROOT='$tmp_root3'
+unset AUTOBOT_SSH_USER AUTOBOT_SLM_NODE_ID
+source '$LIB'
+echo \"\$AUTOBOT_SSH_USER:\$AUTOBOT_SLM_NODE_ID\"
+")
+rm -rf "$tmp_root3"
+check "14173: .env override wins for AUTOBOT_SSH_USER/AUTOBOT_SLM_NODE_ID" "$out" "custom-user:99-Custom-Manager"
+
+# --- DENIAL / reproduction: status-all-vms.sh's own "SSH key not found"
+#     guard used to fire even when a real key existed at the conventional
+#     $HOME/.ssh/autobot_key path, because the library never set
+#     AUTOBOT_SSH_KEY (#14173) -- SSH_KEY="$AUTOBOT_SSH_KEY"
+#     (vm-management/status-all-vms.sh, NO `:-` fallback at all) always
+#     resolved to the empty string. Reproduces the exact guard line read out
+#     of the live script rather than re-describing it by hand, so a future
+#     edit that changes the guard shape trips this test instead of silently
+#     drifting from what actually ships (same idiom as the bootstrap-slm.sh
+#     capture-before-source guard test above).
+_status_script="${REPO_ROOT}/autobot-infrastructure/shared/scripts/vm-management/status-all-vms.sh"
+_key_line=$(grep -m1 '^SSH_KEY=' "$_status_script")
+if [ -z "$_key_line" ]; then
+    echo "FAIL: status-all-vms.sh no longer has the SSH_KEY=\$AUTOBOT_SSH_KEY line this test expects"
+    fail=$((fail + 1))
+else
+    tmp_home="$(mktemp -d)"
+    mkdir -p "$tmp_home/.ssh"
+    printf 'not a real key, just needs to exist\n' > "$tmp_home/.ssh/autobot_key"
+
+    # BEFORE (reproduction of the pre-#14173 bug): the library never exported
+    # AUTOBOT_SSH_KEY, so the guard fires even though a real key file exists
+    # at the conventional path -- a silent lie, not a loud failure.
+    before_out=$(bash -c "
+        export HOME='$tmp_home'
+        unset AUTOBOT_SSH_KEY
+        $_key_line
+        if [ ! -f \"\$SSH_KEY\" ]; then echo NO_KEY_FOUND; else echo KEY_FOUND; fi
+    ")
+    check "DENIAL repro: pre-#14173 state reports NO_KEY_FOUND despite a real key on disk" "$before_out" "NO_KEY_FOUND"
+
+    # AFTER (fixed): sourcing the library resolves AUTOBOT_SSH_KEY to the same
+    # conventional path, so the guard now finds the real key instead of lying.
+    after_out=$(bash -c "
+        export HOME='$tmp_home'
+        unset AUTOBOT_SSH_KEY
+        source '$LIB'
+        $_key_line
+        if [ ! -f \"\$SSH_KEY\" ]; then echo NO_KEY_FOUND; else echo KEY_FOUND; fi
+    ")
+    check "14173 fix: library-resolved AUTOBOT_SSH_KEY finds the real key" "$after_out" "KEY_FOUND"
+
+    rm -rf "$tmp_home"
+fi
+
+# --- Reach self-check: must NOT share the "autobot-infrastructure/ only"
+#     blind spot that undercounted shape-D above (Step 3 note) -- scoped on
+#     `git ls-files -- '*.sh'` (full tracked tree, same anchor as the
+#     offenders guard above), never a subdirectory grep. Two independent
+#     assertions: the file-count floor catches a probe that silently stops
+#     matching anything (an empty/near-empty result reads as "clean" unless
+#     presence is checked, not absence of failure); the var-count floor
+#     catches a regex that stops matching a variable shape. -----------------
+_all_sh_files="$(cd "$REPO_ROOT" && git ls-files -- '*.sh')"
+_sh_count=$(echo "$_all_sh_files" | grep -c . || true)
+if [ "$_sh_count" -lt 100 ]; then
+    echo "FAIL: reach self-check scanned too few shell scripts ($_sh_count) -- probe is too narrow"
+    fail=$((fail + 1))
+else
+    echo "PASS: reach self-check scanned $_sh_count tracked shell scripts"
+    pass=$((pass + 1))
+fi
+
+_distinct_vars=$(cd "$REPO_ROOT" && git ls-files -- '*.sh' | xargs grep -ohE '\$\{?AUTOBOT_[A-Z0-9_]+' 2>/dev/null | sed -E 's/^\$\{?//' | sort -u)
+_distinct_count=$(echo "$_distinct_vars" | grep -c . || true)
+if [ "$_distinct_count" -lt 61 ]; then
+    echo "FAIL: reach self-check found only $_distinct_count distinct AUTOBOT_ names -- expected >= 61 (#14173 baseline)"
+    fail=$((fail + 1))
+else
+    echo "PASS: reach self-check found $_distinct_count distinct AUTOBOT_ names (>= 61 baseline)"
+    pass=$((pass + 1))
+fi
+
+# The counter's own scan must independently rediscover the four #14173
+# families -- not just confirm a hardcoded list matches itself.
+for _fam_var in AUTOBOT_SSH_KEY AUTOBOT_SSH_USER AUTOBOT_SLM_NODE_ID \
+    AUTOBOT_VNC_WEB_HOST AUTOBOT_VNC_WEB_PORT AUTOBOT_VNC_SERVER_HOST AUTOBOT_VNC_SERVER_PORT; do
+    if echo "$_distinct_vars" | grep -qx "$_fam_var"; then
+        echo "PASS: reach self-check's scan independently found $_fam_var"
+        pass=$((pass + 1))
+    else
+        echo "FAIL: reach self-check's scan did not find $_fam_var -- matcher regressed"
+        fail=$((fail + 1))
+    fi
+done
+
 echo
 echo "=== $pass passed, $fail failed ==="
 [ "$fail" -eq 0 ]

--- a/autobot-slm-backend/tests/test_canonical_ssh_key.py
+++ b/autobot-slm-backend/tests/test_canonical_ssh_key.py
@@ -84,6 +84,28 @@ def test_inventories_use_canonical_ssh_key_var():
     )
 
 
+def test_management_ssh_key_never_used_for_inter_node_ssh():
+    """#14173: config.path.management_ssh_key_path/.management_ssh_key is the
+    operator's own $HOME key for management scripts a human runs -- it is
+    NOT ssh_key_path/.ssh_key, the service account's key deployed by Ansible
+    for automated fleet orchestration. Reusing it here would reintroduce
+    #12429's split at a new layer.
+    """
+    offenders: list[str] = []
+    for path in _runtime_py_files():
+        text = path.read_text(encoding="utf-8")
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if "management_ssh_key" in line:
+                rel = path.relative_to(_BACKEND_ROOT)
+                offenders.append(f"{rel}:{lineno}: {line.strip()}")
+    assert not offenders, (
+        "Inter-node SSH orchestration must use config.path.ssh_key_path/.ssh_key "
+        "(#12429), never config.path.management_ssh_key_path/.management_ssh_key "
+        "(#14173, a different key for a different consumer). Found:\n"
+        + "\n".join(offenders)
+    )
+
+
 def test_canonical_ssh_key_var_defined_once():
     """The single canonical Ansible var exists with the /etc default (#12429)."""
     all_yml = _BACKEND_ROOT / "ansible" / "inventory" / "group_vars" / "all.yml"

--- a/autobot-slm-backend/tests/test_canonical_ssh_key.py
+++ b/autobot-slm-backend/tests/test_canonical_ssh_key.py
@@ -101,8 +101,7 @@ def test_management_ssh_key_never_used_for_inter_node_ssh():
     assert not offenders, (
         "Inter-node SSH orchestration must use config.path.ssh_key_path/.ssh_key "
         "(#12429), never config.path.management_ssh_key_path/.management_ssh_key "
-        "(#14173, a different key for a different consumer). Found:\n"
-        + "\n".join(offenders)
+        "(#14173, a different key for a different consumer). Found:\n" + "\n".join(offenders)
     )
 
 

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -198,6 +198,15 @@ class PortConfig(RedactedSettings):
     redis: int = Field(default=6379, alias="AUTOBOT_REDIS_PORT")
     ollama: int = Field(default=11434, alias="AUTOBOT_OLLAMA_PORT")
     vnc: int = Field(default=6080, alias="AUTOBOT_VNC_PORT")
+    # Raw VNC protocol port (x11vnc via vncserver), NOT the noVNC web port
+    # above (#14173). autobot-slm-backend/ansible/roles/vnc/defaults/main.yml
+    # computes this as 5900 + vnc_display, and vnc_display defaults to 1 ->
+    # 5901; vm-management/status-all-vms.sh independently hardcodes the same
+    # "VNC Client: localhost:5901" line. network/network-config.sh's own
+    # AUTOBOT_VNC_SERVER_PORT literal was 5902 -- one off from every other
+    # source of truth in the repo -- so 5901 here is a correction, not a
+    # preserved literal.
+    vnc_server: int = Field(default=5901, alias="AUTOBOT_VNC_SERVER_PORT")
     browser: int = Field(default=9001, alias="AUTOBOT_BROWSER_SERVICE_PORT")  # Issue #4052: 9001; 3000 is Grafana
     aistack: int = Field(default=8080, alias="AUTOBOT_AI_STACK_PORT")
     chromadb: int = Field(default=8100, alias="AUTOBOT_CHROMADB_PORT")  # Issue #3094: 8100 matches Ansible deploy
@@ -1359,6 +1368,31 @@ class PathConfig(RedactedSettings):
         validation_alias=AliasChoices("AUTOBOT_SSH_KEY_PATH", "SLM_SSH_KEY"),
     )
 
+    # Management-plane SSH key (#14173) — DISTINCT from ssh_key_path above, not
+    # an alias of it. autobot-infrastructure/shared/scripts/utilities/setup-ssh-keys.sh
+    # generates and deploys THIS key under the operator's own $HOME the first
+    # time a human runs the vm-management/utilities scripts from their own
+    # workstation; ssh_key_path is the service account's key, deployed by
+    # Ansible to /etc/autobot/ssh for automated fleet orchestration (SLM
+    # backend, code-sync agents). The two are provably different files with
+    # different owners and different consumers — #14173's audit found ~24
+    # scripts reading AUTOBOT_SSH_KEY with a $HOME-relative fallback and
+    # confirmed collapsing it onto ssh_key_path's /etc default would silently
+    # break the human-operator flow, so this stays a second field rather than
+    # a rename or an alias.
+    management_ssh_key_path: str = Field(
+        default_factory=lambda: str(Path.home() / ".ssh" / "autobot_key"),
+        alias="AUTOBOT_SSH_KEY",
+    )
+
+    # SSH user for inter-node connections from management scripts (#14173).
+    # Not a path, but belongs beside the two SSH key fields above — same
+    # feature (fleet SSH identity). Matches the 'autobot' operational account
+    # (autobot-slm-backend/ansible/ansible.cfg remote_user,
+    # inventory/*.yml ansible_user, inventory/group_vars/all.yml
+    # autobot_ssh_key_path's owning account).
+    ssh_user: str = Field(default="autobot", alias="AUTOBOT_SSH_USER")
+
     # Explicit override for the `claude` CLI binary used by the LLC claude_code
     # adapter (GH#12478). Empty string means "not configured" — the adapter falls
     # back to shutil.which("claude") then common per-user install locations before
@@ -1419,6 +1453,11 @@ class PathConfig(RedactedSettings):
     def ssh_pubkey_path(self) -> str:
         """Path to the canonical inter-node SSH public key (private key + .pub)."""
         return f"{self.ssh_key_path}.pub"
+
+    @property
+    def management_ssh_key(self) -> Path:
+        """Absolute path to the management-plane SSH key (#14173, distinct from ssh_key)."""
+        return Path(self.management_ssh_key_path)
 
 
 class MiscConfig(RedactedSettings):
@@ -2038,6 +2077,13 @@ class MiscConfig(RedactedSettings):
     discord_bot_token: str = Field(default="", alias="DISCORD_BOT_TOKEN")
     slack_notifications_channel: str = Field(default="", alias="SLACK_NOTIFICATIONS_CHANNEL")
     slm_auth_token: str = Field(default="", alias="SLM_AUTH_TOKEN")
+    # SLM manager's DB node_id (#14173, #9956). Deployments may rename the
+    # node; this default matches the inventory default (slm_server host in
+    # autobot-slm-backend/ansible/inventory/slm-nodes.yml) and the Ansible
+    # fact derived from it (inventory/group_vars/all.yml slm_manager_node_id).
+    # Overridable per-deployment via AUTOBOT_SLM_NODE_ID; no SSOT source
+    # existed under this name before this field.
+    slm_node_id: str = Field(default="00-SLM-Manager", alias="AUTOBOT_SLM_NODE_ID")
     slm_url: str = Field(default="", alias="SLM_URL")
     skill_hub_url: str = Field(default="", alias="AUTOBOT_SKILL_HUB_URL")
     testing: str = Field(default="", alias="TESTING")

--- a/autobot_shared/ssot_config_test.py
+++ b/autobot_shared/ssot_config_test.py
@@ -681,6 +681,93 @@ class TestAuditLogFileLazyDefault:
         assert cfg.audit_log_file == "/opt/autobot/logs/audit.log"
 
 
+class TestShellVarFamiliesWithNoPriorSsot14173:
+    """#14173: four AUTOBOT_ shell var families that ~24-56 scripts under
+    autobot-infrastructure/ read but nothing defined anywhere (not
+    ssot_config.py, not .env.example, not Ansible group_vars) now have real
+    SSOT fields -- one per family, matching
+    autobot-infrastructure/shared/scripts/lib/ssot-config.sh's shell-side
+    defaults so both languages agree.
+    """
+
+    def test_ssh_user_default(self, monkeypatch) -> None:
+        from autobot_shared.ssot_config import PathConfig
+
+        monkeypatch.delenv("AUTOBOT_SSH_USER", raising=False)
+        cfg = PathConfig(_env_file=None)
+        assert cfg.ssh_user == "autobot"
+
+    def test_ssh_user_honors_env(self, monkeypatch) -> None:
+        from autobot_shared.ssot_config import PathConfig
+
+        monkeypatch.setenv("AUTOBOT_SSH_USER", "custom-user")
+        cfg = PathConfig(_env_file=None)
+        assert cfg.ssh_user == "custom-user"
+
+    def test_management_ssh_key_path_resolves_under_home_when_unset(self, monkeypatch) -> None:
+        from autobot_shared.ssot_config import PathConfig
+
+        monkeypatch.delenv("AUTOBOT_SSH_KEY", raising=False)
+        cfg = PathConfig(_env_file=None)
+        assert cfg.management_ssh_key_path == str(Path.home() / ".ssh" / "autobot_key")
+
+    def test_management_ssh_key_path_distinct_from_ssh_key_path(self, monkeypatch) -> None:
+        """NOT an alias of ssh_key_path (#12429) -- the two are provably
+        different files with different owners and different consumers (see
+        the field comment in ssot_config.py). A regression that collapses
+        them onto one field/value would silently break whichever flow lost.
+        """
+        from autobot_shared.ssot_config import PathConfig
+
+        monkeypatch.delenv("AUTOBOT_SSH_KEY", raising=False)
+        monkeypatch.delenv("AUTOBOT_SSH_KEY_PATH", raising=False)
+        monkeypatch.delenv("SLM_SSH_KEY", raising=False)
+        cfg = PathConfig(_env_file=None)
+        assert cfg.management_ssh_key_path != cfg.ssh_key_path
+        assert cfg.ssh_key_path == "/etc/autobot/ssh/autobot_key"
+
+    def test_management_ssh_key_path_honors_env(self, monkeypatch) -> None:
+        from autobot_shared.ssot_config import PathConfig
+
+        monkeypatch.setenv("AUTOBOT_SSH_KEY", "/tmp/custom-key-14173")
+        monkeypatch.delenv("AUTOBOT_SSH_KEY_PATH", raising=False)
+        monkeypatch.delenv("SLM_SSH_KEY", raising=False)
+        cfg = PathConfig(_env_file=None)
+        assert cfg.management_ssh_key_path == "/tmp/custom-key-14173"
+        # Setting AUTOBOT_SSH_KEY must never move the unrelated service-account key.
+        assert cfg.ssh_key_path == "/etc/autobot/ssh/autobot_key"
+
+    def test_slm_node_id_default(self, monkeypatch) -> None:
+        from autobot_shared.ssot_config import MiscConfig
+
+        monkeypatch.delenv("AUTOBOT_SLM_NODE_ID", raising=False)
+        cfg = MiscConfig(_env_file=None)
+        assert cfg.slm_node_id == "00-SLM-Manager"
+
+    def test_slm_node_id_honors_env(self, monkeypatch) -> None:
+        from autobot_shared.ssot_config import MiscConfig
+
+        monkeypatch.setenv("AUTOBOT_SLM_NODE_ID", "99-Custom-Manager")
+        cfg = MiscConfig(_env_file=None)
+        assert cfg.slm_node_id == "99-Custom-Manager"
+
+    def test_vnc_server_port_default(self, monkeypatch) -> None:
+        from autobot_shared.ssot_config import PortConfig
+
+        monkeypatch.delenv("AUTOBOT_VNC_SERVER_PORT", raising=False)
+        cfg = PortConfig(_env_file=None)
+        assert cfg.vnc_server == 5901
+        # Distinct from the noVNC web port -- same VM, different protocol/port.
+        assert cfg.vnc_server != cfg.vnc
+
+    def test_vnc_server_port_honors_env(self, monkeypatch) -> None:
+        from autobot_shared.ssot_config import PortConfig
+
+        monkeypatch.setenv("AUTOBOT_VNC_SERVER_PORT", "5999")
+        cfg = PortConfig(_env_file=None)
+        assert cfg.vnc_server == 5999
+
+
 class TestNoHardcodedLiveInstallLiterals:
     """Sweep guard (#14050 AC): no ``/opt/autobot`` Field default literal may
     return to this file. A regex over the source, not an import-time check,

--- a/autobot_shared/tests/test_config_repr_redaction_13325.py
+++ b/autobot_shared/tests/test_config_repr_redaction_13325.py
@@ -236,7 +236,24 @@ MUST_STAY_VISIBLE = {
         "tokenizers_parallelism",
     ],
     "tls": ["ca_cert", "cert_dir", "remote_cert_dir"],
-    "path": ["ssh_key_path", "vnc_passwd_file"],
+    "path": [
+        # Service-account inter-node key (#12429) -- location of a credential,
+        # not the credential; `is_credential_field` already excludes it via the
+        # `_path` LOCATION_SUFFIX, this entry only satisfies the broader
+        # name-heuristic sweep below that a "*key*" substring anywhere trips.
+        "ssh_key_path",
+        "vnc_passwd_file",
+        # Operator's own key (#14173), deliberately a SEPARATE field from
+        # ssh_key_path above (different owner, different consumer -- see the
+        # field comment in autobot_shared/ssot_config.py). Classified the SAME
+        # as its sibling for the SAME reason: it is a path to a key, not key
+        # material, and its default (~/.ssh/autobot_key) names no real
+        # user/host/environment. A deployment-supplied override could in
+        # principle embed something sensitive in the path string, but that
+        # risk is identical to ssh_key_path's own overridable default and is
+        # not treated differently there either.
+        "management_ssh_key_path",
+    ],
     "auth": ["google_oauth_client_id", "microsoft_oauth_client_id"],
     "llm": ["searxng_basic_auth_user"],
 }

--- a/docs/audit/ssot_config_shell_library_14041.md
+++ b/docs/audit/ssot_config_shell_library_14041.md
@@ -180,19 +180,40 @@ somewhere materially different and wrong — this lands as a single change, not 
 The one real-value divergence (`AUTOBOT_BROWSER_SERVICE_PORT`) is a correction the
 scripts have needed since #4052 renumbered the port away from Grafana's.
 
-## Follow-up (filed separately, not blocking this PR)
+## Follow-up (filed separately, not blocking this PR) -- RESOLVED by #14173
 
 - `AUTOBOT_SSH_KEY` (script convention) vs `AUTOBOT_SSH_KEY_PATH`/`SLM_SSH_KEY` (SSOT,
   #12429) is a naming split across the same concept — deciding whether to alias or
   rename is a scope call for the owner, not something to invent silently here.
+  **Resolved (#14173):** confirmed deliberately different, not aliased.
+  `utilities/setup-ssh-keys.sh` generates and deploys `AUTOBOT_SSH_KEY` under the
+  *operator's* own `$HOME` for management scripts a human runs from their own
+  workstation; `ssh_key_path`/`AUTOBOT_SSH_KEY_PATH` is the *service account's* key,
+  deployed by Ansible to `/etc/autobot/ssh` for automated fleet orchestration. Both
+  are now real, separate fields (`PathConfig.management_ssh_key_path` and
+  `PathConfig.ssh_key_path`) with a guard test
+  (`autobot-slm-backend/tests/test_canonical_ssh_key.py`) asserting the SLM backend
+  runtime never references the management-plane one.
 - `AUTOBOT_SSH_USER` and `AUTOBOT_SLM_NODE_ID` have no SSOT entry anywhere (Python,
   `.env.example`, or Ansible `group_vars`) — either they should be added to
   `autobot_shared/ssot_config.py`, or the scripts should stop presenting them as
-  SSOT-backed.
+  SSOT-backed. **Resolved (#14173):** added as `PathConfig.ssh_user` (default
+  `autobot`, matching `ansible.cfg remote_user`) and `MiscConfig.slm_node_id`
+  (default `00-SLM-Manager`, matching the `slm-nodes.yml` inventory default).
 - The four `AUTOBOT_VNC_*` names have no field under their exact names, but two closer
   candidates already exist and are just as unused by these scripts:
   `AUTOBOT_VNC_PORT` (`PortConfig`, 6080) and `AUTOBOT_VNC_HOST`
   (`ssot_config.py:1853`, `MiscConfig`, default `""`). Behaviour is unchanged either way
   (the library still exports neither the four script-side names nor rewires them to the
   two SSOT names), but this narrows the follow-up to "consolidate four names down to
-  two that already exist" rather than "invent new SSOT fields".
+  two that already exist" rather than "invent new SSOT fields". **Resolved (#14173):**
+  `AUTOBOT_VNC_WEB_HOST`/`AUTOBOT_VNC_WEB_PORT` (noVNC/websockify) now derive from
+  `AUTOBOT_BACKEND_HOST`/`AUTOBOT_VNC_PORT` — not `AUTOBOT_VNC_HOST`, which turned out
+  to be a bind-address override (`vnc_url` never reads it) rather than a
+  connect-to host. `AUTOBOT_VNC_SERVER_HOST`/`AUTOBOT_VNC_SERVER_PORT` (the raw VNC
+  protocol port, a genuinely separate concept) get a new field,
+  `PortConfig.vnc_server`, default `5901` — a correction of the script's stale `5902`
+  literal, derived from `vnc_display` (default `1`) in
+  `autobot-slm-backend/ansible/roles/vnc/defaults/main.yml` and independently
+  confirmed by `vm-management/status-all-vms.sh`'s own hardcoded
+  `"VNC Client: localhost:5901"` line.


### PR DESCRIPTION
## Thinking Path

#14041 built the shell-side SSOT reader (`autobot-infrastructure/shared/scripts/lib/ssot-config.sh`) for 56 scripts but deliberately left out `AUTOBOT_SSH_KEY`, `AUTOBOT_SSH_USER`, `AUTOBOT_SLM_NODE_ID`, and the four `AUTOBOT_VNC_*` names — none of them had a canonical value anywhere, and inventing one would have been a second source of truth. #14173 asks: either give them a real SSOT field, or stop the scripts from implying they're SSOT-backed.

I re-derived the enumeration rather than trusting the issue's "4" (it's 4 *families*, 7 distinct variable names — matches the #14041 audit doc's own count). For each, I traced who actually reads it and where the value currently comes from, rather than inventing a default:

- **`AUTOBOT_SSH_KEY`** — the issue flagged an owner call: alias to the canonical `ssh_key_path`/`AUTOBOT_SSH_KEY_PATH` (#12429), or confirm they're deliberately different. `utilities/setup-ssh-keys.sh` **generates and deploys** `AUTOBOT_SSH_KEY` under the *operator's own `$HOME`* the first time a human runs it from their workstation; `ssh_key_path` is the *service account's* key, deployed by Ansible to `/etc/autobot/ssh` for automated fleet orchestration (SLM backend, code-sync agents) — the existing `test_canonical_ssh_key.py` guard (#12429) explicitly forbids that path appearing in SLM backend runtime code. These are provably different files with different owners and different consumers, so I did **not** alias or rename — I added a second field, `PathConfig.management_ssh_key_path`, and a guard test asserting the SLM backend runtime never references it.
- **`AUTOBOT_SSH_USER`** — no field anywhere. Added `PathConfig.ssh_user` (default `autobot`), matching `ansible.cfg remote_user` / inventory `ansible_user`.
- **`AUTOBOT_SLM_NODE_ID`** — no field anywhere. Added `MiscConfig.slm_node_id` (default `00-SLM-Manager`), matching the `slm-nodes.yml` inventory default and the Ansible fact derived from it (`slm_manager_node_id`).
- **The four `AUTOBOT_VNC_*` names** — `network/network-config.sh` is the only script reading all four. Tracing `config.vnc_url` (`self.vm.main` + `self.port.vnc`) showed the `WEB` pair (noVNC/websockify) is the *same concept* as the already-canonical `AUTOBOT_BACKEND_HOST`/`AUTOBOT_VNC_PORT` — not `AUTOBOT_VNC_HOST` (a closer name-match the #14041 audit flagged, but that field turned out to be a bind-address override never read by `vnc_url`, so using it as a connect-to host would have been wrong). The `SERVER` pair (raw VNC protocol, x11vnc) is a genuinely separate concept with no prior SSOT anywhere — I derived its port from `ansible/roles/vnc/defaults/main.yml`'s `vnc_display` default (`1` → `5900+1=5901`), independently confirmed by `status-all-vms.sh`'s own hardcoded `"VNC Client: localhost:5901"` line. The script's own `AUTOBOT_VNC_SERVER_PORT` literal was `5902` — one off from every other source of truth in the repo — so `5901` is a correction, not a preserved literal.

**Post-push addendum:** adding `PortConfig.vnc_server` tripped `src/config/__tests__/ssot-parity.spec.ts`'s "no new Python-only port" guard (#13074) — correctly: a port defined on one side only is exactly the drift #13074 exists to catch, and the guard forces a deliberate choice rather than a silent one. I checked whether the frontend needs the raw VNC protocol port before deciding: grepped for `5901` and any `AUTOBOT_VNC_SERVER_PORT` read across `autobot-frontend/src`. No file reads `AUTOBOT_VNC_SERVER_PORT`. Two kinds of hardcoded `5901` exist, both non-functional: the `*.test.ts` mocks (an unrelated per-session `vnc_port` value returned dynamically by `AdvancedControlApiClient`, live per-host data from the backend, not a static SSOT default), and `SecretsManager.vue`'s `placeholder="5901"` on a per-host VNC-port form field — a UI example hint on user-entered data, not a default sourced from anywhere. *(Correction from an earlier draft of this note, which said no `5901` existed outside `*.test.ts` — the `SecretsManager.vue` placeholder was missed; flagged in review.)* The frontend's own desktop viewer already mirrors the *web* port (`PORT_DEFAULTS.vnc`, noVNC/websockify) — it has no code path that would ever open a raw x11vnc socket directly. That makes this option B: genuinely backend-only, allow-listed with its reason recorded inline rather than a bare name (see What Changed).

**Second post-push addendum:** the same field also tripped the #13325 repr-redaction ground-truth guard (`test_classifier_covers_every_str_field_named_like_a_credential`) — `management_ssh_key_path` contains "key" so it matches the guard's deliberately broad, classifier-independent name heuristic, and wasn't in any of the three triage lists. Checked before classifying: the default (`~/.ssh/autobot_key`) names no real user/host, so the path itself isn't sensitive in this deployment; and the sibling `ssh_key_path` (#12429, the service-account key) is triaged `MUST_STAY_VISIBLE` for exactly the reason that applies here too — it's a *location of* a credential, not the credential, and `secret_redaction.is_credential_field()` already excludes both via the `_path` `LOCATION_SUFFIX` before the guard's broader sweep even runs. Classified it the same as its sibling: safe / visible, not masked, with the reason recorded inline in the ground-truth list rather than as a bare name (same rot problem the `PYTHON_ONLY_PORTS` list had).

**Third post-push addendum (review round):** three more findings, all fixed in this PR:
1. **HIGH** — `network-config.sh`'s own `AUTOBOT_VNC_SERVER_PORT` fallback still read the stale `5902` (this PR changed the SSOT default to `5901` everywhere else but missed this pre-existing consumer). `tools/lint/check_port_fallbacks_match_ssot.py` (#14198) caught it as a hook finding, but `enforce-precommit.yml` doesn't fail the build on hook findings yet (#14462), so it landed on an otherwise-green PR. Corrected to `5901`.
2. **MEDIUM** — `network-health-monitor.sh` hardcoded `:5902` directly in a `netstat` health check (no variable, so the guard above could never see it) — reporting a healthy 5901 listener as NOT RUNNING. Now reads `network-config.sh`'s own `VNC_SERVER_PORT` instead.
3. **LOW** — `ssot-parity.spec.ts`'s `chromadb`/`tts`/`chrome_cdp` reasons cited issue numbers (#3094/#3829/#928) inherited verbatim from `ssot_config.py`'s field comments, where they justify the port NUMBER — not the frontend/backend-boundary claim attached to them here. Dropped the wrong citations, stated the architectural reason plainly.

Verified `check_port_fallbacks_match_ssot.py` now reports `every AUTOBOT_*_PORT fallback agrees with the SSOT` (only `AUTOBOT_PLAYWRIGHT_API_PORT`/`AUTOBOT_VNC_WEB_PORT` remain flagged as unverifiable — no SSOT field under those exact names by design, tracked in this issue).

## What Changed

**`autobot_shared/ssot_config.py`** — 4 new fields, one per family:
- `PathConfig.management_ssh_key_path` (alias `AUTOBOT_SSH_KEY`, default `~/.ssh/autobot_key` via `default_factory`) + `.management_ssh_key` property
- `PathConfig.ssh_user` (alias `AUTOBOT_SSH_USER`, default `autobot`)
- `MiscConfig.slm_node_id` (alias `AUTOBOT_SLM_NODE_ID`, default `00-SLM-Manager`)
- `PortConfig.vnc_server` (alias `AUTOBOT_VNC_SERVER_PORT`, default `5901`)

**`autobot-infrastructure/shared/scripts/lib/ssot-config.sh`** — new section 3b exports all 7 names:
- `AUTOBOT_SSH_KEY`, `AUTOBOT_SSH_USER`, `AUTOBOT_SLM_NODE_ID` mirror the new Python defaults
- `AUTOBOT_VNC_WEB_HOST`/`AUTOBOT_VNC_WEB_PORT` now **derive** from `AUTOBOT_BACKEND_HOST`/`AUTOBOT_VNC_PORT` instead of carrying independent literals
- `AUTOBOT_VNC_SERVER_HOST` derives from `AUTOBOT_BACKEND_HOST`; `AUTOBOT_VNC_SERVER_PORT` defaults to `5901`

**`.env.example`** — documents all 7 (`AUTOBOT_SSH_KEY`/`AUTOBOT_SSH_KEY_PATH` as commented examples since they're host-specific, `AUTOBOT_SSH_USER`/`AUTOBOT_SLM_NODE_ID`/`AUTOBOT_VNC_SERVER_PORT` as active defaults).

**`docs/audit/ssot_config_shell_library_14041.md`** — marks the 3 follow-up items RESOLVED with the reasoning above.

**`autobot-frontend/src/config/__tests__/ssot-parity.spec.ts`** — allow-lists `vnc_server` in `PYTHON_ONLY_PORTS` (option B, see Thinking Path). Also gave the 3 pre-existing entries (`chromadb`, `tts`, `chrome_cdp`) inline reasons: the list was previously bare names under one shared block comment, and a bare list rots — an entry naming a field later removed from `PortConfig` would exempt nothing while still looking authoritative, since the "still genuinely one-sided" test only checks the Python side still has the field, never *why* one-sidedness is still correct. The array literal format takes a trailing `//` comment per element without changing its `readonly string[]` type, so the reason lives right next to the name instead of in a separate doc that can drift from the list.

**`autobot_shared/tests/test_config_repr_redaction_13325.py`** — adds `path.management_ssh_key_path` to `MUST_STAY_VISIBLE`, with its classification reason recorded inline (matching its sibling `ssh_key_path`, which got the same treatment in the same edit).

**`autobot-infrastructure/shared/scripts/network/network-config.sh`** — fixes its own `AUTOBOT_VNC_SERVER_PORT` fallback (`5902` → `5901`); this PR set the SSOT default but had missed this pre-existing consumer.

**`autobot-infrastructure/shared/scripts/network/network-health-monitor.sh`** — VNC binding health check now reads `network-config.sh`'s `VNC_SERVER_PORT` instead of a second, ungoverned `:5902` literal.

**Tests:**
- `autobot_shared/ssot_config_test.py` — new `TestShellVarFamiliesWithNoPriorSsot14173` class: defaults, env overrides, and an explicit assertion that `management_ssh_key_path != ssh_key_path` (guards against a future "helpful" consolidation reintroducing #12429's bug).
- `autobot-slm-backend/tests/test_canonical_ssh_key.py` — new guard: `management_ssh_key`/`management_ssh_key_path` must never appear in SLM backend `services/`/`api/` runtime code (that's `ssh_key`/`ssh_key_path` only).
- `autobot-infrastructure/shared/tests/test_ssot_config_lib.sh` — new checks:
  - SSH/SLM/VNC families resolve to the SSOT defaults on a fresh source
  - `.env` override still wins for the new families
  - VNC_WEB_HOST/VNC_SERVER_HOST demonstrably derive from `AUTOBOT_BACKEND_HOST` (not independently hardcoded)
  - **Denial/reproduction**: reads `status-all-vms.sh`'s real `SSH_KEY="$AUTOBOT_SSH_KEY"` line (no `:-` fallback at all) and proves the pre-#14173 state reports `NO_KEY_FOUND` even when a real key exists at the conventional `$HOME/.ssh/autobot_key` path — then proves sourcing the fixed library finds it
  - **Reach self-check**: scans `git ls-files -- '*.sh'` (full tracked tree, not a subdirectory — the exact blind spot #14041 already hit once) and asserts ≥100 scripts / ≥61 distinct `AUTOBOT_` names, then confirms that scan independently rediscovers all 7 of this PR's variable names (not just a hardcoded list matching itself)

**Discovered, filed separately (different failure class — dead code, not a missing SSOT default):** #14457 — `autobot-infrastructure/shared/scripts/test_configuration.py` and `docs/configuration/VNC_PORT_CONFIGURATION.md` reference a `VNC_DISPLAY_PORT`/`VNC_CONTAINER_PORT`/`get_vnc_display_port` config scheme that doesn't exist anywhere in `autobot-backend/config/`.

## Verification

- `python3 -m py_compile` on all 3 changed Python files: clean.
- `bash -n` on both changed shell files: clean.
- Standalone mutation harness (scratch copies, never committed): built a harness reproducing the new shell-library assertions, ran it against the unmodified library (4/4 pass), then against 3 independent mutations — each confirmed `mutated != original` before running:

  | Mutation | Result |
  |---|---|
  | Drop the `AUTOBOT_SSH_KEY` export line (reintroduces the pre-#14173 bug) | 2 FAIL (defaults check + denial-fix check) |
  | Revert `AUTOBOT_VNC_SERVER_PORT` default `5901` → stale `5902` | 1 FAIL |
  | Un-consolidate `AUTOBOT_VNC_WEB_HOST` back onto its own `localhost` literal | 1 FAIL |

  Also manually verified the reach self-check's floor: a deliberately narrow scan (`autobot-infrastructure/*.sh` only, the historical #14041 blind spot) finds just 160 files / 43 distinct names — below the 100/61 floors — confirming the self-check would catch that regression too.
- No `.py`/`.sh` files were executed from the checkout itself; only `bash -n`, `py_compile`, and scratch copies were run, per policy.
- **CI fix verification:** rather than `npm install` + vitest (blocked by the no-manual-installs / never-run-code-from-the-codebase rules, and no `node_modules` present in this worktree), built a standalone Node harness (built-ins only, no install) that copies the parity spec's exact `pythonPortDefaults` regex and the `PORT_DEFAULTS`/`PYTHON_ONLY_PORTS` values, and runs it against the real `ssot_config.py` on disk:
  - With the fixed exclusion list (`vnc_server` included): `unmirrored: []` — PASS, matching what CI should now report.
  - With the pre-fix exclusion list (`vnc_server` omitted): `unmirrored: ['vnc_server']` — reproduces the exact reported `AssertionError: expected [ 'vnc_server' ] to deeply equal []` byte for byte.
- Confirmed the VNC_WEB_HOST/PORT consolidation (shell library only, deriving from the pre-existing `AUTOBOT_VNC_PORT`/`vnc` field) added no second new field to `PortConfig` — `vnc_server` is the only new port, so no second parity failure was hiding behind this one.

- **#13325 guard fix verification:** standalone harness (`/tmp/.../scratchpad/issue14173/redaction_harness.py`, copied pure logic from `secret_redaction.py` + the ground-truth guard's own regex, no import of the codebase) reproduces the exact reported failure with the pre-fix triage list (`ground_truth_guard_would_fail: true`), confirms it clears with the fix, and asserts `management_ssh_key_path`'s repr-visibility and `is_credential_field()` result are identical to sibling `ssh_key_path`'s — proving the classification matches the repr behaviour rather than just asserting the list entry exists.

- **Review-round fixes verified:** `python3 tools/lint/check_port_fallbacks_match_ssot.py` now prints `check-port-fallbacks: every AUTOBOT_*_PORT fallback agrees with the SSOT` (previously flagged `network-config.sh:47`). Standalone harness (`/tmp/.../scratchpad/issue14173/vnc_binding_harness.sh`, simulated `netstat` output, no real service) proves `network-health-monitor.sh`'s pre-fix hardcoded `:5902` reports `NOT_RUNNING` against a real 5901 listener, and the fixed `${VNC_SERVER_PORT}`-driven check reports `SECURE` against the identical input.

## Model Used

Claude Opus 5 (1M context)

Closes #14173