### PR TITLE
fix(lint): anchor .bandit exclude_dirs so bare names stop matching by substring (#14489)

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,19 +1,72 @@
 # Bandit security configuration for AutoBot
 # https://bandit.readthedocs.io/en/latest/config.html
 
+# Exclude directories from scanning.
+#
+# #14489 — HOW BANDIT READS THIS LIST, and why every genuinely-needed entry
+# below is wrapped in path separators. bandit's matcher
+# (`bandit/core/manager.py`, `_is_file_included`) tests each exclude_dirs
+# entry with `x in path for x in excluded_path_strings` — a raw SUBSTRING
+# test against the full candidate path, with no path-component boundary at
+# all. That is broader than flake8's #14419 defect (flake8 at least compares
+# against `os.path.basename()`, so it matches whole components): a bare
+# bandit entry excludes any path that merely *contains* the string anywhere,
+# including mid-filename.
+#
+# Measured against `bandit -c .bandit -r autobot-backend/ autobot-slm-backend/
+# autobot_shared/` (the exact invocation code-quality.yml and security.yml
+# run) with `git ls-files` as ground truth: the pre-fix bare entries `temp`,
+# `logs`, `reports`, `archive` and `venv` silently excluded 34 tracked
+# production files that matched none of them as a real directory — among
+# them all nine files under `autobot-backend/workflow_templates/` (via
+# `temp`), `autobot-backend/archive_safety.py` (via `archive`), and
+# `autobot-backend/services/saved_reports_service.py` (via `reports`).
+# Re-including them surfaced exactly 3 real findings (B608 x1, B311 x2), both
+# reviewed and suppressed at the call site with a specific-ID `# nosec` and a
+# reason — see `autobot-backend/llc/services/template.py` and
+# `autobot-backend/services/autoresearch/archive.py`. None of the five named
+# directories exists anywhere under the three scanned trees (confirmed with
+# `find`), so unlike `tests` below they were never anchoring anything —
+# dropped rather than anchored, the same treatment #14419 gave `.flake8`
+# entries naming no tracked directory.
+#
+# The rule this list now follows, enforced by
+# `repo_tests/bandit_exclude_anchoring_test.py`:
+#   * a bare (separator-free) entry is allowed ONLY for a build/VCS/runtime
+#     artifact directory name that covers no tracked Python anywhere in the
+#     repo, checked with bandit's own substring test — not a component or
+#     basename test, because bandit does not use either. `venv` fails this
+#     check (2 tracked files carry "venv" only in their *filename*, e.g.
+#     `check_venv_producers.py`) even though no `venv/` directory exists in
+#     the scanned trees, so it is dropped rather than kept;
+#   * every other entry is anchored by wrapping it in `/`, requiring a path
+#     separator on both sides. That is bandit's own anchoring form, distinct
+#     from flake8's: flake8 turns a separator-containing entry into an
+#     absolute path prefix naming ONE location, but bandit never rewrites an
+#     entry, so `/tests/` stays a substring test — it still matches every
+#     `tests/` directory at any depth (which is the intent: 786 files across
+#     dozens of `tests/` directories), while no longer matching `repo_tests/`
+#     or `run_unit_tests.py`, which the bare `tests` did.
 exclude_dirs:
+  # Build, VCS and runtime artifact directories. Deliberately depth-agnostic:
+  # none of them holds tracked Python anywhere in the repo (verified with
+  # bandit's own substring test, not a component test), so matching by name
+  # prunes artifacts and never source. A name added here that DOES cover
+  # tracked Python fails the guard, so this list cannot become the new
+  # hiding place.
   - node_modules
   - .venv
-  - venv
   - __pycache__
-  - temp
-  - logs
-  - reports
-  - archive
-  - tests
+  # Test trees, at any depth. Wrapped in `/` so this is a component match,
+  # not the bare `tests` substring that also matched `repo_tests/` and any
+  # `*tests*` filename.
+  - /tests/
   # Co-located test files (repo convention: foo_test.py beside foo.py).
   # Test fixtures legitimately contain dummy passwords/SQL — production
-  # code keeps full per-call-site scanning (#9709).
+  # code keeps full per-call-site scanning (#9709). These are fnmatch
+  # globs, not bare directory names — bandit's substring test never matches
+  # a literal "*" against a real path, so their only exclusion power comes
+  # from `_matches_glob_list`, which is unaffected by #14489.
   - "*_test.py"
   - "*/test_*.py"
 

--- a/.bandit
+++ b/.bandit
@@ -24,11 +24,29 @@
 # Re-including them surfaced exactly 3 real findings (B608 x1, B311 x2), both
 # reviewed and suppressed at the call site with a specific-ID `# nosec` and a
 # reason — see `autobot-backend/llc/services/template.py` and
-# `autobot-backend/services/autoresearch/archive.py`. None of the five named
-# directories exists anywhere under the three scanned trees (confirmed with
-# `find`), so unlike `tests` below they were never anchoring anything —
-# dropped rather than anchored, the same treatment #14419 gave `.flake8`
-# entries naming no tracked directory.
+# `autobot-backend/services/autoresearch/archive.py`.
+#
+# NOT IN `git ls-files` IS NOT "ABSENT" — bandit walks the FILESYSTEM, not the
+# git index. First revision of this fix dropped `venv` and `logs` entirely on
+# exactly that confusion. Checked against the real filesystem instead (`find`,
+# not `git ls-files`): `./venv` is a real, gitignored, 26k-file dependency
+# tree at the repo root (present the moment anyone runs `bandit -c .bandit -r
+# .` locally instead of naming the three CI trees), and `./autobot-backend/
+# logs/` + `./autobot-slm-backend/logs/` are real, gitignored, `.gitignore`
+# line 161/399-documented runtime log directories that exist **inside** the
+# trees CI actually scans. Both are restored, anchored. `temp`, `reports` and
+# `archive` really are absent everywhere on disk — `.gitignore` documents
+# `temp/`, `reports/` and `reports/archives/` as conventional paths, but
+# `find` over the whole checkout (not just the git index) turns up no such
+# directory anywhere, inside or outside the three scanned trees — so those
+# three stay dropped.
+#
+# This is where bandit's fix diverges from #14419's flake8 precedent. There,
+# an entry naming no tracked directory really was inert, because flake8 was
+# invoked over the git-tracked trees it lints. bandit's `-r` walks whatever is
+# on disk, tracked or not — `.gitignore`-only content is exactly the kind of
+# thing `exclude_dirs` exists to prune, so "absent from git ls-files" cannot
+# be read as "absent"; only a filesystem check answers that.
 #
 # The rule this list now follows, enforced by
 # `repo_tests/bandit_exclude_anchoring_test.py`:
@@ -36,9 +54,11 @@
 #     artifact directory name that covers no tracked Python anywhere in the
 #     repo, checked with bandit's own substring test — not a component or
 #     basename test, because bandit does not use either. `venv` fails this
-#     check (2 tracked files carry "venv" only in their *filename*, e.g.
-#     `check_venv_producers.py`) even though no `venv/` directory exists in
-#     the scanned trees, so it is dropped rather than kept;
+#     check on its own (2 tracked files carry "venv" only in their
+#     *filename*, e.g. `check_venv_producers.py`), which is exactly why it is
+#     restored ANCHORED (`/venv/`) below rather than bare: anchoring is what
+#     lets the guard and this file agree that a real `venv/` directory is
+#     excluded while `check_venv_producers.py` is not;
 #   * every other entry is anchored by wrapping it in `/`, requiring a path
 #     separator on both sides. That is bandit's own anchoring form, distinct
 #     from flake8's: flake8 turns a separator-containing entry into an
@@ -46,7 +66,9 @@
 #     entry, so `/tests/` stays a substring test — it still matches every
 #     `tests/` directory at any depth (which is the intent: 786 files across
 #     dozens of `tests/` directories), while no longer matching `repo_tests/`
-#     or `run_unit_tests.py`, which the bare `tests` did.
+#     or `run_unit_tests.py`, which the bare `tests` did. The same anchored
+#     form matches `./venv/...` when bandit is invoked as `-r .` from the
+#     repo root, which is the realistic local-footgun case this guards.
 exclude_dirs:
   # Build, VCS and runtime artifact directories. Deliberately depth-agnostic:
   # none of them holds tracked Python anywhere in the repo (verified with
@@ -57,6 +79,13 @@ exclude_dirs:
   - node_modules
   - .venv
   - __pycache__
+  # Real, gitignored directories confirmed present on disk (not just absent
+  # from `git ls-files`) — a local dependency tree and runtime log dirs
+  # inside the actively-scanned trees. Anchored on both sides: bandit never
+  # rewrites an entry into a path prefix, so an unanchored `venv` would (and
+  # did) also match `check_venv_producers.py` through its filename alone.
+  - /venv/
+  - /logs/
   # Test trees, at any depth. Wrapped in `/` so this is a component match,
   # not the bare `tests` substring that also matched `repo_tests/` and any
   # `*tests*` filename.

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -354,6 +354,18 @@ jobs:
           exit 1
         }
 
