### PR TITLE
fix(lint): re-baseline the file-size ratchet on every shrink so a gain cannot be spent back (#14498)

### DIFF
--- a/repo_tests/python_file_size_ratchet_test.py
+++ b/repo_tests/python_file_size_ratchet_test.py
@@ -18,6 +18,10 @@ obvious:
 * an entry whose file has dropped to the limit must be *removed* — a list still
   naming a compliant file exempts nothing while looking authoritative.
 
+A shrink also has to be locked in, not merely recorded (#14498). ``RATCHET_BASELINE``
+below is re-lowered with every shrink and pinned to the files themselves, so the
+lines a decomposition removed cannot be spent back inside a stale tolerance.
+
 The last test is the reach self-check. It runs the hook's own matcher over a
 tracked-file enumeration produced by ``git ls-files`` rather than by anything in
 the hook, so a matcher that has silently stopped matching cannot pass by
@@ -37,20 +41,39 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[1]
 _SCRIPT = REPO_ROOT / "scripts" / "check_python_file_size.py"
 
-# Frozen snapshot of the exemption as it stood when the ratchet landed (#14236).
-# It is deliberately a second copy: a ratchet needs a fixed reference point, and
-# a list that is only ever compared against itself can drift anywhere. Lowering
-# a ceiling in the hook is fine and needs no edit here. Raising one, or adding a
-# fourth file, must fail — so DO NOT "sync" this dict to make a test pass.
+# The ratchet's second reference point: every entry's size, re-measured on the
+# tree, held outside the hook it constrains. It is deliberately a second copy —
+# a list only ever compared against itself can drift anywhere — and neither copy
+# is derived from the other. The hook's ceilings are anchored to the files by
+# ``audit_ceilings``; this dict is anchored to them by
+# ``test_the_baseline_is_relowered_by_every_shrink``. So no ceiling can be
+# raised by editing one file alone: a bump here alone exceeds the file it names,
+# a bump in the hook alone exceeds this dict.
+#
+# It re-baselines on every shrink (#14498): a file that gets smaller lowers BOTH
+# this dict and ``KNOWN_LARGE`` to the count just achieved, which is what locks
+# the gain in. Left high, the gap between it and the new ceiling is regrowth the
+# ratchet would wave through one compliant-looking raise at a time — 344 lines
+# of it on ``tool_handler.py`` alone. Sync this dict DOWN with every shrink;
+# never up to make a test pass.
 RATCHET_BASELINE = {
     "autobot-backend/orchestrator.py": 1114,
     "autobot-backend/chat_workflow/manager.py": 4068,
-    "autobot-backend/chat_workflow/tool_handler.py": 4063,
+    "autobot-backend/chat_workflow/tool_handler.py": 3719,
 }
 
 # Floor for the tracked-Python enumeration (4958 files at the time of writing).
 # An enumeration that returns nothing must not read as "nothing to check".
 _TRACKED_PY_FLOOR = 3000
+
+
+def _count_lines(rel: str) -> int | None:
+    """Line count for a repo-relative path, or None when it cannot be read."""
+    try:
+        with (REPO_ROOT / rel).open(encoding="utf-8") as handle:
+            return sum(1 for _ in handle)
+    except OSError:
+        return None
 
 
 def _load():
@@ -144,6 +167,33 @@ def test_an_entry_whose_file_is_now_compliant_fails(hook):
         message = hook.verdict(rel, hook.MAX_LINES)
         assert message is not None, f"{rel} could sit here compliant and exempt"
         assert "Delete its KNOWN_LARGE entry" in message
+
+
+def test_the_baseline_is_relowered_by_every_shrink():
+    """A shrink recorded only in the hook leaves the cut lines spendable.
+
+    ``test_a_shrunk_file_must_lower_its_ceiling`` makes a shrink lower the
+    hook's ceiling; without this, the baseline stays where it was and the gap
+    between the two is regrowth every later raise can claim while staying
+    "under the baseline" — the defect in #14498, worth 344 lines on
+    ``tool_handler.py``. Sizes are counted here rather than read out of the
+    hook: a second reference point derived from the thing it checks agrees with
+    it by construction.
+    """
+    stale = {}
+    for rel, baseline in RATCHET_BASELINE.items():
+        actual = _count_lines(rel)
+        assert actual is not None, (
+            f"{rel}: the baseline names a file that moved or was deleted — "
+            "drop the entry from RATCHET_BASELINE with the KNOWN_LARGE one."
+        )
+        if baseline > actual:
+            stale[rel] = (baseline, actual)
+    assert stale == {}, (
+        f"baseline above the file it names (baseline, actual): {stale}. Lower "
+        "RATCHET_BASELINE to the size achieved — a baseline left above the "
+        "file re-licenses every line the shrink removed (#14498)."
+    )
 
 
 def test_a_shrunk_file_must_lower_its_ceiling(hook):

--- a/scripts/check_python_file_size.py
+++ b/scripts/check_python_file_size.py
@@ -24,6 +24,9 @@ The ratchet turns one way only:
 * below its ceiling      -> fail; lower the ceiling to the count just achieved
 * at or below MAX_LINES  -> fail; delete the entry, the file is compliant
 
+Every lowering is mirrored in ``RATCHET_BASELINE`` in the ratchet test, so the
+shrink is locked in rather than left as headroom to regrow into (#14498).
+
 ``--audit-ceilings`` applies those rules to every entry regardless of what is
 staged, so an entry cannot sit here exempting nothing after the file it names
 has shrunk, moved, or been deleted. It reports how many entries it reached,
@@ -52,11 +55,19 @@ MAX_LINES = 600
 #: Repo-relative path of this hook, quoted in the messages that ask for an edit.
 SELF_REL = "scripts/check_python_file_size.py"
 
+#: The ratchet test holding RATCHET_BASELINE, the second copy of these numbers.
+#: Every message that asks for an edit here names it too: a ceiling lowered in
+#: one file alone leaves the other holding the old size (#14498).
+RATCHET_REL = "repo_tests/python_file_size_ratchet_test.py"
+
 # Grandfathered files: over MAX_LINES before the guard existed, mapped to the
 # line count recorded for each. THIS MAPPING ONLY SHRINKS — entries leave when
 # the file reaches MAX_LINES, and a ceiling may be lowered but never raised.
 # Never add an entry to make a new file pass; split the file instead.
-# ``repo_tests/python_file_size_ratchet_test.py`` holds both directions.
+# ``repo_tests/python_file_size_ratchet_test.py`` holds both directions, and its
+# ``RATCHET_BASELINE`` is the second copy of these numbers: lower an entry here
+# and lower it there in the same commit (#14498), or the lines just cut stay
+# spendable in the gap between the two.
 KNOWN_LARGE: dict[str, int] = {
     "autobot-backend/orchestrator.py": 1114,
     "autobot-backend/chat_workflow/manager.py": 4068,
@@ -92,8 +103,9 @@ def _grandfathered_verdict(rel: str, line_count: int, ceiling: int) -> str | Non
     if line_count <= MAX_LINES:
         return (
             f"{rel}: {line_count} lines — now within the {MAX_LINES}-line limit. "
-            f"Delete its KNOWN_LARGE entry in {SELF_REL}: an entry naming a "
-            "compliant file exempts nothing while looking authoritative."
+            f"Delete its KNOWN_LARGE entry in {SELF_REL}, and its RATCHET_BASELINE "
+            f"entry in {RATCHET_REL}: an entry naming a compliant file exempts "
+            "nothing while looking authoritative."
         )
     if line_count > ceiling:
         return (
@@ -104,8 +116,9 @@ def _grandfathered_verdict(rel: str, line_count: int, ceiling: int) -> str | Non
     if line_count < ceiling:
         return (
             f"{rel}: {line_count} lines, under its recorded ceiling of {ceiling}. "
-            f"Lower the ceiling to {line_count} in {SELF_REL} — the ratchet only "
-            "turns down, and an unlowered ceiling re-licenses the lines just cut."
+            f"Lower the ceiling to {line_count} in {SELF_REL}, and the matching "
+            f"RATCHET_BASELINE entry in {RATCHET_REL} — the ratchet only turns "
+            "down, and an unlowered ceiling re-licenses the lines just cut."
         )
     return None
 


### PR DESCRIPTION
Closes #14498

## Thinking Path

The header said "raising a ceiling must fail"; the test only failed a raise above a **frozen** `RATCHET_BASELINE`. Everything between the current ceiling and that frozen number was regrowth the ratchet would wave through — on `tool_handler.py` (4081 → 3863 → 3719 across two PRs) that was **344 lines**, spendable in compliant-looking steps of any size. `test_a_shrunk_file_must_lower_its_ceiling` exists so a shrink is not re-licensed; a later raise back toward the baseline undoes it one PR at a time.

Option 2 from the issue: re-baseline on every shrink. The hard part was keeping the property the frozen dict was there for — a second copy so the list cannot drift by being compared only against itself. Syncing the baseline *from* `KNOWN_LARGE` would have destroyed exactly that: a reference derived from the thing it checks agrees with it by construction.

So the baseline is re-anchored, not re-derived. Each copy is pinned to the tree independently:

- `KNOWN_LARGE` → the files, by the hook's own `audit_ceilings` (`test_recorded_ceilings_match_the_files_today`)
- `RATCHET_BASELINE` → the files, by the new test, counting lines itself rather than asking the hook

That keeps a raise impossible from either file alone. Bump the ceiling only: it exceeds the baseline (`test_no_ceiling_may_be_raised`). Bump the baseline only: it exceeds the file it names (the new test). A genuine growth still takes a deliberate, visible edit in two files plus a real change to the source — never a quiet spend of a gain someone else won.

One follow-on: the hook's own shrink/compliance messages named only `KNOWN_LARGE`, so a developer who followed them exactly would edit one file and land a red test. Both messages now name both edits.

## What Changed

`repo_tests/python_file_size_ratchet_test.py`
- `RATCHET_BASELINE` lowered to today's actual sizes — `tool_handler.py` 4063 → **3719** (`orchestrator.py` 1114 and `manager.py` 4068 already matched). The 344 recovered lines are now locked in rather than spendable.
- New `test_the_baseline_is_relowered_by_every_shrink`: fails when any baseline entry sits above the file it names, and when the file is gone.
- Header comment rewritten to describe what is now enforced — re-baseline **down** with every shrink, never up to make a test pass — and to state why the dict is still a second copy. The old "DO NOT sync this dict" instruction was half the defect and changes with it.

`scripts/check_python_file_size.py`
- New `RATCHET_REL` constant; the "lower the ceiling" and "delete the entry" messages now name the matching `RATCHET_BASELINE` edit too.
- Module docstring and the `KNOWN_LARGE` comment record that every lowering is mirrored in the test.

No change to `KNOWN_LARGE` values, `MAX_LINES`, or the matcher.

## Verification

Mutation, not reading. Two standalone trees were extracted to scratch — `orig` (this branch's merge base) and `fixed` (this branch) — each with synthetic files at the exact recorded sizes; every mutation asserts `mutated != original` before the run. Both trees are green unmutated (20 and 21 passed).

| # | Mutation | `orig` | `fixed` |
|---|---|---|---|
| A | baseline back to 4063 over an actual 3719 (**the current tree**) | — | **FAIL** `test_the_baseline_is_relowered_by_every_shrink` |
| B | spend the shrink: file regrows 3719 → 3800, ceiling follows | **pass** (the defect) | **FAIL** `test_no_ceiling_may_be_raised` |
| C1 | raise the baseline alone, file unchanged | — | **FAIL** `test_the_baseline_is_relowered_by_every_shrink` |
| C2 | raise the ceiling alone, file unchanged | — | **FAIL** `test_no_ceiling_may_be_raised`, `test_recorded_ceilings_match_the_files_today` |

**A** is the discrimination the issue asks for stated directly: the new test fails against the tree as it stands today (baseline 4063 > actual 3719) and passes once the baseline is lowered to 3719. **B** is the defect itself — the identical regrowth scenario passes on the merge base and fails here.

The three existing direction tests were re-checked against the changed hook rather than assumed orthogonal, since two of them assert on message text this PR edited:

| Mutation of the hook | Result |
|---|---|
| disable the `line_count < ceiling` branch | **FAIL** `test_a_shrunk_file_must_lower_its_ceiling` |
| disable the `line_count <= MAX_LINES` branch | **FAIL** `test_an_entry_whose_file_is_now_compliant_fails` |
| add a fourth `KNOWN_LARGE` entry | **FAIL** `test_no_entry_may_be_added`, `test_matcher_reaches_every_entry_over_a_tracked_enumeration` |

All three still discriminate, and their asserted substrings (`Lower the ceiling to N`, `Delete its KNOWN_LARGE entry`) survive the message rewrite — the unmutated `fixed` tree is green.

Line lengths checked against the repo's 120 limit; no file in the repo was executed.

## Model Used

Claude Opus 5 (1M context)
