### PR TITLE
fix(slm): a repeat registration no longer hides an ungated route (#14533)

### DIFF
--- a/autobot-slm-backend/tests/api/test_prometheus_scrape_is_unauthenticated_14339.py
+++ b/autobot-slm-backend/tests/api/test_prometheus_scrape_is_unauthenticated_14339.py
@@ -161,6 +161,23 @@ def _is_plain_name_arg(call: ast.Call) -> bool:
     return bool(call.args) and isinstance(call.args[0], ast.Name)
 
 
+def _is_empty_constructor(value: ast.expr) -> bool:
+    """`list()`, `tuple()`, `set()` with no arguments.
+
+    These parse as calls, so the collection-literal rule does not see them, and
+    the residual below would read them as gates. They are statically resolvable
+    — a no-argument builtin constructor is empty by definition — so they belong
+    with the literals rather than with the names this check cannot evaluate.
+    """
+    return (
+        isinstance(value, ast.Call)
+        and isinstance(value.func, ast.Name)
+        and value.func.id in {"list", "tuple", "set"}
+        and not value.args
+        and not value.keywords
+    )
+
+
 def _is_gated(call: ast.AST) -> bool:
     """Whether a registration actually carries a gate, not merely the keyword.
 
@@ -173,7 +190,9 @@ def _is_gated(call: ast.AST) -> bool:
 
     * **Any constant is ungated.** `None`, `False`, `0`, `""` — no constant is
       a sequence of dependencies, so none of them can gate anything.
-    * **An empty collection is ungated.** `[]`, `()`, `set()` literals.
+    * **An empty collection is ungated** — the `[]` and `()` literals, and a
+      no-argument `list()` / `tuple()` / `set()`, which parse as calls rather
+      than literals but construct exactly the same nothing.
     * **Everything else is gated** — a name, an attribute, a call, a
       non-empty collection.
 
@@ -191,6 +210,8 @@ def _is_gated(call: ast.AST) -> bool:
         if isinstance(value, ast.Constant):
             return False
         if isinstance(value, (ast.List, ast.Tuple, ast.Set)) and not value.elts:
+            return False
+        if _is_empty_constructor(value):
             return False
         return True
     return False
@@ -881,3 +902,42 @@ def test_an_empty_dependency_list_cannot_hide_a_second_mount():
     calls, unparseable = _all_bypass_calls(tree)
     assert unparseable, "an ungated repeat with dependencies=[] was swallowed"
     assert any("evil_router" in item for item in unparseable)
+
+
+def test_no_constant_is_a_gate():
+    """`dependencies=None` is FastAPI's default and gates nothing.
+
+    Ruled by kind rather than by listing forms: no constant is a sequence of
+    dependencies, so every one of these is ungated. Three rounds of this were
+    patched a form at a time — `[]`, then `None` — each keeping a permissive
+    catch-all that the next unlisted form fell through.
+    """
+    for literal in ("None", "False", "0", '""'):
+        call = ast.parse(f"app.include_router(r, dependencies={literal})").body[0].value
+        assert not _is_gated(call), f"dependencies={literal} was treated as a gate"
+
+
+def test_every_empty_collection_literal_is_ungated():
+    for literal in ("[]", "()", "set()"):
+        call = ast.parse(f"app.include_router(r, dependencies={literal})").body[0].value
+        assert not _is_gated(call), f"dependencies={literal} was treated as a gate"
+
+
+def test_a_real_dependency_list_is_still_a_gate():
+    """Guard the guard: if the rules above swallowed everything, the whole
+    suite would report the real `main.py` as entirely ungated."""
+    for expr in ("_SM", "[Depends(require_service_management)]", "get_deps()"):
+        call = ast.parse(f"app.include_router(r, dependencies={expr})").body[0].value
+        assert _is_gated(call), f"dependencies={expr} was not treated as a gate"
+
+
+def test_a_none_dependency_cannot_hide_a_second_mount():
+    """The masking case, through `None` rather than `[]`."""
+    tree = ast.parse(
+        "app = FastAPI()\n"
+        'app.include_router(widgets_router, prefix="/v1", dependencies=_SM)\n'
+        'app.include_router(widgets_router, prefix="/v2", dependencies=None)\n'
+    )
+    calls, unparseable = _all_bypass_calls(tree)
+    assert unparseable, "an ungated repeat with dependencies=None was swallowed"
+    assert any("widgets_router" in item for item in unparseable)

--- a/autobot-slm-backend/tests/api/test_prometheus_scrape_is_unauthenticated_14339.py
+++ b/autobot-slm-backend/tests/api/test_prometheus_scrape_is_unauthenticated_14339.py
@@ -161,6 +161,31 @@ def _is_plain_name_arg(call: ast.Call) -> bool:
     return bool(call.args) and isinstance(call.args[0], ast.Name)
 
 
+def _is_gated(call: ast.AST) -> bool:
+    """Whether a registration actually carries a gate, not merely the keyword.
+
+    `dependencies=[]` is present and enforces nothing. Every gating decision in
+    this file used to be keyword *presence*, so an empty list read as gated
+    everywhere — and once the repeat rule compared presence too, a second live
+    mount with `dependencies=[]` matched its gated twin, took the
+    same-declaration path, and vanished from the map entirely rather than being
+    reported. A latent mistake became a hiding place.
+
+    The value is evaluated rather than trusted: an empty list or tuple gates
+    nothing. Anything else — a name, a call, a non-empty literal — is treated as
+    a real gate, because this check cannot evaluate what a name resolves to and
+    must not guess in the permissive direction.
+    """
+    for keyword in getattr(call, "keywords", []):
+        if keyword.arg != "dependencies":
+            continue
+        value = keyword.value
+        if isinstance(value, (ast.List, ast.Tuple)) and not value.elts:
+            return False
+        return True
+    return False
+
+
 def _record(calls: dict, unparseable: list, idiom: str, name: str, node, lineno: int) -> None:
     """Store a public-surface registration, reporting an ambiguous name.
 
@@ -193,7 +218,7 @@ def _record(calls: dict, unparseable: list, idiom: str, name: str, node, lineno:
             f"line {lineno}: {name} registered as both {prior_idiom} and {idiom}; "
             "the registry declares names, so it cannot say which surface it covers"
         )
-    elif ("dependencies" in _keywords(prior_node)) != ("dependencies" in _keywords(node)):
+    elif _is_gated(prior_node) != _is_gated(node):
         unparseable.append(
             f"line {lineno}: {name} registered twice with different gating; "
             "first-match-wins means the ungated registration serves"
@@ -443,11 +468,11 @@ def test_the_app_mounts_the_scrape_router_without_auth_and_the_rest_with_it():
     assert "performance_metrics_router" in calls, "the scrape router is never mounted on the app"
     assert "performance_router" in calls, "the authenticated performance router is not mounted"
 
-    assert "dependencies" not in _keywords(calls["performance_metrics_router"]), (
+    assert not _is_gated(calls["performance_metrics_router"]), (
         "the scrape router is mounted with a router-level dependency; prometheus "
         "cannot authenticate and every scrape will 401 again (#14339)"
     )
-    assert "dependencies" in _keywords(
+    assert _is_gated(
         calls["performance_router"]
     ), "the authenticated performance router lost its service-management dependency"
 
@@ -490,7 +515,7 @@ def test_every_ungated_router_is_named_in_the_registry():
     """
     declared = _registry_block()
 
-    ungated = {name for name, call in _bypass_calls().items() if "dependencies" not in _keywords(call)}
+    ungated = {name for name, call in _bypass_calls().items() if not _is_gated(call)}
     undeclared = sorted(name for name in ungated if not _is_declared(name, declared))
     assert not undeclared, (
         f"reachable without the service-management gate but not declared in the registry: "
@@ -610,7 +635,7 @@ def test_the_registry_check_actually_sees_the_ungated_mounts():
     If the mount matcher stopped matching — a rename, a different idiom — every
     router would look gated and the registry check would pass over all of them.
     """
-    ungated = {name for name, call in _bypass_calls().items() if "dependencies" not in _keywords(call)}
+    ungated = {name for name, call in _bypass_calls().items() if not _is_gated(call)}
     assert "performance_metrics_router" in ungated
     assert "root" in ungated, "the @app.get('/') banner route is not seen as an ungated bypass"
     assert "prometheus_registry_metrics" in ungated, "the @app.get('/metrics') route is not seen as an ungated bypass"
@@ -636,7 +661,7 @@ def test_a_bare_app_get_route_is_caught_as_an_ungated_bypass():
     calls, unparseable = _decorator_calls(tree, frozenset())
     assert not unparseable
     assert "sneaky_list" in calls, "a bare @app.get(...) route was not caught by the decorator matcher"
-    assert "dependencies" not in _keywords(calls["sneaky_list"])
+    assert not _is_gated(calls["sneaky_list"])
 
 
 def test_a_gated_app_get_route_is_still_found_but_not_flagged_ungated():
@@ -647,7 +672,7 @@ def test_a_gated_app_get_route_is_still_found_but_not_flagged_ungated():
     calls, unparseable = _decorator_calls(tree, frozenset())
     assert not unparseable
     assert "reports" in calls
-    assert "dependencies" in _keywords(calls["reports"])
+    assert _is_gated(calls["reports"])
 
 
 def test_an_add_api_route_call_is_caught_as_an_ungated_bypass():
@@ -657,7 +682,7 @@ def test_an_add_api_route_call_is_caught_as_an_ungated_bypass():
     calls, unparseable = _add_api_route_calls(tree, frozenset())
     assert not unparseable
     assert "sneaky" in calls, "app.add_api_route(...) was not caught"
-    assert "dependencies" not in _keywords(calls["sneaky"])
+    assert not _is_gated(calls["sneaky"])
 
 
 def test_an_alias_of_app_is_resolved_before_receiver_matching():

--- a/autobot-slm-backend/tests/api/test_prometheus_scrape_is_unauthenticated_14339.py
+++ b/autobot-slm-backend/tests/api/test_prometheus_scrape_is_unauthenticated_14339.py
@@ -161,6 +161,29 @@ def _is_plain_name_arg(call: ast.Call) -> bool:
     return bool(call.args) and isinstance(call.args[0], ast.Name)
 
 
+def _record(calls: dict, unparseable: list, name: str, node, lineno: int) -> None:
+    """Store a public-surface call, reporting a repeat rather than overwriting it.
+
+    The three collectors keyed by name and the merge did `dict.update`, so two
+    registrations of the same name collapsed and the LAST one won. That made an
+    ungated registration invisible whenever the same name was also registered
+    with the gate somewhere else — and FastAPI resolves first-match-wins, so the
+    ungated one is the registration that actually serves.
+
+    Demonstrated against the real file: mounting `errors_router` ungated before
+    its existing gated mount left all 22 tests green while the ungated route was
+    the live one.
+
+    A repeat is reported rather than silently kept, because once a name maps to
+    two calls this check cannot say which one it is answering about — the same
+    reason an unreadable call fails instead of being skipped.
+    """
+    if name in calls:
+        unparseable.append(f"line {lineno}: {name} registered more than once; this check cannot say which gates it")
+        return
+    calls[name] = node
+
+
 def _app_mounts(tree: ast.Module | None = None) -> tuple[dict[str, ast.Call], list[str]]:
     """`app.include_router(...)` calls, split into readable and unreadable.
 
@@ -207,7 +230,7 @@ def _app_mounts(tree: ast.Module | None = None) -> tuple[dict[str, ast.Call], li
             unparseable.append(f"line {node.lineno}: receiver {ast.dump(receiver)[:70]}")
             continue
         if _is_plain_name_arg(node):
-            calls[node.args[0].id] = node
+            _record(calls, unparseable, node.args[0].id, node, node.lineno)
         else:
             shape = ast.dump(node.args[0])[:80] if node.args else "no arguments"
             unparseable.append(f"line {node.lineno}: argument {shape}")
@@ -243,7 +266,7 @@ def _decorator_calls(tree: ast.Module, aliases: frozenset[str]) -> tuple[dict[st
             if kind == "unparseable":
                 unparseable.append(f"line {deco.lineno}: receiver {ast.dump(receiver)[:70]}")
                 continue
-            calls[node.name] = deco
+            _record(calls, unparseable, node.name, deco, node.lineno)
     return calls, unparseable
 
 
@@ -281,7 +304,7 @@ def _add_api_route_calls(tree: ast.Module, aliases: frozenset[str]) -> tuple[dic
             continue
         endpoint = _endpoint_arg(node)
         if isinstance(endpoint, ast.Name):
-            calls[endpoint.id] = node
+            _record(calls, unparseable, endpoint.id, node, node.lineno)
         else:
             shape = ast.dump(endpoint)[:80] if endpoint is not None else "no endpoint argument"
             unparseable.append(f"line {node.lineno}: endpoint {shape}")

--- a/autobot-slm-backend/tests/api/test_prometheus_scrape_is_unauthenticated_14339.py
+++ b/autobot-slm-backend/tests/api/test_prometheus_scrape_is_unauthenticated_14339.py
@@ -161,27 +161,43 @@ def _is_plain_name_arg(call: ast.Call) -> bool:
     return bool(call.args) and isinstance(call.args[0], ast.Name)
 
 
-def _record(calls: dict, unparseable: list, name: str, node, lineno: int) -> None:
-    """Store a public-surface call, reporting a repeat rather than overwriting it.
+def _record(calls: dict, unparseable: list, idiom: str, name: str, node, lineno: int) -> None:
+    """Store a public-surface registration, reporting an ambiguous name.
 
-    The three collectors keyed by name and the merge did `dict.update`, so two
-    registrations of the same name collapsed and the LAST one won. That made an
-    ungated registration invisible whenever the same name was also registered
-    with the gate somewhere else — and FastAPI resolves first-match-wins, so the
-    ungated one is the registration that actually serves.
+    Registrations are keyed by name because the registry declares names. A name
+    is not a unique identity for a route surface, though: a router and an
+    endpoint function can carry the same one. The three collectors overwrote
+    each other, so the last registration won — and FastAPI resolves
+    first-match-wins, meaning the overwritten one is what serves. The check
+    reported clean about a route it was not looking at.
 
-    Demonstrated against the real file: mounting `errors_router` ungated before
-    its existing gated mount left all 22 tests green while the ungated route was
-    the live one.
+    Two registrations of one name are reported when they cannot be the same
+    declaration:
 
-    A repeat is reported rather than silently kept, because once a name maps to
-    two calls this check cannot say which one it is answering about — the same
-    reason an unreadable call fails instead of being skipped.
+    * **Different idioms.** An `@app.get` endpoint named after a declared router
+      borrows that router's registry entry while being a different surface. Both
+      may be ungated, so comparing gating alone does not catch it.
+    * **Same idiom, different gating.** One carries the service-management
+      dependency and the other does not.
+
+    The same router mounted twice with identical gating — two prefixes, both
+    gated — is a legitimate FastAPI pattern and is deliberately left alone.
     """
-    if name in calls:
-        unparseable.append(f"line {lineno}: {name} registered more than once; this check cannot say which gates it")
+    previous = calls.get(name)
+    if previous is None:
+        calls[name] = (idiom, node)
         return
-    calls[name] = node
+    prior_idiom, prior_node = previous
+    if prior_idiom != idiom:
+        unparseable.append(
+            f"line {lineno}: {name} registered as both {prior_idiom} and {idiom}; "
+            "the registry declares names, so it cannot say which surface it covers"
+        )
+    elif ("dependencies" in _keywords(prior_node)) != ("dependencies" in _keywords(node)):
+        unparseable.append(
+            f"line {lineno}: {name} registered twice with different gating; "
+            "first-match-wins means the ungated registration serves"
+        )
 
 
 def _app_mounts(tree: ast.Module | None = None) -> tuple[dict[str, ast.Call], list[str]]:
@@ -230,11 +246,11 @@ def _app_mounts(tree: ast.Module | None = None) -> tuple[dict[str, ast.Call], li
             unparseable.append(f"line {node.lineno}: receiver {ast.dump(receiver)[:70]}")
             continue
         if _is_plain_name_arg(node):
-            _record(calls, unparseable, node.args[0].id, node, node.lineno)
+            _record(calls, unparseable, "include_router", node.args[0].id, node, node.lineno)
         else:
             shape = ast.dump(node.args[0])[:80] if node.args else "no arguments"
             unparseable.append(f"line {node.lineno}: argument {shape}")
-    return calls, unparseable
+    return {name: node for name, (_, node) in calls.items()}, unparseable
 
 
 def _decorator_calls(tree: ast.Module, aliases: frozenset[str]) -> tuple[dict[str, ast.Call], list[str]]:
@@ -266,8 +282,8 @@ def _decorator_calls(tree: ast.Module, aliases: frozenset[str]) -> tuple[dict[st
             if kind == "unparseable":
                 unparseable.append(f"line {deco.lineno}: receiver {ast.dump(receiver)[:70]}")
                 continue
-            _record(calls, unparseable, node.name, deco, node.lineno)
-    return calls, unparseable
+            _record(calls, unparseable, "decorator", node.name, deco, node.lineno)
+    return {name: node for name, (_, node) in calls.items()}, unparseable
 
 
 def _endpoint_arg(call: ast.Call) -> ast.expr | None:
@@ -304,11 +320,11 @@ def _add_api_route_calls(tree: ast.Module, aliases: frozenset[str]) -> tuple[dic
             continue
         endpoint = _endpoint_arg(node)
         if isinstance(endpoint, ast.Name):
-            _record(calls, unparseable, endpoint.id, node, node.lineno)
+            _record(calls, unparseable, "add_api_route", endpoint.id, node, node.lineno)
         else:
             shape = ast.dump(endpoint)[:80] if endpoint is not None else "no endpoint argument"
             unparseable.append(f"line {node.lineno}: endpoint {shape}")
-    return calls, unparseable
+    return {name: node for name, (_, node) in calls.items()}, unparseable
 
 
 def _all_bypass_calls(tree: ast.Module | None = None) -> tuple[dict[str, ast.AST], list[str]]:
@@ -329,10 +345,22 @@ def _all_bypass_calls(tree: ast.Module | None = None) -> tuple[dict[str, ast.AST
     decorator_calls, decorator_unparseable = _decorator_calls(tree, aliases)
     api_route_calls, api_route_unparseable = _add_api_route_calls(tree, aliases)
 
-    calls: dict[str, ast.AST] = dict(router_calls)
-    calls.update(decorator_calls)
-    calls.update(api_route_calls)
-    return calls, [*unparseable, *decorator_unparseable, *api_route_unparseable]
+    # NOT `dict.update` across the three. That is the same name-keyed collapse
+    # the collectors themselves had, one layer up: a name registered by two
+    # different idioms silently kept the last, and when the colliding name was
+    # already on the registry's open list the resulting ungated route passed
+    # with zero failures. Reconciled through `_record` so every registration is
+    # judged by the same rule wherever it came from.
+    calls: dict[str, tuple[str, ast.AST]] = {}
+    merged: list[str] = [*unparseable, *decorator_unparseable, *api_route_unparseable]
+    for idiom, source in (
+        ("include_router", router_calls),
+        ("decorator", decorator_calls),
+        ("add_api_route", api_route_calls),
+    ):
+        for name, node in source.items():
+            _record(calls, merged, idiom, name, node, getattr(node, "lineno", 0))
+    return {name: node for name, (_, node) in calls.items()}, merged
 
 
 def _bypass_calls() -> dict[str, ast.AST]:

--- a/autobot-slm-backend/tests/api/test_prometheus_scrape_is_unauthenticated_14339.py
+++ b/autobot-slm-backend/tests/api/test_prometheus_scrape_is_unauthenticated_14339.py
@@ -712,3 +712,38 @@ def test_the_registry_check_sees_the_root_and_metrics_routes_as_app_get_calls():
     assert not unparseable
     assert "root" in decorator_calls
     assert "prometheus_registry_metrics" in decorator_calls
+
+
+def test_a_repeat_registration_cannot_hide_an_ungated_one():
+    """Two registrations of one name must fail, not collapse to the last.
+
+    The collectors keyed by name and the merge did `dict.update`, so an ungated
+    registration was masked whenever the same name was also registered with the
+    gate elsewhere. FastAPI resolves first-match-wins, so the masked one is the
+    registration that actually serves — the check reported clean about a route
+    it was not looking at.
+
+    Asserted against synthetic source: the real `main.py` registers no name
+    twice, so a test built on it could only ever prove the happy path.
+    """
+    tree = ast.parse(
+        "app = FastAPI()\n"
+        'app.include_router(widgets_router, prefix="/evil")\n'
+        'app.include_router(widgets_router, prefix="/api", dependencies=_SM)\n'
+    )
+    calls, unparseable = _all_bypass_calls(tree)
+    assert unparseable, "a name registered twice was collapsed instead of reported"
+    assert any("widgets_router" in item for item in unparseable)
+
+
+def test_the_repeat_check_does_not_fire_on_distinct_names():
+    """Guard the guard: if it flagged every registration, the suite would be
+    red for the real file and the assertion above would prove nothing."""
+    tree = ast.parse(
+        "app = FastAPI()\n"
+        'app.include_router(alpha_router, prefix="/a", dependencies=_SM)\n'
+        'app.include_router(beta_router, prefix="/b", dependencies=_SM)\n'
+    )
+    calls, unparseable = _all_bypass_calls(tree)
+    assert not unparseable, f"distinct names were reported as repeats: {unparseable}"
+    assert set(calls) == {"alpha_router", "beta_router"}

--- a/autobot-slm-backend/tests/api/test_prometheus_scrape_is_unauthenticated_14339.py
+++ b/autobot-slm-backend/tests/api/test_prometheus_scrape_is_unauthenticated_14339.py
@@ -840,3 +840,34 @@ def test_one_router_under_two_prefixes_with_equal_gating_is_allowed():
     calls, unparseable = _all_bypass_calls(tree)
     assert not unparseable, f"a legitimate two-prefix mount was reported: {unparseable}"
     assert "widgets_router" in calls
+
+
+def test_an_empty_dependency_list_is_not_a_gate():
+    """`dependencies=[]` is present and enforces nothing.
+
+    Deciding by keyword presence read it as gated, so a route could be
+    registered wide open while every check in this file called it protected.
+    """
+    gated = ast.parse("app.include_router(r, dependencies=_SM)").body[0].value
+    empty = ast.parse("app.include_router(r, dependencies=[])").body[0].value
+    bare = ast.parse('app.include_router(r, prefix="/x")').body[0].value
+    assert _is_gated(gated)
+    assert not _is_gated(empty), "an empty dependency list gates nothing"
+    assert not _is_gated(bare)
+
+
+def test_an_empty_dependency_list_cannot_hide_a_second_mount():
+    """The interaction that made the latent gap dangerous.
+
+    Comparing presence, this pair looked like one declaration seen twice, so
+    the ungated `/v2` mount was dropped from the map rather than reported —
+    it is a second, independent, live registration.
+    """
+    tree = ast.parse(
+        "app = FastAPI()\n"
+        'app.include_router(evil_router, prefix="/v1", dependencies=_SM)\n'
+        'app.include_router(evil_router, prefix="/v2", dependencies=[])\n'
+    )
+    calls, unparseable = _all_bypass_calls(tree)
+    assert unparseable, "an ungated repeat with dependencies=[] was swallowed"
+    assert any("evil_router" in item for item in unparseable)

--- a/autobot-slm-backend/tests/api/test_prometheus_scrape_is_unauthenticated_14339.py
+++ b/autobot-slm-backend/tests/api/test_prometheus_scrape_is_unauthenticated_14339.py
@@ -775,3 +775,43 @@ def test_the_repeat_check_does_not_fire_on_distinct_names():
     calls, unparseable = _all_bypass_calls(tree)
     assert not unparseable, f"distinct names were reported as repeats: {unparseable}"
     assert set(calls) == {"alpha_router", "beta_router"}
+
+
+def test_a_name_registered_by_two_idioms_is_reported():
+    """An endpoint function named after a router borrows the router's entry.
+
+    The registry declares names, and a name is not a unique identity for a
+    route surface. `performance_metrics_router` is legitimately on the open
+    list as a router; an `@app.get` endpoint function of the same name is a
+    different surface that inherits the declaration.
+
+    Both registrations here are ungated, so a rule comparing only gating lets
+    this through — which is exactly how it survived the first fix.
+    """
+    tree = ast.parse(
+        "app = FastAPI()\n"
+        'app.include_router(performance_metrics_router, prefix="/api")\n'
+        '@app.get("/api/services/admin-dump")\n'
+        "async def performance_metrics_router():\n"
+        "    return {}\n"
+    )
+    _, unparseable = _all_bypass_calls(tree)
+    assert unparseable, "a name registered by two different idioms was collapsed"
+    assert any("performance_metrics_router" in item for item in unparseable)
+
+
+def test_one_router_under_two_prefixes_with_equal_gating_is_allowed():
+    """A legitimate FastAPI pattern must not be forbidden to close the hole.
+
+    An earlier revision failed on any repeat at all, which would have rejected
+    this with no way to declare an exception. The registrations agree on both
+    idiom and gating, so they are the same declaration seen twice.
+    """
+    tree = ast.parse(
+        "app = FastAPI()\n"
+        'app.include_router(widgets_router, prefix="/v1", dependencies=_SM)\n'
+        'app.include_router(widgets_router, prefix="/v2", dependencies=_SM)\n'
+    )
+    calls, unparseable = _all_bypass_calls(tree)
+    assert not unparseable, f"a legitimate two-prefix mount was reported: {unparseable}"
+    assert "widgets_router" in calls

--- a/autobot-slm-backend/tests/api/test_prometheus_scrape_is_unauthenticated_14339.py
+++ b/autobot-slm-backend/tests/api/test_prometheus_scrape_is_unauthenticated_14339.py
@@ -164,23 +164,33 @@ def _is_plain_name_arg(call: ast.Call) -> bool:
 def _is_gated(call: ast.AST) -> bool:
     """Whether a registration actually carries a gate, not merely the keyword.
 
-    `dependencies=[]` is present and enforces nothing. Every gating decision in
-    this file used to be keyword *presence*, so an empty list read as gated
-    everywhere — and once the repeat rule compared presence too, a second live
-    mount with `dependencies=[]` matched its gated twin, took the
-    same-declaration path, and vanished from the map entirely rather than being
-    reported. A latent mistake became a hiding place.
+    Three rounds of this were patched one empty-form at a time — first
+    `dependencies=[]`, then `dependencies=None`, FastAPI's own default and
+    functionally identical to omitting the keyword. Each patch enumerated the
+    forms it had thought of and kept a permissive catch-all underneath, so the
+    next unlisted form read as gated. The rule is stated by kind now rather
+    than by example:
 
-    The value is evaluated rather than trusted: an empty list or tuple gates
-    nothing. Anything else — a name, a call, a non-empty literal — is treated as
-    a real gate, because this check cannot evaluate what a name resolves to and
-    must not guess in the permissive direction.
+    * **Any constant is ungated.** `None`, `False`, `0`, `""` — no constant is
+      a sequence of dependencies, so none of them can gate anything.
+    * **An empty collection is ungated.** `[]`, `()`, `set()` literals.
+    * **Everything else is gated** — a name, an attribute, a call, a
+      non-empty collection.
+
+    That last line is the residual, stated rather than hidden: this check
+    cannot evaluate what a name points at, so `dependencies=some_empty_var`
+    reads as gated. Resolving it needs the value, not the syntax. It is the
+    permissive direction, which is why the two rules above are exhaustive by
+    kind instead of by enumeration — a form nobody listed now falls into the
+    constant or collection rules rather than through a gap beneath them.
     """
     for keyword in getattr(call, "keywords", []):
         if keyword.arg != "dependencies":
             continue
         value = keyword.value
-        if isinstance(value, (ast.List, ast.Tuple)) and not value.elts:
+        if isinstance(value, ast.Constant):
+            return False
+        if isinstance(value, (ast.List, ast.Tuple, ast.Set)) and not value.elts:
             return False
         return True
     return False

--- a/autobot-slm-backend/tests/api/test_prometheus_scrape_is_unauthenticated_14339.py
+++ b/autobot-slm-backend/tests/api/test_prometheus_scrape_is_unauthenticated_14339.py
@@ -172,7 +172,7 @@ def _is_empty_constructor(value: ast.expr) -> bool:
     return (
         isinstance(value, ast.Call)
         and isinstance(value.func, ast.Name)
-        and value.func.id in {"list", "tuple", "set"}
+        and value.func.id in {"list", "tuple", "set", "dict"}
         and not value.args
         and not value.keywords
     )
@@ -190,9 +190,11 @@ def _is_gated(call: ast.AST) -> bool:
 
     * **Any constant is ungated.** `None`, `False`, `0`, `""` — no constant is
       a sequence of dependencies, so none of them can gate anything.
-    * **An empty collection is ungated** — the `[]` and `()` literals, and a
-      no-argument `list()` / `tuple()` / `set()`, which parse as calls rather
-      than literals but construct exactly the same nothing.
+    * **An empty collection is ungated** — the `[]`, `()` and `{}` literals,
+      and a no-argument `list()` / `tuple()` / `set()` / `dict()`, which parse
+      as calls rather than literals but construct exactly the same nothing.
+      `{}` belongs here for the same reason as the rest: FastAPI stores
+      `list(dependencies or [])`, and an empty dict is falsy.
     * **Everything else is gated** — a name, an attribute, a call, a
       non-empty collection.
 
@@ -210,6 +212,8 @@ def _is_gated(call: ast.AST) -> bool:
         if isinstance(value, ast.Constant):
             return False
         if isinstance(value, (ast.List, ast.Tuple, ast.Set)) and not value.elts:
+            return False
+        if isinstance(value, ast.Dict) and not value.keys:
             return False
         if _is_empty_constructor(value):
             return False
@@ -940,4 +944,30 @@ def test_a_none_dependency_cannot_hide_a_second_mount():
     )
     calls, unparseable = _all_bypass_calls(tree)
     assert unparseable, "an ungated repeat with dependencies=None was swallowed"
+    assert any("widgets_router" in item for item in unparseable)
+
+
+def test_an_empty_dict_is_not_a_gate():
+    """`{}` and `dict()` are the dict spellings of the empty collection.
+
+    FastAPI stores `list(dependencies or [])`, so an empty dict is falsy and
+    enforces exactly nothing — the same runtime outcome as `[]`, `()`, `set()`
+    and `None`, all of which were already handled. Reaching for "the empty
+    version of a collection" and typing the dict spelling is an ordinary slip,
+    which is why this belongs in the rule rather than in the residual.
+    """
+    for literal in ("{}", "dict()"):
+        call = ast.parse(f"app.include_router(r, dependencies={literal})").body[0].value
+        assert not _is_gated(call), f"dependencies={literal} was treated as a gate"
+
+
+def test_an_empty_dict_cannot_hide_a_second_mount():
+    """The masking case, through `{}`."""
+    tree = ast.parse(
+        "app = FastAPI()\n"
+        'app.include_router(widgets_router, prefix="/v1", dependencies=_SM)\n'
+        'app.include_router(widgets_router, prefix="/v2", dependencies={})\n'
+    )
+    _, unparseable = _all_bypass_calls(tree)
+    assert unparseable, "an ungated repeat with dependencies={} was swallowed"
     assert any("widgets_router" in item for item in unparseable)


### PR DESCRIPTION
Closes #14533.

## Thinking Path

Found while verifying that #14363 and #14366 — both closed by another session — actually caught their own exploits, rather than trusting the diff.

The alias fix is real: an aliased ungated mount **is** caught when it is the only registration of that router. But my first attempt to reproduce #14366's exploit used `secrets_router`, which is already mounted gated elsewhere, and all 22 tests passed. That was not the alias path failing — it was a different fail-open underneath it.

The three collectors key by name (`calls[name] = node`) and the merge does `dict.update`. Two registrations of one name collapse and the last wins. FastAPI resolves first-match-wins, so the *masked* registration is the one that serves — the check reports clean about a route it is not looking at.

Demonstrated on the real file: an ungated mount placed before `errors_router`'s existing gated mount left all 22 tests green while `/evil` was live and undeclared.

That is worth stating precisely, because it is why #14366's review passed: it tested the alias path with a router that was already mounted elsewhere, so the collapse hid the exploit and the fix read as working.

## What Changed

- **`_record()`** — the three collectors now report a repeat instead of overwriting it. A repeat makes the map lossy, which is the same class as an unreadable call, so it fails the same way.
- **Two regression tests** — asserted against synthetic source, because the real `main.py` registers no name twice and a test built on it could only prove the happy path. The second is the guard-the-guard: if the check fired on every registration, the suite would be red for the real file and the first would prove nothing.

## Verification

| Mutation | Result |
|---|---|
| Ungated mount before the existing gated one | 6 fail |
| Same, through a module-level alias | 6 fail |
| `_record` reverted to a plain overwrite | 1 fail |

`tests/api/` — 503 passed. The one failure in that directory (`test_health_redis_14299.py::test_healthy_when_client_available`) is **pre-existing on base**, verified by running the same suite at `origin/Dev_new_gui`: 501 passed, same 1 failed. Filed separately rather than folded in.

black and flake8 clean.

## Model Used

Opus 5 (1M context).

---

## Round 2 — the same collapse, one layer up

Review found the first fix guarded repeats only **inside** each of the three collectors. `_all_bypass_calls()` still merged them with `dict.update`, so a name registered by two different idioms collapsed exactly as before — the bug this PR describes, reproduced in the layer above the fix.

And the reviewer's exploit is worse than the one I found: an `@app.get` endpoint function named after a router that is **already on the registry's open list** borrows that declaration. Both registrations are ungated, so a rule comparing only gating never fires. They added a live unauthenticated route at an attacker-chosen path with all 24 tests green.

That is why the reviewer's own suggestion — relax to "fail only when gating differs" — could not be taken as written: it would have let their exploit through.

**The rule now.** A name is not a unique identity for a route surface; a router and an endpoint function can share one, and the registry declares names. So two registrations of one name are reported when they cannot be the same declaration:

- **different idioms** — the cross-idiom borrow above
- **same idiom, different gating** — one carries the dependency, one does not

**And one registration shape is now explicitly allowed:** the same router mounted under two prefixes with identical gating. The first fix rejected it, which review correctly flagged as trading a security hole for a blocked idiom.

| Mutation | Result |
|---|---|
| Cross-idiom exploit (`@app.get` named after a declared router) | 3 fail |
| Same idiom, differing gating | 6 fail |
| Same router, two prefixes, equal gating (must be **allowed**) | 24 pass |
| Drop the cross-idiom branch from `_record` | 1 fail |
| Fail on any repeat (the over-strict earlier shape) | 1 fail |

The last two matter most: the rule is pinned at **both** edges, so neither loosening nor tightening it can pass unnoticed.

`tests/api/` — 505 passed, plus the one pre-existing base failure filed as #14535.


---

## Round 3 — the gating comparison was the hole

Round 2 replaced "any repeat fails" with a comparison of gating. That comparison used keyword **presence**, and `dependencies=[]` is present while enforcing nothing.

On its own that blindness predates this PR — every gating decision in the file was presence-based. What round 2 did was turn it into a **hiding place**: a gated `/v1` and a live, ungated `/v2` with `dependencies=[]` compared equal, took the same-declaration path, and the `/v2` mount vanished from the map entirely rather than being reported. Softening the unconditional rule is what opened it.

`_is_gated()` now evaluates the value — an empty list or tuple gates nothing; anything else counts, because this check cannot resolve what a name points at and must not guess permissively. **Every** gating decision in the file goes through it now: the repeat rule, both `ungated` comprehensions, and the five per-router assertions. Eight places to be wrong became one.

| Mutation | Result |
|---|---|
| `_is_gated` reverted to keyword presence | 2 fail |
| `_is_gated` always true | 7 fail |
| Standalone `dependencies=[]` mount added to the real `main.py`, undeclared | 1 fail |

That last row is the one that matters: before this change the real file would have accepted a wide-open mount as gated.

`tests/api/` — 507 passed, plus the pre-existing base failure filed as #14535.

### Count so far

Seven fail-opens have now been found in this guard. Three of them I introduced myself while closing an earlier one, including this round's. The pattern is consistent enough to be worth naming: each fix narrowed the rule, and each narrowing created a shape the narrower rule could not see. The current version is pinned at both edges by tests that fail in opposite directions, which is the first version where loosening *or* tightening it breaks something.


---

## Round 4 — the rule's *shape* was the defect, not the missing case

`dependencies=None` is FastAPI's own default and identical to omitting the keyword, yet `_is_gated` read it as a real gate — so a mount carrying it was reachable, unauthenticated and invisible to the registry, and a second such mount of an already-gated name was silently merged and dropped. The same masking fixed one round earlier for `[]`, arriving through `None`.

The missing case is not the interesting part. **Each round enumerated the empty forms it had thought of and kept "anything else is gated" underneath**, and that catch-all is the permissive direction. So the next unlisted form walked through the gap beneath the list. Three rounds, three forms, one shape.

The rule is now stated by *kind*:

- **No constant is a gate** — `None`, `False`, `0`, `""`. A constant is not a sequence of dependencies, so none of them can gate anything.
- **No empty collection is a gate** — the `[]` and `()` literals, plus a no-argument `list()` / `tuple()` / `set()`, which parse as calls but construct the same nothing.
- **Everything else is a gate** — a name, an attribute, a call, a non-empty collection.

A form nobody listed now lands in one of the first two rules rather than through a gap beneath them. That third line is the residual, and it is **documented rather than hidden**: `dependencies=some_empty_var` still reads as gated, because resolving it needs the value and not the syntax.

Writing the enumeration test is what caught `set()` — the test was right and the rule was short.

| Mutation | Result |
|---|---|
| Drop the constant rule (reopens `dependencies=None`) | 2 fail |
| Drop the empty-constructor rule | 1 fail |
| Treat everything as ungated | 8 fail |
| **`dependencies=None` mount added to the real `main.py`** | **1 fail** |

32 tests; `tests/api/` — 511 passed, plus the pre-existing base failure filed as #14535.

**Eight fail-opens have now been found in this guard; four were mine, each introduced while closing the previous one.** Every one had the same structure: a rule narrow enough to be correct about the cases in front of it, with a permissive default underneath for everything else.



---

## Round 5 — the dict spelling

`{}` and `dict()` are the dict spellings of the empty collection, and FastAPI stores `list(dependencies or [])` — an empty dict is falsy, so it enforces exactly nothing, the same runtime outcome as `[]`, `()`, `set()` and `None`, all already handled.

Review drew the line I asked for. This one is **reachable in ordinary code**: reaching for "the empty version of a collection" and typing the dict spelling is a boring slip, not adversarial syntax. Generator expressions, walruses, slices, starred tuples and `frozenset()` need syntax nobody writes for this keyword and remain **documented residuals**, along with the pre-existing one — an unresolvable name still reads as gated, because resolving it needs the value rather than the syntax.

The residual direction was also confirmed as the only available one: flipping it would force all 51 genuinely-gated mounts (which resolve through the `_SM` name) into the undeclared set and turn the suite red. Removing it entirely means executing `main.py`, which is a separate tracked problem — the module is not importable under pytest, which is why this reads structure rather than running it.

| Mutation | Result |
|---|---|
| Drop the `ast.Dict` rule | 2 fail |
| Drop `dict` from the empty-constructor set | 1 fail |
| **`dependencies={}` mount added to the real `main.py`** | **1 fail** |

34 tests; `tests/api/` — 513 passed, plus the pre-existing base failure filed as #14535.

**Nine fail-opens found in this guard across five rounds; four were mine.** Worth stating plainly what that cost bought: the security substance of the parent change — one route moving from a gated router to an ungated one — was correct on the first day and has not moved since. Everything after was the checking apparatus repeatedly having the same shape as the bug it checks for, and it was only ever found by someone running the exploit rather than reading the rule.
