### PR TITLE
fix(infra): run_code_analysis resolves sub-scripts from project_root, never folds a missing/failed one into success (#14543)

### DIFF
--- a/autobot-infrastructure/shared/scripts/run_code_analysis.py
+++ b/autobot-infrastructure/shared/scripts/run_code_analysis.py
@@ -13,201 +13,170 @@ import json
 import subprocess
 import sys
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional, Tuple
 
 from autobot_shared.paths import project_root
 
 # #14517: this module-level name was ``project_root`` while holding
 # ``autobot-infrastructure/shared`` -- the script's grandparent, not the project
 # root -- so it read as the canonical resolver and was not. Renamed to what it
-# actually is; the value is deliberately unchanged, because the analysis scripts
-# it addresses live at no path in this repo (tracked separately).
+# actually is.
 _SHARED_DIR = Path(__file__).parent.parent
 sys.path.insert(0, str(_SHARED_DIR))
+
+# #14543: the five sub-scripts used to be addressed under
+# ``tools/code-analysis-suite/scripts/``, a directory this repo's Phase 1/4
+# restructuring (#926, #781) deleted years ago, after copying its analyzers to
+# ``autobot-backend/code_analysis/scripts/``. Resolved from the canonical
+# project root (#13149) -- never from CWD, and never from this script's own
+# directory, both of which silently point at the wrong tree when the caller's
+# working directory differs.
+_ANALYSIS_SCRIPTS_DIR = project_root() / "autobot-backend" / "code_analysis" / "scripts"
+
+# Ceiling on a single sub-script's wall-clock time, in seconds.
+_SUBPROCESS_TIMEOUT_SECONDS = 60
+
+# Result keys whose value is checked for a per-analysis failure.
+_ANALYSIS_RESULT_KEYS = ("code_quality", "duplicates", "performance", "architecture")
+
+
+def _invoke_subprocess(
+    script_path: Path, target_path: str, label: str
+) -> Tuple[Optional[subprocess.CompletedProcess], Optional[str]]:
+    """Run *script_path* with ``cwd=target_path``; return ``(result, error)``.
+
+    Exactly one of the pair is ``None``. ``cwd`` is pinned to ``target_path``
+    because these scripts resolve their own analysis root relative to the
+    process's working directory, not from argv.
+    """
+    try:
+        result = subprocess.run(
+            [sys.executable, str(script_path)],
+            cwd=target_path,
+            capture_output=True,
+            text=True,
+            timeout=_SUBPROCESS_TIMEOUT_SECONDS,
+            check=False,
+        )
+        return result, None
+    except subprocess.TimeoutExpired:
+        return None, f"{label} analysis timed out after {_SUBPROCESS_TIMEOUT_SECONDS}s"
+    except OSError as e:
+        return None, f"{label} analysis could not start: {e}"
+
+
+def _run_analysis_script(label: str, script_name: str, target_path: str) -> Dict[str, Any]:
+    """Run one sub-script under ``_ANALYSIS_SCRIPTS_DIR`` and parse its JSON stdout.
+
+    #14543: a missing script, a non-zero exit, and stdout that fails to parse as
+    JSON are all reported as an ``error`` -- none of them may be folded into a
+    fabricated "success" the way this used to synthesize placeholder metrics.
+    """
+    script_path = _ANALYSIS_SCRIPTS_DIR / script_name
+    if not script_path.exists():
+        return {"error": f"Script not found: {script_path}"}
+
+    result, error = _invoke_subprocess(script_path, target_path, label)
+    if error is not None:
+        return {"error": error}
+
+    if result.returncode != 0:
+        return {"error": (result.stderr or "").strip() or f"{label} analysis exited {result.returncode}"}
+
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return {"error": f"{label} analysis produced no parseable JSON output"}
 
 
 def run_code_quality_analysis(target_path: str) -> Dict[str, Any]:
     """Run code quality analysis"""
-    script_path = _SHARED_DIR / "tools" / "code-analysis-suite" / "scripts" / "analyze_code_quality.py"
-
-    if not script_path.exists():
-        return {"error": f"Script not found: {script_path}"}
-
-    try:
-        result = subprocess.run(
-            [sys.executable, str(script_path), target_path],
-            capture_output=True,
-            text=True,
-            timeout=60,
-        )
-
-        # Parse output - the script might output JSON or text
-        if result.returncode == 0:
-            try:
-                return json.loads(result.stdout)
-            except json.JSONDecodeError:
-                # Parse text output
-                lines = result.stdout.strip().split("\n")
-                return {
-                    "status": "success",
-                    "output": lines,
-                    "complexity": 5,  # Default values
-                    "maintainability": "good",
-                    "test_coverage": 70,
-                    "doc_coverage": 65,
-                }
-        else:
-            return {"error": result.stderr or "Analysis failed"}
-
-    except subprocess.TimeoutExpired:
-        return {"error": "Analysis timeout"}
-    except Exception as e:
-        return {"error": str(e)}
+    return _run_analysis_script("code quality", "analyze_code_quality.py", target_path)
 
 
 def run_duplicate_analysis(target_path: str) -> Dict[str, Any]:
     """Run duplicate code analysis"""
-    script_path = _SHARED_DIR / "tools" / "code-analysis-suite" / "scripts" / "analyze_duplicates.py"
-
-    if not script_path.exists():
-        return {"error": f"Script not found: {script_path}"}
-
-    try:
-        result = subprocess.run(
-            [sys.executable, str(script_path), target_path],
-            capture_output=True,
-            text=True,
-            timeout=60,
-        )
-
-        if result.returncode == 0:
-            try:
-                return json.loads(result.stdout)
-            except json.JSONDecodeError:
-                return {
-                    "status": "success",
-                    "duplicates": [],
-                    "total_duplicates": 0,
-                    "output": result.stdout,
-                }
-        else:
-            return {"error": result.stderr or "Analysis failed"}
-
-    except Exception as e:
-        return {"error": str(e)}
+    return _run_analysis_script("duplicate", "analyze_duplicates.py", target_path)
 
 
 def run_performance_analysis(target_path: str) -> Dict[str, Any]:
-    """Run performance analysis"""
-    script_path = _SHARED_DIR / "tools" / "code-analysis-suite" / "scripts" / "analyze_performance_simple.py"
-
-    if not script_path.exists():
-        # Fallback to regular performance script
-        script_path = _SHARED_DIR / "tools" / "code-analysis-suite" / "scripts" / "analyze_performance.py"
-
-    if not script_path.exists():
-        return {"error": f"Script not found: {script_path}"}
-
-    try:
-        result = subprocess.run(
-            [sys.executable, str(script_path), target_path],
-            capture_output=True,
-            text=True,
-            timeout=60,
-        )
-
-        if result.returncode == 0:
-            try:
-                return json.loads(result.stdout)
-            except json.JSONDecodeError:
-                return {
-                    "status": "success",
-                    "performance_issues": [],
-                    "output": result.stdout,
-                }
-        else:
-            return {"error": result.stderr or "Analysis failed"}
-
-    except Exception as e:
-        return {"error": str(e)}
+    """Run performance analysis, preferring the lightweight script"""
+    script_name = "analyze_performance_simple.py"
+    if not (_ANALYSIS_SCRIPTS_DIR / script_name).exists():
+        script_name = "analyze_performance.py"
+    return _run_analysis_script("performance", script_name, target_path)
 
 
 def run_architecture_analysis(target_path: str) -> Dict[str, Any]:
     """Run architecture analysis"""
-    script_path = _SHARED_DIR / "tools" / "code-analysis-suite" / "scripts" / "analyze_architecture.py"
+    return _run_analysis_script("architecture", "analyze_architecture.py", target_path)
 
-    if not script_path.exists():
-        return {"error": f"Script not found: {script_path}"}
 
-    try:
-        result = subprocess.run(
-            [sys.executable, str(script_path), target_path],
-            capture_output=True,
-            text=True,
-            timeout=60,
-        )
+def _collect_failed_analyses(results: Dict[str, Any]) -> List[str]:
+    """Names of the sub-analyses whose result carries an ``error`` key."""
+    return [key for key in _ANALYSIS_RESULT_KEYS if isinstance(results.get(key), dict) and results[key].get("error")]
 
-        if result.returncode == 0:
-            try:
-                return json.loads(result.stdout)
-            except json.JSONDecodeError:
-                return {
-                    "status": "success",
-                    "communication_patterns": {
-                        "api_endpoints": [],
-                        "websocket_patterns": [],
-                        "internal_calls": [],
-                    },
-                    "output": result.stdout,
-                }
-        else:
-            return {"error": result.stderr or "Analysis failed"}
 
-    except Exception as e:
-        return {"error": str(e)}
+def _run_requested_analyses(results: Dict[str, Any], target_path: str, analysis_type: str) -> None:
+    """Populate ``results`` in place with the analyses ``analysis_type`` selects."""
+    if analysis_type in ("full", "quality"):
+        results["code_quality"] = run_code_quality_analysis(target_path)
+
+    if analysis_type in ("full", "duplicates"):
+        results["duplicates"] = run_duplicate_analysis(target_path)
+
+    if analysis_type in ("full", "performance"):
+        results["performance"] = run_performance_analysis(target_path)
+
+    if analysis_type in ("full", "communication_chains", "architecture"):
+        results["architecture"] = run_architecture_analysis(target_path)
+        architecture = results["architecture"]
+        if isinstance(architecture, dict) and "communication_patterns" in architecture:
+            results["communication_patterns"] = architecture["communication_patterns"]
+
+
+def _extract_codebase_metrics(results: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Roll up headline metrics from the quality analysis, when it succeeded."""
+    quality = results.get("code_quality")
+    if not isinstance(quality, dict) or quality.get("error"):
+        return None
+    return {
+        "complexity": quality.get("complexity", 5),
+        "maintainability": quality.get("maintainability", "good"),
+        "test_coverage": quality.get("test_coverage", 70),
+        "doc_coverage": quality.get("doc_coverage", 65),
+    }
 
 
 def run_full_analysis(target_path: str, analysis_type: str = "full") -> Dict[str, Any]:
     """Run complete code analysis suite"""
-    results = {
+    results: Dict[str, Any] = {
         "status": "success",
         "target_path": target_path,
         "analysis_type": analysis_type,
     }
 
-    # Check if target path exists
-    if not Path(target_path).exists():
+    if not Path(target_path).is_dir():
         return {"status": "error", "error": f"Target path not found: {target_path}"}
 
-    if analysis_type in ["full", "quality"]:
-        results["code_quality"] = run_code_quality_analysis(target_path)
+    _run_requested_analyses(results, target_path, analysis_type)
 
-    if analysis_type in ["full", "duplicates"]:
-        results["duplicates"] = run_duplicate_analysis(target_path)
+    # #14543: a failed sub-analysis must flip the overall status -- it used to
+    # stay "success" no matter how many of the five analyses error'd out.
+    failed = _collect_failed_analyses(results)
+    if failed:
+        results["status"] = "error"
+        results["failed_analyses"] = failed
 
-    if analysis_type in ["full", "performance"]:
-        results["performance"] = run_performance_analysis(target_path)
-
-    if analysis_type in ["full", "communication_chains", "architecture"]:
-        results["architecture"] = run_architecture_analysis(target_path)
-        # Extract communication patterns
-        if "architecture" in results and "communication_patterns" in results["architecture"]:
-            results["communication_patterns"] = results["architecture"]["communication_patterns"]
-
-    # Calculate overall metrics
-    if "code_quality" in results and not results["code_quality"].get("error"):
-        results["codebase_metrics"] = {
-            "complexity": results["code_quality"].get("complexity", 5),
-            "maintainability": results["code_quality"].get("maintainability", "good"),
-            "test_coverage": results["code_quality"].get("test_coverage", 70),
-            "doc_coverage": results["code_quality"].get("doc_coverage", 65),
-        }
+    metrics = _extract_codebase_metrics(results)
+    if metrics is not None:
+        results["codebase_metrics"] = metrics
 
     return results
 
 
-def main():
-    """Main entry point"""
+def _build_arg_parser() -> argparse.ArgumentParser:
+    """Construct the CLI parser for :func:`main`."""
     parser = argparse.ArgumentParser(description="Run code analysis suite")
     parser.add_argument(
         "--target",
@@ -235,26 +204,40 @@ def main():
         choices=["json", "text"],
         help="Output format",
     )
+    return parser
 
-    args = parser.parse_args()
 
-    # Run analysis
+def _print_text_report(args: argparse.Namespace, results: Dict[str, Any]) -> None:
+    """Human-readable rendering of ``results`` -- CLI stdout, not logging."""
+    print("Code Analysis Results")  # noqa: print -- CLI output, not application logging
+    print("=" * 50)  # noqa: print
+    print(f"Target: {args.target}")  # noqa: print
+    print(f"Analysis Type: {args.analysis_type}")  # noqa: print
+    print(f"Status: {results.get('status')}")  # noqa: print
+    if results.get("failed_analyses"):
+        print(f"Failed: {', '.join(results['failed_analyses'])}")  # noqa: print
+
+    if results.get("codebase_metrics"):
+        print("\nCodebase Metrics:")  # noqa: print
+        for key, value in results["codebase_metrics"].items():
+            print(f"  {key}: {value}")  # noqa: print
+
+
+def main():
+    """Main entry point"""
+    args = _build_arg_parser().parse_args()
+
     results = run_full_analysis(args.target, args.analysis_type)
 
-    # Output results
     if args.output_format == "json":
-        print(json.dumps(results, indent=2))
+        print(json.dumps(results, indent=2))  # noqa: print -- CLI output, not application logging
     else:
-        print("Code Analysis Results")
-        print("=" * 50)
-        print(f"Target: {args.target}")
-        print(f"Analysis Type: {args.analysis_type}")
-        print(f"Status: {results.get('status')}")
+        _print_text_report(args, results)
 
-        if results.get("codebase_metrics"):
-            print("\nCodebase Metrics:")
-            for key, value in results["codebase_metrics"].items():
-                print(f"  {key}: {value}")
+    # #14543: a run that found nothing must not exit 0 -- that is what let this
+    # print a "completed" report to a caller while every sub-analysis had failed.
+    if results.get("status") != "success":
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/autobot-infrastructure/shared/scripts/run_code_analysis_test.py
+++ b/autobot-infrastructure/shared/scripts/run_code_analysis_test.py
@@ -1,0 +1,154 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for run_code_analysis's silent-failure fix (#14543).
+
+Every one of the five sub-scripts this orchestrator shells out to used to be
+addressed under ``tools/code-analysis-suite/scripts/``, a directory that does
+not exist in this repository. A missing script, a non-zero exit, and stdout
+that fails to parse as JSON were all folded into an ``error`` key nested three
+levels deep, while the *top-level* ``status`` stayed hardcoded to ``"success"``
+and ``main()`` exited 0 -- a run that found nothing read as a completed one.
+
+These drive the real orchestration functions against a scratch directory of
+fake sub-scripts rather than the real (heavy, Redis-dependent) analyzers, so
+a missing, failing, or malformed sub-script can be simulated deterministically.
+"""
+
+import importlib.util
+import json
+import pathlib
+import sys
+
+import pytest
+
+_MODULE_PATH = pathlib.Path(__file__).with_name("run_code_analysis.py")
+
+
+def _load_module():
+    """Import run_code_analysis by path -- its directory is not a package."""
+    spec = importlib.util.spec_from_file_location("run_code_analysis", _MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["run_code_analysis"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+rca = _load_module()
+
+_ALL_ANALYSIS_KEYS = ("code_quality", "duplicates", "performance", "architecture")
+
+
+def _write_script(scripts_dir: pathlib.Path, name: str, body: str) -> None:
+    (scripts_dir / name).write_text(body, encoding="utf-8")
+
+
+@pytest.fixture
+def scripts_dir(tmp_path, monkeypatch):
+    """An empty stand-in for ``_ANALYSIS_SCRIPTS_DIR``, one per test."""
+    directory = tmp_path / "scripts"
+    directory.mkdir()
+    monkeypatch.setattr(rca, "_ANALYSIS_SCRIPTS_DIR", directory)
+    return directory
+
+
+@pytest.fixture
+def target_dir(tmp_path):
+    directory = tmp_path / "target"
+    directory.mkdir()
+    return directory
+
+
+def test_missing_scripts_flip_status_to_error(scripts_dir, target_dir):
+    """No sub-script exists -- #14543's original bug report scenario."""
+    results = rca.run_full_analysis(str(target_dir), "full")
+
+    assert results["status"] == "error"
+    assert sorted(results["failed_analyses"]) == sorted(_ALL_ANALYSIS_KEYS)
+    for key in _ALL_ANALYSIS_KEYS:
+        assert "Script not found" in results[key]["error"]
+    # #14543: no per-analysis fallback may fabricate placeholder metrics.
+    assert "codebase_metrics" not in results
+
+
+def test_missing_script_is_never_folded_into_success(scripts_dir, target_dir):
+    result = rca.run_code_quality_analysis(str(target_dir))
+    assert "error" in result
+    assert result.get("status") != "success"
+
+
+def test_nonzero_exit_reports_error_not_success(scripts_dir, target_dir):
+    _write_script(scripts_dir, "analyze_code_quality.py", "import sys\nsys.exit(3)\n")
+
+    result = rca.run_code_quality_analysis(str(target_dir))
+
+    assert "error" in result
+    assert "complexity" not in result
+
+
+def test_malformed_output_reports_error_not_fabricated_defaults(scripts_dir, target_dir):
+    """A returncode-0 script that prints non-JSON must not synthesize metrics.
+
+    This used to return ``{"complexity": 5, "test_coverage": 70, ...}`` on a
+    ``JSONDecodeError`` -- numbers invented by the orchestrator, not measured.
+    """
+    _write_script(scripts_dir, "analyze_code_quality.py", "print('not json, just log lines')\n")
+
+    result = rca.run_code_quality_analysis(str(target_dir))
+
+    assert "error" in result
+    assert "complexity" not in result
+    assert "test_coverage" not in result
+
+
+def test_valid_json_output_is_returned_verbatim(scripts_dir, target_dir):
+    payload = {"status": "success", "complexity": 3, "maintainability": "excellent"}
+    _write_script(
+        scripts_dir,
+        "analyze_code_quality.py",
+        f"import json\nprint(json.dumps({payload!r}))\n",
+    )
+
+    result = rca.run_code_quality_analysis(str(target_dir))
+
+    assert result == payload
+    assert "error" not in result
+
+
+def test_subprocess_cwd_is_pinned_to_target_path(scripts_dir, target_dir):
+    """The sub-scripts resolve their own analysis root from cwd, not argv."""
+    _write_script(
+        scripts_dir,
+        "analyze_architecture.py",
+        "import json, os\nprint(json.dumps({'cwd': os.getcwd()}))\n",
+    )
+
+    result = rca.run_architecture_analysis(str(target_dir))
+
+    assert result["cwd"] == str(target_dir.resolve())
+
+
+def test_main_exits_nonzero_when_every_analysis_fails(scripts_dir, target_dir, capsys, monkeypatch):
+    argv = ["run_code_analysis.py", "--target", str(target_dir), "--analysis-type", "quality"]
+    monkeypatch.setattr(sys, "argv", argv)
+
+    with pytest.raises(SystemExit) as exc_info:
+        rca.main()
+
+    assert exc_info.value.code != 0
+    printed = json.loads(capsys.readouterr().out)
+    assert printed["status"] == "error"
+
+
+def test_main_exits_zero_when_analysis_succeeds(scripts_dir, target_dir, capsys, monkeypatch):
+    _write_script(
+        scripts_dir,
+        "analyze_code_quality.py",
+        "import json\nprint(json.dumps({'status': 'success', 'complexity': 1}))\n",
+    )
+    argv = ["run_code_analysis.py", "--target", str(target_dir), "--analysis-type", "quality"]
+    monkeypatch.setattr(sys, "argv", argv)
+
+    rca.main()
+
+    printed = json.loads(capsys.readouterr().out)
+    assert printed["status"] == "success"


### PR DESCRIPTION
## Thinking Path

Read #14543 in full, then established the real state before changing anything.
`run_code_analysis.py` resolves each of its five sub-script paths from
`_SHARED_DIR` (`Path(__file__).parent.parent`, i.e. `autobot-infrastructure/shared`)
joined with `tools/code-analysis-suite/scripts/` — anchored to the script's own
file location, not CWD, so the "CWD-relative probe" failure mode did not apply
here; the defect was that the anchor pointed at the wrong subtree entirely.
Verified via `find`: 0 of the 5 (`analyze_code_quality.py`, `analyze_duplicates.py`,
`analyze_performance_simple.py`, `analyze_performance.py`, `analyze_architecture.py`)
exist under `tools/code-analysis-suite/scripts/` anywhere in the repo — that
directory was deleted in `d6d5c66ee` (#781, "Phase 4 - delete original folders").

Traced what happens today when a script is missing: `run_code_quality_analysis`
et al. (`run_code_analysis.py:33-34` on `origin/Dev_new_gui`) return
`{"error": f"Script not found: {script_path}"}` — but `run_full_analysis`
(`run_code_analysis.py:172-176`) initializes `results["status"] = "success"`
and never reads the per-analysis `error` keys to flip it, and `main()`
(`run_code_analysis.py:242-246`) always exits 0 and prints the assembled
report. **A run in which all five sub-analyses fail exits 0 and prints
`"status": "success"`** — the exact "absent result reads as clean" defect
class named in the issue, with the top-level status itself lying, not just an
empty payload.

Searched for where the five scripts actually live now: byte-identical names
exist at `autobot-backend/code_analysis/scripts/` (5/5 found), the destination
of the Phase 1 role-based restructuring (`00ae80e10`, #926) that predates the
Phase 4 deletion above — i.e. the analyzers were copied out before the old
`tools/` tree was deleted. `run_code_analysis.py` has zero callers anywhere in
this repo (grepped `.py`/`.sh`/`.yml`/Makefile/docs/workflows) — it isn't a
live-traffic script, so repointing it carries no behavioural risk to anything
that currently depends on it.

Chose repoint over retire, resolved via `autobot_shared.paths.project_root()`
(#13149's canonical resolver, already imported in this file for `--target`'s
default since #14517) rather than `_SHARED_DIR` or CWD. Per the coordination
note on #14544/PR #14575: did not add any live-install (`/opt/autobot`)
fallback of my own — `project_root()` owns that decision entirely, and #14575
is tightening its last-resort branch to raise rather than guess, which this
file inherits automatically by calling it rather than reimplementing it.

Found the four downstream scripts all analyze `root_path="."` with a hardcoded
`patterns=["src/**/*.py", "backend/**/*.py"]` — a layout this repo abandoned
for `autobot-backend/`/`autobot-frontend/`. Fixing that is a separate,
non-trivial change to a different subsystem's four files; filed as #14582
rather than silently absorbed into this PR's scope. Also found a second,
independent instance of the same "resolved-to-nothing" class in
`analytics_controller.py` (a third path-resolution mechanism, a script that
was never built) — filed as #14581.

## What Changed

- `autobot-infrastructure/shared/scripts/run_code_analysis.py`:
  - Resolves the five sub-scripts from `project_root() / "autobot-backend" / "code_analysis" / "scripts"` instead of `_SHARED_DIR / "tools" / "code-analysis-suite" / "scripts"` (0/5 existed at the old path; 5/5 exist at the new one).
  - `_run_analysis_script`/`_invoke_subprocess`: a missing script, a non-zero exit, a timeout, an `OSError` on launch, and stdout that fails `json.loads` are now **all** reported as `{"error": ...}` — removed the `JSONDecodeError` fallback that fabricated placeholder metrics (`"complexity": 5`, `"test_coverage": 70`, etc.) on a returncode-0 run whose output wasn't parseable JSON.
  - `run_full_analysis`/`_collect_failed_analyses`: the overall `status` now flips to `"error"` (with a `failed_analyses` list) when any sub-analysis failed — it used to stay `"success"` unconditionally.
  - `main()` now calls `sys.exit(1)` when `status != "success"`, so a caller relying on the process exit code (not just re-parsing the JSON) also sees the failure.
  - Subprocess `cwd` is pinned to `target_path` (previously unset, inheriting the orchestrator's own cwd) — the four downstream scripts resolve their own analysis root relative to the process's working directory, not from argv, so this was a second, independent silently-wrong-tree risk beyond the one already fixed by anchoring `_SHARED_DIR` off `__file__`.
  - Refactored into `_invoke_subprocess`/`_run_analysis_script`/`_run_requested_analyses`/`_extract_codebase_metrics`/`_build_arg_parser`/`_print_text_report` to keep every function ≤30 lines.
  - Subprocess safety unchanged/confirmed: `shell=False` (default), argv as a list (`[sys.executable, str(script_path)]`, no interpolation into a command string), explicit `timeout=_SUBPROCESS_TIMEOUT_SECONDS` (60s), `stderr` captured via `capture_output=True` and surfaced in the error message rather than discarded.
- `autobot-infrastructure/shared/scripts/run_code_analysis_test.py` (new): guard tests for the failure modes above, importing the module by path (the directory isn't a package) and driving the real orchestration functions against a `tmp_path` scratch directory of fake sub-scripts.
- Filed #14581 (a second, independent "resolves to nothing forever" instance in `analytics_controller.py`, via a third non-canonical path resolver) and #14582 (the four downstream scripts glob a `src/`/`backend/` layout this repo no longer has) rather than silently expanding this PR's scope.

## Verification

Per "never run code from the codebase tree": all execution below happened
against scratch copies under `/tmp/.../scratchpad/issue14543_verify/`
(`run_code_analysis.py` + `run_code_analysis_test.py` + a minimal
`autobot_shared/paths.py`), using the system's already-installed pytest 9.0.2 —
never the working tree, no `pip install`, no venv.

- **Path resolution, found/5**: 0/5 sub-scripts exist under the old
  `tools/code-analysis-suite/scripts/` resolution; 5/5 exist under the new
  `autobot-backend/code_analysis/scripts/` resolution (`find` output pasted
  into the issue thread).
- **8/8 guard tests pass** against the fixed module: missing-script (all 5),
  non-zero exit, malformed/non-JSON stdout, valid JSON passthrough, `cwd`
  pinned to `target_path`, and `main()`'s exit code in both the all-fail and
  the success case.
- **Mutation**: reintroduced the pre-fix behaviour in the scratch copy only
  (the `JSONDecodeError` fallback fabricating `{"complexity": 5, ...}`, the
  `status` never flipping to `"error"`, and `main()`'s `sys.exit(1)` removed).
  Guard suite went **8 passed → 5 passed / 3 failed**, on exactly the three
  tests that encode the fixed behaviour
  (`test_missing_scripts_flip_status_to_error`,
  `test_malformed_output_reports_error_not_fabricated_defaults`,
  `test_main_exits_nonzero_when_every_analysis_fails`). Reverted the scratch
  mutation and re-ran: back to 8/8. Diffed the scratch copy against the
  worktree file throughout to confirm the mutation never touched the
  committed source (`diff` exit 1 during the mutated window, exit 0 before
  and after).
- Syntax-checked both touched files with `ast.parse` and confirmed no line
  exceeds the repo's 120-column limit.
- Confirmed via `ast` that every function in `run_code_analysis.py` is ≤30
  lines (max: `_build_arg_parser` at exactly 30).

## Model Used

Claude Sonnet 5 (1M context)

Closes #14543
