### PR TITLE
fix(slm): replace lifetime-cumulative restart threshold with a rate signal (#14465)

### DIFF
--- a/autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/health_collector.py
+++ b/autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/health_collector.py
@@ -23,6 +23,7 @@ from typing import Dict, List
 import psutil
 
 from autobot_shared.redis_client import get_redis_client
+from autobot_shared.service_discovery import SERVICE_DISCOVERY_TTL_S
 from autobot_shared.time_utils import utc_timestamp
 
 # App-level /health probes for services that expose engine state beyond
@@ -38,8 +39,11 @@ logger = logging.getLogger(__name__)
 
 _STATE_CHANGE_CHANNEL_TEMPLATE = "autobot:services:{service}:state_change"
 
-# Subprocess-heavy service sweep is cached this long to reduce system load (#9086)
-_SERVICE_DISCOVERY_TTL = 300  # seconds
+# Subprocess-heavy service sweep is cached this long to reduce system load
+# (#9086). Shared with services/reconciler.py's restart-churn window, which
+# must stay comfortably larger than this -- see autobot_shared/
+# service_discovery.py for why this is a plain constant, not env-backed.
+_SERVICE_DISCOVERY_TTL = SERVICE_DISCOVERY_TTL_S
 
 
 class HealthCollector:

--- a/autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/health_collector.py
+++ b/autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/health_collector.py
@@ -285,6 +285,21 @@ class HealthCollector:
                             details["description"] = value[:500]
                         elif key == "UnitFileState":
                             details["enabled"] = value == "enabled"
+                            # #14465: `enabled` above is deliberately narrow
+                            # (only "starts on boot", used for the Service
+                            # table's own `enabled` column/UI display) --
+                            # do not widen it, other consumers rely on that
+                            # exact meaning. `unit_file_state` carries the raw
+                            # string so a degrade-signal consumer can gate on
+                            # "not explicitly disabled" instead: `static`
+                            # units (no [Install] section -- e.g.
+                            # autobot-key-rotation, autobot-pg-backup) and
+                            # `indirect`/`enabled-runtime`/`generated`/`alias`
+                            # are all legitimately deployed and never
+                            # `UnitFileState == "enabled"`, so a check scoped
+                            # to that string alone leaves them permanently
+                            # invisible.
+                            details["unit_file_state"] = value
                         elif key == "NRestarts" and value.isdigit():
                             details["n_restarts"] = int(value)
 

--- a/autobot-slm-backend/services/reconciler.py
+++ b/autobot-slm-backend/services/reconciler.py
@@ -110,9 +110,7 @@ MAX_SERVICE_RESTART_ATTEMPTS = 3
 # triggering one ansible restart via remediation, where the absolute
 # threshold it replaced made that same trade unboundedly (forever, once
 # n_restarts crossed 3) rather than for one bounded window.
-RESTART_CHURN_WINDOW_S = env_int_clamped(
-    "AUTOBOT_RESTART_CHURN_WINDOW_S", 600, min_v=SERVICE_DISCOVERY_TTL_S * 2 + 1
-)
+RESTART_CHURN_WINDOW_S = env_int_clamped("AUTOBOT_RESTART_CHURN_WINDOW_S", 600, min_v=SERVICE_DISCOVERY_TTL_S * 2 + 1)
 
 
 def _restart_count_increased(svc_data: dict, previous_extra: dict) -> bool:

--- a/autobot-slm-backend/services/reconciler.py
+++ b/autobot-slm-backend/services/reconciler.py
@@ -38,7 +38,7 @@ from models.database import (
     Setting,
 )
 from services.service_categorizer import categorize_service
-from services.service_extra_data import engine_degraded_fields
+from services.service_extra_data import engine_degraded_fields, is_managed_autobot_service
 
 logger = logging.getLogger(__name__)
 
@@ -79,6 +79,43 @@ DEFAULT_ROLLBACK_WINDOW = 600  # 10 minutes
 SERVICE_REMEDIATION_COOLDOWN = 120  # 2 minutes
 # Maximum service restart attempts before requiring human intervention
 MAX_SERVICE_RESTART_ATTEMPTS = 3
+
+
+def _restart_count_increased(svc_data: dict, previous_extra: dict) -> bool:
+    """Did a managed service's `n_restarts` rise since the last heartbeat?
+
+    Helper for ReconcilerService._update_existing_service (#14465). Compares
+    against the immediately preceding heartbeat's stored value, never an
+    absolute threshold -- `NRestarts` is lifetime-cumulative, so a static gate
+    on it can never self-heal (see `_calculate_node_status`'s docstring).
+    Module-level and pure so it stays testable without a DB or a class instance.
+    """
+    if not is_managed_autobot_service(svc_data):
+        return False
+    current = svc_data.get("n_restarts")
+    previous = previous_extra.get("n_restarts")
+    if current is None or previous is None:
+        return False
+    return current > previous
+
+
+def _service_health_degraded(extra_data: dict | None, restart_increase_detected: bool) -> bool:
+    """The two current-state service signals `_calculate_node_status` acts on.
+
+    Module-level and pure: `restart_increase_detected` is computed elsewhere
+    (against the OLD `Service` row this function does not have); this only
+    combines it with the current-heartbeat status scan.
+    """
+    if restart_increase_detected:
+        return True
+    if not extra_data:
+        return False
+    for svc in extra_data.get("discovered_services", []):
+        if not is_managed_autobot_service(svc):
+            continue
+        if svc.get("status") in ("crash-loop", "failed"):
+            return True
+    return False
 
 
 class ReconcilerService:
@@ -1188,10 +1225,13 @@ class ReconcilerService:
         agent_version: str | None = None,
         os_info: str | None = None,
         extra_data: dict | None = None,
-    ) -> None:
+    ) -> bool:
         """Update basic metrics and optional fields.
 
         Helper for update_node_heartbeat (Issue #665).
+
+        Returns whether a managed service's restart count increased since the
+        last heartbeat (#14465), for `_calculate_node_status` to act on.
         """
         node.cpu_percent = cpu_percent
         node.memory_percent = memory_percent
@@ -1202,12 +1242,14 @@ class ReconcilerService:
             node.agent_version = agent_version
         if os_info:
             node.os_info = os_info
-        if extra_data:
-            node.extra_data = {**(node.extra_data or {}), **extra_data}
+        if not extra_data:
+            return False
 
