### PR TITLE
fix(lint): anchor .flake8 excludes so a bare directory name stops pruning at any depth (#14419)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -29,10 +29,15 @@ extend-ignore = E203,W503,E704,E402
 # no entry was written for — among them three production packages named
 # `monitoring` (`autobot_shared/`, `autobot-backend/`, `autobot-slm-backend/`),
 # the `autobot-backend/tools/` tool-registry subsystem, and the SDK's
-# `autobot_sdk/resources/`. Several bare entries (`code_analysis`, `analysis`,
-# `monitoring`, `resources`, `tests`) never named a repo-root directory at all:
-# they only ever "worked" through the depth bug, so the intended exclusion and
-# the accidental one were the same entry.
+# `autobot_sdk/resources/`. Eleven entries were dropped because anchoring them
+# would have excluded no Python: ten (`tests`, `monitoring`, `analysis`,
+# `resources`, `code_analysis`, `mcp-tools`, `code-analysis-suite`,
+# `slm-server`, `slm-admin`, `infrastructure`) name no tracked repo-root
+# directory at all, and `docker` names a real one holding 19 tracked files but
+# no `.py`. Those ten only ever "worked" through the depth bug, so the intended
+# exclusion and the accidental one were the same entry. Counted against the git
+# index, not the filesystem — an untracked directory of the same name can exist
+# locally, which is why the guard measures with `git ls-files`.
 #
 # The rule this list now follows, enforced by
 # repo_tests/flake8_exclude_anchoring_test.py:
@@ -45,9 +50,14 @@ extend-ignore = E203,W503,E704,E402
 #
 # Cross-tool agreement (#14419 AC5): pre-commit's flake8 hook adds
 # `^(tests/|autobot-infrastructure/|autobot-backend/code_analysis/)`, all three
-# of which are also excluded here. black and isort take explicit directory
-# arguments and define no `exclude`/`skip` of their own beyond isort's
-# `^autobot-infrastructure/`, so they lint a strict superset — deliberate: a
+# of which are also excluded here. black and isort each carry `exclude:
+# ^autobot-infrastructure/` on their own pre-commit hook, and declare nothing
+# further — `[tool.black]` and `[tool.isort]` in pyproject.toml define no
+# exclusion, and in CI both take explicit directory arguments with none either.
+# So the two formatters lint a strict superset of what flake8 lints, agreeing
+# with it only on `autobot-infrastructure/`. That is deliberate, and it is what
+# kept the pruned trees safe: black alone caught a syntax error under
+# `autobot_shared/monitoring/` for as long as this list hid it from flake8. A
 # formatter disagreeing loudly is the cheaper failure. No ruff config exists.
 #
 # COMMENTS BELOW MUST BE ON THEIR OWN LINE. configparser strips a full-line

--- a/.flake8
+++ b/.flake8
@@ -16,41 +16,100 @@ max-line-length = 120
 #       - Async lock patterns (asyncio.Lock() before dependent imports)
 extend-ignore = E203,W503,E704,E402
 
-# Exclude directories from linting
+# Exclude directories from linting.
+#
+# #14419 — HOW FLAKE8 READS THIS LIST, and why every source entry below carries
+# a trailing slash. flake8 normalises an entry that contains a path separator
+# into an absolute path rooted at *this file's* directory and matches it against
+# the absolute path of each candidate; an entry with no separator is matched
+# against the **basename** instead, so a bare name prunes every directory of
+# that name at ANY depth.
+#
+# Written as bare names, this list silently pruned 973 tracked *.py files that
+# no entry was written for — among them three production packages named
+# `monitoring` (`autobot_shared/`, `autobot-backend/`, `autobot-slm-backend/`),
+# the `autobot-backend/tools/` tool-registry subsystem, and the SDK's
+# `autobot_sdk/resources/`. Several bare entries (`code_analysis`, `analysis`,
+# `monitoring`, `resources`, `tests`) never named a repo-root directory at all:
+# they only ever "worked" through the depth bug, so the intended exclusion and
+# the accidental one were the same entry.
+#
+# The rule this list now follows, enforced by
+# repo_tests/flake8_exclude_anchoring_test.py:
+#   * a bare (separator-free) entry is allowed ONLY for a build/runtime artifact
+#     directory that holds no tracked Python — matching it at any depth is then
+#     the intent and prunes no source;
+#   * every other entry is anchored with a trailing slash and must name a
+#     directory that exists, so an entry stranded by a rename goes red instead
+#     of quietly exempting nothing.
+#
+# Cross-tool agreement (#14419 AC5): pre-commit's flake8 hook adds
+# `^(tests/|autobot-infrastructure/|autobot-backend/code_analysis/)`, all three
+# of which are also excluded here. black and isort take explicit directory
+# arguments and define no `exclude`/`skip` of their own beyond isort's
+# `^autobot-infrastructure/`, so they lint a strict superset — deliberate: a
+# formatter disagreeing loudly is the cheaper failure. No ruff config exists.
+#
+# COMMENTS BELOW MUST BE ON THEIR OWN LINE. configparser strips a full-line
+# `#` from inside a multi-line value, so the section markers below are safe;
+# a *trailing* comment is not, because flake8 then splits what is left on
+# commas AND whitespace and every word becomes its own exclude pattern
+# (`.git,  # vcs` yields `.git`, `#`, `vcs`). Verified both ways in
+# repo_tests/flake8_exclude_anchoring_test.py, which flags a leaked word
+# through the same check that flags a bare directory name.
 exclude =
-    node_modules,
-    .venv,
-    venv,
-    __pycache__,
+    # Build, VCS and runtime artifact directories. Deliberately depth-agnostic:
+    # none of them holds tracked Python, so matching by name prunes artifacts
+    # and never source. A name added here that DOES cover tracked Python fails
+    # the guard, so this list cannot become the new hiding place.
     .git,
+    .tox,
+    __pycache__,
+    node_modules,
+    venv,
+    .venv,
+    build,
+    dist,
+    *.egg-info,
     temp,
     logs,
     reports,
     archive,
     archives,
     backups,
-    tests,
-    tools,
-    scripts,
-    monitoring,
-    mcp-tools,
-    .tox,
-    build,
-    dist,
-    *.egg-info,
-    # Auxiliary directories (not production code)
-    debug,
-    docker,
-    code-analysis-suite,
-    code_analysis,
-    resources,
-    analysis,
-    # Separate deployable components with own standards
-    slm-server,
-    slm-admin,
-    # Infrastructure contains tests, analysis, tools (not production code)
-    infrastructure,
-    autobot-infrastructure
+    # Repo-root auxiliary trees (not production code).
+    tools/,
+    scripts/,
+    debug/,
+    # Infrastructure carries its own tests, analysis and tools.
+    autobot-infrastructure/,
+    # Standalone analysis tool with its own setup.py. Also excluded by
+    # pre-commit and by mypy (pyproject.toml, GH#7105).
+    autobot-backend/code_analysis/,
+    # Test trees. Production lint standards deliberately do not apply to test
+    # packages; colocated *_test.py files keep their own relief under
+    # per-file-ignores below. Enumerated rather than matched by name so that a
+    # NEW directory called tests is linted until it is listed here - failing
+    # closed rather than silently.
+    autobot-backend/agent_loop/extractors/tests/,
+    autobot-backend/agent_loop/tests/,
+    autobot-backend/api/tests/,
+    autobot-backend/context_aware_decision/tests/,
+    autobot-backend/eval/tests/,
+    autobot-backend/knowledge/connectors/tests/,
+    autobot-backend/llc/adapters/tests/,
+    autobot-backend/llc/tests/,
+    autobot-backend/llm_shared/tests/,
+    autobot-backend/tests/,
+    autobot-backend/transcriber/tests/,
+    autobot-frontend/tests/,
+    autobot-npu-worker/resources/windows-npu-worker/tests/,
+    autobot-npu-worker/tests/,
+    autobot-slm-backend/ansible/tests/,
+    autobot-slm-backend/tests/,
+    autobot-tts-worker/tests/,
+    autobot_shared/tests/,
+    libs/autobot-sdk-python/tests/
 
 # Per-file ignores for intentional patterns
 per-file-ignores =

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -418,6 +418,17 @@ jobs:
         # exemption naming a moved file exempts nothing and hides that it does.
         python3 tools/lint/check_extension_import_boundaries.py --audit-baseline
 
+    - name: Audit the .flake8 exclude anchoring (#14419)
+      run: |
+        # A bare directory name in `exclude` prunes that name at ANY depth, not
+        # only at the repo root; 973 tracked .py files were unlinted that way,
+        # three production `monitoring` packages among them. This has to run in
+        # a REQUIRED check because of the direction it fails in: re-adding a
+        # bare name lints FEWER files, so every lint step above reports fewer
+        # violations and goes greener. The pytest copy of these assertions runs
+        # in `python-suite`, which gates nothing (#14353).
+        python3 tools/lint/check_flake8_exclude_anchoring.py --audit-excludes
+
     - name: Audit the python-file-size ceilings for drift (#14236)
       run: |
         # The pre-commit hook only sees staged files, so a grandfathered entry

--- a/autobot-npu-worker/resources/windows-npu-worker/gui/widgets/benchmark_widget.py
+++ b/autobot-npu-worker/resources/windows-npu-worker/gui/widgets/benchmark_widget.py
@@ -11,7 +11,7 @@ and displaying performance metrics.
 
 import logging
 import time
-from typing import Dict, List
+from typing import Dict
 
 from PySide6.QtWidgets import (
     QWidget,

--- a/plugins/core-plugins/image-generation-plugin/tools/generate_image.py
+++ b/plugins/core-plugins/image-generation-plugin/tools/generate_image.py
@@ -274,8 +274,6 @@ class GenerateImageTool(BaseTool):
         images = []
         for artifact in data.get("artifacts", []):
             if artifact.get("finishReason") == "SUCCESS":
-                import base64
-
                 b64 = artifact.get("base64", "")
                 # Return as data URL so frontend can display without a CDN
                 images.append({

--- a/repo_tests/flake8_exclude_anchoring_test.py
+++ b/repo_tests/flake8_exclude_anchoring_test.py
@@ -42,8 +42,7 @@ is an assertion about nothing.
 
 from __future__ import annotations
 
-import configparser
-import re
+import importlib.util
 import subprocess  # nosec B404  # fixed argv, no shell, no caller input
 from pathlib import Path
 
@@ -51,88 +50,35 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 FLAKE8_CONFIG = REPO_ROOT / ".flake8"
+_CHECKER = REPO_ROOT / "tools" / "lint" / "check_flake8_exclude_anchoring.py"
 
-#: Bare names that are allowed to match at any depth. Each names a build, VCS
-#: or runtime artifact directory that holds no tracked Python, so matching by
-#: name prunes artifacts and never source. This set only shrinks: a new name
-#: belongs here only if it can never contain checked-in code, and
-#: ``test_artifact_names_cover_no_tracked_python`` re-proves that on every run
-#: rather than trusting the claim.
-ARTIFACT_DIR_NAMES = frozenset(
-    {
-        ".git",
-        ".tox",
-        "__pycache__",
-        "node_modules",
-        "venv",
-        ".venv",
-        "build",
-        "dist",
-        "*.egg-info",
-        "temp",
-        "logs",
-        "reports",
-        "archive",
-        "archives",
-        "backups",
-    }
-)
+
+def _load_checker():
+    """Import the checker by path.
+
+    The decision lives in the script `code-quality` runs, not here. Restating
+    it would give the guard two definitions that could drift, and the copy CI
+    executes is the one that matters — a test agreeing with a second copy of
+    the rule proves nothing about the check that blocks the merge.
+    """
+    spec = importlib.util.spec_from_file_location("check_flake8_exclude_anchoring", _CHECKER)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+checker = _load_checker()
+
+ARTIFACT_DIR_NAMES = checker.ARTIFACT_DIR_NAMES
+read_exclude_entries = checker.read_exclude_entries
+split_exclude_value = checker.split_exclude_value
+bare_entries = checker.bare_entries
+unanchored_source_entries = checker.unanchored_source_entries
+entries_covering_tracked_python = checker.entries_covering_tracked_python
 
 #: Floor for the tracked-Python enumeration. An enumeration that returns
 #: nothing must not read as "no source is covered by a bare name".
-_TRACKED_PY_FLOOR = 3000
-
-#: Mirror of ``flake8.utils.COMMA_SEPARATED_LIST_RE``. Reimplemented rather
-#: than imported so the guard runs even where flake8 is not installed — a guard
-#: that skips itself reports clean. ``test_split_matches_flake8s_own_parser``
-#: pins the mirror to the real thing wherever flake8 *is* importable.
-_SPLIT_RE = re.compile(r"[,\s]")
-
-
-def split_exclude_value(value: str) -> list[str]:
-    """Split an ``exclude`` option exactly as flake8 does."""
-    return [item for item in (piece.strip() for piece in _SPLIT_RE.split(value)) if item]
-
-
-def read_exclude_entries(config_text: str) -> list[str]:
-    """Parsed ``exclude`` entries of a flake8 config given as text.
-
-    ``RawConfigParser`` rather than ``ConfigParser`` because that is what
-    ``flake8.options.config.load_config`` uses; interpolation would change what
-    a ``%`` in the value means and the guard must read what flake8 reads.
-    """
-    parser = configparser.RawConfigParser()
-    parser.read_string(config_text)
-    return split_exclude_value(parser["flake8"]["exclude"])
-
-
-def bare_entries(entries: list[str]) -> list[str]:
-    """Entries flake8 will match against a basename, i.e. at any depth."""
-    return [entry for entry in entries if "/" not in entry and "\\" not in entry]
-
-
-def unanchored_source_entries(entries: list[str]) -> list[str]:
-    """Bare entries that are not a sanctioned artifact name.
-
-    This is the decision the guard turns on, kept as a function so a test can
-    put a synthetic list through it instead of asserting on the config's text.
-    """
-    return [entry for entry in bare_entries(entries) if entry not in ARTIFACT_DIR_NAMES]
-
-
-def entries_covering_tracked_python(entries: list[str], tracked: list[str]) -> dict[str, int]:
-    """Bare entries that prune tracked Python, mapped to how many files.
-
-    ``fnmatch`` is not needed: flake8 compares a bare entry to a directory's
-    basename, so a directory component equal to the entry is exactly a hit.
-    """
-    counts: dict[str, int] = {}
-    wanted = set(bare_entries(entries))
-    for path in tracked:
-        for component in path.split("/")[:-1]:
-            if component in wanted:
-                counts[component] = counts.get(component, 0) + 1
-    return counts
+_TRACKED_PY_FLOOR = checker.TRACKED_PY_FLOOR
 
 
 @pytest.fixture(scope="module")
@@ -310,3 +256,73 @@ def test_split_matches_flake8s_own_parser():
     flake8_utils = pytest.importorskip("flake8.utils")
     sample = "a,\n b/,\t*.egg-info\n # comment (word)\n c/d/\n"
     assert split_exclude_value(sample) == flake8_utils.parse_comma_separated_list(sample)
+
+
+# --------------------------------------------------------------------------
+# The audit entrypoint, and the check that actually runs it
+# --------------------------------------------------------------------------
+
+
+def test_audit_entrypoint_is_clean_on_the_current_config():
+    """Exercise the exact call `code-quality` makes, not a paraphrase of it."""
+    reached, problems = checker.audit_excludes()
+    assert problems == []
+    assert reached == len(checker.load_entries()), "the audit did not reach every entry"
+    assert reached >= 30, f"only {reached} entries reached — the parse silently collapsed"
+
+
+def test_audit_entrypoint_fails_on_the_pre_fix_config(tmp_path):
+    """The audit must go red on the list this issue was filed against.
+
+    Run against a real config on disk rather than an in-memory list, because
+    that is the path CI takes and it is where a cwd- or root-resolution bug
+    would hide.
+    """
+    (tmp_path / ".flake8").write_text(PRE_FIX_EXCLUDE, encoding="utf-8")
+    subprocess.run(  # nosec B603 B607  # fixed argv, no shell
+        ["git", "init", "-q"], cwd=tmp_path, capture_output=True, text=True, check=True
+    )
+    reached, problems = checker.audit_excludes(tmp_path)
+
+    assert reached > 0, "the audit reached no entries — it would pass having checked nothing"
+    joined = "\n".join(problems)
+    assert "unanchored exclude entries" in joined, f"the anchoring violation was not reported: {problems}"
+    for expected in ("monitoring", "tests", "tools", "resources"):
+        assert expected in joined, f"the audit did not name bare `{expected}`"
+
+
+def test_code_quality_runs_the_audit():
+    """A guard nothing invokes is documentation.
+
+    This is the whole reason the checker is a script: the required `code-quality`
+    job must call it. The failure direction makes it necessary — re-adding a
+    bare name lints FEWER files, so every lint step reports fewer violations and
+    goes greener. Without this invocation nothing that can block a merge would
+    notice (#14353 tracks the wider gap: the pytest suite is not a required
+    check).
+    """
+    workflow = (REPO_ROOT / ".github" / "workflows" / "code-quality.yml").read_text(encoding="utf-8")
+
+    assert "check_flake8_exclude_anchoring.py --audit-excludes" in workflow, (
+        "code-quality.yml no longer runs the exclude-anchoring audit — the guard "
+        "would stop blocking merges while these tests kept passing (#14419)"
+    )
+    assert _CHECKER.is_file(), f"{_CHECKER} is gone but the workflow still calls it"
+
+
+def test_the_checker_needs_no_third_party_import():
+    """It runs in a job that installs linters, not the application's dependencies.
+
+    An import of anything outside the stdlib would fail at runtime in
+    `code-quality`, which is the one place this must not break.
+    """
+    source = _CHECKER.read_text(encoding="utf-8")
+    third_party = [
+        line
+        for line in source.splitlines()
+        if line.startswith(("import ", "from "))
+        and not line.startswith("from __future__")
+        and line.split()[1].split(".")[0]
+        not in {"argparse", "configparser", "logging", "pathlib", "re", "subprocess", "sys"}
+    ]
+    assert third_party == [], f"the checker imports non-stdlib modules: {third_party}"

--- a/repo_tests/flake8_exclude_anchoring_test.py
+++ b/repo_tests/flake8_exclude_anchoring_test.py
@@ -1,0 +1,312 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""#14419 — every ``.flake8`` exclude entry must mean the path it was written for.
+
+flake8 normalises an exclude entry that contains a path separator into an
+absolute path rooted at the config file's directory, and matches it against the
+absolute path of each candidate. An entry with **no** separator is matched
+against the candidate's *basename* instead, so a bare name prunes every
+directory of that name at any depth.
+
+Written as bare names, the list pruned 973 tracked ``*.py`` files no entry was
+written for — including three production packages called ``monitoring``, the
+``autobot-backend/tools/`` tool-registry subsystem, and the SDK's
+``autobot_sdk/resources/``. Nothing reported them as unlinted; a planted
+``SyntaxError`` in ``autobot_shared/monitoring/`` was silently skipped while the
+identical error elsewhere was reported as ``E999``.
+
+A neighbouring hazard falls out of the same parsing. configparser strips a
+*full-line* ``#`` from inside a multi-line value, so the section markers in
+``.flake8`` are safe — but it does not strip a *trailing* one, and flake8 then
+splits what is left on commas **and whitespace**, so ``debug/,  # auxiliary``
+yields the three patterns ``debug/``, ``#`` and ``auxiliary``. The pre-#14419
+config only ever used full-line comments and so did not leak; the check below
+covers the case anyway, because a leaked word is indistinguishable from a bare
+directory name and both should go red.
+
+The invariant enforced here covers both, because both produce the same artefact
+— an entry that is neither an anchored path nor a deliberate artifact name:
+
+* a bare entry is allowed only if it is a listed build/VCS/runtime artifact
+  directory, and only while it covers **no tracked Python** (:func:`bare_entries`
+  plus :func:`entries_covering_tracked_python`);
+* every other entry must be anchored, and must name a directory that exists —
+  an entry stranded by a rename exempts nothing while looking authoritative.
+
+The discrimination tests at the bottom run the checker against the config as it
+stood before this change. A guard that has never been shown to reject anything
+is an assertion about nothing.
+"""
+
+from __future__ import annotations
+
+import configparser
+import re
+import subprocess  # nosec B404  # fixed argv, no shell, no caller input
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FLAKE8_CONFIG = REPO_ROOT / ".flake8"
+
+#: Bare names that are allowed to match at any depth. Each names a build, VCS
+#: or runtime artifact directory that holds no tracked Python, so matching by
+#: name prunes artifacts and never source. This set only shrinks: a new name
+#: belongs here only if it can never contain checked-in code, and
+#: ``test_artifact_names_cover_no_tracked_python`` re-proves that on every run
+#: rather than trusting the claim.
+ARTIFACT_DIR_NAMES = frozenset(
+    {
+        ".git",
+        ".tox",
+        "__pycache__",
+        "node_modules",
+        "venv",
+        ".venv",
+        "build",
+        "dist",
+        "*.egg-info",
+        "temp",
+        "logs",
+        "reports",
+        "archive",
+        "archives",
+        "backups",
+    }
+)
+
+#: Floor for the tracked-Python enumeration. An enumeration that returns
+#: nothing must not read as "no source is covered by a bare name".
+_TRACKED_PY_FLOOR = 3000
+
+#: Mirror of ``flake8.utils.COMMA_SEPARATED_LIST_RE``. Reimplemented rather
+#: than imported so the guard runs even where flake8 is not installed — a guard
+#: that skips itself reports clean. ``test_split_matches_flake8s_own_parser``
+#: pins the mirror to the real thing wherever flake8 *is* importable.
+_SPLIT_RE = re.compile(r"[,\s]")
+
+
+def split_exclude_value(value: str) -> list[str]:
+    """Split an ``exclude`` option exactly as flake8 does."""
+    return [item for item in (piece.strip() for piece in _SPLIT_RE.split(value)) if item]
+
+
+def read_exclude_entries(config_text: str) -> list[str]:
+    """Parsed ``exclude`` entries of a flake8 config given as text.
+
+    ``RawConfigParser`` rather than ``ConfigParser`` because that is what
+    ``flake8.options.config.load_config`` uses; interpolation would change what
+    a ``%`` in the value means and the guard must read what flake8 reads.
+    """
+    parser = configparser.RawConfigParser()
+    parser.read_string(config_text)
+    return split_exclude_value(parser["flake8"]["exclude"])
+
+
+def bare_entries(entries: list[str]) -> list[str]:
+    """Entries flake8 will match against a basename, i.e. at any depth."""
+    return [entry for entry in entries if "/" not in entry and "\\" not in entry]
+
+
+def unanchored_source_entries(entries: list[str]) -> list[str]:
+    """Bare entries that are not a sanctioned artifact name.
+
+    This is the decision the guard turns on, kept as a function so a test can
+    put a synthetic list through it instead of asserting on the config's text.
+    """
+    return [entry for entry in bare_entries(entries) if entry not in ARTIFACT_DIR_NAMES]
+
+
+def entries_covering_tracked_python(entries: list[str], tracked: list[str]) -> dict[str, int]:
+    """Bare entries that prune tracked Python, mapped to how many files.
+
+    ``fnmatch`` is not needed: flake8 compares a bare entry to a directory's
+    basename, so a directory component equal to the entry is exactly a hit.
+    """
+    counts: dict[str, int] = {}
+    wanted = set(bare_entries(entries))
+    for path in tracked:
+        for component in path.split("/")[:-1]:
+            if component in wanted:
+                counts[component] = counts.get(component, 0) + 1
+    return counts
+
+
+@pytest.fixture(scope="module")
+def entries() -> list[str]:
+    return read_exclude_entries(FLAKE8_CONFIG.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def tracked_py_files() -> list[str]:
+    """Every tracked ``*.py`` path, enumerated by git rather than by flake8."""
+    completed = subprocess.run(  # nosec B603 B607  # fixed argv, no shell
+        ["git", "ls-files", "*.py"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    paths = [line for line in completed.stdout.splitlines() if line.strip()]
+    assert len(paths) >= _TRACKED_PY_FLOOR, (
+        f"git ls-files returned only {len(paths)} Python files — the enumeration "
+        "broke; these tests would otherwise pass having checked nothing"
+    )
+    return paths
+
+
+# --------------------------------------------------------------------------
+# The invariant
+# --------------------------------------------------------------------------
+
+
+def test_no_bare_directory_name_is_excluded(entries):
+    """A bare name prunes at every depth — anchor it, or justify it as an artifact."""
+    offenders = unanchored_source_entries(entries)
+    assert offenders == [], (
+        f"unanchored .flake8 exclude entries {offenders} — flake8 matches a "
+        "separator-free entry against the basename, so each of these prunes "
+        "every directory of that name at any depth (#14419). Write the path "
+        "the entry was meant for, e.g. `autobot-backend/tests/` not `tests`. "
+        "Note that flake8 splits this option on whitespace too, so a `#` line "
+        "inside the value leaks each of its words as an entry and shows up here."
+    )
+
+
+def test_artifact_names_cover_no_tracked_python(entries, tracked_py_files):
+    """The artifact allowlist stays honest: none of its names may cover source.
+
+    This is what stops the allowlist becoming the new hiding place. Adding
+    ``monitoring`` to :data:`ARTIFACT_DIR_NAMES` does not buy silence — it fails
+    here instead, and keeps failing the day someone adds a Python file under a
+    directory that a listed name happens to match.
+    """
+    covered = entries_covering_tracked_python(entries, tracked_py_files)
+    assert covered == {}, (
+        f"bare exclude entries cover tracked Python: {covered}. These files are "
+        "silently unlinted. Either the entry is not an artifact directory and "
+        "must be anchored, or the source under it does not belong there."
+    )
+
+
+def test_anchored_entries_name_directories_that_exist(entries):
+    """An entry stranded by a rename exempts nothing while looking authoritative."""
+    anchored = [entry for entry in entries if entry not in bare_entries(entries)]
+    assert anchored, "no anchored entries — the exclude list lost its paths"
+    missing = [entry for entry in anchored if not (REPO_ROOT / entry.rstrip("/")).is_dir()]
+    assert missing == [], (
+        f"exclude entries naming no directory: {missing}. Remove them, or fix "
+        "the path — a dead entry cannot exclude and cannot warn."
+    )
+
+
+def test_the_three_monitoring_packages_are_linted(entries, tracked_py_files):
+    """The regression this issue was filed for, asserted on the outcome.
+
+    ``autobot_shared/monitoring/prometheus_metrics.py`` is production code
+    imported across the platform. It was unlinted purely because of its
+    directory's name.
+    """
+    packages = [
+        "autobot_shared/monitoring",
+        "autobot-backend/monitoring",
+        "autobot-slm-backend/monitoring",
+    ]
+    prefixes = tuple(entry.rstrip("/") + "/" for entry in entries if "/" in entry)
+    bare = set(bare_entries(entries))
+    for package in packages:
+        assert (REPO_ROOT / package).is_dir(), f"{package} moved — update this test"
+        assert not package.startswith(prefixes), f"{package} is excluded by an anchored entry"
+        assert not set(package.split("/")) & bare, f"{package} is excluded by a bare name"
+
+
+# --------------------------------------------------------------------------
+# Discrimination — the guard must reject the config it was written against
+# --------------------------------------------------------------------------
+
+#: The exclude list exactly as it stood before #14419, kept as a fixed
+#: reference point. Do NOT "sync" this to the current config: its whole job is
+#: to be the thing the guard says no to.
+PRE_FIX_EXCLUDE = """
+[flake8]
+exclude =
+    node_modules,
+    .venv,
+    venv,
+    __pycache__,
+    .git,
+    temp,
+    logs,
+    reports,
+    archive,
+    archives,
+    backups,
+    tests,
+    tools,
+    scripts,
+    monitoring,
+    mcp-tools,
+    .tox,
+    build,
+    dist,
+    *.egg-info,
+    # Auxiliary directories (not production code)
+    debug,
+    docker,
+    code-analysis-suite,
+    code_analysis,
+    resources,
+    analysis,
+    # Separate deployable components with own standards
+    slm-server,
+    slm-admin,
+    # Infrastructure contains tests, analysis, tools (not production code)
+    infrastructure,
+    autobot-infrastructure
+"""
+
+
+def test_guard_rejects_the_pre_fix_config():
+    """Against the old list the guard must go red, naming the bare directories."""
+    offenders = unanchored_source_entries(read_exclude_entries(PRE_FIX_EXCLUDE))
+    for expected in ("monitoring", "tests", "tools", "scripts", "resources", "code_analysis"):
+        assert expected in offenders, f"guard failed to flag bare `{expected}`"
+
+
+def test_full_line_comments_survive_but_trailing_ones_leak():
+    """Pin which comment style is safe inside the value, in both directions.
+
+    The distinction is invisible in the file and decides whether a comment is
+    documentation or three extra exclude patterns.
+    """
+    safe = "[flake8]\nexclude =\n    .git,\n    # a full-line note (not production)\n    debug/,\n"
+    assert read_exclude_entries(safe) == [".git", "debug/"]
+
+    leaky = "[flake8]\nexclude =\n    .git,\n    debug/,  # trailing note\n"
+    leaked = read_exclude_entries(leaky)
+    assert leaked == [".git", "debug/", "#", "trailing", "note"]
+    for word in ("#", "trailing", "note"):
+        assert word in unanchored_source_entries(leaked), f"guard missed leaked word `{word}`"
+
+
+def test_guard_rejects_a_bare_name_smuggled_into_the_artifact_list(tracked_py_files):
+    """Widening ARTIFACT_DIR_NAMES must not be a way to re-hide source."""
+    covered = entries_covering_tracked_python(["monitoring", "tests"], tracked_py_files)
+    assert covered.get("monitoring", 0) > 0
+    assert covered.get("tests", 0) > 0
+
+
+def test_guard_accepts_the_current_config(entries, tracked_py_files):
+    """Both directions on the live config, so a passing suite means something."""
+    assert unanchored_source_entries(entries) == []
+    assert entries_covering_tracked_python(entries, tracked_py_files) == {}
+
+
+def test_split_matches_flake8s_own_parser():
+    """Pin the mirrored splitter to flake8's, wherever flake8 is importable."""
+    flake8_utils = pytest.importorskip("flake8.utils")
+    sample = "a,\n b/,\t*.egg-info\n # comment (word)\n c/d/\n"
+    assert split_exclude_value(sample) == flake8_utils.parse_comma_separated_list(sample)

--- a/repo_tests/mcp_verification_script_coverage_14219_test.py
+++ b/repo_tests/mcp_verification_script_coverage_14219_test.py
@@ -26,15 +26,16 @@ down in a pull request that nobody will read again:
   so a syntax error fails black with exit 123, and `.github/workflows/code-quality.yml`
   runs it over `autobot-backend/` and `autobot_shared/` with no exclusions.
 
-  `flake8` does **not** cover three of the four. Its `.flake8` `exclude =` list
-  carries the bare name `monitoring`, and flake8 prunes a bare name at *any*
-  depth rather than only at the repository root, so everything under
-  `autobot_shared/monitoring/` is skipped silently — in CI and in pre-commit
-  alike, since both read the same config. The first draft of this module claimed
-  otherwise and asserted only that the tool name and the tree name appear on one
-  line of the workflow, which is true and proves nothing. The wider problem
-  (1328 of 4938 tracked `.py` files pruned this way, including three production
-  packages named `monitoring`) is #14419 and is not fixed here.
+  `flake8` did **not** cover three of the four until #14419. Its `.flake8`
+  `exclude =` list carried the bare name `monitoring`, and flake8 prunes a bare
+  name at *any* depth rather than only at the repository root, so everything
+  under `autobot_shared/monitoring/` was skipped silently — in CI and in
+  pre-commit alike, since both read the same config. The first draft of this
+  module claimed otherwise and asserted only that the tool name and the tree
+  name appear on one line of the workflow, which is true and proves nothing.
+  #14419 anchored every source entry in that list, so flake8 now reaches all
+  four and `_MEASURED_REACH` below records the wider coverage. The map is the
+  reason that change could not land unnoticed.
 
   So the assertions below measure *reach*: for each file, which linters actually
   arrive at it after their own exclude rules are applied. Reach must be
@@ -69,14 +70,16 @@ _GUARDED_FILES = (
     "autobot-backend/services/mcp_isolated_runtime.py",
 )
 
-#: Which CI linters reach each file, as measured rather than as assumed. black
-#: reaches all four; flake8 reaches only the last, because `.flake8` prunes the
-#: bare component `monitoring` at any depth (#14419). Update this map when that
-#: is fixed — a change here is a real change in what guards these files.
+#: Which CI linters reach each file, as measured rather than as assumed. Both
+#: reach all four since #14419 anchored `.flake8`'s exclude entries; before
+#: that, flake8 reached only the last, because the bare component `monitoring`
+#: pruned the other three at any depth. Re-measure before editing this map — a
+#: change here is a real change in what guards these files, and the direction
+#: that matters is coverage *shrinking*.
 _MEASURED_REACH: dict[str, set[str]] = {
-    "autobot_shared/monitoring/metrics/mcp_worker.py": {"black"},
-    "autobot_shared/monitoring/metrics/__init__.py": {"black"},
-    "autobot_shared/monitoring/prometheus_metrics.py": {"black"},
+    "autobot_shared/monitoring/metrics/mcp_worker.py": {"black", "flake8"},
+    "autobot_shared/monitoring/metrics/__init__.py": {"black", "flake8"},
+    "autobot_shared/monitoring/prometheus_metrics.py": {"black", "flake8"},
     "autobot-backend/services/mcp_isolated_runtime.py": {"black", "flake8"},
 }
 
@@ -138,17 +141,36 @@ def test_the_removed_scripts_have_not_returned_unwired():
 
 
 def _flake8_exclude_patterns(config_text: str | None = None) -> list[str]:
-    """`.flake8`'s `exclude =` entries, as fnmatch patterns.
+    """`.flake8`'s `exclude =` entries, verbatim.
 
-    flake8 matches each entry against every *component* of a path it walks, not
-    against the path as a whole, which is what makes a bare `monitoring` prune
-    `autobot_shared/monitoring/` (#14419).
+    Two shapes, matched differently by flake8 and therefore by
+    :func:`_flake8_prunes` below: an entry with no path separator is compared
+    against a path's *basename*, so it prunes at any depth — that is what made
+    a bare `monitoring` prune `autobot_shared/monitoring/`. An entry containing
+    a separator is normalised to an absolute path rooted at the config file and
+    prunes only there (#14419).
     """
     parser = configparser.ConfigParser()
     parser.read_string(config_text if config_text is not None else (_REPO / ".flake8").read_text(encoding="utf-8"))
     raw = parser["flake8"].get("exclude", "")
     entries = (entry.strip() for line in raw.splitlines() for entry in line.split(","))
     return [entry for entry in entries if entry and not entry.startswith("#")]
+
+
+def _flake8_prunes(rel: str, patterns: list[str]) -> bool:
+    """Whether `.flake8`'s exclude list keeps flake8 away from *rel*.
+
+    Reading only the bare-name half would report the anchored entries as
+    excluding nothing, and a reach measurement that overstates reach is the
+    failure this module exists to prevent.
+    """
+    for pattern in patterns:
+        if "/" in pattern:
+            if (rel + "/").startswith(pattern.rstrip("/") + "/"):
+                return True
+        elif any(fnmatch.fnmatch(part, pattern) for part in Path(rel).parts):
+            return True
+    return False
 
 
 def _invocation(workflow_text: str, tool: str) -> str | None:
@@ -179,9 +201,7 @@ def _reach(rel: str, workflow_text: str | None = None, flake8_text: str | None =
 
     flake8 = _invocation(workflow, "flake8")
     if flake8 and any(rel.startswith(tree) for tree in re.findall(r"\S+/", flake8)):
-        patterns = _flake8_exclude_patterns(flake8_text)
-        pruned = any(fnmatch.fnmatch(part, pattern) for part in Path(rel).parts for pattern in patterns)
-        if not pruned:
+        if not _flake8_prunes(rel, _flake8_exclude_patterns(flake8_text)):
             reaching.add("flake8")
 
     return reaching

--- a/scripts/pr-preflight.sh
+++ b/scripts/pr-preflight.sh
@@ -253,10 +253,28 @@ else
     # That produced failures on pre-existing findings in excluded trees
     # (code_analysis, tools, scripts, tests...) that CI never sees. Drop the same
     # directories here so the gate matches the gate it is meant to predict.
-    FLAKE_EXCLUDES=$(awk '/^exclude *=/{f=1;next} /^[a-z_-]+ *=/{f=0} f' .flake8 \
-                     | sed 's/#.*//' | tr -d ' ,' | grep -vE '^\*|^$' | tr '\n' '|' | sed 's/|$//')
-    mapfile -t PY_LINT < <(printf '%s\n' "${PY[@]}" \
-                           | grep -vE "(^|/)(${FLAKE_EXCLUDES})(/|$)" || true)
+    # #14419: the list now carries two shapes and they are dropped differently.
+    # A bare name (build/runtime artifact directories only) is matched by flake8
+    # against a path's basename, so it prunes at any depth. An anchored entry
+    # ends in `/` and prunes only that path. Treating an anchored entry as a
+    # bare component would drop nothing and make this gate stricter than CI
+    # again -- the exact #13521 regression the block exists to prevent.
+    FLAKE_ENTRIES=$(awk '/^exclude *=/{f=1;next} /^[a-z_-]+ *=/{f=0} f' .flake8 \
+                    | sed 's/#.*//' | tr ',' '\n' | tr -d ' ' | grep -vE '^\*|^$')
+    FLAKE_BARE=$(printf '%s\n' "$FLAKE_ENTRIES" | grep -v '/' | tr '\n' '|' | sed 's/|$//')
+    FLAKE_ANCHORED=$(printf '%s\n' "$FLAKE_ENTRIES" | grep '/' | tr '\n' '|' | sed 's/|$//')
+    mapfile -t PY_LINT < <(printf '%s\n' "${PY[@]}")
+    if [ -n "$FLAKE_BARE" ]; then
+      mapfile -t PY_LINT < <(printf '%s\n' "${PY_LINT[@]}" | grep -vE "(^|/)(${FLAKE_BARE})(/|$)" || true)
+    fi
+    if [ -n "$FLAKE_ANCHORED" ]; then
+      mapfile -t PY_LINT < <(printf '%s\n' "${PY_LINT[@]}" | grep -vE "^(${FLAKE_ANCHORED})" || true)
+    fi
+    # An empty array round-trips through printf as one empty line; drop it so
+    # the count below means "nothing to lint" rather than "one blank path".
+    if [ "${#PY_LINT[@]}" -eq 1 ] && [ -z "${PY_LINT[0]}" ]; then
+      PY_LINT=()
+    fi
 
     if [ "${#PY_LINT[@]}" -eq 0 ]; then
       note "flake8 -- every changed Python file is in .flake8's exclude list"

--- a/tools/lint/check_flake8_exclude_anchoring.py
+++ b/tools/lint/check_flake8_exclude_anchoring.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""#14419 — every ``.flake8`` exclude entry must mean the path it was written for.
+
+flake8 normalises an exclude entry containing a path separator into an absolute
+path rooted at the config file's directory and matches it against a candidate's
+absolute path. An entry with **no** separator is matched against the candidate's
+*basename*, so a bare name prunes every directory of that name at any depth.
+
+Written as bare names, the list pruned 973 tracked ``*.py`` files no entry was
+written for — three production packages called ``monitoring``, the
+``autobot-backend/tools/`` tool-registry subsystem, and the SDK's
+``autobot_sdk/resources/`` among them. Nothing reported them as unlinted.
+
+The invariant:
+
+* a bare entry is allowed only if it is a listed build/VCS/runtime artifact
+  directory **and** covers no tracked Python — so the allowlist cannot become
+  the new hiding place;
+* every other entry must be anchored, and must name a directory that exists —
+  an entry stranded by a rename exempts nothing while looking authoritative.
+
+WHY THIS IS A SCRIPT AND NOT ONLY A TEST. The guard has to run in a check that
+can block a merge, and the direction of this failure is what makes that matter:
+re-adding a bare name lints *fewer* files, so a lint job reports **fewer**
+violations and goes greener. Nothing about the required checks would notice.
+``.github/workflows/code-quality.yml`` therefore calls this module with
+``--audit-excludes``, the same shape as ``check_python_file_size.py
+--audit-ceilings`` and ``check_extension_import_boundaries.py
+--audit-baseline``. ``repo_tests/flake8_exclude_anchoring_test.py`` imports
+these functions rather than restating them, so the decision has one definition.
+
+The audit reports how many entries it reached, because a scan that has silently
+stopped matching otherwise passes having asserted nothing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import configparser
+import logging
+import pathlib
+import re
+import subprocess  # nosec B404  # fixed argv, no shell, no caller input
+import sys
+
+# Plain stdlib logging, deliberately (#1082). This runs as a bare script inside
+# a lint job, and `autobot_shared.logging_manager` would drag config loading
+# into that path. Same trade as `scripts/check_python_file_size.py` and
+# `autobot_shared/user_management/password_epoch.py`; it is what CLAUDE.md's
+# pattern table allows for exactly this case.
+logger = logging.getLogger(__name__)
+
+#: Repo-relative path of this checker, quoted in the messages that ask for an edit.
+SELF_REL = "tools/lint/check_flake8_exclude_anchoring.py"
+
+#: Bare names allowed to match at any depth. Each names a build, VCS or runtime
+#: artifact directory holding no tracked Python, so matching by name prunes
+#: artifacts and never source. THIS SET ONLY SHRINKS. Adding a name here does
+#: not buy silence: :func:`entries_covering_tracked_python` re-proves the "no
+#: tracked Python" half on every run, and keeps failing the day someone adds a
+#: Python file under a directory a listed name matches.
+ARTIFACT_DIR_NAMES = frozenset(
+    {
+        ".git",
+        ".tox",
+        "__pycache__",
+        "node_modules",
+        "venv",
+        ".venv",
+        "build",
+        "dist",
+        "*.egg-info",
+        "temp",
+        "logs",
+        "reports",
+        "archive",
+        "archives",
+        "backups",
+    }
+)
+
+#: Floor for the tracked-Python enumeration. An enumeration that returns nothing
+#: must not read as "no bare entry covers any source".
+TRACKED_PY_FLOOR = 3000
+
+#: Mirror of ``flake8.utils.COMMA_SEPARATED_LIST_RE``. Reimplemented rather than
+#: imported so this runs wherever Python does — a guard that skips itself when a
+#: dependency is missing reports clean. The test pins the mirror to the real
+#: parser wherever flake8 is importable.
+_SPLIT_RE = re.compile(r"[,\s]")
+
+
+def repo_root() -> pathlib.Path:
+    """Repo root derived from this file, never from the caller's cwd.
+
+    A cwd-relative walk answers confidently and wrongly when run from a
+    subdirectory.
+    """
+    return pathlib.Path(__file__).resolve().parents[2]
+
+
+def split_exclude_value(value: str) -> list[str]:
+    """Split an ``exclude`` option exactly as flake8 does."""
+    return [item for item in (piece.strip() for piece in _SPLIT_RE.split(value)) if item]
+
+
+def read_exclude_entries(config_text: str) -> list[str]:
+    """Parsed ``exclude`` entries of a flake8 config given as text.
+
+    ``RawConfigParser`` because that is what ``flake8.options.config.load_config``
+    uses; interpolation would change what a ``%`` in the value means, and this
+    must read what flake8 reads.
+    """
+    parser = configparser.RawConfigParser()
+    parser.read_string(config_text)
+    return split_exclude_value(parser["flake8"]["exclude"])
+
+
+def load_entries(config_path: pathlib.Path | None = None) -> list[str]:
+    """Exclude entries of the repo's ``.flake8`` (or a given config)."""
+    path = config_path if config_path is not None else repo_root() / ".flake8"
+    return read_exclude_entries(path.read_text(encoding="utf-8"))
+
+
+def bare_entries(entries: list[str]) -> list[str]:
+    """Entries flake8 matches against a basename, i.e. at any depth."""
+    return [entry for entry in entries if "/" not in entry and "\\" not in entry]
+
+
+def unanchored_source_entries(entries: list[str]) -> list[str]:
+    """Bare entries that are not a sanctioned artifact name.
+
+    The decision the guard turns on, kept separate so callers can put a
+    synthetic list through it instead of asserting on the config's text.
+    """
+    return [entry for entry in bare_entries(entries) if entry not in ARTIFACT_DIR_NAMES]
+
+
+def tracked_py_files(root: pathlib.Path | None = None) -> list[str]:
+    """Every tracked ``*.py`` path, enumerated by git rather than by flake8."""
+    completed = subprocess.run(  # nosec B603 B607  # fixed argv, no shell
+        ["git", "ls-files", "*.py"],
+        cwd=root if root is not None else repo_root(),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [line for line in completed.stdout.splitlines() if line.strip()]
+
+
+def entries_covering_tracked_python(entries: list[str], tracked: list[str]) -> dict[str, int]:
+    """Bare entries that prune tracked Python, mapped to how many files.
+
+    ``fnmatch`` is not needed: flake8 compares a bare entry to a directory's
+    basename, so a path component equal to the entry is exactly a hit.
+    """
+    counts: dict[str, int] = {}
+    wanted = set(bare_entries(entries))
+    for path in tracked:
+        for component in path.split("/")[:-1]:
+            if component in wanted:
+                counts[component] = counts.get(component, 0) + 1
+    return counts
+
+
+def missing_anchored_targets(entries: list[str], root: pathlib.Path | None = None) -> list[str]:
+    """Anchored entries naming no directory — they exempt nothing, silently."""
+    base = root if root is not None else repo_root()
+    anchored = [entry for entry in entries if entry not in bare_entries(entries)]
+    return [entry for entry in anchored if not (base / entry.rstrip("/")).is_dir()]
+
+
+def audit_excludes(root: pathlib.Path | None = None) -> tuple[int, list[str]]:
+    """Apply the invariant to every entry in ``.flake8``.
+
+    Returns ``(entries_reached, problems)``. ``entries_reached`` is counted from
+    the parsed list so a config whose ``exclude`` has gone missing or empty
+    cannot report a clean scan of nothing.
+    """
+    base = root if root is not None else repo_root()
+    problems: list[str] = []
+
+    entries = load_entries(base / ".flake8")
+    if not entries:
+        return 0, [f"{base / '.flake8'} parsed to zero exclude entries — the guard checked nothing."]
+
+    unanchored = unanchored_source_entries(entries)
+    if unanchored:
+        problems.append(
+            f"unanchored exclude entries {sorted(unanchored)}: flake8 matches a "
+            "separator-free entry against the basename, so each prunes every "
+            "directory of that name at ANY depth. Write the path the entry was "
+            "meant for (`autobot-backend/tests/`, not `tests`). A trailing `# "
+            "comment` inside the value also lands here, one entry per word."
+        )
+
+    tracked = tracked_py_files(base)
+    if len(tracked) < TRACKED_PY_FLOOR:
+        problems.append(
+            f"git ls-files returned only {len(tracked)} Python files (floor "
+            f"{TRACKED_PY_FLOOR}) — the enumeration broke, so the coverage "
+            "check below asserted nothing."
+        )
+    else:
+        covered = entries_covering_tracked_python(entries, tracked)
+        if covered:
+            problems.append(
+                f"bare exclude entries cover tracked Python: {covered}. Those "
+                f"files are silently unlinted. Either the entry is not an "
+                f"artifact directory and must be anchored, or it does not "
+                f"belong in ARTIFACT_DIR_NAMES in {SELF_REL}."
+            )
+
+    missing = missing_anchored_targets(entries, base)
+    if missing:
+        problems.append(
+            f"exclude entries naming no directory: {sorted(missing)}. Remove "
+            "them or fix the path — a dead entry cannot exclude and cannot warn."
+        )
+
+    return len(entries), problems
+
+
+def configure_logging() -> None:
+    """Attach a stderr handler so findings actually reach the developer.
+
+    Run as a bare script the module logger has no handler, and logging's
+    last-resort path drops anything below WARNING.
+    """
+    if not logger.handlers:
+        handler = logging.StreamHandler(sys.stderr)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+
+
+def run_audit() -> int:
+    reached, problems = audit_excludes()
+    if problems:
+        logger.error("%s", "\n\n".join(problems))
+        logger.error("\n.flake8 exclude audit FAILED over %d entries (#14419).", reached)
+        return 1
+    logger.info(".flake8 exclude audit clean over %d entries (#14419).", reached)
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    configure_logging()
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--audit-excludes",
+        action="store_true",
+        help="apply the anchoring invariant to every .flake8 exclude entry",
+    )
+    args = parser.parse_args(argv)
+    if not args.audit_excludes:
+        parser.error("nothing to do — pass --audit-excludes")
+    return run_audit()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
Closes #14419

## Thinking Path

`.flake8`'s `exclude` list was written as bare directory names. flake8 normalises an entry containing a path separator into an absolute path rooted at the config file's directory and matches it against a candidate's absolute path; an entry with **no** separator is matched against the candidate's *basename* instead. A bare name therefore prunes every directory of that name at any depth, and nothing reports that it happened.

I measured the reach rather than trusting the issue's figure. Repo-wide, `1334` of `4958` tracked `.py` files sit under a directory matching a bare entry — close to the issue's `1328 of 4938`, the difference being growth since it was filed. But that total conflates the intended exclusions with the accidental ones. Splitting it: `973` files were pruned *only* because a name matched below the repo root, i.e. by no entry anyone wrote. `918` of those sit inside the three trees CI passes to flake8.

The reproduction confirms it. A `SyntaxError` planted in each of the three production `monitoring` packages and in `autobot-backend/tools/`:

```
OLD config: 0 E999 reported
NEW config: 3 E999 SyntaxError: '(' was never closed
```

Eleven entries were droppable because anchoring them would have excluded no Python. Measured against the git index: **ten** (`tests`, `monitoring`, `analysis`, `resources`, `code_analysis`, `mcp-tools`, `code-analysis-suite`, `slm-server`, `slm-admin`, `infrastructure`) name no tracked repo-root directory at all, and `docker` names a real one carrying 19 tracked files but no `.py`. My first draft said all eleven named nothing; review caught it and I re-measured. The count is against the index rather than the filesystem, because an untracked directory of the same name can exist locally — which is also why the guard measures with `git ls-files`. They only ever "worked" through the depth bug, so the intended exclusion and the accidental one were literally the same entry — which is why this could not be fixed by anchoring alone without first deciding what each entry was for.

The issue anticipated a large violation backlog and a grandfather list in the shape of `scripts/check_python_file_size.py`'s `KNOWN_LARGE`. Measured, that premise does not hold: the re-included trees are already `black`-formatted (black declares no excludes, which is the disagreement the issue flagged and the only reason a syntax error there was ever caught), so a full old-vs-new diff over the whole tree surfaced **two** violations. Two findings do not warrant a ratchet — an exemption list that could be emptied in one edit is a mechanism with nothing to hold. I fixed them and put the ratchet property where it does hold: in the guard, which re-derives from `git ls-files` on every run that no bare entry covers tracked Python, so widening the artifact allowlist cannot become the new hiding place.

One correction along the way, caught by the guard's own discrimination test rather than by review: I first claimed comments inside the value leak their words as patterns. Half true. `configparser` strips a *full-line* `#` from a multi-line value, so the pre-existing section markers were safe; a *trailing* comment is not, because flake8 then splits the remainder on commas **and whitespace**. The config comment and the test now state the narrower, verified fact and pin both directions.

## What Changed

**`.flake8`** — every source entry anchored with a trailing slash. Bare names survive only for build/VCS/runtime artifact directories, none of which holds tracked Python. Test trees are enumerated rather than matched by name, so a new directory called `tests` is linted until someone lists it — failing closed. The eleven dead entries are dropped. A header records how flake8 reads the option, the invariant, and the cross-tool comparison the issue asked for (AC5): pre-commit adds `^(tests/|autobot-infrastructure/|autobot-backend/code_analysis/)`, all three also excluded here; black and isort **each** carry `exclude: ^autobot-infrastructure/` on their own pre-commit hook and declare nothing further, in `pyproject.toml` or in the CI invocations. So the formatters lint a strict superset of what flake8 lints, agreeing with it only on `autobot-infrastructure/` — deliberate, and it is what kept the pruned trees safe: black alone caught a syntax error under `autobot_shared/monitoring/` for as long as this list hid it from flake8. No ruff config exists. (An earlier draft attributed that exclude to isort only; corrected in `6062bc32d` along with the entry count above. The exclude list is byte-identical across that commit — prose only.)

**`repo_tests/flake8_exclude_anchoring_test.py`** (new) — the guard. A bare entry is allowed only if it is a listed artifact name **and** covers zero tracked Python; every other entry must be anchored and must name a directory that exists, so an entry stranded by a rename goes red instead of exempting nothing. The decision is a module-level function so tests feed it synthetic lists instead of asserting on the config's text. The comma/whitespace splitter is mirrored rather than imported so the guard runs where flake8 is absent — a guard that skips itself reports clean — and a separate test pins the mirror to `flake8.utils.parse_comma_separated_list` wherever flake8 *is* importable. The tracked-file enumeration asserts a floor, so a broken `git ls-files` cannot pass as "nothing to check".

**`repo_tests/mcp_verification_script_coverage_14219_test.py`** — this is the module that found the bug, and its `_MEASURED_REACH` map exists to make exactly this change visible. Its matcher compared entries against path components only, so anchored entries would have read as excluding nothing and the measurement would have *overstated* reach — the failure the module exists to prevent. `_flake8_prunes` now handles both shapes; the map records that flake8 reaches all four guarded files rather than only the last.

**`scripts/pr-preflight.sh`** — drops flake8-excluded paths from the changed-file list so the local gate matches CI. Its regex matched components only, so anchored entries would have dropped nothing and the gate would have gone stricter than CI again, reintroducing #13521. Now filters bare names by component and anchored entries by prefix, and no longer counts an empty array as one blank path.

**Two dead imports** removed — the only violations re-inclusion surfaced. `base64` in the image-generation tool reads as live because the next line fetches the dict key `"base64"`; the module itself is never touched.

## Verification

flake8 7.3.0 — the version CI and pre-commit pin — was already present in this environment's system interpreter. Nothing was installed and no virtualenv was created. flake8 parses rather than executes, so no repository code was run.

**Reach, measured not assumed** (`git ls-files` + component analysis):

| Scope | Files |
|---|---|
| Tracked `.py` in the repo | 4958 (issue: 4938) |
| Under any bare-name match, at any depth | 1334 (issue: 1328) |
| Pruned *only* below the root — no entry written for them | 973 |
| …of those, inside the three trees CI lints | 918 |

**Violations surfaced**, full tree, old config vs new, deduplicated by `path|line|code`:

| Code | Count | Where |
|---|---|---|
| F401 | 2 | both outside the trees CI passes to flake8 |
| everything else | 0 | — |

Both fixed in this PR; nothing grandfathered. The three `monitoring` packages, `autobot-backend/tools/`, `autobot-backend/scripts/`, `autobot-slm-backend/scripts/` and `autobot-backend/resources/` — the 85 re-included files inside the CI trees — lint clean:

```
python3 -m flake8 --config=.flake8 autobot-backend/ autobot-slm-backend/ autobot_shared/
0
```

**Guard discrimination** — the guard was run against both configs, with only `.flake8` swapped:

| `.flake8` under test | Result |
|---|---|
| pre-fix (bare names, as on the base branch) | **5 failed, 4 passed** — `test_no_bare_directory_name_is_excluded`, `test_artifact_names_cover_no_tracked_python`, `test_anchored_entries_name_directories_that_exist`, `test_the_three_monitoring_packages_are_linted`, `test_guard_accepts_the_current_config` |
| fixed (this PR) | **9 passed** |

**Reproduction** — a `SyntaxError` planted in `autobot_shared/monitoring/`, `autobot-slm-backend/monitoring/` and `autobot-backend/tools/`: old config reported `0` E999, new config reported all `3`. Planted files were removed before committing; the mutation was never pushed.

`repo_tests/mcp_verification_script_coverage_14219_test.py`: 15 passed. Full `repo_tests/`: 795 passed, 14 xfailed, 2 failed. Both failures are byte-identical to the base branch and unrelated — one is a guard that filters `/.worktrees/` out of resolved paths and so enumerates nothing when run from inside a worktree, the other a YAML inline-python extractor truncating a snippet mid-literal. Filed as #14484 rather than dropped or silently absorbed here.

`black --check` and `isort --check-only` clean on the new test; `bash -n` clean on the preflight script, whose new filter was exercised against a synthetic path set (production files survive, every excluded tree is dropped).

**CI**: `code-quality` — the check that runs `flake8 --config=.flake8` over the three trees — **passed in 6m15s**. That is the independent confirmation of the two-violation figure above: the config under which 918 files were previously pruned now lints them in CI and reports nothing.

## Related

#14489 tracks the same class of defect in `.bandit`, whose `exclude_dirs` uses bare names that bandit matches as a *substring of the full path* — broader still than flake8's basename comparison. Deliberately out of scope here; this PR changes no bandit behaviour.

## Model Used

Claude Opus 5 (1M context)

