### PR TITLE
fix(infra): two live defects no flake8 code can see — an unexpanded ${AUTOBOT_PROJECT_ROOT} string default and an import that never resolved (#14507)

### DIFF
--- a/autobot-infrastructure/shared/scripts/populate_knowledge_base.py
+++ b/autobot-infrastructure/shared/scripts/populate_knowledge_base.py
@@ -21,20 +21,27 @@ produce, keeping every step the extraction had preserved.
 import asyncio
 import fnmatch
 import glob
-import logging
 import os
 import sys
 from pathlib import Path
 from typing import List, Tuple
 
+from autobot_shared.logging_manager import get_logger
 from autobot_shared.paths import project_root
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
-# Add parent directory to path
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-
-from knowledge_base import KnowledgeBase
+# #14507: this used to insert ``autobot-infrastructure/shared`` -- the script's
+# grandparent -- and then ``from knowledge_base import KnowledgeBase``, so the
+# script died with ModuleNotFoundError on its own import block, before reaching
+# any of the code #14405 repaired. The module it wanted is a first-party
+# ``autobot-backend`` module, and that directory was never on the path. Add it
+# the way the other operator entry points in this tree do (#14129), and import
+# the canonical ``knowledge`` package rather than the ``knowledge_base``
+# backward-compatibility shim, whose own docstring points new code here.
+_BACKEND_DIR = Path(__file__).resolve().parents[3] / "autobot-backend"
+if str(_BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_DIR))
 
 # Documentation patterns to include.
 DOC_PATTERNS = [
@@ -117,8 +124,12 @@ async def add_single_file(fp: str, root: Path, kb) -> tuple:
         "doc_type": "markdown",
     }
     logger.info(f"Adding: {rel_path} [{category}]")
-    result = await kb.add_file(file_path=fp, file_type="txt", metadata=metadata)
-    return result["status"] == "success", result
+    # #14507: ``kb.add_file`` is not a KnowledgeBase method -- nothing in the
+    # mixin chain defines it, so every file raised AttributeError and was
+    # counted as an error. ``add_document_from_file`` is the canonical ingest
+    # entry point and takes the category as a first-class argument.
+    result = await kb.add_document_from_file(file_path=fp, category=category, metadata=metadata)
+    return result.get("status") == "success", result
 
 
 async def add_files_to_kb(files: List[str], root: Path, kb) -> Tuple[int, int]:
@@ -143,7 +154,10 @@ async def run_search_smoke_tests(kb) -> None:
     """Query the populated base so an empty or unindexed collection is visible."""
     logger.info("\nTesting search functionality...")
     for query in SEARCH_SMOKE_QUERIES:
-        results = await kb.search(query, n_results=2)
+        # #14507: ``n_results`` is not a parameter of the canonical KB search
+        # (#10666 consolidated the three search paths onto ``top_k``), so this
+        # call raised TypeError on the first smoke query.
+        results = await kb.search(query, top_k=2)
         logger.info(f"\nSearch for '{query}': {len(results)} results")
         if results:
             logger.info(f"  First result: {results[0].get('metadata', {}).get('relative_path', 'Unknown')}")
@@ -151,6 +165,11 @@ async def run_search_smoke_tests(kb) -> None:
 
 async def add_documentation_to_kb():
     """Add all project documentation to the knowledge base."""
+    # Imported here rather than at module scope: ``knowledge/__init__`` loads
+    # the composed class lazily (#1514), so a module-scope import would pull
+    # redis, chromadb and llama_index in merely to inspect this script.
+    from knowledge import KnowledgeBase
+
     kb = KnowledgeBase()
     await kb.ainit()
 

