### PR TITLE
fix(infra): fix 103 undefined names in 12 infra scripts and enforce F821 over the tree (#14405)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -50,7 +50,15 @@ extend-ignore = E203,W503,E704,E402
 #
 # Cross-tool agreement (#14419 AC5): pre-commit's flake8 hook adds
 # `^(tests/|autobot-infrastructure/|autobot-backend/code_analysis/)`, all three
-# of which are also excluded here. black and isort each carry `exclude:
+# of which are also excluded here. #14405 added a SECOND pre-commit flake8 hook
+# that carves `autobot-infrastructure/shared/scripts/` back in for F821 alone —
+# 12 operator scripts there had accumulated 103 undefined names with nothing
+# linting them. That hook passes `--isolated`, so it does not read this file;
+# note that flake8 applies `exclude` while RECURSING, not to a path named
+# explicitly on the command line, so the entry below never protected a file
+# pre-commit handed it by name.
+#
+# Cross-tool agreement (#14419 AC5), continued: black and isort each carry `exclude:
 # ^autobot-infrastructure/` on their own pre-commit hook, and declare nothing
 # further — `[tool.black]` and `[tool.isort]` in pyproject.toml define no
 # exclusion, and in CI both take explicit directory arguments with none either.

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -16,7 +16,7 @@ on:
       - '.pre-commit-config.yaml'
       - 'pipeline-scripts/**'
       - 'tools/lint/**'
-      - 'autobot-infrastructure/shared/scripts/hooks/**'
+      - 'autobot-infrastructure/shared/scripts/**'
       - 'autobot-infrastructure/ansible/roles/slm_agent/files/**'
       - 'docs/developer/**'
       - '.github/workflows/code-quality.yml'
@@ -60,7 +60,7 @@ jobs:
               - '.pre-commit-config.yaml'
               - 'pipeline-scripts/**'
               - 'tools/lint/**'
-              - 'autobot-infrastructure/shared/scripts/hooks/**'
+              - 'autobot-infrastructure/shared/scripts/**'
               - 'autobot-infrastructure/ansible/roles/slm_agent/files/**'
               - 'docs/developer/**'
               - '.github/workflows/code-quality.yml'
@@ -440,6 +440,20 @@ jobs:
         # violations and goes greener. The pytest copy of these assertions runs
         # in `python-suite`, which gates nothing (#14353).
         python3 tools/lint/check_flake8_exclude_anchoring.py --audit-excludes
+
+    - name: Audit undefined names under autobot-infrastructure/shared/scripts (#14405)
+      run: |
+        # `autobot-infrastructure/` is excluded by the pre-commit flake8 hook and
+        # named by no CI flake8 invocation, so nothing ever linted this tree; 12
+        # operator scripts accumulated 103 undefined names -- live NameErrors, not
+        # style. #14405 fixed all 12 and scoped a second pre-commit hook to the tree
+        # for F821. This has to run in a REQUIRED check for the same directional
+        # reason as #14419 and #14489: re-widening the exclusion lints FEWER files, so
+        # every lint step reports fewer violations and goes greener. It re-proves both
+        # halves -- the tree is F821-clean AND a pre-commit hook still reaches it --
+        # and fails below a discovery floor, because a sweep handed an empty file list
+        # reports a comfortable zero. There is no exemption list, deliberately.
+        python3 tools/lint/check_infra_scripts_undefined_names.py --audit
 
     - name: Audit the python-file-size ceilings for drift (#14236)
       run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,8 +63,29 @@ repos:
       - id: flake8
         # Uses .flake8 config file in repo root via args
         args: [--config=.flake8]
-        # Exclude tests, infrastructure, and code analysis tools (non-production code)
+        # Exclude tests, infrastructure, and code analysis tools (non-production code).
+        # This regex is correctly anchored -- it is NOT the #14419 depth bug -- and the
+        # full production ruleset genuinely does not apply here. The narrowing #14405
+        # needed is the hook below, not a hole in this line.
         exclude: ^(tests/|autobot-infrastructure/|autobot-backend/code_analysis/)
+
+      # #14405 -- undefined names ARE production defects, wherever they live.
+      # `autobot-infrastructure/` sat behind the exclude above with nothing else
+      # linting it (no CI flake8 invocation passes the tree either), and 12 operator
+      # scripts accumulated 103 undefined names -- live NameErrors, not style. This
+      # hook carves that one subtree back in for F821 alone, so the gate is clean
+      # today with no exemption list to grandfather the very defect it guards. The
+      # other codes there (E501, F841, F401, F541, E741) stay excluded as a separate
+      # cosmetic backlog. `--isolated` skips .flake8, whose `count`/`statistics`/
+      # `show-source` settings exist for the hook above's human output.
+      # tools/lint/check_infra_scripts_undefined_names.py --audit re-proves from the
+      # REQUIRED code-quality check that this hook still reaches the tree, because a
+      # regression here lints fewer files and would make every lint job look greener.
+      - id: flake8
+        alias: flake8-infra-scripts-undefined-names
+        name: flake8 F821 (autobot-infrastructure/shared/scripts) (#14405)
+        args: [--isolated, --select=F821]
+        files: ^autobot-infrastructure/shared/scripts/.*\.py$
 
   # Remove unused imports and variables with autoflake
   - repo: https://github.com/PyCQA/autoflake

--- a/autobot-infrastructure/shared/scripts/analysis/check_backend_status.py
+++ b/autobot-infrastructure/shared/scripts/analysis/check_backend_status.py
@@ -13,6 +13,10 @@ import sys
 import time
 from urllib.parse import urljoin
 
+import requests
+
+from autobot_shared.network_constants import ServiceURLs
+
 logger = logging.getLogger(__name__)
 
 
@@ -65,18 +69,21 @@ class BackendStatusChecker:
         except Exception as e:
             return {"endpoint": endpoint, "url": url, "error": str(e), "success": False}
 
-        def _run_comprehensive_check_section_1(self):
-            """Display Section of run_comprehensive_check.
+    @staticmethod
+    def _summarise_comprehensive_check(status, successful, failed, critical_endpoints, results):
+        """Build the result payload for run_comprehensive_check.
 
-            Helper for run_comprehensive_check (Issue #825).
-            """
-            return {
-                "status": status,
-                "successful": successful,
-                "failed": failed,
-                "total": len(critical_endpoints),
-                "results": results,
-            }
+        Helper for run_comprehensive_check (Issue #825). Until #14405 this sat
+        nested inside check_endpoint, after that method's final return, reading
+        five names that only exist in run_comprehensive_check's frame.
+        """
+        return {
+            "status": status,
+            "successful": successful,
+            "failed": failed,
+            "total": len(critical_endpoints),
+            "results": results,
+        }
 
     def run_comprehensive_check(self):
         """Run comprehensive backend status check"""
@@ -100,7 +107,7 @@ class BackendStatusChecker:
         failed = 0
 
         for endpoint in critical_endpoints:
-            logger.info(f"Testing {endpoint}...", end=" ")
+            logger.info(f"Testing {endpoint}...")
             result = self.check_endpoint(endpoint)
             results.append(result)
 
@@ -116,10 +123,13 @@ class BackendStatusChecker:
 
         # Overall assessment
         if successful == len(critical_endpoints):
+            status = "healthy"
             logger.info("🟢 Backend Status: HEALTHY")
         elif successful >= len(critical_endpoints) * 0.7:
+            status = "degraded"
             logger.info("🟡 Backend Status: DEGRADED")
         else:
+            status = "unhealthy"
             logger.info("🔴 Backend Status: UNHEALTHY")
 
         # Generate recommendations
@@ -139,11 +149,11 @@ class BackendStatusChecker:
         if successful > 0:
             logger.info("  • Some endpoints working - partial functionality available")
 
-        self._run_comprehensive_check_section_1()
+        return self._summarise_comprehensive_check(status, successful, failed, critical_endpoints, results)
 
     def quick_health_check(self):
         """Quick health check - just test if backend is running"""
-        logger.info("⚡ Quick health check...", end=" ")
+        logger.info("⚡ Quick health check...")
 
         # Try the simplest endpoint first
         result = self.check_endpoint("/api/hello")
@@ -164,8 +174,6 @@ class BackendStatusChecker:
 def main():
     """Main function for command line usage"""
     import argparse
-
-    from constants import ServiceURLs
 
     parser = argparse.ArgumentParser(description="Check AutoBot backend API status")
     parser.add_argument(

--- a/autobot-infrastructure/shared/scripts/analysis/npu_performance_measurement.py
+++ b/autobot-infrastructure/shared/scripts/analysis/npu_performance_measurement.py
@@ -17,6 +17,9 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List
 
+import aiohttp
+import numpy as np
+
 logger = logging.getLogger(__name__)
 
 # Add AutoBot to path

--- a/autobot-infrastructure/shared/scripts/analysis/test_frontend_errors.py
+++ b/autobot-infrastructure/shared/scripts/analysis/test_frontend_errors.py
@@ -6,6 +6,7 @@
 """Test script to capture frontend console errors using Playwright"""
 
 import asyncio
+import logging
 import sys
 
 logger = logging.getLogger(__name__)

--- a/autobot-infrastructure/shared/scripts/analysis/test_gui_chat_visual.py
+++ b/autobot-infrastructure/shared/scripts/analysis/test_gui_chat_visual.py
@@ -5,6 +5,7 @@
 # Author: mrveiss
 """Visual test for AutoBot GUI chat functionality using Playwright service."""
 
+import logging
 import time
 
 logger = logging.getLogger(__name__)

--- a/autobot-infrastructure/shared/scripts/analysis/test_llm_interface_direct.py
+++ b/autobot-infrastructure/shared/scripts/analysis/test_llm_interface_direct.py
@@ -3,12 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
-"""
-
-logger = logging.getLogger(__name__)
-
-Test LLM interface with a simplified version bypassing retry mechanism
-"""
+"""Test LLM interface with a simplified version bypassing retry mechanism."""
 
 import asyncio
 import json
@@ -17,6 +12,8 @@ import sys
 from pathlib import Path
 
 import aiohttp
+
+logger = logging.getLogger(__name__)
 
 # Add src directory to path
 sys.path.insert(0, str(Path(__file__).parent / "src"))

--- a/autobot-infrastructure/shared/scripts/comprehensive_log_aggregator.py
+++ b/autobot-infrastructure/shared/scripts/comprehensive_log_aggregator.py
@@ -37,6 +37,8 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from constants.threshold_constants import TimingConstants
 
+logger = logging.getLogger(__name__)
+
 # Issue #315 - extracted helper functions to reduce deep nesting
 
 

--- a/autobot-infrastructure/shared/scripts/diagnose_backend.py
+++ b/autobot-infrastructure/shared/scripts/diagnose_backend.py
@@ -5,6 +5,7 @@
 # Author: mrveiss
 """Quick backend diagnostic script"""
 
+import logging
 import os
 import sys
 import time

--- a/autobot-infrastructure/shared/scripts/populate_knowledge_base.py
+++ b/autobot-infrastructure/shared/scripts/populate_knowledge_base.py
@@ -5,14 +5,27 @@
 # Author: mrveiss
 """
 Script to populate the knowledge base with all project documentation.
+
+#14405: an automated function-length pass (Issue #825) sliced the single
+``add_documentation_to_kb`` coroutine into eight ``_add_documentation_to_kb_block_N``
+helpers that took no arguments and returned nothing, then left the caller reading
+the locals those helpers had carried away with them -- ``doc_patterns``,
+``exclude_patterns``, ``filtered_files``, ``determine_category``,
+``add_single_file``, ``all_files``, ``project_root``, ``kb``, ``test_queries``
+and ``error_count`` were all undefined at their point of use (13 x F821), so the
+script raised NameError on its first statement of real work. The blocks are
+reassembled below as helpers that take what they read and return what they
+produce, keeping every step the extraction had preserved.
 """
 
 import asyncio
+import fnmatch
 import glob
 import logging
 import os
 import sys
 from pathlib import Path
+from typing import List, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -21,136 +34,122 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from knowledge_base import KnowledgeBase
 
+# Documentation patterns to include.
+DOC_PATTERNS = [
+    "README.md",
+    "CLAUDE.md",
+    "docs/**/*.md",
+    "autobot-backend/resources/prompts/**/*.md",
+    "*.md",  # Any markdown files in root
+]
 
-async def _add_documentation_to_kb_block_5():
-    """Define documentation patterns to include.
+# Files to exclude (e.g., test results, node_modules).
+EXCLUDE_PATTERNS = [
+    "**/node_modules/**",
+    "**/venv/**",
+    "**/test-results/**",
+    "**/playwright-report/**",
+    "**/.pytest_cache/**",
+]
 
-    Helper for add_documentation_to_kb (Issue #825).
-    """
-    # Define documentation patterns to include
-    doc_patterns = [
-        "README.md",
-        "CLAUDE.md",
-        "docs/**/*.md",
-        "autobot-backend/resources/prompts/**/*.md",
-        "*.md",  # Any markdown files in root
-    ]
+# Queries used to smoke-test retrieval once the base has been populated.
+SEARCH_SMOKE_QUERIES = [
+    "installation",
+    "configuration",
+    "embedding",
+    "redis",
+    "ollama",
+    "vue",
+    "debian",
+]
+
+# Category mapping for path prefixes (Issue #315: use lookup instead of elif chain)
+CATEGORY_PREFIXES = [
+    ("docs/developer", "developer-docs"),
+    ("docs/user_guide", "user-guide"),
+    ("docs/reports", "reports"),
+    ("autobot-backend/resources/prompts", "prompts"),
+]
+
+# Default deployment root, matching the ``${AUTOBOT_PROJECT_ROOT:-...}`` shell
+# fallback a sweep left embedded in a Python string literal (#14405).
+DEFAULT_PROJECT_ROOT = "/opt/autobot/code_source"
 
 
-async def _add_documentation_to_kb_block_6():
-    """Files to exclude (e.g., test results, node_modules).
-
-    Helper for add_documentation_to_kb (Issue #825).
-    """
-    # Files to exclude (e.g., test results, node_modules)
-    exclude_patterns = [
-        "**/node_modules/**",
-        "**/venv/**",
-        "**/test-results/**",
-        "**/playwright-report/**",
-        "**/.pytest_cache/**",
-    ]
+def project_root() -> Path:
+    """Resolve the documentation root, honouring AUTOBOT_PROJECT_ROOT."""
+    return Path(os.environ.get("AUTOBOT_PROJECT_ROOT") or DEFAULT_PROJECT_ROOT)
 
 
-async def _add_documentation_to_kb_block_8():
-    """unique_files = set(all_files).
+def should_exclude_file(file_path: str, exclude_patterns: list) -> bool:
+    """Check if file matches any exclude pattern (Issue #315: extracted helper)."""
+    for exclude in exclude_patterns:
+        if fnmatch.fnmatch(file_path, exclude):
+            return True
+    return False
 
-    Helper for add_documentation_to_kb (Issue #825).
-    """
+
+def determine_category(rel_path: str) -> str:
+    """Determine doc category from relative path (Issue #315: extracted helper)."""
+    # Check exact matches first
+    if rel_path == "README.md":
+        return "main-readme"
+    if rel_path == "CLAUDE.md":
+        return "claude-instructions"
+    # Check prefix matches
+    for prefix, category in CATEGORY_PREFIXES:
+        if rel_path.startswith(prefix):
+            return category
+    return "documentation"
+
+
+def collect_documentation_files(root: Path) -> List[str]:
+    """Expand DOC_PATTERNS under *root*, de-duplicate, and drop excluded paths."""
+    all_files: List[str] = []
+    for pattern in DOC_PATTERNS:
+        all_files.extend(glob.glob(str(root / pattern), recursive=True))
+
     unique_files = set(all_files)
-    filtered_files = [fp for fp in unique_files if os.path.isfile(fp) and not should_exclude_file(fp, exclude_patterns)]
+    return [fp for fp in unique_files if os.path.isfile(fp) and not should_exclude_file(fp, EXCLUDE_PATTERNS)]
 
 
-async def _add_documentation_to_kb_block_1():
-    """Category mapping for path prefixes (Issue #315: use lookup i.
-
-    Helper for add_documentation_to_kb (Issue #825).
-    """
-
-    # Category mapping for path prefixes (Issue #315: use lookup instead of elif chain)
-    def determine_category(rel_path: str) -> str:
-        """Determine doc category from relative path (Issue #315: extracted helper)."""
-        category_map = [
-            ("docs/developer", "developer-docs"),
-            ("docs/user_guide", "user-guide"),
-            ("docs/reports", "reports"),
-            ("autobot-backend/resources/prompts", "prompts"),
-        ]
-        # Check exact matches first
-        if rel_path == "README.md":
-            return "main-readme"
-        if rel_path == "CLAUDE.md":
-            return "claude-instructions"
-        # Check prefix matches
-        for prefix, cat in category_map:
-            if rel_path.startswith(prefix):
-                return cat
-        return "documentation"
+async def add_single_file(fp: str, root: Path, kb) -> tuple:
+    """Add a single file to KB (Issue #315: extracted helper)."""
+    rel_path = os.path.relpath(fp, root)
+    category = determine_category(rel_path)
+    metadata = {
+        "source": "project-docs",
+        "category": category,
+        "relative_path": rel_path,
+        "doc_type": "markdown",
+    }
+    logger.info(f"Adding: {rel_path} [{category}]")
+    result = await kb.add_file(file_path=fp, file_type="txt", metadata=metadata)
+    return result["status"] == "success", result
 
 
-async def _add_documentation_to_kb_block_2():
-    """async def add_single_file(fp: str, project_root: Path, kb) -.
-
-    Helper for add_documentation_to_kb (Issue #825).
-    """
-
-    async def add_single_file(fp: str, project_root: Path, kb) -> tuple:
-        """Add a single file to KB (Issue #315: extracted helper)."""
-        rel_path = os.path.relpath(fp, project_root)
-        category = determine_category(rel_path)
-        metadata = {
-            "source": "project-docs",
-            "category": category,
-            "relative_path": rel_path,
-            "doc_type": "markdown",
-        }
-        logger.info(f"Adding: {rel_path} [{category}]")
-        result = await kb.add_file(file_path=fp, file_type="txt", metadata=metadata)
-        return result["status"] == "success", result
-
-
-async def _add_documentation_to_kb_block_3():
-    """for file_path in sorted(filtered_files):.
-
-    Helper for add_documentation_to_kb (Issue #825).
-    """
-    for file_path in sorted(filtered_files):
+async def add_files_to_kb(files: List[str], root: Path, kb) -> Tuple[int, int]:
+    """Add every file to the knowledge base, returning (successes, errors)."""
+    success_count = 0
+    error_count = 0
+    for file_path in sorted(files):
         try:
-            success, result = await add_single_file(file_path, project_root, kb)
+            success, result = await add_single_file(file_path, root, kb)
             if success:
-                pass
+                success_count += 1
             else:
                 error_count += 1
                 logger.error(f"  Error: {result.get('message', 'Unknown error')}")
         except Exception as e:
             error_count += 1
             logger.info(f"  Exception adding {file_path}: {str(e)}")
+    return success_count, error_count
 
 
-async def _add_documentation_to_kb_block_4():
-    """Test search functionality.
-
-    Helper for add_documentation_to_kb (Issue #825).
-    """
-    # Test search functionality
+async def run_search_smoke_tests(kb) -> None:
+    """Query the populated base so an empty or unindexed collection is visible."""
     logger.info("\nTesting search functionality...")
-    test_queries = [
-        "installation",
-        "configuration",
-        "embedding",
-        "redis",
-        "ollama",
-        "vue",
-        "debian",
-    ]
-
-
-async def _add_documentation_to_kb_block_7():
-    """for query in test_queries:.
-
-    Helper for add_documentation_to_kb (Issue #825).
-    """
-    for query in test_queries:
+    for query in SEARCH_SMOKE_QUERIES:
         results = await kb.search(query, n_results=2)
         logger.info(f"\nSearch for '{query}': {len(results)} results")
         if results:
@@ -162,49 +161,17 @@ async def add_documentation_to_kb():
     kb = KnowledgeBase()
     await kb.ainit()
 
-    # Base paths for documentation
-    project_root = Path("${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
-
-    await _add_documentation_to_kb_block_5()
-
-    await _add_documentation_to_kb_block_6()
-
-    all_files = []
-
-    # Collect all documentation files
-    for pattern in doc_patterns:
-        files = glob.glob(str(project_root / pattern), recursive=True)
-        all_files.extend(files)
-
-    # Remove duplicates and filter out excluded patterns (Issue #315: extracted logic)
-    def should_exclude_file(file_path: str, exclude_patterns: list) -> bool:
-        """Check if file matches any exclude pattern (Issue #315: extracted helper)."""
-        for exclude in exclude_patterns:
-            if glob.fnmatch.fnmatch(file_path, exclude):
-                return True
-        return False
-
-    await _add_documentation_to_kb_block_8()
-
+    root = project_root()
+    filtered_files = collect_documentation_files(root)
     logger.info(f"Found {len(filtered_files)} documentation files to add to knowledge base")
 
-    await _add_documentation_to_kb_block_1()
-
-    await _add_documentation_to_kb_block_2()
-
-    # Add each file to the knowledge base
-    success_count = 0
-    error_count = 0
-
-    await _add_documentation_to_kb_block_3()
+    success_count, error_count = await add_files_to_kb(filtered_files, root, kb)
 
     logger.info("\nKnowledge base population complete!")
     logger.info(f"Successfully added: {success_count} files")
     logger.error(f"Errors: {error_count} files")
 
-    await _add_documentation_to_kb_block_4()
-
-    await _add_documentation_to_kb_block_7()
+    await run_search_smoke_tests(kb)
 
 
 if __name__ == "__main__":

--- a/autobot-infrastructure/shared/scripts/populate_knowledge_base.py
+++ b/autobot-infrastructure/shared/scripts/populate_knowledge_base.py
@@ -27,6 +27,8 @@ import sys
 from pathlib import Path
 from typing import List, Tuple
 
+from autobot_shared.paths import project_root
+
 logger = logging.getLogger(__name__)
 
 # Add parent directory to path
@@ -70,15 +72,6 @@ CATEGORY_PREFIXES = [
     ("docs/reports", "reports"),
     ("autobot-backend/resources/prompts", "prompts"),
 ]
-
-# Default deployment root, matching the ``${AUTOBOT_PROJECT_ROOT:-...}`` shell
-# fallback a sweep left embedded in a Python string literal (#14405).
-DEFAULT_PROJECT_ROOT = "/opt/autobot/code_source"
-
-
-def project_root() -> Path:
-    """Resolve the documentation root, honouring AUTOBOT_PROJECT_ROOT."""
-    return Path(os.environ.get("AUTOBOT_PROJECT_ROOT") or DEFAULT_PROJECT_ROOT)
 
 
 def should_exclude_file(file_path: str, exclude_patterns: list) -> bool:

--- a/autobot-infrastructure/shared/scripts/profile_api_endpoints.py
+++ b/autobot-infrastructure/shared/scripts/profile_api_endpoints.py
@@ -14,6 +14,8 @@ import os
 import sys
 import time
 
+import requests
+
 logger = logging.getLogger(__name__)
 
 # Add the project root to Python path

--- a/autobot-infrastructure/shared/scripts/seq_log_forwarder.py
+++ b/autobot-infrastructure/shared/scripts/seq_log_forwarder.py
@@ -17,6 +17,7 @@ Usage:
 import argparse
 import asyncio
 import json
+import logging
 import sys
 from datetime import datetime, timezone
 from pathlib import Path

--- a/autobot-infrastructure/shared/scripts/utilities/report_processing_system.py
+++ b/autobot-infrastructure/shared/scripts/utilities/report_processing_system.py
@@ -10,20 +10,28 @@ import asyncio
 import datetime
 import json
 import logging
+import os
 import shutil
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, List
 
+# A sweep replaced a hardcoded log directory with the SHELL expansion
+# ``${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}`` and left the f-string
+# prefix in place, so Python read ``{AUTOBOT_PROJECT_ROOT:-/opt/...}`` as a
+# replacement field naming an undefined AUTOBOT_PROJECT_ROOT -- the module could
+# not be imported at all (#14405). Resolve the same variable, with the same
+# unset-or-empty fallback ``:-`` gives, in Python.
+_PROJECT_ROOT = os.environ.get("AUTOBOT_PROJECT_ROOT") or "/opt/autobot/code_source"
+_RUN_STARTED_AT = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+
 # Setup logging
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [%(levelname)s] [%(name)s] %(message)s",
     handlers=[
-        logging.FileHandler(
-            f"${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}/report_processing_{datetime.datetime.now().strftime('%Y%m%d_%H%M%S')}.log"
-        ),
+        logging.FileHandler(f"{_PROJECT_ROOT}/report_processing_{_RUN_STARTED_AT}.log"),
         logging.StreamHandler(),
     ],
 )

--- a/autobot-infrastructure/shared/scripts/utilities/report_processing_system.py
+++ b/autobot-infrastructure/shared/scripts/utilities/report_processing_system.py
@@ -10,20 +10,20 @@ import asyncio
 import datetime
 import json
 import logging
-import os
 import shutil
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, List
 
+from autobot_shared.paths import project_root
+
 # A sweep replaced a hardcoded log directory with the SHELL expansion
 # ``${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}`` and left the f-string
 # prefix in place, so Python read ``{AUTOBOT_PROJECT_ROOT:-/opt/...}`` as a
 # replacement field naming an undefined AUTOBOT_PROJECT_ROOT -- the module could
-# not be imported at all (#14405). Resolve the same variable, with the same
-# unset-or-empty fallback ``:-`` gives, in Python.
-_PROJECT_ROOT = os.environ.get("AUTOBOT_PROJECT_ROOT") or "/opt/autobot/code_source"
+# not be imported at all (#14405). autobot_shared.paths exists for exactly this
+# defect class (#13149) and is the one place allowed to answer the question.
 _RUN_STARTED_AT = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
 
 # Setup logging
@@ -31,7 +31,7 @@ logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [%(levelname)s] [%(name)s] %(message)s",
     handlers=[
-        logging.FileHandler(f"{_PROJECT_ROOT}/report_processing_{_RUN_STARTED_AT}.log"),
+        logging.FileHandler(str(project_root() / f"report_processing_{_RUN_STARTED_AT}.log")),
         logging.StreamHandler(),
     ],
 )

--- a/autobot-infrastructure/shared/scripts/utilities/system_monitor.py
+++ b/autobot-infrastructure/shared/scripts/utilities/system_monitor.py
@@ -16,6 +16,7 @@ import time
 from datetime import datetime
 from typing import Any, Dict
 
+import psutil
 import requests
 
 from autobot_shared.network_constants import NetworkConstants, ServiceURLs

--- a/repo_tests/test_infra_scripts_import_14129.py
+++ b/repo_tests/test_infra_scripts_import_14129.py
@@ -12,20 +12,29 @@ its `sys.path` insertion two directories short of `autobot-backend/` (landing on
 `autobot-infrastructure/shared/`, which has no `utils` package). Both operator entry
 points were unimportable.
 
-Nothing caught either: `.pre-commit-config.yaml`'s flake8 hook excludes
+Nothing caught either: `.pre-commit-config.yaml`'s flake8 hook excluded
 `autobot-infrastructure/` entirely, so F821 never gated a commit here, and neither
 script is imported by anything under test. "An import smoke test... would have caught
 both on the commit that broke them" (#14129) — this is that smoke test, generalised to
 the whole directory so the next regression is caught too, not just these two.
 
-Two checks:
+#14405 closed the rest of the hole: the 12 pre-existing offenders this guard once
+`xfail`-marked are fixed, the `KNOWN_BROKEN_AT_GUARD_INTRODUCTION` list is gone with
+them (an undefined name may not be grandfathered — that would exempt the exact defect
+the guard exists for), and the sweep now has a commit-time and a required-check home.
+The static half below therefore imports `tools/lint/check_infra_scripts_undefined_names.py`
+rather than restating it: the copy `code-quality` runs is the one that blocks a merge,
+and a test agreeing with a second copy of the rule proves nothing about it.
+
+Three checks:
 
 1. `test_script_has_no_undefined_names` — a static, per-file `flake8 --select=F821`
    sweep of every script in the tree. Cheap, catches names referenced but never
-   imported/defined (the `manage_system_knowledge.py` class of bug). Pre-existing
-   offenders beyond the two fixed here are tracked in `KNOWN_BROKEN_AT_GUARD_INTRODUCTION`
-   with a reference to #14405 — fixing #14129 is not the same PR as fixing all of them.
-2. `test_operator_script_imports_in_a_realistic_subprocess` — a genuine dynamic import,
+   imported/defined (the `manage_system_knowledge.py` class of bug).
+2. `test_a_pre_commit_hook_still_lints_this_tree` — the commit-time gate is a regex in
+   another file and can be widened back in one line. This replays pre-commit's own
+   file selection to prove some flake8 hook is still handed a script from this tree.
+3. `test_operator_script_imports_in_a_realistic_subprocess` — a genuine dynamic import,
    in a fresh subprocess with `autobot-backend` and the repo root (for `autobot_shared`)
    on PYTHONPATH (the convention every other script under this tree assumes; see
    `autobot-infrastructure/shared/scripts/restore_kb_backup.sh`), for the two scripts
@@ -36,6 +45,7 @@ Two checks:
 
 from __future__ import annotations
 
+import importlib.util
 import os
 import subprocess
 import sys
@@ -46,24 +56,22 @@ import pytest
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _SCRIPTS_DIR = _REPO_ROOT / "autobot-infrastructure" / "shared" / "scripts"
 _BACKEND_DIR = _REPO_ROOT / "autobot-backend"
+_CHECKER = _REPO_ROOT / "tools" / "lint" / "check_infra_scripts_undefined_names.py"
 
-# Pre-existing undefined-name breakage found while introducing this guard, not fixed
-# here (#14129 scoped its fix to the two scripts below). Remove an entry when its file
-# is fixed and #14405 can drop the corresponding acceptance criterion.
-KNOWN_BROKEN_AT_GUARD_INTRODUCTION: dict[str, str] = {
-    "populate_knowledge_base.py": "#14405",
-    "comprehensive_log_aggregator.py": "#14405",
-    "seq_log_forwarder.py": "#14405",
-    "profile_api_endpoints.py": "#14405",
-    "diagnose_backend.py": "#14405",
-    "analysis/test_gui_chat_visual.py": "#14405",
-    "analysis/check_backend_status.py": "#14405",
-    "analysis/test_llm_interface_direct.py": "#14405",
-    "analysis/npu_performance_measurement.py": "#14405",
-    "analysis/test_frontend_errors.py": "#14405",
-    "utilities/report_processing_system.py": "#14405",
-    "utilities/system_monitor.py": "#14405",
-}
+
+def _load_checker():
+    """Import the checker `code-quality` runs, by path (#14405).
+
+    Restating the sweep here would give it two definitions that could drift, and
+    the copy CI executes is the one that blocks a merge.
+    """
+    spec = importlib.util.spec_from_file_location("check_infra_scripts_undefined_names", _CHECKER)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+checker = _load_checker()
 
 # The two scripts #14129 made importable. Exercised with a real subprocess import
 # (Verification bar: "in a subprocess with a realistic path, not via a fixture that
@@ -84,38 +92,9 @@ def _relative_key(path: Path) -> str:
     return str(path.relative_to(_SCRIPTS_DIR))
 
 
-def _undefined_name_lines(path: Path) -> list[str]:
-    """Every `flake8 --select=F821` finding for *path*, one per line.
-
-    `--isolated`: the repo's own `.flake8` sets `count = True` / `statistics = True`
-    for the pre-commit hook's human-readable output, which appends a bare count line
-    (and, with findings, a summary line) after the real violations. Reading `.flake8`
-    here would count every clean file as "broken" (its trailing ``0``).
-    """
-    result = subprocess.run(
-        [sys.executable, "-m", "flake8", "--isolated", "--select=F821", str(path)],
-        capture_output=True,
-        text=True,
-        cwd=_REPO_ROOT,
-        check=False,
-    )
-    return [line for line in result.stdout.splitlines() if line.strip()]
-
-
 def _script_params() -> list:
-    params = []
-    for path in _discover_scripts():
-        key = _relative_key(path)
-        marks = []
-        if key in KNOWN_BROKEN_AT_GUARD_INTRODUCTION:
-            marks.append(
-                pytest.mark.xfail(
-                    reason=f"tracked in {KNOWN_BROKEN_AT_GUARD_INTRODUCTION[key]}",
-                    strict=True,
-                )
-            )
-        params.append(pytest.param(path, id=key, marks=marks))
-    return params
+    """Every script, unmarked. There is no xfail list any more (#14405)."""
+    return [pytest.param(path, id=_relative_key(path)) for path in _discover_scripts()]
 
 
 def test_the_guard_actually_found_scripts():
@@ -131,8 +110,21 @@ def test_script_has_no_undefined_names(path: Path):
     `SystemKnowledgeManager` and `yaml` were referenced inside function bodies with no
     corresponding import anywhere in the file.
     """
-    undefined = _undefined_name_lines(path)
+    undefined = checker.undefined_name_findings([path], _REPO_ROOT)
     assert undefined == [], "\n".join(undefined)
+
+
+def test_a_pre_commit_hook_still_lints_this_tree():
+    """The commit-time gate must keep reaching this tree (#14405).
+
+    Fixing the 12 files by hand while the tree stayed excluded would have left
+    nothing stopping a 13th. That protection is a regex in `.pre-commit-config.yaml`
+    and can be widened back in one line, by someone with no reason to connect the
+    edit to these scripts. `code-quality` re-proves the same thing on every PR;
+    this is its pytest mirror.
+    """
+    problems = checker.commit_gate_problems(_REPO_ROOT)
+    assert problems == [], "\n\n".join(problems)
 
 
 @pytest.mark.parametrize("relative_path", _OPERATOR_ENTRYPOINTS)

--- a/tools/lint/check_infra_scripts_undefined_names.py
+++ b/tools/lint/check_infra_scripts_undefined_names.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""#14405 — no script under ``autobot-infrastructure/shared/scripts/`` may reference a name it never binds.
+
+An undefined name is a live ``NameError`` waiting on the code path that reaches
+it, not a style preference. Twelve operator scripts in this tree carried 103 of
+them — a module logger assigned inside a docstring, ``requests``/``psutil``/
+``numpy``/``aiohttp`` used and never imported, a shell ``${VAR:-default}``
+substituted into an f-string, and a function-length pass that sliced one
+coroutine into eight argument-less helpers, each reading locals the others had
+carried away.
+
+WHY NOTHING CAUGHT THEM. Two independent exclusions cover this tree and neither
+was the #14419 depth bug:
+
+* ``.pre-commit-config.yaml``'s flake8 hook carries
+  ``exclude: ^(tests/|autobot-infrastructure/|autobot-backend/code_analysis/)``.
+  It is correctly anchored and excludes ``autobot-infrastructure/`` on purpose,
+  so the hook reports ``(no files to check) Skipped`` — exit 0 — for a file full
+  of undefined names.
+* No CI flake8 invocation passes this tree as an argument. ``.flake8``'s own
+  ``exclude`` is beside the point here: flake8 only applies it while recursing,
+  so an explicitly-named file under an excluded tree IS linted. Narrowing the
+  pre-commit regex is therefore what turns the check on, and this module is what
+  the narrowed scope runs.
+
+WHY A REQUIRED CHECK AND NOT ONLY A HOOK OR A TEST. A pre-commit hook sees
+staged files only, so it can never prove the whole tree is clean, and the pytest
+copy runs in ``python-suite``, which gates nothing (#14353). The direction of
+this failure is what makes placement matter: re-widening the exclusion lints
+*fewer* files, so every lint job reports fewer violations and goes greener.
+``.github/workflows/code-quality.yml`` — a required check — therefore calls this
+module with ``--audit``, the same shape as ``check_flake8_exclude_anchoring.py
+--audit-excludes`` and ``check_python_file_size.py --audit-ceilings``.
+
+THERE IS NO EXEMPTION LIST, DELIBERATELY. Grandfathering an undefined name would
+make the defect this guard exists for permanently exempt while looking covered
+(#14405). Other flake8 codes in this tree (E501, F841, F401, F541, E741) are a
+separate, cosmetic backlog and stay out of scope — this selects F821 only, so
+the gate is F821-clean today with nothing to ratchet.
+
+The audit reports how many files it reached and fails below a floor, because a
+sweep handed an empty file list reports a comfortable zero that is
+indistinguishable from success.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import pathlib
+import re
+import subprocess  # nosec B404  # fixed argv, no shell, paths come from the repo tree
+import sys
+
+import yaml
+
+# Plain stdlib logging, deliberately (#1082). This runs as a bare script inside a
+# lint job, and `autobot_shared.logging_manager` would drag config loading into
+# that path. Same trade as `tools/lint/check_flake8_exclude_anchoring.py`; it is
+# what CLAUDE.md's pattern table allows for exactly this case.
+logger = logging.getLogger(__name__)
+
+#: Repo-relative path of this checker, quoted in the messages that ask for an edit.
+SELF_REL = "tools/lint/check_infra_scripts_undefined_names.py"
+
+#: The tree this guard covers, repo-relative.
+SCRIPTS_DIR_REL = "autobot-infrastructure/shared/scripts"
+
+#: pyflakes code for "undefined name". Only this one: see the module docstring.
+SELECTED_CODE = "F821"
+
+#: Floor for the audit's own discovery. The tree held 222 scripts when this
+#: landed; a sweep that suddenly reaches a handful has broken, and a clean
+#: result from it asserts nothing.
+DISCOVERY_FLOOR = 100
+
+#: pre-commit config, whose flake8 hooks decide what a commit is allowed to
+#: contain. The audit re-proves that one of them still reaches this tree.
+PRE_COMMIT_CONFIG_REL = ".pre-commit-config.yaml"
+
+#: A real file in the guarded tree, used to replay pre-commit's own file
+#: selection. Asserting on the regex text would pass a rewritten-but-equivalent
+#: regex and fail a stricter one; replaying the selection asks the question that
+#: actually matters — would this hook be handed a script from this tree?
+PROBE_REL = f"{SCRIPTS_DIR_REL}/diagnose_backend.py"
+
+
+def repo_root() -> pathlib.Path:
+    """Repo root, derived from this file's location (``tools/lint/`` is two deep)."""
+    return pathlib.Path(__file__).resolve().parents[2]
+
+
+def scripts_dir(base: pathlib.Path | None = None) -> pathlib.Path:
+    return (base or repo_root()) / SCRIPTS_DIR_REL
+
+
+def discover_scripts(base: pathlib.Path | None = None) -> list[pathlib.Path]:
+    """Every ``*.py`` under the guarded tree, ``__pycache__`` aside."""
+    return sorted(p for p in scripts_dir(base).rglob("*.py") if "__pycache__" not in p.parts)
+
+
+def undefined_name_findings(paths: list[pathlib.Path], base: pathlib.Path | None = None) -> list[str]:
+    """Every ``F821`` flake8 reports for *paths*, one finding per line.
+
+    ``--isolated``: the repo's ``.flake8`` sets ``count``/``statistics`` for the
+    pre-commit hook's human-readable output, which appends a bare count line
+    after the real violations. Reading it here would make every clean file look
+    broken (its trailing ``0``), and ``show-source`` would interleave source
+    echoes that parse as findings too.
+    """
+    if not paths:
+        return []
+    result = subprocess.run(  # nosec B603  # fixed argv, no shell, repo-tree paths
+        [sys.executable, "-m", "flake8", "--isolated", f"--select={SELECTED_CODE}", *[str(p) for p in paths]],
+        capture_output=True,
+        text=True,
+        cwd=str(base or repo_root()),
+        check=False,
+    )
+    if result.returncode not in (0, 1):
+        raise RuntimeError(f"flake8 failed to run ({result.returncode}): {result.stderr.strip()}")
+    return [line for line in result.stdout.splitlines() if line.strip()]
+
+
+def _hook_receives(hook: dict, path: str) -> bool:
+    """Replay pre-commit's include/exclude filtering for one hook and one path."""
+    files = hook.get("files") or ""
+    exclude = hook.get("exclude") or "^$"
+    return bool(re.search(files, path)) and not re.search(exclude, path)
+
+
+def _hook_enforces_undefined_names(hook: dict) -> bool:
+    """True unless the hook's own args select F821 away.
+
+    No ``--select`` at all means the full ruleset, which includes F821 — that is
+    an enforcing hook, not a gap.
+    """
+    args = [str(a) for a in (hook.get("args") or [])]
+    for arg in args:
+        for flag in ("--ignore=", "--extend-ignore="):
+            if arg.startswith(flag) and any(
+                SELECTED_CODE.startswith(code.strip()) for code in arg.split("=", 1)[1].split(",") if code.strip()
+            ):
+                return False
+        if arg.startswith("--select="):
+            return any(SELECTED_CODE.startswith(code.strip()) for code in arg.split("=", 1)[1].split(","))
+    return True
+
+
+def commit_gate_problems(base: pathlib.Path | None = None) -> list[str]:
+    """Re-prove that some pre-commit flake8 hook still lints this tree for F821.
+
+    Fixing the 12 files by hand while the tree stayed excluded would have left
+    nothing stopping a 13th (#14405). That protection lives in a regex in another
+    file, so it can be widened back in one line, by someone with no reason to
+    connect the edit to this tree — which is precisely the regression this
+    function exists to fail on.
+    """
+    base = base or repo_root()
+    config_path = base / PRE_COMMIT_CONFIG_REL
+    if not config_path.is_file():
+        return [f"{PRE_COMMIT_CONFIG_REL} is missing — the commit-time gate cannot be verified."]
+
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    hooks = [hook for repo in config.get("repos", []) for hook in repo.get("hooks", []) if hook.get("id") == "flake8"]
+    if not hooks:
+        return [f"{PRE_COMMIT_CONFIG_REL} declares no flake8 hook at all — nothing lints Python on commit."]
+
+    reaching = [hook for hook in hooks if _hook_receives(hook, PROBE_REL)]
+    if not reaching:
+        return [
+            f"no flake8 hook in {PRE_COMMIT_CONFIG_REL} is handed {PROBE_REL}: every one of "
+            f"{len(hooks)} either does not match it or excludes it. The tree is back to "
+            f"unlinted, which is the state that let 103 undefined names accumulate (#14405). "
+            f"Restore a hook scoped to {SCRIPTS_DIR_REL} with --select={SELECTED_CODE}."
+        ]
+
+    if not any(_hook_enforces_undefined_names(hook) for hook in reaching):
+        return [
+            f"{len(reaching)} flake8 hook(s) in {PRE_COMMIT_CONFIG_REL} reach {PROBE_REL}, but each "
+            f"selects {SELECTED_CODE} away, so an undefined name still commits cleanly (#14405)."
+        ]
+
+    return []
+
+
+def audit(base: pathlib.Path | None = None) -> tuple[int, list[str]]:
+    """Sweep the whole tree. Returns (files reached, problems)."""
+    base = base or repo_root()
+    problems: list[str] = []
+
+    directory = scripts_dir(base)
+    if not directory.is_dir():
+        return 0, [f"{SCRIPTS_DIR_REL} does not exist — the tree moved, so {SELF_REL} now guards nothing."]
+
+    scripts = discover_scripts(base)
+    if len(scripts) < DISCOVERY_FLOOR:
+        problems.append(
+            f"discovery returned only {len(scripts)} script(s) under {SCRIPTS_DIR_REL} "
+            f"(floor {DISCOVERY_FLOOR}) — the sweep broke, so a clean result below "
+            "would assert nothing."
+        )
+
+    problems.extend(commit_gate_problems(base))
+
+    findings = undefined_name_findings(scripts, base)
+    if findings:
+        problems.append(
+            "undefined names (a NameError waiting on the code path that reaches "
+            "them) under "
+            + SCRIPTS_DIR_REL
+            + ":\n"
+            + "\n".join(findings)
+            + f"\n\nImport or define each name. {SELF_REL} carries no exemption list "
+            "on purpose (#14405): grandfathering an undefined name would make the "
+            "defect this guard exists for permanently exempt while looking covered."
+        )
+
+    return len(scripts), problems
+
+
+def check_files(paths: list[str], base: pathlib.Path | None = None) -> tuple[int, list[str]]:
+    """Check the subset of *paths* that lie in the guarded tree (pre-commit's entry).
+
+    Returns (files reached, problems). An empty selection is a legitimate zero
+    here — pre-commit's ``files:`` regex has already narrowed the list — which is
+    exactly why :func:`audit` and not this function is what the required check runs.
+    """
+    base = base or repo_root()
+    directory = scripts_dir(base)
+    selected = []
+    for raw in paths:
+        candidate = pathlib.Path(raw)
+        resolved = candidate if candidate.is_absolute() else (base / candidate)
+        try:
+            resolved.resolve().relative_to(directory.resolve())
+        except ValueError:
+            continue
+        selected.append(resolved)
+
+    findings = undefined_name_findings(selected, base)
+    problems = []
+    if findings:
+        problems.append(
+            "undefined names in the staged scripts:\n"
+            + "\n".join(findings)
+            + "\n\nImport or define each name — an undefined name is a live NameError (#14405)."
+        )
+    return len(selected), problems
+
+
+def configure_logging() -> None:
+    """Attach a stderr handler so findings actually reach the developer.
+
+    Run as a bare script the module logger has no handler, and logging's
+    last-resort path drops anything below WARNING.
+    """
+    if not logger.handlers:
+        handler = logging.StreamHandler(sys.stderr)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+
+
+def main(argv: list[str]) -> int:
+    configure_logging()
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--audit",
+        action="store_true",
+        help=f"sweep every script under {SCRIPTS_DIR_REL}, not only the paths given",
+    )
+    parser.add_argument("paths", nargs="*", help="files to check (pre-commit passes these)")
+    args = parser.parse_args(argv)
+
+    if args.audit:
+        reached, problems = audit()
+        scope = f"{reached} scripts under {SCRIPTS_DIR_REL}"
+    elif args.paths:
+        reached, problems = check_files(args.paths)
+        scope = f"{reached} staged scripts under {SCRIPTS_DIR_REL}"
+    else:
+        parser.error("nothing to do — pass --audit or one or more paths")
+
+    if problems:
+        logger.error("%s", "\n\n".join(problems))
+        logger.error("\nundefined-name audit FAILED over %s (#14405).", scope)
+        return 1
+    logger.info("undefined-name audit clean over %s (#14405).", scope)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
Closes #14405

## Thinking Path

The issue lists 12 files. I measured before assuming anything, per the two
precedents in the issue thread (#14419 predicted a large backlog and measured 2;
#14489 predicted many and found 3): `flake8 --isolated --select=F821` over
`autobot-infrastructure/shared/scripts/` reported **103 findings across exactly
those 12 files** — no more, no fewer. This backlog was real.

Every one is a live `NameError`, and every one traces to an automated sweep that
rewrote code into a shape Python does not read the way the sweep assumed. Three
distinct machine failures, not twelve unrelated typos:

1. A `print()` → `logger.*` conversion that added
   `logger = logging.getLogger(__name__)` without adding `import logging` — and
   in one file dropped that line *inside the module docstring*, where it is
   prose.
2. Missing third-party imports (`requests`, `psutil`, `numpy`, `aiohttp`).
3. A shell `${VAR:-default}` substituted into Python — once into an f-string
   (a replacement field naming an undefined variable), once into a plain string
   (a literal directory name).
4. A function-length pass (#825) that sliced coroutines into argument-less
   `_block_N` helpers, leaving callers reading locals the helpers had carried
   away, and in one case parking a helper *after* a method's final return.

**On the mechanism.** The issue's second comment is right and its first is not:
these files are behind `.pre-commit-config.yaml`'s own `exclude:` regex, which
is correctly anchored and is not the #14419 defect. I verified one further thing
that decides the fix: **flake8 applies `exclude` while recursing, not to a path
named explicitly on the command line.** `.flake8`'s `autobot-infrastructure/`
entry therefore never protected a file pre-commit handed it by name — narrowing
the pre-commit scope is sufficient, and `.flake8` needs no hole cut in it.

**On placement.** The guard goes in `code-quality` (required), following #14486
(`23f5d0768abf`) and #14502 (`d682a48a50cd`), for the directional reason both
cite: re-widening an exclusion lints *fewer* files, so every lint step reports
fewer violations and the job goes **greener**. A guard behind `python-suite`
(which gates nothing, #14353) is invisible exactly when it matters. No job or
check-run name is changed.

**On grandfathering.** There is no exemption list anywhere in this PR. An
undefined name on a shrink-only list would make this issue's entire subject
permanently exempt while looking covered. Nothing needed one — all 103 are
fixed.

## What Changed

### The 12 files (103 × F821 → 0)

| File | F821 | What it actually was |
|---|---|---|
| `comprehensive_log_aggregator.py` | 30 | Bare `logger` at 30 sites; only `__init__` ever built one, as `self.logger`. Added a module logger. |
| `analysis/npu_performance_measurement.py` | 21 | `numpy as np` and `aiohttp` used, neither imported. |
| `analysis/test_llm_interface_direct.py` | 18 | `logger = logging.getLogger(__name__)` had been dropped **inside the module docstring**. Moved to code. |
| `populate_knowledge_base.py` | 13 | Botched extraction — see below. |
| `analysis/check_backend_status.py` | 10 | Botched extraction + missing `requests`/`ServiceURLs` — see below. |
| `utilities/system_monitor.py` | 5 | `psutil` used at 5 sites, never imported. |
| `seq_log_forwarder.py` | 1 | `import logging` missing. |
| `diagnose_backend.py` | 1 | `import logging` missing. |
| `analysis/test_gui_chat_visual.py` | 1 | `import logging` missing. |
| `analysis/test_frontend_errors.py` | 1 | `import logging` missing. |
| `profile_api_endpoints.py` | 1 | `requests` used, never imported. |
| `utilities/report_processing_system.py` | 1 | Shell `${AUTOBOT_PROJECT_ROOT:-…}` substituted into an **f-string** — module unimportable. Now resolved through `autobot_shared.paths.project_root()`. |

The issue asked specifically that `populate_knowledge_base.py` be re-checked for
a botched extraction. It was one. `add_documentation_to_kb` had been sliced into
eight `_add_documentation_to_kb_block_N` coroutines that took no arguments and
returned nothing, while the caller went on reading the locals they had carried
away (`doc_patterns`, `exclude_patterns`, `filtered_files`, `determine_category`,
`add_single_file`, `all_files`, `project_root`, `kb`, `test_queries`,
`error_count`). Every block is reassembled as a helper that takes what it reads
and returns what it produces. Two further defects fell out: `success_count` was
never incremented (the success branch was `pass`, so a full run always reported
0 files added), and the project root was the literal string
`"${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}"`.

`analysis/check_backend_status.py` was the same class of damage. The
result-payload helper sat nested inside `check_endpoint`, *after* that method's
final return — unreachable — reading five names that only exist in
`run_comprehensive_check`'s frame; it is now a method taking them. `status` was
never computed anywhere although `main()` indexes `results["status"]`, and
`run_comprehensive_check` discarded the payload it was supposed to return. Two
`logger.info(..., end=" ")` calls raised `TypeError` (`Logger.info` has no
`end`) and lost the keyword. `ServiceURLs` is imported from the canonical
`autobot_shared.network_constants`, matching its sibling `system_monitor.py`.

Both project-root sites now go through **`autobot_shared.paths.project_root()`**
rather than an open-coded `os.environ.get(...) or "/opt/autobot/code_source"`.
That module exists for precisely this defect class (#13149) and resolves more
than the env var alone — configured deployment, checkout root, then install root,
with the worktree hazard handled. Two local copies would have been a third and
fourth implementation free to drift.

No `# noqa` was added anywhere in this PR.

### Enforcement (so a 13th cannot appear silently)

- **`.pre-commit-config.yaml`** — a second flake8 hook, alias
  `flake8-infra-scripts-undefined-names`, scoped to
  `^autobot-infrastructure/shared/scripts/.*\.py$` with
  `--isolated --select=F821`. The wide hook's `exclude:` regex is left alone; it
  is correctly anchored and the full production ruleset genuinely does not apply
  to this tree.
- **`tools/lint/check_infra_scripts_undefined_names.py`** (new) — run as
  `--audit` from `code-quality`. It proves *both* halves: the tree is F821-clean,
  **and** some pre-commit flake8 hook still reaches it. The second half replays
  pre-commit's own include/exclude selection against a real path in the tree
  rather than asserting on regex text, so an equivalent rewrite passes and a
  genuine re-widening fails. It fails below a **discovery floor of 100** files,
  because a sweep handed an empty file list reports a comfortable zero that is
  indistinguishable from success. It reports how many files it reached.
- **`.github/workflows/code-quality.yml`** — the audit step, plus the path
  filter widened from `autobot-infrastructure/shared/scripts/hooks/**` to
  `autobot-infrastructure/shared/scripts/**` so a script-only change still runs
  the audit that covers it. No job or check-run name changed.
- **`repo_tests/test_infra_scripts_import_14129.py`** —
  `KNOWN_BROKEN_AT_GUARD_INTRODUCTION` deleted in full (all 12 entries), and the
  sweep is now *imported* from the checker rather than restated, so the copy CI
  executes is the only definition. Added a pytest mirror of the commit-gate
  check. The dynamic subprocess-import test for the two #14129 entrypoints is
  unchanged.
- **`.flake8`** — the #14419 cross-tool paragraph updated: it claimed
  `autobot-infrastructure/` was excluded by both tools, which is now only true
  outside `shared/scripts/`, and it did not record that `exclude` does not apply
  to explicitly-named paths.

### Scope held deliberately

F821 only. Re-including this tree for the full ruleset would surface **103**
other findings (81 E501, 14 F841, 4 F541, 3 F401, 1 E741 — 105 before these
fixes). Those are cosmetic, they are the kind of backlog that legitimately needs
a shrink-only ratchet, and mixing them in would have put the F821s next to an
exemption list. Filed separately as the follow-up below.

## Verification

Tooling: `flake8` 7.3.0 and `pre-commit` 4.6.1 from the repo-root gitignored
`venv/`, read-only. flake8 parses rather than executes, so no repo code was run.

**Measurement (the number actually measured, vs the issue's 12):**

```
$ flake8 --isolated --select=F821 autobot-infrastructure/shared/scripts/ | cut -d: -f1 | sort | uniq -c
     30 comprehensive_log_aggregator.py          13 populate_knowledge_base.py
     21 analysis/npu_performance_measurement.py  10 analysis/check_backend_status.py
     18 analysis/test_llm_interface_direct.py     5 utilities/system_monitor.py
      1 each: seq_log_forwarder, profile_api_endpoints, diagnose_backend,
             analysis/test_gui_chat_visual, analysis/test_frontend_errors,
             utilities/report_processing_system
  → 103 findings, 12 files — exactly the 12 the issue named.
```

After: `flake8 --isolated --select=F821 …/scripts/` → **exit 0, no output.**

The touched files are also clean under the repo's *full* `.flake8` ruleset, with
one exception: `seq_log_forwarder.py` carries 5 pre-existing E501s, all on lines
this PR does not touch (`git show origin/Dev_new_gui:…` reports the same 5). They
belong to the backlog filed as #14505; the diff there is a single `import logging`
line.

**Reach proved by reproduction, not predicate.** A deliberate undefined name was
appended to `autobot-infrastructure/shared/scripts/diagnose_backend.py` and the
real hooks were run against it:

| Config | Command | Result |
|---|---|---|
| `origin/Dev_new_gui` | `pre-commit run --config <base config> --files …/diagnose_backend.py` | `flake8 … (no files to check) Skipped` — **exit 0** |
| this branch | `pre-commit run flake8-infra-scripts-undefined-names --files …/diagnose_backend.py` | **Failed, exit 1**: `…/diagnose_backend.py:129:10: F821 undefined name '_deliberately_undefined_name_14405'` |
| this branch | `check_infra_scripts_undefined_names.py --audit` | **exit 1**, naming the line, over 222 scripts |

The base config produced a comfortable zero on a file containing a live
`NameError`. The probe was removed before committing; `git diff` on that file
against base shows only the `import logging` fix. No mutation commit was pushed.

**Guard discrimination** (mutating *scratch copies*, never the repo config):

| Mutation | `commit_gate_problems()` |
|---|---|
| scoped hook removed | fails — "no flake8 hook … is handed …" |
| hook present but `--select=E501` | fails — "each selects F821 away" |
| no flake8 hook at all | fails — "declares no flake8 hook at all" |
| hook with `--select=F821` | clean |
| tree containing 1 script | fails — discovery floor |
| live repo | clean |

**Other audits still green:** `check_flake8_exclude_anchoring.py
--audit-excludes` → clean over 39 entries (the `.flake8` comment edit did not
disturb the parse). Both YAML files re-parse. `flake8 --select=F401,F811,F821,E9`
on the new checker and the updated guard test → clean.

Not run locally: `pytest repo_tests/test_infra_scripts_import_14129.py`, whose
second test executes two infra scripts in a subprocess — running codebase code
locally is not done here; CI covers it. Its static half is the checker function
verified above.

## Model Used

Claude Opus 5 (1M context) — `claude-opus-5[1m]`.
