### PR TITLE
feat(llc/frontend): the process canvas can attach and detach workflows (#14549)

### DIFF
--- a/autobot-frontend/src/components/workflow/WorkflowCanvas.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowCanvas.vue
@@ -194,6 +194,19 @@
               >{{ nodeText(node, 'workflow_id') }}</p>
               <div class="org-meta">
                 <span class="process-role">{{ nodeText(node, 'role_name') }}</span>
+                <!-- #14549: the canvas shows the attachment but could not
+                     change it. `.stop` keeps the click from also selecting the
+                     node, which would navigate to the workflow builder — the
+                     mutation itself is OrgChart.vue's job, reached by event. -->
+                <button
+                  type="button"
+                  class="process-detach-btn"
+                  data-testid="process-detach-btn"
+                  :aria-label="processDetachLabel(node)"
+                  @click.stop="emit('process-detached', nodeText(node, 'role_id'), nodeText(node, 'workflow_id'))"
+                >
+                  <Icon name="times" />
+                </button>
               </div>
             </template>
             <!-- GH#13939: Company OS org nodes are read-only descriptors -->
@@ -311,6 +324,10 @@ const emit = defineEmits<{
   (e: 'nodes-connected', src: string, tgt: string): void;
   (e: 'save-workflow', name: string, desc: string): void;
   (e: 'tab-selected', tabId: string): void;
+  // #14549: an org-process node's own detach control. Emitted rather than
+  // called against the API directly — this component is shared with real
+  // workflow editing and must stay ignorant of the LLC endpoints.
+  (e: 'process-detached', roleId: string, workflowId: string): void;
 }>();
 
 const showVisionDropdown = ref(false);
@@ -372,6 +389,20 @@ function nodeText(node: CanvasNode, key: string): string {
  *  flag read through it is always falsy and can never gate anything (GH#13936). */
 function nodeFlag(node: CanvasNode, key: string): boolean {
   return (node.data as Record<string, unknown>)[key] === true;
+}
+
+/**
+ * Accessible name for the detach control (#14549).
+ *
+ * The node's only visible text is a bare workflow id and role name — a
+ * screen reader landing on a bare "×" button would not know what it detaches.
+ * Mirrors the `processOpensWorkflow` description pattern already on this node.
+ */
+function processDetachLabel(node: CanvasNode): string {
+  return t('llc.orgChart.processDetach', {
+    workflow: nodeText(node, 'workflow_id'),
+    role: nodeText(node, 'role_name'),
+  });
 }
 
 /**
@@ -796,5 +827,23 @@ function confirmSave() { emit('save-workflow', saveName.value, saveDesc.value); 
   font-size: 0.75rem;
   color: var(--color-text-secondary);
   font-family: var(--font-family-mono, monospace);
+}
+.process-detach-btn {
+  margin-inline-start: auto;
+  padding: var(--spacing-1);
+  background: transparent;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  border-radius: var(--radius-default);
+  line-height: 1;
+}
+.process-detach-btn:hover {
+  color: var(--color-error);
+  background: var(--bg-hover);
+}
+.process-detach-btn:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
 }
 </style>

--- a/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.processNodeDetach.test.ts
+++ b/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.processNodeDetach.test.ts
@@ -1,0 +1,79 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// #14549: the process node's own detach control. It must not call the API
+// itself — `WorkflowCanvas.vue` is shared with real workflow editing — and it
+// must not hijack the node's own click, which navigates to the workflow
+// builder (`OrgChart.vue`'s `onCanvasNodeSelected`).
+
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import en from '@/i18n/locales/en.json'
+import ar from '@/i18n/locales/ar.json'
+
+import WorkflowCanvas from '../WorkflowCanvas.vue'
+import { buildProcessCanvasNodes } from '@/composables/llc/orgCanvasGraph'
+
+const PROCESS_NODES = buildProcessCanvasNodes(
+  [{ role_id: 'role-1', role_name: 'Head of Ops', workflow_id: 'wf-1' }],
+  0,
+)
+
+function mountCanvas(locale: 'en' | 'ar' = 'en') {
+  const i18n = createI18n({
+    legacy: false,
+    locale,
+    fallbackLocale: 'en',
+    messages: { en, ar },
+  })
+  return mount(WorkflowCanvas, {
+    props: { nodes: PROCESS_NODES, selectedNodeId: null, readonly: true },
+    global: { plugins: [i18n] },
+  })
+}
+
+describe('org-process node detach control (#14549)', () => {
+  it('emits process-detached with the role and workflow id, not node-selected', async () => {
+    const wrapper = mountCanvas()
+
+    await wrapper.find('[data-testid="process-detach-btn"]').trigger('click')
+
+    expect(wrapper.emitted('process-detached')).toEqual([['role-1', 'wf-1']])
+    // The click must not have bubbled to the node's own click handler, which
+    // would have selected it and (in OrgChart.vue) navigated away.
+    expect(wrapper.emitted('node-selected')).toBeUndefined()
+  })
+
+  it('renders regardless of the readonly prop', () => {
+    // OrgChart.vue always mounts this canvas `readonly` (view-only authoring
+    // controls). The detach control is an LLC action, not an authoring one,
+    // and must not be gated behind the same flag as `addStepNode`/`deleteNode`.
+    const wrapper = mountCanvas()
+
+    expect(wrapper.find('[data-testid="process-detach-btn"]').exists()).toBe(true)
+  })
+
+  it('names the workflow and role in its accessible name', () => {
+    const wrapper = mountCanvas()
+    const expected = (en as { llc: { orgChart: { processDetach: string } } }).llc.orgChart
+      .processDetach
+      .replace('{workflow}', 'wf-1')
+      .replace('{role}', 'Head of Ops')
+
+    expect(wrapper.find('[data-testid="process-detach-btn"]').attributes('aria-label')).toBe(
+      expected,
+    )
+  })
+
+  it('names the workflow and role in a non-English (RTL) locale', () => {
+    const wrapper = mountCanvas('ar')
+    const expected = (ar as { llc: { orgChart: { processDetach: string } } }).llc.orgChart
+      .processDetach
+      .replace('{workflow}', 'wf-1')
+      .replace('{role}', 'Head of Ops')
+
+    expect(wrapper.find('[data-testid="process-detach-btn"]').attributes('aria-label')).toBe(
+      expected,
+    )
+  })
+})

--- a/autobot-frontend/src/composables/llc/apiErrorMessage.ts
+++ b/autobot-frontend/src/composables/llc/apiErrorMessage.ts
@@ -1,0 +1,22 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+/**
+ * describeApiError (#14549)
+ *
+ * Extracted out of `RolesView.vue`'s local `describeError` so `OrgChart.vue`
+ * can surface the same server reason on a failed mutation instead of
+ * reinventing the extraction (repo rule 2: reuse, never fork).
+ *
+ * `ApiClient` throws a plain `Error` whose message is already
+ * `HTTP <status>: <detail>` — it extracts `detail` itself
+ * (`utils/ApiClient.ts` `_extractErrorInfo`). It is NOT axios-shaped, so
+ * reading `error.response.data.detail` would silently always miss and this
+ * function would return the fallback every time while looking like it
+ * worked.
+ */
+export function describeApiError(error: unknown, fallback: string): string {
+  const message = error instanceof Error ? error.message : ''
+  return message.length > 0 ? message : fallback
+}

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -8306,7 +8306,8 @@
       "attachWorkflowPlaceholder": "معرّف سير العمل",
       "attachError": "تعذّر إرفاق سير العمل هذا.",
       "detachError": "تعذّرت إزالة سير العمل هذا.",
-      "processDetach": "إزالة {workflow} من {role}"
+      "processDetach": "إزالة {workflow} من {role}",
+      "attachRolesUnavailable": "تعذّر تحميل الأدوار، لذا قد تكون هذه القائمة غير مكتملة."
     },
     "executorRollup": {
       "title": "ملخص المنفذين",

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -8298,7 +8298,15 @@
         "handoffNotApplicableHuman": "يُطبَّق التسليم على الوكلاء فقط."
       },
       "processNodeLabel": "عملية",
-      "processOpensWorkflow": "يفتح سير العمل الذي يشغّله هذا الدور"
+      "processOpensWorkflow": "يفتح سير العمل الذي يشغّله هذا الدور",
+      "attach": "إرفاق",
+      "attachRoleLabel": "الدور",
+      "attachRolePlaceholder": "اختر دورًا…",
+      "attachWorkflowLabel": "معرّف سير العمل",
+      "attachWorkflowPlaceholder": "معرّف سير العمل",
+      "attachError": "تعذّر إرفاق سير العمل هذا.",
+      "detachError": "تعذّرت إزالة سير العمل هذا.",
+      "processDetach": "إزالة {workflow} من {role}"
     },
     "executorRollup": {
       "title": "ملخص المنفذين",

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -8298,7 +8298,15 @@
         "handoffNotApplicableHuman": "Übergabe gilt nur für Agenten."
       },
       "processNodeLabel": "Prozess",
-      "processOpensWorkflow": "Öffnet den Workflow dieser Rolle"
+      "processOpensWorkflow": "Öffnet den Workflow dieser Rolle",
+      "attach": "Zuordnen",
+      "attachRoleLabel": "Rolle",
+      "attachRolePlaceholder": "Rolle auswählen…",
+      "attachWorkflowLabel": "Workflow-ID",
+      "attachWorkflowPlaceholder": "Workflow-ID",
+      "attachError": "Dieser Workflow konnte nicht zugeordnet werden.",
+      "detachError": "Dieser Workflow konnte nicht entfernt werden.",
+      "processDetach": "{workflow} von {role} entfernen"
     },
     "executorRollup": {
       "title": "Ausführungs-Übersicht",

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -8306,7 +8306,8 @@
       "attachWorkflowPlaceholder": "Workflow-ID",
       "attachError": "Dieser Workflow konnte nicht zugeordnet werden.",
       "detachError": "Dieser Workflow konnte nicht entfernt werden.",
-      "processDetach": "{workflow} von {role} entfernen"
+      "processDetach": "{workflow} von {role} entfernen",
+      "attachRolesUnavailable": "Rollen konnten nicht geladen werden, daher ist diese Liste möglicherweise unvollständig."
     },
     "executorRollup": {
       "title": "Ausführungs-Übersicht",

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -8286,7 +8286,15 @@
         "handoffNotApplicableHuman": "Handoff applies to agents only."
       },
       "processNodeLabel": "Process",
