### PR TITLE
fix(provision): gate privileged node_roles activation on declared roles (#14560)

### DIFF
--- a/autobot-slm-backend/ansible/inventory/group_vars/all.yml
+++ b/autobot-slm-backend/ansible/inventory/group_vars/all.yml
@@ -319,34 +319,52 @@ _role_aliases:
 # (2) and (3). Co-located/single-host installs (where install.sh writes
 # node_roles=['autobot-backend', 'vnc']) hit the gap and got their dirs
 # wiped between deploy and validate.
+# #14560: the five facts below (backend, frontend, ai_stack, npu_worker,
+# browser) gate provision-fleet-roles.yml tasks that unpack a tree onto the
+# host (npm/vite, ChromaDB, OpenVINO, Playwright). #14513/#14552 filtered the
+# GROUP branch of these ORs so a node that only *detected* the role no longer
+# joins the ansible group -- but node_roles (declared UNION detected) was
+# never filtered, so the node_roles branch alone still activated these facts
+# for a detected-only node: the frontend role ran `npx vite build` with no
+# Node.js installed, the #14552 failure, reached through provisioning instead
+# of the update playbook. node_roles_declared (declared roles only) closes
+# that branch; it falls back to node_roles wherever it is not stamped
+# (static inventories, the synthetic test hosts below), so a role assigned
+# through a static inventory keeps activating unchanged. The other facts
+# below (redis, vnc, xrdp, llm, tts_worker) deliberately keep raw node_roles
+# -- role_tts_worker_active in particular has NO group fallback at all
+# (#9965), so node_roles is its only activation path by design. Guarded by
+# services/inventory_privileged_node_roles_test.py, which derives the
+# five-fact set from inventory_builder._DECLARED_ONLY_GROUPS instead of
+# repeating this list, so it fails loud on a sixth privileged fact.
 role_backend_active: >-
-  {{ ('backend' in (node_roles | default([]))) or
-     ('autobot-backend' in (node_roles | default([]))) or
+  {{ ('backend' in (node_roles_declared | default(node_roles | default([])))) or
+     ('autobot-backend' in (node_roles_declared | default(node_roles | default([])))) or
      (inventory_hostname in (groups.get('main', []) | default([]))) or
      (inventory_hostname in (groups.get('backend', []) | default([]))) }}
 
 role_frontend_active: >-
-  {{ ('frontend' in (node_roles | default([]))) or
-     ('autobot-frontend' in (node_roles | default([]))) or
+  {{ ('frontend' in (node_roles_declared | default(node_roles | default([])))) or
+     ('autobot-frontend' in (node_roles_declared | default(node_roles | default([])))) or
      (inventory_hostname in (groups.get('frontend', []) | default([]))) }}
 
 role_ai_stack_active: >-
-  {{ ('ai-stack' in (node_roles | default([]))) or
-     ('autobot-ai-stack' in (node_roles | default([]))) or
+  {{ ('ai-stack' in (node_roles_declared | default(node_roles | default([])))) or
+     ('autobot-ai-stack' in (node_roles_declared | default(node_roles | default([])))) or
      (inventory_hostname in (groups.get('ai_stack', []) | default([]))) or
      (inventory_hostname in (groups.get('aiml', []) | default([]))) }}
 
 role_npu_worker_active: >-
-  {{ ('npu-worker' in (node_roles | default([]))) or
-     ('autobot-npu-worker' in (node_roles | default([]))) or
+  {{ ('npu-worker' in (node_roles_declared | default(node_roles | default([])))) or
+     ('autobot-npu-worker' in (node_roles_declared | default(node_roles | default([])))) or
      (inventory_hostname in (groups.get('npu_worker', []) | default([]))) or
      (inventory_hostname in (groups.get('npu_workers', []) | default([]))) or
      (inventory_hostname in (groups.get('npu', []) | default([]))) }}
 
 role_browser_active: >-
-  {{ ('browser' in (node_roles | default([]))) or
-     ('autobot-browser-worker' in (node_roles | default([]))) or
-     ('browser-service' in (node_roles | default([]))) or
+  {{ ('browser' in (node_roles_declared | default(node_roles | default([])))) or
+     ('autobot-browser-worker' in (node_roles_declared | default(node_roles | default([])))) or
+     ('browser-service' in (node_roles_declared | default(node_roles | default([])))) or
      (inventory_hostname in (groups.get('browser', []) | default([]))) or
      (inventory_hostname in (groups.get('browser_worker', []) | default([]))) }}
 

--- a/autobot-slm-backend/ansible/playbooks/vars/role_active_facts.yml
+++ b/autobot-slm-backend/ansible/playbooks/vars/role_active_facts.yml
@@ -28,34 +28,52 @@
 #   - tools/lint/check_canonical_role_names.py (pre-commit enforcement)
 #   - docs/developer/ANSIBLE_ROLE_NAMES.md (full reference)
 ---
+# #14560: the five facts below (backend, frontend, ai_stack, npu_worker,
+# browser) gate provision-fleet-roles.yml tasks that unpack a tree onto the
+# host (npm/vite, ChromaDB, OpenVINO, Playwright). #14513/#14552 filtered the
+# GROUP branch of these ORs so a node that only *detected* the role no longer
+# joins the ansible group -- but node_roles (declared UNION detected) was
+# never filtered, so the node_roles branch alone still activated these facts
+# for a detected-only node: the frontend role ran `npx vite build` with no
+# Node.js installed, the #14552 failure, reached through provisioning instead
+# of the update playbook. node_roles_declared (declared roles only) closes
+# that branch; it falls back to node_roles wherever it is not stamped
+# (static inventories, the synthetic test hosts below), so a role assigned
+# through a static inventory keeps activating unchanged. The other facts
+# below (redis, vnc, xrdp, llm, tts_worker) deliberately keep raw node_roles
+# -- role_tts_worker_active in particular has NO group fallback at all
+# (#9965), so node_roles is its only activation path by design. Guarded by
+# services/inventory_privileged_node_roles_test.py, which derives the
+# five-fact set from inventory_builder._DECLARED_ONLY_GROUPS instead of
+# repeating this list, so it fails loud on a sixth privileged fact.
 role_backend_active: >-
-  {{ ('backend' in (node_roles | default([]))) or
-     ('autobot-backend' in (node_roles | default([]))) or
+  {{ ('backend' in (node_roles_declared | default(node_roles | default([])))) or
+     ('autobot-backend' in (node_roles_declared | default(node_roles | default([])))) or
      (inventory_hostname in (groups.get('main', []) | default([]))) or
      (inventory_hostname in (groups.get('backend', []) | default([]))) }}
 
 role_frontend_active: >-
-  {{ ('frontend' in (node_roles | default([]))) or
-     ('autobot-frontend' in (node_roles | default([]))) or
+  {{ ('frontend' in (node_roles_declared | default(node_roles | default([])))) or
+     ('autobot-frontend' in (node_roles_declared | default(node_roles | default([])))) or
      (inventory_hostname in (groups.get('frontend', []) | default([]))) }}
 
 role_ai_stack_active: >-
-  {{ ('ai-stack' in (node_roles | default([]))) or
-     ('autobot-ai-stack' in (node_roles | default([]))) or
+  {{ ('ai-stack' in (node_roles_declared | default(node_roles | default([])))) or
+     ('autobot-ai-stack' in (node_roles_declared | default(node_roles | default([])))) or
      (inventory_hostname in (groups.get('ai_stack', []) | default([]))) or
      (inventory_hostname in (groups.get('aiml', []) | default([]))) }}
 
 role_npu_worker_active: >-
-  {{ ('npu-worker' in (node_roles | default([]))) or
-     ('autobot-npu-worker' in (node_roles | default([]))) or
+  {{ ('npu-worker' in (node_roles_declared | default(node_roles | default([])))) or
+     ('autobot-npu-worker' in (node_roles_declared | default(node_roles | default([])))) or
      (inventory_hostname in (groups.get('npu_worker', []) | default([]))) or
      (inventory_hostname in (groups.get('npu_workers', []) | default([]))) or
      (inventory_hostname in (groups.get('npu', []) | default([]))) }}
 
 role_browser_active: >-
-  {{ ('browser' in (node_roles | default([]))) or
-     ('autobot-browser-worker' in (node_roles | default([]))) or
-     ('browser-service' in (node_roles | default([]))) or
+  {{ ('browser' in (node_roles_declared | default(node_roles | default([])))) or
+     ('autobot-browser-worker' in (node_roles_declared | default(node_roles | default([])))) or
+     ('browser-service' in (node_roles_declared | default(node_roles | default([])))) or
      (inventory_hostname in (groups.get('browser', []) | default([]))) or
      (inventory_hostname in (groups.get('browser_worker', []) | default([]))) }}
 

--- a/autobot-slm-backend/ansible/tests/inventory/group_vars/all.yml
+++ b/autobot-slm-backend/ansible/tests/inventory/group_vars/all.yml
@@ -35,34 +35,52 @@
 #   - tools/lint/check_canonical_role_names.py (pre-commit enforcement)
 #   - docs/developer/ANSIBLE_ROLE_NAMES.md (full reference)
 ---
+# #14560: the five facts below (backend, frontend, ai_stack, npu_worker,
+# browser) gate provision-fleet-roles.yml tasks that unpack a tree onto the
+# host (npm/vite, ChromaDB, OpenVINO, Playwright). #14513/#14552 filtered the
+# GROUP branch of these ORs so a node that only *detected* the role no longer
+# joins the ansible group -- but node_roles (declared UNION detected) was
+# never filtered, so the node_roles branch alone still activated these facts
+# for a detected-only node: the frontend role ran `npx vite build` with no
+# Node.js installed, the #14552 failure, reached through provisioning instead
+# of the update playbook. node_roles_declared (declared roles only) closes
+# that branch; it falls back to node_roles wherever it is not stamped
+# (static inventories, the synthetic test hosts below), so a role assigned
+# through a static inventory keeps activating unchanged. The other facts
+# below (redis, vnc, xrdp, llm, tts_worker) deliberately keep raw node_roles
+# -- role_tts_worker_active in particular has NO group fallback at all
+# (#9965), so node_roles is its only activation path by design. Guarded by
+# services/inventory_privileged_node_roles_test.py, which derives the
+# five-fact set from inventory_builder._DECLARED_ONLY_GROUPS instead of
+# repeating this list, so it fails loud on a sixth privileged fact.
 role_backend_active: >-
-  {{ ('backend' in (node_roles | default([]))) or
-     ('autobot-backend' in (node_roles | default([]))) or
+  {{ ('backend' in (node_roles_declared | default(node_roles | default([])))) or
+     ('autobot-backend' in (node_roles_declared | default(node_roles | default([])))) or
      (inventory_hostname in (groups.get('main', []) | default([]))) or
      (inventory_hostname in (groups.get('backend', []) | default([]))) }}
 
 role_frontend_active: >-
-  {{ ('frontend' in (node_roles | default([]))) or
-     ('autobot-frontend' in (node_roles | default([]))) or
+  {{ ('frontend' in (node_roles_declared | default(node_roles | default([])))) or
+     ('autobot-frontend' in (node_roles_declared | default(node_roles | default([])))) or
      (inventory_hostname in (groups.get('frontend', []) | default([]))) }}
 
 role_ai_stack_active: >-
-  {{ ('ai-stack' in (node_roles | default([]))) or
-     ('autobot-ai-stack' in (node_roles | default([]))) or
+  {{ ('ai-stack' in (node_roles_declared | default(node_roles | default([])))) or
+     ('autobot-ai-stack' in (node_roles_declared | default(node_roles | default([])))) or
      (inventory_hostname in (groups.get('ai_stack', []) | default([]))) or
      (inventory_hostname in (groups.get('aiml', []) | default([]))) }}
 
 role_npu_worker_active: >-
-  {{ ('npu-worker' in (node_roles | default([]))) or
-     ('autobot-npu-worker' in (node_roles | default([]))) or
+  {{ ('npu-worker' in (node_roles_declared | default(node_roles | default([])))) or
+     ('autobot-npu-worker' in (node_roles_declared | default(node_roles | default([])))) or
      (inventory_hostname in (groups.get('npu_worker', []) | default([]))) or
      (inventory_hostname in (groups.get('npu_workers', []) | default([]))) or
      (inventory_hostname in (groups.get('npu', []) | default([]))) }}
 
 role_browser_active: >-
-  {{ ('browser' in (node_roles | default([]))) or
-     ('autobot-browser-worker' in (node_roles | default([]))) or
-     ('browser-service' in (node_roles | default([]))) or
+  {{ ('browser' in (node_roles_declared | default(node_roles | default([])))) or
+     ('autobot-browser-worker' in (node_roles_declared | default(node_roles | default([])))) or
+     ('browser-service' in (node_roles_declared | default(node_roles | default([])))) or
      (inventory_hostname in (groups.get('browser', []) | default([]))) or
      (inventory_hostname in (groups.get('browser_worker', []) | default([]))) }}
 

--- a/autobot-slm-backend/ansible/tests/inventory/test_role_facts.yml
+++ b/autobot-slm-backend/ansible/tests/inventory/test_role_facts.yml
@@ -138,6 +138,43 @@ all:
       expected_role_llm_active: false
       expected_role_tts_worker_active: false
 
+    # 10. #14560 reproduction: privileged roles DETECTED but never DECLARED
+    #     (node_roles carries them, node_roles_declared does not — this is
+    #     what inventory_builder.py stamps for a node whose heartbeat
+    #     reports a role the operator never assigned). The five privileged
+    #     facts must stay false; tts-worker (deliberately-union, #9965) must
+    #     still activate off the raw node_roles branch.
+    test-detected-only-privileged:
+      ansible_host: 127.0.0.1
+      ansible_connection: local
+      node_roles:
+        - frontend
+        - backend
+        - ai-stack
+        - npu-worker
+        - browser-service
+        - tts-worker
+      node_roles_declared: []
+      expected_role_backend_active: false
+      expected_role_frontend_active: false
+      expected_role_ai_stack_active: false
+      expected_role_npu_worker_active: false
+      expected_role_browser_active: false
+      expected_role_tts_worker_active: true
+
+    # 11. #14560 over-tight check: a role the operator actually DECLARED
+    #     (present in both node_roles and node_roles_declared) must keep
+    #     activating — mirrors #14552's test_ordinary_groups_are_not_swept_in.
+    test-declared-frontend-still-activates:
+      ansible_host: 127.0.0.1
+      ansible_connection: local
+      node_roles:
+        - frontend
+      node_roles_declared:
+        - frontend
+      expected_role_frontend_active: true
+      expected_role_backend_active: false
+
   children:
     # Group-membership-only test for #8 (test-empty-roles-via-group).
     main:

--- a/autobot-slm-backend/services/inventory_builder.py
+++ b/autobot-slm-backend/services/inventory_builder.py
@@ -230,6 +230,28 @@ def _union_roles(node: Any) -> list[str]:
     return result
 
 
+def _declared_roles(node: Any) -> list[str]:
+    """Return node.roles alone, deduped -- the operator's declared intent.
+
+    Unlike ``_union_roles``, detection never contributes here. Stamped as the
+    ``node_roles_declared`` hostvar so role_active_facts.yml's PRIVILEGED
+    facts (backend, frontend, ai_stack, npu_worker, browser -- the ones that
+    unpack a tree, see ``_DECLARED_ONLY_GROUPS``) can gate their node_roles
+    branch the same way ``_strip_undeclared_privileged_groups`` already gates
+    their group branch (#14560). ``node_roles`` itself is left untouched:
+    ``test_node_roles_unions_detected_roles`` pins it as the union, and the
+    deliberately-union facts (role_tts_worker_active and friends, see the
+    #9965 comment on the ``node_roles`` hostvar below) still need it.
+    """
+    seen: set[str] = set()
+    result: list[str] = []
+    for r in list(node.roles or []):
+        if r not in seen:
+            seen.add(r)
+            result.append(r)
+    return result
+
+
 # Groups whose plays DEPLOY a component's tree onto the host. Detection must
 # never add a node to one of these: the whole failure mode is a node being
 # handed software it does not run.
@@ -303,6 +325,13 @@ def _build_hostvars(node: Any, local_ip_check: Any) -> dict:
         # browser/browser_worker. That mismatch is fixed at the source in
         # ROLE_ANSIBLE_GROUPS rather than left for this stamp to paper over.
         "node_roles": _union_roles(node),
+        # #14560: declared-only counterpart. role_active_facts.yml's five
+        # PRIVILEGED facts (backend, frontend, ai_stack, npu_worker, browser)
+        # read this instead of node_roles, so a role that only DETECTED
+        # (never declared) no longer activates that fact's deploy tasks --
+        # matching the group-side fix already applied by
+        # ``_strip_undeclared_privileged_groups``. See ``_declared_roles``.
+        "node_roles_declared": _declared_roles(node),
     }
     if local_ip_check(node.ip_address):
         hostvars["ansible_connection"] = "local"

--- a/autobot-slm-backend/services/inventory_privileged_node_roles_test.py
+++ b/autobot-slm-backend/services/inventory_privileged_node_roles_test.py
@@ -1,0 +1,237 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""A detected-but-undeclared privileged role must not activate its deploy (#14560).
+
+#14513/#14552 gated the ansible GROUP branch of role_active_facts.yml's
+OR-chains: a node that only *detected* ``frontend`` no longer joins the
+``frontend`` ansible group. ``provision-fleet-roles.yml`` does not read the
+group alone -- every gate is ``when: role_X_active``, and that fact also has
+a ``node_roles`` branch. ``node_roles`` is the UNION of declared and detected
+roles (``inventory_builder._union_roles``), and the union was never filtered,
+so a detected-only node still evaluated the privileged facts (backend,
+frontend, ai_stack, npu_worker, browser) true and got the tree unpacked --
+the same failure #14552 fixed, reached through provisioning instead of the
+update playbook.
+
+The fix stamps a second hostvar, ``node_roles_declared`` (declared roles
+only, see ``inventory_builder._declared_roles``), and repoints the five
+privileged facts' node_roles branch at it. The other facts (redis, vnc,
+xrdp, llm, tts_worker) deliberately keep the raw ``node_roles`` union --
+``role_tts_worker_active`` in particular has no group fallback at all
+(#9965), so node_roles is its only activation path by design.
+
+This module does not hand-list which facts are "privileged": it DERIVES the
+set from ``inventory_builder._DECLARED_ONLY_GROUPS`` (the group set #14552
+already proved matches the playbook, via ``inventory_deploy_groups_test.py``)
+by checking which facts' ``groups.get(...)`` branches reference one of those
+groups. A fact gains "privileged" status automatically the moment it starts
+gating on a privileged group, so this fails loud on a sixth fact without
+anyone maintaining a parallel list.
+
+Extraction uses ``yaml.safe_load`` rather than a scalar-style-specific regex
+-- #14555's derivation regex anchored on one YAML quoting form and silently
+missed 33 of 60 occurrences written in a different style. ``yaml.safe_load``
+resolves the fact value to a plain string regardless of whether it is a
+folded (``>-``), literal (``|``), plain, or quoted scalar.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+jinja2 = pytest.importorskip("jinja2")
+
+_SLM_ROOT = Path(__file__).resolve().parent.parent
+_FACTS_FILE = _SLM_ROOT / "ansible" / "playbooks" / "vars" / "role_active_facts.yml"
+_PROVISION_PLAYBOOK = _SLM_ROOT / "ansible" / "playbooks" / "provision-fleet-roles.yml"
+
+# Facts the #9965 comment on inventory_builder._build_hostvars names as
+# activating via node_roles BY DESIGN, with no (or an incomplete) group
+# fallback. Used only as a non-regression pin (test below), never as the
+# source of the privileged/non-privileged split itself -- that split is
+# derived, see _privileged_facts().
+_DELIBERATELY_UNION_FACTS = frozenset(
+    {
+        "role_tts_worker_active",
+        "role_redis_active",
+        "role_vnc_active",
+        "role_xrdp_active",
+        "role_llm_active",
+    }
+)
+
+_GROUPS_GET_RE = re.compile(r"""groups\.get\(\s*['"]([a-zA-Z0-9_]+)['"]""")
+# "'x' in (node_roles ...)" but NOT "'x' in (node_roles_declared ...)" -- the
+# underscore after node_roles makes \b fail to match at that boundary, so
+# this pattern already skips the declared variant and the `default(...)`
+# fallback (which is never preceded by `in (`).
+_RAW_NODE_ROLES_MEMBERSHIP_RE = re.compile(r"in\s*\(\s*node_roles(?!_declared)\b")
+
+
+def _load_inventory_builder():
+    name = "_inventory_builder_privileged_node_roles"
+    spec = importlib.util.spec_from_file_location(name, _SLM_ROOT / "services" / "inventory_builder.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.modules.pop(name, None)
+    return module
+
+
+inventory_builder = _load_inventory_builder()
+
+
+def _load_facts() -> dict[str, str]:
+    """fact name -> its Jinja expression string, however it was quoted in YAML."""
+    data = yaml.safe_load(_FACTS_FILE.read_text(encoding="utf-8"))
+    return {k: v for k, v in data.items() if k.startswith("role_") and k.endswith("_active")}
+
+
+def _facts_consumed_by_provision_playbook() -> set[str]:
+    text = _PROVISION_PLAYBOOK.read_text(encoding="utf-8")
+    return set(re.findall(r"\brole_\w+_active\b", text))
+
+
+def _privileged_facts(facts: dict[str, str]) -> set[str]:
+    """Facts gated on a privileged group AND carrying a node_roles branch.
+
+    Both conditions matter: ``role_slm_active`` also gates on a privileged
+    group (``slm_server``), but it has no node_roles branch at all -- it is
+    pure group membership, already correctly gated by
+    ``_strip_undeclared_privileged_groups`` on the group side, with nothing
+    for this fix to touch. Requiring a node_roles branch too is what narrows
+    the derived set to exactly the five #14560 names (backend, frontend,
+    ai_stack, npu_worker, browser) without hand-listing them.
+    """
+    privileged = set()
+    for name, expr in facts.items():
+        referenced_groups = set(_GROUPS_GET_RE.findall(expr))
+        gates_privileged_group = bool(referenced_groups & set(inventory_builder._DECLARED_ONLY_GROUPS))
+        has_node_roles_branch = "node_roles" in expr
+        if gates_privileged_group and has_node_roles_branch:
+            privileged.add(name)
+    return privileged
+
+
+def _render_all(facts: dict[str, str], context: dict) -> dict[str, bool]:
+    env = jinja2.Environment()
+    rendered: dict[str, bool] = {}
+    for name, expr in facts.items():
+        rendered[name] = env.from_string(expr).render(context).strip() == "True"
+    return rendered
+
+
+def test_measured_reach():
+    """The numbers #14560 asks to be measured, not assumed."""
+    facts = _load_facts()
+    consumed = _facts_consumed_by_provision_playbook() & set(facts)
+    privileged = _privileged_facts(facts)
+
+    assert facts, "role_active_facts.yml parsed to zero role_*_active facts"
+    assert consumed, "no role_*_active fact referenced by provision-fleet-roles.yml"
+    assert privileged, "derivation found zero privileged facts -- the rule below would be vacuous"
+
+    # Not an assertion on the exact membership (that would be the hand list
+    # this module exists to avoid) -- just that the counts are sane and
+    # every privileged fact is one the playbook actually gates a deploy on.
+    assert privileged <= consumed, f"privileged fact(s) not consumed by the playbook: {sorted(privileged - consumed)}"
+
+
+def test_privileged_facts_use_declared_only_node_roles():
+    """The #14560 invariant: no privileged fact tests the raw union anymore."""
+    facts = _load_facts()
+    privileged = _privileged_facts(facts)
+
+    leaking = {name for name in privileged if _RAW_NODE_ROLES_MEMBERSHIP_RE.search(facts[name])}
+    assert not leaking, (
+        f"{sorted(leaking)} gate a privileged group but still test the raw (union) node_roles -- "
+        "a detected-but-undeclared node still activates them (#14560)"
+    )
+
+
+def test_deliberately_union_facts_are_not_swept_in():
+    """Non-regression: #9965's deliberately-union facts keep their only path."""
+    facts = _load_facts()
+    privileged = _privileged_facts(facts)
+
+    missing = _DELIBERATELY_UNION_FACTS - set(facts)
+    assert not missing, f"expected deliberately-union fact(s) missing from role_active_facts.yml: {sorted(missing)}"
+
+    reclassified = _DELIBERATELY_UNION_FACTS & privileged
+    assert not reclassified, f"deliberately-union fact(s) became privileged: {sorted(reclassified)}"
+
+    for name in _DELIBERATELY_UNION_FACTS:
+        assert _RAW_NODE_ROLES_MEMBERSHIP_RE.search(
+            facts[name]
+        ), f"{name} lost its node_roles activation path -- role_tts_worker_active has no group fallback (#9965)"
+
+
+def test_detected_only_node_does_not_activate_privileged_facts():
+    """End-to-end #14560 reproduction, rendered exactly as Ansible would.
+
+    A node whose privileged roles are DETECTED (node_roles) but never
+    DECLARED (node_roles_declared empty) must not activate any of them --
+    while the deliberately-union tts-worker fact still fires.
+    """
+    facts = _load_facts()
+    privileged = _privileged_facts(facts)
+    context = {
+        "node_roles": ["frontend", "backend", "ai-stack", "npu-worker", "browser-service", "tts-worker"],
+        "node_roles_declared": [],
+        "groups": {},
+        "inventory_hostname": "detected-only-node",
+    }
+    result = _render_all(facts, context)
+
+    still_active = {name for name in privileged if result[name]}
+    assert not still_active, f"privileged fact(s) activated for a detected-only node: {sorted(still_active)}"
+    assert result["role_tts_worker_active"] is True, "deliberately-union fact must still activate off node_roles"
+
+
+def test_declared_role_still_activates():
+    """Over-tight check, mirrors #14552's test_ordinary_groups_are_not_swept_in.
+
+    A role the operator genuinely declared must keep activating -- the gate
+    must not become so strict that a legitimate assignment silently drops
+    out of its deploy.
+    """
+    facts = _load_facts()
+    context = {
+        "node_roles": ["frontend"],
+        "node_roles_declared": ["frontend"],
+        "groups": {},
+        "inventory_hostname": "declared-frontend-node",
+    }
+    result = _render_all(facts, context)
+
+    assert result["role_frontend_active"] is True, "a declared privileged role must still activate its deploy"
+    assert result["role_backend_active"] is False
+
+
+def test_static_inventory_without_node_roles_declared_is_unaffected():
+    """Non-regression: hosts that never stamp node_roles_declared (every
+    static inventory -- localhost.yml, slm-nodes.yml, the CI test fixtures)
+    must behave exactly as before -- the fallback is node_roles itself.
+    """
+    facts = _load_facts()
+    context = {
+        "node_roles": ["autobot-backend", "vnc"],
+        # node_roles_declared deliberately absent, as in every static host.
+        "groups": {},
+        "inventory_hostname": "static-inventory-host",
+    }
+    result = _render_all(facts, context)
+
+    assert result["role_backend_active"] is True
+    assert result["role_vnc_active"] is True
+    assert result["role_frontend_active"] is False

--- a/autobot-slm-backend/tests/services/test_inventory_builder_node_roles.py
+++ b/autobot-slm-backend/tests/services/test_inventory_builder_node_roles.py
@@ -42,3 +42,30 @@ def test_node_roles_unions_detected_roles():
     inv = build_registry_inventory([node], local_ip_check=lambda ip: False)
     roles = inv["all"]["hosts"]["00-SLM-Manager"]["node_roles"]
     assert "backend" in roles and "redis" in roles
+
+
+def test_node_roles_declared_excludes_detected_only_roles():
+    """#14560: node_roles_declared must NOT union in detected_roles.
+
+    role_active_facts.yml's five privileged facts (backend, frontend,
+    ai_stack, npu_worker, browser) read node_roles_declared instead of
+    node_roles precisely so a role that was only DETECTED never activates
+    their deploy tasks. If this hostvar ever unioned detected_roles back in,
+    that gate would be silently defeated again.
+    """
+    node = _node(roles=["backend"], detected=["frontend"])
+    inv = build_registry_inventory([node], local_ip_check=lambda ip: False)
+    hostvars = inv["all"]["hosts"]["00-SLM-Manager"]
+    assert "node_roles_declared" in hostvars, "node_roles_declared must be stamped for the privileged facts"
+    assert hostvars["node_roles_declared"] == ["backend"]
+    assert "frontend" not in hostvars["node_roles_declared"]
+    # node_roles (the union) is unaffected -- other tests pin this stays the union.
+    assert "frontend" in hostvars["node_roles"]
+
+
+def test_node_roles_declared_matches_roles_only():
+    node = _node(roles=["ai-stack", "tts-worker"], detected=["ai-stack", "npu-worker", "tts-worker"])
+    inv = build_registry_inventory([node], local_ip_check=lambda ip: True)
+    hostvars = inv["all"]["hosts"]["00-SLM-Manager"]
+    assert sorted(hostvars["node_roles_declared"]) == ["ai-stack", "tts-worker"]
+    assert "npu-worker" not in hostvars["node_roles_declared"]


### PR DESCRIPTION
Closes #14560

## Thinking Path

#14513/#14552 filtered the ansible GROUP branch of `role_active_facts.yml`'s
OR-chains so a node that only *detected* a privileged role (e.g. `frontend`)
no longer joins the corresponding ansible group. But `provision-fleet-roles.yml`
gates every deploy task on `when: role_X_active`, and each of those facts is
an OR between the group branch AND a `node_roles` branch. `node_roles` is the
UNION of declared and detected roles (`inventory_builder._union_roles`,
stamped at `_build_hostvars`), and that union was never filtered — so a
detected-only node still evaluated `role_frontend_active` true and got the
frontend tree unpacked, the exact #14552 failure signature, reached through
provisioning instead of the update playbook.

The comment at `inventory_builder.py` (now `_build_hostvars`, previously
lines 287-290) documents that `node_roles` is deliberately consulted for
roles like `role_tts_worker_active`, which has **no** group fallback at all
(#9965) — `node_roles` is its only activation path by design. So the fix
could not be "filter `node_roles`" wholesale; it needed to distinguish the
privileged deploy facts from the deliberately-union ones.

**Measured reach** (via a Python guard that parses the actual files, see
Verification): `role_active_facts.yml` defines **11** `role_*_active` facts.
`provision-fleet-roles.yml` consumes **10** of them (all except
`role_slm_active`, whose play targets `slm_server` directly by `hosts:`
rather than a fact). Of those, **5** are both (a) gated on a group in
`inventory_builder._DECLARED_ONLY_GROUPS` and (b) carry a `node_roles`
branch to leak: `role_backend_active`, `role_frontend_active`,
`role_ai_stack_active`, `role_npu_worker_active`, `role_browser_active` —
independently confirming the issue's claim of "five", not just trusting it.
`role_slm_active` also gates on a privileged group (`slm_server`) but has no
`node_roles` branch at all, so it was already fully covered by the
group-side fix and needed no change. The remaining 5 consumed facts (redis,
vnc, xrdp, llm, tts_worker) are the deliberately-union set and were left
untouched.

## What Changed

- `services/inventory_builder.py`: added `_declared_roles()` (node.roles
  only, no detection) and a new `node_roles_declared` hostvar alongside the
  existing `node_roles` union. `node_roles` itself is unchanged —
  `test_node_roles_unions_detected_roles` still pins it as the union, and
  the deliberately-union facts still need it.
- The three files `check_role_facts_synced.py` keeps byte-identical
  (`ansible/inventory/group_vars/all.yml`,
  `ansible/playbooks/vars/role_active_facts.yml`,
  `ansible/tests/inventory/group_vars/all.yml`): the five privileged facts'
  `node_roles` token checks now read
  `node_roles_declared | default(node_roles | default([]))` instead of raw
  `node_roles`. The fallback means any inventory that never stamps
  `node_roles_declared` (every static inventory: `localhost.yml`,
  `slm-nodes.yml`, the CI test fixtures) behaves exactly as before — a role
  assigned there keeps activating unchanged.
- `ansible/tests/inventory/test_role_facts.yml`: two new synthetic hosts —
  a detected-only-privileged reproduction, and an over-tight check that a
  genuinely declared role still activates (mirrors #14552's
  `test_ordinary_groups_are_not_swept_in`).
- `services/inventory_privileged_node_roles_test.py` (new): a Python guard
  that **derives** which facts are privileged from
  `inventory_builder._DECLARED_ONLY_GROUPS` rather than hand-listing them —
  it fails loud the moment a sixth fact starts gating on a privileged group.
  Extraction uses `yaml.safe_load` (not a scalar-style-specific regex —
  #14555's derivation regex anchored on one YAML quoting form and missed 33
  of 60 occurrences written in a different style). Renders every fact with a
  real `jinja2.Environment` for a detected-only node and a declared node to
  prove the behaviour end to end, not just structurally.
- `tests/services/test_inventory_builder_node_roles.py`: two new unit tests
  pinning `node_roles_declared`'s content directly.

## Verification

All verification ran against **scratch copies** under
`/tmp/.../scratchpad/issue-14560/` (with `autobot_shared.ssot_config`
stubbed out) — per the task constraints, no ansible playbook or repo-tree
code was executed directly.

- `yaml.safe_load` on all three edited "facts" files plus the fixture
  inventory: valid YAML, and a byte-for-byte reimplementation of
  `check_role_facts_synced.py`'s comparison shows zero drift across the
  three copies (12 shared facts: 11 `role_*_active` + `chromadb_service_owner`).
- Jinja2-rendered every fact for a **detected-only** node
  (`node_roles=[frontend, backend, ai-stack, npu-worker, browser-service,
  tts-worker]`, `node_roles_declared=[]`): all 5 privileged facts render
  `False`; `role_tts_worker_active` still renders `True`.
- Jinja2-rendered a **declared** node (`node_roles_declared=[frontend]`):
  `role_frontend_active` renders `True` (over-tight non-regression).
- Jinja2-rendered a **static-inventory-shaped** context (`node_roles` set,
  `node_roles_declared` absent): identical to pre-fix behaviour.
- Re-ran all **9** pre-existing synthetic hosts plus the **2** new ones (59
  assertions across 11 hosts) through the same Jinja2 rendering: 0
  mismatches.
- **Mutation**: copied the fixed `role_active_facts.yml` to scratch and
  reverted `node_roles_declared | default(node_roles | default([]))` back to
  `node_roles | default([])` (11 occurrences). Re-ran the guard's two key
  checks against both copies:

  | | fixed | mutated |
  |---|---|---|
  | privileged facts leaking raw `node_roles` | 0 | **5** (`role_ai_stack_active`, `role_backend_active`, `role_browser_active`, `role_frontend_active`, `role_npu_worker_active`) |
  | privileged facts still active for a detected-only node | 0 | **5** (the same five) |

  Both guard assertions pass on the fix and fail on the mutation — the test
  actually detects the bug it exists to catch.
- `python3 -m py_compile` on scratch copies of the new/edited Python files:
  clean.
- `build_registry_inventory()` exercised against scratch `inventory_builder.py`
  with a stubbed `autobot_shared.ssot_config`: a node with `roles=["backend"],
  detected_roles=["frontend"]` stamps `node_roles_declared=["backend"]`
  (frontend excluded) while `node_roles=["backend","frontend"]` (union
  unchanged) — matches the new unit tests exactly.

Ansible playbooks were read, not executed (hard constraint — they SSH to
live nodes and write to the live database).

## Model Used

Claude Sonnet 5