### PR TITLE
fix(security): PermissionEnforcement cannot deny — populate tool_permission and stop swallowing denial into allow (#14420)

### DIFF
--- a/autobot-backend/api/mcp_registry_test.py
+++ b/autobot-backend/api/mcp_registry_test.py
@@ -1,0 +1,44 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Every discovered MCP bridge has a declared default permission (#14420 review).
+
+`autobot_shared.auth.mcp_tool_permissions_test.test_every_bridge_has_a_default`
+already guards the 11 static bridges by parsing `autobot-backend/api/*_mcp.py`
+sources offline. That check cannot see a bridge that only exists via the
+`autobot.mcp_bridges` entry-point group (a plugin, no local `*_mcp.py` file to
+parse) — there are no registrants there today, so the gap is latent.
+
+`required_permission()` resolves an unmapped bridge to `None`, and
+`PermissionEnforcementExtension` (#14420) reads a `None` `tool_permission` as
+"undeclared/legacy, allow" — for every role, including unauthenticated. A
+bridge added tomorrow via the entry-point path with no
+`BRIDGE_DEFAULT_PERMISSIONS` entry would be silently permissive from day one.
+
+This test reads the same `MCP_BRIDGES` list `_build_tool_entry` resolves
+`required_permission` against, so entry-point-discovered bridges are covered
+too, not just the module-scan fallback.
+"""
+
+from api.mcp_registry import MCP_BRIDGES
+from autobot_shared.auth.mcp_tool_permissions import BRIDGE_DEFAULT_PERMISSIONS
+
+
+def test_every_discovered_bridge_has_a_default_permission():
+    """A discovered bridge with no default resolves every one of its tools to
+    `required_permission() is None`, which reads as an unconditional allow —
+    not the "absence is a denial" `mcp_tool_permissions` documents."""
+    discovered = {name for name, _desc, _endpoint, _features in MCP_BRIDGES}
+    missing = discovered - set(BRIDGE_DEFAULT_PERMISSIONS)
+
+    assert not missing, (
+        f"bridge(s) discovered with no BRIDGE_DEFAULT_PERMISSIONS entry: {sorted(missing)} — "
+        "every tool on an unmapped bridge silently allows any role, including unauthenticated"
+    )
+
+
+def test_mcp_bridges_is_actually_populated():
+    """Guard the guard: an empty MCP_BRIDGES would make the assertion above
+    vacuous — discovery failing silently must not read as 'nothing to check'."""
+    assert len(MCP_BRIDGES) >= 10, f"only {len(MCP_BRIDGES)} bridges discovered — did discovery break?"

--- a/autobot-backend/chat_workflow/llm_handler.py
+++ b/autobot-backend/chat_workflow/llm_handler.py
@@ -259,23 +259,44 @@ async def _emit_before_tool_parse(llm_response: str, session_id: str, context: D
     return result if isinstance(result, str) else llm_response
 
 
-async def _emit_before_tool_execute(tool_name: str, tool_params: Dict[str, Any], session_id: str) -> bool:
+async def _emit_before_tool_execute(
+    tool_name: str,
+    tool_params: Dict[str, Any],
+    session_id: str,
+    tool_permission: str | None = None,
+    user_role: str | None = None,
+) -> bool:
     """Emit BEFORE_TOOL_EXECUTE hook to registered extensions.
 
     Issue #4181: Fires before executing a tool so extensions can reject
     or validate the execution.
 
+    Issue #14420: ``tool_permission``/``user_role`` feed
+    ``PermissionEnforcementExtension``. Callers that know the tool's
+    declared permission requirement (e.g. from the MCP registry) and the
+    caller's RBAC role should pass both; callers that do not are unchanged
+    - the extension treats a missing ``tool_permission`` as an undeclared,
+    legacy tool and allows it through.
+
     Args:
         tool_name: Name of tool to execute
         tool_params: Tool parameters
         session_id: Session identifier
+        tool_permission: The dot-style Permission value the tool requires,
+            or None if undeclared/unknown at this call site.
+        user_role: The caller's RBAC role, or None if unauthenticated.
 
     Returns:
         False to cancel tool execution, True otherwise
     """
     ctx = HookContext(
         session_id=session_id,
-        data={"tool_name": tool_name, "tool_params": tool_params},
+        data={
+            "tool_name": tool_name,
+            "tool_params": tool_params,
+            "tool_permission": tool_permission,
+            "user_role": user_role,
+        },
     )
     results = await get_extension_manager().invoke_hook(HookPoint.BEFORE_TOOL_EXECUTE, ctx)
     return not any(result is False for result in results)

--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -1090,10 +1090,18 @@ async def _try_mcp_dispatch(
             "[Issue #4261] Tool execution cancelled by BEFORE_TOOL_EXECUTE hook: %s",
             tool_name,
         )
+        cancellation_metadata = {"tool_name": tool_name, "cancelled_by_hook": True}
+        # Issue #14420 (review): the agent loop cannot otherwise tell a
+        # permission denial from any other hook veto and may retry the same
+        # call forever. A declared permission requirement is the only signal
+        # available at this call site without deeper hook introspection - the
+        # PermissionError detail itself correctly stays server-side.
+        if tool.get("required_permission") is not None:
+            cancellation_metadata["reason"] = "permission_denied"
         return WorkflowMessage(
             type="error",
             content=f"Tool execution cancelled: {tool_name}",
-            metadata={"tool_name": tool_name, "cancelled_by_hook": True},
+            metadata=cancellation_metadata,
         )
 
     try:

--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -1074,7 +1074,17 @@ async def _try_mcp_dispatch(
             )
 
     # Issue #4261: Wire BEFORE_TOOL_EXECUTE hook for MCP tools
-    should_execute = await _emit_before_tool_execute(tool_name, arguments, session_id)
+    # Issue #14420: forward the tool's declared permission requirement
+    # (#13228 stage 1, resolved onto the registry entry as
+    # `required_permission`) and the caller's RBAC role so
+    # PermissionEnforcementExtension has something real to decide against.
+    should_execute = await _emit_before_tool_execute(
+        tool_name,
+        arguments,
+        session_id,
+        tool_permission=tool.get("required_permission"),
+        user_role=role,
+    )
     if not should_execute:
         logger.info(
             "[Issue #4261] Tool execution cancelled by BEFORE_TOOL_EXECUTE hook: %s",

--- a/autobot-backend/chat_workflow/wired_hooks_test.py
+++ b/autobot-backend/chat_workflow/wired_hooks_test.py
@@ -344,6 +344,7 @@ class TestBeforeToolExecute:
 
         class DenyingExtension(Extension):
             name = "denying_permission"
+            fail_closed = True
 
             async def on_before_tool_execute(self, ctx: HookContext):
                 raise PermissionError("caller lacks the required permission")

--- a/autobot-backend/chat_workflow/wired_hooks_test.py
+++ b/autobot-backend/chat_workflow/wired_hooks_test.py
@@ -86,6 +86,8 @@ class _TrackingExtension(Extension):
     async def on_before_tool_execute(self, ctx: HookContext) -> None:
         self.called_hooks.append("before_tool_execute")
         self.captured_data["tool_name"] = ctx.get("tool_name")
+        self.captured_data["tool_permission"] = ctx.get("tool_permission")
+        self.captured_data["user_role"] = ctx.get("user_role")
 
     async def on_after_tool_execute(self, ctx: HookContext) -> Any | None:
         self.called_hooks.append("after_tool_execute")
@@ -304,6 +306,59 @@ class TestBeforeToolExecute:
 
         assert "before_tool_execute" in tracker.called_hooks
         assert tracker.captured_data["tool_name"] == "bash"
+
+    @pytest.mark.asyncio
+    async def test_omitted_tool_permission_reaches_extensions_as_none(self):
+        """#14420: a caller that does not pass tool_permission/user_role
+        must not silently invent one - the extension sees the absence."""
+        tracker = _TrackingExtension()
+        get_extension_manager().register(tracker)
+
+        await _emit_before_tool_execute("bash", {}, "sess-1")
+
+        assert tracker.captured_data["tool_permission"] is None
+        assert tracker.captured_data["user_role"] is None
+
+    @pytest.mark.asyncio
+    async def test_extension_receives_tool_permission_and_role_when_provided(self):
+        """#14420: a caller that knows the tool's declared permission and the
+        caller's RBAC role can forward both through to extensions."""
+        tracker = _TrackingExtension()
+        get_extension_manager().register(tracker)
+
+        await _emit_before_tool_execute(
+            "database_execute",
+            {},
+            "sess-1",
+            tool_permission="mcp.database.write",
+            user_role="operator",
+        )
+
+        assert tracker.captured_data["tool_permission"] == "mcp.database.write"
+        assert tracker.captured_data["user_role"] == "operator"
+
+    @pytest.mark.asyncio
+    async def test_a_denial_raised_by_an_extension_cancels_the_tool(self):
+        """#14420: a raised PermissionError must actually cancel execution,
+        not be flattened to `True` via a swallowed `None`."""
+
+        class DenyingExtension(Extension):
+            name = "denying_permission"
+
+            async def on_before_tool_execute(self, ctx: HookContext):
+                raise PermissionError("caller lacks the required permission")
+
+        get_extension_manager().register(DenyingExtension())
+
+        should_execute = await _emit_before_tool_execute(
+            "database_execute",
+            {},
+            "sess-1",
+            tool_permission="mcp.database.write",
+            user_role="user",
+        )
+
+        assert should_execute is False
 
 
 class TestAfterToolExecute:

--- a/autobot-backend/middleware/base.py
+++ b/autobot-backend/middleware/base.py
@@ -194,34 +194,47 @@ class Extension:
         if method and callable(method):
             try:
                 return await method(context)
-            except PermissionError as e:
-                # Issue #14420: a deliberate denial, raised by an extension
-                # deciding whether an operation may proceed (e.g.
-                # PermissionEnforcementExtension). This must reach the caller
-                # as an explicit `False`, never be flattened to `None` -
-                # `None` reads as "no opinion", which callers such as
-                # `not any(result is False for result in results)` treat as
-                # allow.
-                logger.warning(
-                    "[Issue #658] Extension %s denied %s: %s",
-                    self.name,
-                    hook.name,
-                    str(e),
-                )
-                return False
             except Exception as e:
+                # Issue #14420 (review): a raised `PermissionError` is only
+                # treated as a deliberate denial (`False`) for extensions
+                # that opt into `fail_closed` - their entire purpose is a
+                # permission decision. `PermissionError` is a bare built-in
+                # this codebase already raises for unrelated reasons
+                # elsewhere (secrets storage, credential stores,
+                # container/process backends, skills); matching it
+                # unconditionally at all 25 hook points would let one of
+                # those unrelated raises, reached transitively from inside
+                # *any* extension's hook body, silently cancel an unrelated
+                # legitimate operation. A non-`fail_closed` extension keeps
+                # the pre-#14420 swallow-and-continue behaviour for a
+                # `PermissionError` it did not ask to mean "cancel this
+                # operation" - same as any other exception it raises.
+                if self.fail_closed:
+                    if isinstance(e, PermissionError):
+                        logger.warning(
+                            "[Issue #658] Extension %s denied %s: %s",
+                            self.name,
+                            hook.name,
+                            str(e),
+                        )
+                    else:
+                        logger.error(
+                            "[Issue #658] Extension %s error on %s: %s",
+                            self.name,
+                            hook.name,
+                            str(e),
+                        )
+                    # An extension that fails closed must not have a denial
+                    # OR an unexpected error read as allow - `None` reads as
+                    # "no opinion" to callers like
+                    # `not any(result is False for result in results)`.
+                    return False
                 logger.error(
                     "[Issue #658] Extension %s error on %s: %s",
                     self.name,
                     hook.name,
                     str(e),
                 )
-                if self.fail_closed:
-                    # Issue #14420: an extension that fails closed must not
-                    # have an *unexpected* error read as allow either - that
-                    # is the same permissive outcome PermissionError avoids
-                    # above, reached a different way.
-                    return False
                 # Don't re-raise - extension errors shouldn't crash the system
                 return None
 

--- a/autobot-backend/middleware/base.py
+++ b/autobot-backend/middleware/base.py
@@ -150,6 +150,12 @@ class Extension:
     description: str = ""
     priority: int = 100
     enabled: bool = True
+    # Issue #14420: when True, an *unexpected* error raised while this
+    # extension's hook method runs is treated as a denial (`False`), never
+    # swallowed to `None` (which callers read as "allow"). Extensions whose
+    # job is to decide permission must fail closed; everything else keeps
+    # the default swallow-and-continue behaviour below.
+    fail_closed: bool = False
 
     @property
     def manifest(self) -> "ExtensionManifest":
@@ -188,6 +194,21 @@ class Extension:
         if method and callable(method):
             try:
                 return await method(context)
+            except PermissionError as e:
+                # Issue #14420: a deliberate denial, raised by an extension
+                # deciding whether an operation may proceed (e.g.
+                # PermissionEnforcementExtension). This must reach the caller
+                # as an explicit `False`, never be flattened to `None` -
+                # `None` reads as "no opinion", which callers such as
+                # `not any(result is False for result in results)` treat as
+                # allow.
+                logger.warning(
+                    "[Issue #658] Extension %s denied %s: %s",
+                    self.name,
+                    hook.name,
+                    str(e),
+                )
+                return False
             except Exception as e:
                 logger.error(
                     "[Issue #658] Extension %s error on %s: %s",
@@ -195,6 +216,12 @@ class Extension:
                     hook.name,
                     str(e),
                 )
+                if self.fail_closed:
+                    # Issue #14420: an extension that fails closed must not
+                    # have an *unexpected* error read as allow either - that
+                    # is the same permissive outcome PermissionError avoids
+                    # above, reached a different way.
+                    return False
                 # Don't re-raise - extension errors shouldn't crash the system
                 return None
 

--- a/autobot-backend/middleware/builtin/permission_enforcement.py
+++ b/autobot-backend/middleware/builtin/permission_enforcement.py
@@ -10,61 +10,44 @@ before allowing tool execution. Wires into the BEFORE_TOOL_EXECUTE hook.
 
 Legacy tools that do not set ``tool_permission`` on HookContext are allowed
 through unchanged so that existing callers are not broken.
+
+Issue #14420: two gaps kept this extension inert even once it was correctly
+registered on the live ``ExtensionManager`` singleton (#14280 / #14414):
+
+1. Nothing populated ``tool_permission`` on the hook context. The value now
+   comes from the MCP tool registry's ``required_permission`` (#13228 stage
+   1, ``autobot_shared.auth.mcp_tool_permissions.required_permission``),
+   forwarded through ``_emit_before_tool_execute`` at the real MCP dispatch
+   call site (``chat_workflow.tool_handler._try_mcp_dispatch``).
+2. The role check below used to compare against an ad hoc four-tier ladder
+   ("public"/"authenticated"/"operator"/"admin") that nothing in the
+   registry ever produced. It now delegates to the canonical Permission/Role
+   mapping in ``autobot_shared.auth.permissions`` — the same source
+   ``services.mcp_dispatch._would_deny`` already reads — instead of a second,
+   disconnected permission model.
 """
 
+from autobot_shared.auth.permissions import role_has_permission
 from autobot_shared.logging_manager import get_logger
 from middleware.base import Extension, HookContext
 
 logger = get_logger(__name__)
 
 
-# ---------------------------------------------------------------------------
-# Role / permission maps
-# ---------------------------------------------------------------------------
-
-# Role hierarchy — higher index = more privilege.
-# Roles not in this map default to 0 (public / unauthenticated level).
-_ROLE_LEVELS: dict[str, int] = {
-    "public": 0,
-    "readonly": 1,
-    "user": 2,
-    "editor": 3,
-    "analyst": 3,
-    "operator": 4,
-    "admin": 5,
-    "system": 5,
-}
-
-# Minimum role level required for each tool permission tier.
-_PERMISSION_MIN_LEVEL: dict[str, int] = {
-    "public": 0,
-    "authenticated": 2,  # requires at least "user" level
-    "operator": 4,
-    "admin": 5,
-}
-
-
 def _role_satisfies(user_role: str | None, tool_permission: str) -> bool:
-    """Return True if *user_role* meets the *tool_permission* requirement.
+    """Return True if *user_role* holds *tool_permission*.
 
     Args:
         user_role: User's role string (e.g. ``"user"``, ``"admin"``).
                    ``None`` represents an unauthenticated caller.
-        tool_permission: Required permission tier (e.g. ``"public"``, ``"admin"``).
+        tool_permission: The dot-style ``Permission`` value the tool
+                          requires (e.g. ``"mcp.database.write"``).
 
     Returns:
-        True when the caller has sufficient privilege.
+        True when the caller's role carries *tool_permission*, per the
+        canonical ``ROLE_PERMISSIONS`` mapping.
     """
-    if tool_permission == "public":
-        return True
-
-    if user_role is None:
-        # Unauthenticated — only public tools are permitted
-        return False
-
-    user_level = _ROLE_LEVELS.get(user_role.lower(), 0)
-    required_level = _PERMISSION_MIN_LEVEL.get(tool_permission.lower(), 5)
-    return user_level >= required_level
+    return role_has_permission(user_role, tool_permission)
 
 
 class PermissionEnforcementExtension(Extension):
@@ -74,10 +57,18 @@ class PermissionEnforcementExtension(Extension):
     raises ``PermissionError`` when the caller lacks sufficient privilege.
 
     Legacy tools that do not set ``tool_permission`` on HookContext are
-    allowed through without any check (backward compatibility).
+    allowed through without any check (backward compatibility) — this
+    matches how #13228 stage 1 marks a tool as undeclared rather than
+    denied.
 
     Priority 0 ensures this extension runs before all others so that a
     permission denial short-circuits the entire tool-execution chain.
+
+    ``fail_closed`` (#14420): an unexpected error while deciding a
+    permission — not a deliberate ``PermissionError`` denial — must not be
+    read as "allow" by ``Extension.on_hook``. Other extensions keep the
+    default swallow-and-continue behaviour; this one does not, because its
+    entire purpose is the deny decision.
 
     Usage::
 
@@ -88,16 +79,17 @@ class PermissionEnforcementExtension(Extension):
 
     name = "permission_enforcement"
     priority = 0  # Runs first — before any other extension
+    fail_closed = True
 
     async def on_before_tool_execute(self, ctx: HookContext) -> bool | None:
         """Check caller permission before tool execution.
 
         Args:
             ctx: Hook context.  Reads:
-                 - ``ctx.data["tool_permission"]``: required permission tier
-                   (``"public"``, ``"authenticated"``, ``"operator"``,
-                   ``"admin"``).  If absent the tool is treated as legacy and
-                   allowed through.
+                 - ``ctx.data["tool_permission"]``: the dot-style
+                   ``Permission`` value the tool requires (e.g.
+                   ``"mcp.database.write"``). If absent the tool is
+                   undeclared/legacy and allowed through.
                  - ``ctx.data["user_role"]``: caller's role string.
                    If absent the caller is treated as unauthenticated.
 
@@ -109,7 +101,7 @@ class PermissionEnforcementExtension(Extension):
         """
         tool_permission = ctx.get("tool_permission")
         if tool_permission is None:
-            # Legacy tool — no permission schema declared; allow through
+            # Undeclared/legacy tool — no permission schema declared; allow through
             return None
 
         user_role = ctx.get("user_role")

--- a/autobot-backend/middleware/builtin/permission_enforcement_test.py
+++ b/autobot-backend/middleware/builtin/permission_enforcement_test.py
@@ -2,47 +2,56 @@
 # SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
-"""Tests for PermissionEnforcementExtension — issue #3009."""
+"""Tests for PermissionEnforcementExtension — issue #3009, #14420."""
 
 import pytest
 
+from autobot_shared.auth.permissions import Permission
 from middleware.base import HookContext
 from middleware.builtin.permission_enforcement import (  # nosemgrep: extension-no-sibling-import — test file importing the unit under test; not a production cross-extension coupling
     PermissionEnforcementExtension,
     _role_satisfies,
 )
 
+# #14420: `_role_satisfies` now checks caller role against the canonical
+# Permission/Role mapping (autobot_shared.auth.permissions) rather than the
+# old ad hoc "public"/"authenticated"/"operator"/"admin" tier ladder, which
+# nothing in the registry ever produced. These are real dot-style values a
+# tool can declare via `required_permission`.
+_WRITE_PERM = Permission.MCP_DATABASE_WRITE.value  # granted to operator+, not user
+_ADMIN_ONLY_PERM = Permission.ADMIN_SYSTEM.value  # granted to admin only
+_READ_PERM = Permission.API_READ.value  # granted to readonly+
+
 
 class TestRoleSatisfies:
     """Unit tests for the internal _role_satisfies helper."""
 
-    def test_public_always_allowed(self):
-        assert _role_satisfies(None, "public") is True
-        assert _role_satisfies("user", "public") is True
-        assert _role_satisfies("admin", "public") is True
+    def test_readonly_holds_a_read_permission(self):
+        assert _role_satisfies("readonly", _READ_PERM) is True
 
-    def test_authenticated_requires_user_level(self):
-        assert _role_satisfies("user", "authenticated") is True
-        assert _role_satisfies("editor", "authenticated") is True
-        assert _role_satisfies("admin", "authenticated") is True
+    def test_unauthenticated_holds_no_permission(self):
+        assert _role_satisfies(None, _READ_PERM) is False
 
-    def test_authenticated_blocks_unauthenticated(self):
-        assert _role_satisfies(None, "authenticated") is False
+    def test_user_lacks_a_write_permission(self):
+        assert _role_satisfies("user", _WRITE_PERM) is False
 
-    def test_operator_requires_operator_level(self):
-        assert _role_satisfies("operator", "operator") is True
-        assert _role_satisfies("admin", "operator") is True
+    def test_operator_holds_a_write_permission(self):
+        assert _role_satisfies("operator", _WRITE_PERM) is True
 
-    def test_operator_blocks_user(self):
-        assert _role_satisfies("user", "operator") is False
-        assert _role_satisfies(None, "operator") is False
+    def test_admin_holds_every_permission(self):
+        assert _role_satisfies("admin", _WRITE_PERM) is True
+        assert _role_satisfies("admin", _ADMIN_ONLY_PERM) is True
 
-    def test_admin_requires_admin(self):
-        assert _role_satisfies("admin", "admin") is True
-        assert _role_satisfies("system", "admin") is True
+    def test_superadmin_holds_every_permission(self):
+        """`superadmin` is administrative but not a `Role` enum member (#12704/#12717)."""
+        assert _role_satisfies("superadmin", _ADMIN_ONLY_PERM) is True
 
-    def test_admin_blocks_operator(self):
-        assert _role_satisfies("operator", "admin") is False
+    def test_operator_lacks_an_admin_only_permission(self):
+        assert _role_satisfies("operator", _ADMIN_ONLY_PERM) is False
+
+    def test_unrecognised_role_holds_no_permission(self):
+        """An unrecognised role string fails closed rather than being permitted."""
+        assert _role_satisfies("not-a-real-role", _READ_PERM) is False
 
 
 class TestPermissionEnforcementExtension:
@@ -59,117 +68,72 @@ class TestPermissionEnforcementExtension:
     def test_priority_is_zero(self):
         assert self.ext.priority == 0
 
+    def test_fails_closed(self):
+        """#14420: an unexpected error deciding permission must not read as allow."""
+        assert self.ext.fail_closed is True
+
     # ------------------------------------------------------------------
-    # Legacy tools (no tool_permission set) — backward compat
+    # Undeclared/legacy tools (no tool_permission set) — backward compat
     # ------------------------------------------------------------------
 
     @pytest.mark.asyncio
-    async def test_legacy_tool_no_permission_allowed(self):
-        """Tools without tool_permission (legacy) are allowed through."""
+    async def test_undeclared_tool_no_permission_allowed(self):
+        """Tools without tool_permission (undeclared/legacy) are allowed through."""
         ctx = HookContext(session_id="s1", message="test")
         ctx.set("user_role", "user")
         result = await self.ext.on_before_tool_execute(ctx)
         assert result is None
 
     @pytest.mark.asyncio
-    async def test_legacy_tool_no_role_no_permission_allowed(self):
-        """No tool_permission and no user_role — legacy, allowed."""
+    async def test_undeclared_tool_no_role_no_permission_allowed(self):
+        """No tool_permission and no user_role — undeclared, allowed."""
         ctx = HookContext(session_id="s1", message="test")
         result = await self.ext.on_before_tool_execute(ctx)
         assert result is None
 
     # ------------------------------------------------------------------
-    # Public permission
+    # Declared permission, caller lacks it
     # ------------------------------------------------------------------
 
     @pytest.mark.asyncio
-    async def test_public_tool_unauthenticated_allowed(self):
-        """Public tools work without authentication."""
+    async def test_unauthenticated_caller_blocked(self):
         ctx = HookContext(session_id="s1", message="test")
-        ctx.set("tool_permission", "public")
-        result = await self.ext.on_before_tool_execute(ctx)
-        assert result is None
-
-    @pytest.mark.asyncio
-    async def test_public_tool_any_role_allowed(self):
-        """Public tools work for any role."""
-        for role in ("user", "editor", "operator", "admin"):
-            ctx = HookContext(session_id="s1", message="test")
-            ctx.set("tool_permission", "public")
-            ctx.set("user_role", role)
-            result = await self.ext.on_before_tool_execute(ctx)
-            assert result is None, f"Expected None for role={role}"
-
-    # ------------------------------------------------------------------
-    # Authenticated permission
-    # ------------------------------------------------------------------
-
-    @pytest.mark.asyncio
-    async def test_authenticated_tool_user_role_allowed(self):
-        """Authenticated tools work for any logged-in user."""
-        ctx = HookContext(session_id="s1", message="test")
-        ctx.set("tool_permission", "authenticated")
-        ctx.set("user_role", "user")
-        result = await self.ext.on_before_tool_execute(ctx)
-        assert result is None
-
-    @pytest.mark.asyncio
-    async def test_authenticated_tool_unauthenticated_blocked(self):
-        """Authenticated tools block unauthenticated callers."""
-        ctx = HookContext(session_id="s1", message="test")
-        ctx.set("tool_permission", "authenticated")
-        with pytest.raises(PermissionError, match="authenticated"):
-            await self.ext.on_before_tool_execute(ctx)
-
-    # ------------------------------------------------------------------
-    # Admin permission
-    # ------------------------------------------------------------------
-
-    @pytest.mark.asyncio
-    async def test_admin_tool_blocked_for_user(self):
-        """Admin tools are blocked for regular users."""
-        ctx = HookContext(session_id="s1", message="test")
-        ctx.set("tool_permission", "admin")
-        ctx.set("user_role", "user")
-        with pytest.raises(PermissionError, match="admin"):
+        ctx.set("tool_permission", _READ_PERM)
+        with pytest.raises(PermissionError, match=_READ_PERM):
             await self.ext.on_before_tool_execute(ctx)
 
     @pytest.mark.asyncio
-    async def test_admin_tool_allowed_for_admin(self):
-        """Admin tools work for admin users."""
+    async def test_user_blocked_from_write_permission(self):
         ctx = HookContext(session_id="s1", message="test")
-        ctx.set("tool_permission", "admin")
-        ctx.set("user_role", "admin")
-        result = await self.ext.on_before_tool_execute(ctx)
-        assert result is None
-
-    # ------------------------------------------------------------------
-    # Operator permission
-    # ------------------------------------------------------------------
+        ctx.set("tool_permission", _WRITE_PERM)
+        ctx.set("user_role", "user")
+        with pytest.raises(PermissionError, match="user"):
+            await self.ext.on_before_tool_execute(ctx)
 
     @pytest.mark.asyncio
-    async def test_operator_tool_blocked_for_user(self):
-        """Operator tools are blocked for regular users."""
+    async def test_operator_blocked_from_admin_only_permission(self):
         ctx = HookContext(session_id="s1", message="test")
-        ctx.set("tool_permission", "operator")
-        ctx.set("user_role", "user")
+        ctx.set("tool_permission", _ADMIN_ONLY_PERM)
+        ctx.set("user_role", "operator")
         with pytest.raises(PermissionError):
             await self.ext.on_before_tool_execute(ctx)
 
+    # ------------------------------------------------------------------
+    # Declared permission, caller holds it
+    # ------------------------------------------------------------------
+
     @pytest.mark.asyncio
-    async def test_operator_tool_allowed_for_operator(self):
-        """Operator tools work for operator users."""
+    async def test_operator_allowed_for_write_permission(self):
         ctx = HookContext(session_id="s1", message="test")
-        ctx.set("tool_permission", "operator")
+        ctx.set("tool_permission", _WRITE_PERM)
         ctx.set("user_role", "operator")
         result = await self.ext.on_before_tool_execute(ctx)
         assert result is None
 
     @pytest.mark.asyncio
-    async def test_operator_tool_allowed_for_admin(self):
-        """Operator tools work for admin (higher privilege)."""
+    async def test_admin_allowed_for_admin_only_permission(self):
         ctx = HookContext(session_id="s1", message="test")
-        ctx.set("tool_permission", "operator")
+        ctx.set("tool_permission", _ADMIN_ONLY_PERM)
         ctx.set("user_role", "admin")
         result = await self.ext.on_before_tool_execute(ctx)
         assert result is None
@@ -179,11 +143,11 @@ class TestPermissionEnforcementExtension:
     # ------------------------------------------------------------------
 
     @pytest.mark.asyncio
-    async def test_error_message_includes_required_permission(self):
+    async def test_error_message_includes_required_permission_and_role(self):
         ctx = HookContext(session_id="s1", message="test")
-        ctx.set("tool_permission", "admin")
+        ctx.set("tool_permission", _ADMIN_ONLY_PERM)
         ctx.set("user_role", "user")
         with pytest.raises(PermissionError) as exc_info:
             await self.ext.on_before_tool_execute(ctx)
-        assert "admin" in str(exc_info.value)
+        assert _ADMIN_ONLY_PERM in str(exc_info.value)
         assert "user" in str(exc_info.value)

--- a/autobot-backend/middleware/extension_hooks_test.py
+++ b/autobot-backend/middleware/extension_hooks_test.py
@@ -257,6 +257,72 @@ class TestExtension:
         result = await ext.on_hook(HookPoint.BEFORE_MESSAGE_PROCESS, ctx)
         assert result is None
 
+    # ------------------------------------------------------------------
+    # #14420: a raised denial must not be flattened to allow, and an
+    # extension deciding permission must fail closed on unexpected errors.
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_permission_error_is_not_swallowed_to_none(self):
+        """A PermissionError denial reaches the caller as `False`, not `None`.
+
+        `None` reads as "no opinion" to callers like
+        `not any(result is False for result in results)` - flattening a
+        denial to `None` there is indistinguishable from allow.
+        """
+
+        class DenyingExtension(Extension):
+            name = "denying"
+
+            async def on_before_tool_execute(self, ctx: HookContext):
+                raise PermissionError("caller lacks the required permission")
+
+        ext = DenyingExtension()
+        ctx = HookContext()
+
+        result = await ext.on_hook(HookPoint.BEFORE_TOOL_EXECUTE, ctx)
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_fail_closed_extension_unexpected_error_denies(self):
+        """An extension marked `fail_closed` must not have an unexpected
+        error (not a deliberate PermissionError) read as allow either."""
+
+        class FlakyPermissionExtension(Extension):
+            name = "flaky_permission"
+            fail_closed = True
+
+            async def on_before_tool_execute(self, ctx: HookContext):
+                raise ValueError("permission backend unreachable")
+
+        ext = FlakyPermissionExtension()
+        ctx = HookContext()
+
+        result = await ext.on_hook(HookPoint.BEFORE_TOOL_EXECUTE, ctx)
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_non_fail_closed_extension_unexpected_error_still_swallows(self):
+        """Scope boundary: extensions that do NOT opt into fail_closed keep
+        the pre-#14420 swallow-and-continue behaviour - a logging extension
+        throwing must not take down (or silently cancel) a request."""
+
+        class FlakyLoggingExtension(Extension):
+            name = "flaky_logging"
+            # fail_closed defaults to False - unchanged from before #14420
+
+            async def on_before_tool_execute(self, ctx: HookContext):
+                raise ValueError("log sink unreachable")
+
+        ext = FlakyLoggingExtension()
+        ctx = HookContext()
+
+        result = await ext.on_hook(HookPoint.BEFORE_TOOL_EXECUTE, ctx)
+
+        assert result is None
+
 
 class TestExtensionManager:
     """Test ExtensionManager functionality."""
@@ -404,6 +470,25 @@ class TestExtensionManager:
 
         # Should stop at ext2 (first handler)
         assert result is True
+
+    @pytest.mark.asyncio
+    async def test_invoke_hook_propagates_a_raised_denial(self):
+        """#14420: invoke_hook's collected results must contain the `False`
+        denial signal, not silently drop it because it looks like `None`."""
+
+        class DenyingExtension(Extension):
+            name = "denying"
+
+            async def on_before_tool_execute(self, ctx: HookContext):
+                raise PermissionError("denied")
+
+        manager = ExtensionManager()
+        manager.register(DenyingExtension())
+
+        ctx = HookContext()
+        results = await manager.invoke_hook(HookPoint.BEFORE_TOOL_EXECUTE, ctx)
+
+        assert results == [False]
 
     @pytest.mark.asyncio
     async def test_invoke_cancellable(self):

--- a/autobot-backend/middleware/extension_hooks_test.py
+++ b/autobot-backend/middleware/extension_hooks_test.py
@@ -264,7 +264,8 @@ class TestExtension:
 
     @pytest.mark.asyncio
     async def test_permission_error_is_not_swallowed_to_none(self):
-        """A PermissionError denial reaches the caller as `False`, not `None`.
+        """A `fail_closed` extension's PermissionError denial reaches the
+        caller as `False`, not `None`.
 
         `None` reads as "no opinion" to callers like
         `not any(result is False for result in results)` - flattening a
@@ -273,6 +274,7 @@ class TestExtension:
 
         class DenyingExtension(Extension):
             name = "denying"
+            fail_closed = True
 
             async def on_before_tool_execute(self, ctx: HookContext):
                 raise PermissionError("caller lacks the required permission")
@@ -283,6 +285,30 @@ class TestExtension:
         result = await ext.on_hook(HookPoint.BEFORE_TOOL_EXECUTE, ctx)
 
         assert result is False
+
+    @pytest.mark.asyncio
+    async def test_an_unrelated_permission_error_does_not_cancel_a_non_fail_closed_extension(self):
+        """Review of #14420: `PermissionError` is a bare built-in this
+        codebase already raises for unrelated reasons (secrets storage,
+        credential stores, container backends, skills). An extension that
+        does NOT opt into `fail_closed` must not have one of those, reached
+        transitively from inside its hook body, silently read as a deny."""
+
+        class UnrelatedFileExtension(Extension):
+            name = "unrelated_file_access"
+            # fail_closed defaults to False - this extension is not a
+            # permission decision, it just happens to touch a path that
+            # raises the same built-in exception type for a different reason.
+
+            async def on_before_llm_call(self, ctx: HookContext):
+                raise PermissionError("os.chmod: operation not permitted")
+
+        ext = UnrelatedFileExtension()
+        ctx = HookContext()
+
+        result = await ext.on_hook(HookPoint.BEFORE_LLM_CALL, ctx)
+
+        assert result is None
 
     @pytest.mark.asyncio
     async def test_fail_closed_extension_unexpected_error_denies(self):
@@ -478,6 +504,7 @@ class TestExtensionManager:
 
         class DenyingExtension(Extension):
             name = "denying"
+            fail_closed = True
 
             async def on_before_tool_execute(self, ctx: HookContext):
                 raise PermissionError("denied")

--- a/autobot-backend/tests/unit/chat_workflow/test_permission_enforcement_mcp_dispatch.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_permission_enforcement_mcp_dispatch.py
@@ -1,0 +1,112 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""RBAC denial reaches the real MCP dispatch call site (#14420).
+
+Two independent gaps kept `PermissionEnforcementExtension` inert even once
+correctly registered (#14280/#14414):
+
+1. Nothing populated `HookContext.data["tool_permission"]` at any production
+   call site — only the extension's own unit tests did, which is why its
+   tests passed while the extension never ran.
+2. A denial raised as `PermissionError` was swallowed by
+   `Extension.on_hook`'s blanket `except Exception` into `None`, which
+   `not any(result is False for result in results)` reads as allow.
+
+These tests exercise `_try_mcp_dispatch` — the real call site — end to end,
+not a hand-populated `HookContext`. That distinction is the point: a test
+that only proves the extension's own logic would have passed before either
+gap was closed.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from chat_workflow.tool_handler import _try_mcp_dispatch
+from middleware.builtin.permission_enforcement import PermissionEnforcementExtension
+from middleware.manager import get_extension_manager, reset_extension_manager
+
+_TOOL_NAME = "database_execute"
+_TOOL_ENTRY = {
+    "name": _TOOL_NAME,
+    "bridge": "database_mcp",
+    "endpoint": "/api/database/mcp/database_execute",
+    "input_schema": {},
+    # #13228 stage 1: declared on the registry entry by
+    # autobot_shared.auth.mcp_tool_permissions.required_permission().
+    "required_permission": "mcp.database.write",
+}
+_ARGUMENTS = {"query": "UPDATE accounts SET balance = balance + 1"}
+
+
+class _StubDispatcher:
+    """Stands in for MCPDispatcher — the registry lookup is what matters here,
+    not the HTTP bridge call, which PermissionEnforcementExtension must
+    short-circuit before it ever runs."""
+
+    def __init__(self, tool_entry: dict):
+        self._cache_loaded = True
+        self._tool_cache = {tool_entry["name"]: tool_entry}
+        self.dispatch = AsyncMock(return_value={"success": True, "result": "ran", "bridge": tool_entry["bridge"]})
+
+    def find_tool(self, name: str):
+        return self._tool_cache.get(name)
+
+    async def refresh_tool_cache(self) -> int:  # pragma: no cover - cache pre-seeded
+        return len(self._tool_cache)
+
+
+@pytest.fixture(autouse=True)
+def _reset_manager():
+    reset_extension_manager()
+    yield
+    reset_extension_manager()
+
+
+async def _dispatch(monkeypatch, role: str | None):
+    get_extension_manager().register(PermissionEnforcementExtension())
+    stub = _StubDispatcher(_TOOL_ENTRY)
+    monkeypatch.setattr("services.mcp_dispatch.get_mcp_dispatcher", lambda: stub)
+
+    result = await _try_mcp_dispatch(
+        _TOOL_NAME,
+        {"arguments": _ARGUMENTS},
+        execution_results=[],
+        role=role,
+        session_id="sess-1",
+    )
+    return result, stub
+
+
+class TestDenialReachesTheRealCallSite:
+    @pytest.mark.asyncio
+    async def test_a_caller_lacking_the_required_permission_is_denied(self, monkeypatch):
+        """AC: denied end to end from `_try_mcp_dispatch`, not a hand-built ctx.
+
+        `readonly` does not hold `mcp.database.write` in
+        `autobot_shared.auth.permissions.ROLE_PERMISSIONS`.
+        """
+        result, stub = await _dispatch(monkeypatch, role="readonly")
+
+        assert result.type == "error"
+        assert result.metadata.get("cancelled_by_hook") is True
+        stub.dispatch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_a_caller_holding_the_required_permission_is_allowed(self, monkeypatch):
+        """`operator` holds `mcp.database.write` — this is the control case
+        proving the extension discriminates, not merely always-denies."""
+        result, stub = await _dispatch(monkeypatch, role="operator")
+
+        assert result.type == "tool_result"
+        stub.dispatch.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_an_unauthenticated_caller_is_denied(self, monkeypatch):
+        result, stub = await _dispatch(monkeypatch, role=None)
+
+        assert result.type == "error"
+        assert result.metadata.get("cancelled_by_hook") is True
+        stub.dispatch.assert_not_called()

--- a/autobot-backend/tests/unit/chat_workflow/test_permission_enforcement_mcp_dispatch.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_permission_enforcement_mcp_dispatch.py
@@ -92,6 +92,9 @@ class TestDenialReachesTheRealCallSite:
 
         assert result.type == "error"
         assert result.metadata.get("cancelled_by_hook") is True
+        # #14420 (review): the agent loop must be able to tell this apart
+        # from an arbitrary hook veto, or it may retry forever.
+        assert result.metadata.get("reason") == "permission_denied"
         stub.dispatch.assert_not_called()
 
     @pytest.mark.asyncio
@@ -109,4 +112,5 @@ class TestDenialReachesTheRealCallSite:
 
         assert result.type == "error"
         assert result.metadata.get("cancelled_by_hook") is True
+        assert result.metadata.get("reason") == "permission_denied"
         stub.dispatch.assert_not_called()

--- a/autobot_shared/auth/permissions.py
+++ b/autobot_shared/auth/permissions.py
@@ -335,6 +335,41 @@ ROLE_PERMISSIONS: Dict[Role, List[Permission]] = {
 
 
 # ---------------------------------------------------------------------------
+# Role -> permission lookup (#14420)
+# ---------------------------------------------------------------------------
+
+# role -> the dot-style permission *values* it holds, built once so a caller
+# checking many tools does not rebuild a set per call.
+_ROLE_PERMISSION_VALUES: Dict[Role, frozenset] = {
+    role: frozenset(p.value for p in perms) for role, perms in ROLE_PERMISSIONS.items()
+}
+
+
+def role_has_permission(role: str | None, permission: str) -> bool:
+    """Return True when *role* holds *permission* (a dot-style Permission value).
+
+    This is the canonical role/permission check other lookups (e.g.
+    ``services.mcp_dispatch._would_deny``) already hand-roll against
+    ``ROLE_PERMISSIONS`` — added here so a second consumer (#14420's
+    ``PermissionEnforcementExtension``) does not need its own copy.
+
+    Administrative roles (see ``is_admin_role``) hold every permission. An
+    absent, unrecognised, or non-administrative role that does not carry
+    *permission* is denied — this fails closed rather than defaulting to
+    permissive for a role string this module cannot resolve.
+    """
+    if is_admin_role(role):
+        return True
+    if not role:
+        return False
+    try:
+        role_enum = Role(str(role).lower())
+    except ValueError:
+        return False
+    return permission in _ROLE_PERMISSION_VALUES[role_enum]
+
+
+# ---------------------------------------------------------------------------
 # DB seeding helpers — generated from canonical sources above so a single edit
 # to Permission / ROLE_PERMISSIONS propagates automatically to both.
 # ---------------------------------------------------------------------------

--- a/autobot_shared/auth/permissions_test.py
+++ b/autobot_shared/auth/permissions_test.py
@@ -1,0 +1,60 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for `role_has_permission` (#14420).
+
+Added as a small reusable helper alongside `ROLE_PERMISSIONS` so a second
+consumer (`middleware.builtin.permission_enforcement`, in autobot-backend)
+does not need its own copy of the role/permission membership check
+`services.mcp_dispatch._would_deny` already hand-rolls. Both backends import
+this module (see the module docstring), so it is tested directly here rather
+than only through one caller's delegate.
+"""
+
+import pytest
+
+from autobot_shared.auth.permissions import ROLE_PERMISSIONS, Permission, Role, role_has_permission
+
+# A permission every non-readonly role holds, and one only admin holds —
+# picked from the real enum/mapping rather than invented values, so a
+# ROLE_PERMISSIONS edit that removes a grant is caught here too.
+_WIDELY_GRANTED_PERM = Permission.API_READ.value  # every role in ROLE_PERMISSIONS
+_ADMIN_ONLY_PERM = Permission.ADMIN_SYSTEM.value  # Role.ADMIN only
+
+
+@pytest.mark.parametrize("role", list(Role))
+def test_every_role_holds_its_own_granted_permissions(role):
+    """Ground truth: role_has_permission must agree with ROLE_PERMISSIONS
+    itself for every role the enum defines, not just the ones exercised
+    elsewhere."""
+    for perm in ROLE_PERMISSIONS[role]:
+        assert role_has_permission(role.value, perm.value) is True, f"{role.value} should hold {perm.value}"
+
+
+def test_readonly_lacks_a_write_permission():
+    assert role_has_permission(Role.READONLY.value, _ADMIN_ONLY_PERM) is False
+
+
+def test_admin_holds_every_permission():
+    for perm in Permission:
+        assert role_has_permission("admin", perm.value) is True, perm.value
+
+
+def test_superadmin_holds_every_permission():
+    """`superadmin` is administrative but not a `Role` enum member (#12704/#12717) —
+    `is_admin_role` is the canonical, case-insensitive answer."""
+    for perm in Permission:
+        assert role_has_permission("superadmin", perm.value) is True, perm.value
+
+
+def test_admin_role_is_case_insensitive():
+    assert role_has_permission("ADMIN", _ADMIN_ONLY_PERM) is True
+    assert role_has_permission("Admin", _ADMIN_ONLY_PERM) is True
+
+
+@pytest.mark.parametrize("bad_role", [None, "", "not-a-real-role", "guest"])
+def test_unrecognised_or_absent_role_fails_closed(bad_role):
+    """An absent or unrecognised role must never default to permissive —
+    this is the same fail-closed posture #14420 relies on."""
+    assert role_has_permission(bad_role, _WIDELY_GRANTED_PERM) is False


### PR DESCRIPTION
## Thinking Path

`PermissionEnforcementExtension` (#3009) was registered onto the live `ExtensionManager` singleton by #14280/#14414, but #14420 found it still could not deny anything, for two independent reasons:

1. `HookContext.data["tool_permission"]` was never set by any production call site — only the extension's own unit tests set it, so its tests passed while the extension always took the "undeclared/legacy tool, allow" branch.
2. The extension signals denial by raising `PermissionError`. `Extension.on_hook`'s single `except Exception` caught that, logged it as a generic extension error, and returned `None`. Callers evaluate `not any(result is False for result in results)`, and `None is not False`, so the call was allowed.

Investigating gap 1, I found the codebase already has a real "manifest" for this: `autobot_shared.auth.mcp_tool_permissions.required_permission(tool_name, bridge_name)` resolves a per-tool `Permission` value (#13228 stage 1), and `api/mcp_registry.py._build_tool_entry` already attaches it to every MCP tool registry entry as `required_permission`. `chat_workflow.tool_handler._try_mcp_dispatch` — the real MCP dispatch call site — already looks up that same registry entry and already forwards the caller's RBAC `role` to `MCPDispatcher.dispatch()` (#2629/#13821). That is the real call site and the real source of the permission requirement; nothing new needed inventing.

The pre-existing extension itself, however, checked against an ad hoc four-tier ladder ("public"/"authenticated"/"operator"/"admin") that the registry's `required_permission` values (dot-style `Permission` strings like `mcp.database.write`) never match — wiring the real value in unchanged would have made the extension deny almost everything (any declared permission would fail the tier lookup and default to level 5/admin). That tier system was itself an unwired parallel model, so I replaced it with the canonical `Permission`/`Role`/`ROLE_PERMISSIONS` check already used by `services.mcp_dispatch._would_deny`'s shadow logic, exposed as a new small reusable helper (`autobot_shared.auth.permissions.role_has_permission`) rather than duplicating that lookup a second time.

For gap 2, `Extension.on_hook` now catches `PermissionError` specifically and returns `False` (an explicit, non-`None` denial) instead of falling into the generic handler. A new `fail_closed` class attribute (default `False`, preserving today's behaviour for every other extension) lets `PermissionEnforcementExtension` opt into failing closed on *unexpected* errors too — an error while deciding permission must not read as allow, but a logging extension throwing must still not take down a request.

## What Changed

- `autobot_shared/auth/permissions.py`: added `role_has_permission(role, permission)` — the canonical role/permission membership check, reused instead of duplicated.
- `autobot-backend/middleware/base.py` (`Extension`): added `fail_closed: bool = False`; `on_hook` now catches `PermissionError` → `False`, and for `fail_closed` extensions, any other unexpected exception → `False` too (all other extensions keep the pre-existing swallow-to-`None` behaviour).
- `autobot-backend/middleware/builtin/permission_enforcement.py`: `PermissionEnforcementExtension.fail_closed = True`; `_role_satisfies` now delegates to `role_has_permission` against real `Permission` values instead of the old disconnected tier ladder.
- `autobot-backend/chat_workflow/llm_handler.py`: `_emit_before_tool_execute` gained optional `tool_permission`/`user_role` kwargs (default `None`, so every existing call site is unchanged) and now sets them on the `HookContext`.
- `autobot-backend/chat_workflow/tool_handler.py`: `_try_mcp_dispatch` — the real call site — forwards `tool.get("required_permission")` and the caller's `role`.
- Tests: rewrote `permission_enforcement_test.py` for the canonical-permission model; added `on_hook` denial/fail-closed/scope-boundary tests to `extension_hooks_test.py`; added `_emit_before_tool_execute` passthrough tests to `wired_hooks_test.py`; added `tests/unit/chat_workflow/test_permission_enforcement_mcp_dispatch.py`, exercising `_try_mcp_dispatch` end to end (real dispatcher stub, real extension, real role) rather than a hand-populated `HookContext`.

**Out of scope, filed as #14469:** three other `BEFORE_TOOL_EXECUTE` call sites (`execute_command`, browser tools, `web_search`) have no `required_permission` declaration and no `role` plumbing yet, so they still take the "undeclared, allow" branch — unchanged from before this PR, and no new risk, since nothing enforced anything there previously either.

## Verification

Static-only per repo policy (no code executed from the checkout): `python3 -m py_compile` on every changed file, `git diff` review, and a manual trace of `_try_mcp_dispatch` → `_emit_before_tool_execute` → `ExtensionManager.invoke_hook` → `PermissionEnforcementExtension.on_before_tool_execute` → `Extension.on_hook`'s new `except PermissionError` branch, confirming `False` reaches `not any(result is False for result in results)` and cancels the call.

Mutation-proof (standalone harness, reimplemented logic — not the repo's code — per the "never execute code from the checkout" policy; CI is the authority on the real suite):

| Behaviour | Test | Fixed | Mutant (pre-#14420 shape) | Detects? |
|---|---|---|---|---|
| `PermissionError` → `False`, not swallowed | `test_permission_error_is_false` | True | False | ✅ |
| `fail_closed` extension, unexpected error → `False` | `test_fail_closed_unexpected_error_is_false` | True | False | ✅ |
| non-`fail_closed` extension, unexpected error → `None` (scope boundary) | `test_non_fail_closed_unexpected_error_is_none` | True | True | — (correctly unchanged) |
| unrecognised/undeclared role fails closed | `test_unknown_role_denied` | True | False | ✅ (mutant = old default-allow-on-unknown bug) |
| role holding the permission is allowed | `test_operator_allowed_write` / `test_user_denied_write` | True/True | True/True | — (unaffected by that mutation, covered by other tests) |
| a `False` result cancels the call | `test_denial_cancels` | True | True | — (unaffected by this mutation) |
| a `None` result does not cancel (scope boundary) | `test_no_opinion_allows` | True | False | ✅ |

Each real test file added/changed above targets one of these rows against the actual module, and the harness confirms the assertion shapes are capable of catching the regression they guard.

## Model Used

Claude Sonnet 5

## Review follow-up (commit 18b5e9884)

Code review returned APPROVE with two Medium findings, both fixed here:

1. **`PermissionError` catch was unconditional across all 25 hook points.** `middleware/base.py`'s `except PermissionError: return False` applied to every extension, but `PermissionError` is a bare built-in this codebase already raises for unrelated reasons (`api/secrets.py`, `knowledge/connectors/credential_store.py`, `services/execution/docker_backend.py`, `llc/adapters/process_adapter.py`, `skills/hub.py`). Any of those raised transitively from inside a *non*-permission extension's hook body would have silently cancelled a legitimate operation. **Chose: scope the catch to `self.fail_closed`** (the smaller-diff option offered), rather than a dedicated `ToolPermissionDenied(PermissionError)` marker type — `PermissionEnforcementExtension` already sets `fail_closed = True`, so its own denial is unaffected, and every other (non-`fail_closed`) extension now keeps the pre-#14420 swallow-and-continue behaviour for a `PermissionError` it didn't raise to mean "cancel this operation" — pinned by a new regression test (`test_an_unrelated_permission_error_does_not_cancel_a_non_fail_closed_extension`).
2. **The two `None`s were collapsed.** `required_permission()` returns `None` both for a call site that never declared a permission (legitimate, #14469's exclusions) and for a bridge missing from `BRIDGE_DEFAULT_PERMISSIONS` — the second silently allows every role, including unauthenticated, contradicting `mcp_tool_permissions.py`'s own "absence is a denial" docstring. Added `autobot-backend/api/mcp_registry_test.py::test_every_discovered_bridge_has_a_default_permission`, asserting every bridge `MCP_BRIDGES` discovers (module-scan **and** the `autobot.mcp_bridges` entry-point group, i.e. plugin bridges — not just the 11 static `*_mcp.py` files the existing offline parser in `mcp_tool_permissions_test.py` covers) has a declared default. Chose the CI-assertion fix over a runtime deny-sentinel to avoid flipping live default-allow behaviour for undeclared-but-benign tools ahead of #13228's staged, separately revertible enforcement flip.

Also (Low): `_try_mcp_dispatch`'s cancellation metadata now carries `reason: "permission_denied"` when the tool had a declared `required_permission`, so the agent loop can tell a permission denial apart from any other hook veto instead of potentially retrying forever; and added `autobot_shared/auth/permissions_test.py`, testing `role_has_permission` directly for all 6 `Role` members, `admin`/`superadmin`, and unrecognised/`None` (previously only exercised through `permission_enforcement_test.py`'s one-line delegate).

Mutation results (same standalone-harness method as above, not executed from the checkout):

| Behaviour | Fixed | Mutant (unconditional catch / no coverage check) | Detected |
|---|---|---|---|
| `fail_closed` extension: `PermissionError` → `False` | True | True | unaffected by this mutation (covered above) |
| non-`fail_closed` extension: unrelated `PermissionError` → `None`, not swallowed into a cancel | True | False | yes |
| `fail_closed` extension: unexpected error → `False` | True | True | unaffected by this mutation (covered above) |
| a plugin bridge missing from `BRIDGE_DEFAULT_PERMISSIONS` is caught | True | False | yes |
| fully-declared bridges report clean | True | True | unaffected by this mutation |

Closes #14420

