### PR TITLE
fix(ci): hardened-smoke-test's post-mortem names the actual failing container (#14417)

### DIFF
--- a/.github/workflows/hardened-smoke-test.yml
+++ b/.github/workflows/hardened-smoke-test.yml
@@ -317,6 +317,14 @@ jobs:
           # Backstop for the per-container diagnostics above: full compose
           # logs, printed inline (not just the uploaded artifact) AND kept
           # as an artifact, matching docker-smoke-test.yml. (#14417)
+          #
+          # Same trap as the post-mortem step above: default Actions bash is
+          # `-eo pipefail`, so `docker compose logs` failing (compose already
+          # torn down, daemon hiccup) would abort the pipe before the
+          # `::endgroup::` below runs, leaving an unclosed fold in the job
+          # log. Turn both off so the fold always closes, whatever `docker
+          # compose logs` did.
+          set +e +o pipefail
           echo "::group::docker compose logs (all services)"
           docker compose \
             -f docker-compose.yml \

--- a/.github/workflows/hardened-smoke-test.yml
+++ b/.github/workflows/hardened-smoke-test.yml
@@ -279,10 +279,9 @@ jobs:
             echo "::group::${svc} diagnostics"
 
             echo "=== ${svc} container state ==="
-            docker inspect "$svc" \
+            if ! docker inspect "$svc" \
               --format 'Status={{.State.Status}} ExitCode={{.State.ExitCode}} OOMKilled={{.State.OOMKilled}} Health={{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' \
-              2>&1
-            if [ "$?" -ne 0 ]; then
+              2>&1; then
               echo "(${svc} container not found)"
             fi
 
@@ -290,8 +289,7 @@ jobs:
             echo "=== ${svc} healthcheck probe log (each attempt: ExitCode + Output) ==="
             probe=$(docker inspect "$svc" --format '{{json .State.Health}}' 2>/dev/null)
             if [ -n "$probe" ] && [ "$probe" != "null" ]; then
-              echo "$probe" | python3 -m json.tool 2>/dev/null
-              if [ "$?" -ne 0 ]; then
+              if ! echo "$probe" | python3 -m json.tool 2>/dev/null; then
                 echo "$probe"
               fi
             else
@@ -300,14 +298,12 @@ jobs:
 
             echo ""
             echo "=== ${svc} logs (last 300 lines) ==="
-            docker compose \
+            if ! docker compose \
               -f docker-compose.yml \
               -f docker-compose.hardened.yml \
               --env-file docker/.env.docker \
-              logs --no-color --tail 300 "$svc" 2>&1
-            if [ "$?" -ne 0 ]; then
-              docker logs --tail 300 "$svc" 2>&1
-              if [ "$?" -ne 0 ]; then
+              logs --no-color --tail 300 "$svc" 2>&1; then
+              if ! docker logs --tail 300 "$svc" 2>&1; then
                 echo "(no ${svc} logs available)"
               fi
             fi

--- a/.github/workflows/hardened-smoke-test.yml
+++ b/.github/workflows/hardened-smoke-test.yml
@@ -214,40 +214,120 @@ jobs:
           echo ""
           curl -v http://localhost/slm/api/health 2>&1 | head -20 || true
 
-      - name: Dump autobot-slm diagnostics on failure
-        # #11516: the hardened overlay fails with "container autobot-slm is
-        # unhealthy", but the crash cause lives in the SLM container's own
-        # logs + healthcheck probe output — print them INLINE (not just the
-        # uploaded artifact) so the failure is diagnosable from the run page.
+      - name: Dump diagnostics for unhealthy containers on failure
+        # #14417: #11516 hardcoded this step to autobot-slm, which was the
+        # failing container back then. When the failing container was
+        # anything else (e.g. autobot-backend on PR #14413), this step
+        # printed a healthy SLM and named nothing — the traceback that
+        # explained the failure appeared nowhere in the inline job output.
+        #
+        # Derive the failing container(s) from compose state instead of
+        # assuming one: a service is "unhealthy" here if its container was
+        # never created, isn't running, or reports a failing healthcheck.
+        # Dump full diagnostics (state + healthcheck probe log + tail of
+        # logs) for each one found, INLINE (not just the uploaded artifact
+        # from the next step). If none look unhealthy — the failure happened
+        # somewhere else in the job, e.g. a curl assertion — fall back to
+        # dumping every service so this step is never silent.
         if: failure()
+        shell: bash
         run: |
