### PR TITLE
fix(infrastructure): 18 sys.path bootstraps default to the live install instead of the checkout (#14544)

### DIFF
--- a/.github/filters/python-paths.yml
+++ b/.github/filters/python-paths.yml
@@ -33,3 +33,15 @@ python:
   - '.github/workflows/python-required-context.yml'
   # A change here changes what "python" means for both workflows.
   - '.github/filters/python-paths.yml'
+  # #14544/#14575: repo_tests/deployment_declares_project_root_14544_test.py
+  # asserts each of these five non-.py deployment sources still declares
+  # AUTOBOT_PROJECT_ROOT. Without an explicit entry here, editing only one of
+  # them (no `**/*.py` touched) computes `python != 'true'`, the shim reports
+  # `python-suite` green, and the guard test that would have caught a dropped
+  # declaration never runs -- the exact "required check gated by a filter that
+  # omits the inputs it guards" shape flagged in review.
+  - 'docker/backend/Dockerfile'
+  - 'docker/slm/Dockerfile'
+  - 'autobot-slm-backend/ansible/roles/slm_manager/templates/autobot-slm-backend.service.j2'
+  - 'autobot-slm-backend/ansible/roles/slm_agent/templates/slm-agent.service.j2'
+  - 'autobot-slm-backend/ansible/roles/ai-stack/templates/ai-stack.env.j2'

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -201,6 +201,18 @@ jobs:
     - name: Block hardcoded-IP fallback regressions (#6783, #6991)
       run: bash pipeline-scripts/check-pre-commit-hook-pr.sh --python tools/lint/check_no_hardcoded_ip_fallbacks.py --ext py
 
+    - name: Block live-install sys.path default regressions (#14544)
+      run: |
+        # 18 sys.path bootstraps across 17 files open-coded the project root
+        # as `os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source")`
+        # instead of the canonical `autobot_shared.paths.project_root()` walk.
+        # With the env var unset -- the normal case in a checkout -- that put
+        # the LIVE DEPLOYED INSTALL first on sys.path, so a script run from a
+        # working tree silently imported the deployed copy of every
+        # first-party module it named. #14544 swept all 18; this blocks a new
+        # one from copying the pattern forward.
+        bash pipeline-scripts/check-pre-commit-hook-pr.sh --python tools/lint/check_no_live_install_sys_path_default.py --ext py
+
     - name: Block direct redis client regressions (#1086, #6785)
       run: bash pipeline-scripts/check-pre-commit-hook-pr.sh pre-commit-no-direct-redis
 

--- a/autobot-infrastructure/shared/scripts/analysis/debug_circuit_breaker.py
+++ b/autobot-infrastructure/shared/scripts/analysis/debug_circuit_breaker.py
@@ -10,12 +10,13 @@ Test script to check circuit breaker state
 import asyncio
 import logging
 import sys
-import os
+
+from autobot_shared.paths import project_root
 
 logger = logging.getLogger(__name__)
 
 # Add the src directory to the path
-sys.path.insert(0, os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
+sys.path.insert(0, str(project_root()))
 
 from circuit_breaker import circuit_breaker_manager
 

--- a/autobot-infrastructure/shared/scripts/analysis/redis_final_analysis.py
+++ b/autobot-infrastructure/shared/scripts/analysis/redis_final_analysis.py
@@ -16,7 +16,7 @@ from typing import Any, Dict, List, Tuple
 
 from autobot_shared.paths import project_root
 
-sys.path.insert(0, os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
+sys.path.insert(0, str(project_root()))
 from constants import ServiceURLs
 from constants.network_constants import NetworkConstants
 

--- a/autobot-infrastructure/shared/scripts/analysis/redis_vector_analysis.py
+++ b/autobot-infrastructure/shared/scripts/analysis/redis_vector_analysis.py
@@ -12,14 +12,13 @@ import asyncio
 import json
 import logging
 import sys
-import os
 from typing import Any, Dict, List, Tuple
 
 from autobot_shared.paths import project_root
 from constants import ServiceURLs
 
 # Add project root to path
-sys.path.insert(0, os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
+sys.path.insert(0, str(project_root()))
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")

--- a/autobot-infrastructure/shared/scripts/analysis/simple_kb_test.py
+++ b/autobot-infrastructure/shared/scripts/analysis/simple_kb_test.py
@@ -10,9 +10,10 @@ Simple test of current AutoBot knowledge base functionality
 import asyncio
 import logging
 import sys
-import os
 
-sys.path.insert(0, os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
+from autobot_shared.paths import project_root
+
+sys.path.insert(0, str(project_root()))
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/autobot-infrastructure/shared/scripts/analysis/test_autobot_identity.py
+++ b/autobot-infrastructure/shared/scripts/analysis/test_autobot_identity.py
@@ -10,9 +10,10 @@ Test AutoBot identity in knowledge base
 import asyncio
 import logging
 import sys
-import os
 
-sys.path.insert(0, os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
+from autobot_shared.paths import project_root
+
+sys.path.insert(0, str(project_root()))
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/autobot-infrastructure/shared/scripts/analysis/test_data_layer_debug.py
+++ b/autobot-infrastructure/shared/scripts/analysis/test_data_layer_debug.py
@@ -195,7 +195,9 @@ def test_backend_errors():
         # Test Redis database manager import
         import sys
 
-        sys.path.append(os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
+        from autobot_shared.paths import project_root
+
+        sys.path.append(str(project_root()))
 
         from utils.redis_database_manager import RedisDatabaseManager
 

--- a/autobot-infrastructure/shared/scripts/analysis/test_documentation_api.py
+++ b/autobot-infrastructure/shared/scripts/analysis/test_documentation_api.py
@@ -10,13 +10,12 @@ Test Documentation API Endpoints (Local Testing)
 import asyncio
 import logging
 import sys
-import os
 from pathlib import Path
 
 from autobot_shared.paths import project_root
 
 # Add project root to Python path
-sys.path.insert(0, os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
+sys.path.insert(0, str(project_root()))
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/autobot-infrastructure/shared/scripts/analysis/test_kb_documentation.py
+++ b/autobot-infrastructure/shared/scripts/analysis/test_kb_documentation.py
@@ -10,9 +10,10 @@ Test knowledge base documentation reading functionality
 import asyncio
 import logging
 import sys
-import os
 
-sys.path.insert(0, os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
+from autobot_shared.paths import project_root
+
+sys.path.insert(0, str(project_root()))
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/autobot-infrastructure/shared/scripts/analysis/test_kb_search.py
+++ b/autobot-infrastructure/shared/scripts/analysis/test_kb_search.py
@@ -10,10 +10,11 @@ Test Knowledge Base Documentation Search
 import asyncio
 import logging
 import sys
-import os
+
+from autobot_shared.paths import project_root
 
 # Add the project root to the Python path
-sys.path.insert(0, os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
+sys.path.insert(0, str(project_root()))
 
 from chat_workflow import ChatWorkflowManager
 from knowledge_base import KnowledgeBase

--- a/autobot-infrastructure/shared/scripts/analysis/test_redis_comparison.py
+++ b/autobot-infrastructure/shared/scripts/analysis/test_redis_comparison.py
@@ -14,13 +14,14 @@ import os
 import sys
 import time
 
+from autobot_shared.paths import project_root
 from constants import ServiceURLs
 
 # DB number from redis-databases.yaml SSOT (#2806): knowledge = 1
 _DB_KNOWLEDGE = int(os.getenv("AUTOBOT_REDIS_DB_KNOWLEDGE", "1"))
 
 # Add the project root to the Python path
-sys.path.insert(0, os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
+sys.path.insert(0, str(project_root()))
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")

--- a/autobot-infrastructure/shared/scripts/test_llm_awareness.py
+++ b/autobot-infrastructure/shared/scripts/test_llm_awareness.py
@@ -11,11 +11,12 @@ Demonstrates the functionality of the awareness injection system
 import asyncio
 import logging
 import sys
-import os
+
+from autobot_shared.paths import project_root
 
 logger = logging.getLogger(__name__)
 
-sys.path.append(os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
+sys.path.append(str(project_root()))
 
 from autobot_shared.network_constants import ServiceURLs
 

--- a/autobot-infrastructure/shared/scripts/test_long_running_operations.py
+++ b/autobot-infrastructure/shared/scripts/test_long_running_operations.py
@@ -27,13 +27,12 @@ import argparse
 import asyncio
 import logging
 import sys
-import os
 from datetime import datetime
 
 from autobot_shared.paths import project_root
 
 # Add AutoBot paths
-sys.path.append(os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
+sys.path.append(str(project_root()))
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")

--- a/autobot-infrastructure/shared/tests/ci_cd_integration.py
+++ b/autobot-infrastructure/shared/tests/ci_cd_integration.py
@@ -38,7 +38,7 @@ from typing import Dict, List, Tuple
 from autobot_shared.paths import project_root
 
 # Add AutoBot paths
-sys.path.append(os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
+sys.path.append(str(project_root()))
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)

--- a/autobot-infrastructure/shared/tests/comprehensive_test_suite.py
+++ b/autobot-infrastructure/shared/tests/comprehensive_test_suite.py
@@ -28,7 +28,6 @@ import json
 import logging
 import subprocess
 import sys
-import os
 import time
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -44,7 +43,7 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(
 logger = logging.getLogger(__name__)
 
 # Add AutoBot paths
-sys.path.append(os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
+sys.path.append(str(project_root()))
 
 
 @dataclass

--- a/autobot-infrastructure/shared/tests/performance/test_performance_optimization.py
+++ b/autobot-infrastructure/shared/tests/performance/test_performance_optimization.py
@@ -29,7 +29,6 @@ import logging
 import statistics
 import subprocess
 import sys
-import os
 import time
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -40,7 +39,7 @@ import psutil
 from autobot_shared.paths import project_root
 
 # Add AutoBot paths
-sys.path.append(os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
+sys.path.append(str(project_root()))
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)

--- a/autobot-slm-backend/ansible/roles/ai-stack/templates/ai-stack.env.j2
+++ b/autobot-slm-backend/ansible/roles/ai-stack/templates/ai-stack.env.j2
@@ -3,6 +3,21 @@
 # Author: mrveiss
 # AI Stack Environment
 
+# #14544/#14575: ai_api_server.py imports agents.base_agent, which imports
+# autobot_shared.ssot_config directly (`from autobot_shared.ssot_config import
+# config`) -- autobot-ai-stack.service.j2's own PYTHONPATH comment already
+# says "ai_api_server imports autobot_shared ... (#10121)". Whether the walk
+# in autobot_shared.paths.project_root() finds a `.env` for this unit is
+# topology-dependent: with the ai-stack role's own default
+# (backend_install_dir: /opt/autobot/autobot-backend) it happens to land on a
+# directory that carries one; with the flattened topology
+# deploy-backend-local.yml/deploy-backend-remote.yml set
+# (backend_install_dir: /opt/autobot) it does not, and this unit raises
+# ProjectRootUndeterminable and never starts. ai_install_dir is stable across
+# both topologies, so declare the root explicitly instead of depending on
+# which one is in effect.
+AUTOBOT_PROJECT_ROOT={{ ai_install_dir | dirname }}
+
 # ChromaDB
 CHROMADB_HOST={{ chromadb_host }}
 CHROMADB_PORT={{ chromadb_port }}

--- a/autobot-slm-backend/ansible/roles/npu-worker/templates/npu-worker.env.j2
+++ b/autobot-slm-backend/ansible/roles/npu-worker/templates/npu-worker.env.j2
@@ -3,6 +3,15 @@
 # Author: mrveiss
 # NPU Worker Environment
 
+# #14544/#14575: npu_integration.py imports autobot_shared.ssot_constants,
+# which imports autobot_shared.ssot_config -- and neither this worker's own
+# install dir nor the sibling autobot_shared install beneath
+# {{ npu_install_dir | dirname }} carries a .env or a .git, so
+# autobot_shared.paths.project_root() cannot infer the root by walking up
+# and raises ProjectRootUndeterminable rather than silently guessing
+# /opt/autobot. Tell it explicitly.
+AUTOBOT_PROJECT_ROOT={{ npu_install_dir | dirname }}
+
 # Server
 NPU_HOST={{ npu_host }}
 NPU_PORT={{ npu_port }}

--- a/autobot-slm-backend/ansible/roles/npu-worker/templates/npu-worker.env.j2
+++ b/autobot-slm-backend/ansible/roles/npu-worker/templates/npu-worker.env.j2
@@ -3,15 +3,6 @@
 # Author: mrveiss
 # NPU Worker Environment
 
-# #14544/#14575: npu_integration.py imports autobot_shared.ssot_constants,
-# which imports autobot_shared.ssot_config -- and neither this worker's own
-# install dir nor the sibling autobot_shared install beneath
-# {{ npu_install_dir | dirname }} carries a .env or a .git, so
-# autobot_shared.paths.project_root() cannot infer the root by walking up
-# and raises ProjectRootUndeterminable rather than silently guessing
-# /opt/autobot. Tell it explicitly.
-AUTOBOT_PROJECT_ROOT={{ npu_install_dir | dirname }}
-
 # Server
 NPU_HOST={{ npu_host }}
 NPU_PORT={{ npu_port }}

--- a/autobot-slm-backend/ansible/roles/slm_agent/templates/slm-agent.service.j2
+++ b/autobot-slm-backend/ansible/roles/slm_agent/templates/slm-agent.service.j2
@@ -57,6 +57,13 @@ Environment=SLM_ADMIN_URL={{ effective_admin_url }}
 # /opt/autobot/autobot_shared directly, independent of the per-dir symlink.
 Environment=PYTHONPATH={{ slm_agent_dir }}:{{ slm_agent_dir | dirname }}
 Environment=PYTHONUNBUFFERED=1
+# #14544/#14575: agent.py imports autobot_shared.ssot_config (get_config),
+# and neither {{ slm_agent_dir | dirname }} nor the autobot_shared install
+# beneath it carries a .env or a .git, so
+# autobot_shared.paths.project_root() cannot infer the root by walking up
+# and raises ProjectRootUndeterminable rather than silently guessing
+# /opt/autobot. Tell it explicitly.
+Environment=AUTOBOT_PROJECT_ROOT={{ slm_agent_dir | dirname }}
 # Issue #9226: Redis connection for autobot_shared imports
 Environment=REDIS_HOST={{ slm_agent_redis_host }}
 Environment=AUTOBOT_REDIS_HOST={{ slm_agent_redis_host }}

--- a/autobot-slm-backend/ansible/roles/slm_manager/templates/autobot-slm-backend.service.j2
+++ b/autobot-slm-backend/ansible/roles/slm_manager/templates/autobot-slm-backend.service.j2
@@ -24,6 +24,13 @@ WorkingDirectory={{ slm_backend_dir }}
 Environment="PATH={{ slm_backend_dir }}/venv/bin:/usr/local/bin:/usr/bin:/bin"
 Environment="PYTHONPATH={{ slm_backend_dir }}:{{ slm_shared_dir }}:{{ slm_base_dir }}"
 Environment="PYTHONUNBUFFERED=1"
+# #14544/#14575: neither slm_base_dir nor slm_shared_dir carries a .env or a
+# .git, so autobot_shared.paths.project_root() cannot infer the root by
+# walking up from {{ slm_shared_dir }}/paths.py and raises
+# ProjectRootUndeterminable rather than silently guessing /opt/autobot.
+# Tell it explicitly — it already is /opt/autobot here, but that must be
+# said, not assumed.
+Environment="AUTOBOT_PROJECT_ROOT={{ slm_base_dir }}"
 # #14299: this process cannot import config.registry.ConfigRegistry (its own
 # config.py is a single file, not a package — see connection_manager.py's
 # _ssot_redis_host docstring), so REDIS_HOST/AUTOBOT_REDIS_HOST must be set

--- a/autobot_shared/paths.py
+++ b/autobot_shared/paths.py
@@ -38,8 +38,24 @@ CHECKOUT_MARKERS = (".git", "autobot_shared")
 #: the shell scripts honour, so exporting it once governs both languages.
 PROJECT_ROOT_ENV = "AUTOBOT_PROJECT_ROOT"
 
-#: Where a deployed install lives when nothing else identifies the root.
-DEFAULT_INSTALL_ROOT = "/opt/autobot"
+#: Environment variable naming an explicit deployed-install location. Distinct
+#: from ``PROJECT_ROOT_ENV``: this one is read only as the last resort, after
+#: the walk in step 2 has found neither a ``.env`` nor a checkout.
+BASE_DIR_ENV = "AUTOBOT_BASE_DIR"
+
+
+class ProjectRootUndeterminable(RuntimeError):
+    """No override, ``.env`` or checkout marker identifies the project root.
+
+    #14544: this module used to answer that question with a hardcoded
+    ``/opt/autobot`` guess. A wrong-but-plausible path is exactly how 18
+    ``sys.path`` bootstraps silently imported the live deployed install
+    instead of the checkout under test, and stayed invisible for as long as
+    they did — the guess always looked like a working answer. Raising here
+    forces every caller to say explicitly where it is running (via
+    ``AUTOBOT_PROJECT_ROOT`` or ``AUTOBOT_BASE_DIR``) instead of getting one
+    handed to it silently.
+    """
 
 
 def is_checkout_root(path: Path) -> bool:
@@ -56,7 +72,12 @@ def project_root() -> Path:
        and matches what the shell scripts already do.
     2. Walking up from this file, the nearest ancestor that either holds a
        ``.env`` (a configured deployment) **or** looks like a source checkout.
-    3. ``AUTOBOT_BASE_DIR``/``/opt/autobot`` — the deployed install.
+    3. ``AUTOBOT_BASE_DIR`` — an operator naming the deployed install
+       explicitly. There is no further, unconditional fallback: on a real
+       checkout or a real install, step 1 or step 2 always resolves first
+       (an install always carries a ``.env``), so reaching here at all means
+       the environment is too broken to place. Raises
+       :class:`ProjectRootUndeterminable` rather than guessing (#14544).
 
     Step 2 is a *single* walk on purpose, and a checkout root is a hard
     boundary. The two-pass form — all ancestors for ``.env``, then all
@@ -101,4 +122,14 @@ def resolve_project_root(start: Path) -> Path:
 
     # ssot-config-exempt: bootstrap self-reference (carried from the
     # implementation this replaced, landed in #13646).
-    return Path(os.environ.get("AUTOBOT_BASE_DIR", DEFAULT_INSTALL_ROOT))
+    base_dir = os.environ.get(BASE_DIR_ENV)
+    if base_dir:
+        return Path(base_dir)
+
+    raise ProjectRootUndeterminable(
+        f"cannot determine the project root by walking up from {start}: no "
+        f"{PROJECT_ROOT_ENV} override, no {BASE_DIR_ENV} override, and no "
+        "ancestor holds a .env or looks like a source checkout "
+        f"({', '.join(CHECKOUT_MARKERS)}). Set one of those two environment "
+        "variables — a silent guess is the defect this raise replaces (#14544)."
+    )

--- a/autobot_shared/paths_test.py
+++ b/autobot_shared/paths_test.py
@@ -4,8 +4,12 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from autobot_shared.paths import (
+    BASE_DIR_ENV,
     PROJECT_ROOT_ENV,
+    ProjectRootUndeterminable,
     is_checkout_root,
     project_root,
     resolve_project_root,
@@ -86,14 +90,49 @@ class TestDeployedInstall:
         assert resolve_project_root(inner / "pkg" / "mod.py") == inner
         assert inner != outer
 
-    def test_falls_back_to_the_install_location(self, tmp_path, monkeypatch) -> None:
+    def test_honours_an_explicit_base_dir_override(self, tmp_path, monkeypatch) -> None:
         monkeypatch.delenv(PROJECT_ROOT_ENV, raising=False)
-        monkeypatch.setenv("AUTOBOT_BASE_DIR", "/srv/autobot-test")
+        monkeypatch.setenv(BASE_DIR_ENV, "/srv/autobot-test")
 
         bare = tmp_path / "bare"
         bare.mkdir()
 
         assert resolve_project_root(bare / "mod.py") == Path("/srv/autobot-test")
+
+
+class TestUndeterminableRoot:
+    """#14544: no silent guess — an unplaceable root is a raise, not a path.
+
+    The pre-#14544 last resort returned a hardcoded ``/opt/autobot`` here,
+    which is exactly the "defaults to the live install" defect this module
+    exists to close one layer up in every ``sys.path`` bootstrap that calls
+    it. On a real checkout or a real install this branch is never reached —
+    step 1 or step 2 always resolves first — so raising costs nothing there.
+    """
+
+    def test_raises_when_nothing_identifies_the_root(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.delenv(PROJECT_ROOT_ENV, raising=False)
+        monkeypatch.delenv(BASE_DIR_ENV, raising=False)
+
+        bare = tmp_path / "bare"
+        bare.mkdir()
+
+        with pytest.raises(ProjectRootUndeterminable):
+            resolve_project_root(bare / "mod.py")
+
+    def test_the_raise_names_both_overrides(self, tmp_path, monkeypatch) -> None:
+        """The message must tell the caller what to set, not just that it failed."""
+        monkeypatch.delenv(PROJECT_ROOT_ENV, raising=False)
+        monkeypatch.delenv(BASE_DIR_ENV, raising=False)
+
+        bare = tmp_path / "bare"
+        bare.mkdir()
+
+        with pytest.raises(ProjectRootUndeterminable) as excinfo:
+            resolve_project_root(bare / "mod.py")
+
+        assert PROJECT_ROOT_ENV in str(excinfo.value)
+        assert BASE_DIR_ENV in str(excinfo.value)
 
 
 class TestCheckoutMarkers:

--- a/debug/debug_terminal.py
+++ b/debug/debug_terminal.py
@@ -12,14 +12,15 @@ import asyncio
 import json
 import logging
 import sys
-import os
 from datetime import datetime
 
 import httpx
 import websockets
 
+from autobot_shared.paths import project_root
+
 # Import centralized network configuration
-sys.path.insert(0, os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
+sys.path.insert(0, str(project_root()))
 from constants.network_constants import NetworkConstants
 
 logger = logging.getLogger(__name__)

--- a/debug/debug_terminal_detailed.py
+++ b/debug/debug_terminal_detailed.py
@@ -12,17 +12,18 @@ import asyncio
 import json
 import logging
 import sys
-import os
 import time
 from datetime import datetime
 
 import httpx
 import websockets
 
+from autobot_shared.paths import project_root
+
 logger = logging.getLogger(__name__)
 
 # Import centralized network configuration
-sys.path.insert(0, os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
+sys.path.insert(0, str(project_root()))
 from constants.network_constants import NetworkConstants
 
 # Build URLs from centralized configuration
@@ -184,7 +185,7 @@ def test_system_command_agent_direct():
         # Try to import and test directly
         import sys
 
-        sys.path.append(os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
+        sys.path.append(str(project_root()))
 
         from agents.system_command_agent import SystemCommandAgent
 

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -141,6 +141,12 @@ USER autobot
 
 # Environment
 ENV PYTHONPATH=/app:/app/autobot-backend:/app/autobot_shared
+# #14544/#14575: the image has no .git and no .env, so
+# autobot_shared.paths.project_root() cannot infer the root by walking up
+# from /app/autobot_shared/paths.py and raises ProjectRootUndeterminable
+# rather than silently guessing /opt/autobot (the live install this image is
+# NOT). Tell it explicitly instead of letting it guess.
+ENV AUTOBOT_PROJECT_ROOT=/app
 ENV AUTOBOT_ENVIRONMENT=production
 ENV AUTOBOT_LOG_LEVEL=INFO
 ENV AUTOBOT_DEPLOYMENT_MODE=local

--- a/docker/slm/Dockerfile
+++ b/docker/slm/Dockerfile
@@ -70,6 +70,12 @@ COPY docker/slm/entrypoint.sh /app/entrypoint.sh
 USER autobot
 
 ENV PYTHONPATH=/app:/app/autobot-slm-backend:/app/autobot_shared
+# #14544/#14575: the image has no .git and no .env, so
+# autobot_shared.paths.project_root() cannot infer the root by walking up
+# from /app/autobot_shared/paths.py and raises ProjectRootUndeterminable
+# rather than silently guessing /opt/autobot (the live install this image is
+# NOT). Tell it explicitly instead of letting it guess.
+ENV AUTOBOT_PROJECT_ROOT=/app
 ENV AUTOBOT_ENVIRONMENT=production
 ENV AUTOBOT_LOG_LEVEL=INFO
 

--- a/repo_tests/deployment_declares_project_root_14544_test.py
+++ b/repo_tests/deployment_declares_project_root_14544_test.py
@@ -16,19 +16,45 @@ Both Docker images fail this contract out of the box: `COPY autobot_shared/
 /app/autobot_shared/` ships the package with no `.git` and no `.env`, so
 `smoke-test`/`hardened-smoke-test` failed at import with exactly this raise
 (#14575 review). Three native systemd/env deployments have the identical gap
-for the identical reason — `autobot-slm-backend.service.j2`,
-`slm-agent.service.j2` (agent.py imports `ssot_config.get_config` directly)
-and `npu-worker.env.j2` (`npu_integration.py` imports `ssot_constants`, which
-imports `ssot_config`) each set `PYTHONPATH` for `autobot_shared` without
-ever setting `AUTOBOT_PROJECT_ROOT`/`AUTOBOT_BASE_DIR`. Before #14544 this
-was invisible because the guess happened to be `/opt/autobot`, which is
-where all three actually run — a wrong-but-plausible default working by
-coincidence is exactly the failure mode #14544 exists to close.
+for the identical reason:
+
+- `autobot-slm-backend.service.j2` -- sets `PYTHONPATH` for `autobot_shared`
+  but never `AUTOBOT_PROJECT_ROOT`/`AUTOBOT_BASE_DIR`.
+- `slm-agent.service.j2` -- `agent.py` imports `autobot_shared.ssot_config
+  .get_config` directly; same gap.
+- `ai-stack.env.j2` -- `ai_api_server.py` imports `agents.base_agent`, which
+  imports `autobot_shared.ssot_config.config` directly; same gap, and
+  *topology-dependent* on top of it: whether `project_root()`'s walk finds a
+  `.env` for this unit depends on which `backend_install_dir` a given deploy
+  playbook sets, so it silently worked on one topology and would have
+  silently failed on another (#14575 review, round 2).
+
+Before #14544 this was invisible because the guess happened to be
+`/opt/autobot`, which is where all three actually run (or, for the ai-stack
+case, ran by accident on only one of two shipped topologies) — a
+wrong-but-plausible default working by coincidence is exactly the failure
+mode #14544 exists to close.
+
+`npu-worker.env.j2` was considered and deliberately **not** touched:
+`npu-worker.py.j2`, the script this unit actually runs, imports no
+first-party code at all -- not `autobot_shared`, not anything that imports
+it. `core/npu_integration.py` (which does import `autobot_shared
+.ssot_constants`, transitively pulling in `ssot_config`) belongs to a
+different, unwired module under `autobot-npu-worker/core/` that this unit
+never executes -- confirmed by grepping every importer of it, which is only
+its own test file. An earlier version of this fix declared the variable here
+anyway, citing that file; the citation was wrong, so the declaration was
+reverted rather than kept on a false premise (#14575 review, round 2).
 
 This is a static text check against the deployment sources themselves, not a
 container build or a live systemd unit — sufficient to catch a future edit
 that quietly drops the variable, which is the point: the next person editing
-one of these files cannot remove the line without failing here first.
+one of these files cannot remove the line without failing here first. It
+runs under `python-suite`, which `.github/filters/python-paths.yml` gates on
+`**/*.py` by default; the five files this test names are added to that
+filter explicitly, or a PR touching only one of them (no `.py` change) would
+report `python-suite` green without ever running this test (#14575 review,
+round 2).
 """
 
 from __future__ import annotations
@@ -55,8 +81,8 @@ _DECLARATIONS: tuple[tuple[str, str], ...] = (
         "AUTOBOT_PROJECT_ROOT={{ slm_agent_dir | dirname }}",
     ),
     (
-        "autobot-slm-backend/ansible/roles/npu-worker/templates/npu-worker.env.j2",
-        "AUTOBOT_PROJECT_ROOT={{ npu_install_dir | dirname }}",
+        "autobot-slm-backend/ansible/roles/ai-stack/templates/ai-stack.env.j2",
+        "AUTOBOT_PROJECT_ROOT={{ ai_install_dir | dirname }}",
     ),
 )
 

--- a/repo_tests/deployment_declares_project_root_14544_test.py
+++ b/repo_tests/deployment_declares_project_root_14544_test.py
@@ -1,0 +1,95 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Every runtime that imports `autobot_shared` from a marker-free tree must
+declare `AUTOBOT_PROJECT_ROOT` (#14544, #14575).
+
+`autobot_shared.paths.project_root()` now raises `ProjectRootUndeterminable`
+instead of silently guessing `/opt/autobot` when it cannot find `.env` or a
+checkout (`.git` + `autobot_shared`) by walking up from its own install
+location. That is correct — the silent guess was the defect #14544 fixed —
+but it makes every deployed runtime a contract: the resolver raises unless
+something tells it where it is.
+
+Both Docker images fail this contract out of the box: `COPY autobot_shared/
+/app/autobot_shared/` ships the package with no `.git` and no `.env`, so
+`smoke-test`/`hardened-smoke-test` failed at import with exactly this raise
+(#14575 review). Three native systemd/env deployments have the identical gap
+for the identical reason — `autobot-slm-backend.service.j2`,
+`slm-agent.service.j2` (agent.py imports `ssot_config.get_config` directly)
+and `npu-worker.env.j2` (`npu_integration.py` imports `ssot_constants`, which
+imports `ssot_config`) each set `PYTHONPATH` for `autobot_shared` without
+ever setting `AUTOBOT_PROJECT_ROOT`/`AUTOBOT_BASE_DIR`. Before #14544 this
+was invisible because the guess happened to be `/opt/autobot`, which is
+where all three actually run — a wrong-but-plausible default working by
+coincidence is exactly the failure mode #14544 exists to close.
+
+This is a static text check against the deployment sources themselves, not a
+container build or a live systemd unit — sufficient to catch a future edit
+that quietly drops the variable, which is the point: the next person editing
+one of these files cannot remove the line without failing here first.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from autobot_shared.paths import PROJECT_ROOT_ENV, ProjectRootUndeterminable, resolve_project_root
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+#: (file, must contain) -- every deployment source that has to declare
+#: AUTOBOT_PROJECT_ROOT for a process importing autobot_shared to start.
+_DECLARATIONS: tuple[tuple[str, str], ...] = (
+    ("docker/backend/Dockerfile", "ENV AUTOBOT_PROJECT_ROOT=/app"),
+    ("docker/slm/Dockerfile", "ENV AUTOBOT_PROJECT_ROOT=/app"),
+    (
+        "autobot-slm-backend/ansible/roles/slm_manager/templates/autobot-slm-backend.service.j2",
+        "AUTOBOT_PROJECT_ROOT={{ slm_base_dir }}",
+    ),
+    (
+        "autobot-slm-backend/ansible/roles/slm_agent/templates/slm-agent.service.j2",
+        "AUTOBOT_PROJECT_ROOT={{ slm_agent_dir | dirname }}",
+    ),
+    (
+        "autobot-slm-backend/ansible/roles/npu-worker/templates/npu-worker.env.j2",
+        "AUTOBOT_PROJECT_ROOT={{ npu_install_dir | dirname }}",
+    ),
+)
+
+
+@pytest.mark.parametrize("rel_path, needle", _DECLARATIONS)
+def test_deployment_source_declares_autobot_project_root(rel_path: str, needle: str) -> None:
+    path = _REPO_ROOT / rel_path
+    assert path.is_file(), f"{rel_path} moved or was deleted -- update this test's path"
+
+    source = path.read_text(encoding="utf-8")
+    assert needle in source, (
+        f"{rel_path} no longer declares `{needle}`. Without it, any process there that "
+        "imports autobot_shared (directly or via ssot_config/ssot_constants) raises "
+        "ProjectRootUndeterminable at import time and the service never starts (#14544, #14575)."
+    )
+
+
+def test_project_root_succeeds_under_a_marker_free_tree_once_the_env_is_set(tmp_path, monkeypatch) -> None:
+    """The exact shape a container/systemd unit is in: no .git, no .env, no markers."""
+    monkeypatch.delenv("AUTOBOT_BASE_DIR", raising=False)
+    bare = tmp_path / "app"
+    bare.mkdir()
+    monkeypatch.setenv(PROJECT_ROOT_ENV, str(bare))
+
+    assert resolve_project_root(bare / "autobot_shared" / "paths.py") == bare
+
+
+def test_project_root_raises_under_the_same_tree_without_the_env(tmp_path, monkeypatch) -> None:
+    """The failure this whole contract exists to make loud, not silent."""
+    monkeypatch.delenv(PROJECT_ROOT_ENV, raising=False)
+    monkeypatch.delenv("AUTOBOT_BASE_DIR", raising=False)
+    bare = tmp_path / "app"
+    bare.mkdir()
+
+    with pytest.raises(ProjectRootUndeterminable):
+        resolve_project_root(bare / "autobot_shared" / "paths.py")

--- a/tools/lint/check_no_live_install_sys_path_default.py
+++ b/tools/lint/check_no_live_install_sys_path_default.py
@@ -23,7 +23,11 @@ This checker inspects the AST of every ``sys.path.insert(...)`` /
 ``os.environ.get``/``os.getenv`` whose default string contains the live
 install path, it is the same defect regrowing. There is no exemption list —
 none of the 18 fixed sites needed to keep the pattern, and a fresh site
-copying it forward is never legitimate.
+copying it forward is never legitimate. Nothing in this checker's own source
+needs one either: the pattern is detected structurally (a real ``ast.Call``
+to ``sys.path.insert``/``.append``), so the prose description of it in this
+docstring, and the string-literal test fixtures in the sibling test file
+that never execute a real ``sys.path`` call, do not parse as one.
 
 Exit code:
   0 — clean
@@ -33,6 +37,7 @@ Exit code:
 from __future__ import annotations
 
 import ast
+import logging
 import sys
 from pathlib import Path
 from typing import List, Tuple
@@ -42,6 +47,11 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from _scan_helpers import iter_python_files  # noqa: E402
 
+# Plain stdlib logging, deliberately (#1082). This runs as a bare script inside a
+# lint job, and `autobot_shared.logging_manager` would drag config loading into
+# that path. Same trade as `tools/lint/check_no_shell_placeholder_paths.py`.
+logger = logging.getLogger(__name__)
+
 #: The live-install root, assembled from fragments so this checker's own
 #: source (and its docstring above) does not trip the pattern it detects.
 LIVE_INSTALL_ROOT = "/" + "opt/autobot"
@@ -49,12 +59,18 @@ LIVE_INSTALL_ROOT = "/" + "opt/autobot"
 #: The canonical replacement every finding is told to use.
 RESOLVER = "autobot_shared.paths.project_root()"
 
-ALLOWLIST: frozenset[str] = frozenset(
-    {
-        "tools/lint/check_no_live_install_sys_path_default.py",
-        "tools/lint/check_no_live_install_sys_path_default_test.py",
-    }
-)
+
+def _configure_logging() -> None:
+    """Attach a stderr handler so findings actually reach the developer.
+
+    Run as a bare script the module logger has no handler, and logging's
+    last-resort path drops anything below WARNING.
+    """
+    if not logger.handlers:
+        handler = logging.StreamHandler(sys.stderr)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
 
 
 def _is_sys_path_mutation(func: ast.AST) -> bool:
@@ -110,6 +126,7 @@ def live_install_default_sites(path: Path) -> List[Tuple[int, str]]:
 
 
 def main(argv: List[str]) -> int:
+    _configure_logging()
     repo_root = Path(__file__).resolve().parents[2]
     total = 0
     for path in iter_python_files(argv[1:], repo_root):
@@ -117,24 +134,25 @@ def main(argv: List[str]) -> int:
             rel = str(path.resolve().relative_to(repo_root)).replace("\\", "/")
         except ValueError:
             rel = str(path)
-        if rel in ALLOWLIST:
-            continue
         try:
             hits = live_install_default_sites(path)
         except (SyntaxError, UnicodeDecodeError, OSError):
             continue
         for line_no, text in hits:
-            print(
-                f"[no-live-install-sys-path-default] {rel}:{line_no}: {text} — "
-                f"defaults to the live deployed install; use {RESOLVER} instead (#14544)",
-                file=sys.stderr,
+            logger.error(
+                "[no-live-install-sys-path-default] %s:%s: %s — "
+                "defaults to the live deployed install; use %s instead (#14544)",
+                rel,
+                line_no,
+                text,
+                RESOLVER,
             )
             total += 1
     if total:
-        print(
-            f"\n[no-live-install-sys-path-default] {total} sys.path bootstrap(s) "
+        logger.error(
+            "\n[no-live-install-sys-path-default] %d sys.path bootstrap(s) "
             "still default to the live install. See per-line fix suggestions above.",
-            file=sys.stderr,
+            total,
         )
         return 1
     return 0

--- a/tools/lint/check_no_live_install_sys_path_default.py
+++ b/tools/lint/check_no_live_install_sys_path_default.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""AST-aware regression check for #14544 — no ``sys.path`` bootstrap may
+default to the live deployed install.
+
+18 call sites across 17 files open-coded the project root instead of using
+the canonical resolver::
+
+    sys.path.insert(0, os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
+
+That is ``autobot_shared.paths.project_root()`` reinvented without its walk:
+with ``AUTOBOT_PROJECT_ROOT`` unset — the normal case in a checkout — it puts
+the **live deployed install** first on ``sys.path``, so a script run from a
+working tree silently imports the deployed copy of every first-party module
+it names. #14544 fixed all 18 by routing them through
+``autobot_shared.paths.project_root()`` instead.
+
+This checker inspects the AST of every ``sys.path.insert(...)`` /
+``sys.path.append(...)`` call: if any argument is a call to
+``os.environ.get``/``os.getenv`` whose default string contains the live
+install path, it is the same defect regrowing. There is no exemption list —
+none of the 18 fixed sites needed to keep the pattern, and a fresh site
+copying it forward is never legitimate.
+
+Exit code:
+  0 — clean
+  1 — a live-install default found inside a ``sys.path`` mutation
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+from typing import List, Tuple
+
+# tools/lint/ is not a Python package; ensure sibling module is importable
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _scan_helpers import iter_python_files  # noqa: E402
+
+#: The live-install root, assembled from fragments so this checker's own
+#: source (and its docstring above) does not trip the pattern it detects.
+LIVE_INSTALL_ROOT = "/" + "opt/autobot"
+
+#: The canonical replacement every finding is told to use.
+RESOLVER = "autobot_shared.paths.project_root()"
+
+ALLOWLIST: frozenset[str] = frozenset(
+    {
+        "tools/lint/check_no_live_install_sys_path_default.py",
+        "tools/lint/check_no_live_install_sys_path_default_test.py",
+    }
+)
+
+
+def _is_sys_path_mutation(func: ast.AST) -> bool:
+    """True for ``sys.path.insert(...)`` / ``sys.path.append(...)``."""
+    return (
+        isinstance(func, ast.Attribute)
+        and func.attr in ("insert", "append")
+        and isinstance(func.value, ast.Attribute)
+        and func.value.attr == "path"
+        and isinstance(func.value.value, ast.Name)
+        and func.value.value.id == "sys"
+    )
+
+
+def _is_env_lookup(func: ast.AST) -> bool:
+    """True for ``os.environ.get(...)`` / ``os.getenv(...)``, matched exactly."""
+    if isinstance(func, ast.Attribute) and func.attr == "getenv" and isinstance(func.value, ast.Name):
+        return func.value.id == "os"
+    if isinstance(func, ast.Attribute) and func.attr == "get" and isinstance(func.value, ast.Attribute):
+        return (
+            func.value.attr == "environ"
+            and isinstance(func.value.value, ast.Name)
+            and func.value.value.id == "os"
+        )
+    return False
+
+
+def _default_names_live_install(call: ast.Call) -> bool:
+    """True if an ``os.environ.get``/``os.getenv`` call's default is the live install."""
+    if len(call.args) < 2:
+        return False
+    default = call.args[1]
+    return (
+        isinstance(default, ast.Constant)
+        and isinstance(default.value, str)
+        and LIVE_INSTALL_ROOT in default.value
+    )
+
+
+def live_install_default_sites(path: Path) -> List[Tuple[int, str]]:
+    """Every ``sys.path`` mutation in *path* defaulting to the live install."""
+    source = path.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(path))
+
+    hits: List[Tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not _is_sys_path_mutation(node.func):
+            continue
+        for arg in node.args:
+            if isinstance(arg, ast.Call) and _is_env_lookup(arg.func) and _default_names_live_install(arg):
+                hits.append((node.lineno, ast.unparse(node)))
+    return sorted(hits)
+
+
+def main(argv: List[str]) -> int:
+    repo_root = Path(__file__).resolve().parents[2]
+    total = 0
+    for path in iter_python_files(argv[1:], repo_root):
+        try:
+            rel = str(path.resolve().relative_to(repo_root)).replace("\\", "/")
+        except ValueError:
+            rel = str(path)
+        if rel in ALLOWLIST:
+            continue
+        try:
+            hits = live_install_default_sites(path)
+        except (SyntaxError, UnicodeDecodeError, OSError):
+            continue
+        for line_no, text in hits:
+            print(
+                f"[no-live-install-sys-path-default] {rel}:{line_no}: {text} — "
+                f"defaults to the live deployed install; use {RESOLVER} instead (#14544)",
+                file=sys.stderr,
+            )
+            total += 1
+    if total:
+        print(
+            f"\n[no-live-install-sys-path-default] {total} sys.path bootstrap(s) "
+            "still default to the live install. See per-line fix suggestions above.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tools/lint/check_no_live_install_sys_path_default_test.py
+++ b/tools/lint/check_no_live_install_sys_path_default_test.py
@@ -11,6 +11,7 @@ The banned literal is assembled from fragments (mirroring
 
 from __future__ import annotations
 
+import logging
 import pathlib
 import textwrap
 
@@ -109,7 +110,12 @@ def test_a_live_install_default_outside_a_sys_path_call_is_not_reported(tmp_path
     assert guard.live_install_default_sites(path) == []
 
 
-def test_main_reports_a_nonzero_exit_and_the_resolver_hint(tmp_path, capsys):
+def test_main_reports_a_nonzero_exit_and_the_resolver_hint(tmp_path, caplog):
+    """Uses ``caplog`` (root-logger propagation), not ``capsys`` -- ``main()``'s own
+    ``StreamHandler`` binds to ``sys.stderr`` only on its first call in the process
+    and stays bound to that reference across every later test in the same pytest
+    session, so a second ``capsys``-based assertion would silently capture nothing.
+    """
     path = _write(
         tmp_path,
         "debug/tool.py",
@@ -121,13 +127,14 @@ def test_main_reports_a_nonzero_exit_and_the_resolver_hint(tmp_path, capsys):
         ''',
     )
 
-    exit_code = guard.main(["check_no_live_install_sys_path_default.py", str(path)])
+    with caplog.at_level(logging.ERROR):
+        exit_code = guard.main(["check_no_live_install_sys_path_default.py", str(path)])
 
     assert exit_code == 1
-    assert guard.RESOLVER in capsys.readouterr().err
+    assert guard.RESOLVER in caplog.text
 
 
-def test_main_is_clean_over_the_fixed_files(tmp_path, capsys):
+def test_main_is_clean_over_the_fixed_files(tmp_path, caplog):
     path = _write(
         tmp_path,
         "debug/tool.py",
@@ -140,8 +147,11 @@ def test_main_is_clean_over_the_fixed_files(tmp_path, capsys):
         """,
     )
 
-    assert guard.main(["check_no_live_install_sys_path_default.py", str(path)]) == 0
-    assert capsys.readouterr().err == ""
+    with caplog.at_level(logging.ERROR):
+        exit_code = guard.main(["check_no_live_install_sys_path_default.py", str(path)])
+
+    assert exit_code == 0
+    assert caplog.text == ""
 
 
 def test_the_guard_does_not_need_an_exemption_for_itself():
@@ -150,17 +160,20 @@ def test_the_guard_does_not_need_an_exemption_for_itself():
     assert guard.live_install_default_sites(self_path) == []
 
 
+def test_this_test_file_does_not_need_an_exemption_either():
+    """The f-string fixtures above never execute a real sys.path call -- they are
+    string arguments to ``_write()``, so no ``ast.Call`` to ``sys.path.insert``/
+    ``.append`` exists in this file's own AST for the guard to find.
+    """
+    this_file = pathlib.Path(__file__)
+    assert guard.live_install_default_sites(this_file) == []
+
+
 def test_the_live_repository_has_no_remaining_sites():
     """#14544 swept all 18; nothing should be left to find at HEAD."""
     repo_root = pathlib.Path(__file__).resolve().parents[2]
     total = 0
     for path in guard.iter_python_files([], repo_root):
-        try:
-            rel = str(path.resolve().relative_to(repo_root)).replace("\\", "/")
-        except ValueError:
-            rel = str(path)
-        if rel in guard.ALLOWLIST:
-            continue
         try:
             total += len(guard.live_install_default_sites(path))
         except (SyntaxError, UnicodeDecodeError, OSError):

--- a/tools/lint/check_no_live_install_sys_path_default_test.py
+++ b/tools/lint/check_no_live_install_sys_path_default_test.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Discrimination tests for the #14544 live-install-sys.path-default guard.
+
+The banned literal is assembled from fragments (mirroring
+``guard.LIVE_INSTALL_ROOT``) so this file does not trip the guard it tests.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import textwrap
+
+from tools.lint import check_no_live_install_sys_path_default as guard
+
+#: The live-install root, built the same way the guard builds it.
+LIVE_ROOT = guard.LIVE_INSTALL_ROOT
+
+
+def _write(base: pathlib.Path, rel: str, body: str) -> pathlib.Path:
+    path = base / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(body), encoding="utf-8")
+    return path
+
+
+def test_sys_path_insert_with_live_install_default_is_reported(tmp_path):
+    path = _write(
+        tmp_path,
+        "debug/tool.py",
+        f'''\
+        import os
+        import sys
+
+        sys.path.insert(0, os.environ.get("AUTOBOT_PROJECT_ROOT", "{LIVE_ROOT}/code_source"))
+        ''',
+    )
+
+    hits = guard.live_install_default_sites(path)
+
+    assert hits == [(4, hits[0][1])]
+    assert "sys.path.insert" in hits[0][1]
+
+
+def test_sys_path_append_with_live_install_default_is_reported(tmp_path):
+    path = _write(
+        tmp_path,
+        "debug/tool.py",
+        f'''\
+        import os
+        import sys
+
+        sys.path.append(os.getenv("AUTOBOT_PROJECT_ROOT", "{LIVE_ROOT}/code_source"))
+        ''',
+    )
+
+    hits = guard.live_install_default_sites(path)
+
+    assert len(hits) == 1
+
+
+def test_the_canonical_resolver_is_not_reported(tmp_path):
+    path = _write(
+        tmp_path,
+        "debug/tool.py",
+        """\
+        import sys
+
+        from autobot_shared.paths import project_root
+
+        sys.path.insert(0, str(project_root()))
+        """,
+    )
+
+    assert guard.live_install_default_sites(path) == []
+
+
+def test_an_env_lookup_default_unrelated_to_the_live_install_is_not_reported(tmp_path):
+    """Only the live-install default is banned, not every env-backed sys.path insert."""
+    path = _write(
+        tmp_path,
+        "debug/tool.py",
+        """\
+        import os
+        import sys
+
+        sys.path.insert(0, os.environ.get("AUTOBOT_PROJECT_ROOT", "/srv/checkout"))
+        """,
+    )
+
+    assert guard.live_install_default_sites(path) == []
+
+
+def test_a_live_install_default_outside_a_sys_path_call_is_not_reported(tmp_path):
+    """The defect is specifically a sys.path mutation; an unrelated env lookup is not."""
+    path = _write(
+        tmp_path,
+        "debug/tool.py",
+        f'''\
+        import os
+
+        ANSIBLE_DIR = os.environ.get("SLM_ANSIBLE_DIR", "{LIVE_ROOT}/code_source/ansible")
+        ''',
+    )
+
+    assert guard.live_install_default_sites(path) == []
+
+
+def test_main_reports_a_nonzero_exit_and_the_resolver_hint(tmp_path, capsys):
+    path = _write(
+        tmp_path,
+        "debug/tool.py",
+        f'''\
+        import os
+        import sys
+
+        sys.path.insert(0, os.environ.get("AUTOBOT_PROJECT_ROOT", "{LIVE_ROOT}/code_source"))
+        ''',
+    )
+
+    exit_code = guard.main(["check_no_live_install_sys_path_default.py", str(path)])
+
+    assert exit_code == 1
+    assert guard.RESOLVER in capsys.readouterr().err
+
+
+def test_main_is_clean_over_the_fixed_files(tmp_path, capsys):
+    path = _write(
+        tmp_path,
+        "debug/tool.py",
+        """\
+        import sys
+
+        from autobot_shared.paths import project_root
+
+        sys.path.insert(0, str(project_root()))
+        """,
+    )
+
+    assert guard.main(["check_no_live_install_sys_path_default.py", str(path)]) == 0
+    assert capsys.readouterr().err == ""
+
+
+def test_the_guard_does_not_need_an_exemption_for_itself():
+    """A guard that trips its own rule would need one -- it must not."""
+    self_path = pathlib.Path(guard.__file__)
+    assert guard.live_install_default_sites(self_path) == []
+
+
+def test_the_live_repository_has_no_remaining_sites():
+    """#14544 swept all 18; nothing should be left to find at HEAD."""
+    repo_root = pathlib.Path(__file__).resolve().parents[2]
+    total = 0
+    for path in guard.iter_python_files([], repo_root):
+        try:
+            rel = str(path.resolve().relative_to(repo_root)).replace("\\", "/")
+        except ValueError:
+            rel = str(path)
+        if rel in guard.ALLOWLIST:
+            continue
+        try:
+            total += len(guard.live_install_default_sites(path))
+        except (SyntaxError, UnicodeDecodeError, OSError):
+            continue
+
+    assert total == 0


### PR DESCRIPTION
## Thinking Path

Verified the canonical resolver first, per the issue instructions: `autobot_shared.paths.project_root()` (already used unprotected by 7 of the 17 files — `optimize_agents.py`, `redis_final_analysis.py`, `redis_vector_analysis.py`, `test_documentation_api.py`, `test_long_running_operations.py`, `ci_cd_integration.py`, `comprehensive_test_suite.py`, `test_performance_optimization.py` — proof `autobot_shared` was already importable at *those* entry points before any local `sys.path` bootstrap ran). `resolve_project_root()` walks up from a start path: explicit `AUTOBOT_PROJECT_ROOT` wins outright; failing that, the nearest ancestor holding `.env` or looking like a checkout (`.git` + `autobot_shared`) wins; failing that, it fell through to a hardcoded `Path(os.environ.get("AUTOBOT_BASE_DIR", "/opt/autobot"))` — a **second, quieter copy of the exact defect this issue is about**, one layer inside the "canonical" fix itself.

Measured the site count myself rather than trusting the issue body: **18 sites, 17 unique files** (`debug/debug_terminal_detailed.py` carries 2), matching the issue's own line list 1:1 despite its prose saying 16. Independently re-derived at the merge base by review across three separate sweeps: 0 missed Python variants, 0 remaining at head.

Found the `PlaybookExecutor` `ansible_dir` fallback (`autobot-slm-backend/services/playbook_executor.py:191-200`) is the same *class* of defect but not the same *shape*; PR #14548 is actively editing that file, so filed as #14574 instead of fixed here.

**Round 2 — CI red, then a full review found 5 fixed + 1 missed + 4 unexamined.** All addressed below; see "What Changed" and "Corrections" for each.

## What Changed

### Round 1
- **`autobot_shared/paths.py`**: `resolve_project_root()`'s last-resort branch no longer guesses `/opt/autobot` when `AUTOBOT_BASE_DIR` is unset — it raises `ProjectRootUndeterminable` naming both overrides the caller can set. An explicit `AUTOBOT_BASE_DIR` is still honoured. On a real checkout or a real install this branch is unreachable in practice — step 1 or step 2 always resolves first — so the raise only fires when the environment is genuinely too broken to place.
- **`autobot_shared/paths_test.py`**: renamed the old "falls back to the install location" test to reflect it now covers the explicit-override case; added `TestUndeterminableRoot` for the raise.
- **18 `sys.path` bootstrap sites across 17 files**: `sys.path.insert/append(0, os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))` → `sys.path.insert/append(0, str(project_root()))`, adding `from autobot_shared.paths import project_root` where missing. Removed `import os` where it became unused.
- **`tools/lint/check_no_live_install_sys_path_default.py`** (+ test): AST-based regression guard for the sys.path pattern. Wired into `.github/workflows/code-quality.yml`.

### Round 2 — fixing the review's findings
- **`code-quality` FAILURE on the new file, root-caused**: the guard's own `print(..., file=sys.stderr)` calls (unshielded, since a brand-new file has no `--changed-lines-only` grandfather) are now stdlib `logging` with a stderr handler, mirroring `check_no_shell_placeholder_paths.py`'s established pattern for a bare lint script. `tools/lint/check_no_live_install_sys_path_default_test.py`'s two `main()`-calling tests switched from `capsys` to `caplog` — `capsys` would have silently stopped working the second time `main()` ran in the same pytest session, since the module's `StreamHandler` binds to `sys.stderr` once and keeps that reference across tests.
- **The ai-stack gap (the important one), fixed rather than left topology-dependent**: `ai_api_server.py` imports `agents.base_agent`, which imports `autobot_shared.ssot_config.config` directly — a direct-import grep on `ai_api_server.py` alone missed this, exactly as review said. `ai-stack.env.j2` now declares `AUTOBOT_PROJECT_ROOT={{ ai_install_dir | dirname }}`, independent of which `backend_install_dir` a given deploy playbook sets (the role default and `deploy-backend-{local,remote}.yml:29` disagree, which is why the walk previously succeeded on one topology and would have failed on the other).
- **The npu-worker "fix" was wrong and is reverted**: `npu-worker.py.j2` (the script the unit actually runs) imports no first-party code at all — not `autobot_shared`, not anything that imports it. `core/npu_integration.py`, which I'd cited, belongs to a different, unwired module under `autobot-npu-worker/core/` — grepping every importer of it turns up only its own test file. Reverted the `npu-worker.env.j2` change entirely rather than keep a declaration whose justification doesn't hold.
- **The guard test made enforceable on the paths it guards**: `repo_tests/deployment_declares_project_root_14544_test.py` runs under `python-suite`, gated by `.github/filters/python-paths.yml` (`**/*.py` and a short explicit list — no `.j2`/Dockerfile glob). Added the 5 files this test names (2 Dockerfiles + 3 `.j2`/`.env.j2` templates) to that filter explicitly, so a PR editing only one of them (no `.py` touched) still runs the real suite instead of getting the shim's automatic green.
- **`ALLOWLIST` removed** — it contradicted the module's own "no exemption list" docstring while exempting nothing real (both entries were string prose/fixture text, never a live `ast.Call` the guard would have matched anyway; added `test_this_test_file_does_not_need_an_exemption_either` to prove it structurally rather than assert it in a comment).
- **4 non-`.j2` duplicate unit files under `autobot-infrastructure/*/templates/*.service`** (9 total, 4 Python-relevant: `ai-stack`, `autobot-user-backend`, `npu-worker`, `slm-backend`) were never entered into round 1's enumeration. Traced and filed as **#14590**, with evidence they are dead (not merely unaccounted-for): `ansible.cfg`'s `roles_path = roles` scopes role resolution to `autobot-slm-backend/ansible/roles/`, outside which these files sit; no task anywhere references them by full path (two hits total, both an unrelated Grafana dashboards sync); the `code_only.yml` tasks that update `ai-stack`/`npu-worker` in place use the `.j2` templates, not these; and the 4 Python-relevant ones don't even set `PYTHONPATH`, so they'd `ModuleNotFoundError` on `autobot_shared` before ever reaching the question this PR is about. Not deleted here — "no code deletion without landing proof" — filed for a follow-up that gets host-level confirmation first.

## Corrections (stated, not hidden, per review)

- **`AUTOBOT_PROJECT_ROOT` is step 1 of the resolver and returns *before* the `.env`/checkout walk**, so in the containers `project_root()` moves from the old silent `/opt/autobot` guess to `/app`, and everything derived moves with it: `CODE_SOURCES_BASE` (`source_paths.py`) shifts to the persistent `backend_data` volume — an improvement, verified. `code_source_dir` (`ssot_config.PathConfig`, alias `AUTOBOT_CODE_SOURCE`, unset anywhere in compose) and the snapshot/PKI paths (`snapshot_index.py`'s `_DEFAULT_SNAPSHOT_PATH`, `pki/config.py`'s `PROJECT_ROOT`) also move, to `/app`-relative locations **not** listed in `docker-compose.hardened.yml`'s `tmpfs:` overrides for `autobot-backend`/`autobot-worker`. Under hardened `read_only: true`, a write there would fail with `EROFS`. **Not a new regression** — `/opt/autobot/snapshots` was equally absent from that `tmpfs:` list before this PR, so if this path is ever actually written to, it was already broken, just at a different absolute location; `smoke-test`/`hardened-smoke-test` only exercise `/api/system/health`, which doesn't touch it either way. Filed as **#14591** rather than fixed here (scope: verify whether it's a live write path at all, then either add the missing hardened-overlay mount or point it at `AUTOBOT_DATA_DIR`).
- **The "autobot_shared already importable" proof covers 7 of the 17 files, not all 17.** For the other 10, this PR *added* `from autobot_shared.paths import project_root` above the bootstrap whose job is to make imports work at all — for those, `python3 debug/debug_terminal.py` from a bare checkout with no `PYTHONPATH` set now raises `ModuleNotFoundError` on the new import line, before ever reaching the old (also broken) literal default. Loud-and-broken over silent-and-wrong is the right direction and matches the raise this whole PR is built around — but it is not the "already proven safe" claim the round-1 body implied for all 17.
- **`sys.path.insert(0, str(project_root()))` does not make the 10 debug/analysis scripts' *other* imports work.** `debug_terminal.py:24` wants `constants.network_constants`, which lives at `autobot-backend/constants/`, not at the repo root `project_root()` now points `sys.path` at. Same for `circuit_breaker`, `knowledge_base`, `agents.*` in the other files. This was equally broken before (the old literal default pointed at the same wrong root) — not a regression — but "18/18" describes the `sys.path`-defaults-to-live-install defect being fixed 18/18 times, not that these 18 scripts now run end-to-end. None do, and this PR does not change that; it was out of scope for #14544 and remains so.

## Verification

- **`sys.path` sites found/fixed: 18/18** across 17 files (issue said 16 files; actual 17). Zero remaining at head — the only textual match left is inside the new guard's own docstring (prose, not a live call site).
- **Runtime enumeration, corrected: 5 real declarations** (2 Dockerfiles, `autobot-slm-backend.service.j2`, `slm-agent.service.j2`, `ai-stack.env.j2`) + **1 reverted** (npu-worker, wrong premise) + **9 dead duplicates accounted for** (#14590, not fixed here) + **1 downstream-path risk accounted for** (#14591, not fixed here).
- Per "never run code from the codebase": all execution happened against scratch copies under `/tmp/.../scratchpad/`, never the working tree. `python3 -m pytest` (system pytest 9.0.2) against copies of every touched test file: all pass, including the `caplog`-based `main()` tests run together in one session (proving the `capsys`-staleness bug doesn't recur).
- **Mutation 1** (the resolver): reintroduced the `/opt/autobot` silent guess in a scratch copy of `paths.py` — `TestUndeterminableRoot`'s 2 tests: 2 passed → 2 failed.
- **Mutation 2** (the sys.path guard): a scratch file with the fixed pattern reported exit 0; reintroducing the old literal default flipped it to exit 1 with the expected finding.
- **Mutation 3** (the deployment-declaration guard): removing the added `ENV AUTOBOT_PROJECT_ROOT=/app` line from a scratch copy of `docker/backend/Dockerfile` flipped that parametrized test case from pass to fail.
- Syntax-checked every touched `.py` file (`ast.parse`) and validated both touched YAML files (`yaml.safe_load`).
- `smoke-test` and `hardened-smoke-test` both green as of the round-1 push (commit `22f912018`); `code-quality`'s `print()` failure is fixed in this round (`dcbcf4228`) and CI is re-running.

## Model Used

Claude Opus 5 (1M context)

Closes #14544
