### PR TITLE
fix(chat-workflow): shrink tool_handler.py under its file-size ceiling (#14495)

### DIFF
--- a/autobot-backend/chat_workflow/tool_dispatch_guards.py
+++ b/autobot-backend/chat_workflow/tool_dispatch_guards.py
@@ -200,9 +200,7 @@ async def enforce_pre_action_verifier(
             f"(prob={result.refutation_probability:.2f}): {result.rationale}"
         )
         logger.warning("[#14031] verifier hard-blocked tool '%s' — %s", tool_name, result.rationale[:120])
-        execution_results.append(
-            {"tool": tool_name, "status": "error", "error": error, "verifier_hard_block": True}
-        )
+        execution_results.append({"tool": tool_name, "status": "error", "error": error, "verifier_hard_block": True})
         return WorkflowMessage(
             type="error",
             content=error,

--- a/autobot-backend/chat_workflow/tool_dispatch_guards.py
+++ b/autobot-backend/chat_workflow/tool_dispatch_guards.py
@@ -1,0 +1,338 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Enforcement gates run at the ``_dispatch_tool_call`` production seam.
+
+Extracted from ``chat_workflow.tool_handler`` (#14495) to keep that module
+under its file-size ceiling. Every function here is a pure seam guard —
+none touch ``self`` in their original form, so this module carries no state
+of its own; ``ToolHandlerMixin`` keeps thin delegating methods (same names,
+minus the leading underscore here) so the ``_dispatch_tool_call`` call sites
+and existing test monkey-patches (``mixin._enforce_forbidden_work = ...``)
+are unaffected. See ``tool_handler.py::_dispatch_tool_call`` for the calling
+order and the "return the message before the guarded call" contract each
+one honors.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from async_chat_workflow import WorkflowMessage
+from autobot_shared.logging_manager import get_logger
+from autobot_shared.tool_catalogue import SENSITIVE_TOOLS, match_tool_name
+
+if TYPE_CHECKING:
+    from .models import LLMIterationContext
+
+logger = get_logger(__name__)
+
+
+def enforce_forbidden_work(
+    tool_call: dict[str, Any],
+    ctx: "LLMIterationContext | None",
+    execution_results: list[dict[str, Any]],
+) -> WorkflowMessage | None:
+    """Hard-block a tool the acting agent's forbidden_work manifest forbids (GH#11145).
+
+    Resolves the acting agent id from ``ctx.agent_context`` and matches the tool
+    against that agent's manifest via the shared ``match_forbidden_tool`` matcher.
+    Records the failure in ``execution_results`` and returns an error
+    ``WorkflowMessage`` when the tool is forbidden, else ``None``.
+
+    An empty manifest here means exactly one thing (GH#13588): there is no agent
+    identity on the ctx, i.e. the plain ungoverned chat agent, or the id names a
+    declared executor. An id the registry does not recognise resolves to the
+    default boundary rather than to nothing, so a typo cannot buy free rein.
+    """
+    from orchestration.agent_registry import match_forbidden_tool, resolve_forbidden_tools
+
+    agent_id = ctx.agent_context.agent_id if (ctx is not None and ctx.agent_context is not None) else None
+    forbidden = resolve_forbidden_tools(agent_id)
+    if not forbidden:
+        return None
+    tool_name = tool_call.get("name", "")
+    matched = match_forbidden_tool(tool_name, forbidden)
+    if matched is None:
+        return None
+    error = f"Tool '{tool_name}' is forbidden by agent '{agent_id}' capability manifest (matched '{matched}')"
+    logger.warning(
+        "[GH#11145] Blocked forbidden tool '%s' for agent '%s' (matched '%s')",
+        tool_name,
+        agent_id,
+        matched,
+    )
+    execution_results.append({"tool": tool_name, "status": "error", "error": error, "forbidden_by_manifest": True})
+    return WorkflowMessage(
+        type="error",
+        content=error,
+        metadata={"tool": tool_name, "error": True, "forbidden_by_manifest": True},
+    )
+
+
+def enforce_config_protection(
+    tool_call: dict[str, Any],
+    execution_results: list[dict[str, Any]],
+) -> WorkflowMessage | None:
+    """Block a write that would weaken a linter/formatter config (GH#11177).
+
+    Reuses the dependency-free ``autobot_shared.config_guard`` matcher against
+    the tool's target path (``params`` for built-in tools, ``arguments`` for
+    MCP). Records the failure and returns an error ``WorkflowMessage`` when the
+    target is a protected config, else ``None``. ``AUTOBOT_ALLOW_CONFIG_EDITS``
+    opts out.
+    """
+    from autobot_shared.config_guard import config_edits_allowed, protected_config_for
+
+    if config_edits_allowed():
+        return None
+    args = tool_call.get("params") or tool_call.get("arguments") or {}
+    matched = protected_config_for(tool_call.get("name", ""), args)
+    if matched is None:
+        return None
+    tool_name = tool_call.get("name", "")
+    error = (
+        f"Editing linter/formatter config '{matched}' is blocked (config-protection): "
+        f"fix the code to satisfy the gate instead of weakening it. "
+        f"Set AUTOBOT_ALLOW_CONFIG_EDITS=1 for an intentional change."
+    )
+    logger.warning("[GH#11177] Blocked config-protection write to '%s' (tool '%s')", matched, tool_name)
+    execution_results.append({"tool": tool_name, "status": "error", "error": error, "config_protection": True})
+    return WorkflowMessage(
+        type="error",
+        content=error,
+        metadata={"tool": tool_name, "error": True, "config_protection": True},
+    )
+
+
+def enforce_fact_forcing(
+    tool_call: dict[str, Any],
+    ctx: "LLMIterationContext | None",
+    execution_results: list[dict[str, Any]],
+) -> WorkflowMessage | None:
+    """Block the first edit to an existing, uninvestigated file (GH#11178).
+
+    Records this call's read/grep target on the turn-scoped investigated set
+    (``ctx.context``), then blocks an edit to an existing file not yet read
+    this turn. New files are never blocked; the block self-clears once the
+    agent reads the file. Off unless ``AUTOBOT_FACT_FORCING`` is set, and a
+    no-op without a ``ctx`` to carry the per-turn state.
+    """
+    from autobot_shared.fact_forcing_guard import (
+        fact_forcing_env_enabled,
+        record_investigation,
+        uninvestigated_edit_path,
+    )
+
+    if not fact_forcing_env_enabled() or ctx is None:
+        return None
+    investigated: set[str] = ctx.context.setdefault("_fact_forcing_investigated", set())
+    name = tool_call.get("name", "")
+    args = tool_call.get("params") or tool_call.get("arguments") or {}
+    record_investigation(name, args, investigated)
+    path = uninvestigated_edit_path(name, args, investigated)
+    if path is None:
+        return None
+    error = (
+        f"Editing '{path}' is blocked (fact-forcing): read the file and its "
+        f"importers/call-sites first so the change is grounded, then retry."
+    )
+    logger.warning("[GH#11178] Blocked fact-forcing edit to '%s' (tool '%s')", path, name)
+    execution_results.append({"tool": name, "status": "error", "error": error, "fact_forcing": True})
+    return WorkflowMessage(
+        type="error",
+        content=error,
+        metadata={"tool": name, "error": True, "fact_forcing": True},
+    )
+
+
+async def enforce_pre_action_verifier(
+    tool_call: dict[str, Any],
+    ctx: "LLMIterationContext | None",
+    execution_results: list[dict[str, Any]],
+) -> WorkflowMessage | None:
+    """Run the adversarial pre-action verifier on a sensitive tool call (#14031).
+
+    ``PreActionVerifier`` (#10547) existed only inside the dormant ``AgentLoop``
+    (no production caller — #13587/#14031); this is its first production
+    caller. Scope matches the original: only tools in the canonical
+    ``SENSITIVE_TOOLS`` set are verified, the same set ``AgentLoop._sensitive_tool_name``
+    gated on. Gated on ``pre_action_verifier_enabled``, resolved through the
+    guard profile (defaults ``True`` — ``agent_loop/types.py:266``).
+
+    A BLOCK verdict with ``VERIFIER_HARD_BLOCK=1`` hard-blocks the call,
+    preserving the original semantics exactly. Without hard-block, the call
+    is held pending approval with the verifier's rationale attached — the
+    same ``pending_approval`` shape ``enforce_work_item_approval`` already
+    uses at this seam. A broken or unavailable verifier fails open
+    (SKIP/PASS via ``PreActionVerifier.verify``) and never blocks the loop.
+    """
+    from autobot_shared.pre_action_verifier_guard import (
+        HARD_BLOCK,
+        PreActionVerifier,
+        VerifierVerdict,
+        pre_action_verifier_enabled,
+    )
+
+    tool_name = tool_call.get("name", "")
+    if match_tool_name(tool_name, SENSITIVE_TOOLS) is None:
+        return None
+    if not pre_action_verifier_enabled():
+        return None
+
+    args = tool_call.get("params") or tool_call.get("arguments") or {}
+    if not isinstance(args, dict):
+        args = {"value": repr(args)}
+    reason = tool_call.get("reason", "")
+    # `session_id` is only used as an opaque trajectory/log identifier here —
+    # optional like `requires_approval_before` above, so a ctx double missing
+    # it (as several existing seam tests use) must not crash the guard.
+    task_id = getattr(ctx, "session_id", None) if ctx is not None else None
+
+    result = await PreActionVerifier().verify(tool_name, args, reason, task_id=task_id)
+    if result.verdict != VerifierVerdict.BLOCK:
+        return None
+
+    if HARD_BLOCK:
+        error = (
+            f"Tool '{tool_name}' was hard-blocked by the adversarial verifier "
+            f"(prob={result.refutation_probability:.2f}): {result.rationale}"
+        )
+        logger.warning("[#14031] verifier hard-blocked tool '%s' — %s", tool_name, result.rationale[:120])
+        execution_results.append(
+            {"tool": tool_name, "status": "error", "error": error, "verifier_hard_block": True}
+        )
+        return WorkflowMessage(
+            type="error",
+            content=error,
+            metadata={"tool": tool_name, "error": True, "verifier_hard_block": True},
+        )
+
+    msg = (
+        f"Action '{tool_name}' requires approval before proceeding — the adversarial "
+        f"verifier flagged it (prob={result.refutation_probability:.2f}): {result.rationale}"
+    )
+    logger.warning("[#14031] verifier held tool '%s' pending approval — %s", tool_name, result.rationale[:120])
+    execution_results.append(
+        {
+            "tool": tool_name,
+            "status": "pending_approval",
+            "reason": msg,
+            "verifier_rationale": result.rationale,
+            "verifier_refutation_probability": result.refutation_probability,
+        }
+    )
+    return WorkflowMessage(
+        type="approval_required",
+        content=msg,
+        metadata={
+            "tool": tool_name,
+            "approval_required": True,
+            "verifier_rationale": result.rationale,
+        },
+    )
+
+
+def enforce_repetition(
+    tool_call: dict[str, Any],
+    ctx: "LLMIterationContext | None",
+    execution_results: list[dict[str, Any]],
+) -> WorkflowMessage | None:
+    """Halt a looping or stagnating agent at the live seam (#13590).
+
+    The guard existed in ``agent_loop/`` and ran nowhere; the live path had
+    only a prompt sentence and a counter for *malformed* calls. Counting is
+    keyed on ``(call fingerprint, result hash)``, so a polling loop whose
+    result moves is never halted — only a call reproducing a result it
+    already has.
+
+    State lives on ``ctx.context``, which is per-turn and per-session; the
+    seam is concurrent across sessions, so nothing here may be module-global.
+    A missing ``ctx`` is a no-op, matching the other enforcers.
+    """
+    from autobot_shared.repetition_guard import (  # noqa: PLC0415
+        REPETITION_STATE_KEY,
+        STAGNATION_STATE_KEY,
+        repetition_halt_reason,
+        stagnation_halt_reason,
+    )
+
+    if ctx is None:
+        return None
+
+    rep_state = ctx.context.setdefault(REPETITION_STATE_KEY, {})
+    reason = repetition_halt_reason(tool_call, execution_results, rep_state)
+    halt_kind = "repetition_halt"
+
+    if reason is None:
+        # Repetition catches one call re-issued; stagnation catches a run of
+        # different calls whose results say nothing new. Distinct reasons,
+        # because "you are repeating a call" and "you are learning nothing"
+        # ask the agent for different corrections.
+        stag_state = ctx.context.setdefault(STAGNATION_STATE_KEY, {})
+        reason = stagnation_halt_reason(execution_results, stag_state)
+        halt_kind = "stagnation_halt"
+
+    if reason is None:
+        return None
+
+    name = tool_call.get("name", "")
+    execution_results.append({"tool": name, "status": "error", "error": reason, halt_kind: True})
+    return WorkflowMessage(
+        type="error",
+        content=reason,
+        metadata={"tool": name, "error": True, halt_kind: True},
+    )
+
+
+def enforce_work_item_approval(
+    tool_call: dict[str, Any],
+    ctx: "LLMIterationContext | None",
+    execution_results: list[dict[str, Any]],
+) -> WorkflowMessage | None:
+    """Hold a tool the work item declared as approval-gated (GH#11160).
+
+    When the run carries a work item whose ``requires_approval_before`` names
+    the action category of this tool, the action is held pending approval — the
+    declared gate is honored at the production seam. No work item / no matching
+    category → ``None``. Categories are resolved onto the context upstream, so
+    this needs no DB round-trip.
+    """
+    # Deferred import (mirrors chat_workflow/graph.py's own use of this
+    # symbol): tool_handler imports this module at load time, so importing
+    # `_approval_category_for` from tool_handler back at module scope here
+    # would be circular. By call time both modules are fully loaded.
+    from chat_workflow.tool_handler import _approval_category_for
+
+    if ctx is None or not getattr(ctx, "requires_approval_before", None):
+        return None
+    tool_name = tool_call.get("name", "")
+    category = _approval_category_for(tool_name, ctx.requires_approval_before)
+    if category is None:
+        return None
+    work_item_id = getattr(ctx, "work_item_id", None)
+    msg = (
+        f"Action '{tool_name}' requires approval before proceeding — the work item "
+        f"declares '{category}' as approval-gated (requires_approval_before)."
+    )
+    logger.warning("[GH#11160] Held tool '%s' pending approval — declared category '%s'", tool_name, category)
+    execution_results.append(
+        {
+            "tool": tool_name,
+            "status": "pending_approval",
+            "reason": msg,
+            "approval_category": category,
+            "work_item_id": work_item_id,
+        }
+    )
+    return WorkflowMessage(
+        type="approval_required",
+        content=msg,
+        metadata={
+            "tool": tool_name,
+            "approval_required": True,
+            "category": category,
+            "work_item_id": work_item_id,
+        },
+    )

--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -22,9 +22,17 @@ from typing import TYPE_CHECKING, Any, AsyncIterator
 from async_chat_workflow import WorkflowMessage
 from autobot_shared.env_utils import env_flag, env_int
 from autobot_shared.logging_manager import get_logger
-from autobot_shared.tool_catalogue import APPROVAL_CATEGORY_TOOLS, SENSITIVE_TOOLS, match_tool_name
+from autobot_shared.tool_catalogue import APPROVAL_CATEGORY_TOOLS, match_tool_name
 from chat_workflow.code_exec.tool_policy import CODEEXEC_READONLY_TOOLS
 from chat_workflow.tool_call_grammar import TOOL_CALL_PATTERN
+from chat_workflow.tool_dispatch_guards import (
+    enforce_config_protection,
+    enforce_fact_forcing,
+    enforce_forbidden_work,
+    enforce_pre_action_verifier,
+    enforce_repetition,
+    enforce_work_item_approval,
+)
 from llc.agent_tools import LLC_TOOL_NAMES, LLC_TOOL_SCHEMAS, LLCToolError, dispatch_llc_tool
 from tools.code_interpreter import CODE_INTERPRETER_SCHEMA
 from utils.errors import RepairableException
@@ -3255,6 +3263,12 @@ class ToolHandlerMixin:
             metadata={"message_type": "unknown_tool", "tool_name": tool_name},
         )
 
+    # #14495: the six seam enforcers below moved to tool_dispatch_guards.py to
+    # bring this file under its file-size ceiling (see that module's docstring
+    # for the extraction rationale — none of them touched `self`). These stay
+    # as thin delegating methods, not a straight `= module.func` rebind, so
+    # existing test monkey-patches (`mixin._enforce_forbidden_work = ...`) and
+    # the `_dispatch_tool_call` call sites are unaffected.
     def _enforce_forbidden_work(
         self,
         tool_call: dict[str, Any],
@@ -3263,39 +3277,9 @@ class ToolHandlerMixin:
     ) -> WorkflowMessage | None:
         """Hard-block a tool the acting agent's forbidden_work manifest forbids (GH#11145).
 
-        Resolves the acting agent id from ``ctx.agent_context`` and matches the tool
-        against that agent's manifest via the shared ``match_forbidden_tool`` matcher.
-        Records the failure in ``execution_results`` and returns an error
-        ``WorkflowMessage`` when the tool is forbidden, else ``None``.
-
-        An empty manifest here means exactly one thing (GH#13588): there is no agent
-        identity on the ctx, i.e. the plain ungoverned chat agent, or the id names a
-        declared executor. An id the registry does not recognise resolves to the
-        default boundary rather than to nothing, so a typo cannot buy free rein.
+        See ``tool_dispatch_guards.enforce_forbidden_work`` for the full behavior.
         """
-        from orchestration.agent_registry import match_forbidden_tool, resolve_forbidden_tools
-
-        agent_id = ctx.agent_context.agent_id if (ctx is not None and ctx.agent_context is not None) else None
-        forbidden = resolve_forbidden_tools(agent_id)
-        if not forbidden:
-            return None
-        tool_name = tool_call.get("name", "")
-        matched = match_forbidden_tool(tool_name, forbidden)
-        if matched is None:
-            return None
-        error = f"Tool '{tool_name}' is forbidden by agent '{agent_id}' capability manifest (matched '{matched}')"
-        logger.warning(
-            "[GH#11145] Blocked forbidden tool '%s' for agent '%s' (matched '%s')",
-            tool_name,
-            agent_id,
-            matched,
-        )
-        execution_results.append({"tool": tool_name, "status": "error", "error": error, "forbidden_by_manifest": True})
-        return WorkflowMessage(
-            type="error",
-            content=error,
-            metadata={"tool": tool_name, "error": True, "forbidden_by_manifest": True},
-        )
+        return enforce_forbidden_work(tool_call, ctx, execution_results)
 
     def _enforce_config_protection(
         self,
@@ -3304,33 +3288,9 @@ class ToolHandlerMixin:
     ) -> WorkflowMessage | None:
         """Block a write that would weaken a linter/formatter config (GH#11177).
 
-        Reuses the dependency-free ``autobot_shared.config_guard`` matcher against
-        the tool's target path (``params`` for built-in tools, ``arguments`` for
-        MCP). Records the failure and returns an error ``WorkflowMessage`` when the
-        target is a protected config, else ``None``. ``AUTOBOT_ALLOW_CONFIG_EDITS``
-        opts out.
+        See ``tool_dispatch_guards.enforce_config_protection`` for the full behavior.
         """
-        from autobot_shared.config_guard import config_edits_allowed, protected_config_for
-
-        if config_edits_allowed():
-            return None
-        args = tool_call.get("params") or tool_call.get("arguments") or {}
-        matched = protected_config_for(tool_call.get("name", ""), args)
-        if matched is None:
-            return None
-        tool_name = tool_call.get("name", "")
-        error = (
-            f"Editing linter/formatter config '{matched}' is blocked (config-protection): "
-            f"fix the code to satisfy the gate instead of weakening it. "
-            f"Set AUTOBOT_ALLOW_CONFIG_EDITS=1 for an intentional change."
-        )
-        logger.warning("[GH#11177] Blocked config-protection write to '%s' (tool '%s')", matched, tool_name)
-        execution_results.append({"tool": tool_name, "status": "error", "error": error, "config_protection": True})
-        return WorkflowMessage(
-            type="error",
-            content=error,
-            metadata={"tool": tool_name, "error": True, "config_protection": True},
-        )
+        return enforce_config_protection(tool_call, execution_results)
 
     def _enforce_fact_forcing(
         self,
@@ -3340,38 +3300,9 @@ class ToolHandlerMixin:
     ) -> WorkflowMessage | None:
         """Block the first edit to an existing, uninvestigated file (GH#11178).
 
-        Records this call's read/grep target on the turn-scoped investigated set
-        (``ctx.context``), then blocks an edit to an existing file not yet read
-        this turn. New files are never blocked; the block self-clears once the
-        agent reads the file. Off unless ``AUTOBOT_FACT_FORCING`` is set, and a
-        no-op without a ``ctx`` to carry the per-turn state.
+        See ``tool_dispatch_guards.enforce_fact_forcing`` for the full behavior.
         """
-        from autobot_shared.fact_forcing_guard import (
-            fact_forcing_env_enabled,
-            record_investigation,
-            uninvestigated_edit_path,
-        )
-
-        if not fact_forcing_env_enabled() or ctx is None:
-            return None
-        investigated: set[str] = ctx.context.setdefault("_fact_forcing_investigated", set())
-        name = tool_call.get("name", "")
-        args = tool_call.get("params") or tool_call.get("arguments") or {}
-        record_investigation(name, args, investigated)
-        path = uninvestigated_edit_path(name, args, investigated)
-        if path is None:
-            return None
-        error = (
-            f"Editing '{path}' is blocked (fact-forcing): read the file and its "
-            f"importers/call-sites first so the change is grounded, then retry."
-        )
-        logger.warning("[GH#11178] Blocked fact-forcing edit to '%s' (tool '%s')", path, name)
-        execution_results.append({"tool": name, "status": "error", "error": error, "fact_forcing": True})
-        return WorkflowMessage(
-            type="error",
-            content=error,
-            metadata={"tool": name, "error": True, "fact_forcing": True},
-        )
+        return enforce_fact_forcing(tool_call, ctx, execution_results)
 
     async def _enforce_pre_action_verifier(
         self,
@@ -3381,84 +3312,9 @@ class ToolHandlerMixin:
     ) -> WorkflowMessage | None:
         """Run the adversarial pre-action verifier on a sensitive tool call (#14031).
 
-        ``PreActionVerifier`` (#10547) existed only inside the dormant ``AgentLoop``
-        (no production caller — #13587/#14031); this is its first production
-        caller. Scope matches the original: only tools in the canonical
-        ``SENSITIVE_TOOLS`` set are verified, the same set ``AgentLoop._sensitive_tool_name``
-        gated on. Gated on ``pre_action_verifier_enabled``, resolved through the
-        guard profile (defaults ``True`` — ``agent_loop/types.py:266``).
-
-        A BLOCK verdict with ``VERIFIER_HARD_BLOCK=1`` hard-blocks the call,
-        preserving the original semantics exactly. Without hard-block, the call
-        is held pending approval with the verifier's rationale attached — the
-        same ``pending_approval`` shape ``_enforce_work_item_approval`` already
-        uses at this seam. A broken or unavailable verifier fails open
-        (SKIP/PASS via ``PreActionVerifier.verify``) and never blocks the loop.
+        See ``tool_dispatch_guards.enforce_pre_action_verifier`` for the full behavior.
         """
-        from autobot_shared.pre_action_verifier_guard import (
-            HARD_BLOCK,
-            PreActionVerifier,
-            VerifierVerdict,
-            pre_action_verifier_enabled,
-        )
-
-        tool_name = tool_call.get("name", "")
-        if match_tool_name(tool_name, SENSITIVE_TOOLS) is None:
-            return None
-        if not pre_action_verifier_enabled():
-            return None
-
-        args = tool_call.get("params") or tool_call.get("arguments") or {}
-        if not isinstance(args, dict):
-            args = {"value": repr(args)}
-        reason = tool_call.get("reason", "")
-        # `session_id` is only used as an opaque trajectory/log identifier here —
-        # optional like `requires_approval_before` above, so a ctx double missing
-        # it (as several existing seam tests use) must not crash the guard.
-        task_id = getattr(ctx, "session_id", None) if ctx is not None else None
-
-        result = await PreActionVerifier().verify(tool_name, args, reason, task_id=task_id)
-        if result.verdict != VerifierVerdict.BLOCK:
-            return None
-
-        if HARD_BLOCK:
-            error = (
-                f"Tool '{tool_name}' was hard-blocked by the adversarial verifier "
-                f"(prob={result.refutation_probability:.2f}): {result.rationale}"
-            )
-            logger.warning("[#14031] verifier hard-blocked tool '%s' — %s", tool_name, result.rationale[:120])
-            execution_results.append(
-                {"tool": tool_name, "status": "error", "error": error, "verifier_hard_block": True}
-            )
-            return WorkflowMessage(
-                type="error",
-                content=error,
-                metadata={"tool": tool_name, "error": True, "verifier_hard_block": True},
-            )
-
-        msg = (
-            f"Action '{tool_name}' requires approval before proceeding — the adversarial "
-            f"verifier flagged it (prob={result.refutation_probability:.2f}): {result.rationale}"
-        )
-        logger.warning("[#14031] verifier held tool '%s' pending approval — %s", tool_name, result.rationale[:120])
-        execution_results.append(
-            {
-                "tool": tool_name,
-                "status": "pending_approval",
-                "reason": msg,
-                "verifier_rationale": result.rationale,
-                "verifier_refutation_probability": result.refutation_probability,
-            }
-        )
-        return WorkflowMessage(
-            type="approval_required",
-            content=msg,
-            metadata={
-                "tool": tool_name,
-                "approval_required": True,
-                "verifier_rationale": result.rationale,
-            },
-        )
+        return await enforce_pre_action_verifier(tool_call, ctx, execution_results)
 
     def _enforce_repetition(
         self,
@@ -3468,49 +3324,9 @@ class ToolHandlerMixin:
     ) -> WorkflowMessage | None:
         """Halt a looping or stagnating agent at the live seam (#13590).
 
-        The guard existed in ``agent_loop/`` and ran nowhere; the live path had
-        only a prompt sentence and a counter for *malformed* calls. Counting is
-        keyed on ``(call fingerprint, result hash)``, so a polling loop whose
-        result moves is never halted — only a call reproducing a result it
-        already has.
-
-        State lives on ``ctx.context``, which is per-turn and per-session; the
-        seam is concurrent across sessions, so nothing here may be module-global.
-        A missing ``ctx`` is a no-op, matching the other enforcers.
+        See ``tool_dispatch_guards.enforce_repetition`` for the full behavior.
         """
-        from autobot_shared.repetition_guard import (  # noqa: PLC0415
-            REPETITION_STATE_KEY,
-            STAGNATION_STATE_KEY,
-            repetition_halt_reason,
-            stagnation_halt_reason,
-        )
-
-        if ctx is None:
-            return None
-
-        rep_state = ctx.context.setdefault(REPETITION_STATE_KEY, {})
-        reason = repetition_halt_reason(tool_call, execution_results, rep_state)
-        halt_kind = "repetition_halt"
-
-        if reason is None:
-            # Repetition catches one call re-issued; stagnation catches a run of
-            # different calls whose results say nothing new. Distinct reasons,
-            # because "you are repeating a call" and "you are learning nothing"
-            # ask the agent for different corrections.
-            stag_state = ctx.context.setdefault(STAGNATION_STATE_KEY, {})
-            reason = stagnation_halt_reason(execution_results, stag_state)
-            halt_kind = "stagnation_halt"
-
-        if reason is None:
-            return None
-
-        name = tool_call.get("name", "")
-        execution_results.append({"tool": name, "status": "error", "error": reason, halt_kind: True})
-        return WorkflowMessage(
-            type="error",
-            content=reason,
-            metadata={"tool": name, "error": True, halt_kind: True},
-        )
+        return enforce_repetition(tool_call, ctx, execution_results)
 
     def _enforce_work_item_approval(
         self,
@@ -3520,43 +3336,9 @@ class ToolHandlerMixin:
     ) -> WorkflowMessage | None:
         """Hold a tool the work item declared as approval-gated (GH#11160).
 
-        When the run carries a work item whose ``requires_approval_before`` names
-        the action category of this tool, the action is held pending approval — the
-        declared gate is honored at the production seam. No work item / no matching
-        category → ``None``. Categories are resolved onto the context upstream, so
-        this needs no DB round-trip.
+        See ``tool_dispatch_guards.enforce_work_item_approval`` for the full behavior.
         """
-        if ctx is None or not getattr(ctx, "requires_approval_before", None):
-            return None
-        tool_name = tool_call.get("name", "")
-        category = _approval_category_for(tool_name, ctx.requires_approval_before)
-        if category is None:
-            return None
-        work_item_id = getattr(ctx, "work_item_id", None)
-        msg = (
-            f"Action '{tool_name}' requires approval before proceeding — the work item "
-            f"declares '{category}' as approval-gated (requires_approval_before)."
-        )
-        logger.warning("[GH#11160] Held tool '%s' pending approval — declared category '%s'", tool_name, category)
-        execution_results.append(
-            {
-                "tool": tool_name,
-                "status": "pending_approval",
-                "reason": msg,
-                "approval_category": category,
-                "work_item_id": work_item_id,
-            }
-        )
-        return WorkflowMessage(
-            type="approval_required",
-            content=msg,
-            metadata={
-                "tool": tool_name,
-                "approval_required": True,
-                "category": category,
-                "work_item_id": work_item_id,
-            },
-        )
+        return enforce_work_item_approval(tool_call, ctx, execution_results)
 
     async def _dispatch_tool_call(
         self,

--- a/scripts/check_python_file_size.py
+++ b/scripts/check_python_file_size.py
@@ -60,7 +60,7 @@ SELF_REL = "scripts/check_python_file_size.py"
 KNOWN_LARGE: dict[str, int] = {
     "autobot-backend/orchestrator.py": 1114,
     "autobot-backend/chat_workflow/manager.py": 4068,
-    "autobot-backend/chat_workflow/tool_handler.py": 4063,
+    "autobot-backend/chat_workflow/tool_handler.py": 3863,
 }
 
 


### PR DESCRIPTION
Closes #14495

**This unblocks every open PR.** `Dev_new_gui` is currently red on the
`code-quality` required check because `autobot-backend/chat_workflow/tool_handler.py`
(4081 lines) exceeded its `KNOWN_LARGE` ceiling of 4063 in
`scripts/check_python_file_size.py`. Since Actions checks out the PR *merge*
commit, every open PR against `Dev_new_gui` inherits this failure regardless
of what it touches, until this lands.

## Thinking Path

The squash-merge of #14470 (closing #14420) grew `tool_handler.py` past its
ceiling without lowering it. The ratchet in `check_python_file_size.py` only
ever shrinks — raising `4063` is exactly what it exists to refuse — so the fix
has to shrink the file.

A security review of this file had already flagged three oversized functions
(`_dispatch_tool_call` ~152 lines, `_handle_browser_tool` ~105 lines,
`_process_single_command` ~84 lines) as extraction candidates. Rather than
picking one to shave lines off arbitrarily, I looked for a **cohesive** unit
inside the biggest of the three, `_dispatch_tool_call`: it opens with six
sequential seam-enforcer calls (`_enforce_forbidden_work`,
`_enforce_config_protection`, `_enforce_fact_forcing`,
`_enforce_pre_action_verifier`, `_enforce_repetition`,
`_enforce_work_item_approval`) — each records a block/hold in
`execution_results` and returns a `WorkflowMessage`, or `None` to fall
through. None of the six touch `self` in their current form, which makes
them a clean, self-contained "dispatch guard" concern with zero coupling to
the rest of the mixin.

I moved all six, verbatim apart from mechanical changes, into a new module
`chat_workflow/tool_dispatch_guards.py` as plain functions, and left
`ToolHandlerMixin` with six thin delegating methods of the same name so
every existing call site and every existing test that calls or monkey-patches
`mixin._enforce_forbidden_work(...)` etc. keeps working unchanged.

## What Changed

- **New:** `autobot-backend/chat_workflow/tool_dispatch_guards.py` (338 lines)
  — `enforce_forbidden_work`, `enforce_config_protection`,
  `enforce_fact_forcing`, `enforce_pre_action_verifier`, `enforce_repetition`,
  `enforce_work_item_approval`, moved out of `tool_handler.py`.
- **`autobot-backend/chat_workflow/tool_handler.py`:** the six `_enforce_*`
  methods are now one-line delegates to the module above; unused
  `SENSITIVE_TOOLS` import dropped (its only use moved with
  `enforce_pre_action_verifier`). **4081 → 3863 lines** (218-line margin under
  the old ceiling, and the new one).
- **`scripts/check_python_file_size.py`:** `KNOWN_LARGE` for
  `tool_handler.py` lowered **4063 → 3863** — the ratchet only ever shrinks,
  and this tightens it to the size just achieved, not just far enough to pass.

Nothing was deleted as dead code — every line that left `tool_handler.py`
landed in `tool_dispatch_guards.py`; see the byte-diff evidence below.

One symbol needed a deferred import that didn't exist before:
`enforce_work_item_approval` calls `_approval_category_for`, which stays in
`tool_handler.py` (it's also imported there by `chat_workflow/graph.py` and
`tests/unit/chat_workflow/test_governed_execution.py`, so moving it would
widen the blast radius for no size benefit). `tool_dispatch_guards.py`
imports it back with a deferred, function-body import — the same pattern
`graph.py` already uses for this exact symbol — to avoid a load-time circular
import between the two modules.

## Verification

**Faithful-move evidence (diff-based, not asserted).** I extracted the
original six function bodies from `origin/Dev_new_gui`, mechanically dedented
them one level and stripped the `self,` parameter (the same transform Python
requires to turn a method into a module function), and diffed against the
new module. After normalizing the only three cosmetic differences PEP8/the
move require — the `ctx: "X" | None` → `ctx: "X | None"` quoting style,
blank-line count between top-level functions vs. methods, and the one
`_enforce_x` → `enforce_x` cross-reference inside a docstring — the diff is
empty except for the one legitimately new deferred import
(`enforce_work_item_approval`'s `from chat_workflow.tool_handler import
_approval_category_for`, documented above and in a comment at the call site).
That import is the only non-mechanical line added across all six functions.

```
$ diff -B orig_enforcers_normalized.txt new_module_normalized.txt
IDENTICAL modulo blank-lines and the one documented deferred import
```

**Deny-before-call ordering — unaffected on all three RBAC surfaces.** This
PR does not touch `_process_single_command`, `_handle_browser_tool`, or
`_handle_web_search_tool` at all (grep confirms zero diff lines in those
functions). It also does not touch `_dispatch_tool_call` itself — only the
six methods it calls. Every one of the five `if <enforcer>_msg is not None:
yield <msg>; return` guards in `_dispatch_tool_call` still runs, unchanged,
*before* the tool-specific branches (`compose`, `respond`, `delegate`, LLC
tools, and the uniform-builtin route that reaches
`_process_single_command`/`_handle_browser_tool`/`_handle_web_search_tool`).
The `should_execute` / `_emit_before_tool_execute` guard-before-call pattern
inside those three functions (lines ~2093, ~2435/2461ish, ~2668) is
byte-for-byte what it was in `origin/Dev_new_gui` — confirmed by `git diff`
showing no hunks in that range.

**File size / ratchet:**
```
$ wc -l autobot-backend/chat_workflow/tool_handler.py
3863 autobot-backend/chat_workflow/tool_handler.py
```
`KNOWN_LARGE["autobot-backend/chat_workflow/tool_handler.py"]` lowered to
`3863`, matching exactly — `check_python_file_size.py`'s
`_grandfathered_verdict` passes a file that sits *at* its ceiling, and
`repo_tests/python_file_size_ratchet_test.py::test_a_shrunk_file_must_lower_its_ceiling`
requires exactly this.

**Syntax:** `ast.parse()` over the resulting `tool_handler.py` succeeds (no
codebase code executed — pure static parse, same technique the ratchet test
itself is not required to but the repo's own tooling relies on for `git
ls-files` + AST checks elsewhere).

**Test-compatibility check (static, not executed — per policy, I do not run
code from this codebase):** grepped every test file that calls or
monkey-patches these six methods
(`test_tool_handler_forbidden_work.py`, `test_tool_handler_config_protection.py`,
`test_tool_handler_fact_forcing.py`, `test_tool_handler_pre_action_verifier.py`,
`test_tool_handler_repetition_guard.py`, `test_governed_execution.py`,
`session_role_test.py`, plus four files that stub these via
`mixin._enforce_x = lambda *a, **k: None`). All of them call through
`mixin._enforce_x(...)`, which still resolves to the same-named method on
`ToolHandlerMixin` — now a delegate, but same signature, same return value.
None of them `patch()` an import path inside `chat_workflow.tool_handler`
for the enforcers' own dependencies (`orchestration.agent_registry`,
`autobot_shared.config_guard`, `autobot_shared.fact_forcing_guard`,
`autobot_shared.pre_action_verifier_guard`, `autobot_shared.repetition_guard`)
— every patch in those tests targets the origin module directly (e.g.
`patch("autobot_shared.pre_action_verifier_guard.PreActionVerifier.verify")`),
which resolves identically whether the deferred import executes inside
`tool_handler.py` or `tool_dispatch_guards.py`.

**Conflict check against PR #14492 (in flight, same file, closes #14469 /
threads RBAC through `_process_single_command`, `_handle_browser_tool`,
`_handle_web_search_tool`):** ran a real local 3-way merge of this branch
with `origin/issue-14469` in a scratch worktree (not #14492's own branch —
read-only against the remote ref, discarded after). Result: **clean,
zero-conflict automatic merge** — `git merge --no-commit --no-ff
origin/issue-14469` reported "Automatic merge went well". The two PRs edit
disjoint regions of the file (this PR: the six `_enforce_*` bodies + one
import block; #14492: `_process_single_command`, `_handle_browser_tool`,
`_handle_web_search_tool`, `_builtin_route`, `_dispatch_execute_command`, and
a *different* two-line addition to the same import block). Merged result
parses clean at 3922 lines (3863 + #14492's own net +59).

**Sequencing note for #14492 (not a blocker, but worth doing in order):**
#14492 cannot merge before this PR regardless of order chosen, because the
base is *already* red for every open PR including #14492 — that's the bug
this PR fixes. Once this PR merges, #14492 will need to rebase onto the new
tip; at 3863 (this PR's ceiling) + #14492's own net +59 lines = ~3922, its
rebased branch will re-trip `audit-ceilings` (3922 > 3863) purely from its
own diff — the ratchet is working as designed: any PR that grows a
grandfathered file has to account for it. The fix for #14492 is a one-line
addition to their own diff: set `KNOWN_LARGE["autobot-backend/chat_workflow/
tool_handler.py"]` to their post-rebase actual line count once rebased (e.g.
~3922) — that is still comfortably *below* the frozen ratchet baseline of
4063 in `repo_tests/python_file_size_ratchet_test.py::RATCHET_BASELINE`, so
`test_no_ceiling_may_be_raised` does not object; only
`test_recorded_ceilings_match_the_files_today` requires it (ceiling must
equal the file's actual measured size, exactly, at all times). **Recommended
order: merge this PR first, then rebase #14492 and have it adjust the
ceiling to its own new count as part of that rebase.**

## Model Used

Claude Opus 5 (1M context)
