### PR TITLE
fix(provision): ROLE_ANSIBLE_GROUPS named two groups the ansible layer never reads back (#14460)

### DIFF
--- a/autobot-slm-backend/api/setup_wizard.py
+++ b/autobot-slm-backend/api/setup_wizard.py
@@ -163,11 +163,16 @@ def _build_inventory_children(
     # nothing.
     #
     # The two maps are unioned rather than swapped, because neither is a
-    # superset: `databases`, `browser_automation` and tts-worker's
-    # `npu_worker` exist only in ROLE_ANSIBLE_GROUPS, and playbooks gate on
-    # them. Dropping either vocabulary would trade one silent no-op for
-    # another; a host in more groups cannot make a previously-matching play
-    # stop matching.
+    # superset: tts-worker's `npu_worker` exists only in ROLE_ANSIBLE_GROUPS,
+    # and playbooks gate on it. Dropping either vocabulary would trade one
+    # silent no-op for another; a host in more groups cannot make a
+    # previously-matching play stop matching.
+    #
+    # #14460: the other two names this note used to cite -- `databases` and
+    # `browser_automation` -- were NOT gated on anywhere. They were emitted
+    # and read back by nothing, so they contributed no activation at all;
+    # ROLE_ANSIBLE_GROUPS now names the consulted spellings (`database`,
+    # `browser`), which the canonical map emits too.
     ansible_groups = _ansible_groups_for_nodes(node_roles, node_id_to_inv_name)
 
     children: dict[str, dict] = {

--- a/autobot-slm-backend/services/inventory_builder.py
+++ b/autobot-slm-backend/services/inventory_builder.py
@@ -242,9 +242,12 @@ def _build_hostvars(node: Any, local_ip_check: Any) -> dict:
         # activate roles via node_roles, not group membership alone. Group-based
         # activation silently skips roles whose inventory group isn't the one
         # role_*_active checks (e.g. tts-worker -> npu_worker group, but
-        # role_tts_worker_active checks node_roles only; browser-service ->
-        # browser_automation group, but role_browser_active checks browser/
-        # browser_worker) — so optional assigned roles never deploy.
+        # role_tts_worker_active checks node_roles only) — so optional assigned
+        # roles never deploy.
+        # #14460: browser-service used to be the other example here, mapped to
+        # a `browser_automation` group while role_browser_active reads
+        # browser/browser_worker. That mismatch is fixed at the source in
+        # ROLE_ANSIBLE_GROUPS rather than left for this stamp to paper over.
         "node_roles": _union_roles(node),
     }
     if local_ip_check(node.ip_address):

--- a/autobot-slm-backend/services/role_registry.py
+++ b/autobot-slm-backend/services/role_registry.py
@@ -537,7 +537,13 @@ ROLE_DEPENDENCIES: Dict[str, List[str]] = {
     # SLM roles
     "slm-backend": ["python314", "nginx"],
     "slm-frontend": ["nodejs", "nginx"],
-    "slm-database": ["postgresql"],
+    # #14460: NOT just postgresql. inventory_builder._ROLE_TO_GROUPS puts
+    # slm-database in {redis, database} -- the same groups `role_redis_active`
+    # gates on -- so a node carrying it runs the redis ansible role and its
+    # unconditional `python3.14 -m venv`. The SLM roles are separable (see the
+    # section header above), so a node can carry slm-database without
+    # slm-backend, which is the only other declarer of the interpreter here.
+    "slm-database": ["postgresql", "python314"],
     "slm-monitoring": [],
     # Service roles
     #
@@ -569,8 +575,14 @@ ROLE_DEPENDENCIES: Dict[str, List[str]] = {
     "browser-service": ["nodejs"],
     "npu-worker": ["python314"],
     "tts-worker": ["python314"],
-    "autobot-llm-cpu": [],
-    "autobot-llm-gpu": [],
+    # #14460: NOT empty. The `autobot-llm-` prefix key in
+    # inventory_builder._ROLE_TO_GROUPS lands both roles in {ai_stack, aiml,
+    # ai, llm_nodes}; `role_ai_stack_active` gates on ai_stack/aiml, so
+    # provision-fleet-roles.yml applies the ai-stack ansible role, which
+    # creates a python3.14 venv. Same shape as slm-database above: the
+    # requirement comes from the group, not from the role's own name.
+    "autobot-llm-cpu": ["python314"],
+    "autobot-llm-gpu": ["python314"],
     # #14446: NOT empty. See the note on the service roles above -- vnc maps
     # into the backend group, so the backend ansible role runs on a vnc-only
     # node. Provisioning failed at the venv with "No such file or directory:

--- a/autobot-slm-backend/services/role_registry.py
+++ b/autobot-slm-backend/services/role_registry.py
@@ -485,6 +485,21 @@ DEFAULT_ROLES = (
 # Maps each role name to the inventory group(s) expected by
 # provision-fleet-roles.yml.  Used by _generate_dynamic_inventory()
 # in setup_wizard.py to build role-based host groups.
+#
+# #14460: a value here is only useful if the ansible layer CONSULTS that
+# group -- a `groups.get(...)` clause in playbooks/vars/role_active_facts.yml,
+# a play's `hosts:`, or a `groups[...]` lookup. Two values were consulted
+# nowhere: "databases" (plural) and "browser_automation". The inventory
+# builder created those groups and no play, fact or group_vars file ever
+# read them, so joining one activated nothing and inherited no group_vars.
+# Those roles only ever came up through the `node_roles` clause, which the
+# inventory stamps per host independently of group membership -- so the
+# breakage was invisible until someone relied on the group.
+# The consulted spellings are the ones services/inventory_builder.py already
+# emits (_ROLE_TO_GROUPS), the static inventory defines, and group_vars/ has
+# files for: `database` (+`redis`) and `browser` (+`browser_worker`).
+# test_role_registry.py::test_every_ansible_group_is_consulted_by_ansible
+# fails if any value drifts out of that vocabulary again.
 # ---------------------------------------------------------------------------
 ROLE_ANSIBLE_GROUPS: Dict[str, str] = {
     "backend": "backend",
@@ -494,10 +509,14 @@ ROLE_ANSIBLE_GROUPS: Dict[str, str] = {
     "frontend": "frontend",
     "ai-stack": "ai_stack",
     "chromadb": "ai_stack",
-    "redis": "databases",
-    "postgres": "databases",
+    # #14460: was "databases". `role_redis_active` gates on `redis`/`database`.
+    "redis": "database",
+    "postgres": "database",
     "npu-worker": "npu_worker",
-    "browser-service": "browser_automation",
+    # #14460: was "browser_automation". `role_browser_active` gates on
+    # `browser`/`browser_worker`; group_vars/browser.yml exists, none for the
+    # old spelling.
+    "browser-service": "browser",
     "autobot-llm-cpu": "llm_nodes",
     "autobot-llm-gpu": "llm_nodes",
     # tts-worker has Phase 5c in provision-fleet-roles.yml (#2959);
@@ -537,7 +556,14 @@ ROLE_DEPENDENCIES: Dict[str, List[str]] = {
     # which runs `python3.14 -m venv`. A redis-only node needs the interpreter
     # even though nothing about "redis" suggests it.
     "redis": ["python314"],
-    "postgres": ["postgresql"],
+    # #14460: NOT just postgresql. A postgres node joins the `database` group,
+    # and `role_redis_active` gates on that group -- so Phase 3 applies the
+    # *redis* ansible role, whose main.yml unconditionally
+    # `import_tasks: chromadb.yml` and runs `python3.14 -m venv`. The
+    # interpreter is imposed by the shared group, not by postgres itself.
+    # #14446's guard could not see this: its group path looked up "databases",
+    # a name no fact mentions, so it found nothing to require.
+    "postgres": ["postgresql", "python314"],
     "ai-stack": ["python314"],
     "chromadb": ["python314"],
     "browser-service": ["nodejs"],

--- a/autobot-slm-backend/tests/services/test_role_registry.py
+++ b/autobot-slm-backend/tests/services/test_role_registry.py
@@ -632,9 +632,9 @@ def test_the_derivation_finds_something():
         "slm-database no longer resolves into the `database` group - the union with "
         "inventory_builder._ROLE_TO_GROUPS is not being applied"
     )
-    assert "ai_stack" in _groups_a_role_joins("autobot-llm-cpu"), (
-        "autobot-llm-cpu no longer resolves into `ai_stack` - the prefix half of the canonical map is not reached"
-    )
+    assert "ai_stack" in _groups_a_role_joins(
+        "autobot-llm-cpu"
+    ), "autobot-llm-cpu no longer resolves into `ai_stack` - the prefix half of the canonical map is not reached"
 
 
 def test_every_role_declares_what_its_group_actually_requires():

--- a/autobot-slm-backend/tests/services/test_role_registry.py
+++ b/autobot-slm-backend/tests/services/test_role_registry.py
@@ -15,6 +15,7 @@ implementation, so it removes the stub from sys.modules before importing.
 """
 
 import importlib
+import importlib.util
 import re as _re
 import subprocess as _subprocess
 import sys
@@ -449,6 +450,53 @@ def test_all_role_ansible_playbooks_resolve():
 # The requirement is DERIVED here rather than listed. A test that restated
 # either map would have passed: each map is self-consistent on its own, and
 # the defect lives in the relationship between them.
+#
+# #14460: the group half is now derived from BOTH group maps. Reading
+# ROLE_ANSIBLE_GROUPS alone made this rule blind to every role whose real
+# membership comes from `inventory_builder._ROLE_TO_GROUPS` -- which is the
+# authoritative map for `build_registry_inventory()`, the primary provisioning
+# path, and which `_ansible_groups_for_nodes` unions in on the wizard path too.
+# The rule was reasoning about the wrong vocabulary and reporting clean: the
+# same shape as the defect it exists to catch.
+
+_INVENTORY_BUILDER = None
+
+
+def _inventory_builder():
+    """Real-load services/inventory_builder.py under a private name.
+
+    Loaded by path rather than as `services.inventory_builder`, because the
+    conftest stubs that name with a MagicMock whose group sets iterate as
+    EMPTY -- indistinguishable from a role joining no groups, so every rule
+    below would report clean. Lazy, and the private name is popped again, so
+    nothing leaks into sys.modules for later test files.
+    """
+    global _INVENTORY_BUILDER
+    if _INVENTORY_BUILDER is None:
+        spec = importlib.util.spec_from_file_location("_ib_14460", _Path(_SERVICES_DIR) / "inventory_builder.py")
+        module = importlib.util.module_from_spec(spec)
+        sys.modules["_ib_14460"] = module
+        try:
+            spec.loader.exec_module(module)
+        finally:
+            sys.modules.pop("_ib_14460", None)
+        _INVENTORY_BUILDER = module
+    return _INVENTORY_BUILDER
+
+
+def _groups_a_role_joins(role: str) -> set:
+    """Every inventory group a node carrying *role* lands in (#14460).
+
+    The union of both maps, mirroring what
+    `api/setup_wizard.py::_ansible_groups_for_nodes` does for one node --
+    neither map is a superset, and a group from either one activates ansible
+    roles just the same.
+    """
+    groups = set(_inventory_builder().groups_for_role_tokens([role]))
+    legacy = ROLE_ANSIBLE_GROUPS.get(role)
+    if legacy:
+        groups.add(legacy)
+    return groups
 
 
 def _activation_sources() -> dict:
@@ -576,6 +624,18 @@ def test_the_derivation_finds_something():
     )
     assert _ansible_role_needs_nginx("backend"), "the backend role's ungated nginx start is no longer detected"
 
+    # #14460: the union half. If inventory_builder came back a MagicMock, or
+    # its map moved, `_groups_a_role_joins` would silently collapse to the
+    # legacy map -- exactly the blind spot that let `slm-database` and the two
+    # llm roles sit undeclared. Both memberships come only from _ROLE_TO_GROUPS.
+    assert "database" in _groups_a_role_joins("slm-database"), (
+        "slm-database no longer resolves into the `database` group - the union with "
+        "inventory_builder._ROLE_TO_GROUPS is not being applied"
+    )
+    assert "ai_stack" in _groups_a_role_joins("autobot-llm-cpu"), (
+        "autobot-llm-cpu no longer resolves into `ai_stack` - the prefix half of the canonical map is not reached"
+    )
+
 
 def test_every_role_declares_what_its_group_actually_requires():
     """The #14446 invariant, over every shared dependency -- not just the first to fail.
@@ -600,11 +660,14 @@ def test_every_role_declares_what_its_group_actually_requires():
                 role_requires.setdefault(node_role, {})[dependency] = ansible_role
 
     offenders = []
-    for role, group in ROLE_ANSIBLE_GROUPS.items():
+    for role in sorted(set(ROLE_ANSIBLE_GROUPS) | set(ROLE_DEPENDENCIES)):
         declared = ROLE_DEPENDENCIES.get(role, [])
-        for dependency, via in group_requires.get(group, {}).items():
-            if dependency not in declared:
-                offenders.append(f"{role!r} joins group {group!r} (runs {via!r}) but does not declare {dependency!r}")
+        for group in sorted(_groups_a_role_joins(role)):
+            for dependency, via in group_requires.get(group, {}).items():
+                if dependency not in declared:
+                    offenders.append(
+                        f"{role!r} joins group {group!r} (runs {via!r}) but does not declare {dependency!r}"
+                    )
 
     # The node-roles half: a role that activates itself by name, with no group
     # involved at all.
@@ -640,6 +703,30 @@ def test_the_backend_group_roles_declare_both(role, dependency):
     )
 
 
+@pytest.mark.parametrize(
+    ("role", "group", "ansible_role"),
+    [
+        ("slm-database", "database", "redis"),
+        ("autobot-llm-cpu", "ai_stack", "ai-stack"),
+        ("autobot-llm-gpu", "ai_stack", "ai-stack"),
+    ],
+)
+def test_the_canonical_map_roles_declare_the_interpreter(role, group, ansible_role):
+    """#14460: the three the union-derived rule surfaced, pinned by name.
+
+    Each reaches its group only through `inventory_builder._ROLE_TO_GROUPS`
+    -- `ROLE_ANSIBLE_GROUPS` says `slm_server` / `llm_nodes`, neither of which
+    imposes anything -- so the rule above could not see them while it read one
+    map. Named here so a derivation that quietly stops finding anything fails
+    instead of reporting a clean run.
+    """
+    assert group in _groups_a_role_joins(role), f"{role} no longer joins {group}"
+    assert "python314" in ROLE_DEPENDENCIES[role], (
+        f"{role} joins {group!r}, which activates the {ansible_role!r} ansible role and its "
+        f"unconditional `python3.14 -m venv`, but declares no interpreter (#14460)"
+    )
+
+
 # ---------------------------------------------------------------------------
 # #14460: a group name nothing consults cannot activate anything
 # ---------------------------------------------------------------------------
@@ -669,21 +756,32 @@ def _groups_gated_by_active_facts() -> dict:
     return consulted
 
 
-_GROUPS_LOOKUP = _re.compile(r"groups\[['\"]([a-zA-Z0-9_-]+)['\"]\]|groups\.get\(['\"]([a-zA-Z0-9_-]+)['\"]")
+_GROUPS_LOOKUP = _re.compile(
+    r"groups\[['\"]([a-zA-Z0-9_-]+)['\"]\]"
+    r"|groups\.get\(['\"]([a-zA-Z0-9_-]+)['\"]"
+    # `'<name>' in group_names` is the third form this tree uses, heavily
+    # (manage_services.yml, health-check.yml, recover_host.yml,
+    # pre-deployment-validation.yml, roles/dependency_patching/). Every
+    # current such reference is also reachable via groups.get(...), so
+    # omitting it changed no verdict today -- but a group consulted ONLY this
+    # way would have been reported as an inert offender, blocking a
+    # legitimate change on a false positive.
+    r"|['\"]([a-zA-Z0-9_-]+)['\"]\s+in\s+group_names"
+)
 
 
 def _groups_referenced_in_playbooks() -> dict:
-    """Group name -> ansible files selecting it via `hosts:` or `groups[...]`.
+    """Group name -> ansible files selecting it via `hosts:` or a group lookup.
 
     A group with no `role_*_active` fact can still be live: plays select
-    groups directly. Both forms count, so the rule stays no narrower than its
+    groups directly. Every form counts, so the rule stays no narrower than its
     own subject.
     """
     consulted: dict = {}
     for path in _ANSIBLE_DIR.rglob("*.yml"):
         text = path.read_text(encoding="utf-8", errors="replace")
         for match in _GROUPS_LOOKUP.finditer(text):
-            consulted.setdefault(match.group(1) or match.group(2), set()).add(path.name)
+            consulted.setdefault(match.group(1) or match.group(2) or match.group(3), set()).add(path.name)
         for line in text.splitlines():
             hosts = _re.match(r"\s*hosts:\s*([^#]+)", line)
             if not hosts:

--- a/autobot-slm-backend/tests/services/test_role_registry.py
+++ b/autobot-slm-backend/tests/services/test_role_registry.py
@@ -153,12 +153,33 @@ def test_postgres_role_present():
     assert role["target_path"] == "/var/lib/postgresql"
 
 
-def test_postgres_in_databases_ansible_group():
-    assert ROLE_ANSIBLE_GROUPS["postgres"] == "databases"
+def test_postgres_joins_a_group_the_data_layer_fact_gates_on():
+    """#14460: the group postgres joins must be one `role_redis_active` reads.
+
+    This used to read `== "databases"` -- a literal restatement of the map,
+    which is why it passed for as long as the map named a group no fact, play
+    or group_vars file ever consulted. Anchored to the fact expression, so the
+    two can only agree by actually agreeing.
+    """
+    consulted = _activation_sources()["redis"]["groups"]
+    assert ROLE_ANSIBLE_GROUPS["postgres"] in consulted, (
+        f"postgres joins group {ROLE_ANSIBLE_GROUPS['postgres']!r}, which role_redis_active "
+        f"does not consult ({sorted(consulted)}) - group membership activates nothing"
+    )
 
 
 def test_postgres_dependencies():
-    assert ROLE_DEPENDENCIES["postgres"] == ["postgresql"]
+    """#14460: derived from the group it shares with redis, not restated.
+
+    A postgres node lands in `database`, `role_redis_active` gates on that
+    group, so Phase 3 runs the redis ansible role -- venv included. Whatever
+    redis declares, postgres needs too.
+    """
+    assert "postgresql" in ROLE_DEPENDENCIES["postgres"]
+    assert set(ROLE_DEPENDENCIES["postgres"]) >= set(ROLE_DEPENDENCIES["redis"]), (
+        "postgres shares the `database` inventory group with redis (ROLE_ANSIBLE_GROUPS), so the "
+        "redis ansible role runs on it, but it declares fewer dependencies than redis"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -617,3 +638,111 @@ def test_the_backend_group_roles_declare_both(role, dependency):
         f"{role} does not declare {dependency}, but joins the backend group and runs the backend "
         f"ansible role, which requires it unconditionally (#14446)"
     )
+
+
+# ---------------------------------------------------------------------------
+# #14460: a group name nothing consults cannot activate anything
+# ---------------------------------------------------------------------------
+#
+# ROLE_ANSIBLE_GROUPS is a *producer*: the inventory builder creates whatever
+# group it names. Creating a group only matters if the ansible layer reads it
+# back. Two values were read back nowhere -- "databases" (plural) while every
+# fact, play, static-inventory group and group_vars file says `database`, and
+# "browser_automation" while they all say `browser`/`browser_worker`.
+#
+# Nothing broke visibly because activation has a second path: the inventory
+# stamps `node_roles` per host, and `'redis' in node_roles` still matched. So
+# the group half was dead while reading as live -- adding a node to the group
+# and expecting the role to fire got silence, and the host also inherited no
+# group_vars.
+#
+# The rule below is derived from what the ansible tree actually consults, not
+# from a list of blessed names, so a new value is checked the same way.
+
+
+def _groups_gated_by_active_facts() -> dict:
+    """Group name -> the `role_*_active` facts that OR on it."""
+    consulted: dict = {}
+    for ansible_role, sources in _activation_sources().items():
+        for group in sources["groups"]:
+            consulted.setdefault(group, set()).add(f"role_{ansible_role.replace('-', '_')}_active")
+    return consulted
+
+
+_GROUPS_LOOKUP = _re.compile(r"groups\[['\"]([a-zA-Z0-9_-]+)['\"]\]|groups\.get\(['\"]([a-zA-Z0-9_-]+)['\"]")
+
+
+def _groups_referenced_in_playbooks() -> dict:
+    """Group name -> ansible files selecting it via `hosts:` or `groups[...]`.
+
+    A group with no `role_*_active` fact can still be live: plays select
+    groups directly. Both forms count, so the rule stays no narrower than its
+    own subject.
+    """
+    consulted: dict = {}
+    for path in _ANSIBLE_DIR.rglob("*.yml"):
+        text = path.read_text(encoding="utf-8", errors="replace")
+        for match in _GROUPS_LOOKUP.finditer(text):
+            consulted.setdefault(match.group(1) or match.group(2), set()).add(path.name)
+        for line in text.splitlines():
+            hosts = _re.match(r"\s*hosts:\s*([^#]+)", line)
+            if not hosts:
+                continue
+            for token in _re.split(r"[,:]", hosts.group(1)):
+                token = token.strip().strip("\"'")
+                if token and not token.startswith("{{"):
+                    consulted.setdefault(token, set()).add(f"{path.name} (hosts:)")
+    return consulted
+
+
+def _groups_consulted_by_ansible() -> dict:
+    """Every group name the ansible layer reads back, with where it reads it."""
+    consulted = _groups_gated_by_active_facts()
+    for group, sites in _groups_referenced_in_playbooks().items():
+        consulted.setdefault(group, set()).update(sites)
+    return consulted
+
+
+def test_the_consulted_group_scan_sees_the_live_vocabulary():
+    """An empty or broken scan would make the rule below vacuously green.
+
+    Each name here is consulted by a different mechanism -- `backend` and
+    `database` by active facts, `slm_server` by both, `main` by plays alone --
+    so losing any one mechanism fails loudly instead of reporting a clean run.
+    """
+    consulted = _groups_consulted_by_ansible()
+    assert consulted, f"no group references parsed out of {_ANSIBLE_DIR} - the scan is broken"
+    for live in ("backend", "database", "redis", "browser", "slm_server", "main", "frontend"):
+        assert live in consulted, f"{live!r} is consulted by the ansible tree but the scan missed it"
+
+
+def test_every_ansible_group_is_consulted_by_ansible():
+    """Every group the inventory builder names must be read back somewhere.
+
+    Fails on a producer/consumer mismatch: the builder emits the group, and
+    no fact, play or `groups[...]` lookup mentions it. Such a group cannot
+    activate anything, and the failure is silent -- provisioning reports
+    success having skipped the role.
+    """
+    consulted = _groups_consulted_by_ansible()
+    inert = sorted(
+        f"{role!r} -> group {group!r}" for role, group in ROLE_ANSIBLE_GROUPS.items() if group not in consulted
+    )
+    assert not inert, (
+        "ROLE_ANSIBLE_GROUPS names group(s) the ansible layer never consults, so joining them "
+        "activates nothing and inherits no group_vars (#14460): " + "; ".join(inert)
+    )
+
+
+def test_the_data_layer_roles_reach_their_own_activation_fact():
+    """The instance the rule was written for, named.
+
+    `redis` and `postgres` share one group. `role_redis_active` is what
+    Phase 3 gates the redis ansible role on, so the group they join has to be
+    one of the names that fact reads.
+    """
+    consulted = _activation_sources()["redis"]["groups"]
+    for role in ("redis", "postgres"):
+        assert ROLE_ANSIBLE_GROUPS[role] in consulted, (
+            f"{role} joins {ROLE_ANSIBLE_GROUPS[role]!r}; role_redis_active reads {sorted(consulted)}"
+        )

--- a/autobot-slm-backend/tests/services/test_role_registry.py
+++ b/autobot-slm-backend/tests/services/test_role_registry.py
@@ -743,6 +743,6 @@ def test_the_data_layer_roles_reach_their_own_activation_fact():
     """
     consulted = _activation_sources()["redis"]["groups"]
     for role in ("redis", "postgres"):
-        assert ROLE_ANSIBLE_GROUPS[role] in consulted, (
-            f"{role} joins {ROLE_ANSIBLE_GROUPS[role]!r}; role_redis_active reads {sorted(consulted)}"
-        )
+        assert (
+            ROLE_ANSIBLE_GROUPS[role] in consulted
+        ), f"{role} joins {ROLE_ANSIBLE_GROUPS[role]!r}; role_redis_active reads {sorted(consulted)}"

--- a/autobot-slm-backend/tests/services/test_wizard_inventory_parity_14286.py
+++ b/autobot-slm-backend/tests/services/test_wizard_inventory_parity_14286.py
@@ -188,10 +188,15 @@ def test_the_wizard_children_carry_the_canonical_alias_groups():
 def test_no_group_this_path_already_emitted_disappears():
     """Every ROLE_ANSIBLE_GROUPS value still resolves after the change.
 
-    The two maps are not supersets of each other — `databases`,
-    `browser_automation` and tts-worker's `npu_worker` exist only in
-    ROLE_ANSIBLE_GROUPS, and playbooks gate on them. Swapping rather than
-    unioning would trade one silent no-op for another.
+    The two maps are not supersets of each other — tts-worker's `npu_worker`
+    exists only in ROLE_ANSIBLE_GROUPS, and playbooks gate on it. Swapping
+    rather than unioning would trade one silent no-op for another.
+
+    #14460: this note used to cite `databases` and `browser_automation` as
+    gated-on too. They were not gated on anywhere, which is why they could sit
+    inert; ROLE_ANSIBLE_GROUPS now names `database`/`browser`, so this test
+    passes through the canonical map for those roles rather than through a
+    name only this path emitted.
     """
     for role, legacy_group in ROLE_ANSIBLE_GROUPS.items():
         children = _children_for({"n": [role]})


### PR DESCRIPTION
Closes #14460

## Thinking Path

The issue asks one question first: is `databases` dead naming, or a missing consumer? Those have opposite fixes, so I looked for how the *other* values in `ROLE_ANSIBLE_GROUPS` are consumed rather than grepping the symbol.

Four independent consumption sites agree, and all four say `database`, never `databases`:

| Site | What it says |
|---|---|
| `ansible/playbooks/vars/role_active_facts.yml` | `role_redis_active` ORs on `groups.get('redis')` and `groups.get('database')` |
| `services/inventory_builder.py` `_ROLE_TO_GROUPS` | `redis -> {redis, database}`, `postgres -> {database}` |
| static inventory `inventory/slm-nodes.yml` | defines groups `redis` and `database` |
| `inventory/group_vars/` | has `database.yml` and `browser.yml`; no `databases.yml`, no `browser_automation.yml` |

**Verdict: dead naming, superseded — not a missing consumer.** The superseding site is `_ROLE_TO_GROUPS` in `services/inventory_builder.py`, and the supersession is provable rather than asserted: since #14286 the wizard path unions both maps from the *same* `node_roles` rows (`_ansible_groups_for_nodes`), so every group `ROLE_ANSIBLE_GROUPS` could contribute for these roles — `database`, `redis`, `browser`, `browser_worker` — is already emitted by `groups_for_role_tokens` for the same host. The only thing the old spelling contributed was the inert name itself. So this is a retarget onto the canonical vocabulary, not a removal of behaviour: no node loses a group it had.

Writing the guard surfaced a second instance of the identical mismatch in the same dict — `browser-service -> browser_automation`, while `role_browser_active` reads `browser`/`browser_worker`. A guard scoped to only the db roles would have been narrower than its own subject, so both are fixed.

While checking the retarget I **found** a live provisioning bug — the retarget did not cause or expose it. A postgres node lands in `database`; `role_redis_active` gates on that group; Phase 3 therefore applies the **redis** ansible role, whose `roles/redis/tasks/main.yml` unconditionally `import_tasks: chromadb.yml`, which runs `python3.14 -m venv`. `ROLE_DEPENDENCIES["postgres"]` declared only `postgresql`, so Phase 0 installed no interpreter — the #14446 failure mode, one role over.

To be precise about the causality, because a PR body that overstates its own role is how the next person mis-times a rollback: `_ROLE_TO_GROUPS["postgres"] -> database` has existed since `1e62f0ba6` (#10110), `_ansible_groups_for_nodes` has unioned it since `2eb9c01ea` (#14286), and `build_registry_inventory()` — the primary fleet-provisioning path — never reads `ROLE_ANSIBLE_GROUPS` at all. This retarget changes zero real hosts' membership. The bug was independently live and reachable long before this PR; it was found during unrelated housekeeping.

What *did* hide it is the guard, not the group name: #14446's rule keys off `ROLE_ANSIBLE_GROUPS`, looked up `"databases"`, found no requirement, and reported clean. So the guard was reasoning about a vocabulary that does not decide membership — reviewed and confirmed, and addressed below.

### The guard was reading the wrong map, not just the wrong name

Review pointed out that `test_every_role_declares_what_its_group_actually_requires` never consults `_ROLE_TO_GROUPS`, which is authoritative for `build_registry_inventory()`. The rule now derives group membership from the **union** of both maps, mirroring what `_ansible_groups_for_nodes` already does per node. That surfaces three more roles whose real group comes only from the canonical map, each with the identical undeclared interpreter:

| Role | `ROLE_ANSIBLE_GROUPS` (imposes nothing) | `_ROLE_TO_GROUPS` | Activates | Needs |
|---|---|---|---|---|
| `slm-database` | `slm_server` | `{redis, database}` | `role_redis_active` -> redis role | `python314` |
| `autobot-llm-cpu` | `llm_nodes` | `{ai_stack, aiml, ai, llm_nodes}` | `role_ai_stack_active` -> ai-stack role | `python314` |
| `autobot-llm-gpu` | `llm_nodes` | `{ai_stack, aiml, ai, llm_nodes}` | `role_ai_stack_active` -> ai-stack role | `python314` |

**`slm-database` is live, not a code-level gap.** The round-trip was checked as asked: `main.py::_ensure_local_node` persists `["slm-backend", "slm-frontend", "slm-database", "slm-monitoring"]` into `Node.roles` *and* `Node.detected_roles`, and creates a `NodeRole` row per name — so the short key `slm-database` that both dicts share is the vocabulary actually in the DB, on the `Node.roles` path (`inventory_builder`) and the `NodeRole` path (`setup_wizard`) alike. The SLM roles are separable by design, so a node can carry `slm-database` without `slm-backend`, the only other declarer of the interpreter.

The seeded spelling is a different story and does *not* round-trip: `seed-fleet-nodes.yml` posts `autobot-slm-database`, which matches no `_ROLE_TO_GROUPS` key by exact or prefix match. It is masked today because the startup registration heals `detected_roles` to the short forms. That is a separate vocabulary drift in a different scope, filed as **#14487**.

## What Changed

- `services/role_registry.py`
  - `ROLE_ANSIBLE_GROUPS`: `redis`/`postgres` `databases` -> `database`; `browser-service` `browser_automation` -> `browser`. Comment states the contract: a value is only useful if the ansible layer reads that group back.
  - `ROLE_DEPENDENCIES`: `postgres` `["postgresql"]` -> `["postgresql", "python314"]`; `slm-database` likewise; `autobot-llm-cpu` / `autobot-llm-gpu` `[]` -> `["python314"]`. Each carries the derivation in the comment — the requirement comes from the group, not from the role's own name.
- `tests/services/test_role_registry.py`
  - New guard `test_every_ansible_group_is_consulted_by_ansible`: derives the consulted vocabulary from the ansible tree itself — `role_*_active` `groups.get(...)` clauses, plus play `hosts:` selectors and `groups[...]` lookups — and fails on any `ROLE_ANSIBLE_GROUPS` value outside it. Derived, not a blessed-name list, so a new value is checked the same way.
  - `test_the_consulted_group_scan_sees_the_live_vocabulary`: pins the scan against names reached by different mechanisms, so an empty or broken parse fails loudly instead of reading as clean.
  - `test_the_data_layer_roles_reach_their_own_activation_fact`: the named instance.
  - `test_postgres_joins_a_group_the_data_layer_fact_gates_on` replaces `test_postgres_in_databases_ansible_group`, which asserted `== "databases"` — a literal restatement of the map, which is precisely why it stayed green while the map named a group nothing consulted.
  - `test_postgres_dependencies` re-anchored to `>= ROLE_DEPENDENCIES["redis"]` (same pattern #14446 used for scheduler/backend) instead of restating a literal list.
  - `test_every_role_declares_what_its_group_actually_requires` (#14446) now derives membership from `_groups_a_role_joins()` — the union of `ROLE_ANSIBLE_GROUPS` and `inventory_builder.groups_for_role_tokens()`. `inventory_builder` is real-loaded by path under a private name and popped again: the conftest stubs `services.inventory_builder` with a MagicMock whose group sets iterate as EMPTY, which is indistinguishable from a role joining no groups and would make the rule report clean.
  - `test_the_derivation_finds_something` extended to pin the union half (`slm-database` -> `database`, `autobot-llm-cpu` -> `ai_stack`), so a collapse back to the legacy map fails instead of quietly finding nothing.
  - `test_the_canonical_map_roles_declare_the_interpreter`: the three surfaced roles, named.
  - `_groups_referenced_in_playbooks` widened to the `'<name>' in group_names` form the tree uses in `manage_services.yml`, `health-check.yml`, `recover_host.yml`, `pre-deployment-validation.yml` and `roles/dependency_patching/`. No verdict changes today (36 consulted names either way — every such reference is also reachable via `groups.get(...)`), but a group consulted *only* that way would have been reported as a false offender and blocked a legitimate change.
- Comment corrections at three sites that asserted the old names were gated on by playbooks (`api/setup_wizard.py`, `services/inventory_builder.py`, `tests/services/test_wizard_inventory_parity_14286.py`). The claim was inherited from #14286 and was false for both names; leaving it would re-legitimise the bug.

## Verification

**The guard discriminates.** The derivation was re-implemented standalone (importing nothing from the repo) over the real ansible tree, then applied to the `ROLE_ANSIBLE_GROUPS` literal extracted from both file versions:

```
consulted group names derived from the ansible tree: 36
  backend      consulted by ['all.yml', 'data-migration.yml', 'data-migration.yml (hosts:)']
  database     consulted by ['all.yml', 'backend-env.yml', 'configure-redis-service-management.yml (hosts:)']
  browser      consulted by ['all.yml', 'deploy-backend-local.yml', 'deploy-backend-remote.yml']

PRE-FIX  (origin/Dev_new_gui):
  offenders: ["'browser-service' -> 'browser_automation'", "'postgres' -> 'databases'", "'redis' -> 'databases'"]
POST-FIX (worktree):
  offenders: NONE

databases in consulted set? False
browser_automation in consulted set? False
role_redis_active groups: ['database', 'redis']

DISCRIMINATES: True
```

So against the pre-fix code the guard fails, naming all three entries; against the fixed code it passes. It asserts on parsed behaviour — which groups the facts and plays actually read — not on source text, and `test_the_consulted_group_scan_sees_the_live_vocabulary` makes an empty scan fail rather than pass.

`test_the_data_layer_roles_reach_their_own_activation_fact` and `test_postgres_joins_a_group_the_data_layer_fact_gates_on` discriminate the same way: `"databases" not in {"database", "redis"}` pre-fix, in it post-fix.

`test_postgres_dependencies` discriminates on the other change: pre-fix `{"postgresql"} >= {"python314"}` is false.

**The union-derived rule discriminates, and the legacy-keyed one reported clean.** Same standalone method, re-implementing the #14446 rule both ways over the real ansible tree, against the declarations at commit 1 vs now:

```
group -> requirement (derived):
  ai_stack       {'python314': 'ai-stack'}      database   {'python314': 'redis'}
  aiml           {'python314': 'ai-stack'}      frontend   {'nginx': 'frontend'}
  backend/main   {'python314': 'backend', 'nginx': 'backend'}
  npu/npu_worker/npu_workers  {'python314': 'npu-worker'}    redis  {'python314': 'redis'}

A. legacy-keyed rule (as shipped in commit 1), declarations at commit 1:
    NONE  <- reported clean

B. union-keyed rule, declarations at commit 1 (BEFORE):
  'autobot-llm-cpu' joins 'ai_stack' (runs 'ai-stack') but does not declare 'python314'
  'autobot-llm-cpu' joins 'aiml'     (runs 'ai-stack') but does not declare 'python314'
  'autobot-llm-gpu' joins 'ai_stack' (runs 'ai-stack') but does not declare 'python314'
  'autobot-llm-gpu' joins 'aiml'     (runs 'ai-stack') but does not declare 'python314'
  'slm-database'    joins 'database' (runs 'redis')    but does not declare 'python314'
  'slm-database'    joins 'redis'    (runs 'redis')    but does not declare 'python314'

C. union-keyed rule, declarations now (AFTER):
    NONE

groups slm-database joins:    ['database', 'redis']
groups autobot-llm-cpu joins: ['ai', 'ai_stack', 'aiml', 'llm_nodes']
ROLE_ANSIBLE_GROUPS says: {'slm-database': 'slm_server', 'autobot-llm-cpu': 'llm_nodes',
                           'autobot-llm-gpu': 'llm_nodes'}
```

Line A is the point: the rule as shipped in the first commit was green on exactly the declarations that line B condemns.

**The postgres dependency is forced, not chosen.** With the group renamed and `python314` left out, #14446's existing derived guard (`test_every_role_declares_what_its_group_actually_requires`) fails on its own: `role_redis_active` maps group `database` to ansible role `redis`, `_ansible_role_needs_python("redis")` is true via the ungated `import_tasks: chromadb.yml` -> `python3.14 -m venv`, and postgres declared neither.

**Nothing loses a group.** `test_no_group_this_path_already_emitted_disappears` (#14286) asserts every `ROLE_ANSIBLE_GROUPS` value still resolves to its host; `database` and `browser` are emitted for these roles by `_ROLE_TO_GROUPS` regardless of this map, so it holds. The `node_roles` activation path is untouched, so existing deployments relying on it keep working (AC3).

No ansible, deployment script or repo code was executed — the probe is a standalone parser over the ansible YAML, and CI runs the suite.

## Model Used

Claude Opus 5 (1M context)
