### PR TITLE
security(mcp): required_permission() deny-by-default at runtime (#13228 stage 3)

### DIFF
--- a/autobot-backend/api/mcp_registry.py
+++ b/autobot-backend/api/mcp_registry.py
@@ -437,9 +437,11 @@ def _build_tool_entry(tool: dict, bridge_name: str, bridge_desc: str, endpoint: 
     and ``get_tool_definitions`` both read the cache this populates, so one
     declaration governs execution and advertisement alike.
 
-    ``None`` means the tool is undeclared. Stage 1 records that without acting
-    on it; enforcement (denying the undeclared) is a later, separately
-    revertible step, so this change cannot break a working agent flow.
+    ``None`` means the tool is undeclared. Stage 1 only recorded that value;
+    stage 3 (#14523) is what acts on it — ``PermissionEnforcementExtension``
+    refuses a ``None`` ``tool_permission`` and ``MCPDispatcher.dispatch``/
+    ``get_tool_definitions`` both deny/hide a tool this resolves to ``None``
+    for, via the same canonical check.
     """
     from autobot_shared.auth.mcp_tool_permissions import required_permission  # noqa: PLC0415
 

--- a/autobot-backend/api/mcp_registry_test.py
+++ b/autobot-backend/api/mcp_registry_test.py
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
-"""Every discovered MCP bridge has a declared default permission (#14420 review).
+"""Every discovered MCP bridge has a declared default permission (#14420 review,
+runtime denial landed at #14523).
 
 `autobot_shared.auth.mcp_tool_permissions_test.test_every_bridge_has_a_default`
 already guards the 11 static bridges by parsing `autobot-backend/api/*_mcp.py`
@@ -10,11 +11,16 @@ sources offline. That check cannot see a bridge that only exists via the
 `autobot.mcp_bridges` entry-point group (a plugin, no local `*_mcp.py` file to
 parse) — there are no registrants there today, so the gap is latent.
 
-`required_permission()` resolves an unmapped bridge to `None`, and
-`PermissionEnforcementExtension` (#14420) reads a `None` `tool_permission` as
-"undeclared/legacy, allow" — for every role, including unauthenticated. A
-bridge added tomorrow via the entry-point path with no
-`BRIDGE_DEFAULT_PERMISSIONS` entry would be silently permissive from day one.
+Before #14523, `required_permission()` resolved an unmapped bridge to `None`,
+and `PermissionEnforcementExtension` read that `None` as "undeclared/legacy,
+allow" — for every role, including unauthenticated. A bridge added via the
+entry-point path with no exact `TOOL_PERMISSIONS`/`BRIDGE_DEFAULT_PERMISSIONS`
+entry would have been silently permissive from day one. #14523 makes
+`required_permission()` refuse any undeclared tool regardless of bridge, so an
+entry-point bridge missing here is no longer a silent grant — it is refused
+outright. This test stays: `BRIDGE_DEFAULT_PERMISSIONS` is still the registry
+every governed bridge must join, and a bridge nobody registered here is a
+governance gap even though it can no longer be exploited as an under-grant.
 
 This test reads the same `MCP_BRIDGES` list `_build_tool_entry` resolves
 `required_permission` against, so entry-point-discovered bridges are covered
@@ -26,15 +32,17 @@ from autobot_shared.auth.mcp_tool_permissions import BRIDGE_DEFAULT_PERMISSIONS
 
 
 def test_every_discovered_bridge_has_a_default_permission():
-    """A discovered bridge with no default resolves every one of its tools to
-    `required_permission() is None`, which reads as an unconditional allow —
-    not the "absence is a denial" `mcp_tool_permissions` documents."""
+    """A discovered bridge missing from `BRIDGE_DEFAULT_PERMISSIONS` is refused
+    outright at runtime since #14523 (no fallback grant left to inherit) —
+    this stays as the registry gate: every bridge `_build_tool_entry` resolves
+    a tool against must be acknowledged here, or its tools work for nobody."""
     discovered = {name for name, _desc, _endpoint, _features in MCP_BRIDGES}
     missing = discovered - set(BRIDGE_DEFAULT_PERMISSIONS)
 
     assert not missing, (
         f"bridge(s) discovered with no BRIDGE_DEFAULT_PERMISSIONS entry: {sorted(missing)} — "
-        "every tool on an unmapped bridge silently allows any role, including unauthenticated"
+        "every tool on an unregistered bridge is refused outright (#14523); register the bridge "
+        "here and declare its tools in TOOL_PERMISSIONS."
     )
 
 

--- a/autobot-backend/chat_workflow/llm_handler.py
+++ b/autobot-backend/chat_workflow/llm_handler.py
@@ -274,9 +274,10 @@ async def _emit_before_tool_execute(
     Issue #14420: ``tool_permission``/``user_role`` feed
     ``PermissionEnforcementExtension``. Callers that know the tool's
     declared permission requirement (e.g. from the MCP registry) and the
-    caller's RBAC role should pass both; callers that do not are unchanged
-    - the extension treats a missing ``tool_permission`` as an undeclared,
-    legacy tool and allows it through.
+    caller's RBAC role should pass both. #14523: a caller that omits
+    ``tool_permission`` is no longer treated as a legacy tool waved through —
+    the extension refuses a missing declaration outright, so every call site
+    reaching this function must resolve a real permission.
 
     Args:
         tool_name: Name of tool to execute

--- a/autobot-backend/middleware/builtin/permission_enforcement.py
+++ b/autobot-backend/middleware/builtin/permission_enforcement.py
@@ -8,8 +8,15 @@ Permission Enforcement Extension — issue #3009.
 Built-in extension that checks tool permission levels against user roles
 before allowing tool execution. Wires into the BEFORE_TOOL_EXECUTE hook.
 
-Legacy tools that do not set ``tool_permission`` on HookContext are allowed
-through unchanged so that existing callers are not broken.
+Issue #14523 (stage 3 of #13228): an undeclared tool — ``tool_permission`` is
+``None`` on HookContext — is refused, not allowed through. Before this, a
+missing ``tool_permission`` was read as "legacy tool, no schema declared" and
+waved through unconditionally; that was the runtime half of the default-allow
+#14521's security review flagged in
+``autobot_shared.auth.mcp_tool_permissions.required_permission``. #14494 made
+every tool the eleven governed bridges register today carry an exact
+declaration (measured at #14523 time: 104 live tools, 0 undeclared), which is
+what makes refusing ``None`` safe rather than breaking a working agent flow.
 
 Issue #14420: two gaps kept this extension inert even once it was correctly
 registered on the live ``ExtensionManager`` singleton (#14280 / #14414):
@@ -56,10 +63,13 @@ class PermissionEnforcementExtension(Extension):
     Reads ``tool_permission`` and ``user_role`` from HookContext.data and
     raises ``PermissionError`` when the caller lacks sufficient privilege.
 
-    Legacy tools that do not set ``tool_permission`` on HookContext are
-    allowed through without any check (backward compatibility) — this
-    matches how #13228 stage 1 marks a tool as undeclared rather than
-    denied.
+    #14523: a tool that does not set ``tool_permission`` on HookContext — an
+    undeclared tool, per ``mcp_tool_permissions.required_permission`` — is
+    refused, not allowed through. Before #14523 this was read as "legacy,
+    no schema declared" and waved through unconditionally; #14494 proved
+    every tool the eleven governed bridges register today carries a real
+    declaration, so refusing the undeclared case no longer breaks a working
+    call — it refuses exactly the tool that reached production without one.
 
     Priority 0 ensures this extension runs before all others so that a
     permission denial short-circuits the entire tool-execution chain.
@@ -88,8 +98,10 @@ class PermissionEnforcementExtension(Extension):
             ctx: Hook context.  Reads:
                  - ``ctx.data["tool_permission"]``: the dot-style
                    ``Permission`` value the tool requires (e.g.
-                   ``"mcp.database.write"``). If absent the tool is
-                   undeclared/legacy and allowed through.
+                   ``"mcp.database.write"``). ``None`` means the tool is
+                   undeclared and is refused (#14523) — every tool a governed
+                   bridge registers today carries a real declaration, so this
+                   should never fire for a working call.
                  - ``ctx.data["user_role"]``: caller's role string.
                    If absent the caller is treated as unauthenticated.
 
@@ -97,12 +109,20 @@ class PermissionEnforcementExtension(Extension):
             None when the check passes (execution continues normally).
 
         Raises:
-            PermissionError: When the caller lacks the required permission.
+            PermissionError: When the caller lacks the required permission,
+                or the tool is undeclared (``tool_permission`` is ``None``).
         """
         tool_permission = ctx.get("tool_permission")
         if tool_permission is None:
-            # Undeclared/legacy tool — no permission schema declared; allow through
-            return None
+            # #14523: an undeclared tool is refused, not waved through as legacy.
+            logger.warning(
+                "Permission denied: tool '%s' has no declared permission (session=%s)",
+                ctx.get("tool_name"),
+                ctx.session_id,
+            )
+            raise PermissionError(
+                f"Tool '{ctx.get('tool_name')}' has no declared permission — refused by default (#14523)"
+            )
 
         user_role = ctx.get("user_role")
 

--- a/autobot-backend/middleware/builtin/permission_enforcement_test.py
+++ b/autobot-backend/middleware/builtin/permission_enforcement_test.py
@@ -73,23 +73,35 @@ class TestPermissionEnforcementExtension:
         assert self.ext.fail_closed is True
 
     # ------------------------------------------------------------------
-    # Undeclared/legacy tools (no tool_permission set) — backward compat
+    # Undeclared tools (no tool_permission set) — refused by default (#14523)
     # ------------------------------------------------------------------
 
     @pytest.mark.asyncio
-    async def test_undeclared_tool_no_permission_allowed(self):
-        """Tools without tool_permission (undeclared/legacy) are allowed through."""
+    async def test_undeclared_tool_with_a_role_is_refused(self):
+        """#14523: no tool_permission means undeclared, and undeclared is refused
+        even for an otherwise-known caller — a role cannot make up for a tool
+        that never declared what it needs."""
         ctx = HookContext(session_id="s1", message="test")
         ctx.set("user_role", "user")
-        result = await self.ext.on_before_tool_execute(ctx)
-        assert result is None
+        with pytest.raises(PermissionError, match="no declared permission"):
+            await self.ext.on_before_tool_execute(ctx)
 
     @pytest.mark.asyncio
-    async def test_undeclared_tool_no_role_no_permission_allowed(self):
-        """No tool_permission and no user_role — undeclared, allowed."""
+    async def test_undeclared_tool_with_no_role_is_refused(self):
+        """#14523: no tool_permission and no user_role — still refused, not allowed."""
         ctx = HookContext(session_id="s1", message="test")
-        result = await self.ext.on_before_tool_execute(ctx)
-        assert result is None
+        with pytest.raises(PermissionError, match="no declared permission"):
+            await self.ext.on_before_tool_execute(ctx)
+
+    @pytest.mark.asyncio
+    async def test_undeclared_tool_is_refused_even_for_admin(self):
+        """#14523: undeclared denies unconditionally, before any role is even
+        consulted — an admin role does not grant access to a tool nobody has
+        judged what permission it needs."""
+        ctx = HookContext(session_id="s1", message="test")
+        ctx.set("user_role", "admin")
+        with pytest.raises(PermissionError, match="no declared permission"):
+            await self.ext.on_before_tool_execute(ctx)
 
     # ------------------------------------------------------------------
     # Declared permission, caller lacks it

--- a/autobot-backend/services/mcp_dispatch.py
+++ b/autobot-backend/services/mcp_dispatch.py
@@ -60,23 +60,23 @@ class MCPDispatcher:
     calls do not incur extra HTTP round-trips for discovery.
 
     Cache refreshes automatically after CACHE_TTL_SECONDS (#2598).
-    Tools matching _ADMIN_ONLY_TOOLS patterns require role="admin" (#2598).
+
+    #14523: the original admin gate was ``_ADMIN_ONLY_TOOLS`` — a frozenset of
+    seven Redis command substrings (#2598) — checked before every real tool
+    lookup. It is retired here: ``dispatch()`` now denies on the same
+    canonical-RBAC verdict ``_would_deny`` already computed for stage 2's
+    shadow log, rather than a second, hand-maintained pattern list. Proven
+    equivalent for the blocklist's real targets before removal — every live
+    tool it matched (``redis_client_list``, ``redis_slowlog``) and every
+    pattern with no live tool yet (``config_set``, ``config_rewrite``,
+    ``debug``, ``flushdb``, ``flushall``, all declared ahead of time in
+    ``mcp_tool_permissions._DECLARED_AHEAD_OF_TIME``) resolve through
+    ``mcp_tool_permissions.TOOL_PERMISSIONS`` to ``Permission.MCP_MANAGE``,
+    which only the admin role holds — see the #14523 PR body for the set
+    comparison.
     """
 
     CACHE_TTL_SECONDS: int = 60
-
-    # Tool name substrings that require admin role (#2598)
-    _ADMIN_ONLY_TOOLS: frozenset = frozenset(
-        {
-            "client_list",
-            "slowlog",
-            "config_set",
-            "config_rewrite",
-            "debug",
-            "flushdb",
-            "flushall",
-        }
-    )
 
     def __init__(self) -> None:
         """Initialize dispatcher with empty tool cache."""
@@ -145,19 +145,16 @@ class MCPDispatcher:
     # Dispatch
     # ------------------------------------------------------------------
 
-    def _is_admin_only(self, tool_name: str) -> bool:
-        """Return True if tool_name matches any admin-only pattern (#2598)."""
-        return any(pattern in tool_name for pattern in self._ADMIN_ONLY_TOOLS)
-
     def _would_deny(self, tool_name: str, role: str) -> str | None:
-        """Return why RBAC *would* refuse this call, or None (#13228 stage 2).
+        """Return why canonical RBAC refuses this call, or None to permit (#13228/#14523).
 
-        Reports only; the caller does not act on it. The declaration landed in
-        stage 1 and the enforcement flip is stage 3, so this exists to answer the
-        one question the flip needs answered first: **which working calls would
-        it break?** The issue's own risk note predicts default-deny "will surface
-        tools that were silently reachable" — this turns that prediction into a
-        list before it costs anyone a broken agent run.
+        Stage 2 (#13228) used this for shadow logging only — the caller never
+        acted on it. Stage 3 (#14523) promotes it to the actual decision
+        ``dispatch()`` enforces, now that #14494 has proven the precondition
+        this needs: every tool the eleven governed bridges register carries an
+        exact ``TOOL_PERMISSIONS`` entry, so "undeclared" here means a tool
+        that should not have reached production, not a working call about to
+        break.
 
         Two distinct outcomes, kept distinct because they need different fixes:
         an undeclared tool needs a declaration; a declared one the role lacks
@@ -167,8 +164,8 @@ class MCPDispatcher:
             # An empty cache means the registry never answered, not that every
             # tool is undeclared (refresh_tool_cache swallows failures and
             # returns 0). Reporting "undeclared" here would fill the inventory
-            # with an infrastructure outage dressed as a policy gap — and if
-            # stage 3 enforced on that same signal, a registry blip would deny
+            # with an infrastructure outage dressed as a policy gap — and
+            # enforcing on that same signal would let a registry blip deny
             # every MCP call. No cache, no verdict.
             return None
 
@@ -181,7 +178,7 @@ class MCPDispatcher:
         # ADMIN_ROLES in autobot_shared.auth.permissions), so resolving it
         # through Role() would report the most privileged role in the system as
         # denied on every tool. is_admin_role is the canonical, case-insensitive
-        # answer and is what the legacy gate below already uses.
+        # answer.
         if is_admin_role(role):
             return None
         try:
@@ -192,15 +189,14 @@ class MCPDispatcher:
             return f"unknown-role:{role}"
         return None if declared in held else f"missing:{declared}"
 
-    def _log_rbac_shadow(self, tool_name: str, role: str) -> None:
-        """Log what canonical RBAC would have decided, without deciding (#13228).
+    def _log_rbac_shadow(self, tool_name: str, role: str, reason: str | None) -> None:
+        """Log a canonical-RBAC refusal (#13228 stage 2, now #14523's enforced verdict).
 
         Deduplicated on ``(tool, role, reason)``. The deliverable is the *set* of
-        disagreements, so repeating one per call would multiply the volume without
-        adding a fact — an agent loop touching one undeclared tool would otherwise
-        emit a warning per iteration.
+        distinct disagreements, so repeating one per call would multiply the
+        volume without adding a fact — an agent loop touching one undeclared
+        tool would otherwise emit a warning per iteration.
         """
-        reason = self._would_deny(tool_name, role)
         if reason is None:
             return
         seen_key = (tool_name, role, reason)
@@ -208,11 +204,20 @@ class MCPDispatcher:
             return
         self._rbac_shadow_seen.add(seen_key)
         logger.warning(
-            "MCPDispatcher[rbac-shadow]: role=%s tool=%s would be denied (%s) — " "not enforced yet, see #13228",
+            "MCPDispatcher[rbac-shadow]: role=%s tool=%s denied (%s) — #13228/#14523",
             role,
             tool_name,
             reason,
         )
+
+    @staticmethod
+    def _denial_response(tool_name: str, reason: str) -> dict:
+        """Build the refusal payload for a canonical-RBAC denial (#14523)."""
+        return {
+            "success": False,
+            "result": f"Tool {tool_name} denied: caller lacks the required permission ({reason})",
+            "bridge": None,
+        }
 
     async def dispatch(
         self,
@@ -224,7 +229,8 @@ class MCPDispatcher:
         """Dispatch a tool call to its registered MCP bridge.
 
         Refreshes the tool cache if stale (TTL-based, #2598).
-        Rejects admin-only tools when role != "admin" (#2598).
+        Denies on the canonical-RBAC verdict from ``_would_deny`` (#13228/#14523)
+        — an undeclared tool, or a declared one the caller's role lacks.
 
         Issue #3232: emits agent.tool.call before dispatch and
         agent.tool.result after, with sensitive argument redaction.
@@ -241,21 +247,12 @@ class MCPDispatcher:
 
         await self._ensure_cache_fresh()
 
-        # #13228 stage 2: record the canonical-RBAC verdict alongside the legacy
-        # blocklist without acting on it. The blocklist below still decides.
-        self._log_rbac_shadow(tool_name, role)
-
-        if not is_admin_role(role) and self._is_admin_only(tool_name):
-            logger.warning(
-                "MCPDispatcher: role=%s denied access to admin-only tool %s",
-                role,
-                tool_name,
-            )
-            return {
-                "success": False,
-                "result": f"Tool {tool_name} requires admin role",
-                "bridge": None,
-            }
+        # #14523: _would_deny now decides, replacing the retired _ADMIN_ONLY_TOOLS
+        # substring blocklist — see the class docstring for the coverage proof.
+        verdict = self._would_deny(tool_name, role)
+        self._log_rbac_shadow(tool_name, role, verdict)
+        if verdict is not None:
+            return self._denial_response(tool_name, verdict)
 
         tool = self.find_tool(tool_name)
         if not tool:
@@ -391,7 +388,10 @@ class MCPDispatcher:
     def get_tool_definitions(self, role: str = "user") -> list[dict]:
         """Return tool definitions in LLM-injectable format.
 
-        Admin-only tools are excluded when role != "admin" (#2598).
+        A tool is excluded when *role* fails its canonical-RBAC check (#2598,
+        folded into the canonical path at #14523) — this covers both an
+        under-privileged role and an undeclared tool, so the LLM is never
+        offered a tool that ``dispatch()`` would refuse anyway.
         Each entry contains name, description (prefixed with bridge name),
         and parameters (from the tool's input_schema).
 
@@ -408,7 +408,7 @@ class MCPDispatcher:
                 "parameters": tool.get("input_schema", {}),
             }
             for tool in self._tool_cache.values()
-            if is_admin_role(role) or not self._is_admin_only(tool["name"])
+            if self._would_deny(tool["name"], role) is None
         ]
 
 

--- a/autobot-backend/services/mcp_dispatch_rbac_shadow_test.py
+++ b/autobot-backend/services/mcp_dispatch_rbac_shadow_test.py
@@ -2,16 +2,20 @@
 # SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
-"""Shadow-mode RBAC reporting on the MCP dispatcher (#13228 stage 2).
+"""Canonical-RBAC verdict on the MCP dispatcher — shadow (#13228 stage 2) and
+enforced (#14523 stage 3).
 
-Stage 1 declared a permission per tool. Stage 3 will refuse the undeclared. This
-stage answers the question the flip needs answered first — *which working calls
-would it break?* — by reporting the canonical-RBAC verdict without acting on it.
+Stage 1 declared a permission per tool. Stage 2 (below, the `_would_deny` unit
+tests) reported what canonical RBAC would decide without acting on it, to
+answer the question the flip needed answered first: *which working calls
+would it break?* Stage 3 (#14523) promotes that same verdict to the actual
+decision `dispatch()` enforces, replacing the retired `_ADMIN_ONLY_TOOLS`
+substring blocklist.
 
-So the property under test is unusual and is the whole point: **the verdict must
-change nothing.** A test that only checked the log would pass just as happily if
-the shadow had started denying calls, which is the one outcome that must not
-happen yet.
+The `_would_deny` unit tests below are unchanged by the flip — they test the
+decision function, not who acts on it. The `dispatch()` integration tests in
+the second half now assert the opposite of what they asserted under stage 2:
+a would-be denial refuses the call rather than merely being logged.
 """
 
 from unittest.mock import AsyncMock, patch
@@ -132,17 +136,14 @@ def test_privileged_roles_hold_the_control_grants(role):
     assert d._would_deny("click", role) is None
 
 
-# --------------------------------------------- it must not change behaviour
+# ------------------------------------------------ stage 3: it now refuses
 
 
 @pytest.mark.asyncio
-async def test_a_would_be_denial_still_dispatches():
-    """The load-bearing test: shadow mode reports, it does not refuse.
-
-    If this ever fails, stage 2 has silently become stage 3 and every caller of
-    an undeclared tool starts breaking without the fallout inventory that the
-    flip is supposed to be based on.
-    """
+async def test_an_undeclared_tool_no_longer_dispatches():
+    """#14523: the load-bearing test flips here. Stage 2 pinned that shadow mode
+    must not refuse; stage 3 is exactly that flip landing on purpose, now that
+    #14494 has proven no live tool is actually undeclared."""
     d = _dispatcher({"mystery": _tool("mystery", None)})
     d._ensure_cache_fresh = AsyncMock()
     d._call_bridge = AsyncMock(return_value={"success": True, "result": "ran"})
@@ -153,12 +154,34 @@ async def test_a_would_be_denial_still_dispatches():
     ):
         result = await d.dispatch("mystery", {}, role="readonly")
 
-    assert result.get("success") is True, "shadow mode refused a call it must only report"
+    assert result.get("success") is False, "an undeclared tool must be refused, not dispatched"
+    d._call_bridge.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_the_legacy_blocklist_still_decides():
-    """`_ADMIN_ONLY_TOOLS` remains the authority until stage 3."""
+async def test_an_undeclared_tool_is_refused_even_for_admin():
+    """#14523: undeclared denies unconditionally — no role, including admin,
+    should be able to run a tool nobody has judged what permission it needs."""
+    d = _dispatcher({"mystery": _tool("mystery", None)})
+    d._ensure_cache_fresh = AsyncMock()
+    d._call_bridge = AsyncMock(return_value={"success": True, "result": "ran"})
+
+    with (
+        patch("chat_workflow.cot_events.emit_tool_call", AsyncMock()),
+        patch("chat_workflow.cot_events.emit_tool_result", AsyncMock()),
+    ):
+        result = await d.dispatch("mystery", {}, role="admin")
+
+    assert result.get("success") is False
+    d._call_bridge.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_flushall_still_denies_non_admin_via_canonical_rbac():
+    """#14523: replaces `_ADMIN_ONLY_TOOLS` — flushall's real declaration
+    (`mcp.manage`, `_DECLARED_AHEAD_OF_TIME` in mcp_tool_permissions.py) is
+    admin-exclusive, so the canonical path denies a non-admin exactly like the
+    retired substring blocklist did."""
     d = _dispatcher({"flushall": _tool("flushall", "mcp.manage", bridge="redis_mcp")})
     d._ensure_cache_fresh = AsyncMock()
     d._call_bridge = AsyncMock(return_value={"success": True, "result": "ran"})
@@ -169,7 +192,26 @@ async def test_the_legacy_blocklist_still_decides():
     ):
         result = await d.dispatch("flushall", {}, role="user")
 
-    assert result.get("success") is False, "the legacy blocklist stopped enforcing"
+    assert result.get("success") is False, "the canonical path stopped enforcing"
+    d._call_bridge.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_flushall_still_dispatches_for_admin_via_canonical_rbac():
+    """The control case: the canonical path is not overly strict — admin still
+    reaches flushall, matching the retired blocklist's actual behaviour."""
+    d = _dispatcher({"flushall": _tool("flushall", "mcp.manage", bridge="redis_mcp")})
+    d._ensure_cache_fresh = AsyncMock()
+    d._call_bridge = AsyncMock(return_value={"success": True, "result": "ran"})
+
+    with (
+        patch("chat_workflow.cot_events.emit_tool_call", AsyncMock()),
+        patch("chat_workflow.cot_events.emit_tool_result", AsyncMock()),
+    ):
+        result = await d.dispatch("flushall", {}, role="admin")
+
+    assert result.get("success") is True
+    d._call_bridge.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/autobot-backend/services/mcp_dispatch_test.py
+++ b/autobot-backend/services/mcp_dispatch_test.py
@@ -13,7 +13,14 @@ Coverage:
 - get_tool_definitions() formats correctly
 - refresh_tool_cache() handles registry HTTP errors gracefully
 - Cache TTL triggers refresh after expiry (#2598)
-- RBAC filtering hides admin-only tools from non-admin callers (#2598)
+- RBAC filtering hides admin-only tools from non-admin callers (#2598, folded
+  into the canonical `_would_deny` check at #14523)
+
+#14523: fixture tool dicts now carry `required_permission`, matching what the
+real registry (`mcp_registry._build_tool_entry`) always sets. Before this,
+`dispatch()` only checked a name-based admin blocklist and everything else was
+reachable regardless of declaration; a fixture with no `required_permission`
+would now read as "undeclared" and be refused, same as a real one would be.
 """
 
 import time
@@ -35,6 +42,10 @@ _SAMPLE_TOOL = {
     "bridge": "knowledge_mcp",
     "endpoint": get_test_backend_url() + "/api/knowledge/mcp/search_knowledge_base",
     "features": ["search"],
+    # #14523: real value from mcp_tool_permissions.TOOL_PERMISSIONS — every
+    # role from "user" up holds this, so it stays permitted everywhere it was
+    # implicitly permitted before declarations were enforced.
+    "required_permission": "knowledge.read",
 }
 
 
@@ -242,6 +253,8 @@ _ADMIN_TOOL = {
     "bridge": "redis_mcp",
     "endpoint": get_test_backend_url() + "/api/redis/mcp/client_list",
     "features": [],
+    # #14523: real value from mcp_tool_permissions.TOOL_PERMISSIONS — admin-only.
+    "required_permission": "mcp.manage",
 }
 
 
@@ -329,12 +342,42 @@ def test_get_tool_definitions_shows_all_for_admin() -> None:
 
 @pytest.mark.asyncio
 async def test_dispatch_rejects_admin_tool_for_user() -> None:
-    """dispatch() should return success=False for admin-only tool when role='user' (#2598)."""
+    """dispatch() should return success=False for admin-only tool when role='user'
+    (#2598, now enforced via the canonical `_would_deny` verdict — #14523)."""
     d = _make_dispatcher_with_cache(_ADMIN_TOOL)
     d._cache_timestamp = time.monotonic()  # keep cache fresh to avoid network call
 
     result = await d.dispatch("redis_client_list", {}, role="user")
 
     assert result["success"] is False
-    assert "admin" in result["result"].lower()
+    assert "permission" in result["result"].lower()
     assert result["bridge"] is None
+
+
+@pytest.mark.asyncio
+async def test_dispatch_allows_admin_tool_for_admin() -> None:
+    """#14523: the control case — admin still reaches the admin-only tool."""
+    d = _make_dispatcher_with_cache(_ADMIN_TOOL)
+    d._cache_timestamp = time.monotonic()
+    d._call_bridge = AsyncMock(return_value={"success": True, "result": "ran", "bridge": "redis_mcp"})
+
+    result = await d.dispatch("redis_client_list", {}, role="admin")
+
+    assert result["success"] is True
+    d._call_bridge.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_rejects_an_undeclared_tool() -> None:
+    """#14523: a cached tool with no `required_permission` at all is refused,
+    not silently dispatched — the runtime half of #13228 this issue closes."""
+    undeclared = {**_SAMPLE_TOOL, "name": "mystery_tool", "required_permission": None}
+    d = _make_dispatcher_with_cache(undeclared)
+    d._cache_timestamp = time.monotonic()
+    d._call_bridge = AsyncMock(return_value={"success": True, "result": "ran", "bridge": "knowledge_mcp"})
+
+    result = await d.dispatch("mystery_tool", {}, role="admin")
+
+    assert result["success"] is False
+    assert "permission" in result["result"].lower()
+    d._call_bridge.assert_not_called()

--- a/autobot-backend/tests/unit/chat_workflow/test_auth_role_plumbing.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_auth_role_plumbing.py
@@ -158,6 +158,12 @@ class TestTheEffectOnAdminOnlyTools:
 
     Exercised against the real `MCPDispatcher` gate rather than a stand-in, since
     the bug was that this gate never saw a role other than "user".
+
+    #14523: the gate itself moved from the `_ADMIN_ONLY_TOOLS` substring
+    blocklist to the canonical `required_permission`/role check, so the
+    fixture now carries the declared permission (`mcp.manage`, admin-only in
+    `ROLE_PERMISSIONS`) a real admin-only tool would have — this AC is about
+    the role plumbing, not the specific gating mechanism underneath it.
     """
 
     @staticmethod
@@ -165,7 +171,14 @@ class TestTheEffectOnAdminOnlyTools:
         from services.mcp_dispatch import MCPDispatcher
 
         d = MCPDispatcher()
-        d._tool_cache = {"redis_flushall": {"name": "redis_flushall", "bridge": "redis", "endpoint": "/x"}}
+        d._tool_cache = {
+            "redis_flushall": {
+                "name": "redis_flushall",
+                "bridge": "redis",
+                "endpoint": "/x",
+                "required_permission": "mcp.manage",
+            }
+        }
 
         async def _fresh():
             return None
@@ -188,4 +201,4 @@ class TestTheEffectOnAdminOnlyTools:
         result = await self._dispatcher().dispatch("redis_flushall", {}, role=DEFAULT_AUTH_ROLE)
 
         assert result["success"] is False
-        assert "admin" in str(result["result"]).lower()
+        assert "permission" in str(result["result"]).lower()

--- a/autobot_shared/auth/mcp_tool_permissions.py
+++ b/autobot_shared/auth/mcp_tool_permissions.py
@@ -26,26 +26,27 @@ Two levels, and the order matters:
    no exact entry here, which is what makes falling through to this baseline a
    CI-time event rather than a silent grant.
 
-**What this module actually guarantees, stated precisely (security review,
-#14521).** ``required_permission()`` is not changed by #14494 and still
-default-allows at runtime in both branches it can take:
+**#14523 (stage 3) — deny-by-default at runtime, closing the gap #14521's
+security review found in #14494.** Before this, ``required_permission()``
+default-allowed in both branches it could return: a tool absent from
+``TOOL_PERMISSIONS`` on a *known* bridge fell through to
+``BRIDGE_DEFAULT_PERMISSIONS`` (a real, grantable read permission, not a
+denial), and a tool on an *unknown* bridge resolved to ``None``, which
+``PermissionEnforcementExtension`` treated as "legacy — allow through" with no
+check at all. Both branches now return ``None`` for any tool absent from
+``TOOL_PERMISSIONS``, known bridge or not, and
+``PermissionEnforcementExtension.on_before_tool_execute`` refuses on ``None``
+instead of waving it through (see that module).
 
-* a tool absent from ``TOOL_PERMISSIONS`` on a *known* bridge resolves through
-  ``BRIDGE_DEFAULT_PERMISSIONS`` — a real, grantable read permission, not a
-  denial (pinned by
-  ``test_an_undeclared_tool_on_a_known_bridge_inherits_the_least_privilege``);
-* a tool on an *unknown* bridge resolves to ``None``, and
-  ``PermissionEnforcementExtension`` currently treats ``None`` as legacy —
-  allowed through with no check at all.
-
-What #14494 actually delivers is **complete CI-time coverage**: every tool the
-eleven governed bridges register today has an exact entry, and
-``tools/lint/check_mcp_tool_permission_coverage.py`` (a required check) fails
-the moment a live tool has none. That coverage is backstopped at runtime only
-by the read-level default above — not by a denial. Tightening
-``required_permission``/the enforcement extension so an undeclared tool is
-refused rather than default-allowed at runtime is tracked separately as the
-#13228 stage-3 follow-up; this module does not attempt it.
+This was safe to flip only because #14494 already proved the precondition:
+every tool the eleven governed bridges register carries an exact
+``TOOL_PERMISSIONS`` entry (measured independently at #14523 time: 104 live
+tools, 0 undeclared, 0 name collisions across bridges — see
+``tools/lint/check_mcp_tool_permission_coverage.py``, still the required
+check that keeps it true). ``BRIDGE_DEFAULT_PERMISSIONS`` no longer grants
+anything at runtime; it stays as the registry ``test_every_bridge_has_a_default``
+checks a new bridge into before any of its tools can be declared, and as the
+source for the coverage checker's per-bridge discovery floors.
 
 **#14494 — every tool this system knows about carries an exact entry below.**
 The under-grant guard used to infer "mutating" from a hand-written verb list
@@ -57,17 +58,25 @@ registers today is declared here explicitly, so classification is a property of
 the tool, not a guess from its name. ``_DECLARED_AHEAD_OF_TIME`` below is the
 only sanctioned exception, and only for a tool that does not exist yet.
 
-**This module only describes. It enforces nothing on its own.** Stage 1 attaches
-the resolved value to the registry entry so it can be inspected and logged;
-``dispatch()`` still applies the old rule until the fallout inventory is in.
+**This module only describes; it does not execute a check itself.** Stage 1
+attached the resolved value to the registry entry so it could be inspected and
+logged. ``PermissionEnforcementExtension`` (stage 3, #14523) is what turns the
+``None`` this module now returns for an undeclared tool into an actual refusal;
+``MCPDispatcher.dispatch()`` also acts on the same canonical resolution (via
+``_would_deny``) rather than the retired ``_ADMIN_ONLY_TOOLS`` substring list.
 """
 
 from typing import Dict, Optional
 
 from autobot_shared.auth.permissions import Permission
 
-# Baseline per bridge — deliberately the least-privileged operation the bridge
-# offers, so an undeclared future tool under-grants rather than over-grants.
+# The eleven bridges this system governs, and the least-privileged operation
+# each offers. #14523: no longer consulted by ``required_permission()`` as a
+# runtime fallback grant — an undeclared tool is refused regardless of bridge.
+# Retained as the registry ``test_every_bridge_has_a_default`` requires a new
+# bridge to join before any of its tools can be declared, and as the source
+# for the coverage checker's per-bridge discovery floors
+# (``tools/lint/check_mcp_tool_permission_coverage.py``).
 BRIDGE_DEFAULT_PERMISSIONS: Dict[str, Permission] = {
     "browser_mcp": Permission.MCP_BROWSER_READ,
     "database_mcp": Permission.MCP_DATABASE_READ,
@@ -271,22 +280,25 @@ TOOL_PERMISSIONS: Dict[str, Permission] = {
 
 
 def required_permission(tool_name: str, bridge_name: str = "") -> Optional[Permission]:
-    """Return the permission *tool_name* requires, or ``None`` for an unknown bridge.
+    """Return the permission *tool_name* requires, or ``None`` if undeclared (#14523).
 
-    A tool absent from ``TOOL_PERMISSIONS`` still resolves through
-    ``BRIDGE_DEFAULT_PERMISSIONS`` as long as *bridge_name* is one of the eleven
-    governed bridges — a real, grantable read permission, not a refusal.
-    ``None`` only happens for a bridge this module has never heard of, and
-    ``PermissionEnforcementExtension`` currently treats that ``None`` as legacy
-    (allowed through, unchecked) rather than as a denial — see the module
-    docstring's "what this actually guarantees" note and the #13228 stage-3
-    follow-up. #14494 makes every tool on a *known* bridge carry an exact entry
-    at CI time; it does not change what this function returns.
+    Deny-by-default: an exact ``TOOL_PERMISSIONS`` entry is the only way a tool
+    resolves to a permission. Everything else returns ``None`` — a tool on one
+    of the eleven governed bridges with no exact entry included, not only a
+    tool on a bridge this module has never heard of. Before #14523 the known-
+    bridge case fell through to ``BRIDGE_DEFAULT_PERMISSIONS`` and granted a
+    real read permission instead of refusing; that fallback is retired here.
+    ``PermissionEnforcementExtension.on_before_tool_execute`` refuses on
+    ``None`` rather than treating it as a legacy allow — see that module.
+
+    *bridge_name* is kept for call-site symmetry with callers that already
+    know a tool's bridge (``mcp_registry._build_tool_entry``,
+    ``_handle_browser_tool``); it no longer changes what this function
+    returns. #14494's required check is what keeps the precondition this
+    relies on true: every tool a governed bridge registers today carries an
+    exact entry, so nothing that was reachable before #14523 loses its grant.
     """
-    exact = TOOL_PERMISSIONS.get(tool_name)
-    if exact is not None:
-        return exact
-    return BRIDGE_DEFAULT_PERMISSIONS.get(bridge_name)
+    return TOOL_PERMISSIONS.get(tool_name)
 
 
 __all__ = [

--- a/autobot_shared/auth/mcp_tool_permissions_test.py
+++ b/autobot_shared/auth/mcp_tool_permissions_test.py
@@ -95,6 +95,31 @@ def test_the_bridge_sources_are_actually_being_read():
     assert total > 50, f"only {total} tool names extracted — the parser stopped matching: {found}"
 
 
+def test_no_tool_name_is_shared_across_two_bridges():
+    """#14523: TOOL_PERMISSIONS is keyed by tool name alone, not (bridge, tool).
+
+    Two bridges registering a tool with the same name would have one silently
+    resolve through the other's declared permission. Runs the checker's own
+    `tool_name_collisions()` — the required CI check, not a second parser that
+    could drift from it — against the real bridge sources. Zero collisions
+    across 104 tools when this landed.
+    """
+    checker = _load_coverage_checker()
+    collisions = checker.tool_name_collisions()
+
+    assert not collisions, f"tool name(s) registered on more than one bridge: {collisions}"
+
+
+def test_every_bridge_clears_its_own_discovery_floor():
+    """#14523: a per-bridge floor, so one bridge's count dropping cannot hide
+    inside a healthy sum. See `bridge_discovery_gaps` for the aggregate's
+    blind spot this closes."""
+    checker = _load_coverage_checker()
+    gaps = checker.bridge_discovery_gaps()
+
+    assert not gaps, "\n".join(gaps)
+
+
 def test_every_live_tool_carries_an_explicit_declaration():
     """#14494: the actual required-check guard, run against the real tree.
 
@@ -120,16 +145,21 @@ def test_an_exact_tool_entry_beats_its_bridge_default():
 
 
 def test_an_unknown_bridge_resolves_to_none():
-    """None is what stage 3 refuses — the inversion this issue is about."""
+    """#14523: this is now an actual refusal, not just a signal nothing acts on
+    — PermissionEnforcementExtension.on_before_tool_execute denies on None."""
     assert required_permission("whatever", "not_a_bridge") is None
 
 
-def test_an_undeclared_tool_on_a_known_bridge_inherits_the_least_privilege():
-    """A tool `required_permission` has never heard of under-grants rather than
-    over-grants. `tools/lint/check_mcp_tool_permission_coverage.py` is what stops
-    a REAL tool from staying in this state (#14494) — this pins the fallback
-    itself, which stays in place as defense-in-depth."""
-    assert required_permission("some_future_tool", "browser_mcp") == Permission.MCP_BROWSER_READ
+def test_an_undeclared_tool_on_a_known_bridge_is_also_refused():
+    """#14523 replaces the old invariant this test used to pin (a known bridge's
+    least-privileged default granting an undeclared tool a real read
+    permission). A tool `required_permission` has never heard of is now refused
+    exactly like one on a bridge this module has never heard of — bridge_name no
+    longer changes the answer. `tools/lint/check_mcp_tool_permission_coverage.py`
+    (#14494) is the CI-time guarantee that a REAL tool never actually reaches
+    this branch; this pins what happens if one somehow does."""
+    assert required_permission("some_future_tool", "browser_mcp") is None
+    assert required_permission("some_future_tool", "browser_mcp") != Permission.MCP_BROWSER_READ
 
 
 def test_the_old_blocklist_tools_still_require_management():

--- a/tools/lint/check_mcp_tool_permission_coverage.py
+++ b/tools/lint/check_mcp_tool_permission_coverage.py
@@ -46,6 +46,23 @@ The audit reports how many live tools it reached and fails below a floor,
 because a scan that finds zero tools passes having asserted nothing — the
 exact failure mode #14494 found in ``sequential_thinking_mcp``, whose one tool
 was declared in a source shape the original scanner never matched.
+
+#14523 adds two more checks this module is the natural home for, now that
+runtime resolution denies by default and genuinely relies on this coverage
+being complete:
+
+- PER-BRIDGE DISCOVERY FLOORS. ``DISCOVERY_FLOOR`` is one number over the sum
+  of every bridge's tool count. A bridge whose own scan drops from, say, 25
+  tools to 1 (the parser silently stopped matching that bridge's declaration
+  shape) is invisible to the sum as long as some other bridge's count happens
+  to be healthy — the combined total can still clear the floor. Each bridge in
+  ``PER_BRIDGE_DISCOVERY_FLOOR`` is checked against its own floor so a
+  per-bridge regression cannot hide inside a healthy aggregate.
+- NAME COLLISIONS. ``TOOL_PERMISSIONS`` is keyed by tool name alone, not
+  ``(bridge, tool)``. Two different bridges registering a tool with the same
+  name would have one silently resolve through the other's declared
+  permission. Zero collisions across the 104 tools these eleven bridges
+  register today; this is what would catch a twelfth bridge introducing one.
 """
 
 from __future__ import annotations
@@ -79,10 +96,33 @@ logger = logging.getLogger(__name__)
 #: Repo-relative path of this checker, quoted in the messages that ask for an edit.
 SELF_REL = "tools/lint/check_mcp_tool_permission_coverage.py"
 
-#: Floor for the sweep's own discovery. The eleven governed bridges registered
-#: 104 tools when this landed; a sweep that suddenly reaches a handful has
-#: broken, and a clean result from it would assert nothing.
+#: Floor for the sweep's own discovery, summed over every bridge. The eleven
+#: governed bridges registered 104 tools when this landed; a sweep that
+#: suddenly reaches a handful has broken, and a clean result from it would
+#: assert nothing. Kept as a coarse aggregate sanity net alongside the
+#: per-bridge floors below (#14523) — those catch a single bridge's own count
+#: dropping; this one is the cheap "did the sweep basically work at all" check.
 DISCOVERY_FLOOR = 90
+
+#: Per-bridge floor (#14523): each governed bridge's own tool count today, so
+#: one bridge silently dropping to near-zero cannot hide inside a total the
+#: other ten bridges keep healthy. A legitimate new tool only ever raises a
+#: bridge's count, so raising these is a one-line follow-up when that happens
+#: — a drop is always either a parser regression or a real removal, and either
+#: one deserves a look before it merges.
+PER_BRIDGE_DISCOVERY_FLOOR: dict[str, int] = {
+    "browser_mcp": 17,
+    "database_mcp": 6,
+    "filesystem_mcp": 13,
+    "git_mcp": 6,
+    "http_client_mcp": 6,
+    "knowledge_mcp": 12,
+    "prometheus_mcp": 6,
+    "redis_mcp": 25,
+    "sequential_thinking_mcp": 1,
+    "structured_thinking_mcp": 3,
+    "vnc_mcp": 9,
+}
 
 
 def undeclared_tools(base: pathlib.Path | None = None) -> dict[str, list[str]]:
@@ -98,6 +138,41 @@ def undeclared_tools(base: pathlib.Path | None = None) -> dict[str, list[str]]:
         if missing:
             problems[bridge] = missing
     return problems
+
+
+def bridge_discovery_gaps(base: pathlib.Path | None = None) -> list[str]:
+    """Known bridges whose own scan fell below their own floor (#14523).
+
+    Complements ``DISCOVERY_FLOOR``: that one checks the sum, this checks each
+    bridge in ``PER_BRIDGE_DISCOVERY_FLOOR`` individually, so one bridge's
+    count regressing cannot hide behind a healthy total.
+    """
+    found = all_declared_tools(base)
+    problems: list[str] = []
+    for bridge, floor in PER_BRIDGE_DISCOVERY_FLOOR.items():
+        count = len(found.get(bridge, set()))
+        if count < floor:
+            problems.append(
+                f"{bridge}: scan reached only {count} tool(s), below its own floor of "
+                f"{floor} — either the parser stopped matching this bridge's declaration "
+                "shape, or a real tool was removed without lowering PER_BRIDGE_DISCOVERY_FLOOR."
+            )
+    return problems
+
+
+def tool_name_collisions(base: pathlib.Path | None = None) -> dict[str, list[str]]:
+    """Tool names registered by more than one bridge (#14523).
+
+    ``TOOL_PERMISSIONS`` is keyed by tool name alone. Two bridges registering a
+    tool with the same name would have one silently resolve through the
+    other's declared permission — this is what would catch that before merge.
+    """
+    found = all_declared_tools(base)
+    name_to_bridges: dict[str, list[str]] = {}
+    for bridge, tools in found.items():
+        for tool in tools:
+            name_to_bridges.setdefault(tool, []).append(bridge)
+    return {name: sorted(bridges) for name, bridges in name_to_bridges.items() if len(bridges) > 1}
 
 
 def stale_declarations(base: pathlib.Path | None = None) -> list[str]:
@@ -146,15 +221,24 @@ def audit(base: pathlib.Path | None = None) -> tuple[int, list[str]]:
             f"(floor {DISCOVERY_FLOOR}) — the sweep broke, so a clean result below would "
             "assert nothing."
         )
+    problems.extend(bridge_discovery_gaps(base))
 
     undeclared = undeclared_tools(base)
     if undeclared:
         lines = "\n".join(f"  {bridge}: {', '.join(names)}" for bridge, names in sorted(undeclared.items()))
         problems.append(
             "tool(s) a live bridge registers with no exact entry in TOOL_PERMISSIONS "
-            "(autobot_shared/auth/mcp_tool_permissions.py) — each one silently inherits its "
-            f"bridge's read-level default (#14494):\n{lines}\n\nAdd an exact entry for each, at "
-            "the permission the tool actually needs."
+            "(autobot_shared/auth/mcp_tool_permissions.py) — each one is refused outright at "
+            f"runtime rather than inheriting a bridge default (#14523):\n{lines}\n\nAdd an exact "
+            "entry for each, at the permission the tool actually needs."
+        )
+
+    collisions = tool_name_collisions(base)
+    if collisions:
+        problems.append(
+            "tool name(s) registered by more than one bridge — TOOL_PERMISSIONS is keyed by "
+            f"name alone and would resolve one bridge's tool through the other's entry (#14523): "
+            f"{collisions}. Rename one of the tools, or key TOOL_PERMISSIONS by (bridge, tool)."
         )
 
     problems.extend(declared_ahead_of_time_problems(base))


### PR DESCRIPTION
Closes #14523

## Thinking Path

The issue offers two options and asks for evidence, not a default pick.
Before choosing, I measured the option-1 precondition myself (never assumed
it): using a standalone static scan of the real bridge sources and the real
`TOOL_PERMISSIONS`/`BRIDGE_DEFAULT_PERMISSIONS` tables (regex/AST reading, no
`import autobot_shared`), the eleven governed bridges register **104 live
tools, all 104 with an exact `TOOL_PERMISSIONS` entry, 0 undeclared, and 0
tool names shared across two bridges**. `TOOL_PERMISSIONS` itself parses to
110 unique keys with zero internal duplicates (104 live + 6
`_DECLARED_AHEAD_OF_TIME`). That is exactly the precondition option 1
requires, so I implemented **option 1: flip `required_permission()` to
deny-by-default**, not option 2 (document-and-close) — the precondition holds
today and #14494's required CI check keeps it holding.

For the `_ADMIN_ONLY_TOOLS` blocklist in `MCPDispatcher.dispatch()`, I did the
required set-comparison before touching it: every live tool the 7-substring
blocklist matches (`redis_client_list`, `redis_slowlog`) and every pattern
with no live tool yet (`config_set`, `config_rewrite`, `debug`, `flushdb`,
`flushall`, all in `_DECLARED_AHEAD_OF_TIME`) resolve through the canonical
table to `Permission.MCP_MANAGE`, which only `Role.ADMIN` holds in
`ROLE_PERMISSIONS`. That proves the canonical path covers everything the
blocklist covered, so I folded `dispatch()`'s enforcement into the same
`_would_deny` verdict `MCPDispatcher` already computed for stage 2's shadow
log (promoting it from report-only to enforced), and removed the retired
blocklist rather than leaving two mechanisms that could drift.

## What Changed

- `autobot_shared/auth/mcp_tool_permissions.py`: `required_permission()` now
  returns `None` for **any** tool absent from `TOOL_PERMISSIONS` — a known
  bridge no longer falls through to `BRIDGE_DEFAULT_PERMISSIONS` for a grant.
  `BRIDGE_DEFAULT_PERMISSIONS` stays as the registry `test_every_bridge_has_a_default`
  checks a bridge into, and as the source for the coverage checker's new
  per-bridge floors — it no longer grants anything at runtime.
- `autobot-backend/middleware/builtin/permission_enforcement.py`:
  `PermissionEnforcementExtension.on_before_tool_execute` refuses (raises
  `PermissionError`) when `tool_permission` is `None`, instead of treating it
  as "legacy tool, allow through". Denial happens before any role is even
  consulted — an admin role does not rescue an undeclared tool.
- `autobot-backend/services/mcp_dispatch.py`: removed `_ADMIN_ONLY_TOOLS`/
  `_is_admin_only`. `dispatch()` and `get_tool_definitions()` now both act on
  `_would_deny()`'s canonical-RBAC verdict (undeclared, or declared-but-role-
  lacks-it) instead of the substring blocklist.
- `tools/lint/check_mcp_tool_permission_coverage.py`: added
  `PER_BRIDGE_DISCOVERY_FLOOR` (each of the 11 bridges' own tool count) so one
  bridge's scan regressing can't hide inside a healthy combined sum, and
  `tool_name_collisions()` so a future bridge registering a tool name another
  bridge already uses fails CI instead of silently taking the wrong
  permission.
- Test updates across `mcp_tool_permissions_test.py`,
  `permission_enforcement_test.py`, `mcp_dispatch_test.py`,
  `mcp_dispatch_rbac_shadow_test.py`, `test_auth_role_plumbing.py`,
  `mcp_registry_test.py`: the tests that pinned the old default-allow/
  blocklist behaviour now assert the deny-by-default invariant instead
  (including new coverage for "undeclared denies even admin" and "declared
  admin-only tools still work for admin" as control cases).
- Did not touch the `map_site` entry in `TOOL_PERMISSIONS` (PR #14558 owns
  that line).

## Verification

**Precondition (measured, not assumed):** a standalone scratch script parsed
the real `autobot-backend/api/*_mcp.py` / `*_mcp/tools.py` sources and the
real `mcp_tool_permissions.py` tables as text (no product import) —
**104 live tools across the 11 governed bridges, 0 undeclared, 0 name
collisions, 110 unique `TOOL_PERMISSIONS` keys (104 live + 6 declared-ahead-
of-time), 0 internal duplicate keys.** Per-bridge counts (browser 17,
database 6, filesystem 13, git 6, http_client 6, knowledge 12, prometheus 6,
redis 25, sequential_thinking 1, structured_thinking 3, vnc 9) match the new
`PER_BRIDGE_DISCOVERY_FLOOR` values exactly.

**Blocklist coverage proof (measured):** the same script substring-matched
the 7 legacy patterns against the 104 live tool names — only
`redis_client_list`/`redis_slowlog` match live, and every matched/ahead-of-
time tool resolves to `MCP_MANAGE`, which `ROLE_PERMISSIONS` grants
exclusively to `Role.ADMIN` (confirmed against every non-admin role).

**Exploit run (extracted decision path, not the product's code):** built two
standalone modules mirroring `required_permission()`/the enforcement
decision — one "fixed" (deny-by-default) and one "mutated" back to the
pre-#14523 shape — and drove both an undeclared tool on a known bridge
(`browser_mcp`) and an undeclared tool on an unknown bridge
(`not_a_bridge`) through each via a shared runner.
- **Before (mutated/pre-fix module): 0 passed, 2 failed** — both cases were
  allowed through (known bridge granted `MCP_BROWSER_READ`, unknown bridge's
  `None` treated as "legacy, allow").
- **After (fixed module): 2 passed, 0 failed** — both refused.

This demonstrates the guard's shape, not the deployment — per this repo's
"never run code from the codebase" policy, the actual product modules were
only read/statically analysed, never imported or executed; CI (including the
existing required `mcp-tool-permission-coverage` check plus the new per-
bridge/collision assertions) is the authority on the real change.

## Blast Radius

This changes live MCP authorization for every "legacy" tool call that used to
reach `PermissionEnforcementExtension`/`MCPDispatcher` with no declared
permission. Given the measured precondition (0 undeclared live tools today),
no currently-working call should be affected. If a tool nonetheless reaches
production without a declaration — a twelfth bridge, or a declaration shape
`mcp_bridge_scan` doesn't recognise — an operator would see: the LLM no
longer offered that tool (`get_tool_definitions` filters it), a
`PermissionError` / `permission_denied` cancellation from the hook path, and
an MCP-registry dispatch returning `success: false` with a message naming the
tool and reason. All three now log (`MCPDispatcher[rbac-shadow]` and the
extension's own warning) so the gap is visible rather than silent, which is
the inversion this issue set out to make.

## Model Used

Claude Opus 5 (1M context)