### PR TITLE
fix(infra): resolve 32 unexpanded ${AUTOBOT_PROJECT_ROOT} placeholders and guard the class in code-quality (#14517)

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -455,6 +455,23 @@ jobs:
         # reports a comfortable zero. There is no exemption list, deliberately.
         python3 tools/lint/check_infra_scripts_undefined_names.py --audit
 
+    - name: Audit unexpanded shell placeholders in Python string constants (#14517)
+      run: |
+        # A pasted `${AUTOBOT_PROJECT_ROOT:-...}` inside a PLAIN Python string
+        # literal is never expanded, so the value names a directory that cannot
+        # exist: reads return empty and writes create a junk tree actually named
+        # after the expression. #14405/#14504 could only see the f-string form,
+        # which produces an F821; a plain literal is reported by no flake8 code,
+        # no bandit check and no type checker, and 32 sites accumulated that way
+        # (#14517). This has to run in a REQUIRED check for the same directional
+        # reason as #14419/#14405/#14489: every one of these sites fails quietly,
+        # so a run that stops looking at them goes greener rather than redder.
+        # It fails below a discovery floor, because a sweep handed an empty file
+        # list reports a comfortable zero, and it re-proves the three deliberate
+        # literals (#13658) by path, anchor symbol and exact count, so a rename
+        # cannot strand an exemption. There is no growable baseline.
+        python3 tools/lint/check_no_shell_placeholder_paths.py --audit
+
     - name: Audit MCP tool permission coverage (#14494)
       run: |
         # The under-grant guard used to infer "this tool mutates state" from a

--- a/autobot-infrastructure/shared/scripts/ai-ml/optimize_llm_models.py
+++ b/autobot-infrastructure/shared/scripts/ai-ml/optimize_llm_models.py
@@ -17,6 +17,8 @@ import time
 from pathlib import Path
 from typing import Any
 
+from autobot_shared.paths import project_root
+
 # Setup logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
@@ -102,7 +104,11 @@ class LLMModelOptimizer:
 
     def __init__(self):
         """Initialize LLM optimizer with default paths and state containers."""
-        self.autobot_root = Path("${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
+        # #14517: a shell placeholder in a plain Python string literal is never
+        # expanded, so this named a directory that cannot exist and every model
+        # path below it silently missed. autobot_shared.paths is the canonical
+        # answer to "where is the project root?" (#13149).
+        self.autobot_root = project_root()
         self.installed_models = {}
         self.missing_models = []
         self.optimization_results = {}

--- a/autobot-infrastructure/shared/scripts/analysis/redis_final_analysis.py
+++ b/autobot-infrastructure/shared/scripts/analysis/redis_final_analysis.py
@@ -14,6 +14,8 @@ import os
 import sys
 from typing import Any, Dict, List, Tuple
 
+from autobot_shared.paths import project_root
+
 sys.path.insert(0, os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
 from constants import ServiceURLs
 from constants.network_constants import NetworkConstants
@@ -23,6 +25,10 @@ logger = logging.getLogger(__name__)
 
 # DB number from redis-databases.yaml SSOT (#2806): knowledge = 1
 _DB_KNOWLEDGE = int(os.getenv("AUTOBOT_REDIS_DB_KNOWLEDGE", "1"))
+
+#: Where the final report lands, relative to the project root. One constant so the
+#: writer and the message that tells the operator where to look cannot drift.
+_REPORT_REL = "reports/vector_store_final_analysis.json"
 
 
 def _build_fix_llamaindex_recommendation(data_analysis, llamaindex_fixes):
@@ -484,7 +490,10 @@ class AutoBotVectorStoreAnalysis:
             "recommendation": recommendation,
         }
 
-        output_file = "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}/reports/vector_store_final_analysis.json"
+        # #14517: was a shell placeholder in a plain string literal, so this wrote
+        # the report into a junk tree literally named ``${AUTOBOT_PROJECT_ROOT:-``
+        # under the working directory instead of the project's reports/ (#13149).
+        output_file = str(project_root() / _REPORT_REL)
         os.makedirs(os.path.dirname(output_file), exist_ok=True)
         with open(output_file, "w", encoding="utf-8") as f:
             json.dump(full_report, f, indent=2)
@@ -652,10 +661,7 @@ async def main():
     analyzer = AutoBotVectorStoreAnalysis()
     await analyzer.run_final_analysis()
 
-    logger.info(
-        "\nComplete analysis saved to:"
-        " ${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}/reports/vector_store_final_analysis.json"
-    )
+    logger.info("\nComplete analysis saved to: %s", project_root() / _REPORT_REL)
 
 
 if __name__ == "__main__":

--- a/autobot-infrastructure/shared/scripts/analysis/redis_vector_analysis.py
+++ b/autobot-infrastructure/shared/scripts/analysis/redis_vector_analysis.py
@@ -15,6 +15,7 @@ import sys
 import os
 from typing import Any, Dict, List, Tuple
 
+from autobot_shared.paths import project_root
 from constants import ServiceURLs
 
 # Add project root to path
@@ -655,9 +656,10 @@ async def main():
     analyzer = RedisVectorStoreAnalyzer()
     recommendation = await analyzer.run_comprehensive_analysis()
 
-    from pathlib import Path
-
-    output_file = Path("${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}/reports/redis_vector_recommendation.json")
+    # #14517: was a shell placeholder in a plain string literal, so mkdir(parents=True)
+    # created a junk tree literally named ``${AUTOBOT_PROJECT_ROOT:-`` under the
+    # working directory rather than writing into the project's reports/ (#13149).
+    output_file = project_root() / "reports" / "redis_vector_recommendation.json"
     output_file.parent.mkdir(parents=True, exist_ok=True)
     with open(output_file, "w", encoding="utf-8") as f:
         json.dump(recommendation, f, indent=2)

--- a/autobot-infrastructure/shared/scripts/analysis/test_documentation_api.py
+++ b/autobot-infrastructure/shared/scripts/analysis/test_documentation_api.py
@@ -13,6 +13,8 @@ import sys
 import os
 from pathlib import Path
 
+from autobot_shared.paths import project_root
+
 # Add project root to Python path
 sys.path.insert(0, os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
 
@@ -29,7 +31,11 @@ async def test_documentation_browser_logic():
         import hashlib
         import mimetypes
 
-        project_root = Path("${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
+        # #14517: was a shell placeholder in a plain string literal, so every scan
+        # below walked a directory that cannot exist and reported zero docs as a
+        # success. Named ``root`` rather than ``project_root`` because assigning to
+        # the imported name would make it a local and raise UnboundLocalError.
+        root = project_root()
 
         documentation_files = []
         total_size = 0
@@ -107,7 +113,7 @@ async def test_documentation_browser_logic():
                 for item in dir_path.iterdir():
                     if item.is_file() and item.suffix.lower() in doc_extensions:
                         try:
-                            file_info = _process_doc_file(item, project_root, category_prefix)
+                            file_info = _process_doc_file(item, root, category_prefix)
                             files.append(file_info)
                             total_size += file_info["size_bytes"]
                             total_docs += 1
@@ -139,7 +145,7 @@ async def test_documentation_browser_logic():
         all_files = []
 
         for file_path, title, category in root_files:
-            full_path = project_root / file_path
+            full_path = root / file_path
             if full_path.exists() and full_path.is_file():
                 try:
                     stat = full_path.stat()
@@ -174,7 +180,7 @@ async def test_documentation_browser_logic():
 
         # Scan docs directory
         print("\n📁 Scanning docs directory...")
-        docs_path = project_root / "docs"
+        docs_path = root / "docs"
         if docs_path.exists():
             docs_files = scan_directory(docs_path, "docs")
             all_files.extend(docs_files)
@@ -208,7 +214,7 @@ async def test_documentation_browser_logic():
         # Test reading a specific file
         print("\n📖 Testing file reading:")
         test_file = "CLAUDE.md"
-        full_path = project_root / test_file
+        full_path = root / test_file
         if full_path.exists():
             with open(full_path, "r", encoding="utf-8") as f:
                 content = f.read()

--- a/autobot-infrastructure/shared/scripts/analyze_duplicates.py
+++ b/autobot-infrastructure/shared/scripts/analyze_duplicates.py
@@ -23,6 +23,8 @@ import re
 from collections import Counter, defaultdict
 from pathlib import Path
 
+from autobot_shared.paths import project_root
+
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 logger = logging.getLogger(__name__)
 
@@ -263,7 +265,10 @@ class DuplicateDetector:
 
 def main():
     """Main execution function"""
-    root_path = "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}"
+    # #14517: both paths below were shell placeholders in plain string literals.
+    # The read never matched, so the existence check below turned every run into an
+    # early "AutoBot directory not found" return (#13149).
+    root_path = str(project_root())
 
     if not os.path.exists(root_path):
         logger.error("AutoBot directory not found at %s", root_path)
@@ -274,7 +279,7 @@ def main():
     detector.generate_report(analysis)
 
     # Save detailed results
-    output_file = "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}/reports/duplicate_analysis_results.json"
+    output_file = str(project_root() / "reports" / "duplicate_analysis_results.json")
     os.makedirs(os.path.dirname(output_file), exist_ok=True)
 
     # Prepare serializable data

--- a/autobot-infrastructure/shared/scripts/direct_kb_populate.py
+++ b/autobot-infrastructure/shared/scripts/direct_kb_populate.py
@@ -12,7 +12,8 @@ import glob
 import logging
 import os
 import sys
-from pathlib import Path
+
+from autobot_shared.paths import project_root
 
 logger = logging.getLogger(__name__)
 
@@ -56,12 +57,16 @@ async def populate_directly():
     logger.info(f"  Embedding model: {kb.embedding_model_name}")
 
     # Find documentation files
-    project_root = Path("${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
+    # #14517: was a shell placeholder in a plain string literal, so every glob below
+    # matched nothing and the run reported "Found 0 documentation files" as success.
+    # Named ``root``: assigning to the imported ``project_root`` would make it a
+    # function-local name and raise UnboundLocalError on the call itself.
+    root = project_root()
     doc_patterns = ["README.md", "CLAUDE.md", "docs/**/*.md"]
 
     all_files = []
     for pattern in doc_patterns:
-        files = glob.glob(str(project_root / pattern), recursive=True)
+        files = glob.glob(str(root / pattern), recursive=True)
         all_files.extend(files)
 
     # Remove duplicates and filter
@@ -76,7 +81,7 @@ async def populate_directly():
     # Add all files directly to vector store
     for file_path in sorted(filtered_files):
         try:
-            rel_path = os.path.relpath(file_path, project_root)
+            rel_path = os.path.relpath(file_path, root)
 
             # Categorize documents
             if "user_guide" in rel_path:

--- a/autobot-infrastructure/shared/scripts/fix_search.py
+++ b/autobot-infrastructure/shared/scripts/fix_search.py
@@ -11,6 +11,8 @@ import sys
 
 import requests
 
+from autobot_shared.paths import project_root
+
 # Add parent directory to path
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -18,13 +20,17 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 def upload_docs_as_searchable_facts():
     """Upload docs as facts that can be searched via simple text matching."""
 
-    project_root = "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}"
+    # #14517: was a shell placeholder in a plain string literal, so every glob below
+    # matched nothing and the run reported "Found 0 documentation files" as success.
+    # Named ``root``: assigning to the imported ``project_root`` would make it a
+    # function-local name and raise UnboundLocalError on the call itself.
+    root = str(project_root())
 
     # Find all documentation files
     doc_files = []
     patterns = ["README.md", "CLAUDE.md", "docs/**/*.md"]
     for pattern in patterns:
-        files = glob.glob(os.path.join(project_root, pattern), recursive=True)
+        files = glob.glob(os.path.join(root, pattern), recursive=True)
         doc_files.extend(files)
 
     filtered_files = [f for f in set(doc_files) if os.path.isfile(f) and "node_modules" not in f]
@@ -35,7 +41,7 @@ def upload_docs_as_searchable_facts():
 
     for file_path in filtered_files:
         try:
-            rel_path = os.path.relpath(file_path, project_root)
+            rel_path = os.path.relpath(file_path, root)
 
             # Read file content
             with open(file_path, "r", encoding="utf-8") as f:

--- a/autobot-infrastructure/shared/scripts/optimize_agents.py
+++ b/autobot-infrastructure/shared/scripts/optimize_agents.py
@@ -11,6 +11,8 @@ Reduces token consumption while preserving critical policies.
 import re
 from pathlib import Path
 
+from autobot_shared.paths import project_root
+
 
 def optimize_agent_file(file_path: Path) -> tuple[bool, int, int]:
     """
@@ -19,7 +21,7 @@ def optimize_agent_file(file_path: Path) -> tuple[bool, int, int]:
     Returns:
         (modified, lines_before, lines_after)
     """
-    content = file_path.read_text()
+    content = file_path.read_text(encoding="utf-8")
     original_lines = content.count("\n")
 
     # Pattern to match the entire "MANDATORY LOCAL-ONLY EDITING ENFORCEMENT" section
@@ -44,7 +46,7 @@ def optimize_agent_file(file_path: Path) -> tuple[bool, int, int]:
     optimized_content = re.sub(pattern, replacement, content, flags=re.DOTALL)
 
     # Write back
-    file_path.write_text(optimized_content)
+    file_path.write_text(optimized_content, encoding="utf-8")
 
     optimized_lines = optimized_content.count("\n")
     original_lines - optimized_lines
@@ -54,7 +56,10 @@ def optimize_agent_file(file_path: Path) -> tuple[bool, int, int]:
 
 def main():
     """Main optimization routine."""
-    agents_dir = Path("${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}/.claude/agents")
+    # #14517: was a shell placeholder in a plain string literal, so the exists()
+    # check below always failed and the script exited 1 with "Agents directory not
+    # found" no matter where it ran (#13149).
+    agents_dir = project_root() / ".claude" / "agents"
 
     if not agents_dir.exists():
         print(f"❌ Error: Agents directory not found: {agents_dir}")

--- a/autobot-infrastructure/shared/scripts/populate_docs_knowledge.py
+++ b/autobot-infrastructure/shared/scripts/populate_docs_knowledge.py
@@ -16,6 +16,8 @@ import os
 import sys
 from pathlib import Path
 
+from autobot_shared.paths import project_root
+
 # Add parent directory to path
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -147,12 +149,16 @@ async def populate_docs_knowledge():
 
         await asyncio.sleep(2)
 
-        project_root = Path("${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
-        filtered_files = _gather_documentation_files(project_root)
+        # #14517: was a shell placeholder in a plain string literal, so the gather
+        # below globbed a directory that cannot exist and indexed nothing. Named
+        # ``root``: assigning to the imported ``project_root`` would shadow it as a
+        # local and raise UnboundLocalError on the call itself.
+        root = project_root()
+        filtered_files = _gather_documentation_files(root)
 
         logger.info("Found %s documentation files to index", len(filtered_files))
 
-        successful_adds, failed_adds = await _process_documentation_files(kb, filtered_files, project_root)
+        successful_adds, failed_adds = await _process_documentation_files(kb, filtered_files, root)
 
         logger.info("=== Documentation Population Complete ===")
         logger.info("✓ Successfully added: %s documents", successful_adds)

--- a/autobot-infrastructure/shared/scripts/populate_kb_chromadb.py
+++ b/autobot-infrastructure/shared/scripts/populate_kb_chromadb.py
@@ -14,6 +14,8 @@ import os
 import sys
 from pathlib import Path
 
+from autobot_shared.paths import project_root
+
 # Configure logging
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 logger = logging.getLogger(__name__)
@@ -162,11 +164,15 @@ async def populate_with_chromadb():
     logger.info("ChromaDB knowledge base initialized successfully!")
 
     # Issue #281: Use extracted helpers
-    project_root = Path("${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
-    filtered_files = _find_documentation_files(project_root)
+    # #14517: was a shell placeholder in a plain string literal, so the discovery
+    # below found nothing and the collection was built empty. Named ``root``:
+    # assigning to the imported ``project_root`` would make it a function-local
+    # name and raise UnboundLocalError on the call itself.
+    root = project_root()
+    filtered_files = _find_documentation_files(root)
     logger.info("Found %d documentation files", len(filtered_files))
 
-    success_count, error_count = _add_documents_to_index(filtered_files, project_root, index, Document)
+    success_count, error_count = _add_documents_to_index(filtered_files, root, index, Document)
 
     logger.info("Added %d documents successfully!", success_count)
     logger.info("Errors: %d", error_count)

--- a/autobot-infrastructure/shared/scripts/populate_kb_fixed.py
+++ b/autobot-infrastructure/shared/scripts/populate_kb_fixed.py
@@ -12,6 +12,8 @@ import os
 import sys
 from pathlib import Path
 
+from autobot_shared.paths import project_root
+
 logger = logging.getLogger(__name__)
 
 # Add parent directory to path
@@ -100,8 +102,12 @@ async def populate_knowledge_base_chromadb():
         return False
 
     logger.info("Knowledge base initialized with ChromaDB")
-    project_root = Path("${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
-    filtered_files = _find_documentation_files(project_root)
+    # #14517: was a shell placeholder in a plain string literal, so the discovery
+    # below found nothing and the ingest reported a clean zero. Named ``root``:
+    # assigning to the imported ``project_root`` would shadow it as a local and
+    # raise UnboundLocalError on the call itself.
+    root = project_root()
+    filtered_files = _find_documentation_files(root)
     logger.info("Found %s documentation files", len(filtered_files))
 
     success_count = 0
@@ -109,7 +115,7 @@ async def populate_knowledge_base_chromadb():
 
     for file_path in filtered_files:
         try:
-            rel_path = os.path.relpath(file_path, project_root)
+            rel_path = os.path.relpath(file_path, root)
             category = _categorize_document(rel_path)
             metadata = {
                 "source": "project-docs",

--- a/autobot-infrastructure/shared/scripts/run_code_analysis.py
+++ b/autobot-infrastructure/shared/scripts/run_code_analysis.py
@@ -15,14 +15,20 @@ import sys
 from pathlib import Path
 from typing import Any, Dict
 
-# Add project root to Python path
-project_root = Path(__file__).parent.parent
-sys.path.insert(0, str(project_root))
+from autobot_shared.paths import project_root
+
+# #14517: this module-level name was ``project_root`` while holding
+# ``autobot-infrastructure/shared`` -- the script's grandparent, not the project
+# root -- so it read as the canonical resolver and was not. Renamed to what it
+# actually is; the value is deliberately unchanged, because the analysis scripts
+# it addresses live at no path in this repo (tracked separately).
+_SHARED_DIR = Path(__file__).parent.parent
+sys.path.insert(0, str(_SHARED_DIR))
 
 
 def run_code_quality_analysis(target_path: str) -> Dict[str, Any]:
     """Run code quality analysis"""
-    script_path = project_root / "tools" / "code-analysis-suite" / "scripts" / "analyze_code_quality.py"
+    script_path = _SHARED_DIR / "tools" / "code-analysis-suite" / "scripts" / "analyze_code_quality.py"
 
     if not script_path.exists():
         return {"error": f"Script not found: {script_path}"}
@@ -61,7 +67,7 @@ def run_code_quality_analysis(target_path: str) -> Dict[str, Any]:
 
 def run_duplicate_analysis(target_path: str) -> Dict[str, Any]:
     """Run duplicate code analysis"""
-    script_path = project_root / "tools" / "code-analysis-suite" / "scripts" / "analyze_duplicates.py"
+    script_path = _SHARED_DIR / "tools" / "code-analysis-suite" / "scripts" / "analyze_duplicates.py"
 
     if not script_path.exists():
         return {"error": f"Script not found: {script_path}"}
@@ -93,11 +99,11 @@ def run_duplicate_analysis(target_path: str) -> Dict[str, Any]:
 
 def run_performance_analysis(target_path: str) -> Dict[str, Any]:
     """Run performance analysis"""
-    script_path = project_root / "tools" / "code-analysis-suite" / "scripts" / "analyze_performance_simple.py"
+    script_path = _SHARED_DIR / "tools" / "code-analysis-suite" / "scripts" / "analyze_performance_simple.py"
 
     if not script_path.exists():
         # Fallback to regular performance script
-        script_path = project_root / "tools" / "code-analysis-suite" / "scripts" / "analyze_performance.py"
+        script_path = _SHARED_DIR / "tools" / "code-analysis-suite" / "scripts" / "analyze_performance.py"
 
     if not script_path.exists():
         return {"error": f"Script not found: {script_path}"}
@@ -128,7 +134,7 @@ def run_performance_analysis(target_path: str) -> Dict[str, Any]:
 
 def run_architecture_analysis(target_path: str) -> Dict[str, Any]:
     """Run architecture analysis"""
-    script_path = project_root / "tools" / "code-analysis-suite" / "scripts" / "analyze_architecture.py"
+    script_path = _SHARED_DIR / "tools" / "code-analysis-suite" / "scripts" / "analyze_architecture.py"
 
     if not script_path.exists():
         return {"error": f"Script not found: {script_path}"}
@@ -205,7 +211,9 @@ def main():
     parser = argparse.ArgumentParser(description="Run code analysis suite")
     parser.add_argument(
         "--target",
-        default="${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}",
+        # #14517: the default was a shell placeholder in a plain string literal, so
+        # an invocation without --target analysed a directory that cannot exist.
+        default=str(project_root()),
         help="Target path to analyze",
     )
     parser.add_argument(

--- a/autobot-infrastructure/shared/scripts/search_index_utility.py
+++ b/autobot-infrastructure/shared/scripts/search_index_utility.py
@@ -17,6 +17,8 @@ from typing import Optional
 
 import requests
 
+from autobot_shared.paths import project_root
+
 # Add parent directory to path
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -113,13 +115,17 @@ def search_queries_batch(queries: list, max_workers: int = 4) -> list:
 
 def upload_docs_as_searchable_facts():
     """Upload docs as facts that can be searched via simple text matching."""
-    project_root = "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}"
+    # #14517: was a shell placeholder in a plain string literal, so every glob below
+    # matched nothing and the run reported "Found 0 documentation files" as success.
+    # Named ``root``: assigning to the imported ``project_root`` would make it a
+    # function-local name and raise UnboundLocalError on the call itself.
+    root = str(project_root())
 
     # Find all documentation files
     doc_files = []
     patterns = ["README.md", "CLAUDE.md", "docs/**/*.md"]
     for pattern in patterns:
-        files = glob.glob(os.path.join(project_root, pattern), recursive=True)
+        files = glob.glob(os.path.join(root, pattern), recursive=True)
         doc_files.extend(files)
 
     filtered_files = [f for f in set(doc_files) if os.path.isfile(f) and "node_modules" not in f]
@@ -128,7 +134,7 @@ def upload_docs_as_searchable_facts():
     print(f"Uploading {len(filtered_files)} documents concurrently...")
 
     # Upload all documents concurrently
-    results = upload_docs_batch(filtered_files, project_root)
+    results = upload_docs_batch(filtered_files, root)
 
     added_count = 0
     for result in results:

--- a/autobot-infrastructure/shared/scripts/simple_populate.py
+++ b/autobot-infrastructure/shared/scripts/simple_populate.py
@@ -23,6 +23,8 @@ os.environ["AUTOBOT_VECTOR_STORE_TYPE"] = "chroma"
 
 import requests
 
+from autobot_shared.paths import project_root
+
 API_URL = "http://localhost:8001"
 
 
@@ -90,12 +92,16 @@ def main():
         return
 
     # Find all documentation files
-    project_root = "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}"
+    # #14517: was a shell placeholder in a plain string literal, so every glob below
+    # matched nothing and the run added no documents while reporting success. Named
+    # ``root``: assigning to the imported ``project_root`` would shadow it as a
+    # local and raise UnboundLocalError on the call itself.
+    root = str(project_root())
     doc_files = []
 
     patterns = ["README.md", "CLAUDE.md", "docs/**/*.md"]
     for pattern in patterns:
-        files = glob.glob(os.path.join(project_root, pattern), recursive=True)
+        files = glob.glob(os.path.join(root, pattern), recursive=True)
         doc_files.extend(files)
 
     # Remove duplicates and filter
@@ -109,7 +115,7 @@ def main():
     print(f"Adding {len(files_to_add)} documents concurrently...")
 
     try:
-        results = add_docs_batch(files_to_add, project_root)
+        results = add_docs_batch(files_to_add, root)
 
         added_count = 0
         for result in results:

--- a/autobot-infrastructure/shared/scripts/sync_kb_docs.py
+++ b/autobot-infrastructure/shared/scripts/sync_kb_docs.py
@@ -14,6 +14,8 @@ import os
 import sys
 from datetime import datetime
 
+from autobot_shared.paths import project_root
+
 logger = logging.getLogger(__name__)
 
 # Add parent directory to path
@@ -166,15 +168,19 @@ async def sync_docs():
     removed_count = await _remove_outdated_entries(kb, all_facts)
 
     # Collect documentation files
-    project_root = "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}"
-    filtered_files = _collect_documentation_files(project_root)
+    # #14517: was a shell placeholder in a plain string literal, so the collection
+    # below globbed a directory that cannot exist and the sync reported a clean
+    # zero. Named ``root``: assigning to the imported ``project_root`` would make
+    # it a function-local name and raise UnboundLocalError on the call itself.
+    root = str(project_root())
+    filtered_files = _collect_documentation_files(root)
     logger.info(f"Found {len(filtered_files)} documentation files to sync")
 
     # Sync each file
     success_count = 0
     for file_path in sorted(filtered_files):
         try:
-            if await _sync_single_file(kb, file_path, project_root):
+            if await _sync_single_file(kb, file_path, root):
                 success_count += 1
         except Exception as e:
             logger.error(f"❌ Error syncing {file_path}: {str(e)}")

--- a/autobot-infrastructure/shared/scripts/test_long_running_operations.py
+++ b/autobot-infrastructure/shared/scripts/test_long_running_operations.py
@@ -30,6 +30,8 @@ import sys
 import os
 from datetime import datetime
 
+from autobot_shared.paths import project_root
+
 # Add AutoBot paths
 sys.path.append(os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
 
@@ -310,7 +312,9 @@ class LongRunningOperationsDemo:
 
         # Quick indexing operation
         indexing_op = await execute_codebase_indexing(
-            "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}/src/utils",
+            # #14517: both demo targets were shell placeholders in plain string
+            # literals, so the operations walked directories that cannot exist.
+            str(project_root() / "autobot_shared"),
             self.manager,
             ["*.py"],
         )
@@ -318,7 +322,7 @@ class LongRunningOperationsDemo:
 
         # Test suite operation
         test_op = await execute_comprehensive_test_suite(
-            "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}/tests/unit",
+            str(project_root() / "repo_tests"),
             self.manager,
             ["test_*.py"],
         )

--- a/autobot-infrastructure/shared/scripts/upload_docs.py
+++ b/autobot-infrastructure/shared/scripts/upload_docs.py
@@ -16,6 +16,8 @@ from typing import Optional
 
 import requests
 
+from autobot_shared.paths import project_root
+
 
 @dataclass
 class UploadResult:
@@ -63,14 +65,18 @@ def upload_files_batch(files: list, project_root: str, api_url: str, max_workers
 
 def upload_docs():
     """Upload documentation files to knowledge base via file upload API."""
-    project_root = "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}"
+    # #14517: was a shell placeholder in a plain string literal, so every glob below
+    # matched nothing and the upload reported a clean zero. Named ``root``:
+    # assigning to the imported ``project_root`` would shadow it as a local and
+    # raise UnboundLocalError on the call itself.
+    root = str(project_root())
     api_url = "http://localhost:8001"  # Use proper URL from config
 
     # Find documentation files
     doc_files = []
     patterns = ["README.md", "CLAUDE.md", "docs/**/*.md"]
     for pattern in patterns:
-        files = glob.glob(os.path.join(project_root, pattern), recursive=True)
+        files = glob.glob(os.path.join(root, pattern), recursive=True)
         doc_files.extend(files)
 
     # Remove duplicates and filter
@@ -83,7 +89,7 @@ def upload_docs():
     files_to_upload = filtered_files[:10]
     print(f"Uploading {len(files_to_upload)} files concurrently...")
 
-    results = upload_files_batch(files_to_upload, project_root, api_url)
+    results = upload_files_batch(files_to_upload, root, api_url)
 
     # Display results
     added_count = 0

--- a/autobot-infrastructure/shared/scripts/utilities/enhance_workflow_ui.py
+++ b/autobot-infrastructure/shared/scripts/utilities/enhance_workflow_ui.py
@@ -11,6 +11,14 @@ NOTE: Long methods (create_workflow_notification_component, create_workflow_prog
 are ACCEPTABLE EXCEPTIONS per Issue #490 - template generators with low cyclomatic complexity.
 """
 
+from autobot_shared.paths import project_root
+
+#: Where the generated single-file components land, relative to the project root.
+#: #14517: both write targets were shell placeholders in plain string literals, so
+#: every run raised FileNotFoundError on ``open`` -- the generator has never once
+#: produced a component.
+_COMPONENTS_REL = "autobot-vue/src/components"
+
 
 def create_workflow_notification_component():
     """Create a workflow notification component for real-time updates."""
@@ -767,7 +775,7 @@ def main():
     notification_component = create_workflow_notification_component()
 
     with open(
-        "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}/autobot-vue/src/components/WorkflowNotifications.vue",
+        project_root() / _COMPONENTS_REL / "WorkflowNotifications.vue",
         "w",
         encoding="utf-8",
     ) as f:
@@ -783,7 +791,7 @@ def main():
     progress_widget = create_workflow_progress_widget()
 
     with open(
-        "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}/autobot-vue/src/components/WorkflowProgressWidget.vue",
+        project_root() / _COMPONENTS_REL / "WorkflowProgressWidget.vue",
         "w",
         encoding="utf-8",
     ) as f:

--- a/autobot-infrastructure/shared/scripts/utilities/init_memory_graph_redis.py
+++ b/autobot-infrastructure/shared/scripts/utilities/init_memory_graph_redis.py
@@ -44,7 +44,16 @@ from redis.commands.search.field import NumericField, TagField, TextField, Vecto
 from redis.commands.search.indexDefinition import IndexDefinition, IndexType
 from redis.commands.search.query import Query
 
+from autobot_shared.paths import project_root
 from constants.network_constants import NetworkConstants
+
+# #14517: the log path was a shell placeholder in a plain string literal. Python
+# never expands one, so FileHandler was handed a directory that cannot exist and
+# raised at import time -- every entry point in this module was dead. Resolving it
+# makes the handler reachable, so the directory has to be created first: a fresh
+# checkout has no logs/ at all, and FileHandler does not create parents (#13149).
+_LOG_PATH = project_root() / "logs" / "database" / "memory_graph_init.log"
+_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
 
 # Configure logging
 logging.basicConfig(
@@ -52,10 +61,7 @@ logging.basicConfig(
     format="%(asctime)s [%(levelname)s] %(message)s",
     handlers=[
         logging.StreamHandler(sys.stdout),
-        logging.FileHandler(
-            "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}/logs/database/memory_graph_init.log",
-            mode="a",
-        ),
+        logging.FileHandler(_LOG_PATH, mode="a", encoding="utf-8"),
     ],
 )
 logger = logging.getLogger(__name__)
@@ -878,7 +884,7 @@ def _execute_memory_graph_phases(initializer: MemoryGraphInitializer, args) -> b
         logger.info("PHASE 3: Conversation Migration")
         logger.info("=" * 80)
 
-        transcript_dir = Path("${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}/data/conversation_transcripts")
+        transcript_dir = project_root() / "data" / "conversation_transcripts"
         migration_stats = initializer.migrate_conversations(transcript_dir)
         logger.info("\nMigration Results:")
         logger.info(json.dumps(migration_stats, indent=2))

--- a/autobot-infrastructure/shared/scripts/utilities/migrate_consolidated_config.py
+++ b/autobot-infrastructure/shared/scripts/utilities/migrate_consolidated_config.py
@@ -30,6 +30,8 @@ import shutil
 from pathlib import Path
 from typing import Dict, List
 
+from autobot_shared.paths import project_root
+
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
@@ -244,14 +246,19 @@ def main():
     )
     parser.add_argument(
         "--project-root",
-        default="${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}",
+        # #14517: the default was a shell placeholder in a plain string literal, so
+        # an invocation without --project-root scanned a directory that cannot
+        # exist and reported "0 files scanned" as a successful migration.
+        default=str(project_root()),
         help="Project root directory",
     )
 
     args = parser.parse_args()
 
-    project_root = Path(args.project_root)
-    migrator = ConfigMigrator(project_root)
+    # Named ``root``: assigning to the imported ``project_root`` would make it a
+    # function-local name and raise UnboundLocalError inside the parser default.
+    root = Path(args.project_root)
+    migrator = ConfigMigrator(root)
 
     stats = migrator.run_migration(dry_run=args.dry_run)
 

--- a/autobot-infrastructure/shared/scripts/utilities/npu_worker_design.py
+++ b/autobot-infrastructure/shared/scripts/utilities/npu_worker_design.py
@@ -13,6 +13,8 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict
 
+from autobot_shared.paths import project_root
+
 
 class TaskType(Enum):
     """Types of tasks suitable for NPU processing."""
@@ -324,8 +326,10 @@ if __name__ == "__main__":
     architecture.print_summary()
 
     # Generate full architecture file
+    # #14517: was a shell placeholder in a plain string literal, so this open()
+    # raised FileNotFoundError and the architecture file was never written.
     with open(
-        "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}/NPU_WORKER_ARCHITECTURE.json",
+        project_root() / "NPU_WORKER_ARCHITECTURE.json",
         "w",
         encoding="utf-8",
     ) as f:

--- a/autobot-infrastructure/shared/tests/ci_cd_integration.py
+++ b/autobot-infrastructure/shared/tests/ci_cd_integration.py
@@ -35,6 +35,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Tuple
 
+from autobot_shared.paths import project_root
+
 # Add AutoBot paths
 sys.path.append(os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
 
@@ -220,9 +222,13 @@ class CICDIntegrationTester:
             ),
         ]
 
-        # Create results directory
-        self.results_dir = Path("${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}/tests/results")
-        self.results_dir.mkdir(exist_ok=True)
+        # #14517: was a shell placeholder in a plain string literal, so mkdir either
+        # failed on the missing parent or created a junk tree literally named
+        # ``${AUTOBOT_PROJECT_ROOT:-`` under the working directory. ``parents=True``
+        # because the resolved path now has a real parent that a fresh checkout does
+        # not carry -- ``mkdir(exist_ok=True)`` alone would raise FileNotFoundError.
+        self.results_dir = project_root() / "tests" / "results"
+        self.results_dir.mkdir(parents=True, exist_ok=True)
 
         self.pipeline_id = f"hardware_pipeline_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
 
@@ -281,7 +287,10 @@ class CICDIntegrationTester:
                 text=True,
                 timeout=stage.timeout,
                 env=env,
-                cwd="${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}",
+                # #14517: a non-existent cwd makes subprocess.run raise before the
+                # stage command ever starts, which this except block then reported
+                # as an ordinary stage failure.
+                cwd=str(project_root()),
             )
 
             end_time = datetime.now()

--- a/autobot-infrastructure/shared/tests/comprehensive_test_suite.py
+++ b/autobot-infrastructure/shared/tests/comprehensive_test_suite.py
@@ -32,11 +32,12 @@ import os
 import time
 from dataclasses import dataclass, field
 from datetime import datetime
-from pathlib import Path
 from typing import Dict, List, Optional
 
 import requests
 import websockets
+
+from autobot_shared.paths import project_root
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
@@ -94,9 +95,12 @@ class ComprehensiveTestSuite:
         self.session = requests.Session()
         self.session.timeout = self.config.timeout
 
-        # Create results directory
-        self.results_dir = Path("${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}/tests/results")
-        self.results_dir.mkdir(exist_ok=True)
+        # #14517: was a shell placeholder in a plain string literal, so mkdir either
+        # failed on the missing parent or created a junk tree literally named
+        # ``${AUTOBOT_PROJECT_ROOT:-`` under the working directory. ``parents=True``
+        # because the resolved path now has a real parent a fresh checkout lacks.
+        self.results_dir = project_root() / "tests" / "results"
+        self.results_dir.mkdir(parents=True, exist_ok=True)
 
         # Test execution timestamp
         self.timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")

--- a/autobot-infrastructure/shared/tests/performance/test_performance_optimization.py
+++ b/autobot-infrastructure/shared/tests/performance/test_performance_optimization.py
@@ -33,10 +33,11 @@ import os
 import time
 from dataclasses import dataclass, field
 from datetime import datetime
-from pathlib import Path
 from typing import Dict, List, Optional
 
 import psutil
+
+from autobot_shared.paths import project_root
 
 # Add AutoBot paths
 sys.path.append(os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
@@ -90,9 +91,12 @@ class PerformanceOptimizationTester:
             "cpu_usage": 70.0,  # percentage
         }
 
-        # Create results directory
-        self.results_dir = Path("${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}/tests/results")
-        self.results_dir.mkdir(exist_ok=True)
+        # #14517: was a shell placeholder in a plain string literal, so mkdir either
+        # failed on the missing parent or created a junk tree literally named
+        # ``${AUTOBOT_PROJECT_ROOT:-`` under the working directory. ``parents=True``
+        # because the resolved path now has a real parent a fresh checkout lacks.
+        self.results_dir = project_root() / "tests" / "results"
+        self.results_dir.mkdir(parents=True, exist_ok=True)
 
         self.timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
 

--- a/autobot-infrastructure/shared/tests/results/comprehensive_testing_20250909_150149/system_assessment_report.py
+++ b/autobot-infrastructure/shared/tests/results/comprehensive_testing_20250909_150149/system_assessment_report.py
@@ -19,6 +19,8 @@ from typing import Any, Dict, List, Tuple
 
 import requests
 
+from autobot_shared.paths import project_root
+
 
 @dataclass
 class TestResult:
@@ -461,7 +463,10 @@ class AutoBotSystemTester:
         print("🏗️  Analyzing Frontend Build...")
 
         # Check if frontend directory exists
-        frontend_dir = "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}/autobot-vue"
+        # #14517: was a shell placeholder in a plain string literal, so the exists()
+        # check below always failed and this analysis reported "Frontend directory
+        # not found" as a HIGH-severity finding on every run (#13149).
+        frontend_dir = str(project_root() / "autobot-vue")
         if not os.path.exists(frontend_dir):
             self.add_result(
                 "Frontend Build",
@@ -799,9 +804,10 @@ def main():
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
 
     # Save to multiple formats
-    results_dir = (
-        "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}/tests/results/comprehensive_testing_20250909_150149"
-    )
+    # #14517: was a shell placeholder in a plain string literal, so os.makedirs
+    # created a junk tree literally named ``${AUTOBOT_PROJECT_ROOT:-`` under the
+    # working directory and both reports were written into it.
+    results_dir = str(project_root() / "tests" / "results" / "comprehensive_testing_20250909_150149")
     os.makedirs(results_dir, exist_ok=True)
 
     # JSON report for detailed analysis

--- a/tools/lint/check_no_shell_placeholder_paths.py
+++ b/tools/lint/check_no_shell_placeholder_paths.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""#14517 — no Python string constant may carry an unexpanded shell project-root placeholder.
+
+Python does not interpolate shell syntax inside a string literal, so a pasted
+``${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}`` stays exactly that: a path
+whose first component is the literal text ``${AUTOBOT_PROJECT_ROOT:-``. A read
+through it matches nothing and returns a comfortable empty list; a write through
+it either raises ``FileNotFoundError`` on the missing parent or, under
+``mkdir(parents=True)``, creates a junk tree actually named after the expression.
+Neither outcome names the real defect at the point it happens — which is why
+#14507's report run logged ``MISSION COMPLETED SUCCESSFULLY`` having discovered
+nothing at all.
+
+WHY NO EXISTING LINT SEES THIS. #14405/#14504 could only reach the *f-string*
+form, because ``f"${AUTOBOT_PROJECT_ROOT:-...}"`` parses ``{AUTOBOT_PROJECT_ROOT:-...}``
+as a replacement field naming an undefined name, and pyflakes reports F821 for
+it. A **plain** literal is a perfectly well-formed string: no flake8 code, no
+bandit check and no type checker has anything to say about it. 32 sites
+accumulated across 25 files that way (#14517), on top of the one #14507 named.
+
+WHY A REQUIRED CHECK. The same directional argument as ``check_flake8_exclude_anchoring``
+(#14419), ``check_infra_scripts_undefined_names`` (#14405) and
+``check_bandit_exclude_anchoring`` (#14489): every one of these sites fails
+*quietly*, so a job that stops looking at them goes greener, not redder.
+``.github/workflows/code-quality.yml`` calls this module with ``--audit``, in the
+same shape as its siblings.
+
+WHY THE GUARD LANDS AFTER THE SWEEP. Written first it would have needed a
+32-entry baseline on day one, and this repository's experience with dormant
+exemption lists is that such a list becomes the permanent home of the very defect
+the guard exists for. The sweep landed first; this arrives with the tree already
+clean, so there is nothing to ratchet.
+
+THE EXEMPTIONS ARE DERIVED, NOT GRANDFATHERED. Three sites keep the literal on
+purpose and cannot be rewritten around it: ``compliance_manager`` must locate the
+junk tree the original bug created in order to migrate the audit records inside
+it (#13658), and two test files pin that behaviour. #13658 proved by test that
+hand-splitting the literal into components silently drops the ``}`` that belongs
+to ``code_source}``, producing a path that never matches — so "assemble it from
+fragments" is not available here the way it is for an ordinary fixture. Each
+exemption therefore names a **file, an anchor symbol and an exact site count**,
+and all three are re-proved on every run: an exemption whose file moved, whose
+anchor was renamed, or whose literal count changed fails the audit instead of
+quietly covering something new. A stranded exemption is a finding, not a pass.
+
+The audit reports how many files it reached and fails below a floor, because a
+sweep handed an empty file list reports a comfortable zero that is
+indistinguishable from success. An unparseable file fails for the same reason —
+skipping it would let a syntax error hide a placeholder.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import logging
+import pathlib
+import sys
+from dataclasses import dataclass
+
+# Plain stdlib logging, deliberately (#1082). This runs as a bare script inside a
+# lint job, and `autobot_shared.logging_manager` would drag config loading into
+# that path. Same trade as `tools/lint/check_infra_scripts_undefined_names.py`.
+logger = logging.getLogger(__name__)
+
+#: Repo-relative path of this checker, quoted in the messages that ask for an edit.
+SELF_REL = "tools/lint/check_no_shell_placeholder_paths.py"
+
+#: The canonical replacement every finding is told to use.
+RESOLVER = "autobot_shared.paths.project_root()"
+
+#: The banned text, assembled from fragments so this module does not report
+#: itself. A guard whose own source trips it either needs an exemption entry --
+#: the exact dormant-exemption shape #14517 exists to avoid -- or gets narrowed
+#: until it stops matching, which is worse.
+PLACEHOLDER = "${" + "AUTOBOT_PROJECT_ROOT"
+
+#: Directories that are never repository source.
+SKIP_DIRS = frozenset(
+    {
+        ".git",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".tox",
+        ".venv",
+        ".worktrees",
+        "__pycache__",
+        "build",
+        "dist",
+        "node_modules",
+        "venv",
+    }
+)
+
+#: Floor for the audit's own discovery. The repository held 4,986 tracked ``.py``
+#: files when this landed; a sweep that suddenly reaches a fraction of that has
+#: broken, and a clean result from a broken sweep asserts nothing.
+DISCOVERY_FLOOR = 4000
+
+
+@dataclass(frozen=True)
+class Exemption:
+    """One site that keeps the literal on purpose, with everything needed to re-prove it.
+
+    ``anchor`` is the symbol the literal is bound to (or the test that pins it).
+    ``sites`` is how many placeholder constants the file is allowed to hold. Both
+    are checked on every run: naming only the path would let the file be rewritten
+    around the exemption, and naming no count would let a fresh defect land inside
+    an already-exempt file and inherit its pass.
+    """
+
+    path: str
+    anchor: str
+    sites: int
+    reason: str
+
+
+#: The complete set. Every entry is justified in the module docstring; nothing is
+#: here because it was inconvenient to fix.
+EXEMPTIONS: tuple[Exemption, ...] = (
+    Exemption(
+        path="autobot-backend/security/enterprise/compliance_manager.py",
+        anchor="_LEGACY_AUDIT_ROOT",
+        sites=1,
+        reason=(
+            "the literal names the junk tree the original bug created; the migration "
+            "guard has to find it to avoid orphaning up to 2,555 days of encrypted "
+            "audit records (#13658)"
+        ),
+    ),
+    Exemption(
+        path="repo_tests/compliance_audit_path_test.py",
+        anchor="_PLACEHOLDER",
+        sites=2,
+        reason="pins the round trip that proves hand-splitting the literal drops a brace (#13658)",
+    ),
+    Exemption(
+        path="scripts/check_ansible_file_references_test.py",
+        anchor="test_paths_that_cannot_be_resolved_statically_are_skipped",
+        sites=1,
+        reason="a parametrised case asserting the ansible guard skips paths it cannot resolve statically",
+    ),
+)
+
+
+def repo_root() -> pathlib.Path:
+    """Repo root, derived from this file's location (``tools/lint/`` is two deep)."""
+    return pathlib.Path(__file__).resolve().parents[2]
+
+
+def discover_python_files(base: pathlib.Path | None = None) -> list[pathlib.Path]:
+    """Every ``*.py`` in the repository that is not build output or a nested checkout."""
+    base = base or repo_root()
+    return sorted(p for p in base.rglob("*.py") if not (set(p.relative_to(base).parts) & SKIP_DIRS))
+
+
+def _docstring_constant_ids(tree: ast.AST) -> set[int]:
+    """Identify every ``Constant`` that is a module/class/function docstring.
+
+    Prose describing this defect is not the defect. Excluding docstrings
+    structurally rather than by allowlisting the files that hold them is what
+    keeps ``autobot_shared/paths.py`` -- whose whole docstring is about this bug --
+    out of the findings without an exemption entry that could go stale.
+    """
+    holders = (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+    ids: set[int] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, holders):
+            continue
+        body = getattr(node, "body", None)
+        if not body:
+            continue
+        first = body[0]
+        if isinstance(first, ast.Expr) and isinstance(first.value, ast.Constant) and isinstance(first.value.value, str):
+            ids.add(id(first.value))
+    return ids
+
+
+def placeholder_sites(path: pathlib.Path) -> list[tuple[int, str]]:
+    """Every non-docstring string constant in *path* holding the placeholder.
+
+    Raises:
+        SyntaxError: the file does not parse. Deliberately propagated: a sweep
+            that skips what it cannot read reports a clean zero for it.
+    """
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    docstrings = _docstring_constant_ids(tree)
+    found = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Constant) or not isinstance(node.value, str):
+            continue
+        if PLACEHOLDER not in node.value or id(node) in docstrings:
+            continue
+        found.append((node.lineno, node.value.strip().splitlines()[0][:100]))
+    return sorted(found)
+
+
+def exemption_problems(base: pathlib.Path | None = None) -> list[str]:
+    """Re-prove every exemption still describes what it claims to describe.
+
+    An allowlist entry naming a moved file exempts nothing while still reading as
+    coverage, and an entry whose file grew a second literal silently covers a
+    fresh defect. Both are failures here, in the same direction as a finding.
+    """
+    base = base or repo_root()
+    problems = []
+    for exemption in EXEMPTIONS:
+        path = base / exemption.path
+        if not path.is_file():
+            problems.append(
+                f"{SELF_REL} exempts {exemption.path}, which does not exist. The file moved or "
+                "was deleted, so this entry now exempts nothing while still reading as coverage. "
+                "Repoint it or delete it."
+            )
+            continue
+        source = path.read_text(encoding="utf-8")
+        if exemption.anchor not in source:
+            problems.append(
+                f"{SELF_REL} exempts {exemption.path} for its `{exemption.anchor}`, which the file "
+                "no longer defines. A rename must not strand the exemption: update the anchor, or "
+                "drop the entry if the deliberate literal is gone."
+            )
+            continue
+        actual = len(placeholder_sites(path))
+        if actual == 0:
+            problems.append(
+                f"{SELF_REL} exempts {exemption.path}, which no longer holds any placeholder literal. "
+                "The exemption is dormant — delete it, so the file is guarded like every other."
+            )
+        elif actual != exemption.sites:
+            problems.append(
+                f"{SELF_REL} exempts {exemption.sites} placeholder literal(s) in {exemption.path}, "
+                f"but the file now holds {actual}. A new one inherited an existing exemption. "
+                f"Resolve the new site through {RESOLVER}, or justify and raise the count here."
+            )
+    return problems
+
+
+def _format_findings(findings: dict[str, list[tuple[int, str]]]) -> str:
+    lines = []
+    for rel in sorted(findings):
+        for lineno, text in findings[rel]:
+            lines.append(f"  {rel}:{lineno}  {text}")
+    return "\n".join(lines)
+
+
+def check_paths(paths: list[pathlib.Path], base: pathlib.Path) -> tuple[dict[str, list[tuple[int, str]]], list[str]]:
+    """Scan *paths*, skipping exempt files. Returns (findings by path, parse problems)."""
+    exempt = {e.path for e in EXEMPTIONS}
+    findings: dict[str, list[tuple[int, str]]] = {}
+    problems: list[str] = []
+    for path in paths:
+        rel = path.relative_to(base).as_posix()
+        if rel in exempt or rel == SELF_REL:
+            continue
+        try:
+            sites = placeholder_sites(path)
+        except SyntaxError as exc:
+            problems.append(
+                f"{rel} does not parse ({exc.msg} at line {exc.lineno}), so it could not be scanned. "
+                "A file the sweep cannot read is not a file the sweep found clean — fix the syntax."
+            )
+            continue
+        if sites:
+            findings[rel] = sites
+    return findings, problems
+
+
+def audit(base: pathlib.Path | None = None) -> tuple[int, list[str]]:
+    """Sweep the whole repository. Returns (files reached, problems)."""
+    base = base or repo_root()
+    problems: list[str] = []
+
+    files = discover_python_files(base)
+    if len(files) < DISCOVERY_FLOOR:
+        problems.append(
+            f"discovery returned only {len(files)} Python file(s) (floor {DISCOVERY_FLOOR}) — "
+            "the sweep broke, so a clean result below would assert nothing."
+        )
+
+    problems.extend(exemption_problems(base))
+
+    findings, parse_problems = check_paths(files, base)
+    problems.extend(parse_problems)
+    if findings:
+        total = sum(len(v) for v in findings.values())
+        problems.append(
+            f"{total} unexpanded shell placeholder(s) in Python string constants across "
+            f"{len(findings)} file(s):\n"
+            + _format_findings(findings)
+            + f"\n\nPython never expands shell syntax in a string literal, so each of these names a "
+            f"directory that cannot exist: reads return empty and writes create a junk tree literally "
+            f'named "{PLACEHOLDER}:-". Resolve each through {RESOLVER} — not through an open-coded '
+            f"os.environ.get, which is the same defect one layer down (#13149). {SELF_REL} carries no "
+            "growable baseline on purpose (#14517)."
+        )
+
+    return len(files), problems
+
+
+def configure_logging() -> None:
+    """Attach a stderr handler so findings actually reach the developer.
+
+    Run as a bare script the module logger has no handler, and logging's
+    last-resort path drops anything below WARNING.
+    """
+    if not logger.handlers:
+        handler = logging.StreamHandler(sys.stderr)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+
+
+def main(argv: list[str]) -> int:
+    configure_logging()
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--audit",
+        action="store_true",
+        help="sweep every Python file in the repository, not only the paths given",
+    )
+    parser.add_argument("paths", nargs="*", help="files to check")
+    args = parser.parse_args(argv)
+
+    base = repo_root()
+    if args.audit:
+        reached, problems = audit(base)
+        scope = f"{reached} Python file(s)"
+    elif args.paths:
+        selected = [pathlib.Path(p) if pathlib.Path(p).is_absolute() else base / p for p in args.paths]
+        findings, problems = check_paths([p for p in selected if p.suffix == ".py" and p.is_file()], base)
+        if findings:
+            problems.append(
+                "unexpanded shell placeholder(s) in the given files:\n"
+                + _format_findings(findings)
+                + f"\n\nResolve each through {RESOLVER} (#14517)."
+            )
+        reached = len(selected)
+        scope = f"{reached} given file(s)"
+    else:
+        parser.error("nothing to do — pass --audit or one or more paths")
+
+    if problems:
+        logger.error("%s", "\n\n".join(problems))
+        logger.error("\nshell-placeholder audit FAILED over %s (#14517).", scope)
+        return 1
+    logger.info("shell-placeholder audit clean over %s (#14517).", scope)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tools/lint/check_no_shell_placeholder_paths_test.py
+++ b/tools/lint/check_no_shell_placeholder_paths_test.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Discrimination tests for the #14517 shell-placeholder guard.
+
+Every fixture assembles the banned text from fragments rather than quoting it, so
+this file does not trip the guard it tests and needs no exemption entry of its
+own. That is the whole point: a test that had to be allowlisted would be the
+first dormant exemption (#14517).
+"""
+
+from __future__ import annotations
+
+import pathlib
+import textwrap
+
+import pytest
+
+from tools.lint import check_no_shell_placeholder_paths as guard
+
+#: The full literal the sweep removed, never written out in one piece here.
+FULL = guard.PLACEHOLDER + ":-/opt/autobot/code_source}"
+
+
+def _tree(base: pathlib.Path, files: dict[str, str]) -> pathlib.Path:
+    for rel, body in files.items():
+        path = base / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(textwrap.dedent(body), encoding="utf-8")
+    return base
+
+
+def _padding(count: int) -> dict[str, str]:
+    """Enough clean modules to clear the discovery floor."""
+    return {f"pad/mod_{i}.py": "VALUE = 1\n" for i in range(count)}
+
+
+def _exempt_files() -> dict[str, str]:
+    """The three deliberate sites, reproduced with the anchors and counts the guard expects."""
+    return {
+        "autobot-backend/security/enterprise/compliance_manager.py": (
+            f'_LEGACY_AUDIT_ROOT = "{FULL}/logs/audit"\n'
+        ),
+        "repo_tests/compliance_audit_path_test.py": (
+            f'_PLACEHOLDER = "{FULL}/logs/audit"\nHAND = "{guard.PLACEHOLDER}:-"\n'
+        ),
+        "scripts/check_ansible_file_references_test.py": (
+            "def test_paths_that_cannot_be_resolved_statically_are_skipped():\n"
+            f'    assert "{FULL}/"\n'
+        ),
+    }
+
+
+def _clean_base(tmp_path: pathlib.Path) -> pathlib.Path:
+    return _tree(tmp_path, {**_padding(guard.DISCOVERY_FLOOR), **_exempt_files()})
+
+
+def test_a_clean_tree_passes(tmp_path):
+    reached, problems = guard.audit(_clean_base(tmp_path))
+
+    assert problems == []
+    assert reached >= guard.DISCOVERY_FLOOR
+
+
+def test_a_plain_string_constant_is_reported(tmp_path):
+    base = _clean_base(tmp_path)
+    _tree(base, {"svc/paths.py": f'REPORTS = "{FULL}/reports"\n'})
+
+    _, problems = guard.audit(base)
+
+    assert any("svc/paths.py:1" in p for p in problems)
+    assert any(guard.RESOLVER in p for p in problems)
+
+
+def test_a_docstring_describing_the_defect_is_not_reported(tmp_path):
+    base = _clean_base(tmp_path)
+    _tree(base, {"svc/doc.py": f'"""Fixed: this used to read {FULL}/logs."""\n\nVALUE = 1\n'})
+
+    _, problems = guard.audit(base)
+
+    assert problems == []
+
+
+def test_a_docstring_does_not_shield_a_constant_in_the_same_file(tmp_path):
+    """The docstring exclusion is structural, so it must not extend to the module body."""
+    base = _clean_base(tmp_path)
+    _tree(base, {"svc/both.py": f'"""Explains {FULL}."""\n\nBAD = "{FULL}/logs"\n'})
+
+    _, problems = guard.audit(base)
+
+    assert any("svc/both.py:3" in p for p in problems)
+
+
+def test_an_empty_enumeration_fails_rather_than_reading_clean(tmp_path):
+    """A sweep that reaches nothing must never be indistinguishable from a clean sweep."""
+    reached, problems = guard.audit(_tree(tmp_path, {}))
+
+    assert reached == 0
+    assert any("floor" in p and "assert nothing" in p for p in problems)
+
+
+def test_a_sweep_far_below_the_floor_fails(tmp_path):
+    reached, problems = guard.audit(_tree(tmp_path, _padding(5)))
+
+    assert reached == 5
+    assert any(f"floor {guard.DISCOVERY_FLOOR}" in p for p in problems)
+
+
+def test_an_unparseable_file_fails_instead_of_being_skipped(tmp_path):
+    base = _clean_base(tmp_path)
+    _tree(base, {"svc/broken.py": "def f(:\n"})
+
+    _, problems = guard.audit(base)
+
+    assert any("svc/broken.py does not parse" in p for p in problems)
+
+
+def test_an_exemption_whose_file_moved_fails(tmp_path):
+    base = _clean_base(tmp_path)
+    (base / "repo_tests/compliance_audit_path_test.py").unlink()
+
+    _, problems = guard.audit(base)
+
+    assert any("does not exist" in p and "compliance_audit_path_test.py" in p for p in problems)
+
+
+def test_an_exemption_whose_anchor_was_renamed_fails(tmp_path):
+    base = _clean_base(tmp_path)
+    target = base / "autobot-backend/security/enterprise/compliance_manager.py"
+    target.write_text(f'_RENAMED_AUDIT_ROOT = "{FULL}/logs/audit"\n', encoding="utf-8")
+
+    _, problems = guard.audit(base)
+
+    assert any("_LEGACY_AUDIT_ROOT" in p and "no longer defines" in p for p in problems)
+
+
+def test_an_exemption_that_grew_a_second_literal_fails(tmp_path):
+    """A fresh defect must not inherit an existing file's exemption."""
+    base = _clean_base(tmp_path)
+    target = base / "autobot-backend/security/enterprise/compliance_manager.py"
+    target.write_text(
+        f'_LEGACY_AUDIT_ROOT = "{FULL}/logs/audit"\nNEW_DEFECT = "{FULL}/reports"\n',
+        encoding="utf-8",
+    )
+
+    _, problems = guard.audit(base)
+
+    assert any("now holds 2" in p for p in problems)
+
+
+def test_a_dormant_exemption_fails(tmp_path):
+    """An exemption whose literal is gone is deleted, not left reading as coverage."""
+    base = _clean_base(tmp_path)
+    target = base / "scripts/check_ansible_file_references_test.py"
+    target.write_text(
+        "def test_paths_that_cannot_be_resolved_statically_are_skipped():\n    assert True\n",
+        encoding="utf-8",
+    )
+
+    _, problems = guard.audit(base)
+
+    assert any("dormant" in p for p in problems)
+
+
+@pytest.mark.parametrize("rel", [e.path for e in guard.EXEMPTIONS])
+def test_every_exemption_describes_the_real_repository(rel):
+    """The recorded path, anchor and site count are re-proved against the live tree."""
+    assert (guard.repo_root() / rel).is_file()
+    assert guard.exemption_problems() == []
+
+
+def test_the_live_repository_is_clean():
+    reached, problems = guard.audit()
+
+    assert problems == [], "\n\n".join(problems)
+    assert reached >= guard.DISCOVERY_FLOOR
+
+
+def test_the_guard_does_not_need_an_exemption_for_itself():
+    """A guard that trips its own rule would be the first entry on its own list."""
+    assert guard.SELF_REL not in {e.path for e in guard.EXEMPTIONS}
+    assert guard.placeholder_sites(guard.repo_root() / guard.SELF_REL) == []
+    assert guard.placeholder_sites(pathlib.Path(__file__)) == []


### PR DESCRIPTION
Closes #14517

## Thinking Path

A shell placeholder pasted into a **plain** Python string constant is never expanded, so the value names a directory whose first component is the literal text `${AUTOBOT_PROJECT_ROOT:-`. Reads through it return an empty list and writes either raise on the missing parent or build a junk tree named after the expression. #14504 could only reach the *f-string* form of this, because that produces an F821; a plain literal is reported by no flake8 code, no bandit check and no type checker.

**Re-measured before trusting the issue's count.** An AST sweep for `ast.Constant` string values (not grep — grep undercounts on indentation and quoting and overcounts docstrings) found **36 sites**, of which 4 are the deliberate ones the issue names: `compliance_manager.py`'s `_LEGACY_AUDIT_ROOT` (#13658) and 3 fixture sites across 2 test files. **32 defects, in 25 files — exactly the issue's number**, and the split matches too: 26 sites in 21 files under `shared/scripts/`, 6 under `shared/tests/`. The sweep separately reports 6 docstring hits and excludes them structurally; #14520's author hit one of those as an apparent extra.

The sweep's *first* run returned 0 hits, because its skip list matched `.worktrees` against absolute path parts and every file in a worktree is under that name. It was fixed by matching root-relative parts, and the count reconciled afterwards. Worth recording: an empty enumeration read as a clean tree, which is precisely the failure the guard below is built to refuse.

Two structural decisions came out of the sites themselves:

- **Locals were renamed to `root`, not left as `project_root`.** Eleven sites assigned to a name identical to the resolver. `project_root = project_root()` makes the name function-local for the whole function, so the call on the right-hand side raises `UnboundLocalError` — verified, not assumed (evidence below). Function *parameters* named `project_root` are untouched; only the assignments moved.
- **`run_code_analysis.py` already bound a module-level `project_root`** to `Path(__file__).parent.parent` — `autobot-infrastructure/shared`, not the project root. It read as the canonical resolver and was not. Renamed to `_SHARED_DIR`; its **value is deliberately unchanged**, because the scripts it addresses live at no path in this repo (filed, see below).

**The deliberate literal is preserved.** `autobot-backend/security/enterprise/compliance_manager.py:87` keeps `${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}/logs/audit`: it has to locate the junk tree the original bug created in order to migrate up to 2,555 days of encrypted audit records, and #13658 proved by test that hand-splitting the literal drops the `}` belonging to `code_source}` and yields a path that never matches. The two test files that pin that behaviour keep their literals for the same reason. All three are named in the guard, and named in a way that a rename cannot strand.

**The guard lands after the sweep, deliberately.** Written first it would have needed a 32-entry baseline, and a baseline is where the defect a guard exists for goes to live permanently.

## What Changed

**The sweep — 32 sites, 25 files, all through `autobot_shared.paths.project_root()`** (never an open-coded `os.environ.get`):

- 26 sites under `autobot-infrastructure/shared/scripts/` across 21 files
- 6 sites under `autobot-infrastructure/shared/tests/` across 4 files

Repairing the path made several call sites genuinely reachable for the first time, and each needed the code behind it to be correct:

| site | what the fix reaches |
|---|---|
| `utilities/init_memory_graph_redis.py` | the `FileHandler` ran at **import** time, so the whole module was dead. A resolved path makes it live, and a fresh checkout has no `logs/` at all — `FileHandler` does not create parents — so the directory is now created first, and the handler is given `encoding="utf-8"` |
| `tests/ci_cd_integration.py`, `tests/comprehensive_test_suite.py`, `tests/performance/test_performance_optimization.py` | `results_dir.mkdir(exist_ok=True)` without `parents=True` would now raise `FileNotFoundError`: the resolved parent (`tests/`) does not exist in a checkout, where the junk-tree parent used to. All three take `parents=True` |
| `tests/ci_cd_integration.py` (`cwd=`) | a non-existent `cwd` makes `subprocess.run` raise before the stage command starts, which the surrounding `except` reported as an ordinary stage failure |
| `optimize_agents.py` | `.claude/agents` exists, so the script now really rewrites those files instead of exiting 1. Its `read_text`/`write_text` gained explicit `encoding="utf-8"` |
| `utilities/enhance_workflow_ui.py`, `utilities/npu_worker_design.py` | `open(...)` used to raise `FileNotFoundError`; these generators have never once produced their output file. Neither write target exists in the tree, so nothing is clobbered |
| `analyze_duplicates.py`, `system_assessment_report.py` | both guarded the path with an `os.path.exists` check that could only ever fail, turning every run into an early "directory not found" return / a HIGH-severity false finding |
| `test_long_running_operations.py` | the two demo targets named `src/utils` and `tests/unit`, neither of which exists in this repo; repointed at `autobot_shared/` and `repo_tests/` |
| the 9 KB/doc ingest and upload scripts | every glob matched nothing and each run reported "Found 0 documentation files" as success |

Incidental to the above and required by it: 3 now-unused `from pathlib import Path` imports removed, one redundant function-local `from pathlib import Path` removed, and a duplicated report path in `redis_final_analysis.py` collapsed to one `_REPORT_REL` constant so the writer and the message telling the operator where to look cannot drift.

**The guard — `tools/lint/check_no_shell_placeholder_paths.py`**, wired into `code-quality` (a required check) with `--audit`, following `check_flake8_exclude_anchoring.py`, `check_bandit_exclude_anchoring.py` and `check_infra_scripts_undefined_names.py`. No job or check-run name changed.

- **No growable baseline.** The tree is clean, so there is nothing to ratchet.
- **Docstrings are excluded structurally, not by path.** That is what keeps `autobot_shared/paths.py` — whose entire docstring is about this bug — out of the findings without an allowlist entry that could go stale.
- **The three deliberate sites are re-proved every run** by path, **anchor symbol** and **exact site count**. An exemption whose file moved, whose anchor was renamed, whose literal is gone, or whose file grew a *second* literal fails the audit rather than quietly covering something new. A stranded exemption is a finding, not a pass.
- **It fails on an empty enumeration** (discovery floor 4,000 against 4,990 files today) and **fails on an unparseable file** rather than skipping it — a file the sweep cannot read is not a file the sweep found clean.
- **It self-guards**: the banned needle is assembled from fragments, so the module does not report itself and needs no entry on its own list. Its test file does the same.

## Verification

**Measured count reconciles with the issue.** AST sweep on the pre-fix tree: 36 constant hits − 1 deliberate (`compliance_manager.py`) − 3 fixtures = **32**, in 25 files; 26 under `shared/scripts/` (21 files), 6 under `shared/tests/`. 6 further hits are docstrings, excluded structurally. Post-fix sweep: exactly the 4 deliberate hits remain.

**The guard discriminates.** Run against a clean extraction of the pre-fix base and against the fixed tree:

```
PRE-FIX (base tip, extracted to a scratch tree):
  reached=4988  verdict=FAIL  findings=32 sites across 25 files
POST-FIX (this branch):
  reached=4990  verdict=PASS  (shell-placeholder audit clean)
EMPTY TREE (the empty-enumeration case):
  reached=0     verdict=FAIL
  "discovery returned only 0 Python file(s) (floor 4000) — the sweep broke,
   so a clean result below would assert nothing."
```

The pre-fix count the guard reports (32) is derived independently of the sweep script and lands on the same number.

**16 discrimination tests**, all passing (`tools/lint/check_no_shell_placeholder_paths_test.py`), each asserting the guard *fails* on a specific way it could fail open: a plain constant is reported; a docstring is not; a docstring does **not** shield a constant in the same file; an empty tree fails; a tree far below the floor fails; an unparseable file fails; an exemption whose file moved fails; whose anchor was renamed fails; that grew a second literal fails; that went dormant fails; and the guard does not need an exemption for itself. Every fixture assembles the banned text from fragments, so the test file does not trip the guard it tests.

**Execution evidence** (standalone copies under a scratch directory, never the repo's own modules — output verbatim):

```
1a. broken path parts: ('${AUTOBOT_PROJECT_ROOT:-', 'opt')
1b. mkdir(exist_ok=True) -> FileNotFoundError: No such file or directory
1c. mkdir(parents=True) created junk tree: ['${AUTOBOT_PROJECT_ROOT:-']
1d. rglob('*') over the broken read path yields: [] (silent empty)
2a. project_root() -> True
2b. resolved dir exists: True | under tmp: True
3a. shadowing form -> UnboundLocalError: local variable 'project_root' referenced before assignment
3b. renamed form -> /tmp
```

Line 3a is why the eleven locals were renamed rather than left alone; the naive fix would have replaced a silent empty result with a hard `UnboundLocalError`.

**Static checks on the changed files:** `flake8 --select=F401,F811,F821,F841` clean for everything this branch introduced (the 3 remaining `F841`s are pre-existing and untouched); `py_compile` clean across all 25; `code-quality.yml` parses as YAML with both jobs intact. Pre-commit ran on both commits; nothing was bypassed.

**Filed rather than absorbed:**

- **#14543** — `run_code_analysis.py` shells out to five scripts under `tools/code-analysis-suite/`, a directory that exists **nowhere** in the repo. Every analysis returns `{"error": "Script not found"}` and `main()` folds those five errors into a report it prints as a completed run. The placeholder fix and the `project_root` → `_SHARED_DIR` rename are what made this visible.
- **#14544** — 18 `sys.path` bootstraps across 16 files open-code the root as `os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source")`. Not a straight substitution: those lines run so that first-party packages become importable, so routing them through `autobot_shared.paths` makes the file depend on `autobot_shared` being importable *before* the line that arranges imports. They were left alone here rather than reordering a bootstrap on no evidence. With the variable unset — the normal case in a checkout — that fallback resolves to the live deployed install, the same failure #13092 fixed for one shell script.
- The `from knowledge_base import ...` failures in several of these scripts are **already** covered by #14518 and were not re-filed.

## Model Used

Claude Opus 5 (1M context)