--- a/autobot-infrastructure/shared/scripts/setup/knowledge/fresh_kb_setup.py
+++ b/autobot-infrastructure/shared/scripts/setup/knowledge/fresh_kb_setup.py
@@ -8,18 +8,26 @@ Fresh knowledge base setup - let llama_index create everything from scratch.
 """
 
 import asyncio
-import logging
-import os
 import sys
+from pathlib import Path
 
-logger = logging.getLogger(__name__)
+from autobot_shared.logging_manager import get_logger
 
-# Add parent directory to path
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+logger = get_logger(__name__)
+
+# #14507: this used to insert the script's own parent (``scripts/setup``) and
+# then import ``knowledge_base``, which lives in ``autobot-backend`` -- a
+# directory that was never on the path -- so the KB step died with
+# ModuleNotFoundError. Same defect as ``populate_knowledge_base.py``, which
+# this script's success message tells the operator to run next. Add the
+# directory the way the other operator entry points in this tree do (#14129).
+_BACKEND_DIR = Path(__file__).resolve().parents[5] / "autobot-backend"
+if str(_BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_DIR))
 
 # Import centralized Redis client
-from autobot_shared.redis_client import get_redis_client
-from autobot_shared.redis_utils import decode_redis_list, decode_redis_value
+from autobot_shared.redis_client import get_redis_client  # noqa: E402
+from autobot_shared.redis_utils import decode_redis_list, decode_redis_value  # noqa: E402
 
 
 def _clean_redis_indexes(r) -> None:
@@ -99,16 +107,19 @@ async def _test_knowledge_base(kb, r) -> bool:
 
     test_file = _create_test_document()
 
-    result = await kb.add_file(
+    # #14507: ``add_file`` is defined nowhere in the KnowledgeBase mixin chain
+    # and ``search`` takes ``top_k``, not ``n_results`` (#10666) -- both calls
+    # raised before this smoke test could report anything.
+    result = await kb.add_document_from_file(
         file_path=test_file,
-        file_type="txt",
-        metadata={"source": "test", "category": "documentation"},
+        category="documentation",
+        metadata={"source": "test"},
     )
 
     logger.info(f"   Add result: {result}")
 
-    if result["status"] == "success":
-        results = await kb.search("AutoBot features", n_results=2)
+    if result.get("status") == "success":
+        results = await kb.search("AutoBot features", top_k=2)
         logger.info(f"\n4. Search test results: {len(results)} found")
         if results:
             logger.info(f"   First result score: {results[0].get('score', 0)}")
@@ -154,7 +165,10 @@ async def fresh_setup():
 
     logger.info("\n2. Initializing fresh knowledge base...")
 
-    from knowledge_base import KnowledgeBase
+    # Deferred: ``knowledge/__init__`` loads the composed class lazily (#1514),
+    # so a module-scope import would pull redis, chromadb and llama_index in
+    # merely to inspect this script.
+    from knowledge import KnowledgeBase
 
     kb = KnowledgeBase()
     logger.info(f"   Will use embedding model: {kb.embedding_model_name}")

--- a/autobot-infrastructure/shared/scripts/setup/knowledge/fresh_kb_setup_test.py
+++ b/autobot-infrastructure/shared/scripts/setup/knowledge/fresh_kb_setup_test.py
@@ -46,12 +46,20 @@ class FakeRedis:
 
 
 class FakeKnowledgeBase:
-    """Answers add_file/search like a successful ingest without touching llama_index."""
+    """Answers ingest/search like a successful run without touching llama_index.
 
