### PR TITLE
fix(agents): extract text and usage from the LLMResponse dataclass (#14559)

### DIFF
--- a/autobot-backend/agents/base_modality_agent.py
+++ b/autobot-backend/agents/base_modality_agent.py
@@ -26,6 +26,7 @@ from typing import Any, Dict
 
 from autobot_shared.logging_manager import get_logger
 from constants.threshold_constants import LLMDefaults
+from llm_shared.models import LLMResponse
 
 from .standardized_agent import StandardizedAgent
 
@@ -76,7 +77,7 @@ class BaseModalityAgent(StandardizedAgent):
                 "response_text": response_text,
                 "agent_type": self.AGENT_ID,
                 "model_used": self.model_name,
-                "token_usage": (response.get("usage", {}) if isinstance(response, dict) else {}),
+                "token_usage": self._extract_token_usage(response),
             }
             return await self._after_success(result, context or {}, session_id)
         except Exception as e:
@@ -98,9 +99,20 @@ class BaseModalityAgent(StandardizedAgent):
         return result
 
     def _extract_content(self, response: Any) -> str:
-        """Extract text content from LLM response."""
+        """Extract text content from LLM response.
+
+        Issue #14559: ``chat_optimized`` — the only thing ``process_query``
+        calls — always returns an ``LLMResponse`` dataclass, on every one of
+        its return paths (cache hit, provider-missing error, request
+        exception, and the normal success path). It is neither a ``str`` nor
+        a ``dict``, so that branch is added here rather than replacing the
+        pre-existing ones, which stay for any caller that still hands this
+        method a raw provider payload.
+        """
         if isinstance(response, str):
             return response.strip()
+        if isinstance(response, LLMResponse):
+            return (response.content or "").strip()
         if isinstance(response, dict):
             msg = response.get("message", {})
             if isinstance(msg, dict) and msg.get("content"):
@@ -112,4 +124,26 @@ class BaseModalityAgent(StandardizedAgent):
                     return choice_msg["content"].strip()
             if "content" in response:
                 return str(response["content"]).strip()
-        return str(response)
+            return str(response)
+        # Issue #14559: a genuinely unrecognized shape used to fall through to
+        # `str(response)`, which always succeeds and hides the defect behind a
+        # plausible-looking string (e.g. a dataclass repr). Fail loudly instead;
+        # `process_query`'s `except Exception` turns this into a proper error
+        # result rather than a silent content leak.
+        raise TypeError(
+            f"{self.AGENT_ID}: _extract_content got an unrecognized LLM response "
+            f"type {type(response).__name__!r}; expected str, dict, or LLMResponse"
+        )
+
+    def _extract_token_usage(self, response: Any) -> Dict[str, Any]:
+        """Extract token usage accounting from an LLM response.
+
+        Mirrors `_extract_content`'s shape handling: `LLMResponse.usage` is
+        the real producer shape (Issue #14559); the dict branch is kept for
+        any raw provider payload still passed through.
+        """
+        if isinstance(response, LLMResponse):
+            return response.usage or {}
+        if isinstance(response, dict):
+            return response.get("usage", {})
+        return {}

--- a/autobot-backend/agents/base_modality_agent_test.py
+++ b/autobot-backend/agents/base_modality_agent_test.py
@@ -29,6 +29,7 @@ from agents.sentiment_analysis_agent import SentimentAnalysisAgent
 from agents.summarization_agent import SummarizationAgent
 from agents.translation_agent import TranslationAgent
 from constants.threshold_constants import LLMDefaults
