### PR TITLE
security(codeexec): fix map_site readonly/write classification drift (#14536)

### DIFF
--- a/autobot-backend/tests/unit/chat_workflow/test_code_exec.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_code_exec.py
@@ -597,8 +597,8 @@ def test_tool_policy_and_mcp_permissions_agree_on_readonly_tools():
     Scoped to tools both sources name at all — a rename or moved constant on
     either side must fail loud, not silently pass an empty overlap.
     """
-    from chat_workflow.code_exec import tool_policy as tp
     from autobot_shared.auth.mcp_tool_permissions import TOOL_PERMISSIONS
+    from chat_workflow.code_exec import tool_policy as tp
 
     tool_policy_named = tp.SENSITIVE_TOOLS | tp.CODEEXEC_INJECTABLE_TOOLS
     assert tool_policy_named, "tool_policy.py names no tools — source resolved empty"

--- a/autobot-backend/tests/unit/chat_workflow/test_code_exec.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_code_exec.py
@@ -581,6 +581,45 @@ def test_tool_policy_default_classification_unchanged():
     assert tp.CODEEXEC_MUTATING_TOOLS == frozenset()
 
 
+def _mcp_permission_is_write_level(permission) -> bool:
+    """A permission whose action segment is not `read`/`view` can mutate state."""
+    action = permission.value.rsplit(".", 1)[-1]
+    return action not in {"read", "view"}
+
+
+def test_tool_policy_and_mcp_permissions_agree_on_readonly_tools():
+    """#14536: a tool tool_policy.py auto-approves (no human gate, readonly)
+    must never carry a write-level grant in mcp_tool_permissions.py — that
+    combination is exactly what let a compose script call `map_site` (declared
+    KNOWLEDGE_WRITE) without ever hitting the KNOWLEDGE_WRITE gate, because
+    tool_policy.py's readonly default auto-approved it first.
+
+    Scoped to tools both sources name at all — a rename or moved constant on
+    either side must fail loud, not silently pass an empty overlap.
+    """
+    from chat_workflow.code_exec import tool_policy as tp
+    from autobot_shared.auth.mcp_tool_permissions import TOOL_PERMISSIONS
+
+    tool_policy_named = tp.SENSITIVE_TOOLS | tp.CODEEXEC_INJECTABLE_TOOLS
+    assert tool_policy_named, "tool_policy.py names no tools — source resolved empty"
+    assert TOOL_PERMISSIONS, "mcp_tool_permissions.py declares no tools — source resolved empty"
+
+    named_by_both = tool_policy_named & set(TOOL_PERMISSIONS)
+    assert named_by_both, "no overlap between tool_policy.py and mcp_tool_permissions.py — check for a rename"
+
+    disagreements = {
+        name
+        for name in named_by_both
+        if name in tp.CODEEXEC_READONLY_TOOLS and _mcp_permission_is_write_level(TOOL_PERMISSIONS[name])
+    }
+    agreeing = len(named_by_both) - len(disagreements)
+
+    assert not disagreements, (
+        f"{agreeing}/{len(named_by_both)} agree; auto-approved as readonly in tool_policy.py but "
+        f"declared a write-level MCP permission: {sorted(disagreements)}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # MAJOR-1: shim RPC uses per-call ids so concurrent calls correlate
 # ---------------------------------------------------------------------------

--- a/autobot_shared/auth/mcp_tool_permissions.py
+++ b/autobot_shared/auth/mcp_tool_permissions.py
@@ -181,7 +181,12 @@ TOOL_PERMISSIONS: Dict[str, Permission] = {
     "extract_structured_data": Permission.KNOWLEDGE_READ,
     "get_knowledge_stats": Permission.KNOWLEDGE_READ,
     "langchain_qa_chain": Permission.KNOWLEDGE_READ,
-    "map_site": Permission.KNOWLEDGE_WRITE,
+    # #14536: map_site only enumerates URLs (sitemap.xml parse, or a BFS crawl
+    # that reads links without fetching bodies for ingestion — see
+    # web_fetch/site_mapper.py). It never calls the knowledge-base write path
+    # crawl_site does, so it takes the read grant tool_policy.py already treats
+    # it as auto-approvable under.
+    "map_site": Permission.KNOWLEDGE_READ,
     # Found by the guard's first run against the real bridges (#13228): mcp_crawl
     # registers a WebCrawlerConnector and ingests, so inheriting KNOWLEDGE_READ
     # would have under-granted it.


### PR DESCRIPTION
## Thinking Path
`map_site` was classified two different ways: `tool_policy.py` puts it in the default readonly/injectable set (auto-approved with no human gate in code-exec compose scripts), while `mcp_tool_permissions.py` declared it `KNOWLEDGE_WRITE`. Since #14530/#14491 made `build_compose_dispatch` route shim calls back through `_dispatch_tool_call`, a compose script's `map_site` call now hits the `KNOWLEDGE_WRITE` gate at runtime while the code-exec layer still auto-approves it — the two sources disagree about the same tool.

I traced what `map_site` actually does before touching either classification:
- `tools/tool_registry.py:353` `map_site()` calls
- `web_fetch/site_mapper.py:250` `SiteMapper.map_site()`, which either
  - `web_fetch/site_mapper.py:272` `_resolve_sitemap_urls()` — fetches and parses `sitemap.xml` (`_fetch_xml`, `ET.fromstring`), or
  - `web_fetch/site_mapper.py:279` `_crawl_fallback_with_robots()` → `_crawl_fallback()` (`web_fetch/site_mapper.py:177-200`) — a link-discovery BFS (`Frontier`, `extract_links`) that fetches raw HTML only to harvest links, never bodies for storage.

Neither path calls anything in `knowledge/` or touches Chroma/vector storage — there is no write sink. This matches the distinction already drawn between `map_site` (URL enumeration only) and `crawl_site` (`tools/tool_registry.py:296-351`, which instantiates `WebCrawlerConnector` and calls `.crawl(..., ingest=ingest)` — a real KB write path, and is correctly excluded from `tool_policy.py`'s readonly default). `map_site`'s own MCP tool descriptor (`chat_workflow/tool_handler.py`) also carries no `ingest` parameter, unlike `crawl_site`'s.

Conclusion: `map_site` only maps, it never ingests. `tool_policy.py`'s readonly classification was already correct; `mcp_tool_permissions.py`'s `KNOWLEDGE_WRITE` was the wrong one.

## What Changed
- `autobot_shared/auth/mcp_tool_permissions.py`: `map_site` → `Permission.KNOWLEDGE_READ` (was `KNOWLEDGE_WRITE`), with a comment recording the call-chain reasoning. `tool_policy.py`'s readonly default is unchanged — it was already correct.
- `autobot-backend/tests/unit/chat_workflow/test_code_exec.py`: added `test_tool_policy_and_mcp_permissions_agree_on_readonly_tools`, a consistency guard between `tool_policy.py` (`SENSITIVE_TOOLS | CODEEXEC_INJECTABLE_TOOLS`) and `mcp_tool_permissions.TOOL_PERMISSIONS`. For every tool name both sources declare, it fails if a tool `tool_policy.py` auto-approves (readonly) carries a write-level MCP permission (any action suffix other than `read`/`view`). It asserts both source sets are non-empty and that their overlap is non-empty before comparing, so a rename or moved constant that resolves either side to an empty set fails loud instead of vacuously passing.
- No change to `mcp_tool_permissions.required_permission()` structure — out of scope per #14523.

## Verification
Measured the overlap directly against the live `TOOL_PERMISSIONS` dict (regex-parsed from the file, not imported/executed, since AutoBot policy is to never run code from the codebase) using the exact predicate the new test applies:

- `tools_named_by_both` = 11 (`click`, `delete_file`, `edit_file`, `evaluate`, `extract_structured_data`, `fill`, `map_site`, `navigate`, `scrape_url`, `select`, `write_file`)
- `agreeing` before this PR's fix: **10/11** (only `map_site` disagreed)
- `agreeing` after this PR's fix: **11/11**

Mutation check (scratch copy under `/tmp`, never pushed): reverted `map_site` back to `Permission.KNOWLEDGE_WRITE` in a scratch copy of `mcp_tool_permissions.py` and re-ran the same computation — result reproduced the pre-fix failure (10/11, `disagreements=['map_site']`), i.e. the guard's assertion would raise. Reverting the mutation reproduced 11/11 with no disagreements, matching the real fixed file.

Closes #14536

## Model Used
Claude Sonnet 5