-    async def add_file(self, **_kwargs):
+    #14507: this used to answer ``add_file(**kwargs)`` and ``search(*a, **kw)``
+    -- a shape the real ``KnowledgeBase`` never produced. ``add_file`` is
+    defined nowhere in the mixin chain and ``search`` takes ``top_k``, not
+    ``n_results``, so the fake made two dead calls look alive. Both signatures
+    now mirror the real ones (``knowledge/documents.py``, ``knowledge/search.py``)
+    and reject anything they would reject.
+    """
+
+    async def add_document_from_file(self, file_path: str, category: str = "general", metadata=None):
         return {"status": "success"}
 
-    async def search(self, *_args, **_kwargs):
+    async def search(self, query, top_k=10, similarity_top_k=None, filters=None, mode="auto"):
         return []
 
 

--- a/autobot-infrastructure/shared/scripts/utilities/report_processing_system.py
+++ b/autobot-infrastructure/shared/scripts/utilities/report_processing_system.py
@@ -75,8 +75,25 @@ class ReportDiscoveryAgent:
         self.report_files: List[ReportFile] = []
 
     def discover_reports(self) -> Dict[str, List[ReportFile]]:
-        """Scan all folders for reports and categorize them"""
+        """Scan all folders for reports and categorize them.
+
+        Raises:
+            NotADirectoryError: the configured base path does not exist or is
+                not a directory. ``Path.rglob`` yields nothing at all in that
+                case rather than raising, so without this check a mission
+                pointed at the wrong place is indistinguishable from one that
+                legitimately found no reports (#14507).
+        """
         self.logger.info(f"Starting report discovery in {self.base_path}")
+
+        # #14507: only an unusable *root* is an error. A readable root holding
+        # no matching files is a legitimate outcome -- a fresh checkout, or a
+        # tree whose reports a previous run already archived -- so that case
+        # warns and returns empty rather than failing the mission.
+        if not self.base_path.is_dir():
+            raise NotADirectoryError(
+                f"Report discovery base path does not exist or is not a directory: {self.base_path}"
+            )
 
         report_patterns = [
             "*report*",
@@ -114,6 +131,13 @@ class ReportDiscoveryAgent:
         for category, files in discovered.items():
             if files:
                 self.logger.info(f"  {category}: {len(files)} files")
+
+        if total_files == 0:
+            self.logger.warning(
+                f"No report files matched any pattern under {self.base_path} -- "
+                "the directory is readable but empty of reports, so this mission "
+                "has nothing to process"
+            )
 
         return discovered
 
@@ -430,8 +454,17 @@ class ArchiveOrganizationAgent:
 class ReportProcessingCoordinator:
     """Main coordinator for multi-agent report processing"""
 
-    def __init__(self, base_path: str = "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}"):
-        self.base_path = base_path
+    def __init__(self, base_path: str | None = None):
+        # #14507: the default used to be the *literal* string
+        # ``"${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}"``. Python does not
+        # expand shell syntax inside a plain string literal, so every default-
+        # constructed coordinator -- which is exactly what ``main()`` builds --
+        # scanned a directory named after an unexpanded shell expression. #14504
+        # fixed this same defect class at the two f-string sites in this file,
+        # where pyflakes could see the undefined name; a plain literal is
+        # invisible to every lint code. ``autobot_shared.paths.project_root()``
+        # is the one place allowed to answer this question (#13149).
+        self.base_path = str(project_root()) if base_path is None else base_path
         self.logger = logging.getLogger("Coordinator")
         self.processing_start = datetime.datetime.now()
 

--- a/autobot-infrastructure/shared/scripts/utilities/report_processing_system.py
+++ b/autobot-infrastructure/shared/scripts/utilities/report_processing_system.py
@@ -116,9 +116,19 @@ class ReportDiscoveryAgent:
             "other": [],
         }
 
+        # #14507: the patterns overlap -- ``security_report.json`` matches both
+        # ``*report*`` and ``*.json`` -- so without this set every such file was
+        # discovered, counted, analysed and archived once per matching pattern.
+        # The second archival attempt moves a file that is no longer there.
+        seen: set = set()
+
         for pattern in report_patterns:
             for file_path in self.base_path.rglob(pattern):
+                resolved = file_path.resolve()
+                if resolved in seen:
+                    continue
                 if file_path.is_file() and not self._should_exclude(file_path):
+                    seen.add(resolved)
                     report_file = self._create_report_file(file_path)
                     category = self._categorize_file(report_file)
                     discovered[category].append(report_file)
@@ -469,9 +479,9 @@ class ReportProcessingCoordinator:
         self.processing_start = datetime.datetime.now()
 
         # Initialize agents
-        self.discovery_agent = ReportDiscoveryAgent(base_path)
+        self.discovery_agent = ReportDiscoveryAgent(self.base_path)
         self.error_agent = ErrorAnalysisAgent()
-        self.archive_agent = ArchiveOrganizationAgent(base_path)
+        self.archive_agent = ArchiveOrganizationAgent(self.base_path)
 
         # Processing statistics
         self.stats = {

--- a/repo_tests/infra_scripts_live_defects_14507_test.py
+++ b/repo_tests/infra_scripts_live_defects_14507_test.py
@@ -1,0 +1,337 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Guards for the two live defects in ``autobot-infrastructure/shared/scripts`` that
+no flake8 code can see (#14507).
+
+Both went live when #14504 (#14405) repaired the F821s that had made these
+modules raise ``NameError`` at import. Neither is reachable by pyflakes:
+
+* a shell placeholder pasted into a **plain** string literal is just a string
+  — the two sibling sites #14504 fixed were f-strings, where the undefined
+  name was visible;
+* pyflakes never checks that an import target *resolves*, so a script can be
+  F821-clean and still die on its own import block.
+
+These tests live under ``repo_tests/`` rather than beside the scripts because
+``autobot-infrastructure/`` is in no pytest ``testpaths`` entry and in no CI
+pytest invocation — a test placed next to the module would never run.
+"""
+
+import ast
+import asyncio
+import importlib.util
+import logging
+import pathlib
+import sys
+from unittest.mock import create_autospec
+
+import pytest
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+_SCRIPTS = _REPO_ROOT / "autobot-infrastructure" / "shared" / "scripts"
+_BACKEND = _REPO_ROOT / "autobot-backend"
+
+
+def _load_by_path(path: pathlib.Path, module_name: str):
+    """Import a standalone script by path — its directory is not a package."""
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def report_processing(tmp_path_factory):
+    """Load ``report_processing_system`` with the project root pinned to a temp tree.
+
+    The module calls ``logging.basicConfig`` with a ``FileHandler`` under
+    ``project_root()`` at import time, so an unpinned import would drop a log
+    file into the checkout.  ``project_root()`` is deliberately uncached and
+    honours ``AUTOBOT_PROJECT_ROOT`` first, so setting it redirects the write.
+    """
+    root = tmp_path_factory.mktemp("project_root")
+    monkey = pytest.MonkeyPatch()
+    monkey.setenv("AUTOBOT_PROJECT_ROOT", str(root))
+    before = list(logging.getLogger().handlers)
+    try:
+        module = _load_by_path(
+            _SCRIPTS / "utilities" / "report_processing_system.py",
+            "infra_scripts_report_processing_system_14507",
+        )
+        yield module, root
+    finally:
+        for handler in list(logging.getLogger().handlers):
+            if handler not in before:
+                logging.getLogger().removeHandler(handler)
+                handler.close()
+        monkey.undo()
+
+
+# --------------------------------------------------------------------------
+# Defect 1 — an unexpanded shell placeholder as a Python string default
+# --------------------------------------------------------------------------
+
+
+def test_default_coordinator_base_path_is_a_resolved_directory(report_processing):
+    """The default ``base_path`` resolves through ``project_root()``, not a shell literal.
+
+    Pre-fix: ``base_path`` defaults to the literal
+    ``"${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}"``, so the equality
+    against the resolved root fails (and the directory named by that string
+    can never exist).  Post-fix: the coordinator — and both agents it builds —
+    point at the real root.
+    """
+    module, root = report_processing
+
+    coordinator = module.ReportProcessingCoordinator()
+
+    assert "${" not in str(coordinator.base_path)
+    assert pathlib.Path(coordinator.base_path) == root
+    assert coordinator.discovery_agent.base_path == root
+    assert coordinator.archive_agent.base_path == root
+
+
+# --------------------------------------------------------------------------
+# Defect 1, second half — is an all-empty discovery a success?
+# --------------------------------------------------------------------------
+
+
+def test_discovery_raises_when_the_base_path_is_not_a_directory(report_processing):
+    """A discovery root that does not exist is an error, not an empty result.
+
+    ``Path.rglob`` yields nothing for a missing directory rather than raising,
+    which is what let a coordinator aimed at an unexpanded shell expression
+    report full success having found nothing.
+
+    Pre-fix: ``discover_reports()`` returns ``{"test_results": [], ...}`` and
+    raises nothing, so ``pytest.raises`` fails.  Post-fix: ``NotADirectoryError``.
+    """
+    module, root = report_processing
+
+    agent = module.ReportDiscoveryAgent(str(root / "does-not-exist"))
+
+    with pytest.raises(NotADirectoryError) as excinfo:
+        agent.discover_reports()
+    assert "does-not-exist" in str(excinfo.value)
+
+
+def test_an_empty_but_readable_root_is_a_warning_not_a_failure(report_processing, caplog):
+    """A readable root holding no reports stays a success — and says so out loud.
+
+    This is the legitimate empty case: a fresh checkout, or a tree whose
+    reports a previous run already archived.  Failing on it would be wrong, so
+    the honest signal is a warning that names the directory.
+
+    Pre-fix: the run is silent — no warning is emitted — so the ``caplog``
+    assertion fails while the "returns empty" half passes.  Post-fix: every
+    category is empty, nothing raises, and the warning names the path.
+    """
+    module, root = report_processing
+    empty_root = root / "empty-tree"
+    empty_root.mkdir()
+
+    agent = module.ReportDiscoveryAgent(str(empty_root))
+
+    with caplog.at_level(logging.WARNING, logger=agent.logger.name):
+        discovered = agent.discover_reports()
+
+    assert discovered and all(files == [] for files in discovered.values())
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert warnings, "an all-empty discovery must announce itself"
+    assert str(empty_root) in warnings[0].getMessage()
+
+
+def test_a_populated_root_still_discovers_its_reports(report_processing):
+    """The guard does not swallow the working case it is wrapped around.
+
+    It also pins the de-duplication: ``security_report.json`` matches both the
+    ``*report*`` and ``*.json`` patterns, and the scan used to append it once
+    per matching pattern — inflating every count the mission reports and
+    queueing a second archival of a file the first one had already moved.
+
+    Pre-fix: the file is discovered twice, so the count assertion fails.
+    Post-fix: exactly one entry.  (The category is not asserted:
+    ``_categorize_file`` matches on the whole path, and pytest's own temp
+    directory contains "pytest".)
+    """
+    module, root = report_processing
+    populated = root / "populated"
+    populated.mkdir()
+    report = populated / "security_report.json"
+    report.write_text("{}", encoding="utf-8")
+
+    discovered = module.ReportDiscoveryAgent(str(populated)).discover_reports()
+
+    found = [f.path for files in discovered.values() for f in files]
+    assert found == [str(report)]
+
+
+# --------------------------------------------------------------------------
+# Defect 2 — an import target that does not resolve, and two dead call sites
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def populate_kb():
+    """Import ``populate_knowledge_base``, restoring ``sys.path`` afterwards.
+
+    Pre-fix this raises ``ModuleNotFoundError: No module named 'knowledge_base'``
+    at module scope: the script inserted its own grandparent
+    (``autobot-infrastructure/shared``) on ``sys.path`` and the module it wanted
+    lives in ``autobot-backend``, which was never on the path.
+    """
+    before = list(sys.path)
+    try:
+        yield _load_by_path(_SCRIPTS / "populate_knowledge_base.py", "infra_scripts_populate_knowledge_base_14507")
+    finally:
+        sys.path[:] = before
+
+
+@pytest.fixture(scope="module")
+def fresh_kb_setup():
+    """Import ``setup/knowledge/fresh_kb_setup``, restoring ``sys.path`` afterwards.
+
+    Same defect as ``populate_knowledge_base``: pre-fix its KB import target is
+    ``knowledge_base``, reachable only from ``autobot-backend``, which the
+    script never put on the path.  Its own success message tells the operator
+    to run ``populate_knowledge_base.py`` next, so the pair broke together.
+    """
+    before = list(sys.path)
+    try:
+        yield _load_by_path(
+            _SCRIPTS / "setup" / "knowledge" / "fresh_kb_setup.py",
+            "infra_scripts_fresh_kb_setup_14507",
+        )
+    finally:
+        sys.path[:] = before
+
+
+@pytest.mark.parametrize(
+    ("script", "loader"),
+    [
+        ("populate_knowledge_base.py", "populate_kb"),
+        ("setup/knowledge/fresh_kb_setup.py", "fresh_kb_setup"),
+    ],
+)
+def test_every_absolute_import_target_in_the_script_resolves(request, script, loader):
+    """Each top-level import target the script names is locatable after its own path setup.
+
+    pyflakes reports F401/F821 but never checks that an import *resolves*, so
+    "0 findings" and "cannot run" were both true of this script at once.
+
+    Pre-fix: the fixture itself raises ``ModuleNotFoundError`` on
+    ``knowledge_base``, so this errors out.  Post-fix: the script has put
+    ``autobot-backend`` on ``sys.path`` and every target — including the
+    function-scoped ``knowledge`` import — is found.
+    """
+    request.getfixturevalue(loader)  # the script performs its own sys.path setup
+    source = (_SCRIPTS / script).read_text(encoding="utf-8")
+    targets = set()
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.Import):
+            targets.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            targets.add(node.module.split(".")[0])
+
+    assert "knowledge" in targets, "the knowledge-base import must still be exercised"
+    unresolvable = sorted(name for name in targets if importlib.util.find_spec(name) is None)
+    assert unresolvable == []
+
+
+def test_the_script_ingests_through_a_method_knowledge_base_actually_has(populate_kb, tmp_path):
+    """``add_single_file`` calls an ingest method that exists on the real mixin.
+
+    The fake is ``create_autospec`` of the real ``DocumentsMixin``, so it
+    answers exactly the names that class defines and raises ``AttributeError``
+    for anything else — and produces an ``AsyncMock`` for an ``async def``, so
+    a missing ``await`` could not pass either.
+
+    Pre-fix: the script called ``kb.add_file(...)``, which the mixin chain
+    defines nowhere, so the autospec raises ``AttributeError``.  Post-fix: it
+    calls ``add_document_from_file`` with the category it computed.
+    """
+    if str(_BACKEND) not in sys.path:
+        sys.path.insert(0, str(_BACKEND))
+    from knowledge.documents import DocumentsMixin
+
+    assert not hasattr(DocumentsMixin, "add_file")
+
+    kb = create_autospec(DocumentsMixin, instance=True)
+    kb.add_document_from_file.return_value = {"status": "success"}
+    doc = tmp_path / "docs" / "developer" / "CLAUDE_GIT.md"
+    doc.parent.mkdir(parents=True)
+    doc.write_text("# git\n", encoding="utf-8")
+
+    success, result = asyncio.run(populate_kb.add_single_file(str(doc), tmp_path, kb))
+
+    assert success is True and result == {"status": "success"}
+    kwargs = kb.add_document_from_file.await_args.kwargs
+    assert kwargs["file_path"] == str(doc)
+    assert kwargs["category"] == "developer-docs"
+
+
+def test_the_search_smoke_test_uses_the_canonical_search_parameter(populate_kb):
+    """The post-ingest smoke queries call ``search`` with a parameter it accepts.
+
+    The fake mirrors the real basic-path signature (#10666 consolidated the
+    three search paths onto ``top_k``); it takes no ``n_results``.
+
+    Pre-fix: the script passed ``n_results=2`` and this raises ``TypeError``.
+    Post-fix: every smoke query runs and is recorded.
+    """
+    seen = []
+
+    class FakeKnowledgeBase:
+        async def search(self, query, top_k=10, similarity_top_k=None, filters=None, mode="auto"):
+            seen.append((query, top_k))
+            return [{"metadata": {"relative_path": "README.md"}}]
+
+    asyncio.run(populate_kb.run_search_smoke_tests(FakeKnowledgeBase()))
+
+    assert seen == [(query, 2) for query in populate_kb.SEARCH_SMOKE_QUERIES]
+
+
+def test_fresh_kb_setup_smoke_test_uses_the_real_knowledge_base_surface(fresh_kb_setup):
+    """``fresh_kb_setup``'s post-init smoke test calls methods the real KB defines.
+
+    The ingest half is ``create_autospec`` of the real ``DocumentsMixin``, so
+    it raises ``AttributeError`` for any name that class does not define and
+    produces an ``AsyncMock`` for an ``async def``.  The search half mirrors the
+    real basic-path signature, which takes ``top_k`` and no ``n_results``.
+
+    Pre-fix: the script called ``kb.add_file(...)`` (``AttributeError``) and
+    ``kb.search(..., n_results=2)`` (``TypeError``).  Post-fix: both land, and
+    the FT.INFO walk the sibling test already covers reports success.
+    """
+    if str(_BACKEND) not in sys.path:
+        sys.path.insert(0, str(_BACKEND))
+    from knowledge.documents import DocumentsMixin
+
+    searches = []
+
+    class FakeKnowledgeBase:
+        def __init__(self):
+            self._docs = create_autospec(DocumentsMixin, instance=True)
+            self._docs.add_document_from_file.return_value = {"status": "success"}
+
+        def __getattr__(self, name):
+            return getattr(self._docs, name)
+
+        async def search(self, query, top_k=10, similarity_top_k=None, filters=None, mode="auto"):
+            searches.append((query, top_k))
+            return []
+
+    class FakeRedis:
+        def execute_command(self, *args):
+            if args[0] == "FT._LIST":
+                return ["llama_index"]
+            if args[0] == "FT.INFO":
+                return ["attributes", [["identifier", "vector", "attribute", "vector", "dim", "768"]]]
+            return "OK"
+
+    kb = FakeKnowledgeBase()
+
+    assert asyncio.run(fresh_kb_setup._test_knowledge_base(kb, FakeRedis())) is True
+    assert kb._docs.add_document_from_file.await_args.kwargs["category"] == "documentation"
+    assert searches == [("AutoBot features", 2)]


