### PR TITLE
fix(ci): guard cancel-in-progress on pull_request in 16 workflows (#14450)

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -9,7 +9,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   lint:

--- a/.github/workflows/api-wiring.yml
+++ b/.github/workflows/api-wiring.yml
@@ -45,7 +45,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -32,7 +32,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 
 permissions:

--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -13,7 +13,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   smoke-test:

--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -52,7 +52,7 @@ on:
 # correct block — the tests genuinely have not run.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   NODE_VERSION: '22'

--- a/.github/workflows/hardened-smoke-test.yml
+++ b/.github/workflows/hardened-smoke-test.yml
@@ -33,7 +33,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   hardened-smoke-test:

--- a/.github/workflows/llc-contract.yml
+++ b/.github/workflows/llc-contract.yml
@@ -30,7 +30,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/migration-gate.yml
+++ b/.github/workflows/migration-gate.yml
@@ -40,7 +40,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/phase_validation.yml
+++ b/.github/workflows/phase_validation.yml
@@ -31,7 +31,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   phase-validation:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -37,7 +37,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   NODE_VERSION: '20'

--- a/.github/workflows/slm-frontend-check.yml
+++ b/.github/workflows/slm-frontend-check.yml
@@ -29,7 +29,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/slm-migration-gate.yml
+++ b/.github/workflows/slm-migration-gate.yml
@@ -32,7 +32,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/ssot-coverage.yml
+++ b/.github/workflows/ssot-coverage.yml
@@ -37,7 +37,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/startup-import-smoke.yml
+++ b/.github/workflows/startup-import-smoke.yml
@@ -32,7 +32,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/trajectory-eval.yml
+++ b/.github/workflows/trajectory-eval.yml
@@ -26,7 +26,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/verify-generated-types.yml
+++ b/.github/workflows/verify-generated-types.yml
@@ -50,7 +50,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/repo_tests/workflow_concurrency_guard_test.py
+++ b/repo_tests/workflow_concurrency_guard_test.py
@@ -108,48 +108,35 @@ def test_a_pull_request_workflow_cancels_superseded_runs(path):
 
 # Workflows that trigger on pull_request AND push, and cancel unconditionally, so
 # a merge to the base branch cancels the previous merge's verification (#13432).
-# Measured on Dev_new_gui at d68c09c88 while fixing #14434. This is a RATCHET: the
-# number may only ever go DOWN. Fixing one means deleting its line.
 #
-# SCOPED BY DESIGN, and the scope is narrower than the defect. Everything here
+# #14434 found and fixed twelve workflows with no concurrency group at all, and
+# along the way flagged sixteen more that DID have one but cancelled unconditionally
+# - a RATCHET (`UNGUARDED_BASE_BRANCH_CANCEL`) recorded all sixteen because they
+# could not all be fixed in one change. #14450 fixed the last of them: every one now
+# guards `cancel-in-progress` on `github.event_name == 'pull_request'`, so a
+# base-branch push run is never cancelled by the next one - PR-run superseding,
+# which is correct and saves the singleton runner, is unaffected. With zero
+# offenders left, the ratchet's allowlist has nothing left to name, so this is now
+# a permanent zero-tolerance guard instead: any workflow reintroducing the
+# unconditional idiom fails here immediately, rather than accumulating until the
+# next audit finds it.
+#
+# SCOPED BY DESIGN, and the scope is narrower than the defect. Everything below
 # filters through `_pull_request_workflows()` first, so a workflow with the same
 # collision shape but NO pull_request trigger is structurally invisible to this
-# ratchet - `coverage.yml` (push + schedule) is exactly that, and its own comment
+# guard - `coverage.yml` (push + schedule) is exactly that, and its own comment
 # claims the figure "tracks what actually landed" while two merges inside its ~35
 # minute window cancel each other. Stating the scope because a guard narrower than
-# its subject otherwise reads as coverage of the whole subject. Those cases are
-# recorded on #14450 rather than silently absent.
+# its subject otherwise reads as coverage of the whole subject. That case is
+# tracked on #14450 rather than silently absent.
 #
-# It is not a style nit. Seven of the ten required contexts are produced by
-# workflows on this list - api-wiring, code-quality, smoke-test (docker-smoke-test),
-# migration-gate, startup-import-smoke, verify-generated-types, and
-# "Unit & Integration Tests" (frontend-test) - so on a busy day the base branch is
-# verified by whichever merge happens not to be superseded. #13432 measured exactly
-# that for ci.yml: of 39 completed base runs, 26 were cancelled and NONE succeeded.
-# ci.yml was fixed; these were not. Tracked separately - see the issue referenced
-# from #14434.
-UNGUARDED_BASE_BRANCH_CANCEL = frozenset(
-    {
-        "actionlint.yml",
-        "api-wiring.yml",
-        "code-quality.yml",
-        "docker-smoke-test.yml",
-        "frontend-test.yml",
-        "hardened-smoke-test.yml",
-        "llc-contract.yml",
-        "migration-gate.yml",
-        "phase_validation.yml",
-        "security.yml",
-        "slm-frontend-check.yml",
-        "slm-migration-gate.yml",
-        "ssot-coverage.yml",
-        "startup-import-smoke.yml",
-        "trajectory-eval.yml",
-        "verify-generated-types.yml",
-    }
-)
-
-
+# It was not a style nit. Seven of the ten required contexts were produced by the
+# sixteen - api-wiring, code-quality, smoke-test (docker-smoke-test), migration-gate,
+# startup-import-smoke, verify-generated-types, and "Unit & Integration Tests"
+# (frontend-test) - so on a busy day the base branch was verified by whichever merge
+# happened not to be superseded. #13432 measured exactly that for ci.yml: of 39
+# completed base runs, 26 were cancelled and NONE succeeded. ci.yml was fixed first;
+# the sixteen followed under #14434 and #14450.
 def _cancels_base_branch_runs_unguarded(path: Path, doc: dict) -> bool:
     if "push" not in _triggers(doc):
         return False
@@ -157,11 +144,11 @@ def _cancels_base_branch_runs_unguarded(path: Path, doc: dict) -> bool:
 
 
 def test_base_branch_cancellation_does_not_spread():
-    """A ratchet, because the existing offenders cannot all be fixed in one change.
+    """Zero-tolerance: no pull_request workflow may cancel base-branch runs.
 
-    Each entry cancels base-branch verification. The set may shrink, never grow -
-    a new workflow copying the `cancel-in-progress: true` idiom from a neighbour is
-    exactly how this reached sixteen.
+    #14450 fixed the last of sixteen workflows that cancelled unconditionally.
+    A new offender - e.g. copying `cancel-in-progress: true` from a neighbour -
+    must fail here, not accumulate until the next audit finds it.
     """
     offenders = {
         path.name
@@ -169,16 +156,8 @@ def test_base_branch_cancellation_does_not_spread():
         if _cancels_base_branch_runs_unguarded(path, doc)
     }
 
-    new = offenders - UNGUARDED_BASE_BRANCH_CANCEL
-    assert not new, (
-        f"{sorted(new)} also trigger on push and cancel unconditionally, so a merge "
+    assert not offenders, (
+        f"{sorted(offenders)} trigger on push and cancel unconditionally, so a merge "
         "cancels the previous merge's verification (#13432). Guard cancel-in-progress "
         "on github.event_name == 'pull_request'."
-    )
-
-    fixed = UNGUARDED_BASE_BRANCH_CANCEL - offenders
-    assert not fixed, (
-        f"{sorted(fixed)} no longer cancel base-branch runs - delete them from "
-        "UNGUARDED_BASE_BRANCH_CANCEL so the ratchet keeps its grip. A list that "
-        "still names a fixed file exempts nothing while looking like it does."
     )


### PR DESCRIPTION
## Thinking Path

#14434 added `repo_tests/workflow_concurrency_guard_test.py`, and its `UNGUARDED_BASE_BRANCH_CANCEL` frozenset enumerated 16 pull_request-triggered workflows that also trigger on `push` and cancel their concurrency group unconditionally (`cancel-in-progress: true`). For a PR run that is correct — a new push should supersede a stale one. For a `push` to `Dev_new_gui` it means each merge cancels the *previous* merge's verification, and #13432/#14495 both measured that this makes the base branch effectively unverified: merges arrive faster than the suites finish, so the base ends up "verified" only by whichever merge happened not to be superseded.

Read the guard test first, per the task: `_triggers()` exists specifically because YAML 1.1 resolves a bare `on:` key to boolean `True`, so a naive `doc.get("on")` silently returns nothing and would make the predicate vacuous. `_cancels_base_branch_runs_unguarded()` is the exact predicate the ratchet enforces — checks `"push" in _triggers(doc)` and `concurrency.cancel-in-progress is True`.

Verified per-workflow, not assumed, for all 16: each triggers on `push` (to `Dev_new_gui` among other branches) via `_triggers()`, each has a `concurrency.group` keyed on `${{ github.workflow }}-${{ github.ref }}` (not already PR-scoped by any other mechanism — `github.ref` is shared across all pushes to the same branch), and each had the literal `cancel-in-progress: true`. No workflow needed to be reported-not-edited; all 16 matched the offending shape exactly.

## What Changed

One line changed per workflow, in all 16 files the ratchet named:
`actionlint.yml`, `api-wiring.yml`, `code-quality.yml`, `docker-smoke-test.yml`, `frontend-test.yml`, `hardened-smoke-test.yml`, `llc-contract.yml`, `migration-gate.yml`, `phase_validation.yml`, `security.yml`, `slm-frontend-check.yml`, `slm-migration-gate.yml`, `ssot-coverage.yml`, `startup-import-smoke.yml`, `trajectory-eval.yml`, `verify-generated-types.yml`.

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

PR-run cancellation (superseding a stale PR run) is unchanged and still saves the singleton self-hosted runner; only the unconditional base-branch cancellation is removed.

Scope note: four of the sixteen also carry a non-push/non-pull_request trigger — `docker-smoke-test.yml`, `hardened-smoke-test.yml`, and `security.yml` have `schedule`, and `phase_validation.yml` has `workflow_dispatch`. The same conditional means a scheduled or manually-dispatched run also stops cancelling its in-progress predecessor (it only cancels when `github.event_name == 'pull_request'`), so those runs now serialise instead of the newest one winning. This matches `ci.yml`'s existing precedent and is harmless — arguably more correct for a daily/manual run — but it is a behaviour change beyond the push/PR scope described above, named here so it isn't later read as unintended drift.

`repo_tests/workflow_concurrency_guard_test.py`: `UNGUARDED_BASE_BRANCH_CANCEL` had nothing left to name once all 16 were fixed, so — per #14450's acceptance criteria ("the ratchet is removed with it") — the allowlist frozenset is deleted rather than left empty-but-present, and `test_base_branch_cancellation_does_not_spread` becomes a permanent zero-tolerance assertion (`assert not offenders`) instead of a two-way ratchet diff. `_cancels_base_branch_runs_unguarded()` and `_triggers()` are untouched.

No job id, job `name:`, or workflow `name:` changed in any file — confirmed by diffing a full job/workflow name dump taken before and after the edit (see Verification).

## Verification

**Predicate counts** (imported the shipped `_cancels_base_branch_runs_unguarded()` / `_pull_request_workflows()` from `repo_tests/workflow_concurrency_guard_test.py` via `importlib`, not re-implemented, and pointed `WORKFLOW_DIR` at a `git archive HEAD` export for "before" and the edited worktree for "after"):

- Before: **16** offenders — `actionlint.yml, api-wiring.yml, code-quality.yml, docker-smoke-test.yml, frontend-test.yml, hardened-smoke-test.yml, llc-contract.yml, migration-gate.yml, phase_validation.yml, security.yml, slm-frontend-check.yml, slm-migration-gate.yml, ssot-coverage.yml, startup-import-smoke.yml, trajectory-eval.yml, verify-generated-types.yml` — exact match to the ratchet list.
- After: **0** offenders.
- Re-ran the same import against the final (post-ratchet-removal) test file: still 0.

**Job/workflow names unchanged:** dumped `doc.get("name")` for the workflow and `job.get("name")` for every job in all 16 files, before and after, via PyYAML `safe_load` — `diff` of the two dumps is empty (exit 0). Each file's `git diff` is a single-line change (`cancel-in-progress: true` → the conditional), confirmed individually.

**YAML validity:** all 16 edited files and the test file parse cleanly with `yaml.safe_load` / `py_compile`.

**Guard-scan sanity:** `_pull_request_workflows()` still finds 41 workflows (>= the test's own `>= 20` floor), and both `DELIBERATELY_EXEMPT` shim files (`frontend-required-context.yml`, `python-required-context.yml`) still exist and are untouched — they are not on the 16-file list and were not edited.

Not run: `pytest` itself (no venv/pip install per repo policy) and `actionlint`/`yamllint` (not installed, no ad-hoc install). Verification instead used the repo's own shipped predicate functions directly via `importlib`, plus manual PyYAML parse checks, per the task's "import/extract, don't re-implement" instruction.

## Model Used

Claude Sonnet 5

---

Closes #14450. Issue #14434 (the original 12-workflow fix and the guard test that produced this ratchet) is already closed; #13432 (the original `ci.yml` fix that established this pattern) is already closed.