-          echo "=== autobot-slm container state ==="
-          docker inspect autobot-slm \
-            --format 'Status={{.State.Status}} ExitCode={{.State.ExitCode}} OOMKilled={{.State.OOMKilled}} Health={{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' \
-            2>&1 || echo "(autobot-slm container not found)"
-          echo ""
-          echo "=== autobot-slm healthcheck probe log (each attempt: ExitCode + Output) ==="
-          docker inspect autobot-slm --format '{{json .State.Health}}' 2>/dev/null \
-            | python3 -m json.tool 2>/dev/null \
-            || echo "(no healthcheck state on autobot-slm)"
-          echo ""
-          echo "=== autobot-slm logs (last 300 lines) ==="
-          docker compose \
+          # Default GitHub Actions bash flags are `-eo pipefail`; a docker
+          # inspect/logs call on a container that never started exits
+          # non-zero and must not abort this step before later containers
+          # are dumped, so turn both off for the whole post-mortem.
+          set +e +o pipefail
+
+          services=$(docker compose \
             -f docker-compose.yml \
             -f docker-compose.hardened.yml \
             --env-file docker/.env.docker \
-            logs --no-color --tail 300 autobot-slm 2>&1 \
-            || docker logs --tail 300 autobot-slm 2>&1 \
-            || echo "(no autobot-slm logs available)"
+            config --services 2>/dev/null)
+          services=$(echo "$services" | xargs)
+
+          if [ -z "$services" ]; then
+            echo "(could not enumerate compose services from the compose config)"
+          fi
+
+          unhealthy=""
+          for svc in $services; do
+            status=$(docker inspect "$svc" --format '{{.State.Status}}' 2>/dev/null)
+            if [ -z "$status" ]; then
+              echo "-> ${svc}: container not found (never created)"
+              unhealthy="$unhealthy $svc"
+              continue
+            fi
+            health=$(docker inspect "$svc" --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' 2>/dev/null)
+            echo "-> ${svc}: status=${status} health=${health:-none}"
+            if [ "$health" = "unhealthy" ] || [ "$status" != "running" ]; then
+              unhealthy="$unhealthy $svc"
+            fi
+          done
+          unhealthy=$(echo "$unhealthy" | xargs)
+
+          if [ -z "$unhealthy" ]; then
+            echo ""
+            echo "No container looked unhealthy from compose state -- the failure happened elsewhere in the job. Dumping every service so this step is never silent."
+            unhealthy="$services"
+          fi
+
+          echo ""
+          echo "=== Containers identified as failing: ${unhealthy:-<none enumerable>} ==="
+
+          for svc in $unhealthy; do
+            echo ""
+            echo "::group::${svc} diagnostics"
+
+            echo "=== ${svc} container state ==="
+            docker inspect "$svc" \
+              --format 'Status={{.State.Status}} ExitCode={{.State.ExitCode}} OOMKilled={{.State.OOMKilled}} Health={{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' \
+              2>&1
+            if [ "$?" -ne 0 ]; then
+              echo "(${svc} container not found)"
+            fi
+
+            echo ""
+            echo "=== ${svc} healthcheck probe log (each attempt: ExitCode + Output) ==="
+            probe=$(docker inspect "$svc" --format '{{json .State.Health}}' 2>/dev/null)
+            if [ -n "$probe" ] && [ "$probe" != "null" ]; then
+              echo "$probe" | python3 -m json.tool 2>/dev/null
+              if [ "$?" -ne 0 ]; then
+                echo "$probe"
+              fi
+            else
+              echo "(no healthcheck state on ${svc})"
+            fi
+
+            echo ""
+            echo "=== ${svc} logs (last 300 lines) ==="
+            docker compose \
+              -f docker-compose.yml \
+              -f docker-compose.hardened.yml \
+              --env-file docker/.env.docker \
+              logs --no-color --tail 300 "$svc" 2>&1
+            if [ "$?" -ne 0 ]; then
+              docker logs --tail 300 "$svc" 2>&1
+              if [ "$?" -ne 0 ]; then
+                echo "(no ${svc} logs available)"
+              fi
+            fi
+
+            echo "::endgroup::"
+          done
 
       - name: Collect logs on failure
         if: failure()
         run: |
+          # Backstop for the per-container diagnostics above: full compose
+          # logs, printed inline (not just the uploaded artifact) AND kept
+          # as an artifact, matching docker-smoke-test.yml. (#14417)
+          echo "::group::docker compose logs (all services)"
           docker compose \
             -f docker-compose.yml \
             -f docker-compose.hardened.yml \
             --env-file docker/.env.docker \
-            logs > failure-logs.txt
+            logs --no-color | tee failure-logs.txt
+          echo "::endgroup::"
 
       - name: Upload failure logs
         if: failure()

--- a/repo_tests/hardened_smoke_test_postmortem_14417_test.py
+++ b/repo_tests/hardened_smoke_test_postmortem_14417_test.py
@@ -180,7 +180,13 @@ def test_names_the_actual_failing_container_not_slm(bash, postmortem_script, moc
     assert "::group::autobot-backend diagnostics" in out
     assert "FAKE LOG lines for autobot-backend" in out
     # The historical bug: this step always dumped SLM regardless of which
-    # container actually failed.
+    # container actually failed. `not in out` alone passes vacuously against
+    # the pre-fix script too (it never emitted `::group::` markers at all),
+    # so pin the exact count: exactly one group, for autobot-backend only.
+    assert out.count("::group::") == 1, (
+        f"expected exactly one diagnostics group (autobot-backend), got "
+        f"{out.count('::group::')}:\n{out}"
+    )
     assert "::group::autobot-slm diagnostics" not in out, (
         "post-mortem dumped the healthy autobot-slm instead of (or as well as) "
         "the actually-failing autobot-backend -- the hardcoding regressed"
@@ -208,6 +214,12 @@ def test_names_every_unhealthy_container_when_several_fail(bash, postmortem_scri
     assert "::group::autobot-backend diagnostics" in out
     assert "::group::autobot-frontend diagnostics" in out
     assert "autobot-frontend: container not found (never created)" in out
+    # Exactly the two unhealthy ones -- not the healthy autobot-slm, and not
+    # a count that would also match a "dump everything" fallback.
+    assert out.count("::group::") == 2, (
+        f"expected exactly two diagnostics groups (backend, frontend), got "
+        f"{out.count('::group::')}:\n{out}"
+    )
     assert "::group::autobot-slm diagnostics" not in out
 
 
@@ -231,10 +243,17 @@ def test_falls_back_to_every_service_when_none_look_unhealthy(bash, postmortem_s
     )
     out = result.stdout
 
-    assert out.strip(), "post-mortem step printed nothing at all"
     assert "No container looked unhealthy" in out
+    # `out.strip()` alone would pass vacuously against the pre-fix script too
+    # (it always printed the hardcoded SLM block regardless of health) -- the
+    # discriminating claim is that EVERY service got named and dumped, not
+    # merely that something was printed.
     for svc in SERVICES.split():
         assert f"::group::{svc} diagnostics" in out
+    assert out.count("::group::") == len(SERVICES.split()), (
+        f"expected a diagnostics group for every one of {SERVICES.split()}, "
+        f"got {out.count('::group::')} groups:\n{out}"
+    )
 
 
 def test_step_never_aborts_before_printing_anything(bash, postmortem_script, mock_docker_dir):
@@ -255,3 +274,8 @@ def test_step_never_aborts_before_printing_anything(bash, postmortem_script, moc
     for svc in SERVICES.split():
         assert f"{svc}: container not found (never created)" in result.stdout
         assert f"::group::{svc} diagnostics" in result.stdout
+    assert result.stdout.count("::group::") == len(SERVICES.split()), (
+        f"the loop stopped early instead of reporting every never-created "
+        f"container -- got {result.stdout.count('::group::')} of "
+        f"{len(SERVICES.split())} groups:\n{result.stdout}"
+    )

--- a/repo_tests/hardened_smoke_test_postmortem_14417_test.py
+++ b/repo_tests/hardened_smoke_test_postmortem_14417_test.py
@@ -1,0 +1,257 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""hardened-smoke-test's inline post-mortem must name whichever container
+actually failed, not just `autobot-slm` (#14417).
+
+Before this fix, `.github/workflows/hardened-smoke-test.yml`'s failure
+diagnostics step was hardcoded to inspect and log `autobot-slm` only (added
+for #11516, where SLM happened to be the failing container). On PR #14413 the
+`autobot-backend` container died at import instead: the step printed a
+healthy SLM and named nothing, so the traceback that explained the failure
+appeared nowhere in the inline job output -- only in the uploaded artifact.
+
+These tests execute the step's actual `run:` script (parsed live from the
+workflow file, so there is nothing here to drift out of sync with what CI
+runs) against a mocked `docker` CLI, and assert on its *behaviour*: which
+container(s) it names and dumps, not on its source text. A source-text-only
+check ("does it mention 'autobot-slm'?") would still pass for a hardcoded
+step that merely added a second name -- the defect is the hardcoding itself.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml", reason="PyYAML needed to parse the workflow")
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "hardened-smoke-test.yml"
+STEP_NAME = "Dump diagnostics for unhealthy containers on failure"
+
+# A standalone fake `docker` executable (not a sourced bash function, so
+# `subprocess.run` inheriting only `env=` is sufficient -- no exported-function
+# plumbing needed). Driven entirely by MOCK_* env vars set per scenario below.
+# Assembled from a plain heredoc-free template rather than any of the actual
+# hardened-smoke-test container names being pattern-matched against a lint
+# banlist -- there is no such lint here, but keeping the mock data-driven
+# (service list + status/health come from env, not literals in this file)
+# avoids coupling the test to any future ban on repeating infra names.
+_DOCKER_MOCK = textwrap.dedent(
+    """\
+    #!/usr/bin/env bash
+    if [ "$1" = "compose" ]; then
+      shift
+      joined=" $* "
+      if [[ "$joined" == *" config "*"--services"* ]]; then
+        for s in $MOCK_SERVICES; do echo "$s"; done
+        exit 0
+      fi
+      if [[ "$joined" == *" logs "* ]]; then
+        for last in "$@"; do :; done
+        if [[ "$joined" == *"--tail 300"* ]]; then
+          status_var="MOCK_STATUS_${last//-/_}"
+          if [ -z "${!status_var:-}" ]; then exit 1; fi
+          echo "FAKE LOG lines for $last"
+          exit 0
+        fi
+        echo "FAKE full compose log dump"
+        exit 0
+      fi
+      exit 0
+    fi
+    if [ "$1" = "inspect" ]; then
+      svc="$2"
+      fmt="$4"
+      status_var="MOCK_STATUS_${svc//-/_}"
+      health_var="MOCK_HEALTH_${svc//-/_}"
+      status="${!status_var:-}"
+      health="${!health_var:-none}"
+      if [ -z "$status" ]; then exit 1; fi
+      case "$fmt" in
+        *"json .State.Health"*)
+          if [ "$health" = "none" ]; then echo "null"; else echo "{\\"Status\\":\\"$health\\"}"; fi
+          exit 0 ;;
+        *"ExitCode="*)
+          echo "Status=$status ExitCode=0 OOMKilled=false Health=$health"
+          exit 0 ;;
+        "{{.State.Status}}")
+          echo "$status"
+          exit 0 ;;
+        *)
+          echo "$health"
+          exit 0 ;;
+      esac
+    fi
+    if [ "$1" = "logs" ]; then
+      svc="$4"
+      status_var="MOCK_STATUS_${svc//-/_}"
+      if [ -z "${!status_var:-}" ]; then exit 1; fi
+      echo "FAKE docker logs for $svc"
+      exit 0
+    fi
+    exit 0
+    """
+)
+
+
+def _postmortem_script() -> str:
+    """Extract the step's `run:` block from the real workflow file."""
+    doc = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    steps = doc["jobs"]["hardened-smoke-test"]["steps"]
+    for step in steps:
+        if step.get("name") == STEP_NAME:
+            return step["run"]
+    raise AssertionError(
+        f"no step named {STEP_NAME!r} in {WORKFLOW} -- it was renamed or removed, "
+        "update STEP_NAME to match"
+    )
+
+
+@pytest.fixture(scope="module")
+def bash():
+    path = shutil.which("bash")
+    if path is None:
+        pytest.skip("bash unavailable")
+    return path
+
+
+@pytest.fixture(scope="module")
+def postmortem_script(tmp_path_factory) -> Path:
+    script_dir = tmp_path_factory.mktemp("postmortem")
+    script_path = script_dir / "postmortem.sh"
+    script_path.write_text("#!/usr/bin/env bash\n" + _postmortem_script(), encoding="utf-8")
+    script_path.chmod(0o755)
+    return script_path
+
+
+@pytest.fixture(scope="module")
+def mock_docker_dir(tmp_path_factory) -> Path:
+    bin_dir = tmp_path_factory.mktemp("mockbin")
+    docker_path = bin_dir / "docker"
+    docker_path.write_text(_DOCKER_MOCK, encoding="utf-8")
+    docker_path.chmod(0o755)
+    return bin_dir
+
+
+def _run(bash: str, script: Path, mock_bin: Path, mock_env: dict) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env.update(mock_env)
+    env["PATH"] = f"{mock_bin}:{env.get('PATH', '')}"
+    return subprocess.run(
+        [bash, str(script)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+
+
+SERVICES = "autobot-backend autobot-slm autobot-frontend"
+
+
+def test_names_the_actual_failing_container_not_slm(bash, postmortem_script, mock_docker_dir):
+    """Denial-shaped case: backend is unhealthy, SLM is healthy. This is the
+    exact shape of PR #14413 that #14417 was filed against."""
+    result = _run(
+        bash,
+        postmortem_script,
+        mock_docker_dir,
+        {
+            "MOCK_SERVICES": SERVICES,
+            "MOCK_STATUS_autobot_backend": "exited",
+            "MOCK_HEALTH_autobot_backend": "unhealthy",
+            "MOCK_STATUS_autobot_slm": "running",
+            "MOCK_HEALTH_autobot_slm": "healthy",
+            "MOCK_STATUS_autobot_frontend": "running",
+            "MOCK_HEALTH_autobot_frontend": "none",
+        },
+    )
+    out = result.stdout
+
+    assert "Containers identified as failing: autobot-backend" in out
+    assert "::group::autobot-backend diagnostics" in out
+    assert "FAKE LOG lines for autobot-backend" in out
+    # The historical bug: this step always dumped SLM regardless of which
+    # container actually failed.
+    assert "::group::autobot-slm diagnostics" not in out, (
+        "post-mortem dumped the healthy autobot-slm instead of (or as well as) "
+        "the actually-failing autobot-backend -- the hardcoding regressed"
+    )
+
+
+def test_names_every_unhealthy_container_when_several_fail(bash, postmortem_script, mock_docker_dir):
+    """Multiple unhealthy containers: both must be named and dumped."""
+    result = _run(
+        bash,
+        postmortem_script,
+        mock_docker_dir,
+        {
+            "MOCK_SERVICES": SERVICES,
+            "MOCK_STATUS_autobot_backend": "exited",
+            "MOCK_HEALTH_autobot_backend": "unhealthy",
+            "MOCK_STATUS_autobot_slm": "running",
+            "MOCK_HEALTH_autobot_slm": "healthy",
+            # autobot-frontend: no MOCK_STATUS -> "container not found"
+        },
+    )
+    out = result.stdout
+
+    assert "Containers identified as failing: autobot-backend autobot-frontend" in out
+    assert "::group::autobot-backend diagnostics" in out
+    assert "::group::autobot-frontend diagnostics" in out
+    assert "autobot-frontend: container not found (never created)" in out
+    assert "::group::autobot-slm diagnostics" not in out
+
+
+def test_falls_back_to_every_service_when_none_look_unhealthy(bash, postmortem_script, mock_docker_dir):
+    """The job failed (this step only runs on `if: failure()`) but nothing in
+    compose state looks unhealthy -- e.g. a curl assertion failed. An empty
+    post-mortem here is exactly the original bug in a new shape."""
+    result = _run(
+        bash,
+        postmortem_script,
+        mock_docker_dir,
+        {
+            "MOCK_SERVICES": SERVICES,
+            "MOCK_STATUS_autobot_backend": "running",
+            "MOCK_HEALTH_autobot_backend": "healthy",
+            "MOCK_STATUS_autobot_slm": "running",
+            "MOCK_HEALTH_autobot_slm": "healthy",
+            "MOCK_STATUS_autobot_frontend": "running",
+            "MOCK_HEALTH_autobot_frontend": "none",
+        },
+    )
+    out = result.stdout
+
+    assert out.strip(), "post-mortem step printed nothing at all"
+    assert "No container looked unhealthy" in out
+    for svc in SERVICES.split():
+        assert f"::group::{svc} diagnostics" in out
+
+
+def test_step_never_aborts_before_printing_anything(bash, postmortem_script, mock_docker_dir):
+    """A `docker inspect`/`docker logs` on a container that never started
+    exits non-zero. Under GitHub Actions' default `bash -eo pipefail`, that
+    must not abort the step before it names anything."""
+    result = _run(
+        bash,
+        postmortem_script,
+        mock_docker_dir,
+        {
+            "MOCK_SERVICES": SERVICES,
+            # No MOCK_STATUS_* set for any service -> every `docker inspect`
+            # and `docker logs` call fails.
+        },
+    )
+    assert "Containers identified as failing:" in result.stdout
+    for svc in SERVICES.split():
+        assert f"{svc}: container not found (never created)" in result.stdout
+        assert f"::group::{svc} diagnostics" in result.stdout


### PR DESCRIPTION
## Thinking Path

`hardened-smoke-test`'s inline post-mortem step (`Dump autobot-slm diagnostics on failure`) was hardcoded to inspect and log `autobot-slm` only, added for #11516 where SLM happened to be the failing container. On PR #14413 the actual failing container was `autobot-backend`, so the step printed a healthy SLM and named nothing — the traceback that explained the failure appeared nowhere in the inline job output, only inside the `failure-logs.txt` artifact.

The fix has to derive the failing container(s) from compose state rather than assume one, and must handle three shapes: exactly one unhealthy container, several unhealthy at once, and none unhealthy (the failure happened elsewhere in the job, e.g. a curl assertion) — an empty post-mortem in that last case is the same bug in a new shape.

I also had to route around two shell traps called out in the issue: GitHub Actions' default bash flags are `-eo pipefail`, so a `docker inspect`/`docker logs` call on a container that never started (exits non-zero) would abort the whole step before later containers get dumped unless the loop explicitly turns those flags off first.

## What Changed

`.github/workflows/hardened-smoke-test.yml`:

- Renamed the post-mortem step to `Dump diagnostics for unhealthy containers on failure` and rewrote it to:
  - enumerate compose services via `docker compose config --services` instead of hardcoding `autobot-slm`,
  - classify each as unhealthy if its container was never created, isn't `running`, or reports `Health.Status = unhealthy`,
  - dump the same level of detail #11516 added for SLM (state line, healthcheck probe JSON, last 300 log lines) for **every** unhealthy container found, each inside its own `::group::` so multiple failures stay readable,
  - fall back to dumping **every** service when none look unhealthy, so the step is never silent,
  - `set +e +o pipefail` at the top of the script so a failing `docker inspect`/`docker logs` on a not-yet-created container doesn't abort the post-mortem before it prints anything.
- `Collect logs on failure`: now also prints the full compose log inline inside a `::group::` (via `tee`) as a backstop, matching the sibling `docker-smoke-test.yml` job, in addition to keeping the uploaded artifact.

`repo_tests/hardened_smoke_test_postmortem_14417_test.py` (new): parses the step's `run:` script live out of the workflow file and executes it against a mocked `docker` CLI, asserting on behaviour (which container(s) get named and dumped), not on source text.

## Verification

Per repo policy this session never built the Docker images or ran code from the codebase. All of the following ran outside the repo (scratch space) or as static checks:

- `python3 -c "yaml.safe_load(...)"` — the edited workflow parses and has the expected step names in order.
- `bash -n` on the two edited `run:` blocks (extracted via PyYAML) — no syntax errors.
- A standalone bash harness (mocked `docker` CLI, driven by env vars, never touching the real codebase or Docker) ran the exact extracted post-mortem script against 4 scenarios:
  - **single non-SLM container unhealthy** (`autobot-backend`, the #14413 shape) → names only `autobot-backend`, dumps its log, does **not** touch the healthy `autobot-slm`
  - **multiple unhealthy** (`autobot-backend` unhealthy + `autobot-frontend` never created) → names both, dumps both, does not touch `autobot-slm`
  - **none unhealthy** (job failed elsewhere) → prints the fallback message and dumps all 3 services, never silent
  - **every container missing** (proves the `-eo pipefail` trap is actually handled) → the loop still names and reports each one instead of aborting on the first failing `docker inspect`
  - All 11 assertions passed.
- Mutation proof (not pushed): ran the same harness against the pre-fix script (`git show origin/Dev_new_gui:.github/workflows/hardened-smoke-test.yml`, extracted the old hardcoded step). 8 of the 11 assertions **failed** against it — reproducing the exact reported bug (names SLM regardless, silent about `autobot-backend`, no fallback message) — confirming the tests can fail.
- `python3 -m py_compile` on the new `repo_tests` file — no syntax errors. `python3 -m ast` used to extract and re-verify the embedded mock script's shell-escaping matches the intended output (Python `\\"` → bash `\"` → JSON `"..."`), also checked with `bash -n`.
- The new pytest file follows this repo's existing pattern of executing bash logic under `repo_tests/` (see `repo_tests/shell_lib_test.py`) and will run as part of the required Python suite in CI, which is the actual verification this PR's own CI gates on.

## Model Used

Claude Sonnet 5

Closes #14417