### PR TITLE
fix(kb): single-sentence chunks skip subclass metadata (#14467)

### DIFF
--- a/autobot-backend/utils/semantic_chunker_base.py
+++ b/autobot-backend/utils/semantic_chunker_base.py
@@ -358,19 +358,20 @@ class SemanticChunkerBase(ABC):
             sentences = self._split_into_sentences(text)
             if len(sentences) <= 1:
                 chunks = [self._create_single_sentence_chunk(text, sentences)]
-                self._enrich_chunks_with_metadata(chunks, metadata)
-                return chunks
+            else:
+                logger.debug("Split text into %d sentences", len(sentences))
 
-            logger.debug("Split text into %d sentences", len(sentences))
+                await self._initialize_model()
+                embeddings = await self._compute_embeddings(sentences)
+                distances = self._compute_semantic_distances(embeddings)
+                boundaries = self._find_chunk_boundaries(distances)
 
-            await self._initialize_model()
-            embeddings = await self._compute_embeddings(sentences)
-            distances = self._compute_semantic_distances(embeddings)
-            boundaries = self._find_chunk_boundaries(distances)
+                logger.debug("Found %d semantic boundaries", len(boundaries))
 
-            logger.debug("Found %d semantic boundaries", len(boundaries))
+                chunks = self._create_chunks_with_boundaries(sentences, boundaries, distances)
 
-            chunks = self._create_chunks_with_boundaries(sentences, boundaries, distances)
+            # Issue #14467: a single trailing call so neither branch above — nor a
+            # future one — can reintroduce the defect by forgetting to enrich.
             self._enrich_chunks_with_metadata(chunks, metadata)
 
             if chunks:

--- a/autobot-backend/utils/semantic_chunker_base.py
+++ b/autobot-backend/utils/semantic_chunker_base.py
@@ -256,16 +256,25 @@ class SemanticChunkerBase(ABC):
 
     # ---- Single-sentence + metadata helpers ---------------------------
 
-    def _create_single_sentence_chunk(
-        self, text: str, sentences: List[str], metadata: Dict[str, Any] | None
-    ) -> SemanticChunk:
+    def _create_single_sentence_chunk(self, text: str, sentences: List[str]) -> SemanticChunk:
+        """Zero/one-sentence fallback chunk (Issue #14467).
+
+        Carries only the chunk-shape marker; subclass and pipeline metadata
+        (`optimization_version`, `chunk_index`, ...) is applied afterwards by
+        `_enrich_chunks_with_metadata()` in `chunk_text()` — the same call the
+        multi-sentence path uses — so both paths agree on one enrichment point.
+        """
+        chunk_metadata: Dict[str, Any] = {"single_sentence": True}
+        if not sentences:
+            chunk_metadata["empty_input"] = True
+
         return SemanticChunk(
             content=text,
             start_index=0,
             end_index=1,
             sentences=sentences,
             semantic_score=1.0,
-            metadata=metadata or {"single_sentence": True},
+            metadata=chunk_metadata,
         )
 
     def _build_chunk_metadata(
@@ -348,7 +357,9 @@ class SemanticChunkerBase(ABC):
 
             sentences = self._split_into_sentences(text)
             if len(sentences) <= 1:
-                return [self._create_single_sentence_chunk(text, sentences, metadata)]
+                chunks = [self._create_single_sentence_chunk(text, sentences)]
+                self._enrich_chunks_with_metadata(chunks, metadata)
+                return chunks
 
             logger.debug("Split text into %d sentences", len(sentences))
 

--- a/autobot-backend/utils/semantic_chunker_gpu_test.py
+++ b/autobot-backend/utils/semantic_chunker_gpu_test.py
@@ -36,6 +36,27 @@ from utils.semantic_chunker_gpu import GPUSemanticChunker, get_gpu_semantic_chun
 
 _TEXT = "First sentence here. Second sentence follows now. Third one too right now."
 
+# Issue #14467: input shapes that exercise `chunk_text()`'s zero/one-sentence
+# fallback (`_create_single_sentence_chunk`) instead of the boundary-detection
+# path. "Hi." is filtered to zero sentences by the >=3-word rule in
+# `_split_into_sentences` (#380); the other has exactly one qualifying sentence.
+_EMPTY_SENTENCE_TEXT = "Hi."
+_ONE_SENTENCE_TEXT = "This single sentence is deliberately long enough to survive filtering."
+
+# Keys `_build_chunk_metadata()`/`_extra_chunk_metadata()` add on every chunk,
+# regardless of which internal path produced it.
+_SUBCLASS_METADATA_KEYS = frozenset(
+    {
+        "chunk_index",
+        "total_chunks",
+        "source_metadata",
+        "embedding_model",
+        "chunking_method",
+        "gpu_batch_size",
+        "optimization_version",
+    }
+)
+
 
 @pytest.mark.asyncio
 class TestOptimizationMetadataReachesTheProductionSingleton:
@@ -74,3 +95,49 @@ class TestOptimizationMetadataReachesTheProductionSingleton:
 
         assert chunks
         assert all(c.metadata.get("optimization_version") == "rtx4070_gpu" for c in chunks)
+
+
+@pytest.mark.asyncio
+class TestShortInputChunksCarryTheSameMetadataAsLongInput:
+    """Issue #14467: `_create_single_sentence_chunk` used to return before
+    `_enrich_chunks_with_metadata()` ran, so `chunk_text()` on zero- or
+    one-sentence input silently dropped `optimization_version` and the rest
+    of `_build_chunk_metadata()`'s keys, while identical multi-sentence input
+    kept them. All three assertions below enter through the real, public
+    `chunk_text()` — never `_create_single_sentence_chunk` directly — so a fix
+    that only special-cases the private method without wiring it into the
+    public path would still fail here.
+
+    Pre-fix: the single- and empty-input cases fail (missing every key in
+    `_SUBCLASS_METADATA_KEYS`). Post-fix: all three pass.
+    """
+
+    async def _chunk_text(self, chunker: GPUSemanticChunker, text: str):
+        with (
+            patch.object(chunker, "_initialize_model", AsyncMock(return_value=None)),
+            patch.object(chunker, "_compute_embeddings", AsyncMock(return_value=np.zeros((3, 4)))),
+            patch.object(chunker, "_compute_semantic_distances", return_value=[0.1, 0.1]),
+        ):
+            return await chunker.chunk_text(text)
+
+    async def test_single_sentence_input_matches_multi_sentence_metadata_keys(self):
+        chunker = GPUSemanticChunker(gpu_batch_size=10, enable_gpu_memory_pool=False)
+
+        multi_chunks = await self._chunk_text(chunker, _TEXT)
+        single_chunks = await self._chunk_text(chunker, _ONE_SENTENCE_TEXT)
+
+        assert multi_chunks and single_chunks
+        for chunk in multi_chunks + single_chunks:
+            missing = _SUBCLASS_METADATA_KEYS - chunk.metadata.keys()
+            assert not missing, f"chunk missing keys {missing}: {sorted(chunk.metadata.keys())}"
+
+    async def test_empty_input_matches_multi_sentence_metadata_keys(self):
+        chunker = GPUSemanticChunker(gpu_batch_size=10, enable_gpu_memory_pool=False)
+
+        empty_chunks = await self._chunk_text(chunker, _EMPTY_SENTENCE_TEXT)
+
+        assert empty_chunks
+        for chunk in empty_chunks:
+            missing = _SUBCLASS_METADATA_KEYS - chunk.metadata.keys()
+            assert not missing, f"chunk missing keys {missing}: {sorted(chunk.metadata.keys())}"
+            assert chunk.metadata.get("empty_input") is True


### PR DESCRIPTION
Closes #14467

## Thinking Path

`SemanticChunkerBase.chunk_text()` has two return paths that produce chunks successfully: the primary boundary-detection path, which calls `_enrich_chunks_with_metadata()` (→ `_build_chunk_metadata()` → `_extra_chunk_metadata()`), and the zero/one-sentence fallback via `_create_single_sentence_chunk()`, which returned directly without ever calling enrichment. Identical input differing only in sentence count therefore produced chunks with different metadata *shapes* — the short-input chunk silently missing `chunk_index`, `total_chunks`, `embedding_model`, `chunking_method`, and any subclass-contributed key (`optimization_version` on `GPUSemanticChunker`).

Before touching the fix, I mapped the blast radius:

- **Subclasses of `SemanticChunkerBase`:** `AutoBotSemanticChunker` (`utils/semantic_chunker.py`, CPU) and `GPUSemanticChunker` (`utils/semantic_chunker_gpu.py`). Both override only `_extra_chunk_metadata()`, `_initialize_model()`, `_compute_embeddings()` — neither overrides `chunk_text()` in a way that bypasses the shared enrichment call (`GPUSemanticChunker.chunk_text()` wraps `super().chunk_text()` for perf logging only).
  - `AutoBotSemanticChunker._extra_chunk_metadata()` adds `chunking_method="semantic_percentile"`, `percentile_threshold`.
  - `GPUSemanticChunker._extra_chunk_metadata()` adds `chunking_method="gpu_optimized_semantic"`, `gpu_batch_size`, `optimization_version="rtx4070_gpu"`.
- **Consumers of `chunk_text()`/`chunk.metadata`:** `knowledge_sync_incremental.py` (`_process_file_with_gpu_chunking` → `_store_chunks_in_knowledge_base`) is the only production caller that both invokes `chunk_text()` and persists chunk data — but it builds the stored metadata dict itself from `base_metadata` plus a handful of fields it computes directly (`semantic_score`, `sentence_count`, `character_count`, `chunk_index`, `total_chunks`, `gpu_optimized`); it never reads `chunk.metadata`, so `optimization_version`/`chunking_method` were never persisted to the knowledge base by this caller either way. `advanced_rag_optimizer.py` constructs a `GPUSemanticChunker` but never calls `chunk_text()` on it (used only as an availability flag). `structured_ops.py` reads only `chunk.content`. The public `chunk_document()` LlamaIndex-style entry point (which does surface `chunk.metadata`) has no production caller — only a test does.
  - **Conclusion: no already-stored data is affected.** Nothing in the production path ever persisted the subclass metadata this bug drops, on either the buggy or the fixed path. No migration or backfill is needed or included.
  - **Why the search came back nearly empty: #14485.** The document-ingest pipeline (`knowledge/pipeline/extractors/semantic_chunker.py`, the `ProcessedChunk`-based `ChromaDBLoader` path) uses a completely separate chunker that does not subclass `SemanticChunkerBase` at all. This class's metadata — buggy or fixed — never reaches ingested documents through that pipeline. #14485 tracks that as its own finding; cross-linked here so the next reader doesn't re-derive it.
- While tracing all three return paths out of `chunk_text()` (primary, single/zero-sentence fallback, and the exception-driven `_fallback_chunking()`), I found the exception path has the identical gap. Kept out of scope for this PR and filed as #14480 to avoid mixing an unreported symptom into this fix.

**Review follow-up:** the first version of this fix made the single/zero-sentence branch call `_enrich_chunks_with_metadata()` itself, leaving `chunk_text()` with two separate call sites that happened to agree — the same "two paths, each independently responsible for remembering the same step" shape that produced #14467. Collapsed both branches to only assign `chunks`, converging on one trailing `_enrich_chunks_with_metadata()` call before the coherence-logging block, so a future branch added to this function cannot reintroduce the defect by omission.

**Scope note:** after this change, `chunk_text()` is single-sited for **two of its three** return paths (the primary path and the single/zero-sentence fallback). The third — the exception-driven `_fallback_chunking()` path reached via the `except` block — still builds its own metadata dict in `_create_fallback_chunk()` and bypasses `_build_chunk_metadata()` entirely. That gap is unchanged by this PR and is tracked separately as #14480.

## What Changed

- `autobot-backend/utils/semantic_chunker_base.py`:
  - `_create_single_sentence_chunk()` no longer accepts/returns the caller-supplied `metadata` as the chunk's final metadata. It now only sets the chunk-shape markers (`single_sentence`, plus `empty_input` when the sentence list is empty).
  - `chunk_text()`'s two success branches (single/zero-sentence and boundary-detection) now only assign `chunks`; a single trailing `self._enrich_chunks_with_metadata(chunks, metadata)` call runs before the existing coherence-logging block, for both. The exception-driven `_fallback_chunking()` call in the `except` block is untouched (tracked as #14480).
- `autobot-backend/utils/semantic_chunker_gpu_test.py`: added `TestShortInputChunksCarryTheSameMetadataAsLongInput`, driving the real `GPUSemanticChunker.chunk_text()` (not `_create_single_sentence_chunk()`/`_build_chunk_metadata()` directly) with multi-sentence, single-sentence, and empty (filtered-to-zero-sentence) input, asserting the same subclass/base metadata key set (`chunk_index`, `total_chunks`, `source_metadata`, `embedding_model`, `chunking_method`, `gpu_batch_size`, `optimization_version`) is present on all three.

## Verification

- `python3 -m py_compile` on both changed files — syntax clean.
- Extracted the enrichment-relevant logic into a standalone script outside the repo and ran the same key-set assertion against three shapes:
  - **Pre-fix shape:** fails — `AssertionError: [single] missing subclass metadata keys: {'chunking_method', 'optimization_version', 'embedding_model', 'source_metadata', 'chunk_index', 'total_chunks'} (got ['single_sentence'])`.
  - **First-fix shape (two enrichment call sites):** passes.
  - **Collapsed shape (single trailing enrichment call, matching this PR's current state):** passes — `PASS: single-sentence and empty-input chunks carry the same subclass metadata keys as multi-sentence chunks`.
  - This confirms the new test discriminates the underlying bug (fails pre-fix, passes post-fix) and that collapsing to one call site is behavior-preserving, not just structural in name.
- The existing test assertions were not edited by the collapse — `autobot-backend/utils/semantic_chunker_gpu_test.py` has zero diff between the two fix commits; only `semantic_chunker_base.py` changed.
- CI will run the actual pytest suite (`autobot-backend/utils/semantic_chunker_gpu_test.py`) against the real repo modules, per project policy of not executing repo code locally.

## Model Used

Claude Sonnet 5 (model ID: claude-sonnet-5)
