### PR TITLE
fix(security): thread RBAC role into execute_command/browser/web_search dispatch (#14469)

### DIFF
--- a/autobot-backend/chat_workflow/browser_tool_handler.py
+++ b/autobot-backend/chat_workflow/browser_tool_handler.py
@@ -1,0 +1,334 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Browser tool dispatch and result formatting for ``chat_workflow.tool_handler``.
+
+Extracted from ``tool_handler`` (#14469) to offset that PR's own additions and
+keep the module under its file-size ceiling — the same move #14497 made for
+the seam guards in ``tool_dispatch_guards.py``. None of these functions touch
+instance state beyond calling one another, so this module carries no state of
+its own; ``ToolHandlerMixin`` keeps thin delegating methods (same names, minus
+the leading underscore here) so the ``_dispatch_tool_call`` call sites and
+existing test monkey-patches (``handler._handle_browser_tool = ...``,
+``ToolHandlerMixin._validate_browser_params``) are unaffected.
+
+``handle_browser_tool`` preserves the deny-before-call contract: the
+BEFORE_TOOL_EXECUTE hook's ``should_execute`` verdict is checked and the
+generator ``return``s before ``send_to_browser_vm`` (the guarded call) ever
+runs.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, AsyncIterator
+
+from async_chat_workflow import WorkflowMessage
+from autobot_shared.auth.mcp_tool_permissions import required_permission
+from autobot_shared.env_utils import env_int
+from autobot_shared.logging_manager import get_logger
+from chat_workflow.llm_handler import (
+    _emit_after_tool_execute,
+    _emit_before_tool_execute,
+    _emit_tool_error,
+)
+
+logger = get_logger(__name__)
+
+# Issue #11537: how many numbered elements to render in the LLM-visible state
+# block per browser tool result (the browser-worker itself caps the raw list
+# via BROWSER_STATE_MAX_ELEMENTS; this bounds the prompt-text rendering).
+BROWSER_STATE_PROMPT_MAX_ELEMENTS = env_int("AUTOBOT_BROWSER_STATE_PROMPT_MAX_ELEMENTS", default=30)
+
+# Issue #11537: text formatters for the four indexed-element tool results,
+# keyed by tool name so format_browser_action_text stays a flat dispatch.
+_INDEXED_ELEMENT_TOOL_TEXT: dict[str, Any] = {
+    "click_index": lambda params, inner: (
+        f"Clicked element [{params.get('index')}]: "
+        f"{(inner.get('resolved') or {}).get('name') or (inner.get('resolved') or {}).get('role', 'element')}"
+    ),
+    "fill_index": lambda params, inner: (
+        f"Filled element [{params.get('index')}] "
+        f"({(inner.get('resolved') or {}).get('name') or (inner.get('resolved') or {}).get('role', 'element')}) "
+        "with value"
+    ),
+    "select_index": lambda params, inner: (f"Selected '{params.get('value', '')}' in element [{params.get('index')}]"),
+    "hover_index": lambda params, inner: f"Hovered over element [{params.get('index')}]",
+}
+
+
+async def validate_browser_params(tool_name: str, params: dict[str, Any]) -> str | None:
+    """Validate browser tool params. Returns a user-friendly block notice or None.
+
+    #1368 / #10914: a disallowed URL or unsafe script is an *expected* policy
+    outcome, so the returned text reads as a friendly notice (rendered as a
+    normal assistant message, not a scary error banner — see handle_browser_tool).
+
+    #13236 step 5: ``is_url_allowed`` became async when it stopped matching
+    URL prefixes with a regex and started resolving the host, so this is
+    async too. The caller already awaits inside an async method.
+    """
+    from api.browser_mcp import is_script_safe, is_url_allowed
+
+    if tool_name == "navigate" and not await is_url_allowed(params.get("url", "")):
+        url = params.get("url", "")
+        return f"I can't open that link ({url}) — it isn't on the list of sites I'm allowed to browse."
+    if tool_name == "evaluate" and not is_script_safe(params.get("script", "")):
+        return "I can't run that browser action — it was blocked by the security policy."
+    return None
+
+
+async def handle_browser_tool(
+    tool_call: dict[str, Any],
+    execution_results: list[dict[str, Any]],
+    session_id: str = "",
+    role: str = "user",
+) -> AsyncIterator[WorkflowMessage]:
+    """Execute a browser tool call via browser_mcp. Issue #1368.
+
+    Routes navigate/click/screenshot/etc. to the Browser VM through
+    the existing browser_mcp.send_to_browser_vm() function.
+    Issue #4261: Wires BEFORE/AFTER_TOOL_EXECUTE and TOOL_ERROR hooks.
+    Issue #14469: declares this call's required permission via the same
+    ``required_permission()`` table the ``browser_mcp`` MCP bridge uses —
+    this is the non-registry path for the identical tool names, so it
+    reuses that classification (read baseline, MCP_BROWSER_CONTROL for
+    anything that drives the page) instead of a second, disconnected one.
+
+    Yields:
+        WorkflowMessage for browser tool execution stages
+    """
+    tool_name = tool_call["name"]
+    params = tool_call.get("params", {})
+    description = tool_call.get("description", f"Browser: {tool_name}")
+
+    logger.info("[Issue #1368] Browser tool: %s params=%s", tool_name, params)
+
+    yield WorkflowMessage(
+        type="tool_execution",
+        content=f"Executing browser action: {description}",
+        metadata={"tool": tool_name, "params": params},
+    )
+
+    try:
+        validation_error = await validate_browser_params(tool_name, params)
+        if validation_error:
+            # Keep status="error" so the agent loop still knows the tool didn't run.
+            execution_results.append({"tool": tool_name, "status": "error", "error": validation_error})
+            # #10914: a disallowed URL / unsafe script is an expected policy block,
+            # not a system failure — surface it to the user as a normal assistant
+            # notice (tool_result) so the UI doesn't render a scary red "Error:" banner.
+            yield WorkflowMessage(
+                type="tool_result",
+                content=validation_error,
+                metadata={"tool": tool_name, "blocked": True},
+            )
+            return
+
+        # Issue #4261/#14469: Wire BEFORE_TOOL_EXECUTE hook for browser tools,
+        # declaring the permission this specific action requires.
+        tool_permission = required_permission(tool_name, bridge_name="browser_mcp")
+        should_execute = await _emit_before_tool_execute(
+            tool_name,
+            params,
+            session_id,
+            tool_permission=tool_permission.value if tool_permission else None,
+            user_role=role,
+        )
+        if not should_execute:
+            logger.info(
+                "[Issue #4261] Browser tool execution cancelled by hook: %s",
+                tool_name,
+            )
+            cancellation_metadata = {"tool": tool_name, "cancelled_by_hook": True}
+            if tool_permission is not None:
+                cancellation_metadata["reason"] = "permission_denied"
+            yield WorkflowMessage(
+                type="error",
+                content=f"Browser tool execution cancelled: {tool_name}",
+                metadata=cancellation_metadata,
+            )
+            return
+
+        from api.browser_mcp import DEFAULT_BROWSER_SESSION_ID, send_to_browser_vm
+
+        # #11539: route this call to the BrowserContext dedicated to this
+        # conversation so cookies/login state never bleed into another one.
+        result = await send_to_browser_vm(
+            tool_name,
+            params,
+            session_id=session_id or DEFAULT_BROWSER_SESSION_ID,
+        )
+
+        # Issue #4261: Wire AFTER_TOOL_EXECUTE hook for browser tools
+        result_text = str(result)
+        result_text = await _emit_after_tool_execute(tool_name, result_text, session_id, {})
+
+        yield record_browser_success(tool_name, params, result, execution_results)
+
+    except Exception as e:
+        # Issue #4261: Wire TOOL_ERROR hook for browser tools
+        await _emit_tool_error(tool_name, e, session_id, {})
+        logger.error("[Issue #1368] Browser tool '%s' failed: %s", tool_name, e)
+        execution_results.append(
+            {
+                "tool": tool_name,
+                "status": "error",
+                "error": "Browser tool execution failed",
+            }
+        )
+        yield WorkflowMessage(
+            type="error",
+            content=f"Browser tool '{tool_name}' execution failed",
+            metadata={"tool": tool_name, "error": True},
+        )
+
+
+def record_browser_success(
+    tool_name: str,
+    params: dict[str, Any],
+    result: dict[str, Any],
+    execution_results: list[dict[str, Any]],
+) -> "WorkflowMessage":
+    """Record a successful browser tool execution and return its WorkflowMessage. Issue #2735.
+
+    Extracted from handle_browser_tool to keep parent under 65 lines.
+    Issue #11538: also carries the raw screenshot (if any) into
+    execution_results so the vision-in-the-loop continuation can find it.
+    """
+    summary = format_browser_result(tool_name, params, result)
+    entry: dict[str, Any] = {"tool": tool_name, "status": "success", "output": summary}
+    base64_image = extract_browser_image(result)
+    if base64_image:
+        entry["base64_image"] = base64_image
+    execution_results.append(entry)
+    return WorkflowMessage(
+        type="command_output",
+        content=summary,
+        metadata={
+            "tool": tool_name,
+            "params": params,
+            "result": result,
+            "status": "success",
+        },
+    )
+
+
+def extract_browser_image(result: dict[str, Any]) -> str | None:
+    """Pull the base64 PNG out of a browser tool result, if present. Issue #11538.
+
+    Only the ``screenshot`` action returns image bytes today; kept
+    tool-name-agnostic (checks common keys) so a future browser/VNC
+    action that starts returning images is picked up automatically.
+    """
+    inner = result.get("result", result)
+    return inner.get("image") or inner.get("screenshot")
+
+
+def format_page_state_block(page_state: dict[str, Any] | None) -> str:
+    """Render the numbered interactive-element menu for LLM consumption. Issue #11537.
+
+    OpenManus-style: the model picks click_index/fill_index targets from
+    this menu instead of guessing a CSS selector. Appended to every
+    browser tool result so the menu is always current (task 4).
+    """
+    if not page_state:
+        return ""
+    elements = page_state.get("elements") or []
+    if not elements:
+        return ""
+    lines = [f"\nInteractive elements ({len(elements)}):"]
+    for el in elements[:BROWSER_STATE_PROMPT_MAX_ELEMENTS]:
+        role = el.get("role", el.get("tag", "element"))
+        name = (el.get("name") or "").strip()
+        label = f' "{name}"' if name else ""
+        lines.append(f"  [{el.get('index')}] {role}{label}")
+    return "\n".join(lines)
+
+
+def format_browser_result(
+    tool_name: str,
+    params: dict[str, Any],
+    result: dict[str, Any],
+) -> str:
+    """Format browser tool result as text for LLM context. Issue #1368.
+
+    Browser VM returns: {"success": bool, "action": str, "result": {...}}
+    The inner 'result' dict contains tool-specific data. Issue #11537:
+    appends the numbered interactive-element menu when present.
+    """
+    inner = result.get("result", result)
+    summary = format_browser_action_text(tool_name, params, inner, result)
+    # browser_state's payload *is* the page state; every other action
+    # carries it nested under "page_state" (attached post-action).
+    page_state = inner if tool_name == "browser_state" else inner.get("page_state")
+    state_block = format_page_state_block(page_state)
+    return summary + state_block if state_block else summary
+
+
+def format_browser_action_text(
+    tool_name: str,
+    params: dict[str, Any],
+    inner: dict[str, Any],
+    result: dict[str, Any],
+) -> str:
+    """Build the tool-specific summary line for format_browser_result. Issue #1368/#11537."""
+    if tool_name == "navigate":
+        url = inner.get("url", params.get("url", ""))
+        title = inner.get("title", "")
+        return f"Navigated to: {url}\nPage title: {title}"
+
+    if tool_name == "screenshot":
+        has_image = bool(inner.get("image") or inner.get("screenshot"))
+        if has_image:
+            return "Screenshot captured successfully."
+        return "Screenshot failed."
+
+    if tool_name == "get_text":
+        text = inner.get("text", "")
+        if text:
+            # #12757: browser page text is untrusted third-party content —
+            # sanitize and put it behind a trust boundary before it lands in
+            # the agent's context as if it were operator input.
+            from knowledge.query_sanitizer import sanitize_and_wrap_web_content
+
+            return "Text content: " + sanitize_and_wrap_web_content(text[:2000], params.get("url", ""))
+        return "No text found."
+
+    if tool_name == "get_attribute":
+        value = inner.get("value", "")
+        attr = params.get("attribute", "")
+        return f"Attribute '{attr}': {value}"
+
+    if tool_name == "evaluate":
+        js_result = inner.get("result", "")
+        return f"JavaScript result: {js_result}"
+
+    if tool_name == "click":
+        return f"Clicked: {params.get('selector', '')}"
+
+    if tool_name == "fill":
+        sel = params.get("selector", "")
+        return f"Filled '{sel}' with value"
+
+    if tool_name == "select":
+        val = params.get("value", "")
+        sel = params.get("selector", "")
+        return f"Selected '{val}' in {sel}"
+
+    if tool_name == "hover":
+        return f"Hovered over: {params.get('selector', '')}"
+
+    if tool_name == "wait_for_selector":
+        sel = params.get("selector", "")
+        return f"Element found: {sel}"
+
+    if tool_name in _INDEXED_ELEMENT_TOOL_TEXT:
+        return _INDEXED_ELEMENT_TOOL_TEXT[tool_name](params, inner)
+
+    if tool_name == "browser_state":
+        elements = inner.get("elements") or []
+        return f"Page state: {inner.get('url', '')} — {len(elements)} interactive element(s)"
+
+    return json.dumps(result, default=str)[:1000]

--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -20,11 +20,19 @@ import uuid
 from typing import TYPE_CHECKING, Any, AsyncIterator
 
 from async_chat_workflow import WorkflowMessage
-from autobot_shared.auth.mcp_tool_permissions import required_permission
 from autobot_shared.auth.permissions import Permission
 from autobot_shared.env_utils import env_flag, env_int
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.tool_catalogue import APPROVAL_CATEGORY_TOOLS, match_tool_name
+from chat_workflow.browser_tool_handler import (
+    extract_browser_image,
+    format_browser_action_text,
+    format_browser_result,
+    format_page_state_block,
+    handle_browser_tool,
+    record_browser_success,
+    validate_browser_params,
+)
 from chat_workflow.code_exec.tool_policy import CODEEXEC_READONLY_TOOLS
 from chat_workflow.tool_call_grammar import TOOL_CALL_PATTERN
 from chat_workflow.tool_dispatch_guards import (
@@ -521,27 +529,6 @@ BROWSER_STATE_SCHEMA: dict = {
         "of interactive elements for use with click_index/fill_index/select_index/hover_index."
     ),
     "properties": {},
-}
-
-# Issue #11537: how many numbered elements to render in the LLM-visible state
-# block per browser tool result (the browser-worker itself caps the raw list
-# via BROWSER_STATE_MAX_ELEMENTS; this bounds the prompt-text rendering).
-BROWSER_STATE_PROMPT_MAX_ELEMENTS = env_int("AUTOBOT_BROWSER_STATE_PROMPT_MAX_ELEMENTS", default=30)
-
-# Issue #11537: text formatters for the four indexed-element tool results,
-# keyed by tool name so _format_browser_action_text stays a flat dispatch.
-_INDEXED_ELEMENT_TOOL_TEXT: dict[str, Any] = {
-    "click_index": lambda params, inner: (
-        f"Clicked element [{params.get('index')}]: "
-        f"{(inner.get('resolved') or {}).get('name') or (inner.get('resolved') or {}).get('role', 'element')}"
-    ),
-    "fill_index": lambda params, inner: (
-        f"Filled element [{params.get('index')}] "
-        f"({(inner.get('resolved') or {}).get('name') or (inner.get('resolved') or {}).get('role', 'element')}) "
-        "with value"
-    ),
-    "select_index": lambda params, inner: (f"Selected '{params.get('value', '')}' in element [{params.get('index')}]"),
-    "hover_index": lambda params, inner: f"Hovered over element [{params.get('index')}]",
 }
 
 # Issue #4529: JSON Schema definitions for built-in tools dispatched directly
@@ -2388,25 +2375,19 @@ class ToolHandlerMixin:
                 metadata={"message_type": "delegate_tool", "error": True},
             )
 
+    # #14469: the browser-tool handling below moved to browser_tool_handler.py
+    # to bring this file under its file-size ceiling (see that module's
+    # docstring for the extraction rationale — none of them touched `self`
+    # beyond calling one another). These stay as thin delegating methods, not
+    # a straight `= module.func` rebind, so existing test monkey-patches
+    # (`handler._handle_browser_tool = ...`, `ToolHandlerMixin._validate_browser_params`)
+    # and the `_dispatch_tool_call` call sites are unaffected.
     async def _validate_browser_params(self, tool_name: str, params: dict[str, Any]) -> str | None:
         """Validate browser tool params. Returns a user-friendly block notice or None.
 
-        #1368 / #10914: a disallowed URL or unsafe script is an *expected* policy
-        outcome, so the returned text reads as a friendly notice (rendered as a
-        normal assistant message, not a scary error banner — see _handle_browser_tool).
-
-        #13236 step 5: ``is_url_allowed`` became async when it stopped matching
-        URL prefixes with a regex and started resolving the host, so this is
-        async too. The caller already awaits inside an async method.
+        See ``browser_tool_handler.validate_browser_params`` for the full behavior.
         """
-        from api.browser_mcp import is_script_safe, is_url_allowed
-
-        if tool_name == "navigate" and not await is_url_allowed(params.get("url", "")):
-            url = params.get("url", "")
-            return f"I can't open that link ({url}) — it isn't on the list of sites I'm allowed to browse."
-        if tool_name == "evaluate" and not is_script_safe(params.get("script", "")):
-            return "I can't run that browser action — it was blocked by the security policy."
-        return None
+        return await validate_browser_params(tool_name, params)
 
     async def _handle_browser_tool(
         self,
@@ -2417,102 +2398,13 @@ class ToolHandlerMixin:
     ):
         """Execute a browser tool call via browser_mcp. Issue #1368.
 
-        Routes navigate/click/screenshot/etc. to the Browser VM through
-        the existing browser_mcp.send_to_browser_vm() function.
-        Issue #4261: Wires BEFORE/AFTER_TOOL_EXECUTE and TOOL_ERROR hooks.
-        Issue #14469: declares this call's required permission via the same
-        ``required_permission()`` table the ``browser_mcp`` MCP bridge uses —
-        this is the non-registry path for the identical tool names, so it
-        reuses that classification (read baseline, MCP_BROWSER_CONTROL for
-        anything that drives the page) instead of a second, disconnected one.
+        See ``browser_tool_handler.handle_browser_tool`` for the full behavior.
 
         Yields:
             WorkflowMessage for browser tool execution stages
         """
-        tool_name = tool_call["name"]
-        params = tool_call.get("params", {})
-        description = tool_call.get("description", f"Browser: {tool_name}")
-
-        logger.info("[Issue #1368] Browser tool: %s params=%s", tool_name, params)
-
-        yield WorkflowMessage(
-            type="tool_execution",
-            content=f"Executing browser action: {description}",
-            metadata={"tool": tool_name, "params": params},
-        )
-
-        try:
-            validation_error = await self._validate_browser_params(tool_name, params)
-            if validation_error:
-                # Keep status="error" so the agent loop still knows the tool didn't run.
-                execution_results.append({"tool": tool_name, "status": "error", "error": validation_error})
-                # #10914: a disallowed URL / unsafe script is an expected policy block,
-                # not a system failure — surface it to the user as a normal assistant
-                # notice (tool_result) so the UI doesn't render a scary red "Error:" banner.
-                yield WorkflowMessage(
-                    type="tool_result",
-                    content=validation_error,
-                    metadata={"tool": tool_name, "blocked": True},
-                )
-                return
-
-            # Issue #4261/#14469: Wire BEFORE_TOOL_EXECUTE hook for browser tools,
-            # declaring the permission this specific action requires.
-            tool_permission = required_permission(tool_name, bridge_name="browser_mcp")
-            should_execute = await _emit_before_tool_execute(
-                tool_name,
-                params,
-                session_id,
-                tool_permission=tool_permission.value if tool_permission else None,
-                user_role=role,
-            )
-            if not should_execute:
-                logger.info(
-                    "[Issue #4261] Browser tool execution cancelled by hook: %s",
-                    tool_name,
-                )
-                cancellation_metadata = {"tool": tool_name, "cancelled_by_hook": True}
-                if tool_permission is not None:
-                    cancellation_metadata["reason"] = "permission_denied"
-                yield WorkflowMessage(
-                    type="error",
-                    content=f"Browser tool execution cancelled: {tool_name}",
-                    metadata=cancellation_metadata,
-                )
-                return
-
-            from api.browser_mcp import DEFAULT_BROWSER_SESSION_ID, send_to_browser_vm
-
-            # #11539: route this call to the BrowserContext dedicated to this
-            # conversation so cookies/login state never bleed into another one.
-            result = await send_to_browser_vm(
-                tool_name,
-                params,
-                session_id=session_id or DEFAULT_BROWSER_SESSION_ID,
-            )
-
-            # Issue #4261: Wire AFTER_TOOL_EXECUTE hook for browser tools
-            result_text = str(result)
-            result_text = await _emit_after_tool_execute(tool_name, result_text, session_id, {})
-
-            yield self._record_browser_success(tool_name, params, result, execution_results)
-
-        except Exception as e:
-            # Issue #4261: Wire TOOL_ERROR hook for browser tools
-            await _emit_tool_error(tool_name, e, session_id, {})
-            logger.error("[Issue #1368] Browser tool '%s' failed: %s", tool_name, e)
-            execution_results.append(
-                {
-                    "tool": tool_name,
-                    "status": "error",
-                    "error": "Browser tool execution failed",
-                }
-            )
-            yield WorkflowMessage(
-                type="error",
-                content=f"Browser tool '{tool_name}' execution failed",
-                metadata={"tool": tool_name, "error": True},
-            )
+        async for msg in handle_browser_tool(tool_call, execution_results, session_id, role):
+            yield msg
 
     def _record_browser_success(
         self,
@@ -2523,56 +2415,23 @@ class ToolHandlerMixin:
     ) -> "WorkflowMessage":
         """Record a successful browser tool execution and return its WorkflowMessage. Issue #2735.
 
-        Extracted from _handle_browser_tool to keep parent under 65 lines.
-        Issue #11538: also carries the raw screenshot (if any) into
-        execution_results so the vision-in-the-loop continuation can find it.
+        See ``browser_tool_handler.record_browser_success`` for the full behavior.
         """
-        summary = self._format_browser_result(tool_name, params, result)
-        entry: dict[str, Any] = {"tool": tool_name, "status": "success", "output": summary}
-        base64_image = self._extract_browser_image(result)
-        if base64_image:
-            entry["base64_image"] = base64_image
-        execution_results.append(entry)
-        return WorkflowMessage(
-            type="command_output",
-            content=summary,
-            metadata={
-                "tool": tool_name,
-                "params": params,
-                "result": result,
-                "status": "success",
-            },
-        )
+        return record_browser_success(tool_name, params, result, execution_results)
 
     def _extract_browser_image(self, result: dict[str, Any]) -> str | None:
         """Pull the base64 PNG out of a browser tool result, if present. Issue #11538.
 
-        Only the ``screenshot`` action returns image bytes today; kept
-        tool-name-agnostic (checks common keys) so a future browser/VNC
-        action that starts returning images is picked up automatically.
+        See ``browser_tool_handler.extract_browser_image`` for the full behavior.
         """
-        inner = result.get("result", result)
-        return inner.get("image") or inner.get("screenshot")
+        return extract_browser_image(result)
 
     def _format_page_state_block(self, page_state: dict[str, Any] | None) -> str:
         """Render the numbered interactive-element menu for LLM consumption. Issue #11537.
 
-        OpenManus-style: the model picks click_index/fill_index targets from
-        this menu instead of guessing a CSS selector. Appended to every
-        browser tool result so the menu is always current (task 4).
+        See ``browser_tool_handler.format_page_state_block`` for the full behavior.
         """
-        if not page_state:
-            return ""
-        elements = page_state.get("elements") or []
-        if not elements:
-            return ""
-        lines = [f"\nInteractive elements ({len(elements)}):"]
-        for el in elements[:BROWSER_STATE_PROMPT_MAX_ELEMENTS]:
-            role = el.get("role", el.get("tag", "element"))
-            name = (el.get("name") or "").strip()
-            label = f' "{name}"' if name else ""
-            lines.append(f"  [{el.get('index')}] {role}{label}")
-        return "\n".join(lines)
+        return format_page_state_block(page_state)
 
     def _format_browser_result(
         self,
@@ -2582,17 +2441,9 @@ class ToolHandlerMixin:
     ) -> str:
         """Format browser tool result as text for LLM context. Issue #1368.
 
-        Browser VM returns: {"success": bool, "action": str, "result": {...}}
-        The inner 'result' dict contains tool-specific data. Issue #11537:
-        appends the numbered interactive-element menu when present.
+        See ``browser_tool_handler.format_browser_result`` for the full behavior.
         """
-        inner = result.get("result", result)
-        summary = self._format_browser_action_text(tool_name, params, inner, result)
-        # browser_state's payload *is* the page state; every other action
-        # carries it nested under "page_state" (attached post-action).
-        page_state = inner if tool_name == "browser_state" else inner.get("page_state")
-        state_block = self._format_page_state_block(page_state)
-        return summary + state_block if state_block else summary
+        return format_browser_result(tool_name, params, result)
 
     def _format_browser_action_text(
         self,
@@ -2601,65 +2452,11 @@ class ToolHandlerMixin:
         inner: dict[str, Any],
         result: dict[str, Any],
     ) -> str:
-        """Build the tool-specific summary line for _format_browser_result. Issue #1368/#11537."""
-        if tool_name == "navigate":
-            url = inner.get("url", params.get("url", ""))
-            title = inner.get("title", "")
-            return f"Navigated to: {url}\nPage title: {title}"
+        """Build the tool-specific summary line for _format_browser_result. Issue #1368/#11537.
 
-        if tool_name == "screenshot":
-            has_image = bool(inner.get("image") or inner.get("screenshot"))
-            if has_image:
-                return "Screenshot captured successfully."
-            return "Screenshot failed."
-
-        if tool_name == "get_text":
-            text = inner.get("text", "")
-            if text:
-                # #12757: browser page text is untrusted third-party content —
-                # sanitize and put it behind a trust boundary before it lands in
-                # the agent's context as if it were operator input.
-                from knowledge.query_sanitizer import sanitize_and_wrap_web_content
-
-                return "Text content: " + sanitize_and_wrap_web_content(text[:2000], params.get("url", ""))
-            return "No text found."
-
-        if tool_name == "get_attribute":
-            value = inner.get("value", "")
-            attr = params.get("attribute", "")
-            return f"Attribute '{attr}': {value}"
-
-        if tool_name == "evaluate":
-            js_result = inner.get("result", "")
-            return f"JavaScript result: {js_result}"
-
-        if tool_name == "click":
-            return f"Clicked: {params.get('selector', '')}"
-
-        if tool_name == "fill":
-            sel = params.get("selector", "")
-            return f"Filled '{sel}' with value"
-
-        if tool_name == "select":
-            val = params.get("value", "")
-            sel = params.get("selector", "")
-            return f"Selected '{val}' in {sel}"
-
-        if tool_name == "hover":
-            return f"Hovered over: {params.get('selector', '')}"
-
-        if tool_name == "wait_for_selector":
-            sel = params.get("selector", "")
-            return f"Element found: {sel}"
-
-        if tool_name in _INDEXED_ELEMENT_TOOL_TEXT:
-            return _INDEXED_ELEMENT_TOOL_TEXT[tool_name](params, inner)
-
-        if tool_name == "browser_state":
-            elements = inner.get("elements") or []
-            return f"Page state: {inner.get('url', '')} — {len(elements)} interactive element(s)"
-
-        return json.dumps(result, default=str)[:1000]
+        See ``browser_tool_handler.format_browser_action_text`` for the full behavior.
+        """
+        return format_browser_action_text(tool_name, params, inner, result)
 
     async def _handle_web_search_tool(
         self,

--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -20,6 +20,8 @@ import uuid
 from typing import TYPE_CHECKING, Any, AsyncIterator
 
 from async_chat_workflow import WorkflowMessage
+from autobot_shared.auth.mcp_tool_permissions import required_permission
+from autobot_shared.auth.permissions import Permission
 from autobot_shared.env_utils import env_flag, env_int
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.tool_catalogue import APPROVAL_CATEGORY_TOOLS, match_tool_name
@@ -2076,11 +2078,16 @@ class ToolHandlerMixin:
         selected_model: str,
         execution_results: list,
         additional_response_parts: list,
+        role: str = "user",
     ):
         """Process a single execute_command tool call. Issue #620.
 
         Issue #655: Wraps common errors as RepairableException for retry.
         Issue #4261: Wires BEFORE/AFTER_TOOL_EXECUTE and TOOL_ERROR hooks.
+        Issue #14469: forwards the caller's RBAC role and the tool's declared
+        `Permission.SHELL_EXECUTE` requirement so PermissionEnforcementExtension
+        (#14420) has something to deny against — this call site previously
+        omitted both, so every role reached the shell unconditionally.
 
         Yields:
             WorkflowMessage items
@@ -2088,9 +2095,16 @@ class ToolHandlerMixin:
         command, host, description = self._extract_command_params(tool_call)
         logger.info("[ChatWorkflowManager] Executing command: %s on %s", command, host)
 
-        # Issue #4261: Wire BEFORE_TOOL_EXECUTE hook for execute_command
+        # Issue #4261/#14469: Wire BEFORE_TOOL_EXECUTE hook for execute_command,
+        # declaring the shell-execution permission it requires.
         params = {"command": command, "host": host}
-        should_execute = await _emit_before_tool_execute("execute_command", params, session_id)
+        should_execute = await _emit_before_tool_execute(
+            "execute_command",
+            params,
+            session_id,
+            tool_permission=Permission.SHELL_EXECUTE.value,
+            user_role=role,
+        )
         if not should_execute:
             logger.info(
                 "[Issue #4261] Execute command cancelled by BEFORE_TOOL_EXECUTE hook: %s on %s",
@@ -2100,7 +2114,12 @@ class ToolHandlerMixin:
             yield WorkflowMessage(
                 type="error",
                 content=f"Command execution cancelled: {command}",
-                metadata={"command": command, "host": host, "cancelled_by_hook": True},
+                metadata={
+                    "command": command,
+                    "host": host,
+                    "cancelled_by_hook": True,
+                    "reason": "permission_denied",
+                },
             )
             return
 
@@ -2394,12 +2413,18 @@ class ToolHandlerMixin:
         tool_call: dict[str, Any],
         execution_results: list[dict[str, Any]],
         session_id: str = "",
+        role: str = "user",
     ):
         """Execute a browser tool call via browser_mcp. Issue #1368.
 
         Routes navigate/click/screenshot/etc. to the Browser VM through
         the existing browser_mcp.send_to_browser_vm() function.
         Issue #4261: Wires BEFORE/AFTER_TOOL_EXECUTE and TOOL_ERROR hooks.
+        Issue #14469: declares this call's required permission via the same
+        ``required_permission()`` table the ``browser_mcp`` MCP bridge uses —
+        this is the non-registry path for the identical tool names, so it
+        reuses that classification (read baseline, MCP_BROWSER_CONTROL for
+        anything that drives the page) instead of a second, disconnected one.
 
         Yields:
             WorkflowMessage for browser tool execution stages
@@ -2431,17 +2456,28 @@ class ToolHandlerMixin:
                 )
                 return
 