+    - name: Audit the .bandit exclude_dirs anchoring (#14489)
+      run: |
+        # bandit tests each exclude_dirs entry as a raw SUBSTRING of the full
+        # path, with no path-component boundary -- broader than #14419's flake8
+        # defect. A bare entry like `temp` or `archive` silently excluded 34
+        # tracked production files (all of autobot-backend/workflow_templates/
+        # among them) that named no real directory anywhere in the repo. This
+        # has to run in a REQUIRED check because of the direction it fails in:
+        # re-adding a bare name excludes MORE files, so bandit reports FEWER
+        # findings and this job goes greener.
+        python3 tools/lint/check_bandit_exclude_anchoring.py --audit-excludes
+
     - name: Security check with bandit
       run: |
         python3 -m bandit -c .bandit -r autobot-backend/ autobot-slm-backend/ autobot_shared/ || {

--- a/autobot-backend/llc/services/template.py
+++ b/autobot-backend/llc/services/template.py
@@ -148,7 +148,7 @@ class TemplateService:
                 GROUP BY t.id
                 ORDER BY t.created_at DESC
                 LIMIT :page_size OFFSET :offset
-                """),
+                """),  # nosec B608  # filters is hardcoded clause literals; values are bound params
             {
                 **bind,
                 "page_size": params.page_size,

--- a/autobot-backend/services/autoresearch/archive.py
+++ b/autobot-backend/services/autoresearch/archive.py
@@ -86,9 +86,10 @@ class Archive:
         """Weighted-random selection; uniform fallback when all weights are 0."""
         weights = [max(e.score, 0.0) for e in candidates]
         total = sum(weights)
+        # QD-archive parent selection, not a cryptographic or security context.
         if total == 0.0:
-            return random.choice(candidates)
-        return random.choices(candidates, weights=weights, k=1)[0]
+            return random.choice(candidates)  # nosec B311
+        return random.choices(candidates, weights=weights, k=1)[0]  # nosec B311
 
     # ------------------------------------------------------------------
     # Properties

--- a/repo_tests/bandit_exclude_anchoring_test.py
+++ b/repo_tests/bandit_exclude_anchoring_test.py
@@ -1,0 +1,289 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""#14489 — every ``.bandit`` ``exclude_dirs`` entry must mean the path it was written for.
+
+bandit's matcher (``bandit/core/manager.py``, ``_is_file_included``) tests every
+``exclude_dirs`` entry with ``x in path for x in excluded_path_strings`` — a raw
+**substring** test against the full candidate path, with no path-component
+boundary. A bare entry therefore excludes any path that merely *contains* the
+string anywhere, including mid-filename — broader than flake8's #14419 defect,
+which at least compares against ``os.path.basename()``.
+
+Written bare, ``temp``, ``logs``, ``reports``, ``archive`` and ``venv`` silently
+excluded 34 tracked production files that none of them named as a real
+directory anywhere in the repo — every file under
+``autobot-backend/workflow_templates/`` among them, via ``temp``. Nothing
+reported them as unscanned; a planted hardcoded-password literal in one of
+those paths was silently skipped by the old config and caught by the new one.
+
+The invariant enforced here:
+
+* a bare entry is allowed only if it covers **no tracked Python anywhere in
+  the repo**, tested with bandit's own substring rule
+  (:func:`entries_covering_tracked_python`) — not a path-component rule,
+  because bandit does not use one. This is the point of divergence from
+  #14419's flake8 guard: ``venv`` passes a component check (no directory
+  named ``venv`` holds tracked Python) but fails bandit's real substring
+  check (``check_venv_producers.py`` carries "venv" in its filename), so it
+  must be dropped here even though flake8 could keep it bare;
+* every other entry must be wrapped in ``/`` on both sides — bandit never
+  rewrites an entry into an absolute path the way flake8 does, so an entry
+  with only a trailing ``/`` (``tests/``) is still an unbounded substring
+  test and still matches ``repo_tests/foo.py``.
+
+The discrimination tests at the bottom run the checker against the config as
+it stood before #14489. A guard that has never been shown to reject anything
+is an assertion about nothing.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess  # nosec B404  # fixed argv, no shell, no caller input
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BANDIT_CONFIG = REPO_ROOT / ".bandit"
+_CHECKER = REPO_ROOT / "tools" / "lint" / "check_bandit_exclude_anchoring.py"
+
+
+def _load_checker():
+    """Import the checker by path.
+
+    The decision lives in the script `code-quality` runs, not here. Restating
+    it would give the guard two definitions that could drift, and the copy CI
+    executes is the one that matters — a test agreeing with a second copy of
+    the rule proves nothing about the check that blocks the merge.
+    """
+    spec = importlib.util.spec_from_file_location("check_bandit_exclude_anchoring", _CHECKER)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+checker = _load_checker()
+
+ARTIFACT_DIR_NAMES = checker.ARTIFACT_DIR_NAMES
+read_exclude_entries = checker.read_exclude_entries
+bare_entries = checker.bare_entries
+unanchored_source_entries = checker.unanchored_source_entries
+unanchored_path_entries = checker.unanchored_path_entries
+entries_covering_tracked_python = checker.entries_covering_tracked_python
+is_glob_pattern = checker.is_glob_pattern
+
+#: Floor for the tracked-Python enumeration. An enumeration that returns
+#: nothing must not read as "no source is covered by a bare name".
+_TRACKED_PY_FLOOR = checker.TRACKED_PY_FLOOR
+
+
+@pytest.fixture(scope="module")
+def entries() -> list[str]:
+    return read_exclude_entries(BANDIT_CONFIG.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def tracked_py_files() -> list[str]:
+    """Every tracked ``*.py`` path, enumerated by git rather than by bandit."""
+    completed = subprocess.run(  # nosec B603 B607  # fixed argv, no shell
+        ["git", "ls-files", "*.py"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    paths = [line for line in completed.stdout.splitlines() if line.strip()]
+    assert len(paths) >= _TRACKED_PY_FLOOR, (
+        f"git ls-files returned only {len(paths)} Python files — the enumeration "
+        "broke; these tests would otherwise pass having checked nothing"
+    )
+    return paths
+
+
+# --------------------------------------------------------------------------
+# The invariant
+# --------------------------------------------------------------------------
+
+
+def test_no_bare_directory_name_is_excluded(entries):
+    """A bare name is an unbounded substring test — anchor it, or justify it as an artifact."""
+    offenders = unanchored_source_entries(entries)
+    assert offenders == [], (
+        f"unanchored .bandit exclude_dirs entries {offenders} — bandit matches a "
+        "separator-free entry as a raw substring of the full path, so each of "
+        "these excludes any file whose path merely contains the string, at any "
+        "depth (#14489). Wrap the path the entry was meant for in `/`, e.g. "
+        "`/tests/` not `tests`."
+    )
+
+
+def test_path_entries_are_anchored_on_both_sides(entries):
+    """A trailing-only separator (``tests/``) is still an unbounded substring test."""
+    offenders = unanchored_path_entries(entries)
+    assert offenders == [], (
+        f"exclude_dirs entries anchored on only one side: {offenders}. bandit never "
+        "rewrites an entry into an absolute path the way flake8 does, so `tests/` "
+        "still matches `repo_tests/foo.py` as a raw substring — wrap it as `/tests/`."
+    )
+
+
+def test_artifact_names_cover_no_tracked_python(entries, tracked_py_files):
+    """The artifact allowlist stays honest: none of its names may cover source.
+
+    This is what stops the allowlist becoming the new hiding place, and it
+    uses bandit's own substring rule rather than a path-component rule — the
+    exact distinction that lets ``venv`` slip through a component-based check
+    while still being unsafe under bandit's real matcher.
+    """
+    covered = entries_covering_tracked_python(entries, tracked_py_files)
+    assert covered == {}, (
+        f"bare exclude_dirs entries cover tracked Python: {covered}. These files are "
+        "silently unscanned for security findings. Either the entry is not an "
+        "artifact directory and must be wrapped in `/`, or the source under it "
+        "does not belong there."
+    )
+
+
+def test_the_workflow_templates_package_is_scanned(entries, tracked_py_files):
+    """The regression this issue was filed for, asserted on the outcome.
+
+    ``autobot-backend/workflow_templates/`` is production code. It was
+    unscanned purely because its directory name contains ``temp`` as a
+    substring.
+    """
+    package = "autobot-backend/workflow_templates"
+    assert (REPO_ROOT / package).is_dir(), f"{package} moved — update this test"
+    files = [p for p in tracked_py_files if p.startswith(package + "/")]
+    assert files, f"{package} has no tracked Python — update this test"
+    bare = set(bare_entries(entries))
+    for path in files:
+        assert not any(entry in path for entry in bare), f"{path} is excluded by a bare entry"
+
+
+# --------------------------------------------------------------------------
+# Discrimination — the guard must reject the config it was written against
+# --------------------------------------------------------------------------
+
+#: The exclude_dirs list exactly as it stood before #14489, kept as a fixed
+#: reference point. Do NOT "sync" this to the current config: its whole job
+#: is to be the thing the guard says no to.
+PRE_FIX_EXCLUDE_DIRS = """
+exclude_dirs:
+  - node_modules
+  - .venv
+  - venv
+  - __pycache__
+  - temp
+  - logs
+  - reports
+  - archive
+  - tests
+  - "*_test.py"
+  - "*/test_*.py"
+
+skips:
+  - B101
+"""
+
+
+def test_guard_rejects_the_pre_fix_config():
+    """Against the old list the guard must go red, naming the bare directories."""
+    offenders = unanchored_source_entries(read_exclude_entries(PRE_FIX_EXCLUDE_DIRS))
+    for expected in ("temp", "logs", "reports", "archive", "venv", "tests"):
+        assert expected in offenders, f"guard failed to flag bare `{expected}`"
+
+
+def test_guard_rejects_a_bare_name_smuggled_into_the_artifact_list(tracked_py_files):
+    """Widening ARTIFACT_DIR_NAMES must not be a way to re-hide source."""
+    covered = entries_covering_tracked_python(["temp", "archive"], tracked_py_files)
+    assert covered.get("temp", 0) > 0
+    assert covered.get("archive", 0) > 0
+
+
+def test_venv_fails_the_bandit_matcher_even_though_no_venv_directory_exists(tracked_py_files):
+    """The exact divergence from #14419's component-based flake8 guard.
+
+    No directory named ``venv`` holds tracked Python anywhere in the repo, so
+    a component-based check would call ``venv`` safe. bandit's real matcher
+    is a substring test, and it still catches two files through their
+    filename alone — proving the check below must use bandit's rule, not
+    flake8's.
+    """
+    covered = entries_covering_tracked_python(["venv"], tracked_py_files)
+    assert covered.get("venv", 0) >= 2, covered
+    component_hits = [p for p in tracked_py_files if "venv" in p and "venv" in p.split("/")]
+    assert component_hits == [], "a real venv/ directory now exists with tracked Python — update this test"
+
+
+def test_guard_accepts_the_current_config(entries, tracked_py_files):
+    """Both directions on the live config, so a passing suite means something."""
+    assert unanchored_source_entries(entries) == []
+    assert unanchored_path_entries(entries) == []
+    assert entries_covering_tracked_python(entries, tracked_py_files) == {}
+
+
+def test_test_file_globs_are_unaffected_by_the_substring_bug(entries):
+    """``*_test.py`` and ``*/test_*.py`` are globs, not bare directory names.
+
+    bandit's substring test never matches a literal ``*`` against a real
+    path, so these two entries were never part of #14489 — pinned so a future
+    edit does not fold them into the anchoring requirement by mistake.
+    """
+    globs = [entry for entry in entries if is_glob_pattern(entry)]
+    assert set(globs) == {"*_test.py", "*/test_*.py"}
+    for glob in globs:
+        assert glob not in bare_entries(entries)
+
+
+# --------------------------------------------------------------------------
+# The audit entrypoint, and the check that actually runs it
+# --------------------------------------------------------------------------
+
+
+def test_audit_entrypoint_is_clean_on_the_current_config():
+    """Exercise the exact call `code-quality` makes, not a paraphrase of it."""
+    reached, problems = checker.audit_excludes()
+    assert problems == []
+    assert reached == len(checker.load_entries()), "the audit did not reach every entry"
+    assert reached >= 4, f"only {reached} entries reached — the parse silently collapsed"
+
+
+def test_audit_entrypoint_fails_on_the_pre_fix_config(tmp_path):
+    """The audit must go red on the list this issue was filed against.
+
+    Run against a real config on disk rather than an in-memory list, because
+    that is the path CI takes and it is where a cwd- or root-resolution bug
+    would hide.
+    """
+    (tmp_path / ".bandit").write_text(PRE_FIX_EXCLUDE_DIRS, encoding="utf-8")
+    subprocess.run(  # nosec B603 B607  # fixed argv, no shell
+        ["git", "init", "-q"], cwd=tmp_path, capture_output=True, text=True, check=True
+    )
+    reached, problems = checker.audit_excludes(tmp_path)
+
+    assert reached > 0, "the audit reached no entries — it would pass having checked nothing"
+    joined = "\n".join(problems)
+    assert "unanchored exclude_dirs entries" in joined, f"the anchoring violation was not reported: {problems}"
+    for expected in ("temp", "logs", "reports", "archive", "venv", "tests"):
+        assert expected in joined, f"the audit did not name bare `{expected}`"
+
+
+def test_code_quality_runs_the_audit():
+    """A guard nothing invokes is documentation.
+
+    This is the whole reason the checker is a script: the required
+    `code-quality` job must call it. The failure direction makes it
+    necessary — re-adding a bare name excludes MORE files, so bandit reports
+    FEWER findings and the job goes greener. Without this invocation nothing
+    that can block a merge would notice.
+    """
+    workflow = (REPO_ROOT / ".github" / "workflows" / "code-quality.yml").read_text(encoding="utf-8")
+
+    assert "check_bandit_exclude_anchoring.py --audit-excludes" in workflow, (
+        "code-quality.yml no longer runs the bandit exclude-anchoring audit — the guard "
+        "would stop blocking merges while these tests kept passing (#14489)"
+    )
+    assert _CHECKER.is_file(), f"{_CHECKER} is gone but the workflow still calls it"

--- a/repo_tests/bandit_exclude_anchoring_test.py
+++ b/repo_tests/bandit_exclude_anchoring_test.py
@@ -13,10 +13,22 @@ which at least compares against ``os.path.basename()``.
 
 Written bare, ``temp``, ``logs``, ``reports``, ``archive`` and ``venv`` silently
 excluded 34 tracked production files that none of them named as a real
-directory anywhere in the repo — every file under
+*tracked* directory anywhere in the repo — every file under
 ``autobot-backend/workflow_templates/`` among them, via ``temp``. Nothing
 reported them as unscanned; a planted hardcoded-password literal in one of
 those paths was silently skipped by the old config and caught by the new one.
+
+ABSENT FROM ``git ls-files`` IS NOT ABSENT: bandit walks the filesystem, not
+the git index. A first pass at this fix dropped ``venv`` and ``logs``
+entirely on that exact confusion. Checked against the real filesystem
+instead: ``venv`` is a real, gitignored, ~26k-file dependency tree at the
+repo root (walked in full by any local ``bandit -c .bandit -r .``), and
+``logs`` is a real, gitignored, ``.gitignore``-documented runtime log
+directory that exists inside ``autobot-backend/`` and
+``autobot-slm-backend/`` — the trees CI actually scans. Both are restored,
+anchored (``/venv/``, ``/logs/``). ``temp``, ``reports`` and ``archive`` are
+confirmed absent everywhere on disk (via ``find``, not ``git ls-files``), so
+those three stay dropped.
 
 The invariant enforced here:
 
@@ -26,12 +38,19 @@ The invariant enforced here:
   because bandit does not use one. This is the point of divergence from
   #14419's flake8 guard: ``venv`` passes a component check (no directory
   named ``venv`` holds tracked Python) but fails bandit's real substring
-  check (``check_venv_producers.py`` carries "venv" in its filename), so it
-  must be dropped here even though flake8 could keep it bare;
+  check (``check_venv_producers.py`` carries "venv" in its filename), so a
+  bare ``venv`` cannot pass this guard even though flake8's guard could keep
+  it bare — hence ``venv`` is restored ANCHORED, not bare;
 * every other entry must be wrapped in ``/`` on both sides — bandit never
   rewrites an entry into an absolute path the way flake8 does, so an entry
   with only a trailing ``/`` (``tests/``) is still an unbounded substring
   test and still matches ``repo_tests/foo.py``.
+
+A second divergence from #14419: an anchored entry is not required to name a
+directory that currently exists. ``/venv/`` and ``/logs/`` name gitignored
+runtime directories that a fresh clone or a CI runner legitimately does not
+have yet — the same "guard cannot demand something CI can never have" reason
+:func:`entries_covering_tracked_python` is not applied to anchored entries.
 
 The discrimination tests at the bottom run the checker against the config as
 it stood before #14489. A guard that has never been shown to reject anything
@@ -161,6 +180,44 @@ def test_the_workflow_templates_package_is_scanned(entries, tracked_py_files):
     bare = set(bare_entries(entries))
     for path in files:
         assert not any(entry in path for entry in bare), f"{path} is excluded by a bare entry"
+
+
+def test_venv_and_logs_are_restored_anchored_not_dropped(entries):
+    """Regression pin: a name real on disk must not be dropped as if absent.
+
+    ``git ls-files`` never sees ``venv/`` or ``logs/`` (both gitignored), but
+    both are real directories on disk — ``venv/`` a ~26k-file dependency tree
+    at the repo root, ``logs/`` a runtime log directory nested inside the
+    trees CI scans. Dropping either (as a first pass at this fix did) reads
+    as clean against the git-tracked measurement while a local
+    ``bandit -c .bandit -r .`` would walk all 26k dependency files. They must
+    be present, anchored on both sides — not bare, because bandit's substring
+    matcher still catches ``venv`` through a filename alone (see
+    ``test_venv_fails_the_bandit_matcher_even_though_no_venv_directory_exists``
+    below).
+    """
+    assert "/venv/" in entries, "venv must be excluded, anchored — it is a real, gitignored dependency tree"
+    assert "/logs/" in entries, "logs must be excluded, anchored — it is a real, gitignored runtime directory"
+    assert "venv" not in bare_entries(entries), "venv must not be bare: it still matches a filename substring"
+    assert "logs" not in bare_entries(entries), "logs must not be bare, for the same reason as venv"
+
+
+def test_guard_and_config_agree_on_venv_and_logs(entries, tracked_py_files):
+    """The guard and ``.bandit`` must not disagree about ``venv``/``logs``.
+
+    The guard fails a BARE ``venv``/``logs`` (they cover tracked Python via
+    bandit's substring rule) but has no opinion on the ANCHORED form used in
+    the live config — ``entries_covering_tracked_python`` only ever inspects
+    :func:`bare_entries`. Pinned explicitly so the two conditions this test
+    name promises are both checked, not just implied by the fixture parsing
+    the live file.
+    """
+    assert unanchored_source_entries(entries) == [], "an anchored venv/logs must not be flagged as unanchored"
+    covered = entries_covering_tracked_python(entries, tracked_py_files)
+    assert "venv" not in covered and "logs" not in covered, (
+        "entries_covering_tracked_python only inspects bare entries, so an anchored "
+        "/venv//logs/ correctly never appears here"
+    )
 
 
 # --------------------------------------------------------------------------

--- a/tools/lint/check_bandit_exclude_anchoring.py
+++ b/tools/lint/check_bandit_exclude_anchoring.py
@@ -18,9 +18,21 @@ autobot_shared/`` — the exact invocation ``code-quality.yml`` and
 ``security.yml`` run — with ``git ls-files`` as ground truth: the pre-fix bare
 entries ``temp``, ``logs``, ``reports``, ``archive`` and ``venv`` silently
 excluded 34 tracked production files that none of them named as a real
-directory anywhere in the repo. Re-including them surfaced 3 real bandit
-findings (B608 x1, B311 x2), both reviewed and suppressed at the call site
-with a specific-ID ``# nosec`` and a reason.
+*tracked* directory anywhere in the repo. Re-including them surfaced 3 real
+bandit findings (B608 x1, B311 x2), both reviewed and suppressed at the call
+site with a specific-ID ``# nosec`` and a reason.
+
+ABSENT FROM ``git ls-files`` IS NOT ABSENT. bandit walks the filesystem, not
+the git index, so a name can be dead weight for the git-tracked measurement
+above and still real on disk. Checked against the filesystem instead: ``venv``
+is a real, gitignored, ~26k-file dependency tree at the repo root, present the
+moment anyone runs ``bandit -c .bandit -r .`` locally instead of naming the
+three CI trees, and ``logs`` is a real, gitignored, ``.gitignore``-documented
+runtime log directory that exists **inside** ``autobot-backend/`` and
+``autobot-slm-backend/`` — the trees CI actually scans. Both are restored,
+anchored. ``temp``, ``reports`` and ``archive`` really are absent everywhere
+on disk (confirmed with ``find``, not just ``git ls-files``), so those three
+stay dropped.
 
 The invariant:
 
@@ -30,15 +42,25 @@ The invariant:
   the divergence from #14419's flake8 guard: ``venv`` passes a
   component-based check (no directory literally named ``venv`` holds tracked
   Python) but FAILS bandit's substring check (2 tracked files carry "venv"
-  only inside their filename, e.g. ``check_venv_producers.py``), so it must
-  be dropped here even though flake8 could keep it;
+  only inside their filename, e.g. ``check_venv_producers.py``), so a bare
+  ``venv`` cannot pass this guard even though flake8's component-based guard
+  could keep it bare — it is restored ANCHORED (``/venv/``) instead;
 * every other entry is anchored by wrapping it in ``/``, requiring a path
   separator on both sides. bandit never rewrites an entry the way flake8
   does (flake8 turns a separator-containing entry into an absolute path
   prefix naming one location) — a bandit entry stays a substring test, so
   ``/tests/`` still matches every ``tests/`` directory at any depth, which is
   the intent, while no longer matching ``repo_tests/`` or
-  ``run_unit_tests.py``.
+  ``run_unit_tests.py``. The same anchored form matches ``./venv/...`` when
+  bandit is invoked as ``-r .`` from the repo root — the realistic
+  local-footgun case ``/venv/`` guards against.
+
+A SECOND DIVERGENCE FROM #14419: an anchored entry here is not required to
+name a directory that currently exists, unlike flake8's
+``missing_anchored_targets`` check. ``/venv/`` and ``/logs/`` name gitignored,
+not-guaranteed-to-exist runtime directories — a CI runner or a fresh clone
+legitimately has neither, and failing the guard for that would be exactly the
+kind of false failure this fix is trying to prevent elsewhere.
 
 WHY THIS IS A SCRIPT AND NOT ONLY A TEST. The guard has to run in a check that
 can block a merge, and the direction of this failure is what makes that

--- a/tools/lint/check_bandit_exclude_anchoring.py
+++ b/tools/lint/check_bandit_exclude_anchoring.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""#14489 — every ``.bandit`` ``exclude_dirs`` entry must mean the path it was written for.
+
+bandit's matcher (``bandit/core/manager.py``, ``_is_file_included``) tests every
+``exclude_dirs`` entry with ``x in path for x in excluded_path_strings`` — a raw
+**substring** test against the full candidate path, with no path-component
+boundary at all. That is broader than flake8's #14419 defect (flake8 at least
+compares against ``os.path.basename()``, so it matches whole components): a
+bare bandit entry excludes any path that merely *contains* the string
+anywhere, including mid-filename.
+
+Measured against ``bandit -c .bandit -r autobot-backend/ autobot-slm-backend/
+autobot_shared/`` — the exact invocation ``code-quality.yml`` and
+``security.yml`` run — with ``git ls-files`` as ground truth: the pre-fix bare
+entries ``temp``, ``logs``, ``reports``, ``archive`` and ``venv`` silently
+excluded 34 tracked production files that none of them named as a real
+directory anywhere in the repo. Re-including them surfaced 3 real bandit
+findings (B608 x1, B311 x2), both reviewed and suppressed at the call site
+with a specific-ID ``# nosec`` and a reason.
+
+The invariant:
+
+* a bare (separator-free) entry is allowed only if it covers **no tracked
+  Python anywhere in the repo**, tested with bandit's own substring rule —
+  not a path-component or basename rule, because bandit uses neither. This is
+  the divergence from #14419's flake8 guard: ``venv`` passes a
+  component-based check (no directory literally named ``venv`` holds tracked
+  Python) but FAILS bandit's substring check (2 tracked files carry "venv"
+  only inside their filename, e.g. ``check_venv_producers.py``), so it must
+  be dropped here even though flake8 could keep it;
+* every other entry is anchored by wrapping it in ``/``, requiring a path
+  separator on both sides. bandit never rewrites an entry the way flake8
+  does (flake8 turns a separator-containing entry into an absolute path
+  prefix naming one location) — a bandit entry stays a substring test, so
+  ``/tests/`` still matches every ``tests/`` directory at any depth, which is
+  the intent, while no longer matching ``repo_tests/`` or
+  ``run_unit_tests.py``.
+
+WHY THIS IS A SCRIPT AND NOT ONLY A TEST. The guard has to run in a check that
+can block a merge, and the direction of this failure is what makes that
+matter: re-adding a bare name excludes *more* files, so bandit reports
+*fewer* findings and the required ``code-quality`` job goes greener. Nothing
+about the required checks would otherwise notice. ``code-quality.yml``
+therefore calls this module with ``--audit-excludes``, the same shape as
+``check_flake8_exclude_anchoring.py --audit-excludes`` (#14419).
+``repo_tests/bandit_exclude_anchoring_test.py`` imports these functions
+rather than restating them, so the decision has one definition.
+
+The audit reports how many entries it reached, because a scan that has
+silently stopped matching otherwise passes having asserted nothing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import pathlib
+import subprocess  # nosec B404  # fixed argv, no shell, no caller input
+import sys
+
+import yaml
+
+# Plain stdlib logging, deliberately (#1082) — see check_flake8_exclude_anchoring.py.
+logger = logging.getLogger(__name__)
+
+#: Repo-relative path of this checker, quoted in the messages that ask for an edit.
+SELF_REL = "tools/lint/check_bandit_exclude_anchoring.py"
+
+#: Bare names allowed to match at any depth. Each names a build/VCS/runtime
+#: artifact directory that covers no tracked Python anywhere in the repo,
+#: tested with bandit's own substring rule (:func:`entries_covering_tracked_python`).
+#: THIS SET ONLY SHRINKS. Adding a name here does not buy silence: the audit
+#: re-proves the "no tracked Python" half on every run.
+ARTIFACT_DIR_NAMES = frozenset({"node_modules", ".venv", "__pycache__"})
+
+#: Floor for the tracked-Python enumeration. An enumeration that returns
+#: nothing must not read as "no bare entry covers any source".
+TRACKED_PY_FLOOR = 3000
+
+
+def repo_root() -> pathlib.Path:
+    """Repo root derived from this file, never from the caller's cwd.
+
+    A cwd-relative walk answers confidently and wrongly when run from a
+    subdirectory.
+    """
+    return pathlib.Path(__file__).resolve().parents[2]
+
+
+def read_exclude_entries(config_text: str) -> list[str]:
+    """Parsed ``exclude_dirs`` entries of a bandit config given as YAML text.
+
+    PyYAML because that is what ``bandit.core.config.BanditConfig`` uses to
+    read ``.bandit`` — this must read what bandit reads, and a hand-rolled
+    parser could drift from bandit's own YAML rules (e.g. comment stripping)
+    in a way that hides an entry from the audit.
+    """
+    parsed = yaml.safe_load(config_text) or {}
+    entries = parsed.get("exclude_dirs") or []
+    return [str(entry) for entry in entries]
+
+
+def load_entries(config_path: pathlib.Path | None = None) -> list[str]:
+    """Exclude entries of the repo's ``.bandit`` (or a given config)."""
+    path = config_path if config_path is not None else repo_root() / ".bandit"
+    return read_exclude_entries(path.read_text(encoding="utf-8"))
+
+
+def is_glob_pattern(entry: str) -> bool:
+    """Entries bandit only ever matches via ``fnmatch``, never substring.
+
+    bandit's substring test is ``x in path`` on the *literal* entry string.
+    An entry containing ``*`` never appears literally in a real filesystem
+    path, so its whole exclusion power comes from ``_matches_glob_list`` —
+    unaffected by #14489, and not a "bare directory name" in the sense this
+    guard cares about.
+    """
+    return "*" in entry
+
+
+def bare_entries(entries: list[str]) -> list[str]:
+    """Entries bandit's substring test can match at any depth: no ``/``, no ``*``."""
+    return [entry for entry in entries if "/" not in entry and not is_glob_pattern(entry)]
+
+
+def unanchored_source_entries(entries: list[str]) -> list[str]:
+    """Bare entries that are not a sanctioned artifact name.
+
+    The decision the guard turns on, kept separate so callers can put a
+    synthetic list through it instead of asserting on the config's text.
+    """
+    return [entry for entry in bare_entries(entries) if entry not in ARTIFACT_DIR_NAMES]
+
+
+def tracked_py_files(root: pathlib.Path | None = None) -> list[str]:
+    """Every tracked ``*.py`` path, enumerated by git rather than by bandit."""
+    completed = subprocess.run(  # nosec B603 B607  # fixed argv, no shell
+        ["git", "ls-files", "*.py"],
+        cwd=root if root is not None else repo_root(),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [line for line in completed.stdout.splitlines() if line.strip()]
+
+
+def entries_covering_tracked_python(entries: list[str], tracked: list[str]) -> dict[str, int]:
+    """Bare entries that cover tracked Python under bandit's OWN matcher.
+
+    Deliberately a substring test (``entry in path``), not a path-component
+    test. bandit does not use component matching for a bare entry, so a
+    component-based check here would pass ``venv`` as safe while bandit's
+    real matcher still excludes ``check_venv_producers.py`` through its
+    filename. Verifying against the wrong predicate is how a guard for this
+    exact bug would itself fail open.
+    """
+    counts: dict[str, int] = {}
+    for entry in bare_entries(entries):
+        hits = sum(1 for path in tracked if entry in path)
+        if hits:
+            counts[entry] = hits
+    return counts
+
+
+def unanchored_path_entries(entries: list[str]) -> list[str]:
+    """Path-separator entries not wrapped on both sides, e.g. ``tests/``.
+
+    ``tests/`` (no leading ``/``) still matches ``repo_tests/foo.py`` as a raw
+    substring — ``"tests/" in "repo_tests/foo.py"`` is True. Only
+    ``/tests/`` requires a path separator on both sides.
+    """
+    return [
+        entry
+        for entry in entries
+        if "/" in entry and not is_glob_pattern(entry) and not (entry.startswith("/") and entry.endswith("/"))
+    ]
+
+
+def audit_excludes(root: pathlib.Path | None = None) -> tuple[int, list[str]]:
+    """Apply the invariant to every entry in ``.bandit``.
+
+    Returns ``(entries_reached, problems)``. ``entries_reached`` is counted
+    from the parsed list so a config whose ``exclude_dirs`` has gone missing
+    or empty cannot report a clean scan of nothing.
+    """
+    base = root if root is not None else repo_root()
+    problems: list[str] = []
+
+    entries = load_entries(base / ".bandit")
+    if not entries:
+        return 0, [f"{base / '.bandit'} parsed to zero exclude_dirs entries — the guard checked nothing."]
+
+    unanchored = unanchored_source_entries(entries)
+    if unanchored:
+        problems.append(
+            f"unanchored exclude_dirs entries {sorted(unanchored)}: bandit tests each as a raw "
+            "substring of the full path, with no component boundary, so each of these excludes "
+            "any file whose path merely contains the string, at any depth (#14489). Write the "
+            "path the entry was meant for wrapped in `/` (`/tests/`, not `tests`)."
+        )
+
+    bad_anchor = unanchored_path_entries(entries)
+    if bad_anchor:
+        problems.append(
+            f"exclude_dirs entries missing a leading or trailing `/`: {sorted(bad_anchor)}. bandit "
+            "never rewrites an entry into an absolute path the way flake8 does — without a "
+            "separator on BOTH sides this still matches as an unbounded substring (`tests/` matches "
+            "`repo_tests/foo.py`)."
+        )
+
+    tracked = tracked_py_files(base)
+    if len(tracked) < TRACKED_PY_FLOOR:
+        problems.append(
+            f"git ls-files returned only {len(tracked)} Python files (floor "
+            f"{TRACKED_PY_FLOOR}) — the enumeration broke, so the coverage "
+            "check below asserted nothing."
+        )
+    else:
+        covered = entries_covering_tracked_python(entries, tracked)
+        if covered:
+            problems.append(
+                f"bare exclude_dirs entries cover tracked Python: {covered}. Those files are "
+                f"silently unscanned for security findings. Either the entry is not an artifact "
+                f"directory and must be wrapped in `/`, or it does not belong in "
+                f"ARTIFACT_DIR_NAMES in {SELF_REL}."
+            )
+
+    return len(entries), problems
+
+
+def configure_logging() -> None:
+    """Attach a stderr handler so findings actually reach the developer.
+
+    Run as a bare script the module logger has no handler, and logging's
+    last-resort path drops anything below WARNING.
+    """
+    if not logger.handlers:
+        handler = logging.StreamHandler(sys.stderr)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+
+
+def run_audit() -> int:
+    reached, problems = audit_excludes()
+    if problems:
+        logger.error("%s", "\n\n".join(problems))
+        logger.error("\n.bandit exclude_dirs audit FAILED over %d entries (#14489).", reached)
+        return 1
+    logger.info(".bandit exclude_dirs audit clean over %d entries (#14489).", reached)
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    configure_logging()
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--audit-excludes",
+        action="store_true",
+        help="apply the anchoring invariant to every .bandit exclude_dirs entry",
+    )
+    args = parser.parse_args(argv)
+    if not args.audit_excludes:
+        parser.error("nothing to do — pass --audit-excludes")
+    return run_audit()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Thinking Path

`.bandit`'s `exclude_dirs` used bare directory names, and bandit's matcher
(`bandit/core/manager.py`, `_is_file_included`) tests each entry with
`x in path for x in excluded_path_strings` — a raw **substring** test against
the full candidate path, with no path-component boundary at all. That is
broader than #14419's flake8 defect (flake8 at least compares against
`os.path.basename()`, matching whole components) — a bare bandit entry
excludes any path that merely *contains* the string, including mid-filename.