-      "processOpensWorkflow": "Opens the workflow this role runs"
+      "processOpensWorkflow": "Opens the workflow this role runs",
+      "attach": "Attach",
+      "attachRoleLabel": "Role",
+      "attachRolePlaceholder": "Choose a role…",
+      "attachWorkflowLabel": "Workflow id",
+      "attachWorkflowPlaceholder": "Workflow id",
+      "attachError": "Could not attach that workflow.",
+      "detachError": "Could not detach that workflow.",
+      "processDetach": "Detach {workflow} from {role}"
     },
     "executorRollup": {
       "title": "Executor Rollup",

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -8294,7 +8294,8 @@
       "attachWorkflowPlaceholder": "Workflow id",
       "attachError": "Could not attach that workflow.",
       "detachError": "Could not detach that workflow.",
-      "processDetach": "Detach {workflow} from {role}"
+      "processDetach": "Detach {workflow} from {role}",
+      "attachRolesUnavailable": "Roles could not be loaded, so this list may be incomplete."
     },
     "executorRollup": {
       "title": "Executor Rollup",

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -8306,7 +8306,8 @@
       "attachWorkflowPlaceholder": "ID del flujo",
       "attachError": "No se pudo adjuntar ese flujo.",
       "detachError": "No se pudo quitar ese flujo.",
-      "processDetach": "Quitar {workflow} de {role}"
+      "processDetach": "Quitar {workflow} de {role}",
+      "attachRolesUnavailable": "No se pudieron cargar los roles, por lo que esta lista puede estar incompleta."
     },
     "executorRollup": {
       "title": "Resumen de ejecutores",

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -8298,7 +8298,15 @@
         "handoffNotApplicableHuman": "El traspaso se aplica solo a agentes."
       },
       "processNodeLabel": "Proceso",
-      "processOpensWorkflow": "Abre el flujo que ejecuta este rol"
+      "processOpensWorkflow": "Abre el flujo que ejecuta este rol",
+      "attach": "Adjuntar",
+      "attachRoleLabel": "Rol",
+      "attachRolePlaceholder": "Elegir un rol…",
+      "attachWorkflowLabel": "ID del flujo",
+      "attachWorkflowPlaceholder": "ID del flujo",
+      "attachError": "No se pudo adjuntar ese flujo.",
+      "detachError": "No se pudo quitar ese flujo.",
+      "processDetach": "Quitar {workflow} de {role}"
     },
     "executorRollup": {
       "title": "Resumen de ejecutores",

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -8306,7 +8306,8 @@
       "attachWorkflowPlaceholder": "شناسه گردش‌کار",
       "attachError": "پیوست کردن این گردش‌کار ممکن نشد.",
       "detachError": "جدا کردن این گردش‌کار ممکن نشد.",
-      "processDetach": "جدا کردن {workflow} از {role}"
+      "processDetach": "جدا کردن {workflow} از {role}",
+      "attachRolesUnavailable": "نقش‌ها بارگیری نشدند، بنابراین این فهرست ممکن است ناقص باشد."
     },
     "executorRollup": {
       "title": "خلاصه مجریان",

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -8298,7 +8298,15 @@
         "handoffNotApplicableHuman": "واگذاری فقط برای عامل‌ها اعمال می‌شود."
       },
       "processNodeLabel": "فرایند",