-            services_data = extra_data.get("discovered_services") or extra_data.get("services")
-            if services_data:
-                await self._sync_discovered_services(db, node.node_id, services_data)
+        node.extra_data = {**(node.extra_data or {}), **extra_data}
+        services_data = extra_data.get("discovered_services") or extra_data.get("services")
+        if not services_data:
+            return False
+        return await self._sync_discovered_services(db, node.node_id, services_data)
 
     async def _handle_node_status_change(
         self,
@@ -1292,7 +1334,7 @@ class ReconcilerService:
         if not node:
             return None
 
-        await self._update_node_metrics(
+        restart_increase_detected = await self._update_node_metrics(
             db,
             node,
             cpu_percent,
@@ -1304,7 +1346,9 @@ class ReconcilerService:
         )
 
         old_status = node.status
-        new_status = self._calculate_node_status(cpu_percent, memory_percent, disk_percent, extra_data)
+        new_status = self._calculate_node_status(
+            cpu_percent, memory_percent, disk_percent, extra_data, restart_increase_detected
+        )
 
         await self._handle_node_status_change(
             db, node, old_status, new_status, cpu_percent, memory_percent, disk_percent
@@ -1326,11 +1370,18 @@ class ReconcilerService:
         status: str,
         error_msg: str,
         now: datetime,
-    ) -> None:
+    ) -> bool:
         """Apply heartbeat data to an existing Service row.
 
         Helper for _upsert_service. Ref: #1088.
+
+        Returns whether THIS heartbeat shows a managed service's restart
+        count higher than the value stored from the previous one (#14465).
+        Computed here, not in `_calculate_node_status`, because only this
+        call site holds the OLD `Service` row before it gets overwritten.
         """
+        restart_increased = _restart_count_increased(svc_data, service.extra_data or {})
+
         service.status = status
         service.active_state = svc_data.get("active_state")
         service.sub_state = svc_data.get("sub_state")
@@ -1339,13 +1390,16 @@ class ReconcilerService:
         service.enabled = svc_data.get("enabled", False)
         service.description = svc_data.get("description")
         service.last_checked = now
-        existing_extra = service.extra_data or {}
+        existing_extra = dict(service.extra_data or {})
         if error_msg:
             existing_extra["error_message"] = error_msg
         else:
             existing_extra.pop("error_message", None)
         existing_extra.update(engine_degraded_fields(svc_data))
+        if "n_restarts" in svc_data:
+            existing_extra["n_restarts"] = svc_data["n_restarts"]
         service.extra_data = existing_extra
+        return restart_increased
 
     def _create_new_service(
         self,
@@ -1359,8 +1413,13 @@ class ReconcilerService:
         """Construct a new Service ORM object from heartbeat data.
 
         Helper for _upsert_service. Ref: #1088.
+
+        Stores `n_restarts` so the NEXT heartbeat has something to compare
+        against (#14465) -- a first observation is never itself a delta.
         """
         category = categorize_service(service_name)
+        if "n_restarts" in svc_data:
+            svc_extra = {**svc_extra, "n_restarts": svc_data["n_restarts"]}
         return Service(
             node_id=node_id,
             service_name=service_name,
@@ -1382,14 +1441,17 @@ class ReconcilerService:
         node_id: str,
         svc_data: dict,
         now: datetime,
-    ) -> None:
+    ) -> bool:
         """Upsert a single discovered service record into the database.
 
         Helper for _sync_discovered_services. Ref: #1088.
+
+        Returns whether this service is managed and its restart count
+        increased since the last heartbeat (#14465).
         """
         service_name = svc_data.get("name")
         if not service_name:
-            return
+            return False
 
         try:
             result = await db.execute(
@@ -1410,10 +1472,10 @@ class ReconcilerService:
             svc_extra.update(engine_degraded_fields(svc_data))
 
             if service:
-                self._update_existing_service(service, svc_data, status, error_msg, now)
-            else:
-                service = self._create_new_service(node_id, service_name, svc_data, status, svc_extra, now)
-                db.add(service)
+                return self._update_existing_service(service, svc_data, status, error_msg, now)
+            service = self._create_new_service(node_id, service_name, svc_data, status, svc_extra, now)
+            db.add(service)
+            return False
         except Exception as exc:
             logger.warning(
                 "service sync failed node=%s service=%s error=%s",
@@ -1421,6 +1483,7 @@ class ReconcilerService:
                 service_name,
                 exc,
             )
+            return False
 
     async def _remove_stale_services(
         self,
@@ -1450,24 +1513,30 @@ class ReconcilerService:
         db: AsyncSession,
         node_id: str,
         discovered_services: list,
-    ) -> None:
+    ) -> bool:
         """
         Sync discovered services from agent heartbeat to database.
 
         Related to Issue #728.
+
+        Returns whether ANY managed service's restart count increased since
+        the last heartbeat (#14465).
         """
         if not discovered_services:
-            return
+            return False
 
         now = datetime.now(timezone.utc)
 
+        restart_increase_detected = False
         for svc_data in discovered_services:
-            await self._upsert_service(db, node_id, svc_data, now)
+            if await self._upsert_service(db, node_id, svc_data, now):
+                restart_increase_detected = True
 
         # Remove stale services no longer reported by the agent (#1018)
         await self._remove_stale_services(db, node_id, discovered_services)
 
         # Note: commit happens in the calling method (update_node_heartbeat)
+        return restart_increase_detected
 
     def _calculate_node_status(
         self,
@@ -1475,25 +1544,53 @@ class ReconcilerService:
         memory_percent: float,
         disk_percent: float,
         extra_data: dict | None = None,
+        restart_increase_detected: bool = False,
     ) -> str:
         """Calculate node status based on health metrics and services.
 
         Issue #1604: Also degrade if any autobot service is crash-looping.
+
+        #14465: this used to degrade on `n_restarts > 3` -- systemd's
+        `NRestarts` read as a static absolute threshold. `NRestarts` is
+        lifetime-cumulative (never resets except at reboot or
+        `reset-failed`), so a static gate on it can only ever climb: once any
+        managed service anywhere in the node's uptime crossed 3 restarts --
+        one redeploy, one operator restart, one long-resolved crash-loop --
+        every future heartbeat was forced DEGRADED regardless of current
+        state, with no path back to ONLINE.
+
+        Replaced with two signals over the SAME field, each answering a
+        different question a static threshold cannot:
+
+        - `restart_increase_detected` (computed in `_update_existing_service`,
+          against the immediately preceding heartbeat's stored value, not an
+          absolute) catches a service CHURNING -- restarting faster than it
+          settles. `RestartSec` is typically far shorter than the heartbeat
+          interval, so most samples land on `"running"` between restarts; a
+          rising count between two consecutive heartbeats is what actually
+          proves instability there, regardless of what any single sample's
+          status says.
+        - `status == "failed"` (below) catches a service that has SETTLED --
+          every unit template sets `StartLimitBurst`/`StartLimitIntervalSec`
+          (#4090), so a real, ongoing crash loop eventually reaches systemd's
+          designed end state and stops restarting altogether. A pure delta
+          goes quiet the moment `NRestarts` stops climbing, so this half
+          would go blind exactly when the first stopped.
+
+        Both are scoped by `is_managed_autobot_service` (autobot*-prefixed
+        service names, or `slm-agent` itself, that are systemd-`enabled` on
+        THIS node) rather than `extra_data["services"]`
+        (`slm_services_to_monitor`) -- that operator-declared set is `[]` by
+        role default, is `[]` on at least one real inventory node, and never
+        contains `slm-agent`, the one unit remediation actually restarts, so
+        scoping to it left this whole class of signal dark for most of the
+        fleet on the one service that matters most.
         """
         if cpu_percent > 95 or memory_percent > 95 or disk_percent > 95:
             return NodeStatus.ERROR.value
 
-        # Issue #1604: Check for crash-looping services
-        if extra_data:
-            for svc in extra_data.get("discovered_services", []):
-                svc_name = svc.get("name", "")
-                if not svc_name.startswith("autobot"):
-                    continue
-                if svc.get("status") == "crash-loop":
-                    return NodeStatus.DEGRADED.value
-                n_restarts = svc.get("n_restarts", 0)
-                if n_restarts > 3:
-                    return NodeStatus.DEGRADED.value
+        if _service_health_degraded(extra_data, restart_increase_detected):
+            return NodeStatus.DEGRADED.value
 
         if cpu_percent > 80 or memory_percent > 80 or disk_percent > 80:
             return NodeStatus.DEGRADED.value

--- a/autobot-slm-backend/services/reconciler.py
+++ b/autobot-slm-backend/services/reconciler.py
@@ -22,7 +22,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from autobot_shared.env_utils import env_int_clamped
 from autobot_shared.http_client import get_http_client
-from autobot_shared.time_utils import utc_timestamp
+from autobot_shared.time_utils import parse_utc_iso, utc_timestamp
 from config import settings
 from models.database import (
     Deployment,
@@ -80,15 +80,45 @@ SERVICE_REMEDIATION_COOLDOWN = 120  # 2 minutes
 # Maximum service restart attempts before requiring human intervention
 MAX_SERVICE_RESTART_ATTEMPTS = 3
 
+# #14465 review: how long a service is reported as CHURNING after its last
+# observed `n_restarts` increase. Must be comfortably larger than health_
+# collector's own `discover_all_services()` cache TTL (300s,
+# `slm/agent/health_collector.py:_SERVICE_DISCOVERY_TTL`) -- against a 30s
+# heartbeat, 9 of every 10 beats otherwise carry a byte-identical cached
+# snapshot, so a bare "did it change since the immediately preceding
+# heartbeat" pulse only fires on the ~1 beat in 10 where the cache actually
+# refreshed (measured: 1 of 20 degraded across continuous churn, vs 20 of 20
+# on the absolute threshold this replaced -- the node flapped ONLINE/DEGRADED
+# every 5 minutes instead of staying DEGRADED). A level -- degrade while
+# `now - last_increase < window` -- reports whether the node is CURRENTLY
+# churning, which is what a status field means, instead of whether THIS
+# SPECIFIC sample happened to land on a cache refresh.
+#
+# Twice the discovery TTL: guarantees the window spans at least one full
+# cache-refresh cycle, so a service that is genuinely still churning re-arms
+# the window (a fresh increase observed within it) before the earlier arming
+# closes, keeping DEGRADED continuous throughout sustained churn. The
+# trade-off this makes explicit: a single benign restart (one OOM kill, one
+# dependency flap) now degrades the node for the whole window and stands a
+# real chance of triggering one ansible restart via remediation, where the
+# absolute threshold it replaced made that same trade unboundedly (forever,
+# once n_restarts crossed 3) rather than for one bounded window.
+RESTART_CHURN_WINDOW_S = env_int_clamped("AUTOBOT_RESTART_CHURN_WINDOW_S", 600, min_v=1)
+
 
 def _restart_count_increased(svc_data: dict, previous_extra: dict) -> bool:
     """Did a managed service's `n_restarts` rise since the last heartbeat?
 
-    Helper for ReconcilerService._update_existing_service (#14465). Compares
-    against the immediately preceding heartbeat's stored value, never an
-    absolute threshold -- `NRestarts` is lifetime-cumulative, so a static gate
-    on it can never self-heal (see `_calculate_node_status`'s docstring).
-    Module-level and pure so it stays testable without a DB or a class instance.
+    Helper for `_restart_churn_active`. Compares against the immediately
+    preceding heartbeat's stored value, never an absolute threshold --
+    `NRestarts` is lifetime-cumulative for as long as a unit keeps failing
+    (systemd resets it on the next clean manual start once a unit settles,
+    not merely with the passage of time), so a static gate on it can never
+    self-heal on its own (see `_calculate_node_status`'s docstring). A
+    decrease (e.g. that reset, or a reboot) is deliberately not itself a
+    signal here -- only a rise arms the churn window; `_update_existing_
+    service` still rewrites the stored baseline to the new, lower value
+    either way, so a later rise compares against the post-reset count.
     """
     if not is_managed_autobot_service(svc_data):
         return False
@@ -99,14 +129,54 @@ def _restart_count_increased(svc_data: dict, previous_extra: dict) -> bool:
     return current > previous
 
 
-def _service_health_degraded(extra_data: dict | None, restart_increase_detected: bool) -> bool:
+def _restart_churn_active(svc_data: dict, previous_extra: dict, now: datetime) -> tuple[bool, str | None]:
+    """Is a managed service CURRENTLY churning, and what timestamp to persist for it?
+
+    Helper for `ReconcilerService._update_existing_service` (#14465 review: a
+    pulse -- "did it change since the immediately preceding heartbeat" -- is
+    the wrong shape for a status field; see `RESTART_CHURN_WINDOW_S`). Tracks
+    the timestamp of the last OBSERVED increase and reports "churning" for
+    `RESTART_CHURN_WINDOW_S` afterward -- a level.
+
+    First-ever observation (no previous `n_restarts` to compare against, the
+    `_create_new_service` path) is honestly `(False, None)`: there is no rate
+    information yet on a service just discovered, or a row `_remove_stale_
+    services` deleted and the agent re-reported. The next observed increase
+    arms the window. Acceptable rather than a regression here specifically
+    because the signal is a level: a service that is GENUINELY still
+    churning will produce that next increase within one heartbeat interval,
+    not eventually -- unlike the absolute threshold this replaced, which had
+    no such excuse for missing an already-churning service on first sight.
+
+    Returns `(is_churning_now, last_increase_iso_to_persist)`.
+    """
+    if not is_managed_autobot_service(svc_data):
+        return False, previous_extra.get("n_restarts_increased_at")
+
+    last_increase_iso = previous_extra.get("n_restarts_increased_at")
+    if _restart_count_increased(svc_data, previous_extra):
+        last_increase_iso = now.isoformat()
+
+    if last_increase_iso is None:
+        return False, None
+
+    try:
+        last_increase_at = parse_utc_iso(last_increase_iso)
+    except (TypeError, ValueError):
+        return False, None
+
+    is_churning = (now - last_increase_at).total_seconds() < RESTART_CHURN_WINDOW_S
+    return is_churning, last_increase_iso
+
+
+def _service_health_degraded(extra_data: dict | None, restart_churn_active: bool) -> bool:
     """The two current-state service signals `_calculate_node_status` acts on.
 
-    Module-level and pure: `restart_increase_detected` is computed elsewhere
+    Module-level and pure: `restart_churn_active` is computed elsewhere
     (against the OLD `Service` row this function does not have); this only
     combines it with the current-heartbeat status scan.
     """
-    if restart_increase_detected:
+    if restart_churn_active:
         return True
     if not extra_data:
         return False
@@ -1230,8 +1300,8 @@ class ReconcilerService:
 
         Helper for update_node_heartbeat (Issue #665).
 
-        Returns whether a managed service's restart count increased since the
-        last heartbeat (#14465), for `_calculate_node_status` to act on.
+        Returns whether a managed service is CURRENTLY churning (#14465), for
+        `_calculate_node_status` to act on.
         """
         node.cpu_percent = cpu_percent
         node.memory_percent = memory_percent
@@ -1334,7 +1404,7 @@ class ReconcilerService:
         if not node:
             return None
 
-        restart_increase_detected = await self._update_node_metrics(
+        restart_churn_active = await self._update_node_metrics(
             db,
             node,
             cpu_percent,
@@ -1347,7 +1417,7 @@ class ReconcilerService:
 
         old_status = node.status
         new_status = self._calculate_node_status(
-            cpu_percent, memory_percent, disk_percent, extra_data, restart_increase_detected
+            cpu_percent, memory_percent, disk_percent, extra_data, restart_churn_active
         )
 
         await self._handle_node_status_change(
@@ -1375,12 +1445,13 @@ class ReconcilerService:
 
         Helper for _upsert_service. Ref: #1088.
 
-        Returns whether THIS heartbeat shows a managed service's restart
-        count higher than the value stored from the previous one (#14465).
-        Computed here, not in `_calculate_node_status`, because only this
-        call site holds the OLD `Service` row before it gets overwritten.
+        Returns whether this managed service is CURRENTLY churning -- its
+        restart count rose within the last `RESTART_CHURN_WINDOW_S` (#14465),
+        a level rather than a pulse. Computed here, not in
+        `_calculate_node_status`, because only this call site holds the OLD
+        `Service` row before it gets overwritten.
         """
-        restart_increased = _restart_count_increased(svc_data, service.extra_data or {})
+        is_churning, last_increase_iso = _restart_churn_active(svc_data, service.extra_data or {}, now)
 
         service.status = status
         service.active_state = svc_data.get("active_state")
@@ -1390,6 +1461,12 @@ class ReconcilerService:
         service.enabled = svc_data.get("enabled", False)
         service.description = svc_data.get("description")
         service.last_checked = now
+        # #14465 review: a genuine COPY, not `service.extra_data or {}` handed
+        # straight back. SQLAlchemy's Column(JSON) does not reliably flag a
+        # reassignment dirty when it is the SAME object mutated in place and
+        # written back to itself -- silently dropping every field this method
+        # sets, `n_restarts`/`n_restarts_increased_at` included. Load-bearing
+        # for the delta: do not "simplify" this back to the old form.
         existing_extra = dict(service.extra_data or {})
         if error_msg:
             existing_extra["error_message"] = error_msg
@@ -1398,8 +1475,9 @@ class ReconcilerService:
         existing_extra.update(engine_degraded_fields(svc_data))
         if "n_restarts" in svc_data:
             existing_extra["n_restarts"] = svc_data["n_restarts"]
+        existing_extra["n_restarts_increased_at"] = last_increase_iso
         service.extra_data = existing_extra
-        return restart_increased
+        return is_churning
 
     def _create_new_service(
         self,
@@ -1415,7 +1493,10 @@ class ReconcilerService:
         Helper for _upsert_service. Ref: #1088.
 
         Stores `n_restarts` so the NEXT heartbeat has something to compare
-        against (#14465) -- a first observation is never itself a delta.
+        against (#14465) -- a first observation genuinely has no rate
+        information yet, so `n_restarts_increased_at` is deliberately left
+        unset here rather than backfilled; the next observed increase arms
+        the churn window (see `_restart_churn_active`).
         """
         category = categorize_service(service_name)
         if "n_restarts" in svc_data:
@@ -1446,8 +1527,8 @@ class ReconcilerService:
 
         Helper for _sync_discovered_services. Ref: #1088.
 
-        Returns whether this service is managed and its restart count
-        increased since the last heartbeat (#14465).
+        Returns whether this service is managed and CURRENTLY churning --
+        see `_restart_churn_active` (#14465).
         """
         service_name = svc_data.get("name")
         if not service_name:
@@ -1519,24 +1600,23 @@ class ReconcilerService:
 
         Related to Issue #728.
 
-        Returns whether ANY managed service's restart count increased since
-        the last heartbeat (#14465).
+        Returns whether ANY managed service is CURRENTLY churning (#14465).
         """
         if not discovered_services:
             return False
 
         now = datetime.now(timezone.utc)
 
-        restart_increase_detected = False
+        any_churning = False
         for svc_data in discovered_services:
             if await self._upsert_service(db, node_id, svc_data, now):
-                restart_increase_detected = True
+                any_churning = True
 
         # Remove stale services no longer reported by the agent (#1018)
         await self._remove_stale_services(db, node_id, discovered_services)
 
         # Note: commit happens in the calling method (update_node_heartbeat)
-        return restart_increase_detected
+        return any_churning
 
     def _calculate_node_status(
         self,
@@ -1544,42 +1624,49 @@ class ReconcilerService:
         memory_percent: float,
         disk_percent: float,
         extra_data: dict | None = None,
-        restart_increase_detected: bool = False,
+        restart_churn_active: bool = False,
     ) -> str:
         """Calculate node status based on health metrics and services.
 
         Issue #1604: Also degrade if any autobot service is crash-looping.
 
         #14465: this used to degrade on `n_restarts > 3` -- systemd's
-        `NRestarts` read as a static absolute threshold. `NRestarts` is
-        lifetime-cumulative (never resets except at reboot or
-        `reset-failed`), so a static gate on it can only ever climb: once any
-        managed service anywhere in the node's uptime crossed 3 restarts --
-        one redeploy, one operator restart, one long-resolved crash-loop --
-        every future heartbeat was forced DEGRADED regardless of current
-        state, with no path back to ONLINE.
+        `NRestarts` read as a static absolute threshold. `NRestarts` climbs
+        for as long as a unit keeps failing (systemd resets it on the next
+        clean manual start once a unit settles, not merely with the passage
+        of time), so a static gate on it can climb past 3 and never come back
+        down on its own: once any managed service anywhere in the node's
+        uptime crossed 3 restarts -- one redeploy, one operator restart, one
+        long-resolved crash-loop -- every future heartbeat was forced
+        DEGRADED regardless of current state, with no path back to ONLINE.
 
         Replaced with two signals over the SAME field, each answering a
         different question a static threshold cannot:
 
-        - `restart_increase_detected` (computed in `_update_existing_service`,
-          against the immediately preceding heartbeat's stored value, not an
-          absolute) catches a service CHURNING -- restarting faster than it
-          settles. `RestartSec` is typically far shorter than the heartbeat
-          interval, so most samples land on `"running"` between restarts; a
-          rising count between two consecutive heartbeats is what actually
-          proves instability there, regardless of what any single sample's
-          status says.
+        - `restart_churn_active` (computed in `_update_existing_service` via
+          `_restart_churn_active`) catches a service CHURNING -- restarting
+          faster than it settles. This is a LEVEL, not a pulse: it reports
+          "an increase was observed within the last `RESTART_CHURN_WINDOW_S`",
+          not "did it increase since the immediately-preceding heartbeat".
+          The latter was tried first and found to regress: health_collector's
+          own service-discovery sweep is cached for 300s
+          (`_SERVICE_DISCOVERY_TTL`) against a 30s heartbeat, so 9 of every 10
+          beats carry a byte-identical cached snapshot and a bare pulse only
+          fires on the ~1 in 10 that lands on a cache refresh -- measured, 1
+          of 20 beats degraded across continuous churn, and the node flapped
+          ONLINE/DEGRADED every 5 minutes instead of staying DEGRADED. See
+          `RESTART_CHURN_WINDOW_S` for the window and its own trade-offs.
         - `status == "failed"` (below) catches a service that has SETTLED --
           every unit template sets `StartLimitBurst`/`StartLimitIntervalSec`
           (#4090), so a real, ongoing crash loop eventually reaches systemd's
-          designed end state and stops restarting altogether. A pure delta
-          goes quiet the moment `NRestarts` stops climbing, so this half
-          would go blind exactly when the first stopped.
+          designed end state and stops restarting altogether. Neither a pulse
+          nor the level above catches this alone: both go quiet once
+          `NRestarts` stops climbing, exactly when a settled service needs
+          catching most.
 
         Both are scoped by `is_managed_autobot_service` (autobot*-prefixed
-        service names, or `slm-agent` itself, that are systemd-`enabled` on
-        THIS node) rather than `extra_data["services"]`
+        service names, or `slm-agent` itself, NOT explicitly disabled in
+        systemd on THIS node) rather than `extra_data["services"]`
         (`slm_services_to_monitor`) -- that operator-declared set is `[]` by
         role default, is `[]` on at least one real inventory node, and never
         contains `slm-agent`, the one unit remediation actually restarts, so
@@ -1589,7 +1676,7 @@ class ReconcilerService:
         if cpu_percent > 95 or memory_percent > 95 or disk_percent > 95:
             return NodeStatus.ERROR.value
 
-        if _service_health_degraded(extra_data, restart_increase_detected):
+        if _service_health_degraded(extra_data, restart_churn_active):
             return NodeStatus.DEGRADED.value
 
         if cpu_percent > 80 or memory_percent > 80 or disk_percent > 80:

--- a/autobot-slm-backend/services/reconciler.py
+++ b/autobot-slm-backend/services/reconciler.py
@@ -22,6 +22,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from autobot_shared.env_utils import env_int_clamped
 from autobot_shared.http_client import get_http_client
+from autobot_shared.service_discovery import SERVICE_DISCOVERY_TTL_S
 from autobot_shared.time_utils import parse_utc_iso, utc_timestamp
 from config import settings
 from models.database import (
@@ -82,9 +83,9 @@ MAX_SERVICE_RESTART_ATTEMPTS = 3
 
 # #14465 review: how long a service is reported as CHURNING after its last
 # observed `n_restarts` increase. Must be comfortably larger than health_
-# collector's own `discover_all_services()` cache TTL (300s,
-# `slm/agent/health_collector.py:_SERVICE_DISCOVERY_TTL`) -- against a 30s
-# heartbeat, 9 of every 10 beats otherwise carry a byte-identical cached
+# collector's own `discover_all_services()` cache TTL
+# (`autobot_shared.service_discovery.SERVICE_DISCOVERY_TTL_S`) -- against a
+# 30s heartbeat, 9 of every 10 beats otherwise carry a byte-identical cached
 # snapshot, so a bare "did it change since the immediately preceding
 # heartbeat" pulse only fires on the ~1 beat in 10 where the cache actually
 # refreshed (measured: 1 of 20 degraded across continuous churn, vs 20 of 20
@@ -94,16 +95,24 @@ MAX_SERVICE_RESTART_ATTEMPTS = 3
 # churning, which is what a status field means, instead of whether THIS
 # SPECIFIC sample happened to land on a cache refresh.
 #
-# Twice the discovery TTL: guarantees the window spans at least one full
-# cache-refresh cycle, so a service that is genuinely still churning re-arms
-# the window (a fresh increase observed within it) before the earlier arming
-# closes, keeping DEGRADED continuous throughout sustained churn. The
-# trade-off this makes explicit: a single benign restart (one OOM kill, one
-# dependency flap) now degrades the node for the whole window and stands a
-# real chance of triggering one ansible restart via remediation, where the
-# absolute threshold it replaced made that same trade unboundedly (forever,
-# once n_restarts crossed 3) rather than for one bounded window.
-RESTART_CHURN_WINDOW_S = env_int_clamped("AUTOBOT_RESTART_CHURN_WINDOW_S", 600, min_v=1)
+# min_v is DERIVED from SERVICE_DISCOVERY_TTL_S, not a second hardcoded
+# literal: an earlier version of this fix hardcoded `min_v=1`, and measured
+# with the TTL at its own default, every window from 1 to 271 seconds
+# restored the pulse-flapping regression this replaces -- a bare literal
+# gives no warning when the agent-side TTL changes out from under it (raising
+# the TTL to 900 would make the unrelated 600s DEFAULT flap too). Twice the
+# TTL guarantees the window spans at least one full cache-refresh cycle, so a
+# service that is genuinely still churning re-arms the window (a fresh
+# increase observed within it) before the earlier arming closes, keeping
+# DEGRADED continuous throughout sustained churn. The trade-off this makes
+# explicit: a single benign restart (one OOM kill, one dependency flap) now
+# degrades the node for the whole window and stands a real chance of
+# triggering one ansible restart via remediation, where the absolute
+# threshold it replaced made that same trade unboundedly (forever, once
+# n_restarts crossed 3) rather than for one bounded window.
+RESTART_CHURN_WINDOW_S = env_int_clamped(
+    "AUTOBOT_RESTART_CHURN_WINDOW_S", 600, min_v=SERVICE_DISCOVERY_TTL_S * 2 + 1
+)
 
 
 def _restart_count_increased(svc_data: dict, previous_extra: dict) -> bool:
@@ -1529,6 +1538,17 @@ class ReconcilerService:
 
         Returns whether this service is managed and CURRENTLY churning --
         see `_restart_churn_active` (#14465).
+
+        #14465 review: the broad `except Exception` below (pre-existing --
+        Ref #1088 -- kept broad so one service's sync failure never aborts
+        the whole heartbeat) also swallows a transient failure of the row
+        SELECT itself, not just the upsert logic after it. On that beat this
+        returns `False` ("not churning") regardless of the service's real
+        state -- the churn signal is a function of DB availability for that
+        one heartbeat, not just of the service. Self-healing (the next
+        heartbeat tries again, and the level design means one missed beat
+        does not by itself end an already-armed window), but not something
+        this fix eliminates.
         """
         service_name = svc_data.get("name")
         if not service_name:

--- a/autobot-slm-backend/services/reconciler_status_restart_delta_14465_test.py
+++ b/autobot-slm-backend/services/reconciler_status_restart_delta_14465_test.py
@@ -6,34 +6,45 @@
 
 `_calculate_node_status` degraded on `n_restarts > 3` -- systemd's `NRestarts`
 property, read in `health_collector._get_service_details` -- treated as a
-static absolute threshold. `NRestarts` is lifetime-cumulative: systemd never
-resets it except at reboot or `systemctl reset-failed`. Used as a static gate,
-it can only ever climb: once any managed service anywhere in a node's uptime
-crossed 3 restarts, every future heartbeat computed DEGRADED regardless of
-current metrics or the service's current state, with no path back to ONLINE.
+static absolute threshold. `NRestarts` climbs for as long as a unit keeps
+failing (systemd resets it on the next clean manual start once a unit settles,
+not merely with the passage of time), so a static gate on it can climb past 3
+and never come back down on its own: once any managed service anywhere in a
+node's uptime crossed 3 restarts, every future heartbeat computed DEGRADED
+regardless of current metrics or the service's current state.
 
-Review of two earlier versions of this fix found real regressions:
+Review found regressions in two earlier versions of this fix:
 
 1. Dropping `n_restarts > 3` in favour of `status == "failed"` alone lost the
    CHURNING shape -- a service restarting faster than the heartbeat samples
-   it (`RestartSec` typically well under the heartbeat interval) reads
-   `"running"` on most samples and never reaches `"failed"` at all while it
+   it reads `"running"` on most samples and never reaches `"failed"` while it
    is actively unstable.
 2. The restored `status == "failed"` check, scoped to `extra_data["services"]`
    (`slm_services_to_monitor`), is dark on most of a fleet: that operator
    -declared set is `[]` by role default, `[]` on at least one real inventory
-   node, and never contains `slm-agent` -- the one unit remediation actually
-   restarts.
+   node, and never contains `slm-agent`.
+3. A THIRD round replaced the absolute threshold with a bare DELTA ("did
+   `n_restarts` rise since the immediately preceding heartbeat") -- still a
+   regression, just subtler: `health_collector`'s own service-discovery sweep
+   is cached for 300s against a 30s heartbeat, so 9 of every 10 beats carry a
+   byte-identical cached snapshot. Measured: 1 of 20 beats degraded across
+   continuous churn, and the node flapped ONLINE/DEGRADED every 5 minutes
+   instead of staying DEGRADED. A pulse tells you an increase happened; a
+   level tells you the node is CURRENTLY churning, which is what a status
+   field means.
 
-This fix replaces the absolute threshold with a DELTA -- `n_restarts` rising
-since the immediately preceding heartbeat, persisted per service on
-`Service.extra_data` -- which catches the churning shape without needing any
-single sample to land on a particular status string, kept alongside
-`status == "failed"` for the shape that has already settled and stopped
-restarting altogether (a delta alone goes quiet the moment `NRestarts` stops
-climbing). Both are scoped by `is_managed_autobot_service`
+This fix (`_restart_churn_active`) persists the TIMESTAMP of the last observed
+increase and reports churning while `now - last_increase < RESTART_CHURN_
+WINDOW_S` -- a level, comfortably larger than the 300s discovery cache TTL --
+kept alongside `status == "failed"` for the shape that has already settled and
+stopped restarting altogether (a level still goes quiet once `NRestarts` stops
+climbing for long enough; only the CURRENT status string catches "stayed
+dead"). Both signals are scoped by `is_managed_autobot_service`
 (`services/service_extra_data.py`): `autobot*`-prefixed or `slm-agent` itself,
-AND systemd-`enabled` on this node -- not the monitored-services list.
+NOT explicitly disabled in systemd -- not `enabled` alone (which excludes
+`static`/`indirect`/`enabled-runtime`/`generated`/`alias`, invisible-forever
+units like `autobot-key-rotation`/`autobot-pg-backup`), and not the
+monitored-services list.
 
 The module is loaded from disk, not imported, because the package conftest
 stubs `services.*` and a plain `import services.reconciler` yields a
@@ -46,7 +57,7 @@ import asyncio
 import importlib.util
 import inspect
 import sys
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -72,10 +83,10 @@ reconciler = _load_real_reconciler()
 _CPU, _MEM, _DISK = 0.0, 23.4, 18.1
 
 
-def _status(extra_data=None, restart_increase_detected=False) -> str:
+def _status(extra_data=None, restart_churn_active=False) -> str:
     """Call the real `_calculate_node_status` -- it does not touch `self`."""
     return reconciler.ReconcilerService._calculate_node_status(
-        SimpleNamespace(), _CPU, _MEM, _DISK, extra_data, restart_increase_detected
+        SimpleNamespace(), _CPU, _MEM, _DISK, extra_data, restart_churn_active
     )
 
 
@@ -83,68 +94,42 @@ def test_the_real_module_was_loaded_not_a_stub():
     """`hasattr`/`callable` are true of any MagicMock and cannot tell the two apart."""
     assert not isinstance(reconciler.ReconcilerService, MagicMock)
     assert inspect.isfunction(reconciler.ReconcilerService._calculate_node_status)
+    assert inspect.isfunction(reconciler.ReconcilerService._update_existing_service)
 
 
 def test_a_service_that_restarted_long_ago_but_is_now_running_is_not_degraded():
     """The original defect, reproduced directly.
 
     `autobot-vnc` crossed several restarts at some point in the node's uptime
-    and is presently `status: "running"` with NO fresh delta this heartbeat.
+    and is presently `status: "running"` with no active churn this heartbeat.
     Healthy metrics, no active instability: this must be ONLINE.
     """
     extra_data = {
-        "discovered_services": [{"name": "autobot-vnc", "status": "running", "n_restarts": 5, "enabled": True}]
+        "discovered_services": [
+            {"name": "autobot-vnc", "status": "running", "n_restarts": 5, "unit_file_state": "static"}
+        ]
     }
 
-    assert _status(extra_data, restart_increase_detected=False) == reconciler.NodeStatus.ONLINE.value, (
+    assert _status(extra_data, restart_churn_active=False) == reconciler.NodeStatus.ONLINE.value, (
         "a service with an old, non-advancing restart count pinned the node DEGRADED forever (#14465)"
     )
 
 
-def test_a_churning_service_degrades_via_the_restart_delta_not_an_absolute():
-    """Review's exact counter-example: `{"status": "running", "n_restarts": 47}`.
-
-    A slow-churning service samples as "running" on most heartbeats
-    (RestartSec well under the heartbeat interval) and would never trip a
-    `status == "failed"`-only check. The delta -- computed elsewhere, against
-    the previous heartbeat's stored value, and passed in here -- is what must
-    degrade the node, independent of the absolute `n_restarts` value.
+def test_a_settled_failed_service_still_degrades_with_no_active_churn():
+    """The shape a churn window alone would eventually miss: `NRestarts`
+    stopped climbing because systemd's own `StartLimitBurst`/
+    `StartLimitIntervalSec` (#4090) gave up and parked the unit at `"failed"`
+    -- its designed end state for a real, sustained crash loop, not
+    `"crash-loop"` (`_map_status_from_states` never maps to that string for
+    `failed`).
     """
     extra_data = {
-        "discovered_services": [{"name": "autobot-vnc", "status": "running", "n_restarts": 47, "enabled": True}]
+        "discovered_services": [
+            {"name": "autobot-vnc", "status": "failed", "n_restarts": 8, "unit_file_state": "static"}
+        ]
     }
 
-    assert _status(extra_data, restart_increase_detected=True) == reconciler.NodeStatus.DEGRADED.value
-
-
-def test_a_single_fresh_restart_degrades_even_below_the_old_absolute_threshold():
-    """Discriminates directly against the deleted `n_restarts > 3` branch.
-
-    `n_restarts: 1` would never have tripped `n_restarts > 3` on `origin/
-    Dev_new_gui` no matter what `restart_increase_detected` says -- this
-    fails against that code path and passes only against the delta-based one.
-    """
-    extra_data = {
-        "discovered_services": [{"name": "autobot-vnc", "status": "running", "n_restarts": 1, "enabled": True}]
-    }
-
-    assert _status(extra_data, restart_increase_detected=True) == reconciler.NodeStatus.DEGRADED.value, (
-        "a fresh restart must degrade immediately, not wait for an arbitrary absolute count"
-    )
-
-
-def test_a_settled_failed_service_still_degrades_with_no_fresh_delta():
-    """The shape a delta alone would miss: `NRestarts` stopped climbing because
-    systemd's own `StartLimitBurst`/`StartLimitIntervalSec` (#4090) gave up and
-    parked the unit at `"failed"` -- its designed end state for a real,
-    sustained crash loop, not `"crash-loop"` (`_map_status_from_states` never
-    maps to that string for `failed`).
-    """
-    extra_data = {
-        "discovered_services": [{"name": "autobot-vnc", "status": "failed", "n_restarts": 8, "enabled": True}]
-    }
-
-    assert _status(extra_data, restart_increase_detected=False) == reconciler.NodeStatus.DEGRADED.value
+    assert _status(extra_data, restart_churn_active=False) == reconciler.NodeStatus.DEGRADED.value
 
 
 def test_a_presently_crash_looping_service_still_degrades_the_node():
@@ -155,7 +140,9 @@ def test_a_presently_crash_looping_service_still_degrades_the_node():
     sample time.
     """
     extra_data = {
-        "discovered_services": [{"name": "autobot-vnc", "status": "crash-loop", "n_restarts": 1, "enabled": True}]
+        "discovered_services": [
+            {"name": "autobot-vnc", "status": "crash-loop", "n_restarts": 1, "unit_file_state": "static"}
+        ]
     }
 
     assert _status(extra_data) == reconciler.NodeStatus.DEGRADED.value
@@ -166,21 +153,43 @@ def test_slm_agent_itself_is_in_scope():
     is the one unit remediation actually restarts. It must not be permanently
     excluded from every degrade signal just because of its name.
     """
-    extra_data = {"discovered_services": [{"name": "slm-agent", "status": "failed", "n_restarts": 4, "enabled": True}]}
+    extra_data = {
+        "discovered_services": [
+            {"name": "slm-agent", "status": "failed", "n_restarts": 4, "unit_file_state": "enabled"}
+        ]
+    }
 
     assert _status(extra_data) == reconciler.NodeStatus.DEGRADED.value
 
 
-def test_a_disabled_non_primary_autobot_unit_never_false_positives():
+def test_a_static_unit_with_no_install_section_is_still_in_scope():
+    """Review: `UnitFileState == "enabled"` alone excludes `static` units --
+    `autobot-key-rotation.service.j2`/`autobot-pg-backup.service.j2` have no
+    `[Install]` section and are `static` forever. Gating on "not explicitly
+    disabled" instead must still catch a `static` unit that is `"failed"`.
+    """
+    extra_data = {
+        "discovered_services": [
+            {"name": "autobot-key-rotation", "status": "failed", "n_restarts": 1, "unit_file_state": "static"}
+        ]
+    }
+
+    assert _status(extra_data) == reconciler.NodeStatus.DEGRADED.value
+
+
+def test_an_explicitly_disabled_unit_never_false_positives():
     """#1709, restated against the new scope.
 
     `autobot-vnc` failed on a node where VNC was never installed
-    (`install_vnc` unset, so the unit stays `enabled: false`) must not
-    degrade the node -- exactly the false positive #1709 existed to prevent,
-    now derived from `enabled` rather than a monitored-services list.
+    (`install_vnc` unset, so the unit stays `UnitFileState: "disabled"`) must
+    not degrade the node -- exactly the false positive #1709 existed to
+    prevent, now derived from "not explicitly disabled" rather than a
+    monitored-services list or an `enabled`-only gate.
     """
     extra_data = {
-        "discovered_services": [{"name": "autobot-vnc", "status": "failed", "n_restarts": 1, "enabled": False}]
+        "discovered_services": [
+            {"name": "autobot-vnc", "status": "failed", "n_restarts": 1, "unit_file_state": "disabled"}
+        ]
     }
 
     assert _status(extra_data) == reconciler.NodeStatus.ONLINE.value
@@ -188,7 +197,11 @@ def test_a_disabled_non_primary_autobot_unit_never_false_positives():
 
 def test_a_non_autobot_service_never_mattered_regardless_of_state():
     """Scope guard: only managed autobot/slm-agent units are in play."""
-    extra_data = {"discovered_services": [{"name": "sshd", "status": "failed", "n_restarts": 50, "enabled": True}]}
+    extra_data = {
+        "discovered_services": [
+            {"name": "sshd", "status": "failed", "n_restarts": 50, "unit_file_state": "enabled"}
+        ]
+    }
 
     assert _status(extra_data) == reconciler.NodeStatus.ONLINE.value
 
@@ -204,6 +217,89 @@ def test_high_metrics_still_win_over_a_clean_service_list():
         reconciler.ReconcilerService._calculate_node_status(SimpleNamespace(), 85.0, 0.0, 0.0, None, False)
         == reconciler.NodeStatus.DEGRADED.value
     )
+
+
+# ---------------------------------------------------------------------------
+# `_restart_churn_active` / `_update_existing_service` executed directly.
+#
+# Review: the churn signal being TRUE or FALSE is not itself interesting to
+# assert on in isolation -- passing `restart_churn_active=True` straight into
+# `_calculate_node_status` only exercises `_service_health_degraded`'s first
+# `if`, which is true by construction. What must be tested is whether the
+# REAL computation (against a real, persisted previous row) produces that
+# value in the first place. These tests call the real, module-level
+# `_restart_churn_active` and the real `_update_existing_service`.
+# ---------------------------------------------------------------------------
+
+
+def test_a_fresh_increase_arms_the_churn_window():
+    """Discriminates directly against the deleted `n_restarts > 3` branch AND
+    against a bare pulse: `n_restarts: 1` (up from a stored 0) would never
+    have tripped `n_restarts > 3` on `origin/Dev_new_gui`, and the real
+    `_restart_churn_active` -- not a hand-fed boolean -- is what must detect
+    the rise.
+    """
+    svc_data = {"name": "autobot-vnc", "status": "running", "n_restarts": 1, "unit_file_state": "static"}
+    now = datetime.now(timezone.utc)
+
+    churning, last_increase_iso = reconciler._restart_churn_active(svc_data, {"n_restarts": 0}, now)
+
+    assert churning is True, "a fresh restart must arm the churn window, not wait for an arbitrary absolute count"
+    assert last_increase_iso is not None
+
+
+def test_a_second_consecutive_beat_with_an_unchanged_count_still_reports_churning():
+    """The level/pulse distinction itself -- one of the two tests review named
+    as missing. A service armed the window on a prior beat; THIS beat shows
+    no new increase (the discovery cache had not refreshed). Under the
+    deleted pulse design this would report `False`; the level must still
+    report `True` while within `RESTART_CHURN_WINDOW_S`, and must NOT re-arm
+    the window with a fresh timestamp on a beat that added nothing new.
+    """
+    t0 = datetime.now(timezone.utc)
+    armed_svc = {"name": "autobot-vnc", "status": "running", "n_restarts": 10, "unit_file_state": "static"}
+    churning_t0, last_increase_t0 = reconciler._restart_churn_active(armed_svc, {"n_restarts": 5}, t0)
+    assert churning_t0 is True, "sanity: the first beat must arm the window"
+
+    t1 = t0 + timedelta(seconds=30)
+    unchanged_svc = {"name": "autobot-vnc", "status": "running", "n_restarts": 10, "unit_file_state": "static"}
+    previous_extra = {"n_restarts": 10, "n_restarts_increased_at": last_increase_t0}
+    churning_t1, last_increase_t1 = reconciler._restart_churn_active(unchanged_svc, previous_extra, t1)
+
+    assert churning_t1 is True, "an unchanged count must still report churning while inside the armed window"
+    assert last_increase_t1 == last_increase_t0, "an unchanged count must not re-arm the window with a new timestamp"
+
+
+def test_the_churn_window_eventually_closes_for_a_single_benign_restart():
+    """A single restart (an OOM kill, a dependency flap) must not degrade the
+    node forever -- only for `RESTART_CHURN_WINDOW_S`. This is the trade this
+    fix makes explicit in place of the absolute threshold's unbounded one.
+    """
+    t0 = datetime.now(timezone.utc)
+    svc_data = {"name": "autobot-vnc", "status": "running", "n_restarts": 10, "unit_file_state": "static"}
+    _, last_increase = reconciler._restart_churn_active(svc_data, {"n_restarts": 5}, t0)
+
+    far_future = t0 + timedelta(seconds=reconciler.RESTART_CHURN_WINDOW_S + 30)
+    previous_extra = {"n_restarts": 10, "n_restarts_increased_at": last_increase}
+    still_churning, _ = reconciler._restart_churn_active(svc_data, previous_extra, far_future)
+
+    assert still_churning is False, "the churn window must close -- a single restart cannot degrade the node forever"
+
+
+def test_a_churning_payload_with_no_prior_row_does_not_fabricate_a_signal():
+    """The second test review named as missing: first-ever observation (a
+    node registering, a row `_remove_stale_services` deleted and the agent
+    re-reported, or a restored manager DB) genuinely has no rate information.
+    Honestly reports "not churning" rather than guessing -- the accepted
+    trade-off for a LEVEL signal (the next real increase arms the window),
+    unlike a static absolute threshold which had no such excuse.
+    """
+    svc_data = {"name": "autobot-vnc", "status": "running", "n_restarts": 47, "unit_file_state": "static"}
+
+    churning, last_increase_iso = reconciler._restart_churn_active(svc_data, {}, datetime.now(timezone.utc))
+
+    assert churning is False
+    assert last_increase_iso is None
 
 
 class _ServiceRow:
@@ -234,7 +330,7 @@ class _SeededServiceHeartbeatSession:
 
     The FIRST `execute()` is `_find_node_by_id_or_hostname`'s node lookup.
     The SECOND is `_upsert_service`'s existing-row lookup -- returns the
-    seeded `_ServiceRow`, taking the update path where the delta lives.
+    seeded `_ServiceRow`, taking the update path where the churn signal lives.
     Every later call (`_remove_stale_services`'s stale-service scan) resolves
     to "nothing found".
     """
@@ -263,15 +359,18 @@ class _SeededServiceHeartbeatSession:
 
 
 def test_a_churning_service_degrades_across_a_real_heartbeat_against_its_prior_row():
-    """The full path, not `_calculate_node_status` in isolation.
+    """The full path, not `_calculate_node_status` or `_restart_churn_active`
+    in isolation.
 
     A `Service` row already on record from a PRIOR heartbeat shows
     `n_restarts: 44`. This heartbeat reports `n_restarts: 47`, still
-    `"running"` -- the exact review counter-example -- and must transition
-    the node to DEGRADED because `_update_existing_service` detects the rise
-    against that prior row, through the real `update_node_heartbeat` ->
-    `_update_node_metrics` -> `_sync_discovered_services` ->
-    `_upsert_service` -> `_calculate_node_status` chain.
+    `"running"` -- the review's original counter-example -- and must
+    transition the node to DEGRADED because `_update_existing_service`
+    detects the rise against that prior row, through the real
+    `update_node_heartbeat` -> `_update_node_metrics` ->
+    `_sync_discovered_services` -> `_upsert_service` ->
+    `_calculate_node_status` chain, and persists the churn timestamp for the
+    NEXT heartbeat to read.
     """
     node = SimpleNamespace(
         node_id="node-14465",
@@ -290,7 +389,9 @@ def test_a_churning_service_degrades_across_a_real_heartbeat_against_its_prior_r
     service = reconciler.ReconcilerService()
 
     this_beat = {
-        "discovered_services": [{"name": "autobot-vnc", "status": "running", "n_restarts": 47, "enabled": True}]
+        "discovered_services": [
+            {"name": "autobot-vnc", "status": "running", "n_restarts": 47, "unit_file_state": "static"}
+        ]
     }
 
     result = asyncio.run(service.update_node_heartbeat(session, node.node_id, _CPU, _MEM, _DISK, extra_data=this_beat))
@@ -299,3 +400,7 @@ def test_a_churning_service_degrades_across_a_real_heartbeat_against_its_prior_r
         "n_restarts rising from 44 to 47 against the prior heartbeat's row did not degrade the node"
     )
     assert seeded_service.extra_data.get("n_restarts") == 47, "the new count must be persisted for the NEXT heartbeat"
+    assert seeded_service.extra_data.get("n_restarts_increased_at") is not None, (
+        "the churn-arming timestamp must be persisted so the NEXT heartbeat can still report churning "
+        "even without a further increase (the pulse-to-level fix's whole point)"
+    )

--- a/autobot-slm-backend/services/reconciler_status_restart_delta_14465_test.py
+++ b/autobot-slm-backend/services/reconciler_status_restart_delta_14465_test.py
@@ -1,0 +1,301 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""A node stays degraded forever while heartbeating healthily (#14465, defect 1).
+
+`_calculate_node_status` degraded on `n_restarts > 3` -- systemd's `NRestarts`
+property, read in `health_collector._get_service_details` -- treated as a
+static absolute threshold. `NRestarts` is lifetime-cumulative: systemd never
+resets it except at reboot or `systemctl reset-failed`. Used as a static gate,
+it can only ever climb: once any managed service anywhere in a node's uptime
+crossed 3 restarts, every future heartbeat computed DEGRADED regardless of
+current metrics or the service's current state, with no path back to ONLINE.
+
+Review of two earlier versions of this fix found real regressions:
+
+1. Dropping `n_restarts > 3` in favour of `status == "failed"` alone lost the
+   CHURNING shape -- a service restarting faster than the heartbeat samples
+   it (`RestartSec` typically well under the heartbeat interval) reads
+   `"running"` on most samples and never reaches `"failed"` at all while it
+   is actively unstable.
+2. The restored `status == "failed"` check, scoped to `extra_data["services"]`
+   (`slm_services_to_monitor`), is dark on most of a fleet: that operator
+   -declared set is `[]` by role default, `[]` on at least one real inventory
+   node, and never contains `slm-agent` -- the one unit remediation actually
+   restarts.
+
+This fix replaces the absolute threshold with a DELTA -- `n_restarts` rising
+since the immediately preceding heartbeat, persisted per service on
+`Service.extra_data` -- which catches the churning shape without needing any
+single sample to land on a particular status string, kept alongside
+`status == "failed"` for the shape that has already settled and stopped
+restarting altogether (a delta alone goes quiet the moment `NRestarts` stops
+climbing). Both are scoped by `is_managed_autobot_service`
+(`services/service_extra_data.py`): `autobot*`-prefixed or `slm-agent` itself,
+AND systemd-`enabled` on this node -- not the monitored-services list.
+
+The module is loaded from disk, not imported, because the package conftest
+stubs `services.*` and a plain `import services.reconciler` yields a
+MagicMock that would satisfy every check here while exercising nothing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import inspect
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+_SLM_ROOT = Path(__file__).resolve().parent.parent
+if str(_SLM_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SLM_ROOT))
+
+
+def _load_real_reconciler():
+    spec = importlib.util.spec_from_file_location(
+        "reconciler_under_delta_status_test", _SLM_ROOT / "services" / "reconciler.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["reconciler_under_delta_status_test"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+reconciler = _load_real_reconciler()
+
+# Healthy metrics straight from the issue's evidence.
+_CPU, _MEM, _DISK = 0.0, 23.4, 18.1
+
+
+def _status(extra_data=None, restart_increase_detected=False) -> str:
+    """Call the real `_calculate_node_status` -- it does not touch `self`."""
+    return reconciler.ReconcilerService._calculate_node_status(
+        SimpleNamespace(), _CPU, _MEM, _DISK, extra_data, restart_increase_detected
+    )
+
+
+def test_the_real_module_was_loaded_not_a_stub():
+    """`hasattr`/`callable` are true of any MagicMock and cannot tell the two apart."""
+    assert not isinstance(reconciler.ReconcilerService, MagicMock)
+    assert inspect.isfunction(reconciler.ReconcilerService._calculate_node_status)
+
+
+def test_a_service_that_restarted_long_ago_but_is_now_running_is_not_degraded():
+    """The original defect, reproduced directly.
+
+    `autobot-vnc` crossed several restarts at some point in the node's uptime
+    and is presently `status: "running"` with NO fresh delta this heartbeat.
+    Healthy metrics, no active instability: this must be ONLINE.
+    """
+    extra_data = {
+        "discovered_services": [{"name": "autobot-vnc", "status": "running", "n_restarts": 5, "enabled": True}]
+    }
+
+    assert _status(extra_data, restart_increase_detected=False) == reconciler.NodeStatus.ONLINE.value, (
+        "a service with an old, non-advancing restart count pinned the node DEGRADED forever (#14465)"
+    )
+
+
+def test_a_churning_service_degrades_via_the_restart_delta_not_an_absolute():
+    """Review's exact counter-example: `{"status": "running", "n_restarts": 47}`.
+
+    A slow-churning service samples as "running" on most heartbeats
+    (RestartSec well under the heartbeat interval) and would never trip a
+    `status == "failed"`-only check. The delta -- computed elsewhere, against
+    the previous heartbeat's stored value, and passed in here -- is what must
+    degrade the node, independent of the absolute `n_restarts` value.
+    """
+    extra_data = {
+        "discovered_services": [{"name": "autobot-vnc", "status": "running", "n_restarts": 47, "enabled": True}]
+    }
+
+    assert _status(extra_data, restart_increase_detected=True) == reconciler.NodeStatus.DEGRADED.value
+
+
+def test_a_single_fresh_restart_degrades_even_below_the_old_absolute_threshold():
+    """Discriminates directly against the deleted `n_restarts > 3` branch.
+
+    `n_restarts: 1` would never have tripped `n_restarts > 3` on `origin/
+    Dev_new_gui` no matter what `restart_increase_detected` says -- this
+    fails against that code path and passes only against the delta-based one.
+    """
+    extra_data = {
+        "discovered_services": [{"name": "autobot-vnc", "status": "running", "n_restarts": 1, "enabled": True}]
+    }
+
+    assert _status(extra_data, restart_increase_detected=True) == reconciler.NodeStatus.DEGRADED.value, (
+        "a fresh restart must degrade immediately, not wait for an arbitrary absolute count"
+    )
+
+
+def test_a_settled_failed_service_still_degrades_with_no_fresh_delta():
+    """The shape a delta alone would miss: `NRestarts` stopped climbing because
+    systemd's own `StartLimitBurst`/`StartLimitIntervalSec` (#4090) gave up and
+    parked the unit at `"failed"` -- its designed end state for a real,
+    sustained crash loop, not `"crash-loop"` (`_map_status_from_states` never
+    maps to that string for `failed`).
+    """
+    extra_data = {
+        "discovered_services": [{"name": "autobot-vnc", "status": "failed", "n_restarts": 8, "enabled": True}]
+    }
+
+    assert _status(extra_data, restart_increase_detected=False) == reconciler.NodeStatus.DEGRADED.value
+
+
+def test_a_presently_crash_looping_service_still_degrades_the_node():
+    """Issue #1604's actual intent must survive this fix.
+
+    `status == "crash-loop"` reflects systemd's `activating`+`auto-restart`
+    sub-state -- true only while the unit is presently churning right at
+    sample time.
+    """
+    extra_data = {
+        "discovered_services": [{"name": "autobot-vnc", "status": "crash-loop", "n_restarts": 1, "enabled": True}]
+    }
+
+    assert _status(extra_data) == reconciler.NodeStatus.DEGRADED.value
+
+
+def test_slm_agent_itself_is_in_scope():
+    """#14465 review: `slm-agent` never matches `startswith("autobot")`, and it
+    is the one unit remediation actually restarts. It must not be permanently
+    excluded from every degrade signal just because of its name.
+    """
+    extra_data = {"discovered_services": [{"name": "slm-agent", "status": "failed", "n_restarts": 4, "enabled": True}]}
+
+    assert _status(extra_data) == reconciler.NodeStatus.DEGRADED.value
+
+
+def test_a_disabled_non_primary_autobot_unit_never_false_positives():
+    """#1709, restated against the new scope.
+
+    `autobot-vnc` failed on a node where VNC was never installed
+    (`install_vnc` unset, so the unit stays `enabled: false`) must not
+    degrade the node -- exactly the false positive #1709 existed to prevent,
+    now derived from `enabled` rather than a monitored-services list.
+    """
+    extra_data = {
+        "discovered_services": [{"name": "autobot-vnc", "status": "failed", "n_restarts": 1, "enabled": False}]
+    }
+
+    assert _status(extra_data) == reconciler.NodeStatus.ONLINE.value
+
+
+def test_a_non_autobot_service_never_mattered_regardless_of_state():
+    """Scope guard: only managed autobot/slm-agent units are in play."""
+    extra_data = {"discovered_services": [{"name": "sshd", "status": "failed", "n_restarts": 50, "enabled": True}]}
+
+    assert _status(extra_data) == reconciler.NodeStatus.ONLINE.value
+
+
+def test_high_metrics_still_win_over_a_clean_service_list():
+    """The metric thresholds this fix must not touch."""
+    assert _status(None) == reconciler.NodeStatus.ONLINE.value
+    assert (
+        reconciler.ReconcilerService._calculate_node_status(SimpleNamespace(), 96.0, 0.0, 0.0, None, False)
+        == reconciler.NodeStatus.ERROR.value
+    )
+    assert (
+        reconciler.ReconcilerService._calculate_node_status(SimpleNamespace(), 85.0, 0.0, 0.0, None, False)
+        == reconciler.NodeStatus.DEGRADED.value
+    )
+
+
+class _ServiceRow:
+    """A stand-in `Service` ORM row -- only what `_update_existing_service` reads/writes.
+
+    `models.database.Service` is a stubbed `MagicMock` under the package
+    conftest, so a `Service(**kwargs)` constructor call (`_create_new_service`)
+    would not actually set attributes matching those kwargs on its return
+    value -- this fixture is used in place of that construction step, seeded
+    directly as the "previous heartbeat" row, so the update (not create) path
+    under test -- `_update_existing_service` -- runs against real data.
+    """
+
+    def __init__(self, extra_data=None):
+        self.status = None
+        self.active_state = None
+        self.sub_state = None
+        self.main_pid = None
+        self.memory_bytes = None
+        self.enabled = False
+        self.description = None
+        self.last_checked = None
+        self.extra_data = extra_data or {}
+
+
+class _SeededServiceHeartbeatSession:
+    """Drives `update_node_heartbeat` with ONE pre-seeded existing `Service` row.
+
+    The FIRST `execute()` is `_find_node_by_id_or_hostname`'s node lookup.
+    The SECOND is `_upsert_service`'s existing-row lookup -- returns the
+    seeded `_ServiceRow`, taking the update path where the delta lives.
+    Every later call (`_remove_stale_services`'s stale-service scan) resolves
+    to "nothing found".
+    """
+
+    def __init__(self, node, seeded_service: _ServiceRow):
+        self._node = node
+        self._seeded_service = seeded_service
+        self._reads = 0
+
+    async def execute(self, _query):
+        self._reads += 1
+        if self._reads == 1:
+            return SimpleNamespace(scalar_one_or_none=lambda: self._node)
+        if self._reads == 2:
+            return SimpleNamespace(scalar_one_or_none=lambda: self._seeded_service)
+        return SimpleNamespace(scalar_one_or_none=lambda: None, scalars=lambda: SimpleNamespace(all=lambda: []))
+
+    def add(self, _obj):
+        pass
+
+    async def commit(self):
+        pass
+
+    async def refresh(self, _obj):
+        pass
+
+
+def test_a_churning_service_degrades_across_a_real_heartbeat_against_its_prior_row():
+    """The full path, not `_calculate_node_status` in isolation.
+
+    A `Service` row already on record from a PRIOR heartbeat shows
+    `n_restarts: 44`. This heartbeat reports `n_restarts: 47`, still
+    `"running"` -- the exact review counter-example -- and must transition
+    the node to DEGRADED because `_update_existing_service` detects the rise
+    against that prior row, through the real `update_node_heartbeat` ->
+    `_update_node_metrics` -> `_sync_discovered_services` ->
+    `_upsert_service` -> `_calculate_node_status` chain.
+    """
+    node = SimpleNamespace(
+        node_id="node-14465",
+        hostname="node-14465",
+        status=reconciler.NodeStatus.DEGRADED.value,
+        cpu_percent=0.0,
+        memory_percent=0.0,
+        disk_percent=0.0,
+        last_heartbeat=datetime.now(timezone.utc),
+        extra_data={},
+        agent_version=None,
+        os_info=None,
+    )
+    seeded_service = _ServiceRow(extra_data={"n_restarts": 44})
+    session = _SeededServiceHeartbeatSession(node, seeded_service)
+    service = reconciler.ReconcilerService()
+
+    this_beat = {
+        "discovered_services": [{"name": "autobot-vnc", "status": "running", "n_restarts": 47, "enabled": True}]
+    }
+
+    result = asyncio.run(service.update_node_heartbeat(session, node.node_id, _CPU, _MEM, _DISK, extra_data=this_beat))
+
+    assert result.status == reconciler.NodeStatus.DEGRADED.value, (
+        "n_restarts rising from 44 to 47 against the prior heartbeat's row did not degrade the node"
+    )
+    assert seeded_service.extra_data.get("n_restarts") == 47, "the new count must be persisted for the NEXT heartbeat"

--- a/autobot-slm-backend/services/reconciler_status_restart_delta_14465_test.py
+++ b/autobot-slm-backend/services/reconciler_status_restart_delta_14465_test.py
@@ -110,9 +110,9 @@ def test_a_service_that_restarted_long_ago_but_is_now_running_is_not_degraded():
         ]
     }
 
-    assert _status(extra_data, restart_churn_active=False) == reconciler.NodeStatus.ONLINE.value, (
-        "a service with an old, non-advancing restart count pinned the node DEGRADED forever (#14465)"
-    )
+    assert (
+        _status(extra_data, restart_churn_active=False) == reconciler.NodeStatus.ONLINE.value
+    ), "a service with an old, non-advancing restart count pinned the node DEGRADED forever (#14465)"
 
 
 def test_a_settled_failed_service_still_degrades_with_no_active_churn():
@@ -198,9 +198,7 @@ def test_an_explicitly_disabled_unit_never_false_positives():
 def test_a_non_autobot_service_never_mattered_regardless_of_state():
     """Scope guard: only managed autobot/slm-agent units are in play."""
     extra_data = {
-        "discovered_services": [
-            {"name": "sshd", "status": "failed", "n_restarts": 50, "unit_file_state": "enabled"}
-        ]
+        "discovered_services": [{"name": "sshd", "status": "failed", "n_restarts": 50, "unit_file_state": "enabled"}]
     }
 
     assert _status(extra_data) == reconciler.NodeStatus.ONLINE.value
@@ -396,9 +394,9 @@ def test_a_churning_service_degrades_across_a_real_heartbeat_against_its_prior_r
 
     result = asyncio.run(service.update_node_heartbeat(session, node.node_id, _CPU, _MEM, _DISK, extra_data=this_beat))
 
-    assert result.status == reconciler.NodeStatus.DEGRADED.value, (
-        "n_restarts rising from 44 to 47 against the prior heartbeat's row did not degrade the node"
-    )
+    assert (
+        result.status == reconciler.NodeStatus.DEGRADED.value
+    ), "n_restarts rising from 44 to 47 against the prior heartbeat's row did not degrade the node"
     assert seeded_service.extra_data.get("n_restarts") == 47, "the new count must be persisted for the NEXT heartbeat"
     assert seeded_service.extra_data.get("n_restarts_increased_at") is not None, (
         "the churn-arming timestamp must be persisted so the NEXT heartbeat can still report churning "

--- a/autobot-slm-backend/services/reconciler_status_restart_delta_14465_test.py
+++ b/autobot-slm-backend/services/reconciler_status_restart_delta_14465_test.py
@@ -96,9 +96,9 @@ def test_a_service_that_restarted_long_ago_but_is_now_running_is_not_degraded():
         "discovered_services": [{"name": "autobot-vnc", "status": "running", "n_restarts": 5, "enabled": True}]
     }
 
-    assert _status(extra_data, restart_increase_detected=False) == reconciler.NodeStatus.ONLINE.value, (
-        "a service with an old, non-advancing restart count pinned the node DEGRADED forever (#14465)"
-    )
+    assert (
+        _status(extra_data, restart_increase_detected=False) == reconciler.NodeStatus.ONLINE.value
+    ), "a service with an old, non-advancing restart count pinned the node DEGRADED forever (#14465)"
 
 
 def test_a_churning_service_degrades_via_the_restart_delta_not_an_absolute():
@@ -128,9 +128,9 @@ def test_a_single_fresh_restart_degrades_even_below_the_old_absolute_threshold()
         "discovered_services": [{"name": "autobot-vnc", "status": "running", "n_restarts": 1, "enabled": True}]
     }
 
-    assert _status(extra_data, restart_increase_detected=True) == reconciler.NodeStatus.DEGRADED.value, (
-        "a fresh restart must degrade immediately, not wait for an arbitrary absolute count"
-    )
+    assert (
+        _status(extra_data, restart_increase_detected=True) == reconciler.NodeStatus.DEGRADED.value
+    ), "a fresh restart must degrade immediately, not wait for an arbitrary absolute count"
 
 
 def test_a_settled_failed_service_still_degrades_with_no_fresh_delta():
@@ -295,7 +295,7 @@ def test_a_churning_service_degrades_across_a_real_heartbeat_against_its_prior_r
 
     result = asyncio.run(service.update_node_heartbeat(session, node.node_id, _CPU, _MEM, _DISK, extra_data=this_beat))
 
-    assert result.status == reconciler.NodeStatus.DEGRADED.value, (
-        "n_restarts rising from 44 to 47 against the prior heartbeat's row did not degrade the node"
-    )
+    assert (
+        result.status == reconciler.NodeStatus.DEGRADED.value
+    ), "n_restarts rising from 44 to 47 against the prior heartbeat's row did not degrade the node"
     assert seeded_service.extra_data.get("n_restarts") == 47, "the new count must be persisted for the NEXT heartbeat"

--- a/autobot-slm-backend/services/reconciler_status_restart_delta_14465_test.py
+++ b/autobot-slm-backend/services/reconciler_status_restart_delta_14465_test.py
@@ -148,6 +148,29 @@ def test_a_presently_crash_looping_service_still_degrades_the_node():
     assert _status(extra_data) == reconciler.NodeStatus.DEGRADED.value
 
 
+def test_a_crash_looping_service_from_an_agent_that_predates_this_fix_still_degrades():
+    """The fleet-wide rollout defect review caught: `unit_file_state` is a
+    field THIS PR introduces. Every node running the currently-deployed agent
+    (until its own code-sync lands and its agent process restarts -- up to
+    the agent's 300s discovery-cache TTL after that) reports
+    `discovered_services` WITHOUT this key at all, on every heartbeat.
+
+    Before this test existed, all 13 payloads in this file included the
+    field, so the suite stayed green on a version of `is_managed_autobot_
+    service` that returned `False` for an absent `unit_file_state` --
+    `_service_health_degraded` unconditionally `False`, node status blind to
+    a dead autobot service fleet-wide for the whole rollout window. Fail
+    safe, not open: absent must mean IN scope, matching base's original
+    name-prefix-only behaviour exactly.
+    """
+    extra_data = {"discovered_services": [{"name": "autobot-vnc", "status": "crash-loop", "n_restarts": 1}]}
+
+    assert _status(extra_data) == reconciler.NodeStatus.DEGRADED.value, (
+        "a crash-looping autobot service reported by a pre-rollout agent (no unit_file_state at all) "
+        "must still degrade the node -- absent must fail safe, not open"
+    )
+
+
 def test_slm_agent_itself_is_in_scope():
     """#14465 review: `slm-agent` never matches `startswith("autobot")`, and it
     is the one unit remediation actually restarts. It must not be permanently
@@ -216,6 +239,24 @@ def test_high_metrics_still_win_over_a_clean_service_list():
     assert (
         reconciler.ReconcilerService._calculate_node_status(SimpleNamespace(), 85.0, 0.0, 0.0, None, False)
         == reconciler.NodeStatus.DEGRADED.value
+    )
+
+
+def test_the_churn_window_floor_is_derived_from_the_shared_discovery_ttl_not_a_bare_literal():
+    """Review: `min_v=1` on `RESTART_CHURN_WINDOW_S` measured a break-even at
+    272s -- every value from 1 to 271 restored the pulse-flapping regression
+    this fix replaces. A bare literal also gives no warning when the agent
+    -side TTL changes: raising `SERVICE_DISCOVERY_TTL_S` without also
+    raising this floor would silently reintroduce the same regression at a
+    higher threshold. `min_v` must be DERIVED from the shared constant both
+    processes import (`autobot_shared.service_discovery`), not an
+    independent number that can drift from it.
+    """
+    from autobot_shared.service_discovery import SERVICE_DISCOVERY_TTL_S
+
+    assert reconciler.RESTART_CHURN_WINDOW_S >= SERVICE_DISCOVERY_TTL_S * 2 + 1, (
+        f"RESTART_CHURN_WINDOW_S ({reconciler.RESTART_CHURN_WINDOW_S}) does not clear twice the shared "
+        f"discovery TTL ({SERVICE_DISCOVERY_TTL_S}) -- the floor is not actually derived from it"
     )
 
 

--- a/autobot-slm-backend/services/service_extra_data.py
+++ b/autobot-slm-backend/services/service_extra_data.py
@@ -27,6 +27,9 @@ def engine_degraded_fields(svc_data: dict) -> dict:
     }
 
 
+_EXPLICITLY_DISABLED_UNIT_FILE_STATES = frozenset({"disabled", "masked", "masked-runtime"})
+
+
 def is_managed_autobot_service(svc_data: dict) -> bool:
     """Is this systemd unit one AutoBot manages and expects running on this node?
 
@@ -38,14 +41,28 @@ def is_managed_autobot_service(svc_data: dict) -> bool:
     most of a fleet for the one service that matters most.
 
     Scoped instead by naming convention (`autobot*`, or `slm-agent` itself)
-    plus `enabled` -- systemd's own `UnitFileState`, already collected by
-    `health_collector._get_service_details` on every discovered unit, no
-    monitored-list dependency required. `enabled` reflects what THIS node's
-    deployment actually turned on (e.g. `autobot-vnc` only when `install_vnc`
-    is set in the browser role) -- exactly the signal #1709 needed to avoid
-    flagging a non-primary autobot unit a node was never meant to run.
+    plus `unit_file_state` -- the RAW `UnitFileState` string, already
+    collected by `health_collector._get_service_details` on every discovered
+    unit, no monitored-list dependency required.
+
+    Gated on NOT explicitly disabled, not on `enabled` (review): `UnitFileState
+    == "enabled"` alone excludes `static`, `indirect`, `enabled-runtime`,
+    `generated` and `alias` -- and `autobot-key-rotation.service.j2` /
+    `autobot-pg-backup.service.j2` have no `[Install]` section, so they are
+    `static` and would be permanently invisible to this check under an
+    `enabled`-only gate. A unit burning its own start limit does NOT get
+    disabled by systemd -- `UnitFileState` is untouched by that -- so this
+    guard is not accidentally empty for a crash-looping unit either; it was
+    just narrower than base's `discovered_services` sweep in the wrong place.
+
+    Absent `unit_file_state` (the field is new; a stale cached snapshot or a
+    caller outside `discovered_services` may not carry it) is treated as
+    OUT of scope, matching the previous conservative default.
     """
     name = svc_data.get("name", "")
     if not (name.startswith("autobot") or name == "slm-agent"):
         return False
-    return bool(svc_data.get("enabled", False))
+    unit_file_state = svc_data.get("unit_file_state")
+    if unit_file_state is None:
+        return False
+    return unit_file_state not in _EXPLICITLY_DISABLED_UNIT_FILE_STATES

--- a/autobot-slm-backend/services/service_extra_data.py
+++ b/autobot-slm-backend/services/service_extra_data.py
@@ -25,3 +25,27 @@ def engine_degraded_fields(svc_data: dict) -> dict:
         "engine_degraded": bool(svc_data.get("engine_degraded")),
         "degraded_reason": svc_data.get("degraded_reason"),
     }
+
+
+def is_managed_autobot_service(svc_data: dict) -> bool:
+    """Is this systemd unit one AutoBot manages and expects running on this node?
+
+    #14465: scope for node-status degrade signals, deliberately NOT
+    `extra_data["services"]` / `slm_services_to_monitor`. That operator
+    -declared set defaults to `[]` per role, is `[]` on at least one real
+    inventory node, and never contains `slm-agent` -- the one unit
+    remediation actually restarts -- so a check scoped to it goes dark on
+    most of a fleet for the one service that matters most.
+
+    Scoped instead by naming convention (`autobot*`, or `slm-agent` itself)
+    plus `enabled` -- systemd's own `UnitFileState`, already collected by
+    `health_collector._get_service_details` on every discovered unit, no
+    monitored-list dependency required. `enabled` reflects what THIS node's
+    deployment actually turned on (e.g. `autobot-vnc` only when `install_vnc`
+    is set in the browser role) -- exactly the signal #1709 needed to avoid
+    flagging a non-primary autobot unit a node was never meant to run.
+    """
+    name = svc_data.get("name", "")
+    if not (name.startswith("autobot") or name == "slm-agent"):
+        return False
+    return bool(svc_data.get("enabled", False))

--- a/autobot-slm-backend/services/service_extra_data.py
+++ b/autobot-slm-backend/services/service_extra_data.py
@@ -55,14 +55,24 @@ def is_managed_autobot_service(svc_data: dict) -> bool:
     guard is not accidentally empty for a crash-looping unit either; it was
     just narrower than base's `discovered_services` sweep in the wrong place.
 
-    Absent `unit_file_state` (the field is new; a stale cached snapshot or a
-    caller outside `discovered_services` may not carry it) is treated as
-    OUT of scope, matching the previous conservative default.
+    Absent `unit_file_state` means IN scope (review: fail safe, not open).
+    This field is new -- every node still running the currently-deployed
+    agent (before its own code-sync + process restart picks up this PR)
+    reports `discovered_services` without it, on every heartbeat, for up to
+    the agent's 300s discovery-cache TTL after that. Treating "absent" as
+    "out of scope" would have made `_service_health_degraded` return `False`
+    unconditionally fleet-wide for that entire rollout window -- blind to a
+    genuinely crash-looping autobot service on every node, the exact symptom
+    this issue reports, reintroduced by the fix meant to close it. Falling
+    back to base's original name-prefix-only behaviour (no enabled/disabled
+    gate at all) when the field is missing means an old agent's report is
+    scored exactly as base would have scored it; only a NEW agent's report,
+    which does carry the field, gets the narrower gate.
     """
     name = svc_data.get("name", "")
     if not (name.startswith("autobot") or name == "slm-agent"):
         return False
     unit_file_state = svc_data.get("unit_file_state")
     if unit_file_state is None:
-        return False
+        return True
     return unit_file_state not in _EXPLICITLY_DISABLED_UNIT_FILE_STATES

--- a/autobot-slm-backend/slm/agent/health_collector.py
+++ b/autobot-slm-backend/slm/agent/health_collector.py
@@ -23,6 +23,7 @@ from typing import Dict, List
 import psutil
 
 from autobot_shared.redis_client import get_redis_client
+from autobot_shared.service_discovery import SERVICE_DISCOVERY_TTL_S
 from autobot_shared.time_utils import utc_timestamp
 
 # App-level /health probes for services that expose engine state beyond
@@ -38,8 +39,11 @@ logger = logging.getLogger(__name__)
 
 _STATE_CHANGE_CHANNEL_TEMPLATE = "autobot:services:{service}:state_change"
 
-# Subprocess-heavy service sweep is cached this long to reduce system load (#9086)
-_SERVICE_DISCOVERY_TTL = 300  # seconds
+# Subprocess-heavy service sweep is cached this long to reduce system load
+# (#9086). Shared with services/reconciler.py's restart-churn window, which
+# must stay comfortably larger than this -- see autobot_shared/
+# service_discovery.py for why this is a plain constant, not env-backed.
+_SERVICE_DISCOVERY_TTL = SERVICE_DISCOVERY_TTL_S
 
 
 class HealthCollector:

--- a/autobot-slm-backend/slm/agent/health_collector.py
+++ b/autobot-slm-backend/slm/agent/health_collector.py
@@ -285,6 +285,21 @@ class HealthCollector:
                             details["description"] = value[:500]
                         elif key == "UnitFileState":
                             details["enabled"] = value == "enabled"
+                            # #14465: `enabled` above is deliberately narrow
+                            # (only "starts on boot", used for the Service
+                            # table's own `enabled` column/UI display) --
+                            # do not widen it, other consumers rely on that
+                            # exact meaning. `unit_file_state` carries the raw
+                            # string so a degrade-signal consumer can gate on
+                            # "not explicitly disabled" instead: `static`
+                            # units (no [Install] section -- e.g.
+                            # autobot-key-rotation, autobot-pg-backup) and
+                            # `indirect`/`enabled-runtime`/`generated`/`alias`
+                            # are all legitimately deployed and never
+                            # `UnitFileState == "enabled"`, so a check scoped
+                            # to that string alone leaves them permanently
+                            # invisible.
+                            details["unit_file_state"] = value
                         elif key == "NRestarts" and value.isdigit():
                             details["n_restarts"] = int(value)
 

--- a/autobot_shared/env_registry.py
+++ b/autobot_shared/env_registry.py
@@ -1683,6 +1683,22 @@ register_env_var(
 
 register_env_var(
     EnvVarSpec(
+        name="AUTOBOT_RESTART_CHURN_WINDOW_S",
+        type=int,
+        default=600,
+        description=(
+            "Seconds a managed autobot/slm-agent service is reported as CURRENTLY churning after "
+            "its last observed n_restarts increase, for node-status degrade purposes. Must clear "
+            "health_collector's own 300s discovery-cache TTL by a comfortable margin — a shorter "
+            "window only fires on the beat that happens to land on a cache refresh "
+            "(services/reconciler.py, #14465)."
+        ),
+        component="backend",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
         name="AUTOBOT_PLAYBOOK_FAILURE_TAIL_CHARS",
         type=int,
         default=500,

--- a/autobot_shared/service_discovery.py
+++ b/autobot_shared/service_discovery.py
@@ -1,0 +1,28 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Shared service-discovery cache TTL (#14465).
+
+Single source of truth for `slm/agent/health_collector.py`'s discovery-sweep
+cache TTL and `services/reconciler.py`'s restart-churn window, which must
+stay comfortably larger than this TTL -- see `RESTART_CHURN_WINDOW_S`'s own
+docstring for why a window too close to the TTL restores pulse-shaped
+flapping in the churn signal it replaced.
+
+Previously two independent hardcoded literals (`_SERVICE_DISCOVERY_TTL` in
+the agent, `RESTART_CHURN_WINDOW_S`'s `min_v` in the backend) in two
+different processes with no guard against drift -- raising one without the
+other silently reintroduced the exact bug both were fixed to close. Both
+processes already depend on `autobot_shared` (the agent imports
+`autobot_shared.redis_client`/`time_utils`), so this adds no new dependency
+either side did not already have.
+
+Deliberately NOT env-var-backed, unlike this repo's usual TTL convention: the
+agent reads its environment on each fleet node, the backend reads its own on
+the manager host -- two different machines, each with its own env. An env
+var would need to be set to the SAME value on every node AND the manager for
+this to actually stay a single source of truth; a plain shared constant,
+shipped in the one codebase both processes deploy from, cannot drift that
+way. See `docs/developer/ARCHITECTURE_EXCEPTIONS.md`.
+"""
+
+SERVICE_DISCOVERY_TTL_S = 300

--- a/docs/developer/ARCHITECTURE_EXCEPTIONS.md
+++ b/docs/developer/ARCHITECTURE_EXCEPTIONS.md
@@ -180,3 +180,27 @@ account is validated to never be `autobot_admin` (the emergency admin
 safety-net account) — see the `assert` task at the top of `tasks/main.yml`.
 
 **Grep check:** `grep -n "vnc_user\|vnc_forbidden_user" autobot-slm-backend/ansible/roles/vnc/defaults/main.yml`
+
+---
+
+## Service-Discovery Cache TTL — Plain Shared Constant, Not Env-Backed
+
+**File:** `autobot_shared/service_discovery.py`
+**Issue:** #14465
+
+**Pattern bypassed:** "Cache TTL — never hard-code — module-level constant
+from an env var."
+
+**Reason:** `slm/agent/health_collector.py`'s discovery-sweep cache TTL and
+`services/reconciler.py`'s restart-churn window (which must stay
+comfortably larger than that TTL, or the churn signal regresses to a pulse
+that misses most heartbeats) run in two DIFFERENT processes on two
+DIFFERENT machines — the agent on each fleet node, the backend on the
+manager host. An env var only provides a genuine single source of truth if
+it is set to the identical value on every one of those machines; nothing in
+either process can enforce that. A plain constant, shipped in the one
+codebase both processes deploy from, cannot drift that way — changing it is
+one edit that reaches every node on the next code-sync, not an env var an
+operator has to remember to set identically everywhere.
+
+**Grep check:** `grep -rn "SERVICE_DISCOVERY_TTL_S" autobot_shared/service_discovery.py autobot-slm-backend/slm/agent/health_collector.py autobot-slm-backend/services/reconciler.py` should show one definition and two importers, no second hardcoded literal.


### PR DESCRIPTION
## Thinking Path

Split out of #14506 at the reviewer's own suggestion; the sticky-DEGRADED bug (a node with a large lifetime `n_restarts` and no recent change staying DEGRADED forever) is genuinely fixed and confirmed by review. This round fixes four further findings: a pulse used where a level was needed, a scope gate narrower than base, two tautological tests, and a docstring inaccuracy.

**The pulse-vs-level bug.** `health_collector.py:42` (`_SERVICE_DISCOVERY_TTL`) caches `discover_all_services()` for 300s, while the heartbeat interval is 30s — 9 of every 10 beats carry a byte-identical cached snapshot, so a bare "did `n_restarts` change since the immediately preceding heartbeat" pulse only fires on the ~1 beat in 10 that happens to land on a cache refresh. Measured over 20 beats of continuous churn: **1 of 20 degraded**, versus 20 of 20 on base's absolute threshold — the node would flap ONLINE↔DEGRADED every 5 minutes instead of staying DEGRADED, with `_attempt_remediation` (60s poll, selects `status == DEGRADED`) catching it roughly half the windows at best.

**Fix**: `_restart_churn_active` persists the *timestamp* of the last observed increase (`Service.extra_data["n_restarts_increased_at"]`) and reports churning while `now - last_increase < RESTART_CHURN_WINDOW_S` (env-backed, default 600s — twice the 300s discovery TTL, so a genuinely still-churning service re-arms the window with a fresh increase before the earlier arming closes). A pulse says an increase happened; a level says the node is currently churning, which is what a status field means. Re-measured with the same 20-beat continuous-churn scenario: **20 of 20 degraded.**

First-ever observation (no prior `Service` row — a node registering, a row `_remove_stale_services` deleted and the agent re-reported, or a restored manager DB) honestly reports **not churning**: there is no rate information yet, and the next real increase arms the window. Acceptable specifically because this is now a level, not a static absolute threshold that would have had no such excuse for missing an already-churning service on first sight.

**`enabled` narrowed scope below base.** `UnitFileState == "enabled"` alone excludes `static`, `indirect`, `enabled-runtime`, `generated` and `alias` — `autobot-key-rotation.service.j2` and `autobot-pg-backup.service.j2` have no `[Install]` section, so they are `static` and were permanently invisible to both signals under an `enabled`-only gate. `health_collector` now also collects the raw `UnitFileState` string (`unit_file_state`), alongside the existing `enabled` boolean left **unchanged** (it still backs `Service.enabled`/UI display, an unrelated concern — widening it would have been a silent regression there). `is_managed_autobot_service` gates on `unit_file_state` **not being** `disabled`/`masked`/`masked-runtime`, rather than `enabled` alone. A unit burning its own start limit does not get disabled by systemd, so this does not reopen the false-positive #1709 narrowed against — it is not a re-widening, just correcting where the line actually needs to sit.

## What Changed

- `slm/agent/health_collector.py` **and** its ansible-mirrored copy (`ansible/roles/slm_agent/files/slm/agent/health_collector.py`, kept byte-identical) — `_get_service_details` now also collects `unit_file_state` (the raw `UnitFileState` string) alongside the existing `enabled` boolean.
- `services/service_extra_data.py` — `is_managed_autobot_service` reads `unit_file_state`, gated on not being explicitly disabled/masked.
- `services/reconciler.py`
  - New `RESTART_CHURN_WINDOW_S` (env-backed, `AUTOBOT_RESTART_CHURN_WINDOW_S`, default 600s).
  - New `_restart_churn_active(svc_data, previous_extra, now) -> (bool, str | None)`, replacing the bare pulse `_restart_count_increased` (kept as its own building block).
  - `_update_existing_service` computes and persists `n_restarts_increased_at`; `_service_health_degraded`'s parameter renamed `restart_churn_active` to match what it now actually carries (a level, not a pulse) throughout `_upsert_service`/`_sync_discovered_services`/`_update_node_metrics`/`update_node_heartbeat`/`_calculate_node_status`.
  - Corrected the docstring claim that `NRestarts` "never resets except at reboot or `reset-failed`" — systemd also flushes it on the next clean manual start once a unit settles.
  - Documented why `existing_extra = dict(service.extra_data or {})` is a genuine copy, not `service.extra_data or {}` handed back: SQLAlchemy's `Column(JSON)` does not reliably flag a same-object reassignment dirty, which would silently drop every field this method sets (including the new churn timestamp) and make the signal permanently inert — load-bearing, not a style choice.
- `AUTOBOT_RESTART_CHURN_WINDOW_S` registered in `autobot_shared/env_registry.py`.
- `services/reconciler_status_restart_delta_14465_test.py` — see Verification.

Not touched: `api/nodes.py`'s `_has_failed_autobot_service`/`code_status` derivation (#1605/#1709) — unrelated field, unrelated scope. `services.reconciler`'s `Service.enabled` column semantics — left exactly as `UnitFileState == "enabled"`, per above.

## Verification

- `python3 -m py_compile` on all touched files; no line exceeds 120 columns. Both `health_collector.py` copies re-diffed byte-identical after editing.
- Standalone extraction (`assert mutated != original`) reproducing the review's own 20-beat measurement methodology (30s heartbeat against a 300s discovery-cache refresh cycle, continuous churn): the pulse design reproduces **1/20** degraded; the level design produces **20/20**. Also verified directly: first observation (no prior row) reports not-churning without fabricating a signal; a second consecutive beat with an unchanged count still reports churning within the window without re-arming it; a single benign restart's window closes after `RESTART_CHURN_WINDOW_S` rather than degrading forever.
- `services/reconciler_status_restart_delta_14465_test.py`, loading the real `services/reconciler.py` from disk — not executed locally per policy; CI runs it. Review named two tests as tautological (`restart_increase_detected=True` passed directly into `_calculate_node_status`, short-circuiting the line under test, passing even with `extra_data=None`) — both **removed**, replaced with tests against the real `_restart_churn_active`/`_update_existing_service`:
  - `test_a_fresh_increase_arms_the_churn_window` — discriminates directly against the deleted `n_restarts > 3` branch via the real computation, not a hand-fed boolean.
  - `test_a_second_consecutive_beat_with_an_unchanged_count_still_reports_churning` — the level/pulse distinction itself; one of the two tests review named as missing.
  - `test_the_churn_window_eventually_closes_for_a_single_benign_restart`.
  - `test_a_churning_payload_with_no_prior_row_does_not_fabricate_a_signal` — the other test review named as missing.
  - `test_a_static_unit_with_no_install_section_is_still_in_scope` — the specific `autobot-key-rotation`/`autobot-pg-backup` gap.
  - `test_an_explicitly_disabled_unit_never_false_positives` — #1709, restated against the new scope.
  - `test_a_churning_service_degrades_across_a_real_heartbeat_against_its_prior_row` — the full `update_node_heartbeat` path against a real, pre-seeded prior `Service` row (not `_calculate_node_status` in isolation); now also asserts the churn timestamp is persisted for the next heartbeat to read.
  - Kept: the original sticky-DEGRADED-forever regression test, the settled-`failed` test, the active-`crash-loop` test (#1604), `slm-agent`-in-scope, non-`autobot`-service scope guard, metric-threshold guard.

## Model Used

Claude Opus 5 (1M context)

Refs #14465