Followed PR #14486's shape (23f5d0768abf, the identical class of bug in
`.flake8`) but verified against bandit's actual matcher rather than by
analogy, since the issue explicitly warned the anchoring form differs:
bandit never rewrites an entry into an absolute path prefix the way flake8
does, so a bandit entry stays a substring test even once anchored — `/tests/`
still matches every `tests/` directory at any depth (the intent), while
`tests/` alone (only a trailing separator) would still match `repo_tests/`.

Measured the reach with `bandit -c .bandit -r autobot-backend/
autobot-slm-backend/ autobot_shared/` (the exact CI invocation) against
`git ls-files` as ground truth, rather than assuming a backlog:
- `temp`, `logs`, `reports`, `archive` and `venv` silently excluded 34
  tracked production files (all nine files under
  `autobot-backend/workflow_templates/` via `temp`,
  `autobot-backend/archive_safety.py` via `archive`, etc.) that named no real
  *tracked* directory anywhere in the repo.
- `tests` (786 files, all genuine `tests/` directories) was replaced with the
  anchored `/tests/`, which excludes the identical 786 files while no longer
  matching `repo_tests/` or `run_unit_tests.py`.

**Correction after review** (flagged by the coordinator): the first pass
dropped `temp`, `logs`, `reports`, `archive` and `venv` on the strength of
"names no directory in `git ls-files`". That predicate is wrong for bandit,
because bandit walks the **filesystem**, not the git index — "absent from
the index" is not "absent". Re-checked all five against the real filesystem
(`find`, not `git ls-files`):
- `venv` — real. `./venv` at the repo root is a ~26,000-file dependency tree
  (`find venv -name '*.py' | wc -l` → 26336), gitignored
  (`.gitignore:19:venv/`), so invisible to the git-tracked measurement but
  fully walked by any local `bandit -c .bandit -r .`. **Restored**, anchored
  as `/venv/` (not bare — see below).