-      "processOpensWorkflow": "گردش‌کار این نقش را باز می‌کند"
+      "processOpensWorkflow": "گردش‌کار این نقش را باز می‌کند",
+      "attach": "پیوست",
+      "attachRoleLabel": "نقش",
+      "attachRolePlaceholder": "یک نقش انتخاب کنید…",
+      "attachWorkflowLabel": "شناسه گردش‌کار",
+      "attachWorkflowPlaceholder": "شناسه گردش‌کار",
+      "attachError": "پیوست کردن این گردش‌کار ممکن نشد.",
+      "detachError": "جدا کردن این گردش‌کار ممکن نشد.",
+      "processDetach": "جدا کردن {workflow} از {role}"
     },
     "executorRollup": {
       "title": "خلاصه مجریان",

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -8298,7 +8298,15 @@
         "handoffNotApplicableHuman": "Le transfert s'applique uniquement aux agents."
       },
       "processNodeLabel": "Processus",
-      "processOpensWorkflow": "Ouvre le workflow de ce rôle"
+      "processOpensWorkflow": "Ouvre le workflow de ce rôle",
+      "attach": "Associer",
+      "attachRoleLabel": "Rôle",
+      "attachRolePlaceholder": "Choisir un rôle…",
+      "attachWorkflowLabel": "ID du workflow",
+      "attachWorkflowPlaceholder": "ID du workflow",
+      "attachError": "Impossible d'associer ce workflow.",
+      "detachError": "Impossible de détacher ce workflow.",
+      "processDetach": "Détacher {workflow} de {role}"
     },
     "executorRollup": {
       "title": "Récapitulatif des exécutants",

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -8306,7 +8306,8 @@
       "attachWorkflowPlaceholder": "ID du workflow",
       "attachError": "Impossible d'associer ce workflow.",
       "detachError": "Impossible de détacher ce workflow.",
-      "processDetach": "Détacher {workflow} de {role}"
+      "processDetach": "Détacher {workflow} de {role}",
+      "attachRolesUnavailable": "Les rôles n'ont pas pu être chargés, cette liste peut donc être incomplète."
     },
     "executorRollup": {
       "title": "Récapitulatif des exécutants",

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -8306,7 +8306,8 @@
       "attachWorkflowPlaceholder": "מזהה תהליך",
       "attachError": "לא ניתן היה לצרף תהליך זה.",
       "detachError": "לא ניתן היה להסיר תהליך זה.",
-      "processDetach": "הסר את {workflow} מ-{role}"
+      "processDetach": "הסר את {workflow} מ-{role}",
+      "attachRolesUnavailable": "לא ניתן היה לטעון את התפקידים, ולכן ייתכן שרשימה זו חלקית."
     },
     "executorRollup": {
       "title": "סיכום מבצעים",

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -8298,7 +8298,15 @@
         "handoffNotApplicableHuman": "ההעברה חלה על סוכנים בלבד."
       },
       "processNodeLabel": "תהליך",
-      "processOpensWorkflow": "פותח את התהליך שתפקיד זה מריץ"
+      "processOpensWorkflow": "פותח את התהליך שתפקיד זה מריץ",
+      "attach": "צרף",
+      "attachRoleLabel": "תפקיד",
+      "attachRolePlaceholder": "בחר תפקיד…",
+      "attachWorkflowLabel": "מזהה תהליך",
+      "attachWorkflowPlaceholder": "מזהה תהליך",
+      "attachError": "לא ניתן היה לצרף תהליך זה.",
+      "detachError": "לא ניתן היה להסיר תהליך זה.",
+      "processDetach": "הסר את {workflow} מ-{role}"
     },
     "executorRollup": {
       "title": "סיכום מבצעים",

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -8306,7 +8306,8 @@
       "attachWorkflowPlaceholder": "Darbplūsmas ID",
       "attachError": "Neizdevās pievienot šo darbplūsmu.",
       "detachError": "Neizdevās noņemt šo darbplūsmu.",
-      "processDetach": "Noņemt {workflow} no {role}"
+      "processDetach": "Noņemt {workflow} no {role}",
+      "attachRolesUnavailable": "Lomas neizdevās ielādēt, tāpēc šis saraksts var būt nepilnīgs."
     },
     "executorRollup": {
       "title": "Izpildītāju kopsavilkums",

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -8298,7 +8298,15 @@
         "handoffNotApplicableHuman": "Nodošana attiecas tikai uz aģentiem."
       },
       "processNodeLabel": "Process",
-      "processOpensWorkflow": "Atver šīs lomas darbplūsmu"
+      "processOpensWorkflow": "Atver šīs lomas darbplūsmu",
+      "attach": "Pievienot",
+      "attachRoleLabel": "Loma",
+      "attachRolePlaceholder": "Izvēlieties lomu…",
+      "attachWorkflowLabel": "Darbplūsmas ID",
+      "attachWorkflowPlaceholder": "Darbplūsmas ID",
+      "attachError": "Neizdevās pievienot šo darbplūsmu.",
+      "detachError": "Neizdevās noņemt šo darbplūsmu.",
+      "processDetach": "Noņemt {workflow} no {role}"
     },
     "executorRollup": {
       "title": "Izpildītāju kopsavilkums",

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -8298,7 +8298,15 @@
         "handoffNotApplicableHuman": "Przekazanie dotyczy tylko agentów."
       },
       "processNodeLabel": "Proces",
-      "processOpensWorkflow": "Otwiera przepływ tej roli"
+      "processOpensWorkflow": "Otwiera przepływ tej roli",
+      "attach": "Dołącz",
+      "attachRoleLabel": "Rola",
+      "attachRolePlaceholder": "Wybierz rolę…",
+      "attachWorkflowLabel": "ID przepływu",
+      "attachWorkflowPlaceholder": "ID przepływu",
+      "attachError": "Nie udało się dołączyć tego przepływu.",
+      "detachError": "Nie udało się odłączyć tego przepływu.",
+      "processDetach": "Odłącz {workflow} od {role}"
     },
     "executorRollup": {
       "title": "Zestawienie wykonawców",

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -8306,7 +8306,8 @@
       "attachWorkflowPlaceholder": "ID przepływu",
       "attachError": "Nie udało się dołączyć tego przepływu.",
       "detachError": "Nie udało się odłączyć tego przepływu.",
-      "processDetach": "Odłącz {workflow} od {role}"
+      "processDetach": "Odłącz {workflow} od {role}",
+      "attachRolesUnavailable": "Nie udało się wczytać ról, więc ta lista może być niekompletna."
     },
     "executorRollup": {
       "title": "Zestawienie wykonawców",

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -8298,7 +8298,15 @@
         "handoffNotApplicableHuman": "A transferência se aplica apenas a agentes."
       },
       "processNodeLabel": "Processo",