### PR DESCRIPTION
Closes #14507

## Thinking Path

Both defects only became reachable when #14504 (#14405) fixed the F821s that had made these modules raise `NameError` at import. Neither is visible to any flake8 code, and that is the point: a tree can report "0 findings" while the scripts in it still cannot run.

**Defect 1 — the string default.** `ReportProcessingCoordinator.__init__`'s `base_path` defaulted to the literal `"${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}"`. Python does not expand shell syntax in a string literal, so `main()` — which default-constructs the coordinator — pointed both agents at a directory that can never exist. `Path.rglob` yields nothing for a missing directory rather than raising, so `discover_reports()` returned `{"test_results": [], ...}` for every category and the mission logged `MISSION COMPLETED SUCCESSFULLY` having found nothing. #14504 fixed this same class at the two f-string sites in this file, where the undefined name was visible to pyflakes; a plain literal is invisible to every code. Resolved through `autobot_shared.paths.project_root()` (#13149), not an open-coded `os.environ.get`.

**Should an all-empty discovery be a success?** The honest split is not empty-vs-non-empty, it is *usable root* vs *unusable root*.

- An **unusable root** — missing, or not a directory — is unconditionally an error. It is the only state that is genuinely indistinguishable from "pointed at the wrong place", and it is exactly what the unexpanded placeholder produced. `discover_reports()` now raises `NotADirectoryError` naming the path.
- A **readable root holding no reports** is a legitimate outcome, not a fault: a fresh checkout has no `reports/`, and a tree whose reports a previous run already archived correctly has none left. Failing there would make the second run of an idempotent job fail, which is a worse signal than the one it replaces. That case logs a `WARNING` naming the directory, so an operator reading the log can tell "nothing to do" from "nothing found" without the run going red.

