### PR TITLE
fix(ci): stop frontend-test compiling the same vue-tsc project twice (#14481)

### DIFF
--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -129,11 +129,28 @@ jobs:
 
       - name: Run type checking
         working-directory: autobot-frontend
-        run: npm run type-check
-
+        # #14481: this step used to be followed by `check-ts-delta`, which ran
+        # this exact vue-tsc project a SECOND time in the same job — the first
+        # compile took 215s, the second exceeded its 600s budget and was killed
+        # under runner load, reddening the required "Unit & Integration Tests"
+        # context with no failing test and no error output. `set -eo pipefail`
+        # keeps this step's pass/fail identical to a bare `npm run type-check`:
+        # any nonzero exit from vue-tsc still fails this step immediately, teeing
+        # its output to a file does not change that. `check-ts-delta` below
+        # reads that file instead of recompiling.
+        run: |
+          set -eo pipefail
+          npm run type-check 2>&1 | tee vue-tsc-output.log
+          echo 0 > vue-tsc-status.txt
 
       - name: Check TypeScript error delta
         working-directory: autobot-frontend
+        # #14481: reuse the compile `type-check` just captured (vue-tsc-output.log
+        # / vue-tsc-status.txt) instead of running the same vue-tsc project a
+        # second time — see scripts/check-ts-delta.sh for the reuse contract.
+        # If either file were unexpectedly missing the script falls back to
+        # compiling itself, so this step still gates even then.
+        #
         # #13341: bound the STEP, not just the job. GitHub enforces
         # `timeout-minutes` from the RUNNER side, so when the runner process
         # stops making progress the job-level cancellation may never be issued
@@ -143,17 +160,22 @@ jobs:
         # `timeout` runs inside this step's own process tree, so it fires at a
         # known point whether or not GitHub's cancellation ever arrives, and the
         # step fails with a diagnosable "timed out" instead of hanging silently.
-        # 600s is roughly seven times the ~89s this step took on its last clean
-        # run; TERM first so vue-tsc can flush, KILL 60s later if it will not.
         # `--verbose` matters: without it `timeout` prints NOTHING, so the log
         # ends at "Process completed with exit code 124" and the operator is
         # left to know that 124 means a timeout. With it the step says
         # "timeout: sending signal TERM to command 'npm'", which is the
         # diagnosable failure this bound exists to produce.
-        # The hang itself is fixed at the root in scripts/check-ts-delta.sh
-        # (npx removed) — this bound is the guard for the NEXT unknown cause,
-        # not the fix for the known one.
-        run: timeout --verbose --kill-after=60s 600 npm run check-ts-delta
+        # 60s (was 600s) because this step no longer compiles anything (#14481)
+        # — it only reads the two files above and does a `grep`/arithmetic
+        # comparison, sub-second work on any runner. 60s keeps the same
+        # defense-in-depth this bound has always provided against an unknown
+        # future hang, rightsized to the much smaller job that remains; it is
+        # not a budget for a compile, because there is no longer a compile here
+        # to budget for.
+        run: timeout --verbose --kill-after=15s 60 npm run check-ts-delta
+        env:
+          TSC_OUTPUT_FILE: vue-tsc-output.log
+          TSC_STATUS_FILE: vue-tsc-status.txt
 
       - name: Run linting
         working-directory: autobot-frontend

--- a/autobot-frontend/.gitignore
+++ b/autobot-frontend/.gitignore
@@ -41,6 +41,11 @@ pnpm-lock.yaml
 *.tsbuildinfo
 .vue-tsc-cache/
 
+# === CI vue-tsc OUTPUT CAPTURE (#14481) ===
+# check-ts-delta.sh's status marker; vue-tsc-output.log is already covered
+# by the *.log rule above.
+vue-tsc-status.txt
+
 # === TESTING FRAMEWORK GENERATED FILES ===
 # Cypress
 /cypress/videos/

--- a/autobot-frontend/scripts/check-ts-delta.sh
+++ b/autobot-frontend/scripts/check-ts-delta.sh
@@ -7,6 +7,15 @@
 #
 # Reads baseline from docs/developer/audits/typescript-baseline.md (Total: N line).
 # Exits 1 if current error count exceeds baseline; exits 0 otherwise.
+#
+# #14481: a caller that already compiled this exact project (same command,
+# same tsconfig) can hand this script that output instead of paying for a
+# second compile. Set BOTH TSC_OUTPUT_FILE (raw vue-tsc stdout+stderr) and
+# TSC_STATUS_FILE (its exit code, one line) and this script reads them
+# instead of invoking the compiler again. Either unset, or either file
+# missing, and this script compiles fresh exactly as it always has — so
+# `bash scripts/check-ts-delta.sh` with no environment still works standalone
+# for local development.
 
 set -euo pipefail
 
@@ -30,40 +39,47 @@ if [[ -z "${BASELINE}" ]]; then
   exit 1
 fi
 
-# --- Run TypeScript check ---
-#
-# Why not npx (#13341). This step ran unbounded for over three hours on the
-# singleton self-hosted runner while its sibling `type-check` step — the SAME
-# vue-tsc invocation, reached through `npm run` — finished in about a minute in
-# the same job. The difference was `npx`, and every one of its extra behaviours
-# is an unbounded wait:
-#
-#   * it resolves the package before running it, which can reach the registry;
-#   * when resolution misses it PROMPTS ("Ok to proceed?") and blocks on stdin,
-#     which in a CI step is a pipe that never delivers a line and never closes;
-#   * it takes locks under the shared npm cache, and on the self-hosted runner
-#     $HOME is shared with every concurrently executing job rather than being a
-#     fresh VM per job, so a stale lock blocks instead of being absent.
-#
-# `vue-tsc` is a devDependency, so it is already on disk after `npm ci`; there
-# is nothing for a resolver to do. Calling the installed binary directly removes
-# the network path, the prompt and the cache lock in one move. `</dev/null`
-# guarantees that nothing downstream of this line can ever block on stdin.
-if [[ ! -x "${TSC_BIN}" ]]; then
-  echo "ERROR: vue-tsc not found at ${TSC_BIN}" >&2
-  echo "Run 'npm ci' in ${FRONTEND_DIR} first." >&2
-  exit 1
+# --- Run TypeScript check, or reuse a caller's prior run (#14481) ---
+if [[ -n "${TSC_OUTPUT_FILE:-}" && -n "${TSC_STATUS_FILE:-}" \
+      && -f "${TSC_OUTPUT_FILE}" && -f "${TSC_STATUS_FILE}" ]]; then
+  echo "Reusing vue-tsc output captured by the type-check step (baseline: ${BASELINE} errors)..."
+  TSC_OUTPUT="${TSC_OUTPUT_FILE}"
+  TSC_STATUS="$(<"${TSC_STATUS_FILE}")"
+else
+  #
+  # Why not npx (#13341). This step ran unbounded for over three hours on the
+  # singleton self-hosted runner while its sibling `type-check` step — the SAME
+  # vue-tsc invocation, reached through `npm run` — finished in about a minute in
+  # the same job. The difference was `npx`, and every one of its extra behaviours
+  # is an unbounded wait:
+  #
+  #   * it resolves the package before running it, which can reach the registry;
+  #   * when resolution misses it PROMPTS ("Ok to proceed?") and blocks on stdin,
+  #     which in a CI step is a pipe that never delivers a line and never closes;
+  #   * it takes locks under the shared npm cache, and on the self-hosted runner
+  #     $HOME is shared with every concurrently executing job rather than being a
+  #     fresh VM per job, so a stale lock blocks instead of being absent.
+  #
+  # `vue-tsc` is a devDependency, so it is already on disk after `npm ci`; there
+  # is nothing for a resolver to do. Calling the installed binary directly removes
+  # the network path, the prompt and the cache lock in one move. `</dev/null`
+  # guarantees that nothing downstream of this line can ever block on stdin.
+  if [[ ! -x "${TSC_BIN}" ]]; then
+    echo "ERROR: vue-tsc not found at ${TSC_BIN}" >&2
+    echo "Run 'npm ci' in ${FRONTEND_DIR} first." >&2
+    exit 1
+  fi
+
+  echo "Running vue-tsc (baseline: ${BASELINE} errors)..."
+  TSC_OUTPUT="$(mktemp)"
+  trap 'rm -f "${TSC_OUTPUT}"' EXIT
+
+  TSC_STATUS=0
+  (
+    cd "${FRONTEND_DIR}"
+    "${TSC_BIN}" --noEmit -p tsconfig.app.json
+  ) >"${TSC_OUTPUT}" 2>&1 </dev/null || TSC_STATUS=$?
 fi
-
-echo "Running vue-tsc (baseline: ${BASELINE} errors)..."
-TSC_OUTPUT="$(mktemp)"
-trap 'rm -f "${TSC_OUTPUT}"' EXIT
-
-TSC_STATUS=0
-(
-  cd "${FRONTEND_DIR}"
-  "${TSC_BIN}" --noEmit -p tsconfig.app.json
-) >"${TSC_OUTPUT}" 2>&1 </dev/null || TSC_STATUS=$?
 
 CURRENT=$(grep -c "error TS" "${TSC_OUTPUT}" || true)
 
@@ -78,7 +94,9 @@ CURRENT=$(grep -c "error TS" "${TSC_OUTPUT}" || true)
 # vue-tsc returns TypeScript's ExitStatus: 0 clean, 1 a configuration/command
 # diagnostic, 2 the normal "type errors were found", 3 and 4 invalid project.
 # So anything above 2 never completed a check, and a non-zero status with no
-# diagnostics at all is the crash case.
+# diagnostics at all is the crash case. This holds whether TSC_STATUS came from
+# a compile just above or from a reused TSC_STATUS_FILE — a caller that reused
+# a crash gets caught here exactly like a caller that hit one directly.
 if (( TSC_STATUS > 2 )) || { (( TSC_STATUS != 0 )) && (( CURRENT == 0 )); }; then
   echo "ERROR: vue-tsc exited ${TSC_STATUS} without completing a check." >&2
   echo "The error delta is unknown, so this is a failure, not a pass. Output:" >&2

--- a/repo_tests/frontend_duplicate_typecheck_compile_guard_test.py
+++ b/repo_tests/frontend_duplicate_typecheck_compile_guard_test.py
@@ -1,0 +1,285 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""No CI job may compile the same vue-tsc project more than once (#14481).
+
+`frontend-test.yml`'s `unit-tests` job used to run `vue-tsc --noEmit -p
+tsconfig.app.json` twice: once directly (`npm run type-check`) and once more
+inside `check-ts-delta.sh` (`npm run check-ts-delta`). The first compile took
+215s; the second, running while the runner was busy, exceeded its 600s budget
+and was killed — reddening the required "Unit & Integration Tests" context
+with no failing test and no error output (#14481).
+
+This guard scans every job in every workflow for *unconditional* vue-tsc
+compile invocations, resolving one hop of `npm run <script>` indirection
+through the relevant `package.json` and, where a resolved command shells out
+to a repo-local `*.sh` file, reading that file too — because the duplicate
+compile in #14481 was one hop removed from the workflow YAML itself (behind
+`npm run check-ts-delta` -> `scripts/check-ts-delta.sh`), so a check that only
+looked at the workflow text would have missed it entirely, exactly as it did
+before this guard existed.
+
+A compile invocation found inside `check-ts-delta.sh`'s documented reuse
+fallback (the `else` branch guarded on `TSC_OUTPUT_FILE`/`TSC_STATUS_FILE`
+being pre-supplied) does not count: that branch only runs when no prior step
+in the job captured a compile for it to reuse, which is a *different* compile
+site, not a second one. The discriminator is structural (an `else` following
+a mention of the reuse marker), not the literal step names — a rename of
+"type-check" or "check-ts-delta" must not blind this guard.
+
+Discrimination this guard must show: `test_no_job_compiles_...` PASSES
+against the workflow and script as they stand now (one compile site in
+`unit-tests`: `type-check`'s direct call — `check-ts-delta`'s own compile
+line only exists inside the guarded fallback). `test_the_pre_fix_shape_...`
+proves the counting primitive itself FAILS the pre-#14481 shape — the same
+two call sites the issue names (frontend-test.yml:132 and
+check-ts-delta.sh's then-unconditional compile block) — so a future edit
+that quietly removes the discrimination cannot pass unnoticed.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml", reason="PyYAML needed to parse the workflows")
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
+
+# Matches a line that actually RUNS the compiler against a tsconfig project —
+# either the literal `vue-tsc` command, or the resolved-binary-path idiom this
+# repo uses instead of `npx` (`"$TSC_BIN"` / `"${TSC_BIN}"`, see
+# autobot-frontend/scripts/check-ts-delta.sh). A bare assignment such as
+# `TSC_BIN=".../vue-tsc"` has neither `--noEmit` nor `-p <tsconfig>` on the
+# same line, so it is not a match — this only fires on an actual invocation.
+COMPILE_PATTERN = re.compile(
+    r'(?:\bvue-tsc\b|"\$\{?TSC_BIN\}?")[^\n]*--noEmit[^\n]*-p\s+\S*tsconfig'
+)
+
+# The marker two cooperating steps use to hand off a captured compile instead
+# of running a second one (the #14481 fix's reuse contract). A compile line
+# reachable only through the `else` of a conditional guarded on this name is
+# the documented "no prior capture available" fallback, not a second,
+# unconditional compile.
+REUSE_MARKER = "TSC_OUTPUT_FILE"
+
+NPM_RUN_RE = re.compile(r"npm run(?:-script)?\s+([\w:.-]+)")
+SH_PATH_RE = re.compile(r"[\w./-]+\.sh\b")
+
+
+def _load_yaml(path: Path) -> dict:
+    try:
+        return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except yaml.YAMLError:
+        return {}
+
+
+def _package_scripts(working_directory: str) -> dict:
+    pkg_path = (REPO_ROOT / working_directory / "package.json").resolve()
+    if not pkg_path.is_file():
+        return {}
+    try:
+        data = json.loads(pkg_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return {}
+    return data.get("scripts") or {}
+
+
+def _working_directory_for(job: dict, step: dict) -> str:
+    if step.get("working-directory"):
+        return step["working-directory"]
+    defaults = (job.get("defaults") or {}).get("run") or {}
+    return defaults.get("working-directory") or "."
+
+
+def _executable_lines(text: str) -> str:
+    """Drop lines that only PRINT a command name, never run it.
+
+    Several workflows tell the operator what to run locally inside an `echo`
+    (e.g. frontend-typecheck-regression.yml prints "Run `npm run type-check`
+    ... to inspect") — a real command word inside a string literal, not an
+    invocation. Without this, resolving `npm run <script>` against such a
+    line would credit that job with a compile it never runs, hiding a real
+    duplicate under a false one.
+    """
+    return "\n".join(
+        line
+        for line in text.splitlines()
+        if not line.strip().startswith(("echo", "printf"))
+    )
+
+
+def _unguarded_compile_count(text: str) -> int:
+    """Count compile-pattern matches not reached only via the reuse fallback."""
+    reuse_idx = text.find(REUSE_MARKER)
+    guard_start = text.find("else", reuse_idx) if reuse_idx != -1 else -1
+    count = 0
+    for match in COMPILE_PATTERN.finditer(text):
+        if guard_start != -1 and match.start() > guard_start:
+            continue
+        count += 1
+    return count
+
+
+def _texts_for_step(job: dict, step: dict) -> list[str]:
+    """The step's own script plus anything it delegates to, one hop deep."""
+    run_text = step.get("run")
+    if not isinstance(run_text, str):
+        return []
+
+    working_directory = _working_directory_for(job, step)
+    scripts = _package_scripts(working_directory)
+
+    texts = [run_text]
+    for script_name in NPM_RUN_RE.findall(_executable_lines(run_text)):
+        script_value = scripts.get(script_name)
+        if script_value:
+            texts.append(script_value)
+
+    sh_paths: set[str] = set()
+    for text in texts:
+        sh_paths.update(SH_PATH_RE.findall(text))
+    for rel_path in sh_paths:
+        sh_file = (REPO_ROOT / working_directory / rel_path).resolve()
+        if sh_file.is_file():
+            try:
+                texts.append(sh_file.read_text(encoding="utf-8"))
+            except OSError:
+                pass
+
+    return texts
+
+
+def _compile_site_count(job: dict) -> int:
+    total = 0
+    for step in job.get("steps") or []:
+        for text in _texts_for_step(job, step):
+            total += _unguarded_compile_count(text)
+    return total
+
+
+def _all_jobs() -> list[tuple[str, str, dict]]:
+    """(workflow filename, job key, job dict) for every job in every workflow."""
+    found = []
+    for path in sorted(WORKFLOW_DIR.glob("*.yml")):
+        doc = _load_yaml(path)
+        for job_key, job in (doc.get("jobs") or {}).items():
+            if isinstance(job, dict):
+                found.append((path.name, job_key, job))
+    return found
+
+
+def _unit_tests_job() -> dict:
+    for workflow_name, job_key, job in _all_jobs():
+        if workflow_name == "frontend-test.yml" and job_key == "unit-tests":
+            return job
+    raise AssertionError("frontend-test.yml no longer has a job keyed 'unit-tests'")
+
+
+def test_the_scan_actually_finds_jobs():
+    """An empty scan would make every assertion below vacuous."""
+    jobs = _all_jobs()
+    assert len(jobs) >= 10, f"only {len(jobs)} job(s) found — the scan is broken"
+
+
+def test_the_scan_actually_resolves_the_check_ts_delta_script():
+    """Prove the one-hop npm-script + .sh-file resolution really fires.
+
+    Without this, a path or regex typo could make `_texts_for_step` silently
+    return only the step's own `run:` text forever, and every assertion below
+    would still "pass" without ever having looked at check-ts-delta.sh.
+    """
+    job = _unit_tests_job()
+    delta_step = next(
+        s for s in job["steps"] if s.get("name") == "Check TypeScript error delta"
+    )
+    texts = _texts_for_step(job, delta_step)
+    assert len(texts) >= 2, (
+        "resolving 'npm run check-ts-delta' should yield the step's own run text "
+        "plus the resolved package.json script value at minimum"
+    )
+    combined = "\n".join(texts)
+    assert "vue-tsc" in combined, (
+        "the resolved texts never reached scripts/check-ts-delta.sh's own "
+        "content — the .sh-file hop is not firing, so this guard cannot see "
+        "the duplicate compile it exists to catch"
+    )
+    assert REUSE_MARKER in combined, (
+        f"scripts/check-ts-delta.sh no longer mentions {REUSE_MARKER} — either "
+        "the #14481 reuse contract was removed (reintroducing the duplicate "
+        "compile) or renamed without updating this guard's REUSE_MARKER"
+    )
+
+
+def test_no_job_compiles_the_same_vue_tsc_project_more_than_once():
+    violations = {}
+    for workflow_name, job_key, job in _all_jobs():
+        count = _compile_site_count(job)
+        if count > 1:
+            violations[f"{workflow_name}:{job_key}"] = count
+
+    assert not violations, (
+        f"job(s) compile the same vue-tsc project more than once per run: "
+        f"{violations}. Each extra compile is redundant, expensive work that "
+        f"can time out under runner load while producing no new signal "
+        f"(#14481) — share one compile's output between steps instead of "
+        f"invoking vue-tsc again."
+    )
+
+
+# Verbatim shape of scripts/check-ts-delta.sh's compile block as it stood
+# before #14481 (see git blame / issue #14481 for the original file): always
+# ran the compiler, with no reuse marker anywhere in the script.
+_PRE_FIX_CHECK_TS_DELTA_SH = """
+TSC_BIN="${FRONTEND_DIR}/node_modules/.bin/vue-tsc"
+if [[ ! -x "${TSC_BIN}" ]]; then
+  echo "ERROR: vue-tsc not found at ${TSC_BIN}" >&2
+  exit 1
+fi
+
+echo "Running vue-tsc (baseline: ${BASELINE} errors)..."
+TSC_OUTPUT="$(mktemp)"
+trap 'rm -f "${TSC_OUTPUT}"' EXIT
+
+TSC_STATUS=0
+(
+  cd "${FRONTEND_DIR}"
+  "${TSC_BIN}" --noEmit -p tsconfig.app.json
+) >"${TSC_OUTPUT}" 2>&1 </dev/null || TSC_STATUS=$?
+"""
+
+# Verbatim shape of frontend-test.yml's `type-check` step before #14481
+# (frontend-test.yml:132): `npm run type-check`, resolving through
+# package.json to this — unchanged by the fix, since `type-check` was never
+# the redundant half.
+_PRE_FIX_TYPE_CHECK_RESOLVED = "vue-tsc --noEmit -p tsconfig.app.json"
+
+
+def test_the_pre_fix_shape_fails_the_same_guard():
+    """Discrimination check: the counting primitive must catch the #14481 bug.
+
+    Feeds the exact pre-fix shapes of both call sites the issue names —
+    `type-check`'s resolved command and check-ts-delta.sh's then-unconditional
+    compile block, which had no TSC_OUTPUT_FILE reuse marker at all — through
+    the identical `_unguarded_compile_count` primitive the guard above uses.
+    If this ever reports <= 1, the primitive has stopped discriminating and
+    `test_no_job_compiles_the_same_vue_tsc_project_more_than_once` would pass
+    a real regression.
+    """
+    assert REUSE_MARKER not in _PRE_FIX_CHECK_TS_DELTA_SH, (
+        "the fixture claiming to be the PRE-fix script accidentally contains "
+        "the reuse marker — it would no longer exercise the unguarded path"
+    )
+
+    count = _unguarded_compile_count(
+        _PRE_FIX_TYPE_CHECK_RESOLVED
+    ) + _unguarded_compile_count(_PRE_FIX_CHECK_TS_DELTA_SH)
+
+    assert count > 1, (
+        f"expected the pre-#14481 shape to register more than one unguarded "
+        f"compile site (it ran vue-tsc twice, unconditionally); got {count}. "
+        f"The discriminator no longer catches the bug it was written for."
+    )


### PR DESCRIPTION
Closes #14481

## Thinking Path

`frontend-test.yml`'s `unit-tests` job ran `vue-tsc --noEmit -p tsconfig.app.json` twice: once directly via `npm run type-check` (:132), and once more inside `scripts/check-ts-delta.sh`, reached via `npm run check-ts-delta` (:156). The first compile took 215s; the second, competing for the singleton self-hosted runner, exceeded its 600s budget and was killed — reddening the required `Unit & Integration Tests` context with no failing test and no error output.

Read `check-ts-delta.sh` first, as instructed. Its exit-status discrimination (distinguishing "compiler never ran" from "compiler found errors", and specifically catching TS5xxx/TS6xxx config diagnostics that would otherwise report a false "0 errors") is correct and worth keeping — the bug is that the workflow asks for the compile twice, not that the script's logic is wrong.

I evaluated the "preferred" option (drop `type-check`, let `check-ts-delta` provide both signals) against the baseline file it reads: `docs/developer/audits/typescript-baseline.md` currently says `**Total: 188**`, tracked stale by #13353 (the code was cleared to 0 errors by #9724/#10073, but the baseline document was never updated). `check-ts-delta.sh` only fails when `CURRENT > BASELINE`, so alone it would tolerate up to 188 *new* type errors before failing — a real weakening versus `type-check`, which fails on **any** nonzero `vue-tsc` exit unconditionally. Dropping `type-check` would have silently loosened the gate, which the task explicitly forbids.

**I took the second option**: `type-check` still runs the sole compile and still fails the step on any error exactly as before; it additionally captures vue-tsc's raw output and exit status to two files. `check-ts-delta` reads those files instead of recompiling, but keeps its own exit-status/config-diagnostic discrimination intact as a second, independent read of the same data (not a second compile) — so a bug in the plumbing that produced a bogus "clean" file still gets caught by `check-ts-delta`'s own logic.

## What Changed

- `.github/workflows/frontend-test.yml`
  - `Run type checking`: still `npm run type-check` (unchanged command, so `type-check`'s zero-tolerance gate is identical to before — `set -eo pipefail` means a nonzero `vue-tsc` exit still fails this step immediately), now additionally tees its output to `vue-tsc-output.log` and records exit status `0` to `vue-tsc-status.txt` (only reachable on success, since `-e` aborts the step on failure before that line).
  - `Check TypeScript error delta`: now passes `TSC_OUTPUT_FILE`/`TSC_STATUS_FILE` env vars pointing at those two files; `timeout` budget drops from `600s` to `60s` — not raised, *lowered*, because the step no longer compiles anything, only reads two small files and does a `grep`/arithmetic comparison (sub-second work). This keeps the #13341 defense-in-depth (bound the step so a future unknown hang can't hold the singleton runner) rightsized to the work that remains.
  - Job and step names are unchanged (`Unit & Integration Tests`, `Run type checking`, `Check TypeScript error delta`, etc.) — verified against `origin/Dev_new_gui` below.
- `autobot-frontend/scripts/check-ts-delta.sh`: when both `TSC_OUTPUT_FILE` and `TSC_STATUS_FILE` are set and exist, reuses that captured output instead of compiling; otherwise falls back to compiling itself exactly as before, so `bash scripts/check-ts-delta.sh` with no environment still works standalone for local development. The existing exit-status discriminator (crash vs. clean vs. config-diagnostic) runs unchanged against whichever source the output came from.
- `autobot-frontend/.gitignore`: ignore the new `vue-tsc-status.txt` artifact (`vue-tsc-output.log` was already covered by the existing `*.log` rule).
- `repo_tests/frontend_duplicate_typecheck_compile_guard_test.py` (new): guard test, described below.

**Third compile check (asked for in the issue):** `frontend-typecheck-regression.yml`'s `vue-tsc-baseline` job does independently compile the same `autobot-frontend` project again (confirmed: 1 compile site there). It runs on `ubuntu-latest`, not the self-hosted singleton, so it doesn't contend for the runner this issue is about, and it's a separate job — out of scope for the "twice in one job" bug, and not touched here. For completeness, `ci.yml`'s `frontend-tests` job compiles it a fourth time (also `ubuntu-latest`, inline `npx vue-tsc`). Neither is a new problem introduced by this PR.

## Verification

- Guard test (`repo_tests/frontend_duplicate_typecheck_compile_guard_test.py`), 4 tests, run locally as a design aid (CI is the evidence of record — see the check run on this PR):
  - `test_no_job_compiles_the_same_vue_tsc_project_more_than_once`: scans every job in every workflow (resolving `npm run <script>` through `package.json` and any `.sh` file it shells out to, one hop each), asserting no job has more than one unconditional `vue-tsc` compile invocation. Passes against this branch.
  - `test_the_pre_fix_shape_fails_the_same_guard`: feeds the exact pre-#14481 shapes of both call sites (verbatim from the issue's own quoted evidence) through the identical counting primitive and asserts it reports `> 1`.
  - **Discrimination, run end-to-end against real files (not just the fixture) as a local design check**: checked out `origin/Dev_new_gui`'s actual `frontend-test.yml` + `check-ts-delta.sh` (the real pre-fix files) and ran the guard's own `_compile_site_count` against them: **2** compile sites (fails, as required). Ran the same function against this branch's `unit-tests` job: **1** compile site (passes).
  - `test_the_scan_actually_resolves_the_check_ts_delta_script` / `test_the_scan_actually_finds_jobs`: non-vacuousness checks, so the scan can't silently match nothing.
- `type-check` still fails on any type error: unchanged command (`npm run type-check`), `set -eo pipefail` preserves the same unconditional nonzero-exit-fails-the-step behavior as the bare command it replaces — proven by inspection since the underlying compiler invocation and its exit-code propagation are untouched, only output capture was added around it.
- Job names and the 10 required status contexts (`smoke-test`, `code-quality`, `startup-import-smoke`, `Unit & Integration Tests`, `No open blocks-merge issues reference this PR`, `No commit trailers`, `verify-generated-types`, `migration-matrix`, `verify-precommit-config`, `api-wiring`) are produced by job/workflow names, none of which this PR touches. Diffed job and step names for `frontend-test.yml` between `origin/Dev_new_gui` and this branch programmatically: identical on both counts.
- No `continue-on-error`, `|| true`, or similar was added to either gating step.

## Model Used

Claude Opus 5 (1M context)
