### PR TITLE
fix(ci): reject a malformed TSC_STATUS_FILE instead of reading it as exit 0 (#14503)

### DIFF
--- a/autobot-frontend/scripts/check-ts-delta.sh
+++ b/autobot-frontend/scripts/check-ts-delta.sh
@@ -54,9 +54,26 @@ if [[ -n "${TSC_OUTPUT_FILE:-}" && -n "${TSC_STATUS_FILE:-}" \
   # block exists to prevent: a compiler that never produced a real status would
   # silently read as a clean exit. Route this through the script's own error
   # handling rather than letting `set -u`/arithmetic surface bash's raw message.
-  if [[ ! "${TSC_STATUS}" =~ ^[0-9]+$ ]] || (( TSC_STATUS > 255 )); then
+  #
+  # `^[0-9]+$` alone is not enough — bash's `(( ))` is fixed-width (64-bit) and
+  # NOT decimal-only, so a value the pattern accepts can still defeat the range
+  # check below it:
+  #   - 2**64 (18446744073709551616) matches the pattern, then WRAPS to 0 in
+  #     fixed-width arithmetic, so `(( TSC_STATUS > 255 ))` silently evaluates
+  #     `0 > 255` and accepts it — exactly the empty-file bug, one layer down.
+  #   - A leading zero (e.g. "008") matches the pattern too, but bash parses a
+  #     leading-zero numeral as OCTAL, and 8/9 are not valid octal digits, so
+  #     `(( ))` throws — inside a *tested* context (`if (( ... ))`), where a
+  #     throw is swallowed as "false" rather than propagating. The guard
+  #     neither rejects nor errors, so this also reads as a clean pass.
+  #
+  # The shape check below rejects both before either reaches arithmetic — no
+  # valid status is longer than 3 digits (255) or has a leading zero followed
+  # by another digit — and `10#` on the surviving value forces base-10 parsing
+  # so nothing that does reach `(( ))` can ever be read as octal.
+  if [[ ! "${TSC_STATUS}" =~ ^([0-9]|[1-9][0-9]{1,2})$ ]] || (( 10#${TSC_STATUS} > 255 )); then
     echo "ERROR: ${TSC_STATUS_FILE} does not hold a valid exit status." >&2
-    echo "Expected a single integer 0-255; got: '${TSC_STATUS}'" >&2
+    echo "Expected a single decimal integer 0-255 with no leading zero; got: '${TSC_STATUS}'" >&2
     echo "Refusing to treat this as a clean compile — the compiler's actual exit status is unknown." >&2
     exit 1
   fi

--- a/autobot-frontend/scripts/check-ts-delta.sh
+++ b/autobot-frontend/scripts/check-ts-delta.sh
@@ -45,6 +45,21 @@ if [[ -n "${TSC_OUTPUT_FILE:-}" && -n "${TSC_STATUS_FILE:-}" \
   echo "Reusing vue-tsc output captured by the type-check step (baseline: ${BASELINE} errors)..."
   TSC_OUTPUT="${TSC_OUTPUT_FILE}"
   TSC_STATUS="$(<"${TSC_STATUS_FILE}")"
+
+  # A status file is only a valid handoff if it holds exactly what the type-check
+  # step wrote: a single small non-negative integer (0-255, the POSIX exit status
+  # range). Anything else — empty (the file exists but the write raced or failed),
+  # whitespace, multiple lines, or non-numeric content — is a discriminator failure
+  # in its own right, not a status of 0. Trusting it as 0 is exactly the bug this
+  # block exists to prevent: a compiler that never produced a real status would
+  # silently read as a clean exit. Route this through the script's own error
+  # handling rather than letting `set -u`/arithmetic surface bash's raw message.
+  if [[ ! "${TSC_STATUS}" =~ ^[0-9]+$ ]] || (( TSC_STATUS > 255 )); then
+    echo "ERROR: ${TSC_STATUS_FILE} does not hold a valid exit status." >&2
+    echo "Expected a single integer 0-255; got: '${TSC_STATUS}'" >&2
+    echo "Refusing to treat this as a clean compile — the compiler's actual exit status is unknown." >&2
+    exit 1
+  fi
 else
   #
   # Why not npx (#13341). This step ran unbounded for over three hours on the

--- a/repo_tests/frontend_ts_delta_status_file_validation_test.py
+++ b/repo_tests/frontend_ts_delta_status_file_validation_test.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
-"""check-ts-delta.sh must not read an empty TSC_STATUS_FILE as exit 0 (#14503).
+"""check-ts-delta.sh must not read a malformed TSC_STATUS_FILE as exit 0 (#14503).
 
 `scripts/check-ts-delta.sh` reuses a caller's prior vue-tsc run via
 `TSC_OUTPUT_FILE`/`TSC_STATUS_FILE` (#14481). Bash arithmetic reads an empty
@@ -13,18 +13,36 @@ documented discriminator: "a count alone is not a measurement... the exit
 status is what separates [a compiler that never ran] from a genuine clean
 compile." An empty status file silently supplied a fake clean one.
 
+The first fix (`^[0-9]+$` plus `(( TSC_STATUS > 255 ))`) covered exactly the
+shapes the issue named — empty, whitespace, multi-line, non-numeric — but not
+the input *space*: bash's `(( ))` is fixed-width (64-bit) and NOT
+decimal-only, so a value the pattern accepts can still defeat the range check
+below it. `2**64` matches the pattern, then WRAPS to `0` in fixed-width
+arithmetic (same bug, one layer down); a leading zero (`"008"`) matches the
+pattern too, but bash parses it as octal, `8`/`9` are not valid octal digits,
+`(( ))` throws, and because that arithmetic sits in a *tested* `if (( ... ))`
+context the throw is swallowed as false rather than propagating — the guard's
+own error path silently reads a malformed value as clean, the exact defect
+being fixed, one layer up. The current fix rejects both by shape (length +
+no leading zero) before arithmetic ever sees them, and forces base-10 parsing
+(`10#`) on whatever does reach `(( ))`.
+
 `autobot-frontend/` is in no `testpaths` entry (see pytest.ini), so this test
 lives in `repo_tests/` and drives the real script via `subprocess`, in an
 isolated sandbox tree (its own `docs/developer/audits/typescript-baseline.md`
 and no `node_modules/`) so the always-reachable reuse path never depends on
 `vue-tsc` being installed and no test here runs `npm`/`vue-tsc` for real.
 
-Discrimination: every ``*_is_rejected`` test below FAILS against the
-pre-#14503 script (it printed ``PASS: 0 errors`` / exit 0 for the malformed
-shapes, or leaked bash's raw ``unbound variable`` message for the non-numeric
-one) and PASSES against the fixed one. The three fail-safe controls at the
-bottom prove the fix does not touch: a genuinely clean status of 0, a
-genuinely detected crash status, and the missing-file fallback to recompile.
+Discrimination: every ``*_is_rejected``/``*_rejected`` test below FAILS
+against the pre-#14503 script (empty/whitespace/multiline/overflow/octal all
+printed ``PASS: 0 errors`` / exit 0; non-numeric leaked bash's raw
+``unbound variable`` message) and PASSES against the fixed one — the overflow
+and octal cases specifically discriminate the *first* #14503 patch
+(`^[0-9]+$` + `(( TSC_STATUS > 255 ))`, no length bound, no `10#`) from the
+current one, since the first patch still passed both through. The fail-safe
+controls at the bottom prove the fix does not touch: a genuinely clean status
+of 0, a genuinely detected crash status, the missing-file fallback to
+recompile, and the standalone no-env local path.
 """
 
 from __future__ import annotations
@@ -145,6 +163,42 @@ def test_non_numeric_status_file_reports_through_the_scripts_own_error(
         "non-numeric TSC_STATUS_FILE content must be refused through the "
         f"script's own error handling, not bash's raw message. stderr:\n{result.stderr}"
     )
+    assert "valid exit status" in result.stderr
+
+
+def test_overflow_beyond_64bit_wraps_but_is_still_rejected(sandbox: Path) -> None:
+    """2**64 matches a naive `^[0-9]+$` pattern, then WRAPS to 0 under bash's
+    fixed-width `(( ))` arithmetic — so a length/range-blind check would read
+    it right back as `(( 0 > 255 ))`: false, accepted, PASS. Pre-fix (the
+    first #14503 patch, `^[0-9]+$` + `(( TSC_STATUS > 255 ))` with no `10#`
+    and no length bound) this value sailed straight through both this check
+    and the pre-existing crash discriminator at line ~115, printing
+    `PASS: 0 errors` / exit 0 — reproduced against that shape before this test
+    was written. The shape check must reject it purely on digit count, before
+    arithmetic ever sees it.
+    """
+    result = _run(sandbox, status_content="18446744073709551616")  # 2**64
+    assert result.returncode != 0, f"stdout:\n{result.stdout}"
+    assert "PASS" not in result.stdout
+    assert "valid exit status" in result.stderr
+
+
+def test_leading_zero_octal_invalid_value_is_rejected(sandbox: Path) -> None:
+    """A leading zero makes bash's `(( ))` parse the numeral as OCTAL, and `8`/
+    `9` are not valid octal digits, so `(( ))` throws. Because that arithmetic
+    sits in a *tested* context (an `if (( ... ))` condition), `set -e` does not
+    propagate the throw — it is silently read as boolean false. Pre-fix (the
+    first #14503 patch) "008" passed `^[0-9]+$`, then threw on both `(( TSC_STATUS
+    > 255 ))` here and the pre-existing crash check, each throw swallowed as
+    "false" — so the guard neither rejected nor errored, and the script fell
+    through to `PASS: 0 errors` / exit 0 exactly like the empty-file case this
+    whole fix exists to close. This is the guard's own error path being
+    swallowed by the construct it is written inside — reject the shape before
+    arithmetic, and force base 10 (`10#`) on whatever does reach it.
+    """
+    result = _run(sandbox, status_content="008")
+    assert result.returncode != 0, f"stdout:\n{result.stdout}"
+    assert "PASS" not in result.stdout
     assert "valid exit status" in result.stderr
 
 

--- a/repo_tests/frontend_ts_delta_status_file_validation_test.py
+++ b/repo_tests/frontend_ts_delta_status_file_validation_test.py
@@ -1,0 +1,203 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""check-ts-delta.sh must not read an empty TSC_STATUS_FILE as exit 0 (#14503).
+
+`scripts/check-ts-delta.sh` reuses a caller's prior vue-tsc run via
+`TSC_OUTPUT_FILE`/`TSC_STATUS_FILE` (#14481). Bash arithmetic reads an empty
+`TSC_STATUS_FILE` as `0` — indistinguishable from a genuinely clean compile.
+Fed a crash-shaped output (zero `error TS` lines) alongside an empty status
+file, the script printed ``PASS: 0 errors`` and exited 0, bypassing its own
+documented discriminator: "a count alone is not a measurement... the exit
+status is what separates [a compiler that never ran] from a genuine clean
+compile." An empty status file silently supplied a fake clean one.
+
+`autobot-frontend/` is in no `testpaths` entry (see pytest.ini), so this test
+lives in `repo_tests/` and drives the real script via `subprocess`, in an
+isolated sandbox tree (its own `docs/developer/audits/typescript-baseline.md`
+and no `node_modules/`) so the always-reachable reuse path never depends on
+`vue-tsc` being installed and no test here runs `npm`/`vue-tsc` for real.
+
+Discrimination: every ``*_is_rejected`` test below FAILS against the
+pre-#14503 script (it printed ``PASS: 0 errors`` / exit 0 for the malformed
+shapes, or leaked bash's raw ``unbound variable`` message for the non-numeric
+one) and PASSES against the fixed one. The three fail-safe controls at the
+bottom prove the fix does not touch: a genuinely clean status of 0, a
+genuinely detected crash status, and the missing-file fallback to recompile.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from autobot_shared.paths import project_root
+
+SCRIPT_RELATIVE_PATH = "autobot-frontend/scripts/check-ts-delta.sh"
+
+# Crash-shaped compiler output: zero "error TS" lines, as if vue-tsc died
+# before emitting any diagnostics — the exact shape #14503 was reproduced with.
+_CRASH_OUTPUT = "internal compiler crash, no diagnostics emitted\n"
+
+
+@pytest.fixture
+def sandbox(tmp_path: Path) -> Path:
+    """An isolated repo-shaped tree: real script, no real node_modules.
+
+    Mirrors just enough of the repo layout for the script's own path
+    resolution (SCRIPT_DIR -> REPO_ROOT -> BASELINE_FILE) to work, without
+    depending on this checkout's actual baseline doc or any installed
+    vue-tsc binary — so the missing-status-file fallback below deterministically
+    hits the "vue-tsc not found" branch instead of trying to compile anything.
+    """
+    baseline_dir = tmp_path / "docs" / "developer" / "audits"
+    baseline_dir.mkdir(parents=True)
+    (baseline_dir / "typescript-baseline.md").write_text(
+        "**Total:** 0\n", encoding="utf-8"
+    )
+
+    script_dir = tmp_path / "autobot-frontend" / "scripts"
+    script_dir.mkdir(parents=True)
+    real_script = project_root() / SCRIPT_RELATIVE_PATH
+    assert real_script.is_file(), f"missing {SCRIPT_RELATIVE_PATH}"
+    shutil.copy2(real_script, script_dir / "check-ts-delta.sh")
+
+    return tmp_path
+
+
+def _run(
+    sandbox: Path,
+    status_content: str | None,
+    output_content: str = _CRASH_OUTPUT,
+) -> subprocess.CompletedProcess:
+    """Invoke the sandboxed script with a given TSC_STATUS_FILE shape.
+
+    ``status_content=None`` omits the status file entirely (the missing-file
+    fail-safe case); any string writes it verbatim (no trailing newline added
+    beyond what the caller supplies, so whitespace/multi-line cases are exact).
+    """
+    bash = shutil.which("bash")
+    if bash is None:
+        pytest.skip("bash unavailable")
+
+    work = sandbox / "work"
+    work.mkdir(exist_ok=True)
+    output_file = work / "vue-tsc-output.txt"
+    output_file.write_text(output_content, encoding="utf-8")
+
+    env = {"PATH": "/usr/bin:/bin:/usr/local/bin"}
+    env["TSC_OUTPUT_FILE"] = str(output_file)
+
+    if status_content is not None:
+        status_file = work / "vue-tsc-status.txt"
+        status_file.write_text(status_content, encoding="utf-8")
+        env["TSC_STATUS_FILE"] = str(status_file)
+    else:
+        status_file = work / "vue-tsc-status.txt"  # deliberately never created
+
+    return subprocess.run(
+        [bash, str(sandbox / SCRIPT_RELATIVE_PATH)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        cwd=str(sandbox),
+        env=env,
+    )
+
+
+# --- Malformed status file: must be rejected, never read as a clean 0 ---
+
+
+def test_empty_status_file_is_rejected_not_treated_as_clean(sandbox: Path) -> None:
+    result = _run(sandbox, status_content="")
+    assert result.returncode != 0, (
+        "an empty TSC_STATUS_FILE must not be treated as exit status 0 — "
+        f"got PASS. stdout:\n{result.stdout}"
+    )
+    assert "PASS" not in result.stdout
+
+
+def test_whitespace_only_status_file_is_rejected(sandbox: Path) -> None:
+    result = _run(sandbox, status_content="   \n")
+    assert result.returncode != 0, f"stdout:\n{result.stdout}"
+    assert "PASS" not in result.stdout
+
+
+def test_multiline_status_file_is_rejected(sandbox: Path) -> None:
+    result = _run(sandbox, status_content="0\n1\n")
+    assert result.returncode != 0, f"stdout:\n{result.stdout}"
+    assert "PASS" not in result.stdout
+
+
+def test_non_numeric_status_file_reports_through_the_scripts_own_error(
+    sandbox: Path,
+) -> None:
+    result = _run(sandbox, status_content="banana")
+    assert result.returncode != 0, f"stdout:\n{result.stdout}"
+    assert "PASS" not in result.stdout
+    # The old failure mode: bash's own `set -u` message on the raw arithmetic
+    # read, not the script's crafted diagnostic.
+    assert "unbound variable" not in result.stderr, (
+        "non-numeric TSC_STATUS_FILE content must be refused through the "
+        f"script's own error handling, not bash's raw message. stderr:\n{result.stderr}"
+    )
+    assert "valid exit status" in result.stderr
+
+
+# --- Fail-safe controls: the fix must not touch these ---
+
+
+def test_valid_zero_status_file_still_passes(sandbox: Path) -> None:
+    """A genuinely clean compile (status 0, no diagnostics) must still PASS."""
+    result = _run(sandbox, status_content="0")
+    assert result.returncode == 0, f"stderr:\n{result.stderr}"
+    assert "PASS" in result.stdout
+
+
+def test_valid_nonzero_status_with_no_diagnostics_is_still_a_detected_crash(
+    sandbox: Path,
+) -> None:
+    """Unrelated to #14503: status 2 with zero diagnostics is the pre-existing
+    crash discriminator (comment above TSC_STATUS in the script) — must still fire.
+    """
+    result = _run(sandbox, status_content="2")
+    assert result.returncode != 0
+    assert "without completing a check" in result.stderr
+
+
+def test_missing_status_file_falls_back_to_recompile(sandbox: Path) -> None:
+    """A MISSING file (not an empty one) must still fail open to a fresh compile.
+
+    In this sandbox there is no installed vue-tsc, so the fallback deterministically
+    reports "vue-tsc not found" rather than reusing anything — proving the reuse
+    branch was never taken.
+    """
+    result = _run(sandbox, status_content=None)
+    assert result.returncode != 0
+    assert "Reusing vue-tsc output" not in result.stdout
+    assert "vue-tsc not found" in result.stderr
+
+
+def test_standalone_no_env_still_falls_back_to_recompile(sandbox: Path) -> None:
+    """`bash scripts/check-ts-delta.sh` with neither env var set — the documented
+    standalone local-development path — must be unchanged by this fix.
+    """
+    bash = shutil.which("bash")
+    if bash is None:
+        pytest.skip("bash unavailable")
+
+    result = subprocess.run(
+        [bash, str(sandbox / SCRIPT_RELATIVE_PATH)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        cwd=str(sandbox),
+        env={"PATH": "/usr/bin:/bin:/usr/local/bin"},
+    )
+    assert result.returncode != 0
+    assert "Reusing vue-tsc output" not in result.stdout
+    assert "vue-tsc not found" in result.stderr


### PR DESCRIPTION
## Thinking Path

`autobot-frontend/scripts/check-ts-delta.sh` reads `TSC_STATUS_FILE` (#14481's
handoff from a prior vue-tsc run) with `TSC_STATUS="$(<"${TSC_STATUS_FILE}")"`
and then feeds it straight into bash arithmetic. An empty file reads as the
empty string, and `$(( "" > 2 ))` etc. evaluate the empty string as `0` —
indistinguishable from a genuinely clean compiler exit. Fed a crash-shaped
output (zero `error TS` lines) alongside an empty status file, the script
printed `PASS: 0 errors` and exited 0, bypassing the exact discriminator its
own comments describe at length: a count alone is not a measurement, because
a compiler that never ran also reports zero errors — the exit status is what
tells the two apart, and an empty file silently forges a clean one.

Reachability today is zero (the workflow only ever writes a real exit code
after `set -eo pipefail` has let a real vue-tsc run through, and
`actions/checkout@v7`'s default `clean: true` wipes any stale file before a
job starts), which is why this is a contract fix, not a live incident.

**Round 1** validated `TSC_STATUS_FILE`'s content with `^[0-9]+$` plus
`(( TSC_STATUS > 255 ))`. Review caught that this closes exactly the four
shapes the issue named and nothing past them, because bash's `(( ))` is
neither arbitrary-precision nor decimal-only:

- `18446744073709551616` (2**64) passes `^[0-9]+$`, then **wraps to 0** in
  bash's fixed-width 64-bit arithmetic, so `(( TSC_STATUS > 255 ))` silently
  evaluates `0 > 255` → false → accepted. The pre-existing crash discriminator
  a few lines down reads the same wrapped `0`, so both checks miss it.
- `008` also passes `^[0-9]+$`, but a leading zero makes bash parse the
  numeral as **octal**, and `8` is not a valid octal digit, so `(( ))`
  **throws**. Because the arithmetic sits inside a *tested* context
  (`if (( ... ))`), the throw is swallowed as "false" rather than
  propagating — the guard neither rejects nor errors, which is the exact
  defect being fixed (a malformed value read as clean), one layer up, inside
  the guard meant to catch it.

**Round 2** (this PR, after review) does both fixes the review asked for
rather than one: reject on **shape** (no more than 3 digits, no leading zero
followed by another digit — `^([0-9]|[1-9][0-9]{1,2})$`) before the value
ever reaches arithmetic, and force base-10 parsing (`10#${TSC_STATUS}`) on
whatever does reach the range check, removing the octal parse entirely
rather than relying on the shape check alone to have excluded it. The three
original malformed shapes (empty, whitespace, multi-line) and the
non-numeric case are unaffected by this second round; the two crafted inputs
above now hit the identical rejection path.

## What Changed

- `autobot-frontend/scripts/check-ts-delta.sh`: after reading
  `TSC_STATUS_FILE` in the reuse branch, validate its content by shape
  (`^([0-9]|[1-9][0-9]{1,2})$`, i.e. 1-3 digits with no invalid leading zero)
  and, for whatever passes that, force base-10 arithmetic
  (`(( 10#${TSC_STATUS} > 255 ))`). A failure exits 1 with the script's own
  message. The missing-file fallback and the fresh-compile branch are
  unchanged.
- `repo_tests/frontend_ts_delta_status_file_validation_test.py`: guard test,
  driving the real script via `subprocess` from an isolated sandbox (own
  baseline doc, no real `node_modules/` — `autobot-frontend/` is in no
  `testpaths` entry, and nothing here runs `npm`/`vue-tsc`). Extended in
  round 2 with the overflow (2**64) and octal-invalid (`"008"`) cases the
  first round's test suite didn't enumerate.

## Verification

Crash-shaped output (zero `error TS` lines) in every row:

| TSC_STATUS_FILE content | Before (pre-#14503) | After round 1 | After round 2 (this PR) |
|---|---|---|---|
| empty | `PASS: 0 errors`, exit 0 | rejected, exit 1 | unchanged: rejected, exit 1 |
| whitespace only | `PASS: 0 errors`, exit 0 | rejected, exit 1 | unchanged |
| multi-line (`0\n1`) | `((` syntax error swallowed by the `if`, falls through to `PASS: 0 errors`, exit 0 | rejected, exit 1 | unchanged |
| non-numeric (`banana`) | bash's raw `unbound variable`, exit 1 | script's own message, exit 1 | unchanged |
| valid `0` | `PASS: 0 errors`, exit 0 | unchanged | unchanged |
| valid `2` | crash correctly caught, exit 1 | unchanged | unchanged |
| missing file | falls back to fresh compile, exit 1 | unchanged | unchanged |
| standalone, no env vars | same fresh-compile fallback | unchanged | unchanged |
| **overflow `18446744073709551616` (2**64)** | `PASS: 0 errors`, exit 0 | **still `PASS: 0 errors`, exit 0** — wraps to 0 under `(( ))` | rejected, exit 1, script's own message |
| **octal-invalid `008`** | `PASS: 0 errors`, exit 0 | **still `PASS: 0 errors`, exit 0** — `(( ))` throws inside a tested context and the throw is swallowed | rejected, exit 1, script's own message |

Both crafted inputs now exit non-zero through the script's own
`does not hold a valid exit status` message — confirmed by direct
extraction-copy execution (`/tmp/.../scratchpad/repro2`) and by the guard
test.

`assert mutated != original` held at each round (`diff` against
`origin/Dev_new_gui` and then against round 1's commit each showed exactly
the intended lines) before any of the above was trusted.

Guard test (`python3 -m pytest repo_tests/frontend_ts_delta_status_file_validation_test.py`,
never `npm`/`vue-tsc`), 10 cases total:
- Against the **round 2 (current)** script: 10/10 pass.
- Against **round 1's** script (`git show <round-1-sha>:...` swapped in,
  then restored): exactly the 2 new tests
  (`test_overflow_beyond_64bit_wraps_but_is_still_rejected`,
  `test_leading_zero_octal_invalid_value_is_rejected`) fail, the other 8
  pass — proving the extension discriminates precisely the gap review found,
  and nothing else regressed between rounds.
- Against the **pre-#14503** script (`origin/Dev_new_gui`): the 4
  original malformed-shape tests fail, the 4 fail-safe controls pass
  (round-1 evidence, unchanged by round 2).

Re-ran `repo_tests/frontend_duplicate_typecheck_compile_guard_test.py`
(#14481's own guard, which also reads this script) against the round 2
script: 4/4 still pass.

Not touched: `type-check` remains the unconditional gate ahead of
`check-ts-delta`, and the TypeScript baseline doc stays at its stale value
(#13353) — orthogonal to this fix, tracked separately.

## Model Used

Claude Opus 5 (1M context)

Closes #14503