-            # Issue #4261: Wire BEFORE_TOOL_EXECUTE hook for browser tools
-            should_execute = await _emit_before_tool_execute(tool_name, params, session_id)
+            # Issue #4261/#14469: Wire BEFORE_TOOL_EXECUTE hook for browser tools,
+            # declaring the permission this specific action requires.
+            tool_permission = required_permission(tool_name, bridge_name="browser_mcp")
+            should_execute = await _emit_before_tool_execute(
+                tool_name,
+                params,
+                session_id,
+                tool_permission=tool_permission.value if tool_permission else None,
+                user_role=role,
+            )
             if not should_execute:
                 logger.info(
                     "[Issue #4261] Browser tool execution cancelled by hook: %s",
                     tool_name,
                 )
+                cancellation_metadata = {"tool": tool_name, "cancelled_by_hook": True}
+                if tool_permission is not None:
+                    cancellation_metadata["reason"] = "permission_denied"
                 yield WorkflowMessage(
                     type="error",
                     content=f"Browser tool execution cancelled: {tool_name}",
-                    metadata={"tool": tool_name, "cancelled_by_hook": True},
+                    metadata=cancellation_metadata,
                 )
                 return
 
@@ -2630,12 +2666,17 @@ class ToolHandlerMixin:
         tool_call: dict[str, Any],
         execution_results: list[dict[str, Any]],
         session_id: str = "",
