### PR TITLE
fix(ci): guard requirements-ci drift and ansible-vs-CI system packages (#14550, #14551)

### DIFF
--- a/.github/actions/setup-python-suite/action.yml
+++ b/.github/actions/setup-python-suite/action.yml
@@ -47,18 +47,26 @@ runs:
     # that runner holding the dpkg lock, the same class of flakiness
     # documented for ansible's own apt-get update at roles/nginx/tasks/main.yml
     # (#6719). `-o DPkg::Lock::Timeout=60` makes apt WAIT up to 60s for the
-    # lock instead of an unbounded hang; the step-level `timeout-minutes`
-    # below is the second line of defense — if the lock is still held, THIS
-    # step fails in 3 minutes with a clear error instead of silently
-    # consuming the whole job's budget.
+    # lock instead of an unbounded hang.
+    #
+    # #14550 (second incident): `timeout-minutes` on THIS step does not exist
+    # -- that key is valid on a job, and on a step in a workflow, but a
+    # composite action's own steps accept only `run`, `shell`,
+    # `working-directory`, `env`, `id`, `if` and `name`. Setting it here made
+    # the whole action fail GitHub's template validation before a single step
+    # ran, on every shard, not just the one with a stuck lock. Bounding the
+    # coreutils `timeout` around each COMMAND instead achieves the same
+    # "fail fast, not silently" goal without needing a step-level key that
+    # composite actions cannot have. A timeout (exit 124) is a real failure
+    # here, deliberately: a wedged apt means the toolchain this PR exists to
+    # provision is absent, and the test it gates would pass vacuously again.
     - name: Install CI system packages (#14550)
       shell: bash
-      timeout-minutes: 3
       run: |
         set -euo pipefail
         export DEBIAN_FRONTEND=noninteractive
-        sudo apt-get update -qq -o DPkg::Lock::Timeout=60
-        sudo apt-get install -y --no-install-recommends -o DPkg::Lock::Timeout=60 ffmpeg
+        timeout 180 sudo apt-get update -qq -o DPkg::Lock::Timeout=60
+        timeout 180 sudo apt-get install -y --no-install-recommends -o DPkg::Lock::Timeout=60 ffmpeg
 
     # The venv lives OUTSIDE the workspace on purpose. Inside it, `actions/
     # checkout` and the several `rm -rf .venv` cleanup steps elsewhere in this

--- a/.github/actions/setup-python-suite/action.yml
+++ b/.github/actions/setup-python-suite/action.yml
@@ -39,12 +39,26 @@ runs:
     # binary must have its package added here too, or code-quality fails.
     # Unconditional (not gated on the venv cache hit below): apt state is not
     # part of that cache and must be present on every run regardless.
+    #
+    # #14550 (post-merge incident): a bare `apt-get install` here hung one
+    # shard for the full 60-minute job timeout (ci.yml's python-suite
+    # `timeout-minutes: 60`), taking every test in that shard down with it —
+    # almost certainly the background apt-daily/unattended-upgrades timer on
+    # that runner holding the dpkg lock, the same class of flakiness
+    # documented for ansible's own apt-get update at roles/nginx/tasks/main.yml
+    # (#6719). `-o DPkg::Lock::Timeout=60` makes apt WAIT up to 60s for the
+    # lock instead of an unbounded hang; the step-level `timeout-minutes`
+    # below is the second line of defense — if the lock is still held, THIS
+    # step fails in 3 minutes with a clear error instead of silently
+    # consuming the whole job's budget.
     - name: Install CI system packages (#14550)
       shell: bash
+      timeout-minutes: 3
       run: |
         set -euo pipefail
-        sudo apt-get update -qq
-        sudo apt-get install -y --no-install-recommends ffmpeg
+        export DEBIAN_FRONTEND=noninteractive
+        sudo apt-get update -qq -o DPkg::Lock::Timeout=60
+        sudo apt-get install -y --no-install-recommends -o DPkg::Lock::Timeout=60 ffmpeg
 
     # The venv lives OUTSIDE the workspace on purpose. Inside it, `actions/
     # checkout` and the several `rm -rf .venv` cleanup steps elsewhere in this

--- a/.github/actions/setup-python-suite/action.yml
+++ b/.github/actions/setup-python-suite/action.yml
@@ -60,13 +60,40 @@ runs:
     # composite actions cannot have. A timeout (exit 124) is a real failure
     # here, deliberately: a wedged apt means the toolchain this PR exists to
     # provision is absent, and the test it gates would pass vacuously again.
+    #
+    # #14550 (third incident): 6 of 12 shards hit that timeout, one with
+    # exit 124 -- the command never finished inside 180s. python-shard runs
+    # on `ubuntu-latest` (ci.yml's own comment: "NOT the singleton
+    # [self-hosted, Linux, X64] pool"), so each of the 12 shards is a
+    # SEPARATE, ephemeral GitHub-hosted VM -- there is no dpkg lock shared
+    # BETWEEN shards, and no warm state carried over from a previous run
+    # either way (hosted runners are single-use). What twelve INDEPENDENT
+    # cold VMs share is the same risk profile: each one independently rolls
+    # the dice against its own background apt-daily/unattended-upgrades
+    # timer, and with twelve simultaneous trials several are expected to
+    # land inside that timer's window. 180s was not enough headroom for
+    # that; `command -v ffmpeg` first costs nothing and protects against a
+    # future base image that ships ffmpeg (or a future move to a runner
+    # pool that reuses state), but does NOT fix today's problem by itself --
+    # ffmpeg is absent from ubuntu-latest today, confirmed by this whole
+    # PR's own starting point (shutil.which("ffmpeg") returning None is what
+    # made test_real_audio_extraction skip in the first place), so every
+    # shard still takes the apt path. The actual fix is more headroom on
+    # both the per-command wall-clock bound and the dpkg lock wait, sized to
+    # the well-documented few-minutes duration of apt-daily on a freshly
+    # booted Ubuntu VM, with generous margin against the 60-minute job
+    # budget it draws from.
     - name: Install CI system packages (#14550)
       shell: bash
       run: |
         set -euo pipefail
+        if command -v ffmpeg >/dev/null 2>&1; then
+          echo "ffmpeg already present: $(ffmpeg -version | head -1)"
+          exit 0
+        fi
         export DEBIAN_FRONTEND=noninteractive
-        timeout 180 sudo apt-get update -qq -o DPkg::Lock::Timeout=60
-        timeout 180 sudo apt-get install -y --no-install-recommends -o DPkg::Lock::Timeout=60 ffmpeg
+        timeout 300 sudo apt-get update -qq -o DPkg::Lock::Timeout=120
+        timeout 300 sudo apt-get install -y --no-install-recommends -o DPkg::Lock::Timeout=120 ffmpeg
 
     # The venv lives OUTSIDE the workspace on purpose. Inside it, `actions/
     # checkout` and the several `rm -rf .venv` cleanup steps elsewhere in this

--- a/.github/actions/setup-python-suite/action.yml
+++ b/.github/actions/setup-python-suite/action.yml
@@ -29,6 +29,23 @@ runs:
           requirements*.txt
           autobot-backend/requirements*.txt
 
+    # #14550: system packages ansible installs on every backend host for a
+    # real capability (audio extraction here), that setup-python-suite never
+    # provisioned. media/audio/ffmpeg_service_test.py::test_real_audio_extraction
+    # skip-gates on `shutil.which("ffmpeg")` and was silently skipping on every
+    # CI run as a result — a skip that read as a pass in the job summary.
+    # tools/lint/check_ci_system_package_provisioning.py enforces the pairing
+    # going forward: any new shutil.which(...)-gated test on an ansible-installed
+    # binary must have its package added here too, or code-quality fails.
+    # Unconditional (not gated on the venv cache hit below): apt state is not
+    # part of that cache and must be present on every run regardless.
+    - name: Install CI system packages (#14550)
+      shell: bash
+      run: |
+        set -euo pipefail
+        sudo apt-get update -qq
+        sudo apt-get install -y --no-install-recommends ffmpeg
+
     # The venv lives OUTSIDE the workspace on purpose. Inside it, `actions/
     # checkout` and the several `rm -rf .venv` cleanup steps elsewhere in this
     # repo would fight over it, and pytest would try to collect tests out of

--- a/.github/actions/setup-python-suite/action.yml
+++ b/.github/actions/setup-python-suite/action.yml
@@ -83,6 +83,34 @@ runs:
     # the well-documented few-minutes duration of apt-daily on a freshly
     # booted Ubuntu VM, with generous margin against the 60-minute job
     # budget it draws from.
+    #
+    # #14550 (fourth incident): 11 of 12 shards passed after that increase;
+    # one still hit exit 124. A single failed attempt says nothing about
+    # whether a second would succeed against a background timer that clears
+    # on its own schedule -- that is what a retry is for, and doubling the
+    # timeout again would be guessing rather than reasoning about the actual
+    # failure mode (transient lock contention, not an undersized budget).
+    # Considered making the install lazy instead -- only the one shard whose
+    # pytest-split group actually contains ffmpeg_service_test.py would
+    # install it, cutting exposure from twelve VMs to one. Rejected: which
+    # shard gets that file is decided dynamically by pytest-split's duration
+    # balancing (not knowable statically), so determining it here would mean
+    # running a `--collect-only` dry pass with the SAME --splits/--group
+    # pytest-split sees later, matched exactly or a mismatch silently
+    # re-introduces the vacuous-skip bug this PR exists to close -- and
+    # tools/lint/check_ci_system_package_provisioning.py already generalises
+    # this pairing across every ansible-installed binary, not just ffmpeg;
+    # a per-test lazy-install path would only cover this one case and need
+    # its own maintenance again for the next one. Three attempts with a
+    # short, deliberately modest backoff (the lock holder finishes on its
+    # own schedule -- waiting is the point, not a longer single wait)
+    # converts a roughly 1-in-12 per-shard race into something far smaller,
+    # without pretending to know the right single-attempt budget. Exhausting
+    # all three still fails the step: the retry loop's own exit status IS
+    # the last attempt's exit status, propagated by `set -e` because the
+    # function call is a bare statement, not wrapped in an `if`/`&&` that
+    # would swallow it -- a genuinely unavailable toolchain must still
+    # redden the run.
     - name: Install CI system packages (#14550)
       shell: bash
       run: |
@@ -92,8 +120,20 @@ runs:
           exit 0
         fi
         export DEBIAN_FRONTEND=noninteractive
-        timeout 300 sudo apt-get update -qq -o DPkg::Lock::Timeout=120
-        timeout 300 sudo apt-get install -y --no-install-recommends -o DPkg::Lock::Timeout=120 ffmpeg
+
+        apt_retry() {
+          local attempt
+          for attempt in 1 2 3; do
+            "$@" && return 0
+            echo "apt attempt ${attempt}/3 failed (exit $?) — retrying" >&2
+            sleep $((attempt * 15))
+          done
+          echo "::error::apt did not succeed after 3 attempts — toolchain provisioning failed" >&2
+          return 1
+        }
+
+        apt_retry timeout 300 sudo apt-get update -qq -o DPkg::Lock::Timeout=120
+        apt_retry timeout 300 sudo apt-get install -y --no-install-recommends -o DPkg::Lock::Timeout=120 ffmpeg
 
     # The venv lives OUTSIDE the workspace on purpose. Inside it, `actions/
     # checkout` and the several `rm -rf .venv` cleanup steps elsewhere in this

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -533,6 +533,28 @@ jobs:
         # fail, and the run reports how many entries it reached.
         python3 scripts/check_python_file_size.py --audit-ceilings
 
+    - name: Audit requirements-ci for silent drift from production (#14551)
+      run: |
+        # autobot-backend/requirements.txt and autobot-slm-backend/requirements.txt
+        # declare production; requirements-ci.txt is a hand-maintained mirror
+        # setup-python-suite actually installs. A package present in one and not
+        # the other produces no error -- pytesseract sat undeclared in CI for
+        # months this way (#13885) while every OCR test skipped. This compares
+        # the two sets against repo_tests/requirements_ci_drift_baseline.txt,
+        # which only ever shrinks: a new undeclared omission, or a baseline entry
+        # that no longer describes a real one, both fail.
+        python3 tools/lint/check_requirements_ci_drift.py --audit
+
+    - name: Audit CI system-package provisioning against ansible (#14550)
+      run: |
+        # ansible installs apt packages on every backend host (GUI/VNC, audio,
+        # TTS, OCR, pg_dump) that setup-python-suite never provisions. A test
+        # that skip-gates on one of those binaries via shutil.which(...) has
+        # been silently skipping in CI rather than passing -- indistinguishable
+        # in the job summary. This fails on any such gate whose package is not
+        # installed in .github/actions/setup-python-suite/action.yml.
+        python3 tools/lint/check_ci_system_package_provisioning.py --audit
+
     - name: Code quality summary
       if: always()
       run: |

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -10,6 +10,7 @@ on:
       - '**/*.py'
       - '**/requirements*.txt'
       - 'requirements-ci/**'
+      - 'repo_tests/**'
       - 'pyproject.toml'
       - '.flake8'
       - '.bandit'
@@ -26,6 +27,13 @@ on:
       - 'autobot-slm-backend/ansible/roles/backend/files/**'
       - 'autobot-backend/config/permission_rules.yaml'
       - 'autobot-backend/static/error_messages.yaml'
+      # #14550/#14551: the ansible role check_ci_system_package_provisioning.py reads,
+      # and the composite action both new guards exist to protect. Neither matched any
+      # prior entry, so a PR touching only one of these skipped `code-quality` entirely
+      # -- a required check reporting skipped reads as satisfied to branch protection,
+      # so the guard could not fire on the change it exists to catch.
+      - 'autobot-slm-backend/ansible/roles/backend/tasks/**'
+      - '.github/actions/setup-python-suite/**'
       - 'docs/developer/**'
       - '.github/workflows/code-quality.yml'
   # NOTE: no pull_request.paths filter — this workflow ALWAYS runs on PRs so its
@@ -62,6 +70,7 @@ jobs:
               - '**/*.py'
               - '**/requirements*.txt'
               - 'requirements-ci/**'
+              - 'repo_tests/**'
               - 'pyproject.toml'
               - '.flake8'
               - '.bandit'
@@ -78,6 +87,8 @@ jobs:
               - 'autobot-slm-backend/ansible/roles/backend/files/**'
               - 'autobot-backend/config/permission_rules.yaml'
               - 'autobot-backend/static/error_messages.yaml'
+              - 'autobot-slm-backend/ansible/roles/backend/tasks/**'
+              - '.github/actions/setup-python-suite/**'
               - 'docs/developer/**'
               - '.github/workflows/code-quality.yml'
 
@@ -554,6 +565,19 @@ jobs:
         # in the job summary. This fails on any such gate whose package is not
         # installed in .github/actions/setup-python-suite/action.yml.
         python3 tools/lint/check_ci_system_package_provisioning.py --audit
+
+    - name: Audit that the changes filter covers what the new guards read (#14550/#14551)
+      run: |
+        # This job only runs at all when the `changes` job's dorny/paths-filter
+        # reports a `backend` path touched -- a job that is SKIPPED satisfies
+        # branch protection the same as one that PASSED. The two audits above
+        # read files (the ansible task list, the setup-python-suite action)
+        # that the filter did not originally cover, so a PR touching only one
+        # of them skipped code-quality entirely and neither audit ever ran.
+        # Re-derives each checker's own GUARD_INPUT_PATHS and asserts the
+        # filter covers all of them, so the next guard input added without a
+        # matching filter entry fails loudly instead of silently going dark.
+        python3 tools/lint/check_code_quality_guard_reach.py --audit
 
     - name: Code quality summary
       if: always()

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -33,7 +33,7 @@ on:
       # -- a required check reporting skipped reads as satisfied to branch protection,
       # so the guard could not fire on the change it exists to catch.
       - 'autobot-slm-backend/ansible/roles/backend/tasks/**'
-      - '.github/actions/setup-python-suite/**'
+      - '.github/actions/**'
       - 'docs/developer/**'
       - '.github/workflows/code-quality.yml'
   # NOTE: no pull_request.paths filter — this workflow ALWAYS runs on PRs so its
@@ -88,7 +88,7 @@ jobs:
               - 'autobot-backend/config/permission_rules.yaml'
               - 'autobot-backend/static/error_messages.yaml'
               - 'autobot-slm-backend/ansible/roles/backend/tasks/**'
-              - '.github/actions/setup-python-suite/**'
+              - '.github/actions/**'
               - 'docs/developer/**'
               - '.github/workflows/code-quality.yml'
 
@@ -565,6 +565,20 @@ jobs:
         # in the job summary. This fails on any such gate whose package is not
         # installed in .github/actions/setup-python-suite/action.yml.
         python3 tools/lint/check_ci_system_package_provisioning.py --audit
+
+    - name: Audit composite-action step keys against GitHub's own schema (#14550)
+      run: |
+        # A composite action's own steps accept only run/shell/working-directory/
+        # env/id/if/name(/uses/with) -- `timeout-minutes` looked plausible on a
+        # step but is job/workflow-step-only, and adding it here made GitHub's
+        # template validator reject the WHOLE action.yml before a single step
+        # ran, breaking every shard that used it (#14550 post-merge incident).
+        # code-quality installs no YAML-schema validator for GitHub's own
+        # template engine (and neither does actionlint, scoped to
+        # .github/workflows/** only, per #14632) -- this re-implements the
+        # small, stable allowed-key set directly so a push never reaches a
+        # runner with an invalid composite action again.
+        python3 tools/lint/check_composite_action_step_keys.py --audit
 
     - name: Audit that the changes filter covers what the new guards read (#14550/#14551)
       run: |

--- a/autobot-backend/media/audio/ffmpeg_service.py
+++ b/autobot-backend/media/audio/ffmpeg_service.py
@@ -107,9 +107,23 @@ class FFmpegService:
             # Security: Protocol whitelist (blocks HLS/HTTP/etc.)
             "-protocol_whitelist",
             "file",
-            # Security: Extension whitelist (using allowed_extensions)
-            "-allowed_extensions",
-            ",".join(ext.lstrip(".") for ext in ALLOWED_EXTENSIONS),
+            # #14550: `-allowed_extensions` is NOT a generic/global ffmpeg option —
+            # it is a private AVOption of the dash and hls DEMUXERS only (`ffmpeg -h
+            # protocol=file` lists no such option; `ffmpeg -h full | grep
+            # allowed_extensions` shows it scoped to "dash"/"hls"). Passing it here,
+            # ahead of `-i` with no demuxer context that defines it, made ffmpeg
+            # reject the whole command with "Option allowed_extensions not found" —
+            # extract_audio() has been completely non-functional for every real
+            # audio file, on every ffmpeg version, the entire time. This was
+            # invisible because the one test that ever invoked real ffmpeg
+            # (test_real_audio_extraction) was itself silently skipping in CI for
+            # want of the ffmpeg binary (#14550) — a skip masking a failure masking
+            # another failure. The actual extension enforcement already happens
+            # above, at the application level, before ffmpeg is ever invoked
+            # (`if input_ext not in ALLOWED_EXTENSIONS: raise ValueError(...)`,
+            # Issue #9214) — that check is sufficient on its own; this flag was
+            # attempted defense-in-depth that ffmpeg has no mechanism to honour for
+            # a plain file input.
         ]
 
         # Security: Pin demuxer with -f flag if known

--- a/autobot-backend/media/audio/ffmpeg_service_test.py
+++ b/autobot-backend/media/audio/ffmpeg_service_test.py
@@ -173,10 +173,12 @@ def test_ci_actually_has_the_ffmpeg_toolchain():
     ansible installs ffmpeg on every backend host (#14550) for exactly the
     capability test_real_audio_extraction below exercises; setup-python-suite
     now mirrors that install so the test genuinely runs instead of skipping
-    "FFmpeg not installed" — the pattern is the same one #13896 established
-    for the OCR toolchain: an always-closed gate must fail, not pass quietly.
-    Outside CI (e.g. a contributor's machine without ffmpeg) the capability is
-    legitimately unavailable, so this only asserts when CI is set.
+    "FFmpeg not installed". Applies the same principle
+    tools/lint/check_ci_system_package_provisioning.py enforces structurally:
+    an always-closed gate must fail loudly, not pass quietly, if provisioning
+    ever regresses. Outside CI (e.g. a contributor's machine without ffmpeg)
+    the capability is legitimately unavailable, so this only asserts when CI
+    is set.
     """
     if os.environ.get("CI", "").lower() not in ("1", "true"):
         pytest.skip("not running in CI — ffmpeg is optional on a local machine")

--- a/autobot-backend/media/audio/ffmpeg_service_test.py
+++ b/autobot-backend/media/audio/ffmpeg_service_test.py
@@ -167,6 +167,26 @@ class TestFFmpegService:
         assert service1 is service2
 
 
+def test_ci_actually_has_the_ffmpeg_toolchain():
+    """#14550: fail loudly in CI, rather than silently skip, if ffmpeg regresses.
+
+    ansible installs ffmpeg on every backend host (#14550) for exactly the
+    capability test_real_audio_extraction below exercises; setup-python-suite
+    now mirrors that install so the test genuinely runs instead of skipping
+    "FFmpeg not installed" — the pattern is the same one #13896 established
+    for the OCR toolchain: an always-closed gate must fail, not pass quietly.
+    Outside CI (e.g. a contributor's machine without ffmpeg) the capability is
+    legitimately unavailable, so this only asserts when CI is set.
+    """
+    if os.environ.get("CI", "").lower() not in ("1", "true"):
+        pytest.skip("not running in CI — ffmpeg is optional on a local machine")
+    assert shutil.which("ffmpeg") is not None, (
+        "ffmpeg missing on the CI runner: .github/actions/setup-python-suite/action.yml "
+        "should have installed it (#14550). Without it, test_real_audio_extraction "
+        "silently skips and proves nothing about real audio extraction."
+    )
+
+
 class TestFFmpegServiceIntegration:
     """Integration tests with real FFmpeg (requires FFmpeg installed)."""
 

--- a/autobot-backend/utils/faiss_ivfpq_builder_test.py
+++ b/autobot-backend/utils/faiss_ivfpq_builder_test.py
@@ -155,6 +155,20 @@ class TestBuildOrLoad:
 
 class TestPersistence:
     def test_index_file_written_after_train(self, tmp_index_dir):
+        """#14550/#14551 CI incident: this test itself computed the wrong path.
+
+        FAISSIVFPQBuilder._index_path() embeds the live module-level
+        IVFPQ_NLIST in the filename, and it is a bare global read at CALL
+        time, not captured once at __init__. The assertion used to sit
+        AFTER the `with patch(...)` block had already exited, so it computed
+        a path using the real IVFPQ_NLIST=1024 while training (inside the
+        block) wrote the file under the patched IVFPQ_NLIST=8 -- two
+        different filenames, so `.exists()` was checking a file that was
+        never written. Never caught locally because pytest.importorskip("faiss")
+        always skipped this test until #14551 mirrored faiss-cpu into CI, and
+        this was the first real run against the actual library. Fixed by
+        keeping the assertions inside the same patch scope as the write.
+        """
         from utils.faiss_ivfpq_builder import FAISSIVFPQBuilder
 
         with (
@@ -168,8 +182,8 @@ class TestPersistence:
             vectors = _make_vectors(600, 64)
             asyncio.run(b.train_and_build(vectors))
 
-        assert b._index_path().exists()
-        assert b._index_path().stat().st_size > 0
+            assert b._index_path().exists()
+            assert b._index_path().stat().st_size > 0
 
     def test_load_returns_none_when_file_missing(self, tmp_index_dir):
         from utils.faiss_ivfpq_builder import FAISSIVFPQBuilder

--- a/repo_tests/ci_system_package_provisioning_test.py
+++ b/repo_tests/ci_system_package_provisioning_test.py
@@ -250,15 +250,48 @@ def test_ci_installed_packages_ignores_apt_install_mentioned_in_a_comment(tmp_pa
 
 
 def test_setup_python_suite_apt_step_waits_for_the_dpkg_lock_and_cannot_hang_the_job():
-    """#14550 post-merge incident: an unbounded apt-get install hung one shard
-    for the job's full 60-minute timeout, taking every test in it down too.
-    Both the apt-level lock-wait and the step-level timeout must be present."""
+    """#14550 post-merge incident 1: an unbounded apt-get install hung one
+    shard for the job's full 60-minute timeout, taking every test in it down
+    too. `-o DPkg::Lock::Timeout` bounds the wait for the dpkg lock, and
+    coreutils `timeout` around each COMMAND bounds the whole invocation.
+
+    NOT `timeout-minutes` on the step -- that is incident 2: that key does
+    not exist on a composite action's own steps (only `run`, `shell`,
+    `working-directory`, `env`, `id`, `if`, `name` do), and setting it broke
+    GitHub's template validation for the WHOLE action, on every shard, not
+    just the one with a stuck lock. This test pins the working shape,
+    including the negative half.
+    """
     action = (REPO_ROOT / ".github" / "actions" / "setup-python-suite" / "action.yml").read_text(encoding="utf-8")
     assert "DPkg::Lock::Timeout" in action, "apt-get must bound its wait for the dpkg lock, not hang indefinitely"
     parsed = yaml.safe_load(action)
     apt_steps = [s for s in parsed["runs"]["steps"] if "apt-get install" in s.get("run", "")]
     assert apt_steps, "no step installs system packages — did the step get renamed?"
-    assert apt_steps[0].get("timeout-minutes"), "the apt-get step must have its own short timeout-minutes"
+    step = apt_steps[0]
+    assert "timeout " in step["run"], "the apt-get command itself must be wrapped in coreutils `timeout`"
+
+
+def test_setup_python_suite_steps_use_only_composite_action_keys():
+    """#14550 post-merge incident 2, generalised: not just the apt step.
+
+    A composite action's OWN steps accept only `run`, `shell`,
+    `working-directory`, `env`, `id`, `if`, `name` -- `timeout-minutes` (job-
+    and workflow-step-only) made GitHub's template validator reject the
+    WHOLE action.yml before a single step ran, on every shard. Checks every
+    step, not only the one that caused the incident, since the next
+    workflow-only key added to any step here fails the same way.
+    """
+    action = (REPO_ROOT / ".github" / "actions" / "setup-python-suite" / "action.yml").read_text(encoding="utf-8")
+    parsed = yaml.safe_load(action)
+    steps = parsed["runs"]["steps"]
+    assert steps, "no steps found — did the action structure change?"
+    allowed = {"name", "run", "shell", "working-directory", "env", "id", "if", "uses", "with"}
+    for step in steps:
+        offending = set(step) - allowed
+        assert not offending, (
+            f"step {step.get('name')!r} uses key(s) {offending} that a composite action's own steps do not "
+            "support -- GitHub's template validator rejects the WHOLE file for this, not just the one step"
+        )
 
 
 # --------------------------------------------------------------------------

--- a/repo_tests/ci_system_package_provisioning_test.py
+++ b/repo_tests/ci_system_package_provisioning_test.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
+import yaml
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 _CHECKER = REPO_ROOT / "tools" / "lint" / "check_ci_system_package_provisioning.py"
 
@@ -226,6 +228,37 @@ def test_audit_is_clean_on_the_real_tree():
     reached, problems = checker.audit_provisioning()
     assert reached >= 1, "no shutil.which(...) skip-gate found on the live tree"
     assert problems == [], problems
+
+
+def test_ci_installed_packages_ignores_apt_install_mentioned_in_a_comment(tmp_path):
+    """#14550 incident: a comment EXPLAINING an apt-get command must not be
+    tokenized as one. The action file's own docstring-style comment about
+    this very bug contains the literal substring "apt-get install" in prose,
+    and used to leak words from that sentence into the installed-package set."""
+    action_dir = tmp_path / ".github" / "actions" / "setup-python-suite"
+    action_dir.mkdir(parents=True)
+    fixture = """runs:
+  using: composite
+  steps:
+    # a bare `apt-get install` hung one shard for the full timeout
+    - shell: bash
+      run: |
+        sudo apt-get install -y --no-install-recommends -o DPkg::Lock::Timeout=60 ffmpeg
+"""
+    (action_dir / "action.yml").write_text(fixture, encoding="utf-8")
+    assert checker.ci_installed_packages(tmp_path) == {"ffmpeg"}
+
+
+def test_setup_python_suite_apt_step_waits_for_the_dpkg_lock_and_cannot_hang_the_job():
+    """#14550 post-merge incident: an unbounded apt-get install hung one shard
+    for the job's full 60-minute timeout, taking every test in it down too.
+    Both the apt-level lock-wait and the step-level timeout must be present."""
+    action = (REPO_ROOT / ".github" / "actions" / "setup-python-suite" / "action.yml").read_text(encoding="utf-8")
+    assert "DPkg::Lock::Timeout" in action, "apt-get must bound its wait for the dpkg lock, not hang indefinitely"
+    parsed = yaml.safe_load(action)
+    apt_steps = [s for s in parsed["runs"]["steps"] if "apt-get install" in s.get("run", "")]
+    assert apt_steps, "no step installs system packages — did the step get renamed?"
+    assert apt_steps[0].get("timeout-minutes"), "the apt-get step must have its own short timeout-minutes"
 
 
 # --------------------------------------------------------------------------

--- a/repo_tests/ci_system_package_provisioning_test.py
+++ b/repo_tests/ci_system_package_provisioning_test.py
@@ -156,6 +156,51 @@ def test_toolchain_packages_are_excluded_from_scope():
     assert "ffmpeg" not in checker.TOOLCHAIN_PACKAGES
 
 
+def _write_probe_gated_test(tmp_path, *, rel_path: str) -> None:
+    """A test gated on an indirect probe call, never touching shutil.which.
+
+    The probe call is assembled from fragments rather than written as a
+    literal -- this guard scans the whole tree including repo_tests/ itself,
+    so a literal `get_tesseract_version(` here would make the checker flag
+    ITS OWN test file the moment this fixture is written to disk.
+    """
+    probe_call = "get_tesseract" + "_version()"
+    path = tmp_path / rel_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "import pytest\n\n\n"
+        "def test_real_ocr():\n"
+        '    pytest.importorskip("pytesseract")\n'
+        "    import pytesseract\n"
+        f"    pytesseract.{probe_call}\n",
+        encoding="utf-8",
+    )
+
+
+def test_probe_call_widens_detection_beyond_shutil_which(tmp_path):
+    """#14550 code-review: a get_tesseract_version() gate must not read as
+    "no real test, out of scope" just because it never calls shutil.which."""
+    _write_ansible_task(tmp_path, _SAMPLE_FEATURE_PACKAGES)
+    _write_setup_action(tmp_path, apt_install_line=None)
+    _write_probe_gated_test(tmp_path, rel_path="pkg/thing_test.py")
+
+    reached, problems = checker.audit_provisioning(tmp_path)
+    assert reached == 1
+    assert problems, "a probe-call gate on an unprovisioned package must fail"
+    assert "tesseract" in problems[0]
+
+
+def test_prefix_style_test_files_are_scanned_too(tmp_path):
+    """pytest.ini collects BOTH `test_*.py` and `*_test.py` -- so must this guard."""
+    _write_ansible_task(tmp_path, _SAMPLE_FEATURE_PACKAGES)
+    _write_setup_action(tmp_path, apt_install_line=None)
+    _write_gated_test(tmp_path, rel_path="pkg/test_thing.py", binary="tesseract")
+
+    reached, problems = checker.audit_provisioning(tmp_path)
+    assert reached == 1, "a test_*.py-prefixed file's skip-gate was not found"
+    assert problems
+
+
 # --------------------------------------------------------------------------
 # The live tree, and the #14550 regression this PR fixes
 # --------------------------------------------------------------------------

--- a/repo_tests/ci_system_package_provisioning_test.py
+++ b/repo_tests/ci_system_package_provisioning_test.py
@@ -1,0 +1,216 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""#14550 — system packages ansible installs on hosts are absent from CI runners.
+
+Exercises the exact functions ``code-quality`` calls
+(``tools/lint/check_ci_system_package_provisioning.py --audit``) rather than
+paraphrasing the rule, so a test agreeing with a second copy of the decision
+proves nothing about the copy that actually blocks a merge.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+_CHECKER = REPO_ROOT / "tools" / "lint" / "check_ci_system_package_provisioning.py"
+
+
+def _load_checker():
+    spec = importlib.util.spec_from_file_location("check_ci_system_package_provisioning", _CHECKER)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+checker = _load_checker()
+
+
+# --------------------------------------------------------------------------
+# Discrimination — against a real (synthetic) tree on disk
+# --------------------------------------------------------------------------
+
+
+def _write_ansible_task(tmp_path, packages: list[str]) -> None:
+    tasks_dir = tmp_path / "autobot-slm-backend" / "ansible" / "roles" / "backend" / "tasks"
+    tasks_dir.mkdir(parents=True)
+    body = "\n".join(f"        - {pkg}" for pkg in packages)
+    (tasks_dir / "main.yml").write_text(
+        f"""---
+  - name: "Backend | Install backend-specific system dependencies"
+    ansible.builtin.apt:
+      name:
+{body}
+      state: present
+    tags: ['backend', 'packages']
+""",
+        encoding="utf-8",
+    )
+
+
+def _write_setup_action(tmp_path, apt_install_line: str | None) -> None:
+    action_dir = tmp_path / ".github" / "actions" / "setup-python-suite"
+    action_dir.mkdir(parents=True)
+    body = f"        run: |\n          sudo apt-get install -y {apt_install_line}\n" if apt_install_line else ""
+    text = f"runs:\n  using: composite\n  steps:\n    - shell: bash\n{body}"
+    (action_dir / "action.yml").write_text(text, encoding="utf-8")
+
+
+def _write_gated_test(tmp_path, *, rel_path: str, binary: str) -> None:
+    path = tmp_path / rel_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f"""import shutil
+import pytest
+
+
+@pytest.mark.skipif(
+    shutil.which("{binary}") is None,
+    reason="{binary} not installed",
+)
+def test_real_thing():
+    pass
+""",
+        encoding="utf-8",
+    )
+
+
+#: Mirrors the real ansible role's feature-package group (13 entries) so
+#: fixtures clear FEATURE_PACKAGE_FLOOR without needing the toolchain packages,
+#: which ansible_feature_packages() subtracts out before counting.
+_SAMPLE_FEATURE_PACKAGES = [
+    "xvfb",
+    "x11-utils",
+    "x11-apps",
+    "ffmpeg",
+    "libsndfile1",
+    "libsndfile1-dev",
+    "portaudio19-dev",
+    "espeak-ng",
+    "espeak-ng-data",
+    "tesseract-ocr",
+    "libtesseract-dev",
+    "python3-tk",
+    "postgresql-client",
+]
+
+
+def test_audit_fails_when_a_gated_binarys_package_is_not_provisioned(tmp_path):
+    _write_ansible_task(tmp_path, _SAMPLE_FEATURE_PACKAGES)
+    _write_setup_action(tmp_path, apt_install_line=None)
+    _write_gated_test(tmp_path, rel_path="pkg/thing_test.py", binary="tesseract")
+
+    reached, problems = checker.audit_provisioning(tmp_path)
+    assert reached == 1
+    assert problems, "an ansible-installed, CI-unprovisioned binary must fail"
+    assert "tesseract" in problems[0]
+
+
+def test_audit_passes_when_the_package_is_provisioned(tmp_path):
+    _write_ansible_task(tmp_path, _SAMPLE_FEATURE_PACKAGES)
+    _write_setup_action(tmp_path, apt_install_line="tesseract-ocr")
+    _write_gated_test(tmp_path, rel_path="pkg/thing_test.py", binary="tesseract")
+
+    reached, problems = checker.audit_provisioning(tmp_path)
+    assert reached == 1
+    assert problems == []
+
+
+def test_audit_ignores_a_binary_ansible_does_not_install(tmp_path):
+    """A gate on a binary outside the ansible role's package set is not this guard's concern."""
+    without_ffmpeg = [pkg for pkg in _SAMPLE_FEATURE_PACKAGES if pkg != "ffmpeg"]
+    _write_ansible_task(tmp_path, without_ffmpeg)
+    _write_setup_action(tmp_path, apt_install_line=None)
+    _write_gated_test(tmp_path, rel_path="pkg/thing_test.py", binary="ffmpeg")
+
+    reached, problems = checker.audit_provisioning(tmp_path)
+    assert reached == 1  # the gate is still found and reported...
+    assert problems == []  # ...but produces no problem, since ansible never promised it
+
+
+def test_audit_fails_below_the_feature_package_floor(tmp_path):
+    """A renamed/moved ansible task must not read as a clean scan of nothing."""
+    _write_ansible_task(tmp_path, ["ffmpeg"])  # far below FEATURE_PACKAGE_FLOOR
+    _write_setup_action(tmp_path, apt_install_line="ffmpeg")
+    reached, problems = checker.audit_provisioning(tmp_path)
+    assert reached == 0
+    assert problems and "moved or was renamed" in problems[0]
+
+
+def test_audit_fails_when_no_gated_binary_is_found(tmp_path):
+    """A test-file rename that hides every skip-gate must not read as zero problems."""
+    _write_ansible_task(tmp_path, _SAMPLE_FEATURE_PACKAGES)
+    _write_setup_action(tmp_path, apt_install_line="ffmpeg")
+    reached, problems = checker.audit_provisioning(tmp_path)
+    assert reached == 0
+    assert problems and "zero shutil.which" in problems[0]
+
+
+def test_toolchain_packages_are_excluded_from_scope():
+    """git/curl/build-essential are pre-installed by the runner image — not this guard's job."""
+    assert "git" in checker.TOOLCHAIN_PACKAGES
+    assert "curl" in checker.TOOLCHAIN_PACKAGES
+    assert "ffmpeg" not in checker.TOOLCHAIN_PACKAGES
+
+
+# --------------------------------------------------------------------------
+# The live tree, and the #14550 regression this PR fixes
+# --------------------------------------------------------------------------
+
+
+def test_ansible_feature_packages_reaches_the_floor():
+    packages = checker.ansible_feature_packages()
+    assert len(packages) >= checker.FEATURE_PACKAGE_FLOOR, packages
+    assert "tesseract-ocr" in packages
+    assert "ffmpeg" in packages
+    assert "git" not in packages  # toolchain package, excluded on purpose
+
+
+def test_ffmpeg_is_provisioned_in_ci():
+    """The one live finding #14550 fixed: ffmpeg must now be installed in CI."""
+    assert "ffmpeg" in checker.ci_installed_packages(), (
+        ".github/actions/setup-python-suite/action.yml must install ffmpeg — "
+        "test_real_audio_extraction needs it to run for real, not skip (#14550)"
+    )
+
+
+def test_audit_is_clean_on_the_real_tree():
+    reached, problems = checker.audit_provisioning()
+    assert reached >= 1, "no shutil.which(...) skip-gate found on the live tree"
+    assert problems == [], problems
+
+
+# --------------------------------------------------------------------------
+# The audit entrypoint, and the check that actually runs it
+# --------------------------------------------------------------------------
+
+
+def test_code_quality_runs_the_audit():
+    workflow = (REPO_ROOT / ".github" / "workflows" / "code-quality.yml").read_text(encoding="utf-8")
+    assert "check_ci_system_package_provisioning.py --audit" in workflow, (
+        "code-quality.yml no longer runs the CI system-package provisioning audit — "
+        "the guard would stop blocking merges while these tests kept passing (#14550)"
+    )
+    assert _CHECKER.is_file(), f"{_CHECKER} is gone but the workflow still calls it"
+
+
+def test_setup_python_suite_installs_ffmpeg_directly():
+    """Pin the fix at the source file, not only through the checker's own parse."""
+    action = (REPO_ROOT / ".github" / "actions" / "setup-python-suite" / "action.yml").read_text(encoding="utf-8")
+    assert "ffmpeg" in action, "setup-python-suite/action.yml no longer installs ffmpeg (#14550)"
+
+
+def test_the_checker_needs_no_third_party_import():
+    """It must run in a job that installs linters, not the application's dependencies."""
+    source = _CHECKER.read_text(encoding="utf-8")
+    third_party = [
+        line
+        for line in source.splitlines()
+        if line.startswith(("import ", "from "))
+        and not line.startswith("from __future__")
+        and line.split()[1].split(".")[0] not in {"argparse", "logging", "pathlib", "re", "sys"}
+    ]
+    assert third_party == [], f"the checker imports non-stdlib modules: {third_party}"

--- a/repo_tests/code_quality_guard_reach_test.py
+++ b/repo_tests/code_quality_guard_reach_test.py
@@ -156,7 +156,7 @@ def test_backend_filter_finds_the_real_filters_block_not_the_outputs_key():
     patterns = checker.backend_filter_patterns()
     assert "**/*.py" in patterns
     assert "autobot-slm-backend/ansible/roles/backend/tasks/**" in patterns
-    assert ".github/actions/setup-python-suite/**" in patterns
+    assert ".github/actions/**" in patterns
 
 
 # --------------------------------------------------------------------------

--- a/repo_tests/code_quality_guard_reach_test.py
+++ b/repo_tests/code_quality_guard_reach_test.py
@@ -52,6 +52,36 @@ def test_pattern_regex_handles_a_trailing_double_star():
     assert not rx.search("requirements-ci.txt")
 
 
+def test_backend_filter_patterns_survives_a_comment_mid_list(tmp_path):
+    """#14550/#14551 rebase incident: a comment BETWEEN two bullets truncated
+    the parse. #14650 landed a multi-line comment inside this exact block for
+    the first time; the original parser treated any non-bullet line as the
+    end of the list once it had collected at least one bullet, so every entry
+    after the comment -- including this checker's own guarded paths -- read
+    as uncovered. dorny/paths-filter itself parses this as real YAML and is
+    unaffected by comments; this mirror must not diverge from that."""
+    workflows = tmp_path / ".github" / "workflows"
+    workflows.mkdir(parents=True)
+    (workflows / "code-quality.yml").write_text(
+        "jobs:\n"
+        "  changes:\n"
+        "    outputs:\n"
+        "      backend: ${{ steps.filter.outputs.backend }}\n"
+        "    steps:\n"
+        "      - uses: dorny/paths-filter@x\n"
+        "        id: filter\n"
+        "        with:\n"
+        "          filters: |\n"
+        "            backend:\n"
+        "              - 'before/**'\n"
+        "              # a comment sitting between two bullets, mid-list\n"
+        "              - 'after/**'\n",
+        encoding="utf-8",
+    )
+    patterns = checker.backend_filter_patterns(tmp_path)
+    assert patterns == ["before/**", "after/**"]
+
+
 def test_uncovered_paths_flags_a_guarded_path_no_pattern_reaches():
     guarded = {"tools/lint/fake_checker.py": ("some/new/input.yml",)}
     patterns = ["**/*.py", "requirements-ci/**"]
@@ -147,7 +177,7 @@ def test_audit_fails_on_zero_guard_input_paths(tmp_path):
 
 def test_audit_is_clean_on_the_real_tree():
     reached, problems = checker.audit_reach()
-    assert reached >= 7, f"only {reached} guarded paths reached — a checker lost its GUARD_INPUT_PATHS"
+    assert reached >= 8, f"only {reached} guarded paths reached — a checker lost its GUARD_INPUT_PATHS"
     assert problems == [], problems
 
 

--- a/repo_tests/code_quality_guard_reach_test.py
+++ b/repo_tests/code_quality_guard_reach_test.py
@@ -1,0 +1,186 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""#14550/#14551 — a required check that is SKIPPED is not the same as PASSING.
+
+Exercises the exact functions ``code-quality`` calls
+(``tools/lint/check_code_quality_guard_reach.py --audit``) rather than
+paraphrasing the rule.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+_CHECKER = REPO_ROOT / "tools" / "lint" / "check_code_quality_guard_reach.py"
+
+
+def _load_checker():
+    spec = importlib.util.spec_from_file_location("check_code_quality_guard_reach", _CHECKER)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+checker = _load_checker()
+
+
+# --------------------------------------------------------------------------
+# The invariant, against synthetic input
+# --------------------------------------------------------------------------
+
+
+def test_pattern_regex_matches_a_root_level_file_via_double_star_prefix():
+    """`**/foo` must match a root-level `foo` with zero path segments.
+
+    The original bug in this checker: a bare `.*/`  demands a literal `/`,
+    which a top-level file like `requirements-ci.txt` does not have, so a
+    genuinely-covered path was reported uncovered.
+    """
+    rx = checker._pattern_regex("**/requirements*.txt")
+    assert rx.search("requirements-ci.txt")
+    assert rx.search("autobot-backend/requirements.txt")
+    assert not rx.search("autobot-backend/other.txt")
+
+
+def test_pattern_regex_handles_a_trailing_double_star():
+    rx = checker._pattern_regex("requirements-ci/**")
+    assert rx.search("requirements-ci/automation.txt")
+    assert not rx.search("requirements-ci.txt")
+
+
+def test_uncovered_paths_flags_a_guarded_path_no_pattern_reaches():
+    guarded = {"tools/lint/fake_checker.py": ("some/new/input.yml",)}
+    patterns = ["**/*.py", "requirements-ci/**"]
+    missed = checker.uncovered_paths(guarded, patterns)
+    assert missed == {"tools/lint/fake_checker.py": ["some/new/input.yml"]}
+
+
+def test_uncovered_paths_is_empty_when_every_path_is_covered():
+    guarded = {"tools/lint/fake_checker.py": ("requirements-ci/foo.txt",)}
+    patterns = ["requirements-ci/**"]
+    assert checker.uncovered_paths(guarded, patterns) == {}
+
+
+# --------------------------------------------------------------------------
+# Discrimination — against a real (synthetic) tree on disk
+# --------------------------------------------------------------------------
+
+
+def _write_workflow(tmp_path, backend_patterns: list[str]) -> None:
+    workflows = tmp_path / ".github" / "workflows"
+    workflows.mkdir(parents=True)
+    bullets = "\n".join(f"            - '{p}'" for p in backend_patterns)
+    (workflows / "code-quality.yml").write_text(
+        f"""jobs:
+  changes:
+    outputs:
+      backend: ${{{{ steps.filter.outputs.backend }}}}
+    steps:
+      - uses: dorny/paths-filter@x
+        id: filter
+        with:
+          filters: |
+            backend:
+{bullets}
+""",
+        encoding="utf-8",
+    )
+
+
+def _write_fake_checker(tmp_path, *, rel_path: str, guard_input_paths: tuple[str, ...]) -> None:
+    path = tmp_path / rel_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    joined = ", ".join(f'"{p}"' for p in guard_input_paths)
+    path.write_text(f"GUARD_INPUT_PATHS = ({joined},)\n", encoding="utf-8")
+
+
+def test_audit_fails_when_a_checkers_input_is_not_filtered(tmp_path, monkeypatch):
+    _write_workflow(tmp_path, backend_patterns=["**/*.py"])
+    _write_fake_checker(tmp_path, rel_path="tools/lint/fake_checker.py", guard_input_paths=("some/config.yml",))
+    monkeypatch.setattr(checker, "_GUARDED_CHECKERS", ("tools/lint/fake_checker.py",))
+
+    reached, problems = checker.audit_reach(tmp_path)
+    assert reached == 1
+    assert problems, "an unfiltered guard input must fail the audit"
+    assert "some/config.yml" in problems[0]
+
+
+def test_audit_passes_when_every_input_is_filtered(tmp_path, monkeypatch):
+    _write_workflow(tmp_path, backend_patterns=["some/**"])
+    _write_fake_checker(tmp_path, rel_path="tools/lint/fake_checker.py", guard_input_paths=("some/config.yml",))
+    monkeypatch.setattr(checker, "_GUARDED_CHECKERS", ("tools/lint/fake_checker.py",))
+
+    reached, problems = checker.audit_reach(tmp_path)
+    assert reached == 1
+    assert problems == []
+
+
+def test_audit_fails_on_zero_filter_patterns(tmp_path, monkeypatch):
+    """A malformed/moved filters block must not read as a clean scan of nothing."""
+    workflows = tmp_path / ".github" / "workflows"
+    workflows.mkdir(parents=True)
+    (workflows / "code-quality.yml").write_text("jobs: {}\n", encoding="utf-8")
+    _write_fake_checker(tmp_path, rel_path="tools/lint/fake_checker.py", guard_input_paths=("some/config.yml",))
+    monkeypatch.setattr(checker, "_GUARDED_CHECKERS", ("tools/lint/fake_checker.py",))
+
+    reached, problems = checker.audit_reach(tmp_path)
+    assert reached == 1
+    assert problems and "zero" in problems[0]
+
+
+def test_audit_fails_on_zero_guard_input_paths(tmp_path):
+    """A checker that lost its GUARD_INPUT_PATHS attribute must not read as clean."""
+    _write_workflow(tmp_path, backend_patterns=["**/*.py"])
+    reached, problems = checker.audit_reach(tmp_path)
+    assert reached == 0
+    assert problems and "checked nothing" in problems[0]
+
+
+# --------------------------------------------------------------------------
+# The live tree, and the #14550/#14551 regression this file fixes
+# --------------------------------------------------------------------------
+
+
+def test_audit_is_clean_on_the_real_tree():
+    reached, problems = checker.audit_reach()
+    assert reached >= 7, f"only {reached} guarded paths reached — a checker lost its GUARD_INPUT_PATHS"
+    assert problems == [], problems
+
+
+def test_backend_filter_finds_the_real_filters_block_not_the_outputs_key():
+    """`outputs: backend: ...` sits two lines above the real filter list — must not match first."""
+    patterns = checker.backend_filter_patterns()
+    assert "**/*.py" in patterns
+    assert "autobot-slm-backend/ansible/roles/backend/tasks/**" in patterns
+    assert ".github/actions/setup-python-suite/**" in patterns
+
+
+# --------------------------------------------------------------------------
+# The audit entrypoint, and the check that actually runs it
+# --------------------------------------------------------------------------
+
+
+def test_code_quality_runs_the_audit():
+    workflow = (REPO_ROOT / ".github" / "workflows" / "code-quality.yml").read_text(encoding="utf-8")
+    assert "check_code_quality_guard_reach.py --audit" in workflow, (
+        "code-quality.yml no longer runs the guard-reach audit — the two guards it "
+        "protects could go dark again while these tests kept passing (#14550/#14551)"
+    )
+    assert _CHECKER.is_file(), f"{_CHECKER} is gone but the workflow still calls it"
+
+
+def test_the_checker_needs_no_third_party_import():
+    """It must run in a job that installs linters, not the application's dependencies."""
+    source = _CHECKER.read_text(encoding="utf-8")
+    third_party = [
+        line
+        for line in source.splitlines()
+        if line.startswith(("import ", "from "))
+        and not line.startswith("from __future__")
+        and line.split()[1].split(".")[0] not in {"argparse", "importlib", "logging", "pathlib", "re", "sys"}
+    ]
+    assert third_party == [], f"the checker imports non-stdlib modules: {third_party}"

--- a/repo_tests/composite_action_step_keys_test.py
+++ b/repo_tests/composite_action_step_keys_test.py
@@ -1,0 +1,194 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""#14550 post-merge incident — a composite action step key GitHub silently rejects.
+
+Exercises the exact functions ``code-quality`` calls
+(``tools/lint/check_composite_action_step_keys.py --audit``) rather than
+paraphrasing the rule.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+_CHECKER = REPO_ROOT / "tools" / "lint" / "check_composite_action_step_keys.py"
+
+
+def _load_checker():
+    spec = importlib.util.spec_from_file_location("check_composite_action_step_keys", _CHECKER)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+checker = _load_checker()
+
+
+# --------------------------------------------------------------------------
+# The invariant, against synthetic input
+# --------------------------------------------------------------------------
+
+
+def test_step_key_sets_ignores_keys_nested_inside_with():
+    text = (
+        "runs:\n"
+        "  using: composite\n"
+        "  steps:\n"
+        "    - uses: actions/setup-python@v7\n"
+        "      with:\n"
+        "        python-version: '3.14'\n"
+        "        cache: 'pip'\n"
+    )
+    steps = checker.step_key_sets(text)
+    assert steps == [{"uses", "with"}]
+
+
+def test_step_key_sets_ignores_keys_embedded_in_a_heredoc():
+    """A `run: |` block that writes YAML content must not be mistaken for step keys."""
+    text = (
+        "runs:\n"
+        "  using: composite\n"
+        "  steps:\n"
+        "    - shell: bash\n"
+        "      run: |\n"
+        "        cat > config.yaml << 'EOF'\n"
+        "        llm:\n"
+        "          orchestrator_llm: mock\n"
+        "        EOF\n"
+    )
+    steps = checker.step_key_sets(text)
+    assert steps == [{"shell", "run"}]
+
+
+def test_offending_keys_flags_the_exact_reported_key():
+    steps = [{"name", "shell", "run", "timeout-minutes"}]
+    assert checker.offending_keys(steps) == [{"timeout-minutes"}]
+
+
+def test_offending_keys_is_empty_for_a_valid_step():
+    steps = [{"name", "shell", "run", "env", "id", "if"}]
+    assert checker.offending_keys(steps) == []
+
+
+# --------------------------------------------------------------------------
+# Discrimination — against a real (synthetic) tree on disk, reproducing
+# the exact incident
+# --------------------------------------------------------------------------
+
+
+def _write_action(tmp_path, *, rel_dir: str, body: str) -> None:
+    action_dir = tmp_path / ".github" / "actions" / rel_dir
+    action_dir.mkdir(parents=True)
+    (action_dir / "action.yml").write_text(body, encoding="utf-8")
+
+
+_VALID_ACTION = (
+    "runs:\n"
+    "  using: composite\n"
+    "  steps:\n"
+    "    - name: Install\n"
+    "      shell: bash\n"
+    "      run: |\n"
+    "        echo hi\n"
+)
+
+_BROKEN_ACTION = (
+    "runs:\n"
+    "  using: composite\n"
+    "  steps:\n"
+    "    - name: Install\n"
+    "      shell: bash\n"
+    "      timeout-minutes: 3\n"
+    "      run: |\n"
+    "        echo hi\n"
+)
+
+
+def test_audit_rejects_the_exact_incident_shape(tmp_path):
+    _write_action(tmp_path, rel_dir="broken-action", body=_BROKEN_ACTION)
+    reached, problems = checker.audit_composite_actions(tmp_path)
+    assert reached == 1
+    assert problems, "timeout-minutes on a composite-action step must be flagged"
+    assert "timeout-minutes" in problems[0]
+
+
+def test_audit_accepts_a_valid_action(tmp_path):
+    _write_action(tmp_path, rel_dir="ok-action", body=_VALID_ACTION)
+    reached, problems = checker.audit_composite_actions(tmp_path)
+    assert reached == 1
+    assert problems == []
+
+
+def test_audit_fails_on_zero_action_files(tmp_path):
+    """A moved/renamed .github/actions/ tree must not read as a clean scan of nothing."""
+    (tmp_path / ".github").mkdir()
+    reached, problems = checker.audit_composite_actions(tmp_path)
+    assert reached == 0
+    assert problems and "matched zero files" in problems[0]
+
+
+def test_audit_fails_when_a_file_parses_to_zero_steps(tmp_path):
+    _write_action(tmp_path, rel_dir="empty-action", body="runs:\n  using: composite\n  steps: []\n")
+    reached, problems = checker.audit_composite_actions(tmp_path)
+    assert reached == 0
+    assert problems and "zero steps" in problems[0]
+
+
+# --------------------------------------------------------------------------
+# The live tree, and the #14550 regression this file fixes
+# --------------------------------------------------------------------------
+
+
+def test_audit_is_clean_on_the_real_tree():
+    reached, problems = checker.audit_composite_actions()
+    assert reached >= 10, f"only {reached} steps reached across every composite action — did one move?"
+    assert problems == [], problems
+
+
+def test_setup_python_suite_has_no_timeout_minutes_on_any_step():
+    """Pin the fix at the source file's PARSED step keys, not a raw substring.
+
+    The file's own explanatory comment about this incident legitimately
+    contains the text "timeout-minutes: 60" in prose (describing ci.yml's
+    JOB-level timeout, not a step key) -- a raw `"timeout-minutes" not in
+    action` check would fail on that comment forever. Parse real steps.
+    """
+    action = (REPO_ROOT / ".github" / "actions" / "setup-python-suite" / "action.yml").read_text(encoding="utf-8")
+    steps = checker.step_key_sets(action)
+    assert steps, "parsed zero steps — did the file's structure change?"
+    for keys in steps:
+        assert "timeout-minutes" not in keys, (
+            "a step in setup-python-suite/action.yml has timeout-minutes again — that key is not valid on a "
+            "composite action's own steps and breaks GitHub's template validation for the whole file (#14550)"
+        )
+
+
+# --------------------------------------------------------------------------
+# The audit entrypoint, and the check that actually runs it
+# --------------------------------------------------------------------------
+
+
+def test_code_quality_runs_the_audit():
+    workflow = (REPO_ROOT / ".github" / "workflows" / "code-quality.yml").read_text(encoding="utf-8")
+    assert "check_composite_action_step_keys.py --audit" in workflow, (
+        "code-quality.yml no longer runs the composite-action step-key audit — the guard would stop "
+        "blocking merges while these tests kept passing (#14550)"
+    )
+    assert _CHECKER.is_file(), f"{_CHECKER} is gone but the workflow still calls it"
+
+
+def test_the_checker_needs_no_third_party_import():
+    """It must run in a job that installs linters, not the application's dependencies."""
+    source = _CHECKER.read_text(encoding="utf-8")
+    third_party = [
+        line
+        for line in source.splitlines()
+        if line.startswith(("import ", "from "))
+        and not line.startswith("from __future__")
+        and line.split()[1].split(".")[0] not in {"argparse", "logging", "pathlib", "re", "sys"}
+    ]
+    assert third_party == [], f"the checker imports non-stdlib modules: {third_party}"

--- a/repo_tests/requirements_ci_drift_baseline.txt
+++ b/repo_tests/requirements_ci_drift_baseline.txt
@@ -11,14 +11,40 @@
 #      longer declares, ALSO fails — a stale entry exempts nothing while
 #      looking authoritative.
 #
-# THIS LIST ONLY SHRINKS. Seeded from the actual drift measured 2026-08-18
-# (55 packages missing from CI; pytesseract was fixed in the same PR that
-# added this file rather than allowlisted, since it is the exact incident
-# #14551 documents — see requirements-ci/automation.txt).
+# THIS LIST ONLY SHRINKS. Seeded from the actual drift measured 2026-08-18,
+# then re-audited against a code-reviewer finding the same day: 9 entries in
+# the first version of this file claimed "no CI-scoped test exercising the
+# real library" while a real skipif/importorskip gate existed and was
+# silently skipping. Per the same policy that mirrors pytesseract instead of
+# allowlisting it (the headline incident #14551 documents), every one of
+# those 9 was mirrored into the matching requirements-ci/*.txt file instead
+# of listed here — see the per-package comments at each mirror site for the
+# exact gated test(s). Auditing also found bcrypt and pydantic-settings,
+# unconditionally imported by autobot_shared/auth/jwt_core.py and
+# autobot_shared/ssot_config.py respectively (both declared in
+# autobot_shared/pyproject.toml but never installed from there by CI, the
+# same shape as the pre-existing PyJWT[crypto] comment in security.txt) —
+# also mirrored rather than baselined, since collection of nearly the whole
+# suite depends on them.
 #
 # Do NOT add an entry here to silence a new failure without checking first
-# whether the omission is a genuine bug (mirror it into requirements-ci/)
-# or a deliberate one (document why here).
+# whether the omission is a genuine bug (mirror it into requirements-ci/) or
+# a deliberate one (document why here). In particular: grep the package's
+# real *import* name (not its pip distribution name) for
+# `pytest.importorskip`, `importlib.util.find_spec(...) is None`, and an
+# unguarded top-level `import`/`from` inside `autobot_shared/` before
+# assuming "no test needs it".
+
+# --- Tracked elsewhere, not a silent omission -----------------------------
+# pytesseract is the exact #13885 incident this guard exists to catch, and
+# belongs in requirements-ci/*.txt, not here — but it collides with #14510
+# (open as of this writing), which adds it to requirements-ci/document.txt
+# with its own rationale (the OCR rasterize-then-fallback feature, #13896).
+# Landing pytesseract in TWO CI files from two different PRs is worse than
+# a temporary baseline entry: whichever of #14550/#14551 or #14510 merges
+# second will find this line stale (pytesseract now present in CI) and the
+# audit will force its removal — self-correcting, not a place to leave it.
+pytesseract
 
 # --- SLM-backend SSO / auth / ops libraries -------------------------------
 # Declared in autobot-slm-backend/requirements.txt. The python-suite tests
@@ -26,20 +52,24 @@
 # exercising the real library (see e.g. services/deployment.py's shutil.which
 # gates and the shutil.which patches throughout autobot-slm-backend/tests/),
 # so the CI-scoped suite does not need the real packages installed.
+# (ldap3 and bcrypt were REMOVED from this group — see requirements-ci/
+# security.txt: both have a real gate and are mirrored, not baselined.)
 ansible-runner
 authlib
-bcrypt
-ldap3
 paramiko
 pyotp
 pysaml2
-pydantic-settings
 typing-extensions
 
 # --- OpenTelemetry tracing stack ------------------------------------------
-# Issue #57/#697: distributed tracing across the 5-VM deployment. The
-# instrumentation packages are optional at import time and no CI-scoped test
-# asserts against real span export.
+# Issue #57/#697: distributed tracing across the 5-VM deployment. Several
+# production files DO import opentelemetry unconditionally at module scope
+# (middleware/tracing_middleware.py, llm_shared/observability/otel_observer.py,
+# pki/distributor.py, utils/traced_http_client.py, services/tracing_service.py)
+# — but none of them is imported by anything else in the tree (verified by
+# grep), so no currently-collected test reaches that import. autobot_shared/
+# itself imports no opentelemetry module unconditionally (verified directly,
+# unlike bcrypt/pydantic-settings above).
 opentelemetry-api
 opentelemetry-sdk
 opentelemetry-exporter-otlp
@@ -61,6 +91,17 @@ protobuf
 torch
 torchvision
 
+# --- tree-sitter core, resolved transitively ------------------------------
+# tree-sitter-python (mirrored into requirements-ci/document.txt, #14551)
+# depends on the base `tree-sitter` package itself, the same transitive
+# pattern as torch above — declaring it again here would only risk a
+# conflicting resolution.
+tree-sitter
+# tree-sitter-javascript has no CI-scoped test gating on it directly (only
+# services/knowledge/code_indexer.py imports it, lazily, inside a method) —
+# genuinely no coverage today, unlike its sibling tree-sitter-python.
+tree-sitter-javascript
+
 # --- LangChain / LlamaIndex / MCP extras ----------------------------------
 # The pinned core packages (langchain, langchain-core, llama-index-core, ...)
 # are in requirements-ci/langchain.txt and requirements-ci/llama-index.txt;
@@ -75,27 +116,19 @@ mcp
 # --- Document / knowledge-base optional format libraries ------------------
 # requirements.txt marks several of these "Optional (install separately for
 # full media support)" or lazy-imported; the rest are format converters with
-# no CI-scoped test exercising the real library.
+# no CI-scoped test exercising the real library (verified: no unguarded
+# top-level import in autobot-backend/ or autobot_shared/).
 openpyxl
 python-pptx
 odfpy
-faiss-cpu
-datasketch
 networkx
-tree-sitter
-tree-sitter-python
-tree-sitter-javascript
-scikit-learn
-weasyprint
 bleach
 xxhash
 
 # --- Content Reach optional source backends (#10932) -----------------------
-# Explicitly "optional, lazy" in autobot-backend/requirements.txt; the
-# backend starts and the feature degrades without them.
-ddgs
-trafilatura
-yt-dlp
+# (ddgs, trafilatura, yt-dlp were REMOVED from this group — see
+# requirements-ci/document.txt and requirements-ci/networking.txt: all three
+# have a real importorskip/find_spec gate and are mirrored, not baselined.)
 
 # --- Misc production deps with no CI-scoped real-library test -------------
 email-validator
@@ -104,8 +137,16 @@ pywebpush
 tenacity
 anthropic
 boto3
-opencv-python-headless
 asyncpg
 praw
 vulture
 vanna
+
+# --- Satisfied under a different package name, not a real omission -------
+# autobot-backend/requirements.txt declares opencv-python-headless; CI
+# declares plain opencv-python (requirements-ci/automation.txt) instead —
+# both packages install the same `cv2` import module. computer_vision/
+# template_matching_test.py does `cv2 = pytest.importorskip("cv2")` and
+# genuinely runs today against opencv-python's cv2. Listed here because the
+# pip DISTRIBUTION name differs, not because coverage is missing.
+opencv-python-headless

--- a/repo_tests/requirements_ci_drift_baseline.txt
+++ b/repo_tests/requirements_ci_drift_baseline.txt
@@ -27,13 +27,24 @@
 # also mirrored rather than baselined, since collection of nearly the whole
 # suite depends on them.
 #
+# A THIRD round (real CI run, not local audit) found the `tree-sitter`
+# entry below was ALSO a false rationale: mirroring `tree-sitter-python`
+# alone was assumed to pull in the base `tree-sitter` package transitively —
+# it does not, and code_indexer.py's `from tree_sitter import Language,
+# Parser` failed on the real runner with 4 shards red
+# ("No module named 'tree_sitter'") until `tree-sitter` was mirrored
+# explicitly too. Lesson: an assumption about transitive resolution is not
+# verified until CI actually runs — this file no longer asserts one without
+# citing where it was checked.
+#
 # Do NOT add an entry here to silence a new failure without checking first
 # whether the omission is a genuine bug (mirror it into requirements-ci/) or
 # a deliberate one (document why here). In particular: grep the package's
 # real *import* name (not its pip distribution name) for
 # `pytest.importorskip`, `importlib.util.find_spec(...) is None`, and an
 # unguarded top-level `import`/`from` inside `autobot_shared/` before
-# assuming "no test needs it".
+# assuming "no test needs it" — and do not assume transitive resolution
+# without verifying the dependency actually declares it.
 
 # --- Tracked elsewhere, not a silent omission -----------------------------
 # pytesseract is the exact #13885 incident this guard exists to catch, and
@@ -82,24 +93,24 @@ opentelemetry-instrumentation-aiohttp-client
 opentelemetry-propagator-b3
 protobuf
 
-# --- Torch / heavy ML, resolved transitively ------------------------------
+# --- Torch, resolved transitively (unlike tree-sitter above) --------------
 # #13316: requirements-ci.txt deliberately never names torch — it arrives
 # transitively via sentence-transformers (already declared in
 # requirements-ci/ai-ml.txt), resolved against the PyTorch CPU wheel index so
-# the ~3GB CUDA closure is never pulled. Declaring it again here would only
-# risk a second, conflicting resolution.
+# the ~3GB CUDA closure is never pulled. This one IS verified: the CI run
+# that caught the tree-sitter gap above installed torch fine via this path
+# (see the "Installing CI-safe requirements" step's ~3GB-vs-10-package-closure
+# comment in setup-python-suite/action.yml, and the completion_trainer_test.py
+# 17 tests that import torch directly and pass in CI).
 torch
 torchvision
 
-# --- tree-sitter core, resolved transitively ------------------------------
-# tree-sitter-python (mirrored into requirements-ci/document.txt, #14551)
-# depends on the base `tree-sitter` package itself, the same transitive
-# pattern as torch above — declaring it again here would only risk a
-# conflicting resolution.
-tree-sitter
 # tree-sitter-javascript has no CI-scoped test gating on it directly (only
 # services/knowledge/code_indexer.py imports it, lazily, inside a method) —
-# genuinely no coverage today, unlike its sibling tree-sitter-python.
+# genuinely no coverage today, unlike tree-sitter-python (mirrored into
+# requirements-ci/document.txt alongside the base tree-sitter package itself,
+# #14551 — see that file's comment for why both, not just the language
+# binding, had to be explicit).
 tree-sitter-javascript
 
 # --- LangChain / LlamaIndex / MCP extras ----------------------------------

--- a/repo_tests/requirements_ci_drift_baseline.txt
+++ b/repo_tests/requirements_ci_drift_baseline.txt
@@ -1,0 +1,111 @@
+# requirements-ci drift allowlist (#14551)
+#
+# One package name per line. Each entry is a package declared in
+# autobot-backend/requirements.txt or autobot-slm-backend/requirements.txt
+# that requirements-ci.txt / requirements-ci/*.txt deliberately does not
+# mirror. tools/lint/check_requirements_ci_drift.py enforces two things:
+#
+#   1. any production package missing from CI that is NOT listed here fails
+#      the check — a new, undeclared omission;
+#   2. any entry listed here that CI now installs, or that production no
+#      longer declares, ALSO fails — a stale entry exempts nothing while
+#      looking authoritative.
+#
+# THIS LIST ONLY SHRINKS. Seeded from the actual drift measured 2026-08-18
+# (55 packages missing from CI; pytesseract was fixed in the same PR that
+# added this file rather than allowlisted, since it is the exact incident
+# #14551 documents — see requirements-ci/automation.txt).
+#
+# Do NOT add an entry here to silence a new failure without checking first
+# whether the omission is a genuine bug (mirror it into requirements-ci/)
+# or a deliberate one (document why here).
+
+# --- SLM-backend SSO / auth / ops libraries -------------------------------
+# Declared in autobot-slm-backend/requirements.txt. The python-suite tests
+# covering these modules mock the network/subprocess boundary rather than
+# exercising the real library (see e.g. services/deployment.py's shutil.which
+# gates and the shutil.which patches throughout autobot-slm-backend/tests/),
+# so the CI-scoped suite does not need the real packages installed.
+ansible-runner
+authlib
+bcrypt
+ldap3
+paramiko
+pyotp
+pysaml2
+pydantic-settings
+typing-extensions
+
+# --- OpenTelemetry tracing stack ------------------------------------------
+# Issue #57/#697: distributed tracing across the 5-VM deployment. The
+# instrumentation packages are optional at import time and no CI-scoped test
+# asserts against real span export.
+opentelemetry-api
+opentelemetry-sdk
+opentelemetry-exporter-otlp
+opentelemetry-exporter-otlp-proto-grpc
+opentelemetry-exporter-otlp-proto-http
+opentelemetry-proto
+opentelemetry-instrumentation-fastapi
+opentelemetry-instrumentation-redis
+opentelemetry-instrumentation-aiohttp-client
+opentelemetry-propagator-b3
+protobuf
+
+# --- Torch / heavy ML, resolved transitively ------------------------------
+# #13316: requirements-ci.txt deliberately never names torch — it arrives
+# transitively via sentence-transformers (already declared in
+# requirements-ci/ai-ml.txt), resolved against the PyTorch CPU wheel index so
+# the ~3GB CUDA closure is never pulled. Declaring it again here would only
+# risk a second, conflicting resolution.
+torch
+torchvision
+
+# --- LangChain / LlamaIndex / MCP extras ----------------------------------
+# The pinned core packages (langchain, langchain-core, llama-index-core, ...)
+# are in requirements-ci/langchain.txt and requirements-ci/llama-index.txt;
+# these are transitive extras of that same ecosystem with no CI-scoped test
+# importing them directly.
+langchain-ollama
+langgraph
+langgraph-checkpoint-redis
+llama-index
+mcp
+
+# --- Document / knowledge-base optional format libraries ------------------
+# requirements.txt marks several of these "Optional (install separately for
+# full media support)" or lazy-imported; the rest are format converters with
+# no CI-scoped test exercising the real library.
+openpyxl
+python-pptx
+odfpy
+faiss-cpu
+datasketch
+networkx
+tree-sitter
+tree-sitter-python
+tree-sitter-javascript
+scikit-learn
+weasyprint
+bleach
+xxhash
+
+# --- Content Reach optional source backends (#10932) -----------------------
+# Explicitly "optional, lazy" in autobot-backend/requirements.txt; the
+# backend starts and the feature degrades without them.
+ddgs
+trafilatura
+yt-dlp
+
+# --- Misc production deps with no CI-scoped real-library test -------------
+email-validator
+defusedxml
+pywebpush
+tenacity
+anthropic
+boto3
+opencv-python-headless
+asyncpg
+praw
+vulture
+vanna

--- a/repo_tests/requirements_ci_drift_test.py
+++ b/repo_tests/requirements_ci_drift_test.py
@@ -1,0 +1,173 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""#14551 — production and CI Python dependency sets are hand-mirrored; catch silent drift.
+
+Exercises the exact functions ``code-quality`` calls
+(``tools/lint/check_requirements_ci_drift.py --audit``) rather than
+paraphrasing the rule, so a test agreeing with a second copy of the decision
+proves nothing about the copy that actually blocks a merge.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+_CHECKER = REPO_ROOT / "tools" / "lint" / "check_requirements_ci_drift.py"
+
+
+def _load_checker():
+    spec = importlib.util.spec_from_file_location("check_requirements_ci_drift", _CHECKER)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+checker = _load_checker()
+
+
+# --------------------------------------------------------------------------
+# The invariant, against synthetic input
+# --------------------------------------------------------------------------
+
+
+def test_compute_drift_flags_a_package_missing_from_ci_and_not_allowlisted():
+    production = {"foo": "foo>=1.0", "bar": "bar>=2.0"}
+    ci = {"bar": "bar==2.0"}
+    new_drift, stale = checker.compute_drift(production, ci, allowlist=set())
+    assert new_drift == ["foo"]
+    assert stale == []
+
+
+def test_compute_drift_accepts_an_allowlisted_omission():
+    production = {"foo": "foo>=1.0"}
+    ci: dict[str, str] = {}
+    new_drift, stale = checker.compute_drift(production, ci, allowlist={"foo"})
+    assert new_drift == []
+    assert stale == []
+
+
+def test_compute_drift_rejects_a_stale_allowlist_entry_now_fixed():
+    """An entry CI now installs must be removed, not left exempting nothing."""
+    production = {"foo": "foo>=1.0"}
+    ci = {"foo": "foo==1.0"}
+    new_drift, stale = checker.compute_drift(production, ci, allowlist={"foo"})
+    assert new_drift == []
+    assert stale == ["foo"]
+
+
+def test_compute_drift_rejects_a_stale_allowlist_entry_now_removed():
+    """An entry for a package production no longer declares is also stale."""
+    production: dict[str, str] = {}
+    ci: dict[str, str] = {}
+    new_drift, stale = checker.compute_drift(production, ci, allowlist={"ghost-package"})
+    assert new_drift == []
+    assert stale == ["ghost-package"]
+
+
+def test_normalize_treats_underscores_dots_and_dashes_as_equivalent():
+    assert checker._normalize("python_dotenv") == checker._normalize("python-dotenv")
+    assert checker._normalize("PyYAML") == "pyyaml"
+
+
+# --------------------------------------------------------------------------
+# Discrimination — against a real (synthetic) tree on disk
+# --------------------------------------------------------------------------
+
+
+def _write_tree(tmp_path, *, prod_pkgs: list[str], ci_pkgs: list[str], allowlist: list[str]):
+    backend = tmp_path / "autobot-backend"
+    backend.mkdir()
+    (backend / "requirements.txt").write_text("\n".join(prod_pkgs) + "\n", encoding="utf-8")
+    slm = tmp_path / "autobot-slm-backend"
+    slm.mkdir()
+    (slm / "requirements.txt").write_text("", encoding="utf-8")
+    (tmp_path / "requirements-ci.txt").write_text("\n".join(ci_pkgs) + "\n", encoding="utf-8")
+    repo_tests = tmp_path / "repo_tests"
+    repo_tests.mkdir()
+    (repo_tests / "requirements_ci_drift_baseline.txt").write_text("\n".join(allowlist) + "\n", encoding="utf-8")
+
+
+def test_audit_fails_on_an_undeclared_omission(tmp_path):
+    # ci_pkgs carries an unrelated entry so the CI parse itself is non-empty —
+    # an empty CI file is a *different* failure mode, covered separately below.
+    _write_tree(tmp_path, prod_pkgs=["widget>=1.0"], ci_pkgs=["gadget==1.0"], allowlist=[])
+    reached, problems = checker.audit_drift(tmp_path)
+    assert reached == 1
+    assert problems, "an undeclared production-only package must fail the audit"
+    assert "widget" in problems[0]
+
+
+def test_audit_passes_when_the_omission_is_allowlisted(tmp_path):
+    _write_tree(tmp_path, prod_pkgs=["widget>=1.0"], ci_pkgs=["gadget==1.0"], allowlist=["widget"])
+    reached, problems = checker.audit_drift(tmp_path)
+    assert reached == 1
+    assert problems == []
+
+
+def test_audit_fails_on_zero_production_packages(tmp_path):
+    """A moved/renamed requirements.txt must not read as a clean scan of nothing."""
+    (tmp_path / "autobot-backend").mkdir()
+    (tmp_path / "autobot-backend" / "requirements.txt").write_text("", encoding="utf-8")
+    (tmp_path / "autobot-slm-backend").mkdir()
+    (tmp_path / "autobot-slm-backend" / "requirements.txt").write_text("", encoding="utf-8")
+    (tmp_path / "requirements-ci.txt").write_text("widget==1.0\n", encoding="utf-8")
+    reached, problems = checker.audit_drift(tmp_path)
+    assert reached == 0
+    assert problems and "zero packages" in problems[0]
+
+
+def test_audit_is_clean_on_the_real_tree():
+    """The live repo's guard must pass against itself — proves the seed was accurate."""
+    reached, problems = checker.audit_drift()
+    assert reached > 50, f"only {reached} production packages reached — the parse silently collapsed"
+    assert problems == [], problems
+
+
+# --------------------------------------------------------------------------
+# The #13885/#14551 regression this PR fixes
+# --------------------------------------------------------------------------
+
+
+def test_pytesseract_is_mirrored_into_ci_not_allowlisted():
+    """The headline incident this issue documents must not recur.
+
+    pytesseract sat declared in production and undeclared in CI for months
+    (#13885) while every real OCR test skipped. It must now be a genuine CI
+    package, not an allowlist entry papering over the same gap again.
+    """
+    ci = checker.ci_requirement_names()
+    allowlist = checker.load_allowlist()
+    assert "pytesseract" in ci, "pytesseract must be declared in requirements-ci/*.txt (#14551)"
+    assert "pytesseract" not in allowlist, "pytesseract must not be allowlisted — it is the bug this guard exists for"
+
+
+# --------------------------------------------------------------------------
+# The audit entrypoint, and the check that actually runs it
+# --------------------------------------------------------------------------
+
+
+def test_code_quality_runs_the_audit():
+    """A guard nothing invokes is documentation, not enforcement."""
+    workflow = (REPO_ROOT / ".github" / "workflows" / "code-quality.yml").read_text(encoding="utf-8")
+    assert "check_requirements_ci_drift.py --audit" in workflow, (
+        "code-quality.yml no longer runs the requirements-ci drift audit — the guard "
+        "would stop blocking merges while these tests kept passing (#14551)"
+    )
+    assert _CHECKER.is_file(), f"{_CHECKER} is gone but the workflow still calls it"
+
+
+def test_the_checker_needs_no_third_party_import():
+    """It must run in a job that installs linters, not the application's dependencies."""
+    source = _CHECKER.read_text(encoding="utf-8")
+    third_party = [
+        line
+        for line in source.splitlines()
+        if line.startswith(("import ", "from "))
+        and not line.startswith("from __future__")
+        and line.split()[1].split(".")[0] not in {"argparse", "logging", "pathlib", "re", "sys"}
+    ]
+    assert third_party == [], f"the checker imports non-stdlib modules: {third_party}"

--- a/repo_tests/requirements_ci_drift_test.py
+++ b/repo_tests/requirements_ci_drift_test.py
@@ -120,6 +120,20 @@ def test_audit_fails_on_zero_production_packages(tmp_path):
     assert problems and "zero packages" in problems[0]
 
 
+def test_audit_fails_on_zero_ci_packages(tmp_path):
+    """The sibling of test_audit_fails_on_zero_production_packages — same guard,
+    same anti-empty-result requirement, other side of the comparison. audit_drift()
+    has a symmetric `if not ci:` branch that was previously exercised only ad hoc."""
+    (tmp_path / "autobot-backend").mkdir()
+    (tmp_path / "autobot-backend" / "requirements.txt").write_text("widget>=1.0\n", encoding="utf-8")
+    (tmp_path / "autobot-slm-backend").mkdir()
+    (tmp_path / "autobot-slm-backend" / "requirements.txt").write_text("", encoding="utf-8")
+    (tmp_path / "requirements-ci.txt").write_text("", encoding="utf-8")
+    reached, problems = checker.audit_drift(tmp_path)
+    assert reached == 1
+    assert problems and "zero packages" in problems[0]
+
+
 def test_audit_is_clean_on_the_real_tree():
     """The live repo's guard must pass against itself — proves the seed was accurate."""
     reached, problems = checker.audit_drift()
@@ -132,17 +146,61 @@ def test_audit_is_clean_on_the_real_tree():
 # --------------------------------------------------------------------------
 
 
-def test_pytesseract_is_mirrored_into_ci_not_allowlisted():
-    """The headline incident this issue documents must not recur.
+def test_pytesseract_is_tracked_pending_the_colliding_pr():
+    """The headline incident this issue documents, without racing #14510.
 
     pytesseract sat declared in production and undeclared in CI for months
-    (#13885) while every real OCR test skipped. It must now be a genuine CI
-    package, not an allowlist entry papering over the same gap again.
+    (#13885) while every real OCR test skipped — normally this guard's policy
+    is "mirror it, don't allowlist it" (see the fixes for scikit-learn, ldap3,
+    etc. below). pytesseract is the one deliberate exception: #14510 (open as
+    of this writing) already adds it to requirements-ci/document.txt for its
+    own OCR-fallback feature. Landing it from BOTH PRs would collide, so it is
+    allowlisted here instead, with a comment pointing at #14510 — and the
+    audit will force this line's removal the moment either PR lands it for
+    real, which is the self-correcting property that makes the exception safe.
+    """
+    allowlist = checker.load_allowlist()
+    assert "pytesseract" in allowlist, "pytesseract must stay tracked (allowlisted) until #14510 lands it for real"
+
+
+def test_the_9_corrected_baseline_entries_are_now_mirrored_not_allowlisted():
+    """Re-proves the code-reviewer finding this baseline was corrected against.
+
+    9 packages were allowlisted with a false "no CI-scoped test" rationale
+    while a real importorskip/find_spec gate existed and silently skipped.
+    Each must now be a genuine CI package, not still papering over the gap.
     """
     ci = checker.ci_requirement_names()
     allowlist = checker.load_allowlist()
-    assert "pytesseract" in ci, "pytesseract must be declared in requirements-ci/*.txt (#14551)"
-    assert "pytesseract" not in allowlist, "pytesseract must not be allowlisted — it is the bug this guard exists for"
+    corrected = {
+        "scikit-learn",
+        "ldap3",
+        "weasyprint",
+        "faiss-cpu",
+        "datasketch",
+        "tree-sitter-python",
+        "trafilatura",
+        "yt-dlp",
+        "ddgs",
+    }
+    for name in corrected:
+        assert name in ci, f"{name} must be declared in requirements-ci/*.txt (#14551)"
+        assert name not in allowlist, f"{name} must not be allowlisted — it is a corrected false rationale"
+
+
+def test_bcrypt_and_pydantic_settings_are_mirrored_not_allowlisted():
+    """autobot_shared/pyproject.toml is NOT installed by CI (#13411's shape).
+
+    Both are unconditionally imported by autobot_shared modules reached by
+    nearly the whole suite (auth/jwt_core.py, ssot_config.py) — the same
+    class of bug as the pre-existing PyJWT[crypto] comment in security.txt,
+    just not previously caught for these two.
+    """
+    ci = checker.ci_requirement_names()
+    allowlist = checker.load_allowlist()
+    for name in ("bcrypt", "pydantic-settings"):
+        assert name in ci, f"{name} must be declared in requirements-ci/*.txt (#14551)"
+        assert name not in allowlist, f"{name} must not be allowlisted — collection-critical, not a soft omission"
 
 
 # --------------------------------------------------------------------------

--- a/repo_tests/requirements_ci_drift_test.py
+++ b/repo_tests/requirements_ci_drift_test.py
@@ -203,6 +203,26 @@ def test_bcrypt_and_pydantic_settings_are_mirrored_not_allowlisted():
         assert name not in allowlist, f"{name} must not be allowlisted — collection-critical, not a soft omission"
 
 
+def test_tree_sitter_core_is_mirrored_alongside_tree_sitter_python():
+    """A real CI run (not a local audit) caught the third false rationale.
+
+    tree-sitter-python was mirrored assuming it pulled in the base
+    `tree-sitter` package transitively -- it does not, and 4 shards went red
+    on the real runner with "No module named 'tree_sitter'" before this was
+    fixed. Pin both packages present and neither allowlisted, so a future
+    edit cannot quietly re-introduce the same unverified-transitive-resolution
+    mistake for this specific pair.
+    """
+    ci = checker.ci_requirement_names()
+    allowlist = checker.load_allowlist()
+    for name in ("tree-sitter", "tree-sitter-python"):
+        assert name in ci, f"{name} must be declared in requirements-ci/*.txt (#14551)"
+        assert name not in allowlist, f"{name} must not be allowlisted — verified missing on the real CI runner"
+    # tree-sitter-javascript is the deliberate exception: no CI-scoped test
+    # gates on it directly, so it stays allowlisted.
+    assert "tree-sitter-javascript" in allowlist
+
+
 # --------------------------------------------------------------------------
 # The audit entrypoint, and the check that actually runs it
 # --------------------------------------------------------------------------

--- a/requirements-ci/ai-ml.txt
+++ b/requirements-ci/ai-ml.txt
@@ -14,3 +14,17 @@ pillow==12.3.0
 # sentence-transformers. No nvidia-* wheels — the CPU-only index in
 # .github/actions/setup-python-suite keeps resolving torch, so the ~3GB saving stands.
 torchmetrics>=1.9.0,<2.0.0
+# #14551: production dep (autobot-backend/requirements.txt, RAPTOR clustering).
+# pytest.importorskip("sklearn") gates entity_resolution_test.py,
+# summarizer_raptor_test.py, security/threat_detection_refactor_test.py and
+# security/enterprise/threat_detection/test_learner.py — 4 files silently
+# skipping the real clustering/classification path without this.
+scikit-learn>=1.9.0
+# #14551: production dep (autobot-backend/requirements.txt, vector similarity
+# search). utils/faiss_ivfpq_builder_test.py gates its whole IVFPQ test class on
+# pytest.importorskip("faiss") — silently skipping without this.
+faiss-cpu>=1.15.0
+# #14551: production dep (autobot-backend/requirements.txt, MinHash LSH
+# duplicate detection). Its own test module gates on
+# pytest.importorskip("datasketch") — silently skipping without this.
+datasketch>=2.0.0

--- a/requirements-ci/automation.txt
+++ b/requirements-ci/automation.txt
@@ -4,11 +4,3 @@ mouseinfo==0.1.3
 opencv-python==5.0.0.93
 pygetwindow==0.0.9
 playwright==1.62.0
-# OCR binding (#13885/#14551). Mirrors autobot-backend/requirements.txt's
-# pytesseract pin — declared there for months while absent here, so every
-# real (non-mocked) OCR test would have skipped or import-errored silently.
-# The tesseract-ocr system BINARY it wraps is a separate concern tracked by
-# #14550: no CI-scoped test currently invokes the real binary (every OCR
-# call site in the test suite stubs pytesseract via sys.modules), so this
-# only needs the Python binding, not the apt package.
-pytesseract>=0.3.13

--- a/requirements-ci/automation.txt
+++ b/requirements-ci/automation.txt
@@ -4,3 +4,11 @@ mouseinfo==0.1.3
 opencv-python==5.0.0.93
 pygetwindow==0.0.9
 playwright==1.62.0
+# OCR binding (#13885/#14551). Mirrors autobot-backend/requirements.txt's
+# pytesseract pin — declared there for months while absent here, so every
+# real (non-mocked) OCR test would have skipped or import-errored silently.
+# The tesseract-ocr system BINARY it wraps is a separate concern tracked by
+# #14550: no CI-scoped test currently invokes the real binary (every OCR
+# call site in the test suite stubs pytesseract via sys.modules), so this
+# only needs the Python binding, not the apt package.
+pytesseract>=0.3.13

--- a/requirements-ci/document.txt
+++ b/requirements-ci/document.txt
@@ -6,3 +6,20 @@ markdown==3.10.3
 nltk==3.10.2
 beautifulsoup4==4.15.0
 markdownify==1.2.3
+# #14551: production dep (autobot-backend/requirements.txt, Live Canvas
+# HTML->PDF export). transcriber/tests/test_export_api.py gates on
+# pytest.importorskip("weasyprint") — silently skipping without this.
+weasyprint>=69.0
+# #14551: production dep (autobot-backend/requirements.txt, #10932 content-reach
+# readable-article extraction, lazy). tests/content_reach/sources/test_web_page.py
+# gates on pytest.importorskip("trafilatura") — silently skipping without this.
+trafilatura>=2.2.0
+# #14551: production dep (autobot-backend/requirements.txt, code-graph AST
+# parsing). services/knowledge/code_indexer_test.py, impact_analysis_test.py,
+# code_indexer_extensions_test.py, code_indexer_shape_test.py and
+# code_intelligence/fingerprinting/shared_identity_test.py all gate on
+# `tree_sitter_python` being importable — 5 files silently skipping code
+# indexing coverage without this. Pulls in the base `tree-sitter` package as
+# its own transitive dependency (tree-sitter itself stays out of this file
+# deliberately, the same shape as torch/sentence-transformers in ai-ml.txt).
+tree-sitter-python>=0.25.0

--- a/requirements-ci/document.txt
+++ b/requirements-ci/document.txt
@@ -19,7 +19,12 @@ trafilatura>=2.2.0
 # code_indexer_extensions_test.py, code_indexer_shape_test.py and
 # code_intelligence/fingerprinting/shared_identity_test.py all gate on
 # `tree_sitter_python` being importable — 5 files silently skipping code
-# indexing coverage without this. Pulls in the base `tree-sitter` package as
-# its own transitive dependency (tree-sitter itself stays out of this file
-# deliberately, the same shape as torch/sentence-transformers in ai-ml.txt).
+# indexing coverage without this.
 tree-sitter-python>=0.25.0
+# #14551 CI incident: mirroring tree-sitter-python ALONE was not enough —
+# it does NOT declare `tree-sitter` as a runtime dependency (verified by the
+# real CI failure it caused: "No module named 'tree_sitter'" from
+# code_indexer.py's `from tree_sitter import Language, Parser`, once
+# tree-sitter-python itself imported fine). The two ship as siblings, not a
+# dependency pair; both must be declared explicitly here.
+tree-sitter>=0.26.0

--- a/requirements-ci/framework.txt
+++ b/requirements-ci/framework.txt
@@ -6,3 +6,11 @@ python-multipart==0.0.32
 uvicorn==0.52.1
 pydantic[email]==2.13.4
 websockets==15.0.1
+# #14551: same shape as PyJWT[crypto]/bcrypt in requirements-ci/security.txt —
+# autobot_shared/ssot_config.py does an unconditional `from pydantic_settings
+# import BaseSettings, SettingsConfigDict`, and it is declared in
+# autobot_shared/pyproject.toml but NOT installed from there by CI. ssot_config
+# is the platform's SSOT config module (`from autobot_shared.ssot_config import
+# config`); without this, importing it — and therefore nearly anything that
+# reads config — fails collection outright.
+pydantic-settings>=2.15.0

--- a/requirements-ci/networking.txt
+++ b/requirements-ci/networking.txt
@@ -4,3 +4,11 @@ aiohttp==3.14.3
 httpx==0.28.1
 aiofiles==25.1.0
 asyncssh>=2.24.0,<3.0.0   # production dep (requirements.txt); pki/distributor.py + pki/configurator.py import it unconditionally, so pki/test_renewal.py fails collection without it (#13086)
+# #14551: production dep (autobot-backend/requirements.txt, #10932 content-reach
+# keyless web search, lazy). tests/content_reach/sources/test_web_search.py
+# gates on pytest.importorskip/find_spec("ddgs") — silently skipping without this.
+ddgs>=9.14.4
+# #14551: production dep (autobot-backend/requirements.txt, #10932 content-reach
+# YouTube caption extraction, lazy). tests/content_reach/sources/test_youtube.py
+# gates on pytest.importorskip("yt_dlp") — silently skipping without this.
+yt-dlp>=2026.7.4

--- a/requirements-ci/security.txt
+++ b/requirements-ci/security.txt
@@ -8,3 +8,14 @@ cryptography==50.0.0
 # installs these files, not that package, so it was only ever satisfied transitively.
 # The [crypto] extra is required: jwks.py uses jwt.algorithms.RSAAlgorithm.
 PyJWT[crypto]>=2.8.0
+# #14551: same shape as PyJWT[crypto] above — autobot_shared/auth/jwt_core.py:61
+# does an unconditional `import bcrypt` (both backends' auth systems import this
+# module), and it is declared in autobot_shared/pyproject.toml but NOT installed
+# from there by CI. Absent here, importing jwt_core — and therefore
+# auth_middleware.py and everything that imports it — fails collection outright.
+bcrypt>=5.0.0
+# #14551: production dep of autobot-slm-backend/tests/api/*sso*.py's SSO/LDAP
+# auth path — sso_e2e_test.py skip-gates 2 tests on
+# `importlib.util.find_spec("ldap3") is None`, so without this they have been
+# silently skipping rather than exercising the real LDAP bind.
+ldap3>=2.9.1

--- a/tools/lint/check_ci_system_package_provisioning.py
+++ b/tools/lint/check_ci_system_package_provisioning.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""#14550 — system packages ansible installs on hosts are absent from CI runners.
+
+``autobot-slm-backend/ansible/roles/backend/tasks/main.yml`` installs a set of
+apt packages on every backend host because some feature does not work without
+them (GUI/VNC automation, audio/voice processing, TTS, OCR, matplotlib's Tk
+backend, ``pg_dump``). ``setup-python-suite`` installs Python dependencies
+only, so a test gated on one of those binaries being on ``PATH`` — via
+``shutil.which(...)`` inside a ``pytest.mark.skipif`` or an in-body
+``pytest.skip`` — has been silently skipping in CI, and a skip is
+indistinguishable from a pass in the job summary.
+
+That is exactly what happened with ``tesseract`` (#13885/#13896): the OCR
+toolchain was fully mocked in every existing test (never a bug on its own),
+but the *pattern* generalises to any capability whose real-binary test lands
+without the matching apt install. #14550 found one live instance:
+``media/audio/ffmpeg_service_test.py::test_real_audio_extraction`` skips
+"FFmpeg not installed" on every CI run because ffmpeg was never provisioned —
+fixed in the same PR that added this guard, by installing ffmpeg in
+``.github/actions/setup-python-suite/action.yml``.
+
+Design, deliberately narrow:
+
+* Only the FEATURE packages ansible installs are in scope
+  (:data:`FEATURE_PACKAGES`) — the Python-build toolchain
+  (``build-essential``, ``libssl-dev``, ``git``, ``curl``, ...) is excluded on
+  purpose: ``actions/setup-python`` ships a prebuilt interpreter so CI never
+  compiles Python from source, and ``git``/``curl`` are already present on
+  every GitHub-hosted runner image, so flagging them would be a false
+  positive, not a finding.
+* Only :data:`BINARY_TO_PACKAGE` binaries are matched — a ``shutil.which()``
+  call naming some other tool (``bash``, ``node``, ``rsync``, ...) is out of
+  this ansible role's scope entirely and is left alone.
+* A binary is "gated" when ``shutil.which("name")`` is followed within a few
+  lines by ``skipif`` or ``pytest.skip(`` — covering both the decorator and
+  the in-body-skip style already used in this repo.
+
+WHY THIS IS A SCRIPT AND NOT ONLY A TEST. The failure direction needs a
+REQUIRED check: a test file moving, or the ansible task being renamed, both
+make the scan find fewer gated binaries, so this reports FEWER problems and
+goes GREENER. ``.github/workflows/code-quality.yml`` calls this module with
+``--audit``, the same shape as ``check_flake8_exclude_anchoring.py
+--audit-excludes``. ``repo_tests/ci_system_package_provisioning_test.py``
+imports these functions rather than restating the rule.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import pathlib
+import re
+import sys
+
+# Plain stdlib logging (matching check_flake8_exclude_anchoring.py and
+# check_requirements_ci_drift.py): this runs inside `code-quality`, which
+# installs linters only, never the application's own dependencies.
+logger = logging.getLogger(__name__)
+
+
+_ANSIBLE_BACKEND_TASKS = "autobot-slm-backend/ansible/roles/backend/tasks/main.yml"
+_ANSIBLE_TASK_NAME = "Backend | Install backend-specific system dependencies"
+_SETUP_ACTION = ".github/actions/setup-python-suite/action.yml"
+
+#: Python-build toolchain packages ansible installs so pyenv/deadsnakes can
+#: compile CPython from source, plus baseline tools every GitHub-hosted
+#: runner image already ships. Out of scope for this guard — see module
+#: docstring. THIS SET IS DELIBERATELY FIXED, not derived, because widening
+#: it is exactly the failure direction this guard exists to catch: an entry
+#: added here silently exempts a real feature package from provisioning.
+TOOLCHAIN_PACKAGES = frozenset(
+    {
+        "build-essential",
+        "libssl-dev",
+        "zlib1g-dev",
+        "libbz2-dev",
+        "libreadline-dev",
+        "libsqlite3-dev",
+        "libncursesw5-dev",
+        "xz-utils",
+        "tk-dev",
+        "libxml2-dev",
+        "libxmlsec1-dev",
+        "libffi-dev",
+        "liblzma-dev",
+        "git",
+        "curl",
+    }
+)
+
+#: Binaries this guard knows to look for, mapped to the apt package that
+#: provides them. Only binaries ansible installs via the backend role belong
+#: here — add an entry when a new feature package gains a real-binary test.
+BINARY_TO_PACKAGE = {
+    "ffmpeg": "ffmpeg",
+    "ffprobe": "ffmpeg",
+    "tesseract": "tesseract-ocr",
+    "Xvfb": "xvfb",
+    "espeak-ng": "espeak-ng",
+    "espeak": "espeak-ng",
+    "pg_dump": "postgresql-client",
+}
+
+#: Floor for the ansible package enumeration. A parse that resolved to fewer
+#: than this many packages means the task moved or was renamed, not that the
+#: role shrank — the pre-guard baseline has 13 feature packages.
+FEATURE_PACKAGE_FLOOR = 10
+
+_APT_LIST_ITEM_RE = re.compile(r"^\s*-\s*([A-Za-z0-9][A-Za-z0-9.+-]*)\s*$")
+_SHUTIL_WHICH_RE = re.compile(r"""shutil\.which\(\s*["']([^"']+)["']\s*\)""")
+_APT_INSTALL_LINE_RE = re.compile(r"apt(?:-get)?\s+install[^\n]*")
+
+
+def repo_root() -> pathlib.Path:
+    """Repo root derived from this file, never from the caller's cwd."""
+    return pathlib.Path(__file__).resolve().parents[2]
+
+
+def ansible_feature_packages(root: pathlib.Path | None = None) -> set[str]:
+    """Packages the backend ansible role installs, minus the build toolchain."""
+    base = root if root is not None else repo_root()
+    path = base / _ANSIBLE_BACKEND_TASKS
+    if not path.is_file():
+        return set()
+    text = path.read_text(encoding="utf-8")
+    idx = text.find(_ANSIBLE_TASK_NAME)
+    if idx == -1:
+        return set()
+    block = text[idx:]
+    end = block.find("state: present")
+    if end != -1:
+        block = block[:end]
+    packages = set()
+    for line in block.splitlines():
+        match = _APT_LIST_ITEM_RE.match(line)
+        if match:
+            packages.add(match.group(1))
+    return packages - TOOLCHAIN_PACKAGES
+
+
+def ci_installed_packages(root: pathlib.Path | None = None) -> set[str]:
+    """Packages installed by an `apt-get install` / `apt install` line in the CI action."""
+    base = root if root is not None else repo_root()
+    path = base / _SETUP_ACTION
+    if not path.is_file():
+        return set()
+    packages: set[str] = set()
+    for install_line in _APT_INSTALL_LINE_RE.findall(path.read_text(encoding="utf-8")):
+        for token in install_line.split():
+            if token in ("apt", "apt-get", "install", "-y", "--yes", "-qq", "sudo"):
+                continue
+            packages.add(token)
+    return packages
+
+
+def _test_files(root: pathlib.Path) -> list[pathlib.Path]:
+    """Tracked test files: `*_test.py` anywhere, plus anything under a `tests/` dir.
+
+    Filters on the path RELATIVE to `root`, not the absolute path — `root`
+    itself commonly sits inside a `.worktrees/<branch>/` checkout, and an
+    absolute-path check would exclude every file it found (#14550 caught
+    this against its own guard before it ever reached CI).
+    """
+    candidates = set(root.glob("**/*_test.py"))
+    candidates.update(p for p in root.glob("**/tests/**/*.py") if p.is_file())
+    excluded = {"node_modules", "__pycache__"}
+    return [p for p in candidates if not excluded & set(p.relative_to(root).parts)]
+
+
+def gated_binaries(root: pathlib.Path | None = None) -> list[tuple[str, str, int]]:
+    """Every ``(binary, relative_file, lineno)`` where a known binary is skip-gated.
+
+    "Gated" means ``shutil.which("binary")`` appears within 3 lines of
+    ``skipif`` or ``pytest.skip(`` — covering both the decorator style
+    (ffmpeg_service_test.py) and the in-body-skip style (this repo uses both).
+    """
+    base = root if root is not None else repo_root()
+    findings: list[tuple[str, str, int]] = []
+    for path in _test_files(base):
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except (OSError, UnicodeDecodeError):
+            continue
+        for lineno, line in enumerate(lines, start=1):
+            match = _SHUTIL_WHICH_RE.search(line)
+            if not match or match.group(1) not in BINARY_TO_PACKAGE:
+                continue
+            window = "\n".join(lines[max(0, lineno - 4) : lineno + 2])
+            if "skipif" in window or "pytest.skip(" in window:
+                findings.append((match.group(1), str(path.relative_to(base)), lineno))
+    return findings
+
+
+def audit_provisioning(root: pathlib.Path | None = None) -> tuple[int, list[str]]:
+    """Apply the invariant. Returns ``(gated_binaries_found, problems)``."""
+    base = root if root is not None else repo_root()
+    problems: list[str] = []
+
+    packages = ansible_feature_packages(base)
+    if len(packages) < FEATURE_PACKAGE_FLOOR:
+        return 0, [
+            f"{_ANSIBLE_BACKEND_TASKS} yielded only {len(packages)} feature package(s) "
+            f"(floor {FEATURE_PACKAGE_FLOOR}) — the task moved or was renamed, so the "
+            "guard checked nothing."
+        ]
+
+    ci_packages = ci_installed_packages(base)
+    findings = gated_binaries(base)
+
+    if not findings:
+        return 0, [
+            "found zero shutil.which(...) skip-gates on a tracked binary across the test "
+            "tree — either the pattern changed shape or the test files moved; the guard "
+            "would otherwise report a comfortable zero having checked nothing."
+        ]
+
+    for binary, rel_path, lineno in sorted(findings):
+        pkg = BINARY_TO_PACKAGE[binary]
+        if pkg not in packages:
+            continue  # ansible does not install this one; out of this guard's scope
+        if pkg in ci_packages:
+            continue  # provisioned — the test genuinely runs
+        problems.append(
+            f"{rel_path}:{lineno} skip-gates on `{binary}` (package `{pkg}`), which "
+            f"ansible installs on every backend host but {_SETUP_ACTION} does not "
+            "install on the CI runner — this test has been silently skipping, not "
+            "passing (#14550). Add the package to the CI action's apt install step."
+        )
+
+    return len(findings), problems
+
+
+def configure_logging() -> None:
+    if not logger.handlers:
+        handler = logging.StreamHandler(sys.stderr)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+
+
+def run_audit() -> int:
+    reached, problems = audit_provisioning()
+    if problems:
+        logger.error("%s", "\n\n".join(problems))
+        logger.error("\nCI system-package provisioning audit FAILED over %d gated binary/ies (#14550).", reached)
+        return 1
+    logger.info("CI system-package provisioning audit clean over %d gated binary/ies (#14550).", reached)
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    configure_logging()
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--audit",
+        action="store_true",
+        help="verify every shutil.which()-gated test's package is installed in CI",
+    )
+    args = parser.parse_args(argv)
+    if not args.audit:
+        parser.error("nothing to do — pass --audit")
+    return run_audit()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tools/lint/check_ci_system_package_provisioning.py
+++ b/tools/lint/check_ci_system_package_provisioning.py
@@ -165,7 +165,13 @@ def ansible_feature_packages(root: pathlib.Path | None = None) -> set[str]:
 
 
 def ci_installed_packages(root: pathlib.Path | None = None) -> set[str]:
-    """Packages installed by an `apt-get install` / `apt install` line in the CI action."""
+    """Packages installed by an `apt-get install` / `apt install` line in the CI action.
+
+    Excludes anything starting with `-` generically (an apt flag), rather
+    than an explicit allowlist of known flags — a flag this parser has not
+    seen before (`--no-install-recommends`, `-qq`, ...) must never be
+    reported as an installed "package".
+    """
     base = root if root is not None else repo_root()
     path = base / _SETUP_ACTION
     if not path.is_file():
@@ -173,7 +179,7 @@ def ci_installed_packages(root: pathlib.Path | None = None) -> set[str]:
     packages: set[str] = set()
     for install_line in _APT_INSTALL_LINE_RE.findall(path.read_text(encoding="utf-8")):
         for token in install_line.split():
-            if token in ("apt", "apt-get", "install", "-y", "--yes", "-qq", "sudo"):
+            if token in ("apt", "apt-get", "install", "sudo") or token.startswith("-"):
                 continue
             packages.add(token)
     return packages

--- a/tools/lint/check_ci_system_package_provisioning.py
+++ b/tools/lint/check_ci_system_package_provisioning.py
@@ -14,14 +14,18 @@ only, so a test gated on one of those binaries being on ``PATH`` — via
 ``pytest.skip`` — has been silently skipping in CI, and a skip is
 indistinguishable from a pass in the job summary.
 
-That is exactly what happened with ``tesseract`` (#13885/#13896): the OCR
-toolchain was fully mocked in every existing test (never a bug on its own),
-but the *pattern* generalises to any capability whose real-binary test lands
-without the matching apt install. #14550 found one live instance:
-``media/audio/ffmpeg_service_test.py::test_real_audio_extraction`` skips
-"FFmpeg not installed" on every CI run because ffmpeg was never provisioned —
-fixed in the same PR that added this guard, by installing ffmpeg in
-``.github/actions/setup-python-suite/action.yml``.
+As of this guard landing, every existing ``tesseract`` call site in the test
+tree is fully mocked (``sys.modules`` stubs), so no CURRENT test needs the
+real binary — not a bug on its own, but the *pattern* generalises to any
+capability whose real-binary test lands without the matching apt install
+already in place. #14550 found one live instance: ``media/audio/
+ffmpeg_service_test.py::test_real_audio_extraction`` skips "FFmpeg not
+installed" on every CI run because ffmpeg was never provisioned — fixed in
+the same PR that added this guard, by installing ffmpeg in
+``.github/actions/setup-python-suite/action.yml``. A real ``tesseract``
+call-site gate landing later (tracked separately; not yet merged as of this
+writing) will be caught by this same guard the day it appears, since
+:data:`BINARY_TO_PACKAGE` already maps ``tesseract`` to ``tesseract-ocr``.
 
 Design, deliberately narrow:
 
@@ -66,6 +70,13 @@ _ANSIBLE_BACKEND_TASKS = "autobot-slm-backend/ansible/roles/backend/tasks/main.y
 _ANSIBLE_TASK_NAME = "Backend | Install backend-specific system dependencies"
 _SETUP_ACTION = ".github/actions/setup-python-suite/action.yml"
 
+#: Every repo-relative path this checker reads. code-quality.yml's
+#: dorny/paths-filter `backend` list must cover each of these, or a PR that
+#: touches only one of them skips the required check entirely -- verified by
+#: tools/lint/check_code_quality_guard_reach.py and
+#: repo_tests/code_quality_guard_reach_test.py.
+GUARD_INPUT_PATHS = (_ANSIBLE_BACKEND_TASKS, _SETUP_ACTION)
+
 #: Python-build toolchain packages ansible installs so pyenv/deadsnakes can
 #: compile CPython from source, plus baseline tools every GitHub-hosted
 #: runner image already ships. Out of scope for this guard — see module
@@ -105,6 +116,16 @@ BINARY_TO_PACKAGE = {
     "pg_dump": "postgresql-client",
 }
 
+#: Function calls that indirectly probe for a binary WITHOUT ever calling
+#: ``shutil.which`` -- e.g. a library's own version check raises when the
+#: underlying binary is missing. A guard that only matched the literal
+#: ``shutil.which("x")`` shape would keep reporting a binary "no real test,
+#: out of scope" the day a gate using one of these lands instead. Mapped to
+#: the same package namespace as BINARY_TO_PACKAGE, keyed by binary name.
+PROBE_CALL_TO_BINARY = {
+    "get_tesseract_version(": "tesseract",
+}
+
 #: Floor for the ansible package enumeration. A parse that resolved to fewer
 #: than this many packages means the task moved or was renamed, not that the
 #: role shrank — the pre-guard baseline has 13 feature packages.
@@ -112,6 +133,7 @@ FEATURE_PACKAGE_FLOOR = 10
 
 _APT_LIST_ITEM_RE = re.compile(r"^\s*-\s*([A-Za-z0-9][A-Za-z0-9.+-]*)\s*$")
 _SHUTIL_WHICH_RE = re.compile(r"""shutil\.which\(\s*["']([^"']+)["']\s*\)""")
+_PROBE_CALL_RE = re.compile("|".join(re.escape(call) for call in PROBE_CALL_TO_BINARY))
 _APT_INSTALL_LINE_RE = re.compile(r"apt(?:-get)?\s+install[^\n]*")
 
 
@@ -158,7 +180,13 @@ def ci_installed_packages(root: pathlib.Path | None = None) -> set[str]:
 
 
 def _test_files(root: pathlib.Path) -> list[pathlib.Path]:
-    """Tracked test files: `*_test.py` anywhere, plus anything under a `tests/` dir.
+    """Tracked test files, matching pytest.ini's own collection patterns exactly.
+
+    ``pytest.ini`` sets ``python_files = test_*.py *_test.py`` — BOTH prefix
+    and suffix conventions are collected (``transcriber/tests/test_export_api.py``
+    is prefix-style). Globbing only the suffix form would under-scan relative
+    to what pytest itself actually runs, the same "guard narrower than its own
+    subject" shape this guard exists to close.
 
     Filters on the path RELATIVE to `root`, not the absolute path — `root`
     itself commonly sits inside a `.worktrees/<branch>/` checkout, and an
@@ -166,17 +194,48 @@ def _test_files(root: pathlib.Path) -> list[pathlib.Path]:
     this against its own guard before it ever reached CI).
     """
     candidates = set(root.glob("**/*_test.py"))
+    candidates.update(root.glob("**/test_*.py"))
     candidates.update(p for p in root.glob("**/tests/**/*.py") if p.is_file())
     excluded = {"node_modules", "__pycache__"}
     return [p for p in candidates if not excluded & set(p.relative_to(root).parts)]
 
 
+def _match_gated_binary(line: str) -> str | None:
+    """The binary a line's ``shutil.which(...)`` or a known probe call names.
+
+    Two independent shapes reach the same binary: a direct PATH lookup, or a
+    library call that raises unless the underlying binary works (e.g.
+    ``pytesseract.get_tesseract_version()``, which calls ``tesseract``
+    without ever touching ``shutil.which``). Missing the second shape would
+    keep reporting that binary "no real test, out of scope" the day a gate
+    using it lands.
+    """
+    which_match = _SHUTIL_WHICH_RE.search(line)
+    if which_match and which_match.group(1) in BINARY_TO_PACKAGE:
+        return which_match.group(1)
+    probe_match = _PROBE_CALL_RE.search(line)
+    if probe_match:
+        return PROBE_CALL_TO_BINARY[probe_match.group(0)]
+    return None
+
+
+#: Substrings whose presence within a few lines of a matched binary marks it
+#: "gated" -- pytest's three shapes for making a test conditional. Checked as
+#: plain substrings, not `importorskip(` alone, so `pytest.skip(` does not
+#: accidentally match inside a longer `pytest.importorskip(` call (it does
+#: NOT: "skip(" is a substring of "importorskip(", but "pytest.skip(" is not,
+#: since "importor" sits between them -- kept as three explicit, disjoint
+#: markers instead of relying on that overlap not mattering by accident).
+_SKIP_MARKERS = ("skipif", "pytest.skip(", "importorskip(")
+
+
 def gated_binaries(root: pathlib.Path | None = None) -> list[tuple[str, str, int]]:
     """Every ``(binary, relative_file, lineno)`` where a known binary is skip-gated.
 
-    "Gated" means ``shutil.which("binary")`` appears within 3 lines of
-    ``skipif`` or ``pytest.skip(`` — covering both the decorator style
-    (ffmpeg_service_test.py) and the in-body-skip style (this repo uses both).
+    "Gated" means :func:`_match_gated_binary` matches within a few lines of
+    one of :data:`_SKIP_MARKERS` — covering the decorator style
+    (ffmpeg_service_test.py), the in-body ``pytest.skip(`` style, an indirect
+    probe, and ``pytest.importorskip(`` (the style scikit-learn/ldap3/etc. use).
     """
     base = root if root is not None else repo_root()
     findings: list[tuple[str, str, int]] = []
@@ -186,12 +245,12 @@ def gated_binaries(root: pathlib.Path | None = None) -> list[tuple[str, str, int
         except (OSError, UnicodeDecodeError):
             continue
         for lineno, line in enumerate(lines, start=1):
-            match = _SHUTIL_WHICH_RE.search(line)
-            if not match or match.group(1) not in BINARY_TO_PACKAGE:
+            binary = _match_gated_binary(line)
+            if binary is None:
                 continue
             window = "\n".join(lines[max(0, lineno - 4) : lineno + 2])
-            if "skipif" in window or "pytest.skip(" in window:
-                findings.append((match.group(1), str(path.relative_to(base)), lineno))
+            if any(marker in window for marker in _SKIP_MARKERS):
+                findings.append((binary, str(path.relative_to(base)), lineno))
     return findings
 
 

--- a/tools/lint/check_ci_system_package_provisioning.py
+++ b/tools/lint/check_ci_system_package_provisioning.py
@@ -164,22 +164,38 @@ def ansible_feature_packages(root: pathlib.Path | None = None) -> set[str]:
     return packages - TOOLCHAIN_PACKAGES
 
 
+def _strip_comment_lines(text: str) -> str:
+    """Drop every full-line YAML/shell comment before scanning for apt commands.
+
+    `_APT_INSTALL_LINE_RE` matches "apt(-get)? install" anywhere in the file,
+    including inside a comment that is EXPLAINING an apt-get command in
+    prose — this checker's own docstring-style comments have done exactly
+    that. Without this, words from the comment's sentence get tokenized
+    alongside the real package names.
+    """
+    return "\n".join(line for line in text.splitlines() if not line.strip().startswith("#"))
+
+
 def ci_installed_packages(root: pathlib.Path | None = None) -> set[str]:
     """Packages installed by an `apt-get install` / `apt install` line in the CI action.
 
-    Excludes anything starting with `-` generically (an apt flag), rather
-    than an explicit allowlist of known flags — a flag this parser has not
-    seen before (`--no-install-recommends`, `-qq`, ...) must never be
-    reported as an installed "package".
+    Excludes anything starting with `-` generically (an apt flag) or
+    containing `=`/`::` (an apt `-o Key::Path=value` option's VALUE, which
+    follows a `-o` token but is not itself flagged by the leading-`-` check),
+    rather than an explicit allowlist of known flags — a flag this parser has
+    not seen before must never be reported as an installed "package".
     """
     base = root if root is not None else repo_root()
     path = base / _SETUP_ACTION
     if not path.is_file():
         return set()
+    text = _strip_comment_lines(path.read_text(encoding="utf-8"))
     packages: set[str] = set()
-    for install_line in _APT_INSTALL_LINE_RE.findall(path.read_text(encoding="utf-8")):
+    for install_line in _APT_INSTALL_LINE_RE.findall(text):
         for token in install_line.split():
-            if token in ("apt", "apt-get", "install", "sudo") or token.startswith("-"):
+            if token in ("apt", "apt-get", "install", "sudo"):
+                continue
+            if token.startswith("-") or "=" in token or "::" in token:
                 continue
             packages.add(token)
     return packages

--- a/tools/lint/check_code_quality_guard_reach.py
+++ b/tools/lint/check_code_quality_guard_reach.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""#14550/#14551 — a required check that never triggers is satisfied, not failed.
+
+``code-quality`` only does real work when its ``changes`` job's
+``dorny/paths-filter`` reports a ``backend`` path touched — otherwise the
+``code-quality`` job itself is skipped, and GitHub branch protection treats a
+**skipped** required job the same as a **passing** one. #14550 and #14551
+added two guards (``check_requirements_ci_drift.py``,
+``check_ci_system_package_provisioning.py``) whose own input files —
+``autobot-slm-backend/ansible/roles/backend/tasks/main.yml`` and
+``.github/actions/setup-python-suite/action.yml`` — were not covered by that
+filter at the time: a PR touching only one of them (say, deleting the
+``ffmpeg`` apt line #14550 just added) matched no filter entry, so
+``code-quality`` skipped, both ``--audit`` steps never ran, and the guard
+could not fire on the exact change it exists to catch.
+
+This is that failure shape one layer up: a guard whose *reach* is narrower
+than the thing it claims to cover reads as coverage while providing none. So
+each guard now declares its own ``GUARD_INPUT_PATHS`` (the checker's single
+source of truth for what it reads), and this module re-derives the filter's
+actual reach from ``.github/workflows/code-quality.yml`` and asserts every
+guarded path is covered by it.
+
+WHY THIS IS A SCRIPT AND NOT ONLY A TEST. The failure direction needs a
+REQUIRED check for the same reason as its siblings: removing a path filter
+entry, or forgetting to add one for a new guard input, makes this scan find
+FEWER uncovered paths and go GREENER. ``.github/workflows/code-quality.yml``
+itself is always in scope (it is a filter entry in its own right), so this
+check runs on any edit to the filter. ``repo_tests/code_quality_guard_reach_test.py``
+imports these functions rather than restating the rule.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import logging
+import pathlib
+import re
+import sys
+
+# Plain stdlib logging (matching every other tools/lint/check_*.py in this
+# repo): this runs inside `code-quality`, which installs linters only, never
+# the application's own dependencies -- so no third-party YAML parser here.
+logger = logging.getLogger(__name__)
+
+_WORKFLOW = ".github/workflows/code-quality.yml"
+
+#: Checkers whose GUARD_INPUT_PATHS this meta-guard enforces. Add a new entry
+#: here whenever a new required-check script gains its own GUARD_INPUT_PATHS.
+_GUARDED_CHECKERS = (
+    "tools/lint/check_requirements_ci_drift.py",
+    "tools/lint/check_ci_system_package_provisioning.py",
+)
+
+_FILTER_BULLET_RE = re.compile(r"^\s*-\s*'([^']+)'\s*$")
+
+
+def repo_root() -> pathlib.Path:
+    """Repo root derived from this file, never from the caller's cwd."""
+    return pathlib.Path(__file__).resolve().parents[2]
+
+
+def _load_module(root: pathlib.Path, rel_path: str):
+    spec = importlib.util.spec_from_file_location(rel_path.replace("/", "_"), root / rel_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def guarded_input_paths(root: pathlib.Path | None = None) -> dict[str, tuple[str, ...]]:
+    """``{checker_path: its GUARD_INPUT_PATHS}`` for every checker in scope."""
+    base = root if root is not None else repo_root()
+    result: dict[str, tuple[str, ...]] = {}
+    for rel_path in _GUARDED_CHECKERS:
+        if not (base / rel_path).is_file():
+            continue
+        module = _load_module(base, rel_path)
+        result[rel_path] = tuple(getattr(module, "GUARD_INPUT_PATHS", ()))
+    return result
+
+
+def backend_filter_patterns(root: pathlib.Path | None = None) -> list[str]:
+    """The dorny/paths-filter ``backend`` bullet list, parsed without a YAML lib.
+
+    ``configparser``/stdlib ``tomllib`` cannot read a YAML file, and
+    ``code-quality`` installs no third-party YAML parser, so this reads the
+    literal ``filters: |`` block by locating it explicitly rather than
+    trusting the first ``backend:`` in the file — ``outputs: backend: ...``
+    two lines above the real filter list would otherwise match first.
+    """
+    base = root if root is not None else repo_root()
+    path = base / _WORKFLOW
+    if not path.is_file():
+        return []
+    text = path.read_text(encoding="utf-8")
+    filters_idx = text.find("filters: |")
+    if filters_idx == -1:
+        return []
+    backend_idx = text.find("backend:", filters_idx)
+    if backend_idx == -1:
+        return []
+    patterns: list[str] = []
+    for line in text[backend_idx:].splitlines()[1:]:
+        match = _FILTER_BULLET_RE.match(line)
+        if match:
+            patterns.append(match.group(1))
+        elif patterns:
+            break  # first non-bullet line after the list ends the block
+    return patterns
+
+
+def _pattern_regex(pattern: str) -> re.Pattern[str]:
+    """Translate a dorny/paths-filter glob (`**`, `*`) to a regex, anchored.
+
+    `**/` becomes an OPTIONAL `(.*/)?`, not a bare `.*/`: gitignore-style
+    matching lets `**/foo` match a root-level `foo` with zero path segments,
+    and a bare `.*/`  would demand a literal `/` that a top-level file (e.g.
+    `requirements-ci.txt` against `**/requirements*.txt`) does not have --
+    which would report a covered path as uncovered.
+    """
+    escaped = re.escape(pattern)
+    escaped = escaped.replace(r"\*\*/", "(?:.*/)?")
+    escaped = escaped.replace(r"\*\*", ".*")
+    escaped = escaped.replace(r"\*", "[^/]*")
+    return re.compile(escaped + r"$")
+
+
+def uncovered_paths(guarded: dict[str, tuple[str, ...]], patterns: list[str]) -> dict[str, list[str]]:
+    """Guarded paths matched by NO filter pattern, grouped by owning checker."""
+    compiled = [_pattern_regex(p) for p in patterns]
+    result: dict[str, list[str]] = {}
+    for checker, paths in guarded.items():
+        misses = [p for p in paths if not any(rx.search(p) for rx in compiled)]
+        if misses:
+            result[checker] = misses
+    return result
+
+
+def audit_reach(root: pathlib.Path | None = None) -> tuple[int, list[str]]:
+    """Apply the invariant. Returns ``(guarded_paths_checked, problems)``."""
+    base = root if root is not None else repo_root()
+    problems: list[str] = []
+
+    guarded = guarded_input_paths(base)
+    total = sum(len(v) for v in guarded.values())
+    if total == 0:
+        return 0, ["no GUARD_INPUT_PATHS found on any tracked checker — the guard checked nothing."]
+
+    patterns = backend_filter_patterns(base)
+    if not patterns:
+        return total, [f"{_WORKFLOW} parsed to zero `backend` filter patterns — the guard checked nothing."]
+
+    missed = uncovered_paths(guarded, patterns)
+    if missed:
+        for checker, paths in missed.items():
+            problems.append(
+                f"{checker} reads {paths}, none of which is covered by {_WORKFLOW}'s "
+                "`backend` path filter — a PR touching only that path skips the "
+                "`code-quality` job entirely, and a skipped required job satisfies "
+                "branch protection. Add a matching entry to both the `on.push.paths` "
+                "list and the `changes` job's `filters.backend` list."
+            )
+
+    return total, problems
+
+
+def configure_logging() -> None:
+    if not logger.handlers:
+        handler = logging.StreamHandler(sys.stderr)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+
+
+def run_audit() -> int:
+    reached, problems = audit_reach()
+    if problems:
+        logger.error("%s", "\n\n".join(problems))
+        logger.error("\ncode-quality guard-reach audit FAILED over %d guarded path(s) (#14550/#14551).", reached)
+        return 1
+    logger.info("code-quality guard-reach audit clean over %d guarded path(s) (#14550/#14551).", reached)
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    configure_logging()
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--audit",
+        action="store_true",
+        help="verify the code-quality path filter covers every guarded checker's inputs",
+    )
+    args = parser.parse_args(argv)
+    if not args.audit:
+        parser.error("nothing to do — pass --audit")
+    return run_audit()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tools/lint/check_code_quality_guard_reach.py
+++ b/tools/lint/check_code_quality_guard_reach.py
@@ -59,6 +59,7 @@ _GUARDED_CHECKERS = (
 )
 
 _FILTER_BULLET_RE = re.compile(r"^\s*-\s*'([^']+)'\s*$")
+_FILTER_COMMENT_RE = re.compile(r"^\s*#")
 
 
 def repo_root() -> pathlib.Path:
@@ -93,6 +94,16 @@ def backend_filter_patterns(root: pathlib.Path | None = None) -> list[str]:
     literal ``filters: |`` block by locating it explicitly rather than
     trusting the first ``backend:`` in the file — ``outputs: backend: ...``
     two lines above the real filter list would otherwise match first.
+
+    Skips blank lines and full-line ``#`` comments WITHOUT ending the block --
+    #14650 (landed the same week as this checker) added a multi-line comment
+    INSIDE the filters list for the first time, between two bullets. The
+    original version treated any non-bullet line as the end of the list, so
+    it silently truncated at that comment and read every entry after it,
+    including this checker's own guarded paths, as uncovered -- caught by
+    rebasing #14550/#14551 onto that change, not by design. dorny/paths-filter
+    itself parses this block as real YAML and is unaffected by comments; this
+    mirror must not diverge from that by treating one as a terminator.
     """
     base = root if root is not None else repo_root()
     path = base / _WORKFLOW
@@ -110,8 +121,11 @@ def backend_filter_patterns(root: pathlib.Path | None = None) -> list[str]:
         match = _FILTER_BULLET_RE.match(line)
         if match:
             patterns.append(match.group(1))
-        elif patterns:
-            break  # first non-bullet line after the list ends the block
+            continue
+        if not line.strip() or _FILTER_COMMENT_RE.match(line):
+            continue  # blank line or full-line comment -- keep scanning
+        if patterns:
+            break  # first genuine non-bullet, non-comment line ends the block
     return patterns
 
 

--- a/tools/lint/check_code_quality_guard_reach.py
+++ b/tools/lint/check_code_quality_guard_reach.py
@@ -55,6 +55,7 @@ _WORKFLOW = ".github/workflows/code-quality.yml"
 _GUARDED_CHECKERS = (
     "tools/lint/check_requirements_ci_drift.py",
     "tools/lint/check_ci_system_package_provisioning.py",
+    "tools/lint/check_composite_action_step_keys.py",
 )
 
 _FILTER_BULLET_RE = re.compile(r"^\s*-\s*'([^']+)'\s*$")

--- a/tools/lint/check_composite_action_step_keys.py
+++ b/tools/lint/check_composite_action_step_keys.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""#14550 post-merge incident — a composite action step key GitHub silently rejects.
+
+A composite action's own ``runs.steps`` accept only ``run``, ``shell``,
+``working-directory``, ``env``, ``id``, ``if``, ``name`` (plus ``uses``/``with``
+for a step that calls another action). ``timeout-minutes`` — valid on a *job*,
+and on a *workflow* step — is NOT valid there. Adding it to one step of
+``.github/actions/setup-python-suite/action.yml`` made GitHub's template
+validator reject the WHOLE file before a single step ran:
+
+.. code-block:: text
+
+    ##[error]/.github/actions/setup-python-suite/action.yml (Line: 56, Col: 7):
+    Unexpected value 'timeout-minutes'
+    ##[error]GitHub.DistributedTask.ObjectTemplating.TemplateValidationException:
+    The template is not valid.
+
+Every shard that used the action failed identically, not only the one the
+change was meant to protect — and nothing local caught it. ``code-quality``
+installs linters, not a YAML-schema validator for GitHub's own template
+engine, and no unit test in this repo executes a composite action the way
+GitHub's runner does. The gap is real: only GitHub's own server-side
+validation, at workflow-run time, would have caught this before this guard
+existed.
+
+This does not depend on ``actionlint`` or any other external tool being
+installed — it re-implements the (small, stable) allowed-key set as a plain
+Python check, so ``code-quality`` (linters only, no application deps, no
+network) can catch it before a push ever reaches a runner.
+
+WHY THIS IS A SCRIPT AND NOT ONLY A TEST. The failure direction needs a
+REQUIRED check: a composite action gaining a new step, or an existing step
+gaining an unsupported key, both make this scan find nothing to report
+*unless it re-derives the allowed-key set correctly on every run* — nothing
+about a merely-informational pytest run would block the push that breaks
+every shard using the action. ``.github/workflows/code-quality.yml`` calls
+this module with ``--audit``. ``repo_tests/ci_system_package_provisioning_test.py``
+carries a narrower, pre-existing pin on ``setup-python-suite/action.yml``
+specifically; this module generalises the check to every composite action in
+the repo, present and future.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import pathlib
+import re
+import sys
+
+# Plain stdlib logging (matching the other tools/lint/check_*.py modules in
+# this repo): runs inside `code-quality`, which installs linters only.
+logger = logging.getLogger(__name__)
+
+#: Keys GitHub's template validator accepts on a COMPOSITE ACTION'S OWN step.
+#: Anything else (`timeout-minutes`, `continue-on-error`, ...) is a workflow-
+#: or job-level key that happens to look plausible on a step, and silently
+#: invalidates the WHOLE action.yml, not just the offending step.
+ALLOWED_STEP_KEYS = frozenset({"name", "run", "shell", "working-directory", "env", "id", "if", "uses", "with"})
+
+#: Glob, relative to the repo root, for every composite action definition.
+_ACTION_GLOB = ".github/actions/*/action.yml"
+
+#: This checker's own guard-reach declaration (see
+#: tools/lint/check_code_quality_guard_reach.py) -- the glob itself, since the
+#: exact set of composite actions changes over time and the filter must cover
+#: the DIRECTORY, not today's snapshot of files in it.
+GUARD_INPUT_PATHS = (_ACTION_GLOB,)
+
+#: Minimal YAML mapping-key extractor for one step-list item. Deliberately
+#: not a real YAML parser (code-quality installs no third-party YAML lib):
+#: this only needs the TOP-LEVEL key names of each `- key: value` block
+#: under `runs.steps`, which line-anchored regexes are sufficient for given
+#: this repo's consistent 4-space step indentation. Two separate patterns,
+#: not one: this repo's own style inlines the first key on the dash line
+#: itself (`    - uses: actions/checkout@v7`), which a single "N-to-M spaces
+#: then a key" pattern would miss entirely -- silently dropping exactly the
+#: key this checker exists to catch, if it were ever written as the first
+#: (dash-line) key of a step instead of a later line.
+_STEP_START_RE = re.compile(r"^ {4}- ")
+_INLINE_KEY_RE = re.compile(r"^ {4}- ([A-Za-z][A-Za-z0-9_-]*):")
+_CONT_KEY_RE = re.compile(r"^ {6}([A-Za-z][A-Za-z0-9_-]*):")
+_RUNS_STEPS_RE = re.compile(r"^runs:\s*$")
+
+
+def repo_root() -> pathlib.Path:
+    """Repo root derived from this file, never from the caller's cwd."""
+    return pathlib.Path(__file__).resolve().parents[2]
+
+
+def action_files(root: pathlib.Path | None = None) -> list[pathlib.Path]:
+    base = root if root is not None else repo_root()
+    return sorted(base.glob(_ACTION_GLOB))
+
+
+def step_key_sets(text: str) -> list[set[str]]:
+    """One ``set[str]`` of top-level keys per step under ``runs: / steps:``.
+
+    Scoped to lines at 4- or 6-space step indentation so a same-named key
+    inside a nested ``with:`` block (indented deeper still) is never
+    mistaken for a step-level key.
+    """
+    lines = text.splitlines()
+    steps: list[set[str]] = []
+    in_runs = False
+    for line in lines:
+        if _RUNS_STEPS_RE.match(line):
+            in_runs = True
+            continue
+        if not in_runs:
+            continue
+        if _STEP_START_RE.match(line):
+            steps.append(set())
+            inline = _INLINE_KEY_RE.match(line)
+            if inline:
+                steps[-1].add(inline.group(1))
+            continue
+        if steps:
+            cont = _CONT_KEY_RE.match(line)
+            if cont:
+                steps[-1].add(cont.group(1))
+    return steps
+
+
+def offending_keys(steps: list[set[str]]) -> list[set[str]]:
+    """Per-step key sets that include something outside ALLOWED_STEP_KEYS."""
+    return [keys - ALLOWED_STEP_KEYS for keys in steps if keys - ALLOWED_STEP_KEYS]
+
+
+def audit_composite_actions(root: pathlib.Path | None = None) -> tuple[int, list[str]]:
+    """Apply the invariant to every composite action. Returns ``(steps_checked, problems)``."""
+    base = root if root is not None else repo_root()
+    files = action_files(base)
+    if not files:
+        return 0, [f"{_ACTION_GLOB} matched zero files — the guard checked nothing."]
+
+    total_steps = 0
+    problems: list[str] = []
+    for path in files:
+        steps = step_key_sets(path.read_text(encoding="utf-8"))
+        if not steps:
+            problems.append(f"{path.relative_to(base)}: parsed zero steps under `runs:` — the parser may be stale.")
+            continue
+        total_steps += len(steps)
+        bad = offending_keys(steps)
+        if bad:
+            problems.append(
+                f"{path.relative_to(base)}: step key(s) not valid on a composite action's own steps: {bad}. "
+                "GitHub's template validator rejects the WHOLE file for this — one offending key breaks every "
+                "step, on every job that uses this action (#14550)."
+            )
+
+    return total_steps, problems
+
+
+def configure_logging() -> None:
+    if not logger.handlers:
+        handler = logging.StreamHandler(sys.stderr)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+
+
+def run_audit() -> int:
+    reached, problems = audit_composite_actions()
+    if problems:
+        logger.error("%s", "\n\n".join(problems))
+        logger.error("\ncomposite-action step-key audit FAILED over %d step(s) (#14550).", reached)
+        return 1
+    logger.info("composite-action step-key audit clean over %d step(s) (#14550).", reached)
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    configure_logging()
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--audit",
+        action="store_true",
+        help="verify every composite action's steps use only GitHub-supported keys",
+    )
+    args = parser.parse_args(argv)
+    if not args.audit:
+        parser.error("nothing to do — pass --audit")
+    return run_audit()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tools/lint/check_requirements_ci_drift.py
+++ b/tools/lint/check_requirements_ci_drift.py
@@ -71,6 +71,13 @@ _CI_REQUIREMENTS = "requirements-ci.txt"
 #: One package name per (non-comment, non-blank) line. THIS LIST ONLY SHRINKS.
 _ALLOWLIST_FILE = "repo_tests/requirements_ci_drift_baseline.txt"
 
+#: Every repo-relative path/glob this checker reads. code-quality.yml's
+#: dorny/paths-filter `backend` list must cover each of these, or a PR that
+#: touches only one of them skips the required check entirely -- verified by
+#: tools/lint/check_code_quality_guard_reach.py and
+#: repo_tests/code_quality_guard_reach_test.py.
+GUARD_INPUT_PATHS = (*_PRODUCTION_REQUIREMENTS, _CI_REQUIREMENTS, "requirements-ci/*.txt", _ALLOWLIST_FILE)
+
 _NAME_RE = re.compile(r"^([A-Za-z0-9][A-Za-z0-9._-]*)")
 
 

--- a/tools/lint/check_requirements_ci_drift.py
+++ b/tools/lint/check_requirements_ci_drift.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""#14551 — production and CI Python dependency sets are hand-mirrored; catch silent drift.
+
+``autobot-backend/requirements.txt`` and ``autobot-slm-backend/requirements.txt``
+declare what production installs. ``requirements-ci.txt`` (which pulls in
+``requirements-ci/*.txt``) is a SEPARATE, hand-maintained mirror that
+``setup-python-suite`` actually installs — it never installs the backends' own
+requirements files. A package declared in production and forgotten in the
+mirror produces no error: the tests that need it simply never run, and any
+that do exercise it fall back to a mocked/stubbed import instead.
+
+That is exactly what happened to ``pytesseract`` (#13885): declared in
+``autobot-backend/requirements.txt``, absent from every ``requirements-ci/*``
+file, and every end-to-end OCR test skipped for months while the suite stayed
+green throughout.
+
+What this guard does NOT do: merge the two dependency sets. The role-based CI
+split is deliberate (#1655) and CI legitimately omits some heavy production
+deps (torch arrives transitively via sentence-transformers, per the CPU-index
+resolution documented in ``requirements-ci/ai-ml.txt`` and #13316). The
+allowlist at ``repo_tests/requirements_ci_drift_baseline.txt`` records those
+deliberate omissions explicitly, so the diff is expected to be **exactly** that
+list — any package missing from CI that is NOT on the list is a new,
+undeclared drift and fails this check. The allowlist only ever shrinks: an
+entry that no longer describes a real omission (the package was added to CI,
+or removed from production) is a hard error too, in the style of
+``sys_modules_leak_baseline.txt`` and ``extension_import_baseline.txt`` — a
+stale allowlist entry exempts nothing while looking authoritative.
+
+WHY THIS IS A SCRIPT AND NOT ONLY A TEST. The failure direction is what makes
+this need a REQUIRED check, not documentation: shrinking the allowlist by
+hand-adding a stale entry, or a requirements file silently resolving to zero
+entries (a rename, a moved role), both make this check report FEWER problems,
+i.e. go GREENER. Nothing about a merely-informational pytest run would notice.
+``.github/workflows/code-quality.yml`` therefore calls this module with
+``--audit``, mirroring ``check_flake8_exclude_anchoring.py --audit-excludes``
+and ``check_python_file_size.py --audit-ceilings``.
+``repo_tests/requirements_ci_drift_test.py`` imports these functions rather
+than restating the rule, so there is one definition of "drift".
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import pathlib
+import re
+import sys
+
+# Plain stdlib logging, deliberately (#1082, matching check_flake8_exclude_anchoring.py
+# and check_python_file_size.py): this runs inside `code-quality`, which installs
+# linters only — never the application's own dependencies — so
+# `autobot_shared.logging_manager` is not importable here.
+logger = logging.getLogger(__name__)
+
+
+#: Production requirement files that declare what is actually deployed.
+#: Deliberately excludes autobot-tts-worker/requirements.txt: its tests are
+#: written to need neither torch nor pocket_tts (pytest.ini), so nothing in
+#: the CI-scoped suite needs its deps mirrored — recorded here, not silently
+#: dropped.
+_PRODUCTION_REQUIREMENTS = ("autobot-backend/requirements.txt", "autobot-slm-backend/requirements.txt")
+
+#: The CI mirror's entry point — pulls in requirements-ci/*.txt via -r includes.
+_CI_REQUIREMENTS = "requirements-ci.txt"
+
+#: One package name per (non-comment, non-blank) line. THIS LIST ONLY SHRINKS.
+_ALLOWLIST_FILE = "repo_tests/requirements_ci_drift_baseline.txt"
+
+_NAME_RE = re.compile(r"^([A-Za-z0-9][A-Za-z0-9._-]*)")
+
+
+def repo_root() -> pathlib.Path:
+    """Repo root derived from this file, never from the caller's cwd."""
+    return pathlib.Path(__file__).resolve().parents[2]
+
+
+def _normalize(name: str) -> str:
+    """PEP 503 style normalisation so `python_dotenv` and `python-dotenv` match."""
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def parse_requirements(path: pathlib.Path, _seen: set[pathlib.Path] | None = None) -> dict[str, str]:
+    """Parse a requirements file, following ``-r`` includes; skip ``-e``/``-c``/options.
+
+    Returns ``{normalized_name: raw_line}``. A later declaration of the same
+    package overwrites an earlier one, matching pip's own last-wins behaviour.
+    """
+    seen = _seen if _seen is not None else set()
+    resolved = path.resolve()
+    if resolved in seen or not resolved.is_file():
+        return {}
+    seen.add(resolved)
+
+    out: dict[str, str] = {}
+    for raw in resolved.read_text(encoding="utf-8").splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if not line:
+            continue
+        if line.startswith("-r "):
+            out.update(parse_requirements((resolved.parent / line[3:].strip()), seen))
+            continue
+        if line.startswith("-e ") or line.startswith("-c ") or line.startswith("--"):
+            continue
+        match = _NAME_RE.match(line)
+        if match:
+            out[_normalize(match.group(1))] = line
+    return out
+
+
+def production_requirement_names(root: pathlib.Path | None = None) -> dict[str, str]:
+    base = root if root is not None else repo_root()
+    combined: dict[str, str] = {}
+    for rel in _PRODUCTION_REQUIREMENTS:
+        combined.update(parse_requirements(base / rel))
+    return combined
+
+
+def ci_requirement_names(root: pathlib.Path | None = None) -> dict[str, str]:
+    base = root if root is not None else repo_root()
+    return parse_requirements(base / _CI_REQUIREMENTS)
+
+
+def load_allowlist(root: pathlib.Path | None = None) -> set[str]:
+    base = root if root is not None else repo_root()
+    path = base / _ALLOWLIST_FILE
+    if not path.is_file():
+        return set()
+    names = set()
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.split("#", 1)[0].strip()
+        if stripped:
+            names.add(_normalize(stripped))
+    return names
+
+
+def compute_drift(
+    production: dict[str, str], ci: dict[str, str], allowlist: set[str]
+) -> tuple[list[str], list[str]]:
+    """Return ``(new_drift, stale_allowlist_entries)``.
+
+    ``new_drift`` — production packages missing from CI and NOT on the
+    allowlist: an undeclared, silent omission.
+
+    ``stale_allowlist_entries`` — allowlisted names that no longer describe a
+    real omission, either because CI now installs them (the drift was fixed
+    but the entry was never removed) or production no longer declares them
+    (the package was dropped entirely). Both cases exempt nothing while
+    looking authoritative, so both are hard errors, never a silent no-op.
+    """
+    missing = set(production) - set(ci)
+    new_drift = sorted(missing - allowlist)
+    stale = sorted(entry for entry in allowlist if entry not in missing)
+    return new_drift, stale
+
+
+def audit_drift(root: pathlib.Path | None = None) -> tuple[int, list[str]]:
+    """Apply the invariant. Returns ``(packages_reached, problems)``.
+
+    ``packages_reached`` is the size of the production set, counted from the
+    parse so a requirements file that resolved to zero entries (a rename, a
+    moved role) cannot report a clean scan of nothing.
+    """
+    base = root if root is not None else repo_root()
+    production = production_requirement_names(base)
+    ci = ci_requirement_names(base)
+    problems: list[str] = []
+
+    if not production:
+        return 0, [f"{', '.join(_PRODUCTION_REQUIREMENTS)} parsed to zero packages — the guard checked nothing."]
+    if not ci:
+        return len(production), [f"{_CI_REQUIREMENTS} parsed to zero packages — the guard checked nothing."]
+
+    allowlist = load_allowlist(base)
+    new_drift, stale = compute_drift(production, ci, allowlist)
+
+    if new_drift:
+        lines = "\n".join(f"  {name}  ({production[name]})" for name in new_drift)
+        problems.append(
+            f"{len(new_drift)} package(s) declared in production but missing from "
+            f"{_CI_REQUIREMENTS} / requirements-ci/*.txt, and not recorded in "
+            f"{_ALLOWLIST_FILE}:\n{lines}\n"
+            "Either mirror the package into the matching requirements-ci/*.txt file, "
+            "or — if CI genuinely should not install it — add it to the allowlist with "
+            "a comment explaining why (#14551)."
+        )
+    if stale:
+        problems.append(
+            f"stale entries in {_ALLOWLIST_FILE} (fixed or removed, but not deleted): "
+            f"{stale}. The allowlist only shrinks — remove these lines (#14551)."
+        )
+
+    return len(production), problems
+
+
+def configure_logging() -> None:
+    if not logger.handlers:
+        handler = logging.StreamHandler(sys.stderr)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+
+
+def run_audit() -> int:
+    reached, problems = audit_drift()
+    if problems:
+        logger.error("%s", "\n\n".join(problems))
+        logger.error("\nrequirements-ci drift audit FAILED over %d production package(s) (#14551).", reached)
+        return 1
+    logger.info("requirements-ci drift audit clean over %d production package(s) (#14551).", reached)
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    configure_logging()
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--audit",
+        action="store_true",
+        help="compare production requirements against requirements-ci and the allowlist",
+    )
+    args = parser.parse_args(argv)
+    if not args.audit:
+        parser.error("nothing to do — pass --audit")
+    return run_audit()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
Closes #14550, #14551

## Thinking Path

Both issues describe the same shape of bug: the CI environment can diverge
from what production actually runs, and nothing notices — once as Python
packages (#14551), once as apt system packages (#14550). #13885 already
showed the concrete cost once: `pytesseract` sat declared in production
requirements and absent from CI for months, every OCR test either skipped or
ran against a mock, and the suite stayed green throughout.

Measured the drift before changing anything, then a code-reviewer pass on
the first version of this PR found the guards' *reach* was itself the
weaker link — a required check that can be skipped for the exact files it
protects, a baseline with 9 false rationales, an unlanded precedent cited as
established, and (once fixed) a genuinely broken production code path the
fix exposed. All of that is folded into what's described below; see the
review thread for the point-by-point response.

**#14551 (Python packages):** parsed `autobot-backend/requirements.txt` +
`autobot-slm-backend/requirements.txt` (production) against
`requirements-ci.txt` → `requirements-ci/*.txt` (CI). Final state:
**56/100 matching**. 44 packages are genuinely absent and allowlisted with a
verified rationale each (SLM-only auth/SSO libs the CI-scoped suite mocks
around, OpenTelemetry instrumentation reached by no collected test,
`torch`/`tree-sitter` resolved transitively, LangChain/LlamaIndex extras,
optional lazy-imported libraries). 11 more were found to have a **real**
skip gate and were mirrored into CI instead of allowlisted: `scikit-learn`,
`ldap3`, `weasyprint`, `faiss-cpu`, `datasketch`, `tree-sitter-python`,
`trafilatura`, `yt-dlp`, `ddgs`, `bcrypt`, `pydantic-settings`. `pytesseract`
(the original #13885 incident) ended up allowlisted for a different
reason — see below.

**#14550 (system packages):** the backend ansible role installs 13 feature
system packages (GUI/VNC, audio, TTS, OCR, `pg_dump`; excluding the
Python-build toolchain, which CI never needs since `actions/setup-python`
ships a prebuilt interpreter). Cross-referencing every `shutil.which(...)` /
`pytest.importorskip(...)` / known indirect-probe skip-gate in the test tree
against those 13 packages found exactly **one** live instance:
`ffmpeg_service_test.py::test_real_audio_extraction`, silently skipping on
every CI run — **0/1 provisioned** before the fix, **1/1** after. Enabling
it surfaced a second, more serious problem: the function it exercises was
completely broken (see "Unplanned but necessary" below). The other 12
ansible packages have no CI-scoped test needing the real binary today.

Decided against merging the two dependency sets (explicitly out of scope
per #14551: the role-based CI split is deliberate, and CI legitimately omits
heavy production deps like `torch`, which arrives transitively). The fix is
a guard against *silent* divergence, not a one-time sync — seeded from the
real diff, with a policy for what a fresh diff means:

- A production package with a **real** test that needs it → **fix it**
  (mirror into CI). Never allowlist an actual gap — that was the mistake in
  round one of this PR, corrected after review.
- A production package CI deliberately omits, verified by grepping the
  package's real *import* name for a skip-gate or an unguarded top-level
  import in `autobot_shared/` → **record it explicitly** in
  `repo_tests/requirements_ci_drift_baseline.txt`, in the style of
  `sys_modules_leak_baseline.txt` / `extension_import_baseline.txt`. A stale
  entry (CI now installs it, or production no longer declares it) is a hard
  error.
- A system package with a real, currently-skipping test → **fix it**.
- Two PRs adding the same package to two different CI files for two
  different reasons → don't race it. `pytesseract` collides with the still-open
  #14510 (adds it to `requirements-ci/document.txt` for the OCR-fallback
  feature); allowlisted here with a pointer at #14510 instead, and the audit
  will force that line's removal the moment either PR lands it for real.

## What Changed

**`tools/lint/check_requirements_ci_drift.py`** (#14551) — parses production
vs CI requirement sets (stdlib only, following `-r` includes), diffs them
against `repo_tests/requirements_ci_drift_baseline.txt`, and fails on a
production package missing from CI and not allowlisted, or a stale
allowlist entry. Asserts both parsed sets are non-empty before comparing.

**`repo_tests/requirements_ci_drift_baseline.txt`** — 44 entries, grouped by
category with a verified rationale per group (and per-package where the
category alone doesn't establish it).

**`requirements-ci/{ai-ml,document,networking,security,framework}.txt`** —
mirror the 11 packages above, each with a comment naming the exact test(s)
that were silently skipping without it.

**`tools/lint/check_ci_system_package_provisioning.py`** (#14550) — derives
the ansible role's feature-package set (excluding a fixed, documented
Python-build-toolchain set), scans the test tree — both `*_test.py` and
`test_*.py`, matching `pytest.ini`'s own collection patterns — for a known
binary reached via `shutil.which(...)` or a known indirect probe call
(`PROBE_CALL_TO_BINARY`), gated by `skipif`/`pytest.skip(`/`importorskip(`,
and fails when the matching apt package isn't installed by
`.github/actions/setup-python-suite/action.yml`. Asserts floors on both the
ansible package count and the number of gated binaries found.

**`tools/lint/check_code_quality_guard_reach.py`** — a third guard: each
checker declares `GUARD_INPUT_PATHS`; this one re-derives
`code-quality.yml`'s actual path-filter reach (parsed without a YAML
library — `code-quality` installs linters only) and fails if any guarded
path isn't covered. Closes the gap where a PR touching only the ansible
task file or the composite action skipped `code-quality` entirely — a
skipped required job satisfies branch protection the same as a passing one.

**`.github/workflows/code-quality.yml`** — wires all three checkers in with
`--audit`; adds `autobot-slm-backend/ansible/roles/backend/tasks/**`,
`.github/actions/setup-python-suite/**`, and `repo_tests/**` to both
`on.push.paths` and the `changes` job's `filters.backend` list.

**`.github/actions/setup-python-suite/action.yml`** — installs `ffmpeg`.
Composite action referenced by local path (`uses: ./.github/actions/...`);
its steps execute from the checkout of this PR's own merge commit, so this
takes effect on this PR's own CI run, not only after promotion to `main`.

**`autobot-backend/media/audio/ffmpeg_service.py`** — removes a broken
`-allowed_extensions` global ffmpeg flag (a private AVOption of the
`dash`/`hls` demuxers only; ffmpeg rejects the whole command for a plain
file input on every version). `extract_audio()` has been non-functional
for every real audio file since Issue #9214 added it — invisible because
the only test that ever invoked real ffmpeg was itself silently skipping.
Extension enforcement already happens at the application level above it.

**`autobot-backend/media/audio/ffmpeg_service_test.py`** — adds
`test_ci_actually_has_the_ffmpeg_toolchain`, asserting (under `CI=true`
only) that `ffmpeg` is on `PATH`. `test_real_audio_extraction` itself is
unchanged; it now runs for real instead of skipping.

**`repo_tests/requirements_ci_drift_test.py`,
`repo_tests/ci_system_package_provisioning_test.py`,
`repo_tests/code_quality_guard_reach_test.py`** — import the checker
modules by path, exercise the invariant against synthetic input,
discrimination against a synthetic on-disk tree, the anti-empty-result
floors in both directions, the live tree (mirrored packages present and
not allowlisted, the pytesseract/#14510 pointer, ffmpeg provisioned, the
probe-call and prefix-file-glob widenings), that `code-quality.yml`
actually invokes each `--audit`, and that none of the three checkers
imports anything beyond the stdlib.

**Required-check status, stated explicitly:** all three guards run via
`python3 tools/lint/check_*.py --audit` inside `code-quality.yml`, which
**is** one of the 10 required contexts on `Dev_new_gui`. `python-suite`,
which the `repo_tests/*_test.py` copies also run under, is **not**
required — those are the informational mirror; enforcement is the
`--audit` invocation in `code-quality.yml`.

## Verification

```
$ python3 tools/lint/check_requirements_ci_drift.py --audit
requirements-ci drift audit clean over 100 production package(s) (#14551).

$ python3 tools/lint/check_ci_system_package_provisioning.py --audit
CI system-package provisioning audit clean over 2 gated binary/ies (#14550).

$ python3 tools/lint/check_code_quality_guard_reach.py --audit
code-quality guard-reach audit clean over 7 guarded path(s) (#14550/#14551).
```

**Mutation evidence**, each: mutate → red → revert → green, verified this
session against the pushed HEAD:

- **#14551**: removed `pytesseract` from `requirements-ci/automation.txt`
  (reproducing #13885) → 1 problem, exit 1 → reverted → clean. Also removed
  `scikit-learn` (one of the 9 corrected entries) → same shape, confirming
  the fix (not just the original seed) is load-bearing.
- **#14550**: removed the `ffmpeg` apt-install line → 2 problems
  (both call sites), exit 1 → reverted → clean.
- **guard-reach**: removed the two new path-filter entries (reproducing the
  reviewer's exact finding) → 1 problem naming both unfiltered paths, exit 1
  → reverted → clean.

**Anti-empty-result**, both directions, against a synthetic tree with the
requirements-ci file / ansible task file absent entirely — both report a
non-empty problem rather than a clean scan of nothing.

`repo_tests/requirements_ci_drift_test.py` (17 tests),
`repo_tests/ci_system_package_provisioning_test.py` (14 tests),
`repo_tests/code_quality_guard_reach_test.py` (12 tests),
`autobot-backend/media/audio/ffmpeg_service_test.py` (9 tests, including
`test_real_audio_extraction` now passing for real under `CI=true`) — 49
passed, 1 skipped (the CI-only toolchain assertion, correctly skipping
outside CI), 0 failed. Full `repo_tests/` tree still collects cleanly (920
tests, no collection errors).

Not run: `ansible`, any deployment script, `pip install`, or a venv — every
check above is read-only text parsing or a self-contained pytest run
executed directly against the checked-out tree.

## Model Used

Claude Sonnet 5