So: signal, but at the root check rather than on the count. Both halves are pinned by tests, including one that proves the guard did not simply start raising or warning unconditionally.

**Defect 2 — the import that does not resolve.** The issue states no `knowledge_base.py` exists anywhere in the repo. **That premise is wrong**, and the real cause is worse-behaved: `autobot-backend/knowledge_base.py` does exist, as a backward-compatibility shim. The script died because it inserted its own *grandparent* (`autobot-infrastructure/shared`) on `sys.path` and the module it wanted lives in `autobot-backend`, which was never on the path. So the fix is the path setup, not a module hunt — and per that shim's own docstring ("For new code, prefer importing directly from `knowledge`") the import now targets the canonical package, matching `utilities/manage_system_knowledge.py` (#14129). The import is function-scoped because `knowledge/__init__` loads the composed class lazily (#1514); at module scope it would pull redis, chromadb and llama_index in merely to inspect the script.

Fixing the import exposed two more dead calls on the same object, both of which would have failed on the first file: `kb.add_file` is defined nowhere in the 14-mixin chain (the canonical ingest is `add_document_from_file`), and `kb.search` takes `top_k`, not `n_results` (#10666 consolidated the three search paths). Repairing an import to reach an `AttributeError` is not a fix, so both are corrected.

**Why `fresh_kb_setup.py` is in scope.** It carries the identical defect — same wrong `sys.path` insert, same `knowledge_base` target, same `add_file`, same `n_results` — and its success message tells the operator to run `populate_knowledge_base.py` next. The pair broke together and is fixed together. Its existing test's `FakeKnowledgeBase` answered `add_file(**kwargs)` and `search(*a, **kw)` — a shape the real class never produced, which is how two dead calls kept looking alive — so both fake signatures now mirror the production ones.

**Two further defects the tests caught in the code under repair**, neither in the issue: the coordinator passed the raw `base_path` argument rather than the resolved one to both agents (so the first fix was half-applied), and the discovery scan appended a file once per matching pattern — `security_report.json` matches both `*report*` and `*.json` — inflating every count the mission reports and queueing a second archival of a file the first `shutil.move` had already taken away.

## What Changed

| File | Change |
|---|---|
| `autobot-infrastructure/shared/scripts/utilities/report_processing_system.py` | `base_path` default resolves via `project_root()`; agents receive the resolved path; `discover_reports()` raises `NotADirectoryError` on an unusable root, warns on a readable-but-empty one, and de-duplicates overlapping pattern matches |
| `autobot-infrastructure/shared/scripts/populate_knowledge_base.py` | inserts `autobot-backend` on `sys.path` and imports `knowledge` (function-scoped); `add_file` → `add_document_from_file`; `n_results` → `top_k`; `logging` → `autobot_shared.logging_manager.get_logger` |
| `autobot-infrastructure/shared/scripts/setup/knowledge/fresh_kb_setup.py` | the same three fixes |
| `autobot-infrastructure/shared/scripts/setup/knowledge/fresh_kb_setup_test.py` | fake KB signatures mirror the real `DocumentsMixin` / `SearchMixin` |
| `repo_tests/infra_scripts_live_defects_14507_test.py` | new — 9 discriminating guards |

Tests live in `repo_tests/` rather than beside the scripts because `autobot-infrastructure/` appears in no `pytest.ini` `testpaths` entry and in no CI pytest invocation — a test placed next to the module would never run. Both existing sibling tests in that tree (`fresh_kb_setup_test.py`, `manage_system_knowledge_category_default_test.py`) are unrun today for that reason.

## Verification

**Discrimination.** The pre-fix modules were copied from `origin/Dev_new_gui` into a scratch tree and the identical test file was pointed at them — no mutation commit was pushed, and nothing in the repo was executed to produce this.

| Test | Against pre-fix | Against fixed |
|---|---|---|
| `test_default_coordinator_base_path_is_a_resolved_directory` | FAIL — `assert '${' not in '${AUTOBOT_P...code_source}'` | PASS |
| `test_discovery_raises_when_the_base_path_is_not_a_directory` | FAIL — `DID NOT RAISE NotADirectoryError` | PASS |
| `test_an_empty_but_readable_root_is_a_warning_not_a_failure` | FAIL — `an all-empty discovery must announce itself` | PASS |
| `test_a_populated_root_still_discovers_its_reports` | FAIL — one file discovered twice | PASS |
| `test_every_absolute_import_target_in_the_script_resolves[populate_knowledge_base.py]` | FAIL — `ModuleNotFoundError: No module named 'knowledge_base'` | PASS |
| `test_every_absolute_import_target_in_the_script_resolves[fresh_kb_setup.py]` | FAIL — `the knowledge-base import must still be exercised` | PASS |
| `test_the_script_ingests_through_a_method_knowledge_base_actually_has` | ERROR — `ModuleNotFoundError: No module named 'knowledge_base'` | PASS |
| `test_the_search_smoke_test_uses_the_canonical_search_parameter` | ERROR — `ModuleNotFoundError: No module named 'knowledge_base'` | PASS |
| `test_fresh_kb_setup_smoke_test_uses_the_real_knowledge_base_surface` | FAIL — `AttributeError: Mock object has no attribute 'add_file'` | PASS |

```
pre-fix copies:  7 failed, 2 errors in 0.83s
this branch:     9 passed in 0.92s
```

The ingest fakes are `create_autospec` of the real `DocumentsMixin`, so they answer only names that class defines and produce an `AsyncMock` for an `async def` — a missing `await` could not pass either. The search fakes carry the real basic-path signature, so `n_results=2` raises `TypeError` rather than being silently accepted.

**Other checks**

```
flake8 (full config, 5 changed files)                            0
tools/lint/check_infra_scripts_undefined_names.py --audit        clean over 222 scripts
scripts/check_python_file_size.py --audit-ceilings               3 entries, all live and at size
pytest autobot-infrastructure/.../fresh_kb_setup_test.py         1 passed
pytest repo_tests                                                865 passed, 2 xfailed, 1 failed
```

The single `repo_tests` failure is `with_error_handling_single_definition_test.py`. It fails identically in isolation with none of this branch's files involved, and it is the already-filed **#14484** — guards that filter out `/.worktrees/` neuter themselves when the session runs from inside a worktree. Not a regression from this PR.

*Correction to an earlier revision of this body, which reported `2 failed, 864 passed`.* The second failure was an artifact of the interpreter I ran on, not of the tree. `test_ci_import_smoke_paths_14252.py::test_every_extracted_program_parses` `ast.parse`s the inline Python that CI workflow steps run, and `phase_validation.yml` contains an f-string with same-type nested quotes — `f"...{r.get("overall_maturity", 0):.1f}%"`. PEP 701 made that legal in **3.12**; my local interpreter is 3.10, where it is a `SyntaxError`. `ci.yml` pins `python-version: '3.14'`, so the test passes on the interpreter that actually gates this PR. Extracting all 21 inline programs once and parsing them under each interpreter isolates it exactly:

```
unparseable under python3.10: 1 ['phase_validation.yml']
unparseable under python3.12: 0 []
unparseable under python3.14: 0 []
```

No code in this PR is affected — the correction is to a reported number, which is the one thing a reader cannot cheaply re-check.

**Beyond the two defects — swept, counted, not absorbed.** Two AST sweeps over the same tree found much more of both classes than the issue named. Neither belongs in this PR:

- **#14517** — 32 further unexpanded `${AUTOBOT_PROJECT_ROOT:-…}` placeholders in plain Python string constants: 26 sites across 21 files under `shared/scripts/`, plus 6 under `shared/tests/`. Excludes the one deliberate literal (`compliance_manager.py`, guarded by #13658) and 3 fixtures that quote the pattern on purpose.
- **#14518** — 44 import sites across 11 distinct targets whose target does not resolve: 29 sites naming modules that exist nowhere (`backend` ×22, `llm_interface` ×3, `src` ×3, `chat_history_manager` ×1), 5 naming modules that exist but are not on the importing script's path, and 10 naming third-party packages in no requirements file.

Both issues record that the corresponding guard should land *after* its sweep, not before — a guard needing a 32-entry baseline on day one is the dormant-exemption-list shape this repo has been bitten by.

## Model Used

Claude Opus 5 (1M context)