+from llm_shared.models import LLMResponse
 
 MODALITY_AGENTS = [
     AudioProcessingAgent,
@@ -110,6 +111,54 @@ class TestExtractContent:
     def test_unrecognized_dict_falls_back_to_str(self):
         assert self._agent()._extract_content({"unrelated": 1}) == "{'unrelated': 1}"
 
+    def test_llm_response_content_is_extracted(self):
+        """Issue #14559: `chat_optimized` returns `LLMResponse`, not str/dict.
+
+        Constructed exactly the way the vLLM provider builds the success
+        response inside `chat_optimized` (see
+        `llm_shared/providers/vllm_base.py::_chat_completion_impl`), not
+        hand-rolled with different fields.
+        """
+        response = LLMResponse(
+            content="  The document discusses quarterly revenue growth.  ",
+            model="meta-llama/Llama-3.2-3B-Instruct",
+            provider="vllm",
+            usage={"prompt_tokens": 120, "completion_tokens": 40, "total_tokens": 160},
+            provider_metadata={"model_api_name": "meta-llama/Llama-3.2-3B-Instruct"},
+        )
+        assert self._agent()._extract_content(response) == "The document discusses quarterly revenue growth."
+
+    def test_genuinely_unrecognized_type_raises(self):
+        """Neither str, dict, nor LLMResponse must fail loudly, not repr silently."""
+        with pytest.raises(TypeError):
+            self._agent()._extract_content(12345)
+
+
+class TestExtractTokenUsage:
+    """`_extract_token_usage` (Issue #14559): populated from `LLMResponse.usage`."""
+
+    def _agent(self):
+        return AudioProcessingAgent.__new__(AudioProcessingAgent)
+
+    def test_llm_response_usage_is_extracted(self):
+        response = LLMResponse(
+            content="text",
+            model="m",
+            provider="vllm",
+            usage={"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+        )
+        assert self._agent()._extract_token_usage(response) == {
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "total_tokens": 15,
+        }
+
+    def test_dict_usage_is_extracted(self):
+        assert self._agent()._extract_token_usage({"usage": {"total_tokens": 3}}) == {"total_tokens": 3}
+
+    def test_unrecognized_type_returns_empty(self):
+        assert self._agent()._extract_token_usage(12345) == {}
+
 
 class TestAfterSuccessHook:
     """The one genuine per-agent difference: SentimentAnalysisAgent's diary write."""
@@ -149,3 +198,37 @@ class TestAfterSuccessHook:
             result = {"status": "success", "response": "x"}
             out = await inst._after_success(result, {}, "sess-1")
             assert out is result
+
+
+class TestProcessQueryEndToEnd:
+    """Issue #14559: `process_query` end-to-end against a real `LLMResponse`.
+
+    `llm_interface.chat_optimized` is mocked to return an `LLMResponse`
+    constructed the way the vLLM provider actually builds it (see
+    `llm_shared/providers/vllm_base.py::_chat_completion_impl`), not a bare
+    str/dict — that mismatch is exactly what hid this defect.
+    """
+
+    @pytest.mark.asyncio
+    async def test_success_response_and_token_usage_are_populated(self):
+        inst = SummarizationAgent.__new__(SummarizationAgent)
+        inst.AGENT_ID = "summarization"
+        inst.model_name = "meta-llama/Llama-3.2-3B-Instruct"
+        inst._LOGGER = SummarizationAgent._LOGGER
+        inst.QUERY_TEMPERATURE = SummarizationAgent.QUERY_TEMPERATURE
+        inst.QUERY_MAX_TOKENS = SummarizationAgent.QUERY_MAX_TOKENS
+        inst.QUERY_ERROR_MESSAGE = SummarizationAgent.QUERY_ERROR_MESSAGE
+        inst.llm_interface = AsyncMock()
+        inst.llm_interface.chat_optimized.return_value = LLMResponse(
+            content="Quarterly revenue grew 12% year over year.",
+            model=inst.model_name,
+            provider="vllm",
+            usage={"prompt_tokens": 200, "completion_tokens": 30, "total_tokens": 230},
+        )
+
+        result = await inst.process_query("Summarize the attached report", {"session_id": "sess-42"})
+
+        assert result["status"] == "success"
+        assert result["response"] == "Quarterly revenue grew 12% year over year."
+        assert result["response_text"] == "Quarterly revenue grew 12% year over year."
+        assert result["token_usage"] == {"prompt_tokens": 200, "completion_tokens": 30, "total_tokens": 230}


### PR DESCRIPTION
## Thinking Path

`chat_optimized` is the only thing `BaseModalityAgent.process_query` calls,
and its return type is `LLMResponse` on every one of its return paths, not
just the happy one:

- the normal success path returns `response` (an `LLMResponse` built by the
  vLLM provider's `_chat_completion_impl`, with `content`/`usage` set)
- the cache-hit path returns `cached`, itself an `LLMResponse` rebuilt from
  the cached entry
- the "no provider registered" path and the request-exception path both
  return `_build_error_response(...)`, an `LLMResponse` with `content=""`
  and `error` set

None of the four paths ever returns a bare `str` or `dict`. `_extract_content`
only recognized those two shapes, so it always fell through to
`return str(response)` — the dataclass repr — and `token_usage` always
evaluated the `isinstance(response, dict)` branch to `False`, so usage was
always `{}`.

Verified the reach: all 7 `BaseModalityAgent` subclasses import and inherit
it unmodified — `AudioProcessingAgent`, `CodeGenerationAgent`,
`DataAnalysisAgent`, `ImageAnalysisAgent`, `SentimentAnalysisAgent`,
`SummarizationAgent`, `TranslationAgent` — confirmed via the base class's own
`base_modality_agent_test.py::MODALITY_AGENTS` list and a grep for
`BaseModalityAgent` subclasses.

## What Changed

`autobot-backend/agents/base_modality_agent.py`:
- `_extract_content` gains an `isinstance(response, LLMResponse)` branch
  reading `.content`, added alongside (not replacing) the existing `str`/
  `dict` branches, which stay for any caller still handing this method a raw
  provider payload.
- A genuinely unrecognized shape (neither `str`, `dict`, nor `LLMResponse`)
  now raises `TypeError` instead of silently returning `str(response)`. That
  silent fallback is exactly what hid this defect for as long as it did;
  `process_query`'s existing `except Exception` turns the raise into a
  proper `{"status": "error", ...}` result rather than a new silent
  degradation path.
- New `_extract_token_usage` helper mirrors the same shape handling for
  `token_usage`, reading `LLMResponse.usage` (falling back to `{}` for a
  dict without a `usage` key, or `{}` for the error paths where `usage` is
  never set).

`autobot-backend/agents/base_modality_agent_test.py`: added an `LLMResponse`
extraction test (constructed with the same fields the vLLM provider sets in
`llm_shared/providers/vllm_base.py::_chat_completion_impl`, not hand-rolled),
a `_extract_token_usage` test suite, an unrecognized-type-raises test, and an
end-to-end `process_query` test asserting both `response`/`response_text`
and `token_usage` come back populated from a real `LLMResponse`.

Consumers of `process_query`'s result must still check `status` before
trusting `response`/`response_text` — the `except Exception` branch returns
`{"status": "error", "response": QUERY_ERROR_MESSAGE, ...}` without
re-raising, so a caller reading only text fields sees a plausible non-empty
string on failure. This PR does not change that contract; #14541 is the PR
that got caught reading only the text field.

## Verification

Ran under a scratch copy (`/tmp/.../scratchpad/repo-test`), never inside the
repo tree, using the system's pre-installed `pytest`/`pytest-asyncio`/
`pydantic` — no `pip install`, no venv:

- `pytest autobot-backend/agents/base_modality_agent_test.py`: **41 passed**
  (fix in place).
- Mutated `_extract_content`/`_extract_token_usage` back to the pre-fix
  fallthrough (`str(response)` / always-`{}`) in the scratch copy only:
  **37 passed, 4 failed** — the four new tests went red, including one
  reproducing the exact dataclass-repr leak
  (`'LLMResponse(...seconds=None)'`) described in the issue.
- Restored the fix in the scratch copy: back to **41 passed**.
- `pytest autobot-backend/agents/` (full directory, all 7 subclasses'
  existing suites included): **421 passed**, no regressions.

## Model Used

Claude Opus 5

Closes #14559