- `logs` — real. `./logs`, `./autobot-backend/logs`, and
  `./autobot-slm-backend/logs` all exist on disk, gitignored
  (`.gitignore:161` and `:399`, `# All log files go in the unified logs/
  directory`), holding `.log` files. The latter two are **inside the trees
  CI actually scans**. **Restored**, anchored as `/logs/`.
- `temp`, `reports`, `archive` — genuinely absent. `find . -type d -name
  temp` / `-name reports` (outside `docs/reports`, which is tracked,
  curated documentation) / `-name archive`, run over the whole checkout
  (not `git ls-files`), turned up nothing anywhere on disk, inside or
  outside the three scanned trees, despite `.gitignore` documenting
  `temp/`, `.temp/`, `reports/` and `reports/archives/` as conventional
  paths. **Stay dropped.**

This is where bandit's fix diverges from #14419's flake8 precedent, stated
explicitly in both the guard's docstring and the test file: for flake8, an
entry naming no tracked directory really was inert, because flake8 lints the
git-tracked trees. bandit's `-r` walks whatever is on disk, tracked or not,
so `.gitignore`-only content is exactly what `exclude_dirs` exists to prune —
"absent from `git ls-files`" cannot be read as "absent"; only a filesystem
check answers that. A second, related divergence: an anchored bandit entry is
**not** required to name a directory that currently exists (unlike flake8's
`missing_anchored_targets` check) — `/venv/` and `/logs/` name gitignored
runtime directories a fresh clone or CI runner legitimately does not have,
and failing the guard for that would be the same class of false failure this
fix is trying to remove elsewhere.