+        role: str = "user",
     ):
         """Execute a web search via browser VM. Issue #2306.
 
         Abstracts the multi-step browser flow (navigate → fill → click → get_text)
         into a single tool call so small models don't need to orchestrate it.
         Issue #4261: Wires BEFORE/AFTER_TOOL_EXECUTE and TOOL_ERROR hooks.
+        Issue #14469: declares the same ``MCP_BROWSER_READ`` baseline the
+        ``browser_mcp`` bridge grants an undeclared tool — this abstracts
+        read-only browser navigation (search + read results), never drives
+        arbitrary page state, so it does not need ``MCP_BROWSER_CONTROL``.
 
         Yields:
             WorkflowMessage for search execution stages
@@ -2664,14 +2705,21 @@ class ToolHandlerMixin:
             metadata={"tool": "web_search", "query": query},
         )
 
-        # Issue #4261: Wire BEFORE_TOOL_EXECUTE hook for web_search
-        should_execute = await _emit_before_tool_execute("web_search", params, session_id)
+        # Issue #4261/#14469: Wire BEFORE_TOOL_EXECUTE hook for web_search,
+        # declaring the browser-read permission it requires.
+        should_execute = await _emit_before_tool_execute(
+            "web_search",
+            params,
+            session_id,
+            tool_permission=Permission.MCP_BROWSER_READ.value,
+            user_role=role,
+        )
         if not should_execute:
             logger.info("[Issue #4261] Web search cancelled by hook")
             yield WorkflowMessage(
                 type="error",
                 content="Web search execution cancelled",
-                metadata={"tool": "web_search", "cancelled_by_hook": True},
+                metadata={"tool": "web_search", "cancelled_by_hook": True, "reason": "permission_denied"},
             )
             return
 
@@ -3485,6 +3533,7 @@ class ToolHandlerMixin:
                 selected_model,
                 execution_results,
                 additional_response_parts,
+                role=role,
             ):
                 yield msg
             return
@@ -3502,17 +3551,23 @@ class ToolHandlerMixin:
         selected_model: str,
         execution_results: list[dict[str, Any]],
         additional_response_parts: list[str],
+        role: str = "user",
     ) -> AsyncIterator[Any]:
         """Return the handler async-generator for a uniform builtin tool (GH#11489).
 
         Membership SSOT is ``_UNIFORM_BUILTIN_TOOLS``; the caller has already run
         the shared gate. Adding a builtin that follows the standard gate takes a
         schema entry plus one row here — no new branch at the dispatch seam.
+
+        Issue #14469: ``role`` is forwarded only to the three handlers that now
+        declare a ``tool_permission`` (browser, web_search, execute_command) —
+        web research/live-page-extract/read_spilled_output remain undeclared,
+        tracked separately.
         """
         if tool_name in BROWSER_TOOL_NAMES:  # Issue #1368: route to browser VM
-            return self._handle_browser_tool(tool_call, execution_results, session_id)
+            return self._handle_browser_tool(tool_call, execution_results, session_id, role=role)
         if tool_name == "web_search":  # Issue #2306: multi-step browser flow
-            return self._handle_web_search_tool(tool_call, execution_results, session_id)
+            return self._handle_web_search_tool(tool_call, execution_results, session_id, role=role)
         if tool_name in WEB_RESEARCH_TOOL_NAMES:  # Issue #7509
             return self._handle_web_research_tool(tool_name, tool_call, execution_results, session_id)
         if tool_name in LIVE_PAGE_EXTRACT_TOOL_NAMES:  # Issue #11540
@@ -3528,6 +3583,7 @@ class ToolHandlerMixin:
                 selected_model,
                 execution_results,
                 additional_response_parts,
+                role=role,
             )
         # A member of _UNIFORM_BUILTIN_TOOLS without a route row is a wiring bug —
         # fail loudly rather than falling through to a high-blast-radius handler.
@@ -3566,10 +3622,12 @@ class ToolHandlerMixin:
         selected_model: str,
         execution_results: list[dict[str, Any]],
         additional_response_parts: list[str],
+        role: str = "user",
     ):
         """Delegate execute_command tool call to _process_single_command. Issue #2735.
 
         Extracted from _dispatch_tool_call to keep parent under 65 lines.
+        Issue #14469: forwards `role` — see _process_single_command.
         """
         async for msg in self._process_single_command(
             tool_call,
@@ -3579,6 +3637,7 @@ class ToolHandlerMixin:
             selected_model,
             execution_results,
             additional_response_parts,
+            role=role,
         ):
             yield msg
 

--- a/autobot-backend/tests/unit/chat_workflow/test_permission_enforcement_builtin_surfaces.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_permission_enforcement_builtin_surfaces.py
@@ -1,0 +1,220 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""RBAC denial reaches execute_command/browser/web_search — the three call
+sites #14420 left unwired (#14469).
+
+`_try_mcp_dispatch` was fixed in #14420 to populate `tool_permission` and
+`user_role` on the hook context it feeds `PermissionEnforcementExtension`.
+Three sibling call sites in the same file — `_process_single_command`
+(execute_command), `_handle_browser_tool`, and `_handle_web_search_tool` —
+never received `role` at all and never declared a `tool_permission`, so
+`PermissionEnforcementExtension` read every call through them as an
+undeclared/legacy tool and allowed it through unconditionally regardless of
+the caller's RBAC role.
+
+Every test here dispatches through the real handler with the real
+`ExtensionManager` singleton and the real `PermissionEnforcementExtension`
+registered — only the actual side-effecting I/O (terminal execution, the
+browser VM call) is stubbed. A test that only proved the extension's own
+logic would have passed before this fix; these prove the *call site* denies.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from chat_workflow.tool_handler import ToolHandlerMixin
+from middleware.builtin.permission_enforcement import PermissionEnforcementExtension
+from middleware.manager import get_extension_manager, reset_extension_manager
+
+
+def _handler() -> ToolHandlerMixin:
+    return ToolHandlerMixin.__new__(ToolHandlerMixin)  # no __init__ side effects needed
+
+
+@pytest.fixture(autouse=True)
+def _real_permission_enforcement():
+    """Register the real extension on the real singleton every hook call reads."""
+    reset_extension_manager()
+    get_extension_manager().register(PermissionEnforcementExtension())
+    yield
+    reset_extension_manager()
+
+
+# --------------------------------------------------------------------------
+# execute_command — Permission.SHELL_EXECUTE
+# --------------------------------------------------------------------------
+
+
+class TestExecuteCommandDenial:
+    """`user`/`readonly` do not hold `allow_shell_execute`; `operator`/`admin` do."""
+
+    def _tool_call(self) -> dict:
+        return {"name": "execute_command", "params": {"command": "ls", "host": "main"}, "description": ""}
+
+    @pytest.mark.asyncio
+    async def test_a_role_lacking_shell_execute_is_denied(self):
+        handler = _handler()
+        handler._execute_terminal_command = AsyncMock(return_value={"status": "success", "stdout": "hi"})
+
+        messages = [
+            msg
+            async for msg in handler._process_single_command(
+                self._tool_call(), "sess-1", "term-1", "http://ollama", "model", [], [], role="user"
+            )
+        ]
+
+        assert messages[-1].type == "error"
+        assert messages[-1].metadata.get("cancelled_by_hook") is True
+        assert messages[-1].metadata.get("reason") == "permission_denied"
+        handler._execute_terminal_command.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_an_unauthenticated_caller_is_denied(self):
+        handler = _handler()
+        handler._execute_terminal_command = AsyncMock(return_value={"status": "success", "stdout": "hi"})
+
+        messages = [
+            msg
+            async for msg in handler._process_single_command(
+                self._tool_call(), "sess-1", "term-1", "http://ollama", "model", [], [], role=None
+            )
+        ]
+
+        assert messages[-1].metadata.get("cancelled_by_hook") is True
+        handler._execute_terminal_command.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_a_role_holding_shell_execute_is_allowed(self):
+        """`admin` is the only role holding SHELL_EXECUTE — the control case
+        proving this discriminates rather than always denying."""
+        handler = _handler()
+        handler._execute_terminal_command = AsyncMock(return_value={"status": "error", "error": "boom", "stderr": ""})
+
+        async for _msg in handler._process_single_command(
+            self._tool_call(), "sess-1", "term-1", "http://ollama", "model", [], [], role="admin"
+        ):
+            pass
+
+        handler._execute_terminal_command.assert_awaited_once()
+
+
+# --------------------------------------------------------------------------
+# browser tools — MCP_BROWSER_READ (baseline) / MCP_BROWSER_CONTROL (drives)
+# --------------------------------------------------------------------------
+
+
+class TestBrowserToolDenial:
+    @pytest.mark.asyncio
+    async def test_a_role_lacking_browser_control_is_denied_for_click(self):
+        """`user` holds MCP_BROWSER_READ but not MCP_BROWSER_CONTROL."""
+        handler = _handler()
+        mock_send = AsyncMock(return_value={"success": True, "result": {}})
+        tool_call = {"name": "click", "params": {"selector": "#go"}, "description": "click"}
+
+        with patch("api.browser_mcp.send_to_browser_vm", mock_send):
+            messages = [
+                msg async for msg in handler._handle_browser_tool(tool_call, [], session_id="sess-1", role="user")
+            ]
+
+        assert messages[-1].type == "error"
+        assert messages[-1].metadata.get("cancelled_by_hook") is True
+        assert messages[-1].metadata.get("reason") == "permission_denied"
+        mock_send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_a_role_holding_browser_control_is_allowed_for_click(self):
+        """`operator` holds MCP_BROWSER_CONTROL — the control case."""
+        handler = _handler()
+        mock_send = AsyncMock(return_value={"success": True, "result": {}})
+        tool_call = {"name": "click", "params": {"selector": "#go"}, "description": "click"}
+
+        with patch("api.browser_mcp.send_to_browser_vm", mock_send):
+            async for _msg in handler._handle_browser_tool(tool_call, [], session_id="sess-1", role="operator"):
+                pass
+
+        mock_send.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_a_role_lacking_browser_read_is_denied_for_navigate(self):
+        """`readonly` holds neither MCP_BROWSER_READ nor MCP_BROWSER_CONTROL."""
+        handler = _handler()
+        mock_send = AsyncMock(return_value={"success": True, "result": {}})
+        tool_call = {"name": "navigate", "params": {"url": "https://example.com"}, "description": "go"}
+
+        with (
+            patch("api.browser_mcp.is_url_allowed", AsyncMock(return_value=True)),
+            patch("api.browser_mcp.send_to_browser_vm", mock_send),
+        ):
+            messages = [
+                msg async for msg in handler._handle_browser_tool(tool_call, [], session_id="sess-1", role="readonly")
+            ]
+
+        assert messages[-1].metadata.get("cancelled_by_hook") is True
+        assert messages[-1].metadata.get("reason") == "permission_denied"
+        mock_send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_a_role_holding_browser_read_is_allowed_for_navigate(self):
+        handler = _handler()
+        mock_send = AsyncMock(return_value={"success": True, "result": {}})
+        tool_call = {"name": "navigate", "params": {"url": "https://example.com"}, "description": "go"}
+
+        with (
+            patch("api.browser_mcp.is_url_allowed", AsyncMock(return_value=True)),
+            patch("api.browser_mcp.send_to_browser_vm", mock_send),
+        ):
+            async for _msg in handler._handle_browser_tool(tool_call, [], session_id="sess-1", role="user"):
+                pass
+
+        mock_send.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_a_role_lacking_browser_control_is_denied_for_select(self):
+        """#14469: `select` was previously undeclared (inherited MCP_BROWSER_READ)."""
+        handler = _handler()
+        mock_send = AsyncMock(return_value={"success": True, "result": {}})
+        tool_call = {"name": "select", "params": {"selector": "#opt", "value": "a"}, "description": "select"}
+
+        with patch("api.browser_mcp.send_to_browser_vm", mock_send):
+            messages = [
+                msg async for msg in handler._handle_browser_tool(tool_call, [], session_id="sess-1", role="user")
+            ]
+
+        assert messages[-1].metadata.get("cancelled_by_hook") is True
+        mock_send.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# web_search — MCP_BROWSER_READ
+# --------------------------------------------------------------------------
+
+
+class TestWebSearchDenial:
+    def _tool_call(self) -> dict:
+        return {"name": "web_search", "params": {"query": "hello"}, "description": ""}
+
+    @pytest.mark.asyncio
+    async def test_a_role_lacking_browser_read_is_denied(self):
+        handler = _handler()
+        handler._execute_web_search = AsyncMock(return_value="results")
+
+        messages = [
+            msg async for msg in handler._handle_web_search_tool(self._tool_call(), [], session_id="sess-1", role="readonly")
+        ]
+
+        assert messages[-1].metadata.get("cancelled_by_hook") is True
+        assert messages[-1].metadata.get("reason") == "permission_denied"
+        handler._execute_web_search.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_a_role_holding_browser_read_is_allowed(self):
+        handler = _handler()
+        handler._execute_web_search = AsyncMock(return_value="results")
+
+        async for _msg in handler._handle_web_search_tool(self._tool_call(), [], session_id="sess-1", role="user"):
+            pass
+
+        handler._execute_web_search.assert_awaited_once()

--- a/autobot-backend/tests/unit/chat_workflow/test_permission_enforcement_builtin_surfaces.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_permission_enforcement_builtin_surfaces.py
@@ -202,7 +202,10 @@ class TestWebSearchDenial:
         handler._execute_web_search = AsyncMock(return_value="results")
 
         messages = [
-            msg async for msg in handler._handle_web_search_tool(self._tool_call(), [], session_id="sess-1", role="readonly")
+            msg
+            async for msg in handler._handle_web_search_tool(
+                self._tool_call(), [], session_id="sess-1", role="readonly"
+            )
         ]
 
         assert messages[-1].metadata.get("cancelled_by_hook") is True

--- a/autobot_shared/auth/mcp_tool_permissions.py
+++ b/autobot_shared/auth/mcp_tool_permissions.py
@@ -64,6 +64,12 @@ TOOL_PERMISSIONS: Dict[str, Permission] = {
     "fill_index": Permission.MCP_BROWSER_CONTROL,
     "hover": Permission.MCP_BROWSER_CONTROL,
     "hover_index": Permission.MCP_BROWSER_CONTROL,
+    # #14469: `select` changes a dropdown's value same as click/fill do — its
+    # name carries none of the mutating verbs `mcp_tool_permissions_test.py`
+    # scans for, so the state-changing-tool guard never caught it inheriting
+    # the bridge's read-level default.
+    "select": Permission.MCP_BROWSER_CONTROL,
+    "select_index": Permission.MCP_BROWSER_CONTROL,
     # `evaluate` runs caller-supplied JavaScript in the page — the strongest
     # thing this bridge can do, and it read as an ordinary user tool before.
     "evaluate": Permission.MCP_BROWSER_CONTROL,

--- a/autobot_shared/auth/mcp_tool_permissions_test.py
+++ b/autobot_shared/auth/mcp_tool_permissions_test.py
@@ -188,6 +188,14 @@ def test_browser_evaluate_is_not_a_read():
     assert required_permission("evaluate", "browser_mcp") == Permission.MCP_BROWSER_CONTROL
 
 
+def test_browser_select_is_not_a_read():
+    """#14469: `select` changes a dropdown's value, same as click/fill — its name
+    carries none of `_MUTATING`'s verbs, so it silently inherited the bridge's
+    read-level default until declared here explicitly."""
+    assert required_permission("select", "browser_mcp") == Permission.MCP_BROWSER_CONTROL
+    assert required_permission("select_index", "browser_mcp") == Permission.MCP_BROWSER_CONTROL
+
+
 def test_readonly_holds_no_control_grant():
     """The role split has to mean something at the weakest role."""
     readonly = set(ROLE_PERMISSIONS[Role.READONLY])

--- a/scripts/check_python_file_size.py
+++ b/scripts/check_python_file_size.py
@@ -60,7 +60,7 @@ SELF_REL = "scripts/check_python_file_size.py"
 KNOWN_LARGE: dict[str, int] = {
     "autobot-backend/orchestrator.py": 1114,
     "autobot-backend/chat_workflow/manager.py": 4068,
-    "autobot-backend/chat_workflow/tool_handler.py": 3863,
+    "autobot-backend/chat_workflow/tool_handler.py": 3719,
 }
 
 


### PR DESCRIPTION
## Thinking Path

#14420 fixed two mechanical gaps in `PermissionEnforcementExtension`: `tool_permission` was never populated on the hook context, and a raised `PermissionError` denial was swallowed into an allow by `Extension.on_hook`'s blanket `except Exception`. It wired the fix into the one call site that already carried a permission declaration and a role: `_try_mcp_dispatch` (the MCP registry path).

#14469 asked for a per-surface audit: a mechanism that *can* deny is not a mechanism *proven* to deny on every surface. Grepping the whole backend for `_emit_before_tool_execute` (the only entry point into `BEFORE_TOOL_EXECUTE`) turns up exactly four call sites, all in `chat_workflow/tool_handler.py`:

| Surface | `tool_permission` populated? | Hook fires? | `role` reaches it? | Denial stops execution? |
|---|---|---|---|---|
| `_try_mcp_dispatch` (MCP registry) | Yes — `tool.get("required_permission")` | Yes | Yes (`role=role`, #13821) | Yes (fixed by #14420) |
| `_process_single_command` (`execute_command`) | **No** (pre-fix) | Yes | **No** (pre-fix) | No — every role reached the shell |
| `_handle_browser_tool` (click/fill/navigate/...) | **No** (pre-fix) | Yes | **No** (pre-fix) | No — every role drove the page |
| `_handle_web_search_tool` | **No** (pre-fix) | Yes | **No** (pre-fix) | No — every role could search |
| `_handle_web_research_tool`, `_handle_extract_content_tool`, `_handle_read_spilled_output`, `_handle_compose_tool`, `_handle_delegate_tool`, `_handle_respond_tool`, `_handle_llc_tool` | N/A | **Never invoked** | N/A | N/A — hook point never fires on this path at all |

Registration was already checked (#14280/#14414): `initialization/lifespan.py::_init_builtin_extensions` registers `PermissionEnforcementExtension` onto `middleware.manager.get_extension_manager()`, the same singleton every `_emit_*` call in `chat_workflow/llm_handler.py` reads — no throwaway-instance risk on any of these four sites.

The last row (seven branches that never call the hook at all) is a materially different, larger defect than "hook fires but reads as legacy" — filed separately as #14491 rather than folded in here, since deciding a permission for `compose`/`delegate`/`respond`/LLC work-object tools is design work, and LLC tools in particular need scrutiny as company-scoped mutations with no RBAC check visible at that seam.

**Rebase (#14497 landed on the base in the meantime):** #14497 extracted `tool_handler.py`'s six seam guards into `tool_dispatch_guards.py` and lowered `KNOWN_LARGE["...tool_handler.py"]` to 3863 to match. This branch rebased cleanly onto that — the two PRs touch disjoint regions of the file (guards vs. call-site RBAC threading), confirmed conflict-free with `git merge-tree` before rebasing and with an actual `git rebase origin/Dev_new_gui` producing zero conflicts. After the rebase this PR's own +~59 net lines took the file to 3922, breaching the new 3863 ceiling — see the extraction below.

## What Changed

- `chat_workflow/tool_handler.py`: threads `role` from `_dispatch_tool_call` (where #13821 already resolves the caller's authenticated role) down through `_builtin_route` → `_dispatch_execute_command` / `_handle_browser_tool` / `_handle_web_search_tool`, and declares a `tool_permission` at each:
  - `_process_single_command` (`execute_command`) → `Permission.SHELL_EXECUTE` (admin-only per `ROLE_PERMISSIONS`).
  - `_handle_browser_tool` → resolved per tool name via `autobot_shared.auth.mcp_tool_permissions.required_permission(tool_name, bridge_name="browser_mcp")` — the same table the `browser_mcp` MCP bridge uses, since this is the non-registry path for identical tool names (read baseline, `MCP_BROWSER_CONTROL` for anything that drives the page).
  - `_handle_web_search_tool` → `Permission.MCP_BROWSER_READ` — it abstracts a read-only browser flow (search + read results), never arbitrary page control.
- `autobot_shared/auth/mcp_tool_permissions.py`: declares `select`/`select_index` as `MCP_BROWSER_CONTROL`. Both change a dropdown's value the same as `click`/`fill`/`hover`, but their names carry none of the mutating verbs `mcp_tool_permissions_test.py`'s guard scans for, so both silently inherited the bridge's read-level default — a real under-grant reached directly by the `_handle_browser_tool` reuse above.
- `autobot-backend/tests/unit/chat_workflow/test_permission_enforcement_builtin_surfaces.py`: new dispatch-level tests for all three fixed surfaces.
- `autobot_shared/auth/mcp_tool_permissions_test.py`: pins the `select`/`select_index` declaration.
- **`autobot-backend/chat_workflow/browser_tool_handler.py` (new)**: extracted the whole browser-tool dispatch/formatting unit out of `tool_handler.py` — `_validate_browser_params`, `_handle_browser_tool` (the surface this PR itself touches), `_record_browser_success`, `_extract_browser_image`, `_format_page_state_block`, `_format_browser_result`, `_format_browser_action_text`, plus the two constants they use (`BROWSER_STATE_PROMPT_MAX_ELEMENTS`, `_INDEXED_ELEMENT_TOOL_TEXT`). This is the same shape #14497 used for the seam guards: none of these seven functions touched `self` for anything beyond calling one another (confirmed by grep — `self.` appears only as calls between them), so they became plain module-level functions and `ToolHandlerMixin` keeps thin same-named delegating methods. This pays for this PR's own additions and leaves the file with real margin instead of spending #14497's.
- `scripts/check_python_file_size.py`: lowers `KNOWN_LARGE["autobot-backend/chat_workflow/tool_handler.py"]` from 3863 to **3719** — the file's exact new measured size, per the ratchet's requirement that the recorded ceiling equal reality. `KNOWN_LARGE` was **not** raised at any point to accommodate this PR's additions (`#14498` remains the reason that must never happen).

## Verification

Every new test dispatches through the **real** handler (`_process_single_command` / `_handle_browser_tool` / `_handle_web_search_tool`) with the **real** `ExtensionManager` singleton and the **real** `PermissionEnforcementExtension` registered — only the actual side-effecting I/O is stubbed (`_execute_terminal_command`, `api.browser_mcp.send_to_browser_vm`, `_execute_web_search`). Each asserts the denial *takes effect* (the stubbed I/O is never called) and that a role holding the permission still reaches it (`assert_awaited_once()` / `assert_not_called()`), not merely that a check ran.

Since running code from the codebase isn't available in this environment, I additionally extracted the exact decision logic (role→permission table, `PermissionEnforcementExtension`'s allow/deny branch, and the three call-site permission declarations this PR adds) into a standalone script outside the repo and mutated it back to the pre-#14469 behavior (`tool_permission = None`, unconditionally):

```
mutation guard: all 3 mutated bodies differ from their originals.
ORIGINAL (fixed) guard: all deny/allow assertions passed (deny refused, allow still works).
  execute_command/user: fixed=DENY, mutated(pre-#14469)=ALLOW  -- mutation caught
  click/user: fixed=DENY, mutated(pre-#14469)=ALLOW  -- mutation caught
  select/user: fixed=DENY, mutated(pre-#14469)=ALLOW  -- mutation caught
  navigate/readonly: fixed=DENY, mutated(pre-#14469)=ALLOW  -- mutation caught
  web_search/readonly: fixed=DENY, mutated(pre-#14469)=ALLOW  -- mutation caught
MUTATED (pre-#14469) guard: every case the fix denies now allows once tool_permission stops
being forwarded -- proves the assertions above actually exercise the fix, not a vacuous
always-true/always-false check.
```

This confirms both halves the task asked for: the deny case is refused under the fix and the identical allow case (a role holding the permission) still succeeds, and reverting the fix's forwarding — the exact pre-#14469 defect — flips every one of those outcomes, so the assertions are not vacuously true.

`python3 -m py_compile` passed on every changed/added file (syntax only — no application code executed, per policy).

**Extraction evidence (byte-identical apart from mechanical changes):**

- **Line counts:** `tool_handler.py` 4081 → 3863 (#14497, base) → 3922 after this PR's own additions landed on that base (breaching 3863 by 59) → **3719** after the browser-tool extraction — 144 lines under the 3863 ceiling this PR inherited, comfortable margin rather than "not 3862". The `KNOWN_LARGE` entry is then lowered to 3719 to match, per the ratchet's own rule that the recorded ceiling must equal the file's actual size (no slack is banked in the ceiling itself for a future PR to spend unearned). New file `browser_tool_handler.py`: 334 lines — well under the 600-line plain limit, no `KNOWN_LARGE` entry needed.
- **Faithfulness:** diffed the original 273-line method block (`git show 92acf0164:autobot-backend/chat_workflow/tool_handler.py` lines 2391–2662, the rebased pre-extraction commit) against the new module after mechanically normalizing (`self.` calls → plain calls, `def _foo(self, ...)` → `def foo(...)`, one dedent level). The residual diff is *only*: the 7 function names losing their leading underscore, `self`/`self.` removed from signatures and call sites, one added return-type annotation on the async-generator (`-> AsyncIterator[WorkflowMessage]`), and docstring cross-references updated to the new names (`_handle_browser_tool` → `handle_browser_tool`, `_format_browser_result` → `format_browser_result`). No control flow, no branch, no string, no log line changed. Nothing was deleted — every line moved.
- **Deny-before-call ordering — verified on all three surfaces this PR touches:**
  - `_process_single_command` (untouched by the extraction): `should_execute` checked, `return`s at the cancellation branch **before** `self._execute_terminal_command(...)` (the guarded call) ever runs.
  - `_handle_browser_tool` (now `browser_tool_handler.handle_browser_tool`, delegated to by the same-named method): `should_execute` checked, `return`s **before** `send_to_browser_vm(...)` (the guarded call) — same statement order as before, only the containing function moved.
  - `_handle_web_search_tool` (untouched): `should_execute` checked, `return`s **before** `self._execute_web_search_full`/`self._execute_web_search` (the guarded calls).
- **Test monkey-patch / unbound-call compatibility preserved:** `ToolHandlerMixin._validate_browser_params` is still a method (called unbound with an explicit dummy `self` in `test_tool_handler_browser_block.py`); `handler._handle_browser_tool = ...` (instance monkey-patch in `test_tool_handler_builtin_route.py`) still works since the attribute still exists on the class with the same name and calling convention; `handler._record_browser_success` / `handler._format_browser_result` (called directly in `test_vision_in_the_loop.py`, `test_tool_handler_indexed_browser.py`) are unaffected — all seven names remain instance methods with identical signatures, now one-line delegates.
- Rebase was clean: `git merge-tree` reported zero conflicts before rebasing, and `git rebase origin/Dev_new_gui` completed with no conflict resolution needed.

## Model Used

Claude Opus 5 (1M context)

Closes #14469
Refs #14491
