### PR TITLE
refactor(chat): one reader for both message schemas (#14335)

### DIFF
--- a/autobot-backend/chat_history/context_overflow.py
+++ b/autobot-backend/chat_history/context_overflow.py
@@ -24,6 +24,7 @@ from autobot_shared.redis_utils import decode_redis_value
 from autobot_shared.ssot_constants import CategoryDefaults
 from autobot_shared.token_count import estimate_fast
 from autobot_shared.tool_catalogue import FILE_WRITE_TOOLS, SHELL_EXEC_TOOLS, match_tool_name
+from chat_history.message_schema import message_text
 
 logger = get_logger(__name__)
 
@@ -222,24 +223,21 @@ class SessionTokenTracker:
 def _message_text(msg: object) -> str:
     """The text of a message, for token estimation, on any input (#14065 review).
 
-    ``estimate_fast`` needs a string. A non-dict entry or a non-string ``text``
-    (a provider emitting ``None``, an int, a content-part list) used to raise
-    here — after the token tracker had already been reset.
+    #14335: now backed by the shared reader. This and
+    `message_schema.message_text` were two implementations of the same job, from
+    two sessions fixing the same defect class at once, and they disagreed on
+    `content: []` beside a populated `text` — this one fell through, that one
+    did not. The consolidation adopted falling through, because an empty result
+    here under-counts `retained_tokens` and delays the next compaction. See that
+    function for why the same choice is right for every other consumer.
 
-    #14066: reads **both** schemas. This used to read only ``text``, so every
-    API-schema message (``role``/``content``) estimated as 0 tokens and the
-    post-compaction refill under-counted the retained half — which delays the
-    next compaction rather than triggering it early, so nothing surfaced it.
-    ``_format_messages`` already handled both; this did not.
+    The non-dict guard stays local: `estimate_fast` needs a string, and this
+    runs outside `summarize_messages`' try, so raising would 500 a turn whose
+    answer was already generated and stored.
     """
     if not isinstance(msg, dict):
         return ""
-    value = msg.get("content")
-    if isinstance(value, list):
-        value = " ".join(_text_parts(value))
-    if not isinstance(value, str) or not value:
-        value = msg.get("text", "")
-    return value if isinstance(value, str) else ""
+    return message_text(msg)
 
 
 def _text_parts(parts: list) -> List[str]:

--- a/autobot-backend/chat_history/message_schema.py
+++ b/autobot-backend/chat_history/message_schema.py
@@ -99,47 +99,53 @@ def message_type(message: Dict[str, Any], default: str = "default") -> str:
     return str(message.get("messageType") or message.get("type") or default)
 
 
-def message_text(message: Dict[str, Any]) -> str:
-    """The body, from either schema.
+def _resolved_body(value: Any) -> str:
+    """One key's value as a string: joined part-list, plain string, or ``""``.
 
-    Returns ``""`` when the message carries no text under either key, so callers
-    can filter on emptiness without having to know which schema they were handed.
+    Anything that is neither (``None``, ``0``, ``False``, a stray dict) resolves
+    to ``""`` rather than being ``str()``-ed, which would put the literal
+    ``"False"`` in front of the model.
 
-    Only ``str`` and ``list`` are valid content shapes — a string body, or the
-    multimodal part list. Anything else (``None``, ``0``, ``False``, a stray
-    dict) is treated as *absent* and falls through to the other key, rather than
-    being ``str()``-ed into the conversation: a bare ``str(value)`` puts the
-    literal ``"False"`` or ``"0"`` in front of the model, which is worse than
-    reading the other field or returning nothing.
-
-    An **empty** ``str`` also falls through, but an **empty list** does not: a
-    list is a well-formed answer meaning *this message has no text parts*, so
-    there is nothing to look for elsewhere. That distinction is the reason this
-    is not the bare ``content or text`` it replaced, and it is pinned by tests.
+    ``isinstance(part.get("text"), str)`` is load-bearing, not defensive: a part
+    with ``text: None`` is a shape providers genuinely emit, and it 500'd the
+    live chat path once (#14065). Lifted from the version that survived that
+    incident rather than re-derived.
     """
-    value = _valid_text_value(message.get("content"))
-    if value is None or value == "":
-        other = _valid_text_value(message.get("text"))
-        if other is not None:
-            value = other
-    if value is None:
-        return ""
-    # A list is the multimodal content shape (`[{"type": "text", ...}, ...]`);
-    # join its text parts rather than str()-ing the whole structure into the
-    # conversation, which would put JSON punctuation in front of the model.
-    #
-    # `isinstance(part.get("text"), str)` is load-bearing, not defensive: a part
-    # with ``text: None`` is a shape providers genuinely emit, and it 500'd the
-    # live chat path once already (#14065). Lifted verbatim from
-    # `context_overflow._format_messages` rather than re-derived — that version
-    # is the one that survived the incident.
     if isinstance(value, list):
         return " ".join(
             part["text"]
             for part in value
             if isinstance(part, dict) and part.get("type") == "text" and isinstance(part.get("text"), str)
         ).strip()
-    return str(value)
+    return value if isinstance(value, str) else ""
+
+
+def message_text(message: Dict[str, Any]) -> str:
+    """The body, from either schema.
+
+    Returns ``""`` when the message carries no text under either key, so callers
+    can filter on emptiness without having to know which schema they were handed.
+
+    **An empty part-list falls through to the other key** (#14335). An earlier
+    version of this function did not, on the reasoning that an empty list is a
+    well-formed *"this message has no text parts"* and so nothing needs looking
+    up elsewhere. That reasoning is wrong for a reader whose entire purpose is
+    that either key may hold the body: an empty ``content`` has told us nothing,
+    while ``text`` may still hold everything.
+
+    It is also wrong in the direction that costs data. Every consumer treats an
+    empty result as *absent*, and each loses something different: distillation
+    **drops** the message — precisely the #14259 defect this module exists to
+    fix — the overflow tracker under-counts retained tokens and delays the next
+    compaction, and the chat path sends the model an empty turn. There is no
+    consumer for which returning ``""`` over an available body is the better
+    answer.
+
+    No writer emits ``content: []`` beside a populated ``text`` today, so this
+    changes nothing live; it removes a divergence from
+    ``context_overflow._message_text``, which this function now backs.
+    """
+    return _resolved_body(message.get("content")) or _resolved_body(message.get("text"))
 
 
 def llm_role(message: Dict[str, Any], default: str = _CALLER_ROLE) -> str:

--- a/autobot-backend/chat_history/message_schema.py
+++ b/autobot-backend/chat_history/message_schema.py
@@ -72,11 +72,6 @@ _RESPONDER_ROLE = "assistant"
 _CONVERSATION_ROLES = frozenset({_CALLER_ROLE, _RESPONDER_ROLE})
 
 
-def _valid_text_value(value: Any) -> Any:
-    """The value if it is a shape a message body can take, else ``None``."""
-    return value if isinstance(value, (str, list)) else None
-
-
 def message_role(message: Dict[str, Any], default: str = _UNKNOWN_ROLE) -> str:
     """The speaker, from either schema.
 
@@ -126,10 +121,20 @@ def message_text(message: Dict[str, Any]) -> str:
     Returns ``""`` when the message carries no text under either key, so callers
     can filter on emptiness without having to know which schema they were handed.
 
-    **An empty part-list falls through to the other key** (#14335). An earlier
-    version of this function did not, on the reasoning that an empty list is a
-    well-formed *"this message has no text parts"* and so nothing needs looking
-    up elsewhere. That reasoning is wrong for a reader whose entire purpose is
+    **A ``content`` that yields no text falls through to the other key**
+    (#14335) — an empty part-list, and equally a list whose parts are all
+    non-text, such as an image-only multimodal message. The fallback is decided
+    on the *resolved* body, not on the raw value, which is what makes those two
+    cases behave alike; an earlier version tested the raw value and so fell
+    through only when ``content`` was absent or an empty string.
+
+    The image-only list is the case that matters in practice — a bare
+    ``content: []`` is barely a real shape, while a message carrying an image
+    and a caption is one a provider can genuinely emit.
+
+    The reasoning that was reversed here: that an empty list is a well-formed
+    *"this message has no text parts"* and so nothing needs looking up
+    elsewhere. That reasoning is wrong for a reader whose entire purpose is
     that either key may hold the body: an empty ``content`` has told us nothing,
     while ``text`` may still hold everything.
 
@@ -141,9 +146,14 @@ def message_text(message: Dict[str, Any]) -> str:
     consumer for which returning ``""`` over an available body is the better
     answer.
 
-    No writer emits ``content: []`` beside a populated ``text`` today, so this
-    changes nothing live; it removes a divergence from
-    ``context_overflow._message_text``, which this function now backs.
+    No writer emits either shape beside a populated ``text`` today — swept in
+    review across the persisted-message writers, the summary builder and the
+    workflow batch builder — so nothing live changes. What it removes is a
+    divergence from ``context_overflow._message_text``, which already fell
+    through and which this function now backs. The behavioural delta therefore
+    lands only on this function's *direct* callers (``as_llm_messages``, the
+    chat context builders, the shared-link viewer), not on the overflow token
+    path, which was already on these semantics.
     """
     return _resolved_body(message.get("content")) or _resolved_body(message.get("text"))
 

--- a/autobot-backend/chat_history/message_schema_test.py
+++ b/autobot-backend/chat_history/message_schema_test.py
@@ -87,14 +87,28 @@ class TestTheApiShapeStillWorks:
         that pins why the narrower check was chosen."""
         assert message_text({"content": "", "text": "real"}) == "real"
 
-    def test_an_empty_list_content_does_NOT_fall_back(self):
-        """Pins the deliberate narrowing against a bare `or`.
+    def test_an_empty_list_content_DOES_fall_back(self):
+        """Reversed deliberately in #14335 — this test previously asserted the
+        opposite.
 
-        An empty multimodal list is a well-formed answer — *this message has no
-        text parts* — so there is nothing to look for in `text`. A bare
-        `content or text` would fall back here and invent content.
+        The old reasoning was that an empty part-list is a well-formed *"this
+        message has no text parts"*, so nothing needs looking up elsewhere. That
+        holds for a single-schema reader and not for this one: the whole premise
+        here is that either key may carry the body, so an empty `content` has
+        told us nothing while `text` may still hold everything.
+
+        It also failed in the direction that costs data. Every consumer reads an
+        empty result as *absent*: distillation drops the message (the #14259
+        defect this module exists to fix), the overflow tracker under-counts
+        retained tokens and delays compaction, and the chat path sends an empty
+        turn. `context_overflow._message_text` always fell through here, which
+        is the divergence #14335 consolidated — toward the forgiving one.
         """
-        assert message_text({"content": [], "text": "fallback"}) == ""
+        assert message_text({"content": [], "text": "fallback"}) == "fallback"
+
+    def test_an_empty_list_with_no_other_key_is_still_empty(self):
+        """Falling through must not invent content when there is none to find."""
+        assert message_text({"content": []}) == ""
 
     @pytest.mark.parametrize("invalid", [0, False, {"a": 1}], ids=["zero", "false", "dict"])
     def test_an_invalid_content_type_is_treated_as_absent(self, invalid):

--- a/autobot-backend/chat_history/message_schema_test.py
+++ b/autobot-backend/chat_history/message_schema_test.py
@@ -110,6 +110,31 @@ class TestTheApiShapeStillWorks:
         """Falling through must not invent content when there is none to find."""
         assert message_text({"content": []}) == ""
 
+    def test_an_image_only_part_list_falls_back_to_the_caption(self):
+        """The case that actually occurs, and the one the #14335 reasoning
+        originally failed to name.
+
+        A bare `content: []` is barely a real shape. A message carrying an image
+        part and a caption under the other key is one a provider can genuinely
+        emit — and it behaves the same way here only because the fallback is
+        decided on the *resolved* body rather than the raw value. Testing the
+        raw value, as the reverted version did, would return "" here and lose
+        the caption.
+        """
+        msg = {"content": [{"type": "image_url", "image_url": {"url": "data:..."}}], "text": "the caption"}
+
+        assert message_text(msg) == "the caption"
+
+    def test_a_mixed_list_keeps_its_text_and_does_NOT_fall_back(self):
+        """The boundary on the other side: once a list yields any text, that is
+        the body, and a populated `text` must not override it."""
+        msg = {
+            "content": [{"type": "image_url", "image_url": {}}, {"type": "text", "text": "real body"}],
+            "text": "stale",
+        }
+
+        assert message_text(msg) == "real body"
+
     @pytest.mark.parametrize("invalid", [0, False, {"a": 1}], ids=["zero", "false", "dict"])
     def test_an_invalid_content_type_is_treated_as_absent(self, invalid):
         """Neither `str()`-ing it nor trusting it.


### PR DESCRIPTION
## Thinking Path

Two implementations of "read a chat message from either schema" existed, from two sessions fixing the same defect class at the same time. They agreed on every shape a writer actually produces and disagreed on one:

```
{"content": [], "text": "fallback"}

context_overflow._message_text  →  "fallback"   (empty join is falsy, falls through)
message_schema.message_text     →  ""           (an empty list is a complete answer)
```

**Review corrected the scope of this, and the correction matters.** The fallback now keys on the *resolved* body rather than the raw value, so it covers every `content` list that yields no text — not only a literal `[]`:

```
{"content": [{"type": "image_url", ...}], "text": "caption"}
  before → ""        after → "caption"
```

That case is the one that actually occurs. A bare `content: []` is barely a real shape; an image with a caption is one a provider can genuinely emit. My original reasoning named only the empty list and so did not cover what the code does.

I wrote the second one, and its reasoning was wrong.

The argument was that an empty part-list is a well-formed *"this message has no text parts"*, so there is nothing to look for elsewhere. That holds for a reader of one schema. It does not hold for this one, whose entire premise is that **either key may carry the body** — an empty `content` has told us nothing, while `text` may still hold everything.

It also failed in the direction that costs data. Every consumer reads an empty result as *absent*, and each loses something different:

| Consumer | What `""` does |
|---|---|
| skill distillation | **drops the message** — precisely the #14259 defect this module exists to fix |
| chat LLM context | sends the model an empty turn |
| shared-link viewer | renders the message blank |

(The overflow token tracker is **not** in this list, correcting an earlier claim of mine: `context_overflow._message_text` already had these semantics, so `retained_tokens` is unchanged by this PR. The delta lands only on `message_schema.message_text`'s direct callers.)

There is no consumer for which returning `""` over an available body is the better answer. So the consolidation adopts the forgiving behaviour, and my test asserting the opposite is reversed with the reasoning written down.

## What Changed

`message_text` resolves each key through one helper and takes the first non-empty:

```python
return _resolved_body(message.get("content")) or _resolved_body(message.get("text"))
```

`context_overflow._message_text` is now a two-line delegation. Its non-dict guard stays local and deliberate: `estimate_fast` needs a string, and it runs *outside* `summarize_messages`' try, so raising there 500s a turn whose answer was already generated and stored.

`_text_parts` stays where it is — `_body_key` still needs it to decide which key a clipped body gets written back to, which is a different question from reading.

`_valid_text_value` is deleted — the rewrite left it with zero callers, and an unused top-level function is not something the lint stage strips.

**Nothing live changes.** Verified by an independent producer sweep in review across the persisted-message writers, the summary builder and the workflow batch builder: no path emits either shape beside a populated `text`. This removes a divergence; it does not alter behaviour on any shape in production.

## Verification

```
chat_history/ (all)                                          204 passed
+ api/chat_llm_context_test.py, api/chat_sessions_test.py,
  services/skill_management/                                 283 passed
flake8 / black / isort                                       exit 0
```

Mutation-tested, each change independently:

| Mutation | Tests failed |
|---|---|
| fallback removed from `message_text` | **12** |
| fallback decided on the raw value (the exact reverted semantics) | **5** |
| non-dict guard removed from `_message_text` | **2** |
| delegation replaced with the old single-key read | **10** |

The second is the one that matters: it restores the precise pre-PR logic rather than deleting the fallback outright, so it proves the tests pin *this* change and not merely the presence of a fallback.

Every shape checked directly against the new implementation before wiring it — both schemas, empty string, empty list, populated list, a part with `text: None` (a shape providers emit, which 500'd the live chat path in #14065), and the non-str non-list values (`0`, `False`) that must not be `str()`-ed in front of the model.

## Model Used

Opus 5

Closes #14335