`venv` could not be restored bare: it fails the guard's own substring check
on its own terms (2 tracked files carry "venv" only in their filename, e.g.
`check_venv_producers.py`, `test_agent_venv_isolation_14278.py`), which is
exactly why it's anchored (`/venv/`) rather than bare — anchoring is what
lets the guard and `.bandit` agree that the real `venv/` directory is
excluded while those two filenames are not. Confirmed no disagreement:
`check_bandit_exclude_anchoring.py --audit-excludes` is clean against the
final `.bandit` (8 entries), and the new
`test_guard_and_config_agree_on_venv_and_logs` /
`test_venv_and_logs_are_restored_anchored_not_dropped` tests pin both
directions.

Re-including the 34 files (unaffected by the venv/logs correction — both
were 0-tracked-Python either way, so the CI-facing count doesn't move)
surfaced exactly 3 real bandit findings (B608 x1, B311 x2). Read and fixed
both at the call site, not grandfathered:
- `autobot-backend/llc/services/template.py` (B608): the `WHERE {filters}`
  f-string is built entirely from hardcoded clause literals in
  `_build_list_filters`; every value goes through a bound `:param`, never
  string interpolation — false positive, suppressed with a specific-ID
  `# nosec B608` and the reason.
- `autobot-backend/services/autoresearch/archive.py` (B311 x2): `random.choice`
  / `random.choices` pick a mutation parent in a quality-diversity archive,
  not a cryptographic or security context — false positive, suppressed with
  `# nosec B311` on each call site.

Proved reach by reproduction: planted a hardcoded-password literal
(`DB_PASSWORD = "hunter2_super_secret"`) in an untracked file under
`autobot-backend/services/` whose path only the bare `archive`/`reports`
entries wrongly swallowed. The old `.bandit` reported "Total lines of code:
0 / No issues identified" (the file was never scanned); the new `.bandit`
scanned 2 lines and reported the B105 finding. The plant was removed before
any commit — never in the tree, never pushed.

## What Changed

- `.bandit` — `exclude_dirs` is now `node_modules`, `.venv`, `__pycache__`
  (build/artifact names, verified to cover zero tracked Python anywhere in
  the repo via bandit's own substring rule), `/venv/` and `/logs/` (real,
  gitignored directories, anchored — see Thinking Path), `/tests/` (anchored
  on both sides), and the pre-existing `*_test.py` / `*/test_*.py` globs
  (untouched — they're fnmatch patterns, not bare names, so #14489 never
  applied to them). `temp`, `reports`, `archive` are dropped — confirmed
  absent everywhere on disk, not just the git index.
- `tools/lint/check_bandit_exclude_anchoring.py` — new guard, mirrors
  `check_flake8_exclude_anchoring.py --audit-excludes`'s shape. Re-derives
  from `git ls-files *.py`, fails if that enumeration returns fewer than
  3000 files (an empty result must not read as clean), fails if a bare entry
  is re-added that covers tracked Python under bandit's **substring** rule
  (not a component rule — the deliberate divergence from the flake8
  template), and fails if an anchored entry is missing a leading or
  trailing `/`. Does **not** require an anchored entry to name a directory
  that currently exists (a second, documented divergence from flake8's
  guard), because `/venv/` and `/logs/` legitimately don't exist on a fresh
  checkout or CI runner.
- `repo_tests/bandit_exclude_anchoring_test.py` — imports the guard's
  functions rather than restating the rule; includes discrimination tests
  that run the guard against the exact pre-fix `exclude_dirs` list and
  assert it goes red, a test pinning that `venv` fails bandit's substring
  check even though no `venv/` directory holds tracked Python, and two new
  regression-pin tests (`test_venv_and_logs_are_restored_anchored_not_dropped`,
  `test_guard_and_config_agree_on_venv_and_logs`) added after the
  filesystem-vs-index correction.
- `.github/workflows/code-quality.yml` — new step "Audit the .bandit
  exclude_dirs anchoring (#14489)" runs the guard in `code-quality`, a
  required check, right before the existing bandit scan step. Not
  `python-suite`, which is not required (#14353) — the failure direction
  makes this matter: re-adding a bare name excludes *more* files, so bandit
  reports *fewer* findings and a lint job goes greener, not redder.
- `autobot-backend/llc/services/template.py`,
  `autobot-backend/services/autoresearch/archive.py` — the two real findings
  re-inclusion surfaced, suppressed with `# nosec <ID>  # <reason>`.
- No changes to `scripts/pr-preflight.sh`: unlike flake8, it already invokes
  `bandit -c .bandit "${PY[@]}"` directly, so bandit's own `exclude_dirs`
  parsing (not a bash-side re-derivation) already governs the per-PR check.

## Verification

- `git ls-files autobot-backend/*.py autobot-slm-backend/*.py
  autobot_shared/*.py` → 4392 tracked files under the three bandit-scanned
  trees.
- Old `exclude_dirs`: 2613 included / 1779 excluded (953 by the deliberate
  `*_test.py`/`*/test_*.py` globs, 826 by the bare-substring bug — of which
  786 were genuine `tests/` directories and 40 were accidental).
- New `exclude_dirs`: 2647 included, 0 previously-scanned files lost (`git
  diff` over the file sets shows 34 newly included, 0 removed) — unchanged
  by the venv/logs restoration, since both were 0-tracked-Python either way.
- Filesystem checks (not `git ls-files`), one per restored/dropped name:
  - `venv`: `find venv -name '*.py' | wc -l` → 26336; `git check-ignore -v
    venv` → `.gitignore:19:venv/` → real, restored anchored.
  - `logs`: `ls -la ./logs ./autobot-backend/logs ./autobot-slm-backend/logs`
    → all exist, hold `.log` files; `git check-ignore -v` on all three →
    `.gitignore:399:logs/` → real, restored anchored.
  - `temp`: `find . -type d \( -name temp -o -name .temp \)` (whole
    checkout, `.git`/worktrees excluded) → no results → dropped.
  - `reports`: `find . -type d -name reports -not -path "./docs/*"` → no
    results (only `docs/reports/`, which is tracked and unaffected) →
    dropped.
  - `archive`: `find . -type d -name archive` → no results → dropped.
- `bandit -c .bandit -r autobot-backend/ autobot-slm-backend/ autobot_shared/`
  with the final config: 0 findings (exit 0) after the two `# nosec` fixes.
- `python3 tools/lint/check_bandit_exclude_anchoring.py --audit-excludes`:
  clean over 8 entries against the final `.bandit`; rejects the pre-fix
  `exclude_dirs` list (naming `temp`, `logs`, `reports`, `archive`, `venv`,
  `tests` as unanchored) when pointed at a throwaway git-init'd tmp dir —
  discrimination confirmed both directions.
- `repo_tests/bandit_exclude_anchoring_test.py`: 14 passed (12 original + 2
  added for the venv/logs correction).
- `scripts/check_nosec_format.py`: exit 0 (both new `# nosec` annotations
  are well-formed, no orphaned/malformed shapes).
- `black --check`, `flake8 --config=.flake8`, `isort --check` on every
  touched Python file: clean.
- Did not `pip install` or create a venv. Used the pre-existing
  `venv/lib/python3.14/site-packages/bandit` (1.9.4, already on the machine,
  gitignored) to run bandit directly; nothing was installed for this task.

**Still open / awaiting the coordinator:** a security review is in flight on
the two `# nosec` judgements (`template.py:151` B608, `archive.py:90-91`
B311) and on whether `repo_tests/` and `run_unit_tests.py` — scanned for the
first time now that `tests` is anchored — should have been all along. This
PR is not being merged until that review lands.

## Model Used

Claude Sonnet 5



Closes #14489