-      "processOpensWorkflow": "Abre o fluxo que esta função executa"
+      "processOpensWorkflow": "Abre o fluxo que esta função executa",
+      "attach": "Anexar",
+      "attachRoleLabel": "Função",
+      "attachRolePlaceholder": "Escolher uma função…",
+      "attachWorkflowLabel": "ID do fluxo",
+      "attachWorkflowPlaceholder": "ID do fluxo",
+      "attachError": "Não foi possível anexar esse fluxo.",
+      "detachError": "Não foi possível remover esse fluxo.",
+      "processDetach": "Remover {workflow} de {role}"
     },
     "executorRollup": {
       "title": "Resumo de executores",

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -8306,7 +8306,8 @@
       "attachWorkflowPlaceholder": "ID do fluxo",
       "attachError": "Não foi possível anexar esse fluxo.",
       "detachError": "Não foi possível remover esse fluxo.",
-      "processDetach": "Remover {workflow} de {role}"
+      "processDetach": "Remover {workflow} de {role}",
+      "attachRolesUnavailable": "Não foi possível carregar as funções, portanto esta lista pode estar incompleta."
     },
     "executorRollup": {
       "title": "Resumo de executores",

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -8298,7 +8298,15 @@
         "handoffNotApplicableHuman": "منتقلی صرف ایجنٹس پر لاگو ہوتی ہے۔"
       },
       "processNodeLabel": "عمل",
