### PR TITLE
fix(llc/frontend): a shift-drag pan no longer opens the drawer of the node it started on (#14079)

### DIFF
--- a/autobot-frontend/src/components/workflow/WorkflowCanvas.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowCanvas.vue
@@ -485,6 +485,20 @@ const canvasRef = ref<HTMLElement | null>(null);
 const zoom = ref(1);
 const pan = reactive({ x: 50, y: 50 });
 const isPanning = ref(false);
+/**
+ * Whether the gesture that is ending actually panned the canvas (#14079).
+ *
+ * A pan translates the canvas by the pointer delta, so the node the gesture
+ * started on stays under the cursor. `mouseup` therefore lands on that node,
+ * the browser fires `click`, and the node's drawer opens over the canvas the
+ * user was navigating.
+ *
+ * Cleared on the next `mousedown` rather than by the click it suppresses: a
+ * pan that ends over empty canvas is followed by no node click at all, so a
+ * flag cleared only on click would stay set and swallow the user's next
+ * genuine click on a node.
+ */
+const pannedThisGesture = ref(false);
 const panStart = reactive({ x: 0, y: 0 });
 const dragNode = ref<CanvasNode | null>(null);
 const dragOffset = reactive({ x: 0, y: 0 });
@@ -593,7 +607,11 @@ function deleteNode(id: string) {
   if (props.selectedNodeId === id) emit('node-selected', null);
 }
 
-function selectNode(id: string) { emit('node-selected', id); }
+function selectNode(id: string) {
+  // The click that closes a pan is not a selection (#14079).
+  if (pannedThisGesture.value) return;
+  emit('node-selected', id);
+}
 
 async function clearCanvas() {
   if (props.nodes.length && (await confirm({ title: t('common.confirm'), message: t('workflow.canvas.clearConfirm') }))) {
@@ -614,6 +632,7 @@ function resetZoom() { zoom.value = 1; pan.x = 50; pan.y = 50; }
 function handleWheel(e: WheelEvent) { zoom.value = Math.max(0.3, Math.min(2, zoom.value + (e.deltaY > 0 ? -0.05 : 0.05))); }
 
 function startPan(e: MouseEvent) {
+  pannedThisGesture.value = false;
   if (e.button === 1 || e.shiftKey) { isPanning.value = true; panStart.x = e.clientX - pan.x; panStart.y = e.clientY - pan.y; }
 }
 
@@ -625,6 +644,9 @@ function startPan(e: MouseEvent) {
  * gesture is handed on; everything else still starts a node drag.
  */
 function onNodeMouseDown(node: CanvasNode, e: MouseEvent) {
+  // Reset here too: a plain press on a node stops propagation below, so
+  // `startPan` never runs and would never clear the flag.
+  pannedThisGesture.value = false;
   if (e.shiftKey || e.button === 1) return;
   e.stopPropagation();
   startDrag(node, e);
@@ -649,7 +671,12 @@ function startConnect(nodeId: string, port: string, e: MouseEvent) {
 
 function onMouseMove(e: MouseEvent) {
   mousePos.x = e.clientX; mousePos.y = e.clientY;
-  if (isPanning.value) { pan.x = e.clientX - panStart.x; pan.y = e.clientY - panStart.y; }
+  if (isPanning.value) {
+    pan.x = e.clientX - panStart.x; pan.y = e.clientY - panStart.y;
+    // Set on movement, not on press: a shift-click that never moves is still
+    // a selection, and suppressing it would break selecting with shift held.
+    pannedThisGesture.value = true;
+  }
   else if (dragNode.value) {
     const x = (e.clientX - dragOffset.x - pan.x) / zoom.value;
     const y = (e.clientY - dragOffset.y - pan.y) / zoom.value;

--- a/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.panClick.test.ts
+++ b/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.panClick.test.ts
@@ -1,0 +1,98 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// #14079: every shift-drag pan that started on a node ended with that node's
+// drawer open over the canvas the user had just panned.
+//
+// A pan translates the canvas by the pointer delta, so the node the gesture
+// started on stays under the cursor. `mouseup` lands on it, the browser fires
+// `click`, and `@click.stop="selectNode(node.id)"` emits `node-selected`.
+//
+// The suppression has to be narrow in two directions, and both are asserted
+// here: a shift-click that never moves is still a selection, and a pan that
+// ends over empty canvas must not swallow the user's NEXT click on a node.
+
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import en from '@/i18n/locales/en.json'
+
+import WorkflowCanvas from '../WorkflowCanvas.vue'
+import type { CanvasNode } from '../canvasNode'
+
+const NODES: CanvasNode[] = [
+  {
+    id: 'ceo',
+    type: 'org-person',
+    position: { x: 40, y: 40 },
+    data: { title: 'Ada', rule: 'idle' },
+    connections: [],
+  },
+]
+
+function mountCanvas() {
+  const i18n = createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en } })
+  return mount(WorkflowCanvas, {
+    props: { nodes: NODES, selectedNodeId: null, readonly: true },
+    global: { plugins: [i18n] },
+  })
+}
+
+type Wrapper = ReturnType<typeof mountCanvas>
+
+const node = (w: Wrapper) => w.find('.workflow-node')
+const area = (w: Wrapper) => w.find('.canvas-area')
+const selections = (w: Wrapper) => w.emitted('node-selected') ?? []
+
+/** Shift-drag from `from` to `to`, starting on whichever element is given. */
+async function panFrom(w: Wrapper, start: ReturnType<typeof node>, dx: number): Promise<void> {
+  await start.trigger('mousedown', { shiftKey: true, clientX: 100, clientY: 100, button: 0 })
+  await area(w).trigger('mousemove', { clientX: 100 + dx, clientY: 100 + dx })
+  await area(w).trigger('mouseup', { clientX: 100 + dx, clientY: 100 + dx })
+}
+
+describe('a pan gesture is not a selection (#14079)', () => {
+  it('does not select the node a pan started on', async () => {
+    const w = mountCanvas()
+    await panFrom(w, node(w), 70)
+    // The click the browser fires when the pointer comes up over the node.
+    await node(w).trigger('click')
+
+    expect(selections(w)).toHaveLength(0)
+  })
+
+  it('still selects on a plain click', async () => {
+    const w = mountCanvas()
+    await node(w).trigger('mousedown', { clientX: 100, clientY: 100, button: 0 })
+    await node(w).trigger('mouseup', { clientX: 100, clientY: 100 })
+    await node(w).trigger('click')
+
+    expect(selections(w)).toEqual([['ceo']])
+  })
+
+  it('still selects on a shift-click that never moves', async () => {
+    // Shift is the pan modifier, but a press that does not move is not a pan.
+    // Keying the suppression on the modifier instead of on movement would
+    // silently make shift-click stop working.
+    const w = mountCanvas()
+    await node(w).trigger('mousedown', { shiftKey: true, clientX: 100, clientY: 100, button: 0 })
+    await node(w).trigger('mouseup', { clientX: 100, clientY: 100 })
+    await node(w).trigger('click')
+
+    expect(selections(w)).toEqual([['ceo']])
+  })
+
+  it('does not swallow the click after a pan that ended on empty canvas', async () => {
+    // The failure mode of clearing the flag on the click it suppresses: this
+    // pan is followed by no node click at all, so the flag would still be set
+    // when the user next clicks a node.
+    const w = mountCanvas()
+    await area(w).trigger('mousedown', { shiftKey: true, clientX: 10, clientY: 10, button: 0 })
+    await area(w).trigger('mousemove', { clientX: 90, clientY: 90 })
+    await area(w).trigger('mouseup', { clientX: 90, clientY: 90 })
+
+    await node(w).trigger('mousedown', { clientX: 100, clientY: 100, button: 0 })
+    await node(w).trigger('click')
+
+    expect(selections(w)).toEqual([['ceo']])
+  })
+})


### PR DESCRIPTION
Closes #14079

## Thinking Path

The mechanism is exactly as reported: a pan translates the canvas by the pointer
delta, so the node the gesture started on stays under the cursor. `mouseup`
lands on it, the browser fires `click`, and `@click.stop="selectNode(node.id)"`
emits `node-selected`. The drawer opens over the canvas the user was navigating.

The issue proposed a `movedWhilePanning` flag short-circuiting `selectNode` for
the next click. That is the right shape, but "for the next click" is where it
goes wrong: **a pan that ends over empty canvas is followed by no node click at
all.** A flag cleared by the click it suppresses stays set, and swallows the
user's next genuine click on a node — trading a spurious drawer for a dead one.

So the flag is cleared on the next `mousedown` — the start of a new gesture —
rather than by a click that may never come. There is a test for this specific
case, and it fails against the suggested implementation.

The second decision is when to *set* it. Shift is the pan modifier, but a
shift-press that never moves is still a selection. Setting the flag on press
would silently break shift-click; it is set in `onMouseMove`, so only an actual
pan suppresses.

## What Changed

`autobot-frontend/src/components/workflow/WorkflowCanvas.vue`:

- `pannedThisGesture` — set in `onMouseMove` while panning, read by `selectNode`.
- Cleared in **both** `startPan` and `onNodeMouseDown`. A plain press on a node
  stops propagation, so `startPan` never runs for that gesture and would never
  clear it.

No change to node dragging, which the issue notes already ends in a selection
and calls out of scope. Worth deciding separately: dragging a node to reposition
it also opens its drawer, by the same mechanism.

## Verification

Four tests, each proven able to fail by mutating the line it guards:

| Mutation | Test that went red |
|---|---|
| suppression removed entirely (the reported bug) | does not select the node a pan started on |
| flag set on the modifier instead of on movement | still selects on a shift-click that never moves |
| **the implementation the issue suggested** — clear the flag on the click it suppresses | does not swallow the click after a pan that ended on empty canvas |

The third is the one worth noting: it passes the other three tests and fails
only this one, which is why it is here.

Run from the worktree:

- `vitest run src/components/workflow src/views/llc` — **24 files, 235 tests, all passed**
- `vue-tsc --noEmit` — exit 0 · `eslint` — exit 0 · `oxlint` — exit 0
- `stylelint` — exit 0

## Model Used

Claude Opus 5 (1M context)
