### PR TITLE
security(chat_workflow): gate LLC + web_research tool dispatch on BEFORE_TOOL_EXECUTE (#14491)

### DIFF
--- a/autobot-backend/chat_workflow/code_exec/tool_policy.py
+++ b/autobot-backend/chat_workflow/code_exec/tool_policy.py
@@ -6,7 +6,7 @@
 
 Code-exec tool policy was split across two modules with two env vars that
 could drift: ``shim_codegen.SENSITIVE_TOOLS`` / ``CODEEXEC_INJECTABLE_TOOLS``
-(what may be shimmed) and ``tool_handler.CODEEXEC_READONLY_TOOLS`` (what may
+(what may be shimmed) and ``compose_tool_handler.CODEEXEC_READONLY_TOOLS`` (what may
 be auto-approved). This module is the ONE classification: every tool is
 exactly one of **sensitive** / **mutating** / **readonly**, and the consumer
 sets are derived views with invariants enforced at import:

--- a/autobot-backend/chat_workflow/compose_tool_handler.py
+++ b/autobot-backend/chat_workflow/compose_tool_handler.py
@@ -1,0 +1,255 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Compose-tool (GH#11568) body helpers for ``chat_workflow.tool_handler``.
+
+Extracted from ``tool_handler`` (#14491) to offset that PR's own additions and
+keep the module under its file-size ceiling — the same move #14469 made for
+``browser_tool_handler.py``.
+
+Unlike the browser extraction, several of these functions are called back
+into ``self`` from ``ToolHandlerMixin._handle_compose_tool`` via matching
+one-line delegate methods that KEEP their original names
+(``_guard_compose``, ``_persist_compose_approval``, ``_poll_compose_approval``,
+``_compose_shim_snapshot``, ``_execute_compose``, ...): several are replaced
+wholesale by an ``AsyncMock``/plain mock in
+``tests/unit/chat_workflow/test_code_exec.py`` (e.g.
+``handler._persist_compose_approval = AsyncMock(...)``), which only works
+because ``_handle_compose_tool`` still dispatches through ``self.<method>``
+rather than calling a module-level function directly. Moving the *bodies*
+here while keeping the delegate methods preserves that contract.
+
+``_dispatch_tool_call`` (bound to the live ``ToolHandlerMixin`` instance) is
+threaded in explicitly as ``dispatch_tool_call`` rather than imported, since
+this module carries no instance state of its own.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid as uuid_module
+from typing import TYPE_CHECKING, Any, Awaitable, Callable
+
+from async_chat_workflow import WorkflowMessage
+from autobot_shared.env_utils import env_flag, env_int
+from autobot_shared.logging_manager import get_logger
+from chat_workflow.code_exec.tool_policy import CODEEXEC_READONLY_TOOLS
+from utils.errors import RepairableException
+
+if TYPE_CHECKING:
+    from chat_workflow.models import LLMIterationContext
+
+logger = get_logger(__name__)
+
+# GH#11568: compose tool tuning constants — moved here from tool_handler.py
+# (#14491) along with the functions that are their only readers.
+CODEEXEC_AUTOAPPROVE_READONLY: bool = env_flag("AUTOBOT_CODEEXEC_AUTOAPPROVE_READONLY", default=True)
+# #13481: this is how long THIS TURN waits, not how long the approval lives —
+# see tool_handler.py's CODEEXEC_ENABLED block for the full rationale (kept
+# there since it also documents the deliberate absence of an expiry knob).
+CODEEXEC_APPROVAL_WAIT_SECONDS: int = env_int("AUTOBOT_CODEEXEC_APPROVAL_WAIT_SECONDS", default=1800)
+CODEEXEC_APPROVAL_POLL_SECONDS: int = env_int("AUTOBOT_CODEEXEC_APPROVAL_POLL_SECONDS", default=2)
+
+DispatchToolCall = Callable[..., Any]
+
+
+def guard_compose(program: str, agent_id: "str | None") -> "WorkflowMessage | None":
+    """Run AST guard; return error WorkflowMessage on violation, else None."""
+    from chat_workflow.code_exec.ast_guard import check_script
+    from chat_workflow.code_exec.shim_codegen import injectable_tool_set
+    from orchestration.agent_registry import resolve_forbidden_tools
+
+    forbidden = resolve_forbidden_tools(agent_id)
+    injected = frozenset(injectable_tool_set([], forbidden))
+    verdict = check_script(program, frozenset(forbidden), injected_tools=injected)
+    if verdict.ok:
+        return None
+    lines = "; ".join(f"line {v['line']}: {v['message']}" for v in verdict.violations)
+    return WorkflowMessage(
+        type="tool_result",
+        content=f"compose script rejected by AST guard: {lines}",
+        metadata={"tool_name": "compose", "ast_violations": verdict.violations},
+    )
+
+
+def compose_auto_approvable(shim_snapshot: list[str]) -> bool:
+    """Auto-approve only when the flag is on AND all shims are read-only (design §3.1)."""
+    return CODEEXEC_AUTOAPPROVE_READONLY and set(shim_snapshot) <= CODEEXEC_READONLY_TOOLS
+
+
+async def poll_compose_approval(approval_id: str) -> str:
+    """Poll the WORKFLOW_GATE until decided; return its terminal status (GH#11568 MINOR-2).
+
+    Mirrors the terminal-command approval loop: a bounded poll on the persisted
+    gate. Returns ``approved``/``rejected``/``revision_requested``, or
+    ``timeout`` when no decision lands within the wait budget.
+    """
+    from services.approval_gate_service import ApprovalGateService
+    from user_management.database import get_async_session_factory
+
+    elapsed = 0
+    session_factory = get_async_session_factory()
+    while elapsed < CODEEXEC_APPROVAL_WAIT_SECONDS:
+        async with session_factory() as db:
+            approval = await ApprovalGateService(db).get(uuid_module.UUID(approval_id))
+        status = getattr(approval, "status", None)
+        if status and status != "pending":
+            return status
+        await asyncio.sleep(CODEEXEC_APPROVAL_POLL_SECONDS)
+        elapsed += CODEEXEC_APPROVAL_POLL_SECONDS
+    return "timeout"
+
+
+async def persist_compose_approval(program: str, shim_snapshot: list[str], session_id: str) -> "str | None":
+    """Persist a WORKFLOW_GATE Approval carrying program + shims + budgets (GH#11568)."""
+    from chat_workflow.code_exec.broker import CODEEXEC_MAX_TOOL_CALLS
+    from models.approval import ApprovalType
+    from secure_sandbox_executor import CODEEXEC_TIMEOUT_SECONDS
+    from services.approval_gate_service import ApprovalGateService
+    from user_management.database import get_async_session_factory
+
+    context = {
+        "program": program,
+        "shim_snapshot": shim_snapshot,
+        "budgets": {"max_tool_calls": CODEEXEC_MAX_TOOL_CALLS, "timeout_seconds": CODEEXEC_TIMEOUT_SECONDS},
+    }
+    session_factory = get_async_session_factory()
+    async with session_factory() as db:
+        approval = await ApprovalGateService(db).create_approval(
+            title="compose script execution",
+            approval_type=ApprovalType.WORKFLOW_GATE.value,
+            requested_by_agent="chat_agent",
+            description="Sandboxed Python compose script awaiting approval.",
+            workflow_id=session_id,
+            workflow_step="compose",
+            context=context,
+        )
+        return str(approval.id)
+
+
+def build_compose_dispatch(
+    session_id: str, ctx: "LLMIterationContext | None", dispatch_tool_call: DispatchToolCall
+) -> Callable[[str, dict], Awaitable[Any]]:
+    """Return an async dispatch callable routing shim calls through the seam (GH#11568)."""
+
+    async def _dispatch(tool: str, params: dict) -> Any:
+        from chat_workflow.session_role import DEFAULT_AUTH_ROLE  # noqa: PLC0415
+
+        sub_results: list[dict[str, Any]] = []
+        sub_call = {"name": tool, "params": params}
+        # #13821: a tool called from inside a compose script is still the same
+        # authenticated caller. Omitting the role here left this one path on
+        # the "user" default — the very bug this issue fixes, unfixed.
+        role = ctx.auth_role if ctx is not None else DEFAULT_AUTH_ROLE
+        async for _ in dispatch_tool_call(sub_call, session_id, session_id, "", "", sub_results, [], ctx=ctx, role=role):
+            pass
+        last = sub_results[-1] if sub_results else {}
+        if last.get("status") == "error":
+            raise RepairableException(last.get("error", "tool dispatch failed"))
+        return last.get("output", last)
+
+    return _dispatch
+
+
+async def execute_compose(
+    program: str,
+    agent_id: "str | None",
+    run_id: str,
+    session_id: str,
+    ctx: "LLMIterationContext | None",
+    dispatch_tool_call: DispatchToolCall,
+) -> "WorkflowMessage":
+    """Run the script inside the sandbox via a live broker; return result msg."""
+    from chat_workflow.code_exec.broker import CodeExecBroker
+    from chat_workflow.code_exec.shim_codegen import generate_shim_module, injectable_tool_set
+    from orchestration.agent_registry import resolve_forbidden_tools
+    from secure_sandbox_executor import CODEEXEC_TIMEOUT_SECONDS, SecureSandboxExecutor  # lazy
+
+    forbidden = resolve_forbidden_tools(agent_id)
+    tools = injectable_tool_set([], forbidden)
+    shim_src = generate_shim_module(tools)
+    broker = CodeExecBroker(
+        build_compose_dispatch(session_id, ctx, dispatch_tool_call),
+        tools,
+        forbidden,
+        run_id,
+        f"autobot:codeexec:security:events:{run_id}",
+        progress_channel=f"workflow:{session_id}",
+    )
+    executor = SecureSandboxExecutor()
+    result = await executor.execute_with_stdio_broker(program, shim_src, broker, CODEEXEC_TIMEOUT_SECONDS, run_id)
+    return compose_result_message(result, run_id)
+
+
+def compose_result_message(result: Any, run_id: str) -> "WorkflowMessage":
+    """Build the tool_result WorkflowMessage from a SandboxResult (GH#11568)."""
+    if result.success:
+        return WorkflowMessage(
+            type="tool_result",
+            content=result.stdout or "(no output)",
+            metadata={"tool_name": "compose", "run_id": run_id},
+        )
+    content = f"compose execution failed (exit {result.exit_code}): {result.stderr or result.stdout}"
+    return WorkflowMessage(
+        type="tool_result",
+        content=content,
+        metadata={"tool_name": "compose", "run_id": run_id, "failed": True},
+    )
+
+
+def compose_shim_snapshot(agent_id: "str | None") -> list[str]:
+    """Injectable-tool snapshot for this agent (allowlist ∩ allowed − forbidden)."""
+    from chat_workflow.code_exec.shim_codegen import injectable_tool_set
+    from orchestration.agent_registry import resolve_forbidden_tools
+
+    return injectable_tool_set([], resolve_forbidden_tools(agent_id))
+
+
+def reject_delegated_compose(agent_id: "str | None") -> "WorkflowMessage | None":
+    """Main-chat-only: reject compose for any profile-bound (delegated) agent (GH#11568)."""
+    if agent_id is None:
+        return None
+    return WorkflowMessage(
+        type="tool_result",
+        content="compose is not available for delegated subagents",
+        metadata={"tool_name": "compose"},
+    )
+
+
+def compose_gate_request_msg(approval_id: str, shim_snapshot: list[str]) -> "WorkflowMessage":
+    """Build the WORKFLOW_GATE approval-required notification (GH#11568)."""
+    return WorkflowMessage(
+        type="approval_required",
+        content="compose script requires approval before execution",
+        metadata={
+            "tool": "compose",
+            "approval_required": True,
+            "approval_id": approval_id,
+            "shim_snapshot": shim_snapshot,
+        },
+    )
+
+
+def compose_gate_refusal_msg(status: str) -> "WorkflowMessage":
+    """Terminal refusal message for a non-approved gate (GH#11568)."""
+    return WorkflowMessage(
+        type="tool_result",
+        content=f"compose execution not approved (gate status: {status}).",
+        metadata={"tool_name": "compose", "approval_status": status, "denied": True},
+    )
+
+
+__all__ = [
+    "build_compose_dispatch",
+    "compose_auto_approvable",
+    "compose_gate_refusal_msg",
+    "compose_gate_request_msg",
+    "compose_result_message",
+    "compose_shim_snapshot",
+    "execute_compose",
+    "guard_compose",
+    "persist_compose_approval",
+    "poll_compose_approval",
+    "reject_delegated_compose",
+]

--- a/autobot-backend/chat_workflow/compose_tool_handler.py
+++ b/autobot-backend/chat_workflow/compose_tool_handler.py
@@ -142,7 +142,9 @@ def build_compose_dispatch(
         # authenticated caller. Omitting the role here left this one path on
         # the "user" default — the very bug this issue fixes, unfixed.
         role = ctx.auth_role if ctx is not None else DEFAULT_AUTH_ROLE
-        async for _ in dispatch_tool_call(sub_call, session_id, session_id, "", "", sub_results, [], ctx=ctx, role=role):
+        async for _ in dispatch_tool_call(
+            sub_call, session_id, session_id, "", "", sub_results, [], ctx=ctx, role=role
+        ):
             pass
         last = sub_results[-1] if sub_results else {}
         if last.get("status") == "error":

--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -2629,7 +2629,9 @@ class ToolHandlerMixin:
                 metadata={"tool": tool_name, "error": True},
             )
 
-    async def _handle_llc_tool(self, tool_name, tool_call, execution_results, ctx, session_id: str = "", role: str = "user"):
+    async def _handle_llc_tool(
+        self, tool_name, tool_call, execution_results, ctx, session_id: str = "", role: str = "user"
+    ):
         """Dispatch an LLC work-object tool company-scoped (#11501).
 
         company_id comes from the chat request context (set by the CEO-chat

--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -20,6 +20,7 @@ import uuid
 from typing import TYPE_CHECKING, Any, AsyncIterator
 
 from async_chat_workflow import WorkflowMessage
+from autobot_shared.auth.mcp_tool_permissions import required_permission
 from autobot_shared.auth.permissions import Permission
 from autobot_shared.env_utils import env_flag, env_int
 from autobot_shared.logging_manager import get_logger
@@ -33,7 +34,19 @@ from chat_workflow.browser_tool_handler import (
     record_browser_success,
     validate_browser_params,
 )
-from chat_workflow.code_exec.tool_policy import CODEEXEC_READONLY_TOOLS
+from chat_workflow.compose_tool_handler import (
+    build_compose_dispatch,
+    compose_auto_approvable,
+    compose_gate_refusal_msg,
+    compose_gate_request_msg,
+    compose_result_message,
+    compose_shim_snapshot,
+    execute_compose,
+    guard_compose,
+    persist_compose_approval,
+    poll_compose_approval,
+    reject_delegated_compose,
+)
 from chat_workflow.tool_call_grammar import TOOL_CALL_PATTERN
 from chat_workflow.tool_dispatch_guards import (
     enforce_config_protection,
@@ -63,28 +76,11 @@ from chat_workflow.session_handler import (
 
 logger = get_logger(__name__)
 
-# GH#11568: compose tool feature flag and tuning constants.
+# GH#11568: compose tool feature flag. The auto-approve/poll-interval tuning
+# constants and CODEEXEC_READONLY_TOOLS moved to compose_tool_handler.py
+# (#14491) with the functions that are their only readers.
 CODEEXEC_ENABLED: bool = env_flag("AUTOBOT_CODEEXEC_ENABLED", default=False)
-CODEEXEC_AUTOAPPROVE_READONLY: bool = env_flag("AUTOBOT_CODEEXEC_AUTOAPPROVE_READONLY", default=True)
 CODEEXEC_MAX_SCRIPT_RETRIES: int = env_int("AUTOBOT_CODEEXEC_MAX_SCRIPT_RETRIES", default=1)
-# GH#11568 BLOCKER-4 / GH#11662: the read-only tool set eligible for auto-approval
-# (design §3.1) is CODEEXEC_READONLY_TOOLS, imported above from the single
-# tool-policy classification source (readonly ⊆ injectable; sensitive excluded).
-# Approval-wait polling knobs (mirrors terminal-command approval loop).
-#
-# #13481: this is how long THIS TURN waits, not how long the approval lives.
-# The distinction was invisible before and is the whole of #13216's confusion:
-# the approval is persisted, and approving after this budget still executes the
-# command. Exhausting it means "stop holding the request/generator open", never
-# "the command failed" and never "the approval expired".
-#
-# There is deliberately NO approval-expiry knob here. The reported expectation —
-# that approval should not expire — is the behaviour, so nothing discards a
-# pending approval on a timer. A real expiry policy, if ever wanted, belongs
-# next to the approval's own storage with its own message ("this approval
-# expired, re-request it"), not as a side effect of how long a coroutine lives.
-CODEEXEC_APPROVAL_WAIT_SECONDS: int = env_int("AUTOBOT_CODEEXEC_APPROVAL_WAIT_SECONDS", default=1800)
-CODEEXEC_APPROVAL_POLL_SECONDS: int = env_int("AUTOBOT_CODEEXEC_APPROVAL_POLL_SECONDS", default=2)
 
 # Issue #4482: Default retry count for schema self-correction loop.
 _DEFAULT_SCHEMA_RETRIES = 3
@@ -2564,15 +2560,45 @@ class ToolHandlerMixin:
         tool_call: dict[str, Any],
         execution_results: list[dict[str, Any]],
         session_id: str = "",
+        role: str = "user",
     ):
         """Dispatch one of the 4 web research tools. Issue #7509.
 
         Routes to _exec_scrape_url, _exec_crawl_site, _exec_map_site, or
         _exec_extract_structured_data based on tool_name.  Yields WorkflowMessages
         for execution stages and final output.
+
+        #14491: this builtin dispatch path never called BEFORE_TOOL_EXECUTE at
+        all, so the KNOWLEDGE_READ/KNOWLEDGE_WRITE declarations these same
+        tool names already carry in ``mcp_tool_permissions.TOOL_PERMISSIONS``
+        (for the separate MCP-registry path) were never consulted here.
+        ``crawl_site``/``map_site`` can ingest into the knowledge base
+        (``ingest=True``); reusing the existing declaration rather than
+        inventing a second one.
         """
         params = tool_call.get("params", {})
         logger.info("[Issue #7509] Web research tool: %s params=%s", tool_name, list(params.keys()))
+
+        # #14491: reuses the exact TOOL_PERMISSIONS entry already declared for
+        # this tool name on the MCP-registry path — no bridge_name here (this
+        # is the builtin path), so only the exact-name lookup can hit.
+        declared_permission = required_permission(tool_name)
+        should_execute = await _emit_before_tool_execute(
+            tool_name,
+            params,
+            session_id,
+            tool_permission=declared_permission.value if declared_permission else None,
+            user_role=role,
+        )
+        if not should_execute:
+            logger.info("[#14491] Web research tool %s cancelled by permission hook (role=%s)", tool_name, role)
+            execution_results.append({"tool": tool_name, "status": "error", "error": "permission_denied"})
+            yield WorkflowMessage(
+                type="error",
+                content=f"{tool_name} execution cancelled",
+                metadata={"tool": tool_name, "cancelled_by_hook": True, "reason": "permission_denied"},
+            )
+            return
 
         yield WorkflowMessage(
             type="tool_execution",
@@ -2603,12 +2629,23 @@ class ToolHandlerMixin:
                 metadata={"tool": tool_name, "error": True},
             )
 
-    async def _handle_llc_tool(self, tool_name, tool_call, execution_results, ctx):
+    async def _handle_llc_tool(self, tool_name, tool_call, execution_results, ctx, session_id: str = "", role: str = "user"):
         """Dispatch an LLC work-object tool company-scoped (#11501).
 
         company_id comes from the chat request context (set by the CEO-chat
         endpoint, T2). A missing/invalid context surfaces as a tool error the
         LLM can react to, rather than a crash.
+
+        #14491: every LLC tool mutates company-scoped work objects
+        (``dispatch_llc_tool`` has no RBAC check of its own — only the
+        company/tenant scoping above and the cross-tenant IDOR guard inside
+        ``_update_goal``) and this was the highest-risk of the seven branches
+        never reaching ``BEFORE_TOOL_EXECUTE`` at all. ``Permission.WORKFLOW_CREATE``
+        is the closest existing declaration: it is the permission this system
+        already uses for "create/mutate a unit of work", held by
+        admin/operator/editor and withheld from analyst/user/readonly — the
+        same tier a company board operation should require. Denial returns
+        before ``dispatch_llc_tool`` is ever awaited.
         """
         params = tool_call.get("params", {}) or {}
         _cctx = ctx.context if ctx is not None and ctx.context else {}
@@ -2616,6 +2653,24 @@ class ToolHandlerMixin:
         # #11501 review: actor for audit/authz comes from the authenticated chat
         # context, never from LLM-supplied params.
         user_id = _cctx.get("user_id")
+
+        should_execute = await _emit_before_tool_execute(
+            tool_name,
+            params,
+            session_id,
+            tool_permission=Permission.WORKFLOW_CREATE.value,
+            user_role=role,
+        )
+        if not should_execute:
+            logger.info("[#14491] LLC tool %s cancelled by permission hook (role=%s)", tool_name, role)
+            execution_results.append({"tool": tool_name, "status": "error", "error": "permission_denied"})
+            yield WorkflowMessage(
+                type="error",
+                content=f"{tool_name} execution cancelled",
+                metadata={"tool": tool_name, "cancelled_by_hook": True, "reason": "permission_denied"},
+            )
+            return
+
         try:
             result = await dispatch_llc_tool(tool_name, params, company_id, user_id)
             # #14284: `output` must stay a str — the offload adapter
@@ -3299,7 +3354,10 @@ class ToolHandlerMixin:
                 )
                 yield validation_msg
                 return
-            async for msg in self._handle_llc_tool(tool_name, tool_call, execution_results, ctx):
+            # #14491: forward session_id/role so _handle_llc_tool can declare
+            # Permission.WORKFLOW_CREATE at BEFORE_TOOL_EXECUTE — this branch
+            # never reached the hook before.
+            async for msg in self._handle_llc_tool(tool_name, tool_call, execution_results, ctx, session_id, role):
                 yield msg
             return
 
@@ -3356,17 +3414,17 @@ class ToolHandlerMixin:
         the shared gate. Adding a builtin that follows the standard gate takes a
         schema entry plus one row here — no new branch at the dispatch seam.
 
-        Issue #14469: ``role`` is forwarded only to the three handlers that now
-        declare a ``tool_permission`` (browser, web_search, execute_command) —
-        web research/live-page-extract/read_spilled_output remain undeclared,
-        tracked separately.
+        Issue #14469/#14491: ``role`` is forwarded to every handler that
+        declares a ``tool_permission`` (browser, web_search, execute_command,
+        web research) — live-page-extract/read_spilled_output remain
+        undeclared, tracked separately (#14491's per-branch table).
         """
         if tool_name in BROWSER_TOOL_NAMES:  # Issue #1368: route to browser VM
             return self._handle_browser_tool(tool_call, execution_results, session_id, role=role)
         if tool_name == "web_search":  # Issue #2306: multi-step browser flow
             return self._handle_web_search_tool(tool_call, execution_results, session_id, role=role)
         if tool_name in WEB_RESEARCH_TOOL_NAMES:  # Issue #7509
-            return self._handle_web_research_tool(tool_name, tool_call, execution_results, session_id)
+            return self._handle_web_research_tool(tool_name, tool_call, execution_results, session_id, role=role)
         if tool_name in LIVE_PAGE_EXTRACT_TOOL_NAMES:  # Issue #11540
             return self._handle_extract_content_tool(tool_call, execution_results, session_id)
         if tool_name == "read_spilled_output":  # #13919: the excerpt's note names this
@@ -3441,29 +3499,29 @@ class ToolHandlerMixin:
     # ------------------------------------------------------------------ #
     # GH#11568: compose tool handlers                                     #
     # ------------------------------------------------------------------ #
+    #
+    # Bodies moved to compose_tool_handler.py (#14491) to offset that PR's
+    # additions and keep this module under its file-size ceiling. These stay
+    # as thin delegating methods (same names) rather than a straight rebind
+    # because test_code_exec.py replaces several of them wholesale with a
+    # mock (``handler._persist_compose_approval = AsyncMock(...)``) and
+    # ``_handle_compose_tool`` below must keep dispatching through
+    # ``self.<method>`` for that to still take effect.
 
     def _guard_compose(self, program: str, agent_id: "str | None") -> "WorkflowMessage | None":
-        """Run AST guard; return error WorkflowMessage on violation, else None."""
-        from chat_workflow.code_exec.ast_guard import check_script
-        from chat_workflow.code_exec.shim_codegen import injectable_tool_set
-        from orchestration.agent_registry import resolve_forbidden_tools
+        """Run AST guard; return error WorkflowMessage on violation, else None.
 
-        forbidden = resolve_forbidden_tools(agent_id)
-        injected = frozenset(injectable_tool_set([], forbidden))
-        verdict = check_script(program, frozenset(forbidden), injected_tools=injected)
-        if verdict.ok:
-            return None
-        lines = "; ".join(f"line {v['line']}: {v['message']}" for v in verdict.violations)
-        return WorkflowMessage(
-            type="tool_result",
-            content=f"compose script rejected by AST guard: {lines}",
-            metadata={"tool_name": "compose", "ast_violations": verdict.violations},
-        )
+        See ``compose_tool_handler.guard_compose`` for the full behavior.
+        """
+        return guard_compose(program, agent_id)
 
     @staticmethod
     def _compose_auto_approvable(shim_snapshot: list[str]) -> bool:
-        """Auto-approve only when the flag is on AND all shims are read-only (design §3.1)."""
-        return CODEEXEC_AUTOAPPROVE_READONLY and set(shim_snapshot) <= CODEEXEC_READONLY_TOOLS
+        """Auto-approve only when the flag is on AND all shims are read-only (design §3.1).
+
+        See ``compose_tool_handler.compose_auto_approvable`` for the full behavior.
+        """
+        return compose_auto_approvable(shim_snapshot)
 
     async def _approve_compose(self, program: str, shim_snapshot: list[str], session_id: str) -> "str | None":
         """Return an approval id requiring a gate, or ``None`` to auto-approve (GH#11568).
@@ -3478,152 +3536,67 @@ class ToolHandlerMixin:
     async def _poll_compose_approval(self, approval_id: str) -> str:
         """Poll the WORKFLOW_GATE until decided; return its terminal status (GH#11568 MINOR-2).
 
-        Mirrors the terminal-command approval loop: a bounded poll on the persisted
-        gate. Returns ``approved``/``rejected``/``revision_requested``, or
-        ``timeout`` when no decision lands within the wait budget.
+        See ``compose_tool_handler.poll_compose_approval`` for the full behavior.
         """
-        import uuid as _uuid
-
-        from services.approval_gate_service import ApprovalGateService
-        from user_management.database import get_async_session_factory
-
-        elapsed = 0
-        session_factory = get_async_session_factory()
-        while elapsed < CODEEXEC_APPROVAL_WAIT_SECONDS:
-            async with session_factory() as db:
-                approval = await ApprovalGateService(db).get(_uuid.UUID(approval_id))
-            status = getattr(approval, "status", None)
-            if status and status != "pending":
-                return status
-            await asyncio.sleep(CODEEXEC_APPROVAL_POLL_SECONDS)
-            elapsed += CODEEXEC_APPROVAL_POLL_SECONDS
-        return "timeout"
+        return await poll_compose_approval(approval_id)
 
     async def _persist_compose_approval(self, program: str, shim_snapshot: list[str], session_id: str) -> "str | None":
-        """Persist a WORKFLOW_GATE Approval carrying program + shims + budgets (GH#11568)."""
-        from chat_workflow.code_exec.broker import CODEEXEC_MAX_TOOL_CALLS
-        from models.approval import ApprovalType
-        from secure_sandbox_executor import CODEEXEC_TIMEOUT_SECONDS
-        from services.approval_gate_service import ApprovalGateService
-        from user_management.database import get_async_session_factory
+        """Persist a WORKFLOW_GATE Approval carrying program + shims + budgets (GH#11568).
 
-        context = {
-            "program": program,
-            "shim_snapshot": shim_snapshot,
-            "budgets": {"max_tool_calls": CODEEXEC_MAX_TOOL_CALLS, "timeout_seconds": CODEEXEC_TIMEOUT_SECONDS},
-        }
-        session_factory = get_async_session_factory()
-        async with session_factory() as db:
-            approval = await ApprovalGateService(db).create_approval(
-                title="compose script execution",
-                approval_type=ApprovalType.WORKFLOW_GATE.value,
-                requested_by_agent="chat_agent",
-                description="Sandboxed Python compose script awaiting approval.",
-                workflow_id=session_id,
-                workflow_step="compose",
-                context=context,
-            )
-            return str(approval.id)
+        See ``compose_tool_handler.persist_compose_approval`` for the full behavior.
+        """
+        return await persist_compose_approval(program, shim_snapshot, session_id)
 
     def _build_compose_dispatch(self, session_id: str, ctx: "LLMIterationContext | None"):
-        """Return an async dispatch callable routing shim calls through the seam (GH#11568)."""
+        """Return an async dispatch callable routing shim calls through the seam (GH#11568).
 
-        async def _dispatch(tool: str, params: dict) -> Any:
-            from chat_workflow.session_role import DEFAULT_AUTH_ROLE  # noqa: PLC0415
-
-            sub_results: list[dict[str, Any]] = []
-            sub_call = {"name": tool, "params": params}
-            # #13821: a tool called from inside a compose script is still the same
-            # authenticated caller. Omitting the role here left this one path on
-            # the "user" default — the very bug this issue fixes, unfixed.
-            role = ctx.auth_role if ctx is not None else DEFAULT_AUTH_ROLE
-            async for _ in self._dispatch_tool_call(
-                sub_call, session_id, session_id, "", "", sub_results, [], ctx=ctx, role=role
-            ):
-                pass
-            last = sub_results[-1] if sub_results else {}
-            if last.get("status") == "error":
-                raise RepairableException(last.get("error", "tool dispatch failed"))
-            return last.get("output", last)
-
-        return _dispatch
+        See ``compose_tool_handler.build_compose_dispatch`` for the full behavior.
+        """
+        return build_compose_dispatch(session_id, ctx, self._dispatch_tool_call)
 
     async def _execute_compose(
         self, program: str, agent_id: "str | None", run_id: str, session_id: str, ctx: "LLMIterationContext | None"
     ) -> "WorkflowMessage":
-        """Run the script inside the sandbox via a live broker; return result msg."""
-        from chat_workflow.code_exec.broker import CodeExecBroker
-        from chat_workflow.code_exec.shim_codegen import generate_shim_module, injectable_tool_set
-        from orchestration.agent_registry import resolve_forbidden_tools
-        from secure_sandbox_executor import CODEEXEC_TIMEOUT_SECONDS, SecureSandboxExecutor  # lazy
+        """Run the script inside the sandbox via a live broker; return result msg.
 
-        forbidden = resolve_forbidden_tools(agent_id)
-        tools = injectable_tool_set([], forbidden)
-        shim_src = generate_shim_module(tools)
-        broker = CodeExecBroker(
-            self._build_compose_dispatch(session_id, ctx),
-            tools,
-            forbidden,
-            run_id,
-            f"autobot:codeexec:security:events:{run_id}",
-            progress_channel=f"workflow:{session_id}",
-        )
-        executor = SecureSandboxExecutor()
-        result = await executor.execute_with_stdio_broker(program, shim_src, broker, CODEEXEC_TIMEOUT_SECONDS, run_id)
-        return self._compose_result_message(result, run_id)
+        See ``compose_tool_handler.execute_compose`` for the full behavior.
+        """
+        return await execute_compose(program, agent_id, run_id, session_id, ctx, self._dispatch_tool_call)
 
     def _compose_result_message(self, result: Any, run_id: str) -> "WorkflowMessage":
-        """Build the tool_result WorkflowMessage from a SandboxResult (GH#11568)."""
-        if result.success:
-            return WorkflowMessage(
-                type="tool_result",
-                content=result.stdout or "(no output)",
-                metadata={"tool_name": "compose", "run_id": run_id},
-            )
-        content = f"compose execution failed (exit {result.exit_code}): {result.stderr or result.stdout}"
-        return WorkflowMessage(
-            type="tool_result",
-            content=content,
-            metadata={"tool_name": "compose", "run_id": run_id, "failed": True},
-        )
+        """Build the tool_result WorkflowMessage from a SandboxResult (GH#11568).
+
+        See ``compose_tool_handler.compose_result_message`` for the full behavior.
+        """
+        return compose_result_message(result, run_id)
 
     def _compose_shim_snapshot(self, agent_id: "str | None") -> list[str]:
-        """Injectable-tool snapshot for this agent (allowlist ∩ allowed − forbidden)."""
-        from chat_workflow.code_exec.shim_codegen import injectable_tool_set
-        from orchestration.agent_registry import resolve_forbidden_tools
+        """Injectable-tool snapshot for this agent (allowlist ∩ allowed − forbidden).
 
-        return injectable_tool_set([], resolve_forbidden_tools(agent_id))
+        See ``compose_tool_handler.compose_shim_snapshot`` for the full behavior.
+        """
+        return compose_shim_snapshot(agent_id)
 
     def _reject_delegated_compose(self, agent_id: "str | None") -> "WorkflowMessage | None":
-        """Main-chat-only: reject compose for any profile-bound (delegated) agent (GH#11568)."""
-        if agent_id is None:
-            return None
-        return WorkflowMessage(
-            type="tool_result",
-            content="compose is not available for delegated subagents",
-            metadata={"tool_name": "compose"},
-        )
+        """Main-chat-only: reject compose for any profile-bound (delegated) agent (GH#11568).
+
+        See ``compose_tool_handler.reject_delegated_compose`` for the full behavior.
+        """
+        return reject_delegated_compose(agent_id)
 
     def _compose_gate_request_msg(self, approval_id: str, shim_snapshot: list[str]) -> "WorkflowMessage":
-        """Build the WORKFLOW_GATE approval-required notification (GH#11568)."""
-        return WorkflowMessage(
-            type="approval_required",
-            content="compose script requires approval before execution",
-            metadata={
-                "tool": "compose",
-                "approval_required": True,
-                "approval_id": approval_id,
-                "shim_snapshot": shim_snapshot,
-            },
-        )
+        """Build the WORKFLOW_GATE approval-required notification (GH#11568).
+
+        See ``compose_tool_handler.compose_gate_request_msg`` for the full behavior.
+        """
+        return compose_gate_request_msg(approval_id, shim_snapshot)
 
     def _compose_gate_refusal_msg(self, status: str) -> "WorkflowMessage":
-        """Terminal refusal message for a non-approved gate (GH#11568)."""
-        return WorkflowMessage(
-            type="tool_result",
-            content=f"compose execution not approved (gate status: {status}).",
-            metadata={"tool_name": "compose", "approval_status": status, "denied": True},
-        )
+        """Terminal refusal message for a non-approved gate (GH#11568).
+
+        See ``compose_tool_handler.compose_gate_refusal_msg`` for the full behavior.
+        """
+        return compose_gate_refusal_msg(status)
 
     async def _handle_compose_tool(
         self,

--- a/autobot-backend/tests/unit/chat_workflow/test_ceo_dispatch_routing.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_ceo_dispatch_routing.py
@@ -7,6 +7,15 @@ handler (through the enforcement guards), or is it blocked/misrouted before
 _handle_llc_tool? The earlier chain test called _handle_llc_tool directly and
 bypassed the guards + routing — this closes that gap.
 
+#14491 review: this file's whole purpose — asserting through the real
+_dispatch_tool_call chain rather than the handler in isolation — is exactly
+what the RBAC gate must be proven against too, so PermissionEnforcementExtension
+is registered on the real singleton for every test here (not just the new
+denial one) rather than left absent. Before this fix, `role="user"` here
+"succeeded" only because the extension was never registered — nothing about
+this file exercised the gate #14491 added; a broken guard would have passed
+every assertion below unchanged.
+
 Imports the real ToolHandlerMixin; skips where the heavy chain can't load.
 """
 
@@ -16,6 +25,24 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
+
+from middleware.builtin.permission_enforcement import PermissionEnforcementExtension
+from middleware.manager import get_extension_manager, reset_extension_manager
+
+
+@pytest.fixture(autouse=True)
+def _real_permission_enforcement():
+    """Register the real extension on the real singleton every hook call reads.
+
+    #14491 review: without this, `_emit_before_tool_execute` invokes zero
+    extensions and no-ops to "allow" regardless of role or declared
+    permission — a denial test here would pass against code with the guard
+    ripped out just as readily as against the real gate.
+    """
+    reset_extension_manager()
+    get_extension_manager().register(PermissionEnforcementExtension())
+    yield
+    reset_extension_manager()
 
 
 def _mixin():
@@ -41,29 +68,46 @@ def _ctx():
     )
 
 
-@pytest.mark.asyncio
-async def test_dispatch_routes_create_task_to_llc_handler():
-    m = _mixin()
+async def _dispatch_create_task(m, role: str) -> tuple[list, list]:
     tool_call = {"name": "create_task", "params": {"title": "Write Q3 report", "priority": "high"}}
     exec_results: list = []
+    msgs = [
+        msg
+        async for msg in m._dispatch_tool_call(
+            tool_call,
+            "sess-1",
+            "term-1",
+            "http://x/api/generate",
+            "model",
+            exec_results,
+            [],
+            ctx=_ctx(),
+            role=role,
+        )
+    ]
+    return msgs, exec_results
+
+
+@pytest.mark.asyncio
+async def test_dispatch_routes_create_task_to_llc_handler():
+    """Routing reaches the LLC branch and dispatches — the control case.
+
+    #14491 review: role is "operator" (holds WORKFLOW_CREATE), not "user".
+    This test's job is proving ROUTING — that create_task reaches
+    _handle_llc_tool through the real guard chain rather than being blocked
+    by an unrelated guard or falling through to MCP/unknown — not proving
+    RBAC. Asserting a "user" role succeeds here would silently contradict
+    the RBAC model #14491 added; see
+    test_role_lacking_workflow_create_is_denied_through_dispatch below for
+    the denial case, and test_permission_enforcement_builtin_surfaces.py's
+    TestLLCToolDenial for the handler-level equivalent.
+    """
+    m = _mixin()
     with patch(
         "chat_workflow.tool_handler.dispatch_llc_tool",
         new=AsyncMock(return_value={"status": "success", "entity_type": "work_item", "entity_id": "wi-1"}),
     ) as disp:
-        msgs = [
-            msg
-            async for msg in m._dispatch_tool_call(
-                tool_call,
-                "sess-1",
-                "term-1",
-                "http://x/api/generate",
-                "model",
-                exec_results,
-                [],
-                ctx=_ctx(),
-                role="user",
-            )
-        ]
+        msgs, exec_results = await _dispatch_create_task(m, "operator")
     # The routing must reach the LLC branch and dispatch (not be blocked by a
     # guard, and not fall through to MCP/unknown).
     disp.assert_awaited_once()
@@ -71,3 +115,29 @@ async def test_dispatch_routes_create_task_to_llc_handler():
     assert disp.await_args.args[2] == "co-1"  # company_id from ctx.context
     assert exec_results and exec_results[-1].get("status") == "success"
     assert not any(getattr(x, "type", "") == "approval_required" for x in msgs)
+
+
+@pytest.mark.asyncio
+async def test_role_lacking_workflow_create_is_denied_through_dispatch():
+    """#14491: `user` lacks WORKFLOW_CREATE — denial must happen at the real
+    _dispatch_tool_call seam, not just inside _handle_llc_tool in isolation.
+
+    This is the test the coordinator's review asked for: it goes through
+    _dispatch_tool_call (the production entry point every tool call funnels
+    through), with PermissionEnforcementExtension actually registered, and
+    proves the mutating call (dispatch_llc_tool) never happens.
+    """
+    m = _mixin()
+    with patch(
+        "chat_workflow.tool_handler.dispatch_llc_tool",
+        new=AsyncMock(return_value={"status": "success", "entity_type": "work_item", "entity_id": "wi-1"}),
+    ) as disp:
+        msgs, exec_results = await _dispatch_create_task(m, "user")
+
+    disp.assert_not_awaited()
+    assert exec_results and exec_results[-1].get("status") == "error"
+    assert exec_results[-1].get("error") == "permission_denied"
+    last = msgs[-1]
+    assert last.type == "error"
+    assert last.metadata.get("cancelled_by_hook") is True
+    assert last.metadata.get("reason") == "permission_denied"

--- a/autobot-backend/tests/unit/chat_workflow/test_ceo_tool_execution_chain.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_ceo_tool_execution_chain.py
@@ -55,6 +55,24 @@ def test_parse_extracts_create_task_from_board_output():
 
 @pytest.mark.asyncio
 async def test_handle_llc_tool_dispatches_company_scoped():
+    """Company-id threading through _handle_llc_tool — deliberately narrow.
+
+    #14491 review: this calls _handle_llc_tool directly (skipping
+    _dispatch_tool_call and its guard chain) on purpose — its job is
+    isolating whether company_id/user_id thread correctly from ctx.context,
+    per this file's own module docstring ("(2) fails -> the dispatch/context
+    is [the break]"), not proving RBAC or routing. No
+    PermissionEnforcementExtension is registered here, so this test's result
+    does not depend on role at all; `role="operator"` is passed explicitly
+    (rather than left on the "user" default) purely so a reader does not
+    mistake this for evidence that "user" is allowed to create_task — it
+    is not, since #14491 gates this tool on WORKFLOW_CREATE. That RBAC
+    behaviour is proven at the real dispatch seam by
+    test_ceo_dispatch_routing.py's
+    test_role_lacking_workflow_create_is_denied_through_dispatch and at the
+    handler seam by test_permission_enforcement_builtin_surfaces.py's
+    TestLLCToolDenial.
+    """
     m = _mixin_instance()
     ctx = SimpleNamespace(context={"company_id": "co-1", "user_id": "u-1"}, consecutive_invalid_tool_calls=0)
     tool_call = {"name": "create_task", "params": {"title": "X", "priority": "high"}}
@@ -63,7 +81,10 @@ async def test_handle_llc_tool_dispatches_company_scoped():
         "chat_workflow.tool_handler.dispatch_llc_tool",
         new=AsyncMock(return_value={"status": "success", "entity_type": "work_item", "entity_id": "wi-1"}),
     ) as disp:
-        msgs = [msg async for msg in m._handle_llc_tool("create_task", tool_call, exec_results, ctx)]
+        msgs = [
+            msg
+            async for msg in m._handle_llc_tool("create_task", tool_call, exec_results, ctx, role="operator")
+        ]
     disp.assert_awaited_once()
     args = disp.await_args.args
     # dispatch_llc_tool(tool_name, params, company_id, user_id)

--- a/autobot-backend/tests/unit/chat_workflow/test_ceo_tool_execution_chain.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_ceo_tool_execution_chain.py
@@ -81,10 +81,7 @@ async def test_handle_llc_tool_dispatches_company_scoped():
         "chat_workflow.tool_handler.dispatch_llc_tool",
         new=AsyncMock(return_value={"status": "success", "entity_type": "work_item", "entity_id": "wi-1"}),
     ) as disp:
-        msgs = [
-            msg
-            async for msg in m._handle_llc_tool("create_task", tool_call, exec_results, ctx, role="operator")
-        ]
+        msgs = [msg async for msg in m._handle_llc_tool("create_task", tool_call, exec_results, ctx, role="operator")]
     disp.assert_awaited_once()
     args = disp.await_args.args
     # dispatch_llc_tool(tool_name, params, company_id, user_id)

--- a/autobot-backend/tests/unit/chat_workflow/test_code_exec.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_code_exec.py
@@ -389,7 +389,9 @@ async def test_compose_e2e_with_fake_executor():
     fake_executor_instance.execute_with_stdio_broker = AsyncMock(return_value=fake_result)
 
     msgs = []
-    with patch("chat_workflow.tool_handler.CODEEXEC_AUTOAPPROVE_READONLY", True):
+    # #14491: CODEEXEC_AUTOAPPROVE_READONLY moved to compose_tool_handler.py
+    # with the function (_compose_auto_approvable's body) that reads it.
+    with patch("chat_workflow.compose_tool_handler.CODEEXEC_AUTOAPPROVE_READONLY", True):
         with patch("secure_sandbox_executor.SecureSandboxExecutor", return_value=fake_executor_instance):
             async for msg in handler._handle_compose_tool(tool_call, "s1", [], _FakeCtx()):
                 msgs.append(msg)

--- a/autobot-backend/tests/unit/chat_workflow/test_code_exec.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_code_exec.py
@@ -245,6 +245,7 @@ async def test_compose_ast_violation_rejected():
 @pytest.mark.asyncio
 async def test_compose_approval_gate_creates_record():
     """When auto-approve is off, compose persists a WORKFLOW_GATE record and yields approval_required."""
+    import chat_workflow.compose_tool_handler as cth
     import chat_workflow.tool_handler as th
 
     handler = object.__new__(th.ToolHandlerMixin)
@@ -254,7 +255,9 @@ async def test_compose_approval_gate_creates_record():
     handler._persist_compose_approval = AsyncMock(return_value="approval-uuid-1")
     handler._poll_compose_approval = AsyncMock(return_value="rejected")
 
-    with patch.object(th, "CODEEXEC_AUTOAPPROVE_READONLY", False):
+    # #14491: CODEEXEC_AUTOAPPROVE_READONLY moved to compose_tool_handler.py with
+    # the function (_compose_auto_approvable's body) that reads it.
+    with patch.object(cth, "CODEEXEC_AUTOAPPROVE_READONLY", False):
         async for msg in handler._handle_compose_tool(tool_call, "s1", [], _FakeCtx()):
             msgs.append(msg)
 
@@ -525,13 +528,19 @@ def test_injectable_excludes_sensitive_even_when_env_widened():
 
 
 def test_tool_policy_is_single_source_for_consumers():
-    """shim_codegen and tool_handler must expose the tool_policy objects, not copies."""
-    import chat_workflow.tool_handler as th
+    """shim_codegen and compose_tool_handler must expose the tool_policy objects, not copies.
+
+    #14491: CODEEXEC_READONLY_TOOLS's consumer moved from chat_workflow.tool_handler
+    to chat_workflow.compose_tool_handler (the extracted compose-tool module) — this
+    assertion is pinning that the *consumer*, whichever module that is, shares the
+    one tool_policy object rather than holding a copy, so it moves with the consumer.
+    """
+    import chat_workflow.compose_tool_handler as cth
     from chat_workflow.code_exec import shim_codegen, tool_policy
 
     assert shim_codegen.SENSITIVE_TOOLS is tool_policy.SENSITIVE_TOOLS
     assert shim_codegen.CODEEXEC_INJECTABLE_TOOLS is tool_policy.CODEEXEC_INJECTABLE_TOOLS
-    assert th.CODEEXEC_READONLY_TOOLS is tool_policy.CODEEXEC_READONLY_TOOLS
+    assert cth.CODEEXEC_READONLY_TOOLS is tool_policy.CODEEXEC_READONLY_TOOLS
 
 
 def test_tool_policy_invariants_hold():
@@ -730,6 +739,7 @@ async def test_run_broker_script_starts_container_once():
 @pytest.mark.asyncio
 async def test_compose_non_readonly_shim_forces_gate_despite_flag():
     """A non-read-only tool in the shim snapshot forces approval even when auto-approve is on."""
+    import chat_workflow.compose_tool_handler as cth
     import chat_workflow.tool_handler as th
 
     handler = object.__new__(th.ToolHandlerMixin)
@@ -739,7 +749,8 @@ async def test_compose_non_readonly_shim_forces_gate_despite_flag():
     tool_call = {"name": "compose", "params": {"program": "import asyncio\n"}}
 
     msgs = []
-    with patch.object(th, "CODEEXEC_AUTOAPPROVE_READONLY", True):
+    # #14491: moved to compose_tool_handler.py with its reader.
+    with patch.object(cth, "CODEEXEC_AUTOAPPROVE_READONLY", True):
         async for msg in handler._handle_compose_tool(tool_call, "s1", [], _FakeCtx()):
             msgs.append(msg)
 
@@ -749,13 +760,15 @@ async def test_compose_non_readonly_shim_forces_gate_despite_flag():
 
 def test_compose_auto_approvable_only_for_readonly_set():
     """_compose_auto_approvable is True only when all shims are read-only AND flag on."""
+    import chat_workflow.compose_tool_handler as cth
     import chat_workflow.tool_handler as th
 
     handler = object.__new__(th.ToolHandlerMixin)
-    with patch.object(th, "CODEEXEC_AUTOAPPROVE_READONLY", True):
+    # #14491: moved to compose_tool_handler.py with its reader.
+    with patch.object(cth, "CODEEXEC_AUTOAPPROVE_READONLY", True):
         assert handler._compose_auto_approvable(["web_search"]) is True
         assert handler._compose_auto_approvable(["web_search", "write_file"]) is False
-    with patch.object(th, "CODEEXEC_AUTOAPPROVE_READONLY", False):
+    with patch.object(cth, "CODEEXEC_AUTOAPPROVE_READONLY", False):
         assert handler._compose_auto_approvable(["web_search"]) is False
 
 
@@ -767,6 +780,7 @@ def test_compose_auto_approvable_only_for_readonly_set():
 @pytest.mark.asyncio
 async def test_compose_gate_approved_resumes_execution():
     """An APPROVED gate proceeds to _execute_compose."""
+    import chat_workflow.compose_tool_handler as cth
     import chat_workflow.tool_handler as th
 
     handler = object.__new__(th.ToolHandlerMixin)
@@ -779,7 +793,8 @@ async def test_compose_gate_approved_resumes_execution():
     tool_call = {"name": "compose", "params": {"program": "import asyncio\n"}}
 
     msgs = []
-    with patch.object(th, "CODEEXEC_AUTOAPPROVE_READONLY", False):
+    # #14491: moved to compose_tool_handler.py with its reader.
+    with patch.object(cth, "CODEEXEC_AUTOAPPROVE_READONLY", False):
         async for msg in handler._handle_compose_tool(tool_call, "s1", [], _FakeCtx()):
             msgs.append(msg)
 
@@ -790,6 +805,7 @@ async def test_compose_gate_approved_resumes_execution():
 @pytest.mark.asyncio
 async def test_compose_gate_denied_returns_refusal_and_skips_execution():
     """A DENIED gate returns a refusal and never calls _execute_compose."""
+    import chat_workflow.compose_tool_handler as cth
     import chat_workflow.tool_handler as th
 
     handler = object.__new__(th.ToolHandlerMixin)
@@ -800,7 +816,8 @@ async def test_compose_gate_denied_returns_refusal_and_skips_execution():
     tool_call = {"name": "compose", "params": {"program": "import asyncio\n"}}
 
     msgs = []
-    with patch.object(th, "CODEEXEC_AUTOAPPROVE_READONLY", False):
+    # #14491: moved to compose_tool_handler.py with its reader.
+    with patch.object(cth, "CODEEXEC_AUTOAPPROVE_READONLY", False):
         async for msg in handler._handle_compose_tool(tool_call, "s1", [], _FakeCtx()):
             msgs.append(msg)
 

--- a/autobot-backend/tests/unit/chat_workflow/test_permission_enforcement_builtin_surfaces.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_permission_enforcement_builtin_surfaces.py
@@ -222,6 +222,7 @@ class TestWebSearchDenial:
 
         handler._execute_web_search.assert_awaited_once()
 
+
 # --------------------------------------------------------------------------
 # LLC work-object tools — Permission.WORKFLOW_CREATE (#14491)
 #

--- a/autobot-backend/tests/unit/chat_workflow/test_permission_enforcement_builtin_surfaces.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_permission_enforcement_builtin_surfaces.py
@@ -221,3 +221,145 @@ class TestWebSearchDenial:
             pass
 
         handler._execute_web_search.assert_awaited_once()
+
+# --------------------------------------------------------------------------
+# LLC work-object tools — Permission.WORKFLOW_CREATE (#14491)
+#
+# `_handle_llc_tool` never called BEFORE_TOOL_EXECUTE at all before this: the
+# branch reached `dispatch_llc_tool` (a real DB mutation) directly. This is
+# the highest-risk of the seven branches #14491 catalogued.
+# --------------------------------------------------------------------------
+
+
+class TestLLCToolDenial:
+    def _tool_call(self) -> dict:
+        return {"name": "create_task", "params": {"title": "Ship it"}, "description": ""}
+
+    @pytest.mark.asyncio
+    async def test_a_role_lacking_workflow_create_is_denied(self):
+        handler = _handler()
+        with patch("chat_workflow.tool_handler.dispatch_llc_tool", AsyncMock()) as mock_dispatch:
+            messages = [
+                msg
+                async for msg in handler._handle_llc_tool(
+                    "create_task", self._tool_call(), [], None, session_id="sess-1", role="user"
+                )
+            ]
+
+        assert messages[-1].type == "error"
+        assert messages[-1].metadata.get("cancelled_by_hook") is True
+        assert messages[-1].metadata.get("reason") == "permission_denied"
+        mock_dispatch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_an_unauthenticated_caller_is_denied(self):
+        handler = _handler()
+        with patch("chat_workflow.tool_handler.dispatch_llc_tool", AsyncMock()) as mock_dispatch:
+            async for _msg in handler._handle_llc_tool(
+                "create_task", self._tool_call(), [], None, session_id="sess-1", role=None
+            ):
+                pass
+
+        mock_dispatch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_a_role_holding_workflow_create_is_allowed(self):
+        """`operator` holds WORKFLOW_CREATE — the control case proving this
+        discriminates rather than always denying."""
+        handler = _handler()
+        with patch(
+            "chat_workflow.tool_handler.dispatch_llc_tool",
+            AsyncMock(return_value={"status": "success", "entity_type": "work_item", "entity_id": "wi-1"}),
+        ) as mock_dispatch:
+            async for _msg in handler._handle_llc_tool(
+                "create_task", self._tool_call(), [], None, session_id="sess-1", role="operator"
+            ):
+                pass
+
+        mock_dispatch.assert_awaited_once()
+
+
+# --------------------------------------------------------------------------
+# Web research tools — reuse TOOL_PERMISSIONS' existing KNOWLEDGE_READ/WRITE
+# declaration for the same tool names on the MCP-registry path (#14491).
+# --------------------------------------------------------------------------
+
+
+class TestWebResearchToolDenial:
+    def _tool_call(self, name: str, params: dict) -> dict:
+        return {"name": name, "params": params, "description": ""}
+
+    @pytest.mark.asyncio
+    async def test_an_unauthenticated_caller_is_denied_for_scrape_url(self):
+        """scrape_url declares KNOWLEDGE_READ; role=None holds nothing."""
+        handler = _handler()
+        handler._exec_scrape_url = AsyncMock(return_value="content")
+
+        messages = [
+            msg
+            async for msg in handler._handle_web_research_tool(
+                "scrape_url",
+                self._tool_call("scrape_url", {"url": "https://example.com"}),
+                [],
+                session_id="sess-1",
+                role=None,
+            )
+        ]
+
+        assert messages[-1].metadata.get("cancelled_by_hook") is True
+        assert messages[-1].metadata.get("reason") == "permission_denied"
+        handler._exec_scrape_url.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_a_role_holding_knowledge_read_is_allowed_for_scrape_url(self):
+        handler = _handler()
+        handler._exec_scrape_url = AsyncMock(return_value="content")
+
+        async for _msg in handler._handle_web_research_tool(
+            "scrape_url",
+            self._tool_call("scrape_url", {"url": "https://example.com"}),
+            [],
+            session_id="sess-1",
+            role="user",
+        ):
+            pass
+
+        handler._exec_scrape_url.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_a_role_lacking_knowledge_write_is_denied_for_crawl_site(self):
+        """crawl_site declares KNOWLEDGE_WRITE; `user` holds only KNOWLEDGE_READ."""
+        handler = _handler()
+        handler._exec_crawl_site = AsyncMock(return_value="index")
+
+        messages = [
+            msg
+            async for msg in handler._handle_web_research_tool(
+                "crawl_site",
+                self._tool_call("crawl_site", {"seed_urls": ["https://example.com"]}),
+                [],
+                session_id="sess-1",
+                role="user",
+            )
+        ]
+
+        assert messages[-1].metadata.get("cancelled_by_hook") is True
+        assert messages[-1].metadata.get("reason") == "permission_denied"
+        handler._exec_crawl_site.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_a_role_holding_knowledge_write_is_allowed_for_crawl_site(self):
+        """`operator` holds KNOWLEDGE_WRITE — the control case."""
+        handler = _handler()
+        handler._exec_crawl_site = AsyncMock(return_value="index")
+
+        async for _msg in handler._handle_web_research_tool(
+            "crawl_site",
+            self._tool_call("crawl_site", {"seed_urls": ["https://example.com"]}),
+            [],
+            session_id="sess-1",
+            role="operator",
+        ):
+            pass
+
+        handler._exec_crawl_site.assert_awaited_once()

--- a/repo_tests/python_file_size_ratchet_test.py
+++ b/repo_tests/python_file_size_ratchet_test.py
@@ -59,7 +59,7 @@ _SCRIPT = REPO_ROOT / "scripts" / "check_python_file_size.py"
 RATCHET_BASELINE = {
     "autobot-backend/orchestrator.py": 1114,
     "autobot-backend/chat_workflow/manager.py": 4068,
-    "autobot-backend/chat_workflow/tool_handler.py": 3719,
+    "autobot-backend/chat_workflow/tool_handler.py": 3694,
 }
 
 # Floor for the tracked-Python enumeration (4958 files at the time of writing).

--- a/scripts/check_python_file_size.py
+++ b/scripts/check_python_file_size.py
@@ -71,7 +71,7 @@ RATCHET_REL = "repo_tests/python_file_size_ratchet_test.py"
 KNOWN_LARGE: dict[str, int] = {
     "autobot-backend/orchestrator.py": 1114,
     "autobot-backend/chat_workflow/manager.py": 4068,
-    "autobot-backend/chat_workflow/tool_handler.py": 3692,
+    "autobot-backend/chat_workflow/tool_handler.py": 3694,
 }
 
 

--- a/scripts/check_python_file_size.py
+++ b/scripts/check_python_file_size.py
@@ -71,7 +71,7 @@ RATCHET_REL = "repo_tests/python_file_size_ratchet_test.py"
 KNOWN_LARGE: dict[str, int] = {
     "autobot-backend/orchestrator.py": 1114,
     "autobot-backend/chat_workflow/manager.py": 4068,
-    "autobot-backend/chat_workflow/tool_handler.py": 3719,
+    "autobot-backend/chat_workflow/tool_handler.py": 3692,
 }
 
 


### PR DESCRIPTION
## Thinking Path

#14491 found seven `_dispatch_tool_call` branches that never invoke
`_emit_before_tool_execute` at all, so `PermissionEnforcementExtension` never
runs for them. Established reach independently for each (table below) rather
than trusting the issue's own risk ranking, then scoped the PR to the two
that both (a) genuinely mutate state and (b) have an unambiguous existing
permission to reuse: `_handle_llc_tool` (company-scoped work-object writes,
zero RBAC anywhere in that path) and `_handle_web_research_tool` (the same
tool names already carry `KNOWLEDGE_READ`/`KNOWLEDGE_WRITE` in
`mcp_tool_permissions.TOOL_PERMISSIONS` for the sibling MCP-registry path —
reusing it rather than inventing a second declaration). The other five
(`extract_content`, `read_spilled_output`, `compose`, `delegate`, `respond`)
are read-only, already governed by a different mechanism, or need a design
decision the issue itself flagged as separate — filed as #14529 with their
own reach analysis rather than rushed into this PR.

`tool_handler.py` was already sitting exactly at its file-size ceiling
(3719). Extracted the compose-tool handler bodies to a new
`compose_tool_handler.py` (same shape #14469 used for `browser_tool_handler.py`)
to pay for the LLC/web_research additions, keeping the delegating methods
under their original names so `test_code_exec.py`'s instance-attribute mocks
(`handler._persist_compose_approval = AsyncMock(...)`) keep working. Lowered
the ceiling to the file's exact size (3694 — see note below on the
auto-fix formatting bot) per the ratchet in
`scripts/check_python_file_size.py`.

## What Changed

- `autobot-backend/chat_workflow/tool_handler.py`:
  - `_handle_llc_tool` now declares `Permission.WORKFLOW_CREATE` and checks
    `_emit_before_tool_execute` before `dispatch_llc_tool` is ever awaited;
    `role`/`session_id` threaded from the `LLC_TOOL_NAMES` dispatch branch.
  - `_handle_web_research_tool` now looks up
    `mcp_tool_permissions.required_permission(tool_name)` and checks
    `_emit_before_tool_execute` before the `_exec_*` dispatch table is ever
    invoked; `role` threaded from `_builtin_route`.
  - Compose-tool method bodies replaced with one-line delegates to the new
    `compose_tool_handler` module; `_handle_compose_tool` itself, and the two
    methods (`_approve_compose`, and `_handle_compose_tool` proper) that
    dynamically call sibling `self.<method>`s the test suite mocks, are
    unchanged.
- `autobot-backend/chat_workflow/compose_tool_handler.py` (new): the
  extracted, self-contained compose-tool function bodies + the
  `CODEEXEC_AUTOAPPROVE_READONLY`/`CODEEXEC_APPROVAL_WAIT_SECONDS`/
  `CODEEXEC_APPROVAL_POLL_SECONDS`/`CODEEXEC_READONLY_TOOLS` constants that
  moved with them.
- `autobot-backend/chat_workflow/code_exec/tool_policy.py`: doc comment
  updated for the constant's new home.
- `scripts/check_python_file_size.py`: `tool_handler.py` ceiling lowered
  3719 → 3692, then 3692 → 3694 after the repo's `auto-fix-formatting`
  bot reformatted one over-long signature this PR introduced (net +2
  lines) — see the collision note below.
- `autobot-backend/tests/unit/chat_workflow/test_permission_enforcement_builtin_surfaces.py`:
  dispatch-level denial/allow pairs for both newly wired branches, same
  pattern as the existing execute_command/browser/web_search tests (real
  `ExtensionManager` + real `PermissionEnforcementExtension`, only the
  side-effecting call stubbed).
- `autobot-backend/tests/unit/chat_workflow/test_code_exec.py`: repointed
  the one `patch("chat_workflow.tool_handler.CODEEXEC_AUTOAPPROVE_READONLY", ...)`
  at its new home (`chat_workflow.compose_tool_handler`) — would have raised
  `AttributeError` after the extraction otherwise.
- **Security review follow-up (this PR), round 2 — the extraction's own
  sweep was incomplete:** the first repointing (below) only searched for the
  dotted patch-target string `"chat_workflow.tool_handler.X"` and found one
  hit. `test_code_exec.py` also reaches the same two moved constants via
  `import chat_workflow.tool_handler as th` + attribute access
  (`patch.object(th, "CODEEXEC_AUTOAPPROVE_READONLY", ...)`, `th.CODEEXEC_READONLY_TOOLS`)
  — a second, syntactically distinct reference shape invisible to a
  dotted-string grep. CI caught it: `python-suite shard 9/12` red on six
  `AttributeError`s. Re-swept all 15 moved symbols **by name alone** (not by
  import shape) across the whole repo — the only surviving references are
  `compose_tool_handler.py` itself and `tool_handler.py`'s own delegate
  imports — then repointed all six `patch.object(th, ...)` call sites plus
  the one identity assertion (`test_tool_policy_is_single_source_for_consumers`,
  which pins that whichever module consumes `CODEEXEC_READONLY_TOOLS` shares
  the same object as `tool_policy`'s — now the extracted consumer, so the
  assertion now names it) at `chat_workflow.compose_tool_handler`. Chose
  repointing over a re-export shim on `tool_handler`: a shim would spend back
  the file-size budget this extraction exists to free, and would leave the
  next reader finding the name on the old module with an extra hop to
  discover where the value actually lives.
- **Security review follow-up (this PR):**
  `autobot-backend/tests/unit/chat_workflow/test_ceo_dispatch_routing.py` and
  `test_ceo_tool_execution_chain.py` both asserted `role="user"` successfully
  dispatches `create_task` — true before this PR, false after, and neither
  file registered `PermissionEnforcementExtension`, so they kept passing
  without ever exercising the new gate. Fixed both:
  - `test_ceo_dispatch_routing.py` now registers
    `PermissionEnforcementExtension` on the real singleton for every test in
    the file (autouse fixture), changed its existing routing test to
    `role="operator"` (an allowed role — its job is proving routing reaches
    the LLC branch, not RBAC) with a comment explaining the choice, and adds
    `test_role_lacking_workflow_create_is_denied_through_dispatch`: `role="user"`
    through the real `_dispatch_tool_call` (not the handler directly),
    asserting `dispatch_llc_tool` is never awaited and the yielded message
    carries `cancelled_by_hook`/`reason="permission_denied"`.
  - `test_ceo_tool_execution_chain.py`'s `test_handle_llc_tool_dispatches_company_scoped`
    (intentionally calls `_handle_llc_tool` directly — its job is proving
    company_id/user_id threading, not RBAC or routing, per this file's own
    module docstring) now passes `role="operator"` explicitly instead of
    relying on the `"user"` default, with a comment stating why and pointing
    at the two tests that do cover RBAC.

## Reach table (all seven branches)

| Branch | Mutates state? | Hook reachable before this PR? | Permission | Outcome |
|---|---|---|---|---|
| `_handle_llc_tool` | Yes — company-scoped work item/goal/approval writes, no RBAC anywhere in `dispatch_llc_tool` | No — never called | `Permission.WORKFLOW_CREATE` (existing) | **Wired** |
| `_handle_web_research_tool` | `crawl_site`/`map_site` can ingest into the KB; `scrape_url`/`extract_structured_data` read | No — never called | `mcp_tool_permissions.required_permission(tool_name)` → `KNOWLEDGE_WRITE`/`KNOWLEDGE_READ` (existing, reused from the MCP-registry declaration) | **Wired** |
| `_handle_extract_content_tool` | No — read-only `evaluate` of the current page | Structurally reachable, never called | `Permission.MCP_BROWSER_READ` | Deferred → #14529 |
| `_handle_read_spilled_output` | No — local read of the run's own prior spilled output | Structurally reachable, never called | None stronger than baseline chat access; anchor is server-bound to its run | Deferred → #14529 |
| `_handle_compose_tool` | Indirectly — but its own sub-dispatch re-enters `_dispatch_tool_call`, so it already inherits this PR's LLC/web_research gates for whatever the script calls | Reachable, not the mechanism used | Already governed by the AST guard (`_guard_compose`) + WORKFLOW_GATE approval | Deferred → #14529 (needs an explicit decision comment) |
| `_handle_delegate_tool` | Only when `AUTOBOT_DELEGATION_ENABLED` (default off); when on, spawns a real subagent with no RBAC check on who may delegate | Structurally reachable, never called | `Permission.AGENT_EXECUTE` | Deferred → #14529 |
| `_handle_respond_tool` | No — pure local formatting, no dispatch | N/A — nothing to gate | None (loop-control) | Confirmed ungated |

## Compose is transitively governed, not ungated — corrected example

`_handle_compose_tool` itself declares no `tool_permission` and is correctly
listed as "deferred" in the reach table above — but that is not the same as
"unprotected". Its sandbox's shim dispatch
(`compose_tool_handler.build_compose_dispatch`) routes every tool call the
script makes back through `self._dispatch_tool_call` — the **same top-level
seam** `_handle_llc_tool` and `_handle_web_research_tool` are wired into in
this PR, with `role` taken from `ctx.auth_role`. That mechanism is real, but
an earlier version of this section named the wrong example tools:
`CODEEXEC_INJECTABLE_TOOLS` defaults to
`{web_search, scrape_url, map_site, extract_structured_data}`
(`chat_workflow/code_exec/tool_policy.py`) — **neither `create_task` nor
`crawl_site` is in it**, so a compose script calling either gets a
`NameError` from the generated shim module and never reaches dispatch at
all. The claim holds for **`map_site`**: a compose script calling
`map_site(...)` is shimmed, dispatches through `_dispatch_tool_call`, and
now hits the `KNOWLEDGE_WRITE` gate this PR added to
`_handle_web_research_tool` — that is the one concrete case compose inherits
enforcement for today. `scrape_url`/`extract_structured_data` also route
through the same gate but only ever need `KNOWLEDGE_READ`, which every
authenticated role already holds, so denial is not observable there in
practice.

Filed separately: **#14536** — `tool_policy.py` lists `map_site` in the
default read-only/auto-approvable set while `mcp_tool_permissions.py`
classifies it `KNOWLEDGE_WRITE`; pre-existing, but this PR is what makes
that disagreement enforced (not merely declared) on the compose path, since
an auto-approved compose run can now call a `KNOWLEDGE_WRITE`-gated tool
without a human ever seeing a WORKFLOW_GATE approval for it.

This is stated explicitly here (and carried into #14529) so a reader of
either issue does not conclude compose is unprotected: it is protected for
`map_site` (and `scrape_url`/`extract_structured_data`, though their
enforcement is unobservable at the current permission floor) as a side
effect of this PR, and ungated only for what nothing covers yet
(`extract_content`, `read_spilled_output`, `delegate`, `respond`, and any
non-default-injectable MCP-registry tool an operator's env widens the shim
set to include).

## Known pending collision — `scripts/check_python_file_size.py`

PR #14527 (closing #14498) re-anchors `RATCHET_BASELINE` in
`repo_tests/python_file_size_ratchet_test.py` to today's sizes, including
`tool_handler.py` → 3719. This PR lowers `tool_handler.py`'s **ceiling** in
`scripts/check_python_file_size.py` to 3694 (its actual size after this PR,
including the 2 lines the `auto-fix-formatting` bot added by wrapping one
over-long signature),
but does not touch `RATCHET_BASELINE` in `python_file_size_ratchet_test.py`
— that file's baseline for `tool_handler.py` is still 4063, so today it is
`ceiling(3694) < baseline(4063)`, non-blocking. Once #14527 merges and sets
`baseline == 3719`, this branch will fail #14527's
`test_the_baseline_is_relowered_by_every_shrink` until rebased: I will rebase
onto `Dev_new_gui` after #14527 merges and lower
`RATCHET_BASELINE["autobot-backend/chat_workflow/tool_handler.py"]` to 3694
alongside the ceiling, restoring `ceiling == baseline == actual`. Not
rebasing before #14527 lands deliberately, to avoid computing a green run
against a base that doesn't yet have the new test.

## Verification

- `python3 -c "import ast; ast.parse(open(...).read())"` on every touched
  `.py` — no syntax errors (repo policy forbids running application code;
  this is static parsing only).
- `python3 scripts/check_python_file_size.py --audit-ceilings` →
  `python-file-size ceilings: 3 entries, all live and at size.` (exit 0).
- Grepped for every place `chat_workflow.tool_handler.CODEEXEC_*` was
  referenced outside the file being edited, to catch what the extraction
  would silently break; found and fixed the one hit in `test_code_exec.py`.
- Mutation-tested both new guards in standalone scratch scripts (no repo
  imports, system `python3`, no venv/pip) mirroring the exact control flow
  added: ORIGINAL (deny → `return` before the mutating call) vs MUTATED
  (the `return` dropped — the exact #14420/#14469 defect class). For both
  the LLC branch and the `crawl_site` branch:
  `assert mutated_result != original_result` on the denied-role case (no
  mutation happened under ORIGINAL, mutation happened under MUTATED — deny
  test has teeth) and confirmed the allowed-role case is unaffected by the
  mutation (mutation still happens under both — allow path intact). Both
  scripts printed `All mutation-test assertions passed`.
- Read the new tests against the wired code path by hand: each denial
  assertion checks `metadata["cancelled_by_hook"]`/`"reason"] ==
  "permission_denied"` AND `assert_not_called()`/`assert_not_awaited()` on
  the stubbed mutating call; each allow assertion checks
  `assert_awaited_once()`/`assert_called_once()`.
- **Dispatch-level (not handler-level) denial, mutation-tested against the
  actual pre-#14491 code shape**: a third scratch script models
  `test_role_lacking_workflow_create_is_denied_through_dispatch`'s exact
  assertions against two versions of `_handle_llc_tool` reached through the
  same LLC-branch pass-through `_dispatch_tool_call` uses — POST-FIX
  (today's code, checks `should_execute` and returns before dispatch) and
  PRE-FIX (#11501's original, no permission check existed at all). Result:
  the assertions **pass** against POST-FIX and **FAIL**
  (`disp.assert_not_awaited()` would fail — dispatch_llc_tool was awaited)
  against PRE-FIX, i.e. the new test would have caught the exact gap #14491
  exists to close. Printed
  `assert mutated(pre-fix) != original(post-fix) held: the new dispatch-level test has teeth.`

## Model Used

Claude Opus 5 (1M context)

Refs #14491

