### PR TITLE
fix(lint): give the file-size grandfather list a ceiling that only shrinks (#14236)

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -418,6 +418,15 @@ jobs:
         # exemption naming a moved file exempts nothing and hides that it does.
         python3 tools/lint/check_extension_import_boundaries.py --audit-baseline
 
+    - name: Audit the python-file-size ceilings for drift (#14236)
+      run: |
+        # The pre-commit hook only sees staged files, so a grandfathered entry
+        # whose file shrank, moved, or was deleted would sit there exempting
+        # nothing until somebody happened to touch it. This applies the ratchet
+        # to every entry: over its ceiling, under it, or already compliant all
+        # fail, and the run reports how many entries it reached.
+        python3 scripts/check_python_file_size.py --audit-ceilings
+
     - name: Code quality summary
       if: always()
       run: |

--- a/repo_tests/python_file_size_ratchet_test.py
+++ b/repo_tests/python_file_size_ratchet_test.py
@@ -1,0 +1,235 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""#14236 — the file-size hook's grandfather list must only ever shrink.
+
+``scripts/check_python_file_size.py`` caps Python files at 600 lines and exempts
+three that were already over it. The exemption used to be a bare set of names
+with a comment claiming the files were "under active decomposition". Nothing
+checked the claim, so the three exempted modules grew to 1114, 4068 and 4063
+lines — up to 6.8x the limit — while the hook reported them clean. A guard that
+cannot lose its exemptions stops guarding without ever going red.
+
+These tests pin the ratchet in **both** directions, because only one of them is
+obvious:
+
+* the list may not gain an entry, and no ceiling may be raised (the obvious one),
+* an entry whose file has dropped to the limit must be *removed* — a list still
+  naming a compliant file exempts nothing while looking authoritative.
+
+The last test is the reach self-check. It runs the hook's own matcher over a
+tracked-file enumeration produced by ``git ls-files`` rather than by anything in
+the hook, so a matcher that has silently stopped matching cannot pass by
+agreeing with a counter that shares its blind spot.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess  # nosec B404  # fixed argv, no shell, no caller input
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPT = REPO_ROOT / "scripts" / "check_python_file_size.py"
+
+# Frozen snapshot of the exemption as it stood when the ratchet landed (#14236).
+# It is deliberately a second copy: a ratchet needs a fixed reference point, and
+# a list that is only ever compared against itself can drift anywhere. Lowering
+# a ceiling in the hook is fine and needs no edit here. Raising one, or adding a
+# fourth file, must fail — so DO NOT "sync" this dict to make a test pass.
+RATCHET_BASELINE = {
+    "autobot-backend/orchestrator.py": 1114,
+    "autobot-backend/chat_workflow/manager.py": 4068,
+    "autobot-backend/chat_workflow/tool_handler.py": 4063,
+}
+
+# Floor for the tracked-Python enumeration (4958 files at the time of writing).
+# An enumeration that returns nothing must not read as "nothing to check".
+_TRACKED_PY_FLOOR = 3000
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("check_python_file_size", _SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def hook():
+    return _load()
+
+
+@pytest.fixture(scope="module")
+def tracked_py_files() -> list[str]:
+    """Every tracked ``*.py`` path, enumerated by git rather than by the hook."""
+    out = subprocess.run(  # nosec B603 B607  # fixed argv, no shell
+        ["git", "ls-files", "*.py"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [line for line in out.stdout.splitlines() if line.strip()]
+
+
+# --------------------------------------------------------------------------
+# The exemption is a mapping with a ceiling, not a bare name
+# --------------------------------------------------------------------------
+
+
+def test_every_entry_carries_a_ceiling(hook):
+    """A name with no number is the defect this issue exists for."""
+    assert hook.KNOWN_LARGE, "the list is empty — drop the ratchet tests with it"
+    for rel, ceiling in hook.KNOWN_LARGE.items():
+        assert isinstance(ceiling, int), f"{rel} has no recorded ceiling"
+        assert ceiling > hook.MAX_LINES, f"{rel}: ceiling {ceiling} is not an exemption"
+
+
+def test_recorded_ceilings_match_the_files_today(hook):
+    """The audit is clean on the tree as committed, or the numbers are fiction."""
+    reached, problems = hook.audit_ceilings()
+    assert problems == []
+    assert reached == len(hook.KNOWN_LARGE)
+
+
+# --------------------------------------------------------------------------
+# Direction 1 — the list may not grow, and no ceiling may be raised
+# --------------------------------------------------------------------------
+
+
+def test_no_entry_may_be_added(hook):
+    added = set(hook.KNOWN_LARGE) - set(RATCHET_BASELINE)
+    assert added == set(), (
+        f"new grandfathered files {sorted(added)} — the exemption list only "
+        "shrinks (#14236). Split the file instead of exempting it."
+    )
+
+
+def test_no_ceiling_may_be_raised(hook):
+    raised = {
+        rel: (ceiling, RATCHET_BASELINE[rel])
+        for rel, ceiling in hook.KNOWN_LARGE.items()
+        if rel in RATCHET_BASELINE and ceiling > RATCHET_BASELINE[rel]
+    }
+    assert raised == {}, f"ceilings raised (now, baseline): {raised}"
+
+
+def test_growing_past_the_ceiling_fails(hook):
+    for rel, ceiling in hook.KNOWN_LARGE.items():
+        message = hook.verdict(rel, ceiling + 1)
+        assert message is not None, f"{rel} may grow past {ceiling} unchallenged"
+        assert str(ceiling) in message
+
+
+def test_a_file_at_its_ceiling_passes(hook):
+    """The exemption still exempts; the ratchet is not a blanket ban."""
+    for rel, ceiling in hook.KNOWN_LARGE.items():
+        assert hook.verdict(rel, ceiling) is None
+
+
+# --------------------------------------------------------------------------
+# Direction 2 — the list must LOSE entries, which is the half people forget
+# --------------------------------------------------------------------------
+
+
+def test_an_entry_whose_file_is_now_compliant_fails(hook):
+    """A list naming a compliant file exempts nothing while looking official."""
+    for rel in hook.KNOWN_LARGE:
+        message = hook.verdict(rel, hook.MAX_LINES)
+        assert message is not None, f"{rel} could sit here compliant and exempt"
+        assert "Delete its KNOWN_LARGE entry" in message
+
+
+def test_a_shrunk_file_must_lower_its_ceiling(hook):
+    """Otherwise the ceiling re-licenses every line that was just removed."""
+    for rel, ceiling in hook.KNOWN_LARGE.items():
+        message = hook.verdict(rel, ceiling - 1)
+        assert message is not None, f"{rel} keeps ceiling {ceiling} after shrinking"
+        assert f"Lower the ceiling to {ceiling - 1}" in message
+
+
+def test_the_audit_surfaces_a_ceiling_violation(hook, tmp_path, monkeypatch):
+    """Reaching a file is not the same as reporting on it.
+
+    Today's tree is at its ceilings, so a clean audit run cannot distinguish
+    "no violations" from "violations discarded". This stages a real breach.
+    """
+    monkeypatch.setattr(hook, "repo_root", lambda: tmp_path)
+    for rel, ceiling in hook.KNOWN_LARGE.items():
+        target = tmp_path / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("x\n" * (ceiling + 5), encoding="utf-8")
+
+    reached, problems = hook.audit_ceilings()
+    assert reached == len(hook.KNOWN_LARGE)
+    assert len(problems) == len(hook.KNOWN_LARGE)
+    assert all("over its recorded ceiling" in problem for problem in problems)
+    assert hook.run_audit() == 1
+
+
+def test_run_audit_fails_when_the_scan_reached_nothing(hook, monkeypatch):
+    """A scan of nothing must never read as a clean scan."""
+    monkeypatch.setattr(hook, "audit_ceilings", lambda: (0, []))
+    assert hook.run_audit() == 1
+
+
+def test_the_audit_reports_a_vanished_entry(hook, tmp_path, monkeypatch):
+    """A renamed or deleted file must be a hard error, not a silent no-op."""
+    monkeypatch.setattr(hook, "repo_root", lambda: tmp_path)
+    reached, problems = hook.audit_ceilings()
+    assert reached == 0
+    assert len(problems) == len(hook.KNOWN_LARGE)
+    assert all("moved or was deleted" in problem for problem in problems)
+    assert hook.run_audit() == 1
+
+
+# --------------------------------------------------------------------------
+# The ungrandfathered majority still gets the plain 600-line rule
+# --------------------------------------------------------------------------
+
+
+def test_unlisted_files_keep_the_plain_limit(hook):
+    unlisted = "autobot-backend/api/definitely_not_grandfathered.py"
+    assert hook.verdict(unlisted, hook.MAX_LINES) is None
+    assert hook.verdict(unlisted, hook.MAX_LINES + 1) == (
+        f"{unlisted}: {hook.MAX_LINES + 1} lines (max {hook.MAX_LINES})"
+    )
+
+
+def test_windows_separators_still_match_an_entry(hook):
+    for rel, ceiling in hook.KNOWN_LARGE.items():
+        assert hook.verdict(rel.replace("/", "\\"), ceiling + 1) is not None
+
+
+# --------------------------------------------------------------------------
+# Reach — did the matcher actually reach anything?
+# --------------------------------------------------------------------------
+
+
+def test_enumeration_reaches_the_repo(tracked_py_files):
+    """Guards the reach check below: an empty list would agree with anything."""
+    assert len(tracked_py_files) >= _TRACKED_PY_FLOOR
+
+
+def test_matcher_reaches_every_entry_over_a_tracked_enumeration(hook, tracked_py_files):
+    """Run the hook's matcher over paths git produced, not paths the hook knows.
+
+    Counting the entries the hook thinks it has would share the matcher's blind
+    spot exactly: if a future rewrite changes the key form, both the matcher and
+    a dict-derived counter stop matching and agree that all is well. Driving the
+    matcher from an independent enumeration cannot agree that way.
+    """
+    # A compliant line count is silent for every ordinary file and loud for a
+    # grandfathered one ("delete the entry"), so the probe identifies membership
+    # without depending on any ceiling value.
+    matched = [
+        rel for rel in tracked_py_files if hook.verdict(rel, hook.MAX_LINES) is not None
+    ]
+    assert sorted(matched) == sorted(hook.KNOWN_LARGE), (
+        f"matcher reached {len(matched)} of {len(hook.KNOWN_LARGE)} entries over "
+        f"{len(tracked_py_files)} tracked files: {sorted(matched)}"
+    )

--- a/repo_tests/python_file_size_ratchet_test.py
+++ b/repo_tests/python_file_size_ratchet_test.py
@@ -26,7 +26,9 @@ agreeing with a counter that shares its blind spot.
 
 from __future__ import annotations
 
+import ast
 import importlib.util
+import logging
 import subprocess  # nosec B404  # fixed argv, no shell, no caller input
 from pathlib import Path
 
@@ -203,6 +205,84 @@ def test_unlisted_files_keep_the_plain_limit(hook):
 def test_windows_separators_still_match_an_entry(hook):
     for rel, ceiling in hook.KNOWN_LARGE.items():
         assert hook.verdict(rel.replace("/", "\\"), ceiling + 1) is not None
+
+
+# --------------------------------------------------------------------------
+# The findings have to reach a human (#1082)
+#
+# Writing findings to stdout is banned repo-wide (this comment says so without
+# quoting the call, which would put the banned pattern in a file whose job is to
+# forbid it). The hook emits through stdlib logging instead. A
+# silent conversion is worse than the print it replaced: findings routed to
+# logger.debug on a default configuration vanish, and the guard then passes and
+# reports nothing while looking like it ran. These pin the output path.
+# --------------------------------------------------------------------------
+
+
+def _oversize(tmp_path: Path, lines: int) -> Path:
+    target = tmp_path / "too_big.py"
+    target.write_text("x\n" * lines, encoding="utf-8")
+    return target
+
+
+def test_a_violation_is_reported_to_the_developer(hook, tmp_path, caplog):
+    """The whole point of the hook: run it on a bad file, see the finding."""
+    target = _oversize(tmp_path, hook.MAX_LINES + 7)
+    with caplog.at_level(logging.DEBUG, logger=hook.logger.name):
+        assert hook.main([str(target)]) == 1
+    emitted = "\n".join(record.getMessage() for record in caplog.records)
+    assert str(target) in emitted
+    assert f"{hook.MAX_LINES + 7} lines (max {hook.MAX_LINES})" in emitted
+
+
+def test_findings_are_emitted_above_the_lastresort_threshold(hook, tmp_path, caplog):
+    """Visible even if nothing ever configured logging.
+
+    ``logging.lastResort`` prints WARNING and above when no handler is found.
+    A finding below that level would be swallowed by a bare invocation.
+    """
+    target = _oversize(tmp_path, hook.MAX_LINES + 1)
+    with caplog.at_level(logging.DEBUG, logger=hook.logger.name):
+        hook.main([str(target)])
+    levels = [record.levelno for record in caplog.records]
+    assert levels and min(levels) >= logging.WARNING
+
+
+def test_audit_problems_are_reported_to_the_developer(hook, tmp_path, caplog, monkeypatch):
+    monkeypatch.setattr(hook, "audit_ceilings", lambda: (0, ["ceiling drifted"]))
+    with caplog.at_level(logging.DEBUG, logger=hook.logger.name):
+        assert hook.run_audit() == 1
+    emitted = "\n".join(record.getMessage() for record in caplog.records)
+    assert "ceiling drifted" in emitted
+    assert min(record.levelno for record in caplog.records) >= logging.WARNING
+
+
+def test_configure_logging_makes_the_clean_run_visible(hook):
+    """The 'all live' line is INFO, so it needs a handler to exist at all."""
+    hook.configure_logging()
+    assert hook.logger.handlers, "no handler — INFO output would be discarded"
+    assert hook.logger.isEnabledFor(logging.INFO)
+
+
+def test_the_hook_has_no_stdout_calls_left(hook):
+    """#1082 — every finding leaves through the logger, none through stdout.
+
+    Structural, not textual: the banned name is assembled by implicit string
+    concatenation so this fixture cannot trip the very lint it is checking, and
+    the self-guard below fails if that assembly is ever fat-fingered into a
+    needle that matches nothing.
+    """
+    banned = "pri" "nt"
+    assert len(banned) == 5 and banned.endswith("nt"), "needle assembly broke"
+    tree = ast.parse(_SCRIPT.read_text(encoding="utf-8"))
+    calls = [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == banned
+    ]
+    assert calls == [], f"stdout calls remain at lines {calls}"
 
 
 # --------------------------------------------------------------------------

--- a/scripts/check_python_file_size.py
+++ b/scripts/check_python_file_size.py
@@ -6,38 +6,165 @@
 """Pre-commit hook: reject Python files exceeding MAX_LINES lines.
 
 Extracted from orchestrator.py (#5060) to prevent god-module regressions.
-Files listed in KNOWN_LARGE are grandfathered — they are actively being
-decomposed and will be removed from this exclusion as they shrink.
+
+Files in KNOWN_LARGE were already over the limit when the guard landed. Each
+now carries a **ceiling** — the line count recorded when it was last measured —
+so the exemption is a ratchet instead of a blank cheque (#14236).
+
+Before the ceilings existed the entries were bare names, and the comment
+promising they were "under active decomposition" was never checked by anything:
+``orchestrator.py`` grew from the 779 lines noted beside it to 1114, and the
+other two, which never had a recorded size at all, reached 4068 and 4063 —
+6.8x the limit — while the hook reported all three clean. A measurement that
+lives only in a comment is not an assertion.
+
+The ratchet turns one way only:
+
+* above its ceiling      -> fail; a grandfathered file may not grow
+* below its ceiling      -> fail; lower the ceiling to the count just achieved
+* at or below MAX_LINES  -> fail; delete the entry, the file is compliant
+
+``--audit-ceilings`` applies those rules to every entry regardless of what is
+staged, so an entry cannot sit here exempting nothing after the file it names
+has shrunk, moved, or been deleted. It reports how many entries it reached,
+because a scan that has silently stopped matching otherwise passes having
+asserted nothing.
+
+Decomposing the grandfathered files is out of scope here — that is #5060's
+campaign. This hook only stops them growing while it happens.
 """
+
+from __future__ import annotations
 
 import pathlib
 import sys
 
 MAX_LINES = 600
 
-# Grandfathered files: currently >600 lines but under active decomposition.
-# Remove each entry once the file reaches ≤600 lines.
-KNOWN_LARGE = {
-    "autobot-backend/orchestrator.py",  # 779 lines (#5060 — target <800)
-    "autobot-backend/chat_workflow/manager.py",
-    "autobot-backend/chat_workflow/tool_handler.py",
+#: Repo-relative path of this hook, quoted in the messages that ask for an edit.
+SELF_REL = "scripts/check_python_file_size.py"
+
+# Grandfathered files: over MAX_LINES before the guard existed, mapped to the
+# line count recorded for each. THIS MAPPING ONLY SHRINKS — entries leave when
+# the file reaches MAX_LINES, and a ceiling may be lowered but never raised.
+# Never add an entry to make a new file pass; split the file instead.
+# ``repo_tests/python_file_size_ratchet_test.py`` holds both directions.
+KNOWN_LARGE: dict[str, int] = {
+    "autobot-backend/orchestrator.py": 1114,
+    "autobot-backend/chat_workflow/manager.py": 4068,
+    "autobot-backend/chat_workflow/tool_handler.py": 4063,
 }
 
 
-def main() -> int:
+def repo_root() -> pathlib.Path:
+    """Repo root derived from this file, never from the caller's cwd.
+
+    A cwd-relative walk answers confidently and wrongly when the hook is run
+    from a subdirectory.
+    """
+    return pathlib.Path(__file__).resolve().parents[1]
+
+
+def normalise(path: str) -> str:
+    """Forward-slash repo-relative form used as the KNOWN_LARGE key."""
+    return str(path).replace("\\", "/")
+
+
+def count_lines(path: pathlib.Path) -> int | None:
+    """Line count for *path*, or None when it cannot be read."""
+    try:
+        with path.open(encoding="utf-8") as handle:
+            return sum(1 for _ in handle)
+    except OSError:
+        return None
+
+
+def _grandfathered_verdict(rel: str, line_count: int, ceiling: int) -> str | None:
+    """Violation message for a KNOWN_LARGE file, or None when it is at ceiling."""
+    if line_count <= MAX_LINES:
+        return (
+            f"{rel}: {line_count} lines — now within the {MAX_LINES}-line limit. "
+            f"Delete its KNOWN_LARGE entry in {SELF_REL}: an entry naming a "
+            "compliant file exempts nothing while looking authoritative."
+        )
+    if line_count > ceiling:
+        return (
+            f"{rel}: {line_count} lines, over its recorded ceiling of {ceiling}. "
+            "A grandfathered file may not grow (#14236) — the exemption freezes "
+            "the size it was granted for, it does not license more."
+        )
+    if line_count < ceiling:
+        return (
+            f"{rel}: {line_count} lines, under its recorded ceiling of {ceiling}. "
+            f"Lower the ceiling to {line_count} in {SELF_REL} — the ratchet only "
+            "turns down, and an unlowered ceiling re-licenses the lines just cut."
+        )
+    return None
+
+
+def verdict(rel: str, line_count: int) -> str | None:
+    """Violation message for *rel* at *line_count* lines, or None if acceptable."""
+    ceiling = KNOWN_LARGE.get(normalise(rel))
+    if ceiling is not None:
+        return _grandfathered_verdict(rel, line_count, ceiling)
+    if line_count > MAX_LINES:
+        return f"{rel}: {line_count} lines (max {MAX_LINES})"
+    return None
+
+
+def audit_ceilings() -> tuple[int, list[str]]:
+    """Check every KNOWN_LARGE entry against the file it names.
+
+    Returns ``(entries_reached, problems)``. ``entries_reached`` is counted from
+    reading the file off disk, not from the string lookup ``verdict`` uses, so a
+    key that no longer matches anything cannot report a clean scan of nothing.
+    """
+    root = repo_root()
+    reached = 0
+    problems: list[str] = []
+    for rel, ceiling in sorted(KNOWN_LARGE.items()):
+        line_count = count_lines(root / rel)
+        if line_count is None:
+            problems.append(
+                f"{rel}: unreadable under {root} — this entry (ceiling {ceiling}) "
+                f"names a file that moved or was deleted. Remove it from {SELF_REL}."
+            )
+            continue
+        reached += 1
+        message = verdict(rel, line_count)
+        if message is not None:
+            problems.append(message)
+    return reached, problems
+
+
+def run_audit() -> int:
+    """``--audit-ceilings``: repo-wide drift check over KNOWN_LARGE."""
+    reached, problems = audit_ceilings()
+    expected = len(KNOWN_LARGE)
+    if reached != expected:
+        problems.append(
+            f"reach check: read {reached} of {expected} KNOWN_LARGE entries — the "
+            "scan did not reach every entry, so its verdict covers nothing."
+        )
+    if problems:
+        print("\n".join(problems))
+        return 1
+    print(f"python-file-size ceilings: {expected} entries, all live and at size.")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    if "--audit-ceilings" in argv:
+        return run_audit()
+
     violations = []
-    for arg in sys.argv[1:]:
-        p = pathlib.Path(arg)
-        # Normalise to forward-slash relative path for set lookup
-        rel = str(p).replace("\\", "/")
-        if any(rel == known.replace("\\", "/") for known in KNOWN_LARGE):
+    for arg in argv:
+        line_count = count_lines(pathlib.Path(arg))
+        if line_count is None:
             continue
-        try:
-            line_count = sum(1 for _ in p.open(encoding="utf-8"))
-        except OSError:
-            continue
-        if line_count > MAX_LINES:
-            violations.append(f"{arg}: {line_count} lines (max {MAX_LINES})")
+        message = verdict(normalise(arg), line_count)
+        if message is not None:
+            violations.append(message)
 
     if violations:
         print("\n".join(violations))
@@ -46,4 +173,4 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/check_python_file_size.py
+++ b/scripts/check_python_file_size.py
@@ -36,8 +36,16 @@ campaign. This hook only stops them growing while it happens.
 
 from __future__ import annotations
 
+import logging
 import pathlib
 import sys
+
+# Plain stdlib logging, deliberately (#1082). This is a pre-commit hook: it runs
+# as a bare script on every commit, and `autobot_shared.logging_manager` would
+# drag config loading into that path. The same trade is taken in
+# `autobot_shared/user_management/password_epoch.py`, and it is what CLAUDE.md's
+# pattern table allows for exactly this case.
+logger = logging.getLogger(__name__)
 
 MAX_LINES = 600
 
@@ -137,6 +145,22 @@ def audit_ceilings() -> tuple[int, list[str]]:
     return reached, problems
 
 
+def configure_logging() -> None:
+    """Attach a stderr handler so findings actually reach the developer.
+
+    Run as a bare script the module logger has no handler, and logging's
+    ``lastResort`` fallback emits WARNING and above only — the informational
+    "all live" line would vanish silently. Findings themselves are logged at
+    ERROR precisely so they survive even when this was never called.
+    """
+    logger.setLevel(logging.INFO)
+    if logger.handlers:
+        return
+    handler = logging.StreamHandler(sys.stderr)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    logger.addHandler(handler)
+
+
 def run_audit() -> int:
     """``--audit-ceilings``: repo-wide drift check over KNOWN_LARGE."""
     reached, problems = audit_ceilings()
@@ -147,13 +171,14 @@ def run_audit() -> int:
             "scan did not reach every entry, so its verdict covers nothing."
         )
     if problems:
-        print("\n".join(problems))
+        logger.error("%s", "\n".join(problems))
         return 1
-    print(f"python-file-size ceilings: {expected} entries, all live and at size.")
+    logger.info("python-file-size ceilings: %d entries, all live and at size.", expected)
     return 0
 
 
 def main(argv: list[str]) -> int:
+    configure_logging()
     if "--audit-ceilings" in argv:
         return run_audit()
 
@@ -167,7 +192,7 @@ def main(argv: list[str]) -> int:
             violations.append(message)
 
     if violations:
-        print("\n".join(violations))
+        logger.error("%s", "\n".join(violations))
         return 1
     return 0
 


### PR DESCRIPTION
## Thinking Path

A grandfather list with no ceiling is a ratchet mounted backwards. Entries go
in, nothing takes them out, and the guard quietly stops guarding while
continuing to report green. The defect is the missing ceiling, not the entry
count — so I measured before deciding how hard to push.

**Present state.** `MAX_LINES = 600`. Three entries, measured on `Dev_new_gui`:

| file | annotated in code | today | over the limit by |
|---|---|---|---|
| `autobot-backend/orchestrator.py` | `# 779 lines (#5060 — target <800)` | 1114 | +514 (1.9x) |
| `autobot-backend/chat_workflow/manager.py` | *no number ever recorded* | 4068 | +3468 (6.8x) |
| `autobot-backend/chat_workflow/tool_handler.py` | *no number ever recorded* | 4063 | +3463 (6.8x) |

**Has the list grown?** No. `git log --follow` over the hook shows the same
three names in all five commits since it landed on 2026-05-23; the only change
was #14235 tightening `endswith` to `==`. So the list never gained an entry —
the files inside it grew instead, which is the failure mode a bare-name
exemption cannot see. `orchestrator.py` is 43% past the size it was exempted
at and past its own stated target of <800. The two with no recorded number had
nothing to regress against at all, and grew 6.8x under a passing hook. The
issue quoted 3977 and 4058 yesterday; they are 4068 and 4063 today, so the
drift is live, not historic.

**How aggressive.** Growth is unbounded and two of three entries were never
measured, so the ceiling is enforced in all three directions rather than only
the obvious one, and the audit is wired into a blocking CI step rather than
left to the staged-files hook.

**Do I also shrink the list now? No — explicitly.** All three entries stay, at
their current sizes. Splitting a 4000-line module is #5060's campaign, not a
lint fix, and this PR does not reduce any file by a line. The problem this PR
solves is that the exemption had no bound; the files are still 1.9x–6.8x over
the limit after it merges.

## What Changed

`scripts/check_python_file_size.py`

* `KNOWN_LARGE` is now `dict[str, int]` — path to the line count it was last
  measured at, per the issue's proposed shape.
* The verdict for a grandfathered file is extracted into a pure function so a
  mutation has something to break:
  * `line_count > ceiling` -> fail. A grandfathered file may not grow; the
    exemption freezes the size it was granted for.
  * `line_count < ceiling` -> fail, naming the exact number to write back. An
    unlowered ceiling re-licenses the lines just removed, which is how a
    ratchet stops turning.
  * `line_count <= MAX_LINES` -> fail, asking for the entry to be **deleted**.
    A list still naming a compliant file exempts nothing while looking
    authoritative.
* New `--audit-ceilings` mode applies those rules to every entry regardless of
  what is staged, so a stale entry cannot sit there after its file shrank,
  moved, or was deleted. It reports how many entries it reached and fails when
  that is not the expected count.
* `repo_root()` derives from `__file__`, not the cwd.
* **Findings go through the logger, not stdout (#1082).** stdlib `logging`
  rather than `autobot_shared.logging_manager`: this is a pre-commit hook run
  as a bare script on every commit, and the platform logger would pull config
  loading into that path — the trade taken in
  `autobot_shared/user_management/password_epoch.py`. Findings log at **ERROR**
  so they clear `logging.lastResort`'s WARNING threshold and stay visible even
  when nothing configured logging; `configure_logging()` attaches a stderr
  handler at INFO so the clean-run line is not discarded either.
  The **pre-existing** stdout call in `main()` moved too, rather than being left
  under the changed-lines carve-out. Said here rather than done silently: it is
  the one line in this PR the failing check did not require, and the reason is
  that keeping it would leave a 176-line file with two output paths for the same
  findings.

`.github/workflows/code-quality.yml` — new blocking step running
`--audit-ceilings`, beside the existing extension-import baseline audit. The
pre-commit hook only sees staged files; this is the sink that makes the
repo-wide direction real.

`repo_tests/python_file_size_ratchet_test.py` — 20 tests, new file.

## Verification

**The ceiling asserts both directions.**

| direction | test | asserts |
|---|---|---|
| list may not gain entries | `test_no_entry_may_be_added` | `set(KNOWN_LARGE)` is a subset of a frozen baseline literal |
| ceilings may not be raised | `test_no_ceiling_may_be_raised` | each ceiling `<=` its frozen baseline value |
| a file may not grow | `test_growing_past_the_ceiling_fails` | `verdict(rel, ceiling + 1)` is a violation naming the ceiling |
| **a compliant entry must be removed** | `test_an_entry_whose_file_is_now_compliant_fails` | `verdict(rel, 600)` demands the entry be deleted |
| a shrunk file must lower its ceiling | `test_a_shrunk_file_must_lower_its_ceiling` | `verdict(rel, ceiling - 1)` names the new number |
| a dead entry is a hard error | `test_the_audit_reports_a_vanished_entry` | a moved/deleted file is reported, not skipped |
| the audit reports, not merely reaches | `test_the_audit_surfaces_a_ceiling_violation` | a staged breach produces one problem per entry |
| the exemption still exempts | `test_a_file_at_its_ceiling_passes` | a file exactly at its ceiling passes |

The frozen baseline is a deliberate second copy of the mapping: a ratchet needs
a fixed reference, and a list only ever compared against itself can drift
anywhere. Lowering a ceiling needs no edit to it; raising one or adding a fourth
file must fail, and the comment says so.

**Reach self-check.** `test_matcher_reaches_every_entry_over_a_tracked_enumeration`
drives the hook's own matcher across **4958 paths enumerated by `git ls-files`**,
not by anything in the hook, and asserts the matcher classifies exactly the 3
entries as grandfathered. `test_enumeration_reaches_the_repo` guards the
enumeration itself with a floor of 3000, so an empty listing cannot agree with
anything. The counter deliberately does not share the matcher's blind spot:
counting the dict's own keys would fail exactly when the matcher does — a
key-form rewrite silences both, and both then agree that all is well. Driving the
matcher from an outside enumeration cannot agree that way, and `M6` below is the
demonstration. The audit's own counter is a third mechanism again: it counts
files it actually read off disk, so `run_audit` fails on "reached 0 of 3"
(`test_run_audit_fails_when_the_scan_reached_nothing`).

**The findings still reach the developer.** A silent conversion to logging would
be worse than the stdout call it replaced — a guard whose output vanishes passes
while reporting nothing. Five tests run the checker against a violating fixture
and capture the emitted record: `test_a_violation_is_reported_to_the_developer`
(the finding text and line count are present),
`test_findings_are_emitted_above_the_lastresort_threshold` (level `>= WARNING`,
so a bare invocation that never configured logging still shows them),
`test_audit_problems_are_reported_to_the_developer`,
`test_configure_logging_makes_the_clean_run_visible` (a handler exists and INFO
is enabled, or the clean-run line would be discarded) and
`test_the_hook_has_no_stdout_calls_left`.

Observed from a bare run of a standalone copy:

```
$ python3 <copy> big_fixture.py            # 605 lines
big_fixture.py: 605 lines (max 600)         -> stderr, exit 1

$ python3 <copy> --audit-ceilings           # all three at ceiling
python-file-size ceilings: 3 entries, all live and at size.   -> exit 0

$ python3 <copy> --audit-ceilings           # orchestrator.py grown to 1120
autobot-backend/orchestrator.py: 1120 lines, over its recorded ceiling of
1114. A grandfathered file may not grow (#14236) ...          -> exit 1
```

**Fixture hygiene.** `test_the_hook_has_no_stdout_calls_left` walks the AST for a
call to the banned name, assembled by implicit string concatenation, so this
fixture cannot trip the very lint it enforces — no exemption was added, and it
self-guards on the assembled needle. The prose comment above it describes the
banned call without quoting it. Fixtures needing an over-limit file build one in
`tmp_path` rather than shipping one.

**Mutation table** — standalone harness (`assert mutated != original` before each
run, baseline green first). Mutations applied to a **copy** in scratch; nothing
was pushed to the branch.

```
BASELINE GREEN — 20 passed
```

| # | mutation | test that went red | result |
|---|---|---|---|
| M1 | ceiling check removed | `test_growing_past_the_ceiling_fails` (+2) | CAUGHT |
| M2 | compliant-entry check removed | `test_an_entry_whose_file_is_now_compliant_fails` | CAUGHT |
| M3 | shrink/lower-ceiling check removed | `test_a_shrunk_file_must_lower_its_ceiling` | CAUGHT |
| M4 | a ceiling raised 1114 -> 9999 | `test_no_ceiling_may_be_raised`, `test_recorded_ceilings_match_the_files_today` | CAUGHT |
| M5 | a fourth entry added | `test_no_entry_may_be_added` | CAUGHT |
| M6 | matcher key form changed (stops matching) | `test_matcher_reaches_every_entry_over_a_tracked_enumeration` (+6) | CAUGHT |
| M7 | audit counts entries, not files read | `test_the_audit_reports_a_vanished_entry` (+2) | CAUGHT |
| M8 | vanished entry silently skipped | `test_the_audit_reports_a_vanished_entry` | CAUGHT |
| M9 | audit swallows verdicts | `test_the_audit_surfaces_a_ceiling_violation` | CAUGHT |
| M10 | failing audit exits 0 | `test_run_audit_fails_when_the_scan_reached_nothing` (+3) | CAUGHT |
| M11 | reach check in `run_audit` removed | `test_run_audit_fails_when_the_scan_reached_nothing` | CAUGHT |
| M12 | violations logged at `debug` (invisible) | `test_findings_are_emitted_above_the_lastresort_threshold` (+1) | CAUGHT |
| M13 | violations no longer emitted at all | `test_a_violation_is_reported_to_the_developer` (+1) | CAUGHT |
| M14 | audit problems logged at `debug` | `test_audit_problems_are_reported_to_the_developer` | CAUGHT |
| M15 | `configure_logging` attaches nothing | `test_configure_logging_makes_the_clean_run_visible` | CAUGHT |
| M16 | stdout call reintroduced | `test_the_hook_has_no_stdout_calls_left` | CAUGHT |

**16/16 mutations caught.** M9 and M11 exist because the first pass scored 8/9:
`test_recorded_ceilings_match_the_files_today` passes on today's tree whether or
not the audit reports anything, since there is nothing to report — a green test
proving nothing about the line it names. Two tests were added to stage a real
breach and a reach-zero scan. M12–M16 arrived with the logging conversion, for
the same reason: the conversion had to be provably not silent.

Syntax: `python3 -m py_compile` on both Python files, `yaml.safe_load` on the
workflow. Per repo policy nothing was installed and no application code was run;
the harness is a standalone scratch copy.

## Model Used

Claude Opus 5 (1M context)

## Discovered, filed not fixed

**#14462** — the same guard is unenforced for everything *outside* the list.
500 tracked `.py` files exceed 600 lines; 3 are grandfathered, so **497 are over
the limit with no exemption and no enforcement**: the hook is staged-files-only,
and the one repo-wide run (`enforce-precommit.yml`) routes findings into a
`::warning::` and exits 0. Largest is 31019 lines. Out of scope here — this PR
was asked to bound the three named files, and extending ceilings to 497 files is
a different change with a different risk profile. Cross-linked both ways.

Closes #14236