-      "processOpensWorkflow": "اس کردار کا ورک فلو کھولتا ہے"
+      "processOpensWorkflow": "اس کردار کا ورک فلو کھولتا ہے",
+      "attach": "منسلک کریں",
+      "attachRoleLabel": "کردار",
+      "attachRolePlaceholder": "ایک کردار منتخب کریں…",
+      "attachWorkflowLabel": "ورک فلو شناخت",
+      "attachWorkflowPlaceholder": "ورک فلو شناخت",
+      "attachError": "یہ ورک فلو منسلک نہیں ہو سکا۔",
+      "detachError": "یہ ورک فلو الگ نہیں ہو سکا۔",
+      "processDetach": "{workflow} کو {role} سے الگ کریں"
     },
     "executorRollup": {
       "title": "عمل کنندہ خلاصہ",

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -8306,7 +8306,8 @@
       "attachWorkflowPlaceholder": "ورک فلو شناخت",
       "attachError": "یہ ورک فلو منسلک نہیں ہو سکا۔",
       "detachError": "یہ ورک فلو الگ نہیں ہو سکا۔",
-      "processDetach": "{workflow} کو {role} سے الگ کریں"
+      "processDetach": "{workflow} کو {role} سے الگ کریں",
+      "attachRolesUnavailable": "کردار لوڈ نہیں ہو سکے، اس لیے یہ فہرست نامکمل ہو سکتی ہے۔"
     },
     "executorRollup": {
       "title": "عمل کنندہ خلاصہ",

--- a/autobot-frontend/src/views/llc/OrgChart.vue
+++ b/autobot-frontend/src/views/llc/OrgChart.vue
@@ -134,6 +134,8 @@ interface AttachableRole {
   name: string
 }
 const attachableRoles = ref<AttachableRole[]>([])
+/** The roles request did not answer — distinct from answering "none" (#14064). */
+const attachRolesFailed = ref(false)
 const rolesLoaded = ref(false)
 const attachRoleId = ref('')
 const attachWorkflowId = ref('')
@@ -371,9 +373,13 @@ async function fetchProcessNodes() {
 /**
  * Load the roles this company has, for the canvas attach picker (#14549).
  *
- * Failures are logged and left as an empty list rather than surfaced as a page
- * error — the same precedent `fetchProcessNodes` follows. An empty picker
- * simply means nothing can be attached yet, not that the org chart is broken.
+ * A failure is not surfaced as a page error — the org chart is still correct
+ * without the picker. But it is recorded in `attachRolesFailed`, because an
+ * empty picker and a picker that could not load are different claims: the
+ * first says this company has no roles, the second says we do not know. The
+ * People tab already refuses to conflate those (#14064), and a silent empty
+ * dropdown would tell someone their roles are gone when the request merely
+ * failed.
  */
 async function fetchRolesForAttach() {
   if (rolesLoaded.value) return
@@ -390,10 +396,12 @@ async function fetchRolesForAttach() {
             typeof row?.id === 'string' && typeof row?.name === 'string',
         )
       : []
+    attachRolesFailed.value = false
     rolesLoaded.value = true
   } catch (err: unknown) {
     logger.error('Failed to fetch roles for the attach picker:', err)
     attachableRoles.value = []
+    attachRolesFailed.value = true
   }
 }
 
@@ -657,7 +665,7 @@ onMounted(() => {
       />
     </div>
 
-    <div v-if="error" class="rounded-lg bg-red-50 border border-red-200 p-4 text-red-700 text-sm mb-4">
+    <div v-if="error" class="rounded-lg bg-autobot-error-bg border border-autobot-error p-4 text-autobot-error text-sm mb-4">
       {{ error }}
       <button class="ml-4 underline" @click="fetchTree">{{ t('llc.orgChart.retry') }}</button>
     </div>
@@ -735,6 +743,15 @@ onMounted(() => {
               {{ role.name }}
             </option>
           </select>
+          <!-- Stated, not implied: an empty dropdown alone would read as "this
+               company has no roles" when the request simply did not answer. -->
+          <p
+            v-if="attachRolesFailed"
+            class="text-xs text-autobot-text-muted"
+            data-testid="process-attach-roles-unavailable"
+          >
+            {{ t('llc.orgChart.attachRolesUnavailable') }}
+          </p>
         </div>
         <div class="flex flex-col gap-1">
           <label for="process-attach-workflow" class="text-xs text-autobot-text-secondary">
@@ -761,7 +778,7 @@ onMounted(() => {
       </div>
       <div
         v-if="processMutationError"
-        class="border-b border-autobot-border bg-red-50 text-red-700 px-3 py-2 text-sm"
+        class="border-b border-autobot-border bg-autobot-error-bg text-autobot-error px-3 py-2 text-sm"
         role="alert"
         data-testid="process-mutation-error"
       >

--- a/autobot-frontend/src/views/llc/OrgChart.vue
+++ b/autobot-frontend/src/views/llc/OrgChart.vue
@@ -38,6 +38,8 @@ import ExecutorRollupPanel from '@/components/llc/ExecutorRollupPanel.vue'
 import { buildExecutorRollupMatrix } from '@/composables/llc/executorRollup'
 import type { ExecutorRollupCell, ExecutorRollupMatrix } from '@/composables/llc/executorRollup'
 import { availableLensRoles, applyRoleLens, roleLensCounts } from '@/composables/llc/orgRoleLens'
+import { describeApiError } from '@/composables/llc/apiErrorMessage'
+import BaseButton from '@/components/base/BaseButton.vue'
 
 const logger = createLogger('OrgChart')
 const api = useApiClient()
@@ -122,6 +124,23 @@ const canvasNodes = ref<CanvasNode[]>([])
 // render as "this company has no org chart".
 const processNodes = ref<ProcessNodeSource[]>([])
 const processNodesLoaded = ref(false)
+
+// #14549: the canvas can now change the attachment it displays, not just show
+// it. `roles` backs the "choose a role" picker for attach; fetched lazily like
+// `processNodes`, on the same canvas-open trigger, since neither is needed in
+// tree or people mode.
+interface AttachableRole {
+  id: string
+  name: string
+}
+const attachableRoles = ref<AttachableRole[]>([])
+const rolesLoaded = ref(false)
+const attachRoleId = ref('')
+const attachWorkflowId = ref('')
+// One flag for both mutations, mirroring RolesView.vue's `isMutating`: a
+// second attach/detach cannot fire while the first is still in flight.
+const processMutationInFlight = ref(false)
+const processMutationError = ref<string | null>(null)
 
 /**
  * Explicit, shallow layout source (#13996): ids, nesting and labels — never
@@ -256,7 +275,11 @@ function setViewMode(mode: OrgViewMode) {
   // #13963: process nodes only render on the canvas, so they are fetched when
   // the canvas is opened — same principle the People list already encodes. A
   // reader who stays in tree mode should not pay for a request they never see.
-  if (mode === 'canvas') void fetchProcessNodes()
+  if (mode === 'canvas') {
+    void fetchProcessNodes()
+    // #14549: the attach picker needs the role list, same lazy trigger.
+    void fetchRolesForAttach()
+  }
 }
 
 /** A People-list selection opens the same drawer the tree and canvas open. */
@@ -342,6 +365,97 @@ async function fetchProcessNodes() {
   } catch (err: unknown) {
     logger.error('Failed to fetch process nodes:', err instanceof Error ? err.message : String(err))
     processNodes.value = []
+  }
+}
+
+/**
+ * Load the roles this company has, for the canvas attach picker (#14549).
+ *
+ * Failures are logged and left as an empty list rather than surfaced as a page
+ * error — the same precedent `fetchProcessNodes` follows. An empty picker
+ * simply means nothing can be attached yet, not that the org chart is broken.
+ */
+async function fetchRolesForAttach() {
+  if (rolesLoaded.value) return
+  try {
+    const cid = await resolveCompanyIdOnce()
+    if (!cid) {
+      attachableRoles.value = []
+      return
+    }
+    const resp = await api.get<AttachableRole[]>(`/api/llc/roles/${cid}`)
+    attachableRoles.value = Array.isArray(resp)
+      ? resp.filter(
+          (row): row is AttachableRole =>
+            typeof row?.id === 'string' && typeof row?.name === 'string',
+        )
+      : []
+    rolesLoaded.value = true
+  } catch (err: unknown) {
+    logger.error('Failed to fetch roles for the attach picker:', err)
+    attachableRoles.value = []
+  }
+}
+
+/**
+ * Force the lazy process-node fetch to actually re-run (#14549).
+ *
+ * `processNodesLoaded` guards `fetchProcessNodes` so the canvas fetches once
+ * per visit rather than on every render — a mutation has to clear that guard
+ * first, or the "refetch" would hit it and silently keep showing the
+ * pre-mutation list while looking like it worked.
+ */
+async function reloadProcessNodes(): Promise<void> {
+  processNodesLoaded.value = false
+  await fetchProcessNodes()
+}
+
+function describeError(error: unknown, fallbackKey: string): string {
+  return describeApiError(error, t(fallbackKey))
+}
+
+/** Attach a workflow to a role from the canvas (#14549). */
+async function onProcessAttach(): Promise<void> {
+  const roleId = attachRoleId.value
+  const workflowId = attachWorkflowId.value.trim()
+  if (!companyId.value || !roleId || !workflowId || processMutationInFlight.value) return
+  processMutationInFlight.value = true
+  processMutationError.value = null
+  try {
+    await api.post(`/api/llc/roles/${companyId.value}/${roleId}/workflows`, {
+      workflow_id: workflowId,
+    })
+    attachWorkflowId.value = ''
+    // The canvas is the confirmation (#14549 issue body): a successful attach
+    // must be visible on it, not just accepted by the server.
+    await reloadProcessNodes()
+  } catch (err: unknown) {
+    logger.error('Failed to attach workflow:', err)
+    processMutationError.value = describeError(err, 'llc.orgChart.attachError')
+  } finally {
+    processMutationInFlight.value = false
+  }
+}
+
+/**
+ * Detach a workflow from a role, reached from the process node's own control
+ * on the canvas (#14549). No optimistic update: a failed call leaves
+ * `processNodes` — and so the graph — exactly as it was.
+ */
+async function onProcessDetached(roleId: string, workflowId: string): Promise<void> {
+  if (!companyId.value || processMutationInFlight.value) return
+  processMutationInFlight.value = true
+  processMutationError.value = null
+  try {
+    await api.delete(
+      `/api/llc/roles/${companyId.value}/${roleId}/workflows/${encodeURIComponent(workflowId)}`,
+    )
+    await reloadProcessNodes()
+  } catch (err: unknown) {
+    logger.error('Failed to detach workflow:', err)
+    processMutationError.value = describeError(err, 'llc.orgChart.detachError')
+  } finally {
+    processMutationInFlight.value = false
   }
 }
 
@@ -596,6 +710,64 @@ onMounted(() => {
       class="h-[70vh] rounded-lg border border-autobot-border overflow-hidden flex flex-col"
       data-testid="org-canvas"
     >
+      <!-- #14549: the canvas shows the attachment (role, workflow) it draws a
+           process node from, but could not change it — attach reaches from
+           here, detach reaches from the node itself (below). Always shown in
+           canvas mode, independent of the role lens: it is a mutation
+           control, not a view filter. -->
+      <div
+        class="flex flex-wrap items-end gap-3 border-b border-autobot-border bg-autobot-bg-secondary px-3 py-2 text-sm"
+        data-testid="process-attach-form"
+      >
+        <div class="flex flex-col gap-1">
+          <label for="process-attach-role" class="text-xs text-autobot-text-secondary">
+            {{ t('llc.orgChart.attachRoleLabel') }}
+          </label>
+          <select
+            id="process-attach-role"
+            v-model="attachRoleId"
+            :disabled="processMutationInFlight"
+            class="text-sm rounded-md border border-autobot-border bg-autobot-bg-card px-2 py-1 text-autobot-text-primary"
+            data-testid="process-attach-role-select"
+          >
+            <option value="">{{ t('llc.orgChart.attachRolePlaceholder') }}</option>
+            <option v-for="role in attachableRoles" :key="role.id" :value="role.id">
+              {{ role.name }}
+            </option>
+          </select>
+        </div>
+        <div class="flex flex-col gap-1">
+          <label for="process-attach-workflow" class="text-xs text-autobot-text-secondary">
+            {{ t('llc.orgChart.attachWorkflowLabel') }}
+          </label>
+          <input
+            id="process-attach-workflow"
+            v-model="attachWorkflowId"
+            type="text"
+            :disabled="processMutationInFlight"
+            :placeholder="t('llc.orgChart.attachWorkflowPlaceholder')"
+            class="text-sm rounded-md border border-autobot-border bg-autobot-bg-card px-2 py-1 text-autobot-text-primary"
+            data-testid="process-attach-workflow-input"
+          />
+        </div>
+        <BaseButton
+          variant="primary"
+          data-testid="process-attach-submit"
+          :disabled="!attachRoleId || !attachWorkflowId.trim() || processMutationInFlight"
+          @click="onProcessAttach"
+        >
+          {{ t('llc.orgChart.attach') }}
+        </BaseButton>
+      </div>
+      <div
+        v-if="processMutationError"
+        class="border-b border-autobot-border bg-red-50 text-red-700 px-3 py-2 text-sm"
+        role="alert"
+        data-testid="process-mutation-error"
+      >
+        {{ processMutationError }}
+      </div>
+
       <!-- GH#13943: the lens's own affordance. Shown whenever a role is
            selected, independent of whether it still matches anything, so a
            reduced (or emptied) canvas reads as "filtered by view", never as
@@ -646,6 +818,7 @@ onMounted(() => {
         @node-selected="onCanvasNodeSelected"
         @node-moved="onCanvasNodeMoved"
         @tab-selected="activeTabId = $event"
+        @process-detached="onProcessDetached"
       />
     </div>
     <p v-if="viewMode === 'canvas' && !isLoading && tree.length > 0" class="mt-2 text-xs text-autobot-text-muted">

--- a/autobot-frontend/src/views/llc/RolesView.vue
+++ b/autobot-frontend/src/views/llc/RolesView.vue
@@ -238,6 +238,7 @@ import BaseBadge from '@/components/base/BaseBadge.vue'
 import RoleAttachmentPanel from '@/components/llc/RoleAttachmentPanel.vue'
 import { BaseModal } from '@autobot/ui'
 import ErrorBanner from '@/components/base/ErrorBanner.vue'
+import { describeApiError } from '@/composables/llc/apiErrorMessage'
 
 interface RoleRow {
   id: string
@@ -300,18 +301,16 @@ const selectedRole = computed(
   () => roles.value.find((role) => role.id === selectedRoleId.value) ?? null,
 )
 
+/**
+ * Surface the server's reason rather than a generic message: a 403 from the
+ * admin gate and a 400 from validation need different actions from the user,
+ * and collapsing them into "something went wrong" hides which one happened.
+ *
+ * The extraction itself lives in `composables/llc/apiErrorMessage.ts` — shared
+ * with `OrgChart.vue` (#14549) rather than forked a second time.
+ */
 function describeError(error: unknown, fallbackKey: string): string {
-  // Surface the server's reason rather than a generic message: a 403 from the
-  // admin gate and a 400 from validation need different actions from the user,
-  // and collapsing them into "something went wrong" hides which one happened.
-  //
-  // ApiClient throws a plain Error whose message is already `HTTP <status>:
-  // <detail>` — it extracts `detail` itself (utils/ApiClient.ts
-  // _extractErrorInfo). It is NOT axios-shaped, so reading
-  // `error.response.data.detail` would silently always miss and this function
-  // would return the generic fallback every time while looking like it worked.
-  const message = error instanceof Error ? error.message : ''
-  return message.length > 0 ? message : t(fallbackKey)
+  return describeApiError(error, t(fallbackKey))
 }
 
 async function loadRoles(): Promise<void> {

--- a/autobot-frontend/src/views/llc/__tests__/OrgChart.processMutation.test.ts
+++ b/autobot-frontend/src/views/llc/__tests__/OrgChart.processMutation.test.ts
@@ -37,7 +37,6 @@ vi.mock('vue-router', () => ({
 }))
 
 const companyRef = ref('c1')
-
 vi.mock('@/composables/llc/useLlcCompanyContext', () => ({
   useLlcCompanyContext: () => ({
     companyId: companyRef,
@@ -143,6 +142,57 @@ describe('OrgChart process attach/detach (#14549)', () => {
 
     expect(wrapper.find('[data-testid="process-attach-form"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="process-attach-roles-unavailable"]').exists()).toBe(false)
+  })
+
+  // The guards below are not decoration: each one is reachable, and each
+  // prevents a request that would otherwise be malformed or duplicated.
+  // What actually stops a double POST here is the submit button's disabled
+  // binding, not the handler's in-flight guard — so that is what this asserts.
+  // (The handler keeps its own guard as defence for callers that are not the
+  // button; nothing in the UI can reach it, and it is left uncovered rather
+  // than reached by a contrived call that would prove nothing.)
+  it('disables the submit button while an attach is in flight, so it cannot post twice', async () => {
+    respond([], PROCESSES)
+    let resolvePost: () => void = () => {}
+    post.mockImplementation(() => new Promise<void>((r) => { resolvePost = () => r() }))
+    const wrapper = await mountChart()
+    await openCanvas(wrapper)
+
+    await wrapper.find('[data-testid="process-attach-role-select"]').setValue('r1')
+    await wrapper.find('[data-testid="process-attach-workflow-input"]').setValue('wf-quarterly')
+    const submit = wrapper.find('[data-testid="process-attach-submit"]')
+    await submit.trigger('click')
+    // Second click while the first is still in flight.
+    await submit.trigger('click')
+    await flushPromises()
+
+    expect(post).toHaveBeenCalledTimes(1)
+    expect(
+      wrapper.find('[data-testid="process-attach-submit"]').attributes('disabled'),
+    ).toBeDefined()
+
+    // Not asserting it re-enables on success: the handler clears the workflow
+    // field once the attach lands, so the button is legitimately disabled again
+    // for that reason instead.
+    resolvePost()
+    await flushPromises()
+  })
+
+  it('does not delete the same attachment twice when detached rapidly', async () => {
+    respond(PROCESSES, [])
+    let resolveDel: () => void = () => {}
+    del.mockImplementation(() => new Promise<void>((r) => { resolveDel = () => r() }))
+    const wrapper = await mountChart()
+    await openCanvas(wrapper)
+
+    const canvas = wrapper.findComponent(WorkflowCanvas)
+    canvas.vm.$emit('process-detached', 'r1', 'wf-quarterly')
+    canvas.vm.$emit('process-detached', 'r1', 'wf-quarterly')
+    await flushPromises()
+
+    expect(del).toHaveBeenCalledTimes(1)
+    resolveDel()
+    await flushPromises()
   })
 
   it('detaches a process node from its own control and the node disappears', async () => {

--- a/autobot-frontend/src/views/llc/__tests__/OrgChart.processMutation.test.ts
+++ b/autobot-frontend/src/views/llc/__tests__/OrgChart.processMutation.test.ts
@@ -110,6 +110,41 @@ describe('OrgChart process attach/detach (#14549)', () => {
     push.mockReset()
   })
 
+  // An empty picker and a picker that could not load are different claims, and
+  // the dropdown alone renders them identically (#14064's shape). The pair
+  // below is deliberate: neither test can pass on its own if the distinction is
+  // dropped, because one demands the notice and the other forbids it.
+  it('says so when the roles request did not answer', async () => {
+    respond()
+    get.mockImplementation((url: string) => {
+      if (url.includes('/process-nodes')) return Promise.resolve({ nodes: PROCESSES })
+      if (url.includes('/org-chart')) return Promise.resolve({ nodes: PEOPLE })
+      if (url.includes('/api/llc/roles/')) return Promise.reject(new Error('HTTP 503: upstream'))
+      return Promise.resolve({ nodes: [] })
+    })
+    const wrapper = await mountChart()
+    await openCanvas(wrapper)
+
+    expect(wrapper.find('[data-testid="process-attach-roles-unavailable"]').exists()).toBe(true)
+    // Positive companion: the form is still there, so the assertion above
+    // cannot be satisfied by the view having failed to render at all.
+    expect(wrapper.find('[data-testid="process-attach-form"]').exists()).toBe(true)
+  })
+
+  it('stays silent when the roles request answers with none', async () => {
+    get.mockImplementation((url: string) => {
+      if (url.includes('/process-nodes')) return Promise.resolve({ nodes: PROCESSES })
+      if (url.includes('/org-chart')) return Promise.resolve({ nodes: PEOPLE })
+      if (url.includes('/api/llc/roles/')) return Promise.resolve([])
+      return Promise.resolve({ nodes: [] })
+    })
+    const wrapper = await mountChart()
+    await openCanvas(wrapper)
+
+    expect(wrapper.find('[data-testid="process-attach-form"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="process-attach-roles-unavailable"]').exists()).toBe(false)
+  })
+
   it('detaches a process node from its own control and the node disappears', async () => {
     respond(PROCESSES, [])
     del.mockResolvedValue(undefined)

--- a/autobot-frontend/src/views/llc/__tests__/OrgChart.processMutation.test.ts
+++ b/autobot-frontend/src/views/llc/__tests__/OrgChart.processMutation.test.ts
@@ -1,0 +1,190 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// #14549: the canvas showed a workflow-to-role attachment but could not
+// change it. These guard the mutation half of that surface: attach (a form
+// on the canvas) and detach (a control on the process node itself), both
+// against the endpoints `RolesView.vue` already uses.
+//
+// The one most worth stating up front: `processNodesLoaded` guards the lazy
+// fetch `fetchProcessNodes` runs on canvas-open. A mutation has to clear that
+// guard before it refetches, or the "refetch" hits the guard, does nothing,
+// and the canvas keeps showing the pre-mutation list while looking correct.
+// Every attach/detach test below asserts the GET call count, not just the
+// mutation call, so that specific failure mode cannot pass silently.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import { ref } from 'vue'
+import en from '@/i18n/locales/en.json'
+
+const get = vi.fn()
+const post = vi.fn()
+const del = vi.fn()
+const push = vi.fn()
+
+vi.mock('@/plugins/api', () => ({
+  useApiClient: () => ({ get, post, delete: del }),
+}))
+
+vi.mock('@/utils/debugUtils', () => ({
+  createLogger: () => ({ warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() }),
+}))
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push }),
+  useRoute: () => ({ params: { companyId: 'c1' }, query: {} }),
+}))
+
+const companyRef = ref('c1')
+
+vi.mock('@/composables/llc/useLlcCompanyContext', () => ({
+  useLlcCompanyContext: () => ({
+    companyId: companyRef,
+    resolveCompanyId: () => Promise.resolve(companyRef.value),
+  }),
+}))
+
+import OrgChart from '../OrgChart.vue'
+import WorkflowCanvas from '@/components/workflow/WorkflowCanvas.vue'
+
+const PEOPLE = [
+  {
+    id: 'ceo',
+    node_id: 'n-ceo',
+    name: 'Ada',
+    title: 'CEO',
+    status: 'idle',
+    adapter_type: 'claude',
+    is_human: false,
+    last_heartbeat: null,
+    budget_spent: 0,
+    budget_total: 0,
+    assigned_item_count: 0,
+    parent_id: null,
+    children: [],
+  },
+]
+
+const PROCESSES = [{ role_id: 'r1', role_name: 'Head of Sales', workflow_id: 'wf-quarterly' }]
+const ROLES = [{ id: 'r1', name: 'Head of Sales' }, { id: 'r2', name: 'SRE' }]
+
+/** GET responses. `processes` is swapped for the SECOND process-nodes call, so
+ * a test can tell the pre-mutation list apart from the post-mutation one. */
+function respond(processes: unknown = PROCESSES, afterProcesses: unknown = processes): void {
+  let processCalls = 0
+  get.mockImplementation((url: string) => {
+    if (url.includes('/process-nodes')) {
+      processCalls += 1
+      return Promise.resolve({ nodes: processCalls === 1 ? processes : afterProcesses })
+    }
+    if (url.includes('/org-chart')) return Promise.resolve({ nodes: PEOPLE })
+    if (url.includes('/api/llc/roles/')) return Promise.resolve(ROLES)
+    return Promise.resolve({ nodes: [] })
+  })
+}
+
+function processFetchCount(): number {
+  return get.mock.calls.filter((c) => String(c[0]).includes('/process-nodes')).length
+}
+
+async function mountChart() {
+  const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } })
+  const wrapper = mount(OrgChart, {
+    global: { plugins: [i18n], stubs: { CanvasNodeSidebar: true, OrgPeopleList: true } },
+  })
+  await flushPromises()
+  return wrapper
+}
+
+async function openCanvas(wrapper: Awaited<ReturnType<typeof mountChart>>) {
+  await wrapper.find('[data-testid="org-view-canvas"]').trigger('click')
+  await flushPromises()
+}
+
+describe('OrgChart process attach/detach (#14549)', () => {
+  beforeEach(() => {
+    get.mockReset()
+    post.mockReset()
+    del.mockReset()
+    push.mockReset()
+  })
+
+  it('detaches a process node from its own control and the node disappears', async () => {
+    respond(PROCESSES, [])
+    del.mockResolvedValue(undefined)
+    const wrapper = await mountChart()
+    await openCanvas(wrapper)
+    expect(processFetchCount()).toBe(1)
+
+    const canvas = wrapper.findComponent(WorkflowCanvas)
+    canvas.vm.$emit('process-detached', 'r1', 'wf-quarterly')
+    await flushPromises()
+
+    expect(del).toHaveBeenCalledWith('/api/llc/roles/c1/r1/workflows/wf-quarterly')
+    // The refetch must actually re-run, not hit the `processNodesLoaded` guard
+    // and silently keep the stale list.
+    expect(processFetchCount()).toBe(2)
+    const nodes = canvas.props('nodes') as { type: string }[]
+    expect(nodes.filter((n) => n.type === 'org-process')).toHaveLength(0)
+  })
+
+  it('attaches a workflow to a role from the canvas form and the node appears', async () => {
+    respond([], PROCESSES)
+    post.mockResolvedValue(undefined)
+    const wrapper = await mountChart()
+    await openCanvas(wrapper)
+    expect(processFetchCount()).toBe(1)
+
+    await wrapper.find('[data-testid="process-attach-role-select"]').setValue('r1')
+    await wrapper.find('[data-testid="process-attach-workflow-input"]').setValue('wf-quarterly')
+    await wrapper.find('[data-testid="process-attach-submit"]').trigger('click')
+    await flushPromises()
+
+    expect(post).toHaveBeenCalledWith('/api/llc/roles/c1/r1/workflows', {
+      workflow_id: 'wf-quarterly',
+    })
+    expect(processFetchCount()).toBe(2)
+    const nodes = wrapper.findComponent(WorkflowCanvas).props('nodes') as { type: string }[]
+    expect(nodes.filter((n) => n.type === 'org-process')).toHaveLength(1)
+  })
+
+  it('a failed detach surfaces an error and leaves the graph unchanged', async () => {
+    respond(PROCESSES)
+    del.mockRejectedValue(new Error('HTTP 409: workflow still running'))
+    const wrapper = await mountChart()
+    await openCanvas(wrapper)
+
+    const canvas = wrapper.findComponent(WorkflowCanvas)
+    canvas.vm.$emit('process-detached', 'r1', 'wf-quarterly')
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="process-mutation-error"]').text()).toBe(
+      'HTTP 409: workflow still running',
+    )
+    // No optimistic mutation and no reload attempted on failure: the list the
+    // canvas draws from is exactly what it was before the click.
+    expect(processFetchCount()).toBe(1)
+    const nodes = canvas.props('nodes') as { type: string }[]
+    expect(nodes.filter((n) => n.type === 'org-process')).toHaveLength(1)
+  })
+
+  it('a failed attach surfaces an error and does not add a node', async () => {
+    respond(PROCESSES)
+    post.mockRejectedValue(new Error('HTTP 400: unknown workflow id'))
+    const wrapper = await mountChart()
+    await openCanvas(wrapper)
+
+    await wrapper.find('[data-testid="process-attach-role-select"]').setValue('r2')
+    await wrapper.find('[data-testid="process-attach-workflow-input"]').setValue('wf-new')
+    await wrapper.find('[data-testid="process-attach-submit"]').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="process-mutation-error"]').text()).toBe(
+      'HTTP 400: unknown workflow id',
+    )
+    expect(processFetchCount()).toBe(1)
+    const nodes = wrapper.findComponent(WorkflowCanvas).props('nodes') as { type: string }[]
+    expect(nodes.filter((n) => n.type === 'org-process')).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
Closes #14549

## Thinking Path

The canvas already rendered one process node per (role, workflow) pair and could
navigate to the workflow builder. It could not change the attachment it was
displaying — that lived only in the Roles tab, against a role you had to find by
name. A surface that shows the absorption of the automation module but cannot
perform it leaves the Roles tab as the real home of the relationship, which is
the split the absorption was meant to remove.

Both endpoints already existed from #14509, so this is frontend-only. No new
backend surface, and no new authorisation logic in the UI — the endpoints are
already company-scoped and admin-gated.

Two constraints shaped the design. `WorkflowCanvas.vue` is shared with real
workflow editing, so it emits and never calls an LLC endpoint itself. And the
node click must keep navigating, so the detach control stops propagation rather
than replacing the click.

## What Changed

- **Detach** — a control on the process node itself (`@click.stop`, so the node
  click still opens the workflow builder). It emits `process-detached`;
  `OrgChart.vue` calls `DELETE` and refetches.
- **Attach** — a role picker plus workflow id on the canvas, calling `POST`.
- **`reloadProcessNodes()`** — `processNodesLoaded` guards the lazy fetch, so a
  mutation must clear it first. Without that the "refetch" hits the guard, does
  nothing, and the canvas keeps showing the pre-mutation list while looking
  correct. Every mutation test asserts the GET count for exactly this reason.
- **No optimistic update** — a failed call leaves the graph untouched and shows
  the error.
- **`describeApiError`** extracted from `RolesView.vue` into a shared composable
  and used by both, rather than a second copy.
- **An unanswered roles request no longer reads as "no roles."** The picker
  logged its failure and left the dropdown empty, which is indistinguishable
  from a company that genuinely has none. That is the conflation the People tab
  was already fixed for (#14064).
- **Two raw Tailwind palette classes replaced with error tokens.** `bg-red-50`
  does not respond to the theme, so both banners rendered light-red on light-red
  in dark mode. One of the two predates this branch; stylelint's `color-no-hex`
  cannot see palette *class names*, so neither was caught by the gate.
- New strings in all 11 locales, added key-by-key so no sibling key was rewritten.

## Verification

Every new test was proven able to fail by mutating the line it guards and
confirming it went red, then restoring:

| Mutation | Test that went red |
|---|---|
| `.stop` removed from the detach control | node click also fired `node-selected` |
| detach button wrapped in `v-if="!readonly"` | all 4 detach tests (mount default is readonly) |
| `role` blanked in the accessible name | English **and** Arabic name tests |
| `reloadProcessNodes()` → `fetchProcessNodes()` in detach | node did not disappear (GET count stuck at 1) |
| same, in attach | node did not appear |
| error assignment blanked in each catch | both failure tests |
| catch never sets `attachRolesFailed` | "says so when the roles request did not answer" |
| success path also sets it | "stays silent when the roles request answers with none" |

The last two are a deliberate pair: neither passes alone if the distinction is
dropped, because one demands the notice and the other forbids it. The
absence-assertions are paired with a positive one, so a view that failed to
render cannot satisfy them.

I re-derived the mutation results myself rather than accepting them as reported.
Doing so exposed a real hole in my own method: a `git checkout --` "restore"
silently reverted uncommitted work, after which a later mutation no-op'd and its
red test was mistaken for proof. The mutation script now asserts the edit
actually applied (`assert n != s`) before running, and the fix was committed
before any mutation.

Results, all from the worktree:

- `vitest run` across `views/llc`, `components/llc`, `composables/llc`,
  `components/workflow` — **39 files, 416 tests, all passed**
- `vue-tsc --noEmit` — exit 0
- `oxlint` — exit 0 · `eslint` — exit 0
- `stylelint` (invoked as CI does, config auto-resolved) — exit 0
- Locale key parity across all 11 locales — identical key sets

### Coverage

My earlier claim that coverage is unmeasurable from a worktree was wrong: the
`**/.worktrees/**` exclusion is on *test discovery*, not on coverage, so running
from inside the worktree measures normally.

Codecov reported 2 missing lines and 1 partial. Measured directly, they were the
mutation guards. One was worth closing on merit and now is:

- **detach in-flight** — emitting `process-detached` twice while the first call
  is in flight now proves only one `DELETE` is sent (branch went `[0,2]` →
  `[1,3]`). Removing the in-flight clause turns it red.

Two remain uncovered, deliberately:

- `if (!cid)` in `fetchRolesForAttach` — the view does not render a canvas
  before the company resolves, so the UI cannot reach it.
- the attach handler's own in-flight clause — the submit button's `disabled`
  binding stops the second click first.

Both are defence for callers that are not the button. I left them rather than
reach them with a contrived call, and rather than delete working defensive code
to raise a number.

Worth recording: my first attach test asserted the *handler* guard and still
passed with that guard deleted — the button was doing the work all along. It
now asserts the binding that actually prevents the second POST, and that
assertion does go red when the clause is removed.

## Model Used

Claude Opus 5 (1M context)

