### PR TITLE
security(mcp): declare every tool's permission, retire the verb-list under-grant guard (#14494)

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -455,6 +455,24 @@ jobs:
         # reports a comfortable zero. There is no exemption list, deliberately.
         python3 tools/lint/check_infra_scripts_undefined_names.py --audit
 
+    - name: Audit MCP tool permission coverage (#14494)
+      run: |
+        # The under-grant guard used to infer "this tool mutates state" from a
+        # hand-written verb list matched against the tool's NAME (write, delete,
+        # click, ...). #14469 found `select`/`select_index` inheriting their
+        # bridge's read-level default because neither name matched a verb -- the
+        # guard's reach was decided by a list nobody revisits, while the set of
+        # real tools grows independently of it. This has to run in a REQUIRED
+        # check for the same directional reason as #14419/#14405/#14489: an
+        # under-declared tool makes the audit report FEWER problems, not more, so
+        # it goes greener by doing nothing. The pytest copy of this same guard
+        # runs in `python-suite`, which gates nothing (#14353). Fails below a
+        # discovery floor too, because a bridge scan that reaches zero tools
+        # (this pass found one: `sequential_thinking_mcp`'s only tool was
+        # declared in a source shape the original scanner never matched) reads
+        # as clean having asserted nothing.
+        python3 tools/lint/check_mcp_tool_permission_coverage.py --audit
+
     - name: Audit the python-file-size ceilings for drift (#14236)
       run: |
         # The pre-commit hook only sees staged files, so a grandfathered entry

--- a/autobot_shared/auth/mcp_bridge_scan.py
+++ b/autobot_shared/auth/mcp_bridge_scan.py
@@ -1,0 +1,80 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Static scan of MCP bridge sources for the tool names they register (#14494).
+
+Extracted from ``mcp_tool_permissions_test.py`` (#13228) so the coverage guard
+that has to run as a required check (``tools/lint/check_mcp_tool_permission_coverage.py``)
+and the pytest guards that exercise the same data read the identical answer.
+Two parsers of the same source text can drift the moment one of them misses a
+tool the other still catches — the exact "guard narrower than its own subject"
+shape #13228 already hit once, when globbing only ``*_mcp.py`` silently skipped
+``redis_mcp`` (a package, not a module): all 25 of its tools were undeclared and
+nothing said so.
+
+This module only parses source text. It does not decide what a tool is allowed
+to do — that is ``mcp_tool_permissions.py``.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+#: Bridges live under here; two parents up from this file (``autobot_shared/auth/``).
+BRIDGE_DIR = pathlib.Path(__file__).resolve().parents[2] / "autobot-backend" / "api"
+
+# Three source shapes a bridge uses to declare a tool:
+#  - a `("name", "description", {...})` tuple, 4-space indented inside a list
+#    literal (`[ ( ... ), ( ... ) ]`);
+#  - the same tuple assigned directly to an ALL_CAPS module-level constant, with
+#    no enclosing list. #14494: `sequential_thinking_mcp` declares its one tool
+#    this way, and the list-literal pattern alone never matched it -- that
+#    bridge's whole tool surface was invisible to every guard below it, an
+#    empty-enumeration case that read as clean because nothing was there to fail;
+#  - an MCP SDK `Tool(name="...", ...)` keyword argument.
+_TUPLE_TOOL = re.compile(r'^\s{4}\(\s*\n\s{8}"([a-z0-9_]+)"', re.M)
+_MODULE_TUPLE_TOOL = re.compile(r'^[A-Z_][A-Z0-9_]*\s*=\s*\(\s*\n\s{4}"([a-z0-9_]+)"', re.M)
+_KWARG_TOOL = re.compile(r'name="([a-z0-9_]+)"')
+
+
+def bridge_files(base: pathlib.Path | None = None) -> list[pathlib.Path]:
+    """Every bridge's tool-declaring source, module- or package-shaped.
+
+    #13228: globbing only ``*_mcp.py`` silently omitted ``redis_mcp``, which is
+    a package (``api/redis_mcp/tools.py``). ``manual_mcp`` is excluded on
+    purpose -- man-page lookup is not one of the eleven bridges this system
+    governs (#14494's issue enumerates them).
+    """
+    directory = base or BRIDGE_DIR
+    modules = [p for p in directory.glob("*_mcp.py") if p.stem != "manual_mcp"]
+    packages = [p / "tools.py" for p in directory.glob("*_mcp") if p.is_dir() and (p / "tools.py").is_file()]
+    return sorted(modules + packages)
+
+
+def bridge_name(path: pathlib.Path) -> str:
+    """The bridge a source file belongs to (``redis_mcp/tools.py`` -> ``redis_mcp``)."""
+    return path.parent.name if path.stem == "tools" else path.stem
+
+
+def declared_tools(path: pathlib.Path) -> set[str]:
+    """Tool names a bridge module declares, minus the bridge's own name."""
+    src = path.read_text(encoding="utf-8")
+    named = set(_TUPLE_TOOL.findall(src)) | set(_MODULE_TUPLE_TOOL.findall(src))
+    names = named or set(_KWARG_TOOL.findall(src))
+    return {n for n in names if n != bridge_name(path)}
+
+
+def all_declared_tools(base: pathlib.Path | None = None) -> dict[str, set[str]]:
+    """Bridge name -> set of tool names, for every bridge this system governs."""
+    return {bridge_name(p): declared_tools(p) for p in bridge_files(base)}
+
+
+__all__ = [
+    "BRIDGE_DIR",
+    "all_declared_tools",
+    "bridge_files",
+    "bridge_name",
+    "declared_tools",
+]

--- a/autobot_shared/auth/mcp_tool_permissions.py
+++ b/autobot_shared/auth/mcp_tool_permissions.py
@@ -26,9 +26,26 @@ Two levels, and the order matters:
    no exact entry here, which is what makes falling through to this baseline a
    CI-time event rather than a silent grant.
 
-A tool on an unknown bridge with no exact entry resolves to ``None``, which is
-what the enforcement stage (#13228 step 5) refuses. Absence is a denial, not a
-default-allow — that inversion is the point of the issue.
+**What this module actually guarantees, stated precisely (security review,
+#14521).** ``required_permission()`` is not changed by #14494 and still
+default-allows at runtime in both branches it can take:
+
+* a tool absent from ``TOOL_PERMISSIONS`` on a *known* bridge resolves through
+  ``BRIDGE_DEFAULT_PERMISSIONS`` — a real, grantable read permission, not a
+  denial (pinned by
+  ``test_an_undeclared_tool_on_a_known_bridge_inherits_the_least_privilege``);
+* a tool on an *unknown* bridge resolves to ``None``, and
+  ``PermissionEnforcementExtension`` currently treats ``None`` as legacy —
+  allowed through with no check at all.
+
+What #14494 actually delivers is **complete CI-time coverage**: every tool the
+eleven governed bridges register today has an exact entry, and
+``tools/lint/check_mcp_tool_permission_coverage.py`` (a required check) fails
+the moment a live tool has none. That coverage is backstopped at runtime only
+by the read-level default above — not by a denial. Tightening
+``required_permission``/the enforcement extension so an undeclared tool is
+refused rather than default-allowed at runtime is tracked separately as the
+#13228 stage-3 follow-up; this module does not attempt it.
 
 **#14494 — every tool this system knows about carries an exact entry below.**
 The under-grant guard used to infer "mutating" from a hand-written verb list
@@ -254,11 +271,17 @@ TOOL_PERMISSIONS: Dict[str, Permission] = {
 
 
 def required_permission(tool_name: str, bridge_name: str = "") -> Optional[Permission]:
-    """Return the permission *tool_name* requires, or ``None`` if undeclared.
+    """Return the permission *tool_name* requires, or ``None`` for an unknown bridge.
 
-    ``None`` means "no declaration exists", which the enforcement stage treats as
-    a refusal. It is deliberately not a permissive fallback: the whole defect in
-    #13228 is that an undeclared tool was reachable.
+    A tool absent from ``TOOL_PERMISSIONS`` still resolves through
+    ``BRIDGE_DEFAULT_PERMISSIONS`` as long as *bridge_name* is one of the eleven
+    governed bridges — a real, grantable read permission, not a refusal.
+    ``None`` only happens for a bridge this module has never heard of, and
+    ``PermissionEnforcementExtension`` currently treats that ``None`` as legacy
+    (allowed through, unchecked) rather than as a denial — see the module
+    docstring's "what this actually guarantees" note and the #13228 stage-3
+    follow-up. #14494 makes every tool on a *known* bridge carry an exact entry
+    at CI time; it does not change what this function returns.
     """
     exact = TOOL_PERMISSIONS.get(tool_name)
     if exact is not None:

--- a/autobot_shared/auth/mcp_tool_permissions.py
+++ b/autobot_shared/auth/mcp_tool_permissions.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
-"""Canonical permission required by each MCP tool (#13228).
+"""Canonical permission required by each MCP tool (#13228, #14494).
 
 MCP tool access was governed by ``MCPDispatcher._ADMIN_ONLY_TOOLS`` — a frozenset
 of **seven Redis command substrings**. Everything else on all eleven bridges was
@@ -19,12 +19,26 @@ Two levels, and the order matters:
 1. ``TOOL_PERMISSIONS`` — an exact tool name wins outright. This is where a
    destructive tool declares a stronger grant than its bridge's baseline.
 2. ``BRIDGE_DEFAULT_PERMISSIONS`` — the baseline for a bridge, chosen as its
-   **least**-privileged operation. A tool added tomorrow inherits read-level
-   access rather than whatever the blocklist happened to miss.
+   **least**-privileged operation. It exists as defense-in-depth for a tool
+   nobody has declared yet — never as the mechanism that decides one *should*
+   stay undeclared. ``tools/lint/check_mcp_tool_permission_coverage.py`` (a
+   required check, #14494) fails the moment a real bridge registers a tool with
+   no exact entry here, which is what makes falling through to this baseline a
+   CI-time event rather than a silent grant.
 
 A tool on an unknown bridge with no exact entry resolves to ``None``, which is
 what the enforcement stage (#13228 step 5) refuses. Absence is a denial, not a
 default-allow — that inversion is the point of the issue.
+
+**#14494 — every tool this system knows about carries an exact entry below.**
+The under-grant guard used to infer "mutating" from a hand-written verb list
+(``write``, ``delete``, ``click`` …) matched against a tool's *name*; a
+differently-named mutating tool (``select``, and — found by this pass —
+``intercept_api`` and ``desktop_special_key``) inherited its bridge's read-level
+default and nothing failed. There is no verb list anymore: every tool a bridge
+registers today is declared here explicitly, so classification is a property of
+the tool, not a guess from its name. ``_DECLARED_AHEAD_OF_TIME`` below is the
+only sanctioned exception, and only for a tool that does not exist yet.
 
 **This module only describes. It enforces nothing on its own.** Stage 1 attaches
 the resolved value to the registry entry so it can be inspected and logged;
@@ -53,79 +67,189 @@ BRIDGE_DEFAULT_PERMISSIONS: Dict[str, Permission] = {
     "vnc_mcp": Permission.MCP_DESKTOP_READ,
 }
 
+# Tool names declared ahead of a tool actually existing. Each is a real gap in
+# the old seven-substring blocklist — a pattern like "flushall" that matched no
+# tool the bridge registers today — kept declared so that if the tool is ever
+# added it arrives at its intended permission instead of arriving undeclared.
+#
+# `tools/lint/check_mcp_tool_permission_coverage.py` treats every OTHER
+# `TOOL_PERMISSIONS` entry as required to name a tool some bridge currently
+# registers — that is what catches a declaration stranded by a rename (#14494
+# found exactly one: `intercept_requests`, for a tool renamed `intercept_api`
+# with nothing left pointing at the live name). This set is the only exemption
+# from that reverse check, and it is asserted against the live scan in
+# `mcp_tool_permissions_test.py` so a rename or removal cannot silently turn a
+# "not yet built" declaration into a second stranded one.
+_DECLARED_AHEAD_OF_TIME: Dict[str, str] = {
+    "config_set": "redis_mcp",
+    "config_rewrite": "redis_mcp",
+    "debug": "redis_mcp",
+    "flushdb": "redis_mcp",
+    "flushall": "redis_mcp",
+    # filesystem_mcp registers no `delete_file` tool today; declared ahead of
+    # time so a future one arrives at FILES_DELETE rather than undeclared.
+    "delete_file": "filesystem_mcp",
+}
+
 # Exact tool names that need more than their bridge's baseline. Everything here
 # either changes state, leaves the machine, or reads something the baseline
 # grant does not cover.
 TOOL_PERMISSIONS: Dict[str, Permission] = {
     # --- browser: observation is the baseline; driving the page is not ---
+    "browser_state": Permission.MCP_BROWSER_READ,
     "click": Permission.MCP_BROWSER_CONTROL,
     "click_index": Permission.MCP_BROWSER_CONTROL,
     "fill": Permission.MCP_BROWSER_CONTROL,
     "fill_index": Permission.MCP_BROWSER_CONTROL,
+    "get_attribute": Permission.MCP_BROWSER_READ,
+    "get_text": Permission.MCP_BROWSER_READ,
     "hover": Permission.MCP_BROWSER_CONTROL,
     "hover_index": Permission.MCP_BROWSER_CONTROL,
     # #14469: `select` changes a dropdown's value same as click/fill do — its
-    # name carries none of the mutating verbs `mcp_tool_permissions_test.py`
-    # scans for, so the state-changing-tool guard never caught it inheriting
-    # the bridge's read-level default.
+    # name carried none of the mutating verbs the retired name-matching guard
+    # scanned for, so it inherited the bridge's read-level default silently.
     "select": Permission.MCP_BROWSER_CONTROL,
     "select_index": Permission.MCP_BROWSER_CONTROL,
     # `evaluate` runs caller-supplied JavaScript in the page — the strongest
     # thing this bridge can do, and it read as an ordinary user tool before.
     "evaluate": Permission.MCP_BROWSER_CONTROL,
-    "intercept_requests": Permission.MCP_BROWSER_CONTROL,
+    # #14494: the tool is `intercept_api`, not `intercept_requests` — the name
+    # this entry carried until this pass. `intercept_api` injects an interceptor
+    # script into the page on every navigation (`page.add_init_script`, the same
+    # category of action as `evaluate`), and the stale name meant the live tool
+    # had never actually been declared: it inherited MCP_BROWSER_READ.
+    "intercept_api": Permission.MCP_BROWSER_CONTROL,
+    "navigate": Permission.MCP_BROWSER_READ,
+    "page_snapshot": Permission.MCP_BROWSER_READ,
+    "screenshot": Permission.MCP_BROWSER_READ,
+    "wait_for_selector": Permission.MCP_BROWSER_READ,
     # --- database: reads are the baseline; anything that can mutate is not ---
+    "database_describe_schema": Permission.MCP_DATABASE_READ,
     "database_execute": Permission.MCP_DATABASE_WRITE,
+    "database_list_databases": Permission.MCP_DATABASE_READ,
+    "database_list_tables": Permission.MCP_DATABASE_READ,
+    "database_query": Permission.MCP_DATABASE_READ,
+    "database_statistics": Permission.MCP_DATABASE_READ,
     # --- http: a GET/HEAD is a read; the rest send a body or change state ---
+    "http_delete": Permission.MCP_HTTP_WRITE,
+    "http_get": Permission.MCP_HTTP_READ,
+    "http_head": Permission.MCP_HTTP_READ,
+    "http_patch": Permission.MCP_HTTP_WRITE,
     "http_post": Permission.MCP_HTTP_WRITE,
     "http_put": Permission.MCP_HTTP_WRITE,
-    "http_patch": Permission.MCP_HTTP_WRITE,
-    "http_delete": Permission.MCP_HTTP_WRITE,
     # --- filesystem: FILES_VIEW is the baseline; these write or destroy ---
-    "edit_file": Permission.FILES_UPLOAD,
-    "write_file": Permission.FILES_UPLOAD,
     "create_directory": Permission.FILES_UPLOAD,
+    "directory_tree": Permission.FILES_VIEW,
+    "edit_file": Permission.FILES_UPLOAD,
+    "get_file_info": Permission.FILES_VIEW,
+    "list_allowed_directories": Permission.FILES_VIEW,
+    "list_directory": Permission.FILES_VIEW,
+    "list_directory_with_sizes": Permission.FILES_VIEW,
     "move_file": Permission.FILES_UPLOAD,
-    "delete_file": Permission.FILES_DELETE,
+    "read_media_file": Permission.FILES_VIEW,
+    "read_multiple_files": Permission.FILES_VIEW,
+    "read_text_file": Permission.FILES_VIEW,
+    "search_files": Permission.FILES_VIEW,
+    "write_file": Permission.FILES_UPLOAD,
+    # --- git: every registered tool reads the repository; nothing mutates it ---
+    "git_blame": Permission.MCP_GIT_READ,
+    "git_branch": Permission.MCP_GIT_READ,
+    "git_diff": Permission.MCP_GIT_READ,
+    "git_log": Permission.MCP_GIT_READ,
+    "git_show": Permission.MCP_GIT_READ,
+    "git_status": Permission.MCP_GIT_READ,
     # --- knowledge: reading is the baseline; ingesting is a write ---
     "add_to_knowledge_base": Permission.KNOWLEDGE_WRITE,
     "crawl_site": Permission.KNOWLEDGE_WRITE,
-    # Found by test_state_changing_tools_carry_an_explicit_declaration on its
-    # first run: mcp_crawl registers a WebCrawlerConnector and ingests, so
-    # inheriting KNOWLEDGE_READ would have under-granted it.
-    "mcp_crawl": Permission.KNOWLEDGE_WRITE,
+    "extract_structured_data": Permission.KNOWLEDGE_READ,
+    "get_knowledge_stats": Permission.KNOWLEDGE_READ,
+    "langchain_qa_chain": Permission.KNOWLEDGE_READ,
     "map_site": Permission.KNOWLEDGE_WRITE,
+    # Found by the guard's first run against the real bridges (#13228): mcp_crawl
+    # registers a WebCrawlerConnector and ingests, so inheriting KNOWLEDGE_READ
+    # would have under-granted it.
+    "mcp_crawl": Permission.KNOWLEDGE_WRITE,
+    # #14494: `operation` can be "flush", "reindex" or "backup" as well as
+    # "info" — a single tool whose worst-case action can empty the vector store,
+    # currently undeclared and therefore reachable with mere KNOWLEDGE_READ.
+    "redis_vector_operations": Permission.KNOWLEDGE_MANAGE,
+    "scrape_url": Permission.KNOWLEDGE_READ,
+    "search_knowledge_base": Permission.KNOWLEDGE_READ,
+    "summarize_knowledge_topic": Permission.KNOWLEDGE_READ,
+    "vector_similarity_search": Permission.KNOWLEDGE_READ,
+    # --- prometheus: every registered tool is a metrics/health read ---
+    "get_service_health": Permission.MCP_METRICS_READ,
+    "get_system_metrics": Permission.MCP_METRICS_READ,
+    "get_vm_metrics": Permission.MCP_METRICS_READ,
+    "list_available_metrics": Permission.MCP_METRICS_READ,
+    "query_metric": Permission.MCP_METRICS_READ,
+    "query_range": Permission.MCP_METRICS_READ,
     # --- desktop/vnc: observing is the baseline; driving input is not ---
-    "desktop_mouse_click": Permission.MCP_DESKTOP_CONTROL,
-    "desktop_keyboard_type": Permission.MCP_DESKTOP_CONTROL,
+    "check_vnc_status": Permission.MCP_DESKTOP_READ,
     "desktop_control_status": Permission.MCP_DESKTOP_CONTROL,
+    "desktop_keyboard_type": Permission.MCP_DESKTOP_CONTROL,
+    "desktop_mouse_click": Permission.MCP_DESKTOP_CONTROL,
+    "desktop_observe_state": Permission.MCP_DESKTOP_READ,
+    "desktop_screenshot": Permission.MCP_DESKTOP_READ,
+    # #14494: sends key combinations (Return, Escape, ctrl+c, alt+tab …) to the
+    # desktop — the same category as desktop_keyboard_type — and was undeclared,
+    # so it inherited MCP_DESKTOP_READ.
+    "desktop_special_key": Permission.MCP_DESKTOP_CONTROL,
+    "get_browser_vnc_context": Permission.MCP_DESKTOP_READ,
+    "observe_vnc_activity": Permission.MCP_DESKTOP_READ,
     # --- redis: reads are the baseline; these mutate or expose the server ---
     #
-    # These keys are the tools' real names. The blocklist they replace matched by
-    # *substring* ("client_list" in "redis_client_list"), which hid the mismatch:
-    # exact lookup here found nothing, so every redis tool read as undeclared.
-    "redis_set": Permission.MCP_DATABASE_WRITE,
-    "redis_delete": Permission.MCP_DATABASE_WRITE,
-    "redis_hset": Permission.MCP_DATABASE_WRITE,
-    "redis_lpush": Permission.MCP_DATABASE_WRITE,
-    "redis_rpush": Permission.MCP_DATABASE_WRITE,
-    "redis_xadd": Permission.MCP_DATABASE_WRITE,
-    "redis_vector_create_index": Permission.MCP_DATABASE_WRITE,
+    # These keys are the tools' real names. The blocklist they replaced matched
+    # by *substring* ("client_list" in "redis_client_list"), which hid the
+    # mismatch: exact lookup here found nothing, so every redis tool read as
+    # undeclared.
     "redis_client_list": Permission.MCP_MANAGE,
+    "redis_dbsize": Permission.MCP_DATABASE_READ,
+    "redis_delete": Permission.MCP_DATABASE_WRITE,
+    "redis_get": Permission.MCP_DATABASE_READ,
+    "redis_hget": Permission.MCP_DATABASE_READ,
+    "redis_hgetall": Permission.MCP_DATABASE_READ,
+    "redis_hset": Permission.MCP_DATABASE_WRITE,
+    "redis_hybrid_search": Permission.MCP_DATABASE_READ,
+    "redis_lpush": Permission.MCP_DATABASE_WRITE,
+    "redis_lrange": Permission.MCP_DATABASE_READ,
+    "redis_memory_stats": Permission.MCP_DATABASE_READ,
+    "redis_rpush": Permission.MCP_DATABASE_WRITE,
+    "redis_scan_keys": Permission.MCP_DATABASE_READ,
+    "redis_server_info": Permission.MCP_DATABASE_READ,
+    "redis_set": Permission.MCP_DATABASE_WRITE,
     "redis_slowlog": Permission.MCP_MANAGE,
-    # Declared explicitly to state that it is a *read*: the mutating-verb guard
-    # reads "type" in `redis_type` as the input-driving verb from
+    "redis_stream_health": Permission.MCP_DATABASE_READ,
+    "redis_ttl": Permission.MCP_DATABASE_READ,
+    # Declared explicitly to state that it is a *read*: the retired name-matching
+    # guard read "type" in `redis_type` as the input-driving verb from
     # `desktop_keyboard_type`. It returns a key's type and changes nothing.
     "redis_type": Permission.MCP_DATABASE_READ,
-    # The remaining blocklist patterns — config_set, config_rewrite, debug,
-    # flushdb, flushall — name no tool the redis bridge currently registers, so
-    # the old gate protected nothing. Declared anyway: if any of them is ever
-    # added, it arrives admin-only instead of arriving undeclared.
+    "redis_vector_create_index": Permission.MCP_DATABASE_WRITE,
+    "redis_vector_index_info": Permission.MCP_DATABASE_READ,
+    "redis_vector_search": Permission.MCP_DATABASE_READ,
+    "redis_xadd": Permission.MCP_DATABASE_WRITE,
+    "redis_xrange": Permission.MCP_DATABASE_READ,
+    "redis_zrange": Permission.MCP_DATABASE_READ,
+    # The blocklist patterns with no live tool today. See
+    # `_DECLARED_AHEAD_OF_TIME` above — this bridge's baseline is already the
+    # weakest tier, so admin-only is the correct grant if any of them ships.
     "config_set": Permission.MCP_MANAGE,
     "config_rewrite": Permission.MCP_MANAGE,
     "debug": Permission.MCP_MANAGE,
     "flushdb": Permission.MCP_MANAGE,
     "flushall": Permission.MCP_MANAGE,
+    # --- filesystem: declared ahead of a tool that does not exist yet ---
+    "delete_file": Permission.FILES_DELETE,
+    # --- sequential/structured thinking: single-tier bridges (#14494) ---
+    # Neither bridge exposes a stronger grant than AGENT_EXECUTE, so an
+    # undeclared tool here cannot under-grant relative to its default — these
+    # entries exist so the coverage guard has an exact answer for every real
+    # tool, not because the value differs from the baseline.
+    "sequential_thinking": Permission.AGENT_EXECUTE,
+    "clear_history": Permission.AGENT_EXECUTE,
+    "generate_summary": Permission.AGENT_EXECUTE,
+    "process_thought": Permission.AGENT_EXECUTE,
 }
 
 

--- a/autobot_shared/auth/mcp_tool_permissions_test.py
+++ b/autobot_shared/auth/mcp_tool_permissions_test.py
@@ -2,21 +2,34 @@
 # SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
-"""Every MCP tool declares a permission that exists (#13228).
+"""Every MCP tool declares a permission that exists (#13228, #14494).
 
 The defect was a seven-entry Redis substring blocklist governing all eleven
 bridges, default-allow. The risk in replacing it is a *different* silent failure:
 a declaration that names a permission the enum does not have, or a bridge whose
 tools nobody declared. Both are checked here, offline — the bridge sources are
 parsed rather than a live registry queried, so this runs in CI without a backend.
+
+#14494 retired the guard that used to sit at the bottom of this file
+(``_MUTATING``, a hand-written verb tuple matched against a tool's name). It
+caught an under-grant only when a tool's name happened to contain the right
+verb — ``select`` did not, and inherited MCP_BROWSER_READ despite changing a
+dropdown's value (#14469) — so the coverage it looked like it provided was an
+illusion the moment a bridge added a tool named something else. The guard that
+replaces it, ``tools/lint/check_mcp_tool_permission_coverage.py`` (a required
+check, because the pytest copy of a guard like this gates nothing — #14353),
+requires every live tool to be an *exact* key in ``TOOL_PERMISSIONS``: no verb
+list to dodge, only a missing entry.
 """
 
+import importlib.util
 import pathlib
-import re
 
 import pytest
 
+from autobot_shared.auth.mcp_bridge_scan import bridge_files, bridge_name, declared_tools
 from autobot_shared.auth.mcp_tool_permissions import (
+    _DECLARED_AHEAD_OF_TIME,
     BRIDGE_DEFAULT_PERMISSIONS,
     TOOL_PERMISSIONS,
     required_permission,
@@ -24,36 +37,20 @@ from autobot_shared.auth.mcp_tool_permissions import (
 from autobot_shared.auth.permissions import ROLE_PERMISSIONS, Permission, Role
 
 _BRIDGE_DIR = pathlib.Path(__file__).resolve().parents[2] / "autobot-backend" / "api"
-
-# Tool names declared as `("name", "description", {...})` tuples, or `name="..."`.
-_TUPLE_TOOL = re.compile(r'^\s{4}\(\s*\n\s{8}"([a-z0-9_]+)"', re.M)
-_KWARG_TOOL = re.compile(r'name="([a-z0-9_]+)"')
+_CHECKER_PATH = pathlib.Path(__file__).resolve().parents[2] / "tools" / "lint" / "check_mcp_tool_permission_coverage.py"
 
 
-def _bridge_files():
-    """Every bridge's tool-declaring source, module- or package-shaped.
+def _load_coverage_checker():
+    """Import the required-check script by path — tools/lint is not a package.
 
-    #13228: globbing only ``*_mcp.py`` silently omitted ``redis_mcp``, which is a
-    package (``api/redis_mcp/tools.py``). The omission was invisible precisely
-    because these guards iterate over whatever this function returns — a bridge it
-    cannot see is a bridge every coverage test below reports as fine. All 25 redis
-    tools were undeclared and no test said so.
+    The decision that blocks a merge lives in that script, not here. Restating
+    the comparison would give the guard two definitions that could drift; this
+    runs the exact copy CI executes.
     """
-    modules = [p for p in _BRIDGE_DIR.glob("*_mcp.py") if p.stem != "manual_mcp"]
-    packages = [p / "tools.py" for p in _BRIDGE_DIR.glob("*_mcp") if p.is_dir() and (p / "tools.py").is_file()]
-    return sorted(modules + packages)
-
-
-def _bridge_name(path: pathlib.Path) -> str:
-    """The bridge a source file belongs to (``redis_mcp/tools.py`` → ``redis_mcp``)."""
-    return path.parent.name if path.stem == "tools" else path.stem
-
-
-def _declared_tools(path: pathlib.Path) -> set:
-    """Tool names a bridge module declares, minus the bridge's own name."""
-    src = path.read_text(encoding="utf-8")
-    names = set(_TUPLE_TOOL.findall(src)) or set(_KWARG_TOOL.findall(src))
-    return {n for n in names if n != _bridge_name(path)}
+    spec = importlib.util.spec_from_file_location("_mcp_coverage_checker", _CHECKER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 # ------------------------------------------------------- the declarations
@@ -83,7 +80,7 @@ def test_every_declared_permission_is_granted_to_some_role():
 
 def test_every_bridge_has_a_default():
     """A bridge with no default leaves its whole tool surface undeclared."""
-    bridges = {_bridge_name(p) for p in _bridge_files()}
+    bridges = {bridge_name(p) for p in bridge_files()}
 
     assert not (
         bridges - set(BRIDGE_DEFAULT_PERMISSIONS)
@@ -92,52 +89,25 @@ def test_every_bridge_has_a_default():
 
 def test_the_bridge_sources_are_actually_being_read():
     """Guard the guard: a parser that finds nothing would pass everything."""
-    found = {_bridge_name(p): _declared_tools(p) for p in _bridge_files()}
+    found = {bridge_name(p): declared_tools(p) for p in bridge_files()}
     total = sum(len(v) for v in found.values())
 
     assert total > 50, f"only {total} tool names extracted — the parser stopped matching: {found}"
 
 
-# Verbs that mean a tool changes state, sends a body, or drives input. A tool
-# named with one of these must carry an EXPLICIT entry — inheriting its bridge's
-# read-level baseline is the silent under-grant this issue exists to prevent.
-_MUTATING = (
-    "write",
-    "delete",
-    "remove",
-    "create",
-    "edit",
-    "move",
-    "execute",
-    "set",
-    "post",
-    "put",
-    "patch",
-    "click",
-    "type",
-    "fill",
-    "hover",
-    "evaluate",
-    "flush",
-    "crawl",
-    "add_",
-)
+def test_every_live_tool_carries_an_explicit_declaration():
+    """#14494: the actual required-check guard, run against the real tree.
 
-
-@pytest.mark.parametrize("bridge", [_bridge_name(p) for p in _bridge_files()])
-def test_state_changing_tools_carry_an_explicit_declaration(bridge):
-    """A mutating tool must not silently inherit a read-level bridge default.
-
-    Checking `required_permission(...) is not None` would be tautological — every
-    known bridge has a default, so nothing on one can resolve to None. The real
-    risk is a write tool quietly inheriting read, which is what this catches.
+    No verb list — a mutating tool named something the retired guard never
+    matched (this pass found `intercept_api` and `desktop_special_key`) can no
+    longer inherit its bridge's read-level default silently: an undeclared tool
+    is a failure here, not a fallback.
     """
-    path = next(p for p in _bridge_files() if _bridge_name(p) == bridge)
-    inheriting = [
-        t for t in sorted(_declared_tools(path)) if any(verb in t for verb in _MUTATING) and t not in TOOL_PERMISSIONS
-    ]
+    checker = _load_coverage_checker()
+    reached, problems = checker.audit()
 
-    assert not inheriting, f"{bridge}: mutating tools inheriting a read default: {inheriting}"
+    assert reached >= checker.DISCOVERY_FLOOR, "the bridge scan reached too few tools — see the checker's own floor"
+    assert not problems, "\n\n".join(problems)
 
 
 # -------------------------------------------------------- resolution rules
@@ -155,7 +125,10 @@ def test_an_unknown_bridge_resolves_to_none():
 
 
 def test_an_undeclared_tool_on_a_known_bridge_inherits_the_least_privilege():
-    """A tool added tomorrow under-grants rather than over-grants."""
+    """A tool `required_permission` has never heard of under-grants rather than
+    over-grants. `tools/lint/check_mcp_tool_permission_coverage.py` is what stops
+    a REAL tool from staying in this state (#14494) — this pins the fallback
+    itself, which stays in place as defense-in-depth."""
     assert required_permission("some_future_tool", "browser_mcp") == Permission.MCP_BROWSER_READ
 
 
@@ -170,17 +143,19 @@ def test_the_old_blocklist_tools_still_require_management():
         assert required_permission(name, "redis_mcp") == Permission.MCP_MANAGE, name
 
 
-def test_the_blocklist_patterns_that_name_no_tool_are_still_declared():
-    """``flushall`` and friends match nothing the redis bridge registers today.
+@pytest.mark.parametrize("name,bridge", sorted(_DECLARED_AHEAD_OF_TIME.items()))
+def test_declared_ahead_of_time_tools_still_name_no_live_tool(name, bridge):
+    """Every ``_DECLARED_AHEAD_OF_TIME`` entry matches nothing a real bridge
+    registers today — ``flushall`` and friends match nothing ``redis_mcp``
+    registers, and ``delete_file`` matches nothing ``filesystem_mcp`` registers.
+    Kept declared anyway: if one of these ships, it arrives at its intended
+    permission instead of arriving undeclared. If this fails, the tool now
+    exists — fold it into a real-name test above with its own reasoned entry,
+    the way #14469's `select` and this pass's `intercept_api` were."""
+    path = next(p for p in bridge_files() if bridge_name(p) == bridge)
+    registered = declared_tools(path)
 
-    So the old gate protected nothing. Kept declared anyway: if one is ever added,
-    it arrives admin-only rather than arriving undeclared.
-    """
-    registered = _declared_tools(_BRIDGE_DIR / "redis_mcp" / "tools.py")
-
-    for name in ("config_set", "config_rewrite", "debug", "flushdb", "flushall"):
-        assert name not in registered, f"{name} now exists — fold it into the real-name test above"
-        assert required_permission(name, "redis_mcp") == Permission.MCP_MANAGE, name
+    assert name not in registered, f"{name} now exists on {bridge} — it needs its own declaration, not this exemption"
 
 
 def test_browser_evaluate_is_not_a_read():
@@ -190,10 +165,32 @@ def test_browser_evaluate_is_not_a_read():
 
 def test_browser_select_is_not_a_read():
     """#14469: `select` changes a dropdown's value, same as click/fill — its name
-    carries none of `_MUTATING`'s verbs, so it silently inherited the bridge's
-    read-level default until declared here explicitly."""
+    carried none of the retired name-matching guard's verbs, so it silently
+    inherited the bridge's read-level default until declared here explicitly."""
     assert required_permission("select", "browser_mcp") == Permission.MCP_BROWSER_CONTROL
     assert required_permission("select_index", "browser_mcp") == Permission.MCP_BROWSER_CONTROL
+
+
+def test_browser_intercept_api_is_not_a_read():
+    """#14494: found declared under a name (`intercept_requests`) the bridge does
+    not register — the real tool is `intercept_api`, which injects an
+    interceptor script into the page (`page.add_init_script`), the same category
+    of action as `evaluate`. It had never actually been declared."""
+    assert required_permission("intercept_api", "browser_mcp") == Permission.MCP_BROWSER_CONTROL
+    assert "intercept_requests" not in TOOL_PERMISSIONS
+
+
+def test_desktop_special_key_is_not_a_read():
+    """#14494: sends key combinations (Return, Escape, ctrl+c, alt+tab …) to the
+    desktop — the same category as desktop_keyboard_type — and was undeclared."""
+    assert required_permission("desktop_special_key", "vnc_mcp") == Permission.MCP_DESKTOP_CONTROL
+
+
+def test_knowledge_redis_vector_operations_is_not_a_read():
+    """#14494: `operation` can be "flush", "reindex" or "backup", not only "info"
+    — a tool whose worst case empties the vector store, undeclared and therefore
+    reachable with mere KNOWLEDGE_READ."""
+    assert required_permission("redis_vector_operations", "knowledge_mcp") == Permission.KNOWLEDGE_MANAGE
 
 
 def test_readonly_holds_no_control_grant():

--- a/tools/lint/check_mcp_tool_permission_coverage.py
+++ b/tools/lint/check_mcp_tool_permission_coverage.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""#14494 — every tool a live MCP bridge registers must carry an exact permission entry.
+
+``autobot_shared/auth/mcp_tool_permissions.py`` used to be checked by a guard
+that inferred "this tool is state-changing" from whether its name contained one
+of a hand-written list of verbs (``write``, ``delete``, ``click`` …). A tool
+named something else — ``select``, and this pass found two more —
+inherited its bridge's read-level default and nothing failed. The guard's
+reach was decided by a list nobody revisits, while the set of real tools grows
+independently of it: a future ``toggle_x``, ``enable_x``, ``restart_x``,
+``grant_x`` or ``approve_x`` would have inherited read-level access exactly the
+same way, silently.
+
+There is no verb list here. This module scans every bridge's source for the
+tool names it actually registers (``autobot_shared.auth.mcp_bridge_scan``, the
+same parser the pytest guards use — see that module's docstring for why a
+second copy is the risk, not the fix) and requires each one to be an *exact*
+key in ``TOOL_PERMISSIONS``. Falling through to ``BRIDGE_DEFAULT_PERMISSIONS``
+is no longer how an undeclared tool is allowed to be found — it is what this
+check fails on.
+
+``_DECLARED_AHEAD_OF_TIME`` in ``mcp_tool_permissions.py`` is the only
+exemption, and only in the other direction: a handful of entries pre-declared
+for a tool that does not exist on its bridge yet. This module re-proves each
+one still names no live tool, so a rename or a shipped feature cannot leave a
+declaration stranded and pointed at nothing while the tool it was meant to
+cover — #14494 found exactly this shape once already, `intercept_requests`
+naming nothing after the real tool became `intercept_api` — goes undeclared
+under its new name.
+
+WHY A REQUIRED CHECK AND NOT ONLY A TEST. The pytest copy of these assertions
+runs in `python-suite`, which gates nothing (#14353, and the same reason
+#14419's `check_flake8_exclude_anchoring.py` runs here rather than only in
+pytest). The direction of this failure is what makes placement matter: an
+under-granted tool makes `mcp_tool_permissions_test.py` and this module both
+GREENER by doing nothing, not redder — there is no accidental failure to
+notice. `.github/workflows/code-quality.yml` therefore calls this module with
+``--audit``, the same shape as ``check_flake8_exclude_anchoring.py
+--audit-excludes`` and ``check_infra_scripts_undefined_names.py --audit``.
+
+The audit reports how many live tools it reached and fails below a floor,
+because a scan that finds zero tools passes having asserted nothing — the
+exact failure mode #14494 found in ``sequential_thinking_mcp``, whose one tool
+was declared in a source shape the original scanner never matched.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import pathlib
+import sys
+
+# `tools/lint` is not an importable package in CI's invocation (`python3
+# tools/lint/check_mcp_tool_permission_coverage.py`, run from the repo root
+# with no PYTHONPATH set) — the repo root has to be added explicitly before
+# `autobot_shared` resolves, the same requirement the pytest side gets for
+# free from `pytestini`'s `pythonpath = . autobot-backend autobot_shared …`.
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from autobot_shared.auth.mcp_bridge_scan import all_declared_tools  # noqa: E402
+from autobot_shared.auth.mcp_tool_permissions import (  # noqa: E402
+    _DECLARED_AHEAD_OF_TIME,
+    TOOL_PERMISSIONS,
+)
+
+# Plain stdlib logging, deliberately (#1082) — same trade as
+# `check_infra_scripts_undefined_names.py`: this runs as a bare script inside a
+# required check, and `autobot_shared.logging_manager` would drag config
+# loading into that path.
+logger = logging.getLogger(__name__)
+
+#: Repo-relative path of this checker, quoted in the messages that ask for an edit.
+SELF_REL = "tools/lint/check_mcp_tool_permission_coverage.py"
+
+#: Floor for the sweep's own discovery. The eleven governed bridges registered
+#: 104 tools when this landed; a sweep that suddenly reaches a handful has
+#: broken, and a clean result from it would assert nothing.
+DISCOVERY_FLOOR = 90
+
+
+def undeclared_tools(base: pathlib.Path | None = None) -> dict[str, list[str]]:
+    """Bridge -> live tool names with no exact ``TOOL_PERMISSIONS`` entry.
+
+    This is the primary defect #14494 exists to catch: a tool a bridge really
+    registers, reachable today, resolving through the bridge default because
+    nobody declared it.
+    """
+    problems: dict[str, list[str]] = {}
+    for bridge, tools in all_declared_tools(base).items():
+        missing = sorted(t for t in tools if t not in TOOL_PERMISSIONS)
+        if missing:
+            problems[bridge] = missing
+    return problems
+
+
+def stale_declarations(base: pathlib.Path | None = None) -> list[str]:
+    """``TOOL_PERMISSIONS`` entries naming no tool any live bridge registers.
+
+    Excludes ``_DECLARED_AHEAD_OF_TIME`` — those are meant to name nothing yet.
+    Anything else here is a declaration stranded by a rename or a removal: it
+    looks like coverage while covering nothing, which is how ``intercept_api``
+    went undeclared under its real name while ``intercept_requests`` still sat
+    in the table (#14494).
+    """
+    live = {tool for tools in all_declared_tools(base).values() for tool in tools}
+    unexplained = set(TOOL_PERMISSIONS) - live - set(_DECLARED_AHEAD_OF_TIME)
+    return sorted(unexplained)
+
+
+def declared_ahead_of_time_problems(base: pathlib.Path | None = None) -> list[str]:
+    """Re-prove each ``_DECLARED_AHEAD_OF_TIME`` entry still names no live tool.
+
+    If one of these ships, the entry is doing its job — but it has to move out
+    of this set and get its own reasoned comment, the same way #14469's
+    `select`/`select_index` and this pass's `intercept_api` did, or the fact
+    that it is now reachable stops being reviewed by anyone.
+    """
+    live = {tool for tools in all_declared_tools(base).values() for tool in tools}
+    now_live = sorted(name for name in _DECLARED_AHEAD_OF_TIME if name in live)
+    if not now_live:
+        return []
+    return [
+        f"{name} (declared ahead of time for {_DECLARED_AHEAD_OF_TIME[name]}) is now a live "
+        "tool — move it out of _DECLARED_AHEAD_OF_TIME in mcp_tool_permissions.py and give it "
+        "its own reasoned entry."
+        for name in now_live
+    ]
+
+
+def audit(base: pathlib.Path | None = None) -> tuple[int, list[str]]:
+    """Sweep every governed bridge. Returns (tools reached, problems)."""
+    found = all_declared_tools(base)
+    reached = sum(len(tools) for tools in found.values())
+
+    problems: list[str] = []
+    if reached < DISCOVERY_FLOOR:
+        problems.append(
+            f"the bridge scan reached only {reached} tool(s) across {len(found)} bridge(s) "
+            f"(floor {DISCOVERY_FLOOR}) — the sweep broke, so a clean result below would "
+            "assert nothing."
+        )
+
+    undeclared = undeclared_tools(base)
+    if undeclared:
+        lines = "\n".join(f"  {bridge}: {', '.join(names)}" for bridge, names in sorted(undeclared.items()))
+        problems.append(
+            "tool(s) a live bridge registers with no exact entry in TOOL_PERMISSIONS "
+            "(autobot_shared/auth/mcp_tool_permissions.py) — each one silently inherits its "
+            f"bridge's read-level default (#14494):\n{lines}\n\nAdd an exact entry for each, at "
+            "the permission the tool actually needs."
+        )
+
+    problems.extend(declared_ahead_of_time_problems(base))
+
+    stale = stale_declarations(base)
+    if stale:
+        problems.append(
+            "TOOL_PERMISSIONS entries naming no tool any live bridge registers, outside "
+            f"_DECLARED_AHEAD_OF_TIME: {', '.join(stale)}. A declaration stranded by a rename "
+            "exempts nothing while looking covered (#14494) — point it at the tool's current "
+            "name, or move it into _DECLARED_AHEAD_OF_TIME with a reason if the tool genuinely "
+            "does not exist yet."
+        )
+
+    return reached, problems
+
+
+def configure_logging() -> None:
+    """Attach a stderr handler so findings actually reach the developer.
+
+    Run as a bare script the module logger has no handler, and logging's
+    last-resort path drops anything below WARNING.
+    """
+    if not logger.handlers:
+        handler = logging.StreamHandler(sys.stderr)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+
+
+def main(argv: list[str]) -> int:
+    configure_logging()
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--audit",
+        action="store_true",
+        help="sweep every tool every governed MCP bridge registers",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.audit:
+        parser.error("nothing to do — pass --audit")
+
+    reached, problems = audit()
+    scope = f"{reached} tools across every governed MCP bridge"
+
+    if problems:
+        logger.error("%s", "\n\n".join(problems))
+        logger.error("\nMCP tool permission coverage audit FAILED over %s (#14494).", scope)
+        return 1
+    logger.info("MCP tool permission coverage audit clean over %s (#14494).", scope)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tools/lint/check_mcp_tool_permission_coverage_test.py
+++ b/tools/lint/check_mcp_tool_permission_coverage_test.py
@@ -1,0 +1,119 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Guards for the MCP tool permission coverage checker (#14494).
+
+The checker it exercises replaces a guard that inferred "mutating" from a
+hand-written verb list matched against a tool's name — a tool named something
+else inherited its bridge's read-level default and nothing failed. The property
+worth pinning here is the same one `check_extension_import_boundaries_test.py`
+pins for its own checker: a tool *nobody named in any list* is still blocked,
+because blocking depends on an exact declaration existing, not on a name
+pattern matching.
+
+These tests run the checker **in process** against directories under
+``tmp_path`` — never against the real bridge sources, so a probe file can never
+leak into (or be raced by another test globbing) the real tree.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_CHECKER_PATH = REPO_ROOT / "tools" / "lint" / "check_mcp_tool_permission_coverage.py"
+
+
+def _load_checker():
+    """Import the checker by path — tools/lint is not an importable package.
+
+    The decision lives in the script `code-quality` runs, not here. Restating
+    it would give the guard two definitions that could drift, and the copy CI
+    executes is the one that matters.
+    """
+    spec = importlib.util.spec_from_file_location("_mcp_coverage_checker", _CHECKER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def checker():
+    return _load_checker()
+
+
+def _probe_bridge(tmp_path: Path, filename: str, *tool_names: str) -> Path:
+    """A synthetic ``*_mcp.py`` bridge declaring *tool_names* via the kwarg form."""
+    target = tmp_path / filename
+    body = "\n".join(f'Tool(name="{name}", description="probe")' for name in tool_names)
+    target.write_text(body + "\n", encoding="utf-8")
+    return target
+
+
+def test_repo_currently_passes_the_coverage_audit(checker):
+    """The discrimination tests below are meaningless if the real tree is already red."""
+    reached, problems = checker.audit()
+    assert reached >= checker.DISCOVERY_FLOOR
+    assert not problems, "\n\n".join(problems)
+
+
+def test_an_undeclared_tool_with_no_matching_verb_is_blocked(checker, tmp_path):
+    """The whole point of #14494: no verb list to dodge, only a missing entry.
+
+    `toggle_feature_flag` matches none of the retired guard's verbs (write,
+    delete, click, …) — exactly the shape a future under-grant would take.
+    """
+    _probe_bridge(tmp_path, "probe_mcp.py", "toggle_feature_flag")
+
+    problems = checker.undeclared_tools(base=tmp_path)
+
+    assert problems == {"probe_mcp": ["toggle_feature_flag"]}
+
+
+def test_a_declared_tool_is_not_flagged(checker, tmp_path, monkeypatch):
+    monkeypatch.setattr(checker, "TOOL_PERMISSIONS", {"already_declared": object()})
+    _probe_bridge(tmp_path, "probe_mcp.py", "already_declared")
+
+    assert checker.undeclared_tools(base=tmp_path) == {}
+
+
+def test_an_empty_bridge_directory_does_not_read_as_clean(checker, tmp_path):
+    """A scan that finds zero tools must fail, not pass having asserted nothing."""
+    reached, problems = checker.audit(base=tmp_path)
+
+    assert reached == 0
+    assert problems, "an empty enumeration must not be indistinguishable from success"
+    assert any("reached only 0" in p for p in problems)
+
+
+def test_a_declaration_stranded_by_a_rename_is_flagged(checker, tmp_path, monkeypatch):
+    """#14494's own finding: `intercept_requests` named nothing once the tool
+    it covered became `intercept_api` — the entry still 'passed' because
+    nothing checked the reverse direction."""
+    monkeypatch.setattr(checker, "TOOL_PERMISSIONS", {"renamed_away": object(), "still_live": object()})
+    monkeypatch.setattr(checker, "_DECLARED_AHEAD_OF_TIME", {})
+    _probe_bridge(tmp_path, "probe_mcp.py", "still_live")
+
+    assert checker.stale_declarations(base=tmp_path) == ["renamed_away"]
+
+
+def test_declared_ahead_of_time_entries_are_exempt_from_the_stale_check(checker, tmp_path):
+    """Isolates the exemption itself: with an empty bridge directory (nothing
+    live at all) every real `_DECLARED_AHEAD_OF_TIME` entry must still be
+    absent from `stale_declarations` — the exemption has to hold structurally,
+    not merely because a scan happened to find the tool live somewhere."""
+    assert set(checker._DECLARED_AHEAD_OF_TIME) & set(checker.stale_declarations(base=tmp_path)) == set()
+
+
+def test_a_declared_ahead_of_time_tool_going_live_is_flagged(checker, tmp_path):
+    """Once a pre-declared tool ships, it needs its own reasoned entry, not a
+    permanent exemption from the reverse check."""
+    _probe_bridge(tmp_path, "probe_mcp.py", "delete_file")
+
+    problems = checker.declared_ahead_of_time_problems(base=tmp_path)
+
+    assert problems and "delete_file" in problems[0]


### PR DESCRIPTION
## Thinking Path

#14494's ask was to stop inferring "mutating" from a hand-written verb list
(`_MUTATING` in `mcp_tool_permissions_test.py`) and make it a declared
property of the tool instead, with undeclared tools failing rather than
inheriting a bridge's read-level default.

A full declaration pass turned out to be the same size as the "intermediate
step" the issue offered as a fallback (every live tool needs an exact
`TOOL_PERMISSIONS` entry either way — the only question is what value each
one gets), so I did the full pass rather than the intermediate step: 104 live
tools across the eleven governed bridges (`browser_mcp`, `database_mcp`,
`filesystem_mcp`, `git_mcp`, `http_client_mcp`, `knowledge_mcp`,
`prometheus_mcp`, `redis_mcp`, `sequential_thinking_mcp`,
`structured_thinking_mcp`, `vnc_mcp`), each with an exact permission entry
classified from its actual implementation (source read, not name-guessed).
`_MUTATING` and the guard built on it are retired.

Sweeping every bridge's source (not just the ones a name pattern would have
flagged) surfaced three more live under-grants beyond the `select`/
`select_index` #14469 already fixed:

| Bridge | Tool | Was resolving to | Now | Why |
|---|---|---|---|---|
| `browser_mcp` | `intercept_api` | `MCP_BROWSER_READ` (undeclared — the table had a stale `intercept_requests` key naming a tool that doesn't exist) | `MCP_BROWSER_CONTROL` | Injects an interceptor script into every page load (`page.add_init_script`), same category as `evaluate` |
| `vnc_mcp` | `desktop_special_key` | `MCP_DESKTOP_READ` (undeclared) | `MCP_DESKTOP_CONTROL` | Sends key combinations (Return, Escape, ctrl+c, alt+tab) to the desktop, same category as `desktop_keyboard_type` |
| `knowledge_mcp` | `redis_vector_operations` | `KNOWLEDGE_READ` (undeclared) | `KNOWLEDGE_MANAGE` | `operation` accepts `flush`/`reindex`/`backup` as well as `info` — worst case empties the vector store |

The remaining ~62 additions are genuine reads, declared explicitly at the
same permission their bridge default already granted (so behaviour is
unchanged for them) — the point is that they are now an exact, reviewable
entry rather than a name a verb list happened not to catch.

## What Changed

- **`autobot_shared/auth/mcp_bridge_scan.py`** (new): extracts the bridge
  source parser out of the test file so the production module, the pytest
  guard, and the required-check guard all read the same scan. Also fixes a
  scanner gap: `sequential_thinking_mcp` declares its one tool as a
  module-level tuple assignment, a shape the original list-literal-only
  regex never matched — that bridge's whole tool surface was an
  empty-enumeration case reading as clean.
- **`autobot_shared/auth/mcp_tool_permissions.py`**: every one of the 104
  live tools gets an exact `TOOL_PERMISSIONS` entry (see table above for the
  three real under-grants found). Adds `_DECLARED_AHEAD_OF_TIME`, the only
  sanctioned exemption — six entries (the five pre-existing redis blocklist
  patterns, plus a newly-documented `delete_file` on `filesystem_mcp`) that
  name a tool which does not exist yet, each with a reason.
- **`tools/lint/check_mcp_tool_permission_coverage.py`** (new): the required
  check. `undeclared_tools()` is the primary guard — a live tool with no
  exact `TOOL_PERMISSIONS` entry fails. `stale_declarations()` catches the
  reverse (a declaration stranded by a rename, the `intercept_requests`
  shape). Fails below a discovery floor so an empty bridge scan cannot read
  as clean.
- **`tools/lint/check_mcp_tool_permission_coverage_test.py`** (new):
  `tmp_path`-based discrimination tests — an undeclared tool with a name
  matching none of the retired verbs is blocked, a declared one is not
  flagged, an empty bridge directory fails, and a stranded declaration is
  caught.
- **`autobot_shared/auth/mcp_tool_permissions_test.py`**: retires
  `_MUTATING` and its test; loads and asserts the real required-check script
  passes against the live tree; generalises the old redis-only
  "declared ahead of time" test to cover `_DECLARED_AHEAD_OF_TIME`; adds
  regression tests for `intercept_api`, `desktop_special_key`, and
  `redis_vector_operations`.
- **`.github/workflows/code-quality.yml`**: one new step in the existing
  `code-quality` job (no job/check-run renamed) — `check_mcp_tool_permission_coverage.py --audit`,
  same shape as the neighbouring `--audit-excludes`/`--audit` steps. The
  pytest copy runs in `python-suite`, which gates nothing (#14353), so the
  guard has to block here.

## Verification

- `python3 -m py_compile` on all five touched/new files — clean.
- `python3 -m flake8` (repo config) on all five files — 0 findings.
- `python3 -m bandit -c .bandit` on all five files — 0 findings.
- `python3 -m mypy autobot_shared/auth/` — `Success: no issues found in 8 source files`.
- Extracted a standalone copy of every touched file plus the real
  `autobot-backend/api/` bridge sources under `/tmp` (never ran repo code in
  place) and ran the guard both ways:
  - **Clean tree**: `check_mcp_tool_permission_coverage.py --audit` →
    `MCP tool permission coverage audit clean over 104 tools across every
    governed MCP bridge (#14494)`, exit 0. `pytest` on the extracted copies
    of `mcp_tool_permissions_test.py` + `check_mcp_tool_permission_coverage_test.py`:
    **148 passed**.
  - **Mutated tree** (appended `Tool(name="toggle_capture_mode", ...)` to a
    copy of `browser_mcp.py` — a name matching none of the retired
    `_MUTATING` verbs; confirmed `diff` shows the mutated file differs from
    the original before trusting the result): audit now reports
    `browser_mcp: toggle_capture_mode` and **exits 1**. A second mutation
    (`grant_admin_role` appended to `database_mcp.py`) made
    `test_every_live_tool_carries_an_explicit_declaration` fail with the
    same finding via `pytest`.
  - **Empty enumeration**: emptied the copied `autobot-backend/api/`
    directory entirely — audit reports `reached only 0 tool(s) ... the sweep
    broke` and **exits 1**, proving a zero-tool scan does not read as clean.

The guard discriminates in both directions and passes on the tree as it
stands.

## Security review follow-up (#14521 review comment)

Reviewer approved with one required correction, addressed in a follow-up
commit on this branch:

- **Docstring overclaim fixed.** `mcp_tool_permissions.py` said "Absence is a
  denial, not a default-allow" — not true at runtime.
  `required_permission()` is unmodified by this PR: a known-bridge tool with
  no exact `TOOL_PERMISSIONS` entry still resolves through
  `BRIDGE_DEFAULT_PERMISSIONS` (a real, grantable read permission), and an
  unknown-bridge tool resolves to `None`, which
  `PermissionEnforcementExtension` currently treats as legacy — allowed
  through, unchecked. Both the module docstring and `required_permission()`'s
  own docstring now state the guarantee this PR actually delivers: complete
  **CI-time** declaration coverage across the eleven governed bridges,
  backstopped at runtime only by the read-level default — not a runtime
  denial.
- **Runtime half filed separately: #14523** (#13228 stage 3) — flip
  `required_permission` to deny any undeclared tool regardless of bridge and
  have `PermissionEnforcementExtension` deny on `None` for MCP dispatch, or
  document the default-allow as deliberate. Not attempted here: it changes
  live authorization behaviour for every existing "legacy" tool and needs its
  own review. Also carries the reviewer's two non-blocking notes: the global
  (not per-bridge) `DISCOVERY_FLOOR`, and `TOOL_PERMISSIONS` being keyed by
  tool name alone rather than `(bridge, tool)`.

## Model Used

Claude Sonnet 5

Closes #14